### PR TITLE
Fix broken flowState

### DIFF
--- a/frontend/src/lib/components/FlowStatusViewer.svelte
+++ b/frontend/src/lib/components/FlowStatusViewer.svelte
@@ -67,7 +67,7 @@
 	let globalRefreshes: Record<string, ((clear, root) => Promise<void>)[]> = $state({})
 
 	setContext<FlowStatusViewerContext>('FlowStatusViewer', {
-		flowState: flowState,
+		flowState,
 		suspendStatus,
 		retryStatus,
 		hideDownloadInGraph,
@@ -88,7 +88,7 @@
 			retryStatus.val = {}
 			suspendStatus.val = {}
 			globalRefreshes = {}
-			flowState = {}
+			for (let key in localModuleStates) delete flowState[key]
 			localDurationStatuses = {}
 			localModuleStates = {}
 		}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `flowState` handling in `FlowStatusViewer.svelte` by deleting specific keys instead of resetting the entire object when `jobId` changes.
> 
>   - **Behavior**:
>     - Fixes `flowState` handling in `FlowStatusViewer.svelte` by deleting specific keys instead of resetting the entire object when `jobId` changes.
>     - Ensures `flowState` integrity across job updates.
>   - **Code Changes**:
>     - In `updateJobId()`, modifies `flowState` reset logic to delete keys from `flowState` instead of reassigning it to an empty object.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 408c6bc04fb36410d4bd73323a3c9356aba25c7c. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->