### PR TITLE
fix: show more precise worker memory usage on k8s

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -8313,7 +8313,6 @@ dependencies = [
  "libc",
  "ntapi",
  "once_cell",
- "rayon",
  "windows",
 ]
 
@@ -9873,7 +9872,6 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "sqlx",
- "sysinfo",
  "thiserror",
  "tikv-jemalloc-ctl",
  "tokio",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -249,8 +249,6 @@ tar = "^0"
 http = "^1"
 async-stream = "^0"
 
-sysinfo = "0.30.12"
-
 tikv-jemallocator = { version = "0.5" }
 tikv-jemalloc-sys  = { version = "^0.5" }
 tikv-jemalloc-ctl = { version = "^0.5" }

--- a/backend/windmill-common/Cargo.toml
+++ b/backend/windmill-common/Cargo.toml
@@ -50,7 +50,6 @@ aws-sdk-sts = { workspace = true, optional = true }
 indexmap.workspace = true
 bytes = { workspace = true, optional = true }
 mail-send.workspace = true
-sysinfo.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemalloc-ctl = { optional = true, workspace = true }

--- a/frontend/src/routes/(root)/(logged)/workers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/workers/+page.svelte
@@ -346,7 +346,7 @@
 							<Cell head>Current job</Cell>
 							<Cell head>Occupancy rate</Cell>
 						{/if}
-						<Cell head>Memory usage<br />(Windmill usage)</Cell>
+						<Cell head>Memory usage<br />(Windmill)</Cell>
 						<Cell head>Limits</Cell>
 						<Cell head>Version</Cell>
 						<Cell head last>Liveness</Cell>


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 6b9bfcf6769dba7581b0950579ebc4007b0581ab  | 
|--------|

### Summary:
Replaces `sysinfo` library with system commands for memory and CPU info retrieval in the backend and updates a UI label in the frontend.

**Key points**:
- Removed `sysinfo` dependency from `backend/Cargo.toml`, `backend/Cargo.lock`, and `backend/windmill-common/Cargo.toml`.
- Replaced `sysinfo` usage in `backend/windmill-common/src/worker.rs` with system commands for memory and CPU information retrieval.
- Minor UI label change in `frontend/src/routes/(root)/(logged)/workers/+page.svelte`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
