### PR TITLE
nit: Use shareable discord flow to use it from other repo

### DIFF
--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   call_reusable_workflow:
     if: github.event.pull_request.draft == false
-    uses: ./.github/workflows/shareable-pr-opened.yml
+    uses: ./.github/workflows/shareable-discord-notification.yml
     with:
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -1,4 +1,4 @@
-name: PR Opened
+name: "Send discord notification when a PR is ready for review"
 
 on:
   pull_request:

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -15,4 +15,4 @@ jobs:
       PR_URL: ${{ github.event.pull_request.html_url }}
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
     secrets:
-      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_PR_REVIEWS_WEBHOOK }}

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -1,4 +1,4 @@
-name: "Notify Discord on New PR (with Thread)"
+name: PR Opened
 
 on:
   pull_request:
@@ -7,28 +7,12 @@ on:
       - ready_for_review
 
 jobs:
-  discord_notification:
-    # still guard out any drafts (just in case)
+  call_reusable_workflow:
     if: github.event.pull_request.draft == false
-    runs-on: ubicloud-standard-2
-    steps:
-      - name: Send Discord notification and start a thread
-        env:
-          WEBHOOK_URL: ${{ secrets.DISCORD_PR_REVIEWS_WEBHOOK }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-        run: |
-          payload=$(jq -n \
-            --arg content "${PR_URL}" \
-            --arg thread "$PR_TITLE by \`${PR_AUTHOR}\`" \
-            '{
-              content: $content,
-              thread_name: $thread,
-              auto_archive_duration: 10080
-            }'
-          )
-          curl -H "Content-Type: application/json" \
-               -X POST \
-               --data "$payload" \
-               "$WEBHOOK_URL"
+    uses: ./.github/workflows/shareable-pr-opened.yml
+    with:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+    secrets:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/shareable-discord-notification.yml
+++ b/.github/workflows/shareable-discord-notification.yml
@@ -1,4 +1,4 @@
-name: "Notify Discord when a PR is opened"
+name: "Send discord notification when a PR is ready for review"
 
 on:
   workflow_call:

--- a/.github/workflows/shareable-pr-opened.yml
+++ b/.github/workflows/shareable-pr-opened.yml
@@ -1,0 +1,46 @@
+name: "Notify Discord when a PR is opened"
+
+on:
+  workflow_call:
+    inputs:
+      PR_TITLE:
+        description: "The title of the PR"
+        required: true
+        type: string
+      PR_URL:
+        description: "The URL of the PR"
+        required: true
+        type: string
+      PR_AUTHOR:
+        description: "The author of the PR"
+        required: true
+        type: string
+    secrets:
+      DISCORD_WEBHOOK_URL:
+        description: "Discord Webhook URL"
+        required: true
+
+jobs:
+  send_notification:
+    runs-on: ubicloud-standard-2
+    steps:
+      - name: Send Discord notification and start a thread
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          PR_TITLE: ${{ inputs.PR_TITLE }}
+          PR_URL: ${{ inputs.PR_URL }}
+          PR_AUTHOR: ${{ inputs.PR_AUTHOR }}
+        run: |
+          payload=$(jq -n \
+            --arg content "${PR_URL}" \
+            --arg thread "$PR_TITLE by \`${PR_AUTHOR}\`" \
+            '{
+              content: $content,
+              thread_name: $thread,
+              auto_archive_duration: 10080
+            }'
+          )
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               --data "$payload" \
+               "$WEBHOOK_URL"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces a reusable workflow for Discord notifications on PR readiness, replacing a specific workflow with a shareable one.
> 
>   - **Workflows**:
>     - Adds `discord-notification.yml` to trigger Discord notifications for PRs that are opened or marked ready for review.
>     - Deletes `pr-opened.yml`, replacing its functionality with a reusable workflow.
>     - Introduces `shareable-discord-notification.yml` to handle the notification logic, allowing reuse across repositories.
>   - **Behavior**:
>     - Notifications are sent only if the PR is not a draft.
>     - Uses inputs for `PR_TITLE`, `PR_URL`, and `PR_AUTHOR` to customize the notification message.
>     - Utilizes `DISCORD_WEBHOOK_URL` secret for sending notifications.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 35e20c67db68893a161a8078522de7adaefa402e. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->