### PR TITLE
db_init: removed duplicate code

### DIFF
--- a/init-db-as-superuser.sql
+++ b/init-db-as-superuser.sql
@@ -18,19 +18,4 @@ ALTER DEFAULT PRIVILEGES
 
 
 CREATE ROLE windmill_admin WITH BYPASSRLS;
-
-GRANT ALL
-ON ALL TABLES IN SCHEMA public 
-TO windmill_admin;
-
-GRANT ALL PRIVILEGES 
-ON ALL SEQUENCES IN SCHEMA public 
-TO windmill_admin;
-
-ALTER DEFAULT PRIVILEGES 
-    IN SCHEMA public
-    GRANT ALL ON TABLES TO windmill_admin;
-
-ALTER DEFAULT PRIVILEGES 
-    IN SCHEMA public
-    GRANT ALL ON SEQUENCES TO windmill_admin;
+GRANT windmill_user TO windmill_admin;


### PR DESCRIPTION
Hi, just found how roles are set up. I think it can be improved. Also, it is more clear to rename `windmill_user`-> `windmill_role`, `windmill_admin` -> `windmill_admin_role` so its clear that they cannot login. But it might affect the app, so I did not change it in the PR.

And, actually, why do we need all these roles ? We have database owner, with all of those privileges, isn't it enough ? Those user/admin have strong privileges, so, it is not clear why do we need them, rather then just using database owner ?

Thanks!