### PR TITLE
fix(frontend): prevent subflow expansion from hiding all insertion points

### DIFF
--- a/frontend/src/lib/components/graph/graphBuilder.svelte.ts
+++ b/frontend/src/lib/components/graph/graphBuilder.svelte.ts
@@ -422,10 +422,6 @@ export function graphBuilder(
 				throw new Error(`Duplicated node detected: ${module.id}`)
 			}
 
-			if (module.id.startsWith('subflow:')) {
-				extra.insertable = false
-			}
-
 			nodes.push({
 				id: module.id,
 				data: {
@@ -436,7 +432,7 @@ export function graphBuilder(
 					eventHandlers: eventHandlers,
 					flowModuleState: extra.flowModuleStates?.[module.id],
 					testModuleState: extra.testModuleStates?.states?.[module.id],
-					insertable: extra.insertable,
+					insertable: extra.insertable && !module.id.startsWith('subflow:'),
 					editMode: extra.editMode,
 					isOwner: extra.isOwner,
 					flowJob: extra.flowJob,
@@ -968,11 +964,15 @@ export function graphBuilder(
 							nodes.push(startNode)
 
 							if (previousId) {
-								addEdge(previousId!, startNode.id, undefined, prefix, {
-									type: 'empty'
+								addEdge(previousId, startNode.id, branch, prefix, {
+									subModules: modules,
+									disableMoveIds
 								})
 							} else {
-								addEdge(beforeNode.id, startNode.id, undefined, prefix, { type: 'empty' })
+								addEdge(beforeNode.id, startNode.id, undefined, prefix, {
+									subModules: modules,
+									disableMoveIds
+								})
 							}
 
 							const endId = `${module.id}-subflow-end`


### PR DESCRIPTION
## Summary
When expanding a subflow in the flow editor, all insertion points (the "+" buttons between steps) disappeared — not just those inside the expanded subflow. This made it impossible to add new steps anywhere in the flow while a subflow was expanded.

## Changes
- Stop mutating the shared `extra.insertable` flag when processing subflow nodes — compute `insertable` per-node instead (`extra.insertable && !module.id.startsWith('subflow:')`)
- Replace `type: 'empty'` edges leading into expanded subflows with normal edges carrying `subModules`/`disableMoveIds`, so the insertion button before an expanded subflow remains visible

## Test plan
- [ ] Create a flow with multiple steps including a subflow step
- [ ] Expand the subflow and verify insertion points are still visible between parent flow steps
- [ ] Verify insertion points are NOT visible inside the expanded subflow
- [ ] Verify the insertion point right before the expanded subflow is visible
- [ ] Collapse the subflow and verify insertion points are still correct

---
Generated with [Claude Code](https://claude.com/claude-code)