### PR TITLE
Add `packages: write` for ghcr push

### DIFF
--- a/.github/workflows/docker-image-arm.yml
+++ b/.github/workflows/docker-image-arm.yml
@@ -16,6 +16,7 @@ concurrency:
 permissions:
   contents: read
   id-token: write
+  packages: write
 
 jobs:
   publish_arm:


### PR DESCRIPTION
This should fix the error seen here trying to push the image, https://github.com/windmill-labs/windmill/actions/runs/3924415790/jobs/6708660689.