### PR TITLE
fix: create parent dirs in script new and accept python as language alias

### DIFF
--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -1,7 +1,7 @@
 import { GlobalOptions } from "../../types.ts";
 import { requireLogin } from "../../core/auth.ts";
 import { resolveWorkspace, validatePath } from "../../core/context.ts";
-import { readFile, writeFile, stat } from "node:fs/promises";
+import { readFile, writeFile, stat, mkdir } from "node:fs/promises";
 import { Buffer } from "node:buffer";
 import { colors } from "@cliffy/ansi/colors";
 import { Command } from "@cliffy/command";
@@ -1078,6 +1078,11 @@ async function bootstrap(
     return;
   }
 
+  // normalize language aliases
+  if (language === ("python" as any)) {
+    language = "python3";
+  }
+
   const scriptInitialCode = scriptBootstrapCode[language];
   if (scriptInitialCode === undefined) {
     throw new Error("Language unknown");
@@ -1117,6 +1122,9 @@ async function bootstrap(
     scriptMetadata as Record<string, any>,
     yamlOptions
   );
+
+  const parentDir = path.dirname(scriptCodeFileFullPath);
+  await mkdir(parentDir, { recursive: true });
 
   await writeFile(scriptCodeFileFullPath, scriptInitialCode, {
     flag: 'wx', encoding: 'utf-8',


### PR DESCRIPTION
## Summary
Fix `wmill script new` failing with ENOENT when the target path has nested directories that don't exist yet, and accept `python` as a language alias for `python3`.

## Changes
- Add `mkdir -p` (recursive) before writing script files so nested paths like `f/foo/bar` work
- Normalize `python` → `python3` in the `bootstrap` function so both are accepted

## Test plan
- [ ] `wmill script new f/foo/bar python` — creates `f/foo/bar.py` and `f/foo/bar.script.yaml` with parent dirs
- [ ] `wmill script new f/baz python3` — still works as before
- [ ] `wmill script new existing_script python` — still errors if file already exists

---
Generated with [Claude Code](https://claude.com/claude-code)