### PR TITLE
Forgot to remove ducklake setting tab

### DIFF
--- a/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
@@ -472,14 +472,6 @@
 				</Tab>
 				<Tab
 					size="xs"
-					value="ducklake"
-					aiId="workspace-settings-ducklake"
-					aiDescription="Ducklake workspace settings"
-				>
-					<div class="flex gap-2 items-center my-1">Ducklake</div>
-				</Tab>
-				<Tab
-					size="xs"
 					value="default_app"
 					aiId="workspace-settings-default-app"
 					aiDescription="Default app workspace settings"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `Ducklake` tab from workspace settings in `+page.svelte` to simplify UI.
> 
>   - **UI Changes**:
>     - Remove `Ducklake` tab from `+page.svelte` in workspace settings.
>     - Simplifies UI by eliminating unused `Ducklake` feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for acffefc31afe0f51631d520566dba741fcdabbd0. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->