### PR TITLE
fix: escape env var values in nativets/bun JS string interpolation

### DIFF
--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -3008,7 +3008,10 @@ pub fn build_nativets_env_code(
         "const process = {{ env: {{}} }};\nconst BASE_URL = '{base_internal_url}';\nconst BASE_INTERNAL_URL = '{base_internal_url}';\nprocess.env['BASE_URL'] = BASE_URL;process.env['BASE_INTERNAL_URL'] = BASE_INTERNAL_URL;\n{}",
         reserved_variables
             .iter()
-            .map(|(k, v)| format!("process.env['{}'] = '{}';", k, v))
+            .map(|(k, v)| {
+                let escaped = v.replace('\\', "\\\\").replace('\'', "\\'").replace('\n', "\\n").replace('\r', "\\r");
+                format!("process.env['{}'] = '{}';", k, escaped)
+            })
             .collect::<Vec<String>>()
             .join("\n")
     )

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -4493,7 +4493,10 @@ pub async fn run_language_executor(
             "const process = {{ env: {{}} }};\nconst BASE_URL = '{base_internal_url}';\nconst BASE_INTERNAL_URL = '{base_internal_url}';\nprocess.env['BASE_URL'] = BASE_URL;process.env['BASE_INTERNAL_URL'] = BASE_INTERNAL_URL;\n{}",
             reserved_variables
                 .iter()
-                .map(|(k, v)| format!("const {} = '{}';\nprocess.env['{}'] = '{}';\n", k, v, k, v))
+                .map(|(k, v)| {
+                    let escaped = v.replace('\\', "\\\\").replace('\'', "\\'").replace('\n', "\\n").replace('\r', "\\r");
+                    format!("const {} = '{}';\nprocess.env['{}'] = '{}';\n", k, escaped, k, escaped)
+                })
                 .collect::<Vec<String>>()
                 .join("\n"));
 


### PR DESCRIPTION
## Summary

- **Security fix**: Workspace environment variable values interpolated into JS string literals in the NativeTS and Bun executors were not escaped, allowing a workspace admin to inject arbitrary JavaScript via a crafted env var value (e.g. containing `'`).
- Escapes `\`, `'`, `\n`, and `\r` in env var values before interpolation into single-quoted JS strings in both `worker.rs` (NativeTS) and `bun_executor.rs` (Bun).

## Test plan

- [ ] Set a workspace env var with value `'; console.log("INJECTED"); '` and run a NativeTS script — verify `INJECTED` does **not** appear in logs
- [ ] Set a workspace env var with a value containing backslashes and newlines — verify the script runs correctly and the value is preserved
- [ ] Run a standard NativeTS script with normal env vars — verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)