### PR TITLE
remove unnecessary dispatchIfMounted

### DIFF
--- a/frontend/src/lib/components/ArgInput.svelte
+++ b/frontend/src/lib/components/ArgInput.svelte
@@ -41,7 +41,6 @@
 	import type { Script } from '$lib/gen'
 	import type { SchemaDiff } from '$lib/components/schema/schemaUtils.svelte'
 	import type { ComponentCustomCSS } from './apps/types'
-	import { createDispatcherIfMounted } from '$lib/createDispatcherIfMounted'
 
 	interface Props {
 		label?: string
@@ -224,7 +223,6 @@
 	}
 
 	const dispatch = createEventDispatcher()
-	const dispatchIfMounted = createDispatcherIfMounted(dispatch)
 
 	let ignoreValueUndefined = $state(false)
 	let error: string = $state('')
@@ -447,7 +445,7 @@
 	function compareValues(value) {
 		if (!deepEqual(oldValue, value)) {
 			oldValue = value
-			dispatchIfMounted('change')
+			dispatch('change')
 		}
 	}
 

--- a/frontend/src/lib/components/DisplayResult.svelte
+++ b/frontend/src/lib/components/DisplayResult.svelte
@@ -38,14 +38,12 @@
 	import type { DisplayResultUi } from './custom_ui'
 	import { getContext, hasContext, createEventDispatcher, onDestroy } from 'svelte'
 	import { toJsonStr } from '$lib/utils'
-	import { createDispatcherIfMounted } from '$lib/createDispatcherIfMounted'
 
 	const IMG_MAX_SIZE = 10000000
 	const TABLE_MAX_SIZE = 5000000
 	const DISPLAY_MAX_SIZE = 100000
 
 	const dispatch = createEventDispatcher()
-	const dispatchIfMounted = createDispatcherIfMounted(dispatch)
 
 	let resultKind:
 		| 'json'
@@ -433,7 +431,7 @@
 		} else {
 			toolbarLocation = 'self'
 		}
-		dispatchIfMounted('toolbar-location-changed', toolbarLocation)
+		dispatch('toolbar-location-changed', toolbarLocation)
 	}
 
 	export function getToolbarLocation() {

--- a/frontend/src/lib/components/EditableSchemaForm.svelte
+++ b/frontend/src/lib/components/EditableSchemaForm.svelte
@@ -27,11 +27,9 @@
 	import { tweened } from 'svelte/motion'
 	import type { SchemaDiff } from '$lib/components/schema/schemaUtils.svelte'
 	import type { EditableSchemaFormUi } from '$lib/components/custom_ui'
-	import { createDispatcherIfMounted } from '$lib/createDispatcherIfMounted'
 
 	// export let openEditTab: () => void = () => {}
 	const dispatch = createEventDispatcher()
-	const dispatchIfMounted = createDispatcherIfMounted(dispatch)
 
 	interface Props {
 		schema: Schema | any
@@ -281,7 +279,7 @@
 	function updatePanelSizes(editSize: number, inputSize: number) {
 		editPanelSize = editSize
 		inputPanelSize = inputSize
-		dispatchIfMounted('editPanelSizeChanged', editSize)
+		dispatch('editPanelSizeChanged', editSize)
 	}
 
 	let panelButtonWidth: number = $state(0)

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -42,7 +42,6 @@
 	import HideButton from './apps/editor/settingsPanel/HideButton.svelte'
 	import { base } from '$lib/base'
 	import { SUPPORTED_CHAT_SCRIPT_LANGUAGES } from './copilot/chat/script/core'
-	import { createDispatcherIfMounted } from '$lib/createDispatcherIfMounted'
 	import { getStringError } from './copilot/chat/utils'
 	import type { ScriptOptions } from './copilot/chat/ContextManager.svelte'
 	import { aiChatManager, AIMode } from './copilot/chat/AIChatManager.svelte'
@@ -127,12 +126,11 @@
 	})
 
 	const dispatch = createEventDispatcher()
-	const dispatchIfMounted = createDispatcherIfMounted(dispatch)
 
 	$effect(() => {
 		watchChanges &&
 			(code != undefined || schema != undefined) &&
-			dispatchIfMounted('change', { code, schema })
+			dispatch('change', { code, schema })
 	})
 
 	let width = $state(1200)

--- a/frontend/src/lib/components/apps/components/helpers/RunnableComponent.svelte
+++ b/frontend/src/lib/components/apps/components/helpers/RunnableComponent.svelte
@@ -28,7 +28,6 @@
 	import { computeWorkspaceS3FileInputPolicy } from '../../editor/appUtilsS3'
 	import { executeRunnable } from './executeRunnable'
 	import SchemaForm from '$lib/components/SchemaForm.svelte'
