### PR TITLE
fix(frontend): ensure schedule is deployed before editing or open advanced tab

### DIFF
--- a/frontend/src/lib/components/RunPageSchedules.svelte
+++ b/frontend/src/lib/components/RunPageSchedules.svelte
@@ -92,7 +92,7 @@
 									right: 'Enabled'
 								}}
 								on:change={async (e) => {
-									if (!newItem) {
+									if (!newItem && $initialPrimarySchedule != false) {
 										await ScheduleService.setScheduleEnabled({
 											path: path,
 											workspace: $workspaceStore ?? '',
@@ -143,7 +143,7 @@
 			<p class="text-xs text-tertiary mt-10">Define a schedule frequency first</p>
 		{/if}
 
-		{#if $initialPrimarySchedule != false}
+		{#if $initialPrimarySchedule != false && !newItem}
 			<div class="flex">
 				<Button size="xs" color="light" on:click={() => scheduleEditor?.openEdit(path, isFlow)}
 					>Advanced</Button


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Restrict schedule editing and advanced options in `RunPageSchedules.svelte` to when a schedule is deployed.
> 
>   - **Behavior**:
>     - In `RunPageSchedules.svelte`, restrict enabling schedule toggle and opening advanced tab to when `$initialPrimarySchedule` is not `false` and `newItem` is `false`.
>     - Ensure schedule is deployed before allowing edits or opening advanced options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for b66288651281fe864232d99eb1a3661f07d09687. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->