### PR TITLE
fix: function takes 13 arguments but 14 arguments were supplied

### DIFF
--- a/backend/windmill-worker/src/js_eval.rs
+++ b/backend/windmill-worker/src/js_eval.rs
@@ -755,6 +755,7 @@ pub async fn eval_fetch_timeout(
     _ts_expr: String,
     _js_expr: String,
     _args: Option<&Json<HashMap<String, Box<RawValue>>>>,
+    _script_entrypoint_override: Option<String>,
     _job_id: Uuid,
     _job_timeout: Option<i32>,
     _db: &DB,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `_script_entrypoint_override` parameter to `eval_fetch_timeout()` in `js_eval.rs` to fix argument mismatch error.
> 
>   - **Function Signature**:
>     - Add `_script_entrypoint_override: Option<String>` parameter to `eval_fetch_timeout()` in `js_eval.rs` to fix argument mismatch error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 0db1a848c8ddf29c2a1686c22f2ed452c2e79ce4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->