### PR TITLE
fix: asset usages drawer frozen page due to snippet param shadowing

### DIFF
--- a/frontend/src/lib/components/assets/AssetsUsageDrawer.svelte
+++ b/frontend/src/lib/components/assets/AssetsUsageDrawer.svelte
@@ -65,19 +65,17 @@
 	</DrawerContent>
 </Drawer>
 
-{#snippet rightBadge(text: string | undefined, tooltip?: string)}
-	{#if text}
+{#snippet rightBadge(badgeText: string | undefined, tooltip?: string)}
+	{#if badgeText}
 		<Tooltip disablePopup={!tooltip}>
 			<div class={twMerge('text-xs 	font-normal text-primary min-w-12 p-1 text-center rounded-md')}>
-				{text}
+				{badgeText}
 			</div>
 			{#snippet text()}
-					
-					{#if tooltip}
-						{tooltip}
-					{/if}
-				
-					{/snippet}
+				{#if tooltip}
+					{tooltip}
+				{/if}
+			{/snippet}
 		</Tooltip>
 	{/if}
 {/snippet}


### PR DESCRIPTION
## Summary
- Fixes page freeze (`Cannot read properties of undefined (reading 'before')`) when clicking "asset usages" on the Assets page
- Root cause: Svelte 5 compiler bug where the `rightBadge` snippet parameter `text` was shadowed by an inner `{#snippet text()}` declaration (a Tooltip prop), causing the compiled code to invoke the snippet function instead of reading the string value, passing `undefined` as anchor to `$.append()`
- Fix: rename the snippet parameter from `text` to `badgeText` to avoid the name collision

## Test plan
- [ ] Navigate to Assets page with assets that have usages
- [ ] Click the "X usages" link on any asset row
- [ ] Verify the usage drawer opens without freezing
- [ ] Verify badge text (date, access type) renders correctly in the drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)