### PR TITLE
fix: make notify_event trigger functions SECURITY DEFINER

### DIFF
--- a/backend/migrations/20260206060555_notify_triggers_security_definer.down.sql
+++ b/backend/migrations/20260206060555_notify_triggers_security_definer.down.sql
@@ -1,0 +1,12 @@
+ALTER FUNCTION notify_config_change() SECURITY INVOKER;
+ALTER FUNCTION notify_global_setting_change() SECURITY INVOKER;
+ALTER FUNCTION notify_global_setting_delete() SECURITY INVOKER;
+ALTER FUNCTION notify_webhook_change() SECURITY INVOKER;
+ALTER FUNCTION notify_workspace_envs_change() SECURITY INVOKER;
+ALTER FUNCTION notify_workspace_premium_change() SECURITY INVOKER;
+ALTER FUNCTION notify_team_plan_status_change() SECURITY INVOKER;
+ALTER FUNCTION notify_runnable_version_change() SECURITY INVOKER;
+ALTER FUNCTION notify_http_trigger_change() SECURITY INVOKER;
+ALTER FUNCTION notify_token_invalidation() SECURITY INVOKER;
+ALTER FUNCTION notify_workspace_key_change() SECURITY INVOKER;
+ALTER FUNCTION notify_workspace_rate_limit_change() SECURITY INVOKER;

--- a/backend/migrations/20260206060555_notify_triggers_security_definer.up.sql
+++ b/backend/migrations/20260206060555_notify_triggers_security_definer.up.sql
@@ -1,0 +1,18 @@
+-- Make all notify_event trigger functions SECURITY DEFINER so that
+-- INSERT INTO notify_event runs as the function owner (typically the
+-- superuser that created the function) rather than the invoking role.
+-- This prevents "permission denied for table notify_event" errors when
+-- windmill_user or windmill_admin fire these triggers.
+
+ALTER FUNCTION notify_config_change() SECURITY DEFINER;
+ALTER FUNCTION notify_global_setting_change() SECURITY DEFINER;
+ALTER FUNCTION notify_global_setting_delete() SECURITY DEFINER;
+ALTER FUNCTION notify_webhook_change() SECURITY DEFINER;
+ALTER FUNCTION notify_workspace_envs_change() SECURITY DEFINER;
+ALTER FUNCTION notify_workspace_premium_change() SECURITY DEFINER;
+ALTER FUNCTION notify_team_plan_status_change() SECURITY DEFINER;
+ALTER FUNCTION notify_runnable_version_change() SECURITY DEFINER;
+ALTER FUNCTION notify_http_trigger_change() SECURITY DEFINER;
+ALTER FUNCTION notify_token_invalidation() SECURITY DEFINER;
+ALTER FUNCTION notify_workspace_key_change() SECURITY DEFINER;
+ALTER FUNCTION notify_workspace_rate_limit_change() SECURITY DEFINER;


### PR DESCRIPTION
## Summary
Prevents "permission denied for table notify_event" errors by making all trigger functions that insert into `notify_event` use `SECURITY DEFINER`, so they run as the function owner rather than the invoking role.

## Changes
- Add migration to `ALTER FUNCTION ... SECURITY DEFINER` on all 12 notify trigger functions
- Include down migration to revert to `SECURITY INVOKER`

## Test plan
- [ ] Verify migration applies cleanly on a fresh database
- [ ] Verify `windmill_user` can update tables with notify triggers (e.g. `config`, `workspace_settings`) without permission errors on `notify_event`
- [ ] Verify down migration reverts functions to `SECURITY INVOKER`

---
Generated with [Claude Code](https://claude.com/claude-code)