### PR TITLE
fix(cli): skip standalone metadata files in raw app backend folder

### DIFF
--- a/cli/src/commands/app/raw_apps.ts
+++ b/cli/src/commands/app/raw_apps.ts
@@ -144,6 +144,17 @@ export async function loadRunnablesFromBackend(
         continue;
       }
 
+      // Skip standalone script/flow/resource metadata files
+      // These have patterns like: foo.script.yaml, foo.flow.yaml, foo.resource.yaml
+      // Raw app runnable configs are just: foo.yaml
+      if (
+        fileName.endsWith(".script.yaml") ||
+        fileName.endsWith(".flow.yaml") ||
+        fileName.endsWith(".resource.yaml")
+      ) {
+        continue;
+      }
+
       const runnableId = fileName.replace(".yaml", "");
       processedIds.add(runnableId);
 

--- a/cli/src/commands/generate-metadata/generate-metadata.ts
+++ b/cli/src/commands/generate-metadata/generate-metadata.ts
@@ -19,7 +19,7 @@ import {
   ignoreF,
 } from "../sync/sync.ts";
 import { exts } from "../script/script.ts";
-import { isFlowPath, isAppPath } from "../../utils/resource_folders.ts";
+import { isFolderResourcePath } from "../../utils/resource_folders.ts";
 import { listSyncCodebases } from "../../utils/codebase.ts";
 
 interface StaleItem {
@@ -81,8 +81,7 @@ async function generateMetadata(
         return (
           (!isD && !exts.some((ext) => p.endsWith(ext))) ||
           ignore(p, isD) ||
-          isFlowPath(p) ||
-          isAppPath(p)
+          isFolderResourcePath(p)
         );
       },
       false,

--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -56,8 +56,7 @@ import {
   isRawAppBackendPath as isRawAppBackendPathInternal,
   isAppInlineScriptPath as isAppInlineScriptPathInternal,
   isFlowInlineScriptPath as isFlowInlineScriptPathInternal,
-  isFlowPath,
-  isAppPath,
+  isFolderResourcePath,
 } from "../../utils/resource_folders.ts";
 
 export interface ScriptFile {
@@ -1026,8 +1025,7 @@ export async function generateMetadata(
         return (
           (!isD && !exts.some((ext) => p.endsWith(ext))) ||
           ignore(p, isD) ||
-          isFlowPath(p) ||
-          isAppPath(p)
+          isFolderResourcePath(p)
         );
       },
       false,

--- a/cli/test/raw_app_backend_unit.test.ts
+++ b/cli/test/raw_app_backend_unit.test.ts
@@ -1,0 +1,231 @@
+import { expect, test, describe, beforeEach, afterEach } from "bun:test";
+import { loadRunnablesFromBackend } from "../src/commands/app/raw_apps.ts";
+import * as path from "node:path";
+import { writeFile, rm, mkdir } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+
+// =============================================================================
+// UNIT TESTS: loadRunnablesFromBackend
+// Tests for the raw app backend folder runnable loading
+// =============================================================================
+
+describe("loadRunnablesFromBackend", () => {
+  let tempDir: string;
+  let backendPath: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), "raw-app-test-"));
+    backendPath = path.join(tempDir, "backend");
+    await mkdir(backendPath, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("loads inline runnable from yaml + ts files", async () => {
+    // Create a proper inline runnable
+    await writeFile(
+      path.join(backendPath, "my_runnable.yaml"),
+      "type: inline\n",
+      "utf-8"
+    );
+    await writeFile(
+      path.join(backendPath, "my_runnable.ts"),
+      "export async function main(x: number) { return x; }",
+      "utf-8"
+    );
+
+    const runnables = await loadRunnablesFromBackend(backendPath);
+
+    expect(Object.keys(runnables)).toEqual(["my_runnable"]);
+    expect(runnables["my_runnable"].type).toEqual("inline");
+    expect(runnables["my_runnable"].inlineScript?.content).toContain("export async function main");
+    expect(runnables["my_runnable"].inlineScript?.language).toEqual("bun");
+  });
+
+  test("loads path-based runnable (script type)", async () => {
+    // Create a path-based runnable that references an external script
+    await writeFile(
+      path.join(backendPath, "external.yaml"),
+      `type: script
+path: u/admin/my_script
+`,
+      "utf-8"
+    );
+
+    const runnables = await loadRunnablesFromBackend(backendPath);
+
+    expect(Object.keys(runnables)).toEqual(["external"]);
+    expect(runnables["external"].type).toEqual("path");
+    expect(runnables["external"].runType).toEqual("script");
+    expect(runnables["external"].path).toEqual("u/admin/my_script");
+  });
+
+  test("ignores .script.yaml standalone metadata files", async () => {
+    // Create a proper inline runnable
+    await writeFile(
+      path.join(backendPath, "a.yaml"),
+      "type: inline\n",
+      "utf-8"
+    );
+    await writeFile(
+      path.join(backendPath, "a.ts"),
+      "export async function main(x: number) { return x; }",
+      "utf-8"
+    );
+
+    // Create standalone script metadata files that should be IGNORED
+    // These have 'kind: script' format, not 'type: inline'
+    await writeFile(
+      path.join(backendPath, "a.script.yaml"),
+      `summary: ''
+description: ''
+lock: '!inline some/path/a.script.lock'
+kind: script
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  type: object
+  properties:
+    x:
+      type: number
+  required:
+    - x
+`,
+      "utf-8"
+    );
+    await writeFile(
+      path.join(backendPath, "a.script.lock"),
+      `{
+  "dependencies": {}
+}
+//bun.lock
+<empty>`,
+      "utf-8"
+    );
+
+    const runnables = await loadRunnablesFromBackend(backendPath);
+
+    // Should only load 'a' (from a.yaml), NOT 'a.script' (from a.script.yaml)
+    expect(Object.keys(runnables)).toEqual(["a"]);
+    expect(runnables["a"].type).toEqual("inline");
+    expect(runnables["a.script"]).toBeUndefined();
+  });
+
+  test("ignores .flow.yaml standalone metadata files", async () => {
+    // Create a proper inline runnable
+    await writeFile(
+      path.join(backendPath, "b.yaml"),
+      "type: inline\n",
+      "utf-8"
+    );
+    await writeFile(
+      path.join(backendPath, "b.ts"),
+      "export async function main() { return 'hello'; }",
+      "utf-8"
+    );
+
+    // Create standalone flow metadata file that should be IGNORED
+    await writeFile(
+      path.join(backendPath, "myflow.flow.yaml"),
+      `summary: My Flow
+description: A test flow
+schema:
+  type: object
+`,
+      "utf-8"
+    );
+
+    const runnables = await loadRunnablesFromBackend(backendPath);
+
+    // Should only load 'b', NOT 'myflow.flow'
+    expect(Object.keys(runnables)).toEqual(["b"]);
+    expect(runnables["myflow.flow"]).toBeUndefined();
+  });
+
+  test("ignores .resource.yaml standalone metadata files", async () => {
+    // Create a proper inline runnable
+    await writeFile(
+      path.join(backendPath, "c.yaml"),
+      "type: inline\n",
+      "utf-8"
+    );
+    await writeFile(
+      path.join(backendPath, "c.py"),
+      "def main(): return 'hello'",
+      "utf-8"
+    );
+
+    // Create standalone resource metadata file that should be IGNORED
+    await writeFile(
+      path.join(backendPath, "mydb.resource.yaml"),
+      `value:
+  host: localhost
+  port: 5432
+resource_type: postgresql
+`,
+      "utf-8"
+    );
+
+    const runnables = await loadRunnablesFromBackend(backendPath);
+
+    // Should only load 'c', NOT 'mydb.resource'
+    expect(Object.keys(runnables)).toEqual(["c"]);
+    expect(runnables["mydb.resource"]).toBeUndefined();
+  });
+
+  test("handles empty backend folder", async () => {
+    const runnables = await loadRunnablesFromBackend(backendPath);
+    expect(Object.keys(runnables)).toEqual([]);
+  });
+
+  test("handles non-existent backend folder", async () => {
+    const nonExistentPath = path.join(tempDir, "does_not_exist");
+    const runnables = await loadRunnablesFromBackend(nonExistentPath);
+    expect(Object.keys(runnables)).toEqual([]);
+  });
+
+  test("auto-detects code-only runnables without yaml config", async () => {
+    // Create just a code file without corresponding yaml
+    await writeFile(
+      path.join(backendPath, "auto_detect.ts"),
+      "export async function main(name: string) { return `Hello ${name}`; }",
+      "utf-8"
+    );
+
+    const runnables = await loadRunnablesFromBackend(backendPath);
+
+    expect(Object.keys(runnables)).toEqual(["auto_detect"]);
+    expect(runnables["auto_detect"].type).toEqual("inline");
+    expect(runnables["auto_detect"].inlineScript?.content).toContain("Hello");
+    expect(runnables["auto_detect"].inlineScript?.language).toEqual("bun");
+  });
+
+  test("multiple runnables with mixed formats", async () => {
+    // Inline runnable with yaml config
+    await writeFile(path.join(backendPath, "with_config.yaml"), "type: inline\n", "utf-8");
+    await writeFile(path.join(backendPath, "with_config.ts"), "export async function main() { return 1; }", "utf-8");
+
+    // Auto-detected code-only runnable
+    await writeFile(path.join(backendPath, "auto.py"), "def main(): return 2", "utf-8");
+
+    // Path-based runnable
+    await writeFile(path.join(backendPath, "external.yaml"), "type: flow\npath: f/myflow\n", "utf-8");
+
+    // Standalone metadata files to ignore
+    await writeFile(path.join(backendPath, "standalone.script.yaml"), "kind: script\n", "utf-8");
+    await writeFile(path.join(backendPath, "another.flow.yaml"), "summary: flow\n", "utf-8");
+
+    const runnables = await loadRunnablesFromBackend(backendPath);
+
+    const keys = Object.keys(runnables).sort();
+    expect(keys).toEqual(["auto", "external", "with_config"]);
+
+    // Verify types
+    expect(runnables["with_config"].type).toEqual("inline");
+    expect(runnables["auto"].type).toEqual("inline");
+    expect(runnables["external"].type).toEqual("path");
+    expect(runnables["external"].runType).toEqual("flow");
+  });
+});

