### PR TITLE
backend: fix missing virtual modules when inserting flow version lite

### DIFF
--- a/backend/windmill-worker/src/worker_lockfiles.rs
+++ b/backend/windmill-worker/src/worker_lockfiles.rs
@@ -1130,7 +1130,6 @@ async fn insert_flow_modules<'c>(
         same_worker,
     ))
     .await?;
-    add_virtual_items_if_necessary(modules);
     if modules.is_empty() || crate::worker_flow::is_simple_modules(modules, failure_module) {
         return Ok(tx);
     }
@@ -1259,6 +1258,7 @@ async fn reduce_flow<'c>(
         }
         module.value = to_raw_value(&val);
     }
+    add_virtual_items_if_necessary(&mut *modules);
     Ok(tx)
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move `add_virtual_items_if_necessary` from `insert_flow_modules` to `reduce_flow` in `worker_lockfiles.rs` to ensure virtual items are added during flow reduction.
> 
>   - **Behavior**:
>     - Move `add_virtual_items_if_necessary` call from `insert_flow_modules` to `reduce_flow` in `worker_lockfiles.rs`.
>     - Ensures virtual items are added during flow reduction, not during module insertion.
>   - **Functions**:
>     - Modify `reduce_flow()` to include `add_virtual_items_if_necessary`.
>     - Remove `add_virtual_items_if_necessary` from `insert_flow_modules()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for d07cda3b38792348ebddbd570b921878c16a2afb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->