### PR TITLE
fix(frontend): prevent flow logo to shrink

### DIFF
--- a/frontend/src/lib/components/flows/pickers/WorkspaceScriptPickerQuick.svelte
+++ b/frontend/src/lib/components/flows/pickers/WorkspaceScriptPickerQuick.svelte
@@ -119,7 +119,7 @@
 					}}
 				>
 					{#if kind == 'flow'}
-						<BarsStaggered size={14} />
+						<BarsStaggered size={14} class="shrink-0" />
 					{:else}
 						<Code2 size={14} />
 					{/if}


### PR DESCRIPTION
Quick fix to prevent logo to shrink with long names
![image](https://github.com/user-attachments/assets/93d620be-8fc1-41e4-ada4-bcd817f371e7)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `shrink-0` class to `BarsStaggered` in `WorkspaceScriptPickerQuick.svelte` to prevent logo shrinkage with long names.
> 
>   - **Frontend**:
>     - In `WorkspaceScriptPickerQuick.svelte`, added `shrink-0` class to `BarsStaggered` component to prevent logo from shrinking with long names when `kind` is `flow`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f9462af968f6d1472b8f7724d18d426048926da6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->