### PR TITLE
fix: ECS terraform db url + ami issues

### DIFF
--- a/examples/deploy/aws-ecs-terraform/ecs_cluster.tf
+++ b/examples/deploy/aws-ecs-terraform/ecs_cluster.tf
@@ -1,7 +1,6 @@
 resource "aws_launch_template" "windmill_cluster_lt" {
   name          = "windmill-cluster-lt"
-  // Amazon Linux 2023 https://docs.aws.amazon.com/linux/al2023/ug/naming-and-versioning.html
-  image_id      = "ami-07bff6261f14c3a45"
+  image_id      = data.aws_ssm_parameter.amazon_linux_2023.value
   instance_type = "t3.medium"
   # vpc_security_group_ids = [aws_security_group.windmill_cluster_sg.id]
 

--- a/examples/deploy/aws-ecs-terraform/main.tf
+++ b/examples/deploy/aws-ecs-terraform/main.tf
@@ -26,3 +26,11 @@ variable "database_password" {
   sensitive   = true
   description = "RDS Database password"
 }
+
+locals {
+  db_url = "postgres://${aws_db_instance.windmill_cluster_rds.username}:${aws_db_instance.windmill_cluster_rds.password}@${aws_db_instance.windmill_cluster_rds.endpoint}/${aws_db_instance.windmill_cluster_rds.db_name}"
+}
+
+data "aws_ssm_parameter" "amazon_linux_2023" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id"
+}

--- a/examples/deploy/aws-ecs-terraform/windmill_server.tf
+++ b/examples/deploy/aws-ecs-terraform/windmill_server.tf
@@ -33,9 +33,9 @@ resource "aws_ecs_task_definition" "windmill_cluster_windmill_server_td" {
       environment = [{
         name  = "JSON_FMT"
         value = "true"
-      }, {
+        }, {
         name  = "DATABASE_URL"
-        value = "postgres://${aws_db_instance.windmill_cluster_rds.username}:${aws_db_instance.windmill_cluster_rds.password}@${aws_db_instance.windmill_cluster_rds.endpoint}/${aws_db_instance.windmill_cluster_rds.db_name}?sslmode=disable"
+        value = local.db_url
         }, {
         name  = "MODE"
         value = "server"

--- a/examples/deploy/aws-ecs-terraform/windmill_worker_basic.tf
+++ b/examples/deploy/aws-ecs-terraform/windmill_worker_basic.tf
@@ -24,9 +24,9 @@ resource "aws_ecs_task_definition" "windmill_cluster_windmill_worker_td" {
       environment = [{
         name  = "JSON_FMT"
         value = "true"
-      }, {
+        }, {
         name  = "DATABASE_URL"
-        value = "postgres://${aws_db_instance.windmill_cluster_rds.username}:${aws_db_instance.windmill_cluster_rds.password}@${aws_db_instance.windmill_cluster_rds.endpoint}/${aws_db_instance.windmill_cluster_rds.db_name}?sslmode=disable"
+        value = local.db_url
         }, {
         name  = "MODE"
         value = "worker"

--- a/examples/deploy/aws-ecs-terraform/windmill_worker_high_performance.tf
+++ b/examples/deploy/aws-ecs-terraform/windmill_worker_high_performance.tf
@@ -1,6 +1,6 @@
 resource "aws_launch_template" "windmill_cluster_high_performance_lt" {
   name          = "windmill-cluster-high-perf-lt"
-  image_id      = "ami-09c0b8e7f21923ac0"
+  image_id      = data.aws_ssm_parameter.amazon_linux_2023.value
   instance_type = "t3.xlarge"
   # vpc_security_group_ids = [aws_security_group.windmill_cluster_sg.id]
 
@@ -99,9 +99,9 @@ resource "aws_ecs_task_definition" "windmill_cluster_windmill_high_performance_w
       environment = [{
         name  = "JSON_FMT"
         value = "true"
-      }, {
+        }, {
         name  = "DATABASE_URL"
-        value = "postgres://${aws_db_instance.windmill_cluster_rds.username}:${aws_db_instance.windmill_cluster_rds.password}@${aws_db_instance.windmill_cluster_rds.endpoint}/${aws_db_instance.windmill_cluster_rds.db_name}?sslmode=disable"
+        value = local.db_url
         }, {
         name  = "MODE"
         value = "worker"

--- a/examples/deploy/aws-ecs-terraform/windmill_worker_native.tf
+++ b/examples/deploy/aws-ecs-terraform/windmill_worker_native.tf
@@ -24,9 +24,9 @@ resource "aws_ecs_task_definition" "windmill_cluster_windmill_native_worker_td" 
       environment = [{
         name  = "JSON_FMT"
         value = "true"
-      }, {
+        }, {
         name  = "DATABASE_URL"
-        value = "postgres://${aws_db_instance.windmill_cluster_rds.username}:${aws_db_instance.windmill_cluster_rds.password}@${aws_db_instance.windmill_cluster_rds.endpoint}/${aws_db_instance.windmill_cluster_rds.db_name}?sslmode=disable"
+        value = local.db_url
         }, {
         name  = "MODE"
         value = "worker"


### PR DESCRIPTION
Modifications to improve the terraform experience for bringing up a windmill cluster. Due to the default RDS settings for the version in the terraform, we do not want to disable ssl in connecting. Additionally, change the TF to automatically pull the latest 2023 AMI. Given this is meant to be a quick start example, this seems better than hard-coding since eventually the hard-coded ami doesn't exist.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes ECS Terraform setup by dynamically retrieving the latest AMI and improving database URL handling with SSL support.
> 
>   - **AMI Update**:
>     - Replaces hard-coded AMI IDs with dynamic retrieval using `data.aws_ssm_parameter.amazon_linux_2023.value` in `ecs_cluster.tf` and `windmill_worker_high_performance.tf`.
>   - **Database URL Handling**:
>     - Introduces `local.db_url` in `main.tf` for constructing the database URL without disabling SSL.
>     - Updates `DATABASE_URL` environment variable to use `local.db_url` in `windmill_server.tf`, `windmill_worker_basic.tf`, `windmill_worker_high_performance.tf`, and `windmill_worker_native.tf`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 893b1345b5f47efe3b1e7b00f0f56e7efd606499. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->