### PR TITLE
fix: improve flow status viewer iteration picker

### DIFF
--- a/frontend/src/lib/components/common/menu/MenuV2.svelte
+++ b/frontend/src/lib/components/common/menu/MenuV2.svelte
@@ -18,7 +18,7 @@
 	})
 </script>
 
-<Menu let:open as="div" class="relative hover:z-50 flex w-full h-8">
+<Menu  let:open as="div" class="relative hover:z-50 flex w-full h-8">
 	<ResolveOpen {open} on:open on:close />
 	<div use:floatingRef class="w-full">
 		<MenuButton class={twMerge('w-full', justifyEnd ? 'flex justify-end' : '')}>

--- a/frontend/src/lib/components/flows/content/FlowInputsQuick.svelte
+++ b/frontend/src/lib/components/flows/content/FlowInputsQuick.svelte
@@ -217,7 +217,7 @@
 			{#if ['script', 'trigger', 'approval', 'preprocessor', 'failure'].includes(selectedKind)}
 				{#if (preFilter === 'all' && owners.length > 0) || preFilter === 'workspace'}
 					{#if preFilter !== 'workspace'}
-						<div class="pb-0 text-2xs font-light text-secondary ml-2">Workspace Folders</div>
+						<div class="pb-0 text-2xs font-light text-secondary ml-2">Folders</div>
 					{/if}
 
 					{#if owners.length > 0}

--- a/frontend/src/lib/components/flows/map/FlowJobsMenu.svelte
+++ b/frontend/src/lib/components/flows/map/FlowJobsMenu.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
 	import Menu from '$lib/components/common/menu/MenuV2.svelte'
 	import { createEventDispatcher } from 'svelte'
-	import { ListFilter } from 'lucide-svelte'
+	import { ListFilter, Lock, LockOpen } from 'lucide-svelte'
 	import { MenuItem } from '@rgossiaux/svelte-headlessui'
 
 	const dispatch = createEventDispatcher()
 
-	export let index: number
+	export let id: string
 	export let flowJobs: string[] | undefined
 	export let flowJobsSuccess: (boolean | undefined)[] | undefined
 	export let selected: number
+	export let selectedManually: boolean | undefined
 
 	let filter: number | undefined = undefined
 	function onKeydown(event: KeyboardEvent) {
@@ -21,16 +22,34 @@
 			filter > 0
 		) {
 			event.preventDefault()
-			dispatch('selectedIteration', { index: filter - 1, id: flowJobs[filter - 1] })
+			dispatch('selectedIteration', { index: filter - 1, id: flowJobs[filter - 1], manuallySet: true })
 		}
 	}
+
+	let buttonHover = false
 </script>
 
-<Menu maxHeight={300}>
+{#if selectedManually}
+	<!-- svelte-ignore a11y-click-events-have-key-events -->
+	<!-- svelte-ignore a11y-no-static-element-interactions -->
+	<div title="Iteration picked from new subflow runs automatically" on:mouseenter={() => (buttonHover = true)} on:mouseleave={() => (buttonHover = false)} on:click={(e) => {
+			buttonHover = false
+			dispatch('selectedIteration', { manuallySet: false })}
+		} 
+		class="absolute top-1.5 right-12 cursor-pointer">
+		{#if buttonHover}
+			<LockOpen class="text-primary" size={14} />
+		{:else}
+			<Lock class="text-primary" size={12} />
+		{/if}
+	</div>
+{/if}
+
+<Menu  maxHeight={300}>
 	<div slot="trigger">
 		<button
 			title="Pick an iteration"
-			id={`flow-editor-iteration picker-${index}`}
+			id={`flow-editor-iteration picker-${id}`}
 			type="button"
 			class=" text-xs bg-surface border-[1px] border-gray-300 dark:border-gray-500 focus:outline-none
 		hover:bg-surface-hover focus:ring-4 focus:ring-surface-selected font-medium rounded-sm w-[40px] gap-1 h-[20px]
@@ -42,6 +61,7 @@
 			<ListFilter size={15} />
 		</button>
 	</div>
+
 	<MenuItem disabled>
 		<input type="number" bind:value={filter} on:keydown={onKeydown} />
 	</MenuItem>
@@ -56,7 +76,7 @@
 						: ''}"
 					on:pointerdown={() => {
 						//close()
-						dispatch('selectedIteration', { index: idx, id })
+						dispatch('selectedIteration', { index: idx, id, manuallySet: true })
 					}}
 					role="menuitem"
 					tabindex="-1"

--- a/frontend/src/lib/components/flows/map/MapItem.svelte
+++ b/frontend/src/lib/components/flows/map/MapItem.svelte
@@ -17,16 +17,14 @@
 	export let insertable: boolean
 	export let annotation: string | undefined = undefined
 	export let bgColor: string = ''
-	export let modules: FlowModule[]
 	export let moving: string | undefined = undefined
 	export let duration_ms: number | undefined = undefined
 
 	export let retries: number | undefined = undefined
 	export let flowJobs:
-		| { flowJobs: string[]; selected: number; flowJobsSuccess: (boolean | undefined)[] }
+		| { flowJobs: string[]; selected: number; flowJobsSuccess: (boolean | undefined)[], selectedManually: boolean | undefined }
 		| undefined
 
-	$: idx = modules.findIndex((m) => m.id === mod.id)
 
 	const { selectedId } = getContext<{ selectedId: Writable<string> }>('FlowGraphContext')
 	const dispatch = createEventDispatcher<{
@@ -83,13 +81,14 @@
 		{#if flowJobs && !insertable && (mod.value.type === 'forloopflow' || mod.value.type === 'whileloopflow')}
 			<div class="absolute right-8 z-50 -top-5">
 				<FlowJobsMenu
+					id={mod.id}
 					on:selectedIteration={(e) => {
 						dispatch('selectedIteration', e.detail)
 					}}
 					flowJobsSuccess={flowJobs.flowJobsSuccess}
 					flowJobs={flowJobs.flowJobs}
 					selected={flowJobs.selected}
-					index={idx}
+					selectedManually={flowJobs.selectedManually}
 				/>
 			</div>
 		{/if}

--- a/frontend/src/lib/components/graph/model.ts
+++ b/frontend/src/lib/components/graph/model.ts
@@ -53,6 +53,7 @@ export type GraphModuleState = {
 	parent_module?: string
 	selectedForloop?: string
 	selectedForloopIndex?: number
+	selectedForLoopSetManually?: boolean
 	flow_jobs_success?: (boolean | undefined)[]
 	flow_jobs?: string[]
 	iteration_total?: number

--- a/frontend/src/lib/components/graph/renderers/nodes/BranchOneStart.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/BranchOneStart.svelte
@@ -26,6 +26,7 @@
 		'branchone',
 		data.flowModuleStates?.[data.id]
 	)
+	
 </script>
 
 <NodeWrapper let:darkMode offset={data.offset}>

--- a/frontend/src/lib/components/graph/renderers/nodes/ForLoopStartNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/ForLoopStartNode.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import VirtualItem from '$lib/components/flows/map/VirtualItem.svelte'
 	import NodeWrapper from './NodeWrapper.svelte'
-	import type { FlowModule } from '$lib/gen'
+	import type { FlowModule, FlowStatusModule } from '$lib/gen'
 	import { getStateColor } from '../../util'
 	import type { GraphModuleState } from '../../model'
 	import type { GraphEventHandlers } from '../../graphBuilder'
@@ -26,7 +26,17 @@
 		if (!inputJson || typeof inputJson !== 'object' || !inputJson.iter) return {}
 		return { iter: inputJson.iter }
 	}
+
+	function computeStatus(state: GraphModuleState | undefined): FlowStatusModule["type"] | undefined {
+		if (state?.type == 'InProgress' || state?.type == 'Success' || state?.type == 'Failure') {
+			let r = state?.flow_jobs_success?.[state?.selectedForloopIndex ?? 0] 
+			if (r == undefined) return 'InProgress'
+			return r ? 'Success' : 'InProgress'
+		}
+	}
 </script>
+
+
 
 <NodeWrapper let:darkMode offset={data.offset}>
 	<VirtualItem
@@ -36,7 +46,7 @@
 		id={data.id}
 		hideId
 		bgColor={getStateColor(undefined, darkMode)}
-		borderColor={getStateColor(data.flowModuleStates?.[data.id]?.type, darkMode)}
+		borderColor={getStateColor(computeStatus(data.flowModuleStates?.[data.id]), darkMode)}
 		on:select={(e) => {
 			data?.eventHandlers?.select(e.detail)
 		}}

--- a/frontend/src/lib/components/graph/renderers/nodes/ModuleNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/ModuleNode.svelte
@@ -38,12 +38,14 @@
 		? {
 				flowJobs: state?.flow_jobs,
 				selected: state?.selectedForloopIndex ?? -1,
+				selectedManually: state?.selectedForLoopSetManually,
 				flowJobsSuccess: state?.flow_jobs_success
 		  }
 		: (undefined as any)
 
-	let selectedIteration = -1
 </script>
+
+
 
 <NodeWrapper offset={data.offset} let:darkMode>
 	{#if data.module.value.type == 'flow'}
@@ -65,12 +67,11 @@
 		annotation={flowJobs &&
 		(data.module.value.type === 'forloopflow' || data.module.value.type === 'whileloopflow')
 			? 'Iteration: ' +
-			  (selectedIteration >= 0 ? selectedIteration : state?.flow_jobs?.length) +
+			  ((state?.selectedForloopIndex ?? 0) >= 0 ? (state?.selectedForloopIndex ?? 0) + 1 : state?.flow_jobs?.length) +
 			  '/' +
 			  (state?.iteration_total ?? '?')
 			: ''}
 		bgColor={getStateColor(type, darkMode, true, state?.skipped)}
-		modules={data.modules ?? []}
 		moving={data.moving}
 		duration_ms={state?.duration_ms}
 		retries={data.retries}
@@ -94,7 +95,6 @@
 			data.eventHandlers.select(e.detail)
 		}}
 		on:selectedIteration={(e) => {
-			selectedIteration = e.detail.index + 1
 			data.eventHandlers.selectedIteration(e.detail, data.module.id)
 		}}
 	/>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improved iteration picker in Flow Status Viewer to handle manual selection for loop flows, updated UI components, and adjusted graph rendering logic.
> 
>   - **Behavior**:
>     - Improved iteration picker in `FlowStatusViewerInner.svelte` to handle manual selection of iterations for for-loop and while-loop flows.
>     - Added `selectedForLoopSetManually` to `GraphModuleState` to track manual iteration selection.
>     - Updated `setIteration()` in `FlowStatusViewerInner.svelte` to handle manual selection logic.
>   - **UI Components**:
>     - Updated `FlowJobsMenu.svelte` to display lock icon when iteration is manually selected and allow toggling.
>     - Modified `MenuV2.svelte` to adjust menu behavior and styling.
>     - Changed `FlowInputsQuick.svelte` to update folder label.
>   - **Graph Rendering**:
>     - Updated `ForLoopStartNode.svelte` to compute status based on selected iteration success.
>     - Adjusted `ModuleNode.svelte` to include manual selection state in flow jobs.
>   - **Misc**:
>     - Removed unused `globalRefreshes` and `recursiveRefresh` logic from `FlowStatusViewerInner.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for d0448ac838b9ab8033fd73fcb05d0e924a179144. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->