### PR TITLE
fix(wac): recognize @workflow main, list WAC in scripts/list, run preprocessor

### DIFF
--- a/backend/parsers/windmill-parser-py/src/lib.rs
+++ b/backend/parsers/windmill-parser-py/src/lib.rs
@@ -351,8 +351,11 @@ pub fn parse_python_signature(
         }
     };
 
+    // Mirror the runtime detector `is_wac_v2_py` in `windmill-worker/src/wac_executor.rs`:
+    // a wmill import + an `@workflow` decorator is sufficient. `@task` is optional —
+    // a workflow that only uses inline `step()` calls still goes through the WAC runner,
+    // and labelling it as `wac` here is what aligns the editor badge with execution.
     let is_wac_v2 = (code.contains("@workflow") || code.contains("workflow("))
-        && (code.contains("@task") || code.contains("task("))
         && (code.contains("import wmill") || code.contains("from wmill"));
 
     // Check if main function was found
@@ -1028,6 +1031,23 @@ def main(): return
             }
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_python_wac_step_only() -> anyhow::Result<()> {
+        // A WAC script that uses inline step() instead of @task should still be
+        // detected as auto_kind = "wac" — the runtime path treats @task as
+        // optional, and the editor badge needs to match.
+        let code = r#"
+from wmill import workflow, step
+
+@workflow
+async def main(x: str):
+    return await step("k", lambda: x.upper())
+"#;
+        let sig = parse_python_signature(code, None, false)?;
+        assert_eq!(sig.auto_kind, Some("wac".to_string()));
         Ok(())
     }
 

--- a/backend/parsers/windmill-parser-py/src/lib.rs
+++ b/backend/parsers/windmill-parser-py/src/lib.rs
@@ -351,11 +351,12 @@ pub fn parse_python_signature(
         }
     };
 
+    let is_wac_v2 = (code.contains("@workflow") || code.contains("workflow("))
+        && (code.contains("@task") || code.contains("task("))
+        && (code.contains("import wmill") || code.contains("from wmill"));
+
     // Check if main function was found
     if params.is_none() {
-        let is_wac_v2 = (code.contains("@workflow") || code.contains("workflow("))
-            && (code.contains("@task") || code.contains("task("))
-            && (code.contains("import wmill") || code.contains("from wmill"));
         return Ok(MainArgSignature {
             star_args: false,
             star_kwargs: false,
@@ -476,7 +477,11 @@ pub fn parse_python_signature(
                     }
                 })
                 .collect(),
-            auto_kind: None,
+            auto_kind: if is_wac_v2 {
+                Some("wac".to_string())
+            } else {
+                None
+            },
             has_preprocessor: Some(has_preprocessor),
             ..Default::default()
         })
@@ -485,7 +490,9 @@ pub fn parse_python_signature(
             star_args: false,
             star_kwargs: false,
             args: vec![],
-            auto_kind: if params.is_none() {
+            auto_kind: if is_wac_v2 {
+                Some("wac".to_string())
+            } else if params.is_none() {
                 Some("lib".to_string())
             } else {
                 None
@@ -759,7 +766,7 @@ def main(test1: str, name: datetime.datetime = datetime.now(), byte: bytes = byt
                 ],
                 auto_kind: None,
                 has_preprocessor: Some(false),
-                            ..Default::default()
+                ..Default::default()
             }
         );
 
@@ -825,7 +832,7 @@ def main(test1: str,
                 ],
                 auto_kind: None,
                 has_preprocessor: Some(false),
-                            ..Default::default()
+                ..Default::default()
             }
         );
 
@@ -886,7 +893,7 @@ def main(test1: str,
                 ],
                 auto_kind: None,
                 has_preprocessor: Some(false),
-                            ..Default::default()
+                ..Default::default()
             }
         );
 
@@ -931,7 +938,7 @@ def main(test1: Literal["foo", "bar"], test2: List[Literal["foo", "bar"]]): retu
                 ],
                 auto_kind: None,
                 has_preprocessor: Some(false),
