### PR TITLE
fix: app s3 multi upload policy

### DIFF
--- a/frontend/src/lib/components/ArgInput.svelte
+++ b/frontend/src/lib/components/ArgInput.svelte
@@ -26,7 +26,6 @@
 	import DateTimeInput from './DateTimeInput.svelte'
 	import DateInput from './DateInput.svelte'
 	import CurrencyInput from './apps/components/inputs/currency/CurrencyInput.svelte'
-	import FileUpload from './common/fileUpload/FileUpload.svelte'
 	import autosize from '$lib/autosize'
 	import PasswordArgInput from './PasswordArgInput.svelte'
 	import Password from './Password.svelte'
@@ -622,7 +621,7 @@
 		{:else if (inputCat == 'resource-object' && format && format.split('-').length > 1 && format
 				.replace('resource-', '')
 				.replace('_', '')
-				.toLowerCase() == 's3object') || (inputCat == 'list' && itemsType?.resourceType === 's3_object')}
+				.toLowerCase() == 's3object') || (inputCat == 'list' && (itemsType?.resourceType === 's3_object' || itemsType?.resourceType === 's3object'))}
 			<S3ArgInput
 				multiple={inputCat == 'list'}
 				bind:value
@@ -666,30 +665,6 @@
 								items={safeSelectItems(itemsType?.enum)}
 								onOpen={() => dispatch('focus')}
 								reorderable
-							/>
-						</div>
-					{:else if itemsType?.type == 'object' && itemsType?.resourceType == 's3object'}
-						<div class="w-full">
-							<FileUpload
-								{appPath}
-								computeForceViewerPolicies={computeS3ForceViewerPolicies}
-								{workspace}
-								allowMultiple={true}
-								randomFileKey={true}
-								on:addition={(evt) => {
-									value = [
-										...value,
-										{
-											s3: evt.detail?.path ?? '',
-											filename: evt.detail?.filename ?? ''
-										}
-									]
-								}}
-								on:deletion={(evt) => {
-									value = value.filter((v) => v.s3 !== evt.detail?.path)
-								}}
-								defaultValue={defaultValue?.map((v) => v.s3)}
-								initialValue={value}
 							/>
 						</div>
 					{:else}

--- a/frontend/src/lib/components/apps/editor/AppEditorHeader.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeader.svelte
@@ -321,16 +321,23 @@
 		if (
 			items.findIndex((x) => {
 				const c = x.data as AppComponent
-				if (c.type === 'schemaformcomponent') {
+				if (
+					c.type === 'schemaformcomponent' ||
+					c.type === 'formbuttoncomponent' ||
+					c.type === 'formcomponent'
+				) {
+					const props =
+						c.type === 'schemaformcomponent'
+							? (c.componentInput as any)?.value?.properties
+							: (c.componentInput as any)?.runnable?.type === 'runnableByName'
+								? (c.componentInput as any)?.runnable?.inlineScript?.schema?.properties
+								: (c.componentInput as any)?.runnable?.schema?.properties
 					return (
-						Object.values((c.componentInput as any)?.value?.properties ?? {}).findIndex(
-							(p: any) => p?.type === 'object' && p?.format === 'resource-s3_object'
-						) !== -1
-					)
-				} else if (c.type === 'formbuttoncomponent' || c.type === 'formcomponent') {
-					return (
-						Object.values((c.componentInput as any)?.fields ?? {}).findIndex(
-							(p: any) => p?.fieldType === 'object' && p?.format === 'resource-s3_object'
+						Object.values(props ?? {}).findIndex(
+							(p: any) =>
+								(p?.type === 'object' && p?.format === 'resource-s3_object') ||
+								(p?.type === 'array' &&
+									(p?.items?.resourceType === 's3object' || p?.items?.resourceType === 's3_object'))
 						) !== -1
 					)
 				} else {

--- a/frontend/src/lib/components/common/fileUpload/S3ArgInput.svelte
+++ b/frontend/src/lib/components/common/fileUpload/S3ArgInput.svelte
@@ -126,7 +126,7 @@
 					}
 				}
 			}}
-			defaultValue={defaultValue?.s3}
+			defaultValue={multiple ? defaultValue?.map((v) => v.s3) : defaultValue?.s3}
 			initialValue={value}
 		/>
 	{/if}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhances S3 object handling in `ArgInput.svelte` and `S3ArgInput.svelte`, and updates S3 input policy in `AppEditorHeader.svelte`.
> 
>   - **Behavior**:
>     - Adjusts S3 object handling in `ArgInput.svelte` to support both `s3_object` and `s3object` formats in list contexts.
>     - Removes `FileUpload` component handling for `s3object` in `ArgInput.svelte`.
>   - **Components**:
>     - Updates `S3ArgInput.svelte` to handle multiple S3 objects and raw mode input.
>     - Adds toggle for raw S3 object input in `S3ArgInput.svelte`.
>   - **Policy**:
>     - Updates S3 input policy handling in `AppEditorHeader.svelte` to include both `s3_object` and `s3object` formats.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 4a6fc9763495202565df7745dd61d2fde1b2e8b5. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->