### PR TITLE
optional ro mount /etc/pki in nsjail

### DIFF
--- a/nsjail/download.config.proto
+++ b/nsjail/download.config.proto
@@ -51,6 +51,13 @@ mount {
 }
 
 mount {
+    src: "/etc/pki"
+    dst: "/etc/pki"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
     src: "/etc/ca-certificates"
     dst: "/etc/ca-certificates"
 	is_bind: true

--- a/nsjail/run.deno.config.proto
+++ b/nsjail/run.deno.config.proto
@@ -86,6 +86,13 @@ mount {
 }
 
 mount {
+    src: "/etc/pki"
+    dst: "/etc/pki"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"
 	is_bind: true

--- a/nsjail/run.python3.config.proto
+++ b/nsjail/run.python3.config.proto
@@ -97,6 +97,13 @@ mount {
 }
 
 mount {
+    src: "/etc/pki"
+    dst: "/etc/pki"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"
 	is_bind: true


### PR DESCRIPTION
contents of /etc/ssl symlink to /etc/pki on my system (Fedora) so some
programs (like pip) fail without /etc/pki