### PR TITLE
fix: hide _ENTRYPOINT_OVERRIDE jobs from script/flow history panel

### DIFF
--- a/backend/windmill-api-inputs/src/lib.rs
+++ b/backend/windmill-api-inputs/src/lib.rs
@@ -172,6 +172,7 @@ async fn get_input_history(
             kind IN ('preview', 'flowpreview') as is_preview \
             FROM v2_job JOIN v2_job_completed USING (id) \
             WHERE v2_job.workspace_id = $3 AND {} = $1 AND kind = any($2) \
+            AND v2_job.script_entrypoint_override IS NULL \
             {args_query} AND v2_job_completed.status != 'skipped' {include_non_root} \
             ORDER BY v2_job.created_at DESC LIMIT $4\
         ) t ORDER BY completed_at DESC LIMIT $5 OFFSET $6",

--- a/backend/windmill-api-jobs/src/concurrency_groups.rs
+++ b/backend/windmill-api-jobs/src/concurrency_groups.rs
@@ -226,6 +226,7 @@ async fn get_concurrent_intervals(
             trigger_kind: _,
             include_args: _,
             broad_filter: _,
+            excludes_entrypoint_override: _,
         } => true,
         _ => false,
     };

--- a/backend/windmill-api-jobs/src/query.rs
+++ b/backend/windmill-api-jobs/src/query.rs
@@ -216,6 +216,10 @@ pub fn filter_list_queue_query(
         sqlb.and_where("trigger_kind IS DISTINCT FROM 'schedule'");
     }
 
+    if lq.excludes_entrypoint_override.unwrap_or(false) {
+        sqlb.and_where_is_null("v2_job.script_entrypoint_override");
+    }
+
     if let Some(tk) = &lq.trigger_kind {
         let quoted: Vec<_> = tk.values.iter().map(|v| quote(&format!("{}", v))).collect();
         if tk.negated {
@@ -519,6 +523,10 @@ pub fn filter_list_completed_query(
         sqlb.and_where("trigger_kind IS DISTINCT FROM 'schedule'");
     }
 
+    if lq.excludes_entrypoint_override.unwrap_or(false) {
+        sqlb.and_where_is_null("v2_job.script_entrypoint_override");
+    }
+
     if let Some(tk) = &lq.trigger_kind {
         let quoted: Vec<_> = tk.values.iter().map(|v| quote(&format!("{}", v))).collect();
         if tk.negated {
@@ -624,6 +632,7 @@ mod tests {
             trigger_path: None,
             include_args: None,
             broad_filter: None,
+            excludes_entrypoint_override: None,
         }
     }
 
@@ -668,6 +677,7 @@ mod tests {
             trigger_path: None,
             include_args: None,
             broad_filter: None,
+            excludes_entrypoint_override: None,
         }
     }
 

--- a/backend/windmill-api-jobs/src/types.rs
+++ b/backend/windmill-api-jobs/src/types.rs
@@ -122,6 +122,7 @@ pub struct ListQueueQuery {
     pub trigger_path: Option<NegatedListFilter<String>>,
     pub include_args: Option<bool>,
     pub broad_filter: Option<String>,
+    pub excludes_entrypoint_override: Option<bool>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -167,6 +168,7 @@ pub struct ListCompletedQuery {
     pub trigger_path: Option<NegatedListFilter<String>>,
     pub include_args: Option<bool>,
     pub broad_filter: Option<String>,
+    pub excludes_entrypoint_override: Option<bool>,
 }
 
 impl From<ListCompletedQuery> for ListQueueQuery {
@@ -202,6 +204,7 @@ impl From<ListCompletedQuery> for ListQueueQuery {
             trigger_path: lcq.trigger_path,
             include_args: lcq.include_args,
             broad_filter: lcq.broad_filter,
+            excludes_entrypoint_override: lcq.excludes_entrypoint_override,
         }
     }
 }
@@ -704,6 +707,7 @@ mod tests {
             trigger_path: None,
             include_args: None,
             broad_filter: None,
+            excludes_entrypoint_override: None,
         };
 
         let lqq: ListQueueQuery = lcq.into();
@@ -772,6 +776,7 @@ mod tests {
             trigger_path: None,
             include_args: None,
             broad_filter: None,
+            excludes_entrypoint_override: None,
         };
 
         let lqq: ListQueueQuery = lcq.into();

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -12000,6 +12000,11 @@ paths:
           in: query
           schema:
             type: boolean
+        - name: excludes_entrypoint_override
+          description: exclude jobs that were started with a `_ENTRYPOINT_OVERRIDE` arg (e.g. dynamic-select helper runs and preprocessor previews)
+          in: query
+          schema:
+            type: boolean
         - name: broad_filter
           description: broad search across multiple fields (case-insensitive substring match on path, tag, schedule path, trigger kind, label)
           in: query

--- a/frontend/src/lib/components/HistoricInputs.svelte
+++ b/frontend/src/lib/components/HistoricInputs.svelte
@@ -112,7 +112,8 @@
 				syncQueuedRunsCount: false,
 				refreshRate: 10000,
 				currentWorkspace: $workspaceStore ?? '',
-				skip: !runnableId
+				skip: !runnableId,
+				excludesEntrypointOverride: true
 			}) satisfies UseJobLoaderArgs
 	)
 	let jobs = $derived(jobsLoader?.jobs ?? [])

