### PR TITLE
fix: cargo update with native-tls pin and benchmark feature propagation

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -860,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -1991,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "c81d250916401487680ed13b8b675660281dcfc3ab0121fe44c94bcab9eae2fb"
 dependencies = [
  "allocator-api2",
 ]
@@ -13663,9 +13663,9 @@ dependencies = [
 
 [[package]]
 name = "systemstat"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5021f5184d44b26fb184acd689671bbe1e4bbd24bbdaa6bc7ec383fad32d2033"
+checksum = "a6e89b75de097d0c52a1dc2114e19439d55f0e2e42d32168c6df44f139dfb66f"
 dependencies = [
  "bytesize",
  "lazy_static",
@@ -16687,7 +16687,7 @@ dependencies = [
 
 [[package]]
 name = "windmill-object-store"
-version = "1.638.3"
+version = "1.638.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -18453,9 +18453,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a33bbf307b25a1774cee0687694ec72fa7814b3ab5c1c12a9d2fc6a36fc439c"
+checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
 
 [[package]]
 name = "zstd"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -103,7 +103,7 @@ enterprise = ["windmill-worker/enterprise", "windmill-queue/enterprise", "windmi
 local_reports = ["windmill-common/local_reports"]
 enterprise_saml = ["windmill-api/enterprise_saml", "oauth2"]
 stripe = ["windmill-api/stripe"]
-benchmark = ["windmill-api/benchmark", "windmill-worker/benchmark", "windmill-queue/benchmark", "windmill-common/benchmark"]
+benchmark = ["windmill-api/benchmark", "windmill-worker/benchmark", "windmill-queue/benchmark", "windmill-common/benchmark", "windmill-api-agent-workers?/benchmark"]
 embedding = ["windmill-api/embedding"]
 parquet = ["windmill-api/parquet", "windmill-common/parquet", "windmill-object-store/parquet", "windmill-worker/parquet"]
 prometheus = ["windmill-common/prometheus", "windmill-api/prometheus", "windmill-worker/prometheus", "windmill-queue/prometheus", "dep:prometheus"]
@@ -479,7 +479,7 @@ bit-vec = "=0.6.3"
 mappable-rc = "^0"
 mysql_async = { version = "*", default-features = false, features = ["minimal", "default", "native-tls-tls", "rust_decimal"]}
 postgres-native-tls = "^0"
-native-tls = "^0"
+native-tls = ">=0.2, <0.2.17"
 # samael will break compilation on MacOS. Use this fork instead to make it work
 # samael = { git="https://github.com/njaremko/samael", rev="464d015e3ae393e4b5dd00b4d6baa1b617de0dd6", features = ["xmlsec"] }
 libxml = { version = "=0.3.3" }

--- a/backend/windmill-api-agent-workers/Cargo.toml
+++ b/backend/windmill-api-agent-workers/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 enterprise = ["windmill-common/enterprise", "windmill-queue/enterprise"]
 private = ["windmill-common/private", "windmill-queue/private"]
 python = ["dep:windmill-parser-py-imports"]
-benchmark = []
+benchmark = ["windmill-queue/benchmark"]
 
 [dependencies]
 windmill-api-auth.workspace = true


### PR DESCRIPTION
## Summary
Run cargo update and fix two compilation issues: pin native-tls below 0.2.17 to avoid a broken release, and propagate the benchmark feature to windmill-api-agent-workers.

## Changes
- Run `cargo update` to update dependencies (aws-lc-rs, bumpalo, systemstat, zlib-rs)
- Pin `native-tls` to `>=0.2, <0.2.17` — version 0.2.17 has a non-exhaustive match on `Protocol::Tlsv13` that fails compilation
- Add `windmill-api-agent-workers?/benchmark` to root `benchmark` feature so the feature is propagated when building with `--all-features`
- Forward `benchmark` feature from `windmill-api-agent-workers` to `windmill-queue/benchmark` so the `pull()` call site and function definition agree on argument count

## Test plan
- [ ] `cargo check --all-features` passes
- [ ] CI builds succeed

---
Generated with [Claude Code](https://claude.com/claude-code)