### PR TITLE
fix(flows): fix relative imports cache invalidation [ext]

### DIFF
--- a/backend/windmill-worker/src/worker_lockfiles.rs
+++ b/backend/windmill-worker/src/worker_lockfiles.rs
@@ -1053,9 +1053,7 @@ pub async fn handle_flow_dependency_job(
         .await?;
 
         // NOTE: Temporary solution.
-        // Making new version viewable as the current one.
         // Ideally we do this for every job regardless whether it was triggered by relative import or by creation/update of the flow.
-        // This will also trigger `flow_versions_append_trigger` (check _flow_versions_update_notify.up.sql)
         if triggered_by_relative_import {
             // Making new version viewable as the current one.
             // This will also trigger `flow_versions_append_trigger` (check _flow_versions_update_notify.up.sql)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add handling for cache invalidation on relative imports in flow dependencies by introducing `triggered_by_relative_import` argument in `worker_lockfiles.rs`.
> 
>   - **Behavior**:
>     - Add `triggered_by_relative_import` argument in `trigger_dependents_to_recompute_dependencies()` and `handle_flow_dependency_job()` to handle cache invalidation for relative imports.
>     - Conditional flow version update in `handle_flow_dependency_job()` based on `triggered_by_relative_import` to prevent unnecessary cache invalidation.
>   - **Functions**:
>     - Modify `trigger_dependents_to_recompute_dependencies()` to insert `triggered_by_relative_import` argument.
>     - Update `handle_flow_dependency_job()` to check `triggered_by_relative_import` before updating flow versions.
>   - **Misc**:
>     - Add comments indicating temporary solutions and areas for future improvement.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 388b3414ad94915b30d68c9b4f44f884fbb41063. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->