### PR TITLE
fix(rust-sdk): revert `openapi-generator-cli` to `7.10.0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,6 +48,21 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-oapi-gen": {
+      "locked": {
+        "lastModified": 1740303746,
+        "narHash": "sha256-XcdiWLEhjJkMxDLKQJ0CCivmYYCvA5MDxu9pMybM5kM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2d068ae5c6516b2d04562de50a58c682540de9bf",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "rev": "2d068ae5c6516b2d04562de50a58c682540de9bf",
+        "type": "indirect"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1744536153,
@@ -69,6 +84,7 @@
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "nixpkgs-claude": "nixpkgs-claude",
+        "nixpkgs-oapi-gen": "nixpkgs-oapi-gen",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,9 +5,11 @@
     rust-overlay.url = "github:oxalica/rust-overlay";
     # Use separate channel for claude code. It always needs to be latest
     nixpkgs-claude.url = "nixpkgs/nixos-unstable";
+    nixpkgs-oapi-gen.url =
+      "nixpkgs/2d068ae5c6516b2d04562de50a58c682540de9bf"; # openapi-generator-cli pin to 7.10.0
   };
-
-  outputs = { self, nixpkgs, nixpkgs-claude, flake-utils, rust-overlay }:
+  outputs = { self, nixpkgs, nixpkgs-claude, flake-utils, rust-overlay
+    , nixpkgs-oapi-gen }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
@@ -19,6 +21,10 @@
           inherit system;
           config.allowUnfree = true;
         }).claude-code;
+
+        openapi-generator-cli =
+          (import nixpkgs-oapi-gen { inherit system; }).openapi-generator-cli;
+
         lib = pkgs.lib;
         stdenv = pkgs.stdenv;
         rust = pkgs.rust-bin.stable.latest.default.override {
@@ -106,6 +112,8 @@
           buildInputs = buildInputs ++ [
             # To update run: `nix flake update nixpkgs-claude`
             claude-code
+            # To update run: `nix flake update nixpkgs-oapi-gen`
+            openapi-generator-cli
           ] ++ (with pkgs; [
             # Essentials
             rust
@@ -116,7 +124,6 @@
             sqlx-cli
             sccache
             nsjail
-            openapi-generator-cli
 
             # Python
             flock

--- a/rust-client/Cargo.lock
+++ b/rust-client/Cargo.lock
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "windmill-api"
-version = "1.501.0"
+version = "1.518.2"
 dependencies = [
  "reqwest",
  "serde",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "wmill"
-version = "1.501.0"
+version = "1.518.2"
 dependencies = [
  "anyhow",
  "futures",

--- a/rust-client/dev.nu
+++ b/rust-client/dev.nu
@@ -23,7 +23,7 @@ def main [ --publish(-p) --check(-c) --test(-t) ] {
   open windmill_api/Cargo.toml
   # Use rustls - otherwise compilation will fail due to missing libssl
   | update dependencies.reqwest.features [json, multipart, rustls-tls]
-  | update dependencies.reqwest.default-features false
+  | insert dependencies.reqwest.default-features false
   | update package.license "Apache-2.0"
   | insert package.homepage "https://windmill.dev"
   | save -f windmill_api/Cargo.toml

--- a/rust-client/src/tests.rs
+++ b/rust-client/src/tests.rs
@@ -139,6 +139,7 @@ fn create_and_run() {
                 codebase: None,
                 has_preprocessor: None,
                 on_behalf_of_email: None,
+                assets: None,
             },
         ))
         .unwrap();
@@ -250,6 +251,7 @@ fn main() -> anyhow::Result<i32> {
                 codebase: None,
                 has_preprocessor: None,
                 on_behalf_of_email: None,
+                assets: None,
             },
         ))
         .unwrap();
@@ -322,6 +324,7 @@ async fn simple() {
                 codebase: None,
                 has_preprocessor: None,
                 on_behalf_of_email: None,
+                assets: None,
             },
         ))
         .await


### PR DESCRIPTION
In > 7.10.0 regression was introduced breaking our build process.

This commit reverts the change and fixes tests
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Revert `openapi-generator-cli` to version `7.10.0` and update related configurations and tests.
> 
>   - **Revert `openapi-generator-cli`**:
>     - Pin `openapi-generator-cli` to version `7.10.0` in `flake.nix` and `flake.lock`.
>   - **Cargo Updates**:
>     - Update `windmill-api` and `wmill` versions to `1.518.2` in `Cargo.lock`.
>   - **Test Updates**:
>     - Add `assets: None` field in `create_and_run()`, `main()`, and `simple()` in `tests.rs`.
>   - **Misc**:
>     - Change `update` to `insert` for `dependencies.reqwest.default-features` in `dev.nu`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 1e7259ac682813174b09ee7a7d0a34b2dc667ee6. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->