### PR TITLE
fix: update rust to 1.83.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG DEBIAN_IMAGE=debian:bookworm-slim
-ARG RUST_IMAGE=rust:1.82-slim-bookworm
+ARG RUST_IMAGE=rust:1.83-slim-bookworm
 ARG PYTHON_IMAGE=python:3.11.10-slim-bookworm
 
 FROM ${RUST_IMAGE} AS rust_base


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Rust version to 1.83 in Dockerfile.
> 
>   - **Dockerfile**:
>     - Update Rust version from `1.82` to `1.83` in `RUST_IMAGE` argument.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for b5927812d204b7ecd8d5888297bf01f6ab7d3c2d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->