### PR TITLE
fix: add support for ${} syntax without default in bash

### DIFF
--- a/backend/parsers/windmill-parser-bash/src/lib.rs
+++ b/backend/parsers/windmill-parser-bash/src/lib.rs
@@ -45,7 +45,7 @@ pub fn parse_powershell_sig(code: &str) -> anyhow::Result<MainArgSignature> {
 }
 
 lazy_static::lazy_static! {
-    static ref RE_BASH: Regex = Regex::new(r#"(?m)^(\w+)="\$(?:(\d+)|\{(\d+):-(.*)\})"(?:[\t ]*)?(?:#.*)?$"#).unwrap();
+    static ref RE_BASH: Regex = Regex::new(r#"(?m)^(\w+)="\$(?:(\d+)|\{(\d+)\}|\{(\d+):-(.*)\})"(?:[\t ]*)?(?:#.*)?$"#).unwrap();
 
     pub static ref RE_POWERSHELL_PARAM: Regex = Regex::new(r#"(?m)param[\t ]*\(([^)]*)\)"#).unwrap();
     static ref RE_POWERSHELL_ARGS: Regex = Regex::new(r#"(?:\[(\w+)\])?\$(\w+)[\t ]*(?:=[\t ]*(?:(?:(?:"|')([^"\n\r\$]*)(?:"|'))|([\d.]+)))?"#).unwrap();
@@ -57,11 +57,12 @@ fn parse_bash_file(code: &str) -> anyhow::Result<Option<Vec<Arg>>> {
         hm.insert(
             cap.get(2)
                 .or(cap.get(3))
+                .or(cap.get(4))
                 .and_then(|x| x.as_str().parse::<i32>().ok())
                 .ok_or_else(|| anyhow!("Impossible to parse arg digit"))?,
             (
                 cap[1].to_string(),
-                cap.get(4).map(|x| x.as_str().to_string()),
+                cap.get(5).map(|x| x.as_str().to_string()),
             ),
         );
     }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -71,7 +71,7 @@
 				"windmill-parser-wasm-nu": "^1.474.1",
 				"windmill-parser-wasm-php": "^1.429.0",
 				"windmill-parser-wasm-py": "^1.477.1",
-				"windmill-parser-wasm-regex": "^1.478.2",
+				"windmill-parser-wasm-regex": "^1.481.0",
 				"windmill-parser-wasm-rust": "^1.429.0",
 				"windmill-parser-wasm-ts": "^1.429.0",
 				"windmill-parser-wasm-yaml": "^1.429.0",
@@ -10770,7 +10770,9 @@
 			"version": "1.477.1"
 		},
 		"node_modules/windmill-parser-wasm-regex": {
-			"version": "1.478.2"
+			"version": "1.481.0",
+			"resolved": "https://registry.npmjs.org/windmill-parser-wasm-regex/-/windmill-parser-wasm-regex-1.481.0.tgz",
+			"integrity": "sha512-QY9NOaF0M55SBEbbcAkHoXppjdS2gb2NlwqhlZ1ciYWTtIrbZoL5K8xoG4FbB5vWRHxInG1aRdA2tb+JP180yA=="
 		},
 		"node_modules/windmill-parser-wasm-rust": {
 			"version": "1.429.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -144,7 +144,7 @@
 		"windmill-parser-wasm-nu": "^1.474.1",
 		"windmill-parser-wasm-php": "^1.429.0",
 		"windmill-parser-wasm-py": "^1.477.1",
-		"windmill-parser-wasm-regex": "^1.478.2",
+		"windmill-parser-wasm-regex": "^1.481.0",
 		"windmill-parser-wasm-rust": "^1.429.0",
 		"windmill-parser-wasm-ts": "^1.429.0",
 		"windmill-parser-wasm-yaml": "^1.429.0",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for `${}` syntax without default in bash parsing and update `windmill-parser-wasm-regex` version.
> 
>   - **Bash Parsing**:
>     - Updated regex in `lib.rs` to support `${}` syntax without default value in bash scripts.
>     - Modified `parse_bash_file()` to handle new capture group for `${}` syntax.
>   - **Dependencies**:
>     - Updated `windmill-parser-wasm-regex` version in `package.json` from `^1.478.2` to `^1.481.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 829b3863b348c90387e848577f92c9b3edeb5ec0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->