### PR TITLE
Improve flow forloop right panel UX

### DIFF
--- a/frontend/src/lib/components/flows/content/FlowLoop.svelte
+++ b/frontend/src/lib/components/flows/content/FlowLoop.svelte
@@ -133,7 +133,8 @@
 						<div class="text-sm font-bold whitespace-nowrap">
 							Iterator expression
 							<Tooltip documentationLink="https://www.windmill.dev/docs/flows/flow_loops">
-								List to iterate over.
+								The JavaScript expression that will be evaluated to get the list of items to iterate
+								over. Example : ["banana", "apple", flow_input.my_fruit].
 							</Tooltip>
 						</div>
 						{#if enableAi}

--- a/frontend/src/lib/components/flows/content/FlowLoop.svelte
+++ b/frontend/src/lib/components/flows/content/FlowLoop.svelte
@@ -86,46 +86,6 @@
 		<Splitpanes horizontal class="!max-h-[calc(100%-30px)]">
 			<Pane size={60} minSize={20} class="p-4">
 				{#if mod.value.type === 'forloopflow'}
-					<div class="flex flex-row gap-8 mt-2 mb-6">
-						<div>
-							<div class="mb-2 text-sm font-bold"
-								>Skip failures <Tooltip
-									documentationLink="https://www.windmill.dev/docs/flows/flow_loops"
-									>If disabled, the flow will fail as soon as one of the iteration fail. Otherwise,
-									the error will be collected as the result of the iteration. Regardless of this
-									setting, if an error handler is defined, it will process the error.</Tooltip
-								></div
-							>
-							<Toggle
-								bind:checked={mod.value.skip_failures}
-								options={{
-									right: 'Skip failures'
-								}}
-							/>
-						</div>
-						<div>
-							<div class="mb-2 text-sm font-bold">Run in parallel</div>
-							<Toggle
-								bind:checked={mod.value.parallel}
-								options={{
-									right: 'All iterations run in parallel'
-								}}
-							/>
-						</div>
-						<div>
-							<div class="mb-2 text-sm font-bold"
-								>Parallelism <Tooltip
-									>Assign a maximum number of branches run in parallel to control huge for-loops.</Tooltip
-								>
-							</div>
-							<input
-								type="number"
-								disabled={!mod.value.parallel}
-								bind:value={mod.value.parallelism}
-							/>
-						</div>
-					</div>
-
 					<div class="my-2 flex flex-row gap-2 items-center">
 						<div class="text-sm font-bold whitespace-nowrap">
 							Iterator expression
@@ -210,6 +170,7 @@
 			<Pane size={40} minSize={20} class="flex flex-col flex-1">
 				<Tabs bind:selected>
 					<!-- <Tab value="retries">Retries</Tab> -->
+					<Tab value="settings">Settings</Tab>
 					<Tab value="early-stop">Early Stop/Break</Tab>
 					<Tab value="suspend">Suspend/Approval/Prompt</Tab>
 					<Tab value="sleep">Sleep</Tab>
@@ -223,6 +184,53 @@
 									<FlowRetries bind:flowModule={mod} />
 								</div>
 							</TabContent> -->
+
+							<TabContent value="settings" class="flex flex-col flex-1 h-full">
+								<Pane size={60} minSize={20} class="p-4">
+									<div class="flex flex-row gap-8 mt-2 mb-6">
+										<div>
+											<div class="mb-2 text-sm font-bold"
+												>Skip failures <Tooltip
+													documentationLink="https://www.windmill.dev/docs/flows/flow_loops"
+													>If disabled, the flow will fail as soon as one of the iteration fail.
+													Otherwise, the error will be collected as the result of the iteration.
+													Regardless of this setting, if an error handler is defined, it will
+													process the error.</Tooltip
+												></div
+											>
+											<Toggle
+												bind:checked={mod.value.skip_failures}
+												options={{
+													right: 'Skip failures'
+												}}
+											/>
+										</div>
+										<div>
+											<div class="mb-2 text-sm font-bold">Run in parallel</div>
+											<Toggle
+												bind:checked={mod.value.parallel}
+												options={{
+													right: 'All iterations run in parallel'
+												}}
+											/>
+										</div>
+
+										<div>
+											<div class="mb-2 text-sm font-bold"
+												>Parallelism <Tooltip
+													>Assign a maximum number of branches run in parallel to control huge
+													for-loops.</Tooltip
+												>
+											</div>
+											<input
+												type="number"
+												disabled={!mod.value.parallel}
+												bind:value={mod.value.parallelism}
+											/>
+										</div>
+									</div></Pane
+								>
+							</TabContent>
 
 							<TabContent value="early-stop" class="flex flex-col flex-1 h-full">
 								<div class="p-4 overflow-y-auto">

--- a/frontend/src/lib/components/flows/content/FlowLoop.svelte
+++ b/frontend/src/lib/components/flows/content/FlowLoop.svelte
@@ -80,6 +80,14 @@
 				<div class="grow">
 					<input bind:value={mod.summary} placeholder={'Summary'} />
 				</div>
+				<div class="justify-end">
+					<Button
+						on:click={() => (previewOpen = true)}
+						startIcon={{ icon: Play }}
+						color="dark"
+						size="sm">Test an iteration</Button
+					>
+				</div>
 			</div>
 		</div>
 
@@ -115,14 +123,6 @@
 								pickableProperties={stepPropPicker.pickableProperties}
 							/>
 						{/if}
-						<div class="flex w-full justify-end">
-							<Button
-								on:click={() => (previewOpen = true)}
-								startIcon={{ icon: Play }}
-								color="dark"
-								size="sm">Test an iteration</Button
-							>
-						</div>
 					</div>
 
 					{#if mod.value.iterator.type == 'javascript'}

--- a/frontend/src/lib/components/flows/content/FlowLoop.svelte
+++ b/frontend/src/lib/components/flows/content/FlowLoop.svelte
@@ -9,7 +9,7 @@
 	import FlowModuleEarlyStop from './FlowModuleEarlyStop.svelte'
 	import FlowModuleSuspend from './FlowModuleSuspend.svelte'
 	// import FlowRetries from './FlowRetries.svelte'
-	import { Button, Drawer, Tab, TabContent, Tabs, Alert } from '$lib/components/common'
+	import { Button, Drawer, Tab, TabContent, Tabs } from '$lib/components/common'
 	import { Pane, Splitpanes } from 'svelte-splitpanes'
 	import { getStepPropPicker } from '../previousResults'
 	import { enterpriseLicense } from '$lib/stores'
@@ -187,49 +187,51 @@
 
 							<TabContent value="settings" class="flex flex-col flex-1 h-full">
 								<Pane size={60} minSize={20} class="p-4">
-									<div class="flex flex-row gap-8 mt-2 mb-6">
-										<div>
-											<div class="mb-2 text-sm font-bold"
-												>Skip failures <Tooltip
-													documentationLink="https://www.windmill.dev/docs/flows/flow_loops"
-													>If disabled, the flow will fail as soon as one of the iteration fail.
-													Otherwise, the error will be collected as the result of the iteration.
-													Regardless of this setting, if an error handler is defined, it will
-													process the error.</Tooltip
-												></div
-											>
-											<Toggle
-												bind:checked={mod.value.skip_failures}
-												options={{
-													right: 'Skip failures'
-												}}
-											/>
-										</div>
-										<div>
-											<div class="mb-2 text-sm font-bold">Run in parallel</div>
-											<Toggle
-												bind:checked={mod.value.parallel}
-												options={{
-													right: 'All iterations run in parallel'
-												}}
-											/>
-										</div>
-
-										<div>
-											<div class="mb-2 text-sm font-bold"
-												>Parallelism <Tooltip
-													>Assign a maximum number of branches run in parallel to control huge
-													for-loops.</Tooltip
+									{#if mod.value.type === 'forloopflow'}
+										<div class="flex flex-row gap-8 mt-2 mb-6">
+											<div>
+												<div class="mb-2 text-sm font-bold"
+													>Skip failures <Tooltip
+														documentationLink="https://www.windmill.dev/docs/flows/flow_loops"
+														>If disabled, the flow will fail as soon as one of the iteration fail.
+														Otherwise, the error will be collected as the result of the iteration.
+														Regardless of this setting, if an error handler is defined, it will
+														process the error.</Tooltip
+													></div
 												>
+												<Toggle
+													bind:checked={mod.value.skip_failures}
+													options={{
+														right: 'Skip failures'
+													}}
+												/>
 											</div>
-											<input
-												type="number"
-												disabled={!mod.value.parallel}
-												bind:value={mod.value.parallelism}
-											/>
+											<div>
+												<div class="mb-2 text-sm font-bold">Run in parallel</div>
+												<Toggle
+													bind:checked={mod.value.parallel}
+													options={{
+														right: 'All iterations run in parallel'
+													}}
+												/>
+											</div>
+
+											<div>
+												<div class="mb-2 text-sm font-bold"
+													>Parallelism <Tooltip
+														>Assign a maximum number of branches run in parallel to control huge
+														for-loops.</Tooltip
+													>
+												</div>
+												<input
+													type="number"
+													disabled={!mod.value.parallel}
+													bind:value={mod.value.parallelism}
+												/>
+											</div>
 										</div>
-									</div></Pane
-								>
+									{/if}
+								</Pane>
 							</TabContent>
 
 							<TabContent value="early-stop" class="flex flex-col flex-1 h-full">

--- a/frontend/src/lib/components/flows/content/FlowLoop.svelte
+++ b/frontend/src/lib/components/flows/content/FlowLoop.svelte
@@ -70,24 +70,21 @@
 <div class="h-full flex flex-col">
 	<FlowCard {noEditor} title="For loop">
 		<div slot="header" class="grow">
-			<input bind:value={mod.summary} placeholder={'Summary'} />
-		</div>
-
-		<Splitpanes horizontal class="!max-h-[calc(100%-48px)]">
-			<Pane size={60} minSize={20} class="p-4">
-				{#if !noEditor}
-					<Alert
-						type="info"
-						title="For loops"
-						documentationLink="https://www.windmill.dev/docs/flows/flow_loops"
-						class="mb-4"
-						size="xs"
-					>
+			<div class="my-2 flex flex-row gap-2 items-center">
+				<div>
+					<Tooltip documentationLink="https://www.windmill.dev/docs/flows/flow_loops">
 						Add steps inside the loop and specify an iterator expression that defines the sequence
 						over which your subsequent steps will iterate.
-					</Alert>
-				{/if}
+					</Tooltip>
+				</div>
+				<div class="grow">
+					<input bind:value={mod.summary} placeholder={'Summary'} />
+				</div>
+			</div>
+		</div>
 
+		<Splitpanes horizontal class="!max-h-[calc(100%-30px)]">
+			<Pane size={60} minSize={20} class="p-4">
 				{#if mod.value.type === 'forloopflow'}
 					<div class="flex flex-row gap-8 mt-2 mb-6">
 						<div>

--- a/frontend/src/lib/components/flows/content/FlowLoop.svelte
+++ b/frontend/src/lib/components/flows/content/FlowLoop.svelte
@@ -94,6 +94,45 @@
 		<Splitpanes horizontal class="!max-h-[calc(100%-30px)]">
 			<Pane size={60} minSize={20} class="p-4">
 				{#if mod.value.type === 'forloopflow'}
+					<div class="flex flex-row gap-8 mt-2 mb-6">
+						<div>
+							<div class="mb-2 text-sm font-bold"
+								>Skip failures <Tooltip
+									documentationLink="https://www.windmill.dev/docs/flows/flow_loops"
+									>If disabled, the flow will fail as soon as one of the iteration fail. Otherwise,
+									the error will be collected as the result of the iteration. Regardless of this
+									setting, if an error handler is defined, it will process the error.</Tooltip
+								></div
+							>
+							<Toggle
+								bind:checked={mod.value.skip_failures}
+								options={{
+									right: 'Skip failures'
+								}}
+							/>
+						</div>
+						<div>
+							<div class="mb-2 text-sm font-bold">Run in parallel</div>
+							<Toggle
+								bind:checked={mod.value.parallel}
+								options={{
+									right: 'All iterations run in parallel'
+								}}
+							/>
+						</div>
+						<div>
+							<div class="mb-2 text-sm font-bold"
+								>Parallelism <Tooltip
+									>Assign a maximum number of branches run in parallel to control huge for-loops.</Tooltip
+								>
+							</div>
+							<input
+								type="number"
+								disabled={!mod.value.parallel}
+								bind:value={mod.value.parallelism}
+							/>
+						</div>
+					</div>
 					<div class="my-2 flex flex-row gap-2 items-center">
 						<div class="text-sm font-bold whitespace-nowrap">
 							Iterator expression
@@ -170,7 +209,6 @@
 			<Pane size={40} minSize={20} class="flex flex-col flex-1">
 				<Tabs bind:selected>
 					<!-- <Tab value="retries">Retries</Tab> -->
-					<Tab value="settings">Settings</Tab>
 					<Tab value="early-stop">Early Stop/Break</Tab>
 					<Tab value="suspend">Suspend/Approval/Prompt</Tab>
 					<Tab value="sleep">Sleep</Tab>
@@ -184,55 +222,6 @@
 									<FlowRetries bind:flowModule={mod} />
 								</div>
 							</TabContent> -->
-
-							<TabContent value="settings" class="flex flex-col flex-1 h-full">
-								<Pane size={60} minSize={20} class="p-4">
-									{#if mod.value.type === 'forloopflow'}
-										<div class="flex flex-row gap-8 mt-2 mb-6">
-											<div>
-												<div class="mb-2 text-sm font-bold"
-													>Skip failures <Tooltip
-														documentationLink="https://www.windmill.dev/docs/flows/flow_loops"
-														>If disabled, the flow will fail as soon as one of the iteration fail.
-														Otherwise, the error will be collected as the result of the iteration.
-														Regardless of this setting, if an error handler is defined, it will
-														process the error.</Tooltip
-													></div
-												>
-												<Toggle
-													bind:checked={mod.value.skip_failures}
-													options={{
-														right: 'Skip failures'
-													}}
-												/>
-											</div>
-											<div>
-												<div class="mb-2 text-sm font-bold">Run in parallel</div>
-												<Toggle
-													bind:checked={mod.value.parallel}
-													options={{
-														right: 'All iterations run in parallel'
-													}}
-												/>
-											</div>
-
-											<div>
-												<div class="mb-2 text-sm font-bold"
-													>Parallelism <Tooltip
-														>Assign a maximum number of branches run in parallel to control huge
-														for-loops.</Tooltip
-													>
-												</div>
-												<input
-													type="number"
-													disabled={!mod.value.parallel}
-													bind:value={mod.value.parallelism}
-												/>
-											</div>
-										</div>
-									{/if}
-								</Pane>
-							</TabContent>
 
 							<TabContent value="early-stop" class="flex flex-col flex-1 h-full">
 								<div class="p-4 overflow-y-auto">


### PR DESCRIPTION
4 changes here :
* The text of the iterator expression has been changed
* The original message displayed as an alert under the header has been move into the tootip of **For loop**
* Options have been gathered together
* The "Test an iteration" button has been moved to the top right
before : 
![image](https://github.com/windmill-labs/windmill/assets/64467926/fe20f7c7-8e0f-46c1-80e9-a41c52e520b0)
after
![image](https://github.com/windmill-labs/windmill/assets/64467926/2621d8fa-e602-4bdb-9b33-75437cfc970b)

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit fc6dc554c875278b8131c4e13a4e815e131a0a07  | 
|--------|--------|

### Summary:
Improved the UI of the flow loop component by moving the alert message to a tooltip, gathering options into a new **Settings** tab, and repositioning the 'Test an iteration' button.

**Key points**:
- Updated `frontend/src/lib/components/flows/content/FlowLoop.svelte` to improve UI.
- Moved alert message to tooltip in the **For loop** header.
- Gathered options into a new **Settings** tab.
- Moved 'Test an iteration' button to the top right.
- Changed text for iterator expression tooltip.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->