### PR TITLE
fix(workspaces): split get_settings into admin-only + public endpoint

### DIFF
--- a/backend/.sqlx/query-71eeda25c59d724d6e0c4b2b52078567d6e477a2c62656de1deaef602221edcf.json
+++ b/backend/.sqlx/query-71eeda25c59d724d6e0c4b2b52078567d6e477a2c62656de1deaef602221edcf.json
@@ -1,0 +1,76 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            workspace_id,\n            slack_team_id,\n            slack_name,\n            teams_team_id,\n            teams_team_name,\n            teams_team_guid,\n            mute_critical_alerts,\n            deploy_ui,\n            large_file_storage,\n            datatable\n        FROM\n            workspace_settings\n        WHERE\n            workspace_id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "workspace_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "slack_team_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "slack_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "teams_team_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "teams_team_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "teams_team_guid",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "mute_critical_alerts",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "deploy_ui",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 8,
+        "name": "large_file_storage",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 9,
+        "name": "datatable",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "71eeda25c59d724d6e0c4b2b52078567d6e477a2c62656de1deaef602221edcf"
+}

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -674,6 +674,11 @@ async fn get_settings(
 
     if !authed.is_admin {
         settings.slack_oauth_client_secret = None;
+        // git_app_installations holds GitHub App JWTs and cached installation
+        // tokens used by git-sync. The cached installation_token is refreshed on
+        // each git-sync action and is valid for ~55 minutes, so a value read here
+        // is essentially always live. It must not be exposed to non-admins.
+        settings.git_app_installations = None;
     }
     Ok(Json(settings))
 }

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -83,6 +83,7 @@ pub fn workspaced_service() -> Router {
         .route("/get_imports/{*importer_path}", get(get_imports))
         .route("/get_dependents_amounts", post(get_dependents_amounts))
         .route("/get_settings", get(get_settings))
+        .route("/get_public_settings", get(get_public_settings))
         .route(
             "/get_copilot_settings_state",
             get(get_copilot_settings_state),
@@ -277,6 +278,34 @@ pub struct WorkspaceSettings {
     pub success_handler: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub public_app_execution_limit_per_minute: Option<i32>,
+}
+
+/// Subset of `WorkspaceSettings` that is safe to return to any workspace
+/// member. Adding a field here means it will be readable by every authed user
+/// in the workspace — anything sensitive (OAuth secrets, GitHub App tokens,
+/// billing/customer info, integration credentials, etc.) must NOT be added.
+/// The full `WorkspaceSettings` struct is admin-only via `get_settings`.
+#[derive(FromRow, Serialize, Debug)]
+pub struct WorkspacePublicSettings {
+    pub workspace_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slack_team_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slack_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub teams_team_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub teams_team_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub teams_team_guid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mute_critical_alerts: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deploy_ui: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub large_file_storage: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub datatable: Option<serde_json::Value>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -622,6 +651,10 @@ async fn get_settings(
     Path(w_id): Path<String>,
     Extension(user_db): Extension<UserDB>,
 ) -> JsonResult<WorkspaceSettings> {
+    // Admin-only: this struct contains OAuth secrets, GitHub App tokens, billing
+    // info, and other admin-managed integration credentials. Non-admin callers
+    // should use `get_public_settings`.
+    require_admin(authed.is_admin, &authed.username)?;
     let mut tx = user_db.begin(&authed).await?;
     let settings = sqlx::query_as!(
         WorkspaceSettings,
@@ -669,17 +702,46 @@ async fn get_settings(
     .await
     .map_err(|e| Error::internal_err(format!("getting settings: {e:#}")))?;
 
-    let mut settings = not_found_if_none(settings, "workspace settings", &w_id)?;
+    let settings = not_found_if_none(settings, "workspace settings", &w_id)?;
     tx.commit().await?;
 
-    if !authed.is_admin {
-        settings.slack_oauth_client_secret = None;
-        // git_app_installations holds GitHub App JWTs and cached installation
-        // tokens used by git-sync. The cached installation_token is refreshed on
-        // each git-sync action and is valid for ~55 minutes, so a value read here
-        // is essentially always live. It must not be exposed to non-admins.
-        settings.git_app_installations = None;
-    }
+    Ok(Json(settings))
+}
+
+async fn get_public_settings(
+    authed: ApiAuthed,
+    Path(w_id): Path<String>,
+    Extension(user_db): Extension<UserDB>,
+) -> JsonResult<WorkspacePublicSettings> {
+    let mut tx = user_db.begin(&authed).await?;
+    let settings = sqlx::query_as!(
+        WorkspacePublicSettings,
+        r#"
+        SELECT
+            workspace_id,
+            slack_team_id,
+            slack_name,
+            teams_team_id,
+            teams_team_name,
+            teams_team_guid,
+            mute_critical_alerts,
+            deploy_ui,
+            large_file_storage,
+            datatable
+        FROM
+            workspace_settings
+        WHERE
+            workspace_id = $1
+        "#,
+        &w_id
+    )
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| Error::internal_err(format!("getting public settings: {e:#}")))?;
+
+    let settings = not_found_if_none(settings, "workspace settings", &w_id)?;
+    tx.commit().await?;
+
     Ok(Json(settings))
 }
 

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -3027,9 +3027,51 @@ paths:
                 items:
                   $ref: "#/components/schemas/WorkspaceInvite"
 
+  /w/{workspace}/workspaces/get_public_settings:
+    get:
+      summary: get public settings
+      description: Returns the subset of workspace settings safe to expose to any workspace member. The full settings struct is admin-only via `getSettings`.
+      operationId: getPublicSettings
+      tags:
+        - workspace
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+
+      responses:
+        "200":
+          description: status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  workspace_id:
+                    type: string
+                  slack_name:
+                    type: string
+                  slack_team_id:
+                    type: string
+                  teams_team_id:
+                    type: string
+                  teams_team_name:
+                    type: string
+                  teams_team_guid:
+                    type: string
+                  large_file_storage:
+                    $ref: "#/components/schemas/LargeFileStorage"
+                  datatable:
+                    $ref: "#/components/schemas/DataTableSettings"
+                  deploy_ui:
+                    $ref: "#/components/schemas/WorkspaceDeployUISettings"
+                  mute_critical_alerts:
+                    type: boolean
+                required:
+                  - workspace_id
+
   /w/{workspace}/workspaces/get_settings:
     get:
-      summary: get settings
+      summary: get settings (admin only)
+      description: Returns the full workspace settings including admin-managed integration credentials. Admin-only — non-admin callers should use `getPublicSettings`.
       operationId: getSettings
       tags:
         - workspace

--- a/backend/windmill-api/src/workspaces_export.rs
+++ b/backend/windmill-api/src/workspaces_export.rs
@@ -1038,7 +1038,13 @@ pub(crate) async fn tarball_workspace(
                 slack_name: row.slack_name.clone(),
                 slack_command_script: row.slack_command_script.clone(),
                 slack_oauth_client_id: row.slack_oauth_client_id.clone(),
-                slack_oauth_client_secret: row.slack_oauth_client_secret.clone(),
+                // Mirror the non-admin redaction in `get_settings`: the OAuth
+                // client secret is admin-only and must not leak via tarball.
+                slack_oauth_client_secret: if authed.is_admin {
+                    row.slack_oauth_client_secret.clone()
+                } else {
+                    None
+                },
             };
             serde_json::to_value(settings)
                 .map(|v| serde_json::to_string_pretty(&v).ok())

--- a/frontend/src/lib/components/DatatableSchemaDiff.svelte
+++ b/frontend/src/lib/components/DatatableSchemaDiff.svelte
@@ -229,7 +229,7 @@
 		error = undefined
 		diffs = []
 		try {
-			const forkSettings = await WorkspaceService.getSettings({
+			const forkSettings = await WorkspaceService.getPublicSettings({
 				workspace: currentWorkspaceId
 			})
 			const datatables = forkSettings.datatable?.datatables ?? {}
@@ -364,7 +364,7 @@
 			const { schemaName, tableName } = drawerChange
 			const newTableDef = sourceSchema[schemaName]?.[tableName]
 
-			const forkSettings = await WorkspaceService.getSettings({
+			const forkSettings = await WorkspaceService.getPublicSettings({
 				workspace: currentWorkspaceId
 			})
 			const datatableConfig = forkSettings.datatable ?? { datatables: {} }

--- a/frontend/src/lib/components/ErrorOrRecoveryHandler.svelte
+++ b/frontend/src/lib/components/ErrorOrRecoveryHandler.svelte
@@ -113,7 +113,7 @@
 	const CHANNEL_KEY = 'channel'
 
 	async function loadSlackResources() {
-		const settings = await WorkspaceService.getSettings({ workspace: $workspaceStore! })
+		const settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
 		if (!emptyString(settings.slack_name) && !emptyString(settings.slack_team_id)) {
 			workspaceConnectedToSlack = true
 			slack_team_name = settings.slack_name
@@ -124,7 +124,7 @@
 	}
 
 	async function loadTeamsResources() {
-		const settings = await WorkspaceService.getSettings({ workspace: $workspaceStore! })
+		const settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
 		if (!emptyString(settings.teams_team_name) && !emptyString(settings.teams_team_id)) {
 			workspaceConnectedToTeams = true
 		} else {

--- a/frontend/src/lib/components/InputTransformSchemaForm.svelte
+++ b/frontend/src/lib/components/InputTransformSchemaForm.svelte
@@ -82,7 +82,7 @@
 	async function checkS3Storage() {
 		try {
 			if ($workspaceStore) {
-				const settings = await WorkspaceService.getSettings({ workspace: $workspaceStore })
+				const settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore })
 				s3StorageConfigured = settings.large_file_storage?.s3_resource_path !== undefined
 			}
 		} catch (error) {

--- a/frontend/src/lib/components/apps/editor/AppReportsDrawerInner.svelte
+++ b/frontend/src/lib/components/apps/editor/AppReportsDrawerInner.svelte
@@ -73,7 +73,7 @@
 
 	let isSlackConnectedWorkspace = $state(false)
 	async function getWorspaceSlackSetting() {
-		const settings = await WorkspaceService.getSettings({
+		const settings = await WorkspaceService.getPublicSettings({
 			workspace: $workspaceStore!
 		})
 		if (settings.slack_name) {

--- a/frontend/src/lib/components/home/deploy_ui.ts
+++ b/frontend/src/lib/components/home/deploy_ui.ts
@@ -18,6 +18,6 @@ async function getDeployUiSettingsInner(): Promise<WorkspaceDeployUISettings> {
 	if (!get(enterpriseLicense)) {
 		return ALL_DEPLOYABLE
 	}
-	let settings = await WorkspaceService.getSettings({ workspace: get(workspaceStore)! })
+	let settings = await WorkspaceService.getPublicSettings({ workspace: get(workspaceStore)! })
 	return settings.deploy_ui ?? ALL_DEPLOYABLE
 }

--- a/frontend/src/lib/components/sidebar/SidebarContent.svelte
+++ b/frontend/src/lib/components/sidebar/SidebarContent.svelte
@@ -94,7 +94,7 @@
 	async function loadForkedDatatables() {
 		if (!$workspaceStore) return
 		try {
-			const settings = await WorkspaceService.getSettings({ workspace: $workspaceStore })
+			const settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore })
 			const datatables = settings.datatable?.datatables ?? {}
 			forkedDatatables = Object.entries(datatables)
 				.filter(([_, dt]) => dt.forked_from != null)

--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -363,7 +363,7 @@
 	async function loadCriticalAlertsMuted() {
 		let g_muted = true
 		const ws_muted =
-			(await WorkspaceService.getSettings({ workspace: $workspaceStore! })).mute_critical_alerts ||
+			(await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })).mute_critical_alerts ||
 			false
 
 		if ($superadmin) {

--- a/frontend/src/routes/(root)/(logged)/azure_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/azure_triggers/+page.svelte
@@ -71,7 +71,7 @@
 			deployUiSettings = ALL_DEPLOYABLE
 			return
 		}
-		let settings = await WorkspaceService.getSettings({ workspace: $workspaceStore! })
+		let settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
 		deployUiSettings = settings.deploy_ui ?? ALL_DEPLOYABLE
 	}
 	getDeployUiSettings()

--- a/frontend/src/routes/(root)/(logged)/email_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/email_triggers/+page.svelte
@@ -74,7 +74,7 @@
 			deployUiSettings = ALL_DEPLOYABLE
 			return
 		}
-		let settings = await WorkspaceService.getSettings({ workspace: $workspaceStore! })
+		let settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
 		deployUiSettings = settings.deploy_ui ?? ALL_DEPLOYABLE
 	}
 	getDeployUiSettings()

--- a/frontend/src/routes/(root)/(logged)/flows/get/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/flows/get/[...path]/+page.svelte
@@ -359,7 +359,7 @@
 			deployUiSettings = ALL_DEPLOYABLE
 			return
 		}
-		let settings = await WorkspaceService.getSettings({ workspace: $workspaceStore! })
+		let settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
 		deployUiSettings = settings.deploy_ui ?? ALL_DEPLOYABLE
 	}
 	getDeployUiSettings()

--- a/frontend/src/routes/(root)/(logged)/gcp_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/gcp_triggers/+page.svelte
@@ -71,7 +71,7 @@
 			deployUiSettings = ALL_DEPLOYABLE
 			return
 		}
-		let settings = await WorkspaceService.getSettings({ workspace: $workspaceStore! })
+		let settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
 		deployUiSettings = settings.deploy_ui ?? ALL_DEPLOYABLE
 	}
 	getDeployUiSettings()

--- a/frontend/src/routes/(root)/(logged)/kafka_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/kafka_triggers/+page.svelte
@@ -63,7 +63,7 @@
 			deployUiSettings = ALL_DEPLOYABLE
 			return
 		}
-		let settings = await WorkspaceService.getSettings({ workspace: $workspaceStore! })
+		let settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
 		deployUiSettings = settings.deploy_ui ?? ALL_DEPLOYABLE
 	}
 	getDeployUiSettings()

--- a/frontend/src/routes/(root)/(logged)/mqtt_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/mqtt_triggers/+page.svelte
@@ -58,7 +58,7 @@
 			deployUiSettings = ALL_DEPLOYABLE
 			return
 		}
-		let settings = await WorkspaceService.getSettings({ workspace: $workspaceStore! })
+		let settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
 		deployUiSettings = settings.deploy_ui ?? ALL_DEPLOYABLE
 	}
 	getDeployUiSettings()

--- a/frontend/src/routes/(root)/(logged)/nats_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/nats_triggers/+page.svelte
@@ -63,7 +63,7 @@
 			deployUiSettings = ALL_DEPLOYABLE
 			return
 		}
-		let settings = await WorkspaceService.getSettings({ workspace: $workspaceStore! })
+		let settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
 		deployUiSettings = settings.deploy_ui ?? ALL_DEPLOYABLE
 	}
 	getDeployUiSettings()

--- a/frontend/src/routes/(root)/(logged)/postgres_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/postgres_triggers/+page.svelte
@@ -70,7 +70,7 @@
 			deployUiSettings = ALL_DEPLOYABLE
 			return
 		}
-		let settings = await WorkspaceService.getSettings({ workspace: $workspaceStore! })
+		let settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
 		deployUiSettings = settings.deploy_ui ?? ALL_DEPLOYABLE
 	}
 	getDeployUiSettings()

