### PR TITLE
Glm/polishing prop picker UI

### DIFF
--- a/frontend/src/lib/components/ArgInput.svelte
+++ b/frontend/src/lib/components/ArgInput.svelte
@@ -870,9 +870,9 @@
 										'w-full',
 										valid
 											? ''
-											: 'border border-red-700 border-opacity-30 focus:border-red-700 focus:border-opacity-3'
+											: 'border  border-red-700 border-opacity-30 focus:border-red-700 focus:border-opacity-3'
 									)}
-									placeholder={placeholder ?? defaultValue ?? ''}
+									placeholder="blabla"
 									bind:value
 								/>
 							{/key}

--- a/frontend/src/lib/components/ArgInput.svelte
+++ b/frontend/src/lib/components/ArgInput.svelte
@@ -870,9 +870,9 @@
 										'w-full',
 										valid
 											? ''
-											: 'border  border-red-700 border-opacity-30 focus:border-red-700 focus:border-opacity-3'
+											: 'border border-red-700 border-opacity-30 focus:border-red-700 focus:border-opacity-3'
 									)}
-									placeholder="blabla"
+									placeholder={placeholder ?? defaultValue ?? ''}
 									bind:value
 								/>
 							{/key}

--- a/frontend/src/lib/components/InputTransformForm.svelte
+++ b/frontend/src/lib/components/InputTransformForm.svelte
@@ -9,7 +9,8 @@
 	import type { PropPickerWrapperContext } from './flows/propPicker/PropPickerWrapper.svelte'
 	import { codeToStaticTemplate, getDefaultExpr } from './flows/utils'
 	import SimpleEditor from './SimpleEditor.svelte'
-	import { Button } from './common'
+	import { Button } from '$lib/components/common'
+	import AnimatedButton from '$lib/components/common/button/AnimatedButton.svelte'
 	import ToggleButtonGroup from '$lib/components/common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import ToggleButton from '$lib/components/common/toggleButton-v2/ToggleButton.svelte'
 	import { fade } from 'svelte/transition'
@@ -187,6 +188,9 @@
 	let stepInputGen: StepInputGen | undefined = undefined
 
 	loadResourceTypes()
