### PR TITLE
fix: cache caddy data in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,6 +159,7 @@ services:
     # Configure the mounted Caddyfile and the exposed ports or use another reverse proxy if needed
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
       # - ./certs:/certs # Provide custom certificate files like cert.pem and key.pem to enable HTTPS - See the corresponding section in the Caddyfile
     ports:
       # To change the exposed port, simply change 80:80 to <desired_port>:80. No other changes needed
@@ -176,3 +177,4 @@ volumes:
   worker_logs: null
   windmill_index: null
   lsp_cache: null
+  caddy_data: null


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `caddy_data` volume to `caddy` service in `docker-compose.yml` for caching Caddy data.
> 
>   - **Docker Compose Configuration**:
>     - Add `caddy_data` volume to `caddy` service in `docker-compose.yml` for caching Caddy data.
>     - Define `caddy_data` volume in `volumes` section of `docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for e5101d271dc2be8fe63bf6262a7d255a4a658a6a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->