### PR TITLE
fix infinite loop in app multiselect due to bind

### DIFF
--- a/frontend/src/lib/components/ArgInput.svelte
+++ b/frontend/src/lib/components/ArgInput.svelte
@@ -547,7 +547,14 @@
 								ulOptionsClass={'p-2 !bg-surface-secondary'}
 								outerDivClass={'dark:!border-gray-500 !border-gray-300'}
 								{disabled}
-								bind:selected={value}
+								bind:selected={
+									() => [...value],
+									(v) => {
+										if (!deepEqual(v, value)) {
+											value = v
+										}
+									}
+								}
 								options={itemsType?.enum ?? []}
 								selectedOptionsDraggable={true}
 								on:open={() => {


### PR DESCRIPTION
Fixed infinite loop occurring in app editor on this very specific condition:
Having a Form component with at least two array type fields, whose items are enums.

I honestly have no idea why it does not happen with a single enum-array field. I'd be curious to know if anyone has any thoughts
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes infinite loop in `ArgInput.svelte` for forms with multiple enum-array fields by adjusting `bind:selected` logic in `Multiselect`.
> 
>   - **Fix**:
>     - Resolves infinite loop in `ArgInput.svelte` for forms with multiple enum-array fields by changing `bind:selected` logic in `Multiselect`.
>     - Uses a custom binding function to prevent unnecessary updates when `value` is unchanged.
>   - **Behavior**:
>     - Affects forms with at least two array type fields where items are enums.
>     - Does not affect single enum-array fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 2a591e62d4a3c67d7853f86e7cd134d746c3748a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->