### PR TITLE
chore: add mermaid CLI to sandbox image with usage instructions

### DIFF
--- a/.wmdev.yaml
+++ b/.wmdev.yaml
@@ -79,7 +79,7 @@ profiles:
 
       --- Mermaid Diagrams ---
       You can render Mermaid diagrams to SVG using the pre-installed mmdc CLI.
-      The puppeteer no-sandbox config is at /root/.puppeteerrc.json.
+      The puppeteer config (no-sandbox + Chromium path) is at /root/.puppeteerrc.json.
 
       1) Write a .mmd file with your diagram:
           cat > /tmp/diagram.mmd << 'EOF'
@@ -87,13 +87,19 @@ profiles:
             A[Start] --> B[End]
           EOF
 
-      2) Render to SVG:
-          mmdc -i /tmp/diagram.mmd -o /tmp/diagram.svg
+      2) Render to SVG (the -p flag is required):
+          mmdc -i /tmp/diagram.mmd -o /tmp/diagram.svg -p /root/.puppeteerrc.json
 
-      3) Upload to R2 (same as screenshots):
+      3) Upload to R2:
           aws s3 cp /tmp/diagram.svg
           "s3://$(printenv R2_BUCKET)/$(git rev-parse --abbrev-ref HEAD)/diagram.svg"
           --endpoint-url "$(printenv R2_ENDPOINT)"
+
+      4) The public URL will be:
+          $(printenv R2_PUBLIC_URL)/<branch>/diagram.svg
+
+      5) Include in PR descriptions as markdown images:
+          ![description]($(printenv R2_PUBLIC_URL)/<branch>/diagram.svg)
 
 linkedRepos:
   - repo: windmill-labs/windmill-ee-private

--- a/sandbox-image/Dockerfile.sandbox
+++ b/sandbox-image/Dockerfile.sandbox
@@ -57,9 +57,11 @@ ENV PATH="/root/.local/bin:$PATH"
 RUN npm i -g @openai/codex
 
 # ── Mermaid CLI ───────────────────────────────────────────────────────────────
-RUN npm i -g @mermaid-js/mermaid-cli
-# Allow puppeteer (used by mmdc) to run as root inside the container
-RUN echo '{"args":["--no-sandbox","--disable-setuid-sandbox"]}' > /root/.puppeteerrc.json
+# Skip puppeteer's own Chromium download; reuse the one Playwright already installed above
+RUN PUPPETEER_SKIP_DOWNLOAD=true npm i -g @mermaid-js/mermaid-cli \
+    && CHROMIUM=$(find /root/.cache/ms-playwright -name 'chrome' -executable -type f | head -1) \
+    && printf '{"args":["--no-sandbox","--disable-setuid-sandbox"],"executablePath":"%s"}\n' "$CHROMIUM" \
+       > /root/.puppeteerrc.json
 
 # ── Entrypoint (run explicitly via docker exec, not on container start) ──────
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
## Summary
Adds the Mermaid CLI (`mmdc`) to the sandbox Docker image so Claude can render Mermaid diagrams to SVG files directly from the container.

## Changes
- `sandbox-image/Dockerfile.sandbox`: install `@mermaid-js/mermaid-cli` globally via npm and write `/root/.puppeteerrc.json` with `--no-sandbox` flags (required since the container runs as root)
- `.wmdev.yaml`: add a `--- Mermaid Diagrams ---` section to the system prompt with step-by-step instructions for writing `.mmd` files, rendering to SVG, and uploading to R2
- `sample-diagram.svg`: example rendered SVG demonstrating the workflow

## Test plan
- [ ] Build sandbox image and verify `mmdc --version` works
- [ ] Run `mmdc -i diagram.mmd -o diagram.svg` inside the container and confirm SVG is produced without sandbox errors

---
Generated with [Claude Code](https://claude.com/claude-code)