### PR TITLE
fix(frontend): disable runnable field on route editor from detail panel

### DIFF
--- a/frontend/src/lib/components/triggers/RouteEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/RouteEditorInner.svelte
@@ -28,6 +28,7 @@
 
 	let script_path = ''
 	let initialScriptPath = ''
+	let fixedScriptPath = ''
 
 	let drawerLoading = true
 	export async function openEdit(ePath: string, isFlow: boolean) {
@@ -46,7 +47,7 @@
 		}
 	}
 
-	export async function openNew(nis_flow: boolean, initial_script_path?: string) {
+	export async function openNew(nis_flow: boolean, fixedScriptPath_?: string) {
 		drawerLoading = true
 		try {
 			drawer?.openDrawer()
@@ -58,8 +59,9 @@
 			initialRoutePath = ''
 			route_path = ''
 			http_method = 'post'
-			initialScriptPath = initial_script_path ?? ''
-			script_path = initialScriptPath
+			initialScriptPath = ''
+			fixedScriptPath = fixedScriptPath_ ?? ''
+			script_path = fixedScriptPath
 			path = ''
 			initialPath = ''
 			dirtyPath = false
@@ -282,8 +284,8 @@
 					</p>
 					<div class="flex flex-row mb-2">
 						<ScriptPicker
-							disabled={!can_write}
-							initialPath={initialScriptPath}
+							disabled={fixedScriptPath != '' || !can_write}
+							initialPath={fixedScriptPath || initialScriptPath}
 							kinds={['script']}
 							allowFlow={true}
 							bind:itemKind


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Disables `ScriptPicker` in `RouteEditorInner.svelte` when `fixedScriptPath` is set, ensuring script path immutability.
> 
>   - **Behavior**:
>     - `ScriptPicker` in `RouteEditorInner.svelte` is now disabled if `fixedScriptPath` is set or `!can_write`.
>     - `initialPath` in `openNew()` is replaced with `fixedScriptPath` to control script path initialization.
>   - **Variables**:
>     - Introduces `fixedScriptPath` to manage script path immutability in `RouteEditorInner.svelte`.
>     - Modifies `openNew()` to use `fixedScriptPath` instead of `initialScriptPath`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for eaaedb182705869673e02a6744cd8ecacef8a161. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->