### PR TITLE
perf: partial index for fast failure filtering on runs page

### DIFF
--- a/backend/migrations/20260228000000_v2_job_completed_failure_index.down.sql
+++ b/backend/migrations/20260228000000_v2_job_completed_failure_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS ix_v2_job_completed_failure_workspace;

--- a/backend/migrations/20260228000000_v2_job_completed_failure_index.up.sql
+++ b/backend/migrations/20260228000000_v2_job_completed_failure_index.up.sql
@@ -1,0 +1,7 @@
+-- Partial index for fast failure/canceled filtering on the runs page.
+-- When failures are sparse (<1%) this avoids scanning millions of successful jobs.
+-- The query orders by completed_at DESC (switched from created_at when success=false),
+-- so this index provides both filtering and ordering in a single scan.
+CREATE INDEX IF NOT EXISTS ix_v2_job_completed_failure_workspace
+    ON v2_job_completed (workspace_id, completed_at DESC)
+    WHERE status IN ('failure', 'canceled');

--- a/backend/windmill-api-jobs/src/query.rs
+++ b/backend/windmill-api-jobs/src/query.rs
@@ -556,7 +556,10 @@ pub fn list_completed_jobs_query(
     let mut sqlb = SqlBuilder::select_from("v2_job_completed")
         .fields(fields)
         .order_by(
-            if lq.completed_before.is_some() || lq.completed_after.is_some() {
+            if lq.completed_before.is_some()
+                || lq.completed_after.is_some()
+                || lq.success == Some(false)
+            {
                 "v2_job_completed.completed_at"
             } else {
                 "v2_job.created_at"

--- a/backend/windmill-api/src/db.rs
+++ b/backend/windmill-api/src/db.rs
@@ -81,6 +81,9 @@ lazy_static::lazy_static! {
                     (20260225100000, include_str!(
                         "../../migrations/20260225100000_asset_covering_index.up.sql"
                     ).replace("CREATE INDEX", "CREATE INDEX CONCURRENTLY").replace("DROP INDEX", "DROP INDEX CONCURRENTLY")),
+                    (20260228000000, include_str!(
+                        "../../migrations/20260228000000_v2_job_completed_failure_index.up.sql"
+                    ).replace("CREATE INDEX", "CREATE INDEX CONCURRENTLY")),
                     ].into_iter().collect();
 }
 


### PR DESCRIPTION
## Summary
- Adds a partial index on `v2_job_completed (workspace_id, completed_at DESC) WHERE status IN ('failure', 'canceled')` to speed up failure filtering on the runs page when failures are sparse
- Switches `ORDER BY` from `v2_job.created_at` to `v2_job_completed.completed_at` when filtering by failure status, so Postgres can walk the partial index directly instead of scanning millions of success rows
- Registers the migration in `db.rs` with `CONCURRENTLY` replacement for non-locking index creation on existing deployments

## Benchmarks (5.2M rows, 1% failure rate)

| Query | Before | After | Speedup |
|-------|--------|-------|---------|
| LIMIT 30 | 800ms | 0.4ms | 2000x |
| LIMIT 1000 | 550ms | 21ms | 26x |

## Test plan
- [x] `cargo check -p windmill-api` passes
- [x] `cargo test -p windmill-api-jobs` — all 39 tests pass
- [x] EXPLAIN ANALYZE verified with synthetic data at 1% failure rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)