### PR TITLE
feat: enable workspace exclusion in custom tags

### DIFF
--- a/backend/windmill-api/src/workers.rs
+++ b/backend/windmill-api/src/workers.rs
@@ -150,7 +150,7 @@ async fn get_custom_tags(Query(query): Query<CustomTagQuery>) -> JsonResult<Vec<
         let workspace_tags = tags_o
             .1
             .iter()
-            .filter(|(_, workspaces)| workspaces.contains(&workspace))
+            .filter(|(_, tag_data)| tag_data.applies_to_workspace(&workspace))
             .map(|(tag, _)| tag.clone())
             .collect::<Vec<String>>();
         let all_tags = tags_o.0.clone();

--- a/backend/windmill-api/src/workers.rs
+++ b/backend/windmill-api/src/workers.rs
@@ -147,44 +147,12 @@ async fn get_custom_tags(Query(query): Query<CustomTagQuery>) -> JsonResult<Vec<
     }
     if let Some(workspace) = query.workspace {
         let tags_o = CUSTOM_TAGS_PER_WORKSPACE.read().await;
-        let workspace_tags = tags_o
-            .1
-            .iter()
-            .filter(|(_, tag_data)| tag_data.applies_to_workspace(&workspace))
-            .map(|(tag, _)| tag.clone())
-            .collect::<Vec<String>>();
-        let all_tags = tags_o.0.clone();
-        return Ok(Json(
-            all_tags
-                .into_iter()
-                .chain(workspace_tags.into_iter())
-                .collect(),
-        ));
+        let all_tags = tags_o.to_string_vec(Some(workspace));
+        return Ok(Json(all_tags));
     } else if query.show_workspace_restriction.is_some_and(|x| x) {
         let tags_o = CUSTOM_TAGS_PER_WORKSPACE.read().await;
-        let workspace_tags = tags_o
-            .1
-            .iter()
-            .map(|(tag, tag_data)| {
-                let separator = tag_data.tag_type.corresponding_separator();
-                let workspaces = tag_data.workspaces.join(&*separator.to_string());
-                match tag_data.tag_type {
-                    SpecificTagType::AllExcluding => {
-                        format!("{}({}{})", tag, separator, workspaces)
-                    }
-                    SpecificTagType::NoneExcept => {
-                        format!("{}({})", tag, workspaces)
-                    }
-                }
-            })
-            .collect::<Vec<String>>();
-        let all_tags = tags_o.0.clone();
-        return Ok(Json(
-            all_tags
-                .into_iter()
-                .chain(workspace_tags.into_iter())
-                .collect(),
-        ));
+        let all_tags = tags_o.to_string_vec(None);
+        return Ok(Json(all_tags));
     }
     Ok(Json(ALL_TAGS.read().await.clone().into()))
 }

--- a/backend/windmill-common/src/jobs.rs
+++ b/backend/windmill-common/src/jobs.rs
@@ -663,10 +663,9 @@ pub async fn check_tag_available_for_workspace_internal(
     }
 
     let custom_tags_per_w = CUSTOM_TAGS_PER_WORKSPACE.read().await;
