### PR TITLE
feat(frontend): flow recording and offline replay

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -281,6 +281,11 @@
 			"svelte": "./package/components/FlowStatusViewer.svelte",
 			"default": "./package/components/FlowStatusViewer.svelte"
 		},
+		"./components/FlowRecordingReplay.svelte": {
+			"types": "./package/components/recording/FlowRecordingReplay.svelte.d.ts",
+			"svelte": "./package/components/recording/FlowRecordingReplay.svelte",
+			"default": "./package/components/recording/FlowRecordingReplay.svelte"
+		},
 		"./components/FlowWrapper.svelte": {
 			"types": "./package/components/FlowWrapper.svelte.d.ts",
 			"svelte": "./package/components/FlowWrapper.svelte",

--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -57,7 +57,8 @@
 		Circle,
 		CheckCircle,
 		RefreshCw,
-		CheckCheck
+		CheckCheck,
+		Focus
 	} from 'lucide-svelte'
 	import Awareness from './Awareness.svelte'
 	import { getAllModules } from './flows/flowExplorer'
@@ -913,6 +914,11 @@
 						icon: CheckCheck
 					}
 				]
+			},
+			{
+				displayName: 'Test flow & record',
+				icon: Focus,
+				action: () => flowPreviewButtons?.openRecordingPreview()
 			}
 		]
 	}

--- a/frontend/src/lib/components/FlowLogViewer.svelte
+++ b/frontend/src/lib/components/FlowLogViewer.svelte
@@ -25,6 +25,7 @@
 	import FlowLogRow from './FlowLogRow.svelte'
 	import { Tooltip } from './meltComponents'
 	import FlowTimelineBar from './FlowTimelineBar.svelte'
+	import { getActiveReplay } from './recording/flowRecording.svelte'
 
 	type RootJobData = Partial<Job>
 
@@ -92,6 +93,8 @@
 		timelinelWidth,
 		showTimeline = true
 	}: Props = $props()
