### PR TITLE
fix(go): preserve proxy envs for go mod tidy/download

### DIFF
--- a/backend/windmill-worker/src/go_executor.rs
+++ b/backend/windmill-worker/src/go_executor.rs
@@ -570,6 +570,7 @@ pub async fn install_go_dependencies(
         .env_clear()
         .env("HOME", HOME_ENV.as_str())
         .env("PATH", PATH_ENV.as_str())
+        .envs(PROXY_ENVS.clone())
         .env("GOPATH", {
             #[cfg(unix)]
             {


### PR DESCRIPTION
Summary:
- add PROXY_ENVS to go mod tidy/download command env in Go executor
- keep existing GOPROXY/GOPRIVATE behavior

Why:
go mod runs after env_clear and may miss HTTP_PROXY/HTTPS_PROXY/NO_PROXY transport settings in proxied environments.

Change:
- backend/windmill-worker/src/go_executor.rs: add envs(PROXY_ENVS.clone()) in install_go_dependencies before go mod tidy/download.