### PR TITLE
fix: use uuid instead of crypto for unique ids in AI chat

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -62,6 +62,7 @@
 				"svelte-infinite-loading": "^1.4.0",
 				"svelte-tiny-virtual-list": "^2.0.5",
 				"tailwind-merge": "^1.13.2",
+				"uuid": "^11.1.0",
 				"vscode": "npm:@codingame/monaco-vscode-api@~11.1.2",
 				"vscode-languageclient": "~9.0.1",
 				"vscode-uri": "~3.0.8",
@@ -12221,6 +12222,19 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"devOptional": true
+		},
+		"node_modules/uuid": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
+			}
 		},
 		"node_modules/validate-npm-package-license": {
 			"version": "3.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -138,6 +138,7 @@
 		"svelte-infinite-loading": "^1.4.0",
 		"svelte-tiny-virtual-list": "^2.0.5",
 		"tailwind-merge": "^1.13.2",
+		"uuid": "^11.1.0",
 		"vscode": "npm:@codingame/monaco-vscode-api@~11.1.2",
 		"vscode-languageclient": "~9.0.1",
 		"vscode-uri": "~3.0.8",

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -612,12 +612,8 @@
 	}
 
 	function addChatHandler(editor: meditor.IStandaloneCodeEditor) {
-		try {
-			aiChatEditorHandler = new AIChatEditorHandler(editor)
-			reviewingChanges = aiChatEditorHandler.reviewingChanges
-		} catch (err) {
-			console.error('Could not add chat handler', err)
-		}
+		aiChatEditorHandler = new AIChatEditorHandler(editor)
+		reviewingChanges = aiChatEditorHandler.reviewingChanges
 	}
 
 	$: $reviewingChanges && autocompletor?.reject()
@@ -625,62 +621,58 @@
 	let completorDisposable: Disposable | undefined = undefined
 	let autocompletor: Autocompletor | undefined = undefined
 	function addSuperCompletor(editor: meditor.IStandaloneCodeEditor) {
-		try {
-			if (completorDisposable) {
-				completorDisposable.dispose()
-			}
-			autocompletor = new Autocompletor(editor, lang)
-
-			// last user events (currently disabled):
-			// let lastTs = Date.now()
-			// editor.onDidChangeModelContent((e) => {
-			// 	const thisTs = Date.now()
-			// 	lastTs = thisTs
-			// 	setTimeout(() => {
-			// 		if (thisTs === lastTs) {
-			// 			autocompletor?.savePatch()
-			// 		}
-			// 	}, 150)
-			// })
-
-			completorDisposable = editor.onDidChangeCursorPosition((e) => {
-				autocompletor?.reject()
-				if ($reviewingChanges) {
-					return
-				}
-				const position = editor.getPosition()
-				if (!position) {
-					return
-				}
-				const upToText = editor.getModel()?.getValueInRange({
-					startLineNumber: position.lineNumber,
-					startColumn: 0,
-					endLineNumber: position.lineNumber,
-					endColumn: position.column
-				})
-				const lastChar = upToText ? upToText[upToText.length - 1] : ''
-				if (lastChar && lastChar.match(/[\(\{\s:="',]/)) {
-					autocompletor?.predict()
-				}
-			})
-
-			editor.addCommand(KeyCode.Tab, () => {
-				if (autocompletor?.hasChanges()) {
-					autocompletor?.accept()
-					autocompletor?.predict()
-				} else {
-					editor.trigger('keyboard', 'tab', {})
-				}
-			})
-
-			editor.onKeyDown((e) => {
-				if (e.keyCode === KeyCode.Escape) {
-					autocompletor?.reject()
-				}
-			})
-		} catch (err) {
-			console.error('Could not add supercompletor', err)
+		if (completorDisposable) {
+			completorDisposable.dispose()
 		}
+		autocompletor = new Autocompletor(editor, lang)
+
+		// last user events (currently disabled):
+		// let lastTs = Date.now()
+		// editor.onDidChangeModelContent((e) => {
+		// 	const thisTs = Date.now()
+		// 	lastTs = thisTs
+		// 	setTimeout(() => {
+		// 		if (thisTs === lastTs) {
+		// 			autocompletor?.savePatch()
+		// 		}
+		// 	}, 150)
+		// })
+
+		completorDisposable = editor.onDidChangeCursorPosition((e) => {
+			autocompletor?.reject()
+			if ($reviewingChanges) {
+				return
+			}
+			const position = editor.getPosition()
+			if (!position) {
+				return
+			}
+			const upToText = editor.getModel()?.getValueInRange({
+				startLineNumber: position.lineNumber,
+				startColumn: 0,
+				endLineNumber: position.lineNumber,
+				endColumn: position.column
+			})
+			const lastChar = upToText ? upToText[upToText.length - 1] : ''
+			if (lastChar && lastChar.match(/[\(\{\s:="',]/)) {
+				autocompletor?.predict()
+			}
+		})
+
+		editor.addCommand(KeyCode.Tab, () => {
+			if (autocompletor?.hasChanges()) {
+				autocompletor?.accept()
+				autocompletor?.predict()
+			} else {
+				editor.trigger('keyboard', 'tab', {})
+			}
+		})
+
+		editor.onKeyDown((e) => {
+			if (e.keyCode === KeyCode.Escape) {
+				autocompletor?.reject()
+			}
+		})
 	}
 
 	$: $copilotInfo.enabled &&

--- a/frontend/src/lib/components/copilot/shared.ts
+++ b/frontend/src/lib/components/copilot/shared.ts
@@ -1,4 +1,5 @@
 import { type editor as meditor } from 'monaco-editor'
+import { v4 as uuidv4 } from 'uuid'
 
 export type VisualChange =
 	| {
@@ -71,7 +72,7 @@ export function setGlobalCSS(id: string, cssCode: string) {
 }
 
 function addInlineGhostText(change: Extract<VisualChange, { type: 'added_inline' }>) {
-	const cssId = crypto.randomUUID()
+	const cssId = uuidv4()
 	const decoration = {
 		range: {
 			startLineNumber: change.position.line,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `crypto.randomUUID()` with `uuidv4()` from `uuid` package for unique ID generation in AI chat components and update dependencies.
> 
>   - **Behavior**:
>     - Replace `crypto.randomUUID()` with `uuidv4()` from `uuid` package in `AIChat.svelte`, `Editor.svelte`, and `shared.ts` for generating unique IDs.
>     - Remove try-catch blocks around `AIChatEditorHandler` initialization in `Editor.svelte` and schema update in `AIChat.svelte`.
>   - **Dependencies**:
>     - Add `uuid` package to `package.json` dependencies.
>   - **Misc**:
>     - Remove console logs related to chat database initialization in `AIChat.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 58bf03661387f7321f114ba4a6c029dfe3366415. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->