### PR TITLE
feat: support custom headers in customai resource type

### DIFF
--- a/backend/windmill-api/src/ai.rs
+++ b/backend/windmill-api/src/ai.rs
@@ -169,6 +169,9 @@ struct AIStandardResource {
     /// Enable 1M context window for Anthropic
     #[serde(alias = "enable_1M_context", default)]
     enable_1m_context: bool,
+    /// Custom HTTP headers to include in AI requests
+    #[serde(default)]
+    headers: HashMap<String, String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -200,6 +203,7 @@ struct AIRequestConfig {
     pub aws_session_token: Option<String>,
     pub platform: AIPlatform,
     pub enable_1m_context: bool,
+    pub custom_headers: HashMap<String, String>,
 }
 
 impl AIRequestConfig {
@@ -221,11 +225,13 @@ impl AIRequestConfig {
             aws_session_token,
             platform,
             enable_1m_context,
+            custom_headers,
         ) = match resource {
             AIResource::Standard(resource) => {
                 let region = resource.region.clone();
                 let platform = resource.platform.clone();
                 let enable_1m_context = resource.enable_1m_context;
+                let custom_headers = resource.headers.clone();
                 // Skip get_base_url for Bedrock - it uses SDK directly, not HTTP
                 let base_url = if matches!(provider, AIProvider::AWSBedrock) {
                     String::new()
@@ -271,6 +277,7 @@ impl AIRequestConfig {
                     aws_session_token,
                     platform,
                     enable_1m_context,
+                    custom_headers,
                 )
             }
             AIResource::OAuth(resource) => {
@@ -294,6 +301,7 @@ impl AIRequestConfig {
                     None,
                     AIPlatform::Standard,
                     false,
+                    HashMap::new(),
                 )
             }
         };
@@ -310,6 +318,7 @@ impl AIRequestConfig {
             aws_session_token,
             platform,
             enable_1m_context,
+            custom_headers,
         })
     }
 
@@ -440,6 +449,11 @@ impl AIRequestConfig {
 
         // Apply custom headers from AI_HTTP_HEADERS environment variable
         for (header_name, header_value) in AI_HTTP_HEADERS.iter() {
+            request = request.header(header_name.as_str(), header_value.as_str());
+        }
+
+        // Apply custom headers from the resource
+        for (header_name, header_value) in &self.custom_headers {
             request = request.header(header_name.as_str(), header_value.as_str());
         }
 

--- a/backend/windmill-worker/src/ai/types.rs
+++ b/backend/windmill-worker/src/ai/types.rs
@@ -193,6 +193,9 @@ pub struct ProviderResource {
     /// Enable 1M context window for Anthropic
     #[serde(alias = "enable_1M_context", default)]
     pub enable_1m_context: bool,
+    /// Custom HTTP headers to include in AI requests
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -243,6 +246,10 @@ impl ProviderWithResource {
 
     pub fn get_enable_1m_context(&self) -> bool {
         self.resource.enable_1m_context
+    }
+
+    pub fn get_headers(&self) -> &HashMap<String, String> {
+        &self.resource.headers
     }
 }
 

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -830,6 +830,8 @@ pub async fn run_agent(
                 .await
                 .0;
 
+            let resource_headers = args.provider.get_headers();
+
             // Helper to build HTTP request with headers
             let build_http_request = |body: String| {
                 let mut req = HTTP_CLIENT
@@ -842,6 +844,10 @@ pub async fn run_agent(
                 }
 
                 for (header_name, header_value) in AI_HTTP_HEADERS.iter() {
+                    req = req.header(header_name.as_str(), header_value.as_str());
+                }
+
+                for (header_name, header_value) in resource_headers {
                     req = req.header(header_name.as_str(), header_value.as_str());
                 }
 


### PR DESCRIPTION
## Summary
Allow users to add custom HTTP headers to the `customai` resource type. When the hub updates the resource type to include a `headers` field (a JSON object mapping header names to values), those headers will be sent on every AI request for that resource.

## Changes
- Add `headers: HashMap<String, String>` field (with `#[serde(default)]`) to `AIStandardResource` and `ProviderResource` structs
- Thread custom headers through `AIRequestConfig` and apply them in the API proxy's `prepare_request()`
- Apply resource custom headers in the worker's `build_http_request` closure for AI agent execution

## Test plan
- [ ] Verify existing AI resources without a `headers` field still work (backwards-compatible via `#[serde(default)]`)
- [ ] Create a customai resource with `"headers": {"X-Custom": "test"}` and verify the header is sent on AI requests
- [ ] Confirm custom headers from the resource are applied after env-var `AI_HTTP_HEADERS` (resource headers take precedence)

---
Generated with [Claude Code](https://claude.com/claude-code)