### PR TITLE
fix: explicilty fail when --base-url --token  combination cannot authenticate

### DIFF
--- a/cli/src/commands/sync/pull.ts
+++ b/cli/src/commands/sync/pull.ts
@@ -51,10 +51,16 @@ export async function downloadZip(
   );
 
   if (!zipResponse.ok) {
-    console.log(
-      colors.red("Failed to request tarball from API " + zipResponse.statusText)
-    );
-    throw new Error(await zipResponse.text());
+    const body = await zipResponse.text();
+    if (zipResponse.status === 404 || body.includes("no rows returned")) {
+      log.info(colors.red(`Workspace '${workspace.workspaceId}' not found on ${workspace.remote}. Please check your --workspace and try again.`));
+    } else {
+      log.info(colors.red(`Failed to request tarball from API: ${zipResponse.status} ${zipResponse.statusText}`));
+      if (body) {
+        log.info(colors.red(body));
+      }
+    }
+    return process.exit(1);
   } else {
     log.debug(`Downloaded zip/tarball successfully`);
   }

--- a/cli/src/core/auth.ts
+++ b/cli/src/core/auth.ts
@@ -7,6 +7,7 @@ import { GlobalUserInfo } from "../../gen/types.gen.ts";
 import { loginInteractive, tryGetLoginInfo } from "./login.ts";
 import { GlobalOptions } from "../types.ts";
 
+
 /**
  * Main authentication function - moved from context.ts to break circular dependencies
  * This function maintains the original API signature from context.ts
@@ -33,6 +34,14 @@ export async function requireLogin(
     const errorMsg = error instanceof Error ? error.message : String(error);
     if (errorMsg.includes('fetch') || errorMsg.includes('connection') || errorMsg.includes('ECONNREFUSED') || errorMsg.includes('refused')) {
       throw new Error(`Network error: Could not connect to Windmill server at ${workspace.remote}`);
+    }
+
+    // If the user explicitly provided credentials via flags, fail immediately
+    // rather than falling back to interactive login — they expect their explicit
+    // credentials to work and should fix them if they don't.
+    if (opts.token || opts.baseUrl) {
+      log.info(colors.red("Could not authenticate with the provided credentials. Please check your --token and --base-url and try again."));
+      return process.exit(1);
     }
 
     log.info(


### PR DESCRIPTION
Currently when auth fails, interactive login is used as a fall back, which is confusing