### PR TITLE
fix(backend): csp - tighten script-src directive by leveraging svelte config

### DIFF
--- a/backend/windmill-api/src/static_assets.rs
+++ b/backend/windmill-api/src/static_assets.rs
@@ -80,7 +80,7 @@ fn serve_path(path: String, can_set_security_headers: bool) -> Response<BoxBody>
 }
 
 fn set_security_headers(mut res: Builder) -> Builder {
-    let csp = "frame-ancestors 'none'; frame-src 'none'; worker-src 'self'; child-src 'none'; object-src 'none'; script-src 'self' 'unsafe-inline';";
+    let csp = "frame-ancestors 'none'; frame-src 'none'; worker-src 'self'; child-src 'none'; object-src 'none';";
     res = res.header("Content-Security-Policy", csp);
     res = res.header("X-Frame-Options", "DENY");
     res = res.header("X-Content-Type-Options", "nosniff");

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -22,6 +22,12 @@ const config = {
 		prerender: {
 			default: false,
 		},
+		csp: {
+			mode: 'hash',
+			directives: {
+				'script-src': ['self'],
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
### rationale
as per: https://kit.svelte.dev/docs/configuration#csp
> When pages are prerendered, the CSP header is added via a \<meta http-equiv\> tag

it removes `'unsafe-inline'` which is an improvement: as per https://www.w3.org/TR/CSP3/#csp-directives
> (...) developers SHOULD NOT include either ['unsafe-inline'](https://www.w3.org/TR/CSP3/#grammardef-unsafe-inline), or data: as valid sources in their policies.

### controversy
this change might be considered as disputed because it defines `script-src` outside of HTTP Headers. check https://www.w3.org/TR/CSP3/#policy-delivery
> The Content-Security-Policy HTTP response header field is the preferred mechanism for delivering a policy from a server to a client.

### "why it can't be defined in headers"
svelte generates this code in `frontend/build/index.html`:
```html
	<script type="module" data-sveltekit-hydrate="45h">
		import { set_public_env, start } from "/_app/immutable/start-41ddda7f.js";

		set_public_env({});

		start({
			target: document.querySelector('[data-sveltekit-hydrate="45h"]').parentNode,
			paths: {"base":"","assets":""},
			session: {},
			route: true,
			spa: true,
			trailing_slash: "never",
			hydrate: null
		});
	</script>
```
the hash used in CSP is generated for this part of the code. Now, notice the `"/_app/immutable/start-41ddda7f.js"` - the name of this file will change on each build.

