### PR TITLE
Update lib.rs with cv2

### DIFF
--- a/backend/parsers/windmill-parser-py-imports/src/lib.rs
+++ b/backend/parsers/windmill-parser-py-imports/src/lib.rs
@@ -44,7 +44,8 @@ static PYTHON_IMPORTS_REPLACEMENT: phf::Map<&'static str, &'static str> = phf_ma
     "tabula" => "tabula-py",
     "shapefile" => "pyshp",
     "sklearn" => "scikit-learn",
-    "umap" => "umap-learn"
+    "umap" => "umap-learn",
+    "cv2" => "opencv-python"
 };
 
 fn replace_import(x: String) -> String {


### PR DESCRIPTION
Adding OpenCV to Python install/import exceptions mapping
OpenCV URL: https://pypi.org/project/opencv-python/
You install the package with `pip install opencv-python`, and import with `import cv2`