### PR TITLE
Fix resource picker auto select if single choice

### DIFF
--- a/frontend/src/lib/components/ResourcePicker.svelte
+++ b/frontend/src/lib/components/ResourcePicker.svelte
@@ -85,11 +85,7 @@
 	}
 
 	let loading = $state(true)
-	async function loadResources(
-		resourceType: string | undefined,
-		initialValue: string | undefined,
-		value: string | undefined
-	) {
+	async function loadResources(resourceType: string | undefined) {
 		loading = true
 		try {
 			const resourceTypesToQuery =
@@ -130,12 +126,8 @@
 	}
 
 	$effect(() => {
-		$workspaceStore &&
-			loadResources(
-				resourceType,
-				untrack(() => initialValue),
-				untrack(() => value)
-			)
+		$workspaceStore && resourceType
+		untrack(() => loadResources(resourceType))
 	})
 
 	let appConnect: AppConnect | undefined = $state()
@@ -144,7 +136,7 @@
 
 <AppConnect
 	on:refresh={async (e) => {
-		await loadResources(resourceType, initialValue, value)
+		await loadResources(resourceType)
 		value = e.detail
 		valueType = collection.find((x) => x?.value == value)?.type
 	}}
@@ -154,7 +146,7 @@
 <ResourceEditorDrawer
 	bind:this={resourceEditor}
 	on:refresh={async (e) => {
-		await loadResources(resourceType, initialValue, value)
+		await loadResources(resourceType)
 		if (e.detail) {
 			value = e.detail
 			valueType = collection.find((x) => x?.value == value)?.type
@@ -240,7 +232,7 @@
 			btnClasses="w-8 px-0.5 py-1.5"
 			size="sm"
 			on:click={() => {
-				loadResources(resourceType, initialValue, value)
+				loadResources(resourceType)
 			}}
 			startIcon={{ icon: RotateCw }}
 			iconOnly

--- a/frontend/src/lib/components/ResourcePicker.svelte
+++ b/frontend/src/lib/components/ResourcePicker.svelte
@@ -127,6 +127,7 @@
 
 	$effect(() => {
 		$workspaceStore && resourceType
+		value = undefined
 		untrack(() => loadResources(resourceType))
 	})
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Simplifies `loadResources` function in `ResourcePicker.svelte` by removing unused parameters and updating its calls.
> 
>   - **Behavior**:
>     - Simplifies `loadResources` function in `ResourcePicker.svelte` by removing `initialValue` and `value` parameters.
>     - Resets `value` to `undefined` before calling `loadResources` in `$effect`.
>   - **Function Calls**:
>     - Updates calls to `loadResources` in `ResourcePicker.svelte` to use the simplified signature.
>     - Ensures `loadResources` is called with only `resourceType` in `AppConnect` and `ResourceEditorDrawer` event handlers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 1ee929a0910f2dea3af57caa6d52ca3856da613b. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->