### PR TITLE
fix(python): windows worker fails to install 3.10

### DIFF
--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -351,6 +351,8 @@ impl PyVersion {
 
         let mut child_cmd = Command::new(uv_cmd);
 
+        child_cmd.env_clear();
+
         #[cfg(windows)]
         {
             child_cmd
@@ -369,7 +371,6 @@ impl PyVersion {
 
         let output = child_cmd
             // .current_dir(job_dir)
-            .env_clear()
             .env("HOME", HOME_ENV.to_string())
             .env("PATH", PATH_ENV.to_string())
             .args([


### PR DESCRIPTION
```
execution error:\nFind python error: error: Failed to inspect Python interpreter from managed installations at `C:\\tmp\\windmill\\cache\\py_runtime\\cpython-3.10.16-windows-x86_64-none\\python.exe`\n  Caused by: Querying Python at `C:\\tmp\\windmill\\cache\\py_runtime\\cpython-3.10.16-windows-x86_64-none\\python.exe` failed with exit status exit code: 1\n\n[stderr]\nFatal Python error: _Py_HashRandomization_Init: failed to get random numbers to initialize Python\nPython runtime state: preinitialized\n"
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix Python 3.10 installation on Windows by adjusting environment setup in `python_executor.rs`.
> 
>   - **Environment Setup**:
>     - Move `env_clear()` call before setting environment variables in `find_python()` in `python_executor.rs` to ensure a clean environment for command execution.
>     - Remove redundant `env_clear()` call in `install_python()` in `python_executor.rs`.
>   - **Windows Specific**:
>     - Adjust environment setup for Windows in `find_python()` to fix Python installation issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 6c1537a908e4890da081cd4e9cba01d87346277e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->