### PR TITLE
fix: update flow path

### DIFF
--- a/backend/windmill-api/src/flows.rs
+++ b/backend/windmill-api/src/flows.rs
@@ -730,7 +730,7 @@ async fn update_flow(
 
     sqlx::query!(
         "UPDATE flow SET versions = array_append(versions, $1) WHERE path = $2 AND workspace_id = $3",
-        version, flow_path, w_id
+        version, nf.path, w_id
     ).execute(&mut tx).await?;
 
     if is_new_path {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b42b5a18c57d3ff16b66efd05431d0c8746eb5f0  | 
|--------|--------|

### Summary:
Updated SQL query in `update_flow` function to use `nf.path` instead of `flow_path` for the `path` parameter.

**Key points**:
- **File**: `backend/windmill-api/src/flows.rs`
- **Function**: `update_flow`
- **Change**: Updated SQL query to use `nf.path` instead of `flow_path` for the `path` parameter in the `UPDATE flow SET versions` statement.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->