### PR TITLE
fix: Enable Required toggle and default values for nested object properties

### DIFF
--- a/frontend/src/lib/components/schema/EditableSchemaDrawer.svelte
+++ b/frontend/src/lib/components/schema/EditableSchemaDrawer.svelte
@@ -53,12 +53,16 @@
 		jsonView?: boolean
 		hiddenArgs?: string[]
 		onClose?: () => void
+		isFlowInput?: boolean
+		isAppInput?: boolean
 	}
 
 	let {
 		schema = $bindable(),
 		jsonView = $bindable(false),
-		hiddenArgs = undefined
+		hiddenArgs = undefined,
+		isFlowInput = false,
+		isAppInput = false
 	}: Props = $props()
 
 	// let schema = $state(structuredClone($state.snapshot(schema)))
@@ -172,7 +176,11 @@
 							{#if schema.properties[item.value]?.type === 'object' && !(schema.properties[item.value].oneOf && schema.properties[item.value].oneOf.length >= 2)}
 								<div class="flex flex-col w-full mt-2">
 									<Label label="Nested properties">
-										<EditableSchemaDrawer bind:schema={schema.properties[item.value]} />
+										<EditableSchemaDrawer
+											bind:schema={schema.properties[item.value]}
+											{isFlowInput}
+											{isAppInput}
+										/>
 									</Label>
 								</div>
 							{/if}
@@ -191,7 +199,8 @@
 					schemaFormClassName="min-h-full"
 					bind:this={editableSchemaForm}
 					bind:schema
-					isAppInput
+					{isFlowInput}
+					{isAppInput}
 					on:edit={(e) => {
 						addPropertyComponent?.openDrawer(e.detail)
 					}}

--- a/frontend/src/lib/components/schema/FlowPropertyEditor.svelte
+++ b/frontend/src/lib/components/schema/FlowPropertyEditor.svelte
@@ -274,6 +274,8 @@
 								? 'kind'
 								: 'label'
 						]}
+						isFlowInput={true}
+						isAppInput={true}
 					/>
 				</div>
 			{/if}
@@ -324,6 +326,8 @@
 								requiredProperty = v.required
 							}
 						}
+						isFlowInput={true}
+						isAppInput={true}
 					/>
 				{:else if customObjectSelected === 'json-schema-resource'}
 					{#if format == undefined}

--- a/frontend/src/lib/components/schema/PropertyEditor.svelte
+++ b/frontend/src/lib/components/schema/PropertyEditor.svelte
@@ -272,6 +272,8 @@
 						uiOnly
 						jsonEnabled={false}
 						editTab="inputEditor"
+						{isFlowInput}
+						{isAppInput}
 					/>
 				</div>
 			{/if}
@@ -284,6 +286,8 @@
 					uiOnly
 					jsonEnabled={false}
 					editTab="inputEditor"
+					{isFlowInput}
+					{isAppInput}
 				/>
 			</div>
 		{/if}


### PR DESCRIPTION
Fixes #7476

This change enables the Required toggle and default value editor for nested object properties in script parameters. The issue was that EditableSchemaDrawer component lacked the isFlowInput and isAppInput props, which prevented FlowPropertyEditor from being rendered for nested properties.

The fix propagates these flags through EditableSchemaDrawer, PropertyEditor, and FlowPropertyEditor components. This ensures that when users edit nested object properties in the advanced UI settings, they can now set fields as required, configure default values, and use the nullable option to prevent auto-population of empty strings or arrays.

The changes are minimal and focused on prop propagation, maintaining backward compatibility while enabling full editing capabilities for nested properties.