### PR TITLE
flow: add path to flow script as well

### DIFF
--- a/backend/windmill-common/src/jobs.rs
+++ b/backend/windmill-common/src/jobs.rs
@@ -274,7 +274,8 @@ pub enum JobPayload {
         apply_preprocessor: bool,
     },
     FlowScript {
-        id: FlowNodeId, // flow_node(id).
+        id: FlowNodeId,       // flow_node(id).
+        path: Option<String>, // flow step path.
         language: ScriptLang,
         custom_concurrency_key: Option<String>,
         concurrent_limit: Option<i32>,

--- a/backend/windmill-queue/src/jobs.rs
+++ b/backend/windmill-queue/src/jobs.rs
@@ -2845,7 +2845,8 @@ pub async fn push<'c, 'd>(
             )
         }
         JobPayload::FlowScript {
-            id, // flow_node(id).
+            id,   // flow_node(id).
+            path, // flow step path.
             language,
             custom_concurrency_key,
             concurrent_limit,
@@ -2854,7 +2855,7 @@ pub async fn push<'c, 'd>(
             dedicated_worker,
         } => (
             Some(id.0),
-            None,
+            path,
             None,
             JobKind::FlowScript,
             None,

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -3089,9 +3089,19 @@ async fn compute_next_flow_transform(
             concurrency_time_window_s,
             ..
         } => {
+            let path = if status
+                .preprocessor_module
+                .as_ref()
+                .is_some_and(|x| x.id() == module.id)
+            {
+                format!("{}/preprocessor", flow_job.script_path())
+            } else {
+                format!("{}/step-{}", flow_job.script_path(), status.step)
+            };
             let payload = JobPayloadWithTag {
                 payload: JobPayload::FlowScript {
                     id,
+                    path: Some(path),
                     language,
                     custom_concurrency_key: custom_concurrency_key.clone(),
                     concurrent_limit,
@@ -3693,6 +3703,7 @@ async fn payload_from_simple_module(
         } => JobPayloadWithTag {
             payload: JobPayload::FlowScript {
                 id,
+                path: inner_path,
                 language,
                 custom_concurrency_key,
                 concurrent_limit,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add optional `path` field to `FlowScript` in `JobPayload` to specify flow step paths.
> 
>   - **Behavior**:
>     - Add `path` field to `FlowScript` variant in `JobPayload` in `jobs.rs`.
>     - `path` is optional and represents the flow step path.
>   - **Implementation**:
>     - Update `push()` function in `jobs.rs` to handle `path` for `FlowScript`.
>     - Modify `compute_next_flow_transform()` in `worker_flow.rs` to set `path` for `FlowScript`.
>     - Ensure `path` is set in `update_flow_status_after_job_completion_internal()` in `worker_flow.rs`.
>   - **Misc**:
>     - Adjust comments and formatting for clarity and consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for e505b6f722341fe4c3d15b74d241f3d95de477bb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->