### PR TITLE
fix: allow disable tabs for sidebar/accordion tabs

### DIFF
--- a/frontend/src/lib/components/apps/components/layout/AppTabs.svelte
+++ b/frontend/src/lib/components/apps/components/layout/AppTabs.svelte
@@ -151,10 +151,11 @@
 				)}
 				style={css?.tabRow?.style}
 			>
-				{#each tabs ?? [] as res}
+				{#each tabs ?? [] as res, index}
 					<button
 						on:pointerdown|stopPropagation
-						on:click={() => (selected = res)}
+						on:click={() => !resolvedDisabledTabs[index] && (selected = res)}
+						disabled={resolvedDisabledTabs[index]}
 						class={twMerge(
 							'rounded-sm !truncate text-sm  hover:text-primary px-1 py-2',
 							css?.allTabs?.class,
@@ -165,7 +166,8 @@
 										css?.selectedTab?.class,
 										'wm-tabs-selectedTab'
 									)
-								: ''
+								: '',
+							resolvedDisabledTabs[index] ? 'opacity-50 cursor-not-allowed hover:text-secondary' : ''
 						)}
 						style={selected == res
 							? [css?.allTabs?.style, css?.selectedTab?.style].filter(Boolean).join(';')
@@ -182,7 +184,8 @@
 					<div class="border-b">
 						<button
 							on:pointerdown|stopPropagation
-							on:click={() => (selected = res)}
+							on:click={() => !resolvedDisabledTabs[index] && (selected = res)}
+							disabled={resolvedDisabledTabs[index]}
 							class={twMerge(
 								'w-full text-left bg-surface !truncate text-sm hover:text-primary px-1 py-2',
 								css?.allTabs?.class,
@@ -193,7 +196,8 @@
 											css?.selectedTab?.class,
 											'wm-tabs-selectedTab'
 										)
-									: 'text-secondary'
+									: 'text-secondary',
+								resolvedDisabledTabs[index] ? 'opacity-50 cursor-not-allowed hover:text-secondary' : ''
 							)}
 						>
 							<span class="mr-2 w-8 font-mono">{selected == res ? '-' : '+'}</span>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add functionality to disable specific tabs in `AppTabs.svelte` using `resolvedDisabledTabs`.
> 
>   - **Behavior**:
>     - Tabs can now be disabled in `AppTabs.svelte` using `resolvedDisabledTabs` array.
>     - Disabled tabs have `opacity-50` and `cursor-not-allowed` styles, and do not trigger selection on click.
>   - **Code Changes**:
>     - Updated `on:click` handlers in `AppTabs.svelte` to check `resolvedDisabledTabs` before changing `selected`.
>     - Added `disabled` attribute to buttons in `AppTabs.svelte` to reflect disabled state.
>     - Applied conditional styles for disabled tabs in `AppTabs.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 7f4b82c358c7f0043e5c40b218936a31bf16341a. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->