### PR TITLE
fix: hide serial types in column type dropdown for existing columns

### DIFF
--- a/frontend/src/lib/components/DBTableEditor.svelte
+++ b/frontend/src/lib/components/DBTableEditor.svelte
@@ -48,7 +48,7 @@
 	import DataTable from './table/DataTable.svelte'
 	import Head from './table/Head.svelte'
 	import { datatypeHasLength } from './apps/components/display/dbtable/utils'
-	import { DB_TYPES } from '$lib/consts'
+	import { DB_TYPES, NEW_COLUMN_ONLY_TYPES } from '$lib/consts'
 	import Popover from './meltComponents/Popover.svelte'
 	import ConfirmationModal from './common/confirmationModal/ConfirmationModal.svelte'
 	import { sendUserToast } from '$lib/toast'
@@ -63,6 +63,7 @@
 	import { Debounced } from 'runed'
 	import {
 		type TableEditorValues,
+		type TableEditorValuesColumn,
 		datatypeDefaultLength
 	} from './apps/components/display/dbtable/tableEditor'
 	import Alert from './common/alert/Alert.svelte'
@@ -94,6 +95,12 @@
 	}: Props = $props()
 
 	const columnTypes = DB_TYPES[untrack(() => dbType)]
+	function columnTypesFor(column: TableEditorValuesColumn): string[] {
+		if (column.initialName) {
+			return columnTypes.filter((t) => !NEW_COLUMN_ONLY_TYPES.includes(t))
+		}
+		return columnTypes
+	}
 	const defaultColumnType = (
 		{
 			postgresql: 'BIGSERIAL',
@@ -212,7 +219,7 @@
 											}
 										}
 									}
-									items={safeSelectItems(columnTypes)}
+									items={safeSelectItems(columnTypesFor(column))}
 									class="w-48"
 								/>
 								{#if column.initialName && column.name !== column.initialName}
@@ -490,7 +497,9 @@
 			</Alert>
 		{/if}
 		{#if askingForConfirmation?.codeContent}
-			<div class="bg-surface-secondary border border-surface-selected rounded-md p-2 relative group">
+			<div
+				class="bg-surface-secondary border border-surface-selected rounded-md p-2 relative group"
+			>
 				<button
 					class="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-surface-hover"
 					onclick={() => copyToClipboard(askingForConfirmation?.codeContent)}
@@ -498,7 +507,9 @@
 				>
 					<ClipboardCopy size={14} />
 				</button>
-				<pre class="whitespace-pre-wrap text-sm"><code>{askingForConfirmation.codeContent}</code></pre>
+				<pre class="whitespace-pre-wrap text-sm"
+					><code>{askingForConfirmation.codeContent}</code></pre
+				>
 			</div>
 		{/if}
 	</ConfirmationModal>

--- a/frontend/src/lib/consts.ts
+++ b/frontend/src/lib/consts.ts
@@ -255,6 +255,16 @@ export const DUCKDB_TYPES = [
 	'STRING'
 ]
 
+/** Types that are only valid for new columns (CREATE TABLE / ADD COLUMN), not for altering existing ones. */
+export const NEW_COLUMN_ONLY_TYPES: string[] = [
+	'SMALLSERIAL',
+	'SMALLSERIAL[]',
+	'SERIAL',
+	'SERIAL[]',
+	'BIGSERIAL',
+	'BIGSERIAL[]'
+]
+
 export const DB_TYPES: Record<DbType, string[]> = {
 	bigquery: BIGQUERY_TYPES,
 	ms_sql_server: MSSQL_TYPES,


### PR DESCRIPTION
## Summary
SMALLSERIAL/SERIAL/BIGSERIAL are pseudo-types that only work in CREATE TABLE or ADD COLUMN — they cannot be used when altering an existing column's type. This PR hides them from the type dropdown for existing columns in the DB Manager's ALTER TABLE editor.

## Changes
- Add `NEW_COLUMN_ONLY_TYPES` constant in `consts.ts` listing serial pseudo-types (designed to be extensible for future similar exceptions)
- Add `columnTypesFor(column)` helper in `DBTableEditor.svelte` that filters out new-column-only types for existing columns (those with `initialName`)
- New columns (even in ALTER TABLE's "Add" button) still show all types including serials

## Test plan
- [ ] Open an existing PostgreSQL table in DB Manager for editing (ALTER TABLE). Verify existing columns' type dropdowns do not show SMALLSERIAL, SERIAL, or BIGSERIAL
- [ ] Click "Add" to add a new column in ALTER TABLE — verify serial types are still available
- [ ] Create a new table — verify serial types are available for all columns

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide `SMALLSERIAL`, `SERIAL`, and `BIGSERIAL` (including array forms) from the type dropdown when editing existing PostgreSQL columns to prevent invalid ALTER operations. New columns still show these types.

- **Bug Fixes**
  - Added `NEW_COLUMN_ONLY_TYPES` in `consts.ts` for serial pseudo-types.
  - `DBTableEditor.svelte` uses `columnTypesFor(column)` to filter these for existing columns (those with `initialName`).

<sup>Written for commit f0568fc79c285d2c7915b705d16de2757a881c8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

