### PR TITLE
fix: scope dev server CSS reset to a layer so Tailwind utilities win

### DIFF
--- a/cli/src/commands/app/dev.ts
+++ b/cli/src/commands/app/dev.ts
@@ -54,13 +54,20 @@ const createHTML = (jsPath: string, cssPath: string) => `
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Windmill App Dev Preview</title>
+  <style>
+    /* Declared before the user stylesheet so Tailwind's layers (theme, base,
+       components, utilities) are appended after wmill-shell and win the
+       cascade. Unlayered styles would override Tailwind utilities. */
+    @layer wmill-shell {
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+    }
+  </style>
   <link rel="stylesheet" href="${cssPath}">
   <style>
-    * {
-      margin: 0;
-      padding: 0;
-      box-sizing: border-box;
-    }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
         'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;


### PR DESCRIPTION
## Summary

The `wmill app dev` HTML template injected an unlayered `* { margin: 0; padding: 0; box-sizing: border-box; }` reset. Per CSS Cascade Level 5, unlayered styles always beat styles inside `@layer`, regardless of selector specificity or source order. Tailwind v4 places every utility class inside `@layer utilities`, so the reset silently zeroed every spacing utility (`px-8`, `py-4`, `mx-auto`, etc.) in raw apps that import Tailwind.

The fix wraps the reset in a named layer (`@layer wmill-shell`) **and** moves the `<style>` block to before the `<link>` to the user stylesheet. Both moves are needed: layer order is determined by first-declaration order, and Tailwind's compiled output starts with `@layer theme, base, components, utilities;`. If `wmill-shell` were declared after the link, it would be the last layer and would still override `utilities`.

This is dev-only — production raw apps run in iframes, so the host's styles never reach them.

Reported in #9067.

## Changes

- `cli/src/commands/app/dev.ts`: split the inline `<style>` so the universal reset (now wrapped in `@layer wmill-shell`) sits before the user stylesheet link, while body / `#root` / SQL modal styles stay after.

## Test plan

- [ ] `wmill app new` a React app, install Tailwind v4, add `@import "tailwindcss"`, and put `<div class="px-8 py-4">probe</div>` somewhere
- [ ] `wmill app dev`, open the preview, and confirm in DevTools that computed `padding-inline` is `32px` and `padding-block` is `16px` (was `0px` before the fix)
- [ ] Confirm the body font-family still applies and the SQL migration modal still renders correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped the dev server CSS reset into a named layer and loaded it before the user stylesheet so Tailwind utilities win the cascade. Fixes zeroed spacing utilities in `wmill app dev` when using Tailwind v4.

- **Bug Fixes**
  - Wrapped the universal reset in `@layer wmill-shell` to stop overriding Tailwind `utilities`.
  - Moved the reset `<style>` block before the user CSS `<link>` so Tailwind layers load after and take precedence.

<sup>Written for commit 2a942c7ed047862768953ed09e89472e76df1266. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

