### PR TITLE
fix: fix typo on cli build script

### DIFF
--- a/cli/build.sh
+++ b/cli/build.sh
@@ -16,7 +16,7 @@ add_ts_extensions() {
         cp "$file" "$file.orig"
         
         # Add .ts to relative imports that don't already have extensions
-        gsed -E \
+        sed -E \
             -e 's/(from[[:space:]]+["'"'"'])(\.[^"'"'"']*[^./][^"'"'"']*)(["'"'"'])/\1\2.ts\3/g' \
             -e 's/(import[[:space:]]+["'"'"'])(\.[^"'"'"']*[^./][^"'"'"']*)(["'"'"'])/\1\2.ts\3/g' \
             "$file.orig" > "$file"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes a typo in `cli/build.sh`, replacing `gsed` with `sed` in the `add_ts_extensions` function.
> 
>   - **Fix**:
>     - Corrects a typo in `cli/build.sh`, replacing `gsed` with `sed` in the `add_ts_extensions` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 065a54529a93eb6b143ca7efb0ffa4074e5ef435. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->