### PR TITLE
feat(backend): parse expires_in from string in TokenResponse

### DIFF
--- a/backend/windmill-api/src/oauth2.rs
+++ b/backend/windmill-api/src/oauth2.rs
@@ -37,6 +37,7 @@ use windmill_common::db::UserDB;
 use windmill_common::jobs::JobPayload;
 use windmill_common::users::username_to_permissioned_as;
 use windmill_common::utils::{not_found_if_none, now_from_db};
+use windmill_common::more_serde::maybe_number_opt;
 
 use crate::db::ApiAuthed;
 use crate::saml::SamlSsoLogin;
@@ -340,6 +341,8 @@ pub struct SlackTokenResponse {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TokenResponse {
     access_token: AccessToken,
+    #[serde(deserialize_with = "maybe_number_opt")]
+    #[serde(default)]
     expires_in: Option<u64>,
     refresh_token: Option<RefreshToken>,
     #[serde(deserialize_with = "helpers::deserialize_space_delimited_vec")]

--- a/backend/windmill-common/src/more_serde.rs
+++ b/backend/windmill-common/src/more_serde.rs
@@ -47,7 +47,7 @@ where
     enum NumericOrNull<'a, T> {
         String(String),
         Str(&'a str),
-        FromStr(T),
+        RawT(T),
         Null,
     }
 
@@ -60,7 +60,7 @@ where
             "" => Ok(None),
             _ => T::from_str(s).map(Some).map_err(serde::de::Error::custom),
         },
-        NumericOrNull::FromStr(i) => Ok(Some(i)),
+        NumericOrNull::RawT(i) => Ok(Some(i)),
         NumericOrNull::Null => Ok(None),
     }
 }

--- a/backend/windmill-common/src/more_serde.rs
+++ b/backend/windmill-common/src/more_serde.rs
@@ -9,6 +9,8 @@
 //! helpers for serde + serde derive attributes
 
 use crate::utils::rd_string;
+use serde::{Deserialize, Deserializer};
+use std::{fmt::Display, str::FromStr};
 
 pub fn default_true() -> bool {
     true
@@ -32,4 +34,33 @@ pub fn default_id() -> String {
 
 pub fn is_default<T: Default + std::cmp::PartialEq>(t: &T) -> bool {
     &T::default() == t
+}
+
+pub fn maybe_number_opt<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: FromStr + serde::Deserialize<'de>,
+    <T as FromStr>::Err: Display,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum NumericOrNull<'a, T> {
+        String(String),
+        Str(&'a str),
+        FromStr(T),
+        Null,
+    }
+
+    match NumericOrNull::<T>::deserialize(deserializer)? {
+        NumericOrNull::String(s) => match s.as_str() {
+            "" => Ok(None),
+            _ => T::from_str(&s).map(Some).map_err(serde::de::Error::custom),
+        },
+        NumericOrNull::Str(s) => match s {
+            "" => Ok(None),
+            _ => T::from_str(s).map(Some).map_err(serde::de::Error::custom),
+        },
+        NumericOrNull::FromStr(i) => Ok(Some(i)),
+        NumericOrNull::Null => Ok(None),
+    }
 }


### PR DESCRIPTION
This change allows parsing expires_in from a string while also retaining its previous behavior

This works for the following cases:
- the json response contains `expires_in` as a numeric value (as expected before)
- the json response contains `expires_in` as a string 
- the json response does not contain `expires_in` at all