### PR TITLE
fix popover stuck on screen when clicking outside in fullscreen mode

### DIFF
--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -681,7 +681,7 @@ async fn list_selected_job_groups(
                 SELECT jsonb_build_object(
                     'script_hash', LPAD(TO_HEX(COALESCE(s.hash, f.id)), 16, '0'),
                     'job_ids', ARRAY_AGG(DISTINCT j.id),
-                    'schema', ANY_VALUE(COALESCE(s.schema, f.schema))
+                    'schema', (ARRAY_AGG(COALESCE(s.schema, f.schema)))[1]
                 ) FROM v2_job j
                 LEFT JOIN script s ON s.hash = j.runnable_id AND j.kind = 'script'
                 LEFT JOIN flow_version f ON f.id = j.runnable_id AND j.kind = 'flow'

--- a/frontend/src/lib/components/meltComponents/Popover.svelte
+++ b/frontend/src/lib/components/meltComponents/Popover.svelte
@@ -115,7 +115,8 @@
 	}}
 	on:pointerdown_outside={() => {
 		if (usePointerDownOutside) {
-			close()
+			if (fullScreen) fullScreen = false
+			else close()
 		}
 	}}
 	data-popover


### PR DESCRIPTION
- **replace on click wt on pointer down on flow node click**
- **pointerdown on virtualitems**
- **Load monaco async with a placeholder to avoid size flash**
- **monaco placeholder for editor**
- **less flashing**
- **simulate first line bg**
- **better match to monaco**
- **more fine tune**
- **fix for increased browser font sizes**
- **flow nodes feel much better to click on**
- **move setTimeout upwards**
- **only load async in flow editor**
- **load async monaco in app**
- **lots of components dont respect the type and pass undefined**
- **weird outline when opening and closing OutputPicker**
- **fixed hover flow nodes**
- **first fix**

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix popover behavior in fullscreen mode and adjust SQL schema selection logic.
> 
>   - **Behavior**:
>     - In `Popover.svelte`, update `on:pointerdown_outside` to exit fullscreen mode before closing the popover if `usePointerDownOutside` is true.
>     - Modify SQL query in `jobs.rs` to select the first schema from aggregated results instead of any value.
>   - **UI Components**:
>     - Adjust `Popover.svelte` to handle fullscreen exit on outside click.
>   - **SQL**:
>     - Change in `jobs.rs` to fix schema selection in `list_selected_job_groups()` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for b0491bd1e77b7db4090e32a81c91da32bb5a3a10. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->