### PR TITLE
fix click outside popover fullscreen

### DIFF
--- a/frontend/src/lib/components/meltComponents/Popover.svelte
+++ b/frontend/src/lib/components/meltComponents/Popover.svelte
@@ -115,7 +115,8 @@
 	}}
 	on:pointerdown_outside={() => {
 		if (usePointerDownOutside) {
-			close()
+			if (fullScreen) fullScreen = false
+			else close()
 		}
 	}}
 	data-popover


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `Popover.svelte` to exit fullscreen mode before closing on outside click.
> 
>   - **Behavior**:
>     - In `Popover.svelte`, modify `on:pointerdown_outside` to exit fullscreen mode before closing the popover.
>     - Handles case where `fullScreen` is true by setting it to false instead of closing immediately.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f1e89c416d4096eec1d2c851acef05ce6a2f872f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->