### PR TITLE
fix(frontend): nats config conditional fields

### DIFF
--- a/frontend/src/lib/components/triggers/nats/NatsTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/nats/NatsTriggerEditorInner.svelte
@@ -74,11 +74,16 @@
 	let showLoading = $state(false)
 	let defaultValues: Record<string, any> | undefined = $state(undefined)
 	let natsResourcePath = $state('')
-	let subjects = $state([''])
-	let useJetstream = $state(false)
-	let streamName = $state('')
-	let consumerName = $state('')
 	let initialConfig: Record<string, any> | undefined = undefined
+	let natsCfg: {
+		subjects: string[]
+		use_jetstream: boolean
+		stream_name?: string
+		consumer_name?: string
+	} = $state({
+		subjects: [],
+		use_jetstream: false
+	})
 	let deploymentLoading = $state(false)
 	let isValid = $state(false)
 	let optionTabSelected: 'error_handler' | 'retries' = $state('error_handler')
@@ -140,10 +145,13 @@
 			edit = false
 			itemKind = nis_flow ? 'flow' : 'script'
 			natsResourcePath = nDefaultValues?.nats_resource_path ?? ''
-			subjects = nDefaultValues?.subjects ?? ['']
-			useJetstream = nDefaultValues?.use_jetstream ?? false
-			streamName = useJetstream ? (nDefaultValues?.stream_name ?? '') : undefined
-			consumerName = useJetstream ? (nDefaultValues?.consumer_name ?? '') : undefined
+			const useJetstream = nDefaultValues?.use_jetstream ?? false
+			natsCfg = {
+				subjects: nDefaultValues?.subjects ?? [''],
+				use_jetstream: useJetstream,
+				stream_name: useJetstream ? (nDefaultValues?.stream_name ?? '') : undefined,
+				consumer_name: useJetstream ? (nDefaultValues?.consumer_name ?? '') : undefined
+			}
 			initialScriptPath = ''
 			fixedScriptPath = fixedScriptPath_ ?? ''
 			script_path = fixedScriptPath
@@ -169,10 +177,13 @@
 		is_flow = cfg?.is_flow
 		path = cfg?.path
 		natsResourcePath = cfg?.nats_resource_path
-		streamName = cfg?.stream_name
-		consumerName = cfg?.consumer_name
-		subjects = cfg?.subjects || ['']
-		useJetstream = cfg?.use_jetstream || false
+		const useJetstream = cfg?.use_jetstream || false
+		natsCfg = {
+			subjects: cfg?.subjects || [''],
+			use_jetstream: useJetstream,
+			stream_name: useJetstream ? cfg?.stream_name || '' : undefined,
+			consumer_name: useJetstream ? cfg?.consumer_name || '' : undefined
+		}
 		enabled = cfg?.enabled
 		can_write = canWrite(cfg?.path, cfg?.extra_perms, $userStore)
 		error_handler_path = cfg?.error_handler_path
@@ -201,10 +212,10 @@
 			is_flow,
 			enabled,
 			nats_resource_path: natsResourcePath,
-			stream_name: streamName,
-			consumer_name: consumerName,
-			subjects,
-			use_jetstream: useJetstream,
+			stream_name: natsCfg.stream_name,
+			consumer_name: natsCfg.consumer_name,
+			subjects: natsCfg.subjects,
+			use_jetstream: natsCfg.use_jetstream,
 			error_handler_path,
 			error_handler_args,
 			retry
@@ -390,10 +401,7 @@
 			<NatsTriggersConfigSection
 				{path}
 				bind:natsResourcePath
-				bind:subjects
-				bind:useJetstream
-				bind:streamName
-				bind:consumerName
+				bind:natsCfg
 				on:valid-config={({ detail }) => {
 					isValid = detail
 				}}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor NATS configuration handling by consolidating fields into `natsCfg` object and updating validation logic in `NatsTriggerEditorInner.svelte` and `NatsTriggersConfigSection.svelte`.
> 
>   - **Refactoring**:
>     - Consolidate NATS configuration fields into `natsCfg` object in `NatsTriggerEditorInner.svelte` and `NatsTriggersConfigSection.svelte`.
>     - Update binding and validation logic to use `natsCfg`.
>   - **Behavior**:
>     - Automatically set default `stream_name` and `consumer_name` if not provided when `use_jetstream` is true.
>     - Validate that only one subject is allowed if `use_jetstream` is false.
>   - **Misc**:
>     - Remove individual bindings for `subjects`, `useJetstream`, `streamName`, and `consumerName` in favor of `natsCfg`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 404ed465ca2cad84b217dd0613f4fd069bdaf133. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->