### PR TITLE
Remove flock

### DIFF
--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -1322,7 +1322,11 @@ pub async fn handle_python_reqs(
         } else {
             let fssafe_req = NON_ALPHANUM_CHAR.replace_all(&req, "_").to_string();
             #[cfg(unix)]
-            let req = format!("'{}'", req);
+            let req = if no_uv_install {
+                format!("'{}'", req)
+            } else {
+                req.clone()
+            };
 
             #[cfg(windows)]
             let req = format!("{}", req);
@@ -1403,25 +1407,36 @@ pub async fn handle_python_reqs(
 
             #[cfg(unix)]
             {
-                let mut flock_cmd = Command::new(FLOCK_PATH.as_str());
-                flock_cmd
-                    .env_clear()
-                    .envs(PROXY_ENVS.clone())
-                    .envs(envs)
-                    .args([
-                        "-x",
-                        &format!(
-                            "{}/{}-{}.lock",
-                            LOCK_CACHE_DIR,
-                            if no_uv_install { "pip" } else { "py311" },
-                            fssafe_req
-                        ),
-                        "--command",
-                        &command_args.join(" "),
-                    ])
-                    .stdout(Stdio::piped())
-                    .stderr(Stdio::piped());
-                start_child_process(flock_cmd, FLOCK_PATH.as_str()).await?
+                if no_uv_install {
+                    let mut flock_cmd = Command::new(FLOCK_PATH.as_str());
+                    flock_cmd
+                        .env_clear()
+                        .envs(PROXY_ENVS.clone())
+                        .envs(envs)
+                        .args([
+                            "-x",
+                            &format!(
+                                "{}/{}-{}.lock",
+                                LOCK_CACHE_DIR,
+                                if no_uv_install { "pip" } else { "py311" },
+                                fssafe_req
+                            ),
+                            "--command",
+                            &command_args.join(" "),
+                        ])
+                        .stdout(Stdio::piped())
+                        .stderr(Stdio::piped());
+                    start_child_process(flock_cmd, FLOCK_PATH.as_str()).await?
+                } else {
+                    let mut cmd = Command::new(command_args[0]);
+                    cmd.env_clear()
+                        .envs(PROXY_ENVS.clone())
+                        .envs(envs)
+                        .args(&command_args[1..])
+                        .stdout(Stdio::piped())
+                        .stderr(Stdio::piped());
+                    start_child_process(cmd, UV_PATH.as_str()).await?
+                }
             }
 
             #[cfg(windows)]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes `flock` usage in `python_executor.rs` for Unix systems when `no_uv_install` is false, executing commands directly instead.
> 
>   - **Behavior**:
>     - Removes `flock` usage in `handle_python_reqs()` and `handle_python_reqs()` for Unix systems when `no_uv_install` is false.
>     - Directly executes commands without `flock` when `no_uv_install` is false.
>   - **Functions**:
>     - Modifies `handle_python_reqs()` to conditionally use `flock` based on `no_uv_install` flag.
>     - Modifies `handle_python_reqs()` to execute commands directly if `no_uv_install` is false.
>   - **Misc**:
>     - Adjusts command formatting logic in `handle_python_reqs()` for Unix systems.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for cb4e2ca05b37f0e440036e69a71a9596a00103c6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->