### PR TITLE
fix(cli): missing opts for pull and push instance configs

### DIFF
--- a/cli/instance.ts
+++ b/cli/instance.ts
@@ -261,7 +261,7 @@ export async function pickInstance(
 
   return instance;
 }
-async function instancePull(opts: GlobalOptions & InstanceSyncOptions) {
+async function instancePull(opts: InstanceSyncOptions) {
   const instance = await pickInstance(opts, true);
   log.info("Pulling instance-level changes");
   log.info(`remote (${instance.name}) -> local`);
@@ -393,7 +393,7 @@ async function instancePull(opts: GlobalOptions & InstanceSyncOptions) {
   }
 }
 
-async function instancePush(opts: GlobalOptions & InstanceSyncOptions) {
+async function instancePush(opts: InstanceSyncOptions) {
   let instances = await allInstances();
   const instance = await pickInstance(opts, true);
 

--- a/cli/worker_groups.ts
+++ b/cli/worker_groups.ts
@@ -56,7 +56,7 @@ export async function displayWorkerGroups(opts: void) {
 async function pullWorkerGroups(opts: InstanceSyncOptions) {
   await pickInstance(opts, true);
 
-  const totalChanges =  await pullInstanceConfigs(true) ?? 0;
+  const totalChanges =  await pullInstanceConfigs(opts, true) ?? 0;
 
   if (totalChanges === 0) {
     log.info("No changes to apply");
@@ -72,14 +72,14 @@ async function pullWorkerGroups(opts: InstanceSyncOptions) {
   }
 
   if (confirm) {
-    await pullInstanceConfigs(false);
+    await pullInstanceConfigs(opts, false);
   }
 }
 
 async function pushWorkerGroups(opts: InstanceSyncOptions) {
   await pickInstance(opts, true);
 
-  const totalChanges = await pushInstanceConfigs(true) ?? 0;
+  const totalChanges = await pushInstanceConfigs(opts, true) ?? 0;
 
   if (totalChanges === 0) {
     log.info("No changes to apply");
@@ -95,7 +95,7 @@ async function pushWorkerGroups(opts: InstanceSyncOptions) {
   }
 
   if (confirm) {
-    await pushInstanceConfigs(false);
+    await pushInstanceConfigs(opts, false);
   }
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `GlobalOptions` from instance config functions and add dynamic file path handling based on `InstanceSyncOptions`.
> 
>   - **Behavior**:
>     - Remove `GlobalOptions` from `instancePull()` and `instancePush()` in `instance.ts`, `readInstanceSettings()`, `pullInstanceSettings()`, `pushInstanceSettings()`, `readLocalConfigs()`, `pullInstanceConfigs()`, `pushInstanceConfigs()` in `settings.ts`, `readInstanceUsers()`, `pullInstanceUsers()`, `pushInstanceUsers()`, `readInstanceGroups()`, `pullInstanceGroups()`, `pushInstanceGroups()` in `user.ts`.
>     - Add `checkInstanceSettingsPath()`, `checkInstanceConfigPath()`, `checkInstanceUsersPath()`, `checkInstanceGroupsPath()` to dynamically set file paths based on `InstanceSyncOptions`.
>   - **Misc**:
>     - Fix typo in confirmation message in `worker_groups.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for a18fcceb5fccd8370faf00c895283a191f412424. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->