### PR TITLE
fix(frontend): make argInput indent optional

### DIFF
--- a/frontend/src/lib/components/ArgInput.svelte
+++ b/frontend/src/lib/components/ArgInput.svelte
@@ -354,8 +354,9 @@
 <!-- svelte-ignore a11y-autofocus -->
 <div
 	class={twMerge(
-		'flex flex-col w-full rounded-md px-2 relative',
+		'flex flex-col w-full rounded-md relative',
 		minW ? 'min-w-[250px]' : '',
+		diffStatus?.diff ? 'px-2' : '',
 		diffStatus?.diff == 'added'
 			? 'bg-green-300 dark:bg-green-800'
 			: diffStatus?.diff === 'removed'

--- a/frontend/src/lib/components/SchemaForm.svelte
+++ b/frontend/src/lib/components/SchemaForm.svelte
@@ -190,48 +190,50 @@
 				{#if !schemaSkippedValues.includes(argName) && keys.includes(argName)}
 					{#if typeof diff[argName] === 'object' && diff[argName].oldSchema}
 						{@const formerProperty = diff[argName].oldSchema}
-						<ArgInput
-							{disablePortal}
-							{resourceTypes}
-							{prettifyHeader}
-							autofocus={i == 0 && autofocus ? true : null}
-							label={argName}
-							description={formerProperty?.description}
-							value={args[argName]}
-							type={formerProperty?.type}
-							oneOf={formerProperty?.oneOf}
-							required={formerProperty?.required}
-							pattern={formerProperty?.pattern}
-							valid={inputCheck[argName]}
-							defaultValue={structuredClone(formerProperty?.default)}
-							enum_={formerProperty?.enum}
-							format={formerProperty?.format}
-							contentEncoding={formerProperty?.contentEncoding}
-							customErrorMessage={formerProperty?.customErrorMessage}
-							properties={formerProperty?.properties}
-							order={formerProperty?.order}
-							nestedRequired={formerProperty?.required}
-							itemsType={formerProperty?.items}
-							disabled={disabledArgs.includes(argName) || disabled || formerProperty?.disabled}
-							{compact}
-							{variableEditor}
-							{itemPicker}
-							{pickForField}
-							password={linkedSecret == argName}
-							extra={formerProperty}
-							{showSchemaExplorer}
-							simpleTooltip={schemaFieldTooltip[argName]}
-							{onlyMaskPassword}
-							nullable={formerProperty?.nullable}
-							title={formerProperty?.title}
-							placeholder={formerProperty?.placeholder}
-							orderEditable={dndConfig != undefined}
-							otherArgs={args}
-							{helperScript}
-							{lightHeader}
-							hideNested={typeof diff[argName].diff === 'object'}
-							diffStatus={undefined}
-						/>
+						<div class="px-2">
+							<ArgInput
+								{disablePortal}
+								{resourceTypes}
+								{prettifyHeader}
+								autofocus={i == 0 && autofocus ? true : null}
+								label={argName}
+								description={formerProperty?.description}
+								value={args[argName]}
+								type={formerProperty?.type}
+								oneOf={formerProperty?.oneOf}
+								required={formerProperty?.required}
+								pattern={formerProperty?.pattern}
+								valid={inputCheck[argName]}
+								defaultValue={structuredClone(formerProperty?.default)}
+								enum_={formerProperty?.enum}
+								format={formerProperty?.format}
+								contentEncoding={formerProperty?.contentEncoding}
+								customErrorMessage={formerProperty?.customErrorMessage}
+								properties={formerProperty?.properties}
+								order={formerProperty?.order}
+								nestedRequired={formerProperty?.required}
+								itemsType={formerProperty?.items}
+								disabled={disabledArgs.includes(argName) || disabled || formerProperty?.disabled}
+								{compact}
+								{variableEditor}
+								{itemPicker}
+								{pickForField}
+								password={linkedSecret == argName}
+								extra={formerProperty}
+								{showSchemaExplorer}
+								simpleTooltip={schemaFieldTooltip[argName]}
+								{onlyMaskPassword}
+								nullable={formerProperty?.nullable}
+								title={formerProperty?.title}
+								placeholder={formerProperty?.placeholder}
+								orderEditable={dndConfig != undefined}
+								otherArgs={args}
+								{helperScript}
+								{lightHeader}
+								hideNested={typeof diff[argName].diff === 'object'}
+								diffStatus={undefined}
+							/>
+						</div>
 					{/if}
 					<!-- svelte-ignore a11y-no-static-element-interactions -->
 					<div


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make `ArgInput` padding optional based on `diffStatus` in `ArgInput.svelte` and `SchemaForm.svelte`.
> 
>   - **Styling**:
>     - In `ArgInput.svelte`, make padding (`px-2`) conditional on `diffStatus?.diff`.
>     - Wrap `ArgInput` in `SchemaForm.svelte` with a `div` that applies `px-2` padding.
>   - **Behavior**:
>     - `ArgInput` component now has optional padding based on `diffStatus` property.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 86b9423cf501a6265ed0cba86a33fe9f45bbb29f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->