### PR TITLE
apply jwt ext tag scopes to single job endpoints

### DIFF
--- a/backend/.sqlx/query-55541316c690e4f2e1b7a41071ef0a297a2e65c8e25a17d5c43715481e7633a0.json
+++ b/backend/.sqlx/query-55541316c690e4f2e1b7a41071ef0a297a2e65c8e25a17d5c43715481e7633a0.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id FROM queue WHERE id = ANY($1) AND schedule_path IS NULL",
+  "query": "SELECT id FROM queue WHERE id = ANY($1) AND schedule_path IS NULL AND ($2::text[] IS NULL OR tag = ANY($2))",
   "describe": {
     "columns": [
       {
@@ -11,12 +11,13 @@
     ],
     "parameters": {
       "Left": [
-        "UuidArray"
+        "UuidArray",
+        "TextArray"
       ]
     },
     "nullable": [
       false
     ]
   },
-  "hash": "273d275be89516b135d7846d179c84ba0d684a620e9e5c0c87f82bdc9cd57dbe"
+  "hash": "55541316c690e4f2e1b7a41071ef0a297a2e65c8e25a17d5c43715481e7633a0"
 }

--- a/backend/.sqlx/query-6682bf34caf7efa95b60c747b45dcdd41de7f8e197b163f7865810391471db5b.json
+++ b/backend/.sqlx/query-6682bf34caf7efa95b60c747b45dcdd41de7f8e197b163f7865810391471db5b.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT created_by, CONCAT(coalesce(completed_job.logs, ''), coalesce(job_logs.logs, '')) as logs, job_logs.log_offset, job_logs.log_file_index\n        FROM completed_job \n        LEFT JOIN job_logs ON job_logs.job_id = completed_job.id \n        WHERE completed_job.id = $1 AND completed_job.workspace_id = $2",
+  "query": "SELECT created_by, CONCAT(coalesce(queue.logs, ''), coalesce(job_logs.logs, '')) as logs, coalesce(job_logs.log_offset, 0) as log_offset, job_logs.log_file_index\n            FROM queue \n            LEFT JOIN job_logs ON job_logs.job_id = queue.id \n            WHERE queue.id = $1 AND queue.workspace_id = $2 AND ($3::text[] IS NULL OR queue.tag = ANY($3))",
   "describe": {
     "columns": [
       {
@@ -27,15 +27,16 @@
     "parameters": {
       "Left": [
         "Uuid",
-        "Text"
+        "Text",
+        "TextArray"
       ]
     },
     "nullable": [
       false,
       null,
-      false,
+      null,
       true
     ]
   },
-  "hash": "b4c4b1aa4bcf7e5f49ce3bd93fff3b7c49e812271e4888d33eb73dd638486488"
+  "hash": "6682bf34caf7efa95b60c747b45dcdd41de7f8e197b163f7865810391471db5b"
 }

--- a/backend/.sqlx/query-afd0d1b0511f32ba1981bc8d09b729639a6c0b468aa3f9108071d160d2dee250.json
+++ b/backend/.sqlx/query-afd0d1b0511f32ba1981bc8d09b729639a6c0b468aa3f9108071d160d2dee250.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT created_by, CONCAT(coalesce(queue.logs, ''), coalesce(job_logs.logs, '')) as logs, coalesce(job_logs.log_offset, 0) as log_offset, job_logs.log_file_index\n            FROM queue \n            LEFT JOIN job_logs ON job_logs.job_id = queue.id \n            WHERE queue.id = $1 AND queue.workspace_id = $2",
+  "query": "SELECT created_by, CONCAT(coalesce(completed_job.logs, ''), coalesce(job_logs.logs, '')) as logs, job_logs.log_offset, job_logs.log_file_index\n        FROM completed_job \n        LEFT JOIN job_logs ON job_logs.job_id = completed_job.id \n        WHERE completed_job.id = $1 AND completed_job.workspace_id = $2 AND ($3::text[] IS NULL OR completed_job.tag = ANY($3))",
   "describe": {
     "columns": [
       {
@@ -27,15 +27,16 @@
     "parameters": {
       "Left": [
         "Uuid",
-        "Text"
+        "Text",
+        "TextArray"
       ]
     },
     "nullable": [
       false,
       null,
-      null,
+      false,
       true
     ]
   },
-  "hash": "b2c30137b3b64f8c3f6aea062e8687e119599641beee0a0d6c89c5d90e82d0db"
+  "hash": "afd0d1b0511f32ba1981bc8d09b729639a6c0b468aa3f9108071d160d2dee250"
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance job access control by applying JWT tag scopes to job-related endpoints in `jobs.rs`, updating SQL queries and functions for tag scope filtering.
> 
>   - **Behavior**:
>     - Apply JWT tag scopes to `get_job`, `get_job_logs`, `get_args`, `get_completed_job`, `get_completed_job_result`, `get_completed_job_result_maybe`, and `delete_completed_job` in `jobs.rs`.
>     - Modify SQL queries to include tag scope checks using `tag = ANY($3)` condition.
>   - **Functions**:
>     - Add `with_in_tags` method to `GetQuery` struct for tag scope filtering.
>     - Update `check_tag_available_for_workspace` to include `authed` parameter for scope validation.
>   - **Misc**:
>     - Import `itertools::Itertools` for tag processing in `jobs.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f96c6951fb6bea1eb496481f51f456b6518efd8e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->