### PR TITLE
feat: add support for | None and Optional in python

### DIFF
--- a/backend/parsers/windmill-parser-py/src/lib.rs
+++ b/backend/parsers/windmill-parser-py/src/lib.rs
@@ -96,11 +96,11 @@ pub fn parse_python_signature(
                 .iter()
                 .enumerate()
                 .map(|(i, x)| {
-                    let mut typ = x
+                    let (mut typ, has_default) = x
                         .as_arg()
                         .annotation
                         .as_ref()
-                        .map_or(Typ::Unknown, |e| parse_expr(e));
+                        .map_or((Typ::Unknown, false), |e| parse_expr(e));
 
                     let default = if i >= def_arg_start {
                         params
@@ -138,7 +138,7 @@ pub fn parse_python_signature(
                         otyp: None,
                         name: x.as_arg().arg.to_string(),
                         typ,
-                        has_default: default.is_some(),
+                        has_default: has_default || default.is_some(),
                         default,
                         oidx: None,
                     }
@@ -158,17 +158,27 @@ pub fn parse_python_signature(
     }
 }
 
-fn parse_expr(e: &Box<Expr>) -> Typ {
+fn parse_expr(e: &Box<Expr>) -> (Typ, bool) {
     match e.as_ref() {
-        Expr::Name(ExprName { id, .. }) => parse_typ(id.as_ref()),
+        Expr::Name(ExprName { id, .. }) => (parse_typ(id.as_ref()), false),
         Expr::Attribute(x) => {
             if x.value
                 .as_name_expr()
                 .is_some_and(|x| x.id.as_str() == "wmill")
             {
-                parse_typ(x.attr.as_str())
+                (parse_typ(x.attr.as_str()), false)
             } else {
-                Typ::Unknown
+                (Typ::Unknown, false)
+            }
+        }
+        Expr::BinOp(x) => {
+            if matches!(
+                x.right.as_ref(),
+                Expr::Constant(ExprConstant { value: Constant::None, .. })
+            ) {
+                (parse_expr(&x.left).0, true)
+            } else {
+                (Typ::Unknown, false)
             }
         }
         Expr::Subscript(x) => match x.value.as_ref() {
@@ -193,14 +203,15 @@ fn parse_expr(e: &Box<Expr>) -> Typ {
                         }
                         _ => None,
                     };
-                    Typ::Str(values)
+                    (Typ::Str(values), false)
                 }
-                "List" => Typ::List(Box::new(parse_expr(&x.slice))),
-                _ => Typ::Unknown,
+                "List" => (Typ::List(Box::new(parse_expr(&x.slice).0)), false),
+                "Optional" => (parse_expr(&x.slice).0, true),
+                _ => (Typ::Unknown, false),
             },
-            _ => Typ::Unknown,
+            _ => (Typ::Unknown, false),
         },
-        _ => Typ::Unknown,
+        _ => (Typ::Unknown, false),
     }
 }
 
@@ -668,6 +679,55 @@ def main(a: list, e: List[int], b: list = [1,2,3,4], c = [1,2,3,4], d = ["a", "b
                         has_default: true,
                         oidx: None
                     }
+                ],
+                no_main_func: Some(false),
+                has_preprocessor: Some(false)
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_python_sig_9() -> anyhow::Result<()> {
+        let code = r#"
+from typing import Optional
+def main(a: str, b: Optional[str], c: str | None): return
+"#;
+        println!(
+            "{}",
+            serde_json::to_string(&parse_python_signature(code, None, false)?)?
+        );
+        assert_eq!(
+            parse_python_signature(code, None, false)?,
+            MainArgSignature {
+                star_args: false,
+                star_kwargs: false,
+                args: vec![
+                    Arg {
+                        otyp: None,
+                        name: "a".to_string(),
+                        typ: Typ::Str(None),
+                        default: None,
+                        has_default: false,
+                        oidx: None
+                    },
+                    Arg {
+                        otyp: None,
+                        name: "b".to_string(),
+                        typ: Typ::Str(None),
+                        default: None,
+                        has_default: true,
+                        oidx: None
+                    },
+                    Arg {
+                        otyp: None,
+                        name: "c".to_string(),
+                        typ: Typ::Str(None),
+                        default: None,
+                        has_default: true,
+                        oidx: None
+                    },
                 ],
                 no_main_func: Some(false),
                 has_preprocessor: Some(false)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -70,7 +70,7 @@
 				"windmill-parser-wasm-csharp": "^1.437.1",
 				"windmill-parser-wasm-go": "^1.429.0",
 				"windmill-parser-wasm-php": "^1.429.0",
-				"windmill-parser-wasm-py": "^1.429.0",
+				"windmill-parser-wasm-py": "^1.467.1",
 				"windmill-parser-wasm-regex": "^1.439.0",
 				"windmill-parser-wasm-rust": "^1.429.0",
 				"windmill-parser-wasm-ts": "^1.429.0",
@@ -12594,9 +12594,9 @@
 			"integrity": "sha512-SGJAtNpfdRZftkGboxWsm/yQDnJBJodwPQUbX2cWk/aoNook6ULesZwsYtBC9WN1VH6TIskLiVPohMmu6jtXmw=="
 		},
 		"node_modules/windmill-parser-wasm-py": {
-			"version": "1.429.0",
-			"resolved": "https://registry.npmjs.org/windmill-parser-wasm-py/-/windmill-parser-wasm-py-1.429.0.tgz",
-			"integrity": "sha512-cqc+tblQVHVrc8wNA4esVYD1Dv59XQJ4mHXFFPa8Lx5UjXv7FO/0VQxyQuRyXaP/V6J6DDy0oeN107eFNLxrBg=="
+			"version": "1.467.1",
+			"resolved": "https://registry.npmjs.org/windmill-parser-wasm-py/-/windmill-parser-wasm-py-1.467.1.tgz",
+			"integrity": "sha512-Px/UvNjCCScf5V7B90PirxYe7Mn/zMnhk++cLuvlg08j45GR/mzFOIfC7Xk9e555ppX3gTlCk+auH4aIlG2tVw=="
 		},
 		"node_modules/windmill-parser-wasm-regex": {
 			"version": "1.439.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -145,7 +145,7 @@
 		"windmill-parser-wasm-csharp": "^1.437.1",
 		"windmill-parser-wasm-go": "^1.429.0",
 		"windmill-parser-wasm-php": "^1.429.0",
-		"windmill-parser-wasm-py": "^1.429.0",
+		"windmill-parser-wasm-py": "^1.467.1",
 		"windmill-parser-wasm-regex": "^1.439.0",
 		"windmill-parser-wasm-rust": "^1.429.0",
 		"windmill-parser-wasm-ts": "^1.429.0",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for `| None` and `Optional` in Python signature parsing and update `windmill-parser-wasm-py` version.
> 
>   - **Behavior**:
>     - Add support for `| None` and `Optional` in `parse_expr()` in `lib.rs`.
>     - Update `parse_python_signature()` to handle new type parsing results.
>   - **Tests**:
>     - Add `test_parse_python_sig_9()` in `lib.rs` to test `| None` and `Optional` parsing.
>   - **Dependencies**:
>     - Update `windmill-parser-wasm-py` version in `package.json` to `^1.467.1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 405f658315a1f1b3e88aac59886c249a08d7cff0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->