### PR TITLE
feat: allow external domain override for user-facing links

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -379,6 +379,10 @@
 			"types": "./package/stores.d.ts",
 			"default": "./package/stores.js"
 		},
+		"./externalDomain": {
+			"types": "./package/externalDomain.d.ts",
+			"default": "./package/externalDomain.js"
+		},
 		"./gen": {
 			"types": "./package/gen/index.d.ts",
 			"default": "./package/gen/index.js"

--- a/frontend/src/lib/components/LogViewer.svelte
+++ b/frontend/src/lib/components/LogViewer.svelte
@@ -15,6 +15,7 @@
 	import { Button, Drawer, DrawerContent } from './common'
 	import { copyToClipboard } from '$lib/utils'
 	import { base } from '$lib/base'
+	import { externalDomain, withExternalDomain } from '$lib/externalDomain'
 	import { workspaceStore } from '$lib/stores'
 	import { AnsiUp } from 'ansi_up'
 	import NoWorkerWithTagWarning from './runs/NoWorkerWithTagWarning.svelte'
@@ -204,6 +205,9 @@
 			scroll = true
 		}
 	})
+	let downloadHref = $derived(
+		withExternalDomain(`${base}/api/w/${$workspaceStore}/jobs_u/get_logs/${jobId}`, $externalDomain)
+	)
 	let truncatedContent = $derived(truncateContent(content, loadedFromObjectStore, LOG_LIMIT))
 	let prefixInfo = $derived(findPrefixInfo(truncatedContent))
 	let downloadStartUrl = $derived(findStartUrl(truncatedContent, prefixInfo))
@@ -244,7 +248,7 @@
 		{#snippet actions()}
 			{#if jobId && download}
 				<Button
-					href="{base}/api/w/{$workspaceStore}/jobs_u/get_logs/{jobId}"
+					href={downloadHref}
 					download="windmill_logs_{jobId}.txt"
 					color="light"
 					size="xs"
@@ -273,12 +277,12 @@
 				>{#if content}{@const len =
 						(content?.length ?? 0) +
 						(loadedFromObjectStore?.length ?? 0)}{#if splitHtml}{@html splitHtml.before}<button
-								onclick={getStoreLogs}
-								>Show more... <Tooltip>{tooltipText(prefixInfo)}</Tooltip></button
-							>{@html splitHtml.after}{:else if downloadStartUrl}<button
 							onclick={getStoreLogs}
 							>Show more... <Tooltip>{tooltipText(prefixInfo)}</Tooltip></button
-						><br />{@html html}{:else if len > LOG_LIMIT}(truncated to the last {LOG_LIMIT} characters)...<br
+						>{@html splitHtml.after}{:else if downloadStartUrl}<button onclick={getStoreLogs}
+							>Show more... <Tooltip>{tooltipText(prefixInfo)}</Tooltip></button
+						><br
+						/>{@html html}{:else if len > LOG_LIMIT}(truncated to the last {LOG_LIMIT} characters)...<br
 						/><button onclick={() => showMoreTruncate(len)}>Show more..</button><br
 						/>{@html html}{:else}{@html html}{/if}{:else if isLoading}Waiting for job to start...{:else}No logs are available yet{/if}</pre
 			>
@@ -300,7 +304,7 @@
 							<a
 								class="text-primary pb-0.5"
 								target="_blank"
-								href="{base}/api/w/{$workspaceStore}/jobs_u/get_logs/{jobId}"
+								href={downloadHref}
 								download="windmill_logs_{jobId}.txt"
 								><Download size="14" />
 							</a>
@@ -356,19 +360,18 @@
 					noPadding ? '' : 'p-2'
 				)}
 				>{#if content}{@const len =
-						(content?.length ?? 0) +
-						(loadedFromObjectStore?.length ?? 0)}{#if splitHtml}<span>{@html splitHtml.before}</span><button
-								onclick={getStoreLogs}
-								>Show more... &nbsp;<Tooltip>{tooltipText(prefixInfo)}</Tooltip></button
-							><span>{@html splitHtml.after}</span
-						>{:else if downloadStartUrl}<button
+						(content?.length ?? 0) + (loadedFromObjectStore?.length ?? 0)}{#if splitHtml}<span
+							>{@html splitHtml.before}</span
+						><button onclick={getStoreLogs}
+							>Show more... &nbsp;<Tooltip>{tooltipText(prefixInfo)}</Tooltip></button
+						><span>{@html splitHtml.after}</span>{:else if downloadStartUrl}<button
 							onclick={getStoreLogs}
 							>Show more... &nbsp;<Tooltip>{tooltipText(prefixInfo)}</Tooltip></button
-						><br /><span>{@html html}</span
-						>{:else if len > LOG_LIMIT}<button onclick={() => showMoreTruncate(len)}
-							>Show more..</button
-						>&nbsp;({LOG_LIMIT}/{len} chars)<br /><span>{@html html}</span
-						>{:else}<span>{@html html}</span>{/if}{:else if !isLoading}<span>{customEmptyMessage}</span>{/if}</pre
+						><br /><span>{@html html}</span>{:else if len > LOG_LIMIT}<button
+							onclick={() => showMoreTruncate(len)}>Show more..</button
+						>&nbsp;({LOG_LIMIT}/{len} chars)<br /><span>{@html html}</span>{:else}<span
+							>{@html html}</span
+						>{/if}{:else if !isLoading}<span>{customEmptyMessage}</span>{/if}</pre
 			>
 		</div>
 	</div>

--- a/frontend/src/lib/components/LogViewer.svelte
+++ b/frontend/src/lib/components/LogViewer.svelte
@@ -15,7 +15,7 @@
 	import { Button, Drawer, DrawerContent } from './common'
 	import { copyToClipboard } from '$lib/utils'
 	import { base } from '$lib/base'
-	import { externalDomain, withExternalDomain } from '$lib/externalDomain'
+	import { withExternalDomain } from '$lib/externalDomain'
 	import { workspaceStore } from '$lib/stores'
 	import { AnsiUp } from 'ansi_up'
 	import NoWorkerWithTagWarning from './runs/NoWorkerWithTagWarning.svelte'
@@ -206,7 +206,7 @@
 		}
 	})
 	let downloadHref = $derived(
-		withExternalDomain(`${base}/api/w/${$workspaceStore}/jobs_u/get_logs/${jobId}`, $externalDomain)
+		withExternalDomain(`${base}/api/w/${$workspaceStore}/jobs_u/get_logs/${jobId}`)
 	)
 	let truncatedContent = $derived(truncateContent(content, loadedFromObjectStore, LOG_LIMIT))
 	let prefixInfo = $derived(findPrefixInfo(truncatedContent))

