### PR TITLE
fix(frontend): fix min rows for LightWeightArgInput

### DIFF
--- a/frontend/src/lib/components/LightweightArgInput.svelte
+++ b/frontend/src/lib/components/LightweightArgInput.svelte
@@ -522,7 +522,7 @@
 								<Password bind:password={value} />
 							{:else}
 								<textarea
-									rows={extra?.['rows'] || 1}
+									rows={extra?.['minRows'] || 1}
 									bind:this={el}
 									on:focus={(e) => {
 										dispatch('focus')


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 793df4c9d1e0cde63a1ea2c6df176b6e232282fc  | 
|--------|--------|

### Summary:
Updated `textarea` element in `frontend/src/lib/components/LightweightArgInput.svelte` to use `extra?.['minRows']` for the `rows` attribute.

**Key points**:
- **File Modified**: `frontend/src/lib/components/LightweightArgInput.svelte`
- **Change**: Updated `textarea` element to use `extra?.['minRows']` instead of `extra?.['rows']` for the `rows` attribute.
- **Behavior**: Ensures the minimum number of rows for the `textarea` is set based on the `minRows` property in the `extra` object.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->