### PR TITLE
fix(frontend): clicking on step in graph show details again

### DIFF
--- a/frontend/src/lib/components/FlowGraphViewer.svelte
+++ b/frontend/src/lib/components/FlowGraphViewer.svelte
@@ -6,6 +6,7 @@
 
 	import FlowGraphViewerStep from './FlowGraphViewerStep.svelte'
 	import FlowGraphV2 from './graph/FlowGraphV2.svelte'
+	import { dfs } from './flows/dfs'
 
 	export let flow: {
 		summary: string
@@ -13,6 +14,7 @@
 		value: FlowValue
 		schema?: any
 	}
+
 	export let overflowAuto = false
 	export let noSide = false
 	export let download = false
@@ -35,7 +37,8 @@
 				modules={flow?.value?.modules}
 				failureModule={flow?.value?.failure_module}
 				on:select={(e) => {
-					stepDetail = e.detail
+					const mod = dfs(flow?.value?.modules, (m) => m).find((m) => m?.id === e?.detail)
+					stepDetail = mod ?? e.detail
 					dispatch('select', stepDetail)
 				}}
 			/>

--- a/frontend/src/lib/components/FlowViewer.svelte
+++ b/frontend/src/lib/components/FlowViewer.svelte
@@ -87,6 +87,7 @@
 				{:else}
 					<div class="text-secondary text-xs italic mb-4">No inputs</div>
 				{/if}
+
 				<FlowGraphViewer download {noSide} {flow} overflowAuto />
 			</div>
 		</TabContent>

--- a/frontend/src/lib/components/flows/FlowHistory.svelte
+++ b/frontend/src/lib/components/flows/FlowHistory.svelte
@@ -91,6 +91,7 @@
 		on:close={() => {
 			drawer?.closeDrawer()
 		}}
+		noPadding
 	>
 		<Splitpanes class="!overflow-visible">
 			<Pane size={20}>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit da7adda5f9afbac5da52bdf9a210050203601c81  | 
|--------|--------|

### Summary:
Fixes flow graph step preview by using depth-first search to correctly identify selected modules in `FlowGraphViewer.svelte`.

**Key points**:
- Added `dfs` import in `frontend/src/lib/components/FlowGraphViewer.svelte`.
- Modified `on:select` event in `FlowGraphViewer.svelte` to use `dfs` for finding the correct module.
- Ensured `stepDetail` is set to the correct module or detail in `FlowGraphViewer.svelte`.
- Added `noPadding` attribute to `DrawerContent` in `frontend/src/lib/components/flows/FlowHistory.svelte`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->