### PR TITLE
fix(backend): correct version join of list search flows

### DIFF
--- a/backend/windmill-api/src/flows.rs
+++ b/backend/windmill-api/src/flows.rs
@@ -95,7 +95,7 @@ async fn list_search_flows(
         "SELECT flow.path, flow_version.value
         FROM flow 
         LEFT JOIN flow_version ON flow_version.id = flow.versions[array_upper(flow.versions, 1)]
-        WHERE workspace_id = $1 LIMIT $2",
+        WHERE flow.workspace_id = $1 LIMIT $2",
     )
     .bind(&w_id)
     .bind(n)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 9296f4b42b0b62775a63a59b1647e9a268287e14  | 
|--------|--------|

### Summary:
Fixed SQL query in `list_search_flows` function to correctly reference `flow.workspace_id`.

**Key points**:
- **File**: `backend/windmill-api/src/flows.rs`
- **Function**: `list_search_flows`
- **Change**: Corrected SQL query to use `flow.workspace_id` instead of `workspace_id`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->