### PR TITLE
fix: frontend: add missing down arrow on cancel jobs button

### DIFF
--- a/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
@@ -618,6 +618,7 @@
 									class="mt-1 p-2 h-8 flex flex-row items-center hover:bg-surface-hover cursor-pointer rounded-md"
 								>
 									<span class="text-xs min-w-[5rem]">Cancel jobs</span>
+									<ChevronDown class="w-5 h-5" />
 								</div>
 							</svelte:fragment>
 						</DropdownV2>
@@ -902,6 +903,7 @@
 									class="mt-1 p-2 h-8 flex flex-row items-center hover:bg-surface-hover cursor-pointer rounded-md"
 								>
 									<span class="text-xs min-w-[5rem]">Cancel jobs</span>
+									<ChevronDown class="w-5 h-5" />
 								</div>
 							</svelte:fragment>
 						</DropdownV2>


### PR DESCRIPTION
For non admin users the down arrow was missing
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit eff782950bb6f3dcf7b67657863e2e05bf6b4947  | 
|--------|--------|

### Summary:
Added a missing down arrow icon to the 'Cancel jobs' button for non-admin users in the `+page.svelte` file to maintain UI consistency.

**Key points**:
- Added `<ChevronDown class="w-5 h-5" />` to 'Cancel jobs' button in `/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte` for non-admin users.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->