### PR TITLE
fix: avoid effect loop when clicking flow node on runs page

### DIFF
--- a/frontend/src/lib/components/useNestedRestartState.svelte.ts
+++ b/frontend/src/lib/components/useNestedRestartState.svelte.ts
@@ -91,8 +91,8 @@ export function useNestedRestartState(opts: {
 			return
 		}
 
-		selectedJobStepIsTopLevel =
-			job.flow_status.modules.findIndex((m) => m.id === selectedJobStep) >= 0
+		const isTopLevel = job.flow_status.modules.findIndex((m) => m.id === selectedJobStep) >= 0
+		selectedJobStepIsTopLevel = isTopLevel
 		const moduleDefinition = job.raw_flow?.modules.find((m) => m.id === selectedJobStep)
 		if (moduleDefinition?.value.type === 'forloopflow') {
 			selectedJobStepType = 'forloop'
@@ -107,7 +107,10 @@ export function useNestedRestartState(opts: {
 			selectedJobStepType = 'single'
 		}
 
-		if (selectedJobStepIsTopLevel) return
+		// Read from the local — reading the `$state` we just wrote would register
+		// it as a dependency of this effect, causing `effect_update_depth_exceeded`
+		// because each write would reschedule the effect.
+		if (isTopLevel) return
 
 		// Inline-expanded subflow: id is `subflow:outerStep:[innerSubflow:...]<leaf>`.
 		// The graph adds the `subflow:` prefix only for subflow expansions, so each


### PR DESCRIPTION
## Summary

Clicking a flow node on the runs detail page (`/run/...`) threw `effect_update_depth_exceeded`, breaking the panel's selection behavior.

## Changes

- `useNestedRestartState`: compute `isTopLevel` into a local `const`, write it to the `$state` once, and use the local for the early-return check. Reading the `$state` after writing it inside the same `$effect` was registering it as a dependency, so each write rescheduled the effect into an infinite loop.

## Test plan

- [ ] Run any 2-step flow, open the run detail page, click each node — no console error, right panel updates as before
- [ ] Restart-from-step button still appears for top-level steps and nested (BranchOne / sequential ForLoop / expanded subflow) steps

---
Generated with [Claude Code](https://claude.com/claude-code)