### PR TITLE
feat(backend): implement flow node for inner modules

### DIFF
--- a/backend/.sqlx/query-0ad36c1598ff4ece0c325eaeb9a9177a87e1accd192402e21db5ae09c3498ab0.json
+++ b/backend/.sqlx/query-0ad36c1598ff4ece0c325eaeb9a9177a87e1accd192402e21db5ae09c3498ab0.json
@@ -43,7 +43,8 @@
                 "appdependencies",
                 "deploymentcallback",
                 "singlescriptflow",
-                "flowscript"
+                "flowscript",
+                "flownode"
               ]
             }
           }

--- a/backend/.sqlx/query-113b120ae10ea4469ec3575dc3506aaa6d6a8940017a1172403ca9851d0f13a7.json
+++ b/backend/.sqlx/query-113b120ae10ea4469ec3575dc3506aaa6d6a8940017a1172403ca9851d0f13a7.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT flow as \"flow!: sqlx::types::Json<Box<RawValue>>\" FROM flow_node WHERE id = $1 LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "flow!: sqlx::types::Json<Box<RawValue>>",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "113b120ae10ea4469ec3575dc3506aaa6d6a8940017a1172403ca9851d0f13a7"
+}

--- a/backend/.sqlx/query-337f31c2172194cd594042c561998a03f751b246c40daf056fced0fd91f6dd73.json
+++ b/backend/.sqlx/query-337f31c2172194cd594042c561998a03f751b246c40daf056fced0fd91f6dd73.json
@@ -33,7 +33,8 @@
                 "appdependencies",
                 "deploymentcallback",
                 "singlescriptflow",
-                "flowscript"
+                "flowscript",
+                "flownode"
               ]
             }
           }

--- a/backend/.sqlx/query-3d77e5b691dab38b3e39477ed980560bacd55c6ae9fafcbb0239163a3d7f3c0c.json
+++ b/backend/.sqlx/query-3d77e5b691dab38b3e39477ed980560bacd55c6ae9fafcbb0239163a3d7f3c0c.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT flow AS \"flow!: Json<Box<JsonRawValue>>\" FROM flow_node WHERE id = $1 LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "flow!: Json<Box<JsonRawValue>>",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "3d77e5b691dab38b3e39477ed980560bacd55c6ae9fafcbb0239163a3d7f3c0c"
+}

--- a/backend/.sqlx/query-f9fc0084fe086ef80005bb64a8bb6b493e53583017c18e2ab44f44125c52d548.json
+++ b/backend/.sqlx/query-f9fc0084fe086ef80005bb64a8bb6b493e53583017c18e2ab44f44125c52d548.json
@@ -47,7 +47,8 @@
                 "appdependencies",
                 "deploymentcallback",
                 "singlescriptflow",
-                "flowscript"
+                "flowscript",
+                "flownode"
               ]
             }
           }

--- a/backend/migrations/20241122143108_flow_node_kind.down.sql
+++ b/backend/migrations/20241122143108_flow_node_kind.down.sql
@@ -1,0 +1,1 @@
+-- Add down migration script here

--- a/backend/migrations/20241122143108_flow_node_kind.up.sql
+++ b/backend/migrations/20241122143108_flow_node_kind.up.sql
@@ -1,0 +1,2 @@
+-- Add up migration script here
+ALTER TYPE JOB_KIND ADD VALUE IF NOT EXISTS 'flownode';

--- a/backend/tests/worker.rs
+++ b/backend/tests/worker.rs
@@ -1170,6 +1170,7 @@ async fn test_deno_flow(db: Pool<Postgres>) {
                             continue_on_error: None,
                             skip_if: None,
                         }],
+                        modules_node: None,
                     }
                     .into(),
                     stop_after_if: Default::default(),
@@ -1386,6 +1387,7 @@ async fn test_deno_flow_same_worker(db: Pool<Postgres>) {
                                 skip_if: None,
                             },
                         ],
+                        modules_node: None,
                     }.into(),
                     stop_after_if: Default::default(),
                     stop_after_all_iters_if: Default::default(),

--- a/backend/windmill-api/src/flows.rs
+++ b/backend/windmill-api/src/flows.rs
@@ -1257,6 +1257,7 @@ mod tests {
                             value: windmill_common::worker::to_raw_value(&[1, 2, 3]),
                         },
                         modules: vec![],
