### PR TITLE
Re-added padding affecting subgrid dotted borders

### DIFF
--- a/frontend/src/lib/components/apps/components/layout/AppTabs.svelte
+++ b/frontend/src/lib/components/apps/components/layout/AppTabs.svelte
@@ -164,7 +164,7 @@
 										'border-r  border-primary border-l bg-surface text-primary',
 										css?.selectedTab?.class,
 										'wm-tabs-selectedTab'
-								  )
+									)
 								: ''
 						)}
 						style={selected == res
@@ -192,7 +192,7 @@
 											'bg-surface text-primary ',
 											css?.selectedTab?.class,
 											'wm-tabs-selectedTab'
-									  )
+										)
 									: 'text-secondary'
 							)}
 						>
@@ -200,7 +200,7 @@
 							{res}
 						</button>
 						{#if selected == res}
-							<div class="p-2 border-t">
+							<div class="border-t">
 								<SubGridEditor
 									{id}
 									visible={render && index === selectedIndex}

--- a/frontend/src/lib/components/apps/editor/componentsPanel/ComponentList.svelte
+++ b/frontend/src/lib/components/apps/editor/componentsPanel/ComponentList.svelte
@@ -142,14 +142,9 @@
 
 		const id = insertNewGridItem(
 			$app,
-			appComponentFromType(preset.targetComponent, preset.configuration, undefined, {
-				customCss: {
-					container: {
-						class: '!p-0' as any,
-						style: ''
-					}
-				}
-			}) as (id: string) => AppComponent,
+			appComponentFromType(preset.targetComponent, preset.configuration, undefined) as (
+				id: string
+			) => AppComponent,
 			$focusedGrid,
 			undefined,
 			undefined,


### PR DESCRIPTION
Fix this padding issue
![image](https://github.com/user-attachments/assets/73144e33-b4b6-46fa-a6fd-e97cf6f5f6ee)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove unnecessary padding and custom CSS settings in `AppTabs.svelte` and `ComponentList.svelte` to fix subgrid border issues.
> 
>   - **Behavior**:
>     - Removed padding from `div` in `AppTabs.svelte` affecting subgrid borders.
>     - Removed custom CSS settings for `container` in `ComponentList.svelte`.
>   - **Misc**:
>     - Minor formatting changes in `AppTabs.svelte` for better readability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 63a99c804add4c3b3f4752a54d301a83bfd2a6aa. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->