### PR TITLE
fix(frontend): prevent faulty time display for 0ms jobs

### DIFF
--- a/frontend/src/lib/components/FlowTimeline.svelte
+++ b/frontend/src/lib/components/FlowTimeline.svelte
@@ -72,7 +72,7 @@
 				}
 
 				if (!isStillRunning) {
-					if (v.started_at && v.duration_ms) {
+					if (v.started_at && v.duration_ms != undefined) {
 						let lmax = v.started_at + v.duration_ms
 						if (!nmax) {
 							nmax = lmax


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes faulty time display for 0ms jobs in `FlowTimeline.svelte` by adjusting condition to handle `duration_ms` correctly.
> 
>   - **Behavior**:
>     - Fixes faulty time display for jobs with `duration_ms` of 0ms in `FlowTimeline.svelte`.
>     - Changes condition from `v.duration_ms` to `v.duration_ms != undefined` to correctly handle 0ms durations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 68c17001897f34a76644d6115e44995520498d80. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->