### PR TITLE
fix: ensure schema is inferred on script/flow module load

### DIFF
--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -202,12 +202,18 @@
 	let testPanelSchema: Schema = $state(emptySchema())
 	// editorCode is what the editor shows; code always holds the main script content
 	let editorCode: string = $state(code)
-	// Sync editorCode when code changes externally (template reset, copilot, etc.)
+	// Sync editorCode when code changes externally (template reset, copilot,
+	// new-script template init, etc.). We also re-run schema inference in that
+	// case — otherwise if the code prop is set after ScriptEditor's onMount (as
+	// happens on /scripts/add when initContent sets script.content after the
+	// editor has already mounted with an empty string), the schema would stay
+	// empty until the user typed into the editor.
 	let lastSyncedCode = code
 	$effect.pre(() => {
 		if (activeModuleTab === null && code !== lastSyncedCode) {
 			editorCode = code
 			lastSyncedCode = code
+			untrack(() => inferSchema(code))
 		}
 	})
 
@@ -1111,8 +1117,14 @@
 		}
 	})
 
-	onMount(() => {
-		inferSchema(code, { applyInitialArgs: true })
+	onMount(async () => {
+		await inferSchema(code, { applyInitialArgs: true })
+		// Retry once if the initial inference failed silently (e.g. transient WASM
+		// init race). Without this, users had to modify the code to trigger a
+		// second on:change-driven inference.
+		if (!validCode && code && lang) {
+			await inferSchema(code, { applyInitialArgs: true })
+		}
 		loadPastTests()
 		aiChatManager.saveAndClear()
 		aiChatManager.changeMode(AIMode.SCRIPT)

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -793,7 +793,7 @@
 						const [module, state] = await createScriptFromInlineScript(
 							flowModule,
 							selectedId,
-							flowStateStore.val[flowModule.id].schema,
+							flowStateStore.val[flowModule.id]?.schema,
 							$pathStore
 						)
 						if (flowModule.value.type == 'rawscript') {
@@ -1209,7 +1209,9 @@
 													<Section label="Continue on error">
 														{#snippet header()}
 															<Tooltip>
-																When enabled, the flow will continue to the next step even if this step fails (after exhausting all retries, if any). This enables to process the error in a branch one for instance.
+																When enabled, the flow will continue to the next step even if this
+																step fails (after exhausting all retries, if any). This enables to
+																process the error in a branch one for instance.
 															</Tooltip>
 														{/snippet}
 														<Toggle

--- a/frontend/src/lib/components/flows/flowStateUtils.svelte.ts
+++ b/frontend/src/lib/components/flows/flowStateUtils.svelte.ts
@@ -42,7 +42,11 @@ export async function loadFlowModuleState(flowModule: FlowModule): Promise<FlowM
 		}
 	} catch (e) {
 		console.debug(e)
-		return emptyFlowModuleState()
+		// Leave schema undefined so onSelectedIdChange in FlowModuleComponent
+		// can detect the failed inference and retry when the module is selected.
+		return {
+			previewResult: NEVER_TESTED_THIS_FAR
+		}
 	}
 }
 

--- a/frontend/src/lib/infer.ts
+++ b/frontend/src/lib/infer.ts
@@ -63,8 +63,15 @@ import { workspaceStore } from './stores.js'
 import { argSigToJsonSchemaType } from 'windmill-utils-internal'
 import { type AssetWithAccessType } from './components/assets/lib.js'
 
-const loadSchemaLastRun =
-	writable<[string | undefined, MainArgSignature | undefined, string | undefined]>(undefined)
+const loadSchemaLastRun = writable<
+	| [
+			string | undefined,
+			MainArgSignature | undefined,
+			string | undefined,
+			SupportedLanguage | 'bunnative' | undefined
+	  ]
+	| undefined
+>(undefined)
 
 let initializeTsPromise: Promise<any> | undefined = undefined
 export async function initWasmTs() {
@@ -307,7 +314,13 @@ export async function inferArgs(
 } | null> {
 	const lastRun = get(loadSchemaLastRun)
 	let inferedSchema: MainArgSignature
-	if (lastRun && code == lastRun[0] && lastRun[1] && lastRun[2] == mainOverride) {
+	if (
+		lastRun &&
+		code == lastRun[0] &&
+		lastRun[1] &&
+		lastRun[2] == mainOverride &&
+		lastRun[3] === language
+	) {
 		inferedSchema = lastRun[1]
 	} else {
 		if (code == '') {
@@ -439,7 +452,7 @@ export async function inferArgs(
 		if (inferedSchema.type == 'Invalid') {
 			throw new Error(inferedSchema.error)
 		}
-		loadSchemaLastRun.set([code, inferedSchema, mainOverride])
+		loadSchemaLastRun.set([code, inferedSchema, mainOverride, language])
 	}
 
 	schema.required = []

--- a/frontend/src/lib/infer.ts
+++ b/frontend/src/lib/infer.ts
@@ -73,56 +73,39 @@ const loadSchemaLastRun = writable<
 	| undefined
 >(undefined)
 
-let initializeTsPromise: Promise<any> | undefined = undefined
-export async function initWasmTs() {
-	if (initializeTsPromise == undefined) {
-		initializeTsPromise = initTsParser(wasmUrlTs)
+// Memoize each WASM parser's init promise. Without this, concurrent callers
+// (e.g. Promise.all in initFlowState across modules of the same language)
+// would each invoke the initializer and race — if any one of them rejected
+// transiently, the schema for that module would come back empty and the user
+// had to modify the code to trigger a second inference.
+function memoize(init: () => Promise<any>): () => Promise<any> {
+	let promise: Promise<any> | undefined
+	return () => {
+		if (promise == undefined) {
+			promise = init().catch((e) => {
+				// Allow a subsequent call to retry after a failed init
+				promise = undefined
+				throw e
+			})
+		}
+		return promise
 	}
-	await initializeTsPromise
 }
-async function initWasmRegex() {
-	await initRegexParsers(wasmUrlRegex)
-}
-async function initWasmPython() {
-	await initPythonParser(wasmUrlPy)
-}
-async function initWasmPhp() {
-	await initPhpParser(wasmUrlPhp)
-}
-async function initWasmRust() {
-	await initRustParser(wasmUrlRust)
-}
-async function initWasmGo() {
-	await initGoParser(wasmUrlGo)
-}
-async function initWasmYaml() {
-	await initYamlParser(wasmUrlYaml)
-}
-async function initWasmCSharp() {
-	await initCSharpParser(wasmUrlCSharp)
-}
-async function initWasmNu() {
-	await initNuParser(wasmUrlNu)
-}
-async function initWasmJava() {
-	await initJavaParser(wasmUrlJava)
-}
-async function initWasmRuby() {
-	await initRubyParser(wasmUrlRuby)
-}
-async function initWasmR() {
-	await initRParser(wasmUrlR)
-}
-async function initWasmAsset() {
-	await initAssetParser(wasmUrlAsset)
-}
-let initializeWacPromise: Promise<any> | undefined = undefined
-async function initWasmWac() {
-	if (initializeWacPromise == undefined) {
-		initializeWacPromise = initWacParser(wasmUrlWac)
-	}
-	await initializeWacPromise
-}
+
+export const initWasmTs = memoize(() => initTsParser(wasmUrlTs))
+const initWasmRegex = memoize(() => initRegexParsers(wasmUrlRegex))
+const initWasmPython = memoize(() => initPythonParser(wasmUrlPy))
+const initWasmPhp = memoize(() => initPhpParser(wasmUrlPhp))
+const initWasmRust = memoize(() => initRustParser(wasmUrlRust))
+const initWasmGo = memoize(() => initGoParser(wasmUrlGo))
+const initWasmYaml = memoize(() => initYamlParser(wasmUrlYaml))
+const initWasmCSharp = memoize(() => initCSharpParser(wasmUrlCSharp))
+const initWasmNu = memoize(() => initNuParser(wasmUrlNu))
+const initWasmJava = memoize(() => initJavaParser(wasmUrlJava))
+const initWasmRuby = memoize(() => initRubyParser(wasmUrlRuby))
+const initWasmR = memoize(() => initRParser(wasmUrlR))
+const initWasmAsset = memoize(() => initAssetParser(wasmUrlAsset))
+const initWasmWac = memoize(() => initWacParser(wasmUrlWac))
 
 export type WacDagNode = {
 	id: string


### PR DESCRIPTION
## Summary

Sometimes when opening a script in the script editor (especially via `+Add`) or selecting a flow module, the parameter schema would be empty until the user modified the code. This fixes the root causes so inference reliably runs on load.

## Changes

- **ScriptEditor: re-infer schema when `code` prop changes externally** (`ScriptEditor.svelte:207-218`). The existing effect that synced `editorCode` for template resets/copilot/etc. now also calls `inferSchema(code)`. This is the primary fix for `/scripts/add`: `ScriptBuilder.initContent` sets `script.content` *after* `ScriptEditor` has already mounted with `code = ''`, and previously nothing re-ran inference when the prop updated — the user had to type to trigger an `on:change` re-infer.

- **ScriptEditor: retry onMount inference once on transient failure** (`ScriptEditor.svelte:1120-1126`). If `inferSchema` threw (e.g. a transient WASM init race on first load), `validCode` was set to false and the schema stayed stale. We now re-attempt once if the first attempt failed.

- **Flow modules: let the safety net detect failed initial inference** (`flowStateUtils.svelte.ts:44-50`). `loadFlowModuleState` previously swallowed errors and returned `emptyFlowModuleState()` whose `schema` is a *truthy but empty* `emptySchema()`. `FlowModuleComponent.onSelectedIdChange`'s retry check `!flowStateStore.val[id]?.schema` therefore never fired on silent failure. On error we now omit the `schema` field so the existing safety net correctly re-runs inference on module selection.

- **`inferArgs`: include `language` in cache key** (`infer.ts:66-77, 317-322, 455`). `loadSchemaLastRun` was keyed on `(code, mainOverride)` only. Two concurrent inferences with identical code but different languages could collide and return the wrong signature. Now keyed on `(code, mainOverride, language)`.

- **Minor safety**: `FlowModuleComponent.svelte:796` now uses `?.schema` since the state entry may lack a schema after the `loadFlowModuleState` change.

## Test plan

- [ ] Open `/scripts/add` — the default template's parameter (`a`) should appear in the Arguments panel immediately, without needing to type in the editor
- [ ] Open an existing script via `/scripts/edit/...` — the saved schema should be present on load
- [ ] Open a flow with an inline-script module — select different modules and verify each shows its parameters immediately
- [ ] Switch languages via the language picker on `/scripts/add` — parameters for the new template should refresh without typing
- [ ] Edit the script content — inference should still run on changes

---
Generated with [Claude Code](https://claude.com/claude-code)