### PR TITLE
fix(frontend): do only one request if job is completed [related to #649]

### DIFF
--- a/frontend/src/lib/components/TestJobLoader.svelte
+++ b/frontend/src/lib/components/TestJobLoader.svelte
@@ -65,14 +65,17 @@
 		console.log('watch jobs')
 
 		job = undefined
-		await loadTestJob(testId)
 		syncIteration = 0
-		intervalId = setInterval(() => {
-			syncer(testId)
-		}, 500)
+		const isCompleted = await loadTestJob(testId)
+		if (!isCompleted) {
+			intervalId = setInterval(() => {
+				syncer(testId)
+			}, 500)
+		}
 	}
 
-	async function loadTestJob(id: string): Promise<void> {
+	async function loadTestJob(id: string): Promise<boolean> {
+		let isCompleted = false
 		try {
 			if (job && `running` in job) {
 				let previewJobUpdates = await JobService.getJobUpdates({
@@ -93,6 +96,7 @@
 			}
 			if (job?.type === 'CompletedJob') {
 				//only CompletedJob has success property
+				isCompleted = true
 				clearInterval(intervalId)
 				if (isLoading) {
 					dispatch('done', job)
@@ -102,6 +106,7 @@
 		} catch (err) {
 			console.error(err)
 		}
+		return isCompleted
 	}
 
 	function syncer(id: string): void {


### PR DESCRIPTION
commit 9592c92f70ce9b94e141031c663ccb0cf01ef7d7 introduced a fix for an issue described in #649. After mentioned fix frontend performs 2 requests instead of 1.

This fix can be considered as a vol.2 for #649