### PR TITLE
fix: darkMode props_invalid_value in flows/dev/+page.svelte

### DIFF
--- a/frontend/src/routes/flows/dev/+page.svelte
+++ b/frontend/src/routes/flows/dev/+page.svelte
@@ -52,7 +52,7 @@
 	}
 
 	let darkModeToggle: DarkModeToggle | undefined = $state()
-	let darkMode: boolean | undefined = $state(undefined)
+	let darkMode: boolean = $state(document.documentElement.classList.contains('dark'))
 	let modeInitialized = $state(false)
 	function initializeMode() {
 		modeInitialized = true


### PR DESCRIPTION
## Summary
Same fix as #8260 but for `flows/dev/+page.svelte` — the flow dev panel (VS Code extension) had the identical `darkMode = $state(undefined)` bug.

## Changes
- Initialize `darkMode` in `flows/dev/+page.svelte` to `document.documentElement.classList.contains('dark')` instead of `undefined`

## Test plan
- [ ] Open a flow in VS Code with the Windmill extension and verify the dev panel renders without console errors

---
Generated with [Claude Code](https://claude.com/claude-code)