### PR TITLE
fix(frontend): Add more app custom css

### DIFF
--- a/frontend/src/lib/components/apps/components/display/AppIcon.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppIcon.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
+	import { getContext } from 'svelte'
 	import type { AppInput } from '../../inputType'
-	import { AlignWrapper, InputValue, RunnableWrapper } from '../helpers'
+	import type { AppEditorContext, ComponentCustomCSS } from '../../types'
+	import { concatCustomCss } from '../../utils'
+	import { AlignWrapper, InputValue } from '../helpers'
 	import { loadIcon } from '../icon'
 
 	export let id: string
@@ -8,6 +11,9 @@
 	export let verticalAlignment: 'top' | 'center' | 'bottom' | undefined = undefined
 	export let configuration: Record<string, AppInput>
 	export const staticOutputs: string[] = []
+	export let customCss: ComponentCustomCSS<'container' | 'icon'> | undefined = undefined
+
+	const { app } = getContext<AppEditorContext>('AppEditorContext')
 
 	let icon: string | undefined = undefined
 	let size: number
@@ -22,6 +28,8 @@
 			iconComponent = await loadIcon(icon)
 		}
 	}
+
+	$: css = concatCustomCss($app.css?.iconcomponent, customCss)
 </script>
 
 <InputValue {id} input={configuration.icon} bind:value={icon} />
@@ -29,13 +37,20 @@
 <InputValue {id} input={configuration.color} bind:value={color} />
 <InputValue {id} input={configuration.strokeWidth} bind:value={strokeWidth} />
 
