### PR TITLE
fix: fix "flow" tag being set for flow node

### DIFF
--- a/backend/windmill-queue/src/jobs.rs
+++ b/backend/windmill-queue/src/jobs.rs
@@ -3417,6 +3417,7 @@ pub async fn push<'c, 'd>(
         let default = || {
             let ntag = if job_kind == JobKind::Flow
                 || job_kind == JobKind::FlowPreview
+                || job_kind == JobKind::FlowNode
                 || job_kind == JobKind::SingleScriptFlow
                 || job_kind == JobKind::Identity
             {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes default tag assignment in `push()` in `jobs.rs` to include `JobKind::FlowNode` as a `flow` tag.
> 
>   - **Behavior**:
>     - Fixes the default tag assignment in `push()` in `jobs.rs` to include `JobKind::FlowNode` as a `flow` tag.
>     - Ensures `FlowNode` jobs are tagged consistently with other flow-related job kinds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 40696aa45600579bd6aa56ad9063644c47b914fb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->