### PR TITLE
internal: use pat for claude review

### DIFF
--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -24,7 +24,7 @@ jobs:
       DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_AI_BOT_TOKEN }}
 
   merge_success_emoji:
-    if: github.event.pull_request.merged == true
+    if: github.event.action == 'closed'
     uses: ./.github/workflows/shareable-discord-notification.yml
     with:
       PR_STATUS: "merged"

--- a/.github/workflows/pr-ready-review.yml
+++ b/.github/workflows/pr-ready-review.yml
@@ -9,17 +9,10 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubicloud-standard-2
     steps:
-      - name: Generate an installation token
-        id: app
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.INTERNAL_APP_ID }}
-          private-key: ${{ secrets.INTERNAL_APP_KEY }}
-
       - name: Add review comment
         uses: actions/github-script@v7
         with:
-          github-token: ${{ steps.app.outputs.token }}
+          github-token: ${{ secrets.PUBLIC_REPO_TOKEN }}
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update GitHub Actions workflows to use personal access token and modify conditions for Discord notifications and review comments.
> 
>   - **GitHub Actions Workflows**:
>     - In `.github/workflows/discord-notification.yml`, change condition for `merge_success_emoji` job from `github.event.pull_request.merged == true` to `github.event.action == 'closed'`.
>     - In `.github/workflows/pr-ready-review.yml`, replace GitHub App token with `PUBLIC_REPO_TOKEN` for authentication in `add-review-comment` job.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 4ab5a81b02b25e5c6ab2f61eac67668acf26c245. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->