-<AlignWrapper {horizontalAlignment} {verticalAlignment}>
+<AlignWrapper
+	{horizontalAlignment}
+	{verticalAlignment}
+	class={css?.container?.class ?? ''}
+	style={css?.container?.style ?? ''}
+>
 	{#if iconComponent}
 		<svelte:component
 			this={iconComponent}
 			size={size || 24}
 			color={color || 'currentColor'}
 			strokeWidth={strokeWidth || 2}
+			class={css?.icon?.class ?? ''}
+			style={css?.icon?.style ?? ''}
 		/>
 	{/if}
 </AlignWrapper>

--- a/frontend/src/lib/components/apps/components/display/AppImage.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppImage.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
+	import { getContext } from 'svelte'
+	import { twMerge } from 'tailwind-merge'
 	import type { staticValues } from '../../editor/componentsPanel/componentStaticValues'
 	import type { AppInput } from '../../inputType'
+	import type { AppEditorContext, ComponentCustomCSS } from '../../types'
+	import { concatCustomCss } from '../../utils'
 	import InputValue from '../helpers/InputValue.svelte'
 
 	type FitOption = (typeof staticValues)['objectFitOptions'][number]
@@ -8,7 +12,9 @@
 	export let id: string
 	export let configuration: Record<string, AppInput>
 	export const staticOutputs: string[] = ['loading']
+	export let customCss: ComponentCustomCSS<'image'> | undefined = undefined
 
+	const { app } = getContext<AppEditorContext>('AppEditorContext')
 	const fit: Record<FitOption, string> = {
 		cover: 'object-cover',
 		contain: 'object-contain',
@@ -18,18 +24,18 @@
 	let source: string | undefined = undefined
 	let imageFit: FitOption | undefined = undefined
 	let altText: string | undefined = undefined
-	let customStyles: string | undefined = undefined
+
+	$: css = concatCustomCss($app.css?.imagecomponent, customCss)
 </script>
 
 <InputValue {id} input={configuration.source} bind:value={source} />
 <InputValue {id} input={configuration.imageFit} bind:value={imageFit} />
 <InputValue {id} input={configuration.altText} bind:value={altText} />
-<InputValue {id} input={configuration.customStyles} bind:value={customStyles} />
 
 <img
 	on:pointerdown|preventDefault
 	src={source}
 	alt={altText}
-	style={customStyles}
-	class="w-full h-full {fit[imageFit || 'cover']}"
+	style={css?.image?.style ?? ''}
+	class={twMerge(`w-full h-full ${fit[imageFit || 'cover']}`, css?.image?.class ?? '')}
 />

--- a/frontend/src/lib/components/apps/components/helpers/AlignWrapper.svelte
+++ b/frontend/src/lib/components/apps/components/helpers/AlignWrapper.svelte
@@ -1,41 +1,44 @@
 <script lang="ts">
-	import { classNames } from '$lib/utils'
+	import { twMerge } from 'tailwind-merge'
 	import type { HorizontalAlignment, VerticalAlignment } from '../../types'
 
 	export let horizontalAlignment: HorizontalAlignment | undefined = undefined
 	export let verticalAlignment: VerticalAlignment | undefined = undefined
 	export let noWFull = false
+	let c = ''
+	export { c as class }
+	export let style = ''
 
 	function tailwindHorizontalAlignment(alignment?: HorizontalAlignment) {
-		if(!alignment) return '';
+		if (!alignment) return ''
 		const classes: Record<HorizontalAlignment, string> = {
 			left: 'justify-start',
 			center: 'justify-center',
-			right: 'justify-end',
+			right: 'justify-end'
 		}
 		return classes[alignment]
 	}
 
 	function tailwindVerticalAlignment(alignment?: VerticalAlignment) {
-		if(!alignment) return '';
+		if (!alignment) return ''
 		const classes: Record<VerticalAlignment, string> = {
 			top: 'items-start',
 			center: 'items-center',
-			bottom: 'items-end',
+			bottom: 'items-end'
 		}
 		return classes[alignment]
 	}
 
-	$: classes = classNames(
+	$: classes = twMerge(
 		'flex z-auto',
 		noWFull ? '' : 'w-full',
 		tailwindHorizontalAlignment(horizontalAlignment),
 		tailwindVerticalAlignment(verticalAlignment),
 		verticalAlignment ? 'h-full' : '',
-		$$props.class || ''
+		c
 	)
 </script>
 
-<div class={classes}>
+<div class={classes} {style}>
 	<slot />
 </div>

--- a/frontend/src/lib/components/apps/components/inputs/AppDateInput.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/AppDateInput.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import { getContext } from 'svelte'
+	import { twMerge } from 'tailwind-merge'
 	import type { AppInput } from '../../inputType'
 	import type { Output } from '../../rx'
-	import type { AppEditorContext } from '../../types'
+	import type { AppEditorContext, ComponentCustomCSS } from '../../types'
+	import { concatCustomCss } from '../../utils'
 	import AlignWrapper from '../helpers/AlignWrapper.svelte'
 	import InputDefaultValue from '../helpers/InputDefaultValue.svelte'
 	import InputValue from '../helpers/InputValue.svelte'
@@ -12,8 +14,9 @@
 	export let inputType: 'date' | 'time' | 'datetime-local'
 	export let verticalAlignment: 'top' | 'center' | 'bottom' | undefined = undefined
 	export const staticOutputs: string[] = ['result']
+	export let customCss: ComponentCustomCSS<'input'> | undefined = undefined
 
-	const { worldStore } = getContext<AppEditorContext>('AppEditorContext')
+	const { app, worldStore } = getContext<AppEditorContext>('AppEditorContext')
 	let input: HTMLInputElement
 	let labelValue: string = 'Title'
 	let minValue: string = ''
@@ -29,6 +32,8 @@
 	}
 
 	$: input && handleInput()
+
+	$: css = concatCustomCss($app.css?.dateinputcomponent, customCss)
 </script>
 
 <InputValue {id} input={configuration.label} bind:value={labelValue} />
@@ -46,6 +51,7 @@
 		min={minValue}
 		max={maxValue}
 		placeholder="Type..."
-		class="h-full"
+		class={twMerge('mx-0.5', css?.input?.class ?? '')}
+		style={css?.input?.style ?? ''}
 	/>
 </AlignWrapper>

--- a/frontend/src/lib/components/apps/components/inputs/AppFileInput.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/AppFileInput.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
 	import { getContext } from 'svelte'
+	import { twMerge } from 'tailwind-merge'
 	import { FileInput } from '../../../common'
 	import type { AppInput } from '../../inputType'
 	import type { Output } from '../../rx'
-	import type { AppEditorContext } from '../../types'
+	import type { AppEditorContext, ComponentCustomCSS } from '../../types'
+	import { concatCustomCss } from '../../utils'
 	import InputValue from '../helpers/InputValue.svelte'
 
 	export let id: string
 	export let configuration: Record<string, AppInput>
 	export const staticOutputs: string[] = ['result']
+	export let customCss: ComponentCustomCSS<'container'> | undefined = undefined
 
-	const { worldStore } = getContext<AppEditorContext>('AppEditorContext')
+	const { app, worldStore } = getContext<AppEditorContext>('AppEditorContext')
 
 	let acceptedFileTypes: string[] | undefined = undefined
 	let allowMultiple: boolean | undefined = undefined
@@ -24,6 +27,8 @@
 	async function handleChange(files: string[] | undefined) {
 		outputs?.result.set(files)
 	}
+
+	$: css = concatCustomCss($app.css?.fileinputcomponent, customCss)
 </script>
 
 <InputValue {id} input={configuration.acceptedFileTypes} bind:value={acceptedFileTypes} />
@@ -38,7 +43,8 @@
 		on:change={({ detail }) => {
 			handleChange(detail)
 		}}
-		class="w-full h-full"
+		class={twMerge('w-full h-full', css?.container?.class)}
+		style={css?.container?.style}
 	>
 		{text}
 	</FileInput>

--- a/frontend/src/lib/components/apps/components/inputs/AppNumberInput.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/AppNumberInput.svelte
@@ -2,7 +2,8 @@
 	import { getContext } from 'svelte'
 	import type { AppInput } from '../../inputType'
 	import type { Output } from '../../rx'
-	import type { AppEditorContext } from '../../types'
+	import type { AppEditorContext, ComponentCustomCSS } from '../../types'
+	import { concatCustomCss } from '../../utils'
 	import AlignWrapper from '../helpers/AlignWrapper.svelte'
 	import InputDefaultValue from '../helpers/InputDefaultValue.svelte'
 	import InputValue from '../helpers/InputValue.svelte'
@@ -11,8 +12,9 @@
 	export let configuration: Record<string, AppInput>
 	export let verticalAlignment: 'top' | 'center' | 'bottom' | undefined = undefined
 	export const staticOutputs: string[] = ['result']
+	export let customCss: ComponentCustomCSS<'input'> | undefined = undefined
 
-	const { worldStore } = getContext<AppEditorContext>('AppEditorContext')
+	const { app, worldStore } = getContext<AppEditorContext>('AppEditorContext')
 	let input: HTMLInputElement
 
 	let defaultValue: number | undefined = undefined
@@ -33,6 +35,8 @@
 	}
 
 	$: input && handleInput()
+
+	$: css = concatCustomCss($app.css?.numberinputcomponent, customCss)
 </script>
 
 <InputValue {id} input={configuration.step} bind:value={step} />
@@ -44,6 +48,8 @@
 
 <AlignWrapper {verticalAlignment}>
 	<input
+		class="mx-0.5 {css?.input?.class ?? ''}"
+		style={css?.input?.style ?? ''}
 		bind:this={input}
 		on:input={handleInput}
 		on:focus={(e) => {

--- a/frontend/src/lib/components/apps/components/inputs/AppRangeInput.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/AppRangeInput.svelte
@@ -3,20 +3,24 @@
 	import { getContext } from 'svelte'
 	import type { AppInput } from '../../inputType'
 	import type { Output } from '../../rx'
-	import type { AppEditorContext } from '../../types'
+	import type { AppEditorContext, ComponentCustomCSS } from '../../types'
 	import AlignWrapper from '../helpers/AlignWrapper.svelte'
 	import InputValue from '../helpers/InputValue.svelte'
-	import { Badge } from '$lib/components/common'
+	import { concatCustomCss } from '../../utils'
+	import { twMerge } from 'tailwind-merge'
 
 	export let id: string
 	export let configuration: Record<string, AppInput>
 	export let verticalAlignment: 'top' | 'center' | 'bottom' | undefined = undefined
 	export const staticOutputs: string[] = ['result']
+	export let customCss: ComponentCustomCSS<'handles' | 'bar' | 'limits' | 'values'> | undefined =
+		undefined
 
-	const { worldStore } = getContext<AppEditorContext>('AppEditorContext')
+	const { app, worldStore } = getContext<AppEditorContext>('AppEditorContext')
 	let min = 0
 	let max = 42
 	let step = 1
+	let slider: HTMLElement
 
 	let values: [number, number] = [0, 0]
 
@@ -25,6 +29,17 @@
 	}
 
 	$: outputs?.result.set(values)
+
+	$: css = concatCustomCss($app.css?.rangecomponent, customCss)
+
+	let lastStyle: string | undefined = undefined
+	$: if (css && slider && lastStyle !== css?.handles?.style) {
+		const handles = slider.querySelectorAll<HTMLSpanElement>('.rangeNub')
+		if (handles) {
+			lastStyle = css?.handles?.style
+			handles.forEach((handle) => (handle.style.cssText = css?.handles?.style ?? ''))
+		}
+	}
 </script>
 
 <InputValue {id} input={configuration.step} bind:value={step} />
@@ -36,20 +51,45 @@
 <AlignWrapper {verticalAlignment}>
 	<div class="flex flex-col w-full">
 		<div class="flex items-center w-full gap-1 px-1">
-			<span>{min}</span>
+			<span class={css?.limits?.class ?? ''} style={css?.limits?.style ?? ''}>
+				{min}
+			</span>
 			<div class="grow" on:pointerdown|stopPropagation>
-				<RangeSlider {step} range min={min ?? 0} max={max ?? 1} bind:values />
-				<!-- <DoubleRange bind:start bind:end /> -->
+				<RangeSlider
+					bind:slider
+					bind:values
+					{step}
+					min={min ?? 0}
+					max={max ?? 1}
+					range
+					pips
+					hoverable={false}
+				/>
+				<!-- <RangeSlider {step} range min={min ?? 0} max={max ?? 1} bind:values /> -->
 			</div>
-			<span>{max}</span>
+			<span class={css?.limits?.class ?? ''} style={css?.limits?.style ?? ''}>
+				{max}
+			</span>
 		</div>
 		<div class="flex justify-between px-1">
-			<div>
-				<Badge color="blue">{values[0]}</Badge>
-			</div>
-			<div>
-				<Badge color="blue">{values[1]}</Badge>
-			</div>
+			<span
+				class={twMerge(
+					'text-center text-sm font-medium bg-blue-100 text-blue-800 rounded px-2.5 py-0.5',
+					css?.values?.class ?? ''
+				)}
+				style={css?.values?.style ?? ''}
+			>
+				{values[0]}
+			</span>
+			<span
+				class={twMerge(
+					'text-center text-sm font-medium bg-blue-100 text-blue-800 rounded px-2.5 py-0.5',
+					css?.values?.class ?? ''
+				)}
+				style={css?.values?.style ?? ''}
+			>
+				{values[1]}
+			</span>
 		</div>
 	</div>
 </AlignWrapper>

--- a/frontend/src/lib/components/apps/components/inputs/AppSliderInputs.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/AppSliderInputs.svelte
@@ -1,22 +1,25 @@
 <script lang="ts">
-	import { Badge } from '$lib/components/common'
 	import RangeSlider from 'svelte-range-slider-pips'
 	import { getContext } from 'svelte'
 	import type { AppInput } from '../../inputType'
 	import type { Output } from '../../rx'
-	import type { AppEditorContext } from '../../types'
+	import type { AppEditorContext, ComponentCustomCSS } from '../../types'
 	import AlignWrapper from '../helpers/AlignWrapper.svelte'
 	import InputValue from '../helpers/InputValue.svelte'
+	import { twMerge } from 'tailwind-merge'
+	import { concatCustomCss } from '../../utils'
 
 	export let id: string
 	export let configuration: Record<string, AppInput>
 	export let verticalAlignment: 'top' | 'center' | 'bottom' | undefined = undefined
 	export const staticOutputs: string[] = ['result']
+	export let customCss: ComponentCustomCSS<'handle' | 'limits' | 'value'> | undefined = undefined
 
-	const { worldStore, selectedComponent } = getContext<AppEditorContext>('AppEditorContext')
+	const { app, worldStore, selectedComponent } = getContext<AppEditorContext>('AppEditorContext')
 	let min = 0
 	let max = 42
 	let step = 1
+	let slider: HTMLElement
 
 	$: outputs = $worldStore?.outputsById[id] as {
 		result: Output<number | null>
@@ -34,6 +37,17 @@
 		const num = isNaN(+values[0]) ? null : +values[0]
 		outputs?.result.set(num)
 	}
+
+	$: css = concatCustomCss($app.css?.slidercomponent, customCss)
+
+	let lastStyle: string | undefined = undefined
+	$: if (css && slider && lastStyle !== css?.handle?.style) {
+		const handle = slider.querySelector<HTMLSpanElement>('.rangeNub')
+		if (handle) {
+			lastStyle = css?.handle?.style
+			handle.style.cssText = css?.handle?.style ?? ''
+		}
+	}
 </script>
 
 <InputValue {id} input={configuration.step} bind:value={step} />
@@ -43,11 +57,33 @@
 
 <AlignWrapper {verticalAlignment}>
 	<div class="flex items-center w-full gap-1 px-1">
-		<span>{min}</span>
+		<span class={css?.limits?.class ?? ''} style={css?.limits?.style ?? ''}>
+			{min}
+		</span>
 		<div class="grow" on:pointerdown|stopPropagation={() => ($selectedComponent = id)}>
-			<RangeSlider {step} min={min ?? 0} max={max ?? 1} bind:values />
+			<RangeSlider
+				bind:slider
+				bind:values
+				{step}
+				min={min ?? 0}
+				max={max ?? 1}
+				pips
+				hoverable={false}
+			/>
 		</div>
-		<span>{max}</span>
-		<span class="mx-2"><Badge large color="blue">{values[0]}</Badge></span>
+		<span class={css?.limits?.class ?? ''} style={css?.limits?.style ?? ''}>
+			{max}
+		</span>
+		<span class="mx-2">
+			<span
+				class={twMerge(
+					'text-center text-sm font-medium bg-blue-100 text-blue-800 rounded px-2.5 py-0.5',
+					css?.value?.class ?? ''
+				)}
+				style={css?.value?.style ?? ''}
+			>
+				{values[0]}
+			</span>
+		</span>
 	</div>
 </AlignWrapper>

--- a/frontend/src/lib/components/apps/components/inputs/AppTextInput.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/AppTextInput.svelte
@@ -14,6 +14,7 @@
 	export let verticalAlignment: 'top' | 'center' | 'bottom' | undefined = undefined
 	export const staticOutputs: string[] = ['result']
 	export let customCss: ComponentCustomCSS<'input'> | undefined = undefined
+	export let appCssKey: 'textinputcomponent' | 'passwordinputcomponent' = 'textinputcomponent'
 
 	const { app, worldStore } = getContext<AppEditorContext>('AppEditorContext')
 	let input: HTMLInputElement
@@ -31,7 +32,7 @@
 
 	$: input && handleInput()
 
-	$: css = concatCustomCss($app.css?.textinputcomponent, customCss)
+	$: css = concatCustomCss($app.css?.[appCssKey], customCss)
 </script>
 
 <InputValue {id} input={configuration.placeholder} bind:value={placeholder} />

--- a/frontend/src/lib/components/apps/components/inputs/AppTextInput.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/AppTextInput.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { getContext } from 'svelte'
+	import { twMerge } from 'tailwind-merge'
 	import type { AppInput } from '../../inputType'
 	import type { Output } from '../../rx'
 	import type { AppEditorContext, ComponentCustomCSS } from '../../types'
@@ -41,7 +42,7 @@
 
 <AlignWrapper {verticalAlignment}>
 	<input
-		class="mx-0.5 {css?.input?.class ?? ''}"
+		class={twMerge('mx-0.5', css?.input?.class ?? '')}
 		style={css?.input?.style ?? ''}
 		on:focus={(e) => {
 			e?.stopPropagation()

--- a/frontend/src/lib/components/apps/components/inputs/currency/AppCurrencyInput.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/currency/AppCurrencyInput.svelte
@@ -2,7 +2,8 @@
 	import { getContext } from 'svelte'
 	import type { AppInput } from '../../../inputType'
 	import type { Output } from '../../../rx'
-	import type { AppEditorContext } from '../../../types'
+	import type { AppEditorContext, ComponentCustomCSS } from '../../../types'
+	import { concatCustomCss } from '../../../utils'
 	import AlignWrapper from '../../helpers/AlignWrapper.svelte'
 	import InputValue from '../../helpers/InputValue.svelte'
 	import CurrencyInput from './CurrencyInput.svelte'
@@ -11,8 +12,9 @@
 	export let configuration: Record<string, AppInput>
 	export let verticalAlignment: 'top' | 'center' | 'bottom' | undefined = undefined
 	export const staticOutputs: string[] = ['result']
+	export let customCss: ComponentCustomCSS<'input'> | undefined = undefined
 
-	const { worldStore } = getContext<AppEditorContext>('AppEditorContext')
+	const { app, worldStore } = getContext<AppEditorContext>('AppEditorContext')
 
 	let defaultValue: number | undefined = undefined
 
@@ -37,6 +39,8 @@
 	$: value != undefined && handleInput()
 
 	$: defaultValue != undefined && handleDefault()
+
+	$: css = concatCustomCss($app.css?.currencycomponent, customCss)
 </script>
 
 <InputValue {id} input={configuration.defaultValue} bind:value={defaultValue} />
@@ -49,7 +53,12 @@
 		{#key locale}
 			{#key currency}
 				<CurrencyInput
-					inputClasses={{ formatted: 'p-0', wrapper: 'w-full', formattedZero: 'text-black' }}
+					inputClasses={{
+						formatted: 'p-0 ' + css?.input?.class,
+						wrapper: 'w-full',
+						formattedZero: 'text-black ' + css?.input?.class
+					}}
+					style={css?.input?.style}
 					bind:value
 					{currency}
 					{locale}

--- a/frontend/src/lib/components/apps/components/inputs/currency/CurrencyInput.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/currency/CurrencyInput.svelte
@@ -35,6 +35,7 @@
 	export let isNegativeAllowed: boolean = true
 	export let fractionDigits: number = DEFAULT_FRACTION_DIGITS
 	export let inputClasses: InputClasses | null = null
+	export let style: string = ''
 
 	// Formats value as: e.g. $1,523.00 | -$1,523.00
 	const formatCurrency = (
@@ -175,6 +176,7 @@
 			? inputClasses?.formattedNegative ?? DEFAULT_CLASS_FORMATTED_NEGATIVE
 			: ''}
 		"
+		{style}
 		type="text"
 		inputmode="numeric"
 		name={`formatted-${name}`}

--- a/frontend/src/lib/components/apps/components/layout/AppDivider.svelte
+++ b/frontend/src/lib/components/apps/components/layout/AppDivider.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
+	import { getContext } from 'svelte'
+	import { twMerge } from 'tailwind-merge'
 	import type { AppInput } from '../../inputType'
-	import type { HorizontalAlignment, VerticalAlignment } from '../../types'
+	import type {
+		AppEditorContext,
+		ComponentCustomCSS,
+		HorizontalAlignment,
+		VerticalAlignment
+	} from '../../types'
+	import { concatCustomCss } from '../../utils'
 	import AlignWrapper from '../helpers/AlignWrapper.svelte'
 	import InputValue from '../helpers/InputValue.svelte'
 
@@ -8,17 +16,34 @@
 	export let configuration: Record<string, AppInput>
 	export let horizontalAlignment: HorizontalAlignment | undefined = undefined
 	export let verticalAlignment: VerticalAlignment | undefined = undefined
+	export let customCss: ComponentCustomCSS<'container' | 'divider'> | undefined = undefined
 	export let position: 'horizontal' | 'vertical'
+
+	const { app } = getContext<AppEditorContext>('AppEditorContext')
 	let size = 2
 	let color = '#00000060'
+
+	$: css = concatCustomCss($app.css?.[position + 'dividercomponent'], customCss)
 </script>
 
 <InputValue {id} input={configuration.size} bind:value={size} />
 <InputValue {id} input={configuration.color} bind:value={color} />
 
-<AlignWrapper {horizontalAlignment} {verticalAlignment} class="h-full">
+<AlignWrapper
+	{horizontalAlignment}
+	{verticalAlignment}
+	class={twMerge(css?.container?.class, 'h-full')}
+	style={css?.container?.style}
+>
 	<div
-		class="rounded-full {position === 'horizontal' ? 'w-full' : 'h-full'}"
-		style="{position === 'horizontal' ? 'height' : 'width'}: {size}px; background-color: {color}"
+		class={twMerge(
+			`rounded-full ${position === 'horizontal' ? 'w-full' : 'h-full'}`,
+			css?.divider?.class ?? ''
+		)}
+		style="
+			{position === 'horizontal' ? 'height' : 'width'}: {size}px;
+			background-color: {color};
+			{css?.divider?.style ?? ''}
+		"
 	/>
 </AlignWrapper>

--- a/frontend/src/lib/components/apps/components/layout/AppTabs.svelte
+++ b/frontend/src/lib/components/apps/components/layout/AppTabs.svelte
@@ -4,13 +4,17 @@
 	import SubGridEditor from '../../editor/SubGridEditor.svelte'
 	import type { AppInput } from '../../inputType'
 	import type { Output } from '../../rx'
-	import type { AppEditorContext, GridItem } from '../../types'
+	import type { AppEditorContext, ComponentCustomCSS } from '../../types'
+	import { concatCustomCss } from '../../utils'
 	import InputValue from '../helpers/InputValue.svelte'
 
 	export let id: string
 	export let configuration: Record<string, AppInput>
 	export let componentContainerHeight: number
 	export let tabs: string[]
+	export let customCss:
+		| ComponentCustomCSS<'tabRow' | 'tabs' | 'selectedTab' | 'container'>
+		| undefined = undefined
 
 	export const staticOutputs: string[] = ['selectedTabIndex']
 	const { app, worldStore, focusedGrid, selectedComponent } =
@@ -54,6 +58,8 @@
 	}
 
 	$: $selectedComponent === id && selectedIndex >= 0 && onFocus()
+
+	$: css = concatCustomCss($app.css?.tabscomponent, customCss)
 </script>
 
 <InputValue {id} input={configuration.tabs} bind:value={tabs} />
@@ -61,9 +67,15 @@
 
 <div>
 	<div bind:clientHeight={tabHeight} on:pointerdown|stopPropagation>
-		<Tabs bind:selected>
+		<Tabs bind:selected class={css?.tabRow?.class} style={css?.tabRow?.style}>
 			{#each tabs ?? [] as res}
-				<Tab value={res}>
+				<Tab
+					value={res}
+					class={css?.tabs?.class}
+					style={css?.tabs?.style}
+					selectedClass={css?.selectedTab?.class}
+					selectedStyle={css?.selectedTab?.style}
+				>
 					<span class="font-semibold">{res}</span>
 				</Tab>
 			{/each}
@@ -75,6 +87,8 @@
 				visible={i === selectedIndex}
 				bind:subGrid={$app.subgrids[`${id}-${i}`]}
 				{noPadding}
+				class={css?.container?.class}
+				style={css?.container?.style}
 				containerHeight={componentContainerHeight - tabHeight}
 				on:focus={() => {
 					$selectedComponent = id

--- a/frontend/src/lib/components/apps/editor/component/Component.svelte
+++ b/frontend/src/lib/components/apps/editor/component/Component.svelte
@@ -192,6 +192,7 @@
 		{:else if component.type === 'passwordinputcomponent'}
 			<AppTextInput
 				inputType="password"
+				appCssKey="passwordinputcomponent"
 				{...component}
 				bind:staticOutputs={$staticOutputs[component.id]}
 			/>

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -908,7 +908,9 @@ Hello \${ctx.username}
 					fieldType: 'number'
 				}
 			},
-			customCss: {},
+			customCss: {
+				input: { class: '', style: '' }
+			} as const,
 			card: false
 		}
 	},

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -951,7 +951,9 @@ Hello \${ctx.username}
 					optionValuesKey: 'localeOptions'
 				}
 			},
-			customCss: {},
+			customCss: {
+				input: { class: '', style: '' }
+			} as const,
 			card: false
 		}
 	},

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -990,7 +990,11 @@ Hello \${ctx.username}
 					fieldType: 'number'
 				}
 			},
