### PR TITLE
fix: remove unnecessary rw on cache for powershell in nsjail

### DIFF
--- a/backend/windmill-worker/nsjail/run.powershell.config.proto
+++ b/backend/windmill-worker/nsjail/run.powershell.config.proto
@@ -121,7 +121,7 @@ mount {
     src: "{CACHE_DIR}"
     dst: "/tmp/windmill/cache/powershell"
     is_bind: true
-    rw: true
+    rw: false
     mandatory: false
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change mount permission for `{CACHE_DIR}` in `run.powershell.config.proto` to read-only.
> 
>   - **Configuration Change**:
>     - In `run.powershell.config.proto`, changed mount permission for `{CACHE_DIR}` from `rw: true` to `rw: false` to make it read-only.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 5b94064b8d2fa07577d4d8111b676617bcf0e495. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->