### PR TITLE
fix: Do not ignore file resources with json file ext

### DIFF
--- a/cli/sync.ts
+++ b/cli/sync.ts
@@ -618,8 +618,8 @@ export async function elementsToMap(
   for await (const entry of readDirRecursiveWithIgnore(ignore, els)) {
     if (entry.isDirectory || entry.ignored) continue;
     const path = entry.path;
-    if (json && path.endsWith(".yaml")) continue;
-    if (!json && path.endsWith(".json")) continue;
+    if (json && path.endsWith(".yaml") && !isFileResource(path)) continue;
+    if (!json && path.endsWith(".json") && !isFileResource(path)) continue;
     const ext = json ? ".json" : ".yaml";
     if (!skips.includeSchedules && path.endsWith(".schedule" + ext)) continue;
     if (!skips.includeUsers && path.endsWith(".user" + ext)) continue;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `elementsToMap` in `cli/sync.ts` to correctly process file resources with `.json` and `.yaml` extensions by adding `isFileResource` checks.
> 
>   - **Behavior**:
>     - Modify `elementsToMap` in `cli/sync.ts` to not ignore `.json` files when `json` is false and `.yaml` files when `json` is true if they are file resources.
>     - Adds `isFileResource(path)` check to ensure file resources are processed correctly.
>   - **Functions**:
>     - Update `elementsToMap` to include `isFileResource` check for `.json` and `.yaml` files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for e4e11c696eeec5f0abd1c4b8f0e17493dc6a3881. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->