### PR TITLE
fix: http trigger signature validation

### DIFF
--- a/backend/windmill-api/src/args.rs
+++ b/backend/windmill-api/src/args.rs
@@ -29,14 +29,14 @@ pub enum RawBody {
     Empty,
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
 pub enum Body {
     HashMap(HashMap<String, Box<RawValue>>),
     NoHashMap(Box<RawValue>),
 }
 
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct WebhookArgsMetadata {
     pub raw_string: Option<String>,
     pub headers: HashMap<String, Box<RawValue>>,
@@ -51,7 +51,7 @@ pub struct RawWebhookArgs {
     pub metadata: WebhookArgsMetadata,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct WebhookArgs {
     pub body: Body,
     pub metadata: WebhookArgsMetadata,

--- a/backend/windmill-api/src/capture.rs
+++ b/backend/windmill-api/src/capture.rs
@@ -14,9 +14,14 @@ use {
 };
 
 #[cfg(all(feature = "enterprise", feature = "gcp_trigger"))]
-use crate::gcp_triggers_ee::{
-    manage_google_subscription, process_google_push_request, validate_jwt_token,
-    CreateUpdateConfig, SubscriptionMode,
+use {
+    crate::gcp_triggers_ee::{
+        manage_google_subscription, process_google_push_request, validate_jwt_token,
+        CreateUpdateConfig, SubscriptionMode,
+    },
+    axum::extract::Request,
+    http::HeaderMap,
+    utils::empty_as_none,
 };
 
 #[cfg(all(feature = "enterprise", feature = "sqs_trigger"))]
@@ -26,12 +31,7 @@ use windmill_common::auth::aws::AwsAuthResourceType;
     feature = "http_trigger",
     all(feature = "enterprise", feature = "gcp_trigger")
 ))]
-use {
-    axum::extract::Request,
-    http::HeaderMap,
-    serde::de::DeserializeOwned,
-    windmill_common::{error::Error, utils::empty_as_none},
-};
+use {serde::de::DeserializeOwned, windmill_common::error::Error};
 
 #[cfg(all(feature = "enterprise", feature = "kafka"))]
 use crate::kafka_triggers_ee::KafkaTriggerConfigConnection;

--- a/backend/windmill-api/src/http_trigger_args.rs
+++ b/backend/windmill-api/src/http_trigger_args.rs
@@ -56,7 +56,7 @@ where
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct HttpTriggerArgs(pub WebhookArgs);
 
 impl RawHttpTriggerArgs {

--- a/backend/windmill-api/src/http_triggers.rs
+++ b/backend/windmill-api/src/http_triggers.rs
@@ -1050,20 +1050,10 @@ async fn route_job(
                 }
             };
 
-            let raw_payload = args
-                .0
-                .metadata
-                .raw_string
-                .as_ref()
-                .map(|raw_payload| serde_json::from_str::<String>(raw_payload))
-                .transpose()
-                .map_err(|e| {
-                    windmill_common::error::Error::SerdeJson { location: e.to_string(), error: e }
-                        .into_response()
-                })?;
+            let raw_payload = args.0.metadata.raw_string.as_ref();
 
             let response = authentication_method
-                .authenticate_http_request(&headers, raw_payload.as_ref())
+                .authenticate_http_request(&headers, raw_payload)
                 .map_err(|e| e.into_response())?;
 
             if let Some(response) = response {

--- a/backend/windmill-api/src/http_triggers.rs
+++ b/backend/windmill-api/src/http_triggers.rs
@@ -996,7 +996,15 @@ async fn route_job(
     .map_err(|e| e.into_response())?;
 
     let args = args
-        .process_args(&authed, &db, &trigger.workspace_id, trigger.raw_string)
+        .process_args(
+            &authed,
+            &db,
+            &trigger.workspace_id,
+            match trigger.authentication_method {
+                AuthenticationMethod::CustomScript | AuthenticationMethod::Signature => true,
+                _ => false,
+            },
+        )
         .await
         .map_err(|e| e.into_response())?;
 

--- a/backend/windmill-api/src/http_triggers.rs
+++ b/backend/windmill-api/src/http_triggers.rs
@@ -1002,7 +1002,7 @@ async fn route_job(
             &trigger.workspace_id,
             match trigger.authentication_method {
                 AuthenticationMethod::CustomScript | AuthenticationMethod::Signature => true,
-                _ => false,
+                _ => trigger.raw_string,
             },
         )
         .await


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix HTTP trigger signature validation by updating `process_args` in `route_job` to handle `CustomScript` and `Signature` authentication methods.
> 
>   - **Behavior**:
>     - Update `process_args` in `route_job` in `http_triggers.rs` to handle `CustomScript` and `Signature` authentication methods by setting `force_use_raw` to `true`.
>     - Modify `process_args` in `route_job` to use `trigger.raw_string` for other authentication methods.
>   - **Structs**:
>     - Add `Debug` trait to `Body`, `WebhookArgsMetadata`, `WebhookArgs`, and `HttpTriggerArgs` in `args.rs` and `http_trigger_args.rs` for improved logging.
>   - **Imports**:
>     - Remove unused imports in `capture.rs` to clean up the code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for aa68297c112eaa6ff6dc93e795aee2f1d4472509. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->