### PR TITLE
fix(cli): skip branch-specific files when type is not configured

### DIFF
--- a/cli/src/core/specific_items.ts
+++ b/cli/src/core/specific_items.ts
@@ -136,6 +136,43 @@ function matchesPatterns(path: string, patterns: string[]): boolean {
 }
 
 /**
+ * Check if the item type for a given path is configured in specificItems.
+ * This checks if the TYPE is configured, not whether it matches the pattern.
+ * Used to determine if branch-specific files should be used for this type.
+ */
+export function isItemTypeConfigured(path: string, specificItems: SpecificItemsConfig | undefined): boolean {
+  if (!specificItems) {
+    return false;
+  }
+
+  if (path.endsWith('.variable.yaml')) {
+    return specificItems.variables !== undefined;
+  }
+
+  if (path.endsWith('.resource.yaml')) {
+    return specificItems.resources !== undefined;
+  }
+
+  if (isTriggerFile(path)) {
+    return specificItems.triggers !== undefined;
+  }
+
+  if (path.endsWith('/folder.meta.yaml')) {
+    return specificItems.folders !== undefined;
+  }
+
+  if (path === 'settings.yaml') {
+    return specificItems.settings !== undefined;
+  }
+
+  if (isFileResource(path)) {
+    return specificItems.resources !== undefined;
+  }
+
+  return false;
+}
+
+/**
  * Check if a file path should be treated as branch-specific
  */
 export function isSpecificItem(path: string, specificItems: SpecificItemsConfig | undefined): boolean {


### PR DESCRIPTION
When a type (folders, settings, variables, resources, triggers) is NOT configured in specificItems, branch-specific files of that type should be ignored and only base files used.

Added isItemTypeConfigured() function to distinguish between:
- Type not configured → skip branch-specific file, use base file
- Type configured but doesn't match pattern → skip branch-specific file
- Type configured and matches → use branch-specific file

Added comprehensive tests to prevent regression.