### PR TITLE
fix: support Okta custom authorization servers in SSO configuration

### DIFF
--- a/frontend/src/lib/components/OktaSetting.svelte
+++ b/frontend/src/lib/components/OktaSetting.svelte
@@ -18,17 +18,20 @@
 	function changeDomain(domain, custom) {
 		if (value) {
 			let baseUrl = custom ? `https://${domain}` : `https://${domain}.okta.com`
+			// If baseUrl already contains /oauth2/ (custom authorization server),
+			// only append /v1/... to avoid duplicating the /oauth2 segment
+			let authBase = baseUrl.includes('/oauth2/') ? baseUrl : `${baseUrl}/oauth2`
 			value = {
 				...value,
 				login_config: {
-					auth_url: `${baseUrl}/oauth2/v1/authorize`,
-					token_url: `${baseUrl}/oauth2/v1/token`,
-					userinfo_url: `${baseUrl}/oauth2/v1/userinfo`,
+					auth_url: `${authBase}/v1/authorize`,
+					token_url: `${authBase}/v1/token`,
+					userinfo_url: `${authBase}/v1/userinfo`,
 					scopes: ['openid', 'profile', 'email']
 				},
 				connect_config: {
-					auth_url: `${baseUrl}/oauth2/v1/authorize`,
-					token_url: `${baseUrl}/oauth2/v1/token`,
+					auth_url: `${authBase}/v1/authorize`,
+					token_url: `${authBase}/v1/token`,
 					scopes: ['openid', 'profile', 'email']
 				}
 			}
@@ -77,7 +80,7 @@
 					<div class="grow flex flex-col gap-1">
 						<input type="text" placeholder="yourorg" bind:value={value['domain']} />
 						<span class="text-hint font-normal text-2xs"
-							>{#if value['custom']}Custom ({'https://<domain>'}){:else}
+							>{#if value['custom']}Custom ({'https://<domain>'} or {'https://<domain>/oauth2/<authServerId>'}){:else}
 								Org ({'https://<your org>.okta.com'}){/if}</span
 						>
 					</div>


### PR DESCRIPTION
## Summary
When configuring Okta SSO with a custom authorization server (URL like `https://{domain}/oauth2/{authServerId}`), Windmill was incorrectly appending `/oauth2/v1/authorize` to the base URL, resulting in a malformed double `/oauth2` path: `https://{domain}/oauth2/{authServerId}/oauth2/v1/authorize`.

## Changes
- Detect when the custom domain already includes an `/oauth2/` path segment (indicating a custom authorization server) and only append `/v1/...` endpoints instead of `/oauth2/v1/...`
- Update the UI hint text to show users they can enter a domain with a custom authorization server path (`https://<domain>/oauth2/<authServerId>`)

### URL construction behavior:
| Mode | Domain input | Resulting auth URL |
|------|-------------|-------------------|
| Org | `yourorg` | `https://yourorg.okta.com/oauth2/v1/authorize` |
| Custom (default server) | `custom.domain.com` | `https://custom.domain.com/oauth2/v1/authorize` |
| Custom (custom auth server) | `custom.domain.com/oauth2/aus123` | `https://custom.domain.com/oauth2/aus123/v1/authorize` |

## Test plan
- [ ] Configure Okta SSO with Org mode — verify URLs use `/oauth2/v1/authorize` as before
- [ ] Configure Okta SSO in Custom mode with just a domain — verify URLs use `/oauth2/v1/authorize`
- [ ] Configure Okta SSO in Custom mode with `/oauth2/{authServerId}` in the domain — verify URLs use `/{authServerId}/v1/authorize` (no duplicate `/oauth2`)
- [ ] Verify the hint text shows the custom auth server URL format

---
Generated with [Claude Code](https://claude.com/claude-code)