### PR TITLE
feat(frontend) : triggers panel polishing

### DIFF
--- a/frontend/src/lib/components/SchedulePanel.svelte
+++ b/frontend/src/lib/components/SchedulePanel.svelte
@@ -33,9 +33,7 @@
 	bind:this={scheduleEditor}
 	hideTarget
 	allowDraft
-	hasDraft={!!selectedTrigger.draftConfig}
-	isDraftOnly={selectedTrigger.isDraft}
-	primary={selectedTrigger.isPrimary}
+	trigger={selectedTrigger}
 	draftSchema={schema}
 	{customLabel}
 	{...restProps}

--- a/frontend/src/lib/components/triggers/CaptureSection.svelte
+++ b/frontend/src/lib/components/triggers/CaptureSection.svelte
@@ -307,7 +307,8 @@
 				<div class="mt-4 mb-2">
 					{#if displayAlert}
 						<Alert type="warning" title="Trigger deployed" size="xs" class="mb-4">
-							Capturing will suscribe to the trigger endpoint. Treat carefully.
+							Capturing on a deployed trigger can cause event loss on the deployed trigger. Treat
+							carefully.
 						</Alert>
 					{/if}
 					<Description>

--- a/frontend/src/lib/components/triggers/DeleteTriggerButton.svelte
+++ b/frontend/src/lib/components/triggers/DeleteTriggerButton.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import { Trash } from 'lucide-svelte'
+	import Button from '../common/button/Button.svelte'
+	import ConfirmationModal from '../common/confirmationModal/ConfirmationModal.svelte'
+	import { triggerIconMap, type Trigger } from './utils'
+	import TriggerLabel from './TriggerLabel.svelte'
+	import { twMerge } from 'tailwind-merge'
+
+	interface Props {
+		onDelete: (() => void) | undefined
+		trigger?: Trigger
+		small?: boolean
+	}
+
+	let { onDelete, trigger = undefined, small = false }: Props = $props()
+
+	let confirmationModalOpen = $state(false)
+</script>
+
+<ConfirmationModal
+	title="Are you sure you want to delete this draft trigger ?"
+	confirmationText="Delete"
+	open={confirmationModalOpen}
+	on:canceled={() => {
+		confirmationModalOpen = false
+	}}
+	on:confirmed={() => {
+		onDelete?.()
+		confirmationModalOpen = false
+	}}
+>
+	{#if trigger !== undefined}
+		{@const IconComponent = triggerIconMap[trigger.type]}
+		<div class="flex flex-row gap-2 items-center grow min-w-0 pr-2 rounded-md my-4">
+			<IconComponent
+				size={16}
+				class={twMerge(trigger.isDraft ? 'text-frost-400' : '', 'shrink-0')}
+			/>
+			<TriggerLabel {trigger} />
+		</div>
+	{/if}
+</ConfirmationModal>
+
+<Button
+	size="xs"
+	startIcon={{ icon: Trash }}
+	iconOnly
+	color={'light'}
+	on:click={() => {
+		confirmationModalOpen = true
+	}}
+	btnClasses={twMerge(small ? 'px-1 py-1' : '', 'bg-transparent hover:bg-red-500 hover:text-white')}
+/>

--- a/frontend/src/lib/components/triggers/TriggerEditorToolbar.svelte
+++ b/frontend/src/lib/components/triggers/TriggerEditorToolbar.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import Button from '$lib/components/common/button/Button.svelte'
-	import { Trash, Save, RotateCcw } from 'lucide-svelte'
+	import { Save, RotateCcw } from 'lucide-svelte'
 	import { type Snippet } from 'svelte'
 	import Toggle from '$lib/components/Toggle.svelte'
 	import { Tooltip } from '../meltComponents'
+	import DeleteTriggerButton from './DeleteTriggerButton.svelte'
+	import type { Trigger } from './utils'
 
 	interface Props {
-		isDraftOnly: any
-		hasDraft: any
 		saveDisabled: any
 		enabled: boolean | undefined
 		allowDraft: any
@@ -21,12 +21,10 @@
 		onToggleEnabled?: (enabled: boolean) => void
 		onUpdate?: () => void
 		cloudDisabled?: boolean
-		triggerType?: string
+		trigger?: Trigger
 	}
 
 	let {
-		isDraftOnly,
-		hasDraft,
 		saveDisabled,
 		enabled,
 		allowDraft,
@@ -39,7 +37,8 @@
 		onReset,
 		onToggleEnabled,
 		onUpdate,
-		cloudDisabled = false
+		cloudDisabled = false,
+		trigger
 	}: Props = $props()
 
 	const canSave = $derived((permissions === 'write' && edit) || permissions === 'create')
@@ -73,7 +72,7 @@
 	{/if}
 {:else}
 	<div class="flex flex-row gap-2 items-center">
-		{#if !isDraftOnly && !hasDraft && enabled !== undefined}
+		{#if !trigger?.draftConfig && enabled !== undefined}
 			<div class="center-center">
 				<Toggle
 					size="2sm"
@@ -86,18 +85,9 @@
 				/>
 			</div>
 		{/if}
-		{#if isDraftOnly}
-			<Button
-				size="xs"
-				startIcon={{ icon: Trash }}
-				iconOnly
-				color={'light'}
-				on:click={() => {
-					onDelete?.()
-				}}
-				btnClasses="hover:bg-red-500 hover:text-white"
-			/>
-		{:else if hasDraft}
+		{#if trigger?.isDraft}
+			<DeleteTriggerButton {onDelete} {trigger} />
+		{:else if !trigger?.isDraft && trigger?.draftConfig}
 			<Button
 				size="xs"
 				startIcon={{ icon: RotateCcw }}
@@ -109,7 +99,7 @@
 				Reset changes
 			</Button>
 		{/if}
-		{#if canSave && (isDraftOnly || hasDraft)}
+		{#if canSave && trigger?.draftConfig}
 			<Tooltip placement="bottom-end" disablePopup={!saveDisabled && !cloudDisabled && isDeployed}>
 				<Button
 					size="xs"
@@ -120,7 +110,7 @@
 					}}
 					loading={isLoading}
 				>
-					{isDraftOnly ? 'Deploy' : 'Update'}
+					{trigger?.isDraft ? 'Deploy' : 'Update'}
 				</Button>
 				<span slot="text">
 					{#if !isDeployed}
@@ -128,7 +118,7 @@
 					{:else if cloudDisabled}
 						This trigger is disabled in the multi-tenant cloud
 					{:else}
-						Enter a valid config to {isDraftOnly ? 'deploy' : 'update'} the trigger
+						Enter a valid config to {trigger?.isDraft ? 'deploy' : 'update'} the trigger
 					{/if}
 				</span>
 			</Tooltip>

--- a/frontend/src/lib/components/triggers/TriggersTable.svelte
+++ b/frontend/src/lib/components/triggers/TriggersTable.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import DataTable from '$lib/components/table/DataTable.svelte'
 	import Button from '$lib/components/common/button/Button.svelte'
-	import { Plus, Star, Loader2, Trash, RotateCcw } from 'lucide-svelte'
+	import { Plus, Star, Loader2, RotateCcw } from 'lucide-svelte'
 	import { twMerge } from 'tailwind-merge'
 	import { triggerIconMap, type Trigger, type TriggerType } from './utils'
 	import AddTriggersButton from './AddTriggersButton.svelte'
 	import TriggerLabel from './TriggerLabel.svelte'
+	import DeleteTriggerButton from './DeleteTriggerButton.svelte'
 
 	interface Props {
 		// Props
@@ -94,14 +95,7 @@
 
 							{#if !['email', 'webhook', 'cli'].includes(trigger.type)}
 								{#if trigger.isDraft}
-									<Button
-										size="xs"
-										color="light"
-										btnClasses="transition-all duration-200 text-transparent hover:bg-surface group-hover:text-primary bg-transparent px-1 py-1"
-										startIcon={{ icon: Trash }}
-										iconOnly
-										on:click={() => onDeleteDraft?.(index)}
-									/>
+									<DeleteTriggerButton {trigger} onDelete={() => onDeleteDraft?.(index)} small />
 								{:else if !!trigger.draftConfig && !trigger.isDraft}
 									<Button
 										size="xs"

--- a/frontend/src/lib/components/triggers/TriggersWrapper.svelte
+++ b/frontend/src/lib/components/triggers/TriggersWrapper.svelte
@@ -58,7 +58,7 @@
 		{isFlow}
 		path={initialPath || fakeInitialPath}
 		defaultValues={selectedTrigger.draftConfig ?? selectedTrigger.captureConfig ?? undefined}
-		customLabel={small ? customLabel : undefined}
+		{customLabel}
 		{...props}
 	/>
 {:else if selectedTrigger.type === 'webhook'}
@@ -86,7 +86,7 @@
 		{selectedTrigger}
 		defaultValues={selectedTrigger.draftConfig ?? selectedTrigger.captureConfig ?? undefined}
 		{schema}
-		customLabel={small ? customLabel : undefined}
+		{customLabel}
 		{...props}
 	/>
 {:else if selectedTrigger.type === 'websocket'}
@@ -95,7 +95,7 @@
 		path={initialPath || fakeInitialPath}
 		{selectedTrigger}
 		defaultValues={selectedTrigger.draftConfig ?? selectedTrigger.captureConfig ?? undefined}
-		customLabel={small ? customLabel : undefined}
+		{customLabel}
 		{...props}
 	/>
 {:else if selectedTrigger.type === 'kafka'}
@@ -104,7 +104,7 @@
 		path={initialPath || fakeInitialPath}
 		{selectedTrigger}
 		defaultValues={selectedTrigger.draftConfig ?? selectedTrigger.captureConfig ?? undefined}
-		customLabel={small ? customLabel : undefined}
+		{customLabel}
 		{...props}
 	/>
 {:else if selectedTrigger.type === 'postgres'}
@@ -113,7 +113,7 @@
 		path={initialPath || fakeInitialPath}
 		{selectedTrigger}
 		defaultValues={selectedTrigger.draftConfig ?? selectedTrigger.captureConfig ?? undefined}
-		customLabel={small ? customLabel : undefined}
+		{customLabel}
 		{...props}
 	/>
 {:else if selectedTrigger.type === 'nats'}
@@ -122,7 +122,7 @@
 		path={initialPath || fakeInitialPath}
 		{selectedTrigger}
 		defaultValues={selectedTrigger.draftConfig ?? selectedTrigger.captureConfig ?? undefined}
-		customLabel={small ? customLabel : undefined}
+		{customLabel}
 		{...props}
 	/>
 {:else if selectedTrigger.type === 'mqtt'}
@@ -131,7 +131,7 @@
 		path={initialPath || fakeInitialPath}
 		{selectedTrigger}
 		defaultValues={selectedTrigger.draftConfig ?? selectedTrigger.captureConfig ?? undefined}
-		customLabel={small ? customLabel : undefined}
+		{customLabel}
 		{...props}
 	/>
 {:else if selectedTrigger.type === 'sqs'}
@@ -140,7 +140,7 @@
 		path={initialPath || fakeInitialPath}
 		{selectedTrigger}
 		defaultValues={selectedTrigger.draftConfig ?? selectedTrigger.captureConfig ?? undefined}
-		customLabel={small ? customLabel : undefined}
+		{customLabel}
 		{...props}
 	/>
 {:else if selectedTrigger.type === 'gcp'}
@@ -149,7 +149,7 @@
 		path={initialPath || fakeInitialPath}
 		{selectedTrigger}
 		defaultValues={selectedTrigger.draftConfig ?? selectedTrigger.captureConfig ?? undefined}
-		customLabel={small ? customLabel : undefined}
+		{customLabel}
 		{...props}
 	/>
 {:else if selectedTrigger.type === 'poll'}

--- a/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
@@ -21,7 +21,7 @@
 	import type { Snippet } from 'svelte'
 	import TriggerEditorToolbar from '../TriggerEditorToolbar.svelte'
 	import { saveGcpTriggerFromCfg } from './utils'
-	import { handleConfigChange } from '../utils'
+	import { handleConfigChange, type Trigger } from '../utils'
 
 	let drawer: Drawer | undefined = $state(undefined)
 	let is_flow: boolean = $state(false)
@@ -55,8 +55,7 @@
 		hideTooltips = false,
 		isEditor = false,
 		allowDraft = false,
-		hasDraft = false,
-		isDraftOnly = false,
+		trigger = undefined,
 		isDeployed = false,
 		customLabel = undefined,
 		onConfigChange = undefined,
@@ -72,8 +71,7 @@
 		hideTooltips?: boolean
 		isEditor?: boolean
 		allowDraft?: boolean
-		hasDraft?: boolean
-		isDraftOnly?: boolean
+		trigger?: Trigger
 		isDeployed?: boolean
 		customLabel?: Snippet
 		onConfigChange?: (cfg: Record<string, any>, saveDisabled: boolean, updated: boolean) => void
@@ -225,7 +223,7 @@
 
 	async function handleToggleEnabled(toggleEnabled: boolean) {
 		enabled = toggleEnabled
-		if (!isDraftOnly && !hasDraft) {
+		if (!trigger?.draftConfig) {
 			await GcpTriggerService.setGcpTriggerEnabled({
 				path: initialPath,
 				workspace: $workspaceStore ?? '',
@@ -279,8 +277,6 @@
 {#snippet actionsButtons()}
 	{#if !drawerLoading && can_write}
 		<TriggerEditorToolbar
-			{isDraftOnly}
-			{hasDraft}
 			permissions={drawerLoading || !can_write ? 'none' : 'create'}
 			{saveDisabled}
 			{enabled}
@@ -293,6 +289,7 @@
 			{onDelete}
 			onToggleEnabled={handleToggleEnabled}
 			{cloudDisabled}
+			{trigger}
 		/>
 	{/if}
 {/snippet}

--- a/frontend/src/lib/components/triggers/gcp/GcpTriggerPanel.svelte
+++ b/frontend/src/lib/components/triggers/gcp/GcpTriggerPanel.svelte
@@ -44,8 +44,7 @@
 			hideTarget
 			hideTooltips={!isDeployed || cloudDisabled}
 			allowDraft={true}
-			hasDraft={!!selectedTrigger.draftConfig}
-			isDraftOnly={selectedTrigger.isDraft}
+			trigger={selectedTrigger}
 			{customLabel}
 			{isDeployed}
 			{cloudDisabled}

--- a/frontend/src/lib/components/triggers/http/RouteEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/http/RouteEditorInner.svelte
@@ -39,15 +39,14 @@
 		description = undefined,
 		isEditor = false,
 		customLabel = undefined,
-		isDraftOnly = false,
 		allowDraft = false,
-		hasDraft = false,
 		isDeployed = false,
 		onConfigChange = undefined,
 		onCaptureConfigChange = undefined,
 		onUpdate = undefined,
 		onDelete = undefined,
-		onReset = undefined
+		onReset = undefined,
+		trigger = undefined
 	} = $props()
 
 	// Form data state
@@ -526,7 +525,7 @@
 				{can_write}
 				bind:static_asset_config
 				showTestingBadge={isEditor}
-				{isDraftOnly}
+				isDraftOnly={trigger?.isDraft}
 			/>
 
 			{#if !is_static_website}
@@ -717,8 +716,7 @@
 {#snippet saveButton()}
 	{#if !drawerLoading}
 		<TriggerEditorToolbar
-			{isDraftOnly}
-			{hasDraft}
+			{trigger}
 			permissions={drawerLoading || !can_write ? 'none' : can_write && isAdmin ? 'create' : 'write'}
 			{saveDisabled}
 			enabled={undefined}

--- a/frontend/src/lib/components/triggers/http/RoutesPanel.svelte
+++ b/frontend/src/lib/components/triggers/http/RoutesPanel.svelte
@@ -37,9 +37,8 @@
 	hideTarget
 	{isEditor}
 	{customLabel}
-	isDraftOnly={selectedTrigger.isDraft}
+	trigger={selectedTrigger}
 	allowDraft
-	hasDraft={!!selectedTrigger.draftConfig}
 	{...restProps}
 >
 	{#snippet description()}

--- a/frontend/src/lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte
@@ -15,7 +15,7 @@
 	import type { Snippet } from 'svelte'
 	import TriggerEditorToolbar from '../TriggerEditorToolbar.svelte'
 	import { saveKafkaTriggerFromCfg } from './utils'
-	import { handleConfigChange } from '../utils'
+	import { handleConfigChange, type Trigger } from '../utils'
 
 	interface Props {
 		useDrawer?: boolean
@@ -24,8 +24,7 @@
 		hideTooltips?: boolean
 		isEditor?: boolean
 		allowDraft?: boolean
-		hasDraft?: boolean
-		isDraftOnly?: boolean
+		trigger?: Trigger
 		customLabel?: Snippet
 		isDeployed?: boolean
 		cloudDisabled?: boolean
@@ -43,8 +42,7 @@
 		hideTooltips = false,
 		isEditor = false,
 		allowDraft = false,
-		hasDraft = false,
-		isDraftOnly = false,
+		trigger = undefined,
 		customLabel,
 		isDeployed = false,
 		cloudDisabled = false,
@@ -281,8 +279,7 @@
 {#snippet actionsButtons(size: 'xs' | 'sm' = 'sm')}
 	{#if !drawerLoading}
 		<TriggerEditorToolbar
-			{isDraftOnly}
-			{hasDraft}
+			{trigger}
 			permissions={drawerLoading || !can_write ? 'none' : 'create'}
 			{enabled}
 			{allowDraft}

--- a/frontend/src/lib/components/triggers/kafka/KafkaTriggersPanel.svelte
+++ b/frontend/src/lib/components/triggers/kafka/KafkaTriggersPanel.svelte
@@ -45,8 +45,7 @@
 			hideTarget
 			hideTooltips={!isDeployed || cloudDisabled}
 			allowDraft={true}
-			hasDraft={!!selectedTrigger.draftConfig}
-			isDraftOnly={selectedTrigger.isDraft}
+			trigger={selectedTrigger}
 			{customLabel}
 			{isDeployed}
 			{cloudDisabled}

--- a/frontend/src/lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte
@@ -21,7 +21,7 @@
 	import type { Snippet } from 'svelte'
 	import TriggerEditorToolbar from '../TriggerEditorToolbar.svelte'
 	import { saveMqttTriggerFromCfg } from './utils'
-	import { handleConfigChange } from '../utils'
+	import { handleConfigChange, type Trigger } from '../utils'
 
 	interface Props {
 		useDrawer?: boolean
@@ -30,8 +30,7 @@
 		hideTooltips?: boolean
 		isEditor?: boolean
 		allowDraft?: boolean
-		hasDraft?: boolean
-		isDraftOnly?: boolean
+		trigger?: Trigger
 		customLabel?: Snippet
 		isDeployed?: boolean
 		cloudDisabled?: boolean
@@ -49,8 +48,7 @@
 		hideTooltips = false,
 		isEditor = false,
 		allowDraft = false,
-		hasDraft = false,
-		isDraftOnly = false,
+		trigger = undefined,
 		customLabel = undefined,
 		isDeployed = false,
 		onConfigChange = undefined,
@@ -238,7 +236,7 @@
 
 	async function handleToggleEnabled(newEnabled: boolean) {
 		enabled = newEnabled
-		if (!isDraftOnly && !hasDraft) {
+		if (!trigger?.draftConfig) {
 			await MqttTriggerService.setMqttTriggerEnabled({
 				path: initialPath,
 				workspace: $workspaceStore ?? '',
@@ -292,8 +290,7 @@
 {#snippet actions()}
 	{#if !drawerLoading}
 		<TriggerEditorToolbar
-			{isDraftOnly}
-			{hasDraft}
+			{trigger}
 			permissions={drawerLoading || !can_write ? 'none' : 'create'}
 			{saveDisabled}
 			{enabled}

--- a/frontend/src/lib/components/triggers/mqtt/MqttTriggersPanel.svelte
+++ b/frontend/src/lib/components/triggers/mqtt/MqttTriggersPanel.svelte
@@ -39,8 +39,7 @@
 		hideTarget
 		hideTooltips={!isDeployed || cloudDisabled}
 		allowDraft={true}
-		hasDraft={!!selectedTrigger.draftConfig}
-		isDraftOnly={selectedTrigger.isDraft}
+		trigger={selectedTrigger}
 		{customLabel}
 		{isDeployed}
 		{cloudDisabled}

--- a/frontend/src/lib/components/triggers/nats/NatsTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/nats/NatsTriggerEditorInner.svelte
@@ -15,7 +15,7 @@
 	import type { Snippet } from 'svelte'
 	import TriggerEditorToolbar from '../TriggerEditorToolbar.svelte'
 	import { saveNatsTriggerFromCfg } from './utils'
-	import { handleConfigChange } from '../utils'
+	import { handleConfigChange, type Trigger } from '../utils'
 
 	interface Props {
 		useDrawer?: boolean
@@ -25,8 +25,7 @@
 		useEditButton?: boolean
 		isEditor?: boolean
 		allowDraft?: boolean
-		hasDraft?: boolean
-		isDraftOnly?: boolean
+		trigger?: Trigger
 		isDeployed?: boolean
 		cloudDisabled?: boolean
 		customLabel?: Snippet
@@ -44,8 +43,7 @@
 		hideTooltips = false,
 		isEditor = false,
 		allowDraft = false,
-		hasDraft = false,
-		isDraftOnly = false,
+		trigger = undefined,
 		isDeployed = false,
 		cloudDisabled = false,
 		customLabel = undefined,
@@ -227,7 +225,7 @@
 
 	async function handleToggleEnabled(toggleEnabled: boolean) {
 		enabled = toggleEnabled
-		if (!isDraftOnly && !hasDraft) {
+		if (!trigger?.draftConfig) {
 			await NatsTriggerService.setNatsTriggerEnabled({
 				path: initialPath,
 				workspace: $workspaceStore ?? '',
@@ -285,8 +283,7 @@
 {#snippet actions()}
 	{#if !drawerLoading}
 		<TriggerEditorToolbar
-			{isDraftOnly}
-			{hasDraft}
+			{trigger}
 			permissions={drawerLoading || !can_write ? 'none' : 'create'}
 			{saveDisabled}
 			{enabled}

--- a/frontend/src/lib/components/triggers/nats/NatsTriggersPanel.svelte
+++ b/frontend/src/lib/components/triggers/nats/NatsTriggersPanel.svelte
@@ -45,8 +45,7 @@
 			hideTooltips={!isDeployed}
 			useEditButton
 			allowDraft={true}
-			hasDraft={!!selectedTrigger.draftConfig}
-			isDraftOnly={selectedTrigger.isDraft}
+			trigger={selectedTrigger}
 			{customLabel}
 			{isDeployed}
 			{cloudDisabled}

--- a/frontend/src/lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte
@@ -28,7 +28,7 @@
 	import type { Snippet } from 'svelte'
 	import TriggerEditorToolbar from '../TriggerEditorToolbar.svelte'
 	import TestingBadge from '../testingBadge.svelte'
-	import { handleConfigChange } from '../utils'
+	import { handleConfigChange, type Trigger } from '../utils'
 	import { fade } from 'svelte/transition'
 
 	interface Props {
@@ -38,8 +38,7 @@
 		isEditor?: boolean
 		hideTooltips?: boolean
 		allowDraft?: boolean
-		hasDraft?: boolean
-		isDraftOnly?: boolean
+		trigger?: Trigger
 		isDeployed?: boolean
 		cloudDisabled?: boolean
 		customLabel?: Snippet
@@ -57,8 +56,7 @@
 		isEditor = false,
 		hideTooltips = false,
 		allowDraft = false,
-		hasDraft = false,
-		isDraftOnly = false,
+		trigger = undefined,
 		isDeployed = false,
 		cloudDisabled = false,
 		customLabel = undefined,
@@ -378,7 +376,7 @@
 
 	async function handleToggleEnabled(toggleEnabled: boolean) {
 		enabled = toggleEnabled
-		if (!isDraftOnly && !hasDraft) {
+		if (!trigger?.draftConfig) {
 			await PostgresTriggerService.setPostgresTriggerEnabled({
 				path: initialPath,
 				workspace: $workspaceStore ?? '',
@@ -430,8 +428,7 @@
 {#snippet actions()}
 	{#if !drawerLoading}
 		<TriggerEditorToolbar
-			{isDraftOnly}
-			{hasDraft}
+			{trigger}
 			permissions={drawerLoading || !can_write ? 'none' : 'create'}
 			{saveDisabled}
 			{allowDraft}

--- a/frontend/src/lib/components/triggers/postgres/PostgresTriggersPanel.svelte
+++ b/frontend/src/lib/components/triggers/postgres/PostgresTriggersPanel.svelte
@@ -41,8 +41,7 @@
 		hideTarget
 		hideTooltips={!isDeployed || cloudDisabled}
 		allowDraft={true}
-		hasDraft={!!selectedTrigger.draftConfig}
-		isDraftOnly={selectedTrigger.isDraft}
+		trigger={selectedTrigger}
 		{isEditor}
 		{isDeployed}
 		{cloudDisabled}

--- a/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
@@ -40,16 +40,14 @@
 		hideTarget = false,
 		docDescription = undefined,
 		allowDraft = false,
-		hasDraft = false,
-		isDraftOnly = false,
-		primary = false,
 		draftSchema = undefined,
 		customLabel = undefined,
 		isDeployed = false,
 		onUpdate = undefined,
 		onConfigChange = undefined,
 		onDelete = undefined,
-		onReset = undefined
+		onReset = undefined,
+		trigger = undefined
 	} = $props()
 
 	let optionTabSelected: 'error_handler' | 'recovery_handler' | 'success_handler' | 'retries' =
@@ -289,7 +287,9 @@
 			edit = false
 			itemKind = is_flow ? 'flow' : 'script'
 			initialScriptPath = initial_script_path ?? ''
-			path = initNewPath ? '' : (defaultValues?.path ?? (primary ? initialScriptPath : ''))
+			path = initNewPath
+				? ''
+				: (defaultValues?.path ?? (trigger?.isPrimary ? initialScriptPath : ''))
 			initialPath = path
 			cronVersion = s?.cron_version ?? 'v2'
 			initialCronVersion = cronVersion
@@ -663,7 +663,7 @@
 
 	async function handleToggleEnabled(nEnabled: boolean) {
 		enabled = nEnabled
-		if (!isDraftOnly && !hasDraft) {
+		if (!trigger?.draftConfig) {
 			await ScheduleService.setScheduleEnabled({
 				path: initialPath,
 				workspace: $workspaceStore ?? '',
@@ -683,8 +683,7 @@
 {#snippet saveButton()}
 	{#if !drawerLoading}
 		<TriggerEditorToolbar
-			{isDraftOnly}
-			{hasDraft}
+			{trigger}
 			permissions={drawerLoading || !can_write ? 'none' : 'create'}
 			{saveDisabled}
 			{enabled}
@@ -760,7 +759,7 @@
 					</Label>
 				</div>
 				<Label label="Path">
-					{#if !edit && !primary}
+					{#if !edit && !trigger?.isPrimary}
 						<Path
 							bind:dirty={dirtyPath}
 							bind:this={pathC}

--- a/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
@@ -289,8 +289,7 @@
 			edit = false
 			itemKind = is_flow ? 'flow' : 'script'
 			initialScriptPath = initial_script_path ?? ''
-			path = initNewPath ? '' : (defaultValues?.path ?? initialScriptPath)
-
+			path = initNewPath ? '' : (defaultValues?.path ?? (primary ? initialScriptPath : ''))
 			initialPath = path
 			cronVersion = s?.cron_version ?? 'v2'
 			initialCronVersion = cronVersion
@@ -765,7 +764,7 @@
 						<Path
 							bind:dirty={dirtyPath}
 							bind:this={pathC}
-							checkInitialPathExistence
+							checkInitialPathExistence={!edit}
 							bind:error={pathError}
 							bind:path
 							{initialPath}

--- a/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorInner.svelte
@@ -15,7 +15,7 @@
 	import type { Snippet } from 'svelte'
 	import TriggerEditorToolbar from '../TriggerEditorToolbar.svelte'
 	import { saveSqsTriggerFromCfg } from './utils'
-	import { handleConfigChange } from '../utils'
+	import { handleConfigChange, type Trigger } from '../utils'
 
 	interface Props {
 		useDrawer?: boolean
@@ -23,8 +23,7 @@
 		hideTarget?: boolean
 		hideTooltips?: boolean
 		allowDraft?: boolean
-		hasDraft?: boolean
-		isDraftOnly?: boolean
+		trigger?: Trigger
 		isEditor?: boolean
 		customLabel?: Snippet
 		isDeployed?: boolean
@@ -42,8 +41,7 @@
 		hideTarget = false,
 		hideTooltips = false,
 		allowDraft = false,
-		hasDraft = false,
-		isDraftOnly = false,
+		trigger = undefined,
 		isEditor = false,
 		customLabel = undefined,
 		isDeployed = false,
@@ -194,7 +192,7 @@
 
 	async function handleToggleEnabled(nEnabled: boolean) {
 		enabled = nEnabled
-		if (!isDraftOnly && !hasDraft) {
+		if (!trigger?.draftConfig) {
 			await SqsTriggerService.setSqsTriggerEnabled({
 				path: initialPath,
 				workspace: $workspaceStore ?? '',
@@ -275,8 +273,7 @@
 {#snippet actions()}
 	{#if !drawerLoading}
 		<TriggerEditorToolbar
-			{isDraftOnly}
-			{hasDraft}
+			{trigger}
 			permissions={drawerLoading || !can_write ? 'none' : 'create'}
 			{saveDisabled}
 			{enabled}

--- a/frontend/src/lib/components/triggers/sqs/SqsTriggerPanel.svelte
+++ b/frontend/src/lib/components/triggers/sqs/SqsTriggerPanel.svelte
@@ -45,8 +45,7 @@
 			hideTarget
 			hideTooltips={!isDeployed || cloudDisabled}
 			allowDraft={true}
-			hasDraft={!!selectedTrigger.draftConfig}
-			isDraftOnly={selectedTrigger.isDraft}
+			trigger={selectedTrigger}
 			{customLabel}
 			{isDeployed}
 			{cloudDisabled}

--- a/frontend/src/lib/components/triggers/websocket/WebsocketTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/websocket/WebsocketTriggerEditorInner.svelte
@@ -28,7 +28,7 @@
 
 	import TriggerEditorToolbar from '../TriggerEditorToolbar.svelte'
 	import { saveWebsocketTriggerFromCfg } from './utils'
-	import { handleConfigChange } from '../utils'
+	import { handleConfigChange, type Trigger } from '../utils'
 
 	interface Props {
 		useDrawer?: boolean
@@ -38,8 +38,7 @@
 		useEditButton?: boolean
 		isEditor?: boolean
 		allowDraft?: boolean
-		hasDraft?: boolean
-		isDraftOnly?: boolean
+		trigger?: Trigger
 		isDeployed?: boolean
 		cloudDisabled?: boolean
 		customLabel?: Snippet
@@ -57,8 +56,7 @@
 		hideTooltips = false,
 		isEditor = false,
 		allowDraft = false,
-		hasDraft = false,
-		isDraftOnly = false,
+		trigger = undefined,
 		isDeployed = false,
 		customLabel = undefined,
 		onConfigChange = undefined,
@@ -288,7 +286,7 @@
 
 	async function handleToggleEnabled(newEnabled: boolean) {
 		enabled = newEnabled
-		if (!isDraftOnly && !hasDraft) {
+		if (!trigger?.draftConfig) {
 			await WebsocketTriggerService.setWebsocketTriggerEnabled({
 				path: initialPath,
 				workspace: $workspaceStore!,
@@ -342,8 +340,7 @@
 {#snippet actionsButtons()}
 	{#if !drawerLoading}
 		<TriggerEditorToolbar
-			{isDraftOnly}
-			{hasDraft}
+			{trigger}
 			permissions={!drawerLoading && can_write ? 'create' : 'none'}
 			{enabled}
 			{allowDraft}

--- a/frontend/src/lib/components/triggers/websocket/WebsocketTriggersPanel.svelte
+++ b/frontend/src/lib/components/triggers/websocket/WebsocketTriggersPanel.svelte
@@ -38,8 +38,7 @@
 		hideTarget
 		hideTooltips={!isDeployed || cloudDisabled}
 		allowDraft={true}
-		hasDraft={!!selectedTrigger.draftConfig}
-		isDraftOnly={selectedTrigger.isDraft}
+		trigger={selectedTrigger}
 		{customLabel}
 		{isDeployed}
 		{cloudDisabled}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor trigger components to consolidate properties into a single `trigger` object, add `DeleteTriggerButton`, and improve UI/UX.
> 
>   - **Refactor Trigger Properties**:
>     - Consolidate `hasDraft`, `isDraftOnly`, and `primary` into a single `trigger` object in `SchedulePanel.svelte`, `GcpTriggerPanel.svelte`, `RoutesPanel.svelte`, and other trigger-related components.
>     - Update `TriggerEditorToolbar.svelte` to use `trigger` object for draft and primary checks.
>   - **New Component**:
>     - Add `DeleteTriggerButton.svelte` for handling trigger deletion with confirmation modal.
>     - Integrate `DeleteTriggerButton` in `TriggersTable.svelte`, `TriggerEditorToolbar.svelte`, and other relevant components.
>   - **UI/UX Improvements**:
>     - Update warning message in `CaptureSection.svelte` to clarify event loss risk.
>     - Remove redundant `customLabel` condition in `TriggersWrapper.svelte` and related components.
>   - **Miscellaneous**:
>     - Minor code cleanup and reorganization across multiple trigger components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for febd6ec2df81f538f63926eb623d2968d8ecba4a. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->