### PR TITLE
feat: restore flow version as fork

### DIFF
--- a/frontend/src/lib/components/flows/FlowHistory.svelte
+++ b/frontend/src/lib/components/flows/FlowHistory.svelte
@@ -11,6 +11,7 @@
 	import Button from '../common/button/Button.svelte'
 	import { ArrowRight, Pencil, X } from 'lucide-svelte'
 	import { createEventDispatcher } from 'svelte'
+	import { goto } from '$app/navigation'
 
 	export let path: string
 	let drawer: Drawer
@@ -194,7 +195,7 @@
 									<Button
 										size="xs"
 										on:click={() =>
-											window.open(`/flows/add?template_id=${selectedVersion?.id}&template=${path}`)}
+											goto(`/flows/add?template_id=${selectedVersion?.id}&template=${path}`)}
 									>
 										Restore as fork
 									</Button>

--- a/frontend/src/lib/components/flows/FlowHistory.svelte
+++ b/frontend/src/lib/components/flows/FlowHistory.svelte
@@ -191,6 +191,13 @@
 									{/if}
 								</span>
 								<div class="flex p-1 gap-2">
+									<Button
+										size="xs"
+										on:click={() =>
+											window.open(`/flows/add?template_id=${selectedVersion?.id}&template=${path}`)}
+									>
+										Restore as fork
+									</Button>
 									<Button size="xs" on:click={() => restoreVersion(selected)}
 										>Redeploy with that version
 									</Button>

--- a/frontend/src/routes/(root)/(logged)/flows/add/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/flows/add/+page.svelte
@@ -25,6 +25,7 @@
 
 	const hubId = $page.url.searchParams.get('hub')
 	const templatePath = $page.url.searchParams.get('template')
+	const templateId = $page.url.searchParams.get('template_id')
 	const initialState = hubId || templatePath || nodraft ? undefined : localStorage.getItem('flow')
 
 	let selectedId: string = 'settings-metadata'
@@ -98,13 +99,21 @@
 			state?.selectedId && (selectedId = state?.selectedId)
 		} else {
 			if (templatePath) {
-				const template = await FlowService.getFlowByPath({
-					workspace: $workspaceStore!,
-					path: templatePath
-				})
+				let template: Flow
+				if (templateId) {
+					template = await FlowService.getFlowVersion({
+						workspace: $workspaceStore!,
+						path: templatePath,
+						version: parseInt(templateId)
+					})
+				} else {
+					template = await FlowService.getFlowByPath({
+						workspace: $workspaceStore!,
+						path: templatePath
+					})
+				}
 				Object.assign(flow, template)
 				const oldPath = templatePath.split('/')
-				console.log(oldPath)
 				initialPath = `u/${$userStore?.username.split('@')[0]}/${oldPath[oldPath.length - 1]}_fork`
 				flow = flow
 				goto('?', { replaceState: true })


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7f7b087b5186996c043d3464835458226ab327ca  | 
|--------|--------|

### Summary:
Added 'Restore as fork' functionality in flow history to fork specific flow versions and updated flow add page to handle template parameters.

**Key points**:
- Added 'Restore as fork' button in `frontend/src/lib/components/flows/FlowHistory.svelte`.
- Button navigates to `/flows/add` with `template_id` and `template` parameters using `goto` from `$app/navigation`.
- Updated `frontend/src/routes/(root)/(logged)/flows/add/+page.svelte` to handle `template_id` parameter.
- Fetches specific flow version using `FlowService.getFlowVersion` if `template_id` is present.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->