### PR TITLE
fix: add checkpoint.json mount to python nsjail config for WAC v2

### DIFF
--- a/backend/windmill-worker/nsjail/run.python3.config.proto
+++ b/backend/windmill-worker/nsjail/run.python3.config.proto
@@ -88,6 +88,13 @@ mount {
 }
 
 mount {
+    src: "{JOB_DIR}/checkpoint.json"
+    dst: "/tmp/checkpoint.json"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
     src: "{JOB_DIR}/result.json"
     dst: "/tmp/result.json"
     rw: true


### PR DESCRIPTION
## Summary
Python WAC v2 scripts running in nsjail sandbox fail with `FileNotFoundError: checkpoint.json` because the file is written to `job_dir` but never bind-mounted into the sandbox.

## Changes
- Added `checkpoint.json` mount entry to `run.python3.config.proto` with `mandatory: false`, matching the existing mount in the bun nsjail config

## Test plan
- [ ] Run a Python WAC v2 workflow in sandbox mode — should no longer error on missing checkpoint.json
- [ ] Run a regular (non-WAC) Python script in sandbox mode — should still work (mount is `mandatory: false`)

---
Generated with [Claude Code](https://claude.com/claude-code)