--- a/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
+++ b/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
@@ -53,6 +53,7 @@ export interface UseJobLoaderArgs {
 	skip?: boolean
 	lookback?: number
 	perPage?: number
+	excludesEntrypointOverride?: boolean
 }
 
 export function useJobsLoader(args: () => UseJobLoaderArgs) {
@@ -69,6 +70,7 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 	let lookback = $derived(_args.lookback ?? 0)
 	let timeframe = $derived(_args?.timeframe)
 	let perPage = $derived(_args?.perPage ?? 1000)
+	let excludesEntrypointOverride = $derived(_args.excludesEntrypointOverride ?? false)
 
 	let label = $derived(filters?.label ?? null)
 	let worker = $derived(filters?.worker ?? null)
@@ -274,7 +276,8 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 			allWorkspaces: allWorkspaces ? true : undefined,
 			perPage: perPageOverride ?? perPage,
 			allowWildcards: allowWildcards ? true : undefined,
-			broadFilter
+			broadFilter,
+			excludesEntrypointOverride: excludesEntrypointOverride ? true : undefined
 		})
 		promise = CancelablePromiseUtils.catchErr(promise, (e) => {
 			if (e instanceof CancelError) return CancelablePromiseUtils.err(e)


### PR DESCRIPTION
## Summary

Dynamic-select helper runs and preprocessor previews — both of which carry an `_ENTRYPOINT_OVERRIDE` value in their args — were polluting the History panel on script/flow detail pages. They look like normal user runs in the past-runs list and the live currently-running list, even though they are internal/UI-driven invocations.

The DB column `v2_job.script_entrypoint_override` is already auto-populated from `args->>'_ENTRYPOINT_OVERRIDE'` at job insert time (`backend/windmill-queue/src/jobs.rs:5892`), so we filter on that column rather than scanning the JSONB args.

The filter only applies to the script/flow History panel — the global Runs page is unchanged.

## Changes

- **Backend** (`backend/windmill-api-jobs/src/types.rs`, `query.rs`, `concurrency_groups.rs`): add `excludes_entrypoint_override: Option<bool>` to `ListQueueQuery` and `ListCompletedQuery`; when true, both filter helpers add `WHERE v2_job.script_entrypoint_override IS NULL`.
- **Backend** (`backend/windmill-api-inputs/src/lib.rs`): `get_input_history` (powering the past-runs list) unconditionally adds the same SQL condition — that endpoint only serves the script/flow History panel, so an opt-in flag isn't needed.
- **OpenAPI** (`backend/windmill-api/openapi.yaml`): document `excludes_entrypoint_override` on `listJobs`.
- **Frontend** (`frontend/src/lib/components/runs/useJobsLoader.svelte.ts`): plumb a new `excludesEntrypointOverride` arg through to `JobService.listJobs`.
- **Frontend** (`frontend/src/lib/components/HistoricInputs.svelte`): set `excludesEntrypointOverride: true` so the live currently-running list above the past-runs list is also filtered.

## Test plan

- [ ] Open a deployed script with a dynamic-select input, type in the field a few times to fire helper-script runs, and confirm those runs do NOT appear in the script's History panel (neither the past-runs list below nor the currently-running mini-list above).
- [ ] In the script editor, run a preprocessor preview and confirm it does NOT appear in the same History panel.
- [ ] Confirm the global Runs page (`/runs`) still shows those same dynamic-select / preprocessor runs.
- [ ] Repeat the dynamic-select case for a flow with a dynamic-select schema and confirm the flow detail page History panel filters correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide internal `_ENTRYPOINT_OVERRIDE` runs (dynamic-select helpers and preprocessor previews) from script/flow History panels so only real user runs show. The global Runs page is unchanged.

- **Bug Fixes**
  - Backend: added `excludes_entrypoint_override` to job list queries and apply `v2_job.script_entrypoint_override IS NULL`; `get_input_history` always filters; updated OpenAPI.
  - Frontend: plumbed `excludesEntrypointOverride` through `useJobsLoader` and set it to true in `HistoricInputs` to filter both live and past runs.

<sup>Written for commit 9b3ac34a1efdce5fce9531cc2881ec92af8ec233. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

