### PR TITLE
refactor(git-sync): move gitInitRepo hub path resolution to backend

### DIFF
--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -124,6 +124,10 @@ pub fn workspaced_service() -> Router {
         )
         .route("/edit_datatable_config", post(edit_datatable_config))
         .route("/git_sync_enabled", get(get_git_sync_enabled))
+        .route(
+            "/git_init_repo_script_path",
+            get(get_git_init_repo_script_path),
+        )
         .route("/edit_git_sync_config", post(edit_git_sync_config))
         .route("/edit_git_sync_repository", post(edit_git_sync_repository))
         .route(
@@ -2532,6 +2536,12 @@ async fn get_git_sync_enabled(
         "max_repos": if enabled { Some(1) } else { None::<i32> },
         "user_count": user_count,
         "max_users": CE_GIT_SYNC_MAX_USERS,
+    })))
+}
+
+async fn get_git_init_repo_script_path() -> JsonResult<serde_json::Value> {
+    Ok(Json(serde_json::json!({
+        "script_path": windmill_common::workspaces::LATEST_GIT_INIT_REPO_SCRIPT_PATH,
     })))
 }
 

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -4376,6 +4376,27 @@ paths:
                     type: integer
                     nullable: true
 
+  /w/{workspace}/workspaces/git_init_repo_script_path:
+    get:
+      summary: Get the latest git init repository hub script path
+      operationId: getGitInitRepoScriptPath
+      tags:
+        - workspace
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+      responses:
+        "200":
+          description: Latest hub script path used to initialize a git repository
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  script_path:
+                    type: string
+                required:
+                  - script_path
+
   /w/{workspace}/workspaces/edit_git_sync_config:
     post:
       summary: edit workspace git sync settings

