### PR TITLE
feat(cli): opts.instance as instance name and prefix

### DIFF
--- a/cli/instance.ts
+++ b/cli/instance.ts
@@ -190,6 +190,21 @@ export async function pickInstance(
   allowNew: boolean
 ) {
   const instances = await allInstances();
+  if (opts.baseUrl && opts.token && opts.instance) {
+    log.info("Using instance defined by --instance, --base-url and --token");
+
+    setClient(
+      opts.token,
+      opts.baseUrl.endsWith("/") ? opts.baseUrl.slice(0, -1) : opts.baseUrl
+    );
+
+    return {
+      name: opts.instance,
+      remote: opts.baseUrl,
+      token: opts.token,
+      prefix: opts.instance,
+    };
+  }
   if (opts.baseUrl && opts.token) {
     log.info("Using instance fully defined by --base-url and --token");
 
@@ -687,7 +702,7 @@ const command = new Command()
   .option("--folder-per-instance", "Create a folder per instance")
   .option(
     "--instance <instance:string>",
-    "Name of the instance to push to, override the active instance"
+    "Name of the instance to pull from, override the active instance"
   )
   .action(instancePull as any)
   .command("push")


### PR DESCRIPTION
This PR enable using `--instance` value as instance name and prefix for CLI instance pulls and pushes
___________________________________________________________________________________________

The following Windmill CLI commands may will be affected by this change:
- `wmill instance pull` (when including `--instance`, `--base-url` and `--token`)
- `wmill instance push` (when including `--instance`, `--base-url` and `--token`)
___________________________________________________________________________________________

This change expects the following CLI behaviour:

When `wmill instance pull` (when including `--instance`, `--base-url` and `--token`)

Create in the local a folder structure such as `<opts.instance>_<all_namespace(s)>`
Also applies for `--folder-per-instance` like `<opts.instance>/<all_namespace(s)>`

Similar approach to `wmill instance push` for reading the local folder structure
___________________________________________________________________________________________

Please check if this change impacts `allInstances()` function called by `pickInstance()`
I couldn't test the scenario loading an `instances.ndjson` file with many instances

for your review folks @rubenfiszel @HugoCasa
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances CLI to use `--instance` as name and prefix for instance pull/push commands, affecting folder structure.
> 
>   - **Behavior**:
>     - `pickInstance()` in `instance.ts` now uses `--instance` as both name and prefix when `--base-url` and `--token` are provided.
>     - Updates folder structure for `wmill instance pull` and `wmill instance push` to `<opts.instance>_<all_namespace(s)>` or `<opts.instance>/<all_namespace(s)>` with `--folder-per-instance`.
>   - **CLI Options**:
>     - Updates `--instance` option description in `instance.ts` for `pull` and `push` commands to reflect new behavior.
>   - **Misc**:
>     - Adds log message in `pickInstance()` to indicate usage of `--instance`, `--base-url`, and `--token`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for c09298d0e35b01fccf8ec2668b429b71de1276c1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->