### PR TITLE
fix(frontend): encrypt openai key on workspace creation

### DIFF
--- a/frontend/src/routes/(root)/(logged)/user/(user)/create_workspace/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/user/(user)/create_workspace/+page.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
 	import { goto } from '$app/navigation'
-	import { ResourceService, SettingService, UserService, WorkspaceService } from '$lib/gen'
+	import {
+		ResourceService,
+		SettingService,
+		UserService,
+		VariableService,
+		WorkspaceService
+	} from '$lib/gen'
 	import { validateUsername } from '$lib/utils'
 	import { logoutWithRedirect } from '$lib/logout'
 	import { page } from '$app/stores'
@@ -70,12 +76,21 @@
 				actualUsername = user.username
 			}
 			let path = `u/${actualUsername}/openai_windmill_codegen`
+			await VariableService.createVariable({
+				workspace: id,
+				requestBody: {
+					path,
+					value: openAiKey,
+					is_secret: true,
+					description: 'Token for openai'
+				}
+			})
 			await ResourceService.createResource({
 				workspace: id,
 				requestBody: {
 					path,
 					value: {
-						api_key: openAiKey
+						api_key: '$var:' + path
 					},
 					resource_type: 'openai'
 				}


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 427175412f44bdb5464c816834bfc48751506854  | 
|--------|--------|

### Summary:
Enhances security by encrypting the OpenAI key using `VariableService` during workspace creation in `+page.svelte`.

**Key points**:
- Added `VariableService` import in `+page.svelte`.
- Created a secret variable for the OpenAI key during workspace creation.
- Replaced direct OpenAI key storage with a variable reference in resource creation.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
