### PR TITLE
fix(frontend): improve auto data table headers when array of arrays

### DIFF
--- a/frontend/src/lib/components/table/AutoDataTable.svelte
+++ b/frontend/src/lib/components/table/AutoDataTable.svelte
@@ -30,6 +30,9 @@
 			let hds: string[] = []
 			let objs = objects.map((obj) => {
 				let rowData = obj && typeof obj == 'object' ? obj : {}
+				if (Array.isArray(rowData)) {
+					rowData = Object.fromEntries(rowData.map((x, i) => ['col' + i, x]))
+				}
 				let ks = Object.keys(rowData)
 				ks.forEach((x) => {
 					if (!hds.includes(x)) {


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c4bfdb43af50a83a20aca7d0f920468fe4d104f2  | 
|--------|

### Summary:
Enhanced `AutoDataTable.svelte` to correctly generate headers for data rows that are arrays by converting them to objects.

**Key points**:
- Updated `computeStructuredObjects` in `AutoDataTable.svelte` to handle array data rows by converting them to objects with keys 'col0', 'col1', etc.
- Ensures headers are correctly generated for array-based data rows.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
