### PR TITLE
fix: correct spelling typos in CSS property components

### DIFF
--- a/frontend/src/lib/components/apps/editor/componentsPanel/CssProperty.svelte
+++ b/frontend/src/lib/components/apps/editor/componentsPanel/CssProperty.svelte
@@ -30,8 +30,8 @@
 		tooltip?: string | undefined
 		shouldDisplayLeft?: boolean
 		shouldDisplayRight?: boolean
-		overriden?: boolean
-		overridding?: boolean
+		overridden?: boolean
+		overriding?: boolean
 		wmClass?: string | undefined
 	}
 
@@ -45,8 +45,8 @@
 		tooltip = undefined,
 		shouldDisplayLeft = false,
 		shouldDisplayRight = false,
-		overriden = false,
-		overridding = false,
+		overridden = false,
+		overriding = false,
 		wmClass = undefined
 	}: Props = $props()
 
@@ -143,9 +143,9 @@
 							<div class="text-xs font-medium text-primary"> Plain CSS </div>
 
 							<div class="flex flex-row gap-1">
-								{#if overriden}
-									<Badge color="red" small>Overriden by local</Badge>
-								{:else if overridding}
+								{#if overridden}
+									<Badge color="red" small>Overridden by local</Badge>
+								{:else if overriding}
 									<Badge color="blue" small>Overriding global</Badge>
 								{/if}
 								{#if quickStyleProperties?.length}

--- a/frontend/src/lib/components/apps/editor/settingsPanel/CssPropertyWrapper.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/CssPropertyWrapper.svelte
@@ -7,8 +7,8 @@
 		forceClass?: boolean
 		id: string
 		property?: ComponentCssProperty | undefined
-		overriden?: boolean
-		overridding?: boolean
+		overridden?: boolean
+		overriding?: boolean
 		wmClass?: string | undefined
 	}
 
@@ -17,8 +17,8 @@
 		forceClass = false,
 		id,
 		property = $bindable(undefined),
-		overriden = false,
-		overridding = false,
+		overridden = false,
+		overriding = false,
 		wmClass = undefined
 	}: Props = $props()
 
@@ -38,8 +38,8 @@
 		shouldDisplayLeft={hasValues(property[id])}
 		on:left
 		on:right
-		{overriden}
-		{overridding}
+		{overridden}
+		{overriding}
 		{wmClass}
 	/>
 {/if}

--- a/frontend/src/lib/components/apps/editor/settingsPanel/StylePanel.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/StylePanel.svelte
@@ -250,7 +250,7 @@
 											copyLocalToGlobal(name, component?.customCss?.[name])
 											tab = 'global'
 										}}
-										overridding={hasStyleValue($app.css?.[component.type]?.[name]) &&
+										overriding={hasStyleValue($app.css?.[component.type]?.[name]) &&
 											hasStyleValue(component.customCss[name])}
 									/>
 								</div>
@@ -277,7 +277,7 @@
 											)
 											tab = 'local'
 										}}
-										overriden={hasStyleValue(component.customCss[id])}
+										overridden={hasStyleValue(component.customCss[id])}
 										wmClass={getSelector(id)}
 									/>
 								{/if}

--- a/frontend/src/lib/script_helpers.ts
+++ b/frontend/src/lib/script_helpers.ts
@@ -84,7 +84,7 @@ const NATIVETS_INIT_CODE = `// Fetch-only script, no imports allowed (except win
 //import * as wmill from './windmill.ts'
 
 export async function main(example_input: number = 3) {
-  // "3" is the default value of example_input, it can be overriden with code or using the UI
+  // "3" is the default value of example_input, it can be overridden with code or using the UI
   const res = await fetch(\`https://jsonplaceholder.typicode.com/todos/\${example_input}\`, {
     headers: { "Content-Type": "application/json" },
   });
@@ -101,7 +101,7 @@ const BUNNATIVE_INIT_CODE = `//native
 //import * as wmill from "windmill-client"
 
 export async function main(example_input: number = 3) {
-  // "3" is the default value of example_input, it can be overriden with code or using the UI
+  // "3" is the default value of example_input, it can be overridden with code or using the UI
   const res = await fetch(\`https://jsonplaceholder.typicode.com/todos/\${example_input}\`, {
     headers: { "Content-Type": "application/json" },
   });


### PR DESCRIPTION
## Summary
Fix spelling typos "overriden" → "overridden" and "overridding" → "overriding" in CSS property components and script helper comments.

## Changes
- Fix prop name `overriden` → `overridden` in `CssProperty.svelte` and `CssPropertyWrapper.svelte`
- Fix prop name `overridding` → `overriding` in `CssProperty.svelte` and `CssPropertyWrapper.svelte`
- Fix user-facing badge text "Overriden by local" → "Overridden by local" in `CssProperty.svelte`
- Update prop references in `StylePanel.svelte`
- Fix comment typo in `script_helpers.ts`

## Test plan
- [ ] Open the app editor, select a component with custom CSS, verify the "Overridden by local" badge renders correctly
- [ ] Verify global/local CSS override indicators still work in the style panel

---
Generated with [Claude Code](https://claude.com/claude-code)