### PR TITLE
feat(frontend): add an indicator when a for loop has no iterator expr…

### DIFF
--- a/frontend/src/lib/components/flows/content/FlowModuleHeader.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleHeader.svelte
@@ -62,7 +62,7 @@
 		{#if module.cache_ttl != undefined}
 			<Popover
 				placement="bottom"
-				class="center-center rounded p-2 'bg-blue-100 text-blue-800 border border-blue-300 hover:bg-blue-200 dark:bg-frost-700 dark:text-frost-100 dark:border-frost-600"
+				class="center-center rounded p-2 bg-blue-100 text-blue-800 border border-blue-300 hover:bg-blue-200 dark:bg-frost-700 dark:text-frost-100 dark:border-frost-600"
 				on:click={() => dispatch('toggleCache')}
 			>
 				<Database size={14} />
@@ -92,8 +92,7 @@
 		{#if module.sleep}
 			<Popover
 				placement="bottom"
-				class="center-center rounded p-2bg-blue-100 text-blue-800 border border-blue-300 hover:bg-blue-200
-				dark:bg-frost-700 dark:text-frost-100 dark:border-frost-600"
+				class="center-center rounded p-2 bg-blue-100 text-blue-800 border border-blue-300 hover:bg-blue-200 dark:bg-frost-700 dark:text-frost-100 dark:border-frost-600"
 				on:click={() => dispatch('toggleSleep')}
 			>
 				<Bed size={14} />
@@ -103,7 +102,7 @@
 		{#if module.mock?.enabled}
 			<Popover
 				placement="bottom"
-				class="center-center rounded p-2 bg-blue-100  text-blue-800 border border-blue-300 hover:bg-blue-200"
+				class="center-center rounded p-2 bg-blue-100 text-blue-800 border border-blue-300 hover:bg-blue-200 dark:bg-frost-700 dark:text-frost-100 dark:border-frost-600"
 				on:click={() => dispatch('toggleMock')}
 			>
 				<Voicemail size={14} />

--- a/frontend/src/lib/components/flows/map/FlowModuleSchemaItem.svelte
+++ b/frontend/src/lib/components/flows/map/FlowModuleSchemaItem.svelte
@@ -35,6 +35,7 @@
 	export let bgColor: string = ''
 	export let concurrency: boolean = false
 	export let retries: number | undefined = undefined
+	export let warningMessage: string | undefined = undefined
 
 	const { flowInputsStore } = getContext<{ flowInputsStore: Writable<FlowInput | undefined> }>(
 		'FlowGraphContext'
@@ -174,10 +175,12 @@ hover:border-blue-700 {selected ? '' : '!hidden'}"
 			<Move class="mx-[3px]" size={14} strokeWidth={2} />
 		</button>
 
-		{#if id && !Object.values($flowInputsStore?.[id]?.requiredInputsFilled || {}).every(Boolean)}
+		{#if (id && !Object.values($flowInputsStore?.[id]?.requiredInputsFilled || {}).every(Boolean)) || Boolean(warningMessage)}
 			<div class="absolute -top-[10px] -left-[10px]">
 				<Popover>
-					<svelte:fragment slot="text">At least one required input is not set.</svelte:fragment>
+					<svelte:fragment slot="text"
+						>{warningMessage ?? 'At least one required input is not set.'}
+					</svelte:fragment>
 					<div
 						class="flex items-center justify-center h-full w-full rounded-md p-0.5 border border-yellow-600 text-yellow-600 bg-yellow-100 duration-150 hover:bg-yellow-300"
 					>

--- a/frontend/src/lib/components/flows/map/MapItem.svelte
+++ b/frontend/src/lib/components/flows/map/MapItem.svelte
@@ -138,6 +138,11 @@
 					on:click={() => dispatch('select', mod.id)}
 					{...itemProps}
 					{bgColor}
+					warningMessage={mod?.value?.type === 'forloopflow' &&
+					mod?.value?.iterator?.type === 'javascript' &&
+					mod?.value?.iterator?.expr === ''
+						? 'Iterator expression is empty'
+						: ''}
 				>
 					<div slot="icon">
 						<Repeat size={16} />


### PR DESCRIPTION
New indicator:
![Screenshot 2024-06-24 at 14 36 18](https://github.com/windmill-labs/windmill/assets/456655/02b2d47b-a6a0-47bd-ae26-51c885f94e6e)
…ession

Fix the advanced settings indicators (not consistent):
Now:
![Screenshot 2024-06-24 at 14 36 39](https://github.com/windmill-labs/windmill/assets/456655/60fde0a3-3634-41ce-be65-d6adbad030b2)
Before:
![Screenshot 2024-06-24 at 14 37 04](https://github.com/windmill-labs/windmill/assets/456655/bb3ac0c0-055c-4102-aa4a-493617204725)

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b6934e400c857ac3e11c3c98ff056862be8064b6  | 
|--------|--------|

### Summary:
Added a warning indicator for for-loops without an iterator expression and fixed styling inconsistencies in advanced settings indicators.

**Key points**:
- Added warning indicator for for-loops without an iterator expression in `frontend/src/lib/components/flows/map/FlowModuleSchemaItem.svelte` and `frontend/src/lib/components/flows/map/MapItem.svelte`.
- Fixed styling inconsistencies in advanced settings indicators in `frontend/src/lib/components/flows/content/FlowModuleHeader.svelte`.
- Updated `FlowModuleSchemaItem` to accept a `warningMessage` prop and display it conditionally.
- Modified `MapItem` to pass the appropriate `warningMessage` to `FlowModuleSchemaItem` based on module type and state.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->