### PR TITLE
fix: mask secrets in OAuth config debug/log output

### DIFF
--- a/backend/windmill-common/src/instance_config.rs
+++ b/backend/windmill-common/src/instance_config.rs
@@ -44,13 +44,23 @@ pub struct EnvRefWrapper {
 ///
 /// `Literal` serializes back to a plain JSON string, preserving backwards
 /// compatibility with existing consumers.
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone)]
 #[cfg_attr(feature = "instance_config_schema", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum StringOrSecretRef {
     Literal(String),
     SecretRef(SecretKeyRefWrapper),
     EnvRef(EnvRefWrapper),
+}
+
+impl fmt::Debug for StringOrSecretRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Literal(_) => f.write_str("Literal(****)"),
+            Self::SecretRef(w) => f.debug_tuple("SecretRef").field(w).finish(),
+            Self::EnvRef(w) => f.debug_tuple("EnvRef").field(w).finish(),
+        }
+    }
 }
 
 impl StringOrSecretRef {

--- a/backend/windmill-oauth/src/lib.rs
+++ b/backend/windmill-oauth/src/lib.rs
@@ -94,7 +94,7 @@ pub struct OAuthConfig {
 }
 
 /// OAuth client credentials
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct OAuthClient {
     #[serde(default = "empty_string")]
     pub id: String,
@@ -108,6 +108,21 @@ pub struct OAuthClient {
     pub tenant: Option<String>,
     #[serde(default = "default_grant_types")]
     pub grant_types: Vec<String>,
+}
+
+impl std::fmt::Debug for OAuthClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OAuthClient")
+            .field("id", &self.id)
+            .field("secret", &"***")
+            .field("display_name", &self.display_name)
+            .field("allowed_domains", &self.allowed_domains)
+            .field("connect_config", &self.connect_config)
+            .field("login_config", &self.login_config)
+            .field("tenant", &self.tenant)
+            .field("grant_types", &self.grant_types)
+            .finish()
+    }
 }
 
 fn empty_string() -> String {
@@ -608,7 +623,18 @@ pub async fn refresh_token<'c>(
     .await?;
     let account = windmill_common::utils::not_found_if_none(account, "Account", &id.to_string())?;
 
-    refresh_token_for_account(tx, path, w_id, id, db, account, oauth_clients, http_client, connect_configs_json).await
+    refresh_token_for_account(
+        tx,
+        path,
+        w_id,
+        id,
+        db,
+        account,
+        oauth_clients,
+        http_client,
+        connect_configs_json,
+    )
+    .await
 }
 
 /// Refresh an OAuth token given pre-fetched account info (no additional SELECT).


### PR DESCRIPTION
## Summary
The `tracing::info!("Using OAuth clients from config: {oauths:?}")` log line was printing OAuth client secrets in plaintext. This PR adds custom `Debug` implementations that mask secret values.

## Changes
- Replace derived `Debug` on `windmill_oauth::OAuthClient` with a manual impl that prints `"***"` for the `secret` field
- Replace derived `Debug` on `StringOrSecretRef` with a manual impl that prints `Literal(****)` for literal secret values, protecting all config structs that use it (SMTP password, license key, SCIM token, hub API secret, etc.)

## Test plan
- [ ] Set OAuth clients via instance config and verify the "Using OAuth clients from config" log line masks secrets
- [ ] Verify `StringOrSecretRef` debug output shows `Literal(****)` instead of the actual value

---
Generated with [Claude Code](https://claude.com/claude-code)