### PR TITLE
feat(python): Add functionality and resiliency to wmill python client

### DIFF
--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -1,8 +1,12 @@
 from typing import Any, Union, Dict
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, Optional
 
 import os
 import json
+from datetime import timedelta
+import logging
+import atexit
+import time
 
 from time import sleep
 from windmill_api.models.whoami_response_200 import WhoamiResponse200
@@ -27,6 +31,8 @@ class JobStatus(Enum):
 
 
 _client: "AuthenticatedClient | None" = None
+
+logger = logging.getLogger("wmill_client")
 
 
 def create_client(base_url: "str | None" = None, token: "str | None" = None) -> AuthenticatedClient:
@@ -81,13 +87,49 @@ def run_script_async(
     ).content.decode("us-ascii")
 
 
-def run_script_sync(hash: str, args: Dict[str, Any] = {}, verbose: bool = False) -> Dict[str, Any]:
+def run_script_sync(
+    hash: str, 
+    args: Optional[Dict[str, Any]] = None, 
+    verbose: bool = False,
+    assert_result_is_not_none: bool = True,
+    cancel_atexit: bool = True,
+    timeout: Optional[timedelta] = None,
+) -> Dict[str, Any]:
     """
     Run a script, wait for it to complete and return the result of the launched script
     """
+    args = args or {}
     job_id = run_script_async(hash, args, None)
+
+    def cancel_job():
+        from windmill_api.api.job.cancel_queued_job import (
+            sync_detailed,
+            CancelQueuedJobJsonBody,
+        )
+        import wmill
+        logger.warning(f"cancelling job {job_id}")
+        return sync_detailed(
+            workspace=wmill.get_workspace(),
+            id=job_id,
+            client=wmill.create_client(),
+            json_body=CancelQueuedJobJsonBody(reason="killed by exit handler"),
+        )
+
+    if cancel_atexit:
+        atexit.register(cancel_job)
+
     nb_iter = 0
+
+    start_time = time.time()
+    timeout_seconds = timeout.total_seconds() if timeout else None
+
     while get_job_status(job_id) != JobStatus.COMPLETED:
+        if timeout_seconds is not None:
+            elapsed_time = time.time() - start_time
+            if elapsed_time > timeout_seconds:
+                msg = f"Script execution timed out after {timeout_seconds} seconds"
+                logger.warning(msg)
+                raise TimeoutError(msg)
         if verbose:
             print(f"Waiting for {job_id} to complete...")
         if nb_iter < 10:
@@ -95,7 +137,21 @@ def run_script_sync(hash: str, args: Dict[str, Any] = {}, verbose: bool = False)
         else:
             sleep(5.0)
         nb_iter += 1
