### PR TITLE
fix ci error unused superadmin import

### DIFF
--- a/frontend/src/lib/components/search/GlobalSearchModal.svelte
+++ b/frontend/src/lib/components/search/GlobalSearchModal.svelte
@@ -33,7 +33,7 @@
 	import ContentSearchInner from '../ContentSearchInner.svelte'
 	import { goto } from '$app/navigation'
 	import QuickMenuItem from '../search/QuickMenuItem.svelte'
-	import { devopsRole, enterpriseLicense, superadmin, workspaceStore } from '$lib/stores'
+	import { devopsRole, enterpriseLicense, workspaceStore } from '$lib/stores'
 	import uFuzzy from '@leeoniya/ufuzzy'
 	import BarsStaggered from '../icons/BarsStaggered.svelte'
 	import { scroll_into_view_if_needed_polyfill } from '../multiselect/utils'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove unused `superadmin` import from `GlobalSearchModal.svelte` to fix CI error.
> 
>   - **Imports**:
>     - Remove unused `superadmin` import from `GlobalSearchModal.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for c38643515aaf1561eff8ee1f8ef7195630fdb63b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->