### PR TITLE
fix: resolve blank inline script panel for components with underscores in ID

### DIFF
--- a/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptsPanel.svelte
+++ b/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptsPanel.svelte
@@ -52,8 +52,8 @@
 		return rest.endsWith('_transformer') ? rest.slice(0, -'_transformer'.length) : rest
 	})
 
-	function containsAction(gridItem: GridItem, actionId: string | undefined): boolean {
-		if (!actionId || !gridItem?.data) return false
+	function containsAction(gridItem: GridItem, actionId: string): boolean {
+		if (!gridItem?.data) return false
 		const data = gridItem.data
 		if (data.type === 'tablecomponent') {
 			return data.actionButtons?.some((a) => a.id === actionId) ?? false
@@ -72,6 +72,20 @@
 		}
 		return false
 	}
+
+	// Resolve which grid item ID to render — computed once per selection change
+	let matchedGridItemId = $derived.by(() => {
+		if (!prefixOrId || prefixOrId === 'bg' || prefixOrId.startsWith('unused-')) return undefined
+		const allItems: GridItem[] = [
+			...($app?.grid ?? []),
+			...Object.values($app?.subgrids ?? {}).flat()
+		]
+		// Fast path: direct ID match (most common)
+		if (allItems.some((item) => item?.id === prefixOrId)) return prefixOrId
+		// Slow path: check nested actions
+		const parent = allItems.find((item) => containsAction(item, prefixOrId))
+		return parent?.id
+	})
 
 	interface Props {
 		width?: number | undefined
@@ -94,7 +108,7 @@
 			</div>
 		{:else if prefixOrId != 'bg' && !prefixOrId?.startsWith('unused-')}
 			{#each $app.grid as gridItem, index (gridItem?.id)}
-				{#if gridItem?.id == prefixOrId || containsAction(gridItem, prefixOrId)}
+				{#if gridItem?.id == matchedGridItemId}
 					<InlineScriptsPanelWithTable
 						on:createScriptFromInlineScript={(e) => {
 							createScriptFromInlineScript(
@@ -110,7 +124,7 @@
 			{/each}
 			{#each Object.keys($app.subgrids ?? {}) as subgrid (subgrid)}
 				{#each $app.subgrids?.[subgrid] ?? [] as subgridItem, index (subgridItem?.id)}
-					{#if (subgridItem?.id == prefixOrId || containsAction(subgridItem, prefixOrId)) && $app.subgrids?.[subgrid]}
+					{#if subgridItem?.id == matchedGridItemId && $app.subgrids?.[subgrid]}
 						<InlineScriptsPanelWithTable
 							on:createScriptFromInlineScript={(e) => {
 								createScriptFromInlineScript(


### PR DESCRIPTION
## Summary
- Fixed blank inline script editor panel when selecting components whose IDs contain underscores (e.g., `save_button`, `risiko_table`, `project_input`)
- Fixed blank panel for nested action buttons (e.g., `risiko_table_delete` inside an ag-grid)

## Root Cause
`InlineScriptsPanel.svelte` used `split('_')` to parse the selected component ID, which was designed to separate the `bg_` prefix from background script indices (`bg_0` → `['bg', '0']`). However, this also incorrectly split any component ID containing underscores — `save_button` became `['save', 'button']`, so the grid item lookup `gridItem?.id == 'save'` never matched `'save_button'`, resulting in a blank panel.

Additionally, nested action buttons (table/aggrid actions, menu items) were never matched because the code only checked direct grid item IDs, not their child actions.

## Fix
1. Replaced `split('_')` with targeted parsing: only strip the `bg_` prefix for background scripts, otherwise preserve the full component ID
2. Added a `containsAction()` helper that also matches action buttons within table, aggrid, and menu components

## Test plan
- [x] Type-checks pass (`svelte-check --threshold error`)
- [x] HMR update successful, no build errors
- [ ] Verify selecting `save_button` runnable shows the inline script editor
- [ ] Verify selecting `risiko_table_delete` action shows the inline script editor
- [ ] Verify background scripts (`bg_0`, `bg_1`) still work correctly
- [ ] Verify components without underscores (`title`, etc.) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)