### PR TITLE
fix: improve S3 upload error reporting and remove timeout for streaming

### DIFF
--- a/backend/windmill-common/src/client.rs
+++ b/backend/windmill-common/src/client.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use reqwest::{Body, Response};
 use serde::de::DeserializeOwned;
 
-use crate::utils::HTTP_CLIENT;
+use crate::utils::{HTTP_CLIENT, HTTP_CLIENT_STREAMING};
 
 #[derive(Clone)]
 pub struct AuthedClient {
@@ -166,14 +166,17 @@ impl AuthedClient {
         if let Some(storage) = storage {
             query.push(("storage", storage));
         }
+        let url = format!(
+            "{}/api/w/{}/job_helpers/upload_s3_file",
+            self.base_internal_url, workspace_id
+        );
+        // Use the streaming HTTP client (no total request timeout) because the
+        // upload body is streamed and total time depends on data size.
         let response = self
             .force_client
             .as_ref()
-            .unwrap_or(&HTTP_CLIENT)
-            .post(format!(
-                "{}/api/w/{}/job_helpers/upload_s3_file",
-                self.base_internal_url, workspace_id
-            ))
+            .unwrap_or(&HTTP_CLIENT_STREAMING)
+            .post(&url)
             .query(&query)
             .header(
                 reqwest::header::ACCEPT,
@@ -187,12 +190,17 @@ impl AuthedClient {
             .body(Body::wrap_stream(body))
             .send()
             .await
-            .context(format!("Sent upload_s3_file request",))
-            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+            .context(format!("Failed to send upload_s3_file request to {url}"))?;
 
         match response.status().as_u16() {
             200u16 => Ok(()),
-            _ => Err(anyhow::anyhow!(response.text().await.unwrap_or_default()))?,
+            _ => {
+                let status = response.status();
+                let body = response.text().await.unwrap_or_default();
+                Err(anyhow::anyhow!(
+                    "upload_s3_file request to {url} failed with status {status}: {body}"
+                ))
+            }
         }
     }
 

--- a/backend/windmill-common/src/utils.rs
+++ b/backend/windmill-common/src/utils.rs
@@ -69,6 +69,19 @@ lazy_static::lazy_static! {
 
         builder.build().unwrap()
     };
+    /// HTTP client for streaming uploads (no total request timeout, only connect timeout).
+    /// Used for S3 file uploads where the body is streamed and total time depends on data size.
+    pub static ref HTTP_CLIENT_STREAMING: Client = {
+        let mut builder = reqwest::ClientBuilder::new()
+            .user_agent("windmill/beta")
+            .connect_timeout(std::time::Duration::from_secs(10));
+
+        if *FORCE_IPV4 {
+            builder = builder.local_address(std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)));
+        }
+
+        builder.build().unwrap()
+    };
     pub static ref HTTP_CLIENT_PERMISSIVE: Client = configure_client(reqwest::ClientBuilder::new()
         .user_agent("windmill/beta")
         .connect_timeout(std::time::Duration::from_secs(10))

--- a/backend/windmill-object-store/src/lib.rs
+++ b/backend/windmill-object-store/src/lib.rs
@@ -1083,14 +1083,29 @@ pub async fn convert_json_line_stream<E: Into<anyhow::Error>>(
                 Err(e) => tracing::error!("Error in blocking task: {:?}", &e),
             };
         }
-        task::spawn_blocking(move || {
+        let close_result = task::spawn_blocking(move || {
             writer.lock().unwrap().take().unwrap().close()?;
             drop(writer);
             Ok::<_, anyhow::Error>(())
         })
-        .await??;
+        .await;
+        match close_result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                tracing::error!("Error closing S3 stream writer: {:?}", e);
+                let _ = tx.send(Err(e)).await;
+            }
+            Err(e) => {
+                tracing::error!("S3 stream writer close task panicked: {:?}", e);
+                let _ = tx
+                    .send(Err(anyhow::anyhow!("writer close task panicked: {e}")))
+                    .await;
+            }
+        }
         drop(ctx);
-        tokio::fs::remove_file(&path).await?;
+        if let Err(e) = tokio::fs::remove_file(&path).await {
+            tracing::error!("Error removing temp file {}: {:?}", path.display(), e);
+        }
         Ok::<_, anyhow::Error>(())
     });
 


### PR DESCRIPTION
## Summary
Fixes unhelpful error messages when SQL S3 streaming uploads fail. Previously, the error chain was discarded by `.map_err(|e| anyhow::anyhow!(e.to_string()))`, causing all failures to show only "Sent upload_s3_file request" with no underlying cause. Also switches to a timeout-free HTTP client for streaming uploads since the 20s default timeout is inappropriate for large data transfers.

## Changes
- Add `HTTP_CLIENT_STREAMING` (connect-only timeout, no total request timeout) for S3 file uploads
- Fix error chain loss in `upload_s3_file` by removing `.map_err` that discarded the underlying error
- Improve error context message from "Sent upload_s3_file request" to "Failed to send upload_s3_file request to {url}"
- Include HTTP status code and response body in non-200 error messages
- Properly handle and propagate writer close errors in `convert_json_line_stream` instead of silently dropping them
- Log temp file cleanup errors instead of causing early return from the spawned task

## Test plan
- [ ] Run a PostgreSQL script with S3 streaming enabled on a large dataset and verify it completes
- [ ] Verify error messages now include the actual failure cause when S3 upload fails

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves S3 streaming upload reliability and error visibility. Removes the total HTTP timeout for streamed uploads and preserves full error context, including status and response body.

- **Bug Fixes**
  - Added `HTTP_CLIENT_STREAMING` (connect-only timeout) and used it for `upload_s3_file`.
  - Preserved error chains and improved context: “Failed to send upload_s3_file request to {url}”.
  - Included HTTP status code and response body for non-200 responses.
  - Propagated writer close errors and panic cases in `convert_json_line_stream` via the channel.
  - Logged temp file cleanup errors instead of exiting early.

<sup>Written for commit b6055b1cdee1575229ff8fc003587e5214d7d8d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

