### PR TITLE
fix: bubble handle_flow chaining errors to parent flow

### DIFF
--- a/backend/tests/worker.rs
+++ b/backend/tests/worker.rs
@@ -5061,6 +5061,88 @@ async fn test_flow_substep_tag_availability_check(db: Pool<Postgres>) -> anyhow:
 
 #[cfg(all(feature = "quickjs", feature = "python"))]
 #[sqlx::test(fixtures("base"))]
+async fn test_whileloop_propagates_inner_iterator_eval_failure(
+    db: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    // Regression test: while-loop with skip_failures=false whose body has
+    // a successful step followed by a for-loop whose iterator expression
+    // throws. Previously the iterator-eval failure was silently swallowed
+    // because `handle_flow` returning `Err` left the local `success` set to
+    // the prior step's outcome (true). The parent while-loop received
+    // success=true and kept iterating despite the inner failure.
+    let port = 123;
+    let flow: FlowValue = serde_json::from_value(serde_json::json!({
+        "modules": [
+            {
+                "id": "outer",
+                "value": {
+                    "type": "whileloopflow",
+                    "skip_failures": false,
+                    "modules": [
+                        {
+                            "id": "prev",
+                            "value": {
+                                "input_transforms": {
+                                    "i": {
+                                        "type": "javascript",
+                                        "expr": "flow_input.iter.index",
+                                    },
+                                },
+                                "type": "rawscript",
+                                "language": "python3",
+                                "content": "def main(i): return i",
+                            },
+                        },
+                        {
+                            "id": "inner",
+                            "value": {
+                                "type": "forloopflow",
+                                // results.prev is null, so `.does_not_exist` throws.
+                                "iterator": {
+                                    "type": "javascript",
+                                    "expr": "results.prev.does_not_exist",
+                                },
+                                "skip_failures": false,
+                                "parallel": false,
+                                "modules": [{
+                                    "id": "leaf",
+                                    "value": {
+                                        "type": "rawscript",
+                                        "language": "python3",
+                                        "content": "def main(): return 1",
+                                    },
+                                }],
+                            },
+                        },
+                    ],
+                },
+                // bound iteration count so without the fix the test fails fast
+                // with success=true (rather than running forever); with the fix
+                // the loop stops at iter 0 with success=false.
+                "stop_after_if": {
+                    "expr": "result >= 2",
+                    "skip_if_stopped": false,
+                },
+            },
+        ],
+    }))
+    .unwrap();
+    let job = JobPayload::RawFlow { value: flow, path: None, restarted_from: None };
+
+    let cjob = RunJob::from(job).run_until_complete(&db, false, port).await;
+
+    assert!(
+        !cjob.success,
+        "flow should fail when inner forloop iterator throws inside a while-loop with skip_failures=false"
+    );
+
+    Ok(())
+}
+
+#[cfg(all(feature = "quickjs", feature = "python"))]
+#[sqlx::test(fixtures("base"))]
 async fn test_stop_after_all_iters_if_bad_expr_parallel_branchall(
     db: Pool<Postgres>,
 ) -> anyhow::Result<()> {

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -1999,6 +1999,8 @@ pub async fn update_flow_status_after_job_completion_internal(
                     None,
                 )
                 .await;
+                // override prior child's success so the parent learns this flow failed
+                success = false;
                 true
             }
             Ok(_) => false,


### PR DESCRIPTION
## Summary

When `handle_flow` returns `Err` while chaining to the next step of a sub-flow (e.g. a for-loop iterator expression that throws), `update_flow_status_after_job_completion_internal` records the sub-flow as failed in `v2_job_completed` via `add_completed_job_error`, but never updates the local `success` variable. That variable still holds the previous step's outcome (typically `true`), and is then propagated to the parent via `UpdateFlowStatusAfterJobCompletion::Rec`. The parent — e.g. an enclosing while-loop with `skip_failures: false` — is told the iteration succeeded and silently continues past the failure.

Reproduced with a while-loop whose body contains a for-loop whose iterator expression throws on the second iteration (`results.x.content` where `x` is null). Before the fix: parent flow ends with `success: true`, `flow_jobs_success: [true, true]`. After the fix: parent flow ends with `success: false`, `flow_jobs_success: [false]`, and the underlying error surfaces in the result.

## Changes

- `backend/windmill-worker/src/worker_flow.rs`: in the `Err(err)` arm after `handle_flow`, set `success = false` so the failure propagates to the parent in the `Rec` path.

## Test plan

- [ ] Run a flow with a non-skip_failures while-loop containing an inner for-loop whose iterator expression throws on iter >= 1; verify the flow ends with `success=false` and the loop stops at the failing iteration.
- [ ] Sanity-check a normal failing-step flow (no while-loop) still propagates failure correctly.
- [ ] Sanity-check a normal successful flow still succeeds end-to-end.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failure propagation for sub-flows when chaining via `handle_flow`; when it returns `Err` we now set `success = false` so parent flows (e.g., while-loops with `skip_failures: false`) stop on failure, and add a regression test for a while-loop with an inner for-loop iterator error.

<sup>Written for commit 64975e33f5c5830fad9703ad7620e23fc871d369. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

