### PR TITLE
feat(ci): ping PR author when auto-review verdict is not good to merge

### DIFF
--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -82,10 +82,11 @@ jobs:
           EVENT_TITLE: ${{ github.event.pull_request.title }}
           EVENT_BODY: ${{ github.event.pull_request.body }}
           EVENT_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          EVENT_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           if [ -n "$INPUT_PR_NUMBER" ]; then
             PR_JSON=$(gh pr view "$INPUT_PR_NUMBER" --repo "${{ github.repository }}" \
-              --json number,baseRefName,baseRefOid,headRefOid,title,body,isCrossRepository)
+              --json number,baseRefName,baseRefOid,headRefOid,title,body,isCrossRepository,author)
             PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
             BASE_REF=$(echo "$PR_JSON" | jq -r '.baseRefName')
             BASE_SHA=$(echo "$PR_JSON" | jq -r '.baseRefOid')
@@ -93,6 +94,7 @@ jobs:
             PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
             PR_BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
             IS_FORK=$(echo "$PR_JSON" | jq -r '.isCrossRepository')
+            PR_AUTHOR=$(echo "$PR_JSON" | jq -r '.author.login // ""')
           else
             PR_NUMBER="$EVENT_PR_NUMBER"
             BASE_REF="$EVENT_BASE_REF"
@@ -101,6 +103,7 @@ jobs:
             PR_TITLE="$EVENT_TITLE"
             PR_BODY="$EVENT_BODY"
             IS_FORK="$EVENT_FORK"
+            PR_AUTHOR="$EVENT_AUTHOR"
           fi
           if [ "$IS_FORK" = "true" ]; then
             echo "Skipping Codex review for fork PR."
@@ -113,6 +116,7 @@ jobs:
             echo "base_ref=$BASE_REF"
             echo "base_sha=$BASE_SHA"
             echo "head_sha=$HEAD_SHA"
+            echo "pr_author=$PR_AUTHOR"
             echo 'title<<PR_TITLE_EOF'
             printf '%s\n' "$PR_TITLE"
             echo 'PR_TITLE_EOF'
@@ -211,6 +215,7 @@ jobs:
           PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           PR_TITLE: ${{ steps.pr.outputs.title }}
           PR_BODY: ${{ steps.pr.outputs.body }}
+          PR_AUTHOR: ${{ steps.pr.outputs.pr_author }}
           EXTRA_PROMPT: ${{ inputs.extra_prompt }}
         run: |
           mkdir -p .github/codex
@@ -219,6 +224,7 @@ jobs:
           const lines = [
             `Repository: ${process.env.PR_REPOSITORY}`,
             `PR number: ${process.env.PR_NUMBER}`,
+            `PR AUTHOR: ${process.env.PR_AUTHOR || '(unknown)'}`,
             `Base SHA: ${process.env.PR_BASE_SHA}`,
             `Head SHA: ${process.env.PR_HEAD_SHA}`,
             '',

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -224,7 +224,11 @@ jobs:
           const lines = [
             `Repository: ${process.env.PR_REPOSITORY}`,
             `PR number: ${process.env.PR_NUMBER}`,
-            `PR AUTHOR: ${process.env.PR_AUTHOR || '(unknown)'}`,
+          ];
+          if (process.env.PR_AUTHOR) {
+            lines.push(`PR AUTHOR: ${process.env.PR_AUTHOR}`);
+          }
+          lines.push(
             `Base SHA: ${process.env.PR_BASE_SHA}`,
             `Head SHA: ${process.env.PR_HEAD_SHA}`,
             '',
@@ -242,7 +246,7 @@ jobs:
             '',
             'Full review diff command:',
             `git diff --unified=0 ${process.env.PR_BASE_SHA}...${process.env.PR_HEAD_SHA}`
-          ];
+          );
           if (process.env.EXTRA_PROMPT && process.env.EXTRA_PROMPT.trim()) {
             lines.push('', 'Additional reviewer instructions:', process.env.EXTRA_PROMPT.trim());
           }

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -208,7 +208,11 @@ jobs:
           const lines = [
             `Repository: ${process.env.PR_REPOSITORY}`,
             `PR number: ${process.env.PR_NUMBER}`,
-            `PR AUTHOR: ${process.env.PR_AUTHOR || '(unknown)'}`,
+          ];
+          if (process.env.PR_AUTHOR) {
+            lines.push(`PR AUTHOR: ${process.env.PR_AUTHOR}`);
+          }
+          lines.push(
             `Base SHA: ${process.env.PR_BASE_SHA}`,
             `Head SHA: ${process.env.PR_HEAD_SHA}`,
             '',
@@ -226,7 +230,7 @@ jobs:
             '',
             'Full review diff command:',
             `git diff --unified=0 ${process.env.PR_BASE_SHA}...${process.env.PR_HEAD_SHA}`
-          ];
+          );
           if (process.env.EXTRA_PROMPT && process.env.EXTRA_PROMPT.trim()) {
             lines.push('', 'Additional reviewer instructions:', process.env.EXTRA_PROMPT.trim());
           }

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -82,10 +82,11 @@ jobs:
           EVENT_TITLE: ${{ github.event.pull_request.title }}
           EVENT_BODY: ${{ github.event.pull_request.body }}
           EVENT_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          EVENT_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           if [ -n "$INPUT_PR_NUMBER" ]; then
             PR_JSON=$(gh pr view "$INPUT_PR_NUMBER" --repo "${{ github.repository }}" \
-              --json number,baseRefName,baseRefOid,headRefOid,title,body,isCrossRepository)
+              --json number,baseRefName,baseRefOid,headRefOid,title,body,isCrossRepository,author)
             PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
             BASE_REF=$(echo "$PR_JSON" | jq -r '.baseRefName')
             BASE_SHA=$(echo "$PR_JSON" | jq -r '.baseRefOid')
