### PR TITLE
python: Introduce `<requirement==x.y.z>/valid.windmill`

### DIFF
--- a/backend/windmill-worker/nsjail/download_deps.py.sh
+++ b/backend/windmill-worker/nsjail/download_deps.py.sh
@@ -30,6 +30,7 @@ CMD="/usr/local/bin/uv pip install
 $INDEX_URL_ARG $EXTRA_INDEX_URL_ARG $TRUSTED_HOST_ARG
 --index-strategy unsafe-best-match
 --system
+--reinstall
 "
 
 echo $CMD

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -1861,6 +1861,8 @@ pub async fn handle_python_reqs(
             pids.lock().await.get_mut(i).and_then(|e| e.take());
             // Create a file to indicate that installation was successfull
             let valid_path = venv_p.clone() + "/.valid.windmill";
+            // This is atomic operation, meaning, that it either completes and wheel is valid, 
+            // or it does not and wheel is invalid and will be reinstalled next run
             if let Err(e) = File::create(&valid_path).await{
                 tracing::error!(
                 workspace_id = %w_id,

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -1482,7 +1482,7 @@ pub async fn handle_python_reqs(
             "{py_prefix}/{}",
             req.replace(' ', "").replace('/', "").replace(':', "")
         );
-        if metadata(venv_p.clone() + "/valid.windmill").await.is_ok() {
+        if metadata(venv_p.clone() + "/.valid.windmill").await.is_ok() {
             req_paths.push(venv_p);
             in_cache.push(req.to_string());
         } else {
@@ -1891,7 +1891,7 @@ pub async fn handle_python_reqs(
             }
         } else {
             // Create a file to indicate that installation was successfull
-            let valid_path= venv_p.clone() + "/valid.windmill";
+            let valid_path= venv_p.clone() + "/.valid.windmill";
             if let Err(e) = File::create(&valid_path).await{
                 tracing::error!(
                 workspace_id = %w_id,

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -7,7 +7,6 @@ use std::{
 };
 
 use anyhow::anyhow;
-use futures::lock::Mutex;
 use itertools::Itertools;
 use regex::Regex;
 use serde_json::value::RawValue;


### PR DESCRIPTION
Due to recent migration from pip to uv we have to handle uv's logic properly. 

Problem:
pip install fills target directory at the last moment, additionally operation is atomic. Thus we can assume:
- requirement directory exists -> it is valid

uv install creates target directory at the beginning of execution, thus we cannot rely just on existence of requirement directory.

In this PR we introduce `<requirement==x.y.z>/valid.windmill` which is created only if `uv pip install` succeeded. 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduce `.valid.windmill` file to confirm successful `uv pip install` and remove mutex lock for concurrent installations.
> 
>   - **Behavior**:
>     - Introduce `.valid.windmill` file in `handle_python_reqs()` and `spawn_uv_install()` to confirm successful `uv pip install`.
>     - Remove directory cleanup on installation failure in `handle_python_reqs()`.
>   - **Concurrency**:
>     - Remove `BUSY_WITH_UV_INSTALL` mutex lock in `python_executor.rs` to allow concurrent installations.
>   - **Installation**:
>     - Add `--reinstall` flag in `download_deps.py.sh` and `spawn_uv_install()` to overwrite existing installations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 94cc1b78048efe885d3d55e89f92f88e92814e4b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->