### PR TITLE
backend: rework queue::push after v2

### DIFF
--- a/backend/.sqlx/query-114759d2c9049f7d5f377ba4da5abc33223aa70aacbcb6fd730def35415c48fd.json
+++ b/backend/.sqlx/query-114759d2c9049f7d5f377ba4da5abc33223aa70aacbcb6fd730def35415c48fd.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO concurrency_key (job_id, key) SELECT unnest($1::uuid[]), $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "114759d2c9049f7d5f377ba4da5abc33223aa70aacbcb6fd730def35415c48fd"
+}

--- a/backend/.sqlx/query-90d1c1ed47f1a9186cdde2f720fe86cde5ffefb4578d6e091855bc7a4e94d1b0.json
+++ b/backend/.sqlx/query-90d1c1ed47f1a9186cdde2f720fe86cde5ffefb4578d6e091855bc7a4e94d1b0.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO script (\n                        summary, description, dedicated_worker, content, workspace_id, path, hash,\n                        language, tag, created_by, lock\n                    ) VALUES ('', '', true, $1, $2, $3, $4, $5, $6, $7, '')\n                    ON CONFLICT (workspace_id, hash) DO NOTHING",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Varchar",
+        "Varchar",
+        "Int8",
+        {
+          "Custom": {
+            "name": "script_lang",
+            "kind": {
+              "Enum": [
+                "python3",
+                "deno",
+                "go",
+                "bash",
+                "postgresql",
+                "nativets",
+                "bun",
+                "mysql",
+                "bigquery",
+                "snowflake",
+                "graphql",
+                "powershell",
+                "mssql",
+                "php",
+                "bunnative",
+                "rust",
+                "ansible",
+                "csharp",
+                "oracledb"
+              ]
+            }
+          }
+        },
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "90d1c1ed47f1a9186cdde2f720fe86cde5ffefb4578d6e091855bc7a4e94d1b0"
+}

--- a/backend/.sqlx/query-a5ee62bb42a9e8dba4a54000d182f0ebb6278b87b32b249dbd12cff7eebc49a1.json
+++ b/backend/.sqlx/query-a5ee62bb42a9e8dba4a54000d182f0ebb6278b87b32b249dbd12cff7eebc49a1.json
@@ -1,0 +1,115 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO v2_job (\n                id, workspace_id,\n                created_at, created_by, permissioned_as, permissioned_as_email,\n                kind, runnable_id, runnable_path, root_job, parent_job, script_lang,\n                flow_step, flow_step_id, flow_innermost_root_job,\n                trigger, trigger_kind,\n                tag, same_worker, visible_to_owner, concurrent_limit, concurrency_time_window_s,\n                cache_ttl, timeout, priority,\n                preprocessed, pre_run_error,\n                raw_code, raw_lock, raw_flow,\n                args, script_entrypoint_override)\n            SELECT\n                t.id, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,\n                $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30,\n                t.args, t.args->>'_ENTRYPOINT_OVERRIDE'\n            FROM unnest($1::uuid[], $31::jsonb[]) AS t(id, args)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "Varchar",
+        "Timestamptz",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        {
+          "Custom": {
+            "name": "job_kind",
+            "kind": {
+              "Enum": [
+                "script",
+                "preview",
+                "flow",
+                "dependencies",
+                "flowpreview",
+                "script_hub",
+                "identity",
+                "flowdependencies",
+                "http",
+                "graphql",
+                "postgresql",
+                "noop",
+                "appdependencies",
+                "deploymentcallback",
+                "singlescriptflow",
+                "flowscript",
+                "flownode",
+                "appscript"
+              ]
+            }
+          }
+        },
+        "Int8",
+        "Varchar",
+        "Uuid",
+        "Uuid",
+        {
+          "Custom": {
+            "name": "script_lang",
+            "kind": {
+              "Enum": [
+                "python3",
+                "deno",
+                "go",
+                "bash",
+                "postgresql",
+                "nativets",
+                "bun",
+                "mysql",
+                "bigquery",
+                "snowflake",
+                "graphql",
+                "powershell",
+                "mssql",
+                "php",
+                "bunnative",
+                "rust",
+                "ansible",
+                "csharp",
+                "oracledb"
+              ]
+            }
+          }
+        },
+        "Int4",
+        "Varchar",
+        "Uuid",
+        "Varchar",
+        {
+          "Custom": {
+            "name": "job_trigger_kind",
+            "kind": {
+              "Enum": [
+                "webhook",
+                "http",
+                "websocket",
+                "kafka",
+                "email",
+                "nats",
+                "schedule",
+                "app",
+                "ui",
+                "postgres"
+              ]
+            }
+          }
+        },
+        "Varchar",
+        "Bool",
+        "Bool",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int2",
+        "Bool",
+        "Text",
+        "Text",
+        "Text",
+        "Jsonb",
+        "JsonbArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a5ee62bb42a9e8dba4a54000d182f0ebb6278b87b32b249dbd12cff7eebc49a1"
+}

