### PR TITLE
fix: prevent path editor reload and layout shift in summary popover

### DIFF
--- a/frontend/src/lib/components/SummaryPathDisplay.svelte
+++ b/frontend/src/lib/components/SummaryPathDisplay.svelte
@@ -8,6 +8,7 @@
 	import { sendUserToast } from '$lib/toast'
 	import { updateItemPathAndSummary, checkFlowOnBehalfOf } from './moveRenameManager'
 	import Label from './Label.svelte'
+	import { untrack } from 'svelte'
 
 	interface Props {
 		summary?: string
@@ -35,16 +36,20 @@
 	let hasChanges = $derived(editSummary !== (summary ?? '') || (own && dirtyPath))
 
 	$effect(() => {
-		if (popoverOpen && onSaved) {
-			editSummary = summary ?? ''
-			editPath = path ?? ''
-			own = isOwner(path ?? '', $userStore, $workspaceStore)
-			onBehalfOfEmail = undefined
-			if (kind === 'flow' && $workspaceStore && path) {
-				checkFlowOnBehalfOf($workspaceStore, path).then((email) => {
-					onBehalfOfEmail = email
-				})
-			}
+		if (popoverOpen) {
+			untrack(() => {
+				if (onSaved) {
+					editSummary = summary ?? ''
+					editPath = path ?? ''
+					own = isOwner(path ?? '', $userStore, $workspaceStore)
+					onBehalfOfEmail = undefined
+					if (kind === 'flow' && $workspaceStore && path) {
+						checkFlowOnBehalfOf($workspaceStore, path).then((email) => {
+							onBehalfOfEmail = email
+						})
+					}
+				}
+			})
 		}
 	})
 


### PR DESCRIPTION
## Summary
Fix two issues in the SummaryPathDisplay popover related to the Path component.

## Changes
- Wrap `$effect` body in `untrack()` so only `popoverOpen` is tracked — prevents the Path component from reinitializing on every keystroke in the summary input
- Add a fixed-height placeholder with inline loader in Path.svelte while `meta` is loading, preventing layout shift when the path editor appears

## Test plan
- [ ] Open a flow/script, click the summary/path area to open the popover
- [ ] Type in the summary input — the path editor should NOT reload
- [ ] Verify the popover does not shift when the path editor loads

---
Generated with [Claude Code](https://claude.com/claude-code)