### PR TITLE
fix(frontend): s3 file picker prefix filtering

### DIFF
--- a/frontend/src/lib/components/S3FilePicker.svelte
+++ b/frontend/src/lib/components/S3FilePicker.svelte
@@ -334,7 +334,7 @@
 		listMarkers = []
 		fileMetadata = undefined
 		filePreview = undefined
-		if (keepFilter) {
+		if (!keepFilter) {
 			filter = ''
 		}
 		await loadFiles()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes filter reset logic in `clearAndLoadFiles` function in `S3FilePicker.svelte`.
> 
>   - **Behavior**:
>     - Fixes logic in `clearAndLoadFiles` function in `S3FilePicker.svelte` to reset `filter` only when `keepFilter` is `false`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 11e44283847c8eb2bef4058f9957a95364d8d7f0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->