### PR TITLE
fix: avoid lock contention for native workers on cached connection

### DIFF
--- a/backend/windmill-worker/src/pg_executor.rs
+++ b/backend/windmill-worker/src/pg_executor.rs
@@ -432,10 +432,7 @@ pub async fn do_postgresql(
 
 async fn is_most_used_conn(database_string: &str) -> bool {
     let counter_map = CONNECTION_COUNTER.read().await;
-    let current_count = counter_map
-        .get(&database_string.to_string())
-        .copied()
-        .unwrap_or(0);
+    let current_count = counter_map.get(database_string).copied().unwrap_or(0);
     let max_count = counter_map.values().copied().max().unwrap_or(0);
     current_count >= max_count
 }

--- a/backend/windmill-worker/src/pg_executor.rs
+++ b/backend/windmill-worker/src/pg_executor.rs
@@ -417,7 +417,7 @@ pub async fn do_postgresql(
                             }
 
                             tracing::debug!(
-                                "Keeping cached pg executorconnection alive due to activity"
+                                "Keeping cached pg executor connection alive due to activity"
                             )
                         }
                         let mut mtex = CONNECTION_CACHE.lock().await;

--- a/backend/windmill-worker/src/pg_executor.rs
+++ b/backend/windmill-worker/src/pg_executor.rs
@@ -396,7 +396,9 @@ pub async fn do_postgresql(
                             //we cache connection for 5 minutes at most
                             if last_query + 60 * 1 < now {
                                 // tracing::error!("Closing cache connection due to inactivity");
-                                tracing::info!("Closing cache connection due to inactivity");
+                                tracing::info!(
+                                    "Closing cache pg executor connection due to inactivity"
+                                );
                                 break;
                             }
                             let mtex = CONNECTION_CACHE.lock().await;
@@ -410,7 +412,9 @@ pub async fn do_postgresql(
                                 }
                             }
 
-                            tracing::debug!("Keeping cached connection alive due to activity")
+                            tracing::debug!(
+                                "Keeping cached pg executorconnection alive due to activity"
+                            )
                         }
                         let mut mtex = CONNECTION_CACHE.lock().await;
                         *mtex = None;

--- a/backend/windmill-worker/src/pg_executor.rs
+++ b/backend/windmill-worker/src/pg_executor.rs
@@ -379,7 +379,11 @@ pub async fn do_postgresql(
                     most_used_conn = is_most_used_conn(&database_string).await;
                     if most_used_conn {
                         *mtex = Some((database_string, new_client.0));
+                    } else {
+                        new_client.1.abort();
                     }
+                } else {
+                    handle.abort();
                 }
 
                 LAST_QUERY.store(

--- a/backend/windmill-worker/src/pg_executor.rs
+++ b/backend/windmill-worker/src/pg_executor.rs
@@ -212,10 +212,6 @@ pub async fn do_postgresql(
     );
     let database_string_clone = database_string.clone();
 
-    LAST_QUERY.store(
-        chrono::Utc::now().timestamp().try_into().unwrap_or(0),
-        std::sync::atomic::Ordering::Relaxed,
-    );
     let mtex;
     if !*CLOUD_HOSTED {
         mtex = CONNECTION_CACHE.try_lock().ok();
@@ -231,6 +227,10 @@ pub async fn do_postgresql(
     // tracing::error!("HAS CACHED CON: {}", has_cached_con);
     let (new_client, mtex) = if has_cached_con {
         tracing::info!("Using cached connection");
+        LAST_QUERY.store(
+            chrono::Utc::now().timestamp().try_into().unwrap_or(0),
+            std::sync::atomic::Ordering::Relaxed,
+        );
         (None, mtex)
     } else if sslmode == "require" {
         tracing::info!("Creating new connection");


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimize connection handling in `pg_executor.rs` by reducing lock contention and refining connection caching logic for native workers.
> 
>   - **Connection Handling**:
>     - Replace `Mutex` with `RwLock` for `CONNECTION_COUNTER` in `pg_executor.rs`.
>     - Remove `RUNNING` atomic boolean and related logic.
>     - Use `try_lock` instead of `lock` for `CONNECTION_CACHE` to reduce lock contention.
>     - Introduce `increment_connection_counter()` and `is_most_used_conn()` to manage connection usage.
>   - **Caching Logic**:
>     - Refine connection caching logic to avoid holding locks for too long.
>     - Cache connections only if they are the most used, determined by `is_most_used_conn()`.
>     - Adjust connection inactivity timeout to 1 minute.
>   - **Miscellaneous**:
>     - Add handling for `Type::VOID` in `pg_cell_to_json_value()` to return `JSONValue::Null`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 1ac91110195554217eb169268c61a61cb9badd7d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->