### PR TITLE
fix: handle multipart stream errors gracefully instead of panicking

### DIFF
--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -993,9 +993,18 @@ macro_rules! process_app_multipart {
             let mut uploaded_js = false;
 
             let mut multipart = $multipart;
-            while let Some(field) = multipart.next_field().await.unwrap() {
-                let name = field.name().unwrap().to_string();
-                let data = field.bytes().await.unwrap();
+            while let Some(field) = multipart
+                .next_field()
+                .await
+                .map_err(|e| Error::BadRequest(format!("failed to read multipart field: {e}")))?
+            {
+                let name = field
+                    .name()
+                    .ok_or_else(|| Error::BadRequest("multipart field missing name".to_string()))?
+                    .to_string();
+                let data = field.bytes().await.map_err(|e| {
+                    Error::BadRequest(format!("failed to read multipart stream: {e}"))
+                })?;
                 if name == "app" {
                     let app = serde_json::from_slice(&data).map_err(to_anyhow)?;
                     let (ntx, npath, nid) = $internal_fn(
@@ -2149,7 +2158,8 @@ async fn execute_component(
         (email.as_str(), permissioned_as)
     };
 
-    let end_user_email = get_end_user_email(&db, opt_authed.as_ref(), tokened.token.as_deref()).await;
+    let end_user_email =
+        get_end_user_email(&db, opt_authed.as_ref(), tokened.token.as_deref()).await;
 
     let (uuid, mut tx) = push(
         &db,


### PR DESCRIPTION
## Summary
Replace `.unwrap()` calls in the `process_app_multipart!` macro with proper error handling to prevent panics when multipart stream reads fail (e.g., interrupted uploads, corrupted chunks).

## Changes
- `next_field().await.unwrap()` → `.map_err()` with `Error::BadRequest`
- `field.name().unwrap()` → `.ok_or_else()` with `Error::BadRequest`
- `field.bytes().await.unwrap()` → `.map_err()` with `Error::BadRequest`

All three now return a 400 response with a descriptive error message instead of panicking and returning a 500.

## Test plan
- [ ] Upload an app with a valid multipart payload — should succeed as before
- [ ] Interrupt/abort an app upload mid-stream — should return 400 instead of panicking

---
Generated with [Claude Code](https://claude.com/claude-code)