### PR TITLE
Added space after Use simplified builder button

### DIFF
--- a/frontend/src/lib/components/CronInput.svelte
+++ b/frontend/src/lib/components/CronInput.svelte
@@ -250,7 +250,7 @@
 		</Label>
 
 		{#if !disabled}
-			<div class="flex flex-row gap-2">
+			<div class="flex flex-row gap-2 mb-2">
 				<CronBuilder let:close>
 					<div class="w-full flex flex-col">
 						<div class="w-full flex flex-col gap-1">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added margin-bottom to a div in `CronInput.svelte` for improved spacing after the "Use simplified builder" button.
> 
>   - **CSS Adjustment**:
>     - Added `mb-2` class to a `div` in `CronInput.svelte` to add margin-bottom for better spacing after the "Use simplified builder" button.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 6c63322cddf355bd149ff57c1c1c92721a79e97d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->