### PR TITLE
set rust version for windows build

### DIFF
--- a/.github/workflows/build_windows_worker_.yml
+++ b/.github/workflows/build_windows_worker_.yml
@@ -30,6 +30,11 @@ jobs:
           token: ${{ secrets.WINDMILL_EE_PRIVATE_ACCESS }}
           fetch-depth: 0
 
+      - name: Setup Rust
+        uses: actions/setup-rust@v1
+        with:
+          rust-version: 1.85.0
+
       - name: Substitute EE code
         shell: bash
         run: |

--- a/.github/workflows/build_windows_worker_.yml
+++ b/.github/workflows/build_windows_worker_.yml
@@ -31,9 +31,10 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Rust
-        uses: actions/setup-rust@v1
+        uses: actions-rs/toolchain@v1
         with:
-          rust-version: 1.85.0
+          toolchain: 1.85.0
+          override: true
 
       - name: Substitute EE code
         shell: bash

--- a/.github/workflows/publish_windows_worker.yml
+++ b/.github/workflows/publish_windows_worker.yml
@@ -33,9 +33,10 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Rust
-        uses: actions/setup-rust@v1
+        uses: actions-rs/toolchain@v1
         with:
-          rust-version: 1.85.0
+          toolchain: 1.85.0
+          override: true
 
       - name: Substitute EE code
         shell: bash

--- a/.github/workflows/publish_windows_worker.yml
+++ b/.github/workflows/publish_windows_worker.yml
@@ -32,6 +32,11 @@ jobs:
           token: ${{ secrets.WINDMILL_EE_PRIVATE_ACCESS }}
           fetch-depth: 0
 
+      - name: Setup Rust
+        uses: actions/setup-rust@v1
+        with:
+          rust-version: 1.85.0
+
       - name: Substitute EE code
         shell: bash
         run: |


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set Rust version to 1.85.0 for Windows builds in GitHub Actions workflows.
> 
>   - **Workflows**:
>     - Set Rust version to `1.85.0` in `build_windows_worker_.yml` and `publish_windows_worker.yml` using `actions-rs/toolchain@v1`.
>     - `override: true` ensures the specified Rust version is used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 3305873dc23ca7ca5be59320116d5dbe156ab9e9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->