--- a/frontend/src/routes/(root)/(logged)/resources/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/resources/+page.svelte
@@ -435,7 +435,7 @@
 			deployUiSettings = ALL_DEPLOYABLE
 			return
 		}
-		let settings = await WorkspaceService.getSettings({ workspace: $workspaceStore! })
+		let settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
 		deployUiSettings = settings.deploy_ui ?? ALL_DEPLOYABLE
 	}
 	getDeployUiSettings()

--- a/frontend/src/routes/(root)/(logged)/routes/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/routes/+page.svelte
@@ -91,7 +91,7 @@
 			deployUiSettings = ALL_DEPLOYABLE
 			return
 		}
-		let settings = await WorkspaceService.getSettings({ workspace: $workspaceStore! })
+		let settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
 		deployUiSettings = settings.deploy_ui ?? ALL_DEPLOYABLE
 	}
 	getDeployUiSettings()

--- a/frontend/src/routes/(root)/(logged)/schedules/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/schedules/+page.svelte
@@ -61,7 +61,7 @@
 			deployUiSettings = ALL_DEPLOYABLE
 			return
 		}
-		let settings = await WorkspaceService.getSettings({ workspace: $workspaceStore! })
+		let settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
 		deployUiSettings = settings.deploy_ui ?? ALL_DEPLOYABLE
 	}
 	getDeployUiSettings()

