### PR TITLE
fix: show array type narrowing

### DIFF
--- a/frontend/src/lib/components/ArrayTypeNarrowing.svelte
+++ b/frontend/src/lib/components/ArrayTypeNarrowing.svelte
@@ -42,7 +42,7 @@
 	}
 </script>
 
-{#if canEditResourceType}
+{#if itemsType?.type === 'resource' && canEditResourceType || itemsType?.type !== 'resource'}
 	<Label label="Items type">
 		<select
 			bind:value={selected}

--- a/frontend/src/lib/components/ArrayTypeNarrowing.svelte
+++ b/frontend/src/lib/components/ArrayTypeNarrowing.svelte
@@ -42,7 +42,7 @@
 	}
 </script>
 
-{#if itemsType?.type === 'resource' && canEditResourceType || itemsType?.type !== 'resource'}
+{#if (itemsType?.type === 'resource' && canEditResourceType) || itemsType?.type !== 'resource'}
 	<Label label="Items type">
 		<select
 			bind:value={selected}


### PR DESCRIPTION
Currently narrowing a list/array input to be strings from an enum in the generated UI is not possible as documented below

https://www.windmill.dev/videos/advanced_parameters_enum.mp4


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix condition in `ArrayTypeNarrowing.svelte` to enable array type narrowing to string enums in the UI.
> 
>   - **Behavior**:
>     - Modify condition in `ArrayTypeNarrowing.svelte` to show 'Items type' label and select when `itemsType` is 'resource' and `canEditResourceType` is true, or when `itemsType` is not 'resource'.
>     - Enables narrowing of list/array input to strings from an enum in the UI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 13446ef186269dddd1c30306a2117c3682056b97. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->