### PR TITLE
remove unused reactive statement

### DIFF
--- a/frontend/src/lib/components/settings/ChangeWorkspaceColor.svelte
+++ b/frontend/src/lib/components/settings/ChangeWorkspaceColor.svelte
@@ -8,11 +8,12 @@
 	import Toggle from '$lib/components/Toggle.svelte'
 
 	let colorEnabled = false
+	let workspaceColor = $usersWorkspaceStore?.workspaces.find(w => w.id === $workspaceStore)?.color
+
 	export let open = false
 
-	$: workspaceColor = $usersWorkspaceStore?.workspaces.find(w => w.id === $workspaceStore)?.color
-	$: colorEnabled = !!workspaceColor
-	$: colorEnabled && !workspaceColor && generateRandomColor()
+	$: workspaceColor
+	$: if (colorEnabled && !workspaceColor) generateRandomColor()
 
 	function generateRandomColor() {
 		const randomColor =
@@ -34,6 +35,7 @@
 		})
 
 		usersWorkspaceStore.set(await WorkspaceService.listUserWorkspaces())
+		workspaceColor = colorToSave
 
 		sendUserToast(`Workspace color updated.`)
 	}

--- a/frontend/src/lib/components/settings/ChangeWorkspaceColor.svelte
+++ b/frontend/src/lib/components/settings/ChangeWorkspaceColor.svelte
@@ -12,7 +12,6 @@
 
 	export let open = false
 
-	$: workspaceColor
 	$: if (colorEnabled && !workspaceColor) generateRandomColor()
 
 	function generateRandomColor() {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove unused reactive statement from `ChangeWorkspaceColor.svelte`.
> 
>   - **Code Cleanup**:
>     - Removed unused reactive statement `$: workspaceColor` from `ChangeWorkspaceColor.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f9013a1231dc11f2c95b425b05bc3effa49cd34a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->