### PR TITLE
feat(frontend): add support for GFM and fix max-width issue

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -43,7 +43,7 @@
 				"quill": "^1.3.7",
 				"svelte-carousel": "^1.0.25",
 				"svelte-chartjs": "^3.1.5",
-				"svelte-exmarkdown": "^3.0.3",
+				"svelte-exmarkdown": "^3.0.5",
 				"svelte-infinite-loading": "^1.3.8",
 				"svelte-portal": "^2.2.1",
 				"svelte-tiny-virtual-list": "^2.0.5",
@@ -9308,9 +9308,9 @@
 			}
 		},
 		"node_modules/svelte-exmarkdown": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/svelte-exmarkdown/-/svelte-exmarkdown-3.0.3.tgz",
-			"integrity": "sha512-SRQl95iTC+FeOHxotDM+gab/QufRj+iNrYKIrxssrkqOg2dEF2e1/+JirQvtsKWoCH2tek81LoiDM0/bADa7tQ==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/svelte-exmarkdown/-/svelte-exmarkdown-3.0.5.tgz",
+			"integrity": "sha512-x0ELw7oTziBaJLFsdGZaoursycGK9HPzxRTRZ/rBi2KmseFG29ryyborJxFmeE0X6ORrEW1pRjoi8q41xpIeRQ==",
 			"dependencies": {
 				"remark-gfm": "^4.0.0",
 				"remark-parse": "^11.0.0",
@@ -9318,7 +9318,7 @@
 				"unified": "^11.0.0"
 			},
 			"peerDependencies": {
-				"svelte": "^3.47.0 || ^4.0.0"
+				"svelte": "^3.47.0 || ^4.0.0 || >=5.0.0-next.115"
 			}
 		},
 		"node_modules/svelte-floating-ui": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -123,7 +123,7 @@
 		"quill": "^1.3.7",
 		"svelte-carousel": "^1.0.25",
 		"svelte-chartjs": "^3.1.5",
-		"svelte-exmarkdown": "^3.0.3",
+		"svelte-exmarkdown": "^3.0.5",
 		"svelte-infinite-loading": "^1.3.8",
 		"svelte-portal": "^2.2.1",
 		"svelte-tiny-virtual-list": "^2.0.5",

--- a/frontend/src/lib/components/apps/components/display/AppMarkdown.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppMarkdown.svelte
@@ -86,10 +86,7 @@
 	>
 		{#if result}
 			{#key result}
-				<Markdown
-					md={result}
-					plugins={resolvedConfig?.GithubFlavoredMarkdownEnabled ? [gfmPlugin()] : []}
-				/>
+				<Markdown md={result} plugins={[gfmPlugin()]} />
 			{/key}
 		{/if}
 	</RunnableWrapper>

--- a/frontend/src/lib/components/apps/components/display/AppMarkdown.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppMarkdown.svelte
@@ -10,7 +10,7 @@
 	import { components } from '../../editor/component'
 	import ResolveConfig from '../helpers/ResolveConfig.svelte'
 	import ResolveStyle from '../helpers/ResolveStyle.svelte'
-
+	import { gfmPlugin } from 'svelte-exmarkdown/gfm'
 	export let id: string
 	export let componentInput: AppInput | undefined
 	export let initializing: boolean | undefined = undefined
@@ -67,7 +67,7 @@
 		e?.preventDefault()
 	}}
 	class={classNames(
-		'h-full w-full overflow-y-auto prose',
+		'h-full w-full overflow-y-auto prose max-w-full',
 		resolvedConfig?.size ? proseMapping[resolvedConfig.size] : '',
 		css?.container?.class,
 		' dark:prose-invert',
@@ -86,7 +86,10 @@
 	>
 		{#if result}
 			{#key result}
-				<Markdown md={result} />
+				<Markdown
+					md={result}
+					plugins={resolvedConfig?.GithubFlavoredMarkdownEnabled ? [gfmPlugin()] : []}
+				/>
 			{/key}
 		{/if}
 	</RunnableWrapper>

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -1600,12 +1600,6 @@ This is a paragraph.
 					value: 'Default',
 
 					tooltip: 'See Tailwind documentation: https://tailwindcss.com/docs/typography-plugin'
-				},
-				GithubFlavoredMarkdownEnabled: {
-					fieldType: 'boolean',
-					type: 'static',
-					value: false,
-					tooltip: 'Enable Github flavored markdown. Lean more at https://github.github.com/gfm/'
 				}
 			}
 		}

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -1600,6 +1600,12 @@ This is a paragraph.
 					value: 'Default',
 
 					tooltip: 'See Tailwind documentation: https://tailwindcss.com/docs/typography-plugin'
+				},
+				GithubFlavoredMarkdownEnabled: {
+					fieldType: 'boolean',
+					type: 'static',
+					value: false,
+					tooltip: 'Enable Github flavored markdown. Lean more at https://github.github.com/gfm/'
 				}
 			}
 		}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ebded30159ace963bcff772f567f66928ffdcd92  | 
|--------|--------|

### Summary:
Added support for GitHub Flavored Markdown, fixed max-width issue, and removed `GithubFlavoredMarkdownEnabled` configuration option in Markdown component.

**Key points**:
- Updated `svelte-exmarkdown` dependency in `frontend/package.json` to `^3.0.5`.
- Imported `gfmPlugin` from `svelte-exmarkdown/gfm` in `frontend/src/lib/components/apps/components/display/AppMarkdown.svelte`.
- Modified `Markdown` component in `AppMarkdown.svelte` to use `gfmPlugin`.
- Added `max-w-full` class to Markdown container in `AppMarkdown.svelte` to fix max-width issue.
- Removed `GithubFlavoredMarkdownEnabled` configuration option from `MarkdownComponent` in `frontend/src/lib/components/apps/editor/component/components.ts`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->