### PR TITLE
fix drawer subgrid not selecting

### DIFF
--- a/frontend/src/lib/components/apps/editor/AppEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditor.svelte
@@ -298,7 +298,12 @@
 							}
 						} catch {}
 					} else {
-						$focusedGrid = undefined
+						const drawerAlreadyHandledFocusedGrid =
+							item?.data.type === 'drawercomponent' &&
+							$focusedGrid?.parentComponentId === befSelected
+						if (!drawerAlreadyHandledFocusedGrid) {
+							$focusedGrid = undefined
+						}
 					}
 				}
 			}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `$focusedGrid` reset issue in `AppEditor.svelte` for drawer components by adding a condition to prevent unintended deselection.
> 
>   - **Behavior**:
>     - Fixes issue in `AppEditor.svelte` where `$focusedGrid` was incorrectly set to `undefined` when a drawer component was involved.
>     - Adds check to ensure `$focusedGrid` is not reset if `item?.data.type` is `drawercomponent` and `$focusedGrid?.parentComponentId` matches `befSelected`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for b162cf8e816183b0c18f6c871a57af8adde14e7e. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->