### PR TITLE
fix: app button tooltip also when disabled + audit log filters

### DIFF
--- a/frontend/src/lib/components/apps/components/buttons/AppButton.svelte
+++ b/frontend/src/lib/components/apps/components/buttons/AppButton.svelte
@@ -267,60 +267,64 @@
 			<div class="text-red-500 text-xs">{errorsMessage}</div>
 		{/if}
 		{#key css}
-			<Button
-				on:pointerdown={(e) => e.stopPropagation()}
-				btnClasses={twMerge(
-					css?.button?.class ?? '',
-					isMenuItem ? 'flex items-center justify-start' : '',
-					isMenuItem ? '!border-0' : '',
-					'wm-button',
-					`wm-button-${resolvedConfig.color}`
-				)}
-				variant={isMenuItem ? 'border' : 'contained'}
-				style={css?.button?.style}
-				wrapperClasses={twMerge(
-					css?.container?.class ?? '',
-					resolvedConfig.fillContainer ? 'w-full h-full' : '',
-					isMenuItem ? 'w-full' : '',
-					'wm-button-container',
-					`wm-button-container-${resolvedConfig.color}`
-				)}
-				wrapperStyle={css?.container?.style}
-				disabled={resolvedConfig.disabled}
-				on:click={handleClick}
-				size={resolvedConfig.size}
-				color={resolvedConfig.color}
+			<div
+				class="inline-flex"
 				title={resolvedConfig.tooltip && String(resolvedConfig.tooltip).length > 0
 					? String(resolvedConfig.tooltip)
 					: undefined}
-				loading={resolvedConfig.runInBackground ? backgroundClickFeedback : loading}
 			>
-				{#if resolvedConfig.beforeIcon}
-					{#key resolvedConfig.beforeIcon}
-						<div
-							class={resolvedConfig.label?.toString() &&
-							resolvedConfig.label?.toString()?.length > 0
-								? 'min-w-4'
-								: ''}
-							bind:this={beforeIconComponent}
-						></div>
-					{/key}
-				{/if}
-				{#if resolvedConfig.label?.toString() && resolvedConfig.label?.toString()?.length > 0}
-					<div>{resolvedConfig.label.toString()}</div>
-				{/if}
-				{#if resolvedConfig.afterIcon}
-					{#key resolvedConfig.afterIcon}
-						<div
-							class={resolvedConfig.label?.toString() &&
-							resolvedConfig.label?.toString()?.length > 0
-								? 'min-w-4'
-								: ''}
-							bind:this={afterIconComponent}
-						></div>
-					{/key}
-				{/if}
-			</Button>
+				<Button
+					on:pointerdown={(e) => e.stopPropagation()}
+					btnClasses={twMerge(
+						css?.button?.class ?? '',
+						isMenuItem ? 'flex items-center justify-start' : '',
+						isMenuItem ? '!border-0' : '',
+						'wm-button',
+						`wm-button-${resolvedConfig.color}`
+					)}
+					variant={isMenuItem ? 'border' : 'contained'}
+					style={css?.button?.style}
+					wrapperClasses={twMerge(
+						css?.container?.class ?? '',
+						resolvedConfig.fillContainer ? 'w-full h-full' : '',
+						isMenuItem ? 'w-full' : '',
+						'wm-button-container',
+						`wm-button-container-${resolvedConfig.color}`
+					)}
+					wrapperStyle={css?.container?.style}
+					disabled={resolvedConfig.disabled}
+					on:click={handleClick}
+					size={resolvedConfig.size}
+					color={resolvedConfig.color}
+					loading={resolvedConfig.runInBackground ? backgroundClickFeedback : loading}
+				>
+					{#if resolvedConfig.beforeIcon}
+						{#key resolvedConfig.beforeIcon}
+							<div
+								class={resolvedConfig.label?.toString() &&
+								resolvedConfig.label?.toString()?.length > 0
+									? 'min-w-4'
+									: ''}
+								bind:this={beforeIconComponent}
+							></div>
+						{/key}
+					{/if}
+					{#if resolvedConfig.label?.toString() && resolvedConfig.label?.toString()?.length > 0}
+						<div>{resolvedConfig.label.toString()}</div>
+					{/if}
+					{#if resolvedConfig.afterIcon}
+						{#key resolvedConfig.afterIcon}
+							<div
+								class={resolvedConfig.label?.toString() &&
+								resolvedConfig.label?.toString()?.length > 0
+									? 'min-w-4'
+									: ''}
+								bind:this={afterIconComponent}
+							></div>
+						{/key}
+					{/if}
+				</Button>
+			</div>
 		{/key}
 	</AlignWrapper>
 </RunnableWrapper>

--- a/frontend/src/lib/components/auditLogs/AuditLogsFilters.svelte
+++ b/frontend/src/lib/components/auditLogs/AuditLogsFilters.svelte
@@ -423,7 +423,7 @@
 
 		<Select
 			bind:value={operation}
-			items={['all', ...Object.keys(operations)].map((r) => ({ value: r, label: r }))}
+			items={['all', ...Object.values(operations)].map((r) => ({ value: r, label: r }))}
 			inputClass="dark:!bg-gray-700"
 			RightIcon={ChevronDown}
 		/>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance tooltip display for disabled buttons in `AppButton.svelte` and fix operation filter in `AuditLogsFilters.svelte`.
> 
>   - **AppButton Tooltip**:
>     - Wraps `Button` in a `div` with `title` attribute in `AppButton.svelte` to ensure tooltip is shown even when button is disabled.
>   - **Audit Log Filters**:
>     - Changes `operation` filter in `AuditLogsFilters.svelte` to use `Object.values(operations)` instead of `Object.keys(operations)` for correct display of operation labels.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 4ab47bcde9a07085be9e6b4773371216b0aff149. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->