### PR TITLE
fix: add clearable by default

### DIFF
--- a/frontend/src/lib/components/ScriptPicker.svelte
+++ b/frontend/src/lib/components/ScriptPicker.svelte
@@ -84,7 +84,13 @@
 <div class="flex flex-row items-center gap-4 w-full mt-2">
 	{#if options.length > 1}
 		<div>
-			<ToggleButtonGroup bind:selected={itemKind} let:item>
+			<ToggleButtonGroup
+				bind:selected={itemKind}
+				let:item
+				on:selected={() => {
+					scriptPath = ''
+				}}
+			>
 				{#each options as [label, value, icon, selectedColor]}
 					<ToggleButton {icon} {disabled} {value} {label} {selectedColor} {item} />
 				{/each}

--- a/frontend/src/lib/components/Select.svelte
+++ b/frontend/src/lib/components/Select.svelte
@@ -14,7 +14,7 @@
 		value = $bindable(),
 		filterText: _filterTextBind = $bindable(undefined),
 		class: className = '',
-		clearable = false,
+		clearable = true,
 		listAutoWidth = true,
 		disabled: _disabled = false,
 		containerStyle = '',

--- a/frontend/src/lib/components/triggers/http/RouteEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/http/RouteEditorInner.svelte
@@ -506,7 +506,7 @@
 									allowEdit={!$userStore?.operator}
 								/>
 
-								{#if script_path === undefined}
+								{#if emptyString(script_path)}
 									<Button
 										btnClasses="ml-4 mt-2"
 										color="dark"

--- a/frontend/src/lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte
@@ -526,7 +526,7 @@
 							allowEdit={!$userStore?.operator}
 						/>
 
-						{#if emptyStringTrimmed(script_path) && is_flow === false}
+						{#if emptyString(script_path) && is_flow === false}
 							<div class="flex">
 								<Button
 									disabled={!can_write}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `Select` component to be clearable by default and adjust related logic in `ScriptPicker`, `RouteEditorInner`, and `PostgresTriggerEditorInner`.
> 
>   - **Behavior**:
>     - `Select.svelte`: Change `clearable` default to `true`.
>     - `ScriptPicker.svelte`: Reset `scriptPath` on `ToggleButtonGroup` selection.
>   - **Logic Adjustments**:
>     - `RouteEditorInner.svelte`: Use `emptyString()` instead of `undefined` check for `script_path`.
>     - `PostgresTriggerEditorInner.svelte`: Use `emptyString()` instead of `emptyStringTrimmed()` for `script_path` check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for dc0ac7b641b69396bae1ef489769437c23f7051c. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->