### PR TITLE
feat(aichat): give completions to autocomplete for other languages than ts

### DIFF
--- a/frontend/src/lib/components/copilot/autocomplete/request.ts
+++ b/frontend/src/lib/components/copilot/autocomplete/request.ts
@@ -37,8 +37,6 @@ export async function autocompleteRequest(
 
 	context.prefix = contextLines + '\n' + context.prefix
 
-	console.log('context', context.prefix)
-
 	const providerModel = get(copilotInfo).codeCompletionModel
 
 	if (!providerModel) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `Autocompletor` to support autocompletion for languages beyond TypeScript using `MonacoLanguageClient`.
> 
>   - **Behavior**:
>     - `Autocompletor` now supports autocompletion for languages other than TypeScript by using `MonacoLanguageClient`.
>     - In `Editor.svelte`, `autocompletor.setLanguageClient()` is called for Python with `pyright` client.
>   - **Autocompletor Class**:
>     - Renamed constants for completion limits to `COMPLETIONS_MAX_RATIO` and `MAX_COMPLETIONS_DETAILS`.
>     - Added `#getLanguageClientCompletions()` to fetch completions using `MonacoLanguageClient`.
>     - Modified `#getCompletions()` to choose between TypeScript and other language completions based on `#scriptLang`.
>   - **Misc**:
>     - Adjusted `#autocomplete()` logic to handle new completion sources.
>     - Updated `#formatLanguageClientHelp()` to format help from language clients.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for dde7a3390c10a6d7c1b08cf5d222e68e07aa1392. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->