--- a/backend/.sqlx/query-d93a43bb6332212264abc5ca48879789cac188f3389874d263ff1373155b3a7e.json
+++ b/backend/.sqlx/query-d93a43bb6332212264abc5ca48879789cac188f3389874d263ff1373155b3a7e.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO job_perms (job_id, email, username, is_admin, is_operator, folders,\n                    groups, workspace_id)\n                SELECT unnest($1::uuid[]), $2, $3, $4, $5, $6, $7, $8\n                ON CONFLICT (job_id) DO UPDATE SET\n                    email = EXCLUDED.email,\n                    username = EXCLUDED.username,\n                    is_admin = EXCLUDED.is_admin,\n                    is_operator = EXCLUDED.is_operator,\n                    folders = EXCLUDED.folders,\n                    groups = EXCLUDED.groups,\n                    workspace_id = EXCLUDED.workspace_id",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "Varchar",
+        "Varchar",
+        "Bool",
+        "Bool",
+        "JsonbArray",
+        "TextArray",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d93a43bb6332212264abc5ca48879789cac188f3389874d263ff1373155b3a7e"
+}

--- a/backend/.sqlx/query-ff0e64afd81e55ab91b6e665990676de2a2d959e00e005c296376ba926bb7434.json
+++ b/backend/.sqlx/query-ff0e64afd81e55ab91b6e665990676de2a2d959e00e005c296376ba926bb7434.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO v2_job_queue (id, workspace_id, started_at, scheduled_for, running,\n                created_at, tag, priority)\n            SELECT unnest($1::uuid[]), $2, $3, $4, $5, $6, $7, $8",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "Varchar",
+        "Timestamptz",
+        "Timestamptz",
+        "Bool",
+        "Timestamptz",
+        "Varchar",
+        "Int2"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ff0e64afd81e55ab91b6e665990676de2a2d959e00e005c296376ba926bb7434"
+}

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -11424,6 +11424,7 @@ dependencies = [
  "tokio-postgres 0.7.13",
  "tokio-util",
  "tracing",
+ "ulid",
  "urlencoding",
  "uuid 1.13.1",
  "windmill-audit",

--- a/backend/windmill-common/src/jobs.rs
+++ b/backend/windmill-common/src/jobs.rs
@@ -44,6 +44,22 @@ pub enum JobKind {
     AppScript,
 }
 
+#[derive(sqlx::Type, Serialize, Deserialize, Debug, PartialEq, Copy, Clone)]
+#[sqlx(type_name = "JOB_TRIGGER_KIND", rename_all = "lowercase")]
+#[serde(rename_all(serialize = "lowercase"))]
+pub enum JobTriggerKind {
+    Webhook,
+    Http,
+    Websocket,
+    Kafka,
+    Email,
+    Nats,
+    Schedule,
+    App,
+    Ui,
+    Postgres,
+}
+
 impl JobKind {
     pub fn is_flow(&self) -> bool {
         matches!(

--- a/backend/windmill-worker/Cargo.toml
+++ b/backend/windmill-worker/Cargo.toml
@@ -102,6 +102,7 @@ object_store = { workspace = true, optional = true}
 convert_case.workspace = true
 yaml-rust.workspace = true
 backon.workspace = true
+ulid.workspace = true
 
 opentelemetry = { workspace = true, optional = true }
 bollard = { workspace = true, optional = true }

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1048,9 +1048,9 @@ pub async fn run_worker(
     let is_dedicated_worker: bool = WORKER_CONFIG.read().await.dedicated_worker.is_some();
 
     #[cfg(feature = "benchmark")]
-    let benchmark_jobs: i32 = std::env::var("BENCHMARK_JOBS")
+    let benchmark_jobs: usize = std::env::var("BENCHMARK_JOBS")
         .unwrap_or("5000".to_string())
-        .parse::<i32>()
+        .parse::<usize>()
         .unwrap();
 
     #[cfg(feature = "benchmark")]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor job queue handling by introducing `RawJob` struct, moving benchmark code to `windmill-worker`, and updating job processing logic.
> 
>   - **Behavior**:
>     - Introduces `RawJob` struct in `windmill-queue/src/jobs.rs` to encapsulate job details and streamline job insertion.
>     - Refactors job insertion logic in `push()` and `push_many()` functions in `windmill-queue/src/jobs.rs`.
>     - Updates job processing logic in `add_batch_jobs()` in `windmill-api/src/jobs.rs` to use `RawJob`.
>   - **Benchmarking**:
>     - Moves benchmark-related code from `windmill-common/src/bench.rs` to `windmill-worker/src/bench.rs`.
>     - Updates benchmark initialization in `run_worker()` in `windmill-worker/src/worker.rs`.
>   - **Misc**:
>     - Adds new SQL queries for job handling in `.sqlx` files.
>     - Renames `concurrent_time_window_s` to `concurrency_time_window_s` in `windmill-api/src/jobs.rs` and `windmill-queue/src/jobs.rs`.
>     - Removes `bench.rs` from `windmill-common` and updates references to it in `windmill-worker`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 084dc6e98f128ae6f52100c93c1961928a8a1108. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->