### PR TITLE
fix(backend): make value of flow_version not null

### DIFF
--- a/backend/.sqlx/query-4a764cdcb847b71183425a7a0e863708ef7fe2c88b28d0667988a47b9e995c0e.json
+++ b/backend/.sqlx/query-4a764cdcb847b71183425a7a0e863708ef7fe2c88b28d0667988a47b9e995c0e.json
@@ -16,7 +16,7 @@
       ]
     },
     "nullable": [
-      true
+      false
     ]
   },
   "hash": "4a764cdcb847b71183425a7a0e863708ef7fe2c88b28d0667988a47b9e995c0e"

--- a/backend/migrations/20240708075901_flow_versioning_nit.down.sql
+++ b/backend/migrations/20240708075901_flow_versioning_nit.down.sql
@@ -1,2 +1,2 @@
 -- Add down migration script here
-ALTER TABLE flow_version ALTER COLUMN VALUE SET NULL;
+ALTER TABLE flow_version ALTER COLUMN value DROP NOT NULL;

--- a/backend/migrations/20240708075901_flow_versioning_nit.down.sql
+++ b/backend/migrations/20240708075901_flow_versioning_nit.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+ALTER TABLE flow_version ALTER COLUMN VALUE SET NULL;

--- a/backend/migrations/20240708075901_flow_versioning_nit.up.sql
+++ b/backend/migrations/20240708075901_flow_versioning_nit.up.sql
@@ -1,2 +1,3 @@
 -- Add up migration script here
-ALTER TABLE flow_version ALTER COLUMN VALUE SET NOT NULL;
+UPDATE flow_version SET value = '{"modules":[]}'::jsonb WHERE value IS NULL;
+ALTER TABLE flow_version ALTER COLUMN value SET NOT NULL;

--- a/backend/migrations/20240708075901_flow_versioning_nit.up.sql
+++ b/backend/migrations/20240708075901_flow_versioning_nit.up.sql
@@ -1,0 +1,2 @@
+-- Add up migration script here
+ALTER TABLE flow_version ALTER COLUMN VALUE SET NOT NULL;

--- a/backend/windmill-worker/src/dedicated_worker.rs
+++ b/backend/windmill-worker/src/dedicated_worker.rs
@@ -415,7 +415,7 @@ pub async fn create_dedicated_worker_map(
                 flow_path,
                 _wp.workspace_id
             )
-            .fetch_one(db)
+            .fetch_optional(db)
             .await;
             if let Ok(v) = value {
                 if let Some(v) = v {


### PR DESCRIPTION
- **fix: flow versioning nit: make value of flow version not null**
- **fix: sqlx**

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1c8dd58fd8867ee918fb8fa48979dbe540e761bc  | 
|--------|--------|

### Summary:
Fixes the `flow_version.value` column to be non-null and updates the `create_dedicated_worker_map` function to handle optional query results.

**Key points**:
- **Modified** `backend/.sqlx/query-4a764cdcb847b71183425a7a0e863708ef7fe2c88b28d0667988a47b9e995c0e.json` to set `nullable` to `false` for `flow_version.value`.
- **Added** migration scripts `backend/migrations/20240708075901_flow_versioning_nit.up.sql` and `backend/migrations/20240708075901_flow_versioning_nit.down.sql` to update the `flow_version` table schema.
- **Updated** `backend/windmill-worker/src/dedicated_worker.rs` to use `fetch_optional` instead of `fetch_one` in `create_dedicated_worker_map` function.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->