### PR TITLE
backend: keep tracking minimal worker version

### DIFF
--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -592,9 +592,7 @@ pub async fn update_min_version<'c, E: sqlx::Executor<'c, Database = sqlx::Postg
         tracing::info!("Minimal worker version: {min_version}");
     }
 
-    if min_version >= Version::new(1, 427, 0) {
-        *MIN_VERSION_IS_AT_LEAST_1_427.write().await = true;
-    }
+    *MIN_VERSION_IS_AT_LEAST_1_427.write().await = min_version >= Version::new(1, 427, 0);
 
     *MIN_VERSION.write().await = min_version.clone();
     min_version >= cur_version


### PR DESCRIPTION
Be sure to also track the min version of workers that have been started after the min version variable has been set. e.g. All workers are up to date and `MIN_VERSION_IS_AT_LEAST_1_427` is set to true, a worker is then powered on with an anterior version, leading to a false positive value. This commit fix that.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `update_min_version()` in `worker.rs` to accurately track minimal worker version by directly setting `MIN_VERSION_IS_AT_LEAST_1_427`.
> 
>   - **Behavior**:
>     - Update logic in `update_min_version()` in `worker.rs` to set `MIN_VERSION_IS_AT_LEAST_1_427` directly based on `min_version >= Version::new(1, 427, 0)`.
>     - Ensures accurate tracking of minimal worker version, preventing false positives when older workers start after the flag is set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 006e2d0f60659f5ba765865ce7b71582998b262c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->