### PR TITLE
fix: tab for intellisense

### DIFF
--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -664,18 +664,14 @@
 				}
 			})
 
-			editor.addCommand(KeyCode.Tab, () => {
-				if (autocompletor?.hasChanges()) {
-					autocompletor?.accept()
-					autocompletor?.predict()
-				} else {
-					editor.trigger('keyboard', 'tab', {})
-				}
-			})
-
 			editor.onKeyDown((e) => {
 				if (e.keyCode === KeyCode.Escape) {
 					autocompletor?.reject()
+				} else if (e.keyCode === KeyCode.Tab && autocompletor?.hasChanges()) {
+					e.preventDefault()
+					e.stopPropagation()
+					autocompletor?.accept()
+					autocompletor?.predict()
 				}
 			})
 		} catch (err) {
@@ -692,7 +688,7 @@
 
 	$: $copilotInfo.enabled && initialized && editor && addChatHandler(editor)
 
-	$: !$codeCompletionSessionEnabled && completorDisposable && completorDisposable.dispose()
+	$: !$codeCompletionSessionEnabled && (completorDisposable?.dispose(), autocompletor?.reject())
 
 	const outputChannel = {
 		name: 'Language Server Client',


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modifies Tab key behavior in `Editor.svelte` to enhance IntelliSense by handling it in `onKeyDown` event and removing previous command setup.
> 
>   - **Behavior**:
>     - Removes `addCommand` for `KeyCode.Tab` in `Editor.svelte`.
>     - Adds `onKeyDown` event handling for `KeyCode.Tab` to accept and predict changes if `autocompletor` has changes.
>     - Prevents default Tab behavior when `autocompletor` has changes.
>   - **Misc**:
>     - Updates `$codeCompletionSessionEnabled` logic to dispose `completorDisposable` and reject `autocompletor` in `Editor.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 30f64821271c304d8881b9c4bccb4a572997f191. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->