### PR TITLE
fix python build

### DIFF
--- a/python-client/build.sh
+++ b/python-client/build.sh
@@ -49,7 +49,12 @@ user friendly experience. We use \
 
 echo "" >> windmill-api/README.md.tmp
 
-tail -r windmill-api/README.md | tail -n +14 | tail -r >> windmill-api/README.md.tmp
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    tail -r windmill-api/README.md | tail -n +14 | tail -r >> windmill-api/README.md.tmp
+else
+    head -n -13 windmill-api/README.md >> windmill-api/README.md.tmp
+fi
+
 mv windmill-api/README.md.tmp windmill-api/README.md
 
 cd windmill-api && poetry build


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `tail` command usage in `build.sh` for macOS compatibility.
> 
>   - **Build Script**:
>     - Fixes `tail` command usage in `build.sh` to handle macOS and other systems differently.
>     - Uses `head` command for non-macOS systems to append correct lines to `README.md.tmp`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 55620520178cc96b60a088860acec2c9a16cc39c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->