### PR TITLE
fix: fix worker restart on otel setting set from undefined to null

### DIFF
--- a/backend/migrations/20250131115248_otel_global_settings.down.sql
+++ b/backend/migrations/20250131115248_otel_global_settings.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM global_settings WHERE name = 'otel';

--- a/backend/migrations/20250131115248_otel_global_settings.up.sql
+++ b/backend/migrations/20250131115248_otel_global_settings.up.sql
@@ -1,0 +1,1 @@
+INSERT INTO global_settings (name, value) VALUES ('otel', '{}'); 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add migrations to handle 'otel' setting in `global_settings` to fix worker restart issue.
> 
>   - **Migrations**:
>     - Add `20250131115248_otel_global_settings.up.sql` to insert 'otel' setting into `global_settings`.
>     - Add `20250131115248_otel_global_settings.down.sql` to delete 'otel' setting from `global_settings`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for d7098f843ec6427f140f13e7180a685216be65f7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->