### PR TITLE
fix: clean stale v8 build cache to prevent CI link failures

### DIFF
--- a/.github/workflows/backend-check.yml
+++ b/.github/workflows/backend-check.yml
@@ -119,6 +119,18 @@ jobs:
         with:
           cache-workspaces: backend
           toolchain: 1.93.0
+      - name: Fix stale v8 build cache
+        working-directory: ./backend
+        run: |
+          # Cargo cache may preserve v8 build fingerprints without the actual
+          # librusty_v8.a library. Since fingerprints look valid, cargo skips
+          # build.rs re-run, causing "could not find native static library rusty_v8".
+          for profile in debug release; do
+            if [ -d "target/$profile/.fingerprint" ] && [ ! -f "target/$profile/gn_out/obj/librusty_v8.a" ]; then
+              echo "Cleaning stale v8 build artifacts in target/$profile"
+              rm -rf "target/$profile/build/v8-"* "target/$profile/.fingerprint/v8-"*
+            fi
+          done
       - name: cargo check
         timeout-minutes: 16
         working-directory: ./backend

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -89,6 +89,18 @@ jobs:
         with:
           cache-workspaces: backend
           toolchain: 1.93.0
+      - name: Fix stale v8 build cache
+        working-directory: ./backend
+        run: |
+          # Cargo cache may preserve v8 build fingerprints without the actual
+          # librusty_v8.a library. Since fingerprints look valid, cargo skips
+          # build.rs re-run, causing "could not find native static library rusty_v8".
+          for profile in debug release; do
+            if [ -d "target/$profile/.fingerprint" ] && [ ! -f "target/$profile/gn_out/obj/librusty_v8.a" ]; then
+              echo "Cleaning stale v8 build artifacts in target/$profile"
+              rm -rf "target/$profile/build/v8-"* "target/$profile/.fingerprint/v8-"*
+            fi
+          done
       - name: Read EE repo commit hash
         run: |
           echo "ee_repo_ref=$(cat ./ee-repo-ref.txt)" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

- Fix intermittent CI failures with `error: could not find native static library 'rusty_v8'` in `backend-check` and `backend-test` workflows
- Add a step that detects when Cargo cache has stale v8 fingerprints but the actual `librusty_v8.a` library (137MB) is missing, and cleans them to force a fresh `build.rs` re-run

## Root cause

The `Swatinem/rust-cache` (via `actions-rust-lang/setup-rust-toolchain`) preserves v8 build fingerprints (`target/debug/.fingerprint/v8-*`) across CI runs, but the large `librusty_v8.a` library may be evicted from the cache. When cargo sees valid fingerprints, it skips re-running v8's `build.rs` (which would download the library), and the subsequent link/check step fails because the library file is missing.

Evidence from CI logs:
- `check_ee_full` (caching enabled) fails while `check_oss_full` (`cache: false`) passes in the same workflow run
- v8 goes from "Compiling" to error in ~1.5s — far too fast for a 137MB download, confirming build.rs was skipped

## Test plan

- [ ] Verify `backend-check` workflow passes (specifically `check_ee_full`)
- [ ] Verify `backend-test` workflow passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)