### PR TITLE
docs(skills): document S3Object inputs and S3 streaming in script skills

### DIFF
--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -180,6 +180,37 @@ Name the parameters by adding comments before the statement:
 -- @name2 (int64) = 0
 SELECT * FROM users WHERE name = @name1 AND age > @name2;
 \`\`\`
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type \`(s3object)\`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as a \`STRING\` JSON parameter — Parquet/CSV
+files are decoded server-side into a JSON array of records, JSON/JSONL pass
+through. Consume with \`JSON_EXTRACT_ARRAY\` / \`JSON_VALUE\`:
+
+\`\`\`sql
+-- @file (s3object)
+SELECT
+  CAST(JSON_VALUE(row, '$.id') AS INT64) AS id,
+  JSON_VALUE(row, '$.name') AS name
+FROM UNNEST(JSON_EXTRACT_ARRAY(@file)) AS row;
+\`\`\`
+
+## Streaming query results to S3
+
+Add a \`-- s3\` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its \`S3Object\`
+as the script result.
+
+\`\`\`sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+\`\`\`
+
+All keys are optional: \`prefix\` (object key prefix), \`storage\` (named storage —
+omit to use the workspace default), \`format\` (\`json\` (default), \`parquet\`, or
+\`csv\`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered, bypassing the 10000-row return cap.
 `,
   "write-script-bun": `---
 name: write-script-bun
@@ -303,19 +334,20 @@ export async function preprocessor(event: Event) {
 
 ## S3 Object Operations
 
-Windmill provides built-in support for S3-compatible storage operations.
+Windmill provides built-in support for S3-compatible storage operations. The \`wmill.S3Object\` type covers both the \`s3://storage/key\` URI form (\`s3:///key\` for the workspace default storage) and the \`{ s3, storage? }\` record form — always use it instead of redefining your own.
 
-### S3Object Type
-
-The S3Object type represents a file in S3 storage:
+### Receiving an S3Object as a script parameter
 
 \`\`\`typescript
-type S3Object = {
-  s3: string; // Path within the bucket
-};
+import * as wmill from "windmill-client";
+
+export async function main(file: wmill.S3Object) {
+  const content = await wmill.loadS3File(file);
+  // ...
+}
 \`\`\`
 
-## TypeScript Operations
+### S3 operations
 
 \`\`\`typescript
 import * as wmill from "windmill-client";
@@ -327,7 +359,7 @@ const content: Uint8Array = await wmill.loadS3File(s3object);
 const blob: Blob = await wmill.loadS3FileStream(s3object);
 
 // Write file to S3
-const result: S3Object = await wmill.writeS3File(
+const result: wmill.S3Object = await wmill.writeS3File(
   s3object, // Target path (or undefined to auto-generate)
   fileContent, // string or Blob
   s3ResourcePath // Optional: specific S3 resource to use
@@ -993,19 +1025,20 @@ export async function preprocessor(event: Event) {
 
 ## S3 Object Operations
 
-Windmill provides built-in support for S3-compatible storage operations.
+Windmill provides built-in support for S3-compatible storage operations. The \`wmill.S3Object\` type covers both the \`s3://storage/key\` URI form (\`s3:///key\` for the workspace default storage) and the \`{ s3, storage? }\` record form — always use it instead of redefining your own.
 
-### S3Object Type
-
-The S3Object type represents a file in S3 storage:
+### Receiving an S3Object as a script parameter
 
 \`\`\`typescript
-type S3Object = {
-  s3: string; // Path within the bucket
-};
+import * as wmill from "windmill-client";
+
+export async function main(file: wmill.S3Object) {
+  const content = await wmill.loadS3File(file);
+  // ...
+}
 \`\`\`
 
-## TypeScript Operations
+### S3 operations
 
 \`\`\`typescript
 import * as wmill from "windmill-client";
@@ -1017,7 +1050,7 @@ const content: Uint8Array = await wmill.loadS3File(s3object);
 const blob: Blob = await wmill.loadS3FileStream(s3object);
 
 // Write file to S3
-const result: S3Object = await wmill.writeS3File(
+const result: wmill.S3Object = await wmill.writeS3File(
   s3object, // Target path (or undefined to auto-generate)
   fileContent, // string or Blob
   s3ResourcePath // Optional: specific S3 resource to use
@@ -1771,19 +1804,20 @@ export async function preprocessor(event: Event) {
 
 ## S3 Object Operations
 
-Windmill provides built-in support for S3-compatible storage operations.
+Windmill provides built-in support for S3-compatible storage operations. The \`wmill.S3Object\` type covers both the \`s3://storage/key\` URI form (\`s3:///key\` for the workspace default storage) and the \`{ s3, storage? }\` record form — always use it instead of redefining your own.
 
-### S3Object Type
-
-The S3Object type represents a file in S3 storage:
+### Receiving an S3Object as a script parameter
 
 \`\`\`typescript
-type S3Object = {
-  s3: string; // Path within the bucket
-};
+import * as wmill from "windmill-client";
+
+export async function main(file: wmill.S3Object) {
+  const content = await wmill.loadS3File(file);
+  // ...
+}
 \`\`\`
 
-## TypeScript Operations
+### S3 operations
 
 \`\`\`typescript
 import * as wmill from "windmill-client";
@@ -1795,7 +1829,7 @@ const content: Uint8Array = await wmill.loadS3File(s3object);
 const blob: Blob = await wmill.loadS3FileStream(s3object);
 
 // Write file to S3
-const result: S3Object = await wmill.writeS3File(
+const result: wmill.S3Object = await wmill.writeS3File(
   s3object, // Target path (or undefined to auto-generate)
   fileContent, // string or Blob
   s3ResourcePath // Optional: specific S3 resource to use
@@ -2432,6 +2466,30 @@ SELECT * FROM read_parquet('s3:///path/to/file.parquet');
 -- JSON files
 SELECT * FROM read_json('s3:///path/to/file.json');
 \`\`\`
+
+### Receiving an S3Object as a script parameter
+
+Declare the arg with type \`(s3object)\`. Windmill renders an S3 file picker for it
+and binds the arg as the bare \`s3://storage/key\` URI, which DuckDB's reader
+functions consume directly:
+
+\`\`\`sql
+-- $file (s3object)
+SELECT * FROM read_parquet($file);
+\`\`\`
+
+Works with any DuckDB reader: \`read_csv($file)\`, \`read_json($file)\`, etc.
+
+### Writing query results to S3
+
+DuckDB writes to S3 natively via \`COPY ... TO\`:
+
+\`\`\`sql
+COPY (SELECT * FROM users) TO 's3:///exports/users.parquet' (FORMAT PARQUET);
+\`\`\`
+
+Use this instead of the \`-- s3\` streaming directive supported by the other SQL
+dialects — that directive is not available in DuckDB.
 `,
   "write-script-go": `---
 name: write-script-go
@@ -2748,6 +2806,36 @@ Name the parameters by adding comments before the statement:
 -- @P2 name2 (int) = 0
 SELECT * FROM users WHERE name = @P1 AND age > @P2;
 \`\`\`
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type \`(s3object)\`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as \`nvarchar(max)\` JSON text — Parquet/CSV
+files are decoded server-side into a JSON array of records, JSON/JSONL pass
+through. Consume with \`OPENJSON\`:
+
+\`\`\`sql
+-- @P1 file (s3object)
+SELECT id, name
+FROM OPENJSON(@P1)
+WITH (id INT, name NVARCHAR(200));
+\`\`\`
+
+## Streaming query results to S3
+
+Add a \`-- s3\` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its \`S3Object\`
+as the script result.
+
+\`\`\`sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+\`\`\`
+
+All keys are optional: \`prefix\` (object key prefix), \`storage\` (named storage —
+omit to use the workspace default), \`format\` (\`json\` (default), \`parquet\`, or
+\`csv\`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered as the script return value.
 `,
   "write-script-mysql": `---
 name: write-script-mysql
@@ -2800,6 +2888,37 @@ Name the parameters by adding comments before the statement:
 -- ? name2 (int) = 0
 SELECT * FROM users WHERE name = ? AND age > ?;
 \`\`\`
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type \`(s3object)\`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as JSON text — Parquet/CSV files are
+decoded server-side into a JSON array of records, JSON/JSONL pass through.
+Consume with \`JSON_TABLE\`:
+
+\`\`\`sql
+-- ? file (s3object)
+SELECT id, name
+FROM JSON_TABLE(?, '$[*]'
+  COLUMNS (id INT PATH '$.id', name VARCHAR(200) PATH '$.name')
+) AS r;
+\`\`\`
+
+## Streaming query results to S3
+
+Add a \`-- s3\` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its \`S3Object\`
+as the script result.
+
+\`\`\`sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+\`\`\`
+
+All keys are optional: \`prefix\` (object key prefix), \`storage\` (named storage —
+omit to use the workspace default), \`format\` (\`json\` (default), \`parquet\`, or
+\`csv\`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered as the script return value.
 `,
   "write-script-nativets": `---
 name: write-script-nativets
@@ -3607,6 +3726,35 @@ Name the parameters by adding comments at the beginning of the script (without s
 -- $2 name2 = default_value
 SELECT * FROM users WHERE name = $1::TEXT AND age > $2::INT;
 \`\`\`
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type \`(s3object)\`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as a \`jsonb\` parameter — Parquet/CSV files
+are decoded server-side into a JSON array of records, JSON/JSONL pass through.
+Consume with \`jsonb_to_recordset\` (or any \`jsonb\` API):
+
+\`\`\`sql
+-- $1 file (s3object)
+SELECT *
+FROM jsonb_to_recordset($1::jsonb) AS r(id INT, name TEXT);
+\`\`\`
+
+## Streaming query results to S3
+
+Add a \`-- s3\` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its \`S3Object\`
+as the script result.
+
+\`\`\`sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+\`\`\`
+
+All keys are optional: \`prefix\` (object key prefix), \`storage\` (named storage —
+omit to use the workspace default), \`format\` (\`json\` (default), \`parquet\`, or
+\`csv\`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered as the script return value.
 `,
   "write-script-powershell": `---
 name: write-script-powershell
@@ -3843,6 +3991,21 @@ def preprocessor(event: Event):
 ## S3 Object Operations
 
 Windmill provides built-in support for S3-compatible storage operations.
+
+### Receiving an S3Object as a script parameter
+
+To accept a file from S3 as input to a script, type the parameter with \`S3Object\` (imported from \`wmill\`):
+
+\`\`\`python
+import wmill
+from wmill import S3Object
+
+def main(file: S3Object):
+    content = wmill.load_s3_file(file)
+    # ...
+\`\`\`
+
+### S3 operations
 
 \`\`\`python
 import wmill
@@ -4848,6 +5011,37 @@ Name the parameters by adding comments before the statement:
 -- ? name2 (number) = 0
 SELECT * FROM users WHERE name = ? AND age > ?;
 \`\`\`
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type \`(s3object)\`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as JSON text — Parquet/CSV files are
+decoded server-side into a JSON array of records, JSON/JSONL pass through.
+Wrap the bind with \`PARSE_JSON(?)\` and walk it with \`LATERAL FLATTEN\`:
+
+\`\`\`sql
+-- ? file (s3object)
+SELECT
+  v.value:id::NUMBER AS id,
+  v.value:name::STRING AS name
+FROM LATERAL FLATTEN(input => PARSE_JSON(?)) v;
+\`\`\`
+
+## Streaming query results to S3
+
+Add a \`-- s3\` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its \`S3Object\`
+as the script result.
+
+\`\`\`sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+\`\`\`
+
+All keys are optional: \`prefix\` (object key prefix), \`storage\` (named storage —
+omit to use the workspace default), \`format\` (\`json\` (default), \`parquet\`, or
+\`csv\`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered, bypassing the 10000-row return cap.
 `,
   "write-flow": `---
 name: write-flow

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -2852,6 +2852,37 @@ Name the parameters by adding comments before the statement:
 -- @name2 (int64) = 0
 SELECT * FROM users WHERE name = @name1 AND age > @name2;
 \`\`\`
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type \`(s3object)\`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as a \`STRING\` JSON parameter — Parquet/CSV
+files are decoded server-side into a JSON array of records, JSON/JSONL pass
+through. Consume with \`JSON_EXTRACT_ARRAY\` / \`JSON_VALUE\`:
+
+\`\`\`sql
+-- @file (s3object)
+SELECT
+  CAST(JSON_VALUE(row, '$.id') AS INT64) AS id,
+  JSON_VALUE(row, '$.name') AS name
+FROM UNNEST(JSON_EXTRACT_ARRAY(@file)) AS row;
+\`\`\`
+
+## Streaming query results to S3
+
+Add a \`-- s3\` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its \`S3Object\`
+as the script result.
+
+\`\`\`sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+\`\`\`
+
+All keys are optional: \`prefix\` (object key prefix), \`storage\` (named storage —
+omit to use the workspace default), \`format\` (\`json\` (default), \`parquet\`, or
+\`csv\`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered, bypassing the 10000-row return cap.
 `;
 
 export const LANG_BUN = `# TypeScript (Bun)
@@ -2936,19 +2967,20 @@ export async function preprocessor(event: Event) {
 
 ## S3 Object Operations
 
-Windmill provides built-in support for S3-compatible storage operations.
+Windmill provides built-in support for S3-compatible storage operations. The \`wmill.S3Object\` type covers both the \`s3://storage/key\` URI form (\`s3:///key\` for the workspace default storage) and the \`{ s3, storage? }\` record form — always use it instead of redefining your own.
 
-### S3Object Type
-
-The S3Object type represents a file in S3 storage:
+### Receiving an S3Object as a script parameter
 
 \`\`\`typescript
-type S3Object = {
-  s3: string; // Path within the bucket
-};
+import * as wmill from "windmill-client";
+
+export async function main(file: wmill.S3Object) {
+  const content = await wmill.loadS3File(file);
+  // ...
+}
 \`\`\`
 
-## TypeScript Operations
+### S3 operations
 
 \`\`\`typescript
 import * as wmill from "windmill-client";
@@ -2960,7 +2992,7 @@ const content: Uint8Array = await wmill.loadS3File(s3object);
 const blob: Blob = await wmill.loadS3FileStream(s3object);
 
 // Write file to S3
-const result: S3Object = await wmill.writeS3File(
+const result: wmill.S3Object = await wmill.writeS3File(
   s3object, // Target path (or undefined to auto-generate)
   fileContent, // string or Blob
   s3ResourcePath // Optional: specific S3 resource to use
@@ -3048,19 +3080,20 @@ export async function preprocessor(event: Event) {
 
 ## S3 Object Operations
 
-Windmill provides built-in support for S3-compatible storage operations.
+Windmill provides built-in support for S3-compatible storage operations. The \`wmill.S3Object\` type covers both the \`s3://storage/key\` URI form (\`s3:///key\` for the workspace default storage) and the \`{ s3, storage? }\` record form — always use it instead of redefining your own.
 
-### S3Object Type
-
-The S3Object type represents a file in S3 storage:
+### Receiving an S3Object as a script parameter
 
 \`\`\`typescript
-type S3Object = {
-  s3: string; // Path within the bucket
-};
+import * as wmill from "windmill-client";
+
+export async function main(file: wmill.S3Object) {
+  const content = await wmill.loadS3File(file);
+  // ...
+}
 \`\`\`
 
-## TypeScript Operations
+### S3 operations
 
 \`\`\`typescript
 import * as wmill from "windmill-client";
@@ -3072,7 +3105,7 @@ const content: Uint8Array = await wmill.loadS3File(s3object);
 const blob: Blob = await wmill.loadS3FileStream(s3object);
 
 // Write file to S3
-const result: S3Object = await wmill.writeS3File(
+const result: wmill.S3Object = await wmill.writeS3File(
   s3object, // Target path (or undefined to auto-generate)
   fileContent, // string or Blob
   s3ResourcePath // Optional: specific S3 resource to use
@@ -3209,19 +3242,20 @@ export async function preprocessor(event: Event) {
 
 ## S3 Object Operations
 
-Windmill provides built-in support for S3-compatible storage operations.
+Windmill provides built-in support for S3-compatible storage operations. The \`wmill.S3Object\` type covers both the \`s3://storage/key\` URI form (\`s3:///key\` for the workspace default storage) and the \`{ s3, storage? }\` record form — always use it instead of redefining your own.
 
-### S3Object Type
-
-The S3Object type represents a file in S3 storage:
+### Receiving an S3Object as a script parameter
 
 \`\`\`typescript
-type S3Object = {
-  s3: string; // Path within the bucket
-};
+import * as wmill from "windmill-client";
+
+export async function main(file: wmill.S3Object) {
+  const content = await wmill.loadS3File(file);
+  // ...
+}
 \`\`\`
 
-## TypeScript Operations
+### S3 operations
 
 \`\`\`typescript
 import * as wmill from "windmill-client";
@@ -3233,7 +3267,7 @@ const content: Uint8Array = await wmill.loadS3File(s3object);
 const blob: Blob = await wmill.loadS3FileStream(s3object);
 
 // Write file to S3
-const result: S3Object = await wmill.writeS3File(
+const result: wmill.S3Object = await wmill.writeS3File(
   s3object, // Target path (or undefined to auto-generate)
   fileContent, // string or Blob
   s3ResourcePath // Optional: specific S3 resource to use
@@ -3292,6 +3326,30 @@ SELECT * FROM read_parquet('s3:///path/to/file.parquet');
 -- JSON files
 SELECT * FROM read_json('s3:///path/to/file.json');
 \`\`\`
+
+### Receiving an S3Object as a script parameter
+
+Declare the arg with type \`(s3object)\`. Windmill renders an S3 file picker for it
+and binds the arg as the bare \`s3://storage/key\` URI, which DuckDB's reader
+functions consume directly:
+
+\`\`\`sql
+-- $file (s3object)
+SELECT * FROM read_parquet($file);
+\`\`\`
+
+Works with any DuckDB reader: \`read_csv($file)\`, \`read_json($file)\`, etc.
+
+### Writing query results to S3
+
+DuckDB writes to S3 natively via \`COPY ... TO\`:
+
+\`\`\`sql
+COPY (SELECT * FROM users) TO 's3:///exports/users.parquet' (FORMAT PARQUET);
+\`\`\`
+
+Use this instead of the \`-- s3\` streaming directive supported by the other SQL
+dialects — that directive is not available in DuckDB.
 `;
 
 export const LANG_GO = `# Go
@@ -3452,6 +3510,36 @@ Name the parameters by adding comments before the statement:
 -- @P2 name2 (int) = 0
 SELECT * FROM users WHERE name = @P1 AND age > @P2;
 \`\`\`
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type \`(s3object)\`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as \`nvarchar(max)\` JSON text — Parquet/CSV
+files are decoded server-side into a JSON array of records, JSON/JSONL pass
+through. Consume with \`OPENJSON\`:
+
+\`\`\`sql
+-- @P1 file (s3object)
+SELECT id, name
+FROM OPENJSON(@P1)
+WITH (id INT, name NVARCHAR(200));
+\`\`\`
+
+## Streaming query results to S3
+
+Add a \`-- s3\` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its \`S3Object\`
+as the script result.
+
+\`\`\`sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+\`\`\`
+
+All keys are optional: \`prefix\` (object key prefix), \`storage\` (named storage —
+omit to use the workspace default), \`format\` (\`json\` (default), \`parquet\`, or
+\`csv\`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered as the script return value.
 `;
 
 export const LANG_MYSQL = `# MySQL
@@ -3465,6 +3553,37 @@ Name the parameters by adding comments before the statement:
 -- ? name2 (int) = 0
 SELECT * FROM users WHERE name = ? AND age > ?;
 \`\`\`
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type \`(s3object)\`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as JSON text — Parquet/CSV files are
+decoded server-side into a JSON array of records, JSON/JSONL pass through.
+Consume with \`JSON_TABLE\`:
+
+\`\`\`sql
+-- ? file (s3object)
+SELECT id, name
+FROM JSON_TABLE(?, '$[*]'
+  COLUMNS (id INT PATH '$.id', name VARCHAR(200) PATH '$.name')
+) AS r;
+\`\`\`
+
+## Streaming query results to S3
+
+Add a \`-- s3\` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its \`S3Object\`
+as the script result.
+
+\`\`\`sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+\`\`\`
+
+All keys are optional: \`prefix\` (object key prefix), \`storage\` (named storage —
+omit to use the workspace default), \`format\` (\`json\` (default), \`parquet\`, or
+\`csv\`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered as the script return value.
 `;
 
 export const LANG_NATIVETS = `# TypeScript (Native)
@@ -3616,6 +3735,35 @@ Name the parameters by adding comments at the beginning of the script (without s
 -- $2 name2 = default_value
 SELECT * FROM users WHERE name = $1::TEXT AND age > $2::INT;
 \`\`\`
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type \`(s3object)\`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as a \`jsonb\` parameter — Parquet/CSV files
+are decoded server-side into a JSON array of records, JSON/JSONL pass through.
+Consume with \`jsonb_to_recordset\` (or any \`jsonb\` API):
+
+\`\`\`sql
+-- $1 file (s3object)
+SELECT *
+FROM jsonb_to_recordset($1::jsonb) AS r(id INT, name TEXT);
+\`\`\`
+
+## Streaming query results to S3
+
+Add a \`-- s3\` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its \`S3Object\`
+as the script result.
+
+\`\`\`sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+\`\`\`
+
+All keys are optional: \`prefix\` (object key prefix), \`storage\` (named storage —
+omit to use the workspace default), \`format\` (\`json\` (default), \`parquet\`, or
+\`csv\`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered as the script return value.
 `;
 
 export const LANG_POWERSHELL = `# PowerShell
@@ -3774,6 +3922,21 @@ def preprocessor(event: Event):
 ## S3 Object Operations
 
 Windmill provides built-in support for S3-compatible storage operations.
+
+### Receiving an S3Object as a script parameter
+
+To accept a file from S3 as input to a script, type the parameter with \`S3Object\` (imported from \`wmill\`):
+
+\`\`\`python
+import wmill
+from wmill import S3Object
+
+def main(file: S3Object):
+    content = wmill.load_s3_file(file)
+    # ...
+\`\`\`
+
+### S3 operations
 
 \`\`\`python
 import wmill
@@ -3970,5 +4133,36 @@ Name the parameters by adding comments before the statement:
 -- ? name2 (number) = 0
 SELECT * FROM users WHERE name = ? AND age > ?;
 \`\`\`
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type \`(s3object)\`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as JSON text — Parquet/CSV files are
+decoded server-side into a JSON array of records, JSON/JSONL pass through.
+Wrap the bind with \`PARSE_JSON(?)\` and walk it with \`LATERAL FLATTEN\`:
+
+\`\`\`sql
+-- ? file (s3object)
+SELECT
+  v.value:id::NUMBER AS id,
+  v.value:name::STRING AS name
+FROM LATERAL FLATTEN(input => PARSE_JSON(?)) v;
+\`\`\`
+
+## Streaming query results to S3
+
+Add a \`-- s3\` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its \`S3Object\`
+as the script result.
+
+\`\`\`sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+\`\`\`
+
+All keys are optional: \`prefix\` (object key prefix), \`storage\` (named storage —
+omit to use the workspace default), \`format\` (\`json\` (default), \`parquet\`, or
+\`csv\`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered, bypassing the 10000-row return cap.
 `;
 

