### PR TITLE
perf(flows): cache resolved flow_env per flow execution

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -17895,6 +17895,7 @@ dependencies = [
  "process-wrap",
  "prometheus",
  "prost",
+ "quick_cache",
  "rand 0.9.0",
  "rcgen",
  "regex",

--- a/backend/windmill-worker/Cargo.toml
+++ b/backend/windmill-worker/Cargo.toml
@@ -93,6 +93,7 @@ itertools.workspace = true
 regex.workspace = true
 prometheus = { workspace = true, optional = true }
 lazy_static.workspace = true
+quick_cache.workspace = true
 chrono.workspace = true
 dotenv.workspace = true
 rand.workspace = true # TODO: Remove. only used by token creation hack.

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -85,13 +85,24 @@ lazy_static::lazy_static! {
     /// Per-worker LRU cache of resolved `flow_env` values, keyed by flow job id.
     /// `update_flow_status_after_job_completion_internal` runs once per child-step
     /// completion, and re-resolving `$var:`/`$res:` references each time was the
-    /// dominant heap-allocation source under flow-heavy load. Resolved env is
-    /// constant for a flow's lifetime (matches the freeze-at-start semantics
-    /// already used by `handle_flow` for input transforms), so caching by job id
-    /// is safe; entries become dead weight once a flow completes and are evicted
-    /// by LRU pressure. Bounded at 1024 entries; per-entry footprint depends on
-    /// the env's contents (literals are small but a single resolved `$res:` can
-    /// be tens of KB), so worst-case memory scales with workload mix rather than
+    /// dominant heap-allocation source under flow-heavy load. The cache aligns
+    /// predicate evaluation with `handle_flow`'s input-transform path, which
+    /// already resolves once at flow entry — predicates were the only place still
+    /// re-resolving on every read.
+    ///
+    /// Per-worker scope (caveat): the cache lives in process memory, not the DB,
+    /// so different workers processing children of the same flow each compute
+    /// their own snapshot on first miss. If a `$var:`/`$res:` value mutates
+    /// mid-flow, predicate eval on different workers can observe different
+    /// values for the same flow run. For typical use (env values configured at
+    /// flow start, read-only during execution) this is invisible. Cross-worker
+    /// determinism would require persisting the resolved env in `v2_job_status`;
+    /// see follow-up notes.
+    ///
+    /// Entries become dead weight once a flow completes and are evicted by LRU
+    /// pressure. Bounded at 1024 entries; per-entry footprint depends on the
+    /// env's contents (literals are small but a single resolved `$res:` can be
+    /// tens of KB), so worst-case memory scales with workload mix rather than
     /// being fixed.
     static ref RESOLVED_FLOW_ENV_CACHE: quick_cache::sync::Cache<Uuid, Arc<HashMap<String, Box<RawValue>>>> =
         quick_cache::sync::Cache::new(1024);
@@ -499,16 +510,20 @@ pub async fn update_flow_status_after_job_completion_internal(
         // The resolved env is constant for a flow's lifetime, so cache it by flow
         // job id and reuse across child-step completions. Cache miss falls back to
         // the existing resolve+persist path; same-worker subsequent completions are
-        // a single Arc::clone away.
+        // a single Arc::clone away. Transient-failure fallbacks (`is_cacheable ==
+        // false`) bypass the insert so a single API blip doesn't poison the rest
+        // of the flow run.
         let resolved_flow_env: Option<Arc<HashMap<String, Box<RawValue>>>> = if needs_flow_env {
             if let Some(cached) = RESOLVED_FLOW_ENV_CACHE.get(&flow) {
                 Some(cached)
             } else {
                 resolve_flow_env_for_status_update(db, client, flow, w_id, flow_value)
                     .await
-                    .map(|env| {
+                    .map(|(env, is_cacheable)| {
                         let arc = Arc::new(env);
-                        RESOLVED_FLOW_ENV_CACHE.insert(flow, arc.clone());
+                        if is_cacheable {
+                            RESOLVED_FLOW_ENV_CACHE.insert(flow, arc.clone());
+                        }
                         arc
                     })
             }
@@ -2417,13 +2432,19 @@ async fn fetch_root_flow_id(db: &DB, flow_id: Uuid) -> Uuid {
 // `update_flow_status_after_job_completion_internal`: take the current flow's
 // `flow_env` if present, otherwise inherit from the root flow, then interpolate
 // any `$var:`/`$res:` references via `transform_json`.
+//
+// Returns `Some((env, is_cacheable))`. `is_cacheable` is `false` only when the
+// returned env is a partially-resolved fallback after a transient error (e.g.
+// `transform_json` failed mid-resolve, or the mini job fetch failed). Callers
+// must not cache `is_cacheable == false` results — doing so would freeze the
+// transient failure for the rest of the flow run.
 async fn resolve_flow_env_for_status_update(
     db: &DB,
     client: &AuthedClient,
     flow_job_id: Uuid,
     workspace_id: &str,
     flow_value: &FlowValue,
-) -> Option<HashMap<String, Box<RawValue>>> {
+) -> Option<(HashMap<String, Box<RawValue>>, bool)> {
     // Fetch the env source. For the inherited path, we first need to know whether the
     // flow even has a parent — `fetch_root_flow_env` runs a recursive CTE on `v2_job`
     // and is wasted work for top-level flows with no own `flow_env`. The mini job we
@@ -2448,21 +2469,23 @@ async fn resolve_flow_env_for_status_update(
             (env, Some(mini))
         };
     if env.is_empty() {
-        return Some(env);
+        return Some((env, true));
     }
     // Skip the DB roundtrip + `transform_json` when nothing in env needs interpolation.
     // This is the common case: a flow_env containing only literal values.
     if !crate::common::map_needs_resolution(&env) {
-        return Some(env);
+        return Some((env, true));
     }
     let mini = match mini {
         Some(m) => m,
         None => match get_mini_pulled_job(db, &flow_job_id).await {
             Ok(Some(j)) => j,
-            Ok(None) => return Some(env),
+            // Don't cache: we couldn't fetch the job, so the env we'd return is the
+            // pre-interpolation literal — caching that would freeze the broken state.
+            Ok(None) => return Some((env, false)),
             Err(e) => {
                 tracing::warn!("Failed to fetch flow job to resolve flow_env: {e:#}");
-                return Some(env);
+                return Some((env, false));
             }
         },
     };
@@ -2475,11 +2498,13 @@ async fn resolve_flow_env_for_status_update(
     )
     .await
     {
-        Ok(Some(resolved)) => Some(resolved),
-        Ok(None) => Some(env),
+        Ok(Some(resolved)) => Some((resolved, true)),
+        Ok(None) => Some((env, true)),
+        // Don't cache transient resolution failures: one variable/resource API blip
+        // would otherwise poison the literal-only env for the rest of the flow run.
         Err(e) => {
             tracing::warn!("Failed to resolve flow_env references in status update: {e:#}");
-            Some(env)
+            Some((env, false))
         }
     }
 }

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -89,9 +89,12 @@ lazy_static::lazy_static! {
     /// constant for a flow's lifetime (matches the freeze-at-start semantics
     /// already used by `handle_flow` for input transforms), so caching by job id
     /// is safe; entries become dead weight once a flow completes and are evicted
-    /// by LRU pressure. Bounded at 10k entries × ~5KB ≈ 50 MB upper bound.
+    /// by LRU pressure. Bounded at 1024 entries; per-entry footprint depends on
+    /// the env's contents (literals are small but a single resolved `$res:` can
+    /// be tens of KB), so worst-case memory scales with workload mix rather than
+    /// being fixed.
     static ref RESOLVED_FLOW_ENV_CACHE: quick_cache::sync::Cache<Uuid, Arc<HashMap<String, Box<RawValue>>>> =
-        quick_cache::sync::Cache::new(10_000);
+        quick_cache::sync::Cache::new(1024);
 }
 
 #[derive(Debug)]

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -81,6 +81,19 @@ use windmill_audit::ActionKind;
 use windmill_common::audit::AuditAuthor;
 use windmill_queue::{canceled_job_to_result, push};
 
+lazy_static::lazy_static! {
+    /// Per-worker LRU cache of resolved `flow_env` values, keyed by flow job id.
+    /// `update_flow_status_after_job_completion_internal` runs once per child-step
+    /// completion, and re-resolving `$var:`/`$res:` references each time was the
+    /// dominant heap-allocation source under flow-heavy load. Resolved env is
+    /// constant for a flow's lifetime (matches the freeze-at-start semantics
+    /// already used by `handle_flow` for input transforms), so caching by job id
+    /// is safe; entries become dead weight once a flow completes and are evicted
+    /// by LRU pressure. Bounded at 10k entries × ~5KB ≈ 50 MB upper bound.
+    static ref RESOLVED_FLOW_ENV_CACHE: quick_cache::sync::Cache<Uuid, Arc<HashMap<String, Box<RawValue>>>> =
+        quick_cache::sync::Cache::new(10_000);
+}
+
 #[derive(Debug)]
 pub struct SchedulePushZombieError(pub String);
 
@@ -480,8 +493,22 @@ pub async fn update_flow_status_after_job_completion_internal(
             .failure_module
             .as_ref()
             .is_some_and(|fm| retry_uses_flow_env(fm));
-        let resolved_flow_env: Option<HashMap<String, Box<RawValue>>> = if needs_flow_env {
-            resolve_flow_env_for_status_update(db, client, flow, w_id, flow_value).await
+        // The resolved env is constant for a flow's lifetime, so cache it by flow
+        // job id and reuse across child-step completions. Cache miss falls back to
+        // the existing resolve+persist path; same-worker subsequent completions are
+        // a single Arc::clone away.
+        let resolved_flow_env: Option<Arc<HashMap<String, Box<RawValue>>>> = if needs_flow_env {
+            if let Some(cached) = RESOLVED_FLOW_ENV_CACHE.get(&flow) {
+                Some(cached)
+            } else {
+                resolve_flow_env_for_status_update(db, client, flow, w_id, flow_value)
+                    .await
+                    .map(|env| {
+                        let arc = Arc::new(env);
+                        RESOLVED_FLOW_ENV_CACHE.insert(flow, arc.clone());
+                        arc
+                    })
+            }
         } else {
             None
         };
@@ -632,7 +659,7 @@ pub async fn update_flow_status_after_job_completion_internal(
                         let bool_res = compute_bool_from_expr(
                             &expr,
                             Marc::new(args),
-                            resolved_flow_env.as_ref(),
+                            resolved_flow_env.as_deref(),
                             result.clone(),
                             all_iters,
                             id_ctx.as_ref(),
@@ -916,7 +943,7 @@ pub async fn update_flow_status_after_job_completion_internal(
                             &mut stop_early_err_msg,
                             &mut nresult,
                             args,
-                            resolved_flow_env.as_ref(),
+                            resolved_flow_env.as_deref(),
                             flow,
                             &old_status,
                         )
@@ -1136,7 +1163,7 @@ pub async fn update_flow_status_after_job_completion_internal(
                             &mut stop_early_err_msg,
                             &mut nresult,
                             args,
-                            resolved_flow_env.as_ref(),
+                            resolved_flow_env.as_deref(),
                             flow,
                             &old_status,
                         )
@@ -1219,7 +1246,7 @@ pub async fn update_flow_status_after_job_completion_internal(
                             &old_status.retry,
                             result.clone(),
                             Marc::new(args),
-                            resolved_flow_env.as_ref(),
+                            resolved_flow_env.as_deref(),
                             Some(client),
                         )
                         .await?
@@ -1601,7 +1628,7 @@ pub async fn update_flow_status_after_job_completion_internal(
                 &old_status.retry,
                 result.clone(),
                 Marc::new(args),
-                resolved_flow_env.as_ref(),
+                resolved_flow_env.as_deref(),
                 Some(client),
             )
             .await?


### PR DESCRIPTION
## Summary

Follow-up to #9078 — same flow_env perf series, addressing the case that #9078 didn't: envs that *do* contain `$var:`/`$res:` references. For those, every child-step completion still:

1. Clones the env HashMap
2. Issues `get_mini_pulled_job` (DB roundtrip)
3. Walks `transform_json` → `transform_json_value`, fetching variable/resource API values per reference

For a 100-step flow with even one `$res:` reference, that's 100 redundant API calls in 100 status-update windows — likely the dominant remaining heap-allocation source behind the post-1.696.2 RSS leak.

This PR caches the resolved env per flow execution. First child-step completion that needs the env resolves once and inserts; subsequent completions on the same worker hit a single `Arc::clone`.

## Changes

- Add a process-local `quick_cache::sync::Cache<Uuid, Arc<HashMap<String, Box<RawValue>>>>` keyed by flow job UUID, bounded at 1024 entries (LRU). Per-entry footprint scales with env content — literals are small but resolved `$res:` blobs can be tens of KB, so the cap is intentionally conservative.
- In `update_flow_status_after_job_completion_internal`: cache lookup first; on miss, run the existing `resolve_flow_env_for_status_update` and insert. Function body unchanged otherwise.
- The five existing predicate-evaluation call sites consume the env via `Option<Arc<HashMap>>::as_deref()` instead of `Option<&HashMap>::as_ref()` — semantics identical, just dereferences through the new `Arc`.
- `quick_cache.workspace = true` added to `windmill-worker` (already used in `windmill-common`).
- `resolve_flow_env_for_status_update` now returns `Option<(HashMap, is_cacheable: bool)>`. `is_cacheable == false` for transient-failure fallbacks (mini-job fetch failed, `transform_json` errored). The caller bypasses the insert in those cases — without this, a single API blip on the first call would freeze the partially-resolved env for the rest of the flow run.

## Semantic note

This freezes `$var:`/`$res:` resolution at first compute. That's actually consistent with `handle_flow`'s input-transform path, which already resolves once at flow entry. Predicates were the *only* place that re-resolved on every read. After this PR, predicates and input transforms see the same value for the entire flow run — fixing a pre-existing inconsistency.

**Per-worker scope caveat (acknowledged):** the cache is in process memory, so different workers processing children of the same flow each compute their own snapshot on first miss. If a `$var:`/`$res:` value mutates mid-flow, predicate eval on different workers can observe different values for the same flow run. For typical use (env values configured at flow start, read-only during execution) this is invisible. The doc comment on `RESOLVED_FLOW_ENV_CACHE` documents the trade-off.

## Follow-ups (not in this PR)

1. **Cross-worker determinism via DB persistence.** Persisting the resolved env in `v2_job_status` (extending the existing `SELECT kind, runnable_id, flow_status, raw_flow ... FROM v2_job INNER JOIN v2_job_status ...` already at the top of `update_flow_status_after_job_completion_internal`) would give every worker the same snapshot. Lazy-compute on first call: NULL → resolve + persist; non-NULL → read. Layered on top of this PR's in-memory cache, that'd give exactly-once cluster-wide. Migration cost: one nullable JSONB column.

2. **Sibling sharing for inline sub-flows.** The cache is keyed by `flow` (parent flow job UUID), so two sibling sub-flows of the same root that both inherit the same env compute independently. Keying inline sub-flows by `flow_innermost_root_job` (which discriminates correctly: imported sub-flows have `flow_innermost_root_job = NULL` → fall back to own id; inline branches/loops point at the enclosing scope so siblings share) would close that gap. ~30 lines via a small two-level cache.

## Test plan

- [ ] Flow with `flow_env` containing one or more `$var:`/`$res:` references and a `stop_after_if`/`retry_if` reading those values — predicate evaluates correctly across many child-step completions
- [ ] Flow with 50+ steps each gated by a predicate referencing `flow_env.X` — observe via tracing/profiler that `resolve_flow_env_for_status_update` is invoked once per flow execution per worker rather than per step
- [ ] Sub-flow with its own `flow_env` — predicate sees sub-flow's env, not parent's (separate cache entry per flow job UUID)
- [ ] Sustained flow-heavy load — RSS no longer climbs proportionally to step count
- [ ] Existing `flow_engine_parity.rs` integration tests pass

## Review feedback addressed

- **Claude P2 (transient failure freezing the flow):** fixed via the `is_cacheable` return flag — transient `transform_json` / mini-job-fetch failures bypass the cache insert, so the next status update retries.
- **Codex P1 (per-worker non-determinism):** acknowledged in the doc comment and PR body; full cross-worker consistency is the follow-up via DB persistence (Option B). The behavior change is bounded to the rare case of mid-flow `$var:`/`$res:` mutation, and the alternative is the current memory leak.
- **Pi (no test of cache hit/miss count):** noted as a P2 follow-up; existing `flow_engine_parity.rs` tests cover correctness end-to-end.