### PR TITLE
feat(frontend): Fix object viewer style

### DIFF
--- a/frontend/src/lib/components/apps/editor/contextPanel/ContextPanel.svelte
+++ b/frontend/src/lib/components/apps/editor/contextPanel/ContextPanel.svelte
@@ -44,7 +44,7 @@
 	)
 </script>
 
-<PanelSection noPadding titlePadding="px-4 pt-2" title="Outputs">
+<PanelSection noPadding titlePadding="px-4 pt-2 pb-0.5" title="Outputs">
 	<div
 		class="overflow-auto min-w-[150px] border-t w-full relative flex flex-col gap-4 px-2 pt-4 pb-2"
 	>
@@ -62,18 +62,18 @@
 								? undefined
 								: () => ($selectedComponent = componentId)}
 							class={classNames(
-								'px-2 text-2xs py-0.5 border border-gray-300 font-bold rounded-t-sm w-fit',
+								'px-2 text-2xs py-0.5 border-t border-x font-bold rounded-t-sm w-fit',
 								$selectedComponent === componentId
-									? ' bg-indigo-500 text-white'
-									: 'bg-gray-200 text-gray-500'
+									? ' bg-blue-500 text-white border-blue-500'
+									: 'bg-gray-100 text-gray-500 border-gray-200'
 							)}
 						>
 							{componentId}
 						</button>
 						<span
 							class={classNames(
-								'px-1 text-2xs py-0.5 font-bold rounded-t-sm w-fit',
-								'bg-gray-500 text-white'
+								'px-1 text-2xs py-0.5 font-semibold rounded-t-sm w-fit',
+								'bg-gray-700 text-white'
 							)}
 						>
 							{name}

--- a/frontend/src/lib/components/propertyPicker/ObjectViewer.svelte
+++ b/frontend/src/lib/components/propertyPicker/ObjectViewer.svelte
@@ -58,7 +58,11 @@
 			</span>
 		{/if}
 		{#if level == 0 && topBrackets}<span class="h-0">{openBracket}</span>{/if}
-		<ul class="w-full">
+		<ul
+			class={`w-full ${
+				level === 0 ? 'border-none pl-2' : 'border-l border-dotted border-gray-200 pl-2'
+			}`}
+		>
 			{#each keys as key, index}
 				<li class="pt-1">
 					<button on:click={() => selectProp(key, key)} class="whitespace-nowrap">
@@ -88,7 +92,7 @@
 						<button
 							class="val {pureViewer
 								? 'cursor-auto'
-								: ''} rounded hover:bg-blue-100 {getTypeAsString(json[key])}"
+								: ''} rounded px-1 hover:bg-blue-100 {getTypeAsString(json[key])}"
 							on:click={() => selectProp(key, json[key])}
 						>
 							{#if json[key] === NEVER_TESTED_THIS_FAR}
@@ -134,8 +138,6 @@
 <style>
 	ul {
 		list-style: none;
-		padding-left: 1rem;
-		border-left: 1px dotted lightgray;
 		@apply text-sm;
 	}
 


### PR DESCRIPTION
# Before
<img width="317" alt="Screenshot 2023-03-02 at 15 07 15" src="https://user-images.githubusercontent.com/456655/222451546-6d26f02f-4036-4197-85e1-53cf53951c56.png">

# After
<img width="372" alt="Screenshot 2023-03-02 at 15 05 31" src="https://user-images.githubusercontent.com/456655/222451405-32694190-4925-465f-a699-c63feb8a33bd.png">

