### PR TITLE
fix: read inline-script tag from app policy in run mode

### DIFF
--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -2092,6 +2092,11 @@ async fn execute_component(
     let path = path.to_path();
     let (arc_policy, policy): (Arc<Policy>, Policy);
     let policy_triggerables_default = Default::default();
+    // Preview mode means the request was issued from the editor; the editing
+    // user is already trusted by the policy check, so client-supplied `tag`
+    // on the inline script is honored. In any other case we must read the
+    // tag from the deployed policy and ignore the request body.
+    let is_preview = payload.force_viewer_static_fields.is_some();
 
     // Two cases here:
     // 1. The component is executed from the editor (i.e. in "preview" mode), then:
@@ -2267,23 +2272,31 @@ async fn execute_component(
         .map(|p| p.starts_with("flow/"))
         .unwrap_or(false);
 
+    // Tag for inline-script jobs is read from the deployed policy in run mode;
+    // only preview mode (editor) honors the client-supplied tag. This applies to
+    // both the `id`-bearing app_script path and the legacy `rawscript/<sha>`
+    // path that has no app_script entry yet.
+    let resolved_inline_tag = |client_tag: Option<String>| -> Option<String> {
+        if is_preview {
+            client_tag
+        } else {
+            policy_triggerables.tag.clone()
+        }
+        .filter(|t| !t.is_empty())
+    };
     let (job_payload, tag, on_behalf_of) = match (payload.path, payload.raw_code, payload.id) {
         // flow or script:
         (Some(path), None, None) => get_payload_tag_from_prefixed_path(&path, &db, &w_id).await?,
-        // inline script: in "preview" mode (no entry in `app_script`). Tag is
-        // taken from the client request — preview mode is editor-only and the
-        // editing user is already trusted by the policy check.
+        // inline script: "preview" mode, or run mode without an entry in the
+        // `app_script` table (legacy `rawscript/<sha>`-keyed triggerables).
         (None, Some(raw_code), None) => {
-            let tag = raw_code.tag.clone().filter(|t| !t.is_empty());
+            let tag = resolved_inline_tag(raw_code.tag.clone());
             (JobPayload::Code(raw_code), tag, None)
         }
-        // inline script: in "run" mode (deployed app) with an entry in `app_script`.
-        // Never trust the client-supplied tag here — read it from the policy that
-        // was committed at deploy time, so end users running the app cannot redirect
-        // the job to an arbitrary worker group.
-        (None, Some(RawCode { language, path, cache_ttl, .. }), Some(id)) => (
+        // inline script: run mode (deployed app) with an entry in `app_script`.
+        (None, Some(RawCode { language, path, cache_ttl, tag, .. }), Some(id)) => (
             JobPayload::AppScript { id: AppScriptId(id), cache_ttl, language, path },
-            policy_triggerables.tag.clone().filter(|t| !t.is_empty()),
+            resolved_inline_tag(tag),
             None,
         ),
         _ => unreachable!(),

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -255,6 +255,8 @@ pub struct PolicyTriggerableInputs {
     delete_after_secs: Option<i32>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     sensitive_inputs: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tag: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -2119,6 +2121,7 @@ async fn execute_component(
                 allow_user_resources: force_viewer_allow_user_resources.unwrap_or_default(),
                 delete_after_secs: force_viewer_delete_after_secs,
                 sensitive_inputs: force_viewer_sensitive_inputs.unwrap_or_default(),
+                tag: None,
             },
         ),
         // 2. "run" mode.
@@ -2267,15 +2270,20 @@ async fn execute_component(
     let (job_payload, tag, on_behalf_of) = match (payload.path, payload.raw_code, payload.id) {
         // flow or script:
         (Some(path), None, None) => get_payload_tag_from_prefixed_path(&path, &db, &w_id).await?,
-        // inline script: in "preview" mode or without entry in the `app_script` table.
+        // inline script: in "preview" mode (no entry in `app_script`). Tag is
+        // taken from the client request — preview mode is editor-only and the
+        // editing user is already trusted by the policy check.
         (None, Some(raw_code), None) => {
             let tag = raw_code.tag.clone().filter(|t| !t.is_empty());
             (JobPayload::Code(raw_code), tag, None)
         }
-        // inline script: in "run" mode and with an entry in the `app_script` table.
-        (None, Some(RawCode { language, path, cache_ttl, tag, .. }), Some(id)) => (
+        // inline script: in "run" mode (deployed app) with an entry in `app_script`.
+        // Never trust the client-supplied tag here — read it from the policy that
+        // was committed at deploy time, so end users running the app cannot redirect
+        // the job to an arbitrary worker group.
+        (None, Some(RawCode { language, path, cache_ttl, .. }), Some(id)) => (
             JobPayload::AppScript { id: AppScriptId(id), cache_ttl, language, path },
-            tag.filter(|t| !t.is_empty()),
+            policy_triggerables.tag.clone().filter(|t| !t.is_empty()),
             None,
         ),
         _ => unreachable!(),

--- a/frontend/src/lib/components/apps/editor/appPolicy.ts
+++ b/frontend/src/lib/components/apps/editor/appPolicy.ts
@@ -210,7 +210,8 @@ export async function processRunnable(
 			{
 				static_inputs: staticInputs,
 				one_of_inputs: oneOfInputs,
-				allow_user_resources: allowUserResources
+				allow_user_resources: allowUserResources,
+				...(runnable.inlineScript?.tag ? { tag: runnable.inlineScript.tag } : {})
 			}
 		]
 	} else if (isRunnableByPath(runnable)) {

--- a/frontend/src/lib/components/apps/editor/commonAppUtils.ts
+++ b/frontend/src/lib/components/apps/editor/commonAppUtils.ts
@@ -16,6 +16,7 @@ export type TriggerableV2 = {
 	allow_user_resources?: string[]
 	delete_after_secs?: number
 	sensitive_inputs?: string[]
+	tag?: string
 }
 
 export async function hash(message) {

--- a/frontend/src/lib/components/raw_apps/rawAppPolicy.ts
+++ b/frontend/src/lib/components/raw_apps/rawAppPolicy.ts
@@ -34,14 +34,15 @@ export type Runnable = RunnableWithInlineScript | undefined
 function extraFields(
 	runnable: RunnableWithInlineScript,
 	fields: Record<string, any>
-): Partial<Pick<TriggerableV2, 'delete_after_secs' | 'sensitive_inputs'>> {
-	const out: Partial<Pick<TriggerableV2, 'delete_after_secs' | 'sensitive_inputs'>> = {}
+): Partial<Pick<TriggerableV2, 'delete_after_secs' | 'sensitive_inputs' | 'tag'>> {
+	const out: Partial<Pick<TriggerableV2, 'delete_after_secs' | 'sensitive_inputs' | 'tag'>> = {}
 	if (typeof runnable.delete_after_secs === 'number' && runnable.delete_after_secs >= 0)
 		out.delete_after_secs = runnable.delete_after_secs
 	const sensitive_inputs = Object.entries(fields)
 		.map(([k, v]) => (v['sensitive'] ? k : undefined))
 		.filter(Boolean) as string[]
 	if (sensitive_inputs.length > 0) out.sensitive_inputs = sensitive_inputs
+	if (runnable.inlineScript?.tag) out.tag = runnable.inlineScript.tag
 	return out
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #9002. The worker tag for app inline scripts was taken from the client-supplied `raw_code` body on every execute, including in run mode. An end user running a deployed app could intercept the request and submit any tag they liked, redirecting the job to an arbitrary worker group (for example one nominally reserved for paid tiers, or a privileged tag in a tag-isolated workspace).

This PR makes the server read the tag from the deployed app's policy in run mode and ignore whatever the client sends. Preview mode (editor-only, with `force_viewer_static_fields` set) still honors the client-supplied tag — the editing user is already trusted by the policy check, the same way `force_viewer_delete_after_secs` works.

## Changes

- **Backend** (`windmill-api/src/apps.rs`)
  - Added `tag: Option<String>` to `PolicyTriggerableInputs` (the per-runnable policy entry, alongside `delete_after_secs`/`sensitive_inputs`).
  - In `execute_component`'s run-mode arm, the queue tag now comes from `policy_triggerables.tag`, not `raw_code.tag`.
  - Preview-mode arm unchanged; the synthetic `PolicyTriggerableInputs` for preview gets `tag: None`.
- **Frontend** (`commonAppUtils.ts`, `appPolicy.ts`, `rawAppPolicy.ts`)
  - `TriggerableV2` gains an optional `tag` field.
  - `processRunnable` (apps) and `extraFields` (raw apps) now persist `inlineScript.tag` into the policy on save, so deployed apps carry the tag the editor user picked.

## Test plan

End-to-end verified locally against a deployed app with a Python inline script:

| Scenario | Policy `tag` | `raw_code.tag` (client) | Resulting queue `tag` |
|---|---|---|---|
| Run mode + forged client tag | `secret-tag` | `evil-tag` | `secret-tag` ✅ |
| Run mode + no policy tag | _unset_ | `evil-tag` | `python3` (lang default) ✅ |
| Preview mode | n/a | `mytag` | `mytag` ✅ |

- [ ] Re-run the same scenarios via the UI: open a deployed app as a viewer, verify in DevTools that injecting a tag into the `execute_component` request body produces a job whose `v2_job.tag` matches the saved policy tag, not the injected one.
- [ ] Edit and run an inline script from the editor and verify the chosen tag still flows through (preview mode).
- [ ] Save an app with a custom tag, reload, run — verify the job dispatches with that tag.

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce the worker tag for inline scripts from the deployed app policy in run mode and ignore client-provided tags. This prevents redirecting jobs to unauthorized worker groups; preview mode still honors the client tag.

- **Bug Fixes**
  - Backend: Added `tag: Option<String>` to `PolicyTriggerableInputs`. In run mode, resolve the queue tag from the policy for both `AppScript` and legacy `rawscript/<sha>` inline paths; preview mode uses the client tag via a synthetic policy with `tag: None`.
  - Frontend: Added `tag?: string` to `TriggerableV2`. Persist `inlineScript.tag` into the policy for apps and raw apps.

<sup>Written for commit 1e6439921a1001223882003e02dd758385dccec8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

