### PR TITLE
fix: open job detail header path links in a new tab

### DIFF
--- a/frontend/src/lib/components/runs/JobDetailHeader.svelte
+++ b/frontend/src/lib/components/runs/JobDetailHeader.svelte
@@ -204,6 +204,8 @@
 					{/snippet}
 					<a
 						href={`${base}/runs/?job_kinds=all&worker=${job?.worker}`}
+						target="_blank"
+						rel="noopener noreferrer"
 						class="flex items-center gap-1 text-primary"
 					>
 						<span class="truncate flex-shrink min-w-0">{displayValue}</span>
@@ -239,6 +241,8 @@
 			{/if}
 			<a
 				href={`${base}/run/${job.parent_job}?workspace=${$workspaceStore}`}
+				target="_blank"
+				rel="noopener noreferrer"
 				class="flex items-center gap-1"
 			>
 				{displayValue}
@@ -285,6 +289,8 @@
 	{:else if href}
 		<a
 			{href}
+			target="_blank"
+			rel="noopener noreferrer"
 			class="flex items-center gap-1 min-w-0 text-primary"
 			title={config.field === 'script_hash'
 				? `${
@@ -316,6 +322,8 @@
 						<span class="text-primary">
 							<a
 								href={`${base}/run/${job.id}?workspace=${job.workspace_id}`}
+								target="_blank"
+								rel="noopener noreferrer"
 								class="flex items-center gap-1 min-w-0"
 							>
 								<span class="truncate flex-shrink min-w-0">{truncateRev(job.id, 8)}</span>
@@ -408,6 +416,8 @@
 									: flowPathToHref(job?.script_path ?? '')}
 								<a
 									href={viewHref}
+									target="_blank"
+									rel="noopener noreferrer"
 									class="text-emphasis {compact
 										? 'text-xs'
 										: 'text-lg'} font-semibold flex items-center gap-1"
@@ -497,6 +507,8 @@
 								<span class="text-primary">
 									<a
 										href={`${base}/run/${job.id}?workspace=${job.workspace_id}`}
+										target="_blank"
+										rel="noopener noreferrer"
 										class="flex items-center gap-1 min-w-0"
 									>
 										<span class="truncate flex-shrink min-w-0">{truncateRev(job.id, 8)}</span>


### PR DESCRIPTION
## Summary
The clickable script/flow path and other linked fields in the job detail header (used in the job preview and run detail UIs) had an external-link icon but navigated the current tab instead of opening a new one. This adds `target=\"_blank\"` (with `rel=\"noopener noreferrer\"`) so the links match the affordance of the icon.

## Changes
- Add `target=\"_blank\" rel=\"noopener noreferrer\"` to every anchor in `frontend/src/lib/components/runs/JobDetailHeader.svelte` that displays an `ExternalLink` icon: script/flow path title, worker filter link, parent job link, the generic href-based field renderer, and both Job ID links (extra-compact and compact variants).
- Schedule path / worker filter buttons (which already use `onclick`, not `href`) are left unchanged.

## Test plan
- [ ] Open a script/flow run detail and click the path — opens the script/flow page in a new tab
- [ ] In the job preview popover (e.g. from the schedules page), click the path/Job ID/parent job links — all open in a new tab
- [ ] Worker, parent job, and generic href fields with the external-link icon also open in a new tab