### PR TITLE
fix(frontend): Fix full height component for public apps

### DIFF
--- a/frontend/src/lib/components/apps/editor/AppPreview.svelte
+++ b/frontend/src/lib/components/apps/editor/AppPreview.svelte
@@ -171,7 +171,7 @@
 
 <svelte:window on:hashchange={hashchange} on:resize={resizeWindow} />
 
-<div class="relative h-full" bind:clientHeight={appHeight}>
+<div class="relative min-h-screen h-full" bind:clientHeight={appHeight}>
 	<div id="app-editor-top-level-drawer" />
 	<div id="app-editor-select" />
 

--- a/frontend/src/lib/components/apps/editor/AppPreview.svelte
+++ b/frontend/src/lib/components/apps/editor/AppPreview.svelte
@@ -171,7 +171,7 @@
 
 <svelte:window on:hashchange={hashchange} on:resize={resizeWindow} />
 
-<div class="relative h-full" bind:clientHeight={appHeight}>
+<div class="relative h-screen" bind:clientHeight={appHeight}>
 	<div id="app-editor-top-level-drawer" />
 	<div id="app-editor-select" />
 

--- a/frontend/src/lib/components/apps/editor/AppPreview.svelte
+++ b/frontend/src/lib/components/apps/editor/AppPreview.svelte
@@ -171,7 +171,7 @@
 
 <svelte:window on:hashchange={hashchange} on:resize={resizeWindow} />
 
-<div class="relative h-screen" bind:clientHeight={appHeight}>
+<div class="relative h-full" bind:clientHeight={appHeight}>
 	<div id="app-editor-top-level-drawer" />
 	<div id="app-editor-select" />
 

--- a/frontend/src/routes/public/[workspace]/[...secret]/+page.svelte
+++ b/frontend/src/routes/public/[workspace]/[...secret]/+page.svelte
@@ -65,7 +65,7 @@
 	{#key app}
 		<div
 			class={twMerge(
-				'min-h-screen h-screen w-full',
+				'min-h-screen h-full w-full',
 				app?.value?.['css']?.['app']?.['viewer']?.class,
 				'wm-app-viewer'
 			)}

--- a/frontend/src/routes/public/[workspace]/[...secret]/+page.svelte
+++ b/frontend/src/routes/public/[workspace]/[...secret]/+page.svelte
@@ -65,7 +65,7 @@
 	{#key app}
 		<div
 			class={twMerge(
-				'min-h-screen h-full w-full',
+				'min-h-screen h-screen w-full',
 				app?.value?.['css']?.['app']?.['viewer']?.class,
 				'wm-app-viewer'
 			)}


### PR DESCRIPTION
Fix for: https://github.com/windmill-labs/windmill/issues/3756

<!--
ELLIPSIS_HIDDEN
-->
----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit fbced7ff27b942f03052d92bb0a5ad287af3b8dd  | 
|--------|

### Summary:
Adjusted CSS classes in `AppPreview.svelte` and `+page.svelte` to ensure components consistently occupy the full height of their containers.

**Key points**:
- Updated `class` attribute in `<div>` within `+page.svelte` to ensure full screen height consistency.
- Updated `AppPreview.svelte` to include `min-h-screen` class.
- Changed `h-screen` to `h-full` in `+page.svelte` to ensure full height consistency.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
