### PR TITLE
fix windows build

### DIFF
--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -2,11 +2,7 @@
 use std::{collections::HashMap, os::unix::fs::PermissionsExt, path::PathBuf, process::Stdio};
 
 #[cfg(windows)]
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-    process::Stdio,
-};
+use std::{collections::HashMap, path::PathBuf, process::Stdio};
 
 use anyhow::anyhow;
 use itertools::Itertools;

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -1650,8 +1650,7 @@ async fn spawn_uv_install(
 
         #[cfg(windows)]
         {
-            let installer_path = if no_uv_install { command_args[0] } else { "uv" };
-            let mut cmd: Command = Command::new(&installer_path);
+            let mut cmd: Command = Command::new("uv");
             cmd.env_clear()
                 .envs(envs)
                 .envs(PROXY_ENVS.clone())


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix Windows build by simplifying imports and setting fixed command path for `uv`.
> 
>   - **Imports**:
>     - Simplified imports in `ansible_executor.rs` for Windows by removing redundant `Path` import.
>   - **Command Initialization**:
>     - Fixed command initialization in `spawn_uv_install()` in `python_executor.rs` by setting `Command::new("uv")` directly for Windows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 699a7825fa8ba9b1f2e72fe881eb411c85998cbc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->