### PR TITLE
internal: no max turns on weekly flow

### DIFF
--- a/.github/workflows/weekly-pr-summary.yml
+++ b/.github/workflows/weekly-pr-summary.yml
@@ -96,7 +96,6 @@ jobs:
             ## Saving the Markdown Output:
             After generating the markdown summary, save it to a file, BUT DO NOT COMMIT IT TO THE REPOSITORY.
           claude_args: |
-            --max-turns 10
             --allowedTools "Bash"
 
       - name: Send Summary to Windmill


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `--max-turns 10` from `claude_args` in `weekly-pr-summary.yml` to allow unlimited turns.
> 
>   - **Workflow Configuration**:
>     - Removed `--max-turns 10` from `claude_args` in `.github/workflows/weekly-pr-summary.yml`, allowing unlimited turns for Claude in generating the weekly PR summary.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 7d1eebd4a353ddd7eef42a87ecf200f5bb530235. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->