### PR TITLE
fix: preserve teams oauth tenant on settings page reload

### DIFF
--- a/frontend/src/lib/components/OAuthSetting.svelte
+++ b/frontend/src/lib/components/OAuthSetting.svelte
@@ -89,7 +89,7 @@
 			disabled={eeOnly && !$enterpriseLicense}
 			on:change={(e) => {
 				if (e.detail) {
-					if (name === 'teams' || name === 'microsoft') {
+					if (name === 'teams') {
 						value = { id: '', secret: '', tenant: '' }
 					} else {
 						value = { id: '', secret: '' }


### PR DESCRIPTION
## Summary
- **Teams**: bind tenant input directly to `value['tenant']` — no intermediate state, no effects, no possible loops
- **Microsoft SSO**: keep bidirectional effect sync (tenant is embedded in login_config URLs), with loop termination guaranteed by URL round-trip idempotency (`split('/')[3]` of a URL constructed with tenant X always yields X)
- Remove `onMount` in favor of reactive `$effect` for Microsoft tenant sync

## Root cause
The `OAuthSetting` component initialized tenant from `value.tenant` inside `onMount()`. But `value` is `undefined` at mount time — the instance config API response hasn't arrived yet. By the time the binding propagates the loaded value, `onMount` has already executed and won't re-run.

## Test plan
- [ ] Set Teams OAuth with a tenant ID, save, reload the page — tenant should persist
- [ ] Set Microsoft SSO with a tenant ID, save, reload — tenant should persist
- [ ] Toggle Teams off then on — tenant field should reset to empty
- [ ] Clear the tenant field and save — should save as empty (not retain old value)

Generated with Claude Code