### PR TITLE
fix: improve OOM killer observability for debugging pod-level kills

### DIFF
--- a/backend/src/cgroups.rs
+++ b/backend/src/cgroups.rs
@@ -76,6 +76,13 @@ pub fn disable_oom_group() -> Result<(), CgroupError> {
                         val.trim(),
                         cgroup_path
                     );
+                    return Err(CgroupError::Io(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!(
+                            "memory.oom.group write did not take effect, read back '{}'",
+                            val.trim()
+                        ),
+                    )));
                 }
                 Err(e) => {
                     tracing::warn!(

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -885,7 +885,13 @@ async fn windmill_main() -> anyhow::Result<()> {
         match std::fs::read_to_string("/proc/self/oom_score_adj") {
             Ok(current) => {
                 let current = current.trim().to_string();
-                let current_val = current.parse::<i32>().unwrap_or(0);
+                let current_val = match current.parse::<i32>() {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::warn!("Could not parse oom_score_adj '{current}': {e}");
+                        0
+                    }
+                };
                 if current_val > 0 {
                     match std::fs::write("/proc/self/oom_score_adj", "0") {
                         Ok(_) => {

--- a/backend/windmill-worker/src/handle_child.rs
+++ b/backend/windmill-worker/src/handle_child.rs
@@ -135,7 +135,7 @@ pub async fn handle_child(
                     tracing::error!("Failed to write oom_score_adj for pid {pid}: {e:#}");
                 }
                 if let Err(e) = file.sync_all().await {
-                    tracing::error!("Failed to sync oom_score_adj for pid {pid}: {e:#}");
+                    tracing::warn!("Failed to sync oom_score_adj for pid {pid}: {e:#}");
                 }
             }
             Err(e) => {


### PR DESCRIPTION
## Summary
When a job exceeds memory in Kubernetes, the OOM killer should target the job process (oom_score_adj=1000) instead of the worker (oom_score_adj=937 from k8s burstable QoS). This PR improves logging so we can diagnose why the worker/pod is being killed instead.

Investigation on dfc/windmill-workers-default-66cf659555-66dk5 (EU cluster) showed:
- `memory.oom.group=0` ✓ (disable_oom_group working)
- Worker `oom_score_adj=937`, jobs get `1000` → only 63-point gap (~129MB margin on 2GB cgroup)
- No OOM-related log lines existed at startup — impossible to diagnose failures

## Changes
- **handle_child.rs**: Log errors from `oom_score_adj` write/sync instead of silently discarding with `let _ =`
- **cgroups.rs**: Add cgroup path to all log messages, verify write took effect by reading back, log consequence in every failure path
- **main.rs**: Log worker's own `oom_score_adj` at startup with gap calculation vs jobs (1000)

## Test plan
- [ ] Deploy to a worker pod and verify startup logs show `Worker oom_score_adj=X (jobs get 1000, gap=Y)`
- [ ] Verify `memory.oom.group` status is logged with full cgroup path
- [ ] Trigger an OOM scenario and confirm job-level oom_score_adj write errors (if any) are now visible

---
Generated with [Claude Code](https://claude.com/claude-code)