### PR TITLE
fix(windows&python): Access is denied. (os error 5)

### DIFF
--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -336,6 +336,18 @@ pub async fn uv_pip_compile(
             .args(&args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+
+        #[cfg(windows)]
+        {
+            child_cmd = child_cmd
+                .env("SystemRoot", SYSTEM_ROOT.as_str())
+                .env("USERPROFILE", crate::USERPROFILE_ENV.as_str())
+                .env(
+                    "TMP",
+                    std::env::var("TMP").unwrap_or_else(|_| String::from("/tmp")),
+                );
+        }
+
         let child_process = start_child_process(child_cmd, uv_cmd).await?;
         append_logs(&job_id, &w_id, logs, db).await;
         handle_child(

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -339,7 +339,7 @@ pub async fn uv_pip_compile(
 
         #[cfg(windows)]
         {
-            child_cmd = child_cmd
+            child_cmd
                 .env("SystemRoot", SYSTEM_ROOT.as_str())
                 .env("USERPROFILE", crate::USERPROFILE_ENV.as_str())
                 .env(


### PR DESCRIPTION
resolving dependencies...
content of requirements:
azure-monitor-events-extension
azure-monitor-opentelemetry

error: Access is denied. (os error 5) at path "C:\\Windows\\.tmp17eKl8"
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes 'Access is denied' error on Windows in `uv_pip_compile()` by setting necessary environment variables for the child process.
> 
>   - **Behavior**:
>     - Fixes 'Access is denied' error on Windows in `uv_pip_compile()` in `python_executor.rs` by setting `SystemRoot`, `USERPROFILE`, and `TMP` environment variables for the child process.
>   - **Environment**:
>     - Sets `SystemRoot` and `USERPROFILE` using existing constants.
>     - Sets `TMP` to system `TMP` variable or defaults to `/tmp` if not set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f80ed1d32f476b47baf4aaac82b640ebf5c9f201. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->