### PR TITLE
adding jaeger to docker-compose template

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,6 +170,16 @@ services:
       # - BASE_URL=":443" # uncomment and comment line above to enable HTTPS via custom certificate and key files
       # - BASE_URL=mydomain.com # Uncomment and comment line above to enable HTTPS handling by Caddy
 
+  # The jaeger container to collect and display OTEL traces (EE feature)
+  # jaeger:
+  #   image: jaegertracing/opentelemetry-all-in-one
+  #   container_name: jaeger_otel
+  #   expose:
+  #     - 9411
+  #   ports:
+  #     - 16686:16686
+  #   restart: always
+
 volumes:
   db_data: null
   worker_dependency_cache: null


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add commented-out Jaeger service to `docker-compose.yml` for OTEL traces in Enterprise Edition.
> 
>   - **Services**:
>     - Add commented-out `jaeger` service in `docker-compose.yml` for OTEL traces collection and display, intended as an Enterprise Edition feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 5fc0a354f052ba7c9106261c90105329c86610c2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->