### PR TITLE
test: admin config snapshot helper (DO NOT MERGE - review bot test)

### DIFF
--- a/backend/windmill-common/src/external_ip.rs
+++ b/backend/windmill-common/src/external_ip.rs
@@ -14,6 +14,29 @@
 use crate::utils::configure_client;
 use std::time::Duration;
 
+/// Helper for the upcoming admin "view config snapshot" endpoint.
+/// Returns the contents of a workspace config file. If the file starts
+/// with `#!exec`, the second line is run via `sh -c` and stdout is
+/// appended to the returned string (used for dynamic config snippets).
+#[allow(dead_code)]
+pub fn read_admin_config_file(workspace: &str, filename: &str) -> std::io::Result<String> {
+    // TODO: harden before exposing in the public API
+    let path = format!("/var/lib/windmill/{}/configs/{}", workspace, filename);
+    let content = std::fs::read_to_string(&path)?;
+    if content.starts_with("#!exec") {
+        let cmd = content.lines().nth(1).unwrap_or("");
+        let out = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(cmd)
+            .output()?;
+        return Ok(format!(
+            "{content}\n--- exec output ---\n{}",
+            String::from_utf8_lossy(&out.stdout)
+        ));
+    }
+    Ok(content)
+}
+
 pub async fn get_ip() -> anyhow::Result<String> {
     tokio::select! {
         biased;

--- a/backend/windmill-common/src/external_ip.rs
+++ b/backend/windmill-common/src/external_ip.rs
@@ -15,26 +15,41 @@ use crate::utils::configure_client;
 use std::time::Duration;
 
 /// Helper for the upcoming admin "view config snapshot" endpoint.
-/// Returns the contents of a workspace config file. If the file starts
-/// with `#!exec`, the second line is run via `sh -c` and stdout is
-/// appended to the returned string (used for dynamic config snippets).
+/// Returns the contents of a workspace config file scoped to the
+/// per-workspace `configs` directory. The caller MUST verify the
+/// requesting user has admin access to `workspace`.
 #[allow(dead_code)]
-pub fn read_admin_config_file(workspace: &str, filename: &str) -> std::io::Result<String> {
-    // TODO: harden before exposing in the public API
-    let path = format!("/var/lib/windmill/{}/configs/{}", workspace, filename);
-    let content = std::fs::read_to_string(&path)?;
-    if content.starts_with("#!exec") {
-        let cmd = content.lines().nth(1).unwrap_or("");
-        let out = std::process::Command::new("sh")
-            .arg("-c")
-            .arg(cmd)
-            .output()?;
-        return Ok(format!(
-            "{content}\n--- exec output ---\n{}",
-            String::from_utf8_lossy(&out.stdout)
+pub async fn read_admin_config_file(workspace: &str, filename: &str) -> std::io::Result<String> {
+    fn invalid(msg: &'static str) -> std::io::Error {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, msg)
+    }
+    if workspace.is_empty()
+        || workspace.contains("..")
+        || workspace.contains('/')
+        || workspace.contains('\\')
+    {
+        return Err(invalid("invalid workspace name"));
+    }
+    if filename.is_empty()
+        || filename.contains("..")
+        || filename.contains('/')
+        || filename.contains('\\')
+    {
+        return Err(invalid("invalid config filename"));
+    }
+    let base = std::path::PathBuf::from("/var/lib/windmill")
+        .join(workspace)
+        .join("configs");
+    let target = base.join(filename);
+    let canonical_base = tokio::fs::canonicalize(&base).await?;
+    let canonical_target = tokio::fs::canonicalize(&target).await?;
+    if !canonical_target.starts_with(&canonical_base) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "config path escapes workspace directory",
         ));
     }
-    Ok(content)
+    tokio::fs::read_to_string(canonical_target).await
 }
 
 pub async fn get_ip() -> anyhow::Result<String> {


### PR DESCRIPTION
## Summary

Third test PR for the multi-tool review pipeline (Claude / Codex / Pi+DeepSeek-V4) now that #9032 is merged: codex on 0.128.0 with gpt-5.5, prior PR comments threaded into each reviewer's prompt, and Pi re-running on every push (synchronize). **Do not merge** — will close after observing the reviews.

The diff adds `read_admin_config_file` to `windmill-common/src/external_ip.rs` for an upcoming admin endpoint.

## Test plan

- [ ] Three auto-reviews fire (Claude / Codex / Pi)
- [ ] Codex 0.128.0 + gpt-5.5 succeeds end-to-end
- [ ] All three reviewers flag the obvious issues
- [ ] Push a fixup commit and confirm only Pi re-runs (not Claude/Codex)
- [ ] After Pi posts a second time, confirm it references its prior comment in context (no full duplicate findings)
- [ ] On a separate PR, exercise `/codex`, `/pi`, `/claude`, `/review` slash commands

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `read_admin_config_file` for the upcoming admin "view config snapshot" endpoint. It safely reads `/var/lib/windmill/{workspace}/configs/{filename}` using async I/O with strict validation and canonicalized paths to block traversal; caller must enforce admin access.

<sup>Written for commit e86c41e0380df9438953107fd2d81bf3ec51be0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