--- a/system_prompts/auto-generated/script.md
+++ b/system_prompts/auto-generated/script.md
@@ -90,6 +90,37 @@ Name the parameters by adding comments before the statement:
 SELECT * FROM users WHERE name = @name1 AND age > @name2;
 ```
 
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type `(s3object)`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as a `STRING` JSON parameter — Parquet/CSV
+files are decoded server-side into a JSON array of records, JSON/JSONL pass
+through. Consume with `JSON_EXTRACT_ARRAY` / `JSON_VALUE`:
+
+```sql
+-- @file (s3object)
+SELECT
+  CAST(JSON_VALUE(row, '$.id') AS INT64) AS id,
+  JSON_VALUE(row, '$.name') AS name
+FROM UNNEST(JSON_EXTRACT_ARRAY(@file)) AS row;
+```
+
+## Streaming query results to S3
+
+Add a `-- s3` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its `S3Object`
+as the script result.
+
+```sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+```
+
+All keys are optional: `prefix` (object key prefix), `storage` (named storage —
+omit to use the workspace default), `format` (`json` (default), `parquet`, or
+`csv`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered, bypassing the 10000-row return cap.
+
 
 # TypeScript (Bun)
 
@@ -173,19 +204,20 @@ export async function preprocessor(event: Event) {
 
 ## S3 Object Operations
 
-Windmill provides built-in support for S3-compatible storage operations.
+Windmill provides built-in support for S3-compatible storage operations. The `wmill.S3Object` type covers both the `s3://storage/key` URI form (`s3:///key` for the workspace default storage) and the `{ s3, storage? }` record form — always use it instead of redefining your own.
 
