### PR TITLE
fix no feedback on folder deletion

### DIFF
--- a/frontend/src/routes/(root)/(logged)/folders/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/folders/+page.svelte
@@ -197,6 +197,7 @@
 															workspace: $workspaceStore ?? '',
 															name
 														})
+														folders = folders?.filter((f) => f.name !== name)
 													} catch (e) {
 														sendUserToast(e.body, true)
 														loadFolders()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `folders` list in `+page.svelte` to reflect folder deletion immediately in the UI.
> 
>   - **Behavior**:
>     - Updates `folders` list in `+page.svelte` after a folder is deleted to provide immediate feedback in the UI.
>     - Uses `filter` to remove the deleted folder from the `folders` array.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 4d829e2e9f6cdc345ff53f3647fb267fd515655a. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->