### PR TITLE
refactor: rename *_ee files to *_oss

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -51,6 +51,7 @@ lto = "thin"
 default = []
 agent_worker_server = ["windmill-api/agent_worker_server"]
 enterprise = ["windmill-worker/enterprise", "windmill-queue/enterprise", "windmill-api/enterprise", "dep:windmill-autoscaling", "windmill-autoscaling/enterprise", "windmill-git-sync/enterprise", "windmill-common/prometheus", "windmill-common/enterprise"]
+private = ["windmill-worker/private", "windmill-queue/private", "windmill-api/private", "windmill-autoscaling/private", "windmill-git-sync/private", "windmill-common/private", "windmill-audit/private", "windmill-indexer/private"]
 enterprise_saml = ["windmill-api/enterprise_saml", "oauth2"]
 stripe = ["windmill-api/stripe"]
 benchmark = ["windmill-api/benchmark", "windmill-worker/benchmark", "windmill-queue/benchmark", "windmill-common/benchmark"]

--- a/backend/windmill-api/Cargo.toml
+++ b/backend/windmill-api/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 [features]
 default = []
 enterprise = ["windmill-queue/enterprise", "windmill-audit/enterprise", "windmill-git-sync/enterprise", "windmill-common/enterprise", "windmill-worker/enterprise"]
+private = ["windmill-queue/private", "windmill-audit/private", "windmill-git-sync/private", "windmill-common/private", "windmill-worker/private"]
 stripe = []
 agent_worker_server = []
 enterprise_saml = ["dep:samael", "dep:libxml"]

--- a/backend/windmill-api/src/users_oss.rs
+++ b/backend/windmill-api/src/users_oss.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+
+use crate::db::ApiAuthed;
+
+use crate::users::{EditPassword, NewUser};
+use crate::{db::DB, webhook_util::WebhookShared};
+use argon2::Argon2;
+
+use http::StatusCode;
+
+use windmill_common::error::{Error, Result};
+
+pub async fn create_user(
+    _authed: ApiAuthed,
+    _db: DB,
+    _webhook: WebhookShared,
+    _argon2: Arc<Argon2<'_>>,
+    mut _nu: NewUser,
+) -> Result<(StatusCode, String)> {
+    Err(Error::internal_err(
+        "Not implemented in Windmill's Open Source repository".to_string(),
+    ))
+}
+
+pub async fn set_password(
+    _db: DB,
+    _argon2: Arc<Argon2<'_>>,
+    _authed: ApiAuthed,
+    _user_email: &str,
+    _ep: EditPassword,
+) -> Result<String> {
+    Err(Error::internal_err(
+        "Not implemented in Windmill's Open Source repository".to_string(),
+    ))
+}
+
+pub fn send_email_if_possible(_subject: &str, _content: &str, _to: &str) {
+    tracing::warn!(
+        "send_email_if_possible is not implemented in Windmill's Open Source repository"
+    );
+}

--- a/backend/windmill-api/src/workspaces_oss.rs
+++ b/backend/windmill-api/src/workspaces_oss.rs
@@ -1,0 +1,15 @@
+use crate::{
+    db::{ApiAuthed, DB},
+    workspaces::EditAutoInvite,
+};
+
+pub async fn edit_auto_invite(
+    _authed: ApiAuthed,
+    _db: DB,
+    _w_id: String,
+    _ea: EditAutoInvite,
+) -> windmill_common::error::Result<String> {
+    Err(windmill_common::error::Error::internal_err(
+        "Not implemented on OSS".to_string(),
+    ))
+}

--- a/backend/windmill-audit/Cargo.toml
+++ b/backend/windmill-audit/Cargo.toml
@@ -10,6 +10,7 @@ path = "./src/lib.rs"
 
 [features]
 enterprise = ["windmill-common/enterprise"]
+private = ["windmill-common/private"]
 
 [dependencies]
 serde.workspace = true

