### PR TITLE
Limit the where clause of the Database Studio to stat…

### DIFF
--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -3659,7 +3659,8 @@ See date-fns format for more information. By default, it is 'dd.MM.yyyy HH:mm'
 				whereClause: {
 					type: 'static',
 					fieldType: 'text',
-					value: ''
+					value: '',
+					allowTypeChange: false
 				},
 				flex: {
 					type: 'static',


### PR DESCRIPTION
…ic only

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7abc8d03c1ccd99b2513a0ba8db19296c73d195f  | 
|--------|--------|

### Summary:
Modified the `DBExplorerComponent` to make the `whereClause` static by setting `allowTypeChange` to `false`.

**Key points**:
- Set `allowTypeChange` to `false` for `whereClause` in `DBExplorerComponent` to make it static.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
