### PR TITLE
fix: improve Anthropic API proxy handling and update default models

### DIFF
--- a/frontend/src/lib/components/copilot/lib.ts
+++ b/frontend/src/lib/components/copilot/lib.ts
@@ -55,7 +55,7 @@ export const AI_PROVIDERS: Record<AIProvider, AIProviderDetails> = {
 	},
 	anthropic: {
 		label: 'Anthropic',
-		defaultModels: ['claude-sonnet-4-0', 'claude-sonnet-4-0/thinking', 'claude-3-5-haiku-latest']
+		defaultModels: ['claude-sonnet-4-6', 'claude-sonnet-4-6/thinking', 'claude-3-5-haiku-latest']
 	},
 	mistral: {
 		label: 'Mistral',


### PR DESCRIPTION
## Summary
Fix the AI proxy to properly handle Anthropic API requests and update default Anthropic models to the latest versions.

## Changes
- Strip `/v1` from base URL when Anthropic SDK header is present (Anthropic API doesn't use `/v1` prefix)
- Add `X-API-Key` header for Anthropic providers (their native auth mechanism)
- Forward `anthropic-*` headers from client requests through the proxy
- Update default Anthropic models from `claude-sonnet-4-0` to `claude-sonnet-4-6`

## Test plan
- [ ] Verify Anthropic API requests work through the AI proxy with SDK headers
- [ ] Verify `X-API-Key` header is sent for Anthropic providers
- [ ] Verify `anthropic-*` headers are forwarded correctly
- [ ] Verify non-Anthropic providers are unaffected

---
Generated with [Claude Code](https://claude.com/claude-code)