### PR TITLE
fix backend test image for C#

### DIFF
--- a/.github/DockerfileBackendTests
+++ b/.github/DockerfileBackendTests
@@ -55,3 +55,4 @@ RUN apt-get update \
 RUN rustup component add rustfmt
 COPY --from=bitnami/dotnet-sdk:9.0.101-debian-12-r0 /opt/bitnami/dotnet-sdk /opt/dotnet-sdk
 RUN ln -s /opt/dotnet-sdk/bin/dotnet /usr/bin/dotnet
+ENV DOTNET_ROOT="/opt/dotnet-sdk/bin"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `DOTNET_ROOT` in Dockerfile to ensure correct .NET SDK functionality for backend tests.
> 
>   - **Dockerfile Changes**:
>     - Set `DOTNET_ROOT` environment variable in `.github/DockerfileBackendTests` to `/opt/dotnet-sdk/bin` to ensure correct .NET SDK functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 93d4a82897d96ddccb9fa1c0c3afc0fed0d74532. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->