### PR TITLE
feat: fallback to default hub if official script not found on private hub

### DIFF
--- a/frontend/src/lib/components/instanceSettings.ts
+++ b/frontend/src/lib/components/instanceSettings.ts
@@ -131,7 +131,8 @@ export const settings: Record<string, Setting[]> = {
 		},
 		{
 			label: 'Private hub base url',
-			description: 'Base url of your private hub instance',
+			description: 'Base url of your private hub instance, without trailing slash',
+			placeholder: 'https://hub.company.com',
 			key: 'hub_base_url',
 			fieldType: 'text',
 			storage: 'setting',


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 231be684904280f4a69b7b5cd1deb586da165c91  | 
|--------|--------|

### Summary:
Add fallback to default hub if the script is not found on the private hub.

**Key points**:
- **Backend**: Updated `get_hub_script_by_path` and `get_full_hub_script_by_path` in `backend/windmill-common/src/scripts.rs` to fallback to `DEFAULT_HUB_BASE_URL` if the script is not found on `HUB_BASE_URL`.
- **Frontend**: Updated the description and added a placeholder for the `hub_base_url` setting in `frontend/src/lib/components/instanceSettings.ts`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->