### PR TITLE
Added serpapi import handling

### DIFF
--- a/backend/parsers/windmill-parser-py-imports/src/mapping.rs
+++ b/backend/parsers/windmill-parser-py-imports/src/mapping.rs
@@ -381,5 +381,6 @@ pub static SHORT_IMPORTS_MAP: PyMap = phf_map! {
     "docx" => "python-docx",
     "vt" => "vt-py",
     "grpc" => "grpcio",
+    "serpapi" => "google-search-results",
     // Add new entry here ^
 };


### PR DESCRIPTION
I have read the CLA Document and I hereby sign the CLA

Added the handling for serpapi import. The name of the Python library to be installed is google-search-results.

Source: https://pypi.org/project/google-search-results/