### PR TITLE
fix: derive debug signing key from JWT_SECRET

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -16242,7 +16242,6 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "lazy_static",
- "rand 0.9.0",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -3879,6 +3879,10 @@ pub async fn reload_jwt_secret_setting(db: &DB) -> error::Result<()> {
 
     JWT_SECRET.store(std::sync::Arc::new(jwt_secret));
 
+    // The debug signing key is derived from JWT_SECRET, so re-derive it here so
+    // rotation propagates to /api/debug/* signing without requiring a restart.
+    windmill_api::reload_debug_signing_key().await;
+
     Ok(())
 }
 

--- a/backend/windmill-api-debug/Cargo.toml
+++ b/backend/windmill-api-debug/Cargo.toml
@@ -18,7 +18,6 @@ chrono.workspace = true
 ed25519-dalek.workspace = true
 hex.workspace = true
 lazy_static.workspace = true
-rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/backend/windmill-api-debug/src/lib.rs
+++ b/backend/windmill-api-debug/src/lib.rs
@@ -37,7 +37,7 @@ use tokio::sync::RwLock;
 use uuid::Uuid;
 use windmill_audit::{audit_oss::audit_log, ActionKind};
 use windmill_common::{
-    db::UserDB, error::JsonResult, jobs::JobKind, scripts::ScriptLang,
+    db::UserDB, error::JsonResult, jobs::JobKind, jwt::JWT_SECRET, scripts::ScriptLang,
     users::username_to_permissioned_as,
 };
 
@@ -48,35 +48,67 @@ pub const DEBUG_TOKEN_TTL_SECS: i64 = 60;
 
 lazy_static::lazy_static! {
     /// Ed25519 signing key for debug tokens.
-    /// Generated at startup if not provided via environment variable.
+    ///
+    /// Derived deterministically from the instance `JWT_SECRET` so all API
+    /// replicas agree on the same key without coordination. Refreshed via
+    /// [`reload_debug_signing_key`] when `JWT_SECRET` is reloaded.
     static ref DEBUG_SIGNING_KEY: Arc<RwLock<Option<SigningKey>>> = Arc::new(RwLock::new(None));
 }
 
