### PR TITLE
chore: update rust to `1.81.0`

### DIFF
--- a/docker/DockerfileFull
+++ b/docker/DockerfileFull
@@ -1,7 +1,7 @@
 FROM ghcr.io/windmill-labs/windmill:dev
 
-COPY --from=rust:1.80.1 /usr/local/cargo /usr/local/cargo
-COPY --from=rust:1.80.1 /usr/local/rustup /usr/local/rustup
+COPY --from=rust:1.81.0 /usr/local/cargo /usr/local/cargo
+COPY --from=rust:1.81.0 /usr/local/rustup /usr/local/rustup
 
 RUN pip3 install ansible
 

--- a/docker/DockerfileFullEe
+++ b/docker/DockerfileFullEe
@@ -1,7 +1,7 @@
 FROM ghcr.io/windmill-labs/windmill-ee:dev
 
-COPY --from=rust:1.80.1 /usr/local/cargo /usr/local/cargo
-COPY --from=rust:1.80.1 /usr/local/rustup /usr/local/rustup
+COPY --from=rust:1.81.0 /usr/local/cargo /usr/local/cargo
+COPY --from=rust:1.81.0 /usr/local/rustup /usr/local/rustup
 
 RUN pip3 install ansible
 


### PR DESCRIPTION
This PR updates Rust to `1.81.0` in `DockerfileFull` and `DockerfileFullEe`.

What prompted me is I ran into the following error on one of my scripts:

```
error: rustc 1.80.1 is not supported by the following packages:
  home@0.5.11 requires rustc 1.81
```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Rust to `1.81.0` in `DockerfileFull` and `DockerfileFullEe` to fix compatibility issues.
> 
>   - **Dockerfiles**:
>     - Update Rust version from `1.80.1` to `1.81.0` in `DockerfileFull` and `DockerfileFullEe` to resolve compatibility issues with `home@0.5.11` package.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for deadc81f6e4724484649104d0d8d7f30ec5a1615. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->