### PR TITLE
fix: warn about missing <clear /> in nuget config

### DIFF
--- a/backend/windmill-types/src/scripts.rs
+++ b/backend/windmill-types/src/scripts.rs
@@ -105,15 +105,15 @@ impl ScriptLang {
     pub fn is_native(&self) -> bool {
         matches!(
             self,
-            ScriptLang::Bunnative |
-            ScriptLang::Nativets |
-            ScriptLang::Postgresql |
-            ScriptLang::Mysql |
-            ScriptLang::Graphql |
-            ScriptLang::Snowflake |
-            ScriptLang::Mssql |
-            ScriptLang::Bigquery |
-            ScriptLang::OracleDB
+            ScriptLang::Bunnative
+                | ScriptLang::Nativets
+                | ScriptLang::Postgresql
+                | ScriptLang::Mysql
+                | ScriptLang::Graphql
+                | ScriptLang::Snowflake
+                | ScriptLang::Mssql
+                | ScriptLang::Bigquery
+                | ScriptLang::OracleDB
         )
     }
 
@@ -459,6 +459,7 @@ pub struct NewScript {
     pub path: String,
     pub parent_hash: Option<ScriptHash>,
     pub summary: String,
+    #[serde(default)]
     pub description: String,
     pub content: String,
     pub schema: Option<Schema>,

--- a/frontend/src/lib/components/InstanceSettings.svelte
+++ b/frontend/src/lib/components/InstanceSettings.svelte
@@ -1038,7 +1038,11 @@
 						{oauths}
 						warning={setting.key === 'base_url' && baseUrlIsFallback
 							? 'Auto-detected from browser — not yet saved'
-							: undefined}
+							: setting.key === 'nuget_config' &&
+								  $values['nuget_config'] &&
+								  !/<clear\s*\/>/.test($values['nuget_config'])
+								? 'Missing <clear /> in <packageSources>. Without it, default sources (like nuget.org) are merged with your custom sources, which is likely not what you want.'
+								: undefined}
 					/>
 				{/if}
 				{#if quickSetup && category === 'Core' && setting.key === 'base_url'}

--- a/frontend/src/lib/components/instanceSettings.ts
+++ b/frontend/src/lib/components/instanceSettings.ts
@@ -464,7 +464,8 @@ export const settings: Record<string, Setting[]> = {
 		},
 		{
 			label: 'Nuget Config',
-			description: 'Write a nuget.config file to set custom package sources and credentials',
+			description:
+				'Write a nuget.config file to set custom package sources and credentials. Use <clear /> inside <packageSources> to remove default sources and only use your custom ones',
 			key: 'nuget_config',
 			fieldType: 'codearea',
 			codeAreaLang: 'xml',


### PR DESCRIPTION
## Summary
- Add a warning in instance settings when a nuget config is set without `<clear />` in `<packageSources>`, since without it NuGet merges custom sources with defaults (like nuget.org), which is usually not what users want
- Update the nuget config setting description to mention `<clear />`
- Make `description` field optional (defaults to `""`) in the script create API to avoid unnecessary 400 errors

## Test plan
- [ ] Set a nuget config in instance settings without `<clear />` and verify the warning appears
- [ ] Set a nuget config with `<clear />` and verify no warning
- [ ] Create a script via API without the `description` field and verify it defaults to `""`

🤖 Generated with [Claude Code](https://claude.com/claude-code)