### PR TITLE
fix: show full path on hover in deploy drawer and widen drawer

### DIFF
--- a/frontend/src/lib/components/DeployWorkspaceDrawer.svelte
+++ b/frontend/src/lib/components/DeployWorkspaceDrawer.svelte
@@ -24,7 +24,7 @@
 	}
 </script>
 
-<Drawer bind:this={drawer} size="900px">
+<Drawer bind:this={drawer} size="1200px">
 	<DrawerContent title="Deploy {initialPath}" on:close={drawer.closeDrawer}>
 		{#if (kind != 'trigger' && kind != undefined && initialPath != undefined) || (kind === 'trigger' && initialPath != undefined && additionalInformation?.triggers != undefined)}
 			<DeployWorkspace

--- a/frontend/src/lib/components/common/table/Row.svelte
+++ b/frontend/src/lib/components/common/table/Row.svelte
@@ -17,7 +17,17 @@
 		errorHandlerMuted?: boolean
 		aiId?: string | undefined
 		aiDescription?: string | undefined
-		kind?: 'script' | 'flow' | 'app' | 'raw_app' | 'resource' | 'variable' | 'resource_type' | 'folder' | 'schedule' | 'trigger'
+		kind?:
+			| 'script'
+			| 'flow'
+			| 'app'
+			| 'raw_app'
+			| 'resource'
+			| 'variable'
+			| 'resource_type'
+			| 'folder'
+			| 'schedule'
+			| 'trigger'
 		triggerKind?: string | undefined
 		summary?: string | undefined
 		path: string
@@ -57,7 +67,12 @@
 		onSelect = () => {}
 	}: Props = $props()
 
-	let displayPath: string = (untrack(() => depth) === 0 ? untrack(() => path) : untrack(() => path)?.split('/')?.slice(-1)?.[0]) ?? ''
+	let displayPath: string =
+		(untrack(() => depth) === 0
+			? untrack(() => path)
+			: untrack(() => path)
+					?.split('/')
+					?.slice(-1)?.[0]) ?? ''
 </script>
 
 {#if href}
@@ -135,7 +150,7 @@
 				{!summary || summary.length == 0 ? displayPath : summary}
 			{/if}
 		</div>
-		<div class="text-hint text-3xs truncate text-left font-normal">
+		<div class="text-hint text-3xs truncate text-left font-normal" title={path}>
 			{path}
 		</div>
 	</div>


### PR DESCRIPTION
## Summary
In the Deploy drawer's "All related deployable items" list, long paths were truncated with no way to see the full value. This PR makes the full path visible on hover via a native tooltip and widens the drawer so more paths fit without truncation.

## Changes
- `DeployWorkspaceDrawer.svelte`: bump drawer size from 900px to 1200px
- `Row.svelte`: add `title={path}` on the truncated path element so hovering shows the full path (applies to all row usages across the app)

## Test plan
- [ ] Open a script/flow/app page and trigger the deploy drawer
- [ ] Verify the drawer is wider and long paths in "All related deployable items" fit more comfortably
- [ ] Hover a still-truncated path and confirm the full path shows as a native tooltip

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve path visibility in the Deploy drawer by showing the full path on hover and widening the drawer. Long paths are now readable without leaving the view.

- **Bug Fixes**
  - Show full path via native tooltip on truncated path text (`title={path}` in Row component). Applies across the app, including “All related deployable items”.
  - Widen Deploy drawer from 900px to 1200px to reduce truncation.

<sup>Written for commit 4806dfe2e07acfefbc307fc2154204866e9413fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

