### PR TITLE
No logs is available -> No logs are available

### DIFF
--- a/frontend/src/lib/components/LogViewer.svelte
+++ b/frontend/src/lib/components/LogViewer.svelte
@@ -19,7 +19,7 @@
 <div class="relative w-full h-full">
 	<div bind:this={div} class="w-full h-full overflow-auto bg-gray-50 relative">
 		<pre
-			class="whitespace-pre-wrap break-all bg-gray-50 text-xs w-full p-2">{#if content}{content}{:else if isLoading}Waiting for job to start...{:else}No logs is available yet{/if}</pre>
+			class="whitespace-pre-wrap break-all bg-gray-50 text-xs w-full p-2">{#if content}{content}{:else if isLoading}Waiting for job to start...{:else}No logs are available yet{/if}</pre>
 	</div>
 	<div class="absolute top-0 right-0 mr-2 text-gray-500 text-sm bg-gray-50/20">
 		Auto scroll


### PR DESCRIPTION
"are" because "logs" is plural

![Screenshot 2022-09-29 at 18-39-35 New Script Windmill](https://user-images.githubusercontent.com/10872136/193089529-02c23907-fb94-49c5-937e-f7f33b66e76c.png)
