### PR TITLE
Nit mistake in expression helper text

### DIFF
--- a/frontend/src/lib/components/FakeMonacoPlaceHolder.svelte
+++ b/frontend/src/lib/components/FakeMonacoPlaceHolder.svelte
@@ -60,7 +60,7 @@
 <div
 	bind:clientWidth
 	bind:clientHeight
-	class="h-full w-full relative editor dark:bg-[#272D38] {className}"
+	class="h-full w-full relative editor {className}"
 	style="--vscode-editorCodeLens-lineHeight: 18px; --vscode-editorCodeLens-fontSize: 12px; --vscode-editorCodeLens-fontFeatureSettings: 'liga' off, 'calt' off; --code-editorInlayHintsFontFamily: {fontFamily};"
 >
 	<div

--- a/frontend/src/lib/components/copilot/StepInputsGen.svelte
+++ b/frontend/src/lib/components/copilot/StepInputsGen.svelte
@@ -229,7 +229,7 @@ input_name2: expression2
 				<Button
 					size="xs"
 					color="light"
-					btnClasses="text-violet-800 dark:text-violet-400 border border-violet-200 hover:bg-violet-50"
+					btnClasses={stepInputGenButtonClasses(false)}
 					nonCaptureEvent
 					startIcon={{
 						icon: Wand2

--- a/frontend/src/lib/components/flows/content/DynamicInputHelpBox.svelte
+++ b/frontend/src/lib/components/flows/content/DynamicInputHelpBox.svelte
@@ -27,10 +27,10 @@
 		id="dynamic-input-help-box"
 	>
 		Single JavaScript expression. The following functions and objects are available:
-		<ul class="ml-4">
+		<ul class="ml-4 list-disc">
 			<li
-				><b>{'results.<id>'}</b>: the result of step at id 'id' (use <b>{'results?.<id>'}</b> if id may
-				not exist because branch was not chosen)</li
+				><b>{'results.<id>'}</b>: the result of step at id 'id' (use optional chaining if id may not
+				exist because branch was not chosen, for example: <code>{'results.<id>?.[0]'}</code>)</li
 			>
 			<li><b>flow_input</b>: the object containing the flow input arguments</li>
 			<li><b>previous_result</b>: the result of previous step</li>

--- a/frontend/src/lib/components/flows/content/DynamicInputHelpBox.svelte
+++ b/frontend/src/lib/components/flows/content/DynamicInputHelpBox.svelte
@@ -22,7 +22,7 @@
 
 {#if opened}
 	<div
-		class="bg-surface-secondary border-l-4 text-sm text-secondary p-4 mt-2"
+		class="bg-surface-secondary border-x border-r-0 border-l-4 text-sm text-secondary p-4 mt-2"
 		role="alert"
 		id="dynamic-input-help-box"
 	>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Minor UI styling adjustments and expression helper text clarification in Svelte components.
> 
>   - **UI Styling**:
>     - Remove `dark:bg-[#272D38]` from `class` in `FakeMonacoPlaceHolder.svelte`.
>     - Use `stepInputGenButtonClasses(false)` for `btnClasses` in `StepInputsGen.svelte`.
>   - **Helper Text**:
>     - Update expression helper text in `DynamicInputHelpBox.svelte` to clarify optional chaining usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 6a896a685b2d7f255b57cde107c64fae0d403f02. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->