### PR TITLE
doc link job labels

### DIFF
--- a/frontend/src/lib/components/runs/RunsFilter.svelte
+++ b/frontend/src/lib/components/runs/RunsFilter.svelte
@@ -271,8 +271,8 @@
 
 						<span class="text-xs absolute -top-4"
 							>Label <Tooltip
-								>Labels are string values in the array at the result field 'wm_labels' to easily
-								filter them</Tooltip
+								><a href="https://www.windmill.dev/docs/core_concepts/monitor_past_and_future_runs#jobs-labels" target="_blank">Job Labels</a> are string values in the array at the result field 'wm_labels' to easily
+								filter them.</Tooltip
 							></span
 						>
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updated tooltip in `RunsFilter.svelte` to include a hyperlink to job labels documentation.
> 
>   - **Documentation**:
>     - Updated tooltip in `RunsFilter.svelte` to include a hyperlink to job labels documentation at `https://www.windmill.dev/docs/core_concepts/monitor_past_and_future_runs#jobs-labels`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for ac00f8355ab9a6822afe3cf1de6fe1b6e8ddfa69. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->