### PR TITLE
fix: make `#(extra_)requirements:` work better with pins

### DIFF
--- a/backend/tests/worker.rs
+++ b/backend/tests/worker.rs
@@ -4004,10 +4004,11 @@ async fn test_pins_python(db: Pool<Postgres>) {
 # py311
 # extra_requirements:
 # tiny==0.1.3
+# bottle==0.13.2
 
 import f.system.requirements
 import f.system.pins
-import tiny # repin: bottle==0.13.0
+import tiny # repin: tiny==0.1.3
 import simplejson
 
 def main():
@@ -4021,7 +4022,7 @@ def main():
         ScriptLang::Python3,
         vec![
             "# py311",
-            "bottle==0.13.0",
+            "bottle==0.13.2",
             "microdot==2.2.0",
             "simplejson==3.19.3",
             "tiny==0.1.3",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve Python import parsing to better handle pinned and repinned package requirements, with updated regex and import resolution logic.
> 
>   - **Behavior**:
>     - Update `PKG_RE` regex in `lib.rs` to include `!` in package name matching.
>     - Modify `parse_python_imports` in `lib.rs` to handle `NImportResolved::Auto` with optional `key`.
>   - **Import Handling**:
>     - Change `NImportResolved::Repin` and `NImportResolved::Pin` handling in `parse_python_imports_inner` in `lib.rs`.
>     - Update `parse_python_imports_inner` to use `NImportResolved::Pin` for `extra_requirements`.
>   - **Tests**:
>     - Update `test_pins_python` in `worker.rs` to reflect changes in pin handling.
>     - Adjust expected results for `bottle` and `tiny` versions in `test_pins_python`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 8be41531cd4c19c9e23846b92768a79ca3ab1de0. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->