### PR TITLE
Add another pip import replacement

### DIFF
--- a/backend/parsers/windmill-parser-py-imports/src/lib.rs
+++ b/backend/parsers/windmill-parser-py-imports/src/lib.rs
@@ -31,6 +31,7 @@ static PYTHON_IMPORTS_REPLACEMENT: phf::Map<&'static str, &'static str> = phf_ma
     "riskfolio" => "riskfolio-lib",
     "smb" => "pysmb",
     "PIL" => "Pillow",
+    "googleapiclient" => "google-api-python-client",
 };
 
 fn replace_import(x: String) -> String {


### PR DESCRIPTION
Add python import replacement for google-api-python-client. See: https://github.com/googleapis/google-api-python-client