### PR TITLE
batch re-run from Runs UI v0

### DIFF
--- a/frontend/src/lib/components/runs/BatchRerunPanel.svelte
+++ b/frontend/src/lib/components/runs/BatchRerunPanel.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	import { base } from '$lib/base'
+	import { FlowService, JobService, ScriptService, type Job, type ScriptArgs } from '../../gen'
+	import { Tab, Tabs } from '../common'
+	import { workspaceStore } from '$lib/stores'
+	import type { Schema } from '$lib/common'
+	import SchemaForm from '../SchemaForm.svelte'
+
+	export let selectedIds: string[]
+	export let jobs: Job[] | undefined
+	export let blankLink = false
+	export let workspace: string | undefined
+
+	let viewTab = selectedIds[0] || ''
+	$: currentViewJob =
+		viewTab === 'common_args' ? undefined : jobs?.find((job) => job.id === viewTab)
+
+	export let args: { [jobId: string]: ScriptArgs }[] = []
+	let schemas: { [jobId: string]: Schema }[] = []
+
+	$: {
+		if (currentViewJob && !schemas[currentViewJob.id]) {
+			loadScript(currentViewJob)
+		}
+	}
+
+	async function loadScript(job: Job): Promise<void> {
+		if (job.job_kind === 'script') {
+			if (job.script_hash) {
+				schemas[job.id] = (
+					await ScriptService.getScriptByHash({
+						workspace: $workspaceStore!,
+						hash: job.script_hash
+					})
+				).schema
+			} else if (job.script_path) {
+				schemas[job.id] = (
+					await ScriptService.getScriptByPath({
+						workspace: $workspaceStore!,
+						path: job.script_path
+					})
+				).schema
+			}
+		} else if (job.job_kind === 'flow' && job.script_path) {
+			schemas[job.id] = (
+				await FlowService.getFlowByPath({
+					workspace: $workspaceStore!,
+					path: job.script_path
+				})
+			).schema
+		}
+		if (schemas[job.id]?.properties && Object.keys(schemas[job.id]).length > 0) {
+			args[job.id] = await JobService.getJobArgs({
+				workspace: $workspaceStore ?? '',
+				id: job.id
+			})
+		}
+	}
+
+	$: if (viewTab !== 'common_args' && !selectedIds.includes(viewTab)) {
+		viewTab = selectedIds[0] || '' // when you are viewing a job's tab and you deselect it
+	}
+</script>
+
+<div class="p-4 flex flex-col gap-2 items-start h-full">
+	{#if selectedIds.length > 0}
+		<div class=" w-full h-full">
+			<Tabs bind:selected={viewTab}>
+				<!-- <Tab size="xs" value="common_args">Common Input</Tab> -->
+				{#each selectedIds as selectedJobId}
+					<Tab size="xs" value={selectedJobId}
+						>{jobs?.find((job) => job.id === selectedJobId)?.script_path || 'Job'}</Tab
+					>
+				{/each}
+
+				<svelte:fragment slot="content">
+					<div class="flex flex-col flex-1 h-full">
+						{#if viewTab === 'common_args'}
+							<p>Not currently implemented</p>
+						{:else}
+							{@const currentViewJobId = viewTab}
+							{@const currentViewSchema = schemas[currentViewJobId]}
+							<a
+								href="{base}/run/{currentViewJobId}?workspace={workspace ?? $workspaceStore}"
+								class="flex flex-row gap-1 items-center"
+								target={blankLink ? '_blank' : undefined}
+							>
+								<span class="font-semibold text-sm leading-6">ID:</span>
+								<span class="text-sm">{currentViewJobId ?? ''}</span>
+							</a>
+
+							<span class="font-semibold text-xs leading-6">Arguments</span>
+
+							{#if currentViewSchema}
+								<div class="my-2" />
+								{#if !currentViewSchema.properties || Object.keys(currentViewSchema.properties).length === 0}
+									<div class="text-sm py-4 italic">No arguments</div>
+								{:else if args[currentViewJobId]}
+									<span class=" text-xs leading-6"
+										>Jobs will be re-ran using the old arguments, you can override them below</span
+									>
+									<SchemaForm
+										prettifyHeader
+										autofocus
+										schema={currentViewSchema}
+										bind:args={args[currentViewJobId]}
+									/>
+								{:else}
+									<div class="text-xs text-tertiary">Loading...</div>
+								{/if}
+							{:else}
+								<div class="text-xs text-tertiary">Loading...</div>
+							{/if}
+						{/if}
+					</div>
+				</svelte:fragment>
+			</Tabs>
+		</div>
+	{/if}
+</div>

--- a/frontend/src/lib/components/runs/RunRow.svelte
+++ b/frontend/src/lib/components/runs/RunRow.svelte
@@ -2,7 +2,14 @@
 	import { base } from '$lib/base'
 	import { goto } from '$lib/navigation'
 	import type { Job } from '$lib/gen'
-	import { displayDate, msToReadableTime, truncateHash, truncateRev, isJobCancelable } from '$lib/utils'
+	import {
+		displayDate,
+		msToReadableTime,
+		truncateHash,
+		truncateRev,
+		isJobCancelable,
+		isJobRerunnable
+	} from '$lib/utils'
 	import { Badge, Button } from '../common'
 	import ScheduleEditor from '../ScheduleEditor.svelte'
 	import BarsStaggered from '$lib/components/icons/BarsStaggered.svelte'
@@ -34,11 +41,11 @@
 	export let containsLabel: boolean = false
 	export let activeLabel: string | null
 	export let isSelectingJobsToCancel: boolean = false
+	export let isSelectingJobsToRerun: boolean = false
 
 	let scheduleEditor: ScheduleEditor
 
 	$: isExternal = job && job.id === '-'
-
 </script>
 
 <Portal name="run-row">
@@ -54,13 +61,16 @@
 	)}
 	style="width: {containerWidth}px"
 	on:click={() => {
-		if (!isSelectingJobsToCancel || isJobCancelable(job)) {
+		if (
+			(!isSelectingJobsToCancel || isJobCancelable(job)) &&
+			(!isSelectingJobsToRerun || isJobRerunnable(job))
+		) {
 			dispatch('select')
 		}
 	}}
 >
 	<div class="w-1/12 flex justify-center">
-		{#if isSelectingJobsToCancel && isJobCancelable(job)}
+		{#if (isSelectingJobsToCancel && isJobCancelable(job)) || (isSelectingJobsToRerun && isJobRerunnable(job))}
 			<div class="px-2">
 				<input type="checkbox" checked={selected} />
 			</div>
@@ -123,7 +133,6 @@
 					Scheduled for {displayDate(job.scheduled_for)}
 				{:else if job.canceled}
 					Cancelling job... (created <TimeAgo agoOnlyIfRecent date={job.created_at || ''} />)
-
 				{:else}
 					Waiting for executor (created <TimeAgo agoOnlyIfRecent date={job.created_at || ''} />)
 				{/if}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -20,6 +20,10 @@ export function isJobCancelable(j: Job): boolean {
 	return j.type === 'QueuedJob' && !j.schedule_path && !j.canceled
 }
 
+export function isJobRerunnable(j: Job): boolean {
+	return j.type === 'CompletedJob' && (j.job_kind === "script" || j.job_kind === "flow")
+}
+
 export function validateUsername(username: string): string {
 	if (username != '' && !/^[a-zA-Z]\w+$/.test(username)) {
 		return 'username can only contain letters and numbers and must start with a letter'
@@ -605,7 +609,7 @@ export function isObject(obj: any) {
 
 export function debounce(func: (...args: any[]) => any, wait: number) {
 	let timeout: any
-	return function (...args: any[]) {
+	return function(...args: any[]) {
 		// @ts-ignore
 		const context = this
 		clearTimeout(timeout)
@@ -615,7 +619,7 @@ export function debounce(func: (...args: any[]) => any, wait: number) {
 
 export function throttle<T>(func: (...args: any[]) => T, wait: number) {
 	let timeout: any
-	return function (...args: any[]) {
+	return function(...args: any[]) {
 		if (!timeout) {
 			timeout = setTimeout(() => {
 				timeout = null
@@ -831,7 +835,7 @@ export async function tryEvery({
 		try {
 			await tryCode()
 			break
-		} catch (err) {}
+		} catch (err) { }
 		i++
 	}
 	if (i >= times) {


### PR DESCRIPTION
This is the first version of the _Jobs UI Batch Re-run_ feature.

This PR implements
-  A _Batch re-run jobs_ button in the Runs page which when clicked allows you to select jobs that are re-runnable (job is completed and is either a script or a flow), similar to the `Cancel job` feature
- When selecting jobs to be re-ran, the bottom right panel is used by a new component `<BatchRerunPanel />` to allow to the user to override old arguments for each selected job (each job is a tab)
    -  When visiting a tab, the UI fetches both the job's input schema and its arguments to display the `<SchemaForm />` component
    - When starting the re-run the UI fetches all the jobs arguments which were not overridden in the panel, then runs all the scripts by hash or flows by path

Future Tasks

- [ ] Common Input tab in   `<BatchRerunPanel />`, which sets common job arguments, common arguments should be overridden in each job's own tab if the user chooses to
- [ ] Take a time window range within a schedule that is in the past and run all ticks that would have happened in the past, with optionally not re-running the ticks that did actually happen