### PR TITLE
feat: support multiple folder selection in MCP scope selector

### DIFF
--- a/frontend/src/lib/components/mcp/McpScopeSelector.svelte
+++ b/frontend/src/lib/components/mcp/McpScopeSelector.svelte
@@ -22,6 +22,7 @@
 	let selectedFolders = $state<string[]>([])
 	let allFolders = $state<string[]>([])
 	let loadingFolders = $state(false)
+	let folderNamesCache = new Map<string, string[]>()
 	let selectedScripts = $state<string[]>([])
 	let selectedFlows = $state<string[]>([])
 	let selectedEndpoints = $state<string[]>([])
@@ -96,23 +97,26 @@
 
 	// Clear folders when not in folder mode, load folder names when entering folder mode
 	$effect(() => {
-		if (selectedMode === 'folder') {
-			loadFolderNames()
+		if (selectedMode === 'folder' && workspaceId) {
+			loadFolderNames(workspaceId)
 		} else {
 			selectedFolders = []
 		}
 	})
 
-	async function loadFolderNames() {
-		if (allFolders.length > 0) return
+	async function loadFolderNames(workspace: string) {
+		if (folderNamesCache.has(workspace)) {
+			allFolders = folderNamesCache.get(workspace)!
+			return
+		}
 		try {
 			loadingFolders = true
 			const excludedFolders = ['app_groups', 'app_custom', 'app_themes']
-			allFolders = (
-				await FolderService.listFolderNames({
-					workspace: workspaceId
-				})
+			const names = (
+				await FolderService.listFolderNames({ workspace })
 			).filter((x) => !excludedFolders.includes(x))
+			folderNamesCache.set(workspace, names)
+			allFolders = names
 		} catch {
 			allFolders = []
 		} finally {


### PR DESCRIPTION
## Summary
Changes the MCP scope selector's "Folder" mode to support selecting multiple folders instead of just one. Users can now scope their MCP token access to several folders at once.

## Changes
- Renamed "Folder" toggle to "Folders" with updated tooltip
- Replaced single `FolderPicker` with `MultiSelect` that lists available workspace folders
- Scope generation now produces comma-separated folder patterns (e.g. `mcp:scripts:f/folder1/*,f/folder2/*`)
- Runnables preview fetches and deduplicates scripts/flows from all selected folders


https://github.com/user-attachments/assets/f37f8470-9e1f-47fc-a3bc-29d97f66454f



## Test plan
- [ ] Navigate to user settings → MCP token creation
- [ ] Select "Folders" scope mode
- [ ] Verify multiple folders can be selected via the MultiSelect dropdown
- [ ] Verify the runnables preview shows scripts/flows from all selected folders
- [ ] Verify the generated token scope correctly includes all selected folders
- [ ] Verify existing "Favorites", "All", and "Custom" modes still work

---
Generated with [Claude Code](https://claude.com/claude-code)