### PR TITLE
internal: allow bot to call claude

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -98,6 +98,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           timeout_minutes: "60"
           allowed_tools: "mcp__github__create_pull_request,Bash"
+          allowed_bots: "windmill-internal-app[bot]"
           custom_instructions: |
             ## IMPORTANT INSTRUCTIONS
             - Your branch name should be a short description of the requested changes.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Allow `windmill-internal-app[bot]` to interact with the Claude PR Action workflow in `claude.yml`.
> 
>   - **Workflow Update**:
>     - In `.github/workflows/claude.yml`, added `windmill-internal-app[bot]` to `allowed_bots` in the `Run Claude PR Action` step.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 2ba2c58a1d866df4a3e4f895c0bd0703deb26c74. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->