### PR TITLE
feat(cli): add --locks-required flag to lint and sync push

### DIFF
--- a/cli/deno.lock
+++ b/cli/deno.lock
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@david/code-block-writer@^13.0.2": "13.0.2",
+    "jsr:@david/code-block-writer@^13.0.2": "13.0.3",
     "jsr:@david/code-block-writer@^13.0.3": "13.0.3",
     "jsr:@deno/cache-dir@~0.10.3": "0.10.3",
     "jsr:@deno/dnt@0.41.3": "0.41.3",
@@ -12,10 +12,13 @@
     "jsr:@std/assert@0.226": "0.226.0",
     "jsr:@std/assert@1.0.0-rc.2": "1.0.0-rc.2",
     "jsr:@std/bytes@0.223": "0.223.0",
+    "jsr:@std/bytes@^1.0.2": "1.0.6",
     "jsr:@std/bytes@^1.0.5": "1.0.6",
+    "jsr:@std/bytes@^1.0.6": "1.0.6",
     "jsr:@std/cli@1.0.0-rc.2": "1.0.0-rc.2",
     "jsr:@std/encoding@1.0.0-rc.2": "1.0.0-rc.2",
     "jsr:@std/encoding@1.0.4": "1.0.4",
+    "jsr:@std/encoding@^1.0.10": "1.0.10",
     "jsr:@std/fmt@0.223": "0.223.0",
     "jsr:@std/fmt@1": "1.0.8",
     "jsr:@std/fmt@^1.0.5": "1.0.8",
@@ -30,8 +33,11 @@
     "jsr:@std/io@*": "0.225.2",
     "jsr:@std/io@0.223": "0.223.0",
     "jsr:@std/io@~0.224.2": "0.224.9",
+    "jsr:@std/io@~0.224.9": "0.224.9",
     "jsr:@std/io@~0.225.2": "0.225.2",
     "jsr:@std/log@*": "0.224.14",
+    "jsr:@std/log@~0.224.14": "0.224.14",
+    "jsr:@std/net@^1.0.6": "1.0.6",
     "jsr:@std/path@*": "1.1.4",
     "jsr:@std/path@0.223": "0.223.0",
     "jsr:@std/path@1": "1.1.4",
@@ -40,6 +46,7 @@
     "jsr:@std/path@^1.1.3": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/path@~0.225.2": "0.225.2",
+    "jsr:@std/streams@^1.0.16": "1.0.17",
     "jsr:@std/text@1.0.0-rc.1": "1.0.0-rc.1",
     "jsr:@std/yaml@*": "1.0.10",
     "jsr:@std/yaml@^1.0.10": "1.0.10",
@@ -48,12 +55,16 @@
     "jsr:@ts-morph/common@0.24": "0.24.0",
     "jsr:@ts-morph/common@0.27": "0.27.0",
     "jsr:@windmill-labs/cliffy-ansi@1.0.0-rc.5": "1.0.0-rc.5",
+    "jsr:@windmill-labs/cliffy-ansi@^1.0.0-rc.5": "1.0.0-rc.5",
     "jsr:@windmill-labs/cliffy-command@1.0.0-rc.5": "1.0.0-rc.5",
+    "jsr:@windmill-labs/cliffy-command@^1.0.0-rc.5": "1.0.0-rc.5",
     "jsr:@windmill-labs/cliffy-flags@1.0.0-rc.5": "1.0.0-rc.5",
     "jsr:@windmill-labs/cliffy-internal@1.0.0-rc.5": "1.0.0-rc.5",
     "jsr:@windmill-labs/cliffy-keycode@1.0.0-rc.5": "1.0.0-rc.5",
     "jsr:@windmill-labs/cliffy-prompt@1.0.0-rc.6": "1.0.0-rc.6",
