### PR TITLE
Correctly initialize the flowInputStore for picked scr…

### DIFF
--- a/frontend/src/lib/components/flows/content/FlowModuleWrapper.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleWrapper.svelte
@@ -62,6 +62,15 @@
 
 		flowModule = module
 		$flowStateStore[module.id] = state
+
+		if ($flowInputsStore) {
+			$flowInputsStore[module.id] = {
+				requiredInputsFilled: initRequiredInputFilled(
+					module.value,
+					$flowStateStore[module.id].schema
+				)
+			}
+		}
 	}
 </script>
 

--- a/frontend/src/lib/components/flows/content/FlowModuleWrapper.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleWrapper.svelte
@@ -64,10 +64,10 @@
 		$flowStateStore[module.id] = state
 
 		if ($flowInputsStore) {
-			$flowInputsStore[module.id] = {
+			$flowInputsStore[module?.id] = {
 				requiredInputsFilled: initRequiredInputFilled(
-					module.value,
-					$flowStateStore[module.id].schema
+					module?.value,
+					$flowStateStore[module?.id]?.schema
 				)
 			}
 		}


### PR DESCRIPTION
…ipts/flows
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2b4396bf7dbd707b9a6e356788e3d855fb559eb8  | 
|--------|--------|

### Summary:
Fixes initialization of `flowInputsStore` for picked scripts/flows in `FlowModuleWrapper.svelte`.

**Key points**:
- **File Modified**: `frontend/src/lib/components/flows/content/FlowModuleWrapper.svelte`
- **Function Modified**: `createModuleFromScript`
- **Change**: Added initialization of `flowInputsStore` with `requiredInputsFilled` for picked scripts/flows.
- **Details**: When a module is picked, `flowInputsStore[module.id]` is set with `requiredInputsFilled` using `initRequiredInputFilled` function.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->