--- a/backend/windmill-audit/src/audit_oss.rs
+++ b/backend/windmill-audit/src/audit_oss.rs
@@ -1,0 +1,75 @@
+/*
+ * Author: Ruben Fiszel
+ * Copyright: Windmill Labs, Inc 2022
+ * This file and its contents are licensed under the AGPLv3 License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-AGPL for a copy of the license.
+ */
+use std::collections::HashMap;
+
+use windmill_common::{
+    error::{Error, Result},
+    utils::Pagination,
+};
+
+use crate::{ActionKind, AuditLog, ListAuditLogQuery};
+use sqlx::{Postgres, Transaction};
+
+#[derive(Clone)]
+pub struct AuditAuthor {
+    pub username: String,
+    pub email: String,
+    pub username_override: Option<String>,
+}
+
+impl AuditAuthorable for AuditAuthor {
+    fn email(&self) -> &str {
+        &self.email
+    }
+
+    fn username(&self) -> &str {
+        &self.username
+    }
+
+    fn username_override(&self) -> Option<&str> {
+        self.username_override.as_deref()
+    }
+}
+
+pub trait AuditAuthorable {
+    fn username(&self) -> &str;
+    fn email(&self) -> &str;
+    fn username_override(&self) -> Option<&str>;
+}
+
+#[tracing::instrument(level = "trace", skip_all)]
+pub async fn audit_log<'c, E: sqlx::Executor<'c, Database = Postgres>>(
+    _db: E,
+    _author: &impl AuditAuthorable,
+    mut _operation: &str,
+    _action_kind: ActionKind,
+    _w_id: &str,
+    mut _resource: Option<&str>,
+    _parameters: Option<HashMap<&str, &str>>,
+) -> Result<()> {
+    // Implementation is not open source as Audit logs is a Windmill Enterprise Edition feature
+    Ok(())
+}
+
+pub async fn list_audit(
+    _tx: Transaction<'_, Postgres>,
+    _w_id: String,
+    _pagination: Pagination,
+    _lq: ListAuditLogQuery,
+) -> Result<Vec<AuditLog>> {
+    // Implementation is not open source as Audit logs is a Windmill Enterprise Edition feature
+    return Ok(vec![]);
+}
+
+pub async fn get_audit(tx: Transaction<'_, Postgres>, _id: i32, _w_id: &str) -> Result<AuditLog> {
+    // Implementation is not open source as Audit logs is a Windmill Enterprise Edition feature
+    tx.commit().await?;
+    Err(Error::NotFound(
+        "Audit log not not available in Windmill Community edition".to_string(),
+    ))
+}

--- a/backend/windmill-audit/src/lib.rs
+++ b/backend/windmill-audit/src/lib.rs
@@ -1,7 +1,13 @@
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 
+pub mod audit_oss;
 pub mod audit_ee;
+
+#[cfg(feature = "private")]
+pub use audit_ee::*;
+#[cfg(not(feature = "private"))]
+pub use audit_oss::*;
 
 #[derive(sqlx::Type, Serialize, Deserialize, Debug)]
 #[sqlx(type_name = "ACTION_KIND", rename_all = "lowercase")]

--- a/backend/windmill-autoscaling/Cargo.toml
+++ b/backend/windmill-autoscaling/Cargo.toml
@@ -10,6 +10,7 @@ path = "./src/lib.rs"
 
 [features]
 enterprise = ["windmill-queue/enterprise", "windmill-common/enterprise"]
+private = ["windmill-queue/private", "windmill-common/private"]
 default = []
 
 [dependencies]

--- a/backend/windmill-common/Cargo.toml
+++ b/backend/windmill-common/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 [features]
 default = []
 enterprise = []
+private = []
 jemalloc = ["dep:tikv-jemalloc-ctl"]
 tantivy = []
 prometheus = ["dep:prometheus"]

--- a/backend/windmill-common/src/email_oss.rs
+++ b/backend/windmill-common/src/email_oss.rs
@@ -1,0 +1,11 @@
+use crate::server::Smtp;
+
+pub async fn send_email(
+    _subject: &str,
+    _content: &str,
+    _to: Vec<String>,
+    _smtp: Smtp,
+    _client_timeout: Option<tokio::time::Duration>,
+) -> crate::error::Result<()> {
+    Ok(())
+}

