### PR TITLE
Tokio improvements

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3580,13 +3580,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6edf2d6bc038a43d31353570e27270603f4648d18f5ed10c0e179abe43255af"
+checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
 dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4293,6 +4294,7 @@ dependencies = [
  "time 0.3.15",
  "tokio",
  "tokio-metrics",
+ "tokio-stream",
  "tokio-tar",
  "tokio-util",
  "tower",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -20,9 +20,9 @@ serde_json = { version = "^1", features = ["preserve_order"] }
 uuid = { version = "^1", features = ["serde", "v4"] }
 thiserror = "^1"
 anyhow = "^1"
-chrono = { version = "^0", features = ["serde"]}
+chrono = { version = "^0", features = ["serde"] }
 tracing = "^0"
-tracing-subscriber = { version = "^0", features = ["env-filter", "json"]}
+tracing-subscriber = { version = "^0", features = ["env-filter", "json"] }
 console-subscriber = "^0"
 prometheus = { version = "^0", default-features = false }
 phf = { version = "0.11", features = ["macros"] }
@@ -39,7 +39,13 @@ magic-crypt = "^3"
 git-version = "^0"
 rustpython-parser = "^0"
 cron = "^0"
-lettre = { version = "^0", features = ["rustls-tls", "tokio1", "tokio1-rustls-tls", "builder", "smtp-transport"],  default-features = false}
+lettre = { version = "^0", features = [
+    "rustls-tls",
+    "tokio1",
+    "tokio1-rustls-tls",
+    "builder",
+    "smtp-transport",
+], default-features = false }
 urlencoding = "^2"
 url = "^2"
 async-oauth2 = "^0"
@@ -57,14 +63,24 @@ async-recursion = "^1"
 swc_common = "^0"
 swc_ecma_parser = "^0"
 swc_ecma_ast = "^0"
-base64  = "^0"
+base64 = "^0"
 unicode-general-category = "^0"
 hmac = "^0"
 sha2 = "^0"
 
-sqlx = { version = "^0", features = ["offline", "macros", "migrate", "uuid", "json", "chrono", "postgres", "runtime-tokio-rustls"]}
+sqlx = { version = "^0", features = [
+    "offline",
+    "macros",
+    "migrate",
+    "uuid",
+    "json",
+    "chrono",
+    "postgres",
+    "runtime-tokio-rustls",
+] }
 dotenv = "^0"
 ulid = { version = "^1", features = ["uuid"] }
 futures = "^0"
 tokio-metrics = "0.1.0"
 lazy_static = "1.4.0"
+tokio-stream = { version = "0.1.11", features = ["sync"] }

--- a/backend/src/jobs.rs
+++ b/backend/src/jobs.rs
@@ -1755,11 +1755,11 @@ pub async fn pull(db: &DB) -> Result<Option<QueuedJob>, crate::Error> {
     )
     .fetch_optional(db)
     .await?;
-    
+
     if job.is_some() {
         QUEUE_PULL_COUNT.inc();
     }
-    
+
     Ok(job)
 }
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -266,20 +266,7 @@ async fn openapi() -> &'static str {
 }
 
 pub async fn shutdown_signal(tx: tokio::sync::broadcast::Sender<()>) -> anyhow::Result<()> {
-    use std::io;
-    use tokio::signal::unix::SignalKind;
-
-    async fn terminate() -> io::Result<()> {
-        tokio::signal::unix::signal(SignalKind::terminate())?
-            .recv()
-            .await;
-        Ok(())
-    }
-
-    tokio::select! {
-        _ = terminate() => {},
-        _ = tokio::signal::ctrl_c() => {},
-    }
+    tokio::signal::ctrl_c().await.unwrap();
     println!("signal received, starting graceful shutdown");
     let _ = tx.send(());
     Ok(())

--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -1715,8 +1715,6 @@ async fn handle_child(
                 },
             );
         }
-
-        drop(interval);
     };
 
     #[derive(PartialEq, Debug)]

--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -35,7 +35,6 @@ use tokio::{
     sync::{
         broadcast,
         mpsc::{self, Sender, UnboundedSender},
-        oneshot,
     },
     time::{interval, sleep, Instant, MissedTickBehavior},
 };
