### PR TITLE
fix: filtering not always working with concurrency keys

### DIFF
--- a/frontend/src/lib/components/runs/JobLoader.svelte
+++ b/frontend/src/lib/components/runs/JobLoader.svelte
@@ -191,7 +191,7 @@
 		}
 		loading = true
 		try {
-			if (concurrencyKey == null || concurrencyKey === '') {
+			if ((concurrencyKey == null || concurrencyKey === '') && $workspaceStore != "admins") {
 				let newJobs = await fetchJobs(maxTs, undefined)
 				extendedJobs = { jobs: newJobs, obscured_jobs: [] } as ExtendedJobs
 
@@ -284,7 +284,7 @@
 
 					loading = true
 					let newJobs: Job[]
-					if (concurrencyKey == null || concurrencyKey === '') {
+					if ((concurrencyKey == null || concurrencyKey === '') && $workspaceStore != "admins") {
 						newJobs = await fetchJobs(maxTs, minTs ?? ts)
 					} else {
 						// Obscured jobs have no ids, so we have to do the full request
@@ -298,7 +298,7 @@
 					if (newJobs && newJobs.length > 0 && jobs) {
 						jobs = updateWithNewJobs(jobs, newJobs)
 						jobs = jobs
-						if (concurrencyKey == null || concurrencyKey === '') {
+						if ((concurrencyKey == null || concurrencyKey === '') && $workspaceStore != "admins") {
 							if (!extendedJobs) {
 								extendedJobs = { jobs: jobs, obscured_jobs: [] } as ExtendedJobs
 							} else {


### PR DESCRIPTION
When concurrency key filtering was enabled (and thus using the list extended endpoints was used) the filtering was missing in the case were filters are too specific (only the filter on concurrency key was applied)

Also allow CRON schedules and planned for later filters to not get the warning