### PR TITLE
fix: add missing grant_types field to instance config OAuth structs

### DIFF
--- a/backend/windmill-common/src/instance_config.rs
+++ b/backend/windmill-common/src/instance_config.rs
@@ -420,6 +420,8 @@ pub struct OAuthClient {
     pub login_config: Option<OAuthConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub share_with_workspaces: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub grant_types: Vec<String>,
 }
 
 /// OAuth provider endpoint configuration.
@@ -438,6 +440,8 @@ pub struct OAuthConfig {
     pub extra_params_callback: Option<BTreeMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub req_body_auth: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub grant_types: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -2235,6 +2239,7 @@ mod tests {
                         connect_config: None,
                         login_config: None,
                         share_with_workspaces: None,
+                        grant_types: vec![],
                     },
                 );
                 m


### PR DESCRIPTION
## Summary
The "Support Client Credentials Flow" checkbox in instance settings was not persisting. After saving, the checkbox would appear unchecked on reload. This was caused by the `OAuthClient` and `OAuthConfig` structs in `instance_config.rs` missing the `grant_types` field, which was silently dropped during serialization.

The field existed on the runtime structs in `windmill-oauth` but was omitted when the instance config types were unified in the Feb 2026 refactor (`f7d946943a`), even though client credentials support had been added 7 months earlier.

## Changes
- Add `grant_types: Vec<String>` field to `OAuthClient` struct in `instance_config.rs`
- Add `grant_types: Vec<String>` field to `OAuthConfig` struct in `instance_config.rs`
- Both use `#[serde(default, skip_serializing_if = "Vec::is_empty")]` for backwards compatibility
- Update existing test to include the new field

## Test plan
- [ ] Go to instance settings, configure a custom OAuth2 client
- [ ] Check "Support Client Credentials Flow" checkbox
- [ ] Press "Review changes" and save
- [ ] Reload the page and verify the checkbox is still checked
- [ ] Verify adding new Custom OAuth2 client resources works

---
Generated with [Claude Code](https://claude.com/claude-code)