### PR TITLE
fix(backend): build on macos with deno_core

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -15796,6 +15796,7 @@ dependencies = [
  "itertools 0.14.0",
  "jsonwebtoken 8.3.0",
  "lazy_static",
+ "libffi-sys",
  "libloading 0.8.8",
  "mappable-rc",
  "mime_guess",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -68,6 +68,7 @@ jemalloc = ["windmill-common/jemalloc", "dep:tikv-jemallocator", "dep:tikv-jemal
 tantivy = ["dep:windmill-indexer", "windmill-api/tantivy", "windmill-indexer/enterprise", "windmill-indexer/parquet", "windmill-common/tantivy", "enterprise", "parquet"]
 sqlx = ["windmill-worker/sqlx"]
 deno_core = ["windmill-worker/deno_core", "windmill-api/deno_core", "dep:deno_core", "dep:v8"]
+deno_core_mac = ["deno_core", "windmill-worker/libffi_mac"]
 kafka = ["windmill-api/kafka"]
 nats = ["windmill-api/nats"]
 otel = ["windmill-common/otel", "windmill-worker/otel"]
@@ -274,6 +275,9 @@ deno_permissions = "0.49.0"
 deno_runtime = { version = "0.198.0", features = ["transpile"] }
 deno_telemetry = "0.12.0"
 deno_error = "=0.5.5"
+
+# only used with special deno_core_mac feature to prevent ffi issue on macos, requires libffi to be installed
+libffi-sys = { version = "2.3.0", features = ["system"]}
 
 google-cloud-pubsub = "0.30.0"
 google-cloud-googleapis = {version = "0.16.1", features = ["pubsub"]}

--- a/backend/windmill-worker/Cargo.toml
+++ b/backend/windmill-worker/Cargo.toml
@@ -22,6 +22,7 @@ cloud = []
 sqlx = []
 deno_core = ["dep:deno_fetch", "dep:deno_webidl", "dep:deno_web", "dep:deno_net", "dep:deno_console", "dep:deno_url", "dep:deno_core",
     "dep:deno_ast", "dep:deno_tls", "dep:deno_permissions", "dep:deno_io", "dep:deno_runtime", "dep:deno_telemetry", "dep:deno_error", "dep:winapi"]
+libffi_mac = ["dep:libffi-sys"]
 otel = ["windmill-common/otel", "dep:opentelemetry"]
 dind = ["dep:bollard"]
 php = ["dep:windmill-parser-php"]
@@ -147,3 +148,4 @@ deno_io = { workspace = true, optional = true }
 deno_runtime = { workspace = true, optional = true }
 deno_telemetry = { workspace = true, optional = true }
 winapi = { workspace = true, optional = true }
+libffi-sys = { workspace = true, optional = true }

--- a/frontend/README_DEV.md
+++ b/frontend/README_DEV.md
@@ -139,15 +139,6 @@ If you develop wasm parser for new language you can also pass `--wasm-pkg <langu
 
 - To test that you have Rust and Cargo installed run `cargo --version`
 
-**Known issue on M1 Mac while running `cargorun`**
-
-- You may encounter `linking with cc failed` build time error.
-- To solve this run:
-  ```bash
-  echo 'export RUSTFLAGS="-L/opt/homebrew/opt/libomp/lib"' >> ~/.zshrc
-  source ~/.zshrc
-  ```
-
 In the root folder:
 
 ```bash
@@ -165,6 +156,20 @@ In the frontend folder:
 ```bash
 REMOTE=http://127.0.0.1:8000 REMOTE_LSP=http://127.0.0.1:3001 npm run dev
 ```
+
+**Known issue on M1 Mac while running `cargo run`**
+
+- You may encounter `linking with cc failed` build time error.
+- To solve this run:
+  ```bash
+  echo 'export RUSTFLAGS="-L/opt/homebrew/opt/libomp/lib"' >> ~/.zshrc
+  source ~/.zshrc
+  ```
+
+**Known issue on M1 Mac while running `cargo run` with the `deno_core` feature**
+
+- You may encounter ``failed to run custom build command for `libffi-sys v2.3.0` `` build time error.
+- To solve this use the `deno_core_mac` feature flag _instead_ of `deno_core`. You might need to install `libffi` (e.g. `brew install libffi`).
 
 ### Formatting
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `deno_core_mac` feature and `libffi-sys` dependency to fix macOS build issues with `deno_core`.
> 
>   - **Features**:
>     - Add `deno_core_mac` feature in `backend/Cargo.toml` and `windmill-worker/Cargo.toml` to handle macOS build issues with `deno_core`.
>     - Add `libffi-sys` dependency in `backend/Cargo.toml` and `windmill-worker/Cargo.toml` for macOS builds.
>   - **Documentation**:
>     - Update `README_DEV.md` to include instructions for using `deno_core_mac` feature on M1 Mac to resolve `libffi-sys` build error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for bda27e6acf1154b5071851d5efd901a227acd109. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->