### PR TITLE
fix(cloud): only load premium info when workspace admin

### DIFF
--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -378,7 +378,7 @@
 	$effect(() => {
 		if (isCloudHosted()) {
 			const workspace = $workspaceStore
-			if (workspace) {
+			if (workspace && $userStore?.is_admin) {
 				checkTeamPlanStatus(workspace)
 			}
 		}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize premium info loading in `+layout.svelte` by checking admin status before calling `checkTeamPlanStatus()`.
> 
>   - **Behavior**:
>     - In `+layout.svelte`, `checkTeamPlanStatus()` is now only called if `$userStore?.is_admin` is true, ensuring premium info is loaded only for workspace admins.
>   - **Conditions**:
>     - Added `$userStore?.is_admin` check in `$effect` for cloud-hosted environments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 73128853f4c672104862e9e391376cca02fb47d4. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->