### PR TITLE
fix(frontend): Fix flow graph bg in dark mode on chrome

### DIFF
--- a/frontend/src/lib/components/flows/map/FlowModuleSchemaMap.svelte
+++ b/frontend/src/lib/components/flows/map/FlowModuleSchemaMap.svelte
@@ -254,7 +254,7 @@
 		{/if}
 	</div>
 
-	<div class="z-10 flex-auto grow" bind:clientHeight={minHeight}>
+	<div class="z-10 flex-auto grow bg-surface-secondary" bind:clientHeight={minHeight}>
 		<FlowGraphV2
 			{disableAi}
 			insertable

--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -280,6 +280,7 @@
 			elementsSelectable={false}
 			{proOptions}
 			nodesDraggable={false}
+			--background-color={false}
 		>
 			<div class="absolute inset-0 !bg-surface-secondary" />
 			<Controls position="top-right" orientation="horizontal" showLock={false}>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes background color issue in dark mode for flow graph on Chrome by adding `bg-surface-secondary` class in `FlowModuleSchemaMap.svelte` and `FlowGraphV2.svelte`.
> 
>   - **Behavior**:
>     - Fixes background color issue in dark mode for flow graph on Chrome by adding `bg-surface-secondary` class.
>   - **Files**:
>     - `FlowModuleSchemaMap.svelte`: Adds `bg-surface-secondary` to a `div` wrapping `FlowGraphV2`.
>     - `FlowGraphV2.svelte`: Adds `bg-surface-secondary` to a `div` inside `SvelteFlow`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 2b928d2147aeae4a289ba11a1fceadf8c2d97f2e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->