### PR TITLE
fix: move CiTestResult schema outside python-client inline markers

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -19539,25 +19539,6 @@ components:
     # This is why it is better to inline each of schemas for better compat
     # Do not change next line. It is used by python-client for pre-processing
     # -- INLINE START --
-    CiTestResult:
-      type: object
-      properties:
-        test_script_path:
-          type: string
-        job_id:
-          type: string
-          format: uuid
-          nullable: true
-        status:
-          type: string
-          nullable: true
-        started_at:
-          type: string
-          format: date-time
-          nullable: true
-      required:
-        - test_script_path
-
     OpenFlow:
       $ref: "../../openflow.openapi.yaml#/components/schemas/OpenFlow"
     FlowValue:
@@ -19608,6 +19589,25 @@ components:
       $ref: "../../openflow.openapi.yaml#/components/schemas/FlowNote"
     # -- INLINE END --
     # Do not change line above
+
+    CiTestResult:
+      type: object
+      properties:
+        test_script_path:
+          type: string
+        job_id:
+          type: string
+          format: uuid
+          nullable: true
+        status:
+          type: string
+          nullable: true
+        started_at:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+        - test_script_path
 
     HealthStatusResponse:
       type: object


### PR DESCRIPTION
## Summary
Fixes the PyPI publish job failure in [run 24249090466](https://github.com/windmill-labs/windmill/actions/runs/24249090466/job/70803224379). The `CiTestResult` schema was defined between the `# -- INLINE START --` / `# -- INLINE END --` markers in `openapi.yaml`, which `python-client/build.sh` strips and replaces with a wildcard `$ref` to `openflow.openapi.yaml`. The bundler then fails with "Can't resolve \$ref" because `CiTestResult` does not exist in `openflow.openapi.yaml`.

## Changes
- Move `CiTestResult` schema definition from inside the INLINE markers to just after `# -- INLINE END --` so it survives python-client pre-processing.

## Test plan
- [x] Ran `python-client/build.sh` locally — bundler now succeeds
- [ ] CI `publish_pypi` job passes on this PR

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved `CiTestResult` schema outside the inline block in `openapi.yaml` so python-client preprocessing doesn’t strip it. This fixes unresolved `$ref` errors and unblocks the PyPI publish job.

- **Bug Fixes**
  - Moved `CiTestResult` below `# -- INLINE END --` so `python-client/build.sh` keeps it and bundling resolves refs successfully.

<sup>Written for commit bfc7722f2cdf1bd86bfbc94c940d8b832e2daf3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

