### PR TITLE
feat(backend): move some static fields out of job tables

### DIFF
--- a/backend/.sqlx/query-202a4fee4e70ff74d150a187a8daec3609328b1e3fe6e4fac20fb6fe91ff1732.json
+++ b/backend/.sqlx/query-202a4fee4e70ff74d150a187a8daec3609328b1e3fe6e4fac20fb6fe91ff1732.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT raw_flow->'failure_module' != 'null'::jsonb\n            FROM queue_view\n            WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "?column?",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "202a4fee4e70ff74d150a187a8daec3609328b1e3fe6e4fac20fb6fe91ff1732"
+}

--- a/backend/.sqlx/query-337f31c2172194cd594042c561998a03f751b246c40daf056fced0fd91f6dd73.json
+++ b/backend/.sqlx/query-337f31c2172194cd594042c561998a03f751b246c40daf056fced0fd91f6dd73.json
@@ -1,0 +1,84 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH uuid_table as (\n            select unnest($11::uuid[]) as uuid\n        )\n        INSERT INTO queue \n            (id, script_hash, script_path, job_kind, language, args, tag, created_by, permissioned_as, email, scheduled_for, workspace_id, concurrent_limit, concurrency_time_window_s, timeout, flow_status)\n            (SELECT uuid, $1, $2, $3, $4, ('{ \"uuid\": \"' || uuid || '\" }')::jsonb, $5, $6, $7, $8, $9, $10, $12, $13, $14, $15 FROM uuid_table) \n        RETURNING id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Varchar",
+        {
+          "Custom": {
+            "name": "job_kind",
+            "kind": {
+              "Enum": [
+                "script",
+                "preview",
+                "flow",
+                "dependencies",
+                "flowpreview",
+                "script_hub",
+                "identity",
+                "flowdependencies",
+                "http",
+                "graphql",
+                "postgresql",
+                "noop",
+                "appdependencies",
+                "deploymentcallback",
+                "singlescriptflow"
+              ]
+            }
+          }
+        },
+        {
+          "Custom": {
+            "name": "script_lang",
+            "kind": {
+              "Enum": [
+                "python3",
+                "deno",
+                "go",
+                "bash",
+                "postgresql",
+                "nativets",
+                "bun",
+                "mysql",
+                "bigquery",
+                "snowflake",
+                "graphql",
+                "powershell",
+                "mssql",
+                "php",
+                "bunnative",
+                "rust",
+                "ansible"
+              ]
+            }
+          }
+        },
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Timestamptz",
+        "Varchar",
+        "UuidArray",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Jsonb"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "337f31c2172194cd594042c561998a03f751b246c40daf056fced0fd91f6dd73"
+}

--- a/backend/.sqlx/query-4996b5af348bc335a5ec14496683cee096e37bdde7bb05c11ee0c4792f70dc60.json
+++ b/backend/.sqlx/query-4996b5af348bc335a5ec14496683cee096e37bdde7bb05c11ee0c4792f70dc60.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT raw_flow AS \"raw_flow!: Json<Box<sqlx::types::JsonRawValue>>\"\n            FROM queue_view WHERE id = $1 AND workspace_id = $2 LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "raw_flow!: Json<Box<sqlx::types::JsonRawValue>>",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "4996b5af348bc335a5ec14496683cee096e37bdde7bb05c11ee0c4792f70dc60"
+}

--- a/backend/.sqlx/query-4b923c94f6adcc7a76e8073de5e46b116dba3211487c8408ce2777aafdf94a44.json
+++ b/backend/.sqlx/query-4b923c94f6adcc7a76e8073de5e46b116dba3211487c8408ce2777aafdf94a44.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO job (id, workspace_id, raw_code, raw_lock, raw_flow, tag)\n        VALUES ($1, $2, $3, $4, $5, $6)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Text",
+        "Text",
+        "Jsonb",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4b923c94f6adcc7a76e8073de5e46b116dba3211487c8408ce2777aafdf94a44"
+}

