### PR TITLE
feat(deno-client): support mysql

### DIFF
--- a/deno-client/mysql.ts
+++ b/deno-client/mysql.ts
@@ -1,0 +1,71 @@
+import { createConnection } from "https://deno.land/x/mysql2@v1.0.6/mod.ts";
+import { type Resource } from "./mod.ts";
+
+/**
+ * Establish MySQL connection using MySQL client for Deno:
+ * https://deno.land/x/mysql2@v1.0.6/mod.ts
+ *
+ * IMPORTANT: make sure to close the connection with `.end()`
+ *
+ * @param db the MySQL resource to establish the connection for
+ *
+ * @returns MySQL database connection
+ *
+ * @example
+ * ```ts
+ * const conn = await mysqlClient(db);
+ * await conn.execute('CREATE TABLE IF NOT EXISTS pets (name varchar(255), kind varchar(255))');
+ * await conn.execute('INSERT INTO pets VALUES (?, ?)', ['behemot','cat']);
+ * const [rows] = await conn.execute('SELECT * from pets');
+ * conn.end();
+ * console.log(rows);
+ * ```
+ */
+export async function mysqlClient(
+    db: Resource<"mysql">
+) {
+    const conn = await createConnection(db);
+    return conn;
+}
+
+/**
+ * Execute SQL query. For more info check:
+ * https://deno.land/x/mysql2@v1.0.6/mod.ts
+ *
+ * @param db the MySQL resource to run sql query for
+ *
+ * @returns array with two items: rows and fields
+ *
+ * @example
+ * ```ts
+ * const kind = 'cat';
+ * const { rows } = await mySql(db)`SELECT * from pets WHERE kind = ${kind}`;
+ * console.log(rows);
+ * ```
+ */
+export function mySql(
+    db: Resource<"mysql">,
+    asObjects = false
+) {
+    return async function execute(
+        query: TemplateStringsArray,
+        ...args: unknown[],
+    ) {
+        const conn = await mysqlClient(db);
+        const adapter = getQueryAdapter(query, args);
+        const [rows, fields] = await conn.execute(...adapter);
+        conn.end();
+        return { rows: asObjects ? rows : getRowsAdapter(rows), fields };
+    }
+}
+
+function getQueryAdapter(template: TemplateStringsArray, args: unknown[]) {
+    const text = template.reduce((curr, next) => {
+        return `${curr}?${next}`;
+    });
+    return [text, args];
+}
+
+function getRowsAdapter(rows: object[]) {
+    return rows.map((r) => Object.values(r))
+}

--- a/deno-client/pg.ts
+++ b/deno-client/pg.ts
@@ -3,21 +3,21 @@ import { type Resource } from "./mod.ts"
 
 /**
  * deno-postgres client API is very flexible:
- * https://deno.land/x/postgres@v0.16.1/mod.ts?s=QueryClient
+ * https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient
  * 
- * @param db the postgresql resource to generate the client for
+ * @param db the PostgreSQL resource to generate the client for
  * 
  * @returns the client for the resource
  * 
- * Usage:
- * Static query:
+ * @example
+ * // Static query
  * ```ts
- * const {rows} = await pgClient(db).queryObject(
+ * const { rows } = await pgClient(db).queryObject(
  *   "SELECT ID, NAME FROM CLIENTS"
  * );
  * ```
  * 
- * Prepared Statements:
+ * // Prepared Statements
  * ```ts
  * const { rows } = await pgClient(db).queryObject`SELECT ID, NAME FROM CLIENTS WHERE ID = ${id}`;
  * ```
@@ -32,13 +32,14 @@ export function pgClient(
 
 /**
  * deno-postgres client API is very flexible:
- * https://deno.land/x/postgres@v0.16.1/mod.ts?s=QueryClient
+ * https://deno.land/x/postgres@v0.17.0/mod.ts?s=QueryClient
  * 
- * @param db the postgresql resource to generate the client for
+ * @param db the PostgreSQL resource to run sql query for
  * 
  * @returns the rows corresponding to the returned objetcs
  * 
- * Prepared Statements:
+ * @example
+ * // Prepared Statements
  * ```ts
  * const { rows } = await pgSql(db)`SELECT ID, NAME FROM CLIENTS WHERE ID = ${id}`;
  * ```


### PR DESCRIPTION
I'm using https://deno.land/x/mysql2@v1.0.6/mod.ts only because https://deno.land/x/mysql@v2.11.0/mod.ts has bug that I described in https://github.com/denodrivers/mysql/issues/128#issuecomment-1331477637

hopefully this bug will be fixed soon, then I guess we can switch from https://github.com/sail-sail/mysql2 to https://github.com/denodrivers/mysql

tested locally with:
```ts
import { mysqlClient, mySql } from "./mysql.ts";

const db = {
    host: '0.0.0.0',
    port: 3306,
    user: 'root',
    password: 'change-me',
    database: 'test',
};

const conn = await mysqlClient(db);
await conn.execute('CREATE TABLE IF NOT EXISTS pets (name varchar(255), kind varchar(255))');
await conn.execute('INSERT INTO pets VALUES (?, ?)', ['behemot','cat']);
const [r] = await conn.execute('SELECT * from pets');
conn.end();
console.log(r);

const kind = 'cat';
const { rows } = await mySql(db)`SELECT * from pets WHERE kind = ${kind}`;
console.log(rows);
```