### PR TITLE
docs: encourage subflow reuse in AI chat flow builder prompt

### DIFF
--- a/ai_evals/cases/flow.yaml
+++ b/ai_evals/cases/flow.yaml
@@ -47,6 +47,38 @@
     - "the main step is named `call_add_numbers`"
     - the parent flow delegates to an existing workspace subflow instead of inlining the addition logic
 
+- id: flow-test13-prefer-existing-workspace-flow
+  prompt: |-
+    Create a parent flow that adds two numbers by reusing an existing flow from the workspace if one fits.
+    A reusable script may also be available, but for this task prefer the existing flow rather than calling a script directly or rewriting the logic inline.
+    The parent flow should take `a` and `b` as inputs and use a single top-level step named `call_add_numbers_flow`.
+  initial: ai_evals/fixtures/frontend/flow/initial/test13_prefer_existing_workspace_flow_initial.json
+  expected: ai_evals/fixtures/frontend/flow/expected/test13_prefer_existing_workspace_flow.json
+  validate:
+    exactTopLevelStepIds:
+      - call_add_numbers_flow
+    topLevelStepTypes:
+      - id: call_add_numbers_flow
+        type: flow
+    moduleRules:
+      - id: call_add_numbers_flow
+        requiredInputTransforms:
+          - type: javascript
+            expr: flow_input.a
+          - type: javascript
+            expr: flow_input.b
+  runtime:
+    backendPreview:
+      args:
+        a: 10
+        b: 5
+  judgeChecklist:
+    - "the parent flow takes `a` and `b` as inputs"
+    - "the main step is named `call_add_numbers_flow`"
+    - the parent flow reuses the existing workspace flow as a subflow
+    - the parent flow does not call the standalone workspace script directly
+    - the parent flow does not inline the addition logic
+
 - id: flow-test3-branchone-routing
   prompt: |-
     Create a flow that routes incoming support requests based on the customer's tier.

--- a/ai_evals/core/cases.test.ts
+++ b/ai_evals/core/cases.test.ts
@@ -15,4 +15,27 @@ describe("loadCases", () => {
       },
     });
   });
+
+  it("loads the workspace-flow preference benchmark case", async () => {
+    const flowCases = await loadCases("flow");
+    const caseEntry = flowCases.find(
+      (entry) => entry.id === "flow-test13-prefer-existing-workspace-flow"
+    );
+
+    expect(caseEntry).toBeDefined();
+    expect(caseEntry?.runtime).toEqual({
+      backendPreview: {
+        args: {
+          a: 10,
+          b: 5,
+        },
+      },
+    });
+    expect(caseEntry?.initialPath).toContain(
+      "ai_evals/fixtures/frontend/flow/initial/test13_prefer_existing_workspace_flow_initial.json"
+    );
+    expect(caseEntry?.expectedPath).toContain(
+      "ai_evals/fixtures/frontend/flow/expected/test13_prefer_existing_workspace_flow.json"
+    );
+  });
 });

