### PR TITLE
fix: detect and clearly label OOM in zombie flow alerts

### DIFF
--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -3453,13 +3453,15 @@ async fn handle_zombie_flows(db: &DB) -> error::Result<()> {
                 .worker_last_ping
                 .map(|wp| (now - wp).num_seconds() > 60);
             // Zombie flows between steps are, in practice, almost always the worker
-            // getting OOM-killed mid state-transition. Score the memory signal from
-            // the worker's last ping as a fraction of the cgroup limit — preferring
-            // the cgroup-wide reading and falling back to the windmill process's
-            // jemalloc resident — so the verdict can be stated with appropriate
-            // confidence. If the pod restarted in-place, a fresh worker comes up
-            // with a new worker ID; the flow's recorded worker name still points at
-            // the dead process whose last ping can be under 60s old, and the memory
+            // getting OOM-killed mid state-transition. Score the memory signal at
+            // the worker's last ping as a fraction of the cgroup limit, taking the
+            // larger of the cgroup-wide reading (`worker_memory_usage`) and the
+            // windmill process's jemalloc resident (`worker_wm_memory_usage`) — if
+            // only one is present, that value wins; if both are present, the larger
+            // is the more conservative (higher-signal) choice. If the pod restarted
+            // in-place, a replacement worker process comes up under a new windmill
+            // worker name; this flow's recorded worker name still points at the
+            // dead process whose last ping can be under 60s old, and the memory
             // signal is what lets us catch that window.
             let memory_pct: Option<f64> = flow.worker_memory_total.and_then(|total| {
                 if total <= 0 {
@@ -3471,7 +3473,7 @@ async fn handle_zombie_flows(db: &DB) -> error::Result<()> {
             let oom_strong = memory_pct.is_some_and(|p| p >= 0.85);
             let oom_moderate = memory_pct.is_some_and(|p| p >= 0.60);
             let mem_pct_str = memory_pct
-                .map(|p| format!("{:.0}% of container limit", p * 100.0))
+                .map(|p| format!("{:.1}% of container limit", (p * 100.0).min(100.0)))
                 .unwrap_or_else(|| "memory unknown at last ping".to_string());
             let worker_info = if let Some(worker_name) = flow.worker.as_deref() {
                 let mut s = format!("\nWorker handling the flow: {worker_name}");
@@ -3498,10 +3500,10 @@ async fn handle_zombie_flows(db: &DB) -> error::Result<()> {
                             "WORKER DIED — most likely OOM-killed (no strong memory evidence captured at last ping); less likely: crash, host failure, or network partition".to_string()
                         }
                         (false, true, _) => format!(
-                            "OOM-KILLED — {mem_pct_str} at last ping (a fresh worker may have restarted in the same pod under a new worker ID, which is why this worker's last ping still looks recent)"
+                            "OOM-KILLED — {mem_pct_str} at last ping (a replacement worker process may have started in the same pod under a new windmill worker name; this alert references the dead process's record, which pinged just before being killed)"
                         ),
                         (false, false, true) => format!(
-                            "LIKELY OOM-KILLED — {mem_pct_str} at last ping (a fresh worker may have restarted in the same pod under a new worker ID)"
+                            "LIKELY OOM-KILLED — {mem_pct_str} at last ping (a replacement worker process may have started in the same pod under a new windmill worker name)"
                         ),
                         (false, false, false) => {
                             "worker still pinging with healthy memory — likely deadlocked or blocking on the state transition".to_string()
@@ -3549,15 +3551,15 @@ async fn handle_zombie_flows(db: &DB) -> error::Result<()> {
                     .to_string()
             };
 
-            let hint: String = match (worker_ping_stale, oom_strong || oom_moderate) {
+            let hint: String = match (worker_ping_stale, oom_moderate) {
                 (Some(_), true) => format!(
                     "\nThis is almost certainly an OOM-kill: container memory at the worker's last ping was at {mem_pct_str}. Raise the worker memory limit (e.g. k8s `resources.limits.memory`) or reduce per-flow memory usage. Confirm via pod restart count (`kubectl describe pod` / `kube_pod_container_status_last_terminated_reason`)."
                 ),
                 (Some(true), false) => {
-                    "\nWorker stopped pinging and no memory snapshot was captured at last ping — in practice the overwhelmingly common cause here is still OOM-kill (the worker died too fast to report it). First check pod restart count (`kubectl describe pod` / `kube_pod_container_status_last_terminated_reason`). Less likely: host failure, network partition, or a panic — check worker logs / k8s events around the last ping time.".to_string()
+                    "\nWorker stopped pinging and its last memory snapshot did not look high — in practice the overwhelmingly common cause here is still OOM-kill (memory may have spiked between the last ping and the kill, or never been reported). First check pod restart count (`kubectl describe pod` / `kube_pod_container_status_last_terminated_reason`). Less likely: host failure, network partition, or a panic — check worker logs / k8s events around the last ping time.".to_string()
                 }
                 (Some(false), false) => {
-                    "\nWorker is still pinging and memory looked healthy at its last ping — most likely a deadlock or blocking call during the state transition. Capture a stack trace (e.g. via SIGQUIT) from the worker process. As a sanity check, also verify pod restart count in case a fresh worker under a new ID has silently taken over.".to_string()
+                    "\nWorker is still pinging and memory looked healthy at its last ping — most likely a deadlock or blocking call during the state transition. Capture a stack trace (e.g. via SIGQUIT) from the worker process. As a sanity check, also verify pod restart count in case a replacement worker process in the same pod has silently taken over.".to_string()
                 }
                 (None, _) => String::new(),
             };

--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -3452,6 +3452,27 @@ async fn handle_zombie_flows(db: &DB) -> error::Result<()> {
             let worker_ping_stale = flow
                 .worker_last_ping
                 .map(|wp| (now - wp).num_seconds() > 60);
+            // Zombie flows between steps are, in practice, almost always the worker
+            // getting OOM-killed mid state-transition. Score the memory signal from
+            // the worker's last ping as a fraction of the cgroup limit — preferring
+            // the cgroup-wide reading and falling back to the windmill process's
+            // jemalloc resident — so the verdict can be stated with appropriate
+            // confidence. If the pod restarted in-place, a fresh worker comes up
+            // with a new worker ID; the flow's recorded worker name still points at
+            // the dead process whose last ping can be under 60s old, and the memory
+            // signal is what lets us catch that window.
+            let memory_pct: Option<f64> = flow.worker_memory_total.and_then(|total| {
+                if total <= 0 {
+                    return None;
+                }
+                let used = flow.worker_memory_usage.max(flow.worker_wm_memory_usage)?;
+                Some(used as f64 / total as f64)
+            });
+            let oom_strong = memory_pct.is_some_and(|p| p >= 0.85);
+            let oom_moderate = memory_pct.is_some_and(|p| p >= 0.60);
+            let mem_pct_str = memory_pct
+                .map(|p| format!("{:.0}% of container limit", p * 100.0))
+                .unwrap_or_else(|| "memory unknown at last ping".to_string());
             let worker_info = if let Some(worker_name) = flow.worker.as_deref() {
                 let mut s = format!("\nWorker handling the flow: {worker_name}");
                 match (flow.worker_group.as_deref(), flow.worker_version.as_deref()) {
@@ -3462,10 +3483,29 @@ async fn handle_zombie_flows(db: &DB) -> error::Result<()> {
                 }
                 if let Some(wp) = flow.worker_last_ping {
                     let age = (now - wp).num_seconds();
-                    let status = if worker_ping_stale.unwrap_or(false) {
-                        "APPEARS DEAD OR CRASHED — worker ping is stale"
-                    } else {
-                        "worker still pinging — likely deadlocked or blocking on the state transition"
+                    let status: String = match (
+                        worker_ping_stale.unwrap_or(false),
+                        oom_strong,
+                        oom_moderate,
+                    ) {
+                        (true, true, _) => format!(
+                            "OOM-KILLED — {mem_pct_str} at last ping, worker then stopped pinging"
+                        ),
+                        (true, false, true) => format!(
+                            "LIKELY OOM-KILLED — {mem_pct_str} at last ping, worker then stopped pinging"
+                        ),
+                        (true, false, false) => {
+                            "WORKER DIED — most likely OOM-killed (no strong memory evidence captured at last ping); less likely: crash, host failure, or network partition".to_string()
+                        }
+                        (false, true, _) => format!(
+                            "OOM-KILLED — {mem_pct_str} at last ping (a fresh worker may have restarted in the same pod under a new worker ID, which is why this worker's last ping still looks recent)"
+                        ),
+                        (false, false, true) => format!(
+                            "LIKELY OOM-KILLED — {mem_pct_str} at last ping (a fresh worker may have restarted in the same pod under a new worker ID)"
+                        ),
+                        (false, false, false) => {
+                            "worker still pinging with healthy memory — likely deadlocked or blocking on the state transition".to_string()
+                        }
                     };
                     s.push_str(&format!("\nWorker last ping: {wp} ({age}s ago) — {status}"));
                     if let Some(cjid) = flow.worker_current_job_id {
@@ -3509,10 +3549,17 @@ async fn handle_zombie_flows(db: &DB) -> error::Result<()> {
                     .to_string()
             };
 
-            let hint = match worker_ping_stale {
-                Some(true) => "\nThe worker's own ping is stale — it likely crashed, was killed (OOM?), or lost network connectivity. Check worker logs, k8s/docker events, or host dmesg around the worker's last ping time.",
-                Some(false) => "\nThe worker is still pinging — it is likely deadlocked or stuck in a blocking call during the state transition. Capture a stack trace from the worker process (e.g. via SIGQUIT or a debugger).",
-                None => "",
+            let hint: String = match (worker_ping_stale, oom_strong || oom_moderate) {
+                (Some(_), true) => format!(
+                    "\nThis is almost certainly an OOM-kill: container memory at the worker's last ping was at {mem_pct_str}. Raise the worker memory limit (e.g. k8s `resources.limits.memory`) or reduce per-flow memory usage. Confirm via pod restart count (`kubectl describe pod` / `kube_pod_container_status_last_terminated_reason`)."
+                ),
+                (Some(true), false) => {
+                    "\nWorker stopped pinging and no memory snapshot was captured at last ping — in practice the overwhelmingly common cause here is still OOM-kill (the worker died too fast to report it). First check pod restart count (`kubectl describe pod` / `kube_pod_container_status_last_terminated_reason`). Less likely: host failure, network partition, or a panic — check worker logs / k8s events around the last ping time.".to_string()
+                }
+                (Some(false), false) => {
+                    "\nWorker is still pinging and memory looked healthy at its last ping — most likely a deadlock or blocking call during the state transition. Capture a stack trace (e.g. via SIGQUIT) from the worker process. As a sanity check, also verify pod restart count in case a fresh worker under a new ID has silently taken over.".to_string()
+                }
+                (None, _) => String::new(),
             };
 
             let service_logs_info = match (flow.worker_instance.as_deref(), flow.worker_last_ping) {


### PR DESCRIPTION
## Summary

Zombie flows between steps are empirically almost always caused by the worker being OOM-killed mid state-transition. The current alert either mislabels this case as "APPEARS DEAD OR CRASHED" (stale worker ping) or "likely deadlocked" (recent worker ping), making operators chase the wrong diagnosis. This PR makes the alert say `OOM-KILLED` / `LIKELY OOM-KILLED` explicitly when the memory evidence supports it, and frames OOM as the default suspicion even when evidence is missing.

## Changes

- Replace the boolean `likely_oom` heuristic (with inconsistent 100%/95% thresholds on the two memory columns) with a single `memory_pct: Option<f64>` computed from `max(worker_memory_usage, worker_wm_memory_usage) / worker_memory_total`, tiered into `oom_strong ≥ 85%` and `oom_moderate ≥ 60%`.
- Rewrite the worker status line into a 6-arm match over `(ping_stale, oom_strong, oom_moderate)`. Every arm except the `(recent ping, healthy memory)` one now leads with `OOM-KILLED` or `LIKELY OOM-KILLED` and includes the exact memory percentage inline.
- The `(stale ping, no memory evidence)` arm — today labelled "APPEARS DEAD OR CRASHED" — now says `WORKER DIED — most likely OOM-killed`, matching the empirical prior.
- Rewrite the actionable hint the same way: when memory evidence exists, "This is almost certainly an OOM-kill…" with the percentage and concrete remediations (raise memory limit, check pod restart count). The deadlock framing is reserved for the one arm where it actually fits.

## Test plan

- [ ] Set `FLOW_ZOMBIE_TRANSITION_TIMEOUT=10` and stall a flow between two steps on a worker whose container has a tight `memory.limit`; allocate aggressively in a script to get OOM-killed; verify the resulting critical-alert notification leads with `OOM-KILLED` (or `LIKELY OOM-KILLED`) and includes the container-limit percentage.
- [ ] Kill a worker (`kill -9`) mid state-transition without memory pressure and verify the alert says `WORKER DIED — most likely OOM-killed (no strong memory evidence captured…)` rather than the old "APPEARS DEAD OR CRASHED".
- [ ] Simulate a genuine deadlock (block on a long sleep inside the state-transition path) and verify the alert still says "likely deadlocked" in the one arm that matches.

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clearly label OOM-killed workers in zombie flow alerts to cut misdiagnosis and speed up remediation. Alerts now show memory as a percent of the container limit and catch the “recent ping but dead process” window.

- **Bug Fixes**
  - Compute `memory_pct` from `max(worker_memory_usage, worker_wm_memory_usage) / worker_memory_total`, with tiers: strong ≥85%, moderate ≥60%.
  - Rewrite status logic to match `(ping_stale, oom_strong, oom_moderate)` and lead with `OOM-KILLED`/`LIKELY OOM-KILLED`, including the exact `x.x% of container limit`. Handle the “replacement worker started in the same pod” case where pings look recent but the recorded process was OOM-killed; reserve “likely deadlocked” for healthy memory with recent pings.
  - Default stale, no-evidence cases to “WORKER DIED — most likely OOM-killed,” and update hints to focus on OOM remediation (raise k8s `resources.limits.memory`, verify pod restart count via `kubectl describe pod` / `kube_pod_container_status_last_terminated_reason`). For healthy memory + recent pings, suggest capturing a stack trace and sanity-checking restart count.

<sup>Written for commit 3de5727eb82320618f3796247e0d425238d220ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

