### PR TITLE
chore: restore backend/.env copy in worktree setup

### DIFF
--- a/scripts/worktree-common.sh
+++ b/scripts/worktree-common.sh
@@ -65,6 +65,11 @@ wm_copy_dependencies() {
   local repo_root=$1
   local main_repo_root=$2
 
+  if [[ -f "${main_repo_root}/backend/.env" ]]; then
+    cp "${main_repo_root}/backend/.env" "${repo_root}/backend/"
+    echo "Copied backend/.env"
+  fi
+
   if [[ -d "${main_repo_root}/frontend/node_modules" ]]; then
     cp -a "${main_repo_root}/frontend/node_modules" "${repo_root}/frontend/"
     echo "Copied frontend/node_modules (with symlinks preserved)"


### PR DESCRIPTION
## Summary
- When `.workmux.yaml` was removed, the `files.copy` directive that copied `backend/.env` into new worktrees was lost
- Restores the copy in `wm_copy_dependencies()` in `scripts/worktree-common.sh`, which runs for both workmux and Claude hooks

## Test plan
- [ ] Create a new worktree and verify `backend/.env` is copied from the main repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)