### PR TITLE
feat: export simple editor to windmill-components

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -368,6 +368,11 @@
 			"types": "./package/components/flows/FlowHistoryInner.svelte.d.ts",
 			"svelte": "./package/components/flows/FlowHistoryInner.svelte",
 			"default": "./package/components/flows/FlowHistoryInner.svelte"
+		},
+		"./components/SimpleEditor.svelte": {
+			"types": "./package/components/SimpleEditor.svelte.d.ts",
+			"svelte": "./package/components/SimpleEditor.svelte",
+			"default": "./package/components/SimpleEditor.svelte"
 		}
 	},
 	"files": [
@@ -458,6 +463,9 @@
 			],
 			"components/flows/FlowHistoryInner.svelte": [
 				"./package/components/flows/FlowHistoryInner.svelte.d.ts"
+			],
+			"components/SimpleEditor.svelte": [
+				"./package/components/SimpleEditor.svelte.d.ts"
 			],
 			"utils": [
 				"./package/utils.d.ts"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `SimpleEditor.svelte` to `exports` in `package.json` for `windmill-components`.
> 
>   - **Exports**:
>     - Add `SimpleEditor.svelte` to `exports` in `package.json`, making it available in the `windmill-components` package.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for b3e772c95460d5cc2f6466765b3871b256a4cf4b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->