### PR TITLE
fix: windows compatibility for C#

### DIFF
--- a/backend/windmill-worker/src/csharp_executor.rs
+++ b/backend/windmill-worker/src/csharp_executor.rs
@@ -45,17 +45,16 @@ use crate::SYSTEM_ROOT;
 #[cfg(feature = "csharp")]
 const NSJAIL_CONFIG_RUN_CSHARP_CONTENT: &str = include_str!("../nsjail/run.csharp.config.proto");
 
-#[cfg(feature = "csharp")]
-lazy_static::lazy_static! {
-    static ref DOTNET_ROOT: String = std::env::var("DOTNET_ROOT").unwrap_or_else(|_| DOTNET_ROOT_DEFAULT.to_string());
-
-}
-
 #[cfg(windows)]
 const DOTNET_ROOT_DEFAULT: &str = "C:\\Program Files\\dotnet";
 
 #[cfg(unix)]
 const DOTNET_ROOT_DEFAULT: &str = "/usr/share/dotnet";
+
+#[cfg(feature = "csharp")]
+lazy_static::lazy_static! {
+    static ref DOTNET_ROOT: String = std::env::var("DOTNET_ROOT").unwrap_or_else(|_| DOTNET_ROOT_DEFAULT.to_string());
+}
 
 #[cfg(feature = "csharp")]
 const CSHARP_OBJECT_STORE_PREFIX: &str = "csharpbin/";

--- a/backend/windmill-worker/src/csharp_executor.rs
+++ b/backend/windmill-worker/src/csharp_executor.rs
@@ -45,12 +45,18 @@ use crate::SYSTEM_ROOT;
 #[cfg(feature = "csharp")]
 const NSJAIL_CONFIG_RUN_CSHARP_CONTENT: &str = include_str!("../nsjail/run.csharp.config.proto");
 
+
 #[cfg(feature = "csharp")]
 lazy_static::lazy_static! {
-    static ref HOME_DIR: String = std::env::var("HOME").expect("Could not find the HOME environment variable");
-    static ref DOTNET_ROOT: String = std::env::var("DOTNET_ROOT").expect("Could not find the DOTNET_ROOT environment variable");
+    static ref DOTNET_ROOT: String = std::env::var("DOTNET_ROOT").unwrap_or_else(|_| DOTNET_ROOT_DEFAULT.to_string());
 
 }
+
+#[cfg(windows)]
+const DOTNET_ROOT_DEFAULT: &str = "C:\\Program Files\\dotnet";
+
+#[cfg(unix)]
+const DOTNET_ROOT_DEFAULT: &str =  "/usr/share/dotnet";
 
 #[cfg(feature = "csharp")]
 const CSHARP_OBJECT_STORE_PREFIX: &str = "csharpbin/";
