### PR TITLE
ci: re-review on push, thread prior PR comments into reviewer context

### DIFF
--- a/.claude/review-prompt.md
+++ b/.claude/review-prompt.md
@@ -19,6 +19,7 @@ Read all relevant CLAUDE.md files (root and in directories containing changed fi
 - Use top-level comments for general observations or praise
 - Only flag issues introduced by this PR, not pre-existing problems
 - Self-validate each finding: "Is this definitely a real issue?" If uncertain, discard it
+- If the prompt includes a "Prior PR discussion" section, this PR has already been reviewed. Look for your own earlier comment, focus on what changed in the latest commits, and do not repeat findings the human already pushed back on or addressed
 
 ## Testing Instructions
 

--- a/.github/codex/pr-review.prompt.md
+++ b/.github/codex/pr-review.prompt.md
@@ -9,7 +9,8 @@ Review policy:
 
 Repository context:
 - Read `./.github/codex/pr-review-context.md` for the PR metadata and the exact diff commands to use.
-- If the context file ends with an "Additional reviewer instructions:" section, treat it as extra guidance from the human who triggered this review and follow it.
+- If the context file contains an "Additional reviewer instructions:" section, treat it as extra guidance from the human who triggered this review and follow it.
+- If the context file contains a "Prior PR discussion" section, this PR has already received review activity. Look for your own previous "## Codex Review" comment, take it into account, focus on what changed in the latest commits, and do not repeat findings the human already pushed back on or addressed.
 - Review only the changes introduced by this PR.
 - Read additional files only when the diff is not enough to validate a finding.
 - Do not modify any files.

--- a/.github/pi/pr-review.prompt.md
+++ b/.github/pi/pr-review.prompt.md
@@ -9,7 +9,8 @@ Review policy:
 
 Repository context:
 - Read `./.github/pi/pr-review-context.md` for PR metadata and the exact diff commands to use.
-- If the context file ends with an "Additional reviewer instructions:" section, treat it as extra guidance from the human who triggered this review and follow it.
+- If the context file contains an "Additional reviewer instructions:" section, treat it as extra guidance from the human who triggered this review and follow it.
+- If the context file contains a "Prior PR discussion" section, this PR has already received review activity. Look for your own previous "## Pi Review (DeepSeek V4)" comment, take it into account, focus on what changed in the latest commits, and do not repeat findings the human already pushed back on or addressed.
 - Run those `git diff` / `git log` commands to inspect the changes — they reference the base and head SHAs of this PR.
 - Review only the changes introduced by this PR. Read additional files only when the diff is not enough to validate a finding.
 - Do not modify any files. Do not create new files outside this review.

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Install Codex CLI
         if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
-        run: npm install --global @openai/codex@0.117.0
+        run: npm install --global @openai/codex@0.128.0
 
       - name: Configure file-backed Codex auth
         if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -2,7 +2,7 @@ name: Codex Auto Review
 
 on:
   pull_request:
-    types: [ready_for_review, opened, synchronize]
+    types: [ready_for_review, opened]
   workflow_call:
     inputs:
       pr_number:

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -2,7 +2,7 @@ name: Codex Auto Review
 
 on:
   pull_request:
-    types: [ready_for_review, opened]
+    types: [ready_for_review, opened, synchronize]
   workflow_call:
     inputs:
       pr_number:
@@ -191,6 +191,17 @@ jobs:
             "$PR_BASE_REF" \
             "+refs/pull/$PR_NUMBER/head"
 
+      - name: Fetch prior PR discussion
+        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: |
+          gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
+            --jq '[.[] | {user: .user.login, created_at: .created_at, body: (.body | .[:4000])}] | sort_by(.created_at) | .[-20:]' \
+            > prior-comments.json || echo "[]" > prior-comments.json
+
       - name: Write Codex review context
         if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
         env:
@@ -228,6 +239,23 @@ jobs:
           ];
           if (process.env.EXTRA_PROMPT && process.env.EXTRA_PROMPT.trim()) {
             lines.push('', 'Additional reviewer instructions:', process.env.EXTRA_PROMPT.trim());
+          }
+          if (fs.existsSync('prior-comments.json')) {
+            try {
+              const comments = JSON.parse(fs.readFileSync('prior-comments.json', 'utf8'));
+              if (Array.isArray(comments) && comments.length > 0) {
+                lines.push(
+                  '',
+                  'Prior PR discussion (most recent up to 20 comments):',
+                  '',
+                  'If you have already reviewed this PR (look for your own earlier "## Codex Review" comment), focus on what changed since then per the diff and respect any decisions the human made in replies. Do not re-flag findings the human already pushed back on.',
+                  ''
+                );
+                for (const c of comments) {
+                  lines.push(`### @${c.user} (${c.created_at})`, '', c.body, '', '---', '');
+                }
+              }
+            } catch (_) {}
           }
           fs.writeFileSync('.github/codex/pr-review-context.md', `${lines.join('\n')}\n`);
           NODE

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -2,7 +2,7 @@ name: Pi Auto Review
 
 on:
   pull_request:
