### PR TITLE
fix(nativets): forward OTEL-prefixed console logs to tracing events

### DIFF
--- a/backend/windmill-common/src/tracing_init.rs
+++ b/backend/windmill-common/src/tracing_init.rs
@@ -37,11 +37,16 @@ fn compact_layer<S>() -> Layer<S, format::DefaultFields, format::Format<format::
 lazy_static::lazy_static! {
     pub static ref JSON_FMT: bool = std::env::var("JSON_FMT").map(|x| x == "true").unwrap_or(false);
     pub static ref QUIET_MODE: bool = std::env::var("QUIET").map(|x| x == "true" || x == "1").unwrap_or(false);
+    pub static ref OTEL_JOB_LOGS: bool = std::env::var("OTEL_JOB_LOGS").ok().is_some_and(|x| x == "1" || x == "true");
 }
 
 /// Target name for verbose logs that should be filtered in quiet mode.
 /// Use `tracing::info!(target: windmill_common::tracing_init::VERBOSE_TARGET, ...)` for logs that should be suppressed in quiet mode.
 pub const VERBOSE_TARGET: &str = "windmill_verbose";
+
+/// Prefix used by user scripts to emit a log line as an OTEL tracing event
+/// when `OTEL_JOB_LOGS=true`. Stripped before forwarding to the tracing layer.
+pub const OTEL_PREFIX: &str = "OTEL: ";
 
 /// Creates a Targets filter that optionally filters out verbose logs when quiet mode is enabled.
 fn create_targets_filter(default_env_filter: LevelFilter) -> Targets {

--- a/backend/windmill-runtime-nativets/src/lib.rs
+++ b/backend/windmill-runtime-nativets/src/lib.rs
@@ -579,6 +579,7 @@ pub async fn eval_fetch_timeout(
         ));
     }
 
+    let w_id_for_tracing = w_id.to_string();
     let result_f = tokio::task::spawn_blocking(move || {
         let CreatedRuntime { mut js_runtime, mut log_receiver, mut memory_limit_rx } =
             create_nativets_runtime(ann, spread)?;
@@ -604,6 +605,7 @@ pub async fn eval_fetch_timeout(
                     tracing::error!("failed to send extra logs: {e}");
                 }
             }
+            let w_id_for_tracing = w_id_for_tracing;
             let handle = tokio::spawn(async move {
                 let mut result_stream = String::new();
                 let mut is_stream = false;
@@ -611,8 +613,17 @@ pub async fn eval_fetch_timeout(
                     use windmill_common::result_stream::extract_stream_from_logs;
                     use windmill_common::tracing_init::{OTEL_JOB_LOGS, OTEL_PREFIX};
 
-                    if *OTEL_JOB_LOGS {
-                        for line in log.lines() {
+                    // Mirror `process_streaming_log_lines` (EE) + the OTEL_JOB_LOGS
+                    // hook from handle_child.rs, neither of which runs for nativets
+                    // since nativets delivers logs in-process via the log channel.
+                    for line in log.lines() {
+                        tracing::info!(
+                            target: "windmill:job_log",
+                            job_id = ?job_id,
+                            workspace_id = ?w_id_for_tracing,
+                            "{line}"
+                        );
+                        if *OTEL_JOB_LOGS {
                             if let Some(otel_suffix) = line.strip_prefix(OTEL_PREFIX) {
                                 tracing::event!(tracing::Level::INFO, otel_suffix);
                             }

--- a/backend/windmill-runtime-nativets/src/lib.rs
+++ b/backend/windmill-runtime-nativets/src/lib.rs
@@ -609,6 +609,15 @@ pub async fn eval_fetch_timeout(
                 let mut is_stream = false;
                 while let Some(log) = log_receiver.recv().await {
                     use windmill_common::result_stream::extract_stream_from_logs;
+                    use windmill_common::tracing_init::{OTEL_JOB_LOGS, OTEL_PREFIX};
+
+                    if *OTEL_JOB_LOGS {
+                        for line in log.lines() {
+                            if let Some(otel_suffix) = line.strip_prefix(OTEL_PREFIX) {
+                                tracing::event!(tracing::Level::INFO, otel_suffix);
+                            }
+                        }
+                    }
 
                     if let Some(stream) = extract_stream_from_logs(&log.trim_end_matches("\n")) {
                         if !is_stream {

--- a/backend/windmill-worker/src/handle_child.rs
+++ b/backend/windmill-worker/src/handle_child.rs
@@ -57,11 +57,10 @@ use crate::job_logger_oss::process_streaming_log_lines;
 use crate::worker_utils::{ping_job_status, update_worker_ping_from_job};
 use crate::{MAX_RESULT_SIZE, MAX_WAIT_FOR_SIGINT, MAX_WAIT_FOR_SIGTERM};
 
-use windmill_common::tracing_init::{QUIET_MODE, VERBOSE_TARGET};
+use windmill_common::tracing_init::{OTEL_JOB_LOGS, OTEL_PREFIX, QUIET_MODE, VERBOSE_TARGET};
 
 lazy_static::lazy_static! {
     pub static ref SLOW_LOGS: bool = std::env::var("SLOW_LOGS").ok().is_some_and(|x| x == "1" || x == "true");
-    pub static ref OTEL_JOB_LOGS: bool = std::env::var("OTEL_JOB_LOGS").ok().is_some_and(|x| x == "1" || x == "true");
 }
 
 //  - kill windows process along with all child processes
@@ -357,7 +356,6 @@ pub async fn handle_child(
     }
 }
 
-pub const OTEL_PREFIX: &str = "OTEL: ";
 pub const WAC_STEP_PREFIX: &str = "WM_WAC_STEP: ";
 
 pub async fn write_lines(


### PR DESCRIPTION
## Summary
- Nativets jobs run in-process and deliver logs via an `mpsc` channel straight to `append_logs`, so they never go through `lines_to_stream` / `process_streaming_log_lines`. In EE builds that function emits every stdout line as `tracing::info!(target: "windmill:job_log", ...)`, which the `LogContextBridge` exports to OTEL (the bridge uses only `EnvFilter`, so the targets filter that drops `windmill:job_log` from stdout/file sinks doesn't apply here). As a result, `console.log` from a nativets script showed up in the Windmill UI but never reached OTEL logs.
- Added the equivalent `tracing::info!(target: "windmill:job_log", ...)` emit per line in the nativets log receiver (`backend/windmill-runtime-nativets/src/lib.rs`), and kept the `OTEL_JOB_LOGS` + `OTEL: ` prefix handling from `handle_child.rs` for parity.
- Moved `OTEL_JOB_LOGS` and `OTEL_PREFIX` into `windmill-common::tracing_init` so they are defined once and shared by `windmill-worker` and `windmill-runtime-nativets`.

## Test plan
- [ ] Start a worker with `OTEL_LOGS=true` and an OTLP exporter configured.
- [ ] Run a nativets script containing `console.log("hello from nativets")`.
- [ ] Verify the line reaches the OTLP collector (it previously didn't) while still showing up in the Windmill UI job logs.
- [ ] Optional: with `OTEL_JOB_LOGS=true`, verify that `console.log("OTEL: …")` also shows up as a (non-targeted) tracing event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)