### PR TITLE
fix conditional tabs reactivity

### DIFF
--- a/frontend/src/lib/components/apps/editor/settingsPanel/GridCondition.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/GridCondition.svelte
@@ -122,6 +122,7 @@
 			id: generateRandomString(),
 			originalIndex: items.length
 		})
+		items = items
 		component.numberOfSubgrids = items.length + 1
 	}
 </script>

--- a/frontend/src/lib/components/apps/editor/settingsPanel/GridCondition.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/GridCondition.svelte
@@ -124,7 +124,6 @@
 			id: generateRandomString(),
 			originalIndex: items.length
 		})
-		items = items
 		component.numberOfSubgrids = items.length + 1
 	}
 </script>

--- a/frontend/src/lib/components/apps/editor/settingsPanel/GridCondition.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/GridCondition.svelte
@@ -9,27 +9,29 @@
 	import Alert from '$lib/components/common/alert/Alert.svelte'
 	import { twMerge } from 'tailwind-merge'
 	import type { AppViewerContext, RichConfiguration } from '../../types'
-	import { getContext, tick } from 'svelte'
+	import { getContext, tick, untrack } from 'svelte'
 	import { deleteGridItem } from '../appUtils'
 	import type { AppComponent } from '../component'
 
-	export let conditions: RichConfiguration[] = []
-	export let component: AppComponent
+	interface Props {
+		conditions?: RichConfiguration[]
+		component: AppComponent
+	}
 
-	let items = conditions.slice(0, -1).map((condition, index) => {
-		return { value: condition, id: generateRandomString(), originalIndex: index }
+	let { conditions = $bindable([]), component = $bindable() }: Props = $props()
+
+	let items = $state(
+		conditions.slice(0, -1).map((condition, index) => {
+			return { value: condition, id: generateRandomString(), originalIndex: index }
+		})
+	)
+
+	$effect(() => {
+		const nItems = items
+			.map((item) => item.value)
+			.concat([{ type: 'evalv2', expr: 'true', fieldType: 'boolean', connections: [] }])
+		untrack(() => (conditions = nItems))
 	})
-
-	$: conditions = items
-		.map((item) => item.value)
-		.concat([
-			{
-				type: 'evalv2',
-				expr: 'true',
-				fieldType: 'boolean',
-				connections: []
-			}
-		])
 
 	const { app, runnableComponents, componentControl } =
 		getContext<AppViewerContext>('AppViewerContext')
@@ -142,8 +144,8 @@
 				flipDurationMs: 200,
 				dropTargetStyle: {}
 			}}
-			on:consider={handleConsider}
-			on:finalize={handleFinalize}
+			onconsider={handleConsider}
+			onfinalize={handleFinalize}
 		>
 			{#each items as item, index (item.id)}
 				{@const condition = item.value}
@@ -169,14 +171,14 @@
 					</div>
 
 					<div class="flex flex-col justify-center gap-2">
-						<!-- svelte-ignore a11y-click-events-have-key-events -->
-						<!-- svelte-ignore a11y-no-static-element-interactions -->
-						<div on:click={() => deleteSubgrid(index)}>
+						<!-- svelte-ignore a11y_click_events_have_key_events -->
+						<!-- svelte-ignore a11y_no_static_element_interactions -->
+						<div onclick={() => deleteSubgrid(index)}>
 							<X size={16} />
 						</div>
 
-						<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
-						<!-- svelte-ignore a11y-no-static-element-interactions -->
+						<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+						<!-- svelte-ignore a11y_no_static_element_interactions -->
 						<div use:dragHandle class="w-4 h-4 handle" aria-label="drag-handle">
 							<GripVertical size={16} />
 						</div>


### PR DESCRIPTION
- **fix app conditional wrapper reactivity**
- **Convert GridCondition to Svelte 5**

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix reactivity in `GridCondition.svelte` and convert to Svelte 5 using `$bindable`, `$state`, and updated event syntax.
> 
>   - **Reactivity Fixes**:
>     - Use `$bindable` for `conditions` and `component` in `GridCondition.svelte`.
>     - Use `$state` for `items` to improve reactivity.
>     - Use `$effect` to update `conditions` based on `items` changes.
>   - **Svelte 5 Conversion**:
>     - Convert event handler syntax from `on:event` to `onevent`.
>     - Use `untrack` in `$effect` to prevent unnecessary reactivity.
>   - **Misc**:
>     - Fix Svelte a11y comments to use underscores instead of hyphens.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 1e38feab515a2ce128308948501443c375cf75ba. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->