### PR TITLE
feat: add HIDE_WORKERS_FOR_NON_ADMINS env var and workspace-scoped custom_tags endpoint

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -5920,11 +5920,6 @@ paths:
       tags:
         - worker
       parameters:
-        - name: workspace
-          in: query
-          schema:
-            type: string
-          required: false
         - name: show_workspace_restriction
           in: query
           schema:
@@ -5933,6 +5928,24 @@ paths:
       responses:
         "200":
           description: list of custom tags
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+
+  /w/{workspace}/workers/custom_tags:
+    get:
+      summary: get custom tags available for this workspace
+      operationId: getCustomTagsForWorkspace
+      tags:
+        - worker
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+      responses:
+        "200":
+          description: list of custom tags for workspace
           content:
             application/json:
               schema:

--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -508,6 +508,7 @@ pub async fn run_server(
                             users::workspaced_service().layer(Extension(argon2.clone())),
                         )
                         .nest("/variables", variables::workspaced_service())
+                        .nest("/workers", workers::workspaced_service())
                         .nest("/workspaces", workspaces::workspaced_service())
                         .nest("/oidc", oidc_oss::workspaced_service())
                         .nest("/openapi", {

--- a/backend/windmill-common/src/jobs.rs
+++ b/backend/windmill-common/src/jobs.rs
@@ -825,6 +825,9 @@ lazy_static::lazy_static! {
     pub static ref TAGS_ARE_SENSITIVE: bool = std::env::var("TAGS_ARE_SENSITIVE").map(
         |v| v.parse().unwrap()
     ).unwrap_or(false);
+    pub static ref HIDE_WORKERS_FOR_NON_ADMINS: bool = std::env::var("HIDE_WORKERS_FOR_NON_ADMINS").map(
+        |v| v.parse().unwrap()
+    ).unwrap_or(false);
 }
 
 pub async fn check_tag_available_for_workspace_internal(

--- a/frontend/src/lib/components/RunFormAdvancedPopup.svelte
+++ b/frontend/src/lib/components/RunFormAdvancedPopup.svelte
@@ -30,7 +30,7 @@
 
 	async function loadWorkerGroups() {
 		if (!$workerTags) {
-			$workerTags = await WorkerService.getCustomTags({ workspace: $workspaceStore })
+			$workerTags = await WorkerService.getCustomTagsForWorkspace({ workspace: $workspaceStore! })
 		}
 	}
 </script>

--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -967,7 +967,7 @@
 	loadWorkerTags()
 	async function loadWorkerTags() {
 		if (!$workerTags) {
-			$workerTags = await WorkerService.getCustomTags({ workspace: $workspaceStore })
+			$workerTags = await WorkerService.getCustomTagsForWorkspace({ workspace: $workspaceStore! })
 		}
 	}
 </script>

--- a/frontend/src/lib/components/WorkerTagPicker.svelte
+++ b/frontend/src/lib/components/WorkerTagPicker.svelte
@@ -23,7 +23,7 @@
 	loadWorkerTags()
 	async function loadWorkerTags(force = false) {
 		if (!$workerTags || force) {
-			$workerTags = await WorkerService.getCustomTags({ workspace: $workspaceStore })
+			$workerTags = await WorkerService.getCustomTagsForWorkspace({ workspace: $workspaceStore! })
 		}
 	}
 </script>

--- a/frontend/src/lib/components/WorkerTagSelect.svelte
+++ b/frontend/src/lib/components/WorkerTagSelect.svelte
@@ -52,7 +52,7 @@
 		loading = true
 		try {
 			if (!$workerTags || force) {
-				$workerTags = await WorkerService.getCustomTags({ workspace: $workspaceStore })
+				$workerTags = await WorkerService.getCustomTagsForWorkspace({ workspace: $workspaceStore! })
 			}
 		} catch (e) {
 			$workerTags = []

--- a/frontend/src/lib/components/flows/content/FlowModuleWorkerTagSelect.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleWorkerTagSelect.svelte
@@ -26,7 +26,7 @@
 
 	async function loadWorkerGroups() {
 		if (!$workerTags) {
-			$workerTags = await WorkerService.getCustomTags({ workspace: $workspaceStore })
+			$workerTags = await WorkerService.getCustomTagsForWorkspace({ workspace: $workspaceStore! })
 		}
 	}
 </script>


### PR DESCRIPTION
## Summary
- Add `HIDE_WORKERS_FOR_NON_ADMINS` environment variable to hide the workers list from non-superadmins
- Change custom_tags endpoint to use path parameter for workspace (`/w/{workspace}/workers/custom_tags`) instead of query parameter
- This ensures users can only query custom tags for workspaces they are members of (authentication-based access control)
- Remove `workspace` query parameter from global `/workers/custom_tags` endpoint

## Test plan
- [ ] Set `HIDE_WORKERS_FOR_NON_ADMINS=true` and verify non-superadmin users see an empty workers list
- [ ] Verify superadmins can still see the workers list with the env var set
- [ ] Test that `/w/{workspace}/workers/custom_tags` returns tags for valid workspace members
- [ ] Verify that users cannot access custom tags for workspaces they are not members of
- [ ] Confirm frontend components still work correctly with the new API

🤖 Generated with [Claude Code](https://claude.com/claude-code)