### PR TITLE
fix: improve error handler behavior wrt to parrallel branchall & forloops

### DIFF
--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -100,8 +100,10 @@ pub async fn update_flow_status_after_job_completion(
         stop_early_override,
         skip_error_handler: false,
     };
+    tracing::error!("update_flow_status_after_job_completion: {rec:#?}");
     let mut unrecoverable = unrecoverable;
     loop {
+        tracing::error!("loop");
         potentially_crash_for_testing();
         let nrec = match update_flow_status_after_job_completion_internal(
             db,
@@ -182,6 +184,7 @@ pub enum UpdateFlowStatusAfterJobCompletion {
     NonLastParallelBranch,
     PreprocessingStep,
 }
+#[derive(Debug)]
 pub struct RecUpdateFlowStatusAfterJobCompletion {
     flow: uuid::Uuid,
     job_id_for_status: Uuid,
@@ -1356,7 +1359,7 @@ pub async fn update_flow_status_after_job_completion_internal(
                         } else {
                             None
                         },
-                        skip_error_handler: skip_error_handler || is_failure_step,
+                        skip_error_handler: true,
                     },
                 ));
             }

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -656,8 +656,12 @@ pub async fn update_flow_status_after_job_completion_internal(
                         "parallel iteration {job_id_for_status} of flow {flow} has finished",
                     );
 
+                    // for parallel branchall and forloop, we do not want to trigger the error handler again at the forloop/branchall node since it was already triggered at the leaf level
+                    // so we want to ignore the has_triggered_error_handler flag at the forloop/branchall node and reset it based on if the node is a success or failure
                     if !success && flow_value.failure_module.is_some() {
                         has_triggered_error_handler = true;
+                    } else {
+                        has_triggered_error_handler = false;
                     }
                     (success, Some(new_status))
                 } else {

--- a/frontend/src/lib/components/flows/map/InsertModuleButton.svelte
+++ b/frontend/src/lib/components/flows/map/InsertModuleButton.svelte
@@ -88,7 +88,10 @@ shouldUsePortal={true} -->
 			{#if kind === 'trigger'}
 				<SchedulePollIcon size={14} />
 			{:else if kind === 'failure'}
-				<Bug size={14} />
+				<div class="flex items-center gap-1">
+					<Bug size={14} />
+					<span class="text-xs w-20">Error Handler</span>
+				</div>
 			{:else}
 				<Cross size={iconSize} />
 			{/if}

--- a/frontend/src/lib/components/graph/graphBuilder.svelte.ts
+++ b/frontend/src/lib/components/graph/graphBuilder.svelte.ts
@@ -821,7 +821,6 @@ export function graphBuilder(
 							type: 'branchOneStart'
 						}
 
-
 						nodes.push(defaultBranch)
 
 						addEdge(module.id, defaultBranch.id, { rootId: module.id, branch: 0 }, prefix, {
@@ -884,7 +883,7 @@ export function graphBuilder(
 						let expanded = expandedSubflows[module.id]
 						if (expanded) {
 							expanded = $state.snapshot(expanded)
-							const startId = `${module.id}-subflow-start`
+							const startId = `${module.id}`
 							const idWithoutPrefix = module.id.startsWith('subflow:')
 								? module.id.substring(8)
 								: module.id


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improve error handling in backend flow status updates and enhance frontend UI for error handlers in flow maps.
> 
>   - **Backend**:
>     - Rename `skip_error_handler` to `has_triggered_error_handler` in `worker_flow.rs`.
>     - Modify logic in `update_flow_status_after_job_completion_internal()` to reset `has_triggered_error_handler` for parallel `branchall` and `forloop` nodes.
>     - Filter jobs in parallel branches to exclude those with `skip_failure` set to true.
>   - **Frontend**:
>     - Update `InsertModuleButton.svelte` to display "Error Handler" label next to the bug icon for failure modules.
>     - Remove redundant code in `graphBuilder.svelte.ts` related to subflow start IDs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 8b2760c14a71df8f1db63125f029b25288691ee9. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->