### PR TITLE
fix: resolve skip check crash when first flow node has both skip_if and stop_after_if

### DIFF
--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -1099,21 +1099,23 @@ pub async fn update_flow_status_after_job_completion_internal(
                     || (flow_jobs.is_some() && (skip_loop_failures || skip_seq_branch_failure)))
                     && !(stop_early && stop_early_err_msg.is_some() && !skip_if_stop_early)
                 {
-                    let is_skipped = if current_module.as_ref().is_some_and(|m| m.skip_if.is_some())
-                    {
-                        sqlx::query_scalar!(
-                            "SELECT kind = 'identity' FROM v2_job WHERE id = $1",
-                            job_id_for_status
-                        )
-                        .fetch_one(db)
-                        .await
-                        .map_err(|e| {
-                            Error::internal_err(format!("error during skip check: {e:#}"))
-                        })?
-                        .unwrap_or(false)
-                    } else {
-                        stop_early && skip_if_stop_early // Mark as skipped when stop_after_if with skip_if_stopped=true
-                    };
+                    let is_skipped_via_skip_if =
+                        if current_module.as_ref().is_some_and(|m| m.skip_if.is_some()) {
+                            sqlx::query_scalar!(
+                                "SELECT kind = 'identity' FROM v2_job WHERE id = $1",
+                                job_id_for_status
+                            )
+                            .fetch_optional(db)
+                            .await
+                            .map_err(|e| {
+                                Error::internal_err(format!("error during skip check: {e:#}"))
+                            })?
+                            .flatten()
+                            .unwrap_or(false)
+                        } else {
+                            false
+                        };
+                    let is_skipped = is_skipped_via_skip_if || (stop_early && skip_if_stop_early);
                     success = true;
                     (
                         true,


### PR DESCRIPTION
## Summary

Fixes a panic/crash that occurred when the first node of a flow had both `skip_if` and `stop_after_if` configured. The bug was caused by using `fetch_one` to query the job kind, which would fail with a \"no rows returned\" error when the job had not yet been inserted into `v2_job` (e.g., at flow start before any job exists for the current step).

## Changes
- Changed `fetch_one` to `fetch_optional` when querying `v2_job` for the skip check, so a missing row no longer causes a crash
- Added `.flatten()` to handle the `Option<Option<bool>>` returned by `fetch_optional` + nullable scalar
- Split the `is_skipped` calculation into two parts: `is_skipped_via_skip_if` (from the DB query) and the existing `stop_early && skip_if_stop_early` path, then combined them with `||` to preserve both behaviors

## Test plan
- [ ] Create a flow whose first step has `skip_if` configured and verify it no longer crashes
- [ ] Create a flow whose first step has `stop_after_if` with `skip_if_stopped = true` and verify early-stop skipping still works
- [ ] Create a flow whose first step has both `skip_if` and `stop_after_if` and verify both conditions are evaluated correctly without panicking

---
Generated with [Claude Code](https://claude.com/claude-code)