### PR TITLE
fix: persist indexer max_index_time_window_secs setting

### DIFF
--- a/backend/windmill-common/src/instance_config.rs
+++ b/backend/windmill-common/src/instance_config.rs
@@ -436,6 +436,8 @@ pub struct IndexerSettings {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_indexed_job_log_size: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_index_time_window_secs: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub should_clear_job_index: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub should_clear_log_index: Option<bool>,

--- a/frontend/src/lib/components/instanceSettings.ts
+++ b/frontend/src/lib/components/instanceSettings.ts
@@ -80,6 +80,7 @@ export interface Setting {
 export type SettingStorage = 'setting'
 
 const positiveNumber = z.number().positive('Must be a positive number')
+const nonNegativeNumber = z.number().nonnegative('Must be zero or a positive number')
 
 const indexerSettingsSchema = z
 	.object({
@@ -89,7 +90,7 @@ const indexerSettingsSchema = z
 		max_indexed_job_log_size: positiveNumber.optional(),
 		commit_log_max_batch_size: positiveNumber.optional(),
 		refresh_log_index_period: positiveNumber.optional(),
-		max_index_time_window_secs: positiveNumber.optional()
+		max_index_time_window_secs: nonNegativeNumber.optional()
 	})
 	.passthrough()
 

--- a/frontend/src/lib/components/instanceSettings/IndexerMemorySettings.svelte
+++ b/frontend/src/lib/components/instanceSettings/IndexerMemorySettings.svelte
@@ -9,6 +9,7 @@
 	import IntegerInput from '../IntegerInput.svelte'
 	import InputError from '../InputError.svelte'
 	import Label from '../Label.svelte'
+	import Toggle from '../Toggle.svelte'
 	import { Loader2, RefreshCw } from 'lucide-svelte'
 	import type { Writable } from 'svelte/store'
 
@@ -19,6 +20,20 @@
 	}
 
 	let { values, disabled = false, errors = {} }: Props = $props()
+
+	let isTimeWindowCapped = $derived($values['indexer_settings'].max_index_time_window_secs !== 0)
+
+	function setTimeWindowCapped(checked: boolean) {
+		if (checked) {
+			const { max_index_time_window_secs: _, ...rest } = $values['indexer_settings']
+			$values['indexer_settings'] = rest
+		} else {
+			$values['indexer_settings'] = {
+				...$values['indexer_settings'],
+				max_index_time_window_secs: 0
+			}
+		}
+	}
 
 	let clearJobsIndexModalOpen = $state(false)
 	let clearServiceLogsIndexModalOpen = $state(false)
@@ -91,36 +106,49 @@
 		/>
 		<InputError error={errors.writer_memory_budget ?? ''} />
 	</div>
-	<div class="flex flex-col gap-1">
-		<label for="max_index_time_window_secs" class="block text-xs font-semibold text-emphasis">
-			Index time window (days)
-			<Tooltip>
-				Maximum age of items to include in the index. Jobs and logs older than this window will not
-				be indexed and will be cleaned up from the index. Set to 0 to disable (index everything
-				within the retention period).
-			</Tooltip>
-		</label>
-		<IntegerInput
-			placeholder="7"
-			id="max_index_time_window_secs"
-			{disabled}
-			error={errors.max_index_time_window_secs ?? ''}
-			value={$values['indexer_settings'].max_index_time_window_secs != null
-				? Math.round($values['indexer_settings'].max_index_time_window_secs / 86400)
-				: undefined}
-			oninput={(v) => {
-				if (v == null) {
-					const { max_index_time_window_secs: _, ...rest } = $values['indexer_settings']
-					$values['indexer_settings'] = rest
-				} else {
-					$values['indexer_settings'] = {
-						...$values['indexer_settings'],
-						max_index_time_window_secs: v * 86400
+	<div class="flex flex-col gap-2">
+		<div class="flex flex-row items-center gap-2">
+			<span class="block text-xs font-semibold text-emphasis">
+				Index time window
+				<Tooltip>
+					Cap the age of items the indexer keeps. Jobs and logs older than this window are not
+					indexed and are cleaned up from the index. Disable the cap to index everything within the
+					retention period.
+				</Tooltip>
+			</span>
+			<div class="ml-auto">
+				<Toggle
+					{disabled}
+					checked={isTimeWindowCapped}
+					on:change={(e) => setTimeWindowCapped(e.detail)}
+					options={{ right: 'Cap by time window' }}
+				/>
+			</div>
+		</div>
+		{#if isTimeWindowCapped}
+			<IntegerInput
+				placeholder="7"
+				id="max_index_time_window_secs"
+				{disabled}
+				error={errors.max_index_time_window_secs ?? ''}
+				value={$values['indexer_settings'].max_index_time_window_secs != null
+					? Math.round($values['indexer_settings'].max_index_time_window_secs / 86400)
+					: undefined}
+				oninput={(v) => {
+					if (v == null) {
+						const { max_index_time_window_secs: _, ...rest } = $values['indexer_settings']
+						$values['indexer_settings'] = rest
+					} else {
+						$values['indexer_settings'] = {
+							...$values['indexer_settings'],
+							max_index_time_window_secs: v * 86400
+						}
 					}
-				}
-			}}
-		/>
-		<InputError error={errors.max_index_time_window_secs ?? ''} />
+				}}
+			/>
+			<span class="text-2xs text-tertiary">days (leave blank to use the default of 7 days)</span>
+			<InputError error={errors.max_index_time_window_secs ?? ''} />
+		{/if}
 	</div>
 	<Label label="Indexer status">
 		{#snippet action()}


### PR DESCRIPTION
## Summary

The instance setting **Monitor → Indexer → Index time window (days)** had two issues:
1. Entering `0` was rejected with "Must be a positive number", contradicting the tooltip and the indexer code which treat `0` as "no time window cap".
2. Setting it to a positive value appeared to save but **reset to blank on every page refresh**.

### Root cause of the persistence bug

The PUT path bypasses the typed `IndexerSettings` struct (it diffs a flat `BTreeMap<String, serde_json::Value>`), so the value was actually persisted to `global_settings.value`. The bug was on the **GET path**: `InstanceConfig::from_db` deserializes the row into the typed `IndexerSettings`, which was missing the `max_index_time_window_secs` field, so serde silently dropped it during deserialization. The re-serialized API response then lacked the field, and the frontend always saw a blank value on reload. The runtime indexer (which reads via `TantivyIndexerSettingsOpt`, a different struct that already had the field) was honoring the persisted value all along — only the UI was lying.

### UX redesign

Instead of asking users to type `0` to disable the cap, the field is now a clearly-labeled toggle (`Cap by time window`). The semantics are unchanged at runtime — toggle off stores `0` (which the indexer code already treats as unbounded via the `> 0` gate in `completed_runs_ee.rs:745`); toggle on shows the integer input.

| Toggle ON (default) | Toggle OFF (disabled) | Toggle ON, 30 days |
|---|---|---|
| ![on](https://tmpfiles.org/dl/33472203/zoom-toggle-on.png) | ![off](https://tmpfiles.org/dl/33472205/zoom-toggle-off.png) | ![30](https://tmpfiles.org/dl/33472206/zoom-toggle-on-30.png) |

## Changes

- `backend/windmill-common/src/instance_config.rs` — add `pub max_index_time_window_secs: Option<i64>` to `IndexerSettings` so the GET round-trip preserves the field. Type matches `TantivyIndexerSettings.max_index_time_window_secs`.
- `frontend/src/lib/components/instanceSettings.ts` — switch `max_index_time_window_secs` validation from `positiveNumber` to a new `nonNegativeNumber` schema, since the toggle now sets `0` programmatically when disabled.
- `frontend/src/lib/components/instanceSettings/IndexerMemorySettings.svelte` — replace the bare integer input with a `<Toggle>` ("Cap by time window") that gates the integer input. Toggle ON is derived from `max_index_time_window_secs !== 0` (so undefined falls through to the default 7-day behavior). Toggle OFF writes `0` explicitly.

## Hot reload

No restart needed — the indexer already hot-reloads via Postgres NOTIFY: `global_settings` UPDATE → `notify_global_setting_change` → `reload_indexer_config(db)` (`backend/src/main.rs:1713`) → updates the global `INDEXER_CONFIG: Arc<RwLock<TantivyIndexerSettings>>`. The EE indexer loops re-read `INDEXER_CONFIG.load()` on each iteration, so the new value takes effect on the next `refresh_index_period` tick (default 300s).

## Test plan

- [x] PUT `{max_index_time_window_secs: 604800}` then GET → field round-trips (validated against running backend)
- [x] PUT `{max_index_time_window_secs: 0}` then GET → `0` round-trips (no longer silently dropped)
- [x] UI: toggle off hides the input and stores `0`
- [x] UI: toggle on shows the input with the current value (or empty placeholder `7` if undefined)
- [x] UI: entering a positive integer persists across page refresh
- [ ] Verify in a long-running deployment that the indexer's `monitor_job_index` / `monitor_log_index` loops pick up the new value within one `refresh_index_period`

---
Generated with [Claude Code](https://claude.com/claude-code)