### PR TITLE
fix(cli): revert renaming of inline scripts

### DIFF
--- a/cli/metadata.ts
+++ b/cli/metadata.ts
@@ -20,7 +20,7 @@ import {
 } from "./script_common.ts";
 import { inferContentTypeFromFilePath } from "./script_common.ts";
 import { GlobalDeps, exts, findGlobalDeps } from "./script.ts";
-import { FSFSElement, findCodebase, yamlOptions } from "./sync.ts";
+import { FSFSElement, findCodebase, newPathAssigner, yamlOptions } from "./sync.ts";
 import { generateHash, readInlinePathSync } from "./utils.ts";
 import { SyncCodebase } from "./codebase.ts";
 import { FlowFile } from "./flow.ts";
@@ -190,7 +190,9 @@ export async function generateFlowLockInternal(
     const inlineScripts = extractInlineScriptsForFlows(
       flowValue.value.modules,
       {},
-      SEP
+      SEP,
+      opts.defaultTs,
+      newPathAssigner(opts.defaultTs ?? "bun")
     );
     inlineScripts
       .filter((s) => s.path.endsWith(".lock"))

--- a/cli/sync.ts
+++ b/cli/sync.ts
@@ -328,7 +328,8 @@ export function extractInlineScriptsForApps(rec: any, pathAssigner: PathAssigner
     return Object.entries(rec).flatMap(([k, v]) => {
       if (k == "inlineScript" && typeof v == "object") {
         const o: Record<string, any> = v as any;
-        const [basePath, ext] = assignPath(rec["id"], o["language"]);
+        const name = o["name"];
+        const [basePath, ext] = pathAssigner.assignPath(name, o["language"]);
         const r = [];
         if (o["content"]) {
           const content = o["content"];

--- a/cli/sync.ts
+++ b/cli/sync.ts
@@ -320,7 +320,7 @@ export interface InlineScript {
   content: string;
 }
 
-export function extractInlineScriptsForApps(rec: any): InlineScript[] {
+export function extractInlineScriptsForApps(rec: any, pathAssigner: PathAssigner): InlineScript[] {
   if (!rec) {
     return [];
   }
@@ -348,7 +348,7 @@ export function extractInlineScriptsForApps(rec: any): InlineScript[] {
         }
         return r;
       } else {
-        return extractInlineScriptsForApps(v);
+        return extractInlineScriptsForApps(v, pathAssigner);
       }
     });
   }
@@ -401,7 +401,9 @@ function ZipFSElement(
             const inlineScripts = extractInlineScriptsForFlows(
               flow.value.modules,
               {},
-              SEP
+              SEP,
+              defaultTs,
+              newPathAssigner(defaultTs)
             );
             for (const s of inlineScripts) {
               yield {
@@ -426,7 +428,7 @@ function ZipFSElement(
             };
           } else if (kind == "app") {
             const app = JSON.parse(await f.async("text"));
-            const inlineScripts = extractInlineScriptsForApps(app?.["value"]);
+            const inlineScripts = extractInlineScriptsForApps(app?.["value"], newPathAssigner(defaultTs));
             for (const s of inlineScripts) {
               yield {
                 isDirectory: false,
@@ -2122,5 +2124,66 @@ const command = new Command()
   )
   // deno-lint-ignore no-explicit-any
   .action(push as any);
+
+  interface PathAssigner {
+    assignPath(summary: string | undefined, language: string): [string, string];
+  }
+  const INLINE_SCRIPT = "inline_script";
+
+  export function newPathAssigner(defaultTs: "bun" | "deno"): PathAssigner {
+    let counter = 0;
+    const seen_names = new Set<string>();
+    function assignPath(
+      summary: string | undefined,
+      language: string
+    ): [string, string] {
+      let name;
+  
+      name = summary?.toLowerCase()?.replaceAll(" ", "_") ?? "";
+  
+      let original_name = name;
+  
+      if (name == "") {
+        original_name = INLINE_SCRIPT;
+        name = `${INLINE_SCRIPT}_0`;
+      }
+  
+      while (seen_names.has(name)) {
+        counter++;
+        name = `${original_name}_${counter}`;
+      }
+      seen_names.add(name);
+  
+      let ext;
+      if (language == "python3") ext = "py";
+      else if (language == defaultTs || language == "bunnative") ext = "ts";
+      else if (language == "bun") ext = "bun.ts";
+      else if (language == "deno") ext = "deno.ts";
+      else if (language == "go") ext = "go";
+      else if (language == "bash") ext = "sh";
+      else if (language == "powershell") ext = "ps1";
+      else if (language == "postgresql") ext = "pg.sql";
+      else if (language == "mysql") ext = "my.sql";
+      else if (language == "bigquery") ext = "bq.sql";
+      else if (language == "oracledb") ext = "odb.sql";
+      else if (language == "snowflake") ext = "sf.sql";
+      else if (language == "mssql") ext = "ms.sql";
+      else if (language == "graphql") ext = "gql";
+      else if (language == "nativets") ext = "native.ts";
+      else if (language == "frontend") ext = "frontend.js";
+      else if (language == "php") ext = "php";
+      else if (language == "rust") ext = "rs";
+      else if (language == "csharp") ext = "cs";
+      else if (language == "nu") ext = "nu";
+      else if (language == "ansible") ext = "playbook.yml";
+      else if (language == "java") ext = "java";
+      else if (language == "duckdb") ext = "duckdb.sql";
+      // for related places search: ADD_NEW_LANG
+      else ext = "no_ext";
+  
+      return [`${name}.inline_script.`, ext];
+    }
+    return { assignPath };
+  }
 
 export default command;

--- a/cli/sync.ts
+++ b/cli/sync.ts
@@ -328,7 +328,7 @@ export function extractInlineScriptsForApps(rec: any, pathAssigner: PathAssigner
     return Object.entries(rec).flatMap(([k, v]) => {
       if (k == "inlineScript" && typeof v == "object") {
         const o: Record<string, any> = v as any;
-        const name = o["name"];
+        const name = rec["name"];
         const [basePath, ext] = pathAssigner.assignPath(name, o["language"]);
         const r = [];
         if (o["content"]) {

--- a/cli/windmill-utils-internal/src/inline-scripts/extractor.ts
+++ b/cli/windmill-utils-internal/src/inline-scripts/extractor.ts
@@ -20,15 +20,26 @@ interface InlineScript {
  * @param defaultTs - Default TypeScript runtime to use ("bun" or "deno")
  * @returns Array of inline scripts with their paths and content
  */
+
+interface PathAssigner {
+  assignPath(summary: string | undefined, language: string): [string, string];
+}
+const INLINE_SCRIPT = "inline_script";
 export function extractInlineScripts(
   modules: FlowModule[],
   mapping: Record<string, string> = {},
   separator: string = "/",
-  defaultTs?: "bun" | "deno"
+  defaultTs?: "bun" | "deno",
+  pathAssigner?: PathAssigner
 ): InlineScript[] {
   return modules.flatMap((m) => {
     if (m.value.type == "rawscript") {
-      const [basePath, ext] = assignPath(m.id, m.value.language, defaultTs);
+      let basePath, ext;
+      if (pathAssigner) {
+        [basePath, ext] = pathAssigner.assignPath(m.summary, m.value.language);
+      } else {
+        [basePath, ext] = assignPath(m.id, m.value.language, defaultTs);
+      }
       const path = mapping[m.id] ?? basePath + ext;
       const content = m.value.content;
       const r = [{ path: path, content: content }];

--- a/cli/windmill-utils-internal/src/inline-scripts/replacer.ts
+++ b/cli/windmill-utils-internal/src/inline-scripts/replacer.ts
@@ -52,32 +52,32 @@ export async function replaceInlineScripts(
           }
 
           // rename the file if the prefix is different from the module id (fix old naming)
-          if (pathPrefix != module.id && renamer) {
-            logger.info(`Renaming ${path} to ${module.id}.${pathSuffix}`);
-            try {
-              renamer(localPath + path, localPath + module.id + "." + pathSuffix);
-            } catch {
-              logger.info(`Failed to rename ${path} to ${module.id}.${pathSuffix}`);
-            }
-          }
+          // if (pathPrefix != module.id && renamer) {
+          //   logger.info(`Renaming ${path} to ${module.id}.${pathSuffix}`);
+          //   try {
+          //     renamer(localPath + path, localPath + module.id + "." + pathSuffix);
+          //   } catch {
+          //     logger.info(`Failed to rename ${path} to ${module.id}.${pathSuffix}`);
+          //   }
+          // }
 
           const lock = module.value.lock;
           if (removeLocks && removeLocks.includes(path)) {
             module.value.lock = undefined;
 
           // delete the file if the prefix is different from the module id (fix old naming)
-          if (lock && lock != "") {
-            const path = lock.split(" ")[1];
-            const pathPrefix = path.split(".")[0];
-            if (pathPrefix != module.id && deleter) {
-              logger.info(`Deleting ${path}`);
-              try {
-                deleter(localPath + path);
-              } catch {
-                logger.error(`Failed to delete ${path}`);
-              } 
-            }
-          }
+          // if (lock && lock != "") {
+          //   const path = lock.split(" ")[1];
+          //   const pathPrefix = path.split(".")[0];
+          //   if (pathPrefix != module.id && deleter) {
+          //     logger.info(`Deleting ${path}`);
+          //     try {
+          //       deleter(localPath + path);
+          //     } catch {
+          //       logger.error(`Failed to delete ${path}`);
+          //     } 
+          //   }
+          // }
 
           } else if (
             lock &&


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reverts inline script renaming and introduces `PathAssigner` for path assignment in inline script extraction and replacement.
> 
>   - **Behavior**:
>     - Reverts renaming of inline scripts by commenting out renaming logic in `replaceInlineScripts()` in `replacer.ts`.
>     - Introduces `PathAssigner` interface and `newPathAssigner()` function in `sync.ts` and `metadata.ts` to assign paths to inline scripts.
>   - **Functions**:
>     - Updates `extractInlineScriptsForApps()` in `sync.ts` and `extractInlineScripts()` in `extractor.ts` to use `PathAssigner` for path assignment.
>     - Updates `generateFlowLockInternal()` in `metadata.ts` to use `newPathAssigner()` for inline script path assignment.
>   - **Misc**:
>     - Removes unused import of `assignPath` from `extractor.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 304cf985aebf700bdd526fcd620b326f9f69d090. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->