### PR TITLE
fix s3 proxy dev build

### DIFF
--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -100,7 +100,7 @@ mod integration;
 mod live_migrations;
 #[cfg(feature = "postgres_trigger")]
 mod postgres_triggers;
-#[cfg(all(feature = "private"))]
+#[cfg(all(feature = "private", feature = "parquet"))]
 pub mod s3_proxy_ee;
 mod s3_proxy_oss;
 
@@ -661,10 +661,9 @@ pub async fn run_server(
                     "/w/:workspace_id/capture_u",
                     capture::workspaced_unauthed_service().layer(cors.clone()),
                 )
-                .nest(
-                    "/w/:workspace_id/s3_proxy",
-                    s3_proxy_oss::workspaced_unauthed_service(),
-                )
+                .nest("/w/:workspace_id/s3_proxy", {
+                    s3_proxy_oss::workspaced_unauthed_service()
+                })
                 .nest(
                     "/auth",
                     users::make_unauthed_service().layer(Extension(argon2)),

--- a/backend/windmill-api/src/s3_proxy_oss.rs
+++ b/backend/windmill-api/src/s3_proxy_oss.rs
@@ -1,11 +1,8 @@
-#[cfg(feature = "private")]
+#[cfg(all(feature = "private", feature = "parquet"))]
 #[allow(unused)]
 pub use crate::s3_proxy_ee::*;
 
-#[cfg(not(feature = "private"))]
-use axum::Router;
-
-#[cfg(not(feature = "private"))]
-pub fn workspaced_unauthed_service() -> Router {
-    Router::new()
+#[cfg(not(all(feature = "private", feature = "parquet")))]
+pub fn workspaced_unauthed_service() -> axum::Router {
+    axum::Router::new()
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix S3 proxy build by adding feature flags for `private` and `parquet` in `lib.rs` and `s3_proxy_oss.rs`.
> 
>   - **Feature Flags**:
>     - In `lib.rs`, `s3_proxy_ee` is now conditionally compiled with both `private` and `parquet` features.
>     - In `s3_proxy_oss.rs`, `workspaced_unauthed_service()` is conditionally compiled when not both `private` and `parquet` features are enabled.
>   - **Functionality**:
>     - In `lib.rs`, the `s3_proxy_oss::workspaced_unauthed_service()` is used in the `/w/:workspace_id/s3_proxy` route.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 106bd4404aade0f94966180ebcf95e0690dd4e70. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->