### PR TITLE
proposal: wait for a complete upgrade before doing anything

### DIFF
--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -51,7 +51,7 @@ use windmill_common::{
     utils::{now_from_db, rd_string, report_critical_error, Mode},
     worker::{
         load_worker_config, make_pull_query, make_suspended_pull_query, reload_custom_tags_setting,
-        update_min_version, DEFAULT_TAGS_PER_WORKSPACE, DEFAULT_TAGS_WORKSPACES, SMTP_CONFIG,
+        DEFAULT_TAGS_PER_WORKSPACE, DEFAULT_TAGS_WORKSPACES, SMTP_CONFIG,
         WORKER_CONFIG, WORKER_GROUP,
     },
     BASE_URL, CRITICAL_ALERT_MUTE_UI_ENABLED, CRITICAL_ERROR_CHANNELS, DB, DEFAULT_HUB_BASE_URL,
@@ -1087,10 +1087,6 @@ pub async fn monitor_db(
         }
     };
 
-    let update_min_worker_version_f = async {
-        update_min_version(db).await;
-    };
-
     join!(
         expired_items_f,
         zombie_jobs_f,
@@ -1099,7 +1095,6 @@ pub async fn monitor_db(
         worker_groups_alerts_f,
         jobs_waiting_alerts_f,
         apply_autoscaling_f,
-        update_min_worker_version_f,
     );
 }
 

--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -2,7 +2,6 @@ use anyhow::anyhow;
 use const_format::concatcp;
 use itertools::Itertools;
 use regex::Regex;
-use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 use std::{
@@ -89,8 +88,6 @@ lazy_static::lazy_static! {
     .ok()
     .and_then(|x| x.parse::<bool>().ok())
     .unwrap_or(false);
-
-    pub static ref MIN_VERSION: Arc<RwLock<Version>> = Arc::new(RwLock::new(Version::new(0, 0, 0)));
 }
 
 pub async fn make_suspended_pull_query(wc: &WorkerConfig) {
@@ -585,10 +582,9 @@ pub async fn update_min_version<'c, E: sqlx::Executor<'c, Database = sqlx::Postg
         .unwrap_or_else(|| cur_version.clone());
 
     if min_version != cur_version {
-        tracing::info!("Minimal worker version: {min_version}");
+        tracing::info!("Minimal worker version: {min_version} (current: {cur_version})");
     }
 
-    *MIN_VERSION.write().await = min_version.clone();
     min_version >= cur_version
 }
 


### PR DESCRIPTION
## Proposal

To simplify future changes where handling living workers in a previous codebase version could be a bit tricky, I propose to wait for a complete upgrade **before** doing anything else.

With this change, the main will block until all workers are either dead or at the latest version.

## Cons

- I dont fully understand the repercussions nor implications of such change, so I'm not well suited to even make sure this is doable.
- This can be tricky to handle from the user POV, some support may be needed to smoothly land such radical change.

## Pros

- Future breaking changes to the codebase will be much easier to handle.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add blocking mechanism in `main.rs` to ensure all workers are updated to the latest version before proceeding with operations.
> 
>   - **Behavior**:
>     - In `main.rs`, added a loop to block execution until all workers are updated to the latest version using `update_min_version()`.
>     - Removed redundant `update_min_version()` call in `monitor_db()` in `monitor.rs`.
>   - **Functions**:
>     - `update_min_version()` in `worker.rs` checks for worker version discrepancies and returns a boolean indicating if all workers are up-to-date.
>   - **Misc**:
>     - Minor logging changes in `worker.rs` to include current and minimal worker versions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 02baed896aa851992ee52c18c31c03b678119481. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->