### PR TITLE
style(ai-chat): make message text smaller

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatMessage.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatMessage.svelte
@@ -71,7 +71,7 @@
 	{:else}
 		<div
 			class={twMerge(
-				'text-sm py-1 mx-2',
+				'text-xs py-1 mx-2',
 				message.role === 'user' &&
 					'px-2 border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 rounded-lg relative group',
 				(message.role === 'assistant' || message.role === 'tool') && 'px-[1px]',
@@ -88,7 +88,7 @@
 		</div>
 	{/if}
 	{#if message.role === 'user' && message.snapshot}
-		<div class="mx-2 text-sm text-primary flex flex-row items-center justify-between gap-2 mt-2">
+		<div class="mx-2 text-xs text-primary flex flex-row items-center justify-between gap-2 mt-2">
 			Saved {message.snapshot.type === 'flow' ? 'a flow' : 'an app'} snapshot
 			<Button
 				size="xs2"

--- a/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
+++ b/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
@@ -6,14 +6,14 @@
 	import LinkRenderer from './LinkRenderer.svelte'
 
 	interface Props {
-		message: DisplayMessage;
+		message: DisplayMessage
 	}
 
-	let { message }: Props = $props();
+	let { message }: Props = $props()
 </script>
 
 <div
-	class="prose prose-sm dark:prose-invert w-full max-w-full leading-snug space-y-2 prose-ul:!pl-6"
+	class="prose prose-sm dark:prose-invert w-full max-w-full leading-snug space-y-2 prose-ul:!pl-6 !text-xs"
 >
 	<Markdown
 		md={message.content}


### PR DESCRIPTION
Fixes WIN-1950

## Summary
- Shrink AI chat message text from `text-sm` to `text-xs` in `AIChatMessage.svelte` (user message body + snapshot-revert row)
- Force `!text-xs` on the assistant `prose` wrapper in `AssistantMessage.svelte` so markdown-rendered content also shrinks

## Test plan
- [x] `npm run check:fast` passes
- [ ] Open the AI chat (script editor / flow / app) and confirm user, assistant, and tool messages render at the smaller size with markdown still legible

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce AI chat message font size from text-sm to text-xs to fit more content and meet WIN-1950. Applies to user/assistant/tool messages and the saved-snapshot row, with assistant markdown forced to render at text-xs.

<sup>Written for commit 4ce0767d3e8b6a4ae456b4a01cb95517deda4dd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

