### PR TITLE
Don't use GHCR for LSP image. TEMPORARY see discussion

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           WINDMILL_IMAGE=${{ needs.build-windmill.outputs.tags }}
           export WINDMILL_IMAGE
-          LSP_IMAGE=ghcr.io/windmill-labs/windmill-lsp:latest
+          LSP_IMAGE=registry.uffizzi.com/windmill-lsp:60d
           export LSP_IMAGE
           envsubst '${WINDMILL_IMAGE} ${LSP_IMAGE}' < ./.github/uffizzi/docker-compose.uffizzi.yml > docker-compose.rendered.yml
           cat docker-compose.rendered.yml


### PR DESCRIPTION
Continuing discussion from #1114:

We discovered that [the errors you experienced](https://github.com/windmill-labs/windmill/actions/runs/3933518081/jobs/6727304269) happened because the compose file specified an image on GitHub's Container Registry. This image is public so that should not be a problem. However, right now Uffizzi needs someone's GitHub credentials to pull images from GHCR to avoid rate limiting.

We recognize this is undesirable and so we're considering making an exception for GHCR as we have for Docker Hub. We will follow up with y'all if that change happens. Until then, you have options:

1. You could publish the LSP image on another registry. This PR uses the same image from `registry.uffizzi.com`, so you can merge this and start previewing immediately. Note that this image registry is ephemeral and will expire in 60 days. You could add this registry to your CI/CD targets and keep using it. Alternatively you could publish to Docker Hub.

2. You could add a GitHub Personal Access Token to this repository's secrets and configure Uffizzi's reusable workflow to use it with the `personal-access-token` option. The token should be limited to only the `read:packages` scope. I'm happy to submit a PR demonstrating this, and you can see an example of this configuration here on line 181 https://github.com/UffizziCloud/example-voting-app/blob/8f78f9204c8869aca538cb929d49c5b1074da8ff/.github/workflows/uffizzi-previews.yml#L181

3. You could probably build the LSP image every time and handle it like the primary windmill image. I understand you've already moved away from that, but it remains an option.

We appreciate your patience and we remain excited to see how you will use Uffizzi! The `playwright` integration is especially exciting. We'll monitor this PR and you can also [contact us in our Slack community for more synchronous conversations](https://join.slack.com/t/uffizzi/shared_invite/zt-ffr4o3x0-J~0yVT6qgFV~wmGm19Ux9A). 