### PR TITLE
ci self hosted

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,6 +13,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - "Dockerfile"
+      - ".github/workflows/docker-image.yml"
   workflow_dispatch:
     inputs:
       ee:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -37,7 +37,7 @@ permissions: write-all
 
 jobs:
   build:
-    runs-on: ubicloud
+    runs-on: [self-hosted, new]
     if: (github.event_name != 'workflow_dispatch') || (github.event.inputs &&
       !github.event.inputs.ee)
     steps:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -38,7 +38,7 @@ permissions: write-all
 
 jobs:
   build:
-    runs-on: [self-hosted, new]
+    runs-on: [self-hosted, ubicloud]
     if: (github.event_name != 'workflow_dispatch') || (github.event.inputs &&
       !github.event.inputs.ee)
     steps:
@@ -101,7 +101,7 @@ jobs:
             ${{ steps.meta-public.outputs.labels }}
 
   build_ee:
-    runs-on: ubicloud
+    runs-on: [self-hosted, ubicloud]
     if: (github.event_name != 'workflow_dispatch') || (github.event.inputs.ee || github.event.inputs.nsjail)
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `self-hosted` runner support to `build` and `build_ee` jobs in `.github/workflows/docker-image.yml`.
> 
>   - **Workflow Configuration**:
>     - Modify `runs-on` in `.github/workflows/docker-image.yml` to include `self-hosted` for `build` and `build_ee` jobs.
>     - Ensures jobs can run on both `self-hosted` and `ubicloud` runners.
>   - **Trigger Paths**:
>     - Add `.github/workflows/docker-image.yml` to `paths` for `pull_request` events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 8204ca3dd74065b5b6ae5e0175d8153463e6e712. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->