--- a/frontend/src/lib/externalDomain.ts
+++ b/frontend/src/lib/externalDomain.ts
@@ -1,12 +1,17 @@
-import { writable } from 'svelte/store'
-
 // Optional external domain (e.g. "https://app.windmill.dev") used to build
 // absolute URLs for user-facing links when the Windmill UI is embedded on a
 // different host than the API. Undefined = same-origin (default behavior).
-// Intended to be set once at boot by SDK consumers (e.g. windmill-react-sdk).
-export const externalDomain = writable<string | undefined>(undefined)
+// Intended to be set once at boot by SDK consumers (e.g. windmill-react-sdk),
+// before any component that builds links has rendered — there is no
+// reactivity, so changing it after mount won't update already-rendered hrefs.
+let externalDomain: string | undefined = undefined
 
-export function withExternalDomain(path: string, domain: string | undefined): string {
-	if (!domain) return path
-	return `${domain.replace(/\/$/, '')}${path.startsWith('/') ? path : `/${path}`}`
+export function setExternalDomain(domain: string | undefined): void {
+	externalDomain = domain
+}
+
+export function withExternalDomain(path: string): string {
+	if (!externalDomain) return path
+	const trimmed = externalDomain.replace(/\/$/, '')
+	return `${trimmed}${path.startsWith('/') ? path : `/${path}`}`
 }

--- a/frontend/src/lib/externalDomain.ts
+++ b/frontend/src/lib/externalDomain.ts
@@ -1,0 +1,12 @@
+import { writable } from 'svelte/store'
+
+// Optional external domain (e.g. "https://app.windmill.dev") used to build
+// absolute URLs for user-facing links when the Windmill UI is embedded on a
+// different host than the API. Undefined = same-origin (default behavior).
+// Intended to be set once at boot by SDK consumers (e.g. windmill-react-sdk).
+export const externalDomain = writable<string | undefined>(undefined)
+
+export function withExternalDomain(path: string, domain: string | undefined): string {
+	if (!domain) return path
+	return `${domain.replace(/\/$/, '')}${path.startsWith('/') ? path : `/${path}`}`
+}


### PR DESCRIPTION
## Summary
Introduces an optional, runtime-settable external domain so SDK consumers (e.g. `windmill-react-sdk`) can point user-facing links at a different origin when the Windmill UI is embedded on a host other than the API. Default behavior (undefined) is unchanged — links remain same-origin.

## Changes
- New `frontend/src/lib/externalDomain.ts` exporting a `writable<string | undefined>` store and a `withExternalDomain(path, domain)` helper.
- `LogViewer.svelte` migrates both download links (drawer `<Button>` and inline `<a>`) to a single `downloadHref` derived through the helper. First call site of the pattern; future user-facing links can adopt it incrementally.

## Test plan
- [ ] Default behavior: open any job's logs, both Download controls produce same-origin `/api/w/<ws>/jobs_u/get_logs/<id>` URLs.
- [ ] Override behavior: in DevTools, `(await import('/src/lib/externalDomain.ts')).externalDomain.set('https://app.windmill.dev')`, then re-render — both `href`s should be absolute against that origin while `${base}` is preserved.
- [ ] Trailing slash on the override (`https://app.windmill.dev/`) is stripped exactly once.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional external domain override for user-facing links so embedded UIs can point downloads to a different origin. Default stays same-origin; helpers are also exposed via the `./externalDomain` export for SDKs.

- New Features
  - Added `setExternalDomain(domain)` and `withExternalDomain(path)` in `frontend/src/lib/externalDomain.ts`, and exposed them in `frontend/package.json` as `./externalDomain` (types + JS) for SDK imports.
  - `LogViewer.svelte` now uses a single `downloadHref` via the helper, building absolute URLs and trimming a trailing slash on the override.

- Migration
  - If embedding Windmill on a different host, call `setExternalDomain('https://app.windmill.dev')` at boot (e.g., from your SDK). Not reactive; set it before components render.

<sup>Written for commit 9604569143371b8ad28660af37cb878f69748729. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

