### PR TITLE
fix: prevent async lock gen race condition in mixed case path CI tests

### DIFF
--- a/cli/test/mixed_case_paths.test.ts
+++ b/cli/test/mixed_case_paths.test.ts
@@ -64,6 +64,9 @@ async function createScript(
     language: "bun",
     is_template: false,
     kind: "script",
+    // Provide a non-empty lock to prevent async lock generation by the backend
+    // worker, which causes flaky tests due to race conditions on Windows CI.
+    lock: "\n",
     schema: {
       $schema: "https://json-schema.org/draft/2020-12/schema",
       type: "object",
@@ -255,6 +258,12 @@ async function verifyNoDiffOnPull(backend: any, tempDir: string): Promise<void> 
   const output = parseJsonFromCLIOutput(pullResult.stdout);
   const changes = output.changes || [];
 
+  if (changes.length > 0) {
+    console.error(
+      `Unexpected changes on dry-run pull (expected 0, got ${changes.length}):`,
+      JSON.stringify(changes, null, 2)
+    );
+  }
   expect(changes.length).toEqual(0);
 }
 


### PR DESCRIPTION
## Summary
Fix flaky Windows CI test in `mixed_case_paths.test.ts` caused by async lock generation race condition.

When scripts are created via the API without a `lock` field, the backend enqueues an async dependency resolution job. This creates a timing-dependent race:
1. Test creates scripts → async lock gen starts
2. Test pulls → gets null or generated lock depending on worker timing
3. Test pushes modified scripts with whatever lock was pulled → may trigger another async lock gen
4. Dry-run pull → may see different lock state than local → reports 2 unexpected changes

## Changes
- Add `lock: "\n"` to `createScript()` helper — a non-empty lock prevents the backend from spawning async lock generation (`needs_lock_gen` is only true when `lock.is_none()`)
- Add diagnostic logging to `verifyNoDiffOnPull()` to print actual changes when the assertion fails, making future failures easier to debug

## Test plan
- [ ] Windows CI `mixed_case_paths.test.ts` passes consistently (no more flakes on "multiple resources in same capitalized folder" test)
- [ ] Linux CI `mixed_case_paths.test.ts` continues to pass

---
Generated with [Claude Code](https://claude.com/claude-code)