### PR TITLE
fix: batch job runner empty job kind

### DIFF
--- a/frontend/src/lib/components/runs/JobsLoader.svelte
+++ b/frontend/src/lib/components/runs/JobsLoader.svelte
@@ -32,7 +32,7 @@
 		jobKindsCat?: string | undefined
 		minTs?: string | undefined
 		maxTs?: string | undefined
-		jobKinds?: string
+		jobKinds?: string | undefined
 		queue_count?: Tweened<number> | undefined
 		suspended_count?: Tweened<number> | undefined
 		autoRefresh?: boolean
@@ -98,12 +98,12 @@
 		loadJobsIntern(true)
 	}
 
-	function computeJobKinds(jobKindsCat: string | undefined): string {
+	function computeJobKinds(jobKindsCat: string | undefined): string | undefined {
 		if (jobKindsCat == undefined && jobKinds != undefined) {
 			return jobKinds
 		}
 		if (jobKindsCat == 'all') {
-			return ''
+			return undefined
 		} else if (jobKindsCat == 'dependencies') {
 			let kinds: CompletedJob['job_kind'][] = [
 				'dependencies',


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `computeJobKinds` in `JobsLoader.svelte` to return `undefined` for 'all' job kinds, updating `jobKinds` type accordingly.
> 
>   - **Behavior**:
>     - `computeJobKinds` in `JobsLoader.svelte` now returns `undefined` instead of an empty string when `jobKindsCat` is 'all'.
>     - Updates type of `jobKinds` to `string | undefined` in `JobsLoader.svelte`.
>   - **Misc**:
>     - Minor type adjustment for `jobKinds` in `JobsLoader.svelte`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for af4e9e6a2290b1696e3a6bf176a1601bb469f2a1. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->