### PR TITLE
feat: default to quickjs on ce for flow eval

### DIFF
--- a/backend/windmill-worker/src/js_eval.rs
+++ b/backend/windmill-worker/src/js_eval.rs
@@ -587,7 +587,18 @@ lazy_static! {
 
 #[cfg(feature = "quickjs")]
 #[allow(dead_code)] // Only used when both quickjs and deno_core features are enabled
-static USE_QUICKJS: Lazy<bool> = Lazy::new(|| std::env::var("USE_QUICKJS_FOR_FLOW_EVAL").is_ok());
+static USE_QUICKJS: Lazy<bool> = Lazy::new(|| {
+    // When enterprise is not enabled, default to QuickJS unless USE_DENO_FOR_FLOW_EVAL is set
+    // When enterprise is enabled, default to Deno unless USE_QUICKJS_FOR_FLOW_EVAL is set
+    #[cfg(not(feature = "enterprise"))]
+    {
+        std::env::var("USE_DENO_FOR_FLOW_EVAL").is_err()
+    }
+    #[cfg(feature = "enterprise")]
+    {
+        std::env::var("USE_QUICKJS_FOR_FLOW_EVAL").is_ok()
+    }
+});
 
 #[cfg(any(feature = "deno_core", feature = "quickjs"))]
 pub fn replace_with_await_result(expr: String) -> String {


### PR DESCRIPTION
## Summary
- Makes QuickJS the default JS engine for flow evaluation in Community Edition (non-enterprise) builds
- Enterprise builds continue to use Deno as the default
- Adds `USE_DENO_FOR_FLOW_EVAL` env var to opt back into Deno for CE builds

## Test plan
- [ ] Verify CE builds use QuickJS by default for flow evaluation
- [ ] Verify enterprise builds still use Deno by default
- [ ] Verify `USE_DENO_FOR_FLOW_EVAL=1` switches CE builds back to Deno
- [ ] Verify `USE_QUICKJS_FOR_FLOW_EVAL=1` still works for enterprise builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)