### PR TITLE
fix gcp trigger bind to undefined

### DIFF
--- a/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
@@ -128,7 +128,7 @@
 			delivery_type = defaultValues?.delivery_type ?? 'pull'
 			delivery_config = defaultValues?.delivery_config ?? undefined
 			subscription_id = ''
-			topic_id = defaultValues?.topic_id
+			topic_id = defaultValues?.topic_id ?? ''
 			subscription_mode = defaultValues?.subscription_mode ?? 'create_update'
 			path = defaultValues?.path ?? ''
 			initialPath = ''
@@ -168,7 +168,7 @@
 		is_flow = cfg?.is_flow
 		path = cfg?.path
 		enabled = cfg?.enabled
-		topic_id = cfg?.topic_id
+		topic_id = cfg?.topic_id ?? ''
 		can_write = canWrite(cfg?.path, cfg?.extra_perms, $userStore)
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `topic_id` initialization to default to an empty string in `GcpTriggerEditorInner.svelte` to prevent undefined values.
> 
>   - **Behavior**:
>     - Fix `topic_id` initialization to default to an empty string if undefined in `GcpTriggerEditorInner.svelte`.
>     - Ensures `topic_id` is always defined when loading or creating a new GCP trigger.
>   - **Functions**:
>     - Updates in `openNew()` and `loadTriggerConfig()` to handle `topic_id` defaulting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 3f0e187d62ba2470400d2573a7aea80c8f0e5394. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->