### PR TITLE
fix: ai chat tooltip + user settings autocomplete issue

### DIFF
--- a/frontend/src/lib/components/copilot/chat/ContextTextarea.svelte
+++ b/frontend/src/lib/components/copilot/chat/ContextTextarea.svelte
@@ -334,11 +334,10 @@
 		use:autosize
 		rows={3}
 		on:input={handleInput}
-		on:blur={(e) => {
-			e.preventDefault()
+		on:blur={() => {
 			setTimeout(() => {
 				showContextTooltip = false
-			}, 100)
+			}, 200)
 		}}
 		placeholder={isFirstMessage ? 'Ask anything' : 'Ask followup'}
 		class="resize-none bg-transparent caret-black dark:caret-white"

--- a/frontend/src/lib/components/copilot/chat/ContextTextarea.svelte
+++ b/frontend/src/lib/components/copilot/chat/ContextTextarea.svelte
@@ -334,7 +334,8 @@
 		use:autosize
 		rows={3}
 		on:input={handleInput}
-		on:blur={() => {
+		on:blur={(e) => {
+			e.preventDefault()
 			setTimeout(() => {
 				showContextTooltip = false
 			}, 100)

--- a/frontend/src/lib/components/settings/TokensTable.svelte
+++ b/frontend/src/lib/components/settings/TokensTable.svelte
@@ -334,21 +334,23 @@
 					<input type="text" bind:value={newTokenLabel} class="w-full" />
 				</div>
 
-				<div>
-					<span class="block mb-1"
-						>Expires In <span class="text-xs text-tertiary">(optional)</span></span
-					>
-					<select bind:value={newTokenExpiration} disabled={mcpCreationMode} class="w-full">
-						<option value={undefined}>No expiration</option>
-						<option value={15 * 60}>15m</option>
-						<option value={30 * 60}>30m</option>
-						<option value={1 * 60 * 60}>1h</option>
-						<option value={1 * 24 * 60 * 60}>1d</option>
-						<option value={7 * 24 * 60 * 60}>7d</option>
-						<option value={30 * 24 * 60 * 60}>30d</option>
-						<option value={90 * 24 * 60 * 60}>90d</option>
-					</select>
-				</div>
+				{#if !mcpCreationMode}
+					<div>
+						<span class="block mb-1"
+							>Expires In <span class="text-xs text-tertiary">(optional)</span></span
+						>
+						<select bind:value={newTokenExpiration} class="w-full">
+							<option value={undefined}>No expiration</option>
+							<option value={15 * 60}>15m</option>
+							<option value={30 * 60}>30m</option>
+							<option value={1 * 60 * 60}>1h</option>
+							<option value={1 * 24 * 60 * 60}>1d</option>
+							<option value={7 * 24 * 60 * 60}>7d</option>
+							<option value={30 * 24 * 60 * 60}>30d</option>
+							<option value={90 * 24 * 60 * 60}>90d</option>
+						</select>
+					</div>
+				{/if}
 			</div>
 
 			<div class="mt-4 flex justify-end gap-2 flex-row">

--- a/frontend/src/lib/components/settings/UserInfoSettings.svelte
+++ b/frontend/src/lib/components/settings/UserInfoSettings.svelte
@@ -37,7 +37,7 @@
 			<div class="text-red-600 text-2xs grow">{passwordError}</div>
 		{/if}
 		<div class="flex flex-col gap-2 w-full">
-			<div class="mt-4">
+			<form class="mt-4">
 				<label class="block w-60 mb-2 text-tertiary">
 					<div class="text-secondary">email</div>
 					<input type="text" disabled value={$usersWorkspaceStore?.email} class="input mt-1" />
@@ -66,7 +66,7 @@
 				{:else if login_type == 'github'}
 					<span class="text-sm">Authenticated through Github OAuth2. Cannot set a password.</span>
 				{/if}
-			</div>
+			</form>
 		</div>
 	</div>
 </div>

--- a/frontend/src/lib/components/settings/UserInfoSettings.svelte
+++ b/frontend/src/lib/components/settings/UserInfoSettings.svelte
@@ -46,6 +46,7 @@
 					<label class="block w-120">
 						<div class="text-secondary">password</div>
 						<input
+							autocomplete="new-password"
 							type="password"
 							bind:value={newPassword}
 							class="

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,5 +1,6 @@
 const plugin = require('tailwindcss/plugin')
 const { tailwindClasses } = require('./src/lib/components/apps/editor/componentsPanel/tailwindUtils')
+const { zIndexes } = require('./src/lib/zIndexes')
 
 const lightTheme = {
 	surface: '#ffffff',
@@ -82,6 +83,7 @@ const config = {
 		'autocomplete-list-item-create',
 		'selected',
 		'wm-tab-selected',
+		...Object.values(zIndexes).map((zIndex) => `z-[${zIndex}]`),
 		...tailwindClasses
 	],
 	theme: {


### PR DESCRIPTION
- When we opened user settings it would auto complete the search on the homepage with the user's email when it was saved in chrome password manager
- Fixed ai chat tooltip position when at the edge of the screen
- Fixed missclicks on the buttons of the tooltip by increasing time out for on blur event
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes user settings autocomplete issue and AI chat tooltip positioning, with minor Tailwind config update.
> 
>   - **User Settings Autocomplete**:
>     - Added `autocomplete="new-password"` to password input in `UserInfoSettings.svelte` to prevent Chrome from auto-filling the email.
>   - **AI Chat Tooltip**:
>     - Adjusted tooltip position in `ContextTextarea.svelte` to prevent overflow at screen edges.
>     - Increased `on:blur` timeout from 100ms to 200ms to reduce missclicks on tooltip buttons.
>   - **Misc**:
>     - Conditional rendering of token expiration options in `TokensTable.svelte` based on `mcpCreationMode`.
>     - Added z-index classes from `zIndexes` to Tailwind safelist in `tailwind.config.cjs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 835ae99f292e702dc351093709cc97a59161bb31. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->