### PR TITLE
fix: correct otel log levels

### DIFF
--- a/backend/windmill-common/src/tracing_init.rs
+++ b/backend/windmill-common/src/tracing_init.rs
@@ -126,11 +126,13 @@ pub fn initialize_tracing(
 
     // Create a common filter for OTEL logs bridge and tracing layer to respect RUST_LOG
     let otel_logs_filter = file_env_filter.clone();
-    let otel_tracing_filter = file_env_filter.clone();
 
     // Apply filter to the opentelemetry tracing layer to prevent debug events from being attached to spans
     #[cfg(all(feature = "otel", feature = "enterprise"))]
-    let opentelemetry_filtered = opentelemetry.map(|layer| layer.with_filter(otel_tracing_filter));
+    let opentelemetry_filtered = {
+        let otel_tracing_filter = file_env_filter.clone();
+        opentelemetry.map(|layer| layer.with_filter(otel_tracing_filter))
+    };
 
     #[cfg(not(all(feature = "otel", feature = "enterprise")))]
     let opentelemetry_filtered = opentelemetry;

--- a/backend/windmill-common/src/tracing_init.rs
+++ b/backend/windmill-common/src/tracing_init.rs
@@ -124,9 +124,20 @@ pub fn initialize_tracing(
         file_env_filter.clone()
     };
 
+    // Create a common filter for OTEL logs bridge and tracing layer to respect RUST_LOG
+    let otel_logs_filter = file_env_filter.clone();
+    let otel_tracing_filter = file_env_filter.clone();
+
+    // Apply filter to the opentelemetry tracing layer to prevent debug events from being attached to spans
+    #[cfg(all(feature = "otel", feature = "enterprise"))]
+    let opentelemetry_filtered = opentelemetry.map(|layer| layer.with_filter(otel_tracing_filter));
+
+    #[cfg(not(all(feature = "otel", feature = "enterprise")))]
+    let opentelemetry_filtered = opentelemetry;
+
     let base_layer = tracing_subscriber::registry()
-        .with(logs_bridge)
-        .with(opentelemetry);
+        .with(logs_bridge.with_filter(otel_logs_filter))
+        .with(opentelemetry_filtered);
 
     match *JSON_FMT {
         true => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Apply `file_env_filter` to OpenTelemetry tracing layer in `initialize_tracing()` to respect `RUST_LOG` and prevent debug events from attaching to spans.
> 
>   - **Behavior**:
>     - Apply `file_env_filter` to `logs_bridge` and `opentelemetry` in `initialize_tracing()` in `tracing_init.rs` to respect `RUST_LOG`.
>     - Prevent debug events from being attached to spans in OpenTelemetry tracing layer when `otel` and `enterprise` features are enabled.
>   - **Configuration**:
>     - Conditional application of filters based on `otel` and `enterprise` feature flags.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f6150b346bea9bed6e02e7aec2c02463d9dde6fb. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->