### PR TITLE
fix(frontend): fix popover configuration to avoid content shift

### DIFF
--- a/frontend/src/lib/components/Popover.svelte
+++ b/frontend/src/lib/components/Popover.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createPopperActions } from 'svelte-popperjs'
+	import { createPopperActions, type PopperOptions } from 'svelte-popperjs'
 	import type { PopoverPlacement } from './Popover.model'
 
 	export let placement: PopoverPlacement = 'auto'
@@ -9,28 +9,16 @@
 	export let disapperTimoout = 100
 
 	const [popperRef, popperContent] = createPopperActions({ placement })
-	const betterPreventOverflow = (options) => ({
-		name: 'preventOverflow',
-		options,
-		effect: ({ state }) => {
-			const { padding = 0 } = options
 
-			state.elements.popper.style.maxWidth = `calc(100vw - ${padding * 2}px)`
-		}
-	})
-	const extraOpts = {
+	const popperOptions: PopperOptions<{}> = {
+		placement: 'bottom-end',
+		strategy: 'fixed',
 		modifiers: [
-			betterPreventOverflow({ padding: 10 }),
-			{
-				name: 'offset',
-				options: {
-					offset: [8, 8]
-				}
-			},
+			{ name: 'offset', options: { offset: [8, 8] } },
 			{
 				name: 'arrow',
 				options: {
-					padding: 10 // 5px from the edges of the popper
+					padding: 10
 				}
 			}
 		]
@@ -59,10 +47,10 @@
 {/if}
 {#if showTooltip && !disablePopup}
 	<div
-		use:popperContent={extraOpts}
+		use:popperContent={popperOptions}
 		on:mouseenter={open}
 		on:mouseleave={close}
-		class="z-50  py-2 px-3 rounded-md  text-sm font-normal !text-gray-300 bg-gray-800
+		class="z-50 py-2 px-3 rounded-md text-sm font-normal !text-gray-300 bg-gray-800
 		whitespace-normal text-left {popupClass}"
 	>
 		<div class="max-w-sm">


### PR DESCRIPTION


Changed the configuration to avoid content shift:

Before:
<img width="292" alt="Screenshot 2023-04-10 at 06 48 10" src="https://user-images.githubusercontent.com/456655/230828081-264afee2-7b7d-4cf4-b122-b52d03c21157.png">

After:
<img width="460" alt="Screenshot 2023-04-10 at 06 46 16" src="https://user-images.githubusercontent.com/456655/230827950-c5971bb4-4dba-43bb-8351-ddcedcfe6b91.png">