### PR TITLE
fix: skip nsjail uidmap/gidmap when DISABLE_NUSER=true

### DIFF
--- a/backend/windmill-worker/nsjail/run.bun.config.proto
+++ b/backend/windmill-worker/nsjail/run.bun.config.proto
@@ -15,17 +15,7 @@ clone_newnet: false
 clone_newuser: {CLONE_NEWUSER}
 clone_newcgroup: false
 
-uidmap {
-    inside_id: "1000"
-    outside_id: ""
-    count: 1
-}
-
-gidmap {
-    inside_id: "1000"
-    outside_id: ""
-    count: 1
-}
+{UIDGIDMAP}
 
 skip_setsid: true
 keep_caps: false

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -2079,6 +2079,9 @@ try {{
                 .replace("{LANG}", if annotation.nodejs { "nodejs" } else { "bun" })
                 .replace("{JOB_DIR}", job_dir)
                 .replace("{CLONE_NEWUSER}", &(!*DISABLE_NUSER).to_string())
+                .replace("{UIDGIDMAP}", if *DISABLE_NUSER { "" } else {
+                    "uidmap {\n    inside_id: \"1000\"\n    outside_id: \"\"\n    count: 1\n}\n\ngidmap {\n    inside_id: \"1000\"\n    outside_id: \"\"\n    count: 1\n}"
+                })
                 .replace(
                     "{SHARED_MOUNT}",
                     &shared_mount.replace(


### PR DESCRIPTION
## Summary
When `DISABLE_NUSER=true` (no user namespaces), nsjail's hardcoded `uidmap`/`gidmap` in the bun config causes `setuid(1000)`, making the jailed process unable to write to root-owned bind-mounted files like `result.json` (EACCES). This makes nsjail unusable for bun/TypeScript jobs in non-privileged Kubernetes containers.

## Changes
- Replace hardcoded `uidmap`/`gidmap` blocks in `run.bun.config.proto` with a `{UIDGIDMAP}` template placeholder
- In `bun_executor.rs`, conditionally inject `uidmap`/`gidmap` only when user namespaces are enabled (`DISABLE_NUSER=false`), and inject empty string when disabled

## Context
The `uidmap`/`gidmap` was added in #8058 for the AI sandbox feature to run jailed bun processes as UID 1000. However, it was added unconditionally to the bun nsjail config, breaking `DISABLE_NUSER=true` which is needed for running nsjail without `privileged: true` in Kubernetes (where OCI runtime `/proc` masking prevents user namespace creation).

With this fix, `DISABLE_NUSER=true` + capabilities `SYS_ADMIN`, `SYS_RESOURCE`, `SETPCAP` is sufficient to run nsjail in non-privileged containers — no `privileged: true` needed.

## Test plan
- [ ] Run bun script with `DISABLE_NUSER=true` + `DISABLE_NSJAIL=false` in non-privileged Docker container (`--cap-add SYS_ADMIN --cap-add SYS_RESOURCE --cap-add SETPCAP`)
- [ ] Run bun script with `DISABLE_NUSER=false` (default) in privileged container — verify uidmap still applied
- [ ] Run Python/Bash script with `DISABLE_NUSER=true` — verify unaffected

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip `uidmap`/`gidmap` in nsjail when `DISABLE_NUSER=true` to avoid forced `setuid(1000)` and EACCES on root-owned bind mounts. This restores nsjail support for bun/TypeScript jobs in non-privileged Kubernetes pods.

- **Bug Fixes**
  - Replaced hardcoded maps in `run.bun.config.proto` with `{UIDGIDMAP}` placeholder.
  - In `bun_executor.rs`, only inject uid/gid maps when user namespaces are enabled; inject empty string otherwise.
  - Keeps existing behavior when `DISABLE_NUSER=false`.

<sup>Written for commit 9ad2d3e59d1c0b88e10f4c86925b256da99e76a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

