### PR TITLE
Fix Ctrl C in app right panel Copying component

### DIFF
--- a/frontend/src/lib/components/apps/editor/AppEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditor.svelte
@@ -1158,7 +1158,12 @@
 						<div class="relative flex flex-col h-full"></div>
 					{:else}
 						<Pane bind:size={rightPanelSize} minSize={15} maxSize={33}>
-							<div bind:clientWidth={$runnableJob.width} class="relative flex flex-col h-full">
+							<!-- svelte-ignore a11y_no_static_element_interactions -->
+							<div
+								bind:clientWidth={$runnableJob.width}
+								class="relative flex flex-col h-full"
+								onkeydown={(e) => e.stopPropagation()}
+							>
 								<Tabs bind:selected={selectedTab} wrapperClass="!min-h-[42px]" class="!h-full">
 									<Popover disappearTimeout={0} notClickable placement="bottom">
 										{#snippet text()}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevent keydown event propagation in the right panel of `AppEditor.svelte`.
> 
>   - **Behavior**:
>     - Prevents keydown event propagation in the right panel of `AppEditor.svelte` by adding `onkeydown={(e) => e.stopPropagation()}` to the div bound to `clientWidth` of `$runnableJob.width`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 65ee3d017a366522f6448a86f72bada36d4805e3. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->