### PR TITLE
fix(frontend): fix typo in output picker

### DIFF
--- a/frontend/src/lib/components/flows/propPicker/OutputPickerInner.svelte
+++ b/frontend/src/lib/components/flows/propPicker/OutputPickerInner.svelte
@@ -616,7 +616,7 @@
 				<div class="flex flex-col items-center justify-center h-full">
 					<p class="text-xs text-secondary">
 						Test this step to see results{#if !disableMock}
-							or
+							{' or'}
 							<button
 								class="text-blue-500 hover:text-blue-700 underline"
 								on:click={() => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes a typo in `OutputPickerInner.svelte` to correct spacing in the output text.
> 
>   - **Fix**:
>     - Corrects a typo in `OutputPickerInner.svelte` by changing `or` to `{' or'}` for proper spacing in the output text.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 076321280f3972716cb9de2c43068c5db30b52ce. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->