### PR TITLE
chore(frontend): convert ai context components to svelte5

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
@@ -283,17 +283,16 @@
 			</div>
 			<ContextTextarea
 				bind:this={contextTextareaComponent}
-				instructions={aiChatManager.instructions}
 				{availableContext}
 				{selectedContext}
 				isFirstMessage={messages.length === 0}
-				on:addContext={(e) => addContextToSelection(e.detail.contextElement)}
-				on:sendRequest={() => {
+				onAddContext={(contextElement) => addContextToSelection(contextElement)}
+				onSendRequest={() => {
 					if (!aiChatManager.loading) {
 						aiChatManager.sendRequest()
 					}
 				}}
-				on:updateInstructions={(e) => (aiChatManager.instructions = e.detail.value)}
+				onUpdateInstructions={(value) => (aiChatManager.instructions = value)}
 				{disabled}
 			/>
 		{:else}

--- a/frontend/src/lib/components/copilot/chat/AvailableContextList.svelte
+++ b/frontend/src/lib/components/copilot/chat/AvailableContextList.svelte
@@ -26,26 +26,19 @@
 		default: 3
 	}
 
-	const sortedAvailableContext = $derived.by(() => {
-		let copy = [...availableContext]
-		copy.sort((a, b) => {
-			const priorityA = typePriority[a.type] || typePriority.default
-			const priorityB = typePriority[b.type] || typePriority.default
-			return priorityA - priorityB
-		})
-		return copy
-	})
-
 	const actualAvailableContext = $derived(
-		showAllAvailable
-			? sortedAvailableContext.filter(
-					(c) => !stringSearch || c.title.toLowerCase().includes(stringSearch.toLowerCase())
-				)
-			: sortedAvailableContext.filter(
-					(c) =>
-						!selectedContext.find((sc) => sc.type === c.type && sc.title === c.title) &&
-						(!stringSearch || c.title.toLowerCase().includes(stringSearch.toLowerCase()))
-				)
+		availableContext
+			.filter(
+				(c) =>
+					(showAllAvailable ||
+						!selectedContext.some((sc) => sc.type === c.type && sc.title === c.title)) &&
+					(!stringSearch || c.title.toLowerCase().includes(stringSearch.toLowerCase()))
+			)
+			.sort((a, b) => {
+				const priorityA = typePriority[a.type] || typePriority.default
+				const priorityB = typePriority[b.type] || typePriority.default
+				return priorityA - priorityB
+			})
 	)
 </script>
 

--- a/frontend/src/lib/components/copilot/chat/AvailableContextList.svelte
+++ b/frontend/src/lib/components/copilot/chat/AvailableContextList.svelte
@@ -1,12 +1,23 @@
 <script lang="ts">
 	import { ContextIconMap, type ContextElement } from './context'
 
-	export let availableContext: ContextElement[]
-	export let selectedContext: ContextElement[]
-	export let onSelect: (element: ContextElement) => void
-	export let showAllAvailable = false
-	export let stringSearch = ''
-	export let selectedIndex = 0
+	interface Props {
+		availableContext: ContextElement[]
+		selectedContext: ContextElement[]
+		onSelect: (element: ContextElement) => void
+		showAllAvailable?: boolean
+		stringSearch?: string
+		selectedIndex?: number
+	}
+
+	const {
+		availableContext,
+		selectedContext,
+		onSelect,
+		showAllAvailable = false,
+		stringSearch = '',
+		selectedIndex = 0
+	}: Props = $props()
 
 	// Define priority map for context types
 	const typePriority = {
@@ -15,21 +26,27 @@
 		default: 3
 	}
 
-	$: sortedAvailableContext = availableContext.sort((a, b) => {
-		const priorityA = typePriority[a.type] || typePriority.default
-		const priorityB = typePriority[b.type] || typePriority.default
-		return priorityA - priorityB
+	const sortedAvailableContext = $derived.by(() => {
+		let copy = [...availableContext]
+		copy.sort((a, b) => {
+			const priorityA = typePriority[a.type] || typePriority.default
+			const priorityB = typePriority[b.type] || typePriority.default
+			return priorityA - priorityB
+		})
+		return copy
 	})
 
-	$: actualAvailableContext = showAllAvailable
-		? sortedAvailableContext.filter(
-				(c) => !stringSearch || c.title.toLowerCase().includes(stringSearch.toLowerCase())
-			)
-		: sortedAvailableContext.filter(
-				(c) =>
-					!selectedContext.find((sc) => sc.type === c.type && sc.title === c.title) &&
-					(!stringSearch || c.title.toLowerCase().includes(stringSearch.toLowerCase()))
-			)
+	const actualAvailableContext = $derived(
+		showAllAvailable
+			? sortedAvailableContext.filter(
+					(c) => !stringSearch || c.title.toLowerCase().includes(stringSearch.toLowerCase())
+				)
+			: sortedAvailableContext.filter(
+					(c) =>
+						!selectedContext.find((sc) => sc.type === c.type && sc.title === c.title) &&
+						(!stringSearch || c.title.toLowerCase().includes(stringSearch.toLowerCase()))
+				)
+	)
 </script>
 
 <div class="flex flex-col gap-1 text-tertiary text-xs p-1 min-w-24 max-h-48 overflow-y-scroll">
@@ -37,14 +54,17 @@
 		<div class="text-center text-tertiary text-xs">No available context</div>
 	{:else}
 		{#each actualAvailableContext as element, i}
+			{@const Icon = ContextIconMap[element.type]}
 			<button
 				class="hover:bg-surface-hover rounded-md p-1 text-left flex flex-row gap-1 items-center font-normal {i ===
 				selectedIndex
 					? 'bg-surface-hover'
 					: ''}"
-				on:click={() => onSelect(element)}
+				onclick={() => onSelect(element)}
 			>
-				<svelte:component this={ContextIconMap[element.type]} size={16} />
+				{#if Icon}
+					<Icon size={16} />
+				{/if}
 				{element.type === 'diff' ? element.title.replace(/_/g, ' ') : element.title}
 			</button>
 		{/each}

--- a/frontend/src/lib/components/copilot/chat/ContextElementBadge.svelte
+++ b/frontend/src/lib/components/copilot/chat/ContextElementBadge.svelte
@@ -27,7 +27,7 @@
 	<svelte:fragment slot="trigger">
 		<div
 			class={twMerge(
-				'border rounded-md px-1 py-0.5 flex flex-row items-center gap-1 text-tertiary text-xs cursor-default hover:bg-surface-hover hover:cursor-pointer'
+				'border rounded-md px-1 py-0.5 flex flex-row items-center gap-1 text-tertiary text-xs cursor-default hover:bg-surface-hover hover:cursor-pointer max-w-48'
 			)}
 			on:mouseenter={() => (showDelete = true)}
 			on:mouseleave={() => (showDelete = false)}
@@ -42,9 +42,11 @@
 					<svelte:component this={icon} size={16} />
 				{/if}
 			</button>
-			{contextElement.type === 'diff'
-				? contextElement.title.replace(/_/g, ' ')
-				: contextElement.title}
+			<span class="truncate">
+				{contextElement.type === 'diff'
+					? contextElement.title.replace(/_/g, ' ')
+					: contextElement.title}
+			</span>
 		</div>
 	</svelte:fragment>
 	<svelte:fragment slot="content">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor Svelte components to align with Svelte 5 standards, updating event handling, state management, and component properties.
> 
>   - **Event Handling**:
>     - `AIChatDisplay.svelte`: Renamed events from `on:event` to `onEvent` for `ContextTextarea`.
>     - `ContextTextarea.svelte`: Replaced `createEventDispatcher` with direct function calls for `onAddContext`, `onSendRequest`, and `onUpdateInstructions`.
>   - **State Management**:
>     - `ContextTextarea.svelte`: Introduced `$state` for managing local state variables like `showContextTooltip`, `contextTooltipWord`, etc.
>     - `AvailableContextList.svelte`: Used `$props` to destructure component properties.
>   - **Component Properties**:
>     - `AvailableContextList.svelte` and `ContextTextarea.svelte`: Defined `Props` interface for component properties.
>     - `AIChatDisplay.svelte`: Updated component bindings and event handlers to match new property and event naming conventions.
>   - **Miscellaneous**:
>     - `ContextElementBadge.svelte`: Added `max-w-48` class for truncating long text.
>     - `ContextTextarea.svelte`: Updated tooltip positioning logic and rendering conditions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 38ae0e17bdbe5980aeb90a34259c18345d162a85. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->