### PR TITLE
fix: use constant-time comparison for API key and basic auth validation

### DIFF
--- a/backend/windmill-trigger-http/src/http_trigger_auth.rs
+++ b/backend/windmill-trigger-http/src/http_trigger_auth.rs
@@ -621,7 +621,7 @@ impl AuthenticationMethod {
                 let api_key_to_cmp = headers
                     .try_get_webhook_header(&api_key_header)
                     .map_err(|_| AuthenticationError::InvalidApiKey)?;
-                if api_key_to_cmp != api_key_secret {
+                if !constant_time_eq(api_key_to_cmp.as_bytes(), api_key_secret.as_bytes()) {
                     return Err(AuthenticationError::InvalidApiKey);
                 }
             }
@@ -654,8 +654,11 @@ impl AuthenticationMethod {
                     return Err(AuthenticationError::UnauthorizedBasicHttpAuth);
                 }
 
-                if credentials.get(0).unwrap() != username
-                    || credentials.get(1).unwrap() != password
+                if !constant_time_eq(credentials.get(0).unwrap().as_bytes(), username.as_bytes())
+                    || !constant_time_eq(
+                        credentials.get(1).unwrap().as_bytes(),
+                        password.as_bytes(),
+                    )
                 {
                     return Err(AuthenticationError::UnauthorizedBasicHttpAuth);
                 }


### PR DESCRIPTION
## Summary
Fixes GHSA-8jc4-wj2p-2vmp — HTTP trigger API key and basic auth authentication used non-constant-time string comparison (`!=`), making them vulnerable to timing side-channel attacks. The `constant_time_eq` crate was already imported for HMAC verification but not used for these two auth methods.

## Changes
- Replace `!=` with `constant_time_eq` for API key comparison in `AuthenticationMethod::ApiKey`
- Replace `!=` with `constant_time_eq` for username and password comparison in `AuthenticationMethod::BasicAuth`

## Test plan
- [x] `cargo check -p windmill-trigger-http` passes
- [x] All 70 existing `http_trigger_auth` tests pass

---
Generated with [Claude Code](https://claude.com/claude-code)