### PR TITLE
fix: stop escalating missing email recipients to critical alert

### DIFF
--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -1408,6 +1408,7 @@ async fn send_email_with_instance_smtp(
     Json(send_email): Json<SendEmail>,
 ) -> error::Result<Json<String>> {
     use windmill_common::jobs::EMAIL_ERROR_HANDLER_USER_EMAIL;
+    use windmill_queue::SCHEDULE_ERROR_HANDLER_USER_EMAIL;
 
     if *CLOUD_HOSTED {
         tracing::warn!(
@@ -1416,41 +1417,45 @@ async fn send_email_with_instance_smtp(
         return Err(anyhow::anyhow!("Feature not supported in cloud hosted windmill").into());
     }
 
-    if send_email.email_recipients.is_none() {
-        use windmill_common::utils::report_critical_error;
+    let is_handler_job = authed.email == EMAIL_ERROR_HANDLER_USER_EMAIL
+        || authed.email == SCHEDULE_ERROR_HANDLER_USER_EMAIL;
 
-        tracing::error!("No recipient to send the error");
-        report_critical_error(
-            "No recipient to send the error".to_string(),
-            db.clone(),
-            Some(&w_id),
-            None,
-        )
-        .await;
-        return Err(anyhow::anyhow!("No recipient to send the error").into());
+    if !is_handler_job && !is_super_admin_email(&db, &authed.email).await? {
+        return Err(Error::NotAuthorized(
+            "Only super admin or whitelisted token can access email workspace error handler feature"
+                .to_string(),
+        ));
     }
 
-    if authed.email == EMAIL_ERROR_HANDLER_USER_EMAIL
-        || is_super_admin_email(&db, &authed.email).await?
-    {
-        let resp = send_workspace_trigger_failure_email_notification(
-            &db,
-            &w_id,
-            &send_email.job_id,
-            send_email.trigger_path.as_deref(),
-            send_email.runnable_path.as_deref(),
-            &send_email.email_recipients.unwrap(),
-            &send_email.error,
-        )
-        .await?;
+    // Missing/empty `email_recipients` is a schedule-level misconfiguration (e.g. the
+    // user picked the email handler in the UI but never entered an address). Log a warning
+    // and return a client error — do NOT escalate to `report_critical_error`, which would
+    // fan this out to the instance critical-error channels on every failed run.
+    let Some(recipients) = send_email.email_recipients.as_ref() else {
+        tracing::warn!(
+            workspace_id = %w_id,
+            trigger_path = ?send_email.trigger_path,
+            runnable_path = ?send_email.runnable_path,
+            "Email error handler invoked without any `email_recipients` in on_failure_extra_args; \
+             skipping send. Configure recipients on the schedule / workspace error handler."
+        );
+        return Err(Error::BadRequest(
+            "Email error handler invoked without any `email_recipients` configured".to_string(),
+        ));
+    };
 
-        return Ok(Json(resp));
-    }
+    let resp = send_workspace_trigger_failure_email_notification(
+        &db,
+        &w_id,
+        &send_email.job_id,
+        send_email.trigger_path.as_deref(),
+        send_email.runnable_path.as_deref(),
+        recipients,
+        &send_email.error,
+    )
+    .await?;
 
-    return Err(Error::NotAuthorized(
-        "Only super admin or whitelisted token can access email workspace error handler feature"
-            .to_string(),
-    ));
+    Ok(Json(resp))
 }
 
 #[cfg(not(all(feature = "enterprise", feature = "smtp")))]


### PR DESCRIPTION
## Summary

Customer-reported bug: the instance critical-error channels were receiving noisy `No recipient to send the error` alerts on every run of certain failing schedules. Root cause turned out to be two compounding bugs in the `send_email_with_instance_smtp` endpoint (the one the `hub/.../workspace-or-error-handler-email` script POSTs to).

**Noise amplifier.** When the hub script arrived with a missing/empty `email_recipients` (can happen whenever a schedule has `on_failure = hub/.../workspace-or-error-handler-email` but `on_failure_extra_args.email_recipients` is empty or absent — e.g. the user flipped a schedule from Slack → Email in the UI and never entered an address), the endpoint called `report_critical_error(...)`. That fans the alert out over the instance's `CRITICAL_ERROR_CHANNELS` on every failed run, turning a per-schedule misconfig into a system-level page. Combined with `#[serde(deserialize_with = "empty_as_none")]` on `SendEmail::email_recipients`, an empty array `[]` coming from the hub script is silently turned into `None`.

**Schedule-level email handlers were effectively broken.** The endpoint's auth gate only allowed `EMAIL_ERROR_HANDLER_USER_EMAIL` (the identity assigned to the workspace-level email handler). But `get_email_and_permissioned_as` in `windmill-queue/src/jobs.rs:2078-2082` assigns schedule-level handlers the identity `SCHEDULE_ERROR_HANDLER_USER_EMAIL` regardless of handler type, so the hub script job running on behalf of a schedule would be rejected with `NotAuthorized` even when recipients *were* configured. The `is_none()` check happened to run first, which is why the symptom everyone saw was "No recipient…" and not the auth error — but both paths were defective.

## Changes

- `send_email_with_instance_smtp` (`backend/windmill-api/src/jobs.rs:1403-1459`)
  - Missing/empty `email_recipients` no longer calls `report_critical_error`. Logs a `WARN` with `workspace_id` / `trigger_path` / `runnable_path` and returns a plain `400 BadRequest`. The instance critical-alert loop is broken.
  - Auth gate now also accepts `SCHEDULE_ERROR_HANDLER_USER_EMAIL`, so schedule-level email handlers can actually authorize against the endpoint once recipients are configured.
  - Reordered checks so auth runs before payload validation — avoids leaking endpoint behavior to unauthenticated callers.
  - Replaced the `.unwrap()` on `email_recipients` with a `let Some(recipients) = … else { … }`.

## Test plan

- [ ] Self-hosted instance with SMTP configured. Schedule a script, set its failure handler to **Email** but leave recipients empty, then force a failure. Confirm the server logs `WARN Email error handler invoked without any \`email_recipients\`…` **and no critical error email is sent to the instance critical-error channels**. Before this PR, every failed run would fire a critical alert.
- [ ] Same scenario, but add a valid recipient to the schedule's email handler. Confirm the email actually arrives on failure — this is the path that was previously blocked by the missing `SCHEDULE_ERROR_HANDLER_USER_EMAIL` in the auth whitelist.
- [ ] Workspace-level email error handler with a valid recipient still works (unchanged behavior, covered by existing auth identity).
- [ ] Cloud-hosted path still returns `Feature not supported in cloud hosted windmill` (unchanged).

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop escalating missing email recipient cases to critical alerts and fix auth for schedule-level email handlers using instance SMTP. Reduces alert noise and restores expected failure emails.

- **Bug Fixes**
  - `send_email_with_instance_smtp`: if `email_recipients` is missing/empty, log a WARN with context and return `400 BadRequest` (no `report_critical_error`).
  - Allow `SCHEDULE_ERROR_HANDLER_USER_EMAIL` to pass the auth gate; run auth before payload validation.
  - Replace `.unwrap()` with a safe `let Some(recipients)`; cloud-hosted path remains unchanged.

<sup>Written for commit dcfd3fc7f1f7796c4ea3d1cdc73757371c6a5603. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

