### PR TITLE
fix(backend): copilot info exists_ai_resource

### DIFF
--- a/backend/windmill-api/src/workspaces.rs
+++ b/backend/windmill-api/src/workspaces.rs
@@ -796,7 +796,7 @@ async fn get_copilot_info(
 
     let (ai_provider, exists_ai_resource) = if let Some(ai_resource) = record.ai_resource {
         let ai_resource = serde_json::from_value::<AIResource>(ai_resource)?;
-        (Some(ai_resource.provider), true)
+        (Some(ai_resource.provider), ai_resource.path.is_some())
     } else {
         (None, false)
     };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `exists_ai_resource` logic in `get_copilot_info()` to check for `ai_resource.path` presence in `workspaces.rs`.
> 
>   - **Behavior**:
>     - Fixes `exists_ai_resource` logic in `get_copilot_info()` in `workspaces.rs` to check if `ai_resource.path` is `Some` instead of always returning `true`.
>   - **Functions**:
>     - Updates `get_copilot_info()` to correctly determine `exists_ai_resource` based on `ai_resource.path` presence.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for fcb0937d1249cdfd00cfbd161a8e4e88b6d081cb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->