### PR TITLE
fix(frontend): Add highlight to selected workspace

### DIFF
--- a/frontend/src/lib/components/sidebar/WorkspaceMenu.svelte
+++ b/frontend/src/lib/components/sidebar/WorkspaceMenu.svelte
@@ -30,8 +30,10 @@
 			<table class="w-full">
 				{#each $userWorkspaces as workspace}
 					<tr
-						class="text-xs cursor-pointer hover:bg-gray-100"
+						class="text-xs 
+						{$workspaceStore === workspace.id ? 'cursor-default bg-blue-50' : 'cursor-pointer hover:bg-gray-100'}"
 						on:click={() => {
+							if($workspaceStore === workspace.id) { return }
 							switchWorkspace(workspace.id)
 							close()
 						}}


### PR DESCRIPTION
With the side menu collapsed, it wasn't clear which workspace was selected

<img width="253" alt="Screenshot 2023-01-26 at 10 27 54" src="https://user-images.githubusercontent.com/43071496/214801564-877bc9bf-94ba-4948-919b-4ecc98287b29.png">
