### PR TITLE
fix(frontend): Hide archive toggle with empty list

### DIFF
--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -302,7 +302,7 @@
 	</div>
 	<div class="relative">
 		<ListFilters bind:selectedFilter={ownerFilter} filters={owners} />
-		{#if !loading}
+		{#if !loading && filteredItems?.length}
 			<div class="absolute -bottom-2 right-0 bg-white/90">
 				<Toggle size="xs" bind:checked={archived} options={{ right: 'Show archived' }} /></div
 			>


### PR DESCRIPTION
Fixed issue where the "Show archived" toggle gets misplaced if there are no items in the list

<img width="1106" alt="Screenshot 2023-03-16 at 8 58 38" src="https://user-images.githubusercontent.com/43071496/225551663-6b464ac7-1843-48c4-91ab-4bc413902842.png">
