### PR TITLE
fix: skip down migrations in potentially_stale checksum comparison

### DIFF
--- a/backend/windmill-api/src/db.rs
+++ b/backend/windmill-api/src/db.rs
@@ -284,6 +284,9 @@ pub async fn migrate(
         20260207000004,
     ];
     for m in migrator.migrations.iter() {
+        if m.migration_type.is_down_migration() {
+            continue;
+        }
         if potentially_stale.contains(&m.version) {
             if let Err(err) =
                 sqlx::query("DELETE FROM _sqlx_migrations WHERE version = $1 AND checksum != $2")


### PR DESCRIPTION
## Summary
Fixes concurrent index migrations (20260207000001–4) re-running on every backend startup.

The `potentially_stale` block in `db.rs` iterates `migrator.migrations.iter()` which, in sqlx 0.8.x with reversible migrations, yields both `.up.sql` and `.down.sql` entries sharing the same version number but with different checksums. When the down migration's checksum was compared against the stored up migration's checksum, the mismatch caused the `DELETE` to remove the row, forcing re-application on every start.

## Changes
- Skip down migrations (`m.migration_type.is_down_migration()`) in the `potentially_stale` loop, matching what sqlx's own `run_direct` does internally

## Test plan
- [x] Backend starts without "Started applying migration 20260207000001" log
- [x] Migration rows in `_sqlx_migrations` are preserved across restarts
- [x] Health checks pass after startup

---
Generated with [Claude Code](https://claude.com/claude-code)