### PR TITLE
fix: skip python preinstall on native workers

### DIFF
--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1432,7 +1432,7 @@ pub async fn run_worker(
     tracing::debug!(worker = %worker_name, hostname = %hostname, worker_dir = %worker_dir, "Creating worker dir");
 
     #[cfg(feature = "python")]
-    {
+    if !NATIVE_MODE_RESOLVED.load(std::sync::atomic::Ordering::Relaxed) {
         let (conn, worker_name, hostname, worker_dir) = (
             conn.clone(),
             worker_name.clone(),


### PR DESCRIPTION
## Summary
Native workers don't execute Python jobs, but the worker startup was still preinstalling Python (downloading/verifying the Python binary). This adds a check for `NATIVE_MODE_RESOLVED` to skip the unnecessary Python preinstall on native workers.

## Changes
- Guard the Python preinstall block in `run_worker()` with `!NATIVE_MODE_RESOLVED`, converting the unconditional `{ ... }` block into a conditional `if !NATIVE_MODE_RESOLVED { ... }`

## Test plan
- [ ] Start a native worker and verify Python is not preinstalled at startup
- [ ] Start a regular worker and verify Python is still preinstalled as before

---
Generated with [Claude Code](https://claude.com/claude-code)