### PR TITLE
feat: include token label as end user

### DIFF
--- a/backend/windmill-api/src/users.rs
+++ b/backend/windmill-api/src/users.rs
@@ -119,20 +119,18 @@ pub fn make_unauthed_service() -> Router {
 }
 
 fn username_override_from_label(label: Option<String>) -> Option<String> {
-    if label.as_ref().is_some_and(|x| x.starts_with("webhook-")) {
-        label
-    } else if label
-        .as_ref()
-        .is_some_and(|x| x.starts_with("ephemeral-script-end-user-"))
-    {
-        Some(
+    match label {
+        Some(label) if label.starts_with("webhook-") => Some(label),
+        Some(label) if label.starts_with("ephemeral-script-end-user-") => Some(
             label
-                .unwrap()
                 .trim_start_matches("ephemeral-script-end-user-")
                 .to_string(),
-        )
-    } else {
-        None
+        ),
+        Some(label) if label == "Ephemeral lsp token" => Some("lsp".to_string()),
+        Some(label) if label != "ephemeral-script" && label != "session" && !label.is_empty() => {
+            Some(format!("label-{label}"))
+        }
+        _ => None,
     }
 }
 

--- a/frontend/src/lib/components/auditLogs/AuditLogsTable.svelte
+++ b/frontend/src/lib/components/auditLogs/AuditLogsTable.svelte
@@ -108,10 +108,10 @@
 						</Cell>
 						<Cell>
 							<div class="flex flex-row gap-2 items-center">
-								<div class="whitespace-nowrap overflow-x-auto no-scrollbar w-48">
+								<div class="whitespace-nowrap overflow-x-auto no-scrollbar max-w-52">
 									{username}
 									{#if parameters && 'end_user' in parameters}
-										<span> (end user: {parameters.end_user})</span>
+										<span> ({parameters.end_user})</span>
 									{/if}
 								</div>
 								<Button

--- a/frontend/src/lib/components/runs/RunRow.svelte
+++ b/frontend/src/lib/components/runs/RunRow.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
 	import { goto } from '$app/navigation'
 	import type { Job } from '$lib/gen'
-	import { displayDate, msToSec, truncateHash, truncateRev } from '$lib/utils'
+	import {
+		displayDate,
+		msToSec,
+		truncateHash,
+		truncateRev,
+		usernameToPermissionedAs
+	} from '$lib/utils'
 	import { Badge, Button } from '../common'
 	import ScheduleEditor from '../ScheduleEditor.svelte'
 	import BarsStaggered from '$lib/components/icons/BarsStaggered.svelte'
@@ -64,9 +70,9 @@
 >
 	<div class="w-1/12 flex justify-center">
 		{#if isSelectingJobsToCancel && isJobCancelable(job)}
-		<div class="px-2">
-			<input type="checkbox" checked={selected}/>
-		</div>
+			<div class="px-2">
+				<input type="checkbox" checked={selected} />
+			</div>
 		{/if}
 		{#if isExternal}
 			<Badge color="gray" baseClass="!px-1.5">
@@ -251,9 +257,13 @@
 				</Button>
 			</div>
 		{:else}
+			{@const createdByAsPermissionedAs = usernameToPermissionedAs(job.created_by ?? '')}
 			<div class="flex flex-row gap-1 items-center">
 				<div class="text-xs">
-					{job.created_by}
+					{job.permissioned_as}
+					{#if createdByAsPermissionedAs != job.permissioned_as}
+						(end user: {job.created_by})
+					{/if}
 				</div>
 				{#if !isExternal}
 					<Button

--- a/frontend/src/lib/components/runs/RunRow.svelte
+++ b/frontend/src/lib/components/runs/RunRow.svelte
@@ -260,9 +260,10 @@
 			{@const createdByAsPermissionedAs = usernameToPermissionedAs(job.created_by ?? '')}
 			<div class="flex flex-row gap-1 items-center">
 				<div class="text-xs">
-					{job.permissioned_as}
+					{job.created_by}
 					{#if createdByAsPermissionedAs != job.permissioned_as}
-						(end user: {job.created_by})
+						<br />
+						(permissioned as {job.permissioned_as})
 					{/if}
 				</div>
 				{#if !isExternal}

--- a/frontend/src/lib/components/runs/RunRow.svelte
+++ b/frontend/src/lib/components/runs/RunRow.svelte
@@ -1,13 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation'
 	import type { Job } from '$lib/gen'
-	import {
-		displayDate,
-		msToSec,
-		truncateHash,
-		truncateRev,
-		usernameToPermissionedAs
-	} from '$lib/utils'
+	import { displayDate, msToSec, truncateHash, truncateRev } from '$lib/utils'
 	import { Badge, Button } from '../common'
 	import ScheduleEditor from '../ScheduleEditor.svelte'
 	import BarsStaggered from '$lib/components/icons/BarsStaggered.svelte'
@@ -257,14 +251,9 @@
 				</Button>
 			</div>
 		{:else}
-			{@const createdByAsPermissionedAs = usernameToPermissionedAs(job.created_by ?? '')}
 			<div class="flex flex-row gap-1 items-center">
 				<div class="text-xs">
 					{job.created_by}
-					{#if createdByAsPermissionedAs != job.permissioned_as}
-						<br />
-						(permissioned as {job.permissioned_as})
-					{/if}
 				</div>
 				{#if !isExternal}
 					<Button

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -905,11 +905,3 @@ export function shouldDisplayPlaceholder(
 
 	return type === undefined
 }
-
-export function usernameToPermissionedAs(user: string): string {
-	if (user.includes('@')) {
-		return user
-	} else {
-		return `u/${user}`
-	}
-}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -905,3 +905,11 @@ export function shouldDisplayPlaceholder(
 
 	return type === undefined
 }
+
+export function usernameToPermissionedAs(user: string): string {
+	if (user.includes('@')) {
+		return user
+	} else {
+		return `u/${user}`
+	}
+}


### PR DESCRIPTION
<img width="938" alt="Screenshot 2024-06-27 at 14 24 54" src="https://github.com/windmill-labs/windmill/assets/15649739/0aaa7e99-28e0-4252-ad25-8acbcd725c1d">

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1339935f93122c7a45e4a52f153beaa112ade5be  | 
|--------|--------|

### Summary:
Updated backend and frontend to include token labels and display end-user information in audit logs and runs page.

**Key points**:
- **Backend**: Updated `username_override_from_label` in `backend/windmill-api/src/users.rs` to handle new token labels and end-user cases.
- **Frontend**: 
  - `frontend/src/lib/components/auditLogs/AuditLogsTable.svelte`: Display end-user information in audit logs.
  - `frontend/src/lib/components/runs/RunRow.svelte`: Show end-user and token label information in the runs page.
  - `frontend/src/lib/utils.ts`: Added `usernameToPermissionedAs` function to format usernames.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->