### PR TITLE
fix(frontend): fix the app created from a script or flow with the new…

### DIFF
--- a/frontend/src/lib/components/details/createAppFromScript.ts
+++ b/frontend/src/lib/components/details/createAppFromScript.ts
@@ -5,7 +5,7 @@ export function createAppFromScript(path: string, schema: Record<string, any> | 
 				'3': {
 					fixed: false,
 					x: 0,
-					y: 0,
+					y: 2,
 					w: 2,
 					h: 8,
 					fullHeight: false
@@ -13,7 +13,7 @@ export function createAppFromScript(path: string, schema: Record<string, any> | 
 				'12': {
 					fixed: false,
 					x: 0,
-					y: 0,
+					y: 2,
 					w: 12,
 					h: 21,
 					fullHeight: false
@@ -27,6 +27,38 @@ export function createAppFromScript(path: string, schema: Record<string, any> | 
 					id: 'a'
 				},
 				id: 'a'
+			},
+			{
+				'3': {
+					fixed: false,
+					x: 0,
+					y: 8,
+					fullHeight: false,
+					w: 6,
+					h: 2
+				},
+				'12': {
+					fixed: false,
+					x: 0,
+					y: 0,
+					fullHeight: false,
+					w: 12,
+					h: 2
+				},
+				data: {
+					type: 'containercomponent',
+					configuration: {},
+					customCss: {
+						container: {
+							class: '!p-0',
+							style: ''
+						}
+					},
+					actions: [],
+					numberOfSubgrids: 1,
+					id: 'g'
+				},
+				id: 'g'
 			}
 		],
 		fullscreen: false,
@@ -34,6 +66,7 @@ export function createAppFromScript(path: string, schema: Record<string, any> | 
 		hiddenInlineScripts: [],
 		css: {},
 		norefreshbar: false,
+		hideLegacyTopBar: true,
 		subgrids: {
 			'a-0': [
 				{
@@ -376,6 +409,116 @@ export function createAppFromScript(path: string, schema: Record<string, any> | 
 					},
 					id: 'f'
 				}
+			],
+			'g-0': [
+				{
+					'3': {
+						fixed: false,
+						x: 0,
+						y: 0,
+						fullHeight: false,
+						w: 6,
+						h: 1
+					},
+					'12': {
+						fixed: false,
+						x: 0,
+						y: 0,
+						fullHeight: false,
+						w: 6,
+						h: 1
+					},
+					data: {
+						type: 'textcomponent',
+						configuration: {
+							style: {
+								type: 'static',
+								value: 'Body'
+							},
+							copyButton: {
+								type: 'static',
+								value: false
+							},
+							tooltip: {
+								type: 'evalv2',
+								value: '',
+								fieldType: 'text',
+								expr: '`Author: ${ctx.author}`',
+								connections: [
+									{
+										componentId: 'ctx',
+										id: 'author'
+									}
+								]
+							},
+							disableNoText: {
+								type: 'static',
+								value: true,
+								fieldType: 'boolean'
+							}
+						},
+						componentInput: {
+							type: 'templatev2',
+							fieldType: 'template',
+							eval: '${ctx.summary}',
+							connections: [
+								{
+									id: 'summary',
+									componentId: 'ctx'
+								}
+							]
+						},
+						customCss: {
+							text: {
+								class: 'text-xl font-semibold whitespace-nowrap truncate',
+								style: ''
+							},
+							container: {
+								class: '',
+								style: ''
+							}
+						},
+						actions: [],
+						horizontalAlignment: 'left',
+						verticalAlignment: 'center',
+						id: 'h'
+					},
+					id: 'h'
+				},
+				{
+					'3': {
+						fixed: false,
+						x: 0,
+						y: 1,
+						fullHeight: false,
+						w: 3,
+						h: 1
+					},
+					'12': {
+						fixed: false,
+						x: 6,
+						y: 0,
+						fullHeight: false,
+						w: 6,
+						h: 1
+					},
+					data: {
+						type: 'recomputeallcomponent',
+						configuration: {},
+						customCss: {
+							container: {
+								style: '',
+								class: ''
+							}
+						},
+						actions: [],
+						menuItems: [],
+						horizontalAlignment: 'right',
+						verticalAlignment: 'center',
+						id: 'i'
+					},
+					id: 'i'
+				}
 			]
 		}
 	}
@@ -424,7 +567,7 @@ export function createAppFromFlow(path: string, schema: Record<string, any> | un
 				'3': {
 					fixed: false,
 					x: 0,
-					y: 0,
+					y: 2,
 					w: 2,
 					h: 8,
 					fullHeight: false
@@ -432,7 +575,7 @@ export function createAppFromFlow(path: string, schema: Record<string, any> | un
 				'12': {
 					fixed: false,
 					x: 0,
-					y: 0,
+					y: 2,
 					w: 12,
 					h: 21,
 					fullHeight: false
@@ -446,6 +589,38 @@ export function createAppFromFlow(path: string, schema: Record<string, any> | un
 					id: 'a'
 				},
 				id: 'a'
+			},
+			{
+				'3': {
+					fixed: false,
+					x: 0,
+					y: 8,
+					fullHeight: false,
+					w: 6,
+					h: 2
+				},
+				'12': {
+					fixed: false,
+					x: 0,
+					y: 0,
+					fullHeight: false,
+					w: 12,
+					h: 2
+				},
+				data: {
+					type: 'containercomponent',
+					configuration: {},
+					customCss: {
+						container: {
+							class: '!p-0',
+							style: ''
+						}
+					},
+					actions: [],
+					numberOfSubgrids: 1,
+					id: 'g'
+				},
+				id: 'g'
 			}
 		],
 		fullscreen: false,
@@ -453,6 +628,7 @@ export function createAppFromFlow(path: string, schema: Record<string, any> | un
 		hiddenInlineScripts: [],
 		css: {},
 		norefreshbar: false,
+		hideLegacyTopBar: true,
 		subgrids: {
 			'a-0': [
 				{
@@ -795,6 +971,116 @@ export function createAppFromFlow(path: string, schema: Record<string, any> | un
 						id: 'f'
 					},
 					id: 'f'
+				}
+			],
+			'g-0': [
+				{
+					'3': {
+						fixed: false,
+						x: 0,
+						y: 0,
+						fullHeight: false,
+						w: 6,
+						h: 1
+					},
+					'12': {
+						fixed: false,
+						x: 0,
+						y: 0,
+						fullHeight: false,
+						w: 6,
+						h: 1
+					},
+					data: {
+						type: 'textcomponent',
+						configuration: {
+							style: {
+								type: 'static',
+								value: 'Body'
+							},
+							copyButton: {
+								type: 'static',
+								value: false
+							},
+							tooltip: {
+								type: 'evalv2',
+								value: '',
+								fieldType: 'text',
+								expr: '`Author: ${ctx.author}`',
+								connections: [
+									{
+										componentId: 'ctx',
+										id: 'author'
+									}
+								]
+							},
+							disableNoText: {
+								type: 'static',
+								value: true,
+								fieldType: 'boolean'
+							}
+						},
+						componentInput: {
+							type: 'templatev2',
+							fieldType: 'template',
+							eval: '${ctx.summary}',
+							connections: [
+								{
+									id: 'summary',
+									componentId: 'ctx'
+								}
+							]
+						},
+						customCss: {
+							text: {
+								class: 'text-xl font-semibold whitespace-nowrap truncate',
+								style: ''
+							},
+							container: {
+								class: '',
+								style: ''
+							}
+						},
+						actions: [],
+						horizontalAlignment: 'left',
+						verticalAlignment: 'center',
+						id: 'h'
+					},
+					id: 'h'
+				},
+				{
+					'3': {
+						fixed: false,
+						x: 0,
+						y: 1,
+						fullHeight: false,
+						w: 3,
+						h: 1
+					},
+					'12': {
+						fixed: false,
+						x: 6,
+						y: 0,
+						fullHeight: false,
+						w: 6,
+						h: 1
+					},
+					data: {
+						type: 'recomputeallcomponent',
+						configuration: {},
+						customCss: {
+							container: {
+								style: '',
+								class: ''
+							}
+						},
+						actions: [],
+						menuItems: [],
+						horizontalAlignment: 'right',
+						verticalAlignment: 'center',
+						id: 'i'
+					},
+					id: 'i'
 				}
 			]
 		}


### PR DESCRIPTION
… topbar
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7e51034b6becb52ed4cbd178c8fab849f365101f  | 
|--------|--------|

### Summary:
Updated `createAppFromScript` and `createAppFromFlow` functions to adjust grid layout, add new components, and hide the legacy top bar.

**Key points**:
- Updated `createAppFromScript` and `createAppFromFlow` functions in `frontend/src/lib/components/details/createAppFromScript.ts`.
- Adjusted grid layout by changing `y` coordinates for certain components.
- Added new `containercomponent` with ID `g` to the grid.
- Added subgrid `g-0` with `textcomponent` (ID `h`) and `recomputeallcomponent` (ID `i`).
- Set `hideLegacyTopBar` to `true` for apps created from scripts or flows.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->