### PR TITLE
fix: hide legacy global_settings.worker_configs ghost row

### DIFF
--- a/backend/tests/instance_config.rs
+++ b/backend/tests/instance_config.rs
@@ -172,6 +172,79 @@ async fn test_from_db_unknown_settings_go_to_extra(db: Pool<Postgres>) {
     );
 }
 
+/// Regression: a legacy `global_settings.worker_configs` row must not leak
+/// into `GlobalSettings::extra`. Older Windmill versions stored worker configs
+/// as a single blob in `global_settings`; the row could silently drift from
+/// the real `config WHERE name LIKE 'worker__%'` rows and get resurrected on
+/// every bulk InstanceSettings save via the flatten+extra round-trip.
+#[sqlx::test(fixtures("base"))]
+async fn test_from_db_hides_legacy_worker_configs_ghost_row(db: Pool<Postgres>) {
+    clear_settings_and_configs(&db).await;
+
+    insert_global_setting(
+        &db,
+        "worker_configs",
+        serde_json::json!({
+            "default": {"worker_tags": ["deno", "python3"]},
+            "sldc-standard": {"worker_tags": ["sldc-standard"]}
+        }),
+    )
+    .await;
+    insert_config(&db, "worker__sldc-standard", serde_json::json!({})).await;
+
+    let config = InstanceConfig::from_db(&db).await.unwrap();
+    assert!(
+        !config.global_settings.extra.contains_key("worker_configs"),
+        "legacy worker_configs row must be filtered out of GlobalSettings::extra"
+    );
+    assert!(
+        !config
+            .global_settings
+            .to_settings_map()
+            .contains_key("worker_configs"),
+        "legacy worker_configs row must not re-appear in to_settings_map()"
+    );
+    // The real config-table row is still read normally.
+    assert!(config.worker_configs.contains_key("sldc-standard"));
+}
+
+/// Regression: a bulk `diff_global_settings` upsert must reject a
+/// `worker_configs` key, even if a client PUT carries one in the flattened
+/// extra map. This is the write-side guard that prevents the ghost row from
+/// being resurrected on every InstanceSettings YAML save.
+#[sqlx::test(fixtures("base"))]
+async fn test_diff_global_settings_rejects_worker_configs_upsert(db: Pool<Postgres>) {
+    clear_settings_and_configs(&db).await;
+
+    let current: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    let mut desired: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    desired.insert(
+        "base_url".to_string(),
+        serde_json::json!("https://windmill.test"),
+    );
+    desired.insert(
+        "worker_configs".to_string(),
+        serde_json::json!({"default": {"worker_tags": ["deno"]}}),
+    );
+
+    let diff = diff_global_settings(&current, &desired, ApplyMode::Merge);
+    assert!(diff.upserts.contains_key("base_url"));
+    assert!(
+        !diff.upserts.contains_key("worker_configs"),
+        "worker_configs must never be written as a global setting"
+    );
+
+    apply_settings_diff(&db, &diff).await.unwrap();
+    assert!(
+        get_global_setting(&db, "worker_configs").await.is_none(),
+        "worker_configs row must not exist in global_settings after apply"
+    );
+    assert_eq!(
+        get_global_setting(&db, "base_url").await,
+        Some(serde_json::json!("https://windmill.test"))
+    );
+}
+
 #[sqlx::test(fixtures("base"))]
 async fn test_from_db_with_worker_configs(db: Pool<Postgres>) {
     clear_settings_and_configs(&db).await;

--- a/backend/windmill-common/src/instance_config.rs
+++ b/backend/windmill-common/src/instance_config.rs
@@ -874,6 +874,12 @@ pub const HIDDEN_SETTINGS: &[&str] = &[
     "min_keep_alive_version",
     "automate_username_creation",
     "_restart_coordination",
+    // Legacy ghost: worker configs live in the `config` table with a
+    // `worker__` prefix, not as a single blob in `global_settings`. Older
+    // Windmill versions stored them here and the row would be resurrected on
+    // every bulk InstanceSettings save via `GlobalSettings::extra`. Hiding it
+    // on read + rejecting it in `diff_global_settings` breaks that loop.
+    "worker_configs",
 ];
 
 /// Top-level settings whose entire value is sensitive and must be fully redacted in logs.
@@ -899,7 +905,10 @@ const SENSITIVE_SETTINGS: &[&str] = &[
 /// Maps a top-level key to the sub-field names that must be redacted.
 const NESTED_SENSITIVE_FIELDS: &[(&str, &[&str])] = &[
     ("smtp_settings", &["smtp_password"]),
-    ("secret_backend", &["token", "client_secret", "secret_access_key"]),
+    (
+        "secret_backend",
+        &["token", "client_secret", "secret_access_key"],
+    ),
     (
         "object_store_cache_config",
         &["secret_key", "serviceAccountKey"],
@@ -1045,6 +1054,17 @@ pub fn diff_global_settings(
     let mut previous_values = BTreeMap::new();
     let mut unchanged_count: usize = 0;
     for (key, desired_value) in desired {
+        // `worker_configs` is a legacy ghost: worker configs belong in the
+        // `config` table with a `worker__` prefix. If a client PUT carries a
+        // top-level `worker_configs` key (it flattens into
+        // `GlobalSettings::extra` on deserialize), drop it here instead of
+        // letting it resurrect a stale `global_settings` row.
+        if key == "worker_configs" {
+            tracing::warn!(
+                "Ignoring 'worker_configs' in global_settings diff: worker configs must be written to the config table (worker__ prefix), not global_settings"
+            );
+            continue;
+        }
         if PROTECTED_SETTINGS.contains(&key.as_str())
             && is_empty_or_null(desired_value)
             && current.contains_key(key)

--- a/frontend/src/lib/components/InstanceSettings.svelte
+++ b/frontend/src/lib/components/InstanceSettings.svelte
@@ -657,8 +657,12 @@
 		'workspace_registries'
 	])
 
-	// Settings that should never appear in YAML export/import
-	const excludedKeys: Set<string> = new Set([])
+	// Settings that should never appear in YAML export/import.
+	// `worker_configs` is a legacy ghost key: worker configs live in the `config`
+	// table (managed from /workers), not in `global_settings`. Older DBs may
+	// still carry a stale `global_settings.worker_configs` row; filter it here
+	// so it never round-trips through this editor.
+	const excludedKeys: Set<string> = new Set(['worker_configs'])
 
 	// Nested fields inside object-valued settings that contain secrets.
 	// Each entry maps a top-level key to its sensitive sub-field names.


### PR DESCRIPTION
## Summary

A legacy `global_settings.worker_configs` row (a single JSON blob storing worker group configs from an older Windmill version) could silently drift from the real source of truth in `config WHERE name LIKE 'worker__%'`, and would silently resurrect itself on every bulk Instance Settings YAML save. One customer's `sldc-standard` group diverged as a result: the Instance Settings YAML editor showed `worker_tags: [sldc-standard]` for it while the `/workers` page (and the actual workers) saw `{}`.

The resurrection happened because `GlobalSettings` has a `#[serde(flatten)] pub extra: BTreeMap<_, _>` catch-all. On read, the unknown `worker_configs` row landed in `extra` and was re-serialized back out as a top-level YAML key. On save, the same catch-all deserialized the user's PUT body, and `diff_global_settings` upserted the row straight back. The ghost was self-healing.

## Changes

- `backend/windmill-common/src/instance_config.rs`:
  - Added `"worker_configs"` to `HIDDEN_SETTINGS` so `InstanceConfig::from_db` filters it out on read. It no longer lands in `GlobalSettings::extra`, no longer appears in any export, and is preserved (not deleted) on Replace-mode syncs against customer DBs that still carry a stale row.
  - Added an explicit early-continue in `diff_global_settings`'s upsert loop that drops any `worker_configs` key from the desired map, with a `tracing::warn!` explaining that worker configs must be written to the `config` table. This covers both the API bulk endpoint (`set_instance_config`) and the operator reconciler (`sync_global_settings`), so nothing can resurrect the row going forward.
- `frontend/src/lib/components/InstanceSettings.svelte`: Added `'worker_configs'` to the `excludedKeys` Set in the Instance Settings YAML editor. Belt-and-braces: any legacy DB that still carries the row stops rendering it in the editor even before the backend filter propagates.
- `backend/tests/instance_config.rs`: Two regression tests:
  - `test_from_db_hides_legacy_worker_configs_ghost_row` — inserts a stale row, asserts it does not leak into `GlobalSettings::extra` or re-appear in `to_settings_map()`, and verifies the real `config`-table row is still read normally.
  - `test_diff_global_settings_rejects_worker_configs_upsert` — asserts a `Merge`-mode diff with a `worker_configs` key in desired does not generate an upsert, and that applying the diff leaves no such row in `global_settings` while still upserting sibling settings.

Customer cleanup for `tbs` was done out-of-band (`DELETE FROM global_settings WHERE name = 'worker_configs'`) after taking a backup of the row value. Other customer DBs are not auto-cleaned — stale rows there will stop being displayed and stop being resurrected, but will remain until explicitly removed.

Intentionally out of scope: unifying the two YAML serializers (Instance Settings vs `/workers`) into a single canonical source. That was discussed and deferred.

## Test plan

- [ ] On an instance carrying a legacy `global_settings.worker_configs` row, open Instance Settings as a superadmin, switch the editor into YAML mode, and confirm no `worker_configs:` key appears in the exported YAML.
- [ ] Save the Instance Settings YAML and verify `SELECT name FROM global_settings WHERE name = 'worker_configs'` returns zero rows (row is not resurrected).
- [ ] Navigate to `/workers`, open the worker groups YAML editor, and confirm it still renders the real per-group configs from the `config` table.
- [ ] Run `cargo test --test instance_config` in `backend/` and confirm all 38 tests pass, including the two new regressions.

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide and block the legacy `global_settings.worker_configs` row so it can’t reappear or drift from real worker configs. Worker groups remain sourced only from the `config` table (`worker__*` rows).

- **Bug Fixes**
  - Backend: added `worker_configs` to hidden settings and dropped any `worker_configs` upsert in `diff_global_settings` with a warning, preventing resurrection on bulk saves.
  - Frontend: excluded `worker_configs` from the Instance Settings YAML editor to stop round-trips.
  - Tests: added two regressions to verify the row is hidden on read and rejected on write.

<sup>Written for commit b3080a30858acb204cbb4a9ad925eb9d6ed91d86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

