### PR TITLE
Fix MQTT undefined binding bug

### DIFF
--- a/frontend/src/lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte
@@ -76,12 +76,12 @@
 	let drawerLoading = $state(true)
 	let showLoading = $state(false)
 	let subscribe_topics: MqttSubscribeTopic[] = $state([])
-	let v3_config: MqttV3Config | undefined = $state()
-	let v5_config: MqttV5Config | undefined = $state()
+	let v3_config: MqttV3Config | undefined = $state({})
+	let v5_config: MqttV5Config | undefined = $state({})
 	let client_version: MqttClientVersion | undefined = $state()
-	let client_id: string | undefined = $state(undefined)
-	let isValid: boolean | undefined = $state(undefined)
-	let initialConfig: Record<string, any> | undefined = undefined
+	let client_id: string | undefined = $state('')
+	let isValid: boolean = $state(false)
+	let initialConfig: Record<string, any> | undefined = {}
 	let deploymentLoading = $state(false)
 
 	const mqttConfig = $derived.by(getSaveCfg)
@@ -247,7 +247,7 @@
 	}
 
 	$effect(() => {
-		let args = [captureConfig, isValid ?? false] as const
+		let args = [captureConfig, isValid] as const
 		onCaptureConfigChange?.(...args)
 	})
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes undefined binding issues in `MqttTriggerEditorInner.svelte` by initializing state variables with default values.
> 
>   - **State Initialization**:
>     - Initialize `v3_config` and `v5_config` with empty objects instead of `undefined` in `MqttTriggerEditorInner.svelte`.
>     - Initialize `client_id` with an empty string and `isValid` with `false` instead of `undefined`.
>     - Initialize `initialConfig` with an empty object instead of `undefined`.
>   - **Effects**:
>     - Remove nullish coalescing for `isValid` in `$effect` to use its initialized value directly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 653df0f624678680ff258206c2c79ccf7dbe54d6. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->