### PR TITLE
feat: display agent message in flow graph

### DIFF
--- a/frontend/src/lib/components/FlowStatusViewerInner.svelte
+++ b/frontend/src/lib/components/FlowStatusViewerInner.svelte
@@ -1990,7 +1990,7 @@
 												)}
 												{#if messageContent !== undefined && typeof messageContent === 'string'}
 													<div>
-														<h3 class="text-sm font-semibold mb-2 text-secondary">Message</h3>
+														<div class="text-xs text-emphasis font-semibold mb-1">Message</div>
 														<div class="border rounded p-2 overflow-auto max-h-[500px]">
 															<GfmMarkdown md={messageContent} />
 														</div>

--- a/frontend/src/lib/components/FlowStatusViewerInner.svelte
+++ b/frontend/src/lib/components/FlowStatusViewerInner.svelte
@@ -51,6 +51,7 @@
 	} from './graph/renderers/nodes/AIToolNode.svelte'
 	import JobAssetsViewer from './assets/JobAssetsViewer.svelte'
 	import McpToolCallDetails from './McpToolCallDetails.svelte'
+	import GfmMarkdown from './GfmMarkdown.svelte'
 	import JobOtelTraces from './JobOtelTraces.svelte'
 	import JobDetailHeader from './runs/JobDetailHeader.svelte'
 	import LogViewer from './LogViewer.svelte'
@@ -1987,14 +1988,11 @@
 													agentNode?.result,
 													actionIndex
 												)}