--- a/backend/.sqlx/query-4bbf4dbf5b18d8dfd62c0a029ec4deb95a348dc804ee23a02698adb9aa32b375.json
+++ b/backend/.sqlx/query-4bbf4dbf5b18d8dfd62c0a029ec4deb95a348dc804ee23a02698adb9aa32b375.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n                flow_status AS \"flow_status!: Json<Box<RawValue>>\",\n                raw_flow->'modules'->(flow_status->'step')::int AS \"module: Json<Box<RawValue>>\"\n            FROM queue_view WHERE id = $1 AND workspace_id = $2 LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "flow_status!: Json<Box<RawValue>>",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 1,
+        "name": "module: Json<Box<RawValue>>",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true,
+      null
+    ]
+  },
+  "hash": "4bbf4dbf5b18d8dfd62c0a029ec4deb95a348dc804ee23a02698adb9aa32b375"
+}

--- a/backend/.sqlx/query-63e54fe57ec439b68eead00a02209f81076c5317d590e1441b557555b4d7ad96.json
+++ b/backend/.sqlx/query-63e54fe57ec439b68eead00a02209f81076c5317d590e1441b557555b4d7ad96.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH uuid_table as (\n            select gen_random_uuid() as uuid from generate_series(1, $5)\n        )\n        INSERT INTO job\n            (id, workspace_id, raw_code, raw_lock, raw_flow)\n            (SELECT uuid, $1, $2, $3, $4 FROM uuid_table)\n        RETURNING id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Text",
+        "Text",
+        "Jsonb",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "63e54fe57ec439b68eead00a02209f81076c5317d590e1441b557555b4d7ad96"
+}

--- a/backend/.sqlx/query-6673aeb02e1c39616c6f38fd2bad841271bc08401573f4d1be8e8896cd77507b.json
+++ b/backend/.sqlx/query-6673aeb02e1c39616c6f38fd2bad841271bc08401573f4d1be8e8896cd77507b.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT raw_flow->'failure_module' != 'null'::jsonb\n            FROM completed_job_view\n            WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "?column?",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "6673aeb02e1c39616c6f38fd2bad841271bc08401573f4d1be8e8896cd77507b"
+}

--- a/backend/.sqlx/query-a0a97ad8c36356407f13e6b429d923f59d18743efc77e44abc57632252488160.json
+++ b/backend/.sqlx/query-a0a97ad8c36356407f13e6b429d923f59d18743efc77e44abc57632252488160.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT raw_flow AS \"raw_flow!: Json<Box<JsonRawValue>>\"\n        FROM completed_job_view WHERE id = $1 AND workspace_id = $2 LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "raw_flow!: Json<Box<JsonRawValue>>",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "a0a97ad8c36356407f13e6b429d923f59d18743efc77e44abc57632252488160"
+}

--- a/backend/.sqlx/query-a1a339c9e744b5661d2b4d1354e593b97b4e007fa9a499b49c3d1ebf9b645a3b.json
+++ b/backend/.sqlx/query-a1a339c9e744b5661d2b4d1354e593b97b4e007fa9a499b49c3d1ebf9b645a3b.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT raw_code, raw_lock, raw_flow AS \"raw_flow: Json<Box<JsonRawValue>>\"\n            FROM queue_view WHERE id = $1 AND workspace_id = $2 LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "raw_code",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "raw_lock",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "raw_flow: Json<Box<JsonRawValue>>",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "a1a339c9e744b5661d2b4d1354e593b97b4e007fa9a499b49c3d1ebf9b645a3b"
+}

--- a/backend/.sqlx/query-c05f21e7027a985e5a657b689a0f5bedefcaa15b7887402c0d5d33cb7b5fb362.json
+++ b/backend/.sqlx/query-c05f21e7027a985e5a657b689a0f5bedefcaa15b7887402c0d5d33cb7b5fb362.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT raw_code, raw_lock, raw_flow AS \"raw_flow: Json<Box<RawValue>>\"\n            FROM queue_view WHERE id = $1 AND workspace_id = $2 LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "raw_code",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "raw_lock",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "raw_flow: Json<Box<RawValue>>",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "c05f21e7027a985e5a657b689a0f5bedefcaa15b7887402c0d5d33cb7b5fb362"
+}

