### PR TITLE
fix: resource picker effect loop

### DIFF
--- a/frontend/src/lib/components/ResourcePicker.svelte
+++ b/frontend/src/lib/components/ResourcePicker.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { ResourceService } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
+	import { run } from 'svelte/legacy'
 	import { createEventDispatcher, onMount, untrack } from 'svelte'
 	import AppConnect from './AppConnectDrawer.svelte'
 	import ResourceEditorDrawer from './ResourceEditorDrawer.svelte'
@@ -140,7 +141,7 @@
 			)
 	})
 
-	$effect(() => {
+	run(() => {
 		dispatchIfMounted('change', value)
 	})
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces `$effect` with `run` from `svelte/legacy` in `ResourcePicker.svelte` to fix an effect loop issue.
> 
>   - **Behavior**:
>     - Replaces `$effect` with `run` from `svelte/legacy` in `ResourcePicker.svelte` to fix an effect loop issue.
>   - **Imports**:
>     - Adds `run` from `svelte/legacy` to `ResourcePicker.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 2cff43d88b1f968bd5851e02105d74d2764fb2fd. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->