### PR TITLE
fix: service logs: don't truncate hostnames when graph is not showing

### DIFF
--- a/frontend/src/lib/components/ServiceLogsInner.svelte
+++ b/frontend/src/lib/components/ServiceLogsInner.svelte
@@ -587,7 +587,7 @@
 											<div
 												class="text-sm pt-2 pl-0.5 whitespace-nowrap"
 												title={hn}
-												style="width: 90px;">{truncateRev(hn, 8)}</div
+												style="width: 90px;">{truncateRev(hn, countsPerHost || loadingLogs ? 40 : 8)}</div
 											>
 											{#if loadingLogCounts}
 												<Loader2 size={15} class="animate-spin" />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjusts hostname truncation in `ServiceLogsInner.svelte` to prevent unnecessary truncation when the graph is not displayed.
> 
>   - **Behavior**:
>     - Adjusts `truncateRev` function call in `ServiceLogsInner.svelte` to use a truncation length of 40 when `countsPerHost` is defined or `loadingLogs` is true, otherwise uses 8.
>   - **Misc**:
>     - This change prevents unnecessary truncation of hostnames when the graph is not showing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for d3e1d7f0f3ac4f5787e6fa08163ca3bc3ab56e61. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->