### PR TITLE
fix: treat empty global setting strings as unset

### DIFF
--- a/backend/.sqlx/query-5a219a2532517869578c4504ff3153c43903f929ae5d62fbba12610f89c36d55.json
+++ b/backend/.sqlx/query-5a219a2532517869578c4504ff3153c43903f929ae5d62fbba12610f89c36d55.json
@@ -15,7 +15,7 @@
       ]
     },
     "nullable": [
-      true
+      null
     ]
   },
   "hash": "5a219a2532517869578c4504ff3153c43903f929ae5d62fbba12610f89c36d55"

--- a/backend/tests/instance_config.rs
+++ b/backend/tests/instance_config.rs
@@ -208,6 +208,53 @@ async fn test_from_db_hides_legacy_worker_configs_ghost_row(db: Pool<Postgres>) 
     assert!(config.worker_configs.contains_key("sldc-standard"));
 }
 
+/// Regression: a bulk `diff_global_settings` desired map that contains an
+/// empty-string value for a key must route that key to `deletes` rather than
+/// upserting `""`. Mirrors the single-key endpoint's behavior and prevents
+/// stale `""` rows (e.g. `npmrc`) from tripping the EE registry gate on CE.
+#[sqlx::test(fixtures("base"))]
+async fn test_diff_global_settings_empty_string_routes_to_delete(db: Pool<Postgres>) {
+    clear_settings_and_configs(&db).await;
+
+    insert_global_setting(&db, "npmrc", serde_json::json!("registry=https://x/")).await;
+
+    let current_map = InstanceConfig::from_db(&db)
+        .await
+        .unwrap()
+        .global_settings
+        .to_settings_map();
+
+    let mut desired: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+    desired.insert("npmrc".to_string(), serde_json::json!(""));
+
+    let diff = diff_global_settings(&current_map, &desired, ApplyMode::Merge);
+    assert!(
+        !diff.upserts.contains_key("npmrc"),
+        "empty-string value must not upsert"
+    );
+    assert!(
+        diff.deletes.iter().any(|k| k == "npmrc"),
+        "empty-string value must route to deletes"
+    );
+
+    apply_settings_diff(&db, &diff).await.unwrap();
+    assert!(
+        get_global_setting(&db, "npmrc").await.is_none(),
+        "npmrc row must be deleted after apply"
+    );
+
+    // Second case: key not currently present → no-op (no upsert, no delete).
+    clear_settings_and_configs(&db).await;
+    let current_map = InstanceConfig::from_db(&db)
+        .await
+        .unwrap()
+        .global_settings
+        .to_settings_map();
+    let diff = diff_global_settings(&current_map, &desired, ApplyMode::Merge);
+    assert!(!diff.upserts.contains_key("npmrc"));
+    assert!(!diff.deletes.iter().any(|k| k == "npmrc"));
+}
+
 /// Regression: a bulk `diff_global_settings` upsert must reject a
 /// `worker_configs` key, even if a client PUT carries one in the flattened
 /// extra map. This is the write-side guard that prevents the ghost row from

--- a/backend/tests/instance_config.rs
+++ b/backend/tests/instance_config.rs
@@ -255,6 +255,44 @@ async fn test_diff_global_settings_empty_string_routes_to_delete(db: Pool<Postgr
     assert!(!diff.deletes.iter().any(|k| k == "npmrc"));
 }
 
+/// Regression: whitespace-only values for protected settings (e.g.
+/// `jwt_secret`) must not leak into `deletes`. The empty-string-unset branch
+/// in `diff_global_settings` relies on the `PROTECTED_SETTINGS` guard ahead
+/// of it to catch whitespace, so `is_empty_or_null` must also trim.
+#[sqlx::test(fixtures("base"))]
+async fn test_diff_global_settings_protected_whitespace_not_deleted(db: Pool<Postgres>) {
+    clear_settings_and_configs(&db).await;
+
+    insert_global_setting(&db, "jwt_secret", serde_json::json!("s3cret")).await;
+
+    let current_map = InstanceConfig::from_db(&db)
+        .await
+        .unwrap()
+        .global_settings
+        .to_settings_map();
+
+    for whitespace in [" ", "  ", "\t", "\n", ""] {
+        let mut desired: BTreeMap<String, serde_json::Value> = BTreeMap::new();
+        desired.insert("jwt_secret".to_string(), serde_json::json!(whitespace));
+
+        let diff = diff_global_settings(&current_map, &desired, ApplyMode::Merge);
+        assert!(
+            !diff.deletes.iter().any(|k| k == "jwt_secret"),
+            "protected setting must not be routed to deletes for value {whitespace:?}"
+        );
+        assert!(
+            !diff.upserts.contains_key("jwt_secret"),
+            "protected setting must not be overwritten with whitespace for value {whitespace:?}"
+        );
+    }
+
+    // The underlying secret must still be present after applying each diff.
+    assert_eq!(
+        get_global_setting(&db, "jwt_secret").await,
+        Some(serde_json::json!("s3cret"))
+    );
+}
+
 /// Regression: a bulk `diff_global_settings` upsert must reject a
 /// `worker_configs` key, even if a client PUT carries one in the flattened
 /// extra map. This is the write-side guard that prevents the ghost row from

