### PR TITLE
Revert "fix: fix worker restart on otel setting set from undefined to null"

### DIFF
--- a/backend/migrations/20250131115248_otel_global_settings.down.sql
+++ b/backend/migrations/20250131115248_otel_global_settings.down.sql
@@ -1,1 +1,0 @@
-DELETE FROM global_settings WHERE name = 'otel';

--- a/backend/migrations/20250131115248_otel_global_settings.up.sql
+++ b/backend/migrations/20250131115248_otel_global_settings.up.sql
@@ -1,1 +1,0 @@
-INSERT INTO global_settings (name, value) VALUES ('otel', '{}'); 


### PR DESCRIPTION
Reverts windmill-labs/windmill#5183
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts windmill-labs/windmill#5183 by deleting SQL migration files for 'otel' global settings.
> 
>   - **Revert**:
>     - Reverts changes from windmill-labs/windmill#5183.
>     - Deletes `20250131115248_otel_global_settings.up.sql` and `20250131115248_otel_global_settings.down.sql` which added and removed 'otel' setting in `global_settings` table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 5374696d8293ef34cb1578d6b4c00d08c2fec5b6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->