### PR TITLE
fix: php worker tag migration

### DIFF
--- a/backend/migrations/20240514091000_fix_php_migration.down.sql
+++ b/backend/migrations/20240514091000_fix_php_migration.down.sql
@@ -1,0 +1,1 @@
+-- Add down migration script here

--- a/backend/migrations/20240514091000_fix_php_migration.up.sql
+++ b/backend/migrations/20240514091000_fix_php_migration.up.sql
@@ -1,0 +1,2 @@
+-- Add up migration script here
+UPDATE config SET name = 'worker__default_tmp' WHERE name = 'worker__default';

--- a/backend/migrations/20240515071725_fix_php_migration_2.down.sql
+++ b/backend/migrations/20240515071725_fix_php_migration_2.down.sql
@@ -1,0 +1,1 @@
+-- Add down migration script here

--- a/backend/migrations/20240515071725_fix_php_migration_2.up.sql
+++ b/backend/migrations/20240515071725_fix_php_migration_2.up.sql
@@ -1,0 +1,3 @@
+-- Add up migration script here
+UPDATE config SET name = 'worker__default' WHERE name = 'worker__default_tmp';
+UPDATE config set config = jsonb_set(config, '{worker_tags}', config->'worker_tags' || '["php"]'::jsonb) where name = 'worker__default' and config @> '{"worker_tags": ["deno", "python3", "go", "bash", "powershell", "dependency", "flow", "hub", "other", "bun"]}'::jsonb AND NOT config->'worker_tags' @> '"php"'::jsonb;


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit fe89ec010ad3042a960f5b2bc9adaa3feb0ec5ba  | 
|--------|

### Summary:
This PR adds migration scripts to update worker configuration by temporarily renaming a config entry and adding 'php' to worker tags.

**Key points**:
- Adds two sets of migration scripts: `20240514091000` and `20240515071725`.
- `20240514091000.up.sql` renames `worker__default` to `worker__default_tmp`.
- `20240515071725.up.sql` renames `worker__default_tmp` back to `worker__default` and adds 'php' to `worker_tags` if not present.
- Down migration scripts are placeholders.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
