### PR TITLE
feat: windows memory and vcpu reading

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -14934,6 +14934,7 @@ dependencies = [
  "sqlx",
  "strum 0.27.1",
  "strum_macros 0.27.1",
+ "sysinfo",
  "systemstat",
  "tar",
  "tempfile",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -267,6 +267,7 @@ google-cloud-googleapis = {version = "0.16.1", features = ["pubsub"]}
 # TODO: remove once deno fixes the issue on their end
 # https://github.com/denoland/deno/issues/28557
 winapi = { version = "0.3.9", features = ["sysinfoapi"] }
+sysinfo = { version = "0.32.1" }
 
 swc_common = "=0.37.5"
 swc_ecma_parser = "=0.149.1"

--- a/backend/windmill-common/Cargo.toml
+++ b/backend/windmill-common/Cargo.toml
@@ -102,3 +102,6 @@ tonic = { workspace = true, optional = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemalloc-ctl = { optional = true, workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+sysinfo.workspace = true

--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -19,6 +19,8 @@ use std::{
     str::FromStr,
     sync::{atomic::AtomicBool, Arc},
 };
+#[cfg(windows)]
+use sysinfo::System;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 use windmill_macros::annotations;
@@ -759,6 +761,7 @@ fn write_binary_file(main_path: &str, byts: &mut bytes::Bytes) -> error::Result<
     Ok(())
 }
 
+#[cfg(not(windows))]
 fn get_cgroupv2_path() -> Option<String> {
     let cgroup_path: String = parse_file("/proc/self/cgroup")?;
 
@@ -767,6 +770,7 @@ fn get_cgroupv2_path() -> Option<String> {
         .map(|x| format!("/sys/fs/cgroup{}", x.get(1).unwrap().as_str()))
 }
 
+#[cfg(not(windows))]
 pub fn get_vcpus() -> Option<i64> {
     if Path::new("/sys/fs/cgroup/cpu/cpu.cfs_quota_us").exists() {
         // cgroup v1
@@ -792,6 +796,14 @@ pub fn get_vcpus() -> Option<i64> {
     }
 }
 
+#[cfg(windows)]
+pub fn get_vcpus() -> Option<i64> {
+    let mut sys = System::new();
+    sys.refresh_cpu_all();
+    (sys.cpus().len() * 100000).try_into().ok()
+}
+
+#[cfg(not(windows))]
 fn get_memory_from_meminfo() -> Option<i64> {
     let memory_info = parse_file::<String>("/proc/meminfo")?;
     if memory_info.contains("MemTotal") {
@@ -808,6 +820,7 @@ fn get_memory_from_meminfo() -> Option<i64> {
     None
 }
 
+#[cfg(not(windows))]
 pub fn get_memory() -> Option<i64> {
     let memory_limit: Option<i64> =
         if Path::new("/sys/fs/cgroup/memory/memory.limit_in_bytes").exists() {
@@ -832,6 +845,14 @@ pub fn get_memory() -> Option<i64> {
     }
 }
 
+#[cfg(windows)]
+pub fn get_memory() -> Option<i64> {
+    let mut sys = System::new();
+    sys.refresh_memory();
+    Some(sys.total_memory() as i64)
+}
+
+#[cfg(not(windows))]
 pub fn get_worker_memory_usage() -> Option<i64> {
     if Path::new("/sys/fs/cgroup/memory/memory.usage_in_bytes").exists() {
         // cgroup v1
@@ -867,6 +888,13 @@ pub fn get_worker_memory_usage() -> Option<i64> {
 
         Some(total_memory_usage - inactive_file)
     }
+}
+
+#[cfg(windows)]
+pub fn get_worker_memory_usage() -> Option<i64> {
+    let mut sys = System::new();
+    sys.refresh_memory();
+    Some(sys.used_memory() as i64)
 }
 
 pub fn get_windmill_memory_usage() -> Option<i64> {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add Windows-specific memory and vCPU reading using `sysinfo` in `worker.rs`, with conditional compilation for platform-specific code.
> 
>   - **Behavior**:
>     - Adds Windows-specific implementations for `get_vcpus()`, `get_memory()`, and `get_worker_memory_usage()` in `worker.rs` using `sysinfo`.
>     - Non-Windows implementations remain unchanged and are conditionally compiled.
>   - **Dependencies**:
>     - Adds `sysinfo` crate to `Cargo.toml` in `backend` and `windmill-common`.
>   - **Misc**:
>     - Conditional imports and function definitions in `worker.rs` to handle Windows and non-Windows separately.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f93d7e15d54c4cad5b3a33626849120a564901d0. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->