### PR TITLE
finish migrating app editor to svelte 5

### DIFF
--- a/frontend/src/lib/components/apps/components/GroupWrapper.svelte
+++ b/frontend/src/lib/components/apps/components/GroupWrapper.svelte
@@ -3,10 +3,15 @@
 	import type { Writable } from 'svelte/store'
 	import type { GroupContext } from '../types'
 
-	export let context: Writable<Record<string, any>>
-	export let id: string
+	interface Props {
+		context: Writable<Record<string, any>>
+		id: string
+		children?: import('svelte').Snippet
+	}
+
+	let { context, id, children }: Props = $props()
 
 	setContext<GroupContext>('GroupContext', { id, context })
 </script>
 
-<slot />
+{@render children?.()}

--- a/frontend/src/lib/components/apps/components/display/AppBarChart.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppBarChart.svelte
@@ -22,18 +22,28 @@
 	import ResolveConfig from '../helpers/ResolveConfig.svelte'
 	import { twMerge } from 'tailwind-merge'
 	import ResolveStyle from '../helpers/ResolveStyle.svelte'
-	export let id: string
-	export let componentInput: AppInput | undefined
-	export let configuration: RichConfigurations
-	export let initializing: boolean | undefined = undefined
-	export let customCss: ComponentCustomCSS<'barchartcomponent'> | undefined = undefined
-	export let render: boolean
+	interface Props {
+		id: string
+		componentInput: AppInput | undefined
+		configuration: RichConfigurations
+		initializing?: boolean | undefined
+		customCss?: ComponentCustomCSS<'barchartcomponent'> | undefined
+		render: boolean
+	}
+
+	let {
+		id,
+		componentInput,
+		configuration,
+		initializing = $bindable(undefined),
+		customCss = undefined,
+		render
+	}: Props = $props()
 
 	const { app, worldStore } = getContext<AppViewerContext>('AppViewerContext')
 
-	let resolvedConfig = initConfig(
-		components['barchartcomponent'].initialData.configuration,
-		configuration
+	let resolvedConfig = $state(
+		initConfig(components['barchartcomponent'].initialData.configuration, configuration)
 	)
 
 	let outputs = initOutput($worldStore, id, {
@@ -52,15 +62,17 @@
 		BarElement
 	)
 
-	let result: { data: number[]; labels?: string[] } | undefined = undefined
+	let result = $state(undefined) as { data: number[]; labels?: string[] } | undefined
 
-	$: backgroundColor = {
-		theme1: ['#FF6384', '#4BC0C0', '#FFCE56', '#E7E9ED', '#36A2EB'],
-		// blue theme
-		theme2: ['#4e73df', '#1cc88a', '#36b9cc', '#f6c23e', '#e74a3b'],
-		// red theme
-		theme3: ['#e74a3b', '#4e73df', '#1cc88a', '#36b9cc', '#f6c23e']
-	}[resolvedConfig.theme ?? 'theme1']
+	let backgroundColor = $derived(
+		{
+			theme1: ['#FF6384', '#4BC0C0', '#FFCE56', '#E7E9ED', '#36A2EB'],
+			// blue theme
+			theme2: ['#4e73df', '#1cc88a', '#36b9cc', '#f6c23e', '#e74a3b'],
+			// red theme
+			theme3: ['#e74a3b', '#4e73df', '#1cc88a', '#36b9cc', '#f6c23e']
+		}[resolvedConfig.theme ?? 'theme1']
+	)
 
 	const lineOptions: ChartOptions<'line'> = {
 		responsive: true,
@@ -84,7 +96,7 @@
 		}
 	}
 
-	$: data = {
+	let data = $derived({
 		labels: result?.labels ?? [],
 
 		datasets: [
@@ -105,9 +117,9 @@
 				}
 			}
 		}
-	}
+	})
 
-	let css = initCss($app.css?.barchartcomponent, customCss)
+	let css = $state(initCss($app.css?.barchartcomponent, customCss))
 </script>
 
 {#each Object.keys(components['barchartcomponent'].initialData.configuration) as key (key)}

--- a/frontend/src/lib/components/apps/components/display/AppChartJs.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppChartJs.svelte
@@ -12,12 +12,23 @@
 	import { twMerge } from 'tailwind-merge'
 	import ResolveStyle from '../helpers/ResolveStyle.svelte'
 
-	export let id: string
-	export let componentInput: AppInput | undefined
-	export let configuration: RichConfigurations
-	export let initializing: boolean | undefined = undefined
-	export let customCss: ComponentCustomCSS<'chartjscomponent'> | undefined = undefined
-	export let render: boolean
+	interface Props {
+		id: string
+		componentInput: AppInput | undefined
+		configuration: RichConfigurations
+		initializing?: boolean | undefined
+		customCss?: ComponentCustomCSS<'chartjscomponent'> | undefined
+		render: boolean
+	}
+
+	let {
+		id,
+		componentInput,
+		configuration,
+		initializing = $bindable(undefined),
+		customCss = undefined,
+		render
+	}: Props = $props()
 
 	const { app, worldStore } = getContext<AppViewerContext>('AppViewerContext')
 
@@ -28,20 +39,19 @@
 
 	ChartJS.register(...registerables)
 
-	let result: undefined = undefined
+	let result: undefined = $state(undefined)
 
-	const resolvedConfig = initConfig(
-		components['chartjscomponent'].initialData.configuration,
-		configuration
+	const resolvedConfig = $state(
+		initConfig(components['chartjscomponent'].initialData.configuration, configuration)
 	)
-	$: options = {
+	let options = $derived({
 		responsive: true,
 		animation: false,
 		maintainAspectRatio: false,
 		...(resolvedConfig.options ?? {})
-	} as ChartOptions
+	} as ChartOptions)
 
-	let css = initCss($app.css?.chartjscomponent, customCss)
+	let css = $state(initCss($app.css?.chartjscomponent, customCss))
 </script>
 
 {#each Object.keys(components['chartjscomponent'].initialData.configuration) as key (key)}

--- a/frontend/src/lib/components/apps/components/display/AppCustomComponent.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppCustomComponent.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { getContext, onMount } from 'svelte'
+	import { getContext, onMount, untrack } from 'svelte'
 	import { initOutput } from '../../editor/appUtils'
 	import type { AppViewerContext } from '../../types'
 
@@ -22,10 +22,14 @@
 	import { Loader2 } from 'lucide-svelte'
 	import RunnableWrapper from '../helpers/RunnableWrapper.svelte'
 
-	export let id: string
-	export let render: boolean
-	export let componentInput: AppInput | undefined
-	export let customComponent: CustomComponentConfig
+	interface Props {
+		id: string
+		render: boolean
+		componentInput: AppInput | undefined
+		customComponent: CustomComponentConfig
+	}
+
+	let { id, render, componentInput, customComponent }: Props = $props()
 
 	let divId = `custom-component-${id}`
 	const { worldStore, workspace } = getContext<AppViewerContext>('AppViewerContext')
@@ -36,8 +40,8 @@
 		loading: false
 	})
 
-	let setInput
-	let setRender
+	let setInput = $state() as ((input: any) => void) | undefined
+	let setRender = $state() as ((render: boolean) => void) | undefined
 	let ccProps: CCProps<any> = {
 		render,
 		id: divId,
@@ -49,7 +53,7 @@
 			outputs.output.set(output)
 		}
 	}
-	let loaded = false
+	let loaded = $state(false)
 	let renderer: ((props: CCProps<number>) => void) | undefined = undefined
 	// $: renderer && divEl && renderer(ccProps)
 	onMount(async () => {
@@ -96,18 +100,22 @@
 		}
 		console.log('mounted', render, setRender)
 	})
-	let result
+	let result = $state()
 
-	$: render != undefined && setRender && handleRender()
 	function handleRender() {
 		setRender?.(render)
 	}
 
-	$: result != undefined && setInput && handleResult()
 	function handleResult() {
 		setInput?.(result)
 	}
 	// $: result && setInput && setInput(result)
+	$effect(() => {
+		render != undefined && setRender && untrack(() => handleRender())
+	})
+	$effect(() => {
+		result != undefined && setInput && untrack(() => handleResult())
+	})
 </script>
 
 <InitializeComponent {id} />

--- a/frontend/src/lib/components/apps/components/display/AppPieChart.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppPieChart.svelte
@@ -21,12 +21,23 @@
 	import { twMerge } from 'tailwind-merge'
 	import ResolveStyle from '../helpers/ResolveStyle.svelte'
 
-	export let id: string
-	export let componentInput: AppInput | undefined
-	export let configuration: RichConfigurations
-	export let initializing: boolean | undefined = undefined
-	export let customCss: ComponentCustomCSS<'piechartcomponent'> | undefined = undefined
-	export let render: boolean
+	interface Props {
+		id: string
+		componentInput: AppInput | undefined
+		configuration: RichConfigurations
+		initializing?: boolean | undefined
+		customCss?: ComponentCustomCSS<'piechartcomponent'> | undefined
+		render: boolean
+	}
+
+	let {
+		id,
+		componentInput,
+		configuration,
+		initializing = $bindable(undefined),
+		customCss = undefined,
+		render
+	}: Props = $props()
 
 	const { app, worldStore } = getContext<AppViewerContext>('AppViewerContext')
 
@@ -46,17 +57,19 @@
 		ArcElement
 	)
 
-	let result: { data: number[]; labels?: string[] } | undefined = undefined
-	let theme: string = 'theme1'
-	let doughnut = false
+	let result = $state(undefined) as { data: number[]; labels?: string[] } | undefined
+	let theme: string = $state('theme1')
+	let doughnut = $state(false)
 
-	$: backgroundColor = {
-		theme1: ['#FF6384', '#4BC0C0', '#FFCE56', '#E7E9ED', '#36A2EB'],
-		// blue theme
-		theme2: ['#4e73df', '#1cc88a', '#36b9cc', '#f6c23e', '#e74a3b'],
-		// red theme
-		theme3: ['#e74a3b', '#4e73df', '#1cc88a', '#36b9cc', '#f6c23e']
-	}[theme]
+	let backgroundColor = $derived(
+		{
+			theme1: ['#FF6384', '#4BC0C0', '#FFCE56', '#E7E9ED', '#36A2EB'],
+			// blue theme
+			theme2: ['#4e73df', '#1cc88a', '#36b9cc', '#f6c23e', '#e74a3b'],
+			// red theme
+			theme3: ['#e74a3b', '#4e73df', '#1cc88a', '#36b9cc', '#f6c23e']
+		}[theme]
+	)
 
 	const options = {
 		responsive: true,
@@ -64,7 +77,7 @@
 		maintainAspectRatio: false
 	}
 
-	$: data = {
+	let data = $derived({
 		labels: result?.labels ?? [],
 		datasets: [
 			{
@@ -72,9 +85,9 @@
 				backgroundColor: backgroundColor
 			}
 		]
-	}
+	})
 
-	let css = initCss($app.css?.piechartcomponent, customCss)
+	let css = $state(initCss($app.css?.piechartcomponent, customCss))
 </script>
 
 {#each Object.keys(css ?? {}) as key (key)}

--- a/frontend/src/lib/components/apps/components/display/AppScatterChart.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppScatterChart.svelte
@@ -24,15 +24,26 @@
 	import ResolveStyle from '../helpers/ResolveStyle.svelte'
 	import { Scatter } from '$lib/components/chartjs-wrappers/chartJs'
 
-	export let id: string
-	export let componentInput: AppInput | undefined
-	export let configuration: RichConfigurations
-	export let initializing: boolean | undefined = undefined
-	export let customCss: ComponentCustomCSS<'scatterchartcomponent'> | undefined = undefined
-	export let render: boolean
+	interface Props {
+		id: string
+		componentInput: AppInput | undefined
+		configuration: RichConfigurations
+		initializing?: boolean | undefined
+		customCss?: ComponentCustomCSS<'scatterchartcomponent'> | undefined
+		render: boolean
+	}
 
-	let zoomable = false
-	let pannable = false
+	let {
+		id,
+		componentInput,
+		configuration,
+		initializing = $bindable(undefined),
+		customCss = undefined,
+		render
+	}: Props = $props()
+
+	let zoomable = $state(false)
+	let pannable = $state(false)
 
 	const { app, worldStore } = getContext<AppViewerContext>('AppViewerContext')
 
@@ -53,9 +64,9 @@
 		zoomPlugin
 	)
 
-	let result: { data: { x: any[]; y: string[] } } | undefined = undefined
+	let result: { data: { x: any[]; y: string[] } } | undefined = $state(undefined)
 
-	$: options = {
+	let options = $derived({
 		responsive: true,
 		animation: false,
 		maintainAspectRatio: false,
@@ -74,13 +85,13 @@
 				}
 			}
 		}
-	} as ChartOptions<'scatter'>
+	} as ChartOptions<'scatter'>)
 
-	$: data = {
+	let data = $derived({
 		datasets: result ?? []
-	} as ChartData<'scatter', (number | Point)[], unknown>
+	} as ChartData<'scatter', (number | Point)[], unknown>)
 
-	let css = initCss($app.css?.scatterchartcomponent, customCss)
+	let css = $state(initCss($app.css?.scatterchartcomponent, customCss))
 </script>
 
 {#each Object.keys(css ?? {}) as key (key)}

--- a/frontend/src/lib/components/apps/components/display/AppTimeseries.svelte
+++ b/frontend/src/lib/components/apps/components/display/AppTimeseries.svelte
@@ -27,12 +27,23 @@
 	import { twMerge } from 'tailwind-merge'
 	import ResolveStyle from '../helpers/ResolveStyle.svelte'
 
-	export let id: string
-	export let componentInput: AppInput | undefined
-	export let configuration: RichConfigurations
-	export let initializing: boolean | undefined = undefined
-	export let customCss: ComponentCustomCSS<'timeseriescomponent'> | undefined = undefined
-	export let render: boolean
+	interface Props {
+		id: string
+		componentInput: AppInput | undefined
+		configuration: RichConfigurations
+		initializing?: boolean | undefined
+		customCss?: ComponentCustomCSS<'timeseriescomponent'> | undefined
+		render: boolean
+	}
+
+	let {
+		id,
+		componentInput,
+		configuration,
+		initializing = $bindable(undefined),
+		customCss = undefined,
+		render
+	}: Props = $props()
 
 	const { app, worldStore } = getContext<AppViewerContext>('AppViewerContext')
 
@@ -41,9 +52,9 @@
 		loading: false
 	})
 
-	let logarithmicScale = false
-	let zoomable = false
-	let pannable = false
+	let logarithmicScale = $state(false)
+	let zoomable = $state(false)
+	let pannable = $state(false)
 
 	ChartJS.register(
 		Title,
@@ -59,9 +70,9 @@
 		LogarithmicScale
 	)
 
-	let result: { data: { x: any[]; y: string[] } } | undefined = undefined
+	let result: { data: { x: any[]; y: string[] } } | undefined = $state(undefined)
 
-	$: options = {
+	let options = $derived({
 		responsive: true,
 		animation: false,
 		maintainAspectRatio: false,
@@ -88,13 +99,13 @@
 				type: logarithmicScale ? 'logarithmic' : 'linear'
 			}
 		}
-	} as ChartOptions<'scatter'>
+	} as ChartOptions<'scatter'>)
 
-	$: data = {
+	let data = $derived({
 		datasets: result ?? []
-	} as ChartData<'scatter', (number | Point)[], unknown>
+	} as ChartData<'scatter', (number | Point)[], unknown>)
 
-	let css = initCss($app.css?.timeseriescomponent, customCss)
+	let css = $state(initCss($app.css?.timeseriescomponent, customCss))
 </script>
 
 {#each Object.keys(css ?? {}) as key (key)}

--- a/frontend/src/lib/components/apps/components/display/PlotlyHtmlV2.svelte
+++ b/frontend/src/lib/components/apps/components/display/PlotlyHtmlV2.svelte
@@ -86,6 +86,11 @@
 					yaxis: {
 						color: $darkMode ? '#f3f6f8' : '#000',
 						...(resolvedConfig?.layout?.['yaxis'] ?? {})
+					},
+					legend: {
+						font: {
+							color: $darkMode ? '#f3f6f8' : '#000'
+						}
 					}
 				},
 				{ responsive: true, displayModeBar: false }
@@ -110,8 +115,8 @@
 	let resolvedDatasets: Dataset[] | undefined = $state()
 	let resolvedDatasetsValues: Array<number[]> = $state([])
 	let resolvedXData: number[] = $state([])
