### PR TITLE
cleanup graphql parser code

### DIFF
--- a/backend/parsers/windmill-parser-graphql/src/lib.rs
+++ b/backend/parsers/windmill-parser-graphql/src/lib.rs
@@ -7,55 +7,58 @@ use serde_json::json;
 use windmill_parser::{Arg, MainArgSignature, Typ};
 
 pub fn parse_graphql_sig(code: &str) -> anyhow::Result<MainArgSignature> {
-    parse_graphql_file(&code)
-        .map(|args| MainArgSignature {
-            star_args: false,
-            star_kwargs: false,
-            args,
-            no_main_func: None,
+    parse_graphql_file(&code)?
+        .map(|args| {
+            Ok(MainArgSignature { star_args: false, star_kwargs: false, args, no_main_func: None })
         })
-        .ok_or_else(|| anyhow!("Error parsing sql".to_string()))
+        .ok_or_else(|| anyhow!("Error parsing gql".to_string()))?
 }
 
 lazy_static::lazy_static! {
     static ref RE_ARG_GRAPHQL: Regex = Regex::new(r#"\$(\w+)\s*:\s*(?:(\w+)!?|\[(\w+)!?\])!?\s*(?:=\s*(\w+)\s*)?"#).unwrap();
 }
 
-fn parse_graphql_file(code: &str) -> Option<Vec<Arg>> {
+///Extracts captured groups into tuple of $i elements
+macro_rules! extract_captures {
+    ($cap:expr, $( $i:expr ),* ) => {
+        (
+            $( $cap.get($i).map(|m| m.as_str().to_string()) ),*
+        )
+    };
+}
+
+fn parse_graphql_file(code: &str) -> anyhow::Result<Option<Vec<Arg>>> {
     RE_ARG_GRAPHQL
         .captures_iter(code)
-        .filter_map(|cap| Some(parse_arg_cap(cap)))
+        .map(parse_captures)
         .collect()
 }
-fn parse_arg_cap(cap: regex::Captures) -> Option<Arg> {
-    let mut typ = cap.get(2).map(|x| x.as_str().to_string());
+
+fn parse_captures(cap: regex::Captures) -> anyhow::Result<Option<Arg>> {
+    let (name, mut typ, typ3, default) = extract_captures!(&cap, 1, 2, 3, 4);
+
     let parsed_typ = match typ {
         Some(ref t) => parse_graphql_typ(t),
         None => {
-            typ = cap.get(3).map(|x| format!("[{}]", x.as_str()));
+            typ = typ3;
             Typ::List(Box::new(parse_graphql_typ(typ.as_ref().unwrap())))
         }
     };
 
-    let default = cap.get(4).map(|x| x.as_str().to_string());
     let has_default = default.is_some();
-
     let parsed_default = default.and_then(|x| match parsed_typ {
         Typ::Int => x.parse::<i64>().ok().map(|x| json!(x)),
         Typ::Float => x.parse::<f64>().ok().map(|x| json!(x)),
         _ => Some(json!(x)),
     });
 
-    Some(Arg {
-        name: cap
-            .get(1)
-            .map(|x| x.as_str().to_string())
-            .expect("Failed to capture 'name'"),
+    Ok(Some(Arg {
+        name: name.expect("Failed to capture 'name'"),
         typ: parsed_typ,
         default: parsed_default,
         otyp: typ,
         has_default,
-    })
+    }))
 }
 
 pub fn parse_graphql_typ(typ: &str) -> Typ {

--- a/backend/parsers/windmill-parser-graphql/src/lib.rs
+++ b/backend/parsers/windmill-parser-graphql/src/lib.rs
@@ -7,13 +7,14 @@ use serde_json::json;
 use windmill_parser::{Arg, MainArgSignature, Typ};
 
 pub fn parse_graphql_sig(code: &str) -> anyhow::Result<MainArgSignature> {
-    let parsed = parse_graphql_file(&code);
-    if let Some(x) = parsed {
-        let args = x;
-        Ok(MainArgSignature { star_args: false, star_kwargs: false, args, no_main_func: None })
-    } else {
-        Err(anyhow!("Error parsing sql".to_string()))
-    }
+    parse_graphql_file(&code)
+        .map(|args| MainArgSignature {
+            star_args: false,
+            star_kwargs: false,
+            args,
+            no_main_func: None,
+        })
+        .ok_or_else(|| anyhow!("Error parsing sql".to_string()))
 }
 
 lazy_static::lazy_static! {
@@ -23,36 +24,38 @@ lazy_static::lazy_static! {
 fn parse_graphql_file(code: &str) -> Option<Vec<Arg>> {
     RE_ARG_GRAPHQL
         .captures_iter(code)
-        .fold(Some(Vec::new()), |acc, cap| {
-            acc.and_then(|mut vec| {
-                let mut typ = cap.get(2).map(|x| x.as_str().to_string());
-                let parsed_typ = match typ {
-                    Some(ref t) => parse_graphql_typ(t),
-                    None => {
-                        typ = cap.get(3).map(|x| format!("[{}]", x.as_str()));
-                        Typ::List(Box::new(parse_graphql_typ(typ.as_ref().unwrap())))
-                    }
-                };
+        .filter_map(|cap| Some(parse_arg_cap(cap)))
+        .collect()
+}
+fn parse_arg_cap(cap: regex::Captures) -> Option<Arg> {
+    let mut typ = cap.get(2).map(|x| x.as_str().to_string());
+    let parsed_typ = match typ {
+        Some(ref t) => parse_graphql_typ(t),
+        None => {
+            typ = cap.get(3).map(|x| format!("[{}]", x.as_str()));
+            Typ::List(Box::new(parse_graphql_typ(typ.as_ref().unwrap())))
+        }
+    };
 
-                let default = cap.get(4).map(|x| x.as_str().to_string());
-                let has_default = default.is_some();
+    let default = cap.get(4).map(|x| x.as_str().to_string());
+    let has_default = default.is_some();
 
-                let parsed_default = default.and_then(|x| match parsed_typ {
-                    Typ::Int => x.parse::<i64>().ok().map(|x| json!(x)),
-                    Typ::Float => x.parse::<f64>().ok().map(|x| json!(x)),
-                    _ => Some(json!(x)),
-                });
-                vec.push(Arg {
-                    name: cap.get(1).map(|x| x.as_str().to_string()).unwrap(),
-                    typ: parsed_typ,
-                    default: parsed_default,
-                    otyp: typ,
-                    has_default,
-                });
+    let parsed_default = default.and_then(|x| match parsed_typ {
+        Typ::Int => x.parse::<i64>().ok().map(|x| json!(x)),
+        Typ::Float => x.parse::<f64>().ok().map(|x| json!(x)),
+        _ => Some(json!(x)),
+    });
 
-                Some(vec)
-            })
-        })
+    Some(Arg {
+        name: cap
+            .get(1)
+            .map(|x| x.as_str().to_string())
+            .expect("Failed to capture 'name'"),
+        typ: parsed_typ,
+        default: parsed_default,
+        otyp: typ,
+        has_default,
+    })
 }
 
 pub fn parse_graphql_typ(typ: &str) -> Typ {

--- a/backend/parsers/windmill-parser-graphql/src/lib.rs
+++ b/backend/parsers/windmill-parser-graphql/src/lib.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 use windmill_parser::{Arg, MainArgSignature, Typ};
 
 pub fn parse_graphql_sig(code: &str) -> anyhow::Result<MainArgSignature> {
-    let parsed = parse_graphql_file(&code)?;
+    let parsed = parse_graphql_file(&code);
     if let Some(x) = parsed {
         let args = x;
         Ok(MainArgSignature { star_args: false, star_kwargs: false, args, no_main_func: None })
@@ -20,40 +20,39 @@ lazy_static::lazy_static! {
     static ref RE_ARG_GRAPHQL: Regex = Regex::new(r#"\$(\w+)\s*:\s*(?:(\w+)!?|\[(\w+)!?\])!?\s*(?:=\s*(\w+)\s*)?"#).unwrap();
 }
 
-fn parse_graphql_file(code: &str) -> anyhow::Result<Option<Vec<Arg>>> {
-    let mut args: Vec<Arg> = vec![];
+fn parse_graphql_file(code: &str) -> Option<Vec<Arg>> {
+    RE_ARG_GRAPHQL
+        .captures_iter(code)
+        .fold(Some(Vec::new()), |acc, cap| {
+            acc.and_then(|mut vec| {
+                let mut typ = cap.get(2).map(|x| x.as_str().to_string());
+                let parsed_typ = match typ {
+                    Some(ref t) => parse_graphql_typ(t),
+                    None => {
+                        typ = cap.get(3).map(|x| format!("[{}]", x.as_str()));
+                        Typ::List(Box::new(parse_graphql_typ(typ.as_ref().unwrap())))
+                    }
+                };
 
-    for cap in RE_ARG_GRAPHQL.captures_iter(code) {
-        let name = cap.get(1).map(|x| x.as_str().to_string()).unwrap();
-        let mut typ = cap.get(2).map(|x| x.as_str().to_string());
+                let default = cap.get(4).map(|x| x.as_str().to_string());
+                let has_default = default.is_some();
 
-        let parsed_typ = if typ.is_none() {
-            let inner_typ = cap.get(3).map(|x| x.as_str().to_string());
-            typ = inner_typ.clone().map(|x| format!("[{}]", x.to_string()));
-            Typ::List(Box::new(parse_graphql_typ(inner_typ.unwrap().as_str())))
-        } else {
-            parse_graphql_typ(typ.clone().unwrap().as_str())
-        };
+                let parsed_default = default.and_then(|x| match parsed_typ {
+                    Typ::Int => x.parse::<i64>().ok().map(|x| json!(x)),
+                    Typ::Float => x.parse::<f64>().ok().map(|x| json!(x)),
+                    _ => Some(json!(x)),
+                });
+                vec.push(Arg {
+                    name: cap.get(1).map(|x| x.as_str().to_string()).unwrap(),
+                    typ: parsed_typ,
+                    default: parsed_default,
+                    otyp: typ,
+                    has_default,
+                });
 
-        let default = cap.get(4).map(|x| x.as_str().to_string());
-
-        let has_default = default.is_some();
-
-        let parsed_default = default.and_then(|x| match parsed_typ {
-            Typ::Int => x.parse::<i64>().ok().map(|x| json!(x)),
-            Typ::Float => x.parse::<f64>().ok().map(|x| json!(x)),
-            _ => Some(json!(x)),
-        });
-        args.push(Arg {
-            name,
-            typ: parsed_typ,
-            default: parsed_default,
-            otyp: Some(typ.unwrap()),
-            has_default,
-        });
-    }
-
-    Ok(Some(args))
+                Some(vec)
+            })
+        })
 }
 
 pub fn parse_graphql_typ(typ: &str) -> Typ {


### PR DESCRIPTION
minor cleanup
- updated fn parse_graphql_file() 
- removed direct cloning. 
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1622db3507e1c44d0f23b27cbb71c8cf229cd1fa  | 
|--------|--------|

### Summary:
Refactored `parse_graphql_file` function to remove unnecessary cloning and simplify logic in `backend/parsers/windmill-parser-graphql/src/lib.rs`.

**Key points**:
- Updated `parse_graphql_file` function in `backend/parsers/windmill-parser-graphql/src/lib.rs`
- Removed unnecessary cloning of strings
- Simplified the logic for parsing GraphQL types and defaults
- Adjusted `parse_graphql_sig` to handle the updated `parse_graphql_file` return type


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->