### PR TITLE
fix(frontend): fix slider component styling

### DIFF
--- a/frontend/src/lib/components/apps/components/inputs/AppRangeInput.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/AppRangeInput.svelte
@@ -154,10 +154,6 @@
 		transform: translate(-50%, -50%);
 	}
 
-	:global(#range-slider.rangeSlider .rangeNub) {
-		background-color: #7e9abd;
-	}
-
 	:global(.dark #range-slider.rangeSlider > .rangePips > .pip) {
 		color: #eeeeee;
 	}

--- a/frontend/src/lib/components/apps/components/inputs/AppSliderInputs.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/AppSliderInputs.svelte
@@ -141,7 +141,7 @@
 			on:pointerdown|stopPropagation={() => ($selectedComponent = [id])}
 		>
 			<RangeSlider
-				id="range-slider"
+				id="slider-input"
 				springValues={{ stiffness: 1, damping: 1 }}
 				vertical={resolvedConfig.vertical}
 				bind:slider
@@ -161,17 +161,17 @@
 </AlignWrapper>
 
 <style>
-	:global(#range-slider.rangeSlider) {
+	:global(#slider-input.rangeSlider) {
 		font-size: 12px;
 		text-transform: uppercase;
 	}
 
-	:global(#range-slider.rangeSlider .rangeHandle) {
+	:global(#slider-input.rangeSlider .rangeHandle) {
 		width: 2em;
 		height: 2em;
 	}
 
-	:global(#range-slider.rangeSlider .rangeFloat) {
+	:global(#slider-input.rangeSlider .rangeFloat) {
 		opacity: 1;
 		background: transparent;
 		top: 50%;


### PR DESCRIPTION
![Screenshot 2024-05-13 at 22 01 49](https://github.com/windmill-labs/windmill/assets/456655/d88289b9-ed5d-4642-a72f-1692da13f9d6)


<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 351bcc1dc35861495e395c02c441c2e9d73bc701  | 
|--------|

### Summary:
This PR updates the ID and related CSS of a slider component across two Svelte files, and removes a hardcoded style.

**Key points**:
- Changed slider component ID from `range-slider` to `slider-input` in `AppRangeInput.svelte` and `AppSliderInputs.svelte`.
- Updated related CSS selectors in both files to reflect new ID.
- Removed hardcoded background color for `.rangeNub` in `AppRangeInput.svelte`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
