### PR TITLE
extra logging for agent_token flake

### DIFF
--- a/integration_tests/test/agent_workers.py
+++ b/integration_tests/test/agent_workers.py
@@ -163,6 +163,7 @@ class TestAgentWorkers(unittest.TestCase):
 
     def test_create_agent_token(self):
         token = self._agent_token
+        print(f"Agent token tests for token: {token}")
         self.assertIsNotNone(token)
 
         # JWT tokens have the format: jwt_agent_<prefix>_<token>

--- a/integration_tests/test/wmill_integration_test_utils.py
+++ b/integration_tests/test/wmill_integration_test_utils.py
@@ -415,5 +415,5 @@ class WindmillClient:
             raise Exception(response.content.decode())
 
         token = response.content.decode().strip('"')
-        print(f"Created agent token: {token[:15]}...{token[-15:]}")
+        print(f"Created agent token: {token}")
         return token


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add detailed logging for agent token creation and testing in integration tests.
> 
>   - **Logging**:
>     - Add logging in `test_create_agent_token()` in `agent_workers.py` to print the full agent token.
>     - Modify logging in `create_agent_token()` in `wmill_integration_test_utils.py` to print the full agent token instead of a truncated version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 1844fa5d38b2b2e2c26274e028744fe1315b5d1e. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->