### PR TITLE
fix(frontend): Display app context search on top

### DIFF
--- a/frontend/src/lib/components/apps/editor/contextPanel/ContextPanel.svelte
+++ b/frontend/src/lib/components/apps/editor/contextPanel/ContextPanel.svelte
@@ -29,7 +29,7 @@
 <PanelSection noPadding titlePadding="px-4 pt-2 pb-0.5" title="Outputs">
 	<div class="bg-white w-full h-full z-30">
 		<div class="min-w-[150px]">
-			<div class="sticky top-0 left-0 w-full bg-white p-2">
+			<div class="sticky z-10 top-0 left-0 w-full bg-white p-2">
 				<div class="relative">
 					<input
 						bind:value={$search}


### PR DESCRIPTION
Fixing z-index issue of the search bar in the outputs panel