### PR TITLE
fix(frontend): Flow loop stop after if expr

### DIFF
--- a/frontend/src/lib/components/ModuleStep.svelte
+++ b/frontend/src/lib/components/ModuleStep.svelte
@@ -94,7 +94,10 @@
 
 		flowStateStore.update((flowState: FlowState) => {
 			const expr = 'Array.isArray(result) && result.length == 0'
-			flowState[indexes[0] - 1].flowModule.stop_after_if_expr = expr
+			const [parentIndex] = indexes
+			if (parentIndex >= 1) {
+				flowState[parentIndex - 1].flowModule.stop_after_if_expr = expr
+			}
 
 			return flowState
 		})

--- a/frontend/src/lib/components/ModuleStep.svelte
+++ b/frontend/src/lib/components/ModuleStep.svelte
@@ -91,6 +91,14 @@
 
 	async function applyCreateLoop() {
 		await apply(createLoop, null)
+
+		flowStateStore.update((flowState: FlowState) => {
+			const expr = 'Array.isArray(result) && result.length == 0'
+			flowState[indexes[0] - 1].flowModule.stop_after_if_expr = expr
+
+			return flowState
+		})
+
 		stepOpened.update(() => `${indexes[0]}-0`)
 	}
 

--- a/frontend/src/lib/components/flows/flowStateUtils.ts
+++ b/frontend/src/lib/components/flows/flowStateUtils.ts
@@ -56,7 +56,7 @@ export async function createLoop(): Promise<FlowModuleSchema> {
 			value: {
 				modules: []
 			},
-			iterator: { type: 'javascript', expr: 'result' },
+			iterator: { type: 'javascript', expr: 'Array.isArray(result) && result.length == 0' },
 			skip_failures: true
 		},
 		input_transform: {}

--- a/frontend/src/lib/components/flows/flowStateUtils.ts
+++ b/frontend/src/lib/components/flows/flowStateUtils.ts
@@ -56,7 +56,7 @@ export async function createLoop(): Promise<FlowModuleSchema> {
 			value: {
 				modules: []
 			},
-			iterator: { type: 'javascript', expr: 'Array.isArray(result) && result.length == 0' },
+			iterator: { type: 'javascript', expr: 'result' },
 			skip_failures: true
 		},
 		input_transform: {}


### PR DESCRIPTION
When creating a loop, set the stop_after_if_expr of the previous step to :
`'Array.isArray(result) && result.length == 0'`