### PR TITLE
fix(cli): only preserve case for raw-app runnableIds, not app/flow summaries

### DIFF
--- a/cli/test/inline_scripts_failure_preprocessor_unit.test.ts
+++ b/cli/test/inline_scripts_failure_preprocessor_unit.test.ts
@@ -524,7 +524,7 @@ describe("extractInlineScripts with mapping preserves file paths", () => {
 
     const contentScript = scripts.find((s) => !s.is_lock);
     // Should use assigner path based on summary, not mapped
-    expect(contentScript!.path).toContain("Get_Users_Data");
+    expect(contentScript!.path).toContain("get_users_data");
   });
 
   test("mapped modules and unmapped modules coexist", () => {
@@ -538,7 +538,7 @@ describe("extractInlineScripts with mapping preserves file paths", () => {
 
     const paths = scripts.filter((s) => !s.is_lock).map((s) => s.path);
     expect(paths[0]).toBe("my_custom_name.ts");
-    expect(paths[1]).toContain("Step_B"); // assigner-generated from summary
+    expect(paths[1]).toContain("step_b"); // assigner-generated from summary
   });
 
   test("lock path is derived from mapped content path", () => {
@@ -560,7 +560,7 @@ describe("extractInlineScripts with mapping preserves file paths", () => {
     const scripts = extractInlineScripts([mod], {}, "/", "bun");
 
     const lockScript = scripts.find((s) => s.is_lock);
-    expect(lockScript!.path).toContain("Get_Users_Data");
+    expect(lockScript!.path).toContain("get_users_data");
     expect(lockScript!.path).toEndWith(".lock");
   });
 

--- a/cli/test/raw_app_sync.test.ts
+++ b/cli/test/raw_app_sync.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { withTestBackend } from "./test_backend.ts";
 import { addWorkspace } from "../workspace.ts";
 import * as path from "node:path";
-import { writeFile, readFile, stat, rm, mkdir } from "node:fs/promises";
+import { writeFile, readFile, stat, rm, mkdir, readdir } from "node:fs/promises";
 
 // =============================================================================
 // RAW APP SYNC TESTS
@@ -556,10 +556,14 @@ excludes: []`, "utf-8");
 
       // YAML and code file must both come back with the original case so
       // loadRunnablesFromBackend pairs them as one runnable, not two.
-      expect(await fileExists(path.join(backendDir, "CamelCaseTSRunnable.yaml"))).toBeTruthy();
-      expect(await fileExists(path.join(backendDir, "CamelCaseTSRunnable.ts"))).toBeTruthy();
-      expect(await fileExists(path.join(backendDir, "camelcasetsrunnable.ts"))).toBeFalsy();
-      expect(await fileExists(path.join(backendDir, "camelcasetsrunnable.yaml"))).toBeFalsy();
+      // Use readdir for exact-case comparison: Windows is case-insensitive at
+      // the filesystem level, so fileExists("camelcasetsrunnable.ts") would
+      // resolve to CamelCaseTSRunnable.ts and false-positive the orphan check.
+      const backendEntries = await readdir(backendDir);
+      expect(backendEntries).toContain("CamelCaseTSRunnable.yaml");
+      expect(backendEntries).toContain("CamelCaseTSRunnable.ts");
+      expect(backendEntries).not.toContain("camelcasetsrunnable.ts");
+      expect(backendEntries).not.toContain("camelcasetsrunnable.yaml");
 
       const pulledContent = await readFileContent(path.join(backendDir, "CamelCaseTSRunnable.ts"));
       expect(pulledContent).toContain("Result:");

--- a/cli/test/raw_app_sync.test.ts
+++ b/cli/test/raw_app_sync.test.ts
@@ -508,3 +508,84 @@ excludes: []`, "utf-8");
       expect(hasRawApp).toBeTruthy();
     });
 });
