### PR TITLE
fix: static website serving

### DIFF
--- a/backend/windmill-api/src/http_triggers.rs
+++ b/backend/windmill-api/src/http_triggers.rs
@@ -538,7 +538,7 @@ async fn get_http_route_trigger(
         let route_path = trigger.route_path.clone();
         if trigger.is_static_website {
             router
-                .insert(format!("{}/*wm_subpath", route_path), idx)
+                .insert(format!("/{}/*wm_subpath", route_path), idx)
                 .unwrap_or_else(|e| {
                     tracing::warn!(
                         "Failed to consider http trigger route {}: {:?}",
@@ -547,19 +547,22 @@ async fn get_http_route_trigger(
                     );
                 });
         }
-        router.insert(route_path.as_str(), idx).unwrap_or_else(|e| {
-            tracing::warn!(
-                "Failed to consider http trigger route {}: {:?}",
-                route_path,
-                e,
-            );
-        });
+        router
+            .insert(format!("/{}", route_path), idx)
+            .unwrap_or_else(|e| {
+                tracing::warn!(
+                    "Failed to consider http trigger route {}: {:?}",
+                    route_path,
+                    e,
+                );
+            });
     }
 
-    let trigger_idx = router.at(route_path.0.as_str()).ok();
+    let requested_path = format!("/{}", route_path.0);
+    let trigger_idx = router.at(requested_path.as_str()).ok();
 
     let matchit::Match { value: trigger_idx, params } =
-        not_found_if_none(trigger_idx, "Trigger", route_path.0.as_str())?;
+        not_found_if_none(trigger_idx, "Trigger", requested_path.as_str())?;
 
     let trigger = triggers.remove(trigger_idx.to_owned());
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes route path handling for static websites in `get_http_route_trigger()` by ensuring paths are prefixed with a `/`.
> 
>   - **Behavior**:
>     - Fixes route path handling for static websites in `get_http_route_trigger()` in `http_triggers.rs` by ensuring paths are prefixed with a `/`.
>     - Adjusts `router.insert()` calls to include leading `/` for both static and non-static routes.
>   - **Misc**:
>     - Updates `requested_path` construction to include leading `/` in `get_http_route_trigger()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 1f514cba09939eb37dd977370087d2a7e92c19f0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->