### PR TITLE
make tooltips non-gender specific

### DIFF
--- a/frontend/src/lib/components/AddUser.svelte
+++ b/frontend/src/lib/components/AddUser.svelte
@@ -98,7 +98,7 @@
 				value="author"
 				size="sm"
 				label="Author"
-				tooltip="An Author can execute and view scripts/flows/apps, but he can also create new ones."
+				tooltip="An Author can execute and view scripts/flows/apps, but they can also create new ones."
 			/>
 			<ToggleButton
 				position="right"

--- a/frontend/src/lib/components/InviteUser.svelte
+++ b/frontend/src/lib/components/InviteUser.svelte
@@ -95,7 +95,7 @@
 				value="author"
 				size="sm"
 				label="Author"
-				tooltip="An Author can execute and view scripts/flows/apps, but he can also create new ones."
+				tooltip="An Author can execute and view scripts/flows/apps, but they can also create new ones."
 			/>
 
 			<ToggleButton

--- a/frontend/src/lib/components/settings/WorkspaceUserSettings.svelte
+++ b/frontend/src/lib/components/settings/WorkspaceUserSettings.svelte
@@ -185,7 +185,7 @@
 										value="author"
 										size="xs"
 										label="Author"
-										tooltip="An Author can execute and view scripts/flows/apps, but he can also create new ones."
+										tooltip="An Author can execute and view scripts/flows/apps, but they can also create new ones."
 									/>
 
 									<ToggleButton


### PR DESCRIPTION
Just a small change as I noticed when adding users of my team who are female that 3 tooltips were gender specific.  nbd