### PR TITLE
fix: show skipped label on flow progress bar

### DIFF
--- a/frontend/src/lib/components/flows/FlowProgressBar.svelte
+++ b/frontend/src/lib/components/flows/FlowProgressBar.svelte
@@ -33,13 +33,15 @@
 	let isWaitingForEvents = $state(false)
 	let isCanceled = $state(false)
 	let isScheduled = $state(false)
+	let isSkipped = $state(false)
 
 	let progressBar = $state<ProgressBar | undefined>(undefined)
 
 	function updateJobProgress(job: Job) {
 		// Check if job is scheduled for later
-		const isJobScheduled = Boolean('running' in job && 'scheduled_for' in job &&
-			job.scheduled_for && forLater(job.scheduled_for))
+		const isJobScheduled = Boolean(
+			'running' in job && 'scheduled_for' in job && job.scheduled_for && forLater(job.scheduled_for)
+		)
 		isScheduled = isJobScheduled
 
 		const modules = job?.flow_status?.modules
@@ -113,6 +115,7 @@
 		currentStepId = newCurrentStepId
 		isWaitingForEvents = newIsWaitingForEvents
 		isCanceled = job?.canceled || false
+		isSkipped = Boolean(job?.['is_skipped'] && !('running' in job && job.running))
 	}
 
 	export function reset() {
@@ -126,6 +129,7 @@
 		isWaitingForEvents = false
 		isCanceled = false
 		isScheduled = false
+		isSkipped = false
 	}
 	$effect(() => {
 		job && updateJobProgress(job)
@@ -149,4 +153,5 @@
 	{isWaitingForEvents}
 	{isCanceled}
 	{isScheduled}
+	{isSkipped}
 />

--- a/frontend/src/lib/components/flows/FlowProgressBar.svelte
+++ b/frontend/src/lib/components/flows/FlowProgressBar.svelte
@@ -115,7 +115,7 @@
 		currentStepId = newCurrentStepId
 		isWaitingForEvents = newIsWaitingForEvents
 		isCanceled = job?.canceled || false
-		isSkipped = Boolean(job?.['is_skipped'] && !('running' in job && job.running))
+		isSkipped = 'is_skipped' in job && Boolean(job.is_skipped)
 	}
 
 	export function reset() {

--- a/frontend/src/lib/components/progressBar/ProgressBar.svelte
+++ b/frontend/src/lib/components/progressBar/ProgressBar.svelte
@@ -34,6 +34,8 @@
 		isCanceled?: boolean
 		// Whether the job is scheduled for later
 		isScheduled?: boolean
+		// Whether the job was skipped (early-stop labelled as skipped)
+		isSkipped?: boolean
 	}
 
 	let {
@@ -53,7 +55,8 @@
 		showStepId = false,
 		isWaitingForEvents = false,
 		isCanceled = false,
-		isScheduled = false
+		isScheduled = false,
+		isSkipped = false
 	}: Props = $props()
 	let duration = 200
 
@@ -149,13 +152,15 @@
 				: 'text-blue-700 dark:text-blue-200'}"
 		>
 			<div class={twMerge(slim ? 'text-xs' : 'text-sm', 'flex items-center gap-1')}>
-				{#if status == 'running' && !isCanceled && !isScheduled}
+				{#if status == 'running' && !isCanceled && !isScheduled && !isSkipped}
 					<Loader2 class="animate-spin" size={14} />
 				{/if}
-				{#key status + isWaitingForEvents + stepId + isCanceled + isScheduled}
+				{#key status + isWaitingForEvents + stepId + isCanceled + isScheduled + isSkipped}
 					<span in:fade={{ duration: 150 }}>
 						{#if status == 'error'}
 							Error occurred
+						{:else if isSkipped}
+							Skipped
 						{:else if status == 'done' && isCanceled}
 							Canceled
 						{:else if status == 'done'}
@@ -171,9 +176,11 @@
 						{:else if hideStepTitle}
 							{isCanceled ? 'Canceled' : 'Running'}
 						{:else if subIndexIsPercent}
-							{(isCanceled ? 'Canceled at ' : '') + `Step ${index + 1} (${subIndex !== undefined ? subIndex + '%' : ''})`}
+							{(isCanceled ? 'Canceled at ' : '') +
+								`Step ${index + 1} (${subIndex !== undefined ? subIndex + '%' : ''})`}
 						{:else}
-							{(isCanceled ? 'Canceled at ' : '') + `Step ${index + 1}${subIndex !== undefined ? `.${subIndex + 1}` : ''}`}
+							{(isCanceled ? 'Canceled at ' : '') +
+								`Step ${index + 1}${subIndex !== undefined ? `.${subIndex + 1}` : ''}`}
 						{/if}
 					</span>
 				{/key}


### PR DESCRIPTION
## Summary
When a flow is labelled as skipped (via early-stop "Label flow as skipped"), the run detail page's progress bar kept showing a loading spinner because the bar's `index` never reached `length`. The bar now suppresses the spinner and displays a "Skipped" label while still showing the partial progress at the step where the flow stopped.

## Changes
- `FlowProgressBar.svelte`: derive a new `isSkipped` flag from `job.is_skipped` (only when the job is no longer running) and pass it through to `ProgressBar`.
- `ProgressBar.svelte`: add an `isSkipped` prop. When true, hide the running spinner and render a "Skipped" label (taking precedence over the running/done branches).

## Test plan
- [ ] Run a flow whose first step has an early-stop condition with "Label flow as skipped" enabled and the condition met. On the run detail page, verify the progress bar shows partial fill (no further than the step that ran), no loading spinner, and the label reads "Skipped".
- [ ] Run a normal completed flow and verify "Done" still renders.
- [ ] Run a canceled flow and verify "Canceled" still renders.
- [ ] Run a flow that errors and verify "Error occurred" still renders.

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a "Skipped" label on the flow progress bar for early-stopped flows and hides the loading spinner, while keeping partial progress up to the stop step.

- **Bug Fixes**
  - `FlowProgressBar.svelte`: derive `isSkipped` via `'is_skipped' in job` union narrowing and pass it to `ProgressBar`.
  - `ProgressBar.svelte`: add `isSkipped` prop; suppress spinner and render "Skipped" with higher priority than other states.

<sup>Written for commit b7d6f0a9a1026b1a6736e9e2099243a437ae9e9c. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/8973?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

