### PR TITLE
feat(frontend): Fix flow preview

### DIFF
--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -698,7 +698,7 @@ print(res_json)
 
                 tx.commit().await?;
                 let mut reserved_variables = get_reserved_variables(job, token, db).await?;
-                if !disable_nuser {
+                if !disable_nsjail {
                     let _ = write_file(
                         job_dir,
                         "run.config.proto",
@@ -718,7 +718,7 @@ print(res_json)
                     workspace_id = %job.workspace_id,
                     "started python code execution"
                 );
-                let child = if !disable_nuser {
+                let child = if !disable_nsjail {
                     Command::new(nsjail_path)
                         .current_dir(job_dir)
                         .env_clear()
@@ -822,7 +822,7 @@ run();
             let mut reserved_variables = get_reserved_variables(job, token, db).await?;
             reserved_variables.insert("RUST_LOG".to_string(), "info".to_string());
 
-            if !disable_nuser {
+            if !disable_nsjail {
                 let _ = write_file(
                     job_dir,
                     "run.config.proto",

--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { goto } from '$app/navigation'
 	import { page } from '$app/stores'
-	import { FlowService, ScheduleService, type Flow } from '$lib/gen'
-	import { clearPreviewResults, previewResults, workspaceStore } from '$lib/stores'
+	import { FlowService, Job, ScheduleService, type Flow } from '$lib/gen'
+	import { workspaceStore } from '$lib/stores'
 	import {
 		encodeState,
 		formatCron,
@@ -20,7 +20,7 @@
 	import FlowPreviewContent from './FlowPreviewContent.svelte'
 	import { flowStateStore, flowStateToFlow, type FlowState } from './flows/flowState'
 	import { flowStore } from './flows/flowStore'
-	import { cleanInputs, jobsToResults } from './flows/utils'
+	import { cleanInputs } from './flows/utils'
 
 	import ScriptSchema from './ScriptSchema.svelte'
 
@@ -146,7 +146,6 @@
 
 	onMount(() => {
 		loadHubScripts()
-		clearPreviewResults()
 	})
 
 	onDestroy(() => {
@@ -248,9 +247,6 @@
 					<FlowPreviewContent
 						bind:args={previewArgs}
 						on:close={() => (previewOpen = !previewOpen)}
-						on:change={(e) => {
-							previewResults.set(jobsToResults(e.detail))
-						}}
 					/>
 				</div>
 			{/if}

--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -152,7 +152,6 @@
 		//@ts-ignore
 		$flowStore = undefined
 		//@ts-ignore
-
 		$flowStateStore = undefined
 	})
 </script>

--- a/frontend/src/lib/components/FlowPreview.svelte
+++ b/frontend/src/lib/components/FlowPreview.svelte
@@ -32,7 +32,7 @@
 	let jobs = []
 	let jobId: string
 
-	$: dispatch('change', jobs)
+	$: dispatch('change', { jobs, config: tab })
 
 	export async function runPreview(args: any) {
 		viewPreview = true

--- a/frontend/src/lib/components/FlowPreviewContent.svelte
+++ b/frontend/src/lib/components/FlowPreviewContent.svelte
@@ -41,9 +41,11 @@
 				x.forEach((y, j) => {
 					if (`result` in y) {
 						innerResults.push(y.result)
-						$flowStateStore[i].childFlowModules![j].previewResults = JSON.parse(
-							JSON.stringify(innerResults)
-						)
+						if ($flowStateStore[i].childFlowModules![j] != undefined) {
+							$flowStateStore[i].childFlowModules![j].previewResults = JSON.parse(
+								JSON.stringify(innerResults)
+							)
+						}
 					}
 				})
 				resultsSoFar.push(innerResults)

--- a/frontend/src/lib/components/FlowPreviewContent.svelte
+++ b/frontend/src/lib/components/FlowPreviewContent.svelte
@@ -8,6 +8,7 @@
 	import Icon from 'svelte-awesome'
 	import FlowJobResult from './FlowJobResult.svelte'
 	import { flowStateStore, flowStateToFlow } from './flows/flowState'
+	import { mapJobResultsToFlowState } from './flows/flowStateUtils'
 	import { flowStore } from './flows/flowStore'
 	import { runFlowPreview } from './flows/utils'
 	import FlowStatusViewer from './FlowStatusViewer.svelte'
@@ -17,43 +18,20 @@
 
 	let intervalId: NodeJS.Timer
 	let job: Job | undefined
-	let jobs: (Job | Job[])[] = []
 	let jobId: string
 	let isValid: boolean = false
+
+	$: newFlow = flowStateToFlow($flowStateStore, $flowStore)
+	$: steps = newFlow.value.modules.length
 
 	const dispatch = createEventDispatcher()
 
 	export async function runPreview(args: Record<string, any>) {
 		intervalId && clearInterval(intervalId)
-		const newFlow = flowStateToFlow($flowStateStore, $flowStore)
 
 		jobId = await runFlowPreview(args, newFlow)
-		jobs = []
 		intervalId = setInterval(loadJob, 1000)
 		sendUserToast(`started preview ${truncateRev(jobId, 10)}`)
-	}
-
-	$: {
-		const resultsSoFar: any[] = []
-		jobs.map((x, i) => {
-			if (Array.isArray(x)) {
-				const innerResults: any[] = []
-				x.forEach((y, j) => {
-					if (`result` in y) {
-						innerResults.push(y.result)
-						if ($flowStateStore[i].childFlowModules![j] != undefined) {
-							$flowStateStore[i].childFlowModules![j].previewResult = JSON.parse(
-								JSON.stringify(innerResults)
-							)
-						}
-					}
-				})
-				resultsSoFar.push(innerResults)
-			} else if (`result` in x) {
-				resultsSoFar.push(x.result)
-			}
-			$flowStateStore[i].previewResult = JSON.parse(JSON.stringify(resultsSoFar))
-		})
 	}
 
 	async function loadJob() {
@@ -89,7 +67,10 @@
 	<div class="h-full overflow-y-auto mb-16 grow">
 		{#if job}
 			<div class="w-full">
-				<FlowStatusViewer {job} bind:jobs />
+				<FlowStatusViewer
+					{job}
+					on:jobsLoaded={(e) => mapJobResultsToFlowState(e.detail, 'upto', steps)}
+				/>
 			</div>
 			{#if `result` in job}
 				<FlowJobResult {job} />

--- a/frontend/src/lib/components/FlowPreviewContent.svelte
+++ b/frontend/src/lib/components/FlowPreviewContent.svelte
@@ -69,7 +69,7 @@
 			<div class="w-full">
 				<FlowStatusViewer
 					{job}
-					on:jobsLoaded={(e) => mapJobResultsToFlowState(e.detail, 'upto', steps)}
+					on:jobsLoaded={(e) => mapJobResultsToFlowState(e.detail, 'upto', steps - 1)}
 				/>
 			</div>
 			{#if `result` in job}

--- a/frontend/src/lib/components/FlowStatusViewer.svelte
+++ b/frontend/src/lib/components/FlowStatusViewer.svelte
@@ -10,16 +10,18 @@
 	import FlowJobResult from './FlowJobResult.svelte'
 	import JobStatus from './JobStatus.svelte'
 	import IconedPath from './IconedPath.svelte'
+	import { createEventDispatcher, onMount } from 'svelte'
+	const dispatch = createEventDispatcher()
 
 	export let job: QueuedJob | CompletedJob
-	export let jobs: (Job | Job[] | undefined)[] = []
 	export let fullyRetrieved = -1
 
 	let lastJobid: string | undefined
-
 	let forloop_selected = ''
-
 	let pres: { [key: number]: HTMLElement } = {}
+
+	$: jobs = [] as Array<any>
+	$: jobs && dispatch('jobsLoaded', jobs)
 
 	async function loadResults() {
 		if (!('success' in job)) {
@@ -81,7 +83,9 @@
 		return x as CompletedJob[]
 	}
 
-	$: $workspaceStore && job && loadResults()
+	onMount(() => {
+		$workspaceStore && job && loadResults()
+	})
 </script>
 
 <div class="flow-root w-full p-6">

--- a/frontend/src/lib/components/FlowStatusViewer.svelte
+++ b/frontend/src/lib/components/FlowStatusViewer.svelte
@@ -21,7 +21,7 @@
 	let pres: { [key: number]: HTMLElement } = {}
 
 	$: jobs = [] as Array<any>
-	$: jobs.length > 0 && dispatch('jobsLoaded', jobs)
+	$: jobs && dispatch('jobsLoaded', jobs)
 	$: $workspaceStore && job && loadResults()
 
 	async function loadResults() {

--- a/frontend/src/lib/components/FlowStatusViewer.svelte
+++ b/frontend/src/lib/components/FlowStatusViewer.svelte
@@ -10,7 +10,7 @@
 	import FlowJobResult from './FlowJobResult.svelte'
 	import JobStatus from './JobStatus.svelte'
 	import IconedPath from './IconedPath.svelte'
-	import { createEventDispatcher, onMount } from 'svelte'
+	import { createEventDispatcher } from 'svelte'
 	const dispatch = createEventDispatcher()
 
 	export let job: QueuedJob | CompletedJob
@@ -21,7 +21,8 @@
 	let pres: { [key: number]: HTMLElement } = {}
 
 	$: jobs = [] as Array<any>
-	$: jobs && dispatch('jobsLoaded', jobs)
+	$: jobs.length > 0 && dispatch('jobsLoaded', jobs)
+	$: $workspaceStore && job && loadResults()
 
 	async function loadResults() {
 		if (!('success' in job)) {
@@ -82,10 +83,6 @@
 	function toCompletedJobs(x: any): CompletedJob[] {
 		return x as CompletedJob[]
 	}
-
-	onMount(() => {
-		$workspaceStore && job && loadResults()
-	})
 </script>
 
 <div class="flow-root w-full p-6">
@@ -98,6 +95,7 @@
 			</div>
 		{/if}
 	</div>
+
 	<JobStatus {job} />
 
 	<p class="text-gray-500 mb-6 w-full text-center">

--- a/frontend/src/lib/components/ModuleStep.svelte
+++ b/frontend/src/lib/components/ModuleStep.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Job, RawScript, type Flow, type FlowModule } from '$lib/gen'
+	import { RawScript, type FlowModule } from '$lib/gen'
 	import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons'
 	import Icon from 'svelte-awesome'
 	import Editor from './Editor.svelte'
@@ -19,19 +19,16 @@
 		isEmptyFlowModule,
 		getStepPropPicker
 	} from './flows/flowStateUtils'
-	import { jobsToResults } from './flows/utils'
 	import SchemaForm from './SchemaForm.svelte'
 	import type { Schema } from '$lib/common'
-	import { flowStateStore, type FlowModuleSchema, type FlowState } from './flows/flowState'
+	import { flowStateStore, type FlowModuleSchema } from './flows/flowState'
 	import { stepOpened } from './flows/stepOpenedStore'
-	import { connectdevelop } from 'svelte-awesome/icons'
 
 	export let indexes: number[]
 	export let mod: FlowModule
 	export let args: Record<string, any> = {}
 	export let schema: Schema
 	export let childFlowModules: FlowModuleSchema[] | undefined = undefined
-	export let previewResult: any
 
 	let editor: Editor
 	let websocketAlive = { pyright: false, black: false, deno: false }
@@ -60,23 +57,6 @@
 	async function applyCreateLoop() {
 		await apply(createLoop, null)
 		stepOpened.update(() => `${indexes[0]}-0`)
-	}
-
-	function onPreview(jobs: Job[], config: 'upto' | 'justthis'): void {
-		/*
-		if (config === 'justthis') {
-			const [result] = jobsToResults(jobs)
-			previewResult = result
-		} else {
-			const result = jobsToResults(jobs)
-			flowStateStore.update((flowState: FlowState) => {
-				return flowState.map((flowModuleSchema: FlowModuleSchema, index) => {
-					flowModuleSchema.previewResult = result[index]
-					return flowModuleSchema
-				})
-			})
-		}
-		*/
 	}
 
 	$: opened = $stepOpened === String(indexes.join('-'))
@@ -160,13 +140,7 @@
 				{#if !shouldPick}
 					<div class="border-b border-gray-200" />
 					<div class="p-3">
-						<FlowPreview
-							bind:args
-							flow={$flowStore}
-							{i}
-							{schema}
-							on:change={(e) => onPreview(e.detail.jobs, e.detail.config)}
-						/>
+						<FlowPreview bind:args flow={$flowStore} {i} {schema} />
 					</div>
 				{/if}
 			</div>

--- a/frontend/src/lib/components/flows/FlowBox.svelte
+++ b/frontend/src/lib/components/flows/FlowBox.svelte
@@ -4,7 +4,7 @@
 	let slots = $$props.$$slots
 </script>
 
-<div class="bg-white border border-gray-300 rounded-md">
+<div class="bg-white border border-gray-300 rounded-md shadow-md">
 	<FlowBoxHeader {title}>
 		<slot name="header" />
 	</FlowBoxHeader>

--- a/frontend/src/lib/components/flows/FlowTimeline.svelte
+++ b/frontend/src/lib/components/flows/FlowTimeline.svelte
@@ -160,7 +160,6 @@
 							bind:args
 							bind:schema={flowModuleSchema.schema}
 							bind:childFlowModules={flowModuleSchema.childFlowModules}
-							bind:previewResult={flowModuleSchema.previewResult}
 							on:delete={() => removeAtIndex(index)}
 						/>
 					</span>

--- a/frontend/src/lib/components/flows/FlowTimeline.svelte
+++ b/frontend/src/lib/components/flows/FlowTimeline.svelte
@@ -8,10 +8,7 @@
 	} from '@fortawesome/free-solid-svg-icons'
 	import { Button, Toggle, Tooltip } from 'flowbite-svelte'
 	import Icon from 'svelte-awesome'
-	import { Highlight } from 'svelte-highlight'
-	import typescript from 'svelte-highlight/languages/typescript'
 	import ModuleStep from '../ModuleStep.svelte'
-	import ObjectViewer from '../propertyPicker/ObjectViewer.svelte'
 	import FlowInput from './FlowInput.svelte'
 	import type { FlowState } from './flowState'
 	import { emptyFlowModuleSchema } from './flowStateUtils'
@@ -104,12 +101,6 @@
 							>
 						</span>
 						<span class="flex items-center space-x-2">
-							<!-- 		{#if flowModuleSchema.flowModule.value.iterator.type === 'javascript'}
-								<Highlight
-									language={typescript}
-									code={flowModuleSchema.flowModule.value.iterator.expr}
-								/>
-							{/if} -->
 							<Toggle size="small" bind:checked={flowModuleSchema.flowModule.value.skip_failures}>
 								Skip failures
 							</Toggle>
@@ -169,11 +160,8 @@
 							bind:args
 							bind:schema={flowModuleSchema.schema}
 							bind:childFlowModules={flowModuleSchema.childFlowModules}
-							bind:previewResults={flowModuleSchema.previewResults}
+							bind:previewResult={flowModuleSchema.previewResult}
 							on:delete={() => removeAtIndex(index)}
-							previousStepPreviewResults={index === 0
-								? []
-								: flowModuleSchemas[index - 1].previewResults}
 						/>
 					</span>
 				</li>

--- a/frontend/src/lib/components/flows/flowState.ts
+++ b/frontend/src/lib/components/flows/flowState.ts
@@ -7,7 +7,7 @@ export type FlowModuleSchema = {
 	flowModule: FlowModule
 	schema: Schema
 	childFlowModules?: FlowModuleSchema[]
-	previewResults: Array<any>
+	previewResult?: any
 }
 
 export type FlowState = FlowModuleSchema[]

--- a/frontend/src/lib/components/flows/flowStateUtils.ts
+++ b/frontend/src/lib/components/flows/flowStateUtils.ts
@@ -200,7 +200,7 @@ export function getStepPropPicker(
 	args: Record<string, any>
 ): StepPropPicker {
 	const isInsideLoop: boolean = indexes.length > 1
-	const [parentIndex, childIndex] = indexes
+	const [parentIndex] = indexes
 
 	const flowInput = schemaToObject(flowInputSchema, args)
 	const results = getPreviousResults(flowState, parentIndex)
@@ -224,17 +224,7 @@ export function getStepPropPicker(
 			}
 		}
 
-		/*
-		const forLoopResults = getPreviousResults(flowState[parentIndex]?.childFlowModules, childIndex)
-		const forLoopLastResult =
-			forLoopResults.length > 0 ? forLoopResults[forLoopResults.length - 1] : undefined
-		*/
-
-		const extraLib = buildExtraLib(
-			objectToTsType(forLoopFlowInput),
-			//objectToTsType(forLoopLastResult)
-			undefined
-		)
+		const extraLib = buildExtraLib(objectToTsType(forLoopFlowInput), undefined)
 
 		return {
 			extraLib,
@@ -292,8 +282,6 @@ export function mapJobResultsToFlowState(
 		})
 	} else {
 		const result = jobsToResults(jobs)
-
-		console.log(result, configIndex)
 
 		flowStateStore.update((flowState: FlowState) => {
 			if (!Array.isArray(flowState)) {

--- a/frontend/src/lib/components/flows/flowStateUtils.ts
+++ b/frontend/src/lib/components/flows/flowStateUtils.ts
@@ -271,15 +271,7 @@ function getPreviousResults(
 }
 
 function extractPreviewResults(flowModuleSchemas: FlowModuleSchema[]) {
-	return flowModuleSchemas.map((fms) => {
-		if (fms.flowModule.value.type === 'forloopflow') {
-			const { childFlowModules } = fms
-
-			return Array.isArray(childFlowModules) ? childFlowModules.map((c) => c.previewResult) : []
-		} else {
-			return fms.previewResult
-		}
-	})
+	return flowModuleSchemas.map((fms) => fms.previewResult)
 }
 
 export function mapJobResultsToFlowState(
@@ -300,6 +292,9 @@ export function mapJobResultsToFlowState(
 		})
 	} else {
 		const result = jobsToResults(jobs)
+
+		console.log(result, configIndex)
+
 		flowStateStore.update((flowState: FlowState) => {
 			if (!Array.isArray(flowState)) {
 				return flowState

--- a/frontend/src/lib/components/flows/flowStateUtils.ts
+++ b/frontend/src/lib/components/flows/flowStateUtils.ts
@@ -1,8 +1,16 @@
 import type { Schema } from '$lib/common'
-import { ScriptService, type FlowModule, type RawScript } from '$lib/gen'
+import { ScriptService, type Flow, type FlowModule, type RawScript } from '$lib/gen'
 import { initialCode } from '$lib/script_helpers'
 import { userStore, workspaceStore } from '$lib/stores'
-import { emptyModule, emptySchema, getScriptByPath } from '$lib/utils'
+import {
+	buildExtraLib,
+	emptyModule,
+	emptySchema,
+	getScriptByPath,
+	objectToTsType,
+	schemaToObject,
+	schemaToTsType
+} from '$lib/utils'
 import { get } from 'svelte/store'
 import type { FlowModuleSchema, FlowState } from './flowState'
 import { flowStore } from './flowStore'
@@ -11,8 +19,7 @@ import { loadSchemaFromModule } from './utils'
 export function emptyFlowModuleSchema(): FlowModuleSchema {
 	return {
 		flowModule: emptyModule(),
-		schema: emptySchema(),
-		previewResults: []
+		schema: emptySchema()
 	}
 }
 
@@ -22,9 +29,9 @@ export async function loadFlowModuleSchema(flowModule: FlowModule): Promise<Flow
 
 		flowModule.input_transform = input_transform
 
-		return { flowModule, schema, previewResults: [] }
+		return { flowModule, schema }
 	} catch (e) {
-		return { flowModule, schema: emptySchema(), previewResults: [] }
+		return { flowModule, schema: emptySchema() }
 	}
 }
 
@@ -73,7 +80,7 @@ export async function createLoop(): Promise<FlowModuleSchema> {
 		flowModule,
 		schema,
 		childFlowModules: [emptyFlowModuleSchema()],
-		previewResults: []
+		previewResult: undefined
 	}
 }
 
@@ -171,4 +178,102 @@ async function findNextAvailablePath(path: string): Promise<string> {
 
 export function isEmptyFlowModule(flowModule: FlowModule): boolean {
 	return flowModule.value.type === 'script' && flowModule.value.path === ''
+}
+
+type Result = any
+
+type PickableProperties = {
+	flow_input?: Object
+	previous_result: Result | undefined
+	step: Result[]
+}
+
+type StepPropPicker = {
+	pickableProperties: PickableProperties
+	extraLib: string
+}
+
+export function getStepPropPicker(
+	indexes: number[],
+	flowInputSchema: Schema,
+	flowState: FlowState,
+	args: Record<string, any>
+): StepPropPicker {
+	const isInsideLoop: boolean = indexes.length > 1
+	const [parentIndex, childIndex] = indexes
+
+	const flowInput = schemaToObject(flowInputSchema, args)
+	const results = getPreviousResults(flowState, parentIndex)
+	const lastResult = results.length > 0 ? results[results.length - 1] : undefined
+
+	if (isInsideLoop) {
+		const forLoopFlowInput = {
+			...flowInput,
+			iter: {
+				value: "Iteration's value",
+				index: "Iteration's index"
+			}
+		}
+
+		if (Array.isArray(lastResult) && lastResult.length > 0) {
+			const last = lastResult[lastResult.length - 1]
+
+			forLoopFlowInput.iter = {
+				value: last,
+				index: `Iteration's index (0 to ${lastResult.length - 1})`
+			}
+		}
+
+		const forLoopResults = getPreviousResults(flowState[parentIndex]?.childFlowModules, childIndex)
+		const forLoopLastResult =
+			forLoopResults.length > 0 ? forLoopResults[forLoopResults.length - 1] : undefined
+
+		const extraLib = buildExtraLib(
+			objectToTsType(forLoopFlowInput),
+			objectToTsType(forLoopLastResult)
+		)
+
+		return {
+			extraLib,
+			pickableProperties: {
+				flow_input: forLoopFlowInput,
+				step: forLoopResults,
+				previous_result: forLoopLastResult
+			}
+		}
+	} else {
+		const extraLib = buildExtraLib(schemaToTsType(flowInputSchema), objectToTsType(lastResult))
+
+		return {
+			extraLib,
+			pickableProperties: {
+				flow_input: flowInput,
+				step: results,
+				previous_result: lastResult
+			}
+		}
+	}
+}
+
+function getPreviousResults(
+	flowModuleSchemas: FlowModuleSchema[] | undefined,
+	target: number
+): Result[] {
+	if (!Array.isArray(flowModuleSchemas) || target < 1) {
+		return []
+	}
+
+	return extractPreviewResults(flowModuleSchemas.splice(0, target))
+}
+
+function extractPreviewResults(flowModuleSchemas: FlowModuleSchema[]) {
+	return flowModuleSchemas.map((fms) => {
+		if (fms.flowModule.value.type === 'forloopflow') {
+			const { childFlowModules } = fms
+
+			return Array.isArray(childFlowModules) ? childFlowModules.map((c) => c.previewResult) : []
+		} else {
+			return fms.previewResult
+		}
+	})
 }

--- a/frontend/src/lib/components/flows/utils.ts
+++ b/frontend/src/lib/components/flows/utils.ts
@@ -124,49 +124,12 @@ export function getDefaultExpr(
 	previousExpr?: string
 ) {
 	const expr = previousExpr ?? `previous_result.${key}`
-	return `import { previous_result, flow_input, step, variable, resource, params } from 'windmill${importPath ? `@${importPath}` : ''
-		}'
+	return `import { previous_result, flow_input, step, variable, resource, params } from 'windmill${
+		importPath ? `@${importPath}` : ''
+	}'
 
 ${expr}`
 }
-
-// export function getPickableProperties(
-// 	schema: Schema,
-// 	args: Record<string, any>,
-// 	previewResults: Record<number, Object>,
-// 	i: number
-// ) {
-// 	const flowInputAsObject = schemaToObject(schema, args)
-// 	const flowInput =
-// 		mode === 'pull' && i >= 1
-// 			? computeFlowInputPull(previewResults[0], flowInputAsObject)
-// 			: flowInputAsObject
-
-// 	let previous_result
-// 	if (i === 0 || (i == 1 && mode == 'pull')) {
-// 		previous_result = flowInput
-// 	} else if (mode == 'pull') {
-// 		previous_result = previewResults[1] ? previewResults[1][i - 2] : undefined
-// 	} else {
-// 		previous_result = previewResults[i - 1]
-// 	}
-
-// 	let step: any[]
-// 	if (i >= 1 && mode == 'push') {
-// 		step = Object.values(previewResults).slice(0, i)
-// 	} else if (i >= 2 && mode == 'pull') {
-// 		step = Object.values(previewResults[1] ?? {}).slice(0, i - 1)
-// 	} else {
-// 		step = []
-// 	}
-// 	const pickableProperties = {
-// 		flow_input: flowInput,
-// 		previous_result,
-// 		step
-// 	}
-
-// 	return pickableProperties
-// }
 
 export function jobsToResults(jobs: Job[]) {
 	return jobs.map((job) => {

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -24,12 +24,12 @@ export const usersWorkspaceStore = writable<UserWorkspaceList | undefined>(undef
 export const superadmin = writable<String | false | undefined>(undefined)
 export const hubScripts = writable<
 	| Array<{
-		path: string
-		summary: string
-		approved: boolean
-		is_trigger: boolean,
-		app: string
-	}>
+			path: string
+			summary: string
+			approved: boolean
+			is_trigger: boolean
+			app: string
+	  }>
 	| undefined
 >(undefined)
 
@@ -51,10 +51,3 @@ export function clearStores(): void {
 	usersWorkspaceStore.set(undefined)
 	superadmin.set(undefined)
 }
-
-export const previewResults = writable<Record<number, Object>>({})
-
-export function clearPreviewResults() {
-	previewResults.set({})
-}
-

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -41,8 +41,9 @@ export function displayDate(dateString: string | undefined): string {
 	if (date.toString() === 'Invalid Date') {
 		return ''
 	} else {
-		return `${date.getFullYear()}/${date.getMonth() + 1
-			}/${date.getDate()} at ${date.toLocaleTimeString()}`
+		return `${date.getFullYear()}/${
+			date.getMonth() + 1
+		}/${date.getDate()} at ${date.toLocaleTimeString()}`
 	}
 }
 

--- a/frontend/src/routes/run/[...run].svelte
+++ b/frontend/src/routes/run/[...run].svelte
@@ -55,7 +55,6 @@
 
 	let intervalId: NodeJS.Timer
 	let job: Job | undefined
-	let jobs = []
 	let error: Error | undefined
 	const iconScale = 1
 	let syncIteration: number = 0
@@ -331,7 +330,7 @@
 			{#if job?.job_kind == 'flow' || job?.job_kind == 'flowpreview'}
 				<div class="mt-10" />
 				<div class="max-w-lg">
-					<FlowStatusViewer {job} bind:jobs />
+					<FlowStatusViewer {job} />
 				</div>
 			{/if}
 		</div>


### PR DESCRIPTION
Refactor how the previews are used to populate the prop picker and add code completion in the raw JS editor.

Each module contains its latest result.

When a preview  is run:
- `mapJobResultsToFlowState` takes the results of a preview. and updates the FlowState accordingly.
- Each `ModuleStep` uses `getStepPropPicker` to get the pickable properties and its corresponding type definition

This implementation doesn't support intermediate results in for loops yet.