### PR TITLE
feat(frontend): add http routing templates

### DIFF
--- a/frontend/src/lib/components/triggers/RouteEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/RouteEditorInner.svelte
@@ -280,14 +280,29 @@
 						Pick a script or flow to be triggered<Required required={true} /><br />
 						To handle headers, query or path parameters, add a preprocessor to your runnable.
 					</p>
-					<ScriptPicker
-						disabled={!can_write}
-						initialPath={initialScriptPath}
-						kinds={['script']}
-						allowFlow={true}
-						bind:itemKind
-						bind:scriptPath={script_path}
-					/>
+					<div class="flex flex-row mb-2">
+						<ScriptPicker
+							disabled={!can_write}
+							initialPath={initialScriptPath}
+							kinds={['script']}
+							allowFlow={true}
+							bind:itemKind
+							bind:scriptPath={script_path}
+							allowRefresh
+						/>
+
+						{#if script_path === undefined}
+							<Button
+								btnClasses="ml-4 mt-2"
+								color="dark"
+								size="xs"
+								href={itemKind === 'flow'
+									? '/flows/add?hub=55'
+									: '/scripts/add?hub=hub%2F9088%2Fwindmill%2FHTTP%20route%20script%20with%20preprocessor%20template'}
+								target="_blank">Create from template</Button
+							>
+						{/if}
+					</div>
 				</Section>
 				<Section label="Settings">
 					<div class="flex flex-col gap-4">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a "Create from template" button in `RouteEditorInner.svelte` for undefined `script_path`, linking to script or flow templates.
> 
>   - **Behavior**:
>     - Adds a "Create from template" button in `RouteEditorInner.svelte` when `script_path` is undefined.
>     - Button links to a template creation page based on `itemKind` (flow or script).
>   - **UI Components**:
>     - Updates `ScriptPicker` to include `allowRefresh` property in `RouteEditorInner.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for e226e8d06abc65d4952c15d611076b9c45ab28fa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->