### PR TITLE
fix(frontend): Reload the flowStateStore when a node is restored (undo)

### DIFF
--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -1075,7 +1075,25 @@
 						undoProps={{ disabled: $history.index === 0 }}
 						redoProps={{ disabled: $history.index === $history.history.length - 1 }}
 						on:undo={() => {
+							const currentModules = $flowStore?.value?.modules
+
 							$flowStore = undo(history, $flowStore)
+
+							const newModules = $flowStore?.value?.modules
+							const restoredModules = newModules?.filter(
+								(node) => !currentModules?.some((currentNode) => currentNode?.id === node?.id)
+							)
+
+							for (const mod of restoredModules) {
+								if (mod) {
+									try {
+										loadFlowModuleState(mod).then((state) => ($flowStateStore[mod.id] = state))
+									} catch (e) {
+										console.error('Error loading state for restored node', e)
+									}
+								}
+							}
+
 							$selectedIdStore = 'Input'
 						}}
 						on:redo={() => {


### PR DESCRIPTION
Fix for: https://github.com/windmill-labs/windmill/issues/3990
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 99b71b18f3c86ca898a6751b951abad56d30414f  | 
|--------|--------|

### Summary:
Reloads `flowStateStore` for restored nodes when undoing an action in `FlowBuilder.svelte`.

**Key points**:
- **File Modified**: `frontend/src/lib/components/FlowBuilder.svelte`
- **Function Modified**: `on:undo` event handler in `UndoRedo` component
- **Change**: Reloads `flowStateStore` for restored nodes when undoing an action.
- **Details**: 
  - Captures current modules before undo.
  - Identifies restored modules after undo.
  - Reloads state for each restored module using `loadFlowModuleState`.
  - Logs errors if state loading fails.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->