### PR TITLE
fix: add back missing query args from http trigger object + correct wm_trigger shape

### DIFF
--- a/backend/windmill-api/src/http_trigger_args.rs
+++ b/backend/windmill-api/src/http_trigger_args.rs
@@ -158,9 +158,10 @@ impl HttpTriggerArgs {
         wrap_body: bool,
     ) -> Result<PushArgsOwned, Error> {
         let mut extra = HashMap::new();
-
-        extra.insert(
-            "wm_trigger".to_string(),
+        let mut wm_trigger = HashMap::new();
+        wm_trigger.insert("kind".to_string(), to_raw_value(&"http".to_string()));
+        wm_trigger.insert(
+            "http".to_string(),
             to_raw_value(&HttpTriggerWmTrigger {
                 route: route_path,
                 path: called_path,
@@ -170,6 +171,7 @@ impl HttpTriggerArgs {
                 headers: &self.0.metadata.headers,
             }),
         );
+        extra.insert("wm_trigger".to_string(), to_raw_value(&wm_trigger));
 
         let mut args = self.to_main_args(wrap_body)?;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes query argument handling for HTTP triggers and corrects `wm_trigger` shape in `HttpTriggerArgs`.
> 
>   - **Behavior**:
>     - `DecodeQueries::from_uri` now accepts `is_http_trigger` to correctly handle query args for HTTP triggers in `args.rs`.
>     - Corrects `wm_trigger` shape in `HttpTriggerArgs::to_v1_preprocessor_args` in `http_trigger_args.rs` to include `kind` and `http` fields.
>   - **Functions**:
>     - Updates `DecodeQueries::from_uri` to conditionally parse queries based on `is_http_trigger`.
>     - Modifies `HttpTriggerArgs::to_v1_preprocessor_args` to build `wm_trigger` with `kind` and `http` fields.
>   - **Misc**:
>     - Adjusts `try_from_request_body` in `args.rs` to pass `is_http_trigger` to `DecodeQueries::from_uri`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 2898202c985adeca1d5e9ddf095eb259a9c5968e. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->