### PR TITLE
internal: use git app for git actions

### DIFF
--- a/.github/workflows/change-versions.yml
+++ b/.github/workflows/change-versions.yml
@@ -9,7 +9,14 @@ jobs:
     runs-on: ubicloud
     container: node:18
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.INTERNAL_APP_KEY }}
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app.outputs.token }}
       - run: git config --system --add safe.directory /__w/windmill/windmill
       - name: Change versions
         run: ./.github/change-versions.sh "$(cat version.txt)"
@@ -21,3 +28,5 @@ jobs:
           cd backend
           cargo generate-lockfile
       - uses: stefanzweifel/git-auto-commit-action@v5
+        env:
+          GITHUB_TOKEN: ${{ steps.app.outputs.token }}

--- a/.github/workflows/change-versions.yml
+++ b/.github/workflows/change-versions.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/create-github-app-token@v2
         id: app
         with:
-          app-id: ${{ vars.APP_ID }}
+          app-id: ${{ vars.INTERNAL_APP_ID }}
           private-key: ${{ secrets.INTERNAL_APP_KEY }}
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/change-versions.yml
+++ b/.github/workflows/change-versions.yml
@@ -28,5 +28,8 @@ jobs:
           cd backend
           cargo generate-lockfile
       - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_user_name: windmill-internal-app[bot]
+          commit_user_email: windmill-internal-app[bot]@users.noreply.github.com
         env:
           GITHUB_TOKEN: ${{ steps.app.outputs.token }}

--- a/.github/workflows/check-org-membership.yml
+++ b/.github/workflows/check-org-membership.yml
@@ -1,0 +1,60 @@
+name: Check Organization Membership
+
+on:
+  workflow_call:
+    inputs:
+      commenter:
+        required: true
+        type: string
+        description: 'The username to check for organization membership'
+      organization:
+        required: false
+        type: string
+        default: 'windmill-labs'
+        description: 'The organization to check membership for'
+      trusted_bot:
+        required: false
+        type: string
+        default: 'windmill-internal-app[bot]'
+        description: 'The trusted bot username to allow'
+    secrets:
+      access_token:
+        required: true
+        description: 'The access token to use for org membership check'
+    outputs:
+      is_member:
+        description: 'Whether the user is an organization member or trusted bot'
+        value: ${{ jobs.check-membership.outputs.is_member }}
+
+jobs:
+  check-membership:
+    runs-on: ubicloud-standard-2
+    outputs:
+      is_member: ${{ steps.check-membership.outputs.is_member }}
+    steps:
+      - name: Check organization membership
+        id: check-membership
+        env:
+          ORG_ACCESS_TOKEN: ${{ secrets.access_token }}
+          COMMENTER: ${{ inputs.commenter }}
+          ORG: ${{ inputs.organization }}
+          TRUSTED_BOT: ${{ inputs.trusted_bot }}
+        run: |
+          # 1. Allow the trusted bot straight away
+          if [[ "$COMMENTER" == "$TRUSTED_BOT" ]]; then
+            echo "is_member=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # 2. Otherwise fall back to the org-membership check
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: token $ORG_ACCESS_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/orgs/$ORG/members/$COMMENTER")
+
+          if [ "$STATUS" -eq 204 ]; then
+            echo "is_member=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_member=false" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   check-membership:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/ai') && !contains(github.event.comment.user.login, '[bot]')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '/ai') && !contains(github.event.comment.user.login, '[bot]')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '/ai') && !contains(github.event.review.user.login, '[bot]')) ||
-      (github.event_name == 'issues' && contains(github.event.issue.body, '/ai') && !contains(github.event.issue.user.login, '[bot]'))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/ai')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '/ai')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '/ai')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '/ai'))
     runs-on: ubicloud-standard-2
     outputs:
       is_member: ${{ steps.check-membership.outputs.is_member }}
@@ -25,10 +25,13 @@ jobs:
         id: check-membership
         env:
           ORG_ACCESS_TOKEN: ${{ secrets.ORG_ACCESS_TOKEN }}
+          TRUSTED_BOT: windmill-internal-app[bot]
         run: |
           ORG="windmill-labs"
 
-          if [[ "${{ github.event_name }}" == "issue_comment" || "${{ github.event_name }}" == "pull_request_review_comment" ]]; then
+          # 1. Work out who wrote the comment / review
+          if [[ "${{ github.event_name }}" == "issue_comment" || \
+                "${{ github.event_name }}" == "pull_request_review_comment" ]]; then
             COMMENTER="${{ github.event.comment.user.login }}"
           elif [[ "${{ github.event_name }}" == "pull_request_review" ]]; then
             COMMENTER="${{ github.event.review.user.login }}"
@@ -36,6 +39,13 @@ jobs:
             COMMENTER="${{ github.event.issue.user.login }}"
           fi
 
