### PR TITLE
internal: add demo command for PRs

### DIFF
--- a/.github/workflows/git-commands.yaml
+++ b/.github/workflows/git-commands.yaml
@@ -119,17 +119,16 @@ jobs:
 
   demo:
     if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/demo')
-    runs-on: ubicloud-standard-8
+    runs-on: ubicloud-standard-2
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
-      id-token: write
+      pull-requests: read
+      issues: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code for Demo Generation
         uses: anthropics/claude-code-action@beta
@@ -152,7 +151,7 @@ jobs:
             Example demo.json:
             {
               "instructions": "Instructions here",
-              "url": "https://preview.cloudflare.com"
+              "url": "https://example.pages.dev"
             }
 
             CRITICAL: After creating demo.json, you MUST:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add a GitHub Actions job to automate demo generation for PRs, creating and validating demo instructions in JSON format.
> 
>   - **New Demo Command**:
>     - Adds `demo` job in `git-commands.yaml` triggered by `/demo` comment on PRs.
>     - Uses `anthropics/claude-code-action@beta` to generate demo instructions and create `demo.json`.
>     - Validates `demo.json` using `jq` and sends it to Windmill if valid.
>   - **Validation and Error Handling**:
>     - Ensures `demo.json` is properly formatted and validated before sending.
>     - Logs errors if `demo.json` is missing or invalid.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 51013d113f127a806dd6497e135e5c8ab81e27d0. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->