### PR TITLE
fix: mark base_url as unsaved when using browser fallback

### DIFF
--- a/frontend/src/lib/components/InstanceSetting.svelte
+++ b/frontend/src/lib/components/InstanceSetting.svelte
@@ -35,9 +35,10 @@
 		loading?: boolean
 		openSmtpSettings?: () => void
 		oauths?: Record<string, any>
+		warning?: string
 	}
 
-	let { setting, version, values, loading = true, openSmtpSettings, oauths }: Props = $props()
+	let { setting, version, values, loading = true, openSmtpSettings, oauths, warning }: Props = $props()
 	const dispatch = createEventDispatcher()
 
 	let latestKeyRenewalAttempt: {
@@ -282,6 +283,11 @@
 						bind:value={$values[setting.key]}
 						class="max-w-lg"
 					/>
+					{#if warning}
+						<span class="text-yellow-600 dark:text-yellow-500 text-2xs">
+							{warning}
+						</span>
+					{/if}
 					{#if setting.advancedToggle}
 						<div class="mt-1">
 							<Toggle

--- a/frontend/src/lib/components/InstanceSettings.svelte
+++ b/frontend/src/lib/components/InstanceSettings.svelte
@@ -15,7 +15,7 @@
 	import AuthSettings from './AuthSettings.svelte'
 	import InstanceSetting from './InstanceSetting.svelte'
 	import { writable, type Writable } from 'svelte/store'
-	import { AlertCircle, ExternalLink, Loader2 } from 'lucide-svelte'
+	import { ExternalLink, Loader2 } from 'lucide-svelte'
 	import YAML from 'yaml'
 	import Toggle from './Toggle.svelte'
 	import type SimpleEditor from './SimpleEditor.svelte'
@@ -1007,15 +1007,8 @@
 						{values}
 						{version}
 						{oauths}
+						warning={setting.key === 'base_url' && baseUrlIsFallback ? 'Auto-detected from browser — not yet saved' : undefined}
 					/>
-					{#if setting.key === 'base_url' && baseUrlIsFallback}
-						<div class="flex items-center gap-1.5 mt-1">
-							<AlertCircle size={14} class="text-yellow-600 shrink-0" />
-							<span class="text-yellow-600 dark:text-yellow-500 text-xs">
-								Base URL was auto-detected from the browser and has not been saved yet. Save settings to persist it.
-							</span>
-						</div>
-					{/if}
 				{/if}
 			{/each}
 			{#if quickSetup && category === 'Core'}


### PR DESCRIPTION

<img width="1298" height="437" alt="image" src="https://github.com/user-attachments/assets/8ced1674-c4a3-4df4-b196-c6c06d814ee5" />


When base_url is not set in the database, the frontend silently fills in window.location.origin but also snapshots it as the initial value. This makes the dirty-check see no change, so the Save button stays disabled and the user cannot persist the auto-detected value.

Fix by snapshotting initialValues before applying the fallback, and show a yellow warning indicating the value is auto-detected and unsaved.