### PR TITLE
fix: enforce auth on get_flow_debug_info root job

### DIFF
--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -818,6 +818,7 @@ async fn get_flow_job_debug_info(
     Path((w_id, id)): Path<(String, Uuid)>,
 ) -> error::Result<Response> {
     let job = GetQuery::new()
+        .with_auth(&opt_authed)
         .fetch_queued((&db).into(), &id, &w_id)
         .await?;
     if let Some(job) = job {


### PR DESCRIPTION
## Summary

Adds the missing `.with_auth(&opt_authed)` call on the root job fetch in `get_flow_job_debug_info` so the anonymous-user access check actually runs for this endpoint.

Fixes [GHSA-q9m8-8887-r38q](https://github.com/windmill-labs/windmill/security/advisories/GHSA-q9m8-8887-r38q).

## Details

`get_flow_job_debug_info` is reachable via `GET /api/w/{workspace}/jobs_u/get_flow_debug_info/{id}`, which is mounted under the unauthenticated `workspace_unauthed_service`. Every other handler on that service (`get_job`, `get_completed_job`, `get_completed_job_result_maybe`, `get_flow_all_logs`) calls `.with_auth(&opt_authed)` before fetching, which enables the check inside `GetQuery::check_auth` that refuses non-anonymous jobs when the caller is unauthenticated.

The root-job fetch in this handler (`jobs.rs:820`) was missing that call, while the child-job fetches inside the same function (`jobs.rs:859-860`) already had it — so the gap was clearly an oversight, not intentional.

Effect: an unauthenticated caller who knew a flow job UUID could read the full root-job debug info of that flow, including arguments passed as flow inputs (passwords, API keys, tokens).

## Test plan

- [ ] Unauthenticated GET on a non-anonymous flow job's debug info returns 400 ("As a non logged in user, you can only see jobs ran by anonymous users")
- [ ] Unauthenticated GET on an anonymous flow job still works
- [ ] Authenticated GET behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce authentication on the root job fetch in `get_flow_job_debug_info` (`GET /api/w/{workspace}/jobs_u/get_flow_debug_info/{id}`) to close a gap that allowed unauthenticated access to non-anonymous flow job debug info.

- **Bug Fixes**
  - Added `.with_auth(&opt_authed)` to the root job `GetQuery`, enabling the anonymous-user access check.
  - Unauthenticated requests to non-anonymous jobs now return 400; behavior for anonymous and authenticated requests is unchanged.

<sup>Written for commit b8ab26d0b7fb0cb41ee59709c5c692a8bd5e69cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