+    "jsr:@windmill-labs/cliffy-prompt@^1.0.0-rc.6": "1.0.0-rc.6",
     "jsr:@windmill-labs/cliffy-table@1.0.0-rc.5": "1.0.0-rc.5",
+    "jsr:@windmill-labs/cliffy-table@^1.0.0-rc.5": "1.0.0-rc.5",
     "jsr:@windmill-labs/shared-utils@1.0.10": "1.0.10",
     "jsr:@windmill-labs/shared-utils@1.0.11": "1.0.11",
     "jsr:@windmill-labs/shared-utils@1.0.12": "1.0.12",
@@ -157,6 +168,9 @@
     "@std/encoding@1.0.4": {
       "integrity": "2266cd516b32369e3dc5695717c96bf88343a1f761d6e6187a02a2bbe2af86ae"
     },
+    "@std/encoding@1.0.10": {
+      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
+    },
     "@std/fmt@0.223.0": {
       "integrity": "6deb37794127dfc7d7bded2586b9fc6f5d50e62a8134846608baf71ffc1a5208"
     },
@@ -200,7 +214,10 @@
       ]
     },
     "@std/io@0.224.9": {
-      "integrity": "4414664b6926f665102e73c969cfda06d2c4c59bd5d0c603fd4f1b1c840d6ee3"
+      "integrity": "4414664b6926f665102e73c969cfda06d2c4c59bd5d0c603fd4f1b1c840d6ee3",
+      "dependencies": [
+        "jsr:@std/bytes@^1.0.2"
+      ]
     },
     "@std/io@0.225.2": {
       "integrity": "3c740cd4ee4c082e6cfc86458f47e2ab7cb353dc6234d5e9b1f91a2de5f4d6c7",
@@ -215,6 +232,9 @@
         "jsr:@std/fs@^1.0.11",
         "jsr:@std/io@~0.225.2"
       ]
+    },
+    "@std/net@1.0.6": {
+      "integrity": "110735f93e95bb9feb95790a8b1d1bf69ec0dc74f3f97a00a76ea5efea25500c"
     },
     "@std/path@0.223.0": {
       "integrity": "593963402d7e6597f5a6e620931661053572c982fc014000459edc1f93cc3989",
@@ -244,6 +264,12 @@
       "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
         "jsr:@std/internal"
+      ]
+    },
+    "@std/streams@1.0.17": {
+      "integrity": "7859f3d9deed83cf4b41f19223d4a67661b3d3819e9fc117698f493bf5992140",
+      "dependencies": [
+        "jsr:@std/bytes@^1.0.6"
       ]
     },
     "@std/text@1.0.0-rc.1": {
@@ -294,7 +320,7 @@
         "jsr:@std/text",
         "jsr:@windmill-labs/cliffy-flags",
         "jsr:@windmill-labs/cliffy-internal",
-        "jsr:@windmill-labs/cliffy-table"
+        "jsr:@windmill-labs/cliffy-table@1.0.0-rc.5"
       ]
     },
     "@windmill-labs/cliffy-flags@1.0.0-rc.5": {
@@ -317,7 +343,7 @@
         "jsr:@std/io@~0.224.2",
         "jsr:@std/path@1.0.0-rc.2",
         "jsr:@std/text",
-        "jsr:@windmill-labs/cliffy-ansi",
+        "jsr:@windmill-labs/cliffy-ansi@1.0.0-rc.5",
         "jsr:@windmill-labs/cliffy-internal",
         "jsr:@windmill-labs/cliffy-keycode"
       ]

--- a/cli/src/core/conf.ts
+++ b/cli/src/core/conf.ts
@@ -97,6 +97,7 @@ export interface SyncOptions {
   };
   promotion?: string;
   lint?: boolean;
