### PR TITLE
fix: add missing privileged hub script for app slack reports

### DIFF
--- a/backend/windmill-queue/src/jobs.rs
+++ b/backend/windmill-queue/src/jobs.rs
@@ -3284,7 +3284,9 @@ pub async fn push<'c, 'd>(
             None,
         ),
         JobPayload::ScriptHub { path } => {
-            if path == "hub/7771/slack" || path == "hub/7836/slack" {
+            if path == "hub/7771/slack" || path == "hub/7836/slack" || path == "hub/9084/slack" {
+                // these scripts send app reports to slack
+                // they use the slack bot token and should therefore be run with permissions to access it
                 permissioned_as = SUPERADMIN_NOTIFICATION_EMAIL.to_string();
                 email = SUPERADMIN_NOTIFICATION_EMAIL;
             }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `hub/9084/slack` path to ensure it runs with superadmin permissions in `push()` in `jobs.rs`.
> 
>   - **Behavior**:
>     - Add path `hub/9084/slack` to conditional check in `push()` in `jobs.rs` to ensure it runs with `SUPERADMIN_NOTIFICATION_EMAIL` permissions.
>     - This path is for scripts that send app reports to Slack using the Slack bot token.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 6ca8c4c1c3083572e98cafbac8846ec8c7c84b5f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->