### PR TITLE
add missing capture move on first time deploy

### DIFF
--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -391,6 +391,14 @@
 						deployment_message: deploymentMsg || undefined
 					}
 				})
+				await CaptureService.moveCapturesAndConfigs({
+					workspace: $workspaceStore!,
+					path: fakeInitialPath,
+					requestBody: {
+						new_path: $pathStore
+					},
+					runnableKind: 'flow'
+				})
 				if ($primaryScheduleStore && $primaryScheduleStore.enabled) {
 					await createSchedule($pathStore)
 				}

--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -471,6 +471,17 @@
 				}
 			})
 
+			if (!initialPath) {
+				await CaptureService.moveCapturesAndConfigs({
+					workspace: $workspaceStore!,
+					path: fakeInitialPath,
+					requestBody: {
+						new_path: script.path
+					},
+					runnableKind: 'script'
+				})
+			}
+
 			const scheduleExists =
 				initialPath != '' &&
 				(await ScheduleService.existsSchedule({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add missing capture move functionality during first-time deployment in `FlowBuilder.svelte` and `ScriptBuilder.svelte`.
> 
>   - **Behavior**:
>     - Adds `CaptureService.moveCapturesAndConfigs` call in `FlowBuilder.svelte` to move captures and configs to `$pathStore` during first deployment.
>     - Adds `CaptureService.moveCapturesAndConfigs` call in `ScriptBuilder.svelte` to move captures and configs to `script.path` if `initialPath` is empty.
>   - **Conditions**:
>     - In `FlowBuilder.svelte`, the move is triggered during the first deployment of a new flow.
>     - In `ScriptBuilder.svelte`, the move is triggered if `initialPath` is empty, indicating a new script deployment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 68f91345d3a318e35066ee5c5630aa93925f8f5c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->