### PR TITLE
Fix ducklake save btn disabled on delete

### DIFF
--- a/frontend/src/lib/components/workspaceSettings/DucklakeSettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/DucklakeSettings.svelte
@@ -341,8 +341,11 @@
 <Button
 	wrapperClasses="mt-4 mb-44 max-w-fit"
 	on:click={onSave}
-	disabled={Object.values(ducklakeIsDirty).every((v) => v === false)}>Save ducklake settings</Button
+	disabled={ducklakeSavedSettings.ducklakes.length === ducklakeSettings.ducklakes.length &&
+		Object.values(ducklakeIsDirty).every((v) => v === false)}
 >
+	Save ducklake settings
+</Button>
 <DbManagerDrawer bind:this={dbManagerDrawer} />
 
 <ConfirmationModal {...confirmationModal.props} />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix save button in `DucklakeSettings.svelte` to be disabled only when there are no unsaved changes.
> 
>   - **Behavior**:
>     - In `DucklakeSettings.svelte`, the save button is now disabled if `ducklakeSavedSettings.ducklakes.length` equals `ducklakeSettings.ducklakes.length` and all values in `ducklakeIsDirty` are `false`.
>   - **Misc**:
>     - Minor formatting change in `DucklakeSettings.svelte` for the save button element.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 65fad7da0ebae075af764e99a471a41fef906c40. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->