### PR TITLE
style(ai-chat): make message text smaller

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatMessage.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatMessage.svelte
@@ -71,7 +71,7 @@
 	{:else}
 		<div
 			class={twMerge(
-				'text-sm py-1 mx-2',
+				'text-xs py-1 mx-2',
 				message.role === 'user' &&
 					'px-2 border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 rounded-lg relative group',
 				(message.role === 'assistant' || message.role === 'tool') && 'px-[1px]',
@@ -88,7 +88,7 @@
 		</div>
 	{/if}
 	{#if message.role === 'user' && message.snapshot}
-		<div class="mx-2 text-sm text-primary flex flex-row items-center justify-between gap-2 mt-2">
+		<div class="mx-2 text-xs text-primary flex flex-row items-center justify-between gap-2 mt-2">
 			Saved {message.snapshot.type === 'flow' ? 'a flow' : 'an app'} snapshot
 			<Button
 				size="xs2"

--- a/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
+++ b/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
@@ -6,14 +6,14 @@
 	import LinkRenderer from './LinkRenderer.svelte'
 
 	interface Props {
-		message: DisplayMessage;
+		message: DisplayMessage
 	}
 
-	let { message }: Props = $props();
+	let { message }: Props = $props()
 </script>
 
 <div
-	class="prose prose-sm dark:prose-invert w-full max-w-full leading-snug space-y-2 prose-ul:!pl-6"
+	class="prose prose-sm dark:prose-invert w-full max-w-full leading-snug space-y-2 prose-ul:!pl-6 !text-xs"
 >
 	<Markdown
 		md={message.content}


### PR DESCRIPTION
## Summary

Reduce AI chat message font size from `text-sm` to `text-xs` for user/assistant messages and the saved-snapshot footer. Override `prose-sm` root font-size in `AssistantMessage` with `!text-xs` so markdown content renders proportionally at the smaller size.

Fixes WIN-1950

## Changes

- `AIChatMessage.svelte`: switch user/assistant/tool message container from `text-sm` to `text-xs`
- `AIChatMessage.svelte`: switch saved-snapshot footer line from `text-sm` to `text-xs`
- `AssistantMessage.svelte`: add `!text-xs` to the `prose prose-sm` wrapper so markdown text (paragraphs, lists, etc.) inherits the smaller size

## Test plan

- [ ] Open an AI chat in the frontend and verify user, assistant, and tool messages render at the smaller size
- [ ] Verify markdown formatting (lists, code blocks, links) in assistant messages stays proportionally sized
- [ ] Save a flow/app snapshot from chat and verify the footer line uses the smaller size

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make AI chat message text smaller to satisfy WIN-1950. Switches containers from `text-sm` to `text-xs` for user, assistant, and tool messages and the saved-snapshot footer, and adds `!text-xs` to the `prose` wrapper in `AssistantMessage` so markdown renders proportionally.

<sup>Written for commit 4ce0767d3e8b6a4ae456b4a01cb95517deda4dd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

