### PR TITLE
fix: invalid `jsonb` comparison while inserting flow node

### DIFF
--- a/backend/.sqlx/query-5ac7c9eb3ce21e46f90e23435562b5f818a4274ba223f905e68280b86b24fa25.json
+++ b/backend/.sqlx/query-5ac7c9eb3ce21e46f90e23435562b5f818a4274ba223f905e68280b86b24fa25.json
@@ -1,0 +1,27 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        WITH existing AS (\n            SELECT id FROM flow_node\n            WHERE hash = $1 AND path = $2 AND workspace_id = $3 AND code = $4 AND lock = $5 AND (flow IS NOT DISTINCT FROM $6)\n            LIMIT 1\n        ),\n        inserted AS (\n            INSERT INTO flow_node (hash, path, workspace_id, code, lock, flow)\n            VALUES ($1, $2, $3, $4, $5, $6)\n            ON CONFLICT DO NOTHING\n            RETURNING id\n        )\n        SELECT id FROM existing\n        UNION ALL\n        SELECT id FROM inserted\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Jsonb"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "5ac7c9eb3ce21e46f90e23435562b5f818a4274ba223f905e68280b86b24fa25"
+}

--- a/backend/windmill-worker/src/worker_lockfiles.rs
+++ b/backend/windmill-worker/src/worker_lockfiles.rs
@@ -1023,7 +1023,7 @@ async fn insert_flow_node<'c>(
         r#"
         WITH existing AS (
             SELECT id FROM flow_node
-            WHERE hash = $1 AND path = $2 AND workspace_id = $3 AND code = $4 AND lock = $5 AND flow = $6
+            WHERE hash = $1 AND path = $2 AND workspace_id = $3 AND code = $4 AND lock = $5 AND (flow IS NOT DISTINCT FROM $6)
             LIMIT 1
         ),
         inserted AS (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `jsonb` comparison in `insert_flow_node` function by using `IS NOT DISTINCT FROM` to handle null values correctly.
> 
>   - **Behavior**:
>     - Fixes `jsonb` comparison in `insert_flow_node` function in `worker_lockfiles.rs` by using `IS NOT DISTINCT FROM` to handle null values correctly.
>   - **SQL**:
>     - Updates SQL query in `worker_lockfiles.rs` to use `IS NOT DISTINCT FROM` for `jsonb` comparison.
>     - Adds new query description in `.sqlx/query-5ac7c9eb3ce21e46f90e23435562b5f818a4274ba223f905e68280b86b24fa25.json` reflecting the updated query.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 1b42ff27f47367e0998f20797d5e05577595f006. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->