### PR TITLE
fix: use POST for oidc token request in authed client

### DIFF
--- a/backend/windmill-common/src/client.rs
+++ b/backend/windmill-common/src/client.rs
@@ -49,7 +49,31 @@ impl AuthedClient {
             "{}/api/w/{}/oidc/token/{}",
             self.base_internal_url, self.workspace, audience
         );
-        make_basic_get_request(self, &url, None, Some("decoding oidc token as json string")).await
+        let response = self
+            .force_client
+            .as_ref()
+            .unwrap_or(&HTTP_CLIENT)
+            .post(&url)
+            .header(
+                reqwest::header::AUTHORIZATION,
+                reqwest::header::HeaderValue::from_str(&format!("Bearer {}", self.token))?,
+            )
+            .send()
+            .await
+            .map_err(|e| {
+                tracing::error!("Error requesting oidc token from {url}: {e:#?}");
+                anyhow::anyhow!("Error requesting oidc token from {url}: {e:#?}")
+            })?;
+
+        match response.status().as_u16() {
+            200u16 => Ok(response.text().await.context("reading oidc token body")?),
+            status => {
+                let body = response.text().await.unwrap_or_default();
+                Err(anyhow::anyhow!(
+                    "oidc token request to {url} failed with status {status}: {body}"
+                ))
+            }
+        }
     }
 
     pub async fn get_resource_value<T: DeserializeOwned>(&self, path: &str) -> anyhow::Result<T> {


### PR DESCRIPTION
## Summary
Volume setup fails with `ExecutionErr: Error:  @job_s3_helpers_ee.rs:206:17` when the workspace uses S3 AWS OIDC for large file storage, while plain S3 works.

The worker's `get_workspace_s3_resource_path` calls `TokenGenerator::AsClient(client).gen_token()` which ultimately hits `AuthedClient::get_id_token`. That method was calling `GET /api/w/{workspace}/oidc/token/{audience}` and decoding the response as JSON, but the server route is `POST` and returns a plain-text token. The 405 response had an empty body, which rendered as the cryptic empty-message error.

User scripts fetching OIDC tokens via the Python/TS SDKs already POST correctly, so only the Rust worker's volume setup path — the sole in-tree caller — hit the bug.

## Changes
- `AuthedClient::get_id_token` now POSTs and reads the response as text

## Test plan
- [ ] Configure workspace large file storage to use an S3 AWS OIDC resource
- [ ] Mount a volume in a script and verify it downloads/syncs without the `@job_s3_helpers_ee.rs:206` error
- [ ] Verify volume mounts still work with plain S3 storage (regression)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes volume setup failures with S3 AWS OIDC by switching `AuthedClient::get_id_token` to POST and reading the plain-text token. Prevents 405/empty-body errors so volumes mount and sync correctly.

- **Bug Fixes**
  - Use POST to `/api/w/{workspace}/oidc/token/{audience}` with Bearer auth and read the token as text.
  - Improve error messages on non-200 responses (include status and body).
  - Plain S3 storage behavior is unchanged.

<sup>Written for commit b81fc903cde908d39bddf64e349ceda8bc57b397. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

