### PR TITLE
fix: include workspacedependencies in default git sync include_type

### DIFF
--- a/frontend/src/lib/components/git_sync/GitSyncContext.svelte.ts
+++ b/frontend/src/lib/components/git_sync/GitSyncContext.svelte.ts
@@ -408,7 +408,7 @@ export function createGitSyncContext(workspace: string) {
 							const defaultTypes: GitSyncObjectType[] =
 								workspaceLegacyIncludeType.length > 0
 									? [...workspaceLegacyIncludeType]
-									: ['script', 'flow', 'app', 'folder']
+									: ['script', 'flow', 'app', 'folder', 'workspacedependencies']
 
 							let repoSettings: SettingsObject
 							if (isRepoLegacy) {
@@ -437,6 +437,7 @@ export function createGitSyncContext(workspace: string) {
 										'script',
 										'flow',
 										'app',
+										'folder',
 										'workspacedependencies'
 									]
 								}

--- a/frontend/src/lib/components/git_sync/GitSyncContext.svelte.ts
+++ b/frontend/src/lib/components/git_sync/GitSyncContext.svelte.ts
@@ -194,7 +194,7 @@ export function createGitSyncContext(workspace: string) {
 				include_path: ['f/**'],
 				exclude_path: [],
 				extra_include_path: [],
-				include_type: ['script', 'flow', 'app', 'folder']
+				include_type: ['script', 'flow', 'app', 'folder', 'workspacedependencies']
 			},
 			exclude_types_override: [],
 			legacyImported: false,
@@ -433,7 +433,12 @@ export function createGitSyncContext(workspace: string) {
 									include_path: repo.settings?.include_path ?? ['f/**'],
 									exclude_path: repo.settings?.exclude_path ?? [],
 									extra_include_path: repo.settings?.extra_include_path ?? [],
-									include_type: repo.settings?.include_type ?? ['script', 'flow', 'app']
+									include_type: repo.settings?.include_type ?? [
+										'script',
+										'flow',
+										'app',
+										'workspacedependencies'
+									]
 								}
 							}
 
@@ -662,7 +667,7 @@ export function createGitSyncContext(workspace: string) {
 				include_path: ['f/**'],
 				exclude_path: [],
 				extra_include_path: [],
-				include_type: ['script', 'flow', 'app', 'folder']
+				include_type: ['script', 'flow', 'app', 'folder', 'workspacedependencies']
 			},
 			exclude_types_override: [],
 			legacyImported: false,
@@ -689,7 +694,7 @@ export function createGitSyncContext(workspace: string) {
 				include_path: ['f/**'],
 				exclude_path: [],
 				extra_include_path: [],
-				include_type: ['script', 'flow', 'app', 'folder']
+				include_type: ['script', 'flow', 'app', 'folder', 'workspacedependencies']
 			},
 			exclude_types_override: [],
 			legacyImported: false,

--- a/frontend/src/lib/components/workspaceSettings/GitSyncFilterSettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/GitSyncFilterSettings.svelte
@@ -30,7 +30,13 @@
 	let {
 		git_repo_resource_path = $bindable(''),
 		include_path = $bindable(['f/**']),
-		include_type = $bindable(['script', 'flow', 'app', 'folder'] as GitSyncObjectType[]),
+		include_type = $bindable([
+			'script',
+			'flow',
+			'app',
+			'folder',
+			'workspacedependencies'
+		] as GitSyncObjectType[]),
 		exclude_types_override = $bindable([] as GitSyncObjectType[]),
 		isLegacyRepo = false,
 		excludes = $bindable([] as string[]),


### PR DESCRIPTION
## Summary
Workspace dependencies were not included in the default `include_type` for git sync, meaning they wouldn't be synced unless the user explicitly added `workspacedependencies` to their type filter config.

## Changes
- Added `'workspacedependencies'` to all 4 default `include_type` arrays in `GitSyncContext.svelte.ts`:
  - New connection defaults (2 instances: regular + individual branch)
  - New-format repo fallback (when `repo.settings?.include_type` is missing)
  - Legacy-imported repo template

## Test plan
- [ ] Create a new git sync connection in workspace settings — verify "Workspace Dependencies" is checked by default in the type filter
- [ ] Create/edit a workspace dependency — verify a commit is pushed to the synced repo

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include `workspacedependencies` in the default git sync `include_type` so workspace dependency changes sync by default. Covers new connections (incl. individual-branch), legacy and new-format fallbacks when `repo.settings.include_type` is missing; also adds `folder` to the new-format fallback and aligns `GitSyncFilterSettings` defaults.

<sup>Written for commit 7979ac93f024c8c572cceef28848cdf57f937729. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

