### PR TITLE
chore: update git sync script version to 28191

### DIFF
--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -149,7 +149,7 @@ pub enum ObjectType {
     WorkspaceDependencies,
 }
 
-pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28186/sync-script-to-git-repo-windmill";
+pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28191/sync-script-to-git-repo-windmill";
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GitRepositorySettings {


### PR DESCRIPTION
## Summary
Update the git sync hub script version from 28186 to 28191.

## Changes
- Updated `LATEST_GIT_SYNC_SCRIPT_PATH` constant in `windmill-common/src/workspaces.rs` from `hub/28186/sync-script-to-git-repo-windmill` to `hub/28191/sync-script-to-git-repo-windmill`

## Test plan
- [ ] Verify git sync uses the new hub script version

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the git sync hub script to version 28191 so new syncs use the latest script. Changes LATEST_GIT_SYNC_SCRIPT_PATH from hub/28186/sync-script-to-git-repo-windmill to hub/28191/sync-script-to-git-repo-windmill.

<sup>Written for commit de6b875dbfdcbcf51c74d68bbc5b5322054a2ff4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

