### PR TITLE
feat: add GetResumeUrls to go client

### DIFF
--- a/go-client/windmill.go
+++ b/go-client/windmill.go
@@ -158,16 +158,14 @@ func SetState(state interface{}) error {
 	return nil
 }
 
-func GetResumeUrls(approver string) (struct {
+type ResumeUrls struct {
 	ApprovalPage string `json:"approvalPage"`
 	Cancel       string `json:"cancel"`
 	Resume       string `json:"resume"`
-}, error) {
-	var urls struct {
-		ApprovalPage string `json:"approvalPage"`
-		Cancel       string `json:"cancel"`
-		Resume       string `json:"resume"`
-	}
+}
+
+func GetResumeUrls(approver string) (ResumeUrls, error) {
+	var urls ResumeUrls
 	client, err := GetClient()
 	if err != nil {
 		return urls, err


### PR DESCRIPTION
This PR adds GetResumeUrls to go client for approval scripts. It allows a direct access to the urls instead of using the api client.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7c10e5efdee879b4d9d1f251a660b9350c637b97  | 
|--------|

### Summary:
Adds `GetResumeUrls` function to the Go client for fetching direct access URLs for approval scripts, enhancing automation capabilities.

**Key points**:
- Added `GetResumeUrls` function in `go-client/windmill.go`
- New struct `ResumeUrls` with fields for approval, cancel, and resume URLs
- Handles API client retrieval, job ID parsing, and API response errors
- Utilizes `uuid`, `math/rand`, and `context` for generating request parameters


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
