### PR TITLE
chore: build full docker image for arm64

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -738,11 +738,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push publicly 
+      - name: Build and push publicly
         uses: depot/build-push-action@v1
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           file: "./docker/DockerfileRust"
           tags: |
@@ -787,7 +787,7 @@ jobs:
         uses: depot/build-push-action@v1
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           file: "./docker/DockerfileRustEe"
           tags: |

--- a/docker/DockerfileRust
+++ b/docker/DockerfileRust
@@ -1,4 +1,4 @@
-FROM ghcr.io/windmill-labs/windmill-ee:dev
+FROM ghcr.io/windmill-labs/windmill:dev
 
 COPY --from=rust:1.80.1 /usr/local/cargo /usr/local/cargo
 COPY --from=rust:1.80.1 /usr/local/rustup /usr/local/rustup


### PR DESCRIPTION
Closes #4390

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit dead6570c85926cb76889dc6a20f53c835132d09  | 
|--------|--------|

chore: build full docker image for arm64

### Summary:
Update GitHub Actions to build Docker images for `linux/amd64` and `linux/arm64`, and change base image in `DockerfileRust`.

**Key points**:
- **GitHub Actions Workflow**:
  - Update `.github/workflows/docker-image.yml` to build Docker images for `linux/amd64` and `linux/arm64` platforms.
  - Modify `platforms` parameter in `depot/build-push-action` steps for both public and EE builds.
- **Dockerfile**:
  - Change base image in `docker/DockerfileRust` from `ghcr.io/windmill-labs/windmill-ee:dev` to `ghcr.io/windmill-labs/windmill:dev`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->