### PR TITLE
fix: fix app drawer right offset when ai chat is open

### DIFF
--- a/frontend/src/lib/components/apps/components/layout/AppDrawer.svelte
+++ b/frontend/src/lib/components/apps/components/layout/AppDrawer.svelte
@@ -136,6 +136,7 @@
 				outputs?.open.set(false)
 				onCloseRecomputeIds?.forEach((id) => $runnableComponents?.[id]?.cb?.map((cb) => cb?.()))
 			}}
+			disableChatOffset={true}
 		>
 			<DrawerContent
 				title={resolvedConfig.drawerTitle}

--- a/frontend/src/lib/components/common/drawer/Drawer.svelte
+++ b/frontend/src/lib/components/common/drawer/Drawer.svelte
@@ -13,6 +13,7 @@
 	export let shouldUsePortal: boolean = true
 	export let offset: number = 0
 	export let preventEscape = false
+	export let disableChatOffset: boolean = false
 
 	let disposable: Disposable | undefined = undefined
 
@@ -81,7 +82,7 @@
 			class:open
 			class:close={!open && timeout}
 			class:global-chat-open={aiChatManager.open}
-			style={`${style}; --zIndex: ${zIndex}; --adjusted-offset: calc(${aiChatManager.open && placement === 'right' ? aiChatManager.size : 0}% + 4px)`}
+			style={`${style}; --zIndex: ${zIndex}; --adjusted-offset: calc(${aiChatManager.open && placement === 'right' && !disableChatOffset ? aiChatManager.size : 0}% + 4px)`}
 		>
 			<!-- svelte-ignore a11y-click-events-have-key-events -->
 			<!-- svelte-ignore a11y-no-static-element-interactions -->


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes app drawer right offset issue when AI chat is open by adding `disableChatOffset` property to control offset adjustment.
> 
>   - **Behavior**:
>     - Adds `disableChatOffset` property to `Drawer.svelte` to control offset adjustment when AI chat is open.
>     - Sets `disableChatOffset` to `true` in `AppDrawer.svelte` to fix right offset issue.
>   - **Components**:
>     - Updates `Drawer.svelte` to use `disableChatOffset` in offset calculation.
>     - Modifies `AppDrawer.svelte` to pass `disableChatOffset` to `Drawer` component.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f0766c51e79beeb73e51f2a67ac3dcd0be257ae5. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->