### PR TITLE
Add 'fast' query parameter to API definition

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10644,6 +10644,10 @@ paths:
           in: query
           schema:
             type: boolean
+        - name: fast
+          in: query
+          schema:
+            type: boolean
 
       responses:
         "200":


### PR DESCRIPTION
The current Windmill UI uses the `update_sse` endpoint to retrieve the job updates. Without the `?fast=true` query parameter these updates are only pushed once every 3 seconds. With the `?fast=true` query parameter the updates are pushed nearly instantly.
Currently this option is not defined within the OpenAPI Specification. This PR should close this little change.

#8503 