### PR TITLE
fix: no need to map internal ports to hosts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,8 @@ services:
     restart: unless-stopped
     volumes:
       - db_data:/var/lib/postgresql/data
-    ports:
-      - 5432:5432
-      # NOTE: if port 5432 are already in use locally, we'll also bind another port
-      - 5433:5432
+    expose:
+      - 5432
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_DB: windmill
@@ -25,8 +23,8 @@ services:
     deploy:
       replicas: 1
     restart: unless-stopped
-    ports:
-      - 8000:8000
+    expose:
+      - 8000
     environment:
       - DATABASE_URL=postgres://postgres:${DB_PASSWORD}@db/windmill?sslmode=disable
       - BASE_URL=http://${WM_BASE_URL}
@@ -67,8 +65,8 @@ services:
   lsp:
     image: ghcr.io/windmill-labs/windmill-lsp:latest
     restart: unless-stopped
-    ports:
-      - 3001:3001
+    expose:
+      - 3001
 
   caddy:
     image: caddy:2.5.2-alpine


### PR DESCRIPTION
I found that Windmill has mapped three unnecessary external ports binding to the host, including the port for Postgres, which is not needed and also very dangerous.
After deployment, I noticed many brute force login attempts:
```
windmill-db-1               | 2023-04-05 03:05:23.291 UTC [32142] FATAL:  password authentication failed for user "postgres"
windmill-db-1               | 2023-04-05 03:05:23.291 UTC [32142] DETAIL:  Connection matched pg_hba.conf line 100: "host all all all scram-sha-256"
windmill-db-1               | 2023-04-05 03:05:26.365 UTC [32143] FATAL:  password authentication failed for user "postgres"
windmill-db-1               | 2023-04-05 03:05:26.365 UTC [32143] DETAIL:  Connection matched pg_hba.conf line 100: "host all all all scram-sha-256"
```
Communication between services is already well-resolved by using service names in docker's 172 network, so it's necessary to remove these three external ports.

I tested the change in my env, It seems works fine.
![image](https://user-images.githubusercontent.com/27620242/229992403-8c79f0da-17a9-4f2b-ad72-1d0794b3d412.png)


Additionally, I am not sure if this affects Windmill's distributed deployment (if it is supported), but even in a distributed deployment, the ports should not be exposed in this way. We need a separate conductor.
