### PR TITLE
fix: show diff editor content for resources without a language

### DIFF
--- a/frontend/src/lib/components/DiffEditor.svelte
+++ b/frontend/src/lib/components/DiffEditor.svelte
@@ -102,8 +102,8 @@
 			})
 		}
 
-		if (defaultLang !== undefined) {
-			setupModel(defaultLang, defaultOriginal, defaultModified, defaultModifiedLang)
+		if (defaultLang !== undefined || defaultOriginal !== undefined || defaultModified !== undefined) {
+			setupModel(defaultLang ?? 'plaintext', defaultOriginal, defaultModified, defaultModifiedLang)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Resources like `ansible_inventory` have a `content` field but no `language` field, causing the DiffEditor's `setupModel()` guard to skip initialization entirely — resulting in a blank Monaco diff editor on the Compare Workspaces page
- Widen the guard to check for content presence (not just language) and fall back to `'plaintext'` for syntax highlighting

## Test plan
- [x] Navigate to Compare Workspaces, click "Show diff" on a resource type that has `content` but no `language` (e.g. `ansible_inventory`)
- [x] Verify the Content tab shows a line-by-line diff instead of a blank editor
- [x] Verify script diffs (which have a `language`) still work as before
- [x] `npm run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)