### PR TITLE
perf(flows): skip flow_env DB+transform work when no resolution is needed

### DIFF
--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -148,6 +148,13 @@ lazy_static::lazy_static! {
     static ref RE_RES_VAR: Regex = Regex::new(r#"\$(?:var|jsonvar|res|encrypted)\:"#).unwrap();
 }
 
+/// Returns true if any value in `vs` contains a `$var:`/`$jsonvar:`/`$res:`/`$encrypted:`
+/// reference that would need interpolation by `transform_json`. Cheap pre-check that
+/// callers can use to skip the DB roundtrip + clone path when nothing requires resolution.
+pub(crate) fn map_needs_resolution(vs: &HashMap<String, Box<RawValue>>) -> bool {
+    vs.values().any(|v| (*RE_RES_VAR).is_match(v.get()))
+}
+
 pub async fn transform_json<'a>(
     client: &AuthedClient,
     workspace: &str,

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -2394,21 +2394,47 @@ async fn resolve_flow_env_for_status_update(
     workspace_id: &str,
     flow_value: &FlowValue,
 ) -> Option<HashMap<String, Box<RawValue>>> {
-    let env = if let Some(ref e) = flow_value.flow_env {
-        e.clone()
-    } else {
-        fetch_root_flow_env(db, flow_job_id, workspace_id).await?
-    };
+    // Fetch the env source. For the inherited path, we first need to know whether the
+    // flow even has a parent — `fetch_root_flow_env` runs a recursive CTE on `v2_job`
+    // and is wasted work for top-level flows with no own `flow_env`. The mini job we
+    // pull here can be reused below if `transform_json` ends up needing it.
+    let (env, mini): (HashMap<String, Box<RawValue>>, Option<MiniPulledJob>) =
+        if let Some(ref e) = flow_value.flow_env {
+            (e.clone(), None)
+        } else {
+            let mini = match get_mini_pulled_job(db, &flow_job_id).await {
+                Ok(Some(j)) => j,
+                Ok(None) => return None,
+                Err(e) => {
+                    tracing::warn!("Failed to fetch flow job to resolve flow_env: {e:#}");
+                    return None;
+                }
+            };
+            if mini.parent_job.is_none() {
+                // No own flow_env and no parent to inherit from — nothing to resolve.
+                return None;
+            }
+            let env = fetch_root_flow_env(db, flow_job_id, workspace_id).await?;
+            (env, Some(mini))
+        };
     if env.is_empty() {
         return Some(env);
     }
-    let mini = match get_mini_pulled_job(db, &flow_job_id).await {
-        Ok(Some(j)) => j,
-        Ok(None) => return Some(env),
-        Err(e) => {
-            tracing::warn!("Failed to fetch flow job to resolve flow_env: {e:#}");
-            return Some(env);
-        }
+    // Skip the DB roundtrip + `transform_json` when nothing in env needs interpolation.
+    // This is the common case: a flow_env containing only literal values.
+    if !crate::common::map_needs_resolution(&env) {
+        return Some(env);
+    }
+    let mini = match mini {
+        Some(m) => m,
+        None => match get_mini_pulled_job(db, &flow_job_id).await {
+            Ok(Some(j)) => j,
+            Ok(None) => return Some(env),
+            Err(e) => {
+                tracing::warn!("Failed to fetch flow job to resolve flow_env: {e:#}");
+                return Some(env);
+            }
+        },
     };
     match transform_json(
         client,


### PR DESCRIPTION
## Summary

Suspected memory regression introduced by #9042 (commit `6e5a21a9c7`, "fix(flows): inherit flow_env in sub-flow predicates"). That PR added `resolve_flow_env_for_status_update`, called per child-job completion in any flow with `stop_after_if` / `stop_after_all_iters_if` / `retry_if`. The function unconditionally:

1. Clones the entire `flow_env` HashMap (`e.clone()`)
2. Issues `get_mini_pulled_job` (extra DB roundtrip)
3. Runs `transform_json` even when the env contains only literal values (no `$var:`/`$res:`/`$jsonvar:`/`$encrypted:`)
4. Calls `fetch_root_flow_env` (recursive CTE on `v2_job`) for top-level flows with no own `flow_env` and no parent — wasted work since the CTE returns nothing

For busy customers running predicate-heavy flows this fires on every step completion, producing a high allocation rate of small `Box<RawValue>` values. Under glibc malloc this manifests as monotonic RSS growth that scales with workload — matches the post-1.696.2 leak pattern reported across AWS-US / UBI-EU / UBI-US.

This PR addresses the first two obvious wins. A follow-up (caching the resolved env per flow execution so we compute it once instead of N×) is being investigated separately.

## Changes

- Add `pub(crate) fn map_needs_resolution(vs: &HashMap<...>) -> bool` in `windmill-worker/src/common.rs` exposing the existing `RE_RES_VAR` pattern check.
- Restructure `resolve_flow_env_for_status_update` in `windmill-worker/src/worker_flow.rs`:
  - Fast-path: skip the DB roundtrip + `transform_json` when no value matches `\$(?:var|jsonvar|res|encrypted)\:`.
  - Skip `fetch_root_flow_env`'s recursive CTE when the flow has no `parent_job` (mirrors the gate already used in `handle_flow`).
  - Reuse the `MiniPulledJob` fetched for the parent check when `transform_json` actually needs it — no double fetch.

Semantics preserved: returning `None` from the no-parent branch is equivalent to the prior `fetch_root_flow_env` returning `None` (CTE seed has `flow_innermost_root_job` and `parent_job` both NULL on top-level flows). The pattern check has the same trigger as `transform_json`'s internal `has_match` short-circuit.

## Test plan

- [ ] Top-level flow (no `flow_env`, no parent) with `stop_after_if` — predicate evaluates, flow stops/continues correctly (exercises `parent_job.is_none()` early return)
- [ ] Sub-flow whose root defines `flow_env` containing only literals + a `stop_after_if` reading `flow_env.X` — predicate sees the literal value (exercises `map_needs_resolution == false` fast-path)
- [ ] Flow whose `flow_env` contains `\$var:` / `\$res:` references + a predicate reading the resolved value — works as before (exercises mini-job reuse path)
- [ ] Existing `flow_engine_parity.rs` integration tests pass (cover inherit-from-root semantics)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip resolving `flow_env` during status updates when no interpolation is needed, and skip root env fetch for top‑level flows without a parent. This reduces DB roundtrips and allocations in predicate‑heavy flows.

- **Performance**
  - Added `map_needs_resolution` to detect `$var:`/`$jsonvar:`/`$res:`/`$encrypted:` and bypass `transform_json` when absent.
  - Reused the same `MiniPulledJob` to avoid double `get_mini_pulled_job` calls.
  - Short‑circuited when `parent_job` is missing, skipping the `fetch_root_flow_env` recursive CTE.

<sup>Written for commit 73b2c5757e94c5724130231ea4bf6313dc035227. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

