### PR TITLE
fix: make cli help resilient to npm registry fetch failures

### DIFF
--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -83,6 +83,32 @@ export const VERSION = "1.682.0";
 // Re-exported from constants.ts to maintain backwards compatibility
 export { WM_FORK_PREFIX } from "./core/constants.ts";
 
+// Re-implementation of cliffy's internal `checkVersion` so the help path
+// can wrap it in try/catch. `_check_version` is not in cliffy's package
+// exports map, so it can't be imported directly.
+async function checkVersionSafe(cmd: any): Promise<void> {
+  const mainCommand = cmd.getMainCommand();
+  const upgradeCommand = mainCommand.getCommand("upgrade");
+  if (
+    !upgradeCommand ||
+    typeof (upgradeCommand as any).getLatestVersion !== "function" ||
+    typeof (upgradeCommand as any).hasRequiredPermissions !== "function"
+  ) {
+    return;
+  }
+  if (!(await (upgradeCommand as any).hasRequiredPermissions())) {
+    return;
+  }
+  const latestVersion = await (upgradeCommand as any).getLatestVersion();
+  const currentVersion = mainCommand.getVersion();
+  if (!currentVersion || currentVersion === latestVersion) {
+    return;
+  }
+  mainCommand.version(
+    `${currentVersion}  (New version available: ${latestVersion}. Run '${mainCommand.getName()} upgrade' to upgrade to the latest version!)`
+  );
+}
+
 const command = new Command()
   .name("wmill")
   .action(() =>
@@ -117,6 +143,30 @@ const command = new Command()
   )
   .version(VERSION)
   .versionOption(false)
+  // Override the default help option action so that a failure to contact
+  // the npm registry (e.g. offline / firewalled environment) does not
+  // prevent help from being displayed. Cliffy's default action awaits
+  // `checkVersion` before `showHelp`, which aborts the whole command if
+  // the fetch to registry.npmjs.org fails.
+  .helpOption("-h, --help", "Show this help.", {
+    action: async function () {
+      const self = this as any;
+      const long = self
+        .getRawArgs()
+        .includes(`--${self.getHelpOption()?.name}`);
+      try {
+        await checkVersionSafe(self);
+      } catch (e) {
+        log.warn(
+          `Skipping latest-version check: ${
+            e instanceof Error ? e.message : String(e)
+          }`
+        );
+      }
+      self.showHelp({ long });
+      self.exit();
+    },
+  })
   .command("init", init)
   .command("app", app)
   .command("flow", flow)


### PR DESCRIPTION
## Summary

`npx windmill-cli workspace -h` (and every other `-h` / `--help` invocation) fails with `fetch failed` in firewalled environments that cannot reach `registry.npmjs.org`.

The root cause is cliffy: the default `-h` action awaits `checkVersion()` **before** calling `showHelp()`, and `checkVersion()` calls `NpmProvider.getVersions()` → `fetch('https://registry.npmjs.org/windmill-cli')`. When that fetch throws, the error propagates up and help is never rendered — the user just sees `fetch failed` with no context.

This PR overrides the global help option action in `cli/src/main.ts` so that the version-check call is wrapped in `try/catch`. Help is now always rendered even if the registry is unreachable; the failure is surfaced as a one-line `log.warn`.

## Changes

- `cli/src/main.ts`: add a `checkVersionSafe` helper (re-implementation of cliffy's internal `_check_version`, which is not in cliffy's package exports map and can't be imported directly).
- `cli/src/main.ts`: override `.helpOption()` on the root command with a custom action that runs `checkVersionSafe` inside a `try/catch`, logs failures via `log.warn`, and always calls `showHelp()` / `exit()`.

## Test plan

- [ ] `bun run src/main.ts workspace -h` renders help normally when online.
- [ ] `HTTPS_PROXY=http://127.0.0.1:1 bun run src/main.ts workspace -h` renders help with a single yellow `Skipping latest-version check: ...` warning on top (previously: only `fetch failed`).
- [ ] `HTTPS_PROXY=http://127.0.0.1:1 bun run src/main.ts -h` (root) and `... workspace add -h` (nested) also render help.
- [ ] `wmill upgrade` still surfaces fetch errors normally (unchanged path).
- [ ] `wmill version` still surfaces fetch errors via its existing try/catch (unchanged path).

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI help so `-h`/`--help` always shows, even when `registry.npmjs.org` is unreachable (offline/firewalled). We now skip the version check on network failure and print a short warning instead of crashing.

- **Bug Fixes**
  - Override root `.helpOption()` to run a local `checkVersionSafe()` inside try/catch, then always call `showHelp()`/`exit()` (`cli/src/main.ts`).
  - Add `checkVersionSafe` (small re-implementation of `cliffy`’s internal version check) to safely bypass the registry fetch when it fails.
  - `wmill upgrade` and `wmill version` keep existing error handling (unchanged).

<sup>Written for commit 658310e1f445c789378dda7c129de5f2b9a0f6e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

