### PR TITLE
fix smtp setup documentation link

### DIFF
--- a/frontend/src/lib/components/InstanceSettings.svelte
+++ b/frontend/src/lib/components/InstanceSettings.svelte
@@ -277,7 +277,7 @@
 						<div class="text-secondary pb-4 text-xs"
 							>Setting SMTP unlocks sending emails upon adding new users to the workspace or the
 							instance or sending critical alerts.
-							<a target="_blank" href="https://www.windmill.dev/docs/misc/setup_smtp">Learn more</a
+							<a target="_blank" href="https://www.windmill.dev/docs/advanced/instance_settings#smtp">Learn more</a
 							></div
 						>
 					{:else if category == 'Registries'}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update SMTP setup documentation link in `InstanceSettings.svelte`.
> 
>   - **Documentation**:
>     - Update SMTP setup documentation link in `InstanceSettings.svelte` from `https://www.windmill.dev/docs/misc/setup_smtp` to `https://www.windmill.dev/docs/advanced/instance_settings#smtp`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 74b81d44eef800cd8bd9e9efc10971899ac5693f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->