### PR TITLE
S3 mode returns S3Object

### DIFF
--- a/backend/windmill-worker/src/bigquery_executor.rs
+++ b/backend/windmill-worker/src/bigquery_executor.rs
@@ -206,7 +206,7 @@ fn do_bigquery_inner<'a>(
                             convert_json_line_stream(rows_stream.boxed(), s3.format).await?;
                         s3.upload(stream.boxed()).await?;
 
-                        return Ok(to_raw_value(&s3.object_key));
+                        return Ok(to_raw_value(&s3.to_return_s3_obj()));
                     }
 
                     Ok(to_raw_value(&rows))

--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -1591,7 +1591,7 @@ pub struct S3ModeWorkerData {
 }
 
 impl S3ModeWorkerData {
-    pub async fn upload<S>(&self, stream: S) -> error::Result<reqwest::Response>
+    pub async fn upload<S>(&self, stream: S) -> error::Result<()>
     where
         S: futures::stream::TryStream + Send + 'static,
         S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,

--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -1606,6 +1606,14 @@ impl S3ModeWorkerData {
             )
             .await
     }
+
+    pub fn to_return_s3_obj(&self) -> windmill_common::s3_helpers::S3Object {
+        windmill_common::s3_helpers::S3Object {
+            s3: self.object_key.clone(),
+            storage: self.storage.clone(),
+            ..Default::default()
+        }
+    }
 }
 
 pub fn s3_mode_args_to_worker_data(

--- a/backend/windmill-worker/src/mssql_executor.rs
+++ b/backend/windmill-worker/src/mssql_executor.rs
@@ -214,7 +214,7 @@ pub async fn do_mssql(
             let stream = convert_json_line_stream(rows_stream.boxed(), s3.format).await?;
             s3.upload(stream.boxed()).await?;
 
-            Ok(serde_json::value::to_raw_value(&s3.object_key)?)
+            Ok(to_raw_value(&s3.to_return_s3_obj()))
         } else {
             let stream = prepared_query.query(&mut client).await.map_err(to_anyhow)?;
             let results = stream.into_results().await.map_err(to_anyhow)?;

--- a/backend/windmill-worker/src/mysql_executor.rs
+++ b/backend/windmill-worker/src/mysql_executor.rs
@@ -105,7 +105,7 @@ fn do_mysql_inner<'a>(
             let stream = convert_json_line_stream(rows_stream.boxed(), s3.format).await?;
             s3.upload(stream.boxed()).await?;
 
-            Ok(serde_json::value::to_raw_value(&s3.object_key)?)
+            Ok(to_raw_value(&s3.to_return_s3_obj()))
         } else {
             let rows: Vec<Row> = conn
                 .lock()

--- a/backend/windmill-worker/src/oracledb_executor.rs
+++ b/backend/windmill-worker/src/oracledb_executor.rs
@@ -159,7 +159,7 @@ pub fn do_oracledb_inner<'a>(
             if let Some(s3) = s3 {
                 let stream = convert_json_line_stream(rows_stream.boxed(), s3.format).await?;
                 s3.upload(stream.boxed()).await?;
-                return Ok(serde_json::value::to_raw_value(&s3.object_key)?);
+                return Ok(to_raw_value(&s3.to_return_s3_obj()));
             } else {
                 let rows: Vec<_> = rows_stream.collect().await;
                 Ok(to_raw_value(

--- a/backend/windmill-worker/src/pg_executor.rs
+++ b/backend/windmill-worker/src/pg_executor.rs
@@ -124,7 +124,7 @@ fn do_postgresql_inner<'a>(
             let stream = convert_json_line_stream(rows_stream.boxed(), s3.format).await?;
             s3.upload(stream.boxed()).await?;
 
-            return Ok(serde_json::value::to_raw_value(&s3.object_key)?);
+            return Ok(to_raw_value(&s3.to_return_s3_obj()));
         } else {
             let rows = client
                 .query_raw(&query, query_params)

--- a/backend/windmill-worker/src/snowflake_executor.rs
+++ b/backend/windmill-worker/src/snowflake_executor.rs
@@ -256,7 +256,7 @@ fn do_snowflake_inner<'a>(
                     rows_stream.map(|r| serde_json::value::to_value(&r?).map_err(to_anyhow));
                 let stream = convert_json_line_stream(rows_stream.boxed(), s3.format).await?;
                 s3.upload(stream.boxed()).await?;
-                Ok(to_raw_value(&s3.object_key))
+                Ok(to_raw_value(&s3.to_return_s3_obj()))
             } else {
                 let rows = rows_stream
                     .collect::<Vec<_>>()


### PR DESCRIPTION
- **fix upload_s3_file not checking response**
- **Return S3Object instead of path string**

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Change S3 upload functions to return `S3Object` and validate response status in `upload_s3_file`.
> 
>   - **Behavior**:
>     - `upload_s3_file` in `worker.rs` now checks response status and returns an error if not 200.
>     - Functions in `bigquery_executor.rs`, `mssql_executor.rs`, `mysql_executor.rs`, `oracledb_executor.rs`, `pg_executor.rs`, and `snowflake_executor.rs` now return `S3Object` instead of path string.
>   - **Functions**:
>     - `S3ModeWorkerData::upload` in `common.rs` now returns `Result<()>` instead of `Result<reqwest::Response>`.
>     - Added `S3ModeWorkerData::to_return_s3_obj()` to return `S3Object`.
>   - **Misc**:
>     - Minor changes in `worker.rs` to handle response status in `upload_s3_file`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 2258647901ea24edb04c459bdfccd0a324ad578e. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->