### PR TITLE
Add windir to Windows environment

### DIFF
--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -852,6 +852,7 @@ mount {{
         {
             python_cmd.env("SystemRoot", SYSTEM_ROOT.as_str());
             python_cmd.env("USERPROFILE", crate::USERPROFILE_ENV.as_str());
+            python_cmd.env("windir", SYSTEM_ROOT.as_str());
             python_cmd.env(
                 "LOCALAPPDATA",
                 std::env::var("LOCALAPPDATA")


### PR DESCRIPTION
`%windir%` is a commonly-used alias for `%SystemRoot%`. Some packages (eg [matplotlib](https://github.com/matplotlib/matplotlib/blob/main/lib/matplotlib/font_manager.py#L219)) freak out if `windir` is not set.

A temporary workaround is to set `windir` as a custom environment variable, but I think this ought to be automatic.

This PR only adds `windir` to the Python executor. You may want to consider adding it to the others as well.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `windir` environment variable to Python executor on Windows in `python_executor.rs` to prevent issues with packages expecting it.
> 
>   - **Behavior**:
>     - Adds `windir` environment variable to Python executor in `python_executor.rs` for Windows, using `SystemRoot` value.
>     - Addresses issues with packages like matplotlib that expect `windir` to be set.
>   - **Scope**:
>     - Change is specific to Python executor; other executors not modified.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 101260b0241a8731ce1171462ddde70b738f1c9d. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->