### PR TITLE
fix: improve DND drag feedback in EditableSchemaForm

### DIFF
--- a/frontend/src/lib/components/SchemaForm.svelte
+++ b/frontend/src/lib/components/SchemaForm.svelte
@@ -16,7 +16,11 @@
 	import ArgInput from './ArgInput.svelte'
 	import { createEventDispatcher, untrack } from 'svelte'
 	import { deepEqual } from 'fast-equals'
-	import { dragHandleZone, type Options as DndOptions } from '@windmill-labs/svelte-dnd-action'
+	import {
+		dragHandleZone,
+		SHADOW_ITEM_MARKER_PROPERTY_NAME,
+		type Options as DndOptions
+	} from '@windmill-labs/svelte-dnd-action'
 	import type { SchemaDiff } from '$lib/components/schema/schemaUtils.svelte'
 	import type { ComponentCustomCSS } from './apps/types'
 	import ResizeTransitionWrapper from './common/ResizeTransitionWrapper.svelte'
@@ -295,7 +299,9 @@
 				class={twMerge(
 					typeof diff[argName] === 'object' &&
 						diff[argName].diff !== 'same' &&
-						'bg-red-300 dark:bg-red-800 rounded-md'
+						'bg-red-300 dark:bg-red-800 rounded-md',
+					item[SHADOW_ITEM_MARKER_PROPERTY_NAME] &&
+						'!visible border-2 border-dashed border-blue-300 dark:border-blue-600 bg-blue-50 dark:bg-blue-900/20 rounded-md [&>*]:invisible'
 				)}
 				innerClass="w-full"
 			>

--- a/frontend/src/lib/components/schema/SchemaFormDND.svelte
+++ b/frontend/src/lib/components/schema/SchemaFormDND.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { createEventDispatcher, untrack } from 'svelte'
-	import { dragHandle } from '@windmill-labs/svelte-dnd-action'
+	import { dragHandle, TRIGGERS } from '@windmill-labs/svelte-dnd-action'
 	import SchemaForm from '../SchemaForm.svelte'
 	import { GripVertical } from 'lucide-svelte'
 	import type { Schema } from '$lib/common'
@@ -79,9 +79,24 @@
 		}
 	}
 
+	let dragStartTime = 0
+	const DRAG_GRACE_PERIOD_MS = 200
+
 	function handleConsider(e) {
 		dragDisabledState = false
-		const { items: newItems } = e.detail
+		const { items: newItems, info } = e.detail
+
+		if (info.trigger === TRIGGERS.DRAG_STARTED) {
+			dragStartTime = Date.now()
+			items = $state.snapshot(newItems)
+			return
+		}
+
+		// Ignore reorders during grace period so small movements don't cause jumps
+		if (Date.now() - dragStartTime < DRAG_GRACE_PERIOD_MS) {
+			return
+		}
+
 		items = $state.snapshot(newItems)
 	}
 
@@ -130,7 +145,8 @@
 				items,
 				flipDurationMs,
 				dropTargetStyle: {},
-				type: dndType
+				type: dndType,
+				morphDisabled: true
 			}}
 	{items}
 	{diff}


### PR DESCRIPTION
## Summary
Fixes drag-and-drop feedback in EditableSchemaForm: the dragged field now visually follows the cursor from the start, shows a dashed blue drop-target placeholder, and doesn't jump positions on small movements.

## Changes
- Add `morphDisabled: true` to DND config — prevents the library from copying dimensions from an uninitialized ResizeTransitionWrapper shadow (0 height), which made the floating clone invisible
- Style shadow element as a dashed blue drop-target indicator (`!visible` overrides the library's inline `visibility: hidden` that was inconsistently cleared by RTW's reactive style binding)
- Add 200ms grace period after drag start before processing reorder events, preventing immediate position jumps from small cursor movements

## Test plan
- [ ] Open a Script or Flow input editor with multiple fields
- [ ] Drag a field using the grip handle — verify the floating clone immediately follows the cursor
- [ ] Verify a dashed blue placeholder appears at the drop target position
- [ ] Verify small movements (< ~20px) don't cause the field to jump to a new position
- [ ] Verify reordering works normally after the initial grace period
- [ ] Test in both light and dark mode

---
Generated with [Claude Code](https://claude.com/claude-code)