### PR TITLE
fix: update dockerfile to reduce vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG DEBIAN_IMAGE=debian:bookworm-slim
 ARG RUST_IMAGE=rust:1.75-slim-bookworm
-ARG PYTHON_IMAGE=python:3.11.4-slim-bookworm
+ARG PYTHON_IMAGE=python:slim-bookworm
 
 FROM ${DEBIAN_IMAGE} as nsjail
 


### PR DESCRIPTION
This obviously needs testing and could break a lot of stuff, but it would be ideal to upgrade the docker image here which has a lot of [vulnerabilities]( https://hub.docker.com/layers/library/python/3.11.4-slim-bookworm/images/sha256-0275089b5b654bb33931fc239a447db9fdd1628bc9d1482788754785d6d9e464?context=explore)