### PR TITLE
feat(frontend): Update app table component styles

### DIFF
--- a/frontend/src/lib/components/apps/components/table/AppTable.svelte
+++ b/frontend/src/lib/components/apps/components/table/AppTable.svelte
@@ -131,9 +131,9 @@
 				</div>
 			{/if}
 
-			<div class="overflow-auto flex-1 w-full">
-				<table class="divide-y divide-gray-300 w-full border-b border-b-gray-200">
-					<thead class="bg-gray-50 text-left">
+			<div class="overflow-x-auto flex-1 w-full">
+				<table class="relative w-full border-b border-b-gray-200">
+					<thead class="sticky top-0 bg-gray-50 text-left">
 						{#each $table.getHeaderGroups() as headerGroup}
 							<tr class="divide-x">
 								{#each headerGroup.headers as header}
@@ -141,16 +141,22 @@
 										{@const context = header?.getContext()}
 										{#if context}
 											{@const component = renderCell(header.column.columnDef.header, context)}
-											<th class="px-4 py-4 text-sm font-semibold">
-												{#if !header.isPlaceholder && component}
-													<svelte:component this={component} />
-												{/if}
+											<th class="!p-0">
+												<span class="block px-4 py-4 text-sm font-semibold border-b">
+													{#if !header.isPlaceholder && component}
+														<svelte:component this={component} />
+													{/if}
+												</span>
 											</th>
 										{/if}
 									{/if}
 								{/each}
 								{#if actionButtons.length > 0}
-									<th class="px-4 py-4 text-sm font-semibold">Actions</th>
+									<th class="!p-0">
+										<span class="block px-4 py-4 text-sm font-semibold border-b">
+											Actions
+										</span>
+									</th>
 								{/if}
 							</tr>
 						{/each}

--- a/frontend/src/lib/components/apps/components/table/AppTable.svelte
+++ b/frontend/src/lib/components/apps/components/table/AppTable.svelte
@@ -122,9 +122,9 @@
 	{#if Array.isArray(result) && result.every(isObject)}
 		<div class="border border-gray-300 shadow-sm divide-y divide-gray-300  flex flex-col h-full">
 			{#if search !== 'Disabled'}
-				<div class="px-4 py-2">
+				<div class="px-2 py-1">
 					<div class="flex items-center">
-						<div>
+						<div class="grow max-w-[300px]">
 							<DebouncedInput placeholder="Search..." bind:value={searchValue} />
 						</div>
 					</div>

--- a/frontend/src/lib/components/apps/components/table/AppTableFooter.svelte
+++ b/frontend/src/lib/components/apps/components/table/AppTableFooter.svelte
@@ -2,6 +2,7 @@
 	import Button from '$lib/components/common/button/Button.svelte'
 	import { faDownload } from '@fortawesome/free-solid-svg-icons'
 	import type { Table } from '@tanstack/svelte-table'
+	import { ChevronLeft, ChevronRight } from 'lucide-svelte'
 	import type { Readable } from 'svelte/store'
 	import { tableOptions } from './tableOptions'
 
@@ -22,26 +23,30 @@
 	}
 </script>
 
-<div class="px-4 py-2 text-xs flex flex-row gap-2 items-center justify-between">
+<div class="px-2 py-1 text-xs flex flex-row gap-2 items-center justify-between">
 	{#if paginationEnabled && result.length > (tableOptions.initialState?.pagination?.pageSize ?? 25)}
 		<div class="flex items-center gap-2 flex-row">
 			<Button
 				size="xs"
 				variant="border"
 				color="light"
+				btnClasses="!py-1 !pl-1"
 				on:click={() => $table.previousPage()}
 				disabled={!$table.getCanPreviousPage()}
 			>
+				<ChevronLeft size={14} />
 				Previous
 			</Button>
 			<Button
 				size="xs"
 				variant="border"
 				color="light"
+				btnClasses="!py-1 !pr-1"
 				on:click={() => $table.nextPage()}
 				disabled={!$table.getCanNextPage()}
 			>
 				Next
+				<ChevronRight size={14} />
 			</Button>
 			{$table.getState().pagination.pageIndex + 1} of {$table.getPageCount()}
 		</div>
@@ -53,6 +58,7 @@
 			size="xs"
 			variant="border"
 			color="light"
+			btnClasses="!py-1"
 			on:click={downloadResultAsJSON}
 			startIcon={{ icon: faDownload }}
 		>


### PR DESCRIPTION
Table header and footer are now always visible, scrolling happens only on the table body