### PR TITLE
refactor(git-sync): remove force_branch UI option

### DIFF
--- a/frontend/src/lib/components/git_sync/GitSyncRepositoryCard.svelte
+++ b/frontend/src/lib/components/git_sync/GitSyncRepositoryCard.svelte
@@ -11,14 +11,11 @@
 		Plus
 	} from 'lucide-svelte'
 	import { Button, Alert } from '$lib/components/common'
-	import TextInput from '$lib/components/text_input/TextInput.svelte'
-	import Section from '$lib/components/Section.svelte'
 	import { getGitSyncContext } from './GitSyncContext.svelte'
 	import ResourcePicker from '$lib/components/ResourcePicker.svelte'
 	import GitSyncFilterSettings from '$lib/components/workspaceSettings/GitSyncFilterSettings.svelte'
 	import DetectionFlow from './DetectionFlow.svelte'
 	import { sendUserToast } from '$lib/toast'
-	import Toggle from '$lib/components/Toggle.svelte'
 	import { fade } from 'svelte/transition'
 	import { workspaceStore } from '$lib/stores'
 	import type { GitSyncRepository } from './GitSyncContext.svelte'
@@ -447,8 +444,8 @@
 
 			{#if repo.script_path}
 				<Alert type="warning" title="Pinned git sync script version">
-					This repository uses a pinned sync script: <code>{repo.script_path}</code>.
-					Switch to auto-managed to always use the latest version bundled with Windmill.
+					This repository uses a pinned sync script: <code>{repo.script_path}</code>. Switch to
+					auto-managed to always use the latest version bundled with Windmill.
 					<div class="flex mt-2">
 						<Button
 							size="xs"
@@ -520,30 +517,6 @@
 							</div>
 						{/if}
 					</div>
-
-					<!-- Advanced settings (collapsible) -->
-					<Section label="Advanced" small collapsable initiallyCollapsed={!repo.force_branch}>
-						<Toggle
-							checked={!!repo.force_branch}
-							on:change={(e) => {
-								if (e.detail) {
-									repo.force_branch = $workspaceStore ?? ''
-								} else {
-									repo.force_branch = undefined
-								}
-							}}
-							options={{
-								right: 'Environment (experimental)',
-								rightTooltip:
-									'Made for monobranch setups. Passes the value as --branch/--env to the wmill CLI, which selects the matching branch/env configuration from wmill.yaml and includes the branch/env in the item paths.'
-							}}
-						/>
-						{#if repo.force_branch != null && repo.force_branch !== undefined}
-							<div class="w-48 mt-2">
-								<TextInput size="sm" bind:value={repo.force_branch} />
-							</div>
-						{/if}
-					</Section>
 				{/if}
 			{/if}
 		{:else}


### PR DESCRIPTION
## Summary

With the new `workspaces:` section in `wmill.yaml`, the CLI auto-selects the correct workspace entry from the `--base-url` + `--workspace` flags that the backend already passes during git sync pull/push — via `inferWsNameFromProfile` in `cli/src/commands/sync/sync.ts:161-179`, which matches each entry's `baseUrl` + `workspaceId` against the resolved profile.

That makes the `force_branch` / "Environment (experimental)" override redundant for any repository configured with the new `workspaces:` schema, so this PR removes it from the git sync repository card UI.

## Changes

- Remove the "Advanced" collapsible section containing the `force_branch` toggle and text input from `GitSyncRepositoryCard.svelte`
- Drop the now-unused `Section`, `TextInput`, and `Toggle` imports
- Leave the backend `force_branch` field, API schema, and frontend serializer/save wiring intact so repositories that already have `force_branch` persisted keep round-tripping correctly

## Test plan

- [ ] Workspace settings → Git Sync → expand a configured repository: confirm the "Advanced" section with the "Environment (experimental)" toggle no longer appears
- [ ] Create a new repository and save it: no regressions in save/pull/push flows
- [ ] Pre-existing repository with `force_branch` already persisted: still loads and saves without dropping the value

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the force_branch UI ("Environment (experimental)") from Git Sync repository cards. The CLI now uses the `workspaces:` section in `wmill.yaml` with the existing `--base-url` and `--workspace` flags to auto-select the workspace, making the override redundant.

- **Refactors**
  - Removed the Advanced section and related inputs; cleaned up unused imports.
  - Kept the backend `force_branch` field and API round-trip for existing repos.

<sup>Written for commit 3ced461ba84394b93543abac333fbb0691d0b2c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

