### PR TITLE
feat(frontend): support showing metadata on script add via query param

### DIFF
--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -27,8 +27,9 @@
 	export let initialArgs: Record<string, any> = {}
 	export let lockedLanguage = false
 	export let topHash: string | undefined = undefined
+	export let showMeta: boolean = false
 
-	let metadataOpen = initialPath == '' && $page.url.searchParams.get('state') == undefined
+	let metadataOpen = showMeta || (initialPath == '' && $page.url.searchParams.get('state') == undefined)
 	let advancedOpen = false
 
 	let editor: Editor | undefined = undefined

--- a/frontend/src/routes/(root)/(logged)/scripts/add/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/scripts/add/+page.svelte
@@ -13,6 +13,7 @@
 
 	const templatePath = $page.url.searchParams.get('template')
 	const hubPath = $page.url.searchParams.get('hub')
+	const showMeta = /true|1/i.test($page.url.searchParams.get('showMeta') ?? '0')
 
 	const initialState = $page.url.searchParams.get('state')
 
@@ -79,4 +80,5 @@
 	bind:this={scriptBuilder}
 	lockedLanguage={templatePath != null || hubPath != null}
 	{script}
+	{showMeta}
 />

--- a/frontend/src/routes/(root)/(logged)/scripts/add/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/scripts/add/+page.svelte
@@ -13,7 +13,7 @@
 
 	const templatePath = $page.url.searchParams.get('template')
 	const hubPath = $page.url.searchParams.get('hub')
-	const showMeta = /true|1/i.test($page.url.searchParams.get('showMeta') ?? '0')
+	const showMeta = /true|1/i.test($page.url.searchParams.get('show_meta') ?? '0')
 
 	const initialState = $page.url.searchParams.get('state')
 


### PR DESCRIPTION
Not sure if this is the best way to go about this, but in a previous iteration of the UI we were able to deep link to `/scripts/add` with a state variable to pop someone into the script editor with some default script content and still leverage the default path and naming that windmill provided.  With the latest changes if any `state` is provided you no longer go through the metadata step and we end up with some undefined variables in the meta unless you click somewhere to trigger the drawer.  

Just looking for a way to get a similar flow in the current version where we can send some default script content in a link that will create a new script -- but still leverage the default script naming and path selection that windmill was providing. This will force the drawer to open if a `showMeta` query param is present which triggers the population of the name and path, but willing to do implement something different if there is a preferred way to handle this just let me know.