### PR TITLE
feat(frontend): Enable changing kind for string properties

### DIFF
--- a/frontend/src/lib/common.ts
+++ b/frontend/src/lib/common.ts
@@ -46,6 +46,7 @@ export interface SchemaProperty {
 	title?: string
 	placeholder?: string
 	oneOf?: SchemaProperty[]
+	originalType?: string
 }
 
 export interface ModalSchemaProperty {

--- a/frontend/src/lib/components/StringTypeNarrowing.svelte
+++ b/frontend/src/lib/components/StringTypeNarrowing.svelte
@@ -34,7 +34,6 @@
 		format
 	)
 
-	// if initially the kind is base64 or enum, then the user cannot change the kind
 	const allowKindChange = originalType === 'string'
 
 	let patternStr: string = pattern ?? ''

--- a/frontend/src/lib/components/StringTypeNarrowing.svelte
+++ b/frontend/src/lib/components/StringTypeNarrowing.svelte
@@ -24,7 +24,7 @@
 	export let noExtra = false
 	export let dateFormat: string | undefined
 	export let enumLabels: Record<string, string> = {}
-	export let allowAddingOrDeletingEnumValues: boolean = true
+	export let overrideAllowKindChange: boolean = true
 	export let originalType: string | undefined = undefined
 
 	let kind: 'none' | 'pattern' | 'enum' | 'resource' | 'format' | 'base64' = computeKind(
@@ -34,7 +34,7 @@
 		format
 	)
 
-	const allowKindChange = originalType === 'string'
+	const allowKindChange = overrideAllowKindChange || originalType === 'string'
 
 	let patternStr: string = pattern ?? ''
 	let resource: string | undefined
@@ -206,13 +206,13 @@
 							/>
 						{/if}
 
-						{#if allowAddingOrDeletingEnumValues || allowKindChange}
+						{#if allowKindChange}
 							<Button size="sm" on:click={() => remove(e)}>-</Button>
 						{/if}
 					</div>
 				{/each}
 			</div>
-			{#if allowAddingOrDeletingEnumValues || allowKindChange}
+			{#if allowKindChange}
 				<div class="flex flex-row my-1">
 					<Button color="light" size="sm" on:click={add}>+</Button>
 				</div>

--- a/frontend/src/lib/components/StringTypeNarrowing.svelte
+++ b/frontend/src/lib/components/StringTypeNarrowing.svelte
@@ -24,8 +24,8 @@
 	export let noExtra = false
 	export let dateFormat: string | undefined
 	export let enumLabels: Record<string, string> = {}
-	export let allowKindChange: boolean = true
 	export let allowAddingOrDeletingEnumValues: boolean = true
+	export let originalType: string | undefined = undefined
 
 	let kind: 'none' | 'pattern' | 'enum' | 'resource' | 'format' | 'base64' = computeKind(
 		enum_,
@@ -33,6 +33,9 @@
 		pattern,
 		format
 	)
+
+	// if initially the kind is base64 or enum, then the user cannot change the kind
+	const allowKindChange = originalType === 'string'
 
 	let patternStr: string = pattern ?? ''
 	let resource: string | undefined
@@ -204,13 +207,13 @@
 							/>
 						{/if}
 
-						{#if allowAddingOrDeletingEnumValues}
+						{#if allowAddingOrDeletingEnumValues || allowKindChange}
 							<Button size="sm" on:click={() => remove(e)}>-</Button>
 						{/if}
 					</div>
 				{/each}
 			</div>
-			{#if allowAddingOrDeletingEnumValues}
+			{#if allowAddingOrDeletingEnumValues || allowKindChange}
 				<div class="flex flex-row my-1">
 					<Button color="light" size="sm" on:click={add}>+</Button>
 				</div>

--- a/frontend/src/lib/components/schema/PropertyEditor.svelte
+++ b/frontend/src/lib/components/schema/PropertyEditor.svelte
@@ -149,7 +149,7 @@
 								bind:dateFormat={extra['dateFormat']}
 								bind:enumLabels={extra['enumLabels']}
 								originalType={extra['originalType']}
-								allowAddingOrDeletingEnumValues={isFlowInput || isAppInput}
+								overrideAllowKindChange={isFlowInput || isAppInput}
 							/>
 						{:else if type == 'number' || type == 'integer'}
 							<NumberTypeNarrowing

--- a/frontend/src/lib/components/schema/PropertyEditor.svelte
+++ b/frontend/src/lib/components/schema/PropertyEditor.svelte
@@ -148,7 +148,7 @@
 								bind:disableVariablePicker={extra['disableVariablePicker']}
 								bind:dateFormat={extra['dateFormat']}
 								bind:enumLabels={extra['enumLabels']}
-								allowKindChange={isFlowInput || isAppInput}
+								originalType={extra['originalType']}
 								allowAddingOrDeletingEnumValues={isFlowInput || isAppInput}
 							/>
 						{:else if type == 'number' || type == 'integer'}

--- a/frontend/src/lib/inferArgSig.ts
+++ b/frontend/src/lib/inferArgSig.ts
@@ -36,6 +36,7 @@ export function argSigToJsonSchemaType(
 	} else if (t === 'bytes') {
 		newS.type = 'string'
 		newS.contentEncoding = 'base64'
+		newS.originalType = 'bytes'
 	} else if (t === 'datetime') {
 		newS.type = 'string'
 		newS.format = 'date-time'
@@ -78,8 +79,10 @@ export function argSigToJsonSchemaType(
 	} else if (typeof t !== 'string' && `str` in t) {
 		newS.type = 'string'
 		if (t.str) {
+			newS.originalType = 'enum'
 			newS.enum = t.str
 		} else {
+			newS.originalType = 'string'
 			newS.enum = undefined
 		}
 	} else if (typeof t !== 'string' && `resource` in t) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 43bf9e51a22aa6be150f233936a216051c7bc637  | 
|--------|--------|

### Summary:
Enabled changing kind for string properties by adding `originalType` handling in the frontend components and logic.

**Key points**:
- **Added** `originalType` property to `SchemaProperty` in `frontend/src/lib/common.ts`.
- **Updated** `StringTypeNarrowing.svelte` to use `originalType` and `overrideAllowKindChange` for determining `allowKindChange`.
- **Modified** `PropertyEditor.svelte` to pass `originalType` and `overrideAllowKindChange` to `StringTypeNarrowing`.
- **Updated** `argSigToJsonSchemaType` function in `frontend/src/lib/inferArgSig.ts` to set `originalType` for `bytes` and `enum` types.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->