### PR TITLE
fix(frontend): table footer display on safari

### DIFF
--- a/frontend/src/lib/components/apps/components/display/table/AppAggridTable.svelte
+++ b/frontend/src/lib/components/apps/components/display/table/AppAggridTable.svelte
@@ -483,6 +483,8 @@
 	let refreshCount: number = 0
 	let footerRenderCount: number = 0
 	let computedOrder: string[] | undefined = undefined
+
+	let footerHeight: number = 0
 </script>
 
 {#if actionsOrder}
@@ -539,7 +541,7 @@
 				on:pointerdown|stopPropagation={() => {
 					$selectedComponent = [id]
 				}}
-				style:height="{clientHeight}px"
+				style:height="{clientHeight - (resolvedConfig.footer ? footerHeight : 0)}px"
 				style:width="{clientWidth}px"
 				class="ag-theme-alpine relative"
 				class:ag-theme-alpine-dark={$darkMode}
@@ -571,7 +573,10 @@
 			</div>
 			{#if resolvedConfig.footer}
 				{#key footerRenderCount}
-					<div class="flex gap-1 w-full justify-between items-center text-sm text-secondary/80 p-2">
+					<div
+						class="flex gap-1 w-full justify-between items-center text-sm text-secondary/80 p-2"
+						bind:clientHeight={footerHeight}
+					>
 						<div>
 							<Popover>
 								<svelte:fragment slot="text">Download</svelte:fragment>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 085bf08fb3bfba299d0f6c845ffbe011885c1778  | 
|--------|--------|

fix(frontend): adjust table height for footer display on Safari

### Summary:
Fixes table footer display issue on Safari by adjusting height calculation in `AppAggridTable.svelte`.

**Key points**:
- **Behavior**:
  - Adjusts table height calculation in `AppAggridTable.svelte` to subtract `footerHeight` when `resolvedConfig.footer` is true.
  - Binds `clientHeight` to `footerHeight` for the footer `div` to dynamically adjust its height.
- **Variables**:
  - Introduces `footerHeight` variable to store the footer's height.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->