### PR TITLE
ci: multi-tool PR reviews (Codex/Pi/Claude) with slash commands

### DIFF
--- a/.github/pi/pr-review.prompt.md
+++ b/.github/pi/pr-review.prompt.md
@@ -1,24 +1,25 @@
 You are reviewing a GitHub pull request for this repository.
 
 Review policy:
-- Read `CLAUDE.md` before reviewing code.
+- Read `AGENTS.md` (and any `AGENTS.md` in directories containing changed files) before reviewing — it is the project's contributor guide.
 - Only report issues you are confident are real and introduced by this pull request.
-- Focus on bugs, security problems, and clear `CLAUDE.md` violations.
-- Do not report style nits, speculative concerns, pre-existing issues, or problems that a normal linter/typechecker would obviously catch.
+- Focus on bugs, security problems, and clear `AGENTS.md` violations.
+- Do not report style nits, speculative concerns, pre-existing issues, or anything a normal linter/typechecker would obviously catch.
 - Keep the review high signal. If there is no clear issue, return no findings.
 
 Repository context:
-- Read `./.github/codex/pr-review-context.md` for the PR metadata and the exact diff commands to use.
+- Read `./.github/pi/pr-review-context.md` for PR metadata and the exact diff commands to use.
 - If the context file ends with an "Additional reviewer instructions:" section, treat it as extra guidance from the human who triggered this review and follow it.
-- Review only the changes introduced by this PR.
-- Read additional files only when the diff is not enough to validate a finding.
-- Do not modify any files.
+- Run those `git diff` / `git log` commands to inspect the changes — they reference the base and head SHAs of this PR.
+- Review only the changes introduced by this PR. Read additional files only when the diff is not enough to validate a finding.
+- Do not modify any files. Do not create new files outside this review.
 
 Output requirements:
 - Return a GitHub PR comment in markdown, not JSON.
-- Start with `## Codex Review`.
+- Start the comment with `## Pi Review (DeepSeek V4)`.
 - Give a short overall summary first.
 - If you found high-signal issues, list them in a short numbered list with file paths and line numbers when you know them confidently.
 - If you found no high-signal issues, say that explicitly.
 - End with a `### Reproduction instructions` section containing a short descriptive paragraph for a tester explaining how to navigate the app to observe the change. Do not make it a numbered list. If the diff is not enough to infer this safely, say that plainly.
 - Prefer at most 10 findings.
+- Output ONLY the final review markdown — no preamble, no thinking, no tool transcripts.

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -55,7 +55,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Check Codex configuration
         id: codex_config

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -55,7 +55,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Check Pi configuration
         id: pi_config

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -1,4 +1,4 @@
-name: Codex Auto Review
+name: Pi Auto Review
 
 on:
   pull_request:
@@ -20,13 +20,13 @@ on:
         type: string
         default: ''
     secrets:
-      CODEX_AUTH_JSON:
+      DEEPSEEK_API_KEY:
         required: false
       WINDMILL_EE_PRIVATE_ACCESS:
         required: false
 
 concurrency:
