### PR TITLE
perf: optimize datatable app chat schemas

### DIFF
--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -115,6 +115,11 @@ pub fn workspaced_service() -> Router {
         .route("/list_ducklakes", get(list_ducklakes))
         .route("/list_datatables", get(list_datatables))
         .route("/list_datatable_schemas", get(list_datatable_schemas))
+        .route("/list_datatable_tables", get(list_datatable_tables))
+        .route(
+            "/get_datatable_table_schema",
+            get(get_datatable_table_schema),
+        )
         .route("/edit_datatable_config", post(edit_datatable_config))
         .route("/git_sync_enabled", get(get_git_sync_enabled))
         .route("/edit_git_sync_config", post(edit_git_sync_config))
@@ -1365,6 +1370,9 @@ type TableMap = HashMap<String, ColumnMap>;
 /// Schemas mapped by name to their tables
 type SchemaMap = HashMap<String, TableMap>;
 
+/// Schemas mapped by name to their table names
+type TableListMap = HashMap<String, Vec<String>>;
+
 #[derive(Serialize, Debug)]
 struct DataTableSchema {
     datatable_name: String,
@@ -1374,26 +1382,36 @@ struct DataTableSchema {
     error: Option<String>,
 }
 
+#[derive(Serialize, Debug)]
+struct DataTableTables {
+    datatable_name: String,
+    /// Hierarchical metadata: schema_name -> table_names
+    schemas: TableListMap,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct GetDataTableSchemaQuery {
+    datatable_name: String,
+    schema_name: String,
+    table_name: String,
+}
+
+#[derive(Serialize, Debug)]
+struct DataTableTableSchema {
+    datatable_name: String,
+    schema_name: String,
+    table_name: String,
+    columns: ColumnMap,
+}
+
 async fn list_datatable_schemas(
     _authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Path(w_id): Path<String>,
 ) -> JsonResult<Vec<DataTableSchema>> {
-    // Get all datatable names for this workspace
-    let datatable_names: Vec<String> = sqlx::query_scalar!(
-        r#"
-            SELECT jsonb_object_keys(ws.datatable->'datatables') AS datatable_name
-            FROM workspace_settings ws
-            WHERE ws.workspace_id = $1
-        "#,
-        &w_id
-    )
-    .fetch_all(&db)
-    .await?
-    .into_iter()
-    .filter_map(|s| s)
-    .collect();
-
+    let datatable_names = list_datatable_names(&db, &w_id).await?;
     let mut results = Vec::new();
 
     for datatable_name in datatable_names {
@@ -1409,6 +1427,68 @@ async fn list_datatable_schemas(
     }
 
     Ok(Json(results))
+}
+
+async fn list_datatable_tables(
+    _authed: ApiAuthed,
+    Extension(db): Extension<DB>,
+    Path(w_id): Path<String>,
+) -> JsonResult<Vec<DataTableTables>> {
+    let datatable_names = list_datatable_names(&db, &w_id).await?;
+    let mut results = Vec::new();
+
+    for datatable_name in datatable_names {
+        let tables = match get_datatable_tables(&db, &w_id, &datatable_name).await {
+            Ok(schemas) => DataTableTables { datatable_name, schemas, error: None },
+            Err(e) => DataTableTables {
+                datatable_name,
+                schemas: HashMap::new(),
+                error: Some(e.to_string()),
+            },
+        };
+        results.push(tables);
+    }
+
+    Ok(Json(results))
+}
+
+async fn get_datatable_table_schema(
+    _authed: ApiAuthed,
+    Extension(db): Extension<DB>,
+    Path(w_id): Path<String>,
+    Query(query): Query<GetDataTableSchemaQuery>,
+) -> JsonResult<DataTableTableSchema> {
+    let columns = get_datatable_table_columns(
+        &db,
+        &w_id,
+        &query.datatable_name,
+        &query.schema_name,
+        &query.table_name,
+    )
+    .await?;
+
+    Ok(Json(DataTableTableSchema {
+        datatable_name: query.datatable_name,
+        schema_name: query.schema_name,
+        table_name: query.table_name,
+        columns,
+    }))
+}
+
+async fn list_datatable_names(db: &DB, w_id: &str) -> Result<Vec<String>> {
+    Ok(sqlx::query_scalar!(
+        r#"
+            SELECT jsonb_object_keys(ws.datatable->'datatables') AS datatable_name
+            FROM workspace_settings ws
+            WHERE ws.workspace_id = $1
+        "#,
+        w_id
+    )
+    .fetch_all(db)
+    .await?
+    .into_iter()
+    .filter_map(|s| s)
+    .collect())
 }
 
 async fn get_datatable_schema(db: &DB, w_id: &str, datatable_name: &str) -> Result<SchemaMap> {
@@ -1486,31 +1566,158 @@ async fn get_datatable_schema(db: &DB, w_id: &str, datatable_name: &str) -> Resu
         let is_nullable: String = row.get(4);
         let column_default: Option<String> = row.get(5);
 
-        // Build compact type representation: "type[?][=default]"
-        let mut compact = udt_name;
-        if is_nullable == "YES" {
-            compact.push('?');
-        }
-        if let Some(default) = column_default {
-            // Truncate long defaults for compactness
-            let short_default = if default.len() > 30 {
-                format!("{}...", &default[..27])
-            } else {
-                default
-            };
-            compact.push('=');
-            compact.push_str(&short_default);
-        }
-
         schema_map
             .entry(table_schema)
             .or_default()
             .entry(table_name)
             .or_default()
-            .insert(column_name, compact);
+            .insert(
+                column_name,
+                compact_column_type(udt_name, is_nullable, column_default),
+            );
     }
 
     Ok(schema_map)
+}
+
+async fn get_datatable_tables(db: &DB, w_id: &str, datatable_name: &str) -> Result<TableListMap> {
+    let db_resource = get_datatable_resource_from_db_unchecked(db, w_id, datatable_name).await?;
+    let pg_db: PgDatabase = serde_json::from_value(db_resource)
+        .map_err(|e| Error::internal_err(format!("Failed to parse database credentials: {}", e)))?;
+    let (client, connection) = pg_db.connect(Some(db)).await?;
+
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            tracing::error!("Datatable connection error: {}", e);
+        }
+    });
+
+    let schema_rows = client
+        .query(
+            r#"
+            SELECT nspname::text AS schema_name
+            FROM pg_namespace
+            WHERE nspname NOT IN ('information_schema', 'pg_toast', 'pg_catalog')
+              AND nspname NOT LIKE 'pg_%'
+            ORDER BY nspname
+            "#,
+            &[],
+        )
+        .await
+        .map_err(|e| Error::internal_err(format!("Failed to query schemas: {}", e)))?;
+
+    let mut table_map: TableListMap = HashMap::new();
+    let schema_names: Vec<String> = schema_rows
+        .iter()
+        .map(|row| {
+            let name: String = row.get(0);
+            table_map.entry(name.clone()).or_default();
+            name
+        })
+        .collect();
+
+    let rows = client
+        .query(
+            r#"
+            SELECT DISTINCT
+                table_schema::text,
+                table_name::text
+            FROM information_schema.columns
+            WHERE table_schema = ANY($1)
+              AND table_name IS NOT NULL
+            ORDER BY table_schema, table_name
+            "#,
+            &[&schema_names],
+        )
+        .await
+        .map_err(|e| Error::internal_err(format!("Failed to query tables: {}", e)))?;
+
+    for row in rows {
+        let table_schema: String = row.get(0);
+        let table_name: String = row.get(1);
+        table_map.entry(table_schema).or_default().push(table_name);
+    }
+
+    Ok(table_map)
+}
+
+async fn get_datatable_table_columns(
+    db: &DB,
+    w_id: &str,
+    datatable_name: &str,
+    schema_name: &str,
+    table_name: &str,
+) -> Result<ColumnMap> {
+    let db_resource = get_datatable_resource_from_db_unchecked(db, w_id, datatable_name).await?;
+    let pg_db: PgDatabase = serde_json::from_value(db_resource)
+        .map_err(|e| Error::internal_err(format!("Failed to parse database credentials: {}", e)))?;
+    let (client, connection) = pg_db.connect(Some(db)).await?;
+
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            tracing::error!("Datatable connection error: {}", e);
+        }
+    });
+
+    let rows = client
+        .query(
+            r#"
+            SELECT
+                column_name::text,
+                udt_name::text,
+                is_nullable::text,
+                column_default::text
+            FROM information_schema.columns
+            WHERE table_schema = $1
+              AND table_name = $2
+            ORDER BY ordinal_position
+            "#,
+            &[&schema_name, &table_name],
+        )
+        .await
+        .map_err(|e| Error::internal_err(format!("Failed to query columns: {}", e)))?;
+
+    if rows.is_empty() {
+        return Err(Error::NotFound(format!(
+            "Table '{}.{}' not found in datatable '{}'",
+            schema_name, table_name, datatable_name
+        )));
+    }
+
+    let mut columns: ColumnMap = HashMap::new();
+    for row in rows {
+        let column_name: String = row.get(0);
+        let udt_name: String = row.get(1);
+        let is_nullable: String = row.get(2);
+        let column_default: Option<String> = row.get(3);
+        columns.insert(
+            column_name,
+            compact_column_type(udt_name, is_nullable, column_default),
+        );
+    }
+
+    Ok(columns)
+}
+
+fn compact_column_type(
+    udt_name: String,
+    is_nullable: String,
+    column_default: Option<String>,
+) -> String {
+    let mut compact = udt_name;
+    if is_nullable == "YES" {
+        compact.push('?');
+    }
+    if let Some(default) = column_default {
+        let short_default = if default.len() > 30 {
+            format!("{}...", &default[..27])
+        } else {
+            default
+        };
+        compact.push('=');
+        compact.push_str(&short_default);
+    }
+    compact
 }
 
 /// Resolve a source string to PgDatabase credentials with user-scoped permission checks.

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -24,10 +24,7 @@ use regex::Regex;
 
 use hex;
 use sha2::{Digest, Sha256};
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::collections::{HashMap, HashSet};
 use strum::IntoEnumIterator;
 use uuid::Uuid;
 use windmill_audit::audit_oss::{audit_log, AuditAuthorable};
@@ -42,10 +39,9 @@ use windmill_common::workspaces::GitRepositorySettings;
 #[cfg(feature = "enterprise")]
 use windmill_common::workspaces::WorkspaceDeploymentUISettings;
 use windmill_common::workspaces::{
-    check_user_against_rule, get_datatable_resource_from_db_unchecked,
-    list_datatable_resources_from_db_unchecked, DataTable, DataTableCatalogResourceType,
-    DataTableForkBehavior, ProtectionRuleKind, ProtectionRules, ProtectionRuleset, RuleCheckResult,
-    WorkspaceGitSyncSettings, WM_FORK_PREFIX,
+    check_user_against_rule, get_datatable_resource_from_db_unchecked, DataTable,
+    DataTableCatalogResourceType, DataTableForkBehavior, ProtectionRuleKind, ProtectionRules,
+    ProtectionRuleset, RuleCheckResult, WorkspaceGitSyncSettings, WM_FORK_PREFIX,
 };
 use windmill_common::workspaces::{Ducklake, DucklakeCatalogResourceType};
 use windmill_common::PgDatabase;
@@ -1377,8 +1373,6 @@ type SchemaMap = HashMap<String, TableMap>;
 /// Schemas mapped by name to their table names
 type TableListMap = HashMap<String, Vec<String>>;
 
