### PR TITLE
feat: async dep endpoints and queue-position logs in cli

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10804,6 +10804,74 @@ paths:
                 required:
                   - lock
 
+  /w/{workspace}/jobs/run/dependencies_async:
+    post:
+      summary: queue a one-off dependencies job and return the job uuid
+      operationId: runRawScriptDependenciesAsync
+      tags:
+        - job
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+
+      requestBody:
+        description: raw script content
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                raw_scripts:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/RawScriptForDependencies"
+                entrypoint:
+                  type: string
+              required:
+                - entrypoint
+                - raw_scripts
+      responses:
+        "201":
+          description: dependency job created
+          content:
+            text/plain:
+              schema:
+                type: string
+                format: uuid
+
+  /w/{workspace}/jobs/run/flow_dependencies_async:
+    post:
+      summary: queue a one-off flow dependencies job and return the job uuid
+      operationId: runFlowDependenciesAsync
+      tags:
+        - job
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+
+      requestBody:
+        description: flow value and path
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                path:
+                  type: string
+                flow_value:
+                  $ref: "#/components/schemas/FlowValue"
+              required:
+                - path
+                - flow_value
+      responses:
+        "201":
+          description: flow dependencies job created
+          content:
+            text/plain:
+              schema:
+                type: string
+                format: uuid
+
   /w/{workspace}/jobs/run/preview_flow:
     post:
       summary: run flow preview

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -348,7 +348,12 @@ pub fn workspaced_service() -> Router {
             get(get_flow_env_by_flow_job_id).layer(cors.clone()),
         )
         .route("/run/dependencies", post(run_dependencies_job))
+        .route("/run/dependencies_async", post(run_dependencies_job_async))
         .route("/run/flow_dependencies", post(run_flow_dependencies_job))
