### PR TITLE
chore: add rust client build check workflow

### DIFF
--- a/.github/workflows/rust-client-check.yml
+++ b/.github/workflows/rust-client-check.yml
@@ -7,6 +7,7 @@ on:
   push:
     paths:
       - "rust-client/**"
+      - "backend/**/*.rs"
       - "backend/windmill-api/openapi.yaml"
       - "version.txt"
       - "flake.nix"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add GitHub Actions workflow to check Rust client build on specific file changes and after version changes.
> 
>   - **Workflow**:
>     - Adds `rust-client-check.yml` to `.github/workflows/` to verify Rust client builds.
>     - Triggers on changes to `rust-client/**`, `backend/**/*.rs`, `backend/windmill-api/openapi.yaml`, `version.txt`, `flake.nix`, and the workflow file itself.
>     - Also triggers after the completion of the "Change versions" workflow.
>   - **Jobs**:
>     - `check_rust_client` job runs on `ubicloud-standard-8`.
>     - Uses `actions/checkout@v4` and `cachix/install-nix-action@v20` with experimental Nix features.
>     - Executes `nix develop` to check Rust client build with a 16-minute timeout.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 9d7e1ab8001cc15270110b38b7480e1e9ad0bd77. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->