### PR TITLE
fix: fail on non-integer sleep value

### DIFF
--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -1425,7 +1425,11 @@ async fn push_next_flow_job<R: rsmq_async::RsmqConnection + Send + Sync + Clone>
                 };
                 match json_value {
                     Ok(serde_json::Value::Number(n)) => {
-                        n.as_u64().map(|x| from_now(Duration::from_secs(x)))
+                        if n.is_u64() {
+                            n.as_u64().map(|x| from_now(Duration::from_secs(x)))
+                        } else {
+                            Err(Error::ExecutionErr(format!("Expected an integer, found: {n}")))
+                        }
                     }
                     _ => Err(Error::ExecutionErr(format!(
                         "Expected a number value, found: {json_value:?}"


### PR DESCRIPTION
This pull request introduces a bug fix where previously, a non-integer value
provided for the sleep duration would be silently ignored because `as_u64()`
would return `None` when `n` was a float, leading to an unintended skip over the
sleep behavior.
