### PR TITLE
fix: add indexer case to avoid 0 max_database_connection

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -259,7 +259,7 @@ async fn windmill_main() -> anyhow::Result<()> {
     };
 
     tracing::info!("Connecting to database...");
-    let db = windmill_common::connect_db(server_mode).await?;
+    let db = windmill_common::connect_db(server_mode, indexer_mode).await?;
     tracing::info!("Database connected");
 
     let num_version = sqlx::query_scalar!("SELECT version()").fetch_one(&db).await;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4fe25f36ec61bba6696decc4160733d3fec7df39  | 
|--------|--------|

### Summary:
Added `indexer_mode` handling to set default max database connections for indexers in `connect_db` function.

**Key points**:
- **Modified** `backend/src/main.rs` to pass `indexer_mode` to `connect_db`.
- **Updated** `connect_db` function in `backend/windmill-common/src/lib.rs` to handle `indexer_mode`.
- **Added** `DEFAULT_MAX_CONNECTIONS_INDEXER` constant in `backend/windmill-common/src/lib.rs`.
- **Handled** case where `indexer_mode` sets max database connections to `DEFAULT_MAX_CONNECTIONS_INDEXER`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->