--- a/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
@@ -471,7 +471,7 @@
 			deployUiSettings = ALL_DEPLOYABLE
 			return
 		}
-		let settings = await WorkspaceService.getSettings({ workspace: $workspaceStore! })
+		let settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
 		deployUiSettings = settings.deploy_ui ?? ALL_DEPLOYABLE
 	}
 	getDeployUiSettings()

--- a/frontend/src/routes/(root)/(logged)/sqs_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sqs_triggers/+page.svelte
@@ -57,7 +57,7 @@
 			deployUiSettings = ALL_DEPLOYABLE
 			return
 		}
-		let settings = await WorkspaceService.getSettings({ workspace: $workspaceStore! })
+		let settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
 		deployUiSettings = settings.deploy_ui ?? ALL_DEPLOYABLE
 	}
 	getDeployUiSettings()

--- a/frontend/src/routes/(root)/(logged)/variables/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/variables/+page.svelte
@@ -184,7 +184,7 @@
 			deployUiSettings = ALL_DEPLOYABLE
 			return
 		}
-		let settings = await WorkspaceService.getSettings({ workspace: $workspaceStore! })
+		let settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
 		deployUiSettings = settings.deploy_ui ?? ALL_DEPLOYABLE
 	}
 	getDeployUiSettings()