-	import { createDispatcherIfMounted } from '$lib/createDispatcherIfMounted'
 
 	interface Props {
 		// Component props
@@ -123,7 +122,6 @@
 	const groupContext = getContext<GroupContext>('GroupContext')
 
 	const dispatch = createEventDispatcher()
-	const dispatchIfMounted = createDispatcherIfMounted(dispatch)
 
 	$runnableComponents = $runnableComponents
 
@@ -735,7 +733,7 @@
 	})
 	let ignoreFirst = true
 	$effect(() => {
-		runnableInputValues && !ignoreFirst && dispatchIfMounted('argsChanged')
+		runnableInputValues && !ignoreFirst && dispatch('argsChanged')
 		ignoreFirst = false
 	})
 	let refreshOn = $derived(

--- a/frontend/src/lib/components/common/tabs/Tabs.svelte
+++ b/frontend/src/lib/components/common/tabs/Tabs.svelte
@@ -3,11 +3,9 @@
 	import { writable } from 'svelte/store'
 	import { createEventDispatcher } from 'svelte'
 	import { twMerge } from 'tailwind-merge'
-	import { createDispatcherIfMounted } from '$lib/createDispatcherIfMounted'
 	import type { TabsContext } from '$lib/components/apps/editor/settingsPanel/inputEditor/tabs.svelte'
 
 	const dispatch = createEventDispatcher<{ selected: string }>()
-	const dispatchIfMounted = createDispatcherIfMounted(dispatch)
 
 	interface Props {
 		selected: string
@@ -68,7 +66,7 @@
 	$effect(() => {
 		if ($selectedStore !== untrack(() => lastSelected)) {
 			lastSelected = $selectedStore
-			$selectedStore && dispatchIfMounted('selected', $selectedStore)
+			$selectedStore && dispatch('selected', $selectedStore)
 		}
 	})
 </script>

--- a/frontend/src/lib/components/table/DataTable.svelte
+++ b/frontend/src/lib/components/table/DataTable.svelte
@@ -10,12 +10,10 @@
 	import { ArrowDownIcon, ArrowLeftIcon, ArrowRightIcon, Loader2 } from 'lucide-svelte'
 	import { twMerge } from 'tailwind-merge'
 	import List from '$lib/components/common/layout/List.svelte'
-	import { createDispatcherIfMounted } from '$lib/createDispatcherIfMounted'
 
 	let footerHeight: number = $state(0)
 	let tableHeight: number = $state(0)
 	const dispatch = createEventDispatcher()
-	const dispatchIfMounted = createDispatcherIfMounted(dispatch)
 	let tableContainer: HTMLDivElement | undefined = $state()
 	interface Props {
 		paginated?: boolean
@@ -75,7 +73,7 @@
 
 		const hasScrollbar = tableContainer.scrollHeight > tableContainer.clientHeight
 		if (!hasScrollbar && hasMore) {
-			dispatchIfMounted('loadMore')
+			dispatch('loadMore')
 		}
 	}
 


### PR DESCRIPTION
$effect is always run after mount, so dispatchIfMounted doesn't make sense anymore in places where it is only called in an effect

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `dispatchIfMounted` calls and replace with direct `dispatch` in Svelte components, as `$effect` ensures execution post-mount.
> 
>   - **Behavior**:
>     - Replaces `dispatchIfMounted` with `dispatch` in `$effect` blocks across multiple components, as `$effect` is always run after mount.
>   - **Components**:
>     - `ArgInput.svelte`: Replaces `dispatchIfMounted('change')` with `dispatch('change')` in `compareValues()`.
>     - `DisplayResult.svelte`: Replaces `dispatchIfMounted('toolbar-location-changed', toolbarLocation)` with `dispatch('toolbar-location-changed', toolbarLocation)` in `chooseToolbarLocation()`.
>     - `EditableSchemaForm.svelte`: Replaces `dispatchIfMounted('editPanelSizeChanged', editSize)` with `dispatch('editPanelSizeChanged', editSize)` in `updatePanelSizes()`.
>     - `ScriptEditor.svelte`: Replaces `dispatchIfMounted('change', { code, schema })` with `dispatch('change', { code, schema })` in `$effect` block.
>     - `RunnableComponent.svelte`: Replaces `dispatchIfMounted('argsChanged')` with `dispatch('argsChanged')` in `$effect` block.
>     - `Tabs.svelte`: Replaces `dispatchIfMounted('selected', $selectedStore)` with `dispatch('selected', $selectedStore)` in `$effect` block.
>     - `DataTable.svelte`: Replaces `dispatchIfMounted('loadMore')` with `dispatch('loadMore')` in `checkScrollStatus()` and `handleScroll()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 3a3d3d6630b0d9081189191acc06a0d943dca944. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->