### PR TITLE
fix(frontend): Show app builder header always on top

### DIFF
--- a/frontend/src/lib/components/Popover.model.ts
+++ b/frontend/src/lib/components/Popover.model.ts
@@ -1,0 +1,3 @@
+const SIDE = ['auto', 'top', 'bottom', 'left', 'right'] as const
+const ALIGN = ['start', 'end'] as const
+export type PopoverPlacement = `${typeof SIDE[number]}` | `${typeof SIDE[number]}-${typeof ALIGN[number]}`

--- a/frontend/src/lib/components/Popover.svelte
+++ b/frontend/src/lib/components/Popover.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
 	import { createPopperActions } from 'svelte-popperjs'
+	import type { PopoverPlacement } from './Popover.model'
 
-	const SIDE = ['auto', 'top', 'bottom', 'left', 'right'] as const
-	const ALIGN = ['start', 'end'] as const
-
-	export let placement: `${typeof SIDE[number]}` | `${typeof SIDE[number]}-${typeof ALIGN[number]}` = 'auto'
+	export let placement: PopoverPlacement = 'auto'
 	export let notClickable = false
 	export let popupClass = ''
 	export let disapperTimoout = 100

--- a/frontend/src/lib/components/Tooltip.svelte
+++ b/frontend/src/lib/components/Tooltip.svelte
@@ -1,16 +1,20 @@
 <script lang="ts">
 	import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 	import Icon from 'svelte-awesome'
+	import type { PopoverPlacement } from './Popover.model'
 	import Popover from './Popover.svelte'
 
 	export let light = false
+	export let scale = 0.8
+	export let wrapperClass = ''
+	export let placement: PopoverPlacement | undefined = undefined
 </script>
 
-<Popover notClickable>
+<Popover notClickable {placement} class={wrapperClass}>
 	<Icon
-		class="{light ? 'text-gray-300' : ' text-gray-500'} font-thin inline-block align-middle w-4"
+		class="{light ? 'text-gray-300' : ' text-gray-500'} font-thin inline-block align-middle w-4 {$$props.class}"
 		data={faInfoCircle}
-		scale={0.8}
+		{scale}
 	/>
 	<span slot="text"> <slot /> </span>
 </Popover>

--- a/frontend/src/lib/components/apps/editor/AppPreview.svelte
+++ b/frontend/src/lib/components/apps/editor/AppPreview.svelte
@@ -69,7 +69,7 @@
 	$: width = $breakpoint === 'sm' ? 'max-w-[640px]' : 'w-full '
 </script>
 
-<div class="h-full w-full {app.fullscreen ? '' : 'max-w-6xl'} mx-auto">
+<div class="h-full max-h-[calc(100%-41px)] overflow-auto w-full {app.fullscreen ? '' : 'max-w-6xl'} mx-auto">
 	{#if $appStore.grid}
 		<div class={classNames('mx-auto pb-4', width)}>
 			<GridEditor {policy} />

--- a/frontend/src/lib/components/apps/editor/TablePanel.svelte
+++ b/frontend/src/lib/components/apps/editor/TablePanel.svelte
@@ -9,9 +9,6 @@
 
 {#each component.actionButtons as actionButton (actionButton.id)}
 	{#if actionButton.id === $selectedComponent}
-		<div>
-			{console.log(actionButton)}
-		</div>
 		<ComponentPanel
 			rowColumns
 			bind:component={actionButton}

--- a/frontend/src/lib/components/apps/editor/TablePanel.svelte
+++ b/frontend/src/lib/components/apps/editor/TablePanel.svelte
@@ -9,6 +9,9 @@
 
 {#each component.actionButtons as actionButton (actionButton.id)}
 	{#if actionButton.id === $selectedComponent}
+		<div>
+			{console.log(actionButton)}
+		</div>
 		<ComponentPanel
 			rowColumns
 			bind:component={actionButton}

--- a/frontend/src/lib/components/apps/editor/settingsPanel/InputsSpecsEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/InputsSpecsEditor.svelte
@@ -73,7 +73,7 @@
 											startIcon={{ icon: faTableCells }}
 											size="xs"
 										>
-											<Tooltip>
+											<Tooltip scale={0.6} placement="top-end" wrapperClass="center-center">
 												Use the column name to have the value of the cell be passed to the action
 											</Tooltip>
 										</ToggleButton>

--- a/frontend/src/lib/components/common/button/Button.svelte
+++ b/frontend/src/lib/components/common/button/Button.svelte
@@ -65,7 +65,7 @@
 	$: buttonProps = {
 		id,
 		class: classNames(
-			colorVariants[color][variant],
+			colorVariants?.[color]?.[variant],
 			variant === 'border' ? 'border' : '',
 			ButtonType.FontSizeClasses[size],
 			ButtonType.SpacingClasses[spacingSize],


### PR DESCRIPTION
- the app builder header row is now fixed to the top in preview mode as well
- fixed styling issues
- handled error when the inputs of the button component are tied to free user input (table column selection)