--- a/frontend/src/routes/(root)/(logged)/websocket_triggers/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/websocket_triggers/+page.svelte
@@ -57,7 +57,7 @@
 			deployUiSettings = ALL_DEPLOYABLE
 			return
 		}
-		let settings = await WorkspaceService.getSettings({ workspace: $workspaceStore! })
+		let settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
 		deployUiSettings = settings.deploy_ui ?? ALL_DEPLOYABLE
 	}
 	getDeployUiSettings()


### PR DESCRIPTION
## Summary

Two related leaks where workspace-member-readable endpoints exposed admin-only secrets, fixed by splitting `get_settings` into a typed public/admin pair so future field additions can't silently leak.

### Bugs

**1. `GET /api/w/{w}/get_settings` leaked live GitHub App tokens**

The handler returned the `workspace_settings.git_app_installations` JSONB column verbatim to any authed workspace member. Each entry contains:

```rust
pub struct GitInstallation {
    pub installation_id: i64,
    pub account_id: String,
    pub jwt_token: String,                          // GitHub App JWT (managed flow)
    pub installation_token: Option<String>,         // live x-access-token used to push/pull
    pub installation_token_expiration: Option<i64>,
    pub github_base_url: Option<String>,
}
```

`get_installation_token` (`windmill-common/src/git_sync_ee.rs`) caches the installation token for 55 minutes (GitHub installation tokens last 1h, refreshed 5 min before expiry). Every git-sync action refreshes and writes the token back, so the value sitting in the column is essentially always live. With it, the caller can authenticate as `x-access-token:<token>@github.com` and push/pull the connected repo, scoped to the GitHub App's permissions.

