### PR TITLE
feat: Use ACCEPT_INVALID_CERTS for SMTP

### DIFF
--- a/backend/windmill-api/src/settings.rs
+++ b/backend/windmill-api/src/settings.rs
@@ -58,6 +58,9 @@ pub async fn test_email(
     let to = test_email.to;
     let client = SmtpClientBuilder::new(smtp.host, smtp.port)
         .implicit_tls(smtp.tls_implicit.unwrap_or(false));
+    if std::env::var("ACCEPT_INVALID_CERTS").is_ok() {
+        client.allow_invalid_certs();
+    }
     let client = if let (Some(username), Some(password)) = (smtp.username, smtp.password) {
         if !username.is_empty() {
             client.credentials((username, password))

--- a/backend/windmill-api/src/users.rs
+++ b/backend/windmill-api/src/users.rs
@@ -1681,6 +1681,9 @@ pub async fn send_email_if_possible_intern(subject: &str, content: &str, to: &st
     if let Some(smtp) = SERVER_CONFIG.read().await.smtp.clone() {
         let client = SmtpClientBuilder::new(smtp.host, smtp.port)
             .implicit_tls(smtp.tls_implicit.unwrap_or(false));
+        if std::env::var("ACCEPT_INVALID_CERTS").is_ok() {
+            client.allow_invalid_certs();
+        }
         let client = if let (Some(username), Some(password)) = (smtp.username, smtp.password) {
             if !username.is_empty() {
                 client.credentials((username, password))


### PR DESCRIPTION
The library currently loads fixed set of certificates from a rust package, does not use OS certificate store. Providing a custom CA would need to be done via a custom tls connector.

Would appreciate a patch release with this, so I can pick up the change via official channels 🙇 