### PR TITLE
feat(cli): add --parallel flag to generate-metadata

### DIFF
--- a/cli/src/commands/generate-metadata/generate-metadata.ts
+++ b/cli/src/commands/generate-metadata/generate-metadata.ts
@@ -244,8 +244,11 @@ export async function rehashOnly(
     }
   }
 
-  let parallelism = opts.parallel ?? 1;
-  if (parallelism <= 0) parallelism = 1;
+  let parallelism = Number(opts.parallel ?? 1);
+  if (!Number.isFinite(parallelism) || parallelism <= 0) parallelism = 1;
+  if (parallelism > 1) {
+    log.info(`Parallelizing ${parallelism} items at a time`);
+  }
 
   // Buffer wmill-lock.yaml writes during the parallel phase: each task mutates
   // the shared in-memory lockfile, then we flush once.
@@ -551,8 +554,8 @@ export async function generateMetadata(
 
   const errors: { path: string; error: string }[] = [];
 
-  let parallelism = opts.parallel ?? 1;
-  if (parallelism <= 0) parallelism = 1;
+  let parallelism = Number(opts.parallel ?? 1);
+  if (!Number.isFinite(parallelism) || parallelism <= 0) parallelism = 1;
   if (parallelism > 1) {
     log.info(`Parallelizing ${parallelism} items at a time`);
   }
@@ -704,7 +707,7 @@ const command = new Command()
   .option("--skip-flows", "Skip processing flows")
   .option("--skip-apps", "Skip processing apps")
   .option("--strict-folder-boundaries", "Only update items inside the specified folder (requires folder argument)")
-  .option("--parallel <number>", "Number of items to process in parallel")
+  .option("--parallel <n:number>", "Number of items to process in parallel")
   .option(
     "-i --includes <patterns:file[]>",
     "Comma separated patterns to specify which files to include"
@@ -726,7 +729,7 @@ const command = new Command()
       .option("--skip-scripts", "Skip processing scripts")
       .option("--skip-flows", "Skip processing flows")
       .option("--skip-apps", "Skip processing apps")
-      .option("--parallel <number>", "Number of items to process in parallel")
+      .option("--parallel <n:number>", "Number of items to process in parallel")
       .option(
         "-i --includes <patterns:file[]>",
         "Comma separated patterns to specify which files to include"

--- a/cli/src/commands/generate-metadata/generate-metadata.ts
+++ b/cli/src/commands/generate-metadata/generate-metadata.ts
@@ -8,6 +8,8 @@ import { resolveWorkspace } from "../../core/context.ts";
 import { requireLogin } from "../../core/auth.ts";
 import * as log from "../../core/log.ts";
 import {
+  beginLockfileBatch,
+  flushLockfileBatch,
   generateScriptMetadataInternal,
   getRawWorkspaceDependencies,
   readLockfile,
@@ -200,6 +202,12 @@ export async function rehashOnly(
   const stubWorkspace = {} as any;
   const rehashOpts = { ...opts, rehashOnly: true } as any;
 
+  type RehashTask =
+    | { kind: "script"; scriptPath: string }
+    | { kind: "flow"; folder: string }
+    | { kind: "app"; folder: string; rawApp: boolean };
+  const queue: RehashTask[] = [];
+
   if (!rehashFilter?.skipScripts) {
     for (const e of scriptPaths) {
       // Filter against the derived remote path so a folder argument like
@@ -210,14 +218,7 @@ export async function rehashOnly(
       if (rehashFilter?.missingOnly) {
         if (skipIfExisting(remotePath) || skipIfExisting(remotePath, "__script_hash")) continue;
       }
-      try {
-        await generateScriptMetadataInternal(
-          e, stubWorkspace, rehashOpts, false, true, {}, codebases, false,
-        );
-        counts.scripts++;
-      } catch (err) {
-        log.warn(`Skipping ${e}: ${err instanceof Error ? err.message : err}`);
-      }
+      queue.push({ kind: "script", scriptPath: e });
     }
   }
 
@@ -228,12 +229,7 @@ export async function rehashOnly(
         const folderNormalized = f.replaceAll(SEP, "/");
         if (skipIfExisting(folderNormalized, "__flow_hash")) continue;
       }
-      try {
-        await generateFlowLockInternal(f, false, stubWorkspace, rehashOpts, false, true);
-        counts.flows++;
-      } catch (err) {
-        log.warn(`Skipping ${f}: ${err instanceof Error ? err.message : err}`);
-      }
+      queue.push({ kind: "flow", folder: f });
     }
   }
 
@@ -244,13 +240,49 @@ export async function rehashOnly(
         const folderNormalized = appFolder.replaceAll(SEP, "/");
         if (skipIfExisting(folderNormalized, "__app_hash")) continue;
       }
-      try {
-        await generateAppLocksInternal(appFolder, rawApp, false, stubWorkspace, rehashOpts, false, true);
-        counts.apps++;
-      } catch (err) {
-        log.warn(`Skipping ${appFolder}: ${err instanceof Error ? err.message : err}`);
+      queue.push({ kind: "app", folder: appFolder, rawApp });
+    }
+  }
+
+  let parallelism = opts.parallel ?? 1;
+  if (parallelism <= 0) parallelism = 1;
+
+  // Buffer wmill-lock.yaml writes during the parallel phase: each task mutates
+  // the shared in-memory lockfile, then we flush once.
+  await beginLockfileBatch();
+  try {
+    const pool = new Set<Promise<void>>();
+    while (queue.length > 0 || pool.size > 0) {
+      while (pool.size < parallelism && queue.length > 0) {
+        const task = queue.shift()!;
+        const p = (async () => {
+          try {
+            if (task.kind === "script") {
+              await generateScriptMetadataInternal(
+                task.scriptPath, stubWorkspace, rehashOpts, false, true, {}, codebases, false,
+              );
+              counts.scripts++;
+            } else if (task.kind === "flow") {
+              await generateFlowLockInternal(task.folder, false, stubWorkspace, rehashOpts, false, true);
+              counts.flows++;
+            } else {
+              await generateAppLocksInternal(task.folder, task.rawApp, false, stubWorkspace, rehashOpts, false, true);
+              counts.apps++;
+            }
+          } catch (err) {
+            const label = task.kind === "script" ? task.scriptPath : task.folder;
+            log.warn(`Skipping ${label}: ${err instanceof Error ? err.message : err}`);
+          }
+        })();
+        pool.add(p);
+        p.then(() => pool.delete(p));
+      }
+      if (pool.size > 0) {
+        await Promise.race(pool);
       }
     }
+  } finally {
+    await flushLockfileBatch();
   }
 
   if (counts.scripts + counts.flows + counts.apps > 0 || !rehashFilter?.missingOnly) {
@@ -519,85 +551,117 @@ export async function generateMetadata(
 
   const errors: { path: string; error: string }[] = [];
 
-  // Process scripts
-  for (const item of scripts) {
-    current++;
-    log.info(`${formatProgress(current)} script ${item.path}`);
-    try {
-      await generateScriptMetadataInternal(
-        item.path, // originalPath with extension
-        workspace,
-        opts,
-        false, // dryRun
-        true, // noStaleMessage
-        mismatchedWorkspaceDeps,
-        codebases,
-        false,
-        tree
-      );
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      errors.push({ path: item.path, error: msg });
-      log.error(`  Failed: ${msg}`);
-    }
+  let parallelism = opts.parallel ?? 1;
+  if (parallelism <= 0) parallelism = 1;
+  if (parallelism > 1) {
+    log.info(`Parallelizing ${parallelism} items at a time`);
   }
 
-  // Process flows
-  for (const item of flows) {
-    current++;
-    try {
-      const result = await generateFlowLockInternal(
-        item.folder.replaceAll("/", SEP),
-        false, // dryRun
-        workspace,
-        opts,
-        false,
-        true, // noStaleMessage
-        tree
-      );
-      const flowResult = result as FlowLocksResult | undefined;
-      const scriptsInfo = flowResult?.updatedScripts?.length
-        ? colors.dim(colors.white(`: ${flowResult.updatedScripts.join(", ")}`))
-        : "";
-      log.info(`${formatProgress(current)} flow   ${item.path}${scriptsInfo}`);
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      errors.push({ path: item.path, error: msg });
-      log.info(`${formatProgress(current)} flow   ${item.path}`);
-      log.error(`  Failed: ${msg}`);
-    }
-  }
+  type Task =
+    | { kind: "script"; item: StaleItem }
+    | { kind: "flow"; item: StaleItem }
+    | { kind: "app"; item: StaleItem };
+  const queue: Task[] = [
+    ...scripts.map<Task>((item) => ({ kind: "script", item })),
+    ...flows.map<Task>((item) => ({ kind: "flow", item })),
+    ...apps.map<Task>((item) => ({ kind: "app", item })),
+  ];
 
-  // Process apps
-  for (const item of apps) {
-    current++;
-    try {
-      const result = await generateAppLocksInternal(
-        item.folder.replaceAll("/", SEP),
-        item.isRawApp!, // rawApp
-        false, // dryRun
-        workspace,
-        opts,
-        false,
-        true, // noStaleMessage
-        tree
-      );
-      const appResult = result as AppLocksResult | undefined;
-      const scriptsInfo = appResult?.updatedScripts?.length
-        ? colors.dim(colors.white(`: ${appResult.updatedScripts.join(", ")}`))
-        : "";
-      log.info(`${formatProgress(current)} app    ${item.path}${scriptsInfo}`);
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      errors.push({ path: item.path, error: msg });
-      log.info(`${formatProgress(current)} app    ${item.path}`);
-      log.error(`  Failed: ${msg}`);
+  // Buffer wmill-lock.yaml writes during the parallel phase: each task mutates
+  // the shared in-memory lockfile via clearGlobalLock/updateMetadataGlobalLock,
+  // then we flush once. Without this buffering, two workers' read-modify-write
+  // cycles would race and lose hashes.
+  await beginLockfileBatch();
+  try {
+    const pool = new Set<Promise<void>>();
+    while (queue.length > 0 || pool.size > 0) {
+      while (pool.size < parallelism && queue.length > 0) {
+        const task = queue.shift()!;
+        const taskNumber = ++current;
+        const p = (async () => {
+          if (task.kind === "script") {
+            const item = task.item;
+            log.info(`${formatProgress(taskNumber)} script ${item.path}`);
+            try {
+              await generateScriptMetadataInternal(
+                item.path, // originalPath with extension
+                workspace,
+                opts,
+                false, // dryRun
+                true, // noStaleMessage
+                mismatchedWorkspaceDeps,
+                codebases,
+                false,
+                tree
+              );
+            } catch (e) {
+              const msg = e instanceof Error ? e.message : String(e);
+              errors.push({ path: item.path, error: msg });
+              log.error(`  Failed: ${msg}`);
+            }
+          } else if (task.kind === "flow") {
+            const item = task.item;
+            try {
+              const result = await generateFlowLockInternal(
+                item.folder.replaceAll("/", SEP),
+                false, // dryRun
+                workspace,
+                opts,
+                false,
+                true, // noStaleMessage
+                tree
+              );
+              const flowResult = result as FlowLocksResult | undefined;
+              const scriptsInfo = flowResult?.updatedScripts?.length
+                ? colors.dim(colors.white(`: ${flowResult.updatedScripts.join(", ")}`))
+                : "";
+              log.info(`${formatProgress(taskNumber)} flow   ${item.path}${scriptsInfo}`);
+            } catch (e) {
+              const msg = e instanceof Error ? e.message : String(e);
+              errors.push({ path: item.path, error: msg });
+              log.info(`${formatProgress(taskNumber)} flow   ${item.path}`);
+              log.error(`  Failed: ${msg}`);
+            }
+          } else {
+            const item = task.item;
+            try {
+              const result = await generateAppLocksInternal(
+                item.folder.replaceAll("/", SEP),
+                item.isRawApp!, // rawApp
+                false, // dryRun
+                workspace,
+                opts,
+                false,
+                true, // noStaleMessage
+                tree
+              );
+              const appResult = result as AppLocksResult | undefined;
+              const scriptsInfo = appResult?.updatedScripts?.length
+                ? colors.dim(colors.white(`: ${appResult.updatedScripts.join(", ")}`))
+                : "";
+              log.info(`${formatProgress(taskNumber)} app    ${item.path}${scriptsInfo}`);
+            } catch (e) {
+              const msg = e instanceof Error ? e.message : String(e);
+              errors.push({ path: item.path, error: msg });
+              log.info(`${formatProgress(taskNumber)} app    ${item.path}`);
+              log.error(`  Failed: ${msg}`);
+            }
+          }
+        })();
+        pool.add(p);
+        p.then(() => pool.delete(p));
+      }
+      if (pool.size > 0) {
+        await Promise.race(pool);
+      }
     }
-  }
 
-  // Persist all stale workspace dep hashes (not just filtered — deps are global, not folder-scoped)
-  const allStaleDeps = staleItems.filter((i) => i.type === "dependencies");
-  await tree.persistDepsHashes(allStaleDeps.map((d) => d.path));
+    // Persist all stale workspace dep hashes (not just filtered — deps are global, not folder-scoped)
+    const allStaleDeps = staleItems.filter((i) => i.type === "dependencies");
+    await tree.persistDepsHashes(allStaleDeps.map((d) => d.path));
+  } finally {
+    await flushLockfileBatch();
+  }
 
   const succeeded = total - errors.length;
   log.info("");
@@ -640,6 +704,7 @@ const command = new Command()
   .option("--skip-flows", "Skip processing flows")
   .option("--skip-apps", "Skip processing apps")
   .option("--strict-folder-boundaries", "Only update items inside the specified folder (requires folder argument)")
+  .option("--parallel <number>", "Number of items to process in parallel")
   .option(
     "-i --includes <patterns:file[]>",
     "Comma separated patterns to specify which files to include"
@@ -661,6 +726,7 @@ const command = new Command()
       .option("--skip-scripts", "Skip processing scripts")
       .option("--skip-flows", "Skip processing flows")
       .option("--skip-apps", "Skip processing apps")
+      .option("--parallel <number>", "Number of items to process in parallel")
       .option(
         "-i --includes <patterns:file[]>",
         "Comma separated patterns to specify which files to include"

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -6730,7 +6730,7 @@ Generate metadata (locks, schemas) for all scripts, flows, and apps
 - \`--skip-flows\` - Skip processing flows
 - \`--skip-apps\` - Skip processing apps
 - \`--strict-folder-boundaries\` - Only update items inside the specified folder (requires folder argument)
-- \`--parallel <number>\` - Number of items to process in parallel
+- \`--parallel <n:number>\` - Number of items to process in parallel
 - \`-i --includes <patterns:file[]>\` - Comma separated patterns to specify which files to include
 - \`-e --excludes <patterns:file[]>\` - Comma separated patterns to specify which files to exclude
 
@@ -6740,7 +6740,7 @@ Generate metadata (locks, schemas) for all scripts, flows, and apps
   - \`--skip-scripts\` - Skip processing scripts
   - \`--skip-flows\` - Skip processing flows
   - \`--skip-apps\` - Skip processing apps
-  - \`--parallel <number>\` - Number of items to process in parallel
+  - \`--parallel <n:number>\` - Number of items to process in parallel
   - \`-i --includes <patterns:file[]>\` - Comma separated patterns to specify which files to include
   - \`-e --excludes <patterns:file[]>\` - Comma separated patterns to specify which files to exclude
 

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -6730,6 +6730,7 @@ Generate metadata (locks, schemas) for all scripts, flows, and apps
 - \`--skip-flows\` - Skip processing flows
 - \`--skip-apps\` - Skip processing apps
 - \`--strict-folder-boundaries\` - Only update items inside the specified folder (requires folder argument)
+- \`--parallel <number>\` - Number of items to process in parallel
 - \`-i --includes <patterns:file[]>\` - Comma separated patterns to specify which files to include
 - \`-e --excludes <patterns:file[]>\` - Comma separated patterns to specify which files to exclude
 
@@ -6739,6 +6740,7 @@ Generate metadata (locks, schemas) for all scripts, flows, and apps
   - \`--skip-scripts\` - Skip processing scripts
   - \`--skip-flows\` - Skip processing flows
   - \`--skip-apps\` - Skip processing apps
+  - \`--parallel <number>\` - Number of items to process in parallel
   - \`-i --includes <patterns:file[]>\` - Comma separated patterns to specify which files to include
   - \`-e --excludes <patterns:file[]>\` - Comma separated patterns to specify which files to exclude
 

--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -1202,7 +1202,31 @@ export function normalizeLockPath(p: string): string {
   return n;
 }
 
+// When set, `clearGlobalLock` and `updateMetadataGlobalLock` mutate this
+// in-memory copy instead of doing a full read-modify-write on disk for every
+// call. Callers that fan out item processing through a worker pool wrap the
+// pool with `beginLockfileBatch()`/`flushLockfileBatch()` so the lockfile is
+// only written once at the end — see `generate-metadata` parallelism.
+let inMemoryLock: Lock | null = null;
+
+export async function beginLockfileBatch(): Promise<void> {
+  if (inMemoryLock) return;
+  inMemoryLock = await readLockfile();
+}
+
+export async function flushLockfileBatch(): Promise<void> {
+  if (!inMemoryLock) return;
+  const toWrite = inMemoryLock;
+  inMemoryLock = null;
+  await writeFile(
+    WMILL_LOCKFILE,
+    yamlStringify(toWrite as Record<string, any>, yamlOptions),
+    "utf-8",
+  );
+}
+
 export async function readLockfile(): Promise<Lock> {
+  if (inMemoryLock) return inMemoryLock;
   let parsed: unknown;
   try {
     parsed = await yamlParseFile(WMILL_LOCKFILE);
@@ -1344,11 +1368,13 @@ export async function clearGlobalLock(path: string): Promise<void> {
         }
       });
     }
-    await writeFile(
-      WMILL_LOCKFILE,
-      yamlStringify(conf as Record<string, any>, yamlOptions),
-      "utf-8"
-    );
+    if (!inMemoryLock) {
+      await writeFile(
+        WMILL_LOCKFILE,
+        yamlStringify(conf as Record<string, any>, yamlOptions),
+        "utf-8"
+      );
+    }
   }
 }
 
@@ -1377,9 +1403,11 @@ export async function updateMetadataGlobalLock(
       conf.locks[path] = hash;
     }
   }
-  await writeFile(
-    WMILL_LOCKFILE,
-    yamlStringify(conf as Record<string, any>, yamlOptions),
-    "utf-8"
-  );
+  if (!inMemoryLock) {
+    await writeFile(
+      WMILL_LOCKFILE,
+      yamlStringify(conf as Record<string, any>, yamlOptions),
+      "utf-8"
+    );
+  }
 }

--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -1216,13 +1216,14 @@ export async function beginLockfileBatch(): Promise<void> {
 
 export async function flushLockfileBatch(): Promise<void> {
   if (!inMemoryLock) return;
-  const toWrite = inMemoryLock;
-  inMemoryLock = null;
+  // Write first, then clear: if the disk write throws (e.g. ENOSPC), the
+  // buffered updates remain in memory and a retry can re-attempt the flush.
   await writeFile(
     WMILL_LOCKFILE,
-    yamlStringify(toWrite as Record<string, any>, yamlOptions),
+    yamlStringify(inMemoryLock as Record<string, any>, yamlOptions),
     "utf-8",
   );
+  inMemoryLock = null;
 }
 
 export async function readLockfile(): Promise<Lock> {

--- a/system_prompts/auto-generated/cli/cli-commands.md
+++ b/system_prompts/auto-generated/cli/cli-commands.md
@@ -168,7 +168,7 @@ Generate metadata (locks, schemas) for all scripts, flows, and apps
 - `--skip-flows` - Skip processing flows
 - `--skip-apps` - Skip processing apps
 - `--strict-folder-boundaries` - Only update items inside the specified folder (requires folder argument)
-- `--parallel <number>` - Number of items to process in parallel
+- `--parallel <n:number>` - Number of items to process in parallel
 - `-i --includes <patterns:file[]>` - Comma separated patterns to specify which files to include
 - `-e --excludes <patterns:file[]>` - Comma separated patterns to specify which files to exclude
 
@@ -178,7 +178,7 @@ Generate metadata (locks, schemas) for all scripts, flows, and apps
   - `--skip-scripts` - Skip processing scripts
   - `--skip-flows` - Skip processing flows
   - `--skip-apps` - Skip processing apps
-  - `--parallel <number>` - Number of items to process in parallel
+  - `--parallel <n:number>` - Number of items to process in parallel
   - `-i --includes <patterns:file[]>` - Comma separated patterns to specify which files to include
   - `-e --excludes <patterns:file[]>` - Comma separated patterns to specify which files to exclude
 

--- a/system_prompts/auto-generated/cli/cli-commands.md
+++ b/system_prompts/auto-generated/cli/cli-commands.md
@@ -168,6 +168,7 @@ Generate metadata (locks, schemas) for all scripts, flows, and apps
 - `--skip-flows` - Skip processing flows
 - `--skip-apps` - Skip processing apps
 - `--strict-folder-boundaries` - Only update items inside the specified folder (requires folder argument)
+- `--parallel <number>` - Number of items to process in parallel
 - `-i --includes <patterns:file[]>` - Comma separated patterns to specify which files to include
 - `-e --excludes <patterns:file[]>` - Comma separated patterns to specify which files to exclude
 
@@ -177,6 +178,7 @@ Generate metadata (locks, schemas) for all scripts, flows, and apps
   - `--skip-scripts` - Skip processing scripts
   - `--skip-flows` - Skip processing flows
   - `--skip-apps` - Skip processing apps
+  - `--parallel <number>` - Number of items to process in parallel
   - `-i --includes <patterns:file[]>` - Comma separated patterns to specify which files to include
   - `-e --excludes <patterns:file[]>` - Comma separated patterns to specify which files to exclude
 

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -2316,7 +2316,7 @@ Generate metadata (locks, schemas) for all scripts, flows, and apps
 - \`--skip-flows\` - Skip processing flows
 - \`--skip-apps\` - Skip processing apps
 - \`--strict-folder-boundaries\` - Only update items inside the specified folder (requires folder argument)
-- \`--parallel <number>\` - Number of items to process in parallel
+- \`--parallel <n:number>\` - Number of items to process in parallel
 - \`-i --includes <patterns:file[]>\` - Comma separated patterns to specify which files to include
 - \`-e --excludes <patterns:file[]>\` - Comma separated patterns to specify which files to exclude
 
@@ -2326,7 +2326,7 @@ Generate metadata (locks, schemas) for all scripts, flows, and apps
   - \`--skip-scripts\` - Skip processing scripts
   - \`--skip-flows\` - Skip processing flows
   - \`--skip-apps\` - Skip processing apps
-  - \`--parallel <number>\` - Number of items to process in parallel
+  - \`--parallel <n:number>\` - Number of items to process in parallel
   - \`-i --includes <patterns:file[]>\` - Comma separated patterns to specify which files to include
   - \`-e --excludes <patterns:file[]>\` - Comma separated patterns to specify which files to exclude
 

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -2316,6 +2316,7 @@ Generate metadata (locks, schemas) for all scripts, flows, and apps
 - \`--skip-flows\` - Skip processing flows
 - \`--skip-apps\` - Skip processing apps
 - \`--strict-folder-boundaries\` - Only update items inside the specified folder (requires folder argument)
+- \`--parallel <number>\` - Number of items to process in parallel
 - \`-i --includes <patterns:file[]>\` - Comma separated patterns to specify which files to include
 - \`-e --excludes <patterns:file[]>\` - Comma separated patterns to specify which files to exclude
 
@@ -2325,6 +2326,7 @@ Generate metadata (locks, schemas) for all scripts, flows, and apps
   - \`--skip-scripts\` - Skip processing scripts
   - \`--skip-flows\` - Skip processing flows
   - \`--skip-apps\` - Skip processing apps
+  - \`--parallel <number>\` - Number of items to process in parallel
   - \`-i --includes <patterns:file[]>\` - Comma separated patterns to specify which files to include
   - \`-e --excludes <patterns:file[]>\` - Comma separated patterns to specify which files to exclude
 

--- a/system_prompts/auto-generated/skills/cli-commands/SKILL.md
+++ b/system_prompts/auto-generated/skills/cli-commands/SKILL.md
@@ -173,6 +173,7 @@ Generate metadata (locks, schemas) for all scripts, flows, and apps
 - `--skip-flows` - Skip processing flows
 - `--skip-apps` - Skip processing apps
 - `--strict-folder-boundaries` - Only update items inside the specified folder (requires folder argument)
+- `--parallel <number>` - Number of items to process in parallel
 - `-i --includes <patterns:file[]>` - Comma separated patterns to specify which files to include
 - `-e --excludes <patterns:file[]>` - Comma separated patterns to specify which files to exclude
 
@@ -182,6 +183,7 @@ Generate metadata (locks, schemas) for all scripts, flows, and apps
   - `--skip-scripts` - Skip processing scripts
   - `--skip-flows` - Skip processing flows
   - `--skip-apps` - Skip processing apps
+  - `--parallel <number>` - Number of items to process in parallel
   - `-i --includes <patterns:file[]>` - Comma separated patterns to specify which files to include
   - `-e --excludes <patterns:file[]>` - Comma separated patterns to specify which files to exclude
 

--- a/system_prompts/auto-generated/skills/cli-commands/SKILL.md
+++ b/system_prompts/auto-generated/skills/cli-commands/SKILL.md
@@ -173,7 +173,7 @@ Generate metadata (locks, schemas) for all scripts, flows, and apps
 - `--skip-flows` - Skip processing flows
 - `--skip-apps` - Skip processing apps
 - `--strict-folder-boundaries` - Only update items inside the specified folder (requires folder argument)
-- `--parallel <number>` - Number of items to process in parallel
+- `--parallel <n:number>` - Number of items to process in parallel
 - `-i --includes <patterns:file[]>` - Comma separated patterns to specify which files to include
 - `-e --excludes <patterns:file[]>` - Comma separated patterns to specify which files to exclude
 
@@ -183,7 +183,7 @@ Generate metadata (locks, schemas) for all scripts, flows, and apps
   - `--skip-scripts` - Skip processing scripts
   - `--skip-flows` - Skip processing flows
   - `--skip-apps` - Skip processing apps
-  - `--parallel <number>` - Number of items to process in parallel
+  - `--parallel <n:number>` - Number of items to process in parallel
   - `-i --includes <patterns:file[]>` - Comma separated patterns to specify which files to include
   - `-e --excludes <patterns:file[]>` - Comma separated patterns to specify which files to exclude
 


### PR DESCRIPTION
## Summary

`wmill generate-metadata` processed scripts, flows, and apps in three sequential `for` loops, each `await`-ing a backend round-trip per item. On large workspaces (thousands of items) this is slow because the CLI sits idle waiting on `dependencies_async` jobs.

This PR adds `--parallel <number>` (mirroring `wmill sync push --parallel`) and runs all stale items through a single worker pool. Measured against a real synced workspace: ~5.3× wall-clock speedup at `--parallel 8` on 30 stale items (18.5s → 3.5s).

## Changes

- `cli/src/utils/metadata.ts`: add `inMemoryLock` buffer + `beginLockfileBatch()` / `flushLockfileBatch()`. `clearGlobalLock` and `updateMetadataGlobalLock` now mutate the buffer in-place (skipping the per-call disk write) when a batch is active; `readLockfile()` returns the live buffer when set, so workers see consistent state.
- `cli/src/commands/generate-metadata/generate-metadata.ts`: replace the three sequential loops in both `generateMetadata`'s second pass and `rehashOnly` with a unified worker pool modelled on `sync push` (`cli/src/commands/sync/sync.ts:3447-4094`). Pool body wrapped in `beginLockfileBatch`/`flushLockfileBatch` (try/finally) so the lockfile is written exactly once at the end. `--parallel <number>` option added to both the top-level command and the `rehash` subcommand.
- `system_prompts/auto-generated/*` + `cli/src/guidance/skills.gen.ts`: regenerated via `python system_prompts/generate.py` so agent docs reflect the new flag.

### Concurrency safety

JS is single-threaded between awaits, so the synchronous mutation in `clearGlobalLock` / `updateMetadataGlobalLock` (under batch mode) cannot interleave between workers. Different items don't share lockfile keys. The dependency tree is read-only in the second pass — its sole mutator (the `dryRun` first pass) stays sequential. Per-folder writes (`flow.yaml`, `app.yaml`, inline scripts) don't collide because `staleItems` is deduped per folder upstream.

### Behavior change

With `--parallel > 1`, progress lines (`[N/M] script ...`) are interleaved by completion order rather than grouped by type. Each task is assigned a stable queue-position ID at scheduling time, so the `[N/M]` numbers remain unique. With `--parallel` absent or `1`, behavior is identical to before (single buffered flush at end is functionally equivalent to the pre-change per-call writes).

## Test plan

- [x] `npm run check` in `cli/` — no new type errors introduced
- [x] Sequential parity: `wmill generate-metadata --parallel 1` produces a byte-identical `wmill-lock.yaml` to `wmill generate-metadata --parallel 8` on the same stripped state (verified via `diff` on a real synced workspace)
- [x] No lost writes: post-`--parallel 8` dry-run on 30 stale items reports `All metadata up-to-date`
- [x] Speedup: 5.3× wall-clock improvement at `--parallel 8` on 30 stale items, 3.4× on 11 stale items
- [x] Rehash: `generate-metadata rehash --parallel 8` produces a clean dry-run afterwards
- [x] Display: `[N/M]` IDs are unique and stable per task, interleaved by completion order
- [ ] Reviewer to confirm behavior on a workspace with workspace dependencies (`tree.persistDepsHashes` runs after the pool drains, inside the buffer, so deps are flushed in the same write)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `--parallel` to `wmill generate-metadata` (and `generate-metadata rehash`) to process stale scripts, flows, and apps concurrently with a worker pool, batching `wmill-lock.yaml` writes for consistency and speed. Expect big speedups on large workspaces (e.g., ~5.3× at `--parallel 8`).

- **New Features**
  - `--parallel <number>` for both commands; unified worker pool across all stale items. Defaults to `1` (sequential).
  - In-memory lockfile batching via `beginLockfileBatch`/`flushLockfileBatch` writes once at the end and avoids read-modify-write races.
  - Progress lines interleave when `--parallel > 1`, with stable, unique `[N/M]` IDs. Docs updated (`system_prompts/*`, `cli/src/guidance/skills.gen.ts`).

- **Bug Fixes**
  - Validate `--parallel` input (non-finite or <= 0 → `1`).
  - Hardened flush: write-then-clear buffer and wrap in `try/finally`; `readLockfile()` serves the live buffer; dependency hashes are persisted before the final flush.

<sup>Written for commit 57f1474ab59e60059a14e3d83dd468e483f62bbe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

