### PR TITLE
feat(frontend): add disabled prop to select input

### DIFF
--- a/frontend/src/lib/components/apps/components/inputs/AppSelect.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/AppSelect.svelte
@@ -203,6 +203,7 @@
 					css?.input?.style}
 				{value}
 				placeholder={resolvedConfig.placeholder}
+				disabled={resolvedConfig.disabled}
 				on:focus={() => {
 					if (!$connectingInput.opened) {
 						$selectedComponent = [id]

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -1515,6 +1515,11 @@ This is a paragraph.
 					value: 'Select an item',
 					onlyStatic: true
 				},
+				disabled: {
+					fieldType: 'boolean',
+					type: 'static',
+					value: false
+				},
 				defaultValue: {
 					type: 'static',
 					value: undefined,


### PR DESCRIPTION
Fix #1998 for the Select Input component:
![disabled-select-input-2](https://github.com/windmill-labs/windmill/assets/109326069/4e50c8b9-3957-4504-86f3-edde07c7f90c)

This was surprisingly simple! Let me know of any issues.