### PR TITLE
chore: upgrade bun to 1.2.23

### DIFF
--- a/.github/DockerfileBackendTests
+++ b/.github/DockerfileBackendTests
@@ -42,7 +42,7 @@ RUN wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VER
 RUN /usr/local/bin/python3 -m pip install pip-tools
 
 # Bun
-COPY --from=oven/bun:1.2.18 /usr/local/bin/bun /usr/bin/bun
+COPY --from=oven/bun:1.2.23 /usr/local/bin/bun /usr/bin/bun
 
 ARG TARGETPLATFORM
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -204,7 +204,7 @@ COPY --from=windmill_duckdb_ffi_internal_builder /windmill-duckdb-ffi-internal/t
 
 COPY --from=denoland/deno:2.2.1 --chmod=755 /usr/bin/deno /usr/bin/deno
 
-COPY --from=oven/bun:1.2.18 /usr/local/bin/bun /usr/bin/bun
+COPY --from=oven/bun:1.2.23 /usr/local/bin/bun /usr/bin/bun
 
 COPY --from=php:8.3.7-cli /usr/local/bin/php /usr/bin/php
 COPY --from=composer:2.7.6 /usr/bin/composer /usr/bin/composer

--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -20,7 +20,7 @@ RUN /usr/local/bin/python3 -m pip install pip-tools
 # Install UV
 RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.5.15/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
 
-COPY --from=oven/bun:1.2.18 /usr/local/bin/bun /usr/bin/bun
+COPY --from=oven/bun:1.2.23 /usr/local/bin/bun /usr/bin/bun
 
 # add the docker client to call docker from a worker if enabled
 COPY --from=docker:dind /usr/local/bin/docker /usr/local/bin/

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -19,7 +19,7 @@ RUN /usr/local/bin/python3 -m pip install pip-tools
 # Install UV
 RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.5.15/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
 
-COPY --from=oven/bun:1.2.18 /usr/local/bin/bun /usr/bin/bun
+COPY --from=oven/bun:1.2.23 /usr/local/bin/bun /usr/bin/bun
 
 # add the docker client to call docker from a worker if enabled
 COPY --from=docker:dind /usr/local/bin/docker /usr/local/bin/


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Upgrade Bun from version 1.2.18 to 1.2.23 in multiple Dockerfiles.
> 
>   - **Version Upgrade**:
>     - Upgrade Bun from version `1.2.18` to `1.2.23` in `Dockerfile`, `.github/DockerfileBackendTests`, `docker/DockerfileSlim`, and `docker/DockerfileSlimEe`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for d15699bd38f1f0c0292647f602a77cc12b19defb. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->