### PR TITLE
fix: harden login rate limiting with CLOUD_HOSTED gating and memory eviction

### DIFF
--- a/backend/windmill-api-users/src/users.rs
+++ b/backend/windmill-api-users/src/users.rs
@@ -1758,11 +1758,7 @@ async fn login(
     }
 
     let email = email.to_lowercase();
-    let client_ip = windmill_common::login_rate_limit::extract_client_ip(&headers);
-    windmill_common::login_rate_limit::check_and_increment_login_attempt(
-        client_ip.as_deref(),
-        &email,
-    )?;
+    windmill_common::login_rate_limit::check_and_increment_login_attempt(&headers, &email)?;
 
     let mut tx = db.begin().await?;
     let audit_author = AuditAuthor {

--- a/backend/windmill-common/src/login_rate_limit.rs
+++ b/backend/windmill-common/src/login_rate_limit.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use dashmap::DashMap;
 use hyper::StatusCode;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicI32, AtomicI64, AtomicU64, Ordering};
 use std::sync::LazyLock;
 
 use crate::error::{Error, Result};
@@ -19,7 +19,9 @@ struct RateLimitEntry {
 
 static IP_RATE_LIMIT: LazyLock<DashMap<String, RateLimitEntry>> = LazyLock::new(DashMap::new);
 static ACCOUNT_RATE_LIMIT: LazyLock<DashMap<String, RateLimitEntry>> = LazyLock::new(DashMap::new);
-static GLOBAL_RATE_LIMIT: LazyLock<DashMap<String, RateLimitEntry>> = LazyLock::new(DashMap::new);
+
+static GLOBAL_COUNT: AtomicI32 = AtomicI32::new(0);
+static GLOBAL_MINUTE: AtomicI64 = AtomicI64::new(0);
 
 static EVICTION_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -138,21 +140,23 @@ fn record_failure(map: &DashMap<String, RateLimitEntry>, key: &str) {
 }
 
 /// Called BEFORE authentication. Checks and increments global + per-IP counters.
+/// The global counter counts all login attempts (not just failures), so it acts as
+/// a general throttle on login traffic per server instance.
 /// Per-IP is only active on CLOUD_HOSTED or when LOGIN_RATE_LIMIT_PER_IP is explicitly set.
-pub fn check_and_increment_login_attempt(ip: Option<&str>, email: &str) -> Result<()> {
+pub fn check_and_increment_login_attempt(
+    headers: &axum::http::HeaderMap,
+    email: &str,
+) -> Result<()> {
     let current_minute = Utc::now().timestamp() / 60;
-    maybe_evict(
-        &[&IP_RATE_LIMIT, &ACCOUNT_RATE_LIMIT, &GLOBAL_RATE_LIMIT],
-        current_minute,
-    );
+    maybe_evict(&[&IP_RATE_LIMIT, &ACCOUNT_RATE_LIMIT], current_minute);
 
-    // Global limit: always on
-    check_and_increment(&GLOBAL_RATE_LIMIT, "global", *GLOBAL_LIMIT, current_minute)?;
+    // Global limit: always on, uses atomics (single key, no need for DashMap)
+    check_and_increment_global(current_minute)?;
 
     // Per-IP limit: CLOUD_HOSTED or explicit opt-in
     if *CLOUD_HOSTED || *PER_IP_LIMIT_EXPLICIT {
-        if let Some(ip) = ip {
-            check_and_increment(&IP_RATE_LIMIT, ip, *PER_IP_LIMIT, current_minute)?;
+        if let Some(ip) = extract_client_ip(headers) {
+            check_and_increment(&IP_RATE_LIMIT, &ip, *PER_IP_LIMIT, current_minute)?;
         }
     }
 
@@ -167,6 +171,27 @@ pub fn check_and_increment_login_attempt(ip: Option<&str>, email: &str) -> Resul
                 ));
             }
         }
+    }
+
+    Ok(())
+}
+
+fn check_and_increment_global(current_minute: i64) -> Result<()> {
+    let stored_minute = GLOBAL_MINUTE.load(Ordering::Relaxed);
+    if stored_minute != current_minute {
+        // Minute rolled over — reset. Race here is benign: worst case two threads
+        // both reset, and we lose a few counts at the boundary.
+        GLOBAL_MINUTE.store(current_minute, Ordering::Relaxed);
+        GLOBAL_COUNT.store(1, Ordering::Relaxed);
+        return Ok(());
+    }
+
+    let count = GLOBAL_COUNT.fetch_add(1, Ordering::Relaxed);
+    if count >= *GLOBAL_LIMIT {
+        return Err(Error::Generic(
+            StatusCode::TOO_MANY_REQUESTS,
+            "Too many login attempts. Please try again later.".to_string(),
+        ));
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Follow-up to #8601 — addresses several issues with the per-IP/per-account brute force protection on the login endpoint that could cause false positives for self-hosted deployments behind proxies/NAT, account-level DoS, unbounded memory growth, and TOCTOU race conditions.

## Changes

- **CLOUD_HOSTED gating**: Per-IP and per-account rate limits now only activate on `CLOUD_HOSTED` or when the operator explicitly sets `LOGIN_RATE_LIMIT_PER_IP` / `LOGIN_RATE_LIMIT_PER_ACCOUNT` env vars. Self-hosted deployments behind proxy/NAT are no longer affected by default.
- **Global rate limit (always-on)**: New per-server global limit (120/min, configurable via `LOGIN_RATE_LIMIT_GLOBAL`) protects all deployments against automated brute force without false positives.
- **Raised defaults**: Per-IP 10→30/min, per-account 5→10/min to reduce false positives in shared-IP environments.
- **Memory eviction**: Probabilistic cleanup (every 256 calls) evicts stale DashMap entries older than 1 minute, preventing unbounded memory growth.
- **TOCTOU race fix**: Global and per-IP counters now use atomic check-and-increment (matching `public_app_rate_limit.rs` pattern) instead of separate check/record calls.
- **`extract_client_ip` returns `Option<String>`**: No more `"unknown"` fallback that pooled all headerless requests into one bucket. Per-IP limiting is simply skipped when no trusted header is present.

## Test plan

- [ ] `cargo check` passes
- [ ] Login with correct credentials works normally
- [ ] On CLOUD_HOSTED: after 10 failed attempts against one email, next attempt returns 429
- [ ] On CLOUD_HOSTED: after 30 failed attempts from one IP, next attempt returns 429
- [ ] Without CLOUD_HOSTED: per-IP and per-account limits are not enforced (only global 120/min)
- [ ] Self-hosted operator can opt-in by setting `LOGIN_RATE_LIMIT_PER_IP=20`

---
Generated with [Claude Code](https://claude.com/claude-code)