### PR TITLE
fix random infinite loop in flow input

### DIFF
--- a/frontend/src/lib/components/InputTransformForm.svelte
+++ b/frontend/src/lib/components/InputTransformForm.svelte
@@ -246,10 +246,12 @@
 		}
 	}
 
-	let prevArg = structuredClone(arg)
-	$: {
-		if (!deepEqual(arg, prevArg)) {
-			prevArg = structuredClone(arg)
+	let prevArg: any = undefined
+	$: inputCat && propertyType && arg && onArgChange()
+	function onArgChange() {
+		const newArg = { arg, propertyType, inputCat }
+		if (!deepEqual(newArg, prevArg)) {
+			prevArg = structuredClone(newArg)
 			updateStaticInput(inputCat, propertyType, arg)
 		}
 	}

--- a/frontend/src/lib/components/InputTransformForm.svelte
+++ b/frontend/src/lib/components/InputTransformForm.svelte
@@ -36,6 +36,7 @@
 	import type { PickableProperties } from './flows/previousResults'
 	import { twMerge } from 'tailwind-merge'
 	import FlowPlugConnect from './FlowPlugConnect.svelte'
+	import { deepEqual } from 'fast-equals'
 	export let schema: Schema | { properties?: Record<string, any>; required?: string[] }
 	export let arg: InputTransform | any
 	export let argName: string
@@ -245,7 +246,13 @@
 		}
 	}
 
-	$: updateStaticInput(inputCat, propertyType, arg)
+	let prevArg = structuredClone(arg)
+	$: {
+		if (!deepEqual(arg, prevArg)) {
+			prevArg = structuredClone(arg)
+			updateStaticInput(inputCat, propertyType, arg)
+		}
+	}
 
 	function updateStaticInput(
 		inputCat: InputCat,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes infinite loop in `InputTransformForm.svelte` by adding a `deepEqual` check to ensure `updateStaticInput` is only called on actual changes.
> 
>   - **Behavior**:
>     - Fixes infinite loop in `InputTransformForm.svelte` by adding a `deepEqual` check in `onArgChange()` to compare `newArg` and `prevArg`.
>     - Calls `updateStaticInput()` only if `newArg` differs from `prevArg`.
>   - **Functions**:
>     - Adds `deepEqual` import from `fast-equals`.
>     - Introduces `prevArg` variable to store the previous state of `arg`, `propertyType`, and `inputCat`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for d7557306f7001c9ff5aff1ae08253e3e164f2d97. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->