### PR TITLE
fix(frontend): add missing required argument to correctly compute isV…

### DIFF
--- a/frontend/src/lib/components/ArgInput.svelte
+++ b/frontend/src/lib/components/ArgInput.svelte
@@ -138,7 +138,7 @@
 		}
 	}
 
-	function validateInput(pattern: string | undefined, v: any): void {
+	function validateInput(pattern: string | undefined, v: any, required: boolean): void {
 		if (required && (v == undefined || v == null || v === '')) {
 			error = 'Required'
 			valid = false
@@ -175,7 +175,7 @@
 
 	let customValue = false
 
-	$: validateInput(pattern, value)
+	$: validateInput(pattern, value, required)
 </script>
 
 <!-- svelte-ignore a11y-autofocus -->


### PR DESCRIPTION
…alue

Valid prop was not updated when a script argument becomes optional: from `a: number` to `a: number | undefined`