### PR TITLE
chore(aiagent): select first provider on init

### DIFF
--- a/frontend/src/lib/components/AIProviderPicker.svelte
+++ b/frontend/src/lib/components/AIProviderPicker.svelte
@@ -98,6 +98,10 @@
 			value.model = undefined
 		}
 
+		if (!provider) {
+			value.kind = Object.keys(AI_PROVIDERS)[0] as AIProvider
+		}
+
 		if (provider && resourcePath) {
 			loadModels(abortController.signal)
 		} else {

--- a/frontend/src/lib/components/AIProviderPicker.svelte
+++ b/frontend/src/lib/components/AIProviderPicker.svelte
@@ -25,7 +25,12 @@
 
 	// Initialize value if undefined
 	if (!value) {
-		value = {}
+		const providers = Object.keys(AI_PROVIDERS)
+		value = {
+			kind: providers.length > 0 ? (providers[0] as AIProvider) : undefined,
+			resource: undefined,
+			model: undefined
+		}
 	}
 
 	let loading = $state(false)
@@ -96,10 +101,6 @@
 		filterText = ''
 		if (value) {
 			value.model = undefined
-		}
-
-		if (!provider) {
-			value.kind = Object.keys(AI_PROVIDERS)[0] as AIProvider
 		}
 
 		if (provider && resourcePath) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Initialize `value.kind` to the first provider in `AIProviderPicker.svelte` if `value` is undefined.
> 
>   - **Behavior**:
>     - In `AIProviderPicker.svelte`, initialize `value.kind` to the first provider in `AI_PROVIDERS` if `value` is undefined.
>     - Sets `value.resource` and `value.model` to `undefined` during initialization.
>   - **Misc**:
>     - No changes to other files or functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for a71300ce9dd40bb292fefa0b02cc0a3c31daeadd. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->