### PR TITLE
fix: use bookworm-based php image to fix glibc incompatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -268,7 +268,7 @@ RUN bun install -g windmill-cli \
 RUN curl -fsSL https://claude.ai/install.sh | bash \
     && cp /root/.local/share/claude/versions/* /usr/bin/claude
 
-COPY --from=php:8.3.30-cli /usr/local/bin/php /usr/bin/php
+COPY --from=php:8.3.30-cli-bookworm /usr/local/bin/php /usr/bin/php
 COPY --from=composer:2.9.5 /usr/bin/composer /usr/bin/composer
 
 # add the docker client to call docker from a worker if enabled

--- a/integration_tests/test/identity_script_test.py
+++ b/integration_tests/test/identity_script_test.py
@@ -30,6 +30,12 @@ func main(x int) (interface{}, error) {
 def main(x: int):
     return x
 """,
+    "php": """<?php
+
+function main(int $x): int {
+    return $x;
+}
+""",
 }
 
 
@@ -78,5 +84,10 @@ class TestIdentityScript(unittest.TestCase):
 
     def test_python(self):
         path = PATH_TEMPLATE.format(lang="python3")
+        result = self._client.run_sync(path, {"x": 5})
+        self.assertEqual(result, 5)
+
+    def test_php(self):
+        path = PATH_TEMPLATE.format(lang="php")
         result = self._client.run_sync(path, {"x": 5})
         self.assertEqual(result, 5)


### PR DESCRIPTION
## Summary
Since v1.655.0, the bundled PHP binary fails on startup with `GLIBC_2.38 not found` because `php:8.3.30-cli` defaults to Debian Trixie (glibc 2.38) while the runtime base image is Bookworm (glibc 2.36).

## Changes
- Use `php:8.3.30-cli-bookworm` instead of `php:8.3.30-cli` in the Dockerfile so the PHP binary is compiled against the matching glibc
- Add PHP identity script to integration tests to catch runtime failures in CI

## Test plan
- [ ] Build Docker image and verify `php --version` works without glibc errors
- [ ] Run a PHP script in Windmill and confirm it executes successfully
- [ ] Integration test `test_php` passes in CI

---
Generated with [Claude Code](https://claude.com/claude-code)