### PR TITLE
feat(frontend): improve permissions drawer UX and auto-share resource variables

### DIFF
--- a/frontend/src/lib/components/ShareModal.svelte
+++ b/frontend/src/lib/components/ShareModal.svelte
@@ -1,18 +1,25 @@
 <script lang="ts">
 	import TableCustom from './TableCustom.svelte'
 
-	import { GroupService, UserService, GranularAclService } from '$lib/gen'
+	import {
+		GroupService,
+		UserService,
+		GranularAclService,
+		ResourceService,
+		FolderService
+	} from '$lib/gen'
+	import type { Folder } from '$lib/gen/types.gen'
 	import { createEventDispatcher } from 'svelte'
 	import { userStore, workspaceStore } from '$lib/stores'
 	import { Alert, Button, Drawer } from './common'
 	import DrawerContent from './common/drawer/DrawerContent.svelte'
-	import Tooltip from './Tooltip.svelte'
 	import { sendUserToast } from '$lib/toast'
 	import { isOwner } from '$lib/utils'
 	import ToggleButtonGroup from './common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import ToggleButton from './common/toggleButton-v2/ToggleButton.svelte'
 	import Select from './select/Select.svelte'
 	import { safeSelectItems } from './select/utils.svelte'
+	import Toggle from './Toggle.svelte'
 	import { Trash } from 'lucide-svelte'
 
 	const dispatch = createEventDispatcher()
@@ -53,13 +60,88 @@
 
 	let drawer: Drawer | undefined = $state()
 
+	let linkedVarPaths: string[] = $state([])
+	let alsoApplyToLinked: boolean = $state(true)
+
+	let defaultPerms: { label: string; write: boolean }[] = $state([])
+	let defaultPermsLabel: string = $state('')
+
+	async function loadDefaultPerms() {
+		const parts = path.split('/')
+		if (parts[0] === 'f' && parts.length >= 2) {
+			const folderName = parts[1]
+			defaultPermsLabel = `Folder f/${folderName} permissions`
+			try {
+				const folder: Folder = await FolderService.getFolder({
+					workspace: $workspaceStore!,
+					name: folderName
+				})
+				const perms: { label: string; write: boolean }[] = []
+				for (const owner of folder.owners) {
+					perms.push({ label: owner, write: true })
+				}
+				for (const [owner, write] of Object.entries(folder.extra_perms)) {
+					if (!folder.owners.includes(owner)) {
+						perms.push({ label: owner, write })
+					}
+				}
+				defaultPerms = perms
+			} catch {
+				defaultPerms = []
+			}
+		} else if (parts[0] === 'u' && parts.length >= 2) {
+			defaultPermsLabel = `User u/${parts[1]} permissions`
+			defaultPerms = [{ label: `u/${parts[1]}`, write: true }]
+		} else if (parts[0] === 'g' && parts.length >= 2) {
+			defaultPermsLabel = `Group g/${parts[1]} permissions`
+			defaultPerms = [{ label: `g/${parts[1]}`, write: true }]
+		} else {
+			defaultPerms = []
+			defaultPermsLabel = ''
+		}
+	}
+
+	function collectVarRefs(value: unknown): string[] {
+		const paths: string[] = []
+		function walk(v: unknown) {
+			if (typeof v === 'string' && v.startsWith('$var:')) {
+				paths.push(v.substring('$var:'.length))
+			} else if (Array.isArray(v)) {
+				v.forEach(walk)
+			} else if (v && typeof v === 'object') {
+				Object.values(v).forEach(walk)
+			}
+		}
+		walk(value)
+		return [...new Set(paths)]
+	}
+
+	async function loadLinkedVarPaths() {
+		if (kind !== 'resource') {
+			linkedVarPaths = []
+			return
+		}
+		try {
+			const resource = await ResourceService.getResource({
+				workspace: $workspaceStore!,
+				path
+			})
+			linkedVarPaths = collectVarRefs(resource.value)
+		} catch {
+			linkedVarPaths = []
+		}
+	}
+
 	let own = $state(false)
 	export async function openDrawer(newPath: string, kind_l: Kind, isOwnerOverride?: boolean) {
 		path = newPath
 		kind = kind_l
+		alsoApplyToLinked = true
 		loadAcls()
 		loadGroups()
 		loadUsernames()
+		loadLinkedVarPaths()
+		loadDefaultPerms()
 		if (isOwnerOverride !== undefined) {
 			own = isOwnerOverride
 		} else {
@@ -94,6 +176,20 @@
 				kind,
 				requestBody: { owner }
 			})
