### PR TITLE
fix: error when checking if exist is now hidden when deploy to another workspace

### DIFF
--- a/frontend/src/lib/components/DeployWorkspace.svelte
+++ b/frontend/src/lib/components/DeployWorkspace.svelte
@@ -30,7 +30,6 @@
 		type AdditionalInformation,
 		type Kind
 	} from '$lib/utils_deployable'
-	import { sendUserToast } from '$lib/toast'
 
 	const dispatch = createEventDispatcher()
 
@@ -235,7 +234,6 @@
 				throw new Error(`Unknown kind ${kind}`)
 			}
 		} catch (error) {
-			sendUserToast(error.body ? error.body : error instanceof Error ? error.message : error, true)
 			exists = false
 		}
 		return exists


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove user toast notification for errors in `checkAlreadyExists()` in `DeployWorkspace.svelte`.
> 
>   - **Behavior**:
>     - Removed user toast notification in `checkAlreadyExists()` in `DeployWorkspace.svelte` when an error occurs during existence check.
>     - Errors are now silently handled by setting `exists` to `false`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 44792374caf97af3a66e1f522717b56ca353893a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->