### PR TITLE
fix(frontend): escape wasn't removing the hash when closing a drawer

### DIFF
--- a/frontend/src/lib/components/SuperadminSettings.svelte
+++ b/frontend/src/lib/components/SuperadminSettings.svelte
@@ -57,7 +57,7 @@
 	f={(x) => x.email + ' ' + x.name + ' ' + x.company}
 />
 
-<Drawer bind:this={drawer} on:open={listUsers} size="1200px" on:clickAway={removeHash}>
+<Drawer bind:this={drawer} on:open={listUsers} size="1200px" on:close={removeHash}>
 	<DrawerContent overflow_y={true} title="Instance Settings" on:close={closeDrawer}>
 		<div class="flex flex-col h-full">
 			<div>

--- a/frontend/src/lib/components/UserSettings.svelte
+++ b/frontend/src/lib/components/UserSettings.svelte
@@ -89,7 +89,7 @@
 	}
 </script>
 
-<Drawer bind:this={drawer} size="800px" on:clickAway={removeHash}>
+<Drawer bind:this={drawer} size="800px" on:close={removeHash}>
 	<DrawerContent title="User Settings" on:close={closeDrawer}>
 		<div class="flex flex-col h-full">
 			<div>


### PR DESCRIPTION
Closing the Instance settings and user settings with drawer with escape wouldn't remove the hash from the URL, resulting into a state we couldn't open any of those two menu again.

Clicking away also fires the `on:close` event.