### PR TITLE
feat(aiagent): Store AI provider config in localStorage

### DIFF
--- a/frontend/src/lib/components/AIProviderPicker.svelte
+++ b/frontend/src/lib/components/AIProviderPicker.svelte
@@ -302,7 +302,7 @@
 			<Toggle
 				disabled={disabled || !value?.kind || !value?.resource || !value?.model}
 				bind:checked={useAsDefault}
-				options={{ right: 'Use as default for other agents' }}
+				options={{ right: 'Use as personal default for other new agents' }}
 				size="xs"
 				on:change={(e) => {
 					if (!e.detail) {


### PR DESCRIPTION
## Summary

Implements localStorage persistence for AI provider configuration in AI agent step inputs.

- Stores selected provider, resource, and model in localStorage
- Loads stored values as defaults on component initialization
- Automatically saves when selections change
- Validates stored provider is still available

Fixes #6850

---

Generated with [Claude Code](https://claude.ai/code)