### PR TITLE
fix(frontend): webhook/route payload from args

### DIFF
--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -1298,6 +1298,7 @@
 									on:exitTriggers={() => {
 										captureTable?.loadCaptures(true)
 									}}
+									{args}
 									{initialPath}
 									schema={script.schema}
 									noEditor={true}

--- a/frontend/src/lib/components/flows/content/FlowEditorPanel.svelte
+++ b/frontend/src/lib/components/flows/content/FlowEditorPanel.svelte
@@ -112,6 +112,7 @@
 			}
 		}}
 		on:testWithArgs
+		args={$previewArgs}
 		currentPath={$pathStore}
 		{initialPath}
 		schema={$flowStore.schema}

--- a/frontend/src/lib/components/triggers/CaptureWrapper.svelte
+++ b/frontend/src/lib/components/triggers/CaptureWrapper.svelte
@@ -189,7 +189,7 @@
 				{path}
 				hash={data?.hash}
 				token={data?.token}
-				{args}
+				runnableArgs={data?.args}
 				scopes={data?.scopes}
 				{showCapture}
 				{captureInfo}
@@ -208,6 +208,7 @@
 				{path}
 				{showCapture}
 				can_write={true}
+				runnableArgs={data?.args}
 				bind:args
 				headless
 				{captureInfo}

--- a/frontend/src/lib/components/triggers/RouteEditorConfigSection.svelte
+++ b/frontend/src/lib/components/triggers/RouteEditorConfigSection.svelte
@@ -32,6 +32,7 @@
 	export let captureInfo: CaptureInfo | undefined = undefined
 	export let captureTable: CaptureTable | undefined = undefined
 	export let isValid = false
+	export let runnableArgs: any = {}
 	let validateTimeout: NodeJS.Timeout | undefined = undefined
 
 	let routeError: string = ''
