### PR TITLE
fix: Fix python refetching wheels from S3

### DIFF
--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -2158,6 +2158,18 @@ pub async fn handle_python_reqs(
                                     db
                                 ).await;
                                 pids.lock().await.get_mut(i).and_then(|e| e.take());
+
+                                // Create a file to indicate that installation was successfull
+                                let valid_path = venv_p.clone() + "/.valid.windmill";
+                                // This is atomic operation, meaning, that it either completes and wheel is valid, 
+                                // or it does not and wheel is invalid and will be reinstalled next run
+                                if let Err(e) = File::create(&valid_path).await{
+                                    tracing::error!(
+                                    workspace_id = %w_id,
+                                    job_id = %job_id,
+                                        "Failed to create {}!\n{e}\n
+                                        This file needed for python jobs to function", valid_path)
+                                };
                                 return Ok(());
                             }
                         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds creation of `.valid.windmill` file in `handle_python_reqs()` to indicate successful Python wheel installation, preventing unnecessary reinstalls.
> 
>   - **Behavior**:
>     - In `handle_python_reqs()` in `python_executor.rs`, a file `.valid.windmill` is created after successful installation of Python wheels to indicate validity.
>     - If file creation fails, logs an error with workspace and job IDs.
>   - **Error Handling**:
>     - Logs error to Sentry if `.valid.windmill` file creation fails, including workspace and job IDs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for b5cd14a326d02b794504659ac52db1de6222d7ba. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->