### PR TITLE
Remove click-to-insert prop feature

### DIFF
--- a/frontend/src/lib/components/InputTransformForm.svelte
+++ b/frontend/src/lib/components/InputTransformForm.svelte
@@ -90,7 +90,6 @@
 
 	let monaco: SimpleEditor | undefined = $state(undefined)
 	let monacoTemplate: TemplateEditor | undefined = $state(undefined)
-	let argInput: ArgInput | undefined = $state(undefined)
 	let focusedPrev = false
 
 	let hidden = $state(false)
@@ -685,7 +684,6 @@
 							{resourceTypes}
 							noMargin
 							compact
-							bind:this={argInput}
 							on:focus={onFocus}
 							on:blur={() => {
 								focused = false


### PR DESCRIPTION
In response to a Tristan's interview with a dev who kept accidentally corrupting their inputs when exploring the prop picker. + I never personally use this. Open to thoughts
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove click-to-insert feature from prop picker in `InputTransformForm.svelte`.
> 
>   - **Behavior**:
>     - Removes click-to-insert feature from prop picker in `InputTransformForm.svelte`.
>     - Eliminates `focusProp` function calls for 'append' and 'insert' modes.
>   - **Code Changes**:
>     - Deletes `argInput` binding and related logic.
>     - Simplifies `on:focus` and `on:blur` handlers in `SimpleEditor` and `ArgInput` components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for d9e0913d17a1fa38bed65d8b5ae73c9bc1008487. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->