### PR TITLE
Add `platform: 'node'` to codebase esbuild

### DIFF
--- a/cli/script.ts
+++ b/cli/script.ts
@@ -160,6 +160,7 @@ export async function handleFile(
         format: "esm",
         bundle: true,
         write: false,
+        platform: 'node',
       });
       bundleContent = out.outputFiles[0].text;
       log.info(`Finished building the bundle for ${path}`);


### PR DESCRIPTION
To avoid running into this when bundling:
```
✅ Granted run access to "/Users/lewis/Library/Caches/deno/npm/registry.npmjs.org/@esbuild/darwin-arm64/0.23.0/bin/esbuild".
✘ [ERROR] Could not resolve "crypto"

    ../node_modules/.pnpm/nanoid@3.1.20/node_modules/nanoid/index.js:1:19:
      1 │ import crypto from 'crypto'
        ╵                    ~~~~~~~~

  The package "crypto" wasn't found on the file system but is built into node. Are you trying to
  bundle for node? You can use "platform: 'node'" to do that, which will remove this error.

error: Uncaught (in promise) Error: Build failed with 1 error:
../node_modules/.pnpm/nanoid@3.1.20/node_modules/nanoid/index.js:1:19: ERROR: Could not resolve "crypto"
```
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7d20da4702582a2e0e7ddfb759cfa07a37b3a78d  | 
|--------|--------|

### Summary:
Added `platform: 'node'` to esbuild configuration in `cli/script.ts` to fix 'crypto' module resolution error.

**Key points**:
- **File**: `cli/script.ts`
- **Function**: `handleFile`
- **Change**: Added `platform: 'node'` to esbuild configuration.
- **Reason**: Fixes 'crypto' module resolution error during bundling.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->