### PR TITLE
feat(cli): allow configuring esbuild banner

### DIFF
--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -246,6 +246,7 @@ export async function handleFile(
           platform: "node",
           packages: "bundle",
           target: format == "cjs" ? "node20.15.1" : "esnext",
+          ...(codebase.banner != null && { banner: codebase.banner }),
         });
         const endTime = performance.now();
         bundleContent = out.outputFiles[0].text;

--- a/cli/src/core/conf.ts
+++ b/cli/src/core/conf.ts
@@ -101,6 +101,7 @@ export interface Codebase {
   inject?: string[];
   loader?: any,
   format?: "cjs" | "esm";
+  banner?: string | { js?: string };
 }
 
 function getGitRepoRoot(): string | null {


### PR DESCRIPTION
This patch introduces a new property to the `codebases` configuration in `wmill.yaml`: `banner`. It is an [ESBuild configuration option](https://esbuild.github.io/api/#banner) intended for inserting arbitrary strings at the beginning of generated JavaScript files.

While most commonly used for inserting comments, it is also often used as a workaround for known ESM bundle-related issues (bundling `@redis/client` being a notable [example](https://github.com/redis/node-redis/issues/2672) due to its usage of dynamic require statements which are not supported in ESM).

An example usage of this property would be:

```yaml
# ...
codebases:
  - relative_path: ../shared
    format: esm
    includes:
      - "**"
    excludes: []
    banner:
      js: >-
        const require = (await import('node:module')).createRequire(import.meta.url);
```