### PR TITLE
fix(frontend): fix navbar navigation for not deployed apps

### DIFF
--- a/frontend/src/lib/components/apps/components/display/AppNavbarItem.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppNavbarItem.svelte
@@ -65,7 +65,7 @@
 	$: !initialized && resolvedPath && initSelection()
 
 	function getButtonProps(resolvedPath: string | undefined) {
-		if (resolvedPath?.includes(appPath)) {
+		if (appPath && resolvedPath?.includes(appPath)) {
 			return {
 				onClick: () => {
 					output.result.set({ currentPath: resolvedPath ?? '' })


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f6668ce4dc8d1129896a84fafc836f75436b5b67  | 
|--------|--------|

### Summary:
Added a check to ensure `appPath` is defined before using it in `getButtonProps` to prevent runtime errors in `AppNavbarItem.svelte`.

**Key points**:
- **File**: `frontend/src/lib/components/apps/components/display/AppNavbarItem.svelte`
- **Function**: `getButtonProps`
- **Change**: Added a check to ensure `appPath` is defined before using it in the condition `resolvedPath?.includes(appPath)`.
- **Behavior**: Prevents runtime errors when `appPath` is undefined, ensuring smoother navigation for not deployed apps.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->