### PR TITLE
fix(frontend): improve rename workspace id UX

### DIFF
--- a/frontend/src/lib/components/settings/ChangeWorkspaceId.svelte
+++ b/frontend/src/lib/components/settings/ChangeWorkspaceId.svelte
@@ -30,19 +30,27 @@
 		checking = false
 	}
 
+	let loading = false
 	async function renameWorkspace() {
-		open = false
-		await WorkspaceService.changeWorkspaceId({
-			workspace: $workspaceStore!,
-			requestBody: {
-				new_name: newName,
-				new_id: newId
-			}
-		})
+		try {
+			loading = true
+			await WorkspaceService.changeWorkspaceId({
+				workspace: $workspaceStore!,
+				requestBody: {
+					new_name: newName,
+					new_id: newId
+				}
+			})
 
-		sendUserToast(`Renamed workspace to ${newName}. Reloading...`)
-		await new Promise((resolve) => setTimeout(resolve, 1000))
-		window.location.href = '/workspace_settings?tab=general&workspace=' + newId
+			sendUserToast(`Renamed workspace to ${newName}. Reloading...`)
+			await new Promise((resolve) => setTimeout(resolve, 1000))
+			window.location.href = '/workspace_settings?tab=general&workspace=' + newId
+		} catch (err) {
+			sendUserToast(`Error renaming workspace: ${err}`, true)
+		} finally {
+			loading = false
+			open = false
+		}
 	}
 
 	export let open = false
@@ -73,7 +81,8 @@
 <Modal bind:open title="Change workspace ID">
 	<div class="flex flex-col gap-4">
 		<Alert type="warning" title="Warning">
-			You will have to update your webhook calls and your CLI sync configuration.
+			Renaming the workspace may take a few minutes to complete. Once finished, please update your
+			webhook calls and adjust your CLI sync configuration accordingly.
 		</Alert>
 		<p class="text-secondary text-sm"
 			>Current ID <br /> <span class="font-bold">{$workspaceStore ?? ''}</span></p
@@ -95,6 +104,7 @@
 		<Button
 			size="sm"
 			disabled={checking || errorId.length > 0 || !newName || !newId}
+			{loading}
 			on:click={() => {
 				renameWorkspace()
 			}}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves UX for renaming workspace ID by adding loading state, error handling, and updating user guidance in `ChangeWorkspaceId.svelte`.
> 
>   - **Behavior**:
>     - Adds `loading` state to `renameWorkspace()` in `ChangeWorkspaceId.svelte` to indicate ongoing process.
>     - Catches errors in `renameWorkspace()` and displays error toast if renaming fails.
>     - Updates warning message in `Modal` to inform users about potential delay and necessary updates post-renaming.
>   - **UI**:
>     - Binds `loading` state to `Button` in `Modal` to disable it during the renaming process.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for ed0319c2f0343fe0a1b2122d027f6efa7e280ca8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->