### PR TITLE
Cargo config improvements

### DIFF
--- a/backend/.cargo/config.toml
+++ b/backend/.cargo/config.toml
@@ -1,4 +1,10 @@
 [build]
-rustflags = ["--cfg", "tokio_unstable", "-C", "link-arg=-fuse-ld=lld"]
+rustflags = [
+    "--cfg",
+    "tokio_unstable",
+    "-C",
+    "link-arg=-fuse-ld=lld",
+    "-Clink-arg=-Wl,--no-rosegment",
+]
 incremental = true
 

--- a/backend/.cargo/config.toml
+++ b/backend/.cargo/config.toml
@@ -1,3 +1,4 @@
 [build]
 rustflags = ["--cfg", "tokio_unstable", "-C", "link-arg=-fuse-ld=lld"]
 incremental = true
+


### PR DESCRIPTION
Actually enables the existing configuration and adds --no-rosegment.