+
+test("Raw App: CamelCase backend runnableId round-trips without duplicates", async () => {
+    await withTestBackend(async (backend, tempDir) => {
+      const testWorkspace = {
+        remote: backend.baseUrl,
+        workspaceId: backend.workspace,
+        name: "raw_app_camelcase_test",
+        token: backend.token
+      };
+      await addWorkspace(testWorkspace, { force: true, configDir: backend.testConfigDir });
+
+      await writeFile(`${tempDir}/wmill.yaml`, `defaultTs: bun
+includes:
+  - "**"
+excludes: []`, "utf-8");
+
+      const appDir = path.join(tempDir, "f", "test", "camelcase_app.raw_app");
+      const backendDir = path.join(appDir, "backend");
+      await mkdir(path.join(tempDir, "f", "test"), { recursive: true });
+      await createRawAppOnDisk(appDir);
+
+      // Add a backend runnable whose id contains uppercase letters. The YAML
+      // metadata file is named `${runnableId}.yaml` and must stay in sync with
+      // the code file's casing — the bug fixed here desynced them.
+      await mkdir(backendDir, { recursive: true });
+      await writeFile(path.join(backendDir, "CamelCaseTSRunnable.yaml"), "type: inline\n", "utf-8");
+      await writeFile(
+        path.join(backendDir, "CamelCaseTSRunnable.ts"),
+        `export async function main(x: number): Promise<string> {\n  return \`Result: \${x}\`;\n}\n`,
+        "utf-8"
+      );
+
+      const pushResult1 = await backend.runCLICommand(
+        ["sync", "push", "--yes"],
+        tempDir, "raw_app_camelcase_test"
+      );
+      expect(pushResult1.code).toEqual(0);
+
+      await rm(appDir, { recursive: true });
+
+      const pullResult = await backend.runCLICommand(
+        ["sync", "pull", "--yes"],
+        tempDir, "raw_app_camelcase_test"
+      );
+      expect(pullResult.code).toEqual(0);
+
+      // YAML and code file must both come back with the original case so
+      // loadRunnablesFromBackend pairs them as one runnable, not two.
+      expect(await fileExists(path.join(backendDir, "CamelCaseTSRunnable.yaml"))).toBeTruthy();
+      expect(await fileExists(path.join(backendDir, "CamelCaseTSRunnable.ts"))).toBeTruthy();
+      expect(await fileExists(path.join(backendDir, "camelcasetsrunnable.ts"))).toBeFalsy();
+      expect(await fileExists(path.join(backendDir, "camelcasetsrunnable.yaml"))).toBeFalsy();
+
+      const pulledContent = await readFileContent(path.join(backendDir, "CamelCaseTSRunnable.ts"));
+      expect(pulledContent).toContain("Result:");
+
+      // A second push must not surface a duplicate lowercase runnable: the
+      // dry-run change list should only mention the one app, no orphan code
+      // file getting registered as a separate inline runnable.
+      const dryRun = await backend.runCLICommand(
+        ["sync", "push", "--dry-run", "--json-output"],
+        tempDir, "raw_app_camelcase_test"
+      );
+      expect(dryRun.code).toEqual(0);
+
+      let jsonOutput: any = null;
+      try {
+        jsonOutput = JSON.parse(dryRun.stdout.trim());
+      } catch {
+        const jsonMatch = dryRun.stdout.match(/\{[\s\S]*\}/);
+        if (jsonMatch) {
+          try { jsonOutput = JSON.parse(jsonMatch[0]); } catch { /* ignore */ }
+        }
+      }
+      expect(jsonOutput !== null).toBeTruthy();
+      const changes = (jsonOutput.changes ?? []) as Array<{ path: string }>;
+      // No change should reference a lowercased runnable filename.
+      const lowercased = changes.filter((c) => c.path.includes("camelcasetsrunnable"));
+      expect(lowercased).toEqual([]);
+    });
+});

--- a/cli/test/sync_pull_push.test.ts
+++ b/cli/test/sync_pull_push.test.ts
@@ -631,10 +631,10 @@ test("newPathAssigner with skipInlineScriptSuffix removes .inline_script. from p
   expect(noSuffixPyExt).toEqual("py");
 });
 
