### PR TITLE
fix(frontend): correctly set flow initial job status on running preview

### DIFF
--- a/frontend/src/lib/components/FlowPreviewContent.svelte
+++ b/frontend/src/lib/components/FlowPreviewContent.svelte
@@ -122,7 +122,7 @@
 		args: Record<string, any>,
 		restartedFrom: RestartedFrom | undefined
 	) {
-		if (stepHistoryLoader?.flowJobInitial) {
+		if (stepHistoryLoader?.flowJobInitial !== false) {
 			stepHistoryLoader?.setFlowJobInitial(false)
 		}
 		try {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `runPreview` in `FlowPreviewContent.svelte` to correctly handle `flowJobInitial` state initialization.
> 
>   - **Behavior**:
>     - Fixes `runPreview` function in `FlowPreviewContent.svelte` to correctly check `stepHistoryLoader?.flowJobInitial !== false` before setting it to `false`.
>     - Ensures `flowJobInitial` is only set to `false` if it is not already `false`, preventing unnecessary state changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for bc35b3cf601fe69b9be42f57ae6f4091a33aab5d. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->