### PR TITLE
fix(bun, windows): Fix "A required privilege is not held by the client."

### DIFF
--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -906,7 +906,7 @@ pub async fn handle_bun_job(
         #[cfg(windows)]
         {
             target = format!("{job_dir}\\main.js");
-            symlink = std::os::windows::fs::symlink_dir(&local_path, &target);
+            symlink = std::fs::hard_link(&local_path, &target);
         }
 
         symlink.map_err(|e| {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/05471219-f4d6-441a-9b28-487433502186)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix privilege error on Windows by replacing `symlink_dir` with `hard_link` in `handle_bun_job` in `bun_executor.rs`.
> 
>   - **Behavior**:
>     - In `handle_bun_job` in `bun_executor.rs`, replace `symlink_dir` with `hard_link` for Windows systems to fix privilege error.
>   - **Misc**:
>     - No changes to non-Windows systems or other parts of the code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 5330627c065221b67567d97617200f1a454916d9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->