### PR TITLE
fix: run preprocessor even if empty flow

### DIFF
--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -2007,8 +2007,10 @@ async fn push_next_flow_job(
         }
     });
 
-    // if this is an empty module of if the module has already been completed, successfully, update the parent flow
-    if flow.modules.is_empty() || matches!(status_module, FlowStatusModule::Success { .. }) {
+    // if this is an empty module without preprocessor of if the module has already been completed, successfully, update the parent flow
+    if (flow.modules.is_empty() && !step.is_preprocessor_step())
+        || matches!(status_module, FlowStatusModule::Success { .. })
+    {
         return Ok(PushNextFlowJob::Done(Some(UpdateFlow {
             flow: flow_job.id,
             success: true,

--- a/frontend/src/lib/components/FlowStatusViewerInner.svelte
+++ b/frontend/src/lib/components/FlowStatusViewerInner.svelte
@@ -1292,14 +1292,17 @@
 						{/if}
 					{/each}
 				</div>
-			{:else if innerModules && innerModules.length > 0 && (job.raw_flow?.modules.length ?? 0) > 0}
+			{:else if innerModules && innerModules.length > 0 && ((job.raw_flow?.modules.length ?? 0) > 0 || innerModules[0]?.id == 'preprocessor')}
 				{@const hasPreprocessor = innerModules[0]?.id == 'preprocessor' ? 1 : 0}
+				{@const isPreprocessorOnly = hasPreprocessor && (job.raw_flow?.modules.length ?? 0) === 0}
+				<!-- if the flow is preprocessor only, we should only display the first innerModule: the second one is a placeholder added when running empty flows -->
+				{@const modules = isPreprocessorOnly ? [innerModules[0]] : (innerModules ?? [])}
 				<ul class="w-full">
 					<h3 class="text-md leading-6 font-bold text-primary border-b mb-4 py-2">
 						Step-by-step
 					</h3>
 
-					{#each innerModules ?? [] as mod, i}
+					{#each modules as mod, i}
 						{#if render}
 							<div class="line w-8 h-10"></div>
 							<h3 class="text-tertiary mb-2 w-full">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensure preprocessor step runs in empty flows by updating conditions in `worker_flow.rs` and `FlowStatusViewerInner.svelte`.
> 
>   - **Backend**:
>     - In `worker_flow.rs`, modify `push_next_flow_job()` to run preprocessor even if flow is empty by checking `step.is_preprocessor_step()`.
>   - **Frontend**:
>     - In `FlowStatusViewerInner.svelte`, update conditions to display preprocessor module when flow is empty by checking `innerModules[0]?.id == 'preprocessor'`.
>     - Adjust logic to handle preprocessor-only flows by setting `modules` to `[innerModules[0]]` if preprocessor is the only module.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 4992839f3f0bc6b88abca81db91948e255ef6641. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->