### PR TITLE
chore: make flake dev env vars respect per-worktree overrides

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,7 @@
 use flake
+
+# Per-worktree overrides (ports, DATABASE_URL, etc.) written by webmux/workmux
+# post-create hooks. Must come after `use flake` so they take precedence over
+# the flake's defaults.
+# shellcheck source=/dev/null
+[ -f .env.local ] && source .env.local

--- a/flake.nix
+++ b/flake.nix
@@ -229,12 +229,19 @@
         # ---------------------------------------------------------------
 
         devEnvVars = {
-          DATABASE_URL = "postgres://postgres:changeme@127.0.0.1:5432/windmill?sslmode=disable";
-          REMOTE = "http://127.0.0.1:8000";
-          REMOTE_LSP = "http://127.0.0.1:3001";
           NODE_ENV = "development";
           NODE_OPTIONS = "--max-old-space-size=16384";
         };
+
+        # Connection-specific defaults — set via shellHook so they respect
+        # pre-existing values (e.g. from webmux runtime.env / .env.local).
+        # Nix attrs are injected unconditionally and would override per-worktree
+        # values set by webmux before the interactive shell starts.
+        devShellHook = ''
+          export DATABASE_URL="''${DATABASE_URL:-postgres://postgres:changeme@127.0.0.1:5432/windmill?sslmode=disable}"
+          export REMOTE="''${REMOTE:-http://127.0.0.1:8000}"
+          export REMOTE_LSP="''${REMOTE_LSP:-http://127.0.0.1:3001}"
+        '';
 
         # ---------------------------------------------------------------
         # Helper scripts — base set (default + full)
@@ -402,6 +409,7 @@
         # =============================================================
 
         devShells.default = pkgs.mkShell (buildEnvVars // commonRuntimeVars // devEnvVars // browserVars // {
+          shellHook = devShellHook;
           buildInputs = coreBuildInputs;
 
           packages = helperScriptsBase ++ [ playwrightWrapper ];
@@ -413,6 +421,7 @@
         # =============================================================
 
         devShells.full = pkgs.mkShell (buildEnvVars // commonRuntimeVars // extraRuntimeVars // devEnvVars // browserVars // {
+          shellHook = devShellHook;
           buildInputs = coreBuildInputs ++ extraRuntimes ++ (with pkgs; [
             # Python extras
             poetry


### PR DESCRIPTION
## Summary
Webmux/workmux worktrees get per-worktree `DATABASE_URL`, `REMOTE`, and port assignments via `.env.local`. However, the Nix flake's `devEnvVars` hardcoded these as derivation attributes, which direnv (`use flake`) applied unconditionally — overwriting the correct worktree-specific values with the main worktree defaults.

## Changes
- Move `DATABASE_URL`, `REMOTE`, `REMOTE_LSP` from Nix attrs to a `shellHook` using `${VAR:-default}` so they respect pre-existing values from webmux's `runtime.env`
- Add `shellHook = devShellHook` to both `default` and `full` devShells
- Update `.envrc` to source `.env.local` after `use flake`, so direnv picks up per-worktree overrides (needed because `nix print-dev-env` evaluates shellHook in a clean subshell)

## Test plan
- [ ] Main worktree (no `.env.local`): `echo $DATABASE_URL` still shows `windmill` default
- [ ] Webmux worktree with `.env.local`: `echo $DATABASE_URL` shows worktree-specific DB, `echo $REMOTE` shows correct port
- [ ] `nix develop` without direnv: defaults still apply

---
Generated with [Claude Code](https://claude.com/claude-code)