### PR TITLE
feat(aichat): add gpt5 compatibility

### DIFF
--- a/frontend/src/lib/components/copilot/lib.ts
+++ b/frontend/src/lib/components/copilot/lib.ts
@@ -135,7 +135,7 @@ function getModelSpecificConfig(
 		return {
 			model: modelProvider.model,
 			...(tools && tools.length > 0 ? { tools } : {}),
-			max_completion_tokens: 100000
+			max_completion_tokens: getModelMaxTokens(modelProvider.model)
 		}
 	} else {
 		return {

--- a/frontend/src/lib/components/copilot/lib.ts
+++ b/frontend/src/lib/components/copilot/lib.ts
@@ -96,7 +96,9 @@ export async function fetchAvailableModels(
 }
 
 function getModelMaxTokens(model: string) {
-	if (model.startsWith('gpt-4.1')) {
+	if (model.startsWith('gpt-5')) {
+		return 128000
+	} else if (model.startsWith('gpt-4.1')) {
 		return 32768
 	} else if (model.startsWith('gpt-4o') || model.startsWith('codestral')) {
 		return 16384
@@ -109,6 +111,8 @@ function getModelMaxTokens(model: string) {
 export function getModelContextWindow(model: string) {
 	if (model.startsWith('gpt-4.1') || model.startsWith('gemini')) {
 		return 1000000
+	} else if (model.startsWith('gpt-5')) {
+		return 400000
 	} else if (model.startsWith('gpt-4o') || model.startsWith('llama-3.3')) {
 		return 128000
 	} else if (model.startsWith('claude') || model.startsWith('o4-mini') || model.startsWith('o3')) {
@@ -126,7 +130,7 @@ function getModelSpecificConfig(
 ) {
 	if (
 		(modelProvider.provider === 'openai' || modelProvider.provider === 'azure_openai') &&
-		modelProvider.model.startsWith('o')
+		(modelProvider.model.startsWith('o') || modelProvider.model.startsWith('gpt-5'))
 	) {
 		return {
 			model: modelProvider.model,

--- a/frontend/src/lib/components/copilot/lib.ts
+++ b/frontend/src/lib/components/copilot/lib.ts
@@ -23,7 +23,7 @@ import { z } from 'zod'
 
 export const SUPPORTED_LANGUAGES = new Set(Object.keys(GEN_CONFIG.prompts))
 
-const OPENAI_MODELS = ['gpt-4o', 'gpt-4o-mini', 'o4-mini', 'o3', 'o3-mini']
+const OPENAI_MODELS = ['gpt-5', 'gpt-5-mini', 'gpt-5-nano','gpt-4o', 'gpt-4o-mini', 'o4-mini', 'o3', 'o3-mini']
 
 // need at least one model for each provider except customai
 export const AI_DEFAULT_MODELS: Record<AIProvider, string[]> = {

--- a/frontend/src/lib/components/copilot/lib.ts
+++ b/frontend/src/lib/components/copilot/lib.ts
@@ -95,9 +95,11 @@ export async function fetchAvailableModels(
 	return data?.data.map((m) => m.id) ?? []
 }
 
-function getModelMaxTokens(model: string) {
+function getModelMaxTokens(provider: AIProvider, model: string) {
 	if (model.startsWith('gpt-5')) {
 		return 128000
+	} else if ((provider === 'azure_openai' || provider === 'openai') && model.startsWith('o')) {
+		return 100000
 	} else if (model.startsWith('gpt-4.1')) {
 		return 32768
 	} else if (model.startsWith('gpt-4o') || model.startsWith('codestral')) {
@@ -135,7 +137,7 @@ function getModelSpecificConfig(
 		return {
 			model: modelProvider.model,
 			...(tools && tools.length > 0 ? { tools } : {}),
-			max_completion_tokens: getModelMaxTokens(modelProvider.model)
+			max_completion_tokens: getModelMaxTokens(modelProvider.provider, modelProvider.model)
 		}
 	} else {
 		return {
@@ -152,7 +154,7 @@ function getModelSpecificConfig(
 						temperature: 0
 					}),
 			...(tools && tools.length > 0 ? { tools } : {}),
-			max_tokens: getModelMaxTokens(modelProvider.model)
+			max_tokens: getModelMaxTokens(modelProvider.provider, modelProvider.model)
 		}
 	}
 }

--- a/frontend/src/lib/components/copilot/lib.ts
+++ b/frontend/src/lib/components/copilot/lib.ts
@@ -23,7 +23,7 @@ import { z } from 'zod'
 
 export const SUPPORTED_LANGUAGES = new Set(Object.keys(GEN_CONFIG.prompts))
 
-const OPENAI_MODELS = ['gpt-5', 'gpt-5-mini', 'gpt-5-nano','gpt-4o', 'gpt-4o-mini', 'o4-mini', 'o3', 'o3-mini']
+const OPENAI_MODELS = ['gpt-5', 'gpt-5-mini', 'gpt-5-nano', 'gpt-4o', 'gpt-4o-mini', 'o4-mini', 'o3', 'o3-mini']
 
 // need at least one model for each provider except customai
 export const AI_DEFAULT_MODELS: Record<AIProvider, string[]> = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add GPT-5 model support to AI chat, updating model lists, token limits, and configuration logic in `lib.ts`.
> 
>   - **Model Support**:
>     - Add `gpt-5`, `gpt-5-mini`, and `gpt-5-nano` to `OPENAI_MODELS` in `lib.ts`.
>     - Update `AI_DEFAULT_MODELS` to include new GPT-5 models for `openai` and `azure_openai`.
>   - **Token and Context Handling**:
>     - Update `getModelMaxTokens()` to return 128000 for `gpt-5` models.
>     - Update `getModelContextWindow()` to return 400000 for `gpt-5` models.
>   - **Configuration Adjustments**:
>     - Modify `getModelSpecificConfig()` to use `getModelMaxTokens()` for `gpt-5` models.
>     - Adjust `max_completion_tokens` logic in `getModelSpecificConfig()` for `gpt-5` models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 52489e5b2011d7fb34a07d9262b4818070069fa8. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->