### PR TITLE
fix(frontend): fix navbar item overflow

### DIFF
--- a/frontend/src/lib/components/apps/components/display/AppNavbar.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppNavbar.svelte
@@ -58,7 +58,7 @@
 		class={twMerge(
 			resolvedConfig?.orientation === 'horizontal'
 				? 'flex flex-row w-full items-center border-b px-4 gap-4 h-12'
-				: 'flex flex-col h-full items-start border-r px-8 gap-2 w-56'
+				: 'flex flex-col h-full items-start border-r px-8 gap-2 w-56 mt-4'
 		)}
 	>
 		{#if resolvedConfig.logo?.selected === 'yes'}

--- a/frontend/src/lib/components/apps/components/display/AppNavbarItem.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppNavbarItem.svelte
@@ -156,7 +156,7 @@
 			color="light"
 			size="xs"
 			disabled={resolvedDisabled}
-			btnClasses={orientation === 'vertical' ? '!justify-start' : ''}
+			btnClasses={orientation === 'vertical' ? '!justify-start !whitespace-normal !text-left' : ''}
 		>
 			{#if navbarItem.icon}
 				{#key navbarItem.icon}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1f5b4b20cb8164bbe65d23d189bfd386ed217896  | 
|--------|--------|

### Summary:
Fixed navbar item overflow in vertical orientation by adding specific CSS classes in `AppNavbar.svelte` and `AppNavbarItem.svelte`.

**Key points**:
- Updated `frontend/src/lib/components/apps/components/display/AppNavbar.svelte` to add `mt-4` margin-top class for vertical orientation.
- Modified `frontend/src/lib/components/apps/components/display/AppNavbarItem.svelte` to add `!whitespace-normal` and `!text-left` classes for vertical orientation to handle text overflow.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->