The frontend hits `getSettings` from ~30 call sites — the root layout, every trigger list page, sidebar, etc. — all reachable by non-admins (operators and developers). So every navigation as a non-admin returned the live token.

**2. Tarball export leaked `slack_oauth_client_secret` to non-admins**

`tarball_workspace` is gated on `ApiAuthed` + RLS only — no top-level admin check. The v2 settings format (introduced in #8935 for non-interactive Slack connect) included `slack_oauth_client_secret` with no admin filter, regressing the redaction `get_settings` was applying. The legacy v1 format does not include the field.

### Fix

**Commit 1 — minimum viable redaction**

- `get_settings`: null out `git_app_installations` for non-admins (mirrors existing `slack_oauth_client_secret` redaction)
- Tarball v2 settings: null out `slack_oauth_client_secret` for non-admins

**Commit 2 — structural fix so this can't happen again**

Reactive per-field redaction is fragile: every new field added to `workspace_settings` defaults to leaking until someone notices. This commit splits the API surface by type:

- **`WorkspaceSettings`** + `GET /workspaces/get_settings` — full struct, **admin-only** via `require_admin`. Used by the admin settings page, git-sync admin context, operator settings, Stripe checkout polling.
- **`WorkspacePublicSettings`** + `GET /workspaces/get_public_settings` — typed allowlisted subset (`workspace_id`, `slack_team_id`, `slack_name`, `teams_team_id`, `teams_team_name`, `teams_team_guid`, `mute_critical_alerts`, `deploy_ui`, `large_file_storage`, `datatable`). Used by every non-admin caller.

The type system defines the public surface, so adding a sensitive column to `workspace_settings` no longer defaults to leaking — it stays out of `WorkspacePublicSettings` unless explicitly added there. The per-field redactions in `get_settings` are removed (no longer needed).

The tarball v2 inline redaction from commit 1 is kept — `tarball_workspace` reads `workspace_settings` directly rather than through `get_settings`, so it has its own admin check at the field level.

## Changes

**Backend**

- `backend/windmill-api-workspaces/src/workspaces.rs` — add `WorkspacePublicSettings` struct and `get_public_settings` handler; gate `get_settings` on `require_admin`.
- `backend/windmill-api/src/workspaces_export.rs` — non-admin redaction of `slack_oauth_client_secret` in v2 settings.
- `backend/windmill-api/openapi.yaml` — document `getPublicSettings`; mark `getSettings` admin-only.

**Frontend** (24 files) — migrate all non-admin callers to `getPublicSettings`:

- `+layout.svelte` (mute_critical_alerts), `sidebar/SidebarContent.svelte` (datatable forks)
- All trigger list pages (deploy_ui): email/azure/postgres/websocket/nats/kafka/sqs/mqtt/gcp/routes/schedules
- `variables`, `resources`, `scripts/get`, `flows/get` (deploy_ui)
- `ErrorOrRecoveryHandler.svelte`, `AppReportsDrawerInner.svelte` (slack/teams team identity)
- `DatatableSchemaDiff.svelte` (datatable config), `InputTransformSchemaForm.svelte` (large_file_storage), `home/deploy_ui.ts`

Admin-only callers stay on `getSettings`:

- `workspace_settings/+page.svelte`, `WorkspaceUserSettings.svelte` (auto_invite), `WorkspaceOperatorSettings.svelte`, `git_sync/GitSyncContext.svelte.ts`, `workspace_settings/checkout/+page.svelte`

## Other consumers (not modified, but affected)

These call `get_settings` and read admin-only fields (`git_sync`, etc.). They are correctly admin-only operations and will continue to work for users with admin tokens. Non-admin tokens will start receiving 403 from `getSettings`:

- **CLI** (`cli/src/`): `commands/init/init.ts`, `commands/gitsync-settings/{pull,push}.ts`, `core/settings.ts` — all need `git_sync` and other admin fields. CLI users running `wmill init`, `wmill sync pull/push`, or `wmill gitsync-settings push/pull` should already be using admin tokens for these operations.
- **CLI tests** (`cli/test/`): direct calls to `/workspaces/get_settings` via `apiRequest` — use the default admin test user, no change needed.
- **typescript-client** (`typescript-client/`) and the bundled native runtime client (`backend/windmill-runtime-nativets/src/windmill-client.js`): expose `WorkspaceService.getSettings()` to user scripts. Scripts that call this method as a non-admin executor will start getting 403. **Follow-up needed**: regenerate the typescript-client + native bundle from the updated `openapi.yaml` to expose `getPublicSettings` to script authors. Not done in this PR to keep the blast radius scoped to the API + first-party UI; the SDK regen can ship in the next typescript-client release.

## Test plan

- [ ] As a non-admin workspace member: `GET /api/w/{w}/get_settings` returns 403
- [ ] As a non-admin: `GET /api/w/{w}/get_public_settings` returns only the allowlisted fields (no `git_app_installations`, no `slack_oauth_client_secret`, no `customer_id`, no `git_sync`, etc.)
- [ ] As an admin: both endpoints work; admin endpoint returns the full struct
- [ ] As a non-admin: navigate trigger list pages, scripts/flows detail, variables, resources — no console errors, no 403s
- [ ] As a non-admin: error/recovery handler picker still shows connected Slack/Teams team name
- [ ] As an admin: workspace settings page, git-sync admin section, operator settings still load full data
- [ ] As a non-admin: `GET /api/w/{w}/tarball?include_settings=true&settings_version=v2` — `settings.json` has `slack_oauth_client_secret: null` (redacted at the field level since the tarball is not behind a top-level admin gate)
- [ ] CLI tests pass against the rebuilt backend (`cli/test/*` hits `get_settings` with admin tokens)

## Migration / breaking change note

`getSettings` returning 403 for non-admins is a breaking API change for any external consumer reading public-subset fields with a non-admin token. They should switch to `getPublicSettings` for the safe subset, or use an admin token for the full struct. Token rotation is recommended for any GitHub App installations whose tokens may have been observed in `get_settings` responses prior to this fix.

---
Generated with [Claude Code](https://claude.com/claude-code)