### PR TITLE
fix: handle flow & workspace renames for `flow_node`

### DIFF
--- a/backend/.sqlx/query-5af51d5bf7614274ade044120045893edb73694601544fea7cf20f45dd25a88d.json
+++ b/backend/.sqlx/query-5af51d5bf7614274ade044120045893edb73694601544fea7cf20f45dd25a88d.json
@@ -1,0 +1,27 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO flow_node (path, workspace_id, hash_v2, lock, code, flow)\n        VALUES ($1, $2, $3, $4, $5, $6)\n        ON CONFLICT (path, workspace_id, hash_v2) DO UPDATE SET path = EXCLUDED.path -- trivial update to return the id\n        RETURNING id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Bpchar",
+        "Text",
+        "Text",
+        "Jsonb"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "5af51d5bf7614274ade044120045893edb73694601544fea7cf20f45dd25a88d"
+}

--- a/backend/migrations/20241206075559_flow_node_unique_2.down.sql
+++ b/backend/migrations/20241206075559_flow_node_unique_2.down.sql
@@ -1,0 +1,3 @@
+-- Add down migration script here
+ALTER TABLE flow_node DROP CONSTRAINT IF EXISTS flow_node_unique_2;
+ALTER TABLE flow_node ADD CONSTRAINT flow_node_hash_v2_key UNIQUE (hash_v2);

--- a/backend/migrations/20241206075559_flow_node_unique_2.up.sql
+++ b/backend/migrations/20241206075559_flow_node_unique_2.up.sql
@@ -1,0 +1,3 @@
+-- Add up migration script here
+ALTER TABLE flow_node ADD CONSTRAINT flow_node_unique_2 UNIQUE (path, workspace_id, hash_v2);
+ALTER TABLE flow_node DROP CONSTRAINT IF EXISTS flow_node_hash_v2_key;

--- a/backend/windmill-worker/src/worker_lockfiles.rs
+++ b/backend/windmill-worker/src/worker_lockfiles.rs
@@ -1027,8 +1027,6 @@ async fn insert_flow_node<'c>(
 ) -> Result<(sqlx::Transaction<'c, sqlx::Postgres>, FlowNodeId)> {
     let hash = {
         let mut hasher = sha2::Sha256::new();
-        hasher.update(path);
-        hasher.update(workspace_id);
         hasher.update(code.unwrap_or(&Default::default()));
         hasher.update(lock.unwrap_or(&Default::default()));
         hasher.update(flow.unwrap_or(&Default::default()).get());
@@ -1040,7 +1038,7 @@ async fn insert_flow_node<'c>(
         r#"
         INSERT INTO flow_node (path, workspace_id, hash_v2, lock, code, flow)
         VALUES ($1, $2, $3, $4, $5, $6)
-        ON CONFLICT (hash_v2) DO UPDATE SET path = EXCLUDED.path -- trivial update to return the id
+        ON CONFLICT (path, workspace_id, hash_v2) DO UPDATE SET path = EXCLUDED.path -- trivial update to return the id
         RETURNING id
         "#,
         path,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Handle flow and workspace renames for `flow_node` by updating unique constraints and conflict resolution in database and Rust code.
> 
>   - **Database Migrations**:
>     - Add new unique constraint `flow_node_unique_2` on `(path, workspace_id, hash_v2)` in `flow_node` table in `20241206075559_flow_node_unique_2.up.sql`.
>     - Remove old unique constraint `flow_node_hash_v2_key` in `20241206075559_flow_node_unique_2.up.sql`.
>     - Reverse changes in `20241206075559_flow_node_unique_2.down.sql`.
>   - **Rust Code Changes**:
>     - Update conflict resolution in `insert_flow_node()` in `worker_lockfiles.rs` to use `(path, workspace_id, hash_v2)`.
>     - Remove `path` and `workspace_id` from hash calculation in `insert_flow_node()` in `worker_lockfiles.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 74cfab4476a3e9e6c82daa8c1e4e7caf84d04ceb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->