### PR TITLE
feat(frontend): app static and user resource picker default values

### DIFF
--- a/frontend/src/lib/components/LightweightResourcePicker.svelte
+++ b/frontend/src/lib/components/LightweightResourcePicker.svelte
@@ -1,40 +1,37 @@
 <script lang="ts">
 	import { ResourceService } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
-	import { createEventDispatcher, getContext } from 'svelte'
+	import { getContext, untrack } from 'svelte'
 	import DarkModeObserver from './DarkModeObserver.svelte'
 	import { Button, Drawer, DrawerContent } from './common'
 	import { Plus, Loader2, Link2Off } from 'lucide-svelte'
 	import type { AppViewerContext } from './apps/types'
 	import { sendUserToast } from '$lib/toast'
-	import { createDispatcherIfMounted } from '$lib/createDispatcherIfMounted'
 	import Select from './select/Select.svelte'
 
-	const dispatch = createEventDispatcher()
-	const dispatchIfMounted = createDispatcherIfMounted(dispatch)
+	interface Props {
+		value: string | undefined
+		resourceType?: string | undefined
+		disablePortal?: boolean
+		expressOAuthSetup?: boolean
+		disabled?: boolean
+	}
 
-	export let initialValue: string | undefined = undefined
-	export let value: string | undefined = initialValue
-	export let resourceType: string | undefined = undefined
-	export let disablePortal = false
-	export let expressOAuthSetup = false
-	export let disabled = false
+	let {
+		value = $bindable(),
+		resourceType = undefined,
+		disablePortal = false,
+		expressOAuthSetup = false,
+		disabled = false
+	}: Props = $props()
 
-	let open = false
-	let refreshCount = 0
+	let open = $state(false)
+	let refreshCount = $state(0)
 	const appViewerContext = getContext<AppViewerContext>('AppViewerContext')
 
-	let valueSelect =
-		initialValue || value
-			? {
-					value: value ?? initialValue,
-					label: value ?? initialValue
-				}
-			: undefined
+	let collection = $state(value ? [{ value, label: value }] : [])
 
-	let collection = valueSelect ? [valueSelect] : []
-
-	let loading = true
+	let loading = $state(true)
 	async function loadResources(resourceType: string | undefined) {
 		loading = true
 		try {
@@ -49,26 +46,25 @@
 			}))
 
 			// TODO check if this is needed
-			if (!nc.find((x) => x.value == value) && (initialValue || value)) {
-				nc.push({ value: value ?? initialValue!, label: value ?? initialValue! })
+			if (!nc.find((x) => x.value == value) && value) {
+				nc.push({ value: value, label: value })
 			}
 			collection = nc
 			if (expressOAuthSetup && nc.length > 0) {
 				value = nc[0].value
-				valueSelect = nc[0]
 			}
 		} finally {
 			loading = false
 		}
 	}
 
-	$: $workspaceStore && loadResources(resourceType)
+	$effect(() => {
+		$workspaceStore && resourceType && untrack(() => loadResources(resourceType))
+	})
 
-	$: dispatchIfMounted('change', value)
+	let darkMode: boolean = $state(false)
 
-	let darkMode: boolean = false
-
-	let drawer: Drawer | undefined = undefined
+	let drawer: Drawer | undefined = $state(undefined)
 
 	export function askNewResource() {
 		refreshCount += 1
@@ -93,7 +89,6 @@
 					on:refresh={async (e) => {
 						await loadResources(resourceType)
 						value = e.detail
-						valueSelect = { value, label: value }
 						open = false
 					}}
 				/>
@@ -121,7 +116,6 @@
 					on:refresh={async (e) => {
 						await loadResources(resourceType)
 						value = e.detail
-						valueSelect = { value, label: value }
 						drawer?.closeDrawer?.()
 						open = false
 					}}
@@ -157,7 +151,6 @@
 						const item = collection[0]
 						if (item) {
 							value = item.value
-							valueSelect = item
 						}
 					}}>Use existing</Button
 				>
@@ -167,15 +160,13 @@
 				{disabled}
 				{disablePortal}
 				bind:value={
-					() => valueSelect?.value,
+					() => value,
 					(v) => {
 						value = v
-						valueSelect = collection.find((x) => x.value === v)
 					}
 				}
 				onClear={() => {
 					value = undefined
-					valueSelect = undefined
 				}}
 				clearable
 				items={collection}
