### PR TITLE
fix: add explicit pool acquire_timeout to prevent connection starvation cascade

### DIFF
--- a/backend/src/db_connect.rs
+++ b/backend/src/db_connect.rs
@@ -105,6 +105,7 @@ pub async fn connect(
     let mut pool_options = sqlx::postgres::PgPoolOptions::new()
         .min_connections((max_connections / 5).clamp(1, max_connections))
         .max_connections(max_connections)
+        .acquire_timeout(Duration::from_secs(5))
         .max_lifetime(Duration::from_secs(30 * 60)); // 30 mins
     if worker_mode {
         pool_options = pool_options.idle_timeout(Duration::from_secs(60));


### PR DESCRIPTION
## Summary

Adds an explicit `acquire_timeout(5s)` to the sqlx connection pool to prevent connection starvation cascades that cause workers to block for minutes.

## Problem

Production logs show worker pulls taking up to **29.5 minutes** (1770s) despite existing timeout protections. Workers cascade-block waiting for pool connections:

| Worker | Pool wait |
|--------|-----------|
| wYpR2  | 1770s (29.5 min) |
| VJxaK  | 1218s (20.3 min) |
| 27VBk  | 735s (12.2 min) |

### Why existing timeouts don't help

The code has three timeout layers that should prevent this:

1. **Outer tokio timeout** (`worker.rs:2126`): `timeout(30s, pull(...))` — should cap the entire pull
2. **Inner tokio timeouts** (`jobs.rs:3313`): `timeout(15s, pull_single_job...)` — caps individual query rounds
3. **Pool `acquire_timeout`**: was relying on sqlx 0.8 default (30s)

But under extreme pool contention (8 workers + result processor competing for ~12 connections), the tokio timeout cancellation doesn't reliably propagate through the pool's internal semaphore wait queue. The `warn_after_seconds(2)` log confirms the pull future **completed normally after 1770s** (not cancelled), meaning the 30s tokio timeout never fired.

Additionally, `prefetch_cached_from_handle` at `jobs.rs:3333` has **no timeout wrapper** — on cache miss under contention, it blocks on pool acquire with only the pool's own `acquire_timeout` as protection.

### Why 5s instead of 15s or 30s

The default 30s acquire_timeout is too long — it's the same as the outer tokio timeout, so it can't act as defense in depth. With `NUM_WORKERS=8` and `SLEEP_QUEUE=300ms`, workers poll ~27 times/sec across a pool of ~12 connections. A 5s acquire_timeout means:
- Workers fail fast when the pool is saturated
- The error propagates cleanly as `sqlx::Error::PoolTimedOut` → `Error::SqlErr`
- The worker retries after `SLEEP_QUEUE * 20` (6s), giving the pool time to recover
- The cascade breaks instead of amplifying

## Changes

- Set `.acquire_timeout(Duration::from_secs(5))` on `PgPoolOptions` in `backend/src/db_connect.rs`

## Test plan

- [x] `cargo check` passes
- [ ] Deploy to staging and verify workers fail fast on pool exhaustion instead of blocking for minutes
- [ ] Monitor `worker_pull_duration` metrics — pulls should cap at ~5s instead of minutes
- [ ] Verify no regression under normal load (5s is generous for pool acquire when connections are available)

---
Generated with [Claude Code](https://claude.com/claude-code)