### PR TITLE
feat: add database storage for app scripts

### DIFF
--- a/backend/.sqlx/query-0ad36c1598ff4ece0c325eaeb9a9177a87e1accd192402e21db5ae09c3498ab0.json
+++ b/backend/.sqlx/query-0ad36c1598ff4ece0c325eaeb9a9177a87e1accd192402e21db5ae09c3498ab0.json
@@ -44,7 +44,8 @@
                 "deploymentcallback",
                 "singlescriptflow",
                 "flowscript",
-                "flownode"
+                "flownode",
+                "appscript"
               ]
             }
           }

--- a/backend/.sqlx/query-0c6c80746733be8f561ab0b631854799f5e8122adaf35465cb16c3dc795bdc3b.json
+++ b/backend/.sqlx/query-0c6c80746733be8f561ab0b631854799f5e8122adaf35465cb16c3dc795bdc3b.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO app_script (app, hash, lock, code, code_sha256)\n        VALUES ($1, $2, $3, $4, $5)\n        ON CONFLICT (hash) DO UPDATE SET app = EXCLUDED.app -- trivial update to return the id\n        RETURNING id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Bpchar",
+        "Text",
+        "Text",
+        "Bpchar"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "0c6c80746733be8f561ab0b631854799f5e8122adaf35465cb16c3dc795bdc3b"
+}

--- a/backend/.sqlx/query-1bae415f9440cc1334f24ce3009242cf3a6287e7b4548c7f01ad888230c27013.json
+++ b/backend/.sqlx/query-1bae415f9440cc1334f24ce3009242cf3a6287e7b4548c7f01ad888230c27013.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT format('rawscript/%s', code_sha256) as \"path!: String\"\n                        FROM app_script WHERE id = $1 LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "path!: String",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "1bae415f9440cc1334f24ce3009242cf3a6287e7b4548c7f01ad888230c27013"
+}

--- a/backend/.sqlx/query-337f31c2172194cd594042c561998a03f751b246c40daf056fced0fd91f6dd73.json
+++ b/backend/.sqlx/query-337f31c2172194cd594042c561998a03f751b246c40daf056fced0fd91f6dd73.json
@@ -34,7 +34,8 @@
                 "deploymentcallback",
                 "singlescriptflow",
                 "flowscript",
-                "flownode"
+                "flownode",
+                "appscript"
               ]
             }
           }

--- a/backend/.sqlx/query-5d7081a9ba0d702f63ed9d44be5ffe0ba043565790865c6a6f52fab6ce340d2c.json
+++ b/backend/.sqlx/query-5d7081a9ba0d702f63ed9d44be5ffe0ba043565790865c6a6f52fab6ce340d2c.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT policy as \"policy: sqlx::types::Json<Box<RawValue>>\"\n                FROM app WHERE app.path = $1 AND app.workspace_id = $2 LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "policy: sqlx::types::Json<Box<RawValue>>",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "5d7081a9ba0d702f63ed9d44be5ffe0ba043565790865c6a6f52fab6ce340d2c"
+}

--- a/backend/.sqlx/query-ea9bbb972217bab4d7e8f4c08e331899161e80c239d56eb657d73bbf4272939b.json
+++ b/backend/.sqlx/query-ea9bbb972217bab4d7e8f4c08e331899161e80c239d56eb657d73bbf4272939b.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT app_id, value FROM app_version WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "app_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "value",
+        "type_info": "Json"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "ea9bbb972217bab4d7e8f4c08e331899161e80c239d56eb657d73bbf4272939b"
+}

--- a/backend/.sqlx/query-ee16199b4af456198fae062e948914fca6fc0a8787e4f8d520766b1c89f23602.json
+++ b/backend/.sqlx/query-ee16199b4af456198fae062e948914fca6fc0a8787e4f8d520766b1c89f23602.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO app_version_lite (id, value) VALUES ($1, $2)\n             ON CONFLICT (id) DO UPDATE SET value = EXCLUDED.value",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ee16199b4af456198fae062e948914fca6fc0a8787e4f8d520766b1c89f23602"
+}

