### PR TITLE
fix: use otel.status_message so OTLP Status.message is set on failed job spans

### DIFF
--- a/backend/windmill-worker/src/result_processor.rs
+++ b/backend/windmill-worker/src/result_processor.rs
@@ -112,7 +112,7 @@ async fn process_jc(
             script_hash = field::Empty,
             otel.name = field::Empty,
             otel.status_code = "ERROR",
-            otel.status_description = field::Empty,
+            otel.status_message = field::Empty,
             success = %success,
             error.message = field::Empty,
             error.name = field::Empty,
@@ -167,11 +167,11 @@ async fn process_jc(
             span.record("error.message", result_error.message.as_str());
             span.record("error.name", result_error.name.as_str());
             span.record(
-                "otel.status_description",
+                "otel.status_message",
                 crate::worker::truncate_description(&result_error.message).as_str(),
             );
         } else {
-            span.record("otel.status_description", "Job failed");
+            span.record("otel.status_message", "Job failed");
         }
     }
 

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1342,7 +1342,7 @@ pub fn create_span_with_name(
         script_hash = field::Empty,
         otel.name = field::Empty,
         otel.status_code = field::Empty,
-        otel.status_description = field::Empty,
+        otel.status_message = field::Empty,
     );
 
     let rj = arc_job.flow_innermost_root_job.unwrap_or(arc_job.id);
@@ -1382,12 +1382,12 @@ pub fn create_span_with_name(
     span
 }
 
-/// Max characters of an error message copied into the `otel.status_description`
+/// Max characters of an error message copied into the `otel.status_message`
 /// span attribute. Prevents a single verbose failure from blowing up the span
 /// payload on OTLP exporters.
 const STATUS_DESCRIPTION_MAX_LEN: usize = 512;
 
-/// Record `otel.status_code` / `otel.status_description` on the current span
+/// Record `otel.status_code` / `otel.status_message` on the current span
 /// when a job fails. Called from inside the `.instrument(job_span)` future so
 /// that `Span::current()` resolves to the `"job"` span created by
 /// `create_span_with_name`.
@@ -1402,7 +1402,7 @@ pub(crate) fn record_job_span_status(result: &windmill_common::error::Result<boo
     };
     let span = tracing::Span::current();
     span.record("otel.status_code", "ERROR");
-    span.record("otel.status_description", description.as_str());
+    span.record("otel.status_message", description.as_str());
 }
 
 /// Cap an error description at `STATUS_DESCRIPTION_MAX_LEN` bytes, appending


### PR DESCRIPTION
## Summary
PR #8918 set `otel.status_description` on failed job and `job_postprocessing` spans, intending to populate the OTLP `Status` proto so consumers (Sentry, Honeycomb, Datadog, etc.) can filter on `span.status:internal_error`. In practice, OTLP `Status.code` was being left `UNSET` and `Status.message` was empty — the fix had no effect on filtering.

`tracing-opentelemetry` only recognizes two field names for the OTLP `Status` proto (see `tracing-opentelemetry-0.31.0/src/layer.rs:25-26`):
- `otel.status_code` → `Status.code`
- `otel.status_message` → `Status.message`

`otel.status_description` is not recognized; it falls through to the generic attribute recorder and ends up as a regular span attribute, never as the `Status.message` field.

## Changes
- Rename `otel.status_description` → `otel.status_message` in the failed-job span (`worker.rs`) and the `job_postprocessing` span (`result_processor.rs`)
- Update the related doc comments and the `record_job_span_status` rustdoc

`otel.status_code = "ERROR"` was already correct; together the two fields now produce a complete `Status { code: ERROR, message: <truncated_error> }` on the OTLP span.

## Test plan
- [ ] Run a failing job against an instance with OTLP exporter configured; verify the exported span has `Status.code = ERROR` and `Status.message` populated (not just an attribute named `otel.status_description`)
- [ ] Verify span-based filtering on `span.status:internal_error` matches failed-job spans in Sentry/Honeycomb/Datadog
- [ ] Confirm successful jobs still export `Status.code = UNSET` (no regression)

---
Generated with [Claude Code](https://claude.com/claude-code)