### PR TITLE
support pg jsob array

### DIFF
--- a/backend/windmill-worker/src/pg_executor.rs
+++ b/backend/windmill-worker/src/pg_executor.rs
@@ -688,6 +688,7 @@ fn convert_val(
                 .unwrap_or(vec![]);
             Ok(Box::new(bytes))
         }
+        Value::Array(_) if arg_t == "jsonb" || arg_t == "json" => Ok(Box::new(value.clone())),
         Value::Object(_) if arg_t == "text" || arg_t == "varchar" => {
             Ok(Box::new(serde_json::to_string(value).map_err(|err| {
                 Error::ExecutionErr(format!("Failed to convert JSON to text: {}", err))


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for JSON and JSONB array types in `convert_val()` in `pg_executor.rs`.
> 
>   - **Behavior**:
>     - Add support for JSON and JSONB array types in `convert_val()` in `pg_executor.rs`.
>     - Handles `Value::Array` when `arg_t` is `jsonb` or `json` by returning a boxed clone of the value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 37c466469920e0046c8f5d3b6a51ecee7ee4f017. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->