-### S3Object Type
-
-The S3Object type represents a file in S3 storage:
+### Receiving an S3Object as a script parameter
 
 ```typescript
-type S3Object = {
-  s3: string; // Path within the bucket
-};
+import * as wmill from "windmill-client";
+
+export async function main(file: wmill.S3Object) {
+  const content = await wmill.loadS3File(file);
+  // ...
+}
 ```
 
-## TypeScript Operations
+### S3 operations
 
 ```typescript
 import * as wmill from "windmill-client";
@@ -197,7 +229,7 @@ const content: Uint8Array = await wmill.loadS3File(s3object);
 const blob: Blob = await wmill.loadS3FileStream(s3object);
 
 // Write file to S3
-const result: S3Object = await wmill.writeS3File(
+const result: wmill.S3Object = await wmill.writeS3File(
   s3object, // Target path (or undefined to auto-generate)
   fileContent, // string or Blob
   s3ResourcePath // Optional: specific S3 resource to use
@@ -285,19 +317,20 @@ export async function preprocessor(event: Event) {
 
 ## S3 Object Operations
 
-Windmill provides built-in support for S3-compatible storage operations.
+Windmill provides built-in support for S3-compatible storage operations. The `wmill.S3Object` type covers both the `s3://storage/key` URI form (`s3:///key` for the workspace default storage) and the `{ s3, storage? }` record form — always use it instead of redefining your own.
 
