### PR TITLE
fix(frontend): prevent modal from closing when clicking inside popover content

### DIFF
--- a/frontend/src/lib/components/apps/components/layout/AppModal.svelte
+++ b/frontend/src/lib/components/apps/components/layout/AppModal.svelte
@@ -90,6 +90,10 @@
 		// 32px (2rem) of top and bottom margin
 		wrapperHeight - headerHeight - 64
 	)
+
+	async function getMenuElements(): Promise<HTMLElement[]> {
+		return Array.from(document.querySelectorAll('[data-menu]')) as HTMLElement[]
+	}
 </script>
 
 <InitializeComponent {id} />
@@ -176,7 +180,11 @@
 				<div
 					style={css?.popup?.style}
 					class={twMerge('mx-24 mt-8 bg-surface rounded-lg relative', css?.popup?.class)}
-					use:clickOutside={false}
+					use:clickOutside={{
+						capture: false,
+						stopPropagation: false,
+						exclude: getMenuElements
+					}}
 					on:click_outside={(e) => {
 						if ($mode !== 'dnd' && !unclickableOutside) {
 							handleClickAway(e)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevents modal from closing when clicking inside popover content by modifying `clickOutside` directive in `AppModal.svelte`.
> 
>   - **Behavior**:
>     - Prevents modal from closing when clicking inside popover content in `AppModal.svelte`.
>     - Modifies `clickOutside` directive to use `exclude: getMenuElements`.
>   - **Functions**:
>     - Adds `getMenuElements()` to return elements with `data-menu` attribute.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 2c052e3fd57aa5eddf628a2521575775c7774d97. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->