### PR TITLE
fix: lookback selector to manually look for older jobs and prevent inaccurate concurrency graphs

### DIFF
--- a/backend/windmill-worker/src/bash_executor.rs
+++ b/backend/windmill-worker/src/bash_executor.rs
@@ -379,6 +379,21 @@ $env:PSModulePath = \"{}:$PSModulePathBackup\"",
     )
     .await?;
 
+    let result_json_path = format!("{job_dir}/result.json");
+    if let Ok(metadata) = tokio::fs::metadata(&result_json_path).await {
+        if metadata.len() > 0 {
+            return Ok(read_file(&result_json_path).await?);
+        }
+    }
+
+    let result_out_path = format!("{job_dir}/result.out");
+    if let Ok(metadata) = tokio::fs::metadata(&result_out_path).await {
+        if metadata.len() > 0 {
+            let result = read_file_content(&result_out_path).await?;
+            return Ok(to_raw_value(&json!(result)));
+        }
+    }
+
     let result_out_path2 = format!("{job_dir}/result2.out");
     if tokio::fs::metadata(&result_out_path2).await.is_ok() {
         let result = read_file_content(&result_out_path2)

--- a/frontend/src/lib/components/DateTimeInput.svelte
+++ b/frontend/src/lib/components/DateTimeInput.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte'
 	import { Button } from './common'
-	import { Clock } from 'lucide-svelte'
+	import { Clock, X } from 'lucide-svelte'
 	import { twMerge } from 'tailwind-merge'
 	// import ToggleButtonGroup from './common/toggleButton-v2/ToggleButtonGroup.svelte'
 	// import ToggleButton from './common/toggleButton-v2/ToggleButton.svelte'
@@ -129,6 +129,18 @@
 		}}
 	>
 		Now
+	</Button>
+	<Button
+		variant="border"
+		color="light"
+		wrapperClasses="h-8"
+		{disabled}
+		on:click={() => {
+			value = undefined
+			dispatch('clear')
+		}}
+	>
+		<X size={14} />
 	</Button>
 	<!-- <div>
 		<ToggleButtonGroup bind:selected={format}>

--- a/frontend/src/lib/components/common/calendarPicker/CalendarPicker.svelte
+++ b/frontend/src/lib/components/common/calendarPicker/CalendarPicker.svelte
@@ -40,6 +40,9 @@
 					date = e.detail
 					dispatch('change', date)
 				}}
+				on:clear={() => {
+					dispatch('clear')
+				}}
 			/>
 		</div>
 	</label>

--- a/frontend/src/lib/components/runs/JobLoader.svelte
+++ b/frontend/src/lib/components/runs/JobLoader.svelte
@@ -295,13 +295,12 @@
 					}
 
 					loading = true
