### PR TITLE
fix: remove duplicate tools from script ai chat

### DIFF
--- a/frontend/src/lib/components/copilot/chat/script/core.ts
+++ b/frontend/src/lib/components/copilot/chat/script/core.ts
@@ -306,7 +306,7 @@ export function prepareScriptTools(
 	language: ScriptLang | 'bunnative',
 	context: ContextElement[]
 ): Tool<ScriptChatHelpers>[] {
-	const tools: Tool<ScriptChatHelpers>[] = [resourceTypeTool, dbSchemaTool]
+	const tools: Tool<ScriptChatHelpers>[] = []
 	if (['python3', 'php', 'bun', 'deno', 'nativets', 'bunnative'].includes(language)) {
 		tools.push(resourceTypeTool)
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove duplicate tool initialization in `prepareScriptTools()` in `core.ts`.
> 
>   - **Behavior**:
>     - Removes duplicate initialization of `resourceTypeTool` and `dbSchemaTool` in `prepareScriptTools()` in `core.ts`.
>     - Ensures `resourceTypeTool` is only added for specific languages and `dbSchemaTool` is added based on context type.
>   - **Misc**:
>     - Simplifies tool initialization logic in `prepareScriptTools()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 03310070d4ebcca90de43ea1bdea1a4744a99eb0. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->