### PR TITLE
Add Python support for newspaper4k

### DIFF
--- a/backend/parsers/windmill-parser-py-imports/src/lib.rs
+++ b/backend/parsers/windmill-parser-py-imports/src/lib.rs
@@ -62,6 +62,7 @@ static PYTHON_IMPORTS_REPLACEMENT: phf::Map<&'static str, &'static str> = phf_ma
     "lokalise" => "python-lokalise-api",
     "msgraph" => "msgraph-sdk",
     "pythonjsonlogger" => "python-json-logger",
+    "newspaper" => "newspaper4k",
 };
 
 fn replace_import(x: String) -> String {


### PR DESCRIPTION
Hi there,

This PR adds support for importing the Python module [newspaper4k](https://github.com/AndyTheFactory/newspaper4k) which is loaded under the `newspaper` namespace.

I should note that newspaper4k is a fork of the popular [newspaper3k](https://github.com/codelucas/newspaper). At first I was going to add support for both but I realise this might end up in Windmill might pull in either 3k or 4k depending on list ordering or just a plain race condition.

As neat as magic loading in of libraries is, it seems a bit too magical for cases like this where you have to modify Windmill to support certain libraries. It seems like an aliasing redirect using the [comment format](https://www.windmill.dev/docs/advanced/dependencies_in_python#pinning-dependencies-and-requirements) could be neat ie; `newspaper4k as newspaper; import newspaper`

Anyway, thanks!
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Maps `newspaper` import to `newspaper4k` in `lib.rs` to avoid conflicts with `newspaper3k`.
> 
>   - **Behavior**:
>     - Maps `newspaper` import to `newspaper4k` in `PYTHON_IMPORTS_REPLACEMENT` in `lib.rs`.
>     - Ensures `newspaper4k` is used when `newspaper` is imported, avoiding conflicts with `newspaper3k`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 004fd1f0c6e9d4e013ff4ea9f2714f74cb41fe00. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->