### PR TITLE
feat(frontend): Fix App Select component initial value

### DIFF
--- a/frontend/src/lib/components/apps/components/inputs/AppSelect.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/AppSelect.svelte
@@ -75,7 +75,7 @@
 	let value: string | undefined = noDefault
 		? undefined
 		: outputs?.result.peak()
-		? `"${outputs?.result.peak()}"`
+		? JSON.stringify(outputs?.result.peak())
 		: undefined
 
 	$: resolvedConfig.items && handleItems()

--- a/frontend/src/lib/components/apps/components/inputs/AppSelect.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/AppSelect.svelte
@@ -71,7 +71,12 @@
 		result: undefined as string | undefined
 	})
 
-	let value: string | undefined = noDefault ? undefined : outputs?.result.peak()
+	// The library expects double quotes around the value
+	let value: string | undefined = noDefault
+		? undefined
+		: outputs?.result.peak()
+		? `"${outputs?.result.peak()}"`
+		: undefined
 
 	$: resolvedConfig.items && handleItems()
 


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit fa89e17e7951458e35bea82c4923fa3f5e01532f  | 
|--------|

### Summary:
This PR updates the `AppSelect.svelte` component to ensure the initial value is correctly formatted with double quotes, addressing a specific library requirement.

**Key points**:
- Updated `AppSelect.svelte` to format the initial value with double quotes if not using `noDefault`.
- Ensures compatibility with the library's expectations for value formatting.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
