### PR TITLE
fix(frontend): Fix FileInput state when hidden

### DIFF
--- a/frontend/src/lib/components/apps/components/inputs/AppFileInput.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/AppFileInput.svelte
@@ -46,6 +46,8 @@
 			fileInput?.clearFiles()
 		}
 	}
+
+	let files: File[] | undefined = undefined
 </script>
 
 {#each Object.keys(css ?? {}) as key (key)}
@@ -90,6 +92,7 @@
 			class={twMerge('w-full h-full', css?.container?.class, 'wm-file-input')}
 			style={css?.container?.style}
 			submittedText={submittedFileText}
+			bind:files
 		>
 			{text}
 		</FileInput>

--- a/frontend/src/lib/components/common/fileInput/FileInput.svelte
+++ b/frontend/src/lib/components/common/fileInput/FileInput.svelte
@@ -21,7 +21,7 @@
 
 	const dispatch = createEventDispatcher()
 	let input: HTMLInputElement
-	let files: File[] | undefined = undefined
+	export let files: File[] | undefined = undefined
 
 	async function onChange(fileList: FileList | null) {
 		if (!fileList || !fileList.length) {


### PR DESCRIPTION
Fix for: https://github.com/windmill-labs/windmill/issues/3728

https://github.com/windmill-labs/windmill/assets/456655/898c4bc0-5729-4887-b6c9-928e356afad2



<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f44fabd4f9d9513c7e2239a38cc6416a4c5cb077  | 
|--------|

### Summary:
This PR adds state management for file inputs in `FileInput.svelte` and binds this state in `AppFileInput.svelte` to ensure consistency when components are hidden.

**Key points**:
- Added `export let files: File[] | undefined = undefined` in `/frontend/src/lib/components/common/fileInput/FileInput.svelte`.
- Added `let files: File[] | undefined = undefined` and `bind:files` in `/frontend/src/lib/components/apps/components/inputs/AppFileInput.svelte`.
- Ensures consistent state management of file inputs across component visibility changes.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
