### PR TITLE
internal: Use new token for docs

### DIFF
--- a/.github/workflows/create-docs.yml
+++ b/.github/workflows/create-docs.yml
@@ -12,12 +12,12 @@ jobs:
       - name: Check organization membership
         id: check-membership
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_ACCESS_TOKEN: ${{ secrets.ORG_ACCESS_TOKEN }}
           COMMENTER: ${{ github.event.comment.user.login }}
         run: |
           ORG="windmill-labs"
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "Authorization: token $GH_TOKEN" \
+            -H "Authorization: token $ORG_ACCESS_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/orgs/$ORG/members/$COMMENTER")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces `GH_TOKEN` with `ORG_ACCESS_TOKEN` in `create-docs.yml` for organization membership checks.
> 
>   - **Token Update**:
>     - Replaces `GH_TOKEN` with `ORG_ACCESS_TOKEN` in `create-docs.yml` for organization membership checks.
>     - Affects the `Check organization membership` step, ensuring the correct token is used for authorization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 56ae51eb73639a18f51b41a32afd7716484505cb. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->