### PR TITLE
chore: correct legacy reference from `WM_STATE_PATH_NEW` to `WM_STATE_PATH`

### DIFF
--- a/backend/windmill-common/src/variables.rs
+++ b/backend/windmill-common/src/variables.rs
@@ -181,12 +181,12 @@ pub async fn get_reserved_variables(
         ContextualVariable {
             name: "WM_STATE_PATH".to_string(),
             value: state_path.clone(),
-            description: "State resource path unique to a script and its trigger".to_string(),
+            description: "State resource path unique to a script and its trigger (legacy)".to_string(),
         },
         ContextualVariable {
             name: "WM_STATE_PATH_NEW".to_string(),
             value: state_path,
-            description: "State resource path unique to a script and its trigger (legacy)".to_string(),
+            description: "State resource path unique to a script and its trigger".to_string(),
         },
         ContextualVariable {
             name: "WM_FLOW_STEP_ID".to_string(),

--- a/backend/windmill-queue/src/jobs.rs
+++ b/backend/windmill-queue/src/jobs.rs
@@ -150,7 +150,7 @@ pub async fn cancel_job<'c: 'async_recursion>(
     } else {
         let reason: String = reason
             .clone()
-            .unwrap_or_else(|| "unexplicited reasons".to_string());
+            .unwrap_or_else(|| "unspecified reasons".to_string());
         let e = serde_json::json!({"message": format!("Job canceled: {reason} by {username}"), "name": "Canceled", "reason": reason, "canceler": username});
         let add_job = add_completed_job_error(
             &db,


### PR DESCRIPTION
* also replace `unexplicited` with `unspecified` in cancelled job message string