### PR TITLE
fix slack error handler when error is too long

### DIFF
--- a/frontend/src/lib/hubPaths.json
+++ b/frontend/src/lib/hubPaths.json
@@ -1,7 +1,7 @@
 {
 	"gitSync": "hub/9087/sync-script-to-git-repo-windmill",
 	"gitSyncTest": "hub/9073/git-repo-test-read-write-windmill",
-	"slackErrorHandler": "hub/9079/workspace-or-schedule-error-handler-slack",
+	"slackErrorHandler": "hub/9206/workspace-or-schedule-error-handler-slack",
 	"slackRecoveryHandler": "hub/9080/slack/schedule-recovery-handler-slack",
 	"slackSuccessHandler": "hub/9072/slack/schedule-success-handler-slack",
 	"slackReport": "hub/9084/slack",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `slackErrorHandler` path in `hubPaths.json` to fix Slack error handling.
> 
>   - **Path Update**:
>     - Update `slackErrorHandler` path in `hubPaths.json` from `hub/9079/workspace-or-schedule-error-handler-slack` to `hub/9206/workspace-or-schedule-error-handler-slack`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f3ff94b9ac7528d3d00a7ee009f770f6bc743fb4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->