### PR TITLE
fix: fix `flow_node` uniqueness

### DIFF
--- a/backend/.sqlx/query-83cc9e432aea1450f79e9fce04eca0e75f30faa8c39ad4754bd568ae6f210806.json
+++ b/backend/.sqlx/query-83cc9e432aea1450f79e9fce04eca0e75f30faa8c39ad4754bd568ae6f210806.json
@@ -1,0 +1,27 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO flow_node (path, workspace_id, hash_v2, lock, code, flow)\n        VALUES ($1, $2, $3, $4, $5, $6)\n        ON CONFLICT (hash_v2) DO UPDATE SET path = EXCLUDED.path -- trivial update to return the id\n        RETURNING id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Bpchar",
+        "Text",
+        "Text",
+        "Jsonb"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "83cc9e432aea1450f79e9fce04eca0e75f30faa8c39ad4754bd568ae6f210806"
+}

--- a/backend/migrations/20241205135747_fix_flow_node_uniqueness.down.sql
+++ b/backend/migrations/20241205135747_fix_flow_node_uniqueness.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+ALTER TABLE flow_node DROP COLUMN hash_v2;

--- a/backend/migrations/20241205135747_fix_flow_node_uniqueness.up.sql
+++ b/backend/migrations/20241205135747_fix_flow_node_uniqueness.up.sql
@@ -1,0 +1,4 @@
+-- Add up migration script here
+CREATE SEQUENCE IF NOT EXISTS flow_node_hash_seq;
+ALTER TABLE flow_node ALTER COLUMN hash DROP NOT NULL;
+ALTER TABLE flow_node ADD COLUMN hash_v2 CHAR(64) NOT NULL UNIQUE DEFAULT to_hex(nextval('flow_node_hash_seq'));


### PR DESCRIPTION
`jsonb` comparison wasn't working as expected, and duplicated entries
were inserted within `flow_node`. To resolve this add a second hash
column, `hash_v2` with a unique default for uniqueness, and use this new
column to ensure unique entries. The previous hash column is left for
backward compatibility. Duplicated entries already insterted will remain
as is without breaking, and only new ones will preserve uniqueness.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix `flow_node` uniqueness by switching to SHA-256 hash with a unique constraint in the database schema and updating hash calculation logic.
> 
>   - **Database Schema**:
>     - In `migrations/20241205135747_fix_flow_node_uniqueness.up.sql`, add `hash_v2` column to `flow_node` as `CHAR(64)` with a unique constraint using SHA-256.
>     - In `migrations/20241205135747_fix_flow_node_uniqueness.down.sql`, remove `hash_v2` column.
>   - **Hash Calculation**:
>     - In `worker_lockfiles.rs`, replace `DefaultHasher` with `sha2::Sha256` for `hash` calculation in `insert_flow_node()`.
>   - **SQL Query**:
>     - Update SQL query in `.sqlx/query-83cc9e432aea1450f79e9fce04eca0e75f30faa8c39ad4754bd568ae6f210806.json` to use new `hash_v2` logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for c88daeeee215cea92c2021584224da52b77d42bd. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->