### PR TITLE
refactor(cli): extract fileset parent push helper

### DIFF
--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -609,6 +609,48 @@ async function findFilesetResourceFile(changePath: string): Promise<string> {
   throw new Error(`No resource metadata file found for fileset resource: ${changePath}`);
 }
 
+type FilesetPushResult =
+  | { status: "pushed"; resourceFilePath: string }
+  | { status: "already-synced"; resourceFilePath: string }
+  | { status: "parent-missing" };
+
+async function pushFilesetParentResource(
+  childPath: string,
+  workspaceId: string,
+  alreadySynced: string[],
+  cachedWsName: string | null,
+): Promise<FilesetPushResult> {
+  let resourceFilePath: string;
+  try {
+    resourceFilePath = await findFilesetResourceFile(childPath);
+  } catch {
+    return { status: "parent-missing" };
+  }
+  if (alreadySynced.includes(resourceFilePath)) {
+    return { status: "already-synced", resourceFilePath };
+  }
+  alreadySynced.push(resourceFilePath);
+
+  const newObj = parseFromPath(
+    resourceFilePath,
+    await readTextFile(resourceFilePath),
+  );
+
+  let serverPath = resourceFilePath;
+  if (cachedWsName && isWorkspaceSpecificFile(resourceFilePath)) {
+    serverPath = fromWorkspaceSpecificPath(resourceFilePath, cachedWsName);
+  }
+
+  await pushResource(
+    workspaceId,
+    serverPath,
+    undefined,
+    newObj,
+    resourceFilePath,
+  );
+  return { status: "pushed", resourceFilePath };
+}
+
 function ZipFSElement(
   zip: JSZip,
   useYaml: boolean,
@@ -3337,37 +3379,24 @@ export async function push(
                 }
               }
               if (isFilesetResource(change.path)) {
-                const resourceFilePath = await findFilesetResourceFile(change.path);
-                if (!alreadySynced.includes(resourceFilePath)) {
-                  alreadySynced.push(resourceFilePath);
-
-                  const newObj = parseFromPath(
-                    resourceFilePath,
-                    await readTextFile(resourceFilePath),
+                const result = await pushFilesetParentResource(
+                  change.path,
+                  workspace.workspaceId,
+                  alreadySynced,
+                  cachedWsNameForPush,
+                );
+                if (result.status === "parent-missing") {
+                  throw new Error(
+                    `No resource metadata file found for fileset resource: ${change.path}`,
                   );
-
-                  let serverPath = resourceFilePath;
-                  const currentBranch = cachedWsNameForPush;
-
-                  if (currentBranch && isWorkspaceSpecificFile(resourceFilePath)) {
-                    serverPath = fromWorkspaceSpecificPath(
-                      resourceFilePath,
-                      currentBranch,
-                    );
-                  }
-
-                  await pushResource(
-                    workspace.workspaceId,
-                    serverPath,
-                    undefined,
-                    newObj,
-                    resourceFilePath,
-                  );
+                }
+                if (result.status === "pushed") {
                   if (stateTarget) {
                     await writeFile(stateTarget, change.after, "utf-8");
                   }
                   continue;
                 }
+                // "already-synced": fall through (pre-existing behavior).
               }
               const oldObj = parseFromPath(change.path, change.before);
               const newObj = parseFromPath(change.path, change.after);
@@ -3399,39 +3428,14 @@ export async function push(
               }
             } else if (change.name === "added") {
               if (isFilesetResource(change.path)) {
-                // Re-push the parent resource so the new fileset file is included.
-                // If the parent is also being added here, its own push covers all children.
-                let resourceFilePath: string | undefined;
-                try {
-                  resourceFilePath = await findFilesetResourceFile(change.path);
-                } catch {
-                  continue;
-                }
-                if (alreadySynced.includes(resourceFilePath)) {
-                  continue;
-                }
-                alreadySynced.push(resourceFilePath);
-
-                const newObj = parseFromPath(
-                  resourceFilePath,
-                  await readFile(resourceFilePath, "utf-8"),
-                );
-
-                let serverPath = resourceFilePath;
-                const currentBranch = cachedWsNameForPush;
-                if (currentBranch && isWorkspaceSpecificFile(resourceFilePath)) {
-                  serverPath = fromWorkspaceSpecificPath(
-                    resourceFilePath,
-                    currentBranch,
-                  );
-                }
-
-                await pushResource(
+                // Re-push the parent resource (guarded by alreadySynced).
+                // Parent-missing means the parent itself is also being added and
+                // its own change will push the full fileset — safe to skip.
+                await pushFilesetParentResource(
+                  change.path,
                   workspace.workspaceId,
-                  serverPath,
-                  undefined,
-                  newObj,
-                  resourceFilePath,
+                  alreadySynced,
+                  cachedWsNameForPush,
                 );
                 continue;
               }
@@ -3522,40 +3526,14 @@ export async function push(
                 continue;
               }
               if (isFilesetResource(change.path)) {
-                // Re-push the parent resource with the updated fileset contents.
-                // If the parent is also being deleted, its own "deleted" change
-                // removes the whole resource, so skip this child.
-                let resourceFilePath: string | undefined;
-                try {
-                  resourceFilePath = await findFilesetResourceFile(change.path);
-                } catch {
-                  continue;
-                }
-                if (alreadySynced.includes(resourceFilePath)) {
-                  continue;
-                }
-                alreadySynced.push(resourceFilePath);
-
-                const newObj = parseFromPath(
-                  resourceFilePath,
-                  await readFile(resourceFilePath, "utf-8"),
-                );
-
-                let serverPath = resourceFilePath;
-                const currentBranch = cachedWsNameForPush;
-                if (currentBranch && isWorkspaceSpecificFile(resourceFilePath)) {
-                  serverPath = fromWorkspaceSpecificPath(
-                    resourceFilePath,
-                    currentBranch,
-                  );
-                }
-
-                await pushResource(
+                // Re-push the parent resource (guarded by alreadySynced).
+                // Parent-missing means the parent itself is also being deleted
+                // and its own "deleted" change removes the whole resource.
+                await pushFilesetParentResource(
+                  change.path,
                   workspace.workspaceId,
-                  serverPath,
-                  undefined,
-                  newObj,
-                  resourceFilePath,
+                  alreadySynced,
+                  cachedWsNameForPush,
                 );
                 continue;
               }


### PR DESCRIPTION
## Summary
Follow-up to #8910. The fileset parent-resource push block appeared in three places (edited, added, deleted branches of `push`) as near-identical ~25-line copies. This refactor extracts it into a single `pushFilesetParentResource` helper.

## Changes
- Add `pushFilesetParentResource` in `sync.ts` returning a discriminated result (`pushed` / `already-synced` / `parent-missing`).
- Replace the three inline blocks in the `edited`, `added`, and `deleted` branches with calls to the helper. Behavior is preserved per branch:
  - **edited**: throws on `parent-missing` (as before), writes state on `pushed`, falls through on `already-synced` (pre-existing behavior).
  - **added** / **deleted**: skip on all three outcomes (the helper handles the push; callers just `continue`).

Net: 90 deletions, 68 insertions.

## Test plan
- [ ] Re-run the repro from #8910 (push a fileset resource twice) — second push still succeeds.
- [ ] Add a new file inside an existing `.fileset/` directory — push uploads it via parent re-push.
- [ ] Delete a file from inside an existing `.fileset/` directory — push removes it via parent re-push.
- [ ] Edit a file inside an existing `.fileset/` directory — push updates the parent; state file is written.
- [ ] Delete the whole resource (parent `.resource.json` + fileset dir) — resource is deleted, no spurious errors on children.

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a single `pushFilesetParentResource` helper to handle fileset parent pushes across `edited`, `added`, and `deleted` sync paths. This removes duplicated logic and preserves existing push behavior.

- **Refactors**
  - Added `pushFilesetParentResource(childPath, workspaceId, alreadySynced, cachedWsName)` returning a discriminated result: `{ status: "pushed" | "already-synced", resourceFilePath }` or `{ status: "parent-missing" }`.
  - Replaced three near-identical blocks in `edited`, `added`, and `deleted` with the helper.
  - Behavior kept the same:
    - edited: throw on missing parent; write state on push; fall through if already synced.
    - added/deleted: call helper then continue (safe to skip on missing parent).

<sup>Written for commit dcdea666d3c6ed29b3b5ad8dbb2e3648667a43cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

