### PR TITLE
fix: tag bunnative dependency jobs as bun instead of nativets

### DIFF
--- a/backend/windmill-queue/src/jobs.rs
+++ b/backend/windmill-queue/src/jobs.rs
@@ -5321,7 +5321,11 @@ async fn push_inner<'c, 'd>(
                 .as_ref()
                 .map(|x| {
                     let tag_lang = if x == &ScriptLang::Bunnative {
-                        ScriptLang::Nativets.as_str()
+                        if job_kind == JobKind::Dependencies {
+                            ScriptLang::Bun.as_str()
+                        } else {
+                            ScriptLang::Nativets.as_str()
+                        }
                     } else {
                         x.as_str()
                     };


### PR DESCRIPTION
## Summary
- Bunnative (REST) script dependency jobs were incorrectly tagged as `nativets` instead of `bun`
- Dependency jobs need the bun runtime for bundling, so they should use the `bun` tag
- Regular bunnative script execution jobs correctly keep the `nativets` tag

## Test plan
- [ ] Create a REST (bunnative) script from the UI
- [ ] Verify the dependency job is tagged `bun`
- [ ] Verify the script execution job is still tagged `nativets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)