### PR TITLE
fix(cli): preserve case in raw-app runnable filenames

### DIFF
--- a/cli/src/commands/app/raw_apps.ts
+++ b/cli/src/commands/app/raw_apps.ts
@@ -47,7 +47,10 @@ async function findRunnableContentFile(
   allFiles: string[],
 ): Promise<{ ext: string; content: string } | undefined> {
   // Look for files matching pattern: {runnableId}.{ext}
-  // where ext is a known language extension
+  // where ext is a known language extension. Match case-insensitively so
+  // older repos pulled by a buggy CLI (which lowercased content filenames
+  // while keeping mixed-case YAML filenames) can still pair correctly.
+  const runnableIdLower = runnableId.toLowerCase();
   for (const fileName of allFiles) {
     // Skip yaml and lock files
     if (fileName.endsWith(".yaml") || fileName.endsWith(".lock")) {
@@ -55,7 +58,7 @@ async function findRunnableContentFile(
     }
 
     // Check if file starts with runnableId followed by a dot
-    if (!fileName.startsWith(runnableId + ".")) {
+    if (!fileName.toLowerCase().startsWith(runnableIdLower + ".")) {
       continue;
     }
 
@@ -135,7 +138,10 @@ export async function loadRunnablesFromBackend(
       }
     }
 
-    // Track which runnable IDs have been processed (from YAML files)
+    // Track which runnable IDs have been processed (from YAML files).
+    // Stored lowercase so a YAML and a code file that differ only in case
+    // (e.g. legacy repos pulled by a buggy CLI that lowercased content
+    // filenames) are treated as the same runnable rather than duplicated.
     const processedIds = new Set<string>();
 
     // Process YAML files first (explicit configuration)
@@ -145,7 +151,7 @@ export async function loadRunnablesFromBackend(
       }
 
       const runnableId = fileName.replace(".yaml", "");
-      processedIds.add(runnableId);
+      processedIds.add(runnableId.toLowerCase());
 
       const filePath = path.join(backendPath, fileName);
       const runnable = (await yamlParseFile(filePath)) as Record<string, any>;
@@ -161,14 +167,19 @@ export async function loadRunnablesFromBackend(
         if (contentFile) {
           const language = getLanguageFromExtension(contentFile.ext, defaultTs);
 
-          // Try to load lock file
+          // Try to load lock file. Match case-insensitively for the same
+          // legacy-CLI reason as findRunnableContentFile above.
           let lock: string | undefined;
-          try {
-            lock = await readTextFile(
-              path.join(backendPath, `${runnableId}.lock`),
-            );
-          } catch {
-            // No lock file, that's fine
+          const runnableIdLower = runnableId.toLowerCase();
+          const lockFile = allFiles.find(
+            (f) => f.toLowerCase() === `${runnableIdLower}.lock`,
+          );
+          if (lockFile) {
+            try {
+              lock = await readTextFile(path.join(backendPath, lockFile));
+            } catch {
+              // No lock file, that's fine
+            }
           }
 
           // Reconstruct inlineScript object
@@ -206,12 +217,12 @@ export async function loadRunnablesFromBackend(
         continue; // Not a recognized code file
       }
 
-      if (processedIds.has(runnableId)) {
+      if (processedIds.has(runnableId.toLowerCase())) {
         continue; // Already processed via YAML file
       }
 
       // Found a code file without corresponding YAML - treat as inline runnable
-      processedIds.add(runnableId);
+      processedIds.add(runnableId.toLowerCase());
 
       const contentFile = await findRunnableContentFile(
         backendPath,

--- a/cli/src/commands/app/raw_apps.ts
+++ b/cli/src/commands/app/raw_apps.ts
@@ -37,6 +37,24 @@ export interface AppFile {
   };
 }
 
+// Match siblings of a YAML metadata file case-insensitively. A buggy CLI
+// release lowercased content/lock filenames while keeping mixed-case YAML
+// filenames, so legacy repos can still pair correctly on the next push.
+async function readSiblingLock(
+  backendPath: string,
+  runnableId: string,
+  allFiles: string[],
+): Promise<string | undefined> {
+  const target = `${runnableId.toLowerCase()}.lock`;
+  const lockFile = allFiles.find((f) => f.toLowerCase() === target);
+  if (!lockFile) return undefined;
+  try {
+    return await readTextFile(path.join(backendPath, lockFile));
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Finds the content file for a runnable by looking for files matching the runnableId.
  * Returns the file extension and content, or undefined if not found.
@@ -166,21 +184,7 @@ export async function loadRunnablesFromBackend(
 
         if (contentFile) {
           const language = getLanguageFromExtension(contentFile.ext, defaultTs);
-
-          // Try to load lock file. Match case-insensitively for the same
-          // legacy-CLI reason as findRunnableContentFile above.
-          let lock: string | undefined;
-          const runnableIdLower = runnableId.toLowerCase();
-          const lockFile = allFiles.find(
-            (f) => f.toLowerCase() === `${runnableIdLower}.lock`,
-          );
-          if (lockFile) {
-            try {
-              lock = await readTextFile(path.join(backendPath, lockFile));
-            } catch {
-              // No lock file, that's fine
-            }
-          }
+          const lock = await readSiblingLock(backendPath, runnableId, allFiles);
 
           // Reconstruct inlineScript object
           runnable.inlineScript = {
@@ -232,16 +236,7 @@ export async function loadRunnablesFromBackend(
 
       if (contentFile) {
         const language = getLanguageFromExtension(contentFile.ext, defaultTs);
-
-        // Try to load lock file
-        let lock: string | undefined;
-        try {
-          lock = await readTextFile(
-            path.join(backendPath, `${runnableId}.lock`),
-          );
-        } catch {
-          // No lock file, that's fine
-        }
+        const lock = await readSiblingLock(backendPath, runnableId, allFiles);
 
         // Create inline runnable with default empty fields
         runnables[runnableId] = {

--- a/cli/test/app_dev_wmill_dts_unit.test.ts
+++ b/cli/test/app_dev_wmill_dts_unit.test.ts
@@ -80,9 +80,6 @@ describe("loadRunnablesFromBackend", () => {
     expect(runnables.inlineRunnable.inlineScript.content).toContain("main(");
   });
 
-  // Regression for #8939: a buggy CLI release lowercased the content filename
-  // while keeping the YAML filename mixed-case, splitting one runnable into
-  // two on the next push. Pairing must work case-insensitively.
   test("CamelCase YAML pairs with lowercased sibling code (legacy repo recovery)", async () => {
     fs.writeFileSync(
       path.join(backendDir, "CamelCaseTSRunnable.yaml"),

--- a/cli/test/app_dev_wmill_dts_unit.test.ts
+++ b/cli/test/app_dev_wmill_dts_unit.test.ts
@@ -79,6 +79,27 @@ describe("loadRunnablesFromBackend", () => {
     expect(runnables.inlineRunnable.inlineScript.language).toBe("bun");
     expect(runnables.inlineRunnable.inlineScript.content).toContain("main(");
   });
+
+  // Regression for #8939: a buggy CLI release lowercased the content filename
+  // while keeping the YAML filename mixed-case, splitting one runnable into
+  // two on the next push. Pairing must work case-insensitively.
+  test("CamelCase YAML pairs with lowercased sibling code (legacy repo recovery)", async () => {
+    fs.writeFileSync(
+      path.join(backendDir, "CamelCaseTSRunnable.yaml"),
+      "type: inline\nfields: {}\n",
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(backendDir, "camelcasetsrunnable.ts"),
+      "export async function main() { return 1; }\n",
+      "utf-8",
+    );
+
+    const runnables = await loadRunnablesFromBackend(backendDir);
+
+    expect(Object.keys(runnables)).toEqual(["CamelCaseTSRunnable"]);
+    expect(runnables.CamelCaseTSRunnable.inlineScript.content).toContain("main(");
+  });
 });
 
 describe("genWmillTs (regression: path-based runnable schema)", () => {

--- a/cli/test/inline_scripts_failure_preprocessor_unit.test.ts
+++ b/cli/test/inline_scripts_failure_preprocessor_unit.test.ts
@@ -524,7 +524,7 @@ describe("extractInlineScripts with mapping preserves file paths", () => {
 
     const contentScript = scripts.find((s) => !s.is_lock);
     // Should use assigner path based on summary, not mapped
-    expect(contentScript!.path).toContain("get_users_data");
+    expect(contentScript!.path).toContain("Get_Users_Data");
   });
 
   test("mapped modules and unmapped modules coexist", () => {
@@ -538,7 +538,7 @@ describe("extractInlineScripts with mapping preserves file paths", () => {
 
     const paths = scripts.filter((s) => !s.is_lock).map((s) => s.path);
     expect(paths[0]).toBe("my_custom_name.ts");
-    expect(paths[1]).toContain("step_b"); // assigner-generated from summary
+    expect(paths[1]).toContain("Step_B"); // assigner-generated from summary
   });
 
   test("lock path is derived from mapped content path", () => {
@@ -560,7 +560,7 @@ describe("extractInlineScripts with mapping preserves file paths", () => {
     const scripts = extractInlineScripts([mod], {}, "/", "bun");
 
     const lockScript = scripts.find((s) => s.is_lock);
-    expect(lockScript!.path).toContain("get_users_data");
+    expect(lockScript!.path).toContain("Get_Users_Data");
     expect(lockScript!.path).toEndWith(".lock");
   });
 

--- a/cli/test/sync_pull_push.test.ts
+++ b/cli/test/sync_pull_push.test.ts
@@ -631,10 +631,6 @@ test("newPathAssigner with skipInlineScriptSuffix removes .inline_script. from p
   expect(noSuffixPyExt).toEqual("py");
 });
 
-// Regression for #8939: filenames must preserve the original casing of the
-// summary so raw-app pull/push round-trips don't break for camel-cased
-// runnable ids (e.g. CamelCaseTSRunnable.ts must not become
-// camelcasetsrunnable.ts).
 test("path assigners preserve mixed-case summaries", () => {
   const inlineAssigner = newPathAssigner("bun", { skipInlineScriptSuffix: true });
   const [inlinePath] = inlineAssigner.assignPath("CamelCaseTSRunnable", "bun");
@@ -645,8 +641,6 @@ test("path assigners preserve mixed-case summaries", () => {
   expect(rawPath).toEqual("CamelCaseTSRunnable.");
 });
 
-// Names that differ only by case must still be deduped to avoid colliding
-// on case-insensitive filesystems (Windows, default macOS).
 test("path assigners dedupe case-insensitively", () => {
   const assigner = newRawAppPathAssigner("bun");
   const [first] = assigner.assignPath("Foo", "bun");

--- a/cli/test/sync_pull_push.test.ts
+++ b/cli/test/sync_pull_push.test.ts
@@ -43,7 +43,10 @@ import {
   getModuleFolderSuffix,
   hasWrongFormatSuffix,
 } from "../src/utils/resource_folders.ts";
-import { newPathAssigner } from "../windmill-utils-internal/src/path-utils/path-assigner.ts";
+import {
+  newPathAssigner,
+  newRawAppPathAssigner,
+} from "../windmill-utils-internal/src/path-utils/path-assigner.ts";
 
 // =============================================================================
 // Test Fixtures - Every Type of Windmill Resource
@@ -626,6 +629,30 @@ test("newPathAssigner with skipInlineScriptSuffix removes .inline_script. from p
   const [noSuffixPyPath, noSuffixPyExt] = noSuffixPyAssigner.assignPath("python_script", "python3");
   expect(noSuffixPyPath).toEqual("python_script.");
   expect(noSuffixPyExt).toEqual("py");
+});
+
+// Regression for #8939: filenames must preserve the original casing of the
+// summary so raw-app pull/push round-trips don't break for camel-cased
+// runnable ids (e.g. CamelCaseTSRunnable.ts must not become
+// camelcasetsrunnable.ts).
+test("path assigners preserve mixed-case summaries", () => {
+  const inlineAssigner = newPathAssigner("bun", { skipInlineScriptSuffix: true });
+  const [inlinePath] = inlineAssigner.assignPath("CamelCaseTSRunnable", "bun");
+  expect(inlinePath).toEqual("CamelCaseTSRunnable.");
+
+  const rawAssigner = newRawAppPathAssigner("bun");
+  const [rawPath] = rawAssigner.assignPath("CamelCaseTSRunnable", "bun");
+  expect(rawPath).toEqual("CamelCaseTSRunnable.");
+});
+
+// Names that differ only by case must still be deduped to avoid colliding
+// on case-insensitive filesystems (Windows, default macOS).
+test("path assigners dedupe case-insensitively", () => {
+  const assigner = newRawAppPathAssigner("bun");
+  const [first] = assigner.assignPath("Foo", "bun");
+  const [second] = assigner.assignPath("foo", "bun");
+  expect(first).toEqual("Foo.");
+  expect(second).toEqual("foo_1.");
 });
 
 test("newPathAssigner generates unique paths for duplicate names", () => {

--- a/cli/windmill-utils-internal/src/path-utils/path-assigner.ts
+++ b/cli/windmill-utils-internal/src/path-utils/path-assigner.ts
@@ -120,7 +120,6 @@ const WINDOWS_RESERVED = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])$/;
 
 export function sanitizeForFilesystem(summary: string): string {
   const name = summary
-    .toLowerCase()
     .replaceAll(" ", "_")
     // Remove characters invalid on Windows/Unix/Mac: / \ : * ? " < > |
     // Also remove control characters (0x00-0x1F) and DEL (0x7F)
@@ -131,7 +130,7 @@ export function sanitizeForFilesystem(summary: string): string {
     // Trim leading/trailing dots and underscores (hidden files, Windows edge cases)
     .replace(/^[._]+|[._]+$/g, "");
   // Prefix Windows reserved device names (CON, PRN, AUX, NUL, COM0-9, LPT0-9)
-  return WINDOWS_RESERVED.test(name) ? `_${name}` : name;
+  return WINDOWS_RESERVED.test(name.toLowerCase()) ? `_${name}` : name;
 }
 
 export interface PathAssigner {
@@ -160,6 +159,8 @@ export function newPathAssigner(defaultTs: "bun" | "deno" | PathAssignerOptions,
   const { defaultTs: tsRuntime, skipInlineScriptSuffix } = resolvedOptions;
 
   let counter = 0;
+  // Dedupe case-insensitively so case-only duplicates don't collide on
+  // case-insensitive filesystems (Windows, default macOS).
   const seen_names = new Set<string>();
   function assignPath(
     summary: string | undefined,
@@ -176,11 +177,11 @@ export function newPathAssigner(defaultTs: "bun" | "deno" | PathAssignerOptions,
       name = `${INLINE_SCRIPT_PREFIX}_0`;
     }
 
-    while (seen_names.has(name)) {
+    while (seen_names.has(name.toLowerCase())) {
       counter++;
       name = `${original_name}_${counter}`;
     }
-    seen_names.add(name);
+    seen_names.add(name.toLowerCase());
 
     const ext = getLanguageExtension(language, tsRuntime);
 
@@ -201,6 +202,8 @@ export function newPathAssigner(defaultTs: "bun" | "deno" | PathAssignerOptions,
  */
 export function newRawAppPathAssigner(defaultTs: "bun" | "deno"): PathAssigner {
   let counter = 0;
+  // Dedupe case-insensitively so case-only duplicates don't collide on
+  // case-insensitive filesystems (Windows, default macOS).
   const seen_names = new Set<string>();
   function assignPath(
     summary: string | undefined,
@@ -217,11 +220,11 @@ export function newRawAppPathAssigner(defaultTs: "bun" | "deno"): PathAssigner {
       name = `runnable_0`;
     }
 
-    while (seen_names.has(name)) {
+    while (seen_names.has(name.toLowerCase())) {
       counter++;
       name = `${original_name}_${counter}`;
     }
-    seen_names.add(name);
+    seen_names.add(name.toLowerCase());
 
     const ext = getLanguageExtension(language, defaultTs);
 


### PR DESCRIPTION
## Summary

Fixes #8939. `wmill pull` was lowercasing raw-app backend runnable code filenames, so a runnable id like `CamelCaseTSRunnable` produced a YAML metadata file in original case (`CamelCaseTSRunnable.yaml`) but a code file lowercased to `camelcasetsrunnable.ts`. On the next `wmill push`, the YAML and the code file failed to pair up, the YAML's runnable came back empty, and the lowercase file got auto-detected as a separate runnable — appearing in the app editor as a duplicate.

The lowercasing happened inside `sanitizeForFilesystem`, which is shared by all path assigners. Only raw apps actually broke (their YAML and code file are paired by name match); normal-app and flow inline scripts use an explicit `!inline <path>` reference so they were resilient to the case mismatch. After this PR, all of them just preserve the user's original casing.

## Changes

- `cli/windmill-utils-internal/src/path-utils/path-assigner.ts`: drop `.toLowerCase()` from `sanitizeForFilesystem` so original case is preserved. Dedupe `seen_names` case-insensitively in both `newPathAssigner` and `newRawAppPathAssigner` so case-only duplicates (e.g. `Foo` and `foo`) still get a counter suffix on case-insensitive filesystems (Windows, default macOS). Test the Windows reserved-name pattern case-insensitively.
- `cli/src/commands/app/raw_apps.ts`: in `loadRunnablesFromBackend`, match content/lock files and the processed-id set case-insensitively so repos that were already pulled by the buggy CLI recover gracefully on the next push instead of producing duplicates — they don't have to re-pull.
- `cli/test/app_dev_wmill_dts_unit.test.ts`: regression test that a `CamelCase.yaml` pairs with a sibling `camelcase.ts` (legacy-repo recovery).
- `cli/test/sync_pull_push.test.ts`: unit tests that path assigners preserve mixed-case summaries and dedupe case-insensitively.

## Test plan

- [ ] Create a full-code app with a backend runnable named `CamelCaseTSRunnable` (with code in it). `wmill pull` → file is at `.../backend/CamelCaseTSRunnable.ts` (original case), with sibling `CamelCaseTSRunnable.yaml`.
- [ ] `wmill push` to a different workspace and open the app editor — exactly one runnable `CamelCaseTSRunnable` containing the original code, no lowercase duplicate.
- [ ] Take a repo previously pulled by the buggy 1.691.0 CLI (mixed-case YAML + lowercase code file) and run `wmill push` with this build — it should push as a single runnable, not duplicate.
- [ ] Two runnables named `Foo` and `foo` in the same app still dedupe to distinct files (`Foo.ts` and `foo_1.ts`).
- [ ] `bun test test/app_dev_wmill_dts_unit.test.ts test/sync_pull_push.test.ts` passes.

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves original case for raw‑app runnable filenames to stop YAML/code pairing failures and duplicate runnables during pull/push. Adds case‑insensitive matching so repos pulled with the buggy CLI recover on the next push. Fixes #8939.

- **Bug Fixes**
  - Stop lowercasing in filename sanitization; keep user casing and check Windows reserved names case‑insensitively.
  - Dedupe filenames case‑insensitively in both path assigners to avoid collisions on case‑insensitive filesystems.
  - Match content and lock files, and the processed‑ID set, case‑insensitively in raw‑app loading; extracted `readSiblingLock` and use it in both YAML and orphan‑code paths so partial‑legacy repos also recover without re‑pull.
  - Added regression tests for legacy repo recovery and case‑insensitive deduping; updated inline‑script path assertions to expect case‑preserving names.

<sup>Written for commit 1991fdd5b3903b6484a5e52259c0b8bbd14f5815. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

