### PR TITLE
fix substitute script stopping when file already exists

### DIFF
--- a/backend/substitute_ee_code.sh
+++ b/backend/substitute_ee_code.sh
@@ -69,7 +69,7 @@ if [ "$REVERT" == "YES" ]; then
   for ee_file in $(find ${EE_CODE_DIR} -name "*ee.rs"); do
     ce_file="${ee_file/${EE_CODE_DIR}/}"
     ce_file="${root_dirpath}/backend/${ce_file}"
-    rm ${ce_file}
+    rm ${ce_file} || true
   done
 elif [ "$MOVE_NEW_FILES" == "NO" ]; then
   # This replaces all files in current repo with alternative EE files in windmill-ee-private
@@ -80,7 +80,7 @@ elif [ "$MOVE_NEW_FILES" == "NO" ]; then
       cp "${ee_file}" "${ce_file}"
       echo "File copied '${ee_file}' -->> '${ce_file}'"
     else
-      ln -s "${ee_file}" "${ce_file}"
+      ln -s "${ee_file}" "${ce_file}" || true
       echo "Symlink created '${ee_file}' -->> '${ce_file}'"
     fi
   done


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `substitute_ee_code.sh` to continue execution when `rm` or `ln -s` fail due to existing files or symlinks.
> 
>   - **Behavior**:
>     - Modify `substitute_ee_code.sh` to prevent script from stopping when `rm` or `ln -s` commands fail due to existing files or symlinks.
>     - Use `|| true` with `rm` and `ln -s` commands to ignore errors in these cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for a71ab13a49ecff3024afa3ac28c65dd6700aaf14. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->