### PR TITLE
fix: add HMAC signature verification to Slack callback endpoint

### DIFF
--- a/backend/windmill-api/src/oauth2_oss.rs
+++ b/backend/windmill-api/src/oauth2_oss.rs
@@ -159,13 +159,24 @@ pub async fn check_nb_of_user(db: &DB) -> error::Result<()> {
 #[derive(Clone, Debug)]
 #[cfg(not(feature = "private"))]
 pub struct SlackVerifier {
-    _mac: HmacSha256,
+    mac: HmacSha256,
 }
 #[cfg(not(feature = "private"))]
 impl SlackVerifier {
     pub fn new<S: AsRef<[u8]>>(secret: S) -> anyhow::Result<SlackVerifier> {
         HmacSha256::new_from_slice(secret.as_ref())
-            .map(|mac| SlackVerifier { _mac: mac })
+            .map(|mac| SlackVerifier { mac })
             .map_err(|_| anyhow::anyhow!("invalid secret"))
+    }
+
+    pub fn verify(&self, ts: &str, body: &str, exp_sig: &str) -> anyhow::Result<()> {
+        let basestring = format!("v0:{}:{}", ts, body);
+        let mut mac = self.mac.clone();
+        mac.update(basestring.as_bytes());
+        let sig = format!("v0={}", hex::encode(mac.finalize().into_bytes()));
+        if sig != exp_sig {
+            Err(anyhow::anyhow!("signature mismatch"))?;
+        }
+        Ok(())
     }
 }

--- a/backend/windmill-api/src/slack_approvals.rs
+++ b/backend/windmill-api/src/slack_approvals.rs
@@ -1,7 +1,9 @@
 use axum::{
-    extract::{Form, Path, Query},
+    extract::{Path, Query},
     Extension,
 };
+use bytes::Bytes;
+use http::HeaderMap;
 use hyper::StatusCode;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -119,12 +121,41 @@ struct PrivateMetadata {
     hide_cancel: Option<bool>,
 }
 
+#[cfg(feature = "oauth2")]
+fn verify_slack_callback_signature(headers: &HeaderMap, body: &str) -> Result<(), Error> {
+    if let Some(sv) = crate::SLACK_SIGNING_SECRET.as_ref() {
+        let sig = headers
+            .get("X-Slack-Signature")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        let ts = headers
+            .get("X-Slack-Request-Timestamp")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        sv.verify(ts, body, sig)
+            .map_err(|_| Error::BadRequest("Slack signature verification failed".to_string()))?;
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "oauth2"))]
+fn verify_slack_callback_signature(_headers: &HeaderMap, _body: &str) -> Result<(), Error> {
+    Ok(())
+}
+
 pub async fn slack_app_callback_handler(
     authed: Option<ApiAuthed>,
     opt_tokened: OptTokened,
     Extension(db): Extension<DB>,
-    Form(form_data): Form<SlackFormData>,
+    headers: HeaderMap,
+    body: Bytes,
 ) -> Result<StatusCode, Error> {
+    let body_str = String::from_utf8_lossy(&body);
+    verify_slack_callback_signature(&headers, &body_str)?;
+
+    let form_data: SlackFormData = serde_urlencoded::from_bytes(&body)
+        .map_err(|e| Error::BadRequest(format!("invalid form data: {}", e)))?;
+
     tracing::debug!("Form data: {:#?}", form_data);
     let payload: Payload = serde_json::from_str(&form_data.payload)?;
     tracing::debug!("Payload: {:#?}", payload);


### PR DESCRIPTION
## Summary
Add Slack HMAC-SHA256 signature verification to the `/api/slack` interactive callback endpoint (GHSA-hh9x-rcf8-xjr2). Previously, this endpoint processed Slack interactive callbacks without verifying `X-Slack-Signature`, allowing spoofed payloads. The `/slack_command` and `/slack_events` endpoints already had this verification — this change closes the gap.

## Changes
- Add `verify()` method to the OSS `SlackVerifier` stub in `oauth2_oss.rs` (matching the existing `windmill-oauth` implementation used by EE builds)
- Modify `slack_app_callback_handler` to extract raw body bytes and headers instead of using `Form` extractor
- Verify `X-Slack-Signature` and `X-Slack-Request-Timestamp` against `SLACK_SIGNING_SECRET` before processing any payload
- When `SLACK_SIGNING_SECRET` env var is not set, behavior is unchanged (no verification)

## Test plan
- [x] `cargo check -p windmill-api` passes (OSS build)
- [x] `cargo check -p windmill-api --features private` passes (EE build)
- [ ] With `SLACK_SIGNING_SECRET` set: spoofed payloads without valid signature are rejected with 400
- [ ] With `SLACK_SIGNING_SECRET` set: legitimate Slack callbacks with valid signature are processed normally
- [ ] Without `SLACK_SIGNING_SECRET`: existing behavior unchanged

---
Generated with [Claude Code](https://claude.com/claude-code)