### PR TITLE
fix(cli): suppress verbose lock generation messages in generate-metadata

### DIFF
--- a/cli/src/commands/app/app_metadata.ts
+++ b/cli/src/commands/app/app_metadata.ts
@@ -93,7 +93,16 @@ async function generateAppHash(
 }
 
 /**
- * Updates locks for inline scripts in an app
+ * Result of generating app locks, including which scripts were updated
+ */
+export interface AppLocksResult {
+  path: string;
+  updatedScripts: string[];
+}
+
+/**
+ * Updates locks for inline scripts in an app.
+ * Returns the path if dry-run, or AppLocksResult with updated scripts if actual update occurred.
  */
 export async function generateAppLocksInternal(
   appFolder: string,
@@ -105,7 +114,7 @@ export async function generateAppLocksInternal(
   },
   justUpdateMetadataLock?: boolean,
   noStaleMessage?: boolean
-): Promise<string | void> {
+): Promise<string | AppLocksResult | void> {
   if (appFolder.endsWith(SEP)) {
     appFolder = appFolder.substring(0, appFolder.length - 1);
   }
@@ -167,6 +176,8 @@ export async function generateAppLocksInternal(
     );
   }
 
+  let updatedScripts: string[] = [];
+
   if (!justUpdateMetadataLock) {
     const changedScripts = [];
     // Find hashes that do not correspond to previous hashes
@@ -201,7 +212,7 @@ export async function generateAppLocksInternal(
         replaceInlineScripts(runnables, runnablesPath + SEP, false);
 
         // Update the app runnables with new locks (writes to separate files)
-        await updateRawAppRunnables(
+        updatedScripts = await updateRawAppRunnables(
           workspace,
           runnables,
           remote_path,
@@ -218,7 +229,7 @@ export async function generateAppLocksInternal(
         replaceInlineScripts(normalAppFile.value, appFolder + SEP, false);
 
         // Update the app value with new locks
-        normalAppFile.value = await updateAppInlineScripts(
+        const result = await updateAppInlineScripts(
           workspace,
           normalAppFile.value,
           remote_path,
@@ -227,6 +238,8 @@ export async function generateAppLocksInternal(
           opts.defaultTs,
           noStaleMessage
         );
+        normalAppFile.value = result.value;
+        updatedScripts = result.updatedScripts;
 
         // Write the updated app file (only for normal apps, raw apps use separate files)
         writeIfChanged(
@@ -253,6 +266,8 @@ export async function generateAppLocksInternal(
   if (!noStaleMessage) {
     log.info(colors.green(`App ${remote_path} lockfiles updated`));
   }
+
+  return { path: remote_path, updatedScripts };
 }
 
 /**
@@ -342,6 +357,7 @@ async function traverseAndProcessInlineScripts(
  * Updates locks for all runnables in a raw app, generating locks inline script by inline script.
  * Writes each runnable to its own YAML file in the backend folder (new format).
  * Also writes content and lock files to the runnables folder.
+ * Returns the list of runnable IDs that had their locks updated.
  */
 async function updateRawAppRunnables(
   workspace: Workspace,
@@ -351,7 +367,8 @@ async function updateRawAppRunnables(
   rawDeps?: Record<string, string>,
   defaultTs: "bun" | "deno" = "bun",
   noStaleMessage?: boolean
-): Promise<void> {
+): Promise<string[]> {
+  const updatedRunnables: string[] = [];
   const runnablesFolder = path.join(appFolder, APP_BACKEND_FOLDER);
 
   // Ensure runnables folder exists
@@ -461,6 +478,8 @@ async function updateRawAppRunnables(
       // Write the runnable to its own YAML file
       writeRunnableToBackend(runnablesFolder, runnableId, simplifiedRunnable);
 
+      updatedRunnables.push(runnableId);
+
       if (!noStaleMessage) {
         log.info(
           colors.gray(
@@ -478,11 +497,14 @@ async function updateRawAppRunnables(
       writeRunnableToBackend(runnablesFolder, runnableId, runnable);
     }
   }
+
+  return updatedRunnables;
 }
 
 /**
  * Updates locks for all inline scripts in a normal app, similar to updateRawAppRunnables
- * but for the app.value structure instead of app.runnables
+ * but for the app.value structure instead of app.runnables.
+ * Returns a tuple of [updated app value, list of script names that were updated].
  */
 async function updateAppInlineScripts(
   workspace: Workspace,
@@ -492,8 +514,9 @@ async function updateAppInlineScripts(
   rawDeps?: Record<string, string>,
   defaultTs: "bun" | "deno" = "bun",
   noStaleMessage?: boolean
-): Promise<any> {
+): Promise<{ value: any; updatedScripts: string[] }> {
   const pathAssigner = newPathAssigner(defaultTs, { skipInlineScriptSuffix: getNonDottedPaths() });
+  const updatedScripts: string[] = [];
 
   const processor: InlineScriptProcessor = async (inlineScript, context) => {
     const language = inlineScript.language as SupportedLanguage;
@@ -568,6 +591,11 @@ async function updateAppInlineScripts(
         );
       }
 
+      // Track that this script was updated (only for non-frontend scripts that needed locks)
+      if (language !== "frontend") {
+        updatedScripts.push(scriptName);
+      }
+
       return {
         ...inlineScript,
         content: inlineContentRef,
@@ -586,7 +614,8 @@ async function updateAppInlineScripts(
     }
   };
 
-  return await traverseAndProcessInlineScripts(appValue, processor);
+  const updatedValue = await traverseAndProcessInlineScripts(appValue, processor);
+  return { value: updatedValue, updatedScripts };
 }
 
 /**

--- a/cli/src/commands/flow/flow_metadata.ts
+++ b/cli/src/commands/flow/flow_metadata.ts
@@ -51,6 +51,14 @@ async function generateFlowHash(
   }
   return { ...hashes, [TOP_HASH]: await generateHash(JSON.stringify(hashes)) };
 }
+/**
+ * Result of generating flow locks, including which scripts were updated
+ */
+export interface FlowLocksResult {
+  path: string;
+  updatedScripts: string[];
+}
+
 export async function generateFlowLockInternal(
   folder: string,
   dryRun: boolean,
@@ -60,7 +68,7 @@ export async function generateFlowLockInternal(
   },
   justUpdateMetadataLock?: boolean,
   noStaleMessage?: boolean
-): Promise<string | void> {
+): Promise<string | FlowLocksResult | void> {
   if (folder.endsWith(SEP)) {
     folder = folder.substring(0, folder.length - 1);
   }
@@ -109,8 +117,9 @@ export async function generateFlowLockInternal(
   }
 
 
+  let changedScripts: string[] = [];
+
   if (!justUpdateMetadataLock) {
-    const changedScripts = [];
     //find hashes that do not correspond to previous hashes
     for (const [path, hash] of Object.entries(hashes)) {
       if (path == TOP_HASH) {
@@ -185,6 +194,13 @@ export async function generateFlowLockInternal(
   if (!noStaleMessage) {
     log.info(colors.green(`Flow ${remote_path} lockfiles updated`));
   }
+
+  // Return the list of updated scripts (extract just the filename from the path)
+  const updatedScripts = changedScripts.map(p => {
+    const parts = p.split(SEP);
+    return parts[parts.length - 1].replace(/\.[^.]+$/, ""); // Remove extension
+  });
+  return { path: remote_path, updatedScripts };
 }
 
 /**

--- a/cli/src/commands/generate-metadata/generate-metadata.ts
+++ b/cli/src/commands/generate-metadata/generate-metadata.ts
@@ -11,8 +11,8 @@ import {
   generateScriptMetadataInternal,
   getRawWorkspaceDependencies,
 } from "../../utils/metadata.ts";
-import { generateFlowLockInternal } from "../flow/flow_metadata.ts";
-import { generateAppLocksInternal, getAppFolders } from "../app/app_metadata.ts";
+import { generateFlowLockInternal, FlowLocksResult } from "../flow/flow_metadata.ts";
+import { generateAppLocksInternal, getAppFolders, AppLocksResult } from "../app/app_metadata.ts";
 import {
   elementsToMap,
   FSFSElement,
@@ -280,21 +280,23 @@ async function generateMetadata(
   // Process flows
   for (const item of flows) {
     current++;
-    log.info(`${formatProgress(current)} flow   ${colors.cyan(item.path)}`);
-    await generateFlowLockInternal(
+    const result = await generateFlowLockInternal(
       item.folder,
       false, // dryRun
       workspace,
       opts,
       false,
       true // noStaleMessage - we handle output
-    );
+    ) as FlowLocksResult | void;
+    const scriptsInfo = result?.updatedScripts?.length
+      ? `: ${colors.gray(result.updatedScripts.join(", "))}`
+      : "";
+    log.info(`${formatProgress(current)} flow   ${colors.cyan(item.path)}${scriptsInfo}`);
   }
   // Process apps
   for (const item of apps) {
     current++;
-    log.info(`${formatProgress(current)} app    ${colors.cyan(item.path)}`);
-    await generateAppLocksInternal(
+    const result = await generateAppLocksInternal(
       item.folder,
       item.isRawApp!, // rawApp
       false, // dryRun
@@ -302,7 +304,11 @@ async function generateMetadata(
       opts,
       false,
       true // noStaleMessage - we handle output
-    );
+    ) as AppLocksResult | void;
+    const scriptsInfo = result?.updatedScripts?.length
+      ? `: ${colors.gray(result.updatedScripts.join(", "))}`
+      : "";
+    log.info(`${formatProgress(current)} app    ${colors.cyan(item.path)}${scriptsInfo}`);
   }
 
   log.info("");


### PR DESCRIPTION

<img width="1038" height="385" alt="out" src="https://github.com/user-attachments/assets/90be019d-e1ad-4f96-98c1-7eea4fbf3a70" />

Improves generate-metadata command output by:
  1. Suppressing verbose lock generation messages that were cluttering the output
  2. Showing inline script names that were updated on the same line as the progress

  Before
```
  [4/5] app    u/admin/testrawapp__raw_app
  Generating lock for runnable a (bun)
          }
    Written a.yaml, a.ts and a.lock
  [5/5] app    u/admin/ttt__raw_app
  Generating lock for runnable a (bun)
          }
    Written a.yaml, a.ts and a.lock
```
  After

  [4/5] app    u/admin/testrawapp__raw_app: a
  [5/5] app    u/admin/ttt__raw_app: a

  Multiple inline scripts are shown comma-separated:

  [4/5] app    u/admin/my_app: a, b, c
  [5/5] flow   u/admin/my_flow: step1, step2

  Changes

  - Pass noStaleMessage flag through to internal lock generation functions
  - Add AppLocksResult and FlowLocksResult types to track updated scripts
  - Return list of updated inline script names from lock generation functions
  - Display updated script names inline with progress output