### PR TITLE
forgot $effect.pre

### DIFF
--- a/frontend/src/lib/components/DynamicInput.svelte
+++ b/frontend/src/lib/components/DynamicInput.svelte
@@ -41,7 +41,7 @@
 	let isMultiple = $derived(inputType === 'dynmultiselect')
 	let isSelect = $derived(inputType === 'dynselect' || inputType === 'dynmultiselect')
 
-	$effect(() => {
+	$effect.pre(() => {
 		if (isMultiple && value === undefined) {
 			value = []
 		}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `$effect` to `$effect.pre` in `DynamicInput.svelte` to ensure correct initialization of `value` for multiple selections.
> 
>   - **Behavior**:
>     - Change `$effect` to `$effect.pre` in `DynamicInput.svelte` to ensure initialization of `value` to an empty array when `isMultiple` and `value` is `undefined`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 866a7fe3919b133cd60b2440574230f5590fcc80. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->