### PR TITLE
fix: prevent error if json editor not mounted

### DIFF
--- a/frontend/src/lib/components/SchemaEditor.svelte
+++ b/frontend/src/lib/components/SchemaEditor.svelte
@@ -102,7 +102,9 @@
 		}
 		schema = schema
 		schemaString = JSON.stringify(schema, null, '\t')
-		jsonEditor.setCode(schemaString)
+		if (jsonEditor) {
+			jsonEditor.setCode(schemaString)
+		}
 		dispatch('change', schema)
 	}
 


### PR DESCRIPTION
Fixing : Adding property to a nested object would give error 'jsonEditor undefined'.