### PR TITLE
feat: add homepage connect drawer

### DIFF
--- a/frontend/src/lib/components/details/CopyableCodeBlock.svelte
+++ b/frontend/src/lib/components/details/CopyableCodeBlock.svelte
@@ -9,9 +9,19 @@
 		language: LanguageType<string>
 		disabled?: boolean
 		wrap?: boolean
+		copyOnClick?: boolean
 	}
 
-	let { code, language, disabled = false, wrap = false }: Props = $props()
+	let { code, language, disabled = false, wrap = false, copyOnClick = true }: Props = $props()
+
+	function copyCode(event?: MouseEvent) {
+		if (disabled) {
+			return
+		}
+		event?.preventDefault()
+		event?.stopPropagation()
+		copyToClipboard(code)
+	}
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -19,22 +29,24 @@
 <div
 	class="flex flex-col flex-1 border rounded-md relative bg-surface-input"
 	class:cursor-not-allowed={disabled}
+	class:cursor-pointer={copyOnClick && !disabled}
+	class:cursor-text={!copyOnClick && !disabled}
 	onclick={(e) => {
-		if (disabled) {
-			return
+		if (copyOnClick) {
+			copyCode(e)
 		}
-		e.preventDefault()
-		copyToClipboard(code)
 	}}
 >
-	<div class="absolute top-2 right-1 z-10 pointer-events-none">
-		<Copy size={14} class="w-8 cursor-pointer pointer-events-auto" />
+	<div class="absolute top-2 right-1 z-10">
+		<div class="w-8 cursor-pointer" onclick={copyCode}>
+			<Copy size={14} />
+		</div>
 	</div>
 	<div class="p-2 w-full overflow-auto">
 		<Highlight
 			{language}
 			{code}
-			class="pointer-events-none {wrap ? 'whitespace-pre-wrap break-all pr-8' : ''}"
+			class="{copyOnClick ? 'pointer-events-none' : 'select-text'} {wrap ? 'whitespace-pre-wrap break-all pr-8' : ''}"
 		/>
 	</div>
 </div>

--- a/frontend/src/lib/components/home/HomeConnectDrawer.svelte
+++ b/frontend/src/lib/components/home/HomeConnectDrawer.svelte
@@ -10,10 +10,12 @@
 
 	let drawer: Drawer | undefined = $state()
 	let selectedTab: ConnectTab = $state('cli')
+	let openVersion = $state(0)
 
 	const origin = $derived(typeof window === 'undefined' ? '' : window.location.origin)
+	const workspaceId = $derived($workspaceStore ?? '<workspace>')
 	const cliCommands = $derived(`npm install -g windmill-cli
-wmill workspace add ${$workspaceStore} ${$workspaceStore} ${origin}
+wmill workspace add ${workspaceId} ${workspaceId} ${origin}
 wmill init
 wmill sync pull`)
 
@@ -21,6 +23,7 @@ wmill sync pull`)
 
 	export function openDrawer(tab: ConnectTab = 'cli') {
 		selectedTab = tab
+		openVersion += 1
 		drawer?.openDrawer()
 	}
 
@@ -46,14 +49,16 @@ wmill sync pull`)
 												<h3 class="text-sm font-semibold text-emphasis">Local setup</h3>
 												<p class="text-xs text-secondary max-w-xl">
 													Run this in your local repo to bind the current workspace, create
-													`wmill.yaml`, and pull the latest files.
+													<code class="rounded bg-surface-secondary px-1 py-0.5 font-mono text-2xs text-emphasis"
+														>wmill.yaml</code
+													>, and pull the latest files.
 												</p>
 											</div>
 
 											<Button
 												variant="subtle"
 												unifiedSize="sm"
-												href="https://www.windmill.dev/docs/advanced/cli/sync"
+												href="https://www.windmill.dev/docs/advanced/cli"
 												target="_blank"
 												startIcon={{ icon: ExternalLink }}
 											>
