### PR TITLE
feat(frontend)!: Add option to return file names from file input

### DIFF
--- a/frontend/src/lib/components/apps/components/inputs/AppFileInput.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/AppFileInput.svelte
@@ -19,11 +19,11 @@
 	let text: string | undefined = undefined
 
 	let outputs = initOutput($worldStore, id, {
-		result: [] as string[] | undefined
+		result: [] as { name: string; data: string }[] | undefined
 	})
 
 	// Receives Base64 encoded strings from the input component
-	async function handleChange(files: string[] | undefined) {
+	async function handleChange(files: { name: string; data: string }[] | undefined) {
 		outputs?.result.set(files)
 	}
 
@@ -40,6 +40,7 @@
 			accept={acceptedFileTypes?.length ? acceptedFileTypes?.join(', ') : undefined}
 			multiple={allowMultiple}
 			convertTo="base64"
+			returnFileNames
 			on:change={({ detail }) => {
 				handleChange(detail)
 			}}

--- a/frontend/src/lib/components/common/fileInput/FileInput.svelte
+++ b/frontend/src/lib/components/common/fileInput/FileInput.svelte
@@ -6,6 +6,8 @@
 	import { twMerge } from 'tailwind-merge'
 	import type { ReadFileAs } from './model'
 
+	type ConvertedFile = string | ArrayBuffer | null
+
 	let c = ''
 	export { c as class }
 	export let style = ''
@@ -14,6 +16,7 @@
 	export let convertTo: ReadFileAs | undefined = undefined
 	export let hideIcon = false
 	export let iconSize = 36
+	export let returnFileNames = false
 	const dispatch = createEventDispatcher()
 	let input: HTMLInputElement
 	let files: File[] | undefined = undefined
@@ -77,7 +80,12 @@
 
 		if (convertTo && files) {
 			const promises = files.map(convertFile)
-			const converted = await Promise.all(promises)
+			let converted: ConvertedFile[] | { name: string; data: ConvertedFile }[] = await Promise.all(
+				promises
+			)
+			if (returnFileNames) {
+				converted = converted.map((c, i) => ({ name: files![i].name, data: c }))
+			}
 			dispatch('change', converted)
 		} else {
 			dispatch('change', files)


### PR DESCRIPTION
**Could break existing apps!**

By default the app file input now returns an array of objects (name of the file and the base64 data) instead of an array of strings (base64 data).

This is needed because there is no way to get the name of the files from the base64 encoded data.