-			customCss: {},
+			customCss: {
+				handle: { style: '' },
+				limits: { class: '', style: '' },
+				value: { class: '', style: '' }
+			} as const,
 			card: false
 		}
 	},

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -1094,7 +1094,9 @@ Hello \${ctx.username}
 					fieldType: 'date'
 				}
 			},
-			customCss: {},
+			customCss: {
+				input: { class: '', style: '' }
+			} as const,
 			card: false
 		}
 	},

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -1035,7 +1035,11 @@ Hello \${ctx.username}
 					fieldType: 'number'
 				}
 			},
-			customCss: {},
+			customCss: {
+				handles: { style: '' },
+				limits: { class: '', style: '' },
+				values: { class: '', style: '' }
+			} as const,
 			card: false
 		}
 	},

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -1296,15 +1296,11 @@ Hello \${ctx.username}
 					fieldType: 'text',
 					onlyStatic: true,
 					tooltip: "This text will appear if the image can't be loaded for any reason"
-				},
-				customStyles: {
-					type: 'static',
-					value: '',
-					fieldType: 'textarea',
-					onlyStatic: true
 				}
 			},
-			customCss: {},
+			customCss: {
+				image: { class: '', style: '' }
+			} as const,
 			card: false
 		}
 	}

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -1061,7 +1061,9 @@ Hello \${ctx.username}
 					onlyStatic: true
 				}
 			},
