### PR TITLE
fix: pass pre-bound TcpListener to run_server to fix Windows CI race

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1099,6 +1099,9 @@ Windmill Community Edition {GIT_VERSION}
         }
 
         let addr = SocketAddr::from((server_bind_address, port));
+        let listener = tokio::net::TcpListener::bind(addr)
+            .await
+            .context("binding main windmill server")?;
 
         let (base_internal_tx, base_internal_rx) = tokio::sync::oneshot::channel::<String>();
 
@@ -1232,7 +1235,7 @@ Windmill Community Edition {GIT_VERSION}
                         db.clone(),
                         index_reader,
                         log_index_reader,
-                        addr,
+                        listener,
                         server_killpill_rx,
                         base_internal_tx,
                         server_mode,

--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -45,8 +45,8 @@ use windmill_common::global_settings::EMAIL_DOMAIN_SETTING;
 use windmill_common::worker::HUB_CACHE_DIR;
 
 use std::fs::DirBuilder;
+use std::sync::Arc;
 use std::time::Duration;
-use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::RwLock;
 use tower::ServiceBuilder;
 use tower_cookies::CookieManagerLayer;
@@ -326,7 +326,7 @@ pub async fn run_server(
     db: DB,
     job_index_reader: Option<IndexReader>,
     log_index_reader: Option<ServiceLogIndexReader>,
-    addr: SocketAddr,
+    listener: tokio::net::TcpListener,
     mut killpill_rx: tokio::sync::broadcast::Receiver<()>,
     port_tx: tokio::sync::oneshot::Sender<String>,
     server_mode: bool,
@@ -412,6 +412,9 @@ pub async fn run_server(
                     auth_cache: auth_cache.clone(),
                     base_internal_url: _base_internal_url.clone(),
                 });
+                let addr = listener
+                    .local_addr()
+                    .unwrap_or_else(|_| std::net::SocketAddr::from(([127, 0, 0, 1], 0)));
                 if let Err(err) = smtp_server.start_listener_thread(addr).await {
                     tracing::error!("Error starting SMTP server: {err:#}");
                 }
@@ -452,9 +455,6 @@ pub async fn run_server(
         health::start_health_check_loop(db.clone(), killpill_rx.resubscribe());
     }
 
-    let listener = tokio::net::TcpListener::bind(addr)
-        .await
-        .context("binding main windmill server")?;
     let port = listener.local_addr().map(|x| x.port()).unwrap_or(8000);
     let ip = listener
         .local_addr()

--- a/backend/windmill-test-utils/src/lib.rs
+++ b/backend/windmill-test-utils/src/lib.rs
@@ -97,14 +97,13 @@ impl ApiServer {
     async fn start_inner(db: Pool<Postgres>, agent_mode: bool) -> anyhow::Result<Self> {
         let (tx, rx) = tokio::sync::broadcast::channel::<()>(1);
 
-        let sock = tokio::net::TcpListener::bind("127.0.0.1:0")
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .map_err(|e| anyhow::anyhow!("failed to bind TCP listener: {}", e))?;
 
-        let addr = sock
+        let addr = listener
             .local_addr()
             .map_err(|e| anyhow::anyhow!("failed to get local address: {}", e))?;
-        drop(sock);
         let (port_tx, _port_rx) = tokio::sync::oneshot::channel::<String>();
         let name = next_worker_name();
         tracing::info!("starting api server for name={name}");
@@ -112,7 +111,7 @@ impl ApiServer {
             db.clone(),
             None,
             None,
-            addr,
+            listener,
             rx,
             port_tx,
             agent_mode,


### PR DESCRIPTION
## Summary
Fixes the TOCTOU (time-of-check-time-of-use) race condition causing `test_iteration` and `test_nested_imports_bun` to intermittently fail on Windows CI (`backend-test-windows.yml`).

The test utility `ApiServer::start_inner` was binding a TCP socket to get a random port, dropping the socket, then passing the address to `run_server` which re-bound it. With 10 concurrent test threads on Windows, another test could grab the same port in between, causing `run_server` to fail before sending on `port_tx`, which surfaced as: `"failed to receive port for name=.../worker-...: channel closed"`.

## Changes
- Changed `run_server` to accept a pre-bound `TcpListener` instead of a `SocketAddr`
- Updated `windmill_main` to bind the listener before passing it to `run_server`
- Updated `ApiServer::start_inner` to pass its listener directly instead of dropping and re-binding
- Extracted `local_addr()` from the listener for the SMTP server (EE feature, only uses the IP)

## Test plan
- [x] `cargo check` passes cleanly (no warnings)
- [x] `cargo check --features enterprise,private` passes
- [ ] Windows CI (`backend-test-windows.yml`) should pass with no `test_iteration` / `test_nested_imports_bun` failures

---
Generated with [Claude Code](https://claude.com/claude-code)