### PR TITLE
fix: prevent raw app iframe reload on userStore refresh

### DIFF
--- a/frontend/src/lib/components/raw_apps/RawAppPreview.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppPreview.svelte
@@ -3,7 +3,7 @@
 	import RawAppBackgroundRunner from './RawAppBackgroundRunner.svelte'
 	import type { Runnable } from './rawAppPolicy'
 	import { htmlContent } from './utils'
-	import { onMount } from 'svelte'
+	import { onMount, untrack } from 'svelte'
 
 	interface Props {
 		workspace: string
@@ -26,10 +26,14 @@
 
 	// Use blob URL instead of srcDoc to give the iframe a proper origin.
 	// srcDoc iframes have "null" origin which breaks URL constructor in routers.
+	// untrack(user) so that userStore refreshes don't regenerate the blob URL
+	// and cause the iframe to fully reload (losing all state).
+	// The user context is only needed for initial render.
 	let blobUrl = $derived.by(() => {
 		if (!secret) return undefined
+		const u = untrack(() => user)
 		const baseUrl = typeof window !== 'undefined' ? window.location.origin : ''
-		const html = htmlContent(workspace, secret, { ctx: user, workspace }, baseUrl, initialHash)
+		const html = htmlContent(workspace, secret, { ctx: u, workspace }, baseUrl, initialHash)
 		const blob = new Blob([html], { type: 'text/html' })
 		return URL.createObjectURL(blob)
 	})

--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -50,6 +50,7 @@
 	import { syncTutorialsTodos } from '$lib/tutorialUtils'
 	import { ArrowLeft, Search, WandSparkles } from 'lucide-svelte'
 	import { getUserExt } from '$lib/user'
+	import { deepEqual } from 'fast-equals'
 	import { twMerge } from 'tailwind-merge'
 	import OperatorMenu from '$lib/components/sidebar/OperatorMenu.svelte'
 	import GlobalSearchModal from '$lib/components/search/GlobalSearchModal.svelte'
@@ -125,7 +126,9 @@
 				console.error('Could not persist workspace to local storage', e)
 			}
 			const user = await getUserExt(workspace)
-			userStore.set(user)
+			if (!deepEqual(user, $userStore)) {
+				userStore.set(user)
+			}
 			if (isCloudHosted() && user?.is_admin) {
 				isPremiumStore.set(await WorkspaceService.getIsPremium({ workspace }))
 			}


### PR DESCRIPTION
## Summary
When the userStore is refreshed (e.g. via the 5-minute polling interval), raw apps were fully reloading because the blob URL was regenerated, causing the iframe `src` to change and destroying all in-app state.

## Changes
- **`RawAppPreview.svelte`**: Use `untrack(() => user)` in the `blobUrl` derived so userStore refreshes don't regenerate the blob URL and reload the iframe. The user context is only needed for the initial render.
- **`(logged)/+layout.svelte`**: Add `deepEqual` guard in `updateUserStore()` before calling `userStore.set()`, matching the pattern already used in the root layout's polling. This prevents unnecessary store updates from cascading to all subscribers.

## Test plan
- [ ] Open a raw app, wait for the 5-minute user refresh interval (or manually trigger `userStore.set()` via console), verify the iframe does NOT reload
- [ ] Verify raw app still loads correctly with proper user context on initial navigation
- [ ] Verify switching workspaces still updates the user store correctly

---
Generated with [Claude Code](https://claude.com/claude-code)