### PR TITLE
perf: lazy-load script editor history and hit partial index

### DIFF
--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -561,6 +561,8 @@
 	let testIsLoading = $state(false)
 	let testJob: Job | undefined = $state()
 	let pastPreviews: CompletedJob[] = $state([])
+	let historyTabActive = false
+	let pastPreviewsRequest: ReturnType<typeof JobService.listCompletedJobs> | undefined
 	let validCode = $state(true)
 
 	// Recording
@@ -691,7 +693,9 @@
 						lastRecording = scriptRecording.stop()
 						setActiveRecording(undefined)
 					}
-					loadPastTests()
+					if (historyTabActive) {
+						loadPastTests()
+					}
 				},
 				doneError({ error }) {
 					if (scriptRecording.active) {
@@ -722,12 +726,29 @@
 	}
 
 	async function loadPastTests(): Promise<void> {
-		pastPreviews = await JobService.listCompletedJobs({
+		pastPreviewsRequest?.cancel()
+		const req = JobService.listCompletedJobs({
 			workspace: $workspaceStore!,
 			jobKinds: 'preview',
 			createdBy: $userStore?.username,
-			scriptPathExact: path
+			scriptPathExact: path,
+			hasNullParent: true
 		})
+		pastPreviewsRequest = req
+		try {
+			const result = await req
+			if (pastPreviewsRequest === req) {
+				pastPreviews = result
+			}
+		} catch (err) {
+			if (!(err instanceof Error) || err.name !== 'CancelError') {
+				throw err
+			}
+		} finally {
+			if (pastPreviewsRequest === req) {
+				pastPreviewsRequest = undefined
+			}
+		}
 	}
 
 	export async function inferSchema(
@@ -1128,7 +1149,6 @@
 		if (!validCode && code && lang) {
 			await inferSchema(code, { applyInitialArgs: true })
 		}
-		loadPastTests()
 		aiChatManager.saveAndClear()
 		aiChatManager.changeMode(AIMode.SCRIPT)
 	})
@@ -1209,6 +1229,8 @@
 	}
 
 	onDestroy(() => {
+		pastPreviewsRequest?.cancel()
+		pastPreviewsRequest = undefined
 		disableCollaboration()
 		aiChatManager.scriptEditorApplyCode = undefined
 		aiChatManager.scriptEditorShowDiffMode = undefined
@@ -1676,6 +1698,12 @@
 										} as any)
 									: testJob}
 								{pastPreviews}
+								onTabChange={(tab) => {
+									historyTabActive = tab === 'history'
+									if (historyTabActive) {
+										loadPastTests()
+									}
+								}}
 								previewIsLoading={debugMode
 									? $debugState.running && !$debugState.stopped
 									: testIsLoading}

--- a/frontend/src/lib/components/scriptEditor/LogPanel.svelte
+++ b/frontend/src/lib/components/scriptEditor/LogPanel.svelte
@@ -49,6 +49,7 @@
 		capturesTab?: import('svelte').Snippet
 		customResultPanel?: import('svelte').Snippet
 		showCustomResultPanel?: boolean
+		onTabChange?: (tab: string) => void
 	}
 
 	let {
@@ -65,7 +66,8 @@
 		children,
 		capturesTab,
 		customResultPanel,
-		showCustomResultPanel = false
+		showCustomResultPanel = false,
+		onTabChange
 	}: Props = $props()
 
 	type DContent = {
@@ -77,6 +79,10 @@
 	let selectedTab = $state('logs')
 	let drawerOpen: boolean = $state(false)
 	let drawerContent: DContent | undefined = $state(undefined)
+
+	$effect(() => {
+		onTabChange?.(selectedTab)
+	})
 
 	export function setFocusToLogs() {
 		selectedTab = 'logs'


### PR DESCRIPTION
## Summary

The script editor was firing `/jobs/completed/list` (filtered by `script_path_exact`, `created_by`, `job_kinds=preview`) on mount and after every test, regardless of whether the History tab was visible. On large workspaces this query was extremely slow and could pile up concurrently.

Three issues addressed in the frontend:

1. **No good index hit** — the query filters by `runnable_path` exactly, but the matching indexes on `v2_job` (`ix_job_root_job_index_by_path_2`, `idx_job_v2_job_root_by_path_2`, `ix_job_workspace_id_created_at_new_5`) are partial on `parent_job IS NULL`. Without that predicate, the planner falls back to a wide chronological scan. Editor-issued previews are always top-level, so `hasNullParent: true` is added to the request, letting the planner use the existing partial index.
2. **History query ran even when tab wasn't selected** — the call fired in `onMount` and after every test completion. Now it's lazy: only fires when the History tab is selected, and only refreshes after tests when History is the active tab.
3. **No cancellation / destroy cleanup** — concurrent calls could stack. Now an in-flight `CancelablePromise` is tracked and aborted before a new one is issued or when the component is destroyed; stale responses are discarded.

## Changes

- `ScriptEditor.svelte`: removed unconditional `loadPastTests()` from `onMount`; gated the post-test refresh on `historyTabActive`; added `hasNullParent: true` to the request; tracked the in-flight `pastPreviewsRequest` and cancel on supersede / `onDestroy`.
- `LogPanel.svelte`: added an `onTabChange` callback prop, fired from a `$effect` on `selectedTab`. ScriptEditor uses it to know when History is active and trigger the (now-lazy) load.

## Test plan

- [ ] Open a script editor in a large workspace and confirm no `/jobs/completed/list` request fires on mount.
- [ ] Click the History tab — one request fires and the list populates.
- [ ] Run a test with the Logs tab active — no history refresh request.
- [ ] Run a test with the History tab active — the list refreshes after completion.
- [ ] Rapidly switch tabs / rerun tests — only the latest response wins, no `CancelError` surfaces in the console.
- [ ] Navigate away mid-load — no unhandled rejection appears.
- [ ] Confirm via `EXPLAIN` that the new request plan uses `ix_job_root_job_index_by_path_2`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-load Script Editor history and make the completed jobs query hit the partial index to reduce load and improve speed in large workspaces. Also cancel in-flight requests to avoid stacked queries.

- **Performance**
  - Added `hasNullParent: true` to `/jobs/completed/list` so the planner uses `ix_job_root_job_index_by_path_2` when filtering by `scriptPathExact`.
  - Lazy-load history: no request on mount; fetch only when the History tab is active; refresh after tests only if History is active.
  - Abort and ignore stale requests: track the in-flight `CancelablePromise`, cancel on supersede and `onDestroy`; use `LogPanel` `onTabChange` to trigger loading when History is selected.

<sup>Written for commit 2a77ea372f1c1a4145751fc20972c50ca24a1aa2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

