### PR TITLE
rhel image build workaround

### DIFF
--- a/.github/workflows/build-publish-rh-image.yml
+++ b/.github/workflows/build-publish-rh-image.yml
@@ -97,16 +97,16 @@ jobs:
           image: ${{ steps.meta-ee-public.outputs.tags}}-amd64
           path: "/windmill/target/release/windmill"
 
-      - uses: shrink/actions-docker-extract@v3
-        id: extract-ee-arm64
-        with:
-          image: ${{ steps.meta-ee-public.outputs.tags}}-arm64
-          path: "/windmill/target/release/windmill"
+      # - uses: shrink/actions-docker-extract@v3
+      #   id: extract-ee-arm64
+      #   with:
+      #     image: ${{ steps.meta-ee-public.outputs.tags}}-arm64
+      #     path: "/windmill/target/release/windmill"
 
       - name: Rename binary with corresponding architecture
         run: |
           mv "${{ steps.extract-ee-amd64.outputs.destination }}/windmill" "${{ steps.extract-ee-amd64.outputs.destination }}/windmill-ee-amd64-rhel9"
-          mv "${{ steps.extract-ee-arm64.outputs.destination }}/windmill" "${{ steps.extract-ee-arm64.outputs.destination }}/windmill-ee-arm64-rhel9"
+          # mv "${{ steps.extract-ee-arm64.outputs.destination }}/windmill" "${{ steps.extract-ee-arm64.outputs.destination }}/windmill-ee-arm64-rhel9"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -115,12 +115,12 @@ jobs:
             ${{ steps.extract-ee-amd64.outputs.destination
             }}/windmill-ee-amd64-rhel9
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: RHEL9-arm64 build
-          path:
-            ${{ steps.extract-ee-arm64.outputs.destination
-            }}/windmill-ee-arm64-rhel9
+      # - uses: actions/upload-artifact@v4
+      #   with:
+      #     name: RHEL9-arm64 build
+      #     path:
+      #       ${{ steps.extract-ee-arm64.outputs.destination
+      #       }}/windmill-ee-arm64-rhel9
 
       # - name: Attach binary to release
       #   uses: softprops/action-gh-release@v2

--- a/docker/RHEL9/Dockerfile
+++ b/docker/RHEL9/Dockerfile
@@ -61,7 +61,7 @@ RUN --mount=type=secret,id=rh_username \
 RUN subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms
 
 RUN yum update -y && \
-    yum install -y libxml2-devel xmlsec1-devel xmlsec1-openssl-devel clang llvm-devel cmake libtool-ltdl-devel
+    yum install -y perl-FindBin libxml2-devel xmlsec1-devel xmlsec1-openssl-devel clang llvm-devel cmake libtool-ltdl-devel
 
 # RUN --mount=type=cache,target=/usr/local/cargo/registry \
 #     CARGO_NET_GIT_FETCH_WITH_CLI=true RUST_BACKTRACE=1 cargo chef cook --release --features "$features" --recipe-path recipe.json

--- a/docker/RHEL9/Dockerfile
+++ b/docker/RHEL9/Dockerfile
@@ -63,8 +63,8 @@ RUN subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpm
 RUN yum update -y && \
     yum install -y libxml2-devel xmlsec1-devel xmlsec1-openssl-devel clang llvm-devel cmake libtool-ltdl-devel
 
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    CARGO_NET_GIT_FETCH_WITH_CLI=true RUST_BACKTRACE=1 cargo chef cook --release --features "$features" --recipe-path recipe.json
+# RUN --mount=type=cache,target=/usr/local/cargo/registry \
+#     CARGO_NET_GIT_FETCH_WITH_CLI=true RUST_BACKTRACE=1 cargo chef cook --release --features "$features" --recipe-path recipe.json
 
 COPY ./openflow.openapi.yaml /openflow.openapi.yaml
 COPY ./backend ./

--- a/docker/RHEL9/Dockerfile
+++ b/docker/RHEL9/Dockerfile
@@ -61,7 +61,7 @@ RUN --mount=type=secret,id=rh_username \
 RUN subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms
 
 RUN yum update -y && \
-    yum install -y perl-FindBin libxml2-devel xmlsec1-devel xmlsec1-openssl-devel clang llvm-devel cmake libtool-ltdl-devel
+    yum install -y perl-FindBin perl-IPC-Cmd libxml2-devel xmlsec1-devel xmlsec1-openssl-devel clang llvm-devel cmake libtool-ltdl-devel
 
 # RUN --mount=type=cache,target=/usr/local/cargo/registry \
 #     CARGO_NET_GIT_FETCH_WITH_CLI=true RUST_BACKTRACE=1 cargo chef cook --release --features "$features" --recipe-path recipe.json


### PR DESCRIPTION
- skip chef (probably due to some windmill binary caching)
- for now comment out arm build (shrink/actions-docker-extract@v3 fails for arm)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Temporarily disable ARM64 build steps and skip `cargo chef cook` in RHEL image build due to caching and extraction issues.
> 
>   - **Workflow Adjustments**:
>     - Comment out ARM64 extraction and artifact upload steps in `build-publish-rh-image.yml` due to `shrink/actions-docker-extract@v3` failure.
>   - **Dockerfile Changes**:
>     - Add `perl-FindBin` and `perl-IPC-Cmd` to `yum install` in `Dockerfile`.
>     - Comment out `cargo chef cook` step in `Dockerfile` to skip chef due to caching issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 86423966c5e2978cc52d710ebb92a9deed87174a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->