### PR TITLE
fix(backend): bun cache hash consistency

### DIFF
--- a/backend/parsers/windmill-parser-ts/src/lib.rs
+++ b/backend/parsers/windmill-parser-ts/src/lib.rs
@@ -71,7 +71,9 @@ pub fn parse_expr_for_imports(code: &str) -> anyhow::Result<Vec<String>> {
     let mut visitor = ImportsFinder { imports: HashSet::new() };
     visitor.visit_module(&expr);
 
-    Ok(visitor.imports.into_iter().collect())
+    let mut imports: Vec<_> = visitor.imports.into_iter().collect();
+    imports.sort();
+    Ok(imports)
 }
 
 struct OutputFinder {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Sort imports in `parse_expr_for_imports` in `lib.rs` for consistent output order.
> 
>   - **Behavior**:
>     - In `parse_expr_for_imports` in `lib.rs`, sort the list of imports before returning to ensure consistent order.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for ed02a206816b5cced037e732c081f2f1348e1a75. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->