### PR TITLE
prevent datatable from spamming loadMore on scroll to end

### DIFF
--- a/frontend/src/lib/components/table/DataTable.svelte
+++ b/frontend/src/lib/components/table/DataTable.svelte
@@ -73,7 +73,7 @@
 
 		const hasScrollbar = tableContainer.scrollHeight > tableContainer.clientHeight
 		if (!hasScrollbar && hasMore) {
-			dispatch('loadMore')
+			triggerLoadMore()
 		}
 	}
 
@@ -92,9 +92,18 @@
 
 		if (!tableContainer) return
 		const { scrollTop, scrollHeight, clientHeight } = tableContainer
-		if (scrollHeight - (scrollTop + clientHeight) < 50) {
-			dispatch('loadMore')
+		if (scrollHeight - (scrollTop + clientHeight) === 0) {
+			triggerLoadMore()
 		}
+	}
+
+	let lastLoadMoreDispatch: number | undefined = $state(undefined)
+	function triggerLoadMore() {
+		if (lastLoadMoreDispatch && Date.now() - lastLoadMoreDispatch < 1000) {
+			return
+		}
+		dispatch('loadMore')
+		lastLoadMoreDispatch = Date.now()
 	}
 
 	$effect(() => {
@@ -170,7 +179,7 @@
 				<Button
 					color="light"
 					size="xs2"
-					on:click={() => dispatch('loadMore')}
+					on:click={() => triggerLoadMore()}
 					endIcon={{ icon: ArrowDownIcon }}
 				>
 					Load {loadMore} more


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Debounces 'loadMore' event dispatches in `DataTable.svelte` to prevent spamming when scrolling to the end.
> 
>   - **Behavior**:
>     - Introduces `triggerLoadMore()` in `DataTable.svelte` to debounce `loadMore` event dispatches, limiting them to once per second.
>     - Replaces direct `dispatch('loadMore')` calls with `triggerLoadMore()` in `checkScrollStatus()` and `handleScroll()`.
>     - Updates button click handler to use `triggerLoadMore()` instead of `dispatch('loadMore')`.
>   - **Functions**:
>     - Adds `triggerLoadMore()` function to manage debouncing logic using `lastLoadMoreDispatch` timestamp.
>   - **Misc**:
>     - Minor logic adjustment in `handleScroll()` to check for exact scroll end condition (`scrollHeight - (scrollTop + clientHeight) === 0`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 86fdfe83f3d8c00ffff3e41a7940368ae9c9aa78. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->