### PR TITLE
Fix nightly rustc compilation: update RustPython dependency

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1905,16 +1905,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
- "serde",
-]
-
-[[package]]
 name = "derive_builder"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,18 +2167,6 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "embed-doc-image"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af36f591236d9d822425cb6896595658fa558fcebf5ee8accac1d4b92c47166e"
-dependencies = [
- "base64 0.13.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3428,19 +3406,6 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-macro"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7d079e129b77477a49c5c4f1cfe9ce6c2c909ef52520693e8e811a714c7b20"
-dependencies = [
- "Inflector",
- "pmutil 0.5.3",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "is-macro"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a85abdc13717906baccb5a1e435556ce0df215f242892f721dff62bf25288f"
@@ -3449,15 +3414,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.50",
-]
-
-[[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -3529,15 +3485,6 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
-]
-
-[[package]]
-name = "keccak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
-dependencies = [
- "cpufeatures",
 ]
 
 [[package]]
@@ -3815,9 +3762,9 @@ dependencies = [
 
 [[package]]
 name = "malachite"
-version = "0.3.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6cf7f4730c30071ba374fac86ad35b1cb7a0716f774737768667ea3fa1828e3"
+checksum = "53ff327de42075f680ba15c5cb3c417687eb7241ce2063a91d0186ce5c5e77ee"
 dependencies = [
  "malachite-base",
  "malachite-nz",
@@ -3826,22 +3773,21 @@ dependencies = [
 
 [[package]]
 name = "malachite-base"
-version = "0.3.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b06bfa98a4b4802af5a4263b4ad4660e28e51e8490f6354eb9336c70767e1c5"
+checksum = "e960ee0e7e1b8eec9229f5b20d6b191762574225144ea638eb961d065c97b55d"
 dependencies = [
- "itertools 0.9.0",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
+ "hashbrown 0.14.3",
+ "itertools 0.11.0",
+ "libm",
  "ryu",
- "sha3",
 ]
 
 [[package]]
 name = "malachite-bigint"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5110aee54537b0cef214efbebdd7df79b7408db8eef4f6a4b6db9d0d8fc01b"
+checksum = "17703a19c80bbdd0b7919f0f104f3b0597f7de4fc4e90a477c15366a5ba03faa"
 dependencies = [
  "derive_more",
  "malachite",
@@ -3852,22 +3798,22 @@ dependencies = [
 
 [[package]]
 name = "malachite-nz"
-version = "0.3.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89e21c64b7af5be3dc8cef16f786243faf59459fe4ba93b44efdeb264e5ade4"
+checksum = "770aaf1a4d59a82ed3d8644eb66aff7492a6dd7476def275a922d04d77ca8e57"
 dependencies = [
- "embed-doc-image",
- "itertools 0.9.0",
+ "itertools 0.11.0",
+ "libm",
  "malachite-base",
 ]
 
 [[package]]
 name = "malachite-q"
-version = "0.3.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3755e541d5134b5016594c9043094172c4dda9259b3ce824a7b8101941850360"
+checksum = "33a9dfca114f6b582595990ccfc287cace633aa95f890ade5b1fc099b7175d3b"
 dependencies = [
- "itertools 0.9.0",
+ "itertools 0.11.0",
  "malachite-base",
  "malachite-nz",
 ]
@@ -4237,12 +4183,6 @@ dependencies = [
  "bytemuck",
  "num-traits",
 ]
-
-[[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -4836,17 +4776,6 @@ checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
 
 [[package]]
 name = "pmutil"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3894e5d549cccbe44afecf72922f277f603cd4bb0219c8342631ef18fffbe004"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "pmutil"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
@@ -5277,12 +5206,6 @@ dependencies = [
  "serde_json",
  "uuid 1.7.0",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -6263,11 +6186,10 @@ dependencies = [
 
 [[package]]
 name = "rustpython-ast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf9438da3660e6b88bd659fdc0cd13bcff4b85c584026a48b800c75bf0f8d00"
+version = "0.3.1"
+source = "git+https://github.com/RustPython/Parser?rev=29c4728dbedc7e69cc2560b9b34058bbba9b1303#29c4728dbedc7e69cc2560b9b34058bbba9b1303"
 dependencies = [
- "is-macro 0.2.2",
+ "is-macro",
  "malachite-bigint",
  "rustpython-parser-core",
  "static_assertions",
@@ -6275,13 +6197,12 @@ dependencies = [
 
 [[package]]
 name = "rustpython-parser"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db993974ff12f33c5be8a801741463691502f85ead5c503277937c4077bd92a"
+version = "0.3.1"
+source = "git+https://github.com/RustPython/Parser?rev=29c4728dbedc7e69cc2560b9b34058bbba9b1303#29c4728dbedc7e69cc2560b9b34058bbba9b1303"
 dependencies = [
  "anyhow",
- "is-macro 0.2.2",
- "itertools 0.10.5",
+ "is-macro",
+ "itertools 0.11.0",
  "lalrpop-util",
  "log",
  "malachite-bigint",
@@ -6299,20 +6220,18 @@ dependencies = [
 
 [[package]]
 name = "rustpython-parser-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9d560c6dd4dc774d4bbad48c770e074c178c4ed5f6fd0521fcdb639af21bdd"
+version = "0.3.1"
+source = "git+https://github.com/RustPython/Parser?rev=29c4728dbedc7e69cc2560b9b34058bbba9b1303#29c4728dbedc7e69cc2560b9b34058bbba9b1303"
 dependencies = [
- "is-macro 0.2.2",
+ "is-macro",
  "memchr",
  "rustpython-parser-vendored",
 ]
 
 [[package]]
 name = "rustpython-parser-vendored"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ae3062d7fe5fe38073f3a1c7145ed9a04e15f6e4a596d642c7db2d5cd2b51b"
+version = "0.3.1"
+source = "git+https://github.com/RustPython/Parser?rev=29c4728dbedc7e69cc2560b9b34058bbba9b1303#29c4728dbedc7e69cc2560b9b34058bbba9b1303"
 dependencies = [
  "memchr",
  "once_cell",
@@ -6775,18 +6694,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug",
 ]
 
 [[package]]
@@ -7483,7 +7390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852a48a24a2533de88298c6b25355bc68fdee31ac21cb4fb8939b7001715353c"
 dependencies = [
  "bitflags 2.4.2",
- "is-macro 0.3.5",
+ "is-macro",
  "num-bigint",
  "phf",
  "scoped-tls",
@@ -7742,7 +7649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa8bb05975506741555ea4d10c3a3bdb0e2357cd58e1a4a4332b8ebb4b44c34d"
 dependencies = [
  "Inflector",
- "pmutil 0.6.1",
+ "pmutil",
  "proc-macro2",
  "quote",
  "swc_macros_common",
@@ -7953,14 +7860,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
- "deranged",
  "itoa",
- "num-conv",
- "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -7968,17 +7872,16 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
- "num-conv",
  "time-core",
 ]
 
@@ -8712,9 +8615,26 @@ checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unicode_names2"
-version = "0.6.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446c96c6dd42604779487f0a981060717156648c1706aa1f464677f03c6cc059"
+checksum = "ac64ef2f016dc69dfa8283394a70b057066eb054d5fcb6b9eb17bd2ec5097211"
+dependencies = [
+ "phf",
+ "unicode_names2_generator",
+]
+
+[[package]]
+name = "unicode_names2_generator"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "013f6a731e80f3930de580e55ba41dfa846de4e0fdee4a701f97989cb1597d6a"
+dependencies = [
+ "getopts",
+ "log",
+ "phf_codegen",
+ "rand 0.8.5",
+ "time",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -127,7 +127,7 @@ rand = "0.8.5"
 rand_core = { version = "^0", features = ["std"] }
 magic-crypt = "^3"
 git-version = "^0"
-rustpython-parser = "0.3.0"
+rustpython-parser = { git = "https://github.com/RustPython/Parser", rev = "29c4728dbedc7e69cc2560b9b34058bbba9b1303" }
 cron = "^0"
 mail-send = { version = "0.4.0", features = ["builder"], default-features=false }
 urlencoding = "^2"
@@ -220,3 +220,4 @@ polars = { version = "0.35.4", features = ["lazy", "parquet", "aws", "azure", "c
 polars-io = { version = "0.35.4", features = ["csv"] }
 object_store = { version = "0.8.0", features = ["aws", "azure"] }
 openidconnect = { version = "3.4.0" }
+


### PR DESCRIPTION
Updated to a newer patch of RustPython so the nightly compiler now also works (see https://github.com/RustPython/Parser/pull/111). Of course, the stable compiler also still works correctly. I also needed to change the version of the time crate to fix version mismatches across dependencies. The only two changes are to

(1) `Cargo.toml`, which was a manual version change. Note that RustPython has not had a tagged version update since this nightly fix, so we use the GitHub commit.
```bash
-rustpython-parser = "0.3.0"
+rustpython-parser = { git = "https://github.com/RustPython/Parser", rev = "29c4728dbedc7e69cc2560b9b34058bbba9b1303" }
```

(2) `Cargo.lock`, which was the result of a `cargo update`:
```bash
error: failed to select a version for `time`.
    ... required by package `unicode_names2_generator v1.1.0`
    ... which satisfies dependency `unicode_names2_generator = "^1.1.0"` of package `unicode_names2 v1.1.0`
    ... which satisfies dependency `unicode_names2 = "^1.1.0"` of package `rustpython-parser v0.3.1 (https://github.com/RustPython/Parser?rev=29c4728dbedc7e69cc2560b9b34058bbba9b1303#29c4728d)`
    ... which satisfies git dependency `rustpython-parser` of package `windmill-parser-py v1.273.0 (/home/kapil/Desktop/windmill/backend/parsers/windmill-parser-py)`
    ... which satisfies path dependency `windmill-parser-py` (locked to 1.273.0) of package `windmill-parser-wasm v1.273.0 (/home/kapil/Desktop/windmill/backend/parsers/windmill-parser-wasm)`
versions that meet the requirements `^0.3, <0.3.21` are: 0.3.20, 0.3.19, 0.3.18, 0.3.17, 0.3.16, 0.3.15, 0.3.14, 0.3.13, 0.3.12, 0.3.11, 0.3.10, 0.3.9, 0.3.7, 0.3.6, 0.3.5, 0.3.4, 0.3.3, 0.3.2, 0.3.1, 0.3.0

all possible versions conflict with previously selected packages.

  previously selected package `time v0.3.34`
    ... which satisfies dependency `time = "^0.3.16"` (locked to 0.3.34) of package `windmill-api v1.273.0 (/home/kapil/Desktop/windmill/backend/windmill-api)`
    ... which satisfies path dependency `windmill-api` (locked to 1.273.0) of package `windmill v1.273.0 (/home/kapil/Desktop/windmill/backend)`

$ cargo update time --precise 0.3.20
    Updating crates.io index
    Updating git repository `https://github.com/RustPython/Parser`
    Removing deranged v0.3.11
    Removing embed-doc-image v0.1.4
    Removing is-macro v0.2.2
    Removing itertools v0.9.0
    Removing keccak v0.1.5
    Updating malachite v0.3.2 -> v0.4.5
    Updating malachite-base v0.3.2 -> v0.4.5
    Updating malachite-bigint v0.1.0 -> v0.2.0
    Updating malachite-nz v0.3.2 -> v0.4.5
    Updating malachite-q v0.3.2 -> v0.4.5
    Removing num-conv v0.1.0
    Removing pmutil v0.5.3
    Removing powerfmt v0.2.0
    Removing rustpython-ast v0.3.0
      Adding rustpython-ast v0.3.1 (https://github.com/RustPython/Parser?rev=29c4728dbedc7e69cc2560b9b34058bbba9b1303#29c4728d)
    Removing rustpython-parser v0.3.0
      Adding rustpython-parser v0.3.1 (https://github.com/RustPython/Parser?rev=29c4728dbedc7e69cc2560b9b34058bbba9b1303#29c4728d)
    Removing rustpython-parser-core v0.3.0
      Adding rustpython-parser-core v0.3.1 (https://github.com/RustPython/Parser?rev=29c4728dbedc7e69cc2560b9b34058bbba9b1303#29c4728d)
    Removing rustpython-parser-vendored v0.3.0
      Adding rustpython-parser-vendored v0.3.1 (https://github.com/RustPython/Parser?rev=29c4728dbedc7e69cc2560b9b34058bbba9b1303#29c4728d)
    Removing sha3 v0.9.1
 Downgrading time v0.3.34 -> v0.3.20
 Downgrading time-core v0.1.2 -> v0.1.0
 Downgrading time-macros v0.2.17 -> v0.2.8
    Updating unicode_names2 v0.6.0 -> v1.2.1
      Adding unicode_names2_generator v1.2.1
```