### PR TITLE
chore: Force sqlx version to remain <0.7.0

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -144,7 +144,7 @@ swc_ecma_ast = "0.106.2"
 base64 = "0.21.0"
 hmac = "0.12.1"
 sha2 = "0.10.6"
-sqlx = { version = "^0", features = [
+sqlx = { version = "0.6", features = [
     "offline",
     "macros",
     "migrate",


### PR DESCRIPTION
According to https://github.com/launchbadge/sqlx/blob/main/CHANGELOG.md, sqlx version 0.7.0 is kind of a big jump in terms of features and breaking changes. We should probably stick to 0.6.X. I tried using 0.7.0 by mistake and for example the generation of sqlx-data.json wasn't working properly