### PR TITLE
nit: generalize usage of `has_failure_module`

### DIFF
--- a/backend/windmill-common/src/flows.rs
+++ b/backend/windmill-common/src/flows.rs
@@ -16,6 +16,7 @@ use rand::Rng;
 use serde::{Deserialize, Serialize, Serializer};
 
 use crate::{
+    error::Error,
     more_serde::{default_empty_string, default_id, default_null, default_true, is_default},
     scripts::{Schema, ScriptHash, ScriptLang},
 };
@@ -650,4 +651,30 @@ pub fn add_virtual_items_if_necessary(modules: &mut Vec<FlowModule>) {
             skip_if: None,
         });
     }
+}
+
+pub async fn has_failure_module<'c>(flow: sqlx::types::Uuid, db: &sqlx::Pool<sqlx::Postgres>, completed: bool) -> Result<bool, Error> {
+    if completed {
+        sqlx::query_scalar!(
+            "SELECT raw_flow->'failure_module' != 'null'::jsonb
+            FROM completed_job
+            WHERE id = $1",
+            flow
+        )
+    } else {
+        sqlx::query_scalar!(
+            "SELECT raw_flow->'failure_module' != 'null'::jsonb
+            FROM queue
+            WHERE id = $1",
+            flow
+        )
+    }
+    .fetch_one(db)
+    .await
+    .map_err(|e| {
+        Error::InternalErr(format!(
+            "error during retrieval of has_failure_module: {e:#}"
+        ))
+    })
+    .map(|v| v.unwrap_or(false))
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Generalize `has_failure_module` function for better code reuse across modules by refactoring its usage in `jobs.rs` and `worker_flow.rs`.
> 
>   - **Functionality**:
>     - Generalize `has_failure_module` function to handle both `completed_job` and `queue` tables based on `completed` flag in `flows.rs`.
>   - **Refactoring**:
>     - Remove `RawFlowFailureModule` struct and related logic in `jobs.rs`.
>     - Replace inline failure module checks with `has_failure_module` in `jobs.rs` and `worker_flow.rs`.
>   - **Imports**:
>     - Add import for `has_failure_module` in `jobs.rs` and `worker_flow.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for c1c06d553f5c5179b137fd9de9e46a8f0eb40b7a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->