### PR TITLE
fix(python-client): provide backwards compatibility down to python3.7…

### DIFF
--- a/python-client/wmill/pyproject.toml
+++ b/python-client/wmill/pyproject.toml
@@ -15,7 +15,7 @@ packages = [
 include = ["wmill/py.typed"]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.7"
 windmill-api = "^1.38.1"
 
 [build-system]

--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -27,9 +27,9 @@ class JobStatus(Enum):
     RUNNING = 2
     COMPLETED = 3
 
-_client: AuthenticatedClient | None = None
+_client: "AuthenticatedClient | None" = None
 
-def create_client(base_url: str | None = None, token: str | None = None) -> AuthenticatedClient:
+def create_client(base_url: "str | None" = None, token: "str | None" = None) -> AuthenticatedClient:
     env_base_url = os.environ.get("BASE_INTERNAL_URL")
 
     if env_base_url is not None:

--- a/python-client/wmill_pg/pyproject.toml
+++ b/python-client/wmill_pg/pyproject.toml
@@ -15,7 +15,7 @@ packages = [
 include = ["wmill_pg/py.typed"]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.7"
 wmill = "^1.5.0"
 psycopg2-binary = "*"
 

--- a/python-client/wmill_pg/wmill_pg/client.py
+++ b/python-client/wmill_pg/wmill_pg/client.py
@@ -5,7 +5,7 @@ import wmill
 import psycopg2
 
 
-def query(query: str, connection: str | dict[str, Any] = "g/all/postgres") -> list[tuple[Any, ...]] | None:
+def query(query: str, connection: "str | dict[str, Any]" = "g/all/postgres") -> "list[tuple[Any, ...]] | None":
     """
     Query a postgres database using psycopg2 library underneath. See its documentation for more info.
 


### PR DESCRIPTION
… (#738)

this reverts b46d0ff11db454954561c8df0ee6fe35b02fd7d3 introducing alternative way of avoiding bug described in
https://github.com/windmill-labs/windmill/issues/736#issuecomment-1279679730

the improvement here is that we're able to support more python versions now

## backround
I learned about this fix thanks to this comment: https://github.com/tiangolo/typer/issues/371#issuecomment-1073649190

## how it was tested
for each
* `docker container run -it --mount type=bind,source=/home/kuba/projects/windmill/python-client,target=/data python:3.7 /bin/bash`
* `docker container run -it --mount type=bind,source=/home/kuba/projects/windmill/python-client,target=/data python:3.8 /bin/bash`
* `docker container run -it --mount type=bind,source=/home/kuba/projects/windmill/python-client,target=/data python:3.9 /bin/bash`
* `docker container run -it --mount type=bind,source=/home/kuba/projects/windmill/python-client,target=/data python:3.10 /bin/bash`

this was run:
```console
pip install poetry
cd /data/wmill
poetry shell
poetry install
python3 -c 'import wmill'
```