### PR TITLE
smarter private hub resource type sync

### DIFF
--- a/cli/hub.ts
+++ b/cli/hub.ts
@@ -7,6 +7,8 @@ import { pushResourceType } from "./resource-type.ts";
 import { GlobalOptions } from "./types.ts";
 import { deepEqual } from "./utils.ts";
 
+const DEFAULT_HUB_BASE_URL = "https://hub.windmill.dev";
+
 export async function pull(opts: GlobalOptions) {
   const workspace = await resolveWorkspace(opts);
 
@@ -26,7 +28,7 @@ export async function pull(opts: GlobalOptions) {
   const hubBaseUrl =
     (await wmill.getGlobal({
       key: "hub_base_url",
-    })) ?? "https://hub.windmill.dev";
+    })) ?? DEFAULT_HUB_BASE_URL;
 
   const headers: Record<string, string> = {
     Accept: "application/json",
@@ -37,7 +39,17 @@ export async function pull(opts: GlobalOptions) {
     headers["X-uid"] = uid;
   }
 
-  const list: {
+  let preList = await fetch(hubBaseUrl + "/resource_types/list", {
+    headers,
+  }).then((r) => r.json() as Promise<{ id: number; name: string }[]>);
+
+  if (preList && preList.length === 0 && hubBaseUrl !== DEFAULT_HUB_BASE_URL) {
+    preList = await fetch(DEFAULT_HUB_BASE_URL + "/resource_types/list", {
+      headers,
+    }).then((r) => r.json() as Promise<{ id: number; name: string }[]>);
+  }
+
+  let list: {
     id: number;
     name: string;
     schema: string;
@@ -47,20 +59,15 @@ export async function pull(opts: GlobalOptions) {
     created_by: string;
     created_at: Date;
     comments: never[];
-  }[] = await fetch(hubBaseUrl + "/resource_types/list", {
-    headers,
-  })
-    .then((r) => r.json() as Promise<{ id: number; name: string }[]>)
-    .then((list: { id: number; name: string }[]) =>
-      list.map((x) =>
-        fetch(hubBaseUrl + "/resource_types/" + x.id + "/" + x.name, {
-          headers: {
-            Accept: "application/json",
-          },
-        })
-      )
+  }[] = await Promise.all(
+    preList.map((x) =>
+      fetch(hubBaseUrl + "/resource_types/" + x.id + "/" + x.name, {
+        headers: {
+          Accept: "application/json",
+        },
+      })
     )
-    .then((x) => Promise.all(x))
+  )
     .then((x) =>
       x.map((x) =>
         x.json().catch((e) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhances `pull()` in `cli/hub.ts` to use a fallback URL for resource type synchronization, improving robustness against empty responses from custom hub URLs.
> 
>   - **Behavior**:
>     - Introduces `DEFAULT_HUB_BASE_URL` in `cli/hub.ts` for fallback URL.
>     - Modifies `pull()` to fetch resource types from `DEFAULT_HUB_BASE_URL` if custom `hubBaseUrl` returns an empty list.
>     - Ensures resource type sync only proceeds if schemas differ or are new.
>   - **Error Handling**:
>     - Logs errors when JSON parsing fails for resource type schemas.
>     - Logs info when skipping resource types that are unchanged.
>   - **Misc**:
>     - Refactors `pull()` to use `preList` for initial resource type fetch and `list` for detailed fetch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 1abacb7229698ff83cf8c9125037a4d0f20a6d90. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->