### PR TITLE
fix: remove autocomplete for searchbar

### DIFF
--- a/frontend/src/lib/components/search/GlobalSearchModal.svelte
+++ b/frontend/src/lib/components/search/GlobalSearchModal.svelte
@@ -521,8 +521,9 @@
 							id="quickSearchInput"
 							bind:this={textInput}
 							type="text"
-							class="quick-search-input"
+							class="quick-search-input !bg-surface"
 							bind:value={searchTerm}
+							autocomplete="off"
 						/>
 						<label
 							for="quickSearchInput"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Disables browser autocomplete for the search input field in `GlobalSearchModal.svelte`.
> 
>   - **Behavior**:
>     - Disables browser autocomplete for the search input field in `GlobalSearchModal.svelte` by setting `autocomplete="off"`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for cf34d431091269c335c67b4adfab9c1a3abc1bdd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->