### PR TITLE
Add max-iterations to OpenAPI spec for AI Agent

### DIFF
--- a/openflow.openapi.yaml
+++ b/openflow.openapi.yaml
@@ -1053,6 +1053,12 @@ components:
                 - 0.0 = deterministic, focused responses
                 - 0.7 = balanced (common default)
                 - 1.0+ = more creative/random
+            max_iterations:
+              allOf:
+                - $ref: '#/components/schemas/InputTransform'
+              description: |
+                Number. Limits how many times the agent can loop through reasoning and tool use.
+                Range: 1-1000.
           required:
             - provider
             - user_message


### PR DESCRIPTION
Within the WebUI I can set the `max_iterations` for the AI Agent Node. I can also set it via API, but its not documented within the OpenAPI Specification. Because of this its not working correctly when using OpenAPI Code Generators.

This PR adds the `max_iterations` parameter to the OpenAPI Spec.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `max_iterations` to the AI Agent request schema in `openflow.openapi.yaml` so OpenAPI-generated clients can set it consistently with the WebUI and server. The field is a number using `InputTransform`, with a range of 1–1000.

<sup>Written for commit cd4fe718ae326ebf981e2da27df982d3ff333dcb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

