### PR TITLE
perf(flows): gate flow_env resolve on expr text and share cache with handle_flow

### DIFF
--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -494,19 +494,34 @@ pub async fn update_flow_status_after_job_completion_internal(
         }
 
         // Resolve flow_env for predicate evaluations (stop_after_if,
-        // stop_after_all_iters_if, retry_if). Only fetch when one of these
-        // predicates is configured to avoid an extra DB query on the common
-        // path. `retry` without `retry_if` doesn't consult flow_env.
-        let retry_uses_flow_env =
-            |module: &FlowModule| module.retry.as_ref().is_some_and(|r| r.retry_if.is_some());
+        // stop_after_all_iters_if, retry_if). Two-level gate:
+        //   1. Structural — at least one such predicate is configured.
+        //   2. Textual — the predicate expression actually references
+        //      `flow_env`. Mirrors the existing `expr.contains("results.")`
+        //      check in `get_id_ctx_for_expr`. A substring match has false
+        //      positives (harmless — just runs an unneeded resolve) but no
+        //      false negatives, since `flow_env` must appear textually for the
+        //      expression engine to read it.
+        let expr_uses_flow_env = |expr: &str| expr.contains("flow_env");
+        let retry_if_uses_flow_env = |module: &FlowModule| {
+            module
+                .retry
+                .as_ref()
+                .and_then(|r| r.retry_if.as_ref())
+                .is_some_and(|r| expr_uses_flow_env(&r.expr))
+        };
         let needs_flow_env = current_module.is_some_and(|m| {
-            m.stop_after_if.is_some()
-                || m.stop_after_all_iters_if.is_some()
-                || retry_uses_flow_env(m)
+            m.stop_after_if
+                .as_ref()
+                .is_some_and(|s| expr_uses_flow_env(&s.expr))
+                || m.stop_after_all_iters_if
+                    .as_ref()
+                    .is_some_and(|s| expr_uses_flow_env(&s.expr))
+                || retry_if_uses_flow_env(m)
         }) || flow_value
             .failure_module
             .as_ref()
-            .is_some_and(|fm| retry_uses_flow_env(fm));
+            .is_some_and(|fm| retry_if_uses_flow_env(fm));
         // The resolved env is constant for a flow's lifetime, so cache it by flow
         // job id and reuse across child-step completions. Cache miss falls back to
         // the existing resolve+persist path; same-worker subsequent completions are
@@ -2729,8 +2744,11 @@ pub async fn handle_flow(
     // Resolve $var: and $res: references in flow_env.
     // We resolve into a separate variable to avoid cloning the entire FlowValue
     // (which includes modules, failure_module, etc.) just to replace flow_env.
+    // `is_cacheable` is `false` only on a transient `transform_json` failure,
+    // matching `resolve_flow_env_for_status_update`'s contract — we must not
+    // freeze a partial resolution into the cache.
     let resolved_env;
-    let flow_env = if let Some(env) = env_source {
+    let (flow_env, is_cacheable) = if let Some(env) = env_source {
         match transform_json(
             client,
             &flow_job.workspace_id,
@@ -2742,17 +2760,30 @@ pub async fn handle_flow(
         {
             Ok(Some(resolved)) => {
                 resolved_env = resolved;
-                Some(&resolved_env)
+                (Some(&resolved_env), true)
             }
-            Ok(None) => Some(env),
+            Ok(None) => (Some(env), true),
             Err(e) => {
                 tracing::warn!("Failed to resolve flow_env references: {e}");
-                Some(env)
+                (Some(env), false)
             }
         }
     } else {
-        None
+        (None, true)
     };
+
+    // Populate the per-flow resolved-env cache so subsequent predicate
+    // evaluations in `update_flow_status_after_job_completion_internal` skip
+    // the recursive CTE + transform_json. Costs one HashMap clone per
+    // sub-flow handle_flow entry; saves up to one CTE + one transform_json
+    // per flow execution that has predicates referencing flow_env.
+    if is_cacheable {
+        if let Some(env) = flow_env {
+            if !env.is_empty() {
+                RESOLVED_FLOW_ENV_CACHE.insert(flow_job.id, Arc::new(env.clone()));
+            }
+        }
+    }
 
     let status = flow_job
         .parse_flow_status()


### PR DESCRIPTION
## Summary

Follow-up to #9078 / #9079 (which addressed the OOM regression introduced by #9042). Two cheap, additive optimizations to further reduce wasted work on the predicate-evaluation hot path:

1. **Tighten `needs_flow_env` with an expression-text gate.** The existing structural gate (predicate is configured) over-fires for the dominant historical population: predicates that don't actually reference `flow_env` (since flow_env access from predicates was *broken* until #9042, almost no in-the-wild predicate references it yet). Add a substring check `expr.contains("flow_env")` mirroring the existing `expr.contains("results.")` pattern in `get_id_ctx_for_expr`. Substring match has false positives (harmless — runs an unneeded resolve) but no false negatives, since the JS evaluator only exposes `flow_env` in the global scope when the expression contains the literal name.

2. **Have `handle_flow` populate `RESOLVED_FLOW_ENV_CACHE`.** `handle_flow` already resolves the flow_env once at flow entry for input transforms. The predicate path repeats the same recursive CTE + `transform_json` on first child completion. Insert into the cache after `handle_flow`'s resolve so the predicate path hits the cache from the first call. Honors the same `is_cacheable` contract — skip insert on transient `transform_json` failures so a hiccup doesn't poison the cache for the rest of the flow run.

Net effect on the OOM-shaped path:

| Predicate references `flow_env`? | Before | After |
|---|---|---|
| No (historically dominant) | Cache populated, never read | Skipped — gate filters out |
| Yes, top-level | Predicate path populates on first call | `handle_flow` populates, predicate hits |
| Yes, sub-flow | CTE in handle_flow + CTE in first predicate eval | CTE in handle_flow only, predicate hits cache |

## Changes

- `update_flow_status_after_job_completion_internal`: tighten `needs_flow_env` with `expr.contains("flow_env")` substring check on `stop_after_if.expr`, `stop_after_all_iters_if.expr`, and `retry.retry_if.expr` (current module + failure module).
- `handle_flow`: track `is_cacheable` alongside the resolved env; insert into `RESOLVED_FLOW_ENV_CACHE` keyed by `flow_job.id` when cacheable and non-empty.

## Test plan

- [ ] Flow with `stop_after_if` referencing `flow_env.X` (literal env) — predicate evaluates correctly
- [ ] Flow with `stop_after_if` that does *not* reference `flow_env` — gate filters out, no resolve work, behavior identical to before
- [ ] Sub-flow whose parent has `flow_env` and whose own predicate references `flow_env.Y` — inheritance still works after gate tightening
- [ ] Flow with `flow_env` containing `\$var:` / `\$res:` — handle_flow resolves once, first predicate eval hits cache (verifiable via tracing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate resolving `flow_env` to only when predicate expressions reference it, and share the resolved-env cache from `handle_flow` with the predicate path. This removes redundant resolves/CTEs on the hot path and reduces memory pressure.

- **Refactors**
  - Only resolve when `stop_after_if`, `stop_after_all_iters_if`, or `retry.retry_if` expressions contain "flow_env" (includes `failure_module`).
  - `handle_flow` inserts resolved env into `RESOLVED_FLOW_ENV_CACHE` when cacheable and non-empty; skip insert on transient `transform_json` errors so bad partials aren’t cached.

<sup>Written for commit 6d4b99a95f3c356d14b4fa83f94e430fb8280f20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

