### PR TITLE
Glm/fix cron builder

### DIFF
--- a/frontend/src/lib/components/CronInput.svelte
+++ b/frontend/src/lib/components/CronInput.svelte
@@ -120,18 +120,18 @@
 			if (minutes > 0) {
 				nschedule = `0 */${minutes} * * * *`
 			} else {
-				nschedule = `* * * * *`
+				nschedule = `* * * * * *`
 			}
 		} else if (executeEvery === 'hour') {
 			if (hours > 0) {
-				nschedule = `0 0 */${hours} * *`
+				nschedule = `0 0 */${hours} * * *`
 			} else {
-				nschedule = `* * * * *`
+				nschedule = `* * * * * *`
 			}
 		} else if (executeEvery === 'day-month') {
-			nschedule = `0 ${s_AtUTCMinutes} ${s_AtUTCHours} ${s_daysOfMonth} *`
+			nschedule = `0 ${s_AtUTCMinutes} ${s_AtUTCHours} ${s_daysOfMonth} * *`
 		} else if (executeEvery === 'month') {
-			nschedule = `0 ${s_AtUTCMinutes} ${s_AtUTCHours} ${s_daysOfMonth} ${s_months}`
+			nschedule = `0 ${s_AtUTCMinutes} ${s_AtUTCHours} ${s_daysOfMonth} ${s_months} *`
 		} else if (executeEvery === 'day-week') {
 			nschedule = `0 ${s_AtUTCMinutes} ${s_AtUTCHours} * * ${s_daysOfWeek}`
 		}

--- a/frontend/src/lib/components/CronInput.svelte
+++ b/frontend/src/lib/components/CronInput.svelte
@@ -214,7 +214,7 @@
 				type="text"
 				id="cron-schedule"
 				name="cron-schedule"
-				placeholder="*/30 * * * *"
+				placeholder="0 0 */1 * * *"
 				bind:value={schedule}
 				{disabled}
 			/>

--- a/frontend/src/lib/components/CronInput.svelte
+++ b/frontend/src/lib/components/CronInput.svelte
@@ -112,13 +112,13 @@
 		// If using the basic editor, set the cron string based on the selected options
 		if (executeEvery === 'second') {
 			if (seconds > 0) {
-				nschedule = `*/${seconds} * * * *`
+				nschedule = `*/${seconds} * * * * *`
 			} else {
-				nschedule = `* * * * *`
+				nschedule = `* * * * * *`
 			}
 		} else if (executeEvery === 'minute') {
 			if (minutes > 0) {
-				nschedule = `0 */${minutes} * * *`
+				nschedule = `0 */${minutes} * * * *`
 			} else {
 				nschedule = `* * * * *`
 			}

--- a/frontend/src/lib/components/RunPageSchedules.svelte
+++ b/frontend/src/lib/components/RunPageSchedules.svelte
@@ -218,7 +218,7 @@
 					$primarySchedule = {
 						summary: '',
 						args: {},
-						cron: '0 0 0 /1 * * *',
+						cron: '0 0 */1 * * *',
 						timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 						enabled: true
 					}


### PR DESCRIPTION
Setting cron created by the cron builder with 6 fields.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes cron string format in `CronInput.svelte` by adding a seconds field, changing from 5 to 6 fields, and updates examples and defaults accordingly.
> 
>   - **Behavior**:
>     - Fixes cron string format in `CronInput.svelte` by adding an additional field for seconds, changing from 5 to 6 fields.
>     - Affects scheduling logic for `executeEvery` options: `second`, `minute`, `hour`, `day-month`, `month`.
>   - **Misc**:
>     - Updates cron string examples in `CronInput.svelte` to reflect 6-field format.
>     - Updates default cron string in `RunPageSchedules.svelte` to 6-field format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 0f57cc69fa39975f3221b57d7623d51294160455. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->