### PR TITLE
fix build gcp

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -95,7 +95,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
-            features=embedding,parquet,openidconnect,jemalloc,license,http_trigger,zip,oauth2,dind,postgres_trigger,mqtt_trigger,gcp_trigger,websocket,smtp,static_frontend,agent_worker_server,all_languages
+            features=embedding,parquet,openidconnect,jemalloc,license,http_trigger,zip,oauth2,dind,postgres_trigger,mqtt_trigger,websocket,smtp,static_frontend,agent_worker_server,all_languages
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DEV_SHA }}
             ${{ steps.meta-public.outputs.tags }}

--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -663,11 +663,11 @@ pub async fn run_server(
                 .nest(
                     "/gcp/w/:workspace_id",
                     {
-                        #[cfg(feature = "gcp_trigger")]
+                        #[cfg(all(feature = "enterprise", feature = "gcp_trigger"))]
                         {
                             gcp_triggers_ee::gcp_push_route_handler()
                         }
-                        #[cfg(not(feature = "gcp_trigger"))]
+                        #[cfg(not(all(feature = "enterprise", feature = "gcp_trigger")))]
                         {
                             Router::new()
                         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix build issue by updating GCP trigger feature flags in workflow and code.
> 
>   - **Behavior**:
>     - Removes `gcp_trigger` from `features` in `.github/workflows/docker-image.yml`.
>     - Updates `run_server()` in `lib.rs` to conditionally include `gcp_triggers_ee::gcp_push_route_handler()` only if both `enterprise` and `gcp_trigger` features are enabled.
>   - **Configuration**:
>     - Modifies feature flag conditions in `lib.rs` for GCP triggers to require both `enterprise` and `gcp_trigger` features.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 877083909e8823042eccf7e273e723123833ec81. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->