### PR TITLE
fix: missing toast and tag key mismatch in autoscaling test button

### DIFF
--- a/frontend/src/lib/components/AutoscalingConfigEditor.svelte
+++ b/frontend/src/lib/components/AutoscalingConfigEditor.svelte
@@ -15,6 +15,7 @@
 	import Select from './select/Select.svelte'
 	import ScriptPicker from './ScriptPicker.svelte'
 	import Badge from './common/badge/Badge.svelte'
+	import { sendUserToast } from '$lib/toast'
 
 	interface Props {
 		config: AutoscalingConfig | undefined
@@ -218,13 +219,13 @@
 								id="custom_tag_select"
 								disabled={!config || !config.integration || disabled}
 								bind:value={
-									() => config?.integration?.['tags'] ?? undefined,
+									() => config?.integration?.['tag'] ?? undefined,
 									(v) => {
 										if (!config || !config.integration) return
 										if (!v || v === '') {
-											delete config.integration['tags']
+											delete config.integration['tag']
 										} else {
-											config.integration['tags'] = v
+											config.integration['tag'] = v
 										}
 									}
 								}
@@ -232,7 +233,20 @@
 							/>
 
 							<div class="flex flex-row gap-2 justify-end mt-4">
-								<Button variant="default" unifiedSize="md">Test scaling</Button>
+								<Button
+									variant="default"
+									unifiedSize="md"
+									onclick={() => {
+										if (!config?.integration?.['path']) {
+											sendUserToast('Please select a script before testing scaling', true)
+											return
+										}
+										if (!config?.integration?.['tag']) {
+											sendUserToast('Please select a custom tag before testing scaling', true)
+											return
+										}
+									}}>Test scaling</Button
+								>
 								<div class="flex text-xs flex-row gap-2 items-center">
 									<input class="!w-16" type="number" bind:value={test_input} />
 									workers


### PR DESCRIPTION
## Summary
The "Test scaling" button in the script-integration section of the autoscaling editor silently no-op'd when the user hadn't filled in a custom tag (no `onclick` handler). It also wrote the tag under the wrong key (`tags` plural), while the backend `AutoscalingIntegration` struct deserializes `tag` (singular) — so even a filled tag never reached the worker.

## Changes
- Rename the Select bind key from `config.integration['tags']` to `config.integration['tag']` to match the backend `AutoscalingIntegration.tag` field (`backend/windmill-common/src/instance_config.rs:785`).
- Add an `onclick` guard to the script-integration "Test scaling" button that toasts `"Please select a script before testing scaling"` when `path` is empty, then `"Please select a custom tag before testing scaling"` when `tag` is empty.

## Test plan
- [ ] Open worker group autoscaling config, pick `Custom script`, leave script path empty, click **Test scaling** → red toast about missing script.
- [ ] Pick a script, leave custom tag empty, click **Test scaling** → red toast about missing tag.
- [ ] Pick a script and a tag, save config, reload page → tag selection persists (previously lost because it was saved under `tags`).

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Test scaling button in the autoscaling editor by validating required fields and saving the custom tag under the correct key. Prevents silent no-ops and ensures the tag persists after save.

- **Bug Fixes**
  - Bind `config.integration['tag']` (was `['tags']`) to match backend `AutoscalingIntegration.tag`.
  - Add click guard to “Test scaling”: toast if `path` or `tag` is missing via `sendUserToast`.

<sup>Written for commit ee3371402921468bb0f96a474e347468c818cd39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