+  locksRequired?: boolean;
 }
 
 export interface Codebase {

--- a/cli/src/utils/script_common.ts
+++ b/cli/src/utils/script_common.ts
@@ -39,6 +39,19 @@ export const workspaceDependenciesLanguages: WorkspaceDependenciesLanguage[] = [
   { language: "go", filename: "go.mod" },
 ] as const;
 
+/**
+ * Returns true if a script in the given language requires a lock file.
+ * Matches the condition in updateScriptLock (metadata.ts).
+ */
+export function languageNeedsLock(language: ScriptLanguage | string): boolean {
+  return (
+    workspaceDependenciesLanguages.some((l) => l.language === language) ||
+    language === "deno" ||
+    language === "rust" ||
+    language === "ansible"
+  );
+}
+
 export function inferContentTypeFromFilePath(
   contentPath: string,
   defaultTs: "bun" | "deno" | undefined

--- a/cli/test/locks_required.test.ts
+++ b/cli/test/locks_required.test.ts
@@ -1,0 +1,620 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  checkMissingLocks,
+  runLint,
+} from "../src/commands/lint/lint.ts";
+
+async function withTempDir(
+  fn: (tempDir: string) => Promise<void>,
+): Promise<void> {
+  const tempDir = await Deno.makeTempDir({ prefix: "wmill_locks_test_" });
+  const originalCwd = Deno.cwd();
+  try {
+    Deno.chdir(tempDir);
+    await fn(tempDir);
+  } finally {
+    Deno.chdir(originalCwd);
+    await Deno.remove(tempDir, { recursive: true });
+  }
+}
+
+// --- checkMissingLocks unit tests ---
+
+Deno.test("locks-required: passes for python script with non-empty lock file", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/folder`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.py`,
+      `import pandas\ndef main(): pass`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.script.yaml`,
+      `summary: ""\ndescription: ""\nlock: "!inline f/folder/my_script.script.lock"\nkind: script\nschema:\n  $schema: "https://json-schema.org/draft/2020-12/schema"\n  type: object\n  properties: {}\n  required: []\n`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.script.lock`,
+      `pandas==2.0.0\nnumpy==1.24.0\n`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 0);
+  });
+});
+
+Deno.test("locks-required: fails for python script with empty lock file", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/folder`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.py`,
+      `def main(): pass`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.script.yaml`,
+      `summary: ""\ndescription: ""\nlock: "!inline f/folder/my_script.script.lock"\nkind: script\nschema:\n  $schema: "https://json-schema.org/draft/2020-12/schema"\n  type: object\n  properties: {}\n  required: []\n`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.script.lock`,
+      ``,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 1);
+    assertEquals(issues[0].target, "script");
+    assert(issues[0].errors[0].includes("Missing lock"));
+    assert(issues[0].errors[0].includes("python3"));
+  });
+});
+
+Deno.test("locks-required: fails for python script with missing lock file", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/folder`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.py`,
+      `def main(): pass`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.script.yaml`,
+      `summary: ""\ndescription: ""\nlock: "!inline f/folder/nonexistent.script.lock"\nkind: script\nschema:\n  $schema: "https://json-schema.org/draft/2020-12/schema"\n  type: object\n  properties: {}\n  required: []\n`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 1);
+    assertEquals(issues[0].target, "script");
+  });
+});
+
+Deno.test("locks-required: fails for python script with lock field empty string", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/folder`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.py`,
+      `def main(): pass`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.script.yaml`,
+      `summary: ""\ndescription: ""\nlock: ""\nkind: script\nschema:\n  $schema: "https://json-schema.org/draft/2020-12/schema"\n  type: object\n  properties: {}\n  required: []\n`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 1);
+    assertEquals(issues[0].target, "script");
+  });
+});
+
+Deno.test("locks-required: skips bash scripts (no locks needed)", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/folder`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.sh`,
+      `#!/bin/bash\necho hello`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.script.yaml`,
+      `summary: ""\ndescription: ""\nlock: ""\nkind: script\nschema:\n  $schema: "https://json-schema.org/draft/2020-12/schema"\n  type: object\n  properties: {}\n  required: []\n`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 0);
+  });
+});
+
+Deno.test("locks-required: skips SQL scripts (no locks needed)", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/folder`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_query.pg.sql`,
+      `SELECT 1;`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_query.script.yaml`,
+      `summary: ""\ndescription: ""\nlock: ""\nkind: script\nschema:\n  $schema: "https://json-schema.org/draft/2020-12/schema"\n  type: object\n  properties: {}\n  required: []\n`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 0);
+  });
+});
+
+Deno.test("locks-required: checks bun typescript scripts", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/folder`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.bun.ts`,
+      `export async function main() { return "hello"; }`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.script.yaml`,
+      `summary: ""\ndescription: ""\nlock: ""\nkind: script\nschema:\n  $schema: "https://json-schema.org/draft/2020-12/schema"\n  type: object\n  properties: {}\n  required: []\n`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 1);
+    assert(issues[0].errors[0].includes("bun"));
+  });
+});
+
+Deno.test("locks-required: checks deno typescript scripts", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/folder`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.deno.ts`,
+      `export async function main() { return "hello"; }`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.script.yaml`,
+      `summary: ""\ndescription: ""\nlock: ""\nkind: script\nschema:\n  $schema: "https://json-schema.org/draft/2020-12/schema"\n  type: object\n  properties: {}\n  required: []\n`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 1);
+    assert(issues[0].errors[0].includes("deno"));
+  });
+});
+
+// --- Flow inline script tests ---
+
+Deno.test("locks-required: fails for flow with unlocked inline python script", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/my_flow.flow`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_flow.flow/inline_script_0.inline_script.py`,
+      `def main(): pass`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_flow.flow/flow.yaml`,
+      `summary: My flow
+value:
+  modules:
+    - id: a
+      value:
+        type: rawscript
+        language: python3
+        content: "!inline inline_script_0.inline_script.py"
+        lock: ""
+`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 1);
+    assertEquals(issues[0].target, "flow_inline_script");
+    assert(issues[0].errors[0].includes("python3"));
+    assert(issues[0].errors[0].includes("'a'"));
+  });
+});
+
+Deno.test("locks-required: passes for flow with locked inline python script", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/my_flow.flow`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_flow.flow/inline_script_0.inline_script.py`,
+      `import pandas\ndef main(): pass`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_flow.flow/inline_script_0.inline_script.lock`,
+      `pandas==2.0.0\n`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_flow.flow/flow.yaml`,
+      `summary: My flow
+value:
+  modules:
+    - id: a
+      value:
+        type: rawscript
+        language: python3
+        content: "!inline inline_script_0.inline_script.py"
+        lock: "!inline inline_script_0.inline_script.lock"
+`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 0);
+  });
+});
+
+Deno.test("locks-required: skips flow inline bash scripts", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/my_flow.flow`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_flow.flow/flow.yaml`,
+      `summary: My flow
+value:
+  modules:
+    - id: a
+      value:
+        type: rawscript
+        language: bash
+        content: "echo hello"
+        lock: ""
+`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 0);
+  });
+});
+
+Deno.test("locks-required: checks nested flow modules (forloopflow)", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/my_flow.flow`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_flow.flow/flow.yaml`,
+      `summary: My flow
+value:
+  modules:
+    - id: loop
+      value:
+        type: forloopflow
+        modules:
+          - id: inner
+            value:
+              type: rawscript
+              language: python3
+              content: "def main(): pass"
+`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 1);
+    assert(issues[0].errors[0].includes("'inner'"));
+  });
+});
+
+Deno.test("locks-required: checks nested flow modules (branchone)", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/my_flow.flow`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_flow.flow/flow.yaml`,
+      `summary: My flow
+value:
+  modules:
+    - id: branch
+      value:
+        type: branchone
+        branches:
+          - modules:
+              - id: branch_script
+                value:
+                  type: rawscript
+                  language: bun
+                  content: "export async function main() {}"
+        default:
+          - id: default_script
+            value:
+              type: rawscript
+              language: python3
+              content: "def main(): pass"
+`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 2);
+    const ids = issues.map((i) => i.errors[0]);
+    assert(ids.some((e) => e.includes("'branch_script'")));
+    assert(ids.some((e) => e.includes("'default_script'")));
+  });
+});
+
+// --- Integration with runLint ---
+
+Deno.test("locks-required: runLint includes lock issues when flag is set", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/folder`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.py`,
+      `def main(): pass`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.script.yaml`,
+      `summary: ""\ndescription: ""\nlock: ""\nkind: script\nschema:\n  $schema: "https://json-schema.org/draft/2020-12/schema"\n  type: object\n  properties: {}\n  required: []\n`,
+    );
+
+    const report = await runLint({ locksRequired: true } as any, tempDir);
+    assertEquals(report.success, false);
+    assertEquals(report.exitCode, 1);
+    assert(report.issues.some((i) => i.target === "script"));
+  });
+});
+
+Deno.test("locks-required: runLint skips lock check when flag is not set", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/folder`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.py`,
+      `def main(): pass`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/my_script.script.yaml`,
+      `summary: ""\ndescription: ""\nlock: ""\nkind: script\nschema:\n  $schema: "https://json-schema.org/draft/2020-12/schema"\n  type: object\n  properties: {}\n  required: []\n`,
+    );
+
+    const report = await runLint({} as any, tempDir);
+    assertEquals(report.success, true);
+    assertEquals(report.exitCode, 0);
+    assertEquals(report.issues.length, 0);
+  });
+});
+
+// --- Multiple scripts ---
+
+Deno.test("locks-required: reports multiple missing locks", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/folder`, { recursive: true });
+
+    // Python script without lock
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/script1.py`,
+      `def main(): pass`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/script1.script.yaml`,
+      `summary: ""\ndescription: ""\nlock: ""\nkind: script\nschema:\n  $schema: "https://json-schema.org/draft/2020-12/schema"\n  type: object\n  properties: {}\n  required: []\n`,
+    );
+
+    // Go script without lock
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/script2.go`,
+      `package main\nfunc main() {}`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/script2.script.yaml`,
+      `summary: ""\ndescription: ""\nlock: ""\nkind: script\nschema:\n  $schema: "https://json-schema.org/draft/2020-12/schema"\n  type: object\n  properties: {}\n  required: []\n`,
+    );
+
+    // Bash script (should pass - no lock needed)
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/script3.sh`,
+      `#!/bin/bash\necho ok`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/folder/script3.script.yaml`,
+      `summary: ""\ndescription: ""\nlock: ""\nkind: script\nschema:\n  $schema: "https://json-schema.org/draft/2020-12/schema"\n  type: object\n  properties: {}\n  required: []\n`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 2);
+    assert(issues.every((i) => i.target === "script"));
+  });
+});
+
+// --- Normal app inline script tests ---
+
+Deno.test("locks-required: fails for app with unlocked inline python script", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/my_app.app`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_app.app/app.yaml`,
+      `summary: My app
+value:
+  grid:
+    - data:
+        inlineScript:
+          content: "def main(): pass"
+          language: python3
+          lock: ""
+`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 1);
+    assertEquals(issues[0].target, "app_inline_script");
+    assert(issues[0].errors[0].includes("python3"));
+  });
+});
+
+Deno.test("locks-required: passes for app with locked inline python script", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/my_app.app`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_app.app/inline_script_0.inline_script.lock`,
+      `pandas==2.0.0\n`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_app.app/app.yaml`,
+      `summary: My app
+value:
+  grid:
+    - data:
+        inlineScript:
+          content: "import pandas"
+          language: python3
+          lock: "!inline inline_script_0.inline_script.lock"
+`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 0);
+  });
+});
+
+Deno.test("locks-required: skips app inline bash scripts", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/my_app.app`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_app.app/app.yaml`,
+      `summary: My app
+value:
+  grid:
+    - data:
+        inlineScript:
+          content: "echo hello"
+          language: bash
+          lock: ""
+`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 0);
+  });
+});
+
+Deno.test("locks-required: finds deeply nested app inline scripts", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/my_app.app`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_app.app/app.yaml`,
+      `summary: My app
+value:
+  grid:
+    - components:
+        - nested:
+            deeper:
+              inlineScript:
+                content: "export async function main() {}"
+                language: bun
+                lock: ""
+`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 1);
+    assertEquals(issues[0].target, "app_inline_script");
+    assert(issues[0].errors[0].includes("bun"));
+  });
+});
+
+// --- Raw app backend script tests ---
+
+Deno.test("locks-required: fails for raw app with unlocked backend python script", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/my_app.raw_app/backend`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_app.raw_app/raw_app.yaml`,
+      `summary: My raw app
+`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_app.raw_app/backend/get_data.yaml`,
+      `type: inline
+`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_app.raw_app/backend/get_data.py`,
+      `def main(): pass`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 1);
+    assertEquals(issues[0].target, "raw_app_inline_script");
+    assert(issues[0].errors[0].includes("python3"));
+    assert(issues[0].errors[0].includes("get_data"));
+  });
+});
+
+Deno.test("locks-required: passes for raw app with locked backend python script", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/my_app.raw_app/backend`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_app.raw_app/raw_app.yaml`,
+      `summary: My raw app
+`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_app.raw_app/backend/get_data.yaml`,
+      `type: inline
+`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_app.raw_app/backend/get_data.py`,
+      `import pandas\ndef main(): pass`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_app.raw_app/backend/get_data.lock`,
+      `pandas==2.0.0\n`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 0);
+  });
+});
+
+Deno.test("locks-required: raw app auto-detects code files without YAML config", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/my_app.raw_app/backend`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_app.raw_app/raw_app.yaml`,
+      `summary: My raw app
+`,
+    );
+    // No .yaml config, just a code file
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_app.raw_app/backend/fetch_users.bun.ts`,
+      `export async function main() { return []; }`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 1);
+    assertEquals(issues[0].target, "raw_app_inline_script");
+    assert(issues[0].errors[0].includes("bun"));
+    assert(issues[0].errors[0].includes("fetch_users"));
+  });
+});
+
+Deno.test("locks-required: skips raw app bash backend scripts", async () => {
+  await withTempDir(async (tempDir) => {
+    await Deno.mkdir(`${tempDir}/f/my_app.raw_app/backend`, { recursive: true });
+
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_app.raw_app/raw_app.yaml`,
+      `summary: My raw app
+`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_app.raw_app/backend/cleanup.yaml`,
+      `type: inline
+`,
+    );
+    await Deno.writeTextFile(
+      `${tempDir}/f/my_app.raw_app/backend/cleanup.sh`,
+      `#!/bin/bash\necho done`,
+    );
+
+    const issues = await checkMissingLocks({} as any, tempDir);
+    assertEquals(issues.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `--locks-required` flag to `wmill lint` and `wmill sync push` that fails if scripts or inline scripts that need locks have no locks
- Checks standalone scripts, flow inline scripts, normal app inline scripts, and raw app backend scripts
- Shared `languageNeedsLock()` function in `script_common.ts` matching the canonical condition from `updateScriptLock` (bun, python3, php, go, deno, rust, ansible)
- Flag can be set via CLI (`--locks-required`) or `wmill.yaml` config (`locksRequired: true`)
- On `sync push`, verification runs before any push operations to fail early

## Test plan
- [x] 24 unit tests covering all resource types (standalone scripts, flows, apps, raw apps)
- [x] Existing 14 lint tests still pass
- [x] Type-checks cleanly with `deno check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)