### PR TITLE
fix: accept modern TLDs in superadmin email validation

### DIFF
--- a/frontend/src/routes/(root)/(logged)/user/(user)/instance_settings/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/user/(user)/instance_settings/+page.svelte
@@ -143,7 +143,7 @@
 		}
 	}
 
-	const emailPattern = /^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$/
+	const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/
 	let emailValid = $derived(emailPattern.test(newEmail))
 	let passwordValid = $derived(newPassword.length >= 2)
 	let accountFormValid = $derived(emailValid && passwordValid)


### PR DESCRIPTION
## Summary
Fixes superadmin setup form rejecting valid emails with modern TLDs like .games.
Changes

    Updated superadmin email validation regex in instance settings.
    Removed outdated 2-4 character TLD restriction.

Test plan

    Go to Root login & Resource Types > Superadmin login
    Enter roy.alcala@rankworld.games and confirm it validates

Closes #8471