### PR TITLE
feat: get single capture endpoint + limit arg size in list endpoint

### DIFF
--- a/backend/.sqlx/query-5c1de8473e0e96c1063a9a735a064c5a91e3ed8d9260c72b783fc12542b88fbd.json
+++ b/backend/.sqlx/query-5c1de8473e0e96c1063a9a735a064c5a91e3ed8d9260c72b783fc12542b88fbd.json
@@ -1,0 +1,79 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, created_at, trigger_kind as \"trigger_kind: _\", CASE WHEN pg_column_size(payload) < 40000 THEN payload ELSE '\"WINDMILL_TOO_BIG\"'::jsonb END as \"payload!: _\", trigger_extra as \"trigger_extra: _\"\n        FROM capture\n        WHERE workspace_id = $1\n            AND path = $2 AND is_flow = $3\n            AND ($4::trigger_kind IS NULL OR trigger_kind = $4)\n        ORDER BY created_at DESC\n        OFFSET $5\n        LIMIT $6",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "trigger_kind: _",
+        "type_info": {
+          "Custom": {
+            "name": "trigger_kind",
+            "kind": {
+              "Enum": [
+                "webhook",
+                "http",
+                "websocket",
+                "kafka",
+                "email",
+                "nats"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "payload!: _",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "trigger_extra: _",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Bool",
+        {
+          "Custom": {
+            "name": "trigger_kind",
+            "kind": {
+              "Enum": [
+                "webhook",
+                "http",
+                "websocket",
+                "kafka",
+                "email",
+                "nats"
+              ]
+            }
+          }
+        },
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      true
+    ]
+  },
+  "hash": "5c1de8473e0e96c1063a9a735a064c5a91e3ed8d9260c72b783fc12542b88fbd"
+}

--- a/backend/.sqlx/query-e17ec84003e2ec414622d100f5dfdda86bee33f31835317df512a20c805b35d7.json
+++ b/backend/.sqlx/query-e17ec84003e2ec414622d100f5dfdda86bee33f31835317df512a20c805b35d7.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id, created_at, trigger_kind as \"trigger_kind: _\", payload as \"payload: _\", trigger_extra as \"trigger_extra: _\"\n        FROM capture\n        WHERE workspace_id = $1\n            AND path = $2 AND is_flow = $3\n            AND ($4::trigger_kind IS NULL OR trigger_kind = $4)\n        ORDER BY created_at DESC\n        OFFSET $5\n        LIMIT $6",
+  "query": "SELECT id, created_at, trigger_kind as \"trigger_kind: _\", payload as \"payload!: _\", trigger_extra as \"trigger_extra: _\" FROM capture WHERE id = $1 AND workspace_id = $2",
   "describe": {
     "columns": [
       {
@@ -34,7 +34,7 @@
       },
       {
         "ordinal": 3,
-        "name": "payload: _",
+        "name": "payload!: _",
         "type_info": "Jsonb"
       },
       {
@@ -45,26 +45,8 @@
     ],
     "parameters": {
       "Left": [
-        "Text",
-        "Text",
-        "Bool",
-        {
-          "Custom": {
-            "name": "trigger_kind",
-            "kind": {
-              "Enum": [
-                "webhook",
-                "http",
-                "websocket",
-                "kafka",
-                "email",
-                "nats"
-              ]
-            }
-          }
-        },
         "Int8",
-        "Int8"
+        "Text"
       ]
     },
     "nullable": [
@@ -75,5 +57,5 @@
       true
     ]
   },
-  "hash": "e08dddf6af2656b561c453460ff928e7a158bd29d9035bee136f9952fb96bad4"
+  "hash": "e17ec84003e2ec414622d100f5dfdda86bee33f31835317df512a20c805b35d7"
 }

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -9824,6 +9824,25 @@ paths:
                   $ref: "#/components/schemas/Capture"
 
   /w/{workspace}/capture/{id}:
+    get:
+      summary: get a capture
+      operationId: getCapture
+      tags:
+        - capture
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: capture
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Capture"
     delete:
       summary: delete a capture
       operationId: deleteCapture


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `get_capture` endpoint and handle large payloads in `list_captures` in `capture.rs`.
> 
>   - **Endpoints**:
>     - Add `get_capture` endpoint in `capture.rs` and `openapi.yaml` to retrieve a capture by ID.
>     - Modify `list_captures` in `capture.rs` to handle large payloads by replacing them with a placeholder.
>   - **SQL Queries**:
>     - Update SQL query in `capture.rs` to include logic for large payloads.
>     - Add new SQL query file `query-e17ec84003e2ec414622d100f5dfdda86bee33f31835317df512a20c805b35d7.json` for the new endpoint.
>   - **Misc**:
>     - Rename SQL query file to `query-5c1de8473e0e96c1063a9a735a064c5a91e3ed8d9260c72b783fc12542b88fbd.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for db7688ae34213204b803a8de410c7f94ce4df21b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->