### PR TITLE
fix: display logs in native mode when script fails

### DIFF
--- a/backend/windmill-api/src/smtp_server_ee.rs
+++ b/backend/windmill-api/src/smtp_server_ee.rs
@@ -1,1 +1,0 @@
-/Users/hugo/projects/windmill/../windmill-ee-private//windmill-api/src/smtp_server_ee.rs

--- a/backend/windmill-api/src/smtp_server_ee.rs
+++ b/backend/windmill-api/src/smtp_server_ee.rs
@@ -1,17 +1,1 @@
-use crate::{db::DB, users::AuthCache};
-use std::{net::SocketAddr, sync::Arc};
-use windmill_common::db::UserDB;
-
-pub struct SmtpServer {
-    pub auth_cache: Arc<AuthCache>,
-    pub db: DB,
-    pub user_db: UserDB,
-    pub rsmq: Option<rsmq_async::MultiplexedRsmq>,
-    pub base_internal_url: String,
-}
-
-impl SmtpServer {
-    pub async fn start_listener_thread(self: Arc<Self>, _addr: SocketAddr) -> anyhow::Result<()> {
-        Err(anyhow::anyhow!("Implementation not open source"))
-    }
-}
+/Users/hugo/projects/windmill/../windmill-ee-private//windmill-api/src/smtp_server_ee.rs

--- a/backend/windmill-api/src/smtp_server_ee.rs
+++ b/backend/windmill-api/src/smtp_server_ee.rs
@@ -1,0 +1,17 @@
+use crate::{db::DB, users::AuthCache};
+use std::{net::SocketAddr, sync::Arc};
+use windmill_common::db::UserDB;
+
+pub struct SmtpServer {
+    pub auth_cache: Arc<AuthCache>,
+    pub db: DB,
+    pub user_db: UserDB,
+    pub rsmq: Option<rsmq_async::MultiplexedRsmq>,
+    pub base_internal_url: String,
+}
+
+impl SmtpServer {
+    pub async fn start_listener_thread(self: Arc<Self>, _addr: SocketAddr) -> anyhow::Result<()> {
+        Err(anyhow::anyhow!("Implementation not open source"))
+    }
+}

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -1304,6 +1304,8 @@ try {{
                 job.args.as_ref()
             };
 
+            append_logs(&job.id, &job.workspace_id, format!("{init_logs}\n"), db).await;
+
             let result = crate::js_eval::eval_fetch_timeout(
                 env_code,
                 inner_content.clone(),
@@ -1324,14 +1326,7 @@ try {{
                 "Executed native code in {}ms",
                 started_at.elapsed().as_millis()
             );
-            append_logs(
-                &job.id,
-                &job.workspace_id,
-                format!("{}\n{}", init_logs, result.1),
-                db,
-            )
-            .await;
-            return Ok(result.0);
+            return Ok(result);
         }
     }
     append_logs(&job.id, &job.workspace_id, init_logs, db).await;

--- a/backend/windmill-worker/src/js_eval.rs
+++ b/backend/windmill-worker/src/js_eval.rs
@@ -774,7 +774,9 @@ pub async fn eval_fetch_timeout(
     w_id: &str,
     load_client: bool,
     occupation_metrics: &mut OccupancyMetrics,
-) -> anyhow::Result<(Box<RawValue>, String)> {
+) -> anyhow::Result<Box<RawValue>> {
+    use windmill_queue::append_logs;
+
     let (sender, mut receiver) = oneshot::channel::<IsolateHandle>();
 
     let parsed_args = windmill_parser_ts::parse_deno_signature(&ts_expr, true, None)?.args;
@@ -805,6 +807,8 @@ pub async fn eval_fetch_timeout(
         ));
     }
 
+    let db_ = db.clone();
+    let w_id_ = w_id.to_string();
     let result_f = tokio::task::spawn_blocking(move || {
         let ops = vec![op_get_static_args(), op_log()];
         let ext = Extension { name: "windmill", ops: ops.into(), ..Default::default() };
@@ -892,28 +896,31 @@ pub async fn eval_fetch_timeout(
             .build()?;
 
         let future = async {
-            tokio::select! {
+            let r = tokio::select! {
                 r = eval_fetch(&mut js_runtime, &js_expr, Some(env_code), load_client) => Ok(r),
                 _ = memory_limit_rx.recv() => Err(Error::ExecutionErr("Memory limit reached, killing isolate".to_string()))
-            }
+            };
+
+            append_logs(
+                &job_id,
+                w_id_.as_str(),
+                format!(
+                    "{extra_logs}{}",
+                    js_runtime.op_state().borrow().borrow::<LogString>().s
+                ),
+                db_,
+            )
+            .await;
+
+            r
         };
         let r = runtime.block_on(future)?;
         // tracing::info!("total: {:?}", instant.elapsed());
 
-        (r as anyhow::Result<Box<RawValue>>).map(|x| {
-            (
-                x,
-                js_runtime
-                    .op_state()
-                    .borrow()
-                    .borrow::<LogString>()
-                    .s
-                    .clone(),
-            )
-        })
+        r
     });
 
-    let (res, logs) = run_future_with_polling_update_job_poller(
+    let res = run_future_with_polling_update_job_poller(
         job_id,
         job_timeout,
         db,
@@ -932,7 +939,7 @@ pub async fn eval_fetch_timeout(
         e
     })?;
     *mem_peak = (res.get().len() / 1000) as i32;
-    Ok((res, format!("{extra_logs}{logs}")))
+    Ok(res)
 }
 
 #[cfg(feature = "deno_core")]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improve logging for native script failures and update `eval_fetch_timeout()` to return only results without logs.
> 
>   - **Behavior**:
>     - Append logs before returning results in `eval_fetch_timeout()` in `js_eval.rs` and `bun_executor.rs` to ensure logs are captured even if the script fails.
>     - Remove `SmtpServer` struct from `smtp_server_ee.rs`.
>   - **Functions**:
>     - `eval_fetch_timeout()` in `js_eval.rs` and `bun_executor.rs` now returns only `Box<RawValue>`.
>     - Update `do_nativets()` in `worker.rs` to reflect changes in `eval_fetch_timeout()`.
>   - **Misc**:
>     - Update `eval_fetch_timeout()` signature in `js_eval.rs` and `worker.rs` to return only `Box<RawValue>`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 0723f258dfcb8eba43ffa4f025cf873d516a687f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->