### PR TITLE
fix: make gql params optional by default + use default value if undefined

### DIFF
--- a/backend/parsers/windmill-parser-graphql/src/lib.rs
+++ b/backend/parsers/windmill-parser-graphql/src/lib.rs
@@ -75,7 +75,7 @@ mod tests {
     #[test]
     fn test_parse_graphql_sig() -> anyhow::Result<()> {
         let code = r#"
-query($s: String, $arr: [String]) {
+query($i: Int, $arr: [String]!, $wahoo: String = "wahoo") {
     books {
         title
     }
@@ -89,9 +89,9 @@ query($s: String, $arr: [String]) {
                 star_kwargs: false,
                 args: vec![
                     Arg {
-                        otyp: Some("String".to_string()),
-                        name: "s".to_string(),
-                        typ: Typ::Str(None),
+                        otyp: Some("Int".to_string()),
+                        name: "i".to_string(),
+                        typ: Typ::Int,
                         default: None,
                         has_default: true
                     },
@@ -102,6 +102,13 @@ query($s: String, $arr: [String]) {
                         default: None,
                         has_default: false
                     },
+                    Arg {
+                        otyp: Some("String".to_string()),
+                        name: "wahoo".to_string(),
+                        typ: Typ::Str(None),
+                        default: Some(json!("wahoo")),
+                        has_default: true
+                    }
                 ],
                 no_main_func: None
             }

--- a/backend/parsers/windmill-parser-graphql/src/lib.rs
+++ b/backend/parsers/windmill-parser-graphql/src/lib.rs
@@ -36,8 +36,8 @@ fn parse_graphql_file(code: &str) -> anyhow::Result<Option<Vec<Arg>>> {
         };
 
         let (has_default, default) = match cap.get(6).map(|x| x.as_str().to_string()) {
-            Some(x) => (true, Some(x)), // default value
-            None => (cap.get(3).is_none() && cap.get(5).is_none(), None), // optional (no exclamation mark)
+            Some(x) => (true, Some(x)), // default value => optional
+            None => (cap.get(3).is_none() && cap.get(5).is_none(), None), // optional if no !
         };
 
         let parsed_default = default.and_then(|x| match parsed_typ {
@@ -93,7 +93,7 @@ query($s: String, $arr: [String]) {
                         name: "s".to_string(),
                         typ: Typ::Str(None),
                         default: None,
-                        has_default: false
+                        has_default: true
                     },
                     Arg {
                         otyp: Some("[String]".to_string()),

--- a/backend/parsers/windmill-parser-graphql/src/lib.rs
+++ b/backend/parsers/windmill-parser-graphql/src/lib.rs
@@ -17,7 +17,7 @@ pub fn parse_graphql_sig(code: &str) -> anyhow::Result<MainArgSignature> {
 }
 
 lazy_static::lazy_static! {
-    static ref RE_ARG_GRAPHQL: Regex = Regex::new(r#"\$(\w+)\s*:\s*(?:(\w+)!?|\[(\w+)!?\])!?\s*(?:=\s*(\w+)\s*)?"#).unwrap();
+    static ref RE_ARG_GRAPHQL: Regex = Regex::new(r#"\$(\w+)\s*:\s*(?:(\w+)(!)?|\[(\w+)!?\])(!)?\s*(?:=\s*"?(\w+)"?\s*)?"#).unwrap();
 }
 
 fn parse_graphql_file(code: &str) -> anyhow::Result<Option<Vec<Arg>>> {
@@ -28,16 +28,17 @@ fn parse_graphql_file(code: &str) -> anyhow::Result<Option<Vec<Arg>>> {
         let mut typ = cap.get(2).map(|x| x.as_str().to_string());
 
         let parsed_typ = if typ.is_none() {
-            let inner_typ = cap.get(3).map(|x| x.as_str().to_string());
+            let inner_typ = cap.get(4).map(|x| x.as_str().to_string());
             typ = inner_typ.clone().map(|x| format!("[{}]", x.to_string()));
             Typ::List(Box::new(parse_graphql_typ(inner_typ.unwrap().as_str())))
         } else {
             parse_graphql_typ(typ.clone().unwrap().as_str())
         };
 
-        let default = cap.get(4).map(|x| x.as_str().to_string());
-
-        let has_default = default.is_some();
+        let (has_default, default) = match cap.get(6).map(|x| x.as_str().to_string()) {
+            Some(x) => (true, Some(x)), // default value
+            None => (cap.get(3).is_none() && cap.get(5).is_none(), None), // optional (no exclamation mark)
+        };
 
         let parsed_default = default.and_then(|x| match parsed_typ {
             Typ::Int => x.parse::<i64>().ok().map(|x| json!(x)),

--- a/backend/parsers/windmill-parser-wasm/pkg/package.json
+++ b/backend/parsers/windmill-parser-wasm/pkg/package.json
@@ -3,7 +3,7 @@
   "collaborators": [
     "Ruben Fiszel <ruben@windmill.dev>"
   ],
-  "version": "1.353.0",
+  "version": "1.355.4",
   "files": [
     "windmill_parser_wasm_bg.wasm",
     "windmill_parser_wasm.js",

--- a/backend/parsers/windmill-parser-wasm/pkg/windmill_parser_wasm.js
+++ b/backend/parsers/windmill-parser-wasm/pkg/windmill_parser_wasm.js
@@ -6,20 +6,6 @@ heap.push(undefined, null, true, false);
 
 function getObject(idx) { return heap[idx]; }
 
-let heap_next = heap.length;
-
-function dropObject(idx) {
-    if (idx < 132) return;
-    heap[idx] = heap_next;
-    heap_next = idx;
-}
-
-function takeObject(idx) {
-    const ret = getObject(idx);
-    dropObject(idx);
-    return ret;
-}
-
 let WASM_VECTOR_LEN = 0;
 
 let cachedUint8Memory0 = null;
@@ -98,13 +84,27 @@ function getInt32Memory0() {
     return cachedInt32Memory0;
 }
 
-let cachedFloat64Memory0 = null;
+let heap_next = heap.length;
 
-function getFloat64Memory0() {
-    if (cachedFloat64Memory0 === null || cachedFloat64Memory0.byteLength === 0) {
-        cachedFloat64Memory0 = new Float64Array(wasm.memory.buffer);
-    }
-    return cachedFloat64Memory0;
+function dropObject(idx) {
+    if (idx < 132) return;
+    heap[idx] = heap_next;
+    heap_next = idx;
+}
+
+function takeObject(idx) {
+    const ret = getObject(idx);
+    dropObject(idx);
+    return ret;
+}
+
+const cachedTextDecoder = (typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-8', { ignoreBOM: true, fatal: true }) : { decode: () => { throw Error('TextDecoder not available') } } );
+
+if (typeof TextDecoder !== 'undefined') { cachedTextDecoder.decode(); };
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
 }
 
 function addHeapObject(obj) {
@@ -116,13 +116,13 @@ function addHeapObject(obj) {
     return idx;
 }
 
-const cachedTextDecoder = (typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-8', { ignoreBOM: true, fatal: true }) : { decode: () => { throw Error('TextDecoder not available') } } );
+let cachedFloat64Memory0 = null;
 
-if (typeof TextDecoder !== 'undefined') { cachedTextDecoder.decode(); };
-
-function getStringFromWasm0(ptr, len) {
-    ptr = ptr >>> 0;
-    return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
+function getFloat64Memory0() {
+    if (cachedFloat64Memory0 === null || cachedFloat64Memory0.byteLength === 0) {
+        cachedFloat64Memory0 = new Float64Array(wasm.memory.buffer);
+    }
+    return cachedFloat64Memory0;
 }
 
 let cachedBigInt64Memory0 = null;
@@ -585,13 +585,6 @@ async function __wbg_load(module, imports) {
 function __wbg_get_imports() {
     const imports = {};
     imports.wbg = {};
-    imports.wbg.__wbg_eval_42bb47208302a41e = function(arg0, arg1) {
-        const ret = eval(getStringFromWasm0(arg0, arg1));
-        return addHeapObject(ret);
-    };
-    imports.wbg.__wbindgen_object_drop_ref = function(arg0) {
-        takeObject(arg0);
-    };
     imports.wbg.__wbindgen_string_get = function(arg0, arg1) {
         const obj = getObject(arg1);
         const ret = typeof(obj) === 'string' ? obj : undefined;
@@ -599,6 +592,13 @@ function __wbg_get_imports() {
         var len1 = WASM_VECTOR_LEN;
         getInt32Memory0()[arg0 / 4 + 1] = len1;
         getInt32Memory0()[arg0 / 4 + 0] = ptr1;
+    };
+    imports.wbg.__wbindgen_object_drop_ref = function(arg0) {
+        takeObject(arg0);
+    };
+    imports.wbg.__wbindgen_error_new = function(arg0, arg1) {
+        const ret = new Error(getStringFromWasm0(arg0, arg1));
+        return addHeapObject(ret);
     };
     imports.wbg.__wbindgen_boolean_get = function(arg0) {
         const v = getObject(arg0);
@@ -636,8 +636,8 @@ function __wbg_get_imports() {
         const ret = BigInt.asUintN(64, arg0);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbindgen_error_new = function(arg0, arg1) {
-        const ret = new Error(getStringFromWasm0(arg0, arg1));
+    imports.wbg.__wbg_eval_64ce1594989e82f8 = function(arg0, arg1) {
+        const ret = eval(getStringFromWasm0(arg0, arg1));
         return addHeapObject(ret);
     };
     imports.wbg.__wbindgen_jsval_loose_eq = function(arg0, arg1) {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -52,7 +52,7 @@
 				"vscode-languageclient": "~9.0.1",
 				"vscode-uri": "~3.0.8",
 				"vscode-ws-jsonrpc": "~3.1.0",
-				"windmill-parser-wasm": "^1.353.0",
+				"windmill-parser-wasm": "^1.355.4",
 				"windmill-sql-datatype-parser-wasm": "^1.318.0",
 				"y-monaco": "^0.1.4",
 				"y-websocket": "^1.5.0",
@@ -10261,9 +10261,9 @@
 			}
 		},
 		"node_modules/windmill-parser-wasm": {
-			"version": "1.353.0",
-			"resolved": "https://registry.npmjs.org/windmill-parser-wasm/-/windmill-parser-wasm-1.353.0.tgz",
-			"integrity": "sha512-WjsE9BLDmtX0CCC3JrwRFgnqMo6mxiko3DRUJecs3I1vWRyq6dvspk+rn4e3Kdr8Ba4wRfu4ZZw2HmCUOkH7tQ=="
+			"version": "1.355.4",
+			"resolved": "https://registry.npmjs.org/windmill-parser-wasm/-/windmill-parser-wasm-1.355.4.tgz",
+			"integrity": "sha512-7Usvb55qAULgGg5ULoMm4iWviAl0fQMNxoDQXx4lrPASpXSSV0BS9anP2jF/gse5HQ1usKj63TNtCFYedMThHg=="
 		},
 		"node_modules/windmill-sql-datatype-parser-wasm": {
 			"version": "1.318.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -132,7 +132,7 @@
 		"vscode-languageclient": "~9.0.1",
 		"vscode-uri": "~3.0.8",
 		"vscode-ws-jsonrpc": "~3.1.0",
-		"windmill-parser-wasm": "^1.353.0",
+		"windmill-parser-wasm": "^1.355.4",
 		"windmill-sql-datatype-parser-wasm": "^1.318.0",
 		"y-monaco": "^0.1.4",
 		"y-websocket": "^1.5.0",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4211fe81351ff96dfdf253a0c236f316ef3eb885  | 
|--------|--------|

### Summary:
Made GraphQL parameters optional by default and used default values if undefined, with updates across multiple files and version bumps.

**Key points**:
- Updated `backend/parsers/windmill-parser-graphql/src/lib.rs` to make GraphQL parameters optional by default and use default values if undefined.
- Adjusted regex in `RE_ARG_GRAPHQL` to capture optional parameters and default values.
- Modified `parse_graphql_file` to handle optional parameters and default values.
- Updated `backend/parsers/windmill-parser-wasm/pkg/windmill_parser_wasm.js` to remove redundant functions and adjust imports.
- Bumped version in `backend/parsers/windmill-parser-wasm/pkg/package.json` to `1.355.4`.
- Updated `do_graphql` in `backend/windmill-worker/src/graphql_executor.rs` to insert default values for missing parameters.
- Bumped version in `frontend/package.json` to `1.355.4`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->