### PR TITLE
pass broadcast::Receiver instead of Sender

### DIFF
--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -73,7 +73,7 @@ pub async fn run_worker(
     base_url: &str,
     disable_nuser: bool,
     disable_nsjail: bool,
-    tx: tokio::sync::broadcast::Sender<()>,
+    mut rx: tokio::sync::broadcast::Receiver<()>,
 ) {
     let worker_dir = format!("{TMP_DIR}/{worker_name}");
     tracing::debug!(worker_dir = %worker_dir, worker_name = %worker_name, "Creating worker dir");
@@ -124,8 +124,6 @@ pub async fn run_worker(
     .expect("register prometheus metric");
 
     let mut jobs_executed = 0;
-    let mut rx = tx.subscribe();
-    drop(tx);
 
     loop {
         if last_ping.elapsed().as_secs() > NUM_SECS_ENV_CHECK {
@@ -1403,7 +1401,7 @@ def main():
         let mut listener = PgListener::connect_with(db).await.unwrap();
         listener.listen("insert on completed_job").await.unwrap();
 
-        let (tx, _rx) = tokio::sync::broadcast::channel(1);
+        let (tx, rx) = tokio::sync::broadcast::channel(1);
         /* drop tx at the end of this block to close the channel and stop the worker */
 
         let worker = {
@@ -1432,7 +1430,7 @@ def main():
                 base_url,
                 disable_nuser,
                 disable_nsjail,
-                tx.clone(),
+                rx,
             )
         };
 


### PR DESCRIPTION
I think this was just added a couple months ago.  If all Senders drop
the Receivers close.  This change helps avoid creating Senders that you
never send on that are just held in scope and prevent the channel from
closing.