### PR TITLE
fix(forks): strip mode/enabled from merge-UI deploy payload

### DIFF
--- a/frontend/src/lib/utils_deployable.ts
+++ b/frontend/src/lib/utils_deployable.ts
@@ -94,6 +94,23 @@ export async function existsTrigger(
 }
 
 /**
+ * Strip operational state (`mode`, `enabled`) from a trigger/schedule payload
+ * before sending it to an update endpoint via the merge UI. The backend's
+ * `update_trigger` handler preserves the target row's existing `mode` when
+ * both fields are absent from the request (`is_mode_unspecified()`), so
+ * stripping here lets a fork→parent (or parent→fork) deploy carry config
+ * changes without flipping the target's enabled/disabled state. Schedules'
+ * `EditSchedule` already lacks `enabled` on the backend, but stripping keeps
+ * the intent explicit and matches the YAML/CLI round-trip behavior.
+ */
+function stripOperationalState<T extends Record<string, any>>(
+	payload: T
+): Omit<T, 'mode' | 'enabled'> {
+	const { mode: _mode, enabled: _enabled, ...rest } = payload
+	return rest
+}
+
+/**
  * Get trigger deployment data with optional permissioned_as preservation.
  * @param onBehalfOf - If set, the trigger will be deployed with this permissioned_as (u/username or g/group) and preserve_permissioned_as=true.
  */
