### PR TITLE
fix(frontend): fix timezone issues for Date only inputs

### DIFF
--- a/frontend/src/lib/components/DateInput.svelte
+++ b/frontend/src/lib/components/DateInput.svelte
@@ -19,7 +19,7 @@
 			}
 
 			try {
-				let dateFromValue: Date | undefined = newDate ? new Date(newDate) : undefined
+				let dateFromValue: Date | undefined = newDate ? new Date(newDate + 'T00:00:00') : undefined
 
 				if (dateFromValue === undefined) {
 					return

--- a/frontend/src/lib/components/StringTypeNarrowing.svelte
+++ b/frontend/src/lib/components/StringTypeNarrowing.svelte
@@ -266,8 +266,7 @@
 		{#if format == 'date'}
 			<div class="mt-1" />
 
-			<div class="grid grid-cols-3 gap-2"
-				>x
+			<div class="grid grid-cols-3 gap-2">
 				<Label label="Date format passed to script" class="col-span-2">
 					<svelte:fragment slot="header">
 						<Tooltip light>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c344c1f0f39c351581cd0335e8dfb5f5adfdc696  | 
|--------|--------|

### Summary:
Fixes timezone issues in `DateInput.svelte` by appending 'T00:00:00' to date strings and removes an extraneous character in `StringTypeNarrowing.svelte`.

**Key points**:
- Fixes timezone issues in `DateInput.svelte` by appending 'T00:00:00' to date strings.
- Ensures date is interpreted as midnight in local timezone, preventing timezone shifts.
- Change made in `updateValue` function in `frontend/src/lib/components/DateInput.svelte`.
- Removes extraneous character 'x' in `frontend/src/lib/components/StringTypeNarrowing.svelte`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->