### PR TITLE
Fix ducklake instance DB + Add manual instructions

### DIFF
--- a/frontend/src/lib/components/workspaceSettings/DucklakeSettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/DucklakeSettings.svelte
@@ -208,9 +208,9 @@
 				setup fails in the middle, but in most cases Windmill will handle it for you.
 				<br /><br />
 
-				If the database <code>ducklake_catalog</code> already exists, nothing is done. Otherwise,
-				connect to the Windmill PostgreSQL as the default user (the one in your DATABASE_URL,
-				usually 'postgres') and run :
+				If the database <code>ducklake_catalog</code> already exists, assume the setup was already
+				done and do nothing. Otherwise, connect to the Windmill PostgreSQL as the default user (the
+				one in your DATABASE_URL, usually 'postgres') and run :
 				<br />
 				<code class="block p-2 border rounded-md bg-surface mt-2">
 					CREATE DATABASE <code>ducklake_catalog</code>;<br />

--- a/frontend/src/lib/components/workspaceSettings/DucklakeSettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/DucklakeSettings.svelte
@@ -78,6 +78,7 @@
 	import { deepEqual } from 'fast-equals'
 	import Popover from '../meltComponents/Popover.svelte'
 	import TextInput from '../text_input/TextInput.svelte'
+	import Section from '../Section.svelte'
 
 	const DEFAULT_DUCKLAKE_CATALOG_NAME = 'ducklake_catalog'
 
@@ -194,6 +195,46 @@
 	<Alert title="Instance catalogs use the Windmill database" class="mb-4" type="info">
 		Using an instance catalog is the fastest way to get started with Ducklake. They are public to
 		the instance and can be re-used in other workspaces' Ducklake settings.
+		<div>
+			<Section
+				label="Manual setup instructions"
+				collapsable
+				headerClass="mt-6 border bg-surface px-3 py-1 rounded-md text-xs text-secondary"
+				class="text-secondary"
+				animate
+			>
+				This is what happens when you create a new Instance catalog with the name
+				<code>ducklake_catalog</code>. This may be useful to debug issues in case the automatic
+				setup fails in the middle, but in most cases Windmill will handle it for you.
+				<br /><br />
+
+				If the database <code>ducklake_catalog</code> already exists, nothing is done. Otherwise,
+				connect to the Windmill PostgreSQL as the default user (the one in your DATABASE_URL,
+				usually 'postgres') and run :
+				<br />
+				<code class="block p-2 border rounded-md bg-surface mt-2">
+					CREATE DATABASE <code>ducklake_catalog</code>;<br />
+					GRANT CONNECT ON DATABASE <code>ducklake_catalog</code> TO ducklake_user;
+				</code>
+				<br />
+				Then, connect to the <code>ducklake_catalog</code> database with the same user as above (NOT
+				ducklake_user) and run :
+				<code class="block p-2 border rounded-md bg-surface mt-2">
+					GRANT USAGE ON SCHEMA public TO ducklake_user;<br />
+					GRANT CREATE ON SCHEMA public TO ducklake_user;<br />
+					ALTER DEFAULT PRIVILEGES IN SCHEMA public<br />
+					&nbsp;&nbsp;GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO ducklake_user;
+				</code>
+				<br />
+				After doing that, creating a new Ducklake with an Instance catalog named
+				<code>ducklake_catalog</code> should not prompt you to run the automatic setup, and
+				everything should work fine.
+				<br /><br />
+				Note : the ducklake_user is automatically created by Windmill in a migration. Its password is
+				auto-generated and stored in the database table <code>global_settings</code> with the key
+				<code>ducklake_user_pg_pwd</code>.
+			</Section>
+		</div>
 	</Alert>
 {/if}
 


### PR DESCRIPTION
- **same auth method than worker for tokio_postgres**
- **Add manual setup instructions for Ducklake**

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update `create_ducklake_database` auth method and add Ducklake manual setup instructions in UI.
> 
>   - **Backend**:
>     - Update `create_ducklake_database` in `settings.rs` to use the same auth method as worker for `tokio_postgres`.
>     - Construct connection string with SSL mode handling.
>   - **Frontend**:
>     - Add manual setup instructions for Ducklake in `DucklakeSettings.svelte` under a collapsible section.
>     - Instructions include SQL commands for database creation and permission grants.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for d2d69a72da3da1dbcd9f0ba4310433e3eac1d521. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->