### PR TITLE
Add trigger_kind filter to runs page

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -8100,6 +8100,11 @@ paths:
           in: query
           schema:
             type: boolean
+        - name: trigger_kind
+          description: filter by trigger kind (webhook, http, websocket, kafka, email, nats, schedule, app, ui, postgres, sqs, gcp)
+          in: query
+          schema:
+            type: string
       responses:
         "200":
           description: All queued jobs
@@ -8469,6 +8474,11 @@ paths:
           in: query
           schema:
             type: boolean
+        - name: trigger_kind
+          description: filter by trigger kind (webhook, http, websocket, kafka, email, nats, schedule, app, ui, postgres, sqs, gcp)
+          in: query
+          schema:
+            type: string
       responses:
         "200":
           description: All jobs
@@ -14442,6 +14452,11 @@ paths:
           in: query
           schema:
             type: boolean
+        - name: trigger_kind
+          description: filter by trigger kind (webhook, http, websocket, kafka, email, nats, schedule, app, ui, postgres, sqs, gcp)
+          in: query
+          schema:
+            type: string
       responses:
         "200":
           description: time

--- a/backend/windmill-api/src/concurrency_groups.rs
+++ b/backend/windmill-api/src/concurrency_groups.rs
@@ -222,6 +222,7 @@ async fn get_concurrent_intervals(
             all_workspaces: _,
             concurrency_key: Some(_),
             allow_wildcards: None,
+            trigger_kind: None,
         } => true,
         _ => false,
     };

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -1781,6 +1781,7 @@ pub struct ListQueueQuery {
     pub is_not_schedule: Option<bool>,
     pub concurrency_key: Option<String>,
     pub allow_wildcards: Option<bool>,
+    pub trigger_kind: Option<String>,
 }
 
 impl From<ListCompletedQuery> for ListQueueQuery {
@@ -1812,6 +1813,7 @@ impl From<ListCompletedQuery> for ListQueueQuery {
             is_not_schedule: lcq.is_not_schedule,
             concurrency_key: lcq.concurrency_key,
             allow_wildcards: lcq.allow_wildcards,
+            trigger_kind: lcq.trigger_kind,
         }
     }
 }
@@ -1933,6 +1935,10 @@ pub fn filter_list_queue_query(
 
     if lq.is_not_schedule.unwrap_or(false) {
         sqlb.and_where("trigger_kind IS DISTINCT FROM 'schedule'");
+    }
+
+    if let Some(tk) = &lq.trigger_kind {
+        sqlb.and_where_eq("v2_job.trigger_kind", "?".bind(tk));
     }
 
     sqlb
@@ -7639,6 +7645,10 @@ pub fn filter_list_completed_query(
         sqlb.and_where("trigger_kind IS DISTINCT FROM 'schedule'");
     }
 
+    if let Some(tk) = &lq.trigger_kind {
+        sqlb.and_where_eq("v2_job.trigger_kind", "?".bind(tk));
+    }
+
     sqlb
 }
 
