### PR TITLE
fix(frontend): fix dev graph not loading

### DIFF
--- a/frontend/src/lib/components/Dev.svelte
+++ b/frontend/src/lib/components/Dev.svelte
@@ -113,7 +113,8 @@
 
 	// Flow preview
 	let flowPreviewButtons: FlowPreviewButtons | undefined = $state()
-	const job: Job | undefined = $derived(flowPreviewButtons?.getJob())
+	const flowPreviewContent = $derived(flowPreviewButtons?.getFlowPreviewContent())
+	const job: Job | undefined = $derived(flowPreviewContent?.getJob())
 	let showJobStatus = $state(false)
 	let testModuleId: string | undefined = $state(undefined)
 
@@ -572,13 +573,13 @@
 	})
 
 	const localModuleStates: Writable<Record<string, GraphModuleState>> = $derived(
-		flowPreviewButtons?.getLocalModuleStates() ?? writable({})
+		flowPreviewContent?.getLocalModuleStates() ?? writable({})
 	)
 	const localDurationStatuses: Writable<Record<string, DurationStatus>> = $derived(
-		flowPreviewButtons?.getLocalDurationStatuses() ?? writable({})
+		flowPreviewContent?.getLocalDurationStatuses() ?? writable({})
 	)
 	const suspendStatus: Writable<Record<string, { job: Job; nb: number }>> = $derived(
-		flowPreviewButtons?.getSuspendStatus() ?? writable({})
+		flowPreviewContent?.getSuspendStatus() ?? writable({})
 	)
 
 	// Create a derived store that only shows the module states when showModuleStatus is true
@@ -792,10 +793,10 @@
 								disableStaticInputs
 								localModuleStates={derivedModuleStates}
 								onTestUpTo={flowPreviewButtons?.testUpTo}
-								isOwner={flowPreviewButtons?.getIsOwner()}
+								isOwner={flowPreviewContent?.getIsOwner?.()}
 								onTestFlow={flowPreviewButtons?.runPreview}
-								isRunning={flowPreviewButtons?.getIsRunning()}
-								onCancelTestFlow={flowPreviewButtons?.cancelTest}
+								isRunning={flowPreviewContent?.getIsRunning?.()}
+								onCancelTestFlow={flowPreviewContent?.cancelTest}
 								onOpenPreview={flowPreviewButtons?.openPreview}
 								onHideJobStatus={resetModulesStates}
 								{individualStepTests}
@@ -825,7 +826,7 @@
 								}}
 								onTestFlow={flowPreviewButtons?.runPreview}
 								{job}
-								isOwner={flowPreviewButtons?.getIsOwner()}
+								isOwner={flowPreviewContent?.getIsOwner()}
 								{localDurationStatuses}
 								{suspendStatus}
 								onOpenDetails={flowPreviewButtons?.openPreview}

--- a/frontend/src/lib/components/Dev.svelte
+++ b/frontend/src/lib/components/Dev.svelte
@@ -634,6 +634,8 @@
 	const individualStepTests = $derived(
 		!(showJobStatus && job) && Object.keys($derivedModuleStates).length > 0
 	)
+
+	const flowHasChanged = $derived(flowPreviewContent?.flowHasChanged())
 </script>
 
 <svelte:window onkeydown={onKeyDown} />
@@ -805,6 +807,7 @@
 								onDelete={(id) => {
 									delete $derivedModuleStates[id]
 								}}
+								{flowHasChanged}
 							/>
 						{:else}
 							<div class="text-red-400 mt-20">Missing flow modules</div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `flowPreviewButtons` with `flowPreviewContent` for derived states and functions in `Dev.svelte` to fix the dev graph loading issue.
> 
>   - **Behavior**:
>     - Replace `flowPreviewButtons` with `flowPreviewContent` for derived states and functions in `Dev.svelte`.
>     - Affects `getJob()`, `getLocalModuleStates()`, `getLocalDurationStatuses()`, `getSuspendStatus()`, `getIsOwner()`, `getIsRunning()`, and `cancelTest()`.
>   - **Misc**:
>     - Add `flowHasChanged` derived state in `Dev.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 476b8fb3db6226af438926a0546744ffc0da050f. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->