### PR TITLE
fix(front): unsaved changes dialog when flow already saved

### DIFF
--- a/frontend/src/lib/components/flows/FlowAssetsHandler.svelte
+++ b/frontend/src/lib/components/flows/FlowAssetsHandler.svelte
@@ -130,7 +130,8 @@
 			const old = v.assets?.find((a) => assetEq(a, asset))
 			if (old?.alt_access_type) asset.alt_access_type = old.alt_access_type
 		}
-		if (!deepEqual(v.assets, newAssets)) v.assets = newAssets
+		const normalizedAssets = newAssets.length > 0 ? newAssets : undefined
+		if (!deepEqual(v.assets, normalizedAssets)) v.assets = normalizedAssets
 	}
 
 	// Check for raw script modules whose assets were not parsed. Useful for flows created


### PR DESCRIPTION
Avoid "Unsaved changes" modal opening when changes are saved in a flow after adding a script. `assets` was not defined when adding a script, and `parseAndUpdateRawScriptModule` would always set it to an empty array, creating a difference between current and saved value

https://github.com/user-attachments/assets/4fcaa210-564f-43b8-b31f-adcfffcccfcb

