### PR TITLE
fix: restore email domain (MX) setting in instance settings UI

### DIFF
--- a/frontend/src/lib/components/instanceSettings.ts
+++ b/frontend/src/lib/components/instanceSettings.ts
@@ -141,6 +141,21 @@ export const settings: Record<string, Setting[]> = {
 					!value?.endsWith(' '))
 		},
 		{
+			label: 'Email domain',
+			description: 'Domain to display in webhooks for email triggers (should match the MX record)',
+			key: 'email_domain',
+			fieldType: 'text',
+			placeholder: 'mail.windmill.com',
+			storage: 'setting',
+			error: 'Must be a valid domain',
+			isValid: (value: string | undefined) =>
+				value == undefined ||
+				value === '' ||
+				/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/.test(
+					value
+				)
+		},
+		{
 			label: 'Request size limit in MB',
 			description: 'Maximum size of HTTP requests in MB.',
 			cloudonly: true,


### PR DESCRIPTION
## Summary
The `email_domain` setting was accidentally removed from the instance settings UI in commit `4e38a4f108` ("fix: improve on-boarding experience"). The backend still fully supports it — the setting is used to configure the domain for email triggers (MX record). This PR restores it in the Core section of instance settings.

## Changes
- Re-added `email_domain` text input to the Core settings category in `instanceSettings.ts`
- Includes domain format validation and placeholder (`mail.windmill.com`)

## Test plan
- [ ] Navigate to `/#superadmin-settings` → General tab and verify the "Email domain" field appears
- [ ] Set a valid domain value and confirm it persists after save
- [ ] Verify email triggers still reference the configured domain

---
Generated with [Claude Code](https://claude.com/claude-code)