### PR TITLE
feat(cli): auto-infer args for `wmill app push`

### DIFF
--- a/cli/src/commands/app/app.ts
+++ b/cli/src/commands/app/app.ts
@@ -4,7 +4,7 @@ import { Command } from "@cliffy/command";
 import { Table } from "@cliffy/table";
 import { colors } from "@cliffy/ansi/colors";
 import * as log from "../../core/log.ts";
-import { sep as SEP } from "node:path";
+import { sep as SEP, isAbsolute, resolve as pathResolve, relative as pathRelative, basename } from "node:path";
 import { stat } from "node:fs/promises";
 import * as windmillUtils from "@windmill-labs/shared-utils";
 import { yamlParseFile } from "../../utils/yaml.ts";
@@ -12,6 +12,7 @@ import * as wmill from "../../../gen/services.gen.ts";
 import { ListableApp, Policy } from "../../../gen/types.gen.ts";
 
 import { GlobalOptions, isSuperset } from "../../types.ts";
+import { getWmillYamlPath } from "../../core/conf.ts";
 import { readInlinePathSync } from "../../utils/utils.ts";
 import devCommand from "./dev.ts";
 import lintCommand from "./lint.ts";
@@ -261,31 +262,122 @@ async function get(opts: GlobalOptions & { json?: boolean }, path: string) {
   }
 }
 
