### PR TITLE
fix windows worker gh action build workflow

### DIFF
--- a/.github/workflows/build_windows_worker.yml
+++ b/.github/workflows/build_windows_worker.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Rename binary with corresponding architecture
         run: |
-          ren ./backend/target/release/windmill.exe ./backend/target/release/windmill-ee.exe
+          Rename-Item -Path ".\backend\target\release\windmill.exe" -NewName "windmill-ee.exe"
 
       - name: Attach binary to release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
https://github.com/windmill-labs/windmill/actions/runs/11164362701/job/31033516176

build fails due to bad "rename" command
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix incorrect rename command in `build_windows_worker.yml` to ensure successful build.
> 
>   - **Fix**:
>     - Replace `ren` command with `Rename-Item` in `build_windows_worker.yml` to correctly rename `windmill.exe` to `windmill-ee.exe`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 7122587d98a8996f5e7e106b498adcc6e0fad5d9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->