### PR TITLE
prevent cancelling schedule next tick + remove need of flow_status inside add_completed_job

### DIFF
--- a/backend/.sqlx/query-e4e87539ae18f7e5c6bd9a28d16b7527ececad87d218182ff723e6a6c43ecd50.json
+++ b/backend/.sqlx/query-e4e87539ae18f7e5c6bd9a28d16b7527ececad87d218182ff723e6a6c43ecd50.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT \n                                        flow_status->>'step' = '0' \n                                        AND (\n                                            jsonb_array_length(flow_status->'modules') = 0 \n                                            OR flow_status->'modules'->0->>'type' = 'WaitingForPriorSteps' \n                                            OR (\n                                                flow_status->'modules'->0->>'type' = 'Failure' \n                                                AND flow_status->'modules'->0->>'job' = $1\n                                            )\n                                        )\n                                    FROM completed_job WHERE id = $2 AND workspace_id = $3",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "?column?",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "e4e87539ae18f7e5c6bd9a28d16b7527ececad87d218182ff723e6a6c43ecd50"
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevents cancelling future scheduled jobs and refines next tick scheduling logic using a new SQL query in `jobs.rs`.
> 
>   - **Behavior**:
>     - Prevents cancelling future scheduled jobs in `cancel_job()` by checking if `scheduled_for` is greater than current time.
>     - Refines logic in `add_completed_job()` to determine when to schedule the next tick using a new SQL query.
>   - **SQL**:
>     - Adds new SQL query in `.sqlx/query-e4e87539ae18f7e5c6bd9a28d16b7527ececad87d218182ff723e6a6c43ecd50.json` to check flow status conditions for scheduling.
>   - **Misc**:
>     - Imports `now_from_db` in `jobs.rs` for time comparison.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 45b845da1d7afbe2b1a515f52fca8320ab1e1327. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->