### PR TITLE
Fix reading undefined schema in SchemaForm

### DIFF
--- a/frontend/src/lib/components/SchemaForm.svelte
+++ b/frontend/src/lib/components/SchemaForm.svelte
@@ -226,8 +226,8 @@
 	})
 
 	$effect.pre(() => {
-		schema.order
-		Object.keys(schema.properties ?? {})
+		schema?.order
+		Object.keys(schema?.properties ?? {})
 		schema && (untrack(() => reorder()), (hidden = {}))
 	})
 	$effect.pre(() => {
@@ -236,7 +236,7 @@
 		if (args && typeof args == 'object') {
 			let oneShowExpr = false
 			for (const key of fields) {
-				if (schema.properties?.[key.value]?.showExpr) {
+				if (schema?.properties?.[key.value]?.showExpr) {
 					oneShowExpr = true
 				}
 			}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes handling of undefined schema in `SchemaForm.svelte` by adding optional chaining to prevent errors.
> 
>   - **Behavior**:
>     - Fixes handling of undefined `schema` in `SchemaForm.svelte` by adding optional chaining to `schema.order` and `schema.properties`.
>     - Ensures `schema.properties[key.value].showExpr` is accessed safely with optional chaining.
>   - **Misc**:
>     - No changes to logic or additional features, purely a bug fix for undefined schema access.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 23f677c8722ee77d8f364c5123f669fa145acbad. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->