### PR TITLE
fix(frontend): prevent deploy popover to show if deploy dropdown is open

### DIFF
--- a/frontend/src/lib/components/DeployButton.svelte
+++ b/frontend/src/lib/components/DeployButton.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+	import Button from './common/button/Button.svelte'
+	import { Save, CornerDownLeft } from 'lucide-svelte'
+	import { createEventDispatcher } from 'svelte'
+
+	export let loading = false
+	export let loadingSave = false
+	export let newFlow = false
+	export let dropdownItems: Array<{
+		label: string
+		onClick: () => void
+	}> = []
+
+	const dispatch = createEventDispatcher()
+
+	let msgInput: HTMLInputElement | undefined = undefined
+	let hideDropdown = false
+	let deploymentMsg = ''
+</script>
+
+<Button
+	disabled={loading}
+	loading={loadingSave}
+	size="xs"
+	startIcon={{ icon: Save }}
+	on:click={() => dispatch('save')}
+	dropdownItems={!newFlow ? dropdownItems : undefined}
+	tooltipPopover={{
+		placement: 'bottom-end',
+		content: 'Deploy the flow to the cloud',
+		openDelay: 0,
+		closeDelay: 0,
+		portal: 'body'
+	}}
+	on:tooltipOpen={async ({ detail }) => {
+		if (detail) {
+			// Use setTimeout to ensure DOM is updated
+			setTimeout(() => {
+				msgInput?.focus()
+			}, 0)
+			hideDropdown = true
+		} else {
+			hideDropdown = false
+		}
+	}}
+	{hideDropdown}
+>
+	Deploy
+	<svelte:fragment slot="tooltip">
+		<div class="flex flex-row gap-2 w-80 p-4 bg-surface rounded-lg shadow-lg border z-[5001]">
+			<input
+				type="text"
+				placeholder="Deployment message"
+				bind:value={deploymentMsg}
+				on:keydown={async (e) => {
+					if (e.key === 'Enter') {
+						dispatch('save', deploymentMsg)
+					}
+				}}
+				bind:this={msgInput}
+			/>
+			<Button
+				size="xs"
+				on:click={async () => dispatch('save', deploymentMsg)}
+				endIcon={{ icon: CornerDownLeft }}
+				loading={loadingSave}
+			>
+				Deploy
+			</Button>
+		</div>
+	</svelte:fragment>
+</Button>

--- a/frontend/src/lib/components/DeployButton.svelte
+++ b/frontend/src/lib/components/DeployButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Button from './common/button/Button.svelte'
+	import { Button } from '$lib/components/common'
 	import { Save, CornerDownLeft } from 'lucide-svelte'
 	import { createEventDispatcher } from 'svelte'
 
@@ -52,7 +52,7 @@
 		}
 	}}
 	{hideDropdown}
-	bind:dropdownOpen
+	on:dropdownOpen={({ detail }) => (dropdownOpen = detail)}
 >
 	Deploy
 	<svelte:fragment slot="tooltip">

