### PR TITLE
fix: Add symlink to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,8 +137,10 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then rm /usr/bin/deno-arm; elif [ 
 
 RUN mkdir -p ${APP}
 
+RUN ln -s ${APP}/windmill /usr/local/bin/windmill
+
 WORKDIR ${APP}
 
 EXPOSE 8000
 
-CMD ["./windmill"]
+CMD ["windmill"]

--- a/docker/DockerfileHelm
+++ b/docker/DockerfileHelm
@@ -12,4 +12,4 @@ RUN apt-get update && apt install unzip && curl "https://awscli.amazonaws.com/aw
     unzip awscliv2.zip && \
     ./aws/install 
 
-CMD ["./windmill"]
+CMD ["windmill"]

--- a/docker/DockerfileOpenbb
+++ b/docker/DockerfileOpenbb
@@ -132,8 +132,10 @@ RUN /usr/local/bin/python3 -m pip install openbb[all]
 
 RUN mkdir -p ${APP}
 
+RUN ln -s ${APP}/windmill /usr/local/bin/windmill
+
 WORKDIR ${APP}
 
 EXPOSE 8000
 
-CMD ["./windmill"]
+CMD ["windmill"]


### PR DESCRIPTION
PR adds a symlink towards the end of the docker build process so that `windmill` command can be called directly from the path. Also removes the `./windmill` for the last `CMD` line since `windmill` is now within the `PATH` environment variable.