### PR TITLE
fix(frontend): capture/trigger UI nits

### DIFF
--- a/frontend/src/lib/components/triggers/CaptureWrapper.svelte
+++ b/frontend/src/lib/components/triggers/CaptureWrapper.svelte
@@ -2,7 +2,7 @@
 	import { workspaceStore } from '$lib/stores'
 	import { CaptureService, type CaptureConfig, type CaptureTriggerKind } from '$lib/gen'
 	import { onDestroy, untrack } from 'svelte'
-	import { isObject, sendUserToast, sleep } from '$lib/utils'
+	import { sendUserToast, sleep } from '$lib/utils'
 	import RouteCapture from './http/RouteCapture.svelte'
 	import type { ConnectionInfo } from '../common/alert/ConnectionIndicator.svelte'
 	import type { CaptureInfo } from './CaptureSection.svelte'
@@ -37,7 +37,7 @@
 		captureType = 'webhook',
 		data = {},
 		connectionInfo = $bindable(undefined),
-		args = $bindable({}),
+		args = {},
 		isValid = false,
 		triggerDeployed = false
 	}: Props = $props()
@@ -100,7 +100,6 @@
 		}
 		return captureConfigs
 	}
-	getCaptureConfigs().then((captureConfigs) => setDefaultArgs(captureConfigs))
 
 	async function capture() {
 		let i = 0
@@ -118,16 +117,6 @@
 			i++
 			await sleep(1000)
 		}
-	}
-
-	function setDefaultArgs(captureConfigs: { [key: string]: CaptureConfig }) {
-		if (captureType in captureConfigs) {
-			const triggerConfig = captureConfigs[captureType].trigger_config
-			args = isObject(triggerConfig) ? triggerConfig : {}
-		} else {
-			args = {}
-		}
-		ready = true
 	}
 
 	onDestroy(() => {

--- a/frontend/src/lib/components/triggers/http/RouteEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/http/RouteEditorInner.svelte
@@ -596,7 +596,7 @@
 				{can_write}
 				bind:static_asset_config
 				showTestingBadge={isEditor}
-				isDraftOnly={trigger?.isDraft}
+				isDraftOnly={trigger ? trigger.isDraft : false}
 			/>
 
 			{#if !is_static_website}

--- a/frontend/src/lib/components/triggers/websocket/WebsocketTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/websocket/WebsocketTriggerEditorInner.svelte
@@ -417,8 +417,8 @@
 				</Label>
 			</div>
 
-			{#if !hideTarget}
-				<Section label="Runnable" class="flex flex-col gap-4">
+			<Section label={hideTarget ? 'Runnable options' : 'Runnable'} class="flex flex-col gap-4">
+				{#if !hideTarget}
 					<div>
 						<p class="text-xs mb-1 text-tertiary">
 							Pick a script or flow to be triggered<Required required={true} />
@@ -449,21 +449,21 @@
 							{/if}
 						</div>
 					</div>
+				{/if}
 
-					<Toggle
-						checked={can_return_message}
-						on:change={() => {
-							can_return_message = !can_return_message
-						}}
-						options={{
-							right: 'Send runnable result',
-							rightTooltip:
-								'Whether the runnable result should be sent as a message to the websocket server when not null.'
-						}}
-						disabled={!can_write}
-					/>
-				</Section>
-			{/if}
+				<Toggle
+					checked={can_return_message}
+					on:change={() => {
+						can_return_message = !can_return_message
+					}}
+					options={{
+						right: 'Send runnable result',
+						rightTooltip:
+							'Whether the runnable result should be sent as a message to the websocket server when not null.'
+					}}
+					disabled={!can_write}
+				/>
+			</Section>
 
 			<WebsocketEditorConfigSection
 				bind:url


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix UI nits in trigger components by removing unused imports, adjusting default values, and improving conditional rendering.
> 
>   - **CaptureWrapper.svelte**:
>     - Remove `isObject` import and `setDefaultArgs()` function.
>     - Initialize `args` directly as an empty object.
>     - Remove `getCaptureConfigs().then()` call.
>   - **RouteEditorInner.svelte**:
>     - Fix `isDraftOnly` prop to handle undefined `trigger`.
>   - **WebsocketTriggerEditorInner.svelte**:
>     - Adjust `Section` label based on `hideTarget` value.
>     - Move `Toggle` component outside of `if` block for `hideTarget`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f837f6af6b2cb0108098aa1df9b39c111637000f. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->