### PR TITLE
fix height refresh for flows

### DIFF
--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { FlowService, type FlowModule } from '../../gen'
 	import { NODE, type GraphModuleState } from '.'
-	import { createEventDispatcher, getContext, onDestroy, onMount, setContext } from 'svelte'
+	import { createEventDispatcher, getContext, onDestroy, onMount, setContext, tick } from 'svelte'
 
 	import { get, writable, type Writable } from 'svelte/store'
 	import '@xyflow/svelte/dist/style.css'
@@ -273,7 +273,7 @@
 		return false
 	}
 
-	function updateStores() {
+	async function updateStores() {
 		if (graph.error) {
 			return
 		}
@@ -281,6 +281,7 @@
 
 		$nodes = layoutNodes(newGraph.nodes)
 		$edges = newGraph.edges
+		await tick()
 		height = Math.max(...$nodes.map((n) => n.position.y + NODE.height + 100), minHeight)
 	}
 


### PR DESCRIPTION
solves bug of disapearing flow. To reproduce : 
1. Add flow
2. refresh page
3. Drag flow down

![image](https://github.com/user-attachments/assets/9ff1327c-d218-4551-9ed6-aded0dea8883)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes disappearing flow issue in `FlowGraphV2.svelte` by using `tick()` to ensure height is recalculated after DOM updates.
> 
>   - **Behavior**:
>     - Fixes disappearing flow issue in `FlowGraphV2.svelte` by ensuring height is recalculated after DOM updates.
>     - Uses `tick()` in `updateStores()` to wait for DOM updates before recalculating height.
>   - **Imports**:
>     - Adds `tick` import from `svelte` in `FlowGraphV2.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 5f1a77d5bc12e560abdcd30f016f2eb44f5ee5c8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->