### PR TITLE
fix(frontend): new resource type name must be snake case

### DIFF
--- a/frontend/src/routes/(root)/(logged)/resources/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/resources/+page.svelte
@@ -345,6 +345,16 @@
 		const snakeCaseRegex = /^[a-z]+(_[a-z]+)*$/
 		newResourceType.isValid = snakeCaseRegex.test(newResourceType.name)
 	}
+
+	function toSnakeCase() {
+		newResourceType.name = newResourceType.name
+			.replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+			.replace(/[\W]+/g, '_')
+			.replace(/_+/g, '_')
+			.replace(/^_+|_+$/g, '')
+			.toLowerCase()
+		newResourceTypeNameValid()
+	}
 </script>
 
 <ConfirmationModal
@@ -487,7 +497,9 @@
 				</div>
 				{#if newResourceType.name}
 					{#if !newResourceType.isValid}
-						<p class="mt-1 px-2 text-red-600 dark:text-red-400 text-2xs">Name must be snake_case!</p
+						<p class="mt-1 px-2 text-red-600 dark:text-red-400 text-2xs"
+							>Name must be snake_case!
+							<button on:click={toSnakeCase} class="text-blue-600">Fix...</button></p
 						>
 					{/if}
 				{/if}

--- a/frontend/src/routes/(root)/(logged)/resources/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/resources/+page.svelte
@@ -75,7 +75,8 @@
 	let newResourceType = {
 		name: '',
 		schema: emptySchema(),
-		description: ''
+		description: '',
+		isValid: false
 	}
 	let editResourceType = {
 		name: '',
@@ -244,7 +245,8 @@
 		newResourceType = {
 			name: 'my_resource_type',
 			schema: emptySchema(),
-			description: ''
+			description: '',
+			isValid: true
 		}
 		resourceTypeDrawer.openDrawer?.()
 	}
@@ -338,6 +340,11 @@
 		deployUiSettings = settings.deploy_ui ?? ALL_DEPLOYABLE
 	}
 	getDeployUiSettings()
+
+	function newResourceTypeNameValid() {
+		const snakeCaseRegex = /^[a-z]+(_[a-z]+)*$/
+		newResourceType.isValid = snakeCaseRegex.test(newResourceType.name)
+	}
 </script>
 
 <ConfirmationModal
@@ -437,7 +444,11 @@
 <Drawer bind:this={resourceTypeDrawer} size="1200px">
 	<DrawerContent title="Create resource type" on:close={resourceTypeDrawer.closeDrawer}>
 		<svelte:fragment slot="actions">
-			<Button startIcon={{ icon: Save }} on:click={addResourceType}>Save</Button>
+			<Button
+				startIcon={{ icon: Save }}
+				on:click={addResourceType}
+				disabled={!newResourceType.isValid}>Save</Button
+			>
 		</svelte:fragment>
 		<div class="flex flex-col gap-6">
 			<label for="inp">
@@ -463,6 +474,7 @@
 								type="text"
 								bind:value={newResourceType.name}
 								class={classNames('!h-8  !border ', !disableCustomPrefix ? '!rounded-l-none' : '')}
+								on:input={newResourceTypeNameValid}
 							/>
 						</div>
 					</div>
@@ -473,6 +485,12 @@
 						/>
 					{/if}
 				</div>
+				{#if newResourceType.name}
+					{#if !newResourceType.isValid}
+						<p class="mt-1 px-2 text-red-600 dark:text-red-400 text-2xs">Name must be snake_case!</p
+						>
+					{/if}
+				{/if}
 			</label>
 			<label>
 				<div class="mb-1 font-semibold text-secondary">Description</div>

--- a/frontend/src/routes/(root)/(logged)/resources/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/resources/+page.svelte
@@ -75,9 +75,10 @@
 	let newResourceType = {
 		name: '',
 		schema: emptySchema(),
-		description: '',
-		isValid: false
+		description: ''
 	}
+	let isNewResourceTypeNameValid: boolean
+
 	let editResourceType = {
 		name: '',
 		schema: emptySchema(),
@@ -245,9 +246,10 @@
 		newResourceType = {
 			name: 'my_resource_type',
 			schema: emptySchema(),
-			description: '',
-			isValid: true
+			description: ''
 		}
+		validateResourceTypeName()
+
 		resourceTypeDrawer.openDrawer?.()
 	}
 
@@ -341,9 +343,9 @@
 	}
 	getDeployUiSettings()
 
-	function newResourceTypeNameValid() {
-		const snakeCaseRegex = /^[a-z]+(_[a-z]+)*$/
-		newResourceType.isValid = snakeCaseRegex.test(newResourceType.name)
+	function validateResourceTypeName() {
+		const snakeCaseRegex = /^[a-z0-9]+(_[a-z0-9]+)*$/
+		isNewResourceTypeNameValid = snakeCaseRegex.test(newResourceType.name)
 	}
 
 	function toSnakeCase() {
@@ -353,7 +355,7 @@
 			.replace(/_+/g, '_')
 			.replace(/^_+|_+$/g, '')
 			.toLowerCase()
-		newResourceTypeNameValid()
+		validateResourceTypeName()
 	}
 </script>
 
@@ -457,7 +459,7 @@
 			<Button
 				startIcon={{ icon: Save }}
 				on:click={addResourceType}
-				disabled={!newResourceType.isValid}>Save</Button
+				disabled={!isNewResourceTypeNameValid}>Save</Button
 			>
 		</svelte:fragment>
 		<div class="flex flex-col gap-6">
@@ -484,7 +486,7 @@
 								type="text"
 								bind:value={newResourceType.name}
 								class={classNames('!h-8  !border ', !disableCustomPrefix ? '!rounded-l-none' : '')}
-								on:input={newResourceTypeNameValid}
+								on:input={validateResourceTypeName}
 							/>
 						</div>
 					</div>
@@ -496,7 +498,7 @@
 					{/if}
 				</div>
 				{#if newResourceType.name}
-					{#if !newResourceType.isValid}
+					{#if !isNewResourceTypeNameValid}
 						<p class="mt-1 px-2 text-red-600 dark:text-red-400 text-2xs"
 							>Name must be snake_case!
 							<button on:click={toSnakeCase} class="text-blue-600">Fix...</button></p


### PR DESCRIPTION
Adding a new resource type when not using snake case (e.g using camel case) lead to windmill code editor being unable to find/match the type automatically (not shown as drop down).

- this PR checks/validates the name on the client side only
- offers an option to "auto fix" the name to snake case
- disables button if name invalid


https://github.com/user-attachments/assets/1011a93b-1827-4fd2-899c-26719a5e6459



<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 40d37e4a1e5e0b10d1114cc0902f16efbabde9d7  | 
|--------|--------|

fix(frontend): enforce snake case for new resource type names

### Summary:
Enforces snake case for new resource type names with validation and auto-fix in `+page.svelte`.

**Key points**:
- Enforces snake case for new resource type names in `+page.svelte`.
- Adds `validateResourceTypeName()` to check if names are snake case.
- Updates `isNewResourceTypeNameValid` based on validation.
- Adds `toSnakeCase()` to convert names to snake case.
- Provides "Fix..." button to auto-correct invalid names.
- Disables "Save" button if name is invalid.
- Shows error message and "Fix..." button if name is invalid.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->