### PR TITLE
fix: http trigger routers cache version sequence

### DIFF
--- a/backend/migrations/20250515181903_fix_http_routers_cache.down.sql
+++ b/backend/migrations/20250515181903_fix_http_routers_cache.down.sql
@@ -1,0 +1,1 @@
+-- Add down migration script here

--- a/backend/migrations/20250515181903_fix_http_routers_cache.up.sql
+++ b/backend/migrations/20250515181903_fix_http_routers_cache.up.sql
@@ -4,6 +4,6 @@
 -- which would not refresh the routers cache after the first create/update/delete
 SELECT setval(                                  
     'http_trigger_version_seq',
-    GREATEST((SELECT last_value FROM http_trigger_version_seq), 1),
+    (SELECT last_value FROM http_trigger_version_seq),
     true
 );

--- a/backend/migrations/20250515181903_fix_http_routers_cache.up.sql
+++ b/backend/migrations/20250515181903_fix_http_routers_cache.up.sql
@@ -1,0 +1,9 @@
+-- Add up migration script here
+-- this makes sure that the first time nextval is called, 2 is returned
+-- otherwise, `SELECT last_value from http_trigger_version_seq;` would return 1 before and after the first nextval call
+-- which would not refresh the routers cache after the first create/update/delete
+SELECT setval(                                  
+    'http_trigger_version_seq',
+    GREATEST((SELECT last_value FROM http_trigger_version_seq), 1),
+    true
+);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes `http_trigger_version_seq` to ensure cache refresh by setting initial `nextval` to 2 in up migration.
> 
>   - **Migrations**:
>     - Adds `20250515181903_fix_http_routers_cache.up.sql` to set `http_trigger_version_seq` to return 2 on first `nextval` call, ensuring cache refresh after first operation.
>     - Adds placeholder `20250515181903_fix_http_routers_cache.down.sql` for down migration script.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for ee624ea4eb96fc56237f0816535a80d183dfd907. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->