### PR TITLE
fix: set min_connections(0) to prevent sqlx pool spin loop

### DIFF
--- a/backend/src/db_connect.rs
+++ b/backend/src/db_connect.rs
@@ -103,7 +103,7 @@ pub async fn connect(
     use sqlx::Executor;
     use std::time::Duration;
     let mut pool_options = sqlx::postgres::PgPoolOptions::new()
-        .min_connections((max_connections / 5).clamp(1, max_connections))
+        .min_connections(0)
         .max_connections(max_connections)
         .max_lifetime(Duration::from_secs(30 * 60)); // 30 mins
     if worker_mode {


### PR DESCRIPTION
## Summary

- Sets `min_connections(0)` on the sqlx connection pool to prevent a known sqlx bug ([launchbadge/sqlx#3645](https://github.com/launchbadge/sqlx/issues/3645)) where phantom semaphore permits cause `acquire()` to spin at 100% CPU indefinitely.

## Root cause

With `min_connections > 0`, sqlx spawns a background maintenance task that continuously creates replacement connections as old ones expire (`max_lifetime`). Each create/destroy cycle can desynchronize the pool's semaphore (which tracks available permits) from its idle queue (which holds actual connections). When a permit exists but no connection is in the queue, the acquire loop spins forever:

```
loop {
    semaphore.acquire()  // succeeds — phantom permit
    queue.pop()          // None — no actual connection
    semaphore.release()  // put permit back
    // repeat forever at 100% CPU
}
```

This is particularly likely on ARM/aarch64 due to weak memory ordering in the crossbeam `ArrayQueue` used by sqlx-core.

Setting `min_connections(0)` eliminates the background maintenance task, removing the primary trigger for permit/queue desync. Connections are still created on-demand.

## Observed in production

Native worker pod `windmill-workers-native-6df8d548b6-9pdnf` (ARM/aarch64) stuck at 100% CPU. GDB confirmed a single thread spinning in sqlx-core's pool acquire loop with ~1.3 trillion iterations, semaphore oscillating between 3-4 phantom permits, and an empty idle queue (head == tail).

## Test plan

- [x] `cargo check` passes
- [ ] Deploy to affected ARM cluster and verify no more CPU spin

🤖 Generated with [Claude Code](https://claude.com/claude-code)