### PR TITLE
fix: handle missing schema in RunnableByPath during wmill.d.ts generation

### DIFF
--- a/frontend/src/lib/components/raw_apps/utils.ts
+++ b/frontend/src/lib/components/raw_apps/utils.ts
@@ -107,7 +107,11 @@ function hiddenRunnableToTsType(runnable: Runnable) {
 			return '{}'
 		}
 	} else if (isRunnableByPath(runnable)) {
-		return schemaToTsType(removeStaticFields(runnable?.schema, runnable?.fields ?? {}))
+		if (runnable?.schema) {
+			return schemaToTsType(removeStaticFields(runnable.schema, runnable?.fields ?? {}))
+		} else {
+			return '{}'
+		}
 	} else {
 		return '{}'
 	}


### PR DESCRIPTION
## Summary
Fixes CLI crash during native app bootstrap: `Failed to generate wmill.d.ts: Cannot read properties of undefined (reading properties)`.

When a native app uses a path-based runnable (e.g. `f/libs/.../some_script`), the schema may not be available yet during bootstrap. The `hiddenRunnableToTsType()` function was calling `removeStaticFields(runnable?.schema, ...)` without null-checking `schema`, causing `removeStaticFields` to crash on `schema.properties`.

## Changes
- Add null check for `runnable?.schema` on the `RunnableByPath` branch in `hiddenRunnableToTsType()`, matching the existing pattern used for inline scripts
- Return `'{}'` (empty type) when schema is missing, allowing `wmill.d.ts` generation to succeed

## Test plan
- [ ] Bootstrap a native React app that references a path-based runnable (e.g. `f/libs/transaction_manager/list_asset_app_allowlist_entries`)
- [ ] Verify `wmill.d.ts` is generated without errors
- [ ] Verify the generated types are correct once the schema is fetched on subsequent regeneration

---
Generated with [Claude Code](https://claude.com/claude-code)