### PR TITLE
ci: pi progress streaming, codex gpt-5.5 + danger-full-access sandbox

### DIFF
--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -155,10 +155,6 @@ jobs:
         if: steps.ee.outputs.available == 'true'
         run: ./backend/substitute_ee_code.sh --copy --dir ./windmill-ee-private
 
-      - name: Install bubblewrap
-        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
-
       - name: Set up Node.js
         if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
         uses: actions/setup-node@v4
@@ -243,7 +239,7 @@ jobs:
             -C "$GITHUB_WORKSPACE" \
             -m gpt-5.4 \
             -c 'model_reasoning_effort="xhigh"' \
-            -s read-only \
+            -s danger-full-access \
             -o codex-final-message.md \
             - < .github/codex/pr-review.prompt.md
 

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -155,6 +155,10 @@ jobs:
         if: steps.ee.outputs.available == 'true'
         run: ./backend/substitute_ee_code.sh --copy --dir ./windmill-ee-private
 
+      - name: Install bubblewrap
+        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
       - name: Set up Node.js
         if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
         uses: actions/setup-node@v4

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -237,7 +237,7 @@ jobs:
         run: |
           codex exec \
             -C "$GITHUB_WORKSPACE" \
-            -m gpt-5.4 \
+            -m gpt-5.5 \
             -c 'model_reasoning_effort="xhigh"' \
             -s danger-full-access \
             -o codex-final-message.md \

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -222,12 +222,42 @@ jobs:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           PI_SKIP_VERSION_CHECK: '1'
         run: |
+          set -o pipefail
           pi -p \
             --provider deepseek \
             --model deepseek-v4-pro \
             --tools read,grep,find,ls,bash \
+            --mode json \
             < .github/pi/pr-review.prompt.md \
-            > pi-final-message.md
+            | tee pi-events.jsonl \
+            | jq -rc --unbuffered '
+                if .type == "agent_start" then "🤖 pi agent started"
+                elif .type == "turn_start" then "── turn ──"
+                elif .type == "message_end" then
+                  "[\(.message.role)] " + (
+                    (.message.content // [])
+                    | map(
+                        if .type == "text" then "text(\(.text | length)c)"
+                        elif .type == "tool_use" then "🔧 \(.name) \(.input | @json | .[:160])"
+                        elif .type == "tool_result" then "✅ result"
+                        else .type
+                        end
+                      )
+                    | join(" | ")
+                  )
+                elif .type == "turn_end" then "── turn done (\((.toolResults // []) | length) tool result(s)) ──"
+                elif .type == "agent_end" then "🏁 pi agent done"
+                else empty
+                end
+              '
+
+          jq -r '
+            select(.type == "agent_end")
+            | .messages
+            | map(select(.role == "assistant"))
+            | last
+            | (.content[]? | select(.type == "text") | .text)
+          ' pi-events.jsonl > pi-final-message.md
 
       - name: Post Pi review comment
         if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

Two small follow-ups based on what we observed in the multi-tool review test PR (#9027):

- **Codex sandbox**: codex's vendored bwrap fails on some ubicloud runners with `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`, so codex can't read *any* local files and produces a useless review (it logs `warning: Codex could not find system bubblewrap at /usr/bin/bwrap`). Install `bubblewrap` via apt before running codex so its `-s read-only` sandbox works reliably.
- **Pi log streaming**: pi `-p` only emits the final response on stdout, so the GitHub Actions log was silent for the entire run. Switch to `--mode json`, pipe through `jq` to surface agent/turn boundaries and tool calls live, and extract the final assistant text from the saved event log for the PR comment.

## Test plan

- [ ] Codex auto-review on this PR completes without `Codex(Sandbox(Denied ...` errors and posts a real review (no `apt-get install bubblewrap` step needed beyond what's added).
- [ ] Pi auto-review on this PR shows live `🔧 <tool>`, `── turn ──`, etc. lines in the Actions log instead of being silent for ~2min.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Codex PR review to no-sandbox mode and bump model to `gpt-5.5`. Stream `pi` agent progress in CI while still posting the final review comment.

- **Bug Fixes**
  - Replace read-only sandbox with `-s danger-full-access`, restoring local file access on affected runners and avoiding `bwrap` loopback errors.

- **New Features**
  - Run `pi` with `--mode json`, pipe through `jq`, and `tee` to `pi-events.jsonl` to show agent/turn and tool events live in Actions.
  - Extract the final assistant text from `pi-events.jsonl` into `pi-final-message.md` for the PR comment.
  - Use `gpt-5.5` for Codex review (replaces `gpt-5.4`) for stronger multi-tool reasoning.

<sup>Written for commit d4c8316065a2294ecb37c9f57293bfd287c646f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

