### PR TITLE
fix: persist flow labels when editing

### DIFF
--- a/backend/windmill-api-flows/src/flows.rs
+++ b/backend/windmill-api-flows/src/flows.rs
@@ -1492,6 +1492,8 @@ pub struct FlowWDraft {
     pub visible_to_runner_only: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub on_behalf_of_email: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<Vec<String>>,
 }
 
 async fn get_flow_by_path_w_draft(
@@ -1516,7 +1518,8 @@ async fn get_flow_by_path_w_draft(
             draft.value AS draft,
             flow.tag,
             flow.visible_to_runner_only,
-            flow.on_behalf_of_email
+            flow.on_behalf_of_email,
+            flow.labels
         FROM flow
         LEFT JOIN draft
             ON flow.path = draft.path


### PR DESCRIPTION
## Summary

Fixes #8963 — labels disappear when editing a flow that has labels and adding a new one.

## Root cause

`get_flow_by_path_w_draft` (the endpoint the flow editor uses to load a flow) did not include `flow.labels` in its SELECT or in the `FlowWDraft` struct. So when editing:

1. The labels input rendered empty (frontend received undefined labels).
2. Editing without changes preserved labels because the update SQL uses `labels = COALESCE($14, labels)` — `null` keeps the existing value.
3. Adding a single label sent `[newLabel]` to the backend, which overwrote the saved labels.

## Changes

- Add `labels: Option<Vec<String>>` to `FlowWDraft` in `backend/windmill-api-flows/src/flows.rs`.
- Add `flow.labels` to the `get_flow_by_path_w_draft` SELECT.

## Test plan

- [ ] Create a flow with two labels, deploy, reopen → labels visible in the editor.
- [ ] Edit the flow without touching labels, deploy → both labels still present.
- [ ] Edit the flow, add a third label, deploy → all three labels persist.

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #8963: ensure flow labels persist when editing. The editor now loads existing labels and keeps them when adding new ones.

- **Bug Fixes**
  - Added `labels: Option<Vec<String>>` to `FlowWDraft`.
  - Included `flow.labels` in the `get_flow_by_path_w_draft` SELECT so the editor receives labels.

<sup>Written for commit bbf3beb6290969ec91bef6efb240a42f54cfa4d2. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/8981?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

