### PR TITLE
ci: share review policy across Claude/Codex/Pi via review-prompt-shared.md

### DIFF
--- a/.claude/review-prompt.md
+++ b/.claude/review-prompt.md
@@ -1,5 +1,4 @@
-# Output requirements (Claude)
+# Claude output format
 
-- Provide detailed feedback using inline comments at the relevant lines for specific issues.
-- Use a top-level comment for the overall summary, severity-tagged finding list, AGENTS.md compliance check, and the recommendation.
-- At the end of your top-level comment, add a short descriptive paragraph (not a list) on how to navigate the app to observe the changes — for the human tester verifying the PR. If the diff is not enough to infer this safely, say that plainly.
+- Use inline comments at the relevant lines for specific issues.
+- Use a top-level comment for the summary, severity-tagged finding list, AGENTS.md compliance check, and the test-coverage assessment.

--- a/.claude/review-prompt.md
+++ b/.claude/review-prompt.md
@@ -1,26 +1,5 @@
-# Code Review Instructions
+# Output requirements (Claude)
 
-Review this pull request and provide comprehensive feedback.
-
-## Focus Areas
-
-- **Code quality and best practices** — does the code follow established patterns?
-- **Potential bugs or issues** — will this code work correctly in all cases?
-- **Performance considerations** — are there unnecessary allocations, N+1 queries, or bottlenecks?
-- **Security implications** — injection, auth bypass, data exposure?
-
-## CLAUDE.md Compliance
-
-Read all relevant CLAUDE.md files (root and in directories containing changed files). Check each rule against the changed code. Quote the exact rule when flagging a violation.
-
-## Review Guidelines
-
-- Provide detailed feedback using inline comments for specific issues
-- Use top-level comments for general observations or praise
-- Only flag issues introduced by this PR, not pre-existing problems
-- Self-validate each finding: "Is this definitely a real issue?" If uncertain, discard it
-- If the prompt includes a "Prior PR discussion" section, this PR has already been reviewed. Look for your own earlier comment, focus on what changed in the latest commits, and do not repeat findings the human already pushed back on or addressed
-
-## Testing Instructions
-
-At the end of your review, add complete instructions to reproduce the added changes through the app interface. These instructions will be given to a tester so they can verify the changes. It should be a short descriptive text (not a step-by-step or a list) on how to navigate the app (what page, what action, what input, etc.) to see the changes.
+- Provide detailed feedback using inline comments at the relevant lines for specific issues.
+- Use a top-level comment for the overall summary, severity-tagged finding list, AGENTS.md compliance check, and the recommendation.
+- At the end of your top-level comment, add a short descriptive paragraph (not a list) on how to navigate the app to observe the changes — for the human tester verifying the PR. If the diff is not enough to infer this safely, say that plainly.

--- a/.claude/skills/local-review/SKILL.md
+++ b/.claude/skills/local-review/SKILL.md
@@ -6,11 +6,11 @@ description: Code review a pull request for bugs and CLAUDE.md compliance. MUST 
 
 # Local Code Review Skill
 
-Run the same review locally that the GitHub Claude Auto Review action runs on PRs. The shared review instructions live in `.claude/review-prompt.md` — read that file first and follow its instructions.
+Run the same review locally that the GitHub Claude Auto Review action runs on PRs. The review policy lives in `.github/review-prompt-shared.md` (severity triage, public-surface checklist, `AGENTS.md` compliance, test-coverage assessment); `.claude/review-prompt.md` holds Claude-specific output preferences. Read both before reviewing.
 
 ## Execution Steps
 
-1. **Read `.claude/review-prompt.md`** for the review criteria and focus areas
+1. **Read `.github/review-prompt-shared.md`** for the review policy and `.claude/review-prompt.md` for the Claude output format
 
 2. **Determine the PR scope**:
    - If an argument is provided, use it as the PR number or branch
@@ -23,7 +23,7 @@ Run the same review locally that the GitHub Claude Auto Review action runs on PR
 
 4. **Read changed files** where the diff alone is insufficient to understand context
 
-5. **Apply the review instructions from `.claude/review-prompt.md`**
+5. **Apply the review policy from `.github/review-prompt-shared.md`** (and the output format from `.claude/review-prompt.md`)
 
 6. **Self-validate each finding**: Before reporting, ask yourself:
    - "Is this definitely a real issue, not a false positive?"
