### PR TITLE
fix: number input in app multiselect yields NOT_NUMBER

### DIFF
--- a/frontend/src/lib/components/apps/components/inputs/AppMultiSelectV2.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/AppMultiSelectV2.svelte
@@ -42,14 +42,16 @@
 		result: [] as string[]
 	})
 
-	let selectedItems: (string | { value: string; label: any })[] | undefined = [
+	let selectedItems: (number | string | { value: string; label: any })[] | undefined = [
 		...new Set(outputs?.result.peak())
 	] as string[]
 
 	function setResultsFromSelectedItems() {
 		outputs?.result.set([
 			...(selectedItems?.map((item) => {
-				if (typeof item == 'object' && item.value != undefined && item.label != undefined) {
+				if (typeof item == 'number') {
+					return item.toString()
+				} else if (typeof item == 'object' && item.value != undefined && item.label != undefined) {
 					return item?.value ?? `NOT_STRING`
 				} else if (typeof item == 'string') {
 					return item
@@ -80,6 +82,9 @@
 				if (typeof item == 'object' && item.value != undefined && item.label != undefined) {
 					return item
 				}
+				if (typeof item == 'number') {
+					return item.toString()
+				}
 				return typeof item === 'string' ? item : `NOT_STRING`
 			})
 		}
@@ -97,11 +102,13 @@
 								return deepEqual(item.value, value)
 							}
 							return item == value
-						}) ?? (typeof value == 'string' ? value : undefined)
+						}) ??
+						(typeof value == 'string' ? value : undefined) ??
+						(typeof value == 'number' ? value.toString() : undefined)
 					)
 				})
 				.filter((item) => item != undefined)
-			selectedItems = [...new Set(nvalue)] as (string | { value: string; label: any })[]
+			selectedItems = [...new Set(nvalue)]
 			setResultsFromSelectedItems()
 		}
 	}
@@ -215,7 +222,7 @@
 						e.target?.['parentElement']?.dispatchEvent(newe)
 					}}
 				>
-					{typeof option == 'object' ? option?.label ?? 'NO_LABEL' : option}
+					{typeof option == 'object' ? (option?.label ?? 'NO_LABEL') : option}
 				</div>
 			</MultiSelect>
 			<Portal name="app-multiselect-v2">

--- a/frontend/src/lib/components/apps/components/inputs/AppMultiSelectV2.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/AppMultiSelectV2.svelte
@@ -44,7 +44,7 @@
 
 	let selectedItems: (number | string | { value: string; label: any })[] | undefined = [
 		...new Set(outputs?.result.peak())
-	] as string[]
+	] as (number | string | { value: string; label: any })[]
 
 	function setResultsFromSelectedItems() {
 		outputs?.result.set([


### PR DESCRIPTION
yields NOT_NUMBER when entering a number in a Multi Select that has no default values
https://github.com/windmill-labs/windmill/issues/5602
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `NOT_NUMBER` error in `AppMultiSelectV2.svelte` by converting numbers to strings in multi-select inputs.
> 
>   - **Behavior**:
>     - Fixes issue in `AppMultiSelectV2.svelte` where entering a number in a multi-select input without default values resulted in `NOT_NUMBER`.
>     - Numbers are now converted to strings in `setResultsFromSelectedItems()` and `setSelectedItemsFromValues()` functions.
>   - **Code Changes**:
>     - Updates `selectedItems` to include `number` type.
>     - Modifies logic in `setResultsFromSelectedItems()` to handle `number` type by converting to string.
>     - Adjusts `setSelectedItemsFromValues()` to convert numbers to strings when setting `selectedItems`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for a34193d972dce2f508fdd05ad6e6a5d4275d6885. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->