### PR TITLE
fix(frontend): Remove useless RunnableWrapper on Log and Flow status …

### DIFF
--- a/frontend/src/lib/components/FlowStatusViewer.svelte
+++ b/frontend/src/lib/components/FlowStatusViewer.svelte
@@ -55,6 +55,8 @@
 	globalDurationStatuses={[]}
 	globalModuleStates={[]}
 	bind:selectedNode={selectedJobStep}
+	on:start
+	on:done
 	{jobId}
 	{workspaceId}
 	{isOwner}

--- a/frontend/src/lib/components/FlowStatusViewerInner.svelte
+++ b/frontend/src/lib/components/FlowStatusViewerInner.svelte
@@ -196,6 +196,7 @@
 	let errorCount = 0
 	let notAnonynmous = false
 	async function loadJobInProgress() {
+		dispatch('start')
 		if (jobId != '00000000-0000-0000-0000-000000000000') {
 			try {
 				const newJob = await JobService.getJob({
@@ -223,6 +224,8 @@
 		}
 		if (job?.type !== 'CompletedJob' && errorCount < 4 && !destroyed) {
 			timeout = setTimeout(() => loadJobInProgress(), reducedPolling ? 5000 : 1000)
+		} else {
+			dispatch('done', job)
 		}
 	}
 

--- a/frontend/src/lib/components/apps/components/display/AppFlowStatusComponent.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppFlowStatusComponent.svelte
@@ -10,7 +10,7 @@
 		tooltip="See documentation of the new component:"
 		type="error"
 	>
-		This component is deprecated and will be removed in the future. Please use the Flow status by
-		Job Id component instead.
+		This component is deprecated and hase been removed. Please use the Flow status by Job Id
+		component instead.
 	</Alert>
 </AlignWrapper>

--- a/frontend/src/lib/components/apps/components/display/AppFlowStatusComponent.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppFlowStatusComponent.svelte
@@ -10,7 +10,7 @@
 		tooltip="See documentation of the new component:"
 		type="error"
 	>
-		This component is deprecated and hase been removed. Please use the Flow status by Job Id
+		This component is deprecated and has been removed. Please use the Flow status by Job Id
 		component instead.
 	</Alert>
 </AlignWrapper>

--- a/frontend/src/lib/components/apps/components/display/AppFlowStatusComponent.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppFlowStatusComponent.svelte
@@ -1,80 +1,16 @@
 <script lang="ts">
-	import { getContext } from 'svelte'
-	import { twMerge } from 'tailwind-merge'
-	import { initOutput } from '../../editor/appUtils'
-	import type { AppInput } from '../../inputType'
-	import type { AppViewerContext, ComponentCustomCSS } from '../../types'
-	import RunnableWrapper from '../helpers/RunnableWrapper.svelte'
-	import { initCss } from '../../utils'
-	import FlowStatusViewer from '$lib/components/FlowStatusViewer.svelte'
-	import ResolveStyle from '../helpers/ResolveStyle.svelte'
-
-	export let id: string
-	export let componentInput: AppInput | undefined
-	export let initializing: boolean | undefined = false
-	export let customCss: ComponentCustomCSS<'flowstatuscomponent'> | undefined = undefined
-	export let render: boolean
-
-	const { app, worldStore, workspace } = getContext<AppViewerContext>('AppViewerContext')
-
-	const outputs = initOutput($worldStore, id, {
-		result: undefined,
-		loading: false
-	})
-
-	initializing = false
-
-	let css = initCss($app.css?.flowstatuscomponent, customCss)
-	let jobId: string | undefined
+	import { Alert } from '$lib/components/common'
+	import AlignWrapper from '../helpers/AlignWrapper.svelte'
 </script>
 
-{#each Object.keys(css ?? {}) as key (key)}
-	<ResolveStyle
-		{id}
-		{customCss}
-		{key}
-		bind:css={css[key]}
-		componentStyle={$app.css?.flowstatuscomponent}
-	/>
-{/each}
-
-<RunnableWrapper
-	on:started={(e) => {
-		jobId = e.detail
-	}}
-	{outputs}
-	{render}
-	{componentInput}
-	{id}
->
-	<div class="flex flex-col w-full h-full">
-		<div
-			class={twMerge(
-				'w-full border-b px-2 text-xs p-1 font-semibold bg-gray-500 text-white rounded-t-sm',
-				css?.header?.class,
-				'wm-flow-status-header'
-			)}
-			style={css?.header?.style}
-		>
-			Flow Status
-		</div>
-		<div
-			style={twMerge(
-				$app.css?.['flowstatuscomponent']?.['container']?.style,
-				customCss?.container?.style
-			)}
-			class={twMerge(
-				'p-2 grow overflow-auto',
-				$app.css?.['flowstatuscomponent']?.['container']?.class,
-				customCss?.container?.class,
-				'wm-flow-status-container'
-			)}
-		>
-			{#if jobId}
-				<FlowStatusViewer workspaceId={workspace} {jobId} />
-			{:else}
-				<span class="text-secondary text-xs">No flow</span>
-			{/if}
-		</div>
-	</div>
-</RunnableWrapper>
+<AlignWrapper verticalAlignment="center" horizontalAlignment="center">
+	<Alert
+		title="Deprecated component"
+		documentationLink="https://www.windmill.dev/docs/apps/app_configuration_settings/flow_status"
+		tooltip="See documentation of the new component:"
+		type="error"
+	>
+		This component is deprecated and will be removed in the future. Please use the Flow status by
+		Job Id component instead.
+	</Alert>
+</AlignWrapper>

--- a/frontend/src/lib/components/apps/components/display/AppJobIdFlowStatus.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppJobIdFlowStatus.svelte
@@ -13,6 +13,7 @@
 	export let initializing: boolean | undefined = false
 	export let customCss: ComponentCustomCSS<'jobidflowstatuscomponent'> | undefined = undefined
 	export let configuration: RichConfigurations
+	export let render: boolean
 
 	const { app, worldStore, workspace } = getContext<AppViewerContext>('AppViewerContext')
 
@@ -53,42 +54,44 @@
 	/>
 {/each}
 
-<div class="flex flex-col w-full h-full component-wrapper">
-	<div
-		class={twMerge(
-			'w-full border-b p-2 text-xs font-semibold text-primary bg-surface-secondary',
-			css?.header?.class
-		)}
-		style={css?.header?.style}
-	>
-		Flow Status
+{#if render}
+	<div class="flex flex-col w-full h-full component-wrapper">
+		<div
+			class={twMerge(
+				'w-full border-b p-2 text-xs font-semibold text-primary bg-surface-secondary',
+				css?.header?.class
+			)}
+			style={css?.header?.style}
+		>
+			Flow Status
+		</div>
+		<div
+			style={twMerge(
+				$app.css?.['flowstatuscomponent']?.['container']?.style,
+				customCss?.container?.style
+			)}
+			class={twMerge(
+				'p-2 grow overflow-auto',
+				$app.css?.['flowstatuscomponent']?.['container']?.class,
+				customCss?.container?.class
+			)}
+		>
+			{#if jobId}
+				<FlowStatusViewer
+					workspaceId={workspace}
+					{jobId}
+					on:start={() => {
+						outputs?.jobId.set(jobId)
+						outputs?.loading.set(true)
+					}}
+					on:done={(e) => {
+						outputs?.loading.set(false)
+						outputs?.result.set(e?.detail?.result)
+					}}
+				/>
+			{:else}
+				<span class="text-secondary text-xs">No flow</span>
+			{/if}
+		</div>
 	</div>
-	<div
-		style={twMerge(
-			$app.css?.['flowstatuscomponent']?.['container']?.style,
-			customCss?.container?.style
-		)}
-		class={twMerge(
-			'p-2 grow overflow-auto',
-			$app.css?.['flowstatuscomponent']?.['container']?.class,
-			customCss?.container?.class
-		)}
-	>
-		{#if jobId}
-			<FlowStatusViewer
-				workspaceId={workspace}
-				{jobId}
-				on:start={() => {
-					outputs?.jobId.set(jobId)
-					outputs?.loading.set(true)
-				}}
-				on:done={(e) => {
-					outputs?.loading.set(false)
-					outputs?.result.set(e?.detail?.result)
-				}}
-			/>
-		{:else}
-			<span class="text-secondary text-xs">No flow</span>
-		{/if}
-	</div>
-</div>
+{/if}

--- a/frontend/src/lib/components/apps/components/display/AppJobIdLogComponent.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppJobIdLogComponent.svelte
@@ -15,6 +15,7 @@
 	export let initializing: boolean | undefined = false
 	export let customCss: ComponentCustomCSS<'jobidlogcomponent'> | undefined = undefined
 	export let configuration: RichConfigurations
+	export let render: boolean
 
 	const { app, worldStore, workspace } = getContext<AppViewerContext>('AppViewerContext')
 
@@ -74,27 +75,29 @@
 	}}
 />
 
-<div class="flex flex-col w-full h-full component-wrapper">
-	<div
-		class={twMerge(
-			'w-full border-b p-2 text-xs font-semibold text-primary bg-surface-secondary',
-			css?.header?.class
-		)}
-		style={css?.header?.style}
-	>
-		Logs
+{#if render}
+	<div class="flex flex-col w-full h-full component-wrapper">
+		<div
+			class={twMerge(
+				'w-full border-b p-2 text-xs font-semibold text-primary bg-surface-secondary',
+				css?.header?.class
+			)}
+			style={css?.header?.style}
+		>
+			Logs
+		</div>
+		<div
+			style={css?.container?.style}
+			class={twMerge('grow overflow-auto', css?.container?.class, 'wm-log-container')}
+		>
+			<LogViewer
+				jobId={testJob?.id}
+				duration={testJob?.['duration_ms']}
+				mem={testJob?.['mem_peak']}
+				content={testJob?.logs}
+				isLoading={testIsLoading}
+				tag={testJob?.tag}
+			/>
+		</div>
 	</div>
-	<div
-		style={css?.container?.style}
-		class={twMerge('grow overflow-auto', css?.container?.class, 'wm-log-container')}
-	>
-		<LogViewer
-			jobId={testJob?.id}
-			duration={testJob?.['duration_ms']}
-			mem={testJob?.['mem_peak']}
-			content={testJob?.logs}
-			isLoading={testIsLoading}
-			tag={testJob?.tag}
-		/>
-	</div>
-</div>
+{/if}

--- a/frontend/src/lib/components/apps/components/display/AppLogsComponent.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppLogsComponent.svelte
@@ -1,86 +1,16 @@
 <script lang="ts">
-	import { getContext } from 'svelte'
-	import { twMerge } from 'tailwind-merge'
-	import { initOutput } from '../../editor/appUtils'
-	import type { AppInput } from '../../inputType'
-	import type { AppViewerContext, ComponentCustomCSS } from '../../types'
-	import RunnableWrapper from '../helpers/RunnableWrapper.svelte'
-	import { initCss } from '../../utils'
-	import LogViewer from '$lib/components/LogViewer.svelte'
-	import TestJobLoader from '$lib/components/TestJobLoader.svelte'
-	import type { Job } from '$lib/gen'
-	import ResolveStyle from '../helpers/ResolveStyle.svelte'
-
-	export let id: string
-	export let componentInput: AppInput | undefined
-	export let initializing: boolean | undefined = false
-	export let customCss: ComponentCustomCSS<'logcomponent'> | undefined = undefined
-	export let render: boolean
-
-	const { app, worldStore, workspace } = getContext<AppViewerContext>('AppViewerContext')
-
-	const outputs = initOutput($worldStore, id, {
-		result: undefined,
-		loading: false
-	})
-
-	initializing = false
-
-	let css = initCss($app.css?.logcomponent, customCss)
-	let testJobLoader: TestJobLoader | undefined = undefined
-	let testIsLoading: boolean = false
-	let testJob: Job | undefined = undefined
+	import { Alert } from '$lib/components/common'
+	import AlignWrapper from '../helpers/AlignWrapper.svelte'
 </script>
 
-<TestJobLoader
-	workspaceOverride={workspace}
-	bind:this={testJobLoader}
-	bind:isLoading={testIsLoading}
-	bind:job={testJob}
-/>
-
-{#each Object.keys(css ?? {}) as key (key)}
-	<ResolveStyle
-		{id}
-		{customCss}
-		{key}
-		bind:css={css[key]}
-		componentStyle={$app.css?.logcomponent}
-	/>
-{/each}
-
-<RunnableWrapper
-	on:started={(e) => {
-		testJobLoader?.watchJob(e.detail)
-	}}
-	{outputs}
-	{render}
-	{componentInput}
-	{id}
->
-	<div class="flex flex-col w-full h-full">
-		<div
-			class={twMerge(
-				'w-full border-b px-2 text-xs p-1 font-semibold bg-gray-500 text-white rounded-t-sm',
-				css?.header?.class,
-				'wm-log-header'
-			)}
-			style={css?.header?.style}
-		>
-			Logs
-		</div>
-		<div
-			style={css?.container?.style}
-			class={twMerge('p-2 grow overflow-auto', css?.container?.class, 'wm-log-container')}
-		>
-			<LogViewer
-				jobId={testJob?.id}
-				duration={testJob?.['duration_ms']}
-				mem={testJob?.['mem_peak']}
-				content={testJob?.logs}
-				isLoading={testIsLoading}
-				tag={testJob?.tag}
-			/>
-		</div>
-	</div>
-</RunnableWrapper>
+<AlignWrapper verticalAlignment="center" horizontalAlignment="center">
+	<Alert
+		title="Deprecated component"
+		documentationLink="https://www.windmill.dev/docs/apps/app_configuration_settings/log_display"
+		tooltip="See documentation of the new component:"
+		type="error"
+	>
+		This component is deprecated and has been removed. Please use the Log by Job Id component
+		instead.
+	</Alert>
+</AlignWrapper>

--- a/frontend/src/lib/components/apps/editor/component/Component.svelte
+++ b/frontend/src/lib/components/apps/editor/component/Component.svelte
@@ -191,29 +191,17 @@
 				{render}
 			/>
 		{:else if component.type === 'logcomponent'}
-			<AppLogsComponent
-				id={component.id}
-				customCss={component.customCss}
-				bind:initializing
-				componentInput={component.componentInput}
-				{render}
-			/>
+			<AppLogsComponent />
 		{:else if component.type === 'jobidlogcomponent'}
 			<AppJobIdLogComponent
 				id={component.id}
 				customCss={component.customCss}
 				bind:initializing
 				configuration={component.configuration}
-				componentInput={component.componentInput}
-				{render}
 			/>
 		{:else if component.type === 'flowstatuscomponent'}
 			<AppFlowStatusComponent
-				id={component.id}
-				customCss={component.customCss}
-				bind:initializing
-				componentInput={component.componentInput}
-				{render}
+				
 			/>
 		{:else if component.type === 'jobidflowstatuscomponent'}
 			<AppJobIdFlowStatus
@@ -221,8 +209,6 @@
 				customCss={component.customCss}
 				bind:initializing
 				configuration={component.configuration}
-				componentInput={component.componentInput}
-				{render}
 			/>
 		{:else if component.type === 'barchartcomponent'}
 			<AppBarChart

--- a/frontend/src/lib/components/apps/editor/component/Component.svelte
+++ b/frontend/src/lib/components/apps/editor/component/Component.svelte
@@ -198,17 +198,17 @@
 				customCss={component.customCss}
 				bind:initializing
 				configuration={component.configuration}
+				{render}
 			/>
 		{:else if component.type === 'flowstatuscomponent'}
-			<AppFlowStatusComponent
-				
-			/>
+			<AppFlowStatusComponent />
 		{:else if component.type === 'jobidflowstatuscomponent'}
 			<AppJobIdFlowStatus
 				id={component.id}
 				customCss={component.customCss}
 				bind:initializing
 				configuration={component.configuration}
+				{render}
 			/>
 		{:else if component.type === 'barchartcomponent'}
 			<AppBarChart


### PR DESCRIPTION
…component

<!--
ELLIPSIS_HIDDEN
-->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 67966aca6971d548119b62e2d8231d07953e152a  | 
|--------|--------|

### Summary:
This PR removes the `RunnableWrapper` from several components, updates event handling, and deprecates outdated components.

**Key points**:
- Removed `RunnableWrapper` from `AppFlowStatusComponent.svelte` and `AppLogsComponent.svelte`, replacing them with alerts about deprecation.
- Updated `FlowStatusViewer.svelte` and `FlowStatusViewerInner.svelte` to handle `start` and `done` events directly.
- Modified `AppJobIdFlowStatus.svelte` and `AppJobIdLogComponent.svelte` to manage job status updates and logging without `RunnableWrapper`.
- Deprecated components now show an alert directing users to updated components.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
