### PR TITLE
exclude postgres BIGSERIAL / auto generated columns

### DIFF
--- a/frontend/src/lib/components/apps/components/display/dbtable/InsertRow.svelte
+++ b/frontend/src/lib/components/apps/components/display/dbtable/InsertRow.svelte
@@ -135,8 +135,10 @@
 	let fields = $derived(
 		columnDefs
 			?.filter((t) => {
-				const shouldFilter = t.isidentity === ColumnIdentity.Always || t?.hideInsert === true
-
+				const shouldFilter =
+					t.isidentity === ColumnIdentity.Always ||
+					t?.hideInsert === true ||
+					t.defaultvalue?.startsWith('nextval(') // exclude postgres serial/auto increment fields
 				return !shouldFilter
 			})
 			.map((column) => {

--- a/frontend/src/lib/components/apps/components/display/dbtable/queries/insert.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/queries/insert.ts
@@ -82,7 +82,9 @@ function shouldOmitColumnInInsert(column: ColumnDef) {
 export function makeInsertQuery(table: string, columns: ColumnDef[], dbType: DbType) {
 	if (!table) throw new Error('Table name is required')
 
-	const columnsInsert = columns.filter((x) => !x.hideInsert)
+	const columnsInsert = columns.filter(
+		(x) => !x.hideInsert && !(dbType == 'postgresql' && x.defaultvalue?.startsWith('nextval('))
+	)
 	const columnsDefault = columns.filter((c) => !shouldOmitColumnInInsert(c))
 	const allInsertColumns = columnsInsert.concat(columnsDefault)
 
@@ -97,6 +99,7 @@ export function makeInsertQuery(table: string, columns: ColumnDef[], dbType: DbT
 	const commaOrEmpty = shouldInsertComma ? ', ' : ''
 
 	query += `INSERT INTO ${table} (${columnNames}) VALUES (${insertValues}${commaOrEmpty}${defaultValues})`
+	console.log(query)
 	return query
 }
 

--- a/frontend/src/lib/components/apps/components/display/table/utils.ts
+++ b/frontend/src/lib/components/apps/components/display/table/utils.ts
@@ -27,9 +27,9 @@ export abstract class AbstractCellRenderer implements ICellRendererComp {
 	eGui: any
 	protected component:
 		| {
-			refresh: (params: ICellRendererParams) => void
-			destroy: () => void
-		}
+				refresh: (params: ICellRendererParams) => void
+				destroy: () => void
+		  }
 		| undefined
 	constructor(parentElement = 'span') {
 		// create empty span (or other element) to place svelte component in
@@ -218,18 +218,27 @@ export function transformColumnDefs({
 			// Set default minWidth based on number of actions (if not wrapping)
 			...(!wrapActions ? { minWidth: 130 * actions?.length } : {}),
 			// Respect user-specified overrides when placeholder present (these should override defaults)
-			...(
-				actionsIndex > -1
-					? {
+			...(actionsIndex > -1
+				? {
 						// keep width/pin/flex/align/hide from placeholder when provided
-						...(['width', 'minWidth', 'maxWidth', 'flex', 'pinned', 'headerName', 'cellStyle', 'cellClass', 'autoHeight', 'hide']
-							.reduce((acc, key) => {
-								if (r[actionsIndex] && r[actionsIndex][key] !== undefined) acc[key] = r[actionsIndex][key]
-								return acc
-							}, {} as any))
+						...[
+							'width',
+							'minWidth',
+							'maxWidth',
+							'flex',
+							'pinned',
+							'headerName',
+							'cellStyle',
+							'cellClass',
+							'autoHeight',
+							'hide'
+						].reduce((acc, key) => {
+							if (r[actionsIndex] && r[actionsIndex][key] !== undefined)
+								acc[key] = r[actionsIndex][key]
+							return acc
+						}, {} as any)
 					}
-					: {}
-			),
+				: {}),
 			...(customActionsHeader?.trim() ? { headerName: customActionsHeader } : {})
 		}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Exclude PostgreSQL BIGSERIAL/auto-generated columns from insert operations by filtering columns with default values starting with 'nextval('.
> 
>   - **Behavior**:
>     - Exclude PostgreSQL BIGSERIAL/auto-generated columns from insert operations by filtering columns with default values starting with 'nextval(' in `InsertRow.svelte` and `insert.ts`.
>   - **Code Changes**:
>     - Update `fields` in `InsertRow.svelte` to filter out columns with `defaultvalue` starting with 'nextval('.
>     - Modify `makeInsertQuery` in `insert.ts` to exclude such columns for PostgreSQL.
>   - **Misc**:
>     - Minor formatting changes in `utils.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 84081de2a92bfdae37db8132df3af581fce17ce9. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->