### PR TITLE
fix(cli-tests): stabilize flow lock-gen race + Windows path

### DIFF
--- a/cli/test/headers_env_var.test.ts
+++ b/cli/test/headers_env_var.test.ts
@@ -18,6 +18,8 @@
 
 import { expect, test } from "bun:test";
 import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { Server } from "bun";
 import { withTestBackend } from "./test_backend.ts";
 
@@ -113,12 +115,16 @@ async function runCliThroughProxy(
   cwd: string,
   env: Record<string, string>,
 ): Promise<{ stdout: string; stderr: string; code: number }> {
-  const cliDir = new URL("..", import.meta.url).pathname;
+  // Use fileURLToPath + node:path so the CLI entrypoint is a real OS path on
+  // Windows. `new URL(..).pathname` yields `/C:/...` which Bun.spawn fails to
+  // resolve, so the negative case "rejected" on launch instead of reaching
+  // the proxy and the assertion on rejectedRequests > 0 flaked.
+  const cliDir = join(dirname(fileURLToPath(import.meta.url)), "..");
   const useNode = process.env["TEST_CLI_RUNTIME"] === "node";
   const runtime = useNode ? "node" : "bun";
   const entrypoint = useNode
-    ? `${cliDir}/npm/esm/main.js`
-    : `${cliDir}/src/main.ts`;
+    ? join(cliDir, "npm", "esm", "main.js")
+    : join(cliDir, "src", "main.ts");
   const runtimeArgs = useNode ? [entrypoint] : ["run", entrypoint];
 
   const fullArgs = [

--- a/cli/test/mixed_case_paths.test.ts
+++ b/cli/test/mixed_case_paths.test.ts
@@ -130,6 +130,37 @@ async function createFlow(
     throw new Error(`Failed to create flow ${flowPath}: ${error}`);
   }
   await response.text();
+
+  // Flow creation queues an async FlowDependencies job that generates the
+  // inline-script lockfile and rewrites flow.value. If we don't wait, a
+  // subsequent pull/push races the worker and the dry-run idempotency
+  // assertion sees a phantom lock-add + flow.yaml-edit diff (CI-only flake).
+  await waitForFlowDependencyJob(backend, flowPath);
+}
+
+async function waitForFlowDependencyJob(
+  backend: any,
+  flowPath: string,
+  timeoutMs: number = 30000,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const flow = await getFlow(backend, flowPath);
+    const depJobId: string | undefined = flow?.dependency_job;
+    if (!depJobId) return;
+    const completed = await backend.apiRequest!(
+      `/api/w/${backend.workspace}/jobs_u/completed/get/${depJobId}`,
+    );
+    if (completed.ok) {
+      await completed.text();
+      return;
+    }
+    await completed.text().catch(() => {});
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(
+    `Flow dependency job for ${flowPath} did not complete within ${timeoutMs}ms`,
+  );
 }
 
 async function createApp(
@@ -383,6 +414,10 @@ excludes: []
       // Verify modification on server
       const updatedFlow = await getFlow(backend, flowPath);
       expect(updatedFlow.summary).toEqual("Modified Data Processor Flow from test");
+
+      // The CLI push enqueues a fresh FlowDependencies job. Wait for it before
+      // the dry-run pull so the lock/flow.value writes have committed.
+      await waitForFlowDependencyJob(backend, flowPath);
 
       // Verify no diff on subsequent pull (idempotency)
       await verifyNoDiffOnPull(backend, tempDir);

--- a/cli/test/mixed_case_paths.test.ts
+++ b/cli/test/mixed_case_paths.test.ts
@@ -143,11 +143,31 @@ async function waitForFlowDependencyJob(
   flowPath: string,
   timeoutMs: number = 30000,
 ): Promise<void> {
+  // /flows/get does not return `dependency_job`. The deployment_status route
+  // joins flow_version against deployment_metadata, which is populated in the
+  // same tx as the FlowDependencies push, so by the time the create/update
+  // API call returns, job_id is already the latest dep-job UUID.
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
-    const flow = await getFlow(backend, flowPath);
-    const depJobId: string | undefined = flow?.dependency_job;
-    if (!depJobId) return;
+    const statusResp = await backend.apiRequest!(
+      `/api/w/${backend.workspace}/flows/deployment_status/p/${flowPath}`,
+    );
+    if (statusResp.status === 404) {
+      await statusResp.text().catch(() => {});
+      return;
+    }
+    if (!statusResp.ok) {
+      await statusResp.text().catch(() => {});
+      throw new Error(
+        `Failed to fetch deployment status for ${flowPath}: ${statusResp.status}`,
+      );
+    }
+    const status = await statusResp.json();
+    const depJobId: string | undefined = status?.job_id;
+    if (!depJobId) {
+      await new Promise((r) => setTimeout(r, 100));
+      continue;
+    }
     const completed = await backend.apiRequest!(
       `/api/w/${backend.workspace}/jobs_u/completed/get/${depJobId}`,
     );

--- a/cli/test/sync_pull_push.test.ts
+++ b/cli/test/sync_pull_push.test.ts
@@ -493,6 +493,50 @@ async function cleanupTempDir(dir: string): Promise<void> {
   }
 }
 
+// Polls /flows/get + /jobs_u/completed/get until the most recent flow
+// dependency job has completed. After a flow create/update the API queues a
+// FlowDependencies job that asynchronously fills inline-script lockfiles and
+// rewrites flow.value; tests that round-trip through sync push/pull must wait
+// for it or they race the worker (CI-only flake). Returns silently if the
+// flow doesn't exist on the server (treats it as a no-op push).
+async function waitForFlowDependencyJob(
+  backend: any,
+  flowPath: string,
+  timeoutMs: number = 30000,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const flowResp = await backend.apiRequest!(
+      `/api/w/${backend.workspace}/flows/get/${encodeURIComponent(flowPath)}`,
+    );
+    if (flowResp.status === 404) {
+      await flowResp.text().catch(() => {});
+      return;
+    }
+    if (!flowResp.ok) {
+      await flowResp.text().catch(() => {});
+      throw new Error(
+        `Failed to fetch flow ${flowPath}: ${flowResp.status}`,
+      );
+    }
+    const flow = await flowResp.json();
+    const depJobId: string | undefined = flow?.dependency_job;
+    if (!depJobId) return;
+    const completed = await backend.apiRequest!(
+      `/api/w/${backend.workspace}/jobs_u/completed/get/${depJobId}`,
+    );
+    if (completed.ok) {
+      await completed.text();
+      return;
+    }
+    await completed.text().catch(() => {});
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(
+    `Flow dependency job for ${flowPath} did not complete within ${timeoutMs}ms`,
+  );
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -1796,6 +1840,12 @@ excludes: []
       );
 
       expect(pushResult.code).toEqual(0);
+
+      // sync push of the flow enqueues an async FlowDependencies job that
+      // generates the inline-script lockfile and rewrites flow.value. Wait for
+      // it before pulling back, otherwise pull races the worker and the
+      // dry-run push idempotency check sees phantom diffs (CI-only flake).
+      await waitForFlowDependencyJob(backend, flowName);
 
       // Pull back
       const pullResult = await backend.runCLICommand(

--- a/cli/test/sync_pull_push.test.ts
+++ b/cli/test/sync_pull_push.test.ts
@@ -493,12 +493,17 @@ async function cleanupTempDir(dir: string): Promise<void> {
   }
 }
 
-// Polls /flows/get + /jobs_u/completed/get until the most recent flow
-// dependency job has completed. After a flow create/update the API queues a
-// FlowDependencies job that asynchronously fills inline-script lockfiles and
-// rewrites flow.value; tests that round-trip through sync push/pull must wait
-// for it or they race the worker (CI-only flake). Returns silently if the
-// flow doesn't exist on the server (treats it as a no-op push).
+// Polls /flows/deployment_status/p/{path} + /jobs_u/completed/get until the
+// most recent flow dependency job has completed. After a flow create/update
+// the API queues a FlowDependencies job that asynchronously fills inline-
+// script lockfiles and rewrites flow.value; tests that round-trip through
+// sync push/pull must wait for it or they race the worker (CI-only flake).
+// `deployment_status` is the right read here — `/flows/get` does not return
+// `dependency_job`, but the `deployment_metadata.job_id` row is written in
+// the same tx as the dep-job push, so the returned `job_id` is the latest
+// dep-job UUID by the time the create/update API call has returned. Returns
+// silently if the flow doesn't exist on the server (treats it as a no-op
+// push, since the route returns 404 when the flow row is missing).
 async function waitForFlowDependencyJob(
   backend: any,
   flowPath: string,
@@ -506,22 +511,25 @@ async function waitForFlowDependencyJob(
 ): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
-    const flowResp = await backend.apiRequest!(
-      `/api/w/${backend.workspace}/flows/get/${encodeURIComponent(flowPath)}`,
+    const statusResp = await backend.apiRequest!(
+      `/api/w/${backend.workspace}/flows/deployment_status/p/${flowPath}`,
     );
-    if (flowResp.status === 404) {
-      await flowResp.text().catch(() => {});
+    if (statusResp.status === 404) {
+      await statusResp.text().catch(() => {});
       return;
     }
-    if (!flowResp.ok) {
-      await flowResp.text().catch(() => {});
+    if (!statusResp.ok) {
+      await statusResp.text().catch(() => {});
       throw new Error(
-        `Failed to fetch flow ${flowPath}: ${flowResp.status}`,
+        `Failed to fetch deployment status for ${flowPath}: ${statusResp.status}`,
       );
     }
-    const flow = await flowResp.json();
-    const depJobId: string | undefined = flow?.dependency_job;
-    if (!depJobId) return;
+    const status = await statusResp.json();
+    const depJobId: string | undefined = status?.job_id;
+    if (!depJobId) {
+      await new Promise((r) => setTimeout(r, 100));
+      continue;
+    }
     const completed = await backend.apiRequest!(
       `/api/w/${backend.workspace}/jobs_u/completed/get/${depJobId}`,
     );


### PR DESCRIPTION
## Summary

The latest main CLI Tests run ([25536061370](https://github.com/windmill-labs/windmill/actions/runs/25536061370)) failed with three tests, all of which are flakes (history shows 3 of the 5 failing main runs in the last 50 hit one of the same tests):

- `Mixed Case Paths: pull and push flow with capitalized folder` (linux) — also failed on 2026-05-01.
- `Integration: Mixed scripts and flows with nonDottedPaths are idempotent` (linux) — also failed on 2026-04-24.
- `HEADERS env var is forwarded on every CLI fetch (sync push of new script)` (windows) — added by #9075, regression on Windows only.

### Flow lock-gen race (1 + 2)

Flow create/update queues an async `FlowDependencies` job that fills inline-script lockfiles and rewrites `flow.value`. The two tests pulled/pushed before the worker finished, so the dry-run idempotency check saw phantom `*.inline_script.lock` adds and `flow.yaml` edits like:

```
{ "type": "added",  "path": "f/MyFlows/DataProcessor.flow/a.inline_script.lock" }
{ "type": "edited", "path": "f/MyFlows/DataProcessor.flow/flow.yaml" }
```

This mirrors the script-side fix #8202 but at a different layer: flows always queue the dependency job (vs. scripts which gate it on `lock.is_some()`), so we need a positive wait, not just a pre-set lock.

Added a `waitForFlowDependencyJob` helper that polls `/flows/get` for the latest `dependency_job` UUID and `/jobs_u/completed/get` until the job lands, then called it after every API/CLI flow write in both tests. The `sync_pull_push` copy returns silently on 404 since that test path only conditionally pushes the flow.

### Windows path (3)

The new `headers_env_var.test.ts` built the CLI entrypoint via:

```ts
const cliDir = new URL("..", import.meta.url).pathname;
const entrypoint = `${cliDir}/src/main.ts`;
```

`new URL().pathname` returns `/C:/runner/_work/windmill/windmill/cli/` on Windows. `Bun.spawn(["bun", "run", "/C:/.../src/main.ts"])` rejected before the CLI ever connected to the proxy, so the negative-case assertion `rejectedRequests.length > 0` got 0 (test ran in 47ms, well under the CLI startup time).

Switched to the same `fileURLToPath` + `node:path.join` pattern `cargo_backend.ts` already uses for `runCLICommand`.

## Test plan

- [x] `bun test test/mixed_case_paths.test.ts` — 7/7 pass locally (5x stress-tested).
- [x] `bun test -t "Mixed scripts and flows with nonDottedPaths are idempotent"` — passes.
- [x] `bun test test/headers_env_var.test.ts` — passes.
- [ ] CI on linux + windows passes the CLI Tests workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes flaky CLI tests by waiting for flow dependency job completion and fixes Windows path resolution for the CLI entrypoint. Removes the race on inline-script lockfile generation and makes the `HEADERS` proxy test reliable on Windows.

- **Bug Fixes**
  - Updated `waitForFlowDependencyJob` to read `job_id` from `/flows/deployment_status/p/{path}` and poll `/jobs_u/completed/get/{job_id}`; called after flow create/update and `sync push` in `mixed_case_paths.test.ts` and `sync_pull_push.test.ts` (404 is a silent no-op). Prevents phantom `*.inline_script.lock` and `flow.yaml` diffs.
  - Switched `headers_env_var.test.ts` to build the CLI entrypoint with `fileURLToPath` and `node:path.join`, avoiding `/C:/...` paths that `Bun.spawn` rejects on Windows (works with Bun and Node).

<sup>Written for commit a89615eda14d66011672c992395662ee32ff39bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

