### PR TITLE
replace on click wt on pointer down on flow node click

### DIFF
--- a/frontend/src/lib/components/flows/map/FlowModuleSchemaItem.svelte
+++ b/frontend/src/lib/components/flows/map/FlowModuleSchemaItem.svelte
@@ -203,7 +203,7 @@
 	style="width: 275px; height: 38px; background-color: {bgColor};"
 	on:mouseenter={() => (hover = true)}
 	on:mouseleave={() => (hover = false)}
-	on:click|preventDefault|stopPropagation
+	on:pointerdown|preventDefault|stopPropagation
 >
 	<div class="absolute text-sm right-12 -bottom-3 flex flex-row gap-1 z-10">
 		{#if retry}

--- a/frontend/src/lib/components/flows/map/MapItem.svelte
+++ b/frontend/src/lib/components/flows/map/MapItem.svelte
@@ -122,7 +122,7 @@
 					on:changeId
 					on:move={() => dispatch('move')}
 					on:delete={onDelete}
-					on:click={() => dispatch('select', mod.id)}
+					on:pointerdown={() => dispatch('select', mod.id)}
 					on:updateMock={({ detail }) => {
 						mod.mock = detail
 						dispatch('updateMock')
@@ -148,7 +148,7 @@
 					on:changeId
 					on:delete={onDelete}
 					on:move={() => dispatch('move')}
-					on:click={() => dispatch('select', mod.id)}
+					on:pointerdown={() => dispatch('select', mod.id)}
 					{...itemProps}
 					id={mod.id}
 					label={mod.summary || 'Run one branch'}
@@ -165,7 +165,7 @@
 					on:changeId
 					on:delete={onDelete}
 					on:move={() => dispatch('move')}
-					on:click={() => dispatch('select', mod.id)}
+					on:pointerdown={() => dispatch('select', mod.id)}
 					id={mod.id}
 					{...itemProps}
 					label={mod.summary || `Run all branches${mod.value.parallel ? ' (parallel)' : ''}`}
@@ -180,7 +180,7 @@
 					{retries}
 					{editMode}
 					on:changeId
-					on:click={() => dispatch('select', mod.id)}
+					on:pointerdown={() => dispatch('select', mod.id)}
 					on:delete={onDelete}
 					on:move={() => dispatch('move')}
 					on:updateMock={({ detail }) => {
@@ -196,8 +196,8 @@
 						(mod.id === 'preprocessor'
 							? 'Preprocessor'
 							: mod.id.startsWith('failure')
-							? 'Error Handler'
-							: undefined) ||
+								? 'Error Handler'
+								: undefined) ||
 						(`path` in mod.value ? mod.value.path : undefined) ||
 						(mod.value.type === 'rawscript'
 							? `Inline ${prettyLanguage(mod.value.language)}`

--- a/frontend/src/lib/components/flows/map/VirtualItemWrapper.svelte
+++ b/frontend/src/lib/components/flows/map/VirtualItemWrapper.svelte
@@ -33,7 +33,7 @@
 		onTop ? 'z-[901]' : ''
 	)}
 	style="width: 275px; max-height: 38px; background-color: {bgColor} !important;"
-	on:click={() => {
+	on:pointerdown={() => {
 		if (selectable) {
 			if (id) {
 				dispatch('select', id)

--- a/frontend/src/lib/components/graph/renderers/triggers/TriggersWrapper.svelte
+++ b/frontend/src/lib/components/graph/renderers/triggers/TriggersWrapper.svelte
@@ -25,7 +25,7 @@
 		class="flex w-full flex-row gap-1 px-2 p-1 items-center {selected
 			? 'outline  outline-2  outline-gray-600 rounded-sm dark:bg-white/5 dark:outline-gray-400'
 			: ''}"
-		on:click={() => {
+		on:pointerdown={() => {
 			dispatch('select')
 		}}
 	>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replace `on:click` with `on:pointerdown` in Svelte components to improve interaction handling.
> 
>   - **Event Handling**:
>     - Replace `on:click` with `on:pointerdown` in `FlowModuleSchemaItem.svelte`, `MapItem.svelte`, `VirtualItemWrapper.svelte`, and `TriggersWrapper.svelte`.
>     - Ensures `preventDefault` and `stopPropagation` are used with `on:pointerdown` where applicable.
>   - **Components Affected**:
>     - `FlowModuleSchemaItem.svelte`: Handles node selection and interaction.
>     - `MapItem.svelte`: Manages module selection and dispatches events.
>     - `VirtualItemWrapper.svelte`: Handles selection logic for virtual items.
>     - `TriggersWrapper.svelte`: Manages trigger selection and interaction.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 6cdcd57be0792de0aa893748e3ba3414437eb323. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->