-    return get_result(job_id)
+    
+    result = get_result(
+        job_id,
+        assert_result_is_not_none=assert_result_is_not_none,
+    )
+
+    # the job finished--we don't need to cancel it anymore
+    if cancel_atexit:
+        atexit.unregister(cancel_job)
+
+    error = isinstance(result, dict) and result.get("error")
+
+    assert not error, error
+
+    return result
 
 
 def run_script_by_path_async(
@@ -120,13 +176,48 @@ def run_script_by_path_async(
     ).content.decode("us-ascii")
 
 
-def run_script_by_path_sync(path: str, args: Dict[str, Any] = {}, verbose: bool = False) -> Dict[str, Any]:
+def run_script_by_path_sync(
+    path: str, 
+    args: Dict[str, Any] = {}, 
+    verbose: bool = False,
+    assert_result_is_not_none: bool = True,
+    cancel_atexit: bool = True,
+    timeout: Optional[timedelta] = None,
+) -> Dict[str, Any]:
     """
     Run a script, wait for it to complete and return the result of the launched script
     """
+    args = args or {}
     job_id = run_script_by_path_async(path, args, None)
+
+    def cancel_job():
+        from windmill_api.api.job.cancel_queued_job import (
+            sync_detailed,
+            CancelQueuedJobJsonBody,
+        )
+        logger.warning(f"cancelling job {job_id}")
+        return sync_detailed(
+            workspace=get_workspace(),
+            id=job_id,
+            client=create_client(),
+            json_body=CancelQueuedJobJsonBody(reason="killed by exit handler"),
+        )
+
+    if cancel_atexit:
+        atexit.register(cancel_job)
+
     nb_iter = 0
+
+    start_time = time.time()
+    timeout_seconds = timeout.total_seconds() if timeout else None
+
     while get_job_status(job_id) != JobStatus.COMPLETED:
+        if timeout_seconds is not None:
+            elapsed_time = time.time() - start_time
+            if elapsed_time > timeout_seconds:
+                msg = f"Script execution timed out after {timeout_seconds} seconds"
+                logger.warning(msg)
+                raise TimeoutError(msg)
         if verbose:
             print(f"Waiting for {job_id} to complete...")
         if nb_iter < 10:
@@ -134,7 +225,21 @@ def run_script_by_path_sync(path: str, args: Dict[str, Any] = {}, verbose: bool 
         else:
             sleep(5.0)
         nb_iter += 1
-    return get_result(job_id)
+    
+    result = get_result(
+        job_id,
+        assert_result_is_not_none=assert_result_is_not_none,
+    )
+
+    # the job finished--we don't need to cancel it anymore
+    if cancel_atexit:
+        atexit.unregister(cancel_job)
+
+    error = isinstance(result, dict) and result.get("error")
+
+    assert not error, error
+
+    return result
 
 
 def get_job_status(job_id: str) -> JobStatus:
@@ -160,7 +265,7 @@ def get_job_status(job_id: str) -> JobStatus:
             return JobStatus.WAITING
 
 
-def get_result(job_id: str) -> Dict[str, Any]:
+def get_result(job_id: str, assert_result_is_not_none: bool = True) -> Dict[str, Any]:
     """
     Returns the result of a completed job
     """
@@ -169,8 +274,8 @@ def get_result(job_id: str) -> Dict[str, Any]:
     res = get_completed_job.sync_detailed(client=create_client(), workspace=get_workspace(), id=job_id).parsed
     if not res:
         raise Exception(f"Job {job_id} not found")
-    if not res.result:
-        raise Exception(f"Unexpected result not found for completed job {job_id}")
+    if assert_result_is_not_none and res.result is None:
+        raise Exception(f"result was null for completed job {job_id}")
     else:
         return res.result
 

--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -92,7 +92,7 @@ def run_script_sync(
     args: Optional[Dict[str, Any]] = None, 
     verbose: bool = False,
     assert_result_is_not_none: bool = True,
-    cancel_atexit: bool = True,
+    cleanup: bool = True,
     timeout: Optional[timedelta] = None,
 ) -> Dict[str, Any]:
     """
@@ -106,16 +106,15 @@ def run_script_sync(
             sync_detailed,
             CancelQueuedJobJsonBody,
         )
-        import wmill
         logger.warning(f"cancelling job {job_id}")
         return sync_detailed(
-            workspace=wmill.get_workspace(),
+            workspace=get_workspace(),
             id=job_id,
-            client=wmill.create_client(),
+            client=create_client(),
             json_body=CancelQueuedJobJsonBody(reason="killed by exit handler"),
         )
 
-    if cancel_atexit:
+    if cleanup:
         atexit.register(cancel_job)
 
     nb_iter = 0
@@ -144,7 +143,7 @@ def run_script_sync(
     )
 
     # the job finished--we don't need to cancel it anymore
-    if cancel_atexit:
+    if cleanup:
         atexit.unregister(cancel_job)
 
     error = isinstance(result, dict) and result.get("error")
@@ -181,7 +180,7 @@ def run_script_by_path_sync(
     args: Dict[str, Any] = {}, 
     verbose: bool = False,
     assert_result_is_not_none: bool = True,
-    cancel_atexit: bool = True,
+    cleanup: bool = True,
     timeout: Optional[timedelta] = None,
 ) -> Dict[str, Any]:
     """
@@ -203,7 +202,7 @@ def run_script_by_path_sync(
             json_body=CancelQueuedJobJsonBody(reason="killed by exit handler"),
         )
 
-    if cancel_atexit:
+    if cleanup:
         atexit.register(cancel_job)
 
     nb_iter = 0
@@ -232,7 +231,7 @@ def run_script_by_path_sync(
     )
 
     # the job finished--we don't need to cancel it anymore
-    if cancel_atexit:
+    if cleanup:
         atexit.unregister(cancel_job)
 
     error = isinstance(result, dict) and result.get("error")


### PR DESCRIPTION
This script updates the `wmill` client to add additional arguments to the methods for running scripts synchronously.

* `assert_result_is_not_none`
* `cleanup`
* `timeout`

`assert_result_is_not_none` asserts that the result of the script isn't null. The current behavior is to raise an exception if the result is falsey, which causes unnecessary failures if the result is something like 0, probably a bug.

`cleanup` ensures that jobs that are cancelled gracefully when the parent script is cancelled.

`timeout` throws a `TimeoutError` if passed and the script takes longer than it to execute