### PR TITLE
feat: support struct in Go as script parameters

### DIFF
--- a/frontend/src/lib/components/DisplayResult.svelte
+++ b/frontend/src/lib/components/DisplayResult.svelte
@@ -130,7 +130,7 @@
 				>
 			</div>
 		{:else if !forceJson && resultKind == 'error'}<div
-				><pre class="text-sm text-red-500">{result.error}</pre>
+				><pre class="text-sm text-red-500 whitespace-pre-wrap">{result.error}</pre>
 			</div>
 		{:else}<Highlight
 				language={json}

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -167,19 +167,6 @@
 											Move the focus outside of the text editor to recompute the input schema from
 											main signature or press Ctrl/Cmd+S
 										</p>
-										<p class="mt-4">
-											{#if isValid}
-												<Icon data={faCheck} class="text-green-600 mr-1" scale={0.6} />
-												The current preview input matches requirements defined in arguments
-											{:else}
-												<Icon
-													data={faExclamationTriangle}
-													class="text-yellow-500 mr-1"
-													scale={0.6}
-												/>
-												The current preview input doesn't match requirements defined in arguments
-											{/if}
-										</p>
 									</div>
 									<SchemaForm {schema} bind:args bind:isValid />
 								</div>

--- a/nsjail/run.go.config.proto
+++ b/nsjail/run.go.config.proto
@@ -85,6 +85,12 @@ mount {
 }
 
 mount {
+    src: "{JOB_DIR}/inner/runner.go"
+    dst: "/tmp/go/inner/runner.go"
+    is_bind: true
+}
+
+mount {
     src: "{JOB_DIR}/args.json"
     dst: "/tmp/go/args.json"
     is_bind: true


### PR DESCRIPTION
Fix #697 

![Screenshot 2022-10-08 at 19-56-48 New Script Windmill](https://user-images.githubusercontent.com/275584/194721033-544968f4-ef0b-4529-9ac6-c57cb8485d5f.png)

Some limitations, it doesn't work with named structs, only inlined structs and `json:'XX'` must always be specified as a tag