### PR TITLE
fix: rust nsjail RUSTUP_HOME mount and arch-aware cache keys

### DIFF
--- a/backend/windmill-worker/nsjail/download.rust.config.proto
+++ b/backend/windmill-worker/nsjail/download.rust.config.proto
@@ -93,8 +93,16 @@ mount {
     src: "{CARGO_HOME}"
     dst: "{CARGO_HOME}"
     is_bind: true
-    # Readonly 
+    # Readonly
     rw: false
+}
+
+mount {
+    src: "{RUSTUP_HOME}"
+    dst: "{RUSTUP_HOME}"
+    is_bind: true
+    rw: false
+    mandatory: false
 }
 
 mount {

--- a/backend/windmill-worker/src/csharp_executor.rs
+++ b/backend/windmill-worker/src/csharp_executor.rs
@@ -62,12 +62,8 @@ lazy_static::lazy_static! {
 }
 
 #[cfg(feature = "csharp")]
-const CSHARP_OBJECT_STORE_PREFIX: &str = const_format::concatcp!(
-    std::env::consts::OS,
-    "_",
-    std::env::consts::ARCH,
-    "_csharpbin/"
-);
+const CSHARP_OBJECT_STORE_PREFIX: &str =
+    const_format::concatcp!(crate::global_cache::TARGET, "_csharpbin/");
 
 #[cfg(feature = "csharp")]
 pub async fn generate_nuget_lockfile(

--- a/backend/windmill-worker/src/global_cache.rs
+++ b/backend/windmill-worker/src/global_cache.rs
@@ -7,7 +7,6 @@ use windmill_object_store::object_store_reexports::ObjectStore;
 #[cfg(all(feature = "enterprise", feature = "parquet"))]
 use std::sync::Arc;
 
-#[cfg(all(feature = "enterprise", feature = "parquet"))]
 pub const TARGET: &str = const_format::concatcp!(std::env::consts::OS, "_", std::env::consts::ARCH);
 
 #[cfg(all(feature = "enterprise", feature = "parquet"))]

--- a/backend/windmill-worker/src/go_executor.rs
+++ b/backend/windmill-worker/src/go_executor.rs
@@ -82,7 +82,8 @@ lazy_static::lazy_static! {
     static ref GO_PATH: String = std::env::var("GO_PATH").unwrap_or_else(|_| "/usr/bin/go".to_string());
 }
 
-pub const GO_OBJECT_STORE_PREFIX: &str = "gobin/";
+pub const GO_OBJECT_STORE_PREFIX: &str =
+    const_format::concatcp!(crate::global_cache::TARGET, "_gobin/");
 #[tracing::instrument(level = "trace", skip_all)]
 pub async fn handle_go_job(
     mem_peak: &mut i32,

--- a/backend/windmill-worker/src/rust_executor.rs
+++ b/backend/windmill-worker/src/rust_executor.rs
@@ -101,7 +101,8 @@ lazy_static::lazy_static! {
     static ref RUSTUP_HOME_DEFAULT: String = format!("{}/.rustup", HOME_ENV.as_str());
 }
 
-const RUST_OBJECT_STORE_PREFIX: &str = "rustbin/";
+const RUST_OBJECT_STORE_PREFIX: &str =
+    const_format::concatcp!(crate::global_cache::TARGET, "_rustbin/");
 
 #[cfg(not(windows))]
 lazy_static::lazy_static! {
@@ -476,6 +477,7 @@ pub async fn build_rust_crate(
                 .replace("{JOB_DIR}", job_dir)
                 .replace("{CACHE_DIR}", &*RUST_CACHE_DIR)
                 .replace("{CARGO_HOME}", CARGO_HOME.as_str())
+                .replace("{RUSTUP_HOME}", RUSTUP_HOME.as_str())
                 .replace("{TRACING_PROXY_CA_CERT_PATH}", &*TRACING_PROXY_CA_CERT_PATH)
                 .replace("#{DEV}", DEV_CONF_NSJAIL)
                 .replace("{BUILD}", &build_dir),


### PR DESCRIPTION
## Summary

Two independent Rust/Go cache-related bugs surfaced from a customer report (`execve('/tmp/main') failed: Exec format error` on an arm64 cluster):

1. **Rust builds under nsjail fail with `rustup could not choose a version of cargo to run`.** Introduced by `e144432a16` (Feb 2026, `fix: rust + java works with just /tmp mounted`) which moved `RUSTUP_HOME` from `/usr/local/rustup` to `/tmp/windmill/cache/rustup`. The Rust nsjail config bind-mounts `{JOB_DIR}` over `/tmp`, which masks `/tmp/windmill/cache/rustup` inside the sandbox. The `{CARGO_HOME}` mount was re-added to compensate for this masking but `{RUSTUP_HOME}` was missed, so rustup can't find its `settings.toml` or toolchains dir.

2. **Rust and Go binary object-store cache keys are arch-agnostic** (`rustbin/<hash>`, `gobin/<hash>`). On mixed-arch setups — or any cluster where the cache was ever populated by a different-arch worker — the wrong-arch binary gets fetched and `execve` rejects it with `ENOEXEC`. C# already does this correctly (`<os>_<arch>_csharpbin/`); Rust/Go just forgot.

## Changes

- `backend/windmill-worker/nsjail/download.rust.config.proto`: add `{RUSTUP_HOME}` bind mount next to the existing `{CARGO_HOME}` mount (`mandatory: false`, `rw: false`).
- `backend/windmill-worker/src/rust_executor.rs`: substitute `{RUSTUP_HOME}` when writing the nsjail config; switch `RUST_OBJECT_STORE_PREFIX` to `<os>_<arch>_rustbin/`.
- `backend/windmill-worker/src/go_executor.rs`: switch `GO_OBJECT_STORE_PREFIX` to `<os>_<arch>_gobin/`.
- `backend/windmill-worker/src/csharp_executor.rs`: refactor inline concat to reuse `crate::global_cache::TARGET` (value unchanged).
- `backend/windmill-worker/src/global_cache.rs`: ungate `TARGET` so non-EE/non-parquet builds can reuse it.

## Cache invalidation

- Rust and Go **object store** entries under the old `rustbin/` / `gobin/` keys are orphaned on first deploy. Workers miss, rebuild, and write to the new arch-namespaced key. No runtime errors, just a one-time rebuild per script per arch.
- C# prefix value is unchanged (`<os>_<arch>_csharpbin/` before and after) — pure dedup.
- Per-worker **local disk cache** (`/tmp/windmill/cache/rust/<hash>`) is NOT prefixed and survives the upgrade. If a worker has a wrong-arch binary cached locally, it will keep reusing it until the local cache is cleared (pod restart with `emptyDir`, or manual wipe).

## Test plan

- [ ] Start `ghcr.io/windmill-labs/windmill-ee-full` with `DISABLE_NSJAIL=false`, run a fresh Rust script — compiles under nsjail and executes (manually verified locally).
- [ ] Inspect object store after running a Rust/Go script — entry lives under `linux_x86_64_rustbin/` (resp. `linux_x86_64_gobin/`).
- [ ] Verify C# cache entries remain readable (prefix value unchanged).
- [ ] On a worker with a pre-existing bad local cache, confirm the cache prefix change alone doesn't fix the failing script (local cache wins) — documents the "clear local cache or restart pod" workaround for customers.

## For customers hitting the ENOEXEC

After deploying:
- If `/tmp/windmill/cache` is `emptyDir`/tmpfs: rolling restart clears the bad local caches — they'll repopulate correctly.
- If they use a PVC or hostPath: wipe `/tmp/windmill/cache/rust/*` and `/tmp/windmill/cache/go/*` in each worker, or trivially edit the script to change its hash.

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Rust builds under nsjail by mounting `RUSTUP_HOME`, and makes Rust/Go object-store cache keys arch-aware to prevent wrong-arch binaries causing Exec format errors on mixed-arch clusters.

- **Bug Fixes**
  - Rust nsjail: add a read-only `{RUSTUP_HOME}` bind mount and substitute it when writing the jail config to unblock rustup/cargo.
  - Cache correctness: switch Rust/Go object-store prefixes to `<os>_<arch>_rustbin/` and `<os>_<arch>_gobin/` (e.g., `linux_x86_64_rustbin/`) to avoid fetching wrong-arch binaries.
  - Minor: reuse `crate::global_cache::TARGET` for the C# prefix (value unchanged).

- **Migration**
  - Object store will repopulate under the new prefixes on first run; old `rustbin/` and `gobin/` entries become unused.
  - Local disk caches under `/tmp/windmill/cache/{rust,go}` are not namespaced by arch; clear them or restart pods if persistent storage is used.

<sup>Written for commit b5fc71be2e0a23fb796ec9185f4501b0e8ae4f86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

