### PR TITLE
Resource type description markdown support

### DIFF
--- a/frontend/src/routes/(root)/(logged)/resources/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/resources/+page.svelte
@@ -59,6 +59,7 @@
 	import autosize from '$lib/autosize'
 	import EditableSchemaWrapper from '$lib/components/schema/EditableSchemaWrapper.svelte'
 	import ResourceEditorDrawer from '$lib/components/ResourceEditorDrawer.svelte'
+	import GfmMarkdown from '$lib/components/GfmMarkdown.svelte'
 
 	type ResourceW = ListableResource & { canWrite: boolean; marked?: string }
 	type ResourceTypeW = ResourceType & { canWrite: boolean }
@@ -437,7 +438,7 @@
 		<div>
 			<h1 class="mb-8 mt-4"><IconedResourceType name={resourceTypeViewerObj.rt} formatExtension={resourceTypeViewerObj.formatExtension} /></h1>
 			<div class="py-2 box prose mb-8 text-secondary">
-				{resourceTypeViewerObj.description ?? ''}
+				<GfmMarkdown md={resourceTypeViewerObj.description ?? ''} />
 			</div>
 			{#if resourceTypeViewerObj.formatExtension}
 		<Alert type="info" title="Plain text file resource (.{resourceTypeViewerObj.formatExtension})">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add markdown rendering for resource type descriptions using `GfmMarkdown` in `+page.svelte`.
> 
>   - **Behavior**:
>     - Use `GfmMarkdown` component to render `resourceTypeViewerObj.description` as markdown in `+page.svelte`.
>   - **Components**:
>     - Import `GfmMarkdown` from `$lib/components/GfmMarkdown.svelte` in `+page.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 4c9e12ba0ba94fb258c571c8bc50bfeacdaba598. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->