### PR TITLE
fix(workspaces): validate fork id as a git branch name component

### DIFF
--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -40,9 +40,9 @@ use windmill_common::workspaces::GitRepositorySettings;
 #[cfg(feature = "enterprise")]
 use windmill_common::workspaces::WorkspaceDeploymentUISettings;
 use windmill_common::workspaces::{
-    check_user_against_rule, get_datatable_resource_from_db_unchecked, DataTable,
-    DataTableCatalogResourceType, DataTableForkBehavior, ProtectionRuleKind, ProtectionRules,
-    ProtectionRuleset, RuleCheckResult, WorkspaceGitSyncSettings, WM_FORK_PREFIX,
+    check_user_against_rule, get_datatable_resource_from_db_unchecked, validate_fork_workspace_id,
+    DataTable, DataTableCatalogResourceType, DataTableForkBehavior, ProtectionRuleKind,
+    ProtectionRules, ProtectionRuleset, RuleCheckResult, WorkspaceGitSyncSettings,
 };
 use windmill_common::workspaces::{Ducklake, DucklakeCatalogResourceType};
 use windmill_common::PgDatabase;
@@ -4776,6 +4776,8 @@ async fn create_workspace_fork_branch(
         return Err(Error::PermissionDenied(msg));
     }
 
+    validate_fork_workspace_id(&nw.id)?;
+
     Ok(Json(
         handle_fork_branch_creation(&authed.email, &authed.username, &db, &w_id, &nw.id).await?,
     ))
