### PR TITLE
fix: allow no body in job requests

### DIFF
--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -350,9 +350,7 @@ pub async fn run_server(
                 )
                 .nest(
                     "/r",
-                    http_triggers::routes_global_service()
-                        .layer(from_extractor::<OptAuthed>())
-                        .layer(cors),
+                    http_triggers::routes_global_service().layer(from_extractor::<OptAuthed>()),
                 )
                 .route("/version", get(git_v))
                 .route("/uptodate", get(is_up_to_date))


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Allow HTTP requests with no body and enhance CORS support in `http_triggers.rs` and `jobs.rs`.
> 
>   - **Behavior**:
>     - Allow HTTP requests with no body by setting default values in `PushArgsOwned::from_request` in `jobs.rs`.
>     - Add CORS support for additional HTTP methods in `routes_global_service` in `http_triggers.rs`.
>   - **CORS**:
>     - Add `CorsLayer` to `routes_global_service` in `http_triggers.rs` to allow methods: GET, POST, DELETE, PUT, PATCH.
>     - Allow headers: `CONTENT_TYPE`, `AUTHORIZATION`.
>   - **Misc**:
>     - Remove unused `any` import in `http_triggers.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs/windmill#4413)<sup> for ada58fc263c72404d51e31f43742a32fdbfaf97e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->