### PR TITLE
bump go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,13 +127,13 @@ RUN set -eux; \
     arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
     case "$arch" in \
     'amd64') \
-    targz='go1.21.6.linux-amd64.tar.gz'; \
+    targz='go1.22.5.linux-amd64.tar.gz'; \
     ;; \
     'arm64') \
-    targz='go1.21.6.linux-arm64.tar.gz'; \
+    targz='go1.22.5.linux-arm64.tar.gz'; \
     ;; \
     'armhf') \
-    targz='go1.21.6.linux-armv6l.tar.gz'; \
+    targz='go1.22.5.linux-armv6l.tar.gz'; \
     ;; \
     *) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
     esac; \

--- a/lsp/Dockerfile
+++ b/lsp/Dockerfile
@@ -9,13 +9,13 @@ RUN set -eux; \
     url=; \
     case "$arch" in \
     'amd64') \
-    targz='go1.21.0.linux-amd64.tar.gz'; \
+    targz='go1.22.5.linux-amd64.tar.gz'; \
     ;; \
     'arm64') \
-    targz='go1.21.0.linux-arm64.tar.gz'; \
+    targz='go1.22.5.linux-arm64.tar.gz'; \
     ;; \
     'armhf') \
-    targz='go1.21.0.linux-armv6l.tar.gz'; \
+    targz='go1.22.5.linux-armv6l.tar.gz'; \
     ;; \
     *) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
     esac; \


### PR DESCRIPTION
See #4191 

Bumps Go version to 1.22.5
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 104e65dc761435e308bf87871415994c5c3ec659  | 
|--------|--------|

### Summary:
Update Go version in `Dockerfile` from 1.21.6 to 1.22.5 for multiple architectures.

**Key points**:
- Update Go version in `Dockerfile` from 1.21.6 to 1.22.5.
- Affects Go installation for `amd64`, `arm64`, and `armhf` architectures.
- Changes made in `Dockerfile` lines 9, 11, and 13.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->