-												{#if messageContent !== undefined}
+												{#if messageContent !== undefined && typeof messageContent === 'string'}
 													<div>
 														<h3 class="text-sm font-semibold mb-2 text-secondary">Message</h3>
-														<div class="border rounded">
-															<DisplayResult
-																result={messageContent}
-																workspaceId={job?.workspace_id}
-															/>
+														<div class="border rounded p-2 overflow-auto max-h-[500px]">
+															<GfmMarkdown md={messageContent} />
 														</div>
 													</div>
 												{:else}

--- a/frontend/src/lib/components/FlowStatusViewerInner.svelte
+++ b/frontend/src/lib/components/FlowStatusViewerInner.svelte
@@ -2028,31 +2028,10 @@
 													/>
 												{/if}
 											{:else if selectedNode?.startsWith(AI_WEBSEARCH_PREFIX)}
-												{@const [, agentModuleId, toolCallIndex] = selectedNode.split('-')}
-												{@const agentNode = localModuleStates?.[agentModuleId]}
-												{@const actionIndex = parseInt(toolCallIndex)}
-												{@const searchContent = getAgentActionContent(
-													agentNode?.result,
-													actionIndex
-												)}
-												{#if searchContent !== undefined}
-													<div>
-														<h3 class="text-sm font-semibold mb-2 text-secondary">
-															Web Search Result
-														</h3>
-														<div class="border rounded">
-															<DisplayResult
-																result={searchContent}
-																workspaceId={job?.workspace_id}
-															/>
-														</div>
-													</div>
-												{:else}
-													<Alert
-														type="info"
-														title="Web search output is available on the AI agent node"
-													/>
-												{/if}
+												<Alert
+													type="info"
+													title="Web search output is available on the AI agent node"
+												/>
 											{:else if selectedNode}
 												{@const node = localModuleStates[selectedNode]}
 												{#if selectedNode == 'end'}

--- a/frontend/src/lib/components/FlowStatusViewerInner.svelte
+++ b/frontend/src/lib/components/FlowStatusViewerInner.svelte
@@ -2028,10 +2028,7 @@
 													/>
 												{/if}
 											{:else if selectedNode?.startsWith(AI_WEBSEARCH_PREFIX)}
-												<Alert
-													type="info"
-													title="Web search output is available on the AI agent node"
-												/>
+												<Alert type="info" title="Web search was used in this step" />
 											{:else if selectedNode}
 												{@const node = localModuleStates[selectedNode]}
 												{#if selectedNode == 'end'}

--- a/frontend/src/lib/components/FlowStatusViewerInner.svelte
+++ b/frontend/src/lib/components/FlowStatusViewerInner.svelte
@@ -866,6 +866,20 @@
 		// sub?.()
 	})
 
+	function getAgentActionContent(agentResult: any, actionIndex: number): unknown | undefined {
+		if (!agentResult?.messages || !Array.isArray(agentResult.messages)) return undefined
+		let agentActionIdx = 0
+		for (const m of agentResult.messages) {
+			if (m.agent_action) {
+				if (agentActionIdx === actionIndex) {
+					return m.content
+				}
+				agentActionIdx++
+			}
+		}
+		return undefined
+	}
+
 	function isSuccess(arg: any): boolean | undefined {
 		if (arg == undefined) {
 			return undefined
@@ -1966,12 +1980,31 @@
 									{:else if rightColumnSelect == 'node_status'}
 										<div class="p-4 grow flex flex-col gap-6">
 											{#if selectedNode?.startsWith(AI_TOOL_MESSAGE_PREFIX)}
-												<div class="pt-2 pb-4">
-													<Alert
-														type="info"
-														title="Message output is available on the AI agent node"
-													/>
-												</div>
+												{@const [, agentModuleId, toolCallIndex] = selectedNode.split('-')}
+												{@const agentNode = localModuleStates?.[agentModuleId]}
+												{@const actionIndex = parseInt(toolCallIndex)}
+												{@const messageContent = getAgentActionContent(
+													agentNode?.result,
+													actionIndex
+												)}
+												{#if messageContent !== undefined}
+													<div>
+														<h3 class="text-sm font-semibold mb-2 text-secondary">Message</h3>
+														<div class="border rounded">
+															<DisplayResult
+																result={messageContent}
+																workspaceId={job?.workspace_id}
+															/>
+														</div>
+													</div>
+												{:else}
+													<div class="pt-2 pb-4">
+														<Alert
+															type="info"
+															title="Message output is available on the AI agent node"
+														/>
+													</div>
+												{/if}
 											{:else if selectedNode?.startsWith(AI_MCP_TOOL_CALL_PREFIX)}
 												{@const [, agentModuleId, toolCallIndex] = selectedNode.split('-')}
 												{@const agentNode = localModuleStates?.[agentModuleId]}
@@ -1997,10 +2030,31 @@
 													/>
 												{/if}
 											{:else if selectedNode?.startsWith(AI_WEBSEARCH_PREFIX)}
-												<Alert
-													type="info"
-													title="Web search output is available on the AI agent node"
-												/>
+												{@const [, agentModuleId, toolCallIndex] = selectedNode.split('-')}
+												{@const agentNode = localModuleStates?.[agentModuleId]}
+												{@const actionIndex = parseInt(toolCallIndex)}
+												{@const searchContent = getAgentActionContent(
+													agentNode?.result,
+													actionIndex
+												)}
+												{#if searchContent !== undefined}
+													<div>
+														<h3 class="text-sm font-semibold mb-2 text-secondary">
+															Web Search Result
+														</h3>
+														<div class="border rounded">
+															<DisplayResult
+																result={searchContent}
+																workspaceId={job?.workspace_id}
+															/>
+														</div>
+													</div>
+												{:else}
+													<Alert
+														type="info"
+														title="Web search output is available on the AI agent node"
+													/>
+												{/if}
 											{:else if selectedNode}
 												{@const node = localModuleStates[selectedNode]}
 												{#if selectedNode == 'end'}


### PR DESCRIPTION
## Summary
When clicking on message or web search nodes in the AI agent flow graph, the right panel now displays the actual output content instead of a placeholder alert saying "output is available on the AI agent node".

## Changes
- Added `getAgentActionContent()` helper that maps an agent action index to its corresponding content in the agent job's `result.messages` array
- Message nodes now show their content via `DisplayResult` when clicked in the graph
- Web search nodes now show their content via `DisplayResult` when clicked in the graph
- Falls back to the previous alert when the agent result isn't loaded yet

## Test plan
- [ ] Run a flow with an AI agent step that produces message outputs — click the message node in the graph and verify content is displayed
- [ ] Run a flow with an AI agent step that uses web search — click the web search node in the graph and verify content is displayed
- [ ] Verify MCP tool call nodes still display correctly (unchanged code path)
- [ ] Verify regular tool call nodes still display correctly

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows actual agent message output in the flow graph right panel when a message node is selected. Web search nodes do not show content and display a clearer info alert; the Message title styling now matches other node status sections.

- **New Features**
  - Added `getAgentActionContent` to resolve content from agent `result.messages`.
  - Message nodes render Markdown via `GfmMarkdown`; fall back to the info alert if result isn’t loaded or content isn’t a string.
  - Web search nodes show an info alert: "Web search was used in this step". MCP and regular tool call nodes are unchanged.

<sup>Written for commit 41b6e699136ec829e8a5593f6d9c54dcbf9e2a00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

