### PR TITLE
fix(cli): bump svelte version in `wmill app new` template

### DIFF
--- a/cli/src/commands/app/new.ts
+++ b/cli/src/commands/app/new.ts
@@ -156,7 +156,7 @@ const templates: Record<string, FrameworkTemplate> = {
       "/index.css": indexCss,
       "/package.json": `{
     "dependencies": {
-        "svelte": "5.45.2",
+        "svelte": "^5.55.5",
         "windmill-client": "^1"
     }
 }`,

--- a/frontend/src/routes/(root)/(logged)/apps_raw/add/templates.ts
+++ b/frontend/src/routes/(root)/(logged)/apps_raw/add/templates.ts
@@ -136,7 +136,7 @@ export const svelte5Template = {
 	'/index.css': indexCss,
 	'/package.json': `{
     "dependencies": {
-        "svelte": "5.45.2",
+        "svelte": "^5.55.5",
         "windmill-client": "^1"
     }
 }`


### PR DESCRIPTION
## Summary

The `svelte5` template in `cli/src/commands/app/new.ts` pinned `svelte` to `5.45.2`, but the Svelte compiler bundled in `wmill app dev` emits `$.delegated('click', ...)` calls. The `delegated` export was added to Svelte's internal client later, so 5.45.2 doesn't have it.

Symptom: `wmill app new --framework svelte5` followed by `wmill app dev .` produces a **white page**. esbuild prints `Import "delegated" will always be undefined`, replaces the call with `void 0`, then the page crashes at first event-handler bind.

This bumps the template's `svelte` dependency to `^5.55.5` so the runtime and the bundled compiler stay in sync.

## Test plan
- [ ] `wmill app new --framework svelte5 --path f/test/foo --summary test` (use a fresh CLI build)
- [ ] `cd` into the new app, `npm install`, `wmill app dev .`
- [ ] Browser shows the hello-world without a `(void 0)("click", ...)` call in the bundle and without the `Import "delegated" will always be undefined` warning in the dev server output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a version mismatch by bumping `svelte` to `^5.55.5` in both the `svelte5` CLI template and the UI’s Add raw app template to match the compiler used by `wmill app dev`. This prevents the white screen and `esbuild` warning about a missing `delegated` export.

<sup>Written for commit ba3b0fe32c0890b0f235107eaf94b91a29cec32f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