--- a/frontend/src/lib/components/DeployButton.svelte
+++ b/frontend/src/lib/components/DeployButton.svelte
@@ -35,7 +35,6 @@
 	dropdownItems={!newFlow ? dropdownItems : undefined}
 	tooltipPopover={{
 		placement: 'bottom-end',
-		content: 'Deploy the flow to the cloud',
 		openDelay: dropdownOpen ? 200 : 0,
 		closeDelay: 0,
 		portal: 'body'

--- a/frontend/src/lib/components/DeployButton.svelte
+++ b/frontend/src/lib/components/DeployButton.svelte
@@ -3,19 +3,26 @@
 	import { Save, CornerDownLeft } from 'lucide-svelte'
 	import { createEventDispatcher } from 'svelte'
 
-	export let loading = false
-	export let loadingSave = false
-	export let newFlow = false
-	export let dropdownItems: Array<{
-		label: string
-		onClick: () => void
-	}> = []
+	const {
+		loading = false,
+		loadingSave = false,
+		newFlow = false,
+		dropdownItems = []
+	} = $props<{
+		loading?: boolean
+		loadingSave?: boolean
+		newFlow?: boolean
+		dropdownItems?: Array<{
+			label: string
+			onClick: () => void
+		}>
+	}>()
 
 	const dispatch = createEventDispatcher()
 
-	let msgInput: HTMLInputElement | undefined = undefined
-	let hideDropdown = false
-	let deploymentMsg = ''
+	let msgInput: HTMLInputElement | undefined = $state(undefined)
+	let hideDropdown = $state(false)
+	let deploymentMsg = $state('')
 </script>
 
 <Button
@@ -52,7 +59,7 @@
 				type="text"
 				placeholder="Deployment message"
 				bind:value={deploymentMsg}
-				on:keydown={async (e) => {
+				onkeydown={async (e) => {
 					if (e.key === 'Enter') {
 						dispatch('save', deploymentMsg)
 					}

--- a/frontend/src/lib/components/DeployButton.svelte
+++ b/frontend/src/lib/components/DeployButton.svelte
@@ -23,6 +23,7 @@
 	let msgInput: HTMLInputElement | undefined = $state(undefined)
 	let hideDropdown = $state(false)
 	let deploymentMsg = $state('')
+	let dropdownOpen = $state(false)
 </script>
 
 <Button
@@ -35,7 +36,7 @@
 	tooltipPopover={{
 		placement: 'bottom-end',
 		content: 'Deploy the flow to the cloud',
-		openDelay: 0,
+		openDelay: dropdownOpen ? 200 : 0,
 		closeDelay: 0,
 		portal: 'body'
 	}}
@@ -51,6 +52,7 @@
 		}
 	}}
 	{hideDropdown}
+	bind:dropdownOpen
 >
 	Deploy
 	<svelte:fragment slot="tooltip">

--- a/frontend/src/lib/components/DropdownV2.svelte
+++ b/frontend/src/lib/components/DropdownV2.svelte
@@ -16,6 +16,7 @@
 	import ResolveOpen from '$lib/components/common/menu/ResolveOpen.svelte'
 	import Button from '$lib/components/common/button/Button.svelte'
 	import { twMerge } from 'tailwind-merge'
+	import { createEventDispatcher } from 'svelte'
 
 	export let items: Item[] | (() => Item[]) | (() => Promise<Item[]>) = []
 	export let disabled = false
@@ -23,6 +24,8 @@
 	export let usePointerDownOutside = false
 	export let closeOnOtherDropdownOpen = true
 	export let fixedHeight = true
+
+	const dispatch = createEventDispatcher()
 
 	const {
 		elements: { menu, item, trigger },
@@ -33,7 +36,10 @@
 			placement
 		},
 		loop: true,
-		onOpenChange: ({ next }) => {
+		onOpenChange: ({ curr, next }) => {
+			if (curr !== next) {
+				dispatch('openChange', next)
+			}
 			if (closeOnOtherDropdownOpen) {
 				if (next) {
 					// Close previous dropdown if exists

--- a/frontend/src/lib/components/DropdownV2.svelte
+++ b/frontend/src/lib/components/DropdownV2.svelte
@@ -4,28 +4,6 @@
 		id: null,
 		close: null
 	})
-
-	/**
-	 * Creates a debounced function that delays invoking func until after wait milliseconds
-	 * have elapsed since the last time the debounced function was invoked.
-	 */
-	function debounce<T extends (...args: any[]) => any>(
-		func: T,
-		wait: number
-	): (...args: Parameters<T>) => void {
-		let timeoutId: ReturnType<typeof setTimeout> | null = null
-
-		return function (...args: Parameters<T>): void {
-			if (timeoutId !== null) {
-				clearTimeout(timeoutId)
-			}
-
-			timeoutId = setTimeout(() => {
-				func(...args)
-				timeoutId = null
-			}, wait)
-		}
-	}
 </script>
 
 <script lang="ts">
@@ -38,7 +16,7 @@
 	import ResolveOpen from '$lib/components/common/menu/ResolveOpen.svelte'
 	import Button from '$lib/components/common/button/Button.svelte'
 	import { twMerge } from 'tailwind-merge'
-	import { createEventDispatcher, onDestroy } from 'svelte'
+	import { createEventDispatcher } from 'svelte'
 
 	export let items: Item[] | (() => Item[]) | (() => Promise<Item[]>) = []
 	export let disabled = false
@@ -46,8 +24,6 @@
 	export let usePointerDownOutside = false
 	export let closeOnOtherDropdownOpen = true
 	export let fixedHeight = true
-	export let openOnHover = false
-	export let hoverDelay = 200 // Delay for hover effects in milliseconds
 
 	const dispatch = createEventDispatcher()
 
@@ -62,7 +38,6 @@
 		loop: true,
 		onOpenChange: ({ curr, next }) => {
 			if (curr !== next) {
-				openByHover = false
 				dispatch('openChange', next)
 			}
 			if (closeOnOtherDropdownOpen) {
@@ -78,16 +53,10 @@
 				}
 			}
 			return next
-		},
-		forceVisible: true
+		}
 	})
 
 	let open = false
-	let hovering = false
-	let openByHover = false
-	let hoverTimer: ReturnType<typeof setTimeout> | null = null
-	let leaveTimer: ReturnType<typeof setTimeout> | null = null
-
 	const sync = createSync(states)
 	$: sync.open(open, (v) => (open = Boolean(v)))
 
@@ -105,29 +74,6 @@
 	}
 	async function getMenuElements(): Promise<HTMLElement[]> {
 		return Array.from(document.querySelectorAll('[data-menu]')) as HTMLElement[]
-	}
-
-	const setHovering = (value: boolean) => {
-		hovering = value
-	}
-
-	const debouncedHoverStart = debounce(() => setHovering(true), hoverDelay)
-	const debouncedHoverEnd = debounce(() => setHovering(false), hoverDelay)
-
-	// Clear any pending timers on component destruction
-	onDestroy(() => {
-		if (hoverTimer) clearTimeout(hoverTimer)
-		if (leaveTimer) clearTimeout(leaveTimer)
-	})
-
-	$: if (openOnHover && hovering && !open) {
-		open = true
-		openByHover = true
-	} else {
-		if (openByHover && !hovering) {
-			open = false
-			openByHover = false
-		}
 	}
 </script>
 
@@ -149,14 +95,6 @@
 			close()
 		}
 	}}
