### PR TITLE
fix: invalid path when creating from hub template

### DIFF
--- a/frontend/src/lib/components/Path.svelte
+++ b/frontend/src/lib/components/Path.svelte
@@ -138,7 +138,7 @@
 	}
 
 	export async function reset() {
-		if (path == '' || path == 'u//' || path?.startsWith('tmp/')) {
+		if (path == '' || path == 'u//' || path?.startsWith('tmp/') || path?.startsWith('hub/')) {
 			if ($lastMetaUsed == undefined || $lastMetaUsed.owner != $userStore?.username) {
 				meta = {
 					ownerKind: hideUser ? 'folder' : 'user',
@@ -323,7 +323,7 @@
 
 	async function initPath() {
 		await tick()
-		if (path != undefined && path != '' && !path?.startsWith('tmp/')) {
+		if (path != undefined && path != '' && !path?.startsWith('tmp/') && !path?.startsWith('hub/')) {
 			meta = pathToMeta(path, hideUser)
 			onMetaChange()
 			return


### PR DESCRIPTION
"create from hub template" (e.g error handler) leads to invalid script path ( e.g u//global... see screenshot) 

<img width="1111" height="696" alt="Screenshot 2026-02-04 at 3 11 52 PM" src="https://github.com/user-attachments/assets/654acd85-0314-4b38-9d92-8399fc969cac" />