-async function push(opts: GlobalOptions, filePath: string, remotePath: string) {
-  if (!validatePath(remotePath)) {
-    return;
-  }
+const APP_FOLDER_SUFFIXES = ["__raw_app", ".raw_app", "__app", ".app"] as const;
+
+async function push(
+  opts: GlobalOptions,
+  filePath?: string,
+  remotePath?: string
+) {
+  // Capture original CWD before resolveWorkspace, which may chdir to the
+  // wmill.yaml root. We need it to resolve relative inputs and to derive
+  // the remote path from the user's location when auto-inferring.
+  const originalCwd = process.cwd();
+
   const workspace = await resolveWorkspace(opts);
   await requireLogin(opts);
 
-  // Detect raw apps by checking for raw_app.yaml or __raw_app/.raw_app suffix
-  const normalizedPath = filePath.endsWith(SEP) ? filePath.slice(0, -1) : filePath;
-  const isRawApp = normalizedPath.endsWith("__raw_app") || normalizedPath.endsWith(".raw_app");
+  // Auto-infer file path from CWD when omitted
+  if (!filePath) {
+    filePath = originalCwd;
+  }
+  const absoluteFilePath = isAbsolute(filePath)
+    ? filePath
+    : pathResolve(originalCwd, filePath);
+
+  // Detect app folder type (regular vs raw)
+  const normalizedPath = absoluteFilePath.endsWith(SEP)
+    ? absoluteFilePath.slice(0, -1)
+    : absoluteFilePath;
+  const dirName = basename(normalizedPath);
+  const isRawAppByName =
+    dirName.endsWith("__raw_app") || dirName.endsWith(".raw_app");
+  const isAppByName = dirName.endsWith("__app") || dirName.endsWith(".app");
+
   let hasRawAppYaml = false;
-  if (!isRawApp) {
+  let hasAppYaml = false;
+  try {
+    await stat(normalizedPath + SEP + "raw_app.yaml");
+    hasRawAppYaml = true;
+  } catch { /* not a raw app */ }
+  if (!hasRawAppYaml) {
     try {
-      const rawAppPath = (filePath.endsWith(SEP) ? filePath : filePath + SEP) + "raw_app.yaml";
-      await stat(rawAppPath);
-      hasRawAppYaml = true;
-    } catch { /* not a raw app */ }
+      await stat(normalizedPath + SEP + "app.yaml");
+      hasAppYaml = true;
+    } catch { /* not an app */ }
   }
 
-  if (isRawApp || hasRawAppYaml) {
+  if (!isRawAppByName && !isAppByName && !hasRawAppYaml && !hasAppYaml) {
+    log.error(
+      colors.red(
+        `'${filePath}' is not an app folder (no app.yaml or raw_app.yaml, and not a *.app/*.raw_app folder).`
+      )
+    );
+    return;
+  }
+
+  // Auto-infer remote path from the folder location relative to wmill.yaml root
+  if (!remotePath) {
+    const wmillYamlPath = getWmillYamlPath();
+    if (!wmillYamlPath) {
+      log.error(
+        colors.red(
+          "Could not infer remote path: no wmill.yaml found. Run 'wmill init' or pass <remote_path> explicitly."
+        )
+      );
+      return;
+    }
+    // After resolveWorkspace, process.cwd() is the wmill.yaml dir
+    const wmillRoot = process.cwd();
+    let inferred = pathRelative(wmillRoot, normalizedPath).replaceAll(SEP, "/");
+    if (inferred.startsWith("..") || isAbsolute(inferred)) {
+      log.error(
+        colors.red(
+          `Could not infer remote path: '${filePath}' is outside the wmill.yaml root (${wmillRoot}). Move the folder under the root or pass <remote_path> explicitly.`
+        )
+      );
+      return;
+    }
+    for (const suffix of APP_FOLDER_SUFFIXES) {
+      if (inferred.endsWith(suffix)) {
+        inferred = inferred.slice(0, -suffix.length);
+        break;
+      }
+    }
+    if (!inferred) {
+      log.error(
+        colors.red(
+          "Could not infer remote path: app folder is at the wmill.yaml root. Pass <remote_path> explicitly."
+        )
+      );
+      return;
+    }
+    if (
+      !inferred.startsWith("u/") &&
+      !inferred.startsWith("g/") &&
+      !inferred.startsWith("f/")
+    ) {
+      log.error(
+        colors.red(
+          `Could not infer remote path: '${inferred}' is not under u/, g/, or f/. Move the app under one of these prefixes or pass <remote_path> explicitly.`
+        )
+      );
+      return;
+    }
+    remotePath = inferred;
+    log.info(colors.gray(`Inferred remote path: ${remotePath}`));
+  }
+
+  if (!validatePath(remotePath)) {
+    return;
+  }
+
+  if (isRawAppByName || hasRawAppYaml) {
     const { pushRawApp } = await import("./raw_apps.ts");
-    await pushRawApp(workspace.workspaceId, remotePath, filePath);
+    await pushRawApp(workspace.workspaceId, remotePath, absoluteFilePath);
     log.info(colors.bold.underline.green("Raw app pushed"));
   } else {
-    await pushApp(workspace.workspaceId, remotePath, filePath);
+    await pushApp(workspace.workspaceId, remotePath, absoluteFilePath);
     log.info(colors.bold.underline.green("App pushed"));
   }
 }
@@ -301,8 +393,11 @@ const command = new Command()
   .arguments("<path:string>")
   .option("--json", "Output as JSON (for piping to jq)")
   .action(get as any)
-  .command("push", "push a local app ")
-  .arguments("<file_path:string> <remote_path:string>")
+  .command(
+    "push",
+    "push a local app. With no args, infers the app from the current directory and the remote path from its location relative to wmill.yaml."
+  )
+  .arguments("[file_path:string] [remote_path:string]")
   .action(push as any)
   .command("dev", devCommand)
   .command("lint", lintCommand)

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -6588,7 +6588,7 @@ app related commands
   - \`--json\` - Output as JSON (for piping to jq)
 - \`app get <path:string>\` - get an app's details
   - \`--json\` - Output as JSON (for piping to jq)
-- \`app push <file_path:string> <remote_path:string>\` - push a local app 
+- \`app push [file_path:string] [remote_path:string]\` - push a local app. With no args, infers the app from the current directory and the remote path from its location relative to wmill.yaml.
 - \`app dev [app_folder:string]\` - Start a development server for building apps with live reload and hot module replacement
   - \`--port <port:number>\` - Port to run the dev server on (will find next available port if occupied)
   - \`--host <host:string>\` - Host to bind the dev server to

--- a/system_prompts/auto-generated/cli/cli-commands.md
+++ b/system_prompts/auto-generated/cli/cli-commands.md
@@ -26,7 +26,7 @@ app related commands
   - `--json` - Output as JSON (for piping to jq)
 - `app get <path:string>` - get an app's details
   - `--json` - Output as JSON (for piping to jq)
-- `app push <file_path:string> <remote_path:string>` - push a local app 
+- `app push [file_path:string] [remote_path:string]` - push a local app. With no args, infers the app from the current directory and the remote path from its location relative to wmill.yaml.
 - `app dev [app_folder:string]` - Start a development server for building apps with live reload and hot module replacement
   - `--port <port:number>` - Port to run the dev server on (will find next available port if occupied)
   - `--host <host:string>` - Host to bind the dev server to

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -2174,7 +2174,7 @@ app related commands
   - \`--json\` - Output as JSON (for piping to jq)
 - \`app get <path:string>\` - get an app's details
   - \`--json\` - Output as JSON (for piping to jq)
-- \`app push <file_path:string> <remote_path:string>\` - push a local app 
+- \`app push [file_path:string] [remote_path:string]\` - push a local app. With no args, infers the app from the current directory and the remote path from its location relative to wmill.yaml.
 - \`app dev [app_folder:string]\` - Start a development server for building apps with live reload and hot module replacement
   - \`--port <port:number>\` - Port to run the dev server on (will find next available port if occupied)
   - \`--host <host:string>\` - Host to bind the dev server to

--- a/system_prompts/auto-generated/skills/cli-commands/SKILL.md
+++ b/system_prompts/auto-generated/skills/cli-commands/SKILL.md
@@ -31,7 +31,7 @@ app related commands
   - `--json` - Output as JSON (for piping to jq)
 - `app get <path:string>` - get an app's details
   - `--json` - Output as JSON (for piping to jq)
-- `app push <file_path:string> <remote_path:string>` - push a local app 
+- `app push [file_path:string] [remote_path:string]` - push a local app. With no args, infers the app from the current directory and the remote path from its location relative to wmill.yaml.
 - `app dev [app_folder:string]` - Start a development server for building apps with live reload and hot module replacement
   - `--port <port:number>` - Port to run the dev server on (will find next available port if occupied)
   - `--host <host:string>` - Host to bind the dev server to


### PR DESCRIPTION
## Summary

Make `wmill app push` ergonomic when invoked from inside an app folder. Running the command with no arguments now uses the current directory as the local app folder and infers the remote path from CWD relative to `wmill.yaml`, with `.app`/`.raw_app`/`__app`/`__raw_app` suffixes stripped.

## Changes

- `cli/src/commands/app/app.ts`: both positional arguments are now optional. When omitted, the local path defaults to CWD and the remote path is inferred from the folder location relative to the `wmill.yaml` root.
- New early validation: refuses to push folders that are not app folders (no `app.yaml`/`raw_app.yaml`, and no `.app`/`.raw_app`/`__app`/`__raw_app` suffix), with a clear error.
- Resolves `file_path` against the user's original CWD before `resolveWorkspace` (which may `chdir` to the `wmill.yaml` root). Previously a relative `file_path` could be resolved against the wrong directory if `wmill.yaml` lived in a parent.
- Tailored error messages for the failure modes of inference: no `wmill.yaml` found, folder outside the `wmill.yaml` root, folder at the root, or inferred path not under `u/`/`g/`/`f/`.
- `system_prompts/generate.py` regeneration of the auto-generated CLI docs/skills (`cli-commands.md`, `prompts.ts`, `skills/cli-commands/SKILL.md`, `cli/src/guidance/skills.gen.ts`) to reflect the new optional arguments and description.

## Test plan

- [ ] In a workspace with `wmill.yaml` at the repo root, `cd` into `f/myteam/myapp.app/` and run `wmill app push` — expect `Inferred remote path: f/myteam/myapp` followed by `App pushed`.
- [ ] Same flow for the dotted variant: a `*.raw_app` folder routes through `pushRawApp` and emits `Raw app pushed`.
- [ ] `cd` into a non-app folder and run `wmill app push` — expect the early "not an app folder" error before any network call.
- [ ] Place an app folder at the `wmill.yaml` root (e.g. `./myapp.app`) and run `wmill app push` — expect the "at the wmill.yaml root" error.
- [ ] Run `wmill app push /tmp/myapp.app` outside the `wmill.yaml` root — expect the "outside the wmill.yaml root" error.
- [ ] Existing two-arg form: `wmill app push f/myteam/myapp.app f/myteam/myapp` — expect unchanged behavior, including from a subdirectory of the wmill.yaml root with a relative `file_path`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `wmill app push` usable with zero args by auto-inferring the local app folder and remote path from your CWD and `wmill.yaml` root. Adds safety checks and clearer errors, and fixes relative path resolution.

- **New Features**
  - Both args are optional. Local path defaults to CWD; remote path is derived from folder location relative to `wmill.yaml`, stripping `.app`/`.raw_app`/`__app`/`__raw_app`.
  - Validates app folders and detects raw apps via name or presence of `app.yaml`/`raw_app.yaml`.
  - Clear errors for inference failures (no `wmill.yaml`, outside root, at root, or path not under `u/`, `g/`, `f/`).
  - CLI docs updated to reflect optional args.

- **Bug Fixes**
  - Resolve `file_path` against the original CWD before workspace `chdir`, preventing incorrect relative path resolution.

<sup>Written for commit e02281e4fd5626253648f48a6dd22c14644be60b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

