### PR TITLE
feat(aichat): allow reverting specific line for inline script suggestions

### DIFF
--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -679,6 +679,13 @@
 		aiChatEditorHandler?.reviewAndApply(code, applyAll)
 	}
 
+	export function reviewRevertToCode(
+		originalCode: string,
+		opts?: { labels?: { primary?: string; secondary?: string }; applyAll?: boolean }
+	) {
+		aiChatEditorHandler?.reviewRevertTo(originalCode, opts)
+	}
+
 	function addChatHandler(editor: meditor.IStandaloneCodeEditor) {
 		try {
 			aiChatEditorHandler = new AIChatEditorHandler(editor)

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -676,17 +676,16 @@
 	let selectedCode = $state('')
 
 	export function reviewAndApplyCode(code: string, applyAll: boolean = false) {
-		aiChatEditorHandler?.reviewAndApply(code, applyAll)
+		aiChatEditorHandler?.reviewAndApply(code, { applyAll })
 	}
 
-	export function reviewRevertToCode(
-		originalCode: string,
-		opts?: { labels?: { primary?: string; secondary?: string }; applyAll?: boolean }
-	) {
+	export function reviewRevertToCode(originalCode: string) {
 		// sleep for 1 second
 		setTimeout(() => {
 			console.log('here reviewRevertToCode', aiChatEditorHandler !== undefined)
-			aiChatEditorHandler?.reviewRevertTo(originalCode, opts)
+			aiChatEditorHandler?.reviewAndApply(originalCode, {
+				mode: 'revert'
+			})
 		}, 1000)
 	}
 

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -679,14 +679,14 @@
 		aiChatEditorHandler?.reviewAndApply(code, { applyAll })
 	}
 
-	export function reviewRevertToCode(originalCode: string) {
-		// sleep for 1 second
-		setTimeout(() => {
-			console.log('here reviewRevertToCode', aiChatEditorHandler !== undefined)
-			aiChatEditorHandler?.reviewAndApply(originalCode, {
-				mode: 'revert'
-			})
-		}, 1000)
+	export function reviewAppliedCode(originalCode: string) {
+		aiChatEditorHandler?.reviewAndApply(originalCode, {
+			mode: 'revert'
+		})
+	}
+
+	export function getAiChatEditorHandler() {
+		return aiChatEditorHandler
 	}
 
 	function addChatHandler(editor: meditor.IStandaloneCodeEditor) {

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -144,7 +144,7 @@
 	import { conf, language } from '$lib/vueMonarch'
 
 	import { Autocompletor } from './copilot/autocomplete/Autocompletor'
-	import { AIChatEditorHandler } from './copilot/chat/monaco-adapter'
+	import { AIChatEditorHandler, type ReviewOutcome } from './copilot/chat/monaco-adapter'
 	import GlobalReviewButtons from './copilot/chat/GlobalReviewButtons.svelte'
 	import AIChatInlineWidget from './copilot/chat/AIChatInlineWidget.svelte'
 	import { writable } from 'svelte/store'
@@ -679,9 +679,13 @@
 		aiChatEditorHandler?.reviewAndApply(code, { applyAll })
 	}
 
-	export function reviewAppliedCode(originalCode: string) {
+	export function reviewAppliedCode(
+		originalCode: string,
+		opts?: { onFinishedReview?: (outcome: ReviewOutcome) => void }
+	) {
 		aiChatEditorHandler?.reviewAndApply(originalCode, {
-			mode: 'revert'
+			mode: 'revert',
+			onFinishedReview: opts?.onFinishedReview
 		})
 	}
 

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -144,7 +144,7 @@
 	import { conf, language } from '$lib/vueMonarch'
 
 	import { Autocompletor } from './copilot/autocomplete/Autocompletor'
-	import { AIChatEditorHandler, type ReviewOutcome } from './copilot/chat/monaco-adapter'
+	import { AIChatEditorHandler } from './copilot/chat/monaco-adapter'
 	import GlobalReviewButtons from './copilot/chat/GlobalReviewButtons.svelte'
 	import AIChatInlineWidget from './copilot/chat/AIChatInlineWidget.svelte'
 	import { writable } from 'svelte/store'
@@ -681,7 +681,7 @@
 
 	export function reviewAppliedCode(
 		originalCode: string,
-		opts?: { onFinishedReview?: (outcome: ReviewOutcome) => void }
+		opts?: { onFinishedReview?: () => void }
 	) {
 		aiChatEditorHandler?.reviewChanges(originalCode, {
 			mode: 'revert',

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -1698,10 +1698,24 @@
 {#if $reviewingChanges}
 	<GlobalReviewButtons
 		onAcceptAll={() => {
-			aiChatEditorHandler?.acceptAll()
+			const mode = aiChatEditorHandler?.getReviewMode?.()
+			if (mode === 'revert') {
+				// In revert mode, Accept All means keep current code
+				aiChatEditorHandler?.rejectAll()
+			} else {
+				// In apply mode, Accept All means apply all changes
+				aiChatEditorHandler?.acceptAll()
+			}
 		}}
 		onRejectAll={() => {
-			aiChatEditorHandler?.rejectAll()
+			const mode = aiChatEditorHandler?.getReviewMode?.()
+			if (mode === 'revert') {
+				// In revert mode, Reject All means revert everything
+				aiChatEditorHandler?.acceptAll()
+			} else {
+				// In apply mode, Reject All means discard all changes
+				aiChatEditorHandler?.rejectAll()
+			}
 		}}
 	/>
 {/if}

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -676,14 +676,14 @@
 	let selectedCode = $state('')
 
 	export function reviewAndApplyCode(code: string, applyAll: boolean = false) {
-		aiChatEditorHandler?.reviewAndApply(code, { applyAll })
+		aiChatEditorHandler?.reviewChanges(code, { applyAll, mode: 'apply' })
 	}
 
 	export function reviewAppliedCode(
 		originalCode: string,
 		opts?: { onFinishedReview?: (outcome: ReviewOutcome) => void }
 	) {
-		aiChatEditorHandler?.reviewAndApply(originalCode, {
+		aiChatEditorHandler?.reviewChanges(originalCode, {
 			mode: 'revert',
 			onFinishedReview: opts?.onFinishedReview
 		})

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -683,7 +683,11 @@
 		originalCode: string,
 		opts?: { labels?: { primary?: string; secondary?: string }; applyAll?: boolean }
 	) {
-		aiChatEditorHandler?.reviewRevertTo(originalCode, opts)
+		// sleep for 1 second
+		setTimeout(() => {
+			console.log('here reviewRevertToCode', aiChatEditorHandler !== undefined)
+			aiChatEditorHandler?.reviewRevertTo(originalCode, opts)
+		}, 1000)
 	}
 
 	function addChatHandler(editor: meditor.IStandaloneCodeEditor) {

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -1700,20 +1700,16 @@
 		onAcceptAll={() => {
 			const mode = aiChatEditorHandler?.getReviewMode?.()
 			if (mode === 'revert') {
-				// In revert mode, Accept All means keep current code
-				aiChatEditorHandler?.rejectAll()
+				aiChatEditorHandler?.keepAll()
 			} else {
-				// In apply mode, Accept All means apply all changes
 				aiChatEditorHandler?.acceptAll()
 			}
 		}}
 		onRejectAll={() => {
 			const mode = aiChatEditorHandler?.getReviewMode?.()
 			if (mode === 'revert') {
-				// In revert mode, Reject All means revert everything
-				aiChatEditorHandler?.acceptAll()
+				aiChatEditorHandler?.revertAll()
 			} else {
-				// In apply mode, Reject All means discard all changes
 				aiChatEditorHandler?.rejectAll()
 			}
 		}}

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -92,6 +92,9 @@ class AIChatManager {
 		undefined
 	)
 	scriptEditorShowDiffMode = $state<(() => void) | undefined>(undefined)
+	scriptEditorStartRevertReview = $state<
+		((originalCode: string, applyAll?: boolean) => void) | undefined
+	>(undefined)
 	flowAiChatHelpers = $state<FlowAIChatHelpers | undefined>(undefined)
 	pendingNewCode = $state<string | undefined>(undefined)
 	apiTools = $state<Tool<any>[]>([])
@@ -929,14 +932,25 @@ class AIChatManager {
 					currentEditor.showDiffMode()
 				}
 			}
+			this.scriptEditorStartRevertReview = (originalCode: string, applyAll?: boolean) => {
+				if (currentEditor && currentEditor.type === 'script') {
+					currentEditor.hideDiffMode()
+					currentEditor.editor.reviewRevertToCode(originalCode, {
+						labels: { primary: 'Revert', secondary: 'Keep' },
+						applyAll
+					})
+				}
+			}
 		} else {
 			this.scriptEditorApplyCode = undefined
 			this.scriptEditorShowDiffMode = undefined
+			this.scriptEditorStartRevertReview = undefined
 		}
 
 		return () => {
 			this.scriptEditorApplyCode = undefined
 			this.scriptEditorShowDiffMode = undefined
+			this.scriptEditorStartRevertReview = undefined
 		}
 	}
 

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -92,9 +92,6 @@ class AIChatManager {
 		undefined
 	)
 	scriptEditorShowDiffMode = $state<(() => void) | undefined>(undefined)
-	scriptEditorStartRevertReview = $state<
-		((originalCode: string, applyAll?: boolean) => void) | undefined
-	>(undefined)
 	flowAiChatHelpers = $state<FlowAIChatHelpers | undefined>(undefined)
 	pendingNewCode = $state<string | undefined>(undefined)
 	apiTools = $state<Tool<any>[]>([])
@@ -932,25 +929,14 @@ class AIChatManager {
 					currentEditor.showDiffMode()
 				}
 			}
-			this.scriptEditorStartRevertReview = (originalCode: string, applyAll?: boolean) => {
-				if (currentEditor && currentEditor.type === 'script') {
-					currentEditor.hideDiffMode()
-					currentEditor.editor.reviewRevertToCode(originalCode, {
-						labels: { primary: 'Revert', secondary: 'Keep' },
-						applyAll
-					})
-				}
-			}
 		} else {
 			this.scriptEditorApplyCode = undefined
 			this.scriptEditorShowDiffMode = undefined
-			this.scriptEditorStartRevertReview = undefined
 		}
 
 		return () => {
 			this.scriptEditorApplyCode = undefined
 			this.scriptEditorShowDiffMode = undefined
-			this.scriptEditorStartRevertReview = undefined
 		}
 	}
 

--- a/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
@@ -616,14 +616,17 @@
 
 	// Automatically show revert review when selecting a rawscript module with pending changes
 	$effect(() => {
-		if ($currentEditor?.type === 'script' && $selectedId && affectedModules[$selectedId]) {
+		if (
+			$currentEditor?.type === 'script' &&
+			$selectedId &&
+			affectedModules[$selectedId] &&
+			$currentEditor.editor.getAiChatEditorHandler()
+		) {
 			const moduleLastSnapshot = getModule($selectedId, lastSnapshot)
 			const content =
 				moduleLastSnapshot?.value.type === 'rawscript' ? moduleLastSnapshot.value.content : ''
 			if (content.length > 0) {
-				console.log('here review revert to code')
-				console.log(content.slice(-100))
-				untrack(() => $currentEditor.editor.reviewRevertToCode(content))
+				untrack(() => $currentEditor.editor.reviewAppliedCode(content))
 			}
 		}
 	})

--- a/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
@@ -632,16 +632,10 @@
 			if (content.length > 0) {
 				untrack(() =>
 					$currentEditor.editor.reviewAppliedCode(content, {
-						onFinishedReview: (outcome) => {
+						onFinishedReview: () => {
 							const id = $selectedId
-							if (outcome === 'all_kept' || outcome === 'partial') {
-								// User kept all current changes - accept the module
-								flowHelpers.acceptModuleAction(id)
-								$currentEditor.hideDiffMode()
-							} else if (outcome === 'all_reverted') {
-								// User reverted all changes - revert the module
-								flowHelpers.revertModuleAction(id)
-							}
+							flowHelpers.acceptModuleAction(id)
+							$currentEditor.hideDiffMode()
 						}
 					})
 				)

--- a/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
@@ -622,6 +622,7 @@
 				moduleLastSnapshot?.value.type === 'rawscript' ? moduleLastSnapshot.value.content : ''
 			if (content.length > 0) {
 				console.log('here review revert to code')
+				console.log(content.slice(-100))
 				untrack(() => $currentEditor.editor.reviewRevertToCode(content))
 			}
 		}

--- a/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
@@ -630,27 +630,16 @@
 					$currentEditor.editor.reviewAppliedCode(content, {
 						onFinishedReview: (outcome) => {
 							const id = $selectedId
-							const action = affectedModules[id]?.action
+							const action = affectedModules[id].action
 
-							if (id && action === 'modified') {
-								if (outcome.outcome === 'all_kept') {
+							if (action === 'modified') {
+								if (outcome === 'all_kept') {
 									// User kept all current changes - accept the module
 									flowHelpers.acceptModuleAction(id)
-									if ($currentEditor?.type === 'script' && $currentEditor.stepId === id) {
-										$currentEditor.hideDiffMode()
-									}
-								} else if (outcome.outcome === 'all_reverted') {
+									$currentEditor.hideDiffMode()
+								} else if (outcome === 'all_reverted') {
 									// User reverted all changes - revert the module
 									flowHelpers.revertModuleAction(id)
-								} else {
-									// Partial changes - persist the final code and keep module as modified
-									const currentModule = getModule(id)
-									const currentContent =
-										currentModule?.value.type === 'rawscript' ? currentModule.value.content : ''
-									if (outcome.finalCode !== currentContent) {
-										flowHelpers.setCode(id, outcome.finalCode)
-									}
-									// Keep the module marked as modified
 								}
 							}
 						}

--- a/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
@@ -232,14 +232,6 @@
 			}
 			if ($currentEditor && $currentEditor.type === 'script' && $currentEditor.stepId === id) {
 				$currentEditor.editor.setCode(code)
-
-				// Start revert review if we have a snapshot
-				// if (lastSnapshot) {
-				// 	const originalModule = getModule(id, lastSnapshot)
-				// 	if (originalModule && originalModule.value.type === 'rawscript') {
-				// 		aiChatManager.scriptEditorStartRevertReview?.(originalModule.value.content)
-				// 	}
-				// }
 			}
 			setModuleStatus(id, 'modified')
 		},
@@ -629,29 +621,10 @@
 			const content =
 				moduleLastSnapshot?.value.type === 'rawscript' ? moduleLastSnapshot.value.content : ''
 			if (content.length > 0) {
-				untrack(() => aiChatManager.scriptEditorStartRevertReview?.(content))
+				console.log('here review revert to code')
+				untrack(() => $currentEditor.editor.reviewRevertToCode(content))
 			}
 		}
-
-		// if (
-		// 	$currentEditor?.type === 'script' &&
-		// 	$selectedId &&
-		// 	affectedModules[$selectedId] &&
-		// 	lastSnapshot
-		// ) {
-		// 	const moduleLastSnapshot = getModule($selectedId, lastSnapshot)
-		// 	const currentModule = getModule($selectedId)
-
-		// 	if (
-		// 		moduleLastSnapshot &&
-		// 		currentModule &&
-		// 		currentModule.value.type === 'rawscript' &&
-		// 		moduleLastSnapshot.value.type === 'rawscript'
-		// 	) {
-		// 		// Start revert review automatically when selecting a modified module
-		// 		aiChatManager.scriptEditorStartRevertReview?.(moduleLastSnapshot.value.content ?? '')
-		// 	}
-		// }
 	})
 
 	let diffDrawer: DiffDrawer | undefined = $state(undefined)

--- a/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
@@ -6,7 +6,7 @@
 	import { dfs } from '$lib/components/flows/previousResults'
 	import { dfs as dfsApply } from '$lib/components/flows/dfs'
 	import { getSubModules } from '$lib/components/flows/flowExplorer'
-	import type { FlowModule, OpenFlow, RawScript } from '$lib/gen'
+	import type { FlowModule, OpenFlow } from '$lib/gen'
 	import { getIndexInNestedModules, getNestedModules } from './utils'
 	import type { AIModuleAction, FlowAIChatHelpers } from './core'
 	import {
@@ -93,21 +93,10 @@
 		hasDiff: () => {
 			return Object.keys(affectedModules).length > 0
 		},
-		acceptAllModuleActions: () => {
-			for (const [id, affectedModule] of Object.entries(affectedModules)) {
-				if (affectedModule.action === 'removed') {
-					deleteStep(id)
-				}
-				// Hide diff editor if the module is a rawscript
-				if (
-					affectedModule.action === 'modified' &&
-					$currentEditor?.type === 'script' &&
-					$currentEditor.stepId === id
-				) {
-					$currentEditor.hideDiffMode()
-				}
+		acceptAllModuleActions() {
+			for (const id of Object.keys(affectedModules)) {
+				this.acceptModuleAction(id)
 			}
-			affectedModules = {}
 		},
 		rejectAllModuleActions() {
 			for (const id of Object.keys(affectedModules)) {
@@ -189,8 +178,12 @@
 							$currentEditor?.type === 'script' &&
 							$currentEditor.stepId === id
 						) {
-							$currentEditor.editor.setCode((oldModule.value as RawScript).content)
-							$currentEditor.hideDiffMode()
+							const aiChatEditorHandler = $currentEditor.editor.getAiChatEditorHandler()
+							if (aiChatEditorHandler) {
+								// In revert mode, we accept to keep the current changes
+								aiChatEditorHandler.acceptAll({ disableReviewCallback: true })
+								$currentEditor.hideDiffMode()
+							}
 						}
 
 						Object.keys(newModule).forEach((k) => delete newModule[k])
@@ -205,6 +198,19 @@
 		acceptModuleAction: (id: string) => {
 			if (affectedModules[id]?.action === 'removed') {
 				deleteStep(id)
+			}
+
+			if (
+				affectedModules[id]?.action === 'modified' &&
+				$currentEditor &&
+				$currentEditor.type === 'script' &&
+				$currentEditor.stepId === id
+			) {
+				const aiChatEditorHandler = $currentEditor.editor.getAiChatEditorHandler()
+				if (aiChatEditorHandler) {
+					// In apply mode, we accept to keep the current changes
+					aiChatEditorHandler.rejectAll({ disableReviewCallback: true })
+				}
 			}
 			delete affectedModules[id]
 		},

--- a/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
@@ -630,17 +630,13 @@
 					$currentEditor.editor.reviewAppliedCode(content, {
 						onFinishedReview: (outcome) => {
 							const id = $selectedId
-							const action = affectedModules[id].action
-
-							if (action === 'modified') {
-								if (outcome === 'all_kept') {
-									// User kept all current changes - accept the module
-									flowHelpers.acceptModuleAction(id)
-									$currentEditor.hideDiffMode()
-								} else if (outcome === 'all_reverted') {
-									// User reverted all changes - revert the module
-									flowHelpers.revertModuleAction(id)
-								}
+							if (outcome === 'all_kept' || outcome === 'partial') {
+								// User kept all current changes - accept the module
+								flowHelpers.acceptModuleAction(id)
+								$currentEditor.hideDiffMode()
+							} else if (outcome === 'all_reverted') {
+								// User reverted all changes - revert the module
+								flowHelpers.revertModuleAction(id)
 							}
 						}
 					})

--- a/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
@@ -180,8 +180,7 @@
 						) {
 							const aiChatEditorHandler = $currentEditor.editor.getAiChatEditorHandler()
 							if (aiChatEditorHandler) {
-								// In revert mode, we accept to keep the current changes
-								aiChatEditorHandler.acceptAll({ disableReviewCallback: true })
+								aiChatEditorHandler.revertAll({ disableReviewCallback: true })
 								$currentEditor.hideDiffMode()
 							}
 						}
@@ -208,8 +207,7 @@
 			) {
 				const aiChatEditorHandler = $currentEditor.editor.getAiChatEditorHandler()
 				if (aiChatEditorHandler) {
-					// In apply mode, we accept to keep the current changes
-					aiChatEditorHandler.rejectAll({ disableReviewCallback: true })
+					aiChatEditorHandler.keepAll({ disableReviewCallback: true })
 				}
 			}
 			delete affectedModules[id]

--- a/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
+++ b/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
@@ -30,6 +30,7 @@ export class AIChatEditorHandler {
 	private reviewState: {
 		totalGroups: number
 		revertedGroups: Set<number>
+		mode: 'apply' | 'revert'
 		onFinishedReview?: (outcome: ReviewOutcome) => void
 	} | null = null
 
@@ -75,6 +76,7 @@ export class AIChatEditorHandler {
 	}
 
 	async finish() {
+		// expose mode getter relies on reviewState
 		// Call completion callback if we're tracking review state
 		if (this.reviewState?.onFinishedReview) {
 			const revertedCount = this.reviewState.revertedGroups.size
@@ -103,8 +105,12 @@ export class AIChatEditorHandler {
 		})
 	}
 
+	getReviewMode(): 'apply' | 'revert' | null {
+		return this.reviewState?.mode ?? null
+	}
+
 	async acceptAll() {
-		// Track that all groups were applied (in revert mode this means all reverted)
+		// Track that all groups were applied
 		if (this.reviewState) {
 			for (const group of this.groupChanges) {
 				this.reviewState.revertedGroups.add(group.groupIndex)
@@ -119,8 +125,7 @@ export class AIChatEditorHandler {
 	}
 
 	async rejectAll() {
-		// Track that no groups were applied (no groups reverted in revert mode)
-		// reviewState.revertedGroups remains empty
+		// Don't apply any changes - just finish
 		this.finish()
 	}
 
@@ -228,6 +233,7 @@ export class AIChatEditorHandler {
 		this.reviewState = {
 			totalGroups: this.groupChanges.length,
 			revertedGroups: new Set<number>(),
+			mode: opts?.mode ?? 'apply',
 			onFinishedReview: opts?.onFinishedReview
 		}
 

--- a/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
+++ b/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
@@ -75,10 +75,10 @@ export class AIChatEditorHandler {
 		}
 	}
 
-	async finish() {
+	async finish(opts?: { disableReviewCallback?: boolean }) {
 		// expose mode getter relies on reviewState
 		// Call completion callback if we're tracking review state
-		if (this.reviewState?.onFinishedReview) {
+		if (this.reviewState?.onFinishedReview && !opts?.disableReviewCallback) {
 			const revertedCount = this.reviewState.revertedGroups.size
 			const keptCount = this.reviewState.totalGroups - revertedCount
 
@@ -109,7 +109,7 @@ export class AIChatEditorHandler {
 		return this.reviewState?.mode ?? null
 	}
 
-	async acceptAll() {
+	async acceptAll(opts?: { disableReviewCallback?: boolean }) {
 		// Track that all groups were applied
 		if (this.reviewState) {
 			for (const group of this.groupChanges) {
@@ -121,12 +121,12 @@ export class AIChatEditorHandler {
 		for (const group of this.groupChanges) {
 			this.applyGroup(group)
 		}
-		this.finish()
+		this.finish(opts)
 	}
 
-	async rejectAll() {
+	async rejectAll(opts?: { disableReviewCallback?: boolean }) {
 		// Don't apply any changes - just finish
-		this.finish()
+		this.finish(opts)
 	}
 
 	applyGroup(group: { changes: VisualChangeWithDiffIndex[]; groupIndex: number }) {

--- a/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
+++ b/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
@@ -128,7 +128,7 @@ export class AIChatEditorHandler {
 		this.finish(opts)
 	}
 
-	// Keep all changes, used in apply mode
+	// Keep all changes, used in revert mode
 	async keepAll(opts?: { disableReviewCallback?: boolean }) {
 		this.finish(opts)
 	}

--- a/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
+++ b/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
@@ -222,6 +222,16 @@ export class AIChatEditorHandler {
 				}
 			}
 
+			const isRevert = opts?.mode === 'revert'
+			const acceptFn = isRevert ? secondaryFn : primaryFn // Accept = keep (revert mode), apply (apply mode)
+			const rejectFn = isRevert ? primaryFn : secondaryFn // Reject = revert (revert mode), discard (apply mode)
+			const labels = isRevert
+				? {
+						primary: opts?.labels?.primary ?? 'Keep',
+						secondary: opts?.labels?.secondary ?? 'Revert'
+					}
+				: opts?.labels
+
 			const changes = group.changes.map((c, i) => {
 				if (i === group.changes.length - 1) {
 					return {
@@ -229,9 +239,9 @@ export class AIChatEditorHandler {
 						options: {
 							...(c.options ?? {}),
 							review: {
-								acceptFn: primaryFn,
-								rejectFn: secondaryFn,
-								labels: opts?.labels
+								acceptFn,
+								rejectFn,
+								labels
 							}
 						}
 					}

--- a/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
+++ b/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
@@ -254,7 +254,8 @@ export class AIChatEditorHandler {
 				;({ collection, ids } = await displayVisualChanges(
 					'editor-windmill-chat-style',
 					this.editor,
-					changes
+					changes,
+					isRevert
 				))
 				this.decorationsCollections.push(collection)
 				this.viewZoneIds.push(...ids)

--- a/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
+++ b/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
@@ -266,33 +266,7 @@ export class AIChatEditorHandler {
 		}
 	}
 
-	async reviewAndApply(newCode: string, applyAll: boolean = false) {
-		return this.reviewChanges(newCode, { applyAll, mode: 'apply' })
-	}
-
-	async reviewRevertTo(
-		originalCode: string,
-		opts?: {
-			labels?: { primary?: string; secondary?: string }
-			applyAll?: boolean
-		}
-	) {
-		const currentCode = this.editor.getValue()
-		if (currentCode === originalCode) {
-			return
-		}
-
-		return this.reviewChanges(originalCode, {
-			...opts,
-			mode: 'revert'
-		})
-	}
-
-	async revertAll() {
-		this.acceptAll()
-	}
-
-	async keepAll() {
-		this.rejectAll()
+	async reviewAndApply(newCode: string, opts?: { applyAll?: boolean; mode?: 'apply' | 'revert' }) {
+		return this.reviewChanges(newCode, { ...opts, mode: opts?.mode ?? 'apply' })
 	}
 }

--- a/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
+++ b/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
@@ -210,7 +210,7 @@ export class AIChatEditorHandler {
 		return changedLines
 	}
 
-	private async reviewChanges(
+	async reviewChanges(
 		targetCode: string,
 		opts?: {
 			applyAll?: boolean
@@ -316,16 +316,5 @@ export class AIChatEditorHandler {
 		if (opts?.applyAll) {
 			this.acceptAll()
 		}
-	}
-
-	async reviewAndApply(
-		newCode: string,
-		opts?: {
-			applyAll?: boolean
-			mode?: 'apply' | 'revert'
-			onFinishedReview?: (outcome: ReviewOutcome) => void
-		}
-	) {
-		return this.reviewChanges(newCode, { ...opts, mode: opts?.mode ?? 'apply' })
 	}
 }

--- a/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
+++ b/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
@@ -125,8 +125,17 @@ export class AIChatEditorHandler {
 	}
 
 	async rejectAll(opts?: { disableReviewCallback?: boolean }) {
-		// Don't apply any changes - just finish
 		this.finish(opts)
+	}
+
+	// Keep all changes, used in apply mode
+	async keepAll(opts?: { disableReviewCallback?: boolean }) {
+		this.finish(opts)
+	}
+
+	// Revert all changes, used in revert mode
+	async revertAll(opts?: { disableReviewCallback?: boolean }) {
+		this.acceptAll(opts)
 	}
 
 	applyGroup(group: { changes: VisualChangeWithDiffIndex[]; groupIndex: number }) {

--- a/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
+++ b/frontend/src/lib/components/copilot/chat/monaco-adapter.ts
@@ -175,7 +175,7 @@ export class AIChatEditorHandler {
 			mode?: 'apply' | 'revert'
 		}
 	) {
-		if (aiChatManager.pendingNewCode === targetCode) {
+		if (aiChatManager.pendingNewCode === targetCode && opts?.mode === 'apply') {
 			this.acceptAll()
 			return
 		} else if (aiChatManager.pendingNewCode) {

--- a/frontend/src/lib/components/copilot/shared.ts
+++ b/frontend/src/lib/components/copilot/shared.ts
@@ -24,10 +24,6 @@ export type VisualChange =
 				review?: {
 					acceptFn: () => void
 					rejectFn: () => void
-					labels?: {
-						primary?: string
-						secondary?: string
-					}
 				}
 				extraChanges?: VisualChange[]
 			}
@@ -45,10 +41,6 @@ export type VisualChange =
 				review?: {
 					acceptFn: () => void
 					rejectFn: () => void
-					labels?: {
-						primary?: string
-						secondary?: string
-					}
 				}
 			}
 	  }
@@ -118,8 +110,7 @@ white-space: pre;
 function getReviewButtons(
 	editor: meditor.IStandaloneCodeEditor,
 	acceptFn: () => void,
-	rejectFn: () => void,
-	labels?: { primary?: string; secondary?: string }
+	rejectFn: () => void
 ) {
 	const { contentWidth, verticalScrollbarWidth } = editor.getLayoutInfo()
 	const scrollLeft = editor.getScrollLeft()
@@ -142,7 +133,7 @@ function getReviewButtons(
 	})
 
 	const acceptButton = document.createElement('button')
-	acceptButton.textContent = labels?.primary || 'Accept'
+	acceptButton.textContent = 'Accept'
 	Object.assign(acceptButton.style, {
 		color: 'black',
 		padding: '0.1rem 0.2rem',
@@ -155,7 +146,7 @@ function getReviewButtons(
 	const layout = editor.getLayoutInfo()
 	layout.width
 	const rejectButton = document.createElement('button')
-	rejectButton.textContent = labels?.secondary || 'Reject'
+	rejectButton.textContent = 'Reject'
 	Object.assign(rejectButton.style, {
 		color: 'black',
 		padding: '0.1rem 0.2rem',
@@ -180,10 +171,6 @@ async function addMultilineGhostText(
 		review?: {
 			acceptFn: () => void
 			rejectFn: () => void
-			labels?: {
-				primary?: string
-				secondary?: string
-			}
 		}
 		extraChanges?: VisualChange[]
 	},
@@ -193,12 +180,7 @@ async function addMultilineGhostText(
 	el.textContent = text
 
 	if (options?.review) {
-		const reviewButtons = getReviewButtons(
-			editor,
-			options.review.acceptFn,
-			options.review.rejectFn,
-			options.review.labels
-		)
+		const reviewButtons = getReviewButtons(editor, options.review.acceptFn, options.review.rejectFn)
 		el.append(reviewButtons)
 	}
 	applyMonacoStyles(el, options?.greenHighlight, revertMode)
@@ -254,8 +236,7 @@ export async function displayVisualChanges(
 							const reviewButtons = getReviewButtons(
 								editor,
 								change.options.review.acceptFn,
-								change.options.review.rejectFn,
-								change.options.review.labels
+								change.options.review.rejectFn
 							)
 							el.append(reviewButtons)
 							resolve(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add functionality to revert specific lines in inline script suggestions, enhancing AI chat editor capabilities.
> 
>   - **Behavior**:
>     - Add `reviewAppliedCode()` in `Editor.svelte` to handle reverting specific lines in inline script suggestions.
>     - Modify `GlobalReviewButtons` in `Editor.svelte` to support revert mode with `keepAll()` and `revertAll()`.
>   - **AIChatEditorHandler**:
>     - Add `reviewChanges()` in `monaco-adapter.ts` to handle both apply and revert modes.
>     - Introduce `keepAll()` and `revertAll()` for handling revert mode.
>     - Update `calculateVisualChanges()` to support visual changes in revert mode.
>   - **Visual Changes**:
>     - Update `displayVisualChanges()` in `shared.ts` to handle revert mode styling.
>     - Modify `applyMonacoStyles()` to apply different styles based on revert mode.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 90d65bda66c3a560c7e6b508bb0121b475251b36. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->