-	on:mouseenter={() => {
-		if (leaveTimer) clearTimeout(leaveTimer)
-		debouncedHoverStart()
-	}}
-	on:mouseleave={() => {
-		if (hoverTimer) clearTimeout(hoverTimer)
-		debouncedHoverEnd()
-	}}
 	data-menu
 >
 	{#if $$slots.buttonReplacement}
@@ -173,20 +111,7 @@
 </button>
 
 {#if open}
-	<!-- svelte-ignore a11y-no-static-element-interactions -->
-	<div
-		use:melt={$menu}
-		data-menu
-		class="z-[6000]"
-		on:mouseenter={() => {
-			if (leaveTimer) clearTimeout(leaveTimer)
-			debouncedHoverStart()
-		}}
-		on:mouseleave={() => {
-			if (hoverTimer) clearTimeout(hoverTimer)
-			debouncedHoverEnd()
-		}}
-	>
+	<div use:melt={$menu} data-menu class="z-[6000]">
 		<div
 			class="bg-surface border w-56 origin-top-right rounded-md shadow-md focus:outline-none overflow-y-auto py-1 max-h-[50vh]"
 		>

--- a/frontend/src/lib/components/DropdownV2.svelte
+++ b/frontend/src/lib/components/DropdownV2.svelte
@@ -16,7 +16,6 @@
 	import ResolveOpen from '$lib/components/common/menu/ResolveOpen.svelte'
 	import Button from '$lib/components/common/button/Button.svelte'
 	import { twMerge } from 'tailwind-merge'
-	import { createEventDispatcher } from 'svelte'
 
 	export let items: Item[] | (() => Item[]) | (() => Promise<Item[]>) = []
 	export let disabled = false
@@ -24,8 +23,6 @@
 	export let usePointerDownOutside = false
 	export let closeOnOtherDropdownOpen = true
 	export let fixedHeight = true
-
-	const dispatch = createEventDispatcher()
 
 	const {
 		elements: { menu, item, trigger },
@@ -36,10 +33,7 @@
 			placement
 		},
 		loop: true,
-		onOpenChange: ({ curr, next }) => {
-			if (curr !== next) {
-				dispatch('openChange', next)
-			}
+		onOpenChange: ({ next }) => {
 			if (closeOnOtherDropdownOpen) {
 				if (next) {
 					// Close previous dropdown if exists

--- a/frontend/src/lib/components/DropdownV2.svelte
+++ b/frontend/src/lib/components/DropdownV2.svelte
@@ -24,6 +24,7 @@
 	export let closeOnOtherDropdownOpen = true
 	export let fixedHeight = true
 	export let hidePopup = false
+	export let open = false
 
 	const {
 		elements: { menu, item, trigger },
@@ -51,7 +52,6 @@
 		}
 	})
 
-	let open = false
 	const sync = createSync(states)
 	$: sync.open(open, (v) => (open = Boolean(v)))
 

--- a/frontend/src/lib/components/DropdownV2.svelte
+++ b/frontend/src/lib/components/DropdownV2.svelte
@@ -23,6 +23,7 @@
 	export let usePointerDownOutside = false
 	export let closeOnOtherDropdownOpen = true
 	export let fixedHeight = true
+	export let hidePopup = false
 
 	const {
 		elements: { menu, item, trigger },
@@ -104,7 +105,7 @@
 	{/if}
 </button>
 
-{#if open}
+{#if open && !hidePopup}
 	<div use:melt={$menu} data-menu class="z-[6000]">
 		<div
 			class="bg-surface border w-56 origin-top-right rounded-md shadow-md focus:outline-none overflow-y-auto py-1 max-h-[50vh]"

--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -1479,7 +1479,7 @@
 							await handleSaveFlow()
 						}}
 						dropdownItems={!newFlow ? dropdownItems : undefined}
-						tooltip={{
+						tooltipPopover={{
 							placement: 'bottom-end',
 							content: 'Deploy the flow to the cloud',
 							openDelay: 0,

--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -1260,7 +1260,6 @@
 	let msgInput: HTMLInputElement | undefined = undefined
 
 	let flowPreviewButtons: FlowPreviewButtons
-	let isDropdownOpen = false
 </script>
 
 <svelte:window on:keydown={onKeyDown} />
@@ -1469,7 +1468,7 @@
 						Draft
 					</Button>
 
-					<CustomPopover appearTimeout={0} focusEl={msgInput} disablePopup={isDropdownOpen}>
+					<CustomPopover appearTimeout={0} focusEl={msgInput}>
 						<Button
 							disabled={loading}
 							loading={loadingSave}
@@ -1479,7 +1478,6 @@
 								await handleSaveFlow()
 							}}
 							dropdownItems={!newFlow ? dropdownItems : undefined}
-							on:openChange={({ detail }) => (isDropdownOpen = detail)}
 						>
 							Deploy
 						</Button>

--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -1261,6 +1261,9 @@
 
 	let flowPreviewButtons: FlowPreviewButtons
 	let isDropdownOpen = false
+	let tooltipOpen = false
+	$: tooltipOpen && msgInput && msgInput.focus()
+	$: console.log('dbg isDropdownOpen', isDropdownOpen)
 </script>
 
 <svelte:window on:keydown={onKeyDown} />
@@ -1469,22 +1472,29 @@
 						Draft
 					</Button>
 
-					<CustomPopover appearTimeout={0} focusEl={msgInput} disablePopup={isDropdownOpen}>
-						<Button
-							disabled={loading}
-							loading={loadingSave}
-							size="xs"
-							startIcon={{ icon: Save }}
-							on:click={async () => {
-								await handleSaveFlow()
-							}}
-							dropdownItems={!newFlow ? dropdownItems : undefined}
-							on:openChange={({ detail }) => (isDropdownOpen = detail)}
-						>
-							Deploy
-						</Button>
-						<svelte:fragment slot="overlay">
-							<div class="flex flex-row gap-2 w-80">
+					<Button
+						disabled={loading}
+						loading={loadingSave}
+						size="xs"
+						startIcon={{ icon: Save }}
+						on:click={async () => {
+							await handleSaveFlow()
+						}}
+						dropdownItems={!newFlow ? dropdownItems : undefined}
+						on:open={() => {
+							isDropdownOpen = true
+						}}
+						on:close={() => {
+							isDropdownOpen = false
+						}}
+						on:tooltip-open={async ({ detail }) => {
+							tooltipOpen = true
+						}}
+						dropdownOpenOnHover
+					>
+						Deploy
+						<svelte:fragment slot="tooltip">
+							<div class="flex flex-row gap-2 w-80 bg-surface rounded-md p-4 shadow-md">
 								<input
 									type="text"
 									placeholder="Deployment message"
@@ -1506,7 +1516,7 @@
 								</Button>
 							</div>
 						</svelte:fragment>
-					</CustomPopover>
+					</Button>
 				</div>
 			</div>
 

--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -1260,6 +1260,7 @@
 	let msgInput: HTMLInputElement | undefined = undefined
 
 	let flowPreviewButtons: FlowPreviewButtons
+	let isDropdownOpen = false
 </script>
 
 <svelte:window on:keydown={onKeyDown} />
@@ -1468,7 +1469,7 @@
 						Draft
 					</Button>
 
-					<CustomPopover appearTimeout={0} focusEl={msgInput}>
+					<CustomPopover appearTimeout={0} focusEl={msgInput} disablePopup={isDropdownOpen}>
 						<Button
 							disabled={loading}
 							loading={loadingSave}
@@ -1478,6 +1479,7 @@
 								await handleSaveFlow()
 							}}
 							dropdownItems={!newFlow ? dropdownItems : undefined}
+							on:openChange={({ detail }) => (isDropdownOpen = detail)}
 						>
 							Deploy
 						</Button>

--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -1261,9 +1261,6 @@
 
 	let flowPreviewButtons: FlowPreviewButtons
 	let isDropdownOpen = false
-	let tooltipOpen = false
-	$: tooltipOpen && msgInput && msgInput.focus()
-	$: console.log('dbg isDropdownOpen', isDropdownOpen)
 </script>
 
 <svelte:window on:keydown={onKeyDown} />
@@ -1472,29 +1469,22 @@
 						Draft
 					</Button>
 
-					<Button
-						disabled={loading}
-						loading={loadingSave}
-						size="xs"
-						startIcon={{ icon: Save }}
-						on:click={async () => {
-							await handleSaveFlow()
-						}}
-						dropdownItems={!newFlow ? dropdownItems : undefined}
-						on:open={() => {
-							isDropdownOpen = true
-						}}
-						on:close={() => {
-							isDropdownOpen = false
-						}}
-						on:tooltip-open={async ({ detail }) => {
-							tooltipOpen = true
-						}}
-						dropdownOpenOnHover
-					>
-						Deploy
-						<svelte:fragment slot="tooltip">
-							<div class="flex flex-row gap-2 w-80 bg-surface rounded-md p-4 shadow-md">
+					<CustomPopover appearTimeout={0} focusEl={msgInput} disablePopup={isDropdownOpen}>
+						<Button
+							disabled={loading}
+							loading={loadingSave}
+							size="xs"
+							startIcon={{ icon: Save }}
+							on:click={async () => {
+								await handleSaveFlow()
+							}}
+							dropdownItems={!newFlow ? dropdownItems : undefined}
+							on:openChange={({ detail }) => (isDropdownOpen = detail)}
+						>
+							Deploy
+						</Button>
+						<svelte:fragment slot="overlay">
+							<div class="flex flex-row gap-2 w-80">
 								<input
 									type="text"
 									placeholder="Deployment message"
@@ -1516,7 +1506,7 @@
 								</Button>
 							</div>
 						</svelte:fragment>
-					</Button>
+					</CustomPopover>
 				</div>
 			</div>
 

--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -1501,7 +1501,9 @@
 					>
 						Deploy
 						<svelte:fragment slot="tooltip">
-							<div class="flex flex-row gap-2 w-80 p-4 shadow-lg rounded-md">
+							<div
+								class="flex flex-row gap-2 w-80 p-4 bg-surface rounded-lg shadow-lg border z-[5001]"
+							>
 								<input
 									type="text"
 									placeholder="Deployment message"

--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -48,16 +48,7 @@
 	import FlowPreviewButtons from './flows/header/FlowPreviewButtons.svelte'
 	import type { FlowEditorContext, FlowInput, FlowInputEditorState } from './flows/types'
 	import { cleanInputs, emptyFlowModuleState } from './flows/utils'
-	import {
-		Calendar,
-		Pen,
-		Save,
-		DiffIcon,
-		HistoryIcon,
-		FileJson,
-		type Icon,
-		CornerDownLeft
-	} from 'lucide-svelte'
+	import { Calendar, Pen, Save, DiffIcon, HistoryIcon, FileJson, type Icon } from 'lucide-svelte'
 	import { createEventDispatcher } from 'svelte'
 	import Awareness from './Awareness.svelte'
 	import { getAllModules } from './flows/flowExplorer'
@@ -84,6 +75,7 @@
 	import FlowYamlEditor from './flows/header/FlowYamlEditor.svelte'
 	import { type TriggerContext, type ScheduleTrigger } from './triggers'
 	import type { SavedAndModifiedValue } from './common/confirmationModal/unsavedTypes'
+	import DeployButton from './DeployButton.svelte'
 
 	export let initialPath: string = ''
 	export let pathStoreInit: string | undefined = undefined
@@ -1255,12 +1247,7 @@
 		]
 	}
 
-	let deploymentMsg = ''
-	let msgInput: HTMLInputElement | undefined = undefined
-
 	let flowPreviewButtons: FlowPreviewButtons
-
-	let hideDropdown = false
 </script>
 
 <svelte:window on:keydown={onKeyDown} />
@@ -1470,62 +1457,13 @@
 						Draft
 					</Button>
 
-					<Button
-						disabled={loading}
-						loading={loadingSave}
-						size="xs"
-						startIcon={{ icon: Save }}
-						on:click={async () => {
-							await handleSaveFlow()
-						}}
-						dropdownItems={!newFlow ? dropdownItems : undefined}
-						tooltipPopover={{
-							placement: 'bottom-end',
-							content: 'Deploy the flow to the cloud',
-							openDelay: 0,
-							closeDelay: 0,
-							portal: 'body'
-						}}
-						on:tooltipOpen={async ({ detail }) => {
-							if (detail) {
-								// Use setTimeout to ensure DOM is updated
-								setTimeout(() => {
-									msgInput?.focus()
-								}, 0)
-								hideDropdown = true
-							} else {
-								hideDropdown = false
-							}
-						}}
-						{hideDropdown}
-					>
-						Deploy
-						<svelte:fragment slot="tooltip">
-							<div
-								class="flex flex-row gap-2 w-80 p-4 bg-surface rounded-lg shadow-lg border z-[5001]"
-							>
-								<input
-									type="text"
-									placeholder="Deployment message"
-									bind:value={deploymentMsg}
-									on:keydown={async (e) => {
-										if (e.key === 'Enter') {
-											await handleSaveFlow(deploymentMsg)
-										}
-									}}
-									bind:this={msgInput}
-								/>
-								<Button
-									size="xs"
-									on:click={async () => await handleSaveFlow(deploymentMsg)}
-									endIcon={{ icon: CornerDownLeft }}
-									loading={loadingSave}
-								>
-									Deploy
-								</Button>
-							</div>
-						</svelte:fragment>
-					</Button>
+					<DeployButton
+						on:save={async ({ detail }) => await handleSaveFlow(detail)}
+						{loading}
+						{loadingSave}
+						{newFlow}
+						{dropdownItems}
+					/>
 				</div>
 			</div>
 

--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -79,7 +79,6 @@
 	import { ignoredTutorials } from './tutorials/ignoredTutorials'
 	import type DiffDrawer from './DiffDrawer.svelte'
 	import FlowHistory from './flows/FlowHistory.svelte'
-	import CustomPopover from './CustomPopover.svelte'
 	import Summary from './Summary.svelte'
 	import type { FlowBuilderWhitelabelCustomUi } from './custom_ui'
 	import FlowYamlEditor from './flows/header/FlowYamlEditor.svelte'
@@ -1260,6 +1259,8 @@
 	let msgInput: HTMLInputElement | undefined = undefined
 
 	let flowPreviewButtons: FlowPreviewButtons
+
+	let hideDropdown = false
 </script>
 
 <svelte:window on:keydown={onKeyDown} />
@@ -1303,7 +1304,8 @@
 				class="justify-between flex flex-row items-center pl-2.5 pr-6 space-x-4 scrollbar-hidden overflow-x-auto max-h-12 h-full relative"
 			>
 				{#if $copilotCurrentStepStore !== undefined}
-					<div transition:fade class="absolute inset-0 bg-gray-500 bg-opacity-75 z-[900] !m-0"></div>
+					<div transition:fade class="absolute inset-0 bg-gray-500 bg-opacity-75 z-[900] !m-0"
+					></div>
 				{/if}
 				<div class="flex w-full max-w-md gap-4 items-center">
 					<Summary
@@ -1468,21 +1470,38 @@
 						Draft
 					</Button>
 
-					<CustomPopover appearTimeout={0} focusEl={msgInput}>
-						<Button
-							disabled={loading}
-							loading={loadingSave}
-							size="xs"
-							startIcon={{ icon: Save }}
-							on:click={async () => {
-								await handleSaveFlow()
-							}}
-							dropdownItems={!newFlow ? dropdownItems : undefined}
-						>
-							Deploy
-						</Button>
-						<svelte:fragment slot="overlay">
-							<div class="flex flex-row gap-2 w-80">
+					<Button
+						disabled={loading}
+						loading={loadingSave}
+						size="xs"
+						startIcon={{ icon: Save }}
+						on:click={async () => {
+							await handleSaveFlow()
+						}}
+						dropdownItems={!newFlow ? dropdownItems : undefined}
+						tooltip={{
+							placement: 'bottom-end',
+							content: 'Deploy the flow to the cloud',
+							openDelay: 0,
+							closeDelay: 0,
+							portal: 'body'
+						}}
+						on:tooltipOpen={async ({ detail }) => {
+							if (detail) {
+								// Use setTimeout to ensure DOM is updated
+								setTimeout(() => {
+									msgInput?.focus()
+								}, 0)
+								hideDropdown = true
+							} else {
+								hideDropdown = false
+							}
+						}}
+						{hideDropdown}
+					>
+						Deploy
+						<svelte:fragment slot="tooltip">
+							<div class="flex flex-row gap-2 w-80 p-4 shadow-lg rounded-md">
 								<input
 									type="text"
 									placeholder="Deployment message"
@@ -1504,7 +1523,7 @@
 								</Button>
 							</div>
 						</svelte:fragment>
-					</CustomPopover>
+					</Button>
 				</div>
 			</div>
 

--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -39,7 +39,6 @@
 		Calendar,
 		CheckCircle,
 		Code,
-		CornerDownLeft,
 		Pen,
 		Plus,
 		Rocket,
@@ -65,7 +64,6 @@
 	import { defaultScriptLanguages, processLangs } from '$lib/scripts'
 	import DefaultScripts from './DefaultScripts.svelte'
 	import { createEventDispatcher, onMount, setContext } from 'svelte'
-	import CustomPopover from './CustomPopover.svelte'
 	import Summary from './Summary.svelte'
 	import type { ScriptBuilderWhitelabelCustomUi } from './custom_ui'
 	import DeployOverrideConfirmationModal from '$lib/components/common/confirmationModal/DeployOverrideConfirmationModal.svelte'
@@ -80,6 +78,8 @@
 	import CaptureTable from './triggers/CaptureTable.svelte'
 	import type { SavedAndModifiedValue } from './common/confirmationModal/unsavedTypes'
 	import type { ScriptBuilderFunctionExports } from './scriptBuilder'
+	import DeployButton from './DeployButton.svelte'
+
 	export let script: NewScript
 	export let fullyLoaded: boolean = true
 	export let initialPath: string = ''
@@ -756,9 +756,6 @@
 	})()
 
 	setContext('disableTooltips', customUi?.disableTooltips === true)
-
-	let deploymentMsg = ''
-	let msgInput: HTMLInputElement | undefined = undefined
 
 	function langToLanguage(lang: SupportedLanguage | 'docker' | 'bunnative'): SupportedLanguage {
 		if (lang == 'docker') {
@@ -1575,41 +1572,13 @@
 						<span class="hidden lg:flex"> Draft </span>
 					</Button>
 
-					<CustomPopover appearTimeout={0} focusEl={msgInput}>
-						<Button
-							loading={loadingSave}
-							size="xs"
-							disabled={!fullyLoaded}
-							startIcon={{ icon: Save }}
-							on:click={() => handleEditScript(false)}
-							dropdownItems={computeDropdownItems(initialPath, savedScript, diffDrawer)}
-						>
-							Deploy
-						</Button>
-						<svelte:fragment slot="overlay">
-							<div class="flex flex-row gap-2 min-w-72">
-								<input
-									type="text"
-									placeholder="Deployment message"
-									bind:value={deploymentMsg}
-									bind:this={msgInput}
-									on:keydown={(e) => {
-										if (e.key === 'Enter') {
-											handleEditScript(false, deploymentMsg)
-										}
-									}}
-								/>
-								<Button
-									size="xs"
-									on:click={() => handleEditScript(false, deploymentMsg)}
-									endIcon={{ icon: CornerDownLeft }}
-									loading={loadingSave}
-								>
-									Deploy
-								</Button>
-							</div>
-						</svelte:fragment>
-					</CustomPopover>
+					<DeployButton
+						loading={!fullyLoaded}
+						{loadingSave}
+						newFlow={false}
+						dropdownItems={computeDropdownItems(initialPath, savedScript, diffDrawer)}
+						on:save={({ detail }) => handleEditScript(false, detail)}
+					/>
 				</div>
 			</div>
 		</div>

--- a/frontend/src/lib/components/common/button/Button.svelte
+++ b/frontend/src/lib/components/common/button/Button.svelte
@@ -5,6 +5,7 @@
 	import Dropdown from '$lib/components/DropdownV2.svelte'
 	import { getModifierKey, type Item } from '$lib/utils'
 	import { Loader2, ChevronDown } from 'lucide-svelte'
+	import { createTooltip, melt } from '@melt-ui/svelte'
 
 	export let size: ButtonType.Size = 'md'
 	export let spacingSize: ButtonType.Size = size
@@ -34,6 +35,8 @@
 	export let shortCut:
 		| { key?: string; hide?: boolean; Icon?: any; withoutModifier?: boolean }
 		| undefined = undefined
+	export let dropdownOpen: boolean = false
+	export let dropdownOpenOnHover: boolean = false
 
 	type MenuItem = {
 		label: string
@@ -117,6 +120,24 @@
 	}
 
 	$: lucideIconSize = (iconMap[size] ?? 12) * 1
+
+	const {
+		elements: { trigger, content }
+	} = createTooltip({
+		positioning: {
+			placement: 'bottom-end'
+		},
+		openDelay: 0,
+		closeDelay: 0,
+		group: true,
+		portal: 'body',
+		onOpenChange: ({ curr, next }) => {
+			if (curr != next) {
+				dispatch('tooltip-open', next)
+			}
+			return next
+		}
+	})
 </script>
 
 <div
@@ -200,6 +221,7 @@
 			{...$$restProps}
 			disabled={disabled || (loading && !clickableWhileLoading)}
 			{style}
+			use:melt={$trigger}
 		>
 			{#if loading}
 				<Loader2 class={twMerge('animate-spin', iconOnlyPadding[size])} size={lucideIconSize} />
@@ -232,8 +254,20 @@
 		</button>
 	{/if}
 
+	<div use:melt={$content} class="z-[20000]">
+		<slot name="tooltip" />
+	</div>
+
 	{#if dropdownItems && dropdownItems.length > 0}
-		<Dropdown items={computeDropdowns(dropdownItems)} class="h-auto w-fit" on:openChange>
+		<Dropdown
+			items={computeDropdowns(dropdownItems)}
+			class="h-auto w-fit"
+			on:openChange
+			on:open
+			on:close
+			bind:open={dropdownOpen}
+			openOnHover={dropdownOpenOnHover}
+		>
 			<svelte:fragment slot="buttonReplacement">
 				<div
 					class={twMerge(

--- a/frontend/src/lib/components/common/button/Button.svelte
+++ b/frontend/src/lib/components/common/button/Button.svelte
@@ -56,6 +56,7 @@
 	}
 	export let dropdownItems: MenuItem[] | (() => MenuItem[]) | undefined = undefined
 	export let hideDropdown: boolean = false
+	export let dropdownOpen: boolean = false
 
 	function computeDropdowns(menuItems: MenuItem[] | (() => MenuItem[])): Item[] {
 		const items = typeof menuItems === 'function' ? menuItems() : menuItems
@@ -133,21 +134,24 @@
 
 	const {
 		elements: { trigger, content },
-		states: { open }
+		states: { open },
+		options: { openDelay }
 	} = tooltipPopover
 		? createTooltip({
 				positioning: {
 					placement: tooltipPopover?.placement
 				},
-				openDelay: tooltipPopover?.openDelay,
 				closeDelay: tooltipPopover?.closeDelay,
 				group: true,
 				portal: tooltipPopover?.portal
 			})
 		: {
 				elements: { trigger: undefined, content: undefined },
-				states: { open: undefined }
+				states: { open: undefined },
+				options: { openDelay: undefined }
 			}
+	$: tooltipPopover && ($openDelay = tooltipPopover?.openDelay) //This option is reactive
+
 	$: $open !== undefined && dispatch('tooltipOpen', $open)
 </script>
 
@@ -272,7 +276,13 @@
 	{/if}
 
 	{#if dropdownItems && dropdownItems.length > 0}
-		<Dropdown items={computeDropdowns(dropdownItems)} class="h-auto w-fit" hidePopup={hideDropdown}>
+		<Dropdown
+			items={computeDropdowns(dropdownItems)}
+			class="h-auto w-fit"
+			hidePopup={hideDropdown}
+			usePointerDownOutside
+			bind:open={dropdownOpen}
+		>
 			<svelte:fragment slot="buttonReplacement">
 				<div
 					class={twMerge(

--- a/frontend/src/lib/components/common/button/Button.svelte
+++ b/frontend/src/lib/components/common/button/Button.svelte
@@ -37,7 +37,7 @@
 	export let shortCut:
 		| { key?: string; hide?: boolean; Icon?: any; withoutModifier?: boolean }
 		| undefined = undefined
-	export let tooltip:
+	export let tooltipPopover:
 		| {
 				placement?: Placement
 				content: string
@@ -134,15 +134,15 @@
 	const {
 		elements: { trigger, content },
 		states: { open }
-	} = tooltip
+	} = tooltipPopover
 		? createTooltip({
 				positioning: {
-					placement: tooltip?.placement
+					placement: tooltipPopover?.placement
 				},
-				openDelay: tooltip?.openDelay,
-				closeDelay: tooltip?.closeDelay,
+				openDelay: tooltipPopover?.openDelay,
+				closeDelay: tooltipPopover?.closeDelay,
 				group: true,
-				portal: tooltip?.portal
+				portal: tooltipPopover?.portal
 			})
 		: {
 				elements: { trigger: undefined, content: undefined },
@@ -264,7 +264,7 @@
 				</div>
 			{/if}
 		</button>
-		{#if tooltip && $open}
+		{#if tooltipPopover && $open}
 			<div use:conditionalMelt={content} {...$content} class="z-[20000]">
 				<slot name="tooltip" />
 			</div>

--- a/frontend/src/lib/components/common/button/Button.svelte
+++ b/frontend/src/lib/components/common/button/Button.svelte
@@ -233,7 +233,7 @@
 	{/if}
 
 	{#if dropdownItems && dropdownItems.length > 0}
-		<Dropdown items={computeDropdowns(dropdownItems)} class="h-auto w-fit">
+		<Dropdown items={computeDropdowns(dropdownItems)} class="h-auto w-fit" on:openChange>
 			<svelte:fragment slot="buttonReplacement">
 				<div
 					class={twMerge(

--- a/frontend/src/lib/components/common/button/Button.svelte
+++ b/frontend/src/lib/components/common/button/Button.svelte
@@ -149,7 +149,7 @@
 				states: { open: undefined },
 				options: { openDelay: undefined }
 			}
-	$: tooltipPopover && openDelay && ($openDelay = tooltipPopover?.openDelay) //This option is reactive
+	$: tooltipPopover && openDelay !== undefined && ($openDelay = tooltipPopover?.openDelay) //This option is reactive
 
 	$: $open !== undefined && dispatch('tooltipOpen', $open)
 </script>

--- a/frontend/src/lib/components/common/button/Button.svelte
+++ b/frontend/src/lib/components/common/button/Button.svelte
@@ -40,7 +40,6 @@
 	export let tooltipPopover:
 		| {
 				placement?: Placement
-
 				openDelay?: number
 				closeDelay?: number
 				portal?: string

--- a/frontend/src/lib/components/common/button/Button.svelte
+++ b/frontend/src/lib/components/common/button/Button.svelte
@@ -5,7 +5,6 @@
 	import Dropdown from '$lib/components/DropdownV2.svelte'
 	import { getModifierKey, type Item } from '$lib/utils'
 	import { Loader2, ChevronDown } from 'lucide-svelte'
-	import { createTooltip, melt } from '@melt-ui/svelte'
 
 	export let size: ButtonType.Size = 'md'
 	export let spacingSize: ButtonType.Size = size
@@ -35,8 +34,6 @@
 	export let shortCut:
 		| { key?: string; hide?: boolean; Icon?: any; withoutModifier?: boolean }
 		| undefined = undefined
-	export let dropdownOpen: boolean = false
-	export let dropdownOpenOnHover: boolean = false
 
 	type MenuItem = {
 		label: string
@@ -120,24 +117,6 @@
 	}
 
 	$: lucideIconSize = (iconMap[size] ?? 12) * 1
-
-	const {
-		elements: { trigger, content }
-	} = createTooltip({
-		positioning: {
-			placement: 'bottom-end'
-		},
-		openDelay: 0,
-		closeDelay: 0,
-		group: true,
-		portal: 'body',
-		onOpenChange: ({ curr, next }) => {
-			if (curr != next) {
-				dispatch('tooltip-open', next)
-			}
-			return next
-		}
-	})
 </script>
 
 <div
@@ -221,7 +200,6 @@
 			{...$$restProps}
 			disabled={disabled || (loading && !clickableWhileLoading)}
 			{style}
-			use:melt={$trigger}
 		>
 			{#if loading}
 				<Loader2 class={twMerge('animate-spin', iconOnlyPadding[size])} size={lucideIconSize} />
@@ -254,20 +232,8 @@
 		</button>
 	{/if}
 
-	<div use:melt={$content} class="z-[20000]">
-		<slot name="tooltip" />
-	</div>
-
 	{#if dropdownItems && dropdownItems.length > 0}
-		<Dropdown
-			items={computeDropdowns(dropdownItems)}
-			class="h-auto w-fit"
-			on:openChange
-			on:open
-			on:close
-			bind:open={dropdownOpen}
-			openOnHover={dropdownOpenOnHover}
-		>
+		<Dropdown items={computeDropdowns(dropdownItems)} class="h-auto w-fit" on:openChange>
 			<svelte:fragment slot="buttonReplacement">
 				<div
 					class={twMerge(

--- a/frontend/src/lib/components/common/button/Button.svelte
+++ b/frontend/src/lib/components/common/button/Button.svelte
@@ -233,7 +233,7 @@
 	{/if}
 
 	{#if dropdownItems && dropdownItems.length > 0}
-		<Dropdown items={computeDropdowns(dropdownItems)} class="h-auto w-fit" on:openChange>
+		<Dropdown items={computeDropdowns(dropdownItems)} class="h-auto w-fit">
 			<svelte:fragment slot="buttonReplacement">
 				<div
 					class={twMerge(

--- a/frontend/src/lib/components/common/button/Button.svelte
+++ b/frontend/src/lib/components/common/button/Button.svelte
@@ -56,7 +56,6 @@
 	}
 	export let dropdownItems: MenuItem[] | (() => MenuItem[]) | undefined = undefined
 	export let hideDropdown: boolean = false
-	export let dropdownOpen: boolean = false
 
 	function computeDropdowns(menuItems: MenuItem[] | (() => MenuItem[])): Item[] {
 		const items = typeof menuItems === 'function' ? menuItems() : menuItems
@@ -150,7 +149,7 @@
 				states: { open: undefined },
 				options: { openDelay: undefined }
 			}
-	$: tooltipPopover && ($openDelay = tooltipPopover?.openDelay) //This option is reactive
+	$: tooltipPopover && openDelay && ($openDelay = tooltipPopover?.openDelay) //This option is reactive
 
 	$: $open !== undefined && dispatch('tooltipOpen', $open)
 </script>
@@ -281,7 +280,8 @@
 			class="h-auto w-fit"
 			hidePopup={hideDropdown}
 			usePointerDownOutside
-			bind:open={dropdownOpen}
+			on:open={() => dispatch('dropdownOpen', true)}
+			on:close={() => dispatch('dropdownOpen', false)}
 		>
 			<svelte:fragment slot="buttonReplacement">
 				<div

--- a/frontend/src/lib/components/common/button/Button.svelte
+++ b/frontend/src/lib/components/common/button/Button.svelte
@@ -40,7 +40,7 @@
 	export let tooltipPopover:
 		| {
 				placement?: Placement
-				content: string
+
 				openDelay?: number
 				closeDelay?: number
 				portal?: string


### PR DESCRIPTION
* The main goal is to prevent this from happening
![image](https://github.com/user-attachments/assets/95193f4d-83f1-4bd0-9430-90c766b2334e)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces `DeployButton` to prevent deploy popover from showing when deploy dropdown is open, updating `FlowBuilder` and `ScriptBuilder` to use this new component.
> 
>   - **Behavior**:
>     - Prevents deploy popover from showing if deploy dropdown is open by introducing `DeployButton` in `DeployButton.svelte`.
>     - `DeployButton` manages `dropdownOpen` and `hideDropdown` states to control visibility.
>   - **Components**:
>     - Replaces `CustomPopover` with `DeployButton` in `FlowBuilder.svelte` and `ScriptBuilder.svelte`.
>     - Updates `DropdownV2.svelte` to handle `hidePopup` and `open` props for dropdown visibility.
>     - Modifies `Button.svelte` to support `tooltipPopover` and `dropdownItems` for enhanced button functionality.
>   - **Misc**:
>     - Removes unused imports and variables related to previous popover implementation in `FlowBuilder.svelte` and `ScriptBuilder.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for e5f17aebbefde914a443c1067f3b03f6702453ab. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->