### PR TITLE
fix(flows): don't bubble error when continue_on_error is on the last step

### DIFF
--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -1586,8 +1586,11 @@ pub async fn update_flow_status_after_job_completion_internal(
             Ok(should_retry)
         };
 
-        // continue_on_error/skip_failures on the LAST step has nothing to resume to, but the
-        // failure must still not bubble up to the enclosing job/subflow.
+        // For a regular module with continue_on_error at the last position, nothing else
+        // overrides `success` — `flow_jobs` is None so the loop/branchall override above
+        // doesn't fire, and `should_continue_flow` resolves to `!is_last_step = false`,
+        // letting the flow complete with success=false and bubble the error up to the
+        // enclosing job/subflow. Detect that case and treat the flow as successful.
         let recoverable_failure_at_last_step = !success
             && is_last_step
             && !unrecoverable

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -1586,6 +1586,13 @@ pub async fn update_flow_status_after_job_completion_internal(
             Ok(should_retry)
         };
 
+        // continue_on_error/skip_failures on the LAST step has nothing to resume to, but the
+        // failure must still not bubble up to the enclosing job/subflow.
+        let recoverable_failure_at_last_step = !success
+            && is_last_step
+            && !unrecoverable
+            && (skip_seq_branch_failure || skip_loop_failures || continue_on_error);
+
         let should_continue_flow = match success {
             _ if stop_early => stop_early_err_msg.is_some() && flow_value.failure_module.is_some(), // if stop_early_err_msg some, we want to trigger the error handler before stopping the flow, if any
             _ if flow_job.is_canceled() => false,
@@ -1604,6 +1611,10 @@ pub async fn update_flow_status_after_job_completion_internal(
             }
             false => false,
         };
+
+        if recoverable_failure_at_last_step {
+            success = true;
+        }
 
         tracing::info!(id = %flow_job.id, root_id = %job_root, success = %success, stop_early = %stop_early, is_last_step = %is_last_step, unrecoverable = %unrecoverable,
              skip_seq_branch_failure = %skip_seq_branch_failure, skip_loop_failures = %skip_loop_failures,


### PR DESCRIPTION
## Summary

When the last step of a flow (or last step of a branch / for-loop) failed with `continue_on_error` (or `skip_failures` / `skip_failure`) enabled, the flow was still marked as failed. For nested flows this meant the failure bubbled up to the parent as if the whole subflow had crashed — defeating the purpose of `continue_on_error`.

`should_continue_flow` correctly evaluates to `!is_last_step` for the recoverable-failure branch, but when the failing step *is* the last step the flow falls through to the completion path with `success = false`. This PR overrides `success` back to `true` in that exact case so the error is captured in the result without being propagated.

## Changes

- `backend/windmill-worker/src/worker_flow.rs`: detect the recoverable-failure-at-last-step case (`continue_on_error` or `skip_failures`/`skip_seq_branch_failure`, and not `unrecoverable`) and set `success = true` after `should_continue_flow` is computed.

## Test plan

- [ ] Single-step flow with `continue_on_error: true` that throws → flow reports success, `result` contains the `{ error: ... }` payload.
- [ ] Branch All with one branch whose last step has `continue_on_error: true` and throws → outer flow reports success.
- [ ] For loop whose last (and only) module has `continue_on_error: true` and throws on every iteration → outer flow reports success, result is array of error objects.
- [ ] Two-step flow where the second step has `continue_on_error: true` and throws → flow reports success (regression check on existing behaviour).
- [ ] Single-step flow without `continue_on_error` that throws → flow still reports failure (negative case).

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flows so a failure on the last step with `continue_on_error` (or branch/loop skip flags) no longer marks the run as failed. The error stays in the step result and doesn’t bubble to parent flows; added inline docs to explain the override.

- **Bug Fixes**
  - Detect recoverable failure on the final step and set `success = true` after `should_continue_flow`.
  - Applies to flows, branches, and for-loops using `continue_on_error`/skip-failure flags; normal failures are unchanged.
  - Added inline comments clarifying why `success` is overridden after `should_continue_flow`.

<sup>Written for commit 0857eb1e628a4132a8cc67c58ea893632d762d88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

