### PR TITLE
feat: expose OTEL trace context as env vars in job execution

### DIFF
--- a/backend/windmill-worker/src/java_executor.rs
+++ b/backend/windmill-worker/src/java_executor.rs
@@ -618,6 +618,7 @@ async fn run<'a>(
             .env("BASE_INTERNAL_URL", base_internal_url)
             .envs(envs)
             .envs(reserved_variables)
+            .envs(crate::get_otel_context_envs(&job.id))
             .args(vec![
                 "--config",
                 "run.config.proto",
@@ -675,7 +676,8 @@ async fn run<'a>(
             .env("HOME", &*JAVA_HOME_DIR)
             .env("BASE_INTERNAL_URL", base_internal_url)
             .envs(envs)
-            .envs(reserved_variables);
+            .envs(reserved_variables)
+            .envs(crate::get_otel_context_envs(&job.id));
         if metadata(TRUST_STORE_PATH.clone()).await.is_ok() {
             cmd.args(&[
                 &format!("-Djavax.net.ssl.trustStore={}", *TRUST_STORE_PATH),

--- a/backend/windmill-worker/src/php_executor.rs
+++ b/backend/windmill-worker/src/php_executor.rs
@@ -22,7 +22,7 @@ use crate::{
         get_reserved_variables, read_result, start_child_process, MaybeLock, OccupancyMetrics,
     },
     handle_child::handle_child,
-    COMPOSER_CACHE_DIR, COMPOSER_PATH, is_sandboxing_enabled, DISABLE_NUSER, NSJAIL_PATH, PHP_PATH,
+    is_sandboxing_enabled, COMPOSER_CACHE_DIR, COMPOSER_PATH, DISABLE_NUSER, NSJAIL_PATH, PHP_PATH,
 };
 use windmill_common::client::AuthedClient;
 
@@ -316,6 +316,7 @@ try {{
             .env_clear()
             .envs(envs)
             .envs(reserved_variables)
+            .envs(crate::get_otel_context_envs(&job.id))
             .env("COMPOSER_HOME", &*COMPOSER_CACHE_DIR)
             .env("BASE_INTERNAL_URL", base_internal_url)
             .args(args)
@@ -332,6 +333,7 @@ try {{
             .env_clear()
             .envs(envs)
             .envs(reserved_variables)
+            .envs(crate::get_otel_context_envs(&job.id))
             .env("COMPOSER_HOME", &*COMPOSER_CACHE_DIR)
             .env("BASE_INTERNAL_URL", base_internal_url)
             .stdin(Stdio::null())

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -740,6 +740,24 @@ pub async fn is_otel_tracing_proxy_enabled_for_lang(lang: &ScriptLang) -> bool {
     }
 }
 
+/// Get OTEL trace context environment variables for a job (TRACEPARENT, OTEL_TRACE_ID, OTEL_SPAN_ID).
+/// Returns an empty vec when OTEL tracing is not enabled or on non-enterprise builds.
+pub fn get_otel_context_envs(job_id: &uuid::Uuid) -> Vec<(&'static str, String)> {
+    #[cfg(all(feature = "private", feature = "enterprise"))]
+    if windmill_common::OTEL_TRACING_ENABLED.load(std::sync::atomic::Ordering::Relaxed) {
+        let trace_id = format!("{:032x}", job_id.as_u128());
+        let span_id = format!("{:016x}", job_id.as_u64_pair().1);
+        let traceparent = format!("00-{}-{}-01", trace_id, span_id);
+        return vec![
+            ("TRACEPARENT", traceparent),
+            ("OTEL_TRACE_ID", trace_id),
+            ("OTEL_SPAN_ID", span_id),
+        ];
+    }
+    let _ = job_id;
+    vec![]
+}
+
 /// Get proxy environment variables for job execution for a specific language.
 /// When OTEL tracing proxy is enabled for this language, routes all traffic through the proxy.
 /// Otherwise, uses the standard HTTP_PROXY/HTTPS_PROXY from environment.
@@ -749,12 +767,21 @@ pub async fn get_proxy_envs_for_lang(
     w_id: &str,
     conn: &Connection,
 ) -> anyhow::Result<Vec<(&'static str, String)>> {
+    #[allow(unused_mut)]
+    let mut envs;
     #[cfg(all(feature = "private", feature = "enterprise"))]
     if is_otel_tracing_proxy_enabled_for_lang(lang).await {
-        return get_otel_tracing_proxy_envs(job_id, w_id, conn).await;
+        envs = get_otel_tracing_proxy_envs(job_id, w_id, conn).await?;
+    } else {
+        envs = PROXY_ENVS.clone();
     }
-    let _ = (lang, job_id, w_id, conn);
-    Ok(PROXY_ENVS.clone())
+    #[cfg(not(all(feature = "private", feature = "enterprise")))]
+    {
+        let _ = (lang, w_id, conn);
+        envs = PROXY_ENVS.clone();
+    }
+    envs.extend(get_otel_context_envs(job_id));
+    Ok(envs)
 }
 
 #[cfg(all(feature = "private", feature = "enterprise"))]


### PR DESCRIPTION
## Summary
When OTEL tracing is enabled on enterprise, expose the job's traceId and spanId as environment variables (`TRACEPARENT`, `OTEL_TRACE_ID`, `OTEL_SPAN_ID`) in all job executions. This allows user scripts to propagate trace context to downstream services.

## Changes
- Added `get_otel_context_envs(job_id)` helper in `worker.rs` that returns OTEL context env vars when enterprise + OTEL tracing is enabled, empty vec otherwise
- Modified `get_proxy_envs_for_lang()` to append OTEL context env vars (covers Python, Bash, Bun, Go, Deno, Rust, C#, Ruby, Nu)
- Added `.envs(get_otel_context_envs(&job.id))` to Java executor (sandboxed + non-sandboxed run commands)
- Added `.envs(get_otel_context_envs(&job.id))` to PHP executor (sandboxed + non-sandboxed run commands)

### Env vars exposed
- `TRACEPARENT` — W3C Trace Context format: `00-{trace_id}-{span_id}-01`
- `OTEL_TRACE_ID` — hex-encoded trace ID (same as job UUID bytes)
- `OTEL_SPAN_ID` — hex-encoded span ID (derived from job UUID)

## Test plan
- [ ] Enable OTEL tracing on an enterprise instance
- [ ] Run a Python/Bash/TypeScript job that prints `TRACEPARENT`, `OTEL_TRACE_ID`, `OTEL_SPAN_ID` env vars
- [ ] Verify the trace_id matches the job UUID and the TRACEPARENT follows W3C format
- [ ] Verify env vars are NOT set when OTEL tracing is disabled

---
Generated with [Claude Code](https://claude.com/claude-code)