### PR TITLE
nit(python): add virustotal to imports mapping

### DIFF
--- a/backend/parsers/windmill-parser-py-imports/src/mapping.rs
+++ b/backend/parsers/windmill-parser-py-imports/src/mapping.rs
@@ -376,5 +376,6 @@ pub static SHORT_IMPORTS_MAP: PyMap = phf_map! {
     "socks" => "PySocks",
     "taiga" => "python-taiga",
     "docx" => "python-docx",
+    "vt" => "vt-py",
     // Add new entry here ^
 };


### PR DESCRIPTION
Add mapping of `vt` (see [quickstart](https://virustotal.github.io/vt-py/quickstart.html)) as `vt-py` (see [install](https://virustotal.github.io/vt-py/howtoinstall.html)) to imports mapping.

This does not conflict with the existing `vt` package (see [pip](https://pypi.org/project/vt/)) as this package has been handed over to VirusTotal (see `vt` [owner statement](https://github.com/doomedraven/VirusTotalApi/blob/86f8590d80df8e76b6ccac671f25cce3ee00fbec/README.md?plain=1#L4)).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `vt` to `vt-py` mapping in `SHORT_IMPORTS_MAP` to support VirusTotal's package.
> 
>   - **Mapping Update**:
>     - Add `vt` to `vt-py` mapping in `SHORT_IMPORTS_MAP` in `mapping.rs`.
>     - Ensures compatibility with VirusTotal's `vt-py` package, avoiding conflict with the `vt` package.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f946f021f81f86a13ae4a765e20ff676f88af31b. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->