### PR TITLE
fix: classify fileset resource files with script extensions correctly

### DIFF
--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -1986,7 +1986,7 @@ interface ChangeTracker {
 }
 
 async function addToChangedIfNotExists(p: string, tracker: ChangeTracker) {
-  const isScript = exts.some((e) => p.endsWith(e));
+  const isScript = exts.some((e) => p.endsWith(e)) && !isFileResource(p) && !isFilesetResource(p);
   if (isScript) {
     if (isFlowPath(p)) {
       const folder = extractFolderPath(p, "flow")!;

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -286,6 +286,9 @@ export function getTypeStrFromPath(
   if (p.startsWith("dependencies" + SEP)) {
     return "workspace_dependencies";
   }
+  if (isFileResource(p) || isFilesetResource(p)) {
+    return "resource";
+  }
   const parsed = path.parse(p);
   if (
     parsed.ext == ".go" ||
@@ -349,9 +352,6 @@ export function getTypeStrFromPath(
   ) {
     return typeEnding;
   } else {
-    if (isFileResource(p) || isFilesetResource(p)) {
-      return "resource";
-    }
     throw new Error("Could not infer type of path " + JSON.stringify(parsed));
   }
 }

--- a/cli/test/utils_unit.test.ts
+++ b/cli/test/utils_unit.test.ts
@@ -270,6 +270,10 @@ describe("getTypeStrFromPath", () => {
   test("detects fileset resource files as resource type", () => {
     expect(getTypeStrFromPath("f/test/my_config.fileset/config.yaml")).toBe("resource");
     expect(getTypeStrFromPath("u/admin/templates.fileset/path/to/file.txt")).toBe("resource");
+    // fileset files with script-like extensions should still be detected as resource
+    expect(getTypeStrFromPath("f/test/my_queries.fileset/query.sql")).toBe("resource");
+    expect(getTypeStrFromPath("f/test/my_queries.fileset/script.py")).toBe("resource");
+    expect(getTypeStrFromPath("f/test/my_queries.fileset/nested/dir/file.ts")).toBe("resource");
   });
 
   test("throws for unknown type", () => {


### PR DESCRIPTION
## Summary
Fileset resource files with script-like extensions (`.sql`, `.py`, `.ts`, etc.) were incorrectly classified as scripts during `wmill sync push` and `wmill sync pull`, causing `Error: Invalid language: .sql` failures.

## Changes
- Move `isFileResource`/`isFilesetResource` check before extension-based script classification in `getTypeStrFromPath` so fileset files are detected as resources first
- Add `!isFileResource(p) && !isFilesetResource(p)` guard to `addToChangedIfNotExists` so fileset files aren't tracked as scripts during sync operations
- Add test cases for `.sql`, `.py`, and `.ts` files inside `.fileset/` directories

## Test plan
- [ ] Create a fileset resource type with `.sql` files, run `wmill sync pull` — should succeed without "Invalid language" error
- [ ] Run `wmill sync push` with the same fileset — should succeed
- [ ] Verify regular `.sql` scripts (e.g. `.pg.sql`) still sync correctly
- [ ] Run `bun test test/utils_unit.test.ts` — all tests pass

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misclassification of `.fileset/` resource files with script-like extensions during `wmill sync push/pull`, eliminating “Invalid language: .sql” errors. Files inside `.fileset/` are now always treated as resources, even if they end with `.sql`, `.py`, `.ts`, etc.

- **Bug Fixes**
  - In `getTypeStrFromPath`, prioritize `isFileResource`/`isFilesetResource` before extension checks to return `resource`.
  - In sync tracking, only flag scripts if extension matches and the path is not a file or fileset resource.
  - Added tests for `.sql`, `.py`, `.ts` within `.fileset/` to cover the fix.

<sup>Written for commit 710a5e19ed78daa49dbd297beec451e1b98ca0a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

