### PR TITLE
fix(frontend): fix style panel title

### DIFF
--- a/frontend/src/lib/components/apps/editor/AppEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditor.svelte
@@ -328,7 +328,10 @@
 
 	// Animation logic for cssInput
 	$: animateCssInput($cssEditorOpen)
-	$: $cssEditorOpen && secondaryMenuLeft?.open(StylePanel, {})
+	$: $cssEditorOpen &&
+		secondaryMenuLeft?.open(StylePanel, {
+			type: 'style'
+		})
 
 	function animateCssInput(cssEditorOpen: boolean) {
 		if (cssEditorOpen && !cssToggled) {

--- a/frontend/src/lib/components/apps/editor/settingsPanel/ComponentPanel.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/ComponentPanel.svelte
@@ -415,7 +415,7 @@
 						size="xs"
 						variant="border"
 						startIcon={{ icon: ChevronLeft }}
-						on:click={() => secondaryMenuLeft.toggle(StylePanel, {})}
+						on:click={() => secondaryMenuLeft.toggle(StylePanel, { type: 'style' })}
 					>
 						Show
 					</Button>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b63a43033f19662688992dc30ef11749e3d75717  | 
|--------|--------|

### Summary:
Added `type: 'style'` parameter to `StylePanel` openings in `AppEditor.svelte` and `ComponentPanel.svelte` to ensure correct identification and behavior.

**Key points**:
- **Updated** `frontend/src/lib/components/apps/editor/AppEditor.svelte` to pass `{ type: 'style' }` when opening `StylePanel`.
- **Updated** `frontend/src/lib/components/apps/editor/settingsPanel/ComponentPanel.svelte` to pass `{ type: 'style' }` when toggling `StylePanel`.
- **Ensures** the style panel is correctly identified and opened with the appropriate type.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->