### PR TITLE
fix(frontend): maintain form values when switching tabs

### DIFF
--- a/frontend/src/lib/components/apps/components/buttons/AppForm.svelte
+++ b/frontend/src/lib/components/apps/components/buttons/AppForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Button } from '$lib/components/common'
-	import { getContext } from 'svelte'
+	import { getContext, tick } from 'svelte'
 	import { initConfig, initOutput } from '../../editor/appUtils'
 	import { components } from '../../editor/component'
 	import type { AppInput } from '../../inputType'
@@ -66,7 +66,26 @@
 
 	let css = initCss($app.css?.formcomponent, customCss)
 
-	let wrapper: RunnableWrapper
+	let wrapper: RunnableWrapper | undefined = undefined
+
+	let args: Record<string, any> = {}
+
+	function getArgs() {
+		args = wrapper?.getArgs() ?? {}
+	}
+
+	$: render === false && getArgs()
+
+	function setArgs() {
+		// This is a hack to make the binding work
+		wrapper?.setArgs({})
+
+		tick().then(() => {
+			wrapper?.setArgs(args)
+		})
+	}
+
+	$: render === true && Object.keys(args).length > 0 && setArgs()
 </script>
 
 {#each Object.keys(components['formcomponent'].initialData.configuration) as key (key)}

--- a/frontend/src/lib/components/apps/components/helpers/RunnableComponent.svelte
+++ b/frontend/src/lib/components/apps/components/helpers/RunnableComponent.svelte
@@ -92,6 +92,10 @@
 		args = value
 	}
 
+	export function getArgs() {
+		return args
+	}
+
 	let args: Record<string, any> | undefined = undefined
 	let runnableInputValues: Record<string, any> = {}
 	let executeTimeout: NodeJS.Timeout | undefined = undefined

--- a/frontend/src/lib/components/apps/components/helpers/RunnableWrapper.svelte
+++ b/frontend/src/lib/components/apps/components/helpers/RunnableWrapper.svelte
@@ -96,6 +96,10 @@
 		runnableComponent?.setArgs(value)
 	}
 
+	export function getArgs() {
+		return runnableComponent?.getArgs()
+	}
+
 	const { staticExporter, noBackend, componentControl, runnableComponents } =
 		getContext<AppViewerContext>('AppViewerContext')
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b9adae582821b187429c9f29342a80208df8c608  | 
|--------|--------|

### Summary:
Preserve form values when switching tabs by capturing and resetting arguments in `AppForm.svelte`, with support from `RunnableComponent.svelte` and `RunnableWrapper.svelte`.

**Key points**:
- **Modified** `frontend/src/lib/components/apps/components/buttons/AppForm.svelte` to capture and reset form arguments when `render` changes.
- **Added** `getArgs` and `setArgs` functions in `frontend/src/lib/components/apps/components/helpers/RunnableComponent.svelte` and `frontend/src/lib/components/apps/components/helpers/RunnableWrapper.svelte` to support argument handling.
- **Ensured** form values are maintained when switching tabs by using `tick` to reset arguments after a render change.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->