### PR TITLE
fix: prevent React app editor from overwriting files on theme switch

### DIFF
--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -177,22 +177,22 @@
 	}
 
 	let iframeLoaded = $state(false) // @hmr:keep
+	// Suppresses iframe-sourced events for a short window after we re-push files,
+	// to keep the iframe's boot-time messages from clobbering the user's state.
+	// suppressIframeSetFiles is held across an entire iframe reload (e.g. theme switch);
+	// the timer is reset on every reload so rapid toggles don't clear it prematurely.
 	let suppressSetActiveDocument = false
-	// Suppresses incoming setFiles messages from the iframe while it's reloading
-	// (e.g. after a theme switch), so its built-in default template doesn't
-	// overwrite the user's files before we've re-pushed them.
 	let suppressIframeSetFiles = false
+	let suppressTimer: ReturnType<typeof setTimeout> | undefined
 
 	function populateFiles() {
 		if (files) {
-			// Suppress iframe's automatic setActiveDocument for a short window
-			// after sending files, to prevent it from resetting to App.tsx.
 			suppressSetActiveDocument = true
-			setTimeout(() => {
+			if (suppressTimer !== undefined) clearTimeout(suppressTimer)
+			suppressTimer = setTimeout(() => {
 				suppressSetActiveDocument = false
-			}, 500)
-			setTimeout(() => {
 				suppressIframeSetFiles = false
+				suppressTimer = undefined
 			}, 500)
 			const doc = untrack(() => selectedDocument)
 			if (doc) {
@@ -689,6 +689,13 @@
 			if (iframe && iframeLoaded) {
 				iframeLoaded = false
 				suppressIframeSetFiles = true
+				// Cancel any pending clear from a prior reload — otherwise on rapid
+				// toggles the previous timer can fire mid-reload and drop suppression
+				// before the iframe has finished booting.
+				if (suppressTimer !== undefined) {
+					clearTimeout(suppressTimer)
+					suppressTimer = undefined
+				}
 			}
 		})
 	})

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -178,13 +178,22 @@
 
 	let iframeLoaded = $state(false) // @hmr:keep
 	let suppressSetActiveDocument = false
+	// Suppresses incoming setFiles messages from the iframe while it's reloading
+	// (e.g. after a theme switch), so its built-in default template doesn't
+	// overwrite the user's files before we've re-pushed them.
+	let suppressIframeSetFiles = false
 
 	function populateFiles() {
 		if (files) {
 			// Suppress iframe's automatic setActiveDocument for a short window
 			// after sending files, to prevent it from resetting to App.tsx.
 			suppressSetActiveDocument = true
-			setTimeout(() => { suppressSetActiveDocument = false }, 500)
+			setTimeout(() => {
+				suppressSetActiveDocument = false
+			}, 500)
+			setTimeout(() => {
+				suppressIframeSetFiles = false
+			}, 500)
 			const doc = untrack(() => selectedDocument)
 			if (doc) {
 				setFilesAndSelectInIframe(files, doc)
@@ -600,6 +609,9 @@
 
 	function listener(e: MessageEvent) {
 		if (e.data.type === 'setFiles') {
+			// Ignore setFiles from the iframe while it's reloading (e.g. theme switch);
+			// the iframe boots with its default template and would otherwise clobber the user's files.
+			if (suppressIframeSetFiles) return
 			// Normalize Windows-style path separators to Linux-style
 			const normalizedFiles = normalizeFilePaths(e.data.files)
 			// Only mark pending changes if files actually changed (ignore echo from setFilesInIframe)
@@ -666,6 +678,18 @@
 	$effect(() => {
 		iframe?.addEventListener('load', () => {
 			iframeLoaded = true
+		})
+	})
+	$effect(() => {
+		// Toggling dark mode changes the iframe src, causing it to reload.
+		// Reset iframeLoaded so the populate effect refires after the new load,
+		// and suppress the iframe's initial setFiles (default template) until then.
+		void darkMode
+		untrack(() => {
+			if (iframe && iframeLoaded) {
+				iframeLoaded = false
+				suppressIframeSetFiles = true
+			}
 		})
 	})
 	$effect(() => {


### PR DESCRIPTION
## Summary
While editing a React Full Code app, switching theme via the user-menu "Switch theme" reloaded the `ui_builder` iframe (its `src` embeds the dark-mode flag) and the iframe's built-in default template overwrote the user's `App.tsx` with a "Hello World" placeholder.

## Root cause
- The iframe `src` is `/ui_builder/index.html?dark={darkMode}`, so toggling theme triggers a full iframe reload.
- `iframeLoaded` is `$state(false) // @hmr:keep` and only flips `false → true` once. After a reload, reassigning the same `true` value doesn't re-trigger Svelte reactivity, so the `populateFiles` effect that re-pushes the user's files never refires.
- The reloaded iframe boots with its default template and posts `setFiles` back to the parent, where the listener happily overwrites `files` with the defaults.

## Changes
- New `suppressIframeSetFiles` flag; `setFiles` listener early-returns while it's set.
- New `$effect` watching `darkMode`: when iframe is already loaded, resets `iframeLoaded = false` and sets the suppress flag so the populate effect refires after the new load.
- `populateFiles` clears the flag 500 ms after re-pushing files (same pattern as the existing `suppressSetActiveDocument`).

## Test plan
- [ ] Open a React Full Code app, edit `App.tsx` to non-default content, then click user menu → Switch theme. Verify the edited content is preserved (no "Hello World" reset) and the iframe re-renders in the new theme.
- [ ] Repeat in both light→dark and dark→light directions.
- [ ] Toggle theme rapidly twice in succession; user files should still be intact after the dust settles.
- [ ] On first load with a system/preferred dark theme, verify the editor doesn't lose files (one iframe reload is expected as `DarkModeObserver` settles).
- [ ] Edit a file inside the iframe (normal editing flow) and confirm changes still propagate to the parent (`setFiles` from iframe is only suppressed during the 500 ms reload window).

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes file loss when switching theme in the React Full Code editor by handling iframe reloads safely. Rapid theme toggles no longer risk overwriting user edits.

- **Bug Fixes**
  - Block the iframe’s default template from overwriting files by ignoring iframe `setFiles` during reload suppression.
  - Reset `iframeLoaded` on `darkMode` changes so `populateFiles` re-pushes user files after reload.
  - Use a single tracked 500 ms suppression timer, canceling and restarting it on subsequent toggles to avoid premature clears during rapid switches.
  - Clear both `suppressSetActiveDocument` and `suppressIframeSetFiles` after files are re-pushed.

<sup>Written for commit 728d6ba4a1ba4e5a04aa2fd65fb652b14a035b52. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/8965?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

