### PR TITLE
fix: use hub script language as tag instead of 'hub'

### DIFF
--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -31,9 +31,9 @@ lazy_static::lazy_static! {
         "snowflake".to_string(),
         "mssql".to_string(),
         "graphql".to_string(),
+        "php".to_string(),
         "dependency".to_string(),
         "flow".to_string(),
-        "hub".to_string(),
         "other".to_string()
     ];
 

--- a/frontend/src/lib/components/WorkspaceGroup.svelte
+++ b/frontend/src/lib/components/WorkspaceGroup.svelte
@@ -91,7 +91,6 @@
 		'powershell',
 		'dependency',
 		'flow',
-		'hub',
 		'other',
 		'bun',
 		'php'


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->
| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d18e78dc18d5b1dad9fbb8fb51457abe80e7c093  | 
|--------|

### Summary:
This PR updates the job tagging mechanism to use the script's language, enhancing job categorization in the Windmill backend and updating the frontend tag list.

**Key points**:
- Removed 'hub' tag from default tags in `backend/windmill-common/src/worker.rs`
- Modified job queuing to use script language as tag in `backend/windmill-queue/src/jobs.rs`
- Utilized `get_full_hub_script_by_path` to fetch script details for tagging
- Updated frontend tag list in `frontend/src/lib/components/WorkspaceGroup.svelte`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
