### PR TITLE
fix: Change port for indexer (to remove collision with prometheus)

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -12,7 +12,7 @@
         bind {$ADDRESS}
         reverse_proxy /ws/* http://lsp:3001
         # reverse_proxy /ws_mp/* http://multiplayer:3002
-        # reverse_proxy /api/srch/* http://windmill_indexer:8001
+        # reverse_proxy /api/srch/* http://windmill_indexer:8002
         reverse_proxy /* http://windmill_server:8000
         # tls /certs/cert.pem /certs/key.pem
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,9 +135,9 @@ services:
       replicas: 0 # set to 1 to enable full-text job and log search
     restart: unless-stopped
     expose:
-      - 8001
+      - 8002
     environment:
-      - PORT=8001
+      - PORT=8002
       - DATABASE_URL=${DATABASE_URL}
       - MODE=indexer
     depends_on:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `windmill_indexer` port from `8001` to `8002` in `Caddyfile` and `docker-compose.yml` to avoid collision with Prometheus.
> 
>   - **Port Change**:
>     - Update `Caddyfile` to change `windmill_indexer` reverse proxy port from `8001` to `8002`.
>     - Update `docker-compose.yml` to change `windmill_indexer` exposed port and environment `PORT` from `8001` to `8002`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 2d110e47d06952bf90e94e3fc90f37d450030a34. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->