### PR TITLE
default to false if field not present operator settings

### DIFF
--- a/backend/windmill-api/src/workspaces.rs
+++ b/backend/windmill-api/src/workspaces.rs
@@ -2326,15 +2326,25 @@ pub async fn mute_critical_alerts() -> Error {
 
 #[derive(Deserialize, Serialize)]
 struct ChangeOperatorSettings {
+    #[serde(default)]
     runs: bool,
+    #[serde(default)]
     schedules: bool,
+    #[serde(default)]
     resources: bool,
+    #[serde(default)]
     variables: bool,
+    #[serde(default)]
     assets: bool,
+    #[serde(default)]
     triggers: bool,
+    #[serde(default)]
     audit_logs: bool,
+    #[serde(default)]
     groups: bool,
+    #[serde(default)]
     folders: bool,
+    #[serde(default)]
     workers: bool,
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `#[serde(default)]` to `ChangeOperatorSettings` fields in `workspaces.rs` to default to `false` if not present.
> 
>   - **Struct Changes**:
>     - Added `#[serde(default)]` to fields in `ChangeOperatorSettings` in `workspaces.rs`.
>     - Fields affected: `runs`, `schedules`, `resources`, `variables`, `assets`, `triggers`, `audit_logs`, `groups`, `folders`, `workers`.
>   - **Behavior**:
>     - Fields in `ChangeOperatorSettings` default to `false` if not present in input JSON.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for b04e953aa9d0598144d556e20bcf268cfe005443. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->