### PR TITLE
Fix LanguageStatusService.addStatus is not supported

### DIFF
--- a/frontend/src/lib/components/vscode.ts
+++ b/frontend/src/lib/components/vscode.ts
@@ -9,6 +9,7 @@ import {
 	getEnhancedMonacoEnvironment,
 	MonacoVscodeApiWrapper
 } from 'monaco-languageclient/vscodeApiWrapper'
+import getLanguagesServiceOverride from '@codingame/monaco-vscode-languages-service-override'
 
 export function buildWorkerDefinition() {
 	const envEnhanced = getEnhancedMonacoEnvironment()
@@ -134,6 +135,7 @@ export async function initializeVscode(caller?: string, htmlContainer?: HTMLElem
 					// ...getTextmateServiceOverride()
 					// ...getConfigurationServiceOverride(),
 					// ...getKeybindingsServiceOverride()
+					...getLanguagesServiceOverride()
 				},
 				userConfiguration: {
 					json: JSON.stringify({


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `getLanguagesServiceOverride` to `initializeVscode()` in `vscode.ts` for enhanced language service support.
> 
>   - **Behavior**:
>     - Adds `getLanguagesServiceOverride` to `serviceOverrides` in `initializeVscode()` in `vscode.ts` to support additional language services.
>   - **Imports**:
>     - Imports `getLanguagesServiceOverride` from `@codingame/monaco-vscode-languages-service-override` in `vscode.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for f2ee0577fcd716d24e8f6486e50950d4e888e914. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->