### PR TITLE
internal: use /ai instead of /aider

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   check-membership:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/aider') && !contains(github.event.comment.user.login, '[bot]')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '/aider') && !contains(github.event.comment.user.login, '[bot]')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '/aider') && !contains(github.event.review.user.login, '[bot]')) ||
-      (github.event_name == 'issues' && contains(github.event.issue.body, '/aider') && !contains(github.event.issue.user.login, '[bot]'))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/ai') && !contains(github.event.comment.user.login, '[bot]')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '/ai') && !contains(github.event.comment.user.login, '[bot]')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '/ai') && !contains(github.event.review.user.login, '[bot]')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '/ai') && !contains(github.event.issue.user.login, '[bot]'))
     runs-on: ubicloud-standard-2
     outputs:
       is_member: ${{ steps.check-membership.outputs.is_member }}
@@ -82,4 +82,4 @@ jobs:
           - Bash(npm run generate-backend-client): Generate the backend client. You need this to run npm run check.
           - Bash(cargo check): Run the cargo check script. You should run this tool after making changes to the backend code.
           - Bash(curl https://sh.rustup.rs -sSf | sh): Install Rust. You need this to run cargo check."
-          trigger_phrase: "/aider"
+          trigger_phrase: "/ai"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change trigger phrase from '/aider' to '/ai' in `claude.yml` for GitHub Actions workflow.
> 
>   - **Behavior**:
>     - Change trigger phrase from `/aider` to `/ai` in `claude.yml` for GitHub Actions workflow.
>     - Affects `issue_comment`, `pull_request_review_comment`, `pull_request_review`, and `issues` events.
>   - **Misc**:
>     - Update `trigger_phrase` in `claude-code-action` job to `/ai`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 904bacb3459831e8b52df2943f8ca4c59f1c6890. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->