### PR TITLE
fix: Target dotnet 9.0 for C#

### DIFF
--- a/backend/windmill-worker/src/csharp_executor.rs
+++ b/backend/windmill-worker/src/csharp_executor.rs
@@ -136,7 +136,7 @@ fn gen_cs_proj(
             r#"<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <StartupObject>WindmillScriptCSharpInternal.Wrapper</StartupObject>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
@@ -257,13 +257,14 @@ async fn build_cs_proj(
     }
 
     let mut build_cs_cmd = Command::new(DOTNET_PATH.as_str());
-
     build_cs_cmd
         .current_dir(job_dir)
         .env_clear()
         .env("PATH", PATH_ENV.as_str())
         .env("BASE_INTERNAL_URL", base_internal_url)
         .env("HOME", HOME_ENV.as_str())
+        .env("DOTNET_CLI_TELEMETRY_OPTOUT", "true")
+        .env("DOTNET_NOLOGO", "true")
         .args(vec![
             "publish",
             "--configuration",
@@ -473,6 +474,8 @@ pub async fn handle_csharp_job(
             .env("PATH", PATH_ENV.as_str())
             .env("TZ", TZ_ENV.as_str())
             .env("BASE_INTERNAL_URL", base_internal_url)
+            .env("DOTNET_CLI_TELEMETRY_OPTOUT", "true")
+            .env("DOTNET_NOLOGO", "true")
             .args(vec!["--config", "run.config.proto", "--", "/tmp/main"])
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
@@ -487,6 +490,8 @@ pub async fn handle_csharp_job(
             .envs(reserved_variables)
             .env("PATH", PATH_ENV.as_str())
             .env("TZ", TZ_ENV.as_str())
+            .env("DOTNET_CLI_TELEMETRY_OPTOUT", "true")
+            .env("DOTNET_NOLOGO", "true")
             .env("BASE_INTERNAL_URL", base_internal_url)
             .env("HOME", HOME_ENV.as_str())
             .stdout(Stdio::piped())

--- a/frontend/src/lib/script_helpers.ts
+++ b/frontend/src/lib/script_helpers.ts
@@ -348,8 +348,7 @@ fn main(who_to_greet: String, numbers: Vec<i8>) -> anyhow::Result<Ret> {
 }
 `
 
-const CSHARP_INIT_CODE = `
-#r "nuget: Humanizer, 2.14.1"
+const CSHARP_INIT_CODE = `#r "nuget: Humanizer, 2.14.1"
 
 using System;
 using System.Linq;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update C# target framework to .NET 9.0 and add .NET CLI environment variables in backend, with a minor frontend formatting change.
> 
>   - **Backend**:
>     - Update `gen_cs_proj()` in `csharp_executor.rs` to target .NET 9.0 instead of .NET 7.0.
>     - Add `DOTNET_CLI_TELEMETRY_OPTOUT` and `DOTNET_NOLOGO` environment variables in `build_cs_proj()` and `handle_csharp_job()` in `csharp_executor.rs`.
>   - **Frontend**:
>     - Remove newline in `CSHARP_INIT_CODE` in `script_helpers.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for d71f03b279c63dcf21cb2fd31b1ab0206b6706a6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->