### PR TITLE
fix: use layer instead of route_layer for MCP router to prevent axum 0.8 panic

### DIFF
--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -474,14 +474,17 @@ pub async fn run_server(
             let (mcp_router, mcp_cancellation_token) =
                 setup_mcp_server(db.clone(), user_db, _base_internal_url.clone()).await?;
             // Workspace-scoped MCP router
+            // Use `layer` instead of `route_layer` because the MCP router only has
+            // a fallback_service (no explicit routes), and axum 0.8 panics on
+            // route_layer with no routes.
             let workspaced_mcp_router = mcp_router
                 .clone()
-                .route_layer(from_extractor::<ApiAuthed>())
+                .layer(from_extractor::<ApiAuthed>())
                 .layer(axum::middleware::from_fn(add_www_authenticate_header))
                 .layer(axum::middleware::from_fn(extract_and_store_workspace_id));
             // Gateway MCP router — resolves workspace from token
             let gateway_mcp_router = mcp_router
-                .route_layer(from_extractor::<ApiAuthed>())
+                .layer(from_extractor::<ApiAuthed>())
                 .layer(axum::middleware::from_fn(
                     add_www_authenticate_header_gateway,
                 ))


### PR DESCRIPTION
## Summary
Fix CI integration test failure caused by the server panicking on startup after the axum 0.7→0.8 upgrade.

## Changes
- Changed `route_layer` to `layer` for both MCP router wrappings (workspace-scoped and gateway) in `run_server`
- The MCP router uses `fallback_service` (no explicit routes), and axum 0.8 panics when `route_layer` is called on a router with no routes
- `layer` is semantically correct here since all requests to the MCP fallback service should go through auth

## Context
- The axum upgrade (`0389d9601c`) changed `route_layer` behavior to panic on empty routers
- The MCP router change (`99b0ebd677`) switched from `nest_service` to `fallback_service`, which doesn't count as a "route" in axum 0.8
- CI has been failing on every main push since the axum upgrade

## Test plan
- [ ] CI integration test (`run_integration_test` job in docker-image workflow) passes
- [ ] MCP endpoints still require authentication

---
Generated with [Claude Code](https://claude.com/claude-code)