### PR TITLE
fix: skip debounce arg accumulation when batch table is empty (CE)

### DIFF
--- a/backend/windmill-queue/src/jobs.rs
+++ b/backend/windmill-queue/src/jobs.rs
@@ -3100,41 +3100,46 @@ impl PulledJobResult {
                     "Accumulated arguments from debounced jobs in batch"
                 );
 
-                let new_value = to_raw_value(&accumulated_arg);
+                // If the batch query returned no entries (e.g. CE where
+                // v2_job_debounce_batch is never populated), keep the
+                // original value unchanged instead of replacing it with [].
+                if !accumulated_arg.is_empty() {
+                    let new_value = to_raw_value(&accumulated_arg);
 
-                let original_value = j
-                    .args
-                    .as_ref()
-                    .and_then(|a| a.get(arg_name_to_accumulate))
-                    .map(|v| v.get().to_string())
-                    .unwrap_or_else(|| "null".to_string());
+                    let original_value = j
+                        .args
+                        .as_ref()
+                        .and_then(|a| a.get(arg_name_to_accumulate))
+                        .map(|v| v.get().to_string())
+                        .unwrap_or_else(|| "null".to_string());
 
-                append_logs(
-                    &j_id,
-                    &j.workspace_id,
-                    format!(
-                        "Accumulating debounced argument `{arg_name_to_accumulate}`:\n  original: {original_value}\n  accumulated: {}\n\n",
-                        &new_value
-                    ),
-                    &(db.into()),
-                )
-                .await;
-
-                j.args
-                    .get_or_insert(Json(Default::default()))
-                    .as_mut()
-                    .insert(arg_name_to_accumulate.to_owned(), new_value);
-
-                // Persist accumulated args to v2_job so that flow steps
-                // re-reading from the DB (via get_mini_pulled_job) see them
-                if let Some(ref args) = j.args {
-                    sqlx::query!(
-                        "UPDATE v2_job SET args = $2 WHERE id = $1",
-                        j_id,
-                        args as &Json<HashMap<String, Box<RawValue>>>,
+                    append_logs(
+                        &j_id,
+                        &j.workspace_id,
+                        format!(
+                            "Accumulating debounced argument `{arg_name_to_accumulate}`:\n  original: {original_value}\n  accumulated: {}\n\n",
+                            &new_value
+                        ),
+                        &(db.into()),
                     )
-                    .execute(db)
-                    .await?;
+                    .await;
+
+                    j.args
+                        .get_or_insert(Json(Default::default()))
+                        .as_mut()
+                        .insert(arg_name_to_accumulate.to_owned(), new_value);
+
+                    // Persist accumulated args to v2_job so that flow steps
+                    // re-reading from the DB (via get_mini_pulled_job) see them
+                    if let Some(ref args) = j.args {
+                        sqlx::query!(
+                            "UPDATE v2_job SET args = $2 WHERE id = $1",
+                            j_id,
+                            args as &Json<HashMap<String, Box<RawValue>>>,
+                        )
+                        .execute(db)
+                        .await?;
+                    }
                 }
             }
 


### PR DESCRIPTION
On CE (without private feature), v2_job_debounce_batch is never populated because maybe_debounce_post_preprocessing is EE-only. The accumulation query returns zero rows, producing an empty array that replaces the original nodes_to_relock value. This causes flow modules to never get relocked when triggered by relative imports.

Fix: only replace the original value when the batch query actually returned entries to accumulate.