### PR TITLE
Select subtitle

### DIFF
--- a/frontend/src/lib/components/select/Select.svelte
+++ b/frontend/src/lib/components/select/Select.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" generics="Item extends { label?: string; value: any; }">
+<script lang="ts" generics="Item extends { label?: string; value: any; subtitle?: string }">
 	import { clickOutside } from '$lib/utils'
 	import { twMerge } from 'tailwind-merge'
 	import CloseButton from '../common/CloseButton.svelte'

--- a/frontend/src/lib/components/select/SelectDropdown.svelte
+++ b/frontend/src/lib/components/select/SelectDropdown.svelte
@@ -138,6 +138,9 @@
 							}}
 						>
 							{item.label || '\xa0'}
+							{#if item.subtitle}
+								<div class="text-xs text-tertiary">{item.subtitle}</div>
+							{/if}
 						</button>
 					</li>
 				{/each}

--- a/frontend/src/lib/components/select/utils.svelte.ts
+++ b/frontend/src/lib/components/select/utils.svelte.ts
@@ -43,6 +43,7 @@ export type ProcessedItem<T> = {
 	__is_create?: true
 	label: string
 	value: T
+	subtitle?: string
 }
 
 export function getLabel<T>(item: { label?: string; value: T } | undefined): string {


### PR DESCRIPTION
Add subtitle prop to Select items

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `subtitle` property to `Select` component items, allowing additional descriptive text in dropdown.
> 
>   - **Behavior**:
>     - Add `subtitle` property to `Item` in `Select.svelte` and `SelectDropdown.svelte`.
>     - Conditionally render `subtitle` in `SelectDropdown.svelte` if present.
>   - **Types**:
>     - Update `ProcessedItem` type in `utils.svelte.ts` to include `subtitle`.
>   - **Misc**:
>     - Update `processItems` function in `utils.svelte.ts` to handle `subtitle`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 612c7a858e6818f5aae98f5f38a87917e5c4697e. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->