### PR TITLE
fix: enforce workspace isolation on flow resume endpoint

### DIFF
--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -2179,12 +2179,24 @@ async fn list_jobs(
 pub async fn resume_suspended_flow_as_owner(
     authed: ApiAuthed,
     Extension(db): Extension<DB>,
-    Path((_w_id, flow_id)): Path<(String, Uuid)>,
+    Path((w_id, flow_id)): Path<(String, Uuid)>,
     QueryOrBody(value): QueryOrBody<serde_json::Value>,
 ) -> error::Result<StatusCode> {
     let mut tx = db.begin().await?;
 
     let (flow, job_id, is_wac) = get_suspended_flow_info(flow_id, &mut tx).await?;
+
+    // Verify the job belongs to this workspace
+    let job_workspace: Option<String> =
+        sqlx::query_scalar("SELECT workspace_id FROM v2_job WHERE id = $1")
+            .bind(&flow.id)
+            .fetch_optional(&mut *tx)
+            .await?;
+    if job_workspace.as_deref() != Some(w_id.as_str()) {
+        return Err(Error::NotFound(
+            "Job not found in this workspace".to_string(),
+        ));
+    }
 
     let flow_path = flow.script_path.as_deref().unwrap_or_else(|| "");
     require_owner_of_path(&authed, flow_path)?;


### PR DESCRIPTION
## Summary

- Fixes GHSA-x2wf-f962-7frq: the `POST /api/w/{workspace}/jobs/flow/resume/{id}` handler discarded the workspace path parameter (`_w_id`), allowing any workspace admin to resume/cancel suspended flows in other workspaces
- Adds workspace ownership verification to `resume_suspended_flow_as_owner` — queries `v2_job.workspace_id` and returns 404 if the job doesn't belong to the URL workspace
- Matches the existing check already present in the unauthed `resume_suspended` handler

## Test plan

- [ ] Create a suspended flow in workspace A
- [ ] Attempt to resume it via `/api/w/workspace_b/jobs/flow/resume/{id}` as a workspace-B-only admin — should get 404
- [ ] Resume it via `/api/w/workspace_a/jobs/flow/resume/{id}` as a workspace-A admin — should succeed (201)
- [ ] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)