### PR TITLE
fix workspace color picker issue

### DIFF
--- a/frontend/src/lib/components/settings/ChangeWorkspaceColor.svelte
+++ b/frontend/src/lib/components/settings/ChangeWorkspaceColor.svelte
@@ -8,11 +8,12 @@
 	import Toggle from '$lib/components/Toggle.svelte'
 
 	let colorEnabled = false
+	let workspaceColor = $usersWorkspaceStore?.workspaces.find(w => w.id === $workspaceStore)?.color
+
 	export let open = false
 
-	$: workspaceColor = $usersWorkspaceStore?.workspaces.find(w => w.id === $workspaceStore)?.color
-	$: colorEnabled = !!workspaceColor
-	$: colorEnabled && !workspaceColor && generateRandomColor()
+	$: workspaceColor
+	$: if (colorEnabled && !workspaceColor) generateRandomColor()
 
 	function generateRandomColor() {
 		const randomColor =
@@ -34,6 +35,7 @@
 		})
 
 		usersWorkspaceStore.set(await WorkspaceService.listUserWorkspaces())
+		workspaceColor = colorToSave
 
 		sendUserToast(`Workspace color updated.`)
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes workspace color picker initialization and logic in `ChangeWorkspaceColor.svelte`.
> 
>   - **Behavior**:
>     - Fixes initialization of `workspaceColor` in `ChangeWorkspaceColor.svelte` to correctly fetch from `$usersWorkspaceStore`.
>     - Adjusts logic to ensure `generateRandomColor()` is called only when `colorEnabled` is true and `workspaceColor` is not set.
>   - **State Management**:
>     - Ensures `workspaceColor` is updated after saving changes in `changeWorkspaceColor()` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 8d6fd371c5eb97114a98bae8a7715136277d1c24. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->