@@ -7715,6 +7725,7 @@ pub struct ListCompletedQuery {
     pub concurrency_key: Option<String>,
     pub worker: Option<String>,
     pub allow_wildcards: Option<bool>,
+    pub trigger_kind: Option<String>,
 }
 
 async fn list_completed_jobs(

--- a/frontend/src/lib/components/HistoricInputs.svelte
+++ b/frontend/src/lib/components/HistoricInputs.svelte
@@ -110,6 +110,7 @@
 		folder={null}
 		concurrencyKey={null}
 		tag={null}
+		triggerKind={null}
 		success="running"
 		argFilter={searchArgs ? JSON.stringify(searchArgs) : undefined}
 		bind:loading

--- a/frontend/src/lib/components/SavedInputs.svelte
+++ b/frontend/src/lib/components/SavedInputs.svelte
@@ -161,6 +161,7 @@
 		folder={null}
 		concurrencyKey={null}
 		tag={null}
+		triggerKind={null}
 		success="running"
 		argFilter={undefined}
 		bind:loading

--- a/frontend/src/lib/components/runs/JobsLoader.svelte
+++ b/frontend/src/lib/components/runs/JobsLoader.svelte
@@ -39,6 +39,7 @@
 		externalJobs?: Job[] | undefined
 		concurrencyKey: string | null
 		tag: string | null
+		triggerKind: string | null
 		showSkipped?: boolean
 		extendedJobs?: ExtendedJobs | undefined
 		argError?: string
@@ -78,6 +79,7 @@
 		externalJobs = $bindable(undefined),
 		concurrencyKey,
 		tag,
+		triggerKind,
 		extendedJobs = $bindable(undefined),
 		argError = '',
 		resultError = '',
@@ -217,7 +219,8 @@
 						: undefined,
 				allWorkspaces: allWorkspaces ? true : undefined,
 				perPage,
-				allowWildcards: allowWildcards ? true : undefined
+				allowWildcards: allowWildcards ? true : undefined,
+				triggerKind: triggerKind === null || triggerKind === '' ? undefined : triggerKind
 			})
 		} catch (e) {
 			sendUserToast('There was an issue loading jobs, see browser console for more details', true)
@@ -267,7 +270,8 @@
 						: undefined,
 				allWorkspaces: allWorkspaces ? true : undefined,
 				perPage,
-				allowWildcards
+				allowWildcards,
+				triggerKind: triggerKind === null || triggerKind === '' ? undefined : triggerKind
 			})
 		} catch (e) {
 			sendUserToast('There was an issue loading jobs, see browser console for more details', true)
@@ -548,6 +552,7 @@
 			jobKinds,
 			concurrencyKey,
 			tag,
+			triggerKind,
 			lookback,
 			user,
 			folder,

--- a/frontend/src/lib/components/runs/RunsFilter.svelte
+++ b/frontend/src/lib/components/runs/RunsFilter.svelte
@@ -26,6 +26,7 @@
 		concurrencyKey?: string | null
 		worker?: string | null
 		tag?: string | null
+		triggerKind?: string | null
 		success?: 'running' | 'waiting' | 'suspended' | 'queued' | 'success' | 'failure' | undefined
 		showSkipped?: boolean | undefined
 		argFilter: string
@@ -52,6 +53,7 @@
 			| 'worker'
 			| 'tag'
 			| 'schedulePath'
+			| 'triggerKind'
 		small?: boolean
 		calendarSmall?: boolean
 	}
@@ -62,6 +64,7 @@
 		concurrencyKey = $bindable(null),
 		worker = $bindable(null),
 		tag = $bindable(null),
+		triggerKind = $bindable(null),
 		success = $bindable(undefined),
 		showSkipped = $bindable(undefined),
 		argFilter = $bindable(),
@@ -103,6 +106,8 @@
 			filterBy = 'tag'
 		} else if (schedulePath !== undefined && schedulePath !== '' && filterBy !== 'schedulePath') {
 			filterBy = 'schedulePath'
+		} else if (triggerKind !== null && triggerKind !== '' && filterBy !== 'triggerKind') {
+			filterBy = 'triggerKind'
 		} else if (worker !== null && worker !== '' && filterBy !== 'worker') {
 			filterBy = 'worker'
 		}
@@ -120,7 +125,7 @@
 	let displayedSchedule = $derived(schedulePath)
 	let displayedWorker = $derived(worker)
 	$effect(() => {
-		;(path || user || folder || label || worker || concurrencyKey || tag || schedulePath) &&
+		;(path || user || folder || label || worker || concurrencyKey || tag || triggerKind || schedulePath) &&
 			untrack(() => autosetFilter())
 	})
 
@@ -131,6 +136,7 @@
 		label = null
 		concurrencyKey = null
 		tag = null
+		triggerKind = null
 		schedulePath = undefined
 		worker = null
 	}
@@ -204,6 +210,7 @@
 							{ label: 'Concurrency key', value: 'concurrencyKey' },
 							{ label: 'Label', value: 'label' },
 							{ label: 'Tag', value: 'tag' },
+							{ label: 'Trigger', value: 'triggerKind' },
 							{ label: 'Worker', value: 'worker' }
 						]}
 						{item}
@@ -431,6 +438,31 @@
 							bind:value={displayedSchedule}
 						/>
 					</div>
