### PR TITLE
feat: support restart from steps inside BranchOne, ForLoop, Subflow

### DIFF
--- a/backend/.sqlx/query-5a219a2532517869578c4504ff3153c43903f929ae5d62fbba12610f89c36d55.json
+++ b/backend/.sqlx/query-5a219a2532517869578c4504ff3153c43903f929ae5d62fbba12610f89c36d55.json
@@ -15,7 +15,7 @@
       ]
     },
     "nullable": [
-      null
+      true
     ]
   },
   "hash": "5a219a2532517869578c4504ff3153c43903f929ae5d62fbba12610f89c36d55"

--- a/backend/.sqlx/query-ca60e1875e82a492b34bbfd771ad7ba526e4aa7914f1042c5ea461816f69b658.json
+++ b/backend/.sqlx/query-ca60e1875e82a492b34bbfd771ad7ba526e4aa7914f1042c5ea461816f69b658.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT flow_status FROM v2_job_completed WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "flow_status",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "ca60e1875e82a492b34bbfd771ad7ba526e4aa7914f1042c5ea461816f69b658"
+}

--- a/backend/.sqlx/query-cc181a37ae10254f0b7727655207c40ba729ac4c8a21667ede7b4d13d328482f.json
+++ b/backend/.sqlx/query-cc181a37ae10254f0b7727655207c40ba729ac4c8a21667ede7b4d13d328482f.json
@@ -1,0 +1,71 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n            j.runnable_id AS \"runnable_id: ScriptHash\",\n            j.kind AS \"job_kind!: JobKind\",\n            COALESCE(c.flow_status, c.workflow_as_code_status) AS \"flow_status: sqlx::types::Json<Box<RawValue>>\",\n            j.raw_flow AS \"raw_flow: sqlx::types::Json<Box<RawValue>>\"\n        FROM v2_job_completed c JOIN v2_job j USING (id)\n        WHERE j.id = $1 AND j.workspace_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "runnable_id: ScriptHash",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "job_kind!: JobKind",
+        "type_info": {
+          "Custom": {
+            "name": "job_kind",
+            "kind": {
+              "Enum": [
+                "script",
+                "preview",
+                "flow",
+                "dependencies",
+                "flowpreview",
+                "script_hub",
+                "identity",
+                "flowdependencies",
+                "http",
+                "graphql",
+                "postgresql",
+                "noop",
+                "appdependencies",
+                "deploymentcallback",
+                "singlestepflow",
+                "flowscript",
+                "flownode",
+                "appscript",
+                "aiagent",
+                "unassigned_script",
+                "unassigned_flow",
+                "unassigned_singlestepflow"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "flow_status: sqlx::types::Json<Box<RawValue>>",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "raw_flow: sqlx::types::Json<Box<RawValue>>",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true,
+      false,
+      null,
+      true
+    ]
+  },
+  "hash": "cc181a37ae10254f0b7727655207c40ba729ac4c8a21667ede7b4d13d328482f"
+}

--- a/backend/tests/job_payload.rs
+++ b/backend/tests/job_payload.rs
@@ -829,6 +829,8 @@ mod job_payload {
         let server = ApiServer::start(db.clone()).await?;
         let port = server.addr.port();
 
+        // BranchOne with TWO inner steps so we can verify that earlier siblings
+        // inside the branch are preserved when restarting at a later one.
         let flow_value: FlowValue = serde_json::from_value(json!({
             "modules": [{
                 "id": "a",
@@ -848,14 +850,25 @@ mod job_payload {
                     "branches": [{
                         "expr": "true",
                         "modules": [{
-                            "id": "inner",
+                            "id": "inner_first",
                             "value": {
                                 "type": "rawscript",
                                 "language": "deno",
                                 "input_transforms": {
                                     "world": { "type": "javascript", "expr": "flow_input.world" }
                                 },
-                                "content": "export function main(world: string) { return `inner-${world}` }"
+                                "content": "export function main(world: string) { return `first-${world}` }"
+                            }
+                        }, {
+                            "id": "inner_second",
+                            "value": {
+                                "type": "rawscript",
+                                "language": "deno",
+                                "input_transforms": {
+                                    "world": { "type": "javascript", "expr": "flow_input.world" },
+                                    "first": { "type": "javascript", "expr": "results.inner_first" }
+                                },
+                                "content": "export function main(world: string, first: string) { return `${first}|second-${world}` }"
                             }
                         }]
                     }]
@@ -880,15 +893,16 @@ mod job_payload {
             .arg("world", json!("foo"))
             .run_until_complete(db, false, port)
             .await;
-            assert_eq!(first_run.json_result().unwrap(), json!("inner-foo"));
+            assert_eq!(
+                first_run.json_result().unwrap(),
+                json!("first-foo|second-foo")
+            );
 
             let original_branch_child =
                 child_job_id_for_step(db, first_run.id, "branch", None).await;
 
-            // Restart at the nested `inner` step inside `branch`. The new run should
-            // re-execute step `a` (since it's before the BranchOne) AND `inner`
-            // (the restart point). The chosen branch is locked to branch 0.
-            let restarted = RunJob::from(JobPayload::RawFlow {
+            // Restart at the FIRST inner step. Both inner steps re-run with new args.
+            let restarted_at_first = RunJob::from(JobPayload::RawFlow {
                 value: flow_value.clone(),
                 path: None,
                 restarted_from: Some(RestartedFrom {
@@ -899,7 +913,7 @@ mod job_payload {
                     branch_chosen: Some(BranchChosen::Branch { branch: 0 }),
                     nested: Some(Box::new(RestartedFrom {
                         flow_job_id: original_branch_child,
-                        step_id: "inner".into(),
+                        step_id: "inner_first".into(),
                         branch_or_iteration_n: None,
                         flow_version: None,
                         branch_chosen: None,
@@ -910,7 +924,42 @@ mod job_payload {
             .arg("world", json!("bar"))
             .run_until_complete(db, false, port)
             .await;
-            assert_eq!(restarted.json_result().unwrap(), json!("inner-bar"));
+            assert_eq!(
+                restarted_at_first.json_result().unwrap(),
+                json!("first-bar|second-bar")
+            );
+
+            // Restart at the SECOND inner step (the user-reported case). The first
+            // inner step's original output ("first-foo") must be preserved as a
+            // dependency for the second step's `results.inner_first` reference.
+            let restarted_at_second = RunJob::from(JobPayload::RawFlow {
+                value: flow_value.clone(),
+                path: None,
+                restarted_from: Some(RestartedFrom {
+                    flow_job_id: first_run.id,
+                    step_id: "branch".into(),
+                    branch_or_iteration_n: None,
+                    flow_version: None,
+                    branch_chosen: Some(BranchChosen::Branch { branch: 0 }),
+                    nested: Some(Box::new(RestartedFrom {
+                        flow_job_id: original_branch_child,
+                        step_id: "inner_second".into(),
+                        branch_or_iteration_n: None,
+                        flow_version: None,
+                        branch_chosen: None,
+                        nested: None,
+                    })),
+                }),
+            })
+            .arg("world", json!("baz"))
+            .run_until_complete(db, false, port)
+            .await;
+            // `inner_first` keeps its original "first-foo" result; only `inner_second`
+            // re-runs with the new `world=baz` arg.
+            assert_eq!(
+                restarted_at_second.json_result().unwrap(),
+                json!("first-foo|second-baz")
+            );
         };
         test_for_versions(VERSION_FLAGS.iter().copied(), test).await;
         Ok(())
@@ -1005,6 +1054,90 @@ mod job_payload {
                 json!(["first:x", "second:y"])
             );
         };
+        test_for_versions(VERSION_FLAGS.iter().copied(), test).await;
+        Ok(())
+    }
+
+    /// Regression test for the FlowNode case: when a flow is deployed, container
+    /// bodies (BranchOne branches, ForLoop iterations) get compiled into FlowNodes.
+    /// A nested restart targeting a step inside such a container spawns a child as
+    /// `JobPayload::RestartedFlow` against the original FlowNode-kind child. Without
+    /// preserving the original `JobKind` (the bug we just fixed), the new spawn
+    /// would land as `JobKind::Flow` with the FlowNode id misinterpreted as a
+    /// flow_version id, failing with "Flow version not found".
+    #[cfg(feature = "deno_core")]
+    #[sqlx::test(fixtures("base", "hello"))]
+    async fn test_nested_restart_inside_deployed_loop_flownode(
+        db: Pool<Postgres>,
+    ) -> anyhow::Result<()> {
+        initialize_tracing().await;
+        let server = ApiServer::start(db.clone()).await?;
+        let port = server.addr.port();
+
+        // The fixture's `hello_with_nodes_flow` is a deployed flow with a top-level
+        // ForLoop iterating ['foo', 'bar', 'baz'], whose body has modules `b` (greet)
+        // and `c` (echo greeting). After deployment the body is wrapped in a FlowNode.
+        let test = || async {
+            let db = &db;
+            let first_run = RunJob::from(JobPayload::Flow {
+                path: "f/system/hello_with_nodes_flow".to_string(),
+                dedicated_worker: None,
+                apply_preprocessor: true,
+                version: 1443253234253454,
+                labels: None,
+            })
+            .run_until_complete(db, false, port)
+            .await;
+
+            // Iteration 1's child job (kind=flownode after FlowDependencies has run).
+            let original_iter1_child = child_job_id_for_step(db, first_run.id, "a", Some(1)).await;
+
+            // Restart at inner step `c` of iteration 1. Iteration 0 keeps its original
+            // result; iteration 1 re-runs starting at `c` (so `b` is preserved as
+            // Success inside the iteration); iteration 2 fresh-runs.
+            let restarted = RunJob::from(JobPayload::RestartedFlow {
+                completed_job_id: first_run.id,
+                step_id: "a".into(),
+                branch_or_iteration_n: Some(1),
+                flow_version: None,
+                branch_chosen: None,
+                nested: Some(Box::new(RestartedFrom {
+                    flow_job_id: original_iter1_child,
+                    step_id: "c".into(),
+                    branch_or_iteration_n: None,
+                    flow_version: None,
+                    branch_chosen: None,
+                    nested: None,
+                })),
+            })
+            .run_until_complete(db, false, port)
+            .await;
+            // Same args, same output as original — the goal is to verify the spawn
+            // doesn't 500 with "Flow version not found" when the inner child is a
+            // FlowNode.
+            assert_eq!(
+                restarted.json_result().unwrap(),
+                json!([
+                    "Did you just say \"Hello foo!\"??!",
+                    "Did you just say \"Hello bar!\"??!",
+                    "Did you just say \"Hello baz!\"??!",
+                ])
+            );
+        };
+        // Exercise BOTH the pre-deployment path (raw flow inline, FlowPreview kind)
+        // and the post-deployment path (FlowNode kind) — the latter is the case the
+        // user originally hit.
+        test_for_versions(VERSION_FLAGS.iter().copied(), test).await;
+        let _ = RunJob::from(JobPayload::FlowDependencies {
+            path: "f/system/hello_with_nodes_flow".to_string(),
+            dedicated_worker: None,
+            version: 1443253234253454,
+            debouncing_settings: Default::default(),
+        })
+        .run_until_complete(&db, false, port)
+        .await
+        .json_result()
+        .unwrap();
         test_for_versions(VERSION_FLAGS.iter().copied(), test).await;
         Ok(())
     }

--- a/backend/tests/job_payload.rs
+++ b/backend/tests/job_payload.rs
@@ -1581,6 +1581,23 @@ mod job_payload {
                 "step `c` inside preserved iter 0 should reuse its original UUID"
             );
         };
+        // Pre-deployment: subflow's iteration wrapper is a FlowPreview (inline
+        // RawFlow); leaf `c` runs as a rawscript embedded in the wrapper.
+        test_for_versions(VERSION_FLAGS.iter().copied(), test).await;
+        // Post-deployment: subflow's body is compiled into a FlowNode; the iteration
+        // wrapper jobs run with kind=FlowNode and the leaf becomes a FlowScript
+        // referencing a flow_node id. Re-running the same scenario exercises the
+        // kind-preservation path through the subflow boundary AND a level deeper.
+        let _ = RunJob::from(JobPayload::FlowDependencies {
+            path: "f/system/hello_with_nodes_flow".to_string(),
+            dedicated_worker: None,
+            version: 1443253234253454,
+            debouncing_settings: Default::default(),
+        })
+        .run_until_complete(&db, false, port)
+        .await
+        .json_result()
+        .unwrap();
         test_for_versions(VERSION_FLAGS.iter().copied(), test).await;
         Ok(())
     }

--- a/backend/tests/job_payload.rs
+++ b/backend/tests/job_payload.rs
@@ -785,9 +785,24 @@ mod job_payload {
         Ok(())
     }
 
-    /// Walk a completed flow's `flow_status` to find the child job UUID for a given
-    /// container step at the given iteration. Used by nested-restart tests to
-    /// reconstruct the `nested` chain that the API would resolve normally.
+    /// Walk a chain of `(step_id, iter)` hops through nested completed jobs to
+    /// reach a deeper child UUID. Used by nested-restart tests to assert that
+    /// preserved iterations / preserved siblings reuse the original child UUID
+    /// (and that re-run ones get a new UUID).
+    async fn nested_child_job_id(
+        db: &Pool<Postgres>,
+        mut job_id: uuid::Uuid,
+        path: &[(&str, Option<usize>)],
+    ) -> uuid::Uuid {
+        for (step_id, iter) in path {
+            job_id = child_job_id_for_step(db, job_id, step_id, *iter).await;
+        }
+        job_id
+    }
+
+    /// Look up a single child job UUID from a completed flow's `flow_status` for
+    /// a given top-level step (and optional iteration index for ForLoop /
+    /// BranchAll containers).
     async fn child_job_id_for_step(
         db: &Pool<Postgres>,
         flow_job_id: uuid::Uuid,
@@ -900,6 +915,18 @@ mod job_payload {
 
             let original_branch_child =
                 child_job_id_for_step(db, first_run.id, "branch", None).await;
+            // Capture the original inner_first job UUID so we can later assert the
+            // restart-at-inner_second run preserves it byte-for-byte (i.e., the
+            // step is reused, not silently re-executed with the same args).
+            let original_inner_first =
+                nested_child_job_id(db, first_run.id, &[("branch", None), ("inner_first", None)])
+                    .await;
+            let original_inner_second = nested_child_job_id(
+                db,
+                first_run.id,
+                &[("branch", None), ("inner_second", None)],
+            )
+            .await;
 
             // Restart at the FIRST inner step. Both inner steps re-run with new args.
             let restarted_at_first = RunJob::from(JobPayload::RawFlow {
@@ -959,6 +986,30 @@ mod job_payload {
             assert_eq!(
                 restarted_at_second.json_result().unwrap(),
                 json!("first-foo|second-baz")
+            );
+
+            // Identity proof: inner_first's UUID in the restarted run must be the
+            // exact same UUID as in the original run (no re-execution), and
+            // inner_second must be a fresh UUID (was re-executed).
+            let new_inner_first = nested_child_job_id(
+                db,
+                restarted_at_second.id,
+                &[("branch", None), ("inner_first", None)],
+            )
+            .await;
+            let new_inner_second = nested_child_job_id(
+                db,
+                restarted_at_second.id,
+                &[("branch", None), ("inner_second", None)],
+            )
+            .await;
+            assert_eq!(
+                new_inner_first, original_inner_first,
+                "inner_first should reuse the original job UUID"
+            );
+            assert_ne!(
+                new_inner_second, original_inner_second,
+                "inner_second should be a fresh job"
             );
         };
         test_for_versions(VERSION_FLAGS.iter().copied(), test).await;
@@ -1022,7 +1073,9 @@ mod job_payload {
                 json!(["first:x", "first:y"])
             );
 
-            // Original child job for iteration 1 of `loop`.
+            // Original child jobs for both iterations.
+            let original_iter0_child =
+                child_job_id_for_step(db, first_run.id, "loop", Some(0)).await;
             let original_iter1_child =
                 child_job_id_for_step(db, first_run.id, "loop", Some(1)).await;
 
@@ -1052,6 +1105,17 @@ mod job_payload {
             assert_eq!(
                 restarted.json_result().unwrap(),
                 json!(["first:x", "second:y"])
+            );
+            // Identity proof: iter 0's child UUID survives intact, iter 1 is fresh.
+            let new_iter0_child = child_job_id_for_step(db, restarted.id, "loop", Some(0)).await;
+            let new_iter1_child = child_job_id_for_step(db, restarted.id, "loop", Some(1)).await;
+            assert_eq!(
+                new_iter0_child, original_iter0_child,
+                "iteration 0 should reuse the original child job"
+            );
+            assert_ne!(
+                new_iter1_child, original_iter1_child,
+                "iteration 1 should be a fresh job"
             );
         };
         test_for_versions(VERSION_FLAGS.iter().copied(), test).await;
@@ -1138,6 +1202,385 @@ mod job_payload {
         .await
         .json_result()
         .unwrap();
+        test_for_versions(VERSION_FLAGS.iter().copied(), test).await;
+        Ok(())
+    }
+
+    /// Two ForLoops nested inside each other. We restart at the leaf step inside
+    /// outer iter K=1 and inner iter M=1. Iters before K stay frozen at the parent
+    /// level; iter K's inner iters before M stay frozen at the inner level; the
+    /// inner-M leaf re-runs with new input.
+    #[cfg(feature = "deno_core")]
+    #[sqlx::test(fixtures("base", "hello"))]
+    async fn test_nested_restart_inside_nested_forloops(db: Pool<Postgres>) -> anyhow::Result<()> {
+        initialize_tracing().await;
+        let server = ApiServer::start(db.clone()).await?;
+        let port = server.addr.port();
+
+        // Outer iterates [1,2]; for each outer iter, inner iterates ['x','y'];
+        // leaf returns "<tag>:<inner>". Tag comes from flow_input so we can
+        // observe which leaves re-ran.
+        let flow_value: FlowValue = serde_json::from_value(json!({
+            "modules": [{
+                "id": "outer",
+                "value": {
+                    "type": "forloopflow",
+                    "iterator": { "type": "javascript", "expr": "[1, 2]" },
+                    "skip_failures": false,
+                    "modules": [{
+                        "id": "inner",
+                        "value": {
+                            "type": "forloopflow",
+                            "iterator": { "type": "javascript", "expr": "['x', 'y']" },
+                            "skip_failures": false,
+                            "modules": [{
+                                "id": "leaf",
+                                "value": {
+                                    "type": "rawscript",
+                                    "language": "deno",
+                                    "input_transforms": {
+                                        "tag": { "type": "javascript", "expr": "flow_input.tag" },
+                                        "iv": { "type": "javascript", "expr": "flow_input.iter.value" }
+                                    },
+                                    "content": "export function main(tag: string, iv: string) { return `${tag}:${iv}` }"
+                                }
+                            }]
+                        }
+                    }]
+                }
+            }],
+            "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": { "tag": { "type": "string" } },
+                "order": ["tag"]
+            }
+        }))
+        .unwrap();
+
+        let test = || async {
+            let db = &db;
+            let first_run = RunJob::from(JobPayload::RawFlow {
+                value: flow_value.clone(),
+                path: None,
+                restarted_from: None,
+            })
+            .arg("tag", json!("first"))
+            .run_until_complete(db, false, port)
+            .await;
+            assert_eq!(
+                first_run.json_result().unwrap(),
+                json!([["first:x", "first:y"], ["first:x", "first:y"]])
+            );
+
+            // Snapshot every original child UUID we'll later compare against.
+            let original_outer_iter0 =
+                child_job_id_for_step(db, first_run.id, "outer", Some(0)).await;
+            let outer_iter1_child = child_job_id_for_step(db, first_run.id, "outer", Some(1)).await;
+            let original_outer1_inner0 =
+                child_job_id_for_step(db, outer_iter1_child, "inner", Some(0)).await;
+            let inner_iter1_child =
+                child_job_id_for_step(db, outer_iter1_child, "inner", Some(1)).await;
+
+            let restarted = RunJob::from(JobPayload::RawFlow {
+                value: flow_value.clone(),
+                path: None,
+                restarted_from: Some(RestartedFrom {
+                    flow_job_id: first_run.id,
+                    step_id: "outer".into(),
+                    branch_or_iteration_n: Some(1),
+                    flow_version: None,
+                    branch_chosen: None,
+                    nested: Some(Box::new(RestartedFrom {
+                        flow_job_id: outer_iter1_child,
+                        step_id: "inner".into(),
+                        branch_or_iteration_n: Some(1),
+                        flow_version: None,
+                        branch_chosen: None,
+                        nested: Some(Box::new(RestartedFrom {
+                            flow_job_id: inner_iter1_child,
+                            step_id: "leaf".into(),
+                            branch_or_iteration_n: None,
+                            flow_version: None,
+                            branch_chosen: None,
+                            nested: None,
+                        })),
+                    })),
+                }),
+            })
+            .arg("tag", json!("second"))
+            .run_until_complete(db, false, port)
+            .await;
+            // Outer iter 0 frozen; outer iter 1 has inner iter 0 frozen and inner
+            // iter 1 re-run with new tag.
+            assert_eq!(
+                restarted.json_result().unwrap(),
+                json!([["first:x", "first:y"], ["first:x", "second:y"]])
+            );
+            // Identity proof at every layer:
+            //   * outer iter 0's child UUID survives (preserved iteration)
+            //   * outer iter 1's child UUID is fresh (re-spawned as RestartedFlow)
+            //   * inside that fresh outer-iter-1 child, inner iter 0's UUID equals
+            //     the ORIGINAL outer-iter-1's inner-iter-0 UUID (preserved through
+            //     the nested chain)
+            //   * inner iter 1's UUID is fresh
+            let new_outer_iter0 = child_job_id_for_step(db, restarted.id, "outer", Some(0)).await;
+            let new_outer_iter1 = child_job_id_for_step(db, restarted.id, "outer", Some(1)).await;
+            let new_outer1_inner0 =
+                child_job_id_for_step(db, new_outer_iter1, "inner", Some(0)).await;
+            let new_outer1_inner1 =
+                child_job_id_for_step(db, new_outer_iter1, "inner", Some(1)).await;
+            assert_eq!(
+                new_outer_iter0, original_outer_iter0,
+                "outer iter 0 should reuse original child"
+            );
+            assert_ne!(
+                new_outer_iter1, outer_iter1_child,
+                "outer iter 1 should be a fresh child"
+            );
+            assert_eq!(
+                new_outer1_inner0, original_outer1_inner0,
+                "inner iter 0 inside outer iter 1 should reuse original child"
+            );
+            assert_ne!(
+                new_outer1_inner1, inner_iter1_child,
+                "inner iter 1 inside outer iter 1 should be a fresh child"
+            );
+        };
+        test_for_versions(VERSION_FLAGS.iter().copied(), test).await;
+        Ok(())
+    }
+
+    /// BranchOne nested inside another BranchOne. We restart at the deepest
+    /// leaf with both branches locked to their original choices.
+    #[cfg(feature = "deno_core")]
+    #[sqlx::test(fixtures("base", "hello"))]
+    async fn test_nested_restart_inside_nested_branchone(db: Pool<Postgres>) -> anyhow::Result<()> {
+        use windmill_common::flow_status::BranchChosen;
+
+        initialize_tracing().await;
+        let server = ApiServer::start(db.clone()).await?;
+        let port = server.addr.port();
+
+        let flow_value: FlowValue = serde_json::from_value(json!({
+            "modules": [{
+                "id": "outer_branch",
+                "value": {
+                    "type": "branchone",
+                    "default": [],
+                    "branches": [{
+                        "expr": "true",
+                        "modules": [{
+                            "id": "inner_branch",
+                            "value": {
+                                "type": "branchone",
+                                "default": [],
+                                "branches": [{
+                                    "expr": "true",
+                                    "modules": [{
+                                        "id": "leaf",
+                                        "value": {
+                                            "type": "rawscript",
+                                            "language": "deno",
+                                            "input_transforms": {
+                                                "tag": { "type": "javascript", "expr": "flow_input.tag" }
+                                            },
+                                            "content": "export function main(tag: string) { return `leaf:${tag}` }"
+                                        }
+                                    }]
+                                }]
+                            }
+                        }]
+                    }]
+                }
+            }],
+            "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": { "tag": { "type": "string" } },
+                "order": ["tag"]
+            }
+        }))
+        .unwrap();
+
+        let test = || async {
+            let db = &db;
+            let first_run = RunJob::from(JobPayload::RawFlow {
+                value: flow_value.clone(),
+                path: None,
+                restarted_from: None,
+            })
+            .arg("tag", json!("first"))
+            .run_until_complete(db, false, port)
+            .await;
+            assert_eq!(first_run.json_result().unwrap(), json!("leaf:first"));
+
+            let outer_branch_child =
+                child_job_id_for_step(db, first_run.id, "outer_branch", None).await;
+            let inner_branch_child =
+                child_job_id_for_step(db, outer_branch_child, "inner_branch", None).await;
+
+            let restarted = RunJob::from(JobPayload::RawFlow {
+                value: flow_value.clone(),
+                path: None,
+                restarted_from: Some(RestartedFrom {
+                    flow_job_id: first_run.id,
+                    step_id: "outer_branch".into(),
+                    branch_or_iteration_n: None,
+                    flow_version: None,
+                    branch_chosen: Some(BranchChosen::Branch { branch: 0 }),
+                    nested: Some(Box::new(RestartedFrom {
+                        flow_job_id: outer_branch_child,
+                        step_id: "inner_branch".into(),
+                        branch_or_iteration_n: None,
+                        flow_version: None,
+                        branch_chosen: Some(BranchChosen::Branch { branch: 0 }),
+                        nested: Some(Box::new(RestartedFrom {
+                            flow_job_id: inner_branch_child,
+                            step_id: "leaf".into(),
+                            branch_or_iteration_n: None,
+                            flow_version: None,
+                            branch_chosen: None,
+                            nested: None,
+                        })),
+                    })),
+                }),
+            })
+            .arg("tag", json!("second"))
+            .run_until_complete(db, false, port)
+            .await;
+            assert_eq!(restarted.json_result().unwrap(), json!("leaf:second"));
+        };
+        test_for_versions(VERSION_FLAGS.iter().copied(), test).await;
+        Ok(())
+    }
+
+    /// Restart at a step inside a SUBFLOW (`Flow{path}`) called from a parent flow.
+    /// The parent invokes `f/system/hello_with_nodes_flow` (which has a top-level
+    /// ForLoop). We restart at the inner step `c` of iteration 1 of that loop,
+    /// from the parent's perspective. This exercises the cross-job-spawn chain
+    /// crossing a subflow boundary AND descending into a ForLoop inside the
+    /// subflow.
+    #[cfg(feature = "deno_core")]
+    #[sqlx::test(fixtures("base", "hello"))]
+    async fn test_nested_restart_inside_subflow(db: Pool<Postgres>) -> anyhow::Result<()> {
+        initialize_tracing().await;
+        let server = ApiServer::start(db.clone()).await?;
+        let port = server.addr.port();
+
+        let flow_value: FlowValue = serde_json::from_value(json!({
+            "modules": [{
+                "id": "h",
+                "value": {
+                    "path": "f/system/hello_with_nodes_flow",
+                    "type": "flow",
+                    "input_transforms": {}
+                }
+            }],
+            "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {},
+                "order": []
+            }
+        }))
+        .unwrap();
+
+        let test = || async {
+            let db = &db;
+            let first_run = RunJob::from(JobPayload::RawFlow {
+                value: flow_value.clone(),
+                path: None,
+                restarted_from: None,
+            })
+            .run_until_complete(db, false, port)
+            .await;
+            // The subflow returns the loop's results; the parent flow returns the
+            // subflow's result as its own output.
+            assert_eq!(
+                first_run.json_result().unwrap(),
+                json!([
+                    "Did you just say \"Hello foo!\"??!",
+                    "Did you just say \"Hello bar!\"??!",
+                    "Did you just say \"Hello baz!\"??!",
+                ])
+            );
+
+            let subflow_child = child_job_id_for_step(db, first_run.id, "h", None).await;
+            let original_subflow_iter0 =
+                child_job_id_for_step(db, subflow_child, "a", Some(0)).await;
+            let subflow_iter1_child = child_job_id_for_step(db, subflow_child, "a", Some(1)).await;
+            // Capture the leaf "c" inside iter 0 of the original subflow, which is
+            // a step we explicitly do NOT restart at — its UUID must survive into
+            // the restarted run unchanged, despite crossing two parent layers
+            // (parent's `h` → subflow's `a` → iter 0 → `c`).
+            let original_subflow_iter0_c =
+                nested_child_job_id(db, subflow_child, &[("a", Some(0)), ("c", None)]).await;
+
+            let restarted = RunJob::from(JobPayload::RawFlow {
+                value: flow_value.clone(),
+                path: None,
+                restarted_from: Some(RestartedFrom {
+                    flow_job_id: first_run.id,
+                    step_id: "h".into(),
+                    branch_or_iteration_n: None,
+                    flow_version: None,
+                    branch_chosen: None,
+                    nested: Some(Box::new(RestartedFrom {
+                        flow_job_id: subflow_child,
+                        step_id: "a".into(),
+                        branch_or_iteration_n: Some(1),
+                        flow_version: None,
+                        branch_chosen: None,
+                        nested: Some(Box::new(RestartedFrom {
+                            flow_job_id: subflow_iter1_child,
+                            step_id: "c".into(),
+                            branch_or_iteration_n: None,
+                            flow_version: None,
+                            branch_chosen: None,
+                            nested: None,
+                        })),
+                    })),
+                }),
+            })
+            .run_until_complete(db, false, port)
+            .await;
+            // Same input → same output, produced via the cross-job restart chain.
+            assert_eq!(
+                restarted.json_result().unwrap(),
+                json!([
+                    "Did you just say \"Hello foo!\"??!",
+                    "Did you just say \"Hello bar!\"??!",
+                    "Did you just say \"Hello baz!\"??!",
+                ])
+            );
+            // Identity proof across the subflow boundary:
+            //   * the parent's `h` child UUID is fresh (subflow re-spawned as a
+            //     RestartedFlow) — we don't compare it directly, but inside it…
+            //   * iter 0 of the subflow's `a` loop reuses the original UUID
+            //   * iter 1 is a fresh UUID
+            //   * the inner step `c` inside the preserved iter 0 also reuses its
+            //     original UUID (preservation propagates two layers deep)
+            let new_subflow_child = child_job_id_for_step(db, restarted.id, "h", None).await;
+            let new_subflow_iter0 =
+                child_job_id_for_step(db, new_subflow_child, "a", Some(0)).await;
+            let new_subflow_iter1 =
+                child_job_id_for_step(db, new_subflow_child, "a", Some(1)).await;
+            let new_subflow_iter0_c =
+                nested_child_job_id(db, new_subflow_child, &[("a", Some(0)), ("c", None)]).await;
+            assert_eq!(
+                new_subflow_iter0, original_subflow_iter0,
+                "subflow iter 0 should reuse original child"
+            );
+            assert_ne!(
+                new_subflow_iter1, subflow_iter1_child,
+                "subflow iter 1 should be a fresh child"
+            );
+            assert_eq!(
+                new_subflow_iter0_c, original_subflow_iter0_c,
+                "step `c` inside preserved iter 0 should reuse its original UUID"
+            );
+        };
         test_for_versions(VERSION_FLAGS.iter().copied(), test).await;
         Ok(())
     }

--- a/backend/tests/job_payload.rs
+++ b/backend/tests/job_payload.rs
@@ -49,7 +49,8 @@ mod job_payload {
                 concurrency_settings:
                     windmill_common::runnable_settings::ConcurrencySettings::default().into(),
                 debouncing_settings:
-                    windmill_common::runnable_settings::DebouncingSettings::default(), labels: None,
+                    windmill_common::runnable_settings::DebouncingSettings::default(),
+                labels: None,
                 cache_ttl: None,
                 cache_ignore_s3_path: None,
                 dedicated_worker: None,
@@ -89,7 +90,8 @@ mod job_payload {
                 concurrency_settings:
                     windmill_common::runnable_settings::ConcurrencySettings::default(),
                 debouncing_settings:
-                    windmill_common::runnable_settings::DebouncingSettings::default(), labels: None,
+                    windmill_common::runnable_settings::DebouncingSettings::default(),
+                labels: None,
             })
             .run_until_complete_with(db, false, port, |id| async move {
                 let job = sqlx::query!("SELECT preprocessed FROM v2_job WHERE id = $1", id)
@@ -276,19 +278,25 @@ mod job_payload {
 
     #[sqlx::test(fixtures("base", "hello"))]
     async fn test_dependencies_payload_min_1_427(db: Pool<Postgres>) -> anyhow::Result<()> {
-        MIN_VERSION.store(std::sync::Arc::new(MIN_VERSION_IS_AT_LEAST_1_427.version().clone()));
+        MIN_VERSION.store(std::sync::Arc::new(
+            MIN_VERSION_IS_AT_LEAST_1_427.version().clone(),
+        ));
         test_dependencies_payload(db).await?;
         Ok(())
     }
     #[sqlx::test(fixtures("base", "hello"))]
     async fn test_dependencies_payload_min_1_432(db: Pool<Postgres>) -> anyhow::Result<()> {
-        MIN_VERSION.store(std::sync::Arc::new(MIN_VERSION_IS_AT_LEAST_1_432.version().clone()));
+        MIN_VERSION.store(std::sync::Arc::new(
+            MIN_VERSION_IS_AT_LEAST_1_432.version().clone(),
+        ));
         test_dependencies_payload(db).await?;
         Ok(())
     }
     #[sqlx::test(fixtures("base", "hello"))]
     async fn test_dependencies_payload_min_1_440(db: Pool<Postgres>) -> anyhow::Result<()> {
-        MIN_VERSION.store(std::sync::Arc::new(MIN_VERSION_IS_AT_LEAST_1_440.version().clone()));
+        MIN_VERSION.store(std::sync::Arc::new(
+            MIN_VERSION_IS_AT_LEAST_1_440.version().clone(),
+        ));
         test_dependencies_payload(db).await?;
         Ok(())
     }
@@ -424,7 +432,8 @@ mod job_payload {
                 path: "f/system/hello_with_nodes_flow".to_string(),
                 dedicated_worker: None,
                 apply_preprocessor: false,
-                version: 1443253234253454, labels: None,
+                version: 1443253234253454,
+                labels: None,
             })
             .run_until_complete(&db, false, port)
             .await
@@ -473,7 +482,8 @@ mod job_payload {
                 path: "f/system/hello_with_preprocessor".to_string(),
                 dedicated_worker: None,
                 apply_preprocessor: true,
-                version: 1443253234253456, labels: None,
+                version: 1443253234253456,
+                labels: None,
             })
             .run_until_complete_with(db, false, port, |id| async move {
                 let job = sqlx::query!("SELECT preprocessed FROM v2_job WHERE id = $1", id)
@@ -543,7 +553,8 @@ mod job_payload {
                 path: "f/system/hello_with_nodes_flow".to_string(),
                 dedicated_worker: None,
                 apply_preprocessor: true,
-                version: 1443253234253454, labels: None,
+                version: 1443253234253454,
+                labels: None,
             })
             .run_until_complete(&db, false, port)
             .await
@@ -554,6 +565,8 @@ mod job_payload {
                 step_id: "a".into(),
                 branch_or_iteration_n: None,
                 flow_version: None,
+                branch_chosen: None,
+                nested: None,
             })
             .arg("iter", json!({ "value": "tests", "index": 0 }))
             .run_until_complete(&db, false, port)
@@ -727,6 +740,7 @@ mod job_payload {
                 step_id: "a".into(),
                 branch_or_iteration_n: None,
                 flow_version: None,
+                ..Default::default()
             }),
             json!("foo"),
             json!([
@@ -742,6 +756,7 @@ mod job_payload {
                 step_id: "b".into(),
                 branch_or_iteration_n: None,
                 flow_version: None,
+                ..Default::default()
             }),
             json!("bar"),
             json!([
@@ -757,6 +772,7 @@ mod job_payload {
                 step_id: "c".into(),
                 branch_or_iteration_n: Some(1),
                 flow_version: None,
+                ..Default::default()
             }),
             json!("yolo"),
             json!([
@@ -766,6 +782,230 @@ mod job_payload {
             ]),
         )
         .await;
+        Ok(())
+    }
+
+    /// Walk a completed flow's `flow_status` to find the child job UUID for a given
+    /// container step at the given iteration. Used by nested-restart tests to
+    /// reconstruct the `nested` chain that the API would resolve normally.
+    async fn child_job_id_for_step(
+        db: &Pool<Postgres>,
+        flow_job_id: uuid::Uuid,
+        step_id: &str,
+        iter: Option<usize>,
+    ) -> uuid::Uuid {
+        let row = sqlx::query!(
+            "SELECT flow_status FROM v2_job_completed WHERE id = $1",
+            flow_job_id,
+        )
+        .fetch_one(db)
+        .await
+        .unwrap();
+        let raw = row.flow_status.expect("flow_status missing");
+        let status: windmill_common::flow_status::FlowStatus =
+            serde_json::from_value(raw).expect("parse flow_status");
+        let module = status
+            .modules
+            .iter()
+            .find(|m| m.id() == step_id)
+            .expect("step not found in completed flow_status");
+        match iter {
+            Some(i) => module
+                .flow_jobs()
+                .expect("expected flow_jobs on container module")
+                .get(i)
+                .copied()
+                .expect("iteration not found in flow_jobs"),
+            None => module.job().expect("expected single child job on module"),
+        }
+    }
+
+    #[cfg(feature = "deno_core")]
+    #[sqlx::test(fixtures("base", "hello"))]
+    async fn test_nested_restart_inside_branchone(db: Pool<Postgres>) -> anyhow::Result<()> {
+        use windmill_common::flow_status::BranchChosen;
+
+        initialize_tracing().await;
+        let server = ApiServer::start(db.clone()).await?;
+        let port = server.addr.port();
+
+        let flow_value: FlowValue = serde_json::from_value(json!({
+            "modules": [{
+                "id": "a",
+                "value": {
+                    "type": "rawscript",
+                    "language": "deno",
+                    "input_transforms": {
+                        "world": { "type": "javascript", "expr": "flow_input.world" }
+                    },
+                    "content": "export function main(world: string) { return `pre-${world}` }"
+                }
+            }, {
+                "id": "branch",
+                "value": {
+                    "type": "branchone",
+                    "default": [],
+                    "branches": [{
+                        "expr": "true",
+                        "modules": [{
+                            "id": "inner",
+                            "value": {
+                                "type": "rawscript",
+                                "language": "deno",
+                                "input_transforms": {
+                                    "world": { "type": "javascript", "expr": "flow_input.world" }
+                                },
+                                "content": "export function main(world: string) { return `inner-${world}` }"
+                            }
+                        }]
+                    }]
+                }
+            }],
+            "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": { "world": { "type": "string" } },
+                "order": ["world"]
+            }
+        }))
+        .unwrap();
+
+        let test = || async {
+            let db = &db;
+            let first_run = RunJob::from(JobPayload::RawFlow {
+                value: flow_value.clone(),
+                path: None,
+                restarted_from: None,
+            })
+            .arg("world", json!("foo"))
+            .run_until_complete(db, false, port)
+            .await;
+            assert_eq!(first_run.json_result().unwrap(), json!("inner-foo"));
+
+            let original_branch_child =
+                child_job_id_for_step(db, first_run.id, "branch", None).await;
+
+            // Restart at the nested `inner` step inside `branch`. The new run should
+            // re-execute step `a` (since it's before the BranchOne) AND `inner`
+            // (the restart point). The chosen branch is locked to branch 0.
+            let restarted = RunJob::from(JobPayload::RawFlow {
+                value: flow_value.clone(),
+                path: None,
+                restarted_from: Some(RestartedFrom {
+                    flow_job_id: first_run.id,
+                    step_id: "branch".into(),
+                    branch_or_iteration_n: None,
+                    flow_version: None,
+                    branch_chosen: Some(BranchChosen::Branch { branch: 0 }),
+                    nested: Some(Box::new(RestartedFrom {
+                        flow_job_id: original_branch_child,
+                        step_id: "inner".into(),
+                        branch_or_iteration_n: None,
+                        flow_version: None,
+                        branch_chosen: None,
+                        nested: None,
+                    })),
+                }),
+            })
+            .arg("world", json!("bar"))
+            .run_until_complete(db, false, port)
+            .await;
+            assert_eq!(restarted.json_result().unwrap(), json!("inner-bar"));
+        };
+        test_for_versions(VERSION_FLAGS.iter().copied(), test).await;
+        Ok(())
+    }
+
+    #[cfg(feature = "deno_core")]
+    #[sqlx::test(fixtures("base", "hello"))]
+    async fn test_nested_restart_inside_forloop_iteration(
+        db: Pool<Postgres>,
+    ) -> anyhow::Result<()> {
+        initialize_tracing().await;
+        let server = ApiServer::start(db.clone()).await?;
+        let port = server.addr.port();
+
+        // Sequential ForLoop with an inner step. We restart at the inner step inside
+        // iteration 1, expecting iteration 0 to remain unchanged and only iteration
+        // 1 to re-run with new input.
+        let flow_value: FlowValue = serde_json::from_value(json!({
+            "modules": [{
+                "id": "loop",
+                "value": {
+                    "type": "forloopflow",
+                    "iterator": { "type": "javascript", "expr": "['x', 'y']" },
+                    "skip_failures": false,
+                    "modules": [{
+                        "id": "inner",
+                        "value": {
+                            "type": "rawscript",
+                            "language": "deno",
+                            "input_transforms": {
+                                "iter_val": { "type": "javascript", "expr": "flow_input.iter.value" },
+                                "tag": { "type": "javascript", "expr": "flow_input.tag" }
+                            },
+                            "content": "export function main(iter_val: string, tag: string) { return `${tag}:${iter_val}` }"
+                        }
+                    }]
+                }
+            }],
+            "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": { "tag": { "type": "string" } },
+                "order": ["tag"]
+            }
+        }))
+        .unwrap();
+
+        let test = || async {
+            let db = &db;
+            let first_run = RunJob::from(JobPayload::RawFlow {
+                value: flow_value.clone(),
+                path: None,
+                restarted_from: None,
+            })
+            .arg("tag", json!("first"))
+            .run_until_complete(db, false, port)
+            .await;
+            assert_eq!(
+                first_run.json_result().unwrap(),
+                json!(["first:x", "first:y"])
+            );
+
+            // Original child job for iteration 1 of `loop`.
+            let original_iter1_child =
+                child_job_id_for_step(db, first_run.id, "loop", Some(1)).await;
+
+            let restarted = RunJob::from(JobPayload::RawFlow {
+                value: flow_value.clone(),
+                path: None,
+                restarted_from: Some(RestartedFrom {
+                    flow_job_id: first_run.id,
+                    step_id: "loop".into(),
+                    branch_or_iteration_n: Some(1),
+                    flow_version: None,
+                    branch_chosen: None,
+                    nested: Some(Box::new(RestartedFrom {
+                        flow_job_id: original_iter1_child,
+                        step_id: "inner".into(),
+                        branch_or_iteration_n: None,
+                        flow_version: None,
+                        branch_chosen: None,
+                        nested: None,
+                    })),
+                }),
+            })
+            .arg("tag", json!("second"))
+            .run_until_complete(db, false, port)
+            .await;
+            // Iteration 0 keeps the original "first:x"; iteration 1 re-ran with "second"
+            assert_eq!(
+                restarted.json_result().unwrap(),
+                json!(["first:x", "second:y"])
+            );
+        };
+        test_for_versions(VERSION_FLAGS.iter().copied(), test).await;
         Ok(())
     }
 
@@ -789,7 +1029,8 @@ mod job_payload {
                 concurrency_settings:
                     windmill_common::runnable_settings::ConcurrencySettings::default(),
                 debouncing_settings:
-                    windmill_common::runnable_settings::DebouncingSettings::default(), labels: None,
+                    windmill_common::runnable_settings::DebouncingSettings::default(),
+                labels: None,
             })
             .arg("foo", json!("hello"))
             .arg("bar", json!("world"))
@@ -839,7 +1080,8 @@ mod job_payload {
                 concurrency_settings:
                     windmill_common::runnable_settings::ConcurrencySettings::default(),
                 debouncing_settings:
-                    windmill_common::runnable_settings::DebouncingSettings::default(), labels: None,
+                    windmill_common::runnable_settings::DebouncingSettings::default(),
+                labels: None,
             })
             .arg("foo", json!("hello"))
             .arg("bar", json!("world"))
@@ -889,7 +1131,8 @@ mod job_payload {
                 concurrency_settings:
                     windmill_common::runnable_settings::ConcurrencySettings::default(),
                 debouncing_settings:
-                    windmill_common::runnable_settings::DebouncingSettings::default(), labels: None,
+                    windmill_common::runnable_settings::DebouncingSettings::default(),
+                labels: None,
             })
             .arg("foo", json!("hello"))
             .arg("bar", json!("world"))
@@ -939,7 +1182,8 @@ mod job_payload {
                 concurrency_settings:
                     windmill_common::runnable_settings::ConcurrencySettings::default(),
                 debouncing_settings:
-                    windmill_common::runnable_settings::DebouncingSettings::default(), labels: None,
+                    windmill_common::runnable_settings::DebouncingSettings::default(),
+                labels: None,
             })
             .arg("foo", json!("hello"))
             .arg("bar", json!("world"))
@@ -991,7 +1235,8 @@ mod job_payload {
                 concurrency_settings:
                     windmill_common::runnable_settings::ConcurrencySettings::default(),
                 debouncing_settings:
-                    windmill_common::runnable_settings::DebouncingSettings::default(), labels: None,
+                    windmill_common::runnable_settings::DebouncingSettings::default(),
+                labels: None,
             })
             .arg("foo", json!("hello"))
             .arg("bar", json!("world"))

--- a/backend/tests/restart_at_step_api.rs
+++ b/backend/tests/restart_at_step_api.rs
@@ -1,0 +1,255 @@
+//! HTTP-level integration tests for the `restart_flow_at_step` API endpoint.
+//!
+//! The other restart tests in `job_payload.rs` exercise the worker by hand-
+//! constructing `RestartedFrom` chains and calling `push()` directly. These
+//! tests instead drive the actual HTTP endpoint to lock in the API contract,
+//! including the validation branches in `resolve_nested_restart` (step lookup,
+//! parallel rejection, etc.).
+
+#![cfg(feature = "deno_core")]
+#![cfg(feature = "enterprise")]
+
+use serde_json::json;
+use sqlx::{Pool, Postgres};
+use windmill_common::flows::FlowValue;
+use windmill_common::jobs::JobPayload;
+use windmill_test_utils::*;
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+fn authed(builder: reqwest::RequestBuilder, token: &str) -> reqwest::RequestBuilder {
+    builder.header("Authorization", format!("Bearer {}", token))
+}
+
+const SUPER_TOKEN: &str = "SECRET_TOKEN";
+
+/// Happy path: HTTP nested restart targeting a step inside iteration 1 of a
+/// top-level sequential ForLoop. Verifies the API endpoint accepts a
+/// `nested_path`, walks the original execution to resolve UUIDs, and the
+/// resulting job runs successfully.
+#[sqlx::test(fixtures("base", "hello"))]
+async fn test_api_restart_at_step_nested_happy(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    let first_run = RunJob::from(JobPayload::Flow {
+        path: "f/system/hello_with_nodes_flow".to_string(),
+        dedicated_worker: None,
+        apply_preprocessor: true,
+        version: 1443253234253454,
+        labels: None,
+    })
+    .run_until_complete(&db, false, port)
+    .await;
+
+    let resp = authed(
+        client().post(format!(
+            "http://localhost:{port}/api/w/test-workspace/jobs/restart/f/{}",
+            first_run.id
+        )),
+        SUPER_TOKEN,
+    )
+    .json(&json!({
+        "step_id": "a",
+        "branch_or_iteration_n": 1,
+        "nested_path": [{ "step_id": "c" }],
+    }))
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        201,
+        "expected 201, got {}: {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+    let new_job_id = resp.text().await?;
+    assert!(!new_job_id.is_empty(), "expected job UUID in response body");
+    Ok(())
+}
+
+/// Happy path: top-level (non-nested) restart via HTTP. Same surface as
+/// `test_restarted_flow_payload` but driven through the actual REST endpoint.
+#[sqlx::test(fixtures("base", "hello"))]
+async fn test_api_restart_at_step_top_level_happy(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    let first_run = RunJob::from(JobPayload::Flow {
+        path: "f/system/hello_with_nodes_flow".to_string(),
+        dedicated_worker: None,
+        apply_preprocessor: true,
+        version: 1443253234253454,
+        labels: None,
+    })
+    .run_until_complete(&db, false, port)
+    .await;
+
+    let resp = authed(
+        client().post(format!(
+            "http://localhost:{port}/api/w/test-workspace/jobs/restart/f/{}",
+            first_run.id
+        )),
+        SUPER_TOKEN,
+    )
+    .json(&json!({ "step_id": "a", "branch_or_iteration_n": 0 }))
+    .send()
+    .await?;
+    assert_eq!(resp.status(), 201);
+    Ok(())
+}
+
+/// Rejection: nested step doesn't exist in the original run. The API should
+/// reject with a 4xx (or surface a clear backend error) rather than silently
+/// queue an unrunnable job.
+#[sqlx::test(fixtures("base", "hello"))]
+async fn test_api_restart_at_step_rejects_unknown_step(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    let first_run = RunJob::from(JobPayload::Flow {
+        path: "f/system/hello_with_nodes_flow".to_string(),
+        dedicated_worker: None,
+        apply_preprocessor: true,
+        version: 1443253234253454,
+        labels: None,
+    })
+    .run_until_complete(&db, false, port)
+    .await;
+
+    let resp = authed(
+        client().post(format!(
+            "http://localhost:{port}/api/w/test-workspace/jobs/restart/f/{}",
+            first_run.id
+        )),
+        SUPER_TOKEN,
+    )
+    .json(&json!({
+        "step_id": "a",
+        "branch_or_iteration_n": 1,
+        "nested_path": [{ "step_id": "does_not_exist" }],
+    }))
+    .send()
+    .await?;
+    assert!(
+        !resp.status().is_success(),
+        "expected error, got {}",
+        resp.status()
+    );
+    Ok(())
+}
+
+/// Rejection: nested restart targets an iteration past the actual count.
+/// Original ran 3 iterations (index 0..2); requesting `branch_or_iteration_n=5`
+/// must error.
+#[sqlx::test(fixtures("base", "hello"))]
+async fn test_api_restart_at_step_rejects_out_of_range_iteration(
+    db: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    let first_run = RunJob::from(JobPayload::Flow {
+        path: "f/system/hello_with_nodes_flow".to_string(),
+        dedicated_worker: None,
+        apply_preprocessor: true,
+        version: 1443253234253454,
+        labels: None,
+    })
+    .run_until_complete(&db, false, port)
+    .await;
+
+    let resp = authed(
+        client().post(format!(
+            "http://localhost:{port}/api/w/test-workspace/jobs/restart/f/{}",
+            first_run.id
+        )),
+        SUPER_TOKEN,
+    )
+    .json(&json!({
+        "step_id": "a",
+        "branch_or_iteration_n": 5,
+        "nested_path": [{ "step_id": "c" }],
+    }))
+    .send()
+    .await?;
+    assert!(
+        !resp.status().is_success(),
+        "expected error for out-of-range iteration, got {}: {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+    Ok(())
+}
+
+/// Rejection: parallel ForLoop ancestor on the nested path. The resolver
+/// rejects this category outright — `branch_or_iteration_n` only makes sense
+/// for sequential containers because each iteration runs as a separate
+/// numbered child.
+#[sqlx::test(fixtures("base", "hello"))]
+async fn test_api_restart_at_step_rejects_parallel_loop(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    // Run a parallel ForLoop with an inner script. We use a `RawFlow` with an
+    // explicit `path` so the API endpoint accepts it as a valid completed job
+    // (the handler requires `runnable_path`).
+    let parallel_flow: FlowValue = serde_json::from_value(json!({
+        "modules": [{
+            "id": "loop",
+            "value": {
+                "type": "forloopflow",
+                "iterator": { "type": "javascript", "expr": "[1, 2]" },
+                "skip_failures": false,
+                "parallel": true,
+                "modules": [{
+                    "id": "inner",
+                    "value": {
+                        "type": "rawscript",
+                        "language": "deno",
+                        "input_transforms": {},
+                        "content": "export function main() { return 'ok' }"
+                    }
+                }]
+            }
+        }],
+    }))
+    .unwrap();
+
+    let first_run = RunJob::from(JobPayload::RawFlow {
+        value: parallel_flow,
+        path: Some("u/admin/parallel_test".to_string()),
+        restarted_from: None,
+    })
+    .run_until_complete(&db, false, port)
+    .await;
+
+    let resp = authed(
+        client().post(format!(
+            "http://localhost:{port}/api/w/test-workspace/jobs/restart/f/{}",
+            first_run.id
+        )),
+        SUPER_TOKEN,
+    )
+    .json(&json!({
+        "step_id": "loop",
+        "branch_or_iteration_n": 0,
+        "nested_path": [{ "step_id": "inner" }],
+    }))
+    .send()
+    .await?;
+    assert!(
+        !resp.status().is_success(),
+        "expected rejection of parallel-loop nested restart, got {}: {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+    Ok(())
+}

--- a/backend/tests/worker.rs
+++ b/backend/tests/worker.rs
@@ -3344,6 +3344,7 @@ async fn test_complex_flow_restart(db: Pool<Postgres>) -> anyhow::Result<()> {
             step_id: "h".to_owned(),
             branch_or_iteration_n: None,
             flow_version: None,
+            ..Default::default()
         }),
     })
     .run_until_complete(&db, false, port)

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -26046,8 +26046,21 @@ components:
           type: string
         branch_or_iteration_n:
           type: integer
+          description: 0-based iteration index for ForLoop / branch index for BranchAll. Iterations 0..n-1 are preserved; iteration n is restarted.
         flow_version:
           type: integer
+        branch_chosen:
+          description: For BranchOne nested restart — the branch that was originally chosen, used to lock branch evaluation.
+          type: object
+          properties:
+            type:
+              type: string
+              enum: [default, branch]
+            branch:
+              type: integer
+        nested:
+          $ref: "#/components/schemas/RestartedFrom"
+          description: When set, the worker spawns the child for `step_id` as a `RestartedFlow` against `nested.flow_job_id` instead of fresh-launching it.
 
     Policy:
       type: object

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10598,13 +10598,27 @@ paths:
               properties:
                 step_id:
                   type: string
-                  description: step id to restart the flow from
+                  description: top-level step id to restart the flow from (or the outermost container when restarting at a nested step)
                 branch_or_iteration_n:
                   type: integer
-                  description: for branchall or loop, the iteration at which the flow should restart (optional)
+                  description: for branchall or loop at the top level, the iteration at which the flow should restart (optional)
                 flow_version:
                   type: integer
                   description: specific flow version to use for restart (optional, uses current version if not specified)
+                nested_path:
+                  type: array
+                  description: path of additional steps to descend into AFTER `step_id`. Each entry represents one level of nesting inside the spawned child of the previous level's container (BranchOne / sequential ForLoop iteration / Subflow). When non-empty, the actual restart point is the LAST entry's step_id.
+                  items:
+                    type: object
+                    required:
+                      - step_id
+                    properties:
+                      step_id:
+                        type: string
+                        description: step id at this nesting level
+                      branch_or_iteration_n:
+                        type: integer
+                        description: for ForLoop containers, the iteration to restart at (0-based; iterations 0..n-1 are preserved)
 
       responses:
         "201":

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -4135,8 +4135,10 @@ pub struct RestartFlowRequestBody {
 #[derive(Deserialize)]
 pub struct NestedRestartStep {
     step_id: String,
-    /// For ForLoop containers: the iteration to restart at (1-based; iterations
-    /// 0..N-1 are preserved). Unused for BranchOne / Subflow containers.
+    /// For ForLoop / sequential BranchAll containers: the 0-based iteration
+    /// (or branch) index to restart at. Iterations `0..n-1` are preserved,
+    /// iteration `n` is the restart target. Defaults to `0` when omitted.
+    /// Unused for BranchOne / Subflow containers.
     branch_or_iteration_n: Option<usize>,
 }
 
@@ -4166,10 +4168,6 @@ async fn resolve_nested_restart(
 )> {
     use windmill_common::flow_status::BranchChosen;
     use windmill_common::flows::FlowModuleValue;
-
-    if nested_path.is_empty() {
-        return Ok((None, None));
-    }
 
     let row = sqlx::query!(
         "SELECT
@@ -4230,6 +4228,13 @@ async fn resolve_nested_restart(
                 parent_step_id, parent_job_id
             ))
         })?;
+
+    // Leaf level: validation is done (`parent_step_id` exists), no chain to
+    // build below. Return early so the caller's `nested_path.last()` step is
+    // confirmed to actually exist before we queue the restart job.
+    if nested_path.is_empty() {
+        return Ok((None, None));
+    }
 
     let parent_module_value = parent_module_def.get_value()?;
     let (child_job_id, parent_branch_chosen): (Uuid, Option<BranchChosen>) =

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -4122,6 +4122,209 @@ pub struct RestartFlowRequestBody {
     step_id: String,
     branch_or_iteration_n: Option<usize>,
     flow_version: Option<i64>,
+    /// Optional path of additional steps to descend into AFTER `step_id`. Each entry
+    /// represents one level of nesting inside the spawned child of the previous level's
+    /// container (BranchOne / ForLoop iteration / Subflow). When non-empty, the actual
+    /// restart point is the LAST entry's `step_id`; intermediate entries identify the
+    /// containers along the way.
+    #[serde(default)]
+    nested_path: Vec<NestedRestartStep>,
+}
+
+#[cfg(feature = "enterprise")]
+#[derive(Deserialize)]
+pub struct NestedRestartStep {
+    step_id: String,
+    /// For ForLoop containers: the iteration to restart at (1-based; iterations
+    /// 0..N-1 are preserved). Unused for BranchOne / Subflow containers.
+    branch_or_iteration_n: Option<usize>,
+}
+
+/// Walks the `nested_path` against the original execution to:
+/// - validate each step exists and was executed
+/// - resolve the child job UUID at each level
+/// - capture `branch_chosen` for BranchOne containers (so the worker can lock branch
+///   evaluation and reuse the originally-taken path)
+///
+/// Returns `(top_branch_chosen, nested_chain)`:
+/// - `top_branch_chosen`: locked branch for the TOP-level container if it is a
+///   BranchOne, else None
+/// - `nested_chain`: the `RestartedFrom` to embed under the top-level run's
+///   `restarted_from.nested` (None when `nested_path` is empty)
+#[cfg(feature = "enterprise")]
+async fn resolve_nested_restart(
+    db: &DB,
+    workspace_id: &str,
+    parent_job_id: Uuid,
+    parent_step_id: &str,
+    parent_branch_or_iteration_n: Option<usize>,
+    nested_path: Vec<NestedRestartStep>,
+    parent_flow_version: Option<i64>,
+) -> error::Result<(
+    Option<windmill_common::flow_status::BranchChosen>,
+    Option<Box<RestartedFrom>>,
+)> {
+    use windmill_common::flow_status::BranchChosen;
+    use windmill_common::flows::FlowModuleValue;
+
+    if nested_path.is_empty() {
+        return Ok((None, None));
+    }
+
+    let row = sqlx::query!(
+        "SELECT
+            j.runnable_id AS \"runnable_id: ScriptHash\",
+            j.kind AS \"job_kind!: JobKind\",
+            COALESCE(c.flow_status, c.workflow_as_code_status) AS \"flow_status: sqlx::types::Json<Box<RawValue>>\",
+            j.raw_flow AS \"raw_flow: sqlx::types::Json<Box<RawValue>>\"
+        FROM v2_job_completed c JOIN v2_job j USING (id)
+        WHERE j.id = $1 AND j.workspace_id = $2",
+        parent_job_id,
+        workspace_id,
+    )
+    .fetch_optional(db)
+    .await?
+    .with_context(|| {
+        format!(
+            "completed job {} not found while resolving nested restart path",
+            parent_job_id
+        )
+    })?;
+
+    let flow_data = if let Some(version) = parent_flow_version {
+        cache::flow::fetch_version(db, version).await?
+    } else {
+        cache::job::fetch_flow(db, &row.job_kind, row.runnable_id)
+            .or_else(|_| cache::job::fetch_preview_flow(db, &parent_job_id, row.raw_flow))
+            .await?
+    };
+    let flow_value = flow_data.value();
+    let flow_status: FlowStatus = row
+        .flow_status
+        .as_ref()
+        .and_then(|v| serde_json::from_str::<FlowStatus>(v.get()).ok())
+        .ok_or_else(|| {
+            Error::internal_err(format!(
+                "Unable to parse flow status for job {}",
+                parent_job_id
+            ))
+        })?;
+
+    let parent_status_module = flow_status
+        .modules
+        .iter()
+        .find(|m| m.id() == parent_step_id)
+        .ok_or_else(|| {
+            Error::BadRequest(format!(
+                "step '{}' not found in original run for job {}",
+                parent_step_id, parent_job_id
+            ))
+        })?;
+    let parent_module_def = flow_value
+        .modules
+        .iter()
+        .find(|m| m.id == parent_step_id)
+        .ok_or_else(|| {
+            Error::BadRequest(format!(
+                "step '{}' not found in flow definition for job {}",
+                parent_step_id, parent_job_id
+            ))
+        })?;
+
+    let parent_module_value = parent_module_def.get_value()?;
+    let (child_job_id, parent_branch_chosen): (Uuid, Option<BranchChosen>) =
+        match parent_module_value {
+            FlowModuleValue::BranchOne { .. } => {
+                let job = parent_status_module.job().ok_or_else(|| {
+                    Error::BadRequest(format!(
+                        "BranchOne step '{}' has no child job in original run",
+                        parent_step_id
+                    ))
+                })?;
+                (job, parent_status_module.branch_chosen())
+            }
+            FlowModuleValue::Flow { .. } => {
+                let job = parent_status_module.job().ok_or_else(|| {
+                    Error::BadRequest(format!(
+                        "Subflow step '{}' has no child job in original run",
+                        parent_step_id
+                    ))
+                })?;
+                (job, None)
+            }
+            FlowModuleValue::ForloopFlow { parallel, .. } => {
+                if parallel {
+                    return Err(Error::BadRequest(format!(
+                        "Restart inside a parallel ForLoop is not supported (step '{}')",
+                        parent_step_id
+                    )));
+                }
+                // 0-based iteration to restart at; absent ⟹ iteration 0.
+                // Iterations 0..n-1 are preserved (matching existing top-level semantics).
+                let n = parent_branch_or_iteration_n.unwrap_or(0);
+                let flow_jobs = parent_status_module.flow_jobs().ok_or_else(|| {
+                    Error::BadRequest(format!(
+                        "ForLoop step '{}' has no recorded iterations in original run",
+                        parent_step_id
+                    ))
+                })?;
+                let job = flow_jobs.get(n).copied().ok_or_else(|| {
+                    Error::BadRequest(format!(
+                        "ForLoop step '{}' has only {} iterations; cannot restart at iteration {}",
+                        parent_step_id,
+                        flow_jobs.len(),
+                        n
+                    ))
+                })?;
+                (job, None)
+            }
+            FlowModuleValue::BranchAll { .. } => {
+                return Err(Error::BadRequest(format!(
+                    "Restart inside a BranchAll step ('{}') is not supported",
+                    parent_step_id
+                )));
+            }
+            FlowModuleValue::WhileloopFlow { .. } => {
+                return Err(Error::BadRequest(format!(
+                    "Restart inside a WhileLoop step ('{}') is not supported",
+                    parent_step_id
+                )));
+            }
+            _ => {
+                return Err(Error::BadRequest(format!(
+                    "step '{}' is not a container (BranchOne / sequential ForLoop / Subflow); cannot have a nested restart",
+                    parent_step_id
+                )));
+            }
+        };
+
+    let mut iter = nested_path.into_iter();
+    let head = iter.next().unwrap();
+    let rest: Vec<NestedRestartStep> = iter.collect();
+    let head_step_id = head.step_id;
+    let head_branch_or_iteration_n = head.branch_or_iteration_n;
+
+    let (child_branch_chosen, deeper_nested) = Box::pin(resolve_nested_restart(
+        db,
+        workspace_id,
+        child_job_id,
+        &head_step_id,
+        head_branch_or_iteration_n,
+        rest,
+        None,
+    ))
+    .await?;
+
+    let nested_chain = RestartedFrom {
+        flow_job_id: child_job_id,
+        step_id: head_step_id,
+        branch_or_iteration_n: head_branch_or_iteration_n,
+        flow_version: None,
+        branch_chosen: child_branch_chosen,
+        nested: deeper_nested,
+    };
+
+    Ok((parent_branch_chosen, Some(Box::new(nested_chain))))
 }
 
 #[cfg(feature = "enterprise")]
@@ -4131,9 +4334,12 @@ pub async fn restart_flow(
     Extension(user_db): Extension<UserDB>,
     Path((w_id, job_id)): Path<(String, Uuid)>,
     Query(run_query): Query<RunJobQuery>,
-    Json(RestartFlowRequestBody { step_id, branch_or_iteration_n, flow_version }): Json<
-        RestartFlowRequestBody,
-    >,
+    Json(RestartFlowRequestBody {
+        step_id,
+        branch_or_iteration_n,
+        flow_version,
+        nested_path,
+    }): Json<RestartFlowRequestBody>,
 ) -> error::Result<(StatusCode, String)> {
     check_license_key_valid().await?;
 
@@ -4166,6 +4372,17 @@ pub async fn restart_flow(
 
     let scheduled_for = run_query.get_scheduled_for(&db).await?;
 
+    let (top_branch_chosen, nested_chain) = resolve_nested_restart(
+        &db,
+        &w_id,
+        job_id,
+        &step_id,
+        branch_or_iteration_n,
+        nested_path,
+        flow_version,
+    )
+    .await?;
+
     let tx = PushIsolationLevel::Isolated(user_db, authed.clone().into());
 
     let (uuid, tx) = push(
@@ -4177,6 +4394,8 @@ pub async fn restart_flow(
             step_id,
             branch_or_iteration_n,
             flow_version,
+            branch_chosen: top_branch_chosen,
+            nested: nested_chain,
         },
         push_args,
         &authed.username,

--- a/backend/windmill-queue/src/jobs.rs
+++ b/backend/windmill-queue/src/jobs.rs
@@ -5030,6 +5030,8 @@ async fn push_inner<'c, 'd>(
                             step_id: restarted_from_val.step_id,
                             branch_or_iteration_n: restarted_from_val.branch_or_iteration_n,
                             flow_version: restarted_from_val.flow_version,
+                            branch_chosen: restarted_from_val.branch_chosen,
+                            nested: restarted_from_val.nested,
                         }),
                         user_states,
                         preprocessor_module: None,
@@ -5312,6 +5314,8 @@ async fn push_inner<'c, 'd>(
             step_id,
             branch_or_iteration_n,
             flow_version,
+            branch_chosen,
+            nested,
         } => {
             let (
                 version,
@@ -5351,6 +5355,8 @@ async fn push_inner<'c, 'd>(
                     step_id,
                     branch_or_iteration_n,
                     flow_version,
+                    branch_chosen,
+                    nested,
                 }),
                 user_states,
                 preprocessor_module: None,
@@ -6133,7 +6139,6 @@ async fn restarted_flows_resolution(
     restart_step_id: &str,
     branch_or_iteration_n: Option<usize>,
     flow_version: Option<i64>,
-    // parents: Vec<RestartedParent>,
 ) -> Result<
     (
         Option<i64>,

--- a/backend/windmill-queue/src/jobs.rs
+++ b/backend/windmill-queue/src/jobs.rs
@@ -5000,7 +5000,7 @@ async fn push_inner<'c, 'd>(
 
             let flow_status: FlowStatus = match restarted_from {
                 Some(restarted_from_val) => {
-                    let (_, _, _, step_n, truncated_modules, user_states, cleanup_module) =
+                    let (_, _, _, step_n, truncated_modules, user_states, cleanup_module, _) =
                         restarted_flows_resolution(
                             db,
                             workspace_id,
@@ -5325,6 +5325,7 @@ async fn push_inner<'c, 'd>(
                 truncated_modules,
                 user_states,
                 cleanup_module,
+                original_kind,
             ) = restarted_flows_resolution(
                 db,
                 workspace_id,
@@ -5380,7 +5381,7 @@ async fn push_inner<'c, 'd>(
             JobPayloadUntagged {
                 runnable_id: version,
                 runnable_path: flow_path,
-                job_kind: JobKind::Flow,
+                job_kind: original_kind,
                 raw_flow: value_o,
                 flow_status: Some(restarted_flow_status),
                 cache_ttl,
@@ -6148,6 +6149,7 @@ async fn restarted_flows_resolution(
         Vec<FlowStatusModule>,
         HashMap<String, serde_json::Value>,
         FlowCleanupModule,
+        JobKind,
     ),
     Error,
 > {
@@ -6311,6 +6313,15 @@ async fn restarted_flows_resolution(
         truncated_modules,
         flow_status.user_states,
         flow_status.cleanup_module,
+        // Preserve the original job kind (e.g. FlowNode for BranchOne/loop wrapped
+        // children) so the new run uses the same lookup path. Setting kind=Flow when
+        // the original was FlowNode would cause `cache::job::fetch_flow` to query
+        // `flow_version` with a `flow_node` id and fail at runtime.
+        if is_version_change {
+            JobKind::Flow
+        } else {
+            row.job_kind
+        },
     ))
 }
 

--- a/backend/windmill-types/src/flow_status.rs
+++ b/backend/windmill-types/src/flow_status.rs
@@ -65,6 +65,15 @@ pub struct RestartedFrom {
     pub step_id: String,
     pub branch_or_iteration_n: Option<usize>,
     pub flow_version: Option<i64>,
+    /// For BranchOne nested restart: the branch that was chosen in the original run.
+    /// Used to lock the branch evaluation so the same path is taken on restart.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch_chosen: Option<BranchChosen>,
+    /// When Some, the worker should spawn the child for `step_id` as a `RestartedFlow`
+    /// against `nested.flow_job_id` instead of fresh-launching it. The child's own
+    /// `restarted_from` becomes `*nested`, propagating any further levels of nesting.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nested: Option<Box<RestartedFrom>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/backend/windmill-types/src/jobs.rs
+++ b/backend/windmill-types/src/jobs.rs
@@ -453,6 +453,12 @@ pub enum JobPayload {
         step_id: String,
         branch_or_iteration_n: Option<usize>,
         flow_version: Option<i64>,
+        /// Optional locked branch for BranchOne nested restart at the top level of this run.
+        branch_chosen: Option<crate::flow_status::BranchChosen>,
+        /// Optional nested restart chain. When Some, the worker for the spawned flow,
+        /// upon reaching `step_id`, should spawn the inner child as a `RestartedFlow`
+        /// using this chain rather than fresh-launching it.
+        nested: Option<Box<crate::flow_status::RestartedFrom>>,
     },
     RawFlow {
         value: FlowValue,

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -5146,28 +5146,16 @@ async fn next_loop_iteration(
 ) -> Result<NextFlowTransform, Error> {
     let inner_path = || format!("{}/loop-{}", flow_job.runnable_path(), ns.index);
     if is_simple {
-        // The "simple" iteration fast path needs the same nested-restart spawn
-        // interception as the regular path: when the parent's `restarted_from`
-        // chain targets *this* iteration of *this* loop, swap the freshly-built
-        // simple payload for a `RestartedFlow` so the iteration runs in restart
-        // mode instead of fresh.
-        if let Some(nested) = nested_restart_payload(status, &module.id, Some(ns.index)) {
-            return Ok(NextFlowTransform::Continue(
-                ContinuePayload::SingleJob(JobPayloadWithTag {
-                    payload: nested,
-                    tag: None,
-                    delete_after_use,
-                    delete_after_secs: None,
-                    timeout: None,
-                    on_behalf_of: None,
-                }),
-                NextStatus::NextLoopIteration {
-                    next: ns,
-                    simple_input_transforms: None,
-                    start_runners,
-                },
-            ));
-        }
+        // Note on nested-restart and the is_simple fast path: the swap that the
+        // non-simple path applies (see below) is intentionally NOT mirrored here.
+        // `is_simple_modules` requires the body to be a single `script` /
+        // `rawscript` / `flowscript` module (see `FlowModule::is_simple`); none of
+        // those produce a flow-kind child job. Any nested-restart chain targeting
+        // a leaf inside such an iteration is rejected by `resolve_nested_restart`
+        // at the API layer (the leaf's container isn't a flow). Even if a chain
+        // reached here via direct `JobPayload::RawFlow.restarted_from` use, the
+        // resulting `JobPayload::RestartedFlow` would fail to resolve at push time
+        // (script kind isn't a flow kind). So no swap is meaningful here.
         let mut value = modules[0].get_value()?;
         let simple_input_transforms = match &mut value {
             FlowModuleValue::Script { input_transforms, .. }

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -4485,6 +4485,44 @@ fn insert_iter_arg(
     args.insert(desired_key, value);
 }
 
+/// If the parent flow is a restart whose `nested` chain applies to the child about
+/// to be spawned for `module_id` at iteration/branch `iter_index` (None for non-loop
+/// containers), returns a `RestartedFlow` payload to use instead of the freshly-built
+/// one. The semantics:
+/// - `restarted_from.step_id` must equal `module_id`
+/// - For loop/branchall containers, `restarted_from.branch_or_iteration_n` is the
+///   0-based index of the iteration to restart at, and must equal `iter_index`
+/// - For BranchOne / Subflow (single-child), `iter_index` is None and
+///   `branch_or_iteration_n` is None or 0
+fn nested_restart_payload(
+    flow_status: &FlowStatus,
+    module_id: &str,
+    iter_index: Option<usize>,
+) -> Option<JobPayload> {
+    let restarted_from = flow_status.restarted_from.as_ref()?;
+    if restarted_from.step_id != module_id {
+        return None;
+    }
+    let n = restarted_from.branch_or_iteration_n.unwrap_or(0);
+    let matches = match iter_index {
+        Some(i) => i == n,
+        None => n == 0,
+    };
+    if !matches {
+        return None;
+    }
+    let nested = restarted_from.nested.as_ref()?;
+    let nested = (**nested).clone();
+    Some(JobPayload::RestartedFlow {
+        completed_job_id: nested.flow_job_id,
+        step_id: nested.step_id,
+        branch_or_iteration_n: nested.branch_or_iteration_n,
+        flow_version: nested.flow_version,
+        branch_chosen: nested.branch_chosen,
+        nested: nested.nested,
+    })
+}
+
 fn payload_from_modules<'a>(
     mut modules: Vec<FlowModule>,
     modules_node: Option<FlowNodeId>,
@@ -4583,7 +4621,7 @@ async fn compute_next_flow_transform(
     match module.get_value()? {
         FlowModuleValue::Identity => trivial_next_job(JobPayload::Identity),
         FlowModuleValue::Flow { path, .. } => {
-            let payload = flow_to_payload(
+            let mut payload = flow_to_payload(
                 path,
                 delete_after_use,
                 delete_after_secs,
@@ -4591,6 +4629,9 @@ async fn compute_next_flow_transform(
                 db,
             )
             .await?;
+            if let Some(nested) = nested_restart_payload(status, &module.id, None) {
+                payload.payload = nested;
+            }
             Ok(NextFlowTransform::Continue(
                 ContinuePayload::SingleJob(payload),
                 NextStatus::NextStep,
@@ -4855,59 +4896,76 @@ async fn compute_next_flow_transform(
             }
         }
         FlowModuleValue::BranchOne { branches, default, default_node } => {
-            let branch = match status_module {
-                FlowStatusModule::WaitingForPriorSteps { .. }
-                | FlowStatusModule::WaitingForEvents { .. }
-                | FlowStatusModule::WaitingForExecutor { .. } => {
-                    let mut branch_chosen = BranchChosen::Default;
-                    let idcontext = get_transform_context(&flow_job, previous_id, &status);
-                    let mut predicate_err: Option<Error> = None;
-                    for (i, b) in branches.iter().enumerate() {
-                        let pred_res = compute_bool_from_expr(
-                            &b.expr,
-                            arc_flow_job_args.clone(),
-                            flow_env,
-                            arc_last_job_result.clone(),
-                            None,
-                            Some(&idcontext),
-                            Some(client),
-                            Some((resumes.clone(), resume.clone(), approvers.clone())),
-                            None,
-                        )
-                        .await;
-                        if let Err(e) = &pred_res {
-                            append_predicate_error_to_root_logs(
-                                db,
-                                root_flow_id_for(flow_job),
-                                &flow_job.workspace_id,
-                                Some(&module.id),
-                                &format!("branchone branch {i}"),
+            // Branch lock for nested restart: if this BranchOne is the target of a
+            // nested restart, reuse the branch that was originally chosen instead of
+            // re-evaluating predicates. The lock is opt-in via `restarted_from.nested`
+            // being set, so plain top-level "restart at this BranchOne" still re-evaluates.
+            let locked_branch = status.restarted_from.as_ref().and_then(|rf| {
+                if rf.step_id == module.id && rf.nested.is_some() {
+                    rf.branch_chosen.clone()
+                } else {
+                    None
+                }
+            });
+            let branch = if let Some(branch) = locked_branch {
+                branch
+            } else {
+                match status_module {
+                    FlowStatusModule::WaitingForPriorSteps { .. }
+                    | FlowStatusModule::WaitingForEvents { .. }
+                    | FlowStatusModule::WaitingForExecutor { .. } => {
+                        let mut branch_chosen = BranchChosen::Default;
+                        let idcontext = get_transform_context(&flow_job, previous_id, &status);
+                        let mut predicate_err: Option<Error> = None;
+                        for (i, b) in branches.iter().enumerate() {
+                            let pred_res = compute_bool_from_expr(
                                 &b.expr,
-                                e,
+                                arc_flow_job_args.clone(),
+                                flow_env,
+                                arc_last_job_result.clone(),
+                                None,
+                                Some(&idcontext),
+                                Some(client),
+                                Some((resumes.clone(), resume.clone(), approvers.clone())),
+                                None,
                             )
                             .await;
-                        }
-                        let pred = match pred_res {
-                            Ok(p) => p,
-                            Err(e) => {
-                                predicate_err = Some(e);
+                            if let Err(e) = &pred_res {
+                                append_predicate_error_to_root_logs(
+                                    db,
+                                    root_flow_id_for(flow_job),
+                                    &flow_job.workspace_id,
+                                    Some(&module.id),
+                                    &format!("branchone branch {i}"),
+                                    &b.expr,
+                                    e,
+                                )
+                                .await;
+                            }
+                            let pred = match pred_res {
+                                Ok(p) => p,
+                                Err(e) => {
+                                    predicate_err = Some(e);
+                                    break;
+                                }
+                            };
+
+                            if pred {
+                                branch_chosen = BranchChosen::Branch { branch: i };
                                 break;
                             }
-                        };
-
-                        if pred {
-                            branch_chosen = BranchChosen::Branch { branch: i };
-                            break;
                         }
+                        if let Some(e) = predicate_err {
+                            return Ok(NextFlowTransform::StepFailure {
+                                error: error_to_value(&e),
+                            });
+                        }
+                        branch_chosen
                     }
-                    if let Some(e) = predicate_err {
-                        return Ok(NextFlowTransform::StepFailure { error: error_to_value(&e) });
-                    }
-                    branch_chosen
+                    _ => Err(Error::BadRequest(format!(
+                        "Unrecognized module status for BranchOne {status_module:?}"
+                    )))?,
                 }
-                _ => Err(Error::BadRequest(format!(
-                    "Unrecognized module status for BranchOne {status_module:?}"
-                )))?,
             };
 
             let (modules, modules_node, branch_idx) = match branch {
@@ -4923,7 +4981,7 @@ async fn compute_next_flow_transform(
                     })?,
             };
 
-            let Some(payload) = payload_from_modules(
+            let Some(mut payload) = payload_from_modules(
                 modules,
                 modules_node,
                 flow.failure_module.as_ref(),
@@ -4934,6 +4992,9 @@ async fn compute_next_flow_transform(
             ) else {
                 return Ok(NextFlowTransform::EmptyInnerFlows { branch_chosen: Some(branch) });
             };
+            if let Some(nested) = nested_restart_payload(status, &module.id, None) {
+                payload = nested;
+            }
 
             Ok(NextFlowTransform::Continue(
                 ContinuePayload::SingleJob(JobPayloadWithTag {
@@ -5103,7 +5164,7 @@ async fn next_loop_iteration(
         ));
     }
 
-    let Some(payload) = payload_from_modules(
+    let Some(mut payload) = payload_from_modules(
         modules,
         modules_node,
         flow.failure_module.as_ref(),
@@ -5114,6 +5175,9 @@ async fn next_loop_iteration(
     ) else {
         return Ok(NextFlowTransform::EmptyInnerFlows { branch_chosen: None });
     };
+    if let Some(nested) = nested_restart_payload(status, &module.id, Some(ns.index)) {
+        payload = nested;
+    }
 
     Ok(NextFlowTransform::Continue(
         ContinuePayload::SingleJob(JobPayloadWithTag {

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -5146,6 +5146,28 @@ async fn next_loop_iteration(
 ) -> Result<NextFlowTransform, Error> {
     let inner_path = || format!("{}/loop-{}", flow_job.runnable_path(), ns.index);
     if is_simple {
+        // The "simple" iteration fast path needs the same nested-restart spawn
+        // interception as the regular path: when the parent's `restarted_from`
+        // chain targets *this* iteration of *this* loop, swap the freshly-built
+        // simple payload for a `RestartedFlow` so the iteration runs in restart
+        // mode instead of fresh.
+        if let Some(nested) = nested_restart_payload(status, &module.id, Some(ns.index)) {
+            return Ok(NextFlowTransform::Continue(
+                ContinuePayload::SingleJob(JobPayloadWithTag {
+                    payload: nested,
+                    tag: None,
+                    delete_after_use,
+                    delete_after_secs: None,
+                    timeout: None,
+                    on_behalf_of: None,
+                }),
+                NextStatus::NextLoopIteration {
+                    next: ns,
+                    simple_input_transforms: None,
+                    start_runners,
+                },
+            ));
+        }
         let mut value = modules[0].get_value()?;
         let simple_input_transforms = match &mut value {
             FlowModuleValue::Script { input_transforms, .. }

--- a/frontend/src/lib/components/FlowPreviewContent.svelte
+++ b/frontend/src/lib/components/FlowPreviewContent.svelte
@@ -414,15 +414,19 @@
 				</div>
 			{:else}
 				<div class="grow justify-center flex flex-row gap-2 items-center">
-					{#if jobId !== undefined && selectedJobStep !== undefined && (restart.topLevelRestartable || restart.nestedRestartSupported)}
+					{#if jobId !== undefined && selectedJobStep !== undefined && restart.topLevelRestartable}
+						<!--
+							Nested-step restart is intentionally not surfaced from the editor
+							preview: the chain needs `flow_job_id` resolved at every level,
+							which only the backend can do (by walking the original
+							execution). Users who want nested restart should use the run
+							page, which goes through the dedicated restart API.
+						-->
 						<FlowRestartButton
 							{jobId}
 							{selectedJobStep}
 							selectedJobStepType={restart.selectedJobStepType}
 							restartBranchNames={restart.restartBranchNames}
-							nestedPath={restart.nestedRestartSupported ? restart.nestedRestartPath : undefined}
-							nestedTopStepId={restart.nestedRestartTopStepId}
-							nestedTopBranchOrIterationN={restart.nestedRestartTopBranchOrIterationN}
 							presetIterationN={restart.topLevelLoopIteration}
 							iterationCounts={restart.iterationCounts}
 							onRestart={(stepId, branchOrIterationN) => {

--- a/frontend/src/lib/components/FlowPreviewContent.svelte
+++ b/frontend/src/lib/components/FlowPreviewContent.svelte
@@ -40,6 +40,7 @@
 	import FlowChat from './flows/conversations/FlowChat.svelte'
 	import { stateSnapshot } from '$lib/svelte5Utils.svelte'
 	import FlowRestartButton from './FlowRestartButton.svelte'
+	import { findStepPath } from './restartFromStepPath'
 	import { createFlowRecording, setActiveRecording } from './recording/flowRecording.svelte'
 	import type { FlowRecording } from './recording/types'
 
@@ -91,6 +92,11 @@
 	}: Props = $props()
 
 	let restartBranchNames: [number, string][] = []
+	let nestedRestartTopStepId: string | undefined = $state(undefined)
+	let nestedRestartTopBranchOrIterationN: number | undefined = $state(undefined)
+	let nestedRestartPath: Array<{ step_id: string; branch_or_iteration_n?: number }> | undefined =
+		$state(undefined)
+	let nestedRestartSupported: boolean = $state(false)
 	let isRunning: boolean = $state(false)
 	let jsonView: boolean = $state(false)
 	let jsonEditor: JsonInputs | undefined = $state(undefined)
@@ -212,6 +218,10 @@
 	}
 
 	function onSelectedJobStepChange() {
+		nestedRestartTopStepId = undefined
+		nestedRestartTopBranchOrIterationN = undefined
+		nestedRestartPath = undefined
+		nestedRestartSupported = false
 		if (selectedJobStep !== undefined && job?.flow_status?.modules !== undefined) {
 			selectedJobStepIsTopLevel =
 				job?.flow_status?.modules.map((m) => m.id).indexOf(selectedJobStep) >= 0
@@ -228,6 +238,34 @@
 				})
 			} else {
 				selectedJobStepType = 'single'
+			}
+
+			if (!selectedJobStepIsTopLevel && job?.raw_flow?.modules) {
+				const path = findStepPath(job.raw_flow.modules, selectedJobStep!)
+				if (path && path.ancestors.length > 0) {
+					const blocked = path.ancestors.find(
+						(a) => a.type === 'branchall' || a.type === 'whileloopflow'
+					)
+					if (!blocked) {
+						const top = path.ancestors[0]
+						const inner = path.ancestors.slice(1)
+						const innerPath: Array<{ step_id: string; branch_or_iteration_n?: number }> = []
+						for (const a of inner) {
+							const entry: { step_id: string; branch_or_iteration_n?: number } = {
+								step_id: a.stepId
+							}
+							if (a.type === 'forloopflow') {
+								entry.branch_or_iteration_n = 0
+							}
+							innerPath.push(entry)
+						}
+						innerPath.push({ step_id: selectedJobStep! })
+						nestedRestartTopStepId = top.stepId
+						nestedRestartTopBranchOrIterationN = top.type === 'forloopflow' ? 0 : undefined
+						nestedRestartPath = innerPath
+						nestedRestartSupported = true
+					}
+				}
 			}
 		}
 	}
@@ -418,12 +456,15 @@
 				</div>
 			{:else}
 				<div class="grow justify-center flex flex-row gap-2 items-center">
-					{#if jobId !== undefined && selectedJobStep !== undefined && selectedJobStepIsTopLevel}
+					{#if jobId !== undefined && selectedJobStep !== undefined && (selectedJobStepIsTopLevel || nestedRestartSupported)}
 						<FlowRestartButton
 							{jobId}
 							{selectedJobStep}
 							{selectedJobStepType}
 							{restartBranchNames}
+							nestedPath={nestedRestartSupported ? nestedRestartPath : undefined}
+							nestedTopStepId={nestedRestartTopStepId}
+							nestedTopBranchOrIterationN={nestedRestartTopBranchOrIterationN}
 							onRestart={(stepId, branchOrIterationN) => {
 								runPreview(previewArgs.val, {
 									flow_job_id: jobId,

--- a/frontend/src/lib/components/FlowPreviewContent.svelte
+++ b/frontend/src/lib/components/FlowPreviewContent.svelte
@@ -40,7 +40,7 @@
 	import FlowChat from './flows/conversations/FlowChat.svelte'
 	import { stateSnapshot } from '$lib/svelte5Utils.svelte'
 	import FlowRestartButton from './FlowRestartButton.svelte'
-	import { findStepPath } from './restartFromStepPath'
+	import { findStepPath, parseExpandedSubflowId } from './restartFromStepPath'
 	import { createFlowRecording, setActiveRecording } from './recording/flowRecording.svelte'
 	import type { FlowRecording } from './recording/types'
 
@@ -240,30 +240,52 @@
 				selectedJobStepType = 'single'
 			}
 
-			if (!selectedJobStepIsTopLevel && job?.raw_flow?.modules) {
-				const path = findStepPath(job.raw_flow.modules, selectedJobStep!)
-				if (path && path.ancestors.length > 0) {
-					const blocked = path.ancestors.find(
-						(a) => a.type === 'branchall' || a.type === 'whileloopflow'
-					)
-					if (!blocked) {
-						const top = path.ancestors[0]
-						const inner = path.ancestors.slice(1)
+			if (!selectedJobStepIsTopLevel) {
+				// Inline-expanded subflow: id is `subflow:outerStep:[innerSubflow:...]<leaf>`.
+				const subflowParse = parseExpandedSubflowId(selectedJobStep!)
+				if (subflowParse && job?.raw_flow?.modules) {
+					const top = job.raw_flow.modules.find((m) => m.id === subflowParse.subflowSteps[0])
+					if (top && top.value.type === 'flow') {
 						const innerPath: Array<{ step_id: string; branch_or_iteration_n?: number }> = []
-						for (const a of inner) {
-							const entry: { step_id: string; branch_or_iteration_n?: number } = {
-								step_id: a.stepId
-							}
-							if (a.type === 'forloopflow') {
-								entry.branch_or_iteration_n = 0
-							}
-							innerPath.push(entry)
+						for (const seg of subflowParse.subflowSteps.slice(1)) {
+							innerPath.push({ step_id: seg })
 						}
-						innerPath.push({ step_id: selectedJobStep! })
-						nestedRestartTopStepId = top.stepId
-						nestedRestartTopBranchOrIterationN = top.type === 'forloopflow' ? 0 : undefined
+						innerPath.push({ step_id: subflowParse.leaf })
+						nestedRestartTopStepId = top.id
+						nestedRestartTopBranchOrIterationN = undefined
 						nestedRestartPath = innerPath
 						nestedRestartSupported = true
+					}
+				}
+				// BranchOne / sequential ForLoop nested in the parent's own flow_value.
+				if (!nestedRestartSupported && job?.raw_flow?.modules) {
+					const path = findStepPath(job.raw_flow.modules, selectedJobStep!)
+					if (path && path.ancestors.length > 0) {
+						const blocked = path.ancestors.find(
+							(a) => a.type === 'branchall' || a.type === 'whileloopflow'
+						)
+						if (!blocked) {
+							const top = path.ancestors[0]
+							const inner = path.ancestors.slice(1)
+							const innerPath: Array<{
+								step_id: string
+								branch_or_iteration_n?: number
+							}> = []
+							for (const a of inner) {
+								const entry: { step_id: string; branch_or_iteration_n?: number } = {
+									step_id: a.stepId
+								}
+								if (a.type === 'forloopflow') {
+									entry.branch_or_iteration_n = 0
+								}
+								innerPath.push(entry)
+							}
+							innerPath.push({ step_id: selectedJobStep! })
+							nestedRestartTopStepId = top.stepId
+							nestedRestartTopBranchOrIterationN = top.type === 'forloopflow' ? 0 : undefined
+							nestedRestartPath = innerPath
+							nestedRestartSupported = true
+						}
 					}
 				}
 			}

--- a/frontend/src/lib/components/FlowPreviewContent.svelte
+++ b/frontend/src/lib/components/FlowPreviewContent.svelte
@@ -28,7 +28,7 @@
 		RefreshCw,
 		X
 	} from 'lucide-svelte'
-	import { emptyString, sendUserToast, type StateStore } from '$lib/utils'
+	import { sendUserToast, type StateStore } from '$lib/utils'
 	import { dfs } from './flows/dfs'
 	import { sliceModules } from './flows/flowStateUtils.svelte'
 	import InputSelectedBadge from './schema/InputSelectedBadge.svelte'
@@ -40,7 +40,7 @@
 	import FlowChat from './flows/conversations/FlowChat.svelte'
 	import { stateSnapshot } from '$lib/svelte5Utils.svelte'
 	import FlowRestartButton from './FlowRestartButton.svelte'
-	import { findStepPath, parseExpandedSubflowId } from './restartFromStepPath'
+	import { useNestedRestartState } from './useNestedRestartState.svelte'
 	import { createFlowRecording, setActiveRecording } from './recording/flowRecording.svelte'
 	import type { FlowRecording } from './recording/types'
 
@@ -91,29 +91,20 @@
 		suspendStatus
 	}: Props = $props()
 
-	let restartBranchNames: [number, string][] = []
-	let nestedRestartTopStepId: string | undefined = $state(undefined)
-	let nestedRestartTopBranchOrIterationN: number | undefined = $state(undefined)
-	let nestedRestartPath: Array<{ step_id: string; branch_or_iteration_n?: number }> | undefined =
-		$state(undefined)
-	let nestedRestartSupported: boolean = $state(false)
-	// Pre-fill iteration input for top-level ForLoop restart from the iteration the
-	// user is currently viewing in the graph. Editable in the popup if they want to
-	// pick a different one.
-	let topLevelLoopIteration: number | undefined = $derived(
-		(selectedJobStepType as string) === 'forloop' && selectedJobStep
-			? localModuleStates[selectedJobStep]?.selectedForloopIndex
-			: undefined
-	)
-	let iterationCounts: Record<string, number> = $derived.by(() => {
-		const out: Record<string, number> = {}
-		for (const [id, state] of Object.entries(localModuleStates)) {
-			const n = state.flow_jobs?.length
-			if (typeof n === 'number' && n > 0) {
-				out[id] = n
-			}
-		}
-		return out
+	const restart = useNestedRestartState({
+		selectedJobStep: () => selectedJobStep,
+		job: () => job,
+		graphModuleStates: () => localModuleStates
+	})
+	// `selectedJobStepType` and `selectedJobStepIsTopLevel` are still exposed as
+	// `$bindable` props to legacy parents (FlowPreviewButtons binds them but
+	// doesn't read them). Sync them out of the composable here so the prop
+	// surface stays unchanged.
+	$effect(() => {
+		selectedJobStepIsTopLevel = restart.selectedJobStepIsTopLevel
+	})
+	$effect(() => {
+		selectedJobStepType = restart.selectedJobStepType
 	})
 	let isRunning: boolean = $state(false)
 	let jsonView: boolean = $state(false)
@@ -235,91 +226,6 @@
 		}
 	}
 
-	function onSelectedJobStepChange() {
-		nestedRestartTopStepId = undefined
-		nestedRestartTopBranchOrIterationN = undefined
-		nestedRestartPath = undefined
-		nestedRestartSupported = false
-		if (selectedJobStep !== undefined && job?.flow_status?.modules !== undefined) {
-			selectedJobStepIsTopLevel =
-				job?.flow_status?.modules.map((m) => m.id).indexOf(selectedJobStep) >= 0
-			let moduleDefinition = job?.raw_flow?.modules.find((m) => m.id == selectedJobStep)
-			if (moduleDefinition?.value.type == 'forloopflow') {
-				selectedJobStepType = 'forloop'
-			} else if (moduleDefinition?.value.type == 'branchall') {
-				selectedJobStepType = 'branchall'
-				moduleDefinition?.value.branches.forEach((branch, idx) => {
-					restartBranchNames.push([
-						idx,
-						emptyString(branch.summary) ? `Branch #${idx}` : branch.summary!
-					])
-				})
-			} else {
-				selectedJobStepType = 'single'
-			}
-
-			if (!selectedJobStepIsTopLevel) {
-				// Inline-expanded subflow: id is `subflow:outerStep:[innerSubflow:...]<leaf>`.
-				const subflowParse = parseExpandedSubflowId(selectedJobStep!)
-				if (subflowParse && job?.raw_flow?.modules) {
-					const top = job.raw_flow.modules.find((m) => m.id === subflowParse.subflowSteps[0])
-					if (top && top.value.type === 'flow') {
-						const innerPath: Array<{ step_id: string; branch_or_iteration_n?: number }> = []
-						for (const seg of subflowParse.subflowSteps.slice(1)) {
-							innerPath.push({ step_id: seg })
-						}
-						innerPath.push({ step_id: subflowParse.leaf })
-						nestedRestartTopStepId = top.id
-						nestedRestartTopBranchOrIterationN = undefined
-						nestedRestartPath = innerPath
-						nestedRestartSupported = true
-					}
-				}
-				// BranchOne / sequential ForLoop nested in the parent's own flow_value.
-				if (!nestedRestartSupported && job?.raw_flow?.modules) {
-					const path = findStepPath(job.raw_flow.modules, selectedJobStep!)
-					if (path && path.ancestors.length > 0) {
-						const blocked = path.ancestors.find(
-							(a) => a.type === 'branchall' || a.type === 'whileloopflow'
-						)
-						// Default missing iterations to 0; the popup surfaces them for confirmation.
-						const iterationFor = (stepId: string): number =>
-							localModuleStates[stepId]?.selectedForloopIndex ?? 0
-						if (!blocked) {
-							const top = path.ancestors[0]
-							const inner = path.ancestors.slice(1)
-							const innerPath: Array<{
-								step_id: string
-								branch_or_iteration_n?: number
-							}> = []
-							for (const a of inner) {
-								const entry: { step_id: string; branch_or_iteration_n?: number } = {
-									step_id: a.stepId
-								}
-								if (a.type === 'forloopflow') {
-									entry.branch_or_iteration_n = iterationFor(a.stepId)
-								}
-								innerPath.push(entry)
-							}
-							const leafEntry: { step_id: string; branch_or_iteration_n?: number } = {
-								step_id: selectedJobStep!
-							}
-							if (path.target.value.type === 'forloopflow') {
-								leafEntry.branch_or_iteration_n = iterationFor(selectedJobStep!)
-							}
-							innerPath.push(leafEntry)
-							nestedRestartTopStepId = top.stepId
-							nestedRestartTopBranchOrIterationN =
-								top.type === 'forloopflow' ? iterationFor(top.stepId) : undefined
-							nestedRestartPath = innerPath
-							nestedRestartSupported = true
-						}
-					}
-				}
-			}
-		}
-	}
-
 	let savedArgs = $state(previewArgs.val)
 	let inputSelected: 'captures' | 'history' | 'saved' | undefined = $state(undefined)
 	async function selectInput(input, type?: 'captures' | 'history' | 'saved' | undefined) {
@@ -401,9 +307,6 @@
 			scrollableDiv.scrollTop = scrollTop
 		}
 	}
-	$effect.pre(() => {
-		selectedJobStep !== undefined && untrack(() => onSelectedJobStepChange())
-	})
 	$effect(() => {
 		scrollableDiv && render && untrack(() => onScrollableDivChange())
 	})
@@ -506,17 +409,17 @@
 				</div>
 			{:else}
 				<div class="grow justify-center flex flex-row gap-2 items-center">
-					{#if jobId !== undefined && selectedJobStep !== undefined && (selectedJobStepIsTopLevel || nestedRestartSupported)}
+					{#if jobId !== undefined && selectedJobStep !== undefined && (restart.selectedJobStepIsTopLevel || restart.nestedRestartSupported)}
 						<FlowRestartButton
 							{jobId}
 							{selectedJobStep}
-							{selectedJobStepType}
-							{restartBranchNames}
-							nestedPath={nestedRestartSupported ? nestedRestartPath : undefined}
-							nestedTopStepId={nestedRestartTopStepId}
-							nestedTopBranchOrIterationN={nestedRestartTopBranchOrIterationN}
-							presetIterationN={topLevelLoopIteration}
-							{iterationCounts}
+							selectedJobStepType={restart.selectedJobStepType}
+							restartBranchNames={restart.restartBranchNames}
+							nestedPath={restart.nestedRestartSupported ? restart.nestedRestartPath : undefined}
+							nestedTopStepId={restart.nestedRestartTopStepId}
+							nestedTopBranchOrIterationN={restart.nestedRestartTopBranchOrIterationN}
+							presetIterationN={restart.topLevelLoopIteration}
+							iterationCounts={restart.iterationCounts}
 							onRestart={(stepId, branchOrIterationN) => {
 								runPreview(previewArgs.val, {
 									flow_job_id: jobId,

--- a/frontend/src/lib/components/FlowPreviewContent.svelte
+++ b/frontend/src/lib/components/FlowPreviewContent.svelte
@@ -264,7 +264,12 @@
 						const blocked = path.ancestors.find(
 							(a) => a.type === 'branchall' || a.type === 'whileloopflow'
 						)
-						if (!blocked) {
+						const iterationFor = (stepId: string): number | undefined =>
+							localModuleStates[stepId]?.selectedForloopIndex
+						const missingIteration = path.ancestors.some(
+							(a) => a.type === 'forloopflow' && iterationFor(a.stepId) === undefined
+						)
+						if (!blocked && !missingIteration) {
 							const top = path.ancestors[0]
 							const inner = path.ancestors.slice(1)
 							const innerPath: Array<{
@@ -276,13 +281,14 @@
 									step_id: a.stepId
 								}
 								if (a.type === 'forloopflow') {
-									entry.branch_or_iteration_n = 0
+									entry.branch_or_iteration_n = iterationFor(a.stepId)
 								}
 								innerPath.push(entry)
 							}
 							innerPath.push({ step_id: selectedJobStep! })
 							nestedRestartTopStepId = top.stepId
-							nestedRestartTopBranchOrIterationN = top.type === 'forloopflow' ? 0 : undefined
+							nestedRestartTopBranchOrIterationN =
+								top.type === 'forloopflow' ? iterationFor(top.stepId) : undefined
 							nestedRestartPath = innerPath
 							nestedRestartSupported = true
 						}

--- a/frontend/src/lib/components/FlowPreviewContent.svelte
+++ b/frontend/src/lib/components/FlowPreviewContent.svelte
@@ -97,6 +97,24 @@
 	let nestedRestartPath: Array<{ step_id: string; branch_or_iteration_n?: number }> | undefined =
 		$state(undefined)
 	let nestedRestartSupported: boolean = $state(false)
+	// Pre-fill iteration input for top-level ForLoop restart from the iteration the
+	// user is currently viewing in the graph. Editable in the popup if they want to
+	// pick a different one.
+	let topLevelLoopIteration: number | undefined = $derived(
+		(selectedJobStepType as string) === 'forloop' && selectedJobStep
+			? localModuleStates[selectedJobStep]?.selectedForloopIndex
+			: undefined
+	)
+	let iterationCounts: Record<string, number> = $derived.by(() => {
+		const out: Record<string, number> = {}
+		for (const [id, state] of Object.entries(localModuleStates)) {
+			const n = state.flow_jobs?.length
+			if (typeof n === 'number' && n > 0) {
+				out[id] = n
+			}
+		}
+		return out
+	})
 	let isRunning: boolean = $state(false)
 	let jsonView: boolean = $state(false)
 	let jsonEditor: JsonInputs | undefined = $state(undefined)
@@ -264,12 +282,10 @@
 						const blocked = path.ancestors.find(
 							(a) => a.type === 'branchall' || a.type === 'whileloopflow'
 						)
-						const iterationFor = (stepId: string): number | undefined =>
-							localModuleStates[stepId]?.selectedForloopIndex
-						const missingIteration = path.ancestors.some(
-							(a) => a.type === 'forloopflow' && iterationFor(a.stepId) === undefined
-						)
-						if (!blocked && !missingIteration) {
+						// Default missing iterations to 0; the popup surfaces them for confirmation.
+						const iterationFor = (stepId: string): number =>
+							localModuleStates[stepId]?.selectedForloopIndex ?? 0
+						if (!blocked) {
 							const top = path.ancestors[0]
 							const inner = path.ancestors.slice(1)
 							const innerPath: Array<{
@@ -285,7 +301,13 @@
 								}
 								innerPath.push(entry)
 							}
-							innerPath.push({ step_id: selectedJobStep! })
+							const leafEntry: { step_id: string; branch_or_iteration_n?: number } = {
+								step_id: selectedJobStep!
+							}
+							if (path.target.value.type === 'forloopflow') {
+								leafEntry.branch_or_iteration_n = iterationFor(selectedJobStep!)
+							}
+							innerPath.push(leafEntry)
 							nestedRestartTopStepId = top.stepId
 							nestedRestartTopBranchOrIterationN =
 								top.type === 'forloopflow' ? iterationFor(top.stepId) : undefined
@@ -493,6 +515,8 @@
 							nestedPath={nestedRestartSupported ? nestedRestartPath : undefined}
 							nestedTopStepId={nestedRestartTopStepId}
 							nestedTopBranchOrIterationN={nestedRestartTopBranchOrIterationN}
+							presetIterationN={topLevelLoopIteration}
+							{iterationCounts}
 							onRestart={(stepId, branchOrIterationN) => {
 								runPreview(previewArgs.val, {
 									flow_job_id: jobId,

--- a/frontend/src/lib/components/FlowPreviewContent.svelte
+++ b/frontend/src/lib/components/FlowPreviewContent.svelte
@@ -91,10 +91,15 @@
 		suspendStatus
 	}: Props = $props()
 
+	let previewExpandedSubflows: Record<
+		string,
+		{ modules: import('$lib/gen').FlowModule[]; groups?: any[] }
+	> = $state({})
 	const restart = useNestedRestartState({
 		selectedJobStep: () => selectedJobStep,
 		job: () => job,
-		graphModuleStates: () => localModuleStates
+		graphModuleStates: () => localModuleStates,
+		expandedSubflows: () => previewExpandedSubflows
 	})
 	// `selectedJobStepType` and `selectedJobStepIsTopLevel` are still exposed as
 	// `$bindable` props to legacy parents (FlowPreviewButtons binds them but
@@ -642,6 +647,7 @@
 				<FlowStatusViewer
 					bind:job
 					bind:localModuleStates
+					bind:expandedSubflows={previewExpandedSubflows}
 					bind:localDurationStatuses
 					{suspendStatus}
 					hideDownloadInGraph={customUi?.downloadLogs === false}

--- a/frontend/src/lib/components/FlowPreviewContent.svelte
+++ b/frontend/src/lib/components/FlowPreviewContent.svelte
@@ -414,7 +414,7 @@
 				</div>
 			{:else}
 				<div class="grow justify-center flex flex-row gap-2 items-center">
-					{#if jobId !== undefined && selectedJobStep !== undefined && (restart.selectedJobStepIsTopLevel || restart.nestedRestartSupported)}
+					{#if jobId !== undefined && selectedJobStep !== undefined && (restart.topLevelRestartable || restart.nestedRestartSupported)}
 						<FlowRestartButton
 							{jobId}
 							{selectedJobStep}

--- a/frontend/src/lib/components/FlowRestartButton.svelte
+++ b/frontend/src/lib/components/FlowRestartButton.svelte
@@ -30,6 +30,19 @@
 		nestedTopStepId?: string
 		/** Top-level container branch_or_iteration_n (only used when nestedPath is set) */
 		nestedTopBranchOrIterationN?: number
+		/**
+		 * For top-level ForLoop restart: iteration index the user is currently
+		 * viewing in the graph (read from `selectedForloopIndex` upstream). When
+		 * provided, the popup pre-fills the iteration selector with this value.
+		 */
+		presetIterationN?: number
+		/**
+		 * Map from ForLoop step id to the number of iterations that ran in the
+		 * original execution (i.e. `flow_jobs.length`). When provided for a step,
+		 * the popup renders a `<select>` of `0..count-1` instead of a free-form
+		 * number input — same surface as the graph's iteration tabs.
+		 */
+		iterationCounts?: Record<string, number>
 		/** Called when flow is restarted. If not provided, will navigate to the new run using goto (requires SvelteKit) */
 		onRestart?: (stepId: string, branchOrIterationN: number, flowVersion?: number) => void
 		/** Called when flow restart completes with the new job ID. Used for navigation in non-SvelteKit contexts */
@@ -50,6 +63,8 @@
 		nestedPath = undefined,
 		nestedTopStepId = undefined,
 		nestedTopBranchOrIterationN = undefined,
+		presetIterationN = undefined,
+		iterationCounts = undefined,
 		onRestart,
 		onRestartComplete
 	}: Props = $props()
@@ -66,6 +81,58 @@
 	const RUN_VERSION_SENTINEL = -1
 
 	let branchOrIterationN = $state(0)
+
+	// Iteration inputs for nested-step restart inside one or more ForLoop ancestors.
+	// Each editable position keeps a local copy that the popup can mutate; on
+	// submit we rebuild the request from these. We snapshot from props every time
+	// the popup opens (see `resetEditsFromProps`), not on every prop change — that
+	// way the user's manual edits stick while the popup is open, and re-opening
+	// after picking a different iteration in the graph picks up the new value.
+	type IterField = { key: 'top' | `inner-${number}`; label: string; value: number }
+	let iterationEdits: Record<string, number> = $state({})
+
+	function resetEditsFromProps() {
+		const next: Record<string, number> = {}
+		if (isNested && nestedTopBranchOrIterationN !== undefined) {
+			next['top'] = nestedTopBranchOrIterationN
+		}
+		if (isNested) {
+			nestedPath?.forEach((entry, i) => {
+				if (entry.branch_or_iteration_n !== undefined) {
+					next[`inner-${i}`] = entry.branch_or_iteration_n
+				}
+			})
+		}
+		iterationEdits = next
+		if (selectedJobStepType === 'forloop' && presetIterationN !== undefined) {
+			branchOrIterationN = presetIterationN
+		}
+	}
+	const iterationFields = $derived.by((): IterField[] => {
+		if (!isNested) return []
+		const out: IterField[] = []
+		if (nestedTopBranchOrIterationN !== undefined && nestedTopStepId) {
+			out.push({
+				key: 'top',
+				label: nestedTopStepId,
+				value: iterationEdits['top'] ?? nestedTopBranchOrIterationN
+			})
+		}
+		nestedPath?.forEach((entry, i) => {
+			if (entry.branch_or_iteration_n !== undefined) {
+				const k = `inner-${i}` as const
+				out.push({
+					key: k,
+					label: entry.step_id,
+					value: iterationEdits[k] ?? entry.branch_or_iteration_n
+				})
+			}
+		})
+		return out
+	})
+	const needsPopup = $derived(
+		!!flowPath || iterationFields.length > 0 || selectedJobStepType !== 'single'
+	)
 	let selectedFlowVersion: number = $state(RUN_VERSION_SENTINEL)
 	let flowVersions: Array<FlowVersion> = $state([])
 	let loadingVersions: boolean = $state(false)
@@ -76,9 +143,12 @@
 		const requestBody = isNested
 			? {
 					step_id: nestedTopStepId!,
-					branch_or_iteration_n: nestedTopBranchOrIterationN,
+					branch_or_iteration_n: iterationEdits['top'] ?? nestedTopBranchOrIterationN,
 					flow_version: flowVersion,
-					nested_path: nestedPath
+					nested_path: nestedPath?.map((entry, i) => ({
+						step_id: entry.step_id,
+						branch_or_iteration_n: iterationEdits[`inner-${i}`] ?? entry.branch_or_iteration_n
+					}))
 				}
 			: {
 					step_id: stepId,
@@ -161,23 +231,23 @@
 		{/if}
 	</label>
 {/snippet}
-{#snippet singleRestartButton()}
+{#snippet restartTriggerButton(usePlayIcon: boolean)}
 	<Button
 		title={`Re-start this flow from step ${displayStepId} (included).${enterpriseOnly ? ' This is a feature only available in enterprise edition.' : ''}`}
 		{variant}
 		{unifiedSize}
 		{disabled}
-		startIcon={{ icon: Play }}
-		nonCaptureEvent={!!flowPath}
+		startIcon={{ icon: usePlayIcon ? Play : RefreshCw }}
+		nonCaptureEvent={!usePlayIcon || !!flowPath}
 		onClick={() => {
-			if (!flowPath) {
+			if (usePlayIcon && !flowPath) {
 				handleRestart()
 			}
 		}}
 	>
 		Re-start from
 		<Badge baseClass="ml-1" color="indigo">
-			{selectedJobStep}
+			{displayStepId}
 		</Badge>
 		{#if enterpriseOnly && disabled}
 			(EE)
@@ -185,72 +255,92 @@
 	</Button>
 {/snippet}
 
-{#if selectedJobStepType === 'single'}
-	{#if !flowPath}
-		{@render singleRestartButton()}
-	{:else}
-		<Popover
-			floatingConfig={{ strategy: 'absolute', placement: 'bottom-start' }}
-			disablePopup={!flowPath}
-			on:openChange={(e) => {
-				if (e.detail) loadFlowVersions()
-			}}
-		>
-			{#snippet trigger()}
-				{@render singleRestartButton()}
-			{/snippet}
-			{#snippet content()}
-				<div class="flex flex-col gap-4 text-primary p-4 w-80">
-					{@render flowVersionSelector()}
-
-					<Button variant="accent" onClick={handleRestart}>Restart</Button>
-				</div>
-			{/snippet}
-		</Popover>
-	{/if}
+{#if !needsPopup}
+	{@render restartTriggerButton(true)}
 {:else}
 	<Popover
 		floatingConfig={{ strategy: 'absolute', placement: 'bottom-start' }}
+		disablePopup={!needsPopup}
 		on:openChange={(e) => {
-			if (e.detail) loadFlowVersions()
+			if (e.detail) {
+				loadFlowVersions()
+				resetEditsFromProps()
+			}
 		}}
 	>
 		{#snippet trigger()}
-			<Button
-				title={`Re-start this flow from step ${displayStepId} (included).${enterpriseOnly ? ' This is a feature only available in enterprise edition.' : ''}`}
-				{variant}
-				{unifiedSize}
-				{disabled}
-				startIcon={{ icon: RefreshCw }}
-				nonCaptureEvent={true}
-			>
-				Re-start from
-				<Badge baseClass="ml-1" color="indigo">
-					{displayStepId}
-				</Badge>
-				{#if enterpriseOnly && disabled}
-					(EE)
-				{/if}
-			</Button>
+			{@render restartTriggerButton(selectedJobStepType === 'single')}
 		{/snippet}
 		{#snippet content()}
 			<div class="flex flex-col gap-4 text-primary p-4 w-80">
-				<label>
-					<div class="pb-1 text-xs font-semibold text-emphasis"
-						>{selectedJobStepType == 'forloop' ? 'From iteration #' : 'From branch'}</div
-					>
-					<div class="flex w-full gap-2">
-						{#if selectedJobStepType === 'forloop'}
-							<input type="number" min="0" bind:value={branchOrIterationN} class="!w-32 grow" />
-						{:else}
+				{#if selectedJobStepType === 'forloop'}
+					{@const topCount = iterationCounts?.[selectedJobStep] ?? 0}
+					<label>
+						<div class="pb-1 text-xs font-semibold text-emphasis">From iteration #</div>
+						<div class="flex w-full gap-2">
+							{#if topCount > 0}
+								<select bind:value={branchOrIterationN} class="!w-32 grow">
+									{#each Array.from({ length: topCount }, (_, i) => i) as i (i)}
+										<option value={i}>{i + 1}</option>
+									{/each}
+								</select>
+							{:else}
+								<input type="number" min="0" bind:value={branchOrIterationN} class="!w-32 grow" />
+							{/if}
+						</div>
+					</label>
+				{:else if selectedJobStepType === 'branchall'}
+					<label>
+						<div class="pb-1 text-xs font-semibold text-emphasis">From branch</div>
+						<div class="flex w-full gap-2">
 							<select bind:value={branchOrIterationN} class="!w-32 grow">
 								{#each restartBranchNames as [branchIdx, branchName] (branchIdx)}
 									<option value={branchIdx}>{branchName}</option>
 								{/each}
 							</select>
-						{/if}
-					</div>
-				</label>
+						</div>
+					</label>
+				{/if}
+
+				{#each iterationFields as field (field.key)}
+					{@const count = iterationCounts?.[field.label] ?? 0}
+					<label>
+						<div class="pb-1 text-xs font-semibold text-emphasis">
+							From iteration # of <code class="text-xs">{field.label}</code>
+						</div>
+						<div class="flex w-full gap-2">
+							{#if count > 0}
+								<select
+									value={field.value}
+									onchange={(e) => {
+										const v = parseInt((e.target as HTMLSelectElement).value, 10)
+										if (!Number.isNaN(v)) {
+											iterationEdits = { ...iterationEdits, [field.key]: v }
+										}
+									}}
+									class="!w-32 grow"
+								>
+									{#each Array.from({ length: count }, (_, i) => i) as i (i)}
+										<option value={i}>{i + 1}</option>
+									{/each}
+								</select>
+							{:else}
+								<input
+									type="number"
+									min="0"
+									value={field.value}
+									oninput={(e) => {
+										const v = parseInt((e.target as HTMLInputElement).value, 10)
+										if (!Number.isNaN(v)) {
+											iterationEdits = { ...iterationEdits, [field.key]: v }
+										}
+									}}
+									class="!w-32 grow"
+								/>
+							{/if}
+						</div>
+					</label>
+				{/each}
 
 				{#if flowPath}
 					{@render flowVersionSelector()}

--- a/frontend/src/lib/components/FlowRestartButton.svelte
+++ b/frontend/src/lib/components/FlowRestartButton.svelte
@@ -55,6 +55,12 @@
 	}: Props = $props()
 
 	const isNested = $derived((nestedPath?.length ?? 0) > 0)
+	// Inline-expanded subflow steps come in as `subflow:A:B:leaf` — show only `leaf`.
+	const displayStepId = $derived(
+		isNested && nestedPath && nestedPath.length > 0
+			? nestedPath[nestedPath.length - 1].step_id
+			: selectedJobStep
+	)
 
 	// Sentinel value meaning "use the same version as the original run" (backend receives undefined)
 	const RUN_VERSION_SENTINEL = -1
@@ -157,7 +163,7 @@
 {/snippet}
 {#snippet singleRestartButton()}
 	<Button
-		title={`Re-start this flow from step ${selectedJobStep} (included).${enterpriseOnly ? ' This is a feature only available in enterprise edition.' : ''}`}
+		title={`Re-start this flow from step ${displayStepId} (included).${enterpriseOnly ? ' This is a feature only available in enterprise edition.' : ''}`}
 		{variant}
 		{unifiedSize}
 		{disabled}
@@ -211,7 +217,7 @@
 	>
 		{#snippet trigger()}
 			<Button
-				title={`Re-start this flow from step ${selectedJobStep} (included).${enterpriseOnly ? ' This is a feature only available in enterprise edition.' : ''}`}
+				title={`Re-start this flow from step ${displayStepId} (included).${enterpriseOnly ? ' This is a feature only available in enterprise edition.' : ''}`}
 				{variant}
 				{unifiedSize}
 				{disabled}
@@ -220,7 +226,7 @@
 			>
 				Re-start from
 				<Badge baseClass="ml-1" color="indigo">
-					{selectedJobStep}
+					{displayStepId}
 				</Badge>
 				{#if enterpriseOnly && disabled}
 					(EE)

--- a/frontend/src/lib/components/FlowRestartButton.svelte
+++ b/frontend/src/lib/components/FlowRestartButton.svelte
@@ -18,6 +18,18 @@
 		enterpriseOnly?: boolean
 		variant?: 'default' | 'accent'
 		unifiedSize?: 'xs' | 'sm' | 'md' | 'lg'
+		/**
+		 * For nested-step restarts: path of ancestor containers from the top-level
+		 * step down to the leaf. When provided, the LAST entry's step_id is the
+		 * actual restart point and `selectedJobStep` (the leaf shown in the UI) is
+		 * informational only — the request is built from `nestedTopStepId`,
+		 * `nestedTopBranchOrIterationN` and `nestedPath`.
+		 */
+		nestedPath?: Array<{ step_id: string; branch_or_iteration_n?: number }>
+		/** Top-level container step id (only used when nestedPath is set) */
+		nestedTopStepId?: string
+		/** Top-level container branch_or_iteration_n (only used when nestedPath is set) */
+		nestedTopBranchOrIterationN?: number
 		/** Called when flow is restarted. If not provided, will navigate to the new run using goto (requires SvelteKit) */
 		onRestart?: (stepId: string, branchOrIterationN: number, flowVersion?: number) => void
 		/** Called when flow restart completes with the new job ID. Used for navigation in non-SvelteKit contexts */
@@ -35,9 +47,14 @@
 		enterpriseOnly = false,
 		variant = 'default',
 		unifiedSize = 'md',
+		nestedPath = undefined,
+		nestedTopStepId = undefined,
+		nestedTopBranchOrIterationN = undefined,
 		onRestart,
 		onRestartComplete
 	}: Props = $props()
+
+	const isNested = $derived((nestedPath?.length ?? 0) > 0)
 
 	// Sentinel value meaning "use the same version as the original run" (backend receives undefined)
 	const RUN_VERSION_SENTINEL = -1
@@ -50,14 +67,22 @@
 	let runVersionInList: boolean = $state(false)
 
 	async function restartFlow(stepId: string, branchOrIterationN: number, flowVersion?: number) {
+		const requestBody = isNested
+			? {
+					step_id: nestedTopStepId!,
+					branch_or_iteration_n: nestedTopBranchOrIterationN,
+					flow_version: flowVersion,
+					nested_path: nestedPath
+				}
+			: {
+					step_id: stepId,
+					branch_or_iteration_n: branchOrIterationN,
+					flow_version: flowVersion
+				}
 		let run = await JobService.restartFlowAtStep({
 			workspace: $workspaceStore!,
 			id: jobId,
-			requestBody: {
-				step_id: stepId,
-				branch_or_iteration_n: branchOrIterationN,
-				flow_version: flowVersion
-			}
+			requestBody
 		})
 		onRestartComplete?.(run)
 	}
@@ -161,7 +186,9 @@
 		<Popover
 			floatingConfig={{ strategy: 'absolute', placement: 'bottom-start' }}
 			disablePopup={!flowPath}
-			on:openChange={(e) => { if (e.detail) loadFlowVersions() }}
+			on:openChange={(e) => {
+				if (e.detail) loadFlowVersions()
+			}}
 		>
 			{#snippet trigger()}
 				{@render singleRestartButton()}
@@ -178,7 +205,9 @@
 {:else}
 	<Popover
 		floatingConfig={{ strategy: 'absolute', placement: 'bottom-start' }}
-		on:openChange={(e) => { if (e.detail) loadFlowVersions() }}
+		on:openChange={(e) => {
+			if (e.detail) loadFlowVersions()
+		}}
 	>
 		{#snippet trigger()}
 			<Button

--- a/frontend/src/lib/components/FlowStatusViewer.svelte
+++ b/frontend/src/lib/components/FlowStatusViewer.svelte
@@ -59,7 +59,11 @@
 		isOwner = $bindable(false),
 		wideResults = false,
 		localModuleStates = $bindable({}),
-		expandedSubflows = $bindable({}),
+		// `$bindable()` without default per CLAUDE.md's banned-pattern guidance.
+		// Inner owns the cache; outer just relays the binding. Callers always
+		// initialize a `$state({})` and bind it, so the value is never actually
+		// undefined at runtime.
+		expandedSubflows = $bindable(),
 		localDurationStatuses = $bindable({}),
 		job = $bindable(undefined),
 		render = true,
@@ -103,6 +107,10 @@
 			for (let key in localModuleStates) delete flowState[key]
 			localDurationStatuses = {}
 			localModuleStates = {}
+			// Reset the subflow definition cache too — a new run can reference
+			// different subflow versions; stale entries would confuse nested
+			// restart path-finding.
+			expandedSubflows = {}
 		}
 	}
 

--- a/frontend/src/lib/components/FlowStatusViewer.svelte
+++ b/frontend/src/lib/components/FlowStatusViewer.svelte
@@ -5,7 +5,7 @@
 	import type { DurationStatus, FlowStatusViewerContext, GraphModuleState } from './graph'
 	import { isOwner as loadIsOwner, type StateStore } from '$lib/utils'
 	import { userStore, workspaceStore } from '$lib/stores'
-	import type { CompletedJob, FlowNote, FlowValue, Job } from '$lib/gen'
+	import type { CompletedJob, FlowModule, FlowNote, FlowValue, Job } from '$lib/gen'
 
 	interface Props {
 		jobId: string
@@ -23,6 +23,11 @@
 		isOwner?: boolean
 		wideResults?: boolean
 		localModuleStates?: Record<string, GraphModuleState>
+		/** Cached subflow definitions, keyed by graph node id (subflow step id, with
+		 * `subflow:` prefix for nested subflows). Populated as the user expands a
+		 * subflow in the graph. Bindable so callers can use it to walk inside
+		 * subflows (e.g. for nested-restart path-finding). */
+		expandedSubflows?: Record<string, { modules: FlowModule[]; groups?: any[] }>
 		localDurationStatuses?: Record<string, DurationStatus>
 		job?: Job | undefined
 		render?: boolean
@@ -54,6 +59,7 @@
 		isOwner = $bindable(false),
 		wideResults = false,
 		localModuleStates = $bindable({}),
+		expandedSubflows = $bindable({}),
 		localDurationStatuses = $bindable({}),
 		job = $bindable(undefined),
 		render = true,
@@ -133,6 +139,7 @@
 		}}
 		globalModuleStates={[]}
 		bind:localModuleStates
+		bind:expandedSubflows
 		bind:selectedNode={selectedJobStep}
 		bind:localDurationStatuses
 		{onStart}

--- a/frontend/src/lib/components/FlowStatusViewer.svelte
+++ b/frontend/src/lib/components/FlowStatusViewer.svelte
@@ -59,11 +59,15 @@
 		isOwner = $bindable(false),
 		wideResults = false,
 		localModuleStates = $bindable({}),
-		// `$bindable()` without default per CLAUDE.md's banned-pattern guidance.
-		// Inner owns the cache; outer just relays the binding. Callers always
-		// initialize a `$state({})` and bind it, so the value is never actually
-		// undefined at runtime.
-		expandedSubflows = $bindable(),
+		// `$bindable({})` is the right shape for this prop despite CLAUDE.md's
+		// general guidance against `$bindable(default_value)`: that rule targets
+		// props where `undefined` has distinct semantics from "empty default".
+		// For a Map-typed cache populated by the inner component, callers that
+		// don't bind it should still see a usable empty map (the inner writes to
+		// it when the user expands a subflow). Without the `{}` default, those
+		// callers would crash at write time. Same reasoning applies to the
+		// pre-existing `localModuleStates`/`localDurationStatuses` bindables.
+		expandedSubflows = $bindable({}),
 		localDurationStatuses = $bindable({}),
 		job = $bindable(undefined),
 		render = true,

--- a/frontend/src/lib/components/FlowStatusViewerInner.svelte
+++ b/frontend/src/lib/components/FlowStatusViewerInner.svelte
@@ -111,6 +111,7 @@
 		job?: (Job & { result_stream?: string }) | undefined
 		rightColumnSelect?: 'timeline' | 'node_status' | 'node_definition' | 'user_states' | 'tracing'
 		localModuleStates?: Record<string, GraphModuleState>
+		expandedSubflows?: Record<string, { modules: FlowModule[]; groups?: any[] }>
 		localDurationStatuses?: Record<string, DurationStatus>
 		onResultStreamUpdate?: ({
 			jobId,
@@ -168,6 +169,7 @@
 		job = $bindable(undefined),
 		rightColumnSelect = $bindable('timeline'),
 		localModuleStates = $bindable({}),
+		expandedSubflows = $bindable({}),
 		localDurationStatuses = $bindable({}),
 		customUi,
 		onResultStreamUpdate = undefined,
@@ -265,8 +267,6 @@
 
 	let retry_selected = $state('')
 	let timeout: number | undefined = undefined
-
-	let expandedSubflows: Record<string, { modules: FlowModule[]; groups?: any[] }> = $state({})
 
 	let selectionManager = new SelectionManager()
 

--- a/frontend/src/lib/components/restartFromStepPath.ts
+++ b/frontend/src/lib/components/restartFromStepPath.ts
@@ -7,6 +7,9 @@ export type AncestorEntry = {
 	type: ContainerType
 	/** For BranchOne: -1 means default branch, 0..N-1 means branches[i] */
 	branchIndex?: number
+	/** True for parallel ForLoop / BranchAll — backend rejects nested restart
+	 * inside parallel containers, so the caller should hide the restart button. */
+	parallel?: boolean
 }
 
 export type StepPath = {
@@ -34,7 +37,10 @@ export function findStepPath(modules: FlowModule[], targetId: string): StepPath 
 			if (sub) {
 				return {
 					target: sub.target,
-					ancestors: [{ stepId: mod.id, type: value.type }, ...sub.ancestors]
+					ancestors: [
+						{ stepId: mod.id, type: value.type, parallel: value.parallel === true },
+						...sub.ancestors
+					]
 				}
 			}
 		} else if (value.type === 'branchone') {
@@ -57,7 +63,15 @@ export function findStepPath(modules: FlowModule[], targetId: string): StepPath 
 				if (sub) {
 					return {
 						target: sub.target,
-						ancestors: [{ stepId: mod.id, type: 'branchall', branchIndex: i }, ...sub.ancestors]
+						ancestors: [
+							{
+								stepId: mod.id,
+								type: 'branchall',
+								branchIndex: i,
+								parallel: value.parallel === true
+							},
+							...sub.ancestors
+						]
 					}
 				}
 			}

--- a/frontend/src/lib/components/restartFromStepPath.ts
+++ b/frontend/src/lib/components/restartFromStepPath.ts
@@ -1,0 +1,67 @@
+import type { FlowModule } from '$lib/gen'
+
+export type ContainerType = 'branchone' | 'forloopflow' | 'flow' | 'whileloopflow' | 'branchall'
+
+export type AncestorEntry = {
+	stepId: string
+	type: ContainerType
+	/** For BranchOne: -1 means default branch, 0..N-1 means branches[i] */
+	branchIndex?: number
+}
+
+export type StepPath = {
+	target: FlowModule
+	ancestors: AncestorEntry[]
+}
+
+/**
+ * Walks the flow value tree to locate `targetId`. Returns the target module and
+ * the chain of containers from the root down to (but not including) the target.
+ * Returns `undefined` if the step is not found in this flow value.
+ *
+ * Subflow boundaries are NOT crossed: if the target sits inside a `Flow{path}`
+ * step's referenced flow, this returns `undefined` because we don't have that
+ * subflow's value here.
+ */
+export function findStepPath(modules: FlowModule[], targetId: string): StepPath | undefined {
+	for (const mod of modules) {
+		if (mod.id === targetId) {
+			return { target: mod, ancestors: [] }
+		}
+		const value = mod.value
+		if (value.type === 'forloopflow' || value.type === 'whileloopflow') {
+			const sub = findStepPath(value.modules, targetId)
+			if (sub) {
+				return {
+					target: sub.target,
+					ancestors: [{ stepId: mod.id, type: value.type }, ...sub.ancestors]
+				}
+			}
+		} else if (value.type === 'branchone') {
+			const allBranches: { idx: number; modules: FlowModule[] }[] = [
+				{ idx: -1, modules: value.default }
+			]
+			value.branches.forEach((b, i) => allBranches.push({ idx: i, modules: b.modules }))
+			for (const { idx, modules: bm } of allBranches) {
+				const sub = findStepPath(bm, targetId)
+				if (sub) {
+					return {
+						target: sub.target,
+						ancestors: [{ stepId: mod.id, type: 'branchone', branchIndex: idx }, ...sub.ancestors]
+					}
+				}
+			}
+		} else if (value.type === 'branchall') {
+			for (let i = 0; i < value.branches.length; i++) {
+				const sub = findStepPath(value.branches[i].modules, targetId)
+				if (sub) {
+					return {
+						target: sub.target,
+						ancestors: [{ stepId: mod.id, type: 'branchall', branchIndex: i }, ...sub.ancestors]
+					}
+				}
+			}
+		}
+	}
+	return undefined
+}

--- a/frontend/src/lib/components/restartFromStepPath.ts
+++ b/frontend/src/lib/components/restartFromStepPath.ts
@@ -65,3 +65,31 @@ export function findStepPath(modules: FlowModule[], targetId: string): StepPath 
 	}
 	return undefined
 }
+
+/**
+ * Inline-expanded subflows produce step IDs like
+ * `subflow:<outer_subflow_step>:[<nested_subflow_step>:...]<leaf>`. Each `:`-separated
+ * segment after the `subflow:` marker is a step ID; the last segment is the leaf
+ * (the user's selected step) and the preceding segments are subflow steps along
+ * the way (each one a `Flow{path}` module).
+ *
+ * Returns the parsed segments + leaf, or `undefined` if `id` is not a subflow-prefixed
+ * step.
+ */
+export function parseExpandedSubflowId(
+	id: string
+): { subflowSteps: string[]; leaf: string } | undefined {
+	if (!id.startsWith('subflow:')) {
+		return undefined
+	}
+	const parts = id
+		.slice('subflow:'.length)
+		.split(':')
+		.filter((p) => p.length > 0)
+	if (parts.length < 2) {
+		return undefined
+	}
+	const leaf = parts[parts.length - 1]
+	const subflowSteps = parts.slice(0, -1)
+	return { subflowSteps, leaf }
+}

--- a/frontend/src/lib/components/useNestedRestartState.svelte.ts
+++ b/frontend/src/lib/components/useNestedRestartState.svelte.ts
@@ -1,4 +1,4 @@
-import type { Job } from '$lib/gen'
+import type { FlowModule, Job } from '$lib/gen'
 import type { GraphModuleState } from './graph'
 import { findStepPath, parseExpandedSubflowId } from './restartFromStepPath'
 import { emptyString } from '$lib/utils'
@@ -8,7 +8,8 @@ export type NestedRestartStep = { step_id: string; branch_or_iteration_n?: numbe
 /**
  * Reactive state shared by the run page and the editor's flow preview to drive
  * the "restart flow at step" UI. Given the currently selected step, the
- * completed flow job, and the graph's per-module display state, derives:
+ * completed flow job, the graph's per-module display state, and any expanded
+ * subflow definitions, derives:
  *
  *   - `selectedJobStepIsTopLevel` — whether the selected step appears in the
  *     parent flow's top-level `flow_status.modules`
@@ -23,9 +24,9 @@ export type NestedRestartStep = { step_id: string; branch_or_iteration_n?: numbe
  *     step is nested (subflow expansion or BranchOne / sequential ForLoop)
  *   - `topLevelLoopIteration` — when the selected step IS a top-level ForLoop,
  *     the iteration the user is currently viewing (pre-fills the popup input)
- *   - `iterationCounts` — map of ForLoop step id → number of recorded
- *     iterations, so the popup can render an iteration `<select>` matching
- *     the graph's tabs instead of a free-form number input
+ *   - `iterationCounts` — map of step id → number of recorded iterations,
+ *     so the popup can render an iteration `<select>` matching the graph's tabs
+ *     instead of a free-form number input
  *
  * Inputs are passed as getters so the composable stays reactive in either
  * caller's signal graph.
@@ -34,6 +35,11 @@ export function useNestedRestartState(opts: {
 	selectedJobStep: () => string | undefined
 	job: () => Job | undefined
 	graphModuleStates: () => Record<string, GraphModuleState>
+	/** Subflow definitions cached when the user expands a subflow in the graph,
+	 * keyed by the graph node id (i.e. the prefixed `subflow:...:<step_id>` for
+	 * nested subflows). Lets us walk inside subflows when building the nested
+	 * restart path. */
+	expandedSubflows?: () => Record<string, { modules: FlowModule[] }>
 }) {
 	let selectedJobStepIsTopLevel: boolean | undefined = $state(undefined)
 	let selectedJobStepType: 'single' | 'forloop' | 'branchall' = $state('single')
@@ -47,6 +53,7 @@ export function useNestedRestartState(opts: {
 		const selectedJobStep = opts.selectedJobStep()
 		const job = opts.job()
 		const graphModuleStates = opts.graphModuleStates()
+		const expandedSubflows = opts.expandedSubflows?.() ?? {}
 
 		nestedRestartTopStepId = undefined
 		nestedRestartTopBranchOrIterationN = undefined
@@ -78,16 +85,67 @@ export function useNestedRestartState(opts: {
 
 		// Inline-expanded subflow: id is `subflow:outerStep:[innerSubflow:...]<leaf>`.
 		// The graph adds the `subflow:` prefix only for subflow expansions, so each
-		// segment is a `Flow{path}` step. The backend will validate that the leaf
-		// exists at that path.
+		// segment is a `Flow{path}` step. We walk the chain and, at the deepest
+		// subflow, recurse into its cached modules to detect BranchOne / ForLoop
+		// ancestors of the leaf so the chain captures locked branches and
+		// iteration indices for those too.
 		const subflowParse = parseExpandedSubflowId(selectedJobStep)
 		if (subflowParse && job.raw_flow?.modules) {
 			const top = job.raw_flow.modules.find((m) => m.id === subflowParse.subflowSteps[0])
 			if (top && top.value.type === 'flow') {
 				const innerPath: NestedRestartStep[] = []
+				// Intermediate subflow boundaries: each is itself a Flow{path}, no
+				// branch_or_iteration_n applies.
 				for (const seg of subflowParse.subflowSteps.slice(1)) {
 					innerPath.push({ step_id: seg })
 				}
+
+				// Look up the deepest subflow's modules in expandedSubflows. The graph
+				// stores them under the prefixed key (the graph node id used at that
+				// nesting level).
+				const deepestKey =
+					subflowParse.subflowSteps.length === 1
+						? subflowParse.subflowSteps[0]
+						: 'subflow:' + subflowParse.subflowSteps.join(':')
+				const deepestModules = expandedSubflows[deepestKey]?.modules
+
+				if (deepestModules) {
+					const path = findStepPath(deepestModules, subflowParse.leaf)
+					if (path) {
+						const blocked = path.ancestors.some(
+							(a) => a.type === 'branchall' || a.type === 'whileloopflow'
+						)
+						if (!blocked) {
+							// Inside the subflow, the graph state for ForLoop ancestors
+							// is keyed by the prefixed graph id. Build that key here so
+							// `selectedForloopIndex` lookups land on the right entry.
+							const subflowPrefix = 'subflow:' + subflowParse.subflowSteps.join(':') + ':'
+							const iterationFor = (stepId: string): number =>
+								graphModuleStates[subflowPrefix + stepId]?.selectedForloopIndex ?? 0
+							for (const a of path.ancestors) {
+								const entry: NestedRestartStep = { step_id: a.stepId }
+								if (a.type === 'forloopflow') {
+									entry.branch_or_iteration_n = iterationFor(a.stepId)
+								}
+								innerPath.push(entry)
+							}
+							const leafEntry: NestedRestartStep = { step_id: subflowParse.leaf }
+							if (path.target.value.type === 'forloopflow') {
+								leafEntry.branch_or_iteration_n = iterationFor(subflowParse.leaf)
+							}
+							innerPath.push(leafEntry)
+							nestedRestartTopStepId = top.id
+							nestedRestartPath = innerPath
+							nestedRestartSupported = true
+							return
+						}
+					}
+				}
+
+				// Fallback: subflow's modules not yet loaded (user clicked a step
+				// without expanding the subflow first), or leaf not found / blocked.
+				// Send a flat path; the backend will reject if the leaf is nested
+				// inside an unsupported container.
 				innerPath.push({ step_id: subflowParse.leaf })
 				nestedRestartTopStepId = top.id
 				nestedRestartPath = innerPath
@@ -142,12 +200,20 @@ export function useNestedRestartState(opts: {
 		return opts.graphModuleStates()[sel]?.selectedForloopIndex
 	})
 
+	// Iteration counts indexed by the step id used in `nestedRestartPath`. For
+	// regular nesting that's the bare `step_id`; for steps inside expanded
+	// subflows we ALSO index by the leaf segment of the prefixed graph id (e.g.
+	// `subflow:h:loop_1` → also indexed at `loop_1`) so the popup can find the
+	// count regardless of which path produced the field.
 	const iterationCounts = $derived.by((): Record<string, number> => {
 		const out: Record<string, number> = {}
 		for (const [id, state] of Object.entries(opts.graphModuleStates())) {
 			const n = state.flow_jobs?.length
-			if (typeof n === 'number' && n > 0) {
-				out[id] = n
+			if (typeof n !== 'number' || n <= 0) continue
+			out[id] = n
+			const lastColon = id.lastIndexOf(':')
+			if (lastColon >= 0) {
+				out[id.slice(lastColon + 1)] = n
 			}
 		}
 		return out

--- a/frontend/src/lib/components/useNestedRestartState.svelte.ts
+++ b/frontend/src/lib/components/useNestedRestartState.svelte.ts
@@ -12,18 +12,20 @@ export type NestedRestartStep = { step_id: string; branch_or_iteration_n?: numbe
  * clicked a step inside an `else` branch the original run didn't take, the
  * step never executed — restart there is impossible.
  *
- * Only verifiable for top-level BranchOne ancestors (we have direct access to
- * `job.flow_status.modules`). For deeper BranchOne ancestors (e.g. nested
- * inside a ForLoop iteration) the relevant `flow_status` lives on a child job
- * we don't fetch here — be permissive and let the backend reject if needed,
- * rather than hide the button for valid cases.
+ * Three states for the lookup:
+ *   - `status === undefined`: the BranchOne isn't at the parent's top level, so
+ *     it lives on a child job we don't fetch here (e.g. nested inside a ForLoop
+ *     iteration). Permissive fallback — let the backend reject if needed.
+ *   - `status` defined but `chosen === undefined`: the BranchOne IS at the top
+ *     level but has no chosen branch (never executed / skipped / still
+ *     waiting). The leaf can't have run either, so reject.
+ *   - both defined: compare against `branchIndex`.
  */
 function branchOneAncestorMatchesOriginal(job: Job, ancestor: AncestorEntry): boolean {
 	if (ancestor.type !== 'branchone') return true
 	const status = job.flow_status?.modules?.find((m) => m.id === ancestor.stepId)
 	const chosen = status?.branch_chosen
-	// Status not reachable at this level (deeper BranchOne) — permissive fallback.
-	if (!chosen) return true
+	if (!chosen) return status === undefined
 	const taken = chosen.type === 'default' ? -1 : (chosen.branch ?? -1)
 	return ancestor.branchIndex === taken
 }

--- a/frontend/src/lib/components/useNestedRestartState.svelte.ts
+++ b/frontend/src/lib/components/useNestedRestartState.svelte.ts
@@ -1,9 +1,31 @@
 import type { FlowModule, Job } from '$lib/gen'
 import type { GraphModuleState } from './graph'
-import { findStepPath, parseExpandedSubflowId } from './restartFromStepPath'
+import { findStepPath, parseExpandedSubflowId, type AncestorEntry } from './restartFromStepPath'
 import { emptyString } from '$lib/utils'
 
 export type NestedRestartStep = { step_id: string; branch_or_iteration_n?: number }
+
+/**
+ * Returns true when the BranchOne ancestor's path branch (the one containing the
+ * selected leaf, encoded as `branchIndex` where -1 means default and 0..N-1
+ * means `branches[i]`) is the same branch the original run took. If the user
+ * clicked a step inside an `else` branch the original run didn't take, the
+ * step never executed — restart there is impossible (the resolver would either
+ * not find the step or find it in a non-Success state). We hide the button
+ * preemptively to avoid a confusing backend error.
+ *
+ * Only checks parent-level BranchOne ancestors (we have direct access to
+ * `job.flow_status` for those). Inside-subflow BranchOne mismatches still
+ * reach the backend; it errors with a clear "step not found" message.
+ */
+function branchOneAncestorMatchesOriginal(job: Job, ancestor: AncestorEntry): boolean {
+	if (ancestor.type !== 'branchone') return true
+	const status = job.flow_status?.modules?.find((m) => m.id === ancestor.stepId)
+	const chosen = status?.branch_chosen
+	if (!chosen) return false
+	const taken = chosen.type === 'default' ? -1 : (chosen.branch ?? -1)
+	return ancestor.branchIndex === taken
+}
 
 /**
  * Reactive state shared by the run page and the editor's flow preview to drive
@@ -112,8 +134,12 @@ export function useNestedRestartState(opts: {
 				if (deepestModules) {
 					const path = findStepPath(deepestModules, subflowParse.leaf)
 					if (path) {
+						// Same gating as the parent-flow case, minus the BranchOne
+						// branch-mismatch check (subflow's flow_status isn't directly
+						// reachable here; backend will still reject if the branch
+						// wasn't taken). Parallel and unsupported containers are checked.
 						const blocked = path.ancestors.some(
-							(a) => a.type === 'branchall' || a.type === 'whileloopflow'
+							(a) => a.type === 'branchall' || a.type === 'whileloopflow' || a.parallel === true
 						)
 						if (!blocked) {
 							// Inside the subflow, the graph state for ForLoop ancestors
@@ -156,11 +182,19 @@ export function useNestedRestartState(opts: {
 
 		// BranchOne / sequential ForLoop within the parent's own flow_value. Walk
 		// the tree to find the path; supported when ancestors are BranchOne /
-		// sequential ForLoop only.
+		// sequential ForLoop only — and only when each BranchOne ancestor's chosen
+		// branch in the original run actually contains the leaf, otherwise the
+		// step never executed and the backend would error.
 		if (!job.raw_flow?.modules) return
 		const path = findStepPath(job.raw_flow.modules, selectedJobStep)
 		if (!path || path.ancestors.length === 0) return
-		const blocked = path.ancestors.some((a) => a.type === 'branchall' || a.type === 'whileloopflow')
+		const blocked = path.ancestors.some(
+			(a) =>
+				a.type === 'branchall' ||
+				a.type === 'whileloopflow' ||
+				a.parallel === true ||
+				(a.type === 'branchone' && !branchOneAncestorMatchesOriginal(job, a))
+		)
 		if (blocked) return
 
 		// For each ForLoop ancestor, default to the user's currently-open iteration
@@ -198,6 +232,27 @@ export function useNestedRestartState(opts: {
 		if (!sel) return undefined
 		if ((selectedJobStepType as string) !== 'forloop') return undefined
 		return opts.graphModuleStates()[sel]?.selectedForloopIndex
+	})
+
+	// `selectedJobStepIsTopLevel` answers "is this a top-level module structurally";
+	// `topLevelRestartable` answers "AND should the restart button show". The
+	// difference: parallel ForLoop / parallel BranchAll at the top level are
+	// rejected by the backend, so we hide the button preemptively.
+	const topLevelRestartable = $derived.by((): boolean => {
+		if (!selectedJobStepIsTopLevel) return false
+		const sel = opts.selectedJobStep()
+		const job = opts.job()
+		if (!sel || !job?.raw_flow?.modules) return false
+		const mod = job.raw_flow.modules.find((m) => m.id === sel)
+		if (!mod) return false
+		const v = mod.value
+		if (
+			(v.type === 'forloopflow' || v.type === 'branchall' || v.type === 'whileloopflow') &&
+			(v as { parallel?: boolean }).parallel === true
+		) {
+			return false
+		}
+		return true
 	})
 
 	// Iteration counts indexed by the step id used in `nestedRestartPath`. For
@@ -243,6 +298,9 @@ export function useNestedRestartState(opts: {
 		},
 		get topLevelLoopIteration() {
 			return topLevelLoopIteration
+		},
+		get topLevelRestartable() {
+			return topLevelRestartable
 		},
 		get iterationCounts() {
 			return iterationCounts

--- a/frontend/src/lib/components/useNestedRestartState.svelte.ts
+++ b/frontend/src/lib/components/useNestedRestartState.svelte.ts
@@ -10,19 +10,20 @@ export type NestedRestartStep = { step_id: string; branch_or_iteration_n?: numbe
  * selected leaf, encoded as `branchIndex` where -1 means default and 0..N-1
  * means `branches[i]`) is the same branch the original run took. If the user
  * clicked a step inside an `else` branch the original run didn't take, the
- * step never executed — restart there is impossible (the resolver would either
- * not find the step or find it in a non-Success state). We hide the button
- * preemptively to avoid a confusing backend error.
+ * step never executed — restart there is impossible.
  *
- * Only checks parent-level BranchOne ancestors (we have direct access to
- * `job.flow_status` for those). Inside-subflow BranchOne mismatches still
- * reach the backend; it errors with a clear "step not found" message.
+ * Only verifiable for top-level BranchOne ancestors (we have direct access to
+ * `job.flow_status.modules`). For deeper BranchOne ancestors (e.g. nested
+ * inside a ForLoop iteration) the relevant `flow_status` lives on a child job
+ * we don't fetch here — be permissive and let the backend reject if needed,
+ * rather than hide the button for valid cases.
  */
 function branchOneAncestorMatchesOriginal(job: Job, ancestor: AncestorEntry): boolean {
 	if (ancestor.type !== 'branchone') return true
 	const status = job.flow_status?.modules?.find((m) => m.id === ancestor.stepId)
 	const chosen = status?.branch_chosen
-	if (!chosen) return false
+	// Status not reachable at this level (deeper BranchOne) — permissive fallback.
+	if (!chosen) return true
 	const taken = chosen.type === 'default' ? -1 : (chosen.branch ?? -1)
 	return ancestor.branchIndex === taken
 }
@@ -82,6 +83,7 @@ export function useNestedRestartState(opts: {
 		nestedRestartPath = undefined
 		nestedRestartSupported = false
 		restartBranchNames = []
+		selectedJobStepIsTopLevel = undefined
 
 		if (selectedJobStep === undefined || job?.flow_status?.modules === undefined) {
 			return
@@ -260,6 +262,13 @@ export function useNestedRestartState(opts: {
 	// subflows we ALSO index by the leaf segment of the prefixed graph id (e.g.
 	// `subflow:h:loop_1` → also indexed at `loop_1`) so the popup can find the
 	// count regardless of which path produced the field.
+	//
+	// Known caveat: if the same step id appears at multiple levels (e.g. a
+	// top-level `loop_1` AND a `loop_1` inside a subflow), the last-writer-wins
+	// here may show the wrong option count. The submitted value is still 0-based
+	// and the backend validates it, so a wrong-count display only affects how
+	// many options the `<select>` shows. Step ids are globally unique within a
+	// single flow value, so the collision only happens across subflow boundaries.
 	const iterationCounts = $derived.by((): Record<string, number> => {
 		const out: Record<string, number> = {}
 		for (const [id, state] of Object.entries(opts.graphModuleStates())) {

--- a/frontend/src/lib/components/useNestedRestartState.svelte.ts
+++ b/frontend/src/lib/components/useNestedRestartState.svelte.ts
@@ -1,0 +1,185 @@
+import type { Job } from '$lib/gen'
+import type { GraphModuleState } from './graph'
+import { findStepPath, parseExpandedSubflowId } from './restartFromStepPath'
+import { emptyString } from '$lib/utils'
+
+export type NestedRestartStep = { step_id: string; branch_or_iteration_n?: number }
+
+/**
+ * Reactive state shared by the run page and the editor's flow preview to drive
+ * the "restart flow at step" UI. Given the currently selected step, the
+ * completed flow job, and the graph's per-module display state, derives:
+ *
+ *   - `selectedJobStepIsTopLevel` — whether the selected step appears in the
+ *     parent flow's top-level `flow_status.modules`
+ *   - `selectedJobStepType` — `single` / `forloop` / `branchall`, used by the
+ *     popup to decide which controls to render for the OUTER container
+ *   - `restartBranchNames` — for top-level BranchAll steps, the labels for the
+ *     branch picker
+ *   - `nestedRestartTopStepId` / `nestedRestartTopBranchOrIterationN` /
+ *     `nestedRestartPath` — the API request shape when restarting at a nested
+ *     step (single source of truth for both call sites)
+ *   - `nestedRestartSupported` — gate for showing the button when the selected
+ *     step is nested (subflow expansion or BranchOne / sequential ForLoop)
+ *   - `topLevelLoopIteration` — when the selected step IS a top-level ForLoop,
+ *     the iteration the user is currently viewing (pre-fills the popup input)
+ *   - `iterationCounts` — map of ForLoop step id → number of recorded
+ *     iterations, so the popup can render an iteration `<select>` matching
+ *     the graph's tabs instead of a free-form number input
+ *
+ * Inputs are passed as getters so the composable stays reactive in either
+ * caller's signal graph.
+ */
+export function useNestedRestartState(opts: {
+	selectedJobStep: () => string | undefined
+	job: () => Job | undefined
+	graphModuleStates: () => Record<string, GraphModuleState>
+}) {
+	let selectedJobStepIsTopLevel: boolean | undefined = $state(undefined)
+	let selectedJobStepType: 'single' | 'forloop' | 'branchall' = $state('single')
+	let restartBranchNames: [number, string][] = $state([])
+	let nestedRestartTopStepId: string | undefined = $state(undefined)
+	let nestedRestartTopBranchOrIterationN: number | undefined = $state(undefined)
+	let nestedRestartPath: NestedRestartStep[] | undefined = $state(undefined)
+	let nestedRestartSupported = $state(false)
+
+	$effect(() => {
+		const selectedJobStep = opts.selectedJobStep()
+		const job = opts.job()
+		const graphModuleStates = opts.graphModuleStates()
+
+		nestedRestartTopStepId = undefined
+		nestedRestartTopBranchOrIterationN = undefined
+		nestedRestartPath = undefined
+		nestedRestartSupported = false
+		restartBranchNames = []
+
+		if (selectedJobStep === undefined || job?.flow_status?.modules === undefined) {
+			return
+		}
+
+		selectedJobStepIsTopLevel =
+			job.flow_status.modules.findIndex((m) => m.id === selectedJobStep) >= 0
+		const moduleDefinition = job.raw_flow?.modules.find((m) => m.id === selectedJobStep)
+		if (moduleDefinition?.value.type === 'forloopflow') {
+			selectedJobStepType = 'forloop'
+		} else if (moduleDefinition?.value.type === 'branchall') {
+			selectedJobStepType = 'branchall'
+			const newNames: [number, string][] = []
+			moduleDefinition.value.branches.forEach((branch, idx) => {
+				newNames.push([idx, emptyString(branch.summary) ? `Branch #${idx}` : branch.summary!])
+			})
+			restartBranchNames = newNames
+		} else {
+			selectedJobStepType = 'single'
+		}
+
+		if (selectedJobStepIsTopLevel) return
+
+		// Inline-expanded subflow: id is `subflow:outerStep:[innerSubflow:...]<leaf>`.
+		// The graph adds the `subflow:` prefix only for subflow expansions, so each
+		// segment is a `Flow{path}` step. The backend will validate that the leaf
+		// exists at that path.
+		const subflowParse = parseExpandedSubflowId(selectedJobStep)
+		if (subflowParse && job.raw_flow?.modules) {
+			const top = job.raw_flow.modules.find((m) => m.id === subflowParse.subflowSteps[0])
+			if (top && top.value.type === 'flow') {
+				const innerPath: NestedRestartStep[] = []
+				for (const seg of subflowParse.subflowSteps.slice(1)) {
+					innerPath.push({ step_id: seg })
+				}
+				innerPath.push({ step_id: subflowParse.leaf })
+				nestedRestartTopStepId = top.id
+				nestedRestartPath = innerPath
+				nestedRestartSupported = true
+				return
+			}
+		}
+
+		// BranchOne / sequential ForLoop within the parent's own flow_value. Walk
+		// the tree to find the path; supported when ancestors are BranchOne /
+		// sequential ForLoop only.
+		if (!job.raw_flow?.modules) return
+		const path = findStepPath(job.raw_flow.modules, selectedJobStep)
+		if (!path || path.ancestors.length === 0) return
+		const blocked = path.ancestors.some((a) => a.type === 'branchall' || a.type === 'whileloopflow')
+		if (blocked) return
+
+		// For each ForLoop ancestor, default to the user's currently-open iteration
+		// (`selectedForloopIndex`); fall back to 0. The popup surfaces every value
+		// for confirmation/editing before submit, so we never silently send a guess.
+		const iterationFor = (stepId: string): number =>
+			graphModuleStates[stepId]?.selectedForloopIndex ?? 0
+		const top = path.ancestors[0]
+		const inner = path.ancestors.slice(1)
+		const innerPath: NestedRestartStep[] = []
+		for (const a of inner) {
+			const entry: NestedRestartStep = { step_id: a.stepId }
+			if (a.type === 'forloopflow') {
+				entry.branch_or_iteration_n = iterationFor(a.stepId)
+			}
+			innerPath.push(entry)
+		}
+		// If the SELECTED step is itself a ForLoop, include its iteration too so
+		// the popup exposes a selector for it.
+		const leafEntry: NestedRestartStep = { step_id: selectedJobStep }
+		if (path.target.value.type === 'forloopflow') {
+			leafEntry.branch_or_iteration_n = iterationFor(selectedJobStep)
+		}
+		innerPath.push(leafEntry)
+
+		nestedRestartTopStepId = top.stepId
+		nestedRestartTopBranchOrIterationN =
+			top.type === 'forloopflow' ? iterationFor(top.stepId) : undefined
+		nestedRestartPath = innerPath
+		nestedRestartSupported = true
+	})
+
+	const topLevelLoopIteration = $derived.by((): number | undefined => {
+		const sel = opts.selectedJobStep()
+		if (!sel) return undefined
+		if ((selectedJobStepType as string) !== 'forloop') return undefined
+		return opts.graphModuleStates()[sel]?.selectedForloopIndex
+	})
+
+	const iterationCounts = $derived.by((): Record<string, number> => {
+		const out: Record<string, number> = {}
+		for (const [id, state] of Object.entries(opts.graphModuleStates())) {
+			const n = state.flow_jobs?.length
+			if (typeof n === 'number' && n > 0) {
+				out[id] = n
+			}
+		}
+		return out
+	})
+
+	return {
+		get selectedJobStepIsTopLevel() {
+			return selectedJobStepIsTopLevel
+		},
+		get selectedJobStepType() {
+			return selectedJobStepType
+		},
+		get restartBranchNames() {
+			return restartBranchNames
+		},
+		get nestedRestartTopStepId() {
+			return nestedRestartTopStepId
+		},
+		get nestedRestartTopBranchOrIterationN() {
+			return nestedRestartTopBranchOrIterationN
+		},
+		get nestedRestartPath() {
+			return nestedRestartPath
+		},
+		get nestedRestartSupported() {
+			return nestedRestartSupported
+		},
+		get topLevelLoopIteration() {
+			return topLevelLoopIteration
+		},
+		get iterationCounts() {
+			return iterationCounts
+		}
+	}
+}

--- a/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
@@ -119,6 +119,27 @@
 	let graphModuleStates: Record<string, import('$lib/components/graph').GraphModuleState> = $state(
 		{}
 	)
+	// For top-level ForLoop restart: the iteration the user is currently viewing
+	// (read from `selectedForloopIndex`). Pre-fills the restart button's iteration
+	// input so the user doesn't have to retype it; they can still edit it in the popup.
+	let topLevelLoopIteration: number | undefined = $derived(
+		(selectedJobStepType as string) === 'forloop' && selectedJobStep
+			? graphModuleStates[selectedJobStep]?.selectedForloopIndex
+			: undefined
+	)
+	// Map of ForLoop step id -> iteration count (number of iterations that ran in
+	// the original execution). Lets the restart popup render a `<select>` of
+	// 0..count-1 instead of a free-form number input.
+	let iterationCounts: Record<string, number> = $derived.by(() => {
+		const out: Record<string, number> = {}
+		for (const [id, state] of Object.entries(graphModuleStates)) {
+			const n = state.flow_jobs?.length
+			if (typeof n === 'number' && n > 0) {
+				out[id] = n
+			}
+		}
+		return out
+	})
 
 	let testIsLoading = $state(false)
 	let jobLoader: JobLoader | undefined = $state(undefined)
@@ -241,17 +262,13 @@
 						const blocked = path.ancestors.some(
 							(a) => a.type === 'branchall' || a.type === 'whileloopflow'
 						)
-						// For each ForLoop ancestor on the path, read which iteration the user
-						// is currently viewing in the graph. `selectedForloopIndex` is set
-						// when the user opens an iteration; if it's still undefined we
-						// can't disambiguate which iteration to restart at and refuse to
-						// offer the button rather than silently picking iteration 0.
-						const iterationFor = (stepId: string): number | undefined =>
-							graphModuleStates[stepId]?.selectedForloopIndex
-						const missingIteration = path.ancestors.some(
-							(a) => a.type === 'forloopflow' && iterationFor(a.stepId) === undefined
-						)
-						if (!blocked && !missingIteration) {
+						// For each ForLoop ancestor we pre-fill the iteration from the graph's
+						// `selectedForloopIndex`. When the user hasn't opened an iteration in
+						// the graph we default to 0; the popup surfaces every iteration so the
+						// user can confirm or edit it before submitting.
+						const iterationFor = (stepId: string): number =>
+							graphModuleStates[stepId]?.selectedForloopIndex ?? 0
+						if (!blocked) {
 							const topBranchOrIter: number | undefined =
 								top.type === 'forloopflow' ? iterationFor(top.stepId) : undefined
 							const innerPath: Array<{
@@ -267,7 +284,16 @@
 								}
 								innerPath.push(entry)
 							}
-							innerPath.push({ step_id: selectedJobStep! })
+							// If the SELECTED step is itself a ForLoop (e.g. user clicked a
+							// nested loop's node directly), include its iteration too so the
+							// popup exposes a selector for it.
+							const leafEntry: { step_id: string; branch_or_iteration_n?: number } = {
+								step_id: selectedJobStep!
+							}
+							if (path.target.value.type === 'forloopflow') {
+								leafEntry.branch_or_iteration_n = iterationFor(selectedJobStep!)
+							}
+							innerPath.push(leafEntry)
 
 							nestedRestartTopStepId = top.stepId
 							nestedRestartTopBranchOrIterationN = topBranchOrIter
@@ -732,6 +758,8 @@
 					nestedPath={nestedRestartSupported ? nestedRestartPath : undefined}
 					nestedTopStepId={nestedRestartTopStepId}
 					nestedTopBranchOrIterationN={nestedRestartTopBranchOrIterationN}
+					presetIterationN={topLevelLoopIteration}
+					{iterationCounts}
 					onRestartComplete={(newJobId) => {
 						goto('/run/' + newJobId + '?workspace=' + $workspaceStore)
 					}}

--- a/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
@@ -15,7 +15,6 @@
 		canWrite,
 		computeSharableHash,
 		copyToClipboard,
-		emptyString,
 		encodeState,
 		getHubFlowIdFromPath,
 		isHubFlowPath,
@@ -87,7 +86,7 @@
 	import { page } from '$app/state'
 	import { twMerge } from 'tailwind-merge'
 	import FlowRestartButton from '$lib/components/FlowRestartButton.svelte'
-	import { findStepPath, parseExpandedSubflowId } from '$lib/components/restartFromStepPath'
+	import { useNestedRestartState } from '$lib/components/useNestedRestartState.svelte'
 	import JobOtelTraces from '$lib/components/JobOtelTraces.svelte'
 	import { isRuleActive } from '$lib/workspaceProtectionRules.svelte'
 	import { buildForkEditUrl } from '$lib/utils/editInFork'
@@ -101,44 +100,16 @@
 	let viewTab: 'logs' | 'code' | 'stats' | 'assets' | 'traces' = $state('logs')
 	let selectedJobStep: string | undefined = $state(undefined)
 
-	let selectedJobStepIsTopLevel: boolean | undefined = $state(undefined)
-	let selectedJobStepType: 'single' | 'forloop' | 'branchall' = $state('single')
-	let restartBranchNames: [number, string][] = []
-	// When the selected step is nested inside a top-level container (BranchOne / sequential
-	// ForLoop), this carries the path to send to the backend; the top-level container is
-	// addressed via `nestedTopStepId` + `nestedTopBranchOrIterationN`.
-	let nestedRestartTopStepId: string | undefined = $state(undefined)
-	let nestedRestartTopBranchOrIterationN: number | undefined = $state(undefined)
-	let nestedRestartPath: Array<{ step_id: string; branch_or_iteration_n?: number }> | undefined =
-		$state(undefined)
-	let nestedRestartSupported: boolean = $state(false)
 	// Mirror of the graph's per-module display state (selected iteration of each
-	// ForLoop, etc.). We use it to know which iteration the user is viewing when
-	// they pick a step inside a loop, so the nested-restart path can target that
-	// iteration instead of guessing.
+	// ForLoop, etc.). Drives both the iteration pre-fill and the iteration-count
+	// selectors in the restart popup.
 	let graphModuleStates: Record<string, import('$lib/components/graph').GraphModuleState> = $state(
 		{}
 	)
-	// For top-level ForLoop restart: the iteration the user is currently viewing
-	// (read from `selectedForloopIndex`). Pre-fills the restart button's iteration
-	// input so the user doesn't have to retype it; they can still edit it in the popup.
-	let topLevelLoopIteration: number | undefined = $derived(
-		(selectedJobStepType as string) === 'forloop' && selectedJobStep
-			? graphModuleStates[selectedJobStep]?.selectedForloopIndex
-			: undefined
-	)
-	// Map of ForLoop step id -> iteration count (number of iterations that ran in
-	// the original execution). Lets the restart popup render a `<select>` of
-	// 0..count-1 instead of a free-form number input.
-	let iterationCounts: Record<string, number> = $derived.by(() => {
-		const out: Record<string, number> = {}
-		for (const [id, state] of Object.entries(graphModuleStates)) {
-			const n = state.flow_jobs?.length
-			if (typeof n === 'number' && n > 0) {
-				out[id] = n
-			}
-		}
-		return out
+	const restart = useNestedRestartState({
+		selectedJobStep: () => selectedJobStep,
+		job: () => job,
+		graphModuleStates: () => graphModuleStates
 	})
 
 	let testIsLoading = $state(false)
@@ -204,106 +175,6 @@
 			}
 		})
 		initView()
-	}
-
-	function onSelectedJobStepChange() {
-		nestedRestartTopStepId = undefined
-		nestedRestartTopBranchOrIterationN = undefined
-		nestedRestartPath = undefined
-		nestedRestartSupported = false
-		if (selectedJobStep !== undefined && job?.flow_status?.modules !== undefined) {
-			selectedJobStepIsTopLevel =
-				job?.flow_status?.modules.map((m) => m.id).indexOf(selectedJobStep) >= 0
-			let moduleDefinition = job?.raw_flow?.modules.find((m) => m.id == selectedJobStep)
-			if (moduleDefinition?.value.type == 'forloopflow') {
-				selectedJobStepType = 'forloop'
-			} else if (moduleDefinition?.value.type == 'branchall') {
-				selectedJobStepType = 'branchall'
-				moduleDefinition?.value.branches.forEach((branch, idx) => {
-					restartBranchNames.push([
-						idx,
-						emptyString(branch.summary) ? `Branch #${idx}` : branch.summary!
-					])
-				})
-			} else {
-				selectedJobStepType = 'single'
-			}
-
-			if (!selectedJobStepIsTopLevel) {
-				// Case 1: step is inside an inline-expanded subflow (id has form
-				// `subflow:outerStep:[innerSubflow:...]<leaf>`). The graph adds the
-				// `subflow:` prefix only for subflow expansions, so each segment is
-				// a `Flow{path}` step (or the leaf is a top-level step of the deepest
-				// subflow). The backend will validate that the leaf actually exists
-				// at that path.
-				const subflowParse = parseExpandedSubflowId(selectedJobStep!)
-				if (subflowParse && job?.raw_flow?.modules) {
-					const top = job.raw_flow.modules.find((m) => m.id === subflowParse.subflowSteps[0])
-					if (top && top.value.type === 'flow') {
-						const innerPath: Array<{ step_id: string; branch_or_iteration_n?: number }> = []
-						for (const seg of subflowParse.subflowSteps.slice(1)) {
-							innerPath.push({ step_id: seg })
-						}
-						innerPath.push({ step_id: subflowParse.leaf })
-						nestedRestartTopStepId = top.id
-						nestedRestartTopBranchOrIterationN = undefined
-						nestedRestartPath = innerPath
-						nestedRestartSupported = true
-					}
-				}
-				// Case 2: step is nested inside a BranchOne / ForLoop within the parent's
-				// own flow_value (no subflow expansion). Walk the tree to find the path.
-				// Supported when ancestors are BranchOne / sequential ForLoop only.
-				if (!nestedRestartSupported && job?.raw_flow?.modules) {
-					const path = findStepPath(job.raw_flow.modules, selectedJobStep!)
-					if (path && path.ancestors.length > 0) {
-						const top = path.ancestors[0]
-						const inner = path.ancestors.slice(1)
-						const blocked = path.ancestors.some(
-							(a) => a.type === 'branchall' || a.type === 'whileloopflow'
-						)
-						// For each ForLoop ancestor we pre-fill the iteration from the graph's
-						// `selectedForloopIndex`. When the user hasn't opened an iteration in
-						// the graph we default to 0; the popup surfaces every iteration so the
-						// user can confirm or edit it before submitting.
-						const iterationFor = (stepId: string): number =>
-							graphModuleStates[stepId]?.selectedForloopIndex ?? 0
-						if (!blocked) {
-							const topBranchOrIter: number | undefined =
-								top.type === 'forloopflow' ? iterationFor(top.stepId) : undefined
-							const innerPath: Array<{
-								step_id: string
-								branch_or_iteration_n?: number
-							}> = []
-							for (const a of inner) {
-								const entry: { step_id: string; branch_or_iteration_n?: number } = {
-									step_id: a.stepId
-								}
-								if (a.type === 'forloopflow') {
-									entry.branch_or_iteration_n = iterationFor(a.stepId)
-								}
-								innerPath.push(entry)
-							}
-							// If the SELECTED step is itself a ForLoop (e.g. user clicked a
-							// nested loop's node directly), include its iteration too so the
-							// popup exposes a selector for it.
-							const leafEntry: { step_id: string; branch_or_iteration_n?: number } = {
-								step_id: selectedJobStep!
-							}
-							if (path.target.value.type === 'forloopflow') {
-								leafEntry.branch_or_iteration_n = iterationFor(selectedJobStep!)
-							}
-							innerPath.push(leafEntry)
-
-							nestedRestartTopStepId = top.stepId
-							nestedRestartTopBranchOrIterationN = topBranchOrIter
-							nestedRestartPath = innerPath
-							nestedRestartSupported = true
-						}
-					}
-				}
-			}
-		}
 	}
 
 	let persistentScriptDefinition: Script | undefined = $state(undefined)
@@ -511,9 +382,6 @@
 	})
 	$effect(() => {
 		$workspaceStore && page.params.run && jobLoader && untrack(() => onRunsPageChangeWithLoader())
-	})
-	$effect(() => {
-		selectedJobStep !== undefined && untrack(() => onSelectedJobStepChange())
 	})
 	$effect(() => {
 		job && untrack(() => onJobLoaded())
@@ -749,17 +617,17 @@
 					startIcon={{ icon: Calendar }}>Edit schedule</Button
 				>
 			{/if}
-			{#if job?.type === 'CompletedJob' && job?.job_kind === 'flow' && selectedJobStep !== undefined && (selectedJobStepIsTopLevel || nestedRestartSupported) && job.id}
+			{#if job?.type === 'CompletedJob' && job?.job_kind === 'flow' && selectedJobStep !== undefined && (restart.selectedJobStepIsTopLevel || restart.nestedRestartSupported) && job.id}
 				<FlowRestartButton
 					jobId={job.id}
 					{selectedJobStep}
-					{selectedJobStepType}
-					{restartBranchNames}
-					nestedPath={nestedRestartSupported ? nestedRestartPath : undefined}
-					nestedTopStepId={nestedRestartTopStepId}
-					nestedTopBranchOrIterationN={nestedRestartTopBranchOrIterationN}
-					presetIterationN={topLevelLoopIteration}
-					{iterationCounts}
+					selectedJobStepType={restart.selectedJobStepType}
+					restartBranchNames={restart.restartBranchNames}
+					nestedPath={restart.nestedRestartSupported ? restart.nestedRestartPath : undefined}
+					nestedTopStepId={restart.nestedRestartTopStepId}
+					nestedTopBranchOrIterationN={restart.nestedRestartTopBranchOrIterationN}
+					presetIterationN={restart.topLevelLoopIteration}
+					iterationCounts={restart.iterationCounts}
 					onRestartComplete={(newJobId) => {
 						goto('/run/' + newJobId + '?workspace=' + $workspaceStore)
 					}}

--- a/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
@@ -622,7 +622,7 @@
 					startIcon={{ icon: Calendar }}>Edit schedule</Button
 				>
 			{/if}
-			{#if job?.type === 'CompletedJob' && job?.job_kind === 'flow' && selectedJobStep !== undefined && (restart.selectedJobStepIsTopLevel || restart.nestedRestartSupported) && job.id}
+			{#if job?.type === 'CompletedJob' && job?.job_kind === 'flow' && selectedJobStep !== undefined && (restart.topLevelRestartable || restart.nestedRestartSupported) && job.id}
 				<FlowRestartButton
 					jobId={job.id}
 					{selectedJobStep}

--- a/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
@@ -106,10 +106,15 @@
 	let graphModuleStates: Record<string, import('$lib/components/graph').GraphModuleState> = $state(
 		{}
 	)
+	let expandedSubflows: Record<
+		string,
+		{ modules: import('$lib/gen').FlowModule[]; groups?: any[] }
+	> = $state({})
 	const restart = useNestedRestartState({
 		selectedJobStep: () => selectedJobStep,
 		job: () => job,
-		graphModuleStates: () => graphModuleStates
+		graphModuleStates: () => graphModuleStates,
+		expandedSubflows: () => expandedSubflows
 	})
 
 	let testIsLoading = $state(false)
@@ -911,6 +916,7 @@
 						bind:suspendStatus
 						bind:isOwner
 						bind:localModuleStates={graphModuleStates}
+						bind:expandedSubflows
 					/>
 				{:else}
 					<Skeleton layout={[[5]]} />

--- a/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
@@ -87,7 +87,7 @@
 	import { page } from '$app/state'
 	import { twMerge } from 'tailwind-merge'
 	import FlowRestartButton from '$lib/components/FlowRestartButton.svelte'
-	import { findStepPath } from '$lib/components/restartFromStepPath'
+	import { findStepPath, parseExpandedSubflowId } from '$lib/components/restartFromStepPath'
 	import JobOtelTraces from '$lib/components/JobOtelTraces.svelte'
 	import { isRuleActive } from '$lib/workspaceProtectionRules.svelte'
 	import { buildForkEditUrl } from '$lib/utils/editInFork'
@@ -203,43 +203,68 @@
 				selectedJobStepType = 'single'
 			}
 
-			// Nested-step restart: walk the flow_value to find the selected step's path.
-			// Supported when ancestors are BranchOne / sequential ForLoop only. BranchAll,
-			// parallel loops, and subflow-internal steps are unsupported here.
-			if (!selectedJobStepIsTopLevel && job?.raw_flow?.modules) {
-				const path = findStepPath(job.raw_flow.modules, selectedJobStep!)
-				if (path && path.ancestors.length > 0) {
-					const top = path.ancestors[0]
-					const inner = path.ancestors.slice(1)
-					const blocked = path.ancestors.some(
-						(a) => a.type === 'branchall' || a.type === 'whileloopflow'
-					)
-					if (!blocked) {
-						const topStatus = job.flow_status?.modules?.find((m) => m.id === top.stepId)
-						let topBranchOrIter: number | undefined
-						if (top.type === 'forloopflow') {
-							topBranchOrIter = 0
-							const flowJobs = (topStatus as any)?.flow_jobs as string[] | undefined
-							nestedRestartIterationInputs = [flowJobs?.length ?? 0]
-						}
+			if (!selectedJobStepIsTopLevel) {
+				// Case 1: step is inside an inline-expanded subflow (id has form
+				// `subflow:outerStep:[innerSubflow:...]<leaf>`). The graph adds the
+				// `subflow:` prefix only for subflow expansions, so each segment is
+				// a `Flow{path}` step (or the leaf is a top-level step of the deepest
+				// subflow). The backend will validate that the leaf actually exists
+				// at that path.
+				const subflowParse = parseExpandedSubflowId(selectedJobStep!)
+				if (subflowParse && job?.raw_flow?.modules) {
+					const top = job.raw_flow.modules.find((m) => m.id === subflowParse.subflowSteps[0])
+					if (top && top.value.type === 'flow') {
 						const innerPath: Array<{ step_id: string; branch_or_iteration_n?: number }> = []
-						for (const a of inner) {
-							const entry: { step_id: string; branch_or_iteration_n?: number } = {
-								step_id: a.stepId
-							}
-							if (a.type === 'forloopflow') {
-								entry.branch_or_iteration_n = 0
-								nestedRestartIterationInputs.push(0)
-							}
-							innerPath.push(entry)
+						for (const seg of subflowParse.subflowSteps.slice(1)) {
+							innerPath.push({ step_id: seg })
 						}
-						// The leaf is the selected step itself
-						innerPath.push({ step_id: selectedJobStep! })
-
-						nestedRestartTopStepId = top.stepId
-						nestedRestartTopBranchOrIterationN = topBranchOrIter
+						innerPath.push({ step_id: subflowParse.leaf })
+						nestedRestartTopStepId = top.id
+						nestedRestartTopBranchOrIterationN = undefined
 						nestedRestartPath = innerPath
 						nestedRestartSupported = true
+					}
+				}
+				// Case 2: step is nested inside a BranchOne / ForLoop within the parent's
+				// own flow_value (no subflow expansion). Walk the tree to find the path.
+				// Supported when ancestors are BranchOne / sequential ForLoop only.
+				if (!nestedRestartSupported && job?.raw_flow?.modules) {
+					const path = findStepPath(job.raw_flow.modules, selectedJobStep!)
+					if (path && path.ancestors.length > 0) {
+						const top = path.ancestors[0]
+						const inner = path.ancestors.slice(1)
+						const blocked = path.ancestors.some(
+							(a) => a.type === 'branchall' || a.type === 'whileloopflow'
+						)
+						if (!blocked) {
+							const topStatus = job.flow_status?.modules?.find((m) => m.id === top.stepId)
+							let topBranchOrIter: number | undefined
+							if (top.type === 'forloopflow') {
+								topBranchOrIter = 0
+								const flowJobs = (topStatus as any)?.flow_jobs as string[] | undefined
+								nestedRestartIterationInputs = [flowJobs?.length ?? 0]
+							}
+							const innerPath: Array<{
+								step_id: string
+								branch_or_iteration_n?: number
+							}> = []
+							for (const a of inner) {
+								const entry: { step_id: string; branch_or_iteration_n?: number } = {
+									step_id: a.stepId
+								}
+								if (a.type === 'forloopflow') {
+									entry.branch_or_iteration_n = 0
+									nestedRestartIterationInputs.push(0)
+								}
+								innerPath.push(entry)
+							}
+							innerPath.push({ step_id: selectedJobStep! })
+
+							nestedRestartTopStepId = top.stepId
+							nestedRestartTopBranchOrIterationN = topBranchOrIter
+							nestedRestartPath = innerPath
+							nestedRestartSupported = true
+						}
 					}
 				}
 			}

--- a/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
@@ -87,6 +87,7 @@
 	import { page } from '$app/state'
 	import { twMerge } from 'tailwind-merge'
 	import FlowRestartButton from '$lib/components/FlowRestartButton.svelte'
+	import { findStepPath } from '$lib/components/restartFromStepPath'
 	import JobOtelTraces from '$lib/components/JobOtelTraces.svelte'
 	import { isRuleActive } from '$lib/workspaceProtectionRules.svelte'
 	import { buildForkEditUrl } from '$lib/utils/editInFork'
@@ -103,6 +104,15 @@
 	let selectedJobStepIsTopLevel: boolean | undefined = $state(undefined)
 	let selectedJobStepType: 'single' | 'forloop' | 'branchall' = $state('single')
 	let restartBranchNames: [number, string][] = []
+	// When the selected step is nested inside a top-level container (BranchOne / sequential
+	// ForLoop), this carries the path to send to the backend; the top-level container is
+	// addressed via `nestedTopStepId` + `nestedTopBranchOrIterationN`.
+	let nestedRestartTopStepId: string | undefined = $state(undefined)
+	let nestedRestartTopBranchOrIterationN: number | undefined = $state(undefined)
+	let nestedRestartPath: Array<{ step_id: string; branch_or_iteration_n?: number }> | undefined =
+		$state(undefined)
+	let nestedRestartIterationInputs: number[] = $state([])
+	let nestedRestartSupported: boolean = $state(false)
 
 	let testIsLoading = $state(false)
 	let jobLoader: JobLoader | undefined = $state(undefined)
@@ -170,6 +180,11 @@
 	}
 
 	function onSelectedJobStepChange() {
+		nestedRestartTopStepId = undefined
+		nestedRestartTopBranchOrIterationN = undefined
+		nestedRestartPath = undefined
+		nestedRestartIterationInputs = []
+		nestedRestartSupported = false
 		if (selectedJobStep !== undefined && job?.flow_status?.modules !== undefined) {
 			selectedJobStepIsTopLevel =
 				job?.flow_status?.modules.map((m) => m.id).indexOf(selectedJobStep) >= 0
@@ -186,6 +201,47 @@
 				})
 			} else {
 				selectedJobStepType = 'single'
+			}
+
+			// Nested-step restart: walk the flow_value to find the selected step's path.
+			// Supported when ancestors are BranchOne / sequential ForLoop only. BranchAll,
+			// parallel loops, and subflow-internal steps are unsupported here.
+			if (!selectedJobStepIsTopLevel && job?.raw_flow?.modules) {
+				const path = findStepPath(job.raw_flow.modules, selectedJobStep!)
+				if (path && path.ancestors.length > 0) {
+					const top = path.ancestors[0]
+					const inner = path.ancestors.slice(1)
+					const blocked = path.ancestors.some(
+						(a) => a.type === 'branchall' || a.type === 'whileloopflow'
+					)
+					if (!blocked) {
+						const topStatus = job.flow_status?.modules?.find((m) => m.id === top.stepId)
+						let topBranchOrIter: number | undefined
+						if (top.type === 'forloopflow') {
+							topBranchOrIter = 0
+							const flowJobs = (topStatus as any)?.flow_jobs as string[] | undefined
+							nestedRestartIterationInputs = [flowJobs?.length ?? 0]
+						}
+						const innerPath: Array<{ step_id: string; branch_or_iteration_n?: number }> = []
+						for (const a of inner) {
+							const entry: { step_id: string; branch_or_iteration_n?: number } = {
+								step_id: a.stepId
+							}
+							if (a.type === 'forloopflow') {
+								entry.branch_or_iteration_n = 0
+								nestedRestartIterationInputs.push(0)
+							}
+							innerPath.push(entry)
+						}
+						// The leaf is the selected step itself
+						innerPath.push({ step_id: selectedJobStep! })
+
+						nestedRestartTopStepId = top.stepId
+						nestedRestartTopBranchOrIterationN = topBranchOrIter
+						nestedRestartPath = innerPath
+						nestedRestartSupported = true
+					}
+				}
 			}
 		}
 	}
@@ -633,12 +689,15 @@
 					startIcon={{ icon: Calendar }}>Edit schedule</Button
 				>
 			{/if}
-			{#if job?.type === 'CompletedJob' && job?.job_kind === 'flow' && selectedJobStep !== undefined && selectedJobStepIsTopLevel && job.id}
+			{#if job?.type === 'CompletedJob' && job?.job_kind === 'flow' && selectedJobStep !== undefined && (selectedJobStepIsTopLevel || nestedRestartSupported) && job.id}
 				<FlowRestartButton
 					jobId={job.id}
 					{selectedJobStep}
 					{selectedJobStepType}
 					{restartBranchNames}
+					nestedPath={nestedRestartSupported ? nestedRestartPath : undefined}
+					nestedTopStepId={nestedRestartTopStepId}
+					nestedTopBranchOrIterationN={nestedRestartTopBranchOrIterationN}
 					onRestartComplete={(newJobId) => {
 						goto('/run/' + newJobId + '?workspace=' + $workspaceStore)
 					}}

--- a/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
@@ -111,8 +111,14 @@
 	let nestedRestartTopBranchOrIterationN: number | undefined = $state(undefined)
 	let nestedRestartPath: Array<{ step_id: string; branch_or_iteration_n?: number }> | undefined =
 		$state(undefined)
-	let nestedRestartIterationInputs: number[] = $state([])
 	let nestedRestartSupported: boolean = $state(false)
+	// Mirror of the graph's per-module display state (selected iteration of each
+	// ForLoop, etc.). We use it to know which iteration the user is viewing when
+	// they pick a step inside a loop, so the nested-restart path can target that
+	// iteration instead of guessing.
+	let graphModuleStates: Record<string, import('$lib/components/graph').GraphModuleState> = $state(
+		{}
+	)
 
 	let testIsLoading = $state(false)
 	let jobLoader: JobLoader | undefined = $state(undefined)
@@ -183,7 +189,6 @@
 		nestedRestartTopStepId = undefined
 		nestedRestartTopBranchOrIterationN = undefined
 		nestedRestartPath = undefined
-		nestedRestartIterationInputs = []
 		nestedRestartSupported = false
 		if (selectedJobStep !== undefined && job?.flow_status?.modules !== undefined) {
 			selectedJobStepIsTopLevel =
@@ -236,14 +241,19 @@
 						const blocked = path.ancestors.some(
 							(a) => a.type === 'branchall' || a.type === 'whileloopflow'
 						)
-						if (!blocked) {
-							const topStatus = job.flow_status?.modules?.find((m) => m.id === top.stepId)
-							let topBranchOrIter: number | undefined
-							if (top.type === 'forloopflow') {
-								topBranchOrIter = 0
-								const flowJobs = (topStatus as any)?.flow_jobs as string[] | undefined
-								nestedRestartIterationInputs = [flowJobs?.length ?? 0]
-							}
+						// For each ForLoop ancestor on the path, read which iteration the user
+						// is currently viewing in the graph. `selectedForloopIndex` is set
+						// when the user opens an iteration; if it's still undefined we
+						// can't disambiguate which iteration to restart at and refuse to
+						// offer the button rather than silently picking iteration 0.
+						const iterationFor = (stepId: string): number | undefined =>
+							graphModuleStates[stepId]?.selectedForloopIndex
+						const missingIteration = path.ancestors.some(
+							(a) => a.type === 'forloopflow' && iterationFor(a.stepId) === undefined
+						)
+						if (!blocked && !missingIteration) {
+							const topBranchOrIter: number | undefined =
+								top.type === 'forloopflow' ? iterationFor(top.stepId) : undefined
 							const innerPath: Array<{
 								step_id: string
 								branch_or_iteration_n?: number
@@ -253,8 +263,7 @@
 									step_id: a.stepId
 								}
 								if (a.type === 'forloopflow') {
-									entry.branch_or_iteration_n = 0
-									nestedRestartIterationInputs.push(0)
+									entry.branch_or_iteration_n = iterationFor(a.stepId)
 								}
 								innerPath.push(entry)
 							}
@@ -1005,6 +1014,7 @@
 						bind:selectedJobStep
 						bind:suspendStatus
 						bind:isOwner
+						bind:localModuleStates={graphModuleStates}
 					/>
 				{:else}
 					<Skeleton layout={[[5]]} />


### PR DESCRIPTION
## Summary

Extends the "restart flow at step" feature to support nested steps. Previously, restart was limited to top-level modules of a flow. Now users can restart from a step inside a BranchOne, inside a sequential ForLoop iteration, or inside a Subflow — preserving prior siblings as Success and re-running only what's after the chosen point.

## Changes

**Data model**
- `RestartedFrom` (`backend/windmill-types/src/flow_status.rs`) gains an optional `branch_chosen` (BranchOne lock) and an optional `nested: Box<RestartedFrom>` linked-list, enabling arbitrary-depth restart chains.
- `JobPayload::RestartedFlow` (`backend/windmill-types/src/jobs.rs`) carries the same fields so chains propagate through child-job spawns.

**API**
- `RestartFlowRequestBody` accepts a new `nested_path: Vec<NestedRestartStep>` describing additional levels to descend into.
- New `resolve_nested_restart` helper (`backend/windmill-api/src/jobs.rs`) walks the original execution tree, validates each level, resolves child job UUIDs, and captures BranchOne `branch_chosen` for branch-locking.
- OpenAPI schema updated; frontend client regenerated.

**Worker**
- New `nested_restart_payload` helper at `backend/windmill-worker/src/worker_flow.rs`. When the parent flow's `restarted_from.nested` matches the step about to spawn its child (Subflow / BranchOne / sequential ForLoop iteration), the fresh `RawFlow`/`Flow` payload is swapped for `JobPayload::RestartedFlow` so the child boots in restart mode.
- BranchOne handler honors `restarted_from.branch_chosen` to skip predicate evaluation and lock the originally-taken branch.

**Frontend**
- New helper `frontend/src/lib/components/restartFromStepPath.ts` walks the flow value to find the ancestor chain of a selected step (BranchOne / ForLoop only).
- `FlowRestartButton.svelte` accepts new `nestedPath` / `nestedTopStepId` / `nestedTopBranchOrIterationN` props and sends them to the API.
- The run page (`+page.svelte`) and `FlowPreviewContent.svelte` drop the `selectedJobStepIsTopLevel` gate when a supported nested path can be built; otherwise behavior is unchanged.

**Validations**
- Parallel ForLoop / parallel BranchAll rejected.
- BranchAll restart (sequential or parallel) rejected — out of scope per design.
- WhileLoop nested restart rejected.
- Step-not-in-original-run errors when path coordinates don't match the originally-executed branch/iteration.
- Approval-conditions-on-restart remain TODO (pre-existing limitation).

**Tests**
- `test_nested_restart_inside_branchone`: restart at a step inside a BranchOne, with branch lock preserved.
- `test_nested_restart_inside_forloop_iteration`: restart inside iteration N of a sequential ForLoop, preserving iterations 0..N-1 with original results.
- Existing `test_raw_flow_payload_with_restarted_from` still passes.

## Test plan

- [ ] Run `cargo test --features deno_core --features enterprise --features private --features quickjs --test job_payload test_nested_restart` to validate both new tests pass
- [ ] Manually run a flow with a top-level BranchOne containing inner steps, click an inner step on the run page, restart, verify only the chosen branch re-runs from the inner step onward
- [ ] Same with a top-level sequential ForLoop: click an inner step in iteration N, restart, verify iterations 0..N-1 keep original outputs and iteration N+ re-run with new args
- [ ] Verify BranchAll / parallel containers / WhileLoop still surface a clear error message in the API response
- [ ] Verify existing top-level restart (single step, top-level ForLoop iteration restart, top-level BranchAll branch restart) still works unchanged

## Out of scope

- Restarting INSIDE a BranchAll branch (per design discussion — semantically muddled with parallel branches).
- Drilled-in subflow → restart-parent UI: backend supports it via the `nested` chain, but the frontend doesn't yet build the path when the user is on a child run page.
- Approval conditions are still reset on restart (existing TODO at `windmill-queue/src/jobs.rs:5026`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds restart-from-step for nested steps inside BranchOne, sequential ForLoop iterations, and Subflow. Only steps after the chosen point re-run; earlier siblings are preserved, and BranchOne restarts lock to the originally taken branch.

- **New Features**
  - Data model: `RestartedFrom` adds `branch_chosen` and a `nested` chain; `JobPayload::RestartedFlow` carries both.
  - API: `RestartFlowRequestBody` accepts `nested_path`; resolver validates the path and leaf step; OpenAPI updated (docs clarify 0-based `branch_or_iteration_n` and nested path fields).
  - Worker: Intercepts child spawns in restart mode when the `nested` chain applies; BranchOne reuses `branch_chosen`. The simple ForLoop fast path is intentionally not intercepted (nested restarts into simple iterations are rejected by the API).
  - Frontend: Builds nested restart paths (incl. expanded subflows) via `restartFromStepPath.ts` and `useNestedRestartState`; popup includes per-ForLoop iteration selectors; preview hides nested restart.
  - Validation: Reject nested restarts in BranchAll, WhileLoop, and parallel ForLoop.
  - Tests: Added HTTP endpoint tests (happy path, unknown step, out-of-range iteration, parallel-loop rejection) and more nested cases (deployed subflows, FlowDependencies, cross-boundary chains).

- **Bug Fixes**
  - Preserve original job kind on nested restarts so FlowNode-wrapped children restart correctly.
  - Tighten BranchOne ancestor match; be permissive when status isn’t reachable. Hide restart only for untaken top-level branches and non-restartable steps.
  - Read the selected ForLoop iteration from graph state and pre-fill it; reset `selectedJobStepIsTopLevel` on early returns.
  - Handle undefined `expandedSubflows` and reset its cache on job change; minor doc corrections.

<sup>Written for commit aaa7f8deb89661d66b186f609d170ae6b4b12269. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/8955?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

