### PR TITLE
feat: caddy with l4 image

### DIFF
--- a/.github/workflows/build-caddy-l4-image.yml
+++ b/.github/workflows/build-caddy-l4-image.yml
@@ -1,0 +1,45 @@
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/caddy-l4
+
+name: Build caddy-l4
+on:
+  workflow_dispatch:
+
+permissions: write-all
+
+jobs:
+  build_ee:
+    runs-on: ubicloud
+    steps:
+      - uses: actions/checkout@v4
+      - uses: depot/setup-action@v1
+      - name: Docker meta
+        id: meta-ee-public
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Login to registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push publicly
+        uses: depot/build-push-action@v1
+        with:
+          context: ./docker
+          file: ./docker/DockerfileCaddyL4
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ steps.meta-ee-public.outputs.tags }}
+          labels: |
+            ${{ steps.meta-ee-public.outputs.labels }}

--- a/docker/DockerfileCaddyL4
+++ b/docker/DockerfileCaddyL4
@@ -1,0 +1,10 @@
+FROM caddy:2.8.4-builder-alpine AS builder
+
+RUN xcaddy build \
+  --with github.com/mholt/caddy-l4@145ec36251a44286f05a10d231d8bfb3a8192e09 \
+  --with github.com/RussellLuo/caddy-ext/layer4@ab1e18cfe426012af351a68463937ae2e934a2a1
+
+
+FROM caddy:2.8.4-alpine
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ed526e59b71cce4b622bd0acdbb8089e2ec69919  | 
|--------|--------|

### Summary:
Adds GitHub Actions workflow and Dockerfile to build and push a Caddy server image with L4 extensions.

**Key points**:
- Added `.github/workflows/build-caddy-l4-image.yml` to define a GitHub Actions workflow for building and pushing a Docker image.
- Workflow triggers on `workflow_dispatch` event.
- Uses `actions/checkout@v4`, `depot/setup-action@v1`, `docker/metadata-action@v4`, `docker/login-action@v2`, and `depot/build-push-action@v1`.
- Builds Docker image using `docker/DockerfileCaddyL4`.
- Dockerfile `docker/DockerfileCaddyL4` builds Caddy with `caddy-l4` and `caddy-ext/layer4` plugins.
- Pushes image to `ghcr.io` registry with tags based on commit SHA, branch, and latest if default branch.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->