### PR TITLE
fix: surface scope errors as 403 and show real message in CLI

### DIFF
--- a/backend/windmill-api-auth/src/auth.rs
+++ b/backend/windmill-api-auth/src/auth.rs
@@ -678,7 +678,6 @@ pub async fn resolve_opt_job_authed(
                         path,
                         method,
                     ) {
-                        BRUTE_FORCE_COUNTER.increment().await;
                         return Err((err, parts));
                     }
                 }

--- a/backend/windmill-api-auth/src/lib.rs
+++ b/backend/windmill-api-auth/src/lib.rs
@@ -220,7 +220,7 @@ where
         }
 
         if is_scoped_token {
-            return Err(Error::NotAuthorized(format!(
+            return Err(Error::PermissionDenied(format!(
                 "Required scope: {}",
                 required_scope.as_string()
             )));

--- a/backend/windmill-api-auth/src/scopes.rs
+++ b/backend/windmill-api-auth/src/scopes.rs
@@ -461,7 +461,7 @@ pub fn check_route_access(
         if token_scopes.iter().any(|s| s.starts_with("mcp:")) {
             return Ok(());
         }
-        return Err(Error::NotAuthorized(
+        return Err(Error::PermissionDenied(
             "Access denied. Required scope: mcp:*".to_string(),
         ));
     }
@@ -506,7 +506,7 @@ pub fn check_route_access(
         format!("{}:{}", required_domain.as_str(), required_action.as_str())
     };
 
-    Err(Error::NotAuthorized(format!(
+    Err(Error::PermissionDenied(format!(
         "Access denied. Required scope: {}",
         scope_display
     )))

--- a/cli/src/core/auth.ts
+++ b/cli/src/core/auth.ts
@@ -84,6 +84,32 @@ export async function requireLogin(
     // rather than falling back to interactive login — they expect their explicit
     // credentials to work and should fix them if they don't.
     if (opts.token || opts.baseUrl) {
+      const isApiError = error && typeof error === "object" &&
+        "name" in error && (error as { name: unknown }).name === "ApiError";
+      if (isApiError) {
+        const status = (error as { status?: number }).status;
+        const body = (error as { body?: unknown }).body;
+        const bodyStr = typeof body === "object" && body !== null
+          ? JSON.stringify(body)
+          : String(body ?? "").trim();
+        if (status === 403) {
+          // 403 means the token authenticated but lacks scope — re-issuing
+          // won't help. Keep this distinct from the 401 message so the user
+          // doesn't waste time reproducing the token.
+          log.info(colors.red(
+            `Permission denied: the token is valid but lacks the required scope.${bodyStr ? `\n${bodyStr}` : ""}`
+          ));
+        } else if (status === 401) {
+          log.info(colors.red(
+            `Could not authenticate with the provided credentials. Please check your --token and --base-url and try again.${bodyStr ? `\n${bodyStr}` : ""}`
+          ));
+        } else {
+          log.info(colors.red(
+            `Request failed (${status ?? "unknown"}): ${bodyStr}`
+          ));
+        }
+        return process.exit(1);
+      }
       log.info(colors.red("Could not authenticate with the provided credentials. Please check your --token and --base-url and try again."));
       return process.exit(1);
     }

--- a/cli/src/core/auth.ts
+++ b/cli/src/core/auth.ts
@@ -89,9 +89,17 @@ export async function requireLogin(
       if (isApiError) {
         const status = (error as { status?: number }).status;
         const body = (error as { body?: unknown }).body;
-        const bodyStr = typeof body === "object" && body !== null
+        let bodyStr = typeof body === "object" && body !== null
           ? JSON.stringify(body)
           : String(body ?? "").trim();
+        // Strip backend source-file refs like "(flows.rs:1400)" or
+        // "@scopes.rs:509" from the surfaced message — same pattern used in
+        // main.ts for ApiError display.
+        bodyStr = bodyStr.replace(/\s*[@(]\w+\.rs:\d+[:\d]*\)?/g, "");
+        // The backend's `Error::PermissionDenied` formats with a
+        // "Permission denied: " prefix; the new CLI message also leads with
+        // that phrase, so strip it from the body to avoid duplication.
+        bodyStr = bodyStr.replace(/^(Permission denied|Not authorized): /, "");
         if (status === 403) {
           // 403 means the token authenticated but lacks scope — re-issuing
           // won't help. Keep this distinct from the 401 message so the user


### PR DESCRIPTION
## Summary

Customer reported that `wmill sync push` with a scoped token shows `Could not authenticate with the provided credentials` even when the token is valid — the misleading message hides that the real problem is missing scopes (e.g. `users:read`). This PR fixes the misleading messaging by surfacing the actual server error and aligning the backend status code with HTTP semantics.

## Changes

- **Backend**: scope-check denials in `windmill-api-auth/src/scopes.rs` now return `Error::PermissionDenied` (HTTP 403 Forbidden) instead of `Error::NotAuthorized` (HTTP 401 Unauthorized). Authorization failures should be 403 per HTTP semantics — the token authenticated, it just lacks the required scope.
- **Backend**: removed `BRUTE_FORCE_COUNTER.increment()` for scope-check failures in `windmill-api-auth/src/auth.rs`. Brute-force protection still covers genuinely unauthenticated requests at the bottom of `resolve_opt_job_authed`; a valid token failing a scope check is not a brute-force attempt.
- **CLI**: `requireLogin` in `cli/src/core/auth.ts` now extracts the `body` from `ApiError` when explicit `--token`/`--base-url` were provided and tailors the message: 403 → "Permission denied: the token is valid but lacks the required scope" + body; 401 keeps the auth wording but appends the body. The CLI fix degrades gracefully against older backends still returning 401 — the user still sees the underlying `Access denied. Required scope: users:read` body.

## Test plan

- [ ] Generate a workspace token without `users:read` scope and run `wmill sync push` against it — verify the CLI prints `Permission denied: ... Access denied. Required scope: users:read` (not the generic auth message).
- [ ] Verify that a request with an invalid/expired token still shows the original `Could not authenticate with the provided credentials` 401 message (now with any extra body appended).
- [ ] Confirm the backend now returns 403 for scope denials (`curl` an endpoint with a scoped token and observe HTTP status).
- [ ] Confirm `BRUTE_FORCE_COUNTER` still increments for genuinely bad tokens (unauthenticated path at `auth.rs:712`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misleading auth errors for scoped tokens by returning 403 on missing scopes and showing the server’s message in the CLI. Users now see which scope is required instead of a generic auth failure.

- **Bug Fixes**
  - Scope denials now consistently return 403 Forbidden (was 401) across route-level and handler-level `check_scopes`, so endpoints like scripts/flows/jobs report “authenticated but not authorized.”
  - Removed brute-force counter increment on scope-check failures; still increments for unauthenticated requests.
  - CLI `requireLogin` shows server error details, strips backend file refs and duplicate “Permission denied/Not authorized” prefixes, and differentiates 403 vs 401 while staying compatible with older backends.

<sup>Written for commit 9f1ce4a28d12ebf6ec011a96943d3c7d6b7b4036. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/8953?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

