### PR TITLE
fix unused variable

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -601,6 +601,7 @@ Windmill Community Edition {GIT_VERSION}
                     server_killpill_rx,
                     base_internal_tx,
                     server_mode,
+                    #[cfg(feature = "smtp")]
                     base_internal_url.clone(),
                 )
                 .await?;

--- a/backend/tests/worker.rs
+++ b/backend/tests/worker.rs
@@ -134,6 +134,7 @@ impl ApiServer {
             rx,
             port_tx,
             false,
+            #[cfg(feature = "smtp")]
             format!("http://localhost:{}", addr.port()),
         ));
 

--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -174,6 +174,7 @@ pub async fn run_server(
     mut rx: tokio::sync::broadcast::Receiver<()>,
     port_tx: tokio::sync::oneshot::Sender<String>,
     server_mode: bool,
+    #[cfg(feature = "smtp")]
     base_internal_url: String,
 ) -> anyhow::Result<()> {
     let user_db = UserDB::new(db.clone());


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Conditionally use `base_internal_url` based on `smtp` feature flag to avoid unused variable warnings.
> 
>   - **Behavior**:
>     - Conditionally use `base_internal_url` in `run_server()` in `lib.rs` when `smtp` feature is enabled.
>     - Conditionally use `base_internal_url` in `main()` in `main.rs` when `smtp` feature is enabled.
>     - Conditionally use `base_internal_url` in `ApiServer::start()` in `worker.rs` when `smtp` feature is enabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 6297f541310767d22a20d174022c9401d6f2f195. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->