### PR TITLE
fix: create parent dirs and accept 'python' alias in script bootstrap

### DIFF
--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -1,7 +1,7 @@
 import { GlobalOptions } from "../../types.ts";
 import { requireLogin } from "../../core/auth.ts";
 import { resolveWorkspace, validatePath } from "../../core/context.ts";
-import { readFile, writeFile, stat } from "node:fs/promises";
+import { readFile, writeFile, stat, mkdir } from "node:fs/promises";
 import { Buffer } from "node:buffer";
 import { colors } from "@cliffy/ansi/colors";
 import { Command } from "@cliffy/command";
@@ -1069,16 +1069,22 @@ async function get(opts: GlobalOptions & { json?: boolean }, path: string) {
   }
 }
 
+const languageAliases: Record<string, ScriptLanguage> = {
+  python: "python3",
+};
+
 async function bootstrap(
   opts: GlobalOptions & { summary: string; description: string },
   scriptPath: string,
-  language: ScriptLanguage
+  language: ScriptLanguage | string
 ) {
   if (!validatePath(scriptPath)) {
     return;
   }
 
-  const scriptInitialCode = scriptBootstrapCode[language];
+  const resolvedLanguage = (languageAliases[language] ?? language) as ScriptLanguage;
+
+  const scriptInitialCode = scriptBootstrapCode[resolvedLanguage];
   if (scriptInitialCode === undefined) {
     throw new Error("Language unknown");
   }
@@ -1086,7 +1092,7 @@ async function bootstrap(
   const config = await readConfigFile();
 
   const extension = filePathExtensionFromContentType(
-    language,
+    resolvedLanguage,
     config.defaultTs
   );
   const scriptCodeFileFullPath = scriptPath + extension;
@@ -1117,6 +1123,9 @@ async function bootstrap(
     scriptMetadata as Record<string, any>,
     yamlOptions
   );
+
+  const parentDir = path.dirname(scriptCodeFileFullPath);
+  await mkdir(parentDir, { recursive: true });
 
   await writeFile(scriptCodeFileFullPath, scriptInitialCode, {
     flag: 'wx', encoding: 'utf-8',

--- a/cli/test/standalone_commands.test.ts
+++ b/cli/test/standalone_commands.test.ts
@@ -409,6 +409,63 @@ describe("script bootstrap command", () => {
     });
   });
 
+  test("accepts 'python' as alias for python3", async () => {
+    await withTestBackend(async (backend, tempDir) => {
+      await setupWorkspaceProfile(backend);
+
+      await writeFile(
+        join(tempDir, "wmill.yaml"),
+        `defaultTs: bun\nincludes:\n  - "**"\nexcludes: []\n`,
+        "utf-8"
+      );
+
+      await mkdir(join(tempDir, "f", "test"), { recursive: true });
+
+      const result = await backend.runCLICommand(
+        ["script", "bootstrap", "f/test/py_alias_script", "python"],
+        tempDir
+      );
+
+      expect(result.code).toEqual(0);
+
+      const codeStat = await stat(join(tempDir, "f/test/py_alias_script.py"));
+      expect(codeStat.isFile()).toBe(true);
+
+      const metaStat = await stat(
+        join(tempDir, "f/test/py_alias_script.script.yaml")
+      );
+      expect(metaStat.isFile()).toBe(true);
+    });
+  });
+
+  test("creates parent directories automatically", async () => {
+    await withTestBackend(async (backend, tempDir) => {
+      await setupWorkspaceProfile(backend);
+
+      await writeFile(
+        join(tempDir, "wmill.yaml"),
+        `defaultTs: bun\nincludes:\n  - "**"\nexcludes: []\n`,
+        "utf-8"
+      );
+
+      // Do NOT pre-create f/test — bootstrap should create it
+      const result = await backend.runCLICommand(
+        ["script", "bootstrap", "f/test/auto_dir_script", "bun"],
+        tempDir
+      );
+
+      expect(result.code).toEqual(0);
+
+      const codeStat = await stat(join(tempDir, "f/test/auto_dir_script.ts"));
+      expect(codeStat.isFile()).toBe(true);
+
+      const metaStat = await stat(
+        join(tempDir, "f/test/auto_dir_script.script.yaml")
+      );
+      expect(metaStat.isFile()).toBe(true);
+    });
+  });
+
   test("creates Go script files", async () => {
     await withTestBackend(async (backend, tempDir) => {
       await setupWorkspaceProfile(backend);


### PR DESCRIPTION
## Summary
Fixes `wmill script new f/foo/bar python3` failing with ENOENT when parent directories don't exist. Also adds `python` as an accepted alias for `python3`.

## Changes
- Create parent directories automatically before writing script files in `bootstrap` (using `mkdir` with `recursive: true`)
- Add `languageAliases` map so `python` resolves to `python3`
- Widen `language` parameter type to `ScriptLanguage | string` to accept aliases
- Add tests for `python` alias and automatic directory creation

## Test plan
- [x] `npx bun test test/standalone_commands.test.ts -t "script bootstrap"` — all 6 tests pass
- [ ] `wmill script new f/foo/bar python` creates `f/foo/bar.py` and `f/foo/bar.script.yaml`
- [ ] `wmill script new f/foo/bar python3` still works as before

---
Generated with [Claude Code](https://claude.com/claude-code)