-                            ..Default::default()
+                ..Default::default()
             }
         );
 
@@ -963,7 +970,7 @@ def main(test1: DynSelect_foo): return
                 }],
                 auto_kind: None,
                 has_preprocessor: Some(false),
-                            ..Default::default()
+                ..Default::default()
             }
         );
 
@@ -988,7 +995,7 @@ def hello(): return
                 args: vec![],
                 auto_kind: Some("lib".to_string()),
                 has_preprocessor: Some(false),
-                            ..Default::default()
+                ..Default::default()
             }
         );
 
@@ -1017,10 +1024,31 @@ def main(): return
                 args: vec![],
                 auto_kind: None,
                 has_preprocessor: Some(true),
-                            ..Default::default()
+                ..Default::default()
             }
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_python_wac_main_decorator() -> anyhow::Result<()> {
+        // Reproducer for issue #8945: a workflow-as-code script using the
+        // standard `@workflow async def main(...)` template must be detected
+        // as auto_kind = "wac", not None.
+        let code = r#"
+from wmill import task, workflow
+
+@task()
+async def process(x: str) -> str:
+    return x
+
+@workflow
+async def main(x: str):
+    return await process(x)
+"#;
+        let sig = parse_python_signature(code, None, false)?;
+        assert_eq!(sig.auto_kind, Some("wac".to_string()));
         Ok(())
     }
 
@@ -1083,7 +1111,7 @@ def main(a: list, e: List[int], b: list = [1,2,3,4], c = [1,2,3,4], d = ["a", "b
                 ],
                 auto_kind: None,
                 has_preprocessor: Some(false),
-                            ..Default::default()
+                ..Default::default()
             }
         );
 
@@ -1133,7 +1161,7 @@ def main(a: str, b: Optional[str], c: str | None): return
                 ],
                 auto_kind: None,
                 has_preprocessor: Some(false),
-                            ..Default::default()
+                ..Default::default()
             }
         );
 

--- a/backend/tests/fixtures/wac_preprocessor.sql
+++ b/backend/tests/fixtures/wac_preprocessor.sql
@@ -1,0 +1,25 @@
+-- Python WAC script with both a @workflow-decorated main and a preprocessor.
+-- Used by test_python_wac_v2_with_preprocessor (preprocessor invocation)
+-- and test_scripts_list_includes_wac (auto_kind = 'wac' + scripts/list filter).
+INSERT INTO public.script(workspace_id, created_by, content, schema, summary, description, path, hash, language, lock, auto_kind) VALUES (
+'test-workspace',
+'system',
+'
+from wmill import task, workflow
+
+@task()
+def shout(msg: str) -> str:
+    return msg.upper()
+
+def preprocessor(who: str, count: int):
+    return {"name": who, "qty": count}
+
+@workflow
+async def main(name: str, qty: int):
+    s = await shout(name)
+    return {"greeting": s, "qty": qty}
+',
+'{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"name":{"default":null,"description":"","originalType":"string","type":"string"},"qty":{"default":null,"description":"","originalType":"integer","type":"integer"}},"required":["name","qty"],"type":"object"}',
+'',
+'',
+'f/system/wac_with_preprocessor', 123419, 'python3', NULL, 'wac');

--- a/backend/tests/python_jobs.rs
+++ b/backend/tests/python_jobs.rs
@@ -1015,6 +1015,110 @@ async def main(item: str, qty: int, email: str):
     Ok(())
 }
 
