### PR TITLE
fix required fields in nested schema

### DIFF
--- a/frontend/src/lib/components/SchemaEditor.svelte
+++ b/frontend/src/lib/components/SchemaEditor.svelte
@@ -62,7 +62,8 @@
 			items: schema.items,
 			contentEncoding: schema.contentEncoding,
 			format: schema.format,
-			properties: schema.schema?.properties
+			properties: schema.schema?.properties,
+			required: schema.schema?.required
 		}
 	}
 	function handleAddOrEditArgument(modalProperty: ModalSchemaProperty): void {


### PR DESCRIPTION
Someone forgot to handle the required fields in nested object schemas :)

Here is how we represent "address field is not required but when it is provided, address.city is required".
![Screenshot 2023-07-24 at 17-09-11 Resources Windmill](https://github.com/windmill-labs/windmill/assets/74733630/f0750b42-b07d-4db8-a0b2-e55603843f70)
