### PR TITLE
fix: require admin for workspace encryption key export

### DIFF
--- a/backend/windmill-api/src/workspaces_export.rs
+++ b/backend/windmill-api/src/workspaces_export.rs
@@ -388,8 +388,6 @@ pub(crate) async fn tarball_workspace(
         settings_version,
     }): Query<ArchiveQueryParams>,
 ) -> Result<([(HeaderName, String); 2], impl IntoResponse)> {
-    // require_admin(authed.is_admin, &authed.username)?;
-
     tracing::info!(
         "tarball_workspace called for workspace {}: include_workspace_dependencies={:?}, skip_variables={:?}, skip_resources={:?}",
         w_id,
@@ -1078,6 +1076,8 @@ pub(crate) async fn tarball_workspace(
     }
 
     if include_key.unwrap_or(false) {
+        require_admin(authed.is_admin, &authed.username)?;
+
         let key = sqlx::query_scalar!(
             "SELECT key FROM workspace_key WHERE workspace_id = $1",
             &w_id


### PR DESCRIPTION
## Summary
- Moved the `require_admin` check from blocking the entire tarball export endpoint to only guarding the `include_key=true` code path
- Non-admins can still export workspace tarballs (used for workspace sync/git)
- Only admins can export tarballs that include the raw workspace encryption key (`encryption_key.json`)

## Context
The `require_admin` check on the tarball export endpoint was commented out in `34392ef66f` (Dec 15, 2024) during a refactor that split workspace and auth logic. This left the `include_key=true` path unguarded, allowing any workspace member to retrieve the raw encryption key.

## Test plan
- [ ] Verify non-admin users can still export workspace tarballs without `include_key`
- [ ] Verify non-admin users get a 403 when requesting `include_key=true`
- [ ] Verify admin users can export tarballs with `include_key=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)