### PR TITLE
nit app runnable s3 input

### DIFF
--- a/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/StaticInputEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/StaticInputEditor.svelte
@@ -200,8 +200,8 @@
 					bind:this={s3FilePicker}
 					readOnlyMode={false}
 					on:close={(e) => {
-						if (componentInput?.value?.s3) {
-							if (e.detail) {
+						if (e.detail) {
+							if (componentInput) {
 								componentInput.value = e.detail
 							}
 							s3FileUploadRawMode = true

--- a/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/StaticInputEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/StaticInputEditor.svelte
@@ -201,10 +201,12 @@
 					readOnlyMode={false}
 					on:close={(e) => {
 						if (componentInput?.value?.s3) {
+							if (e.detail) {
+								componentInput.value = e.detail
+							}
 							s3FileUploadRawMode = true
 						}
 					}}
-					bind:selectedFileKey={componentInput.value}
 				/>
 			{:else if format?.startsWith('resource-') && (componentInput.value == undefined || typeof componentInput.value == 'string')}
 				<ResourcePicker


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `StaticInputEditor.svelte` to update `componentInput.value` with `e.detail` on `S3FilePicker` close event and remove `bind:selectedFileKey`.
> 
>   - **Behavior**:
>     - In `StaticInputEditor.svelte`, update `componentInput.value` with `e.detail` on `S3FilePicker` `close` event.
>     - Set `s3FileUploadRawMode` to true if `e.detail` is truthy.
>   - **Misc**:
>     - Remove `bind:selectedFileKey` from `S3FilePicker` component.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 33d638362146374a942a4636d4aa6d52bc8369d0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->