### PR TITLE
fix(frontend): fix decision tree debug menu

### DIFF
--- a/frontend/src/lib/components/apps/components/layout/AppDecisionTree.svelte
+++ b/frontend/src/lib/components/apps/components/layout/AppDecisionTree.svelte
@@ -144,21 +144,6 @@
 			subGridIndex: nodes.findIndex((node) => node.id === currentNodeId)
 		}
 	}
-
-	function updateDebuggingComponents() {
-		const nodeIds = nodes.map((node) => node.id).sort()
-		const debuggingComponentsIds = Object.keys($debuggingComponents).sort()
-
-		if (JSON.stringify(nodeIds) !== JSON.stringify(debuggingComponentsIds)) {
-			debuggingComponentsIds.forEach((id) => {
-				if (!nodeIds.includes(id)) {
-					delete $debuggingComponents[id]
-				}
-			})
-		}
-	}
-
-	$: nodes && $debuggingComponents && updateDebuggingComponents()
 </script>
 
 {#if Object.keys(resolvedConditions).length === nodes.length}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5cc6f5270726e92226c3a8c90d9a13543496674f  | 
|--------|--------|

### Summary:
Removed `updateDebuggingComponents` function and its reactive statement from `AppDecisionTree.svelte`, eliminating node ID synchronization with debugging components.

**Key points**:
- Removed `updateDebuggingComponents` function from `frontend/src/lib/components/apps/components/layout/AppDecisionTree.svelte`.
- Deleted reactive statement that called `updateDebuggingComponents`.
- Function was responsible for synchronizing `nodeIds` with `debuggingComponentsIds`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->