### PR TITLE
nit: improve error reporting on git sync jobs by printing error msg

### DIFF
--- a/frontend/src/lib/components/git_sync/GitSyncRepositoryCard.svelte
+++ b/frontend/src/lib/components/git_sync/GitSyncRepositoryCard.svelte
@@ -305,6 +305,11 @@
 					</a>
 					<span class="text-secondary">WARNING: Only read permissions are verified.</span>
 				</div>
+				{#if gitSyncTestJob.status === 'failure' && gitSyncTestJob.error}
+					<div class="text-red-600 text-xs mt-1">
+						Error: {gitSyncTestJob.error}
+					</div>
+				{/if}
 			{/if}
 
 			<!-- Warnings -->


### PR DESCRIPTION
<img width="1514" height="372" alt="Screenshot 2025-10-23 at 3 15 31 PM" src="https://github.com/user-attachments/assets/7f2a645a-2947-44d3-8d56-fd7014fda3c3" />
<img width="1091" height="105" alt="Screenshot 2025-10-23 at 3 14 21 PM" src="https://github.com/user-attachments/assets/09eeeca6-457a-4eae-89c2-bc4dba4fd39a" />
