### PR TITLE
fix: add path traversal check in service_logs get_log_file endpoint

### DIFF
--- a/backend/windmill-api/src/service_logs.rs
+++ b/backend/windmill-api/src/service_logs.rs
@@ -97,6 +97,9 @@ async fn get_log_file(
 
     require_devops_role(&db, &email).await?;
     let path = path.to_path();
+    if path.contains("..") {
+        return Err(Error::BadRequest("Invalid path".to_string()));
+    }
     #[cfg(feature = "parquet")]
     let s3_client = windmill_object_store::get_object_store().await;
     #[cfg(feature = "parquet")]


### PR DESCRIPTION
## Summary
Fix GHSA-4hrf-mgvv-xp9x: path traversal vulnerability in `GET /api/service_logs/get_log_file/{path}` that allows devops users to read arbitrary files from the container filesystem using `../` sequences.

## Changes
- Add `..` path traversal check in `service_logs::get_log_file` before the path is used for either S3 or local filesystem reads
- Matches the existing mitigation pattern used in `jobs::get_log_file` (fixed in GHSA-24fr-44f8-fqwg)

## Test plan
- [x] Backend compiles cleanly
- [x] PoC request `GET /api/service_logs/get_log_file/../../../../../etc/passwd` returns `400 Bad request: Invalid path`
- [x] Legitimate path `GET /api/service_logs/get_log_file/some-host/2024-01-01.log` returns `404 Not found` (expected, no log files in dev)

---
Generated with [Claude Code](https://claude.com/claude-code)