### PR TITLE
worker page ui fixes

### DIFF
--- a/frontend/src/routes/(root)/(logged)/workers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/workers/+page.svelte
@@ -590,14 +590,17 @@
 									<Cell head>Limits</Cell>
 									<Cell head>Version</Cell>
 									<Cell head>Liveness</Cell>
-									<Cell head last
-										>Live Shell <Tooltip>
-											<p class="text-sm">
-												Open a live shell to execute bash commands on the machine where the worker
-												runs — useful for quick access, inspection, and real-time debugging
-											</p>
-										</Tooltip></Cell
-									>
+									{#if $superadmin}
+										<Cell head>
+											Live Shell
+											<Tooltip>
+												<p class="text-sm">
+													Open a live shell to execute bash commands on the machine where the worker
+													runs — useful for quick access, inspection, and real-time debugging
+												</p>
+											</Tooltip>
+										</Cell>
+									{/if}
 								</tr>
 							</Head>
 							<tbody class="divide-y">
@@ -607,7 +610,7 @@
 										<Cell
 											first
 											colspan={(!config || config?.dedicated_worker == undefined) && $superadmin
-												? 11
+												? 12
 												: 9}
 											scope="colgroup"
 											class="bg-surface-secondary/30 !py-1 border-b !text-xs"
@@ -717,34 +720,36 @@
 															: 'Unknown'}
 													</Badge>
 												</Cell>
-												<Cell last>
-													<Button
-														size="xs"
-														color="light"
-														on:click={() => {
-															if (isWorkerAlive === false) {
-																sendUserToast('Worker must be alive', true)
-																return
-															}
-															if (worker.startsWith(AGENT_WORKER_NAME_PREFIX)) {
-																if (!sshWorker) {
-																	sendUserToast(
-																		'Unexpected error could not find agent worker handling repl feature',
-																		true
-																	)
+												{#if $superadmin}
+													<Cell>
+														<Button
+															size="xs"
+															color="light"
+															on:click={() => {
+																if (isWorkerAlive === false) {
+																	sendUserToast('Worker must be alive', true)
 																	return
 																}
-																tag = sshWorker
-															} else {
-																tag = hostname
-															}
-															replForWorkerDrawer?.openDrawer()
-														}}
-														startIcon={{ icon: Terminal }}
-													>
-														Command
-													</Button>
-												</Cell>
+																if (worker.startsWith(AGENT_WORKER_NAME_PREFIX)) {
+																	if (!sshWorker) {
+																		sendUserToast(
+																			'Unexpected error could not find agent worker handling repl feature',
+																			true
+																		)
+																		return
+																	}
+																	tag = sshWorker
+																} else {
+																	tag = hostname
+																}
+																replForWorkerDrawer?.openDrawer()
+															}}
+															startIcon={{ icon: Terminal }}
+														>
+															Command
+														</Button>
+													</Cell>
+												{/if}
 											</tr>
 										{/each}
 									{/if}

--- a/frontend/src/routes/(root)/(logged)/workers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/workers/+page.svelte
@@ -746,7 +746,7 @@
 															}}
 															startIcon={{ icon: Terminal }}
 														>
-															Command
+															ssh
 														</Button>
 													</Cell>
 												{/if}


### PR DESCRIPTION
Fix group title not spanning whole table + hide Live Shell when not superadmin

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> UI fixes in `+page.svelte` to hide "Live Shell" for non-superadmins and adjust group title span.
> 
>   - **UI Adjustments**:
>     - Hide "Live Shell" column and button in the workers table for non-superadmin users in `+page.svelte`.
>     - Ensure group title spans the entire table by adjusting `colspan` from 11 to 12 in `+page.svelte`.
>   - **Conditional Rendering**:
>     - Wrap "Live Shell" column and button in `{#if $superadmin}` blocks to restrict access to superadmin users in `+page.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 18799c7482daad8f08988fcc9a2a472342d818d5. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->