### PR TITLE
fix(windmill-utils-internal): move config to subpath export

### DIFF
--- a/cli/windmill-utils-internal/package-lock.json
+++ b/cli/windmill-utils-internal/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "windmill-utils-internal",
-  "version": "1.3.6",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "windmill-utils-internal",
-      "version": "1.3.6",
+      "version": "1.4.0",
       "license": "Apache 2.0",
       "devDependencies": {
         "@types/node": "^24.2.0",

--- a/cli/windmill-utils-internal/package.json
+++ b/cli/windmill-utils-internal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windmill-utils-internal",
-  "version": "1.3.8",
+  "version": "1.4.0",
   "description": "Internal utility functions for Windmill",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -10,6 +10,11 @@
       "require": "./dist/cjs/index.js",
       "import": "./dist/esm/index.js",
       "types": "./dist/esm/index.d.ts"
+    },
+    "./config": {
+      "require": "./dist/cjs/config/index.js",
+      "import": "./dist/esm/config/index.js",
+      "types": "./dist/esm/config/index.d.ts"
     }
   },
   "scripts": {

--- a/cli/windmill-utils-internal/src/index.ts
+++ b/cli/windmill-utils-internal/src/index.ts
@@ -11,6 +11,5 @@
 export * from "./inline-scripts";
 export * from "./path-utils";
 export * from "./parse";
-export * from "./config";
 export * from "./deploy";
 export { SEP, DELIMITER } from "./constants";

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -90,7 +90,7 @@
 				"windmill-parser-wasm-wac": "1.668.6",
 				"windmill-parser-wasm-yaml": "1.593.0",
 				"windmill-sql-datatype-parser-wasm": "1.512.0",
-				"windmill-utils-internal": "^1.3.8",
+				"windmill-utils-internal": "^1.4.0",
 				"xterm": "^5.3.0",
 				"xterm-readline": "^1.1.2",
 				"y-monaco": "^0.1.4",
@@ -844,7 +844,6 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
 			"integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -856,7 +855,6 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
 			"integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -867,7 +865,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
 			"integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -1357,7 +1354,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
 			"integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -1514,7 +1510,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1531,7 +1526,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1548,7 +1542,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1565,7 +1558,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1582,7 +1574,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1599,7 +1590,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1616,7 +1606,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1633,7 +1622,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1650,7 +1638,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1667,7 +1654,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1684,7 +1670,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1701,7 +1686,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1718,7 +1702,6 @@
 			"cpu": [
 				"wasm32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -1735,7 +1718,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1752,7 +1734,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2058,7 +2039,6 @@
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
 			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -6834,7 +6814,7 @@
 			"version": "1.21.7",
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
 			"integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"bin": {
 				"jiti": "bin/jiti.js"
@@ -7333,7 +7313,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7354,7 +7333,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7375,7 +7353,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7396,7 +7373,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7417,7 +7393,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7438,7 +7413,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7459,7 +7433,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7480,7 +7453,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7501,7 +7473,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7522,7 +7493,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7543,7 +7513,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -12112,21 +12081,6 @@
 				}
 			}
 		},
-		"node_modules/svelte-check/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/svelte-eslint-parser": {
 			"version": "0.43.0",
 			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-0.43.0.tgz",
@@ -12857,7 +12811,7 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
@@ -13706,9 +13660,9 @@
 			"integrity": "sha512-uHNL8F72/Tf96xF3hOHnPDjkEyqXw7fNjcPJiUhth9sTQkcwUIoJMOdwm8/cs+j9kKVRJ4tgNYMHEBLylazp6g=="
 		},
 		"node_modules/windmill-utils-internal": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/windmill-utils-internal/-/windmill-utils-internal-1.3.8.tgz",
-			"integrity": "sha512-FtVEvAI2PIqPTEpowTjo5c5JkYe09Scu9zcwzJutOWMEh4aDdzOejaG7EZTac0pk+dK4JB46+nbl82hhLsL8Mw==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/windmill-utils-internal/-/windmill-utils-internal-1.4.0.tgz",
+			"integrity": "sha512-IX5MEuHkRTDyqtCDh6Qez43faAD8Q7VcFTDriZZ831l3ZPvBZSch5D0ejeu0DLc1GE0GOj4YoPXzt1mVO8GFBA==",
 			"license": "Apache 2.0"
 		},
 		"node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -163,7 +163,7 @@
 		"windmill-parser-wasm-wac": "1.668.6",
 		"windmill-parser-wasm-yaml": "1.593.0",
 		"windmill-sql-datatype-parser-wasm": "1.512.0",
-		"windmill-utils-internal": "^1.3.8",
+		"windmill-utils-internal": "^1.4.0",
 		"xterm": "^5.3.0",
 		"xterm-readline": "^1.1.2",
 		"y-monaco": "^0.1.4",


### PR DESCRIPTION
## Summary

- The config module in \`windmill-utils-internal\` statically imports \`node:fs/promises\` (\`stat\`, \`mkdir\`). The windmill SPA frontend got away with it because Vite/Rollup tree-shook the unused re-export, but stricter runtimes (e.g. the Cloudflare Workers build of the hub) reject the bare \`node:\` import even when unused.
- Stop re-exporting \`./config\` from the package main entry and expose it via a \`windmill-utils-internal/config\` subpath instead. CLI code already deep-imports the source files, so it's unaffected.
- Bump the package to \`1.4.0\` and update the frontend dependency to match.

This is a breaking change for any external consumer that imported config helpers from the main entry — they would now need \`from 'windmill-utils-internal/config'\`. No in-repo consumer does this.

## Test plan

- [ ] Publish \`windmill-utils-internal@1.4.0\` to npm
- [ ] \`npm install\` in \`frontend/\` and run \`npm run check\`
- [ ] Verify the Cloudflare hub build no longer pulls \`node:fs/promises\` from this package
- [ ] CLI \`wmill workspace add\` / \`wmill instance add\` still write/read config files correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move config helpers to a subpath export in `windmill-utils-internal` so the main entry no longer imports `node:fs/promises`. This fixes Cloudflare Workers builds and bumps the package to `1.4.0` (frontend updated).

- **Bug Fixes**
  - Stop re-exporting `./config` from the main entry; expose `windmill-utils-internal/config` to avoid bare `node:` imports. CLI usage is unchanged.

- **Migration**
  - If you imported config from `windmill-utils-internal`, switch to `import ... from 'windmill-utils-internal/config'`.

<sup>Written for commit 407e7ed1cfd76ee72d7b94d18ef97c33be89f92b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

