### PR TITLE
feat: add bigquery to the list of python depenency exceptions

### DIFF
--- a/backend/parsers/windmill-parser-py-imports/src/lib.rs
+++ b/backend/parsers/windmill-parser-py-imports/src/lib.rs
@@ -37,6 +37,7 @@ static PYTHON_IMPORTS_REPLACEMENT: phf::Map<&'static str, &'static str> = phf_ma
     "smb" => "pysmb",
     "PIL" => "Pillow",
     "googleapiclient" => "google-api-python-client",
+    "googlecloudbigquery" => "google-cloud-bigquery",
     "dateutil" => "python-dateutil",
     "mailparser" => "mail-parser",
     "mailparser-reply" => "mail-parser-reply",


### PR DESCRIPTION
The native BigQuery script is not suited for us (cannot handle > 10.000 rows and no `setFlowUserState`), hence the need to run BigQuery within python. The import root is not the same as the package name: `from google.cloud import bigquery` hence the need for this exception as mentioned here: https://www.windmill.dev/docs/advanced/dependencies_in_python#lockfile-per-script-inferred-from-imports-standard