### PR TITLE
chore: Update references to windmill-ee-full image

### DIFF
--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -185,7 +185,7 @@ async fn install_galaxy_collections(
 #[cfg(not(feature = "enterprise"))]
 fn check_ansible_exists() -> Result<(), error::Error> {
     if !Path::new(ANSIBLE_PLAYBOOK_PATH.as_str()).exists() {
-        let msg = format!("Couldn't find ansible-playbook at {}. This probably means that you are not using the windmill-full image. Please use the image `windmill-full` for your instance in order to run rust jobs.", ANSIBLE_PLAYBOOK_PATH.as_str());
+        let msg = format!("Couldn't find ansible-playbook at {}. This probably means that you are not using the windmill-full image. Please use the image `windmill-full` for your instance in order to run Ansible jobs.", ANSIBLE_PLAYBOOK_PATH.as_str());
         return Err(error::Error::NotFound(msg));
     }
     Ok(())
@@ -194,7 +194,7 @@ fn check_ansible_exists() -> Result<(), error::Error> {
 #[cfg(feature = "enterprise")]
 fn check_ansible_exists() -> Result<(), error::Error> {
     if !Path::new(ANSIBLE_PLAYBOOK_PATH.as_str()).exists() {
-        let msg = format!("Couldn't find ansible-playbook at {}. This probably means that you are not using the windmill-full image. Please use the image `windmill-ee-full` for your instance in order to run rust jobs.", ANSIBLE_PLAYBOOK_PATH.as_str());
+        let msg = format!("Couldn't find ansible-playbook at {}. This probably means that you are not using the windmill-full image. Please use the image `windmill-ee-full` for your instance in order to run Ansible jobs.", ANSIBLE_PLAYBOOK_PATH.as_str());
         return Err(error::Error::NotFound(msg));
     }
     Ok(())

--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -194,7 +194,7 @@ fn check_ansible_exists() -> Result<(), error::Error> {
 #[cfg(feature = "enterprise")]
 fn check_ansible_exists() -> Result<(), error::Error> {
     if !Path::new(ANSIBLE_PLAYBOOK_PATH.as_str()).exists() {
-        let msg = format!("Couldn't find ansible-playbook at {}. This probably means that you are not using the windmill-full image. Please use the image `windmill-full-ee` for your instance in order to run rust jobs.", ANSIBLE_PLAYBOOK_PATH.as_str());
+        let msg = format!("Couldn't find ansible-playbook at {}. This probably means that you are not using the windmill-full image. Please use the image `windmill-ee-full` for your instance in order to run rust jobs.", ANSIBLE_PLAYBOOK_PATH.as_str());
         return Err(error::Error::NotFound(msg));
     }
     Ok(())

--- a/backend/windmill-worker/src/php_executor.rs
+++ b/backend/windmill-worker/src/php_executor.rs
@@ -143,7 +143,7 @@ fn check_php_exists() -> error::Result<()> {
 #[cfg(feature = "enterprise")]
 fn check_php_exists() -> error::Result<()> {
     if !Path::new(PHP_PATH.as_str()).exists() {
-        let msg = format!("Couldn't find php at {}. This probably means that you are not using the windmill-full image. Please use the image `windmill-full-ee` for your instance in order to run php jobs.", PHP_PATH.as_str());
+        let msg = format!("Couldn't find php at {}. This probably means that you are not using the windmill-full image. Please use the image `windmill-ee-full` for your instance in order to run php jobs.", PHP_PATH.as_str());
         return Err(error::Error::NotFound(msg));
     }
     Ok(())

--- a/backend/windmill-worker/src/rust_executor.rs
+++ b/backend/windmill-worker/src/rust_executor.rs
@@ -281,7 +281,7 @@ fn check_cargo_exists() -> Result<(), Error> {
 #[cfg(feature = "enterprise")]
 fn check_cargo_exists() -> Result<(), Error> {
     if !Path::new(CARGO_PATH.as_str()).exists() {
-        let msg = format!("Couldn't find cargo at {}. This probably means that you are not using the windmill-full image. Please use the image `windmill-full-ee` for your instance in order to run rust jobs.", CARGO_PATH.as_str());
+        let msg = format!("Couldn't find cargo at {}. This probably means that you are not using the windmill-full image. Please use the image `windmill-ee-full` for your instance in order to run rust jobs.", CARGO_PATH.as_str());
         return Err(Error::NotFound(msg));
     }
     Ok(())


### PR DESCRIPTION
The messaging in a few backend executors references the need to use the full enterprise image rather than `windmill-ee`. These messages reference the `windmill-full-ee` image but its the image is actually named `windmill-ee-full` under the available Packages. 

https://github.com/windmill-labs/windmill/pkgs/container/windmill-ee-full
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update image references in error messages to `windmill-ee-full` in executor files.
> 
>   - **Error Message Updates**:
>     - In `ansible_executor.rs`, `check_ansible_exists()` function: Change image reference from `windmill-full-ee` to `windmill-ee-full`.
>     - In `php_executor.rs`, `check_php_exists()` function: Change image reference from `windmill-full-ee` to `windmill-ee-full`.
>     - In `rust_executor.rs`, `check_cargo_exists()` function: Change image reference from `windmill-full-ee` to `windmill-ee-full`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 5425095e938cf8a868fb32046bf6b8671b5ef132. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->