### PR TITLE
chore: bump Go in container images to 1.26.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,7 @@ ARG POWERSHELL_DEB_VERSION=7.5.0-1
 ARG KUBECTL_VERSION=1.28.7
 ARG HELM_VERSION=3.14.3
 # NOTE: If changing, also change go version in workspace dependencies template at WorkspaceDependenciesEditor.svelte
-ARG GO_VERSION=1.25.0
+ARG GO_VERSION=1.26.0
 ARG APP=/usr/src/app
 ARG WITH_POWERSHELL=true
 ARG WITH_KUBECTL=true

--- a/backend/windmill-common/src/workspace_dependencies.rs
+++ b/backend/windmill-common/src/workspace_dependencies.rs
@@ -510,7 +510,7 @@ impl WorkspaceDependenciesPrefetched {
         //                 external.get(0).map(|wd| dbg!(wd.content.clone())).or(Some(
         //                     "
         // module mymod
-        // go 1.25
+        // go 1.26
         // require ()
         //                         "
         //                     .to_owned(),

--- a/docker/DockerfileExtra
+++ b/docker/DockerfileExtra
@@ -44,9 +44,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN set -eux; \
     arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
     case "$arch" in \
-    'amd64') targz='go1.21.13.linux-amd64.tar.gz' ;; \
-    'arm64') targz='go1.21.13.linux-arm64.tar.gz' ;; \
-    'armhf') targz='go1.21.13.linux-armv6l.tar.gz' ;; \
+    'amd64') targz='go1.26.0.linux-amd64.tar.gz' ;; \
+    'arm64') targz='go1.26.0.linux-arm64.tar.gz' ;; \
+    'armhf') targz='go1.26.0.linux-armv6l.tar.gz' ;; \
     *) echo >&2 "error: unsupported architecture '$arch'"; exit 1 ;; \
     esac; \
     wget "https://golang.org/dl/$targz" -nv && tar -C /usr/local -xzf "$targz" && rm "$targz"

--- a/docker/entrypoint-extra.sh
+++ b/docker/entrypoint-extra.sh
@@ -36,7 +36,7 @@ fi
 # Setup Monaco temp directory for LSP
 mkdir -p /tmp/monaco
 if [ ! -f /tmp/monaco/go.mod ]; then
-    echo -e "module mymod\ngo 1.25" > /tmp/monaco/go.mod
+    echo -e "module mymod\ngo 1.26" > /tmp/monaco/go.mod
 fi
 
 echo "[entrypoint] Starting Windmill Extra Services"

--- a/frontend/src/lib/components/WorkspaceDependenciesEditor.svelte
+++ b/frontend/src/lib/components/WorkspaceDependenciesEditor.svelte
@@ -138,7 +138,7 @@ numpy>=1.24.0
 
 		// 		go: `module mymod
 
-		// go 1.25
+		// go 1.26
 
 		// require (
 		// 	rsc.io/quote v1.5.2

--- a/lsp/Dockerfile
+++ b/lsp/Dockerfile
@@ -21,13 +21,13 @@ RUN set -eux; \
     url=; \
     case "$arch" in \
     'amd64') \
-    targz='go1.25.0.linux-amd64.tar.gz'; \
+    targz='go1.26.0.linux-amd64.tar.gz'; \
     ;; \
     'arm64') \
-    targz='go1.25.0.linux-arm64.tar.gz'; \
+    targz='go1.26.0.linux-arm64.tar.gz'; \
     ;; \
     'armhf') \
-    targz='go1.25.0.linux-armv6l.tar.gz'; \
+    targz='go1.26.0.linux-armv6l.tar.gz'; \
     ;; \
     *) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; exit 1 ;; \
     esac; \

--- a/lsp/pyls_launcher.py
+++ b/lsp/pyls_launcher.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     go_mod_path = os.path.join(monaco_path, "go.mod")
     if not os.path.exists(go_mod_path):
         f = open(go_mod_path, "w")
-        f.write("module mymod\ngo 1.25")
+        f.write("module mymod\ngo 1.26")
         f.close()
     port = int(os.environ.get("PORT", "3001"))
     app = web.Application(


### PR DESCRIPTION
Created by codex, but I reviewed everything personally and it looks good with the following note:

- I do not know about the DockerfileExtra.  This appears to be an older version of Go and likely no involved with the Go version used for user scripts.

Everything else seems to be correct.

Thanks!