### PR TITLE
fix(frontend): remove the dotted outline around the app editor

### DIFF
--- a/frontend/src/lib/components/apps/editor/GridEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/GridEditor.svelte
@@ -26,7 +26,6 @@
 	const {
 		selectedComponent,
 		app,
-		mode,
 		connectingInput,
 		summary,
 		focusedGrid,
@@ -126,14 +125,7 @@
 		}}
 		bind:clientWidth={$parentWidth}
 	>
-		<div
-			class={twMerge(
-				!$focusedGrid && $mode !== 'preview' ? 'outline-dashed' : '',
-				'subgrid  overflow-visible  z-100',
-				'outline-[#999999] dark:outline-[#aaaaaa] outline-dotted outline-offset-2 outline-1 '
-			)}
-			style={`transform: scale(${$scale / 100});`}
-		>
+		<div class="subgrid overflow-visible z-100" style={`transform: scale(${$scale / 100});`}>
 			<Grid
 				allIdsInPath={$allIdsInPath}
 				selectedIds={$selectedComponent}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 055261d98efc031564376ddba245e776dd4cf13f  | 
|--------|--------|

### Summary:
Remove the dotted outline around the app editor in `GridEditor.svelte` by eliminating the `mode` variable and related class conditions.

**Key points**:
- Remove `mode` variable from `frontend/src/lib/components/apps/editor/GridEditor.svelte`.
- Eliminate conditional class application for `outline-dashed` in the `div` element.
- Simplify `div` class to `subgrid overflow-visible z-100` without outline styles.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->