### PR TITLE
fix: nested delete after use in flows

### DIFF
--- a/backend/.sqlx/query-4d66f509815a8af4b43abae7119ed377312a80ec08ca9a65cbb71a96ce5959b8.json
+++ b/backend/.sqlx/query-4d66f509815a8af4b43abae7119ed377312a80ec08ca9a65cbb71a96ce5959b8.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE v2_job_status\n                    SET flow_status = JSONB_SET(flow_status, ARRAY['cleanup_module', 'flow_jobs_to_clean'], COALESCE(flow_status->'cleanup_module'->'flow_jobs_to_clean', '[]'::jsonb) || $1)\n                    WHERE id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Jsonb",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4d66f509815a8af4b43abae7119ed377312a80ec08ca9a65cbb71a96ce5959b8"
+}

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -15,7 +15,8 @@ use crate::common::{cached_result_path, save_in_cache};
 use crate::js_eval::{eval_timeout, IdContext};
 use crate::worker_utils::get_tag_and_concurrency;
 use crate::{
-    JobCompletedSender, PreviousResult, SameWorkerSender, SendResultPayload, UpdateFlow, KEEP_JOB_DIR
+    JobCompletedSender, PreviousResult, SameWorkerSender, SendResultPayload, UpdateFlow,
+    KEEP_JOB_DIR,
 };
 
 use anyhow::Context;
@@ -1191,7 +1192,25 @@ pub async fn update_flow_status_after_job_completion_internal(
             append_logs(&flow_job.id, w_id, logs, &db.into()).await;
         }
         #[cfg(feature = "enterprise")]
-        if flow_job.parent_job.is_none() {
+        if let Some(parent_job) = flow_job.parent_job {
+            // if has parent job, append flow cleanup modules to parent job
+            if !_cleanup_module.flow_jobs_to_clean.is_empty() {
+                let uuids_json = serde_json::to_value(&_cleanup_module.flow_jobs_to_clean)
+                    .map_err(|e| {
+                        error::Error::internal_err(format!("Unable to serialize uuids: {e:#}"))
+                    })?;
+                sqlx::query!(
+                    "UPDATE v2_job_status
+                    SET flow_status = JSONB_SET(flow_status, ARRAY['cleanup_module', 'flow_jobs_to_clean'], COALESCE(flow_status->'cleanup_module'->'flow_jobs_to_clean', '[]'::jsonb) || $1)
+                    WHERE id = $2",
+                    uuids_json,
+                    parent_job
+                )
+                .execute(db)
+                .warn_after_seconds(3)
+                .await?;
+            }
+        } else {
             // run the cleanup step only when the root job is complete
             if !_cleanup_module.flow_jobs_to_clean.is_empty() {
                 tracing::debug!(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes nested job cleanup in flow processing by appending cleanup modules to parent jobs or handling at root job level in `worker_flow.rs`.
> 
>   - **Behavior**:
>     - In `worker_flow.rs`, `update_flow_status_after_job_completion_internal()` now appends cleanup modules to parent jobs if they exist, otherwise performs cleanup at the root job level.
>     - New SQL query added to `.sqlx/query-4d66f509815a8af4b43abae7119ed377312a80ec08ca9a65cbb71a96ce5959b8.json` for updating `v2_job_status` with cleanup modules.
>   - **Misc**:
>     - Minor formatting changes in `worker_flow.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for fbe68ef5d7644819e44c121ea1ecd2e165a13686. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->