### PR TITLE
fix: allow dedicated flow substeps to inherit parent tag

### DIFF
--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -3703,8 +3703,14 @@ async fn push_next_flow_job(
             )
         };
 
-        // Check tag availability for flow substeps to prevent abuse
-        if let Some(tag_str) = tag.as_deref().filter(|t| !t.is_empty()) {
+        // Check tag availability for flow substeps to prevent abuse.
+        // Skip when the substep inherits the parent flow's tag: that tag was already
+        // validated at flow push time, and for dedicated flows it is the auto-generated
+        // `{workspace_id}:flow/{path}` tag which is never in CUSTOM_TAGS.
+        if let Some(tag_str) = tag
+            .as_deref()
+            .filter(|t| !t.is_empty() && *t != flow_job.tag.as_str())
+        {
             check_tag_available_for_workspace_internal(
                 &db,
                 &flow_job.workspace_id,


### PR DESCRIPTION
## Summary

Dedicated flows fail to run for non-superadmin users with:

> Only super admins are allowed to use tags that are not included in the allowed CUSTOM_TAGS

The PR #7468 tag-abuse check added to `push_next_flow_job` re-validates every substep's tag against `CUSTOM_TAGS`. When a flow is marked dedicated, `push_inner` overrides the flow's tag to the auto-generated `{workspace_id}:flow/{path}`, which is never in `CUSTOM_TAGS`. The substeps then inherit this tag (flow_job.tag) and fail the check.

## Changes

- In `push_next_flow_job`, skip `check_tag_available_for_workspace_internal` when the substep's resolved tag equals `flow_job.tag`. The parent flow's tag was already validated at push time (or is an auto-generated dedicated tag that does not need CUSTOM_TAGS registration), so re-checking it on every substep is both redundant and wrong for dedicated flows.
- The check still runs when a substep overrides its own tag via `payload_tag.tag` (the real abuse vector PR #7468 targeted).

## Test plan

- [ ] Mark a flow as dedicated, configure a worker with the matching `dedicated_workers` entry, trigger the flow as a non-superadmin user, and confirm the substeps run on the dedicated worker instead of erroring out
- [ ] Trigger a regular (non-dedicated) flow whose substep sets a forbidden custom tag as a non-superadmin and confirm the abuse check still rejects it

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dedicated flows failing for non‑superadmin users by skipping tag re-validation on substeps that inherit the parent flow tag. Abuse checks still run when a substep sets its own tag, so `CUSTOM_TAGS` restrictions remain enforced.

- **Bug Fixes**
  - In `push_next_flow_job`, skip `check_tag_available_for_workspace_internal` when the substep tag equals `flow_job.tag` (already validated or an auto-generated dedicated tag like `{workspace_id}:flow/{path}`).
  - Continue validation when a substep provides a different tag via `payload_tag.tag`.

<sup>Written for commit cd86325efec7a866c9c3f269bfff4d481754d440. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

