### PR TITLE
fix: validate JSON before sql_builder bind to prevent JSONB injection

### DIFF
--- a/backend/windmill-api-inputs/src/lib.rs
+++ b/backend/windmill-api-inputs/src/lib.rs
@@ -138,7 +138,11 @@ async fn get_input_history(
     let mut tx = user_db.begin(&authed).await?;
 
     let args_query = if let Some(args) = &g.args {
-        sql_builder::bind::Bind::bind(&"and v2_job.args @> ?", &args.replace("'", "''"))
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(args) {
+            sql_builder::bind::Bind::bind(&"and v2_job.args @> ?", &v.to_string())
+        } else {
+            "AND FALSE".to_string()
+        }
     } else {
         "".to_string()
     };

--- a/backend/windmill-api-jobs/src/query.rs
+++ b/backend/windmill-api-jobs/src/query.rs
@@ -8,6 +8,7 @@
 
 //! Query builders for filtering job lists (queue and completed).
 
+use serde_json;
 use sql_builder::prelude::*;
 use sql_builder::SqlBuilder;
 use windmill_common::utils::{escape_ilike_pattern, paginate_without_limits, Pagination};
@@ -200,7 +201,11 @@ pub fn filter_list_queue_query(
     }
 
     if let Some(args) = &lq.args {
-        sqlb.and_where("args @> ?".bind(&args.replace("'", "''")));
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(args) {
+            sqlb.and_where("args @> ?".bind(&v.to_string()));
+        } else {
+            sqlb.and_where("FALSE");
+        }
     }
 
     if lq.scheduled_for_before_now.is_some_and(|x| x) {
@@ -499,11 +504,19 @@ pub fn filter_list_completed_query(
     }
 
     if let Some(args) = &lq.args {
-        sqlb.and_where("args @> ?".bind(&args.replace("'", "''")));
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(args) {
+            sqlb.and_where("args @> ?".bind(&v.to_string()));
+        } else {
+            sqlb.and_where("FALSE");
+        }
     }
 
     if let Some(result) = &lq.result {
-        sqlb.and_where("result @> ?".bind(&result.replace("'", "''")));
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(result) {
+            sqlb.and_where("result @> ?".bind(&v.to_string()));
+        } else {
+            sqlb.and_where("FALSE");
+        }
     }
 
     if lq.is_not_schedule.unwrap_or(false) {

--- a/backend/windmill-api-schedule/src/lib.rs
+++ b/backend/windmill-api-schedule/src/lib.rs
@@ -658,7 +658,11 @@ async fn list_schedule(
         sqlb.and_where_eq("is_flow", "?".bind(&is_flow));
     }
     if let Some(args) = &lsq.args {
-        sqlb.and_where("args @> ?".bind(&args.replace("'", "''")));
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(args) {
+            sqlb.and_where("args @> ?".bind(&v.to_string()));
+        } else {
+            sqlb.and_where("FALSE");
+        }
     }
     if let Some(path_start) = &lsq.path_start {
         sqlb.and_where_like_left("path", path_start);

--- a/backend/windmill-store/src/resources.rs
+++ b/backend/windmill-store/src/resources.rs
@@ -297,7 +297,11 @@ async fn list_resources(
     }
 
     if let Some(value) = &lq.value {
-        sqlb.and_where("resource.value @> ?".bind(&value.replace("'", "''")));
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(value) {
+            sqlb.and_where("resource.value @> ?".bind(&v.to_string()));
+        } else {
+            sqlb.and_where("FALSE");
+        }
     }
 
     if let Some(broad_filter) = &lq.broad_filter {


### PR DESCRIPTION
## Summary

- Fixes GHSA-55p6-fxj4-v983: `sql_builder`'s `Bind` trait uses string interpolation (not true parameterized queries), and user-controlled strings for JSONB `@>` queries were only protected by manual `replace("'", "''")`
- All 5 affected call sites now validate input as JSON via `serde_json` roundtrip before it reaches the query builder
- `serde_json::Value::to_string()` produces canonical JSON that cannot contain SQL-breaking sequences; invalid JSON falls back to `AND FALSE`

**Files changed:**
- `backend/windmill-api-jobs/src/query.rs` — `args` filter (queue + completed), `result` filter (completed)
- `backend/windmill-api-schedule/src/lib.rs` — `args` filter (schedule listing)
- `backend/windmill-api-inputs/src/lib.rs` — `args` filter (input history)
- `backend/windmill-store/src/resources.rs` — `value` filter (resource queries)

## Test plan

- [x] `cargo check` — clean compile
- [x] `cargo test -p windmill-api-jobs -- query` — 27/27 tests pass
- [ ] Manual: `GET /api/w/{workspace}/jobs/completed/list?args={"key":"value"}` returns filtered results
- [ ] Manual: `GET /api/w/{workspace}/jobs/completed/list?args=\' OR 1=1 --` returns empty list (invalid JSON rejected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)