### PR TITLE
refactor: split git repo viewer effects to remove redundant calls

### DIFF
--- a/frontend/src/lib/components/GitRepoViewer.svelte
+++ b/frontend/src/lib/components/GitRepoViewer.svelte
@@ -74,56 +74,55 @@
 		}
 	}
 
-	async function fetchGitRepoData() {
+	async function fetchCommitHash() {
+		if (commitHash) return
 		try {
 			error = null
-			// Step 1: Fetch commit hash if not provided
-			if (!commitHash) {
-				isLoadingCommitHash = true
-				error = null
-				const result = await ResourceService.getGitCommitHash({
-					workspace: $workspaceStore!,
-					path: gitRepoResourcePath,
-					gitSshIdentity: gitSshIdentity?.join(',')
-				})
-
-				commitHashInput = result.commit_hash
-				isLoadingCommitHash = false
-			}
-
-			// Step 2: Check if S3 path exists
-			if (commitHash) {
-				isCheckingPathExists = true
-
-				const s3Path = `gitrepos/${$workspaceStore}/${gitRepoResourcePath}/${commitHash}/`
-
-				const pathCheck = await HelpersService.checkS3FolderExists({
-					workspace: $workspaceStore!,
-					fileKey: s3Path
-				})
-
-				pathExists = pathCheck.exists && pathCheck.is_folder
-				isCheckingPathExists = false
-			}
+			isLoadingCommitHash = true
+			const result = await ResourceService.getGitCommitHash({
+				workspace: $workspaceStore!,
+				path: gitRepoResourcePath,
+				gitSshIdentity: gitSshIdentity?.join(',')
+			})
+			commitHashInput = result.commit_hash
 		} catch (err: any) {
 			error = `Failed to load git repository ${gitRepoResourcePath}: ${err.status} -  ${err.message || 'Unknown error'}: ${err.body}`
+		} finally {
 			isLoadingCommitHash = false
+		}
+	}
+
+	async function checkS3Path() {
+		if (!commitHash) return
+		try {
+			error = null
+			isCheckingPathExists = true
+			const s3Path = `gitrepos/${$workspaceStore}/${gitRepoResourcePath}/${commitHash}/`
+			const pathCheck = await HelpersService.checkS3FolderExists({
+				workspace: $workspaceStore!,
+				fileKey: s3Path
+			})
+			pathExists = pathCheck.exists && pathCheck.is_folder
+		} catch (err: any) {
+			error = `Failed to load git repository ${gitRepoResourcePath}: ${err.status} -  ${err.message || 'Unknown error'}: ${err.body}`
+		} finally {
 			isCheckingPathExists = false
 		}
 	}
 
 	$effect(() => {
-		;[commitHashInput, gitRepoResourcePath]
-		untrack(() => {
-			fetchGitRepoData()
-		})
+		gitRepoResourcePath
+		untrack(() => fetchCommitHash())
 	})
 
 	$effect(() => {
-		;[commitHash, pathExists, isCheckingPathExists, isLoadingCommitHash]
-		untrack(() => {
-			s3FilePicker?.reloadContent()
-		})
+		;[commitHash, gitRepoResourcePath]
+		untrack(() => checkS3Path())
+	})
+
+	$effect(() => {
+		;[s3FilePicker, commitHash, gitRepoResourcePath, pathExists]
+		untrack(() => s3FilePicker?.reloadContent())
 	})
 </script>
 
@@ -154,31 +153,35 @@
 		<Button onclick={populateS3WithGitRepo} color="blue">Load Repository Contents</Button>
 	</div>
 {:else if commitHash && pathExists === true}
-	<S3FilePickerInner
-		bind:this={s3FilePicker}
-		readOnlyMode
-		hideS3SpecificDetails
-		rootPath={`gitrepos/${$workspaceStore}/${gitRepoResourcePath}/${commitHash}/`}
-		listStoredFilesRequest={HelpersService.listGitRepoFiles}
-		loadFilePreviewRequest={HelpersService.loadGitRepoFilePreview}
-		testConnectionRequest={(async (_d) => {
-			const bucketConfig: any = await SettingService.getGlobal({ key: 'object_store_cache_config' })
-			return SettingService.testObjectStorageConfig({
-				requestBody: bucketConfig
-			})
-		}) as any}
-		loadFileMetadataRequest={HelpersService.loadGitRepoFileMetadata}
-	>
-		{#snippet replaceUnauthorizedWarning()}
-			<div class="mb-2">
-				<Alert type="error" title="Cannot view git repo">
-					<p>
-						The git repo resource you are trying to access either doesn't exist or you don't have
-						access to it. Make sure the resource path is correct and that you have visibility over
-						the resource.
-					</p>
-				</Alert>
-			</div>
-		{/snippet}
-	</S3FilePickerInner>
+	{#key `${gitRepoResourcePath}-${commitHash}`}
+		<S3FilePickerInner
+			bind:this={s3FilePicker}
+			readOnlyMode
+			hideS3SpecificDetails
+			rootPath={`gitrepos/${$workspaceStore}/${gitRepoResourcePath}/${commitHash}/`}
+			listStoredFilesRequest={HelpersService.listGitRepoFiles}
+			loadFilePreviewRequest={HelpersService.loadGitRepoFilePreview}
+			testConnectionRequest={(async (_d) => {
+				const bucketConfig: any = await SettingService.getGlobal({
+					key: 'object_store_cache_config'
+				})
+				return SettingService.testObjectStorageConfig({
+					requestBody: bucketConfig
+				})
+			}) as any}
+			loadFileMetadataRequest={HelpersService.loadGitRepoFileMetadata}
+		>
+			{#snippet replaceUnauthorizedWarning()}
+				<div class="mb-2">
+					<Alert type="error" title="Cannot view git repo">
+						<p>
+							The git repo resource you are trying to access either doesn't exist or you don't have
+							access to it. Make sure the resource path is correct and that you have visibility over
+							the resource.
+						</p>
+					</Alert>
+				</div>
+			{/snippet}
+		</S3FilePickerInner>
+	{/key}
 {/if}

--- a/frontend/src/lib/components/S3FilePickerInner.svelte
+++ b/frontend/src/lib/components/S3FilePickerInner.svelte
@@ -706,53 +706,51 @@
 					{/if}
 				</div>
 			{:else}
-				<div class="p-4 gap-2">
-					<Section
-						label={((p) => (p.startsWith(rootPath) ? p.slice(rootPath.length) : p))(
-							fileMetadata.fileKey
-						)}
-						breakAll
-					>
-						{#snippet action()}
-							<div class="flex gap-2">
-								{#if filePreview !== undefined}
-									{#if !hideS3SpecificDetails}
-										<Button
-											title="Download file from S3"
-											variant="default"
-											href={`${base}/api/w/${$workspaceStore}/job_helpers/download_s3_file?file_key=${encodeURIComponent(fileMetadata?.fileKey ?? '')}${storage ? `&storage=${storage}` : ''}`}
-											download={fileMetadata?.fileKey.split('/').pop() ?? 'unnamed_download.file'}
-											startIcon={{ icon: Download }}
-											iconOnly={true}
-										/>
-									{/if}
-									{#if !readOnlyMode}
-										<Button
-											title="Move file"
-											variant="default"
-											on:click={() => {
-												moveDestKey = fileMetadata?.fileKey ?? ''
-												moveModalOpen = true
-											}}
-											startIcon={{ icon: MoveRight }}
-											iconOnly={true}
-										/>
-									{/if}
-									{#if !readOnlyMode || allowDelete}
-										<Button
-											title="Delete file"
-											variant="default"
-											on:click={() => {
-												deletionModalOpen = true
-											}}
-											startIcon={{ icon: Trash }}
-											iconOnly={true}
-										/>
-									{/if}
+				<div class="px-3 py-2 flex flex-col gap-2">
+					<div class="flex flex-row items-center justify-between gap-2">
+						<h2 class="text-emphasis text-sm font-semibold break-all min-w-0">
+							{((p) => (p.startsWith(rootPath) ? p.slice(rootPath.length) : p))(
+								fileMetadata.fileKey
+							)}
+						</h2>
+						{#if filePreview !== undefined && (!hideS3SpecificDetails || !readOnlyMode || allowDelete)}
+							<div class="flex gap-2 shrink-0">
+								{#if !hideS3SpecificDetails}
+									<Button
+										title="Download file from S3"
+										variant="default"
+										href={`${base}/api/w/${$workspaceStore}/job_helpers/download_s3_file?file_key=${encodeURIComponent(fileMetadata?.fileKey ?? '')}${storage ? `&storage=${storage}` : ''}`}
+										download={fileMetadata?.fileKey.split('/').pop() ?? 'unnamed_download.file'}
+										startIcon={{ icon: Download }}
+										iconOnly={true}
+									/>
+								{/if}
+								{#if !readOnlyMode}
+									<Button
+										title="Move file"
+										variant="default"
+										on:click={() => {
+											moveDestKey = fileMetadata?.fileKey ?? ''
+											moveModalOpen = true
+										}}
+										startIcon={{ icon: MoveRight }}
+										iconOnly={true}
+									/>
+								{/if}
+								{#if !readOnlyMode || allowDelete}
+									<Button
+										title="Delete file"
+										variant="default"
+										on:click={() => {
+											deletionModalOpen = true
+										}}
+										startIcon={{ icon: Trash }}
+										iconOnly={true}
+									/>
 								{/if}
 							</div>
-						{/snippet}
-					</Section>
+						{/if}
+					</div>
 					{#if !hideS3SpecificDetails}
 						<TableSimple
 							headers={['Last modified', 'Size', 'Type']}

--- a/frontend/src/lib/components/S3FilePickerInner.svelte
+++ b/frontend/src/lib/components/S3FilePickerInner.svelte
@@ -789,51 +789,53 @@
 							<Loader2 size={12} class="animate-spin mr-1" /> File preview loading
 						</div>
 					{:else if fileMetadata !== undefined && filePreview !== undefined}
-						<div class="flex items-center text-primary mb-4">
-							{#if filePreview.contentType === 'Unknown'}
-								Type of file not supported for preview.
-							{:else if filePreview.contentType === 'Csv'}
-								Previewing a {filePreview.contentType?.toLowerCase()} file. Separator character:
-								<div class="inline-flex w-12 ml-2 mr-2">
-									<select
-										class="h-8"
-										bind:value={csvSeparatorChar}
-										onchange={(e) =>
-											loadFilePreview(
-												fileMetadata?.fileKey ?? '',
-												fileMetadata?.size,
-												fileMetadata?.mimeType
+						{#if filePreview.contentType === 'Unknown' || filePreview.contentType === 'Csv' || !hideS3SpecificDetails}
+							<div class="flex items-center text-primary mb-4">
+								{#if filePreview.contentType === 'Unknown'}
+									Type of file not supported for preview.
+								{:else if filePreview.contentType === 'Csv'}
+									Previewing a {filePreview.contentType?.toLowerCase()} file. Separator character:
+									<div class="inline-flex w-12 ml-2 mr-2">
+										<select
+											class="h-8"
+											bind:value={csvSeparatorChar}
+											onchange={(e) =>
+												loadFilePreview(
+													fileMetadata?.fileKey ?? '',
+													fileMetadata?.size,
+													fileMetadata?.mimeType
+												)}
+										>
+											<option value=",">,</option>
+											<option value=";">;</option>
+											<option value="\t">\t</option>
+											<option value="|">|</option>
+										</select>
+									</div>
+									Header row:
+									<div class="inline-flex item-center w-4 ml-2 mr-2">
+										<input
+											onfocus={bubble('focus')}
+											onclick={bubble('click')}
+											disabled={false}
+											type="checkbox"
+											id="csv-header"
+											class="h-5"
+											bind:checked={csvHasHeader}
+											onchange={stopPropagation((e) =>
+												loadFilePreview(
+													fileMetadata?.fileKey ?? '',
+													fileMetadata?.size,
+													fileMetadata?.mimeType
+												)
 											)}
-									>
-										<option value=",">,</option>
-										<option value=";">;</option>
-										<option value="\t">\t</option>
-										<option value="|">|</option>
-									</select>
-								</div>
-								Header row:
-								<div class="inline-flex item-center w-4 ml-2 mr-2">
-									<input
-										onfocus={bubble('focus')}
-										onclick={bubble('click')}
-										disabled={false}
-										type="checkbox"
-										id="csv-header"
-										class="h-5"
-										bind:checked={csvHasHeader}
-										onchange={stopPropagation((e) =>
-											loadFilePreview(
-												fileMetadata?.fileKey ?? '',
-												fileMetadata?.size,
-												fileMetadata?.mimeType
-											)
-										)}
-									/>
-								</div>
-							{:else if !hideS3SpecificDetails}
-								Previewing a {filePreview.contentType?.toLowerCase()} file.
-							{/if}
-						</div>
+										/>
+									</div>
+								{:else}
+									Previewing a {filePreview.contentType?.toLowerCase()} file.
+								{/if}
+							</div>
+						{/if}
 						<pre class="grow whitespace-no-wrap break-words"
 							>{#if !emptyString(filePreview.contentPreview)}{filePreview.contentPreview}{:else if filePreview.contentType !== undefined}Preview impossible.{/if}
 					</pre>


### PR DESCRIPTION
## Summary

Follow-up cleanup to #8942. \`GitRepoViewer.svelte\` had a single \`fetchGitRepoData()\` doing both commit-hash fetch and S3-path check, driven by a \`\$effect\` that tracked \`[commitHashInput, gitRepoResourcePath]\`. Because \`fetchGitRepoData\` writes \`commitHashInput\`, the effect re-fired itself, redundantly re-running \`checkS3FolderExists\`. A second \`\$effect\` for reloading the file picker tracked \`[commitHash, pathExists, isCheckingPathExists, isLoadingCommitHash]\` and fired on every loading-state transition, even when the picker wasn't mounted yet.

## Changes

- Split \`fetchGitRepoData\` into \`fetchCommitHash\` and \`checkS3Path\`.
- Three focused effects:
  - \`fetchCommitHash\` triggered by \`gitRepoResourcePath\` only — no self-trigger when it writes \`commitHashInput\`.
  - \`checkS3Path\` triggered by \`[commitHash, gitRepoResourcePath]\`.
  - Picker reload triggered by \`[s3FilePicker, commitHash, gitRepoResourcePath, pathExists]\` — drops the loading-flag deps that caused noisy no-op fires.
- Wrap \`S3FilePickerInner\` in \`{#key \\\`\${gitRepoResourcePath}-\${commitHash}\\\`}\` so its internal \`rootPath\` state remounts cleanly when the repo or commit changes (the \`\$state\` initializer doesn't re-run on prop changes otherwise, which would leave reload calls using a stale path once we support commit changes).

## Net effect on API calls per repo selection

| Call | Before | After |
|---|---|---|
| \`getGitCommitHash\` | 1 | 1 |
| \`checkS3FolderExists\` | 2 (self-trigger) | 1 |
| \`list_git_repo_files\` (reload) | 1+ noisy | 1 |

## Test plan

- [ ] Manual: pick a git_repository resource via **+Git Repo** in an ansible script, verify file browser appears and only 1 \`checkS3FolderExists\` and 1 \`list_git_repo_files\` request fire (DevTools network tab).
- [ ] Manual: change the YAML's \`commit:\` field — picker should remount and list files for the new commit.
- [ ] Manual: click \"Load Repository Contents\" on a new repo — picker mounts after populate, files visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts redundant API calls and stabilizes the git repo file picker by splitting effects in `GitRepoViewer` and remounting the picker when repo or commit changes. Also compacts the preview header and hides empty status rows in `S3FilePickerInner`.

- **Refactors**
  - Split `fetchGitRepoData` into `fetchCommitHash` and `checkS3Path`.
  - Focused `$effect`s: commit hash by `gitRepoResourcePath` only; S3 check by `[commitHash, gitRepoResourcePath]`; picker reload by `[s3FilePicker, commitHash, gitRepoResourcePath, pathExists]`.
  - Wrapped `S3FilePickerInner` in `{#key ${gitRepoResourcePath}-${commitHash}}` so `rootPath` resets on repo/commit change.
  - Compact file preview header and skip the preview status row when no message applies.
  - Net effect per selection: `getGitCommitHash`: 1; `checkS3FolderExists`: 1 (was 2); `list_git_repo_files`: 1.

- **Bug Fixes**
  - Prevented self-triggering when writing `commitHashInput` that caused extra `checkS3FolderExists`.
  - Stopped reloads firing during loading-state transitions or before the picker mounts.

<sup>Written for commit 0c42dee26c98c1ee6d8e62352f430418325583cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