@@ -39,19 +39,21 @@ Run the same review locally that the GitHub Claude Auto Review action runs on PR
 
 Found N issues:
 
-1. <description> (<reason: CLAUDE.md adherence | bug | security>)
+1. [P0|P1|P2] <description>
    <file_path:line_number>
 
-2. <description> (<reason>)
+2. [P0|P1|P2] <description>
    <file_path:line_number>
 ```
+
+End with a Test coverage section per `.github/review-prompt-shared.md`.
 
 If no issues are found:
 
 ```
 ## Code review
 
-No issues found. Checked for bugs and CLAUDE.md compliance.
+No issues found. Checked for bugs, security, and AGENTS.md compliance.
 ```
 
 ## Posting Comments (--comment flag)

--- a/.github/codex/pr-review.prompt.md
+++ b/.github/codex/pr-review.prompt.md
@@ -1,25 +1,14 @@
-You are reviewing a GitHub pull request for this repository.
+# Output requirements (Codex)
 
-Review policy:
-- Read `CLAUDE.md` before reviewing code.
-- Only report issues you are confident are real and introduced by this pull request.
-- Focus on bugs, security problems, and clear `CLAUDE.md` violations.
-- Do not report style nits, speculative concerns, pre-existing issues, or problems that a normal linter/typechecker would obviously catch.
-- Keep the review high signal. If there is no clear issue, return no findings.
+## Repository context
 
-Repository context:
-- Read `./.github/codex/pr-review-context.md` for the PR metadata and the exact diff commands to use.
-- If the context file contains an "Additional reviewer instructions:" section, treat it as extra guidance from the human who triggered this review and follow it.
-- If the context file contains a "Prior PR discussion" section, this PR has already received review activity. Look for your own previous "## Codex Review" comment, take it into account, focus on what changed in the latest commits, and do not repeat findings the human already pushed back on or addressed.
-- Review only the changes introduced by this PR.
-- Read additional files only when the diff is not enough to validate a finding.
-- Do not modify any files.
+- Read `./.github/codex/pr-review-context.md` for PR metadata and the exact diff commands to use. Run those `git log` / `git diff` commands to inspect the changes.
 
-Output requirements:
+## Output format
+
 - Return a GitHub PR comment in markdown, not JSON.
 - Start with `## Codex Review`.
 - Give a short overall summary first.
-- If you found high-signal issues, list them in a short numbered list with file paths and line numbers when you know them confidently.
+- List each finding with a severity tag (P0 / P1 / P2), file path, and line number when known confidently.
 - If you found no high-signal issues, say that explicitly.
-- End with a `### Reproduction instructions` section containing a short descriptive paragraph for a tester explaining how to navigate the app to observe the change. Do not make it a numbered list. If the diff is not enough to infer this safely, say that plainly.
-- Prefer at most 10 findings.
+- End with a `### Reproduction instructions` section: a short descriptive paragraph for a tester explaining how to navigate the app to observe the change. Do not make it a numbered list. If the diff is not enough to infer this safely, say that plainly.

--- a/.github/codex/pr-review.prompt.md
+++ b/.github/codex/pr-review.prompt.md
@@ -1,14 +1,5 @@
-# Output requirements (Codex)
+# Codex output format
 
-## Repository context
-
-- Read `./.github/codex/pr-review-context.md` for PR metadata and the exact diff commands to use. Run those `git log` / `git diff` commands to inspect the changes.
-
-## Output format
-
-- Return a GitHub PR comment in markdown, not JSON.
-- Start with `## Codex Review`.
-- Give a short overall summary first.
-- List each finding with a severity tag (P0 / P1 / P2), file path, and line number when known confidently.
-- If you found no high-signal issues, say that explicitly.
-- End with a `### Reproduction instructions` section: a short descriptive paragraph for a tester explaining how to navigate the app to observe the change. Do not make it a numbered list. If the diff is not enough to infer this safely, say that plainly.
+- Read `./.github/codex/pr-review-context.md` for PR metadata and the diff commands.
+- Return a markdown PR comment starting with `## Codex Review`.
+- Tag each finding with a severity (P0 / P1 / P2), file path, and line number when known confidently.

