### PR TITLE
feat: schedule pausing

### DIFF
--- a/backend/.sqlx/query-4422b7183ede17a9cbde4afae41be4da5447020e39398deedbcca9121492834a.json
+++ b/backend/.sqlx/query-4422b7183ede17a9cbde4afae41be4da5447020e39398deedbcca9121492834a.json
@@ -130,6 +130,11 @@
       },
       {
         "ordinal": 25,
+        "name": "paused_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 26,
         "name": "jobs",
         "type_info": "JsonArray"
       }
@@ -166,6 +171,7 @@
       true,
       true,
       false,
+      true,
       true,
       null
     ]

--- a/backend/.sqlx/query-f9fed1aa8a4bbf1749da8c91b9cbae5605cd3ae7fd2e7ee774411971fa1ddc01.json
+++ b/backend/.sqlx/query-f9fed1aa8a4bbf1749da8c91b9cbae5605cd3ae7fd2e7ee774411971fa1ddc01.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE schedule SET paused_until = NULL WHERE workspace_id = $1 AND path = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f9fed1aa8a4bbf1749da8c91b9cbae5605cd3ae7fd2e7ee774411971fa1ddc01"
+}

--- a/backend/migrations/20240625171454_schedule_pausing.down.sql
+++ b/backend/migrations/20240625171454_schedule_pausing.down.sql
@@ -1,0 +1,1 @@
+-- Add down migration script here

--- a/backend/migrations/20240625171454_schedule_pausing.up.sql
+++ b/backend/migrations/20240625171454_schedule_pausing.up.sql
@@ -1,0 +1,2 @@
+-- Add up migration script here
+alter table schedule add column paused_until timestamptz;

--- a/backend/tests/worker.rs
+++ b/backend/tests/worker.rs
@@ -2938,6 +2938,7 @@ async fn test_script_schedule_handlers(db: Pool<Postgres>) {
         no_flow_overlap: None,
         summary: None,
         tag: None,
+        paused_until: None,
     };
 
     let _ = client.create_schedule("test-workspace", &schedule).await;
@@ -3002,6 +3003,7 @@ async fn test_script_schedule_handlers(db: Pool<Postgres>) {
                 summary: None,
                 no_flow_overlap: None,
                 tag: None,
+                paused_until: None,
             },
         )
         .await
@@ -3081,6 +3083,7 @@ async fn test_flow_schedule_handlers(db: Pool<Postgres>) {
         no_flow_overlap: None,
         summary: None,
         tag: None,
+        paused_until: None,
     };
 
     let _ = client.create_schedule("test-workspace", &schedule).await;
@@ -3146,6 +3149,7 @@ async fn test_flow_schedule_handlers(db: Pool<Postgres>) {
                 summary: None,
                 no_flow_overlap: None,
                 tag: None,
+                paused_until: None,
             },
         )
         .await

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -9988,6 +9988,9 @@ components:
           type: boolean
         tag:
           type: string
+        paused_until:
+          type: string
+          format: date-time
       required:
         - path
         - edited_by
@@ -10063,6 +10066,9 @@ components:
           type: string
         tag:
           type: string
+        paused_until:
+          type: string
+          format: date-time
       required:
         - path
         - schedule
@@ -10105,6 +10111,9 @@ components:
           type: string
         tag:
           type: string
+        paused_until:
+          type: string
+          format: date-time
       required:
         - schedule
         - timezone

