### PR TITLE
fix(frontend): fix style panel for compoents without custom css

### DIFF
--- a/frontend/src/lib/components/apps/editor/appUtils.ts
+++ b/frontend/src/lib/components/apps/editor/appUtils.ts
@@ -366,7 +366,10 @@ export function appComponentFromType<T extends keyof typeof components>(
 			tabs: init.tabs,
 			conditions: init.conditions,
 			nodes: init.nodes,
-			customCss: deepMergeWithPriority(ccomponents[type].customCss as any, override?.customCss),
+			customCss: deepMergeWithPriority(
+				ccomponents[type].customCss as any,
+				override?.customCss ?? {}
+			),
 			recomputeIds: init.recomputeIds ? [] : undefined,
 			actionButtons: init.actionButtons ? [] : undefined,
 			actions: [],


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8d6176c21f826d5c249d9157c5fb3f3eaccc7805  | 
|--------|--------|

### Summary:
Fixes the style panel for components without custom CSS by ensuring `customCss` is always an object in `frontend/src/lib/components/apps/editor/appUtils.ts`.

**Key points**:
- **File Modified**: `frontend/src/lib/components/apps/editor/appUtils.ts`
- **Function Modified**: `appComponentFromType`
- **Change**: Ensure `customCss` is always an object by using `override?.customCss ?? {}`
- **Issue Fixed**: Style panel for components without custom CSS was not functioning correctly.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->