### PR TITLE
fix: ui bugs scopes token

### DIFF
--- a/frontend/src/lib/components/settings/ScopeSelector.svelte
+++ b/frontend/src/lib/components/settings/ScopeSelector.svelte
@@ -349,21 +349,21 @@
 		}
 
 		const parts = trimmedPath.split('/')
-		if (parts.length !== 3) {
-			return 'Path must have exactly 3 parts: u/{user}/{resource} or f/{folder}/{resource}'
+		if (parts.length < 3) {
+			return 'Expected path format: u/{user}/{resource} or f/{folder}/{resource}'
 		}
 
 		if (parts[1] === '') {
 			return 'Username/folder name cannot be empty'
 		}
-
-		if (parts[2] === '') {
+		const last = parts[parts.length - 1]
+		if (last.length === 0) {
 			return 'Resource name cannot be empty'
 		}
 
-		if (parts[2] === '*') return null
+		if (last === '*') return null
 
-		if (parts[2].includes('*')) {
+		if (last.includes('*')) {
 			return 'Wildcards can only be used as the full resource name (*)'
 		}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes path validation logic in `ScopeSelector.svelte` to allow paths with more than 3 parts and updates error messages.
> 
>   - **Validation Logic**:
>     - In `ScopeSelector.svelte`, `validateResourcePath()` now allows paths with more than 3 parts, updating the error message to "Expected path format: u/{user}/{resource} or f/{folder}/{resource}".
>     - Uses `last` variable to check the last part of the path for empty or wildcard conditions.
>   - **Error Messages**:
>     - Updates error messages for path validation to be more descriptive and accurate.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 635a9162b857a63a7baf92964a40267ef9f923e8. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->