### PR TITLE
test: isolate WAC v2 python test from stack overflow

### DIFF
--- a/.github/workflows/backend-test-windows.yml
+++ b/.github/workflows/backend-test-windows.yml
@@ -145,6 +145,10 @@ jobs:
           RUST_LOG_STYLE: never
           CARGO_NET_GIT_FETCH_WITH_CLI: true
           CARGO_BUILD_JOBS: 12
+          # Tests' poll-time stack frames (deep nested async fn chains in
+          # debug builds) reach ~1.8MB. 4MB gives ~2x headroom against flaky
+          # overflows under parallel-test contention.
+          RUST_MIN_STACK: 4194304
           VCPKGRS_DYNAMIC: 1
           OPENSSL_DIR: ${{ env.VCPKG_INSTALLATION_ROOT }}\installed\x64-windows-static
           DENO_PATH: ${{ steps.runtime-paths.outputs.DENO_PATH }}

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -244,6 +244,11 @@ jobs:
           RUST_LOG_STYLE: never
           CARGO_NET_GIT_FETCH_WITH_CLI: true
           CARGO_BUILD_JOBS: 12
+          # Tests' poll-time stack frames (deep nested async fn chains in
+          # debug builds) reach ~1.8MB, leaving very thin headroom on the
+          # default 2MB thread stack. 4MB gives ~2x buffer against flaky
+          # overflows under parallel-test contention.
+          RUST_MIN_STACK: 4194304
           WMDEBUG_FORCE_V0_WORKSPACE_DEPENDENCIES: 1
           WMDEBUG_FORCE_RUNNABLE_SETTINGS_V0: 1
           WMDEBUG_FORCE_NO_LEGACY_DEBOUNCING_COMPAT: 1

--- a/backend/tests/python_jobs.rs
+++ b/backend/tests/python_jobs.rs
@@ -985,33 +985,42 @@ async def main(item: str, qty: int, email: str):
 "#
     .to_string();
 
-    // WAC requires at least 2 workers (parent + task sub-jobs)
-    let db = &db;
-    in_test_worker(
-        db,
-        async move {
-            let job = Box::pin(
-                RunJob::from(JobPayload::Code(RawCode {
-                    language: ScriptLang::Python3,
-                    content,
-                    ..RawCode::default()
-                }))
-                .arg("item", json!("widget"))
-                .arg("qty", json!(5))
-                .arg("email", json!("test@example.com"))
-                .run_until_complete(db, false, port),
-            )
-            .await;
+    // WAC requires at least 2 workers (parent + task sub-jobs).
+    //
+    // Run the heavy `in_test_worker` chain on an isolated OS thread with a
+    // larger stack: the deep nested async chain (test -> in_test_worker ->
+    // run_until_complete -> windmill_queue::push -> ...) composes into one
+    // synchronous poll-stack frame that exceeds the default 2 MB test-thread
+    // stack in debug builds. `Box::pin` at the call site only moves future
+    // *state* to the heap; it can't shrink poll-time stack frames.
+    let db = db.clone();
+    run_in_isolated_thread(move || async move {
+        in_test_worker(
+            &db,
+            async {
+                let job = Box::pin(
+                    RunJob::from(JobPayload::Code(RawCode {
+                        language: ScriptLang::Python3,
+                        content,
+                        ..RawCode::default()
+                    }))
+                    .arg("item", json!("widget"))
+                    .arg("qty", json!(5))
+                    .arg("email", json!("test@example.com"))
+                    .run_until_complete(&db, false, port),
+                )
+                .await;
 
-            let result = job.json_result().unwrap();
-            assert_eq!(result["item"], json!("widget"));
-            assert_eq!(result["qty"], json!(5));
-            assert_eq!(result["email"], json!("test@example.com"));
-            assert_eq!(result["greeting"], json!("hello widget x5"));
-        },
-        port,
-    )
-    .await;
+                let result = job.json_result().unwrap();
+                assert_eq!(result["item"], json!("widget"));
+                assert_eq!(result["qty"], json!(5));
+                assert_eq!(result["email"], json!("test@example.com"));
+                assert_eq!(result["greeting"], json!("hello widget x5"));
+            },
+            port,
+        )
+        .await;
+    });
     Ok(())
 }
 

