### PR TITLE
Workspace settings clarifications, delete workspace message

### DIFF
--- a/frontend/src/lib/components/settings/ChangeWorkspaceColor.svelte
+++ b/frontend/src/lib/components/settings/ChangeWorkspaceColor.svelte
@@ -53,7 +53,7 @@
 </script>
 
 <div>
-	<p class="font-semibold text-sm">Workspace Color</p>
+	<p class="font-semibold text-sm">Workspace color</p>
 	<div class="flex flex-row gap-0.5 items-center">
 		{#if savedWorkspaceColor}
 			<div
@@ -76,6 +76,9 @@
 			}}
 		/>
 	</div>
+	<p class="italic text-xs">
+		Color to identify the current workspace in the list of workspaces
+	</p>
 </div>
 
 <Modal bind:open title="Change Workspace Color">

--- a/frontend/src/lib/components/settings/ChangeWorkspaceId.svelte
+++ b/frontend/src/lib/components/settings/ChangeWorkspaceId.svelte
@@ -67,6 +67,7 @@
 			/>
 		{/if}
 	</div>
+	<p class="italic text-xs">Slug to uniquely identify your workspace</p>
 </div>
 
 <Modal bind:open title="Change workspace ID">

--- a/frontend/src/lib/components/settings/ChangeWorkspaceName.svelte
+++ b/frontend/src/lib/components/settings/ChangeWorkspaceName.svelte
@@ -49,6 +49,10 @@
 			}}
 		/>
 	</div>
+
+	<p class="italic text-xs">
+		Displayable name
+	</p>
 </div>
 
 <Modal bind:open title="Change workspace name">

--- a/frontend/src/routes/(root)/(logged)/user/(user)/create_workspace/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/user/(user)/create_workspace/+page.svelte
@@ -198,7 +198,7 @@
 	</label>
 	<label class="block pb-4">
 		<span class="text-secondary text-sm">Workspace color</span>
-		<span class="ml-5 text-tertiary text-xs">Color to identify the current workspace</span>
+		<span class="ml-5 text-tertiary text-xs">Color to identify the current workspace in the list of workspaces</span>
 		<div class="flex items-center gap-2">
 			<Toggle bind:checked={colorEnabled} options={{ right: 'Enable' }} />
 			{#if colorEnabled}<input class="w-10" type="color" bind:value={workspaceColor} disabled={!colorEnabled} />{/if}

--- a/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
@@ -813,7 +813,12 @@
 			</div>
 		{:else if tab == 'general'}
 			<div class="flex flex-col gap-4 my-8">
-				<div class=" text-primary text-lg font-semibold">General</div>
+				<div class="flex flex-col gap-1">
+					<div class=" text-primary text-lg font-semibold">General</div>
+					<Description link="https://www.windmill.dev/docs/core_concepts/workspace_settings">
+						Configure general workspace settings.
+					</Description>
+				</div>
 			</div>
 
 			<div class="flex flex-col gap-10">
@@ -835,9 +840,15 @@
 
 			<div class="mt-20" />
 			<PageHeader title="Delete workspace" primary={false} />
-			<p class="italic text-xs">
-				The workspace will be archived for a short period of time and then permanently deleted
-			</p>
+			{#if $superadmin}
+				<p class="italic text-xs">
+					When deleting the workspace, it will be archived for a short period of time and then permanently deleted.
+				</p>
+			{:else}
+				<p class="italic text-xs">
+					Only instance superadmins can delete a workspace.
+				</p>
+			{/if}
 			{#if $workspaceStore === 'admins' || $workspaceStore === 'starter'}
 				<p class="italic text-xs">
 					This workspace cannot be deleted as it has a special function. Consult the documentation


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance workspace settings UI with additional descriptions and clarify delete workspace permissions based on user roles.
> 
>   - **UI Enhancements**:
>     - Add descriptions to `ChangeWorkspaceColor.svelte`, `ChangeWorkspaceId.svelte`, and `ChangeWorkspaceName.svelte` to clarify the purpose of each setting.
>     - Update `create_workspace/+page.svelte` to include a more detailed description for workspace color.
>     - Add a description to the "General" tab in `workspace_settings/+page.svelte`.
>   - **Delete Workspace Message**:
>     - Modify delete workspace message in `workspace_settings/+page.svelte` to specify that only superadmins can delete a workspace and provide different messages based on user roles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for dc3888f7c48efab746ea2b3d8918d2b22b167b26. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->