### PR TITLE
fix(frontend): Fr/improve suspend drawer

### DIFF
--- a/frontend/src/lib/components/flows/content/SuspendDrawer.svelte
+++ b/frontend/src/lib/components/flows/content/SuspendDrawer.svelte
@@ -32,7 +32,8 @@
 			<Section label="Prompt">
 				A prompt is simply an approval step that can be self-approved. To do this, include the
 				resume url in the returned payload of the step. The UX will automatically adapt and show the
-				prompt to the operator when running the flow. e.g:
+				prompt to the operator when running the flow. Additionally, adding the cancel url will also
+				render a cancel button, providing the operator with an option to cancel the step e.g:
 				<Tabs selected="bun" class="pt-4">
 					<Tab value="bun">TypeScript (Bun)</Tab>
 					<Tab value="deno">TypeScript (Deno)</Tab>
@@ -49,6 +50,8 @@ export async function main() {
 
     return {
         resume: urls['resume'],
+        // If present, the UI will show a cancel button 
+        cancel: urls['cancel'], 
         default_args: {}, // optional, see below
         enums: {} // optional, see below
     }
@@ -65,6 +68,8 @@ export async function main() {
 
     return {
         resume: urls['resume'],
+        // If present, the UI will show a cancel button
+        cancel: urls['cancel'],
         default_args: {}, // optional, see below
         enums: {} // optional, see below
     }
@@ -80,6 +85,8 @@ def main():
     urls = wmill.get_resume_urls()
     return {
         "resume": urls["resume"],
+        # If present, the UI will show a cancel button
+        "cancel": urls["cancel"],
         "default_args": {}, # optional, see below
         "enums": {} # optional, see below
     }

--- a/frontend/src/lib/components/flows/content/SuspendDrawer.svelte
+++ b/frontend/src/lib/components/flows/content/SuspendDrawer.svelte
@@ -33,7 +33,7 @@
 				A prompt is simply an approval step that can be self-approved. To do this, include the
 				resume url in the returned payload of the step. The UX will automatically adapt and show the
 				prompt to the operator when running the flow. Additionally, adding the cancel url will also
-				render a cancel button, providing the operator with an option to cancel the step e.g:
+				render a cancel button, providing the operator with an option to cancel the step. e.g:
 				<Tabs selected="bun" class="pt-4">
 					<Tab value="bun">TypeScript (Bun)</Tab>
 					<Tab value="deno">TypeScript (Deno)</Tab>
@@ -50,7 +50,6 @@ export async function main() {
 
     return {
         resume: urls['resume'],
-        // If present, the UI will show a cancel button 
         cancel: urls['cancel'], 
         default_args: {}, // optional, see below
         enums: {} // optional, see below
@@ -68,7 +67,6 @@ export async function main() {
 
     return {
         resume: urls['resume'],
-        // If present, the UI will show a cancel button
         cancel: urls['cancel'],
         default_args: {}, // optional, see below
         enums: {} // optional, see below
@@ -85,7 +83,6 @@ def main():
     urls = wmill.get_resume_urls()
     return {
         "resume": urls["resume"],
-        # If present, the UI will show a cancel button
         "cancel": urls["cancel"],
         "default_args": {}, # optional, see below
         "enums": {} # optional, see below


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 9401fd4cf6e7078fcae822c6a87c1bb1b6511d08  | 
|--------|--------|

### Summary:
Added a cancel button to the SuspendDrawer component, allowing operators to cancel steps by including a `cancel` URL in the returned payload.

**Key points**:
- Updated `frontend/src/lib/components/flows/content/SuspendDrawer.svelte` to include a cancel button.
- Modified `Prompt` section to handle `cancel` URL in the returned payload.
- Added `cancel` URL handling in TypeScript (Bun), TypeScript (Deno), and Python code examples.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->