### PR TITLE
http routes static assets nits

### DIFF
--- a/frontend/src/lib/components/triggers/RouteEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/RouteEditorInner.svelte
@@ -283,7 +283,9 @@
 						<ToggleButtonGroup
 							class="w-auto"
 							bind:selected={http_method}
-							disabled={!($userStore?.is_admin || $userStore?.is_super_admin) || !can_write}
+							disabled={!($userStore?.is_admin || $userStore?.is_super_admin) ||
+								!can_write ||
+								!!static_asset_config}
 						>
 							<ToggleButton label="GET" value="get" />
 							<ToggleButton label="POST" value="post" />
@@ -328,6 +330,7 @@
 								script_path = ''
 								initialScriptPath = ''
 								is_flow = false
+								http_method = 'get'
 							} else {
 								static_asset_config = undefined
 							}

--- a/frontend/src/routes/(root)/(logged)/routes/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/routes/+page.svelte
@@ -200,7 +200,7 @@
 			<div class="text-center text-sm text-tertiary mt-2"> No routes </div>
 		{:else if items?.length}
 			<div class="border rounded-md divide-y">
-				{#each items.slice(0, nbDisplayed) as { path, edited_by, edited_at, script_path, route_path, is_flow, extra_perms, canWrite, marked, http_method } (path)}
+				{#each items.slice(0, nbDisplayed) as { path, edited_by, edited_at, script_path, route_path, is_flow, extra_perms, canWrite, marked, http_method, static_asset_config } (path)}
 					{@const href = `${is_flow ? '/flows/get' : '/scripts/get'}/${script_path}`}
 
 					<div
@@ -228,7 +228,11 @@
 									{path}
 								</div>
 								<div class="text-secondary text-xs truncate text-left font-light">
-									runnable: {script_path}
+									{#if static_asset_config}
+										file: {static_asset_config.s3}
+									{:else}
+										runnable: {script_path}
+									{/if}
 								</div>
 							</a>
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance HTTP route handling to support static asset configurations by updating UI logic and disabling certain elements when static assets are configured.
> 
>   - **Behavior**:
>     - In `RouteEditorInner.svelte`, disable `ToggleButtonGroup` for HTTP methods if `static_asset_config` is set.
>     - Set default `http_method` to 'get' when `static_asset_config` is selected.
>     - Update display logic in `+page.svelte` to show `static_asset_config.s3` instead of `script_path` when applicable.
>   - **UI**:
>     - Add `static_asset_config` to `items` in `+page.svelte` for rendering.
>     - Update route display to conditionally show "file: {static_asset_config.s3}" or "runnable: {script_path}".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for a14579dd5649f6533c6566e419f83da8eba9f43b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->