### PR TITLE
fix(frontend): fix flow warnings

### DIFF
--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -197,7 +197,7 @@
 				flowModule.value,
 				$flowInputsStore[flowModule.id].flowStepWarnings ?? {},
 				$flowStateStore[$selectedId]?.schema ?? {},
-				$flowStore?.value?.modules?.map((m) => m?.id) ?? []
+				dfs($flowStore?.value?.modules, (fm) => fm.id) ?? []
 			).then((flowStepWarnings) => {
 				$flowInputsStore[flowModule.id].flowStepWarnings = flowStepWarnings
 			})

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -197,7 +197,7 @@
 				flowModule.value,
 				$flowInputsStore[flowModule.id].flowStepWarnings ?? {},
 				$flowStateStore[$selectedId]?.schema ?? {},
-				dfs($flowStore?.value?.modules, (fm) => fm.id) ?? []
+				dfs($flowStore?.value?.modules ?? [], (fm) => fm.id) ?? []
 			).then((flowStepWarnings) => {
 				$flowInputsStore[flowModule.id].flowStepWarnings = flowStepWarnings
 			})


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 150b1a725dd3086bd5e59cdb83ad596316670a91  | 
|--------|--------|

### Summary:
Updated `FlowModuleComponent.svelte` to use `dfs` for comprehensive module ID retrieval in flow step warnings.

**Key points**:
- Updated `FlowModuleComponent.svelte` to use `dfs` for retrieving module IDs.
- Replaced `map` function with `dfs` in `computeFlowStepWarning` and `initFlowStepWarnings` calls.
- Ensures all module IDs are considered for flow step warnings.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->