### PR TITLE
chore: fix wrong change on togglebuttongroup display

### DIFF
--- a/frontend/src/lib/components/AIProviderPicker.svelte
+++ b/frontend/src/lib/components/AIProviderPicker.svelte
@@ -148,7 +148,7 @@
 <div class="w-full flex flex-col gap-3">
 	<!-- Provider Selection -->
 	<div class="flex flex-col gap-2">
-		<ToggleButtonGroup selected={value?.kind} onSelected={onProviderChange} {disabled}>
+		<ToggleButtonGroup selected={value?.kind} onSelected={onProviderChange} {disabled} wrap>
 			{#snippet children({ item })}
 				{#each providerOptions as option}
 					<ToggleButton value={option.value} label={option.label} {item} />

--- a/frontend/src/lib/components/common/toggleButton-v2/ToggleButtonGroup.svelte
+++ b/frontend/src/lib/components/common/toggleButton-v2/ToggleButtonGroup.svelte
@@ -14,6 +14,7 @@
 		tabListClass?: string
 		allowEmpty?: boolean
 		class?: string
+		wrap?: boolean
 		children?: import('svelte').Snippet<[any]>
 		onSelected?: (value: any) => void
 	}
@@ -26,6 +27,7 @@
 		tabListClass = '',
 		allowEmpty = false,
 		class: className = '',
+		wrap = false,
 		onSelected,
 		children
 	}: Props = $props()
@@ -70,7 +72,8 @@
 >
 	<div
 		class={twMerge(
-			'flex bg-surface-secondary rounded-md p-0.5 gap-1 h-full flex-wrap',
+			'flex bg-surface-secondary rounded-md p-0.5 gap-1 h-full',
+			wrap ? 'flex-wrap' : '',
 			tabListClass
 		)}
 	>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `wrap` prop to `ToggleButtonGroup` for button wrapping, applied in `AIProviderPicker.svelte`.
> 
>   - **Behavior**:
>     - Adds `wrap` prop to `ToggleButtonGroup` in `ToggleButtonGroup.svelte` to control button wrapping.
>     - Updates `AIProviderPicker.svelte` to use `wrap` prop in `ToggleButtonGroup` for correct button display.
>   - **Props**:
>     - Adds `wrap?: boolean` to `Props` interface in `ToggleButtonGroup.svelte`.
>   - **Styling**:
>     - Modifies class binding in `ToggleButtonGroup.svelte` to apply `flex-wrap` based on `wrap` prop.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for eb586a8e8c13f4f37abf5f8dbeb17ff146e01e77. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->