### PR TITLE
Fix ignore confirmation modal if no changes

### DIFF
--- a/frontend/src/lib/components/common/confirmationModal/UnsavedConfirmationModal.svelte
+++ b/frontend/src/lib/components/common/confirmationModal/UnsavedConfirmationModal.svelte
@@ -4,7 +4,12 @@
 	import { goto as gotoUrl } from '$app/navigation'
 	import Button from '../button/Button.svelte'
 	import type DiffDrawer from '$lib/components/DiffDrawer.svelte'
-	import { cleanValueProperties, orderedJsonStringify, type Value } from '$lib/utils'
+	import {
+		cleanValueProperties,
+		orderedJsonStringify,
+		replaceFalseWithUndefined,
+		type Value
+	} from '$lib/utils'
 	import { tick } from 'svelte'
 	import { page } from '$app/stores'
 
@@ -36,7 +41,10 @@
 					path: undefined
 				})
 				const current = cleanValueProperties({ ...(modifiedValue ?? {}), path: undefined })
-				if (orderedJsonStringify(draftOrDeployed) === orderedJsonStringify(current)) {
+				if (
+					orderedJsonStringify(replaceFalseWithUndefined(draftOrDeployed)) ===
+					orderedJsonStringify(replaceFalseWithUndefined(current))
+				) {
 					bypassBeforeNavigate = true
 					gotoUrl(goingTo)
 				} else {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `UnsavedConfirmationModal.svelte` to prevent confirmation modal if no changes by using `replaceFalseWithUndefined`.
> 
>   - **Behavior**:
>     - Modify `UnsavedConfirmationModal.svelte` to prevent confirmation modal if no changes.
>     - Use `replaceFalseWithUndefined` in `orderedJsonStringify` comparison to handle false values as undefined.
>   - **Utils**:
>     - Add `replaceFalseWithUndefined` to `utils` imports in `UnsavedConfirmationModal.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for b11a51af18fc4fc82d0e9a46fcf0b5be9ad67065. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->