### PR TITLE
feat: add old row postgres trigger

### DIFF
--- a/backend/windmill-api/src/postgres_triggers/mapper.rs
+++ b/backend/windmill-api/src/postgres_triggers/mapper.rs
@@ -124,11 +124,13 @@ export async function main(
   transaction_type: "insert" | "update" | "delete",
   schema_name: string,
   table_name: string,
-  row: {}
+  row: {},
+  old_row?: {}
 ) {{
 }}
     "#,
-            struct_definition
+            &struct_definition,
+            &struct_definition
         )
     }
 }

--- a/backend/windmill-api/src/postgres_triggers/relation.rs
+++ b/backend/windmill-api/src/postgres_triggers/relation.rs
@@ -47,7 +47,7 @@ impl RelationConverter {
             .ok_or(RelationConversionError::FailToFindMatchingTable)
     }
 
-    pub fn body_to_json(
+    pub fn row_to_json(
         &self,
         to_decode: (Oid, Vec<TupleData>),
     ) -> Result<Map<String, Value>, RelationConversionError> {

--- a/backend/windmill-api/src/postgres_triggers/trigger.rs
+++ b/backend/windmill-api/src/postgres_triggers/trigger.rs
@@ -650,37 +650,79 @@ async fn listen_to_transactions(
                                                     None
                                                 }
                                                 Insert(insert) => {
-                                                    Some((insert.o_id, relations.body_to_json((insert.o_id, insert.tuple)), "insert"))
+                                                    Some((insert.o_id, Ok(None), relations.row_to_json((insert.o_id, insert.tuple)), "insert"))
                                                 }
                                                 Update(update) => {
-                                                    Some((update.o_id, relations.body_to_json((update.o_id, update.new_tuple)), "update"))
+                                                    let old_row = update.old_tuple.map(|old_tuple| relations.row_to_json((update.o_id, old_tuple))).transpose();
+                                                    let row = relations.row_to_json((update.o_id, update.new_tuple));
+                                                    Some((update.o_id, old_row, row, "update"))
                                                 }
                                                 Delete(delete) => {
-                                                    let body = delete.old_tuple.unwrap_or_else(|| delete.key_tuple.unwrap());
-                                                    Some((delete.o_id, relations.body_to_json((delete.o_id, body)), "delete"))
+                                                    let row = delete.old_tuple.unwrap_or_else(|| delete.key_tuple.unwrap());
+                                                    Some((delete.o_id, Ok(None), relations.row_to_json((delete.o_id, row)), "delete"))
                                                 }
                                             };
-                                            if let Some((o_id, Ok(body), transaction_type)) = json {
-                                                let relation = match relations.get_relation(o_id) {
-                                                    Ok(relation) => relation,
-                                                    Err(err) => {
-                                                        tracing::error!("Postgres trigger named: {}, error: {}", pg.get_path(), err.to_string());
-                                                        continue;
+                                            match json {
+                                                Some((o_id, Ok(old_row), Ok(row), transaction_type)) => {
+                                                    let relation = match relations.get_relation(o_id) {
+                                                        Ok(relation) => relation,
+                                                        Err(err) => {
+                                                            tracing::error!("Postgres trigger named: {}, error: {}", pg.get_path(), err.to_string());
+                                                            continue;
+                                                        }
+                                                    };
+                                                    let database_info = HashMap::from([
+                                                        ("schema_name".to_string(), to_raw_value(&relation.namespace)),
+                                                        ("table_name".to_string(), to_raw_value(&relation.name)),
+                                                        ("transaction_type".to_string(), to_raw_value(&transaction_type)),
+                                                        ("old_row".to_string(), to_raw_value(&old_row)),
+                                                        ("row".to_string(), to_raw_value(&row)),
+                                                    ]);
+                                                    let extra = Some(HashMap::from([(
+                                                        "wm_trigger".to_string(),
+                                                        to_raw_value(&serde_json::json!({"kind": "postgres", })),
+                                                    )]));
+    
+    
+                                                    let _ = pg.handle(&db, Some(database_info), extra).await;
+                                                }
+                                                Some((o_id, old_row, row, transaction_type)) => {
+                                                    let relation = match relations.get_relation(o_id) {
+                                                        Ok(relation) => relation,
+                                                        Err(err) => {
+                                                            tracing::error!("Postgres trigger named: {}, error: {}", pg.get_path(), err.to_string());
+                                                            continue;
+                                                        }
+                                                    };
+                                                
+                                                    if let Err(err) = old_row {
+                                                        tracing::error!(
+                                                            transaction_type = ?transaction_type,
+                                                            schema = %relation.namespace,
+                                                            table = %relation.name,
+                                                            error = %err,
+                                                            "Failed to decode OLD row for {} transaction on {}.{}",
+                                                            transaction_type,
+                                                            relation.namespace,
+                                                            relation.name,
+                                                        );
                                                     }
-                                                };
-                                                let database_info = HashMap::from([
-                                                    ("schema_name".to_string(), to_raw_value(&relation.namespace)),
-                                                    ("table_name".to_string(), to_raw_value(&relation.name)),
-                                                    ("transaction_type".to_string(), to_raw_value(&transaction_type)),
-                                                    ("row".to_string(), to_raw_value(&body)),
-                                                ]);
-                                                let extra = Some(HashMap::from([(
-                                                    "wm_trigger".to_string(),
-                                                    to_raw_value(&serde_json::json!({"kind": "postgres", })),
-                                                )]));
-
-
-                                                let _ = pg.handle(&db, Some(database_info), extra).await;
+                                                    
+                                                    if let Err(err) = row {
+                                                        tracing::error!(
+                                                            transaction_type = ?transaction_type,
+                                                            schema = %relation.namespace,
+                                                            table = %relation.name,
+                                                            error = %err,
+                                                            "Failed to decode NEW row for {} transaction on {}.{}",
+                                                            transaction_type,
+                                                            relation.namespace,
+                                                            relation.name,
+                                                        );
+                                                    }
+                                                    
+                                                }
+                                                _ => {}
                                             }
 
                                         }

--- a/frontend/src/lib/script_helpers.ts
+++ b/frontend/src/lib/script_helpers.ts
@@ -634,7 +634,7 @@ export const TS_PREPROCESSOR_SCRIPT_INTRO = `/**
  * The preprocessor receives trigger metadata (\`wm_trigger\`) along with the main trigger arguments. 
  * The structure of \`wm_trigger\` and the main trigger arguments are specific to each trigger type:
  * - Webhook/HTTP: \`(wm_trigger: { kind: 'http' | 'webhook', http?: { ... } }, body_key_1: any, body_key_2: any, ...)\`
- * - Postgres: \`(wm_trigger: { kind: 'postgres' }, transaction_type: string, schema_name: string, table_name: string, row: any)\`
+ * - Postgres: \`(wm_trigger: { kind: 'postgres' }, transaction_type: string, schema_name: string, table_name: string, old_row?: any, row: any)\`
  * - WebSocket/Kafka/NATS/SQS: \`(wm_trigger: { kind: 'websocket' | 'kafka' | 'nats' | 'sqs', [kind]: { ... } }, msg: string)\`
  * - MQTT: \`(wm_trigger: { kind: 'mqtt', [kind]: { ... } }, payload: Array<number>)\`
  * - GCP: \`(wm_trigger: { kind: 'gcp', [kind]: { ... } }, payload: string)\`
@@ -656,7 +656,7 @@ export const TS_PREPROCESSOR_FLOW_INTRO = `/**
  * The preprocessor receives trigger metadata (\`wm_trigger\`) along with the main trigger arguments. 
  * The structure of \`wm_trigger\` and the main trigger arguments are specific to each trigger type:
  * - Webhook/HTTP: \`(wm_trigger: { kind: 'http' | 'webhook', http?: { ... } }, body_key_1: any, body_key_2: any, ...)\`
- * - Postgres: \`(wm_trigger: { kind: 'postgres' }, transaction_type: string, schema_name: string, table_name: string, row: any)\`
+ * - Postgres: \`(wm_trigger: { kind: 'postgres' }, transaction_type: string, schema_name: string, table_name: string, old_row?: any, row: any)\`
  * - WebSocket/Kafka/NATS/SQS: \`(wm_trigger: { kind: 'websocket' | 'kafka' | 'nats' | 'sqs', [kind]: { ... } }, msg: string)\`
  * - MQTT: \`(wm_trigger: { kind: 'mqtt', [kind]: { ... } }, payload: Array<number>)\`
  * - GCP: \`(wm_trigger: { kind: 'gcp', [kind]: { ... } }, payload: string)\`*
@@ -781,7 +781,7 @@ export const PYTHON_PREPROCESSOR_SCRIPT_INTRO = `# Trigger preprocessor
 # The preprocessor receives trigger metadata (\`wm_trigger\`) along with the main trigger arguments. 
 # The structure of \`wm_trigger\` and the main trigger arguments are specific to each trigger type:
 # - Webhook/HTTP: \`(wm_trigger: { kind: 'http' | 'webhook', http?: { ... } }, body_key_1: any, body_key_2: any, ...)\`
-# - Postgres: \`(wm_trigger: { kind: 'postgres' }, transaction_type: string, schema_name: string, table_name: string, row: any)\`
+# - Postgres: \`(wm_trigger: { kind: 'postgres' }, transaction_type: string, schema_name: string, table_name: string, old_row?: any, row: any)\`
 # - WebSocket/Kafka/NATS/SQS: \`(wm_trigger: { kind: 'websocket' | 'kafka' | 'nats' | 'sqs', [kind]: { ... } }, msg: string)\`
 # - MQTT: \`(wm_trigger: { kind: 'mqtt', [kind]: { ... } }, payload: Array<number>)\`
 # - GCP: \`(wm_trigger: { kind: 'gcp', [kind]: { ... } }, payload: string)\`
@@ -801,7 +801,7 @@ export const PYTHON_PREPROCESSOR_FLOW_INTRO = `# Trigger preprocessor
 # The preprocessor receives the same data the flow would if no preprocessor was used,
 # plus trigger metadata in the \`wm_trigger\` object:
 # - Webhook/HTTP: \`(wm_trigger: { kind: 'http' | 'webhook', http?: { ... } }, body_key_1: any, body_key_2: any, ...)\`
-# - Postgres: \`(wm_trigger: { kind: 'postgres' }, transaction_type: string, schema_name: string, table_name: string, row: any)\`
+# - Postgres: \`(wm_trigger: { kind: 'postgres' }, transaction_type: string, schema_name: string, table_name: string, old_row?:any, row: any)\`
 # - WebSocket/Kafka/NATS/SQS: \`(wm_trigger: { kind: 'websocket' | 'kafka' | 'nats' | 'sqs', [kind]: { ... } }, msg: string)\`
 # - MQTT: \`(wm_trigger: { kind: 'mqtt', [kind]: { ... } }, payload: Array<number>)\`
 # - GCP: \`(wm_trigger: { kind: 'gcp', [kind]: { ... } }, payload: string)\`


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `old_row` support to Postgres triggers for capturing previous row state during updates, with updates to backend logic and frontend documentation.
> 
>   - **Behavior**:
>     - Add `old_row` parameter to Postgres triggers in `mapper.rs` and `trigger.rs` to capture previous row state during updates.
>     - Update `listen_to_transactions()` in `trigger.rs` to handle `old_row` for update operations.
>   - **Functions**:
>     - Rename `body_to_json()` to `row_to_json()` in `relation.rs` to reflect new functionality.
>   - **Documentation**:
>     - Update TypeScript and Python preprocessor comments in `script_helpers.ts` to include `old_row` in Postgres trigger structure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 72cd1d25845cb87d9bdebf7ee1ff0651cf73dfea. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->