### PR TITLE
fix(frontend): improve json display for large table objects

### DIFF
--- a/frontend/src/lib/components/DisplayResult.svelte
+++ b/frontend/src/lib/components/DisplayResult.svelte
@@ -110,7 +110,6 @@
 
 	let is_render_all = false
 	function inferResultKind(result: any) {
-		console.log('inferResultKind')
 		if (result == 'WINDMILL_TOO_BIG') {
 			largeObject = true
 			return 'json'

--- a/frontend/src/lib/components/DisplayResult.svelte
+++ b/frontend/src/lib/components/DisplayResult.svelte
@@ -69,20 +69,48 @@
 	let enableHtml = false
 	let s3FileDisplayRawMode = false
 
-	function isArrayOfArrays(result: any): boolean {
+	function isTableRow(result: any): boolean {
 		return Array.isArray(result) && result.every((x) => Array.isArray(x))
 	}
 
-	function isObjectOfArrays(result: any, keys: string[]): boolean {
+	function isTableCol(result: any, keys: string[]): boolean {
 		return (
 			!Array.isArray(result) && keys.map((k) => Array.isArray(result[k])).reduce((a, b) => a && b)
 		)
 	}
 
+	function isTableRowObject(json) {
+		// check array of objects (with possible a first row of headers)
+		return (
+			Array.isArray(json) &&
+			json.length > 0 &&
+			(json.every(
+				(item) =>
+					item && typeof item === 'object' && Object.keys(item).length > 0 && !Array.isArray(item)
+			) ||
+				(Array.isArray(json[0]) &&
+					json[0].every((item) => typeof item === 'string') &&
+					json
+						.slice(1)
+						.every(
+							(item) =>
+								item &&
+								typeof item === 'object' &&
+								Object.keys(item).length > 0 &&
+								!Array.isArray(item)
+						)))
+		)
+	}
+
 	let largeObject: boolean | undefined = undefined
+
+	function checkIfS3(result: any, keys: string[]) {
+		return keys.length === 1 && keys.includes('s3') && typeof result.s3 === 'string'
+	}
 
 	let is_render_all = false
 	function inferResultKind(result: any) {
+		console.log('inferResultKind')
 		if (result == 'WINDMILL_TOO_BIG') {
 			largeObject = true
 			return 'json'
@@ -101,74 +129,52 @@
 					keys.length == 1 && keys.includes('render_all') && Array.isArray(result['render_all'])
 
 				// Check if the result is an image
-				if (
-					[
-						'png',
-						'svg',
-						'jpeg',
-						'html',
-						'gif',
-						'table-row',
-						'table-col',
-						'table-row-object'
-					].includes(keys[0]) &&
-					keys.length == 1
-				) {
+				if (['png', 'svg', 'jpeg', 'html', 'gif'].includes(keys[0]) && keys.length == 1) {
 					// Check if the image is too large (10mb)
 					largeObject = roughSizeOfObject(result) > IMG_MAX_SIZE
 
-					return keys[0] as
-						| 'png'
-						| 'svg'
-						| 'jpeg'
-						| 'html'
-						| 'gif'
-						| 'table-row'
-						| 'table-col'
-						| 'table-row-object'
+					return keys[0] as 'png' | 'svg' | 'jpeg' | 'html' | 'gif'
+				}
+
+				const tableLargeObject = roughSizeOfObject(result) > TABLE_MAX_SIZE
+				// Otherwise, check if the result is too large (10kb) for json
+				largeObject = tableLargeObject || roughSizeOfObject(result) > DISPLAY_MAX_SIZE
+
+				if (tableLargeObject) {
+					return 'json'
 				}
 
 				if (Array.isArray(result)) {
-					largeObject = roughSizeOfObject(result) > TABLE_MAX_SIZE
-					if (largeObject || result.length === 0) {
+					if (result.length === 0) {
 						return 'json'
-					} else if (result.every((elt) => inferResultKind(elt) === 's3object')) {
+					} else if (
+						result.every((elt) => typeof elt === 'object' && checkIfS3(elt, Object.keys(elt)))
+					) {
 						largeObject = result.length > 100
 						if (largeObject) {
 							return 'json'
 						}
 						return 's3object-list'
-					} else if (isArrayOfArrays(result)) {
+					} else if (isTableRow(result)) {
 						return 'table-row'
-					} else if (isArrayOfObjects(result)) {
+					} else if (isTableRowObject(result)) {
 						return 'table-row-object'
 					} else {
 						return 'json'
 					}
-				} else if (isObjectOfArrays(result, keys)) {
-					largeObject = roughSizeOfObject(result) > TABLE_MAX_SIZE
-					if (largeObject) {
-						return 'json'
-					}
-					return 'table-col'
+				} else if (
+					keys.length === 1 &&
+					['table-row', 'table-row-object', 'table-col'].includes(keys[0])
+				) {
+					return keys[0] as 'table-row' | 'table-row-object' | 'table-col'
 				}
-
-				let length = roughSizeOfObject(result)
-				// Otherwise, check if the result is too large (10kb) for json
-				largeObject = length > DISPLAY_MAX_SIZE
 
 				if (largeObject) {
 					return 'json'
 				}
 
 				if (keys.length != 0) {
-					if (keys.length == 1 && keys[0] == 'table-row') {
-						return 'table-row'
-					} else if (keys.length == 1 && keys[0] == 'table-col') {
-						return 'table-col'
-					} else if (keys.length == 1 && keys[0] == 'table-row-object') {
-						return 'table-row-object'
-					} else if (keys.length == 1 && keys[0] == 'html') {
+					if (keys.length == 1 && keys[0] == 'html') {
 						return 'html'
 					} else if (keys.length == 1 && keys[0] == 'map') {
 						return 'map'
@@ -203,10 +209,12 @@
 						keys.includes('approvalPage')
 					) {
 						return 'approval'
-					} else if (keys.length === 1 && keys.includes('s3') && typeof result.s3 === 'string') {
+					} else if (checkIfS3(result, keys)) {
 						return 's3object'
 					} else if (keys.length === 1 && (keys.includes('md') || keys.includes('markdown'))) {
 						return 'markdown'
+					} else if (isTableCol(result, keys)) {
+						return 'table-col'
 					}
 				}
 			} catch (err) {}
@@ -230,29 +238,6 @@
 		} else {
 			return obj.content
 		}
-	}
-
-	function isArrayOfObjects(json) {
-		// check array of objects (with possible a first row of headers)
-		return (
-			Array.isArray(json) &&
-			json.length > 0 &&
-			(json.every(
-				(item) =>
-					item && typeof item === 'object' && Object.keys(item).length > 0 && !Array.isArray(item)
-			) ||
-				(Array.isArray(json[0]) &&
-					json[0].every((item) => typeof item === 'string') &&
-					json
-						.slice(1)
-						.every(
-							(item) =>
-								item &&
-								typeof item === 'object' &&
-								Object.keys(item).length > 0 &&
-								!Array.isArray(item)
-						)))
-		)
 	}
 
 	function handleArrayOfObjectsHeaders(json: any) {

--- a/frontend/src/lib/components/DisplayResult.svelte
+++ b/frontend/src/lib/components/DisplayResult.svelte
@@ -75,7 +75,8 @@
 
 	function isTableCol(result: any, keys: string[]): boolean {
 		return (
-			return (!Array.isArray(result) && keys.map((k) => Array.isArray(result[k])).reduce((a, b) => a && b, true))
+			!Array.isArray(result) &&
+			keys.map((k) => Array.isArray(result[k])).reduce((a, b) => a && b, true)
 		)
 	}
 

--- a/frontend/src/lib/components/DisplayResult.svelte
+++ b/frontend/src/lib/components/DisplayResult.svelte
@@ -75,7 +75,7 @@
 
 	function isTableCol(result: any, keys: string[]): boolean {
 		return (
-			!Array.isArray(result) && keys.map((k) => Array.isArray(result[k])).reduce((a, b) => a && b)
+			return (!Array.isArray(result) && keys.map((k) => Array.isArray(result[k])).reduce((a, b) => a && b, true))
 		)
 	}
 


### PR DESCRIPTION
- **fix(frontend): fix check for displaying table-col**
- **fix: improve display result json limit for tables**


<!--
ELLIPSIS_HIDDEN
-->
----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d1992dce8f6899744f777e759590cdc923fc9ae6  | 
|--------|

### Summary:
Enhances JSON display for large table objects in `DisplayResult.svelte` by refining size thresholds and result type determination.

**Key points**:
- **fix(frontend): fix check for displaying table-col**
- **fix: improve display result json limit for tables**
- Introduced constants `IMG_MAX_SIZE`, `TABLE_MAX_SIZE`, `DISPLAY_MAX_SIZE` for size thresholds.
- Refactored `inferResultKind` to enhance logic for determining result types.
- Added `isTableRowObject` and `checkIfS3` helper functions for better type checks.
- Adjusted conditions for rendering as 'json' based on object size and type.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
