### PR TITLE
always allow Save resource in JSON mode

### DIFF
--- a/frontend/src/lib/components/ResourceEditor.svelte
+++ b/frontend/src/lib/components/ResourceEditor.svelte
@@ -182,7 +182,7 @@
 		}
 	})
 	run(() => {
-		canSave = can_write && isValid && jsonError == ''
+		canSave = (can_write && isValid && jsonError == '') || (viewJsonSchema && jsonError == '')
 	})
 	$effect(() => {
 		onChange && onChange({ path, args, description })


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `ResourceEditor.svelte` to allow saving resources in JSON mode regardless of JSON errors when `viewJsonSchema` is true.
> 
>   - **Behavior**:
>     - Update `canSave` logic in `ResourceEditor.svelte` to allow saving when `viewJsonSchema` is true, regardless of `jsonError`.
>   - **Conditions**:
>     - `canSave` is true if `viewJsonSchema` is true, even if `jsonError` is not empty.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 7c13be452fb7265797ee3d6aa6d7cd22a115b997. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->