### PR TITLE
internal: add ee ref command

### DIFF
--- a/.github/workflows/git-commands.yaml
+++ b/.github/workflows/git-commands.yaml
@@ -152,6 +152,7 @@ jobs:
           echo "${{ steps.get-commit-hash.outputs.commit_hash }}" > backend/ee-repo-ref.txt
           echo "Updated backend/ee-repo-ref.txt with commit hash: ${{ steps.get-commit-hash.outputs.commit_hash }}"
           # commit and push the changes
+          PR_NUMBER=${{ github.event.issue.number }}
           BRANCH_NAME=$(gh pr view $PR_NUMBER --json headRefName --jq .headRefName)
           echo "Checking out PR branch: $BRANCH_NAME"
           git checkout $BRANCH_NAME
@@ -159,7 +160,7 @@ jobs:
           git config --local user.name "GitHub Action"
           git add backend/ee-repo-ref.txt
           git commit -m "Update ee-repo-ref.txt"
-          git push origin ${{ github.event.issue.pull_request.head.ref }}
+          git push origin $BRANCH_NAME
 
       - name: Comment on PR - Completed
         uses: actions/github-script@v6

--- a/.github/workflows/git-commands.yaml
+++ b/.github/workflows/git-commands.yaml
@@ -1,4 +1,4 @@
-name: Update SQLx
+name: Git commands
 
 on:
   issue_comment:
@@ -102,4 +102,73 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: 'Successfully ran sqlx update'
+            })
+
+  update-ee-ref:
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/eeref')
+    runs-on: ubicloud-standard-2
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Comment on PR - Starting
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Starting ee ref update...'
+            })
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.issue.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Checkout windmill-ee-private
+        uses: actions/checkout@v3
+        with:
+          repository: windmill-labs/windmill-ee-private
+          path: windmill-ee-private
+          token: ${{ secrets.WINDMILL_EE_PRIVATE_ACCESS }}
+
+      - name: Get last commit hash of private-repo
+        id: get-commit-hash
+        run: |
+          cd windmill-ee-private
+          COMMIT_HASH=$(git rev-parse HEAD)
+          echo "commit_hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
+          echo "Latest commit hash: $COMMIT_HASH"
+
+      - name: Update ee-repo-ref.txt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "${{ steps.get-commit-hash.outputs.commit_hash }}" > backend/ee-repo-ref.txt
+          echo "Updated backend/ee-repo-ref.txt with commit hash: ${{ steps.get-commit-hash.outputs.commit_hash }}"
+          # commit and push the changes
+          BRANCH_NAME=$(gh pr view $PR_NUMBER --json headRefName --jq .headRefName)
+          echo "Checking out PR branch: $BRANCH_NAME"
+          git checkout $BRANCH_NAME
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add backend/ee-repo-ref.txt
+          git commit -m "Update ee-repo-ref.txt"
+          git push origin ${{ github.event.issue.pull_request.head.ref }}
+
+      - name: Comment on PR - Completed
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Successfully updated ee-repo-ref.txt'
             })

--- a/.github/workflows/git-commands.yaml
+++ b/.github/workflows/git-commands.yaml
@@ -159,7 +159,7 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add backend/ee-repo-ref.txt
-          git commit -m "Update ee-repo-ref.txt"
+          git commit -m "Update ee-repo-ref.txt" || echo "No changes to commit"
           git push origin $BRANCH_NAME
 
       - name: Comment on PR - Completed


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `update-ee-ref` job to update commit hash in `backend/ee-repo-ref.txt` and renames workflow file to `git-commands.yaml`.
> 
>   - **Workflows**:
>     - Renames `.github/workflows/update-sqlx.yaml` to `.github/workflows/git-commands.yaml`.
>     - Adds `update-ee-ref` job to `git-commands.yaml` to update `backend/ee-repo-ref.txt` with the latest commit hash from `windmill-ee-private`.
>     - Triggers `update-ee-ref` on issue comments starting with `/eeref`.
>   - **Behavior**:
>     - Comments on PR at start and completion of `update-ee-ref` job.
>     - Checks out the repository and `windmill-ee-private` to retrieve the latest commit hash.
>     - Updates and commits `backend/ee-repo-ref.txt` with the new hash, then pushes changes to the PR branch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 9d9ba1f937523d15ff7c8070dbb587471e7e23bb. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->