### PR TITLE
reactivity fix on teams workspace dropdown

### DIFF
--- a/frontend/src/lib/components/ConnectionSection.svelte
+++ b/frontend/src/lib/components/ConnectionSection.svelte
@@ -35,7 +35,7 @@
 		isFetching = false
 	}
 
-	$: workspaceStore && platform && $enterpriseLicense === 'teams' && loadTeams()
+	$: workspaceStore && platform && $enterpriseLicense && loadTeams()
 
 	async function connectTeams() {
 		const selectedTeam = teams.find((team) => team.team_id === selected_teams_team)

--- a/frontend/src/lib/components/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/ScheduleEditorInner.svelte
@@ -344,7 +344,6 @@
 				failedTimes = s.on_failure_times ?? 1
 				failedExact = s.on_failure_exact ?? false
 				errorHandlerExtraArgs = s.on_failure_extra_args ?? {}
-				console.log('errorHandlerExtraArgs', errorHandlerExtraArgs)
 				errorHandlerSelected = getHandlerType('error', errorHandlerPath)
 			} else {
 				errorHandlerPath = undefined


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix reactivity in `ConnectionSection.svelte` and remove a console log from `ScheduleEditorInner.svelte`.
> 
>   - **Reactivity Fix**:
>     - In `ConnectionSection.svelte`, changed condition to call `loadTeams()` when `$enterpriseLicense` is truthy, not just when it equals 'teams'.
>   - **Code Cleanup**:
>     - Removed `console.log('errorHandlerExtraArgs', errorHandlerExtraArgs)` from `ScheduleEditorInner.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for dbd10a2c0e4e3e01ab26d6dff227360f23dd3b96. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->