### PR TITLE
fix: disable `flow_version_lite` in dedicated workers

### DIFF
--- a/backend/.sqlx/query-bbce3e1eae78c48409d4204cd6cb3b9db088f6e51bea5e74a494c4e9f4c3b78e.json
+++ b/backend/.sqlx/query-bbce3e1eae78c48409d4204cd6cb3b9db088f6e51bea5e74a494c4e9f4c3b78e.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT flow_version.value AS \"value!: sqlx::types::Json<Box<sqlx::types::JsonRawValue>>\" \n                FROM flow \n                LEFT JOIN flow_version \n                    ON flow_version.id = flow.versions[array_upper(flow.versions, 1)]\n                WHERE flow.path = $1 AND flow.workspace_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "value!: sqlx::types::Json<Box<sqlx::types::JsonRawValue>>",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "bbce3e1eae78c48409d4204cd6cb3b9db088f6e51bea5e74a494c4e9f4c3b78e"
+}

--- a/backend/windmill-worker/src/dedicated_worker.rs
+++ b/backend/windmill-worker/src/dedicated_worker.rs
@@ -460,12 +460,10 @@ pub async fn create_dedicated_worker_map(
         if let Some(flow_path) = _wp.path.strip_prefix("flow/") {
             is_flow_worker = true;
             let value = sqlx::query_scalar!(
-                "SELECT coalesce(flow_version_lite.value, flow_version.value) AS \"value!: sqlx::types::Json<Box<sqlx::types::JsonRawValue>>\" 
+                "SELECT flow_version.value AS \"value!: sqlx::types::Json<Box<sqlx::types::JsonRawValue>>\" 
                 FROM flow 
                 LEFT JOIN flow_version 
                     ON flow_version.id = flow.versions[array_upper(flow.versions, 1)]
-                LEFT JOIN flow_version_lite 
-                    ON flow_version_lite.id = flow_version.id
                 WHERE flow.path = $1 AND flow.workspace_id = $2",
                 flow_path,
                 _wp.workspace_id


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `flow_version_lite` from SQL query in `dedicated_worker.rs` and add new SQL query description file.
> 
>   - **Behavior**:
>     - Removed `flow_version_lite` from SQL query in `create_dedicated_worker_map()` in `dedicated_worker.rs`, affecting flow version retrieval.
>   - **SQL**:
>     - Added `.sqlx/query-bbce3e1eae78c48409d4204cd6cb3b9db088f6e51bea5e74a494c4e9f4c3b78e.json` for query description and caching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 08df70f264dca625cc5206a00623657208e1bf9e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->