### PR TITLE
fix: migrations do not refer to public schema anymore

### DIFF
--- a/backend/custom_migrations/grant_all_current_schema.sql
+++ b/backend/custom_migrations/grant_all_current_schema.sql
@@ -1,0 +1,27 @@
+DO
+$$
+DECLARE
+    tbl_name text;
+    policy_exists boolean;
+    current_sch text;
+    tbl_names text[] := ARRAY['account', 'app', 'audit', 'capture', 'completed_job', 'flow', 'folder', 'http_trigger', 'queue', 'raw_app', 'resource', 'schedule', 'script', 'usr_to_group', 'variable'];
+BEGIN
+    -- Get the current schema
+    SELECT current_schema() INTO current_sch;
+
+    FOR tbl_name IN SELECT unnest(tbl_names)
+    LOOP
+        SELECT EXISTS (
+            SELECT 1 
+            FROM pg_policies 
+            WHERE schemaname = current_sch
+              AND tablename = tbl_name
+              AND policyname = 'admin_policy'
+        ) INTO policy_exists;
+
+       	IF NOT policy_exists THEN
+        	EXECUTE format('CREATE POLICY admin_policy ON %I.%I TO windmill_admin USING (true);', current_sch, tbl_name);
+       	END IF;
+    END LOOP;
+END;
+$$;

--- a/backend/migrations/20250205131523_grant_all_in_current_schema.down.sql
+++ b/backend/migrations/20250205131523_grant_all_in_current_schema.down.sql
@@ -1,0 +1,1 @@
+-- Add down migration script here

--- a/backend/migrations/20250205131523_grant_all_in_current_schema.up.sql
+++ b/backend/migrations/20250205131523_grant_all_in_current_schema.up.sql
@@ -1,0 +1,31 @@
+DO
+$do$
+DECLARE
+    current_schema_name TEXT;
+BEGIN
+    -- Get the current schema for the session
+    SELECT current_schema() INTO current_schema_name;
+
+    -- Lock the roles table to prevent race conditions
+    LOCK TABLE pg_catalog.pg_roles;
+
+    -- Grant privileges dynamically to the current schema
+    EXECUTE format('GRANT ALL ON ALL TABLES IN SCHEMA %I TO windmill_user', current_schema_name);
+    EXECUTE format('GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I TO windmill_user', current_schema_name);
+
+    -- Alter default privileges dynamically
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON TABLES TO windmill_user', current_schema_name);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON SEQUENCES TO windmill_user', current_schema_name);
+
+        -- Grant privileges dynamically to the current schema
+    EXECUTE format('GRANT ALL ON ALL TABLES IN SCHEMA %I TO windmill_admin', current_schema_name);
+    EXECUTE format('GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I TO windmill_admin', current_schema_name);
+
+    -- Alter default privileges dynamically
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON TABLES TO windmill_admin', current_schema_name);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON SEQUENCES TO windmill_admin', current_schema_name);
+
+EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'Error granting proper permissions to windmill users: %', SQLERRM;
+END
+$do$;

--- a/backend/migrations/20250205131523_grant_all_in_current_schema.up.sql
+++ b/backend/migrations/20250205131523_grant_all_in_current_schema.up.sql
@@ -9,6 +9,12 @@ BEGIN
     -- Lock the roles table to prevent race conditions
     LOCK TABLE pg_catalog.pg_roles;
 
+
+
+    EXECUTE format('GRANT USAGE ON SCHEMA %I TO windmill_user', current_schema_name);
+    EXECUTE format('GRANT USAGE ON SCHEMA %I TO windmill_admin', current_schema_name);
+
+
     -- Grant privileges dynamically to the current schema
     EXECUTE format('GRANT ALL ON ALL TABLES IN SCHEMA %I TO windmill_user', current_schema_name);
     EXECUTE format('GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I TO windmill_user', current_schema_name);

--- a/backend/windmill-api/src/db.rs
+++ b/backend/windmill-api/src/db.rs
@@ -157,9 +157,6 @@ impl Migrate for CustomMigrator {
 
 
             if let Some(migration_sql) = OVERRIDDEN_MIGRATIONS.get(&migration.version) {
-                if migration.version == 20221207103910 {
-                    tracing::info!("Skipping migration 20221207103910 to avoid using md5");
-                }
                 tracing::info!("Using custom migration for version {}", migration.version);
 
                 self.inner

--- a/backend/windmill-api/src/db.rs
+++ b/backend/windmill-api/src/db.rs
@@ -36,22 +36,21 @@ lazy_static::lazy_static! {
     pub static ref OVERRIDDEN_MIGRATIONS: std::collections::HashMap<i64, String> = vec![(20221207103910, include_str!(
                         "../../custom_migrations/create_workspace_without_md5.sql"
                     ).to_string()),
-                    // /home/rubenfiszel/windmill/backend/migrations/20240216100535_improve_policies.up.sql
                     (20240216100535, include_str!(
                         "../../migrations/20240216100535_improve_policies.up.sql"
                     ).replace("public.", "")),
-                    // /home/rubenfiszel/windmill/backend/migrations/20240403083110_remove_team_id_constraint.up.sql
                     (20240403083110, include_str!(
                         "../../migrations/20240403083110_remove_team_id_constraint.up.sql"
                     ).replace("public.", "")),
-                    // /home/rubenfiszel/windmill/backend/migrations/20240613150524_add_job_perms.up.sql
                     (20240613150524, include_str!(
                         "../../migrations/20240613150524_add_job_perms.up.sql"
                     ).replace("public.", "")),
-                    // /home/rubenfiszel/windmill/backend/migrations/20250102145420_more_captures.down.sql
                     (20250102145420, include_str!(
-                        "../../migrations/20250102145420_more_captures.down.sql"
+                        "../../migrations/20250102145420_more_captures.up.sql"
                     ).replace("public.", "")),
+                    (20241006144414, include_str!(
+                        "../../custom_migrations/grant_all_current_schema.sql"
+                    ).to_string()),
                     ].into_iter().collect();
 }
 
@@ -161,6 +160,7 @@ impl Migrate for CustomMigrator {
                 if migration.version == 20221207103910 {
                     tracing::info!("Skipping migration 20221207103910 to avoid using md5");
                 }
+                tracing::info!("Using custom migration for version {}", migration.version);
 
                 self.inner
                     .execute(&**migration_sql)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add dynamic schema migration scripts and update migration logic to avoid reliance on the public schema.
> 
>   - **Migrations**:
>     - Add `grant_all_current_schema.sql` to dynamically create `admin_policy` for tables in the current schema.
>     - Add `20250205131523_grant_all_in_current_schema.up.sql` to grant usage and privileges to `windmill_user` and `windmill_admin` for the current schema.
>     - Add `20250205131523_grant_all_in_current_schema.down.sql` as a placeholder for down migration.
>   - **Code Changes**:
>     - Update `OVERRIDDEN_MIGRATIONS` in `db.rs` to include new migration scripts and remove `public.` schema references.
>     - Modify `apply()` in `CustomMigrator` to use `OVERRIDDEN_MIGRATIONS` for custom migration logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for d01c1acea0c6acd846a56755c7e9b4186f51d9b8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->