### PR TITLE
fix: add --unstable-http arg to deno in deno executor

### DIFF
--- a/backend/windmill-worker/src/deno_executor.rs
+++ b/backend/windmill-worker/src/deno_executor.rs
@@ -123,6 +123,7 @@ pub async fn generate_deno_lock(
             "--unstable-ffi",
             "--unstable-fs",
             "--unstable-worker-options",
+            "--unstable-http",
             "--lock=lock.json",
             "--lock-write",
             "--import-map",
@@ -291,6 +292,7 @@ try {{
         args.push("--unstable-ffi");
         args.push("--unstable-fs");
         args.push("--unstable-worker-options");
+        args.push("--unstable-http");
         if let Some(reqs) = requirements_o {
             if !reqs.is_empty() {
                 let _ = write_file(job_dir, "lock.json", &reqs).await?;
@@ -519,6 +521,7 @@ for await (const chunk of Deno.stdin.readable) {{
             "--unstable-ffi",
             "--unstable-fs",
             "--unstable-worker-options",
+            "--unstable-http",
             "-A",
             &format!("{job_dir}/wrapper.ts"),
         ],


### PR DESCRIPTION
This PR adds the `--unstable-http` arg to deno in deno executor. This flag allows the use of `--unstable-http`

https://github.com/denoland/deno/issues/22155