### PR TITLE
fix: show code option in tree view

### DIFF
--- a/frontend/src/lib/components/home/TreeView.svelte
+++ b/frontend/src/lib/components/home/TreeView.svelte
@@ -79,6 +79,7 @@
 						on:appChanged
 						on:rawAppChanged
 						on:reload
+						{showCode}
 						depth={depth + 1}
 					/>
 				{/each}
@@ -144,6 +145,7 @@
 						on:appChanged
 						on:rawAppChanged
 						on:reload
+						{showCode}
 						depth={depth + 1}
 					/>
 				{/each}

--- a/frontend/src/lib/components/home/TreeViewRoot.svelte
+++ b/frontend/src/lib/components/home/TreeViewRoot.svelte
@@ -7,7 +7,6 @@
 	export let nbDisplayed: number
 	export let items: any[] | undefined
 	export let isSearching: boolean = false
-	console.log(`Show code is ${showCode}`)
 
 	let treeLoading = false
 

--- a/frontend/src/lib/components/home/TreeViewRoot.svelte
+++ b/frontend/src/lib/components/home/TreeViewRoot.svelte
@@ -7,6 +7,7 @@
 	export let nbDisplayed: number
 	export let items: any[] | undefined
 	export let isSearching: boolean = false
+	console.log(`Show code is ${showCode}`)
 
 	let treeLoading = false
 


### PR DESCRIPTION
The show code option was not working when looking at the home page in tree view because the function was not passed recursively to the element

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ba7c4005c2b4946da9b92c4dee831a8582941180  | 
|--------|

### Summary:
This PR fixes the recursive passing of the `showCode` function in `TreeView.svelte` to ensure it works correctly in the tree view on the home page.

**Key points**:
- Fixed `showCode` function not being passed recursively in `TreeView.svelte`.
- Added `showCode` prop to recursive `svelte:self` calls in `TreeView.svelte`.
- Added console log in `TreeViewRoot.svelte` to debug `showCode` state.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
