### PR TITLE
fix(aichat): fix revert all issue on flow mode

### DIFF
--- a/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
@@ -99,8 +99,10 @@
 			}
 		},
 		rejectAllModuleActions() {
-			for (const id of Object.keys(affectedModules)) {
-				this.revertModuleAction(id)
+			// Do it in reverse to revert nested modules first then parents
+			const ids = Object.keys(affectedModules)
+			for (let i = ids.length - 1; i >= 0; i--) {
+				this.revertModuleAction(ids[i])
 			}
 			affectedModules = {}
 		},


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `rejectAllModuleActions()` in `FlowAIChat.svelte` to revert nested modules before parent modules by iterating in reverse order.
> 
>   - **Behavior**:
>     - Fixes `rejectAllModuleActions()` in `FlowAIChat.svelte` to revert nested modules before parent modules by iterating in reverse order.
>   - **Misc**:
>     - No other files or functions are affected by this change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 041f5266bde83595061b14ef00a69ff3694ce7dd. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->