### PR TITLE
fix: job search toast on error

### DIFF
--- a/frontend/src/lib/components/search/GlobalSearchModal.svelte
+++ b/frontend/src/lib/components/search/GlobalSearchModal.svelte
@@ -244,7 +244,7 @@
 					queryParseErrors = searchResults.query_parse_errors
 					indexMetadata = searchResults.index_metadata
 				} catch (e) {
-					sendUserToast(e, true)
+					sendUserToast(e.body, true)
 				}
 				loadingCompletedRuns = false
 				selectedItem = selectItem(0)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix error message display in `GlobalSearchModal.svelte` by using `e.body` in `sendUserToast`.
> 
>   - **Error Handling**:
>     - In `GlobalSearchModal.svelte`, updated `sendUserToast` to use `e.body` instead of `e` for error messages when handling search errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for da4c388909a02a1fc34b669c1426428a92434fcb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->