### PR TITLE
test: add powershell module detection and execution tests

### DIFF
--- a/backend/tests/worker.rs
+++ b/backend/tests/worker.rs
@@ -1518,6 +1518,92 @@ Write-Output "hello $msg"
     Ok(())
 }
 
+#[sqlx::test(fixtures("base"))]
+async fn test_powershell_param_block_with_attributes(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    let content = r#"
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Name,
+    [int]$Count = 3
+)
+Write-Output "$Name-$Count"
+"#
+    .to_owned();
+
+    let job = RunJob::from(JobPayload::Code(RawCode {
+        hash: None,
+        content,
+        path: None,
+        lock: None,
+        language: ScriptLang::Powershell,
+        cache_ttl: None,
+        cache_ignore_s3_path: None,
+        dedicated_worker: None,
+        concurrency_settings: windmill_common::runnable_settings::ConcurrencySettings::default()
+            .into(),
+        debouncing_settings: windmill_common::runnable_settings::DebouncingSettings::default(),
+    }))
+    .arg("Name", json!("test"))
+    .arg("Count", json!(7))
+    .run_until_complete(&db, false, port)
+    .await;
+    assert_eq!(job.json_result(), Some(json!("test-7")));
+    Ok(())
+}
+
+#[sqlx::test(fixtures("base"))]
+async fn test_powershell_error_caught(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    // Script with param block that throws an error — verifies the catch block works
+    let content = r#"
+param($x)
+throw "intentional error"
+"#
+    .to_owned();
+
+    let job = RunJob::from(JobPayload::Code(RawCode {
+        hash: None,
+        content,
+        path: None,
+        lock: None,
+        language: ScriptLang::Powershell,
+        cache_ttl: None,
+        cache_ignore_s3_path: None,
+        dedicated_worker: None,
+        concurrency_settings: windmill_common::runnable_settings::ConcurrencySettings::default()
+            .into(),
+        debouncing_settings: windmill_common::runnable_settings::DebouncingSettings::default(),
+    }))
+    .arg("x", json!(1))
+    .run_until_complete(&db, false, port)
+    .await;
+    assert!(!job.success, "job should fail on thrown error");
+    let result_str = serde_json::to_string(&job.result).unwrap_or_default();
+    assert!(
+        result_str.contains("An error occurred:"),
+        "catch block should output 'An error occurred:', got: {result_str}"
+    );
+    assert!(
+        result_str.contains("intentional error"),
+        "catch block should output the error message, got: {result_str}"
+    );
+    // Verify the catch block doesn't leak "Write-Output" as literal text
+    // (regression from the old broken line continuation in strict_termination_end)
+    let after_marker = result_str.split("An error occurred:").nth(1).unwrap_or("");
+    assert!(
+        !after_marker.starts_with("\\nWrite-Output"),
+        "catch block should not output literal 'Write-Output' text, got: {result_str}"
+    );
+    Ok(())
+}
+
 #[cfg(feature = "php")]
 #[sqlx::test(fixtures("base"))]
 async fn test_php_job(db: Pool<Postgres>) -> anyhow::Result<()> {

--- a/backend/windmill-worker/Cargo.toml
+++ b/backend/windmill-worker/Cargo.toml
@@ -143,5 +143,8 @@ hyper-tls = { workspace = true, optional = true }
 hyper-util = { workspace = true, optional = true }
 rcgen = { workspace = true, optional = true }
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [build-dependencies]
 libffi-sys = { workspace = true, optional = true }

--- a/backend/windmill-worker/src/pwsh_executor.rs
+++ b/backend/windmill-worker/src/pwsh_executor.rs
@@ -696,3 +696,231 @@ $env:PSModulePath = \"{};$PSModulePathBackup\"",
         "No result.out, result2.out or result.json found"
     )))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    // --- RE_POWERSHELL_IMPORTS regex tests ---
