### PR TITLE
fix `s3_storage` decl not being the same as in `ee`

### DIFF
--- a/backend/windmill-worker/src/job_logger.rs
+++ b/backend/windmill-worker/src/job_logger.rs
@@ -35,7 +35,7 @@ pub(crate) async fn append_job_logs(
 ) -> () {
     if must_compact_logs {
         #[cfg(all(feature = "enterprise", feature = "parquet"))]
-        s3_storage(job_id, &w_id, &db, &logs, &total_size, &worker_name).await;
+        s3_storage(job_id, &w_id, &db, logs, total_size, &worker_name).await;
 
         #[cfg(not(all(feature = "enterprise", feature = "parquet")))]
         {

--- a/backend/windmill-worker/src/job_logger_ee.rs
+++ b/backend/windmill-worker/src/job_logger_ee.rs
@@ -12,8 +12,8 @@ pub(crate) async fn s3_storage(
     _job_id: Uuid,
     _w_id: &String,
     _db: &sqlx::Pool<sqlx::Postgres>,
-    _logs: &String,
-    _total_size: &Arc<AtomicU32>,
+    _logs: String,
+    _total_size: Arc<AtomicU32>,
     _worker_name: &String,
 ) {
     tracing::info!("Logs length of {_job_id} has exceeded a threshold. Implementation to store excess on s3 in not OSS");


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes parameter type inconsistency in `s3_storage` function signature between `job_logger.rs` and `job_logger_ee.rs`.
> 
>   - **Function Signature Consistency**:
>     - Updated `s3_storage` function signature in `job_logger.rs` and `job_logger_ee.rs` to have `_logs` as `String` and `_total_size` as `Arc<AtomicU32>`.
>   - **Behavior**:
>     - Ensures consistent parameter types for `s3_storage` across different configurations (enterprise and non-enterprise).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 1445a06bdbcb8e554f1700c241d727c08a383f6f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->