### PR TITLE
chore(python-client): update minimal python version

### DIFF
--- a/python-client/wmill/pyproject.toml
+++ b/python-client/wmill/pyproject.toml
@@ -15,7 +15,7 @@ packages = [
 include = ["wmill/py.typed"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.10"
 windmill-api = "^1.38.1"
 
 [build-system]

--- a/python-client/wmill_pg/pyproject.toml
+++ b/python-client/wmill_pg/pyproject.toml
@@ -15,7 +15,7 @@ packages = [
 include = ["wmill_pg/py.typed"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.10"
 wmill = "^1.5.0"
 psycopg2-binary = "*"
 


### PR DESCRIPTION
this is related to https://github.com/windmill-labs/windmill/issues/736#issuecomment-1279679730

turns out that `wmill` and `wmill_pg` require python3.10 now

## how it was tested
```console
docker run -it python:3.9 /bin/bash
```
```console
pip install wmill && python3 -c 'import wmill'
pip install wmill_pg && python3 -c 'import wmill_pg'
```
vs
```console
docker run -it python:3.10 /bin/bash
```
```console
pip install wmill && python3 -c 'import wmill'
pip install wmill_pg && python3 -c 'import wmill_pg'
```