### PR TITLE
feat(frontend): add full-code app import with tabbed format selection

### DIFF
--- a/frontend/src/lib/components/flows/CreateActionsApp.svelte
+++ b/frontend/src/lib/components/flows/CreateActionsApp.svelte
@@ -5,6 +5,8 @@
 	import { Button } from '$lib/components/common'
 	import Drawer from '$lib/components/common/drawer/Drawer.svelte'
 	import DrawerContent from '$lib/components/common/drawer/DrawerContent.svelte'
+	import Tabs from '$lib/components/common/tabs/Tabs.svelte'
+	import Tab from '$lib/components/common/tabs/Tab.svelte'
 	import Modal from '$lib/components/common/modal/Modal.svelte'
 	import { LayoutDashboard, Loader2, Plus, Code2 } from 'lucide-svelte'
 	import { importStore } from '../apps/store'
@@ -14,12 +16,21 @@
 	let pendingRaw: string = $state('')
 
 	let importType: 'yaml' | 'json' = $state('yaml')
+	let appKind: 'lowcode' | 'fullcode' = $state('lowcode')
 
 	let appTypeModalOpen = $state(false)
 
 	async function importRaw() {
-		$importStore = importType === 'yaml' ? YAML.parse(pendingRaw) : JSON.parse(pendingRaw)
-		await goto('/apps/add?nodraft=true')
+		const parsed = importType === 'yaml' ? YAML.parse(pendingRaw) : JSON.parse(pendingRaw)
+		if (appKind === 'fullcode') {
+			// Navigation to /apps_raw/add triggers a full page reload (for cross-origin isolation),
+			// so the in-memory importStore would be lost. Use sessionStorage instead.
+			sessionStorage.setItem('rawAppImport', JSON.stringify(parsed))
+			await goto('/apps_raw/add?nodraft=true')
+		} else {
+			$importStore = parsed
+			await goto('/apps/add?nodraft=true')
+		}
 		drawer?.closeDrawer?.()
 	}
 
@@ -51,17 +62,19 @@
 			variant="accent"
 			dropdownItems={[
 				{
-					label: 'Import low-code app from YAML',
+					label: 'Import low-code app',
 					onClick: () => {
-						drawer?.toggleDrawer?.()
+						appKind = 'lowcode'
 						importType = 'yaml'
+						drawer?.toggleDrawer?.()
 					}
 				},
 				{
-					label: 'Import low-code app from JSON',
+					label: 'Import full-code app',
 					onClick: () => {
+						appKind = 'fullcode'
+						importType = 'yaml'
 						drawer?.toggleDrawer?.()
-						importType = 'json'
 					}
 				}
 			]}
@@ -118,22 +131,32 @@
 	</div>
 </Modal>
 
-<!-- Raw JSON -->
+<!-- Import Drawer -->
 <Drawer bind:this={drawer} size="800px">
 	<DrawerContent
-		title={'Import low-code app from ' + (importType === 'yaml' ? 'YAML' : 'JSON')}
+		title={appKind === 'fullcode' ? 'Import full-code app' : 'Import low-code app'}
 		on:close={() => drawer?.toggleDrawer?.()}
 	>
-		{#await import('$lib/components/SimpleEditor.svelte')}
-			<Loader2 class="animate-spin" />
-		{:then Module}
-			<Module.default
-				bind:code={pendingRaw}
-				lang={importType}
-				class="h-full"
-				fixedOverflowWidgets={false}
-			/>
-		{/await}
+		<Tabs bind:selected={importType}>
+			<Tab value="yaml" label="YAML" />
+			<Tab value="json" label="JSON" />
+			{#snippet content()}
+				<div class="relative pt-2 h-full">
+					{#key importType}
+						{#await import('$lib/components/SimpleEditor.svelte')}
+							<Loader2 class="animate-spin" />
+						{:then Module}
+							<Module.default
+								bind:code={pendingRaw}
+								lang={importType}
+								class="h-full"
+								fixedOverflowWidgets={false}
+							/>
+						{/await}
+					{/key}
+				</div>
+			{/snippet}
+		</Tabs>
 		{#snippet actions()}
 			<Button size="sm" on:click={importRaw}>Import</Button>
 		{/snippet}

--- a/frontend/src/routes/(root)/(logged)/apps_raw/add/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps_raw/add/+page.svelte
@@ -41,9 +41,17 @@
 	const templateId = $page.url.searchParams.get('template_id')
 	const hubId = $page.url.searchParams.get('hub')
 
-	const importRaw = $importStore
+	// Check in-memory store first, then sessionStorage (used when full page reload occurs)
+	let importRaw = $importStore
 	if ($importStore) {
 		$importStore = undefined
+	}
+	if (!importRaw) {
+		const sessionData = sessionStorage.getItem('rawAppImport')
+		if (sessionData) {
+			sessionStorage.removeItem('rawAppImport')
+			importRaw = JSON.parse(sessionData)
+		}
 	}
 
 	const appState = nodraft || hubId ? undefined : localStorage.getItem('rawapp')
@@ -189,7 +197,7 @@
 			files: svelte5Template
 		}
 	]
-	let templatePicker = $state(nodraft != null)
+	let templatePicker = $state(nodraft != null && !importRaw)
 	let reloadCounter = $state(0)
 
 	// Modal state


### PR DESCRIPTION
## Summary
- Combine YAML/JSON import options into a single drawer with tabbed format selection (YAML as default)
- Add "Import full-code app" dropdown option alongside existing low-code import
- Use `sessionStorage` to persist import data across full page reload (required by cross-origin isolation headers for `/apps_raw/add`)
- Skip template picker modal when importing

## Test plan
- [ ] Open home page → App dropdown → "Import low-code app" → verify drawer with YAML/JSON tabs, paste YAML, import → lands on low-code app editor
- [ ] Open home page → App dropdown → "Import full-code app" → paste raw app YAML, import → lands on full-code app editor with imported content
- [ ] Verify switching between YAML/JSON tabs re-mounts the editor with correct language

🤖 Generated with [Claude Code](https://claude.com/claude-code)