### PR TITLE
feat: gate private registry configuration behind enterprise feature

### DIFF
--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -1346,6 +1346,10 @@ pub async fn reload_maven_settings_xml_setting(conn: &Connection) {
     )
     .await;
 
+    if !cfg!(feature = "enterprise") {
+        return;
+    }
+
     let settings_xml = MAVEN_SETTINGS_XML.read().await.clone();
     match settings_xml {
         Some(ref content) if !content.trim().is_empty() => {

--- a/backend/windmill-worker/src/csharp_executor.rs
+++ b/backend/windmill-worker/src/csharp_executor.rs
@@ -32,8 +32,8 @@ use crate::{
     },
     get_proxy_envs_for_lang,
     handle_child::handle_child,
-    CSHARP_CACHE_DIR, is_sandboxing_enabled, DISABLE_NUSER, DOTNET_PATH, HOME_ENV, NSJAIL_PATH,
-    NUGET_CONFIG, PATH_ENV, TRACING_PROXY_CA_CERT_PATH, TZ_ENV,
+    is_sandboxing_enabled, read_ee_registry, CSHARP_CACHE_DIR, DISABLE_NUSER, DOTNET_PATH,
+    HOME_ENV, NSJAIL_PATH, NUGET_CONFIG, PATH_ENV, TRACING_PROXY_CA_CERT_PATH, TZ_ENV,
 };
 #[cfg(feature = "csharp")]
 use windmill_common::scripts::ScriptLang;
@@ -82,7 +82,15 @@ pub async fn generate_nuget_lockfile(
 ) -> error::Result<String> {
     check_executor_binary_exists("dotnet", DOTNET_PATH.as_str(), "C#")?;
 
-    if let Some(nuget_config) = NUGET_CONFIG.read().await.clone() {
+    if let Some(nuget_config) = read_ee_registry(
+        NUGET_CONFIG.read().await.clone(),
+        "nuget config",
+        job_id,
+        w_id,
+        conn,
+    )
+    .await
+    {
         if !nuget_config.trim().is_empty() {
             write_file(job_dir, "nuget.config", &nuget_config)?;
         }
@@ -336,7 +344,15 @@ async fn build_cs_proj(
     hash: &str,
     occupancy_metrics: &mut OccupancyMetrics,
 ) -> error::Result<String> {
-    if let Some(nuget_config) = NUGET_CONFIG.read().await.clone() {
+    if let Some(nuget_config) = read_ee_registry(
+        NUGET_CONFIG.read().await.clone(),
+        "nuget config",
+        job_id,
+        w_id,
+        conn,
+    )
+    .await
+    {
         if !nuget_config.trim().is_empty() {
             write_file(job_dir, "nuget.config", &nuget_config)?;
         }

--- a/backend/windmill-worker/src/pwsh_executor.rs
+++ b/backend/windmill-worker/src/pwsh_executor.rs
@@ -27,8 +27,9 @@ use crate::{
         read_file_content, start_child_process, OccupancyMetrics,
     },
     handle_child::handle_child,
-    is_sandboxing_enabled, DISABLE_NUSER, HOME_ENV, NSJAIL_PATH, PATH_ENV, POWERSHELL_CACHE_DIR,
-    POWERSHELL_PATH, POWERSHELL_REPO_PAT, POWERSHELL_REPO_URL, PROXY_ENVS, TZ_ENV,
+    is_sandboxing_enabled, read_ee_registry, DISABLE_NUSER, HOME_ENV, NSJAIL_PATH, PATH_ENV,
+    POWERSHELL_CACHE_DIR, POWERSHELL_PATH, POWERSHELL_REPO_PAT, POWERSHELL_REPO_URL, PROXY_ENVS,
+    TZ_ENV,
 };
 
 fn val_to_pwsh_param(v: serde_json::Value) -> String {
@@ -355,8 +356,22 @@ pub async fn handle_powershell_job(
     }
 
     if !modules_to_install.is_empty() {
-        let powershell_repo_url = POWERSHELL_REPO_URL.read().await.clone();
-        let powershell_repo_pat = POWERSHELL_REPO_PAT.read().await.clone();
+        let powershell_repo_url = read_ee_registry(
+            POWERSHELL_REPO_URL.read().await.clone(),
+            "powershell repo url",
+            &job.id,
+            &job.workspace_id,
+            db,
+        )
+        .await;
+        let powershell_repo_pat = read_ee_registry(
+            POWERSHELL_REPO_PAT.read().await.clone(),
+            "powershell repo pat",
+            &job.id,
+            &job.workspace_id,
+            db,
+        )
+        .await;
         let has_private_repo = powershell_repo_url.is_some();
         let has_credentials = powershell_repo_pat.is_some();
 

--- a/backend/windmill-worker/src/rust_executor.rs
+++ b/backend/windmill-worker/src/rust_executor.rs
@@ -1,7 +1,7 @@
 use serde_json::value::RawValue;
-use std::{collections::HashMap, process::Stdio};
 #[cfg(not(windows))]
 use std::sync::Once;
+use std::{collections::HashMap, process::Stdio};
 use uuid::Uuid;
 use windmill_parser_rust::parse_rust_deps_into_manifest;
 
@@ -27,8 +27,8 @@ use crate::{
     },
     get_proxy_envs_for_lang,
     handle_child::handle_child,
-    is_sandboxing_enabled, CARGO_REGISTRIES, DISABLE_NUSER, HOME_ENV, NSJAIL_PATH, PATH_ENV,
-    PROXY_ENVS, RUST_CACHE_DIR, TRACING_PROXY_CA_CERT_PATH, TZ_ENV,
+    is_sandboxing_enabled, read_ee_registry, CARGO_REGISTRIES, DISABLE_NUSER, HOME_ENV,
+    NSJAIL_PATH, PATH_ENV, PROXY_ENVS, RUST_CACHE_DIR, TRACING_PROXY_CA_CERT_PATH, TZ_ENV,
 };
 use windmill_common::client::AuthedClient;
 use windmill_common::scripts::ScriptLang;
@@ -230,8 +230,21 @@ pub fn __WINDMILL_RUN__(_args: __WINDMILL_ARGS__) -> Result<String, Box<dyn std:
     Ok(())
 }
 
-async fn write_cargo_config(job_dir: &str) -> anyhow::Result<()> {
-    if let Some(cargo_registries) = CARGO_REGISTRIES.read().await.clone() {
+async fn write_cargo_config(
+    job_dir: &str,
+    job_id: &Uuid,
+    w_id: &str,
+    conn: &Connection,
+) -> anyhow::Result<()> {
+    if let Some(cargo_registries) = read_ee_registry(
+        CARGO_REGISTRIES.read().await.clone(),
+        "cargo registries",
+        job_id,
+        w_id,
+        conn,
+    )
+    .await
+    {
         if !cargo_registries.trim().is_empty() {
             let cargo_dir = format!("{job_dir}/.cargo");
             create_dir_all(&cargo_dir).await?;
@@ -256,7 +269,7 @@ pub async fn generate_cargo_lockfile(
     check_executor_binary_exists("cargo", CARGO_PATH.as_str(), "rust")?;
 
     gen_cargo_crate(code, job_dir)?;
-    write_cargo_config(job_dir).await?;
+    write_cargo_config(job_dir, job_id, w_id, conn).await?;
 
     let mut gen_lockfile_cmd = Command::new(CARGO_PATH.as_str());
     gen_lockfile_cmd
@@ -621,7 +634,7 @@ pub async fn handle_rust_job(
         append_logs(&job.id, &job.workspace_id, logs1, conn).await;
 
         gen_cargo_crate(inner_content, job_dir)?;
-        write_cargo_config(job_dir).await?;
+        write_cargo_config(job_dir, &job.id, &job.workspace_id, conn).await?;
 
         if let Some(reqs) = requirements_o {
             if !reqs.is_empty() {

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -59,7 +59,7 @@ use std::{
     collections::{HashMap, HashSet},
     fmt::Display,
     sync::{
-        atomic::{AtomicBool, AtomicU8, AtomicU16, Ordering},
+        atomic::{AtomicBool, AtomicU16, AtomicU8, Ordering},
         Arc,
     },
     time::Duration,
@@ -673,6 +673,26 @@ pub fn get_job_isolation() -> JobIsolationLevel {
 
 /// Returns true if nsjail sandboxing should be used for job execution.
 /// DISABLE_NSJAIL=false forces nsjail regardless of the global setting.
+pub async fn read_ee_registry<T>(
+    value: Option<T>,
+    name: &str,
+    job_id: &uuid::Uuid,
+    w_id: &str,
+    conn: &Connection,
+) -> Option<T> {
+    if !cfg!(feature = "enterprise") && value.is_some() {
+        append_logs(
+            job_id,
+            w_id,
+            format!("Private registry ({name}) configuration ignored: this feature requires Windmill Enterprise Edition\n"),
+            conn,
+        )
+        .await;
+        return None;
+    }
+    value
+}
+
 pub fn is_sandboxing_enabled() -> bool {
     if !*DISABLE_NSJAIL {
         return true;


### PR DESCRIPTION
## Summary

- Adds a generic `read_ee_registry<T>()` helper in `worker.rs` that gates private registry config behind the `enterprise` feature flag
- In CE builds, configured private registries are ignored and a job log is emitted: `"Private registry ({name}) configuration ignored: this feature requires Windmill Enterprise Edition"`
- In EE builds, behavior is unchanged (the helper passes values through)
- Applied to all language executors:
  - **Python**: `PIP_EXTRA_INDEX_URL`, `PIP_INDEX_URL`
  - **Bun/npm**: `NPM_CONFIG_REGISTRY`, `BUNFIG_INSTALL_SCOPES`
  - **Deno**: `NPM_CONFIG_REGISTRY`
  - **Rust**: `CARGO_REGISTRIES`
  - **Go**: `GOPROXY`, `GOPRIVATE`
  - **Java**: `MAVEN_REPOS`, `MAVEN_SETTINGS_XML` (file write gated in `monitor.rs`)
  - **C#**: `NUGET_CONFIG`
  - **PowerShell**: `POWERSHELL_REPO_URL`, `POWERSHELL_REPO_PAT`
  - **Ruby**: `RUBY_REPOS`

## Test plan

- [x] `cargo check` passes (CE build, default features)
- [x] `cargo check --features enterprise` passes (EE build)
- [ ] Verify CE build ignores private registries and emits log message
- [ ] Verify EE build uses private registries normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)