### PR TITLE
fix: fix input with wrong height on first render

### DIFF
--- a/frontend/src/lib/autosize.ts
+++ b/frontend/src/lib/autosize.ts
@@ -10,6 +10,8 @@ export const autosize = (node: TextArea) => {
 	const MIN_HEIGHT = 30 // px
 	const EXTRA = 2 // px added to scrollHeight
 
+	let width = 0
+
 	/* ------------------------------------------------------------------
 	 * Core resize routine
 	 * ---------------------------------------------------------------- */
@@ -64,7 +66,13 @@ export const autosize = (node: TextArea) => {
 	 *   • first time the element gets a real width
 	 *   • container/window resizes afterwards
 	 * ---------------------------------------------------------------- */
-	const ro = new ResizeObserver(resize)
+	const ro = new ResizeObserver(([entry]) => {
+		const newWidth = entry.contentRect.width
+		if (newWidth !== width) {
+			width = newWidth
+			resize()
+		}
+	})
 	ro.observe(node)
 
 	/* ------------------------------------------------------------------


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes textarea initial render height issue in `autosize.ts` by refactoring code and improving event handling.
> 
>   - **Behavior**:
>     - Fixes initial render height issue for textareas by ensuring correct height calculation on first render in `autosize()`.
>     - Uses `ResizeObserver` to handle width changes and trigger resize.
>   - **Code Structure**:
>     - Refactors `autosize.ts` to improve readability and maintainability.
>     - Replaces `action` with `autosize` and updates export.
>     - Introduces constants `MIN_HEIGHT` and `EXTRA` for height calculations.
>   - **Event Handling**:
>     - Adds `UPDATE_EVENT` to trigger resize on value changes.
>     - Patches `value` property to dispatch `UPDATE_EVENT` on set.
>     - Adds event listeners for `input` and `update` events to manage resizing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 3ffb4095e7f3eb93c90268ff458fbf94d45c5bdf. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->