### PR TITLE
fix: CLI falls back to workspace whoami for workspace-scoped tokens

### DIFF
--- a/cli/src/commands/workspace/workspace.ts
+++ b/cli/src/commands/workspace/workspace.ts
@@ -412,8 +412,7 @@ async function remove(_opts: GlobalOptions, name: string) {
 }
 
 async function whoami(_opts: GlobalOptions) {
-  await requireLogin(_opts);
-  const whoamiInfo = await wmill.globalWhoami();
+  const whoamiInfo = await requireLogin(_opts);
   log.info(JSON.stringify(whoamiInfo, null, 2));
   const activeName = await getActiveWorkspaceName(_opts);
   const { getCurrentGitBranch, getOriginalBranchForWorkspaceForks } = await import("../../utils/git.ts");

--- a/cli/src/core/auth.ts
+++ b/cli/src/core/auth.ts
@@ -3,7 +3,6 @@ import * as log from "./log.ts";
 import { setClient } from "./client.ts";
 import * as wmill from "../../gen/services.gen.ts";
 import { GlobalUserInfo, User } from "../../gen/types.gen.ts";
-import { ApiError } from "../../gen/core/ApiError.ts";
 
 import { loginInteractive, tryGetLoginInfo } from "./login.ts";
 import { GlobalOptions } from "../types.ts";
@@ -13,11 +12,19 @@ import { GlobalOptions } from "../types.ts";
 // cannot call /api/users/whoami because the backend rejects any token with a
 // workspace binding when the request path has no workspace in it. Fall back to
 // the workspace-scoped whoami endpoint in that case so the CLI still works.
+// Uses a name-based ApiError check rather than `instanceof` to match the
+// pattern in cli/src/main.ts: bundling (bun build for npm, JSR dev path) can
+// produce multiple module instances of gen/core/ApiError.ts, making
+// `instanceof` silently return false and reintroducing the bug this fixes.
 async function fetchWhoami(workspaceId: string): Promise<GlobalUserInfo> {
   try {
     return await wmill.globalWhoami();
   } catch (error) {
-    if (error instanceof ApiError && error.status === 401) {
+    if (
+      error && typeof error === "object" &&
+      "name" in error && (error as { name: unknown }).name === "ApiError" &&
+      (error as { status?: number }).status === 401
+    ) {
       const user = await wmill.whoami({ workspace: workspaceId });
       return workspaceUserToGlobalUserInfo(user);
     }
@@ -25,6 +32,11 @@ async function fetchWhoami(workspaceId: string): Promise<GlobalUserInfo> {
   }
 }
 
+// Adapter for the 401 fallback path. `login_type`, `verified`, `first_time_user`
+// and `role_source` are NOT derivable from the workspace-scoped User response
+// and are filled with best-effort defaults — do not trust them downstream after
+// a fallback whoami. Today only cli/src/commands/hub/hub.ts reads this return
+// value, and only `.email`.
 function workspaceUserToGlobalUserInfo(user: User): GlobalUserInfo {
   return {
     email: user.email,

--- a/cli/src/core/auth.ts
+++ b/cli/src/core/auth.ts
@@ -2,11 +2,43 @@ import { colors } from "@cliffy/ansi/colors";
 import * as log from "./log.ts";
 import { setClient } from "./client.ts";
 import * as wmill from "../../gen/services.gen.ts";
-import { GlobalUserInfo } from "../../gen/types.gen.ts";
+import { GlobalUserInfo, User } from "../../gen/types.gen.ts";
+import { ApiError } from "../../gen/core/ApiError.ts";
 
 import { loginInteractive, tryGetLoginInfo } from "./login.ts";
 import { GlobalOptions } from "../types.ts";
 
+
+// Workspace-scoped tokens (tokens bound to a workspace via token.workspace_id)
+// cannot call /api/users/whoami because the backend rejects any token with a
+// workspace binding when the request path has no workspace in it. Fall back to
+// the workspace-scoped whoami endpoint in that case so the CLI still works.
+async function fetchWhoami(workspaceId: string): Promise<GlobalUserInfo> {
+  try {
+    return await wmill.globalWhoami();
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 401) {
+      const user = await wmill.whoami({ workspace: workspaceId });
+      return workspaceUserToGlobalUserInfo(user);
+    }
+    throw error;
+  }
+}
+
+function workspaceUserToGlobalUserInfo(user: User): GlobalUserInfo {
+  return {
+    email: user.email,
+    login_type: "password",
+    super_admin: user.is_super_admin,
+    verified: true,
+    name: user.name,
+    username: user.username,
+    operator_only: user.operator,
+    first_time_user: false,
+    role_source: "manual",
+    disabled: user.disabled,
+  };
+}
 
 /**
  * Main authentication function - moved from context.ts to break circular dependencies
@@ -28,7 +60,7 @@ export async function requireLogin(
   setClient(token, workspace.remote.substring(0, workspace.remote.length - 1));
 
   try {
-    return await wmill.globalWhoami();
+    return await fetchWhoami(workspace.workspaceId);
   } catch (error) {
     // Check for network errors and provide clearer messages
     const errorMsg = error instanceof Error ? error.message : String(error);
@@ -62,6 +94,6 @@ export async function requireLogin(
       newToken,
       workspace.remote.substring(0, workspace.remote.length - 1)
     );
-    return await wmill.globalWhoami();
+    return await fetchWhoami(workspace.workspaceId);
   }
 }


### PR DESCRIPTION
## Summary

Workspace-scoped tokens (tokens created with a specific workspace selected in the "Create token" UI, which sets `token.workspace_id` on the row) could not be used with the CLI at all — not even `wmill workspace whoami`. The backend's DB-backed token lookup in `windmill-api-auth` filters with `(workspace_id IS NULL OR workspace_id = $2)`, where `$2` is the workspace parsed from the URL. On any global path such as `/api/users/whoami`, `$2` is NULL, so any token with a workspace binding failed to match and auth returned 401. Since `requireLogin` in `cli/src/core/auth.ts` calls `globalWhoami` at the start of every command, every command died at that step.

Rather than loosening the backend (which would widen the blast radius of a workspace-bound token to other global endpoints like `/api/workspaces/list`, `/api/settings/*`, etc.), fix it CLI-side: when the global whoami returns 401, fall back to the workspace-scoped `/api/w/{workspace}/users/whoami` using the workspace already known from the CLI profile, and adapt the `User` response into the `GlobalUserInfo` shape the caller expects. The backend keeps strict workspace-binding enforcement on every global endpoint.

## Changes

- `cli/src/core/auth.ts`: new `fetchWhoami(workspaceId)` helper that tries `globalWhoami()` first and, on a 401 `ApiError`, falls back to `whoami({workspace})`. `requireLogin` now calls this helper on both the initial attempt and the post-reauth attempt.
- `cli/src/core/auth.ts`: new `workspaceUserToGlobalUserInfo` adapter that maps the workspace-scoped `User` fields to `GlobalUserInfo` for consumers that expect the global shape (only `cli/src/commands/hub/hub.ts` actually reads the return value, and only for `.email`).
- `cli/src/commands/workspace/workspace.ts`: `whoami` command now uses `requireLogin`'s return value instead of making a redundant second `globalWhoami()` call — previously that second call would still fail with a workspace-bound token even if `requireLogin` had succeeded via the fallback.
- No backend changes.

## Test plan

- [ ] Create a token via Account Settings → Tokens with the Workspace field set to your current workspace. Note the token value.
- [ ] Configure a CLI profile for that workspace pointing at your server, with the workspace-bound token as the credential.
- [ ] Run `wmill workspace whoami` — should print your identity and the active workspace (previously failed with "Not authorized: Unauthorized").
- [ ] Run a workspace-scoped command such as `wmill flow list` — should succeed.
- [ ] Sanity: with a regular unbound token, confirm `wmill workspace whoami` and other commands still work — the fallback only fires on 401.
- [ ] Sanity: with an invalid/expired token, confirm the CLI still falls back to interactive re-auth (the fallback only triggers on an authenticated-but-not-allowed 401, after which the existing reauth path runs if both whoami calls fail).

## Known remaining gap

`wmill workspace add` calls `POST /api/workspaces/exists` as a pre-flight check during initial profile setup — that is a separate global endpoint the backend still rejects for workspace-bound tokens. Users currently have to seed the profile another way (edit `remotes.ndjson` directly, for example) when using a workspace-bound token. Fixing `workspace add` is out of scope for this PR and can be handled with a similar fallback (e.g. treat a successful workspace-scoped whoami as proof the workspace exists).

---
Generated with [Claude Code](https://claude.com/claude-code)