### PR TITLE
perf: lazy-load JSZip in RawAppEditorHeader

### DIFF
--- a/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
@@ -6,7 +6,6 @@
 	import { AppService, DraftService, type Policy } from '$lib/gen'
 	import { rawAppToHubUrl } from '$lib/hub'
 	import { enterpriseLicense, hubBaseUrlStore, userStore, workspaceStore } from '$lib/stores'
-	import JSZip from 'jszip'
 	import YAML from 'yaml'
 	import {
 		Bug,
@@ -155,6 +154,7 @@
 		if (!app) return
 		publishingToHub = true
 		try {
+			const { default: JSZip } = await import('jszip')
 			const { js, css } = await getBundle()
 			const zip = new JSZip()
 			zip.file('app.yaml', YAML.stringify(app))


### PR DESCRIPTION
## Summary
Lazy-load JSZip in `RawAppEditorHeader.svelte` to reduce initial bundle size. JSZip (~96KB min) is only needed when the user clicks "Publish to Hub", so it is now dynamically imported at that point instead of being statically included.

## Changes
- Removed static `import JSZip from 'jszip'`
- Added `const { default: JSZip } = await import('jszip')` inside `publishToHub()`

## Test plan
- [ ] Open Raw App Editor — verify JSZip chunk is **not** loaded (DevTools → Network → JS)
- [ ] Click "Publish to Hub" — verify a new JSZip chunk is fetched and the flow works correctly
- [ ] `npm run check` passes with 0 errors

---
Generated with [Claude Code](https://claude.com/claude-code)