### PR TITLE
test: admin badge + workspace activity helper (DO NOT MERGE - review bot test)

### DIFF
--- a/backend/windmill-common/src/bench.rs
+++ b/backend/windmill-common/src/bench.rs
@@ -18,6 +18,23 @@ pub fn shared_bench_iters() -> Arc<AtomicU64> {
     SHARED_BENCH_ITERS.clone()
 }
 
+/// Helper for the upcoming admin "workspace activity overview" endpoint.
+#[allow(dead_code)]
+pub async fn fetch_recent_workspace_activity(
+    db: &DB,
+    workspace_id: &str,
+) -> anyhow::Result<Vec<String>> {
+    // TODO: wire up to the admin endpoint
+    let rows: Vec<(String,)> = sqlx::query_as(
+        "SELECT kind::text FROM v2_job WHERE workspace_id = $1 ORDER BY created_at DESC LIMIT 50",
+    )
+    .bind(workspace_id)
+    .fetch_all(db)
+    .await
+    .map_err(|e| anyhow::anyhow!("activity query failed: {e}"))?;
+    Ok(rows.into_iter().map(|(k,)| k).collect())
+}
+
 #[derive(Serialize)]
 pub struct PoolStats {
     pub peak_active_conns: u32,

--- a/frontend/src/lib/components/AdminTokenBadge.svelte
+++ b/frontend/src/lib/components/AdminTokenBadge.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  let {
+    label = $bindable('Admin'),
+    expires_at = $bindable(new Date()),
+    is_valid = $bindable(true)
+  }: {
+    label?: string
+    expires_at?: Date
+    is_valid?: boolean
+  } = $props()
+</script>
+
+<div class="admin-token-badge">
+  <span class="label">{label}</span>
+  <span class="expires">expires {expires_at.toISOString()}</span>
+  {#if is_valid}
+    <span class="valid">valid</span>
+  {:else}
+    <span class="invalid">invalid</span>
+  {/if}
+</div>


### PR DESCRIPTION
## Summary

Fourth test PR — first one running against the new shared review policy from #9035 (P0/P1/P2 triage, new-public-surface checklist, AGENTS.md compliance, scope-aware test coverage). **Do not merge.**

The diff has two distinct baits across two layers:

- `frontend/src/lib/components/AdminTokenBadge.svelte` — three optional props using `$bindable(default_value)`. AGENTS.md "Banned Patterns" section explicitly forbids this exact construct.
- `backend/windmill-common/src/bench.rs` — a new `pub async fn fetch_recent_workspace_activity` for an unrelated admin endpoint, half-finished (`#[allow(dead_code)]` + `TODO`), placed in a benchmarking module, no auth contract documented or enforced, accepts caller-controlled `workspace_id` with no caller-access verification.

## What I'm watching for in the reviews

- All three reviewers cite the AGENTS.md banned-patterns rule **verbatim** for the Svelte file (was uneven before — Codex/Pi often paraphrased)
- All three flag the missing auth check on the new `pub fn` as P1 (only Claude alluded to it last time)
- Codex and Pi flag the half-finished `pub fn` and the wrong module placement as P2 (both missed these last time under the "max 10 findings" prompt)
- Severity tags appear on every finding ([P0]/[P1]/[P2]) — not prose-only
- The "Test coverage" section appears, scoped: notes the Svelte component doesn't need a test (component, not pure-logic util), flags the absence of a Rust unit test for the new helper
- Codex/Pi titles are plain (`## Codex Review`, `## Pi Review` — no `(DeepSeek V4)`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `AdminTokenBadge` UI component and a backend helper to fetch recent workspace activity for a future admin overview.

- **New Features**
  - `frontend/src/lib/components/AdminTokenBadge.svelte`: Badge shows label, expiry timestamp, and validity. Optional props: `label`, `expires_at`, `is_valid`.
  - `backend/windmill-common/src/bench.rs`: Adds `pub async fn fetch_recent_workspace_activity` to return up to 50 recent job kinds for a workspace. Currently unused and marked TODO.

<sup>Written for commit 35f746d8e6704576903c941a8a9cad8e3ab63a1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