@@ -61,12 +66,26 @@ wmill sync pull`)
 											</Button>
 										</div>
 
-										<CopyableCodeBlock code={cliCommands} language={shell} wrap copyOnClick={false} />
+										<CopyableCodeBlock
+											code={cliCommands}
+											language={shell}
+											wrap
+											copyOnClick={false}
+										/>
 
 										<p class="text-2xs text-secondary">
-											`wmill workspace add` will handle authentication, `wmill init`
-											bootstraps the local config, and `wmill sync pull` fetches the
-											workspace content.
+											<code class="rounded bg-surface-secondary px-1 py-0.5 font-mono text-2xs text-emphasis"
+												>wmill workspace add</code
+											>
+											will handle authentication,
+											<code class="rounded bg-surface-secondary px-1 py-0.5 font-mono text-2xs text-emphasis"
+												>wmill init</code
+											>
+											bootstraps the local config, and
+											<code class="rounded bg-surface-secondary px-1 py-0.5 font-mono text-2xs text-emphasis"
+												>wmill sync pull</code
+											>
+											fetches the workspace content.
 										</p>
 									</div>
 								</TabContent>
@@ -77,8 +96,8 @@ wmill sync pull`)
 											<div class="flex flex-col gap-1">
 												<h3 class="text-sm font-semibold text-emphasis">MCP URL</h3>
 												<p class="text-xs text-secondary max-w-xl">
-													Generate an MCP server URL for the current workspace and choose
-													which scripts, flows, and endpoints the client can access.
+													Generate an MCP server URL for the current workspace and choose which
+													scripts, flows, and endpoints the client can access.
 												</p>
 											</div>
 
