### PR TITLE
chore(documentation): Update method name in wmill python README sample code

### DIFF
--- a/python-client/wmill/README.md
+++ b/python-client/wmill/README.md
@@ -17,7 +17,7 @@ def main():
     print(client.version)
     print(client.get("u/user/resource_path"))
 
-    job_id = client.start_execution(path="path/to/script")
+    job_id = client.run_script_async(path="path/to/script")
     print(job_id)
 
     return client.run_script(path="path/to/script", args={"arg1": "value1"})


### PR DESCRIPTION
In the README's example code for the wmill Python client, the method name `start_execution` has been changed to `run_script_async`. This change is in line with the recent updates we made to the client's public API.