### PR TITLE
fix css editor left panel broken bc bindable with default value

### DIFF
--- a/frontend/src/lib/components/apps/editor/componentsPanel/ListItem.svelte
+++ b/frontend/src/lib/components/apps/editor/componentsPanel/ListItem.svelte
@@ -29,7 +29,7 @@
 		wrapperClasses = '',
 		toggleClasses = '',
 		contentWrapperClasses = '',
-		isOpen = $bindable(false),
+		isOpen = $bindable(),
 		tooltip = undefined,
 		documentationLink = undefined,
 		subtitle = undefined,
@@ -45,7 +45,7 @@
 	})
 
 	$effect(() => {
-		dispatch('open', isOpen)
+		dispatch('open', isOpen ?? false)
 	})
 
 	onMount(() => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `isOpen` default in `ListItem.svelte` to resolve CSS editor left panel issue.
> 
>   - **Bug Fix**:
>     - In `ListItem.svelte`, change `isOpen` default from `$bindable(false)` to `$bindable()` to fix CSS editor left panel issue.
>     - Ensure `dispatch('open', isOpen ?? false)` sends `false` if `isOpen` is undefined.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f7420cc9db23ba18654b3076256f8a3eff41a1e9. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->