### PR TITLE
fix: More explicit error message when executable not found

### DIFF
--- a/backend/windmill-worker/src/go_executor.rs
+++ b/backend/windmill-worker/src/go_executor.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, process::Stdio};
+use std::{collections::HashMap, path::Path, process::Stdio};
 
 use itertools::Itertools;
 use tokio::{
@@ -44,6 +44,12 @@ pub async fn handle_go_job(
     worker_name: &str,
     envs: HashMap<String, String>,
 ) -> Result<serde_json::Value, Error> {
+    if !Path::new(GO_PATH.as_str()).exists() {
+        return Result::Err(Error::InternalErr(
+            "Go executable not found on worker".to_string(),
+        ));
+    }
+
     //go does not like executing modules at temp root
     let job_dir = &format!("{job_dir}/go");
     let bin_path = if let Some(requirements) = requirements_o.clone() {


### PR DESCRIPTION
Before:
<img width="566" alt="Screenshot 2023-10-09 at 15 11 13" src="https://github.com/windmill-labs/windmill/assets/18011812/aa648828-f946-4e0e-81ed-4cdd545546d3">


After:
<img width="563" alt="Screenshot 2023-10-09 at 15 09 22" src="https://github.com/windmill-labs/windmill/assets/18011812/8a80aea2-5de2-448b-86db-39757c0c8099">
