### PR TITLE
fix(cli): forward HEADERS env var on every backend fetch

### DIFF
--- a/cli/src/commands/app/dev.ts
+++ b/cli/src/commands/app/dev.ts
@@ -14,7 +14,8 @@ import * as path from "node:path";
 import process from "node:process";
 import { Buffer } from "node:buffer";
 import { writeFileSync } from "node:fs";
-import { readTextFile } from "../../utils/utils.ts";
+import { getHeaders, readTextFile } from "../../utils/utils.ts";
+import { detectAuthGatewayChallenge } from "../../utils/http_guards.ts";
 import { WebSocket, WebSocketServer } from "ws";
 import {
   createFrameworkPlugins,
@@ -1714,12 +1715,16 @@ async function streamJobWithSSE(
   const sseUrl =
     `${baseUrl}api/w/${workspace}/jobs_u/getupdate_sse/${jobId}?fast=true`;
 
+  const extraHeaders = getHeaders();
   const response = await fetch(sseUrl, {
     headers: {
       Accept: "text/event-stream",
       Authorization: `Bearer ${token}`,
+      ...extraHeaders,
     },
   });
+
+  await detectAuthGatewayChallenge(response, sseUrl);
 
   if (!response.ok) {
     throw new Error(

--- a/cli/src/commands/docs/docs.ts
+++ b/cli/src/commands/docs/docs.ts
@@ -4,6 +4,8 @@ import * as log from "../../core/log.ts";
 import { requireLogin } from "../../core/auth.ts";
 import { resolveWorkspace } from "../../core/context.ts";
 import { GlobalOptions } from "../../types.ts";
+import { getHeaders } from "../../utils/utils.ts";
+import { detectAuthGatewayChallenge } from "../../utils/http_guards.ts";
 
 interface DocContentItem {
   title: string;
@@ -36,6 +38,7 @@ async function docs(
 
   console.log(colors.bold(`\nSearching Windmill docs...\n`));
 
+  const extraHeaders = getHeaders();
   let res: Response;
   try {
     res = await fetch(url, {
@@ -43,12 +46,15 @@ async function docs(
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${workspace.token}`,
+        ...extraHeaders,
       },
       body: JSON.stringify({ query }),
     });
   } catch (e) {
     throw new Error(`Network error connecting to ${workspace.remote}: ${e}`);
   }
+
+  await detectAuthGatewayChallenge(res, url);
 
   if (res.status === 403) {
     log.info(

--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -12,7 +12,8 @@ import * as log from "../../core/log.ts";
 import { sep as SEP } from "node:path";
 import * as path from "node:path";
 import { stringify as yamlStringify } from "yaml";
-import { deepEqual, readTextFile, readTextFileSync } from "../../utils/utils.ts";
+import { deepEqual, getHeaders, readTextFile, readTextFileSync } from "../../utils/utils.ts";
+import { detectAuthGatewayChallenge } from "../../utils/http_guards.ts";
 import * as wmill from "../../../gen/services.gen.ts";
 import * as specificItems from "../../core/specific_items.ts";
 import { getCurrentGitBranch } from "../../utils/git.ts";
@@ -725,6 +726,7 @@ async function createScript(
   // (same content, lockfile, and metadata) as a no-op, so the CLI does not
   // produce phantom git-sync / promotion commits on re-pushes.
   const skipIfNoop = "skip_if_noop=true";
+  const extraHeaders = getHeaders();
   if (!bundleContent) {
     try {
       const url =
@@ -738,9 +740,11 @@ async function createScript(
         headers: {
           Authorization: `Bearer ${workspace.token}`,
           "Content-Type": "application/json",
+          ...extraHeaders,
         },
         body: JSON.stringify(body),
       });
+      await detectAuthGatewayChallenge(req, url);
       if (req.status != 201) {
         throw Error(
           `${req.status} - ${req.statusText} - ${await req.text()}`
@@ -771,9 +775,13 @@ async function createScript(
       skipIfNoop;
     const req = await fetch(url, {
       method: "POST",
-      headers: { Authorization: `Bearer ${workspace.token} ` },
+      headers: {
+        Authorization: `Bearer ${workspace.token} `,
+        ...extraHeaders,
+      },
       body: form,
     });
+    await detectAuthGatewayChallenge(req, url);
     if (req.status != 201) {
       throw Error(
         `Script snapshot creation was not successful: ${req.status} - ${
@@ -1587,11 +1595,17 @@ async function preview(
       workspace.workspaceId +
       "/jobs/run/preview_bundle";
 
+    const extraHeaders = getHeaders();
     const response = await fetch(url, {
       method: "POST",
-      headers: { Authorization: `Bearer ${workspace.token}` },
+      headers: {
+        Authorization: `Bearer ${workspace.token}`,
+        ...extraHeaders,
+      },
       body: form,
     });
+
+    await detectAuthGatewayChallenge(response, url);
 
     if (!response.ok) {
       throw new Error(

--- a/cli/test/headers_env_var.test.ts
+++ b/cli/test/headers_env_var.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Integration test: HEADERS env var is forwarded on every CLI fetch call.
+ *
+ * Spins up an auth-gateway proxy in front of the test backend that:
+ *   - 403s + Cloudflare-style HTML if the request is missing CF-Access-Client-Id /
+ *     CF-Access-Client-Secret (mirrors the real-world Cloudflare Access challenge),
+ *   - otherwise reverse-proxies to the backend.
+ *
+ * Then runs `wmill sync push` with --base-url pointed at the proxy. If any fetch
+ * in the CLI bypasses HEADERS, the proxy returns the challenge page and the push
+ * fails (or the request is logged as un-authenticated). Negative case verifies
+ * the gateway actually rejects un-headered requests, so a passing positive case
+ * is meaningful.
+ *
+ * Regression coverage for #6421 and the script.ts pushScript /
+ * jobs/run/preview_bundle / app dev SSE fetch calls that used to skip getHeaders().
+ */
+
+import { expect, test } from "bun:test";
+import { mkdir, writeFile } from "node:fs/promises";
+import type { Server } from "bun";
+import { withTestBackend } from "./test_backend.ts";
+
+const HEADER_NAMES = ["CF-Access-Client-Id", "CF-Access-Client-Secret"] as const;
+const HEADER_VALUES = {
+  "CF-Access-Client-Id": "test-cf-id",
+  "CF-Access-Client-Secret": "test-cf-secret",
+} as const;
+
+const HEADERS_ENV = HEADER_NAMES
+  .map((h) => `${h}: ${HEADER_VALUES[h]}`)
+  .join(", ");
+
+interface ProxyState {
+  authenticatedRequests: { method: string; path: string }[];
+  rejectedRequests: { method: string; path: string }[];
+}
+
+interface RunningProxy {
+  server: Server;
+  state: ProxyState;
+  url: string;
+}
+
+function startGatewayProxy(backendUrl: string): RunningProxy {
+  const state: ProxyState = {
+    authenticatedRequests: [],
+    rejectedRequests: [],
+  };
+
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    async fetch(req) {
+      const reqUrl = new URL(req.url);
+      const pathAndQuery = reqUrl.pathname + reqUrl.search;
+
+      const id = req.headers.get("cf-access-client-id");
+      const secret = req.headers.get("cf-access-client-secret");
+      const passes =
+        id === HEADER_VALUES["CF-Access-Client-Id"] &&
+        secret === HEADER_VALUES["CF-Access-Client-Secret"];
+
+      if (!passes) {
+        state.rejectedRequests.push({ method: req.method, path: pathAndQuery });
+        return new Response(
+          '<!DOCTYPE html><title>Sign in ・ Cloudflare Access</title>' +
+            '<body>Authenticate to reach this site.</body>',
+          {
+            status: 403,
+            headers: {
+              "content-type": "text/html; charset=utf-8",
+              "cf-ray": "0000000000000000-TEST",
+              "cf-mitigated": "challenge",
+            },
+          },
+        );
+      }
+
+      state.authenticatedRequests.push({ method: req.method, path: pathAndQuery });
+
+      const target = new URL(pathAndQuery, backendUrl);
+      const forwardHeaders = new Headers(req.headers);
+      forwardHeaders.delete("cf-access-client-id");
+      forwardHeaders.delete("cf-access-client-secret");
+      forwardHeaders.set("host", new URL(backendUrl).host);
+
+      const body =
+        req.method === "GET" || req.method === "HEAD"
+          ? undefined
+          : await req.arrayBuffer();
+
+      return await fetch(target, {
+        method: req.method,
+        headers: forwardHeaders,
+        body,
+        redirect: "manual",
+      });
+    },
+  });
+
+  return {
+    server,
+    state,
+    url: `http://127.0.0.1:${server.port}`,
+  };
+}
+
+async function runCliThroughProxy(
+  backend: { workspace: string; testConfigDir: string; token?: string },
+  proxyUrl: string,
+  cliArgs: string[],
+  cwd: string,
+  env: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const cliDir = new URL("..", import.meta.url).pathname;
+  const useNode = process.env["TEST_CLI_RUNTIME"] === "node";
+  const runtime = useNode ? "node" : "bun";
+  const entrypoint = useNode
+    ? `${cliDir}/npm/esm/main.js`
+    : `${cliDir}/src/main.ts`;
+  const runtimeArgs = useNode ? [entrypoint] : ["run", entrypoint];
+
+  const fullArgs = [
+    "--base-url", proxyUrl,
+    "--workspace", backend.workspace,
+    "--token", backend.token ?? "",
+    "--config-dir", backend.testConfigDir,
+    ...cliArgs,
+  ];
+
+  const proc = Bun.spawn([runtime, ...runtimeArgs, ...fullArgs], {
+    cwd,
+    env: { ...(process.env as Record<string, string>), ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+  return { stdout, stderr, code };
+}
+
+test(
+  "HEADERS env var is forwarded on every CLI fetch (sync push of new script)",
+  async () => {
+    await withTestBackend(async (backend, tempDir) => {
+      const proxy = startGatewayProxy(backend.baseUrl);
+      try {
+        await writeFile(
+          `${tempDir}/wmill.yaml`,
+          `defaultTs: bun\nincludes:\n  - "**"\nexcludes: []\n`,
+          "utf-8",
+        );
+
+        const uniqueId = Date.now();
+        const scriptName = `headers_${uniqueId}`;
+        const scriptDir = `${tempDir}/f/test`;
+        await mkdir(scriptDir, { recursive: true });
+        await writeFile(
+          `${scriptDir}/${scriptName}.ts`,
+          `export async function main() {\n  return "headers test ${uniqueId}";\n}\n`,
+          "utf-8",
+        );
+        await writeFile(
+          `${scriptDir}/${scriptName}.script.yaml`,
+          [
+            `summary: "headers regression"`,
+            `description: "Push covers /scripts/create + /jobs/run/dependencies_async"`,
+            `lock: ""`,
+            `schema:`,
+            `  $schema: "https://json-schema.org/draft/2020-12/schema"`,
+            `  type: object`,
+            `  properties: {}`,
+            `  required: []`,
+            `is_template: false`,
+            `kind: script`,
+            `language: bun`,
+            ``,
+          ].join("\n"),
+          "utf-8",
+        );
+
+        const includesGlob = `f/test/${scriptName}**`;
+
+        // Negative case: no HEADERS env -> the proxy should return the
+        // gateway challenge and the CLI should bail out non-zero. Proves the
+        // proxy is actually gating, so the positive case isn't a false pass.
+        const noHeaders = await runCliThroughProxy(
+          backend,
+          proxy.url,
+          ["sync", "push", "--yes", "--includes", includesGlob],
+          tempDir,
+          {},
+        );
+        expect(noHeaders.code).not.toEqual(0);
+        expect(proxy.state.rejectedRequests.length).toBeGreaterThan(0);
+        expect(proxy.state.authenticatedRequests.length).toEqual(0);
+
+        // Reset proxy state between cases.
+        proxy.state.authenticatedRequests.length = 0;
+        proxy.state.rejectedRequests.length = 0;
+
+        // Positive case: HEADERS env set -> the proxy must see those headers
+        // on every request the CLI makes for sync push to succeed.
+        const withHeaders = await runCliThroughProxy(
+          backend,
+          proxy.url,
+          ["sync", "push", "--yes", "--includes", includesGlob],
+          tempDir,
+          { HEADERS: HEADERS_ENV },
+        );
+        expect(withHeaders.code).toEqual(0);
+        expect(proxy.state.rejectedRequests).toEqual([]);
+
+        const paths = proxy.state.authenticatedRequests.map((r) => r.path);
+
+        // Print the full path list when an assertion below fails so the
+        // failure is debuggable without re-running with extra logging.
+        const debug = () => paths.join("\n  ");
+
+        // Tarball download (sync diff): src/commands/sync/pull.ts
+        expect(
+          paths.some((p) =>
+            p.startsWith(`/api/w/${backend.workspace}/workspaces/tarball`),
+          ),
+          `expected tarball request, got:\n  ${debug()}`,
+        ).toBe(true);
+
+        // Script create: src/commands/script/script.ts pushScript().
+        // This is the regression: PR #8936 switched from wmill.createScript()
+        // (SDK, inherits OpenAPI.HEADERS) to a raw fetch that didn't forward
+        // HEADERS. Without the fix, the proxy would 403 this request and the
+        // CLI exit would be non-zero — so this assertion is the load-bearing
+        // one for #8936 / #6421-style regressions.
+        expect(
+          paths.some((p) =>
+            p.includes(`/api/w/${backend.workspace}/scripts/create`),
+          ),
+          `expected /scripts/create request, got:\n  ${debug()}`,
+        ).toBe(true);
+
+        // Lock generation: src/utils/metadata.ts. Was the original #6421 fix
+        // (PR #6422) — a soft check; the backend may skip queueing a lock job
+        // for trivial bun scripts under some feature configurations, so we
+        // only verify it *if* the CLI tried to generate one.
+        // (No assertion — covered by the tarball+create checks above plus
+        // the negative case proving the proxy actually gates requests.)
+      } finally {
+        proxy.server.stop(true);
+      }
+    });
+  },
+  240_000,
+);


### PR DESCRIPTION
## Summary

Fix a regression where several `fetch()` calls in the CLI bypassed the `HEADERS` env var, causing `wmill sync push`, `wmill docs`, etc. to fail behind auth gateways like Cloudflare Access. Same shape as #6421 / #6422.

The most impactful site is `pushScript()`:

- **Regressed in #8936** — `/scripts/create` and `/scripts/create_snapshot` were switched from `wmill.createScript()` (SDK, inherits `OpenAPI.HEADERS`) to a raw `fetch` to add a `skip_if_noop` query param, but `getHeaders()` was not added.
- For the user reporting the issue, `wmill sync push` of a brand-new script behind their CF-Access gateway in CI was hitting the gateway challenge page instead of the backend.

Audit of every `fetch()` call in `cli/src/`:

| Site | Status before | Action |
|------|---------------|--------|
| `script.ts` `/scripts/create` (#8936) | missing | **fixed** |
| `script.ts` `/scripts/create_snapshot` (#8936) | missing | **fixed** |
| `script.ts` `/jobs/run/preview_bundle` (#7729) | missing | **fixed** |
| `app/dev.ts` `/jobs_u/getupdate_sse` | missing | **fixed** |
| `docs.ts` `/api/inkeep` | missing | **fixed** |
| `metadata.ts` `/jobs/run/dependencies_async` (#6422) | OK | — |
| `flow_metadata.ts` `/jobs/run/flow_dependencies_async` | OK | — |
| `app_metadata.ts` `/jobs/run/dependencies_async` | OK | — |
| `sync/pull.ts` `/workspaces/tarball` | OK | — |
| `core/context.ts` `/api/version` | OK | — |
| `hub.ts` (public hub) | n/a — different host | — |
| `upgrade.ts` (npm registry) | n/a — different host | — |
| All SDK calls via `OpenAPI.HEADERS` | OK (`main.ts:279`) | — |

All five fixed sites also now call `detectAuthGatewayChallenge()` so a CF-Access HTML challenge surfaces a useful error instead of `JSON.parse` blowing up on `<!DOCTYPE html>`.

## Test plan

- [x] New `test/headers_env_var.test.ts` integration test:
    1. Spins up a Bun HTTP proxy that rejects requests missing `CF-Access-Client-Id` / `CF-Access-Client-Secret` with a Cloudflare-style 403 + HTML body, otherwise reverse-proxies to the backend.
    2. **Negative case**: runs `wmill sync push --yes` of a fresh script through the proxy with no `HEADERS` env — asserts non-zero exit, no requests reach the backend, all requests are rejected. Proves the proxy is actually gating.
    3. **Positive case**: same push with `HEADERS="CF-Access-Client-Id: …, CF-Access-Client-Secret: …"` — asserts zero exit, zero rejected requests, and that both `/workspaces/tarball` (sync diff) and `/scripts/create` (the regression site) were observed with headers attached.
- [x] Verified locally: `DATABASE_URL=… CI_MINIMAL_FEATURES=true bun test test/headers_env_var.test.ts` — 1 pass, 7 expect() calls, ~45s.
- [x] `bun --bun tsc --noEmit -p tsconfig.json` shows no new errors on changed files.
- [x] `bun test test/http_guards_unit.test.ts` still passes (10/10).

## Related

- Original regression: #6421 — fix in #6422 covered lock generation only.
- This PR: covers the remaining backend `fetch` calls and adds end-to-end coverage so future raw-`fetch` additions can't silently re-introduce the same regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward the `HEADERS` env var on all CLI backend fetches and detect auth-gateway challenge pages, fixing `wmill sync push`, previews, and docs behind Cloudflare Access.

- **Bug Fixes**
  - Forward custom headers to: `/scripts/create`, `/scripts/create_snapshot`, `/jobs/run/preview_bundle`, `/jobs_u/getupdate_sse`, and `/api/inkeep`.
  - Use `detectAuthGatewayChallenge()` to surface clear errors when a gateway returns HTML.
  - Add `headers_env_var.test.ts` integration test that gates via a proxy and verifies failure without `HEADERS` and success with it.

<sup>Written for commit 42e5cf387770391a6657c7c80efc7ee35de54ebc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

