### PR TITLE
feat(frontend): allow publishing script to hub from list view

### DIFF
--- a/frontend/src/lib/components/common/table/ScriptRow.svelte
+++ b/frontend/src/lib/components/common/table/ScriptRow.svelte
@@ -8,7 +8,7 @@
 	import type ShareModal from '$lib/components/ShareModal.svelte'
 
 	import { ScriptService, type Script, DraftService } from '$lib/gen'
-	import { userStore, workspaceStore } from '$lib/stores'
+	import { hubBaseUrlStore, userStore, workspaceStore } from '$lib/stores'
 
 	import { createEventDispatcher } from 'svelte'
 	import Badge from '../badge/Badge.svelte'
@@ -34,13 +34,15 @@
 		Pen,
 		Share,
 		Trash,
-		History
+		History,
+		Globe2
 	} from 'lucide-svelte'
 	import ScriptVersionHistory from '$lib/components/ScriptVersionHistory.svelte'
 	import { Drawer, DrawerContent } from '..'
 	import NoMainFuncBadge from '$lib/components/NoMainFuncBadge.svelte'
 	import Tooltip from '$lib/components/Tooltip.svelte'
 	import { getDeployUiSettings } from '$lib/components/home/deploy_ui'
+	import { scriptToHubUrl } from '$lib/hub'
 
 	interface Props {
 		script: Script & { canWrite: boolean; use_codebase: boolean }
@@ -298,6 +300,25 @@
 						icon: Copy,
 						action: () => {
 							copyToClipboard(script.path)
+						}
+					},
+					{
+						displayName: 'Publish to Hub',
+						icon: Globe2,
+						action: () => {
+							window.open(
+								scriptToHubUrl(
+									script.content,
+									script.summary,
+									script.description ?? '',
+									script.kind,
+									script.language,
+									script.schema,
+									script.lock ?? '',
+									$hubBaseUrlStore
+								).toString(),
+								'_blank'
+							)
 						}
 					},
 					{


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds "Publish to Hub" action in `ScriptRow.svelte` to open scripts in a new tab on the hub.
> 
>   - **Behavior**:
>     - Adds "Publish to Hub" action in `ScriptRow.svelte` dropdown menu.
>     - Opens a new tab with the hub URL using `scriptToHubUrl()`.
>   - **Stores**:
>     - Imports `hubBaseUrlStore` in `ScriptRow.svelte` for hub URL construction.
>   - **Icons**:
>     - Adds `Globe2` icon from `lucide-svelte` for the new action.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for a909118cab2f30ffcd2d1ae1d3cf1e3c635b4b8a. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->