### PR TITLE
feat: improve FolderPicker with edit icon pattern

### DIFF
--- a/frontend/src/lib/components/FolderPicker.svelte
+++ b/frontend/src/lib/components/FolderPicker.svelte
@@ -246,7 +246,7 @@
 			</button>
 		{/snippet}
 	</Select>
-	{#if folderName && hovering && !loadingFolders}
+	{#if folderName && hovering && !loadingFolders && !disabled && !disableEditing}
 		<div class="absolute right-2 z-20">
 			<Button
 				variant="subtle"


### PR DESCRIPTION
## Summary
- Replace native `<select>` with custom `Select` component in FolderPicker, matching the ResourcePicker pattern
- Add Pen edit icon on hover over the select field and in each dropdown item via `endSnippet`
- Move "New folder" button into the dropdown's `bottomSnippet` for consistency

## Test plan
- [ ] Open the folder picker, verify the custom dropdown renders correctly
- [ ] Hover over the select field — verify the Pen icon appears when a folder is selected
- [ ] Click the Pen icon (hover or in dropdown) — verify it opens the folder editor drawer
- [ ] Click the Plus button in the dropdown — verify it opens the new folder drawer
- [ ] Verify disabled and read-only states work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)