### PR TITLE
fix(python): verify wheel RECORD on cache pull/install, finalize piptar

### DIFF
--- a/backend/windmill-worker/src/global_cache.rs
+++ b/backend/windmill-worker/src/global_cache.rs
@@ -40,6 +40,9 @@ pub async fn build_tar_and_push(
     let tar_file = std::fs::File::create(&tar_path)?;
     let mut tar = tar::Builder::new(tar_file);
     tar.append_dir_all(".", &folder)?;
+    // Write the trailing zero blocks and close the inner file BEFORE std::fs::read
+    // below. Without this, the bytes we upload to S3 are an unfinalized archive.
+    drop(tar.into_inner()?);
 
     let tar_metadata = tokio::fs::metadata(&tar_path).await;
     if tar_metadata.is_err() || tar_metadata.as_ref().unwrap().len() == 0 {
@@ -231,6 +234,7 @@ pub async fn save_cache(
             let tar_file = std::fs::File::create(&tar_path)?;
             let mut tar = tar::Builder::new(tar_file);
             tar.append_dir_all(".", &origin)?;
+            drop(tar.into_inner()?);
             let tar_metadata = tokio::fs::metadata(&tar_path).await;
             if tar_metadata.is_err() || tar_metadata.as_ref().unwrap().len() == 0 {
                 tracing::info!("Failed to tar cache: {origin}");

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -2113,6 +2113,84 @@ async fn spawn_uv_install(
     }
 }
 
+/// Verify that every file listed in the wheel's RECORD exists on disk under
+/// `venv_p`. Used as a structural integrity check after both a successful
+/// `pull_from_tar` (object-store cache hit) and a successful local
+/// `uv pip install`, so a truncated tar or a dropped wheel entry can never
+/// become an authoritative cache entry. Returns Err with a short description
+/// on the first integrity issue (no .dist-info, no RECORD, or any listed
+/// path missing on disk).
+async fn verify_wheel_record(venv_p: &str) -> Result<(), String> {
+    let mut entries = tokio::fs::read_dir(venv_p)
+        .await
+        .map_err(|e| format!("read_dir({venv_p}): {e}"))?;
+
+    let mut dist_info: Option<String> = None;
+    loop {
+        match entries.next_entry().await {
+            Ok(Some(entry)) => {
+                let name = entry.file_name();
+                let name_s = name.to_string_lossy();
+                if name_s.ends_with(".dist-info") {
+                    if let Ok(ft) = entry.file_type().await {
+                        if ft.is_dir() {
+                            dist_info = Some(name_s.into_owned());
+                            break;
+                        }
+                    }
+                }
+            }
+            Ok(None) => break,
+            Err(e) => return Err(format!("read_dir entry in {venv_p}: {e}")),
+        }
+    }
+
+    let dist_info = match dist_info {
+        Some(d) => d,
+        None => return Err(format!("no .dist-info directory in {venv_p}")),
+    };
+
+    let record_path = format!("{venv_p}/{dist_info}/RECORD");
+    let record_content = tokio::fs::read_to_string(&record_path)
+        .await
+        .map_err(|e| format!("read RECORD at {record_path}: {e}"))?;
+
+    let mut missing: Vec<String> = Vec::new();
+    for line in record_content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let rel_path = match trimmed.split(',').next() {
+            Some(p) if !p.is_empty() => p,
+            _ => continue,
+        };
+        // Defensive: skip absolute paths or escaping entries — we only
+        // validate package-relative files.
+        if rel_path.starts_with('/') || rel_path.contains("..") {
+            continue;
+        }
+        let full = format!("{venv_p}/{rel_path}");
+        if tokio::fs::metadata(&full).await.is_err() {
+            missing.push(rel_path.to_string());
+            // Bound error size in pathological cases (e.g. wholly empty dir).
+            if missing.len() >= 10 {
+                missing.push("...".to_string());
+                break;
+            }
+        }
+    }
+
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "wheel RECORD lists files missing on disk: {}",
+            missing.join(", ")
+        ))
+    }
+}
+
 /// uv pip install, include cached or pull from S3
 pub async fn handle_python_reqs(
     requirements: Vec<String>,
@@ -2484,6 +2562,30 @@ pub async fn handle_python_reqs(
                                     workspace_id = %w_id,
                                     "No tarball was found for {venv_p} on S3 or different problem occurred {job_id}:\n{e}",
                                 );
+                            } else if let Err(verify_err) = verify_wheel_record(&venv_p).await {
+                                // The object-store tar extracted cleanly but the resulting
+                                // directory is missing files referenced by the wheel RECORD.
+                                // Wipe the broken cache entry and fall through to a fresh
+                                // local install rather than treating it as authoritative.
+                                tracing::warn!(
+                                    workspace_id = %w_id,
+                                    job_id = %job_id,
+                                    "Object-store cache for {venv_p} failed wheel RECORD verification, will reinstall locally: {verify_err}"
+                                );
+                                if let Err(rm_err) = tokio::fs::remove_dir_all(&venv_p).await {
+                                    tracing::warn!(
+                                        workspace_id = %w_id,
+                                        "could not remove broken cache dir {venv_p}: {rm_err}"
+                                    );
+                                }
+                                append_logs(
+                                    &job_id,
+                                    &w_id,
+                                    format!(
+                                        "\n[!] cached wheel for {req} from object store failed integrity check, reinstalling: {verify_err}\n"
+                                    ),
+                                    &conn,
+                                ).await;
                             } else {
                                 print_success(
                                     true,
@@ -2638,6 +2740,39 @@ pub async fn handle_python_reqs(
 
             if is_sandboxing_enabled() {
                 let _ = std::fs::remove_file(format!("{job_dir}/{req}.config.proto"));
+            }
+
+            // Verify the install before declaring success: if uv exited 0 but
+            // the on-disk directory is missing files the wheel RECORD says
+            // should exist, do NOT write .valid.windmill, do NOT queue the
+            // piptar upload, and fail the job. This prevents a broken tar
+            // from ever being pushed to the object store and propagated to
+            // every other replica.
+            if let Err(verify_err) = verify_wheel_record(&venv_p).await {
+                tracing::error!(
+                    workspace_id = %w_id,
+                    job_id = %job_id,
+                    "uv pip install of {req} into {venv_p} failed wheel RECORD verification: {verify_err}"
+                );
+                append_logs(
+                    &job_id,
+                    &w_id,
+                    format!(
+                        "\nWheel RECORD verification failed after install of {req}: {verify_err}. \
+                         Aborting to avoid publishing a corrupt cache entry."
+                    ),
+                    &conn,
+                ).await;
+                if let Err(rm_err) = tokio::fs::remove_dir_all(&venv_p).await {
+                    tracing::warn!(
+                        workspace_id = %w_id,
+                        "could not remove broken install dir {venv_p}: {rm_err}"
+                    );
+                }
+                pids.lock().await.get_mut(i).and_then(|e| e.take());
+                return Err(Error::from(anyhow!(
+                    "wheel RECORD verification failed after install of {req}"
+                )));
             }
 
             print_success(


### PR DESCRIPTION
## Summary

Stops the Python dependency cache from persisting and propagating incomplete wheel extractions through the object store. Customer hit this on `argon2-cffi==25.1.0` (missing `argon2/_utils.py`), and previously on `botocore`/`httpx` (truncated tars). Symptom is a runtime `ImportError` that looks like a missing dependency declaration rather than a Windmill bug — and once a corrupt tar is in S3, every replica that pulls it gets the same broken copy.

Three changes:

1. **`pull_from_tar` → verify wheel RECORD before marking valid.** After extracting an object-store tar to `venv_p`, parse `<dist-info>/RECORD` and confirm every listed path exists on disk. If any are missing, wipe `venv_p`, log `[!] cached wheel for <req> from object store failed integrity check, reinstalling: …` to the job, and fall through to a fresh local install. Because the local install path also pushes its (verified) result back to the object store, this **self-heals** corrupt entries.

2. **`uv pip install` → verify wheel RECORD before publishing.** Same check immediately after a successful local install. If verification fails, do not write `.valid.windmill`, do not queue the piptar upload, fail the job. A bad install never becomes the source of a broken tar in the object store.

3. **Finalize the tar before reading its bytes.** `build_tar_and_push` and `save_cache` were calling `std::fs::read(&tar_path)?` while `tar::Builder` was still alive, so the bytes uploaded had no end-of-archive marker. Switched to `drop(tar.into_inner()?)` before the read so the archive is finalized.

## Test plan

End-to-end integration test against a real local Windmill instance with a filesystem-backed object store (`/tmp/wm-objstore`):

- [x] **First-fill**: empty local cache + empty object store. Submit Python preview with 27 diverse deps (argon2-cffi, cryptography, pillow, pydantic, httpx, …). 27 packages installed locally, 27 tars pushed to object store, RECORD-verified, job succeeded with `argon2_ok: true` in 5163 ms.
- [x] **Clear-local-only**: wipe `/tmp/windmill/cache`, keep object store. Re-submit same job. All 27 packages pulled from object store, RECORD-verified, `.valid.windmill` written, job succeeded in 634 ms — pure pull, no install.
- [x] **Corruption recovery**: rebuild the `argon2-cffi==25.1.0.tar` in the object store with `argon2/_utils.py` deleted (mirrors the customer's exact failure mode). Wipe local cache. Re-submit. Worker logs `Object-store cache for /tmp/windmill/cache/python_3_12/argon2-cffi==25.1.0 failed wheel RECORD verification, will reinstall locally: wheel RECORD lists files missing on disk: argon2/_utils.py`, removes the broken cache dir, falls through to local install, and pushes a fresh valid tar back to the object store. Subsequent pulls of that tar include `_utils.py` again. Job succeeds with `argon2_ok: true`.
- [x] Round-trip stress test: same patched `tar::Builder`/`Archive` flow against 58 wheels (numpy, scipy, torch, pyarrow, pandas, transformers, cryptography, lxml, …). 0 false positives — every legitimate install passes the new RECORD check; the only "failures" were the deliberately-corrupted-and-empty-dir negative cases, both correctly rejected.

## Notes for reviewer

- `verify_wheel_record` is intentionally lenient: skips empty paths, absolute paths, and paths containing `..`. Caps the missing-files list at 10 to avoid pathological error strings on a wholly-empty cache dir.
- The local-install verification path is fail-closed (returns `Err`). The pull path is fail-open (falls through to local install + heals S3). This is deliberate — pull failures are recoverable transparently to the user; bad local installs are a real problem the user should hear about.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verify Python wheel RECORD on cache pull and after `uv pip install`, and finalize piptar before upload to prevent corrupt wheels from being cached and propagated. This self-heals broken entries (e.g., `argon2-cffi==25.1.0`, `botocore`, `httpx`) and avoids misleading ImportErrors.

- **Bug Fixes**
  - On `pull_from_tar`, parse `<dist-info>/RECORD`; if any listed file is missing, remove the cache dir, log, and fall back to local install (then republish a verified tar).
  - After local install, run the same check; on failure, do not write `.valid.windmill`, do not queue piptar, and fail the job to block bad artifacts.
  - Finalize tars with `drop(tar.into_inner()?)` in `build_tar_and_push` and `save_cache` before reading bytes to ensure a valid end-of-archive marker.

<sup>Written for commit 7cd342aa7734131f0a0eaf4ebb41703ebf8ad381. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

