### PR TITLE
feat: update git sync scripts with url redacted

### DIFF
--- a/frontend/src/lib/hubPaths.json
+++ b/frontend/src/lib/hubPaths.json
@@ -1,7 +1,9 @@
 {
 	"gitSync_0": "hub/9087/sync-script-to-git-repo-windmill",
-	"gitSync": "hub/9987/sync-script-to-git-repo-windmill",
-	"gitSyncTest": "hub/9073/git-repo-test-read-write-windmill",
+	"gitSync_1": "hub/9987/sync-script-to-git-repo-windmill",
+	"gitSync": "hub/11498/sync-script-to-git-repo-windmill",
+	"gitSyncTest_0": "hub/9073/git-repo-test-read-write-windmill",
+	"gitSyncTest": "hub/11499/git-repo-test-read-write-windmill",
 	"slackErrorHandler": "hub/9206/workspace-or-schedule-error-handler-slack",
 	"slackErrorHandler_0": "hub/9079/workspace-or-schedule-error-handler-slack",
 	"slackRecoveryHandler": "hub/9080/slack/schedule-recovery-handler-slack",

--- a/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
@@ -1474,12 +1474,12 @@
 									<Alert type="warning" title="Script version mismatch">
 										The git sync version for this repository is not latest. Current: <a
 											target="_blank"
-											href="https://hub.windmill.dev/scripts/windmill/6943/sync-script-to-git-repo-windmill/5813/versions"
+											href="https://hub.windmill.dev/scripts/windmill/6943/sync-script-to-git-repo-windmill/9014/versions"
 											>{gitSyncRepository.script_path}</a
 										>, latest:
 										<a
 											target="_blank"
-											href="https://hub.windmill.dev/scripts/windmill/6943/sync-script-to-git-repo-windmill/5813/versions"
+											href="https://hub.windmill.dev/scripts/windmill/6943/sync-script-to-git-repo-windmill/9014/versions"
 											>{latestGitSyncHubScript}</a
 										>
 										<div class="flex mt-2">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update git sync script paths and URLs to latest versions in `hubPaths.json` and `+page.svelte`.
> 
>   - **Paths Update**:
>     - Update `gitSync` and `gitSyncTest` paths in `hubPaths.json` to new versions.
>   - **UI Update**:
>     - Update script version URLs in `+page.svelte` for git sync alerts to reflect the latest version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 50690de10538d9e43fb28ede83461a8d67502e3c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->