### PR TITLE
fix(frontend): select folder after creation in folder picker

### DIFF
--- a/frontend/src/lib/components/FolderPicker.svelte
+++ b/frontend/src/lib/components/FolderPicker.svelte
@@ -96,8 +96,8 @@
 			if ($userStore) {
 				$userStore.folders = [...($userStore.folders ?? []), newFolderName]
 			}
+			await loadFolders()
 			folderName = newFolderName
-			loadFolders()
 		} catch (e) {
 			sendUserToast(`Could not create folder: ${e}`, true)
 		} finally {


### PR DESCRIPTION
## Summary
- Await `loadFolders()` before setting `folderName` so the select items include the new folder when the value is assigned

## Test plan
- [ ] Create a new folder via the folder picker drawer
- [ ] Verify the newly created folder is automatically selected in the dropdown after creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)