### PR TITLE
fix(frontend): use correct kind for flow insert module btn

### DIFF
--- a/frontend/src/lib/components/flows/map/InsertModuleButton.svelte
+++ b/frontend/src/lib/components/flows/map/InsertModuleButton.svelte
@@ -93,6 +93,13 @@ shouldUsePortal={true} -->
 		</button>
 	{/snippet}
 	{#snippet children({ close })}
-		<InsertModuleInner on:close={() => close(null)} on:insert on:new on:pickFlow on:pickScript />
+		<InsertModuleInner
+			on:close={() => close(null)}
+			on:insert
+			on:new
+			on:pickFlow
+			on:pickScript
+			{kind}
+		/>
 	{/snippet}
 </PopupV2>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Passes `kind` prop to `InsertModuleInner` in `InsertModuleButton.svelte` to ensure correct module type is used.
> 
>   - **Behavior**:
>     - Passes `kind` prop to `InsertModuleInner` in `InsertModuleButton.svelte` to ensure correct module type is used when inserting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 171aa894ff9076e6ddca040b63318c4a406f837d. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->