### PR TITLE
improve dark mode readability monaco

### DIFF
--- a/frontend/src/lib/components/InputTransformForm.svelte
+++ b/frontend/src/lib/components/InputTransformForm.svelte
@@ -763,7 +763,7 @@
 						</ArgInput>
 					{:else if arg.expr != undefined}
 						<div
-							class={`bg-surface-secondary rounded-md flex flex-col pl-4 ${inputBorderClass({ forceFocus: focused })}`}
+							class={`${focused ? 'bg-surface' : 'bg-surface-secondary'} transition-colors rounded-md flex flex-col pl-4 ${inputBorderClass({ forceFocus: focused })}`}
 						>
 							<SimpleEditor
 								bind:this={monaco}

--- a/frontend/src/lib/components/InputTransformForm.svelte
+++ b/frontend/src/lib/components/InputTransformForm.svelte
@@ -763,7 +763,7 @@
 						</ArgInput>
 					{:else if arg.expr != undefined}
 						<div
-							class={`${focused ? 'bg-surface' : 'bg-surface-secondary'} transition-colors rounded-md flex flex-col pl-4 ${inputBorderClass({ forceFocus: focused })}`}
+							class={`bg-surface-secondary rounded-md flex flex-col pl-4 ${inputBorderClass({ forceFocus: focused })}`}
 						>
 							<SimpleEditor
 								bind:this={monaco}

--- a/frontend/src/lib/components/vscode.ts
+++ b/frontend/src/lib/components/vscode.ts
@@ -158,7 +158,7 @@ export async function initializeVscode(caller?: string, htmlContainer?: HTMLElem
 						token: 'comment'
 					},
 					{
-						foreground: 'a3be8c',
+						foreground: 'b3deac',
 						token: 'string'
 					},
 					{
@@ -170,7 +170,7 @@ export async function initializeVscode(caller?: string, htmlContainer?: HTMLElem
 						token: 'constant.language'
 					},
 					{
-						foreground: '81a1c1',
+						foreground: '92bae6',
 						token: 'keyword'
 					},
 					{
@@ -227,15 +227,20 @@ export async function initializeVscode(caller?: string, htmlContainer?: HTMLElem
 					{
 						foreground: '8fbcbb',
 						token: 'variable.other.constant'
-					}
+					},
+					{ token: 'string.value.json', foreground: 'e8b886' }, // string values in JSON
+					{ token: 'keyword.json', foreground: 'e8b886' } // true, false, null in JSON
 				],
 				colors: {
 					'editor.foreground': '#D8DEE9',
 					'editor.background': '#00000000',
-					'editor.selectionBackground': '#434C5ECC',
+					'editor.selectionBackground': '#515A6D',
+					'editor.inactiveSelectionBackground': '#515A6DB0',
 					'editor.lineHighlightBackground': '#3B4252',
 					'editorCursor.foreground': '#D8DEE9',
-					'editorWhitespace.foreground': '#434C5ECC'
+					'editorWhitespace.foreground': '#515A6D',
+					'editorIndentGuide.background1': '#5A647860',
+					'editorIndentGuide.activeBackground1': '#6A7488'
 				}
 			})
 


### PR DESCRIPTION
<img width="422" height="278" alt="image" src="https://github.com/user-attachments/assets/78b708ad-cdaf-4f0e-b166-b214043dd88c" />

> [!IMPORTANT]
> Improve dark mode readability in Monaco editor by adjusting color themes and background settings in `InputTransformForm.svelte` and `vscode.ts`.
> 
>   - **Dark Mode Improvements**:
>     - In `InputTransformForm.svelte`, change background color based on focus state for better visibility.
>     - In `vscode.ts`, update color codes for `string`, `keyword`, and JSON tokens for improved contrast.
>     - Adjust `editor.selectionBackground`, `editor.inactiveSelectionBackground`, and `editorWhitespace.foreground` colors for better readability.
>     - Add new color settings for `editorIndentGuide.background1` and `editorIndentGuide.activeBackground1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 7620eecf05daa9d1f8b5f934ed64b29773841777. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improve dark mode readability in Monaco editor by adjusting color themes and background settings in `vscode.ts`.
> 
>   - **Dark Mode Improvements**:
>     - In `vscode.ts`, update color codes for `string`, `keyword`, and JSON tokens for improved contrast.
>     - Adjust `editor.selectionBackground`, `editor.inactiveSelectionBackground`, and `editorWhitespace.foreground` colors for better readability.
>     - Add new color settings for `editorIndentGuide.background1` and `editorIndentGuide.activeBackground1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for e8426aa330a5ab6aa320ba610cfbc739a4d47f1f. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->