### PR TITLE
fix: remove duplicate job loading on chart zoom

### DIFF
--- a/frontend/src/lib/components/RunsPage.svelte
+++ b/frontend/src/lib/components/RunsPage.svelte
@@ -776,9 +776,8 @@
 					maxTimeSet={manualTimeframe?.maxTs}
 					maxIsNow={manualTimeframe?.maxTs == undefined}
 					jobs={completedJobs}
-					onZoom={async (zoom) => {
+					onZoom={(zoom) => {
 						_timeframe.val = buildManualTimeframe(zoom.min.toISOString(), zoom.max.toISOString())
-						jobsLoader?.loadJobs(true)
 					}}
 					onPointClicked={(ids) => {
 						runsTable?.scrollToRun(ids)
@@ -790,9 +789,8 @@
 					maxTimeSet={manualTimeframe?.maxTs}
 					maxIsNow={manualTimeframe?.maxTs == undefined}
 					{extendedJobs}
-					onZoom={async (zoom) => {
+					onZoom={(zoom) => {
 						_timeframe.val = buildManualTimeframe(zoom.min.toISOString(), zoom.max.toISOString())
-						jobsLoader?.loadJobs(true)
 					}}
 				/>
 			{/if}

--- a/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
+++ b/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
@@ -110,6 +110,7 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 	let intervalId: ReturnType<typeof setInterval> | undefined = $state()
 	let sync = true
 	let paramChangeTimeout: ReturnType<typeof setTimeout> | undefined
+	let paramChangePromise: CancelablePromise<void> | undefined
 
 	function onParamChanges() {
 		resetJobs()
@@ -545,14 +546,14 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 		perPage
 		showSchedules
 		showFutureJobs
-		let p: CancelablePromise<void> | undefined
 		clearTimeout(paramChangeTimeout)
+		paramChangePromise?.cancel()
 		paramChangeTimeout = setTimeout(() => {
-			p = untrack(() => onParamChanges())
+			paramChangePromise = untrack(() => onParamChanges())
 		}, 0)
 		return () => {
 			clearTimeout(paramChangeTimeout)
-			p?.cancel()
+			paramChangePromise?.cancel()
 		}
 	})
 	$effect(() => {


### PR DESCRIPTION
## Summary
Fixes double API calls when selecting a range on the runs page chart.

## Changes
- **Remove redundant `loadJobs(true)` from zoom handlers**: Both `RunChart` and `ConcurrentJobsChart` `onZoom` callbacks were setting `_timeframe.val` (which triggers the reactive effect → `onParamChanges`) AND explicitly calling `jobsLoader.loadJobs(true)`, causing two identical API calls
- **Fix debounce promise cancellation**: Hoist the promise ref outside the effect closure so the cleanup function can properly cancel in-flight requests from previous timeouts

## Test plan
- [ ] Select a range on the RunChart by dragging → verify only one `list` API call fires
- [ ] Select a range on the ConcurrencyChart → verify only one `list` API call fires
- [ ] Rapidly change filters → verify debounce prevents duplicate calls

---
Generated with [Claude Code](https://claude.com/claude-code)