### PR TITLE
fix(cli): improve initial dev flow loading

### DIFF
--- a/cli/src/commands/dev/dev.ts
+++ b/cli/src/commands/dev/dev.ts
@@ -94,10 +94,33 @@ async function dev(opts: GlobalOptions & SyncOptions) {
           SEP,
           undefined,
         );
+        if (localFlow.value.failure_module) {
+          await replaceInlineScripts(
+            [localFlow.value.failure_module],
+            async (path: string) => await readFile(localPath + path, "utf-8"),
+            log,
+            localPath,
+            SEP,
+            undefined,
+          );
+        }
+        if (localFlow.value.preprocessor_module) {
+          await replaceInlineScripts(
+            [localFlow.value.preprocessor_module],
+            async (path: string) => await readFile(localPath + path, "utf-8"),
+            log,
+            localPath,
+            SEP,
+            undefined,
+          );
+        }
         currentLastEdit = {
           type: "flow",
           flow: localFlow,
           uriPath: localPath,
+          path: localPath
+            .substring(0, localPath.indexOf(".flow"))
+            .replaceAll(SEP, "/"),
         };
         log.info("Updated " + localPath);
         broadcastChanges(currentLastEdit);
@@ -141,6 +164,7 @@ async function dev(opts: GlobalOptions & SyncOptions) {
     type: "flow";
     flow: OpenFlow;
     uriPath: string;
+    path: string;
   };
 
   const connectedClients: Set<WebSocket> = new Set();
@@ -164,11 +188,13 @@ async function dev(opts: GlobalOptions & SyncOptions) {
       connectedClients.add(ws);
       console.log("New client connected");
 
-      ws.on("open", () => {
-        if (currentLastEdit) {
-          broadcastChanges(currentLastEdit);
-        }
-      });
+      if (currentLastEdit) {
+        setTimeout(() => {
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify(currentLastEdit));
+          }
+        }, 50);
+      }
 
       ws.on("close", () => {
         connectedClients.delete(ws);


### PR DESCRIPTION
## Summary
- send the last edited flow payload immediately to new `wmill dev` websocket clients
- include the flow `path` in dev flow payloads so the frontend receives the full flow identity it expects
- inline `failure_module` and `preprocessor_module` scripts in `wmill dev`, not just regular `modules`

## Why
`wmill dev` had a few pre-existing flow-specific issues unrelated to local PathScript previewing:
- a fresh browser tab could connect and still stay on the placeholder state because the server never sent the initial `currentLastEdit` on connect
- dev flow payloads were missing `path`, while the frontend expects both `uriPath` and `path`
- inline scripts in `failure_module` and `preprocessor_module` were not resolved in dev mode

## Validation
- manual websocket-level verification on a local dev session confirmed that a connected client now receives the latest flow payload immediately
- verified that the emitted flow payload now includes:
  - inlined regular modules
  - inlined `failure_module`
  - inlined `preprocessor_module`
  - flow `path`
