### PR TITLE
fix: azure git sync test connection

### DIFF
--- a/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
@@ -565,7 +565,7 @@
 		}
 		let jobId = await JobService.runScriptByPath({
 			workspace: $workspaceStore!,
-			path: 'hub/7925/git-repo-test-read-write-windmill',
+			path: 'hub/8944/git-repo-test-read-write-windmill',
 			requestBody: {
 				repo_url_resource_path: gitSyncRepository.git_repo_resource_path.replace('$res:', '')
 			}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a34dafe5d007fafea3828262129c416c7bdefcc5  | 
|--------|--------|

### Summary:
Updated script path in `+page.svelte` for Git sync test connection to use `hub/8944/git-repo-test-read-write-windmill`.

**Key points**:
- Updated script path in `frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte`.
- Changed from `hub/7925/git-repo-test-read-write-windmill` to `hub/8944/git-repo-test-read-write-windmill`.
- Affects `JobService.runScriptByPath` function call for Git sync test connection.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->