### PR TITLE
fix: respect NO_COLOR env variable for stdout log output

### DIFF
--- a/backend/windmill-common/src/tracing_init.rs
+++ b/backend/windmill-common/src/tracing_init.rs
@@ -68,7 +68,11 @@ pub fn initialize_tracing(
     mode: &Mode,
     environment: &str,
 ) -> (WorkerGuard, crate::otel_oss::OtelProvider) {
-    let style = std::env::var("RUST_LOG_STYLE").unwrap_or_else(|_| "auto".into());
+    let style = if std::env::var("NO_COLOR").is_ok() {
+        "never".into()
+    } else {
+        std::env::var("RUST_LOG_STYLE").unwrap_or_else(|_| "auto".into())
+    };
 
     let rust_log_env = std::env::var("RUST_LOG");
     let rust_log_stdout_env = std::env::var("RUST_LOG_STDOUT");


### PR DESCRIPTION
## Summary
The Windmill binary did not respect the `NO_COLOR` environment variable ([no-color.org](https://no-color.org/) standard). When `NO_COLOR` is set, ANSI color escape codes were still emitted on stdout.

## Changes
- Check for `NO_COLOR` env variable in `initialize_tracing` and force style to `"never"` when set, which disables ANSI codes on the stdout tracing layer

## Test plan
- [ ] Run with `NO_COLOR=1 ./windmill` and verify stdout has no ANSI escape codes
- [ ] Run without `NO_COLOR` and verify colors still work as before
- [ ] Run with `RUST_LOG_STYLE=never` and verify it still works independently

---
Generated with [Claude Code](https://claude.com/claude-code)