### PR TITLE
Gi syntax docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
         limits:
           cpus: "1"
           memory: 2048M
+          # for GB, use syntax '2Gi'
     restart: unless-stopped
     environment:
       - DATABASE_URL=${DATABASE_URL}
@@ -76,6 +77,7 @@ services:
         limits:
           cpus: "1"
           memory: 2048M
+          # for GB, use syntax '2Gi'
     restart: unless-stopped
     environment:
       - DATABASE_URL=${DATABASE_URL}
@@ -98,6 +100,7 @@ services:
   #       limits:
   #         cpus: "1"
   #         memory: 2048M
+  #         # for GB, use syntax '2Gi'
   #   restart: unless-stopped
   #   environment:
   #     - DATABASE_URL=${DATABASE_URL}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add comments in `docker-compose.yml` to clarify memory limit syntax for gigabytes.
> 
>   - **Documentation**:
>     - Added comments in `docker-compose.yml` to clarify memory limit syntax for gigabytes using '2Gi'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 0cf71b551db7360c6d5d60c638319888e7545a30. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->