### PR TITLE
fix: buffer stdin lines in deno dedicated worker wrapper

### DIFF
--- a/backend/windmill-worker/src/deno_executor.rs
+++ b/backend/windmill-worker/src/deno_executor.rs
@@ -672,10 +672,15 @@ BigInt.prototype.toJSON = function () {{
 console.log('start\n');
 
 const decoder = new TextDecoder();
+let _buffer = "";
 for await (const chunk of Deno.stdin.readable) {{
-    const lines = decoder.decode(chunk);
+    _buffer += decoder.decode(chunk, {{ stream: true }});
+    const _parts = _buffer.split("\n");
+    _buffer = _parts.pop() ?? "";
     let exit = false;
-    for (const line of lines.trim().split("\n")) {{
+    for (const _part of _parts) {{
+        const line = _part.trim();
+        if (!line) continue;
         if (line === "end") {{
             exit = true;
             break;


### PR DESCRIPTION
## Summary
Fix flaky `test_deno_dedicated_worker_simple` CI failure caused by the Deno dedicated worker wrapper reading raw byte chunks from `Deno.stdin.readable` instead of buffered lines.

The wrapper used `decoder.decode(chunk).trim().split("\n")` which breaks when a single protocol message is split across multiple chunks — the parser sees a partial `exec:` command without the colon separator and errors with "Malformed exec command: missing colon separator".

## Changes
- Buffer incomplete stdin data across chunks using a line buffer
- Use `TextDecoder` with `{ stream: true }` to handle multi-byte characters split across chunks
- Split by `\n` and keep the last (potentially incomplete) part for the next chunk
- Skip empty lines explicitly after trimming

This matches how the Bun wrapper already handles stdin (via `Readline.createInterface`).

## Test plan
- [x] All 5 `dedicated_worker_protocol_deno` tests pass locally
- [x] All 15 `dedicated_worker_protocol` (Bun/Node) tests still pass
- [x] `cargo check` passes with production features
- [ ] CI integration tests pass

---
Generated with [Claude Code](https://claude.com/claude-code)