### PR TITLE
fix(editor): validation of strings is broken on empty strings

### DIFF
--- a/frontend/src/lib/components/ArgInput.svelte
+++ b/frontend/src/lib/components/ArgInput.svelte
@@ -108,7 +108,7 @@
 	}
 
 	function validateInput(pattern: string | undefined, v: any): void {
-		if (required && (v == undefined || v == null)) {
+		if (required && (v == undefined || v == null || (type === 'string' && v === ''))) {
 			error = 'This field is required'
 			valid = false
 		} else {
@@ -170,7 +170,7 @@
 							{:else if type == 'array'}
 								<select bind:value={itemsType}>
 									<option value={undefined}>No specific item type</option>
-									<option value={{ type: 'string' }}> Items are strings</option>
+									<option value={{ type: 'string' }}>Items are strings</option>
 									<option value={{ type: 'number' }}>Items are numbers</option>
 									<option value={{ type: 'string', contentEncoding: 'base64' }}
 										>Items are bytes</option


### PR DESCRIPTION
I could not find spec for this frontend component (yet) but to reproduce the bug, open any script that requires a non-empty string as parameter. In the editor, give a value to this parameters, and then empty the field. The validation still says that the input is correct even if it should not (as it's empty)