### PR TITLE
Fix bash flow lock & add flow lock tests

### DIFF
--- a/backend/tests/fixtures/base.sql
+++ b/backend/tests/fixtures/base.sql
@@ -11,6 +11,8 @@ INSERT INTO usr(workspace_id, email, username, is_admin, role) VALUES
 INSERT INTO workspace_key(workspace_id, kind, key) VALUES
 	('test-workspace', 'cloud', 'test-key');
 
+insert INTO token(token, email, label, super_admin) VALUES ('SECRET_TOKEN', 'test@windmill.dev', 'test token', true);
+
 GRANT ALL PRIVILEGES ON TABLE workspace_key TO windmill_admin;
 GRANT ALL PRIVILEGES ON TABLE workspace_key TO windmill_user;
 

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -131,7 +131,7 @@ paths:
   /auth/logout:
     post:
       security: []
-      summary: logout 
+      summary: logout
       operationId: logout
       tags:
         - user
@@ -2386,7 +2386,7 @@ paths:
                 path:
                   type: string
                 value: {}
-                summary: 
+                summary:
                   type: string
                 policy:
                   $ref: "#/components/schemas/Policy"
@@ -2474,7 +2474,7 @@ paths:
                 path:
                   type: string
                 args: {}
-                raw_code: 
+                raw_code:
                   type: object
                   properties:
                     content:
@@ -2498,7 +2498,6 @@ paths:
             text/plain:
               schema:
                 type: string
-
 
   /w/{workspace}/jobs/run/f/{path}:
     post:
@@ -4706,7 +4705,6 @@ components:
         on_behalf_of:
           type: string
 
-
     ListableApp:
       type: object
       properties:
@@ -4749,7 +4747,7 @@ components:
           type: string
           format: date-time
         value: {}
-        policy:        
+        policy:
           $ref: "#/components/schemas/Policy"
         execution_mode:
           type: string

--- a/backend/windmill-api/src/flows.rs
+++ b/backend/windmill-api/src/flows.rs
@@ -6,6 +6,7 @@
  * LICENSE-AGPL for a copy of the license.
  */
 
+use hyper::StatusCode;
 use reqwest::Client;
 use sql_builder::prelude::*;
 
@@ -137,7 +138,7 @@ async fn create_flow(
     Extension(user_db): Extension<UserDB>,
     Path(w_id): Path<String>,
     Json(nf): Json<NewFlow>,
-) -> Result<String> {
+) -> Result<(StatusCode, String)> {
     // cron::Schedule::from_str(&ns.schedule).map_err(|e| error::Error::BadRequest(e.to_string()))?;
     let mut tx = user_db.clone().begin(&authed).await?;
 
@@ -200,7 +201,7 @@ async fn create_flow(
     .await?;
     tx.commit().await?;
 
-    Ok(nf.path.to_string())
+    Ok((StatusCode::CREATED, nf.path.to_string()))
 }
 
 async fn check_schedule_conflict<'c>(

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -2016,9 +2016,7 @@ async fn capture_dependency_job(
         ScriptLang::Deno => {
             generate_deno_lock(job_id, job_raw_code, logs, job_dir, db, timeout, &envs).await
         }
-        _ => Err(error::Error::InternalErr(
-            "Language incompatible with dep job".to_string(),
-        )),
+        ScriptLang::Bash => Ok("".to_owned()),
     }
 }
 


### PR DESCRIPTION
This also includes a small fix to the flow create endpoint to make it align with the OpenAPI spec. The rust client is very pedantic so this was required.

Also enables a test to see whether the rust client works in the first place.