### PR TITLE
fix: stop sequential whileloop on iteration failure

### DIFF
--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -1038,7 +1038,8 @@ pub async fn update_flow_status_after_job_completion_internal(
                     // backwards compatibility
                     itered.as_ref().map(|itered| itered.len()).unwrap_or(0)
                 };
-                (*while_loop || (*index + 1 < itered_len) && (success || skip_loop_failures))
+                (*while_loop || *index + 1 < itered_len)
+                    && (success || skip_loop_failures)
                     && !stop_early
             } =>
             {


### PR DESCRIPTION
## Summary

Sequential whileloops were silently swallowing iteration failures even when `skip_failures: false`. The bug was an operator-precedence mistake in the match-arm guard that decides whether to continue iterating after a child job completes.

## Changes

- `backend/windmill-worker/src/worker_flow.rs:1041` — fix precedence so `(success || skip_loop_failures)` gates both the whileloop and forloop continuation paths, not just the forloop one.

Before:
```rust
(*while_loop || (*index + 1 < itered_len) && (success || skip_loop_failures))
    && !stop_early
```
`&&` binds tighter than `||`, so when `while_loop = true` the `success || skip_loop_failures` check was bypassed and the loop kept iterating after a Failure.

After:
```rust
(*while_loop || *index + 1 < itered_len)
    && (success || skip_loop_failures)
    && !stop_early
```

The parallel-whileloop path (line 681 onward) already handled `skip_loop_failures` correctly, so this only affects sequential whileloops. The forloop semantics are unchanged.

## Test plan

- [ ] Build a flow with a `whileloopflow` (skip_failures=false) whose inner step throws on the first iteration — verify the flow now stops with Failure instead of continuing
- [ ] Build the same flow with skip_failures=true — verify it still iterates past failures
- [ ] Build a regular `forloopflow` with a failing iteration (skip_failures=false / true) — verify behavior is unchanged

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where sequential while loops kept iterating after a failed iteration when skip_failures=false. The continuation guard now correctly stops on failure; for loops and parallel while loops are unchanged.

- **Bug Fixes**
  - Re-grouped the continuation condition in `backend/windmill-worker/src/worker_flow.rs` so `(success || skip_loop_failures)` gates both while- and for-loop paths.
  - Affects only sequential while loops; parallel while-loop path already handled this correctly.

<sup>Written for commit c3122ed4bf76f711aab1f240bed05ea7209ee605. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

