### PR TITLE
Fix unreactive navbar wizard

### DIFF
--- a/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/StaticInputEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/StaticInputEditor.svelte
@@ -25,6 +25,7 @@
 	import JsonEditor from '$lib/components/JsonEditor.svelte'
 	import S3FilePicker from '$lib/components/S3FilePicker.svelte'
 	import FileUpload from '$lib/components/common/fileUpload/FileUpload.svelte'
+	import { stateSnapshot } from '$lib/svelte5Utils.svelte'
 
 	export let componentInput: StaticInput<any> | undefined
 	export let fieldType: InputType | undefined = undefined
@@ -395,7 +396,15 @@
 				</div>
 			</div>
 		{:else if fieldType === 'app-path'}
-			<AppPicker bind:value={componentInput.value} />
+			<AppPicker
+				bind:value={
+					() => componentInput!.value,
+					(v) => {
+						componentInput!.value = v
+						componentInput = stateSnapshot(componentInput)
+					}
+				}
+			/>
 		{:else}
 			<div class="flex gap-1 relative w-full">
 				<textarea

--- a/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/StaticInputEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/StaticInputEditor.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+	import { createBubbler, stopPropagation } from 'svelte/legacy'
+
+	const bubble = createBubbler()
 	import type { InputType, StaticInput, StaticOptions } from '../../../inputType'
 	import ArrayStaticInputEditor from '../ArrayStaticInputEditor.svelte'
 	import ResourcePicker from '$lib/components/ResourcePicker.svelte'
@@ -25,34 +28,62 @@
 	import JsonEditor from '$lib/components/JsonEditor.svelte'
 	import S3FilePicker from '$lib/components/S3FilePicker.svelte'
 	import FileUpload from '$lib/components/common/fileUpload/FileUpload.svelte'
-	import { stateSnapshot } from '$lib/svelte5Utils.svelte'
 
-	export let componentInput: StaticInput<any> | undefined
-	export let fieldType: InputType | undefined = undefined
-	export let subFieldType: InputType | undefined = undefined
-	export let selectOptions: StaticOptions['selectOptions'] | undefined = undefined
-	export let placeholder: string | undefined = undefined
-	export let format: string | undefined = undefined
-	export let id: string | undefined
+	interface Props {
+		componentInput: StaticInput<any> | undefined
+		fieldType?: InputType | undefined
+		subFieldType?: InputType | undefined
+		selectOptions?: StaticOptions['selectOptions'] | undefined
+		placeholder?: string | undefined
+		format?: string | undefined
+		id: string | undefined
+	}
+
+	let {
+		componentInput = $bindable(),
+		fieldType = undefined,
+		subFieldType = undefined,
+		selectOptions = undefined,
+		placeholder = undefined,
+		format = undefined,
+		id
+	}: Props = $props()
 
 	const appContext = getContext<AppViewerContext>('AppViewerContext')
 
-	$: componentInput && appContext?.onchange?.()
-	let s3FileUploadRawMode = false
-	let s3FilePicker: S3FilePicker | undefined = undefined
+	$effect(() => {
+		componentInput && appContext?.onchange?.()
+	})
+	let s3FileUploadRawMode = $state(false)
+	let s3FilePicker: S3FilePicker | undefined = $state(undefined)
 </script>
 
 {#key subFieldType}
 	{#if componentInput?.type === 'static'}
 		{#if fieldType === 'number' || fieldType === 'integer'}
-			<input on:keydown|stopPropagation type="number" bind:value={componentInput.value} />
+			<input
+				onkeydown={stopPropagation(bubble('keydown'))}
+				type="number"
+				bind:value={componentInput.value}
+			/>
 		{:else if fieldType === 'textarea'}
-			<textarea use:autosize on:keydown|stopPropagation bind:value={componentInput.value}
+			<textarea
+				use:autosize
+				onkeydown={stopPropagation(bubble('keydown'))}
+				bind:value={componentInput.value}
 			></textarea>
 		{:else if fieldType === 'date'}
-			<input on:keydown|stopPropagation type="date" bind:value={componentInput.value} />
+			<input
+				onkeydown={stopPropagation(bubble('keydown'))}
+				type="date"
+				bind:value={componentInput.value}
+			/>
 		{:else if fieldType === 'time'}
-			<input on:keydown|stopPropagation type="time" bind:value={componentInput.value} />
+			<input
+				onkeydown={stopPropagation(bubble('keydown'))}
+				type="time"
+				bind:value={componentInput.value}
+			/>
 		{:else if fieldType === 'datetime'}
 			<DateTimeInput bind:value={componentInput.value} />
 		{:else if fieldType === 'boolean'}
@@ -61,7 +92,7 @@
 			{#if subFieldType === 'db-table'}
 				<DBTableSelect bind:componentInput {selectOptions} {id} />
 			{:else}
-				<select on:keydown|stopPropagation bind:value={componentInput.value}>
+				<select onkeydown={stopPropagation(bubble('keydown'))} bind:value={componentInput.value}>
 					{#each selectOptions ?? [] as option}
 						{#if typeof option == 'string'}
 							<option value={option}>
@@ -115,7 +146,7 @@
 			{#if componentInput?.value && typeof componentInput?.value == 'object' && 'label' in componentInput?.value && (componentInput.value?.['value'] == undefined || typeof componentInput.value?.['value'] == 'string')}
 				<div class="flex flex-col gap-1 w-full">
 					<input
-						on:keydown|stopPropagation
+						onkeydown={stopPropagation(bubble('keydown'))}
 						placeholder="Label"
 						type="text"
 						bind:value={componentInput.value['label']}
@@ -401,7 +432,7 @@
 					() => componentInput!.value,
 					(v) => {
 						componentInput!.value = v
-						componentInput = stateSnapshot(componentInput)
+						componentInput = $state.snapshot(componentInput)
 					}
 				}
 			/>
@@ -410,7 +441,7 @@
 				<textarea
 					rows="1"
 					use:autosize
-					on:keydown|stopPropagation
+					onkeydown={stopPropagation(bubble('keydown'))}
 					placeholder={placeholder ?? 'Static value'}
 					bind:value={componentInput.value}
 					class="!pr-12"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improved event handling and state management in `StaticInputEditor.svelte` using `createBubbler`, `stopPropagation`, and reactive state utilities.
> 
>   - **Event Handling**:
>     - Replaced `on:keydown|stopPropagation` with `onkeydown={stopPropagation(bubble('keydown'))}` for inputs and selects in `StaticInputEditor.svelte`.
>   - **State Management**:
>     - Introduced `$bindable`, `$props`, `$effect`, and `$state` for managing component properties and state in `StaticInputEditor.svelte`.
>     - Updated `AppPicker` binding to use `$state.snapshot` for reactivity.
>   - **Misc**:
>     - Added `createBubbler` and `stopPropagation` imports from `svelte/legacy` in `StaticInputEditor.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for b017e659c5036f185c0d52ab47aa16f977bd792d. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->