### PR TITLE
internal: React to merged pr

### DIFF
--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   notify_discord_when_pr_opened:
     if: github.event.pull_request.draft == false
-    uses: ./.github/workflows/usable-pr-opened.yml
+    uses: ./.github/workflows/shareable-discord-notification.yml
     with:
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_URL: ${{ github.event.pull_request.html_url }}
@@ -18,15 +18,15 @@ jobs:
       PR_STATUS: "opened"
       PR_NUMBER: ${{ github.event.pull_request.number }}
     secrets:
-      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_PR_REVIEWS_WEBHOOK }}
 
   merge_success_emoji:
     if: github.event.pull_request.merged == true
-    uses: ./.github/workflows/usable-pr-opened.yml
+    uses: ./.github/workflows/shareable-discord-notification.yml
     with:
       PR_STATUS: "merged"
       DISCORD_CHANNEL_ID: "1372204995868491786"
       DISCORD_GUILD_ID: "930051556043276338"
       PR_NUMBER: ${{ github.event.pull_request.number }}
     secrets:
-      DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+      DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_PR_BOT_TOKEN }}

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -1,4 +1,4 @@
-name: PR Opened
+name: Create discord thread when a PR is opened, react with green checkmark when PR is merged
 
 on:
   pull_request:

--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -1,18 +1,32 @@
-name: "Send discord notification when a PR is ready for review"
+name: PR Opened
 
 on:
   pull_request:
     types:
       - opened
       - ready_for_review
+      - closed
 
 jobs:
-  call_reusable_workflow:
+  notify_discord_when_pr_opened:
     if: github.event.pull_request.draft == false
-    uses: ./.github/workflows/shareable-discord-notification.yml
+    uses: ./.github/workflows/usable-pr-opened.yml
     with:
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_URL: ${{ github.event.pull_request.html_url }}
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      PR_STATUS: "opened"
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     secrets:
-      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_PR_REVIEWS_WEBHOOK }}
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+
+  merge_success_emoji:
+    if: github.event.pull_request.merged == true
+    uses: ./.github/workflows/usable-pr-opened.yml
+    with:
+      PR_STATUS: "merged"
+      DISCORD_CHANNEL_ID: "1372204995868491786"
+      DISCORD_GUILD_ID: "930051556043276338"
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    secrets:
+      DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}

--- a/.github/workflows/shareable-discord-notification.yml
+++ b/.github/workflows/shareable-discord-notification.yml
@@ -1,39 +1,51 @@
-name: "Send discord notification when a PR is ready for review"
+name: "Notify Discord when a PR is opened or merged"
 
 on:
   workflow_call:
     inputs:
       PR_TITLE:
         description: "The title of the PR"
-        required: true
         type: string
       PR_URL:
         description: "The URL of the PR"
-        required: true
         type: string
       PR_AUTHOR:
         description: "The author of the PR"
-        required: true
+        type: string
+      PR_STATUS:
+        description: "The status of the PR"
+        type: string
+      DISCORD_CHANNEL_ID:
+        description: "The Discord channel ID"
+        type: string
+      PR_NUMBER:
+        description: "The number of the PR"
+        type: string
+      DISCORD_GUILD_ID:
+        description: "The Discord guild ID"
         type: string
     secrets:
       DISCORD_WEBHOOK_URL:
         description: "Discord Webhook URL"
-        required: true
+      DISCORD_BOT_TOKEN:
+        description: "Discord Bot Token"
 
 jobs:
-  send_notification:
+  open_thread:
     runs-on: ubicloud-standard-2
+    if: ${{ inputs.PR_STATUS == 'opened' }}
     steps:
       - name: Send Discord notification and start a thread
         env:
           WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           PR_TITLE: ${{ inputs.PR_TITLE }}
+          PR_NUMBER: ${{ inputs.PR_NUMBER }}
           PR_URL: ${{ inputs.PR_URL }}
           PR_AUTHOR: ${{ inputs.PR_AUTHOR }}
         run: |
           payload=$(jq -n \
             --arg content "${PR_URL}" \
-            --arg thread "$PR_TITLE by \`${PR_AUTHOR}\`" \
+            --arg thread "#${PR_NUMBER}: $PR_TITLE by \`${PR_AUTHOR}\`" \
             '{
               content: $content,
               thread_name: $thread,
@@ -41,6 +53,46 @@ jobs:
             }'
           )
           curl -H "Content-Type: application/json" \
-               -X POST \
-               --data "$payload" \
-               "$WEBHOOK_URL"
+            -X POST \
+            -d "$payload" \
+            "$WEBHOOK_URL"
+
+  merge_success_emoji:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.PR_STATUS == 'merged' }}
+    steps:
+      - name: React
+        env:
+          BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          CHANNEL_ID: ${{ inputs.DISCORD_CHANNEL_ID }}
+          GUILD_ID: ${{ inputs.DISCORD_GUILD_ID }}
+          PR_NUMBER: ${{ inputs.PR_NUMBER }}
+        run: |
+          # 1) get PR thread
+          threads=$(curl -H "Authorization: Bot $BOT_TOKEN" "https://discord.com/api/v10/guilds/${GUILD_ID}/threads/active")
+          thread_id=$(
+            echo "$threads" \
+              | jq -r --arg cid "$CHANNEL_ID" \
+                    --arg pref "#${PR_NUMBER}:" \
+                '.threads[]
+                | select(.parent_id == $cid and (.name | startswith($pref)))
+                | .id'
+          )
+          if [ -z "$thread_id" ]; then
+            echo "Thread not found"
+            exit 1
+          fi
+          # 2) get the first message in that thread
+          messages=$(curl -H "Authorization: Bot $BOT_TOKEN" \
+            "https://discord.com/api/v10/channels/$thread_id/messages?limit=1")
+          message_id=$(echo "$messages" | jq -r '.[-1].id')
+
+          if [ -z "$message_id" ]; then
+            echo "Message not found"
+            exit 1
+          fi
+
+          # 3) add the ✅ reaction
+          curl -X PUT \
+            -H "Authorization: Bot $BOT_TOKEN" \
+            "https://discord.com/api/v10/channels/$thread_id/messages/$message_id/reactions/%E2%9C%85/@me"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhances Discord notifications by creating threads for opened PRs and reacting with a checkmark when PRs are merged.
> 
>   - **Behavior**:
>     - Updates `.github/workflows/discord-notification.yml` to create a Discord thread when a PR is opened and react with a green checkmark when a PR is merged.
>     - Adds `closed` event type to trigger actions on PR merge.
>   - **Jobs**:
>     - `notify_discord_when_pr_opened`: Sends notification and starts a thread for non-draft PRs.
>     - `merge_success_emoji`: Reacts with a green checkmark on Discord when a PR is merged.
>   - **Workflow**:
>     - Modifies `shareable-discord-notification.yml` to handle `opened` and `merged` PR statuses.
>     - Adds logic to find the PR thread and react to the first message with a checkmark emoji.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 74707cbc8e97ad907b8860b6beea361d95a03f43. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->