### PR TITLE
deno script args spread to array

### DIFF
--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -604,10 +604,13 @@ print(res_json)
             let wrapper_content: String = format!(
                 r#"
 import {{ main }} from "./inner.ts";
-const {{{spread}}} = JSON.parse(await Deno.readTextFile("args.json"))
+
+const args = await Deno.readTextFile("args.json")
+    .then(JSON.parse)
+    .then(({{ {spread} }}) => [ {spread} ])
 
 async function run() {{
-    let res: any = await main({spread});
+    let res: any = await main(...args);
     if (res == undefined) {{
         res = {{}}
     }}


### PR DESCRIPTION
smol issue where a deno script with parameters named `main` or `run`
will try to assign over imported main or the run function.

This uses the spread syntax to unpack the arguments and arrange them in
an array in argument order.  Instead of making assignments to the scope.

(I am not very JavaScript expert so I'm trying to be careful but I _think_ this is a fine way to do this.)