--- a/backend/windmill-common/src/job_s3_helpers_oss.rs
+++ b/backend/windmill-common/src/job_s3_helpers_oss.rs
@@ -1,0 +1,18 @@
+use std::future::Future;
+
+use crate::{
+    error::Error,
+    s3_helpers::{ObjectStoreResource, StorageResourceType},
+};
+
+pub async fn get_s3_resource_internal<'c, F, Fut>(
+    _resource_type: StorageResourceType,
+    _s3_resource_value_raw: serde_json::Value,
+    _gen_token: F,
+) -> crate::error::Result<ObjectStoreResource>
+where
+    F: FnOnce(String) -> Fut,
+    Fut: Future<Output = Result<String, Error>> + Send + 'static,
+{
+    todo!()
+}

--- a/backend/windmill-common/src/lib.rs
+++ b/backend/windmill-common/src/lib.rs
@@ -33,6 +33,12 @@ pub mod cache;
 pub mod db;
 pub mod ee;
 pub mod email_ee;
+pub mod email_oss;
+
+#[cfg(feature = "private")]
+pub use email_ee::*;
+#[cfg(not(feature = "private"))]
+pub use email_oss::*;
 pub mod error;
 pub mod external_ip;
 pub mod flow_status;
@@ -42,12 +48,25 @@ pub mod indexer;
 pub mod job_metrics;
 #[cfg(feature = "parquet")]
 pub mod job_s3_helpers_ee;
+#[cfg(feature = "parquet")]
+pub mod job_s3_helpers_oss;
+
+#[cfg(all(feature = "parquet", feature = "private"))]
+pub use job_s3_helpers_ee::*;
+#[cfg(all(feature = "parquet", not(feature = "private")))]
+pub use job_s3_helpers_oss::*;
 
 pub mod jobs;
 pub mod jwt;
 pub mod more_serde;
 pub mod oauth2;
 pub mod otel_ee;
+pub mod otel_oss;
+
+#[cfg(feature = "private")]
+pub use otel_ee::*;
+#[cfg(not(feature = "private"))]
+pub use otel_oss::*;
 pub mod queue;
 pub mod s3_helpers;
 pub mod schedule;
@@ -55,7 +74,19 @@ pub mod schema;
 pub mod scripts;
 pub mod server;
 pub mod stats_ee;
+pub mod stats_oss;
 pub mod teams_ee;
+pub mod teams_oss;
+
+#[cfg(feature = "private")]
+pub use stats_ee::*;
+#[cfg(not(feature = "private"))]
+pub use stats_oss::*;
+
+#[cfg(feature = "private")]
+pub use teams_ee::*;
+#[cfg(not(feature = "private"))]
+pub use teams_oss::*;
 pub mod tracing_init;
 pub mod users;
 pub mod utils;

--- a/backend/windmill-common/src/otel_oss.rs
+++ b/backend/windmill-common/src/otel_oss.rs
@@ -1,0 +1,58 @@
+/*
+ * Author: Ruben Fiszel
+ * Copyright: Windmill Labs, Inc 2022
+ * This file and its contents are licensed under the AGPLv3 License.
+ * Please see the included NOTICE for copyright information and
+ * LICENSE-AGPL for a copy of the license.
+ */
+
+use crate::{jobs::QueuedJob, utils::Mode};
+use uuid::Uuid;
+
+pub fn set_span_parent(_span: &tracing::Span, _rj: &Uuid) {}
+
+#[cfg(not(all(feature = "otel", feature = "enterprise")))]
+pub(crate) type OtelProvider = Option<()>;
+
+#[cfg(all(feature = "otel", feature = "enterprise"))]
+pub(crate) type OtelProvider = Option<opentelemetry_sdk::metrics::SdkMeterProvider>;
+
+#[cfg(not(feature = "otel"))]
+pub fn otel_ctx() -> () {}
+
+#[cfg(feature = "otel")]
+#[inline(always)]
+pub fn otel_ctx() -> opentelemetry::Context {
+    opentelemetry::Context::current()
+}
+
+#[cfg(not(feature = "otel"))]
+impl<T: Sized> FutureExt for T {}
+
+#[cfg(not(feature = "otel"))]
+pub trait FutureExt: Sized {
+    fn with_context(self, _otel_cx: ()) -> Self {
+        self
+    }
+}
+
+use tracing_subscriber::EnvFilter;
+
+pub(crate) fn init_logs_bridge(_mode: &Mode, _hostname: &str, _env: &str) -> Option<EnvFilter> {
+    None
+}
+
+#[cfg(all(feature = "otel", feature = "enterprise"))]
+pub(crate) fn init_otlp_tracer(
+    _mode: &Mode,
+    _hostname: &str,
+    _env: &str,
+) -> Option<opentelemetry_sdk::trace::Tracer> {
+    None
+}
+
+pub(crate) fn init_meter_provider(_mode: &Mode, _hostname: &str, _env: &str) -> OtelProvider {
+    None
+}
+
+pub fn add_root_flow_job_to_otlp(_queued_job: &QueuedJob, _success: bool) {}

