### PR TITLE
fix: bind MySQL table listing to configured database name

### DIFF
--- a/backend/windmill-common/src/query_builders.rs
+++ b/backend/windmill-common/src/query_builders.rs
@@ -2434,14 +2434,32 @@ WHERE table_schema = current_schema()",
             let table_filter = if let Some(t) = table {
                 let parts: Vec<&str> = t.split('.').collect();
                 let tname = parts[parts.len() - 1];
-                let schema = if parts.len() > 1 { parts[0] } else { db_name };
+                let schema = if parts.len() > 1 {
+                    parts[0]
+                } else if !db_name.is_empty() {
+                    db_name
+                } else {
+                    "DATABASE()"
+                };
+                let schema_sql = if schema == "DATABASE()" {
+                    schema.to_string()
+                } else {
+                    format!("'{}'", escape_sql_literal(schema))
+                };
                 format!(
-                    "\nWHERE\n    TABLE_NAME = '{}' AND TABLE_SCHEMA = '{}'",
+                    "\nWHERE\n    TABLE_NAME = '{}' AND TABLE_SCHEMA = {}",
                     escape_sql_literal(tname),
-                    escape_sql_literal(schema)
+                    schema_sql
                 )
             } else {
-                "\nWHERE\n    TABLE_SCHEMA NOT IN ('mysql', 'performance_schema', 'information_schema', 'sys', '_vt')".to_string()
+                let schema_predicate = database_name
+                    .filter(|s| !s.is_empty())
+                    .map(|dn| format!("TABLE_SCHEMA = '{}'", escape_sql_literal(dn)))
+                    .unwrap_or_else(|| "TABLE_SCHEMA = DATABASE()".to_string());
+                format!(
+                    "\nWHERE\n    {}\n    AND TABLE_SCHEMA NOT IN ('mysql', 'performance_schema', 'information_schema', 'sys', '_vt')",
+                    schema_predicate
+                )
             };
             let extra_col = if table.is_none() {
                 ",\n    TABLE_NAME as table_name"
@@ -4250,10 +4268,21 @@ mod tests {
     }
 
     #[test]
-    fn test_expand_load_table_metadata_mysql_all_tables() {
+    fn test_expand_load_table_metadata_mysql_all_tables_uses_session_db() {
         let marker = r#"-- WM_INTERNAL_DB_LOAD_TABLE_METADATA {}"#;
         let sql = expand_code(marker, &ScriptLang::Mysql);
         assert!(sql.contains("TABLE_NAME as table_name"));
+        assert!(sql.contains("TABLE_SCHEMA = DATABASE()"));
+        assert!(sql.contains("TABLE_SCHEMA NOT IN"));
+    }
+
+    #[test]
+    fn test_expand_load_table_metadata_mysql_all_tables_with_database_name() {
+        let marker =
+            r#"-- WM_INTERNAL_DB_LOAD_TABLE_METADATA {"databaseName":"mydb"}"#;
+        let sql = expand_code(marker, &ScriptLang::Mysql);
+        assert!(sql.contains("TABLE_NAME as table_name"));
+        assert!(sql.contains("TABLE_SCHEMA = 'mydb'"));
         assert!(sql.contains("TABLE_SCHEMA NOT IN"));
     }
 

--- a/backend/windmill-common/src/query_builders.rs
+++ b/backend/windmill-common/src/query_builders.rs
@@ -2434,17 +2434,12 @@ WHERE table_schema = current_schema()",
             let table_filter = if let Some(t) = table {
                 let parts: Vec<&str> = t.split('.').collect();
                 let tname = parts[parts.len() - 1];
-                let schema = if parts.len() > 1 {
-                    parts[0]
+                let schema_sql = if parts.len() > 1 {
+                    format!("'{}'", escape_sql_literal(parts[0]))
                 } else if !db_name.is_empty() {
-                    db_name
+                    format!("'{}'", escape_sql_literal(db_name))
                 } else {
-                    "DATABASE()"
-                };
-                let schema_sql = if schema == "DATABASE()" {
-                    schema.to_string()
-                } else {
-                    format!("'{}'", escape_sql_literal(schema))
+                    "DATABASE()".to_string()
                 };
                 format!(
                     "\nWHERE\n    TABLE_NAME = '{}' AND TABLE_SCHEMA = {}",
@@ -4268,6 +4263,14 @@ mod tests {
     }
 
     #[test]
+    fn test_expand_load_table_metadata_mysql_single_table_uses_session_db() {
+        let marker = r#"-- WM_INTERNAL_DB_LOAD_TABLE_METADATA {"table":"users"}"#;
+        let sql = expand_code(marker, &ScriptLang::Mysql);
+        assert!(sql.contains("TABLE_NAME = 'users'"));
+        assert!(sql.contains("TABLE_SCHEMA = DATABASE()"));
+    }
+
+    #[test]
     fn test_expand_load_table_metadata_mysql_all_tables_uses_session_db() {
         let marker = r#"-- WM_INTERNAL_DB_LOAD_TABLE_METADATA {}"#;
         let sql = expand_code(marker, &ScriptLang::Mysql);
@@ -4278,8 +4281,7 @@ mod tests {
 
     #[test]
     fn test_expand_load_table_metadata_mysql_all_tables_with_database_name() {
-        let marker =
-            r#"-- WM_INTERNAL_DB_LOAD_TABLE_METADATA {"databaseName":"mydb"}"#;
+        let marker = r#"-- WM_INTERNAL_DB_LOAD_TABLE_METADATA {"databaseName":"mydb"}"#;
         let sql = expand_code(marker, &ScriptLang::Mysql);
         assert!(sql.contains("TABLE_NAME as table_name"));
         assert!(sql.contains("TABLE_SCHEMA = 'mydb'"));

--- a/backend/windmill-common/src/query_builders.rs
+++ b/backend/windmill-common/src/query_builders.rs
@@ -2430,16 +2430,16 @@ WHERE table_schema = current_schema()",
             Ok(q)
         }
         DbType::Mysql => {
-            let db_name = database_name.unwrap_or("");
+            let explicit_db = database_name.filter(|s| !s.is_empty());
             let table_filter = if let Some(t) = table {
                 let parts: Vec<&str> = t.split('.').collect();
                 let tname = parts[parts.len() - 1];
                 let schema_sql = if parts.len() > 1 {
                     format!("'{}'", escape_sql_literal(parts[0]))
-                } else if !db_name.is_empty() {
-                    format!("'{}'", escape_sql_literal(db_name))
                 } else {
-                    "DATABASE()".to_string()
+                    explicit_db
+                        .map(|dn| format!("'{}'", escape_sql_literal(dn)))
+                        .unwrap_or_else(|| "DATABASE()".to_string())
                 };
                 format!(
                     "\nWHERE\n    TABLE_NAME = '{}' AND TABLE_SCHEMA = {}",
@@ -2447,8 +2447,7 @@ WHERE table_schema = current_schema()",
                     schema_sql
                 )
             } else {
-                let schema_predicate = database_name
-                    .filter(|s| !s.is_empty())
+                let schema_predicate = explicit_db
                     .map(|dn| format!("TABLE_SCHEMA = '{}'", escape_sql_literal(dn)))
                     .unwrap_or_else(|| "TABLE_SCHEMA = DATABASE()".to_string());
                 format!(


### PR DESCRIPTION
## Problem
MySQL resource table listing in the Manage view ignores the database name configured in the resource, showing tables from the wrong database or all databases.

## Change
Bind the metadata query to the configured database name from the resource, falling back to `DATABASE()` when no explicit name is given.

Fixes #8938.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MySQL table listing to honor the resource’s `databaseName`; falls back to the session DB when unset. Unifies schema selection for all-table and single-table queries.

- **Bug Fixes**
  - Bind `TABLE_SCHEMA` to `databaseName`; otherwise use `DATABASE()` in both query paths.
  - Exclude system schemas; add tests for session fallback and explicit `databaseName`.

<sup>Written for commit 0daadb84184dbeb7a240ac5d758b96af68a87183. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

