### PR TITLE
fix: batch reruns query missing workspace_id check in subquery

### DIFF
--- a/backend/.sqlx/query-26761fbd7953416eb391de47b1694e0f4ab2bb96a6d838f1b1fdce4b58a8f5d4.json
+++ b/backend/.sqlx/query-26761fbd7953416eb391de47b1694e0f4ab2bb96a6d838f1b1fdce4b58a8f5d4.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT jsonb_build_object(\n            'kind', jb.kind,\n            'script_path', jb.runnable_path,\n            'latest_schema', COALESCE(\n                (SELECT DISTINCT ON (s.path) s.schema FROM script s WHERE s.workspace_id = $1 AND s.path = jb.runnable_path AND jb.kind = 'script' ORDER BY s.path, s.created_at DESC),\n                (SELECT flow_version.schema FROM flow LEFT JOIN flow_version ON flow_version.id = flow.versions[array_upper(flow.versions, 1)] WHERE flow.workspace_id = $1 AND flow.path = jb.runnable_path AND jb.kind = 'flow')\n            ),\n            'schemas', ARRAY(\n                SELECT jsonb_build_object(\n                    'script_hash', LPAD(TO_HEX(COALESCE(s.hash, f.id)), 16, '0'),\n                    'job_ids', ARRAY_AGG(DISTINCT j.id),\n                    'schema', (ARRAY_AGG(COALESCE(s.schema, f.schema)))[1]\n                ) FROM v2_job j\n                LEFT JOIN script s ON s.hash = j.runnable_id AND j.kind = 'script'\n                LEFT JOIN flow_version f ON f.id = j.runnable_id AND j.kind = 'flow'\n                WHERE j.id = ANY(ARRAY_AGG(jb.id))\n                GROUP BY COALESCE(s.hash, f.id)\n            )\n        ) FROM v2_job jb\n        WHERE (jb.kind = 'flow' OR jb.kind = 'script')\n            AND jb.workspace_id = $1 AND jb.id = ANY($2)\n        GROUP BY jb.kind, jb.runnable_path",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "jsonb_build_object",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "26761fbd7953416eb391de47b1694e0f4ab2bb96a6d838f1b1fdce4b58a8f5d4"
+}

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -674,8 +674,8 @@ async fn list_selected_job_groups(
             'kind', jb.kind,
             'script_path', jb.runnable_path,
             'latest_schema', COALESCE(
-                (SELECT DISTINCT ON (s.path) s.schema FROM script s WHERE s.path = jb.runnable_path AND jb.kind = 'script' ORDER BY s.path, s.created_at DESC),
-                (SELECT flow_version.schema FROM flow LEFT JOIN flow_version ON flow_version.id = flow.versions[array_upper(flow.versions, 1)] WHERE flow.path = jb.runnable_path AND jb.kind = 'flow')
+                (SELECT DISTINCT ON (s.path) s.schema FROM script s WHERE s.workspace_id = $1 AND s.path = jb.runnable_path AND jb.kind = 'script' ORDER BY s.path, s.created_at DESC),
+                (SELECT flow_version.schema FROM flow LEFT JOIN flow_version ON flow_version.id = flow.versions[array_upper(flow.versions, 1)] WHERE flow.workspace_id = $1 AND flow.path = jb.runnable_path AND jb.kind = 'flow')
             ),
             'schemas', ARRAY(
                 SELECT jsonb_build_object(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix missing `workspace_id` check in `list_selected_job_groups()` subquery in `jobs.rs` for correct workspace filtering.
> 
>   - **Behavior**:
>     - Fix missing `workspace_id` check in subquery of `list_selected_job_groups()` in `jobs.rs` to ensure correct filtering by workspace.
>   - **SQL**:
>     - Add new query file `query-26761fbd7953416eb391de47b1694e0f4ab2bb96a6d838f1b1fdce4b58a8f5d4.json` to track the updated query with `workspace_id` check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 3d173d3c7e0aa45892d6b145ce5b8b58ece770d9. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->