### PR TITLE
feat: add clearable for script picker

### DIFF
--- a/frontend/src/lib/components/ScriptPicker.svelte
+++ b/frontend/src/lib/components/ScriptPicker.svelte
@@ -29,6 +29,7 @@
 		allowRefresh?: boolean
 		allowEdit?: boolean
 		allowView?: boolean
+		clearable?: boolean
 	}
 
 	let {
@@ -40,7 +41,8 @@
 		disabled = false,
 		allowRefresh = false,
 		allowEdit = true,
-		allowView = true
+		allowView = true,
+		clearable = false
 	}: Props = $props()
 
 	let items: { value: string; label: string }[] = $state([])
@@ -128,6 +130,7 @@
 			}
 			class="grow shrink max-w-full"
 			{items}
+			{clearable}
 			placeholder="Pick {itemKind === 'app' ? 'an' : 'a'} {itemKind}"
 		/>
 	{/if}

--- a/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
@@ -348,6 +348,7 @@
 							bind:scriptPath={script_path}
 							allowRefresh={can_write}
 							allowEdit={!$userStore?.operator}
+							clearable
 						/>
 						{#if emptyString(script_path)}
 							<Button

--- a/frontend/src/lib/components/triggers/http/RouteEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/http/RouteEditorInner.svelte
@@ -538,6 +538,7 @@
 									bind:scriptPath={script_path}
 									allowRefresh={can_write}
 									allowEdit={!$userStore?.operator}
+									clearable
 								/>
 
 								{#if emptyString(script_path)}

--- a/frontend/src/lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte
@@ -349,6 +349,7 @@
 							bind:scriptPath={script_path}
 							allowRefresh={can_write}
 							allowEdit={!$userStore?.operator}
+							clearable
 						/>
 						{#if emptyString(script_path)}
 							<Button

--- a/frontend/src/lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte
@@ -360,6 +360,7 @@
 							bind:scriptPath={script_path}
 							allowRefresh={can_write}
 							allowEdit={!$userStore?.operator}
+							clearable
 						/>
 						{#if emptyString(script_path)}
 							<Button

--- a/frontend/src/lib/components/triggers/nats/NatsTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/nats/NatsTriggerEditorInner.svelte
@@ -351,6 +351,7 @@
 							bind:scriptPath={script_path}
 							allowRefresh={can_write}
 							allowEdit={!$userStore?.operator}
+							clearable
 						/>
 						{#if emptyString(script_path)}
 							<Button

--- a/frontend/src/lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte
@@ -526,6 +526,7 @@
 							bind:scriptPath={script_path}
 							allowRefresh={can_write}
 							allowEdit={!$userStore?.operator}
+							clearable
 						/>
 
 						{#if emptyString(script_path) && is_flow === false}

--- a/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
@@ -875,6 +875,7 @@
 							on:select={(e) => {
 								loadScript(e.detail.path)
 							}}
+							clearable
 						/>
 					{:else}
 						<Alert type="info" title="Runnable path cannot be edited" collapsible>

--- a/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorInner.svelte
@@ -343,6 +343,7 @@
 							bind:scriptPath={script_path}
 							allowRefresh={can_write}
 							allowEdit={!$userStore?.operator}
+							clearable
 						/>
 						{#if emptyString(script_path)}
 							<Button

--- a/frontend/src/lib/components/triggers/websocket/WebsocketTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/websocket/WebsocketTriggerEditorInner.svelte
@@ -412,6 +412,7 @@
 								bind:scriptPath={script_path}
 								allowRefresh={can_write}
 								allowEdit={!$userStore?.operator}
+								clearable
 							/>
 							{#if emptyString(script_path)}
 								<Button


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `clearable` option to `ScriptPicker` component, allowing users to clear selections, and apply it to various trigger editor components.
> 
>   - **Behavior**:
>     - Add `clearable` option to `ScriptPicker` in `ScriptPicker.svelte`, defaulting to `false`.
>     - Pass `clearable` to `Select` component within `ScriptPicker.svelte`.
>     - Enable `clearable` in `GcpTriggerEditorInner.svelte`, `RouteEditorInner.svelte`, and 8 other trigger editor components.
>   - **Components**:
>     - Update `ScriptPicker` component to include `clearable` prop.
>     - Modify trigger editor components to utilize `clearable` prop in `ScriptPicker`.
>   - **Misc**:
>     - No changes to existing functionality, only adds the ability to clear selections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for e706c78e574f3b49a11618210eb5623739cf13c8. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->