+			if (alsoApplyToLinked) {
+				for (const varPath of linkedVarPaths) {
+					try {
+						await GranularAclService.removeGranularAcls({
+							workspace: $workspaceStore!,
+							path: varPath,
+							kind: 'variable',
+							requestBody: { owner }
+						})
+					} catch (err) {
+						sendUserToast(`Failed to update variable ${varPath}: ${err}`, true)
+					}
+				}
+			}
 			loadAcls()
 			dispatch('change', { path, kind })
 		} catch (err) {
@@ -108,111 +204,146 @@
 			kind,
 			requestBody: { owner, write }
 		})
+		if (alsoApplyToLinked) {
+			for (const varPath of linkedVarPaths) {
+				try {
+					await GranularAclService.addGranularAcls({
+						workspace: $workspaceStore!,
+						path: varPath,
+						kind: 'variable',
+						requestBody: { owner, write }
+					})
+				} catch (err) {
+					sendUserToast(`Failed to update variable ${varPath}: ${err}`, true)
+				}
+			}
+		}
 		loadAcls()
 		dispatch('change', { path, kind })
 	}
 </script>
 
 <Drawer bind:this={drawer}>
-	<DrawerContent title="Share {path}" on:close={drawer?.closeDrawer}>
-		<div class="flex flex-col gap-2">
-			<h1 class="text-sm font-semibold text-emphasis">{path}</h1>
-			<span class="text-xs font-semibold text-emphasis"
-				>Extra Permissions ({acls?.length ?? 0}) &nbsp; <Tooltip
-					>Items already have default permissions. If belonging to an user or group, that group or
-					user owns it and can write to it as well as modify its permisions and move it. Folders
-					have read/write that apply to the whole folder and are additive to the items permissions.</Tooltip
-				></span
-			>
-			{#if !own}
-				<Alert type="warning" title="Not owner"
-					>Since you do not own this item, you cannot modify its permission</Alert
-				>
-			{/if}
-			<div>
-				{#if own}
-					<div class="flex flex-row flex-wrap gap-2 items-center">
-						<div>
-							<ToggleButtonGroup bind:selected={ownerKind} on:selected={() => (owner = '')}>
-								{#snippet children({ item })}
-									<ToggleButton value="user" label="User" {item} />
-									<ToggleButton value="group" label="Group" {item} />
-								{/snippet}
-							</ToggleButtonGroup>
+	<DrawerContent title="Permissions for {path}" on:close={drawer?.closeDrawer}>
+		<div class="flex flex-col gap-4">
+			{#if defaultPerms.length > 0}
+				<div class="flex flex-col gap-1">
+					<span class="text-sm font-semibold text-emphasis">{defaultPermsLabel}</span>
+					{#each defaultPerms as perm (perm.label)}
+						<div class="flex items-center justify-between text-xs text-primary">
+							<span>{perm.label}</span>
+							<span class="text-tertiary">{perm.write ? 'Writer' : 'Viewer'}</span>
 						</div>
-						{#key ownerKind}
-							<Select
-								items={safeSelectItems(
-									(ownerKind === 'user' ? usernames : groups).map((x) => x.toString())
-								)}
-								bind:value={owner}
-								class="grow min-w-48"
-							/>
-						{/key}
-						<Button
-							size="lg"
-							variant="accent"
-							disabled={!newOwner}
-							on:click={() => addAcl(newOwner, write)}>Add permission</Button
-						>
+					{/each}
+				</div>
+			{/if}
+			<div class="flex flex-col gap-2">
+				<span class="text-sm font-semibold text-emphasis"
+					>Extra permissions ({acls?.length ?? 0})</span
+				>
+				{#if linkedVarPaths.length > 0}
+					<div class="flex flex-col gap-1.5 p-3 border rounded bg-surface-secondary text-xs">
+						<Toggle
+							size="xs"
+							bind:checked={alsoApplyToLinked}
+							options={{ right: 'Also apply to linked variables' }}
+						/>
+						<ul class="text-2xs text-secondary list-disc ml-4">
+							{#each linkedVarPaths as varPath (varPath)}
+								<li>{varPath}</li>
+							{/each}
+						</ul>
 					</div>
 				{/if}
-				{#if acls?.length > 0}
-					<TableCustom>
-
-						{#snippet headerRow()}
-												<tr >
-								<th>owner</th>
-								<th></th>
-								<th></th>
-							</tr>
-											{/snippet}
-						{#snippet body()}
-							<tbody>
-								{#each acls as [owner, write]}
-									<tr>
-										<td>{owner}</td>
-										<td
-											>{#if own}
-												<div>
-													<ToggleButtonGroup
-														selected={write ? 'writer' : 'viewer'}
-														on:selected={async (e) => {
-															const role = e.detail
-															if (role == 'writer') {
-																await addAcl(owner, true)
-															} else {
-																await addAcl(owner, false)
-															}
-															loadAcls()
-														}}
-													>
-														{#snippet children({ item })}
-															<ToggleButton value="viewer" small label="Viewer" {item} />
-															<ToggleButton value="writer" small label="Writer" {item} />
-														{/snippet}
-													</ToggleButtonGroup>
-												</div>
-											{:else}{write}{/if}</td
-										>
-										<td>
-											{#if own}
-												<Button
-													variant="default"
-													destructive
-													size="xs"
-													on:click={() => deleteAcl(owner)}
-													startIcon={{ icon: Trash }}
-												/>
-											{/if}
-										</td>
-									</tr>
-								{/each}
-							</tbody>
-						{/snippet}
-					</TableCustom>
+				{#if !own}
+					<Alert type="warning" title="Not owner"
+						>Since you do not own this item, you cannot modify its permission</Alert
+					>
 				{/if}
+				<div>
+					{#if own}
+						<div class="flex flex-row flex-wrap gap-2 items-center">
+							<div>
+								<ToggleButtonGroup bind:selected={ownerKind} on:selected={() => (owner = '')}>
+									{#snippet children({ item })}
+										<ToggleButton value="user" label="User" {item} />
+										<ToggleButton value="group" label="Group" {item} />
+									{/snippet}
+								</ToggleButtonGroup>
+							</div>
+							{#key ownerKind}
+								<Select
+									items={safeSelectItems(
+										(ownerKind === 'user' ? usernames : groups).map((x) => x.toString())
+									)}
+									bind:value={owner}
+									class="grow min-w-48"
+								/>
+							{/key}
+							<Button
+								size="lg"
+								variant="accent"
+								disabled={!newOwner}
+								on:click={() => addAcl(newOwner, write)}>Add permission</Button
+							>
+						</div>
+					{/if}
+					{#if acls?.length > 0}
+						<TableCustom>
+							{#snippet headerRow()}
+								<tr>
+									<th>owner</th>
+									<th></th>
+									<th></th>
+								</tr>
+							{/snippet}
+							{#snippet body()}
+								<tbody>
+									{#each acls as [owner, write]}
+										<tr>
+											<td>{owner}</td>
+											<td
+												>{#if own}
+													<div>
+														<ToggleButtonGroup
+															selected={write ? 'writer' : 'viewer'}
+															on:selected={async (e) => {
+																const role = e.detail
+																if (role == 'writer') {
+																	await addAcl(owner, true)
+																} else {
+																	await addAcl(owner, false)
+																}
+																loadAcls()
+															}}
+														>
+															{#snippet children({ item })}
+																<ToggleButton value="viewer" small label="Viewer" {item} />
+																<ToggleButton value="writer" small label="Writer" {item} />
+															{/snippet}
+														</ToggleButtonGroup>
+													</div>
+												{:else}{write}{/if}</td
+											>
+											<td>
+												{#if own}
+													<Button
+														variant="default"
+														destructive
+														size="xs"
+														on:click={() => deleteAcl(owner)}
+														startIcon={{ icon: Trash }}
+													/>
+												{/if}
+											</td>
+										</tr>
+									{/each}
+								</tbody>
+							{/snippet}
+						</TableCustom>
+					{/if}
+				</div>
 			</div>
-		</div>
-	</DrawerContent>
+		</div></DrawerContent
+	>
 </Drawer>

--- a/frontend/src/lib/components/ShareModal.svelte
+++ b/frontend/src/lib/components/ShareModal.svelte
@@ -67,7 +67,8 @@
 	let defaultPermsLabel: string = $state('')
 
 	async function loadDefaultPerms() {
-		const parts = path.split('/')
+		const currentPath = path
+		const parts = currentPath.split('/')
 		if (parts[0] === 'f' && parts.length >= 2) {
 			const folderName = parts[1]
 			defaultPermsLabel = `Folder f/${folderName} permissions`
@@ -76,17 +77,19 @@
 					workspace: $workspaceStore!,
 					name: folderName
 				})
+				if (path !== currentPath) return
 				const perms: { label: string; write: boolean }[] = []
 				for (const owner of folder.owners) {
 					perms.push({ label: owner, write: true })
 				}
-				for (const [owner, write] of Object.entries(folder.extra_perms)) {
+				for (const [owner, write] of Object.entries(folder.extra_perms ?? {})) {
 					if (!folder.owners.includes(owner)) {
 						perms.push({ label: owner, write })
 					}
 				}
 				defaultPerms = perms
 			} catch {
+				if (path !== currentPath) return
 				defaultPerms = []
 			}
 		} else if (parts[0] === 'u' && parts.length >= 2) {
@@ -121,13 +124,16 @@
 			linkedVarPaths = []
 			return
 		}
+		const currentPath = path
 		try {
 			const resource = await ResourceService.getResource({
 				workspace: $workspaceStore!,
-				path
+				path: currentPath
 			})
+			if (path !== currentPath) return
 			linkedVarPaths = collectVarRefs(resource.value)
 		} catch {
+			if (path !== currentPath) return
 			linkedVarPaths = []
 		}
 	}

--- a/frontend/src/lib/components/common/table/AppRow.svelte
+++ b/frontend/src/lib/components/common/table/AppRow.svelte
@@ -21,7 +21,7 @@
 		ChevronUpSquare,
 		History,
 		Pen,
-		Share,
+		Shield,
 		Trash,
 		Copy
 	} from 'lucide-svelte'
@@ -235,8 +235,8 @@
 						hide: $userStore?.operator
 					},
 					{
-						displayName: canWrite ? 'Share' : 'See Permissions',
-						icon: Share,
+						displayName: 'Permissions',
+						icon: Shield,
 						action: () => {
 							shareModal.openDrawer && shareModal.openDrawer(path, 'app')
 						},

--- a/frontend/src/lib/components/common/table/FlowRow.svelte
+++ b/frontend/src/lib/components/common/table/FlowRow.svelte
@@ -26,7 +26,7 @@
 		FolderOpen,
 		ChevronUpSquare,
 		Calendar,
-		Share,
+		Shield,
 		Archive,
 		Copy,
 		Eye,
@@ -273,8 +273,8 @@
 						hide: $userStore?.operator
 					},
 					{
-						displayName: owner ? 'Share' : 'See Permissions',
-						icon: Share,
+						displayName: 'Permissions',
+						icon: Shield,
 						action: () => {
 							shareModal.openDrawer && shareModal.openDrawer(path, 'flow')
 						},

--- a/frontend/src/lib/components/common/table/RawAppRow.svelte
+++ b/frontend/src/lib/components/common/table/RawAppRow.svelte
@@ -7,7 +7,7 @@
 	import { workspaceStore } from '$lib/stores'
 	import Row from './Row.svelte'
 	import type DeployWorkspaceDrawer from '$lib/components/DeployWorkspaceDrawer.svelte'
-	import { Globe, Share } from 'lucide-svelte'
+	import { Globe, Shield } from 'lucide-svelte'
 	import { isDeployable } from '$lib/utils_deployable'
 	import { getDeployUiSettings } from '$lib/components/home/deploy_ui'
 
@@ -46,7 +46,7 @@
 	{#snippet actions()}
 		<Dropdown
 			items={async () => {
-				let { path, canWrite } = app
+				let { path } = app
 
 				return [
 					...(isDeployable('app', path, await getDeployUiSettings())
@@ -61,8 +61,8 @@
 							]
 						: []),
 					{
-						displayName: canWrite ? 'Share' : 'See Permissions',
-						icon: Share,
+						displayName: 'Permissions',
+						icon: Shield,
 						action: () => {
 							shareModal.openDrawer && shareModal.openDrawer(path, 'raw_app')
 						}

--- a/frontend/src/lib/components/common/table/ScriptRow.svelte
+++ b/frontend/src/lib/components/common/table/ScriptRow.svelte
@@ -32,7 +32,7 @@
 		GitFork,
 		List,
 		Pen,
-		Share,
+		Shield,
 		Trash,
 		History,
 		Globe2,
@@ -350,8 +350,8 @@
 						hide: $userStore?.operator
 					},
 					{
-						displayName: owner ? 'Share' : 'See Permissions',
-						icon: Share,
+						displayName: 'Permissions',
+						icon: Shield,
 						action: () => {
 							shareModal.openDrawer && shareModal.openDrawer(script.path, 'script')
 						},

--- a/frontend/src/routes/(root)/(logged)/email_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/email_triggers/+page.svelte
@@ -39,7 +39,7 @@
 		Eye,
 		Pen,
 		Plus,
-		Share,
+		Shield,
 		Trash,
 		FileUp,
 		ClipboardCopy,
@@ -462,8 +462,8 @@
 												href: `${base}/audit_logs?resource=${path}`
 											},
 											{
-												displayName: canWrite ? 'Share' : 'See Permissions',
-												icon: Share,
+												displayName: 'Permissions',
+												icon: Shield,
 												action: () => {
 													shareModal?.openDrawer(path, 'email_trigger')
 												}

--- a/frontend/src/routes/(root)/(logged)/flows/get/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/flows/get/[...path]/+page.svelte
@@ -28,7 +28,7 @@
 		Archive,
 		Trash,
 		ChevronUpSquare,
-		Share,
+		Shield,
 		Loader2,
 		GitFork,
 		Play,
@@ -353,9 +353,9 @@
 		const menuItems: any = []
 
 		menuItems.push({
-			label: 'Share',
+			label: 'Permissions',
 			onclick: () => shareModal?.openDrawer(flow?.path ?? '', 'flow'),
-			Icon: Share,
+			Icon: Shield,
 			disabled: !can_write
 		})
 

--- a/frontend/src/routes/(root)/(logged)/gcp_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/gcp_triggers/+page.svelte
@@ -32,7 +32,7 @@
 		Eye,
 		Pen,
 		Plus,
-		Share,
+		Shield,
 		Trash,
 		Circle,
 		FileUp,
@@ -546,8 +546,8 @@
 											href: `${base}/audit_logs?resource=${path}`
 										},
 										{
-											displayName: canWrite ? 'Share' : 'See Permissions',
-											icon: Share,
+											displayName: 'Permissions',
+											icon: Shield,
 											action: () => {
 												shareModal?.openDrawer(path, 'gcp_trigger')
 											}

--- a/frontend/src/routes/(root)/(logged)/kafka_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/kafka_triggers/+page.svelte
@@ -32,7 +32,7 @@
 		enterpriseLicense,
 		usedTriggerKinds
 	} from '$lib/stores'
-	import { Code, Eye, Pen, Plus, Share, Trash, Circle, FileUp, Pause } from 'lucide-svelte'
+	import { Code, Eye, Pen, Plus, Shield, Trash, Circle, FileUp, Pause } from 'lucide-svelte'
 	import { goto } from '$lib/navigation'
 	import SearchItems from '$lib/components/SearchItems.svelte'
 	import NoItemFound from '$lib/components/home/NoItemFound.svelte'
@@ -519,8 +519,8 @@
 												href: `${base}/audit_logs?resource=${path}`
 											},
 											{
-												displayName: canWrite ? 'Share' : 'See Permissions',
-												icon: Share,
+												displayName: 'Permissions',
+												icon: Shield,
 												action: () => {
 													shareModal?.openDrawer(path, 'kafka_trigger')
 												}

--- a/frontend/src/routes/(root)/(logged)/mqtt_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/mqtt_triggers/+page.svelte
@@ -27,7 +27,7 @@
 	import ShareModal from '$lib/components/ShareModal.svelte'
 	import Toggle from '$lib/components/Toggle.svelte'
 	import { enterpriseLicense, usedTriggerKinds, userStore, workspaceStore } from '$lib/stores'
-	import { Code, Eye, Pen, Plus, Share, Trash, Circle, FileUp, Pause } from 'lucide-svelte'
+	import { Code, Eye, Pen, Plus, Shield, Trash, Circle, FileUp, Pause } from 'lucide-svelte'
 	import { goto } from '$lib/navigation'
 	import SearchItems from '$lib/components/SearchItems.svelte'
 	import NoItemFound from '$lib/components/home/NoItemFound.svelte'
@@ -481,8 +481,8 @@
 											href: `${base}/audit_logs?resource=${path}`
 										},
 										{
-											displayName: canWrite ? 'Share' : 'See Permissions',
-											icon: Share,
+											displayName: 'Permissions',
+											icon: Shield,
 											action: () => {
 												shareModal?.openDrawer(path, 'mqtt_trigger')
 											}

--- a/frontend/src/routes/(root)/(logged)/nats_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/nats_triggers/+page.svelte
@@ -32,7 +32,7 @@
 		enterpriseLicense,
 		usedTriggerKinds
 	} from '$lib/stores'
-	import { Code, Eye, Pen, Plus, Share, Trash, Circle, FileUp, Pause } from 'lucide-svelte'
+	import { Code, Eye, Pen, Plus, Shield, Trash, Circle, FileUp, Pause } from 'lucide-svelte'
 	import { goto } from '$lib/navigation'
 	import SearchItems from '$lib/components/SearchItems.svelte'
 	import NoItemFound from '$lib/components/home/NoItemFound.svelte'
@@ -504,8 +504,8 @@
 												href: `${base}/audit_logs?resource=${path}`
 											},
 											{
-												displayName: canWrite ? 'Share' : 'See Permissions',
-												icon: Share,
+												displayName: 'Permissions',
+												icon: Shield,
 												action: () => {
 													shareModal?.openDrawer(path, 'nats_trigger')
 												}

--- a/frontend/src/routes/(root)/(logged)/postgres_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/postgres_triggers/+page.svelte
@@ -32,7 +32,7 @@
 		Eye,
 		Pen,
 		Plus,
-		Share,
+		Shield,
 		Trash,
 		Circle,
 		Database,
@@ -597,8 +597,8 @@
 											href: `${base}/audit_logs?resource=${path}`
 										},
 										{
-											displayName: canWrite ? 'Share' : 'See Permissions',
-											icon: Share,
+											displayName: 'Permissions',
+											icon: Shield,
 											action: () => {
 												shareModal?.openDrawer(path, 'postgres_trigger')
 											}

--- a/frontend/src/routes/(root)/(logged)/resources/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/resources/+page.svelte
@@ -56,7 +56,7 @@
 		Plus,
 		RotateCw,
 		Save,
-		Share,
+		Shield,
 		Trash
 	} from 'lucide-svelte'
 	import { onMount, untrack } from 'svelte'
@@ -1121,8 +1121,8 @@
 												class="w-fit"
 												items={[
 													{
-														displayName: !canWrite ? 'View Permissions' : 'Share',
-														icon: Share,
+														displayName: 'Permissions',
+														icon: Shield,
 														action: () => {
 															shareModal?.openDrawer?.(path, 'resource')
 														}

--- a/frontend/src/routes/(root)/(logged)/routes/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/routes/+page.svelte
@@ -40,7 +40,7 @@
 		Eye,
 		Pen,
 		Plus,
-		Share,
+		Shield,
 		Trash,
 		FileUp,
 		ClipboardCopy,
@@ -503,8 +503,8 @@
 												href: `${base}/audit_logs?resource=${path}`
 											},
 											{
-												displayName: canWrite ? 'Share' : 'See Permissions',
-												icon: Share,
+												displayName: 'Permissions',
+												icon: Shield,
 												action: () => {
 													shareModal?.openDrawer(path, 'http_trigger')
 												}

--- a/frontend/src/routes/(root)/(logged)/schedules/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/schedules/+page.svelte
@@ -26,7 +26,7 @@
 		Pen,
 		Play,
 		Plus,
-		Share,
+		Shield,
 		Trash
 	} from 'lucide-svelte'
 	import { goto } from '$lib/navigation'
@@ -517,8 +517,8 @@
 												}
 											},
 											{
-												displayName: canWrite ? 'Share' : 'See Permissions',
-												icon: Share,
+												displayName: 'Permissions',
+												icon: Shield,
 												action: () => {
 													shareModal?.openDrawer(path, 'schedule')
 												}

--- a/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
@@ -58,7 +58,7 @@
 		Loader2,
 		Pen,
 		ChevronUpSquare,
-		Share,
+		Shield,
 		Trash,
 		Play,
 		ClipboardCopy,
@@ -503,8 +503,8 @@
 		})
 
 		menuItems.push({
-			label: 'Share',
-			Icon: Share,
+			label: 'Permissions',
+			Icon: Shield,
 			onclick: () => {
 				shareModal?.openDrawer(script?.path ?? '', 'script')
 			}

--- a/frontend/src/routes/(root)/(logged)/sqs_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sqs_triggers/+page.svelte
@@ -26,7 +26,7 @@
 	import ShareModal from '$lib/components/ShareModal.svelte'
 	import Toggle from '$lib/components/Toggle.svelte'
 	import { enterpriseLicense, usedTriggerKinds, userStore, workspaceStore } from '$lib/stores'
-	import { Code, Eye, Pen, Plus, Share, Trash, Circle, FileUp, Pause } from 'lucide-svelte'
+	import { Code, Eye, Pen, Plus, Shield, Trash, Circle, FileUp, Pause } from 'lucide-svelte'
 	import { goto } from '$lib/navigation'
 	import SearchItems from '$lib/components/SearchItems.svelte'
 	import NoItemFound from '$lib/components/home/NoItemFound.svelte'
@@ -476,8 +476,8 @@
 											href: `${base}/audit_logs?resource=${path}`
 										},
 										{
-											displayName: canWrite ? 'Share' : 'See Permissions',
-											icon: Share,
+											displayName: 'Permissions',
+											icon: Shield,
 											action: () => {
 												shareModal?.openDrawer(path, 'sqs_trigger')
 											}

--- a/frontend/src/routes/(root)/(logged)/variables/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/variables/+page.svelte
@@ -33,7 +33,7 @@
 		Link,
 		Pen,
 		RefreshCw,
-		Share,
+		Shield,
 		Trash,
 		Building,
 		DollarSign,
@@ -528,11 +528,11 @@
 															]
 														: []),
 													{
-														displayName: owner ? 'Share' : 'See Permissions',
+														displayName: 'Permissions',
 														action: () => {
 															shareModal?.openDrawer(path, 'variable')
 														},
-														icon: Share
+														icon: Shield
 													},
 													...(account != undefined
 														? [

--- a/frontend/src/routes/(root)/(logged)/websocket_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/websocket_triggers/+page.svelte
@@ -27,7 +27,7 @@
 	import ShareModal from '$lib/components/ShareModal.svelte'
 	import Toggle from '$lib/components/Toggle.svelte'
 	import { enterpriseLicense, usedTriggerKinds, userStore, workspaceStore } from '$lib/stores'
-	import { Unplug, Code, Eye, Pen, Plus, Share, Trash, Circle, FileUp, Pause } from 'lucide-svelte'
+	import { Unplug, Code, Eye, Pen, Plus, Shield, Trash, Circle, FileUp, Pause } from 'lucide-svelte'
 	import { goto } from '$lib/navigation'
 	import SearchItems from '$lib/components/SearchItems.svelte'
 	import NoItemFound from '$lib/components/home/NoItemFound.svelte'
@@ -489,8 +489,8 @@
 											href: `${base}/audit_logs?resource=${path}`
 										},
 										{
-											displayName: canWrite ? 'Share' : 'See Permissions',
-											icon: Share,
+											displayName: 'Permissions',
+											icon: Shield,
 											action: () => {
 												shareModal?.openDrawer(path, 'websocket_trigger')
 											}

--- a/frontend/src/routes/test_dev/kitchen_sink/+page.svelte
+++ b/frontend/src/routes/test_dev/kitchen_sink/+page.svelte
@@ -70,9 +70,9 @@
 			action: () => console.log('Duplicate clicked')
 		},
 		{
-			displayName: 'Share',
+			displayName: 'Permissions',
 			icon: Share,
-			action: () => console.log('Share clicked')
+			action: () => console.log('Permissions clicked')
 		},
 		{
 			displayName: 'Archive',


### PR DESCRIPTION
## Summary
Improves the permissions drawer UX and adds automatic sharing of linked variables when sharing a resource.

## Changes
- **Auto-share linked variables**: When sharing a resource, the drawer detects all `$var:` references in the resource value and offers to apply the same permission changes to those variables via a toggle (enabled by default)
- **Rename "Share" to "Permissions"**: All dropdown menu items across resources, variables, scripts, flows, apps, schedules, and triggers now consistently say "Permissions" instead of the old conditional "Share"/"See Permissions"/"View Permissions"
- **Shield icon**: Replaced the `Share` arrow icon with `Shield` for the permissions action, consistent with the volumes drawer
- **Default permissions section**: The drawer now shows a "Folder/User/Group permissions" section listing the inherited permissions from the item's namespace (folder owners + extra_perms, or user owner)
- **Drawer title**: Now reads "Permissions for {path}" with the path in the title instead of a separate heading
- **Removed tooltip**: The vague tooltip explaining default permissions is replaced by the actual default permissions data

## Test plan
- [ ] Navigate to Resources page, open the three-dot menu on any item -- should show "Permissions" with shield icon
- [ ] Open permissions for a resource with `$var:` references -- should show the linked variables toggle and path list
- [ ] Add a permission with the toggle on -- verify the linked variable also gets the permission
- [ ] Uncheck the toggle, add another permission -- verify only the resource is updated
- [ ] Open permissions for a folder-scoped item (`f/...`) -- should show "Folder f/X permissions" with folder owners and extra_perms
- [ ] Open permissions for a user-scoped item (`u/...`) -- should show "User u/X permissions" with the user as Writer
- [ ] Verify "Permissions" label + shield icon on: scripts, flows, apps, variables, schedules, and all trigger pages (email, kafka, nats, mqtt, sqs, websocket, gcp, postgres)
- [ ] Open permissions for a resource with no `$var:` references -- no linked variables section should appear

---
Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the permissions drawer and adds auto-sharing of linked variables when updating a resource’s permissions. Standardizes the action across the app by renaming it to “Permissions” with a Shield icon and shows inherited defaults in the drawer.

- **New Features**
  - Auto-detect `$var:` references in a resource and offer a toggle to also apply permission changes to those variables (on by default).
  - New “Default permissions” section lists inherited folder/user/group permissions.
  - Drawer title now reads “Permissions for {path}”.

- **Bug Fixes**
  - Guard async loads against stale drawer state when switching items, preventing late responses from overwriting current data.
  - Use a safe `?? {}` fallback for `extra_perms` to handle undefined values.

<sup>Written for commit e46b508a5f0eedafe03a5828148affd52799b6ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


<img width="613" height="390" alt="Screenshot 2026-04-14 at 12 45 36" src="https://github.com/user-attachments/assets/09905371-5f5d-4968-a023-09c7325cda86" />
<img width="256" height="86" alt="Screenshot 2026-04-14 at 12 45 42" src="https://github.com/user-attachments/assets/8a48fa9f-0783-4e17-b933-a41655fd17f7" />
<img width="581" height="244" alt="Screenshot 2026-04-14 at 12 46 40" src="https://github.com/user-attachments/assets/3235f7c5-2232-47d9-b6d2-96850b95c8bb" />

