### PR TITLE
fix schemaform reorder

### DIFF
--- a/frontend/src/lib/components/SchemaForm.svelte
+++ b/frontend/src/lib/components/SchemaForm.svelte
@@ -173,7 +173,10 @@
 					.forEach((x) => {
 						n[x] = schema.properties[x]
 					})
-				if (!deepEqual(schema.properties, n) || !deepEqual(schema.properties, Object.keys(n))) {
+				if (
+					!deepEqual(schema.properties, n) ||
+					!deepEqual(Object.keys(schema.properties), Object.keys(n))
+				) {
 					schema.properties = n
 				}
 			}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes condition in `reorder()` function in `SchemaForm.svelte` to correctly compare keys of `schema.properties` with keys of `n`.
> 
>   - **Behavior**:
>     - Fixes condition in `reorder()` function in `SchemaForm.svelte` to correctly compare keys of `schema.properties` with keys of `n`.
>     - Ensures schema properties are reordered only when necessary, preventing unnecessary updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 09bf92e502783d6824a039f832c6fc9219145412. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->