### PR TITLE
fix: populate teams channel on initial load

### DIFF
--- a/frontend/src/lib/components/InstanceSetting.svelte
+++ b/frontend/src/lib/components/InstanceSetting.svelte
@@ -422,6 +422,9 @@
 														[e.target['value']]: ''
 													}
 												}
+												if (e.target?.['value'] === 'teams_channel') {
+													fetchTeams()
+												}
 											}}
 											value={(() => {
 												if (!v) return 'email'
@@ -456,15 +459,17 @@
 														selected={!$values['critical_error_channels'][i]?.teams_channel
 															?.team_id}>Select team</option
 													>
-													{#each $values['teams'] as team}
-														<option
-															value={team.team_id}
-															selected={$values['critical_error_channels'][i]?.teams_channel
-																?.team_id === team.team_id}
-														>
-															{team.team_name}
-														</option>
-													{/each}
+													{#if $values['teams']}
+														{#each $values['teams'] as team}
+															<option
+																value={team.team_id}
+																selected={$values['critical_error_channels'][i]?.teams_channel
+																	?.team_id === team.team_id}
+															>
+																{team.team_name}
+															</option>
+														{/each}
+													{/if}
 												</select>
 												{#if $values['critical_error_channels'][i]?.teams_channel?.team_id}
 													<select


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes initial load issue by fetching teams when 'teams_channel' is selected in `InstanceSetting.svelte`.
> 
>   - **Behavior**:
>     - Calls `fetchTeams()` when 'teams_channel' is selected in the dropdown in `InstanceSetting.svelte`.
>     - Ensures team options are only rendered if `$values['teams']` is defined.
>   - **Functions**:
>     - Modifies the event handler to include a check for 'teams_channel' selection and trigger `fetchTeams()`.
>     - Wraps the team options rendering in a conditional block to check for `$values['teams']`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 3c31d2f147caddf3f1bae8d03e11e8e1ce63e6e7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->