-					const extendedMinTs = subtractDaysFromDateString(minTs, lookback)
 					let newJobs: Job[]
 					if (concurrencyKey == null || concurrencyKey === '') {
-						newJobs = await fetchJobs(maxTs, extendedMinTs ?? ts, undefined)
+						newJobs = await fetchJobs(maxTs, minTs ?? ts, undefined)
 					} else {
 						// Obscured jobs have no ids, so we have to do the full request
-						extendedJobs = await fetchExtendedJobs(concurrencyKey, maxTs, undefined, extendedMinTs ?? ts)
+						extendedJobs = await fetchExtendedJobs(concurrencyKey, maxTs, undefined, minTs ?? ts)
 						externalJobs = computeExternalJobs(extendedJobs.obscured_jobs)
 
 						// Filter on minTs here and not in the backend

--- a/frontend/src/lib/components/runs/JobLoader.svelte
+++ b/frontend/src/lib/components/runs/JobLoader.svelte
@@ -13,6 +13,7 @@
 	import { workspaceStore } from '$lib/stores'
 
 	import { tweened, type Tweened } from 'svelte/motion'
+	import { subtractDaysFromDateString } from '$lib/utils'
 
 	export let jobs: Job[] | undefined
 	export let user: string | null
@@ -201,7 +202,7 @@
 			// Extend MinTs to fetch jobs mefore minTs and show a correct concurrency graph
 			// TODO: when an ended_at column is created on the completed_job table,
 			// lookback won't be needed anymore (just filter ended_at > minTs instead
-			const extendedMinTs = substractDays(minTs, lookback)
+			const extendedMinTs = subtractDaysFromDateString(minTs, lookback)
 			if (concurrencyKey == null || concurrencyKey === '') {
 				let newJobs = await fetchJobs(maxTs, undefined, extendedMinTs)
 				extendedJobs = { jobs: newJobs, obscured_jobs: [] } as ExtendedJobs
@@ -294,7 +295,7 @@
 					}
 
 					loading = true
-					const extendedMinTs = substractDays(minTs, lookback)
+					const extendedMinTs = subtractDaysFromDateString(minTs, lookback)
 					let newJobs: Job[]
 					if (concurrencyKey == null || concurrencyKey === '') {
 						newJobs = await fetchJobs(maxTs, extendedMinTs ?? ts, undefined)
@@ -334,16 +335,6 @@
 			.filter((x) => oldJobs.includes(x.id))
 			.forEach((x) => (ret![ret?.findIndex((y) => y.id == x.id)!] = x))
 		return ret
-	}
-
-	function substractDays(dateString: string | undefined, days: number): string | undefined {
-		if (dateString == undefined) {
-			return undefined
-		}
-		let date = new Date(dateString)
-		date.setDate(date.getDate() - days)
-		return date.toISOString()
-
 	}
 
 	function sortMinDate(minTs: string | undefined, jobs: Job[]) {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -49,6 +49,16 @@ export function displayDateOnly(dateString: string | Date | undefined): string {
 	}
 }
 
+export function subtractDaysFromDateString(dateString: string | undefined, days: number): string | undefined {
+	if (dateString == undefined) {
+		return undefined
+	}
+	let date = new Date(dateString)
+	date.setDate(date.getDate() - days)
+	return date.toISOString()
+
+}
+
 export function displayDate(
 	dateString: string | Date | undefined,
 	displaySecond = false,
@@ -497,7 +507,7 @@ export function isObject(obj: any) {
 
 export function debounce(func: (...args: any[]) => any, wait: number) {
 	let timeout: any
-	return function (...args: any[]) {
+	return function(...args: any[]) {
 		// @ts-ignore
 		const context = this
 		clearTimeout(timeout)
@@ -507,7 +517,7 @@ export function debounce(func: (...args: any[]) => any, wait: number) {
 
 export function throttle<T>(func: (...args: any[]) => T, wait: number) {
 	let timeout: any
-	return function (...args: any[]) {
+	return function(...args: any[]) {
 		if (!timeout) {
 			timeout = setTimeout(() => {
 				timeout = null
@@ -701,7 +711,7 @@ export async function tryEvery({
 		try {
 			await tryCode()
 			break
-		} catch (err) {}
+		} catch (err) { }
 		i++
 	}
 	if (i >= times) {

--- a/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
@@ -37,7 +37,6 @@
 	import ToggleButton from '$lib/components/common/toggleButton-v2/ToggleButton.svelte'
 	import DropdownV2 from '$lib/components/DropdownV2.svelte'
 	import DarkModeObserver from '$lib/components/DarkModeObserver.svelte'
-	import { subtractDaysFromDateString } from '$lib/utils'
 
 	let jobs: Job[] | undefined
 	let selectedIds: string[] = []
@@ -80,8 +79,7 @@
 		: undefined
 
 	// Handled on the main page
-	let minTs =
-		$page.url.searchParams.get('min_ts') ?? subtractDaysFromDateString(new Date().toISOString(), 2)
+	let minTs = $page.url.searchParams.get('min_ts') ?? undefined
 	let maxTs = $page.url.searchParams.get('max_ts') ?? undefined
 	let schedulePath = $page.url.searchParams.get('schedule_path') ?? undefined
 	let jobKindsCat = $page.url.searchParams.get('job_kinds') ?? 'runs'
@@ -103,7 +101,7 @@
 	let runDrawer: Drawer
 	let isCancelingVisibleJobs = false
 	let isCancelingFilteredJobs = false
-	let lookback: number = 0
+	let lookback: number = 1
 
 	let innerWidth = window.innerWidth
 	let jobLoader: JobLoader | undefined = undefined
@@ -570,7 +568,7 @@
 									action: () => setLookback(0)
 								},
 								{
-									displayName: '1 days',
+									displayName: '1 day',
 									action: () => setLookback(1)
 								},
 								{
@@ -907,7 +905,7 @@
 									action: () => setLookback(0)
 								},
 								{
-									displayName: '1 days',
+									displayName: '1 day',
 									action: () => setLookback(1)
 								},
 								{

--- a/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
@@ -404,6 +404,7 @@
 		extendedJobs.jobs.length + extendedJobs.obscured_jobs.length >= 1000
 
 	let darkMode: boolean = false
+
 </script>
 
 <DarkModeObserver bind:darkMode />
@@ -437,7 +438,7 @@
 	{resultError}
 	bind:loading
 	bind:this={jobLoader}
-	{lookback}
+	lookback={graphIsRunsChart ? 0: lookback}
 />
 
 <ConfirmationModal

--- a/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
@@ -591,7 +591,8 @@
 									<span class="text-xs min-w-[5rem]">{lookback} days lookback</span>
 									<Tooltip>
 										How far behind the min datetime to start considering jobs for the concurrency
-										graph. Try changing it from zero if you want to zoom in on this graph.
+										graph. Change this value to include jobs started before the set time window for
+										the computation of the concurrency graph
 									</Tooltip>
 								</div>
 							</svelte:fragment>

--- a/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
@@ -36,7 +36,6 @@
 	import ToggleButtonGroup from '$lib/components/common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import ToggleButton from '$lib/components/common/toggleButton-v2/ToggleButton.svelte'
 	import DropdownV2 from '$lib/components/DropdownV2.svelte'
-	import DarkModeObserver from '$lib/components/DarkModeObserver.svelte'
 
 	let jobs: Job[] | undefined
 	let selectedIds: string[] = []
@@ -402,10 +401,8 @@
 		extendedJobs !== undefined &&
 		extendedJobs.jobs.length + extendedJobs.obscured_jobs.length >= 1000
 
-	let darkMode: boolean = false
 </script>
 
-<DarkModeObserver bind:darkMode />
 
 <JobLoader
 	{allWorkspaces}

--- a/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
@@ -80,7 +80,8 @@
 		: undefined
 
 	// Handled on the main page
-	let minTs = $page.url.searchParams.get('min_ts') ?? subtractDaysFromDateString((new Date()).toISOString(), 2)
+	let minTs =
+		$page.url.searchParams.get('min_ts') ?? subtractDaysFromDateString(new Date().toISOString(), 2)
 	let maxTs = $page.url.searchParams.get('max_ts') ?? undefined
 	let schedulePath = $page.url.searchParams.get('schedule_path') ?? undefined
 	let jobKindsCat = $page.url.searchParams.get('job_kinds') ?? 'runs'
@@ -404,7 +405,6 @@
 		extendedJobs.jobs.length + extendedJobs.obscured_jobs.length >= 1000
 
 	let darkMode: boolean = false
-
 </script>
 
 <DarkModeObserver bind:darkMode />
@@ -438,7 +438,7 @@
 	{resultError}
 	bind:loading
 	bind:this={jobLoader}
-	lookback={graphIsRunsChart ? 0: lookback}
+	lookback={graphIsRunsChart ? 0 : lookback}
 />
 
 <ConfirmationModal

--- a/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
@@ -592,7 +592,7 @@
 									<Tooltip>
 										How far behind the min datetime to start considering jobs for the concurrency
 										graph. Change this value to include jobs started before the set time window for
-										the computation of the concurrency graph
+										the computation of the graph
 									</Tooltip>
 								</div>
 							</svelte:fragment>
@@ -929,7 +929,7 @@
 									<Tooltip>
 										How far behind the min datetime to start considering jobs for the concurrency
 										graph. Change this value to include jobs started before the set time window for
-										the computation of the concurrency graph
+										the computation of the graph
 									</Tooltip>
 								</div>
 							</svelte:fragment>

--- a/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
@@ -36,6 +36,7 @@
 	import ToggleButtonGroup from '$lib/components/common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import ToggleButton from '$lib/components/common/toggleButton-v2/ToggleButton.svelte'
 	import DropdownV2 from '$lib/components/DropdownV2.svelte'
+	import DarkModeObserver from '$lib/components/DarkModeObserver.svelte'
 
 	let jobs: Job[] | undefined
 	let selectedIds: string[] = []
@@ -100,6 +101,7 @@
 	let runDrawer: Drawer
 	let isCancelingVisibleJobs = false
 	let isCancelingFilteredJobs = false
+	let lookback: number = 0
 
 	let innerWidth = window.innerWidth
 	let jobLoader: JobLoader | undefined = undefined
@@ -385,8 +387,11 @@
 	}
 
 	function jobCountString(count: number) {
+		return `${count} ${count == 1 ? 'job' : 'jobs'}`
+	}
 
-		return `${count} ${count == 1 ? 'job': 'jobs'}`
+	function setLookback(lookbackInDays: number) {
+		lookback = lookbackInDays
 	}
 
 	const warnJobLimitMsg =
@@ -397,7 +402,10 @@
 		extendedJobs !== undefined &&
 		extendedJobs.jobs.length + extendedJobs.obscured_jobs.length >= 1000
 
+	let darkMode: boolean = false
 </script>
+
+<DarkModeObserver bind:darkMode />
 
 <JobLoader
 	{allWorkspaces}
@@ -428,6 +436,7 @@
 	{resultError}
 	bind:loading
 	bind:this={jobLoader}
+	{lookback}
 />
 
 <ConfirmationModal
@@ -551,6 +560,41 @@
 							/>
 						</ToggleButtonGroup>
 					</div>
+					{#if !graphIsRunsChart}
+						<DropdownV2
+							items={[
+								{
+									displayName: 'None',
+									action: () => setLookback(0)
+								},
+								{
+									displayName: '1 days',
+									action: () => setLookback(1)
+								},
+								{
+									displayName: '3 days',
+									action: () => setLookback(3)
+								},
+								{
+									displayName: '7 days',
+									action: () => setLookback(7)
+								}
+							]}
+						>
+							<svelte:fragment slot="buttonReplacement">
+								<div
+									class="mt-1 p-2 h-8 flex flex-row items-center hover:bg-surface-hover cursor-pointer rounded-md"
+								>
+									<ChevronDown class="w-5 h-5" />
+									<span class="text-xs min-w-[5rem]">{lookback} days lookback</span>
+									<Tooltip>
+										How far behind the min datetime to start considering jobs for the concurrency
+										graph. Try changing it from zero if you want to zoom in on this graph.
+									</Tooltip>
+								</div>
+							</svelte:fragment>
+						</DropdownV2>
+					{/if}
 				</div>
 			</div>
 			{#if graph === 'RunChart'}
@@ -838,6 +882,41 @@
 						<ToggleButton value="RunChart" label="Duration" />
 						<ToggleButton value="ConcurrencyChart" label="Concurrency" />
 					</ToggleButtonGroup>
+					{#if !graphIsRunsChart}
+						<DropdownV2
+							items={[
+								{
+									displayName: 'None',
+									action: () => setLookback(0)
+								},
+								{
+									displayName: '1 days',
+									action: () => setLookback(1)
+								},
+								{
+									displayName: '3 days',
+									action: () => setLookback(3)
+								},
+								{
+									displayName: '7 days',
+									action: () => setLookback(7)
+								}
+							]}
+						>
+							<svelte:fragment slot="buttonReplacement">
+								<div
+									class="mt-1 p-2 h-8 flex flex-row items-center hover:bg-surface-hover cursor-pointer rounded-md"
+								>
+									<ChevronDown class="w-5 h-5" />
+									<span class="text-xs min-w-[5rem]">{lookback} days lookback</span>
+									<Tooltip>
+										How far behind the min datetime to start considering jobs for the concurrency
+										graph. Try changing it from zero if you want to zoom in on this graph.
+									</Tooltip>
+								</div>
+							</svelte:fragment>
+						</DropdownV2>
+					{/if}
 				</div>
 			</div>
 			{#if graph === 'RunChart'}

--- a/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
@@ -928,7 +928,8 @@
 									<span class="text-xs min-w-[5rem]">{lookback} days lookback</span>
 									<Tooltip>
 										How far behind the min datetime to start considering jobs for the concurrency
-										graph. Try changing it from zero if you want to zoom in on this graph.
+										graph. Change this value to include jobs started before the set time window for
+										the computation of the concurrency graph
 									</Tooltip>
 								</div>
 							</svelte:fragment>

--- a/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
@@ -37,6 +37,7 @@
 	import ToggleButton from '$lib/components/common/toggleButton-v2/ToggleButton.svelte'
 	import DropdownV2 from '$lib/components/DropdownV2.svelte'
 	import DarkModeObserver from '$lib/components/DarkModeObserver.svelte'
+	import { subtractDaysFromDateString } from '$lib/utils'
 
 	let jobs: Job[] | undefined
 	let selectedIds: string[] = []
@@ -79,7 +80,7 @@
 		: undefined
 
 	// Handled on the main page
-	let minTs = $page.url.searchParams.get('min_ts') ?? undefined
+	let minTs = $page.url.searchParams.get('min_ts') ?? subtractDaysFromDateString((new Date()).toISOString(), 2)
 	let maxTs = $page.url.searchParams.get('max_ts') ?? undefined
 	let schedulePath = $page.url.searchParams.get('schedule_path') ?? undefined
 	let jobKindsCat = $page.url.searchParams.get('job_kinds') ?? 'runs'
@@ -738,6 +739,13 @@
 									jobLoader?.loadJobs(minTs, maxTs, true)
 								}, 1000)
 							}}
+							on:clear={async () => {
+								minTs = undefined
+								calendarChangeTimeout && clearTimeout(calendarChangeTimeout)
+								calendarChangeTimeout = setTimeout(() => {
+									jobLoader?.loadJobs(minTs, maxTs, true)
+								}, 1000)
+							}}
 						/>
 					</div>
 				</div>
@@ -754,6 +762,13 @@
 							label="Max datetimes"
 							on:change={async ({ detail }) => {
 								maxTs = new Date(detail).toISOString()
+								calendarChangeTimeout && clearTimeout(calendarChangeTimeout)
+								calendarChangeTimeout = setTimeout(() => {
+									jobLoader?.loadJobs(minTs, maxTs, true)
+								}, 1000)
+							}}
+							on:clear={async () => {
+								maxTs = undefined
 								calendarChangeTimeout && clearTimeout(calendarChangeTimeout)
 								calendarChangeTimeout = setTimeout(() => {
 									jobLoader?.loadJobs(minTs, maxTs, true)
@@ -1064,6 +1079,13 @@
 									jobLoader?.loadJobs(minTs, maxTs, true)
 								}, 1000)
 							}}
+							on:clear={async () => {
+								minTs = undefined
+								calendarChangeTimeout && clearTimeout(calendarChangeTimeout)
+								calendarChangeTimeout = setTimeout(() => {
+									jobLoader?.loadJobs(minTs, maxTs, true)
+								}, 1000)
+							}}
 						/>
 					</div>
 				</div>
@@ -1080,6 +1102,13 @@
 							label="Max datetimes"
 							on:change={async ({ detail }) => {
 								maxTs = new Date(detail).toISOString()
+								calendarChangeTimeout && clearTimeout(calendarChangeTimeout)
+								calendarChangeTimeout = setTimeout(() => {
+									jobLoader?.loadJobs(minTs, maxTs, true)
+								}, 1000)
+							}}
+							on:clear={async () => {
+								maxTs = undefined
 								calendarChangeTimeout && clearTimeout(calendarChangeTimeout)
 								calendarChangeTimeout = setTimeout(() => {
 									jobLoader?.loadJobs(minTs, maxTs, true)


### PR DESCRIPTION
* Add a lookback selector to fetch extra jobs some days in the past and have less innacurate concurrency graphs
* Add a clear button on the date time picker
* Default the minTs to 2 days back on the runs page
* 
![image](https://github.com/windmill-labs/windmill/assets/53628737/4ab44b55-8d6e-4fd9-84d3-7855309bb8e2)
![image](https://github.com/windmill-labs/windmill/assets/53628737/ea2c0414-c38e-48a4-b8e2-f749cdb94525)
![image](https://github.com/windmill-labs/windmill/assets/53628737/40f0759b-efbd-41a4-82d6-3c57e4d23bbd)

<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0535f7ac001d067938a17a76d1b9092eec8e625a  | 
|--------|--------|

### Summary:
Added lookback selector, clear button on date picker, set default `minTs` to 2 days back for accurate concurrency graphs, and removed `publish_privately` job from GitHub Actions workflow.

**Key points**:
* Add a lookback selector to fetch extra jobs some days in the past for accurate concurrency graphs in `frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte` and `frontend/src/lib/components/runs/JobLoader.svelte`.
* Add a clear button on the date picker in `frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte` and `frontend/src/lib/components/runs/JobLoader.svelte`.
* Default the `minTs` to 2 days back on the runs page in `frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte` and `frontend/src/lib/components/runs/JobLoader.svelte`.
* Modify `fetchJobs` and `fetchExtendedJobs` calls to use `minTs` directly instead of `extendedMinTs` in `frontend/src/lib/components/runs/JobLoader.svelte`.
* Remove `publish_privately` job from `.github/workflows/build_ws.yml`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->