### PR TITLE
fix(flows): populate error handler input args from failure picker

### DIFF
--- a/frontend/src/lib/components/flows/stepsInputArgs.svelte.ts
+++ b/frontend/src/lib/components/flows/stepsInputArgs.svelte.ts
@@ -7,7 +7,7 @@ import {
 	type PickableProperties
 } from './previousResults'
 import { evalValue } from './utils.svelte'
-
+import { getFailureStepPropPicker } from './previousResults'
 export class StepsInputArgs {
 	#stepsEvaluated = $state<Record<string, Record<string, any>>>({})
 	#steps = $state<Record<string, Record<string, any>>>({})
@@ -158,6 +158,15 @@ export class StepsInputArgs {
 		flow: OpenFlow | undefined,
 		previewArgs: Record<string, any> | undefined
 	) {
+		if (id === 'failure' && flow && flow.value.failure_module && flowState) {
+    		const picker = getFailureStepPropPicker(flowState, flow, previewArgs)
+			this.initializeFromSchema(
+			flow.value.failure_module,
+			flowState['failure']?.schema ?? {},
+			picker.pickableProperties
+			)
+    	return
+		}
 		if (!flowState || !flow) {
 			return
 		}

--- a/frontend/src/lib/components/flows/stepsInputArgs.svelte.ts
+++ b/frontend/src/lib/components/flows/stepsInputArgs.svelte.ts
@@ -4,10 +4,10 @@ import {
 	dfs,
 	getPreviousModule,
 	getStepPropPicker,
-	type PickableProperties
+	type PickableProperties,
+	getFailureStepPropPicker
 } from './previousResults'
 import { evalValue } from './utils.svelte'
-import { getFailureStepPropPicker } from './previousResults'
 export class StepsInputArgs {
 	#stepsEvaluated = $state<Record<string, Record<string, any>>>({})
 	#steps = $state<Record<string, Record<string, any>>>({})
@@ -159,13 +159,13 @@ export class StepsInputArgs {
 		previewArgs: Record<string, any> | undefined
 	) {
 		if (id === 'failure' && flow && flow.value.failure_module && flowState) {
-    		const picker = getFailureStepPropPicker(flowState, flow, previewArgs)
+			const picker = getFailureStepPropPicker(flowState, flow, previewArgs)
 			this.initializeFromSchema(
-			flow.value.failure_module,
-			flowState['failure']?.schema ?? {},
-			picker.pickableProperties
+				flow.value.failure_module,
+				flowState['failure']?.schema ?? {},
+				picker.pickableProperties
 			)
-    	return
+			return
 		}
 		if (!flowState || !flow) {
 			return


### PR DESCRIPTION
## Summary
The error-handler step's input args panel was never initialized because `dfs(id, flow, ...)` in `StepsInputArgs.updateStepArgs` only traverses `flow.value.modules`, so `id === 'failure'` falls through to the early-return guard. As a result, error-handler inputs (e.g. `error.message`, `error.name`, `flow_input.*`, prior step results) were not resolved.

## Changes
- `frontend/src/lib/components/flows/stepsInputArgs.svelte.ts`: when `id === 'failure'` and `flow.value.failure_module` exists, route through `getFailureStepPropPicker` and call `initializeFromSchema` with the failure module + its schema, mirroring how the failure step is handled elsewhere in the codebase.

## Test plan
- [ ] Open a flow that has an error handler defined.
- [ ] Select the error-handler step in the flow editor and open its inputs panel.
- [ ] Verify `error.message`, `error.name`, `error.stack`, `error.step_id`, `flow_input.*`, and prior step results resolve to actual evaluated values.
- [ ] Edit an error-handler arg manually, navigate away and back, and confirm the manual edit is preserved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the error-handler step inputs not initializing in the flow editor. Also cleans up indentation in the failure-step branch.

- **Bug Fixes**
  - Initialize input args when `id === 'failure'` using the failure module schema via `getFailureStepPropPicker`.
  - Restores resolution for `error.message`, `error.name`, `error.stack`, `error.step_id`, `flow_input.*`, and prior step results.

- **Refactors**
  - Fix indentation in the failure-step initialization block.

<sup>Written for commit 658d05a884f2f374558450eccfc6db82255c4edd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

