### PR TITLE
Update AMI used in aws-ecs-terraform example

### DIFF
--- a/examples/deploy/aws-ecs-terraform/ecs_cluster.tf
+++ b/examples/deploy/aws-ecs-terraform/ecs_cluster.tf
@@ -1,6 +1,7 @@
 resource "aws_launch_template" "windmill_cluster_lt" {
   name          = "windmill-cluster-lt"
-  image_id      = "ami-09c0b8e7f21923ac0"
+  // Amazon Linux 2023 https://docs.aws.amazon.com/linux/al2023/ug/naming-and-versioning.html
+  image_id      = "ami-07bff6261f14c3a45"
   instance_type = "t3.medium"
   # vpc_security_group_ids = [aws_security_group.windmill_cluster_sg.id]
 


### PR DESCRIPTION
Previous AMI no longer exists, updated to latest Amazon Linux 2023