-const DATATABLE_CATALOG_LIST_CONCURRENCY: usize = 4;
-
 #[derive(Serialize, Debug)]
 struct DataTableSchema {
     datatable_name: String,
@@ -1417,76 +1411,22 @@ async fn list_datatable_schemas(
     Extension(db): Extension<DB>,
     Path(w_id): Path<String>,
 ) -> JsonResult<Vec<DataTableSchema>> {
-    let datatable_resource_results = list_datatable_resources_from_db_unchecked(&db, &w_id).await?;
-    let mut results = Vec::with_capacity(datatable_resource_results.len());
-    let mut datatable_resources = Vec::new();
-    let datatable_resource_results = datatable_resource_results.into_iter().enumerate();
-    for (index, (datatable_name, db_resource)) in datatable_resource_results {
-        results.push(None);
-        match db_resource {
-            Ok(db_resource) => datatable_resources.push((index, datatable_name, db_resource)),
-            Err(e) => {
-                results[index] = Some(DataTableSchema {
-                    datatable_name,
-                    schemas: HashMap::new(),
-                    error: Some(e),
-                })
-            }
-        }
+    let datatable_names = list_datatable_names(&db, &w_id).await?;
+    let mut results = Vec::new();
+
+    for datatable_name in datatable_names {
+        let schema = match get_datatable_schema(&db, &w_id, &datatable_name).await {
+            Ok(schemas) => DataTableSchema { datatable_name, schemas, error: None },
+            Err(e) => DataTableSchema {
+                datatable_name,
+                schemas: HashMap::new(),
+                error: Some(e.to_string()),
+            },
+        };
+        results.push(schema);
     }
 
-    let resource_groups = group_datatables_by_resource(datatable_resources)?;
-    let semaphore = Arc::new(tokio::sync::Semaphore::new(
-        DATATABLE_CATALOG_LIST_CONCURRENCY,
-    ));
-    let mut handles = Vec::with_capacity(resource_groups.len());
-
-    for (db_resource, datatables) in resource_groups {
-        let db = db.clone();
-        let permit = semaphore.clone().acquire_owned().await.map_err(|e| {
-            Error::internal_err(format!("datatable schema list semaphore closed: {}", e))
-        })?;
-
-        handles.push(tokio::spawn(async move {
-            let _permit = permit;
-            let schemas = get_datatable_schema_from_resource(&db_resource, Some(&db)).await;
-            datatables
-                .into_iter()
-                .map(|(index, datatable_name)| match &schemas {
-                    Ok(schemas) => (
-                        index,
-                        DataTableSchema { datatable_name, schemas: schemas.clone(), error: None },
-                    ),
-                    Err(e) => (
-                        index,
-                        DataTableSchema {
-                            datatable_name,
-                            schemas: HashMap::new(),
-                            error: Some(e.to_string()),
-                        },
-                    ),
-                })
-                .collect::<Vec<_>>()
-        }));
-    }
-
-    for handle in handles {
-        let datatables = handle.await.map_err(|e| {
-            Error::internal_err(format!("failed to join datatable schema list task: {}", e))
-        })?;
-        for (index, datatable) in datatables {
-            results[index] = Some(datatable);
-        }
-    }
-
-    let mut ordered_results = Vec::with_capacity(results.len());
-    for result in results {
-        ordered_results.push(result.ok_or_else(|| {
-            Error::internal_err("missing datatable schema list result".to_string())
-        })?);
-    }
-
-    Ok(Json(ordered_results))
+    Ok(Json(results))
 }
 
 async fn list_datatable_tables(
@@ -1494,98 +1434,22 @@ async fn list_datatable_tables(
     Extension(db): Extension<DB>,
     Path(w_id): Path<String>,
 ) -> JsonResult<Vec<DataTableTables>> {
-    let datatable_resource_results = list_datatable_resources_from_db_unchecked(&db, &w_id).await?;
-    let mut results = Vec::with_capacity(datatable_resource_results.len());
-    let mut datatable_resources = Vec::new();
-    let datatable_resource_results = datatable_resource_results.into_iter().enumerate();
-    for (index, (datatable_name, db_resource)) in datatable_resource_results {
-        results.push(None);
-        match db_resource {
-            Ok(db_resource) => datatable_resources.push((index, datatable_name, db_resource)),
-            Err(e) => {
-                results[index] = Some(DataTableTables {
-                    datatable_name,
-                    schemas: HashMap::new(),
-                    error: Some(e),
-                })
-            }
-        }
+    let datatable_names = list_datatable_names(&db, &w_id).await?;
+    let mut results = Vec::new();
+
+    for datatable_name in datatable_names {
+        let tables = match get_datatable_tables(&db, &w_id, &datatable_name).await {
+            Ok(schemas) => DataTableTables { datatable_name, schemas, error: None },
+            Err(e) => DataTableTables {
+                datatable_name,
+                schemas: HashMap::new(),
+                error: Some(e.to_string()),
+            },
+        };
+        results.push(tables);
     }
 
-    let resource_groups = group_datatables_by_resource(datatable_resources)?;
-    let semaphore = Arc::new(tokio::sync::Semaphore::new(
-        DATATABLE_CATALOG_LIST_CONCURRENCY,
-    ));
-    let mut handles = Vec::with_capacity(resource_groups.len());
-
-    for (db_resource, datatables) in resource_groups {
-        let db = db.clone();
-        let permit = semaphore.clone().acquire_owned().await.map_err(|e| {
-            Error::internal_err(format!("datatable table list semaphore closed: {}", e))
-        })?;
-
-        handles.push(tokio::spawn(async move {
-            let _permit = permit;
-            let schemas = get_datatable_tables_from_resource(&db_resource, Some(&db)).await;
-            datatables
-                .into_iter()
-                .map(|(index, datatable_name)| match &schemas {
-                    Ok(schemas) => (
-                        index,
-                        DataTableTables { datatable_name, schemas: schemas.clone(), error: None },
-                    ),
-                    Err(e) => (
-                        index,
-                        DataTableTables {
-                            datatable_name,
-                            schemas: HashMap::new(),
-                            error: Some(e.to_string()),
-                        },
-                    ),
-                })
-                .collect::<Vec<_>>()
-        }));
-    }
-
-    for handle in handles {
-        let datatables = handle.await.map_err(|e| {
-            Error::internal_err(format!("failed to join datatable table list task: {}", e))
-        })?;
-        for (index, datatable) in datatables {
-            results[index] = Some(datatable);
-        }
-    }
-
-    let mut ordered_results = Vec::with_capacity(results.len());
-    for result in results {
-        ordered_results.push(result.ok_or_else(|| {
-            Error::internal_err("missing datatable table list result".to_string())
-        })?);
-    }
-
-    Ok(Json(ordered_results))
-}
-
-fn group_datatables_by_resource(
-    datatable_resources: Vec<(usize, String, serde_json::Value)>,
-) -> Result<Vec<(serde_json::Value, Vec<(usize, String)>)>> {
-    let mut group_indexes: HashMap<String, usize> = HashMap::new();
-    let mut groups: Vec<(serde_json::Value, Vec<(usize, String)>)> = Vec::new();
-
-    for (index, datatable_name, db_resource) in datatable_resources {
-        let key = serde_json::to_string(&db_resource).map_err(|e| {
-            Error::internal_err(format!("failed to serialize datatable resource: {}", e))
-        })?;
-
-        if let Some(group_index) = group_indexes.get(&key) {
-            groups[*group_index].1.push((index, datatable_name));
-        } else {
-            group_indexes.insert(key, groups.len());
-            groups.push((db_resource, vec![(index, datatable_name)]));
-        }
-    }
-
-    Ok(groups)
+    Ok(Json(results))
 }
 
 async fn get_datatable_table_schema(
@@ -1611,13 +1475,32 @@ async fn get_datatable_table_schema(
     }))
 }
 
-async fn get_datatable_schema_from_resource(
-    db_resource: &serde_json::Value,
-    main_db: Option<&DB>,
-) -> Result<SchemaMap> {
-    let pg_db: PgDatabase = serde_json::from_value(db_resource.clone())
+async fn list_datatable_names(db: &DB, w_id: &str) -> Result<Vec<String>> {
+    Ok(sqlx::query_scalar!(
+        r#"
+            SELECT jsonb_object_keys(ws.datatable->'datatables') AS datatable_name
+            FROM workspace_settings ws
+            WHERE ws.workspace_id = $1
+        "#,
+        w_id
+    )
+    .fetch_all(db)
+    .await?
+    .into_iter()
+    .filter_map(|s| s)
+    .collect())
+}
+
+async fn get_datatable_schema(db: &DB, w_id: &str, datatable_name: &str) -> Result<SchemaMap> {
+    // Get the datatable resource (connection credentials)
+    let db_resource = get_datatable_resource_from_db_unchecked(db, w_id, datatable_name).await?;
+
+    // Parse the resource as PgDatabase
+    let pg_db: PgDatabase = serde_json::from_value(db_resource)
         .map_err(|e| Error::internal_err(format!("Failed to parse database credentials: {}", e)))?;
-    let (client, connection) = pg_db.connect(main_db).await?;
+
+    // Connect to the datatable database
+    let (client, connection) = pg_db.connect(Some(db)).await?;
 
     // Spawn the connection handler
     tokio::spawn(async move {
@@ -1626,77 +1509,82 @@ async fn get_datatable_schema_from_resource(
         }
     });
 
-    let rows = client
+    // First, get all non-system schemas (including empty ones)
+    let schema_rows = client
         .query(
             r#"
-            SELECT
-                n.nspname::text AS schema_name,
-                c.relname::text AS table_name,
-                a.attname::text AS column_name,
-                t.typname::text AS udt_name,
-                CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END::text AS is_nullable,
-                pg_get_expr(ad.adbin, ad.adrelid)::text AS column_default
-            FROM pg_namespace n
-            LEFT JOIN pg_class c
-             ON c.relnamespace = n.oid
-             AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
-             AND (
-                pg_catalog.has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
-                OR pg_catalog.has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES')
-             )
-            LEFT JOIN pg_attribute a
-              ON a.attrelid = c.oid
-             AND a.attnum > 0
-             AND NOT a.attisdropped
-             AND (
-                pg_catalog.has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
-                OR pg_catalog.has_column_privilege(c.oid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES')
-             )
-            LEFT JOIN pg_type t
-              ON t.oid = a.atttypid
-            LEFT JOIN pg_attrdef ad
-              ON ad.adrelid = c.oid
-             AND ad.adnum = a.attnum
-            WHERE n.nspname NOT IN ('information_schema', 'pg_toast', 'pg_catalog')
-              AND n.nspname NOT LIKE 'pg_%'
-            ORDER BY n.nspname, c.relname, a.attnum
+            SELECT nspname::text AS schema_name
+            FROM pg_namespace
+            WHERE nspname NOT IN ('information_schema', 'pg_toast', 'pg_catalog')
+              AND nspname NOT LIKE 'pg_%'
+            ORDER BY nspname
             "#,
             &[],
         )
         .await
+        .map_err(|e| Error::internal_err(format!("Failed to query schemas: {}", e)))?;
+
+    // Build hierarchical structure: schema -> table -> column -> compact_type
+    let mut schema_map: SchemaMap = HashMap::new();
+
+    // Collect schema names and initialize map
+    let schema_names: Vec<String> = schema_rows
+        .iter()
+        .map(|row| {
+            let name: String = row.get(0);
+            schema_map.entry(name.clone()).or_default();
+            name
+        })
+        .collect();
+
+    // Query column information only for the schemas we found
+    let rows = client
+        .query(
+            r#"
+            SELECT
+                table_schema::text,
+                table_name::text,
+                column_name::text,
+                udt_name::text,
+                is_nullable::text,
+                column_default::text
+            FROM information_schema.columns
+            WHERE table_schema = ANY($1)
+              AND table_name IS NOT NULL
+            ORDER BY table_schema, table_name, ordinal_position
+            "#,
+            &[&schema_names],
+        )
+        .await
         .map_err(|e| Error::internal_err(format!("Failed to query columns: {}", e)))?;
 
-    let mut schema_map: SchemaMap = HashMap::new();
     for row in rows {
         let table_schema: String = row.get(0);
-        let table_name: Option<String> = row.get(1);
-        let column_name: Option<String> = row.get(2);
-        let udt_name: Option<String> = row.get(3);
+        let table_name: String = row.get(1);
+        let column_name: String = row.get(2);
+        let udt_name: String = row.get(3);
         let is_nullable: String = row.get(4);
         let column_default: Option<String> = row.get(5);
 
-        let schema = schema_map.entry(table_schema).or_default();
-        if let Some(table_name) = table_name {
-            let table = schema.entry(table_name).or_default();
-            if let (Some(column_name), Some(udt_name)) = (column_name, udt_name) {
-                table.insert(
-                    column_name,
-                    compact_column_type(udt_name, is_nullable, column_default),
-                );
-            }
-        }
+        schema_map
+            .entry(table_schema)
+            .or_default()
+            .entry(table_name)
+            .or_default()
+            .insert(
+                column_name,
+                compact_column_type(udt_name, is_nullable, column_default),
+            );
     }
 
     Ok(schema_map)
 }
 
-async fn get_datatable_tables_from_resource(
-    db_resource: &serde_json::Value,
-    main_db: Option<&DB>,
-) -> Result<TableListMap> {
-    let pg_db: PgDatabase = serde_json::from_value(db_resource.clone())
+async fn get_datatable_tables(db: &DB, w_id: &str, datatable_name: &str) -> Result<TableListMap> {
+    let db_resource = get_datatable_resource_from_db_unchecked(db, w_id, datatable_name).await?;
+    let pg_db: PgDatabase = serde_json::from_value(db_resource)
         .map_err(|e| Error::internal_err(format!("Failed to parse database credentials: {}", e)))?;
-    let (client, connection) = pg_db.connect(main_db).await?;
+    let (client, connection) = pg_db.connect(Some(db)).await?;
 
     tokio::spawn(async move {
         if let Err(e) = connection.await {
@@ -1704,37 +1592,50 @@ async fn get_datatable_tables_from_resource(
         }
     });
 
-    let rows = client
+    let schema_rows = client
         .query(
             r#"
-            SELECT
-                n.nspname::text AS schema_name,
-                c.relname::text AS table_name
-            FROM pg_namespace n
-            LEFT JOIN pg_class c
-             ON c.relnamespace = n.oid
-             AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
-             AND (
-                pg_catalog.has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
-                OR pg_catalog.has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES')
-             )
-            WHERE n.nspname NOT IN ('information_schema', 'pg_toast', 'pg_catalog')
-              AND n.nspname NOT LIKE 'pg_%'
-            ORDER BY n.nspname, c.relname
+            SELECT nspname::text AS schema_name
+            FROM pg_namespace
+            WHERE nspname NOT IN ('information_schema', 'pg_toast', 'pg_catalog')
+              AND nspname NOT LIKE 'pg_%'
+            ORDER BY nspname
             "#,
             &[],
         )
         .await
-        .map_err(|e| Error::internal_err(format!("Failed to query tables: {}", e)))?;
+        .map_err(|e| Error::internal_err(format!("Failed to query schemas: {}", e)))?;
 
     let mut table_map: TableListMap = HashMap::new();
+    let schema_names: Vec<String> = schema_rows
+        .iter()
+        .map(|row| {
+            let name: String = row.get(0);
+            table_map.entry(name.clone()).or_default();
+            name
+        })
+        .collect();
+
+    let rows = client
+        .query(
+            r#"
+            SELECT DISTINCT
+                table_schema::text,
+                table_name::text
+            FROM information_schema.columns
+            WHERE table_schema = ANY($1)
+              AND table_name IS NOT NULL
+            ORDER BY table_schema, table_name
+            "#,
+            &[&schema_names],
+        )
+        .await
+        .map_err(|e| Error::internal_err(format!("Failed to query tables: {}", e)))?;
+
     for row in rows {
         let table_schema: String = row.get(0);
-        let table_name: Option<String> = row.get(1);
-        let tables = table_map.entry(table_schema).or_default();
-        if let Some(table_name) = table_name {
-            tables.push(table_name);
-        }
+        let table_name: String = row.get(1);
+        table_map.entry(table_schema).or_default().push(table_name);
     }
 
     Ok(table_map)
@@ -1748,26 +1649,9 @@ async fn get_datatable_table_columns(
     table_name: &str,
 ) -> Result<ColumnMap> {
     let db_resource = get_datatable_resource_from_db_unchecked(db, w_id, datatable_name).await?;
-    get_datatable_table_columns_from_resource(
-        &db_resource,
-        Some(db),
-        datatable_name,
-        schema_name,
-        table_name,
-    )
-    .await
-}
-
-async fn get_datatable_table_columns_from_resource(
-    db_resource: &serde_json::Value,
-    main_db: Option<&DB>,
-    datatable_name: &str,
-    schema_name: &str,
-    table_name: &str,
-) -> Result<ColumnMap> {
-    let pg_db: PgDatabase = serde_json::from_value(db_resource.clone())
+    let pg_db: PgDatabase = serde_json::from_value(db_resource)
         .map_err(|e| Error::internal_err(format!("Failed to parse database credentials: {}", e)))?;
-    let (client, connection) = pg_db.connect(main_db).await?;
+    let (client, connection) = pg_db.connect(Some(db)).await?;
 
     tokio::spawn(async move {
         if let Err(e) = connection.await {
@@ -1779,34 +1663,14 @@ async fn get_datatable_table_columns_from_resource(
         .query(
             r#"
             SELECT
-                a.attname::text AS column_name,
-                t.typname::text AS udt_name,
-                CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END::text AS is_nullable,
-                pg_get_expr(ad.adbin, ad.adrelid)::text AS column_default
-            FROM pg_namespace n
-            JOIN pg_class c
-             ON c.relnamespace = n.oid
-             AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
-             AND (
-                pg_catalog.has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
-                OR pg_catalog.has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES')
-             )
-            LEFT JOIN pg_attribute a
-              ON a.attrelid = c.oid
-             AND a.attnum > 0
-             AND NOT a.attisdropped
-             AND (
-                pg_catalog.has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
-                OR pg_catalog.has_column_privilege(c.oid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES')
-             )
-            LEFT JOIN pg_type t
-              ON t.oid = a.atttypid
-            LEFT JOIN pg_attrdef ad
-              ON ad.adrelid = c.oid
-             AND ad.adnum = a.attnum
-            WHERE n.nspname = $1
-              AND c.relname = $2
-            ORDER BY a.attnum
+                column_name::text,
+                udt_name::text,
+                is_nullable::text,
+                column_default::text
+            FROM information_schema.columns
+            WHERE table_schema = $1
+              AND table_name = $2
+            ORDER BY ordinal_position
             "#,
             &[&schema_name, &table_name],
         )
@@ -1822,16 +1686,14 @@ async fn get_datatable_table_columns_from_resource(
 
     let mut columns: ColumnMap = HashMap::new();
     for row in rows {
-        let column_name: Option<String> = row.get(0);
-        let udt_name: Option<String> = row.get(1);
+        let column_name: String = row.get(0);
+        let udt_name: String = row.get(1);
         let is_nullable: String = row.get(2);
         let column_default: Option<String> = row.get(3);
-        if let (Some(column_name), Some(udt_name)) = (column_name, udt_name) {
-            columns.insert(
-                column_name,
-                compact_column_type(udt_name, is_nullable, column_default),
-            );
-        }
+        columns.insert(
+            column_name,
+            compact_column_type(udt_name, is_nullable, column_default),
+        );
     }
 
     Ok(columns)

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -1707,6 +1707,7 @@ async fn get_datatable_table_columns(
 }
 
 fn is_system_pg_schema(schema_name: &str) -> bool {
+    // Match the datatable listing filter: PostgreSQL reserves pg_* schemas for system use.
     matches!(
         schema_name,
         "information_schema" | "pg_toast" | "pg_catalog"

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -1724,15 +1724,42 @@ fn compact_column_type(
         compact.push('?');
     }
     if let Some(default) = column_default {
-        let short_default = if default.len() > 30 {
-            format!("{}...", &default[..27])
-        } else {
-            default
-        };
         compact.push('=');
-        compact.push_str(&short_default);
+        compact.push_str(&truncate_column_default(default));
     }
     compact
+}
+
+fn truncate_column_default(default: String) -> String {
+    const MAX_DEFAULT_CHARS: usize = 30;
+    const TRUNCATED_DEFAULT_CHARS: usize = 27;
+
+    if default.chars().count() > MAX_DEFAULT_CHARS {
+        format!(
+            "{}...",
+            default
+                .chars()
+                .take(TRUNCATED_DEFAULT_CHARS)
+                .collect::<String>()
+        )
+    } else {
+        default
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_column_type_truncates_multibyte_defaults_safely() {
+        let default = "é".repeat(31);
+
+        assert_eq!(
+            compact_column_type("text".to_string(), "NO".to_string(), Some(default)),
+            format!("text={}...", "é".repeat(27))
+        );
+    }
 }
 
 /// Resolve a source string to PgDatabase credentials with user-scoped permission checks.

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -1648,6 +1648,13 @@ async fn get_datatable_table_columns(
     schema_name: &str,
     table_name: &str,
 ) -> Result<ColumnMap> {
+    if is_system_pg_schema(schema_name) {
+        return Err(Error::BadRequest(format!(
+            "Schema '{}' is not available for datatable schema lookup",
+            schema_name
+        )));
+    }
+
     let db_resource = get_datatable_resource_from_db_unchecked(db, w_id, datatable_name).await?;
     let pg_db: PgDatabase = serde_json::from_value(db_resource)
         .map_err(|e| Error::internal_err(format!("Failed to parse database credentials: {}", e)))?;
@@ -1697,6 +1704,13 @@ async fn get_datatable_table_columns(
     }
 
     Ok(columns)
+}
+
+fn is_system_pg_schema(schema_name: &str) -> bool {
+    matches!(
+        schema_name,
+        "information_schema" | "pg_toast" | "pg_catalog"
+    ) || schema_name.starts_with("pg_")
 }
 
 fn compact_column_type(

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -24,7 +24,10 @@ use regex::Regex;
 
 use hex;
 use sha2::{Digest, Sha256};
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 use strum::IntoEnumIterator;
 use uuid::Uuid;
 use windmill_audit::audit_oss::{audit_log, AuditAuthorable};
@@ -39,9 +42,10 @@ use windmill_common::workspaces::GitRepositorySettings;
 #[cfg(feature = "enterprise")]
 use windmill_common::workspaces::WorkspaceDeploymentUISettings;
 use windmill_common::workspaces::{
-    check_user_against_rule, get_datatable_resource_from_db_unchecked, DataTable,
-    DataTableCatalogResourceType, DataTableForkBehavior, ProtectionRuleKind, ProtectionRules,
-    ProtectionRuleset, RuleCheckResult, WorkspaceGitSyncSettings, WM_FORK_PREFIX,
+    check_user_against_rule, get_datatable_resource_from_db_unchecked,
+    list_datatable_resources_from_db_unchecked, DataTable, DataTableCatalogResourceType,
+    DataTableForkBehavior, ProtectionRuleKind, ProtectionRules, ProtectionRuleset, RuleCheckResult,
+    WorkspaceGitSyncSettings, WM_FORK_PREFIX,
 };
 use windmill_common::workspaces::{Ducklake, DucklakeCatalogResourceType};
 use windmill_common::PgDatabase;
@@ -1373,6 +1377,8 @@ type SchemaMap = HashMap<String, TableMap>;
 /// Schemas mapped by name to their table names
 type TableListMap = HashMap<String, Vec<String>>;
 
+const DATATABLE_CATALOG_LIST_CONCURRENCY: usize = 4;
+
 #[derive(Serialize, Debug)]
 struct DataTableSchema {
     datatable_name: String,
@@ -1411,22 +1417,76 @@ async fn list_datatable_schemas(
     Extension(db): Extension<DB>,
     Path(w_id): Path<String>,
 ) -> JsonResult<Vec<DataTableSchema>> {
-    let datatable_names = list_datatable_names(&db, &w_id).await?;
-    let mut results = Vec::new();
-
-    for datatable_name in datatable_names {
-        let schema = match get_datatable_schema(&db, &w_id, &datatable_name).await {
-            Ok(schemas) => DataTableSchema { datatable_name, schemas, error: None },
-            Err(e) => DataTableSchema {
-                datatable_name,
-                schemas: HashMap::new(),
-                error: Some(e.to_string()),
-            },
-        };
-        results.push(schema);
+    let datatable_resource_results = list_datatable_resources_from_db_unchecked(&db, &w_id).await?;
+    let mut results = Vec::with_capacity(datatable_resource_results.len());
+    let mut datatable_resources = Vec::new();
+    let datatable_resource_results = datatable_resource_results.into_iter().enumerate();
+    for (index, (datatable_name, db_resource)) in datatable_resource_results {
+        results.push(None);
+        match db_resource {
+            Ok(db_resource) => datatable_resources.push((index, datatable_name, db_resource)),
+            Err(e) => {
+                results[index] = Some(DataTableSchema {
+                    datatable_name,
+                    schemas: HashMap::new(),
+                    error: Some(e),
+                })
+            }
+        }
     }
 
-    Ok(Json(results))
+    let resource_groups = group_datatables_by_resource(datatable_resources)?;
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(
+        DATATABLE_CATALOG_LIST_CONCURRENCY,
+    ));
+    let mut handles = Vec::with_capacity(resource_groups.len());
+
+    for (db_resource, datatables) in resource_groups {
+        let db = db.clone();
+        let permit = semaphore.clone().acquire_owned().await.map_err(|e| {
+            Error::internal_err(format!("datatable schema list semaphore closed: {}", e))
+        })?;
+
+        handles.push(tokio::spawn(async move {
+            let _permit = permit;
+            let schemas = get_datatable_schema_from_resource(&db_resource, Some(&db)).await;
+            datatables
+                .into_iter()
+                .map(|(index, datatable_name)| match &schemas {
+                    Ok(schemas) => (
+                        index,
+                        DataTableSchema { datatable_name, schemas: schemas.clone(), error: None },
+                    ),
+                    Err(e) => (
+                        index,
+                        DataTableSchema {
+                            datatable_name,
+                            schemas: HashMap::new(),
+                            error: Some(e.to_string()),
+                        },
+                    ),
+                })
+                .collect::<Vec<_>>()
+        }));
+    }
+
+    for handle in handles {
+        let datatables = handle.await.map_err(|e| {
+            Error::internal_err(format!("failed to join datatable schema list task: {}", e))
+        })?;
+        for (index, datatable) in datatables {
+            results[index] = Some(datatable);
+        }
+    }
+
+    let mut ordered_results = Vec::with_capacity(results.len());
+    for result in results {
+        ordered_results.push(result.ok_or_else(|| {
+            Error::internal_err("missing datatable schema list result".to_string())
+        })?);
+    }
+
+    Ok(Json(ordered_results))
 }
 
 async fn list_datatable_tables(
@@ -1434,22 +1494,98 @@ async fn list_datatable_tables(
     Extension(db): Extension<DB>,
     Path(w_id): Path<String>,
 ) -> JsonResult<Vec<DataTableTables>> {
-    let datatable_names = list_datatable_names(&db, &w_id).await?;
-    let mut results = Vec::new();
-
-    for datatable_name in datatable_names {
-        let tables = match get_datatable_tables(&db, &w_id, &datatable_name).await {
-            Ok(schemas) => DataTableTables { datatable_name, schemas, error: None },
-            Err(e) => DataTableTables {
-                datatable_name,
-                schemas: HashMap::new(),
-                error: Some(e.to_string()),
-            },
-        };
-        results.push(tables);
+    let datatable_resource_results = list_datatable_resources_from_db_unchecked(&db, &w_id).await?;
+    let mut results = Vec::with_capacity(datatable_resource_results.len());
+    let mut datatable_resources = Vec::new();
+    let datatable_resource_results = datatable_resource_results.into_iter().enumerate();
+    for (index, (datatable_name, db_resource)) in datatable_resource_results {
+        results.push(None);
+        match db_resource {
+            Ok(db_resource) => datatable_resources.push((index, datatable_name, db_resource)),
+            Err(e) => {
+                results[index] = Some(DataTableTables {
+                    datatable_name,
+                    schemas: HashMap::new(),
+                    error: Some(e),
+                })
+            }
+        }
     }
 
-    Ok(Json(results))
+    let resource_groups = group_datatables_by_resource(datatable_resources)?;
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(
+        DATATABLE_CATALOG_LIST_CONCURRENCY,
+    ));
+    let mut handles = Vec::with_capacity(resource_groups.len());
+
+    for (db_resource, datatables) in resource_groups {
+        let db = db.clone();
+        let permit = semaphore.clone().acquire_owned().await.map_err(|e| {
+            Error::internal_err(format!("datatable table list semaphore closed: {}", e))
+        })?;
+
+        handles.push(tokio::spawn(async move {
+            let _permit = permit;
+            let schemas = get_datatable_tables_from_resource(&db_resource, Some(&db)).await;
+            datatables
+                .into_iter()
+                .map(|(index, datatable_name)| match &schemas {
+                    Ok(schemas) => (
+                        index,
+                        DataTableTables { datatable_name, schemas: schemas.clone(), error: None },
+                    ),
+                    Err(e) => (
+                        index,
+                        DataTableTables {
+                            datatable_name,
+                            schemas: HashMap::new(),
+                            error: Some(e.to_string()),
+                        },
+                    ),
+                })
+                .collect::<Vec<_>>()
+        }));
+    }
+
+    for handle in handles {
+        let datatables = handle.await.map_err(|e| {
+            Error::internal_err(format!("failed to join datatable table list task: {}", e))
+        })?;
+        for (index, datatable) in datatables {
+            results[index] = Some(datatable);
+        }
+    }
+
+    let mut ordered_results = Vec::with_capacity(results.len());
+    for result in results {
+        ordered_results.push(result.ok_or_else(|| {
+            Error::internal_err("missing datatable table list result".to_string())
+        })?);
+    }
+
+    Ok(Json(ordered_results))
+}
+
+fn group_datatables_by_resource(
+    datatable_resources: Vec<(usize, String, serde_json::Value)>,
+) -> Result<Vec<(serde_json::Value, Vec<(usize, String)>)>> {
+    let mut group_indexes: HashMap<String, usize> = HashMap::new();
+    let mut groups: Vec<(serde_json::Value, Vec<(usize, String)>)> = Vec::new();
+
+    for (index, datatable_name, db_resource) in datatable_resources {
+        let key = serde_json::to_string(&db_resource).map_err(|e| {
+            Error::internal_err(format!("failed to serialize datatable resource: {}", e))
+        })?;
+
+        if let Some(group_index) = group_indexes.get(&key) {
+            groups[*group_index].1.push((index, datatable_name));
+        } else {
+            group_indexes.insert(key, groups.len());
+            groups.push((db_resource, vec![(index, datatable_name)]));
+        }
+    }
+
+    Ok(groups)
 }
 
 async fn get_datatable_table_schema(
@@ -1475,32 +1611,13 @@ async fn get_datatable_table_schema(
     }))
 }
 
-async fn list_datatable_names(db: &DB, w_id: &str) -> Result<Vec<String>> {
-    Ok(sqlx::query_scalar!(
-        r#"
-            SELECT jsonb_object_keys(ws.datatable->'datatables') AS datatable_name
-            FROM workspace_settings ws
-            WHERE ws.workspace_id = $1
-        "#,
-        w_id
-    )
-    .fetch_all(db)
-    .await?
-    .into_iter()
-    .filter_map(|s| s)
-    .collect())
-}
-
-async fn get_datatable_schema(db: &DB, w_id: &str, datatable_name: &str) -> Result<SchemaMap> {
-    // Get the datatable resource (connection credentials)
-    let db_resource = get_datatable_resource_from_db_unchecked(db, w_id, datatable_name).await?;
-
-    // Parse the resource as PgDatabase
-    let pg_db: PgDatabase = serde_json::from_value(db_resource)
+async fn get_datatable_schema_from_resource(
+    db_resource: &serde_json::Value,
+    main_db: Option<&DB>,
+) -> Result<SchemaMap> {
+    let pg_db: PgDatabase = serde_json::from_value(db_resource.clone())
         .map_err(|e| Error::internal_err(format!("Failed to parse database credentials: {}", e)))?;
-
-    // Connect to the datatable database
-    let (client, connection) = pg_db.connect(Some(db)).await?;
+    let (client, connection) = pg_db.connect(main_db).await?;
 
     // Spawn the connection handler
     tokio::spawn(async move {
@@ -1509,82 +1626,77 @@ async fn get_datatable_schema(db: &DB, w_id: &str, datatable_name: &str) -> Resu
         }
     });
 
-    // First, get all non-system schemas (including empty ones)
-    let schema_rows = client
-        .query(
-            r#"
-            SELECT nspname::text AS schema_name
-            FROM pg_namespace
-            WHERE nspname NOT IN ('information_schema', 'pg_toast', 'pg_catalog')
-              AND nspname NOT LIKE 'pg_%'
-            ORDER BY nspname
-            "#,
-            &[],
-        )
-        .await
-        .map_err(|e| Error::internal_err(format!("Failed to query schemas: {}", e)))?;
-
-    // Build hierarchical structure: schema -> table -> column -> compact_type
-    let mut schema_map: SchemaMap = HashMap::new();
-
-    // Collect schema names and initialize map
-    let schema_names: Vec<String> = schema_rows
-        .iter()
-        .map(|row| {
-            let name: String = row.get(0);
-            schema_map.entry(name.clone()).or_default();
-            name
-        })
-        .collect();
-
-    // Query column information only for the schemas we found
     let rows = client
         .query(
             r#"
             SELECT
-                table_schema::text,
-                table_name::text,
-                column_name::text,
-                udt_name::text,
-                is_nullable::text,
-                column_default::text
-            FROM information_schema.columns
-            WHERE table_schema = ANY($1)
-              AND table_name IS NOT NULL
-            ORDER BY table_schema, table_name, ordinal_position
+                n.nspname::text AS schema_name,
+                c.relname::text AS table_name,
+                a.attname::text AS column_name,
+                t.typname::text AS udt_name,
+                CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END::text AS is_nullable,
+                pg_get_expr(ad.adbin, ad.adrelid)::text AS column_default
+            FROM pg_namespace n
+            LEFT JOIN pg_class c
+             ON c.relnamespace = n.oid
+             AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
+             AND (
+                pg_catalog.has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+                OR pg_catalog.has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES')
+             )
+            LEFT JOIN pg_attribute a
+              ON a.attrelid = c.oid
+             AND a.attnum > 0
+             AND NOT a.attisdropped
+             AND (
+                pg_catalog.has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+                OR pg_catalog.has_column_privilege(c.oid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES')
+             )
+            LEFT JOIN pg_type t
+              ON t.oid = a.atttypid
+            LEFT JOIN pg_attrdef ad
+              ON ad.adrelid = c.oid
+             AND ad.adnum = a.attnum
+            WHERE n.nspname NOT IN ('information_schema', 'pg_toast', 'pg_catalog')
+              AND n.nspname NOT LIKE 'pg_%'
+            ORDER BY n.nspname, c.relname, a.attnum
             "#,
-            &[&schema_names],
+            &[],
         )
         .await
         .map_err(|e| Error::internal_err(format!("Failed to query columns: {}", e)))?;
 
+    let mut schema_map: SchemaMap = HashMap::new();
     for row in rows {
         let table_schema: String = row.get(0);
-        let table_name: String = row.get(1);
-        let column_name: String = row.get(2);
-        let udt_name: String = row.get(3);
+        let table_name: Option<String> = row.get(1);
+        let column_name: Option<String> = row.get(2);
+        let udt_name: Option<String> = row.get(3);
         let is_nullable: String = row.get(4);
         let column_default: Option<String> = row.get(5);
 
-        schema_map
-            .entry(table_schema)
-            .or_default()
-            .entry(table_name)
-            .or_default()
-            .insert(
-                column_name,
-                compact_column_type(udt_name, is_nullable, column_default),
-            );
+        let schema = schema_map.entry(table_schema).or_default();
+        if let Some(table_name) = table_name {
+            let table = schema.entry(table_name).or_default();
+            if let (Some(column_name), Some(udt_name)) = (column_name, udt_name) {
+                table.insert(
+                    column_name,
+                    compact_column_type(udt_name, is_nullable, column_default),
+                );
+            }
+        }
     }
 
     Ok(schema_map)
 }
 
-async fn get_datatable_tables(db: &DB, w_id: &str, datatable_name: &str) -> Result<TableListMap> {
-    let db_resource = get_datatable_resource_from_db_unchecked(db, w_id, datatable_name).await?;
-    let pg_db: PgDatabase = serde_json::from_value(db_resource)
+async fn get_datatable_tables_from_resource(
+    db_resource: &serde_json::Value,
+    main_db: Option<&DB>,
+) -> Result<TableListMap> {
+    let pg_db: PgDatabase = serde_json::from_value(db_resource.clone())
         .map_err(|e| Error::internal_err(format!("Failed to parse database credentials: {}", e)))?;
-    let (client, connection) = pg_db.connect(Some(db)).await?;
+    let (client, connection) = pg_db.connect(main_db).await?;
 
     tokio::spawn(async move {
         if let Err(e) = connection.await {
@@ -1592,50 +1704,37 @@ async fn get_datatable_tables(db: &DB, w_id: &str, datatable_name: &str) -> Resu
         }
     });
 
-    let schema_rows = client
+    let rows = client
         .query(
             r#"
-            SELECT nspname::text AS schema_name
-            FROM pg_namespace
-            WHERE nspname NOT IN ('information_schema', 'pg_toast', 'pg_catalog')
-              AND nspname NOT LIKE 'pg_%'
-            ORDER BY nspname
+            SELECT
+                n.nspname::text AS schema_name,
+                c.relname::text AS table_name
+            FROM pg_namespace n
+            LEFT JOIN pg_class c
+             ON c.relnamespace = n.oid
+             AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
+             AND (
+                pg_catalog.has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+                OR pg_catalog.has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES')
+             )
+            WHERE n.nspname NOT IN ('information_schema', 'pg_toast', 'pg_catalog')
+              AND n.nspname NOT LIKE 'pg_%'
+            ORDER BY n.nspname, c.relname
             "#,
             &[],
         )
         .await
-        .map_err(|e| Error::internal_err(format!("Failed to query schemas: {}", e)))?;
-
-    let mut table_map: TableListMap = HashMap::new();
-    let schema_names: Vec<String> = schema_rows
-        .iter()
-        .map(|row| {
-            let name: String = row.get(0);
-            table_map.entry(name.clone()).or_default();
-            name
-        })
-        .collect();
-
-    let rows = client
-        .query(
-            r#"
-            SELECT DISTINCT
-                table_schema::text,
-                table_name::text
-            FROM information_schema.columns
-            WHERE table_schema = ANY($1)
-              AND table_name IS NOT NULL
-            ORDER BY table_schema, table_name
-            "#,
-            &[&schema_names],
-        )
-        .await
         .map_err(|e| Error::internal_err(format!("Failed to query tables: {}", e)))?;
 
+    let mut table_map: TableListMap = HashMap::new();
     for row in rows {
         let table_schema: String = row.get(0);
-        let table_name: String = row.get(1);
-        table_map.entry(table_schema).or_default().push(table_name);
+        let table_name: Option<String> = row.get(1);
+        let tables = table_map.entry(table_schema).or_default();
+        if let Some(table_name) = table_name {
+            tables.push(table_name);
+        }
     }
 
     Ok(table_map)
@@ -1649,9 +1748,26 @@ async fn get_datatable_table_columns(
     table_name: &str,
 ) -> Result<ColumnMap> {
     let db_resource = get_datatable_resource_from_db_unchecked(db, w_id, datatable_name).await?;
-    let pg_db: PgDatabase = serde_json::from_value(db_resource)
+    get_datatable_table_columns_from_resource(
+        &db_resource,
+        Some(db),
+        datatable_name,
+        schema_name,
+        table_name,
+    )
+    .await
+}
+
+async fn get_datatable_table_columns_from_resource(
+    db_resource: &serde_json::Value,
+    main_db: Option<&DB>,
+    datatable_name: &str,
+    schema_name: &str,
+    table_name: &str,
+) -> Result<ColumnMap> {
+    let pg_db: PgDatabase = serde_json::from_value(db_resource.clone())
         .map_err(|e| Error::internal_err(format!("Failed to parse database credentials: {}", e)))?;
-    let (client, connection) = pg_db.connect(Some(db)).await?;
+    let (client, connection) = pg_db.connect(main_db).await?;
 
     tokio::spawn(async move {
         if let Err(e) = connection.await {
@@ -1663,14 +1779,34 @@ async fn get_datatable_table_columns(
         .query(
             r#"
             SELECT
-                column_name::text,
-                udt_name::text,
-                is_nullable::text,
-                column_default::text
-            FROM information_schema.columns
-            WHERE table_schema = $1
-              AND table_name = $2
-            ORDER BY ordinal_position
+                a.attname::text AS column_name,
+                t.typname::text AS udt_name,
+                CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END::text AS is_nullable,
+                pg_get_expr(ad.adbin, ad.adrelid)::text AS column_default
+            FROM pg_namespace n
+            JOIN pg_class c
+             ON c.relnamespace = n.oid
+             AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
+             AND (
+                pg_catalog.has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+                OR pg_catalog.has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES')
+             )
+            LEFT JOIN pg_attribute a
+              ON a.attrelid = c.oid
+             AND a.attnum > 0
+             AND NOT a.attisdropped
+             AND (
+                pg_catalog.has_table_privilege(c.oid, 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER')
+                OR pg_catalog.has_column_privilege(c.oid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES')
+             )
+            LEFT JOIN pg_type t
+              ON t.oid = a.atttypid
+            LEFT JOIN pg_attrdef ad
+              ON ad.adrelid = c.oid
+             AND ad.adnum = a.attnum
+            WHERE n.nspname = $1
+              AND c.relname = $2
+            ORDER BY a.attnum
             "#,
             &[&schema_name, &table_name],
         )
@@ -1686,14 +1822,16 @@ async fn get_datatable_table_columns(
 
     let mut columns: ColumnMap = HashMap::new();
     for row in rows {
-        let column_name: String = row.get(0);
-        let udt_name: String = row.get(1);
+        let column_name: Option<String> = row.get(0);
+        let udt_name: Option<String> = row.get(1);
         let is_nullable: String = row.get(2);
         let column_default: Option<String> = row.get(3);
-        columns.insert(
-            column_name,
-            compact_column_type(udt_name, is_nullable, column_default),
-        );
+        if let (Some(column_name), Some(udt_name)) = (column_name, udt_name) {
+            columns.insert(
+                column_name,
+                compact_column_type(udt_name, is_nullable, column_default),
+            );
+        }
     }
 
     Ok(columns)

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -3996,6 +3996,55 @@ paths:
                 items:
                   $ref: "#/components/schemas/DataTableSchema"
 
+  /w/{workspace}/workspaces/list_datatable_tables:
+    get:
+      summary: list tables of all connected Datatables
+      operationId: listDataTableTables
+      tags:
+        - workspace
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+      responses:
+        "200":
+          description: table metadata of all datatables
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DataTableTables"
+
+  /w/{workspace}/workspaces/get_datatable_table_schema:
+    get:
+      summary: get one Datatable table schema
+      operationId: getDataTableTableSchema
+      tags:
+        - workspace
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - name: datatable_name
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: schema_name
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: table_name
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: schema of one datatable table
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DataTableTableSchema"
+
   /w/{workspace}/workspaces/edit_ducklake_config:
     post:
       summary: edit ducklake settings
@@ -26476,6 +26525,39 @@ components:
                 description: "Compact type: 'type[?][=default]' where ? means nullable"
         error:
           type: string
+
+    DataTableTables:
+      type: object
+      required: [datatable_name, schemas]
+      properties:
+        datatable_name:
+          type: string
+        schemas:
+          type: object
+          description: "Hierarchical metadata: schema_name -> table_names"
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        error:
+          type: string
+
+    DataTableTableSchema:
+      type: object
+      required: [datatable_name, schema_name, table_name, columns]
+      properties:
+        datatable_name:
+          type: string
+        schema_name:
+          type: string
+        table_name:
+          type: string
+        columns:
+          type: object
+          description: "Columns in this table: column_name -> compact_type"
+          additionalProperties:
+            type: string
+            description: "Compact type: 'type[?][=default]' where ? means nullable"
 
     DynamicInputData:
       type: object

--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -499,21 +499,163 @@ pub async fn get_datatable_resource_from_db_unchecked(
     .ok_or_else(|| Error::internal_err(format!("datatable {name} not found")))?;
     let datatable = serde_json::from_value::<DataTable>(datatable)?;
 
+    datatable_resource_from_config_unchecked(db, w_id, &datatable, None, None).await
+}
+
+pub async fn list_datatable_resources_from_db_unchecked(
+    db: &DB,
+    w_id: &str,
+) -> Result<Vec<(String, std::result::Result<serde_json::Value, String>)>> {
+    let config: Option<serde_json::Value> = sqlx::query_scalar::<_, Option<serde_json::Value>>(
+        r#"
+            SELECT ws.datatable->'datatables' AS config
+            FROM workspace_settings ws
+            WHERE ws.workspace_id = $1
+        "#,
+    )
+    .bind(w_id)
+    .fetch_optional(db)
+    .await?
+    .flatten();
+
+    let raw_datatables: std::collections::BTreeMap<String, serde_json::Value> = match config {
+        Some(value) if !value.is_null() => serde_json::from_value(value)?,
+        _ => std::collections::BTreeMap::new(),
+    };
+
+    let mut datatables = Vec::with_capacity(raw_datatables.len());
+    let mut needs_instance_password = false;
+    let mut resource_paths = std::collections::BTreeSet::new();
+    for (name, value) in raw_datatables {
+        match serde_json::from_value::<DataTable>(value) {
+            Ok(datatable) => {
+                needs_instance_password |=
+                    datatable.database.resource_type == DataTableCatalogResourceType::Instance;
+                if datatable.database.resource_type != DataTableCatalogResourceType::Instance {
+                    resource_paths.insert(datatable.database.resource_path.clone());
+                }
+                datatables.push((name, Ok(datatable)));
+            }
+            Err(e) => datatables.push((name, Err(e.to_string()))),
+        }
+    }
+
+    let mut resource_values = std::collections::BTreeMap::new();
+    if !resource_paths.is_empty() {
+        let resource_paths = resource_paths.into_iter().collect::<Vec<_>>();
+        let resources: Vec<(String, serde_json::Value)> = sqlx::query_as(
+            r#"
+                SELECT path, value
+                FROM resource
+                WHERE workspace_id = $1 AND path = ANY($2)
+            "#,
+        )
+        .bind(w_id)
+        .bind(&resource_paths)
+        .fetch_all(db)
+        .await?;
+
+        for (path, value) in resources {
+            resource_values.insert(path, value);
+        }
+    }
+
+    let instance_password = match needs_instance_password {
+        true => Some(
+            get_custom_pg_instance_password(db)
+                .await
+                .map_err(|e| e.to_string()),
+        ),
+        false => None,
+    };
+
+    let mut resources = Vec::with_capacity(datatables.len());
+    for (name, datatable) in datatables {
+        let db_resource = match datatable {
+            Ok(datatable) => {
+                let instance_password =
+                    if datatable.database.resource_type == DataTableCatalogResourceType::Instance {
+                        match instance_password.as_ref() {
+                            Some(Ok(password)) => Some(password.as_str()),
+                            Some(Err(e)) => {
+                                resources.push((name, Err(e.clone())));
+                                continue;
+                            }
+                            None => None,
+                        }
+                    } else {
+                        None
+                    };
+                let resource_value =
+                    if datatable.database.resource_type == DataTableCatalogResourceType::Instance {
+                        None
+                    } else {
+                        match resource_values.get(&datatable.database.resource_path) {
+                            Some(resource_value) => Some(resource_value),
+                            None => {
+                                resources.push((
+                                    name,
+                                    Err(format!(
+                                        "datatable resource {} not found",
+                                        datatable.database.resource_path
+                                    )),
+                                ));
+                                continue;
+                            }
+                        }
+                    };
+
+                datatable_resource_from_config_unchecked(
+                    db,
+                    w_id,
+                    &datatable,
+                    instance_password,
+                    resource_value,
+                )
+                .await
+                .map_err(|e| e.to_string())
+            }
+            Err(e) => Err(e),
+        };
+        resources.push((name, db_resource));
+    }
+
+    Ok(resources)
+}
+
+async fn datatable_resource_from_config_unchecked(
+    db: &DB,
+    w_id: &str,
+    datatable: &DataTable,
+    instance_password: Option<&str>,
+    resource_value: Option<&serde_json::Value>,
+) -> Result<serde_json::Value> {
     let db_resource = if datatable.database.resource_type == DataTableCatalogResourceType::Instance
     {
         let mut pg_creds = PgDatabase::parse_uri(&get_database_url().await?.as_str().await)?;
         pg_creds.dbname = datatable.database.resource_path.clone();
         pg_creds.user = Some("custom_instance_user".to_string());
-        pg_creds.password = Some(get_custom_pg_instance_password(&db).await?);
+        pg_creds.password = Some(match instance_password {
+            Some(password) => password.to_string(),
+            None => get_custom_pg_instance_password(db).await?,
+        });
         serde_json::to_value(&pg_creds)
             .map_err(|e| Error::internal_err(format!("Error serializing pg creds: {}", e)))?
     } else {
-        transform_json_unchecked(
-            &serde_json::Value::String(format!("$res:{}", datatable.database.resource_path)),
-            w_id,
-            db,
-        )
-        .await?
+        match resource_value {
+            Some(resource_value) => transform_json_unchecked(resource_value, w_id, db).await?,
+            None => {
+                transform_json_unchecked(
+                    &serde_json::Value::String(format!(
+                        "$res:{}",
+                        datatable.database.resource_path
+                    )),
+                    w_id,
+                    db,
+                )
+                .await?
+            }
+        }
     };
 
     Ok(db_resource)

--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -499,163 +499,21 @@ pub async fn get_datatable_resource_from_db_unchecked(
     .ok_or_else(|| Error::internal_err(format!("datatable {name} not found")))?;
     let datatable = serde_json::from_value::<DataTable>(datatable)?;
 
-    datatable_resource_from_config_unchecked(db, w_id, &datatable, None, None).await
-}
-
-pub async fn list_datatable_resources_from_db_unchecked(
-    db: &DB,
-    w_id: &str,
-) -> Result<Vec<(String, std::result::Result<serde_json::Value, String>)>> {
-    let config: Option<serde_json::Value> = sqlx::query_scalar::<_, Option<serde_json::Value>>(
-        r#"
-            SELECT ws.datatable->'datatables' AS config
-            FROM workspace_settings ws
-            WHERE ws.workspace_id = $1
-        "#,
-    )
-    .bind(w_id)
-    .fetch_optional(db)
-    .await?
-    .flatten();
-
-    let raw_datatables: std::collections::BTreeMap<String, serde_json::Value> = match config {
-        Some(value) if !value.is_null() => serde_json::from_value(value)?,
-        _ => std::collections::BTreeMap::new(),
-    };
-
-    let mut datatables = Vec::with_capacity(raw_datatables.len());
-    let mut needs_instance_password = false;
-    let mut resource_paths = std::collections::BTreeSet::new();
-    for (name, value) in raw_datatables {
-        match serde_json::from_value::<DataTable>(value) {
-            Ok(datatable) => {
-                needs_instance_password |=
-                    datatable.database.resource_type == DataTableCatalogResourceType::Instance;
-                if datatable.database.resource_type != DataTableCatalogResourceType::Instance {
-                    resource_paths.insert(datatable.database.resource_path.clone());
-                }
-                datatables.push((name, Ok(datatable)));
-            }
-            Err(e) => datatables.push((name, Err(e.to_string()))),
-        }
-    }
-
-    let mut resource_values = std::collections::BTreeMap::new();
-    if !resource_paths.is_empty() {
-        let resource_paths = resource_paths.into_iter().collect::<Vec<_>>();
-        let resources: Vec<(String, serde_json::Value)> = sqlx::query_as(
-            r#"
-                SELECT path, value
-                FROM resource
-                WHERE workspace_id = $1 AND path = ANY($2)
-            "#,
-        )
-        .bind(w_id)
-        .bind(&resource_paths)
-        .fetch_all(db)
-        .await?;
-
-        for (path, value) in resources {
-            resource_values.insert(path, value);
-        }
-    }
-
-    let instance_password = match needs_instance_password {
-        true => Some(
-            get_custom_pg_instance_password(db)
-                .await
-                .map_err(|e| e.to_string()),
-        ),
-        false => None,
-    };
-
-    let mut resources = Vec::with_capacity(datatables.len());
-    for (name, datatable) in datatables {
-        let db_resource = match datatable {
-            Ok(datatable) => {
-                let instance_password =
-                    if datatable.database.resource_type == DataTableCatalogResourceType::Instance {
-                        match instance_password.as_ref() {
-                            Some(Ok(password)) => Some(password.as_str()),
-                            Some(Err(e)) => {
-                                resources.push((name, Err(e.clone())));
-                                continue;
-                            }
-                            None => None,
-                        }
-                    } else {
-                        None
-                    };
-                let resource_value =
-                    if datatable.database.resource_type == DataTableCatalogResourceType::Instance {
-                        None
-                    } else {
-                        match resource_values.get(&datatable.database.resource_path) {
-                            Some(resource_value) => Some(resource_value),
-                            None => {
-                                resources.push((
-                                    name,
-                                    Err(format!(
-                                        "datatable resource {} not found",
-                                        datatable.database.resource_path
-                                    )),
-                                ));
-                                continue;
-                            }
-                        }
-                    };
-
-                datatable_resource_from_config_unchecked(
-                    db,
-                    w_id,
-                    &datatable,
-                    instance_password,
-                    resource_value,
-                )
-                .await
-                .map_err(|e| e.to_string())
-            }
-            Err(e) => Err(e),
-        };
-        resources.push((name, db_resource));
-    }
-
-    Ok(resources)
-}
-
-async fn datatable_resource_from_config_unchecked(
-    db: &DB,
-    w_id: &str,
-    datatable: &DataTable,
-    instance_password: Option<&str>,
-    resource_value: Option<&serde_json::Value>,
-) -> Result<serde_json::Value> {
     let db_resource = if datatable.database.resource_type == DataTableCatalogResourceType::Instance
     {
         let mut pg_creds = PgDatabase::parse_uri(&get_database_url().await?.as_str().await)?;
         pg_creds.dbname = datatable.database.resource_path.clone();
         pg_creds.user = Some("custom_instance_user".to_string());
-        pg_creds.password = Some(match instance_password {
-            Some(password) => password.to_string(),
-            None => get_custom_pg_instance_password(db).await?,
-        });
+        pg_creds.password = Some(get_custom_pg_instance_password(&db).await?);
         serde_json::to_value(&pg_creds)
             .map_err(|e| Error::internal_err(format!("Error serializing pg creds: {}", e)))?
     } else {
-        match resource_value {
-            Some(resource_value) => transform_json_unchecked(resource_value, w_id, db).await?,
-            None => {
-                transform_json_unchecked(
-                    &serde_json::Value::String(format!(
-                        "$res:{}",
-                        datatable.database.resource_path
-                    )),
-                    w_id,
-                    db,
-                )
-                .await?
-            }
-        }
+        transform_json_unchecked(
+            &serde_json::Value::String(format!("$res:{}", datatable.database.resource_path)),
+            w_id,
+            db,
+        )
+        .await?
     };
 
     Ok(db_resource)

--- a/frontend/src/lib/components/copilot/chat/AIChatInput.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatInput.svelte
@@ -109,7 +109,7 @@
 		}
 	}
 
-	function addContextToSelection(contextElement: ContextElement) {
+	async function addContextToSelection(contextElement: ContextElement) {
 		if (!selectedContext || !availableContext) return
 
 		const alreadySelected = selectedContext.find(
@@ -130,20 +130,35 @@
 			return
 		}
 
-		selectedContext = [...selectedContext, contextElement]
+		let contextToAdd = contextElement
 
-		// If it's a datatable table, add it to the app's whitelisted tables
 		if (
 			contextElement.type === 'app_datatable' &&
 			aiChatManager.mode === AIMode.APP &&
 			aiChatManager.appAiChatHelpers
 		) {
+			if (!contextElement.columns) {
+				try {
+					contextToAdd = {
+						...contextElement,
+						columns: await aiChatManager.appAiChatHelpers.getDatatableTableSchema(
+							contextElement.datatableName,
+							contextElement.schemaName,
+							contextElement.tableName
+						)
+					}
+				} catch (e) {
+					console.error('Failed to load datatable table schema:', e)
+				}
+			}
 			aiChatManager.appAiChatHelpers.addTableToWhitelist(
 				contextElement.datatableName,
 				contextElement.schemaName,
 				contextElement.tableName
 			)
 		}
+
+		selectedContext = [...selectedContext, contextToAdd]
 	}
 
 	function sendRequest() {
@@ -342,7 +357,7 @@
 	}
 
 	function handleAppContextSelection(contextElement: ContextElement) {
-		addContextToSelection(contextElement)
+		void addContextToSelection(contextElement)
 		// Update instructions with the selected context title
 		const index = instructions.lastIndexOf('@')
 		if (index !== -1) {
@@ -364,31 +379,27 @@
 			<div class="flex flex-row gap-1 mb-1 overflow-scroll pt-2 no-scrollbar">
 				<Popover>
 					{#snippet trigger()}
-									
-							<div
-								class="border rounded-md px-1 py-0.5 font-normal text-primary text-xs hover:bg-surface-hover bg-surface"
-								>@</div
-							>
-						
-									{/snippet}
+						<div
+							class="border rounded-md px-1 py-0.5 font-normal text-primary text-xs hover:bg-surface-hover bg-surface"
+							>@</div
+						>
+					{/snippet}
 					{#snippet content({ close })}
-									
-							<AvailableContextList
-								{availableContext}
-								{selectedContext}
-								onSelect={(element) => {
-									addContextToSelection(element)
-									close()
-								}}
-								onSelectWorkspaceItem={(element) => {
-									addContextToSelection(element)
-									close()
-								}}
-							/>
-						
-									{/snippet}
+						<AvailableContextList
+							{availableContext}
+							{selectedContext}
+							onSelect={(element) => {
+								void addContextToSelection(element)
+								close()
+							}}
+							onSelectWorkspaceItem={(element) => {
+								void addContextToSelection(element)
+								close()
+							}}
+						/>
+					{/snippet}
 				</Popover>
-				{#each selectedContext as element}
+				{#each selectedContext as element (element.type + '-' + element.title)}
 					<ContextElementBadge
 						contextElement={element}
 						deletable
@@ -408,7 +419,7 @@
 			{selectedContext}
 			{isFirstMessage}
 			placeholder={modePlaceholder}
-			onAddContext={(contextElement) => addContextToSelection(contextElement)}
+			onAddContext={(contextElement) => void addContextToSelection(contextElement)}
 			onSendRequest={() => {
 				if (disabled) {
 					return
@@ -423,25 +434,21 @@
 			<div class="flex flex-row gap-1 mb-1 overflow-scroll pt-2 no-scrollbar">
 				<Popover>
 					{#snippet trigger()}
-											
-							<div
-								class="border rounded-md px-1 py-0.5 font-normal text-primary text-xs hover:bg-surface-hover bg-surface"
-								>@</div
-							>
-						
-											{/snippet}
+						<div
+							class="border rounded-md px-1 py-0.5 font-normal text-primary text-xs hover:bg-surface-hover bg-surface"
+							>@</div
+						>
+					{/snippet}
 					{#snippet content({ close })}
-											
-							<AppAvailableContextList
-								{availableContext}
-								{selectedContext}
-								onSelect={(element) => {
-									addContextToSelection(element)
-									close()
-								}}
-							/>
-						
-											{/snippet}
+						<AppAvailableContextList
+							{availableContext}
+							{selectedContext}
+							onSelect={(element) => {
+								void addContextToSelection(element)
+								close()
+							}}
+						/>
+					{/snippet}
 				</Popover>
 				{#each selectedContext as element (element.type + '-' + element.title)}
 					<ContextElementBadge

--- a/frontend/src/lib/components/copilot/chat/AIChatInput.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatInput.svelte
@@ -12,6 +12,7 @@
 	import Portal from '$lib/components/Portal.svelte'
 	import { zIndexes } from '$lib/zIndexes'
 	import { tick, untrack } from 'svelte'
+	import { sendUserToast } from '$lib/toast'
 
 	interface Props {
 		availableContext: ContextElement[]
@@ -137,11 +138,18 @@
 			aiChatManager.mode === AIMode.APP &&
 			aiChatManager.appAiChatHelpers
 		) {
+			const appAiChatHelpers = aiChatManager.appAiChatHelpers
+			appAiChatHelpers.addTableToWhitelist(
+				contextElement.datatableName,
+				contextElement.schemaName,
+				contextElement.tableName
+			)
+
 			if (!contextElement.columns) {
 				try {
 					contextToAdd = {
 						...contextElement,
-						columns: await aiChatManager.appAiChatHelpers.getDatatableTableSchema(
+						columns: await appAiChatHelpers.getDatatableTableSchema(
 							contextElement.datatableName,
 							contextElement.schemaName,
 							contextElement.tableName
@@ -149,14 +157,20 @@
 					}
 				} catch (e) {
 					console.error('Failed to load datatable table schema:', e)
+					sendUserToast(
+						'Failed to load datatable table schema',
+						true,
+						[],
+						e instanceof Error ? e.message : String(e)
+					)
 				}
 			}
-			aiChatManager.appAiChatHelpers.addTableToWhitelist(
-				contextElement.datatableName,
-				contextElement.schemaName,
-				contextElement.tableName
-			)
 		}
+
+		const duplicateAfterAwait = selectedContext.find(
+			(c) => c.type === contextToAdd.type && c.title === contextToAdd.title
+		)
+		if (duplicateAfterAwait) return
 
 		selectedContext = [...selectedContext, contextToAdd]
 	}

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -1043,7 +1043,7 @@ class AIChatManager {
 		}
 
 		try {
-			const datatables = await this.appAiChatHelpers.getDatatables()
+			const datatables = await this.appAiChatHelpers.listDatatableTables()
 			this.cachedDatatables = flattenDatatablesToAppContextElements(datatables)
 		} catch (err) {
 			console.error('Failed to refresh datatables:', err)

--- a/frontend/src/lib/components/copilot/chat/app/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/app/core.test.ts
@@ -93,7 +93,8 @@ function createHelpers(overrides: Partial<AppAIChatHelpers> = {}): AppAIChatHelp
 		snapshot: () => 1,
 		revertToSnapshot: () => undefined,
 		lint: () => EMPTY_LINT_RESULT,
-		getDatatables: async () => [],
+		listDatatableTables: async () => [],
+		getDatatableTableSchema: async () => ({}),
 		getAvailableDatatableNames: () => [],
 		execDatatableSql: async () => ({ success: true }),
 		addTableToWhitelist: () => undefined,
@@ -195,18 +196,14 @@ describe('app datatable tools', () => {
 			args: {},
 			workspace: 'test-workspace',
 			helpers: createHelpers({
-				getDatatables: async () => [
+				listDatatableTables: async () => [
 					{
 						datatable_name: 'main',
 						schemas: {
-							public: {
-								users: { id: 'int4', email: 'text' },
-								orders: { id: 'int4', total: 'numeric' }
-							},
-							analytics: {
-								events: { id: 'int4', payload: 'jsonb' }
-							}
-						}
+							public: ['users', 'orders'],
+							analytics: ['events']
+						},
+						tableCount: 3
 					}
 				]
 			}),
@@ -240,17 +237,7 @@ describe('app datatable tools', () => {
 			},
 			workspace: 'test-workspace',
 			helpers: createHelpers({
-				getDatatables: async () => [
-					{
-						datatable_name: 'main',
-						schemas: {
-							public: {
-								users: { id: 'int4', email: 'text' },
-								orders: { id: 'int4', total: 'numeric' }
-							}
-						}
-					}
-				]
+				getDatatableTableSchema: async () => ({ id: 'int4', email: 'text' })
 			}),
 			toolCallbacks: createToolCallbacks(),
 			toolId: 'tool-get-table-schema'
@@ -287,7 +274,10 @@ describe('app patch_file tool', () => {
 			toolId: 'tool-1'
 		})
 
-		expect(setFrontendFile).toHaveBeenCalledWith('/index.tsx', 'export const title = "Hello cookbook"\n')
+		expect(setFrontendFile).toHaveBeenCalledWith(
+			'/index.tsx',
+			'export const title = "Hello cookbook"\n'
+		)
 		expect(result).toContain("Patched '/index.tsx' successfully.")
 	})
 

--- a/frontend/src/lib/components/copilot/chat/app/core.ts
+++ b/frontend/src/lib/components/copilot/chat/app/core.ts
@@ -103,6 +103,13 @@ export interface DataTableSchema {
 	error?: string
 }
 
+export interface AppDatatableMetadata {
+	datatable_name: string
+	schemas: Record<string, string[]>
+	tableCount: number
+	error?: string
+}
+
 export interface AppAIChatHelpers {
 	// Frontend file operations
 	listFrontendFiles: () => string[]
@@ -127,8 +134,14 @@ export interface AppAIChatHelpers {
 	/** Lint all frontend files and backend runnables, returns errors and warnings */
 	lint: () => LintResult
 	// Data table operations
-	/** Get all datatables configured in the app with their schemas */
-	getDatatables: () => Promise<DataTableSchema[]>
+	/** List configured datatables with schema/table names only. */
+	listDatatableTables: () => Promise<AppDatatableMetadata[]>
+	/** Get columns for one datatable table. */
+	getDatatableTableSchema: (
+		datatableName: string,
+		schemaName: string,
+		tableName: string
+	) => Promise<Record<string, string>>
 	/** Get unique datatable names configured in the app (for UI policy selector) */
 	getAvailableDatatableNames: () => string[]
 	/** Execute a SQL query on a datatable. Optionally specify newTable to register a newly created table. */
@@ -406,33 +419,6 @@ const getListFilesToolDef = memo(() =>
 
 // ============= Data Table Tools =============
 
-interface AppDatatableMetadata {
-	datatable_name: string
-	schemas: Record<string, string[]>
-	tableCount: number
-	error?: string
-}
-
-function summarizeDatatables(datatables: DataTableSchema[]): AppDatatableMetadata[] {
-	return datatables.map((datatable) => {
-		const schemas: Record<string, string[]> = {}
-		let tableCount = 0
-
-		for (const [schemaName, tables] of Object.entries(datatable.schemas)) {
-			const tableNames = Object.keys(tables)
-			schemas[schemaName] = tableNames
-			tableCount += tableNames.length
-		}
-
-		return {
-			datatable_name: datatable.datatable_name,
-			schemas,
-			tableCount,
-			...(datatable.error && { error: datatable.error })
-		}
-	})
-}
-
 const getListDatatablesSchema = memo(() => z.object({}))
 const getListDatatablesToolDef = memo(() =>
 	createToolDef(
@@ -641,7 +627,9 @@ export const getAppTools = memo((): Tool<AppAIChatHelpers>[] => [
 
 			if (target.type === 'frontend') {
 				if (target.path === '/wmill.d.ts') {
-					throw new Error("'/wmill.d.ts' is generated automatically. Edit backend runnables instead.")
+					throw new Error(
+						"'/wmill.d.ts' is generated automatically. Edit backend runnables instead."
+					)
 				}
 
 				const frontendContent = helpers.getFrontendFile(target.path)
@@ -824,12 +812,11 @@ export const getAppTools = memo((): Tool<AppAIChatHelpers>[] => [
 		fn: async ({ helpers, toolId, toolCallbacks }) => {
 			toolCallbacks.setToolStatus(toolId, { content: 'Listing datatables...' })
 			try {
-				const datatables = await helpers.getDatatables()
-				if (datatables.length === 0) {
+				const metadata = await helpers.listDatatableTables()
+				if (metadata.length === 0) {
 					toolCallbacks.setToolStatus(toolId, { content: 'No datatables configured' })
 					return 'No datatables are configured in this app. Use the Data panel in the sidebar to add datatable references.'
 				}
-				const metadata = summarizeDatatables(datatables)
 				const totalTables = metadata.reduce((acc, datatable) => acc + datatable.tableCount, 0)
 				toolCallbacks.setToolStatus(toolId, {
 					content: `Listed ${metadata.length} datatable(s) with ${totalTables} table(s)`
@@ -850,32 +837,11 @@ export const getAppTools = memo((): Tool<AppAIChatHelpers>[] => [
 				content: `Getting schema for ${parsedArgs.datatable_name}.${parsedArgs.schema_name}.${parsedArgs.table_name}...`
 			})
 			try {
-				const datatables = await helpers.getDatatables()
-				const datatable = datatables.find(
-					(candidate) => candidate.datatable_name === parsedArgs.datatable_name
+				const columns = await helpers.getDatatableTableSchema(
+					parsedArgs.datatable_name,
+					parsedArgs.schema_name,
+					parsedArgs.table_name
 				)
-				if (!datatable) {
-					const availableDatatables = datatables.map((candidate) => candidate.datatable_name)
-					const errorMsg = `Datatable '${parsedArgs.datatable_name}' not found. Available datatables: ${availableDatatables.join(', ') || 'none'}`
-					toolCallbacks.setToolStatus(toolId, { content: errorMsg, error: errorMsg })
-					return errorMsg
-				}
-
-				const schema = datatable.schemas[parsedArgs.schema_name]
-				if (!schema) {
-					const availableSchemas = Object.keys(datatable.schemas)
-					const errorMsg = `Schema '${parsedArgs.schema_name}' not found in datatable '${parsedArgs.datatable_name}'. Available schemas: ${availableSchemas.join(', ') || 'none'}`
-					toolCallbacks.setToolStatus(toolId, { content: errorMsg, error: errorMsg })
-					return errorMsg
-				}
-
-				const columns = schema[parsedArgs.table_name]
-				if (!columns) {
-					const availableTables = Object.keys(schema)
-					const errorMsg = `Table '${parsedArgs.table_name}' not found in '${parsedArgs.datatable_name}.${parsedArgs.schema_name}'. Available tables: ${availableTables.join(', ') || 'none'}`
-					toolCallbacks.setToolStatus(toolId, { content: errorMsg, error: errorMsg })
-					return errorMsg
-				}
 
 				toolCallbacks.setToolStatus(toolId, {
 					content: `Retrieved schema for ${parsedArgs.schema_name}.${parsedArgs.table_name}`
@@ -1271,12 +1237,16 @@ export function prepareAppUserMessage(
 					content += `- **Schema**: ${datatableCtx.schemaName}\n`
 					content += `- **Table**: ${datatableCtx.tableName}\n`
 					// Format columns as column_name: type
-					const columnsStr = JSON.stringify(datatableCtx.columns, null, 2)
-					const truncatedColumns =
-						columnsStr.length > MAX_CONTEXT_CONTENT_LENGTH
-							? columnsStr.slice(0, MAX_CONTEXT_CONTENT_LENGTH) + '\n... [TRUNCATED]'
-							: columnsStr
-					content += `- **Columns** (column_name -> type):\n\`\`\`json\n${truncatedColumns}\n\`\`\`\n`
+					if (datatableCtx.columns) {
+						const columnsStr = JSON.stringify(datatableCtx.columns, null, 2)
+						const truncatedColumns =
+							columnsStr.length > MAX_CONTEXT_CONTENT_LENGTH
+								? columnsStr.slice(0, MAX_CONTEXT_CONTENT_LENGTH) + '\n... [TRUNCATED]'
+								: columnsStr
+						content += `- **Columns** (column_name -> type):\n\`\`\`json\n${truncatedColumns}\n\`\`\`\n`
+					} else {
+						content += `- **Columns**: not loaded. Use get_datatable_table_schema() if column names or types are needed.\n`
+					}
 				}
 			}
 		}

--- a/frontend/src/lib/components/copilot/chat/context.ts
+++ b/frontend/src/lib/components/copilot/chat/context.ts
@@ -12,7 +12,7 @@ import BarsStaggered from '$lib/components/icons/BarsStaggered.svelte'
 import type { ScriptLang, Script, OpenFlow } from '$lib/gen/types.gen'
 import { type DBSchema } from '$lib/stores'
 import { type Change } from 'diff'
-import type { BackendRunnable, DataTableSchema, SelectedContext } from './app/core'
+import type { AppDatatableMetadata, BackendRunnable, SelectedContext } from './app/core'
 
 export const ContextIconMap = {
 	code: Code,
@@ -136,8 +136,8 @@ export interface AppDatatableElement {
 	tableName: string
 	/** Title for display (e.g., "main/public:users" or "main/users") */
 	title: string
-	/** The table columns: column_name -> compact_type */
-	columns: Record<string, string>
+	/** The table columns: column_name -> compact_type. Loaded only when a table is explicitly selected. */
+	columns?: Record<string, string>
 }
 
 export function createAppSelectedContext(options: SelectedContext = {}): SelectedContext {
@@ -184,7 +184,7 @@ export function createAppDatatableContextElement(
 	datatableName: string,
 	schemaName: string,
 	tableName: string,
-	columns: Record<string, string>
+	columns?: Record<string, string>
 ): AppDatatableElement {
 	return {
 		type: 'app_datatable',
@@ -197,7 +197,7 @@ export function createAppDatatableContextElement(
 }
 
 export function flattenDatatablesToAppContextElements(
-	datatables: DataTableSchema[]
+	datatables: AppDatatableMetadata[]
 ): AppDatatableElement[] {
 	return datatables.flatMap((datatable) => {
 		if (datatable.error) {
@@ -205,13 +205,8 @@ export function flattenDatatablesToAppContextElements(
 		}
 
 		return Object.entries(datatable.schemas).flatMap(([schemaName, tables]) =>
-			Object.entries(tables).map(([tableName, columns]) =>
-				createAppDatatableContextElement(
-					datatable.datatable_name,
-					schemaName,
-					tableName,
-					columns
-				)
+			tables.map((tableName) =>
+				createAppDatatableContextElement(datatable.datatable_name, schemaName, tableName)
 			)
 		)
 	})

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -78,9 +78,6 @@
 
 	// Convert to object format for child components
 	let dataTableRefsObjects = $derived(data.tables.map(parseDataTableRef))
-	let datatableTablesCache: { key: string; promise: Promise<AppDatatableMetadata[]> } | undefined =
-		undefined
-	let datatableTableSchemaCache = new Map<string, Promise<Record<string, string>>>()
 
 	type DataTableTablesMetadata = {
 		datatable_name: string
@@ -163,24 +160,6 @@
 		}
 
 		return results
-	}
-
-	function getDatatableTablesCacheKey(): string {
-		return `${$workspaceStore ?? ''}:${data.tables.join('\u0000')}`
-	}
-
-	function invalidateDatatableCaches(datatableName?: string) {
-		datatableTablesCache = undefined
-		if (!datatableName) {
-			datatableTableSchemaCache.clear()
-			return
-		}
-
-		for (const key of datatableTableSchemaCache.keys()) {
-			if (key.includes(`:${datatableName}:`)) {
-				datatableTableSchemaCache.delete(key)
-			}
-		}
 	}
 
 	// Initialize history manager
@@ -558,19 +537,10 @@
 					return []
 				}
 
-				const cacheKey = getDatatableTablesCacheKey()
-				if (datatableTablesCache?.key === cacheKey) {
-					return datatableTablesCache.promise
-				}
-
-				datatableTablesCache = {
-					key: cacheKey,
-					promise: WorkspaceService.listDataTableTables({
-						workspace: $workspaceStore
-					}).then((tables) => filterDatatableTables(tables))
-				}
-
-				return datatableTablesCache.promise
+				const tables = await WorkspaceService.listDataTableTables({
+					workspace: $workspaceStore
+				})
+				return filterDatatableTables(tables)
 			},
 			getDatatableTableSchema: async (
 				datatableName: string,
@@ -581,19 +551,13 @@
 					return {}
 				}
 
-				const cacheKey = `${$workspaceStore}:${datatableName}:${schemaName}:${tableName}`
-				let schemaPromise = datatableTableSchemaCache.get(cacheKey)
-				if (!schemaPromise) {
-					schemaPromise = WorkspaceService.getDataTableTableSchema({
-						workspace: $workspaceStore,
-						datatableName,
-						schemaName,
-						tableName
-					}).then((schema) => schema.columns)
-					datatableTableSchemaCache.set(cacheKey, schemaPromise)
-				}
-
-				return schemaPromise
+				const schema = await WorkspaceService.getDataTableTableSchema({
+					workspace: $workspaceStore,
+					datatableName,
+					schemaName,
+					tableName
+				})
+				return schema.columns
 			},
 			getAvailableDatatableNames: (): string[] => {
 				// Get unique datatable names from dataTableRefs
@@ -635,7 +599,6 @@
 						}
 					}
 
-					invalidateDatatableCaches(datatableName)
 					void aiChatManager.refreshDatatables()
 
 					// Check if result is an array (SELECT) or something else
@@ -660,7 +623,6 @@
 				if (!data.tables.includes(newRef)) {
 					data.tables = [...data.tables, newRef]
 					saveFrontendDraft()
-					invalidateDatatableCaches(datatableName)
 					void aiChatManager.refreshDatatables()
 				}
 			}

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -98,13 +98,11 @@
 		}
 	}
 
-	function filterDatatableTables(allTables: DataTableTablesMetadata[]): AppDatatableMetadata[] {
-		const whitelistedDatatables = new Set(dataTableRefsObjects.map((ref) => ref.datatable))
+	function getWhitelistedDatatableNames(): Set<string> {
+		return new Set(dataTableRefsObjects.map((ref) => ref.datatable))
+	}
 
-		if (whitelistedDatatables.size === 0) {
-			return allTables.map(withTableCount)
-		}
-
+	function getWhitelistedTables(): Map<string, Map<string, Set<string>>> {
 		const whitelistedTables = new Map<string, Map<string, Set<string>>>()
 		for (const ref of dataTableRefsObjects) {
 			if (!ref.table) continue
@@ -118,6 +116,35 @@
 			}
 			schemaMap.get(schemaKey)!.add(ref.table)
 		}
+		return whitelistedTables
+	}
+
+	function isDatatableTableWhitelisted(
+		datatableName: string,
+		schemaName: string,
+		tableName: string
+	): boolean {
+		const whitelistedDatatables = getWhitelistedDatatableNames()
+		if (whitelistedDatatables.size === 0) {
+			return true
+		}
+
+		return (
+			getWhitelistedTables()
+				.get(datatableName)
+				?.get(schemaName || 'public')
+				?.has(tableName) ?? false
+		)
+	}
+
+	function filterDatatableTables(allTables: DataTableTablesMetadata[]): AppDatatableMetadata[] {
+		const whitelistedDatatables = getWhitelistedDatatableNames()
+
+		if (whitelistedDatatables.size === 0) {
+			return allTables.map(withTableCount)
+		}
+
+		const whitelistedTables = getWhitelistedTables()
 
 		const results: AppDatatableMetadata[] = []
 		for (const datatable of allTables) {
@@ -549,6 +576,15 @@
 			): Promise<Record<string, string>> => {
 				if (!$workspaceStore) {
 					return {}
+				}
+
+				if (!isDatatableTableWhitelisted(datatableName, schemaName, tableName)) {
+					const tableRef = formatDataTableRef({
+						datatable: datatableName,
+						schema: schemaName === 'public' ? undefined : schemaName,
+						table: tableName
+					})
+					throw new Error(`Table '${tableRef}' is not configured in this app`)
 				}
 
 				const schema = await WorkspaceService.getDataTableTableSchema({

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -32,8 +32,10 @@
 	import { RawAppHistoryManager } from './RawAppHistoryManager.svelte'
 	import { sendUserToast } from '$lib/utils'
 	import {
+		buildDataTableWhitelist,
 		parseDataTableRef,
 		formatDataTableRef,
+		isDatatableTableAllowed,
 		type RawAppData,
 		DEFAULT_DATA
 	} from './dataTableRefUtils'
@@ -78,6 +80,7 @@
 
 	// Convert to object format for child components
 	let dataTableRefsObjects = $derived(data.tables.map(parseDataTableRef))
+	let dataTableWhitelist = $derived(buildDataTableWhitelist(dataTableRefsObjects))
 
 	type DataTableTablesMetadata = {
 		datatable_name: string
@@ -98,61 +101,31 @@
 		}
 	}
 
-	function getWhitelistedDatatableNames(): Set<string> {
-		return new Set(dataTableRefsObjects.map((ref) => ref.datatable))
-	}
-
-	function getWhitelistedTables(): Map<string, Map<string, Set<string>>> {
-		const whitelistedTables = new Map<string, Map<string, Set<string>>>()
-		for (const ref of dataTableRefsObjects) {
-			if (!ref.table) continue
-			if (!whitelistedTables.has(ref.datatable)) {
-				whitelistedTables.set(ref.datatable, new Map())
-			}
-			const schemaKey = ref.schema || 'public'
-			const schemaMap = whitelistedTables.get(ref.datatable)!
-			if (!schemaMap.has(schemaKey)) {
-				schemaMap.set(schemaKey, new Set())
-			}
-			schemaMap.get(schemaKey)!.add(ref.table)
-		}
-		return whitelistedTables
-	}
-
 	function isDatatableTableWhitelisted(
 		datatableName: string,
 		schemaName: string,
 		tableName: string
 	): boolean {
-		const whitelistedDatatables = getWhitelistedDatatableNames()
-		if (whitelistedDatatables.size === 0) {
-			return true
-		}
-
-		return (
-			getWhitelistedTables()
-				.get(datatableName)
-				?.get(schemaName || 'public')
-				?.has(tableName) ?? false
-		)
+		return isDatatableTableAllowed(dataTableWhitelist, datatableName, schemaName, tableName)
 	}
 
 	function filterDatatableTables(allTables: DataTableTablesMetadata[]): AppDatatableMetadata[] {
-		const whitelistedDatatables = getWhitelistedDatatableNames()
-
-		if (whitelistedDatatables.size === 0) {
+		if (dataTableWhitelist.datatables.size === 0) {
 			return allTables.map(withTableCount)
 		}
 
-		const whitelistedTables = getWhitelistedTables()
-
 		const results: AppDatatableMetadata[] = []
 		for (const datatable of allTables) {
-			if (!whitelistedDatatables.has(datatable.datatable_name)) {
+			if (!dataTableWhitelist.datatables.has(datatable.datatable_name)) {
 				continue
 			}
 
-			const allowedTables = whitelistedTables.get(datatable.datatable_name)
+			if (dataTableWhitelist.allTablesDatatables.has(datatable.datatable_name)) {
+				results.push(withTableCount(datatable))
+				continue
+			}
+
+			const allowedTables = dataTableWhitelist.tables.get(datatable.datatable_name)
 			if (!allowedTables) {
 				results.push(
 					withTableCount({
@@ -597,7 +570,7 @@
 			},
 			getAvailableDatatableNames: (): string[] => {
 				// Get unique datatable names from dataTableRefs
-				return [...new Set(dataTableRefsObjects.map((ref) => ref.datatable))]
+				return [...dataTableWhitelist.datatables]
 			},
 			execDatatableSql: async (
 				datatableName: string,

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -20,7 +20,11 @@
 	import { isRunnableByName, isRunnableByPath } from '../apps/inputType'
 	import { aiChatManager, AIMode } from '../copilot/chat/AIChatManager.svelte'
 	import { onMount, untrack } from 'svelte'
-	import type { LintResult, DataTableSchema, InspectorElementInfo } from '../copilot/chat/app/core'
+	import type {
+		AppDatatableMetadata,
+		LintResult,
+		InspectorElementInfo
+	} from '../copilot/chat/app/core'
 	import { createAppSelectedContext, type AppCodeSelectionElement } from '../copilot/chat/context'
 	import { rawAppLintStore } from './lintStore'
 	import { dbSchemas } from '$lib/stores'
@@ -74,6 +78,110 @@
 
 	// Convert to object format for child components
 	let dataTableRefsObjects = $derived(data.tables.map(parseDataTableRef))
+	let datatableTablesCache: { key: string; promise: Promise<AppDatatableMetadata[]> } | undefined =
+		undefined
+	let datatableTableSchemaCache = new Map<string, Promise<Record<string, string>>>()
+
+	type DataTableTablesMetadata = {
+		datatable_name: string
+		schemas: Record<string, string[]>
+		error?: string
+	}
+
+	function countTables(schemas: Record<string, string[]>): number {
+		return Object.values(schemas).reduce((acc, tables) => acc + tables.length, 0)
+	}
+
+	function withTableCount(datatable: DataTableTablesMetadata): AppDatatableMetadata {
+		return {
+			datatable_name: datatable.datatable_name,
+			schemas: datatable.schemas,
+			tableCount: countTables(datatable.schemas),
+			...(datatable.error && { error: datatable.error })
+		}
+	}
+
+	function filterDatatableTables(allTables: DataTableTablesMetadata[]): AppDatatableMetadata[] {
+		const whitelistedDatatables = new Set(dataTableRefsObjects.map((ref) => ref.datatable))
+
+		if (whitelistedDatatables.size === 0) {
+			return allTables.map(withTableCount)
+		}
+
+		const whitelistedTables = new Map<string, Map<string, Set<string>>>()
+		for (const ref of dataTableRefsObjects) {
+			if (!ref.table) continue
+			if (!whitelistedTables.has(ref.datatable)) {
+				whitelistedTables.set(ref.datatable, new Map())
+			}
+			const schemaKey = ref.schema || 'public'
+			const schemaMap = whitelistedTables.get(ref.datatable)!
+			if (!schemaMap.has(schemaKey)) {
+				schemaMap.set(schemaKey, new Set())
+			}
+			schemaMap.get(schemaKey)!.add(ref.table)
+		}
+
+		const results: AppDatatableMetadata[] = []
+		for (const datatable of allTables) {
+			if (!whitelistedDatatables.has(datatable.datatable_name)) {
+				continue
+			}
+
+			const allowedTables = whitelistedTables.get(datatable.datatable_name)
+			if (!allowedTables) {
+				results.push(
+					withTableCount({
+						datatable_name: datatable.datatable_name,
+						schemas: {},
+						error: datatable.error
+					})
+				)
+				continue
+			}
+
+			const filteredSchemas: Record<string, string[]> = {}
+			for (const [schemaName, tableNames] of Object.entries(datatable.schemas)) {
+				const allowedTablesInSchema = allowedTables.get(schemaName)
+				if (!allowedTablesInSchema) continue
+
+				const filteredTables = tableNames.filter((tableName) =>
+					allowedTablesInSchema.has(tableName)
+				)
+				if (filteredTables.length > 0) {
+					filteredSchemas[schemaName] = filteredTables
+				}
+			}
+
+			results.push(
+				withTableCount({
+					datatable_name: datatable.datatable_name,
+					schemas: filteredSchemas,
+					error: datatable.error
+				})
+			)
+		}
+
+		return results
+	}
+
+	function getDatatableTablesCacheKey(): string {
+		return `${$workspaceStore ?? ''}:${data.tables.join('\u0000')}`
+	}
+
+	function invalidateDatatableCaches(datatableName?: string) {
+		datatableTablesCache = undefined
+		if (!datatableName) {
+			datatableTableSchemaCache.clear()
+			return
+		}
+
+		for (const key of datatableTableSchemaCache.keys()) {
+			if (key.includes(`:${datatableName}:`)) {
+				datatableTableSchemaCache.delete(key)
+			}
+		}
+	}
 
 	// Initialize history manager
 	const historyManager = new RawAppHistoryManager({
@@ -445,84 +553,47 @@
 				console.log('reverting to snapshot', id)
 				handleHistorySelect(id)
 			},
-			getDatatables: async (): Promise<DataTableSchema[]> => {
+			listDatatableTables: async (): Promise<AppDatatableMetadata[]> => {
 				if (!$workspaceStore) {
 					return []
 				}
 
-				// Get all datatable schemas from the backend
-				const allSchemas = await WorkspaceService.listDataTableSchemas({
-					workspace: $workspaceStore
-				})
-
-				// Get unique datatable names from dataTableRefs (the whitelisted tables)
-				const whitelistedDatatables = new Set(dataTableRefsObjects.map((ref) => ref.datatable))
-
-				// If no datatables are configured, return all available datatables
-				// This allows users to see all datatables in the @ context menu
-				if (whitelistedDatatables.size === 0) {
-					return allSchemas
+				const cacheKey = getDatatableTablesCacheKey()
+				if (datatableTablesCache?.key === cacheKey) {
+					return datatableTablesCache.promise
 				}
 
-				// Build a map of whitelisted tables per datatable: datatable -> schema -> Set<table>
-				const whitelistedTables = new Map<string, Map<string, Set<string>>>()
-				for (const ref of dataTableRefsObjects) {
-					if (!ref.table) continue
-					if (!whitelistedTables.has(ref.datatable)) {
-						whitelistedTables.set(ref.datatable, new Map())
-					}
-					const schemaKey = ref.schema || 'public'
-					const schemaMap = whitelistedTables.get(ref.datatable)!
-					if (!schemaMap.has(schemaKey)) {
-						schemaMap.set(schemaKey, new Set())
-					}
-					schemaMap.get(schemaKey)!.add(ref.table)
+				datatableTablesCache = {
+					key: cacheKey,
+					promise: WorkspaceService.listDataTableTables({
+						workspace: $workspaceStore
+					}).then((tables) => filterDatatableTables(tables))
 				}
 
-				// Filter schemas to only include whitelisted datatables and tables
-				const results: DataTableSchema[] = []
-				for (const schema of allSchemas) {
-					if (!whitelistedDatatables.has(schema.datatable_name)) {
-						continue
-					}
-
-					const allowedTables = whitelistedTables.get(schema.datatable_name)
-					if (!allowedTables) {
-						// Include the datatable but with empty schemas
-						results.push({
-							datatable_name: schema.datatable_name,
-							schemas: {},
-							error: schema.error
-						})
-						continue
-					}
-
-					// Filter schemas to only include whitelisted tables
-					const filteredSchemas: Record<string, Record<string, Record<string, string>>> = {}
-					for (const [schemaName, tables] of Object.entries(schema.schemas)) {
-						const allowedTablesInSchema = allowedTables.get(schemaName)
-						if (!allowedTablesInSchema) continue
-
-						const filteredTables: Record<string, Record<string, string>> = {}
-						for (const [tableName, columns] of Object.entries(tables)) {
-							if (allowedTablesInSchema.has(tableName)) {
-								filteredTables[tableName] = columns
-							}
-						}
-
-						if (Object.keys(filteredTables).length > 0) {
-							filteredSchemas[schemaName] = filteredTables
-						}
-					}
-
-					results.push({
-						datatable_name: schema.datatable_name,
-						schemas: filteredSchemas,
-						error: schema.error
-					})
+				return datatableTablesCache.promise
+			},
+			getDatatableTableSchema: async (
+				datatableName: string,
+				schemaName: string,
+				tableName: string
+			): Promise<Record<string, string>> => {
+				if (!$workspaceStore) {
+					return {}
 				}
 
-				return results
+				const cacheKey = `${$workspaceStore}:${datatableName}:${schemaName}:${tableName}`
+				let schemaPromise = datatableTableSchemaCache.get(cacheKey)
+				if (!schemaPromise) {
+					schemaPromise = WorkspaceService.getDataTableTableSchema({
+						workspace: $workspaceStore,
+						datatableName,
+						schemaName,
+						tableName
+					}).then((schema) => schema.columns)
+					datatableTableSchemaCache.set(cacheKey, schemaPromise)
+				}
+
+				return schemaPromise
 			},
 			getAvailableDatatableNames: (): string[] => {
 				// Get unique datatable names from dataTableRefs
@@ -564,6 +635,9 @@
 						}
 					}
 
+					invalidateDatatableCaches(datatableName)
+					void aiChatManager.refreshDatatables()
+
 					// Check if result is an array (SELECT) or something else
 					if (Array.isArray(result)) {
 						return { success: true, result }
@@ -586,6 +660,8 @@
 				if (!data.tables.includes(newRef)) {
 					data.tables = [...data.tables, newRef]
 					saveFrontendDraft()
+					invalidateDatatableCaches(datatableName)
+					void aiChatManager.refreshDatatables()
 				}
 			}
 		})

--- a/frontend/src/lib/components/raw_apps/dataTableRefUtils.test.ts
+++ b/frontend/src/lib/components/raw_apps/dataTableRefUtils.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { buildDataTableWhitelist, isDatatableTableAllowed } from './dataTableRefUtils'
+
+describe('datatable whitelist helpers', () => {
+	it('allows every datatable table when no refs are configured', () => {
+		const whitelist = buildDataTableWhitelist([])
+
+		expect(isDatatableTableAllowed(whitelist, 'main', 'public', 'users')).toBe(true)
+		expect(isDatatableTableAllowed(whitelist, 'analytics', 'events', 'clicks')).toBe(true)
+	})
+
+	it('treats datatable-level refs as all tables in that datatable', () => {
+		const whitelist = buildDataTableWhitelist([{ datatable: 'main' }])
+
+		expect(isDatatableTableAllowed(whitelist, 'main', 'public', 'users')).toBe(true)
+		expect(isDatatableTableAllowed(whitelist, 'main', 'analytics', 'events')).toBe(true)
+		expect(isDatatableTableAllowed(whitelist, 'other', 'public', 'users')).toBe(false)
+	})
+
+	it('allows only explicitly listed tables for table-level refs', () => {
+		const whitelist = buildDataTableWhitelist([
+			{ datatable: 'main', schema: 'public', table: 'users' },
+			{ datatable: 'main', schema: 'analytics', table: 'events' }
+		])
+
+		expect(isDatatableTableAllowed(whitelist, 'main', 'public', 'users')).toBe(true)
+		expect(isDatatableTableAllowed(whitelist, 'main', 'analytics', 'events')).toBe(true)
+		expect(isDatatableTableAllowed(whitelist, 'main', 'public', 'orders')).toBe(false)
+	})
+})

--- a/frontend/src/lib/components/raw_apps/dataTableRefUtils.test.ts
+++ b/frontend/src/lib/components/raw_apps/dataTableRefUtils.test.ts
@@ -27,4 +27,11 @@ describe('datatable whitelist helpers', () => {
 		expect(isDatatableTableAllowed(whitelist, 'main', 'analytics', 'events')).toBe(true)
 		expect(isDatatableTableAllowed(whitelist, 'main', 'public', 'orders')).toBe(false)
 	})
+
+	it('does not treat an explicit empty schema as public', () => {
+		const whitelist = buildDataTableWhitelist([{ datatable: 'main', schema: '', table: 'users' }])
+
+		expect(isDatatableTableAllowed(whitelist, 'main', '', 'users')).toBe(true)
+		expect(isDatatableTableAllowed(whitelist, 'main', 'public', 'users')).toBe(false)
+	})
 })

--- a/frontend/src/lib/components/raw_apps/dataTableRefUtils.ts
+++ b/frontend/src/lib/components/raw_apps/dataTableRefUtils.ts
@@ -47,7 +47,7 @@ export function buildDataTableWhitelist(refs: DataTableRef[]): DataTableWhitelis
 		if (!tables.has(ref.datatable)) {
 			tables.set(ref.datatable, new Map())
 		}
-		const schemaKey = ref.schema || 'public'
+		const schemaKey = ref.schema ?? 'public'
 		const schemaMap = tables.get(ref.datatable)!
 		if (!schemaMap.has(schemaKey)) {
 			schemaMap.set(schemaKey, new Set())
@@ -76,7 +76,7 @@ export function isDatatableTableAllowed(
 		return true
 	}
 
-	return whitelist.tables.get(datatableName)?.get(schemaName || 'public')?.has(tableName) ?? false
+	return whitelist.tables.get(datatableName)?.get(schemaName ?? 'public')?.has(tableName) ?? false
 }
 
 /**

--- a/frontend/src/lib/components/raw_apps/dataTableRefUtils.ts
+++ b/frontend/src/lib/components/raw_apps/dataTableRefUtils.ts
@@ -25,6 +25,60 @@ export const DEFAULT_DATA: RawAppData = {
 	schema: undefined
 }
 
+export type DataTableWhitelist = {
+	datatables: Set<string>
+	allTablesDatatables: Set<string>
+	tables: Map<string, Map<string, Set<string>>>
+}
+
+export function buildDataTableWhitelist(refs: DataTableRef[]): DataTableWhitelist {
+	const datatables = new Set<string>()
+	const allTablesDatatables = new Set<string>()
+	const tables = new Map<string, Map<string, Set<string>>>()
+
+	for (const ref of refs) {
+		datatables.add(ref.datatable)
+
+		if (!ref.table) {
+			allTablesDatatables.add(ref.datatable)
+			continue
+		}
+
+		if (!tables.has(ref.datatable)) {
+			tables.set(ref.datatable, new Map())
+		}
+		const schemaKey = ref.schema || 'public'
+		const schemaMap = tables.get(ref.datatable)!
+		if (!schemaMap.has(schemaKey)) {
+			schemaMap.set(schemaKey, new Set())
+		}
+		schemaMap.get(schemaKey)!.add(ref.table)
+	}
+
+	return { datatables, allTablesDatatables, tables }
+}
+
+export function isDatatableTableAllowed(
+	whitelist: DataTableWhitelist,
+	datatableName: string,
+	schemaName: string,
+	tableName: string
+): boolean {
+	if (whitelist.datatables.size === 0) {
+		return true
+	}
+
+	if (!whitelist.datatables.has(datatableName)) {
+		return false
+	}
+
+	if (whitelist.allTablesDatatables.has(datatableName)) {
+		return true
+	}
+
+	return whitelist.tables.get(datatableName)?.get(schemaName || 'public')?.has(tableName) ?? false
+}
+
 /**
  * Parse a string ref into a DataTableRef object
  * Format: <datatableName>/<schema>:<table> or <datatableName>/<table> (for public schema)


### PR DESCRIPTION
## Summary
Optimize app chat datatable tooling so chat mode no longer loads every column for every table up front. The PR adds targeted backend endpoints for table metadata and single-table schema lookup, then rewires the app chat helpers and context selection flow to load table columns only when needed.

## Changes
- Add workspace API endpoints for datatable table metadata and one-table schema lookup.
- Rewire app chat datatable tools to use targeted metadata/schema helpers instead of fetching full schemas and filtering locally.
- Make app datatable context column loading lazy when a table is selected.
- Refresh cached app datatable context after datatable SQL execution or whitelist updates.
- Preserve datatable-level all-tables refs in app chat context filtering.
- Prevent duplicate app context entries while eager-loading datatable table schemas.
- Update datatable chat and whitelist tests for the new helper contract.

## Test plan
- [x] cargo fmt --manifest-path backend/Cargo.toml --package windmill-api-workspaces
- [x] npm run generate-backend-client
- [x] npm run check:fast
- [x] npx vitest run src/lib/components/copilot/chat/app/core.test.ts src/lib/components/raw_apps/dataTableRefUtils.test.ts
- [x] npm run check
- [x] backend cargo-watch logs show healthy server after rebuild

---
Generated with [Claude Code](https://claude.com/claude-code)