### PR TITLE
fix: handle `'flownode'` job kind where missing

### DIFF
--- a/backend/.sqlx/query-364248db86a9228bba6ff522e811d68c5c902ee0a07ea69bff772ff10d0dc5aa.json
+++ b/backend/.sqlx/query-364248db86a9228bba6ff522e811d68c5c902ee0a07ea69bff772ff10d0dc5aa.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE queue SET flow_status = JSONB_SET(flow_status,  ARRAY['user_states'], JSONB_SET(COALESCE(flow_status->'user_states', '{}'::jsonb), ARRAY[$1], $2))\n        WHERE id = $3 AND workspace_id = $4 AND job_kind IN ('flow', 'flowpreview', 'flownode') RETURNING 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "?column?",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Jsonb",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "364248db86a9228bba6ff522e811d68c5c902ee0a07ea69bff772ff10d0dc5aa"
+}

--- a/backend/.sqlx/query-84576f6add15108ade2ed3a88185d67db17904859e5f01f1d578af4e1d062a85.json
+++ b/backend/.sqlx/query-84576f6add15108ade2ed3a88185d67db17904859e5f01f1d578af4e1d062a85.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE queue SET running = false, started_at = null\n                WHERE last_ping < now() - ($1 || ' seconds')::interval\n                 AND running = true AND job_kind NOT IN ('flow', 'flowpreview', 'flownode', 'singlescriptflow') AND same_worker = false RETURNING id, workspace_id, last_ping",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "workspace_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "last_ping",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "84576f6add15108ade2ed3a88185d67db17904859e5f01f1d578af4e1d062a85"
+}

--- a/backend/.sqlx/query-f6a275ad8bc7dfec7f9a6b60c669f6f2ff93ce57b5afadabd618e1fb52951fef.json
+++ b/backend/.sqlx/query-f6a275ad8bc7dfec7f9a6b60c669f6f2ff93ce57b5afadabd618e1fb52951fef.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n    SELECT usr.email, usage.executions\n        FROM usr\n            , LATERAL (\n            SELECT COALESCE(SUM(duration_ms + 1000)/1000 , 0)::BIGINT executions\n                FROM completed_job\n                WHERE workspace_id = $1\n                AND job_kind NOT IN ('flow', 'flowpreview', 'flownode')\n                AND email = usr.email\n                AND now() - '1 week'::interval < created_at \n            ) usage\n        WHERE workspace_id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "executions",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "f6a275ad8bc7dfec7f9a6b60c669f6f2ff93ce57b5afadabd618e1fb52951fef"
+}

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -2340,7 +2340,7 @@ pub async fn set_flow_user_state(
     let r = sqlx::query_scalar!(
         r#"
         UPDATE queue SET flow_status = JSONB_SET(flow_status,  ARRAY['user_states'], JSONB_SET(COALESCE(flow_status->'user_states', '{}'::jsonb), ARRAY[$1], $2))
-        WHERE id = $3 AND workspace_id = $4 AND job_kind IN ('flow', 'flowpreview') RETURNING 1
+        WHERE id = $3 AND workspace_id = $4 AND job_kind IN ('flow', 'flowpreview', 'flownode') RETURNING 1
         "#,
         key,
         value,

--- a/backend/windmill-api/src/users.rs
+++ b/backend/windmill-api/src/users.rs
@@ -473,7 +473,7 @@ async fn list_user_usage(
             SELECT COALESCE(SUM(duration_ms + 1000)/1000 , 0)::BIGINT executions
                 FROM completed_job
                 WHERE workspace_id = $1
-                AND job_kind NOT IN ('flow', 'flowpreview')
+                AND job_kind NOT IN ('flow', 'flowpreview', 'flownode')
                 AND email = usr.email
                 AND now() - '1 week'::interval < created_at 
             ) usage


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add handling for 'flownode' job kind in SQL queries and logic across the codebase.
> 
>   - **Behavior**:
>     - Add 'flownode' to job kinds in SQL queries in `monitor.rs` and `jobs.rs` to handle it similarly to 'flow' and 'flowpreview'.
>   - **SQL Queries**:
>     - Update `UPDATE queue` queries in `monitor.rs` and `jobs.rs` to include 'flownode'.
>     - Update `SELECT` query in `users.rs` to exclude 'flownode' from certain calculations.
>   - **Misc**:
>     - Add new SQL query files for updated queries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 0f28988b04aef04b5520bdc5ea9db7a1dd862fbe. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->