### PR TITLE
fix(deploy): add HTTPS support to ECS Terraform ALB configuration

### DIFF
--- a/examples/deploy/aws-ecs-terraform/load_balancer.tf
+++ b/examples/deploy/aws-ecs-terraform/load_balancer.tf
@@ -1,3 +1,5 @@
+# --- Target Groups (internal HTTP — TLS terminates at ALB) ---
+
 resource "aws_lb_target_group" "windmill_cluster_windmill_server_tg" {
   name        = "windmill-cluster-server-tg"
   port        = 8000
@@ -22,6 +24,8 @@ resource "aws_lb_target_group" "windmill_cluster_windmill_multiplayer_tg" {
   vpc_id      = aws_vpc.windmill_cluster_vpc.id
 }
 
+# --- ALB ---
+
 resource "aws_lb" "windmill_cluster_alb" {
   name               = "windmill-cluster-alb"
   internal           = false
@@ -37,10 +41,33 @@ resource "aws_lb" "windmill_cluster_alb" {
   }
 }
 
-resource "aws_lb_listener" "windmill_cluster_alb_listener" {
+# --- ACM Certificate (optional — set var.acm_certificate_arn to enable HTTPS) ---
+
+variable "acm_certificate_arn" {
+  type        = string
+  default     = ""
+  description = "ARN of an ACM certificate for HTTPS. If empty, ALB uses HTTP only (not recommended for production)."
+}
+
+variable "enable_https" {
+  type        = bool
+  default     = true
+  description = "Enable HTTPS on the ALB. Requires acm_certificate_arn to be set."
+}
+
+locals {
+  use_https = var.enable_https && var.acm_certificate_arn != ""
+}
+
+# --- HTTPS Listener (when certificate is provided) ---
+
+resource "aws_lb_listener" "windmill_cluster_alb_https_listener" {
+  count             = local.use_https ? 1 : 0
   load_balancer_arn = aws_lb.windmill_cluster_alb.arn
-  port              = 80
-  protocol          = "HTTP"
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.acm_certificate_arn
 
   default_action {
     type             = "forward"
@@ -48,8 +75,40 @@ resource "aws_lb_listener" "windmill_cluster_alb_listener" {
   }
 }
 
+# --- HTTP Listener (redirects to HTTPS when certificate is provided, otherwise forwards directly) ---
+
+resource "aws_lb_listener" "windmill_cluster_alb_http_listener" {
+  load_balancer_arn = aws_lb.windmill_cluster_alb.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = local.use_https ? "redirect" : "forward"
+
+    # Redirect to HTTPS when certificate is available
+    dynamic "redirect" {
+      for_each = local.use_https ? [1] : []
+      content {
+        port        = "443"
+        protocol    = "HTTPS"
+        status_code = "HTTP_301"
+      }
+    }
+
+    # Forward directly when no certificate (development/testing only)
+    target_group_arn = local.use_https ? null : aws_lb_target_group.windmill_cluster_windmill_server_tg.arn
+  }
+}
+
+# Use the appropriate listener ARN for routing rules
+locals {
+  listener_arn = local.use_https ? aws_lb_listener.windmill_cluster_alb_https_listener[0].arn : aws_lb_listener.windmill_cluster_alb_http_listener.arn
+}
+
+# --- Routing Rules ---
+
 resource "aws_lb_listener_rule" "windmill_cluster_alb_lsp_rule" {
-  listener_arn = aws_lb_listener.windmill_cluster_alb_listener.arn
+  listener_arn = local.listener_arn
   priority     = 100
 
   action {
@@ -65,7 +124,7 @@ resource "aws_lb_listener_rule" "windmill_cluster_alb_lsp_rule" {
 }
 
 resource "aws_lb_listener_rule" "windmill_cluster_alb_multiplayer_rule" {
-  listener_arn = aws_lb_listener.windmill_cluster_alb_listener.arn
+  listener_arn = local.listener_arn
   priority     = 50
 
   action {


### PR DESCRIPTION
Add optional HTTPS listener with ACM certificate support to the ALB. When acm_certificate_arn is provided, the ALB:
- Terminates TLS on port 443 with TLS 1.3 policy
- Redirects HTTP (port 80) to HTTPS with 301

When no certificate is provided (default for development), the ALB falls back to HTTP-only mode with a clear variable description noting this is not recommended for production.

This follows Windmill's own self-host guidance which recommends TLS termination at the load balancer level.

Security impact: Prevents API tokens, script source code, database credentials, and OAuth tokens from flowing unencrypted between users and the Windmill server.