### PR TITLE
croner link target _blank / underline on hover

### DIFF
--- a/frontend/src/lib/components/CronInput.svelte
+++ b/frontend/src/lib/components/CronInput.svelte
@@ -212,7 +212,8 @@
 			</svelte:fragment>
 			<div class="flex flex-row-reverse text-2xs text-tertiary -mt-1">
 				<a
-					class="text-tertiary"
+					class="text-tertiary hover:underline"
+					target="_blank"
 					href="https://www.windmill.dev/docs/core_concepts/scheduling#cron-syntax">Croner</a
 				>
 			</div>

--- a/frontend/src/lib/components/CronInput.svelte
+++ b/frontend/src/lib/components/CronInput.svelte
@@ -214,6 +214,7 @@
 				<a
 					class="text-tertiary hover:underline"
 					target="_blank"
+					rel="noopener noreferrer"
 					href="https://www.windmill.dev/docs/core_concepts/scheduling#cron-syntax">Croner</a
 				>
 			</div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance `Croner` link in `CronInput.svelte` to open in a new tab and underline on hover.
> 
>   - **UI Enhancement**:
>     - In `CronInput.svelte`, the `Croner` link now opens in a new tab (`target="_blank"`) and has an underline on hover (`hover:underline`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 13e0ec2ceebad09862f0f283f00837346de46c8d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->