### PR TITLE
snowflake resource picker to show both snowflake + snowflake_oauth

### DIFF
--- a/frontend/src/lib/components/ResourcePicker.svelte
+++ b/frontend/src/lib/components/ResourcePicker.svelte
@@ -47,12 +47,19 @@
 	async function loadResources(resourceType: string | undefined) {
 		loading = true
 		try {
-			const nc = (
-				await ResourceService.listResource({
-					workspace: $workspaceStore!,
-					resourceType
-				})
+			const resourceTypesToQuery =
+				resourceType === 'snowflake' ? ['snowflake', 'snowflake_oauth'] : [resourceType]
+
+			const resources = await Promise.all(
+				resourceTypesToQuery.map((rt) =>
+					ResourceService.listResource({
+						workspace: $workspaceStore!,
+						resourceType: rt
+					})
+				)
 			)
+			const nc = resources
+				.flat()
 				.filter((x) => x.resource_type != 'state' && x.resource_type != 'cache')
 				.map((x) => ({
 					value: x.path,

--- a/frontend/src/lib/components/TestConnection.svelte
+++ b/frontend/src/lib/components/TestConnection.svelte
@@ -40,6 +40,11 @@
 			lang: 'snowflake',
 			argName: 'database'
 		},
+		snowflake_oauth: {
+			code: `select 1`,
+			lang: 'snowflake',
+			argName: 'database'
+		},
 		ms_sql_server: {
 			code: `SELECT 1`,
 			lang: 'mssql',

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -3713,7 +3713,8 @@ See date-fns format for more information. By default, it is 'dd.MM.yyyy HH:mm'
 						mysql: 'MySQL',
 						ms_sql_server: 'MS SQL Server',
 						snowflake: 'Snowflake',
-						bigquery: 'BigQuery'
+						bigquery: 'BigQuery',
+						snowflake_oauth: 'Snowflake OAuth'
 					},
 					configuration: {
 						postgresql: {

--- a/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/StaticInputEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/StaticInputEditor.svelte
@@ -73,7 +73,7 @@
 			<IconSelectInput bind:value={componentInput.value} />
 		{:else if fieldType === 'tab-select'}
 			<TabSelectInput bind:componentInput />
-		{:else if fieldType === 'resource' && subFieldType && ['mysql', 'postgres', 'ms_sql_server', 'snowflake', 'bigquery'].includes(subFieldType)}
+		{:else if fieldType === 'resource' && subFieldType && ['mysql', 'postgres', 'ms_sql_server', 'snowflake', 'snowflake_oauth', 'bigquery'].includes(subFieldType)}
 			<ResourcePicker
 				initialValue={componentInput.value?.split('$res:')?.[1] || ''}
 				on:change={(e) => {

--- a/frontend/src/lib/components/apps/inputType.ts
+++ b/frontend/src/lib/components/apps/inputType.ts
@@ -38,6 +38,7 @@ export type InputType =
 	| 'mysql'
 	| 'ms_sql_server'
 	| 'snowflake'
+	| 'snowflake_oauth'
 	| 'bigquery'
 	| 'app-path'
 
@@ -224,6 +225,7 @@ export type AppInput =
 	| AppInputSpec<'resource', string, 'mysql'>
 	| AppInputSpec<'resource', string, 'ms_sql_server'>
 	| AppInputSpec<'resource', string, 'snowflake'>
+	| AppInputSpec<'resource', string, 'snowflake_oauth'>
 	| AppInputSpec<'resource', string, 'bigquery'>
 	| AppInputSpec<'array', object[], 'number-tuple'>
 	| AppInputSpec<'app-path', string>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for `snowflake_oauth` alongside `snowflake` in resource loading, connection testing, schema handling, and UI components.
> 
>   - **Behavior**:
>     - `ResourcePicker.svelte`: Modified `loadResources()` to query both `snowflake` and `snowflake_oauth` resources.
>     - `TestConnection.svelte`: Added `snowflake_oauth` to the `scripts` object for connection testing.
>     - `utils.ts`: Updated `loadTableMetaData()` and `scripts` to handle `snowflake_oauth`.
>   - **UI Components**:
>     - `components.ts`: Added `snowflake_oauth` to the database type options.
>     - `StaticInputEditor.svelte`: Updated to include `snowflake_oauth` in resource type checks.
>   - **Types**:
>     - `inputType.ts`: Added `snowflake_oauth` to `InputType` and `AppInput`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for ec2f8956b4ecb7a9078b37c637386ca65242b2ee. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->