### PR TITLE
import replacement: haystack >> haystack-ai

### DIFF
--- a/backend/parsers/windmill-parser-py-imports/src/lib.rs
+++ b/backend/parsers/windmill-parser-py-imports/src/lib.rs
@@ -51,7 +51,7 @@ static PYTHON_IMPORTS_REPLACEMENT: phf::Map<&'static str, &'static str> = phf_ma
     "tenable" => "pytenable",
     "ns1" => "ns1-python",
     "pymsql" => "PyMySQL",
-    "haystack" => "haystack-ai"
+    "haystack" => "haystack-ai",
 };
 
 fn replace_import(x: String) -> String {

--- a/backend/parsers/windmill-parser-py-imports/src/lib.rs
+++ b/backend/parsers/windmill-parser-py-imports/src/lib.rs
@@ -51,6 +51,7 @@ static PYTHON_IMPORTS_REPLACEMENT: phf::Map<&'static str, &'static str> = phf_ma
     "tenable" => "pytenable",
     "ns1" => "ns1-python",
     "pymsql" => "PyMySQL",
+    "haystack" => "haystack-ai"
 };
 
 fn replace_import(x: String) -> String {


### PR DESCRIPTION
Discussion: https://discord.com/channels/930051556043276338/1231984078211776532/1231984078211776532

In summary:

```import haystack_ai as haystack```


Installs properly, but after installation will raise the following

```
<module>
    import haystack_ai as haystack
ModuleNotFoundError: No module named 'haystack_ai'
```

And attempting to change the import to `haystack` it will point to other installation.