### PR TITLE
nix: update flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732014248,
-        "narHash": "sha256-y/MEyuJ5oBWrWAic/14LaIr/u5E0wRVzyYsouYY3W6w=",
+        "lastModified": 1733759999,
+        "narHash": "sha256-463SNPWmz46iLzJKRzO3Q2b0Aurff3U1n0nYItxq7jU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+        "rev": "a73246e2eef4c6ed172979932bc80e1404ba2d56",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1732156292,
-        "narHash": "sha256-XuTCME5ZausokOJ28AsIoayBVD1soscdoiKweT4VY50=",
+        "lastModified": 1733884434,
+        "narHash": "sha256-8GXR9kC07dyOIshAyfZhG11xfvBRSZzYghnZ2weOKJU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2d484c7a0db32f2700e253160bcd2aaa6cdca3ba",
+        "rev": "d0483df44ddf0fd1985f564abccbe568e020ddf2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       };
       buildInputs = with pkgs; [
         openssl openssl.dev libxml2.dev xmlsec.dev libxslt.dev
-        rust-bin.stable.latest.default nodejs
+        rust-bin.stable.latest.default nodejs cmake
         postgresql
         pkg-config
       ];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `nixpkgs` and `rust-overlay` in `flake.lock` and add `cmake` to `buildInputs` in `flake.nix`.
> 
>   - **Dependencies**:
>     - Update `nixpkgs` in `flake.lock` to revision `a73246e2eef4c6ed172979932bc80e1404ba2d56`.
>     - Update `rust-overlay` in `flake.lock` to revision `d0483df44ddf0fd1985f564abccbe568e020ddf2`.
>   - **Build Inputs**:
>     - Add `cmake` to `buildInputs` in `flake.nix`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 45ba562dd2c7e87e1ad75d4284b00dce02c61f8e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->