### PR TITLE
fix: delete button now remove table to track

### DIFF
--- a/frontend/src/lib/components/triggers/postgres/PublicationPicker.svelte
+++ b/frontend/src/lib/components/triggers/postgres/PublicationPicker.svelte
@@ -56,7 +56,8 @@
 				publication: publication_name
 			})
 			items = items.filter((item) => item != publication_name)
-			table_to_track = []
+			relations = []
+			transaction_to_track = ['Insert', 'Update', 'Delete']
 			publication_name = ''
 			sendUserToast(message)
 		} catch (error) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `deletePublication()` in `PublicationPicker.svelte` now resets `relations` and `transaction_to_track` after deletion.
> 
>   - **Behavior**:
>     - In `PublicationPicker.svelte`, `deletePublication()` now resets `relations` to an empty array and `transaction_to_track` to `['Insert', 'Update', 'Delete']` after deleting a publication.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for ced268be0a479e1f508f1f21602aa504d32551d3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->