### PR TITLE
fix: preserve negative integers in Bedrock tool schema conversion

### DIFF
--- a/backend/windmill-ai/src/ai_bedrock.rs
+++ b/backend/windmill-ai/src/ai_bedrock.rs
@@ -326,8 +326,10 @@ pub fn json_to_document(value: serde_json::Value) -> aws_smithy_types::Document 
         }
         Value::Array(arr) => Document::Array(arr.into_iter().map(json_to_document).collect()),
         Value::Number(num) => {
-            if let Some(i) = num.as_i64() {
-                Document::Number(aws_smithy_types::Number::PosInt(i as u64))
+            if let Some(u) = num.as_u64() {
+                Document::Number(aws_smithy_types::Number::PosInt(u))
+            } else if let Some(i) = num.as_i64() {
+                Document::Number(aws_smithy_types::Number::NegInt(i))
             } else if let Some(f) = num.as_f64() {
                 Document::Number(aws_smithy_types::Number::Float(f))
             } else {
@@ -842,6 +844,36 @@ mod tests {
                 .expect("valid raw json"),
             },
         }
+    }
+
+    #[test]
+    fn json_to_document_preserves_negative_integers() {
+        let value = serde_json::json!(-1);
+        let doc = json_to_document(value);
+        assert!(matches!(
+            doc,
+            aws_smithy_types::Document::Number(aws_smithy_types::Number::NegInt(-1))
+        ));
+    }
+
+    #[test]
+    fn json_to_document_handles_large_u64_above_i64_max() {
+        let value = serde_json::json!(u64::MAX);
+        let doc = json_to_document(value);
+        assert!(matches!(
+            doc,
+            aws_smithy_types::Document::Number(aws_smithy_types::Number::PosInt(u)) if u == u64::MAX
+        ));
+    }
+
+    #[test]
+    fn json_to_document_handles_positive_integers() {
+        let value = serde_json::json!(42);
+        let doc = json_to_document(value);
+        assert!(matches!(
+            doc,
+            aws_smithy_types::Document::Number(aws_smithy_types::Number::PosInt(42))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bedrock requests with tools fail with `tools.N.custom.input_schema: int too big to convert` whenever any tool's JSON schema contains a negative integer (e.g. `"default": -1`, `"minimum": -1`, or a negative `enum` value). Such schemas are common for Windmill scripts wired as tools (e.g. `def f(offset: int = -1)`).

Root cause is in `json_to_document` (`backend/windmill-ai/src/ai_bedrock.rs`): the code path matched `as_i64()` first and then cast to `u64` via `as`, reinterpreting any negative integer as a huge unsigned value (e.g. `-1` → `18446744073709551615`). Bedrock then rejected the schema.

## Changes

- `json_to_document`: try `as_u64` first (preserves the full `u64` range, including values above `i64::MAX` that previously fell through to lossy `Float`), fall back to `as_i64` → `NegInt(i64)` for negatives, then `as_f64`.
- Add unit tests covering negative integers, positive integers, and `u64::MAX`.

## Test plan

- [x] `cargo test -p windmill-ai --all-features json_to_document` passes (3 new tests)
- [ ] Re-run the failing Bedrock chat that hit `tools.4.custom.input_schema: int too big to convert` and confirm the request now succeeds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Bedrock tool schema conversion to preserve negative integers so tools with values like -1 no longer fail. Prevents “tools.N.custom.input_schema: int too big to convert” errors and supports the full `u64` range.

- **Bug Fixes**
  - In `json_to_document`, parse numbers as `u64` first, then `i64` → `NegInt`, then `f64`, avoiding lossy casts to `PosInt`.
  - Added unit tests for negative integers, positive integers, and `u64::MAX`.

<sup>Written for commit 59cb69655792f4f90eb5519c78b8a4fbf1a2e439. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

