### PR TITLE
fix(backend): return correct content-type for openapi spec

### DIFF
--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -36,8 +36,10 @@ use anyhow::Context;
 use argon2::Argon2;
 use axum::extract::DefaultBodyLimit;
 use axum::{middleware::from_extractor, routing::get, routing::post, Extension, Router};
+use axum::response::Response;
+use axum::http::HeaderValue;
+use axum::body::Body;
 use db::DB;
-use http::HeaderValue;
 use reqwest::Client;
 #[cfg(feature = "oauth2")]
 use std::collections::HashMap;
@@ -890,12 +892,18 @@ async fn ee_license() -> String {
     }
 }
 
-async fn openapi() -> &'static str {
-    include_str!("../openapi-deref.yaml")
+async fn openapi() -> Response {
+    Response::builder()
+        .header("content-type", "application/yaml")
+        .body(Body::from(include_str!("../openapi-deref.yaml")))
+        .unwrap()
 }
 
-async fn openapi_json() -> &'static str {
-    include_str!("../openapi-deref.json")
+async fn openapi_json() -> Response {
+    Response::builder()
+        .header("content-type", "application/json")
+        .body(Body::from(include_str!("../openapi-deref.json")))
+        .unwrap()
 }
 
 pub async fn migrate_db(db: &DB) -> anyhow::Result<Option<JoinHandle<()>>> {


### PR DESCRIPTION
Fix content-type for openapi spec.

Before the patch:
```bash
$  curl -I  http://localhost:8000/api/openapi.yaml
HTTP/1.1 200 OK
content-type: text/plain; charset=utf-8
content-length: 681647
date: Tue, 24 Jun 2025 20:40:44 GMT
```
after patch:
```
$  curl -I  http://localhost:8000/api/openapi.yaml
HTTP/1.1 200 OK
content-type: application/yaml
content-length: 567241
date: Tue, 24 Jun 2025 20:40:49 GMT
$  curl -I  http://localhost:8000/api/openapi.json
HTTP/1.1 200 OK
content-type: application/json
content-length: 681647
date: Tue, 24 Jun 2025 20:40:25 GMT
```



Fixes #6032
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes content-type for OpenAPI spec endpoints in `lib.rs` to return correct MIME types for YAML and JSON.
> 
>   - **Behavior**:
>     - Fixes content-type for OpenAPI spec endpoints in `openapi()` and `openapi_json()` in `lib.rs`.
>     - `openapi()` now returns `application/yaml`.
>     - `openapi_json()` now returns `application/json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 05809a5bb8f21b20bb85e8c6212c43a3ed7f7bfe. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->