### PR TITLE
fix: cannot parse INSTANCE_PYTHON_VERSION

### DIFF
--- a/backend/windmill-worker/src/python_versions.rs
+++ b/backend/windmill-worker/src/python_versions.rs
@@ -296,6 +296,7 @@ impl PyV {
     ) -> Self {
         let mut err = None;
         let pyv = match INSTANCE_PYTHON_VERSION.read().await.clone() {
+            Some(v) if &v == "default" => PyVAlias::default().into(),
             Some(v) => pep440_rs::Version::from_str(&v).unwrap_or_else(|_| {
                 let v = PyVAlias::default().into();
                 err = Some(format!("\nCannot parse INSTANCE_PYTHON_VERSION ({:?}), fallback to latest_stable ({v:?})", *INSTANCE_PYTHON_VERSION));


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix handling of `INSTANCE_PYTHON_VERSION` set to "default" in `gravitational_version()` in `python_versions.rs`.
> 
>   - **Behavior**:
>     - In `gravitational_version()` in `python_versions.rs`, handle `INSTANCE_PYTHON_VERSION` set to "default" by using `PyVAlias::default()`.
>     - Logs an error to Sentry if `INSTANCE_PYTHON_VERSION` cannot be parsed, falling back to `latest_stable`.
>   - **Misc**:
>     - Minor code formatting changes in `python_versions.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 2c222417cb36b20f5145e26f245906546b07c3fc. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->