### PR TITLE
fix: omit empty assets array on scripts and raw app inline scripts

### DIFF
--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -523,7 +523,8 @@
 				const old = assets?.find((a) => assetEq(a, asset))
 				if (old?.alt_access_type) asset.alt_access_type = old.alt_access_type
 			}
-			if (!deepEqual(assets, newAssets)) assets = newAssets
+			const normalizedAssets = newAssets.length > 0 ? newAssets : undefined
+			if (!deepEqual(assets, normalizedAssets)) assets = normalizedAssets
 		}
 	)
 

--- a/frontend/src/lib/components/raw_apps/RawAppInlineScriptEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppInlineScriptEditor.svelte
@@ -148,7 +148,10 @@
 		() => $workspaceStore
 	)
 	$effect(() => {
-		if (inlineScript && inferAssetsRes.current) inlineScript.assets = inferAssetsRes.current?.assets
+		if (inlineScript && inferAssetsRes.current) {
+			const newAssets = inferAssetsRes.current?.assets
+			inlineScript.assets = newAssets && newAssets.length > 0 ? newAssets : undefined
+		}
 	})
 
 	// Debug mode state

--- a/frontend/src/lib/components/raw_apps/RawAppInlineScriptEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppInlineScriptEditor.svelte
@@ -148,10 +148,10 @@
 		() => $workspaceStore
 	)
 	$effect(() => {
-		if (inlineScript && inferAssetsRes.current) {
-			const newAssets = inferAssetsRes.current?.assets
-			inlineScript.assets = newAssets && newAssets.length > 0 ? newAssets : undefined
-		}
+		if (!inlineScript || !inferAssetsRes.current || inferAssetsRes.current.status === 'error')
+			return
+		const newAssets = inferAssetsRes.current.assets
+		inlineScript.assets = newAssets.length > 0 ? newAssets : undefined
 	})
 
 	// Debug mode state


### PR DESCRIPTION
## Summary

Stop writing `assets: []` on scripts and raw-app inline scripts. The asset parser returns `assets: []` when nothing is detected, and the editors were assigning that empty array directly onto the script/inline-script value, polluting saved data with a meaningless field. Flows already normalize this to `undefined` (`FlowAssetsHandler.svelte`, `flows/utils.svelte.ts`), so this change brings scripts and raw apps in line.

## Changes

- `ScriptEditor.svelte`: normalize empty array to `undefined` before assigning to bound `assets`.
- `RawAppInlineScriptEditor.svelte`: same normalization on `inlineScript.assets`.
- All consumer sites (`AssetsDropdownButton`, graph asset nodes, flow diff, flow module component, etc.) already gate on `assets?.length` or `?? []`, so undefined is treated identically to an empty array everywhere.

The defensive `if (current.assets && !current.assets.length) delete current.assets` in `ScriptBuilder.svelte` and the equivalent in `flowDiff.ts` are kept to handle legacy data from before this fix.

## Test plan

- [ ] Open a raw app inline script with no detected assets — confirm saved app value has no `assets` field on that script.
- [ ] Open a regular script with no detected assets — confirm `script.assets` stays `undefined`.
- [ ] Add an asset (e.g. `s3://...` reference) — confirm `assets` array is populated and the dropdown button shows.
- [ ] Remove the asset — confirm the field is dropped (not left as `[]`).
- [ ] Diff a script in the diff drawer with no asset changes — no phantom diff on the `assets` field.

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize asset parsing in `ScriptEditor.svelte` and `RawAppInlineScriptEditor.svelte`: convert empty arrays to undefined and skip updates on parser errors, so we never save `assets: []` or overwrite values. This keeps saved data clean and prevents phantom diffs; consumers already treat undefined like an empty list.

<sup>Written for commit 292651f183f8d83c70e8057d7c8a9dcfd1ddd492. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

