### PR TITLE
fix(bash): improve bash last line as result reliability using bash process substitution

### DIFF
--- a/backend/windmill-worker/src/bash_executor.rs
+++ b/backend/windmill-worker/src/bash_executor.rs
@@ -97,7 +97,7 @@ cleanup() {{
     trap '' SIGTERM SIGINT
 
     # Kill the process group of the script (negative PID value)
-    pkill -P $$
+    pkill -P $$ 2>/dev/null || true
     exit
 }}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves bash script output reliability by using process substitution instead of named pipes in `bash_executor.rs`.
> 
>   - **Behavior**:
>     - Replaces named pipe with process substitution in `bash_executor.rs` for capturing the last line of output in bash scripts.
>     - Updates `wrapper.sh` and `wrapper.ps1` to use process substitution for output redirection.
>   - **Error Handling**:
>     - Adds `2>/dev/null || true` to `pkill` command to suppress errors if no process is found.
>   - **Misc**:
>     - Removes creation and deletion of named pipe `bp` in `bash_executor.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 00304e500023a04ff37e0e65356c1da91413e0e1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->