### PR TITLE
nit: show disabled message when lang not supported

### DIFF
--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -353,12 +353,6 @@
 	let testPanelSize = $state(30)
 	let storedTestPanelSize = untrack(() => testPanelSize)
 
-	$effect(() => {
-		if (SUPPORTED_CHAT_SCRIPT_LANGUAGES.includes(lang ?? '') == !aiChatManager.open) {
-			untrack(() => aiChatManager.toggleOpen())
-		}
-	})
-
 	function toggleTestPanel() {
 		if (testPanelSize > 0) {
 			storedTestPanelSize = testPanelSize

--- a/frontend/src/lib/components/copilot/chat/AIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChat.svelte
@@ -12,15 +12,26 @@
 	import { aiChatManager, AIMode } from './AIChatManager.svelte'
 	import { base } from '$lib/base'
 	import HideButton from '$lib/components/apps/editor/settingsPanel/HideButton.svelte'
+	import { SUPPORTED_CHAT_SCRIPT_LANGUAGES } from './script/core'
 
 	const isAdmin = $derived($userStore?.is_admin || $userStore?.is_super_admin)
 	const hasCopilot = $derived($copilotInfo.enabled)
+	const disabled = $derived(
+		!hasCopilot ||
+			(aiChatManager.mode === AIMode.SCRIPT &&
+				aiChatManager.scriptEditorOptions?.lang &&
+				!SUPPORTED_CHAT_SCRIPT_LANGUAGES.includes(aiChatManager.scriptEditorOptions.lang))
+	)
 	const disabledMessage = $derived(
-		hasCopilot
-			? ''
-			: isAdmin
+		!hasCopilot
+			? isAdmin
 				? `Enable Windmill AI in your [workspace settings](${base}/workspace_settings?tab=ai) to use this chat`
 				: 'Ask an admin to enable Windmill AI in this workspace to use this chat'
+			: aiChatManager.mode === AIMode.SCRIPT &&
+				  aiChatManager.scriptEditorOptions?.lang &&
+				  !SUPPORTED_CHAT_SCRIPT_LANGUAGES.includes(aiChatManager.scriptEditorOptions.lang)
+				? `Windmill AI does not support the ${aiChatManager.scriptEditorOptions.lang} language yet.`
+				: ''
 	)
 
 	const suggestions = [
@@ -143,7 +154,7 @@
 		!!aiChatManager.scriptEditorOptions.lastDeployedCode &&
 		aiChatManager.scriptEditorOptions.lastDeployedCode !== aiChatManager.scriptEditorOptions.code}
 	diffMode={aiChatManager.scriptEditorOptions?.diffMode ?? false}
-	disabled={!hasCopilot}
+	{disabled}
 	{disabledMessage}
 	{suggestions}
 ></AIChatDisplay>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Display a message in `AIChat.svelte` when the selected language is unsupported, and remove redundant effect in `ScriptEditor.svelte`.
> 
>   - **Behavior**:
>     - Display a message in `AIChat.svelte` when the selected language is not supported by Windmill AI.
>     - Removed effect in `ScriptEditor.svelte` that toggled AI chat panel based on language support.
>   - **Logic**:
>     - `disabledMessage` in `AIChat.svelte` now includes a message for unsupported languages.
>     - `disabled` derived in `AIChat.svelte` to disable chat when language is unsupported or copilot is disabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 7cc92af505b782475cf2c66d9aaafca5ed1a1ca6. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->