### PR TITLE
Fix CI failing due to missing feature flag

### DIFF
--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -160,7 +160,7 @@ use crate::mysql_executor::do_mysql;
 #[cfg(feature = "duckdb")]
 use crate::duckdb_executor::do_duckdb;
 
-#[cfg(feature = "oracledb")]
+#[cfg(all(feature = "enterprise", feature = "oracledb"))]
 use crate::oracledb_executor::do_oracledb;
 
 #[cfg(feature = "enterprise")]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify feature flag condition for OracleDB executor in `worker.rs` to require both `enterprise` and `oracledb` features.
> 
>   - **Feature Flags**:
>     - Modify feature flag condition for OracleDB executor in `worker.rs` to require both `enterprise` and `oracledb` features.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for c0386dd8bcdfb3428aa9b4c5f55afd3b0f888839. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->