+
+	$: connecting =
+		$propPickerConfig?.propName == argName && $propPickerConfig?.insertionMode == 'connect'
 </script>
 
 {#if arg != undefined}
@@ -331,22 +335,23 @@
 						</ToggleButtonGroup>
 					</div>
 
-					<Button
-						title="Connect to another node's output"
-						variant="border"
-						color="light"
-						size="xs2"
-						on:click={() => {
-							focusProp(argName, 'connect', (path) => {
-								connectProperty(path)
-								dispatch('change', { argName })
-								return true
-							})
-						}}
-						id="flow-editor-plug"
-					>
-						<Plug size={16} /> &rightarrow;
-					</Button>
+					<AnimatedButton animate={connecting} baseRadius="6px" animationDuration="1s">
+						<Button
+							variant="border"
+							color="light"
+							size="xs2"
+							btnClasses={connecting ? 'text-blue-500' : 'text-primary'}
+							on:click={() => {
+								focusProp(argName, 'connect', (path) => {
+									connectProperty(path)
+									dispatch('change', { argName })
+									return true
+								})
+							}}
+						>
+							<Plug size={16} /> &rightarrow;
+						</Button>
+					</AnimatedButton>
 				</div>
 			{/if}
 		</div>
@@ -354,13 +359,13 @@
 		<div class="max-w-xs" />
 		<!-- svelte-ignore a11y-no-static-element-interactions -->
 		<div class="relative" on:keyup={stepInputGen?.onKeyUp}>
-			{#if $propPickerConfig?.propName == argName && $propPickerConfig?.insertionMode == 'connect'}
+			<!-- {#if $propPickerConfig?.propName == argName && $propPickerConfig?.insertionMode == 'connect'}
 				<span
 					class={'text-white  z-50 px-1 text-2xs py-0.5 font-bold rounded-t-sm w-fit absolute top-0 right-0 bg-blue-500'}
 				>
 					Connect input &rightarrow;
 				</span>
-			{/if}
+			{/if} -->
 			<!-- {inputCat}
 			{propertyType} -->
 			<div class="relative flex flex-row items-top gap-2 justify-between">
@@ -471,7 +476,7 @@
 					{/if}
 				</div>
 
-				{#if $propPickerConfig?.propName == argName}
+				{#if $propPickerConfig?.propName == argName && $propPickerConfig?.insertionMode == 'insert'}
 					<div class="text-blue-500 mt-2" in:fade={{ duration: 200 }}>
 						<svg
 							xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/lib/components/InputTransformForm.svelte
+++ b/frontend/src/lib/components/InputTransformForm.svelte
@@ -12,6 +12,7 @@
 	import { Button } from './common'
 	import ToggleButtonGroup from '$lib/components/common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import ToggleButton from '$lib/components/common/toggleButton-v2/ToggleButton.svelte'
+	import { fade } from 'svelte/transition'
 
 	import type VariableEditor from './VariableEditor.svelte'
 	import type ItemPicker from './ItemPicker.svelte'
@@ -191,14 +192,14 @@
 {#if arg != undefined}
 	<div
 		class={twMerge(
-			'p-2 ml-2 relative hover:bg-surface hover:shadow-[0_0_10px_5px_rgba(0,0,0,0.1)] transition-all duration-200',
+			'pl-2 pt-2 pb-2 ml-2 relative hover:bg-surface hover:shadow-md transition-all duration-200',
 			$propPickerConfig?.propName == argName
-				? 'bg-surface rounded-l-md shadow-[0_0_10px_5px_rgba(0,0,0,0.1)] z-2000'
+				? 'bg-surface border-l-4 border-blue-500 shadow-md rounded-l-md z-2000'
 				: 'hover:rounded-md',
 			$$props.class
 		)}
 	>
-		<div class="flex flex-row justify-between gap-1 pb-1">
+		<div class="flex flex-row justify-between gap-1 pb-1 px-2">
 			<div class="flex flex-wrap grow">
 				<FieldHeader
 					label={argName}
@@ -352,7 +353,7 @@
 
 		<div class="max-w-xs" />
 		<!-- svelte-ignore a11y-no-static-element-interactions -->
-		<div class="relative p-2" on:keyup={stepInputGen?.onKeyUp}>
+		<div class="relative" on:keyup={stepInputGen?.onKeyUp}>
 			{#if $propPickerConfig?.propName == argName && $propPickerConfig?.insertionMode == 'connect'}
 				<span
 					class={'text-white  z-50 px-1 text-2xs py-0.5 font-bold rounded-t-sm w-fit absolute top-0 right-0 bg-blue-500'}
@@ -362,110 +363,134 @@
 			{/if}
 			<!-- {inputCat}
 			{propertyType} -->
-			{#if isStaticTemplate(inputCat) && propertyType == 'static' && !noDynamicToggle}
-				{#if argName && schema?.properties?.[argName]?.description}
-					<div class="text-xs italic pb-1 text-secondary">
-						<pre class="font-main">{schema.properties[argName].description}</pre>
-					</div>
-				{/if}
-				<div class="mt-2 min-h-[28px]">
-					{#if arg}
-						<TemplateEditor
-							bind:this={monacoTemplate}
-							{extraLib}
+			<div class="relative flex flex-row items-top gap-2 justify-between">
+				<div class="min-w-0 grow">
+					{#if isStaticTemplate(inputCat) && propertyType == 'static' && !noDynamicToggle}
+						{#if argName && schema?.properties?.[argName]?.description}
+							<div class="text-xs italic pb-1 text-secondary">
+								<pre class="font-main">{schema.properties[argName].description}</pre>
+							</div>
+						{/if}
+						<div class="mt-2 min-h-[28px]">
+							{#if arg}
+								<TemplateEditor
+									bind:this={monacoTemplate}
+									{extraLib}
+									on:focus={onFocus}
+									on:blur={() => {
+										focused = false
+									}}
+									bind:code={arg.value}
+									fontSize={14}
+									on:change={() => {
+										dispatch('change', { argName })
+									}}
+								/>
+							{/if}
+						</div>
+					{:else if (propertyType === undefined || propertyType == 'static') && schema?.properties?.[argName]}
+						<ArgInput
+							{resourceTypes}
+							noMargin
+							compact
+							bind:this={argInput}
 							on:focus={onFocus}
 							on:blur={() => {
 								focused = false
 							}}
-							bind:code={arg.value}
-							fontSize={14}
+							shouldDispatchChanges
 							on:change={() => {
 								dispatch('change', { argName })
 							}}
+							label={argName}
+							bind:editor={monaco}
+							bind:description={schema.properties[argName].description}
+							bind:value={arg.value}
+							type={schema.properties[argName].type}
+							oneOf={schema.properties[argName].oneOf}
+							required={schema.required?.includes(argName)}
+							bind:pattern={schema.properties[argName].pattern}
+							bind:valid={inputCheck}
+							defaultValue={schema.properties[argName].default}
+							bind:enum_={schema.properties[argName].enum}
+							bind:format={schema.properties[argName].format}
+							contentEncoding={schema.properties[argName].contentEncoding}
+							bind:itemsType={schema.properties[argName].items}
+							properties={schema.properties[argName].properties}
+							nestedRequired={schema.properties[argName].required}
+							displayHeader={false}
+							extra={argExtra}
+							{variableEditor}
+							{itemPicker}
+							bind:pickForField
+							showSchemaExplorer
+							nullable={schema.properties[argName].nullable}
+							bind:title={schema.properties[argName].title}
+							bind:placeholder={schema.properties[argName].placeholder}
 						/>
+					{:else if arg.expr != undefined}
+						<div class="border mt-2">
+							<SimpleEditor
+								bind:this={monaco}
+								bind:code={arg.expr}
+								on:change={() => {
+									dispatch('change', { argName })
+								}}
+								{extraLib}
+								lang="javascript"
+								shouldBindKey={false}
+								on:focus={() => {
+									focused = true
+									focusProp(argName, 'insert', (path) => {
+										monaco?.insertAtCursor(path)
+										return false
+									})
+								}}
+								on:change={() => {
+									dispatch('change', { argName })
+								}}
+								on:blur={() => {
+									focused = false
+								}}
+								autoHeight
+							/>
+						</div>
+						<DynamicInputHelpBox />
+						<div class="mb-2" />
+					{:else}
+						Not recognized input type {argName} ({arg.expr}, {propertyType})
+						<div class="flex mt-2">
+							<Button
+								variant="border"
+								size="xs"
+								on:click={() => {
+									arg.expr = ''
+								}}>Set expr to empty string</Button
+							></div
+						>
 					{/if}
 				</div>
-			{:else if (propertyType === undefined || propertyType == 'static') && schema?.properties?.[argName]}
-				<ArgInput
-					{resourceTypes}
-					noMargin
-					compact
-					bind:this={argInput}
-					on:focus={onFocus}
-					on:blur={() => {
-						focused = false
-					}}
-					shouldDispatchChanges
-					on:change={() => {
-						dispatch('change', { argName })
-					}}
-					label={argName}
-					bind:editor={monaco}
-					bind:description={schema.properties[argName].description}
-					bind:value={arg.value}
-					type={schema.properties[argName].type}
-					oneOf={schema.properties[argName].oneOf}
-					required={schema.required?.includes(argName)}
-					bind:pattern={schema.properties[argName].pattern}
-					bind:valid={inputCheck}
-					defaultValue={schema.properties[argName].default}
-					bind:enum_={schema.properties[argName].enum}
-					bind:format={schema.properties[argName].format}
-					contentEncoding={schema.properties[argName].contentEncoding}
-					bind:itemsType={schema.properties[argName].items}
-					properties={schema.properties[argName].properties}
-					nestedRequired={schema.properties[argName].required}
-					displayHeader={false}
-					extra={argExtra}
-					{variableEditor}
-					{itemPicker}
-					bind:pickForField
-					showSchemaExplorer
-					nullable={schema.properties[argName].nullable}
-					bind:title={schema.properties[argName].title}
-					bind:placeholder={schema.properties[argName].placeholder}
-				/>
-			{:else if arg.expr != undefined}
-				<div class="border mt-2">
-					<SimpleEditor
-						bind:this={monaco}
-						bind:code={arg.expr}
-						on:change={() => {
-							dispatch('change', { argName })
-						}}
-						{extraLib}
-						lang="javascript"
-						shouldBindKey={false}
-						on:focus={() => {
-							focused = true
-							focusProp(argName, 'insert', (path) => {
-								monaco?.insertAtCursor(path)
-								return false
-							})
-						}}
-						on:change={() => {
-							dispatch('change', { argName })
-						}}
-						on:blur={() => {
-							focused = false
-						}}
-						autoHeight
-					/>
-				</div>
-				<DynamicInputHelpBox />
-				<div class="mb-2" />
-			{:else}
-				Not recognized input type {argName} ({arg.expr}, {propertyType})
-				<div class="flex mt-2">
-					<Button
-						variant="border"
-						size="xs"
-						on:click={() => {
-							arg.expr = ''
-						}}>Set expr to empty string</Button
-					></div
-				>
-			{/if}
+
+				{#if $propPickerConfig?.propName == argName}
+					<div class="text-blue-500 mt-2" in:fade={{ duration: 200 }}>
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							width="20"
+							height="20"
+							viewBox="0 0 24 24"
+							fill="currentColor"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<polyline points="24 24 12 12 24 0" />
+						</svg>
+					</div>
+				{:else}
+					<div class="w-0" />
+				{/if}
+			</div>
 		</div>
 	</div>
 {/if}

--- a/frontend/src/lib/components/InputTransformForm.svelte
+++ b/frontend/src/lib/components/InputTransformForm.svelte
@@ -23,7 +23,7 @@
 	import type { FlowCopilotContext } from './copilot/flow'
 	import StepInputGen from './copilot/StepInputGen.svelte'
 	import type { PickableProperties } from './flows/previousResults'
-
+	import { twMerge } from 'tailwind-merge'
 	export let schema: Schema | { properties?: Record<string, any>; required?: string[] }
 	export let arg: InputTransform | any
 	export let argName: string
@@ -189,7 +189,15 @@
 </script>
 
 {#if arg != undefined}
-	<div class={$$props.class}>
+	<div
+		class={twMerge(
+			'p-2 ml-2 relative hover:bg-surface hover:shadow-[0_0_10px_5px_rgba(0,0,0,0.1)] transition-all duration-200',
+			$propPickerConfig?.propName == argName
+				? 'bg-surface rounded-l-md shadow-[0_0_10px_5px_rgba(0,0,0,0.1)] z-2000'
+				: 'hover:rounded-md',
+			$$props.class
+		)}
+	>
 		<div class="flex flex-row justify-between gap-1 pb-1">
 			<div class="flex flex-wrap grow">
 				<FieldHeader
@@ -344,12 +352,7 @@
 
 		<div class="max-w-xs" />
 		<!-- svelte-ignore a11y-no-static-element-interactions -->
-		<div
-			class="relative {$propPickerConfig?.propName == argName
-				? 'outline outline-offset-1 outline-1 outline-blue-500 rounded-md'
-				: ''}"
-			on:keyup={stepInputGen?.onKeyUp}
-		>
+		<div class="relative p-2" on:keyup={stepInputGen?.onKeyUp}>
 			{#if $propPickerConfig?.propName == argName && $propPickerConfig?.insertionMode == 'connect'}
 				<span
 					class={'text-white  z-50 px-1 text-2xs py-0.5 font-bold rounded-t-sm w-fit absolute top-0 right-0 bg-blue-500'}

--- a/frontend/src/lib/components/InputTransformSchemaForm.svelte
+++ b/frontend/src/lib/components/InputTransformSchemaForm.svelte
@@ -84,7 +84,7 @@
 	{#if keys.length > 0}
 		{#each keys as argName (argName)}
 			{#if (!filter || filter.includes(argName)) && Object.keys(schema.properties ?? {}).includes(argName)}
-				<div class="z-10 pt-4">
+				<div class="z-10 pt-2 relative">
 					<InputTransformForm
 						{previousModuleId}
 						bind:arg={args[argName]}
@@ -128,7 +128,7 @@
 >
 	<div
 		slot="submission"
-		class="flex flex-row-reverse w-full bg-surface border-t border-gray-200 rounded-bl-lg rounded-br-lg"
+		class="flex flex-row-reverse w-full border-t border-gray-200 rounded-bl-lg rounded-br-lg"
 	>
 		<Button
 			variant="border"

--- a/frontend/src/lib/components/common/button/AnimatedButton.svelte
+++ b/frontend/src/lib/components/common/button/AnimatedButton.svelte
@@ -11,7 +11,9 @@
 	let clientWidth = 0
 	let clientHeight = 0
 
-	$: circleRadius = Math.sqrt(clientWidth * clientWidth + clientHeight * clientHeight) / 2
+	$: circleRadius = Math.ceil(
+		Math.sqrt(clientWidth * clientWidth + clientHeight * clientHeight) / 2
+	)
 </script>
 
 <div
@@ -53,7 +55,7 @@
 	}
 
 	.gradient-button.animate::before {
-		background: conic-gradient(from 0deg, #63a9ff, #0c79fd, #033b80, #00142c, #63a9ff);
+		background: conic-gradient(from 0deg, #a4c7f2, #0c79fd, #104688, #a4c7f2);
 		animation: rotate var(--animation-duration, 2s) linear infinite;
 	}
 

--- a/frontend/src/lib/components/common/button/AnimatedButton.svelte
+++ b/frontend/src/lib/components/common/button/AnimatedButton.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import { twMerge } from 'tailwind-merge'
+
+	export let marginWidth = '2px'
+	export let animationDuration = '2s'
+	export let baseRadius = '4px'
+	export let animate = true
+	export let wrapperClasses = ''
+	export let ringColor = 'transparent'
+
+	let clientWidth = 0
+	let clientHeight = 0
+
+	$: circleRadius = Math.sqrt(clientWidth * clientWidth + clientHeight * clientHeight) / 2
+</script>
+
+<div
+	class={twMerge('gradient-button', wrapperClasses)}
+	style="--margin-width: {marginWidth}; --animation-duration: {animationDuration}; --base-radius: {baseRadius}; --circle-radius: {circleRadius}; --ring-color: {ringColor}"
+	class:animate
+	bind:clientWidth
+	bind:clientHeight
+>
+	<slot />
+</div>
+
+<style>
+	.gradient-button {
+		position: relative;
+		padding: var(--margin-width, 2px);
+		font-size: inherit;
+		border: none;
+		border-radius: calc(var(--base-radius) + var(--margin-width, 2px));
+		color: currentColor;
+		background: inherit;
+		z-index: 1;
+		overflow: hidden;
+	}
+
+	/* Circular gradient */
+	.gradient-button::before {
+		content: '';
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		width: calc(var(--circle-radius, 300px) * 2px);
+		height: calc(var(--circle-radius, 300px) * 2px);
+		background: var(--ring-color, transparent);
+		border-radius: 50%;
+		z-index: -1;
+		animation: none;
+	}
+
+	.gradient-button.animate::before {
+		background: conic-gradient(from 0deg, #63a9ff, #0c79fd, #033b80, #00142c, #63a9ff);
+		animation: rotate var(--animation-duration, 2s) linear infinite;
+	}
+
+	/* inner background */
+	.gradient-button::after {
+		content: '';
+		position: absolute;
+		top: var(--margin-width, 2px);
+		right: var(--margin-width, 2px);
+		bottom: var(--margin-width, 2px);
+		left: var(--margin-width, 2px);
+		background: inherit;
+		border-radius: var(--base-radius);
+		z-index: -1;
+	}
+
+	@keyframes rotate {
+		from {
+			transform: translate(-50%, -50%) rotate(0deg);
+		}
+		to {
+			transform: translate(-50%, -50%) rotate(360deg);
+		}
+	}
+
+	.gradient-button.animate:hover::before {
+		animation-duration: 1s;
+	}
+</style>

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -378,10 +378,11 @@
 							class={advancedSelected === 'runtime' ? 'h-[calc(100%-68px)]' : 'h-[calc(100%-34px)]'}
 						>
 							{#if selected === 'inputs' && (flowModule.value.type == 'rawscript' || flowModule.value.type == 'script' || flowModule.value.type == 'flow')}
-								<div class="h-full overflow-auto px-2" id="flow-editor-step-input">
+								<div class="h-full overflow-auto px-2 bg-surface" id="flow-editor-step-input">
 									<PropPickerWrapper
 										pickableProperties={stepPropPicker.pickableProperties}
 										error={failureModule}
+										noPadding
 									>
 										<InputTransformSchemaForm
 											bind:this={inputTransformSchemaForm}

--- a/frontend/src/lib/components/flows/propPicker/PropPickerWrapper.svelte
+++ b/frontend/src/lib/components/flows/propPicker/PropPickerWrapper.svelte
@@ -19,7 +19,7 @@
 <script lang="ts">
 	import PropPicker from '$lib/components/propertyPicker/PropPicker.svelte'
 	import PropPickerResult from '$lib/components/propertyPicker/PropPickerResult.svelte'
-	import { clickOutside, sendUserToast } from '$lib/utils'
+	import { clickOutside } from '$lib/utils'
 	import { createEventDispatcher, setContext } from 'svelte'
 	import { Pane, Splitpanes } from 'svelte-splitpanes'
 	import { writable, type Writable } from 'svelte/store'
@@ -76,10 +76,8 @@
 					{result}
 					{extraResults}
 					{flow_input}
+					allowCopy={!notSelectable && !$propPickerConfig}
 					on:select={({ detail }) => {
-						if (!notSelectable && !$propPickerConfig) {
-							sendUserToast('Set cursor within an input or click on the plug first', true)
-						}
 						dispatch('select', detail)
 						if ($propPickerConfig?.onSelect(detail)) {
 							propPickerConfig.set(undefined)
@@ -92,10 +90,8 @@
 					{error}
 					{pickableProperties}
 					{notSelectable}
+					allowCopy={!notSelectable && !$propPickerConfig}
 					on:select={({ detail }) => {
-						if (!notSelectable && !$propPickerConfig) {
-							sendUserToast('Set cursor within an input or click on the plug first', true)
-						}
 						dispatch('select', detail)
 						if ($propPickerConfig?.onSelect(detail)) {
 							propPickerConfig.set(undefined)

--- a/frontend/src/lib/components/flows/propPicker/PropPickerWrapper.svelte
+++ b/frontend/src/lib/components/flows/propPicker/PropPickerWrapper.svelte
@@ -58,18 +58,16 @@
 	use:clickOutside
 	on:click_outside={() => propPickerConfig.set(undefined)}
 >
-	<Splitpanes>
-		<Pane
-			minSize={20}
-			size={60}
-			class={twMerge('relative !transition-none', noPadding ? '' : 'p-2')}
-		>
+	<Splitpanes class="splitpanes-remove-splitter">
+		<Pane class={twMerge('relative !transition-none ', noPadding ? '' : 'p-2')}>
 			<slot />
 		</Pane>
 		<Pane
 			minSize={20}
 			size={40}
-			class="pt-2 relative !transition-none {$propPickerConfig ? 'border-2 border-blue-500' : ''}"
+			class="pt-2 relative ml-[-1px] !transition-none z-1000 {$propPickerConfig
+				? 'shadow-[0_0_10px_5px_rgba(0,0,0,0.1)]'
+				: ''}"
 		>
 			{#if result}
 				<PropPickerResult
@@ -102,3 +100,14 @@
 		</Pane>
 	</Splitpanes>
 </div>
+
+<style>
+	:global(.splitpanes-remove-splitter > .splitpanes__pane) {
+		background-color: inherit !important;
+	}
+	:global(.splitpanes-remove-splitter > .splitpanes__splitter) {
+		background-color: transparent !important;
+		width: 0 !important;
+		border: none !important;
+	}
+</style>

--- a/frontend/src/lib/components/flows/propPicker/PropPickerWrapper.svelte
+++ b/frontend/src/lib/components/flows/propPicker/PropPickerWrapper.svelte
@@ -59,17 +59,28 @@
 	use:clickOutside
 	on:click_outside={() => propPickerConfig.set(undefined)}
 >
-	<Splitpanes class="splitpanes-remove-splitter">
-		<Pane class={twMerge('relative !transition-none ', noPadding ? '' : 'p-2')}>
+	<Splitpanes class={$propPickerConfig ? 'splitpanes-remove-splitter' : ''}>
+		<Pane
+			minSize={20}
+			size={60}
+			class={twMerge('relative !transition-none ', noPadding ? '' : 'p-2')}
+		>
 			<slot />
 		</Pane>
-		<Pane minSize={20} size={40} class="!transition-none z-1000 ml-[-1px]">
+		<Pane
+			minSize={20}
+			size={40}
+			class="!transition-none z-1000 {$propPickerConfig ? 'ml-[-1px]' : ''}"
+		>
 			<AnimatedButton
 				animate={$propPickerConfig?.insertionMode == 'connect'}
 				baseRadius="4px"
 				wrapperClasses="h-full w-full pt-2"
 				marginWidth="4px"
-				ringColor={$propPickerConfig?.insertionMode == 'insert' ? '#3b82f6' : 'transparent'}
+				ringColor={$propPickerConfig?.insertionMode == 'insert' ||
+				$propPickerConfig?.insertionMode == 'append'
+					? '#3b82f6'
+					: 'transparent'}
 				animationDuration="1s"
 			>
 				{#if result}

--- a/frontend/src/lib/components/flows/propPicker/PropPickerWrapper.svelte
+++ b/frontend/src/lib/components/flows/propPicker/PropPickerWrapper.svelte
@@ -65,9 +65,9 @@
 		<Pane
 			minSize={20}
 			size={40}
-			class="pt-2 relative ml-[-1px] !transition-none z-1000 {$propPickerConfig
-				? 'shadow-[0_0_10px_5px_rgba(0,0,0,0.1)]'
-				: ''}"
+			class="pt-2 relative ml-[-1px] border-4 !transition-none z-1000 {$propPickerConfig
+				? 'rounded-l-md border-blue-500'
+				: 'border-transparent'}"
 		>
 			{#if result}
 				<PropPickerResult

--- a/frontend/src/lib/components/flows/propPicker/PropPickerWrapper.svelte
+++ b/frontend/src/lib/components/flows/propPicker/PropPickerWrapper.svelte
@@ -25,6 +25,7 @@
 	import { writable, type Writable } from 'svelte/store'
 	import type { PickableProperties } from '../previousResults'
 	import { twMerge } from 'tailwind-merge'
+	import AnimatedButton from '$lib/components/common/button/AnimatedButton.svelte'
 
 	export let pickableProperties: PickableProperties | undefined
 	export let result: any = undefined
@@ -62,41 +63,44 @@
 		<Pane class={twMerge('relative !transition-none ', noPadding ? '' : 'p-2')}>
 			<slot />
 		</Pane>
-		<Pane
-			minSize={20}
-			size={40}
-			class="pt-2 relative ml-[-1px] border-4 !transition-none z-1000 {$propPickerConfig
-				? 'rounded-l-md border-blue-500'
-				: 'border-transparent'}"
-		>
-			{#if result}
-				<PropPickerResult
-					{result}
-					{extraResults}
-					{flow_input}
-					allowCopy={!notSelectable && !$propPickerConfig}
-					on:select={({ detail }) => {
-						dispatch('select', detail)
-						if ($propPickerConfig?.onSelect(detail)) {
-							propPickerConfig.set(undefined)
-						}
-					}}
-				/>
-			{:else if pickableProperties}
-				<PropPicker
-					{displayContext}
-					{error}
-					{pickableProperties}
-					{notSelectable}
-					allowCopy={!notSelectable && !$propPickerConfig}
-					on:select={({ detail }) => {
-						dispatch('select', detail)
-						if ($propPickerConfig?.onSelect(detail)) {
-							propPickerConfig.set(undefined)
-						}
-					}}
-				/>
-			{/if}
+		<Pane minSize={20} size={40} class="!transition-none z-1000 ml-[-1px]">
+			<AnimatedButton
+				animate={$propPickerConfig?.insertionMode == 'connect'}
+				baseRadius="4px"
+				wrapperClasses="h-full w-full pt-2"
+				marginWidth="4px"
+				ringColor={$propPickerConfig?.insertionMode == 'insert' ? '#3b82f6' : 'transparent'}
+				animationDuration="1s"
+			>
+				{#if result}
+					<PropPickerResult
+						{result}
+						{extraResults}
+						{flow_input}
+						allowCopy={!notSelectable && !$propPickerConfig}
+						on:select={({ detail }) => {
+							dispatch('select', detail)
+							if ($propPickerConfig?.onSelect(detail)) {
+								propPickerConfig.set(undefined)
+							}
+						}}
+					/>
+				{:else if pickableProperties}
+					<PropPicker
+						{displayContext}
+						{error}
+						{pickableProperties}
+						{notSelectable}
+						allowCopy={!notSelectable && !$propPickerConfig}
+						on:select={({ detail }) => {
+							dispatch('select', detail)
+							if ($propPickerConfig?.onSelect(detail)) {
+								propPickerConfig.set(undefined)
+							}
+						}}
+					/>
+				{/if}
+			</AnimatedButton>
 		</Pane>
 	</Splitpanes>
 </div>

--- a/frontend/src/lib/components/flows/propPicker/PropPickerWrapper.svelte
+++ b/frontend/src/lib/components/flows/propPicker/PropPickerWrapper.svelte
@@ -110,4 +110,13 @@
 		width: 0 !important;
 		border: none !important;
 	}
+
+	:global(.splitpanes__pane) {
+		overflow-y: auto;
+		scrollbar-width: none;
+	}
+
+	:global(.splitpanes__pane:hover) {
+		scrollbar-width: thin;
+	}
 </style>

--- a/frontend/src/lib/components/propertyPicker/ObjectViewer.svelte
+++ b/frontend/src/lib/components/propertyPicker/ObjectViewer.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-	import { copyToClipboard, pluralize, truncate } from '$lib/utils'
+	import { copyToClipboard, truncate } from '$lib/utils'
 
 	import { createEventDispatcher } from 'svelte'
-	import { Badge } from '../common'
 	import { computeKey } from './utils'
-	import WarningMessage from './WarningMessage.svelte'
 	import { NEVER_TESTED_THIS_FAR } from '../flows/models'
 	import Portal from '$lib/components/Portal.svelte'
+	import { Button } from '$lib/components/common'
 
 	import { Download, PanelRightOpen } from 'lucide-svelte'
 	import S3FilePicker from '../S3FilePicker.svelte'
@@ -19,7 +18,6 @@
 	export let collapsed = (level != 0 && level % 3 == 0) || Array.isArray(json)
 	export let rawKey = false
 	export let topBrackets = false
-	export let topLevelNode = false
 	export let allowCopy = true
 	export let collapseLevel: number | undefined = undefined
 
@@ -73,28 +71,32 @@
 			{#if level != 0 && keys.length > 1}
 				<!-- svelte-ignore a11y-click-events-have-key-events -->
 				<!-- svelte-ignore a11y-no-static-element-interactions -->
-				<span class="cursor-pointer border hover:bg-surface-hover px-1 rounded" on:click={collapse}>
-					-
-				</span>
+				<Button
+					color="light"
+					size="xs2"
+					variant="border"
+					on:click={collapse}
+					wrapperClasses="inline-flex w-fit h-5"
+					btnClasses="font-semibold text-primary border-nord-300 rounded-[0.275rem]">-</Button
+				>
 			{/if}
 			{#if level == 0 && topBrackets}<span class="h-0">{openBracket}</span>{/if}
 			<ul class={`w-full pl-2 ${level === 0 ? 'border-none' : 'border-l border-dotted'}`}>
 				{#each keys.length > keyLimit ? keys.slice(0, keyLimit) : keys as key, index (key)}
 					<li>
-						<button on:click={() => selectProp(key)} class="whitespace-nowrap">
-							{#if topLevelNode}
-								<Badge baseClass="border border-blue-600" color="indigo">{key}</Badge>
-							{:else}
-								<span
-									class="key {pureViewer
-										? 'cursor-auto'
-										: 'border '} font-semibold rounded px-1 hover:bg-surface-hover text-2xs text-secondary"
-								>
-									{!isArray ? key : index}</span
-								>
-							{/if}:
-						</button>
-
+						<Button
+							on:click={() => selectProp(key)}
+							size="xs2"
+							color="dark"
+							variant="contained"
+							wrapperClasses="inline-flex p-0 whitespace-nowrap w-fit h-4"
+							btnClasses="font-normal rounded-[0.275rem]"
+						>
+							<span class={pureViewer ? 'cursor-auto' : ''}>
+								{!isArray ? key : index}
+							</span>
+						</Button>
+						:
 						{#if getTypeAsString(json[key]) === 'object'}
 							<svelte:self
 								json={json[key]}
@@ -114,9 +116,12 @@
 									json[key]
 								)}"
 								on:click={() => selectProp(key, json[key])}
+								disabled={true}
 							>
 								{#if json[key] === NEVER_TESTED_THIS_FAR}
-									<WarningMessage />
+									<span class="text-2xs text-tertiary font-normal">
+										Test the flow to see a value
+									</span>
 								{:else if json[key] == undefined}
 									<span class="text-2xs">undefined</span>
 								{:else if json[key] == null}
@@ -167,17 +172,18 @@
 
 	<!-- svelte-ignore a11y-click-events-have-key-events -->
 	<!-- svelte-ignore a11y-no-static-element-interactions -->
-	<span
-		class="border border-blue-600 rounded px-1 cursor-pointer hover:bg-gray-200"
-		class:hidden={!fullyCollapsed}
-		on:click={collapse}
-	>
-		{openBracket}{collapsedSymbol}{closeBracket}
-	</span>
+
 	{#if fullyCollapsed}
-		<span class="text-tertiary text-xs">
-			{pluralize(Object.keys(json).length, Array.isArray(json) ? 'item' : 'key')}
-		</span>
+		<Button
+			color="light"
+			size="xs2"
+			variant="border"
+			on:click={collapse}
+			wrapperClasses="inline-flex w-fit h-5"
+			btnClasses="font-semibold border-nord-300 rounded-[0.275rem] p-1"
+		>
+			{openBracket}{collapsedSymbol}{closeBracket}
+		</Button>
 	{/if}
 {:else if topBrackets}
 	<span class="text-primary">{openBracket}{closeBracket}</span>
@@ -200,14 +206,14 @@
 		@apply text-tertiary;
 	}
 	.val.string {
-		@apply text-green-600 dark:text-green-400/80;
+		@apply text-primary;
 	}
 
 	.val.number {
-		@apply text-orange-600 dark:text-orange-400/90;
+		@apply text-primary;
 		@apply font-mono;
 	}
 	.val.boolean {
-		@apply text-blue-600 dark:text-blue-400/90;
+		@apply text-primary;
 	}
 </style>

--- a/frontend/src/lib/components/propertyPicker/ObjectViewer.svelte
+++ b/frontend/src/lib/components/propertyPicker/ObjectViewer.svelte
@@ -61,8 +61,7 @@
 	function selectProp(key: string, value: any | undefined = undefined) {
 		const fullKey = computeFullKey(key, rawKey)
 		if (pureViewer && allowCopy) {
-			const valueToCopy = value !== undefined ? value : fullKey
-			copyToClipboard(valueToCopy)
+			copyToClipboard(fullKey)
 		}
 		dispatch('select', fullKey)
 	}
@@ -125,31 +124,38 @@
 								collapsed={collapseLevel !== undefined ? level + 1 >= collapseLevel : undefined}
 							/>
 						{:else}
-							<button
-								class="val text-left {pureViewer
-									? 'cursor-auto'
-									: ''} rounded px-1 hover:bg-blue-100 dark:hover:bg-blue-100/10 {getTypeAsString(
-									json[key]
-								)}"
-								on:click={() => selectProp(key, json[key])}
-								disabled={true}
-							>
-								{#if json[key] === NEVER_TESTED_THIS_FAR}
-									<span class="text-2xs text-tertiary font-normal">
-										Test the flow to see a value
-									</span>
-								{:else if json[key] == undefined}
-									<span class="text-2xs">undefined</span>
-								{:else if json[key] == null}
-									<span class="text-2xs">null</span>
-								{:else if typeof json[key] == 'string'}
-									<span title={json[key]} class="text-2xs">"{truncate(json[key], 200)}"</span>
-								{:else}
-									<span title={JSON.stringify(json[key])} class="text-2xs">
-										{truncate(JSON.stringify(json[key]), 200)}
-									</span>
-								{/if}
-							</button>
+							<Popover disablePopup={!json[key]}>
+								<svelte:fragment slot="text">
+									{JSON.stringify(json[key])}
+								</svelte:fragment>
+								<button
+									class="val text-left {pureViewer
+										? 'cursor-auto'
+										: ''} rounded px-1 {getTypeAsString(json[key])}"
+									on:click={() => {
+										if (json[key]) {
+											copyToClipboard(json[key])
+										}
+									}}
+									disabled={false}
+								>
+									{#if json[key] === NEVER_TESTED_THIS_FAR}
+										<span class="text-2xs text-tertiary font-normal">
+											Test the flow to see a value
+										</span>
+									{:else if json[key] == undefined}
+										<span class="text-2xs">undefined</span>
+									{:else if json[key] == null}
+										<span class="text-2xs">null</span>
+									{:else if typeof json[key] == 'string'}
+										<span class="text-2xs">"{truncate(json[key], 200)}"</span>
+									{:else}
+										<span class="text-2xs">
+											{truncate(JSON.stringify(json[key]), 200)}
+										</span>
+									{/if}
+								</button>
+							</Popover>
 						{/if}
 					</li>
 				{/each}

--- a/frontend/src/lib/components/propertyPicker/ObjectViewer.svelte
+++ b/frontend/src/lib/components/propertyPicker/ObjectViewer.svelte
@@ -206,14 +206,14 @@
 		@apply text-tertiary;
 	}
 	.val.string {
-		@apply text-primary;
+		@apply text-green-600 dark:text-green-400/80;
 	}
 
 	.val.number {
-		@apply text-primary;
+		@apply text-orange-600 dark:text-orange-400/90;
 		@apply font-mono;
 	}
 	.val.boolean {
-		@apply text-primary;
+		@apply text-blue-600 dark:text-blue-400/90;
 	}
 </style>

--- a/frontend/src/lib/components/propertyPicker/ObjectViewer.svelte
+++ b/frontend/src/lib/components/propertyPicker/ObjectViewer.svelte
@@ -69,8 +69,6 @@
 	$: keyLimit = isArray ? 1 : 100
 
 	$: fullyCollapsed = keys.length > 1 && collapsed
-
-	$: console.log('dbg current path : ', currentPath)
 </script>
 
 <Portal name="object-viewer">

--- a/frontend/src/lib/components/propertyPicker/PropPicker.svelte
+++ b/frontend/src/lib/components/propertyPicker/PropPicker.svelte
@@ -21,7 +21,7 @@
 	let resources: Record<string, any> = {}
 	let displayVariable = false
 	let displayResources = false
-
+	let allResultsCollapsed = true
 	const dispatch = createEventDispatcher()
 
 	const EMPTY_STRING = ''
@@ -68,16 +68,7 @@
 	<div class="px-2">
 		{#if !notSelectable}
 			<div class="flex flex-row space-x-1">
-				{#if $propPickerConfig}
-					<Badge large color="blue">
-						{`Selected: ${$propPickerConfig?.propName}`}
-					</Badge>
-					<Badge large color="blue">
-						{`Mode: ${$propPickerConfig?.insertionMode}`}
-					</Badge>
-				{:else}
-					<Badge large color="blue">&leftarrow; Edit or connect an input</Badge>
-				{/if}
+				<Badge large color="blue">&leftarrow; Edit or connect an input</Badge>
 			</div>
 		{/if}
 		<ClearableInput bind:value={search} placeholder="Search prop..." wrapperClass="py-2" />
@@ -87,7 +78,7 @@
 		class:bg-surface-secondary={!$propPickerConfig && !notSelectable}
 	>
 		<div class="flex justify-between items-center space-x-1">
-			<span class="font-bold text-sm">Flow Input</span>
+			<span class="font-normal text-sm text-secondary">Flow Input</span>
 			<div class="flex space-x-2 items-center" />
 		</div>
 		<div class="overflow-y-auto mb-2">
@@ -104,7 +95,7 @@
 			/>
 		</div>
 		{#if error}
-			<span class="font-bold text-sm">Error</span>
+			<span class="font-normal text-sm text-secondary">Error</span>
 			<div class="overflow-y-auto mb-2">
 				<ObjectViewer
 					allowCopy={false}
@@ -122,11 +113,10 @@
 			</div>
 			{#if Object.keys(pickableProperties.priorIds).length > 0}
 				{#if suggestedPropsFiltered && Object.keys(suggestedPropsFiltered).length > 0}
-					<span class="font-bold text-sm">Suggested Results</span>
+					<span class="font-normal text-sm text-secondary">Suggested Results</span>
 					<div class="overflow-y-auto mb-2">
 						<ObjectViewer
 							allowCopy={false}
-							topLevelNode
 							pureViewer={!$propPickerConfig}
 							collapsed={false}
 							json={suggestedPropsFiltered}
@@ -136,11 +126,10 @@
 						/>
 					</div>
 				{/if}
-				<span class="font-bold text-sm">All Results</span>
+				<span class="font-normal text-sm text-secondary">All Results</span>
 				<div class="overflow-y-auto mb-2">
 					<ObjectViewer
 						allowCopy={false}
-						topLevelNode
 						pureViewer={!$propPickerConfig}
 						collapsed={true}
 						json={resultByIdFiltered}
@@ -152,11 +141,10 @@
 			{/if}
 		{:else}
 			{#if previousId}
-				<span class="font-bold text-sm">Previous Result</span>
+				<span class="font-normal text-sm text-secondary">Previous Result</span>
 				<div class="overflow-y-auto mb-2">
 					<ObjectViewer
 						allowCopy={false}
-						topLevelNode
 						pureViewer={!$propPickerConfig}
 						json={Object.fromEntries(
 							Object.entries(resultByIdFiltered).filter(([k, v]) => k == previousId)
@@ -168,11 +156,10 @@
 				</div>
 			{/if}
 			{#if pickableProperties.hasResume}
-				<span class="font-bold text-sm">Resume payloads</span>
+				<span class="font-normal text-sm text-secondary">Resume payloads</span>
 				<div class="overflow-y-auto mb-2">
 					<ObjectViewer
 						allowCopy={false}
-						topLevelNode
 						pureViewer={!$propPickerConfig}
 						json={{
 							resume: 'The resume payload',
@@ -187,11 +174,10 @@
 			{/if}
 			{#if Object.keys(pickableProperties.priorIds).length > 0}
 				{#if suggestedPropsFiltered && Object.keys(suggestedPropsFiltered).length > 0}
-					<span class="font-bold text-sm">Suggested Results</span>
+					<span class="font-normal text-sm text-secondary">Suggested Results</span>
 					<div class="overflow-y-auto mb-2">
 						<ObjectViewer
 							allowCopy={false}
-							topLevelNode
 							pureViewer={!$propPickerConfig}
 							collapsed={false}
 							json={suggestedPropsFiltered}
@@ -201,13 +187,25 @@
 						/>
 					</div>
 				{/if}
-				<span class="font-bold text-sm">All Results</span>
 				<div class="overflow-y-auto mb-2">
+					<span class="font-normal text-sm text-tertiary">All Results :</span>
+					{#if !allResultsCollapsed}
+						<Button
+							color="light"
+							size="xs2"
+							variant="border"
+							on:click={() => {
+								allResultsCollapsed = true
+							}}
+							wrapperClasses="inline-flex w-fit h-4"
+							btnClasses="font-normal text-primary border-nord-300 rounded-[0.275rem]">-</Button
+						>
+					{/if}
+
 					<ObjectViewer
 						allowCopy={false}
-						topLevelNode
 						pureViewer={!$propPickerConfig}
-						collapsed={true}
+						bind:collapsed={allResultsCollapsed}
 						json={resultByIdFiltered}
 						on:select={(e) => {
 							dispatch('select', `results.${e.detail}`)
@@ -218,19 +216,21 @@
 		{/if}
 
 		{#if displayContext}
-			<span class="font-bold text-sm">Variables </span>
 			<div class="overflow-y-auto mb-2">
+				<span class="font-normal text-sm text-secondary">Variables :</span>
+
 				{#if displayVariable}
-					<div class="flex">
-						<Button
-							color="light"
-							size="xs"
-							variant="border"
-							on:click={() => {
-								displayVariable = false
-							}}>-</Button
-						>
-					</div>
+					<Button
+						color="light"
+						size="xs2"
+						variant="border"
+						on:click={() => {
+							displayVariable = false
+						}}
+						wrapperClasses="inline-flex w-fit h-4"
+						btnClasses="font-normal text-primary border-nord-300 rounded-[0.275rem]">-</Button
+					>
+
 					<ObjectViewer
 						allowCopy={false}
 						pureViewer={!$propPickerConfig}
@@ -239,25 +239,35 @@
 						on:select={(e) => dispatch('select', `variable('${e.detail}')`)}
 					/>
 				{:else}
-					<button
-						class="border border-blue-600 key font-normal rounded hover:bg-blue-100 px-1"
+					<Button
+						color="light"
+						size="xs2"
+						variant="border"
 						on:click={async () => {
 							await loadVariables()
 							displayVariable = true
-						}}>{'{...}'}</button
+						}}
+						wrapperClasses="inline-flex w-fit h-5"
+						btnClasses="font-semibold border-nord-300 rounded-[0.275rem] p-1"
 					>
+						{'{...}'}
+					</Button>
 				{/if}
 			</div>
-			<span class="font-bold text-sm">Resources</span>
+
 			<div class="overflow-y-auto mb-2">
+				<span class="font-normal text-sm text-secondary">Resources :</span>
+
 				{#if displayResources}
 					<Button
 						color="light"
+						size="xs2"
 						variant="border"
-						size="xs"
 						on:click={() => {
 							displayResources = false
-						}}>-</Button
+						}}
+						wrapperClasses="inline-flex w-fit h-5"
+						btnClasses="font-semibold text-primary border-nord-300 rounded-[0.275rem]">-</Button
 					>
 					<ObjectViewer
 						allowCopy={false}
@@ -267,13 +277,19 @@
 						on:select={(e) => dispatch('select', `resource('${e.detail}')`)}
 					/>
 				{:else}
-					<button
-						class="border border-blue-600 px-1 key font-normal rounded hover:bg-blue-100"
+					<Button
+						color="light"
+						size="xs2"
+						variant="border"
 						on:click={async () => {
 							await loadResources()
 							displayResources = true
-						}}>{'{...}'}</button
+						}}
+						wrapperClasses="inline-flex w-fit h-5"
+						btnClasses="font-semibold border-nord-300 rounded-[0.275rem] p-1"
 					>
+						{'{...}'}
+					</Button>
 				{/if}
 			</div>
 		{/if}

--- a/frontend/src/lib/components/propertyPicker/PropPicker.svelte
+++ b/frontend/src/lib/components/propertyPicker/PropPicker.svelte
@@ -63,7 +63,7 @@
 	}
 </script>
 
-<div class="flex flex-col h-full">
+<div class="flex flex-col h-full !bg-surface">
 	<div class="px-2">
 		{#if !notSelectable}
 			<div class="flex flex-row space-x-1">

--- a/frontend/src/lib/components/propertyPicker/PropPicker.svelte
+++ b/frontend/src/lib/components/propertyPicker/PropPicker.svelte
@@ -63,12 +63,19 @@
 	}
 </script>
 
-<div class="flex flex-col h-full !bg-surface">
+<div class="flex flex-col h-full !bg-surface rounded overflow-hidden">
 	<div class="px-2">
 		{#if !notSelectable}
-			<div class="flex flex-row space-x-1">
+			{#if $propPickerConfig}
+				<!-- <Badge large color="blue">
+					{`Selected: ${$propPickerConfig?.propName}`}
+				</Badge> -->
+				<Badge large color="blue">
+					{`Mode: ${$propPickerConfig?.insertionMode}`}
+				</Badge>
+			{:else}
 				<Badge large color="blue">&leftarrow; Edit or connect an input</Badge>
-			</div>
+			{/if}
 		{/if}
 		<ClearableInput bind:value={search} placeholder="Search prop..." wrapperClass="py-2" />
 	</div>

--- a/frontend/src/lib/components/propertyPicker/PropPicker.svelte
+++ b/frontend/src/lib/components/propertyPicker/PropPicker.svelte
@@ -4,7 +4,6 @@
 	import { getContext } from 'svelte'
 	import { Badge, Button } from '../common'
 	import type { PropPickerWrapperContext } from '../flows/propPicker/PropPickerWrapper.svelte'
-	import { createEventDispatcher } from 'svelte'
 
 	import ObjectViewer from './ObjectViewer.svelte'
 	import { keepByKey } from './utils'
@@ -22,7 +21,6 @@
 	let displayVariable = false
 	let displayResources = false
 	let allResultsCollapsed = true
-	const dispatch = createEventDispatcher()
 
 	const EMPTY_STRING = ''
 	let search = ''
@@ -86,12 +84,8 @@
 				allowCopy={false}
 				pureViewer={!$propPickerConfig}
 				json={flowInputsFiltered}
-				on:select={(e) => {
-					dispatch(
-						'select',
-						e.detail?.startsWith('[') ? `flow_input${e.detail}` : `flow_input.${e.detail}`
-					)
-				}}
+				prefix="flow_input"
+				on:select
 			/>
 		</div>
 		{#if error}
@@ -120,9 +114,8 @@
 							pureViewer={!$propPickerConfig}
 							collapsed={false}
 							json={suggestedPropsFiltered}
-							on:select={(e) => {
-								dispatch('select', `results.${e.detail}`)
-							}}
+							prefix="results"
+							on:select
 						/>
 					</div>
 				{/if}
@@ -133,9 +126,8 @@
 						pureViewer={!$propPickerConfig}
 						collapsed={true}
 						json={resultByIdFiltered}
-						on:select={(e) => {
-							dispatch('select', `results.${e.detail}`)
-						}}
+						prefix="results"
+						on:select
 					/>
 				</div>
 			{/if}
@@ -149,9 +141,8 @@
 						json={Object.fromEntries(
 							Object.entries(resultByIdFiltered).filter(([k, v]) => k == previousId)
 						)}
-						on:select={(e) => {
-							dispatch('select', `results.${e.detail}`)
-						}}
+						prefix="results"
+						on:select
 					/>
 				</div>
 			{/if}
@@ -166,9 +157,7 @@
 							resumes: 'All resume payloads from all approvers',
 							approvers: 'The list of approvers'
 						}}
-						on:select={(e) => {
-							dispatch('select', `${e.detail}`)
-						}}
+						on:select
 					/>
 				</div>
 			{/if}
@@ -181,9 +170,8 @@
 							pureViewer={!$propPickerConfig}
 							collapsed={false}
 							json={suggestedPropsFiltered}
-							on:select={(e) => {
-								dispatch('select', `results.${e.detail}`)
-							}}
+							prefix="results"
+							on:select
 						/>
 					</div>
 				{/if}
@@ -207,9 +195,8 @@
 						pureViewer={!$propPickerConfig}
 						bind:collapsed={allResultsCollapsed}
 						json={resultByIdFiltered}
-						on:select={(e) => {
-							dispatch('select', `results.${e.detail}`)
-						}}
+						prefix="results"
+						on:select
 					/>
 				</div>
 			{/if}
@@ -236,7 +223,8 @@
 						pureViewer={!$propPickerConfig}
 						rawKey={true}
 						json={variables}
-						on:select={(e) => dispatch('select', `variable('${e.detail}')`)}
+						prefix="variable"
+						on:select
 					/>
 				{:else}
 					<Button
@@ -274,7 +262,8 @@
 						pureViewer={!$propPickerConfig}
 						rawKey={true}
 						json={resources}
-						on:select={(e) => dispatch('select', `resource('${e.detail}')`)}
+						prefix="resource"
+						on:select
 					/>
 				{:else}
 					<Button

--- a/frontend/src/lib/components/propertyPicker/PropPicker.svelte
+++ b/frontend/src/lib/components/propertyPicker/PropPicker.svelte
@@ -14,6 +14,7 @@
 	export let displayContext = true
 	export let notSelectable: boolean
 	export let error: boolean = false
+	export let allowCopy = false
 
 	$: previousId = pickableProperties?.previousId
 	let variables: Record<string, string> = {}
@@ -81,7 +82,7 @@
 		</div>
 		<div class="overflow-y-auto mb-2">
 			<ObjectViewer
-				allowCopy={false}
+				{allowCopy}
 				pureViewer={!$propPickerConfig}
 				json={flowInputsFiltered}
 				prefix="flow_input"
@@ -92,7 +93,7 @@
 			<span class="font-normal text-sm text-secondary">Error</span>
 			<div class="overflow-y-auto mb-2">
 				<ObjectViewer
-					allowCopy={false}
+					{allowCopy}
 					pureViewer={!$propPickerConfig}
 					json={{
 						error: {
@@ -110,7 +111,7 @@
 					<span class="font-normal text-sm text-secondary">Suggested Results</span>
 					<div class="overflow-y-auto mb-2">
 						<ObjectViewer
-							allowCopy={false}
+							{allowCopy}
 							pureViewer={!$propPickerConfig}
 							collapsed={false}
 							json={suggestedPropsFiltered}
@@ -122,7 +123,7 @@
 				<span class="font-normal text-sm text-secondary">All Results</span>
 				<div class="overflow-y-auto mb-2">
 					<ObjectViewer
-						allowCopy={false}
+						{allowCopy}
 						pureViewer={!$propPickerConfig}
 						collapsed={true}
 						json={resultByIdFiltered}
@@ -136,7 +137,7 @@
 				<span class="font-normal text-sm text-secondary">Previous Result</span>
 				<div class="overflow-y-auto mb-2">
 					<ObjectViewer
-						allowCopy={false}
+						{allowCopy}
 						pureViewer={!$propPickerConfig}
 						json={Object.fromEntries(
 							Object.entries(resultByIdFiltered).filter(([k, v]) => k == previousId)
@@ -150,7 +151,7 @@
 				<span class="font-normal text-sm text-secondary">Resume payloads</span>
 				<div class="overflow-y-auto mb-2">
 					<ObjectViewer
-						allowCopy={false}
+						{allowCopy}
 						pureViewer={!$propPickerConfig}
 						json={{
 							resume: 'The resume payload',
@@ -166,7 +167,7 @@
 					<span class="font-normal text-sm text-secondary">Suggested Results</span>
 					<div class="overflow-y-auto mb-2">
 						<ObjectViewer
-							allowCopy={false}
+							{allowCopy}
 							pureViewer={!$propPickerConfig}
 							collapsed={false}
 							json={suggestedPropsFiltered}
@@ -191,7 +192,7 @@
 					{/if}
 
 					<ObjectViewer
-						allowCopy={false}
+						{allowCopy}
 						pureViewer={!$propPickerConfig}
 						bind:collapsed={allResultsCollapsed}
 						json={resultByIdFiltered}
@@ -219,7 +220,7 @@
 					>
 
 					<ObjectViewer
-						allowCopy={false}
+						{allowCopy}
 						pureViewer={!$propPickerConfig}
 						rawKey={true}
 						json={variables}
@@ -258,7 +259,7 @@
 						btnClasses="font-semibold text-primary border-nord-300 rounded-[0.275rem]">-</Button
 					>
 					<ObjectViewer
-						allowCopy={false}
+						{allowCopy}
 						pureViewer={!$propPickerConfig}
 						rawKey={true}
 						json={resources}

--- a/frontend/src/lib/components/propertyPicker/PropPickerResult.svelte
+++ b/frontend/src/lib/components/propertyPicker/PropPickerResult.svelte
@@ -8,12 +8,12 @@
 </script>
 
 <div class="w-full px-2">
-	<span class="font-bold text-sm">Result</span>
+	<span class="font-normal text-sm text-secondary">Result</span>
 	<div class="overflow-y-auto mb-2 w-full">
 		<ObjectViewer {allowCopy} json={{ result, ...(extraResults ? extraResults : {}) }} on:select />
 	</div>
 	{#if flow_input}
-		<span class="font-bold text-sm">Flow Input</span>
+		<span class="font-normal text-sm text-secondary">Flow Input</span>
 		<div class="overflow-y-auto w-full">
 			<ObjectViewer {allowCopy} json={flow_input} prefix="flow_input" on:select />
 		</div>

--- a/frontend/src/lib/components/propertyPicker/PropPickerResult.svelte
+++ b/frontend/src/lib/components/propertyPicker/PropPickerResult.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import ObjectViewer from './ObjectViewer.svelte'
 
+	export let allowCopy = false
 	export let result: any
 	export let extraResults: any = undefined
 	export let flow_input: any = undefined
@@ -9,16 +10,12 @@
 <div class="w-full px-2">
 	<span class="font-bold text-sm">Result</span>
 	<div class="overflow-y-auto mb-2 w-full">
-		<ObjectViewer
-			allowCopy={false}
-			json={{ result, ...(extraResults ? extraResults : {}) }}
-			on:select
-		/>
+		<ObjectViewer {allowCopy} json={{ result, ...(extraResults ? extraResults : {}) }} on:select />
 	</div>
 	{#if flow_input}
 		<span class="font-bold text-sm">Flow Input</span>
 		<div class="overflow-y-auto w-full">
-			<ObjectViewer allowCopy={false} json={flow_input} prefix="flow_input" on:select />
+			<ObjectViewer {allowCopy} json={flow_input} prefix="flow_input" on:select />
 		</div>
 	{/if}
 </div>

--- a/frontend/src/lib/components/propertyPicker/PropPickerResult.svelte
+++ b/frontend/src/lib/components/propertyPicker/PropPickerResult.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte'
 	import ObjectViewer from './ObjectViewer.svelte'
 
 	export let result: any
 	export let extraResults: any = undefined
 	export let flow_input: any = undefined
-
-	const dispatch = createEventDispatcher()
 </script>
 
 <div class="w-full px-2">
@@ -21,11 +18,7 @@
 	{#if flow_input}
 		<span class="font-bold text-sm">Flow Input</span>
 		<div class="overflow-y-auto w-full">
-			<ObjectViewer
-				allowCopy={false}
-				json={flow_input}
-				on:select={(e) => dispatch('select', `flow_input.${e.detail}`)}
-			/>
+			<ObjectViewer allowCopy={false} json={flow_input} prefix="flow_input" on:select />
 		</div>
 	{/if}
 </div>


### PR DESCRIPTION
Reworking the prop picker
* Before 
![image](https://github.com/user-attachments/assets/a6f40360-9a8d-46c7-b78b-1fabd6b70843)

* After 
![image](https://github.com/user-attachments/assets/3f70fd6c-6b56-4c06-95df-56ff17d74fa2)


**Main features are** :
* Polishing of the UI
* Full path popover on hover
* Copy to clipboard instead of toasting when no arg selected
* Animated button mode for connect
* Append/Insert polishing