### PR TITLE
fix: add missing TARGETPLATFORM arg on dockerfile

### DIFF
--- a/docker/DockerfileFullEe
+++ b/docker/DockerfileFullEe
@@ -1,5 +1,7 @@
 FROM alpine:3.14 AS oracledb-client
 
+ARG TARGETPLATFORM
+
 # Oracle DB Client for amd64
 COPY --from=ghcr.io/oracle/oraclelinux9-instantclient:23 /usr/lib/oracle/23/client64/lib /opt/oracle/23/amd64/lib
 

--- a/docker/DockerfileNsjail
+++ b/docker/DockerfileNsjail
@@ -23,6 +23,8 @@ RUN make
 
 FROM alpine:3.14 AS oracledb-client
 
+ARG TARGETPLATFORM
+
 # Oracle DB Client for amd64
 COPY --from=ghcr.io/oracle/oraclelinux9-instantclient:23 /usr/lib/oracle/23/client64/lib /opt/oracle/23/amd64/lib
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `ARG TARGETPLATFORM` to `DockerfileFullEe` and `DockerfileNsjail` to handle architecture-specific Oracle DB Client libraries.
> 
>   - **Dockerfiles**:
>     - Add `ARG TARGETPLATFORM` to `DockerfileFullEe` and `DockerfileNsjail`.
>     - Use `TARGETPLATFORM` to conditionally copy Oracle DB Client libraries for `amd64` and `arm64`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for ef8e3c27eaccfb31bdc22bf61df9eb426a87ccbf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->