### PR TITLE
UI nits

### DIFF
--- a/frontend/src/lib/components/ResourceEditor.svelte
+++ b/frontend/src/lib/components/ResourceEditor.svelte
@@ -291,10 +291,9 @@
 					<h5 class="mt-4 inline-flex items-center gap-4 pb-2">
 						File content ({resourceTypeInfo.format_extension})
 					</h5>
-					<div class="h-full w-full border p-1 rounded">
+					<div class="">
 						<SimpleEditor
 							autoHeight
-							class="editor"
 							lang={resourceTypeInfo.format_extension}
 							bind:code={textFileContent}
 							fixedOverflowWidgets={false}
@@ -324,14 +323,8 @@
 				{#if !emptyString(jsonError)}<span class="text-red-400 text-xs mb-1 flex flex-row-reverse"
 						>{jsonError}</span
 					>{:else}<div class="py-2"></div>{/if}
-				<div class="h-full w-full border p-1 rounded">
-					<SimpleEditor
-						autoHeight
-						class="editor"
-						lang="json"
-						bind:code={rawCode}
-						fixedOverflowWidgets={false}
-					/>
+				<div class="bg-surface-secondary rounded-md border py-2.5">
+					<SimpleEditor autoHeight lang="json" bind:code={rawCode} />
 				</div>
 			{/if}
 		</div>

--- a/frontend/src/lib/components/schema/EditableSchemaDrawer.svelte
+++ b/frontend/src/lib/components/schema/EditableSchemaDrawer.svelte
@@ -223,24 +223,25 @@
 		{/snippet}
 	</Drawer>
 {:else}
-	<div class="mt-2"></div>
-	<SimpleEditor
-		bind:this={editor}
-		small
-		fixedOverflowWidgets={false}
-		on:change={() => {
-			try {
-				schema = JSON.parse(schemaString)
-				error = ''
-			} catch (err) {
-				error = err.message
-			}
-		}}
-		bind:code={schemaString}
-		lang="json"
-		autoHeight
-		automaticLayout
-	/>
+	<div class="mt-2 bg-surface-secondary rounded-md border py-2.5">
+		<SimpleEditor
+			bind:this={editor}
+			small
+			fixedOverflowWidgets={false}
+			on:change={() => {
+				try {
+					schema = JSON.parse(schemaString)
+					error = ''
+				} catch (err) {
+					error = err.message
+				}
+			}}
+			bind:code={schemaString}
+			lang="json"
+			autoHeight
+			automaticLayout
+		/>
+	</div>
 	{#if !emptyString(error)}
 		<div class="text-red-400 text-xs">{error}</div>
 	{:else}

--- a/frontend/src/lib/components/schema/FlowPropertyEditor.svelte
+++ b/frontend/src/lib/components/schema/FlowPropertyEditor.svelte
@@ -77,6 +77,12 @@
 
 	let oneOfSelected: string | undefined = $state(oneOf?.[0]?.title)
 
+	$effect(() => {
+		if (oneOf?.length && !oneOfSelected) {
+			oneOfSelected = oneOf[0].title
+		}
+	})
+
 	const dispatch = createEventDispatcher()
 
 	function getResourceTypesFromFormat(format: string | undefined): string[] {


### PR DESCRIPTION
- **Fix JSON editor resource styling**
- **fix Edit resource type Object json editor**
- **oneOfSelected not auto selecting**

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix UI styling and auto-selection issues in JSON editors across Svelte components.
> 
>   - **Styling Fixes**:
>     - Adjust JSON editor styling in `ResourceEditor.svelte` and `EditableSchemaDrawer.svelte` by removing unnecessary classes and adding consistent background and border styles.
>   - **Functionality Fixes**:
>     - Add `$effect` in `FlowPropertyEditor.svelte` to ensure `oneOfSelected` is auto-selected when `oneOf` has items but none are selected.
>   - **Misc**:
>     - Remove redundant `class="editor"` from `SimpleEditor` instances in `ResourceEditor.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 95841f9148588e10a03ef64caded3da4ea4300b5. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->