### PR TITLE
feat(backend): extend default scope set for slack resource

### DIFF
--- a/backend/oauth_connect.json
+++ b/backend/oauth_connect.json
@@ -25,7 +25,9 @@
         "auth_url": "https://slack.com/oauth/authorize",
         "token_url": "https://slack.com/api/oauth.access",
         "scopes": [
-            "chat:write:user"
+            "chat:write:user",
+            "users:read",
+            "users:read.email"
         ]
     },
     "gsheets": {


### PR DESCRIPTION
usecase:
> as a windmill user I want to provide email of user to which slack direct message should be send

rationale:
https://api.slack.com/methods/users.lookupByEmail needs to be used. it requires `users:read.email` (which needs to be acquired together with
`users:read` - more info: https://api.slack.com/scopes/users:read.email)