### PR TITLE
Enable GitHub OAuth for Uffizzi Previews.

### DIFF
--- a/.github/uffizzi/docker-compose.uffizzi.yml
+++ b/.github/uffizzi/docker-compose.uffizzi.yml
@@ -31,6 +31,10 @@ services:
       - OAUTH_JSON_BASE64=${OAUTH_JSON_BASE64}
     volumes:
       - worker_dependency_cache:/tmp/windmill/cache
+    deploy:
+      resources:
+        limits:
+          memory: 250M
 
   lsp:
     image: '${LSP_IMAGE}'

--- a/.github/uffizzi/docker-compose.uffizzi.yml
+++ b/.github/uffizzi/docker-compose.uffizzi.yml
@@ -14,13 +14,13 @@ services:
 
   windmill:
     image: '${WINDMILL_IMAGE}'
-    privileged: false
-    restart: unless-stopped
     ports:
       - 8000:8000
+    entrypoint: ['/bin/sh', '-c']
+    command: 'echo ${OAUTH_JSON_BASE64} | base64 --decode > /usr/src/app/oauth.json && ./windmill'
     environment:
       - DATABASE_URL=postgres://postgres:changeme@localhost/windmill?sslmode=disable
-      - BASE_URL=http://localhost
+      - BASE_URL=${EXPECTED_URL}
       - BASE_INTERNAL_URL=http://localhost:8000
       - RUST_LOG=info
       - NUM_WORKERS=3
@@ -28,12 +28,12 @@ services:
       - DENO_PATH=/usr/bin/deno
       - PYTHON_PATH=/usr/local/bin/python3
       - METRICS_ADDR=false
+      - OAUTH_JSON_BASE64=${OAUTH_JSON_BASE64}
     volumes:
       - worker_dependency_cache:/tmp/windmill/cache
 
   lsp:
     image: '${LSP_IMAGE}'
-    restart: unless-stopped
     ports:
       - 3001:3001
 

--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -4,6 +4,7 @@ on:
     types: [opened,synchronize,reopened,closed]
     paths:
       - "backend/**"
+      - ".github/**"
   workflow_dispatch:
       
 jobs:

--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -4,7 +4,8 @@ on:
     types: [opened,synchronize,reopened,closed]
     paths:
       - "backend/**"
-      - ".github/**"
+      - ".github/uffizzi/**"
+      - ".github/workflows/**"
   workflow_dispatch:
       
 jobs:

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -47,21 +47,34 @@ jobs:
           echo 'EVENT_JSON<<EOF' >> $GITHUB_ENV
           cat event.json >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
+      - name: Read PR Number From Event Object
+        id: pr
+        run: echo "PR_NUMBER=${{ fromJSON(env.EVENT_JSON).number }}" >> $GITHUB_ENV
+      - name: Predict Deployment URL
+        id: url
+        # Replace dots in the repo name with the plus sign
+        run: |
+          REPO=$(echo ${{ github.repository }} | sed 's/\./+/g')
+          echo "EXPECTED_URL=https://app.uffizzi.com/github.com/$REPO/pull/$PR_NUMBER" >> $GITHUB_ENV
+
+      - name: Re-Render Compose File
+        run: |
+          OAUTH_JSON_BASE64=${{ secrets.OAUTH_JSON_BASE64 }}
+          export OAUTH_JSON_BASE64
+          envsubst '${OAUTH_JSON_BASE64} ${EXPECTED_URL}' < docker-compose.rendered.yml > docker-compose.uffizzi.yml
+          # cat docker-compose.uffizzi.yml
+
       - name: Hash Rendered Compose File
         id: hash
         # If the previous workflow was triggered by a PR close event, we will not have a compose file artifact.
         if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
-        run: echo "COMPOSE_FILE_HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_ENV
+        run: echo "COMPOSE_FILE_HASH=$(md5sum docker-compose.uffizzi.yml | awk '{ print $1 }')" >> $GITHUB_ENV
       - name: Cache Rendered Compose File
         if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
         uses: actions/cache@v3
         with:
-          path: docker-compose.rendered.yml
+          path: docker-compose.uffizzi.yml
           key: ${{ env.COMPOSE_FILE_HASH }}
-
-      - name: Read PR Number From Event Object
-        id: pr
-        run: echo "PR_NUMBER=${{ fromJSON(env.EVENT_JSON).number }}" >> $GITHUB_ENV
 
       - name: DEBUG - Print Job Outputs
         if: ${{ runner.debug }}
@@ -80,7 +93,7 @@ jobs:
       # If this workflow was triggered by a PR close event, cache-key will be an empty string
       # and this reusable workflow will delete the preview deployment.
       compose-file-cache-key: ${{ needs.cache-compose-file.outputs.compose-file-cache-key }}
-      compose-file-cache-path: docker-compose.rendered.yml
+      compose-file-cache-path: docker-compose.uffizzi.yml
       server: https://app.uffizzi.com
       pr-number: ${{ needs.cache-compose-file.outputs.pr-number }}
     permissions:


### PR DESCRIPTION
We wanted to enable the GitHub login button for windmill previews. Windmill has a few configuration features that made this easier than other applications, including the easy OAuth configuration and ability to specify the `BASE_URL` path. I got this working in about a day.

You can see this running here https://pr-4-deployment-12160-windmill.app.uffizzi.com/

For this PR changeset, you'll want to specify a GitHub Actions Secret with Name `OAUTH_JSON_BASE64` and whose value is a base64-encoded `oauth.json` file with configuration for a GitHub OAuth App. Here's mine as an example:

```json
{
  "github": {
    "id": "afe59a7afe911b5b0714",
    "secret": "[redacted]"
  }
}
```

This secret will be read by the `uffizzi-preview` workflow and injected into the compose file before Uffizzi deploys it. That environment variable will then be decoded and written to `/usr/src/app/oauth.json` when the container starts. We recommend using a different GitHub OAuth App from your production OAuth App.

I admit I'm barely familiar with your testing process, so I look forward to receiving feedback to get this capability integrated. Thanks!