### PR TITLE
fix(frontend): rename correctly delete workspace button

### DIFF
--- a/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
@@ -893,7 +893,7 @@
 							goto('/user/workspaces')
 						}}
 					>
-						General (superadmin)
+						Delete workspace (superadmin)
 					</Button>
 				{/if}
 			</div>


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7af35e70715ac64b871b1b88d6807a86c4b401bb  | 
|--------|

### Summary:
Updated the label of a button in the workspace settings page to more accurately describe its function for superadmin users.

**Key points**:
- Changed button label from `General (superadmin)` to `Delete workspace (superadmin)` in `+page.svelte`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
