### PR TITLE
 fix extraConfig overriding defaultColDef (WIN 1183)

### DIFF
--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -47,7 +47,6 @@
 
 	// Exported
 	export let schema: Schema | any = emptySchema()
-	$: console.log('schema', schema)
 	export let code: string
 	export let path: string | undefined
 	export let lang: Preview['language']

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -47,6 +47,7 @@
 
 	// Exported
 	export let schema: Schema | any = emptySchema()
+	$: console.log('schema', schema)
 	export let code: string
 	export let path: string | undefined
 	export let lang: Preview['language']

--- a/frontend/src/lib/components/apps/components/display/table/AppAggridExplorerTable.svelte
+++ b/frontend/src/lib/components/apps/components/display/table/AppAggridExplorerTable.svelte
@@ -100,6 +100,8 @@
 			oldValue: event.oldValue,
 			columnDef: event.colDef
 		})
+
+		resolvedConfig?.extraConfig?.['defaultColDef']?.['onCellValueChanged']?.(event)
 	}
 
 	let api: GridApi<any> | undefined = undefined
@@ -310,22 +312,13 @@
 					datasource,
 					columnDefs: transformColumnDefs(resolvedConfig?.columnDefs),
 					pagination: false,
-					defaultColDef: {
-						flex: resolvedConfig.flex ? 1 : 0,
-						editable: resolvedConfig?.allEditable,
-						onCellValueChanged
-					},
 					infiniteInitialRowCount: 100,
 					cacheBlockSize: 100,
 					cacheOverflowSize: 10,
 					maxBlocksInCache: 20,
 					...(resolvedConfig?.wrapActions
-						? {
-								rowHeight: Math.max(44, actions.length * 48)
-							}
-						: {
-								rowHeight: 44
-							}),
+						? { rowHeight: Math.max(44, actions.length * 48) }
+						: { rowHeight: 44 }),
 					suppressColumnMoveAnimation: true,
 					suppressDragLeaveHidesColumns: true,
 					rowSelection: resolvedConfig?.multipleSelectable ? 'multiple' : 'single',
@@ -336,6 +329,12 @@
 					suppressRowDeselection: true,
 					enableCellTextSelection: true,
 					...(resolvedConfig?.extraConfig ?? {}),
+					defaultColDef: {
+						flex: resolvedConfig.flex ? 1 : 0,
+						editable: resolvedConfig?.allEditable,
+						onCellValueChanged,
+						...resolvedConfig?.extraConfig?.['defaultColDef']
+					},
 					onViewportChanged: (e) => {
 						firstRow = e.firstRow
 						lastRow = e.lastRow
@@ -415,11 +414,6 @@
 		// console.debug('updateOptions', resolvedConfig, api)
 		api?.updateGridOptions({
 			columnDefs: transformColumnDefs(resolvedConfig?.columnDefs),
-			defaultColDef: {
-				flex: resolvedConfig.flex ? 1 : 0,
-				editable: resolvedConfig?.allEditable,
-				onCellValueChanged
-			},
 			suppressDragLeaveHidesColumns: true,
 			...(resolvedConfig?.wrapActions
 				? {
@@ -432,7 +426,13 @@
 			rowMultiSelectWithClick: resolvedConfig?.multipleSelectable
 				? resolvedConfig.rowMultiselectWithClick
 				: false,
-			...(resolvedConfig?.extraConfig ?? {})
+			...(resolvedConfig?.extraConfig ?? {}),
+			defaultColDef: {
+				flex: resolvedConfig.flex ? 1 : 0,
+				editable: resolvedConfig?.allEditable,
+				onCellValueChanged,
+				...resolvedConfig?.extraConfig?.['defaultColDef']
+			}
 		})
 	}
 </script>

--- a/frontend/src/lib/components/apps/components/display/table/AppAggridTable.svelte
+++ b/frontend/src/lib/components/apps/components/display/table/AppAggridTable.svelte
@@ -191,6 +191,7 @@
 
 			let data = { ...result[event.node.rowIndex] }
 			outputs?.selectedRow?.set(data)
+			resolvedConfig?.extraConfig?.['defaultColDef']?.['onCellValueChanged']?.(event)
 		}
 	}
 
@@ -341,11 +342,6 @@
 						pagination: resolvedConfig?.pagination,
 						paginationAutoPageSize: resolvedConfig?.pagination,
 						suppressPaginationPanel: true,
-						defaultColDef: {
-							flex: resolvedConfig.flex ? 1 : 0,
-							editable: resolvedConfig?.allEditable,
-							onCellValueChanged
-						},
 						rowHeight: resolvedConfig.compactness
 							? rowHeights[resolvedConfig.compactness]
 							: rowHeights['normal'],
@@ -362,6 +358,12 @@
 						suppressDragLeaveHidesColumns: true,
 						enableCellTextSelection: true,
 						...deepCloneWithFunctions(resolvedConfig?.extraConfig ?? {}),
+						defaultColDef: {
+							flex: resolvedConfig.flex ? 1 : 0,
+							editable: resolvedConfig?.allEditable,
+							onCellValueChanged,
+							...resolvedConfig?.extraConfig?.['defaultColDef']
+						},
 						onStateUpdated: (e) => {
 							state = e?.api?.getState()
 							resolvedConfig?.extraConfig?.['onStateUpdated']?.(e)
@@ -492,11 +494,6 @@
 				paginationAutoPageSize: resolvedConfig?.pagination,
 				suppressPaginationPanel: true,
 				suppressDragLeaveHidesColumns: true,
-				defaultColDef: {
-					flex: resolvedConfig.flex ? 1 : 0,
-					editable: resolvedConfig?.allEditable,
-					onCellValueChanged
-				},
 				rowSelection: resolvedConfig?.multipleSelectable ? 'multiple' : 'single',
 				rowMultiSelectWithClick: resolvedConfig?.multipleSelectable
 					? resolvedConfig.rowMultiselectWithClick
@@ -504,7 +501,13 @@
 				rowHeight: resolvedConfig.compactness
 					? rowHeights[resolvedConfig.compactness]
 					: rowHeights['normal'],
-				...deepCloneWithFunctions(resolvedConfig?.extraConfig ?? {})
+				...deepCloneWithFunctions(resolvedConfig?.extraConfig ?? {}),
+				defaultColDef: {
+					flex: resolvedConfig.flex ? 1 : 0,
+					editable: resolvedConfig?.allEditable,
+					onCellValueChanged,
+					...resolvedConfig?.extraConfig?.['defaultColDef']
+				}
 			})
 		} catch (e) {
 			console.error(e)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `extraConfig` overriding `defaultColDef` in ag-Grid components by merging configurations correctly.
> 
>   - **Behavior**:
>     - Fixes issue where `extraConfig` was overriding `defaultColDef` in ag-Grid components.
>     - Merges `defaultColDef` with `extraConfig` in `AppAggridExplorerTable.svelte`, `AppAggridTable.svelte`, and `AppAggridExplorerTable.svelte`.
>     - Ensures `onCellValueChanged` is called from `extraConfig` if defined.
>   - **Misc**:
>     - Adds logging for `schema` in `ScriptEditor.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 509031b9efbc1b418632da37462c12bc18147012. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->