### PR TITLE
fix(cli): Add esbuild loader for .node files for codebase

### DIFF
--- a/cli/script.ts
+++ b/cli/script.ts
@@ -166,6 +166,9 @@ export async function handleFile(
         platform: "node",
         packages: "bundle",
         target: "node20.15.1",
+        loader: {
+          ".node": "file",
+        },
       });
       bundleContent = out.outputFiles[0].text;
       if (Array.isArray(codebase.assets) && codebase.assets.length > 0) {


### PR DESCRIPTION
To hopefully make scripts depending on e.g. ssh2 work

Related issues suggesting this fix:
- https://github.com/aws/aws-cdk/issues/18470
- https://github.com/evanw/esbuild/issues/1051#issuecomment-1515204103

Without this, bundling a script that depends on `ssh2` results in something like:
```
Error: R] Could not resolve "../build/Release/cpufeatures.node"

    ../node_modules/.pnpm/cpu-features@0.0.10/node_modules/cpu-features/lib/index.js:3:24:
      3 │ const binding = require('../build/Release/cpufeatures.node');
        ╵                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
or:
```
✘ [ERROR] No loader is configured for ".node" files: lib/testfunc/node_modules/cpu-features/build/Release/cpufeatures.node

    lib/testfunc/node_modules/cpu-features/lib/index.js:1:24:
      1 │ const binding = require('../build/Release/cpufeatures.node');
        ╵                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

✘ [ERROR] No loader is configured for ".node" files: lib/testfunc/node_modules/ssh2/lib/protocol/crypto/build/Release/sshcrypto.node

    lib/testfunc/node_modules/ssh2/lib/protocol/crypto.js:30:20:
      30 │   binding = require('./crypto/build/Release/sshcrypto.node');
         ╵                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d3973d520c979e4e11120a17ee0e604ce08b4957  | 
|--------|--------|

### Summary:
Added `.node` file loader to `esbuild` configuration in `cli/script.ts` to fix bundling issues with native modules like `ssh2`.

**Key points**:
- Added `.node` file loader to `esbuild` configuration in `cli/script.ts`.
- Modified `handleFile` function to include `{ ".node": "file" }` in `loader` option.
- Fixes bundling issues for scripts using native modules like `ssh2`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->