### PR TITLE
whitelabel sdk light

### DIFF
--- a/frontend/src/lib/components/FlowWrapper.svelte
+++ b/frontend/src/lib/components/FlowWrapper.svelte
@@ -17,7 +17,7 @@
 	if (light) {
 		setTimeout(() => {
 			trialRender = false
-		}, 5)
+		}, 1000 * 300)
 	}
 </script>
 

--- a/frontend/src/lib/components/FlowWrapper.svelte
+++ b/frontend/src/lib/components/FlowWrapper.svelte
@@ -3,11 +3,33 @@
 	import type { FlowBuilderProps } from './flow_builder'
 	import FlowBuilder from './FlowBuilder.svelte'
 
-	let { flowStore: oldFlowStore, disableAi, ...props }: FlowBuilderProps = $props()
+	let {
+		flowStore: oldFlowStore,
+		disableAi,
+		light,
+		...props
+	}: FlowBuilderProps & { light?: boolean } = $props()
 
 	let flowStore = $state(oldFlowStore)
+
+	let trialRender = $state(true)
+
+	if (light) {
+		setTimeout(() => {
+			trialRender = false
+		}, 5)
+	}
 </script>
 
-<AiChatLayout noPadding={true} {disableAi}>
-	<FlowBuilder {flowStore} {disableAi} {...props} />
-</AiChatLayout>
+{#if trialRender}
+	<AiChatLayout noPadding={true} {disableAi}>
+		{#if light}<div class="bg-red-500 absolute z-10">Trial version</div>{/if}
+		<FlowBuilder {flowStore} {disableAi} {...props} />
+	</AiChatLayout>
+{:else}
+	<div class="flex flex-col items-center justify-center h-screen">
+		<div class="text-2xl font-bold"
+			>Windmill Whitelabel SDK is in trial mode and disabled itself after 5 minutes</div
+		>
+	</div>
+{/if}

--- a/frontend/src/lib/components/flows/header/FlowYamlEditor.svelte
+++ b/frontend/src/lib/components/flows/header/FlowYamlEditor.svelte
@@ -10,15 +10,22 @@
 	import { sendUserToast } from '$lib/toast'
 	import { Loader2 } from 'lucide-svelte'
 	import { refreshStateStore } from '$lib/svelte5Utils.svelte'
+	import SimpleEditor from '../../SimpleEditor.svelte'
 
-	const { flowStore } = getContext<FlowEditorContext>('FlowEditorContext')
+	const { flowStore } = $state(getContext<FlowEditorContext>('FlowEditorContext'))
 
-	export let drawer: Drawer | undefined
+	interface Props {
+		drawer: Drawer | undefined
+	}
 
-	let code = ''
+	let { drawer = $bindable() }: Props = $props()
+
+	let code = $state('')
+	let editor = $state(undefined) as SimpleEditor | undefined
 
 	function reload() {
 		code = YAML.stringify(filteredContentForExport(flowStore.val))
+		editor?.setCode(code)
 	}
 
 	function apply() {
@@ -46,6 +53,7 @@
 			flowStore.val.schema = parsed.schema
 			flowStore.val.tag = parsed.tag
 			refreshStateStore(flowStore)
+			sendUserToast('Changes applied')
 		} catch (e) {
 			sendUserToast('Error parsing yaml: ' + e), true
 		}
@@ -63,7 +71,7 @@
 			{#await import('../../SimpleEditor.svelte')}
 				<Loader2 class="animate-spin" />
 			{:then Module}
-				<Module.default autoHeight bind:code lang="yaml" />
+				<Module.default bind:this={editor} autoHeight bind:code lang="yaml" />
 			{/await}
 		{/if}
 	</DrawerContent>

--- a/frontend/src/routes/test_dev/sdk_flow/+page.svelte
+++ b/frontend/src/routes/test_dev/sdk_flow/+page.svelte
@@ -41,6 +41,7 @@
 <!-- <ScriptWrapper {script} neverShowMeta={true} {customUi} /> -->
 
 <FlowWrapper
+	light
 	disableAi
 	pathStoreInit="u/foo/bar"
 	{customUi}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces 'light' mode in `FlowWrapper` for trial version display and enhances `FlowYamlEditor` with direct code manipulation and user feedback.
> 
>   - **FlowWrapper.svelte**:
>     - Introduces `light` mode, which displays a trial version banner and disables the component after 5 minutes.
>     - Adds conditional rendering based on `trialRender` state.
>   - **FlowYamlEditor.svelte**:
>     - Binds `SimpleEditor` instance to `editor` variable for direct code manipulation.
>     - Adds `sendUserToast` notification on successful YAML parsing and application.
>   - **sdk_flow/+page.svelte**:
>     - Utilizes `light` mode in `FlowWrapper` to test trial version behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 6fd1ec6352b7af6815d4a2cac34ffb04015d1451. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->