### PR TITLE
fix: native mode properly sets DB pool size and sleep queue

### DIFF
--- a/backend/.sqlx/query-36b95bc7956eb7bba7cd6fa9cd829980a0bf4970b919cabad1daab16627404fc.json
+++ b/backend/.sqlx/query-36b95bc7956eb7bba7cd6fa9cd829980a0bf4970b919cabad1daab16627404fc.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT (config->>'native_mode')::boolean FROM config WHERE name = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "bool",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "36b95bc7956eb7bba7cd6fa9cd829980a0bf4970b919cabad1daab16627404fc"
+}

--- a/backend/src/db_connect.rs
+++ b/backend/src/db_connect.rs
@@ -20,6 +20,7 @@ pub async fn connect_db(
     server_mode: bool,
     indexer_mode: bool,
     worker_mode: bool,
+    num_workers: i32,
     #[cfg(feature = "private")] mut killpill_rx: tokio::sync::broadcast::Receiver<()>,
 ) -> anyhow::Result<sqlx::Pool<sqlx::Postgres>> {
     use anyhow::Context;
@@ -34,13 +35,7 @@ pub async fn connect_db(
             } else if indexer_mode {
                 DEFAULT_MAX_CONNECTIONS_INDEXER
             } else {
-                DEFAULT_MAX_CONNECTIONS_WORKER
-                    + std::env::var("NUM_WORKERS")
-                        .ok()
-                        .map(|x| x.parse().ok())
-                        .flatten()
-                        .unwrap_or(1)
-                    - 1
+                DEFAULT_MAX_CONNECTIONS_WORKER + (num_workers.max(1) as u32) - 1
             }
         }
     };

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -694,6 +694,7 @@ async fn windmill_main() -> anyhow::Result<()> {
     let mut num_workers = if mode == Mode::Server || mode == Mode::Indexer || mode == Mode::MCP {
         0
     } else if is_native_mode_from_env() {
+        NATIVE_MODE_RESOLVED.store(true, std::sync::atomic::Ordering::Relaxed);
         println!("Native mode enabled: forcing NUM_WORKERS=8");
         8
     } else {
@@ -866,6 +867,30 @@ async fn windmill_main() -> anyhow::Result<()> {
         }
     }
 
+    // Resolve native mode early (before connect_db) so connection pool size accounts for it.
+    // native_mode can come from env OR from the DB worker group config.
+    if worker_mode && !is_native_mode_from_env() {
+        if let Some(db) = conn.as_sql() {
+            let native_from_db: bool = sqlx::query_scalar!(
+                "SELECT (config->>'native_mode')::boolean FROM config WHERE name = $1",
+                format!("worker__{}", *windmill_common::worker::WORKER_GROUP)
+            )
+            .fetch_optional(db)
+            .await
+            .ok()
+            .flatten()
+            .flatten()
+            .unwrap_or(false);
+            if native_from_db {
+                NATIVE_MODE_RESOLVED.store(true, std::sync::atomic::Ordering::Relaxed);
+                num_workers = 8;
+                tracing::info!(
+                    "Native mode detected from worker config (early): forcing NUM_WORKERS=8"
+                );
+            }
+        }
+    }
+
     let conn = if mode == Mode::Agent {
         conn
     } else {
@@ -878,6 +903,7 @@ async fn windmill_main() -> anyhow::Result<()> {
             server_mode,
             indexer_mode,
             worker_mode,
+            num_workers,
             #[cfg(feature = "private")]
             killpill_rx.resubscribe(),
         )
@@ -981,16 +1007,6 @@ Windmill Community Edition {GIT_VERSION}
             disable_s3_store,
         )
         .await;
-
-        // native_mode may also be set via DB worker group config (not just env).
-        // NATIVE_MODE_RESOLVED is updated by load_worker_config during initial_load.
-        if worker_mode
-            && !is_native_mode_from_env()
-            && NATIVE_MODE_RESOLVED.load(std::sync::atomic::Ordering::Relaxed)
-        {
-            num_workers = 8;
-            tracing::info!("Native mode detected from worker config: forcing NUM_WORKERS=8");
-        }
 
         monitor_db(
             &conn,
@@ -1884,7 +1900,7 @@ pub async fn run_workers(
 
     tracing::info!(
         "Starting {num_workers} workers and SLEEP_QUEUE={}ms",
-        *windmill_worker::SLEEP_QUEUE
+        windmill_worker::sleep_queue()
     );
 
     for i in 1..(num_workers + 1) {

--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -251,9 +251,8 @@ pub async fn initial_load(
                     .map(|x| x.tags.clone())
                     .unwrap_or_default();
                 // we only check from env as native_mode is not stored in the token
+                // NATIVE_MODE_RESOLVED is already set in main.rs during startup
                 let native_mode = windmill_common::worker::is_native_mode_from_env();
-                windmill_common::worker::NATIVE_MODE_RESOLVED
-                    .store(native_mode, std::sync::atomic::Ordering::Relaxed);
                 *config = WorkerConfig {
                     worker_tags,
                     env_vars: load_env_vars(

--- a/backend/windmill-api-configs/src/lib.rs
+++ b/backend/windmill-api-configs/src/lib.rs
@@ -129,11 +129,12 @@ async fn update_config(
 
     #[cfg(not(feature = "enterprise"))]
     let config = if name.starts_with("worker__") {
-        // In CE, only allow setting worker_tags, cache_clear, and init_bash
+        // In CE, only allow setting worker_tags, cache_clear, init_bash, and native_mode
         serde_json::json!({
             "worker_tags": config.get("worker_tags"),
             "cache_clear": config.get("cache_clear"),
-            "init_bash": config.get("init_bash")
+            "init_bash": config.get("init_bash"),
+            "native_mode": config.get("native_mode")
         })
     } else {
         config

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -303,7 +303,7 @@ pub struct PowershellRepo {
 
 lazy_static::lazy_static! {
 
-    pub static ref SLEEP_QUEUE: u64 = std::env::var("SLEEP_QUEUE")
+    static ref SLEEP_QUEUE_BASE: u64 = std::env::var("SLEEP_QUEUE")
     .ok()
         .and_then(|x| x.parse::<u64>().ok())
         .unwrap_or_else(|| {
@@ -645,6 +645,14 @@ lazy_static::lazy_static! {
         .unwrap_or(1000);
 
     pub static ref FLOW_RUNNER_RUNNING: Mutex<bool> = Mutex::new(false);
+}
+
+pub fn sleep_queue() -> u64 {
+    if NATIVE_MODE_RESOLVED.load(std::sync::atomic::Ordering::Relaxed) {
+        300
+    } else {
+        *SLEEP_QUEUE_BASE
+    }
 }
 
 type Envs = Vec<(String, String)>;
@@ -1373,7 +1381,7 @@ fn start_interactive_worker_shell(
                         {
                             Duration::from_secs(WORKER_SHELL_NAP_TIME_DURATION)
                         }
-                        _ => Duration::from_millis(*SLEEP_QUEUE * 10),
+                        _ => Duration::from_millis(sleep_queue() * 10),
                     };
                     tokio::select! {
                         _ = tokio::time::sleep(nap_time) => {
@@ -1386,7 +1394,7 @@ fn start_interactive_worker_shell(
 
                 Err(err) => {
                     tracing::error!(worker = %worker_name, hostname = %hostname, "Failed to pull jobs: {}", err);
-                    tokio::time::sleep(Duration::from_millis(*SLEEP_QUEUE * 20)).await;
+                    tokio::time::sleep(Duration::from_millis(sleep_queue() * 20)).await;
                 }
             };
         }
@@ -2699,7 +2707,7 @@ pub async fn run_worker(
                     None
                 };
 
-                tokio::time::sleep(Duration::from_millis(*SLEEP_QUEUE)).await;
+                tokio::time::sleep(Duration::from_millis(sleep_queue())).await;
 
                 #[cfg(feature = "benchmark")]
                 {
@@ -2720,7 +2728,7 @@ pub async fn run_worker(
             }
             Err(err) => {
                 tracing::error!(worker = %worker_name, hostname = %hostname, "Failed to pull jobs: {}", err);
-                tokio::time::sleep(Duration::from_millis(*SLEEP_QUEUE * 5)).await;
+                tokio::time::sleep(Duration::from_millis(sleep_queue() * 5)).await;
             }
         };
     }


### PR DESCRIPTION
## Summary
- Native mode configured via DB worker group config was not accounted for when sizing the connection pool (`connect_db` re-read `NUM_WORKERS` env which is never set in this case) or computing `SLEEP_QUEUE`
- Resolve native mode early by querying the config table before creating the main DB pool, pass `num_workers` directly to `connect_db`
- Replace `SLEEP_QUEUE` lazy_static with `sleep_queue()` function that checks `NATIVE_MODE_RESOLVED` at runtime (300ms for native mode)
- Allow `native_mode` in CE worker group config (was silently stripped on save)

## Test plan
- [ ] Set `native_mode: true` in worker group config via UI on CE — verify it persists after save
- [ ] Start a worker with native mode from DB config — verify log shows `Max connections: 12` (not 5) and `SLEEP_QUEUE=300ms`
- [ ] Start a worker with `NATIVE_MODE=true` env — verify same correct pool size and sleep queue
- [ ] Start a worker without native mode — verify default behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)