### PR TITLE
fix(backend): multiple routes with same path but different methods

### DIFF
--- a/backend/.sqlx/query-28a389a93a3d2472b13d956ec55eb357c6147e186e00e371f7374d166903ef64.json
+++ b/backend/.sqlx/query-28a389a93a3d2472b13d956ec55eb357c6147e186e00e371f7374d166903ef64.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT path, script_path, is_flow, route_path, workspace_id, is_async, requires_auth, edited_by, email, http_method as \"http_method: _\", static_asset_config as \"static_asset_config: _\" FROM http_trigger",
+  "query": "SELECT path, script_path, is_flow, route_path, workspace_id, is_async, requires_auth, edited_by, email, static_asset_config as \"static_asset_config: _\" FROM http_trigger WHERE http_method = $1",
   "describe": {
     "columns": [
       {
@@ -50,8 +50,13 @@
       },
       {
         "ordinal": 9,
-        "name": "http_method: _",
-        "type_info": {
+        "name": "static_asset_config: _",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
           "Custom": {
             "name": "http_method",
             "kind": {
@@ -65,18 +70,9 @@
             }
           }
         }
-      },
-      {
-        "ordinal": 10,
-        "name": "static_asset_config: _",
-        "type_info": "Jsonb"
-      }
-    ],
-    "parameters": {
-      "Left": []
+      ]
     },
     "nullable": [
-      false,
       false,
       false,
       false,
@@ -89,5 +85,5 @@
       true
     ]
   },
-  "hash": "11b698f82a54aac68b3617047dfe2b18dd6da7d962118fee276af354218baac2"
+  "hash": "28a389a93a3d2472b13d956ec55eb357c6147e186e00e371f7374d166903ef64"
 }

--- a/backend/.sqlx/query-a76be7f4e9e8b8c81afe50fcbf1f3d393ed0bb73314e5c430f32541c43bcac52.json
+++ b/backend/.sqlx/query-a76be7f4e9e8b8c81afe50fcbf1f3d393ed0bb73314e5c430f32541c43bcac52.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT path, script_path, is_flow, route_path, workspace_id, is_async, requires_auth, edited_by, email, http_method as \"http_method: _\", static_asset_config as \"static_asset_config: _\" FROM http_trigger WHERE workspace_id = $1",
+  "query": "SELECT path, script_path, is_flow, route_path, workspace_id, is_async, requires_auth, edited_by, email, static_asset_config as \"static_asset_config: _\" FROM http_trigger WHERE workspace_id = $1 AND http_method = $2",
   "describe": {
     "columns": [
       {
@@ -50,8 +50,14 @@
       },
       {
         "ordinal": 9,
-        "name": "http_method: _",
-        "type_info": {
+        "name": "static_asset_config: _",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        {
           "Custom": {
             "name": "http_method",
             "kind": {
@@ -65,16 +71,6 @@
             }
           }
         }
-      },
-      {
-        "ordinal": 10,
-        "name": "static_asset_config: _",
-        "type_info": "Jsonb"
-      }
-    ],
-    "parameters": {
-      "Left": [
-        "Text"
       ]
     },
     "nullable": [
@@ -87,9 +83,8 @@
       false,
       false,
       false,
-      false,
       true
     ]
   },
-  "hash": "c9930fcfe79541af570eace58ba7e15a0816a6b4fd036cf7b991a210654b2633"
+  "hash": "a76be7f4e9e8b8c81afe50fcbf1f3d393ed0bb73314e5c430f32541c43bcac52"
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes handling of routes with the same path but different HTTP methods by updating SQL queries and method conversions.
> 
>   - **Behavior**:
>     - Fixes handling of multiple routes with the same path but different HTTP methods in `get_http_route_trigger()`.
>     - SQL queries in `query-28a389a93a3d2472b13d956ec55eb357c6147e186e00e371f7374d166903ef64.json` and `query-a76be7f4e9e8b8c81afe50fcbf1f3d393ed0bb73314e5c430f32541c43bcac52.json` now include `http_method` as a parameter.
>   - **Code Changes**:
>     - `HttpMethod` enum in `http_triggers.rs` now implements `TryFrom<&http::Method>` instead of `From<HttpMethod>`.
>     - `route_job()` and `get_http_route_trigger()` functions updated to handle `http_method` parameter.
>   - **Misc**:
>     - Removes `http_method` field from `TriggerRoute` struct in `http_triggers.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for e303952d9f0ba6c6d61d7b46fa600e53192b7472. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->