--- a/backend/.sqlx/query-f9fc0084fe086ef80005bb64a8bb6b493e53583017c18e2ab44f44125c52d548.json
+++ b/backend/.sqlx/query-f9fc0084fe086ef80005bb64a8bb6b493e53583017c18e2ab44f44125c52d548.json
@@ -48,7 +48,8 @@
                 "deploymentcallback",
                 "singlescriptflow",
                 "flowscript",
-                "flownode"
+                "flownode",
+                "appscript"
               ]
             }
           }

--- a/backend/.sqlx/query-ffa86babfcab107caffb8dda31a66b142fa628b8983b966357deb3d5e0a1df3c.json
+++ b/backend/.sqlx/query-ffa86babfcab107caffb8dda31a66b142fa628b8983b966357deb3d5e0a1df3c.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT lock, code FROM app_script WHERE id = $1 LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "lock",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "code",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      true,
+      false
+    ]
+  },
+  "hash": "ffa86babfcab107caffb8dda31a66b142fa628b8983b966357deb3d5e0a1df3c"
+}

--- a/backend/migrations/20241202095902_app_script.down.sql
+++ b/backend/migrations/20241202095902_app_script.down.sql
@@ -1,0 +1,3 @@
+-- Add down migration script here
+DROP TABLE IF EXISTS app_version_lite;
+DROP TABLE IF EXISTS app_script;

--- a/backend/migrations/20241202095902_app_script.up.sql
+++ b/backend/migrations/20241202095902_app_script.up.sql
@@ -1,0 +1,26 @@
+-- Add up migration script here
+ALTER TYPE JOB_KIND ADD VALUE IF NOT EXISTS 'appscript';
+
+-- Same as `app_version` but with a "lite" value (w/ `inlineScript.{code,lock}`).
+CREATE TABLE app_version_lite (
+    id BIGSERIAL PRIMARY KEY,
+    value JSONB,
+    FOREIGN KEY (id) REFERENCES app_version (id) ON DELETE CASCADE
+);
+
+GRANT ALL ON app_version_lite TO windmill_user;
+GRANT ALL ON app_version_lite TO windmill_admin;
+
+-- App `inlineScript`.
+CREATE TABLE app_script (
+    id BIGSERIAL PRIMARY KEY,
+    app BIGSERIAL NOT NULL,
+    hash CHAR(64) NOT NULL UNIQUE, -- sha256 of `app`, `lock`, `code`.
+    lock TEXT,
+    code TEXT NOT NULL,
+    code_sha256 CHAR(64) NOT NULL, -- used to retrieve the policy.
+    FOREIGN KEY (app) REFERENCES app (id) ON DELETE CASCADE
+);
+
+GRANT ALL ON app_script TO windmill_user;
+GRANT ALL ON app_script TO windmill_admin;

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -5467,6 +5467,23 @@ paths:
               schema:
                 $ref: "#/components/schemas/AppWithLastVersion"
 
+  /w/{workspace}/apps/get/lite/{path}:
+    get:
+      summary: get app lite by path
+      operationId: getAppLiteByPath
+      tags:
+        - app
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - $ref: "#/components/parameters/ScriptPath"
+      responses:
+        "200":
+          description: app lite details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppWithLastVersion"
+
   /w/{workspace}/apps/get/draft/{path}:
     get:
       summary: get app by path with draft
@@ -5791,6 +5808,8 @@ paths:
                 #flow: flow/<path>
                 path:
                   type: string
+                version:
+                  type: integer
                 args: {}
                 raw_code:
                   type: object
@@ -5808,6 +5827,8 @@ paths:
                   required:
                     - content
                     - language
+                id:
+                  type: integer
                 force_viewer_static_fields:
                   type: object
                 force_viewer_one_of_fields:

