### PR TITLE
fix: update internal hub scritps to bun

### DIFF
--- a/frontend/src/lib/components/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/ScheduleEditorInner.svelte
@@ -765,7 +765,7 @@
 									bind:handlerPath={errorHandlerPath}
 									customInitialScriptPath={errorHandlerCustomInitialPath}
 									slackToggleText="Alert channel on error"
-									customScriptTemplate="/scripts/add?hub=hub%2F2420%2Fwindmill%2Fschedule_error_handler_template"
+									customScriptTemplate="/scripts/add?hub=hub%2F9081%2Fwindmill%2Fschedule_error_handler_template"
 									bind:customHandlerKind={errorHandleritemKind}
 									bind:handlerExtraArgs={errorHandlerExtraArgs}
 								>
@@ -858,7 +858,7 @@
 									bind:handlerPath={recoveryHandlerPath}
 									customInitialScriptPath={recoveryHandlerCustomInitialPath}
 									slackToggleText="Alert channel when error recovered"
-									customScriptTemplate="/scripts/add?hub=hub%2F2794%2Fwindmill%2Fschedule_recovery_handler_template"
+									customScriptTemplate="/scripts/add?hub=hub%2F9082%2Fwindmill%2Fschedule_recovery_handler_template"
 									bind:customHandlerKind={recoveryHandlerItemKind}
 									bind:handlerExtraArgs={recoveryHandlerExtraArgs}
 								>

--- a/frontend/src/lib/hubPaths.json
+++ b/frontend/src/lib/hubPaths.json
@@ -2,11 +2,13 @@
 	"gitSyncLegacy0": "hub/8931/sync-script-to-git-repo-windmill",
 	"gitSync": "hub/9074/sync-script-to-git-repo-windmill",
 	"gitSyncTest": "hub/9073/git-repo-test-read-write-windmill",
-	"slackErrorHandler": "hub/6512/workspace-or-schedule-error-handler-slack",
-	"slackRecoveryHandler": "hub/9067/slack/schedule-recovery-handler-slack",
+	"slackErrorHandler": "hub/9079/workspace-or-schedule-error-handler-slack",
+	"slackErrorHandler_0": "hub/6512/workspace-or-schedule-error-handler-slack",
+	"slackRecoveryHandler": "hub/9080/slack/schedule-recovery-handler-slack",
+	"slackRecoveryHandler_1": "hub/9067/slack/schedule-recovery-handler-slack",
 	"slackRecoveryHandler_0": "hub/2430/slack/schedule-recovery-handler-slack",
 	"slackSuccessHandler": "hub/9072/slack/schedule-success-handler-slack",
-	"slackReport": "hub/7836/slack",
-	"discordReport": "hub/7838/discord",
-	"smtpReport": "hub/7837/smtp"
+	"slackReport": "hub/9084/slack",
+	"discordReport": "hub/9085/discord",
+	"smtpReport": "hub/9086/smtp"
 }

--- a/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
@@ -960,7 +960,7 @@
 				customInitialScriptPath={errorHandlerInitialScriptPath}
 				bind:handlerSelected={errorHandlerSelected}
 				bind:handlerPath={errorHandlerScriptPath}
-				customScriptTemplate="/scripts/add?hub=hub%2F2420%2Fwindmill%2Fworkspace_error_handler_template"
+				customScriptTemplate="/scripts/add?hub=hub%2F9083%2Fwindmill%2Fworkspace_error_handler_template"
 				bind:customHandlerKind={errorHandlerItemKind}
 				bind:handlerExtraArgs={errorHandlerExtraArgs}
 			>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 38b4bdc9edc3f4e70b3aaf86c913d4ee92e56811  | 
|--------|--------|

feat: update internal hub script paths to new hub

### Summary:
Update internal hub script paths in Svelte components and configuration files for error and recovery handlers.

**Key points**:
- **Behavior**:
  - Update `customScriptTemplate` URLs in `ScheduleEditorInner.svelte` for error and recovery handlers.
  - Update `customScriptTemplate` URL in `workspace_settings/+page.svelte` for workspace error handler.
- **Configuration**:
  - Update paths in `hubPaths.json` for `slackErrorHandler`, `slackRecoveryHandler`, `slackReport`, `discordReport`, and `smtpReport`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->