### PR TITLE
fix: delete empty git connection

### DIFF
--- a/backend/windmill-api/src/workspaces.rs
+++ b/backend/windmill-api/src/workspaces.rs
@@ -1154,8 +1154,10 @@ async fn delete_git_sync_repository(
 ) -> Result<String> {
     require_admin(is_admin, &username)?;
 
-    // Validate the resource path format
-    validate_git_repo_resource_path(&request.git_repo_resource_path)?;
+    // For deletion, only validate that path is not empty to allow cleanup of malformed entries
+    if request.git_repo_resource_path.is_empty() {
+        return Err(Error::BadRequest("Resource path cannot be empty".to_string()));
+    }
 
     let mut tx = db.begin().await?;
 

--- a/frontend/src/lib/components/git_sync/GitSyncContext.svelte.ts
+++ b/frontend/src/lib/components/git_sync/GitSyncContext.svelte.ts
@@ -192,7 +192,7 @@ export function createGitSyncContext(workspace: string) {
 		)
 
 		// Only call backend API if repository exists in the saved state
-		if (existsInInitialState && repo.git_repo_resource_path) {
+		if (existsInInitialState) {
 			await WorkspaceService.deleteGitSyncRepository({
 				workspace,
 				requestBody: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix deletion of git sync repositories by checking for empty resource paths in the backend and removing unnecessary checks in the frontend.
> 
>   - **Backend Changes**:
>     - In `workspaces.rs`, `delete_git_sync_repository()` now checks if `git_repo_resource_path` is empty and returns a `BadRequest` error if so.
>   - **Frontend Changes**:
>     - In `GitSyncContext.svelte.ts`, `removeRepository()` no longer checks if `git_repo_resource_path` is present before calling `deleteGitSyncRepository()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for bce2ca61312eef107317301eca4f9fc6afa6f994. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->