@@ -83,6 +89,9 @@ pub async fn generate_nuget_lockfile(
         .args(vec!["restore", "--use-lock-file"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    #[cfg(windows)]
+    gen_lockfile_cmd.env("SystemRoot", SYSTEM_ROOT.as_str());
+
     let gen_lockfile_process = start_child_process(gen_lockfile_cmd, DOTNET_PATH.as_str()).await?;
     handle_child(
         job_id,
@@ -147,6 +156,12 @@ fn gen_cs_proj(
         })
         .join("\n");
 
+    let item_group = if pkgs.is_empty() {"".to_string()} else {format!(
+r#"  <ItemGroup>
+{pkgs}
+  </ItemGroup>
+"#)};
+
     write_file(
         job_dir,
         "Main.csproj",
@@ -159,10 +174,7 @@ fn gen_cs_proj(
     <StartupObject>WindmillScriptCSharpInternal.Wrapper</StartupObject>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
-  <ItemGroup>
-{pkgs}
-  </ItemGroup>
-
+{item_group}
 </Project>
 "#
         ),
@@ -497,6 +509,10 @@ pub async fn handle_csharp_job(
             .args(vec!["--config", "run.config.proto", "--", "/tmp/main"])
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+
+        #[cfg(windows)]
+        nsjail_cmd.env("SystemRoot", SYSTEM_ROOT.as_str());
+
         start_child_process(nsjail_cmd, NSJAIL_PATH.as_str()).await?
     } else {
         let compiled_executable_name = "./Main";
@@ -515,6 +531,9 @@ pub async fn handle_csharp_job(
             .env("HOME", HOME_ENV.as_str())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+
+        #[cfg(windows)]
+        run_csharp.env("SystemRoot", SYSTEM_ROOT.as_str());
 
         start_child_process(run_csharp, compiled_executable_name).await?
     };

--- a/backend/windmill-worker/src/csharp_executor.rs
+++ b/backend/windmill-worker/src/csharp_executor.rs
@@ -100,7 +100,7 @@ pub async fn generate_nuget_lockfile(
         .env(
             "APPDATA",
             std::env::var("APPDATA")
-                .unwrap_or_else(|| format!("{}\\AppData\\Roaming", HOME_ENV.as_str())),
+                .unwrap_or_else(|_| format!("{}\\AppData\\Roaming", HOME_ENV.as_str())),
         )
         .env(
             "ProgramFiles",
@@ -344,7 +344,7 @@ async fn build_cs_proj(
         .env(
             "APPDATA",
             std::env::var("APPDATA")
-                .unwrap_or_else(|| format!("{}\\AppData\\Roaming", HOME_ENV.as_str())),
+                .unwrap_or_else(|_| format!("{}\\AppData\\Roaming", HOME_ENV.as_str())),
         )
         .env(
             "ProgramFiles",
@@ -579,27 +579,28 @@ pub async fn handle_csharp_job(
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
         #[cfg(windows)]
-            run_csharp.env("SystemRoot", SYSTEM_ROOT.as_str())
-        .env("SystemRoot", SYSTEM_ROOT.as_str())
-        .env(
-            "TMP",
-            std::env::var("TMP").unwrap_or_else(|_| "C:\\tmp".to_string()),
-        )
-        .env("USERPROFILE", crate::USERPROFILE_ENV.as_str())
-        .env(
-            "APPDATA",
-            std::env::var("APPDATA")
-                .unwrap_or_else(|| format!("{}\\AppData\\Roaming", HOME_ENV.as_str())),
-        )
-        .env(
-            "ProgramFiles",
-            std::env::var("ProgramFiles").unwrap_or_else(|_| String::from("C:\\Program Files")),
-        )
-        .env(
-            "LOCALAPPDATA",
-            std::env::var("LOCALAPPDATA")
-                .unwrap_or_else(|_| format!("{}\\AppData\\Local", HOME_ENV.as_str())),
-        );
+        run_csharp
+            .env("SystemRoot", SYSTEM_ROOT.as_str())
+            .env("SystemRoot", SYSTEM_ROOT.as_str())
+            .env(
+                "TMP",
+                std::env::var("TMP").unwrap_or_else(|_| "C:\\tmp".to_string()),
+            )
+            .env("USERPROFILE", crate::USERPROFILE_ENV.as_str())
+            .env(
+                "APPDATA",
+                std::env::var("APPDATA")
+                    .unwrap_or_else(|_| format!("{}\\AppData\\Roaming", HOME_ENV.as_str())),
+            )
+            .env(
+                "ProgramFiles",
+                std::env::var("ProgramFiles").unwrap_or_else(|_| String::from("C:\\Program Files")),
+            )
+            .env(
+                "LOCALAPPDATA",
+                std::env::var("LOCALAPPDATA")
+                    .unwrap_or_else(|_| format!("{}\\AppData\\Local", HOME_ENV.as_str())),
+            );
 
         start_child_process(run_csharp, &compiled_executable_name).await?
     };

--- a/backend/windmill-worker/src/csharp_executor.rs
+++ b/backend/windmill-worker/src/csharp_executor.rs
@@ -45,9 +45,11 @@ use crate::SYSTEM_ROOT;
 #[cfg(feature = "csharp")]
 const NSJAIL_CONFIG_RUN_CSHARP_CONTENT: &str = include_str!("../nsjail/run.csharp.config.proto");
 
+#[cfg(feature = "csharp")]
 #[cfg(windows)]
 const DOTNET_ROOT_DEFAULT: &str = "C:\\Program Files\\dotnet";
 
+#[cfg(feature = "csharp")]
 #[cfg(unix)]
 const DOTNET_ROOT_DEFAULT: &str = "/usr/share/dotnet";
 

--- a/backend/windmill-worker/src/csharp_executor.rs
+++ b/backend/windmill-worker/src/csharp_executor.rs
@@ -89,7 +89,28 @@ pub async fn generate_nuget_lockfile(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     #[cfg(windows)]
-    gen_lockfile_cmd.env("SystemRoot", SYSTEM_ROOT.as_str());
+    gen_lockfile_cmd
+        .env("SystemRoot", SYSTEM_ROOT.as_str())
+        .env("SystemRoot", SYSTEM_ROOT.as_str())
+        .env(
+            "TMP",
+            std::env::var("TMP").unwrap_or_else(|_| "C:\\tmp".to_string()),
+        )
+        .env("USERPROFILE", crate::USERPROFILE_ENV.as_str())
+        .env(
+            "APPDATA",
+            std::env::var("APPDATA")
+                .unwrap_or_else(|| format!("{}\\AppData\\Roaming", HOME_ENV.as_str())),
+        )
+        .env(
+            "ProgramFiles",
+            std::env::var("ProgramFiles").unwrap_or_else(|_| String::from("C:\\Program Files")),
+        )
+        .env(
+            "LOCALAPPDATA",
+            std::env::var("LOCALAPPDATA")
+                .unwrap_or_else(|_| format!("{}\\AppData\\Local", HOME_ENV.as_str())),
+        );
 
     let gen_lockfile_process = start_child_process(gen_lockfile_cmd, DOTNET_PATH.as_str()).await?;
     handle_child(
@@ -313,16 +334,27 @@ async fn build_cs_proj(
         .stderr(Stdio::piped());
 
     #[cfg(windows)]
-    {
-        build_cs_cmd.env("SystemRoot", SYSTEM_ROOT.as_str());
-        build_cs_cmd.env(
+    build_cs_cmd
+        .env("SystemRoot", SYSTEM_ROOT.as_str())
+        .env(
             "TMP",
             std::env::var("TMP").unwrap_or_else(|_| "C:\\tmp".to_string()),
+        )
+        .env("USERPROFILE", crate::USERPROFILE_ENV.as_str())
+        .env(
+            "APPDATA",
+            std::env::var("APPDATA")
+                .unwrap_or_else(|| format!("{}\\AppData\\Roaming", HOME_ENV.as_str())),
+        )
+        .env(
+            "ProgramFiles",
+            std::env::var("ProgramFiles").unwrap_or_else(|_| String::from("C:\\Program Files")),
+        )
+        .env(
+            "LOCALAPPDATA",
+            std::env::var("LOCALAPPDATA")
+                .unwrap_or_else(|_| format!("{}\\AppData\\Local", HOME_ENV.as_str())),
         );
-        build_cs_cmd.env("USERPROFILE", crate::USERPROFILE_ENV.as_str());
-        build_cs_cmd.env("APPDATA", std::env::var("APPDATA").unwrap());
-        build_cs_cmd.env("ProgramFiles", std::env::var("ProgramFiles").unwrap());
-    }
 
     let build_cs_process = start_child_process(build_cs_cmd, DOTNET_PATH.as_str()).await?;
     handle_child(
@@ -547,13 +579,27 @@ pub async fn handle_csharp_job(
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
         #[cfg(windows)]
-        {
-            run_csharp.env("SystemRoot", SYSTEM_ROOT.as_str());
-            run_csharp.env(
-                "TMP",
-                std::env::var("TMP").unwrap_or_else(|_| "C:\\tmp".to_string()),
-            );
-        }
+            run_csharp.env("SystemRoot", SYSTEM_ROOT.as_str())
+        .env("SystemRoot", SYSTEM_ROOT.as_str())
+        .env(
+            "TMP",
+            std::env::var("TMP").unwrap_or_else(|_| "C:\\tmp".to_string()),
+        )
+        .env("USERPROFILE", crate::USERPROFILE_ENV.as_str())
+        .env(
+            "APPDATA",
+            std::env::var("APPDATA")
+                .unwrap_or_else(|| format!("{}\\AppData\\Roaming", HOME_ENV.as_str())),
+        )
+        .env(
+            "ProgramFiles",
+            std::env::var("ProgramFiles").unwrap_or_else(|_| String::from("C:\\Program Files")),
+        )
+        .env(
+            "LOCALAPPDATA",
+            std::env::var("LOCALAPPDATA")
+                .unwrap_or_else(|_| format!("{}\\AppData\\Local", HOME_ENV.as_str())),
+        );
 
         start_child_process(run_csharp, &compiled_executable_name).await?
     };

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -331,6 +331,12 @@ lazy_static::lazy_static! {
     pub static ref WORKER_EXECUTION_DURATION: Arc<RwLock<HashMap<String, prometheus::Histogram>>> = Arc::new(RwLock::new(HashMap::new()));
 }
 
+#[cfg(windows)]
+const DOTNET_DEFAULT_PATH: &str = "C:\\Program Files\\dotnet\\dotnet.exe";
+#[cfg(unix)]
+const DOTNET_DEFAULT_PATH: &str = "/usr/bin/dotnet";
+
+
 lazy_static::lazy_static! {
 
     pub static ref JOB_TOKEN: Option<String> = std::env::var("JOB_TOKEN").ok();
@@ -385,7 +391,7 @@ lazy_static::lazy_static! {
     pub static ref POWERSHELL_PATH: String = std::env::var("POWERSHELL_PATH").unwrap_or_else(|_| "/usr/bin/pwsh".to_string());
     pub static ref PHP_PATH: String = std::env::var("PHP_PATH").unwrap_or_else(|_| "/usr/bin/php".to_string());
     pub static ref COMPOSER_PATH: String = std::env::var("COMPOSER_PATH").unwrap_or_else(|_| "/usr/bin/composer".to_string());
-    pub static ref DOTNET_PATH: String = std::env::var("DOTNET_PATH").unwrap_or_else(|_| "/usr/bin/dotnet".to_string());
+    pub static ref DOTNET_PATH: String = std::env::var("DOTNET_PATH").unwrap_or_else(|_| DOTNET_DEFAULT_PATH.to_string());
     pub static ref NSJAIL_PATH: String = std::env::var("NSJAIL_PATH").unwrap_or_else(|_| "nsjail".to_string());
     pub static ref PATH_ENV: String = std::env::var("PATH").unwrap_or_else(|_| String::new());
     pub static ref HOME_ENV: String = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance Windows compatibility for C# execution by adjusting environment variables, file paths, and command configurations in `csharp_executor.rs`.
> 
>   - **Environment Variables**:
>     - Set `DOTNET_ROOT` with default paths for Windows (`C:\Program Files\dotnet`) and Unix (`/usr/share/dotnet`) in `csharp_executor.rs`.
>     - Add Windows-specific environment variables `SystemRoot`, `USERPROFILE`, `APPDATA`, and `ProgramFiles` in `build_cs_proj()` and `generate_nuget_lockfile()`.
>   - **File Paths**:
>     - Use `.exe` extension for `Main` executable on Windows in `build_cs_proj()` and `handle_csharp_job()`.
>     - Adjust symlink creation for Unix only in `handle_csharp_job()`.
>   - **Commands**:
>     - Add `SystemRoot` to `nsjail_cmd` and `run_csharp` commands on Windows in `handle_csharp_job()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for d058c58dfee3ccdda0aa06b61f65fe5b41a96184. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->