### PR TITLE
fix: apply powershell workspace dependencies to deployed scripts

### DIFF
--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -883,6 +883,7 @@ async fn create_script_internal<'c>(
             || ns.language == ScriptLang::Java
             || ns.language == ScriptLang::Ruby
             || ns.language == ScriptLang::Rlang
+            || ns.language == ScriptLang::Powershell
         // for related places search: ADD_NEW_LANG
     ) {
         Some(String::new())

--- a/backend/windmill-worker/src/pwsh_executor.rs
+++ b/backend/windmill-worker/src/pwsh_executor.rs
@@ -6,7 +6,9 @@ use sqlx::types::Json;
 use tokio::process::Command;
 use windmill_common::client::AuthedClient;
 use windmill_common::error::Error;
+use windmill_common::scripts::ScriptLang;
 use windmill_common::worker::{to_raw_value, write_file, Connection};
+use windmill_common::workspace_dependencies::clean_lock_from_annotations;
 use windmill_queue::{
     append_logs, CanceledBy, MiniPulledJob, INIT_SCRIPT_PATH_PREFIX, PERIODIC_SCRIPT_PATH_PREFIX,
 };
@@ -417,10 +419,16 @@ pub async fn handle_powershell_job(
     // Resolve modules from workspace dependencies and/or script imports
     let all_modules = match &maybe_lock {
         MaybeLock::Resolved { lock } if !lock.is_empty() => {
-            // Deployed script with lock: parse workspace deps from lock, merge with script imports
-            let ws_modules = parse_modules_json(lock)?;
+            // Deployed script with lock: strip workspace-dependencies annotation header,
+            // parse the modules.json body, and merge with script imports.
+            let cleaned = clean_lock_from_annotations(lock, ScriptLang::Powershell);
             let script_modules = parse_script_imports(content);
-            merge_module_requests(ws_modules, script_modules)
+            if cleaned.trim().is_empty() {
+                script_modules
+            } else {
+                let ws_modules = parse_modules_json(&cleaned)?;
+                merge_module_requests(ws_modules, script_modules)
+            }
         }
         MaybeLock::Unresolved { workspace_dependencies } => {
             let script_modules = parse_script_imports(content);
@@ -1068,6 +1076,19 @@ mod tests {
     #[test]
     fn test_parse_modules_json_invalid_json() {
         assert!(parse_modules_json("not json").is_err());
+    }
+
+    #[test]
+    fn test_parse_modules_json_after_cleaning_header() {
+        // Simulates the deployed-script lock: workspace-dependencies header
+        // prepended to the modules.json content. `clean_lock_from_annotations`
+        // strips header lines so the remaining body can be JSON-parsed.
+        let lock = "# workspace-dependencies-mode: manual\n# workspace-dependencies: default:abc123\n{\"modules\": {\"PSWriteColor\": \"1.0.0\"}}";
+        let cleaned = clean_lock_from_annotations(lock, ScriptLang::Powershell);
+        let modules = parse_modules_json(&cleaned).unwrap();
+        assert_eq!(modules.len(), 1);
+        assert_eq!(modules[0].name, "PSWriteColor");
+        assert_eq!(modules[0].version, Some("1.0.0".to_string()));
     }
 
     // --- parse_script_imports tests ---

--- a/backend/windmill-worker/src/worker_lockfiles.rs
+++ b/backend/windmill-worker/src/worker_lockfiles.rs
@@ -2881,6 +2881,7 @@ async fn capture_dependency_job(
             )
             .await?
         }
+        ScriptLang::Powershell => workspace_dependencies.get_powershell()?.unwrap_or_default(),
         // for related places search: ADD_NEW_LANG
         _ => "".to_owned(),
     };


### PR DESCRIPTION
## Summary

PowerShell workspace dependencies (e.g. a workspace-wide `modules.json` declaring `PSWriteColor`) worked when running a script in preview but silently had no effect on deployed scripts — the deployed script ran without the workspace-scoped modules installed. This PR makes deployed PowerShell scripts honor workspace dependencies the same way preview does.

Root cause, three gaps:

1. `capture_dependency_job` had no arm for `ScriptLang::Powershell` and fell through to `_ => "".to_owned()`, so the `modules.json` content resolved from workspace deps was never persisted in the script's `lock` column.
2. At script-create time in `windmill-api-scripts`, PowerShell was missing from the list of languages that trigger a dependency job, so no dep job ever ran to generate/persist the lock for PowerShell.
3. The pwsh executor's `MaybeLock::Resolved` branch called `parse_modules_json` directly on the lock, which also contains the `# workspace-dependencies*` annotation header — that would have failed JSON parsing once (1) and (2) were fixed.

## Changes

- `worker_lockfiles.rs`: add `ScriptLang::Powershell` arm in `capture_dependency_job` that stores `workspace_dependencies.get_powershell()` as the lock body (mirrors how PHP stores composer content).
- `windmill-api-scripts/scripts.rs`: include `ScriptLang::Powershell` in the list of languages that need lock generation at deploy time, so a dependency job is actually pushed.
- `pwsh_executor.rs`: strip the `# workspace-dependencies` annotation header via `clean_lock_from_annotations` before JSON-parsing the body; fall back to script-imports-only when the cleaned body is empty (covers older deployed scripts and scripts with no workspace deps).
- Added a unit test exercising the full header + JSON body parse path.

## Test plan

- [x] `cargo check -p windmill-worker` and `cargo check -p windmill-api-scripts` — clean
- [x] `cargo test -p windmill-worker pwsh_executor::` — 28/28 pass
- [x] End-to-end: create a workspace-deps `{"modules": {"PSWriteColor": "1.0.0"}}`, deploy a PowerShell script that calls `Write-Color` with no `Import-Module`, run the deployed script. Before: fails (cmdlet not recognized). After: lock stored is `# workspace-dependencies-mode: manual\n# workspace-dependencies: default:<hash>\n{"modules": {"PSWriteColor": "1.0.0"}}`, deployed script installs the module and returns `pswritecolor-worked`.
- [x] Preview mode still works unchanged.

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deployed PowerShell scripts now honor workspace dependencies from `modules.json`, matching preview behavior. Fixes missing lock capture and parsing so modules install correctly on deploy.

- **Bug Fixes**
  - Persist PowerShell workspace deps in the script lock by handling `ScriptLang::Powershell` and storing `workspace_dependencies.get_powershell()`.
  - Trigger a dependency job for PowerShell at deploy time in `windmill-api-scripts`.
  - In `pwsh_executor`, strip the `# workspace-dependencies*` header with `clean_lock_from_annotations` before parsing JSON; fall back to script imports if empty. Added a unit test.

<sup>Written for commit 24cf44d48bcaa42df8e8d2b4ab89450e663c9e2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

