### PR TITLE
revert bool to text support in  pg

### DIFF
--- a/backend/windmill-worker/src/pg_executor.rs
+++ b/backend/windmill-worker/src/pg_executor.rs
@@ -547,7 +547,6 @@ fn convert_val(
             "text" | "varchar" => Ok(Box::new(None::<String>)),
             _ => Err(anyhow::anyhow!("Unsupported JSON null type"))?,
         },
-        Value::Bool(s) if arg_t == "text" || arg_t == "varchar" => Ok(Box::new(s.to_string())),
         Value::Bool(b) => Ok(Box::new(b.clone())),
         Value::Number(n) if matches!(typ, Typ::Str(_)) => Ok(Box::new(n.to_string())),
         Value::Number(n) if arg_t == "char" && n.is_i64() => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reverts support for converting `Value::Bool` to `text` or `varchar` in `convert_val()` in `pg_executor.rs`.
> 
>   - **Behavior**:
>     - Reverts support for converting `Value::Bool` to `text` or `varchar` in `convert_val()` in `pg_executor.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 7f0435ec218cc5a71414bef728714a4541950c60. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->