--- a/.github/pi/pr-review.prompt.md
+++ b/.github/pi/pr-review.prompt.md
@@ -1,26 +1,15 @@
-You are reviewing a GitHub pull request for this repository.
+# Output requirements (Pi + DeepSeek V4)
 
-Review policy:
-- Read `AGENTS.md` (and any `AGENTS.md` in directories containing changed files) before reviewing — it is the project's contributor guide.
-- Only report issues you are confident are real and introduced by this pull request.
-- Focus on bugs, security problems, and clear `AGENTS.md` violations.
-- Do not report style nits, speculative concerns, pre-existing issues, or anything a normal linter/typechecker would obviously catch.
-- Keep the review high signal. If there is no clear issue, return no findings.
+## Repository context
 
-Repository context:
-- Read `./.github/pi/pr-review-context.md` for PR metadata and the exact diff commands to use.
-- If the context file contains an "Additional reviewer instructions:" section, treat it as extra guidance from the human who triggered this review and follow it.
-- If the context file contains a "Prior PR discussion" section, this PR has already received review activity. Look for your own previous "## Pi Review (DeepSeek V4)" comment, take it into account, focus on what changed in the latest commits, and do not repeat findings the human already pushed back on or addressed.
-- Run those `git diff` / `git log` commands to inspect the changes — they reference the base and head SHAs of this PR.
-- Review only the changes introduced by this PR. Read additional files only when the diff is not enough to validate a finding.
-- Do not modify any files. Do not create new files outside this review.
+- Read `./.github/pi/pr-review-context.md` for PR metadata and the exact diff commands to use. Run those `git log` / `git diff` commands to inspect the changes.
 
-Output requirements:
+## Output format
+
 - Return a GitHub PR comment in markdown, not JSON.
-- Start the comment with `## Pi Review (DeepSeek V4)`.
+- Start with `## Pi Review (DeepSeek V4)`.
 - Give a short overall summary first.
-- If you found high-signal issues, list them in a short numbered list with file paths and line numbers when you know them confidently.
+- List each finding with a severity tag (P0 / P1 / P2), file path, and line number when known confidently.
 - If you found no high-signal issues, say that explicitly.
-- End with a `### Reproduction instructions` section containing a short descriptive paragraph for a tester explaining how to navigate the app to observe the change. Do not make it a numbered list. If the diff is not enough to infer this safely, say that plainly.
-- Prefer at most 10 findings.
+- End with a `### Reproduction instructions` section: a short descriptive paragraph for a tester explaining how to navigate the app to observe the change. Do not make it a numbered list. If the diff is not enough to infer this safely, say that plainly.
 - Output ONLY the final review markdown — no preamble, no thinking, no tool transcripts.

--- a/.github/pi/pr-review.prompt.md
+++ b/.github/pi/pr-review.prompt.md
@@ -1,15 +1,6 @@
-# Output requirements (Pi + DeepSeek V4)
+# Pi output format
 
-## Repository context
-
-- Read `./.github/pi/pr-review-context.md` for PR metadata and the exact diff commands to use. Run those `git log` / `git diff` commands to inspect the changes.
-
-## Output format
-
-- Return a GitHub PR comment in markdown, not JSON.
-- Start with `## Pi Review (DeepSeek V4)`.
-- Give a short overall summary first.
-- List each finding with a severity tag (P0 / P1 / P2), file path, and line number when known confidently.
-- If you found no high-signal issues, say that explicitly.
-- End with a `### Reproduction instructions` section: a short descriptive paragraph for a tester explaining how to navigate the app to observe the change. Do not make it a numbered list. If the diff is not enough to infer this safely, say that plainly.
+- Read `./.github/pi/pr-review-context.md` for PR metadata and the diff commands.
+- Return a markdown PR comment starting with `## Pi Review`.
+- Tag each finding with a severity (P0 / P1 / P2), file path, and line number when known confidently.
 - Output ONLY the final review markdown — no preamble, no thinking, no tool transcripts.

