### PR TITLE
fix: teams selection not sticking in workspace settings

### DIFF
--- a/frontend/src/lib/components/ChannelSelector.svelte
+++ b/frontend/src/lib/components/ChannelSelector.svelte
@@ -26,7 +26,7 @@
 	let {
 		disabled = false,
 		placeholder = 'Select channel',
-		selectedChannel = $bindable(undefined),
+		selectedChannel = $bindable(),
 		containerClass = 'w-64',
 		minWidth = '160px',
 		channels = undefined,
@@ -39,8 +39,6 @@
 	let isFetching = $state(false)
 	let loadedChannels = $state<ChannelItem[]>([])
 	let loadedForTeamId = $state<string | undefined>(undefined)
-
-	let selectedChannelId = $state<string | undefined>(selectedChannel?.channel_id)
 
 	const searchMode = $derived(!channels && !!teamId)
 
@@ -55,21 +53,17 @@
 		return baseChannels
 	})
 
-	$effect(() => {
-		const newChannel = selectedChannelId
-			? displayChannels.find((c) => c.channel_id === selectedChannelId)
-			: undefined
-
-		if (newChannel?.channel_id !== selectedChannel?.channel_id) {
-			selectedChannel = newChannel
+	// Single setter to bridge Select's string value -> selectedChannel object.
+	function setSelectedChannelById(newId: string | undefined) {
+		if (newId) {
+			const channel = displayChannels.find((c) => c.channel_id === newId)
+			if (channel && channel.channel_id !== selectedChannel?.channel_id) {
+				selectedChannel = channel
+			}
+		} else if (selectedChannel !== undefined) {
+			selectedChannel = undefined
 		}
-	})
-
-	$effect(() => {
-		if (selectedChannel?.channel_id !== selectedChannelId) {
-			selectedChannelId = selectedChannel?.channel_id
-		}
-	})
+	}
 
 	let previousChannelId = $state<string | undefined>(undefined)
 
@@ -136,7 +130,10 @@
 						clearable
 						disabled={disabled || !teamId}
 						loading={isFetching}
-						bind:value={selectedChannelId}
+						bind:value={
+							() => selectedChannel?.channel_id,
+							(newId) => setSelectedChannelById(newId)
+						}
 					/>
 				{:else}
 					<Select
@@ -150,7 +147,10 @@
 						{placeholder}
 						clearable
 						disabled={disabled || displayChannels.length === 0}
-						bind:value={selectedChannelId}
+						bind:value={
+							() => selectedChannel?.channel_id,
+							(newId) => setSelectedChannelById(newId)
+						}
 					/>
 				{/if}
 			</div>

--- a/frontend/src/lib/components/TeamSelector.svelte
+++ b/frontend/src/lib/components/TeamSelector.svelte
@@ -45,8 +45,6 @@
 	let preSearchNextLink = $state<string | null>(null)
 	let preSearchTotalCount = $state(0)
 
-	let selectedTeamId = $state<string | undefined>(selectedTeam?.team_id)
-
 	const searchMode = $derived(!teams)
 
 	// Check if there are more teams to load (based on next_link presence)
@@ -62,21 +60,18 @@
 		return baseTeams
 	})
 
-	$effect(() => {
-		const newTeam = selectedTeamId
-			? displayTeams.find((t) => t.team_id === selectedTeamId)
-			: undefined
-
-		if (newTeam?.team_id !== selectedTeam?.team_id) {
-			selectedTeam = newTeam
+	// Single getter/setter to bridge Select's string value ↔ selectedTeam object.
+	// This replaces the previous two bidirectional $effect sync blocks.
+	function setSelectedTeamById(newId: string | undefined) {
+		if (newId) {
+			const team = displayTeams.find((t) => t.team_id === newId)
+			if (team && team.team_id !== selectedTeam?.team_id) {
+				selectedTeam = team
+			}
+		} else if (selectedTeam !== undefined) {
+			selectedTeam = undefined
 		}
-	})
-
-	$effect(() => {
-		if (selectedTeam?.team_id !== selectedTeamId) {
-			selectedTeamId = selectedTeam?.team_id
-		}
-	})
+	}
 
 	let previousTeamId = $state<string | undefined>(undefined)
 
@@ -120,6 +115,7 @@
 	})
 
 	function restorePreSearchState() {
+		debouncedSearch.clearDebounce()
 		searchRequestId++ // Invalidate any in-flight search
 		if (preSearchTeams !== null) {
 			// Restore the accumulated teams from before the search
@@ -262,7 +258,10 @@
 						disabled={disabled || isFetching}
 						loading={isFetching}
 						bind:filterText={searchFilterText}
-						bind:value={selectedTeamId}
+						bind:value={
+							() => selectedTeam?.team_id,
+							(newId) => setSelectedTeamById(newId)
+						}
 					/>
 				{:else}
 					<Select
@@ -274,7 +273,10 @@
 						placeholder="Select a team"
 						clearable
 						disabled={disabled || isFetching}
-						bind:value={selectedTeamId}
+						bind:value={
+							() => selectedTeam?.team_id,
+							(newId) => setSelectedTeamById(newId)
+						}
 					/>
 				{/if}
 			</div>

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -293,7 +293,7 @@ export function validatePassword(password: string): boolean {
 	return re.test(password)
 }
 
-const portalDivs = ['#app-editor-select', '.select-dropdown-portal', '[data-context-menu]']
+const portalDivs = ['#app-editor-select', '.dropdown-portal', '[data-context-menu]']
 
 interface ClickOutsideOptions {
 	capture?: boolean


### PR DESCRIPTION
## Summary
Fix Microsoft Teams selection in workspace settings where selecting a team from the dropdown appeared to have no effect — the selection wouldn't visually stick and the "Connect to Teams" button would remain disabled.

## Changes
- **Fix portal class mismatch in `clickOutside`** (`utils.ts`): The `portalDivs` array checked for `.select-dropdown-portal` but the Select dropdown portal uses class `.dropdown-portal`. This caused every click on a portalled Select dropdown to be incorrectly treated as an "outside click", prematurely closing the dropdown and creating a race condition with the selection logic.
- **Simplify TeamSelector state sync** (`TeamSelector.svelte`): Replaced two bidirectional `$effect` sync blocks (`selectedTeamId` ↔ `selectedTeam`) with a getter/setter `bind:value` on the Select component. This eliminates the intermediate `selectedTeamId` state variable and the potential for effect ordering issues. Also added `debouncedSearch.clearDebounce()` in `restorePreSearchState()` to cancel stale pending searches.
- **Simplify ChannelSelector state sync** (`ChannelSelector.svelte`): Applied the same getter/setter pattern for consistency. Also fixed the banned `$bindable(undefined)` pattern → `$bindable()`.

## Test plan
- [ ] Navigate to workspace settings → Slack/Teams → Teams tab
- [ ] Open the team selector dropdown, select a team — verify the selection visually sticks and the "Connect to Teams" button becomes enabled
- [ ] Type a search query in the team selector, select from results — verify selection persists after search state is restored
- [ ] Verify channel selector still works in error handler settings (workspace settings → Error Handler → Teams)
- [ ] Verify channel selector works in instance settings → Critical Alerts → Teams channels

---
Generated with [Claude Code](https://claude.com/claude-code)