### PR TITLE
fix: gcp script picker

### DIFF
--- a/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
@@ -31,7 +31,6 @@
 	import Toggle from '$lib/components/Toggle.svelte'
 
 	let drawer: Drawer | undefined = $state(undefined)
-	let is_flow: boolean = $state(false)
 	let initialPath = $state('')
 	let edit = $state(true)
 	let delivery_type: DeliveryType = $state('pull')
@@ -132,7 +131,6 @@
 		drawerLoading = true
 		try {
 			drawer?.openDrawer()
-			is_flow = nis_flow
 			itemKind = nis_flow ? 'flow' : 'script'
 			initialScriptPath = ''
 			fixedScriptPath = fixedScriptPath_ ?? ''
@@ -184,7 +182,6 @@
 		subscription_id = cfg?.subscription_id
 		delivery_config = cfg?.delivery_config
 		subscription_mode = cfg?.subscription_mode
-		is_flow = cfg?.is_flow
 		path = cfg?.path
 		enabled = cfg?.enabled
 		topic_id = cfg?.topic_id ?? ''
@@ -229,7 +226,7 @@
 			path,
 			script_path,
 			enabled,
-			is_flow,
+			is_flow : itemKind === 'flow',
 			error_handler_path,
 			error_handler_args,
 			retry,
@@ -268,10 +265,6 @@
 	$effect(() => {
 		const args = [captureConfig, isValid] as const
 		untrack(() => onCaptureConfigChange?.(...args))
-	})
-
-	$effect(() => {
-		is_flow = itemKind === 'flow'
 	})
 
 	$effect(() => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `GcpTriggerEditorInner.svelte` to remove `is_flow` variable and use `itemKind` for flow/script determination.
> 
>   - **Refactoring**:
>     - Remove `is_flow` variable from `GcpTriggerEditorInner.svelte`.
>     - Use `itemKind` to determine if the item is a 'flow' or 'script'.
>   - **Behavior**:
>     - In `openEdit()` and `openNew()`, set `itemKind` based on `isFlow` and `nis_flow` parameters respectively.
>     - In `getGcpConfig()`, set `is_flow` property based on `itemKind`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=windmill-labs%2Fwindmill&utm_source=github&utm_medium=referral)<sup> for 8351fba4eefd8b274b81efbdba66f76114dbfcc8. You can [customize](https://app.ellipsis.dev/windmill-labs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->