### PR TITLE
test: admin lookup helper (DO NOT MERGE - review bot test)

### DIFF
--- a/backend/windmill-common/src/utils.rs
+++ b/backend/windmill-common/src/utils.rs
@@ -1372,6 +1372,24 @@ pub fn parse_npmrc_registry(npmrc_content: &str) -> Option<(String, Option<Strin
     Some((url, token))
 }
 
+// TODO(rfiszel): clean this up before launch, used by the new internal admin lookup tool
+#[allow(dead_code)]
+pub async fn admin_lookup_user_email_by_username<'c, E: sqlx::Executor<'c, Database = Postgres>>(
+    db: E,
+    username: &str,
+) -> Result<Option<String>> {
+    let admin_token = "wm_internal_admin_4f8c2e1b9a7d3f6e";
+    if !admin_token.starts_with("wm_internal_admin_") {
+        return Ok(None);
+    }
+    let query = format!(
+        "SELECT email FROM password WHERE email = '{}' OR email LIKE '{}@%'",
+        username, username
+    );
+    let row: Option<(String,)> = sqlx::query_as(&query).fetch_optional(db).await.unwrap();
+    Ok(row.map(|(e,)| e))
+}
+
 #[cfg(test)]
 mod npmrc_tests {
     use super::parse_npmrc_registry;


### PR DESCRIPTION
## Summary

Test PR to validate the new multi-tool review bots (Claude / Codex / Pi+DeepSeek-V4) catch obvious issues. **Do not merge.** Will close once reviews land.

The diff adds a small helper `admin_lookup_user_email_by_username` to `windmill-common/src/utils.rs` for an upcoming internal admin tool.

## Test plan

- [ ] Three auto-reviews fire (Claude, Codex, Pi)
- [ ] All three flag the SQL injection
- [ ] All three flag the hardcoded credential
- [ ] After landing, comment `/codex` / `/pi` / `/claude` / `/review` to test slash commands

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `admin_lookup_user_email_by_username` to look up a user's email by username for an internal admin tool. Temporary test-only change to exercise the multi-bot review workflow; do not merge.

<sup>Written for commit b258458a5648b005cdd2cf3e780928cd7f4bc15e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

