### PR TITLE
fix(frontend): Fix path overflow on the Runs page

### DIFF
--- a/frontend/src/lib/components/runs/RunRow.svelte
+++ b/frontend/src/lib/components/runs/RunRow.svelte
@@ -34,12 +34,13 @@
 	let scheduleEditor: ScheduleEditor
 
 	$: isExternal = job && job.id === '-'
+
+	let triggeredByWidth: number = 0
 </script>
 
 <Portal>
 	<ScheduleEditor on:update={() => goto('/schedules')} bind:this={scheduleEditor} />
 </Portal>
-
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
@@ -211,7 +212,7 @@
 			{/if}
 		</div>
 	{/if}
-	<div class="w-3/12 flex justify-start">
+	<div class="w-3/12 flex justify-start" bind:clientWidth={triggeredByWidth}>
 		{#if job && job.schedule_path}
 			<div class="flex flex-row items-center gap-1">
 				<Calendar size={14} />
@@ -221,7 +222,12 @@
 					btnClasses="font-normal"
 					on:click={() => scheduleEditor?.openEdit(job.schedule_path ?? '', job.job_kind == 'flow')}
 				>
-					{job.schedule_path}
+					<div
+						class="truncate text-ellipsis text-left"
+						style="max-width: {triggeredByWidth - 48}px"
+					>
+						{job.schedule_path}
+					</div>
 				</Button>
 			</div>
 		{:else}


### PR DESCRIPTION
![Screenshot 2024-05-21 at 14 53 35](https://github.com/windmill-labs/windmill/assets/456655/a5167db5-82e7-4030-8380-a27ce744c514)


<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 45f323f3cc91ea2824083ae481435388c01d8e68  | 
|--------|

### Summary:
This PR fixes text overflow issues on the 'Runs' page by dynamically adjusting the maximum width of the schedule path display based on the container's client width.

**Key points**:
- Updated `RunRow.svelte` to handle dynamic text overflow for schedule paths.
- Introduced a new variable `triggeredByWidth` to capture the client width of the container.
- Applied a dynamic `max-width` to the schedule path text based on the `triggeredByWidth`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
