### PR TITLE
fix: not able to filter runs by schedule

### DIFF
--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -1319,7 +1319,7 @@ pub fn filter_list_queue_query(
     }
     if let Some(p) = &lq.schedule_path {
         sqlb.and_where_eq("trigger", "?".bind(p));
-        sqlb.and_where_eq("trigger_kind", "schedule");
+        sqlb.and_where_eq("trigger_kind", "'schedule'");
     }
     if let Some(h) = &lq.script_hash {
         sqlb.and_where_eq("runnable_id", "?".bind(h));


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes filtering of runs by schedule in `filter_list_queue_query()` in `jobs.rs` by correcting the SQL query to use single quotes around 'schedule'.
> 
>   - **Behavior**:
>     - Fixes filtering of runs by schedule in `filter_list_queue_query()` in `jobs.rs` by correcting the SQL query to use single quotes around 'schedule'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f2481c10e589dc085cd451e40228e671aafb5e66. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->