### PR TITLE
Use userDB instead of DB

### DIFF
--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -1023,7 +1023,8 @@ struct ListableQueuedJob {
 }
 
 async fn list_queue_jobs(
-    Extension(db): Extension<DB>,
+    authed: ApiAuthed,
+    Extension(user_db): Extension<UserDB>,
     Path(w_id): Path<String>,
     Query(lq): Query<ListQueueQuery>,
 ) -> error::JsonResult<Vec<ListableQueuedJob>> {
@@ -1053,9 +1054,11 @@ async fn list_queue_jobs(
         ],
     )
     .sql()?;
+    let mut tx = user_db.begin(&authed).await?;
     let jobs = sqlx::query_as::<_, ListableQueuedJob>(&sql)
-        .fetch_all(&db)
+        .fetch_all(&mut *tx)
         .await?;
+    tx.commit().await?;
     Ok(Json(jobs))
 }
 
@@ -3946,7 +3949,7 @@ pub struct ListCompletedQuery {
 
 async fn list_completed_jobs(
     authed: ApiAuthed,
-    Extension(db): Extension<DB>,
+    Extension(user_db): Extension<UserDB>,
     Path(w_id): Path<String>,
     Query(pagination): Query<Pagination>,
     Query(lq): Query<ListCompletedQuery>,
@@ -3994,9 +3997,11 @@ async fn list_completed_jobs(
         ],
     )
     .sql()?;
+    let mut tx = user_db.begin(&authed).await?;
     let jobs = sqlx::query_as::<_, ListableCompletedJob>(&sql)
-        .fetch_all(&db)
+        .fetch_all(&mut *tx)
         .await?;
+    tx.commit().await?;
     Ok(Json(jobs))
 }
 


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 14c3a8e9c0c2ccadce50f700bbb1190ca0978006  | 
|--------|

### Summary:
This PR updates `list_queue_jobs` and `list_completed_jobs` to use `UserDB` for database interactions, enhancing user-specific data handling.

**Key points**:
- Updated `list_queue_jobs` and `list_completed_jobs` in `backend/windmill-api/src/jobs.rs` to use `UserDB` instead of `DB`.
- Modified database transaction handling in these functions to align with the new `UserDB` context.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
