### PR TITLE
fix: mssql ca_cert deserializing

### DIFF
--- a/backend/windmill-worker/src/mssql_executor.rs
+++ b/backend/windmill-worker/src/mssql_executor.rs
@@ -33,7 +33,7 @@ struct MssqlDatabase {
     #[serde(default, deserialize_with = "deserialize_aad_token")]
     aad_token: Option<AadToken>,
     trust_cert: Option<bool>,
-    #[serde(deserialize_with = "empty_string_as_none")]
+    #[serde(default, deserialize_with = "empty_string_as_none")]
     ca_cert: Option<String>,
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `#[serde(default)]` to `ca_cert` in `MssqlDatabase` to default to `None` if missing during deserialization.
> 
>   - **Deserialization Fix**:
>     - In `MssqlDatabase` struct in `mssql_executor.rs`, added `#[serde(default)]` to `ca_cert` field to default to `None` if missing during deserialization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 29d59a49033b94efaed4d99b67dc54b284cae229. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->