### PR TITLE
fix: align folders page empty state with table style

### DIFF
--- a/frontend/src/routes/(root)/(logged)/folders/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/folders/+page.svelte
@@ -157,7 +157,11 @@
 					{:else}
 						{#if folders.length === 0}
 							<tr>
-								<td colspan="4" class="text-primary mt-2">No folders yet, create one!</td>
+								<Cell colspan="9">
+									<div class="text-xs text-primary py-2 text-center">
+										No folders yet, create one
+									</div>
+								</Cell>
 							</tr>
 						{/if}
 


### PR DESCRIPTION
## Summary
The folders page empty-state message used a raw `<td>` with inconsistent styling, a wrong `colspan="4"` (the table has 9 columns), and an unnecessary trailing `!`. This aligns it with the pattern used in other tables (e.g. workers).

## Changes
- Swap the raw `<td>` for `<Cell colspan="9">` wrapping a centered `<div class="text-xs text-primary py-2 text-center">`, matching the workers page empty state
- Fix `colspan` from 4 → 9 to span the full table
- Drop the trailing `!` from the message

## Test plan
- [ ] In a workspace with no folders, open the Folders page and confirm the empty-state message is centered, full-width, and styled like other tables

---
Generated with [Claude Code](https://claude.com/claude-code)