### PR TITLE
fix: websocket runnable

### DIFF
--- a/backend/windmill-api/src/triggers/websocket/handler.rs
+++ b/backend/windmill-api/src/triggers/websocket/handler.rs
@@ -12,6 +12,7 @@ use tokio_tungstenite::connect_async;
 use windmill_common::{
     db::UserDB,
     error::{Error, Result},
+    worker::to_raw_value,
 };
 use windmill_git_sync::DeployedObject;
 
@@ -236,7 +237,7 @@ impl TriggerCrud for WebsocketTrigger {
                         url.starts_with("$flow:"),
                         &db,
                         authed.clone(),
-                        config.url_runnable_args.as_ref(),
+                        config.url_runnable_args.as_ref().map(to_raw_value).as_ref(),
                         &workspace_id,
                     )
                     .await?,

--- a/backend/windmill-api/src/triggers/websocket/mod.rs
+++ b/backend/windmill-api/src/triggers/websocket/mod.rs
@@ -61,11 +61,11 @@ pub struct TestWebsocketConfig {
 }
 
 pub fn value_to_args_hashmap(
-    args: Option<&serde_json::Value>,
+    args: Option<&Box<RawValue>>,
 ) -> Result<HashMap<String, Box<RawValue>>> {
     let args = if let Some(args) = args {
         let args_map: Option<HashMap<String, serde_json::Value>> =
-            serde_json::from_value(args.clone())
+            serde_json::from_str(args.get())
                 .map_err(|e| Error::BadRequest(format!("invalid json: {}", e)))?;
 
         args_map
@@ -89,7 +89,7 @@ pub async fn get_url_from_runnable_value(
     is_flow: bool,
     db: &DB,
     authed: ApiAuthed,
-    args: Option<&serde_json::Value>,
+    args: Option<&Box<RawValue>>,
     workspace_id: &str,
 ) -> Result<String> {
     tracing::info!(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor WebSocket URL handling by replacing `get_url_from_runnable` with `get_url_from_runnable_value` and updating argument processing.
> 
>   - **Refactor WebSocket URL Handling**:
>     - Replace `get_url_from_runnable` with `get_url_from_runnable_value` in `listener.rs` and `handler.rs`.
>     - Modify `get_url_from_runnable_value` to accept `args` as `Option<&Box<RawValue>>`.
>     - Update `value_to_args_hashmap` to handle `Option<&Box<RawValue>>`.
>   - **Argument Handling**:
>     - Use `to_raw_value` for `url_runnable_args` in `handler.rs` and `listener.rs`.
>     - Update `raw_value_to_args_hashmap` to convert `args` to `HashMap`.
>   - **Miscellaneous**:
>     - Remove `get_url_from_runnable` method from `listener.rs`.
>     - Minor logging adjustments in `listener.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for d3884c78b15c57e38e6ecdcee1d660d337095e93. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->