### PR TITLE
fix: use correct column name completed_at in count_completed_jobs_detail

### DIFF
--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -1933,7 +1933,7 @@ async fn count_completed_jobs_detail(
 
     if let Some(after_s_ago) = query.completed_after_s_ago {
         let after = Utc::now() - chrono::Duration::seconds(after_s_ago);
-        sqlb.and_where_gt("ended_at", "?".bind(&after.to_rfc3339()));
+        sqlb.and_where_gt("completed_at", "?".bind(&after.to_rfc3339()));
     }
 
     if let Some(success) = query.success {


### PR DESCRIPTION
## Summary
- Fixed SQL error `column "ended_at" does not exist` in `count_completed_jobs_detail` by using the correct column name `completed_at` from the `v2_job_completed` table.

## Test plan
- [ ] Verify `count_completed_jobs_detail` endpoint works with `completed_after_s_ago` parameter
- [ ] Confirm no other references to `ended_at` exist on `v2_job_completed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)