@@ -113,7 +130,7 @@ export async function getTriggersDeployData(
 
 		return {
 			data: {
-				...sqsTrigger,
+				...stripOperationalState(sqsTrigger),
 				permissioned_as: onBehalfOf,
 				preserve_permissioned_as: preservePermissionedAs
 			},
@@ -128,7 +145,7 @@ export async function getTriggersDeployData(
 
 		return {
 			data: {
-				...kafkaTrigger,
+				...stripOperationalState(kafkaTrigger),
 				permissioned_as: onBehalfOf,
 				preserve_permissioned_as: preservePermissionedAs
 			},
@@ -143,7 +160,7 @@ export async function getTriggersDeployData(
 
 		return {
 			data: {
-				...mqttTrigger,
+				...stripOperationalState(mqttTrigger),
 				permissioned_as: onBehalfOf,
 				preserve_permissioned_as: preservePermissionedAs
 			},
@@ -158,7 +175,7 @@ export async function getTriggersDeployData(
 
 		return {
 			data: {
-				...natsTrigger,
+				...stripOperationalState(natsTrigger),
 				permissioned_as: onBehalfOf,
 				preserve_permissioned_as: preservePermissionedAs
 			},
@@ -179,7 +196,7 @@ export async function getTriggersDeployData(
 		}
 
 		const data: GcpTriggerData = {
-			...gcpTrigger,
+			...stripOperationalState(gcpTrigger),
 			delivery_config: gcpTrigger.delivery_config ?? undefined,
 			base_endpoint:
 				gcpTrigger.delivery_type === 'push' ? `${window.location.origin}${base}` : undefined,
@@ -200,7 +217,7 @@ export async function getTriggersDeployData(
 
 		return {
 			data: {
-				...postgresTrigger,
+				...stripOperationalState(postgresTrigger),
 				permissioned_as: onBehalfOf,
 				preserve_permissioned_as: preservePermissionedAs
 			},
@@ -215,7 +232,7 @@ export async function getTriggersDeployData(
 
 		return {
 			data: {
-				...websocketTrigger,
+				...stripOperationalState(websocketTrigger),
 				permissioned_as: onBehalfOf,
 				preserve_permissioned_as: preservePermissionedAs
 			},
@@ -230,7 +247,7 @@ export async function getTriggersDeployData(
 
 		return {
 			data: {
-				...httpTrigger,
+				...stripOperationalState(httpTrigger),
 				permissioned_as: onBehalfOf,
 				preserve_permissioned_as: preservePermissionedAs
 			},
@@ -244,7 +261,7 @@ export async function getTriggersDeployData(
 		})
 		return {
 			data: {
-				...schedulesTrigger,
+				...stripOperationalState(schedulesTrigger),
 				// permissioned_as is only set on create, not update
 				permissioned_as: onBehalfOf,
 				preserve_permissioned_as: preservePermissionedAs

--- a/frontend/src/lib/utils_deployable.ts
+++ b/frontend/src/lib/utils_deployable.ts
@@ -1,5 +1,7 @@
 import { minimatch } from 'minimatch'
 import {
+	AzureTriggerService,
+	EmailTriggerService,
 	GcpTriggerService,
 	HttpTriggerService,
 	KafkaTriggerService,
@@ -84,12 +86,16 @@ export async function existsTrigger(
 		return await WebsocketTriggerService.existsWebsocketTrigger(data)
 	} else if (triggerKind === 'nats') {
 		return await NatsTriggerService.existsNatsTrigger(data)
+	} else if (triggerKind === 'azure') {
+		return await AzureTriggerService.existsAzureTrigger(data)
+	} else if (triggerKind === 'emails') {
+		return await EmailTriggerService.existsEmailTrigger(data)
 	} else if (triggerKind === 'schedules') {
 		return await ScheduleService.existsSchedule(data)
 	}
 
 	throw new Error(
-		`Unexpected trigger kind ${triggerKind}. Allowed kinds are: routes, kafka, mqtt, postgres, sqs, gcp, websockets, nats, schedules.`
+		`Unexpected trigger kind ${triggerKind}. Allowed kinds are: routes, kafka, mqtt, postgres, sqs, gcp, websockets, nats, azure, emails, schedules.`
 	)
 }
 
@@ -253,6 +259,36 @@ export async function getTriggersDeployData(
 			},
 			createFn: HttpTriggerService.createHttpTrigger,
 			updateFn: HttpTriggerService.updateHttpTrigger
+		}
+	} else if (kind === 'azure') {
+		const azureTrigger = await AzureTriggerService.getAzureTrigger({
+			workspace: workspace!,
+			path: path
+		})
+
+		return {
+			data: {
+				...stripOperationalState(azureTrigger),
+				permissioned_as: onBehalfOf,
+				preserve_permissioned_as: preservePermissionedAs
+			},
+			createFn: AzureTriggerService.createAzureTrigger,
+			updateFn: AzureTriggerService.updateAzureTrigger
+		}
+	} else if (kind === 'emails') {
+		const emailTrigger = await EmailTriggerService.getEmailTrigger({
+			workspace: workspace!,
+			path: path
+		})
+
+		return {
+			data: {
+				...stripOperationalState(emailTrigger),
+				permissioned_as: onBehalfOf,
+				preserve_permissioned_as: preservePermissionedAs
+			},
+			createFn: EmailTriggerService.createEmailTrigger,
+			updateFn: EmailTriggerService.updateEmailTrigger
 		}
 	} else if (kind === 'schedules') {
 		const schedulesTrigger = await ScheduleService.getSchedule({

--- a/frontend/src/lib/utils_workspace_deploy.ts
+++ b/frontend/src/lib/utils_workspace_deploy.ts
@@ -174,7 +174,9 @@ export async function checkItemExists(
 			'schedules',
 			'sqs',
 			'websockets',
-			'gcp'
+			'gcp',
+			'azure',
+			'emails'
 		]
 		if (
 			additionalInformation?.triggers &&


### PR DESCRIPTION
## Summary

Two follow-up fixes to #8976 for the merge-UI deploy path.

### 1. Strip `mode`/`enabled` from the deploy payload

The merge UI deploys a trigger by fetching the full GET response from the source workspace and spreading it into the target's `updateXTrigger` call (`getTriggersDeployData` → `deployItem`). That spread carries `mode` (and the legacy `enabled`), so a fork→parent (or parent→fork) deploy would overwrite the target's enabled/disabled state — silently disabling a parent's trigger when its config is merged from a freshly-cloned fork (clones are forced `mode='disabled'`).

Affects the four kinds whose `update_trigger` SQL writes the `mode` column: **azure, email, gcp, http**. The other six (kafka, mqtt, nats, postgres, sqs, websocket) don't touch `mode` in their UPDATE so their behavior is unchanged.

**Fix**: strip `mode`/`enabled` in `getTriggersDeployData` before the spread. The backend's existing `is_mode_unspecified()` preservation in `update_trigger` (added in #8976) then queries the target row's existing `mode` and keeps it untouched. Same mechanism that already protects the YAML/CLI round-trip — extended to the merge-UI path.

For create (deploying a new trigger to the target), `BaseTriggerData::mode()` defaults to `Enabled` when both fields are absent — sensible default for an explicit user-driven deploy.

### 2. Wire Azure and Email triggers through the deploy

`CompareWorkspaces.svelte` already lists Azure and Email triggers in its diff (`triggerServices`), but `getTriggersDeployData` and `existsTrigger` were missing the corresponding branches. Deploying either kind from the merge UI threw `Unexpected trigger kind`.

**Fix**: add the branches with the same `stripOperationalState` pattern as the rest, and extend the `triggersKind` whitelist in `checkItemExists`.

## Test plan

- [ ] In a fork with a trigger config change, deploy to parent via the merge UI; verify parent's `mode` is unchanged
- [ ] In a fork, pull a parent's trigger config change; verify fork's `mode` (cloned as `disabled`) stays disabled
- [ ] Deploy an Azure trigger via merge UI — no longer throws "Unexpected trigger kind"
- [ ] Deploy an Email trigger via merge UI — no longer throws "Unexpected trigger kind"
- [ ] Regular trigger create/edit (non-merge flow) still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)