### PR TITLE
fix(frontend): nit worker limits

### DIFF
--- a/frontend/src/routes/(root)/(logged)/workers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/workers/+page.svelte
@@ -567,7 +567,7 @@
 											<Cell>
 												<div class="flex flex-col gap-1">
 													<div>
-														{vcpus ? (vcpus / 100000).toFixed(1) + ' vCPUs' : '--'}
+														{vcpus ? (vcpus / 100000).toFixed(2) + ' vCPUs' : '--'}
 													</div>
 													<div>
 														{memory ? Math.round(memory / 1024 / 1024) + 'MB' : '--'}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit cad2cca401226d736cef03b795201c7fd5fbe17d  | 
|--------|--------|

### Summary:
Increased vCPU display precision from one to two decimal places in `frontend/src/routes/(root)/(logged)/workers/+page.svelte`.

**Key points**:
- Adjusted vCPU display precision in `frontend/src/routes/(root)/(logged)/workers/+page.svelte`.
- Changed vCPU formatting from one decimal place to two decimal places.
- Affects the display of worker limits in the UI.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->