### PR TITLE
feat: add concurrency key for inline scripts in flows

### DIFF
--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -444,11 +444,21 @@
 														bind:seconds={flowModule.value.concurrency_time_window_s}
 													/>
 												</Label>
-												<Label label="Custom concurrency key">
-													<div class="text-tertiary text-xs"
-														>Custom concurrency keys can only be set as the setting of a workspace
-														script</div
-													>
+												<Label label="Custom concurrency key (optional)">
+													<svelte:fragment slot="header">
+														<Tooltip>
+															Concurrency keys are global, you can have them be workspace specific
+															using the variable `$workspace`. You can also use an argument's value
+															using `$args[name_of_arg]`</Tooltip
+														>
+													</svelte:fragment>
+													<input
+														type="text"
+														autofocus
+														disabled={!$enterpriseLicense}
+														bind:value={flowModule.value.custom_concurrency_key}
+														placeholder={`$workspace/script/${$pathStore}-$args[foo]`}
+													/>
 												</Label>
 											{:else}
 												<Alert type="warning" title="Limitation" size="xs">

--- a/openflow.openapi.yaml
+++ b/openflow.openapi.yaml
@@ -247,6 +247,8 @@ components:
           type: number
         concurrency_time_window_s:
           type: number
+        custom_concurrency_key:
+          type: string
       required:
         - type
         - content


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 417e9e2c9ff2e1fad6d43dd406a525c515d096ce  | 
|--------|

### Summary:
This PR adds an optional `custom_concurrency_key` field to `FlowModuleComponent.svelte` for specifying custom concurrency keys in flows, with updates to the OpenAPI spec.

**Key points**:
- Added `custom_concurrency_key` field in `FlowModuleComponent.svelte`.
- Updated OpenAPI spec in `openflow.openapi.yaml` to include new field.
- UI updates to allow conditional input based on enterprise license.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
