### PR TITLE
feat: add support for bytea in pg

### DIFF
--- a/backend/parsers/windmill-parser-sql/src/lib.rs
+++ b/backend/parsers/windmill-parser-sql/src/lib.rs
@@ -316,6 +316,7 @@ pub fn parse_pg_typ(typ: &str) -> Typ {
             | "timestamptz"
             | "timestamp with time zone"
             | "timestamp without time zone" => Typ::Datetime,
+            "bytea" => Typ::Bytes,
             _ => Typ::Str(None),
         }
     }

--- a/backend/parsers/windmill-parser-wasm/pkg/package.json
+++ b/backend/parsers/windmill-parser-wasm/pkg/package.json
@@ -3,7 +3,7 @@
   "collaborators": [
     "Ruben Fiszel <ruben@windmill.dev>"
   ],
-  "version": "1.345.2",
+  "version": "1.347.1",
   "files": [
     "windmill_parser_wasm_bg.wasm",
     "windmill_parser_wasm.js",

--- a/backend/parsers/windmill-parser-wasm/pkg/windmill_parser_wasm.js
+++ b/backend/parsers/windmill-parser-wasm/pkg/windmill_parser_wasm.js
@@ -584,10 +584,6 @@ async function __wbg_load(module, imports) {
 function __wbg_get_imports() {
     const imports = {};
     imports.wbg = {};
-    imports.wbg.__wbg_eval_75d97e58e74fc19b = function(arg0, arg1) {
-        const ret = eval(getStringFromWasm0(arg0, arg1));
-        return addHeapObject(ret);
-    };
     imports.wbg.__wbindgen_object_drop_ref = function(arg0) {
         takeObject(arg0);
     };
@@ -637,6 +633,10 @@ function __wbg_get_imports() {
     };
     imports.wbg.__wbindgen_error_new = function(arg0, arg1) {
         const ret = new Error(getStringFromWasm0(arg0, arg1));
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbg_eval_83a1cdd46625140c = function(arg0, arg1) {
+        const ret = eval(getStringFromWasm0(arg0, arg1));
         return addHeapObject(ret);
     };
     imports.wbg.__wbindgen_jsval_loose_eq = function(arg0, arg1) {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -52,7 +52,7 @@
 				"vscode-languageclient": "~9.0.1",
 				"vscode-uri": "~3.0.8",
 				"vscode-ws-jsonrpc": "~3.1.0",
-				"windmill-parser-wasm": "^1.345.2",
+				"windmill-parser-wasm": "^1.347.1",
 				"windmill-sql-datatype-parser-wasm": "^1.318.0",
 				"y-monaco": "^0.1.4",
 				"y-websocket": "^1.5.0",
@@ -10261,9 +10261,9 @@
 			}
 		},
 		"node_modules/windmill-parser-wasm": {
-			"version": "1.345.2",
-			"resolved": "https://registry.npmjs.org/windmill-parser-wasm/-/windmill-parser-wasm-1.345.2.tgz",
-			"integrity": "sha512-JTAx5zOZgJG/anZ+YZAD7MtWKcr29don0SOrsAHRUenmAtysUqxFYx1dHXJIilU0SxaSeeGblaTTiPHypAIJVw=="
+			"version": "1.347.1",
+			"resolved": "https://registry.npmjs.org/windmill-parser-wasm/-/windmill-parser-wasm-1.347.1.tgz",
+			"integrity": "sha512-0ErA/2Wz+KLEDf4iQqBvtp5FDz2LU2oO3W0MYli67x0OhLVRh2PVr4G39rn2lCRNc3n5RU1HW6qMgBoBy+4yig=="
 		},
 		"node_modules/windmill-sql-datatype-parser-wasm": {
 			"version": "1.318.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -132,7 +132,7 @@
 		"vscode-languageclient": "~9.0.1",
 		"vscode-uri": "~3.0.8",
 		"vscode-ws-jsonrpc": "~3.1.0",
-		"windmill-parser-wasm": "^1.345.2",
+		"windmill-parser-wasm": "^1.347.1",
 		"windmill-sql-datatype-parser-wasm": "^1.318.0",
 		"y-monaco": "^0.1.4",
 		"y-websocket": "^1.5.0",

--- a/frontend/src/lib/consts.ts
+++ b/frontend/src/lib/consts.ts
@@ -81,7 +81,9 @@ export const POSTGRES_TYPES = [
 	'JSON',
 	'JSON[]',
 	'JSONB',
-	'JSONB[]'
+	'JSONB[]',
+	'BYTEA',
+	'BYTEA[]'
 ]
 
 export const MYSQL_TYPES = [


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 291f4cd707a26f2494136d85522874a4b11e11c6  | 
|--------|--------|

### Summary:
Added support for PostgreSQL `bytea` type, including parsing, conversion, JSON serialization, and updated package versions.

**Key points**:
- Added support for PostgreSQL `bytea` type in `backend/parsers/windmill-parser-sql/src/lib.rs` by mapping `bytea` to `Typ::Bytes` in `parse_pg_typ` function.
- Updated `PgType` enum in `backend/windmill-worker/src/pg_executor.rs` to include `Bytea(Vec<u8>)`.
- Modified `convert_val` function in `backend/windmill-worker/src/pg_executor.rs` to handle `bytea` type by decoding base64 strings.
- Updated `pg_cell_to_json_value` function in `backend/windmill-worker/src/pg_executor.rs` to convert `bytea` type to JSON string with hex encoding.
- Updated `package.json` files in `backend/parsers/windmill-parser-wasm/pkg` and `frontend` to version `1.347.1`.
- Modified `POSTGRES_TYPES` array in `frontend/src/lib/consts.ts` to include `BYTEA` and `BYTEA[]`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->