### PR TITLE
fix: prevent slow loading toast interval from leaking on promise cancellation

### DIFF
--- a/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
+++ b/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
@@ -133,7 +133,7 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 				])
 			})
 		}
-		promise = CancelablePromiseUtils.pipe(promise, () => {
+		promise = CancelablePromiseUtils.finallyDo(promise, () => {
 			if (slowStreamIntervalId) {
 				clearInterval(slowStreamIntervalId)
 				slowStreamIntervalId = undefined
@@ -161,7 +161,7 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 			)
 		}, 15000)
 		paramChangePromise = loadJobsIntern(false, size)
-		paramChangePromise = CancelablePromiseUtils.pipe(paramChangePromise, () => {
+		paramChangePromise = CancelablePromiseUtils.finallyDo(paramChangePromise, () => {
 			if (slowStreamIntervalId) {
 				clearInterval(slowStreamIntervalId)
 				slowStreamIntervalId = undefined
@@ -687,6 +687,10 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 		return () => {
 			clearTimeout(paramChangeTimeout)
 			paramChangePromise?.cancel()
+			if (slowStreamIntervalId) {
+				clearInterval(slowStreamIntervalId)
+				slowStreamIntervalId = undefined
+			}
 		}
 	})
 	$effect(() => {


### PR DESCRIPTION
## Summary
Fix the "Loading is taking a long time..." toast repeatedly appearing after navigating away from the runs page. The `slowStreamIntervalId` interval was only cleaned up on promise success, so cancelling the promise (e.g., navigating away) leaked the interval.

## Changes
- Changed `CancelablePromiseUtils.pipe` → `finallyDo` in `onParamChanges()` and `restreamWithBatchSize()` so the interval cleanup runs on success, error, AND cancellation
- Added `slowStreamIntervalId` cleanup to the `$effect` cleanup function for defense-in-depth

## Test plan
- [ ] Open the Runs page, then navigate to the script editor before jobs finish loading — verify no "Loading is taking a long time..." toast appears
- [ ] On the Runs page with slow job loading (>15s), verify the toast still appears correctly
- [ ] Click "Stop loading" on the toast and verify it stops

---
Generated with [Claude Code](https://claude.com/claude-code)