### PR TITLE
fix(frontend) check password input type

### DIFF
--- a/frontend/src/lib/components/PasswordArgInput.svelte
+++ b/frontend/src/lib/components/PasswordArgInput.svelte
@@ -8,7 +8,7 @@
 	export let disabled: boolean
 
 	let path = ''
-	let password = value && !value.startsWith('$var:') ? value : ''
+	let password = value && typeof value === 'string' && !value.startsWith('$var:') ? value : ''
 
 	let isGenerating = false
 	async function generateValue() {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `password` initialization in `PasswordArgInput.svelte` to ensure `value` is a string and does not start with `$var:`.
> 
>   - **Behavior**:
>     - Fixes `password` initialization in `PasswordArgInput.svelte` to check if `value` is a string before assignment.
>     - Ensures `password` is not set if `value` starts with `$var:` or is not a string.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 2df261d963b0a14181a85977dba356d7d0e3c79e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->