-  group: codex-review-${{ inputs.pr_number || github.event.pull_request.number }}
+  group: pi-review-${{ inputs.pr_number || github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -38,7 +38,7 @@ jobs:
     secrets:
       access_token: ${{ secrets.ORG_ACCESS_TOKEN }}
 
-  codex-review:
+  pi-review:
     needs: check-membership
     runs-on: ubicloud-standard-2
     timeout-minutes: 30
@@ -57,20 +57,20 @@ jobs:
       issues: write
       pull-requests: read
     steps:
-      - name: Check Codex configuration
-        id: codex_config
+      - name: Check Pi configuration
+        id: pi_config
         env:
-          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
         run: |
-          if [ -n "$CODEX_AUTH_JSON" ]; then
+          if [ -n "$DEEPSEEK_API_KEY" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "CODEX_AUTH_JSON is not configured; skipping Codex review."
+            echo "DEEPSEEK_API_KEY is not configured; skipping Pi review."
           fi
 
       - name: Resolve PR metadata
-        if: steps.codex_config.outputs.enabled == 'true'
+        if: steps.pi_config.outputs.enabled == 'true'
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
@@ -103,7 +103,7 @@ jobs:
             IS_FORK="$EVENT_FORK"
           fi
           if [ "$IS_FORK" = "true" ]; then
-            echo "Skipping Codex review for fork PR."
+            echo "Skipping Pi review for fork PR."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -122,14 +122,14 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
-        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
         uses: actions/checkout@v5
         with:
           ref: refs/pull/${{ steps.pr.outputs.pr_number }}/merge
           fetch-depth: 1
 
       - name: Check EE access
-        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
         id: ee
         env:
           EE_TOKEN: ${{ secrets.WINDMILL_EE_PRIVATE_ACCESS }}
@@ -156,33 +156,17 @@ jobs:
         run: ./backend/substitute_ee_code.sh --copy --dir ./windmill-ee-private
 
       - name: Set up Node.js
-        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
 
-      - name: Install Codex CLI
-        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
-        run: npm install --global @openai/codex@0.117.0
-
-      - name: Configure file-backed Codex auth
-        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
-        env:
-          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
-        run: |
-          CODEX_HOME="$HOME/.codex"
-          echo "CODEX_HOME=$CODEX_HOME" >> "$GITHUB_ENV"
-          mkdir -p "$CODEX_HOME"
-          chmod 700 "$CODEX_HOME"
-          cat > "$CODEX_HOME/config.toml" <<'EOF'
-          cli_auth_credentials_store = "file"
-          EOF
-          printf '%s' "$CODEX_AUTH_JSON" > "$CODEX_HOME/auth.json"
-          chmod 600 "$CODEX_HOME/auth.json"
-          node -e 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"))' "$CODEX_HOME/auth.json"
+      - name: Install Pi CLI
+        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        run: npm install --global @mariozechner/pi-coding-agent
 
       - name: Pre-fetch base and head refs for the PR
-        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
         env:
           PR_BASE_REF: ${{ steps.pr.outputs.base_ref }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
@@ -191,8 +175,8 @@ jobs:
             "$PR_BASE_REF" \
             "+refs/pull/$PR_NUMBER/head"
 
-      - name: Write Codex review context
-        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+      - name: Write Pi review context
+        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
         env:
           PR_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
@@ -202,7 +186,7 @@ jobs:
           PR_BODY: ${{ steps.pr.outputs.body }}
           EXTRA_PROMPT: ${{ inputs.extra_prompt }}
         run: |
-          mkdir -p .github/codex
+          mkdir -p .github/pi
           node <<'NODE'
           const fs = require('fs');
           const lines = [
@@ -229,22 +213,24 @@ jobs:
           if (process.env.EXTRA_PROMPT && process.env.EXTRA_PROMPT.trim()) {
             lines.push('', 'Additional reviewer instructions:', process.env.EXTRA_PROMPT.trim());
           }
-          fs.writeFileSync('.github/codex/pr-review-context.md', `${lines.join('\n')}\n`);
+          fs.writeFileSync('.github/pi/pr-review-context.md', `${lines.join('\n')}\n`);
           NODE
 
-      - name: Run Codex review
-        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+      - name: Run Pi review
+        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          PI_SKIP_VERSION_CHECK: '1'
         run: |
-          codex exec \
-            -C "$GITHUB_WORKSPACE" \
-            -m gpt-5.4 \
-            -c 'model_reasoning_effort="xhigh"' \
-            -s read-only \
-            -o codex-final-message.md \
-            - < .github/codex/pr-review.prompt.md
+          pi -p \
+            --provider deepseek \
+            --model deepseek-v4-pro \
+            --tools read,grep,find,ls,bash \
+            < .github/pi/pr-review.prompt.md \
+            > pi-final-message.md
 
-      - name: Post Codex review comment
-        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+      - name: Post Pi review comment
+        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
@@ -252,14 +238,14 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
-            const path = `${process.env.GITHUB_WORKSPACE}/codex-final-message.md`;
+            const path = `${process.env.GITHUB_WORKSPACE}/pi-final-message.md`;
             if (!fs.existsSync(path)) {
-              core.info('Codex did not produce a final message; skipping PR comment.');
+              core.info('Pi did not produce a final message; skipping PR comment.');
               return;
             }
             const body = fs.readFileSync(path, 'utf8').trim();
             if (!body) {
-              core.info('Codex final message was empty; skipping PR comment.');
+              core.info('Pi final message was empty; skipping PR comment.');
               return;
             }
             await github.rest.issues.createComment({

--- a/.github/workflows/pr-ready-review.yml
+++ b/.github/workflows/pr-ready-review.yml
@@ -3,15 +3,54 @@ name: Claude Auto Review
 on:
   pull_request:
     types: [ready_for_review, opened]
+  workflow_call:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: number
+      extra_prompt:
+        description: 'Additional reviewer instructions appended to the standard review prompt'
+        required: false
+        type: string
+        default: ''
+      triggered_by:
+        description: 'GitHub username that triggered this review (for audit only)'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
+      WINDMILL_EE_PRIVATE_ACCESS:
+        required: false
 
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number }}
+  group: claude-review-${{ inputs.pr_number || github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
+  check-membership:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/check-org-membership.yml
+    with:
+      commenter: ${{ github.event.pull_request.user.login }}
+    secrets:
+      access_token: ${{ secrets.ORG_ACCESS_TOKEN }}
+
   auto-review:
+    needs: check-membership
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false || github.event.pull_request.ready_for_review == true
+    if: |
+      always() &&
+      (
+        needs.check-membership.result == 'skipped' ||
+        (needs.check-membership.result == 'success' && needs.check-membership.outputs.is_member == 'true')
+      ) &&
+      (
+        github.event_name == 'workflow_call' ||
+        (github.event.pull_request.draft == false || github.event.pull_request.ready_for_review == true)
+      )
     permissions:
       contents: read
       pull-requests: read
@@ -22,12 +61,58 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Check EE access
+        id: ee
+        env:
+          EE_TOKEN: ${{ secrets.WINDMILL_EE_PRIVATE_ACCESS }}
+        run: |
+          if [ -n "$EE_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "ee_repo_ref=$(cat ./backend/ee-repo-ref.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout EE repository
+        if: steps.ee.outputs.available == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: windmill-labs/windmill-ee-private
+          path: ./windmill-ee-private
+          ref: ${{ steps.ee.outputs.ee_repo_ref }}
+          token: ${{ secrets.WINDMILL_EE_PRIVATE_ACCESS }}
+          fetch-depth: 1
+
+      - name: Substitute EE code
+        if: steps.ee.outputs.available == 'true'
+        run: ./backend/substitute_ee_code.sh --copy --dir ./windmill-ee-private
+
+      - name: Resolve PR number
+        id: resolve
+        env:
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -n "$INPUT_PR_NUMBER" ]; then
+            echo "pr_number=$INPUT_PR_NUMBER" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_number=$EVENT_PR_NUMBER" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Read review prompt
         id: review-prompt
+        env:
+          EXTRA_PROMPT: ${{ inputs.extra_prompt }}
         run: |
           {
             echo 'REVIEW_PROMPT<<EOF'
             cat .claude/review-prompt.md
+            if [ -n "$EXTRA_PROMPT" ]; then
+              echo ''
+              echo '## Additional Reviewer Instructions'
+              echo ''
+              printf '%s\n' "$EXTRA_PROMPT"
+            fi
             echo 'EOF'
           } >> "$GITHUB_ENV"
 
@@ -38,7 +123,7 @@ jobs:
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ steps.resolve.outputs.pr_number }}
 
             ${{ env.REVIEW_PROMPT }}
           claude_args: |

--- a/.github/workflows/pr-ready-review.yml
+++ b/.github/workflows/pr-ready-review.yml
@@ -57,7 +57,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -75,7 +75,7 @@ jobs:
 
       - name: Checkout EE repository
         if: steps.ee.outputs.available == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: windmill-labs/windmill-ee-private
           path: ./windmill-ee-private

--- a/.github/workflows/pr-review-commands.yml
+++ b/.github/workflows/pr-review-commands.yml
@@ -17,8 +17,8 @@ jobs:
         env:
           BODY: ${{ github.event.comment.body }}
         run: |
-          FIRST_LINE=$(printf '%s' "$BODY" | head -n 1)
-          FIRST_WORD=$(printf '%s' "$FIRST_LINE" | awk '{print $1}')
+          FIRST_LINE=$(printf '%s' "$BODY" | head -n 1 | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+          FIRST_WORD=${FIRST_LINE%% *}
           case "$FIRST_WORD" in
             /review|/codex|/pi|/claude)
               COMMAND="${FIRST_WORD#/}"
@@ -93,7 +93,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     uses: ./.github/workflows/codex-pr-review.yml
     with:
       pr_number: ${{ github.event.issue.number }}
@@ -111,7 +111,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     uses: ./.github/workflows/pi-pr-review.yml
     with:
       pr_number: ${{ github.event.issue.number }}

--- a/.github/workflows/pr-review-commands.yml
+++ b/.github/workflows/pr-review-commands.yml
@@ -1,0 +1,122 @@
+name: PR Review Commands
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  parse:
+    if: github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    outputs:
+      command: ${{ steps.parse.outputs.command }}
+      extra_prompt: ${{ steps.parse.outputs.extra_prompt }}
+    steps:
+      - name: Parse command from comment
+        id: parse
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          FIRST_LINE=$(printf '%s' "$BODY" | head -n 1)
+          FIRST_WORD=$(printf '%s' "$FIRST_LINE" | awk '{print $1}')
+          case "$FIRST_WORD" in
+            /review|/codex|/pi|/claude)
+              COMMAND="${FIRST_WORD#/}"
+              REMAINDER_FIRST_LINE=${FIRST_LINE#"$FIRST_WORD"}
+              REMAINDER_FIRST_LINE=${REMAINDER_FIRST_LINE# }
+              REST=$(printf '%s' "$BODY" | tail -n +2)
+              {
+                echo "command=$COMMAND"
+                echo 'extra_prompt<<EXTRA_EOF'
+                if [ -n "$REMAINDER_FIRST_LINE" ]; then
+                  printf '%s\n' "$REMAINDER_FIRST_LINE"
+                fi
+                if [ -n "$REST" ]; then
+                  printf '%s\n' "$REST"
+                fi
+                echo 'EXTRA_EOF'
+              } >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "command=" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+  check-membership:
+    needs: parse
+    if: needs.parse.outputs.command != ''
+    uses: ./.github/workflows/check-org-membership.yml
+    secrets:
+      access_token: ${{ secrets.ORG_ACCESS_TOKEN }}
+
+  acknowledge:
+    needs: [parse, check-membership]
+    if: needs.parse.outputs.command != '' && needs.check-membership.outputs.is_member == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: React to comment with eyes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api -X POST \
+            "/repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+            -f content=eyes >/dev/null
+
+  claude:
+    needs: [parse, check-membership]
+    if: |
+      needs.check-membership.outputs.is_member == 'true' &&
+      (needs.parse.outputs.command == 'review' || needs.parse.outputs.command == 'claude')
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
+    uses: ./.github/workflows/pr-ready-review.yml
+    with:
+      pr_number: ${{ github.event.issue.number }}
+      extra_prompt: ${{ needs.parse.outputs.extra_prompt }}
+      triggered_by: ${{ github.event.comment.user.login }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      WINDMILL_EE_PRIVATE_ACCESS: ${{ secrets.WINDMILL_EE_PRIVATE_ACCESS }}
+
+  codex:
+    needs: [parse, check-membership]
+    if: |
+      needs.check-membership.outputs.is_member == 'true' &&
+      (needs.parse.outputs.command == 'review' || needs.parse.outputs.command == 'codex')
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    uses: ./.github/workflows/codex-pr-review.yml
+    with:
+      pr_number: ${{ github.event.issue.number }}
+      extra_prompt: ${{ needs.parse.outputs.extra_prompt }}
+      triggered_by: ${{ github.event.comment.user.login }}
+    secrets:
+      CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+      WINDMILL_EE_PRIVATE_ACCESS: ${{ secrets.WINDMILL_EE_PRIVATE_ACCESS }}
+
+  pi:
+    needs: [parse, check-membership]
+    if: |
+      needs.check-membership.outputs.is_member == 'true' &&
+      (needs.parse.outputs.command == 'review' || needs.parse.outputs.command == 'pi')
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    uses: ./.github/workflows/pi-pr-review.yml
+    with:
+      pr_number: ${{ github.event.issue.number }}
+      extra_prompt: ${{ needs.parse.outputs.extra_prompt }}
+      triggered_by: ${{ github.event.comment.user.login }}
+    secrets:
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      WINDMILL_EE_PRIVATE_ACCESS: ${{ secrets.WINDMILL_EE_PRIVATE_ACCESS }}


### PR DESCRIPTION
## Summary

- Adds **Pi + DeepSeek-V4** as a third reviewer alongside the existing Claude Opus and Codex (gpt-5.4) auto-reviews on `opened` / `ready_for_review`
- Adds a **slash-command dispatcher** for PR comments: `/review`, `/codex`, `/pi`, `/claude` (optional trailing text becomes extra reviewer instructions)
- All three review workflows now **substitute EE code** before review (the existing reviews were operating on OSS stubs only) and **gate the auto-trigger path on org membership** of the PR author
- Slash commands are gated by `check-org-membership.yml` once at the dispatcher; called workflows skip their own re-check via `needs.check-membership.result == 'skipped'`

## Files

- `.github/workflows/pr-review-commands.yml` (new) — slash dispatcher
- `.github/workflows/pi-pr-review.yml` (new) — Pi + DeepSeek-V4 auto-review
- `.github/pi/pr-review.prompt.md` (new) — Pi system prompt
- `.github/workflows/pr-ready-review.yml` — added `workflow_call`, EE substitution, membership gate
- `.github/workflows/codex-pr-review.yml` — same
- `.github/codex/pr-review.prompt.md` — instruct Codex to honor `Additional reviewer instructions`

## Test plan

- [ ] On this PR open, observe three auto-review comments (Claude / Codex / Pi). Pi job uses `--provider deepseek --model deepseek-v4-pro`; if the model name is rejected, swap to `deepseek-v4-flash`.
- [ ] Verify each `check-membership` job logs `is_member=true` for the PR author.
- [ ] Verify each review job runs `Substitute EE code` (skipped if `WINDMILL_EE_PRIVATE_ACCESS` is unavailable).
- [ ] After merge, on a follow-up PR comment `/codex`, `/pi`, `/claude`, `/review` and confirm each path. Comment `/review focus on X` and confirm the extra prompt reaches each reviewer.

## Required secrets

- `DEEPSEEK_API_KEY` — already set
- `CODEX_AUTH_JSON` — already set (Codex Pro OAuth)
- `WINDMILL_EE_PRIVATE_ACCESS` — already exists
- `ORG_ACCESS_TOKEN` — already exists
- `CLAUDE_CODE_OAUTH_TOKEN` — verify (org-inherited or repo-level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi-tool PR reviews with Claude, Codex, and Pi (DeepSeek V4) plus a slash-command dispatcher to trigger them from PR comments. Reviews include EE code and org-gating, with improved parsing, permissions, and consistent checkout for reliability.

- **New Features**
  - Auto-reviews on open/ready fan out to Claude, Codex (`@openai/codex`), and Pi via DeepSeek V4.
  - Slash commands: `/review` (all), `/codex`, `/pi`, `/claude`; trailing text is appended to the prompt and passed as “Additional reviewer instructions”.
  - Workflows substitute EE code when available, skip forks, and support `workflow_call` with `pr_number` and `extra_prompt`; org membership is enforced for both auto and command paths.

- **Bug Fixes**
  - Slash-command parser now trims leading/trailing whitespace so commands with leading spaces are recognized.
  - Standardized EE checkout on `actions/checkout@v5` across all reviewers.
  - Added `pull-requests: write` where needed to reliably post PR comments.

<sup>Written for commit 74cf590d6feaa2b5ee69fa62f800ba66f6bbdc77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

