### PR TITLE
only load critical alerts modal once devops store is set

### DIFF
--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -289,7 +289,8 @@
 	setContext('openSearchWithPrefilledText', openSearchModal)
 
 	$: {
-		if ($enterpriseLicense && $workspaceStore && $userStore && ($devopsRole || $userStore.is_admin)) {
+		if ($enterpriseLicense && $workspaceStore && $userStore && $devopsRole !== undefined && ($devopsRole || $userStore.is_admin)) {
+			console.log('mountModal', $devopsRole, $userStore.is_admin)
 			mountModal = true
 			loadCriticalAlertsMuted()
 		}

--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -290,7 +290,6 @@
 
 	$: {
 		if ($enterpriseLicense && $workspaceStore && $userStore && $devopsRole !== undefined && ($devopsRole || $userStore.is_admin)) {
-			console.log('mountModal', $devopsRole, $userStore.is_admin)
 			mountModal = true
 			loadCriticalAlertsMuted()
 		}


### PR DESCRIPTION
Modal was loading in too early before `$devopsRole` was set. 

The initial load of the modal would show the user to not have devops but workspace admin role and hence display unacknowledged critical alerts for that workspace. Since the badge is updated every 30s or when changing context (to workspace), it would refresh the badge.

Fix: we're only loading the modal once `$devopsRole !== undefined`
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure critical alerts modal in `+layout.svelte` loads only when `$devopsRole` is defined.
> 
>   - **Behavior**:
>     - In `+layout.svelte`, the critical alerts modal now loads only when `$devopsRole` is defined and either `$devopsRole` is true or `$userStore.is_admin` is true.
>     - Prevents modal from loading prematurely and showing incorrect roles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 7837519cfb5c1e9538fdd21139a8b94884266899. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->