### PR TITLE
fix: Take interpreter paths from environment (bash executor)

### DIFF
--- a/backend/windmill-worker/src/bash_executor.rs
+++ b/backend/windmill-worker/src/bash_executor.rs
@@ -11,7 +11,9 @@ use windmill_common::{
 };
 use windmill_queue::{append_logs, CanceledBy};
 
-const BIN_BASH: &str = "/bin/bash";
+lazy_static::lazy_static! {
+    static ref BIN_BASH: String = std::env::var("BASH_PATH").unwrap_or_else(|_| "/bin/bash".to_string());
+}
 const NSJAIL_CONFIG_RUN_BASH_CONTENT: &str = include_str!("../nsjail/run.bash.config.proto");
 const NSJAIL_CONFIG_RUN_POWERSHELL_CONTENT: &str =
     include_str!("../nsjail/run.powershell.config.proto");
@@ -55,7 +57,7 @@ pub async fn handle_bash_job(
     write_file(
         job_dir,
         "wrapper.sh",
-        &format!("set -o pipefail\nset -e\nmkfifo bp\ncat bp | tail -1 > ./result2.out &\n /bin/bash ./main.sh \"$@\" 2>&1 | tee bp\nwait $!"),
+        &format!("set -o pipefail\nset -e\nmkfifo bp\ncat bp | tail -1 > ./result2.out &\n {bash} ./main.sh \"$@\" 2>&1 | tee bp\nwait $!", bash = BIN_BASH.as_str()),
     )?;
 
     let token = client.get_token().await;
@@ -96,7 +98,7 @@ pub async fn handle_bash_job(
             "--config",
             "run.config.proto",
             "--",
-            "/bin/bash",
+            BIN_BASH.as_str(),
             "wrapper.sh",
         ];
         cmd_args.extend(args);
@@ -114,7 +116,7 @@ pub async fn handle_bash_job(
     } else {
         let mut cmd_args = vec!["wrapper.sh"];
         cmd_args.extend(&args);
-        let mut bash_cmd = Command::new(BIN_BASH);
+        let mut bash_cmd = Command::new(BIN_BASH.as_str());
         bash_cmd
             .current_dir(job_dir)
             .env_clear()
@@ -126,7 +128,7 @@ pub async fn handle_bash_job(
             .args(cmd_args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        start_child_process(bash_cmd, BIN_BASH).await?
+        start_child_process(bash_cmd, BIN_BASH.as_str()).await?
     };
     handle_child(
         &job.id,
@@ -332,7 +334,7 @@ $env:PSModulePath = \"{}:$PSModulePathBackup\"",
             "--config",
             "run.config.proto",
             "--",
-            "/bin/bash",
+            BIN_BASH.as_str(),
             "wrapper.sh",
         ];
         cmd_args.extend(pwsh_args.iter().map(|x| x.as_str()));
@@ -350,7 +352,7 @@ $env:PSModulePath = \"{}:$PSModulePathBackup\"",
     } else {
         let mut cmd_args = vec!["wrapper.sh"];
         cmd_args.extend(pwsh_args.iter().map(|x| x.as_str()));
-        Command::new("/bin/bash")
+        Command::new(BIN_BASH.as_str())
             .current_dir(job_dir)
             .env_clear()
             .envs(envs)

--- a/backend/windmill-worker/src/bash_executor.rs
+++ b/backend/windmill-worker/src/bash_executor.rs
@@ -257,7 +257,7 @@ pub async fn handle_powershell_job(
     if !install_string.is_empty() {
         logs1.push_str("\n\nInstalling modules...");
         append_logs(&job.id, &job.workspace_id, logs1, db).await;
-        let child = Command::new("pwsh")
+        let child = Command::new(POWERSHELL_PATH.as_str())
             .args(&["-Command", &install_string])
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())


### PR DESCRIPTION
Updated the bash executor to use both bash and powershell from the environment variables (if set).
I took the simplest approach to get the desired effect, ignoring the example that POWERSHELL_PATH is defined in worker.rs

Ran cargo fmt on the file and validated syntax with cargo check, on latest rust stable (v1.80.1)

<details>

<summary>OPS</summary>

```shell
tee build-shell.nix <<EOF
> { pkgs ? import <nixpkgs> { } }:
pkgs.mkShell {

  buildInputs = with pkgs; [ openssl rustfmt lld stdenv.cc.cc.lib ];

  nativeBuildInputs = with pkgs; [
    rustup
    pkg-config
    makeWrapper
    swagger-cli
    cmake # for libz-ng-sys crate
  ];

  SQLX_OFFLINE = "true";
}
EOF

nix-shell build-shell.nix

rustup default stable

cd backend/windmill-worker && cargo check
```

</details>
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a969678a2fe68945171928cd516e36e61c72c995  | 
|--------|--------|

### Summary:
Updated bash executor to use environment variables for bash and powershell paths in `backend/windmill-worker/src/bash_executor.rs`.

**Key points**:
- Updated `backend/windmill-worker/src/bash_executor.rs` to use environment variables for interpreter paths.
- Defined `BIN_BASH` using `lazy_static` to get `BASH_PATH` from environment or default to `/bin/bash`.
- Replaced hardcoded `/bin/bash` with `BIN_BASH` in `handle_bash_job` and `handle_powershell_job` functions.
- Used `POWERSHELL_PATH` for powershell command execution in `handle_powershell_job`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->