### PR TITLE
write job arguments to file

### DIFF
--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -448,7 +448,7 @@ async fn handle_nondep_job(
             *status = handle_child(job, db, logs, last_line, timeout, child).await;
 
             if status.is_ok() {
-                logs.push_str("\n\n--- PTHON CODE EXECUTION ---\n");
+                logs.push_str("\n\n--- PYTHON CODE EXECUTION ---\n");
 
                 set_logs(logs, job.id, db).await;
 
@@ -486,8 +486,9 @@ async fn handle_nondep_job(
                     None
                 };
                 let ser_args = serde_json::to_string(&args)
-                    .map_err(|e| Error::ExecutionErr(e.to_string()))?
-                    .replace("\\\"", "\\\\\"");
+                    .map_err(|e| Error::ExecutionErr(e.to_string()))?;
+                write_file(job_dir, "args.json", &ser_args).await?;
+
                 let wrapper_content: String = format!(
                     r#"
 import json
@@ -496,7 +497,8 @@ from datetime import datetime
 
 inner_script = __import__("inner")
 
-kwargs = json.loads("""{ser_args}""", strict=False)
+with open("args.json") as f:
+    kwargs = json.load(f, strict=False)
 for k, v in kwargs.items():
     if v == '<function call>':
         kwargs[k] = None
@@ -595,13 +597,14 @@ print(res_json)
                 None
             };
             let ser_args = serde_json::to_string(&args)
-                .map_err(|e| Error::ExecutionErr(e.to_string()))?
-                .replace("\\\"", "\\\\\"");
+                .map_err(|e| Error::ExecutionErr(e.to_string()))?;
+            write_file(job_dir, "args.json", &ser_args).await?;
+
             let spread = sig.args.into_iter().map(|x| x.name).join(",");
             let wrapper_content: String = format!(
                 r#"
 import {{ main }} from "./inner.ts";
-const {{{spread}}} = JSON.parse(`{ser_args}`);
+const {{{spread}}} = JSON.parse(await Deno.readTextFile("args.json"))
 
 async function run() {{
     let res: any = await main({spread});

--- a/nsjail/run.deno.config.proto
+++ b/nsjail/run.deno.config.proto
@@ -73,6 +73,11 @@ mount {
     is_bind: true
 }
 
+mount {
+    src: "{JOB_DIR}/args.json"
+    dst: "/tmp/args.json"
+    is_bind: true
+}
 
 mount {
     src: "/etc/ssl"

--- a/nsjail/run.python3.config.proto
+++ b/nsjail/run.python3.config.proto
@@ -71,6 +71,12 @@ mount {
 }
 
 mount {
+    src: "{JOB_DIR}/args.json"
+    dst: "/tmp/args.json"
+    is_bind: true
+}
+
+mount {
     src: "{JOB_DIR}/dependencies"
     dst: "/tmp/dependencies"
     is_bind: true


### PR DESCRIPTION
Hi I hope I'm not being cheeky by opening a pull request without an issue.  I had a solution in mind so I thought I'd try it out and if it's not satisfactory this can be closed and an issue opened instead.

Escaping job arguments JSON as a string in the bootstrapping script seemed a little funky. Some input like a backtick or backslash would cause scripts to not start in my testing.

There are a few ways to try to improve this.  This pull requests just writes the arguments to a file and then opens and parses it when bootstrapping the user scripts.

I had to add the file to the nsjail config so the scripts could read it. Alternatively, I think they could just read it from a file descriptor like stdin or by inheriting it from the parent or doing whatever the `command-fds` crate does. (That might be a little cleaner; but didn't want to add a dependency here.)

Also, instead of writing a named file, I think you can just make an anonymous file with something like `memfd_create` or `open` using `O_TMPFILE`. Then pass its file descriptor to the child.  But I don't think the Rust standard library includes those so again I wasn't sure it was worth it.

Or, using raw strings might also work but even that makes me want to double take about if there's some weird input that doesn't work.