### PR TITLE
fix: resolve $res: and $var: values inside arrays

### DIFF
--- a/backend/windmill-store/src/resources.rs
+++ b/backend/windmill-store/src/resources.rs
@@ -644,6 +644,16 @@ pub async fn transform_json_value(
             }
             Ok(Value::Object(m))
         }
+        Value::Array(arr) => {
+            let mut result = Vec::with_capacity(arr.len());
+            for item in arr {
+                result.push(
+                    transform_json_value(db_with_opt_authed, workspace, item, job_id, token)
+                        .await?,
+                );
+            }
+            Ok(Value::Array(result))
+        }
         a @ _ => Ok(a),
     }
 }

--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -315,6 +315,15 @@ pub async fn transform_json_value(
             }
             Ok(Value::Object(m))
         }
+        Value::Array(arr) => {
+            let mut result = Vec::with_capacity(arr.len());
+            for item in arr {
+                result.push(
+                    transform_json_value(name, client, workspace, item, job, conn).await?,
+                );
+            }
+            Ok(Value::Array(result))
+        }
         a @ _ => Ok(a),
     }
 }


### PR DESCRIPTION
Fixes #7800, #7253

`transform_json_value` handles `Value::String` (for `$res:`, `$var:`, `$encrypted:`) and `Value::Object` (recursively), but `Value::Array` falls through to the catch-all — so arrays of resource refs like `["$res:u/user/msg1", "$res:u/user/msg2"]` are passed unresolved.

Adds a `Value::Array` arm to both implementations:
- `backend/windmill-worker/src/common.rs` (worker execution path)
- `backend/windmill-store/src/resources.rs` (API/store path)

**Re: performance concern from #7254** — `transform_json()` already gates on `RE_RES_VAR` regex, so arrays without `$res:`/`$var:` never reach this code. Elements without `$` prefix hit the catch-all instantly. The `Value::Object` arm already recurses without depth/size guards — this is symmetric.