### PR TITLE
fix: job perms for agent mode

### DIFF
--- a/backend/windmill-queue/src/jobs.rs
+++ b/backend/windmill-queue/src/jobs.rs
@@ -3645,39 +3645,39 @@ pub async fn push<'c, R: rsmq_async::RsmqConnection + Send + 'c>(
         QUEUE_PUSH_COUNT.inc();
     }
 
-    let job_authed = match authed {
-        Some(authed)
-            if authed.email == email
-                && authed.username == permissioned_as_to_username(&permissioned_as) =>
-        {
-            authed.clone()
-        }
-        _ => {
-            if authed.is_some() {
-                tracing::warn!("Authed passed to push is not the same as permissioned_as, refetching direclty permissions for job {job_id}...")
-            }
-            fetch_authed_from_permissioned_as(
-                permissioned_as.clone(),
-                email.to_string(),
-                workspace_id,
-                _db,
-            )
-            .await
-            .map_err(|e| {
-                Error::InternalErr(format!(
-                    "Could not get permissions directly for job {job_id}: {e:#}"
-                ))
-            })?
-        }
-    };
-
-    let folders = job_authed
-        .folders
-        .iter()
-        .filter_map(|x| serde_json::to_value(x).ok())
-        .collect::<Vec<_>>();
-
     if JOB_TOKEN.is_none() {
+        let job_authed = match authed {
+            Some(authed)
+                if authed.email == email
+                    && authed.username == permissioned_as_to_username(&permissioned_as) =>
+            {
+                authed.clone()
+            }
+            _ => {
+                if authed.is_some() {
+                    tracing::warn!("Authed passed to push is not the same as permissioned_as, refetching direclty permissions for job {job_id}...")
+                }
+                fetch_authed_from_permissioned_as(
+                    permissioned_as.clone(),
+                    email.to_string(),
+                    workspace_id,
+                    _db,
+                )
+                .await
+                .map_err(|e| {
+                    Error::InternalErr(format!(
+                        "Could not get permissions directly for job {job_id}: {e:#}"
+                    ))
+                })?
+            }
+        };
+
+        let folders = job_authed
+            .folders
+            .iter()
+            .filter_map(|x| serde_json::to_value(x).ok())
+            .collect::<Vec<_>>();
+
         if let Err(err) = sqlx::query!("INSERT INTO job_perms (job_id, email, username, is_admin, is_operator, folders, groups, workspace_id) 
             values ($1, $2, $3, $4, $5, $6, $7, $8) 
             ON CONFLICT (job_id) DO UPDATE SET email = $2, username = $3, is_admin = $4, is_operator = $5, folders = $6, groups = $7, workspace_id = $8",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ce35dc7eada9e9e33274461381b796194345b1a3  | 
|--------|--------|

### Summary:
Modified `push` function in `backend/windmill-queue/src/jobs.rs` to handle job permissions accurately when `JOB_TOKEN` is `None`.

**Key points**:
- **File Modified**: `backend/windmill-queue/src/jobs.rs`
- **Function Modified**: `push`
- **Behavior Change**: When `JOB_TOKEN` is `None`, the function now fetches permissions directly if the authenticated user does not match the `permissioned_as` user.
- **Logging**: Added a warning log if the authenticated user does not match the `permissioned_as` user.
- **Error Handling**: Improved error handling for fetching permissions directly.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->