--- a/backend/windmill-api-settings/src/lib.rs
+++ b/backend/windmill-api-settings/src/lib.rs
@@ -382,7 +382,7 @@ pub async fn set_global_setting_internal(
             }
             delete_global_setting(db, &key).await?;
         }
-        serde_json::Value::String(x) if x.is_empty() => {
+        serde_json::Value::String(ref x) if x.trim().is_empty() => {
             if instance_config::PROTECTED_SETTINGS.contains(&key.as_str()) {
                 return Err(error::Error::BadRequest(format!(
                     "{key} is a protected setting and cannot be set to empty"

--- a/backend/windmill-common/src/instance_config.rs
+++ b/backend/windmill-common/src/instance_config.rs
@@ -1015,7 +1015,7 @@ fn license_keys_same_client(a: &serde_json::Value, b: &serde_json::Value) -> boo
 }
 
 fn is_empty_or_null(value: &serde_json::Value) -> bool {
-    value.is_null() || value.as_str().map_or(false, |s| s.is_empty())
+    value.is_null() || value.as_str().map_or(false, |s| s.trim().is_empty())
 }
 
 /// Maximum retention period in seconds for CE builds (30 days).

--- a/backend/windmill-common/src/instance_config.rs
+++ b/backend/windmill-common/src/instance_config.rs
@@ -1051,6 +1051,7 @@ pub fn diff_global_settings(
     mode: ApplyMode,
 ) -> SettingsDiff {
     let mut upserts = BTreeMap::new();
+    let mut deletes = Vec::new();
     let mut previous_values = BTreeMap::new();
     let mut unchanged_count: usize = 0;
     for (key, desired_value) in desired {
@@ -1072,6 +1073,23 @@ pub fn diff_global_settings(
             tracing::warn!(
                 "Skipping {key} update: protected setting cannot be overwritten with empty/null value"
             );
+            continue;
+        }
+        // An empty string means "unset": route it to deletes so clearing a
+        // setting via YAML sync has the same effect as clearing it via the UI
+        // (`set_global_setting_internal` already treats `""` as a delete).
+        // Without this, stale `""` rows linger and trip the EE registry gate,
+        // producing spurious "requires Enterprise" warnings on every CE job.
+        if desired_value
+            .as_str()
+            .map_or(false, |s| s.trim().is_empty())
+        {
+            if let Some(existing) = current.get(key) {
+                previous_values.insert(key.clone(), existing.clone());
+                deletes.push(key.clone());
+            } else {
+                unchanged_count += 1;
+            }
             continue;
         }
         let mut value = if key == "retention_period_secs" {
@@ -1124,7 +1142,6 @@ pub fn diff_global_settings(
             }
         }
     }
-    let mut deletes = Vec::new();
     if matches!(mode, ApplyMode::Replace) {
         for key in current.keys() {
             if !desired.contains_key(key)

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -765,11 +765,14 @@ pub async fn read_ee_registry_with_workspace_override(
             .and_then(|m| m.get(w_id))
             .and_then(|ws| ws.get(setting_key))
             .and_then(|v| match v {
-                serde_json::Value::String(s) => Some(s.clone()),
+                serde_json::Value::String(s) if !s.trim().is_empty() => Some(s.clone()),
                 _ => None,
             })
     };
-    let value = ws_value.or(global_value);
+    // Treat empty/whitespace-only values as unset, so a stale `""` left in
+    // `global_settings` doesn't trigger the spurious "requires Enterprise"
+    // warning on every CE job.
+    let value = ws_value.or(global_value).filter(|s| !s.trim().is_empty());
     read_ee_registry(value, display_name, job_id, w_id, conn).await
 }
 

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -765,13 +765,14 @@ pub async fn read_ee_registry_with_workspace_override(
             .and_then(|m| m.get(w_id))
             .and_then(|ws| ws.get(setting_key))
             .and_then(|v| match v {
-                serde_json::Value::String(s) if !s.trim().is_empty() => Some(s.clone()),
+                serde_json::Value::String(s) => Some(s.clone()),
                 _ => None,
             })
     };
-    // Treat empty/whitespace-only values as unset, so a stale `""` left in
-    // `global_settings` doesn't trigger the spurious "requires Enterprise"
-    // warning on every CE job.
+    // An empty/whitespace-only value (from either source) means "unset" — a
+    // workspace override of `""` still takes precedence over the global
+    // value, but neither triggers the spurious "requires Enterprise" warning
+    // on CE jobs.
     let value = ws_value.or(global_value).filter(|s| !s.trim().is_empty());
     read_ee_registry(value, display_name, job_id, w_id, conn).await
 }


### PR DESCRIPTION
## Summary

CE users with a stale `""` value for `npmrc` (or any other registry setting) in `global_settings` see a spurious

> Private registry (npmrc) configuration ignored: this feature requires Windmill Enterprise Edition

logged on every Bun/Deno/etc. job, even though the setting is effectively unset and the build proceeds normally. The warning is misleading and creates noise in job logs.

Root cause:
- `read_ee_registry` (`backend/windmill-worker/src/worker.rs:731`) only checks `value.is_some()` — it doesn't look at the inner string. A `Some("")` from `global_settings` is treated as "user has configured a private registry".
- The single-key UI endpoint (`set_global_setting_internal`) already deletes the row when the value is `""`, but the bulk YAML-sync path (`diff_global_settings` → `apply_settings_diff`) does not, so an empty value can persist in the DB.

## Changes

- `backend/windmill-worker/src/worker.rs` — `read_ee_registry_with_workspace_override` (String variant) now filters out empty/whitespace-only values before passing them to the EE gating check, in both the workspace-override and global-value sources.
- `backend/windmill-common/src/instance_config.rs` — `diff_global_settings` now routes empty-string desired values to `deletes` instead of upserting `""`, mirroring the single-key endpoint. If the key doesn't exist in current, it's a no-op.
- `backend/windmill-api-settings/src/lib.rs` — `set_global_setting_internal`'s empty-string match arm now uses `trim().is_empty()` for consistency with the diff path (catches `" "` as well as `""`).
- `backend/tests/instance_config.rs` — regression test `test_diff_global_settings_empty_string_routes_to_delete` covering both the "key currently set" and "key absent" cases.

## Test plan

- [ ] `cargo test --test instance_config diff_global_settings` passes (39 instance_config tests pass overall).
- [ ] `cargo check` and `cargo check --features enterprise,private` are clean.
- [ ] On a CE instance, set the npmrc field in superadmin settings to a non-empty value, save, then clear it and save again. Confirm the row is deleted from `global_settings` (and not stored as `""`).
- [ ] On a CE instance with a pre-existing `""` row in `global_settings.npmrc`, run a Bun job and confirm the spurious "Private registry (npmrc) configuration ignored: this feature requires Windmill Enterprise Edition" log line is gone.

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat empty or whitespace-only values as unset to stop false “requires Enterprise” warnings on CE jobs. Empty workspace overrides now mask the global registry value without logging.

- **Bug Fixes**
  - Worker: filter trimmed-empty values in `read_ee_registry_with_workspace_override`; an explicit `""` override hides the global value and avoids the CE warning.
  - Settings diff: `diff_global_settings` routes trimmed-empty desired values to deletes (no-op when key is absent) and ignores whitespace for protected settings.
  - API: `set_global_setting_internal` now uses `trim().is_empty()` to treat `" "` as empty.
  - Tests: added regression tests for empty-string delete routing and protected-setting whitespace not being deleted or overwritten.

<sup>Written for commit 4cc7e22d7f9579ed8fffd4d875562e3f38f56986. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

