### PR TITLE
Fix typo

### DIFF
--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -745,7 +745,7 @@ pub async fn update_flow_status_after_job_completion_internal(
                                 .await
                                 .map_err(|e| {
                                     Error::internal_err(format!(
-                                        "error while fetching sucess from completed_jobs: {e:#}"
+                                        "error while fetching success from completed_jobs: {e:#}"
                                     ))
                                 })?
                                 .into_iter()

--- a/frontend/src/routes/(root)/(logged)/user/cli-success/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/user/cli-success/+page.svelte
@@ -5,7 +5,7 @@
 
 	import { sendUserToast } from '$lib/toast'
 
-	sendUserToast('Sucess. You can return to your terminal now.')
+	sendUserToast('Success. You can return to your terminal now.')
 	goto('/')
 </script>
 


### PR DESCRIPTION
Fix typo `sucess` -> `success`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes typo from `sucess` to `success` in `worker_flow.rs` and `+page.svelte`.
> 
>   - **Typo Fix**:
>     - Corrects typo `sucess` to `success` in `update_flow_status_after_job_completion_internal()` in `worker_flow.rs`.
>     - Corrects typo `Sucess` to `Success` in `sendUserToast()` in `+page.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 010209ad41f3f45bfbd597febc82ca38fbdbe2b8. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->