+				{/key}
+			</RunOption>
+		{:else if filterBy === 'triggerKind'}
+			<RunOption label="Trigger Kind" for="triggerKind">
+				{#key triggerKind}
+					<Select
+						items={safeSelectItems([
+							'webhook',
+							'http',
+							'websocket',
+							'kafka',
+							'email',
+							'nats',
+							'schedule',
+							'app',
+							'ui',
+							'postgres',
+							'sqs',
+							'gcp'
+						])}
+						bind:value={() => triggerKind ?? undefined, (v) => (triggerKind = v ?? null)}
+						clearable
+						onClear={() => ((triggerKind = null), dispatch('reset'))}
+						id="triggerKind"
+					/>
 				{/key}
 			</RunOption>
 		{:else if filterBy === 'worker'}

--- a/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/runs/[...path]/+page.svelte
@@ -67,6 +67,7 @@
 	let allowWildcards: boolean = $state(page.url.searchParams.get('allow_wildcards') == 'true')
 	let concurrencyKey: string | null = $state(page.url.searchParams.get('concurrency_key'))
 	let tag: string | null = $state(page.url.searchParams.get('tag'))
+	let triggerKind: string | null = $state(page.url.searchParams.get('trigger_kind'))
 
 	// Rest of filters handled by RunsFilter
 	let success: 'running' | 'suspended' | 'waiting' | 'success' | 'failure' | undefined = $state(
@@ -123,6 +124,7 @@
 		label = page.url.searchParams.get('label')
 		concurrencyKey = page.url.searchParams.get('concurrency_key')
 		tag = page.url.searchParams.get('tag')
+		triggerKind = page.url.searchParams.get('trigger_kind')
 		worker = page.url.searchParams.get('worker')
 		allowWildcards = page.url.searchParams.get('allow_wildcards') == 'true'
 		// Rest of filters handled by RunsFilter
@@ -324,6 +326,12 @@
 			searchParams.delete('allow_wildcards')
 		}
 
+		if (triggerKind) {
+			searchParams.set('trigger_kind', triggerKind)
+		} else {
+			searchParams.delete('trigger_kind')
+		}
+
 		if (graph != 'RunChart') {
 			searchParams.set('graph', graph)
 		} else {
@@ -471,6 +479,18 @@
 		schedulePath = undefined
 		worker = e.detail
 		allowWildcards = false
+	}
+
+	function filterByTriggerKind(e: CustomEvent<string>) {
+		path = null
+		user = null
+		folder = null
+		label = null
+		concurrencyKey = null
+		tag = null
+		schedulePath = undefined
+		worker = null
+		triggerKind = e.detail
 	}
 
 	let calendarChangeTimeout: number | undefined = $state(undefined)
@@ -744,6 +764,7 @@
 			jobKindsCat,
 			concurrencyKey,
 			tag,
+			triggerKind,
 			graph,
 			maxTs,
 			minTs,
@@ -836,6 +857,7 @@
 	bind:externalJobs
 	bind:extendedJobs
 	{concurrencyKey}
+	{triggerKind}
 	{argError}
 	{resultError}
 	{tag}
@@ -1031,6 +1053,7 @@
 						bind:label
 						bind:concurrencyKey
 						bind:tag
+						bind:triggerKind
 						bind:worker
 						bind:path
 						bind:success
@@ -1284,6 +1307,7 @@
 									on:filterByConcurrencyKey={filterByConcurrencyKey}
 									on:filterByTag={filterByTag}
 									on:filterBySchedule={filterBySchedule}
+									on:filterByTriggerKind={filterByTriggerKind}
 									on:filterByWorker={filterByWorker}
 									bind:this={runsTable}
 								></RunsTable>


### PR DESCRIPTION
Implements #7112

Adds a trigger_kind filter to the runs page and list UI, allowing users to filter jobs by how they were triggered (webhook, http, websocket, kafka, email, nats, schedule, app, ui, postgres, sqs, gcp).

**Changes:**
- Backend: Added trigger_kind query parameter to jobs API endpoints
- Frontend: Added "Trigger" filter option in RunsFilter component with dropdown for all trigger types
- Updated OpenAPI spec and regenerated TypeScript client

🤖 Generated with [Claude Code](https://claude.ai/code)) | [Branch](https://github.com/windmill-labs/windmill/tree/claude/issue-7112-20251111-1943) | [View job run](https://github.com/windmill-labs/windmill/actions/runs/19276595816