### PR TITLE
adding sqlx migration to grant windmill permissions to db user

### DIFF
--- a/backend/migrations/20241127171723_apply_windmill_roles.up.sql
+++ b/backend/migrations/20241127171723_apply_windmill_roles.up.sql
@@ -1,0 +1,4 @@
+-- for some managed dbs (e.g Azure Postgres) the role is not 
+-- automatically applied to the user when created
+GRANT windmill_user to CURRENT_USER;
+GRANT windmill_admin to CURRENT_USER;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add SQL migration to grant `windmill_user` and `windmill_admin` roles to `CURRENT_USER`.
> 
>   - **Migrations**:
>     - Add `20241127171723_apply_windmill_roles.up.sql` to grant `windmill_user` and `windmill_admin` roles to `CURRENT_USER`.
>     - Add `20241127171723_apply_windmill_roles.down.sql` as an empty file for rollback purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f501203278b81acec53e5b81225aa57a255d8f41. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->