### PR TITLE
fix batch rerun reactivity issue

### DIFF
--- a/frontend/src/lib/components/runs/BatchReRunOptionsPane.svelte
+++ b/frontend/src/lib/components/runs/BatchReRunOptionsPane.svelte
@@ -28,6 +28,7 @@
 	} from '$lib/components/jobs/batchReruns'
 	import Toggle from '../Toggle.svelte'
 	import { TriangleAlert } from 'lucide-svelte'
+	import { readFieldsRecursively } from '$lib/utils'
 
 	let {
 		selectedIds,
@@ -149,7 +150,10 @@
 				(options[selected.kind][selected.script_path]?.use_latest_version ?? false))
 	)
 
-	const jobGroupsPromise = $derived(selectedIds && untrack(() => fetchJobGroups()))
+	const jobGroupsPromise = $derived.by(() => {
+		readFieldsRecursively(selectedIds)
+		return untrack(() => fetchJobGroups())
+	})
 </script>
 
 <div class="flex-1 flex flex-col">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix reactivity issue in `BatchReRunOptionsPane.svelte` by modifying `jobGroupsPromise` derivation to track `selectedIds` changes.
> 
>   - **Reactivity Fix**:
>     - In `BatchReRunOptionsPane.svelte`, modify `jobGroupsPromise` derivation to include `readFieldsRecursively(selectedIds)` ensuring reactivity when `selectedIds` changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 76ef600e2a7d893875ec1318af7be35f74ab9424. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->