### PR TITLE
fix: add per-IP and per-account brute force protection on login

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -16564,6 +16564,7 @@ dependencies = [
  "crc",
  "cron",
  "croner",
+ "dashmap 6.1.0",
  "datafusion",
  "equivalent",
  "futures",

--- a/backend/windmill-api-users/src/users.rs
+++ b/backend/windmill-api-users/src/users.rs
@@ -1746,6 +1746,7 @@ async fn set_login_type(
 
 #[allow(unreachable_code, unused_variables)]
 async fn login(
+    headers: axum::http::HeaderMap,
     cookies: Cookies,
     Extension(db): Extension<DB>,
     Extension(argon2): Extension<Arc<Argon2<'_>>>,
@@ -1756,8 +1757,11 @@ async fn login(
         return Ok("no_auth".to_string());
     }
 
-    let mut tx = db.begin().await?;
     let email = email.to_lowercase();
+    let client_ip = windmill_common::login_rate_limit::extract_client_ip(&headers);
+    windmill_common::login_rate_limit::check_login_rate_limit(&client_ip, &email)?;
+
+    let mut tx = db.begin().await?;
     let audit_author = AuditAuthor {
         email: email.clone(),
         username: email.clone(),
@@ -1789,6 +1793,7 @@ async fn login(
                 None,
             )
             .await?;
+            windmill_common::login_rate_limit::record_login_failure(&client_ip, &email);
             Err(Error::BadRequest("Invalid login".to_string()))
         } else {
             let token = create_session_token(&email, super_admin, &mut tx, cookies).await?;
@@ -1825,6 +1830,7 @@ async fn login(
             None,
         )
         .await?;
+        windmill_common::login_rate_limit::record_login_failure(&client_ip, &email);
         Err(Error::BadRequest("Invalid login".to_string()))
     }
 }

--- a/backend/windmill-common/Cargo.toml
+++ b/backend/windmill-common/Cargo.toml
@@ -117,6 +117,7 @@ pin-project-lite.workspace = true
 futures.workspace = true
 tempfile.workspace = true
 globset.workspace = true
+dashmap.workspace = true
 
 opentelemetry-semantic-conventions = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }

--- a/backend/windmill-common/src/lib.rs
+++ b/backend/windmill-common/src/lib.rs
@@ -69,6 +69,7 @@ pub mod git_sync_ee;
 pub mod git_sync_oss;
 pub mod jobs;
 pub mod jwt;
+pub mod login_rate_limit;
 pub mod more_serde;
 pub mod oauth2;
 #[cfg(all(feature = "enterprise", feature = "openidconnect", feature = "private"))]

--- a/backend/windmill-common/src/login_rate_limit.rs
+++ b/backend/windmill-common/src/login_rate_limit.rs
@@ -1,0 +1,102 @@
+use chrono::Utc;
+use dashmap::DashMap;
+use hyper::StatusCode;
+use std::sync::LazyLock;
+
+use crate::error::{Error, Result};
+
+const DEFAULT_PER_IP_LIMIT: i32 = 10;
+const DEFAULT_PER_ACCOUNT_LIMIT: i32 = 5;
+
+struct RateLimitEntry {
+    count: i32,
+    minute_bucket: i64,
+}
+
+static IP_RATE_LIMIT: LazyLock<DashMap<String, RateLimitEntry>> = LazyLock::new(DashMap::new);
+static ACCOUNT_RATE_LIMIT: LazyLock<DashMap<String, RateLimitEntry>> = LazyLock::new(DashMap::new);
+
+static PER_IP_LIMIT: LazyLock<i32> = LazyLock::new(|| {
+    std::env::var("LOGIN_RATE_LIMIT_PER_IP")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_PER_IP_LIMIT)
+});
+
+static PER_ACCOUNT_LIMIT: LazyLock<i32> = LazyLock::new(|| {
+    std::env::var("LOGIN_RATE_LIMIT_PER_ACCOUNT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_PER_ACCOUNT_LIMIT)
+});
+
+pub fn extract_client_ip(headers: &axum::http::HeaderMap) -> String {
+    if let Some(real_ip) = headers.get("x-real-ip") {
+        if let Ok(ip) = real_ip.to_str() {
+            let trimmed = ip.trim();
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+    }
+
+    if let Some(forwarded_for) = headers.get("x-forwarded-for") {
+        if let Ok(ips) = forwarded_for.to_str() {
+            if let Some(first_ip) = ips.split(',').next() {
+                let trimmed = first_ip.trim();
+                if !trimmed.is_empty() {
+                    return trimmed.to_string();
+                }
+            }
+        }
+    }
+
+    "unknown".to_string()
+}
+
+fn check_rate_limit(map: &DashMap<String, RateLimitEntry>, key: &str, limit: i32) -> Result<()> {
+    let current_minute = Utc::now().timestamp() / 60;
+
+    let entry = map
+        .entry(key.to_string())
+        .or_insert(RateLimitEntry { count: 0, minute_bucket: current_minute });
+
+    if entry.minute_bucket != current_minute {
+        return Ok(());
+    }
+
+    if entry.count >= limit {
+        return Err(Error::Generic(
+            StatusCode::TOO_MANY_REQUESTS,
+            "Too many login attempts. Please try again later.".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn record_failure(map: &DashMap<String, RateLimitEntry>, key: &str) {
+    let current_minute = Utc::now().timestamp() / 60;
+
+    let mut entry = map
+        .entry(key.to_string())
+        .or_insert(RateLimitEntry { count: 0, minute_bucket: current_minute });
+
+    if entry.minute_bucket != current_minute {
+        entry.count = 1;
+        entry.minute_bucket = current_minute;
+    } else {
+        entry.count += 1;
+    }
+}
+
+pub fn check_login_rate_limit(ip: &str, email: &str) -> Result<()> {
+    check_rate_limit(&IP_RATE_LIMIT, ip, *PER_IP_LIMIT)?;
+    check_rate_limit(&ACCOUNT_RATE_LIMIT, email, *PER_ACCOUNT_LIMIT)?;
+    Ok(())
+}
+
+pub fn record_login_failure(ip: &str, email: &str) {
+    record_failure(&IP_RATE_LIMIT, ip);
+    record_failure(&ACCOUNT_RATE_LIMIT, email);
+}


### PR DESCRIPTION
## Summary

The brute force counter added in v1.390.1 (CVE-2024-8462 fix) is a single global `AtomicU64` — not per-IP or per-account. It only triggers a 2-second sleep after 10,000 global failures/minute and is on the token auth middleware, not the login endpoint. An attacker can credential-stuff thousands of accounts/minute from a single IP with zero throttle on `POST /api/auth/login`.

This PR adds proper per-IP and per-account rate limiting directly on the password login endpoint.

## Changes

- New `login_rate_limit` module in `windmill-common` with DashMap-based per-IP and per-account counters (follows existing `public_app_rate_limit.rs` pattern)
- IP extraction from `X-Real-IP` / `X-Forwarded-For` headers (works behind reverse proxies)
- Rate limit check runs **before** DB query (no wasted DB load on rate-limited requests)
- Failure recording on both error paths (wrong password, unknown email)
- Returns `429 Too Many Requests` with vague message (doesn't leak which limit was hit)
- Configurable via env vars: `LOGIN_RATE_LIMIT_PER_IP` (default: 10/min), `LOGIN_RATE_LIMIT_PER_ACCOUNT` (default: 5/min)

## Test plan

- [ ] `cargo check` passes (verified)
- [ ] Login with correct credentials succeeds normally
- [ ] After 5 failed attempts against one email, 6th attempt returns 429
- [ ] After 10 failed attempts from one IP, 11th attempt returns 429
- [ ] Counter resets after 1 minute

---
Generated with [Claude Code](https://claude.com/claude-code)