### PR TITLE
internal: remove duplicate caching

### DIFF
--- a/.github/workflows/backend-check.yml
+++ b/.github/workflows/backend-check.yml
@@ -21,9 +21,6 @@ jobs:
         with:
           cache-workspaces: backend
           toolchain: 1.88.0
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: backend
       - name: cargo check
         working-directory: ./backend
         timeout-minutes: 16
@@ -45,9 +42,6 @@ jobs:
         with:
           cache-workspaces: backend
           toolchain: 1.88.0
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: backend
       - name: cargo check
         working-directory: ./backend
         timeout-minutes: 16
@@ -82,9 +76,6 @@ jobs:
         with:
           cache-workspaces: backend
           toolchain: 1.88.0
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: backend
       - name: cargo check
         working-directory: ./backend
         timeout-minutes: 16
@@ -122,9 +113,6 @@ jobs:
         with:
           cache-workspaces: backend
           toolchain: 1.88.0
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: backend
       - name: cargo check
         timeout-minutes: 16
         working-directory: ./backend

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -52,9 +52,6 @@ jobs:
         with:
           cache-workspaces: backend
           toolchain: 1.85.0
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: backend
       - name: cargo test
         timeout-minutes: 16
         run:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -84,10 +84,6 @@ jobs:
           cache-workspaces: backend
           toolchain: 1.88.0
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: backend
-
       - name: cargo check
         working-directory: ./backend
         timeout-minutes: 16


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove duplicate caching steps from GitHub workflows to streamline execution.
> 
>   - **Workflows**:
>     - Remove duplicate `Swatinem/rust-cache@v2` caching steps from `backend-check.yml`, `backend-test.yml`, and `claude.yml`.
>     - Retain `actions-rust-lang/setup-rust-toolchain@v1` caching in all workflows.
>   - **Files Affected**:
>     - `.github/workflows/backend-check.yml`: Removed redundant caching in four job definitions.
>     - `.github/workflows/backend-test.yml`: Removed redundant caching in `cargo_test` job.
>     - `.github/workflows/claude.yml`: Removed redundant caching in `claude-code-action` job.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 74dc8218cf1f67cef0e1c82be12c8eb3f7ed4407. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->