### PR TITLE
fix: rename email_from_username to username_to_email

### DIFF
--- a/backend/windmill-api/src/users.rs
+++ b/backend/windmill-api/src/users.rs
@@ -72,7 +72,7 @@ pub fn workspaced_service() -> Router {
         .route("/whois/:username", get(whois))
         .route("/whoami", get(whoami))
         .route("/leave", post(leave_workspace))
-        .route("/email_from_username/:username", get(email_from_username))
+        .route("/username_to_email/:username", get(username_to_email))
 }
 
 pub fn global_service() -> Router {
@@ -2607,7 +2607,7 @@ async fn get_instance_username_info(
     }))
 }
 
-async fn email_from_username(
+async fn username_to_email(
     Path((w_id, username)): Path<(String, String)>,
     Extension(db): Extension<DB>,
 ) -> Result<String> {


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8c657b6f48da2b5b6eb4e2ea342252df7c7c9280  | 
|--------|

### Summary:
Renamed `email_from_username` function to `username_to_email` and updated the corresponding route in `users.rs` for clarity.

**Key points**:
- Renamed function `email_from_username` to `username_to_email` in `backend/windmill-api/src/users.rs`.
- Updated route from `/email_from_username/:username` to `/username_to_email/:username` in `workspaced_service` function.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
