### PR TITLE
fix: python sdk "ModuleNotFoundError: No module named 'typing_extensions'"

### DIFF
--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -8,7 +8,6 @@ import logging
 import os
 import random
 import time
-import sys
 import warnings
 import json
 from json import JSONDecodeError

--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -8,7 +8,10 @@ import logging
 import os
 import random
 import time
-from typing_extensions import Optional
+import sys
+if sys.version_info < (3, 10):
+    # Import if the version is less than 3.10
+    from typing_extensions import Optional
 import warnings
 import json
 from json import JSONDecodeError

--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -9,9 +9,6 @@ import os
 import random
 import time
 import sys
-if sys.version_info < (3, 10):
-    # Import if the version is less than 3.10
-    from typing_extensions import Optional
 import warnings
 import json
 from json import JSONDecodeError


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove unused `Optional` import from `typing_extensions` in `client.py`.
> 
>   - **Imports**:
>     - Remove `Optional` import from `typing_extensions` in `client.py` as it is not used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 484a5d43db21afc084cd0fdc41fc8b2588b02775. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->