### PR TITLE
fix: correct private hub url in CLI for resource types sync

### DIFF
--- a/cli/hub.ts
+++ b/cli/hub.ts
@@ -25,7 +25,7 @@ export async function pull(opts: GlobalOptions) {
 
   const hubBaseUrl =
     (await wmill.getGlobal({
-      key: "hubBaseUrl",
+      key: "hub_base_url",
     })) ?? "https://hub.windmill.dev";
 
   const headers: Record<string, string> = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes the key for fetching the private hub URL in `pull()` in `cli/hub.ts` to ensure correct URL usage.
> 
>   - **Behavior**:
>     - Corrects the key from `hubBaseUrl` to `hub_base_url` in `pull()` in `cli/hub.ts` to fetch the correct private hub URL.
>     - Ensures the default URL is `https://hub.windmill.dev` if the key is not found.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 9e20c3f73b2b5c0dcba4e988df70bdb75b8bee56. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->