### PR TITLE
fix: show all settings in YAML UI and protect from empty overwrites

### DIFF
--- a/frontend/src/lib/components/InstanceSettings.svelte
+++ b/frontend/src/lib/components/InstanceSettings.svelte
@@ -550,26 +550,25 @@
 
 	const SENSITIVE_UNCHANGED = '__SENSITIVE_AND_UNCHANGED__'
 
-	const sensitiveKeys: Set<string> = new Set(
-		[...Object.values(settings), scimSamlSetting]
+	const sensitiveKeys: Set<string> = new Set([
+		...[...Object.values(settings), scimSamlSetting]
 			.flatMap((s) => Object.values(s))
 			.filter((s) => s.fieldType === 'password' || s.fieldType === 'license_key')
-			.map((s) => s.key)
-	)
+			.map((s) => s.key),
+		'ducklake_user_pg_pwd',
+		'rsa_keys'
+	])
 
 	// Settings that should never appear in YAML export/import
-	const excludedKeys: Set<string> = new Set([
-		'custom_instance_pg_databases',
-		'ducklake_settings',
-		'ducklake_user_pg_pwd'
-	])
+	const excludedKeys: Set<string> = new Set([])
 
 	// Nested fields inside object-valued settings that contain secrets.
 	// Each entry maps a top-level key to its sensitive sub-field names.
 	const nestedSensitiveFields: Record<string, string[]> = {
 		smtp_settings: ['smtp_password'],
 		secret_backend: ['token'],
-		object_store_cache_config: ['secret_key', 'serviceAccountKey']
+		object_store_cache_config: ['secret_key', 'serviceAccountKey'],
+		custom_instance_pg_databases: ['user_pwd']
 	}
 
 	/** Returns SENSITIVE_UNCHANGED if the value is non-empty and matches the initial */


### PR DESCRIPTION
## Summary
Makes all instance settings visible in the frontend YAML editor and backend YAML export with proper sensitive value redaction, and generalizes the empty/null overwrite protection to all protected settings.

## Changes
- **Frontend**: Remove `excludedKeys` entries — `custom_instance_pg_databases`, `ducklake_settings`, `ducklake_user_pg_pwd` now visible in YAML UI
- **Frontend**: Add `ducklake_user_pg_pwd` and `rsa_keys` to `sensitiveKeys` (masked with `__SENSITIVE_AND_UNCHANGED__`)
- **Frontend**: Add `custom_instance_pg_databases: ['user_pwd']` to `nestedSensitiveFields`
- **Backend**: Remove `rsa_keys` from `HIDDEN_SETTINGS` — now included in YAML export
- **Backend**: Add `automate_username_creation` to `HIDDEN_SETTINGS` — excluded from export
- **Backend**: Add `rsa_keys` and `ducklake_user_pg_pwd` to `SENSITIVE_SETTINGS` for log redaction
- **Backend**: Generalize empty/null protection to all `PROTECTED_SETTINGS`:
  - `diff_global_settings`: skips empty/null values for protected settings when DB has existing data
  - `set_global_setting_internal`: returns `BadRequest` when trying to delete/empty a protected setting

## Test plan
- [ ] `cargo check` and `cargo check --features enterprise` pass
- [ ] `cargo test -p windmill-common --lib -- instance_config` (55 tests pass)
- [ ] `cargo test -p windmill-api-settings --lib` (4 tests pass)
- [ ] Toggle YAML mode in Instance Settings — verify `custom_instance_pg_databases`, `ducklake_settings`, `rsa_keys` appear
- [ ] Verify `user_pwd` in `custom_instance_pg_databases` shows as `__SENSITIVE_AND_UNCHANGED__`
- [ ] Verify `rsa_keys` and `ducklake_user_pg_pwd` show as `__SENSITIVE_AND_UNCHANGED__`
- [ ] Try setting any protected setting to empty via API — verify 400 error
- [ ] Operator sync with empty protected setting in ConfigMap — verify DB value preserved

---
Generated with [Claude Code](https://claude.com/claude-code)