### PR TITLE
docs(changelog): add new entries from changelog

### DIFF
--- a/frontend/src/lib/components/sidebar/changelogs.ts
+++ b/frontend/src/lib/components/sidebar/changelogs.ts
@@ -6,6 +6,12 @@ export type Changelog = {
 
 const changelogs: Changelog[] = [
 	{
+		label: 'Test title',
+		href: 'https://www.windmill.dev/changelog/test-slug',
+		date: '2025-06-12'
+	},
+
+	{
 		label: 'MQTT triggers',
 		href: 'https://www.windmill.dev/changelog/mqtt-triggers',
 		date: '2025-03-11'


### PR DESCRIPTION
This PR adds new changelog entries.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a new changelog entry to `changelogs.ts`.
> 
>   - **Changelog Update**:
>     - Adds a new changelog entry with label 'Test title', href 'https://www.windmill.dev/changelog/test-slug', and date '2025-06-12' to `changelogs.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for c6a6837a2e5c10c7c69bde89c01ae0afbe61e95f. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->