### PR TITLE
internal: Avoid duplicate discord threads

### DIFF
--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -17,8 +17,11 @@ jobs:
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       PR_STATUS: "opened"
       PR_NUMBER: ${{ github.event.pull_request.number }}
+      DISCORD_CHANNEL_ID: "1372204995868491786"
+      DISCORD_GUILD_ID: "930051556043276338"
     secrets:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_PR_REVIEWS_WEBHOOK }}
+      DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_AI_BOT_TOKEN }}
 
   merge_success_emoji:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/shareable-discord-notification.yml
+++ b/.github/workflows/shareable-discord-notification.yml
@@ -38,24 +38,44 @@ jobs:
       - name: Send Discord notification and start a thread
         env:
           WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          CHANNEL_ID: ${{ inputs.DISCORD_CHANNEL_ID }}
+          GUILD_ID: ${{ inputs.DISCORD_GUILD_ID }}
           PR_TITLE: ${{ inputs.PR_TITLE }}
           PR_NUMBER: ${{ inputs.PR_NUMBER }}
           PR_URL: ${{ inputs.PR_URL }}
           PR_AUTHOR: ${{ inputs.PR_AUTHOR }}
         run: |
-          payload=$(jq -n \
-            --arg content "${PR_URL}" \
-            --arg thread "#${PR_NUMBER}: $PR_TITLE by \`${PR_AUTHOR}\`" \
-            '{
-              content: $content,
-              thread_name: $thread,
-              auto_archive_duration: 10080
-            }'
-          )
-          curl -H "Content-Type: application/json" \
-            -X POST \
-            -d "$payload" \
-            "$WEBHOOK_URL"
+          # Check if thread already exists
+          thread_exists=false
+          if threads=$(curl -s -H "Authorization: Bot $BOT_TOKEN" "https://discord.com/api/v10/guilds/${GUILD_ID}/threads/active"); then
+            if thread_id=$(echo "$threads" | jq -r --arg cid "$CHANNEL_ID" --arg pref "#${PR_NUMBER}:" '.threads[] | select(.parent_id == $cid and (.name | startswith($pref))) | .id' 2>/dev/null); then
+              if [ -n "$thread_id" ]; then
+                thread_exists=true
+                echo "Thread already exists, skipping creation"
+              fi
+            fi
+          else
+            echo "Failed to check for existing threads, will create new thread"
+          fi
+
+          # Create thread if it doesn't exist or if check failed
+          if [ "$thread_exists" = false ]; then
+            echo "Creating new thread"
+            payload=$(jq -n \
+              --arg content "${PR_URL}" \
+              --arg thread "#${PR_NUMBER}: $PR_TITLE by \`${PR_AUTHOR}\`" \
+              '{
+                content: $content,
+                thread_name: $thread,
+                auto_archive_duration: 10080
+              }'
+            )
+            curl -H "Content-Type: application/json" \
+              -X POST \
+              -d "$payload" \
+              "$WEBHOOK_URL"
+          fi
 
   merge_success_emoji:
     runs-on: ubuntu-latest


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevents duplicate Discord threads for PRs by checking existing threads before creation, using new environment variables and Discord API.
> 
>   - **Behavior**:
>     - Prevents duplicate Discord threads by checking existing threads before creating a new one in `shareable-discord-notification.yml`.
>     - If a thread with the same PR number exists, skips creation.
>   - **Environment Variables**:
>     - Adds `DISCORD_CHANNEL_ID`, `DISCORD_GUILD_ID`, and `DISCORD_BOT_TOKEN` to `discord-notification.yml` and `shareable-discord-notification.yml`.
>   - **Misc**:
>     - Uses Discord API to query active threads and check for existing thread names starting with PR number.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for eca825a28cfd2c86723910595e6c606cf6c8cdc8. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->