### PR TITLE
fix(frontend): fix run page ms readability

### DIFF
--- a/frontend/src/lib/components/DurationMs.svelte
+++ b/frontend/src/lib/components/DurationMs.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { msToSec } from '$lib/utils'
+	import { msToReadableTime } from '$lib/utils'
 	import { Badge } from './common'
 	import { Hourglass } from 'lucide-svelte'
 	import WaitTimeWarning from './common/waitTimeWarning/WaitTimeWarning.svelte'
@@ -11,7 +11,7 @@
 
 <div>
 	<Badge large icon={{ icon: Hourglass, position: 'left' }}>
-		Ran in {msToSec(duration_ms)}s
+		Ran in {msToReadableTime(duration_ms)}
 		{#if self_wait_time_ms || aggregate_wait_time_ms}
 			<WaitTimeWarning {self_wait_time_ms} {aggregate_wait_time_ms} variant="alert" />
 		{/if}

--- a/frontend/src/lib/components/runs/RunRow.svelte
+++ b/frontend/src/lib/components/runs/RunRow.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation'
 	import type { Job } from '$lib/gen'
-	import { displayDate, msToSec, truncateHash, truncateRev } from '$lib/utils'
+	import { displayDate, msToReadableTime, truncateHash, truncateRev } from '$lib/utils'
 	import { Badge, Button } from '../common'
 	import ScheduleEditor from '../ScheduleEditor.svelte'
 	import BarsStaggered from '$lib/components/icons/BarsStaggered.svelte'
@@ -107,9 +107,9 @@
 				{#if 'started_at' in job && job.started_at}
 					Started <TimeAgo withDate agoOnlyIfRecent date={job.started_at ?? ''} />
 					{#if job && 'duration_ms' in job && job.duration_ms != undefined}
-						(Ran in {msToSec(
+						(Ran in {msToReadableTime(
 							job.duration_ms
-						)}s{#if job.job_kind == 'flow' || job.job_kind == 'flowpreview'}&nbsp;total{/if})
+						)}{#if job.job_kind == 'flow' || job.job_kind == 'flowpreview'}&nbsp;total{/if})
 					{/if}
 					{#if job && (job.self_wait_time_ms || job.aggregate_wait_time_ms)}
 						<WaitTimeWarning

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -113,6 +113,25 @@ export function msToSec(ms: number | undefined, maximumFractionDigits?: number):
 	})
 }
 
+export function msToReadableTime(ms: number | undefined): string {
+	if (ms === undefined) return '?'
+
+	const seconds = Math.floor(ms / 1000)
+	const minutes = Math.floor(seconds / 60)
+	const hours = Math.floor(minutes / 60)
+	const days = Math.floor(hours / 24)
+
+	if (days > 0) {
+		return `${days}d ${hours % 24}h ${minutes % 60}m ${seconds % 60}s`
+	} else if (hours > 0) {
+		return `${hours}h ${minutes % 60}m ${seconds % 60}s`
+	} else if (minutes > 0) {
+		return `${minutes}m ${seconds % 60}s`
+	} else {
+		return `${seconds}s`
+	}
+}
+
 export function getToday() {
 	var today = new Date()
 	return today
@@ -271,7 +290,6 @@ export function itemsExists<T>(arr: T[] | undefined, item: T): boolean {
 	}
 	return false
 }
-
 
 export function groupBy<K, V>(
 	items: V[],


### PR DESCRIPTION
<img width="177" alt="Screenshot 2024-07-10 at 17 10 09" src="https://github.com/windmill-labs/windmill/assets/456655/d58b1c35-e739-4bf4-bf20-b60ad92e74e0">

<img width="328" alt="Screenshot 2024-07-10 at 17 12 49" src="https://github.com/windmill-labs/windmill/assets/456655/0e1ffc25-2b34-4da2-b844-0b95ccce228d">

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c0424b67012337723df027b874f9ad4dcf7e795e  | 
|--------|--------|

### Summary:
Improved run duration readability by changing the display format from seconds to a more human-readable format in the frontend.

**Key points**:
- **Changed**: `frontend/src/lib/components/DurationMs.svelte` to use `msToReadableTime` instead of `msToSec` for displaying run duration.
- **Changed**: `frontend/src/lib/components/runs/RunRow.svelte` to use `msToReadableTime` instead of `msToSec` for displaying run duration.
- **Added**: `msToReadableTime` function in `frontend/src/lib/utils.ts` to convert milliseconds to a human-readable format (days, hours, minutes, seconds).


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->