### PR TITLE
nit: flow parallelism toggle button group wrong height

### DIFF
--- a/frontend/src/lib/components/flows/content/FlowLoop.svelte
+++ b/frontend/src/lib/components/flows/content/FlowLoop.svelte
@@ -275,7 +275,6 @@
 										}
 									}
 								}}
-								class="h-6"
 							>
 								{#snippet children({ item })}
 									<ToggleButton small label="static" value="static" {item} />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the parallelism toggle group height in the FlowLoop by removing the hardcoded `h-6` class. The buttons now match the small ToggleButton size and align correctly with the UI.

<sup>Written for commit 2ec7f57fa804c011a42b40854cf586bf41f301ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