+
+	let isReplay = $derived(!!getActiveReplay())
 
 	function getJobLink(jobId: string | undefined): string {
 		if (!jobId) return ''
@@ -595,7 +598,7 @@
 						{/if}
 					</div>
 
-					{#if flowInfo?.jobId}
+					{#if flowInfo?.jobId && !isReplay}
 						<a
 							href={getJobLink(flowInfo.jobId)}
 							class="text-xs text-gray-400 hover:text-primary pl-1"
@@ -615,7 +618,7 @@
 					{#if flowInfo?.logs}
 						<LogViewer
 							content={flowInfo.logs}
-							jobId={flowInfo.jobId}
+							jobId={isReplay ? undefined : flowInfo.jobId}
 							isLoading={false}
 							small={true}
 							download={false}
@@ -805,7 +808,7 @@
 												{/if}
 											</div>
 
-											{#if isLeafStep && jobId}
+											{#if isLeafStep && jobId && !isReplay}
 												<a
 													href={getJobLink(jobId ?? '')}
 													class="text-xs text-gray-400 hover:text-primary pl-1"
@@ -898,7 +901,7 @@
 													<div onclick={() => select(`${module.id}-logs`)}>
 														<LogViewer
 															content={logs}
-															jobId={jobId ?? ''}
+															jobId={isReplay ? undefined : (jobId ?? '')}
 															isLoading={false}
 															small={true}
 															download={false}

--- a/frontend/src/lib/components/flows/header/FlowPreviewButtons.svelte
+++ b/frontend/src/lib/components/flows/header/FlowPreviewButtons.svelte
@@ -53,6 +53,16 @@
 		flowPreviewContent?.test()
 	}
 
+	export async function openRecordingPreview() {
+		if (!previewOpen) {
+			previewOpen = true
+			await tick()
+			flowPreviewContent?.refresh()
+		}
+		previewMode = 'whole'
+		flowPreviewContent?.setRecordingMode(true)
+	}
+
 	export async function runPreview(conversationId?: string): Promise<string | undefined> {
 		if (!previewOpen) {
 			deferContent = true
@@ -172,6 +182,7 @@
 				// keep the data in the preview content
 				deferContent = true
 				previewOpen = false
+				flowPreviewContent?.setRecordingMode(false)
 			}}
 			on:openTriggers={(e) => {
 				previewOpen = false

--- a/frontend/src/lib/components/recording/FlowRecordingReplay.svelte
+++ b/frontend/src/lib/components/recording/FlowRecordingReplay.svelte
@@ -1,0 +1,222 @@
+<script lang="ts">
+	import type { Job } from '$lib/gen'
+	import { workspaceStore } from '$lib/stores'
+	import FlowStatusViewer from '$lib/components/FlowStatusViewer.svelte'
+	import FlowViewer from '$lib/components/FlowViewer.svelte'
+	import FlowProgressBar from '$lib/components/flows/FlowProgressBar.svelte'
+	import FlowExecutionStatus from '$lib/components/runs/FlowExecutionStatus.svelte'
+	import { setActiveReplay } from './flowRecording.svelte'
+	import type { FlowRecording } from './types'
+	import { sendUserToast } from '$lib/toast'
+	import { Button } from '$lib/components/common'
+	import Tooltip from '$lib/components/meltComponents/Tooltip.svelte'
+	import { InfoIcon, LogOut, Play, Square } from 'lucide-svelte'
+	import { onDestroy } from 'svelte'
+
+	interface Props {
+		recording: FlowRecording
+	}
+
+	let { recording }: Props = $props()
+
+	type ReplayState = 'loaded' | 'playing'
+
+	let replayState: ReplayState = $state('loaded')
+	let rootJobId: string | undefined = $state(undefined)
+	let rootInitialJob: Job | undefined = $state(undefined)
+	let job: Job | undefined = $state(undefined)
+	let done = $derived((job as any)?.type === 'CompletedJob')
+
+	function stop() {
+		setActiveReplay(undefined)
+		job = undefined
+		initRecording()
+	}
+
+	function findRootJobId(data: FlowRecording): string | undefined {
+		for (const [id, recorded] of Object.entries(data.jobs)) {
+			const j = recorded.initial_job
+			if (
+				(j.job_kind === 'flow' || j.job_kind === 'flowpreview') &&
+				!j.parent_job
+			) {
+				return id
+			}
+		}
+		for (const [id, recorded] of Object.entries(data.jobs)) {
+			if (!recorded.initial_job.parent_job) return id
+		}
+		return Object.keys(data.jobs)[0]
+	}
+
+	/**
+	 * Offset all absolute timestamps in the recording so they are relative to "now".
+	 * TimelineCompute uses Date.now() for in-progress bars, so we need recorded
+	 * started_at/created_at values to be near the current time.
+	 */
+	function rebaseTimestamps(data: FlowRecording, rootId: string): FlowRecording {
+		const rootJob = data.jobs[rootId]?.initial_job
+		const anchor = rootJob?.started_at ?? rootJob?.created_at
+		if (!anchor) return data
+		const earliest = new Date(anchor).getTime()
+		if (isNaN(earliest)) return data
+
+		const offset = Date.now() - earliest
+
+		function offsetDate(d: string | number | undefined): string | undefined {
+			if (!d) return d as undefined
+			const t = new Date(d).getTime()
+			if (isNaN(t)) return d as string
+			return new Date(t + offset).toISOString()
+		}
+
+		function offsetJobTimestamps(j: any) {
+			if (j.started_at) j.started_at = offsetDate(j.started_at)
+			if (j.created_at) j.created_at = offsetDate(j.created_at)
+			if (j.completed_at) j.completed_at = offsetDate(j.completed_at)
+		}
+
+		function offsetFlowStatus(fs: any) {
+			if (!fs?.modules) return
+			for (const mod of fs.modules) {
+				const durations = mod.flow_jobs_duration
+				if (durations?.started_at) {
+					durations.started_at = durations.started_at.map(
+						(d: string) => offsetDate(d) ?? d
+					)
+				}
+			}
+		}
+
+		for (const recorded of Object.values(data.jobs)) {
+			offsetJobTimestamps(recorded.initial_job)
+			for (const event of recorded.events) {
+				if (event.data?.job) offsetJobTimestamps(event.data.job)
+				if (event.data?.flow_status) offsetFlowStatus(event.data.flow_status)
+			}
+		}
+		return data
+	}
+
+	function buildInitialJob(data: FlowRecording, jobId: string): Job {
+		const initialJob = JSON.parse(JSON.stringify(data.jobs[jobId].initial_job))
+		if (data.flow?.value) {
+			initialJob.raw_flow = JSON.parse(JSON.stringify(data.flow.value))
+		}
+		return initialJob
+	}
+
+	function initRecording() {
+		const flowJobId = findRootJobId(recording)
+		if (!flowJobId) {
+			sendUserToast('Recording has no jobs', true)
+			return
+		}
+		rootJobId = flowJobId
+		rootInitialJob = buildInitialJob(recording, flowJobId)
+		replayState = 'loaded'
+	}
+
+	// Initialize on mount
+	initRecording()
+
+	/**
+	 * Ensure the root flow's completed event fires after all sub-job events.
+	 * During recording, addCompletedJob runs after the flow completes, so sub-job
+	 * completed events can have a later `t` than the root's completed event.
+	 */
+	function fixEventOrdering(data: FlowRecording, rootId: string) {
+		const rootEvents = data.jobs[rootId]?.events
+		if (!rootEvents?.length) return
+
+		// Find the latest event.t across all sub-jobs
+		let maxSubJobT = 0
+		for (const [id, recorded] of Object.entries(data.jobs)) {
+			if (id === rootId) continue
+			for (const event of recorded.events) {
+				if (event.t > maxSubJobT) maxSubJobT = event.t
+			}
+		}
+
+		// Push the root's completed event to fire after all sub-job events
+		let completedIdx = -1
+		for (let i = rootEvents.length - 1; i >= 0; i--) {
+			if (rootEvents[i].data.completed) { completedIdx = i; break }
+		}
+		if (completedIdx >= 0 && rootEvents[completedIdx].t < maxSubJobT) {
+			rootEvents[completedIdx].t = maxSubJobT + 50
+		}
+	}
+
+	function startReplay() {
+		// JSON round-trip to unwrap reactive proxies and strip non-cloneable properties
+		const snapshot = JSON.parse(JSON.stringify(recording)) as FlowRecording
+		fixEventOrdering(snapshot, rootJobId!)
+		rebaseTimestamps(snapshot, rootJobId!)
+		setActiveReplay(snapshot)
+		rootInitialJob = buildInitialJob(snapshot, rootJobId!)
+		job = undefined
+		replayState = 'playing'
+	}
+
+	onDestroy(() => {
+		setActiveReplay(undefined)
+	})
+</script>
+
+{#if !recording?.flow}
+	<div class="flex flex-col items-center justify-center min-h-[60vh]">
+		<div class="border rounded-lg p-8 bg-surface-tertiary max-w-md w-full text-center">
+			<p class="text-xs text-secondary">
+				This recording does not include a flow definition. It was likely recorded with an older
+				version. Re-record the flow to include the flow definition.
+			</p>
+		</div>
+	</div>
+{:else if replayState === 'loaded'}
+	<div class="flex flex-col gap-4">
+		<div class="flex items-center justify-between">
+			<div class="flex items-center gap-2">
+				<h2 class="text-lg font-semibold text-emphasis">{recording.flow_path}</h2>
+				<Tooltip placement="bottom">
+					<InfoIcon size={16} class="text-tertiary" />
+					<span class="text-2xs" slot="text">
+						Recorded {new Date(recording.recorded_at).toLocaleString()} &mdash;
+						{(recording.total_duration_ms / 1000).toFixed(1)}s
+					</span>
+				</Tooltip>
+			</div>
+			<Button variant="contained" color="blue" on:click={startReplay} startIcon={{ icon: Play }}>
+				Play
+			</Button>
+		</div>
+		<FlowViewer flow={recording.flow} noSummary />
+	</div>
+{:else if replayState === 'playing' && rootJobId}
+	<div class="flex flex-col gap-4">
+		<div class="flex items-center justify-between">
+			<h2 class="text-lg font-semibold text-emphasis">Replaying: {recording.flow_path}</h2>
+			<Button variant="border" size="xs" on:click={stop} startIcon={{ icon: done ? LogOut : Square }}>
+				{done ? 'Exit' : 'Stop'}
+			</Button>
+		</div>
+		<FlowProgressBar {job} slim textPosition="bottom" showStepId />
+		{#if job}
+			<FlowExecutionStatus
+				{job}
+				workspaceId={$workspaceStore}
+				isOwner={false}
+				innerModules={job?.flow_status?.modules}
+				suspendStatus={{ val: {} }}
+			/>
+		{/if}
+		<FlowStatusViewer
+			jobId={rootJobId}
+			initialJob={rootInitialJob}
+			bind:job
+			workspaceId={$workspaceStore}
+			wideResults
+			showLogsWithResult
+		/>
+	</div>
+{/if}

--- a/frontend/src/lib/components/recording/flowRecording.svelte.ts
+++ b/frontend/src/lib/components/recording/flowRecording.svelte.ts
@@ -1,0 +1,192 @@
+import type { Job, OpenFlow } from '$lib/gen'
+import type { FlowRecording, RecordedJob } from './types'
+
+// Module-level active instances (bypasses context/portal issues)
+let activeRecording: FlowRecordingStore | undefined = undefined
+let activeReplay: FlowRecording | undefined = undefined
+let replayStartTime: number = 0
+
+export function getActiveRecording() {
+	return activeRecording
+}
+export function setActiveRecording(r: FlowRecordingStore | undefined) {
+	activeRecording = r
+}
+export function getActiveReplay() {
+	return activeReplay
+}
+export function setActiveReplay(r: FlowRecording | undefined) {
+	activeReplay = r
+	replayStartTime = r ? Date.now() : 0
+}
+export function getReplayStartTime() {
+	return replayStartTime
+}
+
+export function createFlowRecording() {
+	let active = $state(false)
+	let startTime = 0
+	let flowPath = ''
+	let jobs: Record<string, RecordedJob> = {}
+	let flow: OpenFlow | undefined = undefined
+	let watchedSubJobs = new Set<string>()
+	let subJobSources: EventSource[] = []
+
+	return {
+		get active() {
+			return active
+		},
+		start(path: string) {
+			subJobSources.forEach((es) => es.close())
+			subJobSources = []
+			watchedSubJobs.clear()
+			active = true
+			startTime = Date.now()
+			flowPath = path
+			jobs = {}
+			flow = undefined
+		},
+		setFlow(f: OpenFlow) {
+			// JSON round-trip to strip non-serializable properties (event handlers, etc.)
+			flow = JSON.parse(JSON.stringify(f)) as OpenFlow
+		},
+		recordInitialJob(jobId: string, job: Job) {
+			if (!active) return
+			// $state.snapshot unwraps Svelte 5 reactive proxies (structuredClone fails on them)
+			jobs[jobId] = {
+				initial_job: $state.snapshot(job) as Job,
+				events: []
+			}
+		},
+		recordEvent(jobId: string, data: Record<string, any>) {
+			if (!active) return
+			if (!jobs[jobId]) {
+				jobs[jobId] = {
+					initial_job: (data as any).job
+						? ($state.snapshot((data as any).job) as Job)
+						: ({} as Job),
+					events: []
+				}
+			}
+			jobs[jobId].events.push({
+				t: Date.now() - startTime,
+				data: $state.snapshot(data) as Record<string, any>
+			})
+		},
+		stop(): FlowRecording {
+			active = false
+			subJobSources.forEach((es) => es.close())
+			subJobSources = []
+			const recording: FlowRecording = {
+				version: 1,
+				recorded_at: new Date().toISOString(),
+				flow_path: flowPath,
+				total_duration_ms: Date.now() - startTime,
+				jobs,
+				flow
+			}
+			return recording
+		},
+		/** Add a completed sub-job to the recording (called after stop for sub-jobs fetched post-completion) */
+		addCompletedJob(jobId: string, completedJob: Job) {
+			const snapshotJob = $state.snapshot(completedJob) as Job
+			if (!jobs[jobId]) {
+				jobs[jobId] = {
+					initial_job: snapshotJob,
+					events: []
+				}
+			} else if (!jobs[jobId].initial_job?.id) {
+				// Replace placeholder initial_job created by recordEvent
+				jobs[jobId].initial_job = snapshotJob
+			}
+			// Only add synthetic completed event if SSE didn't already capture one
+			const hasCompleted = jobs[jobId].events.some((e) => e.data.completed)
+			if (!hasCompleted) {
+				jobs[jobId].events.push({
+					t: Date.now() - startTime,
+					data: { completed: true, job: snapshotJob }
+				})
+			}
+		},
+		/** Watch a sub-job's SSE stream during recording to capture incremental log events */
+		watchSubJob(jobId: string, workspace: string) {
+			if (!active || watchedSubJobs.has(jobId)) return
+			watchedSubJobs.add(jobId)
+
+			let subJobLogOffset = 0
+
+			const params = new URLSearchParams({
+				log_offset: '0',
+				running: 'true',
+				fast: 'true'
+			})
+			const url = `/api/w/${workspace}/jobs_u/getupdate_sse/${jobId}?${params}`
+			const es = new EventSource(url)
+			subJobSources.push(es)
+
+			es.onmessage = (event) => {
+				try {
+					const data = JSON.parse(event.data)
+					if (data.type === 'ping' || data.type === 'timeout') return
+					if (data.type === 'error' || data.type === 'not_found') {
+						es.close()
+						return
+					}
+					if (!active) {
+						es.close()
+						return
+					}
+
+					// Deduplicate log data: SSE may resend full log dumps on reconnect.
+					// Drop log data if the offset hasn't advanced past what we already recorded.
+					if (data.new_logs != null && data.log_offset != null) {
+						if (subJobLogOffset > 0 && data.log_offset <= subJobLogOffset) {
+							delete data.new_logs
+							delete data.log_offset
+						} else {
+							subJobLogOffset = data.log_offset
+						}
+					} else if (data.log_offset != null && data.log_offset > subJobLogOffset) {
+						subJobLogOffset = data.log_offset
+					}
+
+					// Record initial job from the first event that carries job data
+					if (!jobs[jobId] && data.job) {
+						jobs[jobId] = {
+							initial_job: data.job as Job,
+							events: []
+						}
+					} else if (!jobs[jobId]) {
+						jobs[jobId] = {
+							initial_job: {} as Job,
+							events: []
+						}
+					}
+					jobs[jobId].events.push({
+						t: Date.now() - startTime,
+						data
+					})
+					if (data.completed) {
+						es.close()
+					}
+				} catch {
+					// Ignore parse errors
+				}
+			}
+			es.onerror = () => {
+				es.close()
+			}
+		},
+		download(recording: FlowRecording) {
+			const blob = new Blob([JSON.stringify(recording, null, 2)], { type: 'application/json' })
+			const url = URL.createObjectURL(blob)
+			const a = document.createElement('a')
+			a.href = url
+			a.download = `flow-recording-${recording.flow_path.replace(/\//g, '-')}-${Date.now()}.json`
+			a.click()
+			URL.revokeObjectURL(url)
+		}
+	}
+}
+
+export type FlowRecordingStore = ReturnType<typeof createFlowRecording>

--- a/frontend/src/lib/components/recording/types.ts
+++ b/frontend/src/lib/components/recording/types.ts
@@ -1,0 +1,20 @@
+import type { Job, OpenFlow } from '$lib/gen'
+
+export type RecordedEvent = {
+	t: number
+	data: Record<string, any>
+}
+
+export type RecordedJob = {
+	initial_job: Job
+	events: RecordedEvent[]
+}
+
+export type FlowRecording = {
+	version: 1
+	recorded_at: string
+	flow_path: string
+	total_duration_ms: number
+	jobs: Record<string, RecordedJob>
+	flow?: OpenFlow
+}

--- a/frontend/src/routes/(root)/(logged)/replay/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/replay/+page.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import FlowRecordingReplay from '$lib/components/recording/FlowRecordingReplay.svelte'
+	import type { FlowRecording } from '$lib/components/recording/types'
+	import { sendUserToast } from '$lib/toast'
+	import { Button } from '$lib/components/common'
+	import FileInput from '$lib/components/common/fileInput/FileInput.svelte'
+	import { Upload } from 'lucide-svelte'
+	import { setActiveReplay } from '$lib/components/recording/flowRecording.svelte'
+
+	let recording: FlowRecording | undefined = $state(undefined)
+
+	function handleFileChange(event: CustomEvent<(string | ArrayBuffer | null)[]>) {
+		const content = event.detail?.[0]
+		if (!content || typeof content !== 'string') return
+		try {
+			const data = JSON.parse(content) as FlowRecording
+			if (data.version !== 1 || !data.jobs) {
+				sendUserToast('Invalid recording format', true)
+				return
+			}
+			recording = data
+		} catch (err) {
+			sendUserToast('Failed to load recording: ' + err, true)
+		}
+	}
+
+	function quit() {
+		setActiveReplay(undefined)
+		recording = undefined
+	}
+</script>
+
+<div class="max-w-7xl mx-auto px-4 py-8 w-full">
+	{#if recording}
+		<div class="flex justify-end mb-4">
+			<Button variant="border" size="xs" on:click={quit} startIcon={{ icon: Upload }}>
+				Load another recording
+			</Button>
+		</div>
+		<FlowRecordingReplay {recording} />
+	{:else}
+		<div class="flex flex-col items-center justify-center min-h-[60vh]">
+			<div class="flex flex-col items-center gap-2 max-w-md w-full">
+				<h2 class="text-lg font-semibold text-emphasis">Replay a flow recording</h2>
+				<p class="text-xs text-secondary mb-2">
+					Upload a recording JSON file to replay a flow execution offline.
+				</p>
+				<FileInput
+					accept=".json"
+					convertTo="text"
+					class="w-full"
+					on:change={handleFileChange}
+				>
+					Drag and drop a recording file
+				</FileInput>
+			</div>
+		</div>
+	{/if}
+</div>


### PR DESCRIPTION
## Summary

- Add **flow test recording**: a "Test flow & record" option in the editor three-dots menu opens the test drawer in recording mode, capturing all job events (SSE streams, sub-jobs, flow status) and the flow definition into a downloadable JSON file
- Add **offline replay**: standalone `/replay` page where users upload a recording and watch the flow execute with real-time status transitions — zero API calls
- Guard all API call sites in `FlowStatusViewerInner`, `FlowLogViewer`, and `JobLoader` to prevent network requests during replay
- Suppress job links, log downloads, and resource lookups in replay mode

## Test plan

- [ ] Open a flow in the editor, click the three-dots menu → "Test flow & record"
- [ ] Verify the test drawer opens with "Test flow and record" button label
- [ ] Run a test, confirm "Recording" indicator appears during execution
- [ ] After completion, click "Download recording" and verify the JSON contains a `flow` key with modules
- [ ] Navigate to `/replay`, upload the JSON, verify the flow graph preview loads
- [ ] Press Play, confirm flow replays with status transitions, progress bar, and logs
- [ ] Open browser Network tab during replay and confirm zero API calls
- [ ] Press Exit after completion (or Stop during replay) to return to the preview
- [ ] Test with a nested flow (flow-within-flow) to verify recursive sub-job capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)