--- a/backend/windmill-common/src/apps.rs
+++ b/backend/windmill-common/src/apps.rs
@@ -6,7 +6,18 @@
  * LICENSE-AGPL for a copy of the license.
  */
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+
+/// Id in the `app_script` table.
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, Hash, Eq, PartialEq)]
+#[serde(transparent)]
+pub struct AppScriptId(pub i64);
+
+impl Into<u64> for AppScriptId {
+    fn into(self) -> u64 {
+        self.0 as u64
+    }
+}
 
 #[derive(Deserialize)]
 pub struct ListAppQuery {

--- a/backend/windmill-common/src/jobs.rs
+++ b/backend/windmill-common/src/jobs.rs
@@ -14,6 +14,7 @@ pub const ENTRYPOINT_OVERRIDE: &str = "_ENTRYPOINT_OVERRIDE";
 pub const PREPROCESSOR_FAKE_ENTRYPOINT: &str = "__WM_PREPROCESSOR";
 
 use crate::{
+    apps::AppScriptId,
     error::{self, to_anyhow, Error},
     flow_status::{FlowStatus, RestartedFrom},
     flows::{FlowNodeId, FlowValue, Retry},
@@ -41,6 +42,7 @@ pub enum JobKind {
     DeploymentCallback,
     FlowScript,
     FlowNode,
+    AppScript,
 }
 
 #[derive(sqlx::FromRow, Debug, Serialize, Clone)]
@@ -277,6 +279,12 @@ pub enum JobPayload {
     FlowNode {
         id: FlowNodeId, // flow_node(id).
         path: String, // flow node inner path (e.g. `outer/branchall-42`).
+    },
+    AppScript {
+        id: AppScriptId, // app_script(id).
+        path: Option<String>,
+        language: ScriptLang,
+        cache_ttl: Option<i32>,
     },
     Code(RawCode),
     Dependencies {

--- a/backend/windmill-queue/src/jobs.rs
+++ b/backend/windmill-queue/src/jobs.rs
@@ -3228,7 +3228,27 @@ pub async fn push<'c, 'd>(
                 None,
                 None,
             )
-        }
+        },
+        JobPayload::AppScript {
+            id, // app_script(id).
+            path,
+            language,
+            cache_ttl,
+        } => (
+            Some(id.0),
+            path,
+            None,
+            JobKind::AppScript,
+            None,
+            None,
+            Some(language),
+            None,
+            None,
+            None,
+            cache_ttl,
+            None,
+            None,
+        ),
         JobPayload::ScriptHub { path } => {
             if path == "hub/7771/slack" || path == "hub/7836/slack" {
                 permissioned_as = SUPERADMIN_NOTIFICATION_EMAIL.to_string();
@@ -3989,6 +4009,7 @@ pub async fn push<'c, 'd>(
             JobKind::DeploymentCallback => "jobs.run.deployment_callback",
             JobKind::FlowScript => "jobs.run.flow_script",
             JobKind::FlowNode => "jobs.run.flow_node",
+            JobKind::AppScript => "jobs.run.app_script",
         };
 
         let audit_author = if format!("u/{user}") != permissioned_as && user != permissioned_as {

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -7,6 +7,7 @@
  */
 
 use windmill_common::{
+    apps::AppScriptId,
     auth::{fetch_authed_from_permissioned_as, JWTAuthClaims, JobPerms, JWT_SECRET},
     scripts::PREVIEW_IS_TAR_CODEBASE_HASH,
     utils::WarnAfterExt,
@@ -2301,6 +2302,20 @@ async fn handle_code_execution_job(
             let (lockfile, content) = cache::flow::fetch_script(
                 db,
                 FlowNodeId(job.script_hash.unwrap_or(ScriptHash(0)).0),
+            )
+            .await?;
+            ContentReqLangEnvs {
+                content,
+                lockfile,
+                language: job.language.to_owned(),
+                envs: None,
+                codebase: None,
+            }
+        }
+        JobKind::AppScript => {
+            let (lockfile, content) = cache::app::fetch_script(
+                db,
+                AppScriptId(job.script_hash.unwrap_or(ScriptHash(0)).0),
             )
             .await?;
             ContentReqLangEnvs {

--- a/frontend/src/lib/components/apps/components/helpers/RunnableComponent.svelte
+++ b/frontend/src/lib/components/apps/components/helpers/RunnableComponent.svelte
@@ -377,17 +377,24 @@
 						: runnable
 
 					if (inlineScript) {
+						if (inlineScript.id !== undefined) {
+							requestBody['id'] = inlineScript.id
+						}
 						requestBody['raw_code'] = {
-							content: inlineScript.content,
+							content: inlineScript.id === undefined ? inlineScript.content : '',
 							language: inlineScript.language ?? '',
 							path: inlineScript.path,
-							lock: inlineScript.lock,
+							lock: inlineScript.id === undefined ? inlineScript.lock : undefined,
 							cache_ttl: inlineScript.cache_ttl
 						}
 					}
 				} else if (runnable?.type === 'runnableByPath') {
 					const { path, runType } = runnable
 					requestBody['path'] = runType !== 'hubscript' ? `${runType}/${path}` : `script/${path}`
+				}
+
+				if ($app.version !== undefined) {
+					requestBody['version'] = $app.version
 				}
 
 				const uuid = await AppService.executeComponent({

--- a/frontend/src/lib/components/apps/types.ts
+++ b/frontend/src/lib/components/apps/types.ts
@@ -117,6 +117,7 @@ export type InlineScript = {
 	cache_ttl?: number
 	refreshOn?: { id: string; key: string }[]
 	suggestedRefreshOn?: { id: string; key: string }[]
+	id?: number
 }
 
 export type AppCssItemName = 'viewer' | 'grid' | AppComponent['type']
@@ -163,6 +164,7 @@ export type App = {
 	theme: AppTheme | undefined
 	hideLegacyTopBar?: boolean | undefined
 	mobileViewOnSmallerScreens?: boolean | undefined
+	version?: number
 }
 
 export type ConnectingInput = {

--- a/frontend/src/routes/(root)/(logged)/apps/get/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps/get/[...path]/+page.svelte
@@ -17,7 +17,7 @@
 	let can_write = false
 
 	async function loadApp() {
-		app = await AppService.getAppByPath({ workspace: $workspaceStore!, path: $page.params.path })
+		app = await AppService.getAppLiteByPath({ workspace: $workspaceStore!, path: $page.params.path })
 		can_write = canWrite(app?.path, app?.extra_perms!, $userStore)
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add database storage for app scripts, updating database schema, API, worker, caching, and frontend components.
> 
>   - **Database**:
>     - Add `app_script` table with columns `id`, `app_id`, `app_component`, `lock`, and `code`.
>     - Add migration scripts `20241202095902_app_script.up.sql` and `20241202095902_app_script.down.sql`.
>   - **API Changes**:
>     - Modify `update_app()` in `apps.rs` to delete and re-insert inline scripts on deploy.
>     - Update `execute_component()` in `apps.rs` to handle inline scripts by checking the `app_script` table.
>   - **Worker Changes**:
>     - Add `AppScript` to `JobKind` in `jobs.rs`.
>     - Implement `handle_code_execution_job()` in `worker.rs` to fetch inline scripts from cache or database.
>     - Update `lock_modules_app()` in `worker_lockfiles.rs` to handle inline script locking and insertion.
>   - **Caching**:
>     - Add `fetch_script()` in `cache.rs` to manage inline script caching.
>   - **Frontend**:
>     - Update `RunnableComponent.svelte` to handle inline script execution with new `id` field.
>     - Modify `+page.svelte` to use `getAppLiteByPath()` for fetching app data.
>   - **Misc**:
>     - Rename `bool` column to `?column?` in several `.json` files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for c782c580289132d476110c885fa8e1dce11fe952. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->