### PR TITLE
fix: git repository resource picker effect loop

### DIFF
--- a/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
@@ -1265,9 +1265,7 @@
 								<ResourcePicker
 									resourceType="git_repository"
 									initialValue={gitSyncRepository.git_repo_resource_path}
-									on:change={(ev) => {
-										gitSyncRepository.git_repo_resource_path = ev.detail
-									}}
+									bind:value={gitSyncRepository.git_repo_resource_path}
 								/>
 								<Button
 									disabled={emptyString(gitSyncRepository.script_path)}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces `on:change` event handler with `bind:value` for `ResourcePicker` in `+page.svelte`.
> 
>   - **Behavior**:
>     - Replaces `on:change` event handler with `bind:value` for `ResourcePicker` in `+page.svelte` to update `gitSyncRepository.git_repo_resource_path` directly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 2f2f25a61ec488c2ae431863b42ce00fa7c53479. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->