### PR TITLE
fix(python): Merge to site-packages packages with same name

### DIFF
--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -331,6 +331,8 @@ pub struct PythonAnnotations {
     pub no_uv: bool,
     pub no_uv_install: bool,
     pub no_uv_compile: bool,
+
+    pub no_postinstall: bool,
 }
 
 #[annotations("//")]


### PR DESCRIPTION
Iterate overall all python paths and if same folder has same name multiple times, then merge the content and put to <job_dir>/site-packages

Solves problem with imports for some dependencies.

Default layout (/windmill/cache/):

dep==x.y.z
└── X
   └── A
dep-ext==x.y.z
└── X
   └── B

In this case python would be confused with finding B module.

This function will convert it to (/<job_id>):

site-packages
└── X
   ├── A
   └── B

This way python has no problems with finding correct module