### PR TITLE
fix: avoid doubled /oauth2 path in Okta custom authorization server URLs

### DIFF
--- a/frontend/src/lib/components/OktaSetting.svelte
+++ b/frontend/src/lib/components/OktaSetting.svelte
@@ -18,17 +18,18 @@
 	function changeDomain(domain, custom) {
 		if (value) {
 			let baseUrl = custom ? `https://${domain}` : `https://${domain}.okta.com`
+			let authPath = custom ? '/v1' : '/oauth2/v1'
 			value = {
 				...value,
 				login_config: {
-					auth_url: `${baseUrl}/oauth2/v1/authorize`,
-					token_url: `${baseUrl}/oauth2/v1/token`,
-					userinfo_url: `${baseUrl}/oauth2/v1/userinfo`,
+					auth_url: `${baseUrl}${authPath}/authorize`,
+					token_url: `${baseUrl}${authPath}/token`,
+					userinfo_url: `${baseUrl}${authPath}/userinfo`,
 					scopes: ['openid', 'profile', 'email']
 				},
 				connect_config: {
-					auth_url: `${baseUrl}/oauth2/v1/authorize`,
-					token_url: `${baseUrl}/oauth2/v1/token`,
+					auth_url: `${baseUrl}${authPath}/authorize`,
+					token_url: `${baseUrl}${authPath}/token`,
 					scopes: ['openid', 'profile', 'email']
 				}
 			}


### PR DESCRIPTION
## Summary
When configuring Okta SSO with a custom authorization server (URL like `https://{domain}/oauth2/{authServerId}`), Windmill was appending `/oauth2/v1/authorize` to the base URL, resulting in a doubled `/oauth2` path: `https://{domain}/oauth2/{authServerId}/oauth2/v1/authorize`.

This fix detects when a custom authorization server is used and appends only `/v1/authorize` (without the extra `/oauth2` prefix), since the base URL already contains `/oauth2/{authServerId}`.

## Changes
- Modified `OktaSetting.svelte` `changeDomain()` to use `/v1` path prefix for custom auth servers instead of `/oauth2/v1`
- Default (org) server URLs remain unchanged (`/oauth2/v1/...`)

## Test plan
- [ ] Configure Okta SSO with **org** mode (domain = `myorg`) → verify URLs are `https://myorg.okta.com/oauth2/v1/authorize`, `.../token`, `.../userinfo`
- [ ] Configure Okta SSO with **custom** mode (domain = `myorg.okta.com/oauth2/aus123abc`) → verify URLs are `https://myorg.okta.com/oauth2/aus123abc/v1/authorize`, `.../token`, `.../userinfo`
- [ ] Toggle between org and custom modes → verify URLs update correctly each time

---
Generated with [Claude Code](https://claude.com/claude-code)