### PR TITLE
fix: trigger failure_module when branchone predicate throws

### DIFF
--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -53,7 +53,7 @@ use windmill_common::runnable_settings::{
 use windmill_common::scripts::{ScriptHash, ScriptRunnableSettingsInline};
 use windmill_common::users::username_to_permissioned_as;
 use windmill_common::utils::WarnAfterExt;
-use windmill_common::worker::{to_raw_value, Connection};
+use windmill_common::worker::{error_to_value, to_raw_value, Connection};
 use windmill_common::{
     add_time, get_latest_flow_version_info_for_path, get_script_info_for_hash, FlowVersionInfo,
     ScriptHashInfo, DB,
@@ -3540,6 +3540,32 @@ async fn push_next_flow_job(
                 ));
             }
         }
+        NextFlowTransform::StepFailure { error } => {
+            let result = Arc::new(to_raw_value(&WrappedError { error }));
+            update_flow_status_after_job_completion(
+                db,
+                client,
+                flow_job.id,
+                &Uuid::nil(),
+                &flow_job.workspace_id,
+                false,
+                None,
+                result,
+                None,
+                false,
+                same_worker_tx,
+                worker_dir,
+                None,
+                worker_name,
+                job_completed_tx,
+                flow_runners,
+                killpill_rx,
+                #[cfg(feature = "benchmark")]
+                &mut BenchmarkIter::new(),
+            )
+            .await?;
+            return Ok(PushNextFlowJob::Done(None));
+        }
     };
 
     // only start runners if we're not already in a squash for loop
@@ -4396,6 +4422,10 @@ enum ContinuePayload {
 enum NextFlowTransform {
     EmptyInnerFlows { branch_chosen: Option<BranchChosen> },
     Continue(ContinuePayload, NextStatus),
+    // The current module failed in-place (e.g. a BranchOne predicate threw).
+    // The error is reported as the step's result so the normal flow machinery
+    // (including `failure_module` and surrounding `skip_failures`) applies.
+    StepFailure { error: serde_json::Value },
 }
 
 fn insert_iter_arg(
@@ -4793,6 +4823,7 @@ async fn compute_next_flow_transform(
                 | FlowStatusModule::WaitingForExecutor { .. } => {
                     let mut branch_chosen = BranchChosen::Default;
                     let idcontext = get_transform_context(&flow_job, previous_id, &status);
+                    let mut predicate_err: Option<Error> = None;
                     for (i, b) in branches.iter().enumerate() {
                         let pred_res = compute_bool_from_expr(
                             &b.expr,
@@ -4818,12 +4849,21 @@ async fn compute_next_flow_transform(
                             )
                             .await;
                         }
-                        let pred = pred_res?;
+                        let pred = match pred_res {
+                            Ok(p) => p,
+                            Err(e) => {
+                                predicate_err = Some(e);
+                                break;
+                            }
+                        };
 
                         if pred {
                             branch_chosen = BranchChosen::Branch { branch: i };
                             break;
                         }
+                    }
+                    if let Some(e) = predicate_err {
+                        return Ok(NextFlowTransform::StepFailure { error: error_to_value(&e) });
                     }
                     branch_chosen
                 }


### PR DESCRIPTION
## Summary

Inside a `forloopflow` with `skip_failures: true`, a branchone whose predicate threw was silently swallowed: the overall flow reported `success`, the iteration's `failure_module` never ran, and no alert surfaced. See #8889.

Root cause: when a predicate throws in `compute_bool_from_expr`, the error was `?`-propagated out of `compute_next_flow_transform` → `push_next_flow_job` → `handle_flow` → `handle_queued_job`, causing the iteration subflow to exit through the worker's **unhandled-error path** (`handle_job_error`). For a job that has a `parent_job`, that path reports the failure directly to the parent flow and skips the subflow's own `failure_module` entirely. Script steps don't hit this path — their completion goes through the normal `update_flow_status_after_job_completion` which triggers the `failure_module` copied into each iteration subflow.

The fix catches the predicate error before it escapes and routes it through the same completion path a failing script would use. Result: predicate errors now behave exactly like failing script steps — `failure_module`, `skip_failures`, and the workspace error handler all apply as expected.

## Changes

- Add `NextFlowTransform::StepFailure { error }` variant to represent an in-place module failure.
- In `compute_next_flow_transform`'s `BranchOne` arm, catch `compute_bool_from_expr` errors into a local `predicate_err`, break the branch loop, and return `StepFailure` instead of `?`-propagating.
- In `push_next_flow_job`, handle `StepFailure` by wrapping the error as a `WrappedError` and calling `update_flow_status_after_job_completion(flow=self, job_id=nil, success=false, result=<error>)`. The normal machinery then marks the module `Failure`, runs the iteration's `failure_module` if defined, applies `skip_failures` on a surrounding loop, etc.
- Keep `append_predicate_error_to_root_logs` so the predicate error still shows up in the root flow logs.

## Test plan

Verified manually (backend preview_flow runs) against the reproduction in #8889. Now matches the equivalent script-step behavior in every case:

| Scenario | Before | After |
|---|---|---|
| Predicate throws, inside forloop `skip_failures: true`, outer `failure_module` | **silent** — flow success, no handler | iteration's `failure_module` runs, error visible in iteration result |
| Predicate throws, inside forloop `skip_failures: false`, outer `failure_module` | outer `failure_module` ran (accidental path) | iteration's `failure_module` runs, flow fails — consistent with script errors |
| Predicate throws, direct branchone, `failure_module` defined | flow errored via fragile path | flow fails, `failure_module` runs, module marked `Failure` |
| Predicate throws, no `failure_module` | flow errored | flow fails with predicate error as result |
| Branchone happy path (branch chosen / default) | works | unchanged |

- [ ] QA: forloop (`skip_failures: true`) → branchone with a throwing predicate (e.g. `flow_input.iter.value.skip.toLowerCase() == "200"`) → flow-level `failure_module`. Run with mixed inputs; confirm `failure_module` runs per failing iteration and the predicate error appears in flow logs.
- [ ] QA: direct branchone (no forloop) with a throwing predicate + `failure_module` — confirm handler runs.
- [ ] QA: existing branchone happy paths still work (branch chosen and default branch).

Closes #8889

---
Generated with [Claude Code](https://claude.com/claude-code)