### PR TITLE
fix: include importer_kind in dependency debounce key

### DIFF
--- a/backend/windmill-dep-map/src/trigger_dependents.rs
+++ b/backend/windmill-dep-map/src/trigger_dependents.rs
@@ -61,7 +61,7 @@ pub async fn trigger_dependents_to_recompute_dependencies(
         );
 
         let mut debouncing_settings = DebouncingSettings {
-            debounce_key: Some(format!("{w_id}:{importer_path}:dependency")),
+            debounce_key: Some(format!("{w_id}:{importer_path}:{importer_kind}:dependency")),
             debounce_delay_s: Some(5),
             ..Default::default()
         };


### PR DESCRIPTION
## Summary
Fix a bug where `FlowDependencies` and `Dependencies` jobs for the same path could debounce each other, causing flow lock updates to be silently skipped when a relative import is redeployed.

## Changes
- Include `importer_kind` (script/flow/app) in the debounce key in `trigger_dependents_to_recompute_dependencies`, changing the format from `{w_id}:{importer_path}:dependency` to `{w_id}:{importer_path}:{importer_kind}:dependency`

## Root Cause
When a script (e.g. `f/lib/zoho`) used as a relative import is redeployed, the `dependency_map` may contain both a `script` and `flow` entry for the same importer path (e.g. `f/flows/configure_gateway`). This triggers both a `Dependencies` job (for the script version) and a `FlowDependencies` job (for the flow version). Because both shared the same debounce key, the `FlowDependencies` job could be debounced by the `Dependencies` job. The `Dependencies` job only updates the script's lockfile — it does **not** create a new `flow_version` or update the `flow` table. As a result, the flow continues using stale `flow_node` IDs, and the Python `RAW_SCRIPT_CACHE` (keyed by `flow_node.id`) serves the old imported script content.

## Test plan
- [ ] Deploy a script used as a relative import by a flow that also has both `script` and `flow` entries in `dependency_map`
- [ ] Verify that redeploying the imported script triggers separate debounce keys for each importer kind
- [ ] Verify the flow version is updated and subsequent flow executions use the new import

---
Generated with [Claude Code](https://claude.com/claude-code)