### PR TITLE
Fix flow quick picker stuck

### DIFF
--- a/frontend/src/lib/components/common/popup/PopupV2.svelte
+++ b/frontend/src/lib/components/common/popup/PopupV2.svelte
@@ -8,8 +8,8 @@
 		floatingConfig?: ComputeConfig
 		open?: boolean
 		target?: string | undefined
-		button?: import('svelte').Snippet<[any]>
-		children?: import('svelte').Snippet<[any]>
+		button?: import('svelte').Snippet
+		children?: import('svelte').Snippet<[{ close: () => void }]>
 	}
 
 	let {
@@ -31,26 +31,10 @@
 	function close(div: Element | null) {
 		open = false
 	}
-
-	let acceptClickoutside = $state(false)
-	function pointerup() {
-		setTimeout(() => {
-			acceptClickoutside = true
-		}, 100)
-	}
-
-	function pointerdown() {
-		if (acceptClickoutside && open) {
-			open = false
-		} else {
-			acceptClickoutside = false
-			open = true
-		}
-	}
 </script>
 
 <div use:floatingRef>
-	{@render button?.({ pointerup, pointerdown })}
+	{@render button?.()}
 </div>
 
 <Portal name="popup-v2" {target}>
@@ -61,17 +45,13 @@
 			use:floatingContent
 			transition:fly={{ duration: 100, y: -16 }}
 		>
-			<!-- svelte-ignore event_directive_deprecated -->
 			<div
-				use:clickOutside
-				on:click_outside={() => {
-					if (acceptClickoutside) {
-						acceptClickoutside = false
-						open = false
-					}
+				use:clickOutside={{
+					eventToListenName: 'pointerdown',
+					onClickOutside: () => (open = false)
 				}}
 			>
-				{@render children?.({ close })}
+				{@render children?.({ close: () => close(null) })}
 			</div>
 		</div>
 	{/if}

--- a/frontend/src/lib/components/common/popup/PopupV2.svelte
+++ b/frontend/src/lib/components/common/popup/PopupV2.svelte
@@ -28,7 +28,7 @@
 	// export let floatingClasses: string = ''
 	const [floatingRef, floatingContent] = createFloatingActions(floatingConfig)
 
-	function close(div: Element | null) {
+	function close() {
 		open = false
 	}
 </script>

--- a/frontend/src/lib/components/flows/map/InsertModuleButton.svelte
+++ b/frontend/src/lib/components/flows/map/InsertModuleButton.svelte
@@ -88,7 +88,7 @@ shouldUsePortal={true} -->
 	{/snippet}
 	{#snippet children({ close })}
 		<InsertModuleInner
-			on:close={() => close(null)}
+			on:close={() => close()}
 			on:insert
 			on:new
 			on:pickFlow

--- a/frontend/src/lib/components/flows/map/InsertModuleButton.svelte
+++ b/frontend/src/lib/components/flows/map/InsertModuleButton.svelte
@@ -1,7 +1,4 @@
 <script lang="ts">
-	import { preventDefault, stopPropagation } from 'svelte/legacy'
-
-	import { createEventDispatcher } from 'svelte'
 	import { Bug, Cross } from 'lucide-svelte'
 	import InsertModuleInner from './InsertModuleInner.svelte'
 	import { twMerge } from 'tailwind-merge'
@@ -12,8 +9,6 @@
 	import { SchedulePollIcon } from '$lib/components/icons'
 
 	// import type { Writable } from 'svelte/store'
-
-	const dispatch = createEventDispatcher()
 
 	type Alignment = 'start' | 'end' | 'center'
 	type Side = 'top' | 'bottom'
@@ -60,7 +55,7 @@ noTransition
 shouldUsePortal={true} -->
 
 <PopupV2 {floatingConfig} bind:open target="#flow-editor">
-	{#snippet button({ pointerdown, pointerup })}
+	{#snippet button()}
 		<button
 			title={`Add ${
 				kind === 'failure'
@@ -77,13 +72,7 @@ shouldUsePortal={true} -->
 				'w-[17.5px] h-[17.5px] flex items-center justify-center !outline-[1px] outline dark:outline-gray-500 outline-gray-300 text-secondary bg-surface focus:outline-none hover:bg-surface-hover rounded',
 				clazz
 			)}
-			onpointerdown={stopPropagation(
-				preventDefault(() => {
-					dispatch('open')
-					pointerdown()
-				})
-			)}
-			onpointerup={pointerup}
+			onpointerdown={() => (open = !open)}
 		>
 			{#if kind === 'trigger'}
 				<SchedulePollIcon size={14} />

--- a/frontend/src/lib/components/graph/renderers/nodes/NewAIToolNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/NewAIToolNode.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { preventDefault, stopPropagation } from 'svelte/legacy'
-
 	import { twMerge } from 'tailwind-merge'
 	import { type NewAiToolN } from '../../graphBuilder.svelte'
 	import InsertModuleInner from '$lib/components/flows/map/InsertModuleInner.svelte'
@@ -22,11 +20,13 @@
 		middleware: [offset(8), flip()],
 		autoUpdate: true
 	}
+
+	let open = $state(false)
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<PopupV2 {floatingConfig} target="#flow-editor">
-	{#snippet button({ pointerdown, pointerup })}
+<PopupV2 bind:open {floatingConfig} target="#flow-editor">
+	{#snippet button()}
 		<button
 			title={`Add 'tool'
 			}`}
@@ -34,12 +34,7 @@
 			class={twMerge(
 				'!w-full h-6 flex items-center justify-center !outline-[1px] outline dark:outline-gray-500 outline-gray-300 text-secondary bg-surface focus:outline-none hover:bg-surface-hover rounded'
 			)}
-			onpointerdown={stopPropagation(
-				preventDefault(() => {
-					pointerdown()
-				})
-			)}
-			onpointerup={pointerup}
+			onpointerdown={() => (open = !open)}
 		>
 			<div class="flex flex-row items-center gap-1 font-medium text-2xs">
 				<Cross size={12} />

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -309,6 +309,7 @@ interface ClickOutsideOptions {
 	exclude?: (() => Promise<HTMLElement[]>) | HTMLElement[] | undefined
 	stopPropagation?: boolean
 	customEventName?: string
+	eventToListenName?: 'click' | 'pointerdown'
 	// on:click_outside cannot be used with svelte 5
 	onClickOutside?: (event: MouseEvent) => void
 }
@@ -355,14 +356,15 @@ export function clickOutside(
 	}
 
 	const capture = typeof options === 'boolean' ? options : (options?.capture ?? true)
-	document.addEventListener('click', handleClick, capture ?? true)
+	const eventToListenName = (typeof options === 'object' && options.eventToListenName) || 'click'
+	document.addEventListener(eventToListenName, handleClick, capture ?? true)
 
 	return {
 		update(newOptions: ClickOutsideOptions | boolean) {
 			options = newOptions
 		},
 		destroy() {
-			document.removeEventListener('click', handleClick, capture ?? true)
+			document.removeEventListener(eventToListenName, handleClick, capture ?? true)
 		}
 	}
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes flow quick picker issue by simplifying event handling in `PopupV2.svelte` and updating `clickOutside` utility to support `pointerdown` events.
> 
>   - **Behavior**:
>     - Simplified event handling in `PopupV2.svelte` by removing `pointerup` and `pointerdown` functions.
>     - Updated `clickOutside` directive to listen to `pointerdown` events instead of `click`.
>   - **Components**:
>     - Removed `preventDefault` and `stopPropagation` imports from `InsertModuleButton.svelte` and `NewAIToolNode.svelte`.
>     - Updated button event handling in `InsertModuleButton.svelte` and `NewAIToolNode.svelte` to toggle `open` state directly.
>   - **Utils**:
>     - Added `eventToListenName` option to `clickOutside` function in `utils.ts` to support `pointerdown` events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f8941e1496f9be285f0bff4adf7bba4ad1bd1edb. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->