@@ -93,13 +112,15 @@ wmill sync pull`)
 											</Button>
 										</div>
 
-										<CreateToken
-											mcpOnly
-											lockWorkspace
-											title="Generate MCP URL"
-											defaultNewTokenWorkspace={$workspaceStore}
-											onTokenCreated={noop}
-										/>
+										{#key openVersion}
+											<CreateToken
+												mcpOnly
+												lockWorkspace
+												title="Generate MCP URL"
+												defaultNewTokenWorkspace={$workspaceStore}
+												onTokenCreated={noop}
+											/>
+										{/key}
 									</div>
 								</TabContent>
 							</div>

--- a/frontend/src/lib/components/home/HomeConnectDrawer.svelte
+++ b/frontend/src/lib/components/home/HomeConnectDrawer.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	import { workspaceStore } from '$lib/stores'
+	import { Button, Drawer, DrawerContent, Tab, TabContent, Tabs } from '$lib/components/common'
+	import CreateToken from '$lib/components/settings/CreateToken.svelte'
+	import CopyableCodeBlock from '$lib/components/details/CopyableCodeBlock.svelte'
+	import { Bot, ExternalLink, Terminal } from 'lucide-svelte'
+	import { shell } from 'svelte-highlight/languages'
+
+	type ConnectTab = 'cli' | 'mcp'
+
+	let drawer: Drawer | undefined = $state()
+	let selectedTab: ConnectTab = $state('cli')
+
+	const origin = $derived(typeof window === 'undefined' ? '' : window.location.origin)
+	const cliCommands = $derived(`npm install -g windmill-cli
+wmill workspace add ${$workspaceStore} ${$workspaceStore} ${origin}
+wmill init
+wmill sync pull`)
+
+	function noop() {}
+
+	export function openDrawer(tab: ConnectTab = 'cli') {
+		selectedTab = tab
+		drawer?.openDrawer()
+	}
+
+	function closeDrawer() {
+		drawer?.closeDrawer()
+	}
+</script>
+
+<Drawer bind:this={drawer} size="720px">
+	<DrawerContent title="Connect this workspace" on:close={closeDrawer}>
+		<div class="flex flex-col gap-5 pb-4">
+			<div class="flex flex-col gap-2">
+				<div class="w-full">
+					<Tabs values={['cli', 'mcp']} bind:selected={selectedTab} wrapperClass="scrollbar-hidden">
+						<Tab value="cli" label="CLI" icon={Terminal} />
+						<Tab value="mcp" label="MCP" icon={Bot} />
+						{#snippet content()}
+							<div class="pt-4">
+								<TabContent value="cli">
+									<div class="flex flex-col gap-4">
+										<div class="flex items-start justify-between gap-3 flex-wrap">
+											<div class="flex flex-col gap-1">
+												<h3 class="text-sm font-semibold text-emphasis">Local setup</h3>
+												<p class="text-xs text-secondary max-w-xl">
+													Run this in your local repo to bind the current workspace, create
+													`wmill.yaml`, and pull the latest files.
+												</p>
+											</div>
+
+											<Button
+												variant="subtle"
+												unifiedSize="sm"
+												href="https://www.windmill.dev/docs/advanced/cli/sync"
+												target="_blank"
+												startIcon={{ icon: ExternalLink }}
+											>
+												CLI docs
+											</Button>
+										</div>
+
+										<CopyableCodeBlock code={cliCommands} language={shell} wrap copyOnClick={false} />
+
+										<p class="text-2xs text-secondary">
+											`wmill workspace add` will handle authentication, `wmill init`
+											bootstraps the local config, and `wmill sync pull` fetches the
+											workspace content.
+										</p>
+									</div>
+								</TabContent>
+
+								<TabContent value="mcp">
+									<div class="flex flex-col gap-4">
+										<div class="flex items-start justify-between gap-3 flex-wrap">
+											<div class="flex flex-col gap-1">
+												<h3 class="text-sm font-semibold text-emphasis">MCP URL</h3>
+												<p class="text-xs text-secondary max-w-xl">
+													Generate an MCP server URL for the current workspace and choose
+													which scripts, flows, and endpoints the client can access.
+												</p>
+											</div>
+
+											<Button
+												variant="subtle"
+												unifiedSize="sm"
+												href="https://www.windmill.dev/docs/core_concepts/mcp"
+												target="_blank"
+												startIcon={{ icon: ExternalLink }}
+											>
+												MCP docs
+											</Button>
+										</div>
+
+										<CreateToken
+											mcpOnly
+											lockWorkspace
+											title="Generate MCP URL"
+											defaultNewTokenWorkspace={$workspaceStore}
+											onTokenCreated={noop}
+										/>
+									</div>
+								</TabContent>
+							</div>
+						{/snippet}
+					</Tabs>
+				</div>
+			</div>
+		</div>
+	</DrawerContent>
+</Drawer>

--- a/frontend/src/lib/components/settings/CreateToken.svelte
+++ b/frontend/src/lib/components/settings/CreateToken.svelte
@@ -45,6 +45,7 @@
 	let mcpCreationMode = $state(false)
 	let mcpScope = $state('mcp:favorites')
 	let lastRequestedMcpMode = $state<boolean | undefined>(undefined)
+	let mcpLabelAutofilled = $state(false)
 
 	let customScopes = $state<string[]>([])
 	let showCustomScopes = $state(false)
@@ -67,16 +68,25 @@
 		mcpCreationMode = true
 		newTokenExpiration = undefined
 		newTokenWorkspace = defaultNewTokenWorkspace ?? $workspaceStore
-		newTokenLabel = newTokenLabel ?? 'MCP token'
+		newToken = undefined
+		newMcpToken = undefined
+		if (!newTokenLabel) {
+			newTokenLabel = 'MCP token'
+			mcpLabelAutofilled = true
+		} else {
+			mcpLabelAutofilled = false
+		}
 	}
 
 	function exitMcpMode() {
 		mcpCreationMode = false
 		newTokenExpiration = undefined
 		newTokenWorkspace = defaultNewTokenWorkspace
-		if (newTokenLabel === 'MCP token') {
+		newMcpToken = undefined
+		if (mcpLabelAutofilled) {
 			newTokenLabel = undefined
 		}
+		mcpLabelAutofilled = false
 	}
 
 	async function createToken(mcpMode: boolean = false): Promise<void> {
@@ -135,6 +145,12 @@
 		}
 
 		lastRequestedMcpMode = requestedMcpMode
+	})
+
+	$effect(() => {
+		if (mcpLabelAutofilled && newTokenLabel !== 'MCP token') {
+			mcpLabelAutofilled = false
+		}
 	})
 </script>
 

--- a/frontend/src/lib/components/settings/CreateToken.svelte
+++ b/frontend/src/lib/components/settings/CreateToken.svelte
@@ -15,6 +15,9 @@
 	interface Props {
 		showMcpMode?: boolean
 		openWithMcpMode?: boolean
+		mcpOnly?: boolean
+		lockWorkspace?: boolean
+		title?: string
 		newTokenLabel?: string
 		defaultNewTokenWorkspace?: string
 		scopes?: string[]
@@ -24,6 +27,10 @@
 
 	let {
 		showMcpMode = false,
+		openWithMcpMode = false,
+		mcpOnly = false,
+		lockWorkspace = false,
+		title = 'Add a new token',
 		defaultNewTokenWorkspace,
 		scopes,
 		onTokenCreated,
@@ -37,6 +44,7 @@
 	let newTokenWorkspace = $state<string | undefined>(untrack(() => defaultNewTokenWorkspace))
 	let mcpCreationMode = $state(false)
 	let mcpScope = $state('mcp:favorites')
+	let lastRequestedMcpMode = $state<boolean | undefined>(undefined)
 
 	let customScopes = $state<string[]>([])
 	let showCustomScopes = $state(false)
@@ -53,6 +61,22 @@
 			return workspacesList
 		}
 		return [{ id: currentWorkspace, name: currentWorkspace }, ...workspacesList]
+	}
+
+	function enterMcpMode() {
+		mcpCreationMode = true
+		newTokenExpiration = undefined
+		newTokenWorkspace = defaultNewTokenWorkspace ?? $workspaceStore
+		newTokenLabel = newTokenLabel ?? 'MCP token'
+	}
+
+	function exitMcpMode() {
+		mcpCreationMode = false
+		newTokenExpiration = undefined
+		newTokenWorkspace = defaultNewTokenWorkspace
+		if (newTokenLabel === 'MCP token') {
+			newTokenLabel = undefined
+		}
 	}
 
 	async function createToken(mcpMode: boolean = false): Promise<void> {
@@ -79,13 +103,17 @@
 			})
 
 			if (mcpMode) {
+				newToken = undefined
 				newMcpToken = `${createdToken}`
 			} else {
+				newMcpToken = undefined
 				newToken = `${createdToken}`
 			}
 
-			onTokenCreated(newToken ?? newMcpToken ?? '')
-			mcpCreationMode = false
+			onTokenCreated(`${createdToken}`)
+			if (!mcpOnly) {
+				mcpCreationMode = false
+			}
 		} catch (err) {
 			console.error('Failed to create token:', err)
 		}
@@ -93,13 +121,28 @@
 
 	const workspaces = $derived(ensureCurrentWorkspaceIncluded($userWorkspaces, $workspaceStore))
 	const mcpBaseUrl = $derived(`${window.location.origin}/api/mcp/w/${newTokenWorkspace}/mcp?token=`)
+
+	$effect(() => {
+		const requestedMcpMode = mcpOnly || openWithMcpMode
+		if (requestedMcpMode === lastRequestedMcpMode) {
+			return
+		}
+
+		if (requestedMcpMode) {
+			enterMcpMode()
+		} else {
+			exitMcpMode()
+		}
+
+		lastRequestedMcpMode = requestedMcpMode
+	})
 </script>
 
 <div>
 	<div class="p-4 rounded-md mb-6 min-w-min bg-surface-tertiary">
-		<h3 class="pb-2 font-semibold text-emphasis text-sm">Add a new token</h3>
+		<h3 class="pb-2 font-semibold text-emphasis text-sm">{title}</h3>
 
-		{#if showMcpMode}
+		{#if showMcpMode && !mcpOnly}
 			<div
 				class="mb-4 flex flex-row flex-shrink-0"
 				use:triggerableByAI={{
@@ -109,15 +152,10 @@
 			>
 				<Toggle
 					on:change={(e) => {
-						mcpCreationMode = e.detail
 						if (e.detail) {
-							newTokenLabel = 'MCP token'
-							newTokenExpiration = undefined
-							newTokenWorkspace = $workspaceStore
+							enterMcpMode()
 						} else {
-							newTokenLabel = undefined
-							newTokenExpiration = undefined
-							newTokenWorkspace = defaultNewTokenWorkspace
+							exitMcpMode()
 						}
 					}}
 					checked={mcpCreationMode}
@@ -162,70 +200,76 @@
 		{/if}
 
 		<div class="mt-2 grid grid-cols-1 md:grid-cols-2 gap-4">
-			{#if mcpCreationMode}
-				<div class="col-span-2">
-					<McpScopeSelector
-						workspaceId={newTokenWorkspace || $workspaceStore || ''}
-						bind:scope={mcpScope}
-					/>
-				</div>
+				{#if mcpCreationMode}
+					<div class="col-span-2">
+						<McpScopeSelector
+							workspaceId={newTokenWorkspace || $workspaceStore || ''}
+							bind:scope={mcpScope}
+						/>
+					</div>
 
-				<div>
-					<span class="block mb-1 text-emphasis text-xs font-semibold">Workspace</span>
-					<Select
-						bind:value={newTokenWorkspace}
-						items={workspaces.map((w) => ({ label: w.name, value: w.id, subtitle: w.id }))}
-					/>
-				</div>
-			{/if}
+					{#if !lockWorkspace}
+						<div>
+							<span class="block mb-1 text-emphasis text-xs font-semibold">Workspace</span>
+							<Select
+								bind:value={newTokenWorkspace}
+								items={workspaces.map((w) => ({ label: w.name, value: w.id, subtitle: w.id }))}
+							/>
+						</div>
+					{/if}
+				{/if}
 
-			<div>
-				<span class="block mb-1 text-emphasis text-xs font-semibold"
-					>Label <span class="text-xs text-primary">(optional)</span></span
-				>
-				<TextInput inputProps={{ type: 'text' }} bind:value={newTokenLabel} class="w-full" />
-			</div>
+				{#if !mcpOnly}
+					<div>
+						<span class="block mb-1 text-emphasis text-xs font-semibold"
+							>Label <span class="text-xs text-primary">(optional)</span></span
+						>
+						<TextInput inputProps={{ type: 'text' }} bind:value={newTokenLabel} class="w-full" />
+					</div>
+				{/if}
 
-			{#if !mcpCreationMode}
-				<div>
-					<span class="block mb-1 text-xs text-emphasis font-semibold"
-						>Expires In <span class="text-xs text-primary">(optional)</span></span
-					>
-					<Select
-						bind:value={newTokenExpiration}
-						placeholder="No expiration"
-						inputClass="w-full"
-						items={[
-							{ label: 'No expiration', value: undefined },
-							{ label: '15 minutes', value: 15 * 60 },
-							{ label: '30 minutes', value: 30 * 60 },
-							{ label: '1 hour', value: 1 * 60 * 60 },
-							{ label: '1 day', value: 1 * 24 * 60 * 60 },
-							{ label: '7 days', value: 7 * 24 * 60 * 60 },
-							{ label: '30 days', value: 30 * 24 * 60 * 60 },
-							{ label: '90 days', value: 90 * 24 * 60 * 60 }
-						]}
-					/>
-				</div>
-			{/if}
+				{#if !mcpCreationMode}
+					<div>
+						<span class="block mb-1 text-xs text-emphasis font-semibold"
+							>Expires In <span class="text-xs text-primary">(optional)</span></span
+						>
+						<Select
+							bind:value={newTokenExpiration}
+							placeholder="No expiration"
+							inputClass="w-full"
+							items={[
+								{ label: 'No expiration', value: undefined },
+								{ label: '15 minutes', value: 15 * 60 },
+								{ label: '30 minutes', value: 30 * 60 },
+								{ label: '1 hour', value: 1 * 60 * 60 },
+								{ label: '1 day', value: 1 * 24 * 60 * 60 },
+								{ label: '7 days', value: 7 * 24 * 60 * 60 },
+								{ label: '30 days', value: 30 * 24 * 60 * 60 },
+								{ label: '90 days', value: 90 * 24 * 60 * 60 }
+							]}
+						/>
+					</div>
+				{/if}
 		</div>
 
 		<div class="mt-4 flex justify-end gap-2 flex-row">
-			<Button
-				on:click={() => {
-					mcpCreationMode = false
-				}}
-				variant="default"
-			>
-				Cancel
-			</Button>
+			{#if !mcpOnly}
+				<Button
+					on:click={() => {
+						exitMcpMode()
+					}}
+					variant="default"
+				>
+					Cancel
+				</Button>
+			{/if}
 			<Button
 				on:click={() => createToken(mcpCreationMode)}
 				disabled={mcpCreationMode &&
 					(newTokenWorkspace == undefined || !mcpScope || mcpScope.trim().length === 0)}
 				variant="accent"
 			>
-				New token
+				{mcpCreationMode ? 'Generate MCP URL' : 'New token'}
 			</Button>
 		</div>
 	</div>

--- a/frontend/src/routes/(root)/(logged)/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/+page.svelte
@@ -13,6 +13,7 @@
 	import PickHubScript from '$lib/components/flows/pickers/PickHubScript.svelte'
 	import PickHubFlow from '$lib/components/flows/pickers/PickHubFlow.svelte'
 	import HighlightCode from '$lib/components/HighlightCode.svelte'
+	import HomeConnectDrawer from '$lib/components/home/HomeConnectDrawer.svelte'
 	import {
 		Building,
 		ExternalLink,
@@ -20,7 +21,8 @@
 		Globe2,
 		Loader2,
 		Code,
-		LayoutDashboard
+		LayoutDashboard,
+		PlugZap
 	} from 'lucide-svelte'
 	import { hubBaseUrlStore } from '$lib/stores'
 	import { base } from '$lib/base'
@@ -98,6 +100,7 @@
 	}
 
 	let workspaceTutorials: WorkspaceTutorials | undefined = $state(undefined)
+	let homeConnectDrawer: HomeConnectDrawer | undefined = $state(undefined)
 
 	// Provide workspaceTutorials to child components via a reactive wrapper
 	let workspaceTutorialsContext = $derived(workspaceTutorials)
@@ -283,6 +286,15 @@
 			title="Home"
 			childrenWrapperDivClasses="flex-1 flex flex-row gap-4 flex-wrap justify-end items-center"
 		>
+			<Button
+				variant="default"
+				unifiedSize="sm"
+				startIcon={{ icon: PlugZap }}
+				btnClasses="!rounded-full"
+				onClick={() => homeConnectDrawer?.openDrawer?.()}
+			>
+				Connect
+			</Button>
 			{#if !$userStore?.operator && showCreateButtons}
 				<span class="text-xs font-normal text-primary">Create a</span>
 				<CreateActionsScript aiId="create-script-button" aiDescription="Creates a new script" />
@@ -374,3 +386,4 @@
 </div>
 
 <WorkspaceTutorials bind:this={workspaceTutorials} />
+<HomeConnectDrawer bind:this={homeConnectDrawer} />

--- a/frontend/src/routes/(root)/(logged)/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/+page.svelte
@@ -286,17 +286,18 @@
 			title="Home"
 			childrenWrapperDivClasses="flex-1 flex flex-row gap-4 flex-wrap justify-end items-center"
 		>
-			<Button
-				variant="default"
-				unifiedSize="sm"
-				startIcon={{ icon: PlugZap }}
-				btnClasses="!rounded-full"
-				onClick={() => homeConnectDrawer?.openDrawer?.()}
-			>
-				Connect
-			</Button>
+			{#if $userStore?.operator}
+				<Button
+					variant="default"
+					unifiedSize="sm"
+					startIcon={{ icon: PlugZap }}
+					btnClasses="!rounded-full whitespace-nowrap"
+					onClick={() => homeConnectDrawer?.openDrawer?.()}
+				>
+					CLI / MCP
+				</Button>
+			{/if}
 			{#if !$userStore?.operator && showCreateButtons}
-				<span class="text-xs font-normal text-primary">Create a</span>
 				<CreateActionsScript aiId="create-script-button" aiDescription="Creates a new script" />
 				{#if HOME_SHOW_CREATE_FLOW}<CreateActionsFlow />{/if}
 				{#if HOME_SHOW_CREATE_APP}<CreateActionsApp />{/if}
@@ -308,13 +309,25 @@
 		<NoDirectDeployAlert onUpdateCanEditStatus={(v) => showCreateButtons = v}/>
 
 		{#if !$userStore?.operator}
-			<div class="w-full overflow-auto scrollbar-hidden pb-2">
-				<Tabs values={['hub', 'workspace']} hashNavigation bind:selected={tab}>
-					<Tab value="workspace" label="Workspace" icon={Building} />
-					{#if HOME_SHOW_HUB}
-						<Tab value="hub" label="Hub" icon={Globe2} />
-					{/if}
-				</Tabs>
+			<div class="flex w-full items-center gap-3 pb-2">
+				<div class="min-w-0 flex-1 overflow-auto scrollbar-hidden">
+					<Tabs values={['hub', 'workspace']} hashNavigation bind:selected={tab}>
+						<Tab value="workspace" label="Workspace" icon={Building} />
+						{#if HOME_SHOW_HUB}
+							<Tab value="hub" label="Hub" icon={Globe2} />
+						{/if}
+					</Tabs>
+				</div>
+
+				<Button
+					variant="default"
+					unifiedSize="sm"
+					startIcon={{ icon: PlugZap }}
+					btnClasses="!rounded-full whitespace-nowrap shrink-0"
+					onClick={() => homeConnectDrawer?.openDrawer?.()}
+				>
+					CLI / MCP
+				</Button>
 			</div>
 		{/if}
 		{#if tab == 'hub'}

--- a/frontend/src/routes/(root)/(logged)/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/+page.svelte
@@ -291,7 +291,7 @@
 					variant="default"
 					unifiedSize="sm"
 					startIcon={{ icon: PlugZap }}
-					btnClasses="!rounded-full whitespace-nowrap"
+					btnClasses="whitespace-nowrap"
 					onClick={() => homeConnectDrawer?.openDrawer?.()}
 				>
 					CLI / MCP
@@ -323,7 +323,7 @@
 					variant="default"
 					unifiedSize="sm"
 					startIcon={{ icon: PlugZap }}
-					btnClasses="!rounded-full whitespace-nowrap shrink-0"
+					btnClasses="whitespace-nowrap shrink-0"
 					onClick={() => homeConnectDrawer?.openDrawer?.()}
 				>
 					CLI / MCP


### PR DESCRIPTION
## Summary
Add a compact `Connect` button to the homepage header that opens a drawer for local CLI setup and MCP URL generation for the current workspace.


https://github.com/user-attachments/assets/49404036-25cd-490e-9870-efc7bddb6d6e



## Changes
- add a small pill-style `Connect` button to the home page header and wire it to a new `HomeConnectDrawer`
- add CLI and MCP tabs in the drawer, including minimal `wmill` setup commands and documentation links
- reuse and extend the token creation flow so MCP URL generation can run in a focused, current-workspace-only mode
- add a `copyOnClick` prop to `CopyableCodeBlock` and disable click-to-copy on the home CLI block so users can select single lines

## Test plan
- [x] Run `npm run check:fast`
- [x] Run `npm run check`
- [x] Manually verify the home page button opens the drawer
- [x] Manually verify the CLI and MCP tabs render and the MCP form is usable

## Screenshots
- Home: http://tmpfiles.org/34422680/home-connect-home.png
- CLI drawer: http://tmpfiles.org/34422686/home-connect-drawer.png
- MCP tab: http://tmpfiles.org/34422687/home-connect-mcp.png

---
Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "CLI / MCP" button on the home page that opens a drawer for quick CLI setup and per‑workspace MCP URL generation. The drawer resets on open for a fresh start, and the button now uses the standard home style.

- **New Features**
  - Added `HomeConnectDrawer` with CLI and MCP tabs; MCP tab generates a per‑workspace MCP URL using new token options (`mcpOnly`, `lockWorkspace`, `title`, `openWithMcpMode`).
  - Added a "CLI / MCP" button in the home header (operators) and next to the Workspace/Hub tabs (others) to open the drawer.
  - Improved copy UX in code blocks with a dedicated copy icon and optional `copyOnClick` (home CLI block stays selectable).

- **Bug Fixes**
  - Reset drawer state between opens (re-mounts the MCP token form) to avoid stale workspace/form data.
  - Use the standard button style for the home "CLI / MCP" control.

<sup>Written for commit 9235a9057d7706964bc25597a849582bd0b1b7f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



