### PR TITLE
NULL Toggle in InsertRow drawer

### DIFF
--- a/backend/parsers/windmill-parser-sql/src/lib.rs
+++ b/backend/parsers/windmill-parser-sql/src/lib.rs
@@ -561,7 +561,9 @@ fn transform_types_with_spaces<'a>(typ: &'a str, cap: &regex::Match<'_>, code: &
     for (prefix, suffix, alias) in TYPES {
         if typ.eq_ignore_ascii_case(prefix) {
             let remaining = code[cap.end()..].trim_start();
-            if remaining.len() >= 7 && remaining[..7].eq_ignore_ascii_case(suffix) {
+            if remaining.len() >= suffix.len()
+                && remaining[..suffix.len()].eq_ignore_ascii_case(suffix)
+            {
                 return alias;
             }
         }

--- a/backend/parsers/windmill-parser-sql/src/lib.rs
+++ b/backend/parsers/windmill-parser-sql/src/lib.rs
@@ -2,6 +2,7 @@
 
 use anyhow::anyhow;
 
+use lazy_static::lazy_static;
 #[cfg(not(target_arch = "wasm32"))]
 use regex::Regex;
 #[cfg(target_arch = "wasm32")]
@@ -553,12 +554,13 @@ fn transform_types_with_spaces<'a>(typ: &'a str, cap: &regex::Match<'_>, code: &
     // time without time zone
     // timestamp with time zone
     // timestamp without time zone
-
-    static TYPES: [(&str, &str, &str); 2] = [
-        ("character", "varying", "varchar"),
-        ("double", "precision", "double"),
-    ];
-    for (prefix, suffix, alias) in TYPES {
+    lazy_static! {
+        static ref TYPES: [(&'static str, &'static str, &'static str); 2] = [
+            ("character", "varying", "varchar"),
+            ("double", "precision", "double"),
+        ];
+    }
+    for (prefix, suffix, alias) in TYPES.iter() {
         if typ.eq_ignore_ascii_case(prefix) {
             let remaining = code[cap.end()..].trim_start();
             if remaining.len() >= suffix.len()

--- a/backend/windmill-worker/src/pg_executor.rs
+++ b/backend/windmill-worker/src/pg_executor.rs
@@ -88,7 +88,7 @@ fn do_postgresql_inner<'a>(
             let arg_t = arg
                 .otyp
                 .as_ref()
-                .ok_or_else(|| anyhow::anyhow!("Missing otzyp for pg arg"))?;
+                .ok_or_else(|| anyhow::anyhow!("Missing otyp for pg arg"))?;
             let typ = &arg.typ;
             let param = convert_val(value, arg_t, typ)?;
             query_params.push(param);

--- a/frontend/src/lib/common.ts
+++ b/frontend/src/lib/common.ts
@@ -49,6 +49,7 @@ export interface SchemaProperty {
 	placeholder?: string
 	oneOf?: SchemaProperty[]
 	originalType?: string
+	disabled?: boolean
 }
 
 export interface ModalSchemaProperty {

--- a/frontend/src/lib/components/SchemaForm.svelte
+++ b/frontend/src/lib/components/SchemaForm.svelte
@@ -70,7 +70,7 @@
 					| undefined)
 			| undefined
 		workspace?: string | undefined
-		actions?: import('svelte').Snippet
+		actions?: import('svelte').Snippet<[{ item: { id: string; value: string } }]> | undefined
 	}
 
 	let {
@@ -414,7 +414,7 @@
 									{displayType}
 								>
 									{#snippet actions()}
-										{@render actions_render?.()}
+										{@render actions_render?.({ item })}
 										{#if linkedSecretCandidates?.includes(argName)}
 											<div>
 												<ToggleButtonGroup

--- a/frontend/src/lib/components/apps/components/display/dbtable/InsertRow.svelte
+++ b/frontend/src/lib/components/apps/components/display/dbtable/InsertRow.svelte
@@ -192,7 +192,7 @@
 							} else {
 								delete schema.properties[item.id].disabled
 								delete schema.properties[item.id].nullable
-								args[item.id] = ''
+								args[item.id] = schema.properties[item.id].default ?? ''
 							}
 						}
 					}

--- a/frontend/src/lib/components/apps/components/display/dbtable/InsertRow.svelte
+++ b/frontend/src/lib/components/apps/components/display/dbtable/InsertRow.svelte
@@ -17,6 +17,7 @@
 	import { argSigToJsonSchemaType } from 'windmill-utils-internal'
 	import SchemaForm from '$lib/components/SchemaForm.svelte'
 	import { untrack } from 'svelte'
+	import Toggle from '$lib/components/Toggle.svelte'
 
 	let schema: Schema | undefined = $state(undefined)
 
@@ -171,5 +172,29 @@
 </script>
 
 {#if schema}
-	<SchemaForm onlyMaskPassword {schema} bind:args />
+	<SchemaForm onlyMaskPassword {schema} bind:args>
+		{#snippet actions({ item })}
+			<Toggle
+				options={{ right: 'NULL' }}
+				class="pl-2"
+				textClass="text-tertiary"
+				disabled={fields?.[fields?.findIndex((f) => f.name === item.id)]?.nullable != 'YES'}
+				bind:checked={
+					() => args[item.id] === null,
+					(v) => {
+						if (!schema?.properties[item.id]) return
+						if (v) {
+							schema.properties[item.id].nullable = true
+							schema.properties[item.id].disabled = true
+							args[item.id] = null
+						} else {
+							delete schema.properties[item.id].disabled
+							delete schema.properties[item.id].nullable
+							args[item.id] = ''
+						}
+					}
+				}
+			/>
+		{/snippet}
+	</SchemaForm>
 {/if}

--- a/frontend/src/lib/components/apps/components/display/dbtable/InsertRow.svelte
+++ b/frontend/src/lib/components/apps/components/display/dbtable/InsertRow.svelte
@@ -174,27 +174,30 @@
 {#if schema}
 	<SchemaForm onlyMaskPassword {schema} bind:args>
 		{#snippet actions({ item })}
-			<Toggle
-				options={{ right: 'NULL' }}
-				class="pl-2"
-				textClass="text-tertiary"
-				disabled={fields?.[fields?.findIndex((f) => f.name === item.id)]?.nullable != 'YES'}
-				bind:checked={
-					() => args[item.id] === null,
-					(v) => {
-						if (!schema?.properties[item.id]) return
-						if (v) {
-							schema.properties[item.id].nullable = true
-							schema.properties[item.id].disabled = true
-							args[item.id] = null
-						} else {
-							delete schema.properties[item.id].disabled
-							delete schema.properties[item.id].nullable
-							args[item.id] = ''
+			{@const disabled = fields?.[fields?.findIndex((f) => f.name === item.id)]?.nullable != 'YES'}
+			{#if !disabled}
+				<Toggle
+					options={{ right: 'NULL' }}
+					class="pl-2"
+					textClass="text-tertiary"
+					size="2sm"
+					bind:checked={
+						() => args[item.id] === null,
+						(v) => {
+							if (!schema?.properties[item.id]) return
+							if (v) {
+								schema.properties[item.id].nullable = true
+								schema.properties[item.id].disabled = true
+								args[item.id] = null
+							} else {
+								delete schema.properties[item.id].disabled
+								delete schema.properties[item.id].nullable
+								args[item.id] = ''
+							}
 						}
 					}
-				}
-			/>
+				/>
+			{/if}
 		{/snippet}
 	</SchemaForm>
 {/if}

--- a/frontend/src/lib/components/apps/components/display/dbtable/queries/insert.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/queries/insert.ts
@@ -98,6 +98,7 @@ export function makeInsertQuery(table: string, columns: ColumnDef[], dbType: DbT
 
 	query += `INSERT INTO ${table} (${columnNames}) VALUES (${insertValues}${commaOrEmpty}${defaultValues})`
 
+	console.log(query)
 	return query
 }
 

--- a/frontend/src/lib/components/apps/components/display/dbtable/queries/insert.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/queries/insert.ts
@@ -98,7 +98,6 @@ export function makeInsertQuery(table: string, columns: ColumnDef[], dbType: DbT
 
 	query += `INSERT INTO ${table} (${columnNames}) VALUES (${insertValues}${commaOrEmpty}${defaultValues})`
 
-	console.log(query)
 	return query
 }
 

--- a/frontend/src/lib/components/apps/components/display/dbtable/queries/insert.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/queries/insert.ts
@@ -97,7 +97,6 @@ export function makeInsertQuery(table: string, columns: ColumnDef[], dbType: DbT
 	const commaOrEmpty = shouldInsertComma ? ', ' : ''
 
 	query += `INSERT INTO ${table} (${columnNames}) VALUES (${insertValues}${commaOrEmpty}${defaultValues})`
-
 	return query
 }
 


### PR DESCRIPTION
Works in DB Manager and Database Studio

<img width="1191" height="259" alt="image" src="https://github.com/user-attachments/assets/a79e5928-a321-46e9-8b92-19db1e662812" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add NULL toggle feature in InsertRow drawer, handling SQL types with spaces and enhancing nullable field management.
> 
>   - **Backend**:
>     - `lib.rs`: Added `transform_types_with_spaces()` to handle SQL types with spaces, replacing them with shorter counterparts.
>     - `pg_executor.rs`: Fixed typo in error message from `otzyp` to `otyp`.
>   - **Frontend**:
>     - `common.ts`: Added `disabled` property to `SchemaProperty` interface.
>     - `SchemaForm.svelte`: Updated `actions` snippet to handle nullable fields with a toggle.
>     - `InsertRow.svelte`: Integrated `Toggle` component to allow setting fields to NULL if nullable.
>     - `insert.ts`: Removed unnecessary newline in `makeInsertQuery()` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for b81460ebea54ff831efb23451f24bad4f201186f. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->