### PR TITLE
internal: Open discord thread when pr is opened

### DIFF
--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Send Discord notification and start a thread
         env:
-          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          WEBHOOK_URL: ${{ secrets.DISCORD_PR_REVIEWS_WEBHOOK }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -1,0 +1,34 @@
+name: "Notify Discord on New PR (with Thread)"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+
+jobs:
+  discord_notification:
+    # still guard out any drafts (just in case)
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Discord notification and start a thread
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          payload=$(jq -n \
+            --arg content "**New PR opened or ready for review**\n> [${PR_TITLE}](${PR_URL}) by \`${PR_AUTHOR}\`" \
+            --arg thread "$PR_TITLE" \
+            '{
+              content: $content,
+              thread_name: $thread,
+              auto_archive_duration: 10080
+            }'
+          )
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               --data "$payload" \
+               "$WEBHOOK_URL"

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -20,8 +20,8 @@ jobs:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           payload=$(jq -n \
-            --arg content "**New PR opened or ready for review**\n> [${PR_TITLE}](${PR_URL}) by \`${PR_AUTHOR}\`" \
-            --arg thread "$PR_TITLE" \
+            --arg content "${PR_URL}" \
+            --arg thread "$PR_TITLE by \`${PR_AUTHOR}\`" \
             '{
               content: $content,
               thread_name: $thread,

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -10,7 +10,7 @@ jobs:
   discord_notification:
     # still guard out any drafts (just in case)
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     steps:
       - name: Send Discord notification and start a thread
         env:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a GitHub Actions workflow to notify Discord and start a thread when a PR is opened or marked ready for review, excluding drafts.
> 
>   - **Workflow Addition**:
>     - Adds `.github/workflows/pr-opened.yml` to notify Discord when a PR is opened or marked ready for review.
>     - Uses `WEBHOOK_URL` from secrets to send notifications.
>   - **Behavior**:
>     - Triggers on `pull_request` events: `opened` and `ready_for_review`.
>     - Excludes draft PRs using `if: github.event.pull_request.draft == false`.
>     - Sends PR URL and author information to Discord, starting a new thread with a 7-day auto-archive duration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 0619950db7bf706871b495b06478adf5c0c7d764. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->