### PR TITLE
fix(frontend): Fix Timeline/Node Status tab zIndex

### DIFF
--- a/frontend/src/lib/components/FlowStatusViewerInner.svelte
+++ b/frontend/src/lib/components/FlowStatusViewerInner.svelte
@@ -812,7 +812,7 @@
 						/>
 					</div>
 					<div
-						class="border-l border-tertiary-inverse pt-1 overflow-auto min-h-[700px] flex flex-col"
+						class="border-l border-tertiary-inverse pt-1 overflow-auto min-h-[700px] flex flex-col z-0"
 					>
 						<Tabs bind:selected={rightColumnSelect}>
 							<Tab value="timeline"><span class="font-semibold text-md">Timeline</span></Tab>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b29cb8bbaf675477a5f48b98c3be28ea02dd2fab  | 
|--------|--------|

### Summary:
Adjusted the `z-index` of the `Tabs` container in `FlowStatusViewerInner.svelte` to ensure proper UI layering.

**Key points**:
- Updated `z-index` for `Tabs` container in `FlowStatusViewerInner.svelte` to `z-0` to correct layering issues.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->