### PR TITLE
fix(agent): ignore Enter event when event.isComposing is true

### DIFF
--- a/frontend/src/lib/components/flows/conversations/FlowChatManager.svelte.ts
+++ b/frontend/src/lib/components/flows/conversations/FlowChatManager.svelte.ts
@@ -595,7 +595,7 @@ export class FlowChatManager {
 	}
 
 	handleKeyDown = (event: KeyboardEvent) => {
-		if (event.key === 'Enter' && !event.shiftKey) {
+		if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
 			event.preventDefault()
 			this.sendMessage()
 		}


### PR DESCRIPTION
This PR prevents the AI chat input from sending a message when the user presses Enter while an IME is still composing text, which is very comoon for CJK users. 
