### PR TITLE
fix(frontend): add tooltip to schedule pausing

### DIFF
--- a/frontend/src/lib/components/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/ScheduleEditorInner.svelte
@@ -520,7 +520,11 @@
 				</svelte:fragment>
 				<CronInput disabled={!can_write} bind:schedule bind:timezone bind:validCRON />
 				<Toggle
-					options={{ right: 'Pause schedule until...' }}
+					options={{
+						right: 'Pause schedule until...',
+						rightTooltip:
+							'Pausing the schedule will program the next job to run as if the schedule starts at the time the pause is lifted, instead of now.'
+					}}
 					bind:checked={showPauseUntil}
 					size="xs"
 				/>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 69ec486444a8f2c96cd00666541731cbf64bb5d5  | 
|--------|--------|

### Summary:
Added a tooltip to the 'Pause schedule until...' toggle option in `frontend/src/lib/components/ScheduleEditorInner.svelte`.

**Key points**:
- Added a tooltip to the 'Pause schedule until...' toggle option in `frontend/src/lib/components/ScheduleEditorInner.svelte`.
- Tooltip text: 'Pausing the schedule will program the next job to run as if the schedule starts at the time the pause is lifted, instead of now.'


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->