### PR TITLE
support colon in job filter tags scope

### DIFF
--- a/backend/windmill-api/src/users.rs
+++ b/backend/windmill-api/src/users.rs
@@ -706,14 +706,17 @@ where
 }
 
 pub fn get_scope_tags(authed: &ApiAuthed) -> Option<Vec<&str>> {
-    authed
-        .scopes
-        .as_ref()?
-        .iter()
-        .find_map(|s| match s.split(":").collect::<Vec<_>>().as_slice() {
-            ["if_jobs", "filter_tags", tags] => Some(tags.split(",").collect::<Vec<_>>()),
-            _ => None,
-        })
+    authed.scopes.as_ref()?.iter().find_map(|s| {
+        if s.starts_with("if_jobs:filter_tags:") {
+            Some(
+                s.trim_start_matches("if_jobs:filter_tags:")
+                    .split(",")
+                    .collect::<Vec<_>>(),
+            )
+        } else {
+            None
+        }
+    })
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `get_scope_tags` in `users.rs` to support scope tags with colons by simplifying the logic.
> 
>   - **Functionality**:
>     - Update `get_scope_tags` in `users.rs` to support scope tags with colons by checking if the string starts with `if_jobs:filter_tags:` and then splitting the remaining part by commas.
>   - **Code Simplification**:
>     - Simplified the logic in `get_scope_tags` by using `starts_with` and `trim_start_matches` instead of pattern matching with `split`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 8693277e88ba074479748a54e0dd3d0d770aa19f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->