+                        modules_node: None,
                         skip_failures: true,
                         parallel: false,
                         parallelism: None,

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -2430,7 +2430,7 @@ impl Job {
     pub fn is_flow(&self) -> bool {
         matches!(
             self.job_kind(),
-            JobKind::Flow | JobKind::FlowPreview | JobKind::SingleScriptFlow
+            JobKind::Flow | JobKind::FlowPreview | JobKind::SingleScriptFlow | JobKind::FlowNode
         )
     }
 

--- a/backend/windmill-common/src/jobs.rs
+++ b/backend/windmill-common/src/jobs.rs
@@ -40,6 +40,7 @@ pub enum JobKind {
     Noop,
     DeploymentCallback,
     FlowScript,
+    FlowNode,
 }
 
 #[derive(sqlx::FromRow, Debug, Serialize, Clone)]
@@ -115,7 +116,7 @@ impl QueuedJob {
     pub fn is_flow(&self) -> bool {
         matches!(
             self.job_kind,
-            JobKind::Flow | JobKind::FlowPreview | JobKind::SingleScriptFlow
+            JobKind::Flow | JobKind::FlowPreview | JobKind::SingleScriptFlow | JobKind::FlowNode
         )
     }
 
@@ -272,6 +273,10 @@ pub enum JobPayload {
         concurrency_time_window_s: Option<i32>,
         cache_ttl: Option<i32>,
         dedicated_worker: Option<bool>,
+    },
+    FlowNode {
+        id: FlowNodeId, // flow_node(id).
+        path: String, // flow node inner path (e.g. `outer/branchall-42`).
     },
     Code(RawCode),
     Dependencies {

--- a/backend/windmill-worker/src/dedicated_worker.rs
+++ b/backend/windmill-worker/src/dedicated_worker.rs
@@ -329,7 +329,7 @@ async fn spawn_dedicated_workers_for_flow(
                     .await;
                     workers.extend(w);
                 }
-                FlowModuleValue::BranchOne { branches, default } => {
+                FlowModuleValue::BranchOne { branches, default, .. } => {
                     for modules in branches
                         .iter()
                         .map(|x| &x.modules)

--- a/backend/windmill-worker/src/worker_lockfiles.rs
+++ b/backend/windmill-worker/src/worker_lockfiles.rs
@@ -15,7 +15,7 @@ use windmill_common::scripts::ScriptHash;
 use windmill_common::worker::{to_raw_value, to_raw_value_owned, write_file};
 use windmill_common::{
     error::{self, to_anyhow},
-    flows::FlowValue,
+    flows::{add_virtual_items_if_necessary, FlowValue},
     jobs::QueuedJob,
     scripts::ScriptLang,
     DB,
@@ -648,7 +648,7 @@ pub async fn handle_flow_dependency_job(
 
         // Compute a lite version of the flow value (`RawScript` => `FlowScript`).
         let mut value_lite = flow.clone();
-        tx = reduce(tx, &mut value_lite.modules, &job_path, &job.workspace_id).await?;
+        tx = reduce(tx, &mut value_lite.modules, &job_path, &job.workspace_id, flow.failure_module.as_ref(), flow.same_worker).await?;
         sqlx::query!(
             "INSERT INTO flow_version_lite (id, value) VALUES ($1, $2)
              ON CONFLICT (id) DO UPDATE SET value = EXCLUDED.value",
@@ -748,6 +748,7 @@ async fn lock_modules<'c>(
                 FlowModuleValue::ForloopFlow {
                     iterator,
                     modules,
+                    modules_node,
                     skip_failures,
                     parallel,
                     parallelism,
@@ -773,6 +774,7 @@ async fn lock_modules<'c>(
                     e.value = FlowModuleValue::ForloopFlow {
                         iterator,
                         modules: nmodules,
+                        modules_node,
                         skip_failures,
                         parallel,
                         parallelism,
@@ -808,7 +810,7 @@ async fn lock_modules<'c>(
                     }
                     e.value = FlowModuleValue::BranchAll { branches: nbranches, parallel }.into()
                 }
-                FlowModuleValue::WhileloopFlow { modules, skip_failures } => {
+                FlowModuleValue::WhileloopFlow { modules, modules_node, skip_failures } => {
                     let nmodules;
                     (nmodules, tx, nmodified_ids) = Box::pin(lock_modules(
                         modules,
@@ -828,9 +830,9 @@ async fn lock_modules<'c>(
                     ))
                     .await?;
                     e.value =
-                        FlowModuleValue::WhileloopFlow { modules: nmodules, skip_failures }.into()
+                        FlowModuleValue::WhileloopFlow { modules: nmodules, modules_node, skip_failures }.into()
                 }
-                FlowModuleValue::BranchOne { branches, default } => {
+                FlowModuleValue::BranchOne { branches, default, default_node } => {
                     let mut nbranches = vec![];
                     nmodified_ids = vec![];
                     for mut b in branches {
@@ -876,7 +878,7 @@ async fn lock_modules<'c>(
                         occupancy_metrics,
                     ))
                     .await?;
-                    e.value = FlowModuleValue::BranchOne { branches: nbranches, default: ndefault }
+                    e.value = FlowModuleValue::BranchOne { branches: nbranches, default: ndefault, default_node }
                         .into();
                 }
                 _ => (),
@@ -1042,11 +1044,46 @@ async fn insert_flow_node<'c>(
     Ok((tx, FlowNodeId(id)))
 }
 
+async fn insert_flow_modules<'c>(
+    mut tx: sqlx::Transaction<'c, sqlx::Postgres>,
+    path: &str,
+    workspace_id: &str,
+    failure_module: Option<&Box<FlowModule>>,
+    same_worker: bool,
+    modules: &mut Vec<FlowModule>,
+    modules_node: &mut Option<FlowNodeId>,
+) -> Result<sqlx::Transaction<'c, sqlx::Postgres>> {
+    tx = Box::pin(reduce(tx, modules, path, workspace_id, failure_module, same_worker)).await?;
+    add_virtual_items_if_necessary(modules);
+    if modules.is_empty() || crate::worker_flow::is_simple_modules(modules, failure_module) {
+        return Ok(tx);
+    }
+    let id;
+    (tx, id) = insert_flow_node(
+        tx,
+        path,
+        workspace_id,
+        None,
+        None,
+        Some(&Json(to_raw_value(&FlowValue {
+            modules: std::mem::take(modules),
+            failure_module: failure_module.cloned(),
+            same_worker,
+            ..Default::default()
+        })))
+    )
+    .await?;
+    *modules_node = Some(id);
+    Ok(tx)
+}
+
 async fn reduce<'c>(
     mut tx: sqlx::Transaction<'c, sqlx::Postgres>,
     modules: &mut Vec<FlowModule>,
     path: &str,
     workspace_id: &str,
+    failure_module: Option<&Box<FlowModule>>,
+    same_worker: bool,
 ) -> Result<sqlx::Transaction<'c, sqlx::Postgres>> {
     use FlowModuleValue::*;
     for module in &mut *modules {
@@ -1081,12 +1118,31 @@ async fn reduce<'c>(
                     is_trigger,
                 };
             },
-            ForloopFlow { modules, .. } | WhileloopFlow { modules, .. }  => {
-                tx = Box::pin(reduce(tx, &mut *modules, path, workspace_id)).await?;
+            ForloopFlow { modules, modules_node, .. }
+            | WhileloopFlow { modules, modules_node, .. }  => {
+                tx = insert_flow_modules(
+                    tx, path, workspace_id, failure_module, same_worker,
+                    modules, modules_node
+                ).await?;
             }
-            BranchOne { branches, .. } | BranchAll { branches, .. } => {
-                for branch in &mut *branches {
-                    tx = Box::pin(reduce(tx, &mut branch.modules, path, workspace_id)).await?;
+            BranchOne { branches, default, default_node, .. } => {
+                for branch in branches.iter_mut() {
+                    tx = insert_flow_modules(
+                        tx, path, workspace_id, failure_module, same_worker,
+                        &mut branch.modules, &mut branch.modules_node
+                    ).await?;
+                }
+                tx = insert_flow_modules(
+                    tx, path, workspace_id, failure_module, same_worker, 
+                    default, default_node
+                ).await?;
+            }
+            BranchAll { branches, .. } => {
+                for branch in branches.iter_mut() {
+                    tx = insert_flow_modules(
+                        tx, path, workspace_id, failure_module, same_worker,
+                        &mut branch.modules, &mut branch.modules_node
+                    ).await?;
                 }
             }
             _ => {}


### PR DESCRIPTION
This update builds on the ongoing effort initiated in #4748, extending the reduction of flow modules.

## Implementation
The inner `.modules` (e.g., `WhileLoop { modules, ... }`) are replaced entirely with a module node that references the `flow_node` table. When determining the next flow job payload, the `modules_node` is used instead of `modules` (if present), and a new `JobPayload::FlowNode { id }` is returned. During dequeuing, the original modules are retrieved from the `flow_node` table. 

Regarding values returned to the frontend, all modules are seamlessly resolved to their original representations.

## Benchmarks
TBD

## Backward Compatibility
Similar to #4748, the environment variable `DISABLE_FLOW_SCRIPT` can be used to disable this feature.

## Open Questions
The same open questions as in #4748 remain applicable here.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces flow node handling in backend, replacing flow modules with `flow_node` references, updating database and code to support this structure.
> 
>   - **Behavior**:
>     - Replaces `FlowScript` inner `.modules` with `modules_node` referencing `flow_node` table.
>     - Uses `modules_node` for next flow job payload, returning `JobPayload::FlowNode { id }`.
>     - Original modules retrieved from `flow_node` during dequeuing.
>     - All modules resolved to original representations for frontend.
>   - **Database**:
>     - Adds `flow_node` table to store flow modules.
>     - Updates queries in `query-113b120ae10ea4469ec3575dc3506aaa6d6a8940017a1172403ca9851d0f13a7.json` and others.
>     - Migration scripts `20241122143108_flow_node_kind.up.sql` and `20241122143108_flow_node_kind.down.sql` to add `flownode` to `JOB_KIND`.
>   - **Code Changes**:
>     - Updates `resolve_module` and `resolve_modules` in `windmill-common/src/flows.rs` to handle `modules_node`.
>     - Modifies `push_next_flow_job` and `compute_next_flow_transform` in `worker_flow.rs` to support `FlowNode` payloads.
>     - Adjusts `lock_modules` and `reduce` in `worker_lockfiles.rs` to process `modules_node`.
>   - **Backward Compatibility**:
>     - Feature can be disabled with `DISABLE_FLOW_SCRIPT` environment variable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for da75d756c7a9560a3a4354aadaf6e511d2aa539e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->