### PR TITLE
fix(cli): ai resource type typo

### DIFF
--- a/cli/settings.ts
+++ b/cli/settings.ts
@@ -1,7 +1,7 @@
 import process from "node:process";
 import { colors, Confirm, log, yamlParseFile, yamlStringify } from "./deps.ts";
 import * as wmill from "./gen/services.gen.ts";
-import { AiResource, Config, GlobalSetting } from "./gen/types.gen.ts";
+import { AIResource, Config, GlobalSetting } from "./gen/types.gen.ts";
 import { compareInstanceObjects, InstanceSyncOptions } from "./instance.ts";
 import { isSuperset } from "./types.ts";
 import { deepEqual } from "./utils.ts";
@@ -20,7 +20,7 @@ export interface SimplifiedSettings {
   error_handler?: string;
   error_handler_extra_args?: any;
   error_handler_muted_on_cancel?: boolean;
-  ai_resource?: AiResource;
+  ai_resource?: AIResource;
   code_completion_model?: string;
   ai_models: string[];
   large_file_storage?: any;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename `AiResource` to `AIResource` in `cli/settings.ts` to fix a typo.
> 
>   - **Type Rename**:
>     - Rename `AiResource` to `AIResource` in `cli/settings.ts`.
>     - Update `ai_resource` property type in `SimplifiedSettings` interface to `AIResource`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for ef00b8c78ace2dcbb06d2b263716532e3f1d8289. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->