--- a/backend/windmill-common/src/schedule.rs
+++ b/backend/windmill-common/src/schedule.rs
@@ -51,6 +51,8 @@ pub struct Schedule {
     pub summary: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub paused_until: Option<DateTime<chrono::Utc>>,
 }
 
 impl Schedule {

--- a/backend/windmill-queue/src/schedule.rs
+++ b/backend/windmill-queue/src/schedule.rs
@@ -9,6 +9,7 @@
 use crate::push;
 use crate::PushIsolationLevel;
 use crate::QueueTransaction;
+use anyhow::Context;
 use sqlx::{query_scalar, Postgres, Transaction};
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -36,10 +37,27 @@ pub async fn push_scheduled_job<'c, R: rsmq_async::RsmqConnection + Send + 'c>(
     let tz = chrono_tz::Tz::from_str(&schedule.timezone)
         .map_err(|e| error::Error::BadRequest(e.to_string()))?;
 
-    let now = now_from_db(&mut tx).await?.with_timezone(&tz);
+    let now = now_from_db(&mut tx).await?;
+
+    let starting_from = match schedule.paused_until {
+        Some(paused_until) if paused_until > now => paused_until.with_timezone(&tz),
+        paused_until_o => {
+            if paused_until_o.is_some() {
+                sqlx::query!(
+                    "UPDATE schedule SET paused_until = NULL WHERE workspace_id = $1 AND path = $2",
+                    &schedule.workspace_id,
+                    &schedule.path
+                )
+                .execute(&mut tx)
+                .await
+                .context("Failed to clear paused_until for schedule")?;
+            }
+            now.with_timezone(&tz)
+        }
+    };
 
     let next = sched
-        .after(&now)
+        .after(&starting_from)
         .next()
         .expect("a schedule should have a next event");
 

--- a/frontend/src/lib/components/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/ScheduleEditorInner.svelte
@@ -81,6 +81,8 @@
 		runnable = undefined
 		is_flow = nis_flow
 		schedule = '0 0 12 * *'
+		paused_until = undefined
+		showPauseUntil = false
 		let defaultErrorHandlerMaybe = undefined
 		let defaultRecoveryHandlerMaybe = undefined
 		if ($workspaceStore) {
@@ -251,6 +253,7 @@
 			schedule = s.schedule
 			timezone = s.timezone
 			paused_until = s.paused_until
+			showPauseUntil = paused_until !== undefined
 			summary = s.summary ?? ''
 			script_path = s.script_path ?? ''
 			await loadScript(script_path)
@@ -396,6 +399,9 @@
 
 	let pathC: Path
 	let dirtyPath = false
+
+	let showPauseUntil = false
+	$: !showPauseUntil && (paused_until = undefined)
 </script>
 
 <Drawer size="900px" bind:this={drawer}>
@@ -513,18 +519,14 @@
 					<Tooltip>Schedules use CRON syntax. Seconds are mandatory.</Tooltip>
 				</svelte:fragment>
 				<CronInput disabled={!can_write} bind:schedule bind:timezone bind:validCRON />
-				<Label label="Pause until">
-					<div class="flex flex-row gap-1">
-						<DateTimeInput bind:value={paused_until} />
-						<Button
-							size="xs"
-							color="light"
-							on:click={() => {
-								paused_until = undefined
-							}}>Reset</Button
-						>
-					</div>
-				</Label>
+				<Toggle
+					options={{ right: 'Pause schedule until...' }}
+					bind:checked={showPauseUntil}
+					size="xs"
+				/>
+				{#if showPauseUntil}
+					<DateTimeInput bind:value={paused_until} />
+				{/if}
 			</Section>
 			<Section label="Runnable">
 				{#if !edit}

--- a/frontend/src/lib/components/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/ScheduleEditorInner.svelte
@@ -28,6 +28,7 @@
 	import FlowRetries from './flows/content/FlowRetries.svelte'
 	import WorkerTagPicker from './WorkerTagPicker.svelte'
 	import Label from './Label.svelte'
+	import DateTimeInput from './DateTimeInput.svelte'
 
 	let optionTabSelected: 'error_handler' | 'recovery_handler' | 'retries' = 'error_handler'
 
@@ -36,6 +37,7 @@
 	let edit = true
 	let schedule: string = '0 0 12 * *'
 	let timezone: string = Intl.DateTimeFormat().resolvedOptions().timeZone
+	let paused_until: string | undefined = undefined
 
 	let itemKind: 'flow' | 'script' = 'script'
 	let errorHandleritemKind: 'flow' | 'script' = 'script'
@@ -248,6 +250,7 @@
 			enabled = s.enabled
 			schedule = s.schedule
 			timezone = s.timezone
+			paused_until = s.paused_until
 			summary = s.summary ?? ''
 			script_path = s.script_path ?? ''
 			await loadScript(script_path)
@@ -329,7 +332,8 @@
 					retry: retry,
 					summary: summary != '' ? summary : undefined,
 					no_flow_overlap: no_flow_overlap,
-					tag: tag
+					tag: tag,
+					paused_until: paused_until
 				}
 			})
 			sendUserToast(`Schedule ${path} updated`)
@@ -357,7 +361,8 @@
 					retry: retry,
 					summary: summary != '' ? summary : undefined,
 					no_flow_overlap: no_flow_overlap,
-					tag: tag
+					tag: tag,
+					paused_until: paused_until
 				}
 			})
 			sendUserToast(`Schedule ${path} created`)
@@ -508,6 +513,18 @@
 					<Tooltip>Schedules use CRON syntax. Seconds are mandatory.</Tooltip>
 				</svelte:fragment>
 				<CronInput disabled={!can_write} bind:schedule bind:timezone bind:validCRON />