-test("path assigners preserve mixed-case summaries", () => {
+test("newPathAssigner lowercases summaries; newRawAppPathAssigner preserves case", () => {
   const inlineAssigner = newPathAssigner("bun", { skipInlineScriptSuffix: true });
   const [inlinePath] = inlineAssigner.assignPath("CamelCaseTSRunnable", "bun");
-  expect(inlinePath).toEqual("CamelCaseTSRunnable.");
+  expect(inlinePath).toEqual("camelcasetsrunnable.");
 
   const rawAssigner = newRawAppPathAssigner("bun");
   const [rawPath] = rawAssigner.assignPath("CamelCaseTSRunnable", "bun");

--- a/cli/windmill-utils-internal/src/path-utils/path-assigner.ts
+++ b/cli/windmill-utils-internal/src/path-utils/path-assigner.ts
@@ -118,8 +118,11 @@ export function getLanguageFromExtension(
  */
 const WINDOWS_RESERVED = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])$/;
 
-export function sanitizeForFilesystem(summary: string): string {
-  const name = summary
+export function sanitizeForFilesystem(
+  summary: string,
+  options?: { preserveCase?: boolean },
+): string {
+  let name = summary
     .replaceAll(" ", "_")
     // Remove characters invalid on Windows/Unix/Mac: / \ : * ? " < > |
     // Also remove control characters (0x00-0x1F) and DEL (0x7F)
@@ -129,6 +132,9 @@ export function sanitizeForFilesystem(summary: string): string {
     .replace(/_+/g, "_")
     // Trim leading/trailing dots and underscores (hidden files, Windows edge cases)
     .replace(/^[._]+|[._]+$/g, "");
+  if (!options?.preserveCase) {
+    name = name.toLowerCase();
+  }
   // Prefix Windows reserved device names (CON, PRN, AUX, NUL, COM0-9, LPT0-9)
   return WINDOWS_RESERVED.test(name.toLowerCase()) ? `_${name}` : name;
 }
@@ -211,7 +217,7 @@ export function newRawAppPathAssigner(defaultTs: "bun" | "deno"): PathAssigner {
   ): [string, string] {
     let name;
 
-    name = summary ? sanitizeForFilesystem(summary) : "";
+    name = summary ? sanitizeForFilesystem(summary, { preserveCase: true }) : "";
 
     let original_name = name;
 


### PR DESCRIPTION
## Summary

- Limit the case preservation introduced in #8940 to raw-app runnableIds. Normal-app and flow inline scripts derive their on-disk path from the script's human summary (e.g. \"Get Users Data\"), which used to lowercase to \`get_users_data.inline_script.ts\` and now landed as \`Get_Users_Data.inline_script.ts\`. That changed both the on-disk filename and the \`!inline …\` reference inside \`app.yaml\` / \`flow.yaml\`, surfacing as unwanted case churn after users updated to 1.693.x.
- The original #8939 bug was raw-app-specific: the YAML metadata file is named after the runnableId (case preserved) so the code file must also preserve case. That asymmetry doesn't exist for normal apps / flows, so lowercasing is safe and matches pre-#8940 behavior.
- Implementation: add a \`preserveCase\` option to \`sanitizeForFilesystem\`. \`newRawAppPathAssigner\` opts in; \`newPathAssigner\` stays on the default (lowercase).
- Tests: revert three \`Get_Users_Data\` / \`Step_B\` assertions back to lowercase in \`inline_scripts_failure_preprocessor_unit.test.ts\`. Update the \`sync_pull_push.test.ts\` path-assigner test to pin both halves of the contract (newPathAssigner lowercases, newRawAppPathAssigner preserves). Add a new e2e test in \`raw_app_sync.test.ts\` that pushes a \`CamelCaseTSRunnable\` backend runnable, pulls it back, and asserts both YAML and code file preserve case with no lowercase orphan — the missing reproduction for #8939.

## Test plan
- [x] \`bun test test/sync_pull_push.test.ts\` — 67 pass / 3 skip
- [x] \`bun test test/inline_scripts_failure_preprocessor_unit.test.ts\` — 24 pass
- [x] \`bun test test/raw_app_sync.test.ts\` — 5 pass (4 existing + 1 new CamelCase round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore lowercasing for app/flow inline script paths while preserving case only for raw-app backend runnableIds. This stops filename churn in `app.yaml`/`flow.yaml` and keeps raw-app YAML/code files in sync to avoid duplicates.

- **Bug Fixes**
  - Added `preserveCase` option to `sanitizeForFilesystem` (default: lowercase).
  - `newRawAppPathAssigner` opts in to `preserveCase`; `newPathAssigner` continues to lowercase.
  - Tests: reverted inline-script path assertions to lowercase, pinned assigner behavior, added CamelCase raw-app round-trip e2e, and switched to `readdir` for exact-case orphan checks on Windows.

<sup>Written for commit 5374a7810f7a1abdee9139cd5b8d8015ad4fe3d6. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9000?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

