### PR TITLE
style(ai-chat): make message text smaller

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatMessage.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatMessage.svelte
@@ -71,7 +71,7 @@
 	{:else}
 		<div
 			class={twMerge(
-				'text-sm py-1 mx-2',
+				'text-xs py-1 mx-2',
 				message.role === 'user' &&
 					'px-2 border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 rounded-lg relative group',
 				(message.role === 'assistant' || message.role === 'tool') && 'px-[1px]',
@@ -88,7 +88,7 @@
 		</div>
 	{/if}
 	{#if message.role === 'user' && message.snapshot}
-		<div class="mx-2 text-sm text-primary flex flex-row items-center justify-between gap-2 mt-2">
+		<div class="mx-2 text-xs text-primary flex flex-row items-center justify-between gap-2 mt-2">
 			Saved {message.snapshot.type === 'flow' ? 'a flow' : 'an app'} snapshot
 			<Button
 				size="xs2"

--- a/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
+++ b/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
@@ -6,14 +6,14 @@
 	import LinkRenderer from './LinkRenderer.svelte'
 
 	interface Props {
-		message: DisplayMessage;
+		message: DisplayMessage
 	}
 
-	let { message }: Props = $props();
+	let { message }: Props = $props()
 </script>
 
 <div
-	class="prose prose-sm dark:prose-invert w-full max-w-full leading-snug space-y-2 prose-ul:!pl-6"
+	class="prose prose-sm dark:prose-invert w-full max-w-full leading-snug space-y-2 prose-ul:!pl-6 !text-xs"
 >
 	<Markdown
 		md={message.content}


### PR DESCRIPTION
## Summary
- Reduce chat message font size from `text-sm` → `text-xs` for user/assistant messages and the saved-snapshot footer in `AIChatMessage.svelte`.
- Add `!text-xs` to the prose root in `AssistantMessage.svelte` to override `prose-sm`'s default `0.875rem` so markdown renders proportionally smaller.

The tool-execution display and context badges were already `text-xs`, so no change there.

Fixes WIN-1950

## Test plan
- [ ] Verify user message bubbles render at the smaller size.
- [ ] Verify assistant markdown output (paragraphs, lists, code) renders proportionally smaller.
- [ ] Verify the "Saved a flow/app snapshot" footer matches the new size.
- [ ] Light + dark mode look consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make AI chat message text smaller for better density, addressing WIN-1950. User and assistant bubbles and the snapshot footer now use `text-xs`, and `AssistantMessage.svelte` applies `!text-xs` to the prose root so markdown renders proportionally smaller.

<sup>Written for commit 4ce0767d3e8b6a4ae456b4a01cb95517deda4dd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

