### PR TITLE
fix: detect WAC v2 Python workflows using only step() (no @task)

### DIFF
--- a/backend/windmill-worker/src/wac_executor.rs
+++ b/backend/windmill-worker/src/wac_executor.rs
@@ -286,12 +286,13 @@ pub fn inject_wac_task_names(content: &str) -> String {
 }
 
 /// Detect WAC v2 patterns in Python code.
-/// Checks for `@workflow` decorator and `@task` decorator with wmill import,
-/// skipping comment lines.
+/// Checks for a wmill import plus a `@workflow` decorator, skipping comment
+/// lines. `@task` is optional: a workflow that only uses inline `step()` calls
+/// (no child-job `@task`) is still WAC v2 and must go through the WAC runner
+/// so its coroutine gets awaited.
 pub fn is_wac_v2_py(code: &str) -> bool {
     let mut has_wmill_import = false;
     let mut has_workflow_decorator = false;
-    let mut has_task_decorator = false;
     for line in code.lines() {
         let trimmed = line.trim();
         if trimmed.starts_with('#') {
@@ -303,9 +304,6 @@ pub fn is_wac_v2_py(code: &str) -> bool {
         if trimmed == "@workflow" || trimmed.starts_with("@workflow(") {
             has_workflow_decorator = true;
         }
-        if trimmed == "@task" || trimmed.starts_with("@task(") {
-            has_task_decorator = true;
-        }
     }
-    has_wmill_import && has_workflow_decorator && has_task_decorator
+    has_wmill_import && has_workflow_decorator
 }


### PR DESCRIPTION
## Summary

`is_wac_v2_py` required both `@workflow` **and** `@task` decorators. A WAC v2 Python script that only uses inline `step()` calls (no child-job `@task`) fell through to the regular Python execution path, which called `main(n)` without awaiting it — so the job result came back as the raw coroutine object (`"<coroutine object main at 0x...>"`) and `workflow_as_code_status._checkpoint` was never written.

The test `test_python_wac_v2_step_inline_fast_path` exercises exactly this shape and was failing because of this detection gap.

## Changes

- `backend/windmill-worker/src/wac_executor.rs` — drop the `@task` requirement from `is_wac_v2_py`. `wmill` import + `@workflow` decorator is now sufficient, matching the TS detector `is_wac_v2_ts` which also doesn't require a task symbol.
- Docstring updated to capture the why (coroutine would not be awaited otherwise).

## Test plan

- [x] `cargo test --test python_jobs --features enterprise,private,python,deno_core test_python_wac_v2_step_inline_fast_path` — now passes
- [x] `cargo test --test python_jobs --features enterprise,private,python,deno_core test_python_wac_v2` — both `test_python_wac_v2_with_args` and `test_python_wac_v2_step_inline_fast_path` pass (no regression on the `@task` path)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WAC v2 Python detection to handle workflows that use inline `step()` with `@workflow` but no `@task`, ensuring they run through the WAC runner, are awaited, and write `_checkpoint` correctly.

- **Bug Fixes**
  - Updated `is_wac_v2_py` to require only a `wmill` import and `@workflow` (removed `@task` requirement), matching the TS detector.
  - Clarified the docstring on why awaiting is needed for this path.

<sup>Written for commit 13124119f5d955f24972293fd367de4ca4d5401e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

