### PR TITLE
chore: add missing native-trigger skill frontmatter

### DIFF
--- a/.agents/skills/native-trigger/SKILL.md
+++ b/.agents/skills/native-trigger/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: native-trigger
+description: Guidance for adding native trigger services to Windmill. Use when implementing or modifying native trigger integrations across the backend and frontend.
+---
+
 # Skill: Adding Native Trigger Services
 
 This skill provides comprehensive guidance for adding new native trigger services to Windmill. Native triggers allow external services (like Nextcloud, Google Drive, etc.) to trigger Windmill scripts/flows via webhooks or push notifications.

--- a/.claude/skills/native-trigger/SKILL.md
+++ b/.claude/skills/native-trigger/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: native-trigger
+description: Guidance for adding native trigger services to Windmill. Use when implementing or modifying native trigger integrations across the backend and frontend.
+---
+
 # Skill: Adding Native Trigger Services
 
 This skill provides comprehensive guidance for adding new native trigger services to Windmill. Native triggers allow external services (like Nextcloud, Google Drive, etc.) to trigger Windmill scripts/flows via webhooks or push notifications.


### PR DESCRIPTION
## Summary
Add the missing YAML frontmatter to the `native-trigger` skill in both `.agents` and `.claude` so the mirrored skill definitions include the expected metadata.

## Changes
- add `name` and `description` frontmatter to `.agents/skills/native-trigger/SKILL.md`
- add matching frontmatter to `.claude/skills/native-trigger/SKILL.md`
- leave the skill body unchanged

## Test plan
- [x] Verify both files start with matching YAML frontmatter
- [x] Verify the diff only adds the frontmatter block

---
Generated with [Claude Code](https://claude.com/claude-code)