### PR TITLE
internal: close old bump prs on new release

### DIFF
--- a/.github/workflows/helmchart_on_release.yml
+++ b/.github/workflows/helmchart_on_release.yml
@@ -57,6 +57,23 @@ jobs:
           APP_VERSION=${APP_VERSION%/}
           sed -i "s/appVersion: .*/appVersion: $APP_VERSION/" ./charts/windmill/Chart.yaml
 
+      - name: Close existing bump-helm PRs
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+        run: |
+          # List open PR numbers whose title starts with the prefix
+          prs=$(gh pr list \
+                  --state open \
+                  --search '"helm: bump version to" in:title' \
+                  --json number \
+                  -q '.[].number')
+
+          for pr in $prs; do
+            echo "Closing outdated bump PR #$pr"
+            gh pr close "$pr" \
+              --comment "Closed automatically – superseded by a newer Helm-chart bump PR."
+          done
+
       - name: Commit and push
         run: |
           git add .


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a step to close outdated bump-helm PRs in the Helm chart release workflow.
> 
>   - **Workflow Update**:
>     - Adds a step in `.github/workflows/helmchart_on_release.yml` to close outdated bump-helm PRs.
>     - Uses `gh pr list` to find open PRs with titles starting with "helm: bump version to".
>     - Closes these PRs with a comment indicating they are superseded by a newer PR.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 14d1f452d0b57897819d4eaa7e8497f6283b5860. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->