### PR TITLE
backend: fix `v2_job.tag` length

### DIFF
--- a/backend/migrations/20250205131516_v2_job_tag_size.down.sql
+++ b/backend/migrations/20250205131516_v2_job_tag_size.down.sql
@@ -1,0 +1,1 @@
+-- Add down migration script here

--- a/backend/migrations/20250205131516_v2_job_tag_size.up.sql
+++ b/backend/migrations/20250205131516_v2_job_tag_size.up.sql
@@ -1,0 +1,34 @@
+-- Add up migration script here
+DO $$
+DECLARE
+    rec RECORD;
+    view_definitions TEXT[];
+    view_names TEXT[];
+BEGIN
+    -- Step 1: Store view definitions
+    FOR rec IN (
+        SELECT c.relname AS view_name, pg_get_viewdef(c.oid, true) AS view_sql
+        FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid
+        WHERE c.relkind = 'v' AND c.relname IN ('job', 'v2_as_queue', 'v2_as_completed_job')
+    ) LOOP
+        -- Save view names and definitions
+        view_names := array_append(view_names, rec.view_name);
+        view_definitions := array_append(view_definitions, rec.view_sql);
+    END LOOP;
+
+    -- Step 2: Drop the views
+    FOR i IN 1..array_length(view_names, 1) LOOP
+        EXECUTE format('DROP VIEW IF EXISTS %I', view_names[i]);
+    END LOOP;
+
+    -- Step 3: Alter the table column type
+    ALTER TABLE v2_job ALTER COLUMN tag TYPE VARCHAR(255);
+    ALTER TABLE flow ALTER COLUMN tag TYPE VARCHAR(255);
+    ALTER TABLE schedule ALTER COLUMN tag TYPE VARCHAR(255);
+    ALTER TABLE script ALTER COLUMN tag TYPE VARCHAR(255);
+
+    -- Step 4: Recreate the views using stored definitions
+    FOR i IN 1..array_length(view_names, 1) LOOP
+        EXECUTE format('CREATE OR REPLACE VIEW %I AS %s', view_names[i], view_definitions[i]);
+    END LOOP;
+END $$;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds migration to change `tag` column to `VARCHAR(255)` in multiple tables and handles view recreation.
> 
>   - **Database Migration**:
>     - Adds `20250205131516_v2_job_tag_size.up.sql` to alter `tag` column to `VARCHAR(255)` in `v2_job`, `flow`, `schedule`, and `script` tables.
>     - Stores, drops, and recreates views `job`, `v2_as_queue`, `v2_as_completed_job` during migration.
>     - Adds empty `20250205131516_v2_job_tag_size.down.sql` for down migration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 4b17be80cdcecba675fe265a45fa747866ccb1ee. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->