### PR TITLE
fix(frontend): missing config for Custom AI

### DIFF
--- a/frontend/src/lib/components/copilot/lib.ts
+++ b/frontend/src/lib/components/copilot/lib.ts
@@ -92,6 +92,7 @@ export const OPENAI_COMPATIBLE_COMPLETION_CONFIG = {
 	groq: DEFAULT_COMPLETION_CONFIG,
 	openrouter: DEFAULT_COMPLETION_CONFIG,
 	deepseek: DEFAULT_COMPLETION_CONFIG,
+	customai: DEFAULT_COMPLETION_CONFIG,
 	googleai: {
 		...DEFAULT_COMPLETION_CONFIG,
 		seed: undefined // not supported by gemini


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add missing `customai` configuration to `OPENAI_COMPATIBLE_COMPLETION_CONFIG` in `lib.ts`.
> 
>   - **Configuration**:
>     - Add `customai` to `OPENAI_COMPATIBLE_COMPLETION_CONFIG` in `lib.ts`, using `DEFAULT_COMPLETION_CONFIG`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 6b040ab3897afb38ebb874ef0f4a659bba4734ff. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->