### PR TITLE
fix: make typescript client compatible with cf workers

### DIFF
--- a/typescript-client/build.sh
+++ b/typescript-client/build.sh
@@ -9,7 +9,7 @@ cat <<EOF - src/core/OpenAPI.ts > temp_file && mv temp_file src/core/OpenAPI.ts
 const getEnv = (key: string) => {
   if (typeof window === "undefined") {
     // node
-    return process?.env?.[key];
+    return globalThis?.process?.env?.[key];
   }
   // browser
   return window?.process?.env?.[key];

--- a/typescript-client/build.sh
+++ b/typescript-client/build.sh
@@ -8,6 +8,9 @@ npx --yes @hey-api/openapi-ts@0.43.0  --input "${script_dirpath}/../backend/wind
 cat <<EOF - src/core/OpenAPI.ts > temp_file && mv temp_file src/core/OpenAPI.ts
 const getEnv = (key: string) => {
   if (typeof window === "undefined") {
+    if (typeof process !== "undefined") {
+      return process?.env?.[key];
+    }
     // node
     return globalThis?.process?.env?.[key];
   }


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit bab5c218c236204aaaece0e22fff3c8043ecc0dc  | 
|--------|

### Summary:
Updated the `getEnv` function in `typescript-client/build.sh` to enhance compatibility with Cloudflare Workers by using `globalThis?.process?.env`.

**Key points**:
- Update `getEnv` function in `typescript-client/build.sh` to use `globalThis?.process?.env`.
- Ensure compatibility with Cloudflare Workers.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