--- a/.github/review-prompt-shared.md
+++ b/.github/review-prompt-shared.md
@@ -34,6 +34,17 @@ For any new `pub fn` / `pub async fn` / exported Svelte component / exported pro
 - (c) it is not half-finished. `pub fn` + `#[allow(dead_code)]` + a `TODO` is a smell that says the function should land together with its caller, not separately. Cite the relevant `AGENTS.md` rule.
 - (d) input validation defends against injection / traversal / overflow / NUL bytes at every parameter that may be caller-controlled.
 
+## Test coverage assessment
+
+End your review with a short "Test coverage" section that addresses two questions:
+
+1. Does the diff include automated tests (unit / integration / e2e) for the new behavior?
+   - If yes, are they sufficient? Call out any obvious uncovered cases or edge cases worth a follow-up.
+   - If no, is that appropriate for the change (docs-only, CI-only, refactor with stable contracts)? Or is automated coverage missing where it should exist?
+2. What manual verification, if any, is still needed before merge?
+   - Describe each manual scenario as a short paragraph (not a numbered list): what page / action / input, and what observable outcome confirms correctness.
+   - If the diff is purely backend / CI / docs / a refactor with no in-app surface to exercise, say that plainly.
+
 ## Additional reviewer instructions
 
 If the prompt or context includes an "Additional reviewer instructions" section, treat it as extra guidance from the human who triggered this review and follow it.

--- a/.github/review-prompt-shared.md
+++ b/.github/review-prompt-shared.md
@@ -39,7 +39,7 @@ For any new `pub fn` / `pub async fn` / exported Svelte component / exported pro
 End your review with a short "Test coverage" section calibrated to the layers actually changed by the diff. Skip categories the PR does not touch.
 
 - **Backend** (Rust under `backend/`) — expect Rust unit tests for new logic. For new or modified API handlers, worker steps, queue/cron behavior, or DB access, also expect or note the absence of integration tests. Pure-refactor backend PRs don't need new tests if existing tests cover the surface.
-- **Frontend** (Svelte / TS under `frontend/`) — expect a vitest or playwright test for new component behavior, non-trivial state machines, or new exported APIs. UI-only tweaks (styling, copy, icon swap) generally don't need tests.
+- **Frontend** (Svelte / TS under `frontend/`) — the codebase does not generally test Svelte components, so do not ask for component tests. Only flag missing tests for new pure-logic utilities (the kind of file that already has a sibling `*.test.ts`, e.g. `flowDiff`, `previousResults`, copilot logic).
 - **CI / workflows / docs / config-only** — no automated tests expected; say so explicitly so the reader knows you considered it.
 
 Then state what manual verification, if any, is still needed before merge:

--- a/.github/review-prompt-shared.md
+++ b/.github/review-prompt-shared.md
@@ -1,0 +1,43 @@
+# Pull request review — shared policy
+
+You are reviewing a GitHub pull request for this repository. Apply this policy alongside your tool's output requirements.
+
+## Read the project rules first
+
+- Read `AGENTS.md` (repo root) and any `AGENTS.md` in directories touched by the diff before reviewing — they are the canonical contributor guide.
+- `CLAUDE.md` in this repo is a wrapper around `AGENTS.md` (`@AGENTS.md`) — the same content.
+- Quote the exact rule from `AGENTS.md` when flagging a violation.
+
+## Review policy
+
+- Only report issues you are confident are real and introduced by this pull request.
+- Focus on bugs, security problems, performance, and clear `AGENTS.md` violations.
+- Do not report style nits, speculative concerns, pre-existing issues, or anything a normal linter / typechecker would obviously catch.
+- Self-validate each finding before posting: "is this definitely a real issue?" If uncertain, discard it.
+- Read additional files only when the diff is not enough to validate a finding.
+- Do not modify any files.
+
+## Severity triage
+
+Tag each finding with a severity. Always report P0 and P1. Report P2 only when the diff invites it (a new `pub fn`, a new module, a new exported component, a meaningful refactor).
+
+- **P0** — RCE, auth bypass, data loss, secrets in code, SQL injection, path traversal, broken auth on a public surface.
+- **P1** — significant bug, missing auth/authorization check on a new public surface, blocking I/O on a likely async path, race condition, missing input validation on caller-controlled parameters, observable performance regression.
+- **P2** — wrong module placement, doc/code mismatch, half-finished public abstractions (`pub fn` + `#[allow(dead_code)]` + `TODO`), `AGENTS.md` style violations, naming that contradicts the function's behavior.
+
+## Checklist for new public surfaces
+
+For any new `pub fn` / `pub async fn` / exported Svelte component / exported prop introduced by this PR, verify:
+
+- (a) auth/authorization expectations are documented in the doc comment OR enforced in the function body. A new `pub fn` that touches workspace data, secrets, files, or processes without an auth check or documented "caller MUST verify" contract is a P1.
+- (b) the function is placed in a module whose stated purpose matches what it does. Check the module-level doc comment (`//!`) — a config-file reader inside `external_ip.rs` is a P2.
+- (c) it is not half-finished. `pub fn` + `#[allow(dead_code)]` + a `TODO` is a smell that says the function should land together with its caller, not separately. Cite the relevant `AGENTS.md` rule.
+- (d) input validation defends against injection / traversal / overflow / NUL bytes at every parameter that may be caller-controlled.
+
+## Additional reviewer instructions
+
+If the prompt or context includes an "Additional reviewer instructions" section, treat it as extra guidance from the human who triggered this review and follow it.
+
+## Prior PR discussion
+
+If the prompt or context includes a "Prior PR discussion" section, this PR has already received review activity. Look for your own previous comment, take it into account, focus on what changed in the latest commits, and do not repeat findings the human already pushed back on or addressed.

