### PR TITLE
fix: make sync pull produce consistent wmill-lock.yaml hashes

### DIFF
--- a/cli/src/commands/app/app_metadata.ts
+++ b/cli/src/commands/app/app_metadata.ts
@@ -92,7 +92,12 @@ async function generateAppHash(
     }
   }
 
-  return { ...hashes, [TOP_HASH]: await generateHash(JSON.stringify(hashes)) };
+  // Sort keys so the top hash is deterministic regardless of filesystem readdir order
+  const sortedHashes: Record<string, string> = {};
+  for (const k of Object.keys(hashes).sort()) {
+    sortedHashes[k] = hashes[k];
+  }
+  return { ...sortedHashes, [TOP_HASH]: await generateHash(JSON.stringify(sortedHashes)) };
 }
 
 /**

--- a/cli/src/commands/flow/flow_metadata.ts
+++ b/cli/src/commands/flow/flow_metadata.ts
@@ -51,7 +51,12 @@ async function generateFlowHash(
       );
     }
   }
-  return { ...hashes, [TOP_HASH]: await generateHash(JSON.stringify(hashes)) };
+  // Sort keys so the top hash is deterministic regardless of filesystem readdir order
+  const sortedHashes: Record<string, string> = {};
+  for (const k of Object.keys(hashes).sort()) {
+    sortedHashes[k] = hashes[k];
+  }
+  return { ...sortedHashes, [TOP_HASH]: await generateHash(JSON.stringify(sortedHashes)) };
 }
 /**
  * Result of generating flow locks, including which scripts were updated

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -2553,6 +2553,7 @@ export async function pull(
       ),
     );
   }
+
 }
 
 function prettyChanges(

--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -380,7 +380,10 @@ export async function generateScriptMetadataInternal(
     }
   }
 
-  const metadataContentUsedForHash = newMetadataContent;
+  // When justUpdateMetadataLock (sync pull), the metadata file is NOT rewritten,
+  // so use the raw file content for hashing to avoid YAML round-trip differences
+  // (e.g. hand-edited YAML that serializes differently after parse + stringify).
+  const metadataContentUsedForHash = justUpdateMetadataLock ? metadataContent : newMetadataContent;
 
   hash = await generateScriptHash(
     depsForHash,


### PR DESCRIPTION
## Summary

After `wmill sync pull`, running `wmill generate-metadata` would report many items as stale even though nothing changed. This was caused by two issues in how `wmill-lock.yaml` hashes were computed.

## Changes

- **Sort hash keys in `generateFlowHash` / `generateAppHash`**: The top hash (`__flow_hash` / `__app_hash`) used `JSON.stringify(hashes)` which preserves insertion order. Since insertion order comes from `readdir`, different machines/filesystems produce different hashes for the same content. Now keys are sorted before stringifying.

- **Use raw metadata content for script hash when `justUpdateMetadataLock`**: During sync pull, the metadata file is not rewritten, but the stored hash was computed from re-serialized YAML (`yamlStringify(yamlParse(rawContent))`). For hand-edited YAML files, this round-trip produces different output, causing hash mismatches. Now uses the raw file content when the file isn't being rewritten.

## Test plan

- [ ] Run `wmill sync pull` then `wmill generate-metadata --dry-run` on a workspace where items were previously reported as stale — verify fewer false positives
- [ ] Existing tests: 97 pass, 0 fail across `sync_pull_push.test.ts` and `unified_generate_metadata.test.ts`

---
Generated with [Claude Code](https://claude.com/claude-code)