### PR TITLE
MQTT triggers changelog and fix 3 items shown

### DIFF
--- a/frontend/src/lib/components/sidebar/SidebarContent.svelte
+++ b/frontend/src/lib/components/sidebar/SidebarContent.svelte
@@ -275,7 +275,7 @@
 			hasNewChangelogs =
 				recentChangelogs.length > 0 && lastOpened !== new Date().toISOString().split('T')[0]
 		} else {
-			recentChangelogs = changelogs.slice(-3)
+			recentChangelogs = changelogs.slice(0, 3)
 		}
 	})
 

--- a/frontend/src/lib/components/sidebar/changelogs.ts
+++ b/frontend/src/lib/components/sidebar/changelogs.ts
@@ -6,6 +6,11 @@ export type Changelog = {
 
 const changelogs: Changelog[] = [
 	{
+		label: 'MQTT triggers',
+		href: 'https://www.windmill.dev/changelog/mqtt-triggers',
+		date: '2025-03-11'
+	},
+	{
 		label: 'SQS triggers',
 		href: 'https://www.windmill.dev/changelog/sqs-triggers',
 		date: '2025-02-18'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes changelog display logic in `SidebarContent.svelte` and adds 'MQTT triggers' entry to `changelogs.ts`.
> 
>   - **Behavior**:
>     - Fixes logic in `SidebarContent.svelte` to correctly display the first 3 changelogs instead of the last 3 when no `lastOpened` date is present.
>     - Adds a new changelog entry for 'MQTT triggers' in `changelogs.ts` with a date of '2025-03-11'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 7b3eb97e3f85dc3d37b1d8510dff3e74b90ac177. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->