### PR TITLE
fix: OAuth popup login reliability + auto-login Safari edge cases

### DIFF
--- a/frontend/src/lib/components/InstanceSettings.svelte
+++ b/frontend/src/lib/components/InstanceSettings.svelte
@@ -371,7 +371,7 @@
 
 	function getSettingsForCategory(category: string) {
 		if (category === 'Auth/OAuth/SAML') {
-			return scimSamlSetting
+			return [...(settings[category] ?? []), ...scimSamlSetting]
 		}
 		const base = settings[category] ?? []
 		// In quick setup, reorder Core: base settings (without license_key), then extras from Jobs
@@ -502,27 +502,20 @@
 	}
 
 	export function discardCategory(category: string) {
+		const categorySettings = getSettingsForCategory(category)
+		for (const s of categorySettings) {
+			const v = initialValues[s.key]
+			$values[s.key] = v !== undefined ? JSON.parse(JSON.stringify(v)) : undefined
+		}
 		if (category === 'Auth/OAuth/SAML') {
-			for (const s of scimSamlSetting) {
-				const v = initialValues[s.key]
-				$values[s.key] = v !== undefined ? JSON.parse(JSON.stringify(v)) : undefined
-			}
 			oauths = JSON.parse(JSON.stringify(initialOauths))
 			requirePreexistingUserForOauth = initialRequirePreexistingUserForOauth
 			const account_identifier =
 				initialOauths?.snowflake_oauth?.connect_config?.extra_params?.account_identifier
 			snowflakeAccountIdentifier = account_identifier ?? ''
-		} else {
-			const categorySettings = getSettingsForCategory(category)
-			for (const s of categorySettings) {
-				const v = initialValues[s.key]
-				$values[s.key] = v !== undefined ? JSON.parse(JSON.stringify(v)) : undefined
-			}
-			if (category === 'Registries') {
-				const v = initialValues['workspace_registries']
-				$values['workspace_registries'] =
-					v !== undefined ? JSON.parse(JSON.stringify(v)) : undefined
-			}
+		} else if (category === 'Registries') {
+			const v = initialValues['workspace_registries']
+			$values['workspace_registries'] = v !== undefined ? JSON.parse(JSON.stringify(v)) : undefined
 		}
 	}
 

--- a/frontend/src/lib/components/Login.svelte
+++ b/frontend/src/lib/components/Login.svelte
@@ -96,6 +96,7 @@
 	let smtpConfigured: boolean | undefined = $state(undefined)
 	let disablePasswordLogin = $state(false)
 	let autoRedirecting = $state(false)
+	let oauthFlowDone = false
 
 	type OAuthLogin = {
 		type: string
@@ -301,24 +302,39 @@
 		if (data.type === 'error') {
 			sendUserToast(data.error, true)
 		} else if (data.type === 'success') {
-			onLoginSuccess?.()
+			finishOauthFlow('postMessage')
 		}
 	}
 
 	function handleStorageEvent(event) {
 		if (event.key === 'oauth-success') {
 			try {
-				processPopupData(JSON.parse(event.newValue))
+				const data = JSON.parse(event.newValue)
 				console.log('oauth-success from storage')
 				// Clean up
 				localStorage.removeItem('oauth-success')
 				window.removeEventListener('storage', handleStorageEvent)
+				if (data?.type === 'success') {
+					finishOauthFlow('storage')
+				} else {
+					processPopupData(data)
+				}
 			} catch (e) {
 				console.error('Could not process oauth-success from storage', e)
 			}
 		} else {
 			console.log('Storage event', event.key)
 		}
+	}
+
+	function finishOauthFlow(via: 'postMessage' | 'storage' | 'poll', win?: Window) {
+		if (oauthFlowDone) return
+		oauthFlowDone = true
+		console.log(`oauth: signaled via ${via}`)
+		if (win && !win.closed) win.close()
+		window.removeEventListener('message', popupListener)
+		window.removeEventListener('storage', handleStorageEvent)
+		onLoginSuccess?.()
 	}
 
 	onDestroy(() => {
@@ -351,12 +367,46 @@
 				window.removeEventListener('storage', handleStorageEvent)
 				return false
 			}
+			// Safety net for Safari: when the popup is opened without a fresh user
+			// gesture (auto-login), ITP can partition cookies/localStorage between
+			// popup and parent, so neither the close cookie, the postMessage, nor
+			// the localStorage 'oauth-success' signal reaches us. The session
+			// cookie is set same-origin and isn't subject to that partitioning, so
+			// polling whoami catches the success and lets us force-close the popup.
+			pollForLoginSuccess(win)
 			return true
 		} else {
 			localStorage.setItem('closeUponLogin', 'false')
 			window.location.href = url
 			return true
 		}
