### PR TITLE
feat: add support for contextual vars in SQL

### DIFF
--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -3016,6 +3016,7 @@ async fn handle_code_execution_job(
             worker_name,
             column_order,
             occupancy_metrics,
+            parent_runnable_path,
         )
         .await;
     } else if language == Some(ScriptLang::Mysql) {
@@ -3035,6 +3036,7 @@ async fn handle_code_execution_job(
             worker_name,
             column_order,
             occupancy_metrics,
+            parent_runnable_path,
         )
         .await;
     } else if language == Some(ScriptLang::Bigquery) {
@@ -3065,6 +3067,7 @@ async fn handle_code_execution_job(
                 worker_name,
                 column_order,
                 occupancy_metrics,
+                parent_runnable_path,
             )
             .await;
         }
@@ -3088,6 +3091,7 @@ async fn handle_code_execution_job(
                 worker_name,
                 column_order,
                 occupancy_metrics,
+                parent_runnable_path,
             )
             .await;
         }
@@ -3119,6 +3123,7 @@ async fn handle_code_execution_job(
                 worker_name,
                 occupancy_metrics,
                 job_dir,
+                parent_runnable_path,
             )
             .await;
         }
@@ -3150,6 +3155,7 @@ async fn handle_code_execution_job(
                 worker_name,
                 column_order,
                 occupancy_metrics,
+                parent_runnable_path,
             )
             .await;
         }
@@ -3174,6 +3180,7 @@ async fn handle_code_execution_job(
                 worker_name,
                 column_order,
                 occupancy_metrics,
+                parent_runnable_path,
             )
             .await;
         }

--- a/frontend/src/lib/components/EditorBar.svelte
+++ b/frontend/src/lib/components/EditorBar.svelte
@@ -135,7 +135,14 @@
 			'csharp',
 			'nu',
 			'java',
-			'ruby'
+			'ruby',
+			'postgresql',
+			'mysql',
+			'bigquery',
+			'mssql',
+			'oracledb',
+			'snowflake',
+			'duckdb'
 			// for related places search: ADD_NEW_LANG
 		].includes(lang ?? '')
 	)
@@ -443,6 +450,12 @@
 			// for related places search: ADD_NEW_LANG
 		} else if (lang == 'ruby') {
 			editor.insertAtCursor(`ENV['${name}']`)
+		} else if (
+			['postgresql', 'mysql', 'bigquery', 'mssql', 'oracledb', 'snowflake', 'duckdb'].includes(
+				lang ?? ''
+			)
+		) {
+			editor.insertAtCursor(`%%${name}%%`)
 		}
 		sendUserToast(`${name} inserted at cursor`)
 	}}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for contextual variables in SQL queries across multiple executors and update the frontend to support these changes.
> 
>   - **Behavior**:
>     - Add support for contextual variables in SQL queries across multiple executors (`bigquery_executor.rs`, `duckdb_executor.rs`, `mssql_executor.rs`, `mysql_executor.rs`, `oracledb_executor.rs`, `pg_executor.rs`, `snowflake_executor.rs`).
>     - Update `sanitize_and_interpolate_unsafe_sql_args` in `sanitized_sql_params.rs` to handle contextual variables.
>   - **Functions**:
>     - Add `replace_contextual_variables()` in `sanitized_sql_params.rs` to replace contextual variables in SQL queries.
>   - **Frontend**:
>     - Update `EditorBar.svelte` to support contextual variable insertion for SQL languages (e.g., `postgresql`, `mysql`, `bigquery`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for da64eccdfc5aefe50075da854e65dd51f41f27d2. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->