### PR TITLE
fix: prometheus histogram for worker job timer

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2406,6 +2406,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cface98dfa6d645ea4c789839f176e4b072265d085bfcc48eaa8d137f58d3c39"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.1",
+ "thiserror",
+]
+
+[[package]]
 name = "prost"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4527,6 +4541,7 @@ dependencies = [
  "lettre",
  "magic-crypt",
  "mime_guess",
+ "prometheus",
  "rand 0.8.5",
  "rand_core 0.6.3",
  "regex",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -24,6 +24,7 @@ chrono = { version = "^0", features = ["serde"]}
 tracing = "^0"
 tracing-subscriber = { version = "^0", features = ["env-filter", "json"]}
 console-subscriber = "^0"
+prometheus = { version = "^0", default-features = false }
 
 rust-embed = "^6"
 mime_guess = "^2"

--- a/backend/src/jobs.rs
+++ b/backend/src/jobs.rs
@@ -1258,6 +1258,8 @@ pub async fn add_completed_job_error<E: ToString + std::fmt::Debug>(
     logs: String,
     e: E,
 ) -> Result<(Uuid, Map<String, Value>), Error> {
+    let _ = crate::worker::JOBS_FAILED.try_with(|metric| metric.inc());
+
     let mut output_map = serde_json::Map::new();
     output_map.insert(
         "error".to_string(),

--- a/backend/src/jobs.rs
+++ b/backend/src/jobs.rs
@@ -24,6 +24,7 @@ use crate::{
     scripts::{get_hub_script_by_path, ScriptHash, ScriptLang},
     users::{owner_to_token_owner, Authed},
     utils::{require_admin, Pagination, StripPath},
+    worker,
     worker_flow::init_flow_status,
 };
 use axum::{
@@ -1257,9 +1258,9 @@ pub async fn add_completed_job_error<E: ToString + std::fmt::Debug>(
     queued_job: &QueuedJob,
     logs: String,
     e: E,
+    metrics: &worker::Metrics,
 ) -> Result<(Uuid, Map<String, Value>), Error> {
-    let _ = crate::worker::JOBS_FAILED.try_with(|metric| metric.inc());
-
+    metrics.jobs_failed.inc();
     let mut output_map = serde_json::Map::new();
     output_map.insert(
         "error".to_string(),

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -305,8 +305,7 @@ pub async fn serve_metrics(
 
 async fn metrics() -> Result<String, Error> {
     let metric_families = prometheus::gather();
-    prometheus::TextEncoder::new()
+    Ok(prometheus::TextEncoder::new()
         .encode_to_string(&metric_families)
-        .map_err(anyhow::Error::from)
-        .map_err(Error::Anyhow)
+        .map_err(anyhow::Error::from)?)
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -6,7 +6,6 @@
  * LICENSE-AGPL for a copy of the license.
  */
 
-use futures::TryFutureExt;
 use std::net::SocketAddr;
 
 use dotenv::dotenv;
@@ -23,6 +22,16 @@ async fn main() -> anyhow::Result<()> {
         .ok()
         .and_then(|x| x.parse::<i32>().ok())
         .unwrap_or(windmill::DEFAULT_NUM_WORKERS as i32);
+
+    let metrics_addr: Option<SocketAddr> = std::env::var("METRICS_ADDR")
+        .ok()
+        .map(|s| {
+            s.parse::<bool>()
+                .map(|b| b.then(|| SocketAddr::from(([0, 0, 0, 0], 8001))))
+                .or_else(|_| s.parse::<SocketAddr>().map(Some))
+        })
+        .transpose()?
+        .flatten();
 
     let (server_mode, monitor_mode, migrate_db) = (true, true, true);
 
@@ -105,9 +114,14 @@ async fn main() -> anyhow::Result<()> {
             Ok(()) as anyhow::Result<()>
         };
 
-        let metrics_f =
-            windmill::serve_metrics(SocketAddr::from(([0, 0, 0, 0], 8001)), tx.subscribe())
-                .map_err(anyhow::Error::from);
+        let metrics_f = async {
+            match metrics_addr {
+                Some(addr) => windmill::serve_metrics(addr, tx.subscribe())
+                    .await
+                    .map_err(anyhow::Error::from),
+                None => Ok(()),
+            }
+        };
 
         futures::try_join!(shutdown_signal, server_f, workers_f, monitor_f, metrics_f)?;
     }

--- a/backend/src/scripts.rs
+++ b/backend/src/scripts.rs
@@ -67,6 +67,16 @@ pub enum ScriptLang {
     Deno,
     Python3,
 }
+
+impl ScriptLang {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ScriptLang::Deno => "deno",
+            ScriptLang::Python3 => "python3",
+        }
+    }
+}
+
 #[derive(sqlx::Type, PartialEq, Debug, Hash, Clone, Copy)]
 #[sqlx(transparent)]
 pub struct ScriptHash(pub i64);


### PR DESCRIPTION
hosts on :8001

This probably isn't entirely right but I'm hoping it's in the ballpark.

I'm re-reading issue #289 for the seventh time I'm only now realizing what you wanted out the the gauge. I used a histogram instead because it has a timer and also I don't know what I'm doing.

I guess the gauge seems a little awkward if it's not updated before being queried. Like if a worker is waiting for a job it won't show up in the metrics unless it's continually updating the gauge? I'm not sure. You can take this over if it's clear to you otherwise I'll try to clean it up based on any feedback.