### PR TITLE
fix: spelling error dtails -> details

### DIFF
--- a/frontend/src/lib/components/flows/content/FlowInputs.svelte
+++ b/frontend/src/lib/components/flows/content/FlowInputs.svelte
@@ -91,7 +91,7 @@
 		{#if kind == 'approval'}
 			<div class="mt-2" />
 			<Alert title="Approval Step" role="info">
-				An approval step will suspend the execution of a flow until it has been approved through the resume endpoints or the approval page by and solely by the recipients of the secret urls. See dtails in 'Advanced' -> 'Suspend' settings of the step.<br/><br/>
+				An approval step will suspend the execution of a flow until it has been approved through the resume endpoints or the approval page by and solely by the recipients of the secret urls. See details in 'Advanced' -> 'Suspend' settings of the step.<br/><br/>
 				For further details, visit <a
 					href="https://www.windmill.dev/docs/flows/flow_approval"
 					target="_blank"


### PR DESCRIPTION
<img width="788" alt="image" src="https://github.com/windmill-labs/windmill/assets/87331957/c3ee96eb-8bff-4f5a-9571-d55e951dca28">

dtails -> details