### PR TITLE
feat: add diff toggle to flow inline scripts

### DIFF
--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -1529,6 +1529,7 @@
 						$previewArgsStore = JSON.parse(JSON.stringify(e.detail))
 						flowPreviewButtons?.openPreview(true)
 					}}
+					{savedFlow}
 				/>
 			{:else}
 				<CenteredPage>Loading...</CenteredPage>

--- a/frontend/src/lib/components/flows/FlowEditor.svelte
+++ b/frontend/src/lib/components/flows/FlowEditor.svelte
@@ -12,6 +12,7 @@
 	import { writable } from 'svelte/store'
 	import type { PropPickerContext, FlowPropPickerConfig } from '$lib/components/prop_picker'
 	import type { PickableProperties } from '$lib/components/flows/previousResults'
+	import type { Flow } from '$lib/gen'
 	const { flowStore } = getContext<FlowEditorContext>('FlowEditorContext')
 
 	export let loading: boolean

--- a/frontend/src/lib/components/flows/FlowEditor.svelte
+++ b/frontend/src/lib/components/flows/FlowEditor.svelte
@@ -22,7 +22,11 @@
 	export let disabledFlowInputs = false
 	export let smallErrorHandler = false
 	export let newFlow: boolean = false
-
+	export let savedFlow:
+		| (Flow & {
+				draft?: Flow | undefined
+		  })
+		| undefined = undefined
 	let size = 50
 
 	const { currentStepStore: copilotCurrentStepStore } =
@@ -75,6 +79,7 @@
 				<FlowEditorPanel
 					{disabledFlowInputs}
 					{newFlow}
+					{savedFlow}
 					enableAi={!disableAi}
 					on:applyArgs
 					on:testWithArgs

--- a/frontend/src/lib/components/flows/content/FlowEditorPanel.svelte
+++ b/frontend/src/lib/components/flows/content/FlowEditorPanel.svelte
@@ -7,7 +7,7 @@
 	import FlowFailureModule from './FlowFailureModule.svelte'
 	import FlowConstants from './FlowConstants.svelte'
 	import TriggersEditor from '../../triggers/TriggersEditor.svelte'
-	import type { FlowModule } from '$lib/gen'
+	import type { FlowModule, Flow } from '$lib/gen'
 	import { initFlowStepWarnings } from '../utils'
 	import { dfs } from '../dfs'
 	import FlowPreprocessorModule from './FlowPreprocessorModule.svelte'
@@ -18,6 +18,11 @@
 	export let enableAi = false
 	export let newFlow = false
 	export let disabledFlowInputs = false
+	export let savedFlow:
+		| (Flow & {
+				draft?: Flow | undefined
+		  })
+		| undefined = undefined
 
 	const {
 		selectedId,
@@ -140,6 +145,7 @@
 					bind:flowModule
 					previousModule={$flowStore.value.modules[index - 1]}
 					{enableAi}
+					savedModule={savedFlow?.value.modules[index]}
 				/>
 			{/each}
 		{/key}

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -99,12 +99,18 @@
 	let testJob: Job | undefined = undefined
 	let testIsLoading = false
 	let scriptProgress = undefined
+	let lastDeployedCode: string | undefined = undefined
 
-	$: lastDeployedCode =
-		(savedModule?.value as RawScript).content &&
-		(savedModule?.value as RawScript).content !== (flowModule.value as RawScript).content
-			? (savedModule?.value as RawScript).content
-			: undefined
+	$: {
+		const savedRawScript = savedModule?.value as RawScript
+		const currentRawScript = flowModule.value as RawScript
+		lastDeployedCode =
+			savedRawScript?.type === 'rawscript' &&
+			currentRawScript.type === 'rawscript' &&
+			savedRawScript.content !== currentRawScript.content
+				? savedRawScript.content
+				: undefined
+	}
 
 	const { modulesStore: copilotModulesStore } =
 		getContext<FlowCopilotContext | undefined>('FlowCopilotContext') || {}

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -24,7 +24,6 @@
 	import { getFailureStepPropPicker, getStepPropPicker } from '../previousResults'
 	import { deepEqual } from 'fast-equals'
 	import Section from '$lib/components/Section.svelte'
-	import { writable } from 'svelte/store'
 
 	import Button from '$lib/components/common/button/Button.svelte'
 	import Alert from '$lib/components/common/alert/Alert.svelte'
@@ -78,7 +77,7 @@
 	export let savedModule: FlowModule | undefined = undefined
 
 	let tag: string | undefined = undefined
-	let diffMode = writable(false)
+	let diffMode = false
 
 	let editor: Editor
 	let diffEditor: DiffEditor
@@ -257,7 +256,7 @@
 	}
 
 	function showDiffMode() {
-		diffMode.set(true)
+		diffMode = true
 		diffEditor?.setOriginal((savedModule?.value as RawScript).content ?? '')
 		diffEditor?.setModified(editor?.getCode() ?? '')
 		diffEditor?.show()
@@ -265,7 +264,7 @@
 	}
 
 	function hideDiffMode() {
-		diffMode.set(false)
+		diffMode = false
 		diffEditor?.hide()
 		editor?.show()
 	}
@@ -406,7 +405,6 @@
 											fixedOverflowWidgets
 											defaultLang={scriptLangToEditorLang(flowModule.value.language)}
 											class="h-full"
-											{editor}
 										/>
 									{/key}
 								{/if}

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -105,7 +105,6 @@
 		const savedRawScript = savedModule?.value as RawScript
 		const currentRawScript = flowModule.value as RawScript
 		return savedRawScript?.type === 'rawscript' &&
