### PR TITLE
fix: require refresh_token in oauth api spec

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -3684,6 +3684,7 @@ paths:
               properties:
                 refresh_token:
                   type: string
+                  description: "OAuth refresh token. For authorization_code flow, this contains the actual refresh token. For client_credentials flow, this must be set to an empty string."
                 expires_in:
                   type: integer
                 client:
@@ -3701,6 +3702,7 @@ paths:
                   type: string
                   description: "OAuth token URL override for resource-level authentication (client_credentials flow only)"
               required:
+                - refresh_token
                 - expires_in
                 - client
       responses:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Require `refresh_token` in OAuth API spec and update its description in `openapi.yaml`.
> 
>   - **OpenAPI Spec**:
>     - In `openapi.yaml`, `refresh_token` is now a required field in the OAuth API spec.
>     - Adds description for `refresh_token` to clarify its use in `authorization_code` and `client_credentials` flows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f31d96bfb23554430c9f0fdc7106258a16808244. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->