### PR TITLE
nit: fix windows build

### DIFF
--- a/backend/windmill-worker/src/rust_executor.rs
+++ b/backend/windmill-worker/src/rust_executor.rs
@@ -66,6 +66,7 @@ mount {
 #[cfg(not(debug_assertions))]
 const DEV_CONF_NSJAIL: &'static str = "";
 
+#[cfg(not(windows))]
 lazy_static::lazy_static! {
     static ref CARGO_HOME_DEFAULT: String = format!("{}/.cargo", *HOME_DIR);
     static ref RUSTUP_HOME_DEFAULT: String = format!("{}/.rustup", *HOME_DIR);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix Windows build by conditionally compiling `lazy_static` block in `rust_executor.rs` for non-Windows systems.
> 
>   - **Compatibility**:
>     - Add `#[cfg(not(windows))]` to `lazy_static` block in `rust_executor.rs` to fix Windows build issues.
>   - **Behavior**:
>     - Ensures `CARGO_HOME_DEFAULT` and `RUSTUP_HOME_DEFAULT` are only defined for non-Windows systems.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for b771d05c11233de494f5698b9ec7b91c45ac0654. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->