@@ -93,6 +94,7 @@ jobs:
             PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
             PR_BODY=$(echo "$PR_JSON" | jq -r '.body // ""')
             IS_FORK=$(echo "$PR_JSON" | jq -r '.isCrossRepository')
+            PR_AUTHOR=$(echo "$PR_JSON" | jq -r '.author.login // ""')
           else
             PR_NUMBER="$EVENT_PR_NUMBER"
             BASE_REF="$EVENT_BASE_REF"
@@ -101,6 +103,7 @@ jobs:
             PR_TITLE="$EVENT_TITLE"
             PR_BODY="$EVENT_BODY"
             IS_FORK="$EVENT_FORK"
+            PR_AUTHOR="$EVENT_AUTHOR"
           fi
           if [ "$IS_FORK" = "true" ]; then
             echo "Skipping Pi review for fork PR."
@@ -113,6 +116,7 @@ jobs:
             echo "base_ref=$BASE_REF"
             echo "base_sha=$BASE_SHA"
             echo "head_sha=$HEAD_SHA"
+            echo "pr_author=$PR_AUTHOR"
             echo 'title<<PR_TITLE_EOF'
             printf '%s\n' "$PR_TITLE"
             echo 'PR_TITLE_EOF'
@@ -195,6 +199,7 @@ jobs:
           PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           PR_TITLE: ${{ steps.pr.outputs.title }}
           PR_BODY: ${{ steps.pr.outputs.body }}
+          PR_AUTHOR: ${{ steps.pr.outputs.pr_author }}
           EXTRA_PROMPT: ${{ inputs.extra_prompt }}
         run: |
           mkdir -p .github/pi
@@ -203,6 +208,7 @@ jobs:
           const lines = [
             `Repository: ${process.env.PR_REPOSITORY}`,
             `PR number: ${process.env.PR_NUMBER}`,
+            `PR AUTHOR: ${process.env.PR_AUTHOR || '(unknown)'}`,
             `Base SHA: ${process.env.PR_BASE_SHA}`,
             `Head SHA: ${process.env.PR_HEAD_SHA}`,
             '',

--- a/.github/workflows/pr-ready-review.yml
+++ b/.github/workflows/pr-ready-review.yml
@@ -90,14 +90,21 @@ jobs:
       - name: Resolve PR number
         id: resolve
         env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           if [ -n "$INPUT_PR_NUMBER" ]; then
-            echo "pr_number=$INPUT_PR_NUMBER" >> "$GITHUB_OUTPUT"
+            PR_NUMBER="$INPUT_PR_NUMBER"
+            PR_AUTHOR=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.user.login')
           else
-            echo "pr_number=$EVENT_PR_NUMBER" >> "$GITHUB_OUTPUT"
+            PR_NUMBER="$EVENT_PR_NUMBER"
+            PR_AUTHOR="$EVENT_PR_AUTHOR"
           fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "pr_author=$PR_AUTHOR" >> "$GITHUB_OUTPUT"
 
       - name: Fetch prior PR discussion
         id: prior
@@ -148,6 +155,7 @@ jobs:
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ steps.resolve.outputs.pr_number }}
+            PR AUTHOR: ${{ steps.resolve.outputs.pr_author }}
 
             ${{ env.REVIEW_PROMPT }}
           claude_args: |

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -9,7 +9,7 @@ You are reviewing a GitHub pull request for this repository. Apply this policy a
 
 ## Verdict (first line of the review)
 
