### PR TITLE
some reactivity improvements and missing dims for tabcomponents

### DIFF
--- a/frontend/src/lib/components/apps/components/display/AppAccordionList.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppAccordionList.svelte
@@ -23,7 +23,8 @@
 	type InternalAccordionListInput = AppInput & {
 		value: AccordionListValue[];
 	};
-	const accordionInput = componentInput as InternalAccordionListInput
+
+	$: accordionInput = componentInput as InternalAccordionListInput;
 
 	const { app, focusedGrid, selectedComponent, worldStore, connectingInput } =
 		getContext<AppViewerContext>('AppViewerContext')
@@ -101,7 +102,7 @@
 							)}
 						>
 							<span class="mr-2 w-8 font-mono">{activeIndex === index ? '-' : '+'}</span>
-							{accordionInput?.value[index].header || `Header ${index}`}
+							{accordionInput?.value[index]?.header || `Header ${index}`}
 						</button>
 						{#if activeIndex === index}
 							<div class="p-2 overflow-auto w-full">

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -4167,6 +4167,7 @@ export const presetComponents = {
 	sidebartabscomponent: {
 		name: 'Sidebar Tabs',
 		icon: PanelLeft,
+		dims: '3:8-12:8' as AppComponentDimensions,
 		targetComponent: 'tabscomponent' as const,
 		configuration: {
 			tabsKind: {
@@ -4178,6 +4179,7 @@ export const presetComponents = {
 	accordiontabcomponent: {
 		name: 'Accordion Tabs',
 		icon: ListCollapse,
+		dims: '3:8-12:8' as AppComponentDimensions,
 		targetComponent: 'tabscomponent' as const,
 		configuration: {
 			tabsKind: {
@@ -4189,6 +4191,7 @@ export const presetComponents = {
 	invisibletabscomponent: {
 		name: 'Invisible Tabs',
 		icon: PanelTopInactive,
+		dims: '3:8-12:8' as AppComponentDimensions,
 		targetComponent: 'tabscomponent' as const,
 		configuration: {
 			tabsKind: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improved reactivity in `AppAccordionList.svelte` and added missing dimensions to components in `components.ts`.
> 
>   - **Reactivity Improvements**:
>     - In `AppAccordionList.svelte`, changed `accordionInput` to use reactive assignment with `$:`.
>     - Fixed potential undefined access in `accordionInput?.value[index]?.header`.
>   - **Component Dimensions**:
>     - Added `dims: '3:8-12:8'` to `sidebartabscomponent`, `accordiontabcomponent`, and `invisibletabscomponent` in `components.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 04afc9ac5da3164320786286e023b29362157bd6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->