### PR TITLE
internal: Avoid discord length limit

### DIFF
--- a/.github/workflows/shareable-discord-notification.yml
+++ b/.github/workflows/shareable-discord-notification.yml
@@ -62,9 +62,10 @@ jobs:
           # Create thread if it doesn't exist or if check failed
           if [ "$thread_exists" = false ]; then
             echo "Creating new thread"
+            THREAD_TITLE="#${PR_NUMBER}: ${PR_TITLE} by \`${PR_AUTHOR}\`"
             payload=$(jq -n \
               --arg content "${PR_URL}" \
-              --arg thread "#${PR_NUMBER}: $PR_TITLE by \`${PR_AUTHOR}\`" \
+              --arg thread "${THREAD_TITLE:0:99}" \
               '{
                 content: $content,
                 thread_name: $thread,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Truncate Discord thread titles to 99 characters in `shareable-discord-notification.yml` to avoid length limits.
> 
>   - **Behavior**:
>     - Truncate Discord thread titles to 99 characters in `.github/workflows/shareable-discord-notification.yml` to avoid length limits.
>     - Uses `THREAD_TITLE:0:99` to ensure truncation.
>   - **Misc**:
>     - No changes to logic or additional features added.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 6f7dfaccedcf46a3dd9b417586558d9b478b82a0. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->