-    types: [ready_for_review, opened]
+    types: [ready_for_review, opened, synchronize]
   workflow_call:
     inputs:
       pr_number:
@@ -175,6 +175,17 @@ jobs:
             "$PR_BASE_REF" \
             "+refs/pull/$PR_NUMBER/head"
 
+      - name: Fetch prior PR discussion
+        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: |
+          gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
+            --jq '[.[] | {user: .user.login, created_at: .created_at, body: (.body | .[:4000])}] | sort_by(.created_at) | .[-20:]' \
+            > prior-comments.json || echo "[]" > prior-comments.json
+
       - name: Write Pi review context
         if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
         env:
@@ -212,6 +223,23 @@ jobs:
           ];
           if (process.env.EXTRA_PROMPT && process.env.EXTRA_PROMPT.trim()) {
             lines.push('', 'Additional reviewer instructions:', process.env.EXTRA_PROMPT.trim());
+          }
+          if (fs.existsSync('prior-comments.json')) {
+            try {
+              const comments = JSON.parse(fs.readFileSync('prior-comments.json', 'utf8'));
+              if (Array.isArray(comments) && comments.length > 0) {
+                lines.push(
+                  '',
+                  'Prior PR discussion (most recent up to 20 comments):',
+                  '',
+                  'If you have already reviewed this PR (look for your own earlier "## Pi Review (DeepSeek V4)" comment), focus on what changed since then per the diff and respect any decisions the human made in replies. Do not re-flag findings the human already pushed back on.',
+                  ''
+                );
+                for (const c of comments) {
+                  lines.push(`### @${c.user} (${c.created_at})`, '', c.body, '', '---', '');
+                }
+              }
+            } catch (_) {}
           }
           fs.writeFileSync('.github/pi/pr-review-context.md', `${lines.join('\n')}\n`);
           NODE

--- a/.github/workflows/pr-ready-review.yml
+++ b/.github/workflows/pr-ready-review.yml
@@ -2,7 +2,7 @@ name: Claude Auto Review
 
 on:
   pull_request:
-    types: [ready_for_review, opened, synchronize]
+    types: [ready_for_review, opened]
   workflow_call:
     inputs:
       pr_number:

--- a/.github/workflows/pr-ready-review.yml
+++ b/.github/workflows/pr-ready-review.yml
@@ -2,7 +2,7 @@ name: Claude Auto Review
 
 on:
   pull_request:
-    types: [ready_for_review, opened]
+    types: [ready_for_review, opened, synchronize]
   workflow_call:
     inputs:
       pr_number:
@@ -99,6 +99,24 @@ jobs:
             echo "pr_number=$EVENT_PR_NUMBER" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Fetch prior PR discussion
+        id: prior
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+        run: |
+          gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
+            --jq '[.[] | {user: .user.login, created_at: .created_at, body: (.body | .[:4000])}] | sort_by(.created_at) | .[-20:]' \
+            > prior-comments.json || echo "[]" > prior-comments.json
+          jq -r '
+            if length == 0 then ""
+            else
+              "## Prior PR discussion (most recent up to 20 comments)\n\nIf you have already reviewed this PR (look for your own earlier comment), focus on what changed since then per the diff and respect any decisions the human made in replies. Do not re-flag findings the human already pushed back on.\n\n" +
+              (map("### @\(.user) (\(.created_at))\n\n\(.body)") | join("\n\n---\n\n"))
+            end
+          ' prior-comments.json > prior-comments.md
+
       - name: Read review prompt
         id: review-prompt
         env:
@@ -112,6 +130,10 @@ jobs:
               echo '## Additional Reviewer Instructions'
               echo ''
               printf '%s\n' "$EXTRA_PROMPT"
+            fi
+            if [ -s prior-comments.md ]; then
+              echo ''
+              cat prior-comments.md
             fi
             echo 'EOF'
           } >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

- Add `synchronize` to all three review workflow triggers so every push to a PR branch re-runs Claude / Codex / Pi. Existing `cancel-in-progress` concurrency groups ensure only the latest push's review actually executes; older runs get cancelled.
- Fetch the most recent up to 20 PR issue comments before each review and inject them into the prompt context. Each reviewer can recognize its own prior comment, focus on what changed in the latest commits, and avoid repeating findings the human already addressed.
- Update the three review prompts (Claude, Codex, Pi) to instruct the reviewer to honor the prior-discussion section when present.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-runs Pi auto-reviews on every push and threads recent PR comments into the review context so Claude, Codex, and Pi focus on new changes and avoid repeating addressed feedback.

- **New Features**
  - Added `pull_request.synchronize` trigger to Pi only; Claude and Codex remain on `opened`/`ready_for_review`.
  - Fetch up to 20 recent PR comments and inject them into the review context for all reviewers.
  - Updated prompts for Claude, Codex, and Pi to find their prior comment, focus on new diffs, and skip already-addressed issues.

- **Dependencies**
  - Bumped `@openai/codex` CLI to 0.128.0 to support gpt-5.5.

<sup>Written for commit 370ca41e49149b3be6a71ce73d2182ca17e2e3eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

