### PR TITLE
 backend tests for python job and deno flow

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -8,7 +8,8 @@ on:
       - "backend/**"
   pull_request:
     types: [opened, synchronize, reopened]
-
+    paths:
+      - "backend/**"
 jobs:
   cargo_test:
     runs-on: [self-hosted, new]

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -1,0 +1,37 @@
+name: Backend only integration tests
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "backend/**"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "backend/**"
+jobs:
+  cargo_test:
+    runs-on: [self-hosted, new]
+    needs: [build]
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_DB: windmill
+          POSTGRES_USER: admin
+          POSTGRES_PASSWORD: changeme
+        ports:
+          - 5434:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+      - run: /root/.cargo/bin/rustup toolchain install stable --profile minimal
+      - uses: Swatinem/rust-cache@v2
+      - name: "cargo test"
+        timeout-minutes: 5
+        run: mkdir -p frontend/build && cd backend && SQLX_OFFLINE=true DATABASE_URL=postgres://admin:changeme@localhost:5434/windmill /root/.cargo/bin/cargo test

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -8,8 +8,7 @@ on:
       - "backend/**"
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - "backend/**"
+
 jobs:
   cargo_test:
     runs-on: [self-hosted, new]

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -132,4 +132,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: "cargo test"
         timeout-minutes: 2
-        run: cd backend && DATABASE_URL=postgres://admin:changeme@localhost:5434/windmill cargo test
+        run: cd backend && DATABASE_URL=postgres://admin:changeme@localhost:5434/windmill /root/.cargo/bin/cargo test

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -132,4 +132,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: "cargo test"
         timeout-minutes: 5
-        run: cd backend && DATABASE_URL=postgres://admin:changeme@localhost:5434/windmill /root/.cargo/bin/cargo test
+        run: cd backend && SQLX_OFFLINE=true DATABASE_URL=postgres://admin:changeme@localhost:5434/windmill /root/.cargo/bin/cargo test

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -131,5 +131,5 @@ jobs:
       - run: /root/.cargo/bin/rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
       - name: "cargo test"
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: cd backend && DATABASE_URL=postgres://admin:changeme@localhost:5434/windmill /root/.cargo/bin/cargo test

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -120,7 +120,7 @@ jobs:
           POSTGRES_USER: admin
           POSTGRES_PASSWORD: changeme
         ports:
-          - 5432:5432
+          - 5434:5432
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -132,4 +132,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: "cargo test"
         timeout-minutes: 2
-        run: cd backend && DATABASE_URL=postgres://admin:changeme@localhost:5432/windmill cargo test
+        run: cd backend && DATABASE_URL=postgres://admin:changeme@localhost:5434/windmill cargo test

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -104,8 +104,32 @@ jobs:
         run: echo "::set-output name=id::$(docker run --network=host --rm -d -p 8000:8000 --privileged -it -e DATABASE_URL=postgres://admin:changeme@localhost:5432/windmill -e BASE_INTERNAL_URL=http://localhost:8000 ${{ env.LOCAL_REGISTRY }}/${{ env.IMAGE_NAME }}:latest)"
         id: docker-container
       - name: "Playwright run"
-        timeout-minutes: 10
+        timeout-minutes: 2
         run: cd frontend && npm ci @playwright/test && npx playwright install && npm run test
       - name: "Clean up"
         run: docker kill ${{ steps.docker-container.outputs.id }}
         if: always()
+  cargo_test:
+    runs-on: [self-hosted, new]
+    needs: [build]
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_DB: windmill
+          POSTGRES_USER: admin
+          POSTGRES_PASSWORD: changeme
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup toolchain install stable --profile minimal
+      - uses: Swatinem/rust-cache@v2
+      - name: "cargo test"
+        timeout-minutes: 2
+        run: cd backend && DATABASE_URL=postgres://admin:changeme@localhost:5432/windmill cargo test

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -128,7 +128,7 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v3
-      - run: rustup toolchain install stable --profile minimal
+      - run: /root/.cargo/bin/rustup toolchain install stable --profile minimal
       - uses: Swatinem/rust-cache@v2
       - name: "cargo test"
         timeout-minutes: 2

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -109,27 +109,3 @@ jobs:
       - name: "Clean up"
         run: docker kill ${{ steps.docker-container.outputs.id }}
         if: always()
-  cargo_test:
-    runs-on: [self-hosted, new]
-    needs: [build]
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_DB: windmill
-          POSTGRES_USER: admin
-          POSTGRES_PASSWORD: changeme
-        ports:
-          - 5434:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    steps:
-      - uses: actions/checkout@v3
-      - run: /root/.cargo/bin/rustup toolchain install stable --profile minimal
-      - uses: Swatinem/rust-cache@v2
-      - name: "cargo test"
-        timeout-minutes: 5
-        run: cd backend && SQLX_OFFLINE=true DATABASE_URL=postgres://admin:changeme@localhost:5434/windmill /root/.cargo/bin/cargo test

--- a/backend/src/fixtures/base.sql
+++ b/backend/src/fixtures/base.sql
@@ -1,0 +1,19 @@
+-- used for backend automated testing
+-- https://docs.rs/sqlx/latest/sqlx/attr.test.html
+
+INSERT INTO workspace
+            (id,               name,             owner,       domain)
+     VALUES ('test-workspace', 'test-workspace', 'test-user', null);
+
+CREATE FUNCTION "notify_insert_on_completed_job" ()
+RETURNS TRIGGER AS $$
+BEGIN
+    PERFORM pg_notify('insert on completed_job', NEW.id::text);
+    RETURN new;
+END;
+$$ LANGUAGE PLPGSQL;
+
+  CREATE TRIGGER "notify_insert_on_completed_job"
+ AFTER INSERT ON "completed_job"
+    FOR EACH ROW
+EXECUTE FUNCTION "notify_insert_on_completed_job" ();

--- a/backend/src/flows.rs
+++ b/backend/src/flows.rs
@@ -77,6 +77,7 @@ pub struct FlowValue {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct FlowModule {
+    #[serde(default)]
     pub input_transform: HashMap<String, InputTransform>,
     pub value: FlowModuleValue,
     pub stop_after_if_expr: Option<String>,


### PR DESCRIPTION
Worker modifed to drop the `broadcast::Sender` after subscribing a
`broadcast::Receiver` to it.  If the last Sender is closed, the
Recievers are closed.  But this will never happen unless run_worker
drops the Sender passed to it.

Tests don't go through the web/http stuff so they skip serialization and
all that. Not sure if this is good or bad, maybe we want both.

each test marked with `#[sqlx::test]` is run in a new database named
_sqlx_test_N. There's quite a bit of overhead to this compared to
running tests in transactions but it provides more isolation and the
implmentation is a bit simpler.

backend/src/fixtures/base.sql is run by `#[sqlx::test]` to set up some
data when testing.  It also adds a trigger used to synchronize a bit,
it's kind of a hack.  Ideally the testing database scheam doesn't differ
from the actual schema.