### PR TITLE
fix: Dynamic select does not work with tag //native

### DIFF
--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -1271,6 +1271,7 @@ try {{
                 inner_content.clone(),
                 js_code,
                 job_args,
+                job.script_entrypoint_override.clone(),
                 job.id,
                 job.timeout,
                 db,

--- a/backend/windmill-worker/src/js_eval.rs
+++ b/backend/windmill-worker/src/js_eval.rs
@@ -775,6 +775,7 @@ pub async fn eval_fetch_timeout(
     ts_expr: String,
     js_expr: String,
     args: Option<&Json<HashMap<String, Box<RawValue>>>>,
+    script_entrypoint_override: Option<String>,
     job_id: Uuid,
     job_timeout: Option<i32>,
     db: &DB,
@@ -789,7 +790,13 @@ pub async fn eval_fetch_timeout(
 
     let (sender, mut receiver) = oneshot::channel::<IsolateHandle>();
 
-    let parsed_args = windmill_parser_ts::parse_deno_signature(&ts_expr, true, false, None)?.args;
+    let parsed_args = windmill_parser_ts::parse_deno_signature(
+        &ts_expr,
+        true,
+        false,
+        script_entrypoint_override.clone(),
+    )?
+    .args;
     let spread = parsed_args
         .into_iter()
         .map(|x| {
@@ -902,7 +909,7 @@ pub async fn eval_fetch_timeout(
 
         let future = async {
             let r = tokio::select! {
-                r = eval_fetch(&mut js_runtime, &js_expr, Some(env_code), load_client, &job_id) => Ok(r),
+                r = eval_fetch(&mut js_runtime, &js_expr, Some(env_code), script_entrypoint_override, load_client, &job_id) => Ok(r),
                 _ = memory_limit_rx.recv() => Err(Error::ExecutionErr("Memory limit reached, killing isolate".to_string()))
             };
 
@@ -990,6 +997,7 @@ async fn eval_fetch(
     js_runtime: &mut JsRuntime,
     expr: &str,
     env_code: Option<String>,
+    script_entrypoint_override: Option<String>,
     load_client: bool,
     job_id: &Uuid,
 ) -> anyhow::Result<Box<RawValue>> {
@@ -1016,13 +1024,16 @@ async fn eval_fetch(
         })
         .context("failed to load module")?;
 
+    let main_override = script_entrypoint_override.unwrap_or("main".to_string());
     let script = js_runtime
         .execute_script(
             "<anon>",
-            r#"
+            format!(
+                r#"
 let args = Deno.core.ops.op_get_static_args().map(JSON.parse)
-import("file:///eval.ts").then((module) => module.main(...args)).then(JSON.stringify)
-"#,
+import("file:///eval.ts").then((module) => module.{main_override}(...args)).then(JSON.stringify)
+"#
+            ),
         )
         .map_err(|e| {
             write_error_expr(expr, &job_id);

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1991,6 +1991,7 @@ async fn do_nativets(
         code.clone(),
         transpile_ts(code)?,
         job_args,
+        None,
         job.id,
         job.timeout,
         db,


### PR DESCRIPTION
closes #5490

### Before
![Screenshot_2025-04-05_22-27-54](https://github.com/user-attachments/assets/b734d638-757f-4b50-8291-acc285dec814)

### After
![Screenshot_2025-04-05_23-33-15](https://github.com/user-attachments/assets/4669b8c6-f026-49ce-9b83-81d07a272c18)


I have read the CLA Document and I hereby sign the CLA
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes dynamic select issue with `//native` tag by adding `script_entrypoint_override` for custom script entry points.
> 
>   - **Behavior**:
>     - Adds `script_entrypoint_override` parameter to `eval_fetch_timeout()` in `js_eval.rs` and `eval_fetch()` in `js_eval.rs` to allow specifying a custom script entry point.
>     - Updates `do_nativets()` in `worker.rs` to pass `None` for `script_entrypoint_override`.
>   - **Functions**:
>     - Modifies `eval_fetch_timeout()` and `eval_fetch()` in `js_eval.rs` to use `script_entrypoint_override` for dynamic script entry point selection.
>     - Updates `handle_bun_job()` in `bun_executor.rs` to include `script_entrypoint_override` in function calls.
>   - **Misc**:
>     - Closes issue #5490 by fixing dynamic select functionality with `//native` tag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 23bd6478c6a0efecb895012587f0355070815dbb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->