### PR TITLE
fix(pwsh): improving pwsh error handling

### DIFF
--- a/backend/windmill-worker/src/bash_executor.rs
+++ b/backend/windmill-worker/src/bash_executor.rs
@@ -326,7 +326,7 @@ $env:PSModulePath = \"{};$PSModulePathBackup\"",
     let strict_termination_start = "$ErrorActionPreference = 'Stop'\n\
         Set-StrictMode -Version Latest\n\
         try {\n";
-    
+
     let strict_termination_end = "\n\
         } catch {\n\
             Write-Output \"An error occurred:\n\"\

--- a/backend/windmill-worker/src/bash_executor.rs
+++ b/backend/windmill-worker/src/bash_executor.rs
@@ -318,15 +318,33 @@ $env:PSModulePath = \"{};$PSModulePathBackup\"",
         POWERSHELL_CACHE_DIR
     );
 
+    // NOTE: powershell error handling / termination is quite tricky compared to bash
+    // here we're trying to catch terminating errors and propagate the exit code
+    // to the caller such that the job will be marked as failed. It's up to the user
+    // to catch specific errors in their script not caught by the below as there is no
+    // generic set -eu as in bash
+    let strict_termination_start = "$ErrorActionPreference = 'Stop'\n\
+        Set-StrictMode -Version Latest\n\
+        try {\n";
+    
+    let strict_termination_end = "\n\
+        } catch {\n\
+            Write-Output \"An error occurred:\n\"\
+            Write-Output $_
+            exit 1\n\
+        }\n";
+
     // make sure param() is first
     let param_match = windmill_parser_bash::RE_POWERSHELL_PARAM.find(&content);
     let content: String = if let Some(param_match) = param_match {
         let param_match = param_match.as_str();
         format!(
-            "{}\n{}\n{}",
+            "{}\n{}\n{}\n{}\n{}",
             param_match,
             profile,
-            content.replace(param_match, "")
+            strict_termination_start,
+            content.replace(param_match, ""),
+            strict_termination_end
         )
     } else {
         format!("{}\n{}", profile, content)
@@ -351,7 +369,8 @@ $env:PSModulePath = \"{};$PSModulePathBackup\"",
     $pipe = New-TemporaryFile\n\
     & \"{}\" -File ./main.ps1 @args 2>&1 | Tee-Object -FilePath $pipe\n\
     Get-Content -Path $pipe | Select-Object -Last 1 | Set-Content -Path './result2.out'\n\
-    Remove-Item $pipe\n",
+    Remove-Item $pipe\n\
+    exit $LASTEXITCODE\n",
             POWERSHELL_PATH.as_str()
         ),
     )?;


### PR DESCRIPTION
## Unix & Windows

Currently `pwsh` scripts will not return an error exit code if a cmdlet fails in a "non-terminating" way. Error handling in pwsh is [quite complex](https://github.com/MicrosoftDocs/PowerShell-Docs/issues/1583) and different from bash.

The implemented behavior wraps the user provided script in a:

```powershell
$ErrorActionPreference = 'Stop'
Set-StrictMode -Version Latest

try {

     # User Provided Code

} catch {
    Write-Output "An error occurred:\n"
    Write-Output $_
    exit 1;
}
```


## Windows

`exit $LASTEXITCODE` in `wrapper.ps1` will propagate error code to windmill
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves PowerShell error handling in `bash_executor.rs` by wrapping scripts in a try-catch block and setting strict error preferences.
> 
>   - **Behavior**:
>     - Wraps PowerShell scripts in a try-catch block with `$ErrorActionPreference = 'Stop'` and `Set-StrictMode -Version Latest` to catch non-terminating errors.
>     - On error, outputs error message and exits with code 1.
>   - **Files**:
>     - Updates `bash_executor.rs` to include error handling logic for PowerShell scripts.
>     - Modifies `wrapper.ps1` to propagate error code using `exit $LASTEXITCODE`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for d16241c17f2c40609b082ca7ac962d6138d4ef0c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->