### PR TITLE
fix: oracledb tag for native workers + client not working on arm systems

### DIFF
--- a/backend/migrations/20250128162249_addback_oracledb.down.sql
+++ b/backend/migrations/20250128162249_addback_oracledb.down.sql
@@ -1,0 +1,1 @@
+-- Add down migration script here

--- a/backend/migrations/20250128162249_addback_oracledb.up.sql
+++ b/backend/migrations/20250128162249_addback_oracledb.up.sql
@@ -1,0 +1,2 @@
+-- Add up migration script here
+UPDATE config set config = jsonb_set(config, '{worker_tags}', config->'worker_tags' || '["oracledb"]'::jsonb) where name = 'worker__native' and config @> '{"worker_tags": ["nativets", "postgresql", "mysql", "graphql", "snowflake", "bigquery", "mssql"]}'::jsonb AND NOT config->'worker_tags' @> '"oracledb"'::jsonb;

--- a/docker/DockerfileFullEe
+++ b/docker/DockerfileFullEe
@@ -1,3 +1,20 @@
+FROM alpine:3.14 AS oracledb-client
+
+# Oracle DB Client for amd64
+COPY --from=ghcr.io/oracle/oraclelinux9-instantclient:23 /usr/lib/oracle/23/client64/lib /opt/oracle/23/amd64/lib
+
+# Oracle DB Client for arm64
+RUN mkdir -p /opt/oracle/23/arm64 \
+	&& cd /opt/oracle/23/arm64 \
+	&& wget https://download.oracle.com/otn_software/linux/instantclient/instantclient-basiclite-linux-arm64.zip \
+	&& unzip instantclient-basiclite-linux-arm64.zip && rm instantclient-basiclite-linux-arm64.zip && mv instantclient* ./lib
+
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+        mv /opt/oracle/23/arm64/lib /opt/oracle/23/lib; \
+    else \
+        mv /opt/oracle/23/amd64/lib /opt/oracle/23/lib; \
+    fi
+
 FROM ghcr.io/windmill-labs/windmill-ee:dev
 
 COPY --from=rust:1.81.0 /usr/local/cargo /usr/local/cargo
@@ -5,11 +22,12 @@ COPY --from=rust:1.81.0 /usr/local/rustup /usr/local/rustup
 
 RUN pip3 install ansible
 
+# dotnet SDK
 COPY --from=bitnami/dotnet-sdk:9.0.101-debian-12-r0 /opt/bitnami/dotnet-sdk /opt/dotnet-sdk
 RUN ln -s /opt/dotnet-sdk/bin/dotnet /usr/bin/dotnet
 ENV DOTNET_ROOT="/opt/dotnet-sdk/bin"
 
 # Oracle DB Client
-COPY --from=ghcr.io/oracle/oraclelinux9-instantclient:23 /usr/lib/oracle/23/client64/lib /opt/oracle/23/lib
+COPY --from=oracledb-client /opt/oracle/23/lib /opt/oracle/23/lib
 RUN apt-get -y update && apt-get install -y libaio1
 RUN echo /opt/oracle/23/lib > /etc/ld.so.conf.d/oracle-instantclient.conf && ldconfig

--- a/docker/DockerfileNsjail
+++ b/docker/DockerfileNsjail
@@ -21,6 +21,23 @@ RUN apt-get -y update \
 RUN git clone -b master --single-branch https://github.com/google/nsjail.git . && git checkout dccf911fd2659e7b08ce9507c25b2b38ec2c5800
 RUN make
 
+FROM alpine:3.14 AS oracledb-client
+
+# Oracle DB Client for amd64
+COPY --from=ghcr.io/oracle/oraclelinux9-instantclient:23 /usr/lib/oracle/23/client64/lib /opt/oracle/23/amd64/lib
+
+# Oracle DB Client for arm64
+RUN mkdir -p /opt/oracle/23/arm64 \
+	&& cd /opt/oracle/23/arm64 \
+	&& wget https://download.oracle.com/otn_software/linux/instantclient/instantclient-basiclite-linux-arm64.zip \
+	&& unzip instantclient-basiclite-linux-arm64.zip && rm instantclient-basiclite-linux-arm64.zip && mv instantclient* ./lib
+
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+        mv /opt/oracle/23/arm64/lib /opt/oracle/23/lib; \
+    else \
+        mv /opt/oracle/23/amd64/lib /opt/oracle/23/lib; \
+    fi
+
 FROM ghcr.io/windmill-labs/windmill-ee:dev
 
 RUN apt-get update && apt-get install -y libprotobuf-dev libnl-route-3-dev
@@ -30,12 +47,13 @@ COPY --from=rust:1.80.1 /usr/local/rustup /usr/local/rustup
 
 RUN pip3 install ansible
 
+# dotnet SDK
 COPY --from=bitnami/dotnet-sdk:9.0.101-debian-12-r0 /opt/bitnami/dotnet-sdk /opt/dotnet-sdk
 RUN ln -s /opt/dotnet-sdk/bin/dotnet /usr/bin/dotnet
 ENV DOTNET_ROOT="/opt/dotnet-sdk/bin"
 
 # Oracle DB Client
-COPY --from=ghcr.io/oracle/oraclelinux9-instantclient:23 /usr/lib/oracle/23/client64/lib /opt/oracle/23/lib
+COPY --from=oracledb-client /opt/oracle/23/lib /opt/oracle/23/lib
 RUN apt-get -y update && apt-get install -y libaio1
 RUN echo /opt/oracle/23/lib > /etc/ld.so.conf.d/oracle-instantclient.conf && ldconfig
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add multi-architecture support for OracleDB client in Dockerfiles and update worker configuration to include 'oracledb' tag.
> 
>   - **Dockerfiles**:
>     - In `DockerfileFullEe` and `DockerfileNsjail`, added multi-architecture support for OracleDB client by downloading and setting up libraries for both `amd64` and `arm64`.
>     - Introduced a build stage `oracledb-client` to handle architecture-specific library setup.
>   - **Migrations**:
>     - Added `20250128162249_addback_oracledb.up.sql` to update `worker_tags` in `config` to include `oracledb` for native workers.
>     - Created placeholder `20250128162249_addback_oracledb.down.sql` for potential rollback.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for eea9e3cb3a99b64237e5d66866159e1ecf49497e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->