### PR TITLE
Update lib.rs with mosaicml-cli for Python

### DIFF
--- a/backend/parsers/windmill-parser-py-imports/src/lib.rs
+++ b/backend/parsers/windmill-parser-py-imports/src/lib.rs
@@ -38,6 +38,7 @@ static PYTHON_IMPORTS_REPLACEMENT: phf::Map<&'static str, &'static str> = phf_ma
     "gitlab" => "python-gitlab",
     "smbclient" => "smbprotocol",
     "playhouse" => "peewee",
+    "mosaicml_cli" => "mosaicml-cli"
 };
 
 fn replace_import(x: String) -> String {


### PR DESCRIPTION
https://pypi.org/project/mosaicml-cli/ remaps to mosaicml_cli

Cannot use `mcli` because it is already a pypi package. Unfortunately all the MosaicML examples use mcli, so this is the best I could do.

```
import mosaicml_cli
# mosaicml_cli.predict()
```