### PR TITLE
Refresh button in flow picker quick

### DIFF
--- a/frontend/src/lib/components/flows/content/FlowInputsQuick.svelte
+++ b/frontend/src/lib/components/flows/content/FlowInputsQuick.svelte
@@ -38,6 +38,7 @@
 		kind: 'trigger' | 'script' | 'preprocessor' | 'failure' | 'approval'
 		selectedKind?: 'script' | 'flow' | 'approval' | 'trigger' | 'preprocessor' | 'failure'
 		displayPath?: boolean
+		refreshCount?: number
 	}
 
 	let {
@@ -51,7 +52,8 @@
 		small = false,
 		kind,
 		selectedKind = kind,
-		displayPath = false
+		displayPath = false,
+		refreshCount = 0
 	}: Props = $props()
 
 	type HubCompletion = {
@@ -452,9 +454,9 @@
 				on:pickScript
 				on:pickFlow
 				{displayPath}
+				{refreshCount}
 			/>
 		{/if}
-
 		{#if selectedKind != 'preprocessor' && selectedKind != 'flow'}
 			{#if (!selected || selected?.kind === 'integrations') && (preFilter === 'hub' || preFilter === 'all')}
 				{#if !selected && preFilter !== 'hub'}
@@ -475,6 +477,7 @@
 					on:pickScript
 					bind:loading
 					{displayPath}
+					{refreshCount}
 				/>
 			{/if}
 		{/if}

--- a/frontend/src/lib/components/flows/map/InsertModuleInner.svelte
+++ b/frontend/src/lib/components/flows/map/InsertModuleInner.svelte
@@ -5,6 +5,7 @@
 	import type { FlowBuilderWhitelabelCustomUi } from '$lib/components/custom_ui'
 	import ToggleHubWorkspaceQuick from '$lib/components/ToggleHubWorkspaceQuick.svelte'
 	import TopLevelNode from '../pickers/TopLevelNode.svelte'
+	import RefreshButton from '$lib/components/common/button/RefreshButton.svelte'
 
 	const dispatch = createEventDispatcher()
 	interface Props {
@@ -35,6 +36,8 @@
 	let width = $state(0)
 	let height = $state(0)
 
+	let refreshCount = $state(0)
+
 	let displayPath = $derived(width > 650 || height > 400)
 </script>
 
@@ -64,6 +67,7 @@
 		{#if selectedKind != 'preprocessor' && selectedKind != 'flow'}
 			<ToggleHubWorkspaceQuick bind:selected={preFilter} />
 		{/if}
+		<RefreshButton {loading} on:click={() => (refreshCount += 1)} />
 	</div>
 
 	<div class="flex flex-row grow min-h-0">
@@ -165,6 +169,7 @@
 			{preFilter}
 			{small}
 			{displayPath}
+			{refreshCount}
 		/>
 	</div>
 </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a refresh button to flow picker components, using `refreshCount` to trigger data reloads.
> 
>   - **Behavior**:
>     - Adds a `refreshCount` property to `FlowInputsQuick`, `InsertModuleInner`, `PickHubScriptQuick`, and `WorkspaceScriptPickerQuick` components.
>     - Introduces a `RefreshButton` in `InsertModuleInner.svelte` to increment `refreshCount` on click, triggering data refresh.
>   - **Caching**:
>     - Updates `listHubIntegrationsCached` and `listHubScriptsCached` in `PickHubScriptQuick.svelte` to include `refreshCount` as a parameter.
>     - Updates `loadItemsCached` in `WorkspaceScriptPickerQuick.svelte` to include `refreshCount` as a parameter.
>   - **Effects**:
>     - Adds `$effect` in `PickHubScriptQuick.svelte` and `WorkspaceScriptPickerQuick.svelte` to refresh data when `refreshCount` changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 21144b33332d02cd8ee2e6ba27148617f3a994e8. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->