### PR TITLE
fix(frontend): empty arg initial height

### DIFF
--- a/frontend/src/lib/autosize.ts
+++ b/frontend/src/lib/autosize.ts
@@ -17,16 +17,16 @@ export const action = (node) => {
 	const setInitialHeight = () => {
 		let height = 0
 		if (node.value) {
-			height = node.scrollHeight
+			height = Math.max(node.scrollHeight ?? 0, 30) + 2
 		} else {
 			if (node.placeholder) {
 				node.value = node.placeholder
-				height = node.scrollHeight
+				height = Math.max(node.scrollHeight ?? 0, 30) + 2
 				node.value = ''
 			} else {
 				node.value = '|'
 				node.style.height = '0px'
-				height = node.scrollHeight + 20
+				height = Math.max(node.scrollHeight ?? 0, 30) + 2
 				node.value = ''
 			}
 		}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjusts `setInitialHeight()` in `autosize.ts` to ensure a minimum height of 32 pixels for textareas, handling cases with empty or placeholder values.
> 
>   - **Behavior**:
>     - Adjusts `setInitialHeight()` in `autosize.ts` to ensure a minimum height of 32 pixels (30 + 2) for textareas, even if `scrollHeight` is null or less than 30.
>     - Applies the same height adjustment logic when the textarea has a placeholder or is empty.
>   - **Functions**:
>     - Modifies `setInitialHeight()` to use `Math.max(node.scrollHeight ?? 0, 30) + 2` for height calculation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 9a6a68253eacecaaa20afa73293ae4df90b2b1d5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->