### PR TITLE
floor progress in typescript client

### DIFF
--- a/typescript-client/client.ts
+++ b/typescript-client/client.ts
@@ -391,6 +391,7 @@ export async function setState(state: any): Promise<void> {
  * Set the progress
  * Progress cannot go back and limited to 0% to 99% range
  * @param percent Progress to set in %
+ * @param jobId? Job to set progress for
  */
 export async function setProgress(percent: number, jobId?: any): Promise<void> {
   const workspace = getWorkspace();
@@ -412,7 +413,8 @@ export async function setProgress(percent: number, jobId?: any): Promise<void> {
     id: jobId ?? getEnv("WM_JOB_ID") ?? "NO_JOB_ID",
     workspace,
     requestBody: {
-      percent,
+      // In case user inputs float, it should be converted to int
+      percent: Math.floor(percent),
       flow_job_id: (flowId == "") ? undefined : flowId,
     }
   });
@@ -420,6 +422,7 @@ export async function setProgress(percent: number, jobId?: any): Promise<void> {
 
 /**
  * Get the progress
+ * @param jobId? Job to get progress from
  * @returns Optional clamped between 0 and 100 progress value 
  */
 export async function getProgress(jobId?: any): Promise<number | null> {


### PR DESCRIPTION
If user passes float to setProgress it will result BadRequest from server but without any explanation.

Sometimes it is non intuitive that endpoint accepts only integers, so to reduce confusion we convert progress to int.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Floors float input to integer in `setProgress()` in `client.ts` to prevent server errors.
> 
>   - **Behavior**:
>     - Floors float input to integer in `setProgress()` in `client.ts` to prevent BadRequest errors from server.
>   - **Documentation**:
>     - Updates docstring for `setProgress()` to include `jobId` parameter description.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for e7230fb5bd94c2ad059e36b6e4dc5b2ec5e3d6a7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->