### PR TITLE
fix: remove duplicate in cursor rules

### DIFF
--- a/.cursor/rules/rust-best-practices.mdc
+++ b/.cursor/rules/rust-best-practices.mdc
@@ -3,10 +3,6 @@ description:
 globs: backend/**/*.rs
 alwaysApply: false
 ---
----
-description: Rust best practices for the Windmill backend, covering code organization, error handling, performance optimizations, and common patterns to follow when adding new code.
-globs: **/*.rs
----
 # Windmill Backend - Rust Best Practices
 
 ## Project Structure


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove duplicate rule entry in `.cursor/rules/rust-best-practices.mdc`.
> 
>   - **Cleanup**:
>     - Removed duplicate rule entry in `.cursor/rules/rust-best-practices.mdc` that had identical description and globs as an existing entry.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for fa756c83a66cfdb6a5303a499f40b863dc9ff883. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->