-			customCss: {},
+			customCss: {
+				input: { class: '', style: '' }
+			} as const,
 			card: false
 		}
 	},

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -1163,7 +1163,10 @@ Hello \${ctx.username}
 					onlyStatic: true
 				}
 			},
-			customCss: {},
+			customCss: {
+				container: { class: '', style: '' },
+				icon: { class: '', style: '' }
+			} as const,
 			card: false
 		}
 	},

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -1193,7 +1193,10 @@ Hello \${ctx.username}
 					onlyStatic: true
 				}
 			},
-			customCss: {},
+			customCss: {
+				container: { class: '', style: '' },
+				divider: { class: '', style: '' }
+			} as const,
 			card: false
 		}
 	},
@@ -1220,7 +1223,10 @@ Hello \${ctx.username}
 					onlyStatic: true
 				}
 			},
-			customCss: {},
+			customCss: {
+				container: { class: '', style: '' },
+				divider: { class: '', style: '' }
+			} as const,
 			card: false
 		}
 	},

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -1259,7 +1259,9 @@ Hello \${ctx.username}
 					onlyStatic: true
 				}
 			},
-			customCss: {},
+			customCss: {
+				container: { class: '', style: '' }
+			} as const,
 			card: false
 		}
 	},

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -1116,6 +1116,12 @@ Hello \${ctx.username}
 					onlyStatic: true
 				}
 			},
