### PR TITLE
feat(cli): Allow workspace to be newly created

### DIFF
--- a/cli/main.ts
+++ b/cli/main.ts
@@ -66,9 +66,8 @@ try {
 } catch (e) {
   if (e.name === "ApiError") {
     console.log("Server failed. " + e.statusText + ": " + e.body);
-  } else {
-    throw e;
   }
+  throw e;
 }
 
 export default command;


### PR DESCRIPTION
I decided to change this and use `--create` on the existing `workspace add` command. I think this is much more natural to use then the previous `workspace create ...` + more flexible to ensure state is as expected.