### PR TITLE
fix: pre-load cached powershell modules in profile

### DIFF
--- a/backend/windmill-worker/src/pwsh_executor.rs
+++ b/backend/windmill-worker/src/pwsh_executor.rs
@@ -458,25 +458,26 @@ pub async fn handle_powershell_job(
     logs2.push_str("\n\n--- POWERSHELL CODE EXECUTION ---\n");
     append_logs(&job.id, &job.workspace_id, logs2, db).await;
 
-    // make sure default (only allhostsallusers) modules are loaded, disable autoload (cache can be large to explore especially on cloud) and add /tmp/windmill/cache to PSModulePath
+    // Pre-load system modules and cached modules (e.g. WindmillClient), then disable
+    // autoloading so the large cache dir isn't scanned on every command invocation.
     #[cfg(unix)]
     let profile = format!(
         "$PSModuleAutoloadingPreference = 'None'
 $PSModulePathBackup = $env:PSModulePath
-$env:PSModulePath = \"$PSHome/Modules\"
+$env:PSModulePath = \"$PSHome/Modules:{}\"
 Get-Module -ListAvailable | Import-Module
 $env:PSModulePath = \"{}:$PSModulePathBackup\"",
-        *POWERSHELL_CACHE_DIR
+        *POWERSHELL_CACHE_DIR, *POWERSHELL_CACHE_DIR
     );
 
     #[cfg(windows)]
     let profile = format!(
         "$PSModuleAutoloadingPreference = 'None'
 $PSModulePathBackup = $env:PSModulePath
-$env:PSModulePath = \"C:\\Program Files\\PowerShell\\7\\Modules\"
+$env:PSModulePath = \"C:\\Program Files\\PowerShell\\7\\Modules;{}\"
 Get-Module -ListAvailable | Import-Module
 $env:PSModulePath = \"{};$PSModulePathBackup\"",
-        *POWERSHELL_CACHE_DIR
+        *POWERSHELL_CACHE_DIR, *POWERSHELL_CACHE_DIR
     );
 
     // NOTE: powershell error handling / termination is quite tricky compared to bash


### PR DESCRIPTION
## Summary

- Include `POWERSHELL_CACHE_DIR` in `PSModulePath` **before** `Get-Module -ListAvailable | Import-Module` in the PowerShell profile, so cached modules (like WindmillClient) are pre-loaded alongside system modules.

**Root cause**: The profile disables autoloading (`$PSModuleAutoloadingPreference = 'None'`) for performance, then only pre-loads system modules from `$PSHome/Modules`. Cached modules (WindmillClient, etc.) were added to `PSModulePath` afterwards but never imported — so commands like `Connect-Windmill` fail unless the user explicitly writes `Import-Module WindmillClient`.

This was "hit or miss" across workers: workers where `Install-Module WindmillClient -Scope AllUsers` had been run previously had the module in `C:\Program Files\PowerShell\7\Modules`, so `Get-Module -ListAvailable | Import-Module` picked it up. Workers without it failed.

**Before** (only system modules pre-loaded):
```powershell
$env:PSModulePath = "C:\Program Files\PowerShell\7\Modules"
Get-Module -ListAvailable | Import-Module
$env:PSModulePath = "{CACHE_DIR};$PSModulePathBackup"
```

**After** (system + cached modules pre-loaded):
```powershell
$env:PSModulePath = "C:\Program Files\PowerShell\7\Modules;{CACHE_DIR}"
Get-Module -ListAvailable | Import-Module
$env:PSModulePath = "{CACHE_DIR};$PSModulePathBackup"
```

## Test plan

- [ ] Windows worker: script using `Connect-Windmill` without explicit `Import-Module WindmillClient` should work
- [ ] Verify cached modules are pre-loaded (check that `Get-Module WindmillClient` shows the module)
- [ ] Verify system modules still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)