### PR TITLE
Allways render content in the app menu to load runnables

### DIFF
--- a/frontend/src/lib/components/apps/components/display/AppMenu.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppMenu.svelte
@@ -103,6 +103,7 @@
 				justifyEnd={false}
 				class={resolvedConfig.fillContainer ? 'w-full h-full' : ''}
 				usePointerDownOutside={true}
+				renderContent
 			>
 				<svelte:fragment slot="trigger" let:trigger>
 					<MeltButton meltElement={trigger} class="w-full h-full">

--- a/frontend/src/lib/components/meltComponents/Menu.svelte
+++ b/frontend/src/lib/components/meltComponents/Menu.svelte
@@ -17,6 +17,7 @@
 	export let usePointerDownOutside: boolean = false
 	export let menuClass: string = ''
 	export let open = false
+	export let renderContent: boolean = false
 
 	// Use the passed createMenu function
 	const menu = createMenu({
@@ -69,7 +70,7 @@
 	</button>
 
 	<!--svelte-ignore a11y-no-static-element-interactions-->
-	{#if open}
+	{#if open || renderContent}
 		<div
 			use:melt={$menuElement}
 			data-menu


### PR DESCRIPTION
Bug: runnables inside a Dropdown menu in the app editor are not loaded by default, causing the Run button to not be available if the dropdown is closed.

Fix: Allways render dropdown content for this component.