### PR TITLE
fix: Support String Interpolation for Variables and Resources

### DIFF
--- a/backend/windmill-api/src/resources.rs
+++ b/backend/windmill-api/src/resources.rs
@@ -656,8 +656,22 @@ pub async fn transform_json_value<'c>(
                 if let Some(Some(v)) = v {
                     let value_str = if v.is_string() {
                         v.as_str().unwrap().to_string()
-                    } else {
+                    } else if v.is_number() {
                         v.to_string()
+                    } else if v.is_boolean() {
+                        v.to_string()
+                    } else if v.is_null() {
+                        String::new()
+                    } else {
+                        // Object or Array - not suitable for string interpolation
+                        return Err(Error::BadRequest(format!(
+                            "Cannot interpolate resource '$res:{path}' into string. \
+                            The resource contains an object or array with multiple fields. \
+                            \nTo fix this:\n\
+                            1. Use the resource as a separate parameter (e.g., set the whole parameter to '$res:{path}'), OR\n\
+                            2. Create a simpler variable/resource with just the single value you need, OR\n\
+                            3. Extract the field in your script code after receiving the full resource object."
+                        )));
                     };
                     result = result.replace(full_match, &value_str);
                 } else {

--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -326,8 +326,22 @@ pub async fn transform_json_value(
                     Ok(value) => {
                         let value_str = if value.is_string() {
                             value.as_str().unwrap().to_string()
-                        } else {
+                        } else if value.is_number() {
                             value.to_string()
+                        } else if value.is_boolean() {
+                            value.to_string()
+                        } else if value.is_null() {
+                            String::new()
+                        } else {
+                            // Object or Array - not suitable for string interpolation
+                            return Err(Error::BadRequest(format!(
+                                "Cannot interpolate resource '$res:{path}' into string for argument `{name}`. \
+                                The resource contains an object or array with multiple fields. \
+                                \nTo fix this:\n\
+                                1. Use the resource as a separate parameter (e.g., set the whole parameter to '$res:{path}'), OR\n\
+                                2. Create a simpler variable/resource with just the single value you need, OR\n\
+                                3. Extract the field in your script code after receiving the full resource object."
+                            )));
                         };
                         result = result.replace(full_match, &value_str);
                     }


### PR DESCRIPTION
# Support String Interpolation for Variables and Resources

## Summary

This PR adds support for string interpolation of `$var:`, `$res:`, and `$encrypted:` references within string values. Previously, these references were only replaced when they appeared as the entire value. Now they can be embedded within strings, enabling use cases like `"Bearer $var:api_token"` or `"https://api.example.com?key=$var:api_key"`.

## Problem Statement

When using generated UI forms or HTTP request nodes, users often need to compose strings that include variable values. For example:

```javascript
// Input in generated UI:
var1: "$var:f/Narration/jina_api_key"
api_key: "Bearer $var:f/Narration/jina_api_key"
```

Previously, the behavior was:
- ✅ `var1` → Replaced with actual value: `"jina_4797cd5bb8f54314"`
- ❌ `api_key` → **NOT replaced**, remained as literal string: `"Bearer $var:f/Narration/jina_api_key"`

This limitation forced users to handle string concatenation in their scripts, which is problematic for generic HTTP request nodes where the code doesn't know which parameters need concatenation.

## Solution

This PR implements string interpolation for variable/resource/encrypted references:

### Before (Exact Match Only)
```rust
Value::String(y) if y.starts_with("$var:") => {
    // Only replaces if entire string is "$var:path"
}
```

### After (String Interpolation)
```rust
Value::String(y) if y.starts_with("$var:") && !y.contains(' ') => {
    // Exact match: entire string is a variable reference
    // Returns the variable value (could be any JSON type)
}
Value::String(y) if (*RE_RES_VAR).is_match(&y) => {
    // String interpolation: scan and replace all occurrences
    // Always returns a string with substitutions made
}
```

### Interpolation Pattern

The regex pattern `\$var:([^\s"'\},\)\]&;]+)` extracts variable paths, stopping at common delimiters:
- Whitespace, quotes (`"`, `'`)
- JSON/array terminators (`}`, `,`, `)`, `]`)
- URL/query separators (`&`, `;`)

This ensures proper extraction in contexts like:
- JSON values: `{"Authorization": "$var:token"}`
- URL parameters: `?key=$var:api_key&other=value`
- Arrays: `["$var:item1", "$var:item2"]`
- Function calls: `func($var:arg)`

## Changes

### Backend Worker (`windmill-worker/src/common.rs`)

1. **Added regex patterns** for extracting variable/resource/encrypted references:
```rust
static ref RE_VAR_PATTERN: Regex = Regex::new(r#"\$var:([^\s"'\},\)\]&;]+)"#).unwrap();
static ref RE_RES_PATTERN: Regex = Regex::new(r#"\$res:([^\s"'\},\)\]&;]+)"#).unwrap();
static ref RE_ENCRYPTED_PATTERN: Regex = Regex::new(r#"\$encrypted:([^\s"'\},\)\]&;]+)"#).unwrap();
```

2. **Modified `transform_json_value()`** to handle both exact matches and string interpolation:
   - Exact match (e.g., `"$var:path"`) → Returns variable value as-is (preserves type)
   - String interpolation (e.g., `"Bearer $var:token"`) → Scans string, replaces all matches, returns string

### API Layer (`windmill-api/src/resources.rs`)

Applied the same changes to the API layer's `transform_json_value()` function to ensure consistency across all variable resolution paths.

## Behavior

### Exact Match (Unchanged)
```javascript
// Input: "$var:f/config/timeout"
// Variable value: 30 (number)
// Output: 30 (preserves type)
```

### String Interpolation (New)
```javascript
// Input: "Bearer $var:f/auth/api_token"
// Variable value: "sk-abc123"
// Output: "Bearer sk-abc123" (string)
```

### Multiple Substitutions (New)
```javascript
// Input: "$var:greeting $var:name"
// Variables: greeting="Hello", name="World"
// Output: "Hello World"
```

### Mixed Types (New)
```javascript
// Input: "https://api.example.com?key=$var:api_key&user=$res:f/config/user_id"
// Output: "https://api.example.com?key=abc123&user=42"
```

## Error Handling

- If a referenced variable/resource doesn't exist, the job fails with a clear error message:
  ```
  Variable f/auth/api_token not found in string interpolation for `Authorization`: ...
  ```
- Path validation is maintained (e.g., resources must have at least 2 path segments)

## Testing

Tested with various scenarios:
- ✅ Single variable in string
- ✅ Multiple variables in same string
- ✅ Mixed `$var:` and `$res:` references
- ✅ JSON contexts with quotes, brackets, braces
- ✅ URL query parameters with `&` separators
- ✅ Array/function contexts
- ✅ Whitespace and special character boundaries
- ✅ Non-existent variable error handling

## Backward Compatibility

✅ **Fully backward compatible**

- Exact match behavior unchanged: `"$var:path"` still returns the variable value with original type
- Existing scripts and workflows continue to work without modification
- Only adds new functionality for strings containing embedded references

## Frontend Changes

❌ **No frontend changes required**

All variable substitution happens on the backend. Frontend components that display or edit `$var:` references remain unchanged.

## Related Issues
#7253 
Fixes the issue where users couldn't use variable references within composed strings, particularly problematic for:
- Generic HTTP request nodes
- Authorization headers
- API URL construction
- Configuration templates
