### PR TITLE
fix: multi-script dedicated workers race on shared job_dir (#8551)

### DIFF
--- a/backend/ee-repo-ref.txt
+++ b/backend/ee-repo-ref.txt
@@ -1,1 +1,1 @@
-d958cd3b8a9a17b5f3cb6cb411c8ebba0c380fdd
+5e8b1bcfc2c9ade9db39c839f2faed4f82da5efc


### PR DESCRIPTION
## Summary
- Fix race condition where multiple dedicated worker scripts shared the same `job_dir` (`{worker_dir}/dedicated`), causing concurrent `tokio::spawn` tasks to overwrite each other's `wrapper.py`
- The last writer's subprocess worked; the other loaded the wrong wrapper and failed with "Script not found"
- Fix: append sanitized script path to `job_dir` when both `flow_job_id` and `node_id` are `None`

Companion PR: windmill-labs/windmill-ee-private#490
Fixes #8551

## Test plan
- [ ] Configure 2+ scripts as dedicated workers in the same worker group
- [ ] Send requests to both endpoints — both should succeed
- [ ] Verify each script has its own `dedicated-{path}` directory with the correct `wrapper.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)