### PR TITLE
backend: always prioritize flow steps

### DIFF
--- a/backend/windmill-queue/src/jobs.rs
+++ b/backend/windmill-queue/src/jobs.rs
@@ -3550,6 +3550,12 @@ pub async fn push<'c, 'd>(
             _low_level_priority
         }; // else it remains empty, i.e. no priority
     }
+    // prioritize flow steps to drain the queue faster
+    let final_priority = if flow_step_id.is_some() && final_priority.is_none() {
+        Some(0)
+    } else {
+        final_priority
+    };
 
     let is_running = same_worker;
     if let Some(flow) = raw_flow.as_ref() {


### PR DESCRIPTION
When a flow start, his flow steps have lower priority than already scheduled jobs, hence steps are only executed when the queue is drained which considerably increase flow execution time when queue size is significant. This add a very low priority to flow steps in order to prioritize finishing a started flow over new jobs.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Prioritize flow steps in the job queue by setting their priority to 0 in `push()` in `jobs.rs` if no priority is set.
> 
>   - **Behavior**:
>     - In `push()` in `jobs.rs`, set `final_priority` to `Some(0)` for flow steps if no priority is set, ensuring they are prioritized in the queue.
>   - **Misc**:
>     - Add comment explaining the prioritization of flow steps to drain the queue faster.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 3f53c3e1392a917f6fcb4e960c7a64cd1b8e35f2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->