### PR TITLE
fix: trim whitespaces from license key input field

### DIFF
--- a/frontend/src/lib/components/InstanceSetting.svelte
+++ b/frontend/src/lib/components/InstanceSetting.svelte
@@ -368,6 +368,11 @@
 							onKeyDown={() => {
 								licenseKeyChanged = true
 							}}
+							onBlur={() => {
+								if ($values[setting.key] && typeof $values[setting.key] === 'string') {
+									$values[setting.key] = $values[setting.key].trim()
+								}
+							}}
 							bind:password={$values[setting.key]}
 						/>
 						<Button

--- a/frontend/src/lib/components/InstanceSettings.svelte
+++ b/frontend/src/lib/components/InstanceSettings.svelte
@@ -136,6 +136,11 @@
 
 		let shouldReloadPage = false
 		if ($values) {
+			// Trim license key before saving
+			if ($values['license_key'] && typeof $values['license_key'] === 'string') {
+				$values['license_key'] = $values['license_key'].trim()
+			}
+
 			const allSettings = [...Object.values(settings), scimSamlSetting].flatMap((x) =>
 				Object.entries(x)
 			)

--- a/frontend/src/lib/components/Password.svelte
+++ b/frontend/src/lib/components/Password.svelte
@@ -9,6 +9,7 @@
 		required?: boolean
 		small?: boolean
 		onKeyDown?: (event: KeyboardEvent) => void
+		onBlur?: (event: FocusEvent) => void
 	}
 
 	let {
@@ -17,7 +18,8 @@
 		disabled = false,
 		required = false,
 		small = false,
-		onKeyDown
+		onKeyDown,
+		onBlur
 	}: Props = $props()
 
 	let red = $derived(required && (password == '' || password == undefined))
@@ -43,6 +45,7 @@
 			type="password"
 			bind:value={password}
 			onkeydown={onKeyDown}
+			onblur={onBlur}
 			autocomplete="new-password"
 			{placeholder}
 			{disabled}
@@ -55,6 +58,7 @@
 			type="text"
 			bind:value={password}
 			onkeydown={bubble('keydown')}
+			onblur={onBlur}
 			autocomplete="new-password"
 			{placeholder}
 			{disabled}


### PR DESCRIPTION
Fixes #7083

This PR adds automatic whitespace trimming to the license key input field in instance settings.

### Changes
- Add `onBlur` prop support to Password component
- Trim license key on blur in InstanceSetting component
- Trim license key before saving in InstanceSettings component

The license key will now automatically have leading and trailing whitespace removed when the user leaves the field or when settings are saved.

---
Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/windmill-labs/windmill/tree/claude/issue-7083-20251107-1545) | [View job run](https://github.com/windmill-labs/windmill/actions/runs/19173300722