### PR TITLE
feat(frontend): render new job kinds

### DIFF
--- a/backend/windmill-api/openapi-deref.yaml
+++ b/backend/windmill-api/openapi-deref.yaml
@@ -8709,6 +8709,9 @@ paths:
                         - identity
                         - deploymentcallback
                         - singlescriptflow
+                        - flowscript
+                        - flownode
+                        - appscript
                     schedule_path:
                       type: string
                     permissioned_as:
@@ -9267,6 +9270,9 @@ paths:
                         - identity
                         - deploymentcallback
                         - singlescriptflow
+                        - flowscript
+                        - flownode
+                        - appscript
                     schedule_path:
                       type: string
                     permissioned_as:

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10983,6 +10983,8 @@ components:
               "deploymentcallback",
               "singlescriptflow",
               "flowscript",
+              "flownode",
+              "appscript",
             ]
         schedule_path:
           type: string
@@ -11103,6 +11105,8 @@ components:
               "deploymentcallback",
               "singlescriptflow",
               "flowscript",
+              "flownode",
+              "appscript",
             ]
         schedule_path:
           type: string

--- a/backend/windmill-worker/src/windmill-client.js
+++ b/backend/windmill-worker/src/windmill-client.js
@@ -558,6 +558,9 @@ var $QueuedJob = {
         "identity",
         "deploymentcallback",
         "singlescriptflow",
+        "flowscript",
+        "flownode",
+        "appscript",
       ],
     },
     schedule_path: {
@@ -697,6 +700,9 @@ var $CompletedJob = {
         "identity",
         "deploymentcallback",
         "singlescriptflow",
+        "flowscript",
+        "flownode",
+        "appscript",
       ],
     },
     schedule_path: {

--- a/frontend/src/lib/components/runs/JobLoader.svelte
+++ b/frontend/src/lib/components/runs/JobLoader.svelte
@@ -100,7 +100,10 @@
 				'appdependencies',
 				'preview',
 				'flowpreview',
-				'script_hub'
+				'script_hub',
+				'flowscript',
+				'flownode',
+				'appscript',
 			]
 			return kinds.join(',')
 		} else if (jobKindsCat == 'dependencies') {
@@ -117,7 +120,7 @@
 			let kinds: CompletedJob['job_kind'][] = ['deploymentcallback']
 			return kinds.join(',')
 		} else {
-			let kinds: CompletedJob['job_kind'][] = ['script', 'flow']
+			let kinds: CompletedJob['job_kind'][] = ['script', 'flow', 'flowscript', 'flownode', 'appscript']
 			return kinds.join(',')
 		}
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for new job kinds `flowscript`, `flownode`, and `appscript` in both frontend and backend components.
> 
>   - **Frontend**:
>     - Update `JobLoader.svelte` to include new job kinds `flowscript`, `flownode`, and `appscript` in `computeJobKinds()`.
>   - **Backend**:
>     - Add new job kinds `flowscript`, `flownode`, and `appscript` to `openapi-deref.yaml`, `openapi.yaml`, and `windmill-client.js` for both `$QueuedJob` and `$CompletedJob`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 0c329447bfff88a79d2add3e3e02baec6bd6c13a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->