### PR TITLE
fix: Use $lib/base in $lib/navigation:goto

### DIFF
--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -1,5 +1,5 @@
 import { goto as svelteGoto } from '$app/navigation'
-import { base as svelteBase } from '$app/paths'
+import { base as svelteBase } from '$lib/base'
 
 export function goto(path, options = {}) {
 	if (svelteBase == '') {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 19c3660ad89a6499813797792f56698d19d0c9c5  | 
|--------|--------|

### Summary:
Changed import of `base` from `$app/paths` to `$lib/base` in `frontend/src/lib/navigation.ts`, affecting the `goto` function.

**Key points**:
- Changed import of `base` from `$app/paths` to `$lib/base` in `frontend/src/lib/navigation.ts`
- Affects `goto` function to construct full path based on `base` value
- Handles cases where `base` is empty or non-empty


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->