### PR TITLE
feat: add delete_after_secs and sensitive_inputs for raw app runnables

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -10291,6 +10291,12 @@ paths:
                   type: array
                   items:
                     type: string
+                force_viewer_sensitive_inputs:
+                  type: array
+                  items:
+                    type: string
+                force_viewer_delete_after_secs:
+                  type: integer
                 run_query_params:
                   type: object
                   description: Runnable query parameters

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -54,7 +54,7 @@ use windmill_common::{
     cache::{self, future::FutureCachedExt},
     db::{DbWithOptAuthed, UserDB},
     error::{to_anyhow, Error, JsonResult, Result},
-    jobs::{get_payload_tag_from_prefixed_path, JobPayload, RawCode},
+    jobs::{get_payload_tag_from_prefixed_path, schedule_job_deletion, JobPayload, RawCode},
     users::username_to_permissioned_as,
     utils::{
         http_get_from_hub, not_found_if_none, paginate, query_elems_from_hub, require_admin,
@@ -248,6 +248,10 @@ pub struct PolicyTriggerableInputs {
     one_of_inputs: OneOfFields,
     #[serde(default)]
     allow_user_resources: AllowUserResources,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    delete_after_secs: Option<i32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    sensitive_inputs: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -1772,7 +1776,8 @@ async fn update_app_internal<'a>(
 
         if let Some(ncustom_path) = &ns.custom_path {
             require_admin(authed.is_admin, &authed.username)?;
-            let as_workspaced_route = APP_WORKSPACED_ROUTE.load(std::sync::atomic::Ordering::Relaxed);
+            let as_workspaced_route =
+                APP_WORKSPACED_ROUTE.load(std::sync::atomic::Ordering::Relaxed);
 
             if ncustom_path.is_empty() {
                 sqlb.set("custom_path", "NULL");
@@ -2105,6 +2110,8 @@ async fn execute_component(
                 static_inputs,
                 one_of_inputs: force_viewer_one_of_fields.unwrap_or_default(),
                 allow_user_resources: force_viewer_allow_user_resources.unwrap_or_default(),
+                delete_after_secs: None,
+                sensitive_inputs: Vec::new(),
             },
         ),
         // 2. "run" mode.
@@ -2230,6 +2237,10 @@ async fn execute_component(
     let (username, permissioned_as, email) =
         get_on_behalf_details_from_policy_and_authed(&policy, &opt_authed).await?;
 
+    let resolved_delete_secs = policy_triggerables
+        .delete_after_secs
+        .filter(|secs| *secs >= 0);
+
     let (args, job_id) = build_args(
         policy,
         policy_triggerables,
@@ -2317,6 +2328,10 @@ async fn execute_component(
     }
 
     tx.commit().await?;
+
+    if let Some(secs) = resolved_delete_secs {
+        schedule_job_deletion(&db, uuid, &w_id, secs).await?;
+    }
 
     Ok(uuid.to_string())
 }
@@ -3022,6 +3037,8 @@ async fn build_args(
         static_inputs,
         one_of_inputs,
         allow_user_resources,
+        sensitive_inputs,
+        ..
     }: &PolicyTriggerableInputs,
     mut args: HashMap<String, Box<RawValue>>,
     authed: Option<&ApiAuthed>,
@@ -3171,6 +3188,26 @@ async fn build_args(
             );
         }
     }
+    for k in sensitive_inputs {
+        let Some(v) = safe_args.get(k) else { continue };
+        let raw = v.get();
+        if raw.starts_with("\"$encrypted:") {
+            continue;
+        }
+        let job_id = if let Some(job_id) = job_id {
+            job_id
+        } else {
+            job_id = Some(ulid::Ulid::new().into());
+            job_id.unwrap()
+        };
+        let mc = build_crypt_with_key_suffix(&db, &w_id, &job_id.to_string()).await?;
+        let encrypted = encrypt(&mc, raw);
+        safe_args.insert(
+            k.to_string(),
+            to_raw_value(&format!("$encrypted:{encrypted}")),
+        );
+    }
+
     let mut extra = HashMap::new();
     for (k, v) in static_inputs {
         extra.insert(k.to_string(), v.to_owned());

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -54,7 +54,10 @@ use windmill_common::{
     cache::{self, future::FutureCachedExt},
     db::{DbWithOptAuthed, UserDB},
     error::{to_anyhow, Error, JsonResult, Result},
-    jobs::{get_payload_tag_from_prefixed_path, schedule_job_deletion, JobPayload, RawCode},
+    jobs::{
+        get_payload_tag_from_prefixed_path, resolve_delete_after_secs, schedule_job_deletion,
+        JobPayload, RawCode,
+    },
     users::username_to_permissioned_as,
     utils::{
         http_get_from_hub, not_found_if_none, paginate, query_elems_from_hub, require_admin,
@@ -1990,6 +1993,8 @@ pub struct ExecuteApp {
     pub force_viewer_static_fields: Option<StaticFields>,
     pub force_viewer_one_of_fields: Option<OneOfFields>,
     pub force_viewer_allow_user_resources: Option<AllowUserResources>,
+    pub force_viewer_sensitive_inputs: Option<Vec<String>>,
+    pub force_viewer_delete_after_secs: Option<i32>,
     /// Runnable query parameters (e.g., memory_id for chat-enabled flows)
     pub run_query_params: Option<RunJobQuery>,
 }
@@ -2103,6 +2108,8 @@ async fn execute_component(
             force_viewer_static_fields: Some(static_inputs),
             force_viewer_one_of_fields,
             force_viewer_allow_user_resources,
+            force_viewer_sensitive_inputs,
+            force_viewer_delete_after_secs,
             ..
         } => (
             &Policy { execution_mode: ExecutionMode::Viewer, ..Default::default() },
@@ -2110,8 +2117,8 @@ async fn execute_component(
                 static_inputs,
                 one_of_inputs: force_viewer_one_of_fields.unwrap_or_default(),
                 allow_user_resources: force_viewer_allow_user_resources.unwrap_or_default(),
-                delete_after_secs: None,
-                sensitive_inputs: Vec::new(),
+                delete_after_secs: force_viewer_delete_after_secs,
+                sensitive_inputs: force_viewer_sensitive_inputs.unwrap_or_default(),
             },
         ),
         // 2. "run" mode.
@@ -2237,9 +2244,8 @@ async fn execute_component(
     let (username, permissioned_as, email) =
         get_on_behalf_details_from_policy_and_authed(&policy, &opt_authed).await?;
 
-    let resolved_delete_secs = policy_triggerables
-        .delete_after_secs
-        .filter(|secs| *secs >= 0);
+    let resolved_delete_secs =
+        resolve_delete_after_secs(None, policy_triggerables.delete_after_secs);
 
     let (args, job_id) = build_args(
         policy,
@@ -2330,7 +2336,9 @@ async fn execute_component(
     tx.commit().await?;
 
     if let Some(secs) = resolved_delete_secs {
-        schedule_job_deletion(&db, uuid, &w_id, secs).await?;
+        if let Err(e) = schedule_job_deletion(&db, uuid, &w_id, secs).await {
+            tracing::error!("Failed to schedule deletion for app job {uuid} after {secs}s: {e:#}");
+        }
     }
 
     Ok(uuid.to_string())

--- a/frontend/src/lib/components/apps/editor/commonAppUtils.ts
+++ b/frontend/src/lib/components/apps/editor/commonAppUtils.ts
@@ -14,6 +14,8 @@ export type TriggerableV2 = {
 	static_inputs: Record<string, any>
 	one_of_inputs?: Record<string, any[] | undefined>
 	allow_user_resources?: string[]
+	delete_after_secs?: number
+	sensitive_inputs?: string[]
 }
 
 export async function hash(message) {

--- a/frontend/src/lib/components/apps/editor/inlineScriptsPanel/CacheTtlPopup.svelte
+++ b/frontend/src/lib/components/apps/editor/inlineScriptsPanel/CacheTtlPopup.svelte
@@ -30,7 +30,7 @@
 			nonCaptureEvent={true}
 			btnClasses={Boolean(cache_ttl)
 				? 'bg-blue-100 text-blue-800 border border-blue-300 hover:bg-blue-200 dark:bg-frost-700 dark:text-frost-100 dark:border-frost-600'
-				: 'bg-surface text-primay hover:bg-hover'}
+				: 'bg-surface text-primary hover:bg-hover'}
 			color="light"
 			variant="contained"
 			size="xs2"

--- a/frontend/src/lib/components/apps/inputType.ts
+++ b/frontend/src/lib/components/apps/inputType.ts
@@ -71,6 +71,7 @@ export type UserInput<U> = {
 	type: 'user'
 	value: U | undefined
 	allowUserResources?: boolean
+	sensitive?: boolean
 }
 
 // Input can be uploaded with a file selector

--- a/frontend/src/lib/components/raw_apps/DeleteAfterUsePopup.svelte
+++ b/frontend/src/lib/components/raw_apps/DeleteAfterUsePopup.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+	import Toggle from '$lib/components/Toggle.svelte'
+	import { Button, SecondsInput } from '$lib/components/common'
+	import { Trash } from 'lucide-svelte'
+	import Popover from '$lib/components/meltComponents/Popover.svelte'
+	import { autoPlacement } from '@floating-ui/core'
+	import type { ComponentProps } from 'svelte'
+
+	interface Props {
+		delete_after_secs: number | undefined
+		btnProps?: ComponentProps<typeof Button>
+	}
+
+	let { delete_after_secs = $bindable(), btnProps }: Props = $props()
+
+	const enabled = $derived(typeof delete_after_secs === 'number' && delete_after_secs >= 0)
+</script>
+
+<Popover
+	floatingConfig={{
+		middleware: [
+			autoPlacement({
+				allowedPlacements: ['bottom-start', 'bottom-end', 'top-start', 'top-end', 'top', 'bottom']
+			})
+		]
+	}}
+	closeButton
+	contentClasses="block text-primary p-4"
+>
+	{#snippet trigger()}
+		<Button
+			nonCaptureEvent={true}
+			btnClasses={enabled
+				? 'bg-blue-100 text-blue-800 border border-blue-300 hover:bg-blue-200 dark:bg-frost-700 dark:text-frost-100 dark:border-frost-600'
+				: 'bg-surface text-primay hover:bg-hover'}
+			color="light"
+			variant="contained"
+			size="xs2"
+			iconOnly
+			startIcon={{ icon: Trash }}
+			title="Delete job metadata after the job completes"
+			{...btnProps}
+		/>
+	{/snippet}
+	{#snippet content()}
+		<Toggle
+			checked={enabled}
+			on:change={() => {
+				delete_after_secs = enabled ? undefined : 0
+			}}
+			options={{
+				right: 'Delete job metadata after the job completes'
+			}}
+		/>
+		<div class="mt-4">
+			<span class="text-xs font-bold">Delay before deletion</span>
+			<SecondsInput bind:seconds={delete_after_secs} disabled={!enabled} />
+			<span class="text-2xs text-tertiary block mt-1">0 = immediate</span>
+		</div>
+	{/snippet}
+</Popover>

--- a/frontend/src/lib/components/raw_apps/DeleteAfterUsePopup.svelte
+++ b/frontend/src/lib/components/raw_apps/DeleteAfterUsePopup.svelte
@@ -32,7 +32,7 @@
 			nonCaptureEvent={true}
 			btnClasses={enabled
 				? 'bg-blue-100 text-blue-800 border border-blue-300 hover:bg-blue-200 dark:bg-frost-700 dark:text-frost-100 dark:border-frost-600'
-				: 'bg-surface text-primay hover:bg-hover'}
+				: 'bg-surface text-primary hover:bg-hover'}
 			color="light"
 			variant="contained"
 			size="xs2"

--- a/frontend/src/lib/components/raw_apps/RawAppBackgroundRunner.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppBackgroundRunner.svelte
@@ -101,7 +101,15 @@
 										.filter(([k, v]) => v.type == 'static')
 										.map(([k, v]) => [k, v?.['value']])
 								)
-							: undefined
+							: undefined,
+						force_viewer_sensitive_inputs: editor
+							? undefinedIfEmpty(
+									Object.keys(runnable?.fields ?? {}).filter(
+										(k) => runnable?.fields?.[k]?.type == 'user' && runnable?.fields?.[k]?.sensitive
+									)
+								)
+							: undefined,
+						force_viewer_delete_after_secs: editor ? runnable?.delete_after_secs : undefined
 					},
 					undefined
 				)

--- a/frontend/src/lib/components/raw_apps/RawAppInlineScriptEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppInlineScriptEditor.svelte
@@ -16,6 +16,7 @@
 	import DiffEditor from '$lib/components/DiffEditor.svelte'
 	import type { InlineScript, StaticAppInput, UserAppInput, CtxAppInput } from '../apps/inputType'
 	import CacheTtlPopup from '../apps/editor/inlineScriptsPanel/CacheTtlPopup.svelte'
+	import DeleteAfterUsePopup from './DeleteAfterUsePopup.svelte'
 	import { computeFields } from '../apps/editor/inlineScriptsPanel/utils'
 	import EditorBar from '../EditorBar.svelte'
 	import { LanguageIcon } from '../common/languageIcons'
@@ -50,6 +51,7 @@
 		onRun: () => Promise<void>
 		editor?: any | undefined
 		lastDeployedCode?: string | undefined
+		delete_after_secs?: number | undefined
 		/** Called when code is selected in the editor */
 		onSelectionChange?: (
 			selection: {
@@ -71,7 +73,8 @@
 		onRun,
 		editor = $bindable(undefined),
 		lastDeployedCode,
-		onSelectionChange
+		onSelectionChange,
+		delete_after_secs = $bindable()
 	}: Props = $props()
 	let diffEditor = $state() as DiffEditor | undefined
 	let validCode = $state(true)
@@ -626,6 +629,7 @@
 				{#if inlineScript}
 					<CacheTtlPopup bind:cache_ttl={inlineScript.cache_ttl} />
 				{/if}
+				<DeleteAfterUsePopup bind:delete_after_secs />
 
 				<Button
 					variant="default"

--- a/frontend/src/lib/components/raw_apps/RawAppInlineScriptRunnable.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppInlineScriptRunnable.svelte
@@ -32,6 +32,7 @@
 
 	type RunnableWithInlineScript = RunnableWithFields & {
 		inlineScript?: InlineScript & { language: ScriptLang }
+		delete_after_secs?: number
 	}
 	export type Runnable = RunnableWithInlineScript | undefined
 	interface Props {
@@ -204,6 +205,7 @@
 					bind:inlineScript={runnable.inlineScript}
 					bind:name={runnable.name}
 					bind:fields={runnable.fields}
+					bind:delete_after_secs={runnable.delete_after_secs}
 					onRun={testPreview}
 					on:delete
 					path={appPath}

--- a/frontend/src/lib/components/raw_apps/RawAppInputsSpecEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppInputsSpecEditor.svelte
@@ -6,7 +6,7 @@
 
 	import ToggleButtonGroup from '$lib/components/common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import ToggleButton from '$lib/components/common/toggleButton-v2/ToggleButton.svelte'
-	import { Loader2, Pen, User, Shield } from 'lucide-svelte'
+	import { Loader2, Pen, User, Shield, Lock } from 'lucide-svelte'
 
 	import Toggle from '$lib/components/Toggle.svelte'
 	import StaticInputEditor from '../apps/editor/settingsPanel/inputEditor/StaticInputEditor.svelte'
@@ -17,10 +17,22 @@
 
 	// Build ctx properties with current user's actual values
 	let ctxProperties = $derived([
-		{ value: 'username', label: 'Username', subtitle: `string — "${$userStore?.username ?? 'unknown'}"` },
+		{
+			value: 'username',
+			label: 'Username',
+			subtitle: `string — "${$userStore?.username ?? 'unknown'}"`
+		},
 		{ value: 'email', label: 'Email', subtitle: `string — "${$userStore?.email ?? 'unknown'}"` },
-		{ value: 'groups', label: 'Groups', subtitle: `string[] — ${JSON.stringify($userStore?.groups ?? [])}` },
-		{ value: 'workspace', label: 'Workspace', subtitle: `string — "${$workspaceStore ?? 'unknown'}"` },
+		{
+			value: 'groups',
+			label: 'Groups',
+			subtitle: `string[] — ${JSON.stringify($userStore?.groups ?? [])}`
+		},
+		{
+			value: 'workspace',
+			label: 'Workspace',
+			subtitle: `string — "${$workspaceStore ?? 'unknown'}"`
+		},
 		{ value: 'author', label: 'Author', subtitle: `string — "${$userStore?.email ?? 'unknown'}"` }
 	])
 
@@ -131,7 +143,13 @@
 						{#snippet children({ item })}
 							<ToggleButton {item} value="user" icon={User} iconOnly tooltip="User Input" />
 							<ToggleButton {item} value="static" icon={Pen} iconOnly tooltip="Static" />
-							<ToggleButton {item} value="ctx" icon={Shield} iconOnly tooltip="Context (secure backend value)" />
+							<ToggleButton
+								{item}
+								value="ctx"
+								icon={Shield}
+								iconOnly
+								tooltip="Context (secure backend value)"
+							/>
 						{/snippet}
 					</ToggleButtonGroup>
 				{/if}
@@ -180,6 +198,23 @@
 				<Tooltip
 					>Apps are executed on behalf of publishers. If you want to accept resources from user, you
 					need to enable this (potentially dangerous!)</Tooltip
+				>
+			</div>
+		{/if}
+		{#if componentInput?.type === 'user'}
+			<div class="flex flex-row items-center gap-1">
+				<Toggle
+					size="xs"
+					bind:checked={componentInput.sensitive}
+					options={{
+						right: 'sensitive (encrypt in job args)'
+					}}
+				/>
+				<Lock size={12} class="text-tertiary" />
+				<Tooltip
+					>The value is encrypted before being stored in the job's args, so it is not exposed in
+					plaintext to anyone with read access to the job. The script still receives the decrypted
+					value at runtime.</Tooltip
 				>
 			</div>
 		{/if}

--- a/frontend/src/lib/components/raw_apps/RawAppInputsSpecEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppInputsSpecEditor.svelte
@@ -207,7 +207,7 @@
 					size="xs"
 					bind:checked={componentInput.sensitive}
 					options={{
-						right: 'sensitive (encrypt in job args)'
+						right: 'sensitive'
 					}}
 				/>
 				<Lock size={12} class="text-tertiary" />

--- a/frontend/src/lib/components/raw_apps/RawAppInputsSpecEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppInputsSpecEditor.svelte
@@ -205,7 +205,14 @@
 			<div class="flex flex-row items-center gap-1">
 				<Toggle
 					size="xs"
-					bind:checked={componentInput.sensitive}
+					checked={Boolean(componentInput.sensitive)}
+					on:change={(e) => {
+						if (e.detail) {
+							componentInput.sensitive = true
+						} else {
+							delete componentInput.sensitive
+						}
+					}}
 					textClass="!text-tertiary"
 					options={{
 						right: 'sensitive'

--- a/frontend/src/lib/components/raw_apps/RawAppInputsSpecEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppInputsSpecEditor.svelte
@@ -206,6 +206,7 @@
 				<Toggle
 					size="xs"
 					bind:checked={componentInput.sensitive}
+					textClass="!text-tertiary"
 					options={{
 						right: 'sensitive'
 					}}

--- a/frontend/src/lib/components/raw_apps/rawAppPolicy.ts
+++ b/frontend/src/lib/components/raw_apps/rawAppPolicy.ts
@@ -34,8 +34,8 @@ export type Runnable = RunnableWithInlineScript | undefined
 function extraFields(
 	runnable: RunnableWithInlineScript,
 	fields: Record<string, any>
-): Pick<TriggerableV2, 'delete_after_secs' | 'sensitive_inputs'> {
-	const out: Pick<TriggerableV2, 'delete_after_secs' | 'sensitive_inputs'> = {}
+): Partial<Pick<TriggerableV2, 'delete_after_secs' | 'sensitive_inputs'>> {
+	const out: Partial<Pick<TriggerableV2, 'delete_after_secs' | 'sensitive_inputs'>> = {}
 	if (typeof runnable.delete_after_secs === 'number' && runnable.delete_after_secs >= 0)
 		out.delete_after_secs = runnable.delete_after_secs
 	const sensitive_inputs = Object.entries(fields)

--- a/frontend/src/lib/components/raw_apps/rawAppPolicy.ts
+++ b/frontend/src/lib/components/raw_apps/rawAppPolicy.ts
@@ -27,8 +27,23 @@ export async function updateRawAppPolicy(
 
 type RunnableWithInlineScript = RunnableWithFields & {
 	inlineScript?: InlineScript & { language: ScriptLang }
+	delete_after_secs?: number
 }
 export type Runnable = RunnableWithInlineScript | undefined
+
+function extraFields(
+	runnable: RunnableWithInlineScript,
+	fields: Record<string, any>
+): Pick<TriggerableV2, 'delete_after_secs' | 'sensitive_inputs'> {
+	const out: Pick<TriggerableV2, 'delete_after_secs' | 'sensitive_inputs'> = {}
+	if (typeof runnable.delete_after_secs === 'number' && runnable.delete_after_secs >= 0)
+		out.delete_after_secs = runnable.delete_after_secs
+	const sensitive_inputs = Object.entries(fields)
+		.map(([k, v]) => (v['sensitive'] ? k : undefined))
+		.filter(Boolean) as string[]
+	if (sensitive_inputs.length > 0) out.sensitive_inputs = sensitive_inputs
+	return out
+}
 
 async function processRunnable(
 	id: string,
@@ -50,7 +65,8 @@ async function processRunnable(
 			{
 				static_inputs: staticInputs,
 				one_of_inputs: {},
-				allow_user_resources: allowUserResources
+				allow_user_resources: allowUserResources,
+				...extraFields(runnable, fields)
 			}
 		]
 	} else if (isRunnableByPath(runnable)) {
@@ -60,7 +76,8 @@ async function processRunnable(
 			{
 				static_inputs: staticInputs,
 				one_of_inputs: {},
-				allow_user_resources: allowUserResources
+				allow_user_resources: allowUserResources,
+				...extraFields(runnable, fields)
 			}
 		]
 	}


### PR DESCRIPTION
## Summary

Add two per-runnable policy options for raw apps backend runnables:

- **`delete_after_secs`** — schedule the job's args/result/logs to be wiped a configurable number of seconds after completion (0 = immediate)
- **`sensitive_inputs`** — list of arg keys whose values are encrypted (`$encrypted:...`) before being stored in `v2_job.args`; the worker decrypts them at runtime so scripts still see plaintext

Both fields live on `PolicyTriggerableInputs` in the app policy, so they are configured per-runnable, not per-app.

## Changes

### Backend (`windmill-api/src/apps.rs`)
- `PolicyTriggerableInputs` extended with `delete_after_secs: Option<i32>` and `sensitive_inputs: Vec<String>`
- `execute_component` calls `schedule_job_deletion` after the job is pushed when `delete_after_secs >= 0`
- `build_args` encrypts each key in `sensitive_inputs` using `build_crypt_with_key_suffix(db, w_id, job_id)`, matching the existing `$encrypted:` flow used for `allow_user_resources`
- A `job_id` is reused (or generated) so the worker can decrypt with `get_root_job_id` as it already does

### Frontend
- `TriggerableV2` type extended with `delete_after_secs` and `sensitive_inputs`
- `UserInput` gets a `sensitive?: boolean` flag (only user-provided inputs are eligible — static inputs go to `extra` and don't apply)
- `rawAppPolicy.ts` collects the per-field `sensitive` flags into the policy entry's `sensitive_inputs`
- `DeleteAfterUsePopup.svelte` (new) — toggle + seconds input rendered next to the cache-TTL popup in `RawAppInlineScriptEditor`
- `RawAppInputsSpecEditor.svelte` — added a "sensitive (encrypt in job args)" toggle on user-type fields with a lock icon and tooltip

## Test plan

- [x] Verified end-to-end via API: created an app with `delete_after_secs: 30` and `sensitive_inputs: ["secret"]`, called `/apps_u/execute_component` with a sensitive arg
  - `v2_job.args.secret` was stored as `$encrypted:LgTpRYeni9zQ8k/nwe+SPw==`
  - Worker-decrypted job result returned the plaintext value
  - `job_delete_schedule` had a row with `delete_at = now() + 30s`
  - Running the monitor's cleanup SQL manually wiped args/result/logs and removed the schedule row
- [ ] UI smoke test: open a raw app, toggle delete_after_secs and sensitive on a runnable, save, confirm policy round-trip
- [ ] Existing apps without these fields still load (covered by `serde(default)` + Option/Vec defaults)

## Notes

`cleanup_scheduled_job_deletions` in `backend/src/monitor.rs` is `#[cfg(feature = "enterprise")]`-gated — same as the existing `delete_after_secs` on scripts/flows. On CE builds the schedule rows accumulate but are never processed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two per-runnable options for raw apps: auto-delete job metadata after completion and encryption of selected user inputs. Editor preview now mirrors deployed runs for both behaviors.

- **New Features**
  - Backend: add `delete_after_secs` and `sensitive_inputs` to runnable policy; encrypt flagged values in `v2_job.args`; decrypt at runtime.
  - Scheduling: use `resolve_delete_after_secs` to compute deletion timing; schedule cleanup after completion.
  - UI: add a “sensitive” toggle on user inputs (lock icon + tooltip); add a delete-after popup next to the cache TTL in the inline script editor; turning off the sensitive toggle clears the flag.
  - Types: extend `TriggerableV2` and `UserInput`; policy builder collects per-field sensitive flags into `sensitive_inputs`.

- **Bug Fixes**
  - Editor preview sends `force_viewer_sensitive_inputs` and `force_viewer_delete_after_secs`, so preview matches deployed-mode encryption and deletion.
  - Deletion scheduling errors are logged and do not fail the run.
  - Fixed minor UI class typo in cache/delete popovers.

<sup>Written for commit eea22a1bfab5d57dfe029a7232aefcbd47f229fb. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/8975?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

