### PR TITLE
cache old slack error handler

### DIFF
--- a/frontend/src/lib/hubPaths.json
+++ b/frontend/src/lib/hubPaths.json
@@ -2,6 +2,7 @@
 	"gitSync": "hub/9087/sync-script-to-git-repo-windmill",
 	"gitSyncTest": "hub/9073/git-repo-test-read-write-windmill",
 	"slackErrorHandler": "hub/9206/workspace-or-schedule-error-handler-slack",
+	"slackErrorHandler_0": "hub/9079/workspace-or-schedule-error-handler-slack",
 	"slackRecoveryHandler": "hub/9080/slack/schedule-recovery-handler-slack",
 	"slackSuccessHandler": "hub/9072/slack/schedule-success-handler-slack",
 	"slackReport": "hub/9084/slack",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `slackErrorHandler_0` to `hubPaths.json` for caching old Slack error handler.
> 
>   - **Paths Update**:
>     - Added `slackErrorHandler_0` to `hubPaths.json` pointing to `hub/9079/workspace-or-schedule-error-handler-slack`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for bc603bf66d7c6a1b27c3e969bd1b6d70354c66d8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->