### PR TITLE
style(ai-chat): make message text smaller

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatMessage.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatMessage.svelte
@@ -71,7 +71,7 @@
 	{:else}
 		<div
 			class={twMerge(
-				'text-sm py-1 mx-2',
+				'text-xs py-1 mx-2',
 				message.role === 'user' &&
 					'px-2 border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 rounded-lg relative group',
 				(message.role === 'assistant' || message.role === 'tool') && 'px-[1px]',
@@ -88,7 +88,7 @@
 		</div>
 	{/if}
 	{#if message.role === 'user' && message.snapshot}
-		<div class="mx-2 text-sm text-primary flex flex-row items-center justify-between gap-2 mt-2">
+		<div class="mx-2 text-xs text-primary flex flex-row items-center justify-between gap-2 mt-2">
 			Saved {message.snapshot.type === 'flow' ? 'a flow' : 'an app'} snapshot
 			<Button
 				size="xs2"

--- a/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
+++ b/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
@@ -6,14 +6,14 @@
 	import LinkRenderer from './LinkRenderer.svelte'
 
 	interface Props {
-		message: DisplayMessage;
+		message: DisplayMessage
 	}
 
-	let { message }: Props = $props();
+	let { message }: Props = $props()
 </script>
 
 <div
-	class="prose prose-sm dark:prose-invert w-full max-w-full leading-snug space-y-2 prose-ul:!pl-6"
+	class="prose prose-sm dark:prose-invert w-full max-w-full leading-snug space-y-2 prose-ul:!pl-6 !text-xs"
 >
 	<Markdown
 		md={message.content}


### PR DESCRIPTION
## Summary

Reduces text size in the AI chat from `text-sm` to `text-xs` for user messages, snapshot rows, and the assistant prose block.

Fixes WIN-1950.

## Changes

- `AIChatMessage.svelte`: `text-sm` → `text-xs` on the user/tool/assistant message wrapper and on the snapshot info row.
- `AssistantMessage.svelte`: added `!text-xs` to the prose container so markdown content (which `prose-sm` would otherwise size up) matches the surrounding chat text.

## Test plan

- [ ] Open the AI chat in flow/script/app contexts and confirm user, assistant (markdown), and tool messages all render at the smaller size.
- [ ] Save a flow/app snapshot and confirm the snapshot row text is consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make AI chat text smaller per WIN-1950: user, tool, and assistant messages and the saved-snapshot row now render at `text-xs` instead of `text-sm`. Also override the prose container in `AssistantMessage.svelte` so markdown respects `text-xs` for consistent sizing.

<sup>Written for commit 4ce0767d3e8b6a4ae456b4a01cb95517deda4dd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

