### PR TITLE
fix: add missing run job transaction drop

### DIFF
--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -4507,6 +4507,7 @@ pub async fn run_wait_result_script_by_path_internal(
     let mut tx = user_db.clone().begin(&authed).await?;
     let (job_payload, tag, delete_after_use, timeout, on_behalf_of) =
         script_path_to_payload(script_path, &mut *tx, &w_id, run_query.skip_preprocessor).await?;
+    drop(tx);
 
     let tag = run_query.tag.clone().or(tag);
     check_tag_available_for_workspace(&w_id, &tag, &authed).await?;
@@ -4727,6 +4728,7 @@ pub async fn run_wait_result_flow_by_path_internal(
         edited_by,
         version,
     } = get_latest_flow_version_info_for_path(&mut *tx, &w_id, &flow_path, true).await?;
+    drop(tx);
 
     let tag = run_query.tag.clone().or(tag);
     check_tag_available_for_workspace(&w_id, &tag, &authed).await?;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add missing transaction drop in `run_wait_result_script_by_path_internal()` and `run_wait_result_flow_by_path_internal()` in `jobs.rs`.
> 
>   - **Behavior**:
>     - Add missing `drop(tx)` in `run_wait_result_script_by_path_internal()` and `run_wait_result_flow_by_path_internal()` in `jobs.rs` to ensure transactions are properly closed after use.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for e6077d2235d256b18b68a3c036b11c94ab480a27. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->