### PR TITLE
make initialize_tracing sync and infallable

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -60,6 +60,8 @@ use crate::{
     utils::rd_string,
 };
 
+pub use crate::tracing_init::initialize_tracing;
+
 const GIT_VERSION: &str = git_version!(args = ["--tag", "--always"], fallback = "unknown-version");
 pub const DEFAULT_NUM_WORKERS: usize = 3;
 pub const DEFAULT_TIMEOUT: i32 = 300;
@@ -84,10 +86,6 @@ pub async fn connect_db() -> anyhow::Result<DB> {
     };
 
     Ok(db::connect(&database_url, max_connections).await?)
-}
-
-pub async fn initialize_tracing() -> anyhow::Result<()> {
-    tracing_init::initialize_tracing().await
 }
 
 struct BaseUrl(String);

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -14,7 +14,7 @@ use dotenv::dotenv;
 async fn main() -> anyhow::Result<()> {
     dotenv().ok();
 
-    windmill::initialize_tracing().await?;
+    windmill::initialize_tracing();
 
     let db = windmill::connect_db().await?;
 

--- a/backend/src/tracing_init.rs
+++ b/backend/src/tracing_init.rs
@@ -58,7 +58,7 @@ fn filter_metadata(meta: &Metadata) -> bool {
     meta.target().starts_with("windmill")
 }
 
-pub async fn initialize_tracing() -> anyhow::Result<()> {
+pub fn initialize_tracing() {
     let tokio_console = std::env::var("TOKIO_CONSOLE")
         .map(|x| x == "true")
         .unwrap_or(false);
@@ -70,8 +70,8 @@ pub async fn initialize_tracing() -> anyhow::Result<()> {
 
     let nenv_filter = if tokio_console {
         env_filter
-            .add_directive("runtime=trace".parse()?)
-            .add_directive("tokio=trace".parse()?)
+            .add_directive("runtime=trace".parse().unwrap())
+            .add_directive("tokio=trace".parse().unwrap())
     } else {
         env_filter
     };
@@ -93,5 +93,4 @@ pub async fn initialize_tracing() -> anyhow::Result<()> {
             .with(compact_layer().with_filter(filter_fn(filter_metadata)))
             .init(),
     }
-    Ok(())
 }

--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -1205,20 +1205,10 @@ mod tests {
     use super::*;
 
     async fn initialize_tracing() {
-        use std::sync::atomic::Ordering::SeqCst;
+        use std::sync::Once;
 
-        // TODO a bit of a race condition here.
-        // Only one test calls tracing_init::initialize_tracing() (good) but it may not have
-        // finished & returned while other tests return from this function and start doing things.
-
-        static IS_INIT: AtomicBool = AtomicBool::new(false);
-
-        if IS_INIT
-            .compare_exchange(false, true, SeqCst, SeqCst)
-            .is_ok()
-        {
-            crate::tracing_init::initialize_tracing().await.unwrap();
-        }
+        static ONCE: Once = Once::new();
+        ONCE.call_once(|| crate::tracing_init::initialize_tracing());
     }
 
     /// it's important this is unique between tests as there is one prometheus registry and


### PR DESCRIPTION
also remove tiny bit of raceyness from worker tests, there's a bit of
sync around Once but it's short so it should be fine