### PR TITLE
Add Explicit Progress Hint

### DIFF
--- a/frontend/src/lib/components/ExecutionDuration.svelte
+++ b/frontend/src/lib/components/ExecutionDuration.svelte
@@ -13,12 +13,12 @@
 	/** Is current job running more than specified value in `longDefinition` seconds */
 	export let longRunning: boolean = false
 	/** What do we count as "long" (in seconds)*/
-	export let longDefinition: number = 3
+	export let longDefinition: number = 30
 	/** How often component updates execution duration (in seconds)
 	 *   Higher value -> more efficient component is, less accuracy it has
 	 *   Lower value -> less efficient component is, more accuracy it has
 	 */
-	export let updateResolution: number = 2
+	export let updateResolution: number = 10
 
 	// Use this internally and write results to exported executionDuration
 	let _executionDuration: number = 0

--- a/frontend/src/lib/components/ExecutionDuration.svelte
+++ b/frontend/src/lib/components/ExecutionDuration.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+	// Efficient way to track execution time of jobs
+	import { type Job } from '$lib/gen'
+	import { onDestroy } from 'svelte'
+
+	export let job: Job | undefined = undefined
+	/** Pure execution duration of current active job
+	 *  If job is flow, variable will represent duration of currently active subjob
+	 *  It will count only level-0 subjobs, meaning subjobs of subflows will be ignored
+	 *  executionDuration is guranteed to be started when job starts execution
+	 */
+	export let executionDuration: number = 0
+	/** Is current job running more than specified value in `longDefinition` seconds */
+	export let longRunning: boolean = false
+	/** What do we count as "long" (in seconds)*/
+	export let longDefinition: number = 3
+	/** How often component updates execution duration (in seconds)
+	 *   Higher value -> more efficient component is, less accuracy it has
+	 *   Lower value -> less efficient component is, more accuracy it has
+	 */
+	export let updateResolution: number = 2
+
+	// Use this internally and write results to exported executionDuration
+	let _executionDuration: number = 0
+	// Track job
+	let trackedJob: string | undefined = undefined
+	// In case of flows (flow_status.step)
+	let trackedIndex: number | undefined = undefined
+
+	let interval: NodeJS.Timeout | undefined
+	// Detect when execution of job started
+	$: if (
+		(trackedIndex == undefined || trackedIndex != job?.flow_status?.step) &&
+		!trackedJob &&
+		job
+	)
+		tryStart(job)
+
+	// We want to start timer just right after job execution started
+	function tryStart(job: Job) {
+		console.log('Update in job')
+		// Handle individual jobs
+		if (job.job_kind == 'script' || job.job_kind == 'preview') {
+			// It is possible that this function is invoked multiple times on single job
+			if (trackedJob != job.id && job['running']) {
+				trackedJob = job.id
+				start()
+			}
+		}
+
+		// Handle flows
+		else if (
+			job.flow_status &&
+			['flow', 'flowpreview', 'singlescriptflow'].includes(job.job_kind)
+		) {
+			const status = job.flow_status
+			let module = status.modules[status?.step]
+
+			if (trackedIndex != status.step && module.type == 'InProgress' ) {
+				_executionDuration = 0
+				trackedIndex = status.step
+				longRunning = false
+				// We want to track every subjob right after beginning of their execution
+				start()
+			}
+		}
+		// Other job kinds are not supported
+		else
+			console.warn(
+				"JobKind of '",
+				job.job_kind,
+				"' is not supported by ExecutionDuration component"
+			)
+	}
+
+	function start() {
+		// If there is any running intervals we want to make sure we stop them
+		clearInterval(interval)
+		interval = setInterval(updateDuration, updateResolution * 1_000)
+	}
+
+	function updateDuration() {
+		if (job?.type == 'CompletedJob') {
+			clearInterval(interval)
+			return
+		}
+
+		_executionDuration += updateResolution
+
+		// Detect long running
+		if (_executionDuration >= longDefinition) longRunning = true
+
+		// Update exposed executionDuration
+		executionDuration = _executionDuration
+	}
+
+	onDestroy(() => {
+		// Clear the interval when the component is destroyed
+		clearInterval(interval)
+	})
+</script>

--- a/frontend/src/lib/components/flows/FlowProgressBar.svelte
+++ b/frontend/src/lib/components/flows/FlowProgressBar.svelte
@@ -3,6 +3,7 @@
 	import ProgressBar from '../progressBar/ProgressBar.svelte'
 
 	export let job: Job | undefined = undefined
+	export let currentSubJobProgress: number | undefined = undefined
 
 	let error: number | undefined = undefined
 	let index = 0
@@ -59,6 +60,9 @@
 			//                  Jitter protection >^^^^^^^^
 			subStepLength = 100
 			subIndexIsPercent = true;
+			currentSubJobProgress = subStepIndex
+		} else {
+			currentSubJobProgress = undefined
 		}
 
 		error = newError

--- a/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
@@ -757,7 +757,7 @@
 					<FlowMetadata {job} {scheduleEditor} />
 					{#if showExplicitProgressTip && currentJobIsLongRunning && !scriptProgress && 'running' in job}
 						<Alert
-							class="mt-4 p-1 flex flex-row relative text-center absolute"
+							class="mt-4 p-1 flex flex-row relative text-center"
 							size="xs"
 							type="info"
 							title="tip: Track progress of longer jobs"

--- a/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
@@ -857,7 +857,6 @@
 			</div>
 		{:else if !job?.['deleted']}
 			<div class="mt-10" />
-			<FlowProgressBar {job} class="py-4 max-w-7xl mx-auto px-4" />
 			<FlowProgressBar
 				{job}
 				bind:currentSubJobProgress={scriptProgress}

--- a/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
@@ -762,7 +762,7 @@
 							type="info"
 							title="tip: Track progress of longer jobs"
 							tooltip="For better transparency and verbosity, you can try setting progress from within the script."
-							documentationLink="https://www.windmill.dev/docs/core_concepts/explicit_progress"
+							documentationLink="https://www.windmill.dev/docs/advanced/explicit_progress"
 						>
 							<button
 								type="button"


### PR DESCRIPTION
Hint will show up for jobs running more than 30 seconds.
Users can click on `X` to hide hint. Choice will be preserved in device's local storage

![2024-09-24_15-01](https://github.com/user-attachments/assets/6ee93cfb-145c-40e8-901a-b081d9015f78)
![2024-09-24_15-08](https://github.com/user-attachments/assets/f66796e5-ed61-4177-8768-eec0e9e04ff2)

