### PR TITLE
fix: slim app ai chat context

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
@@ -3,8 +3,6 @@
 	import { type Snippet } from 'svelte'
 	import {
 		CheckIcon,
-		Code2,
-		FileCode,
 		HistoryIcon,
 		Loader2,
 		MousePointer2,
@@ -293,38 +291,7 @@
 						{/if}
 						<ProviderModelSelector />
 
-						{#if aiChatManager.mode === AIMode.APP && appContext && (appContext.type !== 'none' || appContext.inspectorElement || appContext.codeSelection)}
-							{#if appContext.type === 'frontend' && appContext.frontendPath && !appContext.selectionExcluded}
-								<div
-									class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 text-2xs"
-									title={appContext.frontendPath}
-								>
-									<FileCode class="w-3 h-3" />
-									<span class="truncate max-w-[80px]">{appContext.frontendPath}</span>
-									<button
-										class="hover:bg-blue-200 dark:hover:bg-blue-800/50 rounded p-0.5 -mr-0.5"
-										onclick={() => appContext.toggleSelectionExcluded?.()}
-										title="Exclude from prompt"
-									>
-										<X class="w-2.5 h-2.5" />
-									</button>
-								</div>
-							{:else if appContext.type === 'backend' && appContext.backendKey && !appContext.selectionExcluded}
-								<div
-									class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 text-2xs"
-									title={appContext.backendKey}
-								>
-									<Code2 class="w-3 h-3" />
-									<span class="truncate max-w-[80px]">{appContext.backendKey}</span>
-									<button
-										class="hover:bg-green-200 dark:hover:bg-green-800/50 rounded p-0.5 -mr-0.5"
-										onclick={() => appContext.toggleSelectionExcluded?.()}
-										title="Exclude from prompt"
-									>
-										<X class="w-2.5 h-2.5" />
-									</button>
-								</div>
-							{/if}
+						{#if aiChatManager.mode === AIMode.APP && appContext && (appContext.inspectorElement || appContext.codeSelection)}
 							{#if appContext.inspectorElement}
 								<div
 									class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 text-2xs"

--- a/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
@@ -141,7 +141,7 @@
 								<div class="text-center text-primary text-xs">No history</div>
 							{:else}
 								<div class="flex flex-col">
-									{#each pastChats as chat}
+									{#each pastChats as chat (chat.id)}
 										<button
 											class="text-left flex flex-row items-center gap-2 justify-between hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md p-1"
 											onclick={() => {
@@ -204,7 +204,7 @@
 			}}
 		>
 			<div class="flex flex-col" bind:clientHeight={height}>
-				{#each messages as message, messageIndex}
+				{#each messages as message, messageIndex (messageIndex)}
 					<AIChatMessage
 						{message}
 						{messageIndex}
@@ -341,7 +341,7 @@
 		{#if (aiChatManager.mode === AIMode.NAVIGATOR || aiChatManager.mode === AIMode.ASK) && suggestions.length > 0 && messages.filter((m) => m.role === 'user').length === 0 && !disabled}
 			<div class="px-2 mt-4">
 				<div class="flex flex-col gap-2">
-					{#each suggestions as suggestion}
+					{#each suggestions as suggestion (suggestion)}
 						<Button
 							on:click={() => submitSuggestion(suggestion)}
 							size="xs2"

--- a/frontend/src/lib/components/copilot/chat/app/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/app/core.test.ts
@@ -235,29 +235,18 @@ describe('prepareAppUserMessage app context', () => {
 	it('does not serialize the current frontend file automatically', () => {
 		const message = prepareAppUserMessage('Update the layout', {
 			type: 'frontend',
-			frontendPath: '/index.tsx',
-			frontendContent: 'const hiddenImplementationDetail = true'
+			frontendPath: '/index.tsx'
 		})
 
 		const content = message.content as string
 		expect(content).toBe('## INSTRUCTIONS:\nUpdate the layout')
 		expect(content).not.toContain('/index.tsx')
-		expect(content).not.toContain('hiddenImplementationDetail')
 	})
 
 	it('does not serialize the current backend runnable automatically', () => {
 		const selectedContext: SelectedContext = {
 			type: 'backend',
-			backendKey: 'loadUsers',
-			backendRunnable: {
-				name: 'Load users',
-				type: 'inline',
-				staticInputs: { admin: true },
-				inlineScript: {
-					language: 'bun',
-					content: 'export async function main() { return "secret" }'
-				}
-			}
+			backendKey: 'loadUsers'
 		}
 
 		const message = prepareAppUserMessage('Use the existing runnable', selectedContext)
@@ -265,15 +254,12 @@ describe('prepareAppUserMessage app context', () => {
 		const content = message.content as string
 		expect(content).toBe('## INSTRUCTIONS:\nUse the existing runnable')
 		expect(content).not.toContain('loadUsers')
-		expect(content).not.toContain('export async function main')
-		expect(content).not.toContain('admin')
 	})
 
 	it('still serializes inspector and code selections', () => {
 		const selectedContext: SelectedContext = {
 			type: 'frontend',
 			frontendPath: '/index.tsx',
-			frontendContent: 'const wholeFileShouldNotBeSent = true',
 			inspectorElement: {
 				path: 'body > button.primary',
 				tagName: 'button',
@@ -304,7 +290,6 @@ describe('prepareAppUserMessage app context', () => {
 		expect(content).toContain('body > button.primary')
 		expect(content).toContain('### CODE SELECTION:')
 		expect(content).toContain('const selectedCode = true')
-		expect(content).not.toContain('wholeFileShouldNotBeSent')
 	})
 
 	it('serializes mentioned frontend files and backend runnables as identifiers only', () => {

--- a/frontend/src/lib/components/copilot/chat/app/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/app/core.test.ts
@@ -120,14 +120,6 @@ function getPatchFileTool() {
 	return tool
 }
 
-describe('app tools', () => {
-	it('does not expose selected editor context as a tool', () => {
-		expect(getAppTools().map((entry) => entry.def.function.name)).not.toContain(
-			'get_selected_context'
-		)
-	})
-})
-
 describe('app patch_file tool', () => {
 	it('patches frontend files with an exact replacement', async () => {
 		const setFrontendFile = vi.fn(() => EMPTY_LINT_RESULT)

--- a/frontend/src/lib/components/copilot/chat/app/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/app/core.test.ts
@@ -93,7 +93,7 @@ function createHelpers(overrides: Partial<AppAIChatHelpers> = {}): AppAIChatHelp
 		setBackendRunnable: async () => EMPTY_LINT_RESULT,
 		deleteBackendRunnable: () => undefined,
 		getFiles: () => ({ frontend: {}, backend: {} }),
-		getSelectedContext: () => ({ type: 'none' }),
+		getSelectedContext: () => ({}),
 		snapshot: () => 1,
 		revertToSnapshot: () => undefined,
 		lint: () => EMPTY_LINT_RESULT,
@@ -236,7 +236,7 @@ describe('prepareAppUserMessage app context', () => {
 		const message = prepareAppUserMessage('Update the layout', {
 			type: 'frontend',
 			frontendPath: '/index.tsx'
-		})
+		} as unknown as SelectedContext)
 
 		const content = message.content as string
 		expect(content).toBe('## INSTRUCTIONS:\nUpdate the layout')
@@ -247,7 +247,7 @@ describe('prepareAppUserMessage app context', () => {
 		const selectedContext: SelectedContext = {
 			type: 'backend',
 			backendKey: 'loadUsers'
-		}
+		} as unknown as SelectedContext
 
 		const message = prepareAppUserMessage('Use the existing runnable', selectedContext)
 
@@ -281,7 +281,7 @@ describe('prepareAppUserMessage app context', () => {
 				startColumn: 1,
 				endColumn: 25
 			}
-		}
+		} as unknown as SelectedContext
 
 		const message = prepareAppUserMessage('Change this selected area', selectedContext)
 

--- a/frontend/src/lib/components/copilot/chat/app/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/app/core.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
-import { getAppTools, type AppAIChatHelpers, type BackendRunnable, type LintResult } from './core'
+import {
+	getAppTools,
+	prepareAppUserMessage,
+	type AppAIChatHelpers,
+	type BackendRunnable,
+	type LintResult,
+	type SelectedContext
+} from './core'
+import type { ContextElement } from '../context'
 
 vi.mock('../shared', () => ({
 	createToolDef: (_schema: unknown, name: string, description: string) => ({
@@ -112,6 +120,14 @@ function getPatchFileTool() {
 	return tool
 }
 
+describe('app tools', () => {
+	it('does not expose selected editor context as a tool', () => {
+		expect(getAppTools().map((entry) => entry.def.function.name)).not.toContain(
+			'get_selected_context'
+		)
+	})
+})
+
 describe('app patch_file tool', () => {
 	it('patches frontend files with an exact replacement', async () => {
 		const setFrontendFile = vi.fn(() => EMPTY_LINT_RESULT)
@@ -212,5 +228,140 @@ describe('app patch_file tool', () => {
 				toolId: 'tool-4'
 			})
 		).rejects.toThrow('generated automatically')
+	})
+})
+
+describe('prepareAppUserMessage app context', () => {
+	it('does not serialize the current frontend file automatically', () => {
+		const message = prepareAppUserMessage('Update the layout', {
+			type: 'frontend',
+			frontendPath: '/index.tsx',
+			frontendContent: 'const hiddenImplementationDetail = true'
+		})
+
+		const content = message.content as string
+		expect(content).toBe('## INSTRUCTIONS:\nUpdate the layout')
+		expect(content).not.toContain('/index.tsx')
+		expect(content).not.toContain('hiddenImplementationDetail')
+	})
+
+	it('does not serialize the current backend runnable automatically', () => {
+		const selectedContext: SelectedContext = {
+			type: 'backend',
+			backendKey: 'loadUsers',
+			backendRunnable: {
+				name: 'Load users',
+				type: 'inline',
+				staticInputs: { admin: true },
+				inlineScript: {
+					language: 'bun',
+					content: 'export async function main() { return "secret" }'
+				}
+			}
+		}
+
+		const message = prepareAppUserMessage('Use the existing runnable', selectedContext)
+
+		const content = message.content as string
+		expect(content).toBe('## INSTRUCTIONS:\nUse the existing runnable')
+		expect(content).not.toContain('loadUsers')
+		expect(content).not.toContain('export async function main')
+		expect(content).not.toContain('admin')
+	})
+
+	it('still serializes inspector and code selections', () => {
+		const selectedContext: SelectedContext = {
+			type: 'frontend',
+			frontendPath: '/index.tsx',
+			frontendContent: 'const wholeFileShouldNotBeSent = true',
+			inspectorElement: {
+				path: 'body > button.primary',
+				tagName: 'button',
+				id: 'save',
+				className: 'primary action',
+				rect: { top: 10, left: 20, width: 120, height: 40 },
+				html: '<button id="save" class="primary action">Save</button>',
+				textContent: 'Save',
+				styles: {}
+			},
+			codeSelection: {
+				type: 'app_code_selection',
+				source: '/index.tsx',
+				sourceType: 'frontend',
+				title: '/index.tsx:3-4',
+				content: 'const selectedCode = true',
+				startLine: 3,
+				endLine: 4,
+				startColumn: 1,
+				endColumn: 25
+			}
+		}
+
+		const message = prepareAppUserMessage('Change this selected area', selectedContext)
+
+		const content = message.content as string
+		expect(content).toContain('The user has selected an element in the app preview')
+		expect(content).toContain('body > button.primary')
+		expect(content).toContain('### CODE SELECTION:')
+		expect(content).toContain('const selectedCode = true')
+		expect(content).not.toContain('wholeFileShouldNotBeSent')
+	})
+
+	it('serializes mentioned frontend files and backend runnables as identifiers only', () => {
+		const additionalContext: ContextElement[] = [
+			{
+				type: 'app_frontend_file',
+				path: '/index.tsx',
+				title: '/index.tsx',
+				content: 'const fullFrontendContent = true'
+			},
+			{
+				type: 'app_backend_runnable',
+				key: 'loadUsers',
+				title: 'loadUsers',
+				runnable: {
+					name: 'Load users',
+					type: 'inline',
+					staticInputs: { admin: true },
+					inlineScript: {
+						language: 'bun',
+						content: 'export async function main() { return "secret" }'
+					}
+				}
+			}
+		]
+
+		const message = prepareAppUserMessage('Wire these together', undefined, additionalContext)
+
+		const content = message.content as string
+		expect(content).toContain('- Frontend file: /index.tsx')
+		expect(content).toContain('- Backend runnable: loadUsers')
+		expect(content).not.toContain('fullFrontendContent')
+		expect(content).not.toContain('export async function main')
+		expect(content).not.toContain('Static inputs')
+		expect(content).not.toContain('Load users')
+	})
+
+	it('keeps mentioned datatable schema context', () => {
+		const additionalContext: ContextElement[] = [
+			{
+				type: 'app_datatable',
+				datatableName: 'main',
+				schemaName: 'public',
+				tableName: 'users',
+				title: 'main/users',
+				columns: {
+					id: 'int4',
+					email: 'text'
+				}
+			}
+		]
+
+		const message = prepareAppUserMessage('Query users', undefined, additionalContext)
+
+		const content = message.content as string
+		expect(content).toContain('**Table: main/users**')
+		expect(content).toContain('"id": "int4"')
+		expect(content).toContain('"email": "text"')
 	})
 })

--- a/frontend/src/lib/components/copilot/chat/app/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/app/core.test.ts
@@ -232,28 +232,20 @@ describe('app patch_file tool', () => {
 })
 
 describe('prepareAppUserMessage app context', () => {
-	it('does not serialize the current frontend file automatically', () => {
-		const message = prepareAppUserMessage('Update the layout', {
+	it('does not serialize implicit selected frontend or backend files', () => {
+		const frontendMessage = prepareAppUserMessage('Update the layout', {
 			type: 'frontend',
 			frontendPath: '/index.tsx'
 		} as unknown as SelectedContext)
-
-		const content = message.content as string
-		expect(content).toBe('## INSTRUCTIONS:\nUpdate the layout')
-		expect(content).not.toContain('/index.tsx')
-	})
-
-	it('does not serialize the current backend runnable automatically', () => {
-		const selectedContext: SelectedContext = {
+		const backendMessage = prepareAppUserMessage('Use the existing runnable', {
 			type: 'backend',
 			backendKey: 'loadUsers'
-		} as unknown as SelectedContext
+		} as unknown as SelectedContext)
 
-		const message = prepareAppUserMessage('Use the existing runnable', selectedContext)
-
-		const content = message.content as string
-		expect(content).toBe('## INSTRUCTIONS:\nUse the existing runnable')
-		expect(content).not.toContain('loadUsers')
+		expect(frontendMessage.content).toBe('## INSTRUCTIONS:\nUpdate the layout')
+		expect(frontendMessage.content).not.toContain('/index.tsx')
+		expect(backendMessage.content).toBe('## INSTRUCTIONS:\nUse the existing runnable')
+		expect(backendMessage.content).not.toContain('loadUsers')
 	})
 
 	it('still serializes inspector and code selections', () => {
@@ -292,7 +284,7 @@ describe('prepareAppUserMessage app context', () => {
 		expect(content).toContain('const selectedCode = true')
 	})
 
-	it('serializes mentioned frontend files and backend runnables as identifiers only', () => {
+	it('serializes explicit mentions with lightweight file context', () => {
 		const additionalContext: ContextElement[] = [
 			{
 				type: 'app_frontend_file',
@@ -313,22 +305,7 @@ describe('prepareAppUserMessage app context', () => {
 						content: 'export async function main() { return "secret" }'
 					}
 				}
-			}
-		]
-
-		const message = prepareAppUserMessage('Wire these together', undefined, additionalContext)
-
-		const content = message.content as string
-		expect(content).toContain('- Frontend file: /index.tsx')
-		expect(content).toContain('- Backend runnable: loadUsers')
-		expect(content).not.toContain('fullFrontendContent')
-		expect(content).not.toContain('export async function main')
-		expect(content).not.toContain('Static inputs')
-		expect(content).not.toContain('Load users')
-	})
-
-	it('keeps mentioned datatable schema context', () => {
-		const additionalContext: ContextElement[] = [
+			},
 			{
 				type: 'app_datatable',
 				datatableName: 'main',
@@ -342,9 +319,15 @@ describe('prepareAppUserMessage app context', () => {
 			}
 		]
 
-		const message = prepareAppUserMessage('Query users', undefined, additionalContext)
+		const message = prepareAppUserMessage('Wire these together', undefined, additionalContext)
 
 		const content = message.content as string
+		expect(content).toContain('- Frontend file: /index.tsx')
+		expect(content).toContain('- Backend runnable: loadUsers')
+		expect(content).not.toContain('fullFrontendContent')
+		expect(content).not.toContain('export async function main')
+		expect(content).not.toContain('Static inputs')
+		expect(content).not.toContain('Load users')
 		expect(content).toContain('**Table: main/users**')
 		expect(content).toContain('"id": "int4"')
 		expect(content).toContain('"email": "text"')

--- a/frontend/src/lib/components/copilot/chat/app/core.ts
+++ b/frontend/src/lib/components/copilot/chat/app/core.ts
@@ -80,14 +80,8 @@ export interface InspectorElementInfo {
 	styles: Record<string, string>
 }
 
-/** Context about the currently selected file or runnable in the app editor */
+/** App editor context that is implicitly attached to app-mode AI messages. */
 export interface SelectedContext {
-	/** Type of selection: 'frontend' for frontend files, 'backend' for backend runnables, or 'none' if nothing is selected */
-	type: 'frontend' | 'backend' | 'none'
-	/** The path of the selected frontend file (when type is 'frontend') */
-	frontendPath?: string
-	/** The key of the selected backend runnable (when type is 'backend') */
-	backendKey?: string
 	/** Inspector-selected element info (when user has used the inspector tool) */
 	inspectorElement?: InspectorElementInfo
 	/** Function to clear the inspector selection */

--- a/frontend/src/lib/components/copilot/chat/app/core.ts
+++ b/frontend/src/lib/components/copilot/chat/app/core.ts
@@ -14,8 +14,6 @@ import { getDatatableSdkReference } from '$system_prompts'
 import { aiChatManager } from '../AIChatManager.svelte'
 import type {
 	ContextElement,
-	AppFrontendFileElement,
-	AppBackendRunnableElement,
 	AppCodeSelectionElement,
 	AppDatatableElement
 } from '../context'
@@ -436,17 +434,6 @@ const getExecDatatableSqlToolDef = memo(() =>
 	)
 )
 
-// ============= Selected Context Tool =============
-
-const getGetSelectedContextSchema = memo(() => z.object({}))
-const getGetSelectedContextToolDef = memo(() =>
-	createToolDef(
-		getGetSelectedContextSchema(),
-		'get_selected_context',
-		'Get information about what is currently selected in the app editor. Returns the type of selection (frontend file or backend runnable) and the path/key of the selected item.'
-	)
-)
-
 // ============= Lint Result Formatting =============
 
 function formatLintMessages(messages: Record<string, string[]>): string {
@@ -558,22 +545,6 @@ export const getAppTools = memo((): Tool<AppAIChatHelpers>[] => [
 			}
 
 			return result
-		}
-	},
-	// Selected context tool
-	{
-		def: getGetSelectedContextToolDef(),
-		fn: async ({ helpers, toolId, toolCallbacks }) => {
-			toolCallbacks.setToolStatus(toolId, { content: 'Getting selected context...' })
-			const context = helpers.getSelectedContext()
-			const statusMsg =
-				context.type === 'frontend'
-					? `Frontend file selected: ${context.frontendPath}`
-					: context.type === 'backend'
-						? `Backend runnable selected: ${context.backendKey}`
-						: 'No selection'
-			toolCallbacks.setToolStatus(toolId, { content: statusMsg })
-			return JSON.stringify(context, null, 2)
 		}
 	},
 	// Frontend tools
@@ -1114,6 +1085,7 @@ When you are using the windmill-client, do not forget that as id for variables o
 4. Use \`lint()\` at the end to check for and fix any remaining errors
 
 When creating a new app, use \`search_workspace\` or \`search_hub_scripts\` to find existing scripts/flows to reuse.
+When the user mentions frontend files or backend runnables in context, only their identifiers are included. Use \`get_frontend_file\` or \`get_backend_runnable\` to inspect their contents before editing them or relying on implementation details.
 
 `
 
@@ -1158,59 +1130,11 @@ export function prepareAppUserMessage(
 
 	// Check if we have any context to add
 	const hasSelectedContext =
-		selectedContext && (selectedContext.type !== 'none' || selectedContext.inspectorElement)
+		selectedContext && (selectedContext.inspectorElement || selectedContext.codeSelection)
 	const hasAdditionalContext = additionalContext && additionalContext.length > 0
 
 	if (hasSelectedContext || hasAdditionalContext) {
 		content += `## SELECTED CONTEXT:\n`
-
-		// Add frontend file context with content (unless excluded)
-		if (
-			selectedContext &&
-			selectedContext.type === 'frontend' &&
-			selectedContext.frontendPath &&
-			!selectedContext.selectionExcluded
-		) {
-			content += `The user is currently viewing the frontend file: **${selectedContext.frontendPath}**\n`
-			if (selectedContext.frontendContent) {
-				const truncatedContent =
-					selectedContext.frontendContent.length > MAX_CONTEXT_CONTENT_LENGTH
-						? selectedContext.frontendContent.slice(0, MAX_CONTEXT_CONTENT_LENGTH) +
-							'\n... [TRUNCATED]'
-						: selectedContext.frontendContent
-				content += `\n\`\`\`\n${truncatedContent}\n\`\`\`\n`
-			}
-		}
-
-		// Add backend runnable context with content (unless excluded)
-		if (
-			selectedContext &&
-			selectedContext.type === 'backend' &&
-			selectedContext.backendKey &&
-			!selectedContext.selectionExcluded
-		) {
-			content += `The user is currently viewing the backend runnable: **${selectedContext.backendKey}**\n`
-			if (selectedContext.backendRunnable) {
-				const runnable = selectedContext.backendRunnable
-				content += `- **Name**: ${runnable.name}\n`
-				content += `- **Type**: ${runnable.type}\n`
-				if (runnable.path) {
-					content += `- **Path**: ${runnable.path}\n`
-				}
-				if (runnable.inlineScript) {
-					const truncatedCode =
-						runnable.inlineScript.content.length > MAX_CONTEXT_CONTENT_LENGTH
-							? runnable.inlineScript.content.slice(0, MAX_CONTEXT_CONTENT_LENGTH) +
-								'\n... [TRUNCATED]'
-							: runnable.inlineScript.content
-					content += `- **Language**: ${runnable.inlineScript.language}\n`
-					content += `- **Code**:\n\`\`\`${runnable.inlineScript.language === 'bun' ? 'typescript' : 'python'}\n${truncatedCode}\n\`\`\`\n`
-				}
-				if (runnable.staticInputs && Object.keys(runnable.staticInputs).length > 0) {
-					content += `- **Static inputs**: ${JSON.stringify(runnable.staticInputs)}\n`
-				}
-			}
-		}
 
 		// Add inspector element context if available
 		if (selectedContext?.inspectorElement) {
@@ -1249,34 +1173,9 @@ export function prepareAppUserMessage(
 
 			for (const ctx of additionalContext) {
 				if (ctx.type === 'app_frontend_file') {
-					const fileCtx = ctx as AppFrontendFileElement
-					content += `\n**Frontend File: ${fileCtx.path}**\n`
-					const truncatedContent =
-						fileCtx.content.length > MAX_CONTEXT_CONTENT_LENGTH
-							? fileCtx.content.slice(0, MAX_CONTEXT_CONTENT_LENGTH) + '\n... [TRUNCATED]'
-							: fileCtx.content
-					content += `\`\`\`\n${truncatedContent}\n\`\`\`\n`
+					content += `\n- Frontend file: ${ctx.path}\n`
 				} else if (ctx.type === 'app_backend_runnable') {
-					const runnableCtx = ctx as AppBackendRunnableElement
-					const runnable = runnableCtx.runnable
-					content += `\n**Backend Runnable: ${runnableCtx.key}**\n`
-					content += `- **Name**: ${runnable.name}\n`
-					content += `- **Type**: ${runnable.type}\n`
-					if (runnable.path) {
-						content += `- **Path**: ${runnable.path}\n`
-					}
-					if (runnable.inlineScript) {
-						const truncatedCode =
-							runnable.inlineScript.content.length > MAX_CONTEXT_CONTENT_LENGTH
-								? runnable.inlineScript.content.slice(0, MAX_CONTEXT_CONTENT_LENGTH) +
-									'\n... [TRUNCATED]'
-								: runnable.inlineScript.content
-						content += `- **Language**: ${runnable.inlineScript.language}\n`
-						content += `- **Code**:\n\`\`\`${runnable.inlineScript.language === 'bun' ? 'typescript' : 'python'}\n${truncatedCode}\n\`\`\`\n`
-					}
-					if (runnable.staticInputs && Object.keys(runnable.staticInputs).length > 0) {
-						content += `- **Static inputs**: ${JSON.stringify(runnable.staticInputs)}\n`
-					}
+					content += `\n- Backend runnable: ${ctx.key}\n`
 				} else if (ctx.type === 'app_datatable') {
 					const datatableCtx = ctx as AppDatatableElement
 					const tableRef =

--- a/frontend/src/lib/components/copilot/chat/app/core.ts
+++ b/frontend/src/lib/components/copilot/chat/app/core.ts
@@ -86,22 +86,12 @@ export interface SelectedContext {
 	type: 'frontend' | 'backend' | 'none'
 	/** The path of the selected frontend file (when type is 'frontend') */
 	frontendPath?: string
-	/** The content of the selected frontend file */
-	frontendContent?: string
 	/** The key of the selected backend runnable (when type is 'backend') */
 	backendKey?: string
-	/** The configuration of the selected backend runnable */
-	backendRunnable?: BackendRunnable
 	/** Inspector-selected element info (when user has used the inspector tool) */
 	inspectorElement?: InspectorElementInfo
-	/** Whether the file/runnable selection is excluded from being sent to the AI prompt */
-	selectionExcluded?: boolean
-	/** Function to toggle whether the selection is excluded from the prompt */
-	toggleSelectionExcluded?: () => void
 	/** Function to clear the inspector selection */
 	clearInspector?: () => void
-	/** Function to clear the runnable selection (go back to frontend view) */
-	clearRunnable?: () => void
 	/** Code selection from the editor (either frontend or backend) */
 	codeSelection?: AppCodeSelectionElement
 	/** Function to clear the code selection */

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -418,21 +418,16 @@
 			getSelectedContext: () => {
 				const baseContext = {
 					inspectorElement: inspectorElement,
-					selectionExcluded: selectionExcludedFromPrompt,
-					toggleSelectionExcluded: toggleSelectionExcluded,
 					clearInspector: clearInspectorSelection,
-					clearRunnable: handleClearRunnable,
 					codeSelection: codeSelection,
 					clearCodeSelection: () => {
 						codeSelection = undefined
 					}
 				}
 				if (selectedRunnable) {
-					const runnable = convertToBackendRunnable(selectedRunnable, runnables[selectedRunnable])
 					return {
 						type: 'backend' as const,
 						backendKey: selectedRunnable,
-						backendRunnable: runnable,
 						...baseContext
 					}
 				}
@@ -440,7 +435,6 @@
 					return {
 						type: 'frontend' as const,
 						frontendPath: selectedDocument,
-						frontendContent: files?.[selectedDocument],
 						...baseContext
 					}
 				}
@@ -608,12 +602,7 @@
 	let selectedRunnable: string | undefined = $state(undefined)
 	let selectedDocument: string | undefined = $state(undefined)
 	let inspectorElement: InspectorElementInfo | undefined = $state(undefined)
-	let selectionExcludedFromPrompt: boolean = $state(false)
 	let codeSelection: AppCodeSelectionElement | undefined = $state(undefined)
-
-	function toggleSelectionExcluded() {
-		selectionExcludedFromPrompt = !selectionExcludedFromPrompt
-	}
 
 	let modules = $state({}) as Modules
 
@@ -722,23 +711,17 @@
 		)
 	}
 
-	function handleClearRunnable() {
-		selectedRunnable = undefined
-	}
-
 	// Track previous values for change detection
 	let prevSelectedRunnable: string | undefined = undefined
 	let prevSelectedDocument: string | undefined = undefined
 
-	// Clear inspector and reset exclusion when selection changes
+	// Clear inspector when selection changes
 	$effect(() => {
 		if (selectedRunnable !== prevSelectedRunnable || selectedDocument !== prevSelectedDocument) {
 			// Only clear if we're actually switching to something different
 			if (prevSelectedRunnable !== undefined || prevSelectedDocument !== undefined) {
 				clearInspectorSelection()
 			}
-			// Reset exclusion when switching files/runnables
-			selectionExcludedFromPrompt = false
 			prevSelectedRunnable = selectedRunnable
 			prevSelectedDocument = selectedDocument
 		}

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -416,31 +416,13 @@
 				}
 			},
 			getSelectedContext: () => {
-				const baseContext = {
+				return {
 					inspectorElement: inspectorElement,
 					clearInspector: clearInspectorSelection,
 					codeSelection: codeSelection,
 					clearCodeSelection: () => {
 						codeSelection = undefined
 					}
-				}
-				if (selectedRunnable) {
-					return {
-						type: 'backend' as const,
-						backendKey: selectedRunnable,
-						...baseContext
-					}
-				}
-				if (selectedDocument) {
-					return {
-						type: 'frontend' as const,
-						frontendPath: selectedDocument,
-						...baseContext
-					}
-				}
-				return {
-					type: 'none' as const,
-					...baseContext
 				}
 			},
 			snapshot: () => {


### PR DESCRIPTION
## Summary
This PR makes app-mode AI chat context explicit instead of implicit.

Before this change, app mode would automatically include the currently selected frontend file or backend runnable in the model prompt just because it was open in the editor. It would also expose that selected editor state through a dedicated tool. In practice, that made app-mode prompts larger and less predictable than they needed to be.

We decided to change this for a few reasons:
- The current file/runnable was hidden prompt context. The AI could receive a large file just because it happened to be open, even when the user did not intend to provide it as context.
- The implicit selection overlapped with explicit `@` mentions and with existing file-reading tools, which meant the same file/runnable context could be duplicated in multiple ways.
- The UI implied that the current file/runnable was part of the active AI context, even though the better model is: if the user wants a file to matter, they should mention it explicitly.
- `get_selected_context` bypassed that explicit model by giving the AI another way to recover selected editor state directly.

The new behavior is:
- Inspector-selected elements and explicit code selections are still included automatically, because they are strong user-intent signals and are not as easy to reconstruct through tools.
- Frontend files and backend runnables are only part of AI context when the user explicitly mentions them with `@`.
- When those files/runnables are mentioned, we send only their identifiers and let the model fetch content on demand via `get_frontend_file` and `get_backend_runnable`.

This makes app-mode context cheaper, less surprising, and more aligned with explicit user intent.

## Changes
- Stop serializing the currently selected frontend file or backend runnable into app-mode user messages
- Keep implicit context only for inspector element selections and explicit code selections
- Serialize `@`-mentioned frontend files and backend runnables as identifiers only instead of embedding their full contents
- Remove the `get_selected_context` app-mode tool so selected editor state cannot bypass the explicit-context flow
- Remove stale current file/runnable badges and the old exclusion toggle/state from the app-mode chat UI
- Trim the remaining selected-context shape so it only carries data that is still actually used
- Keep focused regression coverage for the supported app-mode context behavior

## Test plan
- [x] `npm run test:unit -- --run src/lib/components/copilot/chat/app/core.test.ts`
- [x] `npm run check:fast`
- [x] `npm run check`

---
Generated with [Claude Code](https://claude.com/claude-code)