### PR TITLE
list input z-index nit

### DIFF
--- a/frontend/src/lib/components/LightweightArgInput.svelte
+++ b/frontend/src/lib/components/LightweightArgInput.svelte
@@ -327,6 +327,7 @@
 									options={itemsType?.multiselect ?? []}
 									selectedOptionsDraggable={true}
 									{disabled}
+									--sms-open-z-index={20}
 								/>
 							</div>
 						{:else if Array.isArray(itemsType?.enum) && Array.isArray(value)}
@@ -337,6 +338,7 @@
 									options={itemsType?.enum ?? []}
 									selectedOptionsDraggable={true}
 									{disabled}
+									--sms-open-z-index={20}
 								/>
 							</div>
 						{:else if Array.isArray(enum_) && Array.isArray(value)}
@@ -347,6 +349,7 @@
 									options={enum_ ?? []}
 									selectedOptionsDraggable={true}
 									{disabled}
+									--sms-open-z-index={20}
 								/>
 							</div>
 						{:else}

--- a/frontend/src/lib/components/multiselect/MultiSelect.svelte
+++ b/frontend/src/lib/components/multiselect/MultiSelect.svelte
@@ -687,7 +687,7 @@
 	:where(div.multiselect.open) {
 		/* increase z-index when open to ensure the dropdown of one <MultiSelect />
     displays above that of another slightly below it on the page */
-		z-index: var(--sms-open-z-index, 20);
+		z-index: var(--sms-open-z-index, 4);
 	}
 	:where(div.multiselect:focus-within) {
 		border: var(--sms-focus-border, 1pt solid var(--sms-active-color, cornflowerblue));


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjust z-index for `MultiSelect` dropdowns in `LightweightArgInput.svelte` and `MultiSelect.svelte` to ensure proper stacking order.
> 
>   - **Behavior**:
>     - Adjusts z-index for `MultiSelect` dropdown in `MultiSelect.svelte` from 20 to 4 to ensure proper stacking order.
>     - Applies z-index adjustment in `LightweightArgInput.svelte` for `Multiselect` components in three conditional blocks.
>   - **Files**:
>     - `LightweightArgInput.svelte`: Sets `--sms-open-z-index` to 20 for `Multiselect` components.
>     - `MultiSelect.svelte`: Changes default z-index to 4 for open dropdowns.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 0eec4609c69a290c03477eec855a41d3fba83a2b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->