### PR TITLE
remove delay between spawning each worker

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -12,7 +12,6 @@ use axum::{handler::Handler, middleware::from_extractor, routing::get, Extension
 use db::DB;
 use futures::FutureExt;
 use git_version::git_version;
-use rand::Rng;
 use slack_http_verifier::SlackVerifier;
 use std::{net::SocketAddr, sync::Arc};
 use tower::ServiceBuilder;
@@ -234,7 +233,6 @@ pub async fn run_workers(
     });
 
     let mut handles = Vec::new();
-    let mut rng = rand::thread_rng();
 
     for i in 1..(num_workers + 1) {
         let db1 = db.clone();
@@ -259,11 +257,6 @@ pub async fn run_workers(
             )
             .await
         }));
-        //avoid having all the workers start at the same time
-        tokio::time::sleep(std::time::Duration::from_millis(
-            rng.gen_range(0..sleep_queue * num_workers as u64),
-        ))
-        .await;
     }
     futures::future::try_join_all(handles).await?;
     Ok(())


### PR DESCRIPTION
This is a little bit annoying. You seemed amicable to having this removed on the call but if you are concerned about initiating a lot of database connections at once let me know.

It's particularly annoying because the delay between workers increases with the number of workers.