### PR TITLE
bun install with no cache option if env: BUN_NO_CACHE

### DIFF
--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -20,7 +20,7 @@ use crate::{
         read_file_content, read_result, start_child_process, write_file_binary, OccupancyMetrics,
     },
     handle_child::handle_child,
-    BUNFIG_INSTALL_SCOPES, BUN_BUNDLE_CACHE_DIR, BUN_CACHE_DIR, BUN_PATH, DISABLE_NSJAIL,
+    BUNFIG_INSTALL_SCOPES, BUN_BUNDLE_CACHE_DIR, BUN_CACHE_DIR, BUN_NO_CACHE, BUN_PATH, DISABLE_NSJAIL,
     DISABLE_NUSER, HOME_ENV, NODE_BIN_PATH, NODE_PATH, NPM_CONFIG_REGISTRY, NPM_PATH, NSJAIL_PATH,
     PATH_ENV, PROXY_ENVS, TZ_ENV,
 };
@@ -296,10 +296,7 @@ pub async fn install_bun_lockfile(
 
     let mut args = vec!["install", "--save-text-lockfile"];
 
-    let no_cache = !npm_mode && std::env::var("BUN_NO_CACHE")
-        .ok()
-        .and_then(|x| x.parse::<bool>().ok())
-        .unwrap_or(false);
+    let no_cache = !npm_mode && *BUN_NO_CACHE;
 
     if no_cache {
         args.push("--no-cache");

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -328,6 +328,10 @@ lazy_static::lazy_static! {
 
     pub static ref NPM_CONFIG_REGISTRY: Arc<RwLock<Option<String>>> = Arc::new(RwLock::new(None));
     pub static ref BUNFIG_INSTALL_SCOPES: Arc<RwLock<Option<String>>> = Arc::new(RwLock::new(None));
+    pub static ref BUN_NO_CACHE: bool = std::env::var("BUN_NO_CACHE")
+        .ok()
+        .and_then(|x| x.parse::<bool>().ok())
+        .unwrap_or(false);
     pub static ref NUGET_CONFIG: Arc<RwLock<Option<String>>> = Arc::new(RwLock::new(None));
     pub static ref MAVEN_REPOS: Arc<RwLock<Option<String>>> = Arc::new(RwLock::new(None));
     pub static ref NO_DEFAULT_MAVEN: AtomicBool = AtomicBool::new(std::env::var("NO_DEFAULT_MAVEN")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `BUN_NO_CACHE` environment variable to control Bun install caching, adding `--no-cache` flag when true.
> 
>   - **Behavior**:
>     - Add `BUN_NO_CACHE` environment variable to control Bun install caching in `bun_executor.rs`.
>     - If `BUN_NO_CACHE` is true, `--no-cache` flag is added to Bun install command.
>   - **Logging**:
>     - Log message added for Bun install with `--no-cache` in `install_bun_lockfile()`.
>   - **Environment**:
>     - Define `BUN_NO_CACHE` in `worker.rs` as a boolean from environment variable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 08cc380eb665ceb57b588bbe3c61304fc2ff7856. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->