### PR TITLE
fix: remove timeout on python client httpx to prevent ducklake query timeouts

### DIFF
--- a/python-client/wmill/wmill/client.py
+++ b/python-client/wmill/wmill/client.py
@@ -94,7 +94,7 @@ class Windmill:
             base_url=self.base_url,
             headers=self.headers,
             verify=self.verify,
-            timeout=httpx.Timeout(300.0),
+            timeout=httpx.Timeout(900.0),
         )
 
     def get(self, endpoint, raise_for_status=True, **kwargs) -> httpx.Response:


### PR DESCRIPTION
## Summary
- The Python client's `httpx.Client` was created without a timeout parameter, defaulting to **5 seconds**
- `wmill.ducklake()` queries use `run_inline_script_preview`, a synchronous endpoint that only responds after query completion
- Any DuckDB/ducklake query taking >5s would cause a `ReadTimeout` on the client side
- Fixed by setting `timeout=httpx.Timeout(300.0)` (5 minutes)

## Test plan
- [ ] Run a ducklake query that takes >5 seconds and verify it completes without timeout
- [ ] Verify short queries still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the Python client’s `httpx.Client` timeout to 900s to prevent `wmill.ducklake()` queries from failing on the synchronous `run_inline_script_preview` endpoint. Long-running queries no longer hit client `ReadTimeout`, while a 15-minute cap avoids indefinite waits.

<sup>Written for commit 7ff4d74d34be81a3368c3a70b7412883ec32564b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

