### PR TITLE
chore: bump Bun to v1.3.10

### DIFF
--- a/.github/DockerfileBackendTests
+++ b/.github/DockerfileBackendTests
@@ -42,7 +42,7 @@ RUN wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VER
 RUN /usr/local/bin/python3 -m pip install pip-tools
 
 # Bun
-COPY --from=oven/bun:1.3.8 /usr/local/bin/bun /usr/bin/bun
+COPY --from=oven/bun:1.3.10 /usr/local/bin/bun /usr/bin/bun
 
 # Install windmill CLI
 RUN bun install -g windmill-cli \

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -55,7 +55,7 @@ jobs:
           go-version: 1.21.5
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.8
+          bun-version: 1.3.10
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/Dockerfile
+++ b/Dockerfile
@@ -256,7 +256,7 @@ COPY --from=windmill_duckdb_ffi_internal_builder /windmill-duckdb-ffi-internal/t
 
 COPY --from=denoland/deno:2.2.1 --chmod=755 /usr/bin/deno /usr/bin/deno
 
-COPY --from=oven/bun:1.3.8 /usr/local/bin/bun /usr/bin/bun
+COPY --from=oven/bun:1.3.10 /usr/local/bin/bun /usr/bin/bun
 
 # Install windmill CLI
 RUN bun install -g windmill-cli \

--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -54,7 +54,7 @@ RUN mkdir -p /tmp/windmill/cache && \
     rm -rf /tmp/build_cache && \
     mkdir -p -m 777 /tmp/windmill/cache/uv
 
-COPY --from=oven/bun:1.3.8 /usr/local/bin/bun /usr/bin/bun
+COPY --from=oven/bun:1.3.10 /usr/local/bin/bun /usr/bin/bun
 
 # Install windmill CLI (node symlink needed for bun install)
 RUN ln -s /usr/bin/bun /usr/bin/node \

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -54,7 +54,7 @@ RUN mkdir -p /tmp/windmill/cache && \
     rm -rf /tmp/build_cache && \
     mkdir -p -m 777 /tmp/windmill/cache/uv
 
-COPY --from=oven/bun:1.3.8 /usr/local/bin/bun /usr/bin/bun
+COPY --from=oven/bun:1.3.10 /usr/local/bin/bun /usr/bin/bun
 
 # Install windmill CLI (node symlink needed for bun install)
 RUN ln -s /usr/bin/bun /usr/bin/node \


### PR DESCRIPTION
## Summary
Upgrade Bun from v1.3.8 to v1.3.10 across all Dockerfiles and CI workflows.

## Changes
- Update `Dockerfile` to use `oven/bun:1.3.10`
- Update `docker/DockerfileSlim` to use `oven/bun:1.3.10`
- Update `docker/DockerfileSlimEe` to use `oven/bun:1.3.10`
- Update `.github/DockerfileBackendTests` to use `oven/bun:1.3.10`
- Update `.github/workflows/backend-test.yml` to use `bun-version: 1.3.10`

## Test plan
- [ ] CI backend tests pass with new Bun version
- [ ] Docker images build successfully

---
Generated with [Claude Code](https://claude.com/claude-code)