### PR TITLE
feat: Add a per-script concurrency limit

### DIFF
--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -2396,7 +2396,7 @@ pub async fn handle_child(
                         .expect("update worker ping");
                     }
                     let mem_peak = get_mem_peak(pid, nsjail).await;
-                    tracing::info!("{job_id} still running. mem peak: {}kB", mem_peak);
+                    tracing::debug!("{job_id} still running. mem peak: {}kB", mem_peak);
                     let mem_peak = if mem_peak > 0 { Some(mem_peak) } else { None };
                     if sqlx::query_scalar!("UPDATE queue SET mem_peak = GREATEST($1, mem_peak), last_ping = now() WHERE id = $2 RETURNING canceled", mem_peak, job_id)
                         .fetch_optional(&db)


### PR DESCRIPTION
Currently setting it to 5 for the v0.
In the v1 we will be able to customise this concurrency limit on a per-script basis (both for real scripts and also inline-scripts in flows)