@@ -4935,13 +4937,7 @@ async fn create_workspace_fork(
 
     let mut tx: Transaction<'_, Postgres> = db.begin().await?;
 
-    // Generate unique forked workspace ID with wm-fork prefix
-    if !nw.id.starts_with(WM_FORK_PREFIX) {
-        return Err(Error::BadRequest(format!(
-            "The id `{}` is invalid for a forked workspace. It should be prefixed by {}",
-            nw.id, WM_FORK_PREFIX
-        )));
-    }
+    validate_fork_workspace_id(&nw.id)?;
 
     let forked_id = nw.id;
 

--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -163,6 +163,65 @@ pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28217/sync-script-to-git-repo
 /// fork of another workspace.
 pub const WM_FORK_PREFIX: &str = "wm-fork-";
 
+/// Validate that a fork workspace id is safe to interpolate into a git branch name.
+///
+/// The id is appended verbatim to a branch like `wm-fork/<original_branch>/<id>`,
+/// so it must satisfy `git check-ref-format` rules. We validate synchronously at the API
+/// layer because the actual branch creation runs in a deferred git-sync worker job — without
+/// this check, the API returns 200 and the failure only surfaces later in the worker.
+pub fn validate_fork_workspace_id(id: &str) -> error::Result<()> {
+    if !id.starts_with(WM_FORK_PREFIX) {
+        return Err(Error::BadRequest(format!(
+            "The id `{}` is invalid for a forked workspace. It should be prefixed by {}",
+            id, WM_FORK_PREFIX
+        )));
+    }
+
+    let reject = |reason: &str| {
+        Err::<(), _>(Error::BadRequest(format!(
+            "Fork workspace id `{}` is invalid: {} (must be a valid git branch name component)",
+            id, reason
+        )))
+    };
+
+    if id.ends_with('.') {
+        return reject("cannot end with '.'");
+    }
+    if id.ends_with(".lock") {
+        return reject("cannot end with '.lock'");
+    }
+    if id.contains("..") {
+        return reject("cannot contain '..'");
+    }
+    if id.contains("@{") {
+        return reject("cannot contain '@{'");
+    }
+    if id.contains("//") {
+        return reject("cannot contain '//'");
+    }
+    for ch in id.chars() {
+        match ch {
+            ':' | '~' | '^' | '?' | '*' | '[' | '\\' | ' ' => {
+                return reject(&format!("contains forbidden character '{}'", ch));
+            }
+            c if c.is_ascii_control() || c == '\u{7f}' => {
+                return reject("contains a control character");
+            }
+            _ => {}
+        }
+    }
+    // Each slash-separated component cannot start with '.' or end with '.lock'.
+    for component in id.split('/') {
+        if component.starts_with('.') {
+            return reject("a path component cannot start with '.'");
+        }
+        if component.ends_with(".lock") {
+            return reject("a path component cannot end with '.lock'");
+        }
+    }
+    Ok(())
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GitRepositorySettings {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -665,4 +724,54 @@ async fn transform_json_unchecked(
     };
 
     Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_fork_workspace_id_accepts_valid() {
+        validate_fork_workspace_id("wm-fork-test-allow").unwrap();
+        validate_fork_workspace_id("wm-fork-my_workspace.42").unwrap();
+        validate_fork_workspace_id("wm-fork-a").unwrap();
+    }
+
+    #[test]
+    fn test_validate_fork_workspace_id_rejects_missing_prefix() {
+        assert!(validate_fork_workspace_id("not-a-fork").is_err());
+        assert!(validate_fork_workspace_id("wm-fork").is_err());
+    }
+
+    #[test]
+    fn test_validate_fork_workspace_id_rejects_git_unsafe_chars() {
+        for bad in [
+            "wm-fork-test:allow",
+            "wm-fork-test allow",
+            "wm-fork-test~allow",
+            "wm-fork-test^allow",
+            "wm-fork-test?allow",
+            "wm-fork-test*allow",
+            "wm-fork-test[allow",
+            "wm-fork-test\\allow",
+            "wm-fork-test\nallow",
+        ] {
+            assert!(
+                validate_fork_workspace_id(bad).is_err(),
+                "expected `{}` to be rejected",
+                bad
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_fork_workspace_id_rejects_git_unsafe_sequences() {
+        assert!(validate_fork_workspace_id("wm-fork-foo..bar").is_err());
+        assert!(validate_fork_workspace_id("wm-fork-foo@{bar").is_err());
+        assert!(validate_fork_workspace_id("wm-fork-foo//bar").is_err());
+        assert!(validate_fork_workspace_id("wm-fork-foo.").is_err());
+        assert!(validate_fork_workspace_id("wm-fork-foo.lock").is_err());
+        assert!(validate_fork_workspace_id("wm-fork-foo/.bar").is_err());
+        assert!(validate_fork_workspace_id("wm-fork-foo/bar.lock").is_err());
+    }
 }


### PR DESCRIPTION
## Summary

`POST /w/{workspace}/workspaces/create_workspace_fork_branch` was returning 200 even when the id contained characters that make the resulting git branch name invalid (e.g. `wm-fork-test:allow` → `wm-fork/master/test:allow`). The endpoint queues a deferred git-sync worker job, so the actual branch creation failure never made it back to the API caller. Reported by Matthew Parry.

This PR validates the fork id synchronously at the API layer against `git check-ref-format` rules, rejecting unsafe inputs with HTTP 400 before a job is queued. The same validator is also applied to `POST /w/{workspace}/workspaces/create_fork`, where the id likewise becomes a git branch suffix.

## Changes

- Add `validate_fork_workspace_id()` in `windmill-common/src/workspaces.rs`. Enforces the existing `wm-fork-` prefix check plus git ref rules: rejects `:`, ` `, `~`, `^`, `?`, `*`, `[`, `\`, control chars, `..`, `@{`, `//`, trailing `.`, `.lock` suffix, and components starting with `.`.
- Call the validator from both `create_workspace_fork_branch` and `create_workspace_fork` in `windmill-api-workspaces/src/workspaces.rs`. The previous inline `starts_with(WM_FORK_PREFIX)` block in `create_workspace_fork` is folded into the helper so both endpoints share the same error contract.
- Add four unit tests covering the positive case, missing prefix, nine forbidden characters, and seven forbidden sequences.

## Test plan

- [x] `cargo test -p windmill-common --lib workspaces::tests` — all four new tests pass
- [x] Manual: `POST /api/w/admins/workspaces/create_workspace_fork_branch` with `{"id":"wm-fork-test-allow","name":"test-allow"}` → 200
- [x] Manual: same endpoint with `{"id":"wm-fork-test:allow",...}` → 400 with `Fork workspace id 'wm-fork-test:allow' is invalid: contains forbidden character ':' (must be a valid git branch name component)`
- [x] Manual: same endpoint with `{"id":"not-a-fork",...}` → 400 with prefix error
- [x] Manual: `POST /api/w/admins/workspaces/create_fork` with the same colon id → 400 (validation also applies to fork creation)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate fork workspace ids as safe git branch components to prevent invalid refs. The API now returns 400 for bad ids and avoids enqueueing failing git-sync jobs.

- **Bug Fixes**
  - Added `validate_fork_workspace_id()` in `windmill-common` enforcing `WM_FORK_PREFIX` and `git check-ref-format` rules.
  - Applied the validator to `create_workspace_fork_branch` and `create_workspace_fork` in `windmill-api-workspaces` for consistent early rejection.
  - Added unit tests for valid ids, missing prefix, forbidden characters, and unsafe sequences.

<sup>Written for commit 0c69202fb54d8e73cae036d1f52d4356a6a05491. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

