### PR TITLE
fix: add missing grants on app_bundles table

### DIFF
--- a/backend/migrations/20260325000000_app_bundles_grants.down.sql
+++ b/backend/migrations/20260325000000_app_bundles_grants.down.sql
@@ -1,0 +1,3 @@
+-- Revoke grants for app_bundles table
+REVOKE ALL ON app_bundles FROM windmill_user;
+REVOKE ALL ON app_bundles FROM windmill_admin;

--- a/backend/migrations/20260325000000_app_bundles_grants.up.sql
+++ b/backend/migrations/20260325000000_app_bundles_grants.up.sql
@@ -1,0 +1,3 @@
+-- Add grants for app_bundles table
+GRANT ALL ON app_bundles TO windmill_user;
+GRANT ALL ON app_bundles TO windmill_admin;


### PR DESCRIPTION
## Summary
The `app_bundles` table (created in migration `20251001140645`) was missing `GRANT ALL` statements for `windmill_user` and `windmill_admin`, which every other table has.

## Changes
- Add migration `20260325000000_app_bundles_grants` with `GRANT ALL ON app_bundles` to both `windmill_user` and `windmill_admin`
- Add corresponding down migration with `REVOKE ALL`

## Test plan
- [ ] Verify migration applies cleanly on a fresh database
- [ ] Verify `windmill_user` and `windmill_admin` can read/write `app_bundles`

---
Generated with [Claude Code](https://claude.com/claude-code)