### PR TITLE
fix: handle empty parallelism value to prevent null error

### DIFF
--- a/frontend/src/lib/components/flows/content/FlowLoop.svelte
+++ b/frontend/src/lib/components/flows/content/FlowLoop.svelte
@@ -246,9 +246,13 @@
 											: ''
 									},
 									(value) => {
-										;(mod.value as ForloopFlow).parallelism = {
-											type: 'static',
-											value
+										if (value === '' || value === null || value === undefined) {
+											;(mod.value as ForloopFlow).parallelism = undefined
+										} else {
+											;(mod.value as ForloopFlow).parallelism = {
+												type: 'static',
+												value
+											}
 										}
 									}
 								}


### PR DESCRIPTION
## Summary
When editing a Flow step with parallelism enabled, clearing the parallelism input field (via backspace) and clicking "Execute" throws a `parallelism value is null` error. This is because the input setter always creates a `{ type: 'static', value: '' }` object, even when the value is empty.

## Changes
Added a guard in the parallelism input's setter to set `parallelism` to `undefined` when the value is empty/null/undefined, instead of creating an object with an empty value. This prevents the null error and effectively disables parallelism when the field is cleared.

Closes #7864

Assisted-by: GLM 5.1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when executing a Flow step after clearing the parallelism input. Empty values now set parallelism to undefined, disabling parallelism instead of creating an empty static value and preventing the "parallelism value is null" error (closes #7864).

<sup>Written for commit f2beab1a0a18f34a880ce767a5fd15fb70336d3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

