### PR TITLE
Fix(frontend): fix mobile filter display

### DIFF
--- a/frontend/src/lib/components/auditLogs/AuditLogMobileFilters.svelte
+++ b/frontend/src/lib/components/auditLogs/AuditLogMobileFilters.svelte
@@ -8,7 +8,7 @@
 	floatingConfig={{ strategy: 'absolute', placement: 'bottom-end' }}
 	contentClasses="border rounded-lg shadow-lg p-4 flex flex-col w-80 pt-8 bg-surface"
 >
-	<svelte:fragment slot="button">
+	<svelte:fragment slot="trigger">
 		<Button color="dark" size="xs" nonCaptureEvent={true} startIcon={{ icon: Filter }}>
 			Filters
 		</Button>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix slot name from `button` to `trigger` in `AuditLogMobileFilters.svelte` to correct mobile filter display.
> 
>   - **Fix**:
>     - Change slot name from `button` to `trigger` in `AuditLogMobileFilters.svelte` to correct mobile filter display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 2eab9e35ff9d80364bcfe01c9c0d20b17c2ba3dc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->