### PR TITLE
small ui fix for result display in psql + adding --return_last_result

### DIFF
--- a/frontend/src/lib/components/DisplayResult.svelte
+++ b/frontend/src/lib/components/DisplayResult.svelte
@@ -281,6 +281,7 @@
 			Array.isArray(json) &&
 			json.length > 0 &&
 			Array.isArray(json[0]) &&
+			json[0].length > 0 &&
 			json[0].every((item) => typeof item === 'string') &&
 			json
 				.slice(1)
@@ -339,6 +340,7 @@
 			if (
 				input.length > 1 &&
 				Array.isArray(input[0]) &&
+				input[0].length > 0 &&
 				input[0].every((item) => typeof item === 'string')
 			) {
 				const headers = input[0]

--- a/frontend/src/lib/components/table/AutoDataTable.svelte
+++ b/frontend/src/lib/components/table/AutoDataTable.svelte
@@ -400,7 +400,7 @@
 												disablePopup={typeof value === 'string' && value.length < 100}
 											>
 												<div
-													class="max-w-80 text-wrap whitespace-pre-wrap flex flex-grow w-max three-lines cursor-text"
+													class="max-w-[100ch] text-wrap whitespace-pre-wrap flex flex-grow w-max three-lines cursor-text"
 												>
 													{txt?.length > 100 ? txt.slice(0, 100) + '...' : txt}
 												</div>

--- a/frontend/src/lib/script_helpers.ts
+++ b/frontend/src/lib/script_helpers.ts
@@ -241,6 +241,7 @@ export async function main(message: string, name: string, step_id: string) {
 `
 
 const POSTGRES_INIT_CODE = `-- to pin the database use '-- database f/your/path'
+-- to only return the result of the last query use '--return_last_result'
 -- $1 name1 = default arg
 -- $2 name2
 -- $3 name3


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> UI fix for result display in tables and added `--return_last_result` option for PostgreSQL scripts.
> 
>   - **UI Fixes**:
>     - In `DisplayResult.svelte`, added check for non-empty arrays in `isTableRowObject()` and `handleArrayOfObjectsHeaders()`.
>     - In `AutoDataTable.svelte`, updated CSS class `max-w-80` to `max-w-[100ch]` for better text wrapping.
>   - **PostgreSQL Scripts**:
>     - Added `--return_last_result` option in `POSTGRES_INIT_CODE` in `script_helpers.ts` to return only the last query result.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for a4db716fc55c15cb2be01980281ebe7a16010a37. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->