--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -159,6 +159,8 @@ pub enum ObjectType {
 
 pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28217/sync-script-to-git-repo-windmill";
 
+pub const LATEST_GIT_INIT_REPO_SCRIPT_PATH: &str = "hub/28219/git-sync%3A-init-repository-windmill";
+
 /// Prefix used to identify fork workspaces. A workspace whose id starts with this string is a
 /// fork of another workspace.
 pub const WM_FORK_PREFIX: &str = "wm-fork-";

--- a/frontend/src/lib/components/git_sync/GitSyncContext.svelte.ts
+++ b/frontend/src/lib/components/git_sync/GitSyncContext.svelte.ts
@@ -301,9 +301,10 @@ export function createGitSyncContext(workspace: string) {
 		const detectionTimestamp = Date.now()
 
 		try {
+			const { script_path } = await WorkspaceService.getGitInitRepoScriptPath({ workspace })
 			const jobId = await JobService.runScriptByPath({
 				workspace,
-				path: hubPaths.gitInitRepo,
+				path: script_path,
 				requestBody: {
 					workspace_id: workspace,
 					repo_url_resource_path: repo.git_repo_resource_path,

--- a/frontend/src/lib/components/git_sync/PullWorkspaceModal.svelte
+++ b/frontend/src/lib/components/git_sync/PullWorkspaceModal.svelte
@@ -12,10 +12,9 @@
 		Edit3
 	} from 'lucide-svelte'
 	import GitDiffPreview from '../GitDiffPreview.svelte'
-	import { JobService } from '$lib/gen'
+	import { JobService, WorkspaceService } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
 	import { sendUserToast } from '$lib/toast'
-	import hubPaths from '$lib/hubPaths.json'
 	import { jobManager } from '$lib/services/JobManager'
 	import type { SyncResponse, SettingsResponse, SettingsObject } from '$lib/git-sync'
 
@@ -158,9 +157,10 @@
 					currentGitSyncSettings?.repositories?.[repoIndex!]?.use_individual_branch === true
 			}
 
+			const { script_path } = await WorkspaceService.getGitInitRepoScriptPath({ workspace })
 			const jobId = await JobService.runScriptByPath({
 				workspace,
-				path: hubPaths.gitInitRepo,
+				path: script_path,
 				requestBody: payload,
 				skipPreprocessor: true
 			})

--- a/frontend/src/lib/components/git_sync/PushWorkspaceModal.svelte
+++ b/frontend/src/lib/components/git_sync/PushWorkspaceModal.svelte
@@ -3,9 +3,8 @@
 	import { Button, Alert } from '$lib/components/common'
 	import { Loader2, CheckCircle2, XCircle, Terminal, ChevronDown, ChevronUp } from 'lucide-svelte'
 	import GitDiffPreview from '../GitDiffPreview.svelte'
-	import { JobService } from '$lib/gen'
+	import { JobService, WorkspaceService } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
-	import hubPaths from '$lib/hubPaths.json'
 	import { jobManager } from '$lib/services/JobManager'
 	import type { SyncResponse, SettingsObject } from '$lib/git-sync'
 
@@ -89,9 +88,10 @@
 				settings_json: JSON.stringify(uiState)
 			}
 
+			const { script_path } = await WorkspaceService.getGitInitRepoScriptPath({ workspace })
 			const jobId = await JobService.runScriptByPath({
 				workspace,
-				path: hubPaths.gitInitRepo,
+				path: script_path,
 				requestBody: payload,
 				skipPreprocessor: true
 			})

--- a/frontend/src/lib/hub.ts
+++ b/frontend/src/lib/hub.ts
@@ -93,7 +93,6 @@ export function rawAppToHubUrl(hubBaseUrl: string, summary?: string): URL {
 
 type HubPaths = {
 	gitSyncTest: string
-	gitInitRepo: string
 	slackErrorHandler: string
 	slackRecoveryHandler: string
 	slackSuccessHandler: string

--- a/frontend/src/lib/hubPaths.json
+++ b/frontend/src/lib/hubPaths.json
@@ -27,7 +27,6 @@
 	"deprecated_gitSync_latest": "hub/28180/sync-script-to-git-repo-windmill",
 	"deprecated_gitSync_25": "hub/28183/sync-script-to-git-repo-windmill",
 	"gitSyncTest": "hub/28184/git-repo-test-read-write-windmill",
-	"gitInitRepo": "hub/28219/git-sync%3A-init-repository-windmill",
 	"slackErrorHandler": "hub/19741/workspace-or-schedule-error-handler-slack",
 	"slackErrorHandler_0": "hub/9079/workspace-or-schedule-error-handler-slack",
 	"slackErrorHandler_1": "hub/9206/workspace-or-schedule-error-handler-slack",


### PR DESCRIPTION
## Summary

The init-repository hub script path (`gitInitRepo`) was baked into the frontend bundle via `hubPaths.json`, so customers whose browser/CDN cached an older bundle kept invoking the previous hub script (e.g. `hub/28218/...`) even after upgrading to a release where the path had been bumped. Moving the source of truth to the backend fixes this by making the value always reflect the running server, regardless of bundle cache state.

## Changes

- Add `LATEST_GIT_INIT_REPO_SCRIPT_PATH` constant in `windmill-common/src/workspaces.rs` next to `LATEST_GIT_SYNC_SCRIPT_PATH`.
- Expose it via a new authenticated workspaced endpoint `GET /api/w/{workspace}/workspaces/git_init_repo_script_path` returning `{ script_path }`.
- Update the 3 frontend callsites (`PushWorkspaceModal`, `PullWorkspaceModal`, `GitSyncContext`) to fetch the path before calling `JobService.runScriptByPath`.
- Remove `gitInitRepo` from `hubPaths.json` and from the `HubPaths` type in `hub.ts`.

## Test plan

- [ ] `GET /api/w/{ws}/workspaces/git_init_repo_script_path` returns `200 { script_path: "hub/28219/git-sync%3A-init-repository-windmill" }` when authenticated; `401` when not.
- [ ] Init repo flow from the workspace settings UI runs the job against the backend-resolved path.
- [ ] Push / Pull workspace modals trigger the init script via the same path.
- [ ] Bumping the constant in the backend takes effect without any frontend rebuild.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move git init repo hub script path resolution to the backend to avoid stale cached bundles calling outdated scripts. The frontend now fetches the latest path at runtime, so upgrades always run the correct job.

- **Refactors**
  - Added `LATEST_GIT_INIT_REPO_SCRIPT_PATH` and exposed `GET /api/w/{workspace}/workspaces/git_init_repo_script_path` returning `{ script_path }`.
  - Updated `GitSyncContext`, `PushWorkspaceModal`, and `PullWorkspaceModal` to use `WorkspaceService.getGitInitRepoScriptPath` and pass the result to `JobService.runScriptByPath`.
  - Removed `gitInitRepo` from `hubPaths.json` and the `HubPaths` type; documented the new endpoint in `openapi.yaml`.

<sup>Written for commit f8112485f40605c1d78a1e43f3fcbac800ee8fb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

