### PR TITLE
fix: cast DuckDB IS_NULLABLE to string in metadata query

### DIFF
--- a/backend/windmill-common/src/query_builders.rs
+++ b/backend/windmill-common/src/query_builders.rs
@@ -2369,7 +2369,7 @@ fn make_load_table_metadata_query(
     COLUMN_DEFAULT as DefaultValue,
     false as IsPrimaryKey,
     false as IsIdentity,
-    IS_NULLABLE as IsNullable,
+    CASE WHEN IS_NULLABLE = true THEN 'YES' ELSE 'NO' END as IsNullable,
     false as IsEnum,
     TABLE_NAME as table_name
 FROM information_schema.columns c


### PR DESCRIPTION
## Summary
- DuckDB's `information_schema.columns` returns `IS_NULLABLE` as a boolean (`true`/`false`), but the Rust `ColumnDef` struct expects a string (`'YES'`/`'NO'`).
- This caused deserialization to fail when expanding `WM_INTERNAL_DB` markers (e.g. COUNT) for Ducklake/DuckDB tables, with the error: `Invalid COUNT payload: invalid type: boolean false, expected a string`.
- Fixed by adding a `CASE WHEN` cast in the DuckDB metadata query, matching the pattern used by all other database types (PostgreSQL, MySQL, MSSQL, Snowflake).

## Test plan
- [x] Backend compiles and starts successfully (`cargo watch -x run`)
- [x] No backend errors in logs
- [x] Manually verified PostgreSQL data table DB Manager loads correctly
- [ ] Verify Ducklake DB Manager loads without the COUNT payload error (requires DuckDB instance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)