### PR TITLE
fix: Double apply on ai chat

### DIFF
--- a/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
+++ b/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
@@ -22,6 +22,7 @@ export class AIChatEditorHandler {
 
 	reviewingChanges: Writable<boolean> = writable(false)
 	groupChanges: { changes: VisualChangeWithDiffIndex[]; groupIndex: number }[] = []
+	pendingNewCode: string | undefined = undefined
 
 	constructor(editor: meditor.IStandaloneCodeEditor) {
 		this.editor = editor
@@ -29,6 +30,7 @@ export class AIChatEditorHandler {
 
 	clear() {
 		this.groupChanges = []
+		this.pendingNewCode = undefined
 		for (const collection of this.decorationsCollections) {
 			collection.clear()
 		}
@@ -166,6 +168,12 @@ export class AIChatEditorHandler {
 	}
 
 	async reviewAndApply(newCode: string) {
+		if (this.pendingNewCode === newCode) {
+			return
+		} else if (this.pendingNewCode) {
+			this.clear()
+		}
+		this.pendingNewCode = newCode
 		const changedLines = await this.calculateVisualChanges(newCode)
 		if (changedLines.length === 0) return
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes double application of code in AI chat editor by tracking and clearing pending changes in `monaco-adapter.ts`.
> 
>   - **Behavior**:
>     - Prevents double application of the same code in `reviewAndApply()` in `monaco-adapter.ts` by checking `pendingNewCode`.
>     - Clears `pendingNewCode` in `clear()` to reset state.
>   - **State Management**:
>     - Adds `pendingNewCode` property to track the last applied code in `AIChatEditorHandler`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 21f837da4e91760df30a77ef82a235ce1fa90d93. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->