### PR TITLE
fix: skip loading flow preview history for new flows

### DIFF
--- a/frontend/src/lib/components/FlowHistoryJobPicker.svelte
+++ b/frontend/src/lib/components/FlowHistoryJobPicker.svelte
@@ -12,13 +12,15 @@
 		selected?: string | undefined
 		selectInitial?: boolean
 		loading?: boolean
+		newFlow?: boolean
 	}
 
 	let {
 		path,
 		selected = undefined,
 		selectInitial = false,
-		loading = $bindable(false)
+		loading = $bindable(false),
+		newFlow = false
 	}: Props = $props()
 	const dispatch = createEventDispatcher()
 
@@ -41,7 +43,9 @@
 	}
 
 	$effect(() => {
-		$workspaceStore && untrack(() => loadInitial())
+		if ($workspaceStore && !newFlow) {
+			untrack(() => loadInitial())
+		}
 	})
 </script>
 

--- a/frontend/src/lib/components/FlowPreviewContent.svelte
+++ b/frontend/src/lib/components/FlowPreviewContent.svelte
@@ -588,6 +588,7 @@
 				{/if}
 				<FlowHistoryJobPicker
 					selectInitial={jobId == undefined}
+					newFlow={$initialPathStore === ''}
 					on:select={(e) => {
 						if (!currentJobId) {
 							currentJobId = jobId
@@ -607,7 +608,9 @@
 				/>
 			</div>
 
-			<FlowProgressBar {job} bind:this={flowProgressBar} slim textPosition="bottom" showStepId />
+			{#if jobId}
+				<FlowProgressBar {job} bind:this={flowProgressBar} slim textPosition="bottom" showStepId />
+			{/if}
 
 			{#if job}
 				<div class="w-full my-6">
@@ -669,6 +672,10 @@
 			{:else if loadingHistory}
 				<div class="italic text-primary h-full grow mx-auto flex flex-row items-center gap-2">
 					<Loader2 class="animate-spin" /> <span> Loading history... </span>
+				</div>
+			{:else}
+				<div class="italic text-tertiary h-full grow mx-auto flex flex-row items-center">
+					Flow status will display here
 				</div>
 			{/if}
 		</div>


### PR DESCRIPTION
## Summary
- Skip initial history API call in flow preview for new (unsaved) flows to avoid unnecessary loading state
- Hide progress bar when no job is active or loaded
- Show "Flow status will display here" placeholder for empty state

## Test plan
- [ ] Create a new flow, open preview — no loading spinner, shows placeholder
- [ ] Run a preview on the new flow — progress bar and status viewer appear normally
- [ ] Open an existing flow's preview — history loads as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)