### PR TITLE
concurrency_limit(32) on api server

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -120,6 +120,7 @@ pub async fn run_server(
         .build()
         .map_err(to_anyhow)?;
     let middleware_stack = ServiceBuilder::new()
+        .concurrency_limit(32)
         .layer(
             TraceLayer::new_for_http()
                 .on_response(MyOnResponse {})


### PR DESCRIPTION
We should think about setting some concurrency limit on handling API requests, mostly because they'll often tie up a database connection to handle the request and I think this can lead to the workers being starved of database connections since they share the same pool. We could also think about having two separate pools avoid that, but we might want to allow users to set a concurrency limit anyway.

32 is not the correct number it's just a placeholder, maybe it should be an environment variable like everything else is?