### PR TITLE
wrap array results from deno scripts in object

### DIFF
--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -614,7 +614,7 @@ async function run() {{
     if (res == undefined) {{
         res = {{}}
     }}
-    if (typeof res !== 'object') {{
+    if (typeof res !== 'object' || Array.isArray(res)) {{
         res = {{ res1: res }}
     }}
 


### PR DESCRIPTION
Returning an array from a deno script fails the job because it can't serialize into a `Map<String, Value>`.

In JavaScript `typeof []` is `'object'`.

Wasn't 100% sure what the correct behaviour is -- for Python scripts, tuples are handled differently from lists.  So I guessed and did the thing that it does for lists.