### PR TITLE
fix: filter null entries in FileUpload to prevent s3 access error

### DIFF
--- a/frontend/src/lib/components/common/fileUpload/FileUpload.svelte
+++ b/frontend/src/lib/components/common/fileUpload/FileUpload.svelte
@@ -92,7 +92,7 @@
 
 	let initialS3 = $derived(
 		Array.isArray(initialValue)
-			? initialValue?.map((v) => v.s3)
+			? initialValue?.filter((v) => v != null).map((v) => v.s3)
 			: initialValue?.s3
 				? [initialValue?.s3]
 				: undefined
@@ -112,7 +112,7 @@
 				if (!$fileUploads.find((fileUpload) => fileUpload.path === s3)) {
 					let initialFileUploads = initialValue
 						? Array.isArray(initialValue)
-							? initialValue.map(transform)
+							? initialValue.filter((v) => v != null).map(transform)
 							: [transform(initialValue)]
 						: []
 					$fileUploads = [...$fileUploads, ...initialFileUploads]


### PR DESCRIPTION
## Summary
Fix crash when AI agent module's `user_images` is a JS expression like `[flow_input.image]` and the flow input is not available during "test this step" — the array resolves to `[null]`, causing `Cannot read properties of null (reading 's3')`.

## Changes
- Filter out null/undefined entries before accessing `.s3` in the `initialS3` derived value
- Filter out null/undefined entries before mapping through `transform` in the `init` function

## Test plan
- [ ] Create a flow with an AI agent step where `user_images` is set to `[flow_input.image]`
- [ ] Switch to "test this step" tab — should no longer throw console error
- [ ] Verify that normal S3 file upload still works when values are present

---
Generated with [Claude Code](https://claude.com/claude-code)