### PR TITLE
add 'submitted' output to button when running in background

### DIFF
--- a/frontend/src/lib/components/apps/components/helpers/RunnableComponent.svelte
+++ b/frontend/src/lib/components/apps/components/helpers/RunnableComponent.svelte
@@ -47,6 +47,7 @@
 			result: Output<any>
 			loading: Output<boolean>
 			jobId?: Output<any> | undefined
+			submitted?: Output<any> | undefined
 		}
 		extraKey?: string
 		initializing?: boolean
@@ -176,6 +177,7 @@
 				console.log('started', id)
 				loading = true
 				outputs.jobId?.set(id)
+				outputs.submitted?.set(true)
 				dispatch('started', id)
 			},
 			doneWithoutCompute(r: any) {
@@ -349,6 +351,9 @@
 		dynamicArgsOverride?: Record<string, any>,
 		callbacks?: RunnableCallback
 	): Promise<string | undefined> {
+		// Reset submitted flag for new execution
+		outputs.submitted?.set(undefined)
+
 		let jobId: string | undefined
 		console.debug(`Executing ${id}`)
 		if (iterContext && $iterContext.disabled) {

--- a/frontend/src/lib/components/apps/components/helpers/RunnableWrapper.svelte
+++ b/frontend/src/lib/components/apps/components/helpers/RunnableWrapper.svelte
@@ -83,11 +83,13 @@
 			result: Output<any>
 			loading: Output<boolean>
 			jobId?: Output<any> | undefined
+			submitted?: Output<any> | undefined
 		}
 		extraKey?: string | undefined
 		refreshOnStart?: boolean
 		errorHandledByComponent?: boolean
 		allowConcurentRequests?: boolean
+		skipSideEffectOnSuccess?: boolean
 		onSuccess?: (result: any) => void
 		children?: import('svelte').Snippet
 		nonRenderedPlaceholder?: import('svelte').Snippet
@@ -120,6 +122,7 @@
 		refreshOnStart = false,
 		errorHandledByComponent = false,
 		allowConcurentRequests = false,
+		skipSideEffectOnSuccess = false,
 		onSuccess = () => {},
 		children,
 		nonRenderedPlaceholder
@@ -355,7 +358,9 @@
 		}}
 		on:success={(e) => {
 			onSuccess(e.detail)
-			handleSideEffect(true)
+			if (!skipSideEffectOnSuccess) {
+				handleSideEffect(true)
+			}
 		}}
 		on:handleError={(e) => handleSideEffect(false, e.detail)}
 		{outputs}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds 'submitted' output to track job submissions and modifies background job handling to trigger success immediately upon submission.
> 
>   - **Behavior**:
>     - Adds `submitted` output to track job submission in `AppButton.svelte`, `RunnableComponent.svelte`, and `RunnableWrapper.svelte`.
>     - For background jobs, triggers success handler immediately upon job submission in `AppButton.svelte`.
>     - Resets `submitted` flag for new executions in `RunnableComponent.svelte`.
>   - **Props and Outputs**:
>     - Adds `submitted` to outputs in `RunnableComponent.svelte` and `RunnableWrapper.svelte`.
>     - Adds `skipSideEffectOnSuccess` prop to `RunnableWrapper.svelte` to control side effect execution on success.
>   - **Misc**:
>     - Modifies `handleSideEffect` in `RunnableWrapper.svelte` to respect `skipSideEffectOnSuccess`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 28aa06e83512739ef81abc540b1cb39f2f326408. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->