### PR TITLE
fix: show workspace prefix to non superadmins for app deploy custom path

### DIFF
--- a/backend/windmill-api/src/settings.rs
+++ b/backend/windmill-api/src/settings.rs
@@ -359,6 +359,7 @@ pub async fn get_global_setting(
         && key != HUB_BASE_URL_SETTING
         && key != HUB_ACCESSIBLE_URL_SETTING
         && key != EMAIL_DOMAIN_SETTING
+        && key != APP_WORKSPACED_ROUTE_SETTING
     {
         require_super_admin(&db, &authed.email).await?;
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Non-superadmins can now access `APP_WORKSPACED_ROUTE_SETTING` in `get_global_setting()` without super admin privileges.
> 
>   - **Behavior**:
>     - Non-superadmins can now access `APP_WORKSPACED_ROUTE_SETTING` in `get_global_setting()` in `settings.rs` without requiring super admin privileges.
>   - **Access Control**:
>     - Updated `get_global_setting()` in `settings.rs` to exclude `APP_WORKSPACED_ROUTE_SETTING` from super admin check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 7cea0ef370291c1648d8954aaaa090bc7421f7dc. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->