### PR TITLE
fix(frontend): support special chars in postgresql client [#1775]

### DIFF
--- a/frontend/src/lib/components/TestConnection.svelte
+++ b/frontend/src/lib/components/TestConnection.svelte
@@ -19,7 +19,14 @@
 				content: `
 import { Client } from 'https://deno.land/x/postgres/mod.ts'
 export async function main(args: any) {
-	const client = new Client("postgres://" + args.user + ":" + args.password + "@" + args.host + ":" + (args.port ?? 5432) + "/" + args.dbname + "?sslmode=" + args.sslmode)
+	const u = new URL(`postgres://${args.user}:${args.password}@${args.host}:${args.port ?? 5432}/${args.dbname}?sslmode=${args.sslmode}`)
+	u.hash = ''
+	u.search = `?sslmode=${args.sslmode}`
+	u.pathname = args.dbname
+	u.host = args.host
+	u.password = args.password
+	u.username = args.user
+	const client = new Client(u.toString())
 	await client.connect()
 	return 'Connection successful'
 }


### PR DESCRIPTION
Fix #1775 

tested with:
1. setup fresh postgres15.3 container with `POSTGRES_PASSWORD` `kot@behemot#zonk`
2. get DB URI with
```javascript
const args = { user: 'postgres', password: 'kot@behemot#zonk', host: '0.0.0.0', dbname: 'postgres', sslmode: 'disable' };
const u = new URL(`postgres://${args.user}:${args.password}@${args.host}:${args.port ?? 5432}/${args.dbname}?sslmode=${args.sslmode}`);
u.hash = '';
u.search = `?sslmode=${args.sslmode}`;
u.pathname = args.dbname;
u.host = args.host;
u.password = args.password;
u.username = args.user;

u.toString();
```
3. connect to db
```console
psql 'postgres://postgres:kot%40behemot%23zonk@0.0.0.0/postgres?sslmode=disable'
```