### PR TITLE
change workspace id super nit

### DIFF
--- a/frontend/src/lib/components/settings/ChangeWorkspaceId.svelte
+++ b/frontend/src/lib/components/settings/ChangeWorkspaceId.svelte
@@ -41,6 +41,7 @@
 					new_id: newId
 				}
 			})
+			open = false
 
 			sendUserToast(`Renamed workspace to ${newName}. Reloading...`)
 			await new Promise((resolve) => setTimeout(resolve, 1000))
@@ -49,7 +50,6 @@
 			sendUserToast(`Error renaming workspace: ${err}`, true)
 		} finally {
 			loading = false
-			open = false
 		}
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `open = false` before sending success toast in `renameWorkspace()` in `ChangeWorkspaceId.svelte`.
> 
>   - **Behavior**:
>     - In `ChangeWorkspaceId.svelte`, set `open = false` before sending the success toast in `renameWorkspace()`.
>     - Ensures UI element is closed before notifying user of workspace rename.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 1a011a92700770fa9600a8ba608e9a92f47c2b01. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->