### PR TITLE
fix: windows.exe build with github workflow doesn't have openssl.dll bundled in

### DIFF
--- a/.github/workflows/build_windows_worker.yml
+++ b/.github/workflows/build_windows_worker.yml
@@ -38,9 +38,13 @@ jobs:
           ./backend/substitute_ee_code.sh --copy --dir ./windmill-ee-private
 
       - name: Cargo build windows
-        timeout-minutes: 60
+        timeout-minutes: 90
         run: |
-          $env:OPENSSL_DIR = "${Env:ProgramFiles}\OpenSSL"
+          vcpkg.exe install openssl-windows:x64-windows
+          vcpkg.exe install openssl:x64-windows-static
+          vcpkg.exe integrate install
+          $env:VCPKGRS_DYNAMIC=1
+          $env:OPENSSL_DIR="${Env:VCPKG_INSTALLATION_ROOT}\installed\x64-windows-static"
           mkdir frontend/build && cd backend
           New-Item -Path . -Name "windmill-api/openapi-deref.yaml" -ItemType "File" -Force
           cargo build --release --features=enterprise,stripe,embedding,parquet,prometheus,openidconnect,cloud,jemalloc,tantivy

--- a/.github/workflows/build_windows_worker.yml
+++ b/.github/workflows/build_windows_worker.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Rename binary with corresponding architecture
         run: |
-          ren ./backend/target/release/windmill.exe ./backend/target/release/windmill-ee.exe
+          Rename-Item -Path ".\backend\target\release\windmill.exe" -NewName "windmill-ee.exe"
 
       - name: Attach binary to release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
using vcpck built opensll version
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix Windows build by using vcpkg for OpenSSL and increasing build timeout in GitHub workflow.
> 
>   - **Build Process**:
>     - Use `vcpkg` to install `openssl-windows:x64-windows` and `openssl:x64-windows-static` in `build_windows_worker.yml`.
>     - Set `OPENSSL_DIR` to use vcpkg's OpenSSL installation.
>     - Increase build timeout from 60 to 90 minutes.
>   - **File Operations**:
>     - Use `Rename-Item` for renaming `windmill.exe` to `windmill-ee.exe`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 30f3c0f987a2987cd0892ceeac8c4bfe08658877. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->