### PR TITLE
feat: job view audit logging based on env variable

### DIFF
--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -8,6 +8,7 @@
 
 use axum::body::Body;
 use axum::http::HeaderValue;
+use quick_cache::sync::Cache;
 use serde_json::value::RawValue;
 use sqlx::Pool;
 use std::collections::HashMap;
@@ -297,11 +298,17 @@ struct JsonPath {
     pub approver: Option<String>,
 }
 async fn get_result_by_id(
+    authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Path((w_id, flow_id, node_id)): Path<(String, Uuid, String)>,
     Query(JsonPath { json_path, .. }): Query<JsonPath>,
 ) -> windmill_common::error::JsonResult<Box<JsonRawValue>> {
-    let res = windmill_queue::get_result_by_id(db, w_id, flow_id, node_id, json_path).await?;
+    let res =
+        windmill_queue::get_result_by_id(db.clone(), w_id.clone(), flow_id, node_id, json_path)
+            .await?;
+
+    log_job_view(&db, Some(&authed), &w_id, &flow_id).await?;
+
     Ok(Json(res))
 }
 
@@ -622,6 +629,9 @@ async fn get_flow_job_debug_info(
                 jobs.insert(job.id().to_string(), job);
             }
         }
+
+        log_job_view(&db, opt_authed.as_ref(), &w_id, &id).await?;
+
         Ok(Json(jobs).into_response())
     } else {
         Err(error::Error::NotFound(format!(
@@ -651,6 +661,9 @@ async fn get_job(
     )
     .await?;
     job.fetch_outstanding_wait_time(&db).await?;
+
+    log_job_view(&db, opt_authed.as_ref(), &w_id, &id).await?;
+
     Ok(Json(job).into_response())
 }
 
@@ -871,6 +884,9 @@ async fn get_job_logs(
             ));
         }
         let logs = record.logs.unwrap_or_default();
+
+        log_job_view(&db, opt_authed.as_ref(), &w_id, &id).await?;
+
         #[cfg(all(feature = "enterprise", feature = "parquet"))]
         if let Some(r) = get_logs_from_store(record.log_offset, &logs, &record.log_file_index).await
         {
@@ -900,6 +916,9 @@ async fn get_job_logs(
             ));
         }
         let logs = text.logs.unwrap_or_default();
+
+        log_job_view(&db, opt_authed.as_ref(), &w_id, &id).await?;
+
         #[cfg(all(feature = "enterprise", feature = "parquet"))]
         if let Some(r) = get_logs_from_store(text.log_offset, &logs, &text.log_file_index).await {
             return r.map(content_plain);
@@ -938,6 +957,9 @@ async fn get_args(
                 "As a non logged in user, you can only see jobs ran by anonymous users".to_string(),
             ));
         }
+
+        log_job_view(&db, opt_authed.as_ref(), &w_id, &id).await?;
+
         Ok(Json(record.args.map(|x| x.0).unwrap_or_default()))
     } else {
         let record = sqlx::query_as::<_, RawArgs>(
@@ -955,6 +977,9 @@ async fn get_args(
                 "As a non logged in user, you can only see jobs ran by anonymous users".to_string(),
             ));
         }
+
+        log_job_view(&db, opt_authed.as_ref(), &w_id, &id).await?;
+
         Ok(Json(record.args.map(|x| x.0).unwrap_or_default()))
     }
 }
@@ -1944,7 +1969,7 @@ pub async fn get_suspended_job_flow(
         Job::QueuedJob(job) => &job.email,
         Job::CompletedJobWithFormattedResult(job) => &job.cj.email,
     };
-    conditionally_require_authed_user(authed, flow_status.clone(), trigger_email)?;
+    conditionally_require_authed_user(authed.clone(), flow_status.clone(), trigger_email)?;
 
     let approvers_from_status = match flow_module_status {
         FlowStatusModule::Success { approvers, .. } => approvers.to_owned(),
@@ -1970,6 +1995,8 @@ pub async fn get_suspended_job_flow(
     } else {
         approvers_from_status
     };
+
+    log_job_view(&db, authed.as_ref(), &w_id, &job).await?;
 
     Ok(Json(SuspendedJobFlow { job: flow, approvers }).into_response())
 }
