### PR TITLE
fix: handle empty base_url and region strings in AI providers

### DIFF
--- a/backend/windmill-common/src/ai_providers.rs
+++ b/backend/windmill-common/src/ai_providers.rs
@@ -39,8 +39,8 @@ impl AIProvider {
         region: Option<String>,
         db: &DB,
     ) -> Result<String> {
-        // If a base URL is provided in the resource, use it
-        if let Some(base_url) = resource_base_url {
+        // If a base URL is provided in the resource, use it (ignore empty strings)
+        if let Some(base_url) = resource_base_url.filter(|s| !s.is_empty()) {
             return Ok(base_url);
         }
 
@@ -74,29 +74,25 @@ impl AIProvider {
             AIProvider::TogetherAI => Ok("https://api.together.xyz/v1".to_string()),
             AIProvider::Anthropic => Ok("https://api.anthropic.com/v1".to_string()),
             AIProvider::Mistral => Ok("https://api.mistral.ai/v1".to_string()),
-            p @ (AIProvider::CustomAI | AIProvider::AzureOpenAI) => {
-                if let Some(base_url) = resource_base_url {
-                    Ok(base_url)
-                } else {
-                    Err(Error::BadRequest(format!(
-                        "{:?} provider requires a base URL in the resource",
-                        p
-                    )))
-                }
-            }
+            p @ (AIProvider::CustomAI | AIProvider::AzureOpenAI) => Err(Error::BadRequest(
+                format!("{:?} provider requires a base URL in the resource", p),
+            )),
             AIProvider::AWSBedrock => {
                 #[cfg(feature = "bedrock")]
                 {
                     Ok(format!(
                         "https://bedrock-runtime.{}.amazonaws.com",
-                        region.unwrap_or_else(|| "us-east-1".to_string())
+                        region
+                            .filter(|s| !s.is_empty())
+                            .unwrap_or_else(|| "us-east-1".to_string())
                     ))
                 }
                 #[cfg(not(feature = "bedrock"))]
                 {
                     let _ = region;
                     Err(Error::BadRequest(
-                        "AWS Bedrock support is not enabled. Build with 'bedrock' feature.".to_string()
+                        "AWS Bedrock support is not enabled. Build with 'bedrock' feature."
+                            .to_string(),
                     ))
                 }
             }


### PR DESCRIPTION
## Summary
- Filter out empty strings when checking for custom `base_url` in AI provider resources
- Filter out empty strings when checking for `region` in AWS Bedrock configuration
- Simplify CustomAI/AzureOpenAI error handling (redundant check removed)

## Problem
When creating an Anthropic resource with "standard platform", the resource JSON may contain `"base_url": ""` rather than omitting the field. Serde deserializes this as `Some("")`, which bypassed the fallback logic and caused:
```
Failed to send request: 500 Error: builder error: relative URL without a base @ai.rs:822:20
```

Similarly, AWS Bedrock with an empty region string would produce an invalid URL like `https://bedrock-runtime..amazonaws.com`.

## Test plan
- [ ] Create Anthropic resource with empty `base_url` field, verify AI chat works
- [ ] Create AWS Bedrock resource with empty `region` field, verify default region is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)