### PR TITLE
fix: update cachix/install-nix-action from v20 to v31

### DIFF
--- a/.github/workflows/rust-client-check.yml
+++ b/.github/workflows/rust-client-check.yml
@@ -18,10 +18,7 @@ jobs:
     runs-on: ubicloud-standard-8
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v20
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+      - uses: cachix/install-nix-action@v31
       - name: Check rust client builds
         run: cd rust-client && nix develop ../ --command ./dev.nu --check
         timeout-minutes: 16

--- a/.github/workflows/rust_on_release.yml
+++ b/.github/workflows/rust_on_release.yml
@@ -10,10 +10,7 @@ jobs:
     runs-on: ubicloud-standard-8
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v20
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+      - uses: cachix/install-nix-action@v31
       - run: cd rust-client && nix develop ../ --command ./dev.nu --check --publish 
         env:
           CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
## Summary
Fix CI hash mismatch failure in rust-client workflows by updating `cachix/install-nix-action` from v20 to v31. The old version bundled a hardcoded SHA-256 hash for the Nix tarball that no longer matches the upstream binary.

## Changes
- Updated `cachix/install-nix-action` from `@v20` to `@v31` in `rust-client-check.yml`
- Updated `cachix/install-nix-action` from `@v20` to `@v31` in `rust_on_release.yml`
- Removed `extra_nix_config` for `experimental-features` (enabled by default in recent Nix)

## Test plan
- [ ] CI passes on `rust-client-check` workflow
- [ ] Nix installs without hash mismatch errors

---
Generated with [Claude Code](https://claude.com/claude-code)