@@ -184,7 +175,7 @@
 			/>
 		{/if}
 		<div class="flex gap-1 items-center">
-			{#if valueSelect && expressOAuthSetup}
+			{#if value && expressOAuthSetup}
 				<Button
 					{disabled}
 					color="light"
@@ -193,15 +184,13 @@
 					btnClasses="w-8 px-0.5 py-1.5"
 					iconOnly
 					on:click={async () => {
-						if (valueSelect && valueSelect.label) {
-							value = undefined
+						if (value) {
 							await ResourceService.deleteResource({
 								workspace: appViewerContext?.workspace ?? $workspaceStore,
-								path: valueSelect.label
+								path: value
 							})
-							await loadResources(resourceType)
 							value = undefined
-							valueSelect = undefined
+							await loadResources(resourceType)
 						}
 					}}
 					startIcon={{ icon: Link2Off }}

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -1648,8 +1648,8 @@ export const components = {
 							backgroundColor: ['#FF6384', '#4BC0C0', '#FFCE56']
 						}
 					]
-				},
-			},
+				}
+			}
 		}
 	},
 	chartjscomponentv2: {
@@ -1687,9 +1687,8 @@ export const components = {
 							backgroundColor: ['#FF6384', '#4BC0C0', '#FFCE56']
 						}
 					]
-				},
-
-			},
+				}
+			}
 		}
 	},
 	barchartcomponent: {
@@ -1859,8 +1858,7 @@ This is a paragraph.
 							width: 2.5
 						}
 					}
-				},
-
+				}
 			},
 			configuration: {
 				layout: {
@@ -1893,7 +1891,7 @@ This is a paragraph.
 							width: 2.5
 						}
 					}
-				},
+				}
 			},
 			configuration: {
 				layout: {
@@ -1904,8 +1902,7 @@ This is a paragraph.
 						'Layout options for the plot. See https://plotly.com/javascript/reference/layout/ for more information'
 				}
 			}
-		},
-
+		}
 	},
 	timeseriescomponent: {
 		name: 'Timeseries',
@@ -2431,6 +2428,12 @@ This is a paragraph.
 					allowTypeChange: false,
 					value: []
 				} as StaticAppInput,
+				defaultValue: {
+					type: 'static',
+					fieldType: 'text',
+					value: undefined,
+					tooltip: 'Format: $res:path/to/resource'
+				},
 				placeholder: {
 					type: 'static',
 					fieldType: 'text',
@@ -2467,6 +2470,12 @@ This is a paragraph.
 					type: 'static',
 					fieldType: 'text',
 					value: 'postgresql'
+				},
+				defaultValue: {
+					type: 'static',
+					fieldType: 'text',
+					value: undefined,
+					tooltip: 'Format: $res:path/to/resource'
 				},
 				expressOauthSetup: {
 					type: 'static',

--- a/frontend/src/routes/(root)/(logged)/apps/add/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps/add/+page.svelte
@@ -156,8 +156,8 @@
 	<div class="h-screen">
 		{#key value}
 			<AppEditor
-				on:savedNewAppPath={(event) => {
-					goto(`/apps/edit/${event.detail}`)
+				onSavedNewAppPath={(path) => {
+					goto(`/apps/edit/${path}`)
 				}}
 				{summary}
 				app={value}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance frontend resource pickers with reactive state management and default value handling.
> 
>   - **Behavior**:
>     - `LightweightResourcePicker.svelte` now uses reactive state management with `$state` for variables like `open`, `refreshCount`, `collection`, and `loading`.
>     - Default values for `value` and `resourceType` are handled using `$bindable()` and `$props()`.
>     - `AppUserResource.svelte` introduces `getDefaultValue()` to handle default values for user resources, updating `value` reactively.
>     - `components.ts` adds `defaultValue` configuration for `userresourcecomponent` and `resourceselectcomponent`.
>   - **Misc**:
>     - Event handling in `+page.svelte` is updated to use `onSavedNewAppPath` instead of `on:savedNewAppPath`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 11b18cf6211de15e6ab0d6866e0c5a3ab713451f. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->