### PR TITLE
fix: remove admin requirement to cancel job selection

### DIFF
--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -1459,7 +1459,6 @@ async fn cancel_selection(
     Path(w_id): Path<String>,
     Json(jobs): Json<Vec<Uuid>>,
 ) -> error::JsonResult<Vec<Uuid>> {
-    require_admin(authed.is_admin, &authed.username)?;
 
     let mut tx = user_db.begin(&authed).await?;
     let jobs_to_cancel = sqlx::query_scalar!(

--- a/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
@@ -449,6 +449,7 @@
 		selectedIds = []
 		jobLoader?.loadJobs(minTs, maxTs, true, true)
 		sendUserToast(`Canceled ${uuids.length} jobs`)
+		isSelectingJobsToCancel = false
 	}}
 	loading={fetchingFilteredJobs}
 	on:canceled={() => {
@@ -472,6 +473,7 @@
 		selectedIds = []
 		jobLoader?.loadJobs(minTs, maxTs, true, true)
 		sendUserToast(`Canceled ${uuids.length} jobs`)
+		isSelectingJobsToCancel = false
 	}}
 	on:canceled={() => {
 		isCancelingVisibleJobs = false


### PR DESCRIPTION
also turn off the selection mode after canceling
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8ffa6773f5bb3aa879ddb5012145ffb6022d835e  | 
|--------|--------|

### Summary:
Removed admin requirement for canceling job selections and ensured selection mode is turned off after canceling.

**Key points**:
- Removed `require_admin` check in `cancel_selection` function in `backend/windmill-api/src/jobs.rs`.
- Updated `frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte` to turn off `isSelectingJobsToCancel` after canceling jobs.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->