### PR TITLE
fix: Dynamic select does not work with tag //native

### DIFF
--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -1271,6 +1271,7 @@ try {{
                 inner_content.clone(),
                 js_code,
                 job_args,
+                job.script_entrypoint_override.clone(),
                 job.id,
                 job.timeout,
                 db,

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1991,6 +1991,7 @@ async fn do_nativets(
         code.clone(),
         transpile_ts(code)?,
         job_args,
+        None,
         job.id,
         job.timeout,
         db,


### PR DESCRIPTION
closes #5490

### Before:
![Screenshot_2025-04-05_22-27-54](https://github.com/user-attachments/assets/85abedf4-8525-4127-a626-599ead463b53)

### After:
![Screenshot_2025-04-05_22-21-18](https://github.com/user-attachments/assets/bd987729-0c42-4a2f-8451-19cac4f81f69)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for `script_entrypoint_override` in `eval_fetch_timeout` and `eval_fetch` to fix dynamic select with `//native` tag.
> 
>   - **Behavior**:
>     - Adds `script_entrypoint_override` parameter to `eval_fetch_timeout()` and `eval_fetch()` in `js_eval.rs` to support dynamic select with `//native` tag.
>     - Updates `do_nativets()` in `worker.rs` to pass `None` for `script_entrypoint_override`.
>   - **Functions**:
>     - Modifies `eval_fetch_timeout()` and `eval_fetch()` in `js_eval.rs` to handle `script_entrypoint_override`.
>     - Updates `do_nativets()` in `worker.rs` to include `script_entrypoint_override` parameter.
>   - **Misc**:
>     - Visual update shown in screenshots indicating behavior change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for c5074a7bda84dc4c5d2a97b2775b77cc70d3e006. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->