### PR TITLE
Result node message

### DIFF
--- a/frontend/src/lib/components/flows/content/FlowEditorPanel.svelte
+++ b/frontend/src/lib/components/flows/content/FlowEditorPanel.svelte
@@ -62,7 +62,7 @@
 {:else if $selectedId === 'Input'}
 	<FlowInput {noEditor} disabled={disabledFlowInputs} />
 {:else if $selectedId === 'Result'}
-	<p class="p-4 text-secondary">Nothing to show about the result node. Happy flow building!</p>
+	<p class="p-4 text-secondary">Result of the flow will be the result of the last node.</p>
 {:else if $selectedId === 'constants'}
 	<FlowConstants {noEditor} />
 {:else if $selectedId === 'failure'}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "windmill",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update message for 'Result' node in `FlowEditorPanel.svelte` to clarify its purpose.
> 
>   - **UI Text Update**:
>     - In `FlowEditorPanel.svelte`, updated the message for the 'Result' node from "Nothing to show about the result node. Happy flow building!" to "Result of the flow will be the result of the last node."
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 40674253424c2af38fea575ae9117a1250a4b174. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->