### PR TITLE
backend: fix missing `v2_job_runtime`

### DIFF
--- a/backend/migrations/20250201145632_v2_fix_no_runtime.down.sql
+++ b/backend/migrations/20250201145632_v2_fix_no_runtime.down.sql
@@ -1,0 +1,1 @@
+-- Add down migration script here

--- a/backend/migrations/20250201145632_v2_fix_no_runtime.up.sql
+++ b/backend/migrations/20250201145632_v2_fix_no_runtime.up.sql
@@ -1,0 +1,8 @@
+-- Add up migration script here
+-- Migrate `v2_job_queue` moved columns to `v2_job_runtime`:
+INSERT INTO v2_job_runtime (id, ping, memory_peak)
+SELECT id, __last_ping, __mem_peak
+FROM v2_job_queue
+   -- Locked ones will sync within triggers
+    FOR UPDATE SKIP LOCKED
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add migration to move data from `v2_job_queue` to `v2_job_runtime` with conflict handling.
> 
>   - **Migrations**:
>     - Adds `20250201145632_v2_fix_no_runtime.up.sql` to migrate data from `v2_job_queue` to `v2_job_runtime`.
>       - Moves `id`, `__last_ping`, `__mem_peak` to `id`, `ping`, `memory_peak`.
>       - Uses `FOR UPDATE SKIP LOCKED` to handle locked rows.
>       - Uses `ON CONFLICT (id) DO NOTHING` to handle conflicts.
>     - Adds `20250201145632_v2_fix_no_runtime.down.sql` as a placeholder for down migration script.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 860c85f7e6c824d068a58637721e0a7e296402c2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->