+          # 2. Allow the GitHub App straight away
+          if [[ "$COMMENTER" == "$TRUSTED_BOT" ]]; then
+            echo "is_member=true"  >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # 3. Otherwise fall back to the org-membership check
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
             -H "Authorization: token $ORG_ACCESS_TOKEN" \
             -H "Accept: application/vnd.github+json" \
@@ -64,13 +74,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      # Cache rust dependencies
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "./backend -> target"
-
-      # Cache node dependencies
       - uses: actions/cache@v3
         with:
           path: ~/.npm

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ on:
     types: [submitted]
 
 jobs:
-  check-membership:
+  determine-commenter:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/ai')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '/ai')) ||
@@ -19,17 +19,12 @@ jobs:
       (github.event_name == 'issues' && contains(github.event.issue.body, '/ai'))
     runs-on: ubicloud-standard-2
     outputs:
-      is_member: ${{ steps.check-membership.outputs.is_member }}
+      commenter: ${{ steps.determine-commenter.outputs.commenter }}
     steps:
-      - name: Check organization membership
-        id: check-membership
-        env:
-          ORG_ACCESS_TOKEN: ${{ secrets.ORG_ACCESS_TOKEN }}
-          TRUSTED_BOT: windmill-internal-app[bot]
+      - name: Determine commenter
+        id: determine-commenter
         run: |
-          ORG="windmill-labs"
-
-          # 1. Work out who wrote the comment / review
+          # Work out who wrote the comment / review
           if [[ "${{ github.event_name }}" == "issue_comment" || \
                 "${{ github.event_name }}" == "pull_request_review_comment" ]]; then
             COMMENTER="${{ github.event.comment.user.login }}"
@@ -38,28 +33,18 @@ jobs:
           else
             COMMENTER="${{ github.event.issue.user.login }}"
           fi
+          echo "commenter=$COMMENTER" >> $GITHUB_OUTPUT
 
-          # 2. Allow the GitHub App straight away
-          if [[ "$COMMENTER" == "$TRUSTED_BOT" ]]; then
-            echo "is_member=true"  >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # 3. Otherwise fall back to the org-membership check
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "Authorization: token $ORG_ACCESS_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/orgs/$ORG/members/$COMMENTER")
-
-          if [ "$STATUS" -eq 204 ]; then
-            echo "is_member=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_member=false" >> $GITHUB_OUTPUT
-          fi
+  check-membership:
+    needs: determine-commenter
+    uses: ./.github/workflows/check-org-membership.yml
+    with:
+      commenter: ${{ needs.determine-commenter.outputs.commenter }}
+    secrets:
+      access_token: ${{ secrets.ORG_ACCESS_TOKEN }}
 
   claude-code-action:
-    needs: check-membership
+    needs: [determine-commenter, check-membership]
     if: |
       needs.check-membership.outputs.is_member == 'true'
     runs-on: ubicloud-standard-8

--- a/.github/workflows/create-docs.yml
+++ b/.github/workflows/create-docs.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.INTERNAL_APP_KEY }}
+          owner: windmill-labs
 
   trigger-docs:
     needs: [generate-token, check-membership]

--- a/.github/workflows/create-docs.yml
+++ b/.github/workflows/create-docs.yml
@@ -22,7 +22,7 @@ jobs:
         id: app
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.APP_ID }}
+          app-id: ${{ vars.INTERNAL_APP_ID }}
           private-key: ${{ secrets.INTERNAL_APP_KEY }}
           owner: windmill-labs
 

--- a/.github/workflows/create-docs.yml
+++ b/.github/workflows/create-docs.yml
@@ -4,38 +4,35 @@ on:
 
 jobs:
   check-membership:
-    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/docs') && github.event.comment.user.type != 'Bot' }}
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/docs') }}
+    uses: ./.github/workflows/check-org-membership.yml
+    with:
+      commenter: ${{ github.event.comment.user.login }}
+    secrets:
+      access_token: ${{ secrets.ORG_ACCESS_TOKEN }}
+
+  generate-token:
+    needs: check-membership
+    if: ${{ needs.check-membership.outputs.is_member == 'true' }}
     runs-on: ubicloud-standard-2
     outputs:
-      is_member: ${{ steps.check-membership.outputs.is_member }}
+      app_token: ${{ steps.app.outputs.token }}
     steps:
-      - name: Check organization membership
-        id: check-membership
-        env:
-          ORG_ACCESS_TOKEN: ${{ secrets.ORG_ACCESS_TOKEN }}
-          COMMENTER: ${{ github.event.comment.user.login }}
-        run: |
-          ORG="windmill-labs"
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "Authorization: token $ORG_ACCESS_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/orgs/$ORG/members/$COMMENTER")
-
-          if [ "$STATUS" -eq 204 ]; then
-            echo "is_member=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_member=false" >> $GITHUB_OUTPUT
-          fi
+      - name: Generate an installation token
+        id: app
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.INTERNAL_APP_KEY }}
 
   trigger-docs:
