### PR TITLE
fix: copy .npmrc in Dockerfiles so npm ci resolves legacy-peer-deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ FROM node:24-alpine as frontend
 
 # install dependencies
 WORKDIR /frontend
-COPY ./frontend/package.json ./frontend/package-lock.json ./
+COPY ./frontend/package.json ./frontend/package-lock.json ./.npmrc ./
 COPY ./frontend/scripts/ ./scripts/
 RUN npm ci
 

--- a/docker/RHEL8/Dockerfile
+++ b/docker/RHEL8/Dockerfile
@@ -22,7 +22,7 @@ FROM node:20-alpine as frontend
 
 # install dependencies
 WORKDIR /frontend
-COPY ./frontend/package.json ./frontend/package-lock.json ./
+COPY ./frontend/package.json ./frontend/package-lock.json ./.npmrc ./
 COPY ./frontend/scripts/ ./scripts/
 RUN npm ci
 

--- a/docker/RHEL9/Dockerfile
+++ b/docker/RHEL9/Dockerfile
@@ -22,7 +22,7 @@ FROM node:20-alpine as frontend
 
 # install dependencies
 WORKDIR /frontend
-COPY ./frontend/package.json ./frontend/package-lock.json ./
+COPY ./frontend/package.json ./frontend/package-lock.json ./.npmrc ./
 COPY ./frontend/scripts/ ./scripts/
 RUN npm ci
 


### PR DESCRIPTION
## Summary
Docker image builds fail because `npm ci` doesn't respect `legacy-peer-deps=true`. The `.npmrc` file in `frontend/` sets this option, but it wasn't being copied into the build context before `npm ci` runs.

## Changes
- Copy `.npmrc` alongside `package.json` and `package-lock.json` before `npm ci` in `Dockerfile`, `docker/RHEL8/Dockerfile`, and `docker/RHEL9/Dockerfile`

## Test plan
- [ ] Verify Docker image builds succeed with `docker build .`

---
Generated with [Claude Code](https://claude.com/claude-code)