### PR TITLE
fix: support variable parsing in arrays for job arguments

### DIFF
--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -301,6 +301,13 @@ pub async fn transform_json_value(
             }
             Ok(Value::Object(m))
         }
+        Value::Array(arr) => {
+            let mut result = Vec::with_capacity(arr.len());
+            for item in arr {
+                result.push(transform_json_value(name, client, workspace, item, job, conn).await?);
+            }
+            Ok(Value::Array(result))
+        }
         a @ _ => Ok(a),
     }
 }


### PR DESCRIPTION
  Previously, variables like `$var:f/path/to/variable` were not being
  resolved when they appeared inside arrays in job arguments. This was
  because the `transform_json_value` function in `common.rs` only
  handled recursive transformation for `Value::Object`, but was missing
  the case for `Value::Array`.

  This commit adds support for recursively transforming array elements,
  allowing variables to be properly resolved when used within arrays.

  Example:
  - Before: `["$var:f/Narration/jina_api_key"]` would remain as literal string
  - After: `["jina_this_is_real_jian_key_value"]` (variable is properly resolved)

  Note: String concatenation with variables (e.g., "Bearer: $var:...")
  is still not supported as it requires a more complex implementation
  with regex-based pattern matching and substitution.

  Fixes issue #7253 where variables in array parameters were not being parsed.