### PR TITLE
fix: reject root-rooted paths in ansible playbook validator on windows

### DIFF
--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -121,18 +121,24 @@ fn validate_relative_path(path: &str, field_name: &str) -> error::Result<()> {
         )));
     }
     let p = std::path::Path::new(trimmed);
-    if p.is_absolute() {
-        return Err(error::Error::BadRequest(format!(
-            "`{}` must be a relative path inside the cloned repo, got: {}",
-            field_name, trimmed
-        )));
-    }
     for component in p.components() {
-        if matches!(component, std::path::Component::ParentDir) {
-            return Err(error::Error::BadRequest(format!(
-                "`{}` must not contain `..` segments, got: {}",
-                field_name, trimmed
-            )));
+        match component {
+            // RootDir catches leading `/` or `\`; Prefix catches Windows drive
+            // letters and UNC paths. `Path::is_absolute()` alone misses
+            // RootDir-only paths on Windows (e.g. `/etc/passwd`).
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => {
+                return Err(error::Error::BadRequest(format!(
+                    "`{}` must be a relative path inside the cloned repo, got: {}",
+                    field_name, trimmed
+                )));
+            }
+            std::path::Component::ParentDir => {
+                return Err(error::Error::BadRequest(format!(
+                    "`{}` must not contain `..` segments, got: {}",
+                    field_name, trimmed
+                )));
+            }
+            _ => {}
         }
     }
     Ok(())
@@ -1765,7 +1771,17 @@ mod tests {
 
     #[test]
     fn test_validate_relative_path_rejects_absolute() {
+        // `/etc/passwd` isn't `is_absolute()` on Windows (no drive prefix), but
+        // its leading RootDir still escapes the cloned repo, so reject it on
+        // every platform.
         assert!(validate_relative_path("/etc/passwd", "playbook").is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_validate_relative_path_rejects_windows_absolute() {
+        assert!(validate_relative_path("\\etc\\passwd", "playbook").is_err());
+        assert!(validate_relative_path("C:\\Windows\\System32", "playbook").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
The Windows backend test job has been failing on `windmill-worker::ansible_executor::tests::test_validate_relative_path_rejects_absolute`. Root cause: `Path::new(\"/etc/passwd\").is_absolute()` returns `false` on Windows because Windows requires a drive prefix (e.g. `C:\\…`) for `is_absolute()`. The leading `/` only produces a `RootDir` component without a `Prefix`, so the existing check let the path through. This is also a real security gap — that path would resolve to the root of the current drive on Windows and still escape the cloned repo.

## Changes
- `backend/windmill-worker/src/ansible_executor.rs`: replace the `is_absolute()` check with a single component-walk that rejects `RootDir` and `Prefix` alongside the existing `ParentDir` rejection. Covers `/foo`, `\foo`, `C:\foo`, drive-relative `C:foo`, and UNC paths uniformly across platforms.
- Added a `#[cfg(windows)]` test asserting backslash and drive-prefixed paths are rejected.

## Test plan
- [x] `cargo test -p windmill-worker --lib ansible_executor::tests` passes locally on Linux (9/9)
- [ ] Windows CI (`backend-test-windows.yml`) goes green on next `v*` tag push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes path validation for Ansible playbooks on Windows by rejecting root-rooted and drive/UNC paths to prevent repo escape. This closes the gap that let "/etc/passwd" pass on Windows and stabilizes the failing test.

- **Bug Fixes**
  - Replaced `is_absolute()` with a component check that rejects `RootDir`, `Prefix`, and `ParentDir`.
  - Blocks `/foo`, `\foo`, `C:\foo`, `C:foo`, and UNC paths consistently across platforms.
  - Added Windows-only tests for backslash and drive-prefixed paths.

<sup>Written for commit edbadf4defb239f4ffc13b83f9e905dd5d4a0f2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

