### PR TITLE
fix: items with starred info

### DIFF
--- a/backend/windmill-api/src/flows.rs
+++ b/backend/windmill-api/src/flows.rs
@@ -36,7 +36,7 @@ use windmill_common::HUB_BASE_URL;
 use windmill_common::{
     db::UserDB,
     error::{self, to_anyhow, Error, JsonResult, Result},
-    flows::{Flow, ListFlowQuery, ListableFlow, NewFlow},
+    flows::{Flow, FlowWithStarred, ListFlowQuery, ListableFlow, NewFlow},
     jobs::JobPayload,
     schedule::Schedule,
     scripts::Schema,
@@ -878,12 +878,12 @@ async fn get_flow_by_path(
     Extension(user_db): Extension<UserDB>,
     Path((w_id, path)): Path<(String, StripPath)>,
     Query(query): Query<WithStarredInfoQuery>,
-) -> JsonResult<Flow> {
+) -> JsonResult<FlowWithStarred> {
     let path = path.to_path();
     let mut tx = user_db.begin(&authed).await?;
 
     let flow_o = if query.with_starred_info.unwrap_or(false) {
-        sqlx::query_as::<_, Flow>(
+        sqlx::query_as::<_, FlowWithStarred>(
             "SELECT flow.workspace_id, flow.path, flow.summary, flow.description, flow.archived, flow.extra_perms, flow.draft_only, flow.dedicated_worker, flow.tag, flow.ws_error_handler_muted, flow.timeout, flow.visible_to_runner_only, flow_version.schema, flow_version.value, flow_version.created_at as edited_at, flow_version.created_by as edited_by, favorite.path IS NOT NULL as starred
             FROM flow
             LEFT JOIN favorite
@@ -900,7 +900,7 @@ async fn get_flow_by_path(
             .fetch_optional(&mut *tx)
             .await?
     } else {
-        sqlx::query_as::<_, Flow>(
+        sqlx::query_as::<_, FlowWithStarred>(
             "SELECT flow.workspace_id, flow.path, flow.summary, flow.description, flow.archived, flow.extra_perms, flow.draft_only, flow.dedicated_worker, flow.tag, flow.ws_error_handler_muted, flow.timeout, flow.visible_to_runner_only, flow_version.schema, flow_version.value, flow_version.created_at as edited_at, flow_version.created_by as edited_by, NULL as starred
             FROM flow
             LEFT JOIN flow_version ON flow_version.id = flow.versions[array_upper(flow.versions, 1)]

--- a/backend/windmill-common/src/flows.rs
+++ b/backend/windmill-common/src/flows.rs
@@ -33,8 +33,6 @@ pub struct Flow {
     pub schema: Option<Schema>,
     pub extra_perms: serde_json::Value,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub starred: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub draft_only: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dedicated_worker: Option<bool>,
@@ -46,6 +44,15 @@ pub struct Flow {
     pub timeout: Option<i32>,
     #[serde(skip_serializing_if = "is_none_or_false")]
     pub visible_to_runner_only: Option<bool>,
+}
+
+#[derive(Serialize, sqlx::FromRow)]
+pub struct FlowWithStarred {
+    #[sqlx(flatten)]
+    #[serde(flatten)]
+    pub flow: Flow,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub starred: Option<bool>,
 }
 
 fn is_none_or_false(b: &Option<bool>) -> bool {

--- a/backend/windmill-common/src/scripts.rs
+++ b/backend/windmill-common/src/scripts.rs
@@ -160,8 +160,6 @@ pub struct Script {
     pub kind: ScriptKind,
     pub tag: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub starred: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub draft_only: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub envs: Option<Vec<String>>,
@@ -191,6 +189,15 @@ pub struct Script {
     pub no_main_func: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub codebase: Option<String>,
+}
+
+#[derive(Serialize, sqlx::FromRow)]
+pub struct ScriptWithStarred {
+    #[sqlx(flatten)]
+    #[serde(flatten)]
+    pub script: Script,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub starred: Option<bool>,
 }
 
 #[derive(Serialize, sqlx::FromRow)]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 098e692a30516beefe63773a1c6d53c779113a76  | 
|--------|--------|

### Summary:
This PR adds support for including starred information in app, flow, and script responses by introducing new structs and modifying relevant functions and SQL queries.

**Key points**:
- Introduced `AppWithLastVersionAndStarred` in `backend/windmill-api/src/apps.rs` to include starred info.
- Modified `get_app` function to return `AppWithLastVersionAndStarred`.
- Introduced `FlowWithStarred` in `backend/windmill-common/src/flows.rs` to include starred info.
- Modified `get_flow_by_path` function to return `FlowWithStarred`.
- Introduced `ScriptWithStarred` in `backend/windmill-common/src/scripts.rs` to include starred info.
- Modified `get_script_by_path` function to return `ScriptWithStarred`.
- Updated SQL queries to handle starred information in the above functions.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->