### PR TITLE
fix(frontend): Handle three significant digits for jobs that ran in l…

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -129,7 +129,7 @@ export function msToReadableTime(ms: number | undefined): string {
 	} else if (minutes > 0) {
 		return `${minutes}m ${seconds % 60}s`
 	} else {
-		return `${seconds}s`
+		return `${msToSec(ms)}s`
 	}
 }
 


### PR DESCRIPTION
Fix for :https://github.com/windmill-labs/windmill/issues/4083
…ess than 1 min
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3d5d232573a14ea98189a5b4a45a5b003e7e0ed8  | 
|--------|--------|

### Summary:
Modified `msToReadableTime` in `frontend/src/lib/utils.ts` to display seconds with three significant digits for jobs that ran in less than 1 minute.

**Key points**:
- **File Modified**: `frontend/src/lib/utils.ts`
- **Function Modified**: `msToReadableTime`
- **Change**: Replaced `seconds` with `msToSec(ms)` to display seconds with three significant digits for jobs that ran in less than 1 minute.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->