### PR TITLE
fix: allow fileupload drag and drop in edit mode on full component without triggering file picker

### DIFF
--- a/frontend/src/lib/components/common/fileInput/FileInput.svelte
+++ b/frontend/src/lib/components/common/fileInput/FileInput.svelte
@@ -27,6 +27,24 @@
 	type FileWithPath = File & { path?: string }
 	export let files: FileWithPath[] | undefined = undefined
 
+	let pointerStartX = 0
+	let pointerStartY = 0
+	let hasMoved = false
+
+	function handlePointerDown(e: PointerEvent) {
+		pointerStartX = e.clientX
+		pointerStartY = e.clientY
+		hasMoved = false
+	}
+
+	function handlePointerMove(e: PointerEvent) {
+		const deltaX = Math.abs(e.clientX - pointerStartX)
+		const deltaY = Math.abs(e.clientY - pointerStartY)
+		if (deltaX > 5 || deltaY > 5) {
+			hasMoved = true
+		}
+	}
+
 	async function onChange(fileList: FileWithPath[] | null) {
 		if (!fileList || !fileList.length) {
 			files = undefined
@@ -179,14 +197,24 @@
 
 <button
 	class={twMerge(
-		`relative center-center flex-col text-center font-medium text-tertiary 
-		border border-dashed border-gray-400 hover:border-blue-500 
-		focus-within:border-blue-300 hover:bg-blue-50 dark:hover:bg-frost-900  
+		`relative center-center flex-col text-center font-medium text-tertiary
+		border border-dashed border-gray-400 hover:border-blue-500
+		focus-within:border-blue-300 hover:bg-blue-50 dark:hover:bg-frost-900
 		duration-200 rounded-component p-1`,
 		c
 	)}
 	on:dragover={handleDragOver}
 	on:drop={handleDrop}
+	on:pointerdown={handlePointerDown}
+	on:pointermove={handlePointerMove}
+	on:click={(e) => {
+		if (hasMoved) {
+			e.preventDefault()
+			e.stopPropagation()
+			return
+		}
+		hasMoved = false
+	}}
 	{style}
 	{disabled}
 >

--- a/frontend/src/lib/components/common/fileInput/FileInput.svelte
+++ b/frontend/src/lib/components/common/fileInput/FileInput.svelte
@@ -29,20 +29,10 @@
 
 	let pointerStartX = 0
 	let pointerStartY = 0
-	let hasMoved = false
 
 	function handlePointerDown(e: PointerEvent) {
 		pointerStartX = e.clientX
 		pointerStartY = e.clientY
-		hasMoved = false
-	}
-
-	function handlePointerMove(e: PointerEvent) {
-		const deltaX = Math.abs(e.clientX - pointerStartX)
-		const deltaY = Math.abs(e.clientY - pointerStartY)
-		if (deltaX > 5 || deltaY > 5) {
-			hasMoved = true
-		}
 	}
 
 	async function onChange(fileList: FileWithPath[] | null) {
@@ -206,14 +196,14 @@
 	on:dragover={handleDragOver}
 	on:drop={handleDrop}
 	on:pointerdown={handlePointerDown}
-	on:pointermove={handlePointerMove}
 	on:click={(e) => {
-		if (hasMoved) {
+		const deltaX = Math.abs(e.clientX - pointerStartX)
+		const deltaY = Math.abs(e.clientY - pointerStartY)
+		if (deltaX > 5 || deltaY > 5) {
 			e.preventDefault()
 			e.stopPropagation()
 			return
 		}
-		hasMoved = false
 	}}
 	{style}
 	{disabled}


### PR DESCRIPTION
not sure if there is a better way as MoveResize captures all events
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Prevents file picker from triggering during drag events in `FileInput.svelte` by checking pointer movement before allowing click events.
> 
>   - **Behavior**:
>     - Prevents file picker from triggering on drag events by tracking pointer start positions (`pointerStartX`, `pointerStartY`) and checking movement in `on:click` event.
>     - If movement exceeds 5 pixels in any direction, the click event is prevented.
>   - **Functions**:
>     - Adds `handlePointerDown()` to record initial pointer positions.
>     - Modifies `on:click` event handler to include movement check logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for a0c4807c6d5e5ac6b0249b909b0b77160e229b42. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->