-    let (global_tags, specific_tags) = (&custom_tags_per_w.0, &custom_tags_per_w.1);
-    if global_tags.contains(&tag.to_string()) {
+    if custom_tags_per_w.global.contains(&tag.to_string()) {
         is_tag_in_workspace_custom_tags = true;
-    } else if let Some(specific_tag) = specific_tags.get(tag) {
+    } else if let Some(specific_tag) = custom_tags_per_w.specific.get(tag) {
         is_tag_in_workspace_custom_tags = specific_tag.applies_to_workspace(w_id);
     }
 

--- a/backend/windmill-common/src/jobs.rs
+++ b/backend/windmill-common/src/jobs.rs
@@ -663,16 +663,11 @@ pub async fn check_tag_available_for_workspace_internal(
     }
 
     let custom_tags_per_w = CUSTOM_TAGS_PER_WORKSPACE.read().await;
-    if custom_tags_per_w.0.contains(&tag.to_string()) {
+    let (global_tags, specific_tags) = (&custom_tags_per_w.0, &custom_tags_per_w.1);
+    if global_tags.contains(&tag.to_string()) {
         is_tag_in_workspace_custom_tags = true;
-    } else if custom_tags_per_w.1.contains_key(tag)
-        && custom_tags_per_w
-            .1
-            .get(tag)
-            .unwrap()
-            .contains(&w_id.to_string())
-    {
-        is_tag_in_workspace_custom_tags = true;
+    } else if let Some(specific_tag) = specific_tags.get(tag) {
+        is_tag_in_workspace_custom_tags = specific_tag.applies_to_workspace(w_id);
     }
 
     match is_tag_in_scope_tags {

--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -81,7 +81,7 @@ impl CustomTags {
                 .map(|(tag, tag_data)| {
                     let separator = tag_data.tag_type.corresponding_separator();
                     let mut workspaces = tag_data.workspaces.join(&*separator.to_string());
-                    if tag_data.tag_type != SpecificTagType::AllExcluding {
+                    if tag_data.tag_type == SpecificTagType::AllExcluding {
                         // the AllExcluding tag syntax has a leading separator
                         workspaces.insert(0, separator);
                     }
@@ -1767,7 +1767,7 @@ mod tests {
         let input = vec![
             "global".to_string(),
             "feat(ws1+ws2)".to_string(),
-            "hotfix(^ws3)".to_string(),
+            "hotfix(^ws3^ws4)".to_string(),
         ];
         let result = CustomTags::from(input);
 
@@ -1785,7 +1785,7 @@ mod tests {
             "hotfix".to_string(),
             SpecificTagData {
                 tag_type: SpecificTagType::AllExcluding,
-                workspaces: vec!["ws3".to_string()],
+                workspaces: vec!["ws3".to_string(), "ws4".to_string()],
             },
         );
 
@@ -1891,7 +1891,7 @@ mod tests {
             result,
             vec![
                 "foo",
-                "urgent(+ws1+ws2)", // Note leading `+` for NoneExcept
+                "urgent(ws1+ws2)",
                 "legacy(^ws1^ws2)"
             ]
         );

--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -1717,50 +1717,6 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    #[test]
-    fn test_global_tag_only() {
-        let input = vec!["global-tag".to_string()];
-        let result = CustomTags::from(input);
-
-        assert_eq!(result.global, vec!["global-tag"]);
-        assert!(result.specific.is_empty());
-    }
-
-    #[test]
-    fn test_specific_tag_none_except() {
-        let input = vec!["feature(ws1+ws2)".to_string()];
-        let result = CustomTags::from(input);
-
-        let mut expected = HashMap::new();
-        expected.insert(
-            "feature".to_string(),
-            SpecificTagData {
-                tag_type: SpecificTagType::NoneExcept,
-                workspaces: vec!["ws1".to_string(), "ws2".to_string()],
-            },
-        );
-
-        assert!(result.global.is_empty());
-        assert_eq!(result.specific, expected);
-    }
-
-    #[test]
-    fn test_specific_tag_all_excluding() {
-        let input = vec!["bugfix(^ws3^ws4)".to_string()];
-        let result = CustomTags::from(input);
-
-        let mut expected = HashMap::new();
-        expected.insert(
-            "bugfix".to_string(),
-            SpecificTagData {
-                tag_type: SpecificTagType::AllExcluding,
-                workspaces: vec!["ws3".to_string(), "ws4".to_string()],
-            },
-        );
-
-        assert!(result.global.is_empty());
-        assert_eq!(result.specific, expected);
-    }
 
     #[test]
     fn test_mixed_tags() {

--- a/frontend/src/lib/components/AssignableTagsInner.svelte
+++ b/frontend/src/lib/components/AssignableTagsInner.svelte
@@ -96,6 +96,11 @@
 			></span
 		>
 		<span class="text-2xs text-tertiary"
+			>To exclude 'workspace1' and 'workspace2' from a tag, use <pre
+				class="inline">tag(^workspace1^workspace2)</pre
+			></span
+		>
+		<span class="text-2xs text-tertiary"
 			>For dynamic tags based on the workspace, use <pre class="inline">$workspace</pre>, e.g:
 			<pre class="inline">tag-$workspace</pre></span
 		>


### PR DESCRIPTION
- This PR enables excluding some workspace from a tag, using the `tag(^workspace1^workspace2)` syntax.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enable workspace exclusion in custom tags using `tag(^workspace1^workspace2)` syntax, with backend and frontend updates to support and display this feature.
> 
>   - **Behavior**:
>     - Enable workspace exclusion in custom tags using `tag(^workspace1^workspace2)` syntax in `workers.rs` and `jobs.rs`.
>     - Update `get_custom_tags()` in `workers.rs` to handle new syntax.
>     - Update `check_tag_available_for_workspace_internal()` in `jobs.rs` to support exclusion logic.
>   - **Models**:
>     - Add `SpecificTagData` and `SpecificTagType` in `worker.rs` to represent tag types and workspace lists.
>     - Update `CUSTOM_TAGS_PER_WORKSPACE` to use `SpecificTagData`.
>   - **Regex**:
>     - Update `CUSTOM_TAG_REGEX` in `worker.rs` to support exclusion syntax.
>   - **Frontend**:
>     - Update `AssignableTagsInner.svelte` to display new syntax for excluding workspaces.
>   - **Tests**:
>     - Add tests in `worker.rs` to verify new tag exclusion functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 18f17f3c41ac8e234946933533bc9581474f761b. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->