### PR TITLE
chore: add codex svelte mcp config

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,4 @@
+#:schema https://developers.openai.com/codex/config-schema.json
+
+[mcp_servers.svelte]
+url = "https://mcp.svelte.dev/mcp"


### PR DESCRIPTION
## Summary
Add a project-scoped Codex config that registers the Svelte MCP server at the repo level, mirroring the existing `.mcp.json` used for Claude.

## Changes
- add `.codex/config.toml` with the Codex config schema header
- configure `mcp_servers.svelte` to use `https://mcp.svelte.dev/mcp`
- keep the project-level Codex MCP setup aligned with the existing Claude MCP entry

## Test plan
- [x] Run `codex mcp list` from the repo root and confirm `svelte` is enabled
- [x] Run `codex mcp get svelte` and confirm the server URL is `https://mcp.svelte.dev/mcp`

---
Generated with [Codex](https://openai.com/codex/)