### PR TITLE
fix(frontend): display branchone default branch label

### DIFF
--- a/frontend/src/lib/components/graph/renderers/nodes/NoBranchNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/NoBranchNode.svelte
@@ -14,7 +14,7 @@
 <NodeWrapper offset={data.offset} enableSourceHandle enableTargetHandle>
 	{#snippet children({ darkMode })}
 		<VirtualItem
-			label="No branches"
+			label={data.label ?? 'No branches'}
 			id={data.id}
 			hideId={true}
 			selectable={true}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `VirtualItem` label in `NoBranchNode.svelte` to use `data.label` if available, defaulting to 'No branches'.
> 
>   - **Behavior**:
>     - In `NoBranchNode.svelte`, change `VirtualItem` label to use `data.label` if available, defaulting to 'No branches'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for ae6b43bd89c9ca0d280f90c2c15044fab17e50ad. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->