### PR TITLE
fix: mysql/rust decimal build

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5318,6 +5318,7 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
  "regex",
+ "rust_decimal",
  "saturating",
  "serde",
  "serde_json",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -260,7 +260,7 @@ getrandom = "0.2"
 tokio-postgres = {version = "^0.7", features = ["array-impls", "with-serde_json-1", "with-chrono-0_4", "with-uuid-1", "with-bit-vec-0_6"]}
 bit-vec = "=0.6.3"
 mappable-rc = "^0"
-mysql_async = { version = "*", default-features = false, features = ["minimal", "default", "native-tls-tls"]}
+mysql_async = { version = "*", default-features = false, features = ["minimal", "default", "native-tls-tls", "rust_decimal"]}
 postgres-native-tls = "^0"
 native-tls = "^0"
 # samael will break compilation on MacOS. Use this fork instead to make it work


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `rust_decimal` feature to `mysql_async` and update `Cargo.lock` to fix MySQL/Rust decimal build issue.
> 
>   - **Dependencies**:
>     - Add `rust_decimal` feature to `mysql_async` in `Cargo.toml`.
>     - Update `Cargo.lock` to include `rust_decimal` dependency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 926b345233dc72d62e38f89374e5e015dfea5fd5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->