### PR TITLE
fix: add property while viewing as JSON (+ ui tweaks)

### DIFF
--- a/frontend/src/lib/components/SchemaEditor.svelte
+++ b/frontend/src/lib/components/SchemaEditor.svelte
@@ -36,6 +36,7 @@
 	let oldArgName: string | undefined // when editing argument and changing name
 
 	let viewJsonSchema = false
+	let jsonEditor: SimpleEditor
 
 	// Binding is not enough because monaco Editor does not support two-way binding
 	export function getSchema(): Schema {
@@ -101,6 +102,7 @@
 		}
 		schema = schema
 		schemaString = JSON.stringify(schema, null, '\t')
+		jsonEditor.setCode(schemaString)
 		dispatch('change', schema)
 	}
 
@@ -300,11 +302,9 @@
 				{/if}
 			</div>
 		{:else}
-			{#if !emptyString(error)}<span class="text-red-400">{error}</span>{:else}<div
-					class="py-6"
-				/>{/if}
 			<div class="border rounded p-2">
 				<SimpleEditor
+					bind:this={jsonEditor}
 					fixedOverflowWidgets={false}
 					on:change={() => {
 						try {
@@ -319,6 +319,11 @@
 					class="small-editor"
 				/>
 			</div>
+			{#if !emptyString(error)}
+				<div class="text-red-400">{error}</div>
+			{:else}
+				<div><br /></div>
+			{/if}
 		{/if}
 	</div>
 </div>

--- a/frontend/src/routes/(root)/(logged)/resources/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/resources/+page.svelte
@@ -393,11 +393,13 @@
 				/></label
 			>
 			<div>
-				<div class="mb-1 font-semibold text-secondary">Schema</div>
-				<div class="mb-2 w-full flex flex-row-reverse">
-					<Button on:click={openInferrer} size="sm" color="dark" variant="border">
-						Infer schema from a json value
-					</Button>
+				<div class="flex justify-between w-full items-center">
+					<div class="mb-1 font-semibold text-secondary">Schema</div>
+					<div class="mb-2 w-full flex flex-row-reverse">
+						<Button on:click={openInferrer} size="sm" color="dark" variant="border">
+							Infer schema from a json value
+						</Button>
+					</div>
 				</div>
 				<SchemaEditor bind:schema={newResourceType.schema} />
 			</div>


### PR DESCRIPTION
When viewing schema as JSON and adding property via the "Add property button", JSON schema would not show the newly added property. PR fixes this behavior.

Minor layout tweaks to remove unnecessary whitespace and scroll jitter.

![af-error](https://github.com/windmill-labs/windmill/assets/74733630/3807c783-11c5-4f0f-988b-791ad18fc678)