### PR TITLE
fix: use route_service instead of fallback_service for MCP router

### DIFF
--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -475,17 +475,14 @@ pub async fn run_server(
             let (mcp_router, mcp_cancellation_token) =
                 setup_mcp_server(db.clone(), user_db, _base_internal_url.clone()).await?;
             // Workspace-scoped MCP router
-            // Use `layer` instead of `route_layer` because the MCP router only has
-            // a fallback_service (no explicit routes), and axum 0.8 panics on
-            // route_layer with no routes.
             let workspaced_mcp_router = mcp_router
                 .clone()
-                .layer(from_extractor::<ApiAuthed>())
+                .route_layer(from_extractor::<ApiAuthed>())
                 .layer(axum::middleware::from_fn(add_www_authenticate_header))
                 .layer(axum::middleware::from_fn(extract_and_store_workspace_id));
             // Gateway MCP router — resolves workspace from token
             let gateway_mcp_router = mcp_router
-                .layer(from_extractor::<ApiAuthed>())
+                .route_layer(from_extractor::<ApiAuthed>())
                 .layer(axum::middleware::from_fn(
                     add_www_authenticate_header_gateway,
                 ))

--- a/backend/windmill-api/src/mcp/core.rs
+++ b/backend/windmill-api/src/mcp/core.rs
@@ -546,7 +546,7 @@ pub async fn setup_mcp_server(
     let service =
         StreamableHttpService::new(move || Ok(runner.clone()), session_manager, service_config);
 
-    let router = Router::new().fallback_service(service);
+    let router = Router::new().route_service("/", service);
     Ok((router, cancellation_token))
 }
 


### PR DESCRIPTION
## Summary
- **`fallback_service` → `route_service`** in `mcp/core.rs`: A router with only a `fallback_service` (no explicit routes) is invisible to axum's `nest()` — requests to the nested prefix never reach the inner router, causing 404s on all MCP endpoints. `route_service("/", service)` registers an actual route so `nest()` forwards correctly.
- **`layer` → `route_layer`** in `lib.rs`: With a real route now registered, `route_layer` works again and is preferred — it only runs the `ApiAuthed` extractor on matched routes. Removes the stale comment from #8572.

## Context
#8566 replaced `nest_service("/", ...)` with `fallback_service(...)` to fix an axum 0.8 panic on root nesting. #8572 then changed `route_layer` to `layer` because `route_layer` panics on routers with no routes. This PR fixes the root cause: use `route_service` so the router has an actual route, making both `nest()` forwarding and `route_layer` work correctly.

## Test plan
- [ ] `cargo check --features mcp -p windmill-api`
- [ ] `curl -X POST http://localhost:8000/api/mcp/w/{workspace}/mcp` returns MCP response (not 404)
- [ ] MCP OAuth endpoints still reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)