### PR TITLE
fix(backend): use correct ai tool job dir

### DIFF
--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -871,8 +871,6 @@ pub async fn run_agent(
 
                                 let tool_job = Arc::new(tool_job);
 
-                                let job_dir = create_job_dir(&worker_dir, job.id).await;
-
                                 let (inner_job_completed_tx, inner_job_completed_rx) =
                                     JobCompletedSender::new(&conn, 1);
 
@@ -891,7 +889,6 @@ pub async fn run_agent(
                                 let hostname_spawn = hostname.to_string();
                                 let worker_name_spawn = worker_name.to_string();
                                 let worker_dir_spawn = worker_dir.to_string();
-                                let job_dir_spawn = job_dir.clone();
                                 let base_internal_url_spawn = base_internal_url.to_string();
                                 let inner_job_completed_tx_spawn = inner_job_completed_tx.clone();
                                 let mut occupancy_metrics_spawn = occupancy_metrics.clone();
@@ -902,6 +899,9 @@ pub async fn run_agent(
                                     #[cfg(feature = "benchmark")]
                                     let mut bench_spawn =
                                         windmill_common::bench::BenchmarkIter::new();
+
+                                    let job_dir =
+                                        create_job_dir(&worker_dir_spawn, tool_job_spawn.id).await;
 
                                     let result = handle_queued_job(
                                         tool_job_spawn,
@@ -914,7 +914,7 @@ pub async fn run_agent(
                                         &hostname_spawn,
                                         &worker_name_spawn,
                                         &worker_dir_spawn,
-                                        &job_dir_spawn,
+                                        &job_dir,
                                         None,
                                         &base_internal_url_spawn,
                                         inner_job_completed_tx_spawn,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes job directory creation in `run_agent` to use correct job ID for AI tool jobs.
> 
>   - **Behavior**:
>     - Moves `create_job_dir` call in `run_agent` to use `tool_job_spawn.id` instead of `job.id`.
>     - Ensures job directory is created with the correct job ID for AI tool jobs.
>   - **Functions**:
>     - Affects `run_agent` and `handle_queued_job` in `ai_executor.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for db853a0860841b21bf56ea5ab16d0302d439fdb3. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->