### PR TITLE
fix: don't print success message when workspace add is cancelled

### DIFF
--- a/cli/src/commands/workspace/workspace.ts
+++ b/cli/src/commands/workspace/workspace.ts
@@ -260,7 +260,7 @@ export async function add(
     Deno.exit(1);
   }
 
-  await addWorkspace(
+  const added = await addWorkspace(
     {
       name: workspaceName,
       remote: remote,
@@ -269,6 +269,9 @@ export async function add(
     },
     opts
   );
+  if (!added) {
+    return;
+  }
   await setActiveWorkspace(workspaceName, opts.configDir);
 
   log.info(
@@ -278,7 +281,7 @@ export async function add(
   );
 }
 
-export async function addWorkspace(workspace: Workspace, opts: any) {
+export async function addWorkspace(workspace: Workspace, opts: any): Promise<boolean> {
   workspace.remote = new URL(workspace.remote).toString(); // add trailing slash in all cases!
 
   // Check for conflicts before adding
@@ -330,7 +333,7 @@ export async function addWorkspace(workspace: Workspace, opts: any) {
 
         if (!overwrite) {
           log.info(colors.yellow("Operation cancelled."));
-          return;
+          return false;
         }
       }
     }
@@ -350,6 +353,7 @@ export async function addWorkspace(workspace: Workspace, opts: any) {
   await file.write(new TextEncoder().encode(JSON.stringify(workspace) + "\n"));
 
   file.close();
+  return true;
 }
 
 export async function removeWorkspace(

--- a/cli/test/workspace_conflicts.test.ts
+++ b/cli/test/workspace_conflicts.test.ts
@@ -121,6 +121,45 @@ Deno.test("addWorkspace: allows same workspace (name, remote, workspaceId) with 
   });
 });
 
+Deno.test("addWorkspace: returns true on successful add", async () => {
+  await withTestConfig(async (testConfigDir) => {
+    await clearTestRemotes(testConfigDir);
+
+    const workspace = {
+      name: "return_test",
+      remote: "http://localhost:8001/",
+      workspaceId: "test",
+      token: "token1"
+    };
+
+    const result = await addWorkspace(workspace, { force: true, configDir: testConfigDir });
+    assertEquals(result, true);
+  });
+});
+
+Deno.test("addWorkspace: returns true when force-overwriting conflict", async () => {
+  await withTestConfig(async (testConfigDir) => {
+    await clearTestRemotes(testConfigDir);
+
+    const workspace1 = {
+      name: "force_test",
+      remote: "http://localhost:8001/",
+      workspaceId: "workspace1",
+      token: "token1"
+    };
+    await addWorkspace(workspace1, { force: true, configDir: testConfigDir });
+
+    const workspace2 = {
+      name: "force_test",
+      remote: "http://localhost:8002/",
+      workspaceId: "workspace2",
+      token: "token2"
+    };
+    const result = await addWorkspace(workspace2, { force: true, configDir: testConfigDir });
+    assertEquals(result, true);
+  });
+});
+
 Deno.test("addWorkspace: allows different workspaces on different remotes", async () => {
   await withTestConfig(async (testConfigDir) => {
     await clearTestRemotes(testConfigDir);


### PR DESCRIPTION
## Summary
When `wmill workspace add` detects a name conflict and the user declines the overwrite prompt, the CLI still prints the "Added workspace" success message. This fix ensures the success message and `setActiveWorkspace` are skipped when the user cancels.

## Changes
- `addWorkspace()` now returns `Promise<boolean>` — `true` on success, `false` when cancelled
- `add()` checks the return value and exits early if `false`, skipping the success message and active workspace update

## Test plan
- [ ] Run `wmill workspace add <name>` with a conflicting workspace name, decline the overwrite prompt, and verify no success message is printed
- [ ] Run `wmill workspace add <name>` with a conflicting name and accept overwrite — verify the success message still appears
- [ ] Run `wmill workspace add <name>` with no conflict — verify normal behavior is unchanged

---
Generated with [Claude Code](https://claude.com/claude-code)