### PR TITLE
fix(deno-client): add missing approver encoding to hmac api request

### DIFF
--- a/deno-client/mod.ts
+++ b/deno-client/mod.ts
@@ -152,8 +152,17 @@ export interface NonceAndHmac {
  */
 export async function genNounceAndHmac(workspace: string, jobId: string, approver?: string): Promise<NonceAndHmac> {
     const nonce = Math.floor(Math.random() * 4294967295);
-    const sig = await fetch(Deno.env.get("WM_BASE_URL") +
-        `/api/w/${workspace}/jobs/job_signature/${jobId}/${nonce}?token=${Deno.env.get("WM_TOKEN")}${approver ? `&approver=${approver}` : ''}`)
+    const u = new URL(
+        `/api/w/${workspace}/jobs/job_signature/${jobId}/${nonce}`,
+        Deno.env.get("WM_BASE_URL"),
+    );
+
+    u.searchParams.append('token', Deno.env.get("WM_TOKEN"));
+    if (approver) {
+        u.searchParams.append('approver', approver);
+    }
+
+    const sig = await fetch(u.toString());
     return {
         nonce,
         signature: await sig.text()


### PR DESCRIPTION
related to 10e1de84760b6b7eec92397117c44a938b0bc358