### PR TITLE
build: Publish windmill-amd64 binary for each release

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -165,8 +165,8 @@ jobs:
           bucket: windmill-frontend
           bucket-region: us-east-1
 
-  attach_artifacts_to_release:
-    needs: [build] # TODO before merging: should we publish ee or normal binary here? Or both?
+  attach_binary_to_release:
+    needs: [build]
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     steps:
@@ -183,6 +183,31 @@ jobs:
           arch="$(dpkg --print-architecture)"; arch="${arch##*-}";
           cd ${{ steps.extract.outputs.destination }}/
           mv windmill "windmill-${arch}"
+
+      - name: Attach binary to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ${{ steps.extract.outputs.destination }}/*
+
+  attach_ee_binary_to_release:
+    needs: [build-ee]
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: shrink/actions-docker-extract@v2
+        id: extract
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-ee:latest
+          path: "/usr/src/app/windmill"
+
+      - name: Rename binary with corresponding architecture
+        run: |
+          # The GH worker downloaded the image corresponding to its own architecture
+          arch="$(dpkg --print-architecture)"; arch="${arch##*-}";
+          cd ${{ steps.extract.outputs.destination }}/
+          mv windmill "windmill-ee-${arch}"
 
       - name: Attach binary to release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
   packages: write
 
@@ -164,6 +164,31 @@ jobs:
           folder: ${{ steps.extract.outputs.destination }}
           bucket: windmill-frontend
           bucket-region: us-east-1
+
+  attach_artifacts_to_release:
+    needs: [build] # TODO before merging: should we publish ee or normal binary here? Or both?
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: shrink/actions-docker-extract@v2
+        id: extract
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          path: "/usr/src/app/windmill"
+
+      - name: Rename binary with corresponding architecture
+        run: |
+          # The GH worker downloaded the image corresponding to its own architecture
+          arch="$(dpkg --print-architecture)"; arch="${arch##*-}";
+          cd ${{ steps.extract.outputs.destination }}/
+          mv windmill "windmill-${arch}"
+
+      - name: Attach binary to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ${{ steps.extract.outputs.destination }}/*
 
   publish_ecr:
     needs: [build_ee]


### PR DESCRIPTION
The windmill binary will be extracted from the built docker image, renamed and uploaded to the release.

- [x] TODO: Check with Ruben whether we extract the oss or ee binary