### PR TITLE
fix: delete instance settings cleared via bulk endpoint

### DIFF
--- a/backend/windmill-common/src/instance_config.rs
+++ b/backend/windmill-common/src/instance_config.rs
@@ -1079,15 +1079,15 @@ pub fn diff_global_settings(
             );
             continue;
         }
-        // An empty string means "unset": route it to deletes so clearing a
-        // setting via YAML sync has the same effect as clearing it via the UI
-        // (`set_global_setting_internal` already treats `""` as a delete).
-        // Without this, stale `""` rows linger and trip the EE registry gate,
-        // producing spurious "requires Enterprise" warnings on every CE job.
-        if desired_value
-            .as_str()
-            .map_or(false, |s| s.trim().is_empty())
-        {
+        // An empty string or explicit null means "unset": route it to deletes
+        // so clearing a setting via the bulk endpoint has the same effect as
+        // clearing it via the per-key endpoint (`set_global_setting_internal`
+        // already treats both `""` and `null` as deletes).
+        // Without this, the InstanceSettings YAML editor cannot delete keys
+        // (Merge mode silently preserves missing/null values), and stale `""`
+        // rows linger and trip the EE registry gate, producing spurious
+        // "requires Enterprise" warnings on every CE job.
+        if is_empty_or_null(desired_value) {
             if let Some(existing) = current.get(key) {
                 previous_values.insert(key.clone(), existing.clone());
                 deletes.push(key.clone());
@@ -1837,6 +1837,40 @@ mod tests {
                 "Protected key {key} should not be in deletes"
             );
         }
+    }
+
+    #[test]
+    fn diff_global_settings_merge_deletes_on_null_or_empty_string() {
+        // Frontend sends explicit null when the user removes a key (e.g.
+        // deletes `object_store_cache_config` in the YAML editor). Merge mode
+        // must honor this as a deletion, just like `set_global_setting_internal`.
+        let mut current = BTreeMap::new();
+        current.insert(
+            "object_store_cache_config".to_string(),
+            serde_json::json!({"type": "S3"}),
+        );
+        current.insert("base_url".to_string(), serde_json::json!("http://x"));
+        current.insert("hub_base_url".to_string(), serde_json::json!("http://y"));
+
+        let mut desired = BTreeMap::new();
+        desired.insert(
+            "object_store_cache_config".to_string(),
+            serde_json::Value::Null,
+        );
+        desired.insert("base_url".to_string(), serde_json::json!("http://x"));
+        desired.insert("hub_base_url".to_string(), serde_json::json!(""));
+
+        let diff = diff_global_settings(&current, &desired, ApplyMode::Merge);
+        assert!(diff.upserts.is_empty(), "no upserts expected");
+        let mut deletes = diff.deletes.clone();
+        deletes.sort();
+        assert_eq!(
+            deletes,
+            vec![
+                "hub_base_url".to_string(),
+                "object_store_cache_config".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/frontend/src/lib/components/InstanceSettings.svelte
+++ b/frontend/src/lib/components/InstanceSettings.svelte
@@ -214,6 +214,29 @@
 			// Build the full global_settings object for the bulk PUT
 			const globalSettings: Record<string, any> = { ...$values }
 
+			// Send explicit null for keys that were set on load but are now
+			// missing/cleared, so the Merge-mode bulk endpoint deletes them
+			// instead of silently preserving the old DB value. Covers both:
+			//   - YAML mode: user removed a line / set it to null / set it to {}.
+			//   - Form mode: user toggled a setting off (e.g.
+			//     object_store_cache_config), making the value undefined.
+			const isClearedValue = (v: any) => {
+				if (v === undefined || v === null) return true
+				if (typeof v === 'object') {
+					return Array.isArray(v) ? v.length === 0 : Object.keys(v).length === 0
+				}
+				return false
+			}
+			for (const key of Object.keys(initialValues ?? {})) {
+				if (excludedKeys.has(key)) continue
+				if (key === 'oauths' || key === 'require_preexisting_user_for_oauth') continue
+				if (!isClearedValue(globalSettings[key])) continue
+				// Only flag for deletion if it was non-empty before — otherwise
+				// every save would delete-then-recreate harmless `{}`/`[]` defaults.
+				if (isClearedValue(initialValues[key])) continue
+				globalSettings[key] = null
+			}
+
 			// Include oauths and require_preexisting_user_for_oauth
 			if (!deepEqual(initialOauths, oauths)) {
 				globalSettings['oauths'] = oauths


### PR DESCRIPTION
## Summary
Users reported that deleting `object_store_cache_config` in the YAML editor (or setting it to `{}` or `null`) had no effect — the previous value would reappear after reload. The same bug affected toggling the setting off in the regular form UI.

Root cause: `set_instance_config` (the bulk PUT endpoint behind InstanceSettings) uses `ApplyMode::Merge`, which only upserts changed keys and never deletes. When the user removed a key in YAML or toggled it off in the form, the request body either lacked the key (Merge silently kept the old DB row) or had `null`/`{}` (Merge upserted noise). Either way, on reload the setting came back.

## Changes
- **Backend** (`backend/windmill-common/src/instance_config.rs`): `diff_global_settings` now treats explicit `Value::Null` as a deletion signal in Merge mode, alongside the existing empty-string handling. Matches the per-key `set_global_setting_internal` endpoint's behavior. Protected settings remain protected via the earlier `is_empty_or_null` guard. Added a regression test.
- **Frontend** (`frontend/src/lib/components/InstanceSettings.svelte`): `saveSettings` now sends explicit `null` for any key that was set on load but is now `undefined` / `null` / `{}` / `[]` in `$values`. The "was non-empty initially" guard avoids spurious delete-then-recreate cycles for harmless defaults like `smtp_settings: {}`.

## Test plan
- [ ] Open `/#superadmin-settings` as superadmin, configure `object_store_cache_config` (e.g. an S3 bucket), save, reload, confirm it persists.
- [ ] Toggle the setting off in form mode → save → reload → confirm it's gone.
- [ ] Re-configure, switch to YAML mode, delete the `object_store_cache_config` block → save → reload → confirm gone.
- [ ] Same with YAML value set to `null`.
- [ ] Same with YAML value set to `{}`.
- [ ] Confirm unrelated settings (e.g. `base_url`, `smtp_settings`) are unaffected by an unchanged save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes deletion of instance settings through the bulk endpoint. Clearing `object_store_cache_config` in YAML or toggling it off in the form now actually removes it and it no longer comes back after reload.

- **Bug Fixes**
  - Backend: In Merge mode, `diff_global_settings` now treats `null` (and empty strings) as delete signals, matching per-key behavior. Added a regression test.
  - Frontend: `saveSettings` sends `null` for keys that were previously set but are now cleared (`undefined`/`null`/`{}`/`[]`), avoiding delete/recreate loops for harmless defaults.

<sup>Written for commit c29b71276bc7995eb6bda7792bb9d227ed15d44b. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/8949?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

