### PR TITLE
perf: lazy-load heavy deps (graphql, openapi-parser, sha256)

### DIFF
--- a/frontend/src/lib/components/DBSchemaExplorer.svelte
+++ b/frontend/src/lib/components/DBSchemaExplorer.svelte
@@ -32,10 +32,10 @@
 	</ToggleButtonGroup>
 {/if}
 {#if dbSchema.lang === 'graphql'}
-	{#await import('$lib/components/GraphqlSchemaViewer.svelte')}
+	{#await Promise.all([import('$lib/components/GraphqlSchemaViewer.svelte'), formatGraphqlSchema(dbSchema.schema)])}
 		<Loader2 class="animate-spin" />
-	{:then Module}
-		<Module.default code={formatGraphqlSchema(dbSchema.schema)} class="h-full" />
+	{:then [Module, code]}
+		<Module.default {code} class="h-full" />
 	{/await}
 {:else}
 	<ObjectViewer json={formatSchema(dbSchema)} pureViewer collapseLevel={1} />

--- a/frontend/src/lib/components/apps/components/display/dbtable/metadata.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/metadata.ts
@@ -13,7 +13,7 @@ import {
 import { type Preview } from '$lib/gen'
 import type { DBSchema, GraphqlSchema, SQLSchema } from '$lib/stores'
 
-import { stringifySchema } from '$lib/components/copilot/lib'
+import { stringifyGraphqlSchema, stringifySchema } from '$lib/components/copilot/lib'
 import type { DbType } from '$lib/components/dbTypes'
 import { getDatabaseArg } from '$lib/components/dbOps'
 
@@ -416,7 +416,7 @@ export async function getDbSchemas(
 			workspace,
 			requestBody: {
 				language: sqlScript.lang as Preview['language'],
-				content: sqlScript.code,
+				content: typeof sqlScript.code === 'function' ? await sqlScript.code() : sqlScript.code,
 				tag: options.customTag,
 				args: {
 					[sqlScript.argName]: resourcePath.startsWith('datatable://')
@@ -458,7 +458,10 @@ export async function getDbSchemas(
 					lang: 'graphql' as GraphqlSchema['lang'],
 					schema: result
 				}
-				return { ...(dbSchema as any), stringified: stringifySchema(dbSchema as any) }
+				return {
+					...(dbSchema as any),
+					stringified: await stringifyGraphqlSchema(result)
+				}
 			}
 		}
 	}

--- a/frontend/src/lib/components/apps/components/display/dbtable/utils.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/utils.ts
@@ -1,11 +1,6 @@
 import type { ScriptLang } from '$lib/gen'
 import type { SQLSchema } from '$lib/stores'
-import {
-	buildClientSchema,
-	getIntrospectionQuery,
-	printSchema,
-	type IntrospectionQuery
-} from 'graphql'
+import type { IntrospectionQuery } from 'graphql'
 
 import type { DbType } from '$lib/components/dbTypes'
 
@@ -64,7 +59,7 @@ export function resourceTypeToLang(rt: string) {
 const legacyScripts: Record<
 	string,
 	{
-		code: string
+		code: string | (() => Promise<string>)
 		lang: string
 		processingFn?: (any: any) => SQLSchema['schema']
 		argName: string
@@ -146,7 +141,7 @@ const legacyScripts: Record<
 		argName: 'database'
 	},
 	graphql: {
-		code: getIntrospectionQuery(),
+		code: () => import('graphql').then((m) => m.getIntrospectionQuery()),
 		lang: 'graphql',
 		argName: 'api'
 	},
@@ -305,7 +300,8 @@ export function formatSchema(dbSchema: {
 	}
 }
 
-export function formatGraphqlSchema(schema: IntrospectionQuery): string {
+export async function formatGraphqlSchema(schema: IntrospectionQuery): Promise<string> {
+	const { buildClientSchema, printSchema } = await import('graphql')
 	return printSchema(buildClientSchema(schema))
 }
 

--- a/frontend/src/lib/components/apps/editor/appPolicy.ts
+++ b/frontend/src/lib/components/apps/editor/appPolicy.ts
@@ -1,4 +1,3 @@
-import { Sha256 } from '@aws-crypto/sha256-js'
 import { getCountInput } from '../components/display/dbtable/queries/count'
 import { getDeleteInput } from '../components/display/dbtable/queries/delete'
 import { getInsertInput } from '../components/display/dbtable/queries/insert'
@@ -236,6 +235,7 @@ async function hash(message) {
 		return hashHex
 	} catch {
 		//subtle not available, trying pure js
+		const { Sha256 } = await import('@aws-crypto/sha256-js')
 		const hash = new Sha256()
 		hash.update(message ?? '')
 		const result = Array.from(await hash.digest())

--- a/frontend/src/lib/components/apps/editor/commonAppUtils.ts
+++ b/frontend/src/lib/components/apps/editor/commonAppUtils.ts
@@ -1,37 +1,35 @@
-import type { StaticAppInput } from "../inputType"
-import { Sha256 } from '@aws-crypto/sha256-js'
+import type { StaticAppInput } from '../inputType'
 
-export function collectStaticFields(
-    fields: Record<string, StaticAppInput>
-) {
-    return Object.fromEntries(
-        Object.entries(fields ?? {})
-            .filter(([k, v]) => v.type == 'static')
-            .map(([k, v]) => {
-                return [k, v['value']]
-            })
-    )
+export function collectStaticFields(fields: Record<string, StaticAppInput>) {
+	return Object.fromEntries(
+		Object.entries(fields ?? {})
+			.filter(([k, v]) => v.type == 'static')
+			.map(([k, v]) => {
+				return [k, v['value']]
+			})
+	)
 }
 
 export type TriggerableV2 = {
-    static_inputs: Record<string, any>
-    one_of_inputs?: Record<string, any[] | undefined>
-    allow_user_resources?: string[]
+	static_inputs: Record<string, any>
+	one_of_inputs?: Record<string, any[] | undefined>
+	allow_user_resources?: string[]
 }
 
 export async function hash(message) {
-    try {
-        const msgUint8 = new TextEncoder().encode(message) // encode as (utf-8) Uint8Array
-        const hashBuffer = await crypto.subtle.digest('SHA-256', msgUint8) // hash the message
-        const hashArray = Array.from(new Uint8Array(hashBuffer)) // convert buffer to byte array
-        const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('') // convert bytes to hex string
-        return hashHex
-    } catch {
-        //subtle not available, trying pure js
-        const hash = new Sha256()
-        hash.update(message ?? '')
-        const result = Array.from(await hash.digest())
-        const hex = result.map((b) => b.toString(16).padStart(2, '0')).join('') // convert bytes to hex string
-        return hex
-    }
+	try {
+		const msgUint8 = new TextEncoder().encode(message) // encode as (utf-8) Uint8Array
+		const hashBuffer = await crypto.subtle.digest('SHA-256', msgUint8) // hash the message
+		const hashArray = Array.from(new Uint8Array(hashBuffer)) // convert buffer to byte array
+		const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('') // convert bytes to hex string
+		return hashHex
+	} catch {
+		//subtle not available, trying pure js
+		const { Sha256 } = await import('@aws-crypto/sha256-js')
+		const hash = new Sha256()
+		hash.update(message ?? '')
+		const result = Array.from(await hash.digest())
+		const hex = result.map((b) => b.toString(16).padStart(2, '0')).join('') // convert bytes to hex string
+		return hex
+	}
 }

--- a/frontend/src/lib/components/copilot/chat/ContextElementBadge.svelte
+++ b/frontend/src/lib/components/copilot/chat/ContextElementBadge.svelte
@@ -64,13 +64,10 @@
 		{:else if contextElement.type === 'db'}
 			<div class="p-2 max-w-96 max-h-[300px] text-xs overflow-auto">
 				{#if contextElement.schema && contextElement.schema.lang === 'graphql'}
-					{#await import('$lib/components/GraphqlSchemaViewer.svelte')}
+					{#await Promise.all([import('$lib/components/GraphqlSchemaViewer.svelte'), formatGraphqlSchema(contextElement.schema.schema)])}
 						<Loader2 class="animate-spin" />
-					{:then Module}
-						<Module.default
-							code={formatGraphqlSchema(contextElement.schema.schema)}
-							class="h-full"
-						/>
+					{:then [Module, code]}
+						<Module.default {code} class="h-full" />
 					{/await}
 				{:else if contextElement.schema}
 					<ObjectViewer json={formatSchema(contextElement.schema)} pureViewer collapseLevel={1} />

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -17,8 +17,6 @@ export { sendUserToast }
 import type { AnyMeltElement } from '@melt-ui/svelte'
 import type { TriggerKind } from './components/triggers'
 import { stateSnapshot } from './svelte5Utils.svelte'
-import { validate, dereference } from '@scalar/openapi-parser'
-
 export namespace OpenApi {
 	export enum OpenApiVersion {
 		V2,
@@ -59,6 +57,7 @@ export namespace OpenApi {
 	 * @throws Will throw an error if the specification is invalid or cannot be parsed.
 	 */
 	export async function parse(api: string): Promise<[OpenAPI.Document, OpenApiVersion]> {
+		const { validate, dereference } = await import('@scalar/openapi-parser')
 		const { valid, errors } = await validate(api)
 
 		if (!valid) {


### PR DESCRIPTION
## Summary

- Lazy-load `graphql` library (~180KB) — split GraphQL code paths from SQL in `stringifySchema`, `formatGraphqlSchema`, and `getIntrospectionQuery`
- Lazy-load `@scalar/openapi-parser` (~100-200KB) in `utils.ts` `parse()` function
- Lazy-load `@aws-crypto/sha256-js` (~30KB) fallback in `appPolicy.ts` and `commonAppUtils.ts`

These libraries are only needed in rare code paths (GraphQL schema display, OpenAPI validation, SHA-256 when `crypto.subtle` is unavailable) but were previously eagerly imported, pulling them into shared chunks loaded on every page.

## Changes

- `copilot/lib.ts`: `stringifySchema` is now SQL-only (sync). New `stringifyGraphqlSchema` async function for GraphQL
- `dbtable/utils.ts`: `formatGraphqlSchema` is now async with dynamic `import('graphql')`. `legacyScripts.graphql.code` uses lazy getter
- `dbtable/metadata.ts`: Uses `stringifyGraphqlSchema` for GraphQL path, sync `stringifySchema` for SQL
- `DBSchemaExplorer.svelte` / `ContextElementBadge.svelte`: `formatGraphqlSchema` calls wrapped in `{#await}` blocks
- `utils.ts`: `@scalar/openapi-parser` dynamically imported inside `parse()`
- `appPolicy.ts` / `commonAppUtils.ts`: `@aws-crypto/sha256-js` dynamically imported in catch block

## Test plan

- [ ] DB Explorer: verify SQL databases (PostgreSQL, MySQL, etc.) still load schemas correctly
- [ ] DB Explorer: verify GraphQL resources still display schema correctly  
- [ ] Copilot chat: verify DB context badges render for both SQL and GraphQL schemas
- [ ] App editor: verify DB explorer component works (select, insert, update, delete)
- [ ] OpenAPI: verify importing an OpenAPI spec still validates correctly
- [ ] App policy: verify app save/deploy still computes policies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)