### PR TITLE
fix(frontend): correct asset node x offset inside loops and branches

### DIFF
--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -585,7 +585,7 @@
 		let assetNodesResult = $showAssets
 			? computeAssetNodes(
 					newNodes.map((n) => ({
-						data: { assets: n.data?.assets as AssetWithAltAccessType[] },
+						data: { assets: n.data?.assets as AssetWithAltAccessType[], offset: n.data?.offset as number },
 						id: n.id,
 						position: n.position
 					}))

--- a/frontend/src/lib/components/graph/renderers/nodes/AssetNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/AssetNode.svelte
@@ -11,7 +11,7 @@
 	let computeAssetNodesCache: [NodeDep[], ReturnType<typeof computeAssetNodes>] | undefined
 
 	type NodeDep = {
-		data: object & { assets?: AssetWithAltAccessType[] | undefined }
+		data: object & { assets?: AssetWithAltAccessType[] | undefined; offset?: number }
 		id: string
 		position: { x: number; y: number }
 	}
@@ -78,13 +78,14 @@
 					width: inputAssetWidth,
 					position: {
 						x:
-							displayedInputAssets.length === 1
+							(node.data.offset ?? 0) +
+							(displayedInputAssets.length === 1
 								? (NODE.width - inputAssetWidth) / 2 - 10 // Ensure we see the edge
 								: (inputAssetWidth + inputAssetXGap) * (i - displayedInputAssets.length / 2) +
 									(NODE.width + inputAssetXGap) / 2 +
 									(overflowedInputAssets.length
 										? (-ASSETS_OVERFLOWED_NODE_WIDTH - inputAssetXGap) / 2
-										: 0),
+										: 0)),
 						y: READ_ASSET_Y_OFFSET
 					},
 					selectable: false
@@ -115,13 +116,14 @@
 					width: outputAssetWidth,
 					position: {
 						x:
-							displayedOutputAssets.length === 1
+							(node.data.offset ?? 0) +
+							(displayedOutputAssets.length === 1
 								? (NODE.width - outputAssetWidth) / 2 - 10 // Ensure we see the edge
 								: (outputAssetWidth + outputAssetXGap) * (i - displayedOutputAssets.length / 2) +
 									(NODE.width + outputAssetXGap) / 2 +
 									(overflowedOutputAssets.length
 										? (-ASSETS_OVERFLOWED_NODE_WIDTH - outputAssetXGap) / 2
-										: 0),
+										: 0)),
 						y: WRITE_ASSET_Y_OFFSET
 					},
 					selectable: false
@@ -155,7 +157,7 @@
 					parentId: node.id,
 					width: ASSETS_OVERFLOWED_NODE_WIDTH,
 					position: {
-						x: MAX_ASSET_ROW_WIDTH - ASSETS_OVERFLOWED_NODE_WIDTH - 14,
+						x: (node.data.offset ?? 0) + MAX_ASSET_ROW_WIDTH - ASSETS_OVERFLOWED_NODE_WIDTH - 14,
 						y: READ_ASSET_Y_OFFSET
 					}
 				} satisfies Node & AssetsOverflowedN)
@@ -174,7 +176,7 @@
 					parentId: node.id,
 					width: ASSETS_OVERFLOWED_NODE_WIDTH,
 					position: {
-						x: MAX_ASSET_ROW_WIDTH - ASSETS_OVERFLOWED_NODE_WIDTH - 14,
+						x: (node.data.offset ?? 0) + MAX_ASSET_ROW_WIDTH - ASSETS_OVERFLOWED_NODE_WIDTH - 14,
 						y: WRITE_ASSET_Y_OFFSET
 					}
 				} satisfies Node & AssetsOverflowedN)


### PR DESCRIPTION
## Summary
- Asset nodes (read/write indicators) were misaligned horizontally when the parent step was inside a loop or branch
- Root cause: module nodes inside loops have a `data.offset` value (25px per nesting level) applied as CSS `margin-left`, but asset child nodes didn't account for this shift in their position.x calculation
- Fix: pass `offset` from module node data into `computeAssetNodes()` and add it to the x position of all 4 asset child node types (input, output, overflowed input, overflowed output)

## Test plan
- [ ] Open a flow with a for/while loop containing a step that has assets (e.g. a Postgres resource)
- [ ] Verify asset nodes are horizontally centered under the step node
- [ ] Verify asset nodes outside loops still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)