### PR TITLE
fix: fix v1.523.0 rust sdk build

### DIFF
--- a/rust-client/src/client.rs
+++ b/rust-client/src/client.rs
@@ -415,6 +415,7 @@ impl Windmill {
                     path: None,
                     description: None,
                     value: Some(value),
+                    resource_type: Some(resource_type.to_owned()),
                 },
             )
             .await?;
@@ -825,8 +826,14 @@ impl Windmill {
     }
 
     async fn get_job_status_inner<'a>(&'a self, job_id: &'a str) -> Result<JobStatus, SdkError> {
-        let job =
-            job_api::get_job(&self.client_config, &self.workspace, job_id, Some(true), Some(true)).await?;
+        let job = job_api::get_job(
+            &self.client_config,
+            &self.workspace,
+            job_id,
+            Some(true),
+            Some(true),
+        )
+        .await?;
 
         Ok(match job {
             windmill_api::models::Job::JobOneOf(..) => JobStatus::Completed,
@@ -926,8 +933,14 @@ impl Windmill {
     ) -> MaybeFuture<'a, Result<(), SdkError>> {
         let f = async move {
             let job_id = job_id.unwrap_or(var("WM_JOB_ID")?);
-            let job =
-                job_api::get_job(&self.client_config, &self.workspace, &job_id, Some(true), Some(true)).await?;
+            let job = job_api::get_job(
+                &self.client_config,
+                &self.workspace,
+                &job_id,
+                Some(true),
+                Some(true),
+            )
+            .await?;
 
             let flow_id = match job {
                 windmill_api::models::Job::JobOneOf(job) => job.parent_job,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix Rust SDK build by adding `resource_type` to `EditResource` and reformatting `get_job` calls for readability.
> 
>   - **Behavior**:
>     - Add `resource_type` field to `EditResource` in `set_resource_inner()` to ensure correct resource handling.
>     - Reformat `get_job()` calls in `get_job_status_inner()` and `set_progress()` for improved readability.
>   - **Functions**:
>     - Update `set_resource_inner()` to include `resource_type` when updating resources.
>     - Reformat `get_job()` calls in `get_job_status_inner()` and `set_progress()` for better readability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 3d6497d976dc28c7b7aa55ac5a423d4217b49004. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->