### PR TITLE
chore: staging image CI

### DIFF
--- a/.github/workflows/build-staging-image.yml
+++ b/.github/workflows/build-staging-image.yml
@@ -1,0 +1,70 @@
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+name: Build windmill-staging
+on:
+  workflow_dispatch:
+
+permissions: write-all
+
+jobs:
+  build_ee:
+    runs-on: ubicloud
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read EE repo commit hash
+        run: |
+          echo "ee_repo_ref=$(cat ./backend/ee-repo-ref.txt)" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v4
+        with:
+          repository: windmill-labs/windmill-ee-private
+          path: ./windmill-ee-private
+          ref: ${{ env.ee_repo_ref }}
+          token: ${{ secrets.WINDMILL_EE_PRIVATE_ACCESS }}
+          fetch-depth: 0
+
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v2
+      - uses: depot/setup-action@v1
+
+      - name: Docker meta
+        id: meta-ee-public
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-staging-ee
+          flavor: |
+            latest=false
+          tags: |
+            type=sha
+            type=branch,event=workflow_dispatch
+
+      - name: Login to registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Substitute EE code
+        run: |
+          ./backend/substitute_ee_code.sh --copy --dir ./windmill-ee-private
+
+      - name: Build and push publicly ee
+        uses: depot/build-push-action@v1
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            features=enterprise,enterprise_saml,stripe,embedding,parquet,prometheus,openidconnect,cloud,jemalloc
+          tags: |
+            ${{ steps.meta-ee-public.outputs.tags }}
+          labels: |
+            ${{ steps.meta-ee-public.outputs.labels }}
+            org.opencontainers.image.licenses=Windmill-Enterprise-License


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 022aa6f17e49f25f7ed6fecd5bd97872f5dba886  | 
|--------|--------|

### Summary:
Add GitHub Actions workflow to build and push a staging Docker image for the enterprise edition.

**Key points**:
- Add `.github/workflows/build-staging-image.yml` to define a new GitHub Actions workflow.
- Workflow triggers on `workflow_dispatch` event.
- Job `build_ee` runs on `ubicloud` and includes steps:
  - Checkout repository with `actions/checkout@v4`.
  - Read EE repo commit hash from `./backend/ee-repo-ref.txt`.
  - Checkout `windmill-ee-private` repository using the commit hash.
  - Set up Docker using `depot/setup-action@v1`.
  - Generate Docker metadata with `docker/metadata-action@v4`.
  - Login to Docker registry using `docker/login-action@v2`.
  - Substitute EE code using `./backend/substitute_ee_code.sh`.
  - Build and push Docker image using `depot/build-push-action@v1` with specified build args, tags, and labels.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->