-	let data = $derived(
-		datasets && xData && resolvedDatasets
+	let data = $derived.by(() => {
+		return datasets && xData && resolvedDatasets
 			? resolvedDatasets.map((d, index) => {
 					const fields =
 						d.type === 'pie'
@@ -127,6 +132,7 @@
 						type: d.type,
 						color: d.color,
 						text: d.tooltip,
+						name: d.name,
 						...fields,
 						marker: {
 							color: d.color
@@ -144,7 +150,7 @@
 			: Array.isArray(result)
 				? result
 				: [result]
-	)
+	})
 	$effect(() => {
 		Plotly &&
 			render &&
@@ -153,6 +159,7 @@
 			h &&
 			w &&
 			shouldeUpdate &&
+			data &&
 			untrack(() => plot(data))
 	})
 </script>
@@ -172,7 +179,6 @@
 		key={'datasets'}
 		bind:resolvedConfig={resolvedDatasets}
 		configuration={datasets}
-		debug
 	/>
 {/if}
 

--- a/frontend/src/lib/components/apps/components/display/PlotlyHtmlV2.svelte
+++ b/frontend/src/lib/components/apps/components/display/PlotlyHtmlV2.svelte
@@ -172,6 +172,7 @@
 		key={'datasets'}
 		bind:resolvedConfig={resolvedDatasets}
 		configuration={datasets}
+		debug
 	/>
 {/if}
 

--- a/frontend/src/lib/components/apps/components/display/PlotlyHtmlV2.svelte
+++ b/frontend/src/lib/components/apps/components/display/PlotlyHtmlV2.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
+	import { createBubbler } from 'svelte/legacy'
+
+	const bubble = createBubbler()
 	import { Alert } from '$lib/components/common'
-	import { getContext, onMount } from 'svelte'
+	import { getContext, onMount, untrack } from 'svelte'
 	import { initConfig, initOutput } from '../../editor/appUtils'
 	import { components } from '../../editor/component'
 	import type { AppInput } from '../../inputType'
@@ -8,20 +11,30 @@
 	import ResolveConfig from '../helpers/ResolveConfig.svelte'
 	import RunnableWrapper from '../helpers/RunnableWrapper.svelte'
 
-	export let id: string
-	export let componentInput: AppInput | undefined
-	export let configuration: RichConfigurations
-	export let datasets: RichConfiguration | undefined
-	export let xData: RichConfiguration | undefined
+	interface Props {
+		id: string
+		componentInput: AppInput | undefined
+		configuration: RichConfigurations
+		datasets: RichConfiguration | undefined
+		xData: RichConfiguration | undefined
+		initializing?: boolean | undefined
+		render: boolean
+	}
 
-	export let initializing: boolean | undefined = undefined
-	export let render: boolean
+	let {
+		id,
+		componentInput,
+		configuration,
+		datasets,
+		xData,
+		initializing = $bindable(undefined),
+		render
+	}: Props = $props()
 
 	const { worldStore, darkMode } = getContext<AppViewerContext>('AppViewerContext')
 
-	let resolvedConfig = initConfig(
-		components['plotlycomponentv2'].initialData.configuration,
-		configuration
+	let resolvedConfig = $state(
+		initConfig(components['plotlycomponentv2'].initialData.configuration, configuration)
 	)
 
 	const outputs = initOutput($worldStore, id, {
@@ -29,10 +42,10 @@
 		loading: false
 	})
 
-	let result: object | undefined = undefined
-	let divEl: HTMLDivElement | null = null
+	let result: object | undefined = $state(undefined)
+	let divEl: HTMLDivElement | null = $state(null)
 
-	let Plotly
+	let Plotly = $state() as any
 	onMount(async () => {
 		//@ts-ignore
 		await import(
@@ -44,53 +57,16 @@
 		Plotly = window['Plotly']
 	})
 
-	let h: number | undefined = undefined
-	let w: number | undefined = undefined
+	let h: number | undefined = $state(undefined)
+	let w: number | undefined = $state(undefined)
 
-	let shouldeUpdate = 1
+	let shouldeUpdate = $state(1)
 
 	darkMode.subscribe(() => {
 		shouldeUpdate++
 	})
 
-	$: Plotly && render && resolvedConfig.layout && divEl && h && w && shouldeUpdate && plot(data)
-
-	$: data =
-		datasets && xData && resolvedDatasets
-			? resolvedDatasets.map((d, index) => {
-					const fields =
-						d.type === 'pie'
-							? {
-									values: resolvedDatasetsValues[index]
-							  }
-							: {
-									x: resolvedXData,
-									y: resolvedDatasetsValues[index]
-							  }
-
-					return {
-						type: d.type,
-						color: d.color,
-						text: d.tooltip,
-						...fields,
-						marker: {
-							color: d.color
-						},
-						transforms: [
-							{
-								type: 'aggregate',
-								groups: resolvedXData,
-								aggregations: [{ target: 'y', func: d.aggregation_method, enabled: true }]
-							}
-						],
-						...(d?.extraOptions ?? {})
-					}
-			  })
-			: Array.isArray(result)
-			? result
-			: [result]
-
-	let error = ''
+	let error = $state('')
 	function plot(data) {
 		try {
 			Plotly.newPlot(
@@ -131,9 +107,54 @@
 		extraOptions?: { mode: 'markers' | 'lines' | 'lines+markers' } | undefined
 	}
 
-	let resolvedDatasets: Dataset[]
-	let resolvedDatasetsValues: Array<number[]> = []
-	let resolvedXData: number[] = []
+	let resolvedDatasets: Dataset[] | undefined = $state()
+	let resolvedDatasetsValues: Array<number[]> = $state([])
+	let resolvedXData: number[] = $state([])
+	let data = $derived(
+		datasets && xData && resolvedDatasets
+			? resolvedDatasets.map((d, index) => {
+					const fields =
+						d.type === 'pie'
+							? {
+									values: resolvedDatasetsValues[index]
+								}
+							: {
+									x: resolvedXData,
+									y: resolvedDatasetsValues[index]
+								}
+
+					return {
+						type: d.type,
+						color: d.color,
+						text: d.tooltip,
+						...fields,
+						marker: {
+							color: d.color
+						},
+						transforms: [
+							{
+								type: 'aggregate',
+								groups: resolvedXData,
+								aggregations: [{ target: 'y', func: d.aggregation_method, enabled: true }]
+							}
+						],
+						...(d?.extraOptions ?? {})
+					}
+				})
+			: Array.isArray(result)
+				? result
+				: [result]
+	)
+	$effect(() => {
+		Plotly &&
+			render &&
+			resolvedConfig.layout &&
+			divEl &&
+			h &&
+			w &&
+			shouldeUpdate &&
+			untrack(() => plot(data))
+	})
 </script>
 
 {#each Object.keys(components['plotlycomponentv2'].initialData.configuration) as key (key)}
@@ -179,7 +200,7 @@
 					</Alert>
 				</div>
 			{/if}
-			<div on:pointerdown bind:this={divEl}></div>
+			<div onpointerdown={bubble('pointerdown')} bind:this={divEl}></div>
 		</RunnableWrapper>
 	</div>
 {:else}

--- a/frontend/src/lib/components/apps/components/display/ResolveNavbarItemPath.svelte
+++ b/frontend/src/lib/components/apps/components/display/ResolveNavbarItemPath.svelte
@@ -3,20 +3,25 @@
 	import ResolveConfig from '../helpers/ResolveConfig.svelte'
 	import { initConfig } from '../../editor/appUtils'
 
-	export let navbarItem: NavbarItem
-	export let id: string
-	export let index: number
+	interface Props {
+		navbarItem: NavbarItem
+		id: string
+		index: number
+		resolvedPath?: string | undefined
+	}
 
-	export let resolvedPath: string | undefined = undefined
+	let { navbarItem, id, index, resolvedPath = $bindable(undefined) }: Props = $props()
 
-	let resolvedConfig = initConfig({ path: navbarItem.path }, { path: navbarItem.path })
+	let resolvedConfig = $state(initConfig({ path: navbarItem.path }, { path: navbarItem.path }))
 
-	$: resolvedPath = (
-		resolvedConfig?.path?.selected === 'href'
-			? resolvedConfig?.path?.configuration?.href?.href
-			: resolvedConfig?.path?.configuration?.app?.path +
-			  (resolvedConfig?.path?.configuration?.app?.queryParamsOrHash ?? '')
-	) as string | undefined
+	$effect.pre(() => {
+		resolvedPath = (
+			resolvedConfig?.path?.selected === 'href'
+				? resolvedConfig?.path?.configuration?.href?.href
+				: resolvedConfig?.path?.configuration?.app?.path +
+					(resolvedConfig?.path?.configuration?.app?.queryParamsOrHash ?? '')
+		) as string | undefined
+	})
 </script>
 
 <ResolveConfig

--- a/frontend/src/lib/components/apps/components/display/dbtable/UpdateCell.svelte
+++ b/frontend/src/lib/components/apps/components/display/dbtable/UpdateCell.svelte
@@ -9,7 +9,11 @@
 	import { sendUserToast } from '$lib/toast'
 	import { getUpdateInput } from './queries/update'
 
-	export let id: string
+	interface Props {
+		id: string
+	}
+
+	let { id }: Props = $props()
 
 	const { worldStore } = getContext<AppViewerContext>('AppViewerContext')
 
@@ -19,9 +23,9 @@
 		jobId: undefined
 	})
 
-	let runnableComponent: RunnableComponent
-	let loading = false
-	let input: AppInput | undefined = undefined
+	let runnableComponent: RunnableComponent | undefined = $state(undefined)
+	let loading = $state(false)
+	let input: AppInput | undefined = $state(undefined)
 
 	export async function triggerUpdate(
 		resource: string,

--- a/frontend/src/lib/components/apps/components/display/table/AppAggridInfiniteTableEe.svelte
+++ b/frontend/src/lib/components/apps/components/display/table/AppAggridInfiniteTableEe.svelte
@@ -1,4 +1,4 @@
-<script context="module">
+<script module>
 </script>
 
 <script lang="ts">
@@ -11,16 +11,29 @@
 	import type { TableAction } from '$lib/components/apps/editor/component'
 	import AppAggridInfiniteTable from './AppAggridInfiniteTable.svelte'
 
-	export let id: string
-	export let license: string
-	export let componentInput: AppInput | undefined
-	export let configuration: RichConfigurations
-	export let initializing: boolean | undefined = undefined
-	export let render: boolean
-	export let customCss: ComponentCustomCSS<'aggridinfinitecomponentee'> | undefined = undefined
-	export let actions: TableAction[] = []
+	interface Props {
+		id: string
+		license: string
+		componentInput: AppInput | undefined
+		configuration: RichConfigurations
+		initializing?: boolean | undefined
+		render: boolean
+		customCss?: ComponentCustomCSS<'aggridinfinitecomponentee'> | undefined
+		actions?: TableAction[]
+	}
 
-	let loaded = false
+	let {
+		id,
+		license,
+		componentInput,
+		configuration,
+		initializing = $bindable(undefined),
+		render,
+		customCss = undefined,
+		actions = []
+	}: Props = $props()
+
+	let loaded = $state(false)
 	async function load() {
 		await import('ag-grid-enterprise')
 		const { LicenseManager } = await import('ag-grid-enterprise')

--- a/frontend/src/lib/components/apps/components/display/table/AppAggridTableEe.svelte
+++ b/frontend/src/lib/components/apps/components/display/table/AppAggridTableEe.svelte
@@ -1,4 +1,4 @@
-<script context="module">
+<script module>
 </script>
 
 <script lang="ts">
@@ -15,17 +15,31 @@
 	import { Loader2 } from 'lucide-svelte'
 	import type { TableAction } from '$lib/components/apps/editor/component'
 
-	export let id: string
-	export let license: string
-	export let componentInput: AppInput | undefined
-	export let configuration: RichConfigurations
-	export let initializing: boolean | undefined = undefined
-	export let render: boolean
-	export let customCss: ComponentCustomCSS<'aggridcomponent'> | undefined = undefined
-	export let actions: TableAction[] = []
-	export let actionsOrder: RichConfiguration | undefined = undefined
+	interface Props {
+		id: string
+		license: string
+		componentInput: AppInput | undefined
+		configuration: RichConfigurations
+		initializing?: boolean | undefined
+		render: boolean
+		customCss?: ComponentCustomCSS<'aggridcomponent'> | undefined
+		actions?: TableAction[]
+		actionsOrder?: RichConfiguration | undefined
+	}
 
-	let loaded = false
+	let {
+		id,
+		license,
+		componentInput,
+		configuration,
+		initializing = $bindable(undefined),
+		render,
+		customCss = undefined,
+		actions = [],
+		actionsOrder = undefined
+	}: Props = $props()
+
+	let loaded = $state(false)
 	async function load() {
 		await import('ag-grid-enterprise')
 		const { LicenseManager } = await import('ag-grid-enterprise')

--- a/frontend/src/lib/components/apps/components/display/table/AppCell.svelte
+++ b/frontend/src/lib/components/apps/components/display/table/AppCell.svelte
@@ -1,16 +1,23 @@
 <script lang="ts">
+	import { createBubbler } from 'svelte/legacy'
+
+	const bubble = createBubbler()
 	import Badge from '$lib/components/common/badge/Badge.svelte'
 	import { createEventDispatcher, tick } from 'svelte'
 	import { writable } from 'svelte/store'
 	import { twMerge } from 'tailwind-merge'
 	import { isLinkObject } from './utils'
 
-	export let type: 'text' | 'badge' | 'link' = 'text'
-	export let value: any
-	export let width: number
+	interface Props {
+		type?: 'text' | 'badge' | 'link'
+		value: any
+		width: number
+	}
+
+	let { type = 'text', value = $bindable(), width }: Props = $props()
 
 	let isEditable = writable(false)
-	let tempValue = value
+	let tempValue = $state(value)
 
 	const dispatch = createEventDispatcher()
 
@@ -42,8 +49,8 @@
 </script>
 
 <td
-	on:keydown
-	on:click
+	onkeydown={bubble('keydown')}
+	onclick={bubble('click')}
 	class={twMerge(
 		'p-4 whitespace-pre-wrap truncate text-xs text-primary',
 		$isEditable && 'bg-gray-100'
@@ -66,20 +73,20 @@
 		<input
 			type="text"
 			value={tempValue}
-			on:input={handleInput}
-			on:blur={saveEdit}
+			oninput={handleInput}
+			onblur={saveEdit}
 			id="cell"
 			class="!appearance-none !bg-transparent !border-none !p-0 !m-0 leading-normal !text-xs"
 			style="outline: none; box-shadow: none; height: auto; resize: none;"
-			on:keypress={(e) => {
+			onkeypress={(e) => {
 				if (e.key === 'Enter') {
 					saveEdit()
 				}
 			}}
 		/>
 	{:else}
-		<!-- svelte-ignore a11y-no-static-element-interactions -->
-		<div on:dblclick={toggleEdit}>
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div ondblclick={toggleEdit}>
 			{#if typeof value == 'object'}
 				{JSON.stringify(value)}
 			{:else}

--- a/frontend/src/lib/components/apps/components/helpers/DebouncedInput.svelte
+++ b/frontend/src/lib/components/apps/components/helpers/DebouncedInput.svelte
@@ -1,18 +1,31 @@
 <script lang="ts">
+	import { createBubbler, stopPropagation } from 'svelte/legacy'
+
+	const bubble = createBubbler()
 	import { onMount } from 'svelte'
 	import { twMerge } from 'tailwind-merge'
 
-	export let placeholder: string = 'Search...'
 	// Using 'any' so 'type="number"' can be passed to the input
-	// which should return a number
-	export let value: any
-	export let debounceDelay: number = 100
 
-	let parentClass: string | undefined = undefined
-	export { parentClass as class }
+	interface Props {
+		placeholder?: string
+		// which should return a number
+		value: any
+		debounceDelay?: number
+		class?: string | undefined
+		[key: string]: any
+	}
+
+	let {
+		placeholder = 'Search...',
+		value = $bindable(),
+		debounceDelay = 100,
+		class: parentClass = undefined,
+		...rest
+	}: Props = $props()
 
 	let timer: NodeJS.Timeout
-	let inputElement: HTMLInputElement | null = null
+	let inputElement: HTMLInputElement | null = $state(null)
 
 	function debounce(event: KeyboardEvent): void {
 		clearTimeout(timer)
@@ -33,9 +46,9 @@
 <input
 	bind:this={inputElement}
 	{placeholder}
-	on:pointerdown|stopPropagation
-	on:keyup={debounce}
-	on:keydown|stopPropagation
+	onpointerdown={stopPropagation(bubble('pointerdown'))}
+	onkeyup={debounce}
+	onkeydown={stopPropagation(bubble('keydown'))}
 	class={twMerge(parentClass, 'mb-1 h-8 !rounded-md !shadow-none')}
-	{...$$restProps}
+	{...rest}
 />

--- a/frontend/src/lib/components/apps/components/helpers/HiddenComponent.svelte
+++ b/frontend/src/lib/components/apps/components/helpers/HiddenComponent.svelte
@@ -6,13 +6,18 @@
 	import RunnableComponent from './RunnableComponent.svelte'
 	import InitializeComponent from './InitializeComponent.svelte'
 
-	export let id: string
-	export let runnable: HiddenRunnable
+	interface Props {
+		id: string
+		runnable: HiddenRunnable
+		children?: import('svelte').Snippet
+	}
+
+	let { id, runnable, children }: Props = $props()
 
 	const { worldStore, staticExporter, noBackend, runnableComponents } =
 		getContext<AppViewerContext>('AppViewerContext')
 
-	let result: any = noBackend ? runnable.noBackendValue : undefined
+	let result: any = $state(noBackend ? runnable.noBackendValue : undefined)
 
 	export function onSuccess() {
 		if (runnable.recomputeIds) {
@@ -49,7 +54,7 @@
 		on:success={onSuccess}
 		{outputs}
 	>
-		<slot />
+		{@render children?.()}
 	</RunnableComponent>
 {:else}
 	<InitializeComponent {id} />

--- a/frontend/src/lib/components/apps/components/helpers/InitializeComponent.svelte
+++ b/frontend/src/lib/components/apps/components/helpers/InitializeComponent.svelte
@@ -2,7 +2,11 @@
 	import { getContext, onDestroy, onMount } from 'svelte'
 	import type { AppViewerContext } from '../../types'
 
-	export let id: string
+	interface Props {
+		id: string
+	}
+
+	let { id }: Props = $props()
 	const { initialized } = getContext<AppViewerContext>('AppViewerContext')
 
 	onMount(() => {

--- a/frontend/src/lib/components/apps/components/helpers/InputDefaultValue.svelte
+++ b/frontend/src/lib/components/apps/components/helpers/InputDefaultValue.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
+	import { untrack } from 'svelte'
+
 	type InputType = string | number | boolean
-	export let input: HTMLInputElement | undefined = undefined
-	export let defaultValue: InputType | undefined = undefined
+	interface Props {
+		input?: HTMLInputElement | undefined
+		defaultValue?: InputType | undefined
+	}
+
+	let { input = $bindable(undefined), defaultValue = undefined }: Props = $props()
 
 	function setInputValueToDefaultValue() {
 		if (defaultValue !== undefined && input) {
@@ -15,8 +21,12 @@
 		}
 	}
 
-	$: input && defaultValue && setInputValueToDefaultValue()
-	$: input &&
-		(defaultValue === '' || defaultValue === undefined || defaultValue === null) &&
-		clearInputValue()
+	$effect.pre(() => {
+		input && defaultValue && untrack(() => setInputValueToDefaultValue())
+	})
+	$effect.pre(() => {
+		input &&
+			(defaultValue === '' || defaultValue === undefined || defaultValue === null) &&
+			untrack(() => clearInputValue())
+	})
 </script>

--- a/frontend/src/lib/components/apps/components/helpers/InputValue.svelte
+++ b/frontend/src/lib/components/apps/components/helpers/InputValue.svelte
@@ -347,6 +347,10 @@
 			) &&
 			untrack(() => debounceTemplate())
 	})
+
+	// $effect(() => {
+	// 	console.log('handleConnection4', input)
+	// })
 	$effect(() => {
 		input?.type == 'static' && input.value
 		input && $worldStore && untrack(() => debounce(handleConnection))

--- a/frontend/src/lib/components/apps/components/helpers/Loader.svelte
+++ b/frontend/src/lib/components/apps/components/helpers/Loader.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
 	import { Loader2 } from 'lucide-svelte'
 
-	export let loading: boolean
+	interface Props {
+		loading: boolean
+		children?: import('svelte').Snippet
+	}
+
+	let { loading, children }: Props = $props()
 </script>
 
 {#if !loading}
-	<slot />
+	{@render children?.()}
 {:else}
 	<div class="w-full h-full">
 		<div class="absolute inset-0 center-center flex-col bg-surface text-tertiary border">

--- a/frontend/src/lib/components/apps/components/helpers/MissingConnectionWarning.svelte
+++ b/frontend/src/lib/components/apps/components/helpers/MissingConnectionWarning.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 	import type { AppInput } from '../../inputType'
 
-	export let input: AppInput
+	interface Props {
+		input: AppInput
+	}
+
+	let { input }: Props = $props()
 </script>
 
 {#if input.type === 'connected'}

--- a/frontend/src/lib/components/apps/components/helpers/ResolveConfig.svelte
+++ b/frontend/src/lib/components/apps/components/helpers/ResolveConfig.svelte
@@ -54,8 +54,10 @@
 	{/each}
 {:else}
 	{#if debug}
-		<pre>
-			key: {key} {JSON.stringify({ r: resolvedConfig })} {JSON.stringify(configuration)}</pre
+		<pre class="text-2xs">
+			key: {key} 
+			{JSON.stringify({ r: resolvedConfig })}
+			{JSON.stringify(configuration)}</pre
 		>
 	{/if}
 	<InputValue

--- a/frontend/src/lib/components/apps/components/helpers/ResolveConfig.svelte
+++ b/frontend/src/lib/components/apps/components/helpers/ResolveConfig.svelte
@@ -54,8 +54,7 @@
 	{/each}
 {:else}
 	{#if debug}
-		<pre
-			>{JSON.stringify(configuration)}
+		<pre>
 			key: {key} {JSON.stringify({ r: resolvedConfig })} {JSON.stringify(configuration)}</pre
 		>
 	{/if}

--- a/frontend/src/lib/components/apps/components/helpers/ResolveConfig.svelte
+++ b/frontend/src/lib/components/apps/components/helpers/ResolveConfig.svelte
@@ -10,6 +10,7 @@
 		resolvedConfig: any | { type: 'oneOf'; configuration: any; selected: string }
 		configuration: RichConfiguration
 		initialConfig?: RichConfiguration | undefined
+		debug?: boolean
 	}
 
 	let {
@@ -18,15 +19,17 @@
 		key,
 		resolvedConfig = $bindable(),
 		configuration,
-		initialConfig = undefined
+		initialConfig = undefined,
+		debug = false
 	}: Props = $props()
 
 	function handleSelected(selected: string) {
 		if (resolvedConfig?.selected != undefined && resolvedConfig?.selected != selected) {
 			resolvedConfig.selected = selected
 		}
+		// console.log('handleSelected', JSON.stringify({ resolvedConfig, configuration }))
 	}
-	$effect(() => {
+	$effect.pre(() => {
 		configuration?.type == 'oneOf' &&
 			configuration.selected &&
 			untrack(() => handleSelected(configuration.selected))
@@ -50,6 +53,12 @@
 		{/if}
 	{/each}
 {:else}
+	{#if debug}
+		<pre
+			>{JSON.stringify(configuration)}
+			key: {key} {JSON.stringify({ r: resolvedConfig })} {JSON.stringify(configuration)}</pre
+		>
+	{/if}
 	<InputValue
 		field={key}
 		key={key + extraKey}

--- a/frontend/src/lib/components/apps/components/helpers/ResolveStyle.svelte
+++ b/frontend/src/lib/components/apps/components/helpers/ResolveStyle.svelte
@@ -2,17 +2,28 @@
 	import { deepEqual } from 'fast-equals'
 	import type { ComponentCssProperty } from '../../types'
 	import InputValue from './InputValue.svelte'
+	import { untrack } from 'svelte'
 
-	export let css: ComponentCssProperty
-	export let id: string
-	export let key: string
-	export let extraKey: string = ''
+	interface Props {
+		css: ComponentCssProperty
+		id: string
+		key: string
+		extraKey?: string
+		customCss?: Record<string, ComponentCssProperty> | undefined
+		componentStyle?: Record<string, ComponentCssProperty> | undefined
+	}
 
-	export let customCss: Record<string, ComponentCssProperty> | undefined = undefined
-	export let componentStyle: Record<string, ComponentCssProperty> | undefined = undefined
+	let {
+		css = $bindable(),
+		id,
+		key,
+		extraKey = '',
+		customCss = undefined,
+		componentStyle = undefined
+	}: Props = $props()
 
-	let evalClassValue: string | undefined = undefined
-	let evalClassValueGlobal: string | undefined = undefined
+	let evalClassValue: string | undefined = $state(undefined)
+	let evalClassValueGlobal: string | undefined = $state(undefined)
 
 	function updateCss(
 		componentStyle: Record<string, ComponentCssProperty> | undefined,
@@ -36,17 +47,24 @@
 	}
 
 	// When any of the values change, update the css
-	$: updateCss(componentStyle, customCss, evalClassValue, evalClassValueGlobal)
+	$effect(() => {
+		;[componentStyle, customCss, evalClassValue, evalClassValueGlobal]
+		untrack(() => updateCss(componentStyle, customCss, evalClassValue, evalClassValueGlobal))
+	})
 
 	// We need to clear the evalClassValue if the user has disabled the evalClass
-	$: if (customCss?.[key]?.evalClass === undefined && evalClassValue !== undefined) {
-		evalClassValue = undefined
-	}
+	$effect(() => {
+		if (customCss?.[key]?.evalClass === undefined && evalClassValue !== undefined) {
+			evalClassValue = undefined
+		}
+	})
 
 	// We need to clear the evalClassValue if the user has disabled the evalClass
-	$: if (componentStyle?.[key]?.evalClass === undefined && evalClassValueGlobal !== undefined) {
-		evalClassValueGlobal = undefined
-	}
+	$effect(() => {
+		if (componentStyle?.[key]?.evalClass === undefined && evalClassValueGlobal !== undefined) {
+			evalClassValueGlobal = undefined
+		}
+	})
 </script>
 
 {#if customCss}

--- a/frontend/src/lib/components/apps/components/inputs/AppMultiSelect.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/AppMultiSelect.svelte
@@ -2,9 +2,13 @@
 	import AlignWrapper from '../helpers/AlignWrapper.svelte'
 	import InitializeComponent from '../helpers/InitializeComponent.svelte'
 
-	export let id: string
-	export let render: boolean
-	export let verticalAlignment: 'top' | 'center' | 'bottom' | undefined = undefined
+	interface Props {
+		id: string
+		render: boolean
+		verticalAlignment?: 'top' | 'center' | 'bottom' | undefined
+	}
+
+	let { id, render, verticalAlignment = undefined }: Props = $props()
 </script>
 
 <InitializeComponent {id} />

--- a/frontend/src/lib/components/apps/components/inputs/AppS3FileInput.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/AppS3FileInput.svelte
@@ -15,16 +15,26 @@
 	import { defaultIfEmptyString } from '$lib/utils'
 	import { userStore } from '$lib/stores'
 
-	export let id: string
-	export let configuration: RichConfigurations
-	export let customCss: ComponentCustomCSS<'s3fileinputcomponent'> | undefined = undefined
-	export let render: boolean
-	export let extraKey: string | undefined = undefined
-	export let onFileChange: string[] | undefined = undefined
+	interface Props {
+		id: string
+		configuration: RichConfigurations
+		customCss?: ComponentCustomCSS<'s3fileinputcomponent'> | undefined
+		render: boolean
+		extraKey?: string | undefined
+		onFileChange?: string[] | undefined
+	}
 
-	let resolvedConfig = initConfig(
-		components['s3fileinputcomponent'].initialData.configuration,
-		configuration
+	let {
+		id,
+		configuration,
+		customCss = undefined,
+		render,
+		extraKey = undefined,
+		onFileChange = undefined
+	}: Props = $props()
+
+	let resolvedConfig = $state(
+		initConfig(components['s3fileinputcomponent'].initialData.configuration, configuration)
 	)
 
 	let fileUploads: Writable<FileUploadData[]> = writable([])
@@ -38,16 +48,16 @@
 		}
 	}
 
-	let value: { path: string; filename: string }[] | undefined = undefined
+	let value: { path: string; filename: string }[] | undefined = $state(undefined)
 	const outputs = initOutput($worldStore, id, {
 		result: value ?? ([] as { path: string; filename: string }[] | undefined),
 		loading: false,
 		jobId: undefined
 	})
 
-	$: resolvedConfigS3 = resolvedConfig.type.configuration.s3
+	let resolvedConfigS3 = $derived(resolvedConfig.type.configuration.s3)
 
-	let css = initCss($app.css?.fileinputcomponent, customCss)
+	let css = $state(initCss($app.css?.fileinputcomponent, customCss))
 	/*
 
 		{#if resolvedConfig.displayDirectLink && fileUpload.progress === 100}

--- a/frontend/src/lib/components/apps/components/inputs/currency/CurrencyInput.svelte
+++ b/frontend/src/lib/components/apps/components/inputs/currency/CurrencyInput.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import DarkModeObserver from '$lib/components/DarkModeObserver.svelte'
+	import { untrack } from 'svelte'
 
 	/* Forked from MIT LICENSE
     https://raw.githubusercontent.com/Canutin/svelte-currency-input/main/src/lib/CurrencyInput.svelte 
@@ -27,18 +28,35 @@
 		formattedZero?: string
 	}
 
-	export let value: number = DEFAULT_VALUE
-	export let locale: string = DEFAULT_LOCALE
-	export let currency: string = DEFAULT_CURRENCY
-	export let name: string = DEFAULT_NAME
-	export let required: boolean = false
-	export let disabled: boolean = false
-	export let placeholder: number | null = DEFAULT_VALUE
-	export let isNegativeAllowed: boolean = true
-	export let fractionDigits: number = DEFAULT_FRACTION_DIGITS
-	export let inputClasses: InputClasses | null = null
-	export let noColor: boolean = false
-	export let style: string = ''
+	interface Props {
+		value?: number
+		locale?: string
+		currency?: string
+		name?: string
+		required?: boolean
+		disabled?: boolean
+		placeholder?: number | null
+		isNegativeAllowed?: boolean
+		fractionDigits?: number
+		inputClasses?: InputClasses | null
+		noColor?: boolean
+		style?: string
+	}
+
+	let {
+		value = $bindable(DEFAULT_VALUE),
+		locale = DEFAULT_LOCALE,
+		currency = DEFAULT_CURRENCY,
+		name = DEFAULT_NAME,
+		required = false,
+		disabled = false,
+		placeholder = DEFAULT_VALUE,
+		isNegativeAllowed = true,
+		fractionDigits = DEFAULT_FRACTION_DIGITS,
+		inputClasses = null,
+		noColor = false,
+		style = ''
+	}: Props = $props()
 
 	// Formats value as: e.g. $1,523.00 | -$1,523.00
 	const formatCurrency = (
@@ -158,14 +176,19 @@
 		}, 0.1)
 	}
 
-	let formattedValue = ''
+	let formattedValue = $state('')
 	let formattedPlaceholder =
 		placeholder !== null ? formatCurrency(placeholder, fractionDigits, fractionDigits) : ''
-	$: isZero = value === 0
-	$: isNegative = value < 0
-	$: value, setFormattedValue()
+	let isZero = $derived(value === 0)
+	let isNegative = $derived(value < 0)
+	$effect(() => {
+		value
+		untrack(() => {
+			setFormattedValue()
+		})
+	})
 
-	let darkMode: boolean = false
+	let darkMode: boolean = $state(false)
 </script>
 
 <DarkModeObserver bind:darkMode />
@@ -182,11 +205,11 @@
 		class="
 			{inputClasses?.formatted ?? DEFAULT_CLASS_FORMATTED}
 			{isNegativeAllowed && !isZero && !isNegative
-			? inputClasses?.formattedPositive ?? DEFAULT_CLASS_FORMATTED_POSITIVE
+			? (inputClasses?.formattedPositive ?? DEFAULT_CLASS_FORMATTED_POSITIVE)
 			: ''}
-			{isZero ? inputClasses?.formattedZero ?? DEFAULT_CLASS_FORMATTED_ZERO : ''}
+			{isZero ? (inputClasses?.formattedZero ?? DEFAULT_CLASS_FORMATTED_ZERO) : ''}
 			{isNegativeAllowed && isNegative
-			? inputClasses?.formattedNegative ?? DEFAULT_CLASS_FORMATTED_NEGATIVE
+			? (inputClasses?.formattedNegative ?? DEFAULT_CLASS_FORMATTED_NEGATIVE)
 			: ''}
 		"
 		style={style ? style : noColor ? (darkMode ? 'color: white;' : 'color: black;') : ''}
@@ -197,8 +220,8 @@
 		placeholder={formattedPlaceholder}
 		{disabled}
 		bind:value={formattedValue}
-		on:keydown={handleKeyDown}
-		on:keyup={setUnformattedValue}
+		onkeydown={handleKeyDown}
+		onkeyup={setUnformattedValue}
 	/>
 </div>
 

--- a/frontend/src/lib/components/apps/components/layout/AppDivider.svelte
+++ b/frontend/src/lib/components/apps/components/layout/AppDivider.svelte
@@ -15,21 +15,33 @@
 	import InitializeComponent from '../helpers/InitializeComponent.svelte'
 	import ResolveStyle from '../helpers/ResolveStyle.svelte'
 
-	export let id: string
-	export let configuration: RichConfigurations
-	export let horizontalAlignment: HorizontalAlignment | undefined = undefined
-	export let verticalAlignment: VerticalAlignment | undefined = undefined
-	export let customCss:
-		| ComponentCustomCSS<'verticaldividercomponent' | 'horizontaldividercomponent'>
-		| undefined = undefined
-	export let position: 'horizontal' | 'vertical'
-	export let render: boolean
+	interface Props {
+		id: string
+		configuration: RichConfigurations
+		horizontalAlignment?: HorizontalAlignment | undefined
+		verticalAlignment?: VerticalAlignment | undefined
+		customCss?:
+			| ComponentCustomCSS<'verticaldividercomponent' | 'horizontaldividercomponent'>
+			| undefined
+		position: 'horizontal' | 'vertical'
+		render: boolean
+	}
+
+	let {
+		id,
+		configuration,
+		horizontalAlignment = undefined,
+		verticalAlignment = undefined,
+		customCss = undefined,
+		position,
+		render
+	}: Props = $props()
 
 	const { app, worldStore } = getContext<AppViewerContext>('AppViewerContext')
-	let size = 2
-	let color = '#00000060'
+	let size = $state(2)
+	let color = $state('#00000060')
 
-	let css = initCss($app.css?.[position + 'dividercomponent'], customCss)
+	let css = $state(initCss($app.css?.[position + 'dividercomponent'], customCss))
 
 	//used so that we can count number of outputs setup for first refresh
 	initOutput($worldStore, id, {})

--- a/frontend/src/lib/components/apps/components/layout/ListWrapper.svelte
+++ b/frontend/src/lib/components/apps/components/layout/ListWrapper.svelte
@@ -3,14 +3,28 @@
 	import type { ListInputs, ListContext } from '../../types'
 	import { writable } from 'svelte/store'
 
-	export let index: number
-	export let value: any
-	export let disabled = false
-	export let onSet: ((id: string, value: any) => void) | undefined = undefined
-	export let onRemove: ((id: string) => void) | undefined = undefined
+	interface Props {
+		index: number
+		value: any
+		disabled?: boolean
+		onSet?: ((id: string, value: any) => void) | undefined
+		onRemove?: ((id: string) => void) | undefined
+		children?: import('svelte').Snippet
+	}
+
+	let {
+		index,
+		value,
+		disabled = false,
+		onSet = undefined,
+		onRemove = undefined,
+		children
+	}: Props = $props()
 	const ctx = writable({ index, value, disabled })
 
-	$: $ctx = { index, value, disabled }
+	$effect(() => {
+		$ctx = { index, value, disabled }
+	})
 	setContext<ListContext>('ListWrapperContext', ctx)
 	setContext<ListInputs>('ListInputs', {
 		set: (id: string, value: any) => {
@@ -22,4 +36,4 @@
 	})
 </script>
 
-<slot />
+{@render children?.()}

--- a/frontend/src/lib/components/apps/components/layout/RowWrapper.svelte
+++ b/frontend/src/lib/components/apps/components/layout/RowWrapper.svelte
@@ -3,15 +3,22 @@
 	import type { ListInputs, ListContext } from '../../types'
 	import { writable } from 'svelte/store'
 
-	export let index: number
-	export let value: any
-	export let disabled = false
-	export let onSet: (id: string, value: any) => void
-	export let onRemove: (id: string) => void
+	interface Props {
+		index: number
+		value: any
+		disabled?: boolean
+		onSet: (id: string, value: any) => void
+		onRemove: (id: string) => void
+		children?: import('svelte').Snippet
+	}
+
+	let { index, value, disabled = false, onSet, onRemove, children }: Props = $props()
 
 	const ctx = writable({ index, value, disabled })
 
-	$: $ctx = { index, value, disabled }
+	$effect(() => {
+		$ctx = { index, value, disabled }
+	})
 
 	setContext<ListContext>('RowWrapperContext', ctx)
 	setContext<ListInputs>('RowInputs', {
@@ -24,4 +31,4 @@
 	})
 </script>
 
-<slot />
+{@render children?.()}

--- a/frontend/src/lib/components/apps/editor/AppComponentInput.svelte
+++ b/frontend/src/lib/components/apps/editor/AppComponentInput.svelte
@@ -2,8 +2,12 @@
 	import { components, type AppComponent } from './component'
 	import InputsSpecsEditor from './settingsPanel/InputsSpecsEditor.svelte'
 
-	export let component: AppComponent
-	export let resourceOnly = false
+	interface Props {
+		component: AppComponent
+		resourceOnly?: boolean
+	}
+
+	let { component = $bindable(), resourceOnly = false }: Props = $props()
 </script>
 
 {#if component?.componentInput?.type === 'runnable' && Object.keys(component?.componentInput?.fields ?? {}).length > 0}

--- a/frontend/src/lib/components/apps/editor/AppDeploymentHistory.svelte
+++ b/frontend/src/lib/components/apps/editor/AppDeploymentHistory.svelte
@@ -5,8 +5,12 @@
 	import { sendUserToast } from '$lib/toast'
 	import DeploymentHistory from './DeploymentHistory.svelte'
 
-	export let appPath: string | undefined = undefined
-	let historyBrowserDrawerOpen = false
+	interface Props {
+		appPath?: string | undefined
+	}
+
+	let { appPath = undefined }: Props = $props()
+	let historyBrowserDrawerOpen = $state(false)
 
 	export function open() {
 		historyBrowserDrawerOpen = true

--- a/frontend/src/lib/components/apps/editor/AppEditorBottomPanel.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorBottomPanel.svelte
@@ -1,15 +1,26 @@
 <script lang="ts">
+	import { createBubbler } from 'svelte/legacy'
+
+	const bubble = createBubbler()
 	import InlineScriptsPanel from './inlineScriptsPanel/InlineScriptsPanel.svelte'
 	import RunnableJobPanel from './RunnableJobPanel.svelte'
 
-	export let rightPanelSize: number = 0
-	export let centerPanelWidth: number = 0
-	export let runnablePanelSize: number = 0
+	interface Props {
+		rightPanelSize?: number
+		centerPanelWidth?: number
+		runnablePanelSize?: number
+	}
+
+	let { rightPanelSize = 0, centerPanelWidth = 0, runnablePanelSize = 0 }: Props = $props()
 </script>
 
 {#if rightPanelSize !== 0}
-	<!-- svelte-ignore a11y-no-static-element-interactions -->
-	<div class="relative h-full w-full overflow-x-visible" on:mouseenter on:mouseleave>
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div
+		class="relative h-full w-full overflow-x-visible"
+		onmouseenter={bubble('mouseenter')}
+		onmouseleave={bubble('mouseleave')}
+	>
 		<InlineScriptsPanel on:hidePanel />
 		<RunnableJobPanel hidden={runnablePanelSize === 0} />
 	</div>

--- a/frontend/src/lib/components/apps/editor/AppReportsDrawer.svelte
+++ b/frontend/src/lib/components/apps/editor/AppReportsDrawer.svelte
@@ -2,8 +2,12 @@
 	import { Drawer } from '$lib/components/common'
 
 	import AppReportsDrawerInner from './AppReportsDrawerInner.svelte'
-	export let appPath: string
-	export let open = false
+	interface Props {
+		appPath: string
+		open?: boolean
+	}
+
+	let { appPath, open = $bindable(false) }: Props = $props()
 </script>
 
 <Drawer bind:open size="800px">

--- a/frontend/src/lib/components/apps/editor/AppTimeline.svelte
+++ b/frontend/src/lib/components/apps/editor/AppTimeline.svelte
@@ -1,24 +1,30 @@
 <script lang="ts">
 	import { debounce } from '$lib/utils'
-	import { onDestroy } from 'svelte'
+	import { onDestroy, untrack } from 'svelte'
 
 	import TimelineBar from '$lib/components/TimelineBar.svelte'
 	import type { JobById } from '../types'
 
-	export let jobs: string[]
-	export let jobsById: Record<string, JobById>
+	interface Props {
+		jobs: string[]
+		jobsById: Record<string, JobById>
+	}
 
-	let min: undefined | number = undefined
+	let { jobs, jobsById }: Props = $props()
+
+	let min: undefined | number = $state(undefined)
 	let max: undefined | number = undefined
-	let total: number | undefined = undefined
+	let total: number | undefined = $state(undefined)
 
 	let { debounced, clearDebounce } = debounce(() => computeItems(jobs), 30)
-	$: jobs && jobsById && debounced()
+	$effect(() => {
+		jobs && jobsById && untrack(() => debounced())
+	})
 
 	let items: Record<
 		string,
 		{ created_at?: number; started_at?: number; duration_ms?: number; id: string }[]
-	> = {}
+	> = $state({})
 
 	export function reset() {
 		min = undefined
@@ -88,7 +94,7 @@
 		items = nitems
 	}
 
-	let now = Date.now()
+	let now = $state(Date.now())
 
 	let interval = setInterval((x) => {
 		if (!max) {

--- a/frontend/src/lib/components/apps/editor/GridEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/GridEditor.svelte
@@ -231,7 +231,7 @@
 				}}
 				disableMove={!!$connectingInput.opened}
 			>
-				{#snippet children({ dataItem, overlapped, moveMode, componentDraggedId })}
+				{#snippet children({ dataItem, overlapped, componentDraggedId })}
 					<ComponentWrapper
 						id={dataItem.id}
 						type={dataItem.data.type}
@@ -276,7 +276,6 @@
 									$app = $app
 								}}
 								{overlapped}
-								{moveMode}
 								{componentDraggedId}
 							/>
 						</GridEditorMenu>

--- a/frontend/src/lib/components/apps/editor/GridViewer.svelte
+++ b/frontend/src/lib/components/apps/editor/GridViewer.svelte
@@ -18,34 +18,49 @@
 
 	const { app } = getContext<AppViewerContext>('AppViewerContext')
 
-	export let items: FilledItem<T>[]
-	export let rowHeight: number = ROW_HEIGHT
-	export let gap = [ROW_GAP_X, ROW_GAP_Y]
-	export let throttleUpdate = 100
-	export let maxRow: number
-	export let breakpoint: EditorBreakpoint
+	interface Props {
+		items: FilledItem<T>[]
+		rowHeight?: number
+		gap?: any
+		throttleUpdate?: number
+		maxRow: number
+		breakpoint: EditorBreakpoint
+		allIdsInPath?: string[] | undefined
+		containerWidth?: number | undefined
+		parentWidth?: number | undefined
+		children?: import('svelte').Snippet<[any]>
+	}
 
-	export let allIdsInPath: string[] | undefined = undefined
-	export let containerWidth: number | undefined = undefined
-
-	export let parentWidth: number | undefined = undefined
+	let {
+		items = $bindable(),
+		rowHeight = ROW_HEIGHT,
+		gap = [ROW_GAP_X, ROW_GAP_Y],
+		throttleUpdate = 100,
+		maxRow,
+		breakpoint,
+		allIdsInPath = undefined,
+		containerWidth = $bindable(undefined),
+		parentWidth = undefined,
+		children
+	}: Props = $props()
 
 	const cols = columnConfiguration
 
-	let showSkeleton = false
+	let showSkeleton = $state(false)
 
-	let getComputedCols: 3 | 12 | undefined =
+	let getComputedCols: 3 | 12 | undefined = $state(
 		$app.mobileViewOnSmallerScreens == false ? WIDE_GRID_COLUMNS : undefined
+	)
 
-	let container
+	let container = $state()
 
-	$: [gapX, gapY] = gap
+	let [gapX, gapY] = $derived(gap)
 
-	let xPerPx = 0
+	let xPerPx = $state(0)
 
 	let yPerPx = rowHeight
 
-	$: containerHeight = getContainerHeight(items, yPerPx, getComputedCols)
+	let containerHeight = $derived(getContainerHeight(items, yPerPx, getComputedCols))
 
 	const onResize = throttle(() => {
 		if (!getComputedCols) return
@@ -92,7 +107,7 @@
 			})
 		})
 
-		sizeObserver.observe(container)
+		sizeObserver.observe(container as Element)
 
 		return () => sizeObserver.disconnect()
 	})
@@ -121,7 +136,7 @@
 					: ''} top: {top}px; left: {left}px;"
 			>
 				{#if item[getComputedCols]}
-					<slot dataItem={item} item={item[getComputedCols]} />
+					{@render children?.({ dataItem: item, item: item[getComputedCols] })}
 				{/if}
 			</div>
 		{/each}

--- a/frontend/src/lib/components/apps/editor/RunnableJobPanelInner.svelte
+++ b/frontend/src/lib/components/apps/editor/RunnableJobPanelInner.svelte
@@ -5,12 +5,16 @@
 	import type { Job } from '$lib/gen'
 	import { Loader2 } from 'lucide-svelte'
 
-	export let frontendJob: boolean | any = false
-	export let testJob: Job | any = undefined
-	export let testIsLoading = false
+	interface Props {
+		frontendJob?: boolean | any
+		testJob?: Job | any
+		testIsLoading?: boolean
+	}
 
-	let logDrawerOpen = false
-	let resultDrawerOpen = false
+	let { frontendJob = false, testJob = undefined, testIsLoading = false }: Props = $props()
+
+	let logDrawerOpen = $state(false)
+	let resultDrawerOpen = $state(false)
 </script>
 
 <Splitpanes horizontal>

--- a/frontend/src/lib/components/apps/editor/SettingsPanel.svelte
+++ b/frontend/src/lib/components/apps/editor/SettingsPanel.svelte
@@ -109,58 +109,37 @@
 </script>
 
 {#if gridItemWithLocation}
-	{#key gridItemWithLocation.item.id}
-		<ComponentPanel
-			bind:componentSettings={
-				() => gridItemWithLocation,
-				(cs) => {
-					if (gridItemWithLocation?.location.type === 'grid') {
-						$app.grid[gridItemWithLocation.location.gridItemIndex] = cs.item
-					} else if (
-						gridItemWithLocation?.location.type === 'subgrid' &&
-						Array.isArray($app.subgrids?.[gridItemWithLocation.location.subgridKey])
-					) {
-						if (
-							$app.subgrids[gridItemWithLocation.location.subgridKey][
-								gridItemWithLocation.location.subgridItemIndex
-							]
-						) {
-							$app.subgrids[gridItemWithLocation.location.subgridKey][
-								gridItemWithLocation.location.subgridItemIndex
-							] = cs.item
-						}
-					}
-				}
-			}
-			onDelete={() => {
-				dispatch('delete')
-			}}
-		/>
-	{/key}
+	{#if gridItemWithLocation.location.type === 'grid'}
+		{#each $app.grid as gridItem, gridItemIndex}
+			{#if gridItem.data.id === gridItemWithLocation.item.id}
+				<ComponentPanel
+					bind:item={$app.grid[gridItemIndex]}
+					parent={gridItemWithLocation.parent}
+					onDelete={() => {
+						dispatch('delete')
+					}}
+				/>
+			{/if}
+		{/each}
+	{:else if gridItemWithLocation.location.type === 'subgrid' && $app.subgrids}
+		{#each $app.subgrids[gridItemWithLocation.location.subgridKey] as subgridItem, subgridItemIndex}
+			{#if subgridItem.data.id === gridItemWithLocation.item.id}
+				<ComponentPanel
+					bind:item={$app.subgrids[gridItemWithLocation.location.subgridKey][subgridItemIndex]}
+					parent={gridItemWithLocation.parent}
+					onDelete={() => {
+						dispatch('delete')
+					}}
+				/>
+			{/if}
+		{/each}
+	{/if}
 {:else if tableActionSettings}
 	{#key tableActionSettings?.item?.data?.id}
 		<ComponentPanel
 			noGrid
-			bind:componentSettings={
-				() => tableActionSettings,
-				(cs) => {
-					if (tableActionSettings) {
-						if (tableActionSettings.gridItemLocation.type === 'grid') {
-							const { gridItemIndex } = tableActionSettings.gridItemLocation
-							const { key, index } = tableActionSettings.location
-							if ($app.grid[gridItemIndex]?.data?.[key]) {
-								$app.grid[gridItemIndex].data[key][index] = cs.item.data
-							}
-						} else if (tableActionSettings.gridItemLocation.type === 'subgrid') {
-							const { subgridKey, subgridItemIndex } = tableActionSettings.gridItemLocation
-							const { key, index } = tableActionSettings.location
-							if ($app.subgrids?.[subgridKey]?.[subgridItemIndex]?.data?.[key]) {
-								$app.subgrids[subgridKey][subgridItemIndex].data[key][index] = cs.item.data
-							}
-						}
-					}
-				}
-			}
+			bind:item={tableActionSettings.item}
+			parent={tableActionSettings.parent}
 			duplicateMoveAllowed={false}
 			onDelete={() => {
 				if (tableActionSettings) {
@@ -209,24 +188,8 @@
 	{#key menuItemsSettings?.item?.id}
 		<ComponentPanel
 			noGrid
-			bind:componentSettings={
-				() => menuItemsSettings,
-				(cs) => {
-					if (menuItemsSettings) {
-						if (menuItemsSettings.gridItemLocation.type === 'grid') {
-							const { gridItemIndex } = menuItemsSettings.gridItemLocation
-							if ($app.grid[gridItemIndex]?.data?.type === 'menucomponent') {
-								$app.grid[gridItemIndex].data.menuItems[cs.index] = cs.item.data
-							}
-						} else if (menuItemsSettings.gridItemLocation.type === 'subgrid') {
-							const { subgridKey, subgridItemIndex } = menuItemsSettings.gridItemLocation
-							if ($app.subgrids?.[subgridKey]?.[subgridItemIndex]?.data?.type === 'menucomponent') {
-								$app.subgrids[subgridKey][subgridItemIndex].data.menuItems[cs.index] = cs.item.data
-							}
-						}
-					}
-				}
-			}
+			bind:item={menuItemsSettings.item}
+			parent={menuItemsSettings.parent}
 			onDelete={() => {
 				if (menuItemsSettings) {
 					const item = findGridItemWithLocation($app, menuItemsSettings.parent)

--- a/frontend/src/lib/components/apps/editor/SubGridEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/SubGridEditor.svelte
@@ -268,7 +268,7 @@
 						}}
 						disableMove={!!$connectingInput.opened}
 					>
-						{#snippet children({ dataItem, overlapped, moveMode, componentDraggedId })}
+						{#snippet children({ dataItem, overlapped, componentDraggedId })}
 							<ComponentWrapper
 								id={dataItem.id}
 								type={dataItem.data.type}
@@ -314,7 +314,6 @@
 											}
 											$app = $app
 										}}
-										{moveMode}
 										{componentDraggedId}
 									/>
 								</GridEditorMenu>

--- a/frontend/src/lib/components/apps/editor/appUtils.ts
+++ b/frontend/src/lib/components/apps/editor/appUtils.ts
@@ -6,7 +6,8 @@ import type {
 	EditorBreakpoint,
 	FocusedGrid,
 	GeneralAppInput,
-	GridItem
+	GridItem,
+	RichConfiguration
 } from '../types'
 import {
 	ccomponents,
@@ -38,14 +39,14 @@ import gridHelp from '../svelte-grid/utils/helper'
 
 type GridItemLocation =
 	| {
-			type: 'grid'
-			gridItemIndex: number
-	  }
+		type: 'grid'
+		gridItemIndex: number
+	}
 	| {
-			type: 'subgrid'
-			subgridItemIndex: number
-			subgridKey: string
-	  }
+		type: 'subgrid'
+		subgridItemIndex: number
+		subgridKey: string
+	}
 interface GridItemWithLocation {
 	location: GridItemLocation
 	item: GridItem
@@ -186,7 +187,7 @@ export function selectId(
 	selectedComponent: Writable<string[] | undefined>,
 	app: App
 ) {
-	;(document?.activeElement as HTMLElement)?.blur()
+	; (document?.activeElement as HTMLElement)?.blur()
 	if (e.shiftKey) {
 		selectedComponent.update((old) => {
 			if (old && old?.[0]) {
@@ -482,8 +483,65 @@ export function appComponentFromType<T extends keyof typeof components>(
 			horizontalAlignment: override?.horizontalAlignment ?? init.horizontalAlignment,
 			verticalAlignment: override?.verticalAlignment ?? init.verticalAlignment,
 			id,
+			datasets:
+				type === 'plotlycomponentv2'
+					? createPlotlyComponentDataset()
+					: type === 'chartjscomponentv2'
+						? createChartjsComponentDataset()
+						: undefined,
+			xData:
+				type === 'plotlycomponentv2' || type === 'chartjscomponentv2'
+					? {
+						type: 'evalv2',
+						fieldType: 'array',
+						expr: '[1, 2, 3, 4]',
+						connections: []
+					}
+					: undefined,
 			...(extra ?? {})
 		}
+	}
+}
+
+export function createChartjsComponentDataset(): RichConfiguration {
+	return {
+		type: 'static',
+		fieldType: 'array',
+		subFieldType: 'chartjs',
+		value: [
+			{
+				value: {
+					type: 'static',
+					fieldType: 'array',
+					subFieldType: 'number',
+					value: [25, 25, 50]
+				},
+				name: 'Dataset 1'
+			}
+		]
+	}
+}
+
+export function createPlotlyComponentDataset(): RichConfiguration {
+	return {
+		type: 'static',
+		fieldType: 'array',
+		subFieldType: 'plotly',
+		value: [
+			{
+				value: {
+					type: 'static',
+					fieldType: 'array',
+					subFieldType: 'number',
+					value: [1, 2, 3, 4]
+				},
+				name: 'Dataset 1',
+				aggregation_method: 'sum',
+				type: 'bar',
+				tooltip: '',
+				color: '#C8A2C8'
+			}
+		]
 	}
 }
 export function insertNewGridItem(
@@ -845,33 +903,33 @@ export type InitConfig<
 		| EvalAppInput
 		| EvalV2AppInput
 		| {
-				type: 'oneOf'
-				selected: string
-				configuration: Record<
-					string,
-					Record<string, StaticAppInput | EvalAppInput | EvalV2AppInput>
-				>
-		  }
+			type: 'oneOf'
+			selected: string
+			configuration: Record<
+				string,
+				Record<string, StaticAppInput | EvalAppInput | EvalV2AppInput>
+			>
+		}
 	>
 > = {
-	[Property in keyof T]: T[Property] extends StaticAppInput
+		[Property in keyof T]: T[Property] extends StaticAppInput
 		? T[Property]['value'] | undefined
 		: T[Property] extends { type: 'oneOf' }
-			? {
-					type: 'oneOf'
-					selected: keyof T[Property]['configuration']
-					configuration: {
-						[Choice in keyof T[Property]['configuration']]: {
-							[IT in keyof T[Property]['configuration'][Choice]]: T[Property]['configuration'][Choice][IT] extends StaticAppInput
-								? T[Property]['configuration'][Choice][IT] extends StaticAppInputOnDemand
-									? () => Promise<T[Property]['configuration'][Choice][IT]['value'] | undefined>
-									: T[Property]['configuration'][Choice][IT]['value'] | undefined
-								: undefined
-						}
-					}
+		? {
+			type: 'oneOf'
+			selected: keyof T[Property]['configuration']
+			configuration: {
+				[Choice in keyof T[Property]['configuration']]: {
+					[IT in keyof T[Property]['configuration'][Choice]]: T[Property]['configuration'][Choice][IT] extends StaticAppInput
+					? T[Property]['configuration'][Choice][IT] extends StaticAppInputOnDemand
+					? () => Promise<T[Property]['configuration'][Choice][IT]['value'] | undefined>
+					: T[Property]['configuration'][Choice][IT]['value'] | undefined
+					: undefined
 				}
-			: undefined
-}
+			}
+		}
+		: undefined
+	}
 
 export function initConfig<
 	T extends Record<
@@ -880,13 +938,13 @@ export function initConfig<
 		| EvalAppInput
 		| EvalV2AppInput
 		| {
-				type: 'oneOf'
-				selected: string
-				configuration: Record<
-					string,
-					Record<string, StaticAppInput | EvalAppInput | EvalV2AppInput>
-				>
-		  }
+			type: 'oneOf'
+			selected: string
+			configuration: Record<
+				string,
+				Record<string, StaticAppInput | EvalAppInput | EvalV2AppInput>
+			>
+		}
 	>
 >(
 	r: T,
@@ -894,13 +952,13 @@ export function initConfig<
 		string,
 		| StaticAppInput
 		| {
-				type: 'oneOf'
-				selected: string
-				configuration: Record<
-					string,
-					Record<string, StaticAppInput | EvalAppInput | EvalV2AppInput | boolean>
-				>
-		  }
+			type: 'oneOf'
+			selected: string
+			configuration: Record<
+				string,
+				Record<string, StaticAppInput | EvalAppInput | EvalV2AppInput | boolean>
+			>
+		}
 		| any
 	>
 ): InitConfig<T> {
@@ -910,31 +968,31 @@ export function initConfig<
 				Object.entries(r).map(([key, value]) =>
 					value.type == 'static'
 						? [
-								key,
-								configuration?.[key]?.type == 'static' ? configuration?.[key]?.['value'] : undefined
-							]
+							key,
+							configuration?.[key]?.type == 'static' ? configuration?.[key]?.['value'] : undefined
+						]
 						: value.type == 'oneOf'
 							? [
-									key,
-									{
-										selected: value.selected,
-										type: 'oneOf',
-										configuration: Object.fromEntries(
-											Object.entries(value.configuration).map(([choice, config]) => {
-												const conf = initConfig(
-													config,
-													configuration?.[key]?.configuration?.[choice]
-												)
-												Object.entries(config).forEach(([innerKey, innerValue]) => {
-													if (innerValue.type === 'static' && !(innerKey in conf)) {
-														conf[innerKey] = innerValue.value
-													}
-												})
-												return [choice, conf]
+								key,
+								{
+									selected: value.selected,
+									type: 'oneOf',
+									configuration: Object.fromEntries(
+										Object.entries(value.configuration).map(([choice, config]) => {
+											const conf = initConfig(
+												config,
+												configuration?.[key]?.configuration?.[choice]
+											)
+											Object.entries(config).forEach(([innerKey, innerValue]) => {
+												if (innerValue.type === 'static' && !(innerKey in conf)) {
+													conf[innerKey] = innerValue.value
+												}
 											})
-										)
-									}
-								]
+											return [choice, conf]
+										})
+									)
+								}
+							]
 							: [key, undefined]
 				)
 			) as any

--- a/frontend/src/lib/components/apps/editor/component/Component.svelte
+++ b/frontend/src/lib/components/apps/editor/component/Component.svelte
@@ -14,7 +14,6 @@
 		fullHeight: boolean
 		overlapped?: string | undefined
 		componentDraggedId?: string | undefined
-		moveMode?: string | undefined
 	}
 
 	let {
@@ -24,8 +23,7 @@
 		render,
 		fullHeight,
 		overlapped = undefined,
-		componentDraggedId = undefined,
-		moveMode = undefined
+		componentDraggedId = undefined
 	}: Props = $props()
 	let everRender = $state(render)
 
@@ -39,7 +37,6 @@
 		on:expand
 		on:lock
 		on:fillHeight
-		{moveMode}
 		{componentDraggedId}
 		{overlapped}
 		{render}

--- a/frontend/src/lib/components/apps/editor/component/Component.svelte
+++ b/frontend/src/lib/components/apps/editor/component/Component.svelte
@@ -5,19 +5,33 @@
 	import type { AppComponent } from './components'
 	import type { AppViewerContext } from '../../types'
 
-	export let component: AppComponent
-	export let selected: boolean
-	export let locked: boolean = false
-	export let render: boolean
-	export let fullHeight: boolean
-	export let overlapped: string | undefined = undefined
-	export let componentDraggedId: string | undefined = undefined
-
 	const { app } = getContext<AppViewerContext>('AppViewerContext')
-	export let moveMode: string | undefined = undefined
-	let everRender = render
+	interface Props {
+		component: AppComponent
+		selected: boolean
+		locked?: boolean
+		render: boolean
+		fullHeight: boolean
+		overlapped?: string | undefined
+		componentDraggedId?: string | undefined
+		moveMode?: string | undefined
+	}
 
-	$: render && !everRender && (everRender = true)
+	let {
+		component,
+		selected,
+		locked = false,
+		render,
+		fullHeight,
+		overlapped = undefined,
+		componentDraggedId = undefined,
+		moveMode = undefined
+	}: Props = $props()
+	let everRender = $state(render)
+
+	$effect(() => {
+		render && !everRender && (everRender = true)
+	})
 </script>
 
 {#if everRender || $app.eagerRendering}

--- a/frontend/src/lib/components/apps/editor/component/ComponentInner.svelte
+++ b/frontend/src/lib/components/apps/editor/component/ComponentInner.svelte
@@ -221,8 +221,6 @@
 			customCss={component.customCss}
 			bind:initializing
 			componentInput={component.componentInput}
-			datasets={component.datasets}
-			xData={component.xData}
 			{render}
 		/>
 	{:else if component.type === 'agchartscomponentee'}
@@ -232,8 +230,6 @@
 			customCss={component.customCss}
 			bind:initializing
 			componentInput={component.componentInput}
-			datasets={component.datasets}
-			xData={component.xData}
 			license={component.license}
 			ee={true}
 			{render}

--- a/frontend/src/lib/components/apps/editor/component/ComponentInner.svelte
+++ b/frontend/src/lib/components/apps/editor/component/ComponentInner.svelte
@@ -94,7 +94,11 @@
 	}: Props = $props()
 </script>
 
-<svelte:boundary>
+<svelte:boundary
+	onerror={(e) => {
+		console.error(e)
+	}}
+>
 	{#if component.type === 'displaycomponent'}
 		<AppDisplayComponent
 			id={component.id}

--- a/frontend/src/lib/components/apps/editor/component/ComponentRendered.svelte
+++ b/frontend/src/lib/components/apps/editor/component/ComponentRendered.svelte
@@ -1,9 +1,11 @@
-<script lang="ts" context="module">
+<script lang="ts" module>
 	let outTimeout: NodeJS.Timeout | undefined = undefined
 </script>
 
 <script lang="ts">
-	import { getContext, onMount } from 'svelte'
+	import { stopPropagation } from 'svelte/legacy'
+
+	import { getContext, onMount, untrack } from 'svelte'
 	import { twMerge } from 'tailwind-merge'
 	import type { AppEditorContext, AppViewerContext } from '../../types'
 	import ComponentHeader from '../ComponentHeader.svelte'
@@ -13,16 +15,29 @@
 	import { findGridItemParentGrid, isContainer } from '../appUtils'
 	import ComponentInner from './ComponentInner.svelte'
 
-	export let component: AppComponent
-	export let selected: boolean
-	export let locked: boolean = false
-	export let fullHeight: boolean
-	export let overlapped: string | undefined = undefined
-	export let moveMode: string | undefined = undefined
-	export let componentDraggedId: string | undefined = undefined
-	export let render: boolean = false
+	interface Props {
+		component: AppComponent
+		selected: boolean
+		locked?: boolean
+		fullHeight: boolean
+		overlapped?: string | undefined
+		moveMode?: string | undefined
+		componentDraggedId?: string | undefined
+		render?: boolean
+	}
 
-	let initializing: boolean | undefined
+	let {
+		component,
+		selected,
+		locked = false,
+		fullHeight,
+		overlapped = undefined,
+		moveMode = undefined,
+		componentDraggedId = undefined,
+		render = false
+	}: Props = $props()
+
+	let initializing: boolean | undefined = $state()
 
 	const { mode, app, hoverStore, connectingInput } =
 		getContext<AppViewerContext>('AppViewerContext')
@@ -31,15 +46,16 @@
 	const componentActive = editorContext?.componentActive
 
 	const movingcomponents = editorContext?.movingcomponents
-	$: ismoving =
+	let ismoving = $derived(
 		movingcomponents != undefined && $mode == 'dnd' && $movingcomponents?.includes(component.id)
+	)
 
-	let errorHandledByComponent: boolean = false
-	let componentContainerHeight: number = 0
-	let componentContainerWidth: number = 0
+	let errorHandledByComponent: boolean = $state(false)
+	let componentContainerHeight: number = $state(0)
+	let componentContainerWidth: number = $state(0)
 
-	let inlineEditorOpened: boolean = false
-	let showSkeleton = false
+	let inlineEditorOpened: boolean = $state(false)
+	let showSkeleton = $state(false)
 
 	onMount(() => {
 		setTimeout(() => {
@@ -74,8 +90,8 @@
 		)
 	}
 
-	let cachedComponentDraggedIsNotChild: boolean | undefined
-	let cachedAreOnTheSameSubgrid: boolean | undefined
+	let cachedComponentDraggedIsNotChild: boolean | undefined = $state()
+	let cachedAreOnTheSameSubgrid: boolean | undefined = $state()
 
 	function updateCache(componentDraggedId: string | undefined) {
 		if (componentDraggedId) {
@@ -90,19 +106,24 @@
 		}
 	}
 
-	$: updateCache(componentDraggedId)
+	$effect(() => {
+		componentDraggedId
+		untrack(() => {
+			updateCache(componentDraggedId)
+		})
+	})
 </script>
 
-<!-- svelte-ignore a11y-mouse-events-have-key-events -->
-<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y_mouse_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-	on:mouseover|stopPropagation={() => {
+	onmouseover={stopPropagation(() => {
 		outTimeout && clearTimeout(outTimeout)
 		if (component.id !== $hoverStore) {
 			$hoverStore = component.id
 		}
-	}}
-	on:mouseout|stopPropagation={mouseOut}
+	})}
+	onmouseout={stopPropagation(mouseOut)}
 	class={twMerge(
 		'h-full flex flex-col w-full component relative',
 		initializing ? 'overflow-hidden h-0' : ''
@@ -162,7 +183,7 @@
 			<div class="absolute -top-8 w-40">
 				<button
 					class="border p-0.5 text-xs"
-					on:click={() => {
+					onclick={() => {
 						$movingcomponents = undefined
 					}}
 				>
@@ -202,19 +223,19 @@
 	</div>
 </div>
 {#if initializing && render && showSkeleton}
-	<!-- svelte-ignore a11y-mouse-events-have-key-events -->
-	<!-- svelte-ignore a11y-no-static-element-interactions -->
+	<!-- svelte-ignore a11y_mouse_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div
-		on:mouseover|stopPropagation={() => {
+		onmouseover={stopPropagation(() => {
 			if (component.id !== $hoverStore) {
 				$hoverStore = component.id
 			}
-		}}
-		on:mouseout|stopPropagation={() => {
+		})}
+		onmouseout={stopPropagation(() => {
 			if ($hoverStore !== undefined) {
 				$hoverStore = undefined
 			}
-		}}
+		})}
 		class="absolute inset-0 center-center flex-col border animate-skeleton dark:bg-frost-900/50 [animation-delay:1000ms]"
 	></div>
 {/if}

--- a/frontend/src/lib/components/apps/editor/component/ComponentRendered.svelte
+++ b/frontend/src/lib/components/apps/editor/component/ComponentRendered.svelte
@@ -14,6 +14,7 @@
 	import { Anchor } from 'lucide-svelte'
 	import { findGridItemParentGrid, isContainer } from '../appUtils'
 	import ComponentInner from './ComponentInner.svelte'
+	import { moveMode } from '../../gridUtils'
 
 	interface Props {
 		component: AppComponent
@@ -21,7 +22,6 @@
 		locked?: boolean
 		fullHeight: boolean
 		overlapped?: string | undefined
-		moveMode?: string | undefined
 		componentDraggedId?: string | undefined
 		render?: boolean
 	}
@@ -32,7 +32,6 @@
 		locked = false,
 		fullHeight,
 		overlapped = undefined,
-		moveMode = undefined,
 		componentDraggedId = undefined,
 		render = false
 	}: Props = $props()
@@ -131,7 +130,7 @@
 	data-connection-button
 >
 	{#if render}
-		{#if locked && componentActive && $componentActive && moveMode === 'move' && componentDraggedId && componentDraggedId !== component.id && cachedAreOnTheSameSubgrid}
+		{#if locked && componentActive && $componentActive && $moveMode === 'move' && componentDraggedId && componentDraggedId !== component.id && cachedAreOnTheSameSubgrid}
 			<div
 				class={twMerge('absolute inset-0 bg-locked center-center flex-col z-50', 'bg-locked-hover')}
 			>
@@ -140,7 +139,7 @@
 					<div class="text-xs"> Anchored: The component cannot be moved. </div>
 				</div>
 			</div>
-		{:else if moveMode === 'insert' && isContainer(component.type) && componentDraggedId && componentDraggedId !== component.id && cachedComponentDraggedIsNotChild}
+		{:else if $moveMode === 'insert' && isContainer(component.type) && componentDraggedId && componentDraggedId !== component.id && cachedComponentDraggedIsNotChild}
 			<div
 				class={twMerge(
 					'absolute inset-0  flex-col rounded-md bg-blue-100 dark:bg-gray-800 bg-opacity-50',

--- a/frontend/src/lib/components/apps/editor/component/ComponentWrapper.svelte
+++ b/frontend/src/lib/components/apps/editor/component/ComponentWrapper.svelte
@@ -3,8 +3,14 @@
 	import type { AppViewerContext, ContextPanelContext } from '../../types'
 	import { dfs, selectId } from '../appUtils'
 
-	export let id: string
-	export let type: string
+	interface Props {
+		id: string
+		type: string
+		class: string
+		children?: import('svelte').Snippet
+	}
+
+	let { id, type, class: clazz, children }: Props = $props()
 
 	const { app, connectingInput, selectedComponent } =
 		getContext<AppViewerContext>('AppViewerContext')
@@ -40,34 +46,34 @@
 	}
 </script>
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
-<!-- svelte-ignore a11y-mouse-events-have-key-events -->
-<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_mouse_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-	class={$$props.class}
-	on:pointerover={(e) => {
+	class={clazz}
+	onpointerover={(e) => {
 		if ($connectingInput.opened && $connectingInput.hoveredComponent !== id) {
 			$connectingInput.hoveredComponent = id
 		}
 		e.stopPropagation()
 	}}
-	on:pointerleave={(e) => {
+	onpointerleave={(e) => {
 		if ($connectingInput.opened) {
 			$connectingInput.hoveredComponent = undefined
 			e.stopPropagation()
 		}
 	}}
-	on:focus={(e) => {
+	onfocus={(e) => {
 		if ($connectingInput.opened) {
 			e.stopPropagation()
 		}
 	}}
-	on:pointerdown={onPointerDown}
-	on:click|capture={(event) =>
+	onpointerdown={onPointerDown}
+	onclickcapture={(event) =>
 		preventInteraction(event, type === 'tabscomponent' || type === 'steppercomponent')}
-	on:drag|capture={preventInteraction}
-	on:pointerup|capture={(event) =>
+	ondragcapture={preventInteraction}
+	onpointerupcapture={(event) =>
 		preventInteraction(event, type === 'tabscomponent' || type === 'steppercomponent')}
 >
-	<slot />
+	{@render children?.()}
 </div>

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -972,7 +972,27 @@ const agchartscomponentconst = {
 	},
 	initialData: {
 		configuration: {},
-		componentInput: undefined
+		componentInput: {
+			type: 'evalv2',
+			noStatic: true,
+			fieldType: 'object',
+			expr: `({
+				data: [
+					{ x: 1, y: 5 },
+					{ x: 2, y: 10 },
+					{ x: 3, y: 2 },
+					{ x: 4, y: 8 }
+				],
+				series: [{
+					type: 'bar',
+					xKey: 'x',
+					yKey: 'y',
+					fill: '#C8A2C8',
+					strokeWidth: 2.5
+				}]
+			})`,
+			connections: [] as InputConnectionEval[]
+		}
 	}
 } as const
 
@@ -1628,8 +1648,8 @@ export const components = {
 							backgroundColor: ['#FF6384', '#4BC0C0', '#FFCE56']
 						}
 					]
-				}
-			}
+				},
+			},
 		}
 	},
 	chartjscomponentv2: {
@@ -1656,7 +1676,20 @@ export const components = {
 					tooltip: 'ChartJs options object https://www.chartjs.org/docs/latest/general/options.html'
 				}
 			},
-			componentInput: undefined
+			componentInput: {
+				type: 'static',
+				fieldType: 'object',
+				value: {
+					labels: ['Pie', 'Charts', '<3'],
+					datasets: [
+						{
+							data: [25, 50, 25],
+							backgroundColor: ['#FF6384', '#4BC0C0', '#FFCE56']
+						}
+					]
+				},
+
+			},
 		}
 	},
 	barchartcomponent: {
@@ -1826,7 +1859,8 @@ This is a paragraph.
 							width: 2.5
 						}
 					}
-				}
+				},
+
 			},
 			configuration: {
 				layout: {
@@ -1846,7 +1880,21 @@ This is a paragraph.
 		dims: '2:8-6:8' as AppComponentDimensions,
 		customCss: {},
 		initialData: {
-			componentInput: undefined,
+			componentInput: {
+				type: 'static',
+				fieldType: 'object',
+				value: {
+					type: 'bar',
+					x: [1, 2, 3, 4],
+					y: [5, 10, 2, 8],
+					marker: {
+						color: '#C8A2C8',
+						line: {
+							width: 2.5
+						}
+					}
+				},
+			},
 			configuration: {
 				layout: {
 					type: 'static',
@@ -1856,7 +1904,8 @@ This is a paragraph.
 						'Layout options for the plot. See https://plotly.com/javascript/reference/layout/ for more information'
 				}
 			}
-		}
+		},
+
 	},
 	timeseriescomponent: {
 		name: 'Timeseries',

--- a/frontend/src/lib/components/apps/editor/componentsPanel/CssEval.svelte
+++ b/frontend/src/lib/components/apps/editor/componentsPanel/CssEval.svelte
@@ -3,12 +3,16 @@
 	import type { AppViewerContext, RichConfiguration } from '../../types'
 	import InputsSpecEditor from '../settingsPanel/InputsSpecEditor.svelte'
 
-	export let evalClass: RichConfiguration
-	export let key: string
+	interface Props {
+		evalClass: RichConfiguration
+		key: string
+	}
+
+	let { evalClass = $bindable(), key }: Props = $props()
 
 	const { selectedComponent } = getContext<AppViewerContext>('AppViewerContext')
 
-	$: id = Array.isArray($selectedComponent) ? $selectedComponent[0] : $selectedComponent
+	let id = $derived(Array.isArray($selectedComponent) ? $selectedComponent[0] : $selectedComponent)
 </script>
 
 {#if evalClass && id}

--- a/frontend/src/lib/components/apps/editor/componentsPanel/CssHelperPanel.svelte
+++ b/frontend/src/lib/components/apps/editor/componentsPanel/CssHelperPanel.svelte
@@ -98,7 +98,7 @@
 					}
 				}}
 			>
-				<div slot="title" class="flex items-center">
+				<div slot="titleSlot" class="flex items-center">
 					<svelte:component this={icon} size={18} />
 					<span class="ml-1">
 						{name}

--- a/frontend/src/lib/components/apps/editor/componentsPanel/GroupList.svelte
+++ b/frontend/src/lib/components/apps/editor/componentsPanel/GroupList.svelte
@@ -14,15 +14,19 @@
 	import type { AppViewerContext, GridItem } from '../../types'
 	import { getAllSubgridsAndComponentIds } from '../appUtils'
 
-	export let item: GridItem
+	interface Props {
+		item: GridItem
+	}
+
+	let { item }: Props = $props()
 	const { app } = getContext<AppViewerContext>('AppViewerContext')
 
 	let groups: Array<{
 		name: string
 		path: string
-	}> = []
+	}> = $state([])
 
-	let loading: boolean = false
+	let loading: boolean = $state(false)
 
 	async function getGroups() {
 		loading = true
@@ -79,7 +83,7 @@
 		nameField = ''
 	}
 
-	let nameField: string = ''
+	let nameField: string = $state('')
 
 	getGroups()
 </script>

--- a/frontend/src/lib/components/apps/editor/componentsPanel/GroupManagementDrawer.svelte
+++ b/frontend/src/lib/components/apps/editor/componentsPanel/GroupManagementDrawer.svelte
@@ -3,17 +3,21 @@
 	import GroupList from './GroupList.svelte'
 	import type { GridItem } from '../../types'
 
-	export let item: GridItem
+	interface Props {
+		item: GridItem
+	}
 
-	let codeDrawer: Drawer
+	let { item }: Props = $props()
+
+	let codeDrawer: Drawer | undefined = $state()
 
 	export async function openDrawer() {
-		codeDrawer.openDrawer()
+		codeDrawer?.openDrawer()
 	}
 </script>
 
 <Drawer bind:this={codeDrawer}>
-	<DrawerContent title="Component Groups" on:close={codeDrawer.closeDrawer}>
+	<DrawerContent title="Component Groups" on:close={() => codeDrawer?.closeDrawer()}>
 		<GroupList {item} />
 	</DrawerContent>
 </Drawer>

--- a/frontend/src/lib/components/apps/editor/componentsPanel/NameEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/componentsPanel/NameEditor.svelte
@@ -4,13 +4,17 @@
 	import { Pen } from 'lucide-svelte'
 	import { createEventDispatcher } from 'svelte'
 
-	export let kind: string
-	export let row: {
-		name: string
-		path: string
+	interface Props {
+		kind: string
+		row: {
+			name: string
+			path: string
+		}
 	}
 
-	let editedName = row.name
+	let { kind, row }: Props = $props()
+
+	let editedName = $state(row.name)
 
 	const dispatch = createEventDispatcher()
 	function onkeydown(e) {
@@ -21,18 +25,18 @@
 </script>
 
 <Popover floatingConfig={{ strategy: 'absolute', placement: 'bottom-end' }}>
-	<svelte:fragment slot="trigger">
+	{#snippet trigger()}
 		<Button color="light" size="xs2" nonCaptureEvent={true}>
 			<div class="flex flex-row gap-1 items-center">
 				<Pen size={16} />
 			</div>
 		</Button>
-	</svelte:fragment>
-	<svelte:fragment slot="content" let:close>
+	{/snippet}
+	{#snippet content({ close })}
 		<div class="flex flex-col w-80 gap-2 p-4">
 			<div class="leading-6 font-semibold text-xs">Edit {kind} name</div>
 			<div class="flex flex-row gap-2">
-				<input on:keydown={onkeydown} bind:value={editedName} />
+				<input {onkeydown} bind:value={editedName} />
 				<Button
 					color="dark"
 					size="xs"
@@ -45,5 +49,5 @@
 				</Button>
 			</div>
 		</div>
-	</svelte:fragment>
+	{/snippet}
 </Popover>

--- a/frontend/src/lib/components/apps/editor/componentsPanel/QuickStyleMenu.svelte
+++ b/frontend/src/lib/components/apps/editor/componentsPanel/QuickStyleMenu.svelte
@@ -211,7 +211,7 @@
 				{isOpen[prefix] ? '!bg-surface-secondary hover:!bg-surface-hover' : ''}"
 			>
 				<!-- @migration-task: migrate this slot by hand, `title` would shadow a prop on the parent component -->
-				<svelte:fragment slot="title">
+				<svelte:fragment slot="titleSlot">
 					<span class="font-normal text-xs">
 						{group}
 					</span>

--- a/frontend/src/lib/components/apps/editor/componentsPanel/ThemeCodePreview.svelte
+++ b/frontend/src/lib/components/apps/editor/componentsPanel/ThemeCodePreview.svelte
@@ -5,10 +5,15 @@
 	import { onMount } from 'svelte'
 	import SimpleEditor from '$lib/components/SimpleEditor.svelte'
 
-	export let theme: AppTheme | undefined = undefined
+	interface Props {
+		theme?: AppTheme | undefined
+		children?: import('svelte').Snippet
+	}
 
-	let code: string | undefined = undefined
-	let cssEditor: SimpleEditor | undefined = undefined
+	let { theme = undefined, children }: Props = $props()
+
+	let code: string | undefined = $state(undefined)
+	let cssEditor: SimpleEditor | undefined = $state(undefined)
 
 	onMount(async () => {
 		code = await resolveTheme(theme, $workspaceStore)
@@ -18,7 +23,7 @@
 
 <div class="relative h-full">
 	<div class="absolute z-[100] left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%]">
-		<slot />
+		{@render children?.()}
 	</div>
 	<div class="absolute top-0 left-0 right-0 bottom-0 bg-gray-100 bg-opacity-50 z-50"></div>
 	<SimpleEditor

--- a/frontend/src/lib/components/apps/editor/componentsPanel/ThemeDrawer.svelte
+++ b/frontend/src/lib/components/apps/editor/componentsPanel/ThemeDrawer.svelte
@@ -7,13 +7,17 @@
 	import { workspaceStore } from '$lib/stores'
 	import HighlightTheme from '$lib/components/HighlightTheme.svelte'
 
-	export let theme: AppTheme
+	interface Props {
+		theme: AppTheme
+	}
 
-	let code: string | undefined = undefined
-	let codeDrawer: Drawer
+	let { theme }: Props = $props()
+
+	let code: string | undefined = $state(undefined)
+	let codeDrawer: Drawer | undefined = $state()
 
 	export async function openDrawer() {
-		codeDrawer.openDrawer()
+		codeDrawer?.openDrawer()
 		code = await resolveTheme(theme, $workspaceStore)
 	}
 </script>

--- a/frontend/src/lib/components/apps/editor/componentsPanel/ThemeNameEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/componentsPanel/ThemeNameEditor.svelte
@@ -7,12 +7,16 @@
 	import { createEventDispatcher } from 'svelte'
 	import { sendUserToast } from '$lib/toast'
 
-	export let row: {
-		name: string
-		path: string
+	interface Props {
+		row: {
+			name: string
+			path: string
+		}
 	}
 
-	let editedName = row.name
+	let { row }: Props = $props()
+
+	let editedName = $state(row.name)
 
 	const dispatch = createEventDispatcher()
 </script>
@@ -22,14 +26,14 @@
 	closeOnOtherPopoverOpen
 	contentClasses="flex flex-col w-80 gap-2 p-4"
 >
-	<svelte:fragment slot="trigger">
+	{#snippet trigger()}
 		<Button color="light" size="xs2" nonCaptureEvent={true}>
 			<div class="flex flex-row gap-1 items-center">
 				<Pen size={16} />
 			</div>
 		</Button>
-	</svelte:fragment>
-	<svelte:fragment slot="content" let:close>
+	{/snippet}
+	{#snippet content({ close })}
 		<div class="leading-6 font-semibold text-xs">Edit theme name</div>
 		<div class="flex flex-row gap-2">
 			<input bind:value={editedName} />
@@ -52,5 +56,5 @@
 				Update
 			</Button>
 		</div>
-	</svelte:fragment>
+	{/snippet}
 </Popover>

--- a/frontend/src/lib/components/apps/editor/contextPanel/ContextPanel.svelte
+++ b/frontend/src/lib/components/apps/editor/contextPanel/ContextPanel.svelte
@@ -19,11 +19,11 @@
 
 	const dispatch = createEventDispatcher()
 
-	let hasState: boolean = false
+	let hasState: boolean = $state(false)
 </script>
 
 <PanelSection noPadding titlePadding="px-2 pt-2" title="Outputs">
-	<svelte:fragment slot="action">
+	{#snippet action()}
 		<div class="p-0.5">
 			<HideButton
 				on:click={() => {
@@ -33,7 +33,7 @@
 			/>
 			<DocLink docLink="https://www.windmill.dev/docs/apps/outputs" />
 		</div>
-	</svelte:fragment>
+	{/snippet}
 	<AnimatedButton
 		animate={$connectingInput.opened}
 		baseRadius="0px"
@@ -57,39 +57,35 @@
 					<div>
 						<span class="text-xs font-semibold text-secondary p-2">State & Context</span>
 
-						<OutputHeader
-							let:render
-							selectable={false}
-							id={'ctx'}
-							name={'App Context'}
-							first
-							color="blue"
-						>
-							<ComponentOutputViewer
-								{render}
-								componentId={'ctx'}
-								on:select={({ detail }) => {
-									$connectingInput = connectInput($connectingInput, 'ctx', detail)
-								}}
-							/>
+						<OutputHeader selectable={false} id={'ctx'} name={'App Context'} first color="blue">
+							{#snippet children({ render })}
+								<ComponentOutputViewer
+									{render}
+									componentId={'ctx'}
+									on:select={({ detail }) => {
+										$connectingInput = connectInput($connectingInput, 'ctx', detail)
+									}}
+								/>
+							{/snippet}
 						</OutputHeader>
 
 						<OutputHeader
-							let:render
 							selectable={false}
 							id={'state'}
 							name={'State'}
 							color="blue"
 							disabled={!hasState}
 						>
-							<ComponentOutputViewer
-								{render}
-								bind:hasContent={hasState}
-								componentId={'state'}
-								on:select={({ detail }) => {
-									$connectingInput = connectInput($connectingInput, 'state', detail)
-								}}
-							/>
+							{#snippet children({ render })}
+								<ComponentOutputViewer
+									{render}
+									bind:hasContent={hasState}
+									componentId={'state'}
+									on:select={({ detail }) => {
+										$connectingInput = connectInput($connectingInput, 'state', detail)
+									}}
+								/>
+							{/snippet}
 						</OutputHeader>
 					</div>
 

--- a/frontend/src/lib/components/apps/editor/contextPanel/SubGridOutput.svelte
+++ b/frontend/src/lib/components/apps/editor/contextPanel/SubGridOutput.svelte
@@ -3,31 +3,28 @@
 	import { getContext } from 'svelte'
 	import type { Output } from '../../rx'
 	import type { AppViewerContext } from '../../types'
-	import { connectInput } from '../appUtils'
 	import ComponentOutput from './ComponentOutput.svelte'
 
-	export let name: string | undefined = undefined
-	export let parentId: string
-	export let expanded: boolean = false
-	export let subGrids: string[]
-	export let nameOverrides: string[] | undefined = undefined
-	export let render: boolean
-	const { app, connectingInput, worldStore } = getContext<AppViewerContext>('AppViewerContext')
-
-	let selected = 0
-
-	$: outputs = $worldStore?.outputsById[parentId] as {
-		selectedTabIndex: Output<number>
+	interface Props {
+		name?: string | undefined
+		parentId: string
+		expanded?: boolean
+		subGrids: string[]
+		nameOverrides?: string[] | undefined
+		render: boolean
 	}
 
-	$: subgridItems = subGrids.map((k) => ({
-		k,
-		items: $app.subgrids?.[k] ?? []
-	}))
+	let {
+		name = undefined,
+		parentId,
+		expanded = false,
+		subGrids,
+		nameOverrides = undefined,
+		render
+	}: Props = $props()
+	const { app, worldStore } = getContext<AppViewerContext>('AppViewerContext')
 
-	$: if (outputs?.selectedTabIndex) {
-		subscribeToOutput()
-	}
+	let selected = $state(0)
 
 	function subscribeToOutput() {
 		outputs.selectedTabIndex.subscribe(
@@ -40,19 +37,35 @@
 			selected
 		)
 	}
+	let outputs = $derived(
+		$worldStore?.outputsById[parentId] as {
+			selectedTabIndex: Output<number>
+		}
+	)
+	let subgridItems = $derived(
+		subGrids.map((k) => ({
+			k,
+			items: $app.subgrids?.[k] ?? []
+		}))
+	)
+	$effect(() => {
+		if (outputs?.selectedTabIndex) {
+			subscribeToOutput()
+		}
+	})
 </script>
 
 {#each subgridItems as { k, items }, index (k)}
 	<div class="ml-2 my-2">
 		{#if subGrids.length > 1 && render}
-			<!-- svelte-ignore a11y-click-events-have-key-events -->
-			<!-- svelte-ignore a11y-no-static-element-interactions -->
+			<!-- svelte-ignore a11y_click_events_have_key_events -->
+			<!-- svelte-ignore a11y_no_static_element_interactions -->
 			<div
 				class={classNames(
 					'px-1 py-0.5 flex justify-between items-center font-semibold text-xs border-l border-y w-full cursor-pointer',
 					selected === index ? 'bg-surface-selected' : 'bg-surface'
 				)}
-				on:click={() => {
+				onclick={() => {
 					selected = index
 				}}
 			>
@@ -78,9 +91,6 @@
 							gridItem={subGridItem}
 							first={index === 0}
 							{expanded}
-							on:select={({ detail }) => {
-								$connectingInput = connectInput($connectingInput, subGridItem.id, detail)
-							}}
 						/>
 					{/each}
 				{:else}

--- a/frontend/src/lib/components/apps/editor/contextPanel/components/BackgroundScriptOutput.svelte
+++ b/frontend/src/lib/components/apps/editor/contextPanel/components/BackgroundScriptOutput.svelte
@@ -7,17 +7,23 @@
 
 	const { connectingInput } = getContext<AppViewerContext>('AppViewerContext')
 
-	export let id: string
-	export let name: string
-	export let first: boolean = false
+	interface Props {
+		id: string;
+		name: string;
+		first?: boolean;
+	}
+
+	let { id, name, first = false }: Props = $props();
 </script>
 
-<OutputHeader let:render renamable={false} selectable={true} {id} {name} color="blue" {first}>
-	<ComponentOutputViewer
-		{render}
-		componentId={id}
-		on:select={({ detail }) => {
-			$connectingInput = connectInput($connectingInput, id, detail)
-		}}
-	/>
+<OutputHeader  renamable={false} selectable={true} {id} {name} color="blue" {first}>
+	{#snippet children({ render })}
+		<ComponentOutputViewer
+			{render}
+			componentId={id}
+			on:select={({ detail }) => {
+				$connectingInput = connectInput($connectingInput, id, detail)
+			}}
+		/>
+	{/snippet}
 </OutputHeader>

--- a/frontend/src/lib/components/apps/editor/contextPanel/components/IdEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/contextPanel/components/IdEditor.svelte
@@ -8,11 +8,15 @@
 
 	const { app, selectedComponent } = getContext<AppViewerContext>('AppViewerContext')
 
-	export let id: string
+	interface Props {
+		id: string
+	}
+
+	let { id }: Props = $props()
 
 	const dispatch = createEventDispatcher()
 
-	$: reservedIds = allItems($app.grid, $app.subgrids).map((item) => item.id)
+	let reservedIds = $derived(allItems($app.grid, $app.subgrids).map((item) => item.id))
 </script>
 
 <Popover
@@ -20,9 +24,9 @@
 	closeOnOtherPopoverOpen
 	contentClasses="p-4"
 >
-	<svelte:fragment slot="trigger">
+	{#snippet trigger()}
 		<button
-			on:click={() => {
+			onclick={() => {
 				$selectedComponent = [id]
 			}}
 			title="Edit ID"
@@ -31,8 +35,8 @@
 		>
 			<Pencil size={14} />
 		</button>
-	</svelte:fragment>
-	<svelte:fragment slot="content" let:close>
+	{/snippet}
+	{#snippet content({ close })}
 		<IdEditorInput
 			initialId={id}
 			on:close={() => close()}
@@ -42,5 +46,5 @@
 			}}
 			{reservedIds}
 		/>
-	</svelte:fragment>
+	{/snippet}
 </Popover>

--- a/frontend/src/lib/components/apps/editor/contextPanel/components/MenuItemsOutput.svelte
+++ b/frontend/src/lib/components/apps/editor/contextPanel/components/MenuItemsOutput.svelte
@@ -2,8 +2,12 @@
 	import type { GridItem } from '$lib/components/apps/types'
 	import Output from './Output.svelte'
 
-	export let gridItem: GridItem
-	export let render: boolean
+	interface Props {
+		gridItem: GridItem
+		render: boolean
+	}
+
+	let { gridItem, render }: Props = $props()
 </script>
 
 <div class="my-1">

--- a/frontend/src/lib/components/apps/editor/contextPanel/components/Output.svelte
+++ b/frontend/src/lib/components/apps/editor/contextPanel/components/Output.svelte
@@ -7,18 +7,24 @@
 
 	const { connectingInput } = getContext<AppViewerContext>('AppViewerContext')
 
-	export let id: string
-	export let first: boolean = false
-	export let label: string
-	export let renderRec: boolean
+	interface Props {
+		id: string
+		first?: boolean
+		label: string
+		renderRec: boolean
+	}
+
+	let { id, first = false, label, renderRec }: Props = $props()
 </script>
 
-<OutputHeader render={renderRec} let:render renamable={false} {id} name={label} {first}>
-	<ComponentOutputViewer
-		{render}
-		componentId={id}
-		on:select={({ detail }) => {
-			$connectingInput = connectInput($connectingInput, id, detail)
-		}}
-	/>
+<OutputHeader render={renderRec} renamable={false} {id} name={label} {first}>
+	{#snippet children({ render })}
+		<ComponentOutputViewer
+			{render}
+			componentId={id}
+			on:select={({ detail }) => {
+				$connectingInput = connectInput($connectingInput, id, detail)
+			}}
+		/>
+	{/snippet}
 </OutputHeader>

--- a/frontend/src/lib/components/apps/editor/contextPanel/components/OutputHeader.svelte
+++ b/frontend/src/lib/components/apps/editor/contextPanel/components/OutputHeader.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { stopPropagation } from 'svelte/legacy'
+
 	import type { AppViewerContext, ContextPanelContext } from '$lib/components/apps/types'
 	import { allItems } from '$lib/components/apps/utils'
 	import { classNames } from '$lib/utils'
@@ -10,28 +12,46 @@
 	import type { Runnable } from '$lib/components/apps/inputType'
 	import DocLink from '../../settingsPanel/DocLink.svelte'
 
-	export let id: string
-	export let name: string
-	export let first: boolean = false
-	export let nested: boolean = false
-	export let color: 'blue' | 'indigo' = 'indigo'
-	export let selectable: boolean = true
-	export let renamable: boolean = true
-	export let disabled: boolean = false
-	export let render: boolean = true
+	interface Props {
+		id: string
+		name: string
+		first?: boolean
+		nested?: boolean
+		color?: 'blue' | 'indigo'
+		selectable?: boolean
+		renamable?: boolean
+		disabled?: boolean
+		render?: boolean
+		children?: import('svelte').Snippet<[any]>
+	}
+
+	let {
+		id,
+		name,
+		first = false,
+		nested = false,
+		color = 'indigo',
+		selectable = true,
+		renamable = true,
+		disabled = false,
+		render = true,
+		children
+	}: Props = $props()
 
 	const { manuallyOpened, search, hasResult } = getContext<ContextPanelContext>('ContextPanel')
 
 	const { selectedComponent, app, hoverStore, allIdsInPath, connectingInput, worldStore } =
 		getContext<AppViewerContext>('AppViewerContext')
 
-	$: subids = $search != '' ? allsubIds($app, id) : []
-	$: inSearch =
+	let subids = $derived($search != '' ? allsubIds($app, id) : [])
+	let inSearch = $derived(
 		$search != '' &&
-		($hasResult[id] ||
-			Object.entries($hasResult).some(([key, value]) => value && subids.includes(key)))
-	$: open =
+			($hasResult[id] ||
+				Object.entries($hasResult).some(([key, value]) => value && subids.includes(key)))
+	)
+	let open = $derived(
 		$allIdsInPath.includes(id) || id == $selectedComponent?.[0] || $manuallyOpened[id] || inSearch
+	)
 
 	const hoverColor = {
 		blue: 'hover:bg-blue-100 hover:text-blue-500 dark:hover:bg-frost-900 dark:hover:text-frost-100',
@@ -199,35 +219,35 @@
 	}
 </script>
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
 <div class={render && ($search == '' || inSearch) ? '' : 'invisible h-0 overflow-hidden'}>
 	{#if render && ($search == '' || inSearch)}
-		<!-- svelte-ignore a11y-mouse-events-have-key-events -->
-		<!-- svelte-ignore a11y-no-static-element-interactions -->
+		<!-- svelte-ignore a11y_mouse_events_have_key_events -->
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<div
-			on:mouseenter|stopPropagation={() => {
+			onmouseenter={stopPropagation(() => {
 				if (id !== $hoverStore) {
 					$hoverStore = id
 				}
-			}}
-			on:mouseleave|stopPropagation={() => {
+			})}
+			onmouseleave={stopPropagation(() => {
 				if ($hoverStore !== undefined) {
 					$hoverStore = undefined
 				}
-			}}
+			})}
 			class={classNames(
 				'flex items-center justify-between p-1 cursor-pointer gap-1 truncate',
 				hoverColor[color],
 				$selectedComponent?.includes(id)
 					? openBackground[color]
 					: $connectingInput.hoveredComponent === id
-					? 'bg-[#fab157]'
-					: 'bg-surface-secondary',
+						? 'bg-[#fab157]'
+						: 'bg-surface-secondary',
 				first ? 'border-t' : '',
 				nested ? 'border-l' : '',
 				'transition-all'
 			)}
-			on:click={() => {
+			onclick={() => {
 				if (!disabled) {
 					$manuallyOpened[id] = $manuallyOpened[id] != undefined ? !$manuallyOpened[id] : true
 				}
@@ -238,7 +258,7 @@
 				<button
 					disabled={!(selectable && !$selectedComponent?.includes(id)) || $connectingInput?.opened}
 					title="Select component"
-					on:click|stopPropagation={() => ($selectedComponent = [id])}
+					onclick={stopPropagation(() => ($selectedComponent = [id]))}
 					class="flex items-center ml-0.5 rounded-sm bg-surface-selected hover:text-primary text-tertiary"
 				>
 					<div
@@ -271,8 +291,8 @@
 						docLink={id === 'state'
 							? 'https://www.windmill.dev/docs/apps/outputs#state'
 							: id === 'ctx'
-							? 'https://www.windmill.dev/docs/apps/outputs#app-context'
-							: ''}
+								? 'https://www.windmill.dev/docs/apps/outputs#app-context'
+								: ''}
 						size="xs2"
 					/>
 				{/if}
@@ -299,7 +319,7 @@
 			: ''}"
 	>
 		<div class={classNames(nested ? 'border-l ml-2' : '', open ? 'border-t' : '')}>
-			<slot render={open && render} />
+			{@render children?.({ render: open && render })}
 		</div>
 	</div>
 </div>

--- a/frontend/src/lib/components/apps/editor/contextPanel/components/TableActionsOutput.svelte
+++ b/frontend/src/lib/components/apps/editor/contextPanel/components/TableActionsOutput.svelte
@@ -2,8 +2,12 @@
 	import type { GridItem } from '$lib/components/apps/types'
 	import Output from './Output.svelte'
 
-	export let gridItem: GridItem
-	export let render: boolean
+	interface Props {
+		gridItem: GridItem
+		render: boolean
+	}
+
+	let { gridItem, render }: Props = $props()
 </script>
 
 <div class="my-1">

--- a/frontend/src/lib/components/apps/editor/inlineScriptsPanel/AppRunButton.svelte
+++ b/frontend/src/lib/components/apps/editor/inlineScriptsPanel/AppRunButton.svelte
@@ -9,10 +9,19 @@
 
 	import RunButtonInner from '$lib/components/RunButton.svelte'
 
-	export let id: string
-	export let inlineScript: InlineScript | undefined = undefined
-	export let runLoading = false
-	export let hideShortcut = false
+	interface Props {
+		id: string
+		inlineScript?: InlineScript | undefined
+		runLoading?: boolean
+		hideShortcut?: boolean
+	}
+
+	let {
+		id,
+		inlineScript = undefined,
+		runLoading = $bindable(false),
+		hideShortcut = false
+	}: Props = $props()
 
 	const { runnableComponents } = getContext<AppViewerContext>('AppViewerContext')
 	const { runnableJobEditorPanel } = getContext<AppEditorContext>('AppEditorContext')

--- a/frontend/src/lib/components/apps/editor/inlineScriptsPanel/CacheTtlPopup.svelte
+++ b/frontend/src/lib/components/apps/editor/inlineScriptsPanel/CacheTtlPopup.svelte
@@ -5,7 +5,11 @@
 	import Popover from '$lib/components/meltComponents/Popover.svelte'
 	import { autoPlacement } from '@floating-ui/core'
 
-	export let cache_ttl: number | undefined
+	interface Props {
+		cache_ttl: number | undefined
+	}
+
+	let { cache_ttl = $bindable() }: Props = $props()
 </script>
 
 <Popover
@@ -19,7 +23,7 @@
 	closeButton
 	contentClasses="block text-primary p-4"
 >
-	<svelte:fragment slot="trigger">
+	{#snippet trigger()}
 		<Button
 			nonCaptureEvent={true}
 			btnClasses={Boolean(cache_ttl)
@@ -32,8 +36,8 @@
 			startIcon={{ icon: Database }}
 			title="Cache settings"
 		/>
-	</svelte:fragment>
-	<svelte:fragment slot="content">
+	{/snippet}
+	{#snippet content()}
 		<Toggle
 			checked={Boolean(cache_ttl)}
 			on:change={() => {
@@ -56,5 +60,5 @@
 				<SecondsInput disabled />
 			{/if}
 		</div>
-	</svelte:fragment>
+	{/snippet}
 </Popover>

--- a/frontend/src/lib/components/apps/editor/inlineScriptsPanel/EmptyInlineScript.svelte
+++ b/frontend/src/lib/components/apps/editor/inlineScriptsPanel/EmptyInlineScript.svelte
@@ -20,14 +20,23 @@
 	import type { Preview } from '$lib/gen'
 	import type { InlineScript } from '../../types'
 
-	export let componentType: string | undefined = undefined
-	export let showScriptPicker = false
-	export let rawApps = false
-	export let unusedInlineScripts: { name: string; inlineScript: InlineScript }[]
+	interface Props {
+		componentType?: string | undefined
+		showScriptPicker?: boolean
+		rawApps?: boolean
+		unusedInlineScripts: { name: string; inlineScript: InlineScript }[]
+	}
 
-	let tab = 'workspacescripts'
-	let filter: string = ''
-	let picker: Drawer
+	let {
+		componentType = undefined,
+		showScriptPicker = false,
+		rawApps = false,
+		unusedInlineScripts
+	}: Props = $props()
+
+	let tab = $state('workspacescripts')
+	let filter: string = $state('')
+	let picker: Drawer | undefined = $state(undefined)
 
 	const dispatch = createEventDispatcher()
 
@@ -78,13 +87,15 @@
 		newInlineScript(script.content, script.language)
 	}
 
-	$: langs = processLangs(undefined, $defaultScripts?.order ?? Object.keys(defaultScriptLanguages))
-		.map((l) => [defaultScriptLanguages[l], l])
-		.filter(
-			(x) =>
-				x[1] != 'docker' &&
-				($defaultScripts?.hidden == undefined || !$defaultScripts.hidden.includes(x[1]))
-		) as [string, Preview['language']][]
+	let langs = $derived(
+		processLangs(undefined, $defaultScripts?.order ?? Object.keys(defaultScriptLanguages))
+			.map((l) => [defaultScriptLanguages[l], l])
+			.filter(
+				(x) =>
+					x[1] != 'docker' &&
+					($defaultScripts?.hidden == undefined || !$defaultScripts.hidden.includes(x[1]))
+			) as [string, Preview['language']][]
+	)
 </script>
 
 <Drawer bind:this={picker} size="1000px">

--- a/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptEditorPanel.svelte
+++ b/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptEditorPanel.svelte
@@ -8,11 +8,21 @@
 	import type { AppViewerContext } from '../../types'
 	import InlineScriptRunnableByPath from './InlineScriptRunnableByPath.svelte'
 
-	export let componentInput: AppInput | undefined
-	export let defaultUserInput = false
-	export let componentType: string
-	export let id: string
-	export let transformer: boolean
+	interface Props {
+		componentInput: AppInput | undefined
+		defaultUserInput?: boolean
+		componentType: string
+		id: string
+		transformer: boolean
+	}
+
+	let {
+		componentInput = $bindable(),
+		defaultUserInput = false,
+		componentType,
+		id,
+		transformer
+	}: Props = $props()
 
 	const { app } = getContext<AppViewerContext>('AppViewerContext')
 

--- a/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptHiddenRunnable.svelte
+++ b/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptHiddenRunnable.svelte
@@ -6,9 +6,13 @@
 	import type { Runnable, StaticAppInput } from '../../inputType'
 	import { createEventDispatcher, getContext } from 'svelte'
 
-	export let runnable: HiddenRunnable
-	export let id: string
-	export let transformer: boolean
+	interface Props {
+		runnable: HiddenRunnable
+		id: string
+		transformer: boolean
+	}
+
+	let { runnable = $bindable(), id, transformer }: Props = $props()
 
 	const { runnableComponents, app } = getContext<AppViewerContext>('AppViewerContext')
 	async function fork(nrunnable: Runnable) {

--- a/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptRunnableByPath.svelte
+++ b/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptRunnableByPath.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+	import { createBubbler, stopPropagation } from 'svelte/legacy'
+
+	const bubble = createBubbler()
 	import { Button, Drawer, DrawerContent } from '$lib/components/common'
 	import { base } from '$lib/base'
 	import FlowModuleScript from '$lib/components/flows/content/FlowModuleScript.svelte'
 	import FlowPathViewer from '$lib/components/flows/content/FlowPathViewer.svelte'
 	import { emptySchema } from '$lib/utils'
-	import { getContext, tick } from 'svelte'
+	import { getContext, tick, untrack } from 'svelte'
 	import type {
 		ConnectedAppInput,
 		RowAppInput,
@@ -27,21 +30,33 @@
 	import RunButton from '$lib/components/RunButton.svelte'
 	import Popover from '$lib/components/meltComponents/Popover.svelte'
 
-	export let runnable: RunnableByPath
-	export let fields:
-		| Record<string, StaticAppInput | ConnectedAppInput | RowAppInput | UserAppInput>
-		| undefined
-	export let id: string
-	export let rawApps = false
-	export let isLoading = false
-	export let onRun = async () => {}
-	export let onCancel = async () => {}
+	interface Props {
+		runnable: RunnableByPath
+		fields:
+			| Record<string, StaticAppInput | ConnectedAppInput | RowAppInput | UserAppInput>
+			| undefined
+		id: string
+		rawApps?: boolean
+		isLoading?: boolean
+		onRun?: any
+		onCancel?: any
+	}
+
+	let {
+		runnable = $bindable(),
+		fields = $bindable(),
+		id,
+		rawApps = false,
+		isLoading = false,
+		onRun = async () => {},
+		onCancel = async () => {}
+	}: Props = $props()
 
 	const viewerContext = getContext<AppViewerContext>('AppViewerContext')
 
-	let drawerFlowViewer: Drawer
-	let flowPath: string = ''
-	let notFound = false
+	let drawerFlowViewer: Drawer | undefined = $state(undefined)
+	let flowPath: string = $state('')
+	let notFound = $state(false)
 
 	const dispatch = createEventDispatcher()
 
@@ -110,7 +125,12 @@
 		}
 		lastRunnable = runnable
 	}
-	$: refresh(runnable)
+	$effect(() => {
+		runnable.path
+		untrack(() => {
+			refresh(runnable)
+		})
+	})
 </script>
 
 <Drawer bind:this={drawerFlowViewer} size="1200px">
@@ -160,7 +180,7 @@
 				startIcon={{ icon: Eye }}
 				on:click={() => {
 					flowPath = runnable.path
-					drawerFlowViewer.openDrawer()
+					drawerFlowViewer?.openDrawer()
 				}}
 			>
 				Expand
@@ -215,7 +235,7 @@
 			closeButton
 			contentClasses="block text-primary text-xs p-4 w-[20vh]"
 		>
-			<svelte:fragment slot="trigger">
+			{#snippet trigger()}
 				<Button
 					nonCaptureEvent={true}
 					btnClasses={'bg-surface text-primay hover:bg-hover'}
@@ -223,16 +243,16 @@
 					variant="border"
 					size="xs">Cache</Button
 				>
-			</svelte:fragment>
-			<svelte:fragment slot="content">
+			{/snippet}
+			{#snippet content()}
 				Since this is a reference to a workspace {runnable.runType}, set the cache in the {runnable.runType}
 				settings directly by editing it. The cache will be shared by any app or flow that uses this
 				{runnable.runType}.
-			</svelte:fragment>
+			{/snippet}
 		</Popover>
 
 		<input
-			on:keydown|stopPropagation
+			onkeydown={stopPropagation(bubble('keydown'))}
 			bind:value={runnable.name}
 			placeholder="Background runnable name"
 			class="!text-xs !rounded-xs"

--- a/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptsPanel.svelte
+++ b/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptsPanel.svelte
@@ -40,24 +40,33 @@
 		}
 	}
 
-	$: gridItem =
+	let gridItem = $derived(
 		$selectedComponentInEditor && !$selectedComponentInEditor.startsWith(BG_PREFIX)
 			? findGridItem($app, $selectedComponentInEditor?.split('_')?.[0])
 			: undefined
-
-	$: hiddenInlineScript = $app?.hiddenInlineScripts?.findIndex((k_, index) => {
-		const [prefix, id] = $selectedComponentInEditor?.split('_') || []
-
-		if (prefix !== 'bg') return false
-
-		return Number(id) === index
-	})
-
-	$: unusedInlineScript = $app?.unusedInlineScripts?.findIndex(
-		(k_, index) => `unused-${index}` === $selectedComponentInEditor
 	)
 
-	export let width: number | undefined = undefined
+	let hiddenInlineScript = $derived(
+		$app?.hiddenInlineScripts?.findIndex((k_, index) => {
+			const [prefix, id] = $selectedComponentInEditor?.split('_') || []
+
+			if (prefix !== 'bg') return false
+
+			return Number(id) === index
+		})
+	)
+
+	let unusedInlineScript = $derived(
+		$app?.unusedInlineScripts?.findIndex(
+			(k_, index) => `unused-${index}` === $selectedComponentInEditor
+		)
+	)
+
+	interface Props {
+		width?: number | undefined
+	}
+
+	let { width = undefined }: Props = $props()
 </script>
 
 <Splitpanes

--- a/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptsPanelList.svelte
+++ b/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptsPanelList.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { run } from 'svelte/legacy'
+
 	import { Badge, Button } from '$lib/components/common'
 	import { Plus } from 'lucide-svelte'
 	import { createEventDispatcher, getContext } from 'svelte'
@@ -25,11 +27,6 @@
 			$selectedComponent = [$selectedComponentInEditor.split('_transformer')[0]]
 		}
 	}
-
-	$: runnables = getAppScripts($app.grid, $app.subgrids)
-
-	// When selected component changes, update selectedScriptComponentId
-	$: selectedComponent && handleSelectedComponent($selectedComponent)
 
 	function handleSelectedComponent(selectedComponent: string[] | undefined) {
 		if (
@@ -79,12 +76,17 @@
 		selectScript(`${BG_PREFIX}${$app.hiddenInlineScripts.length - 1}`)
 	}
 
-	let appTutorials: AppTutorials | undefined = undefined
+	let appTutorials: AppTutorials | undefined = $state(undefined)
 	const dispatch = createEventDispatcher()
+	let runnables = $derived(getAppScripts($app.grid, $app.subgrids))
+	// When selected component changes, update selectedScriptComponentId
+	run(() => {
+		selectedComponent && handleSelectedComponent($selectedComponent)
+	})
 </script>
 
 <PanelSection title="Runnables" id="app-editor-runnable-panel">
-	<svelte:fragment slot="action">
+	{#snippet action()}
 		<div class="flex flex-row gap-1">
 			<HideButton
 				direction="bottom"
@@ -96,7 +98,7 @@
 				docLink="https://www.windmill.dev/docs/apps/app-runnable-panel#creating-a-runnable"
 			/>
 		</div>
-	</svelte:fragment>
+	{/snippet}
 	<div class="w-full flex flex-col gap-6 py-1">
 		<div>
 			<div class="flex flex-col gap-2 w-full">
@@ -109,7 +111,7 @@
 				{$selectedComponentInEditor === id
 									? 'border-blue-500 bg-blue-100 dark:bg-frost-900/50'
 									: 'hover:bg-blue-50 dark:hover:bg-frost-900/50'}"
-								on:click={() => selectScript(id)}
+								onclick={() => selectScript(id)}
 							>
 								<span class="text-2xs truncate">{name}</span>
 								<div>
@@ -124,7 +126,7 @@
 			{$selectedComponentInEditor === id + '_transformer'
 											? 'border-blue-500 bg-blue-100 dark:bg-frost-900/50'
 											: 'hover:bg-blue-50 dark:hover:bg-frost-900/50'}"
-										on:click={() => selectScript(id + '_transformer')}
+										onclick={() => selectScript(id + '_transformer')}
 									>
 										<span class="text-2xs truncate">Transformer</span>
 									</button>
@@ -140,7 +142,7 @@
 						{$selectedComponentInEditor === id
 							? 'border-blue-500 bg-blue-100 dark:bg-frost-900/50'
 							: 'hover:bg-blue-50'}"
-						on:click={() => selectScript(id)}
+						onclick={() => selectScript(id)}
 					>
 						<span class="text-2xs truncate">{name}</span>
 						<Badge color="indigo">{id}</Badge>
@@ -153,7 +155,7 @@
 {$selectedComponentInEditor === id + '_transformer'
 									? 'border-blue-500 bg-blue-100 dark:bg-frost-900/50'
 									: 'hover:bg-blue-50 dark:hover:bg-frost-900/50'}"
-								on:click={() => selectScript(id + '_transformer')}
+								onclick={() => selectScript(id + '_transformer')}
 							>
 								<span class="text-2xs truncate">Transformer</span>
 							</button>
@@ -171,7 +173,7 @@
 								{$selectedComponentInEditor === id
 									? 'border-blue-500 bg-blue-100 dark:bg-frost-900/50'
 									: 'hover:bg-blue-50 dark:hover:bg-frost-900/50'}"
-								on:click={() => selectScript(id)}
+								onclick={() => selectScript(id)}
 							>
 								<span class="text-2xs truncate">{unusedInlineScript.name}</span>
 								<Badge color="red">Detached</Badge>
@@ -220,7 +222,7 @@
 								{$selectedComponentInEditor === id
 									? 'border-blue-500 bg-blue-100 dark:bg-frost-900/50'
 									: 'hover:bg-blue-50 dark:hover:bg-frost-900/50'}"
-								on:click={() => selectScript(id)}
+								onclick={() => selectScript(id)}
 							>
 								<span class="text-2xs truncate">{name}</span>
 								<Badge color="indigo">{id}</Badge>
@@ -233,7 +235,7 @@
 		{$selectedComponentInEditor === id + '_transformer'
 											? 'border-blue-500 bg-blue-100 dark:bg-frost-900/50'
 											: 'hover:bg-blue-50 dark:hover:bg-frost-900/50'}"
-										on:click={() => selectScript(id + '_transformer')}
+										onclick={() => selectScript(id + '_transformer')}
 									>
 										<span class="text-2xs truncate">Transformer</span>
 									</button>

--- a/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptsPanelList.svelte
+++ b/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptsPanelList.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-	import { run } from 'svelte/legacy'
-
 	import { Badge, Button } from '$lib/components/common'
 	import { Plus } from 'lucide-svelte'
-	import { createEventDispatcher, getContext } from 'svelte'
+	import { createEventDispatcher, getContext, untrack } from 'svelte'
 	import Tooltip from '../../../Tooltip.svelte'
 	import type { AppEditorContext, AppViewerContext } from '../../types'
 	import { BG_PREFIX, getAllScriptNames } from '../../utils'
@@ -80,8 +78,8 @@
 	const dispatch = createEventDispatcher()
 	let runnables = $derived(getAppScripts($app.grid, $app.subgrids))
 	// When selected component changes, update selectedScriptComponentId
-	run(() => {
-		selectedComponent && handleSelectedComponent($selectedComponent)
+	$effect(() => {
+		$selectedComponent && untrack(() => handleSelectedComponent($selectedComponent))
 	})
 </script>
 

--- a/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptsPanelWithTable.svelte
+++ b/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptsPanelWithTable.svelte
@@ -5,7 +5,11 @@
 
 	const { selectedComponentInEditor } = getContext<AppEditorContext>('AppEditorContext')
 
-	export let gridItem: GridItem
+	interface Props {
+		gridItem: GridItem
+	}
+
+	let { gridItem = $bindable() }: Props = $props()
 </script>
 
 {#if gridItem?.data?.id === $selectedComponentInEditor || gridItem?.data?.id + '_transformer' === $selectedComponentInEditor}

--- a/frontend/src/lib/components/apps/editor/inlineScriptsPanel/RunButton.svelte
+++ b/frontend/src/lib/components/apps/editor/inlineScriptsPanel/RunButton.svelte
@@ -9,14 +9,23 @@
 	import { Button } from '$lib/components/common'
 	import { CornerDownLeft, Loader2 } from 'lucide-svelte'
 
-	export let id: string
-	export let inlineScript: InlineScript | undefined = undefined
-	export let runLoading = false
-	export let hideShortcut = false
+	interface Props {
+		id: string
+		inlineScript?: InlineScript | undefined
+		runLoading?: boolean
+		hideShortcut?: boolean
+	}
+
+	let {
+		id,
+		inlineScript = undefined,
+		runLoading = $bindable(false),
+		hideShortcut = false
+	}: Props = $props()
 
 	const { runnableComponents } = getContext<AppViewerContext>('AppViewerContext')
 	const { runnableJobEditorPanel } = getContext<AppEditorContext>('AppEditorContext')
-	let cancelable: CancelablePromise<void>[] | undefined = undefined
+	let cancelable: CancelablePromise<void>[] | undefined = $state(undefined)
 </script>
 
 {#if $runnableComponents[id] != undefined}

--- a/frontend/src/lib/components/apps/editor/settingsPanel/AGChartRichEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/AGChartRichEditor.svelte
@@ -3,9 +3,13 @@
 	import InputsSpecEditor from './InputsSpecEditor.svelte'
 	import PanelSection from './common/PanelSection.svelte'
 
-	export let datasets: RichConfiguration | undefined = undefined
-	export let xData: RichConfiguration | undefined = undefined
-	export let id: string
+	interface Props {
+		datasets?: RichConfiguration | undefined
+		xData?: RichConfiguration | undefined
+		id: string
+	}
+
+	let { datasets = $bindable(undefined), xData = $bindable(undefined), id }: Props = $props()
 </script>
 
 <PanelSection

--- a/frontend/src/lib/components/apps/editor/settingsPanel/ArrayStaticInputEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/ArrayStaticInputEditor.svelte
@@ -180,6 +180,7 @@
 				})
 			}
 		}
+		componentInput.value = $state.snapshot(componentInput.value)
 		componentInput = componentInput
 		items = getItems(componentInput)
 	}

--- a/frontend/src/lib/components/apps/editor/settingsPanel/CSSMigrationModal.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/CSSMigrationModal.svelte
@@ -16,14 +16,18 @@
 	import CloseButton from '$lib/components/common/CloseButton.svelte'
 	import HighlightTheme from '$lib/components/HighlightTheme.svelte'
 	import Portal from '$lib/components/Portal.svelte'
-	export let component: AppComponent | undefined
+	interface Props {
+		component: AppComponent | undefined
+	}
+
+	let { component = $bindable() }: Props = $props()
 
 	const { app } = getContext<AppViewerContext>('AppViewerContext')
 
 	function fadeFast(node: HTMLElement) {
 		return fade(node, { duration: 100 })
 	}
-	let migrationModalOpen: boolean = false
+	let migrationModalOpen: boolean = $state(false)
 
 	export function open() {
 		migrationModalOpen = true
@@ -37,9 +41,6 @@
 
 		return code
 	}
-
-	$: generatedCode = generateCodeFromMigrations(migrations)
-	$: migrations = new Map<string, string[]>()
 
 	function getSelector(key: string) {
 		return customisationByComponent
@@ -126,6 +127,8 @@
 	}
 
 	let type: string | undefined = component?.type
+	let migrations = $derived(new Map<string, string[]>())
+	let generatedCode = $derived(generateCodeFromMigrations(migrations))
 </script>
 
 <HighlightTheme />

--- a/frontend/src/lib/components/apps/editor/settingsPanel/ChartJSRichEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/ChartJSRichEditor.svelte
@@ -3,9 +3,13 @@
 	import InputsSpecEditor from './InputsSpecEditor.svelte'
 	import PanelSection from './common/PanelSection.svelte'
 
-	export let datasets: RichConfiguration | undefined = undefined
-	export let xData: RichConfiguration | undefined = undefined
-	export let id: string
+	interface Props {
+		datasets?: RichConfiguration | undefined
+		xData?: RichConfiguration | undefined
+		id: string
+	}
+
+	let { datasets = $bindable(undefined), xData = $bindable(undefined), id }: Props = $props()
 </script>
 
 <PanelSection

--- a/frontend/src/lib/components/apps/editor/settingsPanel/ComponentControl.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/ComponentControl.svelte
@@ -7,29 +7,35 @@
 	import typescript from 'svelte-highlight/languages/typescript'
 	import { Button } from '$lib/components/common'
 	import HighlightTheme from '$lib/components/HighlightTheme.svelte'
-	export let type: keyof typeof components
+	interface Props {
+		type: keyof typeof components
+	}
+
+	let { type }: Props = $props()
 
 	const componentControls = getComponentControl(type)
 
-	let collapsed: boolean = true
+	let collapsed: boolean = $state(true)
 </script>
 
 <HighlightTheme />
 
 {#if componentControls?.length > 0}
 	<PanelSection title="Controls">
-		<div slot="action" class="flex justify-end flex-wrap gap-1">
-			<Button
-				color="light"
-				size="xs2"
-				btnClasses="text-2xs font-normal"
-				on:click={() => {
-					collapsed = !collapsed
-				}}
-			>
-				{collapsed ? 'Show' : 'Hide'} details
-			</Button>
-		</div>
+		{#snippet action()}
+			<div class="flex justify-end flex-wrap gap-1">
+				<Button
+					color="light"
+					size="xs2"
+					btnClasses="text-2xs font-normal"
+					on:click={() => {
+						collapsed = !collapsed
+					}}
+				>
+					{collapsed ? 'Show' : 'Hide'} details
+				</Button>
+			</div>
+		{/snippet}
 
 		{#if collapsed}
 			<div class="flex flex-row gap-1 flex-wrap">

--- a/frontend/src/lib/components/apps/editor/settingsPanel/ComponentPanelDataSource.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/ComponentPanelDataSource.svelte
@@ -6,10 +6,11 @@
 	import PlotlyRichEditor from './PlotlyRichEditor.svelte'
 	import ChartJSRichEditor from './ChartJSRichEditor.svelte'
 	import AGChartRichEditor from './AGChartRichEditor.svelte'
-	import { getContext, onMount } from 'svelte'
+	import { getContext } from 'svelte'
 	import type { AppViewerContext, RichConfiguration } from '../../types'
 	import type { InputConnectionEval } from '../../inputType'
 	import ConfirmationModal from '$lib/components/common/confirmationModal/ConfirmationModal.svelte'
+	import { createChartjsComponentDataset, createPlotlyComponentDataset } from '../appUtils'
 
 	interface Props {
 		component: AppComponent
@@ -19,24 +20,15 @@
 	let { component = $bindable(), children }: Props = $props()
 	let convertToUIEditorCallback: (() => void) | undefined = $state(undefined)
 
-	let selected = $state('ui-editor')
-	let renderCount = $state(0)
+	console.log('FOOBAR', component.type)
 
-	onMount(() => {
-		if (
-			(component.type === 'plotlycomponentv2' ||
-				component.type === 'chartjscomponentv2' ||
-				component.type === 'agchartscomponent' ||
-				component.type === 'agchartscomponentee') &&
-			component.componentInput === undefined &&
-			component.datasets === undefined
-		) {
-			setUpUIEditor()
-			renderCount++
-		} else if (component.componentInput !== undefined) {
-			selected = 'json'
-		}
-	})
+	let selected = $state(
+		(component.type === 'plotlycomponentv2' || component.type === 'chartjscomponentv2') &&
+			component.datasets !== undefined
+			? 'ui-editor'
+			: 'json'
+	)
+	let renderCount = $state(0)
 
 	const { worldStore } = getContext<AppViewerContext>('AppViewerContext')
 	interface Dataset {
@@ -231,48 +223,6 @@
 		}
 	}
 
-	function createChartjsComponentDataset(): RichConfiguration {
-		return {
-			type: 'static',
-			fieldType: 'array',
-			subFieldType: 'chartjs',
-			value: [
-				{
-					value: {
-						type: 'static',
-						fieldType: 'array',
-						subFieldType: 'number',
-						value: [25, 25, 50]
-					},
-					name: 'Dataset 1'
-				}
-			]
-		}
-	}
-
-	function createPlotlyComponentDataset(): RichConfiguration {
-		return {
-			type: 'static',
-			fieldType: 'array',
-			subFieldType: 'plotly',
-			value: [
-				{
-					value: {
-						type: 'static',
-						fieldType: 'array',
-						subFieldType: 'number',
-						value: [1, 2, 3, 4]
-					},
-					name: 'Dataset 1',
-					aggregation_method: 'sum',
-					type: 'bar',
-					tooltip: '',
-					color: '#C8A2C8'
-				}
-			]
-		}
-	}
-
 	function createXData(): RichConfiguration {
 		return {
 			type: 'evalv2',
@@ -395,7 +345,7 @@
 	}
 </script>
 
-{#if component.type === 'plotlycomponentv2' || component.type === 'chartjscomponentv2' || component.type === 'agchartscomponent' || component.type === 'agchartscomponentee'}
+{#if component.type === 'plotlycomponentv2' || component.type === 'chartjscomponentv2'}
 	<div class="p-2">
 		<ToggleButtonGroup
 			bind:selected

--- a/frontend/src/lib/components/apps/editor/settingsPanel/CssPropertyWrapper.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/CssPropertyWrapper.svelte
@@ -2,13 +2,25 @@
 	import type { ComponentCssProperty } from '../../types'
 	import CssProperty from '../componentsPanel/CssProperty.svelte'
 
-	export let forceStyle: boolean = false
-	export let forceClass: boolean = false
-	export let id: string
-	export let property: ComponentCssProperty | undefined = undefined
-	export let overriden: boolean = false
-	export let overridding: boolean = false
-	export let wmClass: string | undefined = undefined
+	interface Props {
+		forceStyle?: boolean
+		forceClass?: boolean
+		id: string
+		property?: ComponentCssProperty | undefined
+		overriden?: boolean
+		overridding?: boolean
+		wmClass?: string | undefined
+	}
+
+	let {
+		forceStyle = false,
+		forceClass = false,
+		id,
+		property = $bindable(undefined),
+		overriden = false,
+		overridding = false,
+		wmClass = undefined
+	}: Props = $props()
 
 	function hasValues(obj: ComponentCssProperty | undefined) {
 		if (!obj) return false

--- a/frontend/src/lib/components/apps/editor/settingsPanel/DecisionTreeGraphEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/DecisionTreeGraphEditor.svelte
@@ -14,13 +14,17 @@
 	import type { AppViewerContext } from '../../types'
 	import Badge from '$lib/components/common/badge/Badge.svelte'
 
-	export let component: AppComponent
-	export let nodes: DecisionTreeNode[]
+	interface Props {
+		component: AppComponent
+		nodes: DecisionTreeNode[]
+	}
 
-	let drawer: Drawer | undefined = undefined
-	let paneWidth = 0
-	let paneHeight = 0
-	let renderCount = 0
+	let { component = $bindable(), nodes = $bindable() }: Props = $props()
+
+	let drawer: Drawer | undefined = $state(undefined)
+	let paneWidth = $state(0)
+	let paneHeight = $state(0)
+	let renderCount = $state(0)
 
 	const { debuggingComponents } = getContext<AppViewerContext>('AppViewerContext')
 
@@ -31,11 +35,13 @@
 		renderCount++
 	}, 300)
 
-	$: selectedNode = nodes?.find((node) => node.id == $selectedNodeId)
+	let selectedNode = $derived(nodes?.find((node) => node.id == $selectedNodeId))
 
 	setContext('DecisionTreeEditor', { selectedNodeId })
 
-	$: sortedSelectedNextNodes = selectedNode?.next.sort((n1, n2) => n1.id.localeCompare(n2.id))
+	let sortedSelectedNextNodes = $derived(
+		selectedNode?.next.sort((n1, n2) => n1.id.localeCompare(n2.id))
+	)
 </script>
 
 <Drawer bind:this={drawer} on:close={() => {}} on:open={() => {}} size="1200px">
@@ -66,14 +72,14 @@
 				<!-- svelte-ignore a11y_no_static_element_interactions -->
 				<div
 					class="h-full w-full bg-surface p-4 flex flex-col gap-6"
-					on:keydown={(e) => {
+					onkeydown={(e) => {
 						// Prevent keyboard events from bubbling to SvelteFlow
 						e.stopPropagation()
 					}}
 				>
 					{#if selectedNode}
 						<Section label="Conditions" class="w-full flex flex-col gap-2">
-							<svelte:fragment slot="action">
+							{#snippet action()}
 								<Button
 									size="xs"
 									color="light"
@@ -92,17 +98,17 @@
 								>
 									Delete node
 								</Button>
-							</svelte:fragment>
+							{/snippet}
 
 							<Label label="Summary">
 								<input
 									type="text"
 									class="input input-primary input-bordered"
 									bind:value={selectedNode.label}
-									on:input={() => {
+									oninput={() => {
 										debouncedNodes()
 									}}
-									on:keydown={(e) => {
+									onkeydown={(e) => {
 										// Prevent keyboard events from bubbling to SvelteFlow
 										e.stopPropagation()
 									}}

--- a/frontend/src/lib/components/apps/editor/settingsPanel/DecisionTreeGraphEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/DecisionTreeGraphEditor.svelte
@@ -53,7 +53,6 @@
 	>
 		<Splitpanes>
 			<Pane size={60}>
-				{renderCount}
 				<div class="w-full h-full" bind:clientWidth={paneWidth} bind:clientHeight={paneHeight}>
 					{#if paneWidth && paneHeight}
 						<DecisionTreePreview

--- a/frontend/src/lib/components/apps/editor/settingsPanel/DecisionTreeGraphHeader.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/DecisionTreeGraphHeader.svelte
@@ -1,23 +1,29 @@
 <script lang="ts">
+	import { preventDefault, stopPropagation } from 'svelte/legacy'
+
 	import type { DecisionTreeNode } from '../component'
 	import { twMerge } from 'tailwind-merge'
 	import InsertDecisionTreeNode from './decisionTree/InsertDecisionTreeNode.svelte'
 	import { X } from 'lucide-svelte'
 	import NodeWrapper from '$lib/components/graph/renderers/nodes/NodeWrapper.svelte'
 
-	export let data: {
-		node: DecisionTreeNode
-		canDelete: boolean
-		nodeCallbackHandler: (
-			event: string,
-			detail: string,
-			graphNode: DecisionTreeNode | undefined,
-			parentIds: string[],
-			branchInsert: boolean
-		) => void
-		parentIds: string[]
-		branchHeader: boolean
+	interface Props {
+		data: {
+			node: DecisionTreeNode
+			canDelete: boolean
+			nodeCallbackHandler: (
+				event: string,
+				detail: string,
+				graphNode: DecisionTreeNode | undefined,
+				parentIds: string[],
+				branchInsert: boolean
+			) => void
+			parentIds: string[]
+			branchHeader: boolean
+		}
 	}
+
+	let { data }: Props = $props()
 
 	let open: boolean = false
 </script>
@@ -42,9 +48,17 @@
 			<div class="w-[27px] absolute -top-[32px] left-[50%] right-[50%] -translate-x-1/2">
 				<button
 					title="Delete branch"
-					on:click|preventDefault|stopPropagation={() => {
-						data.nodeCallbackHandler('removeBranch', data.node.id, data.node, data.parentIds, false)
-					}}
+					onclick={stopPropagation(
+						preventDefault(() => {
+							data.nodeCallbackHandler(
+								'removeBranch',
+								data.node.id,
+								data.node,
+								data.parentIds,
+								false
+							)
+						})
+					)}
 					type="button"
 					class="text-primary bg-surface border mx-[1px] border-gray-300 dark:border-gray-500 focus:outline-none hover:bg-surface-hover focus:ring-4 focus:ring-gray-200 font-medium rounded-full text-sm w-[25px] h-[25px] flex items-center justify-center"
 				>

--- a/frontend/src/lib/components/apps/editor/settingsPanel/DeleteComponent.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/DeleteComponent.svelte
@@ -4,8 +4,12 @@
 	import { deleteGridItem, findComponentSettings } from '../appUtils'
 	import { push } from '$lib/history'
 
-	export let onDelete: (() => void) | undefined = undefined
-	export let noGrid = false
+	interface Props {
+		onDelete?: (() => void) | undefined
+		noGrid?: boolean
+	}
+
+	let { onDelete = undefined, noGrid = false }: Props = $props()
 
 	const {
 		app,

--- a/frontend/src/lib/components/apps/editor/settingsPanel/GridAgChartsLicenseKe.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/GridAgChartsLicenseKe.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	export let license: string
+	interface Props {
+		license: string
+	}
+
+	let { license = $bindable() }: Props = $props()
 
 	let initial = license
 </script>

--- a/frontend/src/lib/components/apps/editor/settingsPanel/GridAgGridLicenseKey.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/GridAgGridLicenseKey.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
 	import Badge from '$lib/components/common/badge/Badge.svelte'
 
-	export let license: string
+	interface Props {
+		license: string
+	}
 
-	let valid = false
-	$: license && checkLicenseKey(license)
+	let { license = $bindable() }: Props = $props()
+
+	let valid = $state(false)
 
 	async function checkLicenseKey(key: string) {
 		try {
@@ -16,6 +19,9 @@
 			console.error(e)
 		}
 	}
+	$effect(() => {
+		license && checkLicenseKey(license)
+	})
 </script>
 
 <div class="p-2">

--- a/frontend/src/lib/components/apps/editor/settingsPanel/GridGroup.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/GridGroup.svelte
@@ -8,14 +8,18 @@
 	import { Plus } from 'lucide-svelte'
 	import { Alert } from '$lib/components/common'
 
-	export let groupFields: RichConfigurations | undefined
-	export let item: GridItem
+	interface Props {
+		groupFields: RichConfigurations | undefined
+		item: GridItem
+	}
 
-	let groupManagementDrawer: GroupManagementDrawer | undefined = undefined
+	let { groupFields = $bindable(), item }: Props = $props()
+
+	let groupManagementDrawer: GroupManagementDrawer | undefined = $state(undefined)
 
 	// const { app, runnableComponents } = getContext<AppViewerContext>('AppViewerContext')
 
-	let fieldName: string = ''
+	let fieldName: string = $state('')
 	function addField(name: string) {
 		if (name == '') return
 		groupFields = {
@@ -92,7 +96,8 @@
 			<div class="flex flex-row gap-2 items-center relative">
 				<input
 					type="text"
-					on:keydown|stopPropagation={(event) => {
+					onkeydown={(event) => {
+						event.stopPropagation()
 						switch (event.key) {
 							case 'Enter':
 								event.preventDefault()

--- a/frontend/src/lib/components/apps/editor/settingsPanel/GridNavbar.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/GridNavbar.svelte
@@ -16,16 +16,24 @@
 	import type { StaticAppInput } from '../../inputType'
 	import ResolveNavbarItemPath from '../../components/display/ResolveNavbarItemPath.svelte'
 
-	export let navbarItems: NavbarItem[] = []
-	export let id: string
+	interface Props {
+		navbarItems?: NavbarItem[]
+		id: string
+	}
+
+	let { navbarItems = $bindable([]), id }: Props = $props()
 
 	const { appPath } = getContext<AppViewerContext>('AppViewerContext')
 
-	let items = navbarItems.map((tab, index) => {
-		return { value: tab, id: generateRandomString(), originalIndex: index }
-	})
+	let items = $state(
+		navbarItems.map((tab, index) => {
+			return { value: tab, id: generateRandomString(), originalIndex: index }
+		})
+	)
 
-	$: navbarItems = items.map((item) => item.value)
+	$effect(() => {
+		navbarItems = items.map((item) => item.value)
+	})
 
 	function addPath() {
 		const emptyAppPath: NavbarItem = {
@@ -105,8 +113,8 @@
 		items = newItems
 	}
 
-	let resolvedPaths: string[] = []
-	let resolvedLabels: string[] = []
+	let resolvedPaths: string[] = $state([])
+	let resolvedLabels: string[] = $state([])
 </script>
 
 <PanelSection
@@ -122,8 +130,8 @@
 				flipDurationMs: 200,
 				dropTargetStyle: {}
 			}}
-			on:consider={handleConsider}
-			on:finalize={handleFinalize}
+			onconsider={handleConsider}
+			onfinalize={handleFinalize}
 		>
 			{#each items as item, index (item.id)}
 				{#key item.id}
@@ -153,18 +161,18 @@
 								/>
 							</div>
 							<NavbarWizard bind:value={items[index].value}>
-								<svelte:fragment slot="trigger">
+								{#snippet trigger()}
 									<Button color="light" size="xs2" nonCaptureEvent={true}>
 										<div class="flex flex-row items-center gap-2 text-xs font-normal">
 											<Settings size={16} />
 										</div>
 									</Button>
-								</svelte:fragment>
+								{/snippet}
 							</NavbarWizard>
 
 							<div class="flex flex-col justify-center gap-2">
-								<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
-								<!-- svelte-ignore a11y-no-static-element-interactions -->
+								<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+								<!-- svelte-ignore a11y_no_static_element_interactions -->
 								<div use:dragHandle class="handle w-4 h-4" aria-label="drag-handle">
 									<GripVertical size={16} />
 								</div>

--- a/frontend/src/lib/components/apps/editor/settingsPanel/GridNavbar.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/GridNavbar.svelte
@@ -21,12 +21,18 @@
 		id: string
 	}
 
-	let { navbarItems = $bindable([]), id }: Props = $props()
+	let { navbarItems = $bindable(), id }: Props = $props()
+
+	$effect.pre(() => {
+		if (!navbarItems) {
+			navbarItems = []
+		}
+	})
 
 	const { appPath } = getContext<AppViewerContext>('AppViewerContext')
 
 	let items = $state(
-		navbarItems.map((tab, index) => {
+		(navbarItems ?? []).map((tab, index) => {
 			return { value: tab, id: generateRandomString(), originalIndex: index }
 		})
 	)

--- a/frontend/src/lib/components/apps/editor/settingsPanel/GridPane.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/GridPane.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+	import { createBubbler, stopPropagation } from 'svelte/legacy'
+
+	const bubble = createBubbler()
 	import Button from '$lib/components/common/button/Button.svelte'
 	import { getContext } from 'svelte'
 	import type { AppViewerContext } from '../../types'
@@ -7,8 +10,12 @@
 	import PanelSection from './common/PanelSection.svelte'
 	import { Plus, Trash } from 'lucide-svelte'
 
-	export let panes: number[]
-	export let component: AppComponent
+	interface Props {
+		panes: number[]
+		component: AppComponent
+	}
+
+	let { panes = $bindable(), component = $bindable() }: Props = $props()
 
 	const { app, runnableComponents } = getContext<AppViewerContext>('AppViewerContext')
 
@@ -51,9 +58,13 @@
 		<span class="text-xs text-tertiary">No panes</span>
 	{/if}
 	<div class="w-full flex gap-2 flex-col">
-		{#each panes as value, index (index)}
+		{#each panes as _, index (index)}
 			<div class="w-full flex flex-row gap-1 items-center relative">
-				<input on:keydown|stopPropagation type="number" bind:value />
+				<input
+					onkeydown={stopPropagation(bubble('keydown'))}
+					type="number"
+					bind:value={panes[index]}
+				/>
 
 				<Button
 					size="xs"

--- a/frontend/src/lib/components/apps/editor/settingsPanel/MenuItems.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/MenuItems.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+	import { createBubbler } from 'svelte/legacy'
+
+	const bubble = createBubbler()
 	import { Badge } from '$lib/components/common'
 	import Button from '$lib/components/common/button/Button.svelte'
 	import { getNextId } from '$lib/components/flows/idUtils'
@@ -10,8 +13,12 @@
 	import PanelSection from './common/PanelSection.svelte'
 	import { Plus, Trash } from 'lucide-svelte'
 
-	export let components: (BaseAppComponent & ButtonComponent)[]
-	export let id: string
+	interface Props {
+		components: (BaseAppComponent & ButtonComponent)[]
+		id: string
+	}
+
+	let { components = $bindable(), id }: Props = $props()
 
 	const { selectedComponent, app, errorByComponent } =
 		getContext<AppViewerContext>('AppViewerContext')
@@ -42,17 +49,17 @@
 		<span class="text-xs text-tertiary">No action buttons</span>
 	{/if}
 	{#each components as component}
-		<!-- svelte-ignore a11y-no-static-element-interactions -->
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<div
 			class={classNames(
 				'w-full text-xs font-bold gap-1 truncate py-1.5 px-2 cursor-pointer transition-all justify-between flex items-center border border-gray-3 rounded-md',
 				'bg-surface border-gray-300  hover:bg-gray-100 focus:bg-gray-100 text-secondary',
 				$selectedComponent?.includes(component.id) ? 'outline outline-blue-500 bg-red-400' : ''
 			)}
-			on:click={() => {
+			onclick={() => {
 				$selectedComponent = [component.id]
 			}}
-			on:keypress
+			onkeypress={bubble('keypress')}
 		>
 			<Badge color="dark-indigo">
 				{component.id}

--- a/frontend/src/lib/components/apps/editor/settingsPanel/OneOfInputSpecsEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/OneOfInputSpecsEditor.svelte
@@ -5,20 +5,37 @@
 	import { cleanseOneOfConfiguration } from '../appUtils'
 	import InputsSpecEditor from './InputsSpecEditor.svelte'
 
-	export let key: string
-	export let oneOf: { selected: string; configuration: RichConfiguration } | any
-	export let inputSpecsConfiguration: RichConfiguration | any
-	export let labels: Record<string, string> | undefined
-	export let shouldCapitalize: boolean
-	export let id: string
-	export let resourceOnly: boolean
-	export let tooltip: string | undefined
-	export let disabledOptions: string[] = []
-	export let acceptSelf: boolean = false
-	export let recomputeOnInputChanged = true
-	export let showOnDemandOnlyToggle = true
+	interface Props {
+		key: string
+		oneOf: { selected: string; configuration: RichConfiguration } | any
+		inputSpecsConfiguration: RichConfiguration | any
+		labels: Record<string, string> | undefined
+		shouldCapitalize: boolean
+		id: string
+		resourceOnly: boolean
+		tooltip: string | undefined
+		disabledOptions?: string[]
+		acceptSelf?: boolean
+		recomputeOnInputChanged?: boolean
+		showOnDemandOnlyToggle?: boolean
+	}
 
-	$: {
+	let {
+		key,
+		oneOf = $bindable(),
+		inputSpecsConfiguration,
+		labels,
+		shouldCapitalize,
+		id,
+		resourceOnly,
+		tooltip,
+		disabledOptions = [],
+		acceptSelf = false,
+		recomputeOnInputChanged = true,
+		showOnDemandOnlyToggle = true
+	}: Props = $props()
+
+	$effect(() => {
 		if (oneOf == undefined) {
 			oneOf = { configuration: {}, selected: '' }
 		}
@@ -41,7 +58,7 @@
 				type: 'oneOf'
 			}
 		}
-	}
+	})
 
 	function getValueOfDeprecated(obj: object): boolean {
 		if (!obj) return false
@@ -62,7 +79,7 @@
 	<select
 		class="w-full border border-gray-300 rounded-md p-2"
 		value={oneOf.selected}
-		on:change={(e) => {
+		onchange={(e) => {
 			oneOf = { ...oneOf, selected: e?.target?.['value'] }
 		}}
 	>

--- a/frontend/src/lib/components/apps/editor/settingsPanel/PlotlyRichEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/PlotlyRichEditor.svelte
@@ -3,9 +3,13 @@
 	import InputsSpecEditor from './InputsSpecEditor.svelte'
 	import PanelSection from './common/PanelSection.svelte'
 
-	export let datasets: RichConfiguration | undefined = undefined
-	export let xData: RichConfiguration | undefined = undefined
-	export let id: string
+	interface Props {
+		datasets?: RichConfiguration | undefined
+		xData?: RichConfiguration | undefined
+		id: string
+	}
+
+	let { datasets = $bindable(undefined), xData = $bindable(undefined), id }: Props = $props()
 </script>
 
 <PanelSection

--- a/frontend/src/lib/components/apps/editor/settingsPanel/RefreshDatabaseStudioTable.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/RefreshDatabaseStudioTable.svelte
@@ -4,7 +4,11 @@
 	import { getContext } from 'svelte'
 	import type { AppViewerContext } from '../../types'
 
-	export let id: string | undefined = undefined
+	interface Props {
+		id?: string | undefined
+	}
+
+	let { id = undefined }: Props = $props()
 
 	const { componentControl } = getContext<AppViewerContext>('AppViewerContext')
 

--- a/frontend/src/lib/components/apps/editor/settingsPanel/SubTypeEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/SubTypeEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { readFieldsRecursively } from '$lib/utils'
 	import type { InputType, StaticInput } from '../../inputType'
 	import StaticInputEditor from './inputEditor/StaticInputEditor.svelte'
 
@@ -11,22 +12,22 @@
 
 	let { value = $bindable(), componentInput = $bindable(), subFieldType, id }: Props = $props()
 
+	let fakeComponentInput: StaticInput<any> = $state({
+		...componentInput,
+		value
+	})
+
+	$effect(() => {
+		readFieldsRecursively(fakeComponentInput)
+		// console.log('fakeComponentInput', fakeComponentInput.value)
+		value = fakeComponentInput.value
+	})
 	// Bubble up changes to the real componentInput
 </script>
 
 <StaticInputEditor
 	{id}
 	fieldType={subFieldType}
-	bind:componentInput={
-		() => {
-			return {
-				...componentInput,
-				value
-			}
-		},
-		(v) => {
-			value = v.value
-		}
-	}
+	bind:componentInput={fakeComponentInput}
 	on:remove
 />

--- a/frontend/src/lib/components/apps/editor/settingsPanel/SubTypeEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/SubTypeEditor.svelte
@@ -2,23 +2,31 @@
 	import type { InputType, StaticInput } from '../../inputType'
 	import StaticInputEditor from './inputEditor/StaticInputEditor.svelte'
 
-	export let value: any
-	export let componentInput: StaticInput<any>
-	export let subFieldType: InputType | undefined
-	export let id: string | undefined
-
-	let fakeComponentInput: StaticInput<any> = {
-		...componentInput,
-		value
+	interface Props {
+		value: any
+		componentInput: StaticInput<any>
+		subFieldType: InputType | undefined
+		id: string | undefined
 	}
 
+	let { value = $bindable(), componentInput = $bindable(), subFieldType, id }: Props = $props()
+
 	// Bubble up changes to the real componentInput
-	$: fakeComponentInput && (value = fakeComponentInput.value)
 </script>
 
 <StaticInputEditor
 	{id}
 	fieldType={subFieldType}
-	bind:componentInput={fakeComponentInput}
+	bind:componentInput={
+		() => {
+			return {
+				...componentInput,
+				value
+			}
+		},
+		(v) => {
+			value = v.value
+		}
+	}
 	on:remove
 />

--- a/frontend/src/lib/components/apps/editor/settingsPanel/TableActions.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/TableActions.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+	import { createBubbler } from 'svelte/legacy'
+
+	const bubble = createBubbler()
 	import { Badge } from '$lib/components/common'
 	import Button from '$lib/components/common/button/Button.svelte'
 	import { getNextId } from '$lib/components/flows/idUtils'
@@ -15,11 +18,15 @@
 	import TableActionsWizard from '$lib/components/wizards/TableActionsWizard.svelte'
 	import Alert from '$lib/components/common/alert/Alert.svelte'
 
-	export let components:
-		| (BaseAppComponent & (ButtonComponent | CheckboxComponent | SelectComponent))[]
-		| undefined
+	interface Props {
+		components:
+			| (BaseAppComponent & (ButtonComponent | CheckboxComponent | SelectComponent))[]
+			| undefined
+		actionsOrder?: RichConfiguration | undefined
+		id: string
+	}
 
-	export let actionsOrder: RichConfiguration | undefined = undefined
+	let { components = $bindable(), actionsOrder = $bindable(undefined), id }: Props = $props()
 
 	// Migration code:
 	onMount(() => {
@@ -28,14 +35,15 @@
 		}
 	})
 
-	let items =
+	let items = $state(
 		components?.map((tab, index) => {
 			return { value: tab, id: generateRandomString(), originalIndex: index }
 		}) ?? []
+	)
 
-	$: components = items.map((item) => item.value)
-
-	export let id: string
+	$effect(() => {
+		components = items.map((item) => item.value)
+	})
 
 	const { selectedComponent, app, errorByComponent, hoverStore } =
 		getContext<AppViewerContext>('AppViewerContext')
@@ -99,9 +107,9 @@
 
 {#if components}
 	<PanelSection title={`Table Actions`}>
-		<svelte:fragment slot="action">
+		{#snippet action()}
 			<TableActionsWizard bind:actionsOrder selectedId={$selectedComponent?.[0] ?? ''} {components}>
-				<svelte:fragment slot="trigger">
+				{#snippet trigger()}
 					<Button
 						color="light"
 						size="xs2"
@@ -113,9 +121,9 @@
 							<ListOrdered size={16} />
 						</div>
 					</Button>
-				</svelte:fragment>
+				{/snippet}
 			</TableActionsWizard>
-		</svelte:fragment>
+		{/snippet}
 		{#if components.length == 0}
 			<span class="text-xs text-tertiary">No action buttons</span>
 		{/if}
@@ -126,27 +134,27 @@
 					flipDurationMs: 200,
 					dropTargetStyle: {}
 				}}
-				on:consider={handleConsider}
-				on:finalize={handleFinalize}
+				onconsider={handleConsider}
+				onfinalize={handleFinalize}
 			>
 				{#each items as item, index (item.id)}
 					{@const component = items[index].value}
 
 					<div animate:flip={{ duration: 200 }} class="flex flex-row gap-2 items-center mb-2">
-						<!-- svelte-ignore a11y-no-static-element-interactions -->
-						<!-- svelte-ignore a11y-mouse-events-have-key-events -->
+						<!-- svelte-ignore a11y_no_static_element_interactions -->
+						<!-- svelte-ignore a11y_mouse_events_have_key_events -->
 						<div
 							class={classNames(
 								'w-full text-xs text-semibold truncate py-1.5 px-2 cursor-pointer justify-between flex items-center border rounded-md',
 								'bg-surface hover:bg-surface-hover focus:border-primary text-secondary'
 							)}
-							on:click={() => {
+							onclick={() => {
 								$selectedComponent = [component.id]
 							}}
-							on:mouseover={() => {
+							onmouseover={() => {
 								$hoverStore = component.id
 							}}
-							on:keypress
+							onkeypress={bubble('keypress')}
 						>
 							<div class="flex flex-row gap-2 items-center">
 								<Badge color="dark-indigo">

--- a/frontend/src/lib/components/apps/editor/settingsPanel/common/PanelSection.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/common/PanelSection.svelte
@@ -2,18 +2,36 @@
 	import { classNames } from '$lib/utils'
 	import Tooltip from '../../../../Tooltip.svelte'
 
-	export let title: string
-	export let noPadding: boolean = false
-	export let fullHeight: boolean = true
-	export let titlePadding: string = ''
-	export let tooltip = ''
-	export let documentationLink: string | undefined = undefined
-	export let id: string | undefined = undefined
+	interface Props {
+		title: string
+		noPadding?: boolean
+		fullHeight?: boolean
+		titlePadding?: string
+		tooltip?: string
+		documentationLink?: string | undefined
+		id?: string | undefined
+		class?: string | undefined
+		action?: import('svelte').Snippet
+		children?: import('svelte').Snippet
+	}
+
+	let {
+		title,
+		noPadding = false,
+		fullHeight = true,
+		titlePadding = '',
+		tooltip = '',
+		documentationLink = undefined,
+		id = undefined,
+		class: clazz = undefined,
+		action,
+		children
+	}: Props = $props()
 </script>
 
 <div
 	class={classNames(
-		$$props.class,
+		clazz,
 		'flex flex-col gap-2 items-start',
 		noPadding ? '' : 'p-3',
 		fullHeight ? 'h-full' : ''
@@ -31,7 +49,7 @@
 				</Tooltip>
 			{/if}
 		</div>
-		<slot name="action" />
+		{@render action?.()}
 	</div>
-	<slot />
+	{@render children?.()}
 </div>

--- a/frontend/src/lib/components/apps/editor/settingsPanel/decisionTree/InsertDecisionTreeNode.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/decisionTree/InsertDecisionTreeNode.svelte
@@ -5,15 +5,19 @@
 
 	const dispatch = createEventDispatcher()
 
-	export let canAddBranch: boolean = true
-	export let canAddNode: boolean = true
+	interface Props {
+		canAddBranch?: boolean
+		canAddNode?: boolean
+	}
+
+	let { canAddBranch = true, canAddNode = true }: Props = $props()
 </script>
 
 <div class="relative flex flex-row gap-1">
 	{#if canAddNode}
 		<button
 			title="Add step"
-			on:pointerdown={() => {
+			onpointerdown={() => {
 				dispatch('node')
 			}}
 			type="button"
@@ -26,7 +30,7 @@
 		<button
 			title="Add branch"
 			type="button"
-			on:click={() => dispatch('addBranch')}
+			onclick={() => dispatch('addBranch')}
 			class={twMerge(
 				'text-secondary bg-surface outline-[1px] outline dark:outline-gray-500 outline-gray-300 focus:outline-none hover:bg-surface-hover focus:ring-4 focus:ring-surface-selected font-medium rounded-full text-sm w-[25px] h-[25px] flex items-center justify-center',
 				!canAddNode && 'ml-16 mb-2'

--- a/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/ColorInput.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/ColorInput.svelte
@@ -5,16 +5,20 @@
 	import { createPopperActions } from 'svelte-popperjs'
 	import { fade } from 'svelte/transition'
 	import { zIndexes } from '$lib/zIndexes'
-	import { createDispatcherIfMounted } from '$lib/createDispatcherIfMounted'
 
-	export let value: string = '#fff'
+	interface Props {
+		value?: string
+	}
+
+	let { value = $bindable('#fff') }: Props = $props()
 	const dispatch = createEventDispatcher()
-	const dispatchIfMounted = createDispatcherIfMounted(dispatch)
 	const [popperRef, popperContent] = createPopperActions()
-	let isOpen = false
-	let width: number
+	let isOpen = $state(false)
+	let width: number | undefined = $state()
 
-	$: dispatchIfMounted('change', value)
+	$effect(() => {
+		dispatch('change', value)
+	})
 
 	function open() {
 		isOpen = true

--- a/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/ConnectedInputEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/ConnectedInputEditor.svelte
@@ -5,7 +5,11 @@
 	import type { ConnectedAppInput, InputConnection } from '../../../inputType'
 	import { Plug, Unplug } from 'lucide-svelte'
 
-	export let componentInput: ConnectedAppInput
+	interface Props {
+		componentInput: ConnectedAppInput
+	}
+
+	let { componentInput = $bindable() }: Props = $props()
 
 	const { connectingInput, app } = getContext<AppViewerContext>('AppViewerContext')
 

--- a/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/EvalInputEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/EvalInputEditor.svelte
@@ -6,8 +6,12 @@
 	import SimpleEditor from '$lib/components/SimpleEditor.svelte'
 	import { buildExtraLib } from '$lib/components/apps/utils'
 
-	export let componentInput: EvalAppInput | undefined
-	export let id: string
+	interface Props {
+		componentInput: EvalAppInput | undefined
+		id: string
+	}
+
+	let { componentInput = $bindable(), id }: Props = $props()
 
 	const {
 		onchange,
@@ -15,10 +19,11 @@
 		state: stateStore
 	} = getContext<AppViewerContext>('AppViewerContext')
 
-	$: extraLib =
+	let extraLib = $derived(
 		componentInput?.expr && $worldStore
 			? buildExtraLib($worldStore?.outputsById ?? {}, id, $stateStore, false)
 			: undefined
+	)
 
 	// 	`
 	// /** The current's app state */

--- a/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/IconSelectInput.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/IconSelectInput.svelte
@@ -43,7 +43,7 @@
 	}
 
 	let {
-		value = $bindable(''),
+		value = $bindable(undefined),
 		floatingConfig = {
 			strategy: 'absolute',
 			placement: 'bottom-end'

--- a/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/IconSelectInput.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/IconSelectInput.svelte
@@ -5,20 +5,20 @@
 	import type { ComputeConfig } from 'svelte-floating-ui'
 	import Popover from '$lib/components/meltComponents/Popover.svelte'
 
-	export let value: string | undefined = ''
+	let loading = $state(false)
+	let items: string[] | undefined = $state()
+	let filteredItems: string[] | undefined = $state()
+	let search = $state('')
 
-	let loading = false
-	let items: string[]
-	let filteredItems: string[]
-	let search = ''
-
-	$: if (search) {
-		filteredItems = items.filter((item) => {
-			return item.toLowerCase().includes(search.toLowerCase())
-		})
-	} else {
-		filteredItems = items
-	}
+	$effect.pre(() => {
+		if (search) {
+			filteredItems = items?.filter((item) => {
+				return item.toLowerCase().includes(search.toLowerCase())
+			})
+		} else {
+			filteredItems = items
+		}
+	})
 
 	async function getData() {
 		loading = true
@@ -37,14 +37,22 @@
 		}
 	}
 
-	export let floatingConfig: ComputeConfig = {
-		strategy: 'absolute',
-		placement: 'bottom-end'
+	interface Props {
+		value?: string | undefined
+		floatingConfig?: ComputeConfig
 	}
+
+	let {
+		value = $bindable(''),
+		floatingConfig = {
+			strategy: 'absolute',
+			placement: 'bottom-end'
+		}
+	}: Props = $props()
 </script>
 
 <Popover {floatingConfig} closeOnOtherPopoverOpen contentClasses="p-4">
-	<svelte:fragment slot="trigger">
+	{#snippet trigger()}
 		<div class="relative">
 			<ClearableInput
 				readonly
@@ -59,13 +67,13 @@
 				</div>
 			{/if}
 		</div>
-	</svelte:fragment>
-	<svelte:fragment slot="content" let:close>
+	{/snippet}
+	{#snippet content({ close })}
 		{#if !loading}
 			{#if filteredItems}
 				<div class="w-72">
 					<input
-						on:keydown={(event) => {
+						onkeydown={(event) => {
 							if (!['ArrowDown', 'ArrowUp'].includes(event.key)) {
 								event.stopPropagation()
 							}
@@ -80,15 +88,15 @@
 							<button
 								type="button"
 								title={label}
-								on:click={() => {
+								onclick={() => {
 									select(label)
 									close()
 								}}
 								class="w-full center-center flex-col font-normal p-1
-											hover:bg-gray-100 focus:bg-gray-100 rounded duration-200 dark:hover:bg-frost-900 dark:focus:bg-frost-900
-											{label === value ? 'text-blue-600 bg-blue-50 pointer-events-none' : ''}"
+												hover:bg-gray-100 focus:bg-gray-100 rounded duration-200 dark:hover:bg-frost-900 dark:focus:bg-frost-900
+												{label === value ? 'text-blue-600 bg-blue-50 pointer-events-none' : ''}"
 							>
-								<!-- svelte-ignore a11y-missing-attribute -->
+								<!-- svelte-ignore a11y_missing_attribute -->
 								<img
 									class="dark:invert"
 									loading="lazy"
@@ -109,5 +117,5 @@
 				<div class="text-center text-sm text-secondary p-2"> Couldn't load options </div>
 			{/if}
 		{/if}
-	</svelte:fragment>
+	{/snippet}
 </Popover>

--- a/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/RowInputEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/RowInputEditor.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 	import type { RowAppInput } from '../../../inputType'
 
-	export let componentInput: RowAppInput | undefined
+	interface Props {
+		componentInput: RowAppInput | undefined
+	}
+
+	let { componentInput = $bindable() }: Props = $props()
 </script>
 
 {#if componentInput}

--- a/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/RunnableInputEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/RunnableInputEditor.svelte
@@ -7,9 +7,13 @@
 	import SelectedRunnable from '../SelectedRunnable.svelte'
 	import type { AppEditorContext, AppViewerContext } from '$lib/components/apps/types'
 
-	export let appInput: ResultAppInput
-	export let defaultUserInput = false
-	export let appComponent: AppComponent
+	interface Props {
+		appInput: ResultAppInput
+		defaultUserInput?: boolean
+		appComponent: AppComponent
+	}
+
+	let { appInput = $bindable(), defaultUserInput = false, appComponent }: Props = $props()
 
 	const { selectedComponentInEditor } = getContext<AppEditorContext>('AppEditorContext')
 	const { app } = getContext<AppViewerContext>('AppViewerContext')

--- a/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/StaticInputEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/StaticInputEditor.svelte
@@ -54,6 +54,7 @@
 	$effect(() => {
 		componentInput && appContext?.onchange?.()
 	})
+
 	let s3FileUploadRawMode = $state(false)
 	let s3FilePicker: S3FilePicker | undefined = $state(undefined)
 </script>

--- a/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/TabSelectInput.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/TabSelectInput.svelte
@@ -4,7 +4,11 @@
 	import { allItems } from '$lib/components/apps/utils'
 	import { getContext } from 'svelte'
 
-	export let componentInput: StaticInput<{ id: string; index: number }>
+	interface Props {
+		componentInput: StaticInput<{ id: string; index: number }>
+	}
+
+	let { componentInput = $bindable() }: Props = $props()
 
 	const { app } = getContext<AppViewerContext>('AppViewerContext')
 

--- a/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/UploadInputEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/inputEditor/UploadInputEditor.svelte
@@ -10,12 +10,23 @@
 	import FileUpload from '$lib/components/common/fileUpload/FileUpload.svelte'
 	import { writable, type Writable } from 'svelte/store'
 
-	export let componentInput: UploadAppInput | UploadS3AppInput | StaticInput<any> | undefined
-	export let fileUpload: UploadAppInput['fileUpload'] | UploadS3AppInput['fileUploadS3'] | undefined
-	export let s3: boolean | undefined = false
-	export let prefix: string | undefined = undefined
-	export let workspace: string | undefined = undefined
-	export let s3FileUploadRawMode: boolean = false
+	interface Props {
+		componentInput: UploadAppInput | UploadS3AppInput | StaticInput<any> | undefined
+		fileUpload: UploadAppInput['fileUpload'] | UploadS3AppInput['fileUploadS3'] | undefined
+		s3?: boolean | undefined
+		prefix?: string | undefined
+		workspace?: string | undefined
+		s3FileUploadRawMode?: boolean
+	}
+
+	let {
+		componentInput = $bindable(),
+		fileUpload,
+		s3 = false,
+		prefix = undefined,
+		workspace = undefined,
+		s3FileUploadRawMode = $bindable(false)
+	}: Props = $props()
 
 	let fileUploads: Writable<FileUploadData[]> = writable([])
 
@@ -63,6 +74,7 @@
 			}
 		}}
 	>
+		<!-- @migration-task: migrate this slot by hand, `selected-title` is an invalid identifier -->
 		<svelte:fragment slot="selected-title">
 			<!-- Removing the title when there is a selected file -->
 			<span></span>

--- a/frontend/src/lib/components/apps/editor/settingsPanel/mainInput/InlineScriptList.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/mainInput/InlineScriptList.svelte
@@ -1,25 +1,33 @@
 <script lang="ts">
+	import { createBubbler, stopPropagation } from 'svelte/legacy'
+
+	const bubble = createBubbler()
 	import { createEventDispatcher } from 'svelte'
 	import SearchItems from '$lib/components/SearchItems.svelte'
 	import NoItemFound from '$lib/components/home/NoItemFound.svelte'
 	import RowIcon from '$lib/components/common/table/RowIcon.svelte'
 
-	export let filter = ''
-	export let inlineScripts: string[] = []
+	interface Props {
+		filter?: string
+		inlineScripts?: string[]
+		children?: import('svelte').Snippet
+	}
+
+	let { filter = $bindable(''), inlineScripts = [], children }: Props = $props()
 
 	type Item = { title: string }
-	let filteredItems: (Item & { marked?: string })[] = []
-	$: items = inlineScripts.map((x) => ({ title: x }))
-	$: prefilteredItems = items ?? []
+	let filteredItems: (Item & { marked?: string })[] = $state([])
+	let items = $derived(inlineScripts.map((x) => ({ title: x })))
+	let prefilteredItems = $derived(items ?? [])
 
 	const dispatch = createEventDispatcher()
 </script>
 
 <SearchItems {filter} items={prefilteredItems} bind:filteredItems f={(x) => x.summary} />
 <div class="w-full flex mt-1 items-center gap-2">
-	<slot />
+	{@render children?.()}
 	<input
-		on:keydown|stopPropagation
+		onkeydown={stopPropagation(bubble('keydown'))}
 		type="text"
 		placeholder="Search inline scripts"
 		bind:value={filter}
@@ -39,7 +47,7 @@
 			<li class="flex flex-row w-full">
 				<button
 					class="p-4 gap-4 flex flex-row grow justify-between hover:bg-surface-hover bg-surface transition-all items-center rounded-md"
-					on:click={() => dispatch('pick', item.title)}
+					onclick={() => dispatch('pick', item.title)}
 				>
 					<div class="flex items-center gap-4">
 						<RowIcon kind="script" />

--- a/frontend/src/lib/components/apps/editor/settingsPanel/mainInput/RunnableSelector.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/mainInput/RunnableSelector.svelte
@@ -14,23 +14,35 @@
 	import { workspaceStore } from '$lib/stores'
 	import type { InlineScript } from '$lib/components/apps/types'
 
-	type Tab = 'hubscripts' | 'workspacescripts' | 'workspaceflows' | 'inlinescripts'
+	type TabType = 'hubscripts' | 'workspacescripts' | 'workspaceflows' | 'inlinescripts'
 
-	export let defaultUserInput = false
-	export let hideCreateScript = false
-	export let onlyFlow = false
-	export let rawApps = false
-	export let unusedInlineScripts: { name: string; inlineScript: InlineScript }[]
+	interface Props {
+		defaultUserInput?: boolean
+		hideCreateScript?: boolean
+		onlyFlow?: boolean
+		rawApps?: boolean
+		unusedInlineScripts: { name: string; inlineScript: InlineScript }[]
+	}
+
+	let {
+		defaultUserInput = false,
+		hideCreateScript = false,
+		onlyFlow = false,
+		rawApps = false,
+		unusedInlineScripts = $bindable()
+	}: Props = $props()
 
 	// const { app, workspace } = getContext<AppViewerContext>('AppViewerContext')
 
-	let tab: Tab = onlyFlow
-		? 'workspaceflows'
-		: unusedInlineScripts?.length > 0
-			? 'inlinescripts'
-			: 'workspacescripts'
-	let filter: string = ''
-	let picker: Drawer
+	let tab: TabType = $state(
+		onlyFlow
+			? 'workspaceflows'
+			: unusedInlineScripts?.length > 0
+				? 'inlinescripts'
+				: 'workspacescripts'
+	)
+	let filter: string = $state('')
+	let picker: Drawer | undefined = $state()
 
 	const dispatch = createEventDispatcher<{
 		pick: {

--- a/frontend/src/lib/components/apps/editor/settingsPanel/mainInput/WorkspaceFlowList.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/mainInput/WorkspaceFlowList.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+	import { createBubbler, stopPropagation } from 'svelte/legacy'
+
+	const bubble = createBubbler()
 	import { createEventDispatcher, onMount } from 'svelte'
 	import SearchItems from '$lib/components/SearchItems.svelte'
 	import NoItemFound from '$lib/components/home/NoItemFound.svelte'
@@ -8,11 +11,16 @@
 	import { emptyString } from '$lib/utils'
 	import { Skeleton } from '$lib/components/common'
 
-	export let filter = ''
+	interface Props {
+		filter?: string
+		children?: import('svelte').Snippet
+	}
 
-	let flows: Flow[] | undefined = undefined
-	let filteredItems: (Flow & { marked?: string })[] = []
-	$: prefilteredItems = flows ?? []
+	let { filter = $bindable(''), children }: Props = $props()
+
+	let flows: Flow[] | undefined = $state(undefined)
+	let filteredItems: (Flow & { marked?: string })[] = $state([])
+	let prefilteredItems = $derived(flows ?? [])
 
 	const dispatch = createEventDispatcher()
 
@@ -37,11 +45,11 @@
 	f={(x) => (emptyString(x.summary) ? x.path : x.summary + ' (' + x.path + ')')}
 />
 <div class="w-full flex mt-1 items-center gap-2">
-	<slot />
+	{@render children?.()}
 	<input
 		type="text"
 		placeholder="Search workspace flows"
-		on:keydown|stopPropagation
+		onkeydown={stopPropagation(bubble('keydown'))}
 		bind:value={filter}
 		class="text-2xl grow mb-4"
 	/>
@@ -56,7 +64,7 @@
 				<li class="flex flex-row w-full">
 					<button
 						class="p-4 gap-4 flex flex-row grow justify-between hover:bg-surface-hover bg-surface transition-all items-center rounded-md"
-						on:click={() => dispatch('pick', item.path)}
+						onclick={() => dispatch('pick', item.path)}
 					>
 						<div class="flex items-center gap-4">
 							<RowIcon kind="flow" />

--- a/frontend/src/lib/components/apps/editor/settingsPanel/mainInput/WorkspaceScriptList.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/mainInput/WorkspaceScriptList.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+	import { createBubbler, stopPropagation } from 'svelte/legacy'
+
+	const bubble = createBubbler()
 	import { createEventDispatcher, onMount } from 'svelte'
 	import SearchItems from '$lib/components/SearchItems.svelte'
 	import NoItemFound from '$lib/components/home/NoItemFound.svelte'
@@ -8,11 +11,16 @@
 	import { emptyString } from '$lib/utils'
 	import { Skeleton } from '$lib/components/common'
 
-	export let filter = ''
+	interface Props {
+		filter?: string
+		children?: import('svelte').Snippet
+	}
 
-	let scripts: Script[] | undefined = undefined
-	let filteredItems: (Script & { marked?: string })[] = []
-	$: prefilteredItems = scripts ?? []
+	let { filter = $bindable(''), children }: Props = $props()
+
+	let scripts: Script[] | undefined = $state(undefined)
+	let filteredItems: (Script & { marked?: string })[] = $state([])
+	let prefilteredItems = $derived(scripts ?? [])
 
 	const dispatch = createEventDispatcher()
 
@@ -37,10 +45,10 @@
 	f={(x) => (emptyString(x.summary) ? x.path : x.summary + ' (' + x.path + ')')}
 />
 <div class="w-full flex mt-1 items-center gap-2">
-	<slot />
+	{@render children?.()}
 	<input
 		type="text"
-		on:keydown|stopPropagation
+		onkeydown={stopPropagation(bubble('keydown'))}
 		placeholder="Search workspace scripts"
 		bind:value={filter}
 		class="text-2xl grow mb-4"
@@ -56,7 +64,7 @@
 				<li class="flex flex-row w-full">
 					<button
 						class="p-4 gap-4 flex flex-row grow justify-between hover:bg-surface-hover bg-surface transition-all items-center rounded-md"
-						on:click={() => dispatch('pick', item.path)}
+						onclick={() => dispatch('pick', item.path)}
 					>
 						<div class="flex items-center gap-4">
 							<RowIcon kind="script" />

--- a/frontend/src/lib/components/apps/editor/settingsPanel/script/BackgroundScriptSettings.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/script/BackgroundScriptSettings.svelte
@@ -7,8 +7,12 @@
 	import ScriptSettingsSection from './shared/ScriptSettingsSection.svelte'
 	import ScriptTransformer from './shared/ScriptTransformer.svelte'
 
-	export let runnable: HiddenRunnable
-	export let id: string
+	interface Props {
+		runnable: HiddenRunnable
+		id: string
+	}
+
+	let { runnable = $bindable(), id }: Props = $props()
 
 	const { runnableComponents } = getContext<AppViewerContext>('AppViewerContext')
 

--- a/frontend/src/lib/components/apps/editor/settingsPanel/script/ComponentScriptSettings.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/script/ComponentScriptSettings.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" context="module">
+<script lang="ts" module>
 	export type ActionType = {
 		label: string
 		icon: any
@@ -22,14 +22,20 @@
 	import ScriptSettingsSection from './shared/ScriptSettingsSection.svelte'
 	import Toggle from '$lib/components/Toggle.svelte'
 
-	export let appInput: ResultAppInput
-	export let appComponent: AppComponent
-	export let hasScript: boolean
-
-	let runnable = appInput.runnable
-
 	const { runnableComponents, stateId } = getContext<AppViewerContext>('AppViewerContext')
-	export let actions: ActionType[] = []
+	interface Props {
+		appInput: ResultAppInput
+		appComponent: AppComponent
+		hasScript: boolean
+		actions?: ActionType[]
+	}
+
+	let {
+		appInput = $bindable(),
+		appComponent = $bindable(),
+		hasScript,
+		actions = []
+	}: Props = $props()
 
 	function updateAutoRefresh() {
 		const autoRefresh =
@@ -51,12 +57,13 @@
 
 <div>
 	{#key $stateId}
+		{@const runnable = appInput.runnable}
 		<ScriptSettingHeader
 			name={runnable?.type === 'runnableByName'
 				? runnable.name
 				: runnable?.type === 'runnableByPath'
-				? runnable.path
-				: ''}
+					? runnable.path
+					: ''}
 			{actions}
 		/>
 	{/key}

--- a/frontend/src/lib/components/apps/editor/settingsPanel/script/shared/BackgroundScriptTriggerBy.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/script/shared/BackgroundScriptTriggerBy.svelte
@@ -4,12 +4,18 @@
 	import { getDependencies } from '../utils'
 	import ScriptTriggers from './ScriptTriggers.svelte'
 
-	export let script: HiddenRunnable
-	export let recomputeOnInputChanged: boolean | undefined = undefined
-	export let id: string
+	interface Props {
+		script: HiddenRunnable
+		recomputeOnInputChanged?: boolean | undefined
+		id: string
+	}
 
-	$: isFrontend = script.type == 'runnableByName' && script.inlineScript?.language === 'frontend'
-	$: triggerEvents = script.autoRefresh ? ['start', 'refresh'] : []
+	let { script = $bindable(), recomputeOnInputChanged = undefined, id }: Props = $props()
+
+	let isFrontend = $derived(
+		script.type == 'runnableByName' && script.inlineScript?.language === 'frontend'
+	)
+	let triggerEvents = $derived(script.autoRefresh ? ['start', 'refresh'] : [])
 </script>
 
 {#if script.type == 'runnableByName' && script.inlineScript}

--- a/frontend/src/lib/components/apps/editor/settingsPanel/script/shared/ComponentScriptTriggerBy.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/script/shared/ComponentScriptTriggerBy.svelte
@@ -5,15 +5,21 @@
 
 	import ScriptTriggers from './ScriptTriggers.svelte'
 
-	export let appComponent: AppComponent
-	export let appInput: ResultAppInput
+	interface Props {
+		appComponent: AppComponent
+		appInput: ResultAppInput
+	}
 
-	$: triggerEvents = getAllTriggerEvents(appComponent, appInput.autoRefresh)
-	$: isFrontend =
+	let { appComponent, appInput = $bindable() }: Props = $props()
+
+	let triggerEvents = $derived(getAllTriggerEvents(appComponent, appInput.autoRefresh))
+	let isFrontend = $derived(
 		appInput.runnable?.type == 'runnableByName' &&
-		appInput.runnable?.inlineScript?.language === 'frontend'
-	$: shoudlDisplayChangeEvents =
+			appInput.runnable?.inlineScript?.language === 'frontend'
+	)
+	let shoudlDisplayChangeEvents = $derived(
 		appInput.recomputeOnInputChanged && !isTriggerable(appComponent.type)
+	)
 </script>
 
 {#if appInput?.runnable?.type === 'runnableByName'}

--- a/frontend/src/lib/components/apps/editor/settingsPanel/script/shared/ScriptRunConfiguration.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/script/shared/ScriptRunConfiguration.svelte
@@ -4,10 +4,21 @@
 	import ScriptSettingsSection from './ScriptSettingsSection.svelte'
 	import Toggle from '$lib/components/Toggle.svelte'
 
-	export let autoRefresh: boolean | undefined = false
-	export let recomputeOnInputChanged: boolean | undefined = false
-	export let canConfigureRecomputeOnInputChanged: boolean = true
-	export let canConfigureRunOnStart: boolean = true
+	interface Props {
+		autoRefresh?: boolean | undefined
+		recomputeOnInputChanged?: boolean | undefined
+		canConfigureRecomputeOnInputChanged?: boolean
+		canConfigureRunOnStart?: boolean
+		children?: import('svelte').Snippet
+	}
+
+	let {
+		autoRefresh = $bindable(false),
+		recomputeOnInputChanged = $bindable(false),
+		canConfigureRecomputeOnInputChanged = true,
+		canConfigureRunOnStart = true,
+		children
+	}: Props = $props()
 
 	const dispatch = createEventDispatcher()
 </script>
@@ -50,10 +61,10 @@
 				</div>
 			{/if}
 		</div>
-		<slot />
+		{@render children?.()}
 	</ScriptSettingsSection>
 {:else}
 	<ScriptSettingsSection title="Triggers">
-		<slot />
+		{@render children?.()}
 	</ScriptSettingsSection>
 {/if}

--- a/frontend/src/lib/components/apps/editor/settingsPanel/script/shared/ScriptSettingHeader.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/script/shared/ScriptSettingHeader.svelte
@@ -4,9 +4,13 @@
 	import ScriptSettingsActions from './ScriptSettingsActions.svelte'
 	import { twMerge } from 'tailwind-merge'
 
-	export let name: string
-	export let actions: ActionType[] = []
-	export let noBorder: boolean = false
+	interface Props {
+		name: string
+		actions?: ActionType[]
+		noBorder?: boolean
+	}
+
+	let { name, actions = [], noBorder = false }: Props = $props()
 </script>
 
 <div

--- a/frontend/src/lib/components/apps/editor/settingsPanel/script/shared/ScriptSettingsSection.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/script/shared/ScriptSettingsSection.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
 	import Tooltip from '$lib/components/Tooltip.svelte'
 
-	export let title: string
-	export let tooltip: string | undefined = undefined
+	interface Props {
+		title: string
+		tooltip?: string | undefined
+		children?: import('svelte').Snippet
+	}
+
+	let { title, tooltip = undefined, children }: Props = $props()
 </script>
 
 <div class="py-2">
@@ -16,5 +21,5 @@
 		{/if}
 	</div>
 
-	<slot />
+	{@render children?.()}
 </div>

--- a/frontend/src/lib/components/apps/editor/settingsPanel/script/shared/ScriptTransformer.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/script/shared/ScriptTransformer.svelte
@@ -7,10 +7,14 @@
 
 	const { selectedComponentInEditor } = getContext<AppEditorContext>('AppEditorContext')
 
-	export let appInput: { transformer?: InlineScript & { language: 'frontend' } }
-	export let id: string
+	interface Props {
+		appInput: { transformer?: InlineScript & { language: 'frontend' } }
+		id: string
+	}
 
-	$: checked = Boolean(appInput.transformer)
+	let { appInput = $bindable(), id }: Props = $props()
+
+	let checked = $derived(Boolean(appInput.transformer))
 </script>
 
 <div class="mt-2">
@@ -19,7 +23,7 @@
 		tooltip={"A transformer is an optional frontend script that is executed right after the component's script whose purpose is to do lightweight transformation in the browser. It takes the previous computation's result as `result`"}
 		small
 	>
-		<svelte:fragment slot="action">
+		{#snippet action()}
 			<Button
 				size="xs"
 				color={checked ? 'red' : 'light'}
@@ -39,6 +43,6 @@
 			>
 				{checked ? 'Remove' : 'Add'}
 			</Button>
-		</svelte:fragment>
+		{/snippet}
 	</Section>
 </div>

--- a/frontend/src/lib/components/apps/editor/settingsPanel/script/shared/ScriptTriggers.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/script/shared/ScriptTriggers.svelte
@@ -4,24 +4,33 @@
 	import { classNames, itemsExists } from '$lib/utils'
 	import { Plus, X } from 'lucide-svelte'
 	import { Button } from '$lib/components/common'
-	import { getContext } from 'svelte'
+	import { getContext, untrack } from 'svelte'
 	import type { App, AppViewerContext, InlineScript } from '$lib/components/apps/types'
 	import Tooltip from '$lib/components/Tooltip.svelte'
 	import { deepEqual } from 'fast-equals'
 	import { getAllGridItems } from '../../../appUtils'
 
-	export let triggerEvents: string[] = []
-	export let inlineScript: InlineScript | undefined = undefined
-	export let isFrontend: boolean = false
-	export let dependencies: string[] = []
-	export let shoudlDisplayChangeEvents: boolean = false
-	export let id: string
+	interface Props {
+		triggerEvents?: string[]
+		inlineScript?: InlineScript | undefined
+		isFrontend?: boolean
+		dependencies?: string[]
+		shoudlDisplayChangeEvents?: boolean
+		id: string
+	}
+
+	let {
+		triggerEvents = [],
+		inlineScript = $bindable(undefined),
+		isFrontend = false,
+		dependencies = [],
+		shoudlDisplayChangeEvents = false,
+		id
+	}: Props = $props()
 
 	const { connectingInput, app, stateId } = getContext<AppViewerContext>('AppViewerContext')
 
-	let onSuccessEvents: string[] = []
-
-	$: computeOnSuccessEvents($app, id)
+	let onSuccessEvents: string[] = $state([])
 
 	function computeOnSuccessEvents(app: App, _id: string) {
 		const nr: string[] = []
@@ -47,16 +56,6 @@
 		})
 		onSuccessEvents = nr
 	}
-	$: changeEvents = isFrontend
-		? inlineScript?.refreshOn
-			? inlineScript.refreshOn.map((x) => `${x.id}.${x.key}`)
-			: []
-		: dependencies
-
-	$: hasNoTriggers =
-		triggerEvents.length === 0 &&
-		(changeEvents.length === 0 || !shoudlDisplayChangeEvents) &&
-		onSuccessEvents.length == 0
 
 	const badgeClass = 'inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium border'
 	const colors = {
@@ -87,6 +86,24 @@
 		inlineScript = inlineScript
 		$app = $app
 	}
+	$effect(() => {
+		;[app, id]
+		untrack(() => {
+			computeOnSuccessEvents($app, id)
+		})
+	})
+	let changeEvents = $derived(
+		isFrontend
+			? inlineScript?.refreshOn
+				? inlineScript.refreshOn.map((x) => `${x.id}.${x.key}`)
+				: []
+			: dependencies
+	)
+	let hasNoTriggers = $derived(
+		triggerEvents.length === 0 &&
+			(changeEvents.length === 0 || !shoudlDisplayChangeEvents) &&
+			onSuccessEvents.length == 0
+	)
 </script>
 
 {#if hasNoTriggers}
@@ -118,7 +135,7 @@
 					{#if isFrontend}
 						<button
 							class="bg-blue-300 ml-2 p-0.5 rounded-md hover:bg-blue-400 cursor-pointer"
-							on:click={() => {
+							onclick={() => {
 								if (inlineScript?.refreshOn) {
 									inlineScript.refreshOn = inlineScript.refreshOn.filter(
 										(x) => `${x.id}.${x.key}` !== changeEvent
@@ -173,7 +190,7 @@
 							'p-0.5 rounded-md hover:bg-blue-400 cursor-pointer !text-2xs text-secondary',
 							badgeClass
 						)}
-						on:click={() => {
+						onclick={() => {
 							if (inlineScript) {
 								if (!itemsExists(inlineScript.refreshOn, suggestion)) {
 									inlineScript.refreshOn = [...(inlineScript.refreshOn ?? []), suggestion]

--- a/frontend/src/lib/components/apps/editor/settingsPanel/secondaryMenu/SecondaryMenu.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/secondaryMenu/SecondaryMenu.svelte
@@ -5,10 +5,14 @@
 	import { zIndexes } from '$lib/zIndexes'
 	import DocLink from '../DocLink.svelte'
 
-	export let right: boolean
+	interface Props {
+		right: boolean
+	}
+
+	let { right }: Props = $props()
 
 	let secondaryMenu = right ? secondaryMenuRight : secondaryMenuLeft
-	let width: number
+	let width: number | undefined = $state()
 </script>
 
 <div
@@ -39,7 +43,8 @@
 				{#if typeof $secondaryMenu.component === 'string'}
 					{@html $secondaryMenu.component}
 				{:else}
-					<svelte:component this={$secondaryMenu.component} {...$secondaryMenu.props} />
+					{@const SvelteComponent = $secondaryMenu.component}
+					<SvelteComponent {...$secondaryMenu.props} />
 				{/if}
 			</div>
 		</div>

--- a/frontend/src/lib/components/apps/gridUtils.ts
+++ b/frontend/src/lib/components/apps/gridUtils.ts
@@ -1,3 +1,4 @@
+import { writable } from 'svelte/store'
 import type { GridItem } from './types'
 
 type ColumnConfiguration = [number, number][]
@@ -6,6 +7,9 @@ const Breakpoints = {
 	sm: 640,
 	lg: 1024
 }
+
+export const moveMode = writable<'move' | 'insert'>('move')
+
 
 const WIDE_GRID_COLUMNS = 12 as const
 const NARROW_GRID_COLUMNS = 3 as const

--- a/frontend/src/lib/components/apps/svelte-grid/MoveResize.svelte
+++ b/frontend/src/lib/components/apps/svelte-grid/MoveResize.svelte
@@ -10,6 +10,7 @@
 		type GridShadow
 	} from '../editor/appUtils'
 	import { throttle } from './utils/other'
+	import { moveMode } from '../gridUtils'
 
 	const dispatch = createEventDispatcher()
 
@@ -31,7 +32,6 @@
 		onTop: any
 		shadow?: { x: number; y: number; w: number; h: number } | undefined
 		overlapped?: string | undefined
-		moveMode?: 'move' | 'insert'
 		type?: string | undefined
 		fakeShadow?: GridShadow | undefined
 		disableMove?: boolean
@@ -64,7 +64,6 @@
 		onTop,
 		shadow = $bindable(undefined),
 		overlapped = undefined,
-		moveMode = 'move',
 		type = undefined,
 		fakeShadow = undefined,
 		disableMove = true,
@@ -288,7 +287,7 @@
 		const { clientX, clientY } = event
 		const cordDiff = { x: (clientX / $scale) * 100 - initX, y: (clientY / $scale) * 100 - initY }
 
-		if (moveMode === 'move') {
+		if ($moveMode === 'move') {
 			onMove({
 				cordDiff,
 				clientY,
@@ -545,7 +544,7 @@
 				} transform: translate(${left}px, ${top}px); `} "
 >
 	{@render children?.()}
-	{#if moveMode === 'move' && !disableMove}
+	{#if $moveMode === 'move' && !disableMove}
 		<div class="svlt-grid-resizer-bottom" onpointerdown={(e) => resizePointerDown(e, 'vertical')}
 		></div>
 		<div class="svlt-grid-resizer-side" onpointerdown={(e) => resizePointerDown(e, 'horizontal')}
@@ -558,7 +557,7 @@
 	<div
 		class={twMerge(
 			'svlt-grid-shadow shadow-active',
-			shouldDisplayShadow(moveMode, overlapped) ? '' : 'hidden'
+			shouldDisplayShadow($moveMode, overlapped) ? '' : 'hidden'
 		)}
 		style="width: {shadow.w * xPerPx - gapX * 2}px; height: {shadow.h * yPerPx -
 			gapY * 2}px; transform: translate({shadow.x * xPerPx + gapX}px, {shadow.y * yPerPx +

--- a/frontend/src/lib/components/apps/svelte-select/lib/ConditionalPortal.svelte
+++ b/frontend/src/lib/components/apps/svelte-select/lib/ConditionalPortal.svelte
@@ -4,15 +4,20 @@
 
 	import type { AppViewerContext } from '../../types'
 
-	export let condition = false
+	interface Props {
+		condition?: boolean
+		children?: import('svelte').Snippet
+	}
+
+	let { condition = false, children }: Props = $props()
 
 	const { mode } = getContext<AppViewerContext>('AppViewerContext')
 
-	$: target = $mode === 'preview' ? '#app-editor-select' : 'body'
+	let target = $derived($mode === 'preview' ? '#app-editor-select' : 'body')
 </script>
 
 {#if condition}
-	<Portal name="conditional-portal-select" {target}><slot /></Portal>
+	<Portal name="conditional-portal-select" {target}>{@render children?.()}</Portal>
 {:else}
-	<slot />
+	{@render children?.()}
 {/if}

--- a/frontend/src/lib/components/apps/svelte-select/lib/ConditionalPortalGlobal.svelte
+++ b/frontend/src/lib/components/apps/svelte-select/lib/ConditionalPortalGlobal.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
 	import Portal from '$lib/components/Portal.svelte'
 
-	export let condition = false
+	interface Props {
+		condition?: boolean
+		children?: import('svelte').Snippet
+	}
+
+	let { condition = false, children }: Props = $props()
 </script>
 
 {#if condition}
-	<Portal name="conditional-portal-global"><slot /></Portal>
+	<Portal name="conditional-portal-global">{@render children?.()}</Portal>
 {:else}
-	<slot />
+	{@render children?.()}
 {/if}

--- a/frontend/src/lib/components/raw_apps/RawAppInlineScriptPanelList.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppInlineScriptPanelList.svelte
@@ -9,8 +9,12 @@
 	import type { Runnable } from '../apps/inputType'
 	import { getNextId } from '$lib/components/flows/idUtils'
 
-	export let selectedRunnable: string | undefined
-	export let runnables: Writable<Record<string, Runnable>>
+	interface Props {
+		selectedRunnable: string | undefined
+		runnables: Writable<Record<string, Runnable>>
+	}
+
+	let { selectedRunnable = $bindable(), runnables }: Props = $props()
 
 	function createBackgroundScript() {
 		const nid = getNextId(Object.keys($runnables ?? {}))
@@ -30,7 +34,7 @@
 </script>
 
 <PanelSection title="Backend Runnables" id="app-editor-runnable-panel">
-	<svelte:fragment slot="action">
+	{#snippet action()}
 		<div class="flex flex-row gap-1">
 			<HideButton
 				direction="bottom"
@@ -54,7 +58,7 @@
 				<Plus size={14} class="!text-primary" />
 			</Button>
 		</div>
-	</svelte:fragment>
+	{/snippet}
 	<div class="w-full flex flex-col gap-6 py-1">
 		<div>
 			<div class="flex flex-col gap-1 w-full">
@@ -67,7 +71,7 @@
 								{selectedRunnable === id
 									? 'border-blue-500 bg-blue-100 dark:bg-frost-900/50'
 									: 'hover:bg-blue-50 dark:hover:bg-frost-900/50'}"
-								on:click={() => (selectedRunnable = id)}
+								onclick={() => (selectedRunnable = id)}
 							>
 								<span class="text-2xs truncate">{runnable?.name}</span>
 								<Badge color="indigo">{id}</Badge>

--- a/frontend/src/lib/components/wizards/NavbarWizard.svelte
+++ b/frontend/src/lib/components/wizards/NavbarWizard.svelte
@@ -11,9 +11,16 @@
 	import Alert from '../common/alert/Alert.svelte'
 	import OneOfInputSpecsEditor from '../apps/editor/settingsPanel/OneOfInputSpecsEditor.svelte'
 
-	export let value: NavbarItem
+	interface Props {
+		value: NavbarItem
+		trigger?: import('svelte').Snippet
+	}
+
+	let { value = $bindable(), trigger }: Props = $props()
 
 	const { selectedComponent } = getContext<AppViewerContext>('AppViewerContext')
+
+	const trigger_render = $derived(trigger)
 </script>
 
 <Popover
@@ -25,10 +32,10 @@
 	closeButton
 	contentClasses="p-4 max-h-[70vh] overflow-y-auto"
 >
-	<svelte:fragment slot="trigger">
-		<slot name="trigger" />
-	</svelte:fragment>
-	<svelte:fragment slot="content">
+	{#snippet trigger()}
+		{@render trigger_render?.()}
+	{/snippet}
+	{#snippet content()}
 		{#if value}
 			<Section label="Navbar item" class="flex flex-col gap-2 w-80 overflow-y-auto max-h-screen">
 				<InputsSpecEditor
@@ -133,5 +140,5 @@
 				</Label>
 			</Section>
 		{/if}
-	</svelte:fragment>
+	{/snippet}
 </Popover>

--- a/frontend/src/lib/components/wizards/TableActionsWizard.svelte
+++ b/frontend/src/lib/components/wizards/TableActionsWizard.svelte
@@ -12,11 +12,23 @@
 		CheckboxComponent,
 		SelectComponent
 	} from '../apps/editor/component'
-	export let actionsOrder: RichConfiguration | undefined = undefined
-	export let selectedId: string | undefined = undefined
-	export let components:
-		| (BaseAppComponent & (ButtonComponent | CheckboxComponent | SelectComponent))[]
-		| undefined
+	interface Props {
+		actionsOrder?: RichConfiguration | undefined
+		selectedId?: string | undefined
+		components:
+			| (BaseAppComponent & (ButtonComponent | CheckboxComponent | SelectComponent))[]
+			| undefined
+		trigger?: import('svelte').Snippet
+	}
+
+	let {
+		actionsOrder = $bindable(undefined),
+		selectedId = undefined,
+		components,
+		trigger
+	}: Props = $props()
+
+	const trigger_render = $derived(trigger)
 </script>
 
 <Popover
@@ -27,15 +39,15 @@
 	}}
 	closeButton
 >
-	<svelte:fragment slot="trigger">
-		<slot name="trigger" />
-	</svelte:fragment>
-	<svelte:fragment slot="content">
+	{#snippet trigger()}
+		{@render trigger_render?.()}
+	{/snippet}
+	{#snippet content()}
 		<div class="w-96">
 			<PanelSection
 				title={`Manage actions programmatically`}
 				tooltip="
-		You can manage the order of the actions programmatically: You need to return an array of action ids in the order you want them to appear in the table. You can also hide actions by not including them in the array."
+			You can manage the order of the actions programmatically: You need to return an array of action ids in the order you want them to appear in the table. You can also hide actions by not including them in the array."
 			>
 				<div class="w-full flex gap-2 flex-col mt-2">
 					{#if actionsOrder}
@@ -93,5 +105,5 @@
 				</div>
 			</PanelSection>
 		</div>
-	</svelte:fragment>
+	{/snippet}
 </Popover>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Migrate app editor components to Svelte 5, updating reactivity, state management, and event handling across multiple components.
> 
>   - **Migration to Svelte 5**:
>     - Refactor components to use Svelte 5 reactivity model (`$state`, `$effect`, `$derived`).
>     - Replace `$:` with `$effect` for reactive statements.
>     - Use `@render` for slot rendering in components.
>   - **Components Updated**:
>     - `WorkspaceFlowList.svelte`, `WorkspaceScriptList.svelte`, `BackgroundScriptSettings.svelte`, `ComponentScriptSettings.svelte`, `Grid.svelte`, `MoveResize.svelte`, `ConditionalPortal.svelte`, `RawAppInlineScriptPanelList.svelte`, `NavbarWizard.svelte`, `TableActionsWizard.svelte`.
>     - Introduce `Props` interface for component props typing.
>   - **State Management**:
>     - Use `$state` for local state management.
>     - Use `$derived` for computed values.
>   - **Event Handling**:
>     - Use `stopPropagation` and `createBubbler` for event handling.
>   - **Miscellaneous**:
>     - Update grid utilities to support new move modes (`move` and `insert`).
>     - Adjust component styles and transitions to align with Svelte 5.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 8320a7e2e8ef16fcb4ddf3ba74cd64bdf92484a7. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->