--- a/backend/windmill-common/src/stats_oss.rs
+++ b/backend/windmill-common/src/stats_oss.rs
@@ -1,0 +1,47 @@
+use sqlx::Postgres;
+
+use crate::{error::Result, scripts::ScriptLang, DB};
+
+pub async fn get_disable_stats_setting(_db: &DB) -> bool {
+    // stats details are closed source
+
+    false
+}
+
+pub async fn schedule_stats(_db: &DB, _http_client: &reqwest::Client) -> () {
+    // stats details are closed source
+}
+
+#[derive(Debug, sqlx::FromRow, serde::Serialize)]
+struct JobsUsage {
+    language: Option<ScriptLang>,
+    total_duration: i64,
+    count: i64,
+}
+
+pub enum SendStatsReason {
+    Manual,
+    Schedule,
+    OnStart,
+}
+
+pub async fn send_stats(
+    _http_client: &reqwest::Client,
+    _db: &DB,
+    _reason: SendStatsReason,
+) -> Result<()> {
+    // stats details are closed source
+    Ok(())
+}
+
+pub struct ActiveUserUsage {
+    pub author_count: Option<i32>,
+    pub operator_count: Option<i32>,
+}
+
+pub async fn get_user_usage<'c, E: sqlx::Executor<'c, Database = Postgres>>(
+    _db: E,
+) -> Result<ActiveUserUsage> {
+    let usage = ActiveUserUsage { author_count: None, operator_count: None };
+    Ok(usage)
+}

--- a/backend/windmill-git-sync/Cargo.toml
+++ b/backend/windmill-git-sync/Cargo.toml
@@ -10,6 +10,7 @@ path = "./src/lib.rs"
 
 [features]
 enterprise = ["windmill-queue/enterprise", "windmill-common/enterprise"]
+private = ["windmill-queue/private", "windmill-common/private"]
 default = []
 
 [dependencies]

--- a/backend/windmill-git-sync/src/git_sync_oss.rs
+++ b/backend/windmill-git-sync/src/git_sync_oss.rs
@@ -1,0 +1,16 @@
+use windmill_common::error::Result;
+
+use crate::{DeployedObject, DB};
+
+pub async fn handle_deployment_metadata<'c>(
+    _email: &str,
+    _created_by: &str,
+    _db: &DB,
+    _w_id: &str,
+    _obj: DeployedObject,
+    _deployment_message: Option<String>,
+    _skip_db_insert: bool,
+) -> Result<()> {
+    // Git sync is an enterprise feature and not part of the open-source version
+    return Ok(());
+}

--- a/backend/windmill-git-sync/src/lib.rs
+++ b/backend/windmill-git-sync/src/lib.rs
@@ -11,8 +11,12 @@ use sqlx::{Pool, Postgres};
 use windmill_common::scripts::ScriptHash;
 
 pub mod git_sync_ee;
+pub mod git_sync_oss;
 
+#[cfg(feature = "private")]
 pub use git_sync_ee::handle_deployment_metadata;
+#[cfg(not(feature = "private"))]
+pub use git_sync_oss::handle_deployment_metadata;
 pub type DB = Pool<Postgres>;
 
 #[derive(Clone, Debug)]

--- a/backend/windmill-indexer/Cargo.toml
+++ b/backend/windmill-indexer/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 default = []
 parquet = ["dep:object_store"]
 enterprise = []
+private = ["windmill-common/private"]
 
 [dependencies]
 windmill-common.workspace = true

