### PR TITLE
fix windows build

### DIFF
--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -1685,7 +1685,7 @@ async fn spawn_uv_install(
                 .args(&command_args[1..])
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());
-            start_child_process(cmd, installer_path).await
+            start_child_process(cmd, "uv").await
         }
     }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix Windows build by changing `start_child_process` command to `"uv"` in `spawn_uv_install()` in `python_executor.rs`.
> 
>   - **Windows Build Fix**:
>     - In `spawn_uv_install()` in `python_executor.rs`, change `start_child_process` command from `installer_path` to `"uv"` for Windows platform.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 668a8723b488d6c75e27142e2964c91da34c53b7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->