### PR TITLE
feat: increase url column length of websocket table

### DIFF
--- a/backend/migrations/20250421120705_alter_url_column_length_on_websocket_triggers.down.sql
+++ b/backend/migrations/20250421120705_alter_url_column_length_on_websocket_triggers.down.sql
@@ -1,0 +1,3 @@
+-- Add down migration script here
+ALTER TABLE websocket_trigger
+ALTER COLUMN url TYPE VARCHAR(255);

--- a/backend/migrations/20250421120705_alter_url_column_length_on_websocket_triggers.up.sql
+++ b/backend/migrations/20250421120705_alter_url_column_length_on_websocket_triggers.up.sql
@@ -1,0 +1,3 @@
+-- Add up migration script here
+ALTER TABLE websocket_trigger
+ALTER COLUMN url TYPE VARCHAR(1000);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add migration scripts to change `url` column length in `websocket_trigger` table from 255 to 1000 and back.
> 
>   - **Migrations**:
>     - Add `20250421120705_alter_url_column_length_on_websocket_triggers.up.sql` to increase `url` column length to `VARCHAR(1000)` in `websocket_trigger` table.
>     - Add `20250421120705_alter_url_column_length_on_websocket_triggers.down.sql` to revert `url` column length to `VARCHAR(255)`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 7d55028de0e61edf803aaed15419520a1fc9c479. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->