### PR TITLE
fix(frontend): popover close on click outside

### DIFF
--- a/frontend/src/lib/components/runs/RunsFilter.svelte
+++ b/frontend/src/lib/components/runs/RunsFilter.svelte
@@ -522,6 +522,7 @@
 		floatingConfig={{ strategy: 'absolute', placement: 'bottom-end' }}
 		contentClasses="p-4"
 		closeButton
+		usePointerDownOutside
 	>
 		{#snippet trigger()}
 			<Button color="dark" size="xs" nonCaptureEvent={true} startIcon={{ icon: Filter }}>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `usePointerDownOutside` to `Popover` in `RunsFilter.svelte` to close popover on outside click.
> 
>   - **Behavior**:
>     - Adds `usePointerDownOutside` to `Popover` in `RunsFilter.svelte` to close popover on outside click.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 46e9c7fe60cbd5622777b28a0305c357c4328ef6. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->