### PR TITLE
fix: use job timeout for snowflake timeout

### DIFF
--- a/backend/windmill-worker/src/snowflake_executor.rs
+++ b/backend/windmill-worker/src/snowflake_executor.rs
@@ -17,7 +17,7 @@ use windmill_queue::{CanceledBy, HTTP_CLIENT};
 
 use serde::{Deserialize, Serialize};
 
-use crate::common::run_future_with_polling_update_job_poller;
+use crate::common::{resolve_job_timeout, run_future_with_polling_update_job_poller};
 use crate::{common::build_args_values, AuthedClientBackgroundTask};
 
 #[derive(Serialize)]
@@ -304,7 +304,11 @@ pub async fn do_snowflake(
             json!(database.database.unwrap().to_uppercase()),
         );
     }
-    body.insert("timeout".to_string(), json!(10)); // in seconds
+    let timeout = resolve_job_timeout(&db, &job.workspace_id, job.id, job.timeout)
+        .await
+        .0
+        .as_secs();
+    body.insert("timeout".to_string(), json!(timeout));
 
     let queries = parse_sql_blocks(query);
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d9f8f7fb8e74b442cfc80523f7a6d849d2a4a656  | 
|--------|--------|

### Summary:
The PR updates `do_snowflake` in `backend/windmill-worker/src/snowflake_executor.rs` to use a dynamic timeout from `resolve_job_timeout` instead of a hardcoded value.

**Key points**:
- Updated `do_snowflake` in `backend/windmill-worker/src/snowflake_executor.rs` to use dynamic timeout.
- Replaced hardcoded timeout with `resolve_job_timeout` function call.
- `resolve_job_timeout` retrieves timeout based on job's configuration.
- Ensures timeout is set in the `body` JSON for Snowflake API requests.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->