@@ -1836,10 +1835,7 @@ async fn handle_child(
         }
     };
 
-    /* a stream updating "queue"."last_ping" at an interval */
-
-    let (kill_tx, mut kill_rx) = oneshot::channel::<()>();
-
+    let mut kill_reason_rx = kill_reason_rx_org.resubscribe();
     let mut interval = interval(ping_interval);
     interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
@@ -1855,12 +1851,11 @@ async fn handle_child(
                 tracing::error!(%job_id, %err, "error setting last ping for job {job_id}: {err}");
                     };
                 },
-                _ = (&mut kill_rx) => return,
+                _ = kill_reason_rx.recv() => return,
             }
         }
     });
     let (wait_result, _) = tokio::join!(wait_on_child, lines);
-    kill_tx.send(()).expect("send should always work");
 
     match wait_result {
         Ok(Ok(status)) => {

--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -1631,8 +1631,11 @@ async fn handle_child(
     let cancel_check = async {
         let db = db.clone();
 
-        let mut interval = interval_skipping_missed(cancel_check_interval).boxed();
-        while let Some(_) = interval.next().await {
+        let mut interval = interval(cancel_check_interval);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        loop {
+            interval.tick().await;
             if sqlx::query_scalar!("SELECT canceled FROM queue WHERE id = $1", job_id)
                 .fetch_optional(&db)
                 .await
@@ -1645,6 +1648,8 @@ async fn handle_child(
                 break;
             }
         }
+
+        drop(interval);
     };
 
     #[derive(PartialEq, Debug)]
@@ -1784,23 +1789,31 @@ async fn handle_child(
 
     /* a stream updating "queue"."last_ping" at an interval */
 
-    let ping = interval_skipping_missed(ping_interval)
-        .map(|_| db.clone())
-        .then(move |db| async move {
-            if let Err(err) =
-                sqlx::query!("UPDATE queue SET last_ping = now() WHERE id = $1", job_id)
-                    .execute(&db)
+    // this is technically oneshot, but borrowing rules don't allow it in a loop.
+    let (tx, mut rx) = mpsc::channel::<()>(1);
+
+    let mut interval = interval(ping_interval);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    let db1 = db.clone();
+    tokio::spawn(async move {
+        'outer: loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    if let Err(err) = sqlx::query!("UPDATE queue SET last_ping = now() WHERE id = $1", job_id)
+                        .execute(&db1)
                     .await
             {
                 tracing::error!(%job_id, %err, "error setting last ping for job {job_id}: {err}");
+                    };
+                },
+                _ = rx.recv() => break 'outer,
             }
+        }
+        drop(interval);
         });
-
-    let wait_result = tokio::select! {
-        (w, _) = future::join(wait_on_child, lines) => w,
-        /* ping should repeat forever without stopping */
-        _ = ping.collect::<()>() => unreachable!("job ping stopped"),
-    };
+    let (wait_result, _) = tokio::join!(wait_on_child, lines);
+    tx.send(()).await.expect("send should always work");
 
     match wait_result {
         _ if *too_many_logs.borrow() => Err(Error::ExecutionErr(
@@ -1822,12 +1835,6 @@ async fn handle_child(
         ))),
         Err(err) => Err(Error::ExecutionErr(format!("job process io error: {err}"))),
     }
-}
-
-fn interval_skipping_missed(period: Duration) -> impl futures::Stream<Item = Instant> {
-    let mut interval = interval(period);
-    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
-    stream::poll_fn(move |cx| interval.poll_tick(cx).map(Some))
 }
 
 /// takes stdout and stderr from Child, panics if either are not present

--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -7,7 +7,7 @@
  */
 
 use itertools::Itertools;
-use std::{collections::HashMap, io, panic, process::Stdio, time::Duration};
+use std::{collections::HashMap, future::IntoFuture, io, panic, process::Stdio, time::Duration};
 use tokio_stream::wrappers::BroadcastStream;
 use uuid::Uuid;
 
@@ -35,7 +35,7 @@ use tokio::{
     sync::{
         broadcast,
         mpsc::{self, Sender, UnboundedSender},
-        watch,
+        oneshot, watch,
     },
     time::{interval, sleep, Instant, MissedTickBehavior},
 };
@@ -43,6 +43,7 @@ use tokio::{
 use futures::{
     future,
     stream::{self, StreamExt},
+    FutureExt,
 };
 
 use async_recursion::async_recursion;
@@ -1820,15 +1821,14 @@ async fn handle_child(
 
     /* a stream updating "queue"."last_ping" at an interval */
 
-    // this is technically oneshot, but borrowing rules don't allow it in a loop.
-    let (tx, mut rx) = mpsc::channel::<()>(1);
+    let (kill_tx, mut kill_rx) = oneshot::channel::<()>();
 
     let mut interval = interval(ping_interval);
     interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     let db1 = db.clone();
     tokio::spawn(async move {
-        'outer: loop {
+        loop {
             tokio::select! {
                 _ = interval.tick() => {
                     if let Err(err) = sqlx::query!("UPDATE queue SET last_ping = now() WHERE id = $1", job_id)
@@ -1838,13 +1838,12 @@ async fn handle_child(
                 tracing::error!(%job_id, %err, "error setting last ping for job {job_id}: {err}");
                     };
                 },
-                _ = rx.recv() => break 'outer,
+                _ = (&mut kill_rx) => return,
             }
         }
-        drop(interval);
     });
     let (wait_result, _) = tokio::join!(wait_on_child, lines);
-    tx.send(()).await.expect("send should always work");
+    kill_tx.send(()).expect("send should always work");
 
     match wait_result {
         _ if *too_many_logs.borrow() => Err(Error::ExecutionErr(

--- a/backend/src/worker.rs
+++ b/backend/src/worker.rs
@@ -7,7 +7,7 @@
  */
 
 use itertools::Itertools;
-use std::{collections::HashMap, future::IntoFuture, io, panic, process::Stdio, time::Duration};
+use std::{collections::HashMap, io, panic, process::Stdio, time::Duration};
 use tokio_stream::wrappers::BroadcastStream;
 use uuid::Uuid;
 
@@ -35,7 +35,7 @@ use tokio::{
     sync::{
         broadcast,
         mpsc::{self, Sender, UnboundedSender},
-        oneshot, watch,
+        oneshot,
     },
     time::{interval, sleep, Instant, MissedTickBehavior},
 };
@@ -43,7 +43,6 @@ use tokio::{
 use futures::{
     future,
     stream::{self, StreamExt},
-    FutureExt,
 };
 
 use async_recursion::async_recursion;
@@ -1683,27 +1682,34 @@ async fn handle_child(
     let cancel_check_interval = Duration::from_millis(500);
     let write_logs_delay = Duration::from_millis(500);
 
-    let (set_too_many_logs, mut too_many_logs) = watch::channel::<bool>(false);
-
     let output = child_joined_output_stream(&mut child);
     let job_id = job_id.clone();
 
-    let (tx, mut rx) = mpsc::channel::<()>(1);
+    #[derive(Eq, PartialEq, Debug, Clone)]
+    enum KillReason {
+        TooManyLogs,
+        Timeout,
+        Cancelled,
+    }
+
+    let (kill_reason_tx_org, kill_reason_rx_org) = broadcast::channel::<KillReason>(3);
+
+    let kill_reason_tx = kill_reason_tx_org.clone();
+    let mut kill_reason_rx = kill_reason_rx_org.resubscribe();
 
     /* the cancellation future is polled on by `wait_on_child` while
      * waiting for the child to exit normally */
-    let cancel_check = async {
-        let db = db.clone();
-
+    let db1 = db.clone();
+    tokio::spawn(async move {
         let mut interval = interval(cancel_check_interval);
         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         loop {
             tokio::select!(
-                _ = rx.recv() => break,
+                _ = kill_reason_rx.recv() => break,
                 _ = interval.tick() => {
                     if sqlx::query_scalar!("SELECT canceled FROM queue WHERE id = $1", job_id)
-                        .fetch_optional(&db)
+                        .fetch_optional(&db1)
                         .await
                         .map(|v| Some(true) == v)
                         .unwrap_or_else(|err| {
@@ -1711,32 +1717,37 @@ async fn handle_child(
                             false
                         })
                     {
+                        kill_reason_tx.send(KillReason::Cancelled).expect("kill_reason_rx should never be dropped");
                         break;
                     }
                 },
             );
         }
-    };
+    });
 
-    #[derive(PartialEq, Debug)]
-    enum KillReason {
-        TooManyLogs,
-        Timeout,
-        Cancelled,
-    }
+    let kill_reason_tx = kill_reason_tx_org.clone();
+    let mut kill_reason_rx = kill_reason_rx_org.resubscribe();
+    let mut kill_reason_rx2 = kill_reason_rx_org.resubscribe();
     /* a future that completes when the child process exits */
     let wait_on_child = async {
         let db = db.clone();
 
+        tokio::spawn(async move {
+            if tokio::time::timeout(timeout, kill_reason_rx2.recv())
+                .await
+                .is_err()
+            {
+                kill_reason_tx
+                    .send(KillReason::Timeout)
+                    .expect("kill_reason_rx should never be dropped");
+            }
+        });
+
         let kill_reason = tokio::select! {
             biased;
             result = child.wait() => return result.map(Ok),
-            Ok(()) = too_many_logs.changed() => KillReason::TooManyLogs,
-            _ = cancel_check => KillReason::Cancelled,
-            _ = sleep(timeout) => KillReason::Timeout,
+            r = kill_reason_rx.recv() => r.expect("kill_reason_tx should never be dropped")
         };
-        tx.send(()).await.expect("rx should never be dropped");
-        drop(tx);
 
         let set_reason = async {
             if kill_reason == KillReason::Timeout {
@@ -1764,12 +1775,14 @@ async fn handle_child(
         kill.map(|()| Err(kill_reason))
     };
 
+    let kill_reason_tx = kill_reason_tx_org.clone();
     /* a future that reads output from the child and appends to the database */
     let lines = async move {
         /* log_remaining is zero when output limit was reached */
         let mut log_remaining = MAX_LOG_SIZE as usize - 1000;
         let mut result = io::Result::Ok(());
         let mut output = output;
+        // Note that this loop doesn't react to kill. This is to ensure all lines are read, even if the job outputs a large burst of data, and is then killed.
         while let Some(line) = output.by_ref().next().await {
             let mut read_lines = stream::once(async { line })
                 .chain(output.by_ref())
@@ -1782,6 +1795,7 @@ async fn handle_child(
              * handle log lines first and then the error... */
             let mut joined = String::new();
 
+            let mut too_many_logs = false;
             while let Some(line) = read_lines.next().await {
                 match line {
                     Ok(_) if log_remaining == 0 => (),
@@ -1791,7 +1805,10 @@ async fn handle_child(
 
                         if log_remaining == 0 {
                             tracing::info!(%job_id, "Too many logs lines for job {job_id}");
-                            let _ = set_too_many_logs.send(true);
+                            too_many_logs = true;
+                            kill_reason_tx
+                                .send(KillReason::TooManyLogs)
+                                .expect("kill_reason_rx should never be dropped");
                             let m = format!(
                                 "Job logs or result reached character limit of {MAX_LOG_SIZE}; killing job."
                             );
@@ -1813,7 +1830,7 @@ async fn handle_child(
                 break;
             }
 
-            if *set_too_many_logs.borrow() {
+            if too_many_logs {
                 break;
             }
         }
@@ -1846,9 +1863,6 @@ async fn handle_child(
     kill_tx.send(()).expect("send should always work");
 
     match wait_result {
-        _ if *too_many_logs.borrow() => Err(Error::ExecutionErr(
-            "logs or result reached limit".to_string(),
-        )),
         Ok(Ok(status)) => {
             if status.success() {
                 Ok(())


### PR DESCRIPTION
Tokio related improvements. Especially around interval usage. Reworks logs to use streaming.

All benches done with a dedicated server and worker process. Only one worker instance running.

Perf Metrics:
1a935935291bcb01bb8b7cc037949fb6b36afff0 (base):
throughput /s 16.19
zombie jobs:  0
incorrect results:  0
queue length: 0
waiting for metrics
done

7393b7fec6ab364c55ba56691ee02b4d4c5d2b0b (latest):
throughput /s 16.76
zombie jobs:  0
incorrect results:  0
queue length: 0