### PR TITLE
chore: return structured error object on AI agent max iterations

### DIFF
--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -1042,6 +1042,8 @@ pub async fn run_agent(
                     struct MaxIterError<'a> {
                         message: String,
                         name: &'static str,
+                        #[serde(skip_serializing_if = "Option::is_none")]
+                        step_id: Option<&'a str>,
                         result: MaxIterPartialResult<'a>,
                     }
                     #[derive(serde::Serialize)]
@@ -1055,6 +1057,7 @@ pub async fn run_agent(
                                 max_iterations
                             ),
                             name: "ExecutionErr",
+                            step_id: effective_flow_step_id,
                             result: MaxIterPartialResult { messages: &messages },
                         })?,
                     ));


### PR DESCRIPTION
## Summary
- Changes the AI agent max iterations error from a flat string (with partial result embedded in the message) to a structured JSON object with separate `message` and `result` fields
- Uses `Error::ExecutionRawError` instead of `Error::internal_err` so the error object passes through as-is
- The `result` field contains `{ "messages": [...] }` with the conversation history up to the iteration limit, making it easy for downstream steps (with "continue on error") to access the partial result programmatically

## Test plan
- [ ] Trigger an AI agent step that exceeds `max_iterations` and verify the error result has `message`, `name`, and `result` fields
- [ ] Verify "continue on error" still works and the next step can access `result.messages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)