### PR TITLE
fix: silence user-facing toast for non-critical hub script tracking error

### DIFF
--- a/frontend/src/lib/components/flows/pickers/PickHubScriptQuick.svelte
+++ b/frontend/src/lib/components/flows/pickers/PickHubScriptQuick.svelte
@@ -38,7 +38,7 @@
 <script lang="ts">
 	import { createEventDispatcher, getContext, untrack } from 'svelte'
 	import { Skeleton } from '$lib/components/common'
-	import { classNames, createCache, sendUserToast } from '$lib/utils'
+	import { classNames, createCache } from '$lib/utils'
 	import { APP_TO_ICON_COMPONENT } from '$lib/components/icons'
 	import { IntegrationService, ScriptService, type HubScriptKind } from '$lib/gen'
 	import { Circle, ExternalLink } from 'lucide-svelte'

--- a/frontend/src/lib/components/flows/pickers/PickHubScriptQuick.svelte
+++ b/frontend/src/lib/components/flows/pickers/PickHubScriptQuick.svelte
@@ -151,7 +151,7 @@
 			try {
 				await ScriptService.pickHubScriptByPath({ path: item.path })
 			} catch (error) {
-				sendUserToast('Failed to call ScriptService.pickHubScriptByPath: ' + error, 'error')
+				console.error('Failed to track hub script pick:', error)
 				// Don't block the flow if tracking fails
 			}
 		}


### PR DESCRIPTION
## Summary
Replace the error toast shown to users when `ScriptService.pickHubScriptByPath` fails with a `console.error`. This tracking call is non-critical and its failure should not interrupt the user's workflow.

## Changes
- Replace `sendUserToast` error notification with `console.error` in `PickHubScriptQuick.svelte`

## Test plan
- [ ] Pick a hub script in a flow — verify it works normally
- [ ] Simulate a tracking failure (e.g. network error) — verify no toast appears and the script selection still completes

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences the user-facing toast for non-critical tracking failures when picking a hub script, so users aren’t interrupted. In `PickHubScriptQuick.svelte`, removed `sendUserToast` and now use `console.error` to log `ScriptService.pickHubScriptByPath` failures without blocking the flow.

<sup>Written for commit ecf176781f43c315e933d2fcf1ca747c8d1f49db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