+
+    fn match_import(line: &str) -> Option<(String, Option<String>)> {
+        RE_POWERSHELL_IMPORTS.captures(line).map(|cap| {
+            let name = cap.get(1).unwrap().as_str().to_string();
+            let version = cap.get(2).map(|m| m.as_str().to_string());
+            (name, version)
+        })
+    }
+
+    #[test]
+    fn test_import_module_basic() {
+        let (name, version) = match_import("Import-Module WindmillClient").unwrap();
+        assert_eq!(name, "WindmillClient");
+        assert_eq!(version, None);
+    }
+
+    #[test]
+    fn test_import_module_with_leading_whitespace() {
+        let (name, _) = match_import("    Import-Module WindmillClient").unwrap();
+        assert_eq!(name, "WindmillClient");
+    }
+
+    #[test]
+    fn test_import_module_with_tab_indent() {
+        let (name, _) = match_import("\tImport-Module WindmillClient").unwrap();
+        assert_eq!(name, "WindmillClient");
+    }
+
+    #[test]
+    fn test_import_module_with_name_flag() {
+        let (name, _) = match_import("Import-Module -Name WindmillClient").unwrap();
+        assert_eq!(name, "WindmillClient");
+    }
+
+    #[test]
+    fn test_import_module_with_required_version() {
+        let (name, version) =
+            match_import(r#"Import-Module WindmillClient -RequiredVersion "1.655.0""#).unwrap();
+        assert_eq!(name, "WindmillClient");
+        assert_eq!(version, Some("1.655.0".to_string()));
+    }
+
+    #[test]
+    fn test_import_module_quoted_name() {
+        let (name, _) = match_import(r#"Import-Module "WindmillClient""#).unwrap();
+        assert_eq!(name, "WindmillClient");
+    }
+
+    #[test]
+    fn test_import_module_name_flag_quoted_with_version() {
+        let (name, version) =
+            match_import(r#"Import-Module -Name "WindmillClient" -RequiredVersion "2.0.0""#)
+                .unwrap();
+        assert_eq!(name, "WindmillClient");
+        assert_eq!(version, Some("2.0.0".to_string()));
+    }
+
+    #[test]
+    fn test_import_module_indented_with_version() {
+        let (name, version) =
+            match_import(r#"    Import-Module WindmillClient -RequiredVersion 1.0.0"#).unwrap();
+        assert_eq!(name, "WindmillClient");
+        assert_eq!(version, Some("1.0.0".to_string()));
+    }
+
+    #[test]
+    fn test_commented_import_not_matched() {
+        assert!(match_import("# Import-Module WindmillClient").is_none());
+    }
+
+    // --- get_module_versions / check_module_installed tests ---
+
+    #[tokio::test]
+    async fn test_empty_module_dir_not_installed() {
+        let tmp = TempDir::new().unwrap();
+        let module_dir = tmp.path().join("WindmillClient");
+        fs::create_dir(&module_dir).unwrap();
+
+        let versions = get_module_versions(module_dir.to_str().unwrap())
+            .await
+            .unwrap();
+        assert!(versions.is_empty(), "empty dir should have no versions");
+    }
+
+    #[tokio::test]
+    async fn test_empty_version_subdir_not_installed() {
+        let tmp = TempDir::new().unwrap();
+        let module_dir = tmp.path().join("WindmillClient");
+        let version_dir = module_dir.join("1.655.0");
+        fs::create_dir_all(&version_dir).unwrap();
+
+        let versions = get_module_versions(module_dir.to_str().unwrap())
+            .await
+            .unwrap();
+        assert!(
+            versions.is_empty(),
+            "version dir without .psd1/.psm1 should not count"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_valid_versioned_module_detected() {
+        let tmp = TempDir::new().unwrap();
+        let module_dir = tmp.path().join("WindmillClient");
+        let version_dir = module_dir.join("1.655.0");
+        fs::create_dir_all(&version_dir).unwrap();
+        fs::write(version_dir.join("WindmillClient.psd1"), "# manifest").unwrap();
+        fs::write(version_dir.join("WindmillClient.psm1"), "# module").unwrap();
+
+        let versions = get_module_versions(module_dir.to_str().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(versions, vec!["1.655.0"]);
+    }
+
+    #[tokio::test]
+    async fn test_flat_module_with_files_detected() {
+        let tmp = TempDir::new().unwrap();
+        let module_dir = tmp.path().join("MyModule");
+        fs::create_dir(&module_dir).unwrap();
+        fs::write(module_dir.join("MyModule.psm1"), "# module").unwrap();
+
+        let versions = get_module_versions(module_dir.to_str().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(versions, vec!["unknown"]);
+    }
+
+    #[tokio::test]
+    async fn test_flat_module_without_files_not_detected() {
+        let tmp = TempDir::new().unwrap();
+        let module_dir = tmp.path().join("MyModule");
+        fs::create_dir(&module_dir).unwrap();
+        fs::write(module_dir.join("readme.txt"), "not a module").unwrap();
+
+        let versions = get_module_versions(module_dir.to_str().unwrap())
+            .await
+            .unwrap();
+        assert!(versions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_check_module_installed_empty_dir_returns_false() {
+        let tmp = TempDir::new().unwrap();
+        let module_dir = tmp.path().join("WindmillClient");
+        fs::create_dir(&module_dir).unwrap();
+
+        let mut dirs = HashMap::new();
+        dirs.insert(
+            "windmillclient".to_string(),
+            module_dir.to_str().unwrap().to_string(),
+        );
+
+        let (installed, _) = check_module_installed(&dirs, "WindmillClient", None)
+            .await
+            .unwrap();
+        assert!(
+            !installed,
+            "empty module dir should not be considered installed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_module_installed_valid_module_returns_true() {
+        let tmp = TempDir::new().unwrap();
+        let module_dir = tmp.path().join("WindmillClient");
+        let version_dir = module_dir.join("1.655.0");
+        fs::create_dir_all(&version_dir).unwrap();
+        fs::write(version_dir.join("WindmillClient.psd1"), "# manifest").unwrap();
+
+        let mut dirs = HashMap::new();
+        dirs.insert(
+            "windmillclient".to_string(),
+            module_dir.to_str().unwrap().to_string(),
+        );
+
+        let (installed, versions) = check_module_installed(&dirs, "WindmillClient", None)
+            .await
+            .unwrap();
+        assert!(installed);
+        assert_eq!(versions, vec!["1.655.0"]);
+    }
+
+    #[tokio::test]
+    async fn test_check_module_installed_wrong_version_returns_false() {
+        let tmp = TempDir::new().unwrap();
+        let module_dir = tmp.path().join("WindmillClient");
+        let version_dir = module_dir.join("1.0.0");
+        fs::create_dir_all(&version_dir).unwrap();
+        fs::write(version_dir.join("WindmillClient.psd1"), "# manifest").unwrap();
+
+        let mut dirs = HashMap::new();
+        dirs.insert(
+            "windmillclient".to_string(),
+            module_dir.to_str().unwrap().to_string(),
+        );
+
+        let (installed, _) = check_module_installed(&dirs, "WindmillClient", Some("2.0.0"))
+            .await
+            .unwrap();
+        assert!(!installed, "wrong version should not match");
+    }
+
+    #[tokio::test]
+    async fn test_multiple_versions_detected() {
+        let tmp = TempDir::new().unwrap();
+        let module_dir = tmp.path().join("WindmillClient");
+        for ver in &["1.0.0", "1.655.0"] {
+            let version_dir = module_dir.join(ver);
+            fs::create_dir_all(&version_dir).unwrap();
+            fs::write(version_dir.join("WindmillClient.psd1"), "# manifest").unwrap();
+        }
+
+        let mut versions = get_module_versions(module_dir.to_str().unwrap())
+            .await
+            .unwrap();
+        versions.sort();
+        assert_eq!(versions, vec!["1.0.0", "1.655.0"]);
+    }
+}


### PR DESCRIPTION
## Summary

Adds test coverage for the PowerShell module loading fixes from #8370 and #8371.

**18 unit tests** in `pwsh_executor.rs` covering:
- `RE_POWERSHELL_IMPORTS` regex: basic, indented (spaces/tabs), quoted names, `-Name` flag, `-RequiredVersion`, commented-out imports
- `get_module_versions()`: empty dir, empty version subdir, valid versioned module, flat module with/without files, multiple versions
- `check_module_installed()`: empty dir returns false, valid module returns true, wrong version returns false

**2 new e2e integration tests** in `tests/worker.rs`:
- `test_powershell_param_block_with_attributes`: param block with `[Parameter]` attributes and typed params
- `test_powershell_error_caught`: verifies catch block outputs "An error occurred:" and the error message without leaking literal "Write-Output" text

## Test plan

- [x] `cargo test -p windmill-worker pwsh_executor::tests` — 18/18 passed
- [x] `cargo test --test worker test_powershell` — 3/3 passed (including existing `test_powershell_job`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)