### PR TITLE
fix: resolve duplicate JobTriggerKind typename in Go codegen

### DIFF
--- a/backend/windmill-api/openapi-deref.yaml
+++ b/backend/windmill-api/openapi-deref.yaml
@@ -28049,6 +28049,7 @@ components:
       name: trigger_kind
       description: trigger kind (schedule, http, websocket...)
       in: query
+      x-go-name: JobTriggerKindParam
       schema: *ref_160
     OrderDesc:
       name: order_desc

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -17324,6 +17324,7 @@ components:
       name: trigger_kind
       description: "filter by trigger kind. Supports comma-separated list (e.g. 'schedule,webhook') and negation by prefixing all values with '!' (e.g. '!schedule,!webhook')"
       in: query
+      x-go-name: JobTriggerKindParam
       schema:
         type: string
     OrderDesc:


### PR DESCRIPTION
## Summary
- Added `x-go-name: JobTriggerKindParam` to the `JobTriggerKind` parameter definition (under `components/parameters`) in both `openapi.yaml` and `openapi-deref.yaml`
- This disambiguates it from the `JobTriggerKind` schema (under `components/schemas`), which keeps its original Go type name since it's the enum type
- Fixes: `duplicate typename 'JobTriggerKind' detected, can't auto-rename`

## Test plan
- [ ] Verify Go client generation succeeds without the duplicate typename error

🤖 Generated with [Claude Code](https://claude.com/claude-code)