### PR TITLE
fix: openapi 

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -11028,11 +11028,8 @@ paths:
           description: a config
           content:
             application/json:
-              type: object
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/Configs"
-                  - type: "null"
+                $ref: "#/components/schemas/Configs"
 
   /configs/update/{name}:
     post:
@@ -13211,6 +13208,7 @@ components:
 
     Configs:
       type: object
+      nullable: true
       properties:
         alerts:
           type: array


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplifies OpenAPI schema in `openapi.yaml` by removing `oneOf` and making `Configs` nullable.
> 
>   - **OpenAPI Specification**:
>     - In `openapi.yaml`, removed `oneOf` schema for `/configs` path and directly referenced `#/components/schemas/Configs`.
>     - Made `Configs` schema nullable in `components` section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 42cbd76c6131856143afbea7505c2e5a627bfc0b. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->