--- a/backend/windmill-indexer/src/completed_runs_oss.rs
+++ b/backend/windmill-indexer/src/completed_runs_oss.rs
@@ -1,0 +1,22 @@
+use anyhow::anyhow;
+use sqlx::{Pool, Postgres};
+use windmill_common::error::Error;
+
+#[derive(Clone)]
+pub struct IndexReader;
+
+#[derive(Clone)]
+pub struct IndexWriter;
+
+pub async fn init_index(_db: &Pool<Postgres>) -> Result<(IndexReader, IndexWriter), Error> {
+    Err(anyhow!("Cannot initialize index: not in EE").into())
+}
+
+pub async fn run_indexer(
+    _db: Pool<Postgres>,
+    mut _index_writer: IndexWriter,
+    mut _killpill_rx: tokio::sync::broadcast::Receiver<()>,
+) -> Result<(), Error> {
+    tracing::error!("Cannot run indexer: not in EE");
+    Err(anyhow!("Cannot run indexer: not in EE").into())
+}

--- a/backend/windmill-indexer/src/lib.rs
+++ b/backend/windmill-indexer/src/lib.rs
@@ -1,3 +1,21 @@
 pub mod completed_runs_ee;
+pub mod completed_runs_oss;
 pub mod indexer_ee;
+pub mod indexer_oss;
 pub mod service_logs_ee;
+pub mod service_logs_oss;
+
+#[cfg(feature = "private")]
+pub use completed_runs_ee::*;
+#[cfg(not(feature = "private"))]
+pub use completed_runs_oss::*;
+
+#[cfg(feature = "private")]
+pub use indexer_ee::*;
+#[cfg(not(feature = "private"))]
+pub use indexer_oss::*;
+
+#[cfg(feature = "private")]
+pub use service_logs_ee::*;
+#[cfg(not(feature = "private"))]
+pub use service_logs_oss::*;

--- a/backend/windmill-indexer/src/service_logs_oss.rs
+++ b/backend/windmill-indexer/src/service_logs_oss.rs
@@ -1,0 +1,25 @@
+use anyhow::anyhow;
+use sqlx::{Pool, Postgres};
+use windmill_common::error::Error;
+use windmill_common::KillpillSender;
+#[derive(Clone)]
+pub struct ServiceLogIndexReader;
+
+#[derive(Clone)]
+pub struct ServiceLogIndexWriter;
+
+pub async fn init_index(
+    _db: &Pool<Postgres>,
+    mut _killpill_tx: KillpillSender,
+) -> Result<(ServiceLogIndexReader, ServiceLogIndexWriter), Error> {
+    Err(anyhow!("Cannot initialize index: not in EE").into())
+}
+
+pub async fn run_indexer(
+    _db: Pool<Postgres>,
+    mut _index_writer: ServiceLogIndexWriter,
+    mut _killpill_rx: tokio::sync::broadcast::Receiver<()>,
+) -> Result<(), Error> {
+    tracing::error!("Cannot run indexer: not in EE");
+    Err(anyhow!("Cannot run indexer: not in EE").into())
+}

--- a/backend/windmill-queue/Cargo.toml
+++ b/backend/windmill-queue/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 [features]
 default = []
 enterprise = ["windmill-common/enterprise"]
+private = ["windmill-common/private"]
 cloud = []
 benchmark = ["windmill-common/benchmark"]
 prometheus = ["dep:prometheus"]

--- a/backend/windmill-queue/src/jobs_oss.rs
+++ b/backend/windmill-queue/src/jobs_oss.rs
@@ -1,0 +1,16 @@
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+use windmill_common::DB;
+
+#[allow(dead_code)]
+pub(crate) async fn update_concurrency_counter(
+    _db: &DB,
+    _job_id: &Uuid,
+    _job_concurrency_key: String,
+    _jobs_uuids_init_json_value: serde_json::Value,
+    _pulled_job_id: String,
+    _job_custom_concurrency_time_window_s: i32,
+    _limit: i32,
+) -> anyhow::Result<(bool, Option<DateTime<Utc>>)> {
+    Ok((true, None))
+}

--- a/backend/windmill-queue/src/lib.rs
+++ b/backend/windmill-queue/src/lib.rs
@@ -8,7 +8,14 @@
 
 mod jobs;
 pub mod jobs_ee;
+pub mod jobs_oss;
 pub mod schedule;
