### PR TITLE
feat: Add "list_resources" function to the wmill python package (client.py)

### DIFF
--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -534,6 +534,35 @@ class Windmill:
                 json={"value": value},
             )
 
+    def list_resources(
+        self,
+        resource_type: str = None,
+        page: int = None,
+        per_page: int = None,
+    ) -> list[dict]:
+        """List resources from Windmill workspace.
+        
+        Args:
+            resource_type: Optional resource type to filter by (e.g., "postgresql", "mysql", "s3")
+            page: Optional page number for pagination
+            per_page: Optional number of results per page
+            
+        Returns:
+            List of resource dictionaries
+        """
+        params = {}
+        if resource_type is not None:
+            params["resource_type"] = resource_type
+        if page is not None:
+            params["page"] = page
+        if per_page is not None:
+            params["per_page"] = per_page
+            
+        return self.get(
+            f"/w/{self.workspace}/resources/list",
+            params=params if params else None,
+        ).json()
+    
     def set_state(self, value: Any):
         self.set_resource(value, path=self.state_path, resource_type="state")
 
@@ -1261,6 +1290,36 @@ def set_resource(path: str, value: Any, resource_type: str = "any") -> None:
     Set the resource at a given path as a string, creating it if it does not exist
     """
     return _client.set_resource(value=value, path=path, resource_type=resource_type)
+
+
+@init_global_client
+def list_resources(
+    resource_type: str = None,
+    page: int = None,
+    per_page: int = None,
+) -> list[dict]:
+    """List resources from Windmill workspace.
+    
+    Args:
+        resource_type: Optional resource type to filter by (e.g., "postgresql", "mysql", "s3")
+        page: Optional page number for pagination
+        per_page: Optional number of results per page
+        
+    Returns:
+        List of resource dictionaries
+        
+    Example:
+        >>> # Get all resources
+        >>> all_resources = wmill.list_resources()
+        
+        >>> # Get only PostgreSQL resources
+        >>> pg_resources = wmill.list_resources(resource_type="postgresql")
+    """
+    return _client.list_resources(
+        resource_type=resource_type,
+        page=page,
+        per_page=per_page,
+    )
 
 
 @init_global_client


### PR DESCRIPTION
## Key Points

- Adds a new `list_resources` method to the windmill python client, enabling users to enumerate all resources in a workspace, optionally filtered by resource type (e.g. `"postgresql"`, `"c_energy_meter"`, etc).
- Supports optional `page` and `per_page` arguments for pagination, but currently pagination is not enforced (results are returned as-is from the API).  
  **Would you prefer pagination be enforced by default?**
- I did my best to follow the style and conventions of the existing client code, including both a method on the `Windmill` class and a top-level function with the same signature.
- Includes full docstrings and usage examples.
---

If you have any feedback on the implementation please let me know, I'm happy to make any changes or improvements. Also, if this approach doesn't match the ambitions or methodology for the project I understand, no worries. Thanks for your consideration!

---
## Background

I work on code for asset managers amongst other things and store various object definitions in long YAML config files, currently in GitHub. [files like: asset_details, energy meters, dashboards etc]. Many of my scripts need to loop over all of a certain type (ie. meters for data imports). I intend to migrate these resources into Windmill for better management and would like an elegant, idiomatic way to loop over all resources of a specific type (such as all `c_energy_meter` resources) via the Python client. 

_Alternatively I could put everything in one big yaml file as a single resource but that makes it harder for non tech users to contribute and add new objects. I think it would be more elegant if every park, meter, report is a custom resource type and has its own windmill resource objects. For this approach to work cleanly I would benefit from a function like "list_resources" to loop elegantly._
