### PR TITLE
fix: show sync endpoint timeout setting on all instances

### DIFF
--- a/frontend/src/lib/components/instanceSettings.ts
+++ b/frontend/src/lib/components/instanceSettings.ts
@@ -231,7 +231,6 @@ export const settings: Record<string, Setting[]> = {
 			description:
 				'Maximum amount of time (measured in seconds) that a <a href="https://www.windmill.dev/docs/core_concepts/webhooks">sync endpoint</a> is allowed to run before it is forcibly stopped or timed out.',
 			key: 'timeout_wait_result',
-			cloudonly: true,
 			fieldType: 'seconds',
 			placeholder: '60',
 			storage: 'setting'


### PR DESCRIPTION
## Summary
- Remove `cloudonly: true` from the "Max timeout for sync endpoints" instance setting so it's visible on self-hosted instances, not just `app.windmill.dev`
- The backend already supports this setting on all instances (via DB or `TIMEOUT_WAIT_RESULT` env var)

## Test plan
- [ ] Verify the setting appears in superadmin instance settings on a self-hosted instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)