### PR TITLE
backend: garbage collect `job` table + delete leaked ones

### DIFF
--- a/backend/.sqlx/query-02424907504848e983bfa89eec343061932dc5b4b17cf13d5cf8d833aedbe6d5.json
+++ b/backend/.sqlx/query-02424907504848e983bfa89eec343061932dc5b4b17cf13d5cf8d833aedbe6d5.json
@@ -5,7 +5,7 @@
     "columns": [
       {
         "ordinal": 0,
-        "name": "bool",
+        "name": "?column?",
         "type_info": "Bool"
       }
     ],

--- a/backend/.sqlx/query-661f472ff3860983322162420457f5033b9c9afc344d9c3e385ba20a3ad2197a.json
+++ b/backend/.sqlx/query-661f472ff3860983322162420457f5033b9c9afc344d9c3e385ba20a3ad2197a.json
@@ -5,7 +5,7 @@
     "columns": [
       {
         "ordinal": 0,
-        "name": "bool",
+        "name": "?column?",
         "type_info": "Bool"
       }
     ],

--- a/backend/.sqlx/query-803b9c1373541cf52f416cde9e9e99ab79072e21dfaafb498aac25a059bd2f30.json
+++ b/backend/.sqlx/query-803b9c1373541cf52f416cde9e9e99ab79072e21dfaafb498aac25a059bd2f30.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM job WHERE id = ANY($1)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "803b9c1373541cf52f416cde9e9e99ab79072e21dfaafb498aac25a059bd2f30"
+}

--- a/backend/migrations/20241121071235_gc_jobs.down.sql
+++ b/backend/migrations/20241121071235_gc_jobs.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+-- Nothing to do here

--- a/backend/migrations/20241121071235_gc_jobs.up.sql
+++ b/backend/migrations/20241121071235_gc_jobs.up.sql
@@ -1,0 +1,4 @@
+-- Add up migration script here
+DELETE FROM job
+WHERE NOT EXISTS (SELECT 1 FROM completed_job WHERE completed_job.id = job.id)
+  AND NOT EXISTS (SELECT 1 FROM queue WHERE queue.id = job.id);

--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -686,6 +686,15 @@ pub async fn delete_expired_items(db: &DB) -> () {
                             {
                                 tracing::error!("Error deleting log file: {:?}", e);
                             }
+                            if let Err(e) = sqlx::query!(
+                                "DELETE FROM job WHERE id = ANY($1)",
+                                &deleted_jobs
+                            )
+                            .execute(&mut *tx)
+                            .await
+                            {
+                                tracing::error!("Error deleting job: {:?}", e);
+                            }
                         }
                     }
                     Err(e) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds garbage collection for `job` table by deleting unreferenced entries and updates related SQL queries and enums.
> 
>   - **Behavior**:
>     - Adds SQL migration `gc_jobs.up.sql` to delete `job` entries not in `completed_job` or `queue`.
>     - Updates `delete_expired_items()` in `monitor.rs` to delete jobs using `DELETE FROM job WHERE id = ANY($1)`.
>   - **SQL Queries**:
>     - New query `DELETE FROM job WHERE id = ANY($1)` added in `query-803b9c1373541cf52f416cde9e9e99ab79072e21dfaafb498aac25a059bd2f30.json`.
>   - **Misc**:
>     - Removes `csharp` from `script_lang` enum in `query-0ad36c1598ff4ece0c325eaeb9a9177a87e1accd192402e21db5ae09c3498ab0.json`, `query-1a612eb0b64eddd2c5657ef73598c47886545796424f8612135b711e2b9ddb6c.json`, and 8 other files.
>     - Renames `bool` column to `?column?` in `query-02424907504848e983bfa89eec343061932dc5b4b17cf13d5cf8d833aedbe6d5.json` and `query-661f472ff3860983322162420457f5033b9c9afc344d9c3e385ba20a3ad2197a.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for a3896f5627a7bdc538d6a36e587069488cbfd60a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->