### PR TITLE
fix: ai chat textarea caret wrong positionning

### DIFF
--- a/frontend/src/lib/components/copilot/chat/ContextTextarea.svelte
+++ b/frontend/src/lib/components/copilot/chat/ContextTextarea.svelte
@@ -333,11 +333,8 @@
 </script>
 
 <div class="relative w-full px-2 scroll-pb-2">
-	<div
-		class="absolute top-0 left-0 w-full h-full min-h-12 px-4 text-sm pt-1 pointer-events-none"
-		style="line-height: 1.72"
-	>
-		<span class="break-words" style="white-space: pre-wrap;">
+	<div class="shared-input-styles absolute top-0 left-0 pointer-events-none">
+		<span class="break-words">
 			{@html getHighlightedText(aiChatManager.instructions)}
 		</span>
 	</div>
@@ -355,7 +352,7 @@
 			}, 200)
 		}}
 		placeholder={isFirstMessage ? 'Ask anything' : 'Ask followup'}
-		class="resize-none bg-transparent caret-black dark:caret-white"
+		class="shared-input-styles resize-none bg-transparent caret-black dark:caret-white"
 		style={aiChatManager.instructions.length > 0
 			? 'color: transparent; -webkit-text-fill-color: transparent;'
 			: ''}
@@ -381,3 +378,17 @@
 		/>
 	</div>
 {/if}
+
+<style>
+	.shared-input-styles {
+		padding: 0.25rem 1rem;
+		border: 1px solid transparent;
+		font-family: inherit;
+		font-size: 0.875rem;
+		line-height: 1.72;
+		white-space: pre-wrap;
+		word-break: break-words;
+		width: 100%;
+		min-height: 3rem;
+	}
+</style>

--- a/frontend/src/lib/components/copilot/chat/ContextTextarea.svelte
+++ b/frontend/src/lib/components/copilot/chat/ContextTextarea.svelte
@@ -333,7 +333,7 @@
 </script>
 
 <div class="relative w-full px-2 scroll-pb-2">
-	<div class="shared-input-styles absolute top-0 left-0 pointer-events-none">
+	<div class="textarea-input absolute top-0 left-0 pointer-events-none">
 		<span class="break-words">
 			{@html getHighlightedText(aiChatManager.instructions)}
 		</span>
@@ -352,7 +352,7 @@
 			}, 200)
 		}}
 		placeholder={isFirstMessage ? 'Ask anything' : 'Ask followup'}
-		class="shared-input-styles resize-none bg-transparent caret-black dark:caret-white"
+		class="textarea-input resize-none bg-transparent caret-black dark:caret-white"
 		style={aiChatManager.instructions.length > 0
 			? 'color: transparent; -webkit-text-fill-color: transparent;'
 			: ''}
@@ -380,7 +380,7 @@
 {/if}
 
 <style>
-	.shared-input-styles {
+	.textarea-input {
 		padding: 0.25rem 1rem;
 		border: 1px solid transparent;
 		font-family: inherit;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes caret positioning in `ContextTextarea.svelte` by adjusting CSS and class usage.
> 
>   - **UI Fix**:
>     - Fixes caret positioning issue in `ContextTextarea.svelte` by adjusting CSS styles.
>     - Adds `.textarea-input` class to both `div` and `textarea` elements for consistent styling.
>   - **Styling**:
>     - Defines `.textarea-input` class in `ContextTextarea.svelte` with padding, border, font, and size properties.
>     - Removes inline styles from `div` and `textarea` elements, consolidating them under `.textarea-input`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 3ab781a0b4c04dfc74130cab57864cdb7f4f5457. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->