### PR TITLE
fix: add missing export tab on mobile view of flow detail

### DIFF
--- a/frontend/src/lib/components/details/DetailPageLayout.svelte
+++ b/frontend/src/lib/components/details/DetailPageLayout.svelte
@@ -73,7 +73,9 @@
 				{#if !isOperator}
 					<Tab value="triggers">Triggers</Tab>
 				{/if}
-				{#if !flow_json}
+				{#if flow_json}
+					<Tab value="raw">Export</Tab>
+				{:else}
 					<Tab value="script">Script</Tab>
 				{/if}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds missing `Export` tab in mobile view of `DetailPageLayout.svelte` when `flow_json` is present.
> 
>   - **Behavior**:
>     - Adds missing `Export` tab in mobile view of `DetailPageLayout.svelte` when `flow_json` is present.
>     - Corrects conditional logic to display `Export` tab instead of `Script` tab when `flow_json` is available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 6435054add9bbfadccf00dcef0be0e7ffa5e3263. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->