### PR TITLE
fix: skip stop_after_if evaluation for skipped (identity) flow steps

### DIFF
--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -554,9 +554,7 @@ pub async fn update_flow_status_after_job_completion_internal(
         // as an identity job.  We must skip the stop_after_if evaluation in that
         // case because the result is just a pass-through of the previous step's
         // result, not the output of the actual step logic.
-        let is_identity_job = if current_module
-            .is_some_and(|m| m.skip_if.is_some() && m.stop_after_if.is_some())
-        {
+        let is_identity_job = if current_module.is_some_and(|m| m.skip_if.is_some()) {
             sqlx::query_scalar!(
                 "SELECT kind = 'identity' FROM v2_job WHERE id = $1",
                 job_id_for_status


### PR DESCRIPTION
## Summary
- When a flow step has both `skip_if` and `stop_after_if` configured and the skip condition is true, the step runs as an identity (pass-through) job. Previously, the `stop_after_if` expression was still evaluated against the pass-through result, which could produce a QuickJS evaluation error.
- Pre-computes whether the completed job was an identity job before the `stop_after_if` evaluation, and skips the evaluation entirely for skipped steps.
- Reuses the pre-computed `is_identity_job` flag in the existing `is_skipped` determination, eliminating a redundant DB query.

## Test plan
- [ ] Create a flow with a step that has both "Skip" (`skip_if`) and "Stop flow early" (`stop_after_if`) enabled
- [ ] Set the skip condition to evaluate to `true`
- [ ] Run the flow and verify no QuickJS evaluation error occurs
- [ ] Verify the step is correctly marked as skipped in the flow status
- [ ] Verify flows without `skip_if` still evaluate `stop_after_if` normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)