### PR TITLE
fix: Add missing trigger pages to quick access menu (Ctrl + K)

### DIFF
--- a/frontend/src/lib/components/search/GlobalSearchModal.svelte
+++ b/frontend/src/lib/components/search/GlobalSearchModal.svelte
@@ -818,7 +818,7 @@
 									</div>
 								</div>
 							{:else}
-								<div class="flex flex-col w-full justify-center items-center h-48">
+								<div class="flex flex-col h-full w-full justify-center items-center h-48">
 									<div class="text-tertiary text-center">
 										{#if searchTerm === RUNS_PREFIX}
 											<div class="text-2xl font-bold">Enter your search terms</div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds hidden trigger pages to the global search modal in `GlobalSearchModal.svelte`, making them searchable but not initially visible, and introduces a disabled state for menu items based on user roles.
> 
>   - **Behavior**:
>     - Adds hidden menu items in `GlobalSearchModal.svelte` for HTTP routes, WebSockets, Postgres triggers, Kafka triggers, NATS triggers, SQS triggers, GCP Pub/Sub, and MQTT triggers.
>     - Hidden items are searchable but not initially visible in the menu.
>     - Adds `disabled` property to menu items, disabling them for operators.
>   - **Search Functionality**:
>     - Updates `fuzzyFilter()` to include hidden items when searching.
>     - Modifies `handleSearch()` to handle hidden items based on search term.
>   - **UI**:
>     - Updates `QuickMenuItem` rendering to respect the `disabled` state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 659f4214e3d0bb28dea297cb887438b121f58e85. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->