### PR TITLE
fix: prevent S3 file browser crash when selecting storage

### DIFF
--- a/frontend/src/lib/components/S3FilePickerInner.svelte
+++ b/frontend/src/lib/components/S3FilePickerInner.svelte
@@ -592,10 +592,18 @@
 						<input type="text" placeholder="Folder prefix" bind:value={filter} class="text-xl" />
 					</div>
 				{/if}
-				{#if fileListLoading === false && displayedFileKeys.length === 0}
-					<div class="p-4 text-primary text-xs text-center italic">
-						No files in the workspace S3 bucket at that prefix
-					</div>
+				{#if displayedFileKeys.length === 0}
+					{#if fileListLoading}
+						<div class="grow min-h-0 flex justify-center items-center">
+							<div class="flex text-secondary text-xs items-center">
+								<Loader2 size={12} class="animate-spin mr-1" /> Loading content
+							</div>
+						</div>
+					{:else}
+						<div class="p-4 text-primary text-xs text-center italic">
+							No files in the workspace S3 bucket at that prefix
+						</div>
+					{/if}
 				{:else}
 					<div class="grow min-h-0" bind:clientHeight={listDivHeight}>
 						<VirtualList


### PR DESCRIPTION
## Summary
Fix crash `Uncaught Error: Requested index 0 is outside of range 0..0` when selecting a storage in the S3 file browser.

## Changes
- Changed the conditional guard in `S3FilePickerInner.svelte` from `fileListLoading === false && displayedFileKeys.length === 0` to `displayedFileKeys.length === 0`, so VirtualList is never mounted with zero items
- When loading with no items yet, show a centered loading spinner instead of an empty VirtualList
- When not loading and no items exist, show the existing "No files" message

## Root cause
The `@tutorlatin/svelte-tiny-virtual-list` VirtualList component crashes on mount when `itemCount = 0` and `height > 0`. Its internal `SizeAndPositionManager.getSizeAndPositionForIndex(0)` throws because `0 >= itemCount (0)`.

The old condition allowed VirtualList to unmount (when a storage had no files) and then remount with `itemCount = 0` when switching to another storage — because `reloadContent()` sets `fileListLoading = true` before files load, flipping the condition. Meanwhile `listDivHeight` retained its previous non-zero value, giving VirtualList a positive height and triggering the crash in the mount effect.

## Test plan
- [ ] Open S3 file browser with a storage that has files
- [ ] Switch to a secondary storage — verify no crash and loading spinner appears
- [ ] Switch to a storage with no files — verify "No files" message appears
- [ ] Switch back to a storage with files — verify files load correctly

---
Generated with [Claude Code](https://claude.com/claude-code)