### PR TITLE
fix: add `DOTNET_ROOT` env variable

### DIFF
--- a/backend/windmill-worker/src/csharp_executor.rs
+++ b/backend/windmill-worker/src/csharp_executor.rs
@@ -48,6 +48,8 @@ const NSJAIL_CONFIG_RUN_CSHARP_CONTENT: &str = include_str!("../nsjail/run.cshar
 #[cfg(feature = "csharp")]
 lazy_static::lazy_static! {
     static ref HOME_DIR: String = std::env::var("HOME").expect("Could not find the HOME environment variable");
+    static ref DOTNET_ROOT: String = std::env::var("DOTNET_ROOT").expect("Could not find the DOTNET_ROOT environment variable");
+
 }
 
 #[cfg(feature = "csharp")]
@@ -281,6 +283,7 @@ async fn build_cs_proj(
         .env("HOME", HOME_ENV.as_str())
         .env("DOTNET_CLI_TELEMETRY_OPTOUT", "true")
         .env("DOTNET_NOLOGO", "true")
+        .env("DOTNET_ROOT", DOTNET_ROOT.as_str())
         .args(vec![
             "publish",
             "--configuration",
@@ -493,6 +496,7 @@ pub async fn handle_csharp_job(
             .env("BASE_INTERNAL_URL", base_internal_url)
             .env("DOTNET_CLI_TELEMETRY_OPTOUT", "true")
             .env("DOTNET_NOLOGO", "true")
+            .env("DOTNET_ROOT", DOTNET_ROOT.as_str())
             .args(vec!["--config", "run.config.proto", "--", "/tmp/main"])
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
@@ -509,6 +513,7 @@ pub async fn handle_csharp_job(
             .env("TZ", TZ_ENV.as_str())
             .env("DOTNET_CLI_TELEMETRY_OPTOUT", "true")
             .env("DOTNET_NOLOGO", "true")
+            .env("DOTNET_ROOT", DOTNET_ROOT.as_str())
             .env("BASE_INTERNAL_URL", base_internal_url)
             .env("HOME", HOME_ENV.as_str())
             .stdout(Stdio::piped())

--- a/docker/DockerfileFull
+++ b/docker/DockerfileFull
@@ -7,3 +7,4 @@ RUN pip3 install ansible
 
 COPY --from=bitnami/dotnet-sdk:9.0.101-debian-12-r0 /opt/bitnami/dotnet-sdk /opt/dotnet-sdk
 RUN ln -s /opt/dotnet-sdk/bin/dotnet /usr/bin/dotnet
+ENV DOTNET_ROOT="/opt/dotnet-sdk/bin"

--- a/docker/DockerfileFullEe
+++ b/docker/DockerfileFullEe
@@ -7,3 +7,4 @@ RUN pip3 install ansible
 
 COPY --from=bitnami/dotnet-sdk:9.0.101-debian-12-r0 /opt/bitnami/dotnet-sdk /opt/dotnet-sdk
 RUN ln -s /opt/dotnet-sdk/bin/dotnet /usr/bin/dotnet
+ENV DOTNET_ROOT="/opt/dotnet-sdk/bin"

--- a/docker/DockerfileNsjail
+++ b/docker/DockerfileNsjail
@@ -32,5 +32,6 @@ RUN pip3 install ansible
 
 COPY --from=bitnami/dotnet-sdk:9.0.101-debian-12-r0 /opt/bitnami/dotnet-sdk /opt/dotnet-sdk
 RUN ln -s /opt/dotnet-sdk/bin/dotnet /usr/bin/dotnet
+ENV DOTNET_ROOT="/opt/dotnet-sdk/bin"
 
 COPY --from=nsjail /nsjail/nsjail /bin/nsjail


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `DOTNET_ROOT` environment variable to set .NET SDK path in Rust code and Dockerfiles.
> 
>   - **Environment Variable**:
>     - Add `DOTNET_ROOT` environment variable in `csharp_executor.rs` to ensure the .NET SDK path is set.
>     - Set `DOTNET_ROOT` in `DockerfileFull`, `DockerfileFullEe`, and `DockerfileNsjail` to `/opt/dotnet-sdk/bin`.
>   - **Code Changes**:
>     - Use `DOTNET_ROOT` in `build_cs_proj()` and `handle_csharp_job()` in `csharp_executor.rs` to set the environment for .NET commands.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 377d1f1f6fd7aa548de2adb372c0942ab21ad3fb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->