### PR TITLE
fix: Clarify message about indexer service being EE-only

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -284,7 +284,8 @@ async fn windmill_main() -> anyhow::Result<()> {
                 tracing::info!("Binary is in 'indexer' mode");
                 #[cfg(not(feature = "tantivy"))]
                 {
-                    panic!("Indexer mode requires the tantivy feature flag");
+                    tracing::error!("Cannot start the indexer because tantivy is not included in this binary/image. Make sure you are using the EE image if you want to access the full text search features.");
+                    panic!("Indexer mode requires compiling with the tantivy feature flag.");
                 }
                 #[cfg(feature = "tantivy")]
                 Mode::Indexer


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update error message in `windmill_main()` to clarify indexer mode requires EE image for full text search.
> 
>   - **Behavior**:
>     - Update error message in `windmill_main()` in `main.rs` to clarify that the indexer requires the EE image for full text search features.
>     - Adds a `tracing::error` log before the panic to provide more context about the missing `tantivy` feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 7d8bd3ffdb144c30cb93299fbd42aeb2a565e303. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->