### PR TITLE
fix: sql input horizontal scroll missing after switching flow steps

### DIFF
--- a/frontend/src/lib/components/TemplateEditor.svelte
+++ b/frontend/src/lib/components/TemplateEditor.svelte
@@ -438,7 +438,6 @@
 	let cip
 	let extraModel
 
-	let width = $state(0)
 	// let widgets: HTMLElement | undefined = document.getElementById('monaco-widgets-root') ?? undefined
 
 	let initialized = $state(false)
@@ -545,9 +544,6 @@
 				if (divEl) {
 					divEl.style.height = `${contentHeight}px`
 				}
-				try {
-					editor?.layout({ width, height: contentHeight })
-				} catch {}
 			}
 			editor.onDidContentSizeChange(updateHeight)
 			updateHeight()
@@ -718,7 +714,6 @@
 		bind:this={divEl}
 		style="height: 18px;"
 		class="template nonmain-editor rounded-md overflow-clip {!editor ? 'hidden' : ''}"
-		bind:clientWidth={width}
 	></div>
 </div>
 


### PR DESCRIPTION
## Summary
Fix horizontal scrollbar not appearing on `wmill.Sql` (and other template) inputs in flow steps after switching to another step and back.

## Changes
- Remove manual `editor.layout()` call from TemplateEditor's `autoHeight` handler, letting Monaco's built-in `automaticLayout` (ResizeObserver) handle layout instead

The root cause: when TemplateEditor remounts, Monaco is created inside a `hidden` (`display: none`) div, so `width` is `0`. The manual `layout(0, contentHeight)` call told Monaco it had zero width. On first use this was harmless (user types after the div becomes visible), but on remount with existing content, no `onDidContentSizeChange` event fired to correct the stale dimensions.

## Test plan
- [x] Create a flow step with a `wmill.Sql` input, type a long SQL line, switch to another step, switch back — horizontal scrollbar should persist
- [x] Verify string and YAML template inputs in flow steps still auto-resize height correctly
- [x] Verify template expressions in the app builder still work
- [x] Resize the flow editor splitpane while a template input is visible — editor should adapt

---
Generated with [Claude Code](https://claude.com/claude-code)