### PR TITLE
Smaller and better positioned Add branch message

### DIFF
--- a/frontend/src/lib/components/flows/content/FlowBranchesAllWrapper.svelte
+++ b/frontend/src/lib/components/flows/content/FlowBranchesAllWrapper.svelte
@@ -45,7 +45,6 @@
 						<h3 class="mb-4"
 							>{value.branches.length} branch{value.branches.length > 1 ? 'es' : ''}</h3
 						>
-						<p>Add branches and steps directly on the graph.</p>
 						<div class="flex flex-col gap-y-4 py-2 w-full">
 							{#each value.branches as branch, i}
 								<div class="flex flex-row gap-x-4 w-full items-center">
@@ -64,6 +63,7 @@
 								</div>
 							{/each}
 						</div>
+						<p class="text-sm">Add branches and steps directly on the graph.</p>
 						<div class="mt-6 mb-2 text-sm font-bold">Run in parallel</div>
 						<Toggle
 							bind:checked={value.parallel}

--- a/frontend/src/lib/components/flows/content/FlowBranchesOneWrapper.svelte
+++ b/frontend/src/lib/components/flows/content/FlowBranchesOneWrapper.svelte
@@ -47,7 +47,6 @@
 						<h3 class="my-4">
 							{value.branches.length + 1} branch{value.branches.length + 1 > 1 ? 'es' : ''}
 						</h3>
-						<p>Add branches and steps directly on the graph.</p>
 						<div class="py-2">
 							<div class="flex flex-row gap-2 text-sm p-2">
 								<Badge large={true} color="blue">Default branch</Badge>
@@ -83,6 +82,7 @@
 								</div>
 							{/each}
 						</div>
+						<p class="text-sm">Add branches and steps directly on the graph.</p>
 					</div>
 				</Pane>
 				{#if flowModule}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7ef70c32238d6934e84e448d76d23faad8e8cc59  | 
|--------|--------|

### Summary:
Repositioned and resized the 'Add branches and steps directly on the graph.' message in `FlowBranchesAllWrapper.svelte` and `FlowBranchesOneWrapper.svelte`.

**Key points**:
- Updated `frontend/src/lib/components/flows/content/FlowBranchesAllWrapper.svelte` to reposition and resize the 'Add branches and steps directly on the graph.' message.
- Updated `frontend/src/lib/components/flows/content/FlowBranchesOneWrapper.svelte` to reposition and resize the 'Add branches and steps directly on the graph.' message.
- The message is now placed after the list of branches and has a smaller text size (`text-sm`).


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->