### PR TITLE
feat: generate tsconfig.json during wmill init for IDE type support

### DIFF
--- a/cli/src/commands/resource-type/resource-type.ts
+++ b/cli/src/commands/resource-type/resource-type.ts
@@ -12,6 +12,7 @@ import {
 } from "../../types.ts";
 import { requireLogin } from "../../core/auth.ts";
 import { resolveWorkspace } from "../../core/context.ts";
+import { generateTsconfigForIde } from "./tsconfig.ts";
 import { colors } from "@cliffy/ansi/colors";
 import { Command } from "@cliffy/command";
 import { Table } from "@cliffy/table";
@@ -189,6 +190,8 @@ export async function generateRTNamespace(opts: GlobalOptions) {
       "Created rt.d.ts with resource types namespace (RT) for TypeScript."
     )
   );
+
+  await generateTsconfigForIde();
 }
 
 const command = new Command()

--- a/cli/src/commands/resource-type/tsconfig.ts
+++ b/cli/src/commands/resource-type/tsconfig.ts
@@ -1,0 +1,87 @@
+import { execSync } from "node:child_process";
+import { existsSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import { colors } from "@cliffy/ansi/colors";
+import * as log from "../../core/log.ts";
+import { readConfigFile } from "../../core/conf.ts";
+
+export async function generateTsconfigForIde() {
+  const tsconfigPath = path.join(process.cwd(), "tsconfig.json");
+  if (existsSync(tsconfigPath)) {
+    log.info(colors.gray("tsconfig.json already exists, skipping"));
+    return;
+  }
+
+  let defaultTs: "bun" | "deno" = "bun";
+  try {
+    const conf = await readConfigFile({ warnIfMissing: false });
+    if (conf?.defaultTs === "deno") {
+      defaultTs = "deno";
+    }
+  } catch {
+    // fall back to bun if wmill.yaml is missing or unreadable
+  }
+
+  // Only reference bun-types in tsconfig if it's actually available; otherwise
+  // the IDE will flag the missing type definitions.
+  const bunTypesAvailable =
+    defaultTs === "bun" ? ensureBunTypesAvailable() : false;
+
+  const tsconfig: {
+    compilerOptions: Record<string, unknown>;
+    include: string[];
+  } = {
+    compilerOptions: {
+      target: "ESNext",
+      module: "ESNext",
+      moduleResolution: "bundler",
+      noEmit: true,
+      strict: false,
+    },
+    include: ["**/*.ts", "rt.d.ts"],
+  };
+
+  if (bunTypesAvailable) {
+    tsconfig.compilerOptions.types = ["bun-types"];
+  }
+
+  writeFileSync(tsconfigPath, JSON.stringify(tsconfig, null, 2) + "\n");
+  log.info(colors.green("Created tsconfig.json for IDE type support."));
+}
+
+function ensureBunTypesAvailable(): boolean {
+  const cwd = process.cwd();
+  if (existsSync(path.join(cwd, "node_modules", "bun-types"))) {
+    return true;
+  }
+
+  try {
+    execSync("bun --version", { stdio: "ignore" });
+  } catch {
+    log.info(
+      "Install bun (https://bun.sh) then run 'bun add -d bun-types' and add \"types\": [\"bun-types\"] to tsconfig.json for Bun API autocompletion."
+    );
+    return false;
+  }
+
+  try {
+    log.info(
+      colors.yellow("Installing bun-types with 'bun add -d bun-types'...")
+    );
+    execSync("bun add -d bun-types", { stdio: "inherit" });
+    log.info(colors.green("Installed bun-types."));
+    return true;
+  } catch (e) {
+    log.warn(
+      `Failed to install bun-types automatically: ${
+        e instanceof Error ? e.message : e
+      }`
+    );
+    log.info(
+      "Run 'bun add -d bun-types' manually and add \"types\": [\"bun-types\"] to tsconfig.json for Bun API autocompletion."
+    );
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

`wmill init` and `wmill resource-type generate-namespace` already create `rt.d.ts` with TypeScript declarations for workspace resource types, but IDEs (VS Code, JetBrains) don't reliably pick up loose `.d.ts` files without a `tsconfig.json`. This PR also generates a minimal `tsconfig.json` alongside `rt.d.ts` so `RT.*` types and Bun APIs autocomplete out of the box.

## Changes

- New `cli/src/commands/resource-type/tsconfig.ts` with `generateTsconfigForIde()` — called from the end of `generateRTNamespace()` so all three entry points (`wmill init`, `wmill workspace add/bind`, `wmill resource-type generate-namespace`) pick it up automatically.
- Never overwrites an existing `tsconfig.json` — logs "tsconfig.json already exists, skipping".
- Reads `defaultTs` from `wmill.yaml` (defaults to `bun`). For `deno`, omits the `bun-types` entry.
- For `bun` projects: auto-installs `bun-types` via `bun add -d bun-types` when `bun` is on `PATH` (creates a `package.json` if none exists). Falls back to an actionable log message when bun isn't installed or the install fails.
- Only adds `"types": ["bun-types"]` to the tsconfig if `bun-types` is actually available — avoids the IDE flagging missing type definitions.

## Test plan

- [ ] `wmill init` in an empty directory with a bound workspace → generates `rt.d.ts`, `tsconfig.json`, `package.json`, installs `bun-types`
- [ ] Re-running `wmill init` or `wmill resource-type generate-namespace` with an existing `tsconfig.json` → leaves it alone and logs skip message
- [ ] `defaultTs: deno` in `wmill.yaml` → generates `tsconfig.json` without `bun-types`, no bun install attempted
- [ ] With `bun` uninstalled → logs hint, writes tsconfig without `bun-types` in `types`
- [ ] Open a script in VS Code / JetBrains → `RT.*` types and `Bun.file()` autocomplete

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate a minimal tsconfig.json during initialization and resource-type namespace generation so IDEs index rt.d.ts and provide RT.* and Bun API autocomplete. Skips existing configs and only references `bun-types` when present.

- **New Features**
  - Creates tsconfig.json with minimal compiler options and includes rt.d.ts.
  - Hooks into generateRTNamespace, so it runs during wmill init, workspace add/bind, and generate-namespace.
  - Reads defaultTs from wmill.yaml (defaults to bun). For deno, no `bun-types` reference or install.
  - For bun: tries to install `bun-types` via bun add -d bun-types; adds to tsconfig only if available; otherwise logs next steps.

<sup>Written for commit 5160f1f5a0d4a1003421aa622eecfbe0c35a590e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

