### PR TITLE
fix(backend): add sslmode parameter to DuckLake PostgreSQL connections

### DIFF
--- a/backend/windmill-worker/src/duckdb_executor.rs
+++ b/backend/windmill-worker/src/duckdb_executor.rs
@@ -350,7 +350,7 @@ fn format_attach_db_conn_str(db_resource: Value, db_type: &str) -> Result<String
         "postgres" | "postgresql" => {
             let res: PgDatabase = serde_json::from_value(db_resource)?;
             format!(
-                "dbname={} {} host={} {} {}",
+                "dbname={} {} host={} {} {} {}",
                 res.dbname,
                 res.user.map(|u| format!("user={}", u)).unwrap_or_default(),
                 res.host,
@@ -358,6 +358,9 @@ fn format_attach_db_conn_str(db_resource: Value, db_type: &str) -> Result<String
                     .map(|p| format!("password={}", p))
                     .unwrap_or_default(),
                 res.port.map(|p| format!("port={}", p)).unwrap_or_default(),
+                res.sslmode
+                    .map(|s| format!("sslmode={}", s))
+                    .unwrap_or_default(),
             )
         }
         #[cfg(feature = "mysql")]


### PR DESCRIPTION
## Summary

Fixes #7109 - DuckLake setup now works with PostgreSQL databases that require TLS (e.g., AWS RDS with `sslmode=require`).

## Problem

When configuring a DuckLake instance catalog with a PostgreSQL database that requires TLS, the setup would fail at step 5 with the error:
```
error performing TLS handshake: no TLS implementation configured
```

This occurred even though:
- The main Windmill application successfully connects to the same database using SQLx with rustls
- The PostgreSQL resource has an `sslmode` field configured (e.g., `sslmode=require`)

## Root Cause

In `backend/windmill-worker/src/duckdb_executor.rs`, the `format_attach_db_conn_str` function constructs a PostgreSQL connection string for DuckDB's `postgres_scanner` extension. This connection string was missing the `sslmode` parameter, even though the `PgDatabase` struct contains this field.

## Solution

Added the `sslmode` parameter to the PostgreSQL connection string construction in `format_attach_db_conn_str` function. The parameter is now properly included when constructing the connection string for DuckDB's postgres_scanner extension.

## Changes

- **backend/windmill-worker/src/duckdb_executor.rs**: Added sslmode parameter to PostgreSQL connection string format

## Testing

The fix follows the existing pattern for other optional PostgreSQL parameters like `port`. When a PostgreSQL resource is configured with any `sslmode` value (`disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full`), it will now be properly passed to the postgres_scanner extension.

## Impact

- Enables DuckLake to work with TLS-required PostgreSQL databases (AWS RDS, Azure Database for PostgreSQL, etc.)
- Minimal change with no breaking impact on existing functionality
- Backwards compatible (sslmode is optional and defaults to empty string if not provided)