### PR TITLE
fix: powershell WindmillClient module loading on Windows workers

### DIFF
--- a/backend/windmill-worker/src/pwsh_executor.rs
+++ b/backend/windmill-worker/src/pwsh_executor.rs
@@ -18,7 +18,7 @@ const NSJAIL_CONFIG_RUN_POWERSHELL_CONTENT: &str =
     include_str!("../nsjail/run.powershell.config.proto");
 
 lazy_static::lazy_static! {
-    static ref RE_POWERSHELL_IMPORTS: Regex = Regex::new(r#"^Import-Module\s+(?:-Name\s+)?"?([^\s"]+)"?(?:\s+-RequiredVersion\s+"?([^\s"]+)"?)?"#).unwrap();
+    static ref RE_POWERSHELL_IMPORTS: Regex = Regex::new(r#"^\s*Import-Module\s+(?:-Name\s+)?"?([^\s"]+)"?(?:\s+-RequiredVersion\s+"?([^\s"]+)"?)?"#).unwrap();
 }
 
 use crate::{
@@ -196,17 +196,24 @@ async fn get_module_versions(module_path: &str) -> Result<Vec<String>, Error> {
                         .to_string();
 
                     // Check if this looks like a version (contains dots and numbers)
+                    // and verify a module manifest (.psd1) or script (.psm1) actually exists
                     if version.chars().any(|c| c.is_numeric()) && version.contains('.') {
-                        versions.push(version);
+                        let has_module_files = fs::read_dir(&version_path)
+                            .map(|entries| {
+                                entries.filter_map(|e| e.ok()).any(|e| {
+                                    let name = e.file_name();
+                                    let name = name.to_string_lossy();
+                                    name.ends_with(".psd1") || name.ends_with(".psm1")
+                                })
+                            })
+                            .unwrap_or(false);
+                        if has_module_files {
+                            versions.push(version);
+                        }
                     }
                 }
             }
         }
-    }
-
-    // If no version subdirectories found, treat as single version installation
-    if versions.is_empty() {
-        versions.push("unknown".to_string());
     }
 
     Ok(versions)
@@ -466,8 +473,8 @@ $env:PSModulePath = \"{};$PSModulePathBackup\"",
 
     let strict_termination_end = "\n\
         } catch {\n\
-            Write-Output \"An error occurred:\n\"\
-            Write-Output $_
+            Write-Output \"An error occurred:\"\n\
+            Write-Output $_\n\
             exit 1\n\
         }\n";
 


### PR DESCRIPTION
## Summary

- **Fix stale module cache detection**: `get_module_versions()` previously returned `["unknown"]` for empty/corrupted module directories, causing `check_module_installed()` to treat them as installed. Now verifies `.psd1`/`.psm1` files actually exist in version subdirectories before considering a module cached.
- **Fix Import-Module regex**: `RE_POWERSHELL_IMPORTS` used `^Import-Module` which skipped indented imports. Changed to `^\s*Import-Module` — the old behavior was masked by caching (module only needed to be detected once), but became visible when the cache path changed in 1.650.0.
- **Fix catch block formatting**: `Write-Output $_` was merged onto the same line as the closing `"` of the previous `Write-Output` due to a Rust line-continuation bug, causing PowerShell to parse `$_` as an argument rather than a separate command. This is why error output showed the literal text `Write-Output` in the error message.

**Regression introduced in**: 1.650.0 (`424ca59dfe` — make WINDMILL_DIR configurable), which moved the Windows PowerShell cache from `/tmp/windmill/cache/powershell` to `{temp_dir}/windmill/cache/powershell`. The old cache was abandoned, and the bugs in module detection/regex prevented recovery.

## Test plan

- [ ] Windows worker: run a PowerShell script with `Import-Module WindmillClient` and verify it installs and loads correctly
- [ ] Windows worker: run with indented `Import-Module WindmillClient` (inside function body or with leading spaces)
- [ ] Verify error output no longer shows literal `Write-Output` text when a script fails
- [ ] Delete the `powershell` cache directory and verify modules are re-downloaded on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)