### PR TITLE
fix: populate raw_code for flowscript and appscript runs

### DIFF
--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -1067,10 +1067,15 @@ impl<'a> GetQuery<'a> {
                 .ok()
                 .inspect(|data| job.raw_flow = Some(sqlx::types::Json(data.raw_flow.clone())));
         }
-        if self.with_code && job.job_kind() == &JobKind::Preview {
+        if self.with_code
+            && matches!(
+                job.job_kind(),
+                JobKind::Preview | JobKind::FlowScript | JobKind::AppScript
+            )
+        {
             // Try to fetch the code from the cache, fallback to the preview code.
-            // NOTE: This could check for the job kinds instead of the `or_else` but it's not
-            // necessary as `fetch_script` return early if the job kind is not a preview one.
+            // `fetch_script` resolves FlowScript / AppScript via their runnable_id; for
+            // Preview jobs it returns early and we fall through to `fetch_preview_script`.
             let conn = Connection::from(db.clone());
             cache::job::fetch_script(db.clone(), job.job_kind(), hash)
                 .or_else(|_| cache::job::fetch_preview_script(&conn, &id, raw_lock, raw_code))


### PR DESCRIPTION
## Summary
On the run page for a `flowscript` (inline script step of a flow) or `appscript` job, the **Code** tab showed "No code available" and the **Fork code preview** action opened an empty editor. Both depend on `job.raw_code` being populated in the API response, but the backend only resolved `raw_code` from the cache for `JobKind::Preview` jobs.

## Changes
- `backend/windmill-api/src/jobs.rs`: widen `resolve_raw_values` to also resolve `raw_code` for `JobKind::FlowScript` and `JobKind::AppScript`. The underlying `cache::job::fetch_script` already supports all three kinds (Preview / FlowScript / AppScript) — it dispatches on `job_kind` and resolves FlowScript / AppScript via their `runnable_id` against the `flow_node` / `app_script` tables. The `or_else` fallback to `fetch_preview_script` is preserved for legacy Preview jobs.

## Test plan
- [ ] Open the run page for a completed flowscript (inline step inside a flow) — the Code tab shows the source.
- [ ] Open the run page for an appscript job — the Code tab shows the source.
- [ ] Click "Fork code preview" on a flowscript run — the editor opens prefilled with the script.
- [ ] Open a preview script run — Code tab still works (regression check).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty Code tab and empty "Fork code preview" for flowscript and appscript runs by resolving `raw_code` for these job kinds in the API. Keeps preview job behavior unchanged.

- **Bug Fixes**
  - Populate `raw_code` for `FlowScript` and `AppScript` jobs via `cache::job::fetch_script` (previously only `Preview`).
  - Preserve fallback to `fetch_preview_script` for legacy preview runs.
  - Code tab now shows source and "Fork code preview" pre-fills the editor for flowscript/appscript runs.

<sup>Written for commit b76c2bad6dc6ecedabc71f50d1054e78c9b7334f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

