### PR TITLE
make app drawer subgrid take full height

### DIFF
--- a/frontend/src/lib/components/apps/components/layout/AppDrawer.svelte
+++ b/frontend/src/lib/components/apps/components/layout/AppDrawer.svelte
@@ -46,6 +46,8 @@
 		open: false
 	})
 
+	let containerHeight: number = 0
+
 	let appDrawer: Drawer
 
 	$componentControl[id] = {
@@ -146,6 +148,7 @@
 				<div
 					class={twMerge('h-full', css?.drawer?.class, 'wm-drawer')}
 					style={css?.drawer?.style}
+					bind:clientHeight={containerHeight}
 					on:pointerdown={(e) => {
 						e?.stopPropagation()
 						if (!$connectingInput.opened) {
@@ -161,6 +164,7 @@
 						<SubGridEditor
 							visible={open && render}
 							{id}
+							{containerHeight}
 							subGridId={`${id}-0`}
 							on:focus={() => {
 								if (!$connectingInput.opened) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensure `SubGridEditor` in `AppDrawer.svelte` takes full height by binding `clientHeight` to `containerHeight`.
> 
>   - **Behavior**:
>     - `AppDrawer.svelte`: Binds `clientHeight` of drawer to `containerHeight` to ensure full height usage.
>     - Passes `containerHeight` to `SubGridEditor` to adjust its layout accordingly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f019b325b16869cac63aa4a4ee1472d8bd289715. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->