-### S3Object Type
-
-The S3Object type represents a file in S3 storage:
+### Receiving an S3Object as a script parameter
 
 ```typescript
-type S3Object = {
-  s3: string; // Path within the bucket
-};
+import * as wmill from "windmill-client";
+
+export async function main(file: wmill.S3Object) {
+  const content = await wmill.loadS3File(file);
+  // ...
+}
 ```
 
-## TypeScript Operations
+### S3 operations
 
 ```typescript
 import * as wmill from "windmill-client";
@@ -309,7 +342,7 @@ const content: Uint8Array = await wmill.loadS3File(s3object);
 const blob: Blob = await wmill.loadS3FileStream(s3object);
 
 // Write file to S3
-const result: S3Object = await wmill.writeS3File(
+const result: wmill.S3Object = await wmill.writeS3File(
   s3object, // Target path (or undefined to auto-generate)
   fileContent, // string or Blob
   s3ResourcePath // Optional: specific S3 resource to use
@@ -446,19 +479,20 @@ export async function preprocessor(event: Event) {
 
 ## S3 Object Operations
 
-Windmill provides built-in support for S3-compatible storage operations.
+Windmill provides built-in support for S3-compatible storage operations. The `wmill.S3Object` type covers both the `s3://storage/key` URI form (`s3:///key` for the workspace default storage) and the `{ s3, storage? }` record form — always use it instead of redefining your own.
 
-### S3Object Type
-
-The S3Object type represents a file in S3 storage:
+### Receiving an S3Object as a script parameter
 
 ```typescript
-type S3Object = {
-  s3: string; // Path within the bucket
-};
+import * as wmill from "windmill-client";
+
+export async function main(file: wmill.S3Object) {
+  const content = await wmill.loadS3File(file);
+  // ...
+}
 ```
 
-## TypeScript Operations
+### S3 operations
 
 ```typescript
 import * as wmill from "windmill-client";
@@ -470,7 +504,7 @@ const content: Uint8Array = await wmill.loadS3File(s3object);
 const blob: Blob = await wmill.loadS3FileStream(s3object);
 
 // Write file to S3
-const result: S3Object = await wmill.writeS3File(
+const result: wmill.S3Object = await wmill.writeS3File(
   s3object, // Target path (or undefined to auto-generate)
   fileContent, // string or Blob
   s3ResourcePath // Optional: specific S3 resource to use
@@ -529,6 +563,30 @@ SELECT * FROM read_parquet('s3:///path/to/file.parquet');
 -- JSON files
 SELECT * FROM read_json('s3:///path/to/file.json');
 ```
+
+### Receiving an S3Object as a script parameter
+
+Declare the arg with type `(s3object)`. Windmill renders an S3 file picker for it
+and binds the arg as the bare `s3://storage/key` URI, which DuckDB's reader
+functions consume directly:
+
+```sql
+-- $file (s3object)
+SELECT * FROM read_parquet($file);
+```
+
+Works with any DuckDB reader: `read_csv($file)`, `read_json($file)`, etc.
+
+### Writing query results to S3
+
+DuckDB writes to S3 natively via `COPY ... TO`:
+
+```sql
+COPY (SELECT * FROM users) TO 's3:///exports/users.parquet' (FORMAT PARQUET);
+```
+
+Use this instead of the `-- s3` streaming directive supported by the other SQL
+dialects — that directive is not available in DuckDB.
 
 
 # Go
