### PR TITLE
nit: update sqlx for java

### DIFF
--- a/backend/.sqlx/query-03ae5b1c912b13a8a7aadf50cb4984a2ea952e782fd52eb3088454690bd13dd1.json
+++ b/backend/.sqlx/query-03ae5b1c912b13a8a7aadf50cb4984a2ea952e782fd52eb3088454690bd13dd1.json
@@ -40,7 +40,8 @@
                 "ansible",
                 "csharp",
                 "oracledb",
-                "nu"
+                "nu",
+                "java"
               ]
             }
           }

--- a/backend/.sqlx/query-29624682d687790dd199c4af759132d79fdb2982de111cb5fd43e3d9ecd0f15e.json
+++ b/backend/.sqlx/query-29624682d687790dd199c4af759132d79fdb2982de111cb5fd43e3d9ecd0f15e.json
@@ -69,7 +69,8 @@
                 "ansible",
                 "csharp",
                 "oracledb",
-                "nu"
+                "nu",
+                "java"
               ]
             }
           }

--- a/backend/.sqlx/query-488dd591096b2b47787afdc3a1d73917ed13269f2ee20b86df79fca2c8efe672.json
+++ b/backend/.sqlx/query-488dd591096b2b47787afdc3a1d73917ed13269f2ee20b86df79fca2c8efe672.json
@@ -69,7 +69,8 @@
                 "ansible",
                 "csharp",
                 "oracledb",
-                "nu"
+                "nu",
+                "java"
               ]
             }
           }

--- a/backend/.sqlx/query-4aaab98ebdaa90f1edf49ac96fba6c391c4d0054a618b861464ee37239f1f1e0.json
+++ b/backend/.sqlx/query-4aaab98ebdaa90f1edf49ac96fba6c391c4d0054a618b861464ee37239f1f1e0.json
@@ -136,7 +136,8 @@
                 "ansible",
                 "csharp",
                 "oracledb",
-                "nu"
+                "nu",
+                "java"
               ]
             }
           }

--- a/backend/.sqlx/query-61c29d684e8e683e839a6d7210b3b9b96854e5bfd752e45922c358c42ebea0c4.json
+++ b/backend/.sqlx/query-61c29d684e8e683e839a6d7210b3b9b96854e5bfd752e45922c358c42ebea0c4.json
@@ -60,7 +60,8 @@
                 "ansible",
                 "csharp",
                 "oracledb",
-                "nu"
+                "nu",
+                "java"
               ]
             }
           }

--- a/backend/.sqlx/query-75451b6d48e4c26812ae64981d0d968b8fb0bf4374a2fccc167fa879bad7078f.json
+++ b/backend/.sqlx/query-75451b6d48e4c26812ae64981d0d968b8fb0bf4374a2fccc167fa879bad7078f.json
@@ -60,7 +60,8 @@
                 "ansible",
                 "csharp",
                 "oracledb",
-                "nu"
+                "nu",
+                "java"
               ]
             }
           }

--- a/backend/.sqlx/query-804fc11e35f4afc0db194b6fe2594f91df7e588d4d2431bc85f4d8734920c8bf.json
+++ b/backend/.sqlx/query-804fc11e35f4afc0db194b6fe2594f91df7e588d4d2431bc85f4d8734920c8bf.json
@@ -33,7 +33,8 @@
                 "ansible",
                 "csharp",
                 "oracledb",
-                "nu"
+                "nu",
+                "java"
               ]
             }
           }

--- a/backend/.sqlx/query-89de3ff8ab32e545efcbcda05f994cb1a32c4991cbd25046282d34272587d2de.json
+++ b/backend/.sqlx/query-89de3ff8ab32e545efcbcda05f994cb1a32c4991cbd25046282d34272587d2de.json
@@ -60,7 +60,8 @@
                 "ansible",
                 "csharp",
                 "oracledb",
-                "nu"
+                "nu",
+                "java"
               ]
             }
           }

--- a/backend/.sqlx/query-ab04cda71f8e2be9acbecabe1ee5ef756b8e5c1955fbe111df9ee171dc262338.json
+++ b/backend/.sqlx/query-ab04cda71f8e2be9acbecabe1ee5ef756b8e5c1955fbe111df9ee171dc262338.json
@@ -64,7 +64,8 @@
                 "ansible",
                 "csharp",
                 "oracledb",
-                "nu"
+                "nu",
+                "java"
               ]
             }
           }

--- a/backend/.sqlx/query-d15f02f090b8d1a7e816fe11b2e0867540ab6bb02ac6bf82decc220dce0ab048.json
+++ b/backend/.sqlx/query-d15f02f090b8d1a7e816fe11b2e0867540ab6bb02ac6bf82decc220dce0ab048.json
@@ -41,7 +41,8 @@
                 "ansible",
                 "csharp",
                 "oracledb",
-                "nu"
+                "nu",
+                "java"
               ]
             }
           }

--- a/backend/.sqlx/query-ec7836df5f9056ec70015800b7f4feaeb1b671120f5f8c98fca8c89c6587fc35.json
+++ b/backend/.sqlx/query-ec7836df5f9056ec70015800b7f4feaeb1b671120f5f8c98fca8c89c6587fc35.json
@@ -55,7 +55,8 @@
                 "ansible",
                 "csharp",
                 "oracledb",
-                "nu"
+                "nu",
+                "java"
               ]
             }
           }

--- a/backend/.sqlx/query-ff0403790674cdb07022af71c2377afbd8b3a660b3be27514b517c077c63c238.json
+++ b/backend/.sqlx/query-ff0403790674cdb07022af71c2377afbd8b3a660b3be27514b517c077c63c238.json
@@ -64,7 +64,8 @@
                 "ansible",
                 "csharp",
                 "oracledb",
-                "nu"
+                "nu",
+                "java"
               ]
             }
           }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add 'java' to the 'script_lang' enum in multiple SQLX query JSON files to support Java as a script language.
> 
>   - **Behavior**:
>     - Add `java` to `script_lang` enum in `query-03ae5b1c912b13a8a7aadf50cb4984a2ea952e782fd52eb3088454690bd13dd1.json`, `query-29624682d687790dd199c4af759132d79fdb2982de111cb5fd43e3d9ecd0f15e.json`, and `query-488dd591096b2b47787afdc3a1d73917ed13269f2ee20b86df79fca2c8efe672.json`.
>     - Similar updates in 8 other query JSON files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 3d9546705a41c50825c8cbd488eca097e579339e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->