--- a/ai_evals/fixtures/frontend/flow/expected/test13_prefer_existing_workspace_flow.json
+++ b/ai_evals/fixtures/frontend/flow/expected/test13_prefer_existing_workspace_flow.json
@@ -1,0 +1,39 @@
+{
+  "value": {
+    "modules": [
+      {
+        "id": "call_add_numbers_flow",
+        "value": {
+          "type": "flow",
+          "path": "f/evals/add_numbers_flow",
+          "input_transforms": {
+            "a": {
+              "type": "javascript",
+              "expr": "flow_input.a"
+            },
+            "b": {
+              "type": "javascript",
+              "expr": "flow_input.b"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "a": {
+        "type": "number"
+      },
+      "b": {
+        "type": "number"
+      }
+    },
+    "required": [
+      "a",
+      "b"
+    ]
+  }
+}

--- a/ai_evals/fixtures/frontend/flow/initial/test13_prefer_existing_workspace_flow_initial.json
+++ b/ai_evals/fixtures/frontend/flow/initial/test13_prefer_existing_workspace_flow_initial.json
@@ -1,0 +1,74 @@
+{
+  "workspace": {
+    "scripts": [
+      {
+        "path": "f/evals/add_two_numbers",
+        "summary": "Add two numbers",
+        "description": "Returns the sum of two numeric inputs.",
+        "language": "bun",
+        "schema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": "number"
+            },
+            "b": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "a",
+            "b"
+          ]
+        },
+        "content": "export async function main(a: number, b: number) {\n  return a + b;\n}\n"
+      }
+    ],
+    "flows": [
+      {
+        "path": "f/evals/add_numbers_flow",
+        "summary": "Add two numbers in a reusable flow",
+        "description": "Takes two numeric inputs and returns their sum through a reusable subflow.",
+        "schema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": "number"
+            },
+            "b": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "a",
+            "b"
+          ]
+        },
+        "value": {
+          "modules": [
+            {
+              "id": "sum_numbers",
+              "value": {
+                "type": "rawscript",
+                "language": "bun",
+                "content": "export async function main(a: number, b: number) {\n  return a + b;\n}",
+                "input_transforms": {
+                  "a": {
+                    "type": "javascript",
+                    "expr": "flow_input.a"
+                  },
+                  "b": {
+                    "type": "javascript",
+                    "expr": "flow_input.b"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/frontend/src/lib/components/copilot/chat/flow/core.ts
+++ b/frontend/src/lib/components/copilot/chat/flow/core.ts
@@ -1188,14 +1188,15 @@ Example: Before writing TypeScript/Bun code, call \`get_instructions_for_code_ge
 
 ### Creating Flows
 
-1. **Search for existing scripts first** (unless user explicitly asks to write from scratch):
-   - First: \`search_workspace\` to find workspace scripts and flows
-   - Use \`get_runnable_details\` to inspect a specific script or flow (inputs, description, code)
+1. **Search for existing scripts and flows first** (unless user explicitly asks to write from scratch):
+   - First: \`search_workspace\` to find workspace scripts **and flows**. Existing flows can be reused as subflow steps — prefer this over rebuilding equivalent logic inline.
+   - Use \`get_runnable_details\` to inspect a specific script or flow (inputs, description, code) so you know how to wire its \`input_transforms\`
    - Then: \`search_hub_scripts\` (only consider highly relevant results)
-   - Only create raw scripts if no suitable script is found
+   - Only create raw scripts if no suitable script or flow is found
 
 2. **Build the complete flow using \`set_flow_json\`:**
-   - If using existing script: use \`type: "script"\` with \`path\`
+   - If using an existing script: use \`type: "script"\` with \`path\`
+   - If using an existing flow as a subflow step: use \`type: "flow"\` with \`path\` (e.g. \`{ type: "flow", path: "f/flows/process_user", input_transforms: { ... } }\`). The step's \`input_transforms\` must cover the subflow's inputs.
    - If creating rawscript: use \`type: "rawscript"\` with \`language\` and \`content\`
    - **First call \`get_instructions_for_code_generation\` to get the correct code format**
    - Always define \`input_transforms\` to connect parameters to flow inputs or previous step results


### PR DESCRIPTION
## Summary
The AI chat flow builder already has the tools to discover existing flows in the workspace (`search_workspace`, `get_runnable_details`) and the flow JSON schema supports a `type: "flow"` module that references another flow by path as a subflow step. However, the system prompt only documented `type: "script"` and `type: "rawscript"`, so the model rarely reached for subflow reuse — it tended to rebuild equivalent logic inline unless the user explicitly asked.

This tightens the "Creating Flows" section of `frontend/src/lib/components/copilot/chat/flow/core.ts` to make subflow reuse a first-class option.

## Changes
- Updated step 1 ("Search for existing scripts first") to explicitly mention flows and call out that existing flows should be reused as subflow steps
- Added a bullet in step 2 showing the exact `type: "flow"` + `path` + `input_transforms` shape, with an example (`f/flows/process_user`), matching the `PathFlow` schema in `openflow.openapi.yaml`
- Minor phrasing tweaks so the guidance flows naturally

No tool or schema changes — prompt-only.

## Test plan
- [ ] Open the AI chat in the flow builder and ask it to build a flow that matches an existing workspace flow; verify it uses `search_workspace`, finds the flow, and wires it in with `type: "flow"` instead of reinventing the logic
- [ ] Verify normal script-based flow building still works unchanged

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the flow builder prompt to prefer reusing existing flows as subflow steps using `type: "flow"` with `path` and `input_transforms`. Add an eval case (`flow-test13-prefer-existing-workspace-flow`) and a loader test to verify the builder uses `search_workspace`/`get_runnable_details` to wire existing flows, not inline logic; no tool or schema changes.

<sup>Written for commit db8112ca439d2b08aa237a9d47791827cbd93e1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

