### PR TITLE
fix(frontend): allow dates before 2000 in date picker

### DIFF
--- a/frontend/src/lib/components/DateTimeInput.svelte
+++ b/frontend/src/lib/components/DateTimeInput.svelte
@@ -68,6 +68,7 @@
 		if (date && time && (initialDate != date || initialTime != time)) {
 			let newDate = new Date(`${date}T${time}`)
 			if (newDate.toString() === 'Invalid Date') return
+			if (newDate.getFullYear() < 1900) return
 
 			value = newDate.toISOString()
 			dispatchIfMounted('change', value)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change minimum valid year from 2000 to 1900 in `DateTimeInput.svelte` to allow earlier date selection.
> 
>   - **Behavior**:
>     - In `DateTimeInput.svelte`, change minimum valid year from 2000 to 1900 in `parseDateAndTime()` function.
>     - Allows date selection from 1900 onwards, previously restricted to 2000.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for cc1a4a0284a1c34e8ccc7a7f78c8e4cdfb8243c7. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->