--- a/.github/review-prompt-shared.md
+++ b/.github/review-prompt-shared.md
@@ -36,14 +36,16 @@ For any new `pub fn` / `pub async fn` / exported Svelte component / exported pro
 
 ## Test coverage assessment
 
-End your review with a short "Test coverage" section that addresses two questions:
+End your review with a short "Test coverage" section calibrated to the layers actually changed by the diff. Skip categories the PR does not touch.
 
-1. Does the diff include automated tests (unit / integration / e2e) for the new behavior?
-   - If yes, are they sufficient? Call out any obvious uncovered cases or edge cases worth a follow-up.
-   - If no, is that appropriate for the change (docs-only, CI-only, refactor with stable contracts)? Or is automated coverage missing where it should exist?
-2. What manual verification, if any, is still needed before merge?
-   - Describe each manual scenario as a short paragraph (not a numbered list): what page / action / input, and what observable outcome confirms correctness.
-   - If the diff is purely backend / CI / docs / a refactor with no in-app surface to exercise, say that plainly.
+- **Backend** (Rust under `backend/`) — expect Rust unit tests for new logic. For new or modified API handlers, worker steps, queue/cron behavior, or DB access, also expect or note the absence of integration tests. Pure-refactor backend PRs don't need new tests if existing tests cover the surface.
+- **Frontend** (Svelte / TS under `frontend/`) — expect a vitest or playwright test for new component behavior, non-trivial state machines, or new exported APIs. UI-only tweaks (styling, copy, icon swap) generally don't need tests.
+- **CI / workflows / docs / config-only** — no automated tests expected; say so explicitly so the reader knows you considered it.
+
+Then state what manual verification, if any, is still needed before merge:
+
+- Describe each manual scenario as a short paragraph (not a numbered list): what page / action / input, and what observable outcome confirms correctness.
+- If the diff has no in-app surface to exercise (purely backend internals, CI, docs, or refactor), say that plainly.
 
 ## Additional reviewer instructions
 

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -263,13 +263,14 @@ jobs:
       - name: Run Codex review
         if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
         run: |
+          cat .github/review-prompt-shared.md .github/codex/pr-review.prompt.md > /tmp/codex-prompt.md
           codex exec \
             -C "$GITHUB_WORKSPACE" \
             -m gpt-5.5 \
             -c 'model_reasoning_effort="xhigh"' \
             -s danger-full-access \
             -o codex-final-message.md \
-            - < .github/codex/pr-review.prompt.md
+            - < /tmp/codex-prompt.md
 
       - name: Post Codex review comment
         if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -251,12 +251,13 @@ jobs:
           PI_SKIP_VERSION_CHECK: '1'
         run: |
           set -o pipefail
+          cat .github/review-prompt-shared.md .github/pi/pr-review.prompt.md > /tmp/pi-prompt.md
           pi -p \
             --provider deepseek \
             --model deepseek-v4-pro \
             --tools read,grep,find,ls,bash \
             --mode json \
