### PR TITLE
fix(frontend): Add missing on change event when connecting an input

### DIFF
--- a/frontend/src/lib/components/InputTransformForm.svelte
+++ b/frontend/src/lib/components/InputTransformForm.svelte
@@ -329,6 +329,7 @@
 						on:click={() => {
 							focusProp(argName, 'connect', (path) => {
 								connectProperty(path)
+								dispatch('change', { argName })
 								return true
 							})
 						}}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8133078abed9a370a306954a21f546a6e66c1564  | 
|--------|--------|

### Summary:
Adds missing 'change' event dispatch when connecting an input property in `InputTransformForm.svelte`.

**Key points**:
- **File Modified**: `frontend/src/lib/components/InputTransformForm.svelte`
- **Function Modified**: `connectProperty`
- **Change**: Added `dispatch('change', { argName })` to the `on:click` event handler for the connect button.
- **Behavior**: Ensures 'change' event is dispatched when connecting an input property.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->