### PR TITLE
backend: move `bench.rs` from common to worker crate

### DIFF
--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -1713,7 +1713,7 @@ async fn handle_zombie_jobs(db: &Pool<Postgres>, base_internal_url: &str, worker
             worker_name,
             send_result_never_used,
             #[cfg(feature = "benchmark")]
-            &mut windmill_common::bench::BenchmarkIter::new(),
+            &mut windmill_worker::bench::BenchmarkIter::new(),
         )
         .await;
     }

--- a/backend/windmill-common/src/lib.rs
+++ b/backend/windmill-common/src/lib.rs
@@ -19,8 +19,6 @@ use sqlx::{Pool, Postgres};
 
 pub mod apps;
 pub mod auth;
-#[cfg(feature = "benchmark")]
-pub mod bench;
 pub mod cache;
 pub mod db;
 pub mod ee;

--- a/backend/windmill-worker/src/bench.rs
+++ b/backend/windmill-worker/src/bench.rs
@@ -1,9 +1,9 @@
-use crate::{
+use serde::Serialize;
+use tokio::time::Instant;
+use windmill_common::{
     worker::{write_file, TMP_DIR},
     DB,
 };
-use serde::Serialize;
-use tokio::time::Instant;
 
 #[derive(Serialize)]
 pub struct BenchmarkInfo {
@@ -79,7 +79,7 @@ impl BenchmarkIter {
 }
 
 pub async fn benchmark_init(benchmark_jobs: i32, db: &DB) {
-    use crate::{jobs::JobKind, scripts::ScriptLang};
+    use windmill_common::{jobs::JobKind, scripts::ScriptLang};
 
     let benchmark_kind = std::env::var("BENCHMARK_KIND").unwrap_or("noop".to_string());
 

--- a/backend/windmill-worker/src/lib.rs
+++ b/backend/windmill-worker/src/lib.rs
@@ -9,6 +9,8 @@ mod snowflake_executor;
 mod ansible_executor;
 mod bash_executor;
 
+#[cfg(feature = "benchmark")]
+pub mod bench;
 mod bun_executor;
 pub mod common;
 mod config;
@@ -38,6 +40,7 @@ mod rust_executor;
 mod worker;
 mod worker_flow;
 mod worker_lockfiles;
+
 pub use worker::*;
 
 pub use result_processor::handle_job_error;

--- a/backend/windmill-worker/src/result_processor.rs
+++ b/backend/windmill-worker/src/result_processor.rs
@@ -26,7 +26,7 @@ use windmill_common::{
 };
 
 #[cfg(feature = "benchmark")]
-use windmill_common::bench::{BenchmarkInfo, BenchmarkIter};
+use crate::bench::{BenchmarkInfo, BenchmarkIter};
 
 use windmill_queue::{append_logs, get_queued_job, CanceledBy, WrappedError};
 

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -146,7 +146,7 @@ use crate::mssql_executor::do_mssql;
 use crate::bigquery_executor::do_bigquery;
 
 #[cfg(feature = "benchmark")]
-use windmill_common::bench::{benchmark_init, BenchmarkInfo, BenchmarkIter};
+use crate::bench::{benchmark_init, BenchmarkInfo, BenchmarkIter};
 
 use windmill_common::add_time;
 

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -11,6 +11,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+#[cfg(feature = "benchmark")]
+use crate::bench::BenchmarkIter;
 use crate::common::{cached_result_path, save_in_cache};
 use crate::js_eval::{eval_timeout, IdContext};
 use crate::{
@@ -30,8 +32,6 @@ use tracing::instrument;
 use uuid::Uuid;
 use windmill_common::add_time;
 use windmill_common::auth::JobPerms;
-#[cfg(feature = "benchmark")]
-use windmill_common::bench::BenchmarkIter;
 use windmill_common::cache::{self, RawData};
 use windmill_common::db::Authed;
 use windmill_common::flow_status::{


### PR DESCRIPTION
Move in preparation of https://github.com/windmill-labs/windmill/pull/5220 to not loose git history on that file
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move `bench.rs` from `windmill-common` to `windmill-worker` and update related imports and references.
> 
>   - **File Relocation**:
>     - Move `bench.rs` from `windmill-common` to `windmill-worker`.
>   - **Imports and References**:
>     - Update imports in `monitor.rs`, `result_processor.rs`, and `worker.rs` to use `windmill_worker::bench` instead of `windmill_common::bench`.
>     - Remove `bench` module from `windmill-common/src/lib.rs` and add it to `windmill-worker/src/lib.rs`.
>   - **Benchmarking**:
>     - Update references to `BenchmarkIter` and `BenchmarkInfo` in `worker.rs`, `result_processor.rs`, and `worker_flow.rs` to reflect the new module path.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 16bf861357be0976c6c11902958258dc668d7933. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->