### PR TITLE
fix: add missing display_name and tenant fields to instance config OAuthClient

### DIFF
--- a/backend/windmill-common/src/instance_config.rs
+++ b/backend/windmill-common/src/instance_config.rs
@@ -413,11 +413,15 @@ pub struct OAuthClient {
     pub id: String,
     pub secret: StringOrSecretRef,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_domains: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connect_config: Option<OAuthConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub login_config: Option<OAuthConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub share_with_workspaces: Option<bool>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -2235,9 +2239,11 @@ mod tests {
                         secret: StringOrSecretRef::EnvRef(EnvRefWrapper {
                             env_ref: "__WM_TEST_OAUTH_SECRET".to_string(),
                         }),
+                        display_name: None,
                         allowed_domains: None,
                         connect_config: None,
                         login_config: None,
+                        tenant: None,
                         share_with_workspaces: None,
                         grant_types: vec![],
                     },


### PR DESCRIPTION
## Summary
Follow-up to #8175. The `OAuthClient` struct in `instance_config.rs` was also missing `display_name` and `tenant` fields, which are silently dropped during save — same class of bug as the `grant_types` fix.

- `display_name` — used by custom OAuth providers to show a friendly name
- `tenant` — used by Microsoft Teams OAuth to store the tenant ID

## Changes
- Add `display_name: Option<String>` to `OAuthClient` in `instance_config.rs`
- Add `tenant: Option<String>` to `OAuthClient` in `instance_config.rs`
- Update test to include the new fields

## Test plan
- [ ] Configure a Teams OAuth with a tenant ID, save, reload — tenant should persist
- [ ] Configure a custom OAuth with a display name, save, reload — display name should persist

---
Generated with [Claude Code](https://claude.com/claude-code)