### PR TITLE
button icon size should be proportional to button size

### DIFF
--- a/frontend/src/lib/components/apps/components/buttons/AppButton.svelte
+++ b/frontend/src/lib/components/apps/components/buttons/AppButton.svelte
@@ -76,12 +76,29 @@
 	$: resolvedConfig.beforeIcon && beforeIconComponent && handleBeforeIcon()
 	$: resolvedConfig.afterIcon && afterIconComponent && handleAfterIcon()
 
+	function getIconSize() {
+		switch (resolvedConfig.size as 'xs' | 'sm' | 'md' | 'lg' | 'xl') {
+			case 'xs':
+				return 14
+			case 'sm':
+				return 16
+			case 'md':
+				return 20
+			case 'lg':
+				return 24
+			case 'xl':
+				return 26
+			default:
+				return 24
+		}
+	}
+
 	async function handleBeforeIcon() {
 		if (resolvedConfig.beforeIcon) {
 			beforeIconComponent = await loadIcon(
 				resolvedConfig.beforeIcon,
 				beforeIconComponent,
-				14,
+				getIconSize(),
 				undefined,
 				undefined
 			)
@@ -93,7 +110,7 @@
 			afterIconComponent = await loadIcon(
 				resolvedConfig.afterIcon,
 				afterIconComponent,
-				14,
+				getIconSize(),
 				undefined,
 				undefined
 			)


### PR DESCRIPTION
![Screenshot 2025-02-06 at 10 02 15 AM](https://github.com/user-attachments/assets/d7beafe4-7d10-475a-a014-ddd445729381)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Icon size in `AppButton.svelte` is now proportional to button size using a new `getIconSize()` function.
> 
>   - **Behavior**:
>     - Icon size in `AppButton.svelte` is now proportional to button size using `getIconSize()`.
>     - `getIconSize()` returns sizes 14, 16, 20, 24, or 26 based on button size ('xs', 'sm', 'md', 'lg', 'xl').
>     - Applied in `handleBeforeIcon()` and `handleAfterIcon()` functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 127fe619ba87a5e8ee6f370a7dd1eb7b8809f251. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->