### PR TITLE
Fix SELinux issues when downloading Python packages.

### DIFF
--- a/backend/windmill-worker/nsjail/download_deps.py.sh
+++ b/backend/windmill-worker/nsjail/download_deps.py.sh
@@ -19,6 +19,7 @@ then
       echo "\$TRUSTED_HOST is set to $TRUSTED_HOST"
 fi
 
-CMD="/usr/local/bin/python3 -m pip install -v $REQ -I -t $TARGET --no-cache --no-color --no-deps --isolated --no-warn-conflicts --disable-pip-version-check $INDEX_URL_ARG $EXTRA_INDEX_URL_ARG $TRUSTED_HOST_ARG"
+mkdir -p /tmp/windmill/cache/tmp
+CMD="TMPDIR=/tmp/windmill/cache/tmp /usr/local/bin/python3 -m pip install -v $REQ -I -t $TARGET --no-cache --no-color --no-deps --isolated --no-warn-conflicts --disable-pip-version-check $INDEX_URL_ARG $EXTRA_INDEX_URL_ARG $TRUSTED_HOST_ARG"
 echo $CMD
 eval $CMD


### PR DESCRIPTION
This PR creates a directory inside the cache directory that is volume mounted and then tells pip to use that directory instead of `/tmp` to avoid SELinux drama.

Fixes #2381