### PR TITLE
fix: break stale companion script cycle in dependency_map

### DIFF
--- a/backend/windmill-dep-map/src/lib.rs
+++ b/backend/windmill-dep-map/src/lib.rs
@@ -88,7 +88,13 @@ pub fn extract_referenced_paths(
 ) -> Option<Vec<String>> {
     let mut referenced_paths = vec![];
     if let Some(wk_deps_refs) = language
-        .and_then(|l| windmill_common::scripts::extract_workspace_dependencies_annotated_refs(&l, raw_code, script_path))
+        .and_then(|l| {
+            windmill_common::scripts::extract_workspace_dependencies_annotated_refs(
+                &l,
+                raw_code,
+                script_path,
+            )
+        })
         .map(|r| r.external)
     {
         let l = language.expect("should be some");
@@ -135,7 +141,10 @@ pub async fn process_relative_imports(
     use scoped_dependency_map::ScopedDependencyMap;
     use trigger_dependents::trigger_dependents_to_recompute_dependencies;
 
-    // TODO: Should be moved into handle_dependency_job body to be more consistent with how flows and apps are handled
+    let triggered_by_relative_import = args
+        .map(|x| x.get("triggered_by_relative_import").is_some())
+        .unwrap_or(false);
+
     {
         let mut tx = db.begin().await?;
         let mut dependency_map = ScopedDependencyMap::fetch_maybe_rearranged(
@@ -147,14 +156,19 @@ pub async fn process_relative_imports(
         )
         .await?;
 
-        tx = dependency_map
-            .patch(
-                extract_referenced_paths(&code, script_path, *script_lang),
-                // Ideally should be None, but due to current implementation will use empty string to represent None.
-                "".into(),
-                tx,
-            )
-            .await?;
+        // When triggered by a relative import change, don't re-confirm the entries
+        // via patch. This causes dissolve to clear stale importer_kind=script entries
+        // (e.g. companion scripts at flow paths), breaking the self-sustaining cycle.
+        if !triggered_by_relative_import {
+            tx = dependency_map
+                .patch(
+                    extract_referenced_paths(&code, script_path, *script_lang),
+                    // Ideally should be None, but due to current implementation will use empty string to represent None.
+                    "".into(),
+                    tx,
+                )
+                .await?;
+        }
 
         dependency_map.dissolve(tx).await.commit().await?;
     }


### PR DESCRIPTION
## Summary
When a `Dependencies` job is triggered by a relative import change (`triggered_by_relative_import=true`), skip re-writing the `importer_kind=script` entry in `dependency_map`. This breaks a self-sustaining cycle where stale companion scripts at flow paths keep getting re-created.

## Context
A historical CLI bug (fixed in `be1b4100dd`) caused inline flow scripts to be deployed as standalone scripts at the flow path. Once these companion scripts exist, they create `importer_kind=script` entries in `dependency_map`. When a relative import changes:

1. `trigger_dependents` sees the entry → creates a `Dependencies` job
2. `clone_runnable` clones the companion script → new version
3. `process_relative_imports` re-creates the `dependency_map` entry → back to step 1

This cycle is the root cause behind the debounce collision fixed in #8567 — without the stale `script` entry, there's no `Dependencies` job to collide with the `FlowDependencies` job.

## Changes
- In `process_relative_imports`, check the `triggered_by_relative_import` arg. If true, skip the `dependency_map` re-write (the entry already exists). Downstream propagation still runs.

## Test plan
- [ ] Deploy a flow with inline Python scripts that import a relative module
- [ ] Redeploy the imported module
- [ ] Verify only a `FlowDependencies` job is created (no `Dependencies` job for the companion script)
- [ ] Verify the `importer_kind=script` entry in `dependency_map` is cleared after one cycle

---
Generated with [Claude Code](https://claude.com/claude-code)