### PR TITLE
fix: missing static_asset_config from api call

### DIFF
--- a/frontend/src/lib/components/triggers/http/utils.ts
+++ b/frontend/src/lib/components/triggers/http/utils.ts
@@ -51,6 +51,7 @@ export async function saveHttpRouteFromCfg(
 		route_path: isAdmin || !edit ? routeCfg.route_path : undefined,
 		http_method: routeCfg.http_method,
 		is_static_website: routeCfg.is_static_website,
+		static_asset_config: routeCfg.static_asset_config,
 		workspaced_route: routeCfg.workspaced_route,
 		authentication_resource_path: routeCfg.authentication_resource_path,
 		wrap_body: routeCfg.wrap_body,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `static_asset_config` to `saveHttpRouteFromCfg()` in `utils.ts` to include it in API calls.
> 
>   - **Behavior**:
>     - Adds `static_asset_config` to the request body in `saveHttpRouteFromCfg()` in `utils.ts` to ensure it is included in API calls.
>   - **Misc**:
>     - No other changes or refactoring were made.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for b498370459560555948a6f69ddc56db4e012c302. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->