### PR TITLE
Fix CVE-2025-62518 by migrating to astral-tokio-tar

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -551,6 +551,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash 2.1.1",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10521,15 +10537,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
@@ -13774,21 +13781,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tar"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
-dependencies = [
- "filetime",
- "futures-core",
- "libc",
- "redox_syscall 0.3.5",
- "tokio",
- "tokio-stream",
- "xattr",
-]
-
-[[package]]
 name = "tokio-tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15187,6 +15179,7 @@ version = "1.566.1"
 dependencies = [
  "anyhow",
  "argon2",
+ "astral-tokio-tar",
  "async-nats",
  "async-oauth2",
  "async-recursion",
@@ -15275,7 +15268,6 @@ dependencies = [
  "tokio-postgres 0.7.11",
  "tokio-postgres 0.7.13",
  "tokio-stream",
- "tokio-tar",
  "tokio-tungstenite",
  "tokio-util",
  "tonic",
@@ -15453,6 +15445,7 @@ name = "windmill-indexer"
 version = "1.566.1"
 dependencies = [
  "anyhow",
+ "astral-tokio-tar",
  "bytes",
  "chrono",
  "const_format",
@@ -15466,7 +15459,6 @@ dependencies = [
  "tantivy",
  "tempfile",
  "tokio",
- "tokio-tar",
  "tracing",
  "uuid",
  "windmill-common",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -255,7 +255,7 @@ async-oauth2 = "0.5.1"
 reqwest = { version = "^0.12", features = ["json", "stream", "gzip", "multipart"] }
 time = "^0"
 serde_urlencoded = "^0"
-tokio-tar = "^0"
+astral-tokio-tar = "0.5.6"
 tempfile = "^3"
 tokio-util = { version = "^0", features = ["io"] }
 json-pointer = "^0"

--- a/backend/windmill-api/Cargo.toml
+++ b/backend/windmill-api/Cargo.toml
@@ -92,7 +92,7 @@ mail-parser = { workspace = true, features = ["serde_support"], optional = true 
 magic-crypt.workspace = true
 tempfile.workspace = true
 tokio-util.workspace = true
-tokio-tar.workspace = true
+astral-tokio-tar.workspace = true
 tokio-postgres.workspace = true
 hmac.workspace = true
 cookie.workspace = true

--- a/backend/windmill-indexer/Cargo.toml
+++ b/backend/windmill-indexer/Cargo.toml
@@ -29,7 +29,7 @@ futures.workspace = true
 tempfile.workspace = true
 bytes.workspace = true
 object_store = { workspace = true, optional = true}
-tokio-tar.workspace = true
+astral-tokio-tar.workspace = true
 lazy_static.workspace = true
 const_format.workspace = true
 flume.workspace = true


### PR DESCRIPTION
tokio-tar is abandoned and has a high severity CVE that is addressed by astral-tokio-tar 0.5.6

astral-tokio-tar can be used as an actively maintained drop-in replacement

