### PR TITLE
fix: restore flat powershell module detection with file existence check

### DIFF
--- a/backend/windmill-worker/src/pwsh_executor.rs
+++ b/backend/windmill-worker/src/pwsh_executor.rs
@@ -216,6 +216,23 @@ async fn get_module_versions(module_path: &str) -> Result<Vec<String>, Error> {
         }
     }
 
+    // If no version subdirectories found, check if module files exist directly
+    // in the module directory (flat/single-version installation)
+    if versions.is_empty() {
+        let has_module_files = fs::read_dir(module_path)
+            .map(|entries| {
+                entries.filter_map(|e| e.ok()).any(|e| {
+                    let name = e.file_name();
+                    let name = name.to_string_lossy();
+                    name.ends_with(".psd1") || name.ends_with(".psm1")
+                })
+            })
+            .unwrap_or(false);
+        if has_module_files {
+            versions.push("unknown".to_string());
+        }
+    }
+
     Ok(versions)
 }
 


### PR DESCRIPTION
## Summary

- Followup to #8370. The removed `"unknown"` fallback in `get_module_versions()` was handling flat module installations (files directly in module dir, no version subdirectory). Restores that case but now verifies `.psd1`/`.psm1` files actually exist instead of blindly treating any directory as installed.

## Test plan

- [ ] Module installed with version subdirectory (`WindmillClient/1.655.0/WindmillClient.psd1`) is detected
- [ ] Module installed flat (`SomeModule/SomeModule.psd1`) is detected
- [ ] Empty module directory is NOT detected as installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)