### PR TITLE
fix: clean up slow-load toast interval on component destroy

### DIFF
--- a/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
+++ b/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
@@ -666,6 +666,11 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 		if (intervalId) {
 			clearInterval(intervalId)
 		}
+		if (slowStreamIntervalId) {
+			clearInterval(slowStreamIntervalId)
+			slowStreamIntervalId = undefined
+		}
+		paramChangePromise?.cancel()
 	})
 	$effect(() => {
 		Object.keys(filters ?? {}).map((k) => filters?.[k as keyof RunsFilterInstance])


### PR DESCRIPTION
## Summary
- Fixed "Loading is taking a long time..." toasts persisting after navigating away from the runs page
- The `slowStreamIntervalId` interval (fires every 15s) was not cleared in `onDestroy`, so it kept firing indefinitely after the component was torn down
- Also cancel in-flight `paramChangePromise` on destroy for completeness

## Test plan
- [ ] Navigate to runs page with a slow-loading query
- [ ] While "Loading is taking a long time..." toast appears, navigate away
- [ ] Verify no further toasts appear after leaving the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)