### PR TITLE
fix: resolve typo in bun_executor.rs error message

### DIFF
--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -535,7 +535,7 @@ pub async fn handle_bun_job(
         let splitted = reqs.split(BUN_LOCKB_SPLIT).collect::<Vec<&str>>();
         if splitted.len() != 2 {
             return Err(error::Error::ExecutionErr(
-                format!("Invalid requirements, expectd to find //bun.lockb split pattern in reqs. Found: |{reqs}|")
+                format!("Invalid requirements, expected to find //bun.lockb split pattern in reqs. Found: |{reqs}|")
             ));
         }
         let _ = write_file(job_dir, "package.json", &splitted[0]).await?;


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f191d92f4db55f85d1730748aa13264885615862  | 
|--------|

### Summary:
Fixes a typo in the error message of `handle_bun_job` function in `bun_executor.rs` to improve clarity.

**Key points**:
- Corrects typo in error message within `handle_bun_job` function in `bun_executor.rs`.
- Changes 'expectd' to 'expected' in the error string.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
