### PR TITLE
fix: time handling in bun and deno

### DIFF
--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -976,7 +976,7 @@ pub async fn handle_bun_job(
             .map(|x| {
                 return format!(r#"args["{x}"] = args["{x}"] ? new Date(args["{x}"]) : undefined"#);
             })
-            .join("\n");
+            .join("\n    ");
 
         let spread = args.into_iter().map(|x| x.name).join(",");
         // logs.push_str(format!("infer args: {:?}\n", start.elapsed().as_micros()).as_str());
@@ -1022,8 +1022,8 @@ BigInt.prototype.toJSON = function () {{
     return this.toString();
 }};
 
-{dates}
 async function run() {{
+    {dates}
     {preprocessor}
     const argsArr = argsObjToArr(args);
     if (Main.{main_name} === undefined || typeof Main.{main_name} !== 'function') {{

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -966,15 +966,16 @@ pub async fn handle_bun_job(
             .as_ref()
             .unwrap_or(&args)
             .iter()
-            .enumerate()
-            .filter_map(|(i, x)| {
+            .filter_map(|x| {
                 if matches!(x.typ, Typ::Datetime) {
-                    Some(i)
+                    Some(x.name.as_str())
                 } else {
                     None
                 }
             })
-            .map(|x| return format!("args[{x}] = args[{x}] ? new Date(args[{x}]) : undefined"))
+            .map(|x| {
+                return format!(r#"args["{x}"] = args["{x}"] ? new Date(args["{x}"]) : undefined"#);
+            })
             .join("\n");
 
         let spread = args.into_iter().map(|x| x.name).join(",");

--- a/backend/windmill-worker/src/deno_executor.rs
+++ b/backend/windmill-worker/src/deno_executor.rs
@@ -224,7 +224,7 @@ pub async fn handle_deno_job(
             .map(|x| {
                 return format!(r#"args["{x}"] = args["{x}"] ? new Date(args["{x}"]) : undefined"#);
             })
-            .join("\n");
+            .join("\n    ");
 
         let spread = args.into_iter().map(|x| x.name).join(",");
         let main_name = main_override.unwrap_or("main".to_string());
@@ -265,8 +265,8 @@ BigInt.prototype.toJSON = function () {{
     return this.toString();
 }};
 
-{dates}
 async function run() {{
+    {dates}
     {preprocessor}
     const argsArr = argsObjToArr(args);
     if ({main_name} === undefined || typeof {main_name} !== 'function') {{

--- a/backend/windmill-worker/src/deno_executor.rs
+++ b/backend/windmill-worker/src/deno_executor.rs
@@ -214,15 +214,16 @@ pub async fn handle_deno_job(
             .as_ref()
             .unwrap_or(&args)
             .iter()
-            .enumerate()
-            .filter_map(|(i, x)| {
+            .filter_map(|x| {
                 if matches!(x.typ, Typ::Datetime) {
-                    Some(i)
+                    Some(x.name.as_str())
                 } else {
                     None
                 }
             })
-            .map(|x| return format!("args[{x}] = args[{x}] ? new Date(args[{x}]) : undefined"))
+            .map(|x| {
+                return format!(r#"args["{x}"] = args["{x}"] ? new Date(args["{x}"]) : undefined"#);
+            })
             .join("\n");
 
         let spread = args.into_iter().map(|x| x.name).join(",");


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix datetime argument handling in `handle_bun_job` and `handle_deno_job` to use argument names instead of indices, with minor refactoring.
> 
>   - Fix datetime argument handling in `handle_bun_job` and `handle_deno_job` to use argument names instead of indices.
>   - Modify datetime handling in `bun_executor.rs` and `deno_executor.rs`.
>   - Ensure datetime arguments are formatted as `args["{x}"] = args["{x}"] ? new Date(args["{x}"]) : undefined`.
>   - Minor refactoring for clarity and consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 92daf3058d74265f8856cc2065d4c5d36b302870. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->