### PR TITLE
chore(frontend): (opinionated) description improvement

### DIFF
--- a/frontend/src/routes/resources.svelte
+++ b/frontend/src/routes/resources.svelte
@@ -303,7 +303,7 @@
 												<Popover>
 													<Icon data={faRefresh} />
 													<div slot="text">
-														The OAuth token is kept up-to-date in the background by Windmill using
+														The OAuth token will be kept up-to-date in the background by Windmill using
 														its refresh token
 													</div>
 												</Popover>

--- a/frontend/src/routes/variables.svelte
+++ b/frontend/src/routes/variables.svelte
@@ -164,7 +164,7 @@
 											<Popover>
 												<Icon data={faRefresh} />
 												<div slot="text">
-													This OAuth token is kept up-to-date in the background by Windmill using
+													This OAuth token will be kept up-to-date in the background by Windmill using
 													its refresh token
 												</div>
 											</Popover>


### PR DESCRIPTION
background:

I was confused while reading
> The OAuth token is kept up-to-date in the background by Windmill using its refresh token

next to

> The access_token is expired, it will get renewed the next time this variable is fetched or you can request is to be refreshed in the dropdown on the right.

for me this descriptions are mutually exclusive. `kept up-to-date in the background` sounds like there is some background scheduled job that refreshes the token even if it's not used