### PR TITLE
cloud_hosted non ee scope

### DIFF
--- a/backend/windmill-common/src/utils.rs
+++ b/backend/windmill-common/src/utils.rs
@@ -32,7 +32,6 @@ pub const GIT_VERSION: &str =
 use crate::CRITICAL_ALERT_MUTE_UI_ENABLED;
 use std::sync::atomic::Ordering;
 
-#[cfg(feature = "enterprise")]
 use crate::worker::CLOUD_HOSTED;
 
 lazy_static::lazy_static! {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removed `#[cfg(feature = "enterprise")]` from `use crate::worker::CLOUD_HOSTED;` in `utils.rs`.
> 
>   - **Code Simplification**:
>     - Removed `#[cfg(feature = "enterprise")]` attribute from `use crate::worker::CLOUD_HOSTED;` in `utils.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 099d9eb748009d30e0cb37655da34f631a5623b6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->