### PR TITLE
add component inspector

### DIFF
--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -30,6 +30,10 @@ const config = {
 		alias: {
 			'$system_prompts': '../system_prompts/auto-generated'
 		}
+	},
+
+	vitePlugin: {
+		inspector: true
 	}
 }
 


### PR DESCRIPTION
This saves a ton of time identifying Svelte components from the browser.

Just Alt-X in the browser and hover over anything, the corresponding component path is displayed in a tooltip. 