### PR TITLE
fix: make indexer opt-in when in standalone mode

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -150,6 +150,8 @@ async fn windmill_main() -> anyhow::Result<()> {
         _ => {}
     }
 
+    let mut enable_indexer: bool = false;
+
     let mode = std::env::var("MODE")
         .map(|x| x.to_lowercase())
         .map(|x| {
@@ -180,10 +182,15 @@ async fn windmill_main() -> anyhow::Result<()> {
                 {
                     panic!("Indexer mode requires the tantivy feature flag");
                 }
-
+                enable_indexer = true;
                 #[cfg(feature = "tantivy")]
                 Mode::Indexer
-            } else {
+            } else if &x == "standalone+search"{
+                    enable_indexer = true;
+                    tracing::info!("Binary is in 'standalone' mode with search enabled");
+                    Mode::Standalone
+            }
+            else {
                 if &x != "standalone" {
                     tracing::error!("mode not recognized, defaulting to standalone: {x}");
                 } else {
@@ -358,7 +365,8 @@ Windmill Community Edition {GIT_VERSION}
             .expect("could not create initial server dir");
 
         #[cfg(feature = "tantivy")]
-        let should_index_jobs = mode == Mode::Indexer || mode == Mode::Standalone;
+        let should_index_jobs =
+            enable_indexer && (mode == Mode::Indexer || mode == Mode::Standalone);
 
         #[cfg(not(feature = "tantivy"))]
         let should_index_jobs = false;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -150,7 +150,7 @@ async fn windmill_main() -> anyhow::Result<()> {
         _ => {}
     }
 
-    let mut enable_indexer: bool = false;
+    let mut enable_standalone_indexer: bool = false;
 
     let mode = std::env::var("MODE")
         .map(|x| x.to_lowercase())
@@ -182,11 +182,10 @@ async fn windmill_main() -> anyhow::Result<()> {
                 {
                     panic!("Indexer mode requires the tantivy feature flag");
                 }
-                enable_indexer = true;
                 #[cfg(feature = "tantivy")]
                 Mode::Indexer
             } else if &x == "standalone+search"{
-                    enable_indexer = true;
+                    enable_standalone_indexer = true;
                     tracing::info!("Binary is in 'standalone' mode with search enabled");
                     Mode::Standalone
             }
@@ -366,7 +365,7 @@ Windmill Community Edition {GIT_VERSION}
 
         #[cfg(feature = "tantivy")]
         let should_index_jobs =
-            enable_indexer && (mode == Mode::Indexer || mode == Mode::Standalone);
+              mode == Mode::Indexer || (enable_standalone_indexer && mode == Mode::Standalone);
 
         #[cfg(not(feature = "tantivy"))]
         let should_index_jobs = false;


### PR DESCRIPTION
add the possibility to run the ee image without the indexer in standalone mode
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1c0f6a9ed2e0a8223d01d10d578ec0a1af48f1ec  | 
|--------|--------|

### Summary:
Added `standalone+search` mode and `enable_standalone_indexer` flag to control indexer activation in standalone mode in `backend/src/main.rs`.

**Key points**:
- Added `standalone+search` mode to run the application in standalone mode with search enabled in `backend/src/main.rs`.
- Introduced `enable_standalone_indexer` flag to control the indexer activation.
- Modified mode parsing logic in `windmill_main` to handle `standalone+search` mode.
- Updated `should_index_jobs` logic to consider `enable_standalone_indexer` flag.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->