### PR TITLE
fix(cli): stable auto-numbered inline-script names in app pull

### DIFF
--- a/cli/src/commands/app/app_metadata.ts
+++ b/cli/src/commands/app/app_metadata.ts
@@ -26,7 +26,7 @@ import {
 import { generateHash, getHeaders, readTextFile, writeIfChanged } from "../../utils/utils.ts";
 import { detectAuthGatewayChallenge } from "../../utils/http_guards.ts";
 import { exts } from "../script/script.ts";
-import { FSFSElement, yamlOptions } from "../sync/sync.ts";
+import { FSFSElement, yamlOptions, yamlSortedEntries } from "../sync/sync.ts";
 import { Workspace } from "../workspace/workspace.ts";
 import {
   AppFile as RawAppFile,
@@ -441,7 +441,10 @@ async function traverseAndProcessInlineScripts(
 
   const result: Record<string, any> = {};
 
-  for (const [key, value] of Object.entries(obj)) {
+  // Iterate in YAML output order so the path-assigner inside `processor`
+  // sees keys in the same order they appear on disk — matches
+  // extractInlineScriptsForApps and keeps auto-numbered names stable.
+  for (const [key, value] of yamlSortedEntries(obj)) {
     if (key === "inlineScript" && typeof value === "object") {
       // Found an inline script - process it
       result[key] = await processor(value, {

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -394,6 +394,30 @@ export const yamlOptions: DocumentOptions & SchemaOptions & CreateNodeOptions & 
   singleQuote: true,
 };
 
+/**
+ * Iterate object/array entries in the same order they will appear in the
+ * YAML output. Arrays preserve their index order; plain objects are sorted
+ * by the same comparator as `yamlOptions.sortMapEntries`.
+ *
+ * Use this whenever traversal order influences a side effect that the YAML
+ * representation also expresses (e.g. auto-numbered inline-script paths in
+ * `extractInlineScriptsForApps`). Without it, the path-assigner walks the
+ * in-memory key order returned by `JSON.parse` (server insertion order),
+ * but the YAML serializer reorders keys alphabetically — so identically
+ * named scripts get numbers that don't line up with their position on disk
+ * and shuffle between pulls when the server returns keys in a different order.
+ */
+export function yamlSortedEntries(rec: any): [string, any][] {
+  const entries = Object.entries(rec);
+  if (Array.isArray(rec)) {
+    return entries;
+  }
+  entries.sort(([a], [b]) =>
+    prioritizeName(a).localeCompare(prioritizeName(b)),
+  );
+  return entries;
+}
+
 export interface InlineScript {
   path: string;
   content: string;
@@ -552,7 +576,11 @@ export function extractInlineScriptsForApps(
     return [];
   }
   if (typeof rec == "object") {
-    return Object.entries(rec).flatMap(([k, v]) => {
+    // Iterate in YAML output order so that auto-numbered names assigned by
+    // the path-assigner line up with the position they will appear in the
+    // serialized YAML — and stay stable across pulls regardless of the key
+    // order the server returns. See yamlSortedEntries above.
+    return yamlSortedEntries(rec).flatMap(([k, v]) => {
       if (k == "inlineScript" && v != null && typeof v == "object") {
         rec["type"] = undefined;
         const o: Record<string, any> = v as any;

--- a/cli/test/app_inline_script_ordering_unit.test.ts
+++ b/cli/test/app_inline_script_ordering_unit.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for stable auto-numbered inline-script naming in apps.
+ *
+ * Bug: when an app has multiple components that share the same runnable
+ * `name` (e.g. several "Eval of b" cells), the path-assigner auto-numbers
+ * them (`eval_of_b`, `eval_of_b_1`, …) in traversal order. Before the fix,
+ * traversal walked the in-memory `Object.entries` order returned by
+ * `JSON.parse` — i.e. whatever key order the server happened to send —
+ * while the YAML output sorted keys via `yamlOptions.sortMapEntries`. The
+ * two orders could disagree, so identically named scripts ended up with
+ * numbers that didn't line up with their position in `app.yaml` and could
+ * shuffle between pulls when the server returned keys in a different
+ * order.
+ *
+ * Fix: traverse with `yamlSortedEntries`, which sorts plain-object keys
+ * with the same comparator as YAML output (and preserves array order).
+ * Names are then assigned in the order the scripts will appear on disk,
+ * making them deterministic across pulls.
+ *
+ * No backend required — tests the extractor directly.
+ */
+
+import { expect, test, describe } from "bun:test";
+import {
+  extractInlineScriptsForApps,
+  yamlOptions,
+} from "../src/commands/sync/sync.ts";
+import { newPathAssigner } from "../windmill-utils-internal/src/path-utils/path-assigner.ts";
+import { stringify as yamlStringify } from "yaml";
+
+function makeEvalCell(name: string, expr: string) {
+  return {
+    componentInput: {
+      type: "evalv2",
+      expr,
+      runnable: {
+        name,
+        inlineScript: {
+          content: "return JSON.stringify(freezeTable.selectedRow, null, 2)",
+          language: "frontend",
+        },
+      },
+    },
+  };
+}
+
+function buildAppValue(subgridKeysInOrder: string[]) {
+  const subgrids: Record<string, any[]> = {};
+  for (const key of subgridKeysInOrder) {
+    subgrids[key] = [
+      {
+        id: `${key}_text`,
+        data: makeEvalCell("Eval of b", `JSON.stringify(${key}.selectedRow)`),
+      },
+    ];
+  }
+  return { subgrids };
+}
+
+describe("extractInlineScriptsForApps — stable auto-numbered naming", () => {
+  test("auto-numbered names match YAML output order, not server insertion order", () => {
+    // Server returns subgrids with keys in non-alphabetical order — e.g.
+    // "r-0" before "pendingContainer-0". This is the order the user reports
+    // in their bug repro.
+    const value = buildAppValue([
+      "b-0",
+      "d-0",
+      "g-0",
+      "n-0",
+      "r-0",
+      "pendingContainer-0",
+    ]);
+
+    const scripts = extractInlineScriptsForApps(
+      undefined,
+      value,
+      newPathAssigner("bun"),
+      (_, val) => val["name"],
+      false,
+    );
+
+    // Names assigned in YAML output order (alphabetical via prioritizeName):
+    //   b-0, d-0, g-0, n-0, pendingContainer-0, r-0
+    const paths = scripts.map((s) => s.path);
+    expect(paths).toEqual([
+      "eval_of_b.inline_script.frontend.js",
+      "eval_of_b_1.inline_script.frontend.js",
+      "eval_of_b_2.inline_script.frontend.js",
+      "eval_of_b_3.inline_script.frontend.js",
+      "eval_of_b_4.inline_script.frontend.js", // pendingContainer-0
+      "eval_of_b_5.inline_script.frontend.js", // r-0
+    ]);
+  });
+
+  test("naming is identical regardless of server insertion order", () => {
+    const insertionOrders = [
+      ["b-0", "d-0", "g-0", "n-0", "r-0", "pendingContainer-0"],
+      ["pendingContainer-0", "r-0", "b-0", "d-0", "g-0", "n-0"],
+      ["r-0", "n-0", "g-0", "d-0", "pendingContainer-0", "b-0"],
+    ];
+
+    const refRefs: Record<string, string> = {};
+    for (const order of insertionOrders) {
+      const value = buildAppValue(order);
+      extractInlineScriptsForApps(
+        undefined,
+        value,
+        newPathAssigner("bun"),
+        (_, val) => val["name"],
+        false,
+      );
+      // After extraction, every cell's inlineScript.content has been
+      // rewritten to "!inline <path>". Capture (subgridKey -> ref) so we
+      // can compare across runs.
+      const refs: Record<string, string> = {};
+      for (const [subgridKey, items] of Object.entries(
+        value.subgrids as Record<string, any[]>,
+      )) {
+        refs[subgridKey] = items[0].data.componentInput.runnable.inlineScript
+          .content as string;
+      }
+      if (Object.keys(refRefs).length === 0) {
+        Object.assign(refRefs, refs);
+      } else {
+        // Same subgrid must always get the same !inline reference,
+        // regardless of which order the server returned the keys.
+        expect(refs).toEqual(refRefs);
+      }
+    }
+  });
+
+  test("inline reference for each subgrid lines up with its YAML position", () => {
+    const value = buildAppValue([
+      "b-0",
+      "d-0",
+      "g-0",
+      "n-0",
+      "r-0",
+      "pendingContainer-0",
+    ]);
+    extractInlineScriptsForApps(
+      undefined,
+      value,
+      newPathAssigner("bun"),
+      (_, val) => val["name"],
+      false,
+    );
+
+    // After extraction, stringify with the same yamlOptions used in the
+    // pull pipeline. The auto-numbered file references must appear in
+    // sequential order (0, 1, 2, …) when read top-to-bottom.
+    const yaml = yamlStringify(value, yamlOptions);
+    const refs = [
+      ...yaml.matchAll(/!inline (eval_of_b(?:_\d+)?)\.inline_script\.frontend\.js/g),
+    ].map((m) => m[1]);
+    expect(refs).toEqual([
+      "eval_of_b",
+      "eval_of_b_1",
+      "eval_of_b_2",
+      "eval_of_b_3",
+      "eval_of_b_4",
+      "eval_of_b_5",
+    ]);
+  });
+
+  test("array order within a subgrid is preserved (not sorted)", () => {
+    // Two cells with the same name in array order [zebra, apple]. Array
+    // entries must keep their index order — sorting them would reorder
+    // visible UI elements.
+    const value = {
+      grid: [
+        {
+          id: "zebra",
+          data: makeEvalCell("Eval of b", "zebra.selectedRow"),
+        },
+        {
+          id: "apple",
+          data: makeEvalCell("Eval of b", "apple.selectedRow"),
+        },
+      ],
+    };
+    const scripts = extractInlineScriptsForApps(
+      undefined,
+      value,
+      newPathAssigner("bun"),
+      (_, val) => val["name"],
+      false,
+    );
+    expect(scripts.map((s) => s.path)).toEqual([
+      "eval_of_b.inline_script.frontend.js", // zebra (array index 0)
+      "eval_of_b_1.inline_script.frontend.js", // apple (array index 1)
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

In normal apps, when multiple components share the same runnable `name` (e.g. several "Eval of b" cells), `wmill sync pull` auto-numbers their inline-script files (`eval_of_b`, `eval_of_b_1`, …). The numbers were unstable: identical content could appear with different numbers across pulls, and the order of references inside `app.yaml` could be non-sequential (e.g. `eval_of_b_5` before `eval_of_b_4`), producing churn in git for purely cosmetic renames.

Root cause: the path-assigner walked the in-memory `Object.entries(rec)` order returned by `JSON.parse` (i.e. whatever key order the server happened to send), but the YAML serializer reorders map keys alphabetically via `yamlOptions.sortMapEntries`. The two orders could disagree, so auto-numbered names were baked in based on traversal order but appeared in sorted order on disk.

Fix: traverse with a new `yamlSortedEntries` helper that sorts plain-object keys with the **same comparator** used by `yamlOptions.sortMapEntries` (i.e. `prioritizeName(...).localeCompare(...)`), and preserves array index order. Names are now assigned in the order the scripts appear on disk, making them deterministic across pulls regardless of server JSON key order.

Reproduced from the user-reported `Banking_Dashboard_Deposit_Withdraw.app/app.yaml`: 6 "Eval of b" cells, where subgrids `r-0` and `pendingContainer-0` were swapped because the server's JSON had `r-0` before `pendingContainer-0` while the YAML output sorted them the other way.

## Changes

- `cli/src/commands/sync/sync.ts`: add and export `yamlSortedEntries(rec)` helper that mirrors `yamlOptions.sortMapEntries`. Apply it in `extractInlineScriptsForApps` so traversal matches serialized YAML order.
- `cli/src/commands/app/app_metadata.ts`: import and use `yamlSortedEntries` in `traverseAndProcessInlineScripts` (used by `updateAppInlineScripts` during lock generation) for the same reason.
- `cli/test/app_inline_script_ordering_unit.test.ts`: new unit test reproducing the user's exact `eval_of_b_5` ↔ `eval_of_b_4` swap. Verifies (a) names match YAML output order, (b) naming is identical across three different server insertion orders, (c) `!inline` references inside the serialized YAML appear sequentially, and (d) array index order is preserved (not sorted). Confirmed the test fails without the fix and passes with it.

Note: existing apps will see a one-time rename on the next pull as numbers re-anchor to YAML order. Subsequent pulls are stable.

## Test plan

- [x] Unit tests pass (`UNIT_ONLY=1 bun test test/app_inline_script_ordering_unit.test.ts`) — 4/4 pass.
- [x] All CLI unit tests pass (`UNIT_ONLY=1 bun test test/*unit*.test.ts`) — 655/655 pass.
- [x] Verified the new test fails on `main` (without the fix) with the exact swap pattern (`eval_of_b_5` before `eval_of_b_4`) the user reported.
- [ ] Manual: pull an app twice in a row from a workspace with multiple cells sharing a runnable name; confirm the `*.inline_script.*` filenames and `!inline ...` references are byte-identical between pulls.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes auto-numbered inline-script filenames during app pulls by aligning traversal order with the YAML output order. This stops cosmetic renames when multiple components share the same runnable name.

- **Bug Fixes**
  - Added `yamlSortedEntries` to sort object keys using the same comparator as `yamlOptions.sortMapEntries`; arrays keep index order.
  - Applied it in `extractInlineScriptsForApps` and `traverseAndProcessInlineScripts` for consistent path assignment and lock generation.
  - Added a unit test to verify numbering is deterministic across server key orders and that `!inline` references are sequential.

- **Migration**
  - On the next pull, some inline-script files may be renamed once to match YAML order. Pull once and commit the changes. Subsequent pulls are stable.

<sup>Written for commit 8dcc5d7001ce85c9cd0a8a231ac5019298faa76a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

