### PR TITLE
chore(backend): allow disabling nsjail for unit tests

### DIFF
--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -3526,8 +3526,14 @@ def main(error, port):
         let worker_config = WorkerConfig {
             base_internal_url: String::new(),
             base_url: String::new(),
-            disable_nuser: false,
-            disable_nsjail: false,
+            disable_nuser: std::env::var("DISABLE_NUSER")
+                    .ok()
+                    .and_then(|x| x.parse::<bool>().ok())
+                    .unwrap_or(false),
+            disable_nsjail: std::env::var("DISABLE_NSJAIL")
+                    .ok()
+                    .and_then(|x| x.parse::<bool>().ok())
+                    .unwrap_or(false),
             keep_job_dir: std::env::var("KEEP_JOB_DIR")
                 .ok()
                 .and_then(|x| x.parse::<bool>().ok())


### PR DESCRIPTION
UC: as a developer I want to be able to test code w/o nsjail

bug: flaky test `test_go_job`
```
running 1 test
test worker::tests::test_go_job ... FAILED

failures:

---- worker::tests::test_go_job stdout ----
received killpill for worker 0
thread 'worker::tests::test_go_job' panicked at 'assertion failed: `(left == right)`
  left: `Object {"error": String("Error during execution of the script:\n\ngo: error obtaining buildID for go tool compile: pipe2: too many open files\ngo: error obtaining buildID for go tool compile: pipe2: too many open files\ngo: error obtaining buildID for go tool compile: pipe2: too many open files")}`,
 right: `String("hello world")`', src/worker.rs:2434:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

workaround: disable nsjail