### PR TITLE
fix(frontend): fix InlineScriptEditor zIndex

### DIFF
--- a/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptEditor.svelte
@@ -299,7 +299,7 @@
 
 		<!-- {inlineScript.content} -->
 
-		<div class="border-y h-full z-[{zIndexes.monacoEditor}]">
+		<div class="border-y h-full" style="z-index: {zIndexes.monacoEditor}">
 			{#if !drawerIsOpen}
 				{#if inlineScript.language != 'frontend'}
 					<Editor

--- a/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptEditor.svelte
@@ -20,6 +20,7 @@
 	import DiffEditor from '$lib/components/DiffEditor.svelte'
 	import { userStore } from '$lib/stores'
 	import CacheTtlPopup from './CacheTtlPopup.svelte'
+	import { zIndexes } from '$lib/zIndexes'
 
 	let inlineScriptEditorDrawer: InlineScriptEditorDrawer
 
@@ -298,7 +299,7 @@
 
 		<!-- {inlineScript.content} -->
 
-		<div class="border-y h-full">
+		<div class="border-y h-full z-[{zIndexes.monacoEditor}]">
 			{#if !drawerIsOpen}
 				{#if inlineScript.language != 'frontend'}
 					<Editor


### PR DESCRIPTION
https://github.com/windmill-labs/windmill/issues/3900
![Screenshot 2024-06-18 at 11 24 58](https://github.com/windmill-labs/windmill/assets/456655/f3801a03-ba1d-420d-b8bb-5ccea8ce3e24)

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 19a597bd72c74f0f5e0215f770f86932317141a6  | 
|--------|--------|

### Summary:
Fixes z-index issue in `InlineScriptEditor` to ensure correct display order.

**Key points**:
- **File Modified**: `frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptEditor.svelte`
- **Issue Fixed**: z-index issue in `InlineScriptEditor`
- **Change**: Added `z-[{zIndexes.monacoEditor}]` class to the main editor div to ensure correct stacking order
- **Specific Line**: Modified line 302 to include the z-index class


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->