### PR TITLE
internal: remove claude-code from nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,21 +33,6 @@
         "type": "indirect"
       }
     },
-    "nixpkgs-claude": {
-      "locked": {
-        "lastModified": 1764517877,
-        "narHash": "sha256-pp3uT4hHijIC8JUK5MEqeAWmParJrgBVzHLNfJDZxg4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "2d293cbfa5a793b4c50d17c05ef9e385b90edf6c",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-unstable",
-        "type": "indirect"
-      }
-    },
     "nixpkgs-oapi-gen": {
       "locked": {
         "lastModified": 1740303746,
@@ -83,7 +68,6 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-claude": "nixpkgs-claude",
         "nixpkgs-oapi-gen": "nixpkgs-oapi-gen",
         "rust-overlay": "rust-overlay"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,12 +3,10 @@
     nixpkgs.url = "nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay.url = "github:oxalica/rust-overlay";
-    # Use separate channel for claude code. It always needs to be latest
-    nixpkgs-claude.url = "nixpkgs/nixos-unstable";
     nixpkgs-oapi-gen.url =
       "nixpkgs/2d068ae5c6516b2d04562de50a58c682540de9bf"; # openapi-generator-cli pin to 7.10.0
   };
-  outputs = { self, nixpkgs, nixpkgs-claude, flake-utils, rust-overlay
+  outputs = { self, nixpkgs, flake-utils, rust-overlay
     , nixpkgs-oapi-gen }:
     flake-utils.lib.eachDefaultSystem (system:
       let
@@ -17,10 +15,6 @@
           config.allowUnfree = true;
           overlays = [ (import rust-overlay) ];
         };
-        claude-code = (import nixpkgs-claude {
-          inherit system;
-          config.allowUnfree = true;
-        }).claude-code;
 
         openapi-generator-cli =
           (import nixpkgs-oapi-gen { inherit system; }).openapi-generator-cli;
@@ -141,8 +135,6 @@
 
         devShells.default = pkgs.mkShell {
           buildInputs = buildInputs ++ [
-            # To update run: `nix flake update nixpkgs-claude`
-            claude-code
             # To update run: `nix flake update nixpkgs-oapi-gen`
             openapi-generator-cli
           ] ++ (with pkgs; [


### PR DESCRIPTION
## Summary
- Removes `claude-code` package from the Nix dev shell
- Removes the dedicated `nixpkgs-claude` input that was used to pin claude-code to the latest version

## Test plan
- [ ] Verify `nix develop` still works without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)