### PR TITLE
fix: guard null inlineScript in app cli extractor

### DIFF
--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -526,7 +526,7 @@ export function extractInlineScriptsForApps(
   }
   if (typeof rec == "object") {
     return Object.entries(rec).flatMap(([k, v]) => {
-      if (k == "inlineScript" && typeof v == "object") {
+      if (k == "inlineScript" && v != null && typeof v == "object") {
         rec["type"] = undefined;
         const o: Record<string, any> = v as any;
         const name = toId(key ?? "", rec);


### PR DESCRIPTION
## Summary
`wmill sync pull` crashes on apps whose stored JSON contains `"inlineScript": null` on a `HiddenRunnable` (e.g. apps that went through Hub export/import or older migrations). The extractor treats `null` as an object because `typeof null === "object"` in JS, then dereferences it on the next line.

## Changes
- `cli/src/commands/sync/sync.ts:529` — add `v != null` guard in `extractInlineScriptsForApps` so null inline-script slots are skipped instead of crashing.

## Test plan
- [ ] Against a workspace containing an app with `hiddenInlineScripts[i].inlineScript === null`, run `wmill sync pull` — before the fix it throws `Failed to extract inline scripts for app`; after, the pull completes.
- [ ] Existing app sync tests still pass.

## Not covered here
There is a separate UI bug where clicking a background runnable shows "script not found" on first click but renders correctly on the second (likely a swallowed first-load error in `FlowModuleScript.svelte` that is never cached). That needs its own investigation and is out of scope for this PR.

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in `wmill sync pull` when an app’s hidden runnable stores `"inlineScript": null`. The extractor now skips null inline-script entries instead of dereferencing them.

- **Bug Fixes**
  - Add `v != null` guard before handling `inlineScript` in `extractInlineScriptsForApps` (`cli/src/commands/sync/sync.ts`), preventing the "Failed to extract inline scripts for app" error.

<sup>Written for commit 3bab11c69de2a4a75357e11ca83e145b157be135. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

