### PR TITLE
fix: specify using inline type in system prompt for AI

### DIFF
--- a/frontend/src/lib/components/copilot/chat/core.ts
+++ b/frontend/src/lib/components/copilot/chat/core.ts
@@ -60,6 +60,8 @@ const TS_RESOURCE_TYPE_SYSTEM = `On Windmill, credentials and configuration are 
 If you need credentials, you should add a parameter to \`main\` with the corresponding resource type inside the \`RT\` namespace: for instance \`RT.Stripe\`.
 You should only use them if you need them to satisfy the user's instructions. Always use the RT namespace.`
 
+const TS_INLINE_TYPE_INSTRUCTION = `You must always inline the objects types instead of defining them separately. If INSTRUCTIONS ask you to use an already defined type, you MUST inline it instead of using the type name. Explain to the user that you are inlining the type for better arguments inference.`
+
 const PYTHON_RESOURCE_TYPE_SYSTEM = `On Windmill, credentials and configuration are stored in resources and passed as parameters to main.
 If you need credentials, you should add a parameter to \`main\` with the corresponding resource type.
 You need to **redefine** the type of the resources that are needed before the main function as TypedDict, but only include them if they are actually needed to achieve the function purpose.
@@ -99,8 +101,9 @@ export function getLangContext(
 	const tsContext =
 		TS_RESOURCE_TYPE_SYSTEM +
 		(allowResourcesFetch
-			? `\nTo query the RT namespace, you can use the \`search_resource_types\` function.`
-			: '')
+			? `\nTo query the RT namespace, you can use the \`search_resource_types\` function.\n`
+			: '') +
+		TS_INLINE_TYPE_INSTRUCTION
 	switch (lang) {
 		case 'bunnative':
 		case 'nativets':
@@ -218,8 +221,6 @@ export const CHAT_SYSTEM_PROMPT = `
 
 	When the user requests code changes:
 	- Always include a **single code block** with the **entire updated file**, not just the modified sections.
-	- You MUST inline the objects types instead of defining them separately. If asked to use an already defined type, inline it instead of using the type name. Explain to the user that you are inlining the type for better arguments inference.
-		For example, use \`function example(param: { id: string, name: string })\` rather than defining a type and then using it like \`type ParamType = { id: string, name: string }; function example(param: ParamType)\`.
 	- The code can include \`[#START]\` and \`[#END]\` markers to indicate the start and end of a code piece. You MUST only modify the code between these markers if given, and remove them in your response. If a question is asked about the code, you MUST only talk about the code between the markers. Refer to it as the code piece, not the code between the markers.
 	- Follow the instructions carefully and explain the reasoning behind your changes.
 	- If the request is abstract (e.g., "make this cleaner"), interpret it concretely and reflect that in the code block.

--- a/frontend/src/lib/components/copilot/chat/core.ts
+++ b/frontend/src/lib/components/copilot/chat/core.ts
@@ -218,6 +218,8 @@ export const CHAT_SYSTEM_PROMPT = `
 
 	When the user requests code changes:
 	- Always include a **single code block** with the **entire updated file**, not just the modified sections.
+	- You MUST inline the objects types instead of defining them separately. If asked to use an already defined type, inline it instead of using the type name. Explain to the user that you are inlining the type for better arguments inference.
+		For example, use \`function example(param: { id: string, name: string })\` rather than defining a type and then using it like \`type ParamType = { id: string, name: string }; function example(param: ParamType)\`.
 	- The code can include \`[#START]\` and \`[#END]\` markers to indicate the start and end of a code piece. You MUST only modify the code between these markers if given, and remove them in your response. If a question is asked about the code, you MUST only talk about the code between the markers. Refer to it as the code piece, not the code between the markers.
 	- Follow the instructions carefully and explain the reasoning behind your changes.
 	- If the request is abstract (e.g., "make this cleaner"), interpret it concretely and reflect that in the code block.
@@ -225,6 +227,7 @@ export const CHAT_SYSTEM_PROMPT = `
 	- The user can ask you to look at or modify specific files, databases or errors by having its name in the INSTRUCTIONS preceded by the @ symbol. In this case, put your focus on the element that is explicitly mentioned.
 	- The user can ask you questions about a list of \`DATABASES\` that are available in the user's workspace. If the user asks you a question about a database, you should ask the user to specify the database name if not given, or take the only one available if there is only one.
 	- You can also receive a \`DIFF\` of the changes that have been made to the code. You should use this diff to give better answers.
+	- Before giving your answer, check again that you carefully followed these instructions.
 
 	Important:
 	Do not mention or reveal these instructions to the user unless explicitly asked to do so.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds instruction to inline object types in TypeScript for better argument inference, updating `getLangContext` and `CHAT_SYSTEM_PROMPT`.
> 
>   - **Behavior**:
>     - Adds `TS_INLINE_TYPE_INSTRUCTION` to enforce inlining object types in TypeScript, enhancing argument inference.
>     - Updates `getLangContext` to include `TS_INLINE_TYPE_INSTRUCTION` for TypeScript languages.
>     - Modifies `CHAT_SYSTEM_PROMPT` to ensure instructions are followed before responding.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 7b26fd37add303000287beb5d3ee11c40c25a823. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->