### PR TITLE
fix(frontend): improve flow input completion prompt when not in a loop

### DIFF
--- a/frontend/src/lib/components/copilot/IteratorGen.svelte
+++ b/frontend/src/lib/components/copilot/IteratorGen.svelte
@@ -54,7 +54,7 @@
 				flow_input: pickableProperties?.flow_input
 			}
 			const user = `I'm building a workflow which is a DAG of script steps.
-The current step is ${selectedId} and represents a for-loop. You can find the details of all the steps below:
+The current step is ${$selectedId} and represents a for-loop. You can find the details of all the steps below:
 ${flowDetails}
 Determine the iterator expression to pass either from the previous results or the flow inputs. Here's a summary of the available data:
 <available>

--- a/frontend/src/lib/components/copilot/PredicateGen.svelte
+++ b/frontend/src/lib/components/copilot/PredicateGen.svelte
@@ -46,7 +46,7 @@
 				flow_input: pickableProperties?.flow_input
 			}
 			const user = `I'm building a workflow which is a DAG of script steps.
-The current step is ${selectedId} and is a branching step (if-else). 
+The current step is ${$selectedId} and is a branching step (if-else). 
 The user wants to generate a predicate for the branching condition.
 Here's the user's request: ${instructions}
 You can find the details of all the steps below:

--- a/frontend/src/lib/components/copilot/StepInputGen.svelte
+++ b/frontend/src/lib/components/copilot/StepInputGen.svelte
@@ -84,16 +84,25 @@
 				results: pickableProperties?.priorIds,
 				flow_input: pickableProperties?.flow_input
 			}
+			const isInsideLoop = availableData.flow_input && 'iter' in availableData.flow_input
 			const user = `I'm building a workflow which is a DAG of script steps.
-The current step is ${selectedId}, you can find the details for the step and previous ones below:
+The current step is ${$selectedId}, you can find the details for the step and previous ones below:
 ${flowDetails}
 Determine for the input "${argName}", what to pass either from the previous results or the flow inputs. 
 All possibles inputs either start with results. or flow_input. and are followed by the key of the input.
-When the step is in a loop, the iterator value is accessible as flow_input.iter.value
+${
+	isInsideLoop
+		? 'As the step is in a loop, the iterator value is accessible as flow_input.iter.value.'
+		: 'As the step is not in a loop, flow_input.iter.value is not available.'
+}
 Here's a summary of the available data:
 <available>
 ${YAML.stringify(availableData)}</available>
-Favor results and flow_input.iter.value over flow inputs.
+${
+	isInsideLoop
+		? 'Favor results and flow_input.iter.value over flow inputs.'
+		: 'Favor results over flow inputs'
+}
 If none of the available results are appropriate, are already used or are more appropriate for other inputs, you can also imagine new flow_input properties which we will create programmatically based on what you provide.
 Reply with the most probable answer, do not explain or discuss.
 Use javascript object dot notation to access the properties.

--- a/frontend/src/lib/components/copilot/StepInputsGen.svelte
+++ b/frontend/src/lib/components/copilot/StepInputsGen.svelte
@@ -56,15 +56,20 @@
 				results: pickableProperties?.priorIds,
 				flow_input: pickableProperties?.flow_input
 			}
+			const isInsideLoop = availableData.flow_input && 'iter' in availableData.flow_input
 			const user = `I'm building a workflow which is a DAG of script steps. 
-The current step is ${selectedId}, you can find the details for the step and previous ones below:
+The current step is ${$selectedId}, you can find the details for the step and previous ones below:
 ${flowDetails}
 
 Determine for all the inputs "${argNames.join(
 				'", "'
 			)}", what to pass either from the previous results of the flow inputs. 
 All possibles inputs either start with results. or flow_input. and are followed by the key of the input.			
-When the step is in a loop, the iterator value is accessible as flow_input.iter.value
+${
+	isInsideLoop
+		? 'As the step is in a loop, the iterator value is accessible as flow_input.iter.value.'
+		: 'As the step is not in a loop, flow_input.iter.value is not available.'
+}
 Here's a summary of the available data:
 <available>
 ${YAML.stringify(availableData)}</available>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7b9cd68df7cff8675fe5ecaddcb52f27c1ee73e6  | 
|--------|--------|

### Summary:
Improved prompt messages for flow input completions in Svelte components to accurately reflect loop context.

**Key points**:
- **Updated** `frontend/src/lib/components/copilot/IteratorGen.svelte` to use `$selectedId` for the current step ID in the prompt message.
- **Updated** `frontend/src/lib/components/copilot/PredicateGen.svelte` to use `$selectedId` for the current step ID in the prompt message.
- **Enhanced** `frontend/src/lib/components/copilot/StepInputGen.svelte` to check if the step is inside a loop and adjust the prompt message accordingly.
- **Enhanced** `frontend/src/lib/components/copilot/StepInputsGen.svelte` to check if the step is inside a loop and adjust the prompt message accordingly.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->