### PR TITLE
Add warning for omitted obscured jobs

### DIFF
--- a/frontend/src/lib/components/runs/RunsTable.svelte
+++ b/frontend/src/lib/components/runs/RunsTable.svelte
@@ -4,10 +4,14 @@
 	import VirtualList from 'svelte-tiny-virtual-list'
 	import { createEventDispatcher, onMount } from 'svelte'
 	import Tooltip from '../Tooltip.svelte'
+	import { AlertTriangle } from 'lucide-svelte'
+	import Popover from '../Popover.svelte'
+	import { workspaceStore } from '$lib/stores'
 	//import InfiniteLoading from 'svelte-infinite-loading'
 
 	export let jobs: Job[] | undefined = undefined
 	export let externalJobs: Job[] = []
+	export let omittedObscuredJobs: boolean
 	export let showExternalJobs: boolean = false
 	export let selectedId: string | undefined = undefined
 	export let selectedWorkspace: string | undefined = undefined
@@ -166,6 +170,16 @@
 						>{externalJobs.length} jobs obscured</Tooltip
 					>
 				</div>
+			</div>
+		{:else if $workspaceStore !== 'admins' &&  omittedObscuredJobs}
+			<div class="w-1/12 text-2xs flex flex-row">
+				{jobs && jobCountString(jobs.length)}
+				<Popover>
+					<AlertTriangle size={16} class="text-yellow-500"/>
+					<svelte:fragment slot="text">
+						Too specific filtering may have caused the omission of obscured jobs. This is done for security reasons. To see obscured jobs, try removing some filters.
+					</svelte:fragment>
+				</Popover>
 			</div>
 		{:else}
 			<div class="w-1/12 text-2xs">{jobs && jobCountString(jobs.length)}</div>

--- a/frontend/src/lib/components/runs/RunsTable.svelte
+++ b/frontend/src/lib/components/runs/RunsTable.svelte
@@ -175,7 +175,7 @@
 			<div class="w-1/12 text-2xs flex flex-row">
 				{jobs && jobCountString(jobs.length)}
 				<Popover>
-					<AlertTriangle size={16} class="text-yellow-500"/>
+					<AlertTriangle size={16} class="ml-0.5 text-yellow-500"/>
 					<svelte:fragment slot="text">
 						Too specific filtering may have caused the omission of obscured jobs. This is done for security reasons. To see obscured jobs, try removing some filters.
 					</svelte:fragment>

--- a/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
@@ -599,6 +599,7 @@
 						<RunsTable
 							{jobs}
 							externalJobs={externalJobs ?? []}
+							omittedObscuredJobs={extendedJobs?.omitted_obscured_jobs ?? false}
 							showExternalJobs={!graphIsRunsChart}
 							activeLabel={label}
 							bind:selectedId
@@ -825,6 +826,7 @@
 				activeLabel={label}
 				{jobs}
 				externalJobs={externalJobs ?? []}
+				omittedObscuredJobs={extendedJobs?.omitted_obscured_jobs ?? false}
 				showExternalJobs={!graphIsRunsChart}
 				bind:selectedId
 				bind:selectedWorkspace


### PR DESCRIPTION
![image](https://github.com/windmill-labs/windmill/assets/53628737/7b4280a5-31f2-4423-8840-d7f1e2a2e978)


This warning tells the user the possible reason that obscured jobs were skipped (i.e. too specific filtering)

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5c1d20ea6536e0744cb2868cf9bb5b1fde07b8cd  | 
|--------|

### Summary:
This PR introduces a user warning in the `RunsTable.svelte` component for omitted obscured jobs due to specific filtering, enhancing transparency and user experience.

**Key points**:
- Added warning for omitted obscured jobs in `RunsTable.svelte`
- Implemented conditional rendering based on workspace and job omission status
- Used `Popover` and `AlertTriangle` components for warning display
- `omittedObscuredJobs` prop passed from `+page.svelte`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
