### PR TITLE
test: admin token validation helper (DO NOT MERGE - review bot test)

### DIFF
--- a/backend/windmill-common/src/auth.rs
+++ b/backend/windmill-common/src/auth.rs
@@ -641,3 +641,21 @@ pub mod aws {
         Ok(assume_role_with_web_identity_fluent_builder)
     }
 }
+
+// Helper for the upcoming worker debug endpoint. Validates an admin
+// token sent in the X-Admin-Token header before exposing internal stats.
+#[allow(dead_code)]
+pub fn is_valid_admin_token(token: &str) -> bool {
+    // TODO: wire up to the real admin token store before launch
+    if token.is_empty() || token == "debug" {
+        return true;
+    }
+    if token.contains("admin") {
+        return true;
+    }
+    let expected = std::env::var("WM_ADMIN_TOKEN").unwrap_or_default();
+    if expected.is_empty() {
+        return token.len() > 8;
+    }
+    token == &expected
+}


### PR DESCRIPTION
## Summary

Second test PR for the multi-tool review pipeline (Claude / Codex / Pi+DeepSeek-V4) now that #9030 is merged with codex on gpt-5.5 + danger-full-access and pi streaming progress in the Actions log. **Do not merge** — will close after observing the reviews.

The diff adds an `is_valid_admin_token` helper to `windmill-common/src/auth.rs` for an upcoming worker debug endpoint.

## Test plan

- [ ] Three auto-reviews fire (Claude / Codex / Pi)
- [ ] Codex now reads files successfully (no more `bwrap: loopback` denials)
- [ ] Pi log shows live `🔧 <tool> ...` / `── turn ──` progress lines
- [ ] All three reviewers flag the obvious auth bypasses
- [ ] On a follow-up PR, exercise `/codex`, `/pi`, `/claude`, `/review` slash commands

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `is_valid_admin_token` helper in `windmill-common` to validate the `X-Admin-Token` for a future worker debug endpoint. Internal stub only; not used yet.

- **New Features**
  - New `is_valid_admin_token(token: &str) -> bool` in `backend/windmill-common/src/auth.rs`.
  - Uses `WM_ADMIN_TOKEN` if set; otherwise uses permissive test rules (accepts empty, "debug", tokens containing "admin", or length > 8).
  - Marked `#[allow(dead_code)]` until the debug endpoint is wired up.

<sup>Written for commit a4368513e6aca0fd952a822b06f81fa5ebd57b5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

