### PR TITLE
fix(frontend): Remove full height for the event handlers of runnables

### DIFF
--- a/frontend/src/lib/components/apps/editor/SettingsPanel.svelte
+++ b/frontend/src/lib/components/apps/editor/SettingsPanel.svelte
@@ -156,6 +156,7 @@
 		{/if}
 		<PanelSection
 			title={`Event handlers`}
+			fullHeight={false}
 			tooltip="Event handlers are used to trigger actions on other components when a specific event occurs. For example, you can trigger a recompute on a component when a script has successfully run."
 		>
 			<EventHandlerItem

--- a/frontend/src/lib/components/apps/editor/settingsPanel/common/PanelSection.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/common/PanelSection.svelte
@@ -4,6 +4,7 @@
 
 	export let title: string
 	export let noPadding: boolean = false
+	export let fullHeight: boolean = true
 	export let titlePadding: string = ''
 	export let tooltip = ''
 	export let documentationLink: string | undefined = undefined
@@ -13,8 +14,9 @@
 <div
 	class={classNames(
 		$$props.class,
-		'flex flex-col h-full gap-2 items-start',
-		noPadding ? '' : 'p-3'
+		'flex flex-col gap-2 items-start',
+		noPadding ? '' : 'p-3',
+		fullHeight ? 'h-full' : ''
 	)}
 	{id}
 >


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 922b6ad7d2223bc2438cbcd76a8761e5c4c60aa4  | 
|--------|--------|

### Summary:
Removed full height property for event handlers in `SettingsPanel.svelte` to prevent them from occupying the entire container height.

**Key points**:
- Updated `frontend/src/lib/components/apps/editor/SettingsPanel.svelte` to set `fullHeight={false}` for the `PanelSection` containing event handlers.
- Modified `frontend/src/lib/components/apps/editor/settingsPanel/common/PanelSection.svelte` to add `fullHeight` prop with a default value of `true`.
- Adjusted class bindings in `PanelSection.svelte` to conditionally apply `h-full` based on `fullHeight` prop.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->