### PR TITLE
fix: compute wall-clock duration for flow job groups in CLI

### DIFF
--- a/cli/src/commands/job/job.ts
+++ b/cli/src/commands/job/job.ts
@@ -155,21 +155,36 @@ function formatFlowSteps(
     // For-loop modules: show parent line + iteration sub-lines
     const flowJobs = mod.flow_jobs as string[] | undefined;
     if (flowJobs && flowJobs.length > 0) {
-      // Total duration for the for-loop
-      const totalMs = flowJobsDuration?.duration_ms
-        ? (flowJobsDuration.duration_ms as number[]).reduce((a: number, b: number) => a + b, 0)
-        : undefined;
+      // Compute actual wall-clock duration for the group from started_at + duration_ms
+      const startedAtArr = (flowJobsDuration?.started_at ?? []) as (string | null)[];
+      const durationMsArr = (flowJobsDuration?.duration_ms ?? []) as (number | null)[];
+      let totalMs: number | undefined;
+      {
+        let minStart = Infinity;
+        let maxEnd = -Infinity;
+        for (let i = 0; i < startedAtArr.length; i++) {
+          const sa = startedAtArr[i];
+          const dm = durationMsArr[i];
+          if (sa != null && dm != null) {
+            const startMs = new Date(sa).getTime();
+            minStart = Math.min(minStart, startMs);
+            maxEnd = Math.max(maxEnd, startMs + dm);
+          }
+        }
+        if (minStart < Infinity && maxEnd > -Infinity) {
+          totalMs = maxEnd - minStart;
+        }
+      }
       const durationStr = totalMs != null ? colors.dim(formatDuration(totalMs)) : "";
       console.log(`  ${icon} ${label}  ${durationStr}`);
 
       const flowJobsSuccess = (mod.flow_jobs_success ?? []) as boolean[];
-      const durationMs = (flowJobsDuration?.duration_ms ?? []) as number[];
       for (let iter = 0; iter < flowJobs.length; iter++) {
         const iterSuccess = flowJobsSuccess[iter];
         const iterIcon = iterSuccess === true ? colors.green("✓")
           : iterSuccess === false ? colors.red("✗")
           : colors.dim("·");
-        const iterDur = durationMs[iter] != null ? colors.dim(formatDuration(durationMs[iter])) : "";
+        const iterDur = durationMsArr[iter] != null ? colors.dim(formatDuration(durationMsArr[iter]!)) : "";
         const iterJobId = colors.dim(flowJobs[iter]);
         console.log(`    ${iterIcon} iteration ${iter}  ${iterJobId}  ${iterDur}`);
       }


### PR DESCRIPTION
## Summary
Fix the total duration displayed for for-loop/branchall groups in `wmill job get`. Previously it naively summed all iteration `duration_ms` values, which is wrong for parallel execution and doesn't reflect actual elapsed time. Now computes wall-clock time as `max(started_at[i] + duration_ms[i]) - min(started_at[i])`.

## Changes
- Replace `reduce((a, b) => a + b)` sum of `duration_ms` with wall-clock span from earliest start to latest completion
- Use both `started_at` and `duration_ms` arrays from `flow_jobs_duration` to compute the span

## Test plan
- [ ] Run `wmill job get <flow-job-id>` on a flow with a sequential for-loop — total should match elapsed time
- [ ] Run on a flow with a parallel for-loop — total should be ~max(individual) not sum(all)
- [ ] Verify individual iteration durations still display correctly

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes total duration for for-loop/branchall groups in `wmill job get` by computing real wall-clock time instead of summing iteration durations. This makes parallel flows report accurate elapsed time.

- **Bug Fixes**
  - Compute group duration as max(started_at + duration_ms) - min(started_at).
  - Use `flow_jobs_duration.started_at` and `duration_ms`, skipping nulls safely.
  - Per-iteration durations still display as before.

<sup>Written for commit c1381f735919e239bb484638a39b31f35b5ffa22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

