### PR TITLE
docs: add job-debugging guidance to wmill init output

### DIFF
--- a/cli/src/guidance/core.ts
+++ b/cli/src/guidance/core.ts
@@ -49,6 +49,19 @@ You MUST use the \`resources\` skill to manage resource types and credentials.
 
 You MUST use the \`cli-commands\` skill to use the CLI.
 
+## Debugging Jobs
+
+When the user reports a script or flow failure, is investigating unexpected output, or asks why something ran the way it did, use the CLI to fetch job details before speculating. See the \`cli-commands\` skill for all flags.
+
+- \`wmill job list --script-path <path>\` — recent runs of a specific script or flow
+- \`wmill job list --failed --limit 20\` — recent failures across the workspace
+- \`wmill job get <id>\` — status, timing, and (for flows) the step tree with sub-job IDs
+- \`wmill job logs <id>\` — stdout/stderr; for flows, aggregates every step's logs
+- \`wmill job result <id>\` — JSON result of a completed job
+- \`wmill job cancel <id>\` — stop a running or queued job
+
+For flow failures, start with \`wmill job get <id>\` to identify the failing step and its sub-job ID, then \`wmill job logs <sub-job-id>\` to drill in.
+
 ## Skills
 
 For specific guidance, ALWAYS use the skills listed below.

--- a/cli/src/guidance/skills.ts
+++ b/cli/src/guidance/skills.ts
@@ -32,7 +32,7 @@ export const SKILLS: SkillMetadata[] = [
   { name: "triggers", description: "MUST use when configuring triggers." },
   { name: "schedules", description: "MUST use when configuring schedules." },
   { name: "resources", description: "MUST use when managing resources." },
-  { name: "cli-commands", description: "MUST use when using the CLI." },
+  { name: "cli-commands", description: "MUST use when using the CLI, including debugging job failures and inspecting run history via `wmill job`." },
 ];
 
 // Skill content for each skill (loaded inline for bundling)

--- a/cli/src/guidance/skills.ts
+++ b/cli/src/guidance/skills.ts
@@ -5253,7 +5253,7 @@ wmill sync push
 `,
   "cli-commands": `---
 name: cli-commands
-description: MUST use when using the CLI.
+description: MUST use when using the CLI, including debugging job failures and inspecting run history via \`wmill job\`.
 ---
 
 # Windmill CLI Commands

--- a/system_prompts/auto-generated/skills/cli-commands/SKILL.md
+++ b/system_prompts/auto-generated/skills/cli-commands/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cli-commands
-description: MUST use when using the CLI.
+description: MUST use when using the CLI, including debugging job failures and inspecting run history via `wmill job`.
 ---
 
 # Windmill CLI Commands

--- a/system_prompts/generate.py
+++ b/system_prompts/generate.py
@@ -924,7 +924,7 @@ SKILL_DEFINITIONS = [
     },
     {
         'name': 'cli-commands',
-        'description': 'MUST use when using the CLI.',
+        'description': 'MUST use when using the CLI, including debugging job failures and inspecting run history via `wmill job`.',
         'content_key': 'cli_commands',
     },
 ]


### PR DESCRIPTION
## Summary
The `AGENTS.md` generated by `wmill init` never tells AI agents to reach for the `wmill job` CLI when debugging script or flow failures. The `cli-commands` skill documents the subcommands, but nothing at the top level signals *when* to use them — so agents speculate about failures instead of fetching job details.

## Changes
- `cli/src/guidance/core.ts`: new "Debugging Jobs" section in the generated `AGENTS.md`, listing `wmill job list/get/logs/result/cancel` recipes with a flow-specific drill-in tip.
- `cli/src/guidance/skills.ts`: expand the `cli-commands` skill description to mention debugging and run-history inspection so it triggers during investigation, not only on explicit CLI requests.

## Test plan
- [ ] Existing `cli/test/guidance_writer_unit.test.ts` passes (4/4 locally).
- [ ] Run `wmill init` in an empty dir and confirm the new "Debugging Jobs" section appears in `AGENTS.md` between "CLI Reference" and "Skills".
- [ ] Confirm `.claude/skills/cli-commands/SKILL.md` still lists the `job` subcommands.

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Debugging Jobs” section to `AGENTS.md` generated by `wmill init`, and expand the `cli-commands` skill to steer users to `wmill job list/get/logs/result/cancel` when investigating runs and failures instead of guessing. Also update `system_prompts/generate.py` so the auto-generated `cli-commands` SKILL description includes this debugging guidance.

<sup>Written for commit 9d9471c1e07eaaa208a18527e8f6c66cff57d76d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

