### PR TITLE
chore: fix typo in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -210,7 +210,7 @@
               set -e
               cd ./backend
               ${pkgs.minio-client}/bin/mc alias set 'wmill-minio-dev' 'http://localhost:9000' 'minioadmin' 'minioadmin'
-              ${pkgs.minio-client}/bin/mc admin accesskey create myminio | tee .minio-data/secrets.txt
+              ${pkgs.minio-client}/bin/mc admin accesskey create 'wmill-minio-dev' | tee .minio-data/secrets.txt
               echo ""
               echo 'Saving to: ./backend/.minio-data/secrets.txt'
               echo "bucket: wmill"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes alias name typo in `flake.nix` for MinIO client access key creation.
> 
>   - **Fix**:
>     - Corrects alias name from `myminio` to `wmill-minio-dev` in `flake.nix` for MinIO client access key creation command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 7f4c806e2725e076ecd71f6fde616b510326ec09. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->