### PR TITLE
fix: resource editor should not autoselect resources for optional fields

### DIFF
--- a/frontend/src/lib/components/ArgInput.svelte
+++ b/frontend/src/lib/components/ArgInput.svelte
@@ -1016,7 +1016,7 @@
 			<ObjectResourceInput
 				{disabled}
 				{defaultValue}
-				selectFirst={!noDefaultOnSelectFirst}
+				selectFirst={!noDefaultOnSelectFirst && required}
 				{disablePortal}
 				format={format ?? ''}
 				bind:value


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `ObjectResourceInput` in `ArgInput.svelte` to prevent auto-selection of resources for optional fields by checking if the field is required.
> 
>   - **Behavior**:
>     - Fixes `ObjectResourceInput` in `ArgInput.svelte` to prevent auto-selection of resources for optional fields by updating `selectFirst` to check if the field is `required`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 19d4235d72b6578da8afac56e61092e4ff8c3d68. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->