### PR TITLE
chore: fix Vite dependency pre-bundling errors

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -88,10 +88,11 @@ const config = {
 	plugins: [sveltekit(), ...(process.env.HTTPS === 'true' ? [mkcert()] : []), plugin],
 	define: { __pkg__: version },
 	optimizeDeps: {
-		include: ['highlight.js', 'highlight.js/lib/core', 'monaco-vim', 'monaco-editor-wrapper'],
+		include: ['highlight.js', 'highlight.js/lib/core', 'monaco-vim'],
 		exclude: [
 			'@codingame/monaco-vscode-standalone-typescript-language-features',
 			'@codingame/monaco-vscode-standalone-languages',
+			'windmill-client'
 		]
 	},
 	worker: { format: 'es' },


### PR DESCRIPTION
## Summary
- Exclude `windmill-client` from `optimizeDeps` — it only appears in template string literals (code snippets for Windmill workers), not as an actual frontend import
- Remove uninstalled `monaco-editor-wrapper` from `optimizeDeps.include`

🤖 Generated with [Claude Code](https://claude.com/claude-code)