### PR TITLE
Changelog update to frontend 27 09

### DIFF
--- a/frontend/src/lib/components/sidebar/changelogs.ts
+++ b/frontend/src/lib/components/sidebar/changelogs.ts
@@ -6,6 +6,16 @@ export type Changelog = {
 
 const changelogs: Changelog[] = [
 	{
+		label: 'Custom HTTP routes',
+		href: 'https://www.windmill.dev/changelog/http-routing',
+		date: '2024-09-23'
+	},
+	{
+		label: 'Set/Get progress from code',
+		href: 'https://www.windmill.dev/changelog/explicit-progress',
+		date: '2024-09-18'
+	},
+	{
 		label: 'Directly edit flow YAML',
 		href: 'https://www.windmill.dev/changelog/flow-yaml-editor',
 		date: '2024-09-02'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added two new changelog entries for 'Custom HTTP routes' and 'Set/Get progress from code' in `changelogs.ts`.
> 
>   - **Changelog Updates**:
>     - Added 'Custom HTTP routes' entry with date '2024-09-23' and link to 'https://www.windmill.dev/changelog/http-routing'.
>     - Added 'Set/Get progress from code' entry with date '2024-09-18' and link to 'https://www.windmill.dev/changelog/explicit-progress'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for aaa90126c4364e71affd5799b355ef845cd91363. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->