### PR TITLE
fix: Add current workspace if not in workspace list in user settings

### DIFF
--- a/frontend/src/lib/components/settings/TokensTable.svelte
+++ b/frontend/src/lib/components/settings/TokensTable.svelte
@@ -5,7 +5,7 @@
 	import { UserService } from '$lib/gen'
 	import { Button } from '$lib/components/common'
 	import { Clipboard, Plus } from 'lucide-svelte'
-	import { workspaceStore, userWorkspaces } from '$lib/stores'
+	import { workspaceStore, userWorkspaces, type UserWorkspace } from '$lib/stores'
 	import { createEventDispatcher } from 'svelte'
 	import ToggleButtonGroup from '../common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import ToggleButton from '../common/toggleButton-v2/ToggleButton.svelte'
@@ -42,6 +42,21 @@
 	let newMcpScope = $state('favorites')
 	let newMcpToken = $state<string | undefined>(undefined)
 
+	function ensureCurrentWorkspaceIncluded(
+		workspacesList: UserWorkspace[],
+		currentWorkspace: string | undefined
+	) {
+		if (!currentWorkspace) {
+			return workspacesList
+		}
+		const hasCurrentWorkspace = workspacesList.some((w) => w.id === currentWorkspace)
+		if (hasCurrentWorkspace) {
+			return workspacesList
+		}
+		return [{ id: currentWorkspace, name: currentWorkspace }, ...workspacesList]
+	}
+
+	const workspaces = $derived(ensureCurrentWorkspaceIncluded($userWorkspaces, $workspaceStore))
 	const mcpBaseUrl = $derived(`${window.location.origin}/api/mcp/w/${newTokenWorkspace}/sse?token=`)
 	const dispatch = createEventDispatcher()
 
@@ -221,8 +236,8 @@
 					</div>
 					<div class="flex flex-col">
 						<label for="label">Workspace</label>
-						<select bind:value={newTokenWorkspace} disabled={$userWorkspaces.length === 1}>
-							{#each $userWorkspaces as workspace}
+						<select bind:value={newTokenWorkspace} disabled={workspaces.length === 1}>
+							{#each workspaces as workspace}
 								<option value={workspace.id}>{workspace.name}</option>
 							{/each}
 						</select>

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -28,6 +28,14 @@ export interface UserExt {
 	folders_owners: string[]
 }
 
+export interface UserWorkspace {
+	id: string
+	name: string
+	username: string
+	color: string | null
+	operator_settings?: OperatorSettings
+}
+
 const persistedWorkspace = BROWSER && getWorkspace()
 
 function getWorkspace(): string | undefined {
@@ -60,31 +68,26 @@ export const superadmin = writable<string | false | undefined>(undefined)
 export const devopsRole = writable<string | false | undefined>(undefined)
 export const lspTokenStore = writable<string | undefined>(undefined)
 export const hubBaseUrlStore = writable<string>('https://hub.windmill.dev')
-export const userWorkspaces: Readable<
-	Array<{
-		id: string
-		name: string
-		username: string
-		color: string | null
-		operator_settings?: OperatorSettings
-	}>
-> = derived([usersWorkspaceStore, superadmin], ([store, superadmin]) => {
-	const originalWorkspaces = store?.workspaces ?? []
-	if (superadmin) {
-		return [
-			...originalWorkspaces.filter((x) => x.id != 'admins'),
-			{
-				id: 'admins',
-				name: 'Admins',
-				username: 'superadmin',
-				color: null,
-				operator_settings: null
-			}
-		]
-	} else {
-		return originalWorkspaces
+export const userWorkspaces: Readable<Array<UserWorkspace>> = derived(
+	[usersWorkspaceStore, superadmin],
+	([store, superadmin]) => {
+		const originalWorkspaces = store?.workspaces ?? []
+		if (superadmin) {
+			return [
+				...originalWorkspaces.filter((x) => x.id != 'admins'),
+				{
+					id: 'admins',
+					name: 'Admins',
+					username: 'superadmin',
+					color: null,
+					operator_settings: null
+				}
+			]
+		} else {
+			return originalWorkspaces
+		}
 	}
-})
+)
 export const copilotInfo = writable<{
 	enabled: boolean
 	codeCompletionModel?: AIProviderModel


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensures current workspace is included in workspace list for token creation in `TokensTable.svelte`.
> 
>   - **Behavior**:
>     - Adds `ensureCurrentWorkspaceIncluded()` in `TokensTable.svelte` to include current workspace in `workspaces` if missing.
>     - Updates workspace dropdown in `TokensTable.svelte` to use `workspaces` instead of `$userWorkspaces`.
>   - **Stores**:
>     - Introduces `UserWorkspace` interface in `stores.ts` for better type management.
>     - Refactors `userWorkspaces` in `stores.ts` to use `UserWorkspace` type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for dbd312a88aebc89580654bf1a2addba772111cf9. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->