### PR TITLE
feat: add multipart/form-data support

### DIFF
--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -20,7 +20,7 @@ use crate::{
 #[cfg(feature = "parquet")]
 use crate::{
     job_helpers_ee::{
-        get_random_file_name, get_s3_resource, get_workspace_s3_resource, upload_file_internal,
+        get_random_file_name, get_s3_resource, get_workspace_s3_resource, upload_file_from_req,
         UploadFileResponse,
     },
     users::fetch_api_authed_from_permissioned_as,
@@ -1681,7 +1681,7 @@ async fn upload_s3_file_from_app(
     ])
     .into();
 
-    upload_file_internal(s3_client, &file_key, request, options).await?;
+    upload_file_from_req(s3_client, &file_key, request, options).await?;
 
     return Ok(Json(UploadFileResponse { file_key }));
 }

--- a/backend/windmill-api/src/args.rs
+++ b/backend/windmill-api/src/args.rs
@@ -40,7 +40,7 @@ impl WebhookArgs {
     ) -> Result<PushArgsOwned, Error> {
         if self.multipart.is_some() {
             return Err(Error::BadRequest(format!(
-                "Uploading files requires the parquet feature"
+                "multipart/form-data requires the parquet feature"
             )));
         }
 
@@ -135,7 +135,7 @@ impl WebhookArgs {
             }
 
             return Err(Error::BadRequest(format!(
-                "You need to connect your workspace to an S3 bucket to upload files"
+                "You need to connect your workspace to an S3 bucket to use multipart/form-data"
             )));
         }
 

--- a/backend/windmill-queue/src/jobs.rs
+++ b/backend/windmill-queue/src/jobs.rs
@@ -2515,7 +2515,7 @@ macro_rules! fetch_scalar_isolated {
 
 use sqlx::types::JsonRawValue;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct PushArgsOwned {
     pub extra: Option<HashMap<String, Box<RawValue>>>,
     pub args: HashMap<String, Box<RawValue>>,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for `multipart/form-data` in `WebhookArgs` and update S3 upload handling in the backend.
> 
>   - **Behavior**:
>     - Add `multipart/form-data` support in `WebhookArgs` in `args.rs`.
>     - Replace `upload_file_internal` with `upload_file_from_req` in `apps.rs` for S3 uploads.
>     - Handle multipart fields in `to_push_args_owned()` in `args.rs`.
>   - **Functions**:
>     - Modify `upload_s3_file_from_app()` in `apps.rs` to use `upload_file_from_req`.
>     - Update `from_request()` in `args.rs` to handle `multipart/form-data`.
>   - **Structs**:
>     - Add `multipart` and `wrap_body` fields to `WebhookArgs` in `args.rs`.
>     - Implement `Default` for `PushArgsOwned` in `jobs.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for b83654a56226f4d8bcf63daf77930e31f92d686f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->