### PR TITLE
fix: add Input, Result, Trigger to reserved flow step IDs

### DIFF
--- a/frontend/src/lib/components/flows/idUtils.ts
+++ b/frontend/src/lib/components/flows/idUtils.ts
@@ -14,7 +14,10 @@ export const forbiddenIds: string[] = [
 	'in',
 	'failure',
 	'preprocessor',
-	'as'
+	'as',
+	'Input',
+	'Result',
+	'Trigger'
 ]
 
 export function numberToChars(n: number) {


### PR DESCRIPTION
## Problem

Renaming a flow step's ID to `Input`, `Result`, or `Trigger` silently corrupts the flow editor UI: the right-hand panel switches to rendering the special virtual node panel (Input settings, Result viewer, etc.) instead of the step's own config panel, making the step unreachable without editing YAML directly. Reported in #7139.

## Root cause

`FlowEditorPanel.svelte` switches panels based on `selectedId === 'Input'`, `selectedId === 'Result'`, and `selectedId === 'Trigger'`. These virtual IDs were already treated as reserved in `multiSelectUtils.ts` (the `VIRTUAL_ID_PREFIXES` list) but were **not** in the `forbiddenIds` array in `idUtils.ts` that backs `IdEditorInput`'s validation, so users received no warning when choosing these names.

## Fix

Add `'Input'`, `'Result'`, and `'Trigger'` to the `forbiddenIds` array. The `IdEditorInput` component already checks this list and shows a "This ID is reserved" error, blocking the save — no UI changes required.

## Testing

1. Open the flow editor and add a step.
2. Click the step ID to rename it.
3. Type `Input`, `Result`, or `Trigger` — you should see "This ID is reserved" and the save button should be disabled.

Note: `preprocessor` and `failure` were already in `forbiddenIds`; this PR brings `Input`, `Result`, and `Trigger` to parity with `multiSelectUtils.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reserve "Input", "Result", and "Trigger" as flow step IDs to stop the editor from switching to special virtual panels when a step is renamed to these. Adds them to `forbiddenIds` used by `IdEditorInput`, blocking save with "This ID is reserved", matching `multiSelectUtils.ts`, and fixing #7139.

<sup>Written for commit f2d51aa665c75b0d8b4aaf9c208538351ef86e49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

