### PR TITLE
feat: forward PR comments to Discord threads

### DIFF
--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -6,6 +6,12 @@ on:
       - opened
       - ready_for_review
       - closed
+  issue_comment:
+    types:
+      - created
+  pull_request_review_comment:
+    types:
+      - created
 
 jobs:
   notify_discord_when_pr_opened:
@@ -31,5 +37,35 @@ jobs:
       DISCORD_CHANNEL_ID: "1372204995868491786"
       DISCORD_GUILD_ID: "930051556043276338"
       PR_NUMBER: ${{ github.event.pull_request.number }}
+    secrets:
+      DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_AI_BOT_TOKEN }}
+
+  notify_discord_on_comment:
+    if: >
+      github.event_name == 'issue_comment'
+      && github.event.issue.pull_request
+    uses: ./.github/workflows/shareable-discord-notification.yml
+    with:
+      PR_STATUS: "comment"
+      PR_NUMBER: ${{ github.event.issue.number }}
+      COMMENT_BODY: ${{ github.event.comment.body }}
+      COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+      COMMENT_URL: ${{ github.event.comment.html_url }}
+      DISCORD_CHANNEL_ID: "1372204995868491786"
+      DISCORD_GUILD_ID: "930051556043276338"
+    secrets:
+      DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_AI_BOT_TOKEN }}
+
+  notify_discord_on_review_comment:
+    if: github.event_name == 'pull_request_review_comment'
+    uses: ./.github/workflows/shareable-discord-notification.yml
+    with:
+      PR_STATUS: "comment"
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      COMMENT_BODY: ${{ github.event.comment.body }}
+      COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+      COMMENT_URL: ${{ github.event.comment.html_url }}
+      DISCORD_CHANNEL_ID: "1372204995868491786"
+      DISCORD_GUILD_ID: "930051556043276338"
     secrets:
       DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_AI_BOT_TOKEN }}

--- a/.github/workflows/shareable-discord-notification.yml
+++ b/.github/workflows/shareable-discord-notification.yml
@@ -24,9 +24,22 @@ on:
       DISCORD_GUILD_ID:
         description: "The Discord guild ID"
         type: string
+      COMMENT_BODY:
+        description: "The comment body"
+        type: string
+        default: ""
+      COMMENT_AUTHOR:
+        description: "The comment author"
+        type: string
+        default: ""
+      COMMENT_URL:
+        description: "The comment URL"
+        type: string
+        default: ""
     secrets:
       DISCORD_WEBHOOK_URL:
         description: "Discord Webhook URL"
+        required: false
       DISCORD_BOT_TOKEN:
         description: "Discord Bot Token"
 
@@ -117,3 +130,54 @@ jobs:
           curl -X PUT \
             -H "Authorization: Bot $BOT_TOKEN" \
             "https://discord.com/api/v10/channels/$thread_id/messages/$message_id/reactions/%E2%9C%85/@me"
+
+  post_comment:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.PR_STATUS == 'comment' }}
+    steps:
+      - name: Post comment to Discord thread
+        env:
+          BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          CHANNEL_ID: ${{ inputs.DISCORD_CHANNEL_ID }}
+          GUILD_ID: ${{ inputs.DISCORD_GUILD_ID }}
+          PR_NUMBER: ${{ inputs.PR_NUMBER }}
+          COMMENT_BODY: ${{ inputs.COMMENT_BODY }}
+          COMMENT_AUTHOR: ${{ inputs.COMMENT_AUTHOR }}
+          COMMENT_URL: ${{ inputs.COMMENT_URL }}
+        run: |
+          # 1) Find the thread by PR number
+          threads=$(curl -s -H "Authorization: Bot $BOT_TOKEN" \
+            "https://discord.com/api/v10/guilds/${GUILD_ID}/threads/active")
+          thread_id=$(echo "$threads" | jq -r \
+            --arg cid "$CHANNEL_ID" \
+            --arg pref "#${PR_NUMBER}:" \
+            '.threads[] | select(.parent_id == $cid and (.name | startswith($pref))) | .id')
+
+          if [ -z "$thread_id" ]; then
+            echo "Thread not found for PR #${PR_NUMBER}, skipping"
+            exit 0
+          fi
+
+          # 2) Truncate comment body to fit Discord's 2000 char limit
+          # Reserve space for the author line + link (~100 chars)
+          max_body=1800
+          if [ ${#COMMENT_BODY} -gt $max_body ]; then
+            # For bot comments, show the tail (conclusions/code tend to be at the end)
+            if [[ "$COMMENT_AUTHOR" == *"[bot]"* ]] || [[ "$COMMENT_AUTHOR" == *"-bot"* ]]; then
+              truncated_body="...${COMMENT_BODY: -$max_body}"
+            else
+              truncated_body="${COMMENT_BODY:0:$max_body}..."
+            fi
+          else
+            truncated_body="$COMMENT_BODY"
+          fi
+
+          # 3) Post the comment to the thread
+          message=$(printf '**%s** [commented](%s):\n%s' "$COMMENT_AUTHOR" "$COMMENT_URL" "$truncated_body")
+          payload=$(jq -n --arg content "$message" '{content: $content}')
+
+          curl -s -X POST \
+            -H "Authorization: Bot $BOT_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            "https://discord.com/api/v10/channels/${thread_id}/messages"


### PR DESCRIPTION
## Summary
Forward PR comments (both regular and inline review comments) into the corresponding Discord thread, so the team can follow discussions without leaving Discord.

## Changes
- Added `issue_comment` and `pull_request_review_comment` event triggers to `discord-notification.yml`
- Added two new caller jobs: `notify_discord_on_comment` (regular PR comments, filtered to exclude issues) and `notify_discord_on_review_comment` (inline review comments)
- Added `COMMENT_BODY`, `COMMENT_AUTHOR`, `COMMENT_URL` optional inputs to `shareable-discord-notification.yml`
- Added `post_comment` job that finds the Discord thread by PR number and posts the comment with author name and link
- Comment body is truncated to 1800 chars to stay within Discord's 2000-char limit; bot comments show the tail (conclusions/code at the end), human comments show the head
- Gracefully skips if the thread doesn't exist (e.g., archived)

## Test plan
- [ ] Open a PR and verify thread is created (existing behavior, unchanged)
- [ ] Post a comment on the PR and verify it appears in the Discord thread with author name and link
- [ ] Post an inline review comment and verify same behavior
- [ ] Post a long bot comment and verify the tail is shown
- [ ] Merge the PR and verify checkmark reaction (existing behavior, unchanged)
- [ ] Comment on an issue (not PR) and verify no Discord notification fires

---
Generated with [Claude Code](https://claude.com/claude-code)