### PR TITLE
chore: fix 19 CVEs by upgrading php, docker, and node-tar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -268,11 +268,11 @@ RUN bun install -g windmill-cli \
 RUN curl -fsSL https://claude.ai/install.sh | bash \
     && cp /root/.local/share/claude/versions/* /usr/bin/claude
 
-COPY --from=php:8.3.7-cli /usr/local/bin/php /usr/bin/php
-COPY --from=composer:2.7.6 /usr/bin/composer /usr/bin/composer
+COPY --from=php:8.3.30-cli /usr/local/bin/php /usr/bin/php
+COPY --from=composer:2.9.5 /usr/bin/composer /usr/bin/composer
 
 # add the docker client to call docker from a worker if enabled
-COPY --from=docker:dind /usr/local/bin/docker /usr/local/bin/
+COPY --from=docker:29-dind /usr/local/bin/docker /usr/local/bin/
 
 ENV RUSTUP_HOME="/tmp/windmill/cache/rustup"
 ENV CARGO_HOME="/tmp/windmill/cache/cargo"

--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -67,7 +67,7 @@ RUN curl -fsSL https://claude.ai/install.sh | bash \
     && cp /root/.local/share/claude/versions/* /usr/bin/claude
 
 # add the docker client to call docker from a worker if enabled
-COPY --from=docker:dind /usr/local/bin/docker /usr/local/bin/
+COPY --from=docker:29-dind /usr/local/bin/docker /usr/local/bin/
 
 # nsjail runtime deps and binary
 RUN apt-get update && apt-get install -y libprotobuf-dev libnl-route-3-dev \

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -67,7 +67,7 @@ RUN curl -fsSL https://claude.ai/install.sh | bash \
     && cp /root/.local/share/claude/versions/* /usr/bin/claude
 
 # add the docker client to call docker from a worker if enabled
-COPY --from=docker:dind /usr/local/bin/docker /usr/local/bin/
+COPY --from=docker:29-dind /usr/local/bin/docker /usr/local/bin/
 
 # nsjail runtime deps and binary
 RUN apt-get update && apt-get install -y libprotobuf-dev libnl-route-3-dev \

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -144,7 +144,7 @@
 				"svelte-range-slider-pips": "^2.3.1",
 				"svelte-splitpanes": "^8.0.9",
 				"tailwindcss": "^3.4.1",
-				"tar": "^7.4.3",
+				"tar": "^7.5.4",
 				"tslib": "^2.6.1",
 				"typescript": "^5.5.0",
 				"vite": "^8.0.0-beta.16",
@@ -5524,39 +5524,6 @@
 			"license": "MIT",
 			"optional": true
 		},
-		"node_modules/fs-minipass": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/fs-minipass/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/fs-minipass/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5681,84 +5648,12 @@
 				"giget": "dist/cli.mjs"
 			}
 		},
-		"node_modules/giget/node_modules/chownr": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/giget/node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/giget/node_modules/minizlib": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/giget/node_modules/minizlib/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/giget/node_modules/pathe": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
 			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/giget/node_modules/tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/giget/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/github-from-package": {
 			"version": "0.0.0",
@@ -8264,19 +8159,6 @@
 			},
 			"engines": {
 				"node": ">= 18"
-			}
-		},
-		"node_modules/mkdirp": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/mkdirp-classic": {
@@ -11652,11 +11534,11 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "7.5.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.1.tgz",
-			"integrity": "sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==",
+			"version": "7.5.11",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
+			"integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/fs-minipass": "^4.0.0",
 				"chownr": "^3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,7 +67,7 @@
 		"svelte-range-slider-pips": "^2.3.1",
 		"svelte-splitpanes": "^8.0.9",
 		"tailwindcss": "^3.4.1",
-		"tar": "^7.4.3",
+		"tar": "^7.5.4",
 		"tslib": "^2.6.1",
 		"typescript": "^5.5.0",
 		"vite": "^8.0.0-beta.16",
@@ -78,7 +78,8 @@
 	"overrides": {
 		"monaco-graphql": {
 			"monaco-editor": "$monaco-editor"
-		}
+		},
+		"tar": "$tar"
 	},
 	"type": "module",
 	"dependencies": {


### PR DESCRIPTION
## Summary
Address 19 high/critical CVEs identified in the CI/CD image scan for `windmill-ee-full:1.634.6`.

## Changes
- **PHP 8.3.7 → 8.3.30** + Composer 2.7.6 → 2.9.5 (`Dockerfile`): fixes 12 CVEs including 3 critical (CVE-2024-11236, CVE-2025-1861, CVE-2024-5585, CVE-2024-8926, CVE-2024-8927, CVE-2024-11233, CVE-2024-11234, CVE-2025-1735, CVE-2025-1736, CVE-2025-14177, CVE-2025-14178, CVE-2025-14180)
- **docker:dind → docker:29-dind** (`Dockerfile`, `DockerfileSlim`, `DockerfileSlimEe`): fixes up to 5 CVEs from bundled Go binaries/containerd (CVE-2024-24790 critical, CVE-2025-68121 critical CVSS 10, CVE-2024-45338 x2, CVE-2024-25621)
- **node-tar 7.4.3 → 7.5.4+** with npm override to eliminate transitive tar 6.2.1 (`frontend/package.json`, `frontend/package-lock.json`): fixes 2 CVEs (CVE-2026-23745, CVE-2026-23950)

### Not addressed (transitive / not in our deps)
- pillow 9.4.0, cryptography 38.0.4 (from Ansible)
- aircompressor 0.27 (Java transitive)
- microsoft.build.tasks.core 17.7.2 (from .NET SDK)
- cross-spawn was already at 7.0.6 (fix version 7.0.5)

## Test plan
- [ ] Docker image builds successfully with updated PHP, composer, and docker client
- [ ] PHP scripts execute correctly in workers
- [ ] `npm ci` succeeds in frontend build stage
- [ ] Docker-from-worker functionality works with updated docker client

---
Generated with [Claude Code](https://claude.com/claude-code)