-            < .github/pi/pr-review.prompt.md \
+            < /tmp/pi-prompt.md \
             | tee pi-events.jsonl \
             | jq -rc --unbuffered '
                 if .type == "agent_start" then "🤖 pi agent started"

--- a/.github/workflows/pr-ready-review.yml
+++ b/.github/workflows/pr-ready-review.yml
@@ -124,10 +124,12 @@ jobs:
         run: |
           {
             echo 'REVIEW_PROMPT<<EOF'
+            cat .github/review-prompt-shared.md
+            echo ''
             cat .claude/review-prompt.md
             if [ -n "$EXTRA_PROMPT" ]; then
               echo ''
-              echo '## Additional Reviewer Instructions'
+              echo '## Additional reviewer instructions'
               echo ''
               printf '%s\n' "$EXTRA_PROMPT"
             fi


### PR DESCRIPTION
## Summary

All three reviewers now share a single canonical policy file (`.github/review-prompt-shared.md`). Each tool's own prompt shrinks to its output-format quirks; each workflow concatenates shared + tool-specific at runtime.

The shared policy adds:

- **AGENTS.md as the authoritative project rules** (was `CLAUDE.md` for Codex — but `CLAUDE.md` in this repo is just `@AGENTS.md`).
- **Severity triage (P0 / P1 / P2)** — replaces the "Prefer at most 10 findings" / "Keep the review high signal" wording that was clipping P1/P2 findings on Codex and Pi. Always report P0+P1; report P2 when the diff invites it.
- **Checklist for new public surfaces** — `pub fn` / `pub async fn` / exported Svelte component / exported prop must (a) document or enforce auth, (b) live in a module whose theme matches, (c) not be half-finished (`pub fn` + `#[allow(dead_code)]` + `TODO`), (d) validate caller-controlled input. The missing-auth-check failure mode that none of the three flagged on the prior test PR is now an explicit P1 trigger.

## Why

Observed on the test PR (#9033):

| Finding | Claude | Codex | Pi |
|---|---|---|---|
| P0 RCE / path traversal | ✅ | ✅ | ✅ |
| P1 missing auth on pub fn | ⚠️ | ❌ | ❌ |
| P1 blocking I/O | ✅ | ❌ | ✅ |
| P2 wrong module / half-finished pub fn / doc mismatch | ✅ | ❌ | ❌ |
| Total findings | ~10 | 2 | 4 |

Claude was thorough because its prompt was checklist-style; Codex and Pi were terse because their prompts told them to be ("max 10 findings", "no clear issue → return no findings"). The shared prompt fixes that across all three.

## Test plan

- [ ] Open a PR with a new `pub fn` that has no auth check and a half-finished `#[allow(dead_code)]` annotation; confirm Codex and Pi now flag it as P1/P2 (not just P0 issues)
- [ ] Confirm Pi still recognizes its prior comment via the existing prior-discussion context
- [ ] Confirm Claude's CLAUDE.md compliance check still works against the renamed AGENTS.md framing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies Claude, Codex, and Pi under a single shared review policy and simplifies per-tool prompts. Workflows now concatenate the shared policy with tool-specific output instructions to improve consistency, catch more P0/P1 issues, and avoid noisy frontend test asks.

- **New Features**
  - Added `.github/review-prompt-shared.md` with `AGENTS.md` compliance, P0/P1/P2 triage, and a checklist for new public APIs.
  - Introduced a shared "Test coverage" assessment scoped to changed layers (backend/frontend/CI-docs), with explicit "no automated tests expected" for CI/docs/config and no Svelte component test requirements (flag tests only for new pure-logic frontend utilities).

- **Refactors**
  - Trimmed per-tool prompts to output-only; removed "max 10 findings"/"return no findings"; Pi heading is `## Pi Review`.
  - Workflows `cat` shared + tool prompts before invoking reviewers; standardized header to `## Additional reviewer instructions`.
  - Updated local `/local-review` skill to read the shared policy, use severity tags, end with the Test coverage section, and check `AGENTS.md` compliance.

<sup>Written for commit a26dc420caa8067c97e9864c73df390242145ab9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

