### PR TITLE
feat: download files via openapi client when token is set

### DIFF
--- a/frontend/src/lib/components/DisplayResult.svelte
+++ b/frontend/src/lib/components/DisplayResult.svelte
@@ -5,6 +5,7 @@
 	import { json } from 'svelte-highlight/languages'
 	import { copyToClipboard, parseS3Object, roughSizeOfObject } from '$lib/utils'
 	import { base } from '$lib/base'
+	import { downloadViaClient, shouldDownloadViaClient } from '$lib/utils/downloadFile'
 	import { Button, Drawer, DrawerContent } from './common'
 	import {
 		ClipboardCopy,
@@ -172,6 +173,25 @@
 	}
 
 	let largeObject: boolean | undefined = $state(undefined)
+
+	let resultApiPath = $derived(
+		workspaceId && jobId
+			? nodeId
+				? `/w/${workspaceId}/jobs/result_by_id/${jobId}/${nodeId}`
+				: `/w/${workspaceId}/jobs_u/completed/get_result/${jobId}`
+			: undefined
+	)
+	let resultDownloadHref = $derived(
+		resultApiPath
+			? `${base}/api${resultApiPath}`
+			: `data:text/json;charset=utf-8,${encodeURIComponent(toJsonStr(result))}`
+	)
+	let resultDownloadName = $derived(`${filename ?? 'result'}.json`)
+	async function onResultDownload(e: MouseEvent) {
+		if (!resultApiPath || !shouldDownloadViaClient()) return
+		e.preventDefault()
+		await downloadViaClient(resultApiPath, resultDownloadName)
+	}
 
 	function checkIfS3(result: any, keys: string[]) {
 		return keys.includes('s3') && typeof result.s3 === 'string'
@@ -1001,12 +1021,9 @@
 						{#if largeObject}
 							<div class="text-xs text-emphasis"
 								><a
-									download="{filename ?? 'result'}.json"
-									href={workspaceId && jobId
-										? nodeId
-											? `${base}/api/w/${workspaceId}/jobs/result_by_id/${jobId}/${nodeId}`
-											: `${base}/api/w/${workspaceId}/jobs_u/completed/get_result/${jobId}`
-										: `data:text/json;charset=utf-8,${encodeURIComponent(toJsonStr(result))}`}
+									download={resultDownloadName}
+									href={resultDownloadHref}
+									onclick={onResultDownload}
 								>
 									Download {filename ? '' : 'as JSON'}
 								</a>
@@ -1074,19 +1091,26 @@
 			<DrawerContent title="Expanded Result" on:close={jsonViewer.closeDrawer}>
 				{#snippet actions()}
 					{#if customUi?.disableDownload !== true}
-						<Button
-							download="{filename ?? 'result'}.json"
-							href={workspaceId && jobId
-								? nodeId
-									? `${base}/api/w/${workspaceId}/jobs/result_by_id/${jobId}/${nodeId}`
-									: `${base}/api/w/${workspaceId}/jobs_u/completed/get_result/${jobId}`
-								: `data:text/json;charset=utf-8,${encodeURIComponent(toJsonStr(result))}`}
-							startIcon={{ icon: Download }}
-							variant="subtle"
-							unifiedSize="md"
-						>
-							Download
-						</Button>
+						{#if resultApiPath && shouldDownloadViaClient()}
+							<Button
+								on:click={() => downloadViaClient(resultApiPath!, resultDownloadName)}
+								startIcon={{ icon: Download }}
+								variant="subtle"
+								unifiedSize="md"
+							>
+								Download
+							</Button>
+						{:else}
+							<Button
+								download={resultDownloadName}
+								href={resultDownloadHref}
+								startIcon={{ icon: Download }}
+								variant="subtle"
+								unifiedSize="md"
+							>
+								Download
+							</Button>
+						{/if}
 					{/if}
 					<Button
 						on:click={() => copyToClipboard(toJsonStr(result))}

--- a/frontend/src/lib/components/FlowStatusViewerInner.svelte
+++ b/frontend/src/lib/components/FlowStatusViewerInner.svelte
@@ -27,6 +27,7 @@
 	import { type DurationStatus, type FlowStatusViewerContext, type GraphModuleState } from './graph'
 	import ModuleStatus from './ModuleStatus.svelte'
 	import { clone, isScriptPreview, msToSec, readFieldsRecursively, truncateRev } from '$lib/utils'
+	import { downloadViaClient, shouldDownloadViaClient } from '$lib/utils/downloadFile'
 	import JobArgs from './JobArgs.svelte'
 	import { ChevronDown, Download, ExternalLink, Hourglass } from 'lucide-svelte'
 	import { deepEqual } from 'fast-equals'
@@ -1838,16 +1839,29 @@
 				style="min-height: {minTabHeight}px"
 			>
 				{#if !hideDownloadLogs && !isReplay && job?.id}
+					{@const logsApiPath = `/w/${workspace}/jobs_u/get_flow_all_logs/${job.id}`}
+					{@const logsName = `windmill_flow_logs_${job.id}.txt`}
 					<div class="flex justify-end p-1">
-						<Button
-							href="{base}/api/w/{workspace}/jobs_u/get_flow_all_logs/{job.id}"
-							download="windmill_flow_logs_{job.id}.txt"
-							color="light"
-							size="xs"
-							startIcon={{ icon: Download }}
-						>
-							Download all logs
-						</Button>
+						{#if shouldDownloadViaClient()}
+							<Button
+								on:click={() => downloadViaClient(logsApiPath, logsName)}
+								color="light"
+								size="xs"
+								startIcon={{ icon: Download }}
+							>
+								Download all logs
+							</Button>
+						{:else}
+							<Button
+								href="{base}/api{logsApiPath}"
+								download={logsName}
+								color="light"
+								size="xs"
+								startIcon={{ icon: Download }}
+							>
+								Download all logs
+							</Button>
+						{/if}
 					</div>
 				{/if}
 				<FlowLogViewerWrapper

--- a/frontend/src/lib/components/LogViewer.svelte
+++ b/frontend/src/lib/components/LogViewer.svelte
@@ -16,6 +16,7 @@
 	import { copyToClipboard } from '$lib/utils'
 	import { base } from '$lib/base'
 	import { withExternalDomain } from '$lib/externalDomain'
+	import { downloadViaClient, shouldDownloadViaClient } from '$lib/utils/downloadFile'
 	import { workspaceStore } from '$lib/stores'
 	import { AnsiUp } from 'ansi_up'
 	import NoWorkerWithTagWarning from './runs/NoWorkerWithTagWarning.svelte'
@@ -166,8 +167,7 @@
 	}
 
 	export function scrollToBottom() {
-		scroll &&
-			setTimeout(() => preEl?.scroll({ top: preEl?.scrollHeight, behavior: 'smooth' }), 100)
+		scroll && setTimeout(() => preEl?.scroll({ top: preEl?.scrollHeight, behavior: 'smooth' }), 100)
 	}
 
 	let logViewer: Drawer | undefined = $state()
@@ -205,9 +205,14 @@
 			scroll = true
 		}
 	})
-	let downloadHref = $derived(
-		withExternalDomain(`${base}/api/w/${$workspaceStore}/jobs_u/get_logs/${jobId}`)
-	)
+	let logsApiPath = $derived(`/w/${$workspaceStore}/jobs_u/get_logs/${jobId}`)
+	let downloadHref = $derived(withExternalDomain(`${base}/api${logsApiPath}`))
+	let downloadName = $derived(`windmill_logs_${jobId}.txt`)
+	async function onDownloadClick(e: MouseEvent) {
+		if (!shouldDownloadViaClient()) return
+		e.preventDefault()
+		await downloadViaClient(logsApiPath, downloadName)
+	}
 	let truncatedContent = $derived(truncateContent(content, loadedFromObjectStore, LOG_LIMIT))
 	let prefixInfo = $derived(findPrefixInfo(truncatedContent))
 	let downloadStartUrl = $derived(findStartUrl(truncatedContent, prefixInfo))
@@ -247,17 +252,30 @@
 	<DrawerContent title="Expanded Logs" on:close={logViewer.closeDrawer}>
 		{#snippet actions()}
 			{#if jobId && download}
-				<Button
-					href={downloadHref}
-					download="windmill_logs_{jobId}.txt"
-					color="light"
-					size="xs"
-					startIcon={{
-						icon: Download
-					}}
-				>
-					Download
-				</Button>
+				{#if shouldDownloadViaClient()}
+					<Button
+						on:click={() => downloadViaClient(logsApiPath, downloadName)}
+						color="light"
+						size="xs"
+						startIcon={{
+							icon: Download
+						}}
+					>
+						Download
+					</Button>
+				{:else}
+					<Button
+						href={downloadHref}
+						download={downloadName}
+						color="light"
+						size="xs"
+						startIcon={{
+							icon: Download
+						}}
+					>
+						Download
+					</Button>
+				{/if}
 			{/if}
 
 			<Button
@@ -328,7 +346,8 @@
 								class="text-primary pb-0.5"
 								target="_blank"
 								href={downloadHref}
-								download="windmill_logs_{jobId}.txt"
+								download={downloadName}
+								onclick={onDownloadClick}
 								><Download size="14" />
 							</a>
 						</div>

--- a/frontend/src/lib/components/ParqetCsvTableRenderer.svelte
+++ b/frontend/src/lib/components/ParqetCsvTableRenderer.svelte
@@ -9,6 +9,7 @@
 	import DarkModeObserver from './DarkModeObserver.svelte'
 	import { HelpersService } from '$lib/gen'
 	import { base } from '$lib/base'
+	import { downloadViaClient, shouldDownloadViaClient } from '$lib/utils/downloadFile'
 	import { enterpriseLicense, workspaceStore } from '$lib/stores'
 	import { Download } from 'lucide-svelte'
 	import { Loader2 } from 'lucide-svelte'
@@ -200,13 +201,17 @@
 		</div>
 	{/if}
 	{#if !disable_download && !s3resource.endsWith('.csv')}
+		{@const csvApiPath = `/w/${workspaceId}/job_helpers/download_s3_parquet_file_as_csv?file_key=${encodeURIComponent(s3resource)}${storage ? `&storage=${storage}` : ''}`}
+		{@const csvName = (s3resource.split('/').pop() ?? 'download') + '.csv'}
 		<a
 			target="_blank"
-			href="{base}/api/w/{workspaceId}/job_helpers/download_s3_parquet_file_as_csv?file_key={encodeURIComponent(
-				s3resource
-			)}{storage ? `&storage=${storage}` : ''}"
+			href="{base}/api{csvApiPath}"
 			class="text-secondary w-full text-right underline text-2xs whitespace-nowrap"
-			><div class="flex flex-row-reverse gap-2 items-center"><Download size={12} /> CSV</div></a
+			onclick={async (e) => {
+				if (!shouldDownloadViaClient()) return
+				e.preventDefault()
+				await downloadViaClient(csvApiPath, csvName)
+			}}><div class="flex flex-row-reverse gap-2 items-center"><Download size={12} /> CSV</div></a
 		>
 	{/if}
 

--- a/frontend/src/lib/components/S3FilePickerInner.svelte
+++ b/frontend/src/lib/components/S3FilePickerInner.svelte
@@ -38,6 +38,7 @@
 		sendUserToast,
 		type S3Object
 	} from '$lib/utils'
+	import { downloadViaClient, shouldDownloadViaClient } from '$lib/utils/downloadFile'
 	import { Alert, Button } from './common'
 	import Section from './Section.svelte'
 	import { createEventDispatcher, untrack, type Snippet } from 'svelte'
@@ -716,14 +717,27 @@
 						{#if filePreview !== undefined && (!hideS3SpecificDetails || !readOnlyMode || allowDelete)}
 							<div class="flex gap-2 shrink-0">
 								{#if !hideS3SpecificDetails}
-									<Button
-										title="Download file from S3"
-										variant="default"
-										href={`${base}/api/w/${$workspaceStore}/job_helpers/download_s3_file?file_key=${encodeURIComponent(fileMetadata?.fileKey ?? '')}${storage ? `&storage=${storage}` : ''}`}
-										download={fileMetadata?.fileKey.split('/').pop() ?? 'unnamed_download.file'}
-										startIcon={{ icon: Download }}
-										iconOnly={true}
-									/>
+									{@const downloadApiPath = `/w/${$workspaceStore}/job_helpers/download_s3_file?file_key=${encodeURIComponent(fileMetadata?.fileKey ?? '')}${storage ? `&storage=${storage}` : ''}`}
+									{@const downloadName =
+										fileMetadata?.fileKey.split('/').pop() ?? 'unnamed_download.file'}
+									{#if shouldDownloadViaClient()}
+										<Button
+											title="Download file from S3"
+											variant="default"
+											on:click={() => downloadViaClient(downloadApiPath, downloadName)}
+											startIcon={{ icon: Download }}
+											iconOnly={true}
+										/>
+									{:else}
+										<Button
+											title="Download file from S3"
+											variant="default"
+											href={`${base}/api${downloadApiPath}`}
+											download={downloadName}
+											startIcon={{ icon: Download }}
+											iconOnly={true}
+										/>
+									{/if}
 								{/if}
 								{#if !readOnlyMode}
 									<Button

--- a/frontend/src/lib/components/common/fileDownload/FileDownload.svelte
+++ b/frontend/src/lib/components/common/fileDownload/FileDownload.svelte
@@ -2,6 +2,7 @@
 	import { workspaceStore } from '$lib/stores'
 	import { Download } from 'lucide-svelte'
 	import { base } from '$lib/base'
+	import { downloadViaClient, shouldDownloadViaClient } from '$lib/utils/downloadFile'
 
 	interface Props {
 		s3object: any
@@ -10,6 +11,26 @@
 	}
 
 	let { s3object, workspaceId = undefined, appPath = undefined }: Props = $props()
+
+	let workspace = $derived(workspaceId ?? $workspaceStore)
+	let filename = $derived(s3object?.s3?.split?.('/')?.pop() ?? 'unnamed_download.file')
+
+	let apiPath = $derived(
+		`${
+			appPath
+				? `/w/${workspace}/apps_u/download_s3_file/${appPath}`
+				: `/w/${workspace}/job_helpers/download_s3_file`
+		}?${appPath ? 's3' : 'file_key'}=${encodeURIComponent(s3object?.s3 ?? '')}${
+			s3object?.storage ? `&storage=${s3object.storage}` : ''
+		}${appPath && s3object?.presigned ? `&${s3object?.presigned}` : ''}`
+	)
+	let href = $derived(`${base}/api${apiPath}`)
+
+	async function onclick(e: MouseEvent) {
+		if (!shouldDownloadViaClient()) return
+		e.preventDefault()
+		await downloadViaClient(apiPath, filename)
+	}
 </script>
 
 {#if s3object && s3object?.s3}
@@ -18,12 +39,9 @@
 border border-dashed border-gray-400 hover:border-blue-500
 focus-within:border-blue-500 hover:bg-blue-50 dark:hover:bg-frost-900 focus-within:bg-blue-50
 duration-200 rounded-lg p-1 gap-2"
-		href={`${base}/api/w/${workspaceId ?? $workspaceStore}${
-			appPath ? `/apps_u/download_s3_file/${appPath}` : '/job_helpers/download_s3_file'
-		}?${appPath ? 's3' : 'file_key'}=${encodeURIComponent(s3object?.s3 ?? '')}${
-			s3object?.storage ? `&storage=${s3object.storage}` : ''
-		}${appPath && s3object?.presigned ? `&${s3object?.presigned}` : ''}`}
-		download={s3object?.s3?.split?.('/')?.pop() ?? 'unnamed_download.file'}
+		{href}
+		download={filename}
+		{onclick}
 	>
 		<Download />
 		<span>

--- a/frontend/src/lib/components/propertyPicker/ObjectViewer.svelte
+++ b/frontend/src/lib/components/propertyPicker/ObjectViewer.svelte
@@ -2,6 +2,7 @@
 	import ObjectViewer from './ObjectViewer.svelte'
 
 	import { copyToClipboard, truncate } from '$lib/utils'
+	import { downloadViaClient, shouldDownloadViaClient } from '$lib/utils/downloadFile'
 
 	import {
 		createEventDispatcher,
@@ -407,12 +408,17 @@
 					<div class="flex">
 						<span class="text-primary">{closeBracket}</span>
 						{#if getTypeAsString(jsonFiltered) === 's3object'}
+							{@const s3DownloadApiPath = `/w/${$workspaceStore}/job_helpers/download_s3_file?file_key=${encodeURIComponent(jsonFiltered?.s3 ?? '')}${jsonFiltered?.storage ? `&storage=${jsonFiltered.storage}` : ''}`}
+							{@const s3DownloadName = jsonFiltered?.s3.split('/').pop() ?? 'unnamed_download.file'}
 							<a
 								class="text-secondary underline font-semibold text-2xs whitespace-nowrap ml-1 w-fit"
-								href={`/api/w/${$workspaceStore}/job_helpers/download_s3_file?file_key=${encodeURIComponent(
-									jsonFiltered?.s3 ?? ''
-								)}${jsonFiltered?.storage ? `&storage=${jsonFiltered.storage}` : ''}`}
-								download={jsonFiltered?.s3.split('/').pop() ?? 'unnamed_download.file'}
+								href={`/api${s3DownloadApiPath}`}
+								download={s3DownloadName}
+								onclick={async (e) => {
+									if (!shouldDownloadViaClient()) return
+									e.preventDefault()
+									await downloadViaClient(s3DownloadApiPath, s3DownloadName)
+								}}
 							>
 								<span class="flex items-center gap-1"><Download size={12} />download</span>
 							</a>

--- a/frontend/src/lib/utils/downloadFile.ts
+++ b/frontend/src/lib/utils/downloadFile.ts
@@ -1,0 +1,48 @@
+import { OpenAPI } from '$lib/gen'
+import { sendUserToast } from '$lib/toast'
+
+async function resolveToken(): Promise<string | undefined> {
+	const t = OpenAPI.TOKEN
+	if (!t) return undefined
+	return typeof t === 'string' ? t : await t({} as any)
+}
+
+/**
+ * When OpenAPI.TOKEN is set we cannot rely on a plain `<a href>` browser navigation
+ * because the browser does not attach the Authorization header. In that case fetch
+ * the file via the OpenAPI client (which uses OpenAPI.BASE and the Bearer token) and
+ * trigger a download from a blob URL. Otherwise let the default link behavior happen.
+ *
+ * `apiPath` should be the path relative to OpenAPI.BASE, starting with `/`
+ * (e.g. `/w/foo/job_helpers/download_s3_file?file_key=...`).
+ */
+export function shouldDownloadViaClient(): boolean {
+	return Boolean(OpenAPI.TOKEN)
+}
+
+export async function downloadViaClient(apiPath: string, filename: string): Promise<void> {
+	const token = await resolveToken()
+	const url = `${OpenAPI.BASE}${apiPath}`
+	const headers: Record<string, string> = {}
+	if (token) headers['Authorization'] = `Bearer ${token}`
+	let response: Response
+	try {
+		response = await fetch(url, { headers, credentials: OpenAPI.CREDENTIALS })
+	} catch (e) {
+		sendUserToast(`Download failed: ${e}`, true)
+		return
+	}
+	if (!response.ok) {
+		sendUserToast(`Download failed: ${response.status} ${response.statusText}`, true)
+		return
+	}
+	const blob = await response.blob()
+	const blobUrl = URL.createObjectURL(blob)
+	const a = document.createElement('a')
+	a.href = blobUrl
+	a.download = filename
+	document.body.appendChild(a)
+	a.click()
+	a.remove()
+	URL.revokeObjectURL(blobUrl)
+}

--- a/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/workspace_settings/+page.svelte
@@ -36,6 +36,7 @@
 	} from '$lib/stores'
 	import { sendUserToast } from '$lib/toast'
 	import { clone, emptyString, encodeState, hasUnsavedChanges } from '$lib/utils'
+	import { downloadViaClient, shouldDownloadViaClient } from '$lib/utils/downloadFile'
 	import { Slack } from 'lucide-svelte'
 	import SidebarNavigation from '$lib/components/common/sidebar/SidebarNavigation.svelte'
 
@@ -1499,13 +1500,26 @@
 
 							<div class="text-xs font-semibold text-emphasis mt-6 mb-1">Export workspace</div>
 							<div class="flex justify-start">
-								<Button
-									size="sm"
-									href="{base}/api/w/{$workspaceStore ?? ''}/workspaces/tarball?archive_type=zip"
-									target="_blank"
-								>
-									Export workspace as zip file
-								</Button>
+								{#if shouldDownloadViaClient()}
+									<Button
+										size="sm"
+										on:click={() =>
+											downloadViaClient(
+												`/w/${$workspaceStore ?? ''}/workspaces/tarball?archive_type=zip`,
+												`${$workspaceStore ?? 'workspace'}.zip`
+											)}
+									>
+										Export workspace as zip file
+									</Button>
+								{:else}
+									<Button
+										size="sm"
+										href="{base}/api/w/{$workspaceStore ?? ''}/workspaces/tarball?archive_type=zip"
+										target="_blank"
+									>
+										Export workspace as zip file
+									</Button>
+								{/if}
 							</div>
 
 							<div class="mt-12"></div>


### PR DESCRIPTION
## Summary

Browser downloads currently use a plain `<a href="/api/...">` that relies on the session cookie for auth. When the frontend is running cross-origin (embed / SDK consumer) with `OpenAPI.TOKEN` set, those direct links 401 because the browser does not attach the Bearer header to anchor navigation.

This PR keeps the existing fast `<a href>` direct-stream path when no token is set (default cookie auth, unchanged), and switches to a fetch-via-OpenAPI-client + blob-URL download when `OpenAPI.TOKEN` is set.

## Changes

- Add `frontend/src/lib/utils/downloadFile.ts` exposing `shouldDownloadViaClient()` and `downloadViaClient(apiPath, filename)` — fetches with `OpenAPI.BASE` + Bearer token, then triggers a blob-URL download.
- Migrate every authenticated API download to gate on `shouldDownloadViaClient()`:
  - `FileDownload.svelte` (S3 file card)
  - `S3FilePickerInner.svelte` (S3 picker download icon)
  - `propertyPicker/ObjectViewer.svelte` (inline `s3:` download link)
  - `ParqetCsvTableRenderer.svelte` (CSV export of parquet)
  - `FlowStatusViewerInner.svelte` (Download all logs)
  - `LogViewer.svelte` (single-job log download, both drawer Button and inline icon link)
  - `DisplayResult.svelte` (large result + drawer JSON download)
  - `workspace_settings/+page.svelte` (Export workspace as zip)

External-redirect `<a href>` links (Supabase OAuth wizard, Stripe billing portal) are intentionally left as plain links — they're not authenticated downloads.

## Test plan

- [ ] In a normal cookie-authenticated session, every touched download still triggers a native browser download with the correct filename (S3 file card, S3 picker, ObjectViewer s3 link, Parquet→CSV, flow logs, single-job logs drawer + inline icon, large result + drawer JSON, workspace zip export).
- [ ] In an embed / SDK-mode session where `OpenAPI.TOKEN` is set and `OpenAPI.BASE` points to a remote API, each of the same buttons produces a blob-driven download instead of navigating, and a 401/403 surfaces via toast rather than a silent failure.
- [ ] Right-click → "Save link as" still works in cookie mode (href is preserved).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable token-authenticated downloads via the `OpenAPI` client when `OpenAPI.TOKEN` is set, while keeping native link streaming for cookie-auth sessions. This fixes 401s for cross-origin embeds/SDK consumers and preserves right‑click “Save link as” in cookie mode.

- **New Features**
  - Added `frontend/src/lib/utils/downloadFile.ts` with `shouldDownloadViaClient()` and `downloadViaClient(apiPath, filename)` to fetch via `OpenAPI.BASE` + Bearer and trigger a blob-URL download with toast on errors.
  - Switched authenticated downloads to use the client path when a token is set in: S3 file card/picker and inline `s3:` links, job and flow log downloads, result JSON (inline and drawer), Parquet→CSV export, and workspace ZIP export.

<sup>Written for commit 448864c871b3c978667e9f544ef1bdc92652e92a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