+	}
+
+	function pollForLoginSuccess(win: Window) {
+		const startedAt = Date.now()
+		const interval = setInterval(async () => {
+			if (oauthFlowDone) {
+				clearInterval(interval)
+				return
+			}
+			if (Date.now() - startedAt > 5 * 60 * 1000) {
+				clearInterval(interval)
+				console.log('oauth: poll timed out after 5 minutes')
+				return
+			}
+			if (win.closed) {
+				clearInterval(interval)
+				console.log('oauth: popup closed before login completed')
+				return
+			}
+			try {
+				await UserService.getCurrentEmail()
+			} catch {
+				return
+			}
+			clearInterval(interval)
+			finishOauthFlow('poll', win)
+		}, 1500)
 	}
 
 	function redirectSaml(): boolean {

--- a/frontend/src/routes/user/login_callback/[client_name]/+page.svelte
+++ b/frontend/src/routes/user/login_callback/[client_name]/+page.svelte
@@ -21,15 +21,13 @@
 	let state = page.url.searchParams.get('state') ?? undefined
 
 	onMount(async () => {
-		// const closeCookie = getAndDeleteCookie('close')
-		// console.log('closeCookie', closeCookie)
 		const rawRd = localStorage.getItem('rd')
 		if (rawRd) {
 			localStorage.removeItem('rd')
 		}
 		const rd = rawRd?.startsWith('http') && !isValidLogoutRedirect(rawRd) ? null : rawRd
-		const cookieCloseUponLogin = getCookie('close') == 'true'
-		const closeUponLogin = cookieCloseUponLogin ?? localStorage.getItem('closeUponLogin') == 'true'
+		const closeUponLogin =
+			getCookie('close') == 'true' || localStorage.getItem('closeUponLogin') == 'true'
 		if (error) {
 			sendUserToast(`Error trying to login with ${clientName} ${error}`, true)
 			if (closeUponLogin) {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -35,8 +35,7 @@ const config = {
 			'rubendev.wimill.xyz',
 			'windmill.xyz',
 			'app.windmill.xyz',
-			'public.windmill.xyz',
-			'hugo.ngrok.pro'
+			'public.windmill.xyz'
 		],
 		port: parseInt(process.env.FRONTEND_PORT) || 3000,
 		cors: { origin: '*' },


### PR DESCRIPTION
## Summary

Three fixes in the OAuth popup login + instance-settings UI, prompted by a customer report of the auto-login flow misbehaving in Safari (popup completes OAuth, navigates to Windmill home, never closes; parent stays unauthenticated).

- **`Login.svelte`** — Add a whoami poll as a safety net when the popup is opened. Cross-window signaling (postMessage, localStorage \`oauth-success\`, \`window.opener\`, the \`close=true\` cookie) can all fail in Safari when the popup is opened without a fresh user gesture (auto-login) due to ITP partitioning. The session cookie set by \`loginWithOauth\` is same-origin first-party and is the one signal partitioning never breaks, so polling \`/api/users/email\` from the parent reliably detects login success. Once whoami succeeds, parent \`win.close()\`s the popup and fires \`onLoginSuccess\`. An \`oauthFlowDone\` flag guards the three terminal paths so \`onLoginSuccess\` fires exactly once. Compact \`oauth: signaled via {postMessage|storage|poll}\` diagnostic logs let future bug reports identify which path completed.
- **`routes/user/login_callback/[client_name]/+page.svelte`** — Replace \`??\` with \`||\` on the cookie/localStorage fallback. \`getCookie('close') == 'true'\` returns a boolean, so the \`??\` never fell through and the localStorage branch was dead code.
- **`lib/components/InstanceSettings.svelte`** — Per-category save/discard for the Auth/OAuth/SAML tab now includes \`auto_login_provider\` and \`disable_password_login\`. \`getSettingsForCategory\` was returning only \`scimSamlSetting\`, leaving the dirty check and per-category save unable to detect changes to those fields. (Pre-existing bug exposed by the recent auto-login feature.)
- **`vite.config.js`** — Drop a stale personal dev hostname from \`allowedHosts\`.

## Test plan

- [ ] OAuth popup login on Chrome (top-level, manual click) — fast path via postMessage; \`oauth: signaled via postMessage\` in console; popup closes instantly
- [ ] OAuth popup login on Safari (auto-login) — polling-rescued path expected for partitioned-Safari customers; \`oauth: signaled via poll\` in console; popup force-closed within ~1.5s of OAuth completion
- [ ] OAuth popup login on Safari (manual click) — fast path expected; \`oauth: signaled via postMessage\`
- [ ] Cancel popup mid-flow — \`oauth: popup closed before login completed\` logged, polling stops, parent stays in pre-login state
- [ ] Instance settings: superadmin → Auth/OAuth/SAML — type/clear \`auto_login_provider\`, save button activates and persists; same for \`disable_password_login\`
- [ ] Instance settings: discard with only auto_login_provider modified — field reverts to initial value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves OAuth popup login reliability (especially Safari auto‑login) by adding a whoami poll and ensuring the parent closes the popup and logs in once. Also fixes Auth settings dirty checks and Safari close logic, and removes a stale dev host.

- **Bug Fixes**
  - `Login.svelte`: Add whoami polling as a safety net; unify completion via `postMessage`/`storage`/poll with `oauthFlowDone`; close popup and call `onLoginSuccess` once; add concise diagnostic logs.
  - `routes/user/login_callback/[client_name]/+page.svelte`: Use `||` for cookie/localStorage fallback so the popup reliably closes after OAuth.
  - `InstanceSettings.svelte`: Include all Auth/OAuth/SAML settings in dirty checks so `auto_login_provider` and `disable_password_login` can be saved/discarded; align discard logic; keep Registries special case.
  - `vite.config.js`: Remove a stale host from `allowedHosts`.

<sup>Written for commit 38a67fe7bba06125ccbaa150da4933a050144582. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/8971?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

