### PR TITLE
fix: handle OSS onboarding error gracefully

### DIFF
--- a/backend/windmill-api/src/users_oss.rs
+++ b/backend/windmill-api/src/users_oss.rs
@@ -38,7 +38,7 @@ pub async fn create_user(
     mut _nu: NewUser,
 ) -> Result<(StatusCode, String)> {
     Err(Error::internal_err(
-        "User creation is not implemented in the open-source version. Use the default credentials (admin@windmill.dev / changeme).".to_string(),
+        "User creation is not implemented in the open-source version.".to_string(),
     ))
 }
 

--- a/frontend/src/routes/(root)/(logged)/user/(user)/instance_settings/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/user/(user)/instance_settings/+page.svelte
@@ -675,8 +675,8 @@
 				{ossAccountError}
 			</Alert>
 			<span>
-				You can change your password after logging in from the user settings. Click
-				"Continue" to finish setup and log in with the default credentials.
+				Click "Continue" to finish setup and log in with the default credentials
+				(admin@windmill.dev / changeme).
 			</span>
 		</div>
 	</ConfirmationModal>


### PR DESCRIPTION
## Summary
- When `createUserGlobally` fails on OSS builds (not implemented in open-source), the setup wizard now shows a helpful dialog instead of a generic error
- Updated the backend error message in `windmill-api/src/users_oss.rs` to be specific and identifiable
- The dialog displays the backend error and offers a "Continue with default credentials" button that redirects to login with `admin@windmill.dev / changeme`

## Screenshots

### Account setup step (step 3 of onboarding wizard)
![account-step](https://tmpfiles.org/dl/29668210/ss-3-account-step.png)

### Dialog shown after clicking "Set account & finish" on OSS
![oss-dialog](https://tmpfiles.org/dl/29668212/ss-5-oss-dialog.png)

## Test plan
- [ ] Start a fresh OSS instance (no `base_url` set, default admin account)
- [ ] Go through the onboarding setup wizard to the final step
- [ ] Fill in email/password and click "Set account & finish"
- [ ] Verify the dialog appears showing the backend error and default credentials info
- [ ] Click "Continue with default credentials" and verify redirect to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)