### PR TITLE
Fr/anchored subgrid indicator

### DIFF
--- a/frontend/src/lib/components/apps/editor/SubGridEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/SubGridEditor.svelte
@@ -108,6 +108,7 @@
 					selectedIds={$selectedComponent}
 					let:dataItem
 					let:hidden
+					let:overlapped
 					cols={columnConfiguration}
 					scroller={container}
 					parentWidth={$parentWidth - 17}
@@ -125,6 +126,7 @@
 						<GridEditorMenu id={dataItem.id}>
 							<Component
 								{hidden}
+								{overlapped}
 								fullHeight={dataItem?.[$breakpoint === 'sm' ? 3 : 12]?.fullHeight}
 								render={visible}
 								component={dataItem.data}

--- a/frontend/src/lib/components/apps/editor/component/Component.svelte
+++ b/frontend/src/lib/components/apps/editor/component/Component.svelte
@@ -98,8 +98,6 @@
 	$: ismoving =
 		movingcomponents != undefined && $mode == 'dnd' && $movingcomponents?.includes(component.id)
 
-	const componentActive = editorContext?.componentActive
-
 	let initializing: boolean | undefined = undefined
 	let errorHandledByComponent: boolean = false
 	let componentContainerHeight: number = 0
@@ -139,7 +137,8 @@
 		hidden && $mode === 'preview' ? 'hidden' : ''
 	)}
 >
-	{#if locked && componentActive && $componentActive && $selectedComponent?.[0] !== component.id}
+
+	{#if locked && $selectedComponent?.[0] !== component.id && overlapped}
 		<div
 			class={twMerge(
 				'absolute inset-0 bg-locked center-center flex-col z-50',

--- a/frontend/src/lib/components/apps/editor/component/Component.svelte
+++ b/frontend/src/lib/components/apps/editor/component/Component.svelte
@@ -94,6 +94,8 @@
 		getContext<AppViewerContext>('AppViewerContext')
 
 	const editorContext = getContext<AppEditorContext>('AppEditorContext')
+	const componentActive = editorContext?.componentActive
+
 	const movingcomponents = editorContext?.movingcomponents
 	$: ismoving =
 		movingcomponents != undefined && $mode == 'dnd' && $movingcomponents?.includes(component.id)
@@ -137,8 +139,7 @@
 		hidden && $mode === 'preview' ? 'hidden' : ''
 	)}
 >
-
-	{#if locked && $selectedComponent?.[0] !== component.id && overlapped}
+	{#if locked && componentActive && $componentActive && $selectedComponent?.[0] !== component.id && overlapped}
 		<div
 			class={twMerge(
 				'absolute inset-0 bg-locked center-center flex-col z-50',

--- a/frontend/src/lib/components/apps/svelte-grid/utils/item.ts
+++ b/frontend/src/lib/components/apps/svelte-grid/utils/item.ts
@@ -136,7 +136,7 @@ export function moveItem(active, items, cols) {
 	if (fixed) {
 		return {
 			items: items,
-			overlap: true
+			overlap: closeBlocks.length > 0
 		}
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 772c7eea8fd0088db622b9c3c97ebf92d27ce95d  | 
|--------|--------|

### Summary:
Introduced an `overlapped` property to handle overlapping components in grid layouts, updating the `moveItem` function and UI to indicate anchored components.

**Key points**:
- Added `overlapped` property in `SubGridEditor.svelte` and `Component.svelte` to handle overlapping components.
- Updated `moveItem` function in `frontend/src/lib/components/apps/svelte-grid/utils/item.ts` to return `overlap` status based on close blocks.
- Modified UI to display an anchored indicator when a component is overlapped and locked.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->