### PR TITLE
fix: Remaining svelte 5 bugs

### DIFF
--- a/frontend/src/lib/components/EditableSchemaForm.svelte
+++ b/frontend/src/lib/components/EditableSchemaForm.svelte
@@ -11,7 +11,7 @@
 	import FlowPropertyEditor from './schema/FlowPropertyEditor.svelte'
 	import PropertyEditor from './schema/PropertyEditor.svelte'
 	import SimpleEditor from './SimpleEditor.svelte'
-	import { createEventDispatcher } from 'svelte'
+	import { createEventDispatcher, tick } from 'svelte'
 	import ToggleButton from './common/toggleButton-v2/ToggleButton.svelte'
 	import ToggleButtonGroup from './common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import Label from './Label.svelte'
@@ -83,7 +83,7 @@
 
 	let keys: string[] = Array.isArray(schema?.order)
 		? [...schema.order]
-		: Object.keys(schema?.properties ?? {}) ?? Object.keys(schema?.properties ?? {})
+		: (Object.keys(schema?.properties ?? {}) ?? Object.keys(schema?.properties ?? {}))
 
 	$: schema && onSchemaChange()
 
@@ -157,10 +157,10 @@
 			? property.type !== 'object'
 				? property.type
 				: property.format === 'resource-s3_object'
-				? 'S3'
-				: property.oneOf && property.oneOf.length >= 2
-				? 'oneOf'
-				: 'object'
+					? 'S3'
+					: property.oneOf && property.oneOf.length >= 2
+						? 'oneOf'
+						: 'object'
 			: ''
 	}
 
@@ -209,7 +209,7 @@
 	let editor: SimpleEditor | undefined = undefined
 
 	const editTabDefaultSize = noPreview ? 100 : 50
-	editPanelSize = editTab ? editPanelInitialSize ?? editTabDefaultSize : 0
+	editPanelSize = editTab ? (editPanelInitialSize ?? editTabDefaultSize) : 0
 	let inputPanelSize = 100 - editPanelSize
 	let editPanelSizeSmooth = tweened(editPanelSize, {
 		duration: 150
@@ -293,11 +293,11 @@
 							on:reorder={(e) => {
 								schema.order = e.detail
 								schema = schema
-								dispatch('change', schema)
+								tick().then(() => dispatch('change', schema))
 							}}
 							on:change={() => {
 								schema = schema
-								dispatch('change', schema)
+								tick().then(() => dispatch('change', schema))
 							}}
 							prettifyHeader={isAppInput}
 							disabled={!!previewSchema}
@@ -447,8 +447,9 @@
 															bind:enum_={schema.properties[argName].enum}
 															bind:format={schema.properties[argName].format}
 															bind:contentEncoding={schema.properties[argName].contentEncoding}
-															bind:customErrorMessage={schema.properties[argName]
-																.customErrorMessage}
+															bind:customErrorMessage={
+																schema.properties[argName].customErrorMessage
+															}
 															bind:itemsType={schema.properties[argName].items}
 															bind:extra={schema.properties[argName]}
 															bind:title={schema.properties[argName].title}

--- a/frontend/src/lib/components/copilot/chat/CodeDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/CodeDisplay.svelte
@@ -32,9 +32,11 @@
 
 	const { message } = getContext<{ message: DisplayMessage }>('AssistantMessageContext')
 
-	$: codeContext = message.contextElements?.find((e) => e.type === 'code') as
-		| Extract<ContextElement, { type: 'code' }>
-		| undefined
+	let codeContext = $derived(
+		message.contextElements?.find((e) => e.type === 'code') as
+			| Extract<ContextElement, { type: 'code' }>
+			| undefined
+	)
 
 	function getSmartLang(lang: string) {
 		switch (lang) {
@@ -93,22 +95,22 @@
 		yaml: yaml
 	}
 
-	$: code = astNode.current.children?.[0]?.children?.[0]?.value
+	let code = $derived(astNode.current.children?.[0]?.children?.[0]?.value)
 
-	$: language = (astNode.current.children?.[0]?.properties?.class as string | undefined)?.split(
-		'-'
-	)[1]
+	let language = $derived(
+		(astNode.current.children?.[0]?.properties?.class as string | undefined)?.split('-')[1]
+	)
 
-	let loading = true
+	let loading = $state(true)
 	function shouldStopLoading(astNode: HastNode, replying: boolean) {
 		if (!replying || $currentReply.length > (astNode.position?.end.offset ?? 0)) {
 			loading = false
 		}
 	}
-	$: shouldStopLoading(astNode.current, $loadingContext)
+	$effect(() => shouldStopLoading(astNode.current, $loadingContext))
 
-	let diffEl: HTMLDivElement | undefined
-	let diffEditor: meditor.IStandaloneDiffEditor | undefined
+	let diffEl: HTMLDivElement | undefined = $state()
+	let diffEditor: meditor.IStandaloneDiffEditor | undefined = $state()
 	async function setDiffEditor(diffEl: HTMLDivElement) {
 		if (!codeContext) {
 			return
@@ -165,13 +167,15 @@
 			modifiedModel.setValue(code ?? '')
 		}
 	}
-	$: updateModifiedModel(code ?? '')
+	$effect(() => updateModifiedModel(code ?? ''))
 
-	$: diffEl &&
-		language &&
-		codeContext &&
-		getSmartLang(codeContext.lang) === getSmartLang(language) &&
-		setDiffEditor(diffEl)
+	$effect(() => {
+		diffEl &&
+			language &&
+			codeContext &&
+			getSmartLang(codeContext.lang) === getSmartLang(language) &&
+			setDiffEditor(diffEl)
+	})
 </script>
 
 <div class="flex flex-col gap-0.5 rounded-lg relative not-prose">


### PR DESCRIPTION
Fix remaining svelte 5 bugs
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Svelte 5 bugs by improving event dispatching, code formatting, and state management in `EditableSchemaForm.svelte` and `CodeDisplay.svelte`.
> 
>   - **EditableSchemaForm.svelte**:
>     - Added `tick` from Svelte to ensure event dispatching occurs after DOM updates in `on:reorder` and `on:change` events.
>     - Improved code formatting for readability in conditional statements and assignments.
>     - Adjusted `editPanelSize` calculation to use parentheses for clarity.
>   - **CodeDisplay.svelte**:
>     - Replaced reactive statements with `$derived` and `$state` for `code`, `language`, `loading`, `diffEl`, and `diffEditor` to improve state management.
>     - Used `$effect` to manage side effects for `shouldStopLoading`, `updateModifiedModel`, and `setDiffEditor` functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 6dcecc0a6eec764a7fb50765208c1ba4161d5a9c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->