-    needs: check-membership
-    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/docs') && needs.check-membership.outputs.is_member == 'true' }}
+    needs: [generate-token, check-membership]
+    if: ${{ needs.check-membership.outputs.is_member == 'true' }}
     uses: windmill-labs/windmilldocs/.github/workflows/create-docs.yml@main
     with:
       pr_number: ${{ github.event.issue.number }}
       repo: ${{ github.event.repository.name }}
       comment_text: ${{ github.event.comment.body }}
     secrets:
-      DOCS_TOKEN: ${{ secrets.DOCS_TOKEN }}
+      DOCS_TOKEN: ${{ needs.generate-token.outputs.app_token }}
       GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}

--- a/.github/workflows/helmchart_on_release.yml
+++ b/.github/workflows/helmchart_on_release.yml
@@ -13,7 +13,7 @@ jobs:
         id: app
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.APP_ID }}
+          app-id: ${{ vars.INTERNAL_APP_ID }}
           private-key: ${{ secrets.INTERNAL_APP_KEY }}
           owner: windmill-labs
 

--- a/.github/workflows/helmchart_on_release.yml
+++ b/.github/workflows/helmchart_on_release.yml
@@ -9,11 +9,18 @@ jobs:
     runs-on: ubicloud-standard-2
 
     steps:
+      - name: Generate an installation token
+        id: app
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.INTERNAL_APP_KEY }}
+
       - name: Checkout on helm repository
         uses: actions/checkout@v3
         with:
           repository: windmill-labs/windmill-helm-charts
-          token: ${{ secrets.HELM_CHART_TOKEN }}
+          token: ${{ steps.app.outputs.token }}
 
       - name: Get version
         id: get_version
@@ -57,7 +64,7 @@ jobs:
 
       - name: Create PR
         env:
-          GH_TOKEN: ${{ secrets.HELM_CHART_TOKEN }}
+          GH_TOKEN: ${{ steps.app.outputs.token }}
         run: |
           gh pr create \
             --title "helm: bump version to ${{ env.VERSION }}" \

--- a/.github/workflows/helmchart_on_release.yml
+++ b/.github/workflows/helmchart_on_release.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.INTERNAL_APP_KEY }}
+          owner: windmill-labs
 
       - name: Checkout on helm repository
         uses: actions/checkout@v3

--- a/.github/workflows/pr-ready-review.yml
+++ b/.github/workflows/pr-ready-review.yml
@@ -1,0 +1,29 @@
+name: Auto Comment on PR Ready for Review
+
+on:
+  pull_request:
+    types: [ready_for_review]
+
+jobs:
+  add-review-comment:
+    if: github.event.pull_request.draft == false
+    runs-on: ubicloud-standard-2
+    steps:
+      - name: Generate an installation token
+        id: app
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.INTERNAL_APP_KEY }}
+
+      - name: Add review comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: '/ai review these changes'
+            });

--- a/.github/workflows/pr-ready-review.yml
+++ b/.github/workflows/pr-ready-review.yml
@@ -25,5 +25,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: '/ai review these changes'
+              body: '/ai review this PR'
             });

--- a/.github/workflows/pr-ready-review.yml
+++ b/.github/workflows/pr-ready-review.yml
@@ -13,7 +13,7 @@ jobs:
         id: app
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.APP_ID }}
+          app-id: ${{ vars.INTERNAL_APP_ID }}
           private-key: ${{ secrets.INTERNAL_APP_KEY }}
 
       - name: Add review comment


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Integrate GitHub App tokens for authentication across workflows, enhancing security and consistency in GitHub Actions.
> 
>   - **Authentication**:
>     - Use `actions/create-github-app-token@v2` to generate GitHub App tokens in `change-versions.yml`, `helmchart_on_release.yml`, `pr-ready-review.yml`, and `create-docs.yml`.
>     - Replace personal access tokens with app tokens for repository access and actions.
>   - **Workflows**:
>     - Add `check-org-membership.yml` to verify organization membership using GitHub App tokens.
>     - Modify `claude.yml` to determine commenter and check membership before executing Claude actions.
>     - Update `create-docs.yml` to trigger documentation creation only if the commenter is a member.
>     - Enhance `helmchart_on_release.yml` to use app tokens for Helm chart version bumping and PR creation.
>     - Introduce `pr-ready-review.yml` to auto-comment on PRs ready for review using app tokens.
>   - **Misc**:
>     - Remove redundant bot checks in `claude.yml` and `create-docs.yml`.
>     - Simplify membership check logic in `check-org-membership.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 64d10acf88ed455ac13ccaff224a128186847138. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->