### PR TITLE
fix: add windir env var to pwsh for legacy modules like AD

### DIFF
--- a/backend/windmill-worker/src/bash_executor.rs
+++ b/backend/windmill-worker/src/bash_executor.rs
@@ -742,7 +742,10 @@ $env:PSModulePath = \"{};$PSModulePathBackup\"",
         && job
             .runnable_path
             .as_ref()
-            .map(|x| !x.starts_with(INIT_SCRIPT_PATH_PREFIX) && !x.starts_with(PERIODIC_SCRIPT_PATH_PREFIX))
+            .map(|x| {
+                !x.starts_with(INIT_SCRIPT_PATH_PREFIX)
+                    && !x.starts_with(PERIODIC_SCRIPT_PATH_PREFIX)
+            })
             .unwrap_or(true);
     let child = if nsjail {
         let _ = write_file(
@@ -808,6 +811,7 @@ $env:PSModulePath = \"{};$PSModulePathBackup\"",
         #[cfg(windows)]
         {
             cmd.env("SystemRoot", SYSTEM_ROOT.as_str())
+                .env("WINDIR", SYSTEM_ROOT.as_str())
                 .env(
                     "LOCALAPPDATA",
                     std::env::var("LOCALAPPDATA")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `WINDIR` environment variable for PowerShell on Windows in `bash_executor.rs` to support legacy modules.
> 
>   - **Environment Variables**:
>     - Add `WINDIR` environment variable in `bash_executor.rs` for PowerShell execution on Windows.
>     - Ensures compatibility with legacy modules like Active Directory that require `WINDIR`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f1e127e211e75ab8eb7f242be6cf0de1e05113ab. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->