-/// Initialize the debug signing key.
-/// Call this at server startup.
-pub async fn init_debug_signing_key() {
-    let mut key_guard = DEBUG_SIGNING_KEY.write().await;
+/// Domain-separation tag so the debug Ed25519 seed cannot be confused with
+/// any other HMAC/HS256 usage of `JWT_SECRET`.
+const DEBUG_KEY_DERIVATION_TAG: &[u8] = b"windmill-debug-signing-key:v1:";
 
-    // Check if key is provided via environment variable (base64-encoded seed)
+fn derive_signing_key_from_jwt_secret(jwt_secret: &str) -> SigningKey {
+    let mut hasher = Sha256::new();
+    hasher.update(DEBUG_KEY_DERIVATION_TAG);
+    hasher.update(jwt_secret.as_bytes());
+    let seed: [u8; 32] = hasher.finalize().into();
+    SigningKey::from_bytes(&seed)
+}
+
+fn compute_debug_signing_key() -> Option<SigningKey> {
+    // Env var override: base64url-encoded 32-byte seed. Useful for tests or
+    // advanced deployments that want to pin the key independently.
     if let Ok(seed_b64) = std::env::var("DEBUG_SIGNING_KEY_SEED") {
-        if let Ok(seed_bytes) = URL_SAFE_NO_PAD.decode(&seed_b64) {
-            if seed_bytes.len() >= 32 {
+        match URL_SAFE_NO_PAD.decode(&seed_b64) {
+            Ok(seed_bytes) if seed_bytes.len() >= 32 => {
                 let mut seed = [0u8; 32];
                 seed.copy_from_slice(&seed_bytes[..32]);
-                *key_guard = Some(SigningKey::from_bytes(&seed));
-                tracing::info!("Debug signing key loaded from environment");
-                return;
+                tracing::info!("Debug signing key loaded from DEBUG_SIGNING_KEY_SEED");
+                return Some(SigningKey::from_bytes(&seed));
             }
+            _ => tracing::warn!(
+                "Invalid DEBUG_SIGNING_KEY_SEED (expect base64url-encoded 32+ bytes); falling back to JWT_SECRET derivation"
+            ),
         }
-        tracing::warn!("Invalid DEBUG_SIGNING_KEY_SEED, generating new key");
     }
 
-    // Generate a new random key using rand
-    let mut seed = [0u8; 32];
-    rand::Rng::fill(&mut rand::rng(), &mut seed);
-    let signing_key = SigningKey::from_bytes(&seed);
-    tracing::info!("Generated new debug signing key");
-    *key_guard = Some(signing_key);
+    let jwt_secret = JWT_SECRET.load();
+    if jwt_secret.is_empty() {
+        return None;
+    }
+    Some(derive_signing_key_from_jwt_secret(&jwt_secret))
+}
+
+/// Initialize the debug signing key. Call once at server startup, after
+/// `reload_jwt_secret_setting` so `JWT_SECRET` is populated.
+pub async fn init_debug_signing_key() {
+    reload_debug_signing_key().await;
+}
+
+/// Recompute and store the debug signing key. Call after `JWT_SECRET` is
+/// (re)loaded so rotation propagates without a pod restart.
+pub async fn reload_debug_signing_key() {
+    let key = compute_debug_signing_key();
+    if key.is_none() {
+        tracing::warn!(
+            "Debug signing key not initialized: JWT_SECRET is empty and DEBUG_SIGNING_KEY_SEED is not set. /api/debug/* endpoints will return an error."
+        );
+    } else {
+        tracing::info!("Debug signing key initialized from JWT_SECRET");
+    }
+    *DEBUG_SIGNING_KEY.write().await = key;
 }
 
 pub fn global_service() -> Router {

--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -216,6 +216,8 @@ pub use windmill_common::utils::HTTP_CLIENT_PERMISSIVE as HTTP_CLIENT;
 
 pub use windmill_common::utils::{COOKIE_DOMAIN, IS_SECURE};
 
+pub use windmill_api_debug::reload_debug_signing_key;
+
 #[cfg(feature = "oauth2")]
 pub use windmill_oauth::OAUTH_CLIENTS;
 


### PR DESCRIPTION
## Summary

Reported on multi-replica k8s deployments: `windmill-extra` (multiplayer server) rejects every client with `Invalid JWT signature` after upgrading. Root cause is that each `windmill-app` replica generates its own **random** Ed25519 signing key at startup. When the browser's `sign_multiplayer` request and the multiplayer server's JWKS fetch land on different replicas, the signatures don't verify.

The regular `JWT_SECRET` does not have this problem — it's DB-backed via `global_settings` and loaded by every replica. The debug signing key (added later for multiplayer + debugger + signed expressions) was implemented standalone and never got wired through the same mechanism.

This PR derives the Ed25519 seed deterministically from `JWT_SECRET`:

```
seed = SHA-256("windmill-debug-signing-key:v1:" || JWT_SECRET)
```

- All replicas share the same `JWT_SECRET` → all replicas compute the same Ed25519 key → JWKS verification works regardless of which pod answers.
- Domain-separation tag keeps the Ed25519 seed independent from any other HS256/HMAC use of `JWT_SECRET`.
- Rotation: `reload_jwt_secret_setting` (monitor.rs) now also calls `reload_debug_signing_key`, so admin-rotating the JWT secret propagates to the debug key without requiring a pod restart.
- `DEBUG_SIGNING_KEY_SEED` env override is preserved for edge cases.
- Random-seed fallback is removed — if `JWT_SECRET` is empty and no env override is set, debug endpoints return a clear error instead of silently desynchronizing across pods.

### Correctness walk-through

1. `backend/src/main.rs:1018` — `initial_load` runs before `run_server` and populates `JWT_SECRET` via `reload_jwt_secret_setting`.
2. `backend/src/main.rs:1188` → `windmill-api/src/lib.rs:368` — `init_debug_signing_key` runs after `JWT_SECRET` is populated.
3. Rotation path (`backend/src/main.rs:1849` → `monitor.rs:3865`) — reload reloads both.

## Workaround (for anyone hitting this before the fix ships)

Set `DEBUG_SIGNING_KEY_SEED` to a shared base64url-encoded 32-byte seed on every `windmill-app` pod:

```bash
openssl rand -base64 32 | tr '+/' '-_' | tr -d '='
```

## Test plan

- [ ] Unit: assert `derive_signing_key_from_jwt_secret` is deterministic for a given input
- [ ] Manual: run two `windmill-app` replicas behind a service, verify that multiplayer connects from a browser regardless of which pod receives the `sign_multiplayer` call and which pod answered `windmill-extra`'s JWKS fetch
- [ ] Manual: rotate `jwt_secret` in superadmin settings; confirm new multiplayer tokens verify and old cached JWKS stops working (extra needs a restart to pick up the new public key)
- [ ] Manual: set `DEBUG_SIGNING_KEY_SEED` and confirm it still overrides the JWT_SECRET derivation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives the debug Ed25519 signing key from `JWT_SECRET` using a tagged SHA-256 seed so all API replicas share the same key, fixing "Invalid JWT signature" failures in `windmill-extra` on multi-replica setups. The key now rotates automatically when `JWT_SECRET` changes.

- **Bug Fixes**
  - Deterministic seed: SHA-256 of `windmill-debug-signing-key:v1:` + `JWT_SECRET`.
  - Rotation: re-derives via `reload_debug_signing_key` when `JWT_SECRET` reloads.
  - Keeps `DEBUG_SIGNING_KEY_SEED` override; removes random fallback and returns a clear error if neither is set.

- **Dependencies**
  - Removed `rand` from `windmill-api-debug`.

<sup>Written for commit 7bf15f02ec16d2586bfe33e6b2a743bb3f1e49d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

