### PR TITLE
fix: correctly set selected step editor code when reverting to snapshot

### DIFF
--- a/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
@@ -115,6 +115,19 @@
 			if (snapshot) {
 				flowStore.val = snapshot
 				refreshStateStore(flowStore)
+
+				if ($currentEditor) {
+					const module = getModule($currentEditor.stepId, snapshot)
+					if (module) {
+						if ($currentEditor.type === 'script' && module.value.type === 'rawscript') {
+							$currentEditor.editor.setCode(module.value.content)
+						} else if ($currentEditor.type === 'iterator' && module.value.type === 'forloopflow') {
+							$currentEditor.editor.setCode(
+								module.value.iterator.type === 'javascript' ? module.value.iterator.expr : ''
+							)
+						}
+					}
+				}
 			}
 		},
 		showModuleDiff(id: string) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes editor code update when reverting to a snapshot in `FlowAIChat.svelte`, handling `script` and `iterator` types correctly.
> 
>   - **Behavior**:
>     - In `FlowAIChat.svelte`, updates the editor code when reverting to a snapshot.
>     - Handles `script` type with `rawscript` module and `iterator` type with `forloopflow` module.
>     - Sets editor code to module content or iterator expression based on type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 3aafafc3b3258cfcdff7185be909adf33ce7b298. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->