@@ -107,9 +108,9 @@
 				<CopyableCodeBlock
 					disabled={!captureInfo.active}
 					code={`curl \\
--X POST ${captureURL} \\
+-X ${http_method.toUpperCase()} ${captureURL} \\
 -H 'Content-Type: application/json' \\
--d '{"foo": 42}'`}
+-d '${JSON.stringify(runnableArgs ?? {}, null, 2)}'`}
 					language={bash}
 				/>
 			</Label>

--- a/frontend/src/lib/components/triggers/RoutesPanel.svelte
+++ b/frontend/src/lib/components/triggers/RoutesPanel.svelte
@@ -17,6 +17,7 @@
 	export let isEditor: boolean = false
 	export let canHavePreprocessor: boolean = false
 	export let hasPreprocessor: boolean = false
+	export let args: Record<string, any> = {}
 
 	let routeEditor: RouteEditor
 
@@ -82,6 +83,7 @@
 		{canHavePreprocessor}
 		{hasPreprocessor}
 		{newItem}
+		data={{ args }}
 	/>
 	{#if !newItem}
 		<Section label="Routes">

--- a/frontend/src/lib/components/triggers/TriggersEditor.svelte
+++ b/frontend/src/lib/components/triggers/TriggersEditor.svelte
@@ -27,7 +27,7 @@
 	export let isFlow: boolean
 	export let canHavePreprocessor: boolean = false
 	export let hasPreprocessor: boolean = false
-
+	export let args: Record<string, any> = {}
 	let eventStreamType: 'kafka' | 'nats' = 'kafka'
 
 	$: {
@@ -80,7 +80,7 @@
 									path={currentPath}
 									{hash}
 									{isFlow}
-									args={{}}
+									{args}
 									token=""
 									{newItem}
 									isEditor={true}
@@ -113,6 +113,7 @@
 									on:updateSchema
 									on:testWithArgs
 									{newItem}
+									{args}
 									path={currentPath}
 									{isFlow}
 									isEditor={true}

--- a/frontend/src/lib/components/triggers/TriggersEditorSection.svelte
+++ b/frontend/src/lib/components/triggers/TriggersEditorSection.svelte
@@ -77,7 +77,6 @@
 						{disabled}
 						startIcon={{ icon: Save }}
 						on:click={() => {
-							console.log('saveTrigger', args)
 							dispatch('saveTrigger', {
 								config: args
 							})

--- a/frontend/src/lib/components/triggers/TriggersWrapper.svelte
+++ b/frontend/src/lib/components/triggers/TriggersWrapper.svelte
@@ -36,7 +36,7 @@
 			{path}
 			hash={data?.hash}
 			token={data?.token}
-			{args}
+			runnableArgs={data?.args}
 			scopes={data?.scopes}
 			showCapture={false}
 		/>

--- a/frontend/src/lib/components/triggers/WebhooksConfigSection.svelte
+++ b/frontend/src/lib/components/triggers/WebhooksConfigSection.svelte
@@ -29,7 +29,7 @@
 	export let path: string = ''
 	export let hash: string | undefined = undefined
 	export let token: string = ''
-	export let args: any
+	export let runnableArgs: any
 	export let triggerTokens: TriggerTokens | undefined = undefined
 	export let scopes: string[] = []
 	export let showCapture: boolean = false
@@ -117,7 +117,10 @@ async function triggerJob() {
   ${
 		requestType === 'get_path'
 			? '// Payload is a base64 encoded string of the arguments'
-			: `const body = JSON.stringify(${JSON.stringify(args, null, 2).replaceAll('\n', '\n\t')});`
+			: `const body = JSON.stringify(${JSON.stringify(runnableArgs ?? {}, null, 2).replaceAll(
+					'\n',
+					'\n\t'
+			  )});`
 	}
   const endpoint = \`${url}\`;
 
@@ -142,7 +145,10 @@ export async function main() {
 		// triggerJob function
 		let triggerJobFunction = `
 async function triggerJob() {
-  const body = JSON.stringify(${JSON.stringify(args, null, 2).replaceAll('\n', '\n\t')});
+  const body = JSON.stringify(${JSON.stringify(runnableArgs ?? {}, null, 2).replaceAll(
+		'\n',
+		'\n\t'
+	)});
   const endpoint = \`${url}\`;
 
   return await fetch(endpoint, {
@@ -199,7 +205,7 @@ function waitForJobCompletion(UUID) {
 
 	function curlCode() {
 		return `TOKEN='${token}'
-${requestType !== 'get_path' ? `BODY='${JSON.stringify(args)}'` : ''}
+${requestType !== 'get_path' ? `BODY='${JSON.stringify(runnableArgs ?? {})}'` : ''}
 URL='${url}'
 ${webhookType === 'sync' ? 'RESULT' : 'UUID'}=$(curl -s ${
 			requestType != 'get_path' ? "-H 'Content-Type: application/json'" : ''
@@ -230,12 +236,12 @@ done`
 		(tokenType === 'query'
 			? `?token=${token}${
 					requestType === 'get_path'
-						? `&payload=${encodeURIComponent(btoa(JSON.stringify(args)))}`
+						? `&payload=${encodeURIComponent(btoa(JSON.stringify(runnableArgs ?? {})))}`
 						: ''
 			  }`
 			: `${
 					requestType === 'get_path'
-						? `?payload=${encodeURIComponent(btoa(JSON.stringify(args)))}`
+						? `?payload=${encodeURIComponent(btoa(JSON.stringify(runnableArgs ?? {})))}`
 						: ''
 			  }`)
 </script>
@@ -373,7 +379,7 @@ done`
 
 								{#if requestType !== 'get_path'}
 									<Label label="Body">
-										<ClipboardPanel content={JSON.stringify(args, null, 2)} />
+										<ClipboardPanel content={JSON.stringify(runnableArgs ?? {}, null, 2)} />
 									</Label>
 								{/if}
 								{#key requestType}
@@ -387,7 +393,7 @@ done`
 						</TabContent>
 						<TabContent value="curl" class="flex flex-col flex-1 h-full">
 							<div class="relative">
-								{#key args}
+								{#key runnableArgs}
 									{#key requestType}
 										{#key webhookType}
 											{#key tokenType}
@@ -408,7 +414,7 @@ done`
 							</div>
 						</TabContent>
 						<TabContent value="fetch">
-							{#key args}
+							{#key runnableArgs}
 								{#key requestType}
 									{#key webhookType}
 										{#key tokenType}

--- a/frontend/src/lib/components/triggers/WebhooksPanel.svelte
+++ b/frontend/src/lib/components/triggers/WebhooksPanel.svelte
@@ -5,7 +5,7 @@
 	import TriggersEditorSection from './TriggersEditorSection.svelte'
 
 	export let token: string
-	export let args: any
+	export let args: Record<string, any> = {}
 	export let scopes: string[] = []
 	export let isFlow: boolean = false
 	export let hash: string | undefined = undefined
@@ -15,7 +15,7 @@
 	export let canHavePreprocessor: boolean = false
 	export let hasPreprocessor: boolean = false
 
-	let data: any = {
+	$: data = {
 		hash,
 		token,
 		scopes,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Pass `args` and `runnableArgs` to various components to handle webhook and route payloads effectively in the frontend.
> 
>   - **Behavior**:
>     - Pass `args` to `ScriptBuilder.svelte` and `FlowEditorPanel.svelte` for handling webhook and route payloads.
>     - Use `runnableArgs` instead of `args` in `CaptureWrapper.svelte`, `WebhooksConfigSection.svelte`, and `RouteEditorConfigSection.svelte` to ensure correct payload handling.
>   - **Components**:
>     - Update `TriggersEditor.svelte`, `TriggersEditorSection.svelte`, and `TriggersWrapper.svelte` to pass `args` or `runnableArgs` to child components.
>     - Modify `RoutesPanel.svelte` and `WebhooksPanel.svelte` to include `args` in data handling.
>   - **Misc**:
>     - Remove console log in `TriggersEditorSection.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for d588b0aca542f6a502735a34f8e896be038a58b1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->