### PR TITLE
fix: disable Reset Code and Apply Changes buttons when no YAML changes

### DIFF
--- a/frontend/src/lib/components/flows/header/FlowYamlEditor.svelte
+++ b/frontend/src/lib/components/flows/header/FlowYamlEditor.svelte
@@ -21,10 +21,13 @@
 	let { drawer = $bindable() }: Props = $props()
 
 	let code = $state('')
+	let initialCode = $state('')
 	let editor = $state(undefined) as SimpleEditor | undefined
+	let hasChanges = $derived(code !== initialCode)
 
 	function reload() {
 		code = YAML.stringify(filteredContentForExport(flowStore.val))
+		initialCode = code
 		editor?.setCode(code)
 	}
 
@@ -53,6 +56,7 @@
 			flowStore.val.schema = parsed.schema
 			flowStore.val.tag = parsed.tag
 			refreshStateStore(flowStore)
+			initialCode = code
 			sendUserToast('Changes applied')
 		} catch (e) {
 			;(sendUserToast('Error parsing yaml: ' + e), true)
@@ -65,8 +69,8 @@
 <Drawer on:open={reload} bind:this={drawer} size="800px">
 	<DrawerContent title="OpenFlow" on:close={() => drawer?.toggleDrawer()}>
 		{#snippet actions()}
-			<Button variant="default" unifiedSize="md" on:click={reload}>Reset code</Button>
-			<Button variant="accent" unifiedSize="md" on:click={apply}>Apply changes</Button>
+			<Button variant="default" unifiedSize="md" disabled={!hasChanges} on:click={reload}>Reset code</Button>
+			<Button variant="accent" unifiedSize="md" disabled={!hasChanges} on:click={apply}>Apply changes</Button>
 		{/snippet}
 
 		{#if flowStore.val}


### PR DESCRIPTION
## Summary
- Disable "Reset code" and "Apply changes" buttons in the Flow YAML editor when no changes have been made
- Track initial YAML content and compare with current editor content using `$derived`
- Re-disable buttons after applying changes or resetting code

## Test plan
- [ ] Open a flow, click "Edit YAML" — both buttons should be disabled
- [ ] Edit the YAML content — both buttons should become enabled
- [ ] Click "Reset code" — buttons should become disabled again
- [ ] Edit again, click "Apply changes" — buttons should become disabled again

🤖 Generated with [Claude Code](https://claude.com/claude-code)