### PR TITLE
fix(frontend): improve folder picker with sticky create button and drawer flow

### DIFF
--- a/frontend/src/lib/components/Path.svelte
+++ b/frontend/src/lib/components/Path.svelte
@@ -406,7 +406,6 @@
 			{#if !hideUser}
 				<div class="block">
 					<ToggleButtonGroup
-						class="mt-0.5"
 						bind:selected={meta.ownerKind}
 						on:selected={(e) => {
 							setDirty()


### PR DESCRIPTION
## Summary
- Replace inline create item in folder picker dropdown with a sticky `bottomSnippet` button that's always visible
- Open a drawer with name input instead of creating the folder immediately from the select
- Prefill drawer input with filter text from select and auto-focus it
- Highlight create button and support Enter key when no items match the filter
- Support Enter key in the drawer to create the folder

## Test plan
- [ ] Open folder picker, verify "Create folder" button is always visible at bottom of dropdown
- [ ] Type a non-matching name, verify the create button gets highlighted
- [ ] Press Enter when no items match, verify the drawer opens with the name prefilled
- [ ] Verify the text input is focused when the drawer opens
- [ ] Press Enter in the drawer input to create the folder
- [ ] Verify the folder is created and the FolderEditor is shown after creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)