### PR TITLE
fix: validate tarball URL host in npm proxy to prevent SSRF

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -16208,6 +16208,7 @@ dependencies = [
  "tar",
  "tower-http",
  "tracing",
+ "url",
  "windmill-api-auth",
  "windmill-common",
 ]

--- a/backend/windmill-api-npm-proxy/Cargo.toml
+++ b/backend/windmill-api-npm-proxy/Cargo.toml
@@ -20,3 +20,4 @@ sqlx.workspace = true
 tar.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
+url.workspace = true


### PR DESCRIPTION
## Summary
Fix a Server-Side Request Forgery (SSRF) vulnerability in the npm proxy that allowed exfiltration of private registry auth tokens via crafted `dist.tarball` URLs in package metadata.

## Changes
- Modified `build_registry_request` to accept the registry base URL and validate that the request URL host matches the registry host before attaching the Bearer token
- Updated all 6 call sites to pass the registry base URL
- Added `url` crate dependency for URL parsing and host comparison

## Test plan
- [ ] Configure a private npm registry and verify packages still resolve and download correctly
- [ ] Verify that a package with a `dist.tarball` pointing to a different host is rejected with a 400 error
- [ ] Verify the Bearer token is never sent to non-registry hosts

---
Generated with [Claude Code](https://claude.com/claude-code)