### PR TITLE
fix(frontend): add folder picker validation, error handling, and loading state

### DIFF
--- a/frontend/src/lib/components/FolderPicker.svelte
+++ b/frontend/src/lib/components/FolderPicker.svelte
@@ -93,7 +93,9 @@
 				requestBody: { name: newFolderName }
 			})
 			folderCreated = newFolderName
-			$userStore?.folders?.push(newFolderName)
+			if ($userStore) {
+				$userStore.folders = [...($userStore.folders ?? []), newFolderName]
+			}
 			folderName = newFolderName
 			loadFolders()
 		} catch (e) {


### PR DESCRIPTION
## Summary
- Add client-side folder name validation matching backend regex (`^[a-zA-Z_0-9]+$`)
- Show inline `InputError` for invalid names and duplicate folder names
- Add error handling with toast on API failure
- Add loading/creating states to prevent double-submit
- Add loading spinner on the Select while folders are being fetched

## Test plan
- [ ] Type invalid characters in folder name input, verify error message appears
- [ ] Type an existing folder name, verify duplicate error appears
- [ ] Verify Create button is disabled when validation fails
- [ ] Verify loading spinner shows on Select while folders load
- [ ] Verify toast appears on API error

🤖 Generated with [Claude Code](https://claude.com/claude-code)