### PR TITLE
fix: use-exists-function-for-folder-and-improve-error-handling

### DIFF
--- a/backend/.sqlx/query-ddf2eccb78a310ed00c7d8b9c3f05d394a7cbcf0038c72a78add5c7b02ef5927.json
+++ b/backend/.sqlx/query-ddf2eccb78a310ed00c7d8b9c3f05d394a7cbcf0038c72a78add5c7b02ef5927.json
@@ -15,7 +15,7 @@
       ]
     },
     "nullable": [
-      true
+      null
     ]
   },
   "hash": "ddf2eccb78a310ed00c7d8b9c3f05d394a7cbcf0038c72a78add5c7b02ef5927"

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10033,6 +10033,23 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Folder"
+  
+  /w/{workspace}/folders/exists/{name}:
+    get:
+      summary: exists folder
+      operationId: existsFolder
+      tags:
+        - folder
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - $ref: "#/components/parameters/Name"
+      responses:
+        "200":
+          description: folder exists
+          content:
+            application/json:
+              schema:
+                type: boolean
 
   /w/{workspace}/folders/getusage/{name}:
     get:


### PR DESCRIPTION
… function folder instead of get folder for folder kind
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `exists_folder` API endpoint and update frontend to use it for folder existence checks, improving error handling.
> 
>   - **Backend**:
>     - Add `exists_folder` route and function in `folders.rs` to check folder existence by name and workspace ID.
>     - Update `openapi.yaml` to include new `/w/{workspace}/folders/exists/{name}` endpoint.
>   - **Frontend**:
>     - Modify `checkAlreadyExists` in `DeployWorkspace.svelte` to use `FolderService.existsFolder` for folder kind.
>     - Improve error handling by removing try-catch block in `checkAlreadyExists` for folder kind.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 4c9d0332e2ed1537ae990c2b01f7c5e3542d006d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->