--- a/backend/.sqlx/query-e0e895527d6807699c918ca87e0b016751c9b5a1dab632dc4abdb1dd6aa1fcbc.json
+++ b/backend/.sqlx/query-e0e895527d6807699c918ca87e0b016751c9b5a1dab632dc4abdb1dd6aa1fcbc.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT raw_flow AS \"raw_flow!: Json<Box<JsonRawValue>>\"\n            FROM completed_job_view WHERE id = $1 AND workspace_id = $2 LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "raw_flow!: Json<Box<JsonRawValue>>",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "e0e895527d6807699c918ca87e0b016751c9b5a1dab632dc4abdb1dd6aa1fcbc"
+}

--- a/backend/.sqlx/query-f5c94d89eb8c86916d7c64ffa8ea2de1feecbfde74e9a1374b3668ec72d7bac1.json
+++ b/backend/.sqlx/query-f5c94d89eb8c86916d7c64ffa8ea2de1feecbfde74e9a1374b3668ec72d7bac1.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT raw_flow->'modules'->($1)::text->'value'->>'type' = 'flow' FROM queue_view WHERE id = $2 LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "?column?",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "f5c94d89eb8c86916d7c64ffa8ea2de1feecbfde74e9a1374b3668ec72d7bac1"
+}

--- a/backend/migrations/20241119062608_create_job_and_views.down.sql
+++ b/backend/migrations/20241119062608_create_job_and_views.down.sql
@@ -1,0 +1,4 @@
+-- Add down migration script here
+DROP TABLE job CASCADE;
+DROP VIEW queue_view CASCADE;
+DROP VIEW completed_job_view CASCADE;

--- a/backend/migrations/20241119062608_create_job_and_views.up.sql
+++ b/backend/migrations/20241119062608_create_job_and_views.up.sql
@@ -1,0 +1,38 @@
+-- Add up migration script here
+CREATE TABLE job (
+  id UUID PRIMARY KEY,
+  raw_code TEXT,
+  raw_lock TEXT,
+  raw_flow jsonb NULL,
+  tag VARCHAR(50),
+  workspace_id VARCHAR(50)
+);
+
+-- Create `queue_view` and `completed_job_view` views.
+DO $$
+DECLARE
+  t TEXT;
+BEGIN
+  FOR t IN VALUES ('queue'), ('completed_job') LOOP
+    EXECUTE format(
+      'CREATE OR REPLACE VIEW '||t||'_view AS
+       SELECT %s, job_logs.log_offset, job_logs.log_file_index FROM '||t||'
+       LEFT JOIN job ON '||t||'.id = job.id AND '||t||'.workspace_id = job.workspace_id
+       LEFT JOIN job_logs ON '||t||'.id = job_logs.job_id', (
+        SELECT string_agg(
+          CASE
+            WHEN column_name = 'logs' THEN -- Concatenate logs from base and job_logs.
+              'concat(coalesce('||t||'.logs, ''''), coalesce(job_logs.logs, '''')) as logs'
+            WHEN column_name IN ('raw_code', 'raw_lock', 'raw_flow') THEN -- Coalesce column from base and job.
+              format('coalesce('||t||'.%s, job.%s) as %s', column_name, column_name, column_name)
+            ELSE
+              format('%s.%s', t, column_name)
+          END,
+          ', '
+        )
+        FROM information_schema.columns
+        WHERE table_name = t
+      )
+    );
+  END LOOP;
+END $$;

