### PR TITLE
feat: add ai chat resource action buttons

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
+++ b/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
@@ -10,6 +10,7 @@
 	import { onDestroy } from 'svelte'
 	import Button from '$lib/components/common/button/Button.svelte'
 	import { Menu } from 'lucide-svelte'
+	import CreatedResourceActionDrawers from './CreatedResourceActionDrawers.svelte'
 
 	interface Props {
 		noPadding?: boolean
@@ -48,6 +49,7 @@
 </script>
 
 {#if !disableAi}
+	<CreatedResourceActionDrawers />
 	<Splitpanes horizontal={false} class="flex-1 min-h-0">
 		<Pane size={100 - chatState.size} minSize={50} class="flex flex-col grow min-h-0 ">
 			<div

--- a/frontend/src/lib/components/copilot/chat/CreatedResourceActionDrawers.svelte
+++ b/frontend/src/lib/components/copilot/chat/CreatedResourceActionDrawers.svelte
@@ -1,0 +1,185 @@
+<script lang="ts">
+	import { onDestroy, tick } from 'svelte'
+	import type { Component } from 'svelte'
+	import { Drawer } from '$lib/components/common'
+	import DrawerContent from '$lib/components/common/drawer/DrawerContent.svelte'
+	import { Loader2 } from 'lucide-svelte'
+	import { registerToolDisplayActionHandler } from './createdResourceActions.svelte'
+	import type { CreatedResourceTriggerKind, ToolDisplayAction } from './shared'
+
+	type DrawerKey = 'schedule' | CreatedResourceTriggerKind
+	type EditorHandle = {
+		openEdit: (path: string, isFlow: boolean) => Promise<void>
+	}
+	type EditorComponent = Component<
+		{
+			useDrawer?: boolean
+			onUpdate?: (path?: string) => void
+		},
+		EditorHandle
+	>
+	type EditorModule = { default: unknown }
+	type DrawerConfig = {
+		label: string
+		load: () => Promise<EditorModule>
+	}
+
+	const DRAWER_SIZE = '800px'
+
+	let drawer: Drawer | undefined = $state(undefined)
+	let editor: EditorHandle | undefined = $state(undefined)
+	let activeDrawer: DrawerKey | undefined = $state(undefined)
+	let activePath = $state('')
+	let editorPromise: Promise<EditorModule> | undefined = $state(undefined)
+
+	const drawerConfigs: Record<DrawerKey, DrawerConfig> = {
+		schedule: {
+			label: 'schedule',
+			load: () => import('$lib/components/triggers/schedules/ScheduleEditorInner.svelte')
+		},
+		http: {
+			label: 'HTTP trigger',
+			load: () => import('$lib/components/triggers/http/RouteEditorInner.svelte')
+		},
+		websocket: {
+			label: 'WebSocket trigger',
+			load: () => import('$lib/components/triggers/websocket/WebsocketTriggerEditorInner.svelte')
+		},
+		postgres: {
+			label: 'Postgres trigger',
+			load: () => import('$lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte')
+		},
+		kafka: {
+			label: 'Kafka trigger',
+			load: () => import('$lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte')
+		},
+		nats: {
+			label: 'NATS trigger',
+			load: () => import('$lib/components/triggers/nats/NatsTriggerEditorInner.svelte')
+		},
+		mqtt: {
+			label: 'MQTT trigger',
+			load: () => import('$lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte')
+		},
+		sqs: {
+			label: 'SQS trigger',
+			load: () => import('$lib/components/triggers/sqs/SqsTriggerEditorInner.svelte')
+		},
+		gcp: {
+			label: 'GCP Pub/Sub trigger',
+			load: () => import('$lib/components/triggers/gcp/GcpTriggerEditorInner.svelte')
+		},
+		azure: {
+			label: 'Azure Event Grid trigger',
+			load: () => import('$lib/components/triggers/azure/AzureTriggerEditorInner.svelte')
+		}
+	}
+
+	const activeConfig = $derived.by(() => {
+		const current = activeDrawer
+		return current ? drawerConfigs[current] : undefined
+	})
+	const drawerTitle = $derived(
+		activeConfig ? `Edit ${activeConfig.label} ${activePath}` : 'Edit trigger'
+	)
+
+	function waitForAnimationFrame(): Promise<void> {
+		return new Promise((resolve) => {
+			if (typeof requestAnimationFrame === 'function') {
+				requestAnimationFrame(() => resolve())
+			} else {
+				resolve()
+			}
+		})
+	}
+
+	async function getEditor(
+		expectedDrawer: DrawerKey,
+		expectedPromise: Promise<EditorModule>,
+		expectedPath: string
+	): Promise<EditorHandle | undefined> {
+		await expectedPromise
+		await tick()
+		await waitForAnimationFrame()
+
+		if (
+			activeDrawer !== expectedDrawer ||
+			editorPromise !== expectedPromise ||
+			activePath !== expectedPath
+		) {
+			return undefined
+		}
+
+		if (!editor) {
+			await tick()
+			await waitForAnimationFrame()
+		}
+
+		if (!editor) {
+			throw new Error(`${activeConfig?.label ?? 'Trigger'} drawer is not ready`)
+		}
+		return editor
+	}
+
+	async function openCreatedResource(action: ToolDisplayAction) {
+		if (action.type !== 'open_created_resource') {
+			return
+		}
+
+		const key = action.resource === 'schedule' ? 'schedule' : action.triggerKind
+		if (!key) {
+			throw new Error('Missing trigger kind')
+		}
+
+		const config = drawerConfigs[key]
+		const nextEditorPromise = activeDrawer === key && editorPromise ? editorPromise : config.load()
+		if (activeDrawer !== key) {
+			editor = undefined
+		}
+		activeDrawer = key
+		activePath = action.path
+		editorPromise = nextEditorPromise
+		drawer?.openDrawer()
+
+		const currentEditor = await getEditor(key, nextEditorPromise, action.path)
+		if (
+			!currentEditor ||
+			activeDrawer !== key ||
+			editorPromise !== nextEditorPromise ||
+			activePath !== action.path
+		) {
+			return
+		}
+		await currentEditor.openEdit(action.path, action.targetKind === 'flow')
+	}
+
+	function onInnerUpdate() {
+		drawer?.closeDrawer()
+	}
+
+	const unregisterCreatedResourceHandler = registerToolDisplayActionHandler(
+		'open_created_resource',
+		openCreatedResource
+	)
+
+	onDestroy(() => {
+		unregisterCreatedResourceHandler()
+	})
+</script>
+
+<Drawer bind:this={drawer} size={DRAWER_SIZE}>
+	<DrawerContent title={drawerTitle} on:close={() => drawer?.closeDrawer()}>
+		{#if activeDrawer && editorPromise}
+			{#key activeDrawer}
+				{#await editorPromise}
+					<div class="p-4 flex justify-center">
+						<Loader2 class="animate-spin" />
+					</div>
+				{:then Module}
+					{@const Editor = Module.default as EditorComponent}
+					<Editor bind:this={editor} useDrawer={false} onUpdate={onInnerUpdate} />
+				{/await}
+			{/key}
+		{/if}
+	</DrawerContent>
+</Drawer>

--- a/frontend/src/lib/components/copilot/chat/CreatedResourceActionDrawers.svelte
+++ b/frontend/src/lib/components/copilot/chat/CreatedResourceActionDrawers.svelte
@@ -23,14 +23,19 @@
 		label: string
 		load: () => Promise<EditorModule>
 	}
+	type ActiveDrawerState = {
+		id: number
+		key: DrawerKey
+		path: string
+		promise: Promise<EditorModule>
+	}
 
 	const DRAWER_SIZE = '800px'
 
 	let drawer: Drawer | undefined = $state(undefined)
 	let editor: EditorHandle | undefined = $state(undefined)
-	let activeDrawer: DrawerKey | undefined = $state(undefined)
-	let activePath = $state('')
-	let editorPromise: Promise<EditorModule> | undefined = $state(undefined)
+	let activeDrawer: ActiveDrawerState | undefined = $state(undefined)
+	let nextActiveDrawerId = 0
 
 	const drawerConfigs: Record<DrawerKey, DrawerConfig> = {
 		schedule: {
@@ -75,13 +80,10 @@
 		}
 	}
 
-	const activeConfig = $derived.by(() => {
+	const drawerTitle = $derived.by(() => {
 		const current = activeDrawer
-		return current ? drawerConfigs[current] : undefined
+		return current ? `Edit ${drawerConfigs[current.key].label} ${current.path}` : 'Edit trigger'
 	})
-	const drawerTitle = $derived(
-		activeConfig ? `Edit ${activeConfig.label} ${activePath}` : 'Edit trigger'
-	)
 
 	function waitForAnimationFrame(): Promise<void> {
 		return new Promise((resolve) => {
@@ -93,20 +95,12 @@
 		})
 	}
 
-	async function getEditor(
-		expectedDrawer: DrawerKey,
-		expectedPromise: Promise<EditorModule>,
-		expectedPath: string
-	): Promise<EditorHandle | undefined> {
-		await expectedPromise
+	async function getEditor(request: ActiveDrawerState): Promise<EditorHandle | undefined> {
+		await request.promise
 		await tick()
 		await waitForAnimationFrame()
 
-		if (
-			activeDrawer !== expectedDrawer ||
-			editorPromise !== expectedPromise ||
-			activePath !== expectedPath
-		) {
+		if (activeDrawer?.id !== request.id) {
 			return undefined
 		}
 
@@ -116,7 +110,7 @@
 		}
 
 		if (!editor) {
-			throw new Error(`${activeConfig?.label ?? 'Trigger'} drawer is not ready`)
+			throw new Error(`${drawerConfigs[request.key].label} drawer is not ready`)
 		}
 		return editor
 	}
@@ -132,22 +126,17 @@
 		}
 
 		const config = drawerConfigs[key]
-		const nextEditorPromise = activeDrawer === key && editorPromise ? editorPromise : config.load()
-		if (activeDrawer !== key) {
+		const promise = activeDrawer?.key === key ? activeDrawer.promise : config.load()
+		if (activeDrawer?.key !== key) {
 			editor = undefined
 		}
-		activeDrawer = key
-		activePath = action.path
-		editorPromise = nextEditorPromise
+
+		const request: ActiveDrawerState = { id: nextActiveDrawerId++, key, path: action.path, promise }
+		activeDrawer = request
 		drawer?.openDrawer()
 
-		const currentEditor = await getEditor(key, nextEditorPromise, action.path)
-		if (
-			!currentEditor ||
-			activeDrawer !== key ||
-			editorPromise !== nextEditorPromise ||
-			activePath !== action.path
-		) {
+		const currentEditor = await getEditor(request)
+		if (!currentEditor) {
 			return
 		}
 		await currentEditor.openEdit(action.path, action.targetKind === 'flow')
@@ -169,9 +158,9 @@
 
 <Drawer bind:this={drawer} size={DRAWER_SIZE}>
 	<DrawerContent title={drawerTitle} on:close={() => drawer?.closeDrawer()}>
-		{#if activeDrawer && editorPromise}
-			{#key activeDrawer}
-				{#await editorPromise}
+		{#if activeDrawer}
+			{#key activeDrawer.key}
+				{#await activeDrawer.promise}
 					<div class="p-4 flex justify-center">
 						<Loader2 class="animate-spin" />
 					</div>

--- a/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
@@ -5,6 +5,7 @@
 	import type { ToolDisplayMessage } from './shared'
 	import { twMerge } from 'tailwind-merge'
 	import ToolContentDisplay from './ToolContentDisplay.svelte'
+	import ToolMessageActions from './ToolMessageActions.svelte'
 
 	interface Props {
 		message: ToolDisplayMessage
@@ -20,6 +21,12 @@
 		message.showDetails ||
 			(message.isStreamingArguments && hasParameters) ||
 			(message.isLoading && message.needsConfirmation)
+	)
+
+	const visibleActions = $derived(
+		message.actions && !message.isLoading && !message.error && !message.needsConfirmation
+			? message.actions
+			: []
 	)
 </script>
 
@@ -121,6 +128,10 @@
 					error={message.error}
 					loading={message.isLoading}
 				/>
+
+				{#if visibleActions.length > 0}
+					<ToolMessageActions actions={visibleActions} />
+				{/if}
 			{/if}
 		</div>
 	{/if}

--- a/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
@@ -122,15 +122,15 @@
 					showWhileLoading={false}
 				/>
 
-				<ToolContentDisplay
-					title="Result"
-					content={message.result}
-					error={message.error}
-					loading={message.isLoading}
-				/>
-
 				{#if visibleActions.length > 0}
 					<ToolMessageActions actions={visibleActions} />
+				{:else}
+					<ToolContentDisplay
+						title="Result"
+						content={message.result}
+						error={message.error}
+						loading={message.isLoading}
+					/>
 				{/if}
 			{/if}
 		</div>

--- a/frontend/src/lib/components/copilot/chat/ToolMessageActions.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolMessageActions.svelte
@@ -1,15 +1,47 @@
 <script lang="ts">
 	import { Button } from '$lib/components/common'
-	import { ExternalLink } from 'lucide-svelte'
+	import { Calendar, Database, Route, SquarePen, Unplug, Webhook } from 'lucide-svelte'
+	import AwsIcon from '$lib/components/icons/AwsIcon.svelte'
+	import AzureIcon from '$lib/components/icons/AzureIcon.svelte'
+	import GoogleCloudIcon from '$lib/components/icons/GoogleCloudIcon.svelte'
+	import KafkaIcon from '$lib/components/icons/KafkaIcon.svelte'
+	import MqttIcon from '$lib/components/icons/MqttIcon.svelte'
+	import NatsIcon from '$lib/components/icons/NatsIcon.svelte'
 	import { runToolDisplayAction } from './createdResourceActions.svelte'
-	import type { ToolDisplayAction } from './shared'
+	import type { CreatedResourceTriggerKind, ToolDisplayAction } from './shared'
 
 	interface Props {
 		actions: ToolDisplayAction[]
 	}
 
+	type ActionCardKey = 'schedule' | CreatedResourceTriggerKind
+	type ActionCardConfig = {
+		title: string
+		icon: any
+	}
+
 	let { actions }: Props = $props()
 	let runningActionId: string | undefined = $state(undefined)
+
+	const actionCardConfigs: Record<ActionCardKey, ActionCardConfig> = {
+		schedule: { title: 'Schedule', icon: Calendar },
+		http: { title: 'HTTP trigger', icon: Route },
+		websocket: { title: 'WebSocket trigger', icon: Unplug },
+		postgres: { title: 'Postgres trigger', icon: Database },
+		kafka: { title: 'Kafka trigger', icon: KafkaIcon },
+		nats: { title: 'NATS trigger', icon: NatsIcon },
+		mqtt: { title: 'MQTT trigger', icon: MqttIcon },
+		sqs: { title: 'SQS trigger', icon: AwsIcon },
+		gcp: { title: 'GCP Pub/Sub trigger', icon: GoogleCloudIcon },
+		azure: { title: 'Azure Event Grid trigger', icon: AzureIcon }
+	}
+
+	function getActionCardConfig(action: ToolDisplayAction): ActionCardConfig {
+		const key = action.resource === 'schedule' ? 'schedule' : action.triggerKind
+		return key
+			? actionCardConfigs[key]
+			: { title: action.label.replace(/^Open\s+/i, ''), icon: Webhook }
+	}
 
 	async function handleAction(action: ToolDisplayAction) {
 		if (runningActionId) {
@@ -25,19 +57,32 @@
 </script>
 
 {#if actions.length > 0}
-	<div class="pt-1 flex flex-row flex-wrap justify-center gap-1">
+	<div class="space-y-2">
 		{#each actions as action (action.id)}
-			<Button
-				size="xs"
-				variant="accent"
-				title={action.label}
-				loading={runningActionId === action.id}
-				disabled={runningActionId !== undefined && runningActionId !== action.id}
-				startIcon={{ icon: ExternalLink }}
-				onClick={() => handleAction(action)}
-			>
-				{action.label}
-			</Button>
+			{@const card = getActionCardConfig(action)}
+			{@const Icon = card.icon}
+			<div class="flex items-center gap-3 rounded-md border !border-green-500/40 bg-surface p-3">
+				<div
+					class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-blue-50 text-blue-600 dark:bg-blue-500/10 dark:text-blue-300"
+				>
+					<Icon class="h-5 w-5" />
+				</div>
+				<div class="min-w-0 flex-1">
+					<div class="truncate text-xs font-semibold text-primary">{card.title}</div>
+					<div class="truncate text-2xs text-secondary">{action.path}</div>
+				</div>
+				<Button
+					size="xs"
+					variant="default"
+					title={action.label}
+					loading={runningActionId === action.id}
+					disabled={runningActionId !== undefined && runningActionId !== action.id}
+					startIcon={{ icon: SquarePen }}
+					onClick={() => handleAction(action)}
+				>
+					Open
+				</Button>
+			</div>
 		{/each}
 	</div>
 {/if}

--- a/frontend/src/lib/components/copilot/chat/ToolMessageActions.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolMessageActions.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { Button } from '$lib/components/common'
+	import { ExternalLink } from 'lucide-svelte'
+	import { runToolDisplayAction } from './createdResourceActions.svelte'
+	import type { ToolDisplayAction } from './shared'
+
+	interface Props {
+		actions: ToolDisplayAction[]
+	}
+
+	let { actions }: Props = $props()
+	let runningActionId: string | undefined = $state(undefined)
+
+	async function handleAction(action: ToolDisplayAction) {
+		if (runningActionId) {
+			return
+		}
+		runningActionId = action.id
+		try {
+			await runToolDisplayAction(action)
+		} finally {
+			runningActionId = undefined
+		}
+	}
+</script>
+
+{#if actions.length > 0}
+	<div class="pt-1 flex flex-row flex-wrap justify-center gap-1">
+		{#each actions as action (action.id)}
+			<Button
+				size="xs"
+				variant="accent"
+				title={action.label}
+				loading={runningActionId === action.id}
+				disabled={runningActionId !== undefined && runningActionId !== action.id}
+				startIcon={{ icon: ExternalLink }}
+				onClick={() => handleAction(action)}
+			>
+				{action.label}
+			</Button>
+		{/each}
+	</div>
+{/if}

--- a/frontend/src/lib/components/copilot/chat/createdResourceActions.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/createdResourceActions.svelte.ts
@@ -1,0 +1,40 @@
+import { sendUserToast } from '$lib/toast'
+import type { ToolDisplayAction } from './shared'
+
+type MaybePromise<T> = T | Promise<T>
+type ToolDisplayActionHandler = (action: ToolDisplayAction) => MaybePromise<void>
+
+const toolDisplayActionHandlers = $state<Record<string, ToolDisplayActionHandler | undefined>>({})
+
+function formatUnknownError(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message
+	}
+	return String(error)
+}
+
+export function registerToolDisplayActionHandler(
+	type: ToolDisplayAction['type'],
+	handler: ToolDisplayActionHandler
+): () => void {
+	toolDisplayActionHandlers[type] = handler
+	return () => {
+		if (toolDisplayActionHandlers[type] === handler) {
+			delete toolDisplayActionHandlers[type]
+		}
+	}
+}
+
+export async function runToolDisplayAction(action: ToolDisplayAction): Promise<void> {
+	const handler = toolDisplayActionHandlers[action.type]
+	if (!handler) {
+		sendUserToast('This action is not available right now.', true)
+		return
+	}
+
+	try {
+		await handler(action)
+	} catch (error) {
+		sendUserToast(`Could not run action "${action.label}": ${formatUnknownError(error)}`, true)
+	}
+}

--- a/frontend/src/lib/components/copilot/chat/shared.test.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.test.ts
@@ -277,7 +277,17 @@ describe('processToolCall', () => {
 					target_path: 'f/scripts/current',
 					target_kind: 'script',
 					backend_result: 'schedule-created'
-				})
+				}),
+				actions: [
+					expect.objectContaining({
+						id: 'open-created-schedule:f/schedules/current',
+						type: 'open_created_resource',
+						label: 'Open schedule',
+						resource: 'schedule',
+						path: 'f/schedules/current',
+						targetKind: 'script'
+					})
+				]
 			})
 		)
 		expect(JSON.parse(scheduleResult.content as string)).toEqual(
@@ -342,7 +352,18 @@ describe('processToolCall', () => {
 					target_path: 'f/flows/current',
 					target_kind: 'flow',
 					backend_result: 'trigger-created'
-				})
+				}),
+				actions: [
+					expect.objectContaining({
+						id: 'open-created-trigger:http:f/triggers/current',
+						type: 'open_created_resource',
+						label: 'Open HTTP trigger',
+						resource: 'trigger',
+						triggerKind: 'http',
+						path: 'f/triggers/current',
+						targetKind: 'flow'
+					})
+				]
 			})
 		)
 		expect(JSON.parse(triggerResult.content as string)).toEqual(

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -409,6 +409,29 @@ export type UserDisplayMessage = BaseDisplayMessage & {
 	error?: boolean
 }
 
+export type CreatedResourceTriggerKind =
+	| 'http'
+	| 'websocket'
+	| 'kafka'
+	| 'nats'
+	| 'postgres'
+	| 'mqtt'
+	| 'sqs'
+	| 'gcp'
+	| 'azure'
+
+export type CreatedResourceAction = {
+	id: string
+	type: 'open_created_resource'
+	label: string
+	resource: 'schedule' | 'trigger'
+	path: string
+	targetKind: 'script' | 'flow'
+	triggerKind?: CreatedResourceTriggerKind
+}
+
+export type ToolDisplayAction = CreatedResourceAction
+
 export type ToolDisplayMessage = {
 	role: 'tool'
 	tool_call_id: string
@@ -423,6 +446,7 @@ export type ToolDisplayMessage = {
 	isStreamingArguments?: boolean
 	toolName?: string
 	showFade?: boolean
+	actions?: ToolDisplayAction[]
 }
 
 export type AssistantDisplayMessage = BaseDisplayMessage & {

--- a/frontend/src/lib/components/copilot/chat/workspaceTools.ts
+++ b/frontend/src/lib/components/copilot/chat/workspaceTools.ts
@@ -26,7 +26,13 @@ import {
 	triggerRequestSchemas
 } from './workspaceToolsZod.gen'
 import { z } from 'zod'
-import { createToolDef, type Tool, type ToolCallbacks } from './shared'
+import {
+	createToolDef,
+	type CreatedResourceTriggerKind,
+	type Tool,
+	type ToolCallbacks,
+	type ToolDisplayAction
+} from './shared'
 import { emptyString } from '$lib/utils'
 
 type TriggerKind = keyof typeof triggerRequestSchemas
@@ -60,7 +66,9 @@ function getWorkspaceMutationTarget(helpers: unknown): WorkspaceMutationTarget |
 	return (helpers as WorkspaceMutationHelpers | undefined)?.getWorkspaceMutationTarget?.()
 }
 
-function getWorkspaceMutationTargetError(target: WorkspaceMutationTarget | undefined): string | undefined {
+function getWorkspaceMutationTargetError(
+	target: WorkspaceMutationTarget | undefined
+): string | undefined {
 	if (!target) {
 		return 'the script or flow needs to be deployed before doing this action'
 	}
@@ -74,7 +82,9 @@ function validateWorkspaceMutationTarget(helpers: unknown): string | undefined {
 	return getWorkspaceMutationTargetError(getWorkspaceMutationTarget(helpers))
 }
 
-function requireWorkspaceMutationTarget(helpers: unknown): WorkspaceMutationTarget & { path: string } {
+function requireWorkspaceMutationTarget(
+	helpers: unknown
+): WorkspaceMutationTarget & { path: string } {
 	const target = getWorkspaceMutationTarget(helpers)
 	const error = getWorkspaceMutationTargetError(target)
 	if (error) {
@@ -83,7 +93,9 @@ function requireWorkspaceMutationTarget(helpers: unknown): WorkspaceMutationTarg
 	return target as WorkspaceMutationTarget & { path: string }
 }
 
-function getWorkspaceMutationTargetFields(helpers: unknown): Pick<NewSchedule, 'script_path' | 'is_flow'> {
+function getWorkspaceMutationTargetFields(
+	helpers: unknown
+): Pick<NewSchedule, 'script_path' | 'is_flow'> {
 	const target = requireWorkspaceMutationTarget(helpers)
 	return {
 		script_path: target.path,
@@ -165,6 +177,38 @@ const triggerConfigs = {
 		label: string
 		requestSchema: z.ZodType<TriggerRequestByKind[K]>
 		create: (data: { workspace: string; requestBody: TriggerRequestByKind[K] }) => Promise<string>
+	}
+}
+
+function getActionTargetKind(isFlow: boolean): 'script' | 'flow' {
+	return isFlow ? 'flow' : 'script'
+}
+
+function createOpenScheduleAction(path: string, targetKind: 'script' | 'flow'): ToolDisplayAction {
+	return {
+		id: `open-created-schedule:${path}`,
+		type: 'open_created_resource',
+		label: 'Open schedule',
+		resource: 'schedule',
+		path,
+		targetKind
+	}
+}
+
+function createOpenTriggerAction(
+	kind: TriggerKind,
+	path: string,
+	targetKind: 'script' | 'flow',
+	label: string
+): ToolDisplayAction {
+	return {
+		id: `open-created-trigger:${kind}:${path}`,
+		type: 'open_created_resource',
+		label: `Open ${label}`,
+		resource: 'trigger',
+		triggerKind: kind as CreatedResourceTriggerKind,
+		path,
+		targetKind
 	}
 }
 
@@ -265,16 +309,18 @@ const createScheduleTool: Tool<any> = {
 			})
 			try {
 				const result = await ScheduleService.createSchedule({ workspace, requestBody })
+				const targetKind = getActionTargetKind(requestBody.is_flow)
 				const toolResult = {
 					success: true,
 					path: requestBody.path,
 					target_path: requestBody.script_path,
-					target_kind: requestBody.is_flow ? 'flow' : 'script',
+					target_kind: targetKind,
 					backend_result: result
 				}
 				toolCallbacks.setToolStatus(toolId, {
 					content: `Created schedule "${requestBody.path}"`,
-					result: toolResult
+					result: toolResult,
+					actions: [createOpenScheduleAction(requestBody.path, targetKind)]
 				})
 				return JSON.stringify(toolResult)
 			} catch (error) {
@@ -311,17 +357,26 @@ const createTriggerTool: Tool<any> = {
 			})
 			try {
 				const result = await triggerConfig.create({ workspace, requestBody } as never)
+				const targetKind = getActionTargetKind(requestBody.is_flow)
 				const toolResult = {
 					success: true,
 					kind: parsedArgs.kind,
 					path: requestBody.path,
 					target_path: requestBody.script_path,
-					target_kind: requestBody.is_flow ? 'flow' : 'script',
+					target_kind: targetKind,
 					backend_result: result
 				}
 				toolCallbacks.setToolStatus(toolId, {
 					content: `Created ${triggerConfig.label} "${requestBody.path}"`,
-					result: toolResult
+					result: toolResult,
+					actions: [
+						createOpenTriggerAction(
+							parsedArgs.kind,
+							requestBody.path,
+							targetKind,
+							triggerConfig.label
+						)
+					]
 				})
 				return JSON.stringify(toolResult)
 			} catch (error) {


### PR DESCRIPTION
## Summary
Add follow-up action buttons to AI chat tool results when a tool creates a schedule or trigger. The buttons open the existing schedule/trigger edit drawers for the created resource, while keeping drawer code lazy-loaded until the user clicks an action.


https://github.com/user-attachments/assets/efc608fd-d522-4859-bb91-ae21a6282a53



## Changes
- Add serialized tool action metadata for created schedules/triggers so actions persist with chat history.
- Attach `Open schedule` / `Open <trigger>` actions to successful `create_schedule` and `create_trigger` tool results.
- Render primary centered action buttons below the tool result.
- Add a central action registry and lazy drawer host that dynamically imports the relevant existing drawer, waits a frame for first-open animations, then opens it in edit mode.
- Cover schedule/HTTP trigger action metadata in existing chat tool unit tests.

## Test plan
- [x] `cd frontend && npm run test:unit -- src/lib/components/copilot/chat/shared.test.ts`
- [x] `cd frontend && npm run check:fast`
- [x] `cd frontend && npm run check`
- [ ] Manually create a schedule from AI chat and verify the primary centered button opens the schedule drawer.
- [ ] Manually create a trigger from AI chat and verify the primary centered button opens the matching trigger drawer with first-open slide animation.

---
Generated with [Claude Code](https://claude.com/claude-code)