+        .route(
+            "/run/flow_dependencies_async",
+            post(run_flow_dependencies_job_async),
+        )
         .route(
             "/send_email_with_instance_smtp",
             post(send_email_with_instance_smtp),
@@ -5909,13 +5914,13 @@ pub struct RunDependenciesResponse {
     pub dependencies: String,
 }
 
-async fn run_dependencies_job(
-    authed: ApiAuthed,
-    Extension(db): Extension<DB>,
-    Path(w_id): Path<String>,
-    Json(req): Json<RunDependenciesRequest>,
-) -> error::Result<Response> {
-    check_scopes(&authed, || format!("jobs:run"))?;
+async fn push_dependencies_job(
+    authed: &ApiAuthed,
+    db: &DB,
+    w_id: &str,
+    req: RunDependenciesRequest,
+) -> error::Result<Uuid> {
+    check_scopes(authed, || format!("jobs:run"))?;
     if authed.is_operator {
         return Err(error::Error::NotAuthorized(
             "Operators cannot run dependencies jobs for security reasons".to_string(),
@@ -5944,12 +5949,7 @@ async fn run_dependencies_job(
             ));
     }
 
-    let RawScriptForDependencies {
-        // unwrap
-        script_path,
-        raw_code,
-        language,
-    } = req.raw_scripts[0].clone();
+    let RawScriptForDependencies { script_path, raw_code, language } = req.raw_scripts[0].clone();
 
     let mut hm = HashMap::new();
     req.raw_workspace_dependencies
@@ -5958,9 +5958,9 @@ async fn run_dependencies_job(
         .map(|v| hm.insert("temp_script_refs".to_owned(), to_raw_value(&v)));
 
     let (uuid, tx) = push(
-        &db,
+        db,
         PushIsolationLevel::IsolatedRoot(db.clone()),
-        &w_id,
+        w_id,
         JobPayload::RawScriptDependencies {
             script_path,
             content: raw_code.unwrap_or_default(),
@@ -5993,9 +5993,27 @@ async fn run_dependencies_job(
     )
     .await?;
     tx.commit().await?;
+    Ok(uuid)
+}
 
-    let wait_result = run_wait_result(&db, uuid, &w_id, None, &authed.username).await;
-    wait_result
+async fn run_dependencies_job(
+    authed: ApiAuthed,
+    Extension(db): Extension<DB>,
+    Path(w_id): Path<String>,
+    Json(req): Json<RunDependenciesRequest>,
+) -> error::Result<Response> {
+    let uuid = push_dependencies_job(&authed, &db, &w_id, req).await?;
+    run_wait_result(&db, uuid, &w_id, None, &authed.username).await
+}
+
+async fn run_dependencies_job_async(
+    authed: ApiAuthed,
+    Extension(db): Extension<DB>,
+    Path(w_id): Path<String>,
+    Json(req): Json<RunDependenciesRequest>,
+) -> error::Result<(StatusCode, String)> {
+    let uuid = push_dependencies_job(&authed, &db, &w_id, req).await?;
+    Ok((StatusCode::CREATED, uuid.to_string()))
 }
 
 #[derive(Deserialize)]
@@ -6015,13 +6033,13 @@ pub struct RunFlowDependenciesResponse {
     pub dependencies: String,
 }
 
-async fn run_flow_dependencies_job(
-    authed: ApiAuthed,
-    Extension(db): Extension<DB>,
-    Path(w_id): Path<String>,
-    Json(req): Json<RunFlowDependenciesRequest>,
-) -> error::Result<Response> {
-    check_scopes(&authed, || format!("jobs:run"))?;
+async fn push_flow_dependencies_job(
+    authed: &ApiAuthed,
+    db: &DB,
+    w_id: &str,
+    req: RunFlowDependenciesRequest,
+) -> error::Result<Uuid> {
+    check_scopes(authed, || format!("jobs:run"))?;
     if authed.is_operator {
         return Err(error::Error::NotAuthorized(
             "Operators cannot run dependencies jobs for security reasons".to_string(),
@@ -6044,21 +6062,18 @@ async fn run_flow_dependencies_job(
             .await?;
     }
 
-    // Create args HashMap with skip_flow_update and raw_workspace_dependencies if present
     let mut args_map = HashMap::from([("skip_flow_update".to_string(), to_raw_value(&true))]);
 
-    // Add raw_workspace_dependencies to args if present
     req.raw_workspace_dependencies
         .map(|v| args_map.insert("raw_workspace_dependencies".to_string(), to_raw_value(&v)));
 
-    // Add temp_script_refs to args if present (for CLI local import resolution)
     req.temp_script_refs
         .map(|v| args_map.insert("temp_script_refs".to_string(), to_raw_value(&v)));
 
     let (uuid, tx) = push(
-        &db,
+        db,
         PushIsolationLevel::IsolatedRoot(db.clone()),
-        &w_id,
+        w_id,
         JobPayload::RawFlowDependencies { path: req.path, flow_value: req.flow_value },
         PushArgs::from(&args_map),
         authed.display_username(),
@@ -6087,9 +6102,27 @@ async fn run_flow_dependencies_job(
     )
     .await?;
     tx.commit().await?;
+    Ok(uuid)
+}
 
-    let wait_result = run_wait_result(&db, uuid, &w_id, None, &authed.username).await;
-    wait_result
+async fn run_flow_dependencies_job(
+    authed: ApiAuthed,
+    Extension(db): Extension<DB>,
+    Path(w_id): Path<String>,
+    Json(req): Json<RunFlowDependenciesRequest>,
+) -> error::Result<Response> {
+    let uuid = push_flow_dependencies_job(&authed, &db, &w_id, req).await?;
+    run_wait_result(&db, uuid, &w_id, None, &authed.username).await
+}
+
+async fn run_flow_dependencies_job_async(
+    authed: ApiAuthed,
+    Extension(db): Extension<DB>,
+    Path(w_id): Path<String>,
+    Json(req): Json<RunFlowDependenciesRequest>,
+) -> error::Result<(StatusCode, String)> {
+    let uuid = push_flow_dependencies_job(&authed, &db, &w_id, req).await?;
+    Ok((StatusCode::CREATED, uuid.to_string()))
 }
 
 #[derive(Deserialize)]

--- a/cli/src/commands/app/app_metadata.ts
+++ b/cli/src/commands/app/app_metadata.ts
@@ -46,6 +46,7 @@ import { requireLogin } from "../../core/auth.ts";
 import { getNonDottedPaths } from "../../utils/resource_folders.ts";
 import { extractRelativeImports } from "../../utils/relative_imports.ts";
 import { DoubleLinkedDependencyTree } from "../../utils/dependency_tree.ts";
+import { pollJobWithQueueLogging } from "../../utils/job_polling.ts";
 
 const TOP_HASH = "__app_hash";
 export const APP_BACKEND_FOLDER = "backend";
@@ -710,8 +711,8 @@ async function generateInlineScriptLock(
 
   const extraHeaders = getHeaders();
 
-  const rawResponse = await fetch(
-    `${workspace.remote}api/w/${workspace.workspaceId}/jobs/run/dependencies`,
+  const queueResponse = await fetch(
+    `${workspace.remote}api/w/${workspace.workspaceId}/jobs/run/dependencies_async`,
     {
       method: "POST",
       headers: {
@@ -739,36 +740,43 @@ async function generateInlineScriptLock(
     }
   );
 
-  if (!rawResponse.ok) {
-    const text = await rawResponse.text();
+  if (!queueResponse.ok) {
+    const text = await queueResponse.text();
     throw new Error(
-      `Dependency generation failed: ${rawResponse.status} ${rawResponse.statusText}\n${text}`
+      `Dependency generation failed: ${queueResponse.status} ${queueResponse.statusText}\n${text}`
     );
   }
 
-  let responseText = "reading response failed";
+  const jobId = (await queueResponse.text()).trim();
+
+  let completion;
   try {
-    responseText = await rawResponse.text();
-    const response = JSON.parse(responseText);
-    const lock = response.lock;
-
-    if (lock === undefined) {
-      if (response?.["error"]?.["message"]) {
-        throw new Error(
-          `Failed to generate lockfile: ${response?.["error"]?.["message"]}`
-        );
-      }
-      throw new Error(
-        `Failed to generate lockfile: ${JSON.stringify(response, null, 2)}`
-      );
-    }
-
-    return lock ?? "";
+    completion = await pollJobWithQueueLogging(
+      workspace.workspaceId,
+      jobId,
+      { label: `deps ${scriptPath}` },
+    );
   } catch (e: any) {
     throw new Error(
-      `Failed to parse dependency response: ${rawResponse.statusText}, ${responseText}, ${e.message}`
+      `Failed to poll dependencies job ${jobId}: ${e?.message ?? e}`
     );
   }
+
+  const result = completion.result as any;
+  if (!completion.success) {
+    const message =
+      result?.error?.message ??
+      (typeof result === "string" ? result : JSON.stringify(result, null, 2));
+    throw new Error(`Failed to generate lockfile: ${message}`);
+  }
+
+  const lock = result?.lock;
+  if (lock === undefined) {
+    throw new Error(
+      `Failed to generate lockfile: ${JSON.stringify(result, null, 2)}`
+    );
+  }
+  return lock ?? "";
 }
 
 /**

--- a/cli/src/commands/app/dev.ts
+++ b/cli/src/commands/app/dev.ts
@@ -1618,6 +1618,47 @@ async function executeRunnable(
 
 const ITERATIONS_BEFORE_SLOW_REFRESH = 10;
 const ITERATIONS_BEFORE_SUPER_SLOW_REFRESH = 100;
+const QUEUE_LOG_INTERVAL_MS = 5000;
+
+async function logQueuePositionForJob(
+  workspace: string,
+  jobId: string,
+): Promise<void> {
+  try {
+    const job: any = await wmill.getJob({ workspace, id: jobId });
+    if (!job || typeof job.running !== "boolean") return;
+    if (job.running === true) {
+      log.info(colors.gray(`Job ${jobId}: running, waiting for completion...`));
+      return;
+    }
+    const scheduledFor = job.scheduled_for as string | undefined;
+    const scheduledForMs = scheduledFor ? new Date(scheduledFor).getTime() : NaN;
+    if (!Number.isFinite(scheduledForMs)) {
+      log.info(colors.gray(`Job ${jobId}: queued, waiting for executor...`));
+      return;
+    }
+    try {
+      const pos = await wmill.getQueuePosition({
+        workspace,
+        scheduledFor: scheduledForMs,
+      });
+      const position = (pos as any)?.position;
+      if (position != null) {
+        log.info(
+          colors.gray(
+            `Job ${jobId}: queued, waiting for executor (position ${position} in queue)`,
+          ),
+        );
+      } else {
+        log.info(colors.gray(`Job ${jobId}: queued, waiting for executor...`));
+      }
+    } catch {
+      log.info(colors.gray(`Job ${jobId}: queued, waiting for executor...`));
+    }
+  } catch {
+    // ignore transient errors
+  }
+}
 
 async function waitForJob(workspace: string, jobId: string): Promise<any> {
   if (!jobId) {
@@ -1625,6 +1666,7 @@ async function waitForJob(workspace: string, jobId: string): Promise<any> {
   }
 
   let syncIteration = 0;
+  let lastQueueLogAt = Date.now();
 
   return new Promise((resolve, reject) => {
     async function checkJob() {
@@ -1650,6 +1692,11 @@ async function waitForJob(workspace: string, jobId: string): Promise<any> {
         }
       } catch (err: any) {
         log.error(colors.red(`Error checking job ${jobId}: ${err.message}`));
+      }
+
+      if (Date.now() - lastQueueLogAt >= QUEUE_LOG_INTERVAL_MS) {
+        lastQueueLogAt = Date.now();
+        logQueuePositionForJob(workspace, jobId);
       }
 
       syncIteration++;

--- a/cli/src/commands/app/dev.ts
+++ b/cli/src/commands/app/dev.ts
@@ -23,6 +23,7 @@ import {
 } from "./bundle.ts";
 import { wmillTsDev as wmillTs } from "./wmillTsDev.ts";
 import * as wmill from "../../../gen/services.gen.ts";
+import { logQueueStatus } from "../../utils/job_polling.ts";
 import { resolveWorkspace } from "../../core/context.ts";
 import { requireLogin } from "../../core/auth.ts";
 import { GLOBAL_CONFIG_OPT } from "../../core/conf.ts";
@@ -1620,46 +1621,6 @@ const ITERATIONS_BEFORE_SLOW_REFRESH = 10;
 const ITERATIONS_BEFORE_SUPER_SLOW_REFRESH = 100;
 const QUEUE_LOG_INTERVAL_MS = 5000;
 
-async function logQueuePositionForJob(
-  workspace: string,
-  jobId: string,
-): Promise<void> {
-  try {
-    const job: any = await wmill.getJob({ workspace, id: jobId });
-    if (!job || typeof job.running !== "boolean") return;
-    if (job.running === true) {
-      log.info(colors.gray(`Job ${jobId}: running, waiting for completion...`));
-      return;
-    }
-    const scheduledFor = job.scheduled_for as string | undefined;
-    const scheduledForMs = scheduledFor ? new Date(scheduledFor).getTime() : NaN;
-    if (!Number.isFinite(scheduledForMs)) {
-      log.info(colors.gray(`Job ${jobId}: queued, waiting for executor...`));
-      return;
-    }
-    try {
-      const pos = await wmill.getQueuePosition({
-        workspace,
-        scheduledFor: scheduledForMs,
-      });
-      const position = (pos as any)?.position;
-      if (position != null) {
-        log.info(
-          colors.gray(
-            `Job ${jobId}: queued, waiting for executor (position ${position} in queue)`,
-          ),
-        );
-      } else {
-        log.info(colors.gray(`Job ${jobId}: queued, waiting for executor...`));
-      }
-    } catch {
-      log.info(colors.gray(`Job ${jobId}: queued, waiting for executor...`));
-    }
-  } catch {
-    // ignore transient errors
-  }
-}
-
 async function waitForJob(workspace: string, jobId: string): Promise<any> {
   if (!jobId) {
     throw new Error("Job ID is required");
@@ -1696,7 +1657,7 @@ async function waitForJob(workspace: string, jobId: string): Promise<any> {
 
       if (Date.now() - lastQueueLogAt >= QUEUE_LOG_INTERVAL_MS) {
         lastQueueLogAt = Date.now();
-        logQueuePositionForJob(workspace, jobId);
+        await logQueueStatus(workspace, jobId);
       }
 
       syncIteration++;

--- a/cli/src/commands/flow/flow_metadata.ts
+++ b/cli/src/commands/flow/flow_metadata.ts
@@ -32,6 +32,7 @@ import { workspaceDependenciesLanguages } from "../../utils/script_common.ts";
 import { extractNameFromFolder, getFolderSuffix, getNonDottedPaths } from "../../utils/resource_folders.ts";
 import { extractRelativeImports } from "../../utils/relative_imports.ts";
 import { DoubleLinkedDependencyTree } from "../../utils/dependency_tree.ts";
+import { pollJobWithQueueLogging } from "../../utils/job_polling.ts";
 
 const TOP_HASH = "__flow_hash";
 async function generateFlowHash(
@@ -341,84 +342,71 @@ export async function updateFlow(
   rawWorkspaceDependencies: Record<string, string>,
   tempScriptRefs?: Record<string, string>
 ): Promise<FlowValue | undefined> {
-  let rawResponse;
-
-  if (Object.keys(rawWorkspaceDependencies).length > 0) {
+  const useRawWorkspaceDeps = Object.keys(rawWorkspaceDependencies).length > 0;
+  if (useRawWorkspaceDeps) {
     log.info(
       colors.blue("Using raw workspace dependencies for flow dependencies")
     );
-
-    // generate the script lock running a dependency job in Windmill and update it inplace
-    const extraHeaders = getHeaders();
-    rawResponse = await fetch(
-      `${workspace.remote}api/w/${workspace.workspaceId}/jobs/run/flow_dependencies`,
-      {
-        method: "POST",
-        headers: {
-          Cookie: `token=${workspace.token}`,
-          "Content-Type": "application/json",
-          ...extraHeaders,
-        },
-        body: JSON.stringify({
-          flow_value,
-          path: remotePath,
-          use_local_lockfiles: true,
-          raw_workspace_dependencies: rawWorkspaceDependencies,
-          ...(tempScriptRefs && Object.keys(tempScriptRefs).length > 0
-            ? { temp_script_refs: tempScriptRefs }
-            : {}),
-        }),
-      }
-    );
-  } else {
-    // Standard dependency resolution on the server
-    const extraHeaders = getHeaders();
-    rawResponse = await fetch(
-      `${workspace.remote}api/w/${workspace.workspaceId}/jobs/run/flow_dependencies`,
-      {
-        method: "POST",
-        headers: {
-          Cookie: `token=${workspace.token}`,
-          "Content-Type": "application/json",
-          ...extraHeaders,
-        },
-        body: JSON.stringify({
-          flow_value,
-          path: remotePath,
-          ...(tempScriptRefs && Object.keys(tempScriptRefs).length > 0
-            ? { temp_script_refs: tempScriptRefs }
-            : {}),
-        }),
-      }
-    );
   }
 
-  let responseText = "reading response failed";
-  try {
-    const res = (await rawResponse.json()) as
-      | { updated_flow_value: any }
-      | { error: { message: string } }
-      | undefined;
-    if (rawResponse.status != 200) {
-      const msg = (res as any)?.["error"]?.["message"];
-      if (msg) {
-        throw new LockfileGenerationError(
-          `Failed to generate lockfile: ${msg}`
-        );
-      }
-      throw new LockfileGenerationError(
-        `Failed to generate lockfile: ${rawResponse.statusText}, ${responseText}`
-      );
+  const body: Record<string, unknown> = {
+    flow_value,
+    path: remotePath,
+  };
+  if (useRawWorkspaceDeps) {
+    body.use_local_lockfiles = true;
+    body.raw_workspace_dependencies = rawWorkspaceDependencies;
+  }
+  if (tempScriptRefs && Object.keys(tempScriptRefs).length > 0) {
+    body.temp_script_refs = tempScriptRefs;
+  }
+
+  const extraHeaders = getHeaders();
+  const queueResponse = await fetch(
+    `${workspace.remote}api/w/${workspace.workspaceId}/jobs/run/flow_dependencies_async`,
+    {
+      method: "POST",
+      headers: {
+        Cookie: `token=${workspace.token}`,
+        "Content-Type": "application/json",
+        ...extraHeaders,
+      },
+      body: JSON.stringify(body),
     }
-    return (res as any).updated_flow_value;
-  } catch (e) {
+  );
+
+  if (!queueResponse.ok) {
+    let bodyText = "";
     try {
-      responseText = await rawResponse.text();
-    } catch {
-      responseText = "";
-    }
-    throw new Error(
-      `Failed to generate lockfile. Status was: ${rawResponse.statusText}, ${responseText}, ${e}`
+      bodyText = await queueResponse.text();
+    } catch { /* ignore */ }
+    throw new LockfileGenerationError(
+      `Failed to queue flow dependencies job: ${queueResponse.status} ${queueResponse.statusText}, ${bodyText}`
     );
   }
+
+  const jobId = (await queueResponse.text()).trim();
+
+  let completion;
+  try {
+    completion = await pollJobWithQueueLogging(
+      workspace.workspaceId,
+      jobId,
+      { label: `flow deps ${remotePath}` },
+    );
+  } catch (e: any) {
+    throw new LockfileGenerationError(
+      `Failed to poll flow dependencies job ${jobId}: ${e?.message ?? e}`
+    );
+  }
+
+  const result = completion.result as any;
+  if (!completion.success) {
+    const message =
+      result?.error?.message ??
+      (typeof result === "string" ? result : JSON.stringify(result, null, 2));
+    throw new LockfileGenerationError(`Failed to generate lockfile: ${message}`);
+  }
+
+  return result?.updated_flow_value;
 }

--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -53,6 +53,7 @@ import {
   readConfigFile,
 } from "../../core/conf.ts";
 import { SyncCodebase, listSyncCodebases } from "../../utils/codebase.ts";
+import { pollJobWithQueueLogging } from "../../utils/job_polling.ts";
 import fs from "node:fs";
 import { createTarBlob, type TarEntry } from "../../utils/tar.ts";
 
@@ -1143,25 +1144,11 @@ export async function track_job(workspace: string, id: string) {
   }
 }
 
-const POLL_INTERVAL_MS = 2000;
-
 export async function pollForJobResult(
   workspace: string,
   jobId: string,
 ): Promise<{ result: unknown; success: boolean }> {
-  while (true) {
-    const maybeResult = await wmill.getCompletedJobResultMaybe({
-      workspace,
-      id: jobId,
-      getStarted: false,
-    });
-
-    if (maybeResult.completed) {
-      return { result: maybeResult.result, success: maybeResult.success ?? false };
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-  }
+  return await pollJobWithQueueLogging(workspace, jobId);
 }
 
 async function show(opts: GlobalOptions, path: string) {

--- a/cli/src/utils/job_polling.ts
+++ b/cli/src/utils/job_polling.ts
@@ -9,10 +9,10 @@ const QUEUE_LOG_INTERVAL_MS = 5000;
 
 export type JobCompletion = { result: unknown; success: boolean };
 
-async function logQueueStatus(
+export async function logQueueStatus(
   workspace: string,
   jobId: string,
-  label: string,
+  label: string = "Job ",
 ): Promise<void> {
   try {
     const job: any = await wmill.getJob({ workspace, id: jobId });

--- a/cli/src/utils/job_polling.ts
+++ b/cli/src/utils/job_polling.ts
@@ -6,6 +6,7 @@ const DEFAULT_FAST_POLL_INTERVAL_MS = 100;
 const DEFAULT_FAST_POLL_DURATION_MS = 2000;
 const DEFAULT_SLOW_POLL_INTERVAL_MS = 2000;
 const QUEUE_LOG_INTERVAL_MS = 5000;
+const MAX_CONSECUTIVE_POLL_ERRORS = 10;
 
 export type JobCompletion = { result: unknown; success: boolean };
 
@@ -85,16 +86,33 @@ export async function pollJobWithQueueLogging(
   const label = options?.label ? `[${options.label}] ` : "Job ";
   const startedAt = Date.now();
   let lastQueueLogAt = Date.now();
+  let consecutiveErrors = 0;
 
   while (true) {
-    const maybe = await wmill.getCompletedJobResultMaybe({
-      workspace,
-      id: jobId,
-      getStarted: false,
-    });
+    try {
+      const maybe = await wmill.getCompletedJobResultMaybe({
+        workspace,
+        id: jobId,
+        getStarted: false,
+      });
 
-    if (maybe.completed) {
-      return { result: maybe.result, success: maybe.success ?? false };
+      consecutiveErrors = 0;
+
+      if (maybe.completed) {
+        return { result: maybe.result, success: maybe.success ?? false };
+      }
+    } catch (err: any) {
+      consecutiveErrors++;
+      log.warn(
+        colors.yellow(
+          `${label}${jobId}: error checking job status (${consecutiveErrors}/${MAX_CONSECUTIVE_POLL_ERRORS}): ${err?.message ?? err}`,
+        ),
+      );
+      if (consecutiveErrors >= MAX_CONSECUTIVE_POLL_ERRORS) {
+        throw new Error(
+          `Giving up polling job ${jobId} after ${MAX_CONSECUTIVE_POLL_ERRORS} consecutive errors. Last error: ${err?.message ?? err}`,
+        );
+      }
     }
 
     if (Date.now() - lastQueueLogAt >= QUEUE_LOG_INTERVAL_MS) {

--- a/cli/src/utils/job_polling.ts
+++ b/cli/src/utils/job_polling.ts
@@ -1,0 +1,111 @@
+import * as wmill from "../../gen/services.gen.ts";
+import * as log from "../core/log.ts";
+import { colors } from "@cliffy/ansi/colors";
+
+const DEFAULT_FAST_POLL_INTERVAL_MS = 100;
+const DEFAULT_FAST_POLL_DURATION_MS = 2000;
+const DEFAULT_SLOW_POLL_INTERVAL_MS = 2000;
+const QUEUE_LOG_INTERVAL_MS = 5000;
+
+export type JobCompletion = { result: unknown; success: boolean };
+
+async function logQueueStatus(
+  workspace: string,
+  jobId: string,
+  label: string,
+): Promise<void> {
+  try {
+    const job: any = await wmill.getJob({ workspace, id: jobId });
+    if (!job) return;
+
+    if (job.running === true) {
+      log.info(
+        colors.gray(`${label}${jobId}: running, waiting for completion...`),
+      );
+      return;
+    }
+
+    if (typeof job.running !== "boolean") {
+      return;
+    }
+
+    const scheduledFor = job.scheduled_for as string | undefined;
+    if (!scheduledFor) {
+      log.info(colors.gray(`${label}${jobId}: queued, waiting for executor...`));
+      return;
+    }
+
+    const scheduledForMs = new Date(scheduledFor).getTime();
+    if (!Number.isFinite(scheduledForMs)) {
+      log.info(colors.gray(`${label}${jobId}: queued, waiting for executor...`));
+      return;
+    }
+
+    try {
+      const pos = await wmill.getQueuePosition({
+        workspace,
+        scheduledFor: scheduledForMs,
+      });
+      const position = (pos as any)?.position;
+      if (position != null) {
+        log.info(
+          colors.gray(
+            `${label}${jobId}: queued, waiting for executor (position ${position} in queue)`,
+          ),
+        );
+      } else {
+        log.info(
+          colors.gray(`${label}${jobId}: queued, waiting for executor...`),
+        );
+      }
+    } catch {
+      log.info(colors.gray(`${label}${jobId}: queued, waiting for executor...`));
+    }
+  } catch {
+    // getJob may fail transiently; ignore and retry on next tick
+  }
+}
+
+export async function pollJobWithQueueLogging(
+  workspace: string,
+  jobId: string,
+  options?: {
+    fastPollIntervalMs?: number;
+    fastPollDurationMs?: number;
+    slowPollIntervalMs?: number;
+    label?: string;
+  },
+): Promise<JobCompletion> {
+  const fastPollIntervalMs =
+    options?.fastPollIntervalMs ?? DEFAULT_FAST_POLL_INTERVAL_MS;
+  const fastPollDurationMs =
+    options?.fastPollDurationMs ?? DEFAULT_FAST_POLL_DURATION_MS;
+  const slowPollIntervalMs =
+    options?.slowPollIntervalMs ?? DEFAULT_SLOW_POLL_INTERVAL_MS;
+  const label = options?.label ? `[${options.label}] ` : "Job ";
+  const startedAt = Date.now();
+  let lastQueueLogAt = Date.now();
+
+  while (true) {
+    const maybe = await wmill.getCompletedJobResultMaybe({
+      workspace,
+      id: jobId,
+      getStarted: false,
+    });
+
+    if (maybe.completed) {
+      return { result: maybe.result, success: maybe.success ?? false };
+    }
+
+    if (Date.now() - lastQueueLogAt >= QUEUE_LOG_INTERVAL_MS) {
+      lastQueueLogAt = Date.now();
+      await logQueueStatus(workspace, jobId, label);
+    }
+
+    const delayMs =
+      Date.now() - startedAt < fastPollDurationMs
+        ? fastPollIntervalMs
+        : slowPollIntervalMs;
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+}

--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -28,6 +28,7 @@ import { argSigToJsonSchemaType } from "../../windmill-utils-internal/src/parse/
 import { getIsWin } from "./utils.ts";
 import { extractRelativeImports } from "./relative_imports.ts";
 import { DoubleLinkedDependencyTree } from "./dependency_tree.ts";
+import { pollJobWithQueueLogging } from "./job_polling.ts";
 
 const _require = createRequire(import.meta.url);
 const _parserCache = new Map<string, Promise<any>>();
@@ -578,8 +579,8 @@ async function fetchScriptLock(
   }
 
   const extraHeaders = getHeaders();
-  const rawResponse = await fetch(
-    `${workspace.remote}api/w/${workspace.workspaceId}/jobs/run/dependencies`,
+  const queueResponse = await fetch(
+    `${workspace.remote}api/w/${workspace.workspaceId}/jobs/run/dependencies_async`,
     {
       method: "POST",
       headers: {
@@ -604,33 +605,49 @@ async function fetchScriptLock(
     }
   );
 
-  let responseText = "reading response failed";
-  try {
-    responseText = await rawResponse.text();
-    const response = JSON.parse(responseText);
-    const lock = response.lock;
-    if (lock === undefined) {
-      if (response?.["error"]?.["message"]) {
-        throw new LockfileGenerationError(
-          `Failed to generate lockfile: ${response?.["error"]?.["message"]}`
-        );
-      }
-      throw new LockfileGenerationError(
-        `Failed to generate lockfile: ${JSON.stringify(response, null, 2)}`
-      );
-    }
-    if (cacheKey) {
-      lockCache.set(cacheKey, lock);
-    }
-    return lock;
-  } catch (e) {
-    if (e instanceof LockfileGenerationError) {
-      throw e;
-    }
+  if (!queueResponse.ok) {
+    let bodyText = "";
+    try {
+      bodyText = await queueResponse.text();
+    } catch { /* ignore */ }
     throw new LockfileGenerationError(
-      `Failed to generate lockfile:${rawResponse.statusText}, ${responseText}, ${e}`
+      `Failed to queue dependencies job: ${queueResponse.status} ${queueResponse.statusText}, ${bodyText}`
     );
   }
+
+  const jobId = (await queueResponse.text()).trim();
+
+  let completion;
+  try {
+    completion = await pollJobWithQueueLogging(
+      workspace.workspaceId,
+      jobId,
+      { label: `deps ${remotePath}` },
+    );
+  } catch (e: any) {
+    throw new LockfileGenerationError(
+      `Failed to poll dependencies job ${jobId}: ${e?.message ?? e}`
+    );
+  }
+
+  const result = completion.result as any;
+  if (!completion.success) {
+    const message =
+      result?.error?.message ??
+      (typeof result === "string" ? result : JSON.stringify(result, null, 2));
+    throw new LockfileGenerationError(`Failed to generate lockfile: ${message}`);
+  }
+
+  const lock = result?.lock;
+  if (lock === undefined) {
+    throw new LockfileGenerationError(
+      `Failed to generate lockfile: ${JSON.stringify(result, null, 2)}`
+    );
+  }
+  if (cacheKey) {
+    lockCache.set(cacheKey, lock);
+  }
+  return lock;
 }
 
 async function updateScriptLock(


### PR DESCRIPTION
## Summary
The CLI was still calling the sync `/jobs/run/dependencies` and `/jobs/run/flow_dependencies` endpoints, which keep the HTTP connection open for the duration of the dep job. This replaces those with async variants (new endpoints) and polls for completion from the CLI. While polling, every 5s we also log the job's position in the queue or whether it started running, so users see progress when a worker is busy.

## Changes
- Backend: extract `push_dependencies_job` / `push_flow_dependencies_job` helpers; existing sync handlers call the helper then `run_wait_result` (byte-for-byte equivalent behavior). Add `run_dependencies_job_async` / `run_flow_dependencies_job_async` that return the queued job UUID. Scope check is inherited via the `contains("jobs/run/dependencies")` match.
- OpenAPI: add `runRawScriptDependenciesAsync` and `runFlowDependenciesAsync`.
- CLI: new shared `pollJobWithQueueLogging` helper (`cli/src/utils/job_polling.ts`) — fast initial polling (100ms for 2s, then 2s) matching `run_wait_result`'s internal cadence, plus a 5s-interval queue-position log using `getJob` + `getQueuePosition(scheduled_for)`.
- CLI: `fetchScriptLock` (metadata.ts), `updateFlow` (flow_metadata.ts), and `generateInlineScriptLock` (app_metadata.ts) now queue via the async endpoint and poll.
- CLI: `pollForJobResult` (script.ts) delegates to the shared helper, so `script preview`/`flow preview` also get queue-position logging.
- CLI: `waitForJob` in `app dev` preserves its 50/500/2000ms backoff but adds the same 5s queue-position log.

## Behavioral notes
- Sync endpoints are unchanged logically; same validation, same `push(...)` args, same `run_wait_result`.
- CLI-side deltas vs the previous blocking HTTP: no server-side cancel on client abort (dep jobs are idempotent, benign), and no client-side timeout (`TIMEOUT_WAIT_RESULT` no longer applies since the CLI polls). The perceived-latency delta was mitigated by the fast-then-slow poll cadence.
- No remaining sync job endpoints are called from the CLI (`run_wait_result` is not used anywhere in `cli/src`).

## Test plan
- [ ] `wmill script generate-metadata <deno-script-with-url-import>` writes the expected `script.lock`
- [ ] `wmill flow generate-locks <flow-folder>` writes `inline_script.lock` files
- [ ] `wmill generate-metadata` regenerates inline-script locks for a normal `app.yaml` and for a `.raw_app/backend/*.ts` runnable
- [ ] Pre-queue a long-running sleep job, then trigger a dep generation — verify the CLI prints `queued, waiting for executor (position N in queue)` every ~5s
- [ ] Error path: an inline script with an unresolvable URL surfaces `Failed to generate lockfile: ...` with the worker's error

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CLI dependency jobs to async endpoints with polling and queue-position logs, replacing blocking HTTP calls. Adds resilient polling that tolerates transient API errors, and the backend now returns a job UUID.

- **New Features**
  - Backend: added `/jobs/run/dependencies_async` and `/jobs/run/flow_dependencies_async`; sync endpoints remain.
  - OpenAPI: added `runRawScriptDependenciesAsync` and `runFlowDependenciesAsync`.
  - CLI: shared `pollJobWithQueueLogging` (fast-then-slow polling, logs queue position every 5s via `getJob`/`getQueuePosition`); `app dev` uses the same queue logger.
  - CLI commands now queue and poll: generate inline script locks, `wmill script generate-metadata`, `wmill flow generate-locks` and flow updates, and preview commands. No client timeout; aborting the CLI no longer cancels server-side dep jobs.

- **Bug Fixes**
  - Polling now continues on transient API errors with warnings and stops after 10 consecutive failures.

<sup>Written for commit 00461121efef23161dc2cf093c714e631dda335c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

