### PR TITLE
adding oauth.login_failure to openapi spec

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10747,6 +10747,7 @@ components:
             - "users.impersonate"
             - "users.leave_workspace"
             - "oauth.login"
+            - "oauth.login_failure"
             - "oauth.signup"
             - "variables.create"
             - "variables.delete"

--- a/frontend/src/lib/components/auditLogs/AuditLogsFilters.svelte
+++ b/frontend/src/lib/components/auditLogs/AuditLogsFilters.svelte
@@ -252,6 +252,7 @@
 		USERS_IMPERSONATE: 'users.impersonate',
 		USERS_LEAVE_WORKSPACE: 'users.leave_workspace',
 		OAUTH_LOGIN: 'oauth.login',
+		OAUTH_LOGIN_FAILURE: 'oauth.login_failure',
 		OAUTH_SIGNUP: 'oauth.signup',
 		VARIABLES_CREATE: 'variables.create',
 		VARIABLES_DELETE: 'variables.delete',


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `oauth.login_failure` to OpenAPI spec and frontend audit log filters.
> 
>   - **OpenAPI Specification**:
>     - Add `oauth.login_failure` to `openapi.yaml` under `components`.
>   - **Frontend**:
>     - Add `OAUTH_LOGIN_FAILURE: 'oauth.login_failure'` to `AuditLogsFilters.svelte` for filtering audit logs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for bcaf3aacf952891510df5fac9e7493e0db7781a9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->