### PR TITLE
chore: publish oneOf parser improvement

### DIFF
--- a/backend/parsers/windmill-parser-wasm/pkg/package.json
+++ b/backend/parsers/windmill-parser-wasm/pkg/package.json
@@ -3,7 +3,7 @@
   "collaborators": [
     "Ruben Fiszel <ruben@windmill.dev>"
   ],
-  "version": "1.355.4",
+  "version": "1.364.3",
   "files": [
     "windmill_parser_wasm_bg.wasm",
     "windmill_parser_wasm.js",

--- a/backend/parsers/windmill-parser-wasm/pkg/windmill_parser_wasm.js
+++ b/backend/parsers/windmill-parser-wasm/pkg/windmill_parser_wasm.js
@@ -6,6 +6,20 @@ heap.push(undefined, null, true, false);
 
 function getObject(idx) { return heap[idx]; }
 
+let heap_next = heap.length;
+
+function dropObject(idx) {
+    if (idx < 132) return;
+    heap[idx] = heap_next;
+    heap_next = idx;
+}
+
+function takeObject(idx) {
+    const ret = getObject(idx);
+    dropObject(idx);
+    return ret;
+}
+
 let WASM_VECTOR_LEN = 0;
 
 let cachedUint8Memory0 = null;
@@ -84,27 +98,13 @@ function getInt32Memory0() {
     return cachedInt32Memory0;
 }
 
-let heap_next = heap.length;
+let cachedFloat64Memory0 = null;
 
-function dropObject(idx) {
-    if (idx < 132) return;
-    heap[idx] = heap_next;
-    heap_next = idx;
-}
-
-function takeObject(idx) {
-    const ret = getObject(idx);
-    dropObject(idx);
-    return ret;
-}
-
-const cachedTextDecoder = (typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-8', { ignoreBOM: true, fatal: true }) : { decode: () => { throw Error('TextDecoder not available') } } );
-
-if (typeof TextDecoder !== 'undefined') { cachedTextDecoder.decode(); };
-
-function getStringFromWasm0(ptr, len) {
-    ptr = ptr >>> 0;
-    return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
+function getFloat64Memory0() {
+    if (cachedFloat64Memory0 === null || cachedFloat64Memory0.byteLength === 0) {
+        cachedFloat64Memory0 = new Float64Array(wasm.memory.buffer);
+    }
+    return cachedFloat64Memory0;
 }
 
 function addHeapObject(obj) {
@@ -116,13 +116,13 @@ function addHeapObject(obj) {
     return idx;
 }
 
-let cachedFloat64Memory0 = null;
+const cachedTextDecoder = (typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-8', { ignoreBOM: true, fatal: true }) : { decode: () => { throw Error('TextDecoder not available') } } );
 
-function getFloat64Memory0() {
-    if (cachedFloat64Memory0 === null || cachedFloat64Memory0.byteLength === 0) {
-        cachedFloat64Memory0 = new Float64Array(wasm.memory.buffer);
-    }
-    return cachedFloat64Memory0;
+if (typeof TextDecoder !== 'undefined') { cachedTextDecoder.decode(); };
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
 }
 
 let cachedBigInt64Memory0 = null;
@@ -585,6 +585,9 @@ async function __wbg_load(module, imports) {
 function __wbg_get_imports() {
     const imports = {};
     imports.wbg = {};
+    imports.wbg.__wbindgen_object_drop_ref = function(arg0) {
+        takeObject(arg0);
+    };
     imports.wbg.__wbindgen_string_get = function(arg0, arg1) {
         const obj = getObject(arg1);
         const ret = typeof(obj) === 'string' ? obj : undefined;
@@ -592,13 +595,6 @@ function __wbg_get_imports() {
         var len1 = WASM_VECTOR_LEN;
         getInt32Memory0()[arg0 / 4 + 1] = len1;
         getInt32Memory0()[arg0 / 4 + 0] = ptr1;
-    };
-    imports.wbg.__wbindgen_object_drop_ref = function(arg0) {
-        takeObject(arg0);
-    };
-    imports.wbg.__wbindgen_error_new = function(arg0, arg1) {
-        const ret = new Error(getStringFromWasm0(arg0, arg1));
-        return addHeapObject(ret);
     };
     imports.wbg.__wbindgen_boolean_get = function(arg0) {
         const v = getObject(arg0);
@@ -636,7 +632,11 @@ function __wbg_get_imports() {
         const ret = BigInt.asUintN(64, arg0);
         return addHeapObject(ret);
     };
-    imports.wbg.__wbg_eval_64ce1594989e82f8 = function(arg0, arg1) {
+    imports.wbg.__wbindgen_error_new = function(arg0, arg1) {
+        const ret = new Error(getStringFromWasm0(arg0, arg1));
+        return addHeapObject(ret);
+    };
+    imports.wbg.__wbg_eval_2ea6d5f9a10f336a = function(arg0, arg1) {
         const ret = eval(getStringFromWasm0(arg0, arg1));
         return addHeapObject(ret);
     };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -52,7 +52,7 @@
 				"vscode-languageclient": "~9.0.1",
 				"vscode-uri": "~3.0.8",
 				"vscode-ws-jsonrpc": "~3.1.0",
-				"windmill-parser-wasm": "^1.355.4",
+				"windmill-parser-wasm": "^1.364.3",
 				"windmill-sql-datatype-parser-wasm": "^1.318.0",
 				"y-monaco": "^0.1.4",
 				"y-websocket": "^1.5.0",
@@ -10261,9 +10261,9 @@
 			}
 		},
 		"node_modules/windmill-parser-wasm": {
-			"version": "1.355.4",
-			"resolved": "https://registry.npmjs.org/windmill-parser-wasm/-/windmill-parser-wasm-1.355.4.tgz",
-			"integrity": "sha512-7Usvb55qAULgGg5ULoMm4iWviAl0fQMNxoDQXx4lrPASpXSSV0BS9anP2jF/gse5HQ1usKj63TNtCFYedMThHg=="
+			"version": "1.364.3",
+			"resolved": "https://registry.npmjs.org/windmill-parser-wasm/-/windmill-parser-wasm-1.364.3.tgz",
+			"integrity": "sha512-P/t7uwyUfi7EjMveE7M5swj2FXlMq36kTb79rN7rsW8a2KMxgR1zs+sP0DBmBoAHMVywyjewF8/6i/8WP9+7Iw=="
 		},
 		"node_modules/windmill-sql-datatype-parser-wasm": {
 			"version": "1.318.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -132,7 +132,7 @@
 		"vscode-languageclient": "~9.0.1",
 		"vscode-uri": "~3.0.8",
 		"vscode-ws-jsonrpc": "~3.1.0",
-		"windmill-parser-wasm": "^1.355.4",
+		"windmill-parser-wasm": "^1.364.3",
 		"windmill-sql-datatype-parser-wasm": "^1.318.0",
 		"y-monaco": "^0.1.4",
 		"y-websocket": "^1.5.0",

--- a/frontend/src/lib/script_helpers.ts
+++ b/frontend/src/lib/script_helpers.ts
@@ -70,6 +70,13 @@ export async function main(
   //d: wmill.S3Object, // for large files backed by S3 (https://www.windmill.dev/docs/core_concepts/persistent_storage/large_data_files)
   e = "inferred type string from default arg",
   f = { nested: "object" },
+	g: {
+    label: "Variant 1",
+    foo: string
+  } | {
+    label: "Variant 2",
+    bar: number
+  }
 ) {
   // let x = await wmill.getVariable('u/user/foo')
   return { foo: a };

--- a/frontend/src/lib/script_helpers.ts
+++ b/frontend/src/lib/script_helpers.ts
@@ -70,7 +70,7 @@ export async function main(
   //d: wmill.S3Object, // for large files backed by S3 (https://www.windmill.dev/docs/core_concepts/persistent_storage/large_data_files)
   e = "inferred type string from default arg",
   f = { nested: "object" },
-	g: {
+  g: {
     label: "Variant 1",
     foo: string
   } | {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e5604891855ea0b29cbb37fadc347f8622e9dcf5  | 
|--------|--------|

### Summary:
Improved `oneOf` parser in TypeScript parser and updated `windmill-parser-wasm` package version.

**Key points**:
- Refactored `tstype_to_typ` function in `backend/parsers/windmill-parser-ts/src/lib.rs` for better readability.
- Improved `parse_one_of_type`, `one_of_label`, and `one_of_properties` functions in `backend/parsers/windmill-parser-ts/src/lib.rs`.
- Updated `windmill-parser-wasm` package version to `1.364.3` in `backend/parsers/windmill-parser-wasm/pkg/package.json` and `frontend/package.json`.
- Added new `g` parameter with `oneOf` type in `frontend/src/lib/script_helpers.ts`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->