### PR TITLE
fix: use fallback_service instead of nest_service for MCP router

### DIFF
--- a/backend/windmill-api/src/mcp/core.rs
+++ b/backend/windmill-api/src/mcp/core.rs
@@ -546,7 +546,7 @@ pub async fn setup_mcp_server(
     let service =
         StreamableHttpService::new(move || Ok(runner.clone()), session_manager, service_config);
 
-    let router = Router::new().nest_service("/", service);
+    let router = Router::new().fallback_service(service);
     Ok((router, cancellation_token))
 }
 


### PR DESCRIPTION
## Summary
Fixes MCP router setup by using `fallback_service` instead of `nest_service` for the Streamable HTTP service, which ensures proper request routing.

## Changes
- Replace `Router::new().nest_service("/", service)` with `Router::new().fallback_service(service)` in `setup_mcp_server`

## Test plan
- [ ] Verify MCP server accepts and handles requests correctly
- [ ] Run CI integration tests

---
Generated with [Claude Code](https://claude.com/claude-code)