### PR TITLE
fix: disabling app custom url

### DIFF
--- a/frontend/src/lib/components/apps/editor/AppEditorHeader.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeader.svelte
@@ -482,7 +482,7 @@
 				policy,
 				path: npath,
 				deployment_message: deploymentMsg,
-				custom_path: $userStore?.is_admin || $userStore?.is_super_admin ? customPath : undefined
+				custom_path: $userStore?.is_admin || $userStore?.is_super_admin ? (customPath ?? '') : undefined
 			}
 		})
 		savedApp = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix handling of app custom paths by treating empty paths as `None` and restricting setting to admin users.
> 
>   - **Backend**:
>     - In `create_app` and `update_app` functions in `apps.rs`, handle empty `custom_path` by setting it to `None`.
>     - Ensure `custom_path` is only set if non-empty and unique within the workspace.
>   - **Frontend**:
>     - In `AppEditorHeader.svelte`, ensure `custom_path` is set to an empty string if not provided by admin users.
>     - Validate `custom_path` to ensure it is unique and follows the correct format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for e95c03261121f6e3cfab553e59527de5c52859a8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->