### PR TITLE
fix `get_job_update` returning error

### DIFF
--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -4663,8 +4663,8 @@ async fn get_job_update(
                 "progress_perc"
                 
             )
-            .fetch_one(&db)
-            .await?
+            .fetch_optional(&db)
+            .await?.and_then(|inner| inner)
     } else {
         None
     };


### PR DESCRIPTION
When get_progress specified to true, but there is no record of progress for given job Endpoint will fail and return error.

Nothing critical but should be fixed.