### PR TITLE
fix: openapi spec uses 3.0 nullable pattern for deployment request

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -5348,9 +5348,9 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
+                nullable: true
+                allOf:
                   - $ref: "#/components/schemas/DeploymentRequest"
-                  - type: "null"
 
   /w/{workspace}/deployment_request:
     post:


### PR DESCRIPTION
## Summary

The Go-client and Python-client release jobs failed on commit e0066b266f because the new `getOpenDeploymentRequest` endpoint used `oneOf: [$ref, {type: "null"}]` in `backend/windmill-api/openapi.yaml`. That's OpenAPI 3.1 syntax, but the spec is declared as `3.0.3`, so both `oapi-codegen` and `openapi-python-client` rejected it:

- Go: `error generating type for oneOf: error resolving primitive type: unhandled Schema type: &[null]`
- Python: `Input should be 'string','number','integer','boolean','array' or 'object' [input_value='null']`

Failing runs:
- https://github.com/windmill-labs/windmill/actions/runs/24369959616/job/71171088699
- https://github.com/windmill-labs/windmill/actions/runs/24369959644/job/71171088940

## Changes

- Switched the `/w/{workspace}/deployment_request/open` 200 response to the standard OpenAPI 3.0 nullable-ref pattern: `nullable: true` + `allOf: [$ref]`. This matches the existing usage at `openapi.yaml:21410`.

## Test plan

- [ ] Re-run the `build_go_and_push_to_repo` and `publish_pypi` jobs after merge and confirm both succeed
- [ ] Spot-check the generated Go/Python clients return `nil`/`None` when no open deployment request exists

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OpenAPI spec for the deployment request endpoint to use the OpenAPI 3.0 nullable pattern, unblocking Go and Python client generation. The 200 response now correctly supports null while keeping the spec at 3.0.3.

- **Bug Fixes**
  - Replaced `oneOf: [$ref, {type: "null"}]` with `nullable: true` + `allOf: [$ref]` for `/w/{workspace}/deployment_request/open` 200 response so `oapi-codegen` and `openapi-python-client` accept the spec.

<sup>Written for commit 350256e065992ae8cba7eda35c5ab081658a3e5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

