### PR TITLE
nit: fix error if db oversize checker is disabled

### DIFF
--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -2213,7 +2213,9 @@ pub async fn reload_critical_error_channels_setting(conn: &DB) -> error::Result<
 pub async fn reload_critical_alerts_on_db_oversize(conn: &DB) -> error::Result<()> {
     #[derive(Deserialize)]
     struct DBOversize {
+        #[serde(default)]
         enabled: bool,
+        #[serde(default)]
         value: f32,
     }
     let db_oversize_value =


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes potential error in `reload_critical_alerts_on_db_oversize` by adding default values for `DBOversize` fields in `monitor.rs`.
> 
>   - **Behavior**:
>     - Fixes potential error in `reload_critical_alerts_on_db_oversize` in `monitor.rs` by adding default values for `enabled` and `value` fields in `DBOversize` struct.
>     - Ensures no error occurs if `enabled` or `value` is missing in configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 3341265be143fb5b7faf92d04b58d519dba65949. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->