### PR TITLE
fix: validate saved module before passing to flow module editor

### DIFF
--- a/frontend/src/lib/components/flows/content/FlowEditorPanel.svelte
+++ b/frontend/src/lib/components/flows/content/FlowEditorPanel.svelte
@@ -94,9 +94,9 @@
 {:else if $selectedId === 'constants'}
 	<FlowConstants {noEditor} />
 {:else if $selectedId === 'failure'}
-	<FlowFailureModule {noEditor} />
+	<FlowFailureModule {noEditor} savedModule={savedFlow?.value.failure_module} />
 {:else if $selectedId === 'preprocessor'}
-	<FlowPreprocessorModule {noEditor} />
+	<FlowPreprocessorModule {noEditor} savedModule={savedFlow?.value.preprocessor_module} />
 {:else if $selectedId === 'triggers'}
 	<TriggersEditor
 		on:applyArgs

--- a/frontend/src/lib/components/flows/content/FlowFailureModule.svelte
+++ b/frontend/src/lib/components/flows/content/FlowFailureModule.svelte
@@ -2,8 +2,10 @@
 	import { getContext } from 'svelte'
 	import type { FlowEditorContext } from '../types'
 	import FlowModuleWrapper from './FlowModuleWrapper.svelte'
+	import type { FlowModule } from '$lib/gen'
 
 	export let noEditor = false
+	export let savedModule: FlowModule | undefined = undefined
 
 	const { flowStore } = getContext<FlowEditorContext>('FlowEditorContext')
 </script>
@@ -15,6 +17,7 @@
 		on:delete={() => {
 			$flowStore.value.failure_module = undefined
 		}}
+		{savedModule}
 		previousModule={undefined}
 	/>
 {/if}

--- a/frontend/src/lib/components/flows/content/FlowModuleWrapper.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleWrapper.svelte
@@ -1,11 +1,5 @@
 <script lang="ts">
-	import {
-		type BranchAll,
-		type BranchOne,
-		type FlowModule,
-		type ForloopFlow,
-		type WhileloopFlow
-	} from '$lib/gen'
+	import { type FlowModule } from '$lib/gen'
 	import { getContext } from 'svelte'
 
 	import type { FlowEditorContext } from '../types'
@@ -207,7 +201,10 @@
 			bind:flowModule={flowModule.value.modules[index]}
 			bind:parentModule={flowModule}
 			previousModule={flowModule.value.modules[index - 1]}
-			savedModule={(savedModule?.value as ForloopFlow | WhileloopFlow).modules[index]}
+			savedModule={savedModule?.value.type === 'forloopflow' ||
+			savedModule?.value.type === 'whileloopflow'
+				? savedModule.value.modules[index]
+				: undefined}
 			{enableAi}
 		/>
 	{/each}
@@ -224,7 +221,9 @@
 				bind:flowModule={flowModule.value.default[index]}
 				bind:parentModule={flowModule}
 				previousModule={flowModule.value.default[index - 1]}
-				savedModule={flowModule.value.default[index]}
+				savedModule={savedModule?.value.type === 'branchone'
+					? savedModule.value.default[index]
+					: undefined}
 				{enableAi}
 			/>
 		{/each}
@@ -245,7 +244,9 @@
 					bind:flowModule={flowModule.value.branches[branchIndex].modules[index]}
 					bind:parentModule={flowModule}
 					previousModule={flowModule.value.branches[branchIndex].modules[index - 1]}
-					savedModule={(savedModule?.value as BranchOne).branches[branchIndex].modules[index]}
+					savedModule={savedModule?.value.type === 'branchone'
+						? savedModule.value.branches[branchIndex]?.modules[index]
+						: undefined}
 					{enableAi}
 				/>
 			{/each}
@@ -263,7 +264,9 @@
 					bind:parentModule={flowModule}
 					previousModule={flowModule.value.branches[branchIndex].modules[index - 1]}
 					{enableAi}
-					savedModule={(savedModule?.value as BranchAll).branches[branchIndex].modules[index]}
+					savedModule={savedModule?.value.type === 'branchall'
+						? savedModule.value.branches[branchIndex]?.modules[index]
+						: undefined}
 				/>
 			{/each}
 		{/if}

--- a/frontend/src/lib/components/flows/content/FlowPreprocessorModule.svelte
+++ b/frontend/src/lib/components/flows/content/FlowPreprocessorModule.svelte
@@ -2,8 +2,10 @@
 	import { getContext } from 'svelte'
 	import type { FlowEditorContext } from '../types'
 	import FlowModuleWrapper from './FlowModuleWrapper.svelte'
+	import type { FlowModule } from '$lib/gen'
 
 	export let noEditor = false
+	export let savedModule: FlowModule | undefined = undefined
 
 	const { flowStore } = getContext<FlowEditorContext>('FlowEditorContext')
 </script>
@@ -16,5 +18,6 @@
 			$flowStore.value.preprocessor_module = undefined
 		}}
 		previousModule={undefined}
+		{savedModule}
 	/>
 {/if}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Pass `savedModule` to `FlowFailureModule` and `FlowPreprocessorModule` and update `FlowModuleWrapper` to handle it based on module type.
> 
>   - **Behavior**:
>     - Pass `savedModule` prop to `FlowFailureModule` and `FlowPreprocessorModule` in `FlowEditorPanel.svelte`.
>     - Update `FlowModuleWrapper.svelte` to handle `savedModule` for different module types (`forloopflow`, `whileloopflow`, `branchone`, `branchall`).
>   - **Components**:
>     - Add `savedModule` prop to `FlowFailureModule.svelte` and `FlowPreprocessorModule.svelte`.
>     - Modify `FlowModuleWrapper.svelte` to conditionally set `savedModule` based on module type.
>   - **Misc**:
>     - Remove unused imports in `FlowModuleWrapper.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 27e02766b4ccd5a458b5a91b36b1a8fcdd030a06. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->