-			savedRawScript?.type === 'rawscript' &&
 			currentRawScript.type === 'rawscript' &&
 			savedRawScript.content !== currentRawScript.content
 			? savedRawScript.content

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -99,17 +99,17 @@
 	let testJob: Job | undefined = undefined
 	let testIsLoading = false
 	let scriptProgress = undefined
-	let lastDeployedCode: string | undefined = undefined
 
-	$: {
+	$: lastDeployedCode = onModulesChange(savedModule, flowModule)
+	function onModulesChange(savedModule: FlowModule | undefined, flowModule: FlowModule) {
 		const savedRawScript = savedModule?.value as RawScript
 		const currentRawScript = flowModule.value as RawScript
-		lastDeployedCode =
+		return savedRawScript?.type === 'rawscript' &&
 			savedRawScript?.type === 'rawscript' &&
 			currentRawScript.type === 'rawscript' &&
 			savedRawScript.content !== currentRawScript.content
-				? savedRawScript.content
-				: undefined
+			? savedRawScript.content
+			: undefined
 	}
 
 	const { modulesStore: copilotModulesStore } =

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -102,12 +102,10 @@
 
 	$: lastDeployedCode = onModulesChange(savedModule, flowModule)
 	function onModulesChange(savedModule: FlowModule | undefined, flowModule: FlowModule) {
-		const savedRawScript = savedModule?.value as RawScript
-		const currentRawScript = flowModule.value as RawScript
-		return savedRawScript?.type === 'rawscript' &&
-			currentRawScript.type === 'rawscript' &&
-			savedRawScript.content !== currentRawScript.content
-			? savedRawScript.content
+		return savedModule?.value?.type === 'rawscript' &&
+			flowModule.value.type === 'rawscript' &&
+			savedModule.value.content !== flowModule.value.content
+			? savedModule.value.content
 			: undefined
 	}
 

--- a/frontend/src/lib/components/flows/content/FlowModuleWrapper.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleWrapper.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-	import { type FlowModule } from '$lib/gen'
+	import {
+		type BranchAll,
+		type BranchOne,
+		type FlowModule,
+		type ForloopFlow,
+		type WhileloopFlow
+	} from '$lib/gen'
 	import { getContext } from 'svelte'
 
 	import type { FlowEditorContext } from '../types'
@@ -201,6 +207,7 @@
 			bind:flowModule={submodule}
 			bind:parentModule={flowModule}
 			previousModule={flowModule.value.modules[index - 1]}
+			savedModule={(savedModule?.value as ForloopFlow | WhileloopFlow).modules[index]}
 			{enableAi}
 		/>
 	{/each}
@@ -217,6 +224,7 @@
 				bind:flowModule={submodule}
 				bind:parentModule={flowModule}
 				previousModule={flowModule.value.default[index - 1]}
+				savedModule={flowModule.value.default[index]}
 				{enableAi}
 			/>
 		{/each}
@@ -237,6 +245,7 @@
 					bind:flowModule={submodule}
 					bind:parentModule={flowModule}
 					previousModule={flowModule.value.branches[branchIndex].modules[index - 1]}
+					savedModule={(savedModule?.value as BranchOne).branches[branchIndex].modules[index]}
 					{enableAi}
 				/>
 			{/each}
@@ -254,6 +263,7 @@
 					bind:parentModule={flowModule}
 					previousModule={flowModule.value.branches[branchIndex].modules[index - 1]}
 					{enableAi}
+					savedModule={(savedModule?.value as BranchAll).branches[branchIndex].modules[index]}
 				/>
 			{/each}
 		{/if}

--- a/frontend/src/lib/components/flows/content/FlowModuleWrapper.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleWrapper.svelte
@@ -25,6 +25,7 @@
 	export let flowModule: FlowModule
 	export let noEditor: boolean = false
 	export let enableAi = false
+	export let savedModule: FlowModule | undefined = undefined
 
 	const { selectedId, flowStateStore, flowInputsStore, flowStore } =
 		getContext<FlowEditorContext>('FlowEditorContext')
@@ -190,6 +191,7 @@
 			{scriptKind}
 			{scriptTemplate}
 			{enableAi}
+			{savedModule}
 		/>
 	{/if}
 {:else if flowModule.value.type === 'forloopflow' || flowModule.value.type == 'whileloopflow'}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a diff toggle feature for flow inline scripts, enabling comparison between current and saved script versions across multiple components.
> 
>   - **Behavior**:
>     - Adds `savedFlow` prop to `FlowBuilder.svelte`, `FlowEditor.svelte`, and `FlowEditorPanel.svelte` to manage flow state.
>     - Implements `showDiffMode()` and `hideDiffMode()` in `FlowModuleComponent.svelte` to toggle between diff and normal modes.
>     - Updates `FlowModuleComponent.svelte` to use `DiffEditor` for displaying differences between current and saved script content.
>   - **Components**:
>     - Passes `savedFlow` and `savedModule` props through `FlowEditorPanel.svelte`, `FlowModuleWrapper.svelte`, and `FlowModuleComponent.svelte` to manage module states.
>     - Updates `FlowModuleWrapper.svelte` to handle `savedModule` for different flow module types, including loops and branches.
>   - **Misc**:
>     - Adds `lastDeployedCode` reactive statement in `FlowModuleComponent.svelte` to track changes in module content.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 4d39b4ae50f43fb45edea4250f1fbe10a1a458ea. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->