### PR TITLE
fix: set urllib user-agent header in loader.py (cloudflare block)

### DIFF
--- a/backend/windmill-worker/loader.py
+++ b/backend/windmill-worker/loader.py
@@ -31,7 +31,10 @@ class WindmillFinder(MetaPathFinder):
             import urllib.parse
             import urllib.request
 
-            headers = {"Authorization": f"Bearer {os.environ.get('WM_TOKEN')}"}
+            headers = {
+                "Authorization": f"Bearer {os.environ.get('WM_TOKEN')}",
+                "User-Agent": "windmill/beta"
+            }
             url = f"{os.environ.get('BASE_INTERNAL_URL')}/api/w/{os.environ.get('WM_WORKSPACE')}/scripts/raw/p/{script_path}.py"
 
             req = urllib.request.Request(url, None, headers)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `User-Agent` header to HTTP requests in `find_spec` method of `WindmillFinder` class in `loader.py` to prevent Cloudflare blocking.
> 
>   - **Behavior**:
>     - Adds `User-Agent: windmill/beta` to HTTP request headers in `find_spec` method of `WindmillFinder` class in `loader.py` to prevent Cloudflare blocking.
>   - **Misc**:
>     - No other changes or refactoring in the file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for d75498d265e65d93d3036b0dbe91c74625b45e07. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->