### PR TITLE
wip: step after forloop results

### DIFF
--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -1390,6 +1390,58 @@ def main():
         assert_eq!(result, serde_json::json!("hello world"));
     }
 
+    #[sqlx::test(fixtures("base"))]
+    async fn test_step_after_loop(db: DB) {
+        initialize_tracing().await;
+
+        let flow: FlowValue = serde_json::from_value(serde_json::json!({
+            "modules": [
+                {
+                    "value": {
+                        "type": "forloopflow",
+                        "iterator": { "type": "static", "value": [2,3,4] },
+                        "value": {
+                            "modules": [
+                                {
+                                    "input_transform": {
+                                        "n": {
+                                            "type": "javascript",
+                                            "expr": "previous_result.iter.value",
+                                        },
+                                    },
+                                    "value": {
+                                        "type": "rawscript",
+                                        "language": "python3",
+                                        "content": "def main(n): return n",
+                                    },
+                                }
+                            ],
+                        }
+                    },
+                },
+                {
+                    "input_transform": {
+                        "items": {
+                            "type": "javascript",
+                            "expr": "previous_result",
+                        },
+                    },
+                    "value": {
+                        "type": "rawscript",
+                        "language": "python3",
+                        "content": "def main(items): return sum(items)",
+                    },
+                },
+            ],
+        }))
+        .unwrap();
+
+        let flow = JobPayload::RawFlow { value: flow, path: None };
+        let result = run_job_in_new_worker_until_complete(&db, flow).await;
+
+        assert_eq!(result, serde_json::json!(9));
+    }
+
     async fn run_job_in_new_worker_until_complete(db: &DB, job: JobPayload) -> serde_json::Value {
         let (uuid, tx) = push(
             db.begin().await.unwrap(),


### PR DESCRIPTION
Adding a failing test so I don't forget out about it.

In the last step, `items` is `4`, the last item in iteration, rather
than the collected list.  My guess is this is because the results aren't
collected unless the flow quits early or the forloop module is the last
module so that `last_step` is true.