### PR TITLE
fix: fix forking raw apps and summary setting in deploy drawer

### DIFF
--- a/frontend/src/lib/components/copilot/chat/app/core.ts
+++ b/frontend/src/lib/components/copilot/chat/app/core.ts
@@ -696,7 +696,7 @@ export const getAppTools = memo((): Tool<AppAIChatHelpers>[] => [
 			})
 			const lintResult = await helpers.setBackendRunnable(parsedArgs.key, runnable)
 			toolCallbacks.setToolStatus(toolId, {
-				content: `Backend runnable '${parsedArgs.key}' analyzed`,
+				content: `Backend runnable '${parsedArgs.key}' set successfully.`,
 				result: 'Success'
 			})
 			return formatLintResultResponse(

--- a/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
@@ -712,7 +712,7 @@
 			{appPath}
 			{onLatest}
 			{savedApp}
-			{summary}
+			bind:summary
 			bind:customPath
 			bind:deploymentMsg
 			bind:customPathError

--- a/frontend/src/lib/components/raw_apps/RawAppInlineScriptsPanel.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppInlineScriptsPanel.svelte
@@ -7,7 +7,6 @@
 		runnables: Record<string, Runnable>
 		selectedRunnable: string | undefined
 		appPath: string
-		initRunnablesContent: Record<string, string>
 		/** Called when code is selected in the editor */
 		onSelectionChange?: (
 			selection: {

--- a/frontend/src/routes/(root)/(logged)/apps_raw/add/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps_raw/add/+page.svelte
@@ -588,12 +588,12 @@
 		on:savedNewAppPath={(event) => {
 			goto(`/apps_raw/edit/${event.detail}`)
 		}}
-		initFiles={files}
-		initRunnables={runnables}
-		initData={data}
+		bind:files
+		bind:runnables
+		bind:data
 		{policy}
 		path={''}
-		{summary}
+		bind:summary
 		newApp
 	/>
 {/key}

--- a/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
@@ -231,10 +231,10 @@
 					newPath = event.detail
 				}}
 				on:restore={onRestore}
-				initFiles={files}
-				initRunnables={runnables}
-				initData={data}
-				{summary}
+				bind:files
+				bind:runnables
+				bind:data
+				bind:summary
 				{newPath}
 				path={page.params.path ?? ''}
 				{policy}


### PR DESCRIPTION
## Summary
Fix raw app forking and summary binding in the deploy drawer by switching from `init*` one-way props to `$bindable()` two-way props in the RawAppEditor component.

## Changes
- Replace `initFiles`, `initRunnables`, `initData` one-way props with `$bindable()` `files`, `runnables`, `data` props in `RawAppEditor.svelte`
- Remove redundant local state copies that were duplicating prop values
- Remove unused `initRunnablesContent` prop from `RawAppInlineScriptsPanel`
- Bind `summary` in `RawAppEditorHeader` deploy drawer so edits propagate correctly
- Update `add` and `edit` page routes to use `bind:` for files, runnables, data, and summary
- Fix copilot tool status message for backend runnable

## Test plan
- [ ] Fork an existing raw app and verify files, runnables, and data carry over correctly
- [ ] Edit summary in the deploy drawer and verify it persists
- [ ] Create a new raw app and verify all fields work correctly
- [ ] Restore a raw app from history and verify state is correct

---
Generated with [Claude Code](https://claude.com/claude-code)