### PR TITLE
feat: slow stream warnings, batch size control, and fix result/skipped filters

### DIFF
--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -2062,6 +2062,8 @@ async fn list_jobs(
 
     let sql = if lq.success.is_none()
         && lq.label.is_none()
+        && lq.result.is_none()
+        && !lq.is_skipped.unwrap_or(false)
         && lq.created_before.is_none()
         && lq.started_before.is_none()
         && lq.created_or_started_before.is_none()

--- a/frontend/src/lib/components/RunsPage.svelte
+++ b/frontend/src/lib/components/RunsPage.svelte
@@ -171,6 +171,7 @@
 		currentWorkspace: $workspaceStore ?? ''
 	}))
 	let batchProgress = $derived(jobsLoader.batchProgress)
+	let currentBatchSize = $derived(jobsLoader.currentBatchSize)
 	let lastFetchWentToEnd = $derived(jobsLoader.lastFetchWentToEnd)
 	let queue_count = $derived(jobsLoader.queue_count)
 	let suspended_count = $derived(jobsLoader.suspended_count)
@@ -830,12 +831,29 @@
 											style="width: {Math.round((batchProgress.loaded / batchProgress.total) * 100)}%"
 										></div>
 									</div>
-									<button
-										class="text-xs text-secondary hover:text-primary underline"
-										onclick={() => jobsLoader.stopBatchLoading()}
+									{#if currentBatchSize != null}
+										<span class="whitespace-nowrap shrink-0">Batch size:</span>
+										<input
+											type="number"
+											min="1"
+											max="1000"
+											value={currentBatchSize}
+											class="!w-14 shrink-0 text-xs px-1 py-0.5 border rounded text-center"
+											onchange={(e) => {
+												const v = parseInt(e.currentTarget.value)
+												if (v >= 1 && v <= 1000) {
+													jobsLoader.restreamWithBatchSize(v)
+												}
+											}}
+										/>
+									{/if}
+									<Button
+										size="xs"
+										destructive
+										onClick={() => jobsLoader.stopBatchLoading()}
 									>
 										Stop
-									</button>
+									</Button>
 								</div>
 							{/if}
 							<!-- Runs table. Add overflow-hidden because scroll is handled inside the runs table based on this wrapper height -->

--- a/frontend/src/lib/components/runs/runsFilter.ts
+++ b/frontend/src/lib/components/runs/runsFilter.ts
@@ -238,6 +238,7 @@ export const buildRunsFilterPresets = ({
 }) => [
 	{ name: 'Hide schedules', value: 'job_trigger_kind:\\ !schedule' },
 	{ name: 'Hide future jobs', value: 'show_future_jobs:\\ false' },
+	{ name: 'Show skipped', value: 'show_skipped:\\ true' },
 	...(isSuperadmin && isAdminsWorkspace
 		? [{ name: 'All workspaces', value: 'all_workspaces:\\ true' }]
 		: [])


### PR DESCRIPTION
## Summary
- Show recurring toast every 15s (8s duration) when any job loading takes long, with a "Stop loading" action button
- When streaming by batches of 25 and a single batch takes >4s, offer to switch to streaming 1 by 1
- Expose current batch size in the progress bar with an editable number input so users can customize it on the fly
- Make the Stop button in the progress bar more prominent (uses destructive `Button` component)
- Fix `list_jobs` UNION query: exclude queue jobs when filtering by `result` or `is_skipped=true` (queue jobs don't have these columns)
- Add "Show skipped" preset to the runs filter dropdown

## Test plan
- [ ] Open runs page with many jobs, verify the 15s recurring toast appears with "Stop loading" button
- [ ] Trigger slow loading, accept "Stream by batches of 25", verify 4s timeout offers "Stream 1 by 1"
- [ ] Verify batch size input in progress bar works and restarts streaming with new size
- [ ] Verify Stop button is visually prominent (red/destructive style)
- [ ] Filter by result, verify no queued jobs appear in results
- [ ] Verify "Show skipped" preset appears in filter presets

🤖 Generated with [Claude Code](https://claude.com/claude-code)