### PR TITLE
fix(frontend): markdown shows single backtick in single line code block

### DIFF
--- a/frontend/src/lib/components/apps/components/display/AppMarkdown.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppMarkdown.svelte
@@ -5,12 +5,14 @@
 	import type { AppViewerContext, ComponentCustomCSS, RichConfigurations } from '../../types'
 	import { initCss } from '../../utils'
 	import RunnableWrapper from '../helpers/RunnableWrapper.svelte'
-	import Markdown from 'svelte-exmarkdown'
+	import { Markdown, type Plugin } from 'svelte-exmarkdown'
+	import { gfmPlugin } from 'svelte-exmarkdown/gfm'
+	import rehypeRaw from 'rehype-raw'
+	import { rehypeGithubAlerts } from 'rehype-github-alerts'
 	import { classNames } from '$lib/utils'
 	import { components } from '../../editor/component'
 	import ResolveConfig from '../helpers/ResolveConfig.svelte'
 	import ResolveStyle from '../helpers/ResolveStyle.svelte'
-	import { gfmPlugin } from 'svelte-exmarkdown/gfm'
 	export let id: string
 	export let componentInput: AppInput | undefined
 	export let initializing: boolean | undefined = undefined
@@ -18,6 +20,11 @@
 	export let render: boolean
 	export let configuration: RichConfigurations
 
+	const plugins: Plugin[] = [
+		gfmPlugin(),
+		{ rehypePlugin: [rehypeRaw] },
+		{ rehypePlugin: [rehypeGithubAlerts] }
+	]
 	const { app, worldStore, mode } = getContext<AppViewerContext>('AppViewerContext')
 
 	const resolvedConfig = initConfig(
@@ -86,7 +93,7 @@
 			{id}
 			bind:initializing
 			bind:result
-			>{#if result}{#key result}<Markdown md={result} plugins={[gfmPlugin()]} />{/key}{/if}
+			>{#if result}{#key result}<Markdown md={result} {plugins} />{/key}{/if}
 		</RunnableWrapper>
 	</div>
 {:else}
@@ -142,5 +149,13 @@
 	}
 	.wm-markdown h4:last-child {
 		margin-bottom: 0;
+	}
+	.wm-markdown code:not([class~="not-prose"]):not(.not-prose *)::before,
+	.wm-markdown code:not([class~="not-prose"]):not(.not-prose *)::after {
+		content: none !important;
+	}
+	.wm-markdown.prose code::before,
+	.wm-markdown.prose code::after {
+		content: none !important;
 	}
 </style>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes single backtick display in single-line code blocks in `AppMarkdown.svelte` by adding plugins and updating CSS.
> 
>   - **Behavior**:
>     - Fixes issue with single backticks showing in single-line code blocks in `AppMarkdown.svelte`.
>     - Uses `rehypeRaw` and `rehypeGithubAlerts` plugins to enhance markdown rendering.
>   - **Plugins**:
>     - Adds `rehypeRaw` and `rehypeGithubAlerts` to the `plugins` array in `AppMarkdown.svelte`.
>   - **Styles**:
>     - Updates CSS in `AppMarkdown.svelte` to remove `::before` and `::after` content for code blocks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for dbd88dcdab17483aa8b1e6d468ec7066dd6406e1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->