+
+#[cfg(feature = "private")]
+pub use jobs_ee::*;
+#[cfg(not(feature = "private"))]
+pub use jobs_oss::*;
+
 pub use jobs::*;
 pub mod flow_status;
 pub mod tags;

--- a/backend/windmill-worker/Cargo.toml
+++ b/backend/windmill-worker/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 default = []
 prometheus = ["dep:prometheus", "windmill-common/prometheus"]
 enterprise = ["windmill-queue/enterprise", "windmill-git-sync/enterprise", "windmill-common/enterprise", "dep:pem", "dep:tokio-util"]
+private = ["windmill-queue/private", "windmill-git-sync/private", "windmill-common/private"]
 mssql = ["dep:tiberius"]
 bigquery = ["dep:gcp_auth"]
 benchmark = ["windmill-queue/benchmark", "windmill-common/benchmark"]

--- a/backend/windmill-worker/src/job_logger_oss.rs
+++ b/backend/windmill-worker/src/job_logger_oss.rs
@@ -1,0 +1,41 @@
+use std::io;
+use std::sync::atomic::AtomicU32;
+use std::sync::Arc;
+
+use uuid::Uuid;
+use windmill_common::DB;
+
+use crate::job_logger::CompactLogs;
+
+#[cfg(all(feature = "enterprise", feature = "parquet"))]
+pub(crate) async fn s3_storage(
+    _job_id: &Uuid,
+    _w_id: &str,
+    _db: &sqlx::Pool<sqlx::Postgres>,
+    _logs: &str,
+    _total_size: Arc<AtomicU32>,
+    _worker_name: &str,
+) {
+    tracing::info!("Logs length of {_job_id} has exceeded a threshold. Implementation to store excess on s3 in not OSS");
+}
+
+#[allow(dead_code)]
+pub(crate) async fn default_disk_log_storage(
+    job_id: &Uuid,
+    _w_id: &str,
+    _db: &DB,
+    _logs: &str,
+    _total_size: Arc<AtomicU32>,
+    _compact_kind: CompactLogs,
+    _worker_name: &str,
+) {
+    tracing::info!("Logs length of {job_id} has exceeded a threshold. Implementation to store excess on disk in not OSS");
+}
+
+pub(crate) fn process_streaming_log_lines(
+    r: Result<Option<String>, io::Error>,
+    _stderr: bool,
+    _job_id: &Uuid,
+) -> Option<Result<String, io::Error>> {
+    r.transpose()
+}

--- a/backend/windmill-worker/src/lib.rs
+++ b/backend/windmill-worker/src/lib.rs
@@ -26,6 +26,12 @@ mod graphql_executor;
 mod handle_child;
 pub mod job_logger;
 mod job_logger_ee;
+mod job_logger_oss;
+
+#[cfg(feature = "private")]
+pub use job_logger_ee::*;
+#[cfg(not(feature = "private"))]
+pub use job_logger_oss::*;
 mod js_eval;
 #[cfg(feature = "mysql")]
 mod mysql_executor;
@@ -34,6 +40,12 @@ mod nu_executor;
 #[cfg(feature = "oracledb")]
 mod oracledb_executor;
 mod otel_ee;
+mod otel_oss;
+
+#[cfg(feature = "private")]
+pub use otel_ee::*;
+#[cfg(not(feature = "private"))]
+pub use otel_oss::*;
 mod pg_executor;
 #[cfg(feature = "php")]
 mod php_executor;

--- a/backend/windmill-worker/src/otel_oss.rs
+++ b/backend/windmill-worker/src/otel_oss.rs
@@ -1,0 +1,3 @@
+use windmill_queue::MiniPulledJob;
+
+pub fn add_root_flow_job_to_otlp(_queued_job: &MiniPulledJob, _success: bool) {}


### PR DESCRIPTION
This PR implements the renaming of *_ee files to use a more structured approach:

1. For each *_ee.rs file, create a corresponding *_oss.rs file with the OSS implementation
2. Add a private feature flag to control which implementation is used
3. Update the imports in lib.rs files to conditionally import the correct module
   - If private feature is enabled: use *_ee.rs implementations
   - If private feature is not enabled: use *_oss.rs implementations

Fixes #5775

Generated with [Claude Code](https://claude.ai/code)