### PR TITLE
feat(frontend): app builder - force json configuration in rich result

### DIFF
--- a/frontend/src/lib/components/apps/components/display/AppDisplayComponent.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppDisplayComponent.svelte
@@ -98,6 +98,7 @@
 				{requireHtmlApproval}
 				disableExpand={resolvedConfig?.hideDetails}
 				appPath={$userStore ? undefined : $appPath}
+				forceJson={resolvedConfig?.forceJson}
 			/>
 		</div>
 	</div>

--- a/frontend/src/lib/components/apps/components/display/AppDisplayComponentByJobId.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppDisplayComponentByJobId.svelte
@@ -117,6 +117,7 @@
 				{requireHtmlApproval}
 				disableExpand={resolvedConfig?.hideDetails}
 				appPath={$userStore ? undefined : $appPath}
+				forceJson={resolvedConfig?.forceJson}
 			/>
 		</div>
 	</div>

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -963,6 +963,12 @@ export const components = {
 					value: false,
 					tooltip:
 						'Hide the details section: the object keys, the clipboard button and the maximise button'
+				},
+				forceJson: {
+					type: 'static',
+					fieldType: 'boolean',
+					value: false,
+					tooltip: 'Force the result to be displayed as JSON'
 				}
 			}
 		}
@@ -1644,9 +1650,9 @@ Hello \${ctx.username}
 				type: 'templatev2',
 				fieldType: 'template',
 				eval: `# This is a header
-## This is a subheader				
+## This is a subheader
 This is a paragraph.
-				
+
 * This is a list
 * With two items`,
 				connections: [] as InputConnectionEval[]
@@ -2680,7 +2686,7 @@ This is a paragraph.
 					type: 'static',
 					value: 'yyyy-MM-dd',
 					fieldType: 'text',
-					markdownTooltip: `### Output format				
+					markdownTooltip: `### Output format
 See date-fns format for more information. By default, it is 'yyyy-MM-dd'
 
 | Format      | Result | Description |
@@ -2737,7 +2743,7 @@ See date-fns format for more information. By default, it is 'yyyy-MM-dd'
 					fieldType: 'text',
 					documentationLink: 'https://date-fns.org/v2.30.0/docs/format',
 					placeholder: 'dd.MM.yyyy HH:mm',
-					markdownTooltip: `### Output format				
+					markdownTooltip: `### Output format
 See date-fns format for more information. By default, it is 'dd.MM.yyyy HH:mm'
 
 | Format      | Result | Description |
@@ -4153,6 +4159,12 @@ See date-fns format for more information. By default, it is 'dd.MM.yyyy HH:mm'
 					value: false,
 					tooltip:
 						'Hide the details section: the object keys, the clipboard button and the maximise button'
+				},
+				forceJson: {
+					type: 'static',
+					fieldType: 'boolean',
+					value: false,
+					tooltip: 'Force the result to be displayed as JSON'
 				}
 			}
 		}


### PR DESCRIPTION

https://github.com/user-attachments/assets/0f286ded-63da-43ea-8724-26baf9013763


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `forceJson` configuration to `AppDisplayComponent` and `AppDisplayComponentByJobId` to force JSON result display.
> 
>   - **Behavior**:
>     - Adds `forceJson` prop to `AppDisplayComponent.svelte` and `AppDisplayComponentByJobId.svelte` to force JSON display of results.
>   - **Configuration**:
>     - Adds `forceJson` configuration option to `components.ts` for `displaycomponent` and `jobiddisplaycomponent`.
>   - **Misc**:
>     - Removes trailing spaces in `components.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for febf8d6de5f5aba379b7493d47bc9e424d921289. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->