### PR TITLE
fix(frontend): Display 'parallel'and 'skip failure' even when a summa…

### DIFF
--- a/frontend/src/lib/components/flows/map/MapItem.svelte
+++ b/frontend/src/lib/components/flows/map/MapItem.svelte
@@ -146,10 +146,11 @@
 			{#if mod.value.type === 'forloopflow' || mod.value.type === 'whileloopflow'}
 				<FlowModuleSchemaItem
 					deletable={insertable}
-					label={mod.summary ||
-						`${mod.value.type == 'forloopflow' ? 'For' : 'While'} loop ${
-							mod.value.parallel ? '(parallel)' : ''
-						} ${mod.value.skip_failures ? '(skip failures)' : ''}`}
+					label={`${
+						mod.summary || (mod.value.type == 'forloopflow' ? 'For loop' : 'While loop')
+					}  ${mod.value.parallel ? '(parallel)' : ''} ${
+						mod.value.skip_failures ? '(skip failures)' : ''
+					}`}
 					id={mod.id}
 					on:move={() => dispatch('move')}
 					on:delete={onDelete}


### PR DESCRIPTION
…ry is set
<img width="369" alt="Screenshot 2024-07-17 at 17 12 42" src="https://github.com/user-attachments/assets/928f5cc5-9300-4321-a4ad-d7e3234967db">

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit da095a329ac9ddaab6a4dce5a0f3ebd41027bbc3  | 
|--------|--------|

### Summary:
Modified label rendering for `forloopflow` and `whileloopflow` modules to display 'parallel' and 'skip failures' even when a summary is set.

**Key points**:
- Updated `frontend/src/lib/components/flows/map/MapItem.svelte`.
- Modified label rendering for `forloopflow` and `whileloopflow` modules.
- Ensured 'parallel' and 'skip failures' are displayed even when `mod.summary` is set.
- Affected function: `FlowModuleSchemaItem` component rendering.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->