### PR TITLE
fix: showexpr in inputtransformform

### DIFF
--- a/frontend/src/lib/components/InputTransformForm.svelte
+++ b/frontend/src/lib/components/InputTransformForm.svelte
@@ -311,6 +311,7 @@
 		}
 	}
 
+	// This only works if every fields are static, as we can't eval javascript
 	function handleFieldVisibility(
 		schema: Schema | any,
 		arg: InputTransform | any,
@@ -326,15 +327,20 @@
 				[argName]: currentValue
 			}
 
+			let hasJavascript = false
+
 			// Extract values from InputTransform objects in otherArgs
 			Object.keys(otherArgs ?? {}).forEach((key) => {
+				if (otherArgs[key].type === 'javascript') {
+					hasJavascript = true
+				}
 				const otherArg = otherArgs[key]
 				const otherArgValue = otherArg.type === 'static' ? otherArg.value : otherArg.expr
 				contextArgs[key] = otherArgValue
 			})
 
 			const shouldShow = computeShow(argName, schemaProperty.showExpr, contextArgs)
-			if (shouldShow) {
+			if (shouldShow || hasJavascript) {
 				hidden = false
 			} else if (!hidden) {
 				hidden = true
@@ -443,7 +449,7 @@
 	)
 </script>
 
-{#if arg != undefined}
+{#if arg != undefined && !hidden}
 	<div class={twMerge('pt-2 pb-2 relative group', className)}>
 		<div class="flex flex-row justify-between gap-1 pb-1">
 			<div class="flex flex-wrap grow min-h-7 items-end">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `InputTransformForm.svelte` to improve field visibility handling by checking for JavaScript type in `otherArgs`.
> 
>   - **Behavior**:
>     - Update `handleFieldVisibility()` in `InputTransformForm.svelte` to check for JavaScript type in `otherArgs` and set `hidden` to false if present.
>     - Modify rendering condition to `{#if arg != undefined && !hidden}` to respect the `hidden` state.
>   - **Misc**:
>     - Add comment in `handleFieldVisibility()` explaining limitation with static fields and JavaScript evaluation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for c4104dc4769a50e3899de84996e8fe6339578204. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->