### PR TITLE
fix: use WM_BASE_URL for hub sync authentication

### DIFF
--- a/backend/migrations/20240907150910_migrate_to_new_cli.up.sql
+++ b/backend/migrations/20240907150910_migrate_to_new_cli.up.sql
@@ -3,7 +3,7 @@
 UPDATE script SET content = 'import * as wmill from "windmill-cli@1.393.2"
 
 export async function main(x: string) {
-  await wmill.hubPull({ workspace: "admins", token: process.env["WM_TOKEN"], baseUrl: process.env["BASE_URL"] })
+  await wmill.hubPull({ workspace: "admins", token: process.env["WM_TOKEN"], baseUrl: process.env["WM_BASE_URL"] })
   return x
 }
 ', language = 'bun',

--- a/backend/migrations/20240908214334_migrate_to_new_cli_2.up.sql
+++ b/backend/migrations/20240908214334_migrate_to_new_cli_2.up.sql
@@ -4,7 +4,7 @@
 UPDATE script SET content = 'import * as wmill from "windmill-cli@1.393.2"
 
 export async function main() {
-  await wmill.hubPull({ workspace: "admins", token: process.env["WM_TOKEN"], baseUrl: process.env["BASE_URL"] });
+  await wmill.hubPull({ workspace: "admins", token: process.env["WM_TOKEN"], baseUrl: process.env["WM_BASE_URL"] });
 }
 ', language = 'bun',
 lock = '{

--- a/backend/migrations/20240908222917_migrate_to_new_cli_3.up.sql
+++ b/backend/migrations/20240908222917_migrate_to_new_cli_3.up.sql
@@ -2,7 +2,7 @@
 UPDATE script SET content = 'import * as wmill from "windmill-cli@1.393.2"
 
 export async function main() {
-  await wmill.hubPull({ workspace: "admins", token: process.env["WM_TOKEN"], baseUrl: globalThis.process.env["BASE_URL"] });
+  await wmill.hubPull({ workspace: "admins", token: process.env["WM_TOKEN"], baseUrl: globalThis.process.env["WM_BASE_URL"] });
 }
 ', language = 'bun',
 lock = '{

--- a/backend/migrations/20250407124204_update_hub_sync_script.up.sql
+++ b/backend/migrations/20250407124204_update_hub_sync_script.up.sql
@@ -3,7 +3,7 @@
 UPDATE script SET content = 'import * as wmill from "windmill-cli@1.481.0"
 
 export async function main() {
-  await wmill.hubPull({ workspace: "admins", token: process.env["WM_TOKEN"], baseUrl: globalThis.process.env["BASE_URL"] });
+  await wmill.hubPull({ workspace: "admins", token: process.env["WM_TOKEN"], baseUrl: globalThis.process.env["WM_BASE_URL"] });
 }
 ', language = 'bun',
 lock = '{

--- a/backend/migrations/20251027091803_update_hub_sync_script.up.sql
+++ b/backend/migrations/20251027091803_update_hub_sync_script.up.sql
@@ -2,7 +2,7 @@
 UPDATE script SET content = 'import * as wmill from "windmill-cli@1.566.1"
 
 export async function main() {
-  await wmill.hubPull({ workspace: "admins", token: process.env["WM_TOKEN"], baseUrl: process.env["BASE_URL"] });
+  await wmill.hubPull({ workspace: "admins", token: process.env["WM_TOKEN"], baseUrl: process.env["WM_BASE_URL"] });
 }
 ', language = 'bun',
 lock = '{


### PR DESCRIPTION
Fixes #7475

Hub sync scripts were using BASE_URL (which contains the internal localhost URL) instead of WM_BASE_URL (which contains the public instance URL), causing authentication failures in self-hosted deployments.

Changed 5 migration files to use WM_BASE_URL for hub sync operations.