### PR TITLE
feat(frontend): Add HTML result rendering

### DIFF
--- a/frontend/src/lib/components/DisplayResult.svelte
+++ b/frontend/src/lib/components/DisplayResult.svelte
@@ -12,6 +12,7 @@
 		| 'json'
 		| 'table-col'
 		| 'table-row'
+		| 'html'
 		| 'png'
 		| 'file'
 		| 'jpeg'
@@ -19,9 +20,14 @@
 		| 'error'
 		| 'approval'
 		| undefined
+
+	$: if(result) {
+		enableHtml = false
+	}
 	$: resultKind = inferResultKind(result)
 
 	let forceJson = false
+	let enableHtml = false
 
 	function isRectangularArray(obj: any) {
 		if (!Array.isArray(obj) || obj.length == 0) {
@@ -53,6 +59,8 @@
 					return 'table-row'
 				} else if (keys.map((k) => Array.isArray(result[k])).reduce((a, b) => a && b)) {
 					return 'table-col'
+				} else if (keys.length == 1 && keys[0] == 'html') {
+					return 'html'
 				} else if (keys.length == 1 && keys[0] == 'png') {
 					return 'png'
 				} else if (keys.length == 1 && keys[0] == 'jpeg') {
@@ -118,6 +126,34 @@
 						{/each}
 					</tbody>
 				</TableCustom>
+			</div>
+		{:else if !forceJson && resultKind == 'html'}
+			<div class="h-full">
+				{#if enableHtml}
+					{@html result.html}
+				{:else}
+					<div class="font-main text-sm">
+						<div class="flex flex-col">
+							<div class="bg-red-400 py-1 rounded-t text-white font-bold text-center">
+								Warning
+							</div>
+							<p
+								class="text-gray-600 mb-2 text-left border-2 !border-t-0 rounded-b border-red-400 overflow-auto p-1"
+							>Rendering HTML can expose you to XSS attacks.
+Only enable it if you trust the author of the script.
+							</p>
+						</div>
+						<div class="center-center">
+							<Button
+								size="sm"
+								color="dark"
+								on:click={() => enableHtml = true}
+							>
+								Enable HTML rendering
+							</Button>
+						</div>
+					</div>
+				{/if}
 			</div>
 		{:else if !forceJson && resultKind == 'png'}
 			<div class="h-full"

--- a/frontend/src/lib/components/DisplayResult.svelte
+++ b/frontend/src/lib/components/DisplayResult.svelte
@@ -139,7 +139,7 @@
 							</div>
 							<p
 								class="text-gray-600 mb-2 text-left border-2 !border-t-0 rounded-b border-red-400 overflow-auto p-1"
-							>Rendering HTML can expose you to XSS attacks.
+							>Rendering HTML can expose you to <a href="https://owasp.org/www-community/attacks/xss/" target="_blank" rel="noreferrer" class="hover:underline">XSS attacks</a>.
 Only enable it if you trust the author of the script.
 							</p>
 						</div>


### PR DESCRIPTION
Added the possiblity (with responsibility given to the user) to render HTML (and therefore display SVG images) in the result panel of the script editor


<img width="449" alt="Screenshot 2023-01-26 at 14 55 50" src="https://user-images.githubusercontent.com/43071496/214853722-a6a9d818-2adc-4e89-87c4-e233903bbb8a.png">
