### PR TITLE
fix: remove main decorator after split from end of file during py imports parsing

### DIFF
--- a/backend/parsers/windmill-parser-py-imports/src/lib.rs
+++ b/backend/parsers/windmill-parser-py-imports/src/lib.rs
@@ -55,7 +55,7 @@ static PYTHON_IMPORTS_REPLACEMENT: phf::Map<&'static str, &'static str> = phf_ma
     "github" => "PyGithub",
     "ldap" => "python-ldap",
     "opensearchpy" => "opensearch-py",
-    
+
 };
 
 fn replace_import(x: String) -> String {
@@ -111,9 +111,25 @@ pub fn parse_relative_imports(code: &str, path: &str) -> error::Result<Vec<Strin
 }
 
 fn parse_code_for_imports(code: &str, path: &str) -> error::Result<Vec<String>> {
-    let code = code.split(DEF_MAIN).next().unwrap_or("");
-    let ast = Suite::parse(code, "main.py").map_err(|e| {
-        error::Error::ExecutionErr(format!("Error parsing code: {}", e.to_string()))
+    let mut code = code.split(DEF_MAIN).next().unwrap_or("").to_string();
+
+    // remove main function decorator if it exists
+    if code
+        .lines()
+        .last()
+        .map(|x| x.starts_with("@"))
+        .unwrap_or(false)
+    {
+        code = code
+            .lines()
+            .take(code.lines().count() - 1)
+            .collect::<Vec<&str>>()
+            .join("\n")
+            + "\n";
+    }
+
+    let ast = Suite::parse(&code, "main.py").map_err(|e| {
+        error::Error::ExecutionErr(format!("Error parsing code for imports: {}", e.to_string()))
     })?;
     let nimports: Vec<String> = ast
         .into_iter()

--- a/backend/parsers/windmill-parser-py-imports/src/lib.rs
+++ b/backend/parsers/windmill-parser-py-imports/src/lib.rs
@@ -113,7 +113,7 @@ pub fn parse_relative_imports(code: &str, path: &str) -> error::Result<Vec<Strin
 fn parse_code_for_imports(code: &str, path: &str) -> error::Result<Vec<String>> {
     let mut code = code.split(DEF_MAIN).next().unwrap_or("").to_string();
 
-    // remove main function decorator if it exists
+    // remove main function decorator from end of file if it exists
     if code
         .lines()
         .last()


### PR DESCRIPTION
- **fix: remove main decorator after split from end of file during py imports parsing**
- **fix: nit**

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5da7a103f4cf4aa1f12b4f18a092b42bea267fad  | 
|--------|--------|

### Summary:
Updated `parse_code_for_imports` to remove the main function decorator from the end of the file, ensuring cleaner code parsing for Python imports.

**Key points**:
- Updated `parse_code_for_imports` in `backend/parsers/windmill-parser-py-imports/src/lib.rs` to remove main function decorator if present at EOF.
- Minor formatting fix by removing unnecessary whitespace.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->