### PR TITLE
fix: broken event dispatch for simpleditor

### DIFF
--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -372,7 +372,7 @@
 			return
 		}
 		code = ncode
-		dispatch('change', ncode)
+		dispatch('change', { code: ncode })
 	}
 
 	export function append(code: string): void {

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -372,7 +372,7 @@
 			return
 		}
 		code = ncode
-		dispatch('change', { code: ncode })
+		dispatch('change', ncode)
 	}
 
 	export function append(code: string): void {

--- a/frontend/src/lib/components/SimpleEditor.svelte
+++ b/frontend/src/lib/components/SimpleEditor.svelte
@@ -169,7 +169,7 @@
 			return
 		}
 		code = ncode
-		dispatch('change', ncode)
+		dispatch('change', { code: ncode })
 	}
 
 	function updatePlaceholderVisibility(value: string) {

--- a/frontend/src/lib/components/TemplateEditor.svelte
+++ b/frontend/src/lib/components/TemplateEditor.svelte
@@ -478,7 +478,7 @@
 				return
 			}
 			code = ncode
-			dispatch('change', code)
+			dispatch('change', { code: ncode })
 		}
 
 		let timeoutModel: NodeJS.Timeout | undefined = undefined


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes event dispatch in `SimpleEditor.svelte` and `TemplateEditor.svelte` to include `code` in an object.
> 
>   - **Behavior**:
>     - Fixes event dispatch in `updateCode()` in `SimpleEditor.svelte` and `TemplateEditor.svelte` to include `code` in an object.
>   - **Functions**:
>     - Modifies `dispatch('change', ncode)` to `dispatch('change', { code: ncode })` in `updateCode()` in both `SimpleEditor.svelte` and `TemplateEditor.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 653e73ffc7b26b6f9f45fc48a2c16d3c8694a789. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->