@@ -3256,6 +3283,76 @@ lazy_static::lazy_static! {
         .ok()
         .and_then(|x| x.parse().ok())
         .unwrap_or(200);
+
+    static ref JOB_VIEW_AUDIT_LOGS: bool = std::env::var("JOB_VIEW_AUDIT_LOGS")
+        .ok()
+        .and_then(|x| x.parse().ok())
+        .unwrap_or(false);
+
+    static ref JOB_VIEW_CACHE: JobViewCache = JobViewCache::new(500);
+}
+
+struct JobViewCache {
+    cache: Cache<String, std::time::Instant>,
+}
+
+impl JobViewCache {
+    fn new(items_capacity: usize) -> Self {
+        Self { cache: Cache::new(items_capacity) }
+    }
+    fn get_or_insert(&self, key: &str) -> Option<std::time::Instant> {
+        match self.cache.get(key) {
+            Some(t) if t < std::time::Instant::now() => {
+                self.cache.insert(
+                    key.to_string(),
+                    std::time::Instant::now() + std::time::Duration::from_secs(60),
+                );
+                None
+            }
+            v => {
+                self.cache.insert(
+                    key.to_string(),
+                    std::time::Instant::now() + std::time::Duration::from_secs(60),
+                );
+                v
+            }
+        }
+    }
+}
+
+async fn log_job_view(
+    db: &DB,
+    opt_authed: Option<&ApiAuthed>,
+    w_id: &str,
+    job_id: &Uuid,
+) -> error::Result<()> {
+    if *JOB_VIEW_AUDIT_LOGS {
+        let audit_author = match opt_authed {
+            Some(authed) => AuditAuthor::from(authed),
+            None => AuditAuthor {
+                username: "anonymous".to_string(),
+                username_override: None,
+                email: "anonymous".to_string(),
+            },
+        };
+        if JOB_VIEW_CACHE
+            .get_or_insert(&format!("{}_{}", job_id, audit_author.email))
+            .is_none()
+        {
+            audit_log(
+                db,
+                &audit_author,
+                "jobs.view",
+                ActionKind::Execute,
+                w_id,
+                Some(&job_id.to_string()),
+                None,
+            )
+            .await?;
+        };
+    }
+
+    Ok(())
 }
 
 pub async fn run_wait_result_job_by_path_get(
@@ -4402,6 +4499,7 @@ async fn get_job_update(
                 "As a non logged in user, you can only see jobs ran by anonymous users".to_string(),
             ));
         }
+        log_job_view(&db, opt_authed.as_ref(), &w_id, &job_id).await?;
         Ok(Json(JobUpdate {
             running: if !running && record.running {
                 Some(true)
@@ -4437,6 +4535,7 @@ async fn get_job_update(
                         .to_string(),
                 ));
             }
+            log_job_view(&db, opt_authed.as_ref(), &w_id, &job_id).await?;
             Ok(Json(JobUpdate {
                 running: Some(false),
                 completed: Some(true),
@@ -4688,7 +4787,7 @@ async fn get_completed_job<'a>(
     schedule_path, permissioned_as, flow_status, raw_flow, is_flow_step, language, started_at, is_skipped,
     raw_lock, email, visible_to_owner, mem_peak, tag, priority, result->'wm_labels' as labels FROM completed_job WHERE id = $1 AND workspace_id = $2")
         .bind(id)
-        .bind(w_id)
+        .bind(&w_id)
         .fetch_optional(&db)
         .await?;
 
@@ -4710,6 +4809,9 @@ async fn get_completed_job<'a>(
     // )
     // .fetch_optional(db)
     // .await.ok().flatten().flatten();
+
+    log_job_view(&db, opt_authed.as_ref(), &w_id, &id).await?;
+
     Ok(response)
 }
 
@@ -4804,6 +4906,8 @@ async fn get_completed_job_result(
         raw_result.result.map(|x| x.0),
     );
 
+    log_job_view(&db, opt_authed.as_ref(), &w_id, &id).await?;
+
     Ok(Json(result).into_response())
 }
 
@@ -4845,6 +4949,9 @@ async fn get_completed_job_result_maybe(
                 "As a non logged in user, you can only see jobs ran by anonymous users".to_string(),
             ));
         }
+
+        log_job_view(&db, opt_authed.as_ref(), &w_id, &id).await?;
+
         Ok(Json(CompletedJobResult {
             started: Some(true),
             success: Some(res.success),

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -3289,7 +3289,7 @@ lazy_static::lazy_static! {
         .and_then(|x| x.parse().ok())
         .unwrap_or(false);
 
-    static ref JOB_VIEW_CACHE: JobViewCache = JobViewCache::new(500);
+    static ref JOB_VIEW_CACHE: JobViewCache = JobViewCache::new(50000);
 }
 
 struct JobViewCache {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d1e60ae1914bec62539809906685c1d866b28e2a  | 
|--------|--------|

### Summary:
Introduced audit logging for job views based on an environment variable and added caching to avoid redundant logging in `backend/windmill-api/src/jobs.rs`.

**Key points**:
- Added `log_job_view` function in `backend/windmill-api/src/jobs.rs` to log job views based on `JOB_VIEW_AUDIT_LOGS` environment variable.
- Introduced `JobViewCache` to cache job views and avoid redundant logging within a 60-second window.
- Updated `get_result_by_id`, `get_flow_job_debug_info`, `get_job`, `get_job_logs`, `get_args`, `get_suspended_job_flow`, `get_completed_job`, `get_completed_job_result`, `get_completed_job_result_maybe`, and `get_job_update` functions to call `log_job_view` for audit logging.
- Added `JOB_VIEW_AUDIT_LOGS` and `JOB_VIEW_CACHE` static variables to control and cache job view logging.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->