### PR TITLE
backend: do not force `get_schedule_opt` to be within a transaction

### DIFF
--- a/backend/windmill-api/src/schedule.rs
+++ b/backend/windmill-api/src/schedule.rs
@@ -438,7 +438,7 @@ async fn get_schedule(
     let path = path.to_path();
     let mut tx = user_db.begin(&authed).await?;
 
-    let schedule_o = windmill_queue::schedule::get_schedule_opt(&mut tx, &w_id, path).await?;
+    let schedule_o = windmill_queue::schedule::get_schedule_opt(&mut *tx, &w_id, path).await?;
     let schedule = not_found_if_none(schedule_o, "Schedule", path)?;
     tx.commit().await?;
     Ok(Json(schedule))

--- a/backend/windmill-queue/src/jobs.rs
+++ b/backend/windmill-queue/src/jobs.rs
@@ -700,7 +700,7 @@ pub async fn add_completed_job<T: Serialize + Send + Sync + ValidableJson>(
                 let script_path = queued_job.script_path.as_ref().unwrap();
 
                 let schedule =
-                    get_schedule_opt(&mut tx, &queued_job.workspace_id, schedule_path).await?;
+                    get_schedule_opt(&mut *tx, &queued_job.workspace_id, schedule_path).await?;
 
                 if let Some(schedule) = schedule {
                     #[cfg(feature = "enterprise")]

--- a/backend/windmill-queue/src/schedule.rs
+++ b/backend/windmill-queue/src/schedule.rs
@@ -9,7 +9,7 @@
 use crate::push;
 use crate::PushIsolationLevel;
 use anyhow::Context;
-use sqlx::{query_scalar, Postgres, Transaction};
+use sqlx::{query_scalar, PgExecutor, Postgres, Transaction};
 use std::collections::HashMap;
 use std::str::FromStr;
 use windmill_common::db::Authed;
@@ -245,7 +245,7 @@ pub async fn push_scheduled_job<'c>(
 }
 
 pub async fn get_schedule_opt<'c>(
-    db: &mut Transaction<'c, Postgres>,
+    e: impl PgExecutor<'c>,
     w_id: &str,
     path: &str,
 ) -> Result<Option<Schedule>> {
@@ -254,7 +254,7 @@ pub async fn get_schedule_opt<'c>(
     )
     .bind(path)
     .bind(w_id)
-    .fetch_optional(&mut **db)
+    .fetch_optional(e)
     .await?;
     Ok(schedule_opt)
 }

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -1510,15 +1510,11 @@ pub async fn handle_flow(
         && flow_job.script_path.is_some()
         && status.step == 0
     {
-        let mut tx = db.begin().await?;
-
         let schedule_path = flow_job.schedule_path.as_ref().unwrap();
 
-        let schedule = get_schedule_opt(&mut tx, &flow_job.workspace_id, schedule_path)
+        let schedule = get_schedule_opt(db, &flow_job.workspace_id, schedule_path)
             .warn_after_seconds(5)
             .await?;
-
-        tx.commit().await?;
 
         if let Some(schedule) = schedule {
             if let Err(err) = handle_maybe_scheduled_job(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `get_schedule_opt` to use `PgExecutor` instead of `Transaction`, removing transaction requirement in multiple files.
> 
>   - **Functionality**:
>     - `get_schedule_opt` in `schedule.rs` now accepts `PgExecutor` instead of `Transaction`, removing the need for a transaction context.
>   - **Code Changes**:
>     - Updated `get_schedule_opt` calls in `schedule.rs`, `jobs.rs`, and `worker_flow.rs` to use `PgExecutor`.
>     - Removed transaction requirement for `get_schedule_opt` in `get_schedule()` in `schedule.rs` and `add_completed_job()` in `jobs.rs`.
>     - Adjusted `handle_flow()` in `worker_flow.rs` to call `get_schedule_opt` without a transaction.
>   - **Misc**:
>     - Added `PgExecutor` import in `schedule.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for fe0d7a8c031910c46973f03838d28aae1024e8d3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->