### PR TITLE
fix(cli): handle fileset child add/delete in push

### DIFF
--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -3397,12 +3397,48 @@ export async function push(
                 await writeFile(stateTarget, change.after, "utf-8");
               }
             } else if (change.name === "added") {
+              if (isFilesetResource(change.path)) {
+                // Re-push the parent resource so the new fileset file is included.
+                // If the parent is also being added here, its own push covers all children.
+                let resourceFilePath: string | undefined;
+                try {
+                  resourceFilePath = await findFilesetResourceFile(change.path);
+                } catch {
+                  continue;
+                }
+                if (alreadySynced.includes(resourceFilePath)) {
+                  continue;
+                }
+                alreadySynced.push(resourceFilePath);
+
+                const newObj = parseFromPath(
+                  resourceFilePath,
+                  await readFile(resourceFilePath, "utf-8"),
+                );
+
+                let serverPath = resourceFilePath;
+                const currentBranch = cachedWsNameForPush;
+                if (currentBranch && isWorkspaceSpecificFile(resourceFilePath)) {
+                  serverPath = fromWorkspaceSpecificPath(
+                    resourceFilePath,
+                    currentBranch,
+                  );
+                }
+
+                await pushResource(
+                  workspace.workspaceId,
+                  serverPath,
+                  undefined,
+                  newObj,
+                  resourceFilePath,
+                );
+                continue;
+              }
               if (
                 change.path.endsWith(".script.json") ||
                 change.path.endsWith(".script.yaml") ||
                 change.path.endsWith(".lock") ||
-                isFileResource(change.path) ||
-                isFilesetResource(change.path)
+                isFileResource(change.path)
               ) {
                 continue;
               } else if (
@@ -3481,6 +3517,44 @@ export async function push(
                   opts,
                   rawWorkspaceDependencies,
                   codebases,
+                );
+                continue;
+              }
+              if (isFilesetResource(change.path)) {
+                // Re-push the parent resource with the updated fileset contents.
+                // If the parent is also being deleted, its own "deleted" change
+                // removes the whole resource, so skip this child.
+                let resourceFilePath: string | undefined;
+                try {
+                  resourceFilePath = await findFilesetResourceFile(change.path);
+                } catch {
+                  continue;
+                }
+                if (alreadySynced.includes(resourceFilePath)) {
+                  continue;
+                }
+                alreadySynced.push(resourceFilePath);
+
+                const newObj = parseFromPath(
+                  resourceFilePath,
+                  await readFile(resourceFilePath, "utf-8"),
+                );
+
+                let serverPath = resourceFilePath;
+                const currentBranch = cachedWsNameForPush;
+                if (currentBranch && isWorkspaceSpecificFile(resourceFilePath)) {
+                  serverPath = fromWorkspaceSpecificPath(
+                    resourceFilePath,
+                    currentBranch,
+                  );
+                }
+
+                await pushResource(
+                  workspace.workspaceId,
+                  serverPath,
+                  undefined,
+                  newObj,
+                  resourceFilePath,
                 );
                 continue;
               }


### PR DESCRIPTION
## Summary
Fixes a bug where the second `wmill sync push` of a fileset resource fails with a 404 on a truncated path (e.g. `f/resources/x.fileset/Databa` instead of `f/resources/x.fileset/Database/qt.fest.sql`).

## Root cause
When the diff produced a `deleted` change for a file inside a `.fileset/` directory, the code fell through to the generic `case "resource"` delete handler and ran `removeSuffix(target, ".resource.json")`. `removeSuffix` unconditionally strips N chars from the end without checking the suffix actually matches, so it chopped 14 chars from a path that didn't end in `.resource.json`, producing a truncated path that the backend rejected.

The symmetric `added` case silently skipped fileset children, so files added to an existing fileset directory were never synced unless the parent `.resource.json` also happened to change.

## Changes
- In the `added` branch of push: when the change path is a fileset child, locate the parent `.resource.{json,yaml}` and re-push the full resource (guarded by `alreadySynced`). Skip if the parent no longer exists locally.
- In the `deleted` branch of push: same treatment — re-push the parent so the updated fileset contents are uploaded, or skip if the parent is also being deleted (its own `deleted` change removes the whole resource server-side).

## Test plan
- [ ] Push a fileset resource twice in a row — second push succeeds (previously 404'd with a truncated path).
- [ ] Add a new file inside an existing `.fileset/` directory without touching the parent `.resource.json` — push uploads the new file.
- [ ] Delete a file from inside an existing `.fileset/` directory — push removes it server-side via a parent re-push.
- [ ] Delete the whole resource (parent `.resource.json` + fileset dir) — resource is deleted, no spurious errors on children.

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `wmill sync push` handling for files inside `.fileset/` by re-pushing the parent resource on child add/delete. Prevents 404s from truncated paths and ensures child changes sync correctly.

- **Bug Fixes**
  - Detect fileset child changes and push the parent `.resource.{json,yaml}` once (guarded by `alreadySynced`).
  - Skip when the parent is missing or also being added/deleted, relying on the parent’s own change.
  - Removed the incorrect delete fallthrough that chopped non-`.resource.json` paths, eliminating truncated-path 404s.

<sup>Written for commit 05bb744da96d90f698454d6784738b2d59c55268. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

