### PR TITLE
fix: infinite loop in resource picker

### DIFF
--- a/frontend/src/lib/components/ResourcePicker.svelte
+++ b/frontend/src/lib/components/ResourcePicker.svelte
@@ -41,7 +41,7 @@
 					value: value ?? initialValue,
 					label: value ?? initialValue,
 					type: valueType
-			  }
+				}
 			: undefined
 
 	$: if (value === undefined && initialValue) {
@@ -97,7 +97,9 @@
 
 	$: $workspaceStore && loadResources(resourceType)
 
-	$: dispatch('change', value)
+	let oldValue = value
+	$:  (oldValue !== value) && dispatch('change', (oldValue = value))
+	
 
 	let appConnect: AppConnect
 	let resourceEditor: ResourceEditorDrawer


### PR DESCRIPTION
dispatches event even when value did not change change
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes infinite loop in `ResourcePicker.svelte` by dispatching 'change' event only when `value` changes.
> 
>   - **Behavior**:
>     - Fixes infinite loop in `ResourcePicker.svelte` by dispatching 'change' event only when `value` changes.
>     - Introduces `oldValue` to track previous `value` and compare for changes.
>   - **Code Changes**:
>     - Modifies event dispatch logic in `ResourcePicker.svelte` to use `(oldValue !== value) && dispatch('change', (oldValue = value))`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 480e2acba591bad33de36b17f14c35c56dd8b502. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->