### PR TITLE
nit: always show flow meta data, append user provided msg

### DIFF
--- a/backend/windmill-api/src/slack_approvals.rs
+++ b/backend/windmill-api/src/slack_approvals.rs
@@ -1024,7 +1024,7 @@ async fn get_modal_blocks(
 
     let created_at_formatted = created_at.format("%Y-%m-%d %H:%M:%S").to_string();
 
-    let fallback_message = format!(
+    let mut message_str = format!(
         "A workflow has been suspended and is waiting for approval:\n\n\
         *Created by*: {created_by}\n\
         *Created at*: {created_at_formatted}\n\
@@ -1033,7 +1033,10 @@ async fn get_modal_blocks(
         *Flow ID*: {parent_job_id_str}\n\n"
     );
 
-    let mut message_str: String = message.unwrap_or_else(|| fallback_message.as_str()).to_string();
+    // Append custom message if provided
+    if let Some(msg) = message {
+        message_str.push_str(msg);
+    }
 
     tracing::debug!("Schema: {:#?}", schema);
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `get_modal_blocks` to always show flow metadata and append user-provided message if available.
> 
>   - **Behavior**:
>     - In `get_modal_blocks`, always show flow metadata and append user-provided message if available.
>   - **Code Changes**:
>     - Rename `fallback_message` to `message_str` in `get_modal_blocks`.
>     - Add logic to append custom message to `message_str` if provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for e8655451fae5e7fb993006cbfd1574d1a8002c2e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->