### PR TITLE
feat: Allow running image as non-root user

### DIFF
--- a/lsp/Dockerfile
+++ b/lsp/Dockerfile
@@ -54,7 +54,7 @@ RUN pipenv install
 
 COPY pyls_launcher.py .
 
-RUN mkdir -p /tmp/monaco
+RUN mkdir -p /tmp/monaco && chmod -R 777 /tmp/monaco
 
 RUN cd /tmp/monaco && yarn add -D windmill-client
 


### PR DESCRIPTION
Currently /tmp/monaco ends up only writable by root, as build context runs as root, and read-only by other users. 
Running the image with a non-root uid fails, as launcher fails to write out go.mod to the root owned directory.
Some environments do not allow running things as root.