### PR TITLE
feat(frontend): add custom actions header

### DIFF
--- a/frontend/src/lib/components/apps/components/display/table/AppAggridExplorerTable.svelte
+++ b/frontend/src/lib/components/apps/components/display/table/AppAggridExplorerTable.svelte
@@ -212,7 +212,9 @@
 
 		if (actions && actions.length > 0) {
 			r.push({
-				headerName: 'Actions',
+				headerName: resolvedConfig?.customActionsHeader
+					? resolvedConfig?.customActionsHeader
+					: 'Actions',
 				cellRenderer: tableActionsFactory,
 				autoHeight: true,
 				cellStyle: { textAlign: 'center' },

--- a/frontend/src/lib/components/apps/components/display/table/AppAggridTable.svelte
+++ b/frontend/src/lib/components/apps/components/display/table/AppAggridTable.svelte
@@ -252,7 +252,9 @@
 				// Add the action column if actions are defined
 				if (actions && actions.length > 0) {
 					columnDefs.push({
-						headerName: 'Actions',
+						headerName: resolvedConfig?.customActionsHeader
+							? resolvedConfig?.customActionsHeader
+							: 'Actions',
 						cellRenderer: tableActionsFactory,
 						autoHeight: true,
 						cellStyle: { textAlign: 'center' },
@@ -392,7 +394,9 @@
 			// Add the action column if actions are defined
 			if (actions && actions.length > 0) {
 				columnDefs.push({
-					headerName: 'Actions',
+					headerName: resolvedConfig?.customActionsHeader
+						? resolvedConfig?.customActionsHeader
+						: 'Actions',
 					cellRenderer: tableActionsFactory,
 					autoHeight: true,
 					cellStyle: { textAlign: 'center' },

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -742,6 +742,12 @@ const aggridcomponentconst = {
 				fieldType: 'boolean',
 				value: true,
 				tooltip: 'Allow visible footer for pagination and download'
+			},
+			customActionsHeader: {
+				type: 'static',
+				fieldType: 'text',
+				value: undefined,
+				tooltip: 'Custom header for the actions columns'
 			}
 		},
 		componentInput: {
@@ -845,6 +851,12 @@ const aggridinfinitecomponentconst = {
 				fieldType: 'boolean',
 				value: true,
 				tooltip: 'Allow visible footer for pagination and download'
+			},
+			customActionsHeader: {
+				type: 'static',
+				fieldType: 'text',
+				value: undefined,
+				tooltip: 'Custom header for the actions columns'
 			}
 		},
 		componentInput: {
@@ -3778,6 +3790,12 @@ See date-fns format for more information. By default, it is 'dd.MM.yyyy HH:mm'
 					fieldType: 'boolean',
 					value: true,
 					tooltip: 'Allow visible footer for pagination and download'
+				},
+				customActionsHeader: {
+					type: 'static',
+					fieldType: 'text',
+					value: undefined,
+					tooltip: 'Custom actions header'
 				}
 			},
 			componentInput: undefined

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -3795,7 +3795,7 @@ See date-fns format for more information. By default, it is 'dd.MM.yyyy HH:mm'
 					type: 'static',
 					fieldType: 'text',
 					value: undefined,
-					tooltip: 'Custom actions header'
+					tooltip: 'Custom header for the actions columns'
 				}
 			},
 			componentInput: undefined


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c078e141b0dc1fb782d0ceb00b1228e48c9fab1c  | 
|--------|--------|

### Summary:
Added a feature to allow custom headers for action columns in ag-Grid tables by introducing a `customActionsHeader` configuration option.

**Key points**:
- Added `customActionsHeader` configuration option to `resolvedConfig` in `frontend/src/lib/components/apps/components/display/table/AppAggridExplorerTable.svelte` and `frontend/src/lib/components/apps/components/display/table/AppAggridTable.svelte`.
- Updated `transformColumnDefs` and `mountGrid` functions to use `customActionsHeader` if provided.
- Modified `frontend/src/lib/components/apps/editor/component/components.ts` to include `customActionsHeader` in the initial configuration for `aggridcomponent`, `aggridinfinitecomponent`, and `dbexplorercomponent`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->