### PR TITLE
Bump uv version to 0.5.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,7 +159,7 @@ ENV PATH="${PATH}:/usr/local/go/bin"
 ENV GO_PATH=/usr/local/go/bin/go
 
 # Install UV
-RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.4.18/uv-installer.sh | sh && mv /root/.cargo/bin/uv /usr/local/bin/uv
+RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.5.15/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
 
 RUN curl -sL https://deb.nodesource.com/setup_20.x | bash - 
 RUN apt-get -y update && apt-get install -y curl procps nodejs awscli && apt-get clean \

--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -18,7 +18,7 @@ ENV TZ=Etc/UTC
 RUN /usr/local/bin/python3 -m pip install pip-tools
 
 # Install UV
-RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.4.18/uv-installer.sh | sh && mv /root/.cargo/bin/uv /usr/local/bin/uv
+RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.5.15/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
 
 COPY --from=oven/bun:1.1.40 /usr/local/bin/bun /usr/bin/bun
 

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -17,7 +17,7 @@ ENV TZ=Etc/UTC
 
 RUN /usr/local/bin/python3 -m pip install pip-tools
 # Install UV
-RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.4.18/uv-installer.sh | sh && mv /root/.cargo/bin/uv /usr/local/bin/uv
+RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.5.15/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
 
 COPY --from=oven/bun:1.1.40 /usr/local/bin/bun /usr/bin/bun
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `uv` version to `0.5.15` and adjust installation path in three Dockerfiles.
> 
>   - **Dockerfile Changes**:
>     - Update `uv` version to `0.5.15` in `Dockerfile`, `DockerfileSlim`, and `DockerfileSlimEe`.
>     - Modify `mv` command path from `/root/.cargo/bin/uv` to `/root/.local/bin/uv` in all three Dockerfiles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 1766563da49981465f1cfa34b40694fb6fa61ea8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->