### PR TITLE
fix(backend): improve csp

### DIFF
--- a/backend/windmill-api/src/static_assets.rs
+++ b/backend/windmill-api/src/static_assets.rs
@@ -80,7 +80,7 @@ fn serve_path(path: String, can_set_security_headers: bool) -> Response<BoxBody>
 }
 
 fn set_security_headers(mut res: Builder) -> Builder {
-    let csp = "frame-ancestors 'none'; frame-src 'none'; worker-src 'self'; child-src 'none'; object-src 'none'";
+    let csp = "frame-ancestors 'none'; frame-src 'none'; worker-src 'self'; child-src 'none'; object-src 'none'; script-src 'self' 'unsafe-inline'";
     res = res.header("Content-Security-Policy", csp);
     res = res.header("X-Frame-Options", "DENY");
     res = res.header("X-Content-Type-Options", "nosniff");


### PR DESCRIPTION
rationale for setting `'unsafe-inline'` is that it cannot be more void than the lack of `script-src` but it still might add some benefits