### PR TITLE
fix: rename json key in zoom challenge request

### DIFF
--- a/backend/windmill-api/src/http_trigger_auth.rs
+++ b/backend/windmill-api/src/http_trigger_auth.rs
@@ -253,8 +253,8 @@ mod zoom {
     use super::*;
 
     #[derive(Debug, Deserialize)]
-    #[serde(rename_all = "snake_case")]
     struct ZoomPayload {
+        #[serde(rename = "plainToken")]
         plain_token: String,
     }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renames JSON key `plain_token` to `plainToken` in `ZoomPayload` struct for Zoom challenge requests.
> 
>   - **Behavior**:
>     - Renames JSON key `plain_token` to `plainToken` in `ZoomPayload` struct in `http_trigger_auth.rs`.
>     - Affects deserialization of Zoom challenge requests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f261fc241b16058a911d68e79811b3d932ac472a. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->