### PR TITLE
ts client s3 upload add content type/disposition

### DIFF
--- a/typescript-client/client.ts
+++ b/typescript-client/client.ts
@@ -706,7 +706,9 @@ export async function loadS3FileStream(
 export async function writeS3File(
   s3object: S3Object | undefined,
   fileContent: string | Blob,
-  s3ResourcePath: string | undefined = undefined
+  s3ResourcePath: string | undefined = undefined,
+  contentType: string | undefined = undefined,
+  contentDisposition: string | undefined = undefined
 ): Promise<S3Object> {
   let fileContentBlob: Blob;
   if (typeof fileContent === "string") {
@@ -724,6 +726,8 @@ export async function writeS3File(
     s3ResourcePath: s3ResourcePath,
     requestBody: fileContentBlob,
     storage: s3object?.storage,
+    contentType,
+    contentDisposition,
   });
   return {
     s3: response.file_key,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `contentType` and `contentDisposition` parameters to `writeS3File` in `client.ts` for S3 uploads.
> 
>   - **Functionality**:
>     - `writeS3File` in `client.ts` now accepts `contentType` and `contentDisposition` as optional parameters.
>     - These parameters are passed to `HelpersService.fileUpload` to set metadata for S3 uploads.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 139d6df1e5dac0b508f101b234ffebf3d5192525. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->