### PR TITLE
fix: background runnable 'script not found' on first click

### DIFF
--- a/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptRunnableByPath.svelte
+++ b/frontend/src/lib/components/apps/editor/inlineScriptsPanel/InlineScriptRunnableByPath.svelte
@@ -39,7 +39,10 @@
 	interface Props {
 		runnable: RunnableByPath
 		fields:
-			| Record<string, StaticAppInput | ConnectedAppInput | RowAppInput | UserAppInput | CtxAppInput>
+			| Record<
+					string,
+					StaticAppInput | ConnectedAppInput | RowAppInput | UserAppInput | CtxAppInput
+			  >
 			| undefined
 		id: string
 		rawApps?: boolean
@@ -79,7 +82,8 @@
 	async function refreshScript(runnable: RunnableByPath) {
 		hubFlowPreview = undefined
 		try {
-			let { schema } = await getScriptByPath(runnable.path)
+			const loaded = await getScriptByPath(runnable.path)
+			const schema = loaded.schema ?? emptySchema()
 			if (!deepEqual(runnable.schema, schema)) {
 				runnable.schema = schema
 				if (!runnable.schema.order) {
@@ -127,8 +131,8 @@
 				return
 			}
 
-			const { schema } =
-				(await loadSchema($workspaceStore ?? '', runnable.path, 'flow')) ?? emptySchema()
+			const loaded = await loadSchema($workspaceStore ?? '', runnable.path, 'flow')
+			const schema = loaded?.schema ?? emptySchema()
 			if (!deepEqual(runnable.schema, schema)) {
 				runnable.schema = schema
 				if (!runnable.schema.order) {


### PR DESCRIPTION
## Summary
App editor showed "script not found" on the first click of a background runnable whose referenced script (or flow) has `schema: null` in the DB (e.g. scripts created via the CLI without schema inference, or legacy data). Clicking away and back silently recovered — which masked the real bug.

Root cause: in `InlineScriptRunnableByPath.refreshScript`, after `let { schema } = await getScriptByPath(...)`, the code does `runnable.schema = schema` then immediately `if (!runnable.schema.order)`. When `schema` is `null`, dereferencing `.order` throws `TypeError: Cannot read properties of null (reading 'order')`. The `catch` turns every error into `notFound = true` → misleading "script not found". The second click works only because the first failed load already assigned `runnable.schema = null`, so `deepEqual(null, null)` now short-circuits past the buggy block.

The same bug exists in the non-hub branch of `refreshFlow`; the hub branch was already defensive with `emptySchema()`.

## Changes
- `InlineScriptRunnableByPath.svelte:85-86` — default a null loaded script schema to `emptySchema()` before the deepEqual/assign.
- `InlineScriptRunnableByPath.svelte:134-135` — same defensive default for the non-hub flow path.

## Test plan
- [ ] With a script whose DB `schema` is `NULL` (`UPDATE script SET schema = NULL WHERE path = '...'`), open an app with a background runnable pointing at it. Before fix: first click shows "script not found", console logs `TypeError: Cannot read properties of null (reading 'order')`. After fix: first click renders the script correctly.
- [ ] Same with a flow whose backend schema is null (non-hub flow via `loadSchema`).
- [ ] Regression: scripts with proper schemas continue to render and compute fields on first click.

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “script not found” error shown on the first click of a background runnable when the target script/flow has a null schema by defaulting to an empty schema so the UI renders correctly on first load.

- **Bug Fixes**
  - In `refreshScript`, default a null loaded `schema` to `emptySchema()` before comparing/assigning.
  - In non-hub `refreshFlow`, default a null loaded `schema` to `emptySchema()` to avoid the same crash.

<sup>Written for commit ca8e77e2b872362799815f49c97ea75a37f13598. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