--- a/backend/windmill-test-utils/src/lib.rs
+++ b/backend/windmill-test-utils/src/lib.rs
@@ -395,6 +395,36 @@ pub async fn in_test_worker<Fut: std::future::Future>(
     res
 }
 
+/// Run an async test body on a freshly-spawned OS thread with a large stack
+/// and a fresh current-thread tokio runtime. Use this for tests whose async
+/// chain (e.g. nested `in_test_worker` -> `run_until_complete` ->
+/// `windmill_queue::push`) blows the default 2 MB test-thread stack in debug
+/// builds, where `async fn` state machines are unoptimized and `Box::pin` at
+/// the call site only moves *future state* to the heap, not the synchronous
+/// poll-time stack frames composed along the chain.
+///
+/// The chain contains `?Send` futures (trait objects), so `tokio::spawn`
+/// is not viable; `std::thread::spawn` sidesteps the shared-stack issue.
+pub fn run_in_isolated_thread<F, Fut, R>(f: F) -> R
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = R>,
+    R: Send + 'static,
+{
+    std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build current-thread runtime");
+            rt.block_on(f())
+        })
+        .expect("spawn isolated test thread")
+        .join()
+        .expect("isolated test thread panicked")
+}
+
 pub fn spawn_test_worker(
     conn: &Connection,
     port: u16,


### PR DESCRIPTION
## Summary

`test_python_wac_v2_with_args` overflows the test-thread stack under reduced stack budgets (e.g. `RUST_MIN_STACK<2MB` or parallel-test contention) — it consumes ~1.8 MB of the default 2 MB budget, leaving almost no headroom. Move the heavy async chain to an isolated OS thread with an 8 MB stack so the test passes reliably regardless of test-thread stack pressure.

## Why `Box::pin` alone doesn't fix this

The future *state* is only ~912 bytes — `Box::pin` already moves state to the heap. The 1.8 MB is consumed by *synchronous poll-time stack frames* composed along the chain:

```
test fn -> in_test_worker -> run_until_complete -> windmill_queue::push (28-arg push_inner construction) -> ...
```

`Box::pin` at the call site cannot shrink those frames in unoptimized debug builds. Tried Box::pin at every level (test call site, `in_test_worker` body, `run_until_complete` body, `spawn_test_worker`'s spawned future) — threshold remained at ~1.8 MB.

Breaking the chain across a thread boundary gives the polling stack a fresh scope and reliably fixes the issue.

## Changes

- `backend/windmill-test-utils/src/lib.rs`: add `run_in_isolated_thread<F, Fut, R>(f)` helper that spawns an OS thread with an 8 MB stack, builds a fresh current-thread tokio runtime, and runs the future there. The `?Send` constraint on the inner async chain (trait objects from `StreamFind::find`) rules out `tokio::spawn`; `std::thread::spawn` sidesteps it because `Fut` is created on the new thread and never crosses thread boundaries.
- `backend/tests/python_jobs.rs`: wrap `test_python_wac_v2_with_args`'s body in `run_in_isolated_thread`.

## Test plan

- [ ] `cargo test --features python,private --test python_jobs 'test_python_wac'` passes (all 3 WAC v2 python tests)
- [ ] `RUST_MIN_STACK=1048576 cargo test --features python,private --test python_jobs test_python_wac_v2_with_args` passes (used to overflow at 1 MB)
- [ ] `RUST_MIN_STACK=262144 ./target/debug/deps/python_jobs-* test_python_wac_v2_with_args --nocapture` passes (verifies chain is fully broken from test thread)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolate the heavy async chain in `test_python_wac_v2_with_args` on a dedicated OS thread with a larger stack to stop test-thread stack overflows. Also set `RUST_MIN_STACK` to 4 MB in CI to add headroom and reduce flakiness.

- **Bug Fixes**
  - Added `run_in_isolated_thread` (8 MB stack + current-thread Tokio runtime) in `backend/windmill-test-utils/src/lib.rs` for `?Send` async chains.
  - Wrapped the test’s `in_test_worker` path in `backend/tests/python_jobs.rs` with the helper to avoid ~1.8 MB poll-time stack frames overrunning the default 2 MB stack.
  - CI: set `RUST_MIN_STACK=4194304` in `backend-test.yml` and `backend-test-windows.yml` to provide ~2x headroom during parallel tests.

<sup>Written for commit 1ff84eb73eae1f94b3550c81ca631ba6c6683730. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/8979?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

