### PR TITLE
fix: preserve s3 rootPath in ansible git repo viewer

### DIFF
--- a/frontend/src/lib/components/GitRepoViewer.svelte
+++ b/frontend/src/lib/components/GitRepoViewer.svelte
@@ -24,7 +24,7 @@
 
 	let { gitRepoResourcePath, gitSshIdentity, commitHashInput = $bindable() }: Props = $props()
 
-	let commitHash = $derived(commitHashInput);
+	let commitHash = $derived(commitHashInput)
 
 	async function populateS3WithGitRepo() {
 		const workspace = $workspaceStore
@@ -34,7 +34,7 @@
 			workspace: workspace,
 			resource_path: gitRepoResourcePath,
 			git_ssh_identity: gitSshIdentity,
-			commit: commitHash,
+			commit: commitHash
 		}
 
 		isLoadingRepoClone = true
@@ -53,7 +53,7 @@
 				if (jobSuccess) {
 					await JobService.getCompletedJobResult({ workspace, id: jobId })
 				} else {
-					error = (testResult.result as any).error.message ?? "Failed to clone"
+					error = (testResult.result as any).error.message ?? 'Failed to clone'
 				}
 			},
 			timeoutCode: async () => {
@@ -84,7 +84,7 @@
 				const result = await ResourceService.getGitCommitHash({
 					workspace: $workspaceStore!,
 					path: gitRepoResourcePath,
-					gitSshIdentity: gitSshIdentity?.join(",")
+					gitSshIdentity: gitSshIdentity?.join(',')
 				})
 
 				commitHashInput = result.commit_hash
@@ -117,13 +117,12 @@
 		untrack(() => {
 			fetchGitRepoData()
 		})
-
 	})
 
 	$effect(() => {
 		;[commitHash, pathExists, isCheckingPathExists, isLoadingCommitHash]
 		untrack(() => {
-			s3FilePicker?.open(undefined)
+			s3FilePicker?.reloadContent()
 		})
 	})
 </script>


### PR DESCRIPTION
## Summary

Fixes \"Invalid path format for this git repo resource in this workspace\" error when picking a git repo via the **+Git Repo** button in the ansible script editor.

## Root cause

In \`GitRepoViewer.svelte\`, an \`\$effect\` ran \`s3FilePicker?.open(undefined)\` whenever \`commitHash\` / \`pathExists\` settled. \`S3FilePickerInner.open()\` called with \`undefined\` falls into the \`else\` branch and **clobbers \`rootPath\` to \`''\`** (\`S3FilePickerInner.svelte:439\`). The next \`loadFiles()\` then sent \`prefix=''\` to \`/api/w/{w_id}/job_helpers/list_git_repo_files\`, which fails this validation in EE (\`windmill-api/src/job_helpers_ee.rs:632-639\`):

\`\`\`rust
let path_after_workspace = prefix
    .strip_prefix(&format!(\"gitrepos/{}/\", w_id))
    .ok_or_else(|| Error::BadRequest(
        \"Invalid path format for this git repo resource in this workspace\".to_string(),
    ))?;
\`\`\`

\`\"\".strip_prefix(\"gitrepos/admins/\")\` returns \`None\` → user gets the error.

The specific repo URL (e.g. \`https://github.com/geerlingguy/internet-pi\`) is incidental; any repo whose commit content has been populated to S3 (so \`pathExists === true\` and \`S3FilePickerInner\` mounts) triggers it.

## Fix

Replace \`open(undefined)\` with \`reloadContent()\` — refreshes the file list without mutating \`rootPath\`. The other \`open()\` callsites without args (\`EditorBar\`, \`InputsSpecEditor\`, \`StaticInputEditor\`) don't pass a \`rootPath\` prop, so they're unaffected.

## Test plan

- [ ] On an EE instance with object storage configured, create a \`git_repository\` resource pointing at any public repo (e.g. \`https://github.com/geerlingguy/internet-pi\`)
- [ ] In a new ansible script, click **+Git Repo** and pick the resource
- [ ] First time: click \"Load Repository Contents\" to populate S3
- [ ] After populate: file browser should appear (no \"Invalid path format\" error)
- [ ] Confirm \`GET /api/w/{ws}/job_helpers/list_git_repo_files\` is called with \`prefix=gitrepos/{ws}/{path}/{commit}/\`, not empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the S3 file picker rootPath in the Ansible Git repo viewer to prevent the “Invalid path format for this git repo resource in this workspace” error. Users can load and browse repo contents without API validation failures.

- **Bug Fixes**
  - In `frontend/src/lib/components/GitRepoViewer.svelte`, use `s3FilePicker.reloadContent()` instead of `open(undefined)` to avoid clearing `rootPath`.
  - Prevents sending an empty `prefix` to `/api/w/{ws}/job_helpers/list_git_repo_files`, keeping `prefix=gitrepos/{ws}/{path}/{commit}/`.

<sup>Written for commit 280434d2de366464b0cd2088b5782e9d9bb7af3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

