### PR TITLE
feat(python): add `custom_wheels` directory to `PYTHONPATH`

### DIFF
--- a/backend/windmill-worker/nsjail/run.python3.config.proto
+++ b/backend/windmill-worker/nsjail/run.python3.config.proto
@@ -123,6 +123,13 @@ mount {
     is_bind: true
 }
 
+mount {
+    src: "{CUSTOM_WHEELS}"
+    dst: "{CUSTOM_WHEELS}"
+    is_bind: true
+   	mandatory: false
+}
+
 {SHARED_MOUNT}
 
 {SHARED_DEPENDENCIES}

--- a/backend/windmill-worker/nsjail/run.python3.config.proto
+++ b/backend/windmill-worker/nsjail/run.python3.config.proto
@@ -124,8 +124,8 @@ mount {
 }
 
 mount {
-    src: "{CUSTOM_WHEELS}"
-    dst: "{CUSTOM_WHEELS}"
+    src: "{GLOBAL_SITE_PACKAGES}"
+    dst: "{GLOBAL_SITE_PACKAGES}"
     is_bind: true
    	mandatory: false
 }

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -902,6 +902,11 @@ pub async fn handle_python_job(
         tracing::debug!("Finished deps postinstall stage");
     }
 
+    // Add /tmp/windmill/cache/python_xyz/custom_wheels to PYTHONPATH.
+    // Usefull if certain wheels needs to be preinstalled before execution.
+    // We want this be at the beginning, so it gets prioritized
+    additional_python_paths.insert(0, py_version.to_cache_dir() + "/custom_wheels" );
+
     if no_uv {
         append_logs(
             &job.id,

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -12,7 +12,7 @@ use regex::Regex;
 use serde_json::value::RawValue;
 use sqlx::{types::Json, Pool, Postgres};
 use tokio::{
-    fs::{create_dir_all, metadata, DirBuilder, File},
+    fs::{metadata, DirBuilder, File},
     io::AsyncReadExt,
     process::Command,
     sync::Semaphore,

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -1053,21 +1053,21 @@ except BaseException as e:
     let client = client.get_authed().await;
     let mut reserved_variables = get_reserved_variables(job, &client.token, db).await?;
 
-    // Add /tmp/windmill/cache/python_xyz/custom_wheels to PYTHONPATH.
+    // Add /tmp/windmill/cache/python_xyz/global-site-packages to PYTHONPATH.
     // Usefull if certain wheels needs to be preinstalled before execution.
-    let custom_wheels_path = py_version.to_cache_dir() + "/custom_wheels";
+    let global_site_packages_path = py_version.to_cache_dir() + "/global-site-packages";
     let additional_python_paths_folders = {
         let mut paths= additional_python_paths.clone();
-        if std::fs::metadata(&custom_wheels_path).is_ok() {
-            // We want custom_wheels_path to be included in additonal_python_paths_folders, but
-            // we don't want it to be included in custom_wheels_path.
+        if std::fs::metadata(&global_site_packages_path).is_ok() {
+            // We want global_site_packages_path to be included in additonal_python_paths_folders, but
+            // we don't want it to be included in global_site_packages_path.
             // The reason for this is that additional_python_paths_folders is used to fill PYTHONPATH env variable for jailed script
-            // When custom_wheels_path used to place mount point of wheels to the jail config.
-            // Since we handle mount of custom_wheels on our own, we don't want it to be mounted automatically.
+            // When global_site_packages_path used to place mount point of wheels to the jail config.
+            // Since we handle mount of global_site_packages on our own, we don't want it to be mounted automatically.
             // We do this because existence of every wheel in cache is mandatory and if it is not there and nsjail expects it, it is a bug.
-            // On the other side custom_wheels is purely optional.
+            // On the other side global_site_packages is purely optional.
             // NOTE: This behaviour can be changed in future, so verification of wheels can be offloaded from nsjail to windmill
-            paths.insert(0, custom_wheels_path.clone());
+            paths.insert(0, global_site_packages_path.clone());
             //    ^^^^^^^^
             // We also want this be priorotized, that's why we insert it to the beginning
         }
@@ -1102,7 +1102,7 @@ mount {{
                 .replace("{CLONE_NEWUSER}", &(!*DISABLE_NUSER).to_string())
                 .replace("{SHARED_MOUNT}", shared_mount)
                 .replace("{SHARED_DEPENDENCIES}", shared_deps.as_str())
-                .replace("{CUSTOM_WHEELS}", &custom_wheels_path)
+                .replace("{GLOBAL_SITE_PACKAGES}", &global_site_packages_path)
                 .replace("{MAIN}", format!("{dirs}/{last}").as_str())
                 .replace(
                     "{ADDITIONAL_PYTHON_PATHS}",

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -1058,7 +1058,7 @@ except BaseException as e:
     let custom_wheels_path = py_version.to_cache_dir() + "/custom_wheels";
     let additional_python_paths_folders = {
         let mut paths= additional_python_paths.clone();
-        if metadata(&custom_wheels_path).await.is_ok() {
+        if std::fs::metadata(&custom_wheels_path).is_ok() {
             // We want custom_wheels_path to be included in additonal_python_paths_folders, but
             // we don't want it to be included in custom_wheels_path.
             // The reason for this is that additional_python_paths_folders is used to fill PYTHONPATH env variable for jailed script

--- a/frontend/src/lib/components/TestJobLoader.svelte
+++ b/frontend/src/lib/components/TestJobLoader.svelte
@@ -113,7 +113,7 @@
 				logOffset: job.logs?.length ?? 0
 			})
 
-			if ((job.logs ?? '').length == 0) {
+			if ((job?.logs ?? '').length == 0) {
 				job.logs = getUpdate.new_logs ?? ''
 				logOffset = getUpdate.log_offset ?? 0
 			}


### PR DESCRIPTION
Add global directory by path `<CACHE_DIR>/python_xyz/custom_wheels`

For example for scripts running python 3.11, in every execution
`<CACHE_DIR>/python_311/custom_wheels` will be accessible and all wheels placed there could be imported and used.

This is usefull for preinstalling wheels before runtime
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `custom_wheels` directory to `PYTHONPATH` for Python scripts, allowing pre-installed wheels to be used if the directory exists.
> 
>   - **Behavior**:
>     - Adds `<CACHE_DIR>/python_xyz/custom_wheels` to `PYTHONPATH` in `python_executor.rs` if the directory exists.
>     - Mounts `{CUSTOM_WHEELS}` in `run.python3.config.proto` as an optional bind.
>   - **Configuration**:
>     - Updates `run.python3.config.proto` to include a new mount for `{CUSTOM_WHEELS}`.
>     - Modifies `handle_python_job()` in `python_executor.rs` to include `custom_wheels_path` in `additional_python_paths_folders`.
>   - **Misc**:
>     - Adds comments explaining the optional nature of `custom_wheels` and its prioritization in `PYTHONPATH`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f8ea63cf984913660b515eda263db420c72f1093. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->