### PR TITLE
style(log-viewer): tighter top bar (icons, hyphenated label, scoped overflow)

### DIFF
--- a/frontend/src/lib/components/LogViewer.svelte
+++ b/frontend/src/lib/components/LogViewer.svelte
@@ -11,7 +11,7 @@
 </script>
 
 <script lang="ts">
-	import { ClipboardCopy, Download, Expand, Loader2 } from 'lucide-svelte'
+	import { ClipboardCopy, Download, Expand, Loader2, Timer, Cpu } from 'lucide-svelte'
 	import { Button, Drawer, DrawerContent } from './common'
 	import { copyToClipboard } from '$lib/utils'
 	import { base } from '$lib/base'
@@ -166,8 +166,7 @@
 	}
 
 	export function scrollToBottom() {
-		scroll &&
-			setTimeout(() => preEl?.scroll({ top: preEl?.scrollHeight, behavior: 'smooth' }), 100)
+		scroll && setTimeout(() => preEl?.scroll({ top: preEl?.scrollHeight, behavior: 'smooth' }), 100)
 	}
 
 	let logViewer: Drawer | undefined = $state()
@@ -296,7 +295,9 @@
 			class="w-full h-full bg-surface-secondary flex flex-col {noMaxH ? '' : 'max-h-screen'}"
 			data-nav-id={navigationId}
 		>
-			<div class="flex gap-2 ml-2 {small ? 'py-1' : 'py-2'} border-b">
+			<div
+				class="flex gap-2 ml-2 {small ? 'py-1' : 'py-2'} border-b overflow-x-auto overflow-y-hidden"
+			>
 				{#if isLoading}
 					<div class="flex gap-2 items-center">
 						<Loader2 class="animate-spin" />
@@ -312,14 +313,27 @@
 					</div>
 				{:else if duration}
 					<span
-						class={twMerge('text-secondary dark:text-gray-400', small ? '!text-2xs' : '!text-xs')}
-						>took {duration}ms</span
+						class={twMerge(
+							'flex items-center gap-1 text-secondary dark:text-gray-400',
+							small ? '!text-2xs' : '!text-xs'
+						)}
+						title="Duration"
 					>
+						<Timer size={small ? 10 : 12} />
+						{duration}ms
+					</span>
 				{/if}
 				{#if mem}
-					<span class="{small ? '!text-2xs' : '!text-xs'} text-secondary dark:text-gray-400"
-						>mem peak: {(mem / 1024).toPrecision(4)}MB</span
+					<span
+						class={twMerge(
+							'flex items-center gap-1 text-secondary dark:text-gray-400',
+							small ? '!text-2xs' : '!text-xs'
+						)}
+						title="Memory peak"
 					>
+						<Cpu size={small ? 10 : 12} />
+						{(mem / 1024).toPrecision(4)}MB
+					</span>
 				{/if}
 				<div class="flex gap-2 justify-end flex-1">
 					{#if jobId && download}
@@ -335,8 +349,10 @@
 					{/if}
 					<button onclick={logViewer.openDrawer}><Expand size="12" /></button>
 					{#if !noAutoScroll}
-						<label class="pr-2 text-2xs flex gap-2 font-normal text-primary items-center">
-							Auto scroll
+						<label
+							class="pr-2 text-2xs flex gap-2 font-normal text-primary items-center whitespace-nowrap"
+						>
+							auto-scroll
 							<input class="windmillapp" type="checkbox" bind:checked={scroll} />
 						</label>
 					{/if}


### PR DESCRIPTION
## Summary

Three tightening changes to the log viewer's top bar:

- Replaced the textual `took Xms` / `mem peak: YMB` chunks with `Timer` / `Cpu` Lucide icons (text-as-tooltip on the wrapping span). Saves horizontal space without losing information.
- Renamed the toggle from `Auto scroll` to lowercase `auto-scroll`, added `whitespace-nowrap` so it doesn't wrap when the panel is narrow.
- Scoped horizontal overflow to the top bar (\`overflow-x-auto overflow-y-hidden\`). Previously, when the bar's contents didn't fit, the bar grew the entire log panel's width — letting the user accidentally horizontally-scroll the whole panel by interacting with the toolbar. Now the bar scrolls itself; the log \`<pre>\` keeps its plain \`overflow-auto\`.

## Test plan

- [ ] In a script editor, run a job and observe the log panel
- [ ] Top bar shows clock/cpu icons in place of \`took X\` / \`mem peak: Y\`; tooltips read \"Duration\" and \"Memory peak\"
- [ ] Toggle reads \`auto-scroll\` and stays on a single line at narrow widths
- [ ] Resize the log panel narrower than the toolbar's natural width — the toolbar scrolls horizontally on its own; the log content area's width is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened the log viewer top bar to save space and prevent horizontal scrolling of the whole panel. Replaced duration and memory text with icons (with tooltips), renamed the toggle to "auto-scroll" and made it non-wrapping, and scoped horizontal overflow to the top bar only.

<sup>Written for commit 65515f645f3802fc44305ae3335e377746aa441d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