--- a/cli/test/utils_unit.test.ts
+++ b/cli/test/utils_unit.test.ts
@@ -596,3 +596,73 @@ describe("removeExtensionToPath", () => {
     expect(removeExtensionToPath("f/test/api.fetch.ts")).toBe("f/test/api");
   });
 });
+
+// =============================================================================
+// isFolderResourcePath - ensures raw app paths are properly identified
+// Regression test: generate-metadata was missing isRawAppPath check, causing
+// it to process files inside raw_app/backend/ as standalone scripts
+// =============================================================================
+
+import {
+  isFolderResourcePath,
+  isFlowPath,
+  isAppPath,
+  isRawAppPath,
+} from "../src/utils/resource_folders.ts";
+
+describe("isFolderResourcePath", () => {
+  // These tests use dotted paths (.flow, .app, .raw_app) which is the default format
+  // The non-dotted format (__flow, __app, __raw_app) is only used when nonDottedPaths
+  // is enabled via wmill.yaml, which requires runtime configuration
+
+  test("identifies flow paths", () => {
+    expect(isFlowPath("f/test/myflow.flow/flow.yaml")).toBe(true);
+    expect(isFlowPath("f/test/myflow.flow/inline_script.ts")).toBe(true);
+    expect(isFlowPath("f/test/script.ts")).toBe(false);
+  });
+
+  test("identifies app paths", () => {
+    expect(isAppPath("f/test/myapp.app/app.yaml")).toBe(true);
+    expect(isAppPath("f/test/myapp.app/inline_script.ts")).toBe(true);
+    expect(isAppPath("f/test/script.ts")).toBe(false);
+  });
+
+  test("identifies raw app paths", () => {
+    expect(isRawAppPath("f/test/myapp.raw_app/raw_app.yaml")).toBe(true);
+    expect(isRawAppPath("f/test/myapp.raw_app/backend/a.ts")).toBe(true);
+    expect(isRawAppPath("u/admin/testraw.raw_app/backend/a.ts")).toBe(true);
+    expect(isRawAppPath("f/test/script.ts")).toBe(false);
+  });
+
+  test("isFolderResourcePath includes all three types", () => {
+    // Flow
+    expect(isFolderResourcePath("f/test/myflow.flow/flow.yaml")).toBe(true);
+
+    // App
+    expect(isFolderResourcePath("f/test/myapp.app/app.yaml")).toBe(true);
+
+    // Raw App - THIS IS THE CRITICAL TEST
+    // Before the fix, isRawAppPath was missing from generate-metadata.ts
+    expect(isFolderResourcePath("f/test/myapp.raw_app/raw_app.yaml")).toBe(true);
+    expect(isFolderResourcePath("u/admin/testraw.raw_app/backend/a.ts")).toBe(true);
+
+    // Regular scripts should NOT match
+    expect(isFolderResourcePath("f/test/script.ts")).toBe(false);
+    expect(isFolderResourcePath("u/admin/my_script.ts")).toBe(false);
+  });
+
+  test("raw app backend files are identified as folder resources", () => {
+    // This is the specific case that was broken:
+    // Files inside raw_app/backend/ should be identified as folder resources
+    // so generate-metadata doesn't treat them as standalone scripts
+    const rawAppBackendPaths = [
+      "u/admin/testraw.raw_app/backend/a.ts",
+      "u/admin/testraw.raw_app/backend/runnable.py",
+      "f/myteam/dashboard.raw_app/backend/query.ts",
+    ];
+
+    for (const p of rawAppBackendPaths) {
+      expect(isFolderResourcePath(p)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
When loading runnables from a raw app's backend folder, skip files that match standalone script/flow/resource metadata patterns:
- *.script.yaml
- *.flow.yaml
- *.resource.yaml

These files use a different format (e.g., `kind: script`) than raw app runnable configs (which use `type: inline` or `type: path`), causing updateRawAppPolicy to fail with "Object.fromEntries requires the first iterable parameter yields objects" when processRunnable returns undefined.
