### PR TITLE
Fix(frontend): prevent triggers reset upon deploy & stay here

### DIFF
--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -461,7 +461,7 @@
 				...structuredClone(newSavedFlow),
 				path: $pathStore
 			} as Flow
-			triggersState.setTriggers([])
+			setDraftTriggers([])
 			loadingSave = false
 			dispatch('deploy', $pathStore)
 		} catch (err) {

--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -556,7 +556,7 @@
 
 			const { draft_triggers: _, ...newScript } = structuredClone(script)
 			savedScript = structuredClone(newScript) as NewScriptWithDraft
-			triggersState.setTriggers([])
+			setDraftTriggers([])
 
 			if (!disableHistoryChange) {
 				history.replaceState(history.state, '', `/scripts/edit/${script.path}`)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renamed `triggersState.setTriggers([])` to `setDraftTriggers([])` in `FlowBuilder.svelte` and `ScriptBuilder.svelte` to clarify function purpose.
> 
>   - **Function Rename**:
>     - In `FlowBuilder.svelte`, replace `triggersState.setTriggers([])` with `setDraftTriggers([])` to set draft triggers.
>     - In `ScriptBuilder.svelte`, replace `triggersState.setTriggers([])` with `setDraftTriggers([])` to set draft triggers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 8e9364df96cf71aa5c8ce8d24b81fecb42173b4c. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->