### PR TITLE
feat: add support for text/plain webhook

### DIFF
--- a/backend/windmill-queue/src/jobs.rs
+++ b/backend/windmill-queue/src/jobs.rs
@@ -2862,6 +2862,14 @@ where
                 Error::BadRequest(format!("Cloud events batching is not supported yet"))
                     .into_response(),
             )
+        } else if content_type.unwrap().starts_with("text/plain") {
+            let bytes = Bytes::from_request(req, _state)
+                .await
+                .map_err(IntoResponse::into_response)?;
+            let str = String::from_utf8(bytes.to_vec())
+                .map_err(|e| Error::BadRequest(format!("invalid utf8: {}", e)).into_response())?;
+            extra.insert("raw_string".to_string(), to_raw_value(&str));
+            Ok(PushArgsOwned { extra: Some(extra), args: HashMap::new() })
         } else if content_type
             .unwrap()
             .starts_with("application/x-www-form-urlencoded")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e3615f97ce31c395cd4b0bfaca9447c31210281a  | 
|--------|--------|

### Summary:
Added support for handling `text/plain` content type in webhook payloads in `backend/windmill-queue/src/jobs.rs`.

**Key points**:
- **File Modified**: `backend/windmill-queue/src/jobs.rs`
- **Function Modified**: `PushArgsOwned::from_request`
- **New Behavior**: Added support for `text/plain` content type in webhook payloads.
- **Implementation Details**:
  - Checks if `content_type` is `text/plain`.
  - Reads request body as bytes and converts to UTF-8 string.
  - Inserts the string into the `extra` field of `PushArgsOwned`.
- **Error Handling**: Returns a `BadRequest` error if the UTF-8 conversion fails.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->