+				<Label label="Pause until">
+					<div class="flex flex-row gap-1">
+						<DateTimeInput bind:value={paused_until} />
+						<Button
+							size="xs"
+							color="light"
+							on:click={() => {
+								paused_until = undefined
+							}}>Reset</Button
+						>
+					</div>
+				</Label>
 			</Section>
 			<Section label="Runnable">
 				{#if !edit}

--- a/frontend/src/routes/(root)/(logged)/schedules/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/schedules/+page.svelte
@@ -325,7 +325,7 @@
 								</div>
 							</a>
 
-							{#if paused_until}
+							{#if paused_until && new Date(paused_until) > new Date()}
 								<div class="pb-1">
 									<Badge color="yellow"
 										>Paused until {new Date(paused_until).toLocaleString()}</Badge

--- a/frontend/src/routes/(root)/(logged)/schedules/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/schedules/+page.svelte
@@ -127,7 +127,7 @@
 	let filterEnabledDisabled: 'all' | 'enabled' | 'disabled' = 'all'
 
 	const SCHEDULE_PATH_KIND_FILTER_SETTING = 'schedulePathKindFilter'
-	const FILTER_USER_FOLDER_SETTING_NAME = 'filterUserFolders'
+	const FILTER_USER_FOLDER_SETTING_NAME = 'user_and_folders_only'
 	let selectedFilterKind =
 		(getLocalSetting(SCHEDULE_PATH_KIND_FILTER_SETTING) as 'schedule' | 'script_flow') ?? 'schedule'
 	let filterUserFolders = getLocalSetting(FILTER_USER_FOLDER_SETTING_NAME) == 'true'
@@ -203,20 +203,22 @@
 	$: items = filter !== '' ? filteredItems : preFilteredItems
 
 	function updateQueryFilters(selectedFilterKind, filterUserFolders, filterEnabledDisabled) {
-		setQuery(new URL(window.location.href), 'scheduleFilterKind', selectedFilterKind).then(() => {
-			setQuery(new URL(window.location.href), 'filterUserFolders', String(filterUserFolders)).then(
-				() => {
-					setQuery(new URL(window.location.href), 'filterEnabledDisabled', filterEnabledDisabled)
-				}
-			)
+		setQuery(new URL(window.location.href), 'filter_kind', selectedFilterKind).then(() => {
+			setQuery(
+				new URL(window.location.href),
+				'user_and_folders_only',
+				String(filterUserFolders)
+			).then(() => {
+				setQuery(new URL(window.location.href), 'status', filterEnabledDisabled)
+			})
 		})
 	}
 
 	function loadQueryFilters() {
 		let url = new URL(window.location.href)
-		let queryFilterKind = url.searchParams.get('scheduleFilterKind')
-		let queryFilterUserFolders = url.searchParams.get('filterUserFolders')
-		let queryFilterEnabledDisabled = url.searchParams.get('filterEnabledDisabled')
+		let queryFilterKind = url.searchParams.get('filter_kind')
+		let queryFilterUserFolders = url.searchParams.get('user_and_folders_only')
+		let queryFilterEnabledDisabled = url.searchParams.get('status')
 		if (queryFilterKind) {
 			selectedFilterKind = queryFilterKind as 'schedule' | 'script_flow'
 		}
@@ -291,7 +293,7 @@
 			<div class="text-center text-sm text-tertiary mt-2"> No schedules </div>
 		{:else if items?.length}
 			<div class="border rounded-md divide-y">
-				{#each items.slice(0, nbDisplayed) as { path, error, summary, edited_by, edited_at, schedule, timezone, enabled, script_path, is_flow, extra_perms, canWrite, args, marked, jobs } (path)}
+				{#each items.slice(0, nbDisplayed) as { path, error, summary, edited_by, edited_at, schedule, timezone, enabled, script_path, is_flow, extra_perms, canWrite, args, marked, jobs, paused_until } (path)}
 					{@const href = `${is_flow ? '/flows/get' : '/scripts/get'}/${script_path}`}
 					{@const avg_s = jobs
 						? jobs.reduce((acc, x) => acc + x.duration_ms, 0) / jobs.length
@@ -322,6 +324,14 @@
 									schedule: {path}
 								</div>
 							</a>
+
+							{#if paused_until}
+								<div class="pb-1">
+									<Badge color="yellow"
+										>Paused until {new Date(paused_until).toLocaleString()}</Badge
+									>
+								</div>
+							{/if}
 
 							<div class="gap-2 items-center hidden md:flex">
 								<Badge large color="blue">{schedule}</Badge>


### PR DESCRIPTION

https://github.com/windmill-labs/windmill/assets/15649739/6a494a16-daa2-48ec-89de-2ab1a58a0c04


<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 66eb7e2f9611a930ffb64997becf5b170192530b  | 
|--------|--------|

### Summary:
Added support for pausing schedules until a specified datetime, including backend handling and frontend UI changes.

**Key points**:
- Added `paused_until` field to `schedule` table
- Updated `backend/windmill-api/src/schedule.rs` for `paused_until` handling
- Modified `backend/windmill-queue/src/schedule.rs` to respect `paused_until`
- Updated `frontend/src/lib/components/ScheduleEditorInner.svelte` for datetime input
- Display `paused_until` badge in schedule list
- Added tests for `paused_until` in `backend/tests/worker.rs`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->