### PR TITLE
fix: fix base path for relative imports in parallel loop

### DIFF
--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -948,7 +948,7 @@ pub async fn clean_cache() -> error::Result<()> {
 }
 
 lazy_static::lazy_static! {
-    static ref RE_FLOW_ROOT: Regex = Regex::new(r"(?i)(.*?)(?:/branchone-\d+/|/branchall-\d+/|/loop-\d+/)").unwrap();
+    static ref RE_FLOW_ROOT: Regex = Regex::new(r"(?i)(.*?)(?:/branchone-\d+/|/branchall-\d+/|/loop-\d+|/forloop-\d+/)").unwrap();
 
 }
 


### PR DESCRIPTION
When using a parallel loop, the path of the steps is of the form
`<flow>/forloop-<n>/step-<m>`. When building the path to use as a base for
relative imports in flow scripts, the regex in `use_flow_root_path` does not
strip `forloop-`. Instead, it only strips `loop-`.

This patch adds `forloop-` to the regex, which allows for correct base path
resolution when using parallel for loops.

PS: I couldn't decide between this change (editing the regex) or making both
non-parallel and parallel loops use `loop-<n>` when building the path, either
one should fix the issue. In my head, this is the "safer" change, as it doesn't
change any of the flow executor behavior.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes base path resolution for parallel loops by updating regex in `common.rs` to include `forloop-`.
> 
>   - **Behavior**:
>     - Fixes base path resolution for parallel loops by updating regex in `common.rs` to include `forloop-`.
>   - **Regex**:
>     - Modifies `RE_FLOW_ROOT` in `common.rs` to match `/forloop-<n>/` paths.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for deadfcff5d9270ca0e86688512c73a46a2841f69. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->