### PR TITLE
if CLOUD_HOSTED and workspace_id set, autoacknowledge for superadmin

### DIFF
--- a/backend/windmill-common/src/utils.rs
+++ b/backend/windmill-common/src/utils.rs
@@ -276,7 +276,7 @@ pub async fn report_critical_error(
     // we ack_global if mute_global is true, or if mute_workspace is true
     // but we ignore global mute setting for ack_workspace
     let acknowledge_workspace = mute_workspace;
-    let acknowledge_global = mute_global || mute_workspace;
+    let acknowledge_global = mute_global || mute_workspace || ( workspace_id.is_some() && *CLOUD_HOSTED);
 
     if let Err(err) = sqlx::query!(
         "INSERT INTO alerts (alert_type, message, acknowledged, acknowledged_workspace, workspace_id, resource)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `report_critical_error` in `utils.rs` to auto-acknowledge global alerts if `workspace_id` is set and `CLOUD_HOSTED` is true.
> 
>   - **Behavior**:
>     - In `report_critical_error` in `utils.rs`, modify `acknowledge_global` to include condition `(workspace_id.is_some() && *CLOUD_HOSTED)`.
>     - This ensures global acknowledgment if `workspace_id` is set and `CLOUD_HOSTED` is true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for ba5576c741f0fe2022348bbb2d2281a3f71728db. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->