@@ -690,6 +748,36 @@ Name the parameters by adding comments before the statement:
 SELECT * FROM users WHERE name = @P1 AND age > @P2;
 ```
 
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type `(s3object)`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as `nvarchar(max)` JSON text — Parquet/CSV
+files are decoded server-side into a JSON array of records, JSON/JSONL pass
+through. Consume with `OPENJSON`:
+
+```sql
+-- @P1 file (s3object)
+SELECT id, name
+FROM OPENJSON(@P1)
+WITH (id INT, name NVARCHAR(200));
+```
+
+## Streaming query results to S3
+
+Add a `-- s3` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its `S3Object`
+as the script result.
+
+```sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+```
+
+All keys are optional: `prefix` (object key prefix), `storage` (named storage —
+omit to use the workspace default), `format` (`json` (default), `parquet`, or
+`csv`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered as the script return value.
+
 
 # MySQL
 
@@ -702,6 +790,37 @@ Name the parameters by adding comments before the statement:
 -- ? name2 (int) = 0
 SELECT * FROM users WHERE name = ? AND age > ?;
 ```
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type `(s3object)`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as JSON text — Parquet/CSV files are
+decoded server-side into a JSON array of records, JSON/JSONL pass through.
+Consume with `JSON_TABLE`:
+
+```sql
+-- ? file (s3object)
+SELECT id, name
+FROM JSON_TABLE(?, '$[*]'
+  COLUMNS (id INT PATH '$.id', name VARCHAR(200) PATH '$.name')
+) AS r;
+```
+
+## Streaming query results to S3
+
+Add a `-- s3` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its `S3Object`
+as the script result.
+
+```sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+```
+
+All keys are optional: `prefix` (object key prefix), `storage` (named storage —
+omit to use the workspace default), `format` (`json` (default), `parquet`, or
+`csv`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered as the script return value.
 
 
 # TypeScript (Native)
@@ -853,6 +972,35 @@ Name the parameters by adding comments at the beginning of the script (without s
 -- $2 name2 = default_value
 SELECT * FROM users WHERE name = $1::TEXT AND age > $2::INT;
 ```
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type `(s3object)`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as a `jsonb` parameter — Parquet/CSV files
+are decoded server-side into a JSON array of records, JSON/JSONL pass through.
+Consume with `jsonb_to_recordset` (or any `jsonb` API):
+
+```sql
+-- $1 file (s3object)
+SELECT *
+FROM jsonb_to_recordset($1::jsonb) AS r(id INT, name TEXT);
+```
+
+## Streaming query results to S3
+
+Add a `-- s3` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its `S3Object`
+as the script result.
+
+```sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+```
+
+All keys are optional: `prefix` (object key prefix), `storage` (named storage —
+omit to use the workspace default), `format` (`json` (default), `parquet`, or
+`csv`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered as the script return value.
 
 
 # PowerShell
@@ -1011,6 +1159,21 @@ def preprocessor(event: Event):
 ## S3 Object Operations
 
 Windmill provides built-in support for S3-compatible storage operations.
+
+### Receiving an S3Object as a script parameter
+
+To accept a file from S3 as input to a script, type the parameter with `S3Object` (imported from `wmill`):
+
+```python
+import wmill
+from wmill import S3Object
+
+def main(file: S3Object):
+    content = wmill.load_s3_file(file)
+    # ...
+```
+
+### S3 operations
 
 ```python
 import wmill
@@ -1207,6 +1370,37 @@ Name the parameters by adding comments before the statement:
 -- ? name2 (number) = 0
 SELECT * FROM users WHERE name = ? AND age > ?;
 ```
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type `(s3object)`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as JSON text — Parquet/CSV files are
+decoded server-side into a JSON array of records, JSON/JSONL pass through.
+Wrap the bind with `PARSE_JSON(?)` and walk it with `LATERAL FLATTEN`:
+
+```sql
+-- ? file (s3object)
+SELECT
+  v.value:id::NUMBER AS id,
+  v.value:name::STRING AS name
+FROM LATERAL FLATTEN(input => PARSE_JSON(?)) v;
+```
+
+## Streaming query results to S3
+
+Add a `-- s3` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its `S3Object`
+as the script result.
+
+```sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+```
+
+All keys are optional: `prefix` (object key prefix), `storage` (named storage —
+omit to use the workspace default), `format` (`json` (default), `parquet`, or
+`csv`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered, bypassing the 10000-row return cap.
 
 
 # TypeScript SDK (windmill-client)

--- a/system_prompts/auto-generated/skills/write-script-bigquery/SKILL.md
+++ b/system_prompts/auto-generated/skills/write-script-bigquery/SKILL.md
@@ -49,3 +49,34 @@ Name the parameters by adding comments before the statement:
 -- @name2 (int64) = 0
 SELECT * FROM users WHERE name = @name1 AND age > @name2;
 ```
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type `(s3object)`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as a `STRING` JSON parameter — Parquet/CSV
+files are decoded server-side into a JSON array of records, JSON/JSONL pass
+through. Consume with `JSON_EXTRACT_ARRAY` / `JSON_VALUE`:
+
+```sql
+-- @file (s3object)
+SELECT
+  CAST(JSON_VALUE(row, '$.id') AS INT64) AS id,
+  JSON_VALUE(row, '$.name') AS name
+FROM UNNEST(JSON_EXTRACT_ARRAY(@file)) AS row;
+```
+
+## Streaming query results to S3
+
+Add a `-- s3` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its `S3Object`
+as the script result.
+
+```sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+```
+
+All keys are optional: `prefix` (object key prefix), `storage` (named storage —
+omit to use the workspace default), `format` (`json` (default), `parquet`, or
+`csv`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered, bypassing the 10000-row return cap.

--- a/system_prompts/auto-generated/skills/write-script-bun/SKILL.md
+++ b/system_prompts/auto-generated/skills/write-script-bun/SKILL.md
@@ -120,19 +120,20 @@ export async function preprocessor(event: Event) {
 
 ## S3 Object Operations
 
-Windmill provides built-in support for S3-compatible storage operations.
+Windmill provides built-in support for S3-compatible storage operations. The `wmill.S3Object` type covers both the `s3://storage/key` URI form (`s3:///key` for the workspace default storage) and the `{ s3, storage? }` record form — always use it instead of redefining your own.
 
-### S3Object Type
-
-The S3Object type represents a file in S3 storage:
+### Receiving an S3Object as a script parameter
 
 ```typescript
-type S3Object = {
-  s3: string; // Path within the bucket
-};
+import * as wmill from "windmill-client";
+
+export async function main(file: wmill.S3Object) {
+  const content = await wmill.loadS3File(file);
+  // ...
+}
 ```
 
-## TypeScript Operations
+### S3 operations
 
 ```typescript
 import * as wmill from "windmill-client";
@@ -144,7 +145,7 @@ const content: Uint8Array = await wmill.loadS3File(s3object);
 const blob: Blob = await wmill.loadS3FileStream(s3object);
 
 // Write file to S3
-const result: S3Object = await wmill.writeS3File(
+const result: wmill.S3Object = await wmill.writeS3File(
   s3object, // Target path (or undefined to auto-generate)
   fileContent, // string or Blob
   s3ResourcePath // Optional: specific S3 resource to use

--- a/system_prompts/auto-generated/skills/write-script-bunnative/SKILL.md
+++ b/system_prompts/auto-generated/skills/write-script-bunnative/SKILL.md
@@ -118,19 +118,20 @@ export async function preprocessor(event: Event) {
 
 ## S3 Object Operations
 
-Windmill provides built-in support for S3-compatible storage operations.
+Windmill provides built-in support for S3-compatible storage operations. The `wmill.S3Object` type covers both the `s3://storage/key` URI form (`s3:///key` for the workspace default storage) and the `{ s3, storage? }` record form — always use it instead of redefining your own.
 
-### S3Object Type
-
-The S3Object type represents a file in S3 storage:
+### Receiving an S3Object as a script parameter
 
 ```typescript
-type S3Object = {
-  s3: string; // Path within the bucket
-};
+import * as wmill from "windmill-client";
+
+export async function main(file: wmill.S3Object) {
+  const content = await wmill.loadS3File(file);
+  // ...
+}
 ```
 
-## TypeScript Operations
+### S3 operations
 
 ```typescript
 import * as wmill from "windmill-client";
@@ -142,7 +143,7 @@ const content: Uint8Array = await wmill.loadS3File(s3object);
 const blob: Blob = await wmill.loadS3FileStream(s3object);
 
 // Write file to S3
-const result: S3Object = await wmill.writeS3File(
+const result: wmill.S3Object = await wmill.writeS3File(
   s3object, // Target path (or undefined to auto-generate)
   fileContent, // string or Blob
   s3ResourcePath // Optional: specific S3 resource to use

--- a/system_prompts/auto-generated/skills/write-script-deno/SKILL.md
+++ b/system_prompts/auto-generated/skills/write-script-deno/SKILL.md
@@ -124,19 +124,20 @@ export async function preprocessor(event: Event) {
 
 ## S3 Object Operations
 
-Windmill provides built-in support for S3-compatible storage operations.
+Windmill provides built-in support for S3-compatible storage operations. The `wmill.S3Object` type covers both the `s3://storage/key` URI form (`s3:///key` for the workspace default storage) and the `{ s3, storage? }` record form — always use it instead of redefining your own.
 
-### S3Object Type
-
-The S3Object type represents a file in S3 storage:
+### Receiving an S3Object as a script parameter
 
 ```typescript
-type S3Object = {
-  s3: string; // Path within the bucket
-};
+import * as wmill from "windmill-client";
+
+export async function main(file: wmill.S3Object) {
+  const content = await wmill.loadS3File(file);
+  // ...
+}
 ```
 
-## TypeScript Operations
+### S3 operations
 
 ```typescript
 import * as wmill from "windmill-client";
@@ -148,7 +149,7 @@ const content: Uint8Array = await wmill.loadS3File(s3object);
 const blob: Blob = await wmill.loadS3FileStream(s3object);
 
 // Write file to S3
-const result: S3Object = await wmill.writeS3File(
+const result: wmill.S3Object = await wmill.writeS3File(
   s3object, // Target path (or undefined to auto-generate)
   fileContent, // string or Blob
   s3ResourcePath // Optional: specific S3 resource to use

--- a/system_prompts/auto-generated/skills/write-script-duckdb/SKILL.md
+++ b/system_prompts/auto-generated/skills/write-script-duckdb/SKILL.md
@@ -89,3 +89,27 @@ SELECT * FROM read_parquet('s3:///path/to/file.parquet');
 -- JSON files
 SELECT * FROM read_json('s3:///path/to/file.json');
 ```
+
+### Receiving an S3Object as a script parameter
+
+Declare the arg with type `(s3object)`. Windmill renders an S3 file picker for it
+and binds the arg as the bare `s3://storage/key` URI, which DuckDB's reader
+functions consume directly:
+
+```sql
+-- $file (s3object)
+SELECT * FROM read_parquet($file);
+```
+
+Works with any DuckDB reader: `read_csv($file)`, `read_json($file)`, etc.
+
+### Writing query results to S3
+
+DuckDB writes to S3 natively via `COPY ... TO`:
+
+```sql
+COPY (SELECT * FROM users) TO 's3:///exports/users.parquet' (FORMAT PARQUET);
+```
+
+Use this instead of the `-- s3` streaming directive supported by the other SQL
+dialects — that directive is not available in DuckDB.

--- a/system_prompts/auto-generated/skills/write-script-mssql/SKILL.md
+++ b/system_prompts/auto-generated/skills/write-script-mssql/SKILL.md
@@ -49,3 +49,33 @@ Name the parameters by adding comments before the statement:
 -- @P2 name2 (int) = 0
 SELECT * FROM users WHERE name = @P1 AND age > @P2;
 ```
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type `(s3object)`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as `nvarchar(max)` JSON text — Parquet/CSV
+files are decoded server-side into a JSON array of records, JSON/JSONL pass
+through. Consume with `OPENJSON`:
+
+```sql
+-- @P1 file (s3object)
+SELECT id, name
+FROM OPENJSON(@P1)
+WITH (id INT, name NVARCHAR(200));
+```
+
+## Streaming query results to S3
+
+Add a `-- s3` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its `S3Object`
+as the script result.
+
+```sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+```
+
+All keys are optional: `prefix` (object key prefix), `storage` (named storage —
+omit to use the workspace default), `format` (`json` (default), `parquet`, or
+`csv`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered as the script return value.

--- a/system_prompts/auto-generated/skills/write-script-mysql/SKILL.md
+++ b/system_prompts/auto-generated/skills/write-script-mysql/SKILL.md
@@ -49,3 +49,34 @@ Name the parameters by adding comments before the statement:
 -- ? name2 (int) = 0
 SELECT * FROM users WHERE name = ? AND age > ?;
 ```
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type `(s3object)`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as JSON text — Parquet/CSV files are
+decoded server-side into a JSON array of records, JSON/JSONL pass through.
+Consume with `JSON_TABLE`:
+
+```sql
+-- ? file (s3object)
+SELECT id, name
+FROM JSON_TABLE(?, '$[*]'
+  COLUMNS (id INT PATH '$.id', name VARCHAR(200) PATH '$.name')
+) AS r;
+```
+
+## Streaming query results to S3
+
+Add a `-- s3` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its `S3Object`
+as the script result.
+
+```sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+```
+
+All keys are optional: `prefix` (object key prefix), `storage` (named storage —
+omit to use the workspace default), `format` (`json` (default), `parquet`, or
+`csv`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered as the script return value.

--- a/system_prompts/auto-generated/skills/write-script-postgresql/SKILL.md
+++ b/system_prompts/auto-generated/skills/write-script-postgresql/SKILL.md
@@ -49,3 +49,32 @@ Name the parameters by adding comments at the beginning of the script (without s
 -- $2 name2 = default_value
 SELECT * FROM users WHERE name = $1::TEXT AND age > $2::INT;
 ```
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type `(s3object)`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as a `jsonb` parameter — Parquet/CSV files
+are decoded server-side into a JSON array of records, JSON/JSONL pass through.
+Consume with `jsonb_to_recordset` (or any `jsonb` API):
+
+```sql
+-- $1 file (s3object)
+SELECT *
+FROM jsonb_to_recordset($1::jsonb) AS r(id INT, name TEXT);
+```
+
+## Streaming query results to S3
+
+Add a `-- s3` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its `S3Object`
+as the script result.
+
+```sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+```
+
+All keys are optional: `prefix` (object key prefix), `storage` (named storage —
+omit to use the workspace default), `format` (`json` (default), `parquet`, or
+`csv`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered as the script return value.

--- a/system_prompts/auto-generated/skills/write-script-python3/SKILL.md
+++ b/system_prompts/auto-generated/skills/write-script-python3/SKILL.md
@@ -138,6 +138,21 @@ def preprocessor(event: Event):
 
 Windmill provides built-in support for S3-compatible storage operations.
 
+### Receiving an S3Object as a script parameter
+
+To accept a file from S3 as input to a script, type the parameter with `S3Object` (imported from `wmill`):
+
+```python
+import wmill
+from wmill import S3Object
+
+def main(file: S3Object):
+    content = wmill.load_s3_file(file)
+    # ...
+```
+
+### S3 operations
+
 ```python
 import wmill
 

--- a/system_prompts/auto-generated/skills/write-script-snowflake/SKILL.md
+++ b/system_prompts/auto-generated/skills/write-script-snowflake/SKILL.md
@@ -49,3 +49,34 @@ Name the parameters by adding comments before the statement:
 -- ? name2 (number) = 0
 SELECT * FROM users WHERE name = ? AND age > ?;
 ```
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type `(s3object)`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as JSON text — Parquet/CSV files are
+decoded server-side into a JSON array of records, JSON/JSONL pass through.
+Wrap the bind with `PARSE_JSON(?)` and walk it with `LATERAL FLATTEN`:
+
+```sql
+-- ? file (s3object)
+SELECT
+  v.value:id::NUMBER AS id,
+  v.value:name::STRING AS name
+FROM LATERAL FLATTEN(input => PARSE_JSON(?)) v;
+```
+
+## Streaming query results to S3
+
+Add a `-- s3` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its `S3Object`
+as the script result.
+
+```sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+```
+
+All keys are optional: `prefix` (object key prefix), `storage` (named storage —
+omit to use the workspace default), `format` (`json` (default), `parquet`, or
+`csv`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered, bypassing the 10000-row return cap.

--- a/system_prompts/languages/bigquery.md
+++ b/system_prompts/languages/bigquery.md
@@ -9,3 +9,34 @@ Name the parameters by adding comments before the statement:
 -- @name2 (int64) = 0
 SELECT * FROM users WHERE name = @name1 AND age > @name2;
 ```
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type `(s3object)`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as a `STRING` JSON parameter — Parquet/CSV
+files are decoded server-side into a JSON array of records, JSON/JSONL pass
+through. Consume with `JSON_EXTRACT_ARRAY` / `JSON_VALUE`:
+
+```sql
+-- @file (s3object)
+SELECT
+  CAST(JSON_VALUE(row, '$.id') AS INT64) AS id,
+  JSON_VALUE(row, '$.name') AS name
+FROM UNNEST(JSON_EXTRACT_ARRAY(@file)) AS row;
+```
+
+## Streaming query results to S3
+
+Add a `-- s3` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its `S3Object`
+as the script result.
+
+```sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+```
+
+All keys are optional: `prefix` (object key prefix), `storage` (named storage —
+omit to use the workspace default), `format` (`json` (default), `parquet`, or
+`csv`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered, bypassing the 10000-row return cap.

--- a/system_prompts/languages/bun.md
+++ b/system_prompts/languages/bun.md
@@ -80,19 +80,20 @@ export async function preprocessor(event: Event) {
 
 ## S3 Object Operations
 
-Windmill provides built-in support for S3-compatible storage operations.
+Windmill provides built-in support for S3-compatible storage operations. The `wmill.S3Object` type covers both the `s3://storage/key` URI form (`s3:///key` for the workspace default storage) and the `{ s3, storage? }` record form — always use it instead of redefining your own.
 
-### S3Object Type
-
-The S3Object type represents a file in S3 storage:
+### Receiving an S3Object as a script parameter
 
 ```typescript
-type S3Object = {
-  s3: string; // Path within the bucket
-};
+import * as wmill from "windmill-client";
+
+export async function main(file: wmill.S3Object) {
+  const content = await wmill.loadS3File(file);
+  // ...
+}
 ```
 
-## TypeScript Operations
+### S3 operations
 
 ```typescript
 import * as wmill from "windmill-client";
@@ -104,7 +105,7 @@ const content: Uint8Array = await wmill.loadS3File(s3object);
 const blob: Blob = await wmill.loadS3FileStream(s3object);
 
 // Write file to S3
-const result: S3Object = await wmill.writeS3File(
+const result: wmill.S3Object = await wmill.writeS3File(
   s3object, // Target path (or undefined to auto-generate)
   fileContent, // string or Blob
   s3ResourcePath // Optional: specific S3 resource to use

--- a/system_prompts/languages/bunnative.md
+++ b/system_prompts/languages/bunnative.md
@@ -78,19 +78,20 @@ export async function preprocessor(event: Event) {
 
 ## S3 Object Operations
 
-Windmill provides built-in support for S3-compatible storage operations.
+Windmill provides built-in support for S3-compatible storage operations. The `wmill.S3Object` type covers both the `s3://storage/key` URI form (`s3:///key` for the workspace default storage) and the `{ s3, storage? }` record form — always use it instead of redefining your own.
 
-### S3Object Type
-
-The S3Object type represents a file in S3 storage:
+### Receiving an S3Object as a script parameter
 
 ```typescript
-type S3Object = {
-  s3: string; // Path within the bucket
-};
+import * as wmill from "windmill-client";
+
+export async function main(file: wmill.S3Object) {
+  const content = await wmill.loadS3File(file);
+  // ...
+}
 ```
 
-## TypeScript Operations
+### S3 operations
 
 ```typescript
 import * as wmill from "windmill-client";
@@ -102,7 +103,7 @@ const content: Uint8Array = await wmill.loadS3File(s3object);
 const blob: Blob = await wmill.loadS3FileStream(s3object);
 
 // Write file to S3
-const result: S3Object = await wmill.writeS3File(
+const result: wmill.S3Object = await wmill.writeS3File(
   s3object, // Target path (or undefined to auto-generate)
   fileContent, // string or Blob
   s3ResourcePath // Optional: specific S3 resource to use

--- a/system_prompts/languages/deno.md
+++ b/system_prompts/languages/deno.md
@@ -84,19 +84,20 @@ export async function preprocessor(event: Event) {
 
 ## S3 Object Operations
 
-Windmill provides built-in support for S3-compatible storage operations.
+Windmill provides built-in support for S3-compatible storage operations. The `wmill.S3Object` type covers both the `s3://storage/key` URI form (`s3:///key` for the workspace default storage) and the `{ s3, storage? }` record form — always use it instead of redefining your own.
 
-### S3Object Type
-
-The S3Object type represents a file in S3 storage:
+### Receiving an S3Object as a script parameter
 
 ```typescript
-type S3Object = {
-  s3: string; // Path within the bucket
-};
+import * as wmill from "windmill-client";
+
+export async function main(file: wmill.S3Object) {
+  const content = await wmill.loadS3File(file);
+  // ...
+}
 ```
 
-## TypeScript Operations
+### S3 operations
 
 ```typescript
 import * as wmill from "windmill-client";
@@ -108,7 +109,7 @@ const content: Uint8Array = await wmill.loadS3File(s3object);
 const blob: Blob = await wmill.loadS3FileStream(s3object);
 
 // Write file to S3
-const result: S3Object = await wmill.writeS3File(
+const result: wmill.S3Object = await wmill.writeS3File(
   s3object, // Target path (or undefined to auto-generate)
   fileContent, // string or Blob
   s3ResourcePath // Optional: specific S3 resource to use

--- a/system_prompts/languages/duckdb.md
+++ b/system_prompts/languages/duckdb.md
@@ -49,3 +49,27 @@ SELECT * FROM read_parquet('s3:///path/to/file.parquet');
 -- JSON files
 SELECT * FROM read_json('s3:///path/to/file.json');
 ```
+
+### Receiving an S3Object as a script parameter
+
+Declare the arg with type `(s3object)`. Windmill renders an S3 file picker for it
+and binds the arg as the bare `s3://storage/key` URI, which DuckDB's reader
+functions consume directly:
+
+```sql
+-- $file (s3object)
+SELECT * FROM read_parquet($file);
+```
+
+Works with any DuckDB reader: `read_csv($file)`, `read_json($file)`, etc.
+
+### Writing query results to S3
+
+DuckDB writes to S3 natively via `COPY ... TO`:
+
+```sql
+COPY (SELECT * FROM users) TO 's3:///exports/users.parquet' (FORMAT PARQUET);
+```
+
+Use this instead of the `-- s3` streaming directive supported by the other SQL
+dialects — that directive is not available in DuckDB.

--- a/system_prompts/languages/mssql.md
+++ b/system_prompts/languages/mssql.md
@@ -9,3 +9,33 @@ Name the parameters by adding comments before the statement:
 -- @P2 name2 (int) = 0
 SELECT * FROM users WHERE name = @P1 AND age > @P2;
 ```
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type `(s3object)`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as `nvarchar(max)` JSON text — Parquet/CSV
+files are decoded server-side into a JSON array of records, JSON/JSONL pass
+through. Consume with `OPENJSON`:
+
+```sql
+-- @P1 file (s3object)
+SELECT id, name
+FROM OPENJSON(@P1)
+WITH (id INT, name NVARCHAR(200));
+```
+
+## Streaming query results to S3
+
+Add a `-- s3` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its `S3Object`
+as the script result.
+
+```sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+```
+
+All keys are optional: `prefix` (object key prefix), `storage` (named storage —
+omit to use the workspace default), `format` (`json` (default), `parquet`, or
+`csv`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered as the script return value.

--- a/system_prompts/languages/mysql.md
+++ b/system_prompts/languages/mysql.md
@@ -9,3 +9,34 @@ Name the parameters by adding comments before the statement:
 -- ? name2 (int) = 0
 SELECT * FROM users WHERE name = ? AND age > ?;
 ```
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type `(s3object)`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as JSON text — Parquet/CSV files are
+decoded server-side into a JSON array of records, JSON/JSONL pass through.
+Consume with `JSON_TABLE`:
+
+```sql
+-- ? file (s3object)
+SELECT id, name
+FROM JSON_TABLE(?, '$[*]'
+  COLUMNS (id INT PATH '$.id', name VARCHAR(200) PATH '$.name')
+) AS r;
+```
+
+## Streaming query results to S3
+
+Add a `-- s3` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its `S3Object`
+as the script result.
+
+```sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+```
+
+All keys are optional: `prefix` (object key prefix), `storage` (named storage —
+omit to use the workspace default), `format` (`json` (default), `parquet`, or
+`csv`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered as the script return value.

--- a/system_prompts/languages/postgresql.md
+++ b/system_prompts/languages/postgresql.md
@@ -9,3 +9,32 @@ Name the parameters by adding comments at the beginning of the script (without s
 -- $2 name2 = default_value
 SELECT * FROM users WHERE name = $1::TEXT AND age > $2::INT;
 ```
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type `(s3object)`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as a `jsonb` parameter — Parquet/CSV files
+are decoded server-side into a JSON array of records, JSON/JSONL pass through.
+Consume with `jsonb_to_recordset` (or any `jsonb` API):
+
+```sql
+-- $1 file (s3object)
+SELECT *
+FROM jsonb_to_recordset($1::jsonb) AS r(id INT, name TEXT);
+```
+
+## Streaming query results to S3
+
+Add a `-- s3` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its `S3Object`
+as the script result.
+
+```sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+```
+
+All keys are optional: `prefix` (object key prefix), `storage` (named storage —
+omit to use the workspace default), `format` (`json` (default), `parquet`, or
+`csv`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered as the script return value.

--- a/system_prompts/languages/python3.md
+++ b/system_prompts/languages/python3.md
@@ -98,6 +98,21 @@ def preprocessor(event: Event):
 
 Windmill provides built-in support for S3-compatible storage operations.
 
+### Receiving an S3Object as a script parameter
+
+To accept a file from S3 as input to a script, type the parameter with `S3Object` (imported from `wmill`):
+
+```python
+import wmill
+from wmill import S3Object
+
+def main(file: S3Object):
+    content = wmill.load_s3_file(file)
+    # ...
+```
+
+### S3 operations
+
 ```python
 import wmill
 

--- a/system_prompts/languages/snowflake.md
+++ b/system_prompts/languages/snowflake.md
@@ -9,3 +9,34 @@ Name the parameters by adding comments before the statement:
 -- ? name2 (number) = 0
 SELECT * FROM users WHERE name = ? AND age > ?;
 ```
+
+## Receiving an S3Object as a script parameter
+
+Declare the arg with type `(s3object)`. Windmill renders an S3 file picker for
+it, downloads the file, and binds it as JSON text — Parquet/CSV files are
+decoded server-side into a JSON array of records, JSON/JSONL pass through.
+Wrap the bind with `PARSE_JSON(?)` and walk it with `LATERAL FLATTEN`:
+
+```sql
+-- ? file (s3object)
+SELECT
+  v.value:id::NUMBER AS id,
+  v.value:name::STRING AS name
+FROM LATERAL FLATTEN(input => PARSE_JSON(?)) v;
+```
+
+## Streaming query results to S3
+
+Add a `-- s3` directive at the top of the script to stream the result set to S3
+instead of returning rows. Windmill writes the file and returns its `S3Object`
+as the script result.
+
+```sql
+-- s3 prefix=exports/users format=parquet
+SELECT id, name FROM users;
+```
+
+All keys are optional: `prefix` (object key prefix), `storage` (named storage —
+omit to use the workspace default), `format` (`json` (default), `parquet`, or
+`csv`). Use this for large result sets — rows stream directly to S3 instead of
+being buffered, bypassing the 10000-row return cap.


### PR DESCRIPTION
## Summary

The CLI `init`-time skill prompts didn't tell agents how to declare a script parameter as an S3 file, and the SQL skills said nothing about taking S3 files as input or streaming results back to S3. This adds that guidance for every language that supports it.

## Changes

**TypeScript / Python script skills** (`bun`, `bunnative`, `deno`, `python3`):
- Add a "Receiving an S3Object as a script parameter" snippet showing `main(file: wmill.S3Object)` (TS) and `main(file: S3Object)` (Python).
- Drop the inline `type S3Object = { s3: string }` redefinition from the TS skills — the SDK's `wmill.S3Object` already covers both `s3://bucket/key` and `{ s3, storage? }`. Use it instead of redefining.
- Switch the `writeS3File` return-type annotation to `wmill.S3Object` for consistency.

**SQL script skills** (`postgresql`, `mssql`, `mysql`, `bigquery`, `snowflake`):
- Add "Receiving an S3Object as a script parameter" — declare with `(s3object)`. Windmill downloads the file, decodes Parquet/CSV → JSON array, JSON/JSONL pass through. Each dialect gets a consume example: `jsonb_to_recordset` (PG), `OPENJSON` (MSSQL), `JSON_TABLE` (MySQL), `JSON_EXTRACT_ARRAY`/`JSON_VALUE` (BQ), `LATERAL FLATTEN(input => PARSE_JSON(?))` (Snowflake).
- Add "Streaming query results to S3" — `-- s3 [prefix=...] [storage=...] [format=json|parquet|csv]` directive at the top of the script. Returns an `S3Object`. Dialect-neutral wording on why ("stream rows directly to S3 instead of buffering as the script return value"); BQ/Snowflake additionally call out the 10000-row return cap.

**DuckDB**:
- Add "Receiving an S3Object as a script parameter" — bound as the bare `s3://storage/key` URI, usable directly in `read_parquet($file)` / `read_csv($file)` / etc.
- Add "Writing query results to S3" pointing to native `COPY ... TO 's3:///...'`, with a callout that the `-- s3` directive is **not** supported on DuckDB.

`system_prompts/auto-generated/**` and `cli/src/guidance/skills.gen.ts` are regenerated outputs of `system_prompts/generate.py`.

## Test plan
- [ ] `wmill init` in a fresh directory; open the generated `.claude/skills/write-script-bun/SKILL.md` and confirm the new S3 sections render.
- [ ] Same check for `write-script-python3`, `write-script-duckdb`, `write-script-postgresql`, `write-script-mssql`, `write-script-mysql`, `write-script-bigquery`, `write-script-snowflake`.
- [ ] Author a DuckDB script with `-- \$file (s3object)` + `read_parquet(\$file)` and run it against an uploaded parquet file.
- [ ] Author a PG script with `-- \$1 file (s3object)` + `jsonb_to_recordset(\$1::jsonb)` and verify it consumes the materialized JSON.
- [ ] Author a PG script prefixed with `-- s3 format=parquet` and confirm the result is written to S3 and the script returns an `S3Object`.

## Tester notes

In the Windmill UI, create a new script in any of the supported dialects and follow the snippets in the regenerated skill files. For SQL `(s3object)` args, the editor should render an S3 file picker for the parameter; running the script then reads the file via the dialect's JSON helpers (DuckDB reads the URI directly). For the `-- s3` directive, run any `SELECT` and confirm the script result is an `S3Object` rather than rows.

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add docs for accepting S3 files as inputs and streaming SQL results to S3 across script skills, and standardize TypeScript examples to `wmill.S3Object`. This improves `wmill init` prompts and makes S3 usage consistent across languages.

- **New Features**
  - TypeScript (`bun`, `bunnative`, `deno`) and `python3` script skills: add “Receiving an S3Object” with `main(file: wmill.S3Object)` / `def main(file: S3Object)` and simple load examples.
  - SQL (`postgresql`, `mssql`, `mysql`, `bigquery`, `snowflake`): document `(s3object)` params, server-side decode (Parquet/CSV → JSON array; JSON/JSONL pass-through), and per-dialect consume examples: PG `jsonb_to_recordset`, MSSQL `OPENJSON`, MySQL `JSON_TABLE`, BQ `JSON_EXTRACT_ARRAY`/`JSON_VALUE`, Snowflake `PARSE_JSON` + `LATERAL FLATTEN`; add `-- s3 [prefix=...] [storage=...] [format=json|parquet|csv]` to stream results to S3 and return an `S3Object` (bypasses the 10k-row cap on BQ/Snowflake).
  - DuckDB: `(s3object)` binds as an `s3://...` URI usable in `read_parquet($file)`/`read_csv($file)`; write via native `COPY ... TO 's3:///...'`; `-- s3` not supported.

- **Refactors**
  - Replace inline TS `S3Object` types with `wmill.S3Object`; update `writeS3File` return type to `wmill.S3Object`.
  - Regenerate guidance and prompts (`system_prompts/auto-generated/**`, `cli/src/guidance/skills.gen.ts`).

<sup>Written for commit 16b0757c4f395ff10def12ed4c17bf820b4eb1e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

