### PR TITLE
feat: add separate filter searchbar for resource types tab

### DIFF
--- a/frontend/src/lib/components/resources/resourceTypesFilter.ts
+++ b/frontend/src/lib/components/resources/resourceTypesFilter.ts
@@ -1,0 +1,23 @@
+import { Boxes, FileText } from 'lucide-svelte'
+import type { FilterSchemaRec } from '../FilterSearchbar.svelte'
+
+export function buildResourceTypesFilterSchema() {
+	return {
+		_default_: {
+			type: 'string' as const,
+			hidden: true
+		},
+		name: {
+			type: 'string' as const,
+			label: 'Name',
+			icon: Boxes,
+			description: 'Search in resource type name'
+		},
+		description: {
+			type: 'string' as const,
+			label: 'Description',
+			icon: FileText,
+			description: 'Search in resource type description'
+		}
+	} satisfies FilterSchemaRec
+}

--- a/frontend/src/routes/(root)/(logged)/resources/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/resources/+page.svelte
@@ -16,9 +16,11 @@
 	import { resourceTypesStore } from '$lib/components/resourceTypesStore'
 	import SchemaViewer from '$lib/components/SchemaViewer.svelte'
 	import FilterSearchbar, {
-		useUrlSyncedFilterInstance
+		useUrlSyncedFilterInstance,
+		type FilterInstanceRec
 	} from '$lib/components/FilterSearchbar.svelte'
 	import { buildResourcesFilterSchema } from '$lib/components/resources/resourcesFilter'
+	import { buildResourceTypesFilterSchema } from '$lib/components/resources/resourceTypesFilter'
 	import SharedBadge from '$lib/components/SharedBadge.svelte'
 	import ShareModal from '$lib/components/ShareModal.svelte'
 	import SimpleEditor from '$lib/components/SimpleEditor.svelte'
@@ -156,6 +158,25 @@
 			.sort()
 			.map((f) => f.replace(/^f\//, ''))
 	)
+	let resourceTypesFilterSchema = buildResourceTypesFilterSchema()
+	let resourceTypesFilters: {
+		val: Partial<FilterInstanceRec<typeof resourceTypesFilterSchema>>
+	} = $state({ val: {} })
+	let filteredResourceTypes = $derived.by(() => {
+		if (!resourceTypes) return resourceTypes
+		const f = resourceTypesFilters.val
+		const defaultSearch = f._default_?.toLowerCase()
+		const nameSearch = f.name?.toLowerCase()
+		const descSearch = f.description?.toLowerCase()
+		if (!defaultSearch && !nameSearch && !descSearch) return resourceTypes
+		return resourceTypes.filter((rt) => {
+			if (defaultSearch && !rt.name.toLowerCase().includes(defaultSearch)) return false
+			if (nameSearch && !rt.name.toLowerCase().includes(nameSearch)) return false
+			if (descSearch && !(rt.description ?? '').toLowerCase().includes(descSearch)) return false
+			return true
+		})
+	})
+
 	let folderPresets = $derived([
 		...itemFolders.map((f) => ({ name: `f/${f}`, value: `path_start:\\ f/${f}/` })),
 		...allLabels.map((l) => ({ name: l, value: `label:\\ ${l}` })),
@@ -922,13 +943,22 @@
 						classes: loading.resources || loading.types ? 'animate-spin' : ''
 					}}
 				/>
-				<FilterSearchbar
-					schema={resourcesFilterSchema}
-					class="max-w-[26rem] grow"
-					bind:value={filters.val}
-					placeholder="Filter resources..."
-					presets={folderPresets}
-				/>
+				{#if tab == 'types'}
+					<FilterSearchbar
+						schema={resourceTypesFilterSchema}
+						class="max-w-[26rem] grow"
+						bind:value={resourceTypesFilters.val}
+						placeholder="Filter resource types..."
+					/>
+				{:else}
+					<FilterSearchbar
+						schema={resourcesFilterSchema}
+						class="max-w-[26rem] grow"
+						bind:value={filters.val}
+						placeholder="Filter resources..."
+						presets={folderPresets}
+					/>
+				{/if}
 			</div>
 		</div>
 		{#if showTable}
@@ -1199,6 +1229,13 @@
 				{#each new Array(6) as _}
 					<Skeleton layout={[[4], 0.7]} />
 				{/each}
+			{:else if filteredResourceTypes?.length == 0}
+				<div class="flex flex-col items-center justify-center h-full mt-4">
+					<div class="text-xs text-emphasis font-semibold">No resource types found</div>
+					<div class="text-2xs text-secondary font-normal">
+						Try changing the filters or creating a new resource type
+					</div>
+				</div>
 			{:else}
 				<div class="overflow-auto mt-4">
 					<DataTable>
@@ -1210,8 +1247,8 @@
 							</Row>
 						</Head>
 						<tbody class="divide-y bg-surface">
-							{#if resourceTypes}
-								{#each resourceTypes as { name, description, schema, canWrite, format_extension, is_fileset }}
+							{#if filteredResourceTypes}
+								{#each filteredResourceTypes as { name, description, schema, canWrite, format_extension, is_fileset }}
 									<Row>
 										<Cell first>
 											<a


### PR DESCRIPTION
## Summary
The resources page uses a single `FilterSearchbar` across all tabs, but its schema (paths, owners, labels, OAuth/value filters, etc.) doesn't make sense on the **Resource Types** tab. This PR adds a dedicated searchbar for that tab with a minimal, type-appropriate schema.
