### PR TITLE
feat: add customUi props for History and Save to workspace editor bar buttons

### DIFF
--- a/frontend/src/lib/components/EditorBar.svelte
+++ b/frontend/src/lib/components/EditorBar.svelte
@@ -1096,7 +1096,7 @@ JsonNode ${windmillPathToCamelCaseName(path)} = JsonNode.Parse(await client.GetS
 
 	<div class="flex flex-row items-center gap-2 whitespace-nowrap">
 		{@render right?.()}
-		{#if scriptPath && !noHistory}
+		{#if scriptPath && !noHistory && customUi?.history != false}
 			<Button
 				unifiedSize="sm"
 				variant="subtle"
@@ -1120,7 +1120,7 @@ JsonNode ${windmillPathToCamelCaseName(path)} = JsonNode.Parse(await client.GetS
 				Library
 			</Button>
 		{/if}
-		{#if saveToWorkspace}
+		{#if saveToWorkspace && customUi?.saveToWorkspace != false}
 			<Button
 				unifiedSize="sm"
 				variant="subtle"

--- a/frontend/src/lib/components/custom_ui.ts
+++ b/frontend/src/lib/components/custom_ui.ts
@@ -81,6 +81,8 @@ export type EditorBarUi = {
 	ducklake?: boolean
 	dataTable?: boolean
 	debug?: boolean
+	history?: boolean
+	saveToWorkspace?: boolean
 }
 
 export type EditableSchemaFormUi = {


### PR DESCRIPTION
## Summary
Add missing `customUi` disabling support for the History and Save to workspace buttons in the editor bar, ensuring every button can be toggled via whitelabel `customUi` configuration.

## Changes
- Add `history` and `saveToWorkspace` boolean properties to `EditorBarUi` type in `custom_ui.ts`
- Add `customUi?.history != false` check to the History button in `EditorBar.svelte`
- Add `customUi?.saveToWorkspace != false` check to the Save to workspace button in `EditorBar.svelte`
- These props flow through both ScriptEditor (`customUi?.editorBar`) and FlowModuleComponent (via context) since both pass `customUi={customUi?.editorBar}` to EditorBar

## Test plan
- [ ] Verify History button is hidden when `editorBar.history` is set to `false` in customUi
- [ ] Verify Save to workspace button is hidden when `editorBar.saveToWorkspace` is set to `false` in customUi
- [ ] Verify both buttons still show by default (when customUi properties are undefined)
- [ ] Verify this works in both the standalone script editor and the flow inline script editor

---
Generated with [Claude Code](https://claude.com/claude-code)