### PR TITLE
fix: cache for querying scripts correclty handles ScriptMetadata

### DIFF
--- a/backend/windmill-common/src/cache.rs
+++ b/backend/windmill-common/src/cache.rs
@@ -802,6 +802,12 @@ const _: () = {
         }
     }
 
+    impl ScriptMetadata {
+        fn export_metadata(&self, dst: &impl Storage) -> error::Result<()> {
+            Ok(dst.put("info.json", serde_json::to_vec(self)?)?)
+        }
+    }
+
     impl Export for ScriptFull {
         type Untrusted = RawScript;
 
@@ -817,7 +823,7 @@ const _: () = {
 
         fn export(&self, dst: &impl Storage) -> error::Result<()> {
             self.data.export(dst)?;
-            self.meta.export(dst)?;
+            self.meta.export_metadata(dst)?;
             Ok(())
         }
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `export_metadata()` to `ScriptMetadata` and updates `ScriptFull` to use it for exporting metadata.
> 
>   - **Behavior**:
>     - Adds `export_metadata()` method to `ScriptMetadata` to export metadata to `info.json`.
>     - Updates `export()` in `ScriptFull` to use `export_metadata()` for exporting metadata.
>   - **Functions**:
>     - `export_metadata()` in `ScriptMetadata` serializes metadata to JSON and stores it using `Storage`.
>     - `export()` in `ScriptFull` now calls `export_metadata()` instead of `meta.export()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for cbcc6684da1955025c96d8330ab425ae69d04bb3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->