### PR TITLE
fix: disable workspace webhook events when CLOUD_HOSTED

### DIFF
--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -1134,6 +1134,12 @@ async fn edit_webhook(
 ) -> Result<String> {
     require_admin(is_admin, &username)?;
 
+    if *CLOUD_HOSTED {
+        return Err(Error::BadRequest(
+            "Workspace webhooks are not available on cloud-hosted instances".to_string(),
+        ));
+    }
+
     let mut tx = db.begin().await?;
 
     if let Some(webhook) = &ew.webhook {

--- a/backend/windmill-common/src/webhook.rs
+++ b/backend/windmill-common/src/webhook.rs
@@ -233,6 +233,9 @@ impl WebhookShared {
     }
 
     pub fn send_message(&self, workspace_id: String, message: WebhookMessage) {
+        if *crate::worker::CLOUD_HOSTED {
+            return;
+        }
         let _ = self.channel.send(WebhookPayload::WorkspaceEvent(
             workspace_id.clone(),
             message,

--- a/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
@@ -1113,7 +1113,7 @@
 					label: 'Webhook',
 					aiId: 'workspace-settings-webhook',
 					aiDescription: 'Webhook workspace settings',
-					showIf: WORKSPACE_SHOW_WEBHOOK_CLI_SYNC
+					showIf: WORKSPACE_SHOW_WEBHOOK_CLI_SYNC && !isCloudHosted()
 				},
 				{
 					id: 'native_triggers',


### PR DESCRIPTION
## Summary
Disables the workspace webhook feature on cloud-hosted instances.

## Changes
- **`backend/windmill-common/src/webhook.rs`**: Short-circuit `send_message()` when `CLOUD_HOSTED` to prevent all workspace webhook events from being queued/sent
- **`backend/windmill-api-workspaces/src/workspaces.rs`**: Return 400 from `edit_webhook` endpoint when `CLOUD_HOSTED`
- **`frontend/workspace_settings/+page.svelte`**: Hide the Webhook settings tab when `isCloudHosted()`

## Test plan
- [ ] Verify backend compiles with `cargo check` ✅
- [ ] Verify frontend checks pass with `npm run check:fast` ✅
- [ ] On cloud-hosted: webhook tab should not appear in workspace settings
- [ ] On cloud-hosted: POST to `/api/w/{workspace}/workspaces/edit_webhook` returns 400
- [ ] On self-hosted: webhook feature works unchanged

---
Generated with [Claude Code](https://claude.com/claude-code)