### PR TITLE
bump go version & add private packages go support

### DIFF
--- a/lsp/Dockerfile
+++ b/lsp/Dockerfile
@@ -9,7 +9,7 @@ ENV PIPENV_VENV_IN_PROJECT=1
 ENV XDG_CACHE_HOME=/pyls/.cache
 
 RUN apt-get update \
-    && apt-get install -y shellcheck wget \
+    && apt-get install -y shellcheck wget git ca-certificates \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && pip install pipenv
@@ -21,13 +21,13 @@ RUN set -eux; \
     url=; \
     case "$arch" in \
     'amd64') \
-    targz='go1.22.5.linux-amd64.tar.gz'; \
+    targz='go1.25.0.linux-amd64.tar.gz'; \
     ;; \
     'arm64') \
-    targz='go1.22.5.linux-arm64.tar.gz'; \
+    targz='go1.25.0.linux-arm64.tar.gz'; \
     ;; \
     'armhf') \
-    targz='go1.22.5.linux-armv6l.tar.gz'; \
+    targz='go1.25.0.linux-armv6l.tar.gz'; \
     ;; \
     *) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
     esac; \
@@ -59,4 +59,4 @@ RUN chmod -R a+rX /usr/local && \
 
 EXPOSE 3001
 
-CMD ["sh", "-c", "if [ -d /root/.cache ]; then export XDG_CACHE_HOME=/root/.cache && cp -r /pyls/.cache /root/.cache; fi && python3 pyls_launcher.py"]
+CMD ["sh", "-c", "if [ -n \"$NETRC\" ]; then echo \"$NETRC\" > /root/.netrc && chmod 600 /root/.netrc; fi && if [ -d /root/.cache ]; then export XDG_CACHE_HOME=/root/.cache && cp -r /pyls/.cache /root/.cache; fi && python3 pyls_launcher.py"]

--- a/lsp/pyls_launcher.py
+++ b/lsp/pyls_launcher.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     go_mod_path = os.path.join(monaco_path, "go.mod")
     if not os.path.exists(go_mod_path):
         f = open(go_mod_path, "w")
-        f.write("module mymod\ngo 1.22")
+        f.write("module mymod\ngo 1.25")
         f.close()
     port = int(os.environ.get("PORT", "3001"))
     app = web.Application(


### PR DESCRIPTION
Bump go version of LSP, following https://github.com/windmill-labs/windmill/pull/6415.

I also added the support for private go packages by adding git and ca-certificates packages in the Dockerfile + the support for the NETRC env variable as it is done in the windmill_worker.