### PR TITLE
add support for anthropic, bedrock, azure, huggingface, replicate, togetherai, etc.

### DIFF
--- a/llm/src/gen_samples.py
+++ b/llm/src/gen_samples.py
@@ -6,7 +6,7 @@ from test_data import RESOURCE_TYPES, DB_SCHEMA
 
 load_dotenv()
 
-import openai
+from litellm import completion 
 
 import re
 
@@ -119,7 +119,7 @@ def gen_samples(queries_path: str, answers_path: str, prompts_path: str):
         (system, prompt, template_prompt) = prepare_prompt(
             query, GEN_CONFIG, EDIT_CONFIG, FIX_CONFIG
         )
-        chat_completion = openai.ChatCompletion.create(
+        chat_completion = completion(
             model="gpt-4",
             messages=[
                 {"role": "system", "content": system},


### PR DESCRIPTION
Hi @HugoCasa @rubenfiszel,

Noticed you're calling the openai chat completions endpoint. I'm working on litellm (simple library to standardize LLM API Calls - https://github.com/BerriAI/litellm) and wanted to see how i could be helpful.

My PR adds support for new LLM providers (bedrock, togetherai, huggingface tgi, replicate, ai21, cohere, ai21 etc.) by replacing `openai's ChatCompletion` with `litellm.completion`.

Curious if you find this useful?

Happy to add additional tests/documentation if the initial PR looks good.