### PR TITLE
fix(backend): backend compatability on macos

### DIFF
--- a/backend/.cargo/config.toml
+++ b/backend/.cargo/config.toml
@@ -8,3 +8,14 @@ rustflags = [
 ]
 incremental = true
 
+[target.x86_64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-undefined",
+    "-C", "link-arg=dynamic_lookup",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-undefined",
+    "-C", "link-arg=dynamic_lookup",
+]

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -2417,6 +2417,7 @@ async fn handle_child(
     let write_logs_delay = Duration::from_millis(500);
 
     let pid = child.id();
+    #[cfg(target_os = "linux")]
     if let Some(pid) = pid {
         //set the highest oom priority
         let mut file = File::create(format!("/proc/{pid}/oom_score_adj")).await?;


### PR DESCRIPTION
Not sure if this is the best way to handle these cases, but frequently I build and test on my local os which is macos which  needs some slightly different flags when compiling and doesn't have the procfs (which breaks the workers as it will fail when trying to adjust the priority on the process).