### PR TITLE
fix: cap input history per_page to 100 on cloud

### DIFF
--- a/backend/windmill-api-inputs/src/lib.rs
+++ b/backend/windmill-api-inputs/src/lib.rs
@@ -26,6 +26,7 @@ use windmill_common::{
     jobs::JobKind,
     scripts::to_i64,
     utils::{not_found_if_none, paginate, Pagination},
+    worker::CLOUD_HOSTED,
 };
 pub fn workspaced_service() -> Router {
     Router::new()
@@ -134,6 +135,11 @@ async fn get_input_history(
     Query(g): Query<GetInputHistory>,
 ) -> JsonResult<Vec<Input>> {
     let (per_page, offset) = paginate(pagination);
+    let per_page = if *CLOUD_HOSTED {
+        per_page.min(100)
+    } else {
+        per_page
+    };
 
     let mut tx = user_db.begin(&authed).await?;
 


### PR DESCRIPTION
## Summary
Cloud instance crashed after serving a `per_page=1840` request on `/inputs/history` with `include_preview=true`. This caps the endpoint to 100 per page on cloud to prevent excessive memory/query load.

## Changes
- Import `CLOUD_HOSTED` flag in `windmill-api-inputs`
- After `paginate()`, clamp `per_page` to 100 when running on cloud
- Self-hosted instances are unaffected (keep the existing 10k max)

## Test plan
- [ ] On cloud: `GET /api/w/{w}/inputs/history?per_page=200` returns at most 100 results
- [ ] Self-hosted: `GET /api/w/{w}/inputs/history?per_page=200` returns up to 200 results

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps `per_page` on `/inputs/history` to 100 for cloud deployments to prevent crashes and heavy queries. Self‑hosted instances keep existing limits.

- **Bug Fixes**
  - In `windmill-api-inputs`, clamp `per_page` to 100 after `paginate()` when `CLOUD_HOSTED` is true.
  - Cloud: max 100 per page; self‑hosted: existing max (up to 10k) unchanged.

<sup>Written for commit ce5e17f520a23f73120d948f6ca25978e57afbf2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