+			customCss: {
+				tabRow: { class: '', style: '' },
+				allTabs: { class: '', style: '' },
+				selectedTab: { class: '', style: '' },
+				container: { class: '', style: '' }
+			} as const,
 			componentInput: undefined,
 			card: false,
 			numberOfSubgrids: 2,

--- a/frontend/src/lib/components/apps/editor/componentsPanel/CssSettings.svelte
+++ b/frontend/src/lib/components/apps/editor/componentsPanel/CssSettings.svelte
@@ -178,7 +178,6 @@
 									{#each ids as id}
 										<div class="mb-3">
 											{#if $app?.css?.[type][id]}
-												{JSON.stringify($app.css[type][id])}
 												<CssProperty
 													name={id}
 													bind:value={$app.css[type][id]}

--- a/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptsPanel.svelte
+++ b/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptsPanel.svelte
@@ -21,7 +21,9 @@
 		</Pane>
 		<Pane size={75}>
 			{#if !selectedScriptComponentId}
-				<span class="p-2 text-sm text-gray-600">Select a script on the left panel</span>
+				<div class="text-sm text-gray-500 text-center py-8 px-2">
+					Select a script on the left panel
+				</div>
 			{/if}
 
 			{#each $app.grid as gridItem (gridItem.data.id)}

--- a/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptsPanelList.svelte
+++ b/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptsPanelList.svelte
@@ -53,7 +53,11 @@
 	}
 </script>
 
-<div class="mb-0 pb-0 pl-2 sticky top-0 bg-white border-b text-xs font-semibold">Runnables</div>
+<div
+	class="sticky top-0 py-0.5 px-2 text-center bg-gray-200 text-gray-500 text-2xs font-bold tracking-wide border-b border-gray-300"
+>
+	RUNNABLES
+</div>
 <div bind:this={list} class="grow flex flex-col gap-4">
 	<PanelSection title="Inline scripts" smallPadding>
 		<div class="flex flex-col gap-2 w-full">

--- a/frontend/src/lib/components/common/fileInput/FileInput.svelte
+++ b/frontend/src/lib/components/common/fileInput/FileInput.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
-	import { createEventDispatcher } from "svelte"
-	import { FileUp } from "lucide-svelte"
-	import Button from "../../common/button/Button.svelte"
-	import { faTrash } from "@fortawesome/free-solid-svg-icons"
+	import { createEventDispatcher } from 'svelte'
+	import { FileUp } from 'lucide-svelte'
+	import Button from '../../common/button/Button.svelte'
+	import { faTrash } from '@fortawesome/free-solid-svg-icons'
+	import { twMerge } from 'tailwind-merge'
 
 	let c = ''
 	export { c as class }
+	export let style = ''
 	export let accept = '*'
 	export let multiple = false
 	export let convertToBase64 = false
@@ -16,20 +18,20 @@
 	let files: File[] | undefined = undefined
 
 	async function onChange(fileList: FileList | null) {
-		if(!fileList || !fileList.length) {
-			files = undefined;
-			dispatch('change', files);
-			return;
+		if (!fileList || !fileList.length) {
+			files = undefined
+			dispatch('change', files)
+			return
 		}
 
-		if(!multiple || !files) {
+		if (!multiple || !files) {
 			files = []
 		}
-		for(let i = 0; i < fileList.length; i++) {
-			const file = fileList.item(i);
-			if(file) files.push(file);
+		for (let i = 0; i < fileList.length; i++) {
+			const file = fileList.item(i)
+			if (file) files.push(file)
 		}
-		// Needs to be reset so the same file can be selected 
+		// Needs to be reset so the same file can be selected
 		// multiple times in a row
 		input.value = ''
 
@@ -38,16 +40,16 @@
 
 	async function fileToBase64(file: File): Promise<string> {
 		return new Promise((resolve) => {
-			const reader = new FileReader();
+			const reader = new FileReader()
 			reader.onloadend = () => {
-				resolve(reader.result as string);
-			};
-			reader.readAsDataURL(file);
+				resolve(reader.result as string)
+			}
+			reader.readAsDataURL(file)
 		})
 	}
 
 	function removeFile(index: number) {
-		if(!files) return;
+		if (!files) return
 		files.splice(index, 1)
 		files = files.length ? files : undefined
 		dispatchChange()
@@ -56,21 +58,25 @@
 	async function dispatchChange() {
 		files = files
 
-		if(convertToBase64 && files) {
-			const promises = files.map(fileToBase64);
-			const b64s = await Promise.all(promises);
-			dispatch('change', b64s);
+		if (convertToBase64 && files) {
+			const promises = files.map(fileToBase64)
+			const b64s = await Promise.all(promises)
+			dispatch('change', b64s)
 		} else {
-			dispatch('change', files);
+			dispatch('change', files)
 		}
 	}
 </script>
 
 <button
-	class="relative center-center flex-col text-center font-medium text-gray-600 
-	border-2 border-dashed border-gray-400 hover:border-blue-500 
-	focus-within:border-blue-500 hover:bg-blue-50 focus-within:bg-blue-50 
-	duration-200 rounded-lg p-1 {c ?? ''}"
+	class={twMerge(
+		`relative center-center flex-col text-center font-medium text-gray-600 
+		border-2 border-dashed border-gray-400 hover:border-blue-500 
+		focus-within:border-blue-500 hover:bg-blue-50 focus-within:bg-blue-50 
+		duration-200 rounded-lg p-1`,
+		c
+	)}
+	{style}
 >
 	{#if !hideIcon && !files}
 		<FileUp size={iconSize} class="mb-2" />
@@ -83,9 +89,11 @@
 				</div>
 			</slot>
 			<ul class="relative z-20 max-w-[250px] bg-white rounded-lg overflow-hidden mx-auto">
-				{#each files as {name}, i}
-					<li class="flex justify-between items-center font-normal text-sm
-					hover:bg-gray-300/20 duration-200 py-1 px-2 cursor-default">
+				{#each files as { name }, i}
+					<li
+						class="flex justify-between items-center font-normal text-sm
+					hover:bg-gray-300/20 duration-200 py-1 px-2 cursor-default"
+					>
 						<span class="pr-2 ellipsize">{name}</span>
 						<Button
 							size="xs"
@@ -110,7 +118,9 @@
 		type="file"
 		title={files ? `${files.length} file${files.length > 1 ? 's' : ''} chosen` : 'No file chosen'}
 		bind:this={input}
-		on:change={({currentTarget}) => {onChange(currentTarget.files)}}
+		on:change={({ currentTarget }) => {
+			onChange(currentTarget.files)
+		}}
 		{accept}
 		{multiple}
 		{...$$restProps}

--- a/frontend/src/lib/components/common/tabs/Tab.svelte
+++ b/frontend/src/lib/components/common/tabs/Tab.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
-	import { classNames } from '$lib/utils'
 	import { getContext } from 'svelte'
+	import { twMerge } from 'tailwind-merge'
 	import type { TabsContext } from './Tabs.svelte'
 
 	export let value: string
 	export let size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' = 'sm'
+	let c = ''
+	export { c as class }
+	export let style = ''
+	export let selectedClass = ''
+	export let selectedStyle = ''
 
 	const fontSizeClasses = {
 		xs: 'text-xs',
@@ -19,14 +24,16 @@
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <div
-	class={classNames(
+	class={twMerge(
+		'border-b-2 py-1 px-4 cursor-pointer transition-all ease-linear font-medium',
 		$selected?.startsWith(value)
 			? 'border-gray-600 text-gray-800 '
 			: 'border-gray-300 border-opacity-0 hover:border-opacity-100 text-gray-600',
-		'border-b-2 py-1 px-4 cursor-pointer transition-all ease-linear font-medium',
 		fontSizeClasses[size],
-		$$props.class
+		c,
+		$selected?.startsWith(value) ? selectedClass : ''
 	)}
+	style={`${style} ${$selected?.startsWith(value) ? selectedStyle : ''}`}
 	on:click={() => update(value)}
 >
 	<slot />

--- a/frontend/src/lib/components/common/tabs/Tabs.svelte
+++ b/frontend/src/lib/components/common/tabs/Tabs.svelte
@@ -9,11 +9,14 @@
 	import { setContext } from 'svelte'
 	import { writable, type Writable } from 'svelte/store'
 	import { createEventDispatcher } from 'svelte'
-	import { classNames } from '$lib/utils'
+	import { twMerge } from 'tailwind-merge'
 
 	const dispatch = createEventDispatcher()
 
 	export let selected: string
+	let c = ''
+	export { c as class }
+	export let style = ''
 
 	$: selected && updateSelected()
 
@@ -36,10 +39,8 @@
 
 <div class="overflow-x-auto">
 	<div
-		class={classNames(
-			'border-b border-gray-200 flex flex-row whitespace-nowrap  scrollbar-hidden',
-			$$props.class
-		)}
+		class={twMerge('border-b border-gray-200 flex flex-row whitespace-nowrap  scrollbar-hidden', c)}
+		{style}
 	>
 		<slot {selected} />
 	</div>


### PR DESCRIPTION
Added CSS customisation options to the following app components:
- number input
- currency input
- slider
- range
- password input
- date input
- tabs
- icon
- horizontal divider
- vertical divider
- file input
- image