### PR TITLE
Use backwards-compatible union type syntax in Python client

### DIFF
--- a/python-client/wmill/wmill/s3_reader.py
+++ b/python-client/wmill/wmill/s3_reader.py
@@ -1,11 +1,11 @@
 from io import BufferedReader, BytesIO
-from json import JSONDecodeError
+from typing import Optional, Union
 
 import httpx
 
 
 class S3BufferedReader(BufferedReader):
-    def __init__(self, workspace: str, windmill_client: httpx.Client, file_key: str, s3_resource_path: str | None, storage: str | None):
+    def __init__(self, workspace: str, windmill_client: httpx.Client, file_key: str, s3_resource_path: Optional[str], storage: Optional[str]):
         params = {
             "file_key": file_key,
         }
@@ -61,7 +61,7 @@ class S3BufferedReader(BufferedReader):
         self._context_manager.__exit__(*args)
 
 
-def bytes_generator(buffered_reader: BufferedReader | BytesIO):
+def bytes_generator(buffered_reader: Union[BufferedReader, BytesIO]):
     while True:
         byte = buffered_reader.read(50 * 1024)
         if not byte:

--- a/python-client/wmill/wmill/s3_types.py
+++ b/python-client/wmill/wmill/s3_types.py
@@ -1,7 +1,10 @@
+from typing import Optional
+
+
 class S3Object(dict):
     s3: str
-    storage: str | None
-    presigned: str | None
+    storage: Optional[str]
+    presigned: Optional[str]
 
     def __getattr__(self, attr):
         return self[attr]


### PR DESCRIPTION
Some of our Python code has a hard dependency on Python 3.9. The Windmill client works just fine in Python 3.9, but some of the type declarations use the `|` union syntax introduced in 3.10. This PR replaces union type declarations with backwards-compatible `Optional` and `Union`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace Python 3.10 union type syntax with backwards-compatible `Optional` and `Union` in `s3_reader.py` and `s3_types.py`.
> 
>   - **Type Declarations**:
>     - Replace `s3_resource_path: str | None` and `storage: str | None` with `Optional[str]` in `S3BufferedReader.__init__()` in `s3_reader.py`.
>     - Replace `buffered_reader: BufferedReader | BytesIO` with `Union[BufferedReader, BytesIO]` in `bytes_generator()` in `s3_reader.py`.
>     - Replace `storage: str | None` and `presigned: str | None` with `Optional[str]` in `S3Object` in `s3_types.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for c80aba66a366b1efa3a596c307d52c930ba7f73a. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->