### PR TITLE
Use Uffizzi workflow `v2` and other minor improvements.

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           WINDMILL_IMAGE=${{ needs.build-windmill.outputs.tags }}
           export WINDMILL_IMAGE
-          LSP_IMAGE=ghcr.io/windmill-labs/windmill-lsp
+          LSP_IMAGE=ghcr.io/windmill-labs/windmill-lsp:latest
           export LSP_IMAGE
           envsubst '${WINDMILL_IMAGE} ${LSP_IMAGE}' < ./.github/uffizzi/docker-compose.uffizzi.yml > docker-compose.rendered.yml
           cat docker-compose.rendered.yml

--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -38,8 +38,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-
-
   render-compose-file:
     name: Render Docker Compose File
     # Pass output of this workflow to another triggered by `workflow_run` event.
@@ -66,7 +64,7 @@ jobs:
           path: docker-compose.rendered.yml
           retention-days: 2
       - name: Serialize PR Event to File
-        run:  |
+        run: |
           cat << EOF > event.json
           ${{ toJSON(github.event) }}
           EOF
@@ -84,7 +82,10 @@ jobs:
     steps:
       # If this PR is closing, we will not render a compose file nor pass it to the next workflow.
       - name: Serialize PR Event to File
-        run: echo '${{ toJSON(github.event) }}' > event.json
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }}
+          EOF
       - name: Upload PR Event as Artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -11,6 +11,7 @@ jobs:
   cache-compose-file:
     name: Cache Compose File
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
       compose-file-cache-key: ${{ env.COMPOSE_FILE_HASH }}
       pr-number: ${{ env.PR_NUMBER }}
@@ -28,6 +29,9 @@ jobs:
             let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "preview-spec"
             })[0];
+            if (matchArtifact === undefined) {
+              throw TypeError('Build Artifact not found!');
+            }
             let download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
@@ -65,17 +69,19 @@ jobs:
           echo "PR number: ${{ env.PR_NUMBER }}"
           echo "Compose file hash: ${{ env.COMPOSE_FILE_HASH }}"
           cat event.json
+
   deploy-uffizzi-preview:
     name: Use Remote Workflow to Preview on Uffizzi
     needs:
       - cache-compose-file
-    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2.6.1
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2
     with:
       # If this workflow was triggered by a PR close event, cache-key will be an empty string
       # and this reusable workflow will delete the preview deployment.
       compose-file-cache-key: ${{ needs.cache-compose-file.outputs.compose-file-cache-key }}
       compose-file-cache-path: docker-compose.rendered.yml
-      server: https://app.uffizzi.com/
+      server: https://app.uffizzi.com
       pr-number: ${{ needs.cache-compose-file.outputs.pr-number }}
     permissions:
       contents: read

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -99,4 +99,4 @@ jobs:
           node-version: 16
       - name: "Playwright run"
         timeout-minutes: 2
-        run: cd frontend && npm ci @playwright/test && npx playwright install && export BASE_URL=http://localhost:8000 && npm run test
+        run: cd frontend && npm ci @playwright/test && npx playwright install && export BASE_URL=${{ needs.deploy-uffizzi-preview.outputs.url }} && npm run test


### PR DESCRIPTION
I could not comment on locked PR #1106 so I've opened this new PR to get Uffizzi previews working better.

The most important change here is using Uffizzi' reusable workflow at our `v2` branch. This will keep you up to date with the latest changes. I suspect this version mismatch with our API is causing the failures such as this https://github.com/windmill-labs/windmill/actions/runs/3933057820/jobs/6726352392#step:16:25

Some other minor improvements are included: error handling, quote handling, formatting, etc.