--- a/backend/windmill-common/src/flows.rs
+++ b/backend/windmill-common/src/flows.rs
@@ -657,14 +657,14 @@ pub async fn has_failure_module<'c>(flow: sqlx::types::Uuid, db: &sqlx::Pool<sql
     if completed {
         sqlx::query_scalar!(
             "SELECT raw_flow->'failure_module' != 'null'::jsonb
-            FROM completed_job
+            FROM completed_job_view
             WHERE id = $1",
             flow
         )
     } else {
         sqlx::query_scalar!(
             "SELECT raw_flow->'failure_module' != 'null'::jsonb
-            FROM queue
+            FROM queue_view
             WHERE id = $1",
             flow
         )

--- a/backend/windmill-common/src/jobs.rs
+++ b/backend/windmill-common/src/jobs.rs
@@ -60,10 +60,6 @@ pub struct QueuedJob {
     pub args: Option<Json<HashMap<String, Box<RawValue>>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub logs: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub raw_code: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub raw_lock: Option<String>,
     pub canceled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub canceled_by: Option<String>,
@@ -77,8 +73,6 @@ pub struct QueuedJob {
     pub permissioned_as: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub flow_status: Option<Json<Box<RawValue>>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub raw_flow: Option<Json<Box<RawValue>>>,
     pub is_flow_step: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub language: Option<ScriptLang>,
@@ -133,14 +127,6 @@ impl QueuedJob {
         )
     }
 
-    pub fn parse_raw_flow(&self) -> Option<FlowValue> {
-        self.raw_flow.as_ref().and_then(|v| {
-            let str = (**v).get();
-            // tracing::error!("raw_flow: {}", str);
-            return serde_json::from_str::<FlowValue>(str).ok();
-        })
-    }
-
     pub fn parse_flow_status(&self) -> Option<FlowStatus> {
         self.flow_status
             .as_ref()
@@ -163,8 +149,6 @@ impl Default for QueuedJob {
             script_path: None,
             args: None,
             logs: None,
-            raw_code: None,
-            raw_lock: None,
             canceled: false,
             canceled_by: None,
             canceled_reason: None,
@@ -173,7 +157,6 @@ impl Default for QueuedJob {
             schedule_path: None,
             permissioned_as: "".to_string(),
             flow_status: None,
-            raw_flow: None,
             is_flow_step: false,
             language: None,
             same_worker: false,
@@ -216,8 +199,6 @@ pub struct CompletedJob {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub logs: Option<String>,
     pub deleted: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub raw_code: Option<String>,
     pub canceled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub canceled_by: Option<String>,
@@ -229,8 +210,6 @@ pub struct CompletedJob {
     pub permissioned_as: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub flow_status: Option<sqlx::types::Json<Box<RawValue>>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub raw_flow: Option<sqlx::types::Json<Box<RawValue>>>,
     pub is_flow_step: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub language: Option<ScriptLang>,
@@ -252,12 +231,6 @@ impl CompletedJob {
             .as_ref()
             .map(|r| serde_json::from_str(r.get()).ok())
             .flatten()
-    }
-
-    pub fn parse_raw_flow(&self) -> Option<FlowValue> {
-        self.raw_flow
-            .as_ref()
-            .and_then(|v| serde_json::from_str::<FlowValue>((**v).get()).ok())
     }
 
     pub fn parse_flow_status(&self) -> Option<FlowStatus> {

--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -91,6 +91,7 @@ lazy_static::lazy_static! {
     .unwrap_or(false);
 
     pub static ref MIN_VERSION: Arc<RwLock<Version>> = Arc::new(RwLock::new(Version::new(0, 0, 0)));
+    pub static ref MIN_VERSION_IS_AT_LEAST_1_423: Arc<RwLock<bool>> = Arc::new(RwLock::new(false));
 }
 
 pub async fn make_suspended_pull_query(wc: &WorkerConfig) {
@@ -113,10 +114,10 @@ pub async fn make_suspended_pull_query(wc: &WorkerConfig) {
                 LIMIT 1
             )
             RETURNING  id,  workspace_id,  parent_job,  created_by,  created_at,  started_at,  scheduled_for,
-            running,  script_hash,  script_path,  args,   null as logs,  raw_code,  canceled,  canceled_by,
+            running,  script_hash,  script_path,  args,   null as logs,  canceled,  canceled_by,
             canceled_reason,  last_ping,  job_kind, schedule_path,  permissioned_as,
-            flow_status,  raw_flow,  is_flow_step,  language,  suspend,  suspend_until,
-            same_worker,  raw_lock,  pre_run_error,  email,  visible_to_owner,  mem_peak,
+            flow_status,  is_flow_step,  language,  suspend,  suspend_until,
+            same_worker,  pre_run_error,  email,  visible_to_owner,  mem_peak,
              root_job,  leaf_jobs,  tag,  concurrent_limit,  concurrency_time_window_s,
              timeout,  flow_step_id,  cache_ttl, priority", wc.worker_tags.iter().map(|x| format!("'{x}'")).join(", "));
     let mut l = WORKER_SUSPENDED_PULL_QUERY.write().await;
@@ -144,10 +145,10 @@ pub async fn make_pull_query(wc: &WorkerConfig) {
             LIMIT 1
         )
         RETURNING  id,  workspace_id,  parent_job,  created_by,  created_at,  started_at,  scheduled_for,
-        running,  script_hash,  script_path,  args,  null as logs,  raw_code,  canceled,  canceled_by,
+        running,  script_hash,  script_path,  args,  null as logs,  canceled,  canceled_by,
         canceled_reason,  last_ping,  job_kind,  schedule_path,  permissioned_as,
-        flow_status,  raw_flow,  is_flow_step,  language,  suspend,  suspend_until,
-        same_worker,  raw_lock,  pre_run_error,  email,  visible_to_owner,  mem_peak,
+        flow_status,  is_flow_step,  language,  suspend,  suspend_until,
+        same_worker,  pre_run_error,  email,  visible_to_owner,  mem_peak,
          root_job,  leaf_jobs,  tag,  concurrent_limit,  concurrency_time_window_s,
          timeout,  flow_step_id,  cache_ttl, priority", tags.tags.iter().map(|x| format!("'{x}'")).join(", "));
 
@@ -586,6 +587,10 @@ pub async fn update_min_version<'c, E: sqlx::Executor<'c, Database = sqlx::Postg
 
     if min_version != cur_version {
         tracing::info!("Minimal worker version: {min_version}");
+    }
+
+    if min_version >= Version::new(1, 423, 0) {
+        *MIN_VERSION_IS_AT_LEAST_1_423.write().await = true;
     }
 
     *MIN_VERSION.write().await = min_version.clone();

--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -91,7 +91,7 @@ lazy_static::lazy_static! {
     .unwrap_or(false);
 
     pub static ref MIN_VERSION: Arc<RwLock<Version>> = Arc::new(RwLock::new(Version::new(0, 0, 0)));
-    pub static ref MIN_VERSION_IS_AT_LEAST_1_423: Arc<RwLock<bool>> = Arc::new(RwLock::new(false));
+    pub static ref MIN_VERSION_IS_AT_LEAST_1_427: Arc<RwLock<bool>> = Arc::new(RwLock::new(false));
 }
 
 pub async fn make_suspended_pull_query(wc: &WorkerConfig) {
@@ -589,8 +589,8 @@ pub async fn update_min_version<'c, E: sqlx::Executor<'c, Database = sqlx::Postg
         tracing::info!("Minimal worker version: {min_version}");
     }
 
-    if min_version >= Version::new(1, 423, 0) {
-        *MIN_VERSION_IS_AT_LEAST_1_423.write().await = true;
+    if min_version >= Version::new(1, 427, 0) {
+        *MIN_VERSION_IS_AT_LEAST_1_427.write().await = true;
     }
 
     *MIN_VERSION.write().await = min_version.clone();

--- a/backend/windmill-queue/src/jobs.rs
+++ b/backend/windmill-queue/src/jobs.rs
@@ -59,8 +59,8 @@ use windmill_common::{
     users::{SUPERADMIN_NOTIFICATION_EMAIL, SUPERADMIN_SECRET_EMAIL},
     utils::{not_found_if_none, report_critical_error, StripPath},
     worker::{
-        to_raw_value, DEFAULT_TAGS_PER_WORKSPACE, DEFAULT_TAGS_WORKSPACES, NO_LOGS, WORKER_CONFIG,
-        WORKER_PULL_QUERIES, WORKER_SUSPENDED_PULL_QUERY,
+        to_raw_value, DEFAULT_TAGS_PER_WORKSPACE, DEFAULT_TAGS_WORKSPACES, MIN_VERSION_IS_AT_LEAST_1_423,
+        NO_LOGS, WORKER_CONFIG, WORKER_PULL_QUERIES, WORKER_SUSPENDED_PULL_QUERY,
     },
     DB, METRICS_ENABLED,
 };
@@ -581,6 +581,20 @@ pub async fn add_completed_job<
         serde_json::to_string(&result).unwrap_or_else(|_| "".to_string())
     );
 
+    let (raw_code, raw_lock, raw_flow) = if !*MIN_VERSION_IS_AT_LEAST_1_423.read().await {
+        sqlx::query!(
+            "SELECT raw_code, raw_lock, raw_flow AS \"raw_flow: Json<Box<JsonRawValue>>\"
+            FROM queue_view WHERE id = $1 AND workspace_id = $2 LIMIT 1",
+            &job_id, &queued_job.workspace_id
+        )
+        .fetch_one(db)
+        .await
+        .map(|record| (record.raw_code, record.raw_lock, record.raw_flow))
+        .unwrap_or_default()
+    } else {
+        (None, None, None)
+    };
+
     let mem_peak = mem_peak.max(queued_job.mem_peak.unwrap_or(0));
     add_time!(bench, "add_completed_job query START");
     let _duration: i64 = sqlx::query_scalar!(
@@ -630,8 +644,8 @@ pub async fn add_completed_job<
         queued_job.script_path,
         &queued_job.args as &Option<Json<HashMap<String, Box<RawValue>>>>,
         result as Json<&T>,
-        queued_job.raw_code,
-        queued_job.raw_lock,
+        raw_code,
+        raw_lock,
         canceled_by.is_some(),
         canceled_by.clone().map(|cb| cb.username).flatten(),
         canceled_by.clone().map(|cb| cb.reason).flatten(),
@@ -639,7 +653,7 @@ pub async fn add_completed_job<
         queued_job.schedule_path,
         queued_job.permissioned_as,
         &queued_job.flow_status as &Option<Json<Box<RawValue>>>,
-        &queued_job.raw_flow as &Option<Json<Box<RawValue>>>,
+        &raw_flow as &Option<Json<Box<RawValue>>>,
         queued_job.is_flow_step,
         skipped,
         queued_job.language.clone() as Option<ScriptLang>,
@@ -2068,10 +2082,10 @@ async fn pull_single_job_and_mark_as_running_no_concurrency_limit<
             , suspend_until = null
             WHERE id = $1
             RETURNING  id,  workspace_id,  parent_job,  created_by,  created_at,  started_at,  scheduled_for,
-                running,  script_hash,  script_path,  args,   right(logs, 900000) as logs,  raw_code,  canceled,  canceled_by,  
+                running,  script_hash,  script_path,  args,   right(logs, 900000) as logs,  canceled,  canceled_by,  
                 canceled_reason,  last_ping,  job_kind,  schedule_path,  permissioned_as, 
-                flow_status,  raw_flow,  is_flow_step,  language,  suspend,  suspend_until,  
-                same_worker,  raw_lock,  pre_run_error,  email,  visible_to_owner,  mem_peak, 
+                flow_status,  is_flow_step,  language,  suspend,  suspend_until,  
+                same_worker,  pre_run_error,  email,  visible_to_owner,  mem_peak, 
                  root_job,  leaf_jobs,  tag,  concurrent_limit,  concurrency_time_window_s,  
                  timeout,  flow_step_id,  cache_ttl, priority",
             )
@@ -3885,6 +3899,27 @@ pub async fn push<'c, 'd, R: rsmq_async::RsmqConnection + Send + 'c>(
         None
     };
 
+    let raw_flow = raw_flow.map(Json);
+
+    sqlx::query!(
+        "INSERT INTO job (id, workspace_id, raw_code, raw_lock, raw_flow, tag)
+        VALUES ($1, $2, $3, $4, $5, $6)",
+        job_id,
+        workspace_id,
+        raw_code,
+        raw_lock,
+        raw_flow.as_ref() as Option<&Json<FlowValue>>,
+        tag,
+    )
+    .execute(&mut tx)
+    .await?;
+
+    let (raw_code, raw_lock, raw_flow) = if !*MIN_VERSION_IS_AT_LEAST_1_423.read().await {
+        (raw_code, raw_lock, raw_flow)
+    } else {
+        (None, None, None)
+    };
+
     tracing::debug!("Pushing job {job_id} with tag {tag}, schedule_path {schedule_path:?}, script_path: {script_path:?}, email {email}, workspace_id {workspace_id}");
     let uuid = sqlx::query_scalar!(
         "INSERT INTO queue
@@ -3909,7 +3944,7 @@ pub async fn push<'c, 'd, R: rsmq_async::RsmqConnection + Send + 'c>(
         Json(args) as Json<PushArgs>,
         job_kind.clone() as JobKind,
         schedule_path,
-        raw_flow.map(Json) as Option<Json<FlowValue>>,
+        raw_flow.as_ref() as Option<&Json<FlowValue>>,
         flow_status.map(Json) as Option<Json<FlowStatus>>,
         is_flow_step,
         language as Option<ScriptLang>,
@@ -4091,12 +4126,19 @@ async fn restarted_flows_resolution(
         ))
     })?;
 
-    let raw_flow = completed_job
-        .parse_raw_flow()
-        .ok_or(Error::InternalErr(format!(
-            "Unable to parse raw definition for job {} in workspace {}",
-            completed_flow_id, workspace_id,
-        )))?;
+    let raw_flow = sqlx::query_scalar!(
+        "SELECT raw_flow AS \"raw_flow!: Json<Box<JsonRawValue>>\"
+        FROM completed_job_view WHERE id = $1 AND workspace_id = $2 LIMIT 1",
+        &completed_flow_id, workspace_id
+    )
+    .fetch_one(db)
+    .await
+    .ok()
+    .and_then(|raw_flow| serde_json::from_str::<FlowValue>(raw_flow.get()).ok())
+    .ok_or(Error::InternalErr(format!(
+        "Unable to parse raw definition for job {} in workspace {}",
+        completed_flow_id, workspace_id,
+    )))?;
     let flow_status = completed_job
         .parse_flow_status()
         .ok_or(Error::InternalErr(format!(

--- a/backend/windmill-queue/src/jobs.rs
+++ b/backend/windmill-queue/src/jobs.rs
@@ -59,7 +59,7 @@ use windmill_common::{
     users::{SUPERADMIN_NOTIFICATION_EMAIL, SUPERADMIN_SECRET_EMAIL},
     utils::{not_found_if_none, report_critical_error, StripPath},
     worker::{
-        to_raw_value, DEFAULT_TAGS_PER_WORKSPACE, DEFAULT_TAGS_WORKSPACES, MIN_VERSION_IS_AT_LEAST_1_423,
+        to_raw_value, DEFAULT_TAGS_PER_WORKSPACE, DEFAULT_TAGS_WORKSPACES, MIN_VERSION_IS_AT_LEAST_1_427,
         NO_LOGS, WORKER_CONFIG, WORKER_PULL_QUERIES, WORKER_SUSPENDED_PULL_QUERY,
     },
     DB, METRICS_ENABLED,
@@ -581,7 +581,7 @@ pub async fn add_completed_job<
         serde_json::to_string(&result).unwrap_or_else(|_| "".to_string())
     );
 
-    let (raw_code, raw_lock, raw_flow) = if !*MIN_VERSION_IS_AT_LEAST_1_423.read().await {
+    let (raw_code, raw_lock, raw_flow) = if !*MIN_VERSION_IS_AT_LEAST_1_427.read().await {
         sqlx::query!(
             "SELECT raw_code, raw_lock, raw_flow AS \"raw_flow: Json<Box<JsonRawValue>>\"
             FROM queue_view WHERE id = $1 AND workspace_id = $2 LIMIT 1",
@@ -3914,7 +3914,7 @@ pub async fn push<'c, 'd, R: rsmq_async::RsmqConnection + Send + 'c>(
     .execute(&mut tx)
     .await?;
 
-    let (raw_code, raw_lock, raw_flow) = if !*MIN_VERSION_IS_AT_LEAST_1_423.read().await {
+    let (raw_code, raw_lock, raw_flow) = if !*MIN_VERSION_IS_AT_LEAST_1_427.read().await {
         (raw_code, raw_lock, raw_flow)
     } else {
         (None, None, None)

--- a/backend/windmill-worker/src/worker_lockfiles.rs
+++ b/backend/windmill-worker/src/worker_lockfiles.rs
@@ -204,6 +204,7 @@ pub fn extract_relative_imports(
 #[tracing::instrument(level = "trace", skip_all)]
 pub async fn handle_dependency_job<R: rsmq_async::RsmqConnection + Send + Sync + Clone>(
     job: &QueuedJob,
+    raw_code: Option<String>,
     mem_peak: &mut i32,
     canceled_by: &mut Option<CanceledBy>,
     job_dir: &str,
@@ -215,8 +216,8 @@ pub async fn handle_dependency_job<R: rsmq_async::RsmqConnection + Send + Sync +
     rsmq: Option<R>,
     occupancy_metrics: &mut OccupancyMetrics,
 ) -> error::Result<Box<RawValue>> {
-    let raw_code = match job.raw_code {
-        Some(ref code) => code.to_owned(),
+    let raw_code = match raw_code {
+        Some(code) => code,
         None => sqlx::query_scalar!(
             "SELECT content FROM script WHERE hash = $1 AND workspace_id = $2",
             &job.script_hash.unwrap_or(ScriptHash(0)).0,
@@ -527,6 +528,7 @@ async fn trigger_dependents_to_recompute_dependencies<
 
 pub async fn handle_flow_dependency_job<R: rsmq_async::RsmqConnection + Send + Sync + Clone>(
     job: &QueuedJob,
+    raw_flow: Option<Json<Box<RawValue>>>,
     mem_peak: &mut i32,
     canceled_by: &mut Option<CanceledBy>,
     job_dir: &str,
@@ -570,7 +572,7 @@ pub async fn handle_flow_dependency_job<R: rsmq_async::RsmqConnection + Send + S
         )
     };
 
-    let raw_flow = job.raw_flow.clone().map(|v| Ok(v)).unwrap_or_else(|| {
+    let raw_flow = raw_flow.map(|v| Ok(v)).unwrap_or_else(|| {
         Err(Error::InternalErr(
             "Flow Dependency requires raw flow".to_owned(),
         ))


### PR DESCRIPTION
This change aims to reduce the row size of the `queue` and `completed_job` tables by migrating "persistent" columns (i.e., columns not directly associated with runtime status) to a new shared `job` table. Both queued and completed jobs will reference this table, leading to significantly faster updates on the `queue` table.

## Backward compatibility

- **Database integrity**: Original columns from `queue` and `completed_job` are left in place but will remains empty after the upgrade in complete.

- **Handling Legacy Workers**: After the upgrade, legacy workers (those running a previous version of the codebase) may still be operational. To maintain compatibility, the migrated columns will continue to be inserted into the `queue` table until all workers are updated ([Reference: windmill-queue/src/jobs.rs#584](https://github.com/windmill-labs/windmill/pull/4689/files#diff-906910f106d16370529d12f9a05a23156ea1596ef3dee27518c8566476f54ce4R584)).
  
- **Support for Pre-Upgrade Jobs**: Completed jobs from before the update and queued jobs created by legacy workers may still exist. To address this, two `VIEW`s (`queue_view` and `completed_job_view`) have been added ([Reference: `queue_view` and `completed_job_view`](https://github.com/windmill-labs/windmill/pull/4689/files#diff-d991cb17730689c31489899e8e893e10ce7b5805f1058be29621e7dbe4e078bbR11)). Queries targeting the migrated columns are now routed through these views, which seamlessly retrieve data from the appropriate tables ([Reference: windmill-api/src/jobs.rs#685](https://github.com/windmill-labs/windmill/pull/4689/files#diff-55e9fc649a3fd37067faf6745654be78d1de1ac45ae778a58f7d65a167eaa382R685)).

The pinned version for this change is `1.427.0` right now, it must be [updated](https://github.com/windmill-labs/windmill/pull/4689/files#diff-ee79b848bc9b4eaf896a014db630cc35a767c4a6e48ee72af74b6e1b4efb5d88R592) if `1.427.0` is tagged without this change.

## Benchmarks

Performance benchmarks demonstrate substantial improvements when processing large raw scripts or executing complex workflows.

## Open questions

- Deleting from `completed_job` do not really delete the row, hence `job` rows exists forever. Also, the response on "delete" does not contains the moved columns **but** they does not seems to be used by the frontend.

- `VIEW`s where used where fallback queries could have been used instead, the performance impact of using views has been measured to be negligible, but we may still want to remove them in the future. 