### PR TITLE
fix: allow deleting code context

### DIFF
--- a/frontend/src/lib/components/copilot/chat/ContextElementBadge.svelte
+++ b/frontend/src/lib/components/copilot/chat/ContextElementBadge.svelte
@@ -23,12 +23,11 @@
 	}>()
 </script>
 
-<Popover disablePopup={contextElement.type === 'code' && deletable}>
+<Popover>
 	<svelte:fragment slot="trigger">
 		<div
 			class={twMerge(
-				'border rounded-md px-1 py-0.5 flex flex-row items-center gap-1 text-tertiary text-xs cursor-default hover:bg-surface-hover',
-				contextElement.type === 'code' && deletable ? '' : 'hover:cursor-pointer'
+				'border rounded-md px-1 py-0.5 flex flex-row items-center gap-1 text-tertiary text-xs cursor-default hover:bg-surface-hover hover:cursor-pointer'
 			)}
 			on:mouseenter={() => (showDelete = true)}
 			on:mouseleave={() => (showDelete = false)}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enables deletion of code context elements in `ContextElementBadge.svelte` by modifying `Popover` behavior and cursor interaction.
> 
>   - **Behavior**:
>     - Allows deletion of code context elements in `ContextElementBadge.svelte` by enabling `Popover` for code elements when `deletable`.
>     - Adjusts cursor behavior to always show pointer on hover for context elements.
>   - **UI**:
>     - Removes condition disabling `Popover` for code elements when `deletable`.
>     - Ensures hover effect is consistent across all context elements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for df2a5ef15b72ad0dede9e33abee161c364b99899. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->