### PR TITLE
allow running docker container as any non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -221,9 +221,10 @@ RUN cp -r /root/.cache /home/windmill/.cache
 RUN mkdir -p /tmp/windmill/logs && \
     mkdir -p /tmp/windmill/search
 
-RUN chown -R windmill:windmill ${APP} && \
-     chown -R windmill:windmill /tmp/windmill && \
-     chown -R windmill:windmill /home/windmill/.cache
+# Make directories world-readable and writable
+RUN chmod -R 777 ${APP} && \
+     chmod -R 777 /tmp/windmill && \
+     chmod -R 777 /home/windmill/.cache
 
 USER root
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `Dockerfile` to allow running the container as any non-root user by changing directory permissions to be world-readable and writable.
> 
>   - **Security**:
>     - Changes directory permissions in `Dockerfile` to be world-readable and writable using `chmod -R 777` for `${APP}`, `/tmp/windmill`, and `/home/windmill/.cache`.
>     - Allows running the Docker container as any non-root user by making necessary directories accessible.
>   - **Misc**:
>     - Removes `chown` commands for `windmill` user, replaced by `chmod` for broader access.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 51f58b2aa41c0456897515b7a186faeee6c743eb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->