### PR TITLE
fix: runs page date picker query parameter handling

### DIFF
--- a/frontend/src/lib/components/RunsPage.svelte
+++ b/frontend/src/lib/components/RunsPage.svelte
@@ -760,7 +760,7 @@
 						transformInputSelectedText={(_, v) => `${pluralize(v, 'day')} lookback`}
 						tooltip={'How far behind the min datetime to start considering jobs for the concurrency graph. Change this value to include jobs started before the set time window for the computation of the graph'}
 					/>
-				{:else if !lastFetchWentToEnd}
+				{:else if !lastFetchWentToEnd && (jobs?.length ?? 0) >= (perPage.val ?? 1000)}
 					<Button wrapperClasses="ml-2" unifiedSize="md" onClick={() => jobsLoader.loadExtraJobs()}>
 						Load more
 						<Tooltip>There are more jobs to load</Tooltip>

--- a/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
+++ b/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
@@ -100,7 +100,7 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 	let queue_count: Tweened<number> | undefined = $state()
 	let suspended_count: Tweened<number> | undefined = $state()
 	let loading = $state(false)
-	let lastFetchWentToEnd = $state(false)
+	let lastFetchWentToEnd = $state(true)
 
 	let completedJobs: CompletedJob[] | undefined = $state()
 	let externalJobs: Job[] | undefined = $state()
@@ -329,6 +329,7 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 					jobs = sortMinDate(minTs, newJobs)
 					externalJobs = []
 					computeCompletedJobs()
+					lastFetchWentToEnd = newJobs.length < perPage
 					loading = false
 				}
 			)
@@ -359,6 +360,7 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 						externalJobs = computeExternalJobs(newExternalJobs)
 					}
 					computeCompletedJobs()
+					lastFetchWentToEnd = newJobs.length < perPage
 					loading = false
 				}
 			)


### PR DESCRIPTION
## Summary
Fixes several issues with the runs page job loader when using the date picker / timeframe filters.

## Changes
- **Fix running/suspended/waiting status filter**: Route time params to `createdBeforeQueue`/`createdAfterQueue` instead of `completedBefore`/`completedAfter` for queue-only statuses, avoiding a backend `BadRequest` error
- **Skip queue params for completed-only statuses**: Don't send `createdAfterQueue` when filtering for success/failure since only completed jobs are relevant
- **Pass `completedAfter` on initial load**: Previously hardcoded to `null`, meaning the backend fetched all completed jobs up to `maxTs` with no lower bound. Now passes `extendedMinTs` to avoid overfetching
- **Skip auto-refresh for manual timeframes**: No point polling for new jobs when the date range is a fixed past window
- **Debounce param change effect**: Prevents double API calls when multiple filter properties change in the same tick
- **Remove redundant `timeframe` dep**: Was already tracked via `filters`, causing duplicate effect triggers

## Test plan
- [ ] Select "Status: Running" filter → should show running jobs without error
- [ ] Select a manual date range via the date picker → should send both `completed_before` and `completed_after`
- [ ] Verify only one `list` API call fires when changing timeframe
- [ ] Verify no auto-refresh polling when a manual date range is selected
- [ ] Select "Status: Success" → verify no `created_after_queue` in the request

---
Generated with [Claude Code](https://claude.com/claude-code)