### PR TITLE
fix(frontend): graph cache of ai agent step tools

### DIFF
--- a/frontend/src/lib/components/graph/renderers/nodes/AIToolNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/AIToolNode.svelte
@@ -28,6 +28,20 @@
 			: AI_TOOL_MESSAGE_PREFIX + '-' + agentModuleId + '-' + idx
 	}
 
+	function getComparableNode(node: Node & NodeLayout): Node & NodeLayout {
+		if (node.type === 'module' && node.data.module.value.type === 'aiagent') {
+			return {
+				...node,
+				data: {
+					...node.data,
+					module: $state.snapshot(node.data.module) // module is a proxy object so we need to snapshot to be able to compare
+				}
+			}
+		} else {
+			return node
+		}
+	}
+
 	export function computeAIToolNodes(
 		nodes: (Node & NodeLayout)[],
 		eventHandlers: GraphEventHandlers,
@@ -41,7 +55,7 @@
 		if (
 			computeAIToolNodesCache &&
 			!!flowModuleStates === computeAIToolNodesCache.hasFlowModuleStates &&
-			deepEqual(nodes, computeAIToolNodesCache.nodes)
+			deepEqual(nodes.map(getComparableNode), computeAIToolNodesCache.nodes)
 		) {
 			return computeAIToolNodesCache.ret
 		}
@@ -201,7 +215,7 @@
 		}
 
 		computeAIToolNodesCache = {
-			nodes,
+			nodes: nodes.map(getComparableNode),
 			hasFlowModuleStates: !!flowModuleStates,
 			ret
 		}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves AI tool node caching by introducing `getComparableNode` to handle proxy objects in `AIToolNode.svelte`.
> 
>   - **Caching**:
>     - Introduce `getComparableNode` function in `AIToolNode.svelte` to snapshot proxy objects for comparison.
>     - Update `computeAIToolNodes` to use `getComparableNode` for node comparison, ensuring accurate cache hits.
>     - Cache now stores nodes mapped with `getComparableNode` to handle proxy objects correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for b9fac1d46feb7f8faf40b1dbc8dccc6514bdf628. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->