### PR TITLE
fix(mcp): use base internal url

### DIFF
--- a/backend/windmill-api/src/mcp/tools/endpoint_tools.rs
+++ b/backend/windmill-api/src/mcp/tools/endpoint_tools.rs
@@ -6,9 +6,8 @@
 use crate::db::ApiAuthed;
 use rmcp::{model::Tool, ErrorData};
 use std::sync::Arc;
-use windmill_common::auth::create_jwt_token;
 use windmill_common::db::Authed;
-use windmill_common::BASE_URL;
+use windmill_common::{auth::create_jwt_token, BASE_INTERNAL_URL};
 
 // Import the auto-generated tools
 use super::auto_generated_endpoints;
@@ -130,7 +129,7 @@ pub async fn call_endpoint_tool(
     let query_string = build_query_string(args_map, &tool.query_params_schema);
     let full_url = format!(
         "{}/api{}{}",
-        BASE_URL.read().await,
+        BASE_INTERNAL_URL.as_str(),
         path_template,
         query_string
     );


### PR DESCRIPTION
Fixes https://github.com/windmill-labs/windmill/issues/6693

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switch `call_endpoint_tool` in `endpoint_tools.rs` to use `BASE_INTERNAL_URL` for API URLs.
> 
>   - **Behavior**:
>     - Change `call_endpoint_tool` in `endpoint_tools.rs` to use `BASE_INTERNAL_URL` instead of `BASE_URL` for constructing API URLs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 272d8588e4fff8563a8a5d730e6fd972aaa36a28. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->