### PR TITLE
Add basic git integration docs

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -62,6 +62,12 @@ You can push individual resources using
 `wmill <type> push <file_name> \<remote_name\>`. This does not require a special
 folder layout or file name, as this is given at runtime.
 
+### Git
+
+`wmill workspace add` creates a .wmill directory in the the current directory
+containing all workspaces, flows and scripts that can be version controlled
+with git.
+
 ## Listing
 
 All commands support listing by just not providing a subcommand, ie


### PR DESCRIPTION
The current docs don't make it very clear how to integrate windmill scripts with a github repo. This is a very basic edit to mention that `.wmill/` gets created and contains scripts. However it would be useful to define best practices for keeping wmill workspaces and github repos in sync. A few things to note:

1. I haven't tried adding more than 1 workspace, but my assumption is that they would all be in `.wmill/u/{workspace_name}` - ideally there'd be robust solution for syncing workspaces with individual repos that isn't making each `.wmill/u/{workspace_name}` a repo. 
2. Noticed this `.wmill/u/vrachev/u/vrachev/{script_file}` after syncing a workspace. The {script_file} is also present earlier: `.wmill/u/vrachev/{script_file}`. Not sure if this is a bug or not, but is confusing to me. 
3. Would be nice to be able to map scripts in a config file or something to this effect. I have scripts in a repo already and would like to link them to windmill without moving them into the windmill location. Symlinking files works but is not great or scalable.
4. I also can't tell what the proper conventions are for multi-file scripts. Ideally this would be supported without needing to paste everything into one file.
5. Overall could use a better git integration story with some conventions and standards. I can also create an issue if that would be more helpful. 

Thanks,
Vlad