### PR TITLE
make hub embeddings pulling interval configurable

### DIFF
--- a/backend/windmill-api/src/embeddings.rs
+++ b/backend/windmill-api/src/embeddings.rs
@@ -608,10 +608,6 @@ pub fn load_embeddings_db(db: &Pool<Postgres>) -> () {
                 drop(model_instance_lock);
                 loop {
                     update_embeddings_db(&db_clone).await;
-                    tracing::info!(
-                        "Pulling embeddings from hub next in {} secs...",
-                        *HUB_EMBEDDINGS_PULLING_INTERVAL_SECS
-                    );
                     tokio::time::sleep(std::time::Duration::from_secs(
                         *HUB_EMBEDDINGS_PULLING_INTERVAL_SECS,
                     ))


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Make hub embeddings pulling interval configurable via `HUB_EMBEDDINGS_PULLING_INTERVAL_SECS` in `embeddings.rs`, defaulting to 24 hours.
> 
>   - **Behavior**:
>     - Introduces `HUB_EMBEDDINGS_PULLING_INTERVAL_SECS` in `embeddings.rs` to configure the interval for pulling embeddings from the hub.
>     - Default interval set to 24 hours if the environment variable is not set.
>   - **Logging**:
>     - Adds logging in `load_embeddings_db` to indicate the next pulling interval using the configured value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for d014b697c35b6d7617987d7749373ae051248642. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->