+/// Reproducer for issue #8946: WAC scripts (`auto_kind = 'wac'`) must show up
+/// in `GET /api/w/{workspace}/scripts/list?kinds=script`. The previous filter
+/// hid them by requiring `auto_kind IS NULL`, breaking trigger configuration
+/// dropdowns.
+#[cfg(feature = "python")]
+#[sqlx::test(fixtures("base", "wac_preprocessor"))]
+async fn test_scripts_list_includes_wac(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    let url = format!(
+        "http://localhost:{port}/api/w/test-workspace/scripts/list?kinds=script&without_description=true"
+    );
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .header("Authorization", "Bearer SECRET_TOKEN")
+        .send()
+        .await?;
+    assert!(
+        resp.status().is_success(),
+        "scripts/list failed: {}",
+        resp.status()
+    );
+    let scripts: Vec<serde_json::Value> = resp.json().await?;
+    let paths: Vec<&str> = scripts.iter().filter_map(|s| s["path"].as_str()).collect();
+    assert!(
+        paths.contains(&"f/system/wac_with_preprocessor"),
+        "WAC script missing from scripts/list response. Got: {:?}",
+        paths
+    );
+    Ok(())
+}
+
+/// Reproducer for issue #8947: a Python WAC script that defines a
+/// `preprocessor` function alongside the `@workflow` entrypoint must run the
+/// preprocessor on the trigger payload before invoking the workflow, persist
+/// the preprocessed args to `v2_job.args`, and dispatch inline child re-runs
+/// using the post-preprocessor args (so children of the WAC parent see the
+/// transformed shape, not the raw event).
+#[cfg(feature = "python")]
+#[sqlx::test(fixtures("base", "wac_preprocessor"))]
+async fn test_python_wac_v2_with_preprocessor(db: Pool<Postgres>) -> anyhow::Result<()> {
+    use windmill_common::scripts::ScriptHash;
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    let db = &db;
+    in_test_worker(
+        db,
+        async move {
+            let job = Box::pin(
+                RunJob::from(JobPayload::ScriptHash {
+                    hash: ScriptHash(123419),
+                    path: "f/system/wac_with_preprocessor".to_string(),
+                    cache_ttl: None,
+                    cache_ignore_s3_path: None,
+                    dedicated_worker: None,
+                    language: ScriptLang::Python3,
+                    priority: None,
+                    apply_preprocessor: true,
+                    concurrency_settings:
+                        windmill_common::runnable_settings::ConcurrencySettings::default(),
+                    debouncing_settings:
+                        windmill_common::runnable_settings::DebouncingSettings::default(),
+                    labels: None,
+                })
+                .arg("who", json!("alice"))
+                .arg("count", json!(7))
+                .run_until_complete(db, false, port),
+            )
+            .await;
+
+            let result = job.json_result().unwrap();
+            // Preprocessor maps {who, count} -> {name, qty}. The @task
+            // `shout` upper-cases the name; the workflow returns greeting + qty.
+            assert_eq!(result["greeting"], json!("ALICE"));
+            assert_eq!(result["qty"], json!(7));
+
+            // Args column should now hold the preprocessed shape.
+            let args: serde_json::Value =
+                sqlx::query_scalar("SELECT args FROM v2_job WHERE id = $1")
+                    .bind(job.id)
+                    .fetch_one(db)
+                    .await
+                    .unwrap();
+            assert_eq!(args["name"], json!("alice"));
+            assert_eq!(args["qty"], json!(7));
+
+            let preprocessed: Option<bool> =
+                sqlx::query_scalar("SELECT preprocessed FROM v2_job WHERE id = $1")
+                    .bind(job.id)
+                    .fetch_one(db)
+                    .await
+                    .unwrap();
+            assert_eq!(preprocessed, Some(true));
+        },
+        port,
+    )
+    .await;
+    Ok(())
+}
+
 /// End-to-end comparison between the legacy `step()` suspend-and-replay path
 /// and the new SDK inline-persist fast path, toggled per-job via the
 /// `WM_WAC_INLINE_FAST_PATH` env var which the Python script sets on its own

