### PR TITLE
Added a code style guideline section to the ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,15 @@ settings. Do note that there is a limit of 10 SSO users on the community
 edition.
 
 [See documentation](https://www.windmill.dev/docs/misc/setup_oauth).
+### Code Style Guidelines
+
+Naming Conventions:
+
+Use camelCase for variables and functions.
+Use PascalCase for class names.
+Use uppercase letters for constants.
+
+Commenting: Write clear, concise comments to explain complex logic. Use // for single-line comments and /* */ for multi-line comments.
 
 ### Commercial license
 


### PR DESCRIPTION
I added a contributors style guide to the ReadMe to help keep naming conventions and comments organized and clean. This is to help new comers to open source contributing. This could also be moved to the contributors guide website that you've linked at the top of the ReadMe. 
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 94d609f43f3a54d3b0136ded8b087dfb8ba1d156  | 
|--------|--------|

### Summary:
Added a `Code Style Guidelines` section to `README.md` for consistent naming conventions and commenting practices.

**Key points**:
- Added `Code Style Guidelines` section to `README.md`.
- Specifies naming conventions: camelCase for variables/functions, PascalCase for classes, uppercase for constants.
- Provides commenting guidelines: use `//` for single-line, `/* */` for multi-line comments.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->