### PR TITLE
nit: remove Assistants button for Nushell

### DIFF
--- a/frontend/src/lib/components/EditorBar.svelte
+++ b/frontend/src/lib/components/EditorBar.svelte
@@ -719,7 +719,7 @@ JsonNode ${windmillPathToCamelCaseName(path)} = JsonNode.Parse(await client.GetS
 			{/if}
 
 			{#if customUi?.assistants != false}
-				{#if lang == 'deno' || lang == 'python3' || lang == 'go' || lang == 'bash' || lang == 'nu'}
+				{#if lang == 'deno' || lang == 'python3' || lang == 'go' || lang == 'bash'}
 					<Button
 						aiId="editor-bar-reload-assistants"
 						aiDescription="Reload assistants"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes the Assistants button for Nushell scripts in `EditorBar.svelte`.
> 
>   - **Behavior**:
>     - Removes 'nu' from the list of languages that show the Assistants button in `EditorBar.svelte`.
>     - Affects the UI for Nushell scripts, removing the Assistants button when `lang` is 'nu'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 190905e6f988d6fe42edaff456b786407849ef7e. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->