--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -347,9 +347,11 @@ async fn list_scripts(
             .unwrap_or(true))
         || authed.is_operator
     {
-        // only include scripts that have a main function
-        // do not hide scripts without main if preprocessor is in the kinds
-        sqlb.and_where("o.auto_kind IS NULL");
+        // only include scripts that have a runnable entrypoint:
+        // - auto_kind IS NULL: regular script with main()
+        // - auto_kind = 'wac': workflow-as-code script
+        // exclude auto_kind = 'lib' (library scripts without main)
+        sqlb.and_where("(o.auto_kind IS NULL OR o.auto_kind = 'wac')");
     }
 
     if !lq.include_draft_only.unwrap_or(false) || authed.is_operator {

--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -347,11 +347,10 @@ async fn list_scripts(
             .unwrap_or(true))
         || authed.is_operator
     {
-        // only include scripts that have a runnable entrypoint:
-        // - auto_kind IS NULL: regular script with main()
-        // - auto_kind = 'wac': workflow-as-code script
-        // exclude auto_kind = 'lib' (library scripts without main)
-        sqlb.and_where("(o.auto_kind IS NULL OR o.auto_kind = 'wac')");
+        // only include scripts that have a runnable entrypoint. Use a
+        // deny-list: anything that isn't a 'lib' (library script without
+        // main) is callable, including future `auto_kind` values.
+        sqlb.and_where("(o.auto_kind IS NULL OR o.auto_kind <> 'lib')");
     }
 
     if !lq.include_draft_only.unwrap_or(false) || authed.is_operator {

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -2275,7 +2275,7 @@ try {{
 
     // WAC v2 post-execution: parse output and handle dispatch/suspend
     if is_wac_v2 {
-        return handle_wac_v2_output(result, job, conn, modules).await;
+        return handle_wac_v2_output(result, job, conn, modules, new_args.as_ref()).await;
     }
 
     Ok(result)
@@ -2306,6 +2306,7 @@ pub async fn handle_wac_v2_output(
     job: &MiniPulledJob,
     conn: &Connection,
     modules: &Option<std::collections::HashMap<String, windmill_common::scripts::ScriptModule>>,
+    preprocessed_args: Option<&HashMap<String, Box<RawValue>>>,
 ) -> error::Result<Box<RawValue>> {
     use crate::wac_executor::{
         load_checkpoint, parse_wac_output, update_checkpoint_for_dispatch, WacOutput,
@@ -2379,8 +2380,23 @@ pub async fn handle_wac_v2_output(
             //   2. Save checkpoint + suspend parent + seed child checkpoints
             //   3. THEN push the child jobs (making them visible to workers)
 
-            // Read the parent's original args for the child jobs
-            let parent_args: HashMap<String, Box<RawValue>> = {
+            // Read the parent's original args for the child jobs.
+            // If preprocessed_args is Some, the wrapper just ran the preprocessor
+            // and the DB row hasn't been updated yet — use those instead so child
+            // re-runs of the parent see the post-preprocessor args.
+            let parent_args: HashMap<String, Box<RawValue>> = if let Some(pre) = preprocessed_args {
+                let map: serde_json::Map<String, Value> = pre
+                    .iter()
+                    .map(|(k, v)| {
+                        (
+                            k.clone(),
+                            serde_json::from_str::<Value>(v.get()).unwrap_or(Value::Null),
+                        )
+                    })
+                    .collect();
+                checkpoint.input_args = map;
+                pre.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+            } else {
                 let stored: serde_json::Map<String, Value> = checkpoint.input_args.clone();
                 if stored.is_empty() {
                     // First dispatch — read from the parent job's args

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -2385,17 +2385,23 @@ pub async fn handle_wac_v2_output(
             // and the DB row hasn't been updated yet — use those instead so child
             // re-runs of the parent see the post-preprocessor args.
             let parent_args: HashMap<String, Box<RawValue>> = if let Some(pre) = preprocessed_args {
-                let map: serde_json::Map<String, Value> = pre
-                    .iter()
-                    .map(|(k, v)| {
-                        (
-                            k.clone(),
-                            serde_json::from_str::<Value>(v.get()).unwrap_or(Value::Null),
-                        )
-                    })
-                    .collect();
+                // Single pass: parse each raw value into a serde_json::Value for
+                // checkpoint.input_args, and clone the Box<RawValue> for the
+                // returned HashMap. A parse failure surfaces as an error rather
+                // than being silently coerced to null and persisted.
+                let mut map = serde_json::Map::with_capacity(pre.len());
+                let mut owned = HashMap::with_capacity(pre.len());
+                for (k, v) in pre.iter() {
+                    let parsed = serde_json::from_str::<Value>(v.get()).map_err(|e| {
+                        error::Error::internal_err(format!(
+                            "Failed to parse preprocessed arg '{k}': {e}"
+                        ))
+                    })?;
+                    map.insert(k.clone(), parsed);
+                    owned.insert(k.clone(), v.clone());
+                }
                 checkpoint.input_args = map;
-                pre.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+                owned
             } else {
                 let stored: serde_json::Map<String, Value> = checkpoint.input_args.clone();
                 if stored.is_empty() {

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -675,6 +675,7 @@ pub async fn handle_python_job(
         spread,
         main_name,
         pre_spread,
+        wac_pre_spread,
     ) = prepare_wrapper(
         job_dir,
         job.flow_step_id.as_deref(),
@@ -721,6 +722,29 @@ pub async fn handle_python_job(
 
     let main_override = main_name.unwrap_or_else(|| "main".to_string());
     let res_to_json_body = python_res_to_json_body(postprocessor);
+    let wac_preprocessor = if let Some(pre_spread) = wac_pre_spread.as_ref() {
+        format!(
+            r#"if not hasattr(inner_script, 'preprocessor') or not callable(inner_script.preprocessor):
+    raise ValueError("preprocessor function is missing")
+pre_args = {{}}
+{pre_spread}
+for k, v in list(pre_args.items()):
+    if v == '<function call>':
+        del pre_args[k]
+_pre_result = inner_script.preprocessor(**pre_args)
+if hasattr(_pre_result, '__await__'):
+    import asyncio
+    _pre_result = asyncio.get_event_loop().run_until_complete(_pre_result)
+kwargs = _pre_result if _pre_result is not None else {{}}
+_pre_json = json.dumps(kwargs, separators=(',', ':'), default=str)
+with open("args.json", 'w') as f:
+    f.write(_pre_json)
+sys.stdout.write("wm_res[preprocessed_args]:" + _pre_json + "\n")
+sys.stdout.flush()"#
+        )
+    } else {
+        "".to_string()
+    };
     let wrapper_content: String = if is_wac_v2 {
         format!(
             r#"
@@ -737,6 +761,7 @@ from wmill.client import _run_workflow
 with open("args.json") as f:
     kwargs = json.load(f, strict=False)
 {transforms}
+{wac_preprocessor}
 args = kwargs
 
 with open("checkpoint.json") as f:
@@ -1069,7 +1094,11 @@ mount {{
     // Box::pin to avoid bloating handle_python_job's async state machine (stack overflow).
     if is_wac_v2 {
         return Box::pin(crate::bun_executor::handle_wac_v2_output(
-            result, job, conn, modules,
+            result,
+            job,
+            conn,
+            modules,
+            new_args.as_ref(),
         ))
         .await;
     }
@@ -1079,12 +1108,12 @@ mount {{
 
 /// Generate Python code to spread preprocessor args from `kwargs` into `pre_args`.
 /// The `indent` parameter controls the join separator for multi-arg spreads.
-fn python_preprocessor_spread(sig: windmill_parser::MainArgSignature, indent: &str) -> String {
+fn python_preprocessor_spread(sig: &windmill_parser::MainArgSignature, indent: &str) -> String {
     if sig.star_kwargs {
         "pre_args = kwargs".to_string()
     } else {
         sig.args
-            .into_iter()
+            .iter()
             .map(|x| {
                 let name = &x.name;
                 if x.default.is_none() {
@@ -1208,7 +1237,7 @@ pub fn compute_py_codegen(content: &str, script_path: &str) -> PyScriptCodegen {
             .join("\n    ")
     };
 
-    let pre_spread = pre_sig.map(|sig| python_preprocessor_spread(sig, "    "));
+    let pre_spread = pre_sig.map(|sig| python_preprocessor_spread(&sig, "    "));
 
     let module_dir_dot = dirs.replace("/", ".").replace("-", "_");
 
@@ -1479,6 +1508,7 @@ async fn prepare_wrapper(
     String,
     Option<String>,
     Option<String>,
+    Option<String>,
 )> {
     let main_override = job_script_entrypoint_override.as_deref();
     let apply_preprocessor =
@@ -1614,7 +1644,12 @@ async fn prepare_wrapper(
             .join("\n    ")
     };
 
-    let pre_spread = pre_sig.map(|sig| python_preprocessor_spread(sig, "        "));
+    let pre_spread = pre_sig
+        .as_ref()
+        .map(|sig| python_preprocessor_spread(sig, "        "));
+    let wac_pre_spread = pre_sig
+        .as_ref()
+        .map(|sig| python_preprocessor_spread(sig, ""));
 
     let module_dir_dot = dirs.replace("/", ".").replace("-", "_");
 
@@ -1629,6 +1664,7 @@ async fn prepare_wrapper(
         spread,
         main_override.map(ToString::to_string),
         pre_spread,
+        wac_pre_spread,
     ))
 }
 

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -722,25 +722,28 @@ pub async fn handle_python_job(
 
     let main_override = main_name.unwrap_or_else(|| "main".to_string());
     let res_to_json_body = python_res_to_json_body(postprocessor);
+    // Indented at 4 spaces so it can be inlined inside the wrapper's
+    // `try:` block — preprocessor failures route through the same error
+    // serializer as workflow failures.
     let wac_preprocessor = if let Some(pre_spread) = wac_pre_spread.as_ref() {
         format!(
             r#"if not hasattr(inner_script, 'preprocessor') or not callable(inner_script.preprocessor):
-    raise ValueError("preprocessor function is missing")
-pre_args = {{}}
-{pre_spread}
-for k, v in list(pre_args.items()):
-    if v == '<function call>':
-        del pre_args[k]
-_pre_result = inner_script.preprocessor(**pre_args)
-if hasattr(_pre_result, '__await__'):
-    import asyncio
-    _pre_result = asyncio.get_event_loop().run_until_complete(_pre_result)
-kwargs = _pre_result if _pre_result is not None else {{}}
-_pre_json = json.dumps(kwargs, separators=(',', ':'), default=str)
-with open("args.json", 'w') as f:
-    f.write(_pre_json)
-sys.stdout.write("wm_res[preprocessed_args]:" + _pre_json + "\n")
-sys.stdout.flush()"#
+        raise ValueError("preprocessor function is missing")
+    pre_args = {{}}
+    {pre_spread}
+    for k, v in list(pre_args.items()):
+        if v == '<function call>':
+            del pre_args[k]
+    _pre_result = inner_script.preprocessor(**pre_args)
+    if hasattr(_pre_result, '__await__'):
+        import asyncio
+        _pre_result = asyncio.run(_pre_result)
+    kwargs = _pre_result if _pre_result is not None else {{}}
+    _pre_json = json.dumps(kwargs, separators=(',', ':'), default=str)
+    with open("args.json", 'w') as f:
+        f.write(_pre_json)
+    sys.stdout.write("wm_res[preprocessed_args]:" + _pre_json + "\n")
+    sys.stdout.flush()"#
         )
     } else {
         "".to_string()
@@ -761,30 +764,28 @@ from wmill.client import _run_workflow
 with open("args.json") as f:
     kwargs = json.load(f, strict=False)
 {transforms}
-{wac_preprocessor}
-args = kwargs
 
 with open("checkpoint.json") as f:
     checkpoint = json.load(f, strict=False)
 
 result_json = os.path.join(os.path.abspath(os.path.dirname(__file__)), "result.json")
 
-# Find the @workflow-decorated function
-workflow_fn = None
-for name in dir(inner_script):
-    obj = getattr(inner_script, name)
-    if callable(obj) and getattr(obj, '_is_workflow', False):
-        workflow_fn = obj
-        break
-
-if workflow_fn is None:
-    raise ValueError("No @workflow function found in script")
-
-for k, v in list(args.items()):
-    if v == '<function call>':
-        del args[k]
-
 try:
+    {wac_preprocessor}
+    args = kwargs
+    for k, v in list(args.items()):
+        if v == '<function call>':
+            del args[k]
+
+    workflow_fn = None
+    for name in dir(inner_script):
+        obj = getattr(inner_script, name)
+        if callable(obj) and getattr(obj, '_is_workflow', False):
+            workflow_fn = obj
+            break
+    if workflow_fn is None:
+        raise ValueError("No @workflow function found in script")
+
     output = _run_workflow(workflow_fn, checkpoint, args)
     if isinstance(output, dict) and output.get("type") == "complete":
         print("")
@@ -1647,9 +1648,11 @@ async fn prepare_wrapper(
     let pre_spread = pre_sig
         .as_ref()
         .map(|sig| python_preprocessor_spread(sig, "        "));
+    // 4-space indent for the WAC wrapper, where the preprocessor block is
+    // injected inside the `try:` body so failures get serialized to result.json.
     let wac_pre_spread = pre_sig
         .as_ref()
-        .map(|sig| python_preprocessor_spread(sig, ""));
+        .map(|sig| python_preprocessor_spread(sig, "    "));
 
     let module_dir_dot = dirs.replace("/", ".").replace("-", "_");
 


### PR DESCRIPTION
## Summary
Fixes the three latest workflow-as-code bug reports:

- **#8945** — Python WAC template (`@workflow async def main(...)`) was not detected as `auto_kind = \"wac\"`. The detection only ran when no `main` function was found, so the standard template silently fell back to `None`. Hoisted the heuristic so it runs regardless of whether `main` is the entrypoint.
- **#8946** — `GET /api/w/{ws}/scripts/list?kinds=script` excluded WAC scripts because the query filtered `auto_kind IS NULL` to hide library scripts. WAC scripts have `auto_kind = 'wac'` and are runnable, so they should be returned. Changed the filter to allow both `NULL` and `'wac'`, still excluding `'lib'`.
- **#8947** — Preprocessors defined alongside a WAC workflow were never invoked. Injected the preprocessor call into the Python WAC wrapper (gated by `apply_preprocessor` exactly like the regular wrapper), and plumbed the preprocessed args through `handle_wac_v2_output` so inline child re-runs see the post-preprocessor args via `checkpoint.input_args`.

## Test plan
- [x] New unit test `test_parse_python_wac_main_decorator` in `windmill-parser-py` (passes)
- [x] Existing `windmill-parser-wac` tests still pass
- [x] `cargo check -p windmill-worker --features=private` clean
- [x] `cargo check -p windmill-api-scripts` clean
- [ ] Manually deploy a Python WAC script with `@workflow async def main` — confirm \"wac\" label appears
- [ ] Manually create an HTTP trigger and confirm the WAC script appears in the dropdown
- [ ] Manually run a WAC script triggered by a webhook with a preprocessor that maps event payload → workflow args

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WAC detection and behavior: detect Python workflows with `@workflow` main (no `@task` needed), include WAC scripts in `scripts/list`, and run preprocessors before workflows with preprocessed args safely propagated to child runs.

- **Bug Fixes**
  - #8945: Python parser now flags WAC when `@workflow` and `wmill` imports are present, even with `async def main` and without `@task`. Adds a step-only unit test.
  - #8946: `GET /api/w/{ws}/scripts/list?kinds=script` now includes WAC and other runnable scripts by excluding only `'lib'` (`auto_kind <> 'lib'`). Adds an integration test.
  - #8947: Python WAC wrapper runs `preprocessor` inside the `try:` block and supports coroutine preprocessors via `asyncio.run`. Both Python and `bun` pass preprocessed args to `handle_wac_v2_output`, which seeds `checkpoint.input_args` and surfaces JSON parse errors. Adds an integration test.

<sup>Written for commit 3a9b71c823d38ce8310eaf94e9cec4c1a85f7c1a. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/8951?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

