### PR TITLE
fix(cli): make `wmill app lint` and `wmill app generate-agents` respect nonDottedPaths setting

### DIFF
--- a/cli/src/commands/app/generate_agents.ts
+++ b/cli/src/commands/app/generate_agents.ts
@@ -7,6 +7,11 @@ import { DataTableSchema } from "../../../gen/types.gen.ts";
 import { generateAgentsDocumentation } from "../sync/sync.ts";
 import path from "node:path";
 import * as fs from "node:fs";
+import {
+  getFolderSuffix,
+  hasFolderSuffix,
+  loadNonDottedPathsSetting,
+} from "../../utils/resource_folders.ts";
 
 interface GenerateAgentsOptions extends GlobalOptions {
   output?: string;
@@ -230,14 +235,17 @@ async function generateAgents(
       : path.join(cwd, appFolder);
   }
 
-  // Ensure we're in a .raw_app folder or targeting one
+  // Load nonDottedPaths setting before using folder suffix functions
+  await loadNonDottedPathsSetting();
+
+  // Ensure we're in a raw_app folder or targeting one
   const dirName = path.basename(targetDir);
-  if (!dirName.endsWith(".raw_app")) {
-    // Check if current directory is a .raw_app folder
-    if (!path.basename(cwd).endsWith(".raw_app") && !appFolder) {
+  if (!hasFolderSuffix(dirName, "raw_app")) {
+    // Check if current directory is a raw_app folder
+    if (!hasFolderSuffix(path.basename(cwd), "raw_app") && !appFolder) {
       log.error(
         colors.red(
-          "Error: Must be run inside a .raw_app folder or specify one as argument."
+          `Error: Must be run inside a ${getFolderSuffix("raw_app")} folder or specify one as argument.`
         )
       );
       log.info(colors.gray("Usage: wmill app generate-agents [app_folder]"));

--- a/cli/src/commands/app/lint.ts
+++ b/cli/src/commands/app/lint.ts
@@ -10,6 +10,7 @@ import { loadRunnablesFromBackend } from "./raw_apps.ts";
 import {
   getFolderSuffix,
   hasFolderSuffix,
+  loadNonDottedPathsSetting,
 } from "../../utils/resource_folders.ts";
 
 interface LintOptions extends GlobalOptions {
@@ -200,6 +201,9 @@ async function lintRawApp(
  * Main lint command
  */
 async function lint(opts: LintOptions, appFolder?: string) {
+  // Load nonDottedPaths setting before using folder suffix functions
+  await loadNonDottedPathsSetting();
+
   const targetDir = appFolder ?? process.cwd();
 
   log.info(colors.bold.blue(`\n🔍 Linting raw app: ${targetDir}\n`));


### PR DESCRIPTION
## Summary
- Fix `wmill app lint` to load `nonDottedPaths` setting before validating folder names
- Fix `wmill app generate-agents` to use `hasFolderSuffix()` and `getFolderSuffix()` utilities instead of hardcoded `.raw_app` checks

These commands were failing when run inside folders with non-dotted names (e.g., `myapp__raw_app` instead of `myapp.raw_app`) because they weren't loading the `nonDottedPaths` setting from `wmill.yaml`.

This is a follow-up to #7700 which fixed the same issue for `wmill app new`.

## Test plan
- [ ] Run `wmill init` (creates `wmill.yaml` with `nonDottedPaths: true`)
- [ ] Run `wmill app new` → creates folder like `myapp__raw_app/`
- [ ] Run `wmill app lint` inside the folder → should work now
- [ ] Run `wmill app generate-agents` inside the folder → should work now

🤖 Generated with [Claude Code](https://claude.com/claude-code)