### PR TITLE
fix: capture panel never stopping + http saved config

### DIFF
--- a/frontend/src/lib/components/triggers/CaptureSection.svelte
+++ b/frontend/src/lib/components/triggers/CaptureSection.svelte
@@ -30,7 +30,7 @@
 	export let captureTable: CaptureTable | undefined
 
 	const dispatch = createEventDispatcher<{
-		captureToggle: undefined
+		captureToggle: { disableOnly?: boolean }
 		updateSchema: { payloadData: Record<string, any>; redirect: boolean }
 	}>()
 
@@ -38,7 +38,10 @@
 
 	onDestroy(() => {
 		if (captureInfo.active) {
-			dispatch('captureToggle')
+			dispatch('captureToggle', {
+				// this on destroy can be called after capturing has already been stopped (aka after on destroy of the wrapper), make sure we do not start it again
+				disableOnly: true
+			})
 		}
 	})
 
@@ -70,7 +73,7 @@
 					<AnimatedButton animate={captureInfo.active} baseRadius="6px" wrapperClasses="ml-[-2px]">
 						<Button
 							size="xs2"
-							on:click={() => dispatch('captureToggle')}
+							on:click={() => dispatch('captureToggle', {})}
 							variant="border"
 							{disabled}
 							color="light"

--- a/frontend/src/lib/components/triggers/CaptureWrapper.svelte
+++ b/frontend/src/lib/components/triggers/CaptureWrapper.svelte
@@ -110,12 +110,12 @@
 		)
 	}
 
-	export async function handleCapture() {
-		if (!captureActive) {
+	export async function handleCapture(e: CustomEvent<{ disableOnly?: boolean }>) {
+		if (captureActive || e.detail.disableOnly) {
+			captureActive = false
+		} else {
 			await setConfig()
 			capture()
-		} else {
-			captureActive = false
 		}
 	}
 
@@ -178,9 +178,7 @@
 				on:applyArgs
 				on:updateSchema
 				on:addPreprocessor
-				on:captureToggle={() => {
-					handleCapture()
-				}}
+				on:captureToggle={handleCapture}
 				on:testWithArgs
 			/>
 		{:else if captureType === 'webhook'}
@@ -197,9 +195,7 @@
 				on:applyArgs
 				on:updateSchema
 				on:addPreprocessor
-				on:captureToggle={() => {
-					handleCapture()
-				}}
+				on:captureToggle={handleCapture}
 				on:testWithArgs
 			/>
 		{:else if captureType === 'http'}
@@ -209,16 +205,15 @@
 				{showCapture}
 				can_write={true}
 				runnableArgs={data?.args}
-				bind:args
+				bind:route_path={args.route_path}
+				bind:http_method={args.http_method}
 				headless
 				{captureInfo}
 				bind:captureTable
 				on:applyArgs
 				on:updateSchema
 				on:addPreprocessor
-				on:captureToggle={() => {
-					handleCapture()
-				}}
+				on:captureToggle={handleCapture}
 				on:testWithArgs
 			/>
 		{:else if captureType === 'email'}
@@ -235,9 +230,7 @@
 				on:applyArgs
 				on:updateSchema
 				on:addPreprocessor
-				on:captureToggle={() => {
-					handleCapture()
-				}}
+				on:captureToggle={handleCapture}
 				on:testWithArgs
 			/>
 		{:else if captureType === 'kafka'}
@@ -252,9 +245,7 @@
 				on:applyArgs
 				on:updateSchema
 				on:addPreprocessor
-				on:captureToggle={() => {
-					handleCapture()
-				}}
+				on:captureToggle={handleCapture}
 				on:testWithArgs
 			/>
 		{:else if captureType === 'nats'}
@@ -269,9 +260,7 @@
 				on:applyArgs
 				on:updateSchema
 				on:addPreprocessor
-				on:captureToggle={() => {
-					handleCapture()
-				}}
+				on:captureToggle={handleCapture}
 			/>
 		{/if}
 	</div>

--- a/frontend/src/lib/components/triggers/TriggersWrapper.svelte
+++ b/frontend/src/lib/components/triggers/TriggersWrapper.svelte
@@ -44,7 +44,8 @@
 		<RouteEditorConfigSection
 			showCapture={false}
 			can_write={true}
-			bind:args
+			bind:route_path={args.route_path}
+			bind:http_method={args.http_method}
 			headless
 			{isFlow}
 			{path}

--- a/frontend/src/lib/components/triggers/http/RouteEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/http/RouteEditorInner.svelte
@@ -166,10 +166,6 @@
 	let drawer: Drawer
 
 	let dirtyPath = false
-
-	let args: Record<string, any> = { route_path: '' }
-
-	$: args && (route_path = args.route_path)
 </script>
 
 {#if static_asset_config}
@@ -227,7 +223,6 @@
 					isFlow={is_flow}
 					{path}
 					bind:route_path
-					bind:args
 					bind:isValid
 					bind:dirtyRoutePath
 					bind:http_method


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix capture panel stopping issue and update HTTP config handling with `disableOnly` flag and direct bindings.
> 
>   - **Behavior**:
>     - `captureToggle` event in `CaptureSection.svelte` now includes `disableOnly` flag to prevent restarting capture on destroy.
>     - `handleCapture` in `CaptureWrapper.svelte` updated to handle `disableOnly` flag, ensuring capture stops correctly.
>   - **Bindings**:
>     - Bind `route_path` and `http_method` directly in `RouteEditorConfigSection.svelte` and `TriggersWrapper.svelte`.
>   - **Misc**:
>     - Remove redundant `args` binding in `RouteEditorInner.svelte` and `CaptureWrapper.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for cc07f9fab65a3d8f8f9965816e284a19f3864eff. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->