### PR TITLE
chore: npx sv migrate self-closing-tags

### DIFF
--- a/frontend/src/lib/components/apps/editor/AppJobsDrawer.svelte
+++ b/frontend/src/lib/components/apps/editor/AppJobsDrawer.svelte
@@ -241,7 +241,7 @@
 												{/if}
 											</Splitpanes>
 										{:else}
-											<div class="mt-10" />
+											<div class="mt-10"></div>
 											<FlowProgressBar {job} class="py-4" />
 											<div class="w-full mt-10 mb-20">
 												{#if job?.id}

--- a/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
@@ -701,7 +701,7 @@
 					}}
 				/>
 			</div>
-			<div class="py-2" />
+			<div class="py-2"></div>
 			<Path
 				autofocus={false}
 				bind:this={path}
@@ -712,7 +712,7 @@
 				namePlaceholder="app"
 				kind="app"
 			/>
-			<div class="py-4" />
+			<div class="py-4"></div>
 
 			<div slot="actions">
 				<Button
@@ -732,7 +732,7 @@
 			<Alert title="You're not on the latest app version. " type="warning">
 				By deploying, you may overwrite changes made by other users. Press 'Deploy' to see diff.
 			</Alert>
-			<div class="py-2" />
+			<div class="py-2"></div>
 		{/if}
 		<span class="text-secondary text-sm font-bold">Summary</span>
 		<div class="w-full pt-2">
@@ -757,7 +757,7 @@
 				}}
 			/>
 		</div>
-		<div class="py-4" />
+		<div class="py-4"></div>
 		<span class="text-secondary text-sm font-bold">Deployment message</span>
 		<div class="w-full pt-2">
 			<!-- svelte-ignore a11y-autofocus -->
@@ -768,7 +768,7 @@
 				bind:value={deploymentMsg}
 			/>
 		</div>
-		<div class="py-4" />
+		<div class="py-4"></div>
 		<span class="text-secondary text-sm font-bold">Path</span>
 		<Path
 			bind:this={path}
@@ -838,7 +838,7 @@
 				Deploy
 			</Button>
 		</div>
-		<div class="py-2" />
+		<div class="py-2"></div>
 		{#if appPath == ''}
 			<Alert title="Require saving" type="error">
 				Save this app once before you can publish it
@@ -856,10 +856,10 @@
 				</Tooltip>
 			</Alert>
 
-			<div class="mt-10" />
+			<div class="mt-10"></div>
 
 			<h2>Public URL</h2>
-			<div class="mt-4" />
+			<div class="mt-4"></div>
 
 			<div class="flex gap-2 items-center">
 				<Toggle
@@ -894,12 +894,12 @@
 						<Alert title="EE Only" type="warning" size="xs">
 							Custom path is an enterprise only feature.
 						</Alert>
-						<div class="mb-2" />
+						<div class="mb-2"></div>
 					{:else if !($userStore?.is_admin || $userStore?.is_super_admin)}
 						<Alert type="warning" title="Admin only" size="xs">
 							Custom path can only be set by workspace admins
 						</Alert>
-						<div class="mb-2" />
+						<div class="mb-2"></div>
 					{/if}
 					<Toggle
 						on:change={({ detail }) => {

--- a/frontend/src/lib/components/raw_apps/RawAppInlineScriptEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppInlineScriptEditor.svelte
@@ -109,7 +109,7 @@
 					<div
 						title={validCode ? 'Main function parsable' : 'Main function not parsable'}
 						class="rounded-full !w-2 !h-2 {validCode ? 'bg-green-300' : 'bg-red-300'}"
-					/>
+					></div>
 				</div>
 			{/if}
 			<div class="flex w-full flex-row gap-1 items-center justify-end">

--- a/frontend/src/lib/components/raw_apps/RawAppPreview.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppPreview.svelte
@@ -20,4 +20,4 @@
 	title="raw-app"
 	srcDoc={htmlContent(workspace, version, { ctx: user, workspace })}
 	class="w-full h-full min-h-screen bg-white border-none"
-/>
+></iframe>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Convert self-closing tags to standard closing tags in multiple Svelte components for consistency.
> 
>   - **Syntax Changes**:
>     - Convert self-closing `<div />` to `<div></div>` in `AppJobsDrawer.svelte`.
>     - Convert self-closing `<div />` to `<div></div>` in `RawAppEditorHeader.svelte`.
>     - Convert self-closing `<div />` to `<div></div>` in `RawAppInlineScriptEditor.svelte`.
>     - Convert self-closing `<iframe />` to `<iframe></iframe>` in `RawAppPreview.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f268801cd3eb1977dc70eef2759337f8bdca905b. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->