### PR TITLE
fix: rendering of datatable in workers page

### DIFF
--- a/frontend/src/routes/(root)/(logged)/workers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/workers/+page.svelte
@@ -590,7 +590,7 @@
 									<Cell head>Limits</Cell>
 									<Cell head>Version</Cell>
 									<Cell head>Liveness</Cell>
-									<Cell head last
+									<Cell head last 
 										>Live Shell <Tooltip>
 											<p class="text-sm">
 												Open a live shell to execute bash commands on the machine where the worker
@@ -718,6 +718,7 @@
 												<Cell last>
 													<Button
 														size="xs"
+														btnClasses="pl-0"
 														color="light"
 														on:click={() => {
 															if (isWorkerAlive === false) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add padding adjustment to a button in `+page.svelte`.
> 
>   - **UI Changes**:
>     - Add `btnClasses="pl-0"` to a `Button` element in `+page.svelte` to adjust padding.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for e4997dcb45438a8a50db87cad6a870cababf203d. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->