### PR TITLE
feat: add breadcrumb navigation to advanced setup mode

### DIFF
--- a/frontend/src/routes/(root)/(logged)/user/(user)/instance_settings/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/user/(user)/instance_settings/+page.svelte
@@ -475,12 +475,11 @@
 					selectedIndex={fullStep + 1}
 					numbered
 					onselect={(i) => {
-						if (i !== fullStep) {
-							const cb = () => {
+						if (i < fullStep) {
+							saveAndProceed(() => {
 								yamlMode = false
 								fullStep = i
-							}
-							i > fullStep ? proceedFromCore(cb) : saveAndProceed(cb)
+							})
 						}
 					}}
 				>


### PR DESCRIPTION
## Summary

- Add a 2-step breadcrumb ("Settings" / "Root login & Resource Types") to the advanced setup mode on `/user/first-time`, matching the wizard mode's step indicator pattern
- Extract account setup UI (email, password, resource types) into a reusable Svelte 5 snippet shared by both wizard and advanced modes
- Add step-aware navigation buttons (Continue/Back/Set account & finish) and URL state sync for the full mode steps

## Test plan

- [ ] Quick setup still works with its 3-step breadcrumb
- [ ] Click "Advanced setup" → full mode shows 2-step breadcrumb with "1. Settings" active
- [ ] YAML toggle visible on step 1, hidden on step 2
- [ ] Click "Continue" → saves settings, advances to "2. Root login & Resource Types"
- [ ] Breadcrumb shows step 2 active, step 1 clickable
- [ ] Click breadcrumb "1. Settings" or "Back" button → returns to settings
- [ ] "Set account & finish" works on step 2
- [ ] "Quick setup" button returns to wizard mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)