### PR TITLE
fix: exclude wm_deployers group from CE group limit check

### DIFF
--- a/backend/.sqlx/query-bc6ebef9d41aba232f115f95404922c6054df01fa7f38f5d15d6d4af6c726a3c.json
+++ b/backend/.sqlx/query-bc6ebef9d41aba232f115f95404922c6054df01fa7f38f5d15d6d4af6c726a3c.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) FROM group_ WHERE name != 'all' AND name != 'error_handler' AND name != 'slack' AND name != 'wm_deployers'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "bc6ebef9d41aba232f115f95404922c6054df01fa7f38f5d15d6d4af6c726a3c"
+}

--- a/backend/windmill-api-groups/src/groups.rs
+++ b/backend/windmill-api-groups/src/groups.rs
@@ -215,12 +215,12 @@ pub async fn require_is_owner(
 }
 
 async fn _check_nb_of_groups(db: &DB) -> Result<()> {
-    let nb_groups = sqlx::query_scalar!("SELECT COUNT(*) FROM group_ WHERE name != 'all' AND name != 'error_handler' AND name != 'slack'",)
+    let nb_groups = sqlx::query_scalar!("SELECT COUNT(*) FROM group_ WHERE name != 'all' AND name != 'error_handler' AND name != 'slack' AND name != 'wm_deployers'",)
         .fetch_one(db)
         .await?;
     if nb_groups.unwrap_or(0) >= 3 {
         return Err(Error::BadRequest(
-            "You have reached the maximum number of groups (3 outside of native groups 'all', 'slack' and 'error_handler') without an enterprise license"
+            "You have reached the maximum number of groups (3 outside of native groups 'all', 'slack', 'error_handler' and 'wm_deployers') without an enterprise license"
                 .to_string(),
         ));
     }


### PR DESCRIPTION
## Summary
The `wm_deployers` built-in group was counting toward the CE limit of 3 custom groups, preventing users from creating groups when `wm_deployers` existed.

## Changes
- Added `AND name != 'wm_deployers'` to the SQL query in `_check_nb_of_groups` so the native `wm_deployers` group is excluded from the count
- Updated the error message to list `wm_deployers` as a native group
- Added corresponding sqlx offline cache file

## Test plan
- [ ] Create a CE workspace, verify `wm_deployers` group exists and does not count toward the 3-group limit
- [ ] Verify you can still create 3 custom groups alongside `all`, `slack`, `error_handler`, and `wm_deployers`

---
Generated with [Claude Code](https://claude.com/claude-code)