### PR TITLE
fix: rename `job` workspace as well

### DIFF
--- a/backend/.sqlx/query-43fcdf5243e17bfbdcd21f09feee6e104b40f4b937914f56f01c299cddfc17e9.json
+++ b/backend/.sqlx/query-43fcdf5243e17bfbdcd21f09feee6e104b40f4b937914f56f01c299cddfc17e9.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE job SET workspace_id = $1 WHERE workspace_id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "43fcdf5243e17bfbdcd21f09feee6e104b40f4b937914f56f01c299cddfc17e9"
+}

--- a/backend/windmill-api/src/workspaces.rs
+++ b/backend/windmill-api/src/workspaces.rs
@@ -2949,6 +2949,14 @@ async fn change_workspace_id(
     .await?;
 
     sqlx::query!(
+        "UPDATE job SET workspace_id = $1 WHERE workspace_id = $2",
+        &rw.new_id,
+        &old_id
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query!(
         "UPDATE raw_app SET workspace_id = $1 WHERE workspace_id = $2",
         &rw.new_id,
         &old_id


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds functionality to update `workspace_id` in `job` table when changing workspace IDs in `workspaces.rs`.
> 
>   - **Behavior**:
>     - Updates `workspace_id` in `job` table when changing workspace IDs in `change_workspace_id()` in `workspaces.rs`.
>   - **Database**:
>     - Adds SQL query to update `workspace_id` in `job` table in `.sqlx/query-43fcdf5243e17bfbdcd21f09feee6e104b40f4b937914f56f01c299cddfc17e9.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 94abe5f386087c780367fd494573f1dfd2f72d69. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->