### PR TITLE
fix(frontend): add missing truncate for branch predicates

### DIFF
--- a/frontend/src/lib/components/flows/content/BranchPredicateEditor.svelte
+++ b/frontend/src/lib/components/flows/content/BranchPredicateEditor.svelte
@@ -57,9 +57,8 @@
 	</PropPickerWrapper>
 {:else}
 	<div class="flex justify-between gap-4 p-2">
-		<div><pre class="text-sm">{branch.expr}</pre></div><div
-			class="flex flex-row gap-2 items-center"
-		>
+		<div class="truncate"><pre class="text-sm truncate">{branch.expr}</pre></div>
+		<div class="flex flex-row gap-2 items-center">
 			{#if enableAi}
 				<PredicateGen
 					on:setExpr={(e) => {


### PR DESCRIPTION
Fix for: https://github.com/windmill-labs/windmill/issues/4135
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 880b2863a317da08622eee207b29aa4f07db32f9  | 
|--------|--------|

### Summary:
Added truncation to branch expression display in `BranchPredicateEditor.svelte` to prevent overflow.

**Key points**:
- **File Modified**: `frontend/src/lib/components/flows/content/BranchPredicateEditor.svelte`
- **Change**: Added `truncate` class to `<div>` and `<pre>` elements displaying `branch.expr`.
- **Behavior**: Long branch expressions are truncated to fit within the container, preventing overflow.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->