-Start every review with a single verdict line, before any other section. Pick exactly one:
+Start every review with a single verdict line, before any other section (the only thing that may appear above the verdict is the optional `cc @<PR_AUTHOR>` ping described in "Pinging the author" below). Pick exactly one:
 
 - **Good to merge** — no blocking issues and no nits worth surfacing.
 - **Mergeable, but should ideally address nits: <short list>** — no blockers, but P2 findings that are worth a look. The list must name each nit briefly (e.g. "doc/code mismatch in `foo.rs`, half-finished `pub fn bar`").

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -17,6 +17,10 @@ Start every review with a single verdict line, before any other section. Pick ex
 
 The names in the list must match findings detailed later in the review. If you list a nit or issue here, it must appear with full context in the body. Do not invent items that aren't in the body, and do not bury blockers in the body without surfacing them in the verdict.
 
+## Pinging the author
+
+If the prompt context provides a `PR AUTHOR` (GitHub login) and the verdict is NOT "Good to merge" (i.e. it is "Mergeable, but should ideally address nits: ..." or "Should address issues before merging: ..."), prepend a single line `cc @<PR_AUTHOR>` to the top-level review comment, above the verdict line. This pings the author so they get a notification that there are items to address. Skip the ping entirely when the verdict is "Good to merge" — there is nothing for the author to act on. Do not add the ping to inline comments; the top-level summary comment is the only place it belongs.
+
 ## Review policy
 
 - Only report issues you are confident are real and introduced by this pull request.


### PR DESCRIPTION
## Summary

Auto-review workflows (Claude, Codex, Pi) now ping the PR author from the top-level review comment when the verdict isn't `Good to merge`, so the author gets a notification that there's something to address.

## Changes

- `REVIEW.md`: new "Pinging the author" section instructing reviewers to prepend `cc @<PR_AUTHOR>` above the verdict line when the verdict is `Mergeable, but should ideally address nits: ...` or `Should address issues before merging: ...`. Skipped for `Good to merge`. Clarified the verdict-line ordering rule so the ping is the only thing allowed above it.
- `.github/workflows/pr-ready-review.yml`: resolve `pr_author` from the webhook on event triggers, from `gh api repos/.../pulls/N` on `workflow_call`, and forward it as `PR AUTHOR:` in the Claude prompt header.
- `.github/workflows/codex-pr-review.yml` and `pi-pr-review.yml`: extend the existing PR-metadata resolver with `author.login` (via `gh pr view --json ...,author` on `workflow_call`, `github.event.pull_request.user.login` on the event path) and conditionally write a `PR AUTHOR:` line into the prompt context file when non-empty.

The slash-command dispatcher (`pr-review-commands.yml`) is unchanged — it reuses the three workflows, so it picks up the author resolution transparently. The local `/local-review` flow doesn't set `PR AUTHOR`, so it remains ping-free.

## Test plan

- [ ] Trigger each workflow on a non-fork PR with a non-`Good to merge` verdict and confirm the comment opens with `cc @<author>` above the verdict line.
- [ ] Trigger each workflow on a PR with a `Good to merge` verdict and confirm no ping is prepended.
- [ ] Exercise the `workflow_call` path for `pr-ready-review.yml` (e.g. via `/claude` on an existing PR) to confirm the `gh api repos/.../pulls/N` author lookup succeeds with `pull-requests: read`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-review comments now ping the PR author when the verdict isn’t Good to merge. Pings only happen when the author is known, so no “(unknown)” fallback.

- **New Features**
  - Resolve the PR author on event and `workflow_call`, and pass it into prompts as `PR AUTHOR:` for the Claude, Codex, and Pi workflows.
  - Prepend `cc @<PR_AUTHOR>` above the verdict in the top-level review when the verdict is not Good to merge; skip the ping for Good to merge or when the author is missing.
  - Update `REVIEW.md` to document the ping and clarify that it’s the only content allowed above the verdict line.

<sup>Written for commit 0591d64a753d2c8c7d4bff91ebc621bc10fb2c89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

