### PR TITLE
build: update nix flake lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735471104,
-        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
+        "lastModified": 1736883708,
+        "narHash": "sha256-uQ+NQ0/xYU0N1CnXsa2zghgNaOPxWpMJXSUJJ9W7140=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
+        "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1728538411,
-        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "lastModified": 1736320768,
+        "narHash": "sha256-nIYdTAiKIGnFNugbomgBJR+Xv5F1ZQU+HfaBqJKroC0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "rev": "4bc9c909d9ac828a039f288cf872d16d38185db8",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1735612067,
-        "narHash": "sha256-rsjojgfPUf9tWuMXuuo2KAIoUZ49XGZQJSjFGOO8Cq4=",
+        "lastModified": 1737080704,
+        "narHash": "sha256-n+J2h9GM9ZpFOQUmtZoCr1+DFF/iO5UlmLJeHIxbZGY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d199142e84bfaae476ffb4e09a70879d7918784d",
+        "rev": "f9953fe89f8b65401fc4d4a288940bc2cb072949",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -137,8 +137,13 @@
         version = (pkgs.lib.strings.trim (builtins.readFile ./version.txt));
 
         src = ./backend;
-        nativeBuildInputs = buildInputs ++ [ self.packages.${system}.windmill-client pkgs.perl ];
-
+        nativeBuildInputs = buildInputs
+          ++ [ self.packages.${system}.windmill-client pkgs.perl ]
+          ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            # Additional darwin specific inputs can be set here
+            pkgs.libiconv
+            pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+          ];
 
         cargoLock = {
           lockFile = ./backend/Cargo.lock;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Nix flake lock and add Darwin-specific build inputs in `flake.nix`.
> 
>   - **Flake Lock Update**:
>     - Update `nixpkgs` to revision `eb62e6aa39ea67e0b8018ba8ea077efe65807dc8`.
>     - Update `rust-overlay` to revision `f9953fe89f8b65401fc4d4a288940bc2cb072949`.
>   - **Flake Nix Changes**:
>     - Add Darwin-specific build inputs `pkgs.libiconv` and `pkgs.darwin.apple_sdk.frameworks.SystemConfiguration` to `nativeBuildInputs` for `windmill` package.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for c22032740209d52d20ea3c85ff395424f4ac098c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->