### PR TITLE
refactor: move openai-compatible proxy building

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -13880,6 +13880,7 @@ dependencies = [
  "bytes",
  "eventsource-stream",
  "futures",
+ "http 1.4.0",
  "lazy_static",
  "mime_guess",
  "reqwest 0.13.1",

--- a/backend/windmill-ai/Cargo.toml
+++ b/backend/windmill-ai/Cargo.toml
@@ -24,6 +24,7 @@ base64.workspace = true
 bytes.workspace = true
 eventsource-stream.workspace = true
 futures.workspace = true
+http.workspace = true
 mime_guess.workspace = true
 reqwest.workspace = true
 serde.workspace = true

--- a/backend/windmill-ai/src/lib.rs
+++ b/backend/windmill-ai/src/lib.rs
@@ -6,6 +6,7 @@ pub mod ai_providers;
 pub mod ai_types;
 pub mod image_handler;
 pub mod providers;
+pub mod proxy;
 pub mod query_builder;
 pub mod sse;
 pub mod types;

--- a/backend/windmill-ai/src/providers/mod.rs
+++ b/backend/windmill-ai/src/providers/mod.rs
@@ -6,7 +6,10 @@ pub mod openai;
 pub mod openrouter;
 pub mod other;
 
-use crate::{ai_providers::AIProvider, query_builder::QueryBuilder, types::ProviderWithResource};
+use crate::{
+    ai_providers::AIProvider, proxy::ProviderCredentials, query_builder::QueryBuilder,
+    types::ProviderWithResource,
+};
 
 use self::{
     anthropic::AnthropicQueryBuilder, google_ai::GoogleAIQueryBuilder, openai::OpenAIQueryBuilder,
@@ -27,5 +30,20 @@ pub fn create_query_builder(provider: &ProviderWithResource) -> Box<dyn QueryBui
         )),
         AIProvider::OpenRouter => Box::new(OpenRouterQueryBuilder::new()),
         _ => Box::new(OtherQueryBuilder::new(provider.kind.clone())),
+    }
+}
+
+/// Factory function to create the appropriate query builder from resolved proxy credentials.
+pub fn create_proxy_query_builder(credentials: &ProviderCredentials) -> Box<dyn QueryBuilder> {
+    match credentials.provider {
+        AIProvider::GoogleAI => Box::new(GoogleAIQueryBuilder::new(credentials.platform.clone())),
+        AIProvider::OpenAI => Box::new(OpenAIQueryBuilder::new(credentials.provider.clone())),
+        AIProvider::Anthropic => Box::new(AnthropicQueryBuilder::new(
+            credentials.provider.clone(),
+            credentials.platform.clone(),
+            credentials.enable_1m_context,
+        )),
+        AIProvider::OpenRouter => Box::new(OpenRouterQueryBuilder::new()),
+        _ => Box::new(OtherQueryBuilder::new(credentials.provider.clone())),
     }
 }

--- a/backend/windmill-ai/src/providers/openai.rs
+++ b/backend/windmill-ai/src/providers/openai.rs
@@ -2,6 +2,7 @@ use crate::{
     ai_providers::AIProvider,
     ai_types::OpenAIToolCall,
     image_handler::{prepare_messages_for_api, s3_object_to_content_part},
+    proxy::{build_openai_compatible_proxy_request, ProxyBuildArgs, ProxyRequest},
     query_builder::{BuildRequestArgs, ParsedResponse, QueryBuilder, StreamEventSink},
     sse::{OpenAIResponsesSSEParser, SSEParser},
     types::*,
@@ -477,6 +478,10 @@ impl QueryBuilder for OpenAIQueryBuilder {
     fn supports_tools_with_output_type(&self, _output_type: &OutputType) -> bool {
         // OpenAI supports tools for both text and image output
         true
+    }
+
+    fn build_proxy_request(&self, args: &ProxyBuildArgs<'_>) -> Result<ProxyRequest, Error> {
+        build_openai_compatible_proxy_request(args)
     }
 
     async fn parse_streaming_response(

--- a/backend/windmill-ai/src/providers/openrouter.rs
+++ b/backend/windmill-ai/src/providers/openrouter.rs
@@ -1,6 +1,7 @@
 use crate::{
     ai_providers::AIProvider,
     image_handler::prepare_messages_for_api,
+    proxy::{build_openai_compatible_proxy_request, ProxyBuildArgs, ProxyRequest},
     query_builder::{BuildRequestArgs, ParsedResponse, QueryBuilder, StreamEventSink},
     types::*,
 };
@@ -70,6 +71,10 @@ impl QueryBuilder for OpenRouterQueryBuilder {
     fn supports_tools_with_output_type(&self, _output_type: &OutputType) -> bool {
         // OpenRouter supports tools for both text and image output (via OpenAI-compatible API)
         true
+    }
+
+    fn build_proxy_request(&self, args: &ProxyBuildArgs<'_>) -> Result<ProxyRequest, Error> {
+        build_openai_compatible_proxy_request(args)
     }
 
     async fn build_request(

--- a/backend/windmill-ai/src/providers/other.rs
+++ b/backend/windmill-ai/src/providers/other.rs
@@ -1,6 +1,7 @@
 use crate::{
     ai_providers::AIProvider,
     image_handler::prepare_messages_for_api,
+    proxy::{build_openai_compatible_proxy_request, ProxyBuildArgs, ProxyRequest},
     query_builder::{BuildRequestArgs, ParsedResponse, QueryBuilder, StreamEventSink},
     sse::{OpenAISSEParser, SSEParser},
     types::*,
@@ -186,6 +187,10 @@ impl QueryBuilder for OtherQueryBuilder {
 
     fn supports_retry_without_usage(&self) -> bool {
         true
+    }
+
+    fn build_proxy_request(&self, args: &ProxyBuildArgs<'_>) -> Result<ProxyRequest, Error> {
+        build_openai_compatible_proxy_request(args)
     }
 
     async fn parse_image_response(

--- a/backend/windmill-ai/src/proxy.rs
+++ b/backend/windmill-ai/src/proxy.rs
@@ -1,0 +1,44 @@
+use std::collections::HashMap;
+
+use http::{HeaderMap, Method};
+
+use crate::ai_providers::{AIPlatform, AIProvider};
+
+/// Resolved provider credentials and proxy-specific context.
+///
+/// This is intentionally separate from the worker's `ProviderWithResource`: API
+/// proxy credentials are already resolved from workspace or instance resources.
+#[derive(Clone, Debug)]
+pub struct ProviderCredentials {
+    pub provider: AIProvider,
+    pub base_url: String,
+    pub api_key: Option<String>,
+    pub access_token: Option<String>,
+    pub organization_id: Option<String>,
+    pub user: Option<String>,
+    pub region: Option<String>,
+    pub aws_access_key_id: Option<String>,
+    pub aws_secret_access_key: Option<String>,
+    pub aws_session_token: Option<String>,
+    pub platform: AIPlatform,
+    pub enable_1m_context: bool,
+    pub custom_headers: HashMap<String, String>,
+}
+
+/// Inputs needed to transform an OpenAI-compatible proxy request for a provider.
+pub struct ProxyBuildArgs<'a> {
+    pub method: &'a Method,
+    pub path: &'a str,
+    pub headers: &'a HeaderMap,
+    pub body: &'a [u8],
+    pub credentials: &'a ProviderCredentials,
+}
+
+/// Provider-specific request produced by proxy request builders.
+#[derive(Clone, Debug)]
+pub struct ProxyRequest {
+    pub method: Method,
+    pub url: String,
+    pub headers: HeaderMap,
+    pub body: Vec<u8>,
+}

--- a/backend/windmill-ai/src/proxy.rs
+++ b/backend/windmill-ai/src/proxy.rs
@@ -1,8 +1,11 @@
 use std::collections::HashMap;
 
 use http::{HeaderMap, Method};
+use serde_json::value::RawValue;
+use windmill_common::error::{Error, Result};
 
 use crate::ai_providers::{AIPlatform, AIProvider};
+use crate::utils::AI_HTTP_HEADERS;
 
 /// Resolved provider credentials and proxy-specific context.
 ///
@@ -39,6 +42,183 @@ pub struct ProxyBuildArgs<'a> {
 pub struct ProxyRequest {
     pub method: Method,
     pub url: String,
-    pub headers: HeaderMap,
+    pub headers: Vec<(String, String)>,
     pub body: Vec<u8>,
+}
+
+pub fn supports_openai_compatible_proxy(provider: &AIProvider) -> bool {
+    matches!(
+        provider,
+        AIProvider::OpenAI
+            | AIProvider::AzureOpenAI
+            | AIProvider::Mistral
+            | AIProvider::DeepSeek
+            | AIProvider::Groq
+            | AIProvider::OpenRouter
+            | AIProvider::TogetherAI
+            | AIProvider::CustomAI
+    )
+}
+
+pub fn build_openai_compatible_proxy_request(args: &ProxyBuildArgs<'_>) -> Result<ProxyRequest> {
+    let credentials = args.credentials;
+    let body = if let Some(user) = credentials.user.as_ref() {
+        add_user_to_body(args.body, user)?
+    } else {
+        args.body.to_vec()
+    };
+
+    let base_url = credentials.base_url.trim_end_matches('/');
+    let is_azure = credentials.provider.is_azure_openai(base_url);
+    let url = if is_azure {
+        AIProvider::build_azure_openai_url(base_url, args.path)
+    } else {
+        format!("{}/{}", base_url, args.path)
+    };
+
+    let mut headers = vec![("content-type".to_string(), "application/json".to_string())];
+
+    if let Some(api_key) = credentials.api_key.as_ref() {
+        if is_azure {
+            headers.push(("api-key".to_string(), api_key.clone()));
+        } else {
+            headers.push(("authorization".to_string(), format!("Bearer {}", api_key)));
+        }
+    }
+
+    if let Some(access_token) = credentials.access_token.as_ref() {
+        headers.push((
+            "authorization".to_string(),
+            format!("Bearer {}", access_token),
+        ));
+    }
+
+    if let Some(org_id) = credentials.organization_id.as_ref() {
+        headers.push(("OpenAI-Organization".to_string(), org_id.clone()));
+    }
+
+    for (header_name, header_value) in AI_HTTP_HEADERS.iter() {
+        headers.push((header_name.clone(), header_value.clone()));
+    }
+
+    for (header_name, header_value) in &credentials.custom_headers {
+        headers.push((header_name.clone(), header_value.clone()));
+    }
+
+    Ok(ProxyRequest { method: args.method.clone(), url, headers, body })
+}
+
+fn add_user_to_body(body: &[u8], user: &str) -> Result<Vec<u8>> {
+    tracing::debug!("Adding user to request body");
+    let mut json_body: HashMap<String, Box<RawValue>> = serde_json::from_slice(body)
+        .map_err(|e| Error::internal_err(format!("Failed to parse request body: {}", e)))?;
+
+    let user_json_string = serde_json::Value::String(user.to_string()).to_string();
+
+    json_body.insert(
+        "user".to_string(),
+        RawValue::from_string(user_json_string)
+            .map_err(|e| Error::internal_err(format!("Failed to parse user: {}", e)))?,
+    );
+
+    serde_json::to_vec(&json_body)
+        .map_err(|e| Error::internal_err(format!("Failed to reserialize request body: {}", e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn credentials(provider: AIProvider, base_url: &str) -> ProviderCredentials {
+        ProviderCredentials {
+            provider,
+            base_url: base_url.to_string(),
+            api_key: Some("api-key".to_string()),
+            access_token: None,
+            organization_id: Some("org-id".to_string()),
+            user: None,
+            region: None,
+            aws_access_key_id: None,
+            aws_secret_access_key: None,
+            aws_session_token: None,
+            platform: AIPlatform::Standard,
+            enable_1m_context: false,
+            custom_headers: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn builds_openai_compatible_proxy_request() {
+        let credentials = credentials(AIProvider::OpenRouter, "https://openrouter.ai/api/v1/");
+        let method = Method::POST;
+        let headers = HeaderMap::new();
+        let body = br#"{"model":"openrouter/model","messages":[]}"#;
+
+        let request = build_openai_compatible_proxy_request(&ProxyBuildArgs {
+            method: &method,
+            path: "chat/completions",
+            headers: &headers,
+            body,
+            credentials: &credentials,
+        })
+        .unwrap();
+
+        assert_eq!(request.method, Method::POST);
+        assert_eq!(request.url, "https://openrouter.ai/api/v1/chat/completions");
+        assert_eq!(request.body, body.to_vec());
+        assert!(request
+            .headers
+            .contains(&("authorization".to_string(), "Bearer api-key".to_string())));
+        assert!(request
+            .headers
+            .contains(&("OpenAI-Organization".to_string(), "org-id".to_string())));
+    }
+
+    #[test]
+    fn builds_azure_openai_proxy_request() {
+        let credentials = credentials(
+            AIProvider::AzureOpenAI,
+            "https://example.openai.azure.com/openai",
+        );
+        let method = Method::POST;
+        let headers = HeaderMap::new();
+
+        let request = build_openai_compatible_proxy_request(&ProxyBuildArgs {
+            method: &method,
+            path: "chat/completions",
+            headers: &headers,
+            body: br#"{"model":"deployment","messages":[]}"#,
+            credentials: &credentials,
+        })
+        .unwrap();
+
+        assert_eq!(
+            request.url,
+            "https://example.openai.azure.com/openai/v1/chat/completions"
+        );
+        assert!(request
+            .headers
+            .contains(&("api-key".to_string(), "api-key".to_string())));
+    }
+
+    #[test]
+    fn injects_user_into_proxy_body() {
+        let mut credentials = credentials(AIProvider::OpenAI, "https://api.openai.com/v1");
+        credentials.user = Some("user-1".to_string());
+        let method = Method::POST;
+        let headers = HeaderMap::new();
+
+        let request = build_openai_compatible_proxy_request(&ProxyBuildArgs {
+            method: &method,
+            path: "chat/completions",
+            headers: &headers,
+            body: br#"{"model":"gpt-4o","messages":[]}"#,
+            credentials: &credentials,
+        })
+        .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+
+        assert_eq!(body["user"], "user-1");
+        assert_eq!(body["model"], "gpt-4o");
+    }
 }

--- a/backend/windmill-ai/src/query_builder.rs
+++ b/backend/windmill-ai/src/query_builder.rs
@@ -3,6 +3,7 @@ use windmill_common::{client::AuthedClient, error::Error};
 use windmill_types::s3::S3Object;
 
 use crate::ai_types::OpenAIToolCall;
+use crate::proxy::{ProxyBuildArgs, ProxyRequest};
 use crate::types::*;
 
 /// Arguments for building an AI request
@@ -71,6 +72,14 @@ pub trait QueryBuilder: Send + Sync {
     /// Only OtherQueryBuilder (OpenAI-compatible providers) needs this
     fn supports_retry_without_usage(&self) -> bool {
         false
+    }
+
+    /// Build a provider-specific request from an OpenAI-compatible proxy request.
+    fn build_proxy_request(&self, args: &ProxyBuildArgs<'_>) -> Result<ProxyRequest, Error> {
+        Err(Error::BadRequest(format!(
+            "Proxy request building is not supported for provider {:?}",
+            args.credentials.provider
+        )))
     }
 
     /// Parse the image response from the provider

--- a/backend/windmill-api/src/ai.rs
+++ b/backend/windmill-api/src/ai.rs
@@ -19,6 +19,7 @@ use windmill_ai::ai_cache::current_instance_ai_config_revision;
 use windmill_ai::ai_providers::{
     empty_string_as_none, AIPlatform, AIProvider, ProviderConfig, ProviderModel,
 };
+use windmill_ai::proxy::ProviderCredentials;
 use windmill_ai::utils::AI_HTTP_HEADERS;
 use windmill_audit::{audit_oss::audit_log, ActionKind};
 use windmill_common::db::UserDB;
@@ -372,19 +373,22 @@ impl AIRequestConfig {
         headers: HeaderMap,
         body: Bytes,
     ) -> Result<RequestBuilder> {
-        let body = if let Some(user) = self.user {
-            Self::add_user_to_body(body, user)?
+        let credentials = self.into_provider_credentials(provider.clone());
+
+        let body = if let Some(user) = credentials.user.as_ref() {
+            Self::add_user_to_body(body, user.clone())?
         } else {
             body
         };
 
-        let base_url = self.base_url.trim_end_matches('/');
+        let base_url = credentials.base_url.trim_end_matches('/');
 
-        let is_azure = provider.is_azure_openai(base_url);
-        let is_anthropic = matches!(provider, AIProvider::Anthropic);
-        let is_anthropic_vertex = is_anthropic && self.platform == AIPlatform::GoogleVertexAi;
+        let is_azure = credentials.provider.is_azure_openai(base_url);
+        let is_anthropic = credentials.provider == AIProvider::Anthropic;
+        let is_anthropic_vertex =
+            is_anthropic && credentials.platform == AIPlatform::GoogleVertexAi;
         let is_anthropic_sdk = headers.get("X-Anthropic-SDK").is_some();
-        let is_google_ai = matches!(provider, AIProvider::GoogleAI);
+        let is_google_ai = credentials.provider == AIProvider::GoogleAI;
 
         let base_url = base_url.to_string();
         let base_url = base_url.as_str();
@@ -423,12 +427,12 @@ impl AIRequestConfig {
             }
         }
 
-        if is_anthropic_sdk && self.enable_1m_context {
+        if is_anthropic_sdk && credentials.enable_1m_context {
             request = request.header("anthropic-beta", "context-1m-2025-08-07");
         }
 
         // Add authentication headers
-        if let Some(api_key) = self.api_key {
+        if let Some(api_key) = credentials.api_key {
             if is_azure {
                 request = request.header("api-key", api_key.clone())
             } else if is_google_ai {
@@ -445,13 +449,13 @@ impl AIRequestConfig {
             }
         }
 
-        if let Some(access_token) = self.access_token {
+        if let Some(access_token) = credentials.access_token {
             request = request.header("authorization", format!("Bearer {}", access_token))
         }
 
         request = request.body(body);
 
-        if let Some(org_id) = self.organization_id {
+        if let Some(org_id) = credentials.organization_id {
             request = request.header("OpenAI-Organization", org_id);
         }
 
@@ -461,11 +465,29 @@ impl AIRequestConfig {
         }
 
         // Apply custom headers from the resource
-        for (header_name, header_value) in &self.custom_headers {
+        for (header_name, header_value) in &credentials.custom_headers {
             request = request.header(header_name.as_str(), header_value.as_str());
         }
 
         Ok(request)
+    }
+
+    fn into_provider_credentials(self, provider: AIProvider) -> ProviderCredentials {
+        ProviderCredentials {
+            provider,
+            base_url: self.base_url,
+            api_key: self.api_key,
+            access_token: self.access_token,
+            organization_id: self.organization_id,
+            user: self.user,
+            region: self.region,
+            aws_access_key_id: self.aws_access_key_id,
+            aws_secret_access_key: self.aws_secret_access_key,
+            aws_session_token: self.aws_session_token,
+            platform: self.platform,
+            enable_1m_context: self.enable_1m_context,
+            custom_headers: self.custom_headers,
+        }
     }
 
     fn add_user_to_body(body: Bytes, user: String) -> Result<Bytes> {
@@ -1101,6 +1123,55 @@ mod tests {
             enable_1m_context: false,
             custom_headers: HashMap::new(),
         }
+    }
+
+    #[test]
+    fn maps_request_config_to_provider_credentials() {
+        let mut custom_headers = HashMap::new();
+        custom_headers.insert("X-Test".to_string(), "yes".to_string());
+
+        let config = AIRequestConfig {
+            base_url: "https://example.com".to_string(),
+            api_key: Some("api-key".to_string()),
+            access_token: Some("access-token".to_string()),
+            organization_id: Some("org-id".to_string()),
+            user: Some("user-id".to_string()),
+            region: Some("us-east-1".to_string()),
+            aws_access_key_id: Some("aws-access-key".to_string()),
+            aws_secret_access_key: Some("aws-secret-key".to_string()),
+            aws_session_token: Some("aws-session-token".to_string()),
+            platform: AIPlatform::GoogleVertexAi,
+            enable_1m_context: true,
+            custom_headers,
+        };
+
+        let credentials = config.into_provider_credentials(AIProvider::Anthropic);
+
+        assert_eq!(credentials.provider, AIProvider::Anthropic);
+        assert_eq!(credentials.base_url, "https://example.com");
+        assert_eq!(credentials.api_key.as_deref(), Some("api-key"));
+        assert_eq!(credentials.access_token.as_deref(), Some("access-token"));
+        assert_eq!(credentials.organization_id.as_deref(), Some("org-id"));
+        assert_eq!(credentials.user.as_deref(), Some("user-id"));
+        assert_eq!(credentials.region.as_deref(), Some("us-east-1"));
+        assert_eq!(
+            credentials.aws_access_key_id.as_deref(),
+            Some("aws-access-key")
+        );
+        assert_eq!(
+            credentials.aws_secret_access_key.as_deref(),
+            Some("aws-secret-key")
+        );
+        assert_eq!(
+            credentials.aws_session_token.as_deref(),
+            Some("aws-session-token")
+        );
+        assert_eq!(credentials.platform, AIPlatform::GoogleVertexAi);
+        assert!(credentials.enable_1m_context);
+        assert_eq!(
+            credentials.custom_headers.get("X-Test").map(String::as_str),
+            Some("yes")
+        );
     }
 
     #[test]

--- a/backend/windmill-api/src/ai.rs
+++ b/backend/windmill-api/src/ai.rs
@@ -19,7 +19,10 @@ use windmill_ai::ai_cache::current_instance_ai_config_revision;
 use windmill_ai::ai_providers::{
     empty_string_as_none, AIPlatform, AIProvider, ProviderConfig, ProviderModel,
 };
-use windmill_ai::proxy::ProviderCredentials;
+use windmill_ai::providers::create_proxy_query_builder;
+use windmill_ai::proxy::{
+    supports_openai_compatible_proxy, ProviderCredentials, ProxyBuildArgs, ProxyRequest,
+};
 use windmill_ai::utils::AI_HTTP_HEADERS;
 use windmill_audit::{audit_oss::audit_log, ActionKind};
 use windmill_common::db::UserDB;
@@ -663,6 +666,14 @@ fn is_sse_response(headers: &HeaderMap) -> bool {
         .unwrap_or(false)
 }
 
+fn proxy_request_to_request_builder(proxy_request: ProxyRequest) -> RequestBuilder {
+    let mut request = HTTP_CLIENT.request(proxy_request.method.clone(), &proxy_request.url);
+    for (header_name, header_value) in &proxy_request.headers {
+        request = request.header(header_name.as_str(), header_value.as_str());
+    }
+    request.body(proxy_request.body)
+}
+
 pub(crate) fn inject_keepalives<S>(
     upstream: S,
     interval: Duration,
@@ -715,37 +726,64 @@ async fn global_proxy(
 
     let base_url = provider.get_base_url(None, &db).await?;
 
-    let is_anthropic = provider.is_anthropic();
-    let is_anthropic_sdk = headers.get("X-Anthropic-SDK").is_some();
-
-    let url = if is_anthropic_sdk {
-        let truncated_base_url = base_url.trim_end_matches("/v1");
-        format!("{}/{}", truncated_base_url, ai_path)
+    let request = if supports_openai_compatible_proxy(&provider) {
+        let credentials = ProviderCredentials {
+            provider: provider.clone(),
+            base_url,
+            api_key: Some(api_key.clone()),
+            access_token: None,
+            organization_id: None,
+            user: None,
+            region: None,
+            aws_access_key_id: None,
+            aws_secret_access_key: None,
+            aws_session_token: None,
+            platform: AIPlatform::Standard,
+            enable_1m_context: false,
+            custom_headers: HashMap::new(),
+        };
+        let query_builder = create_proxy_query_builder(&credentials);
+        let proxy_request = query_builder.build_proxy_request(&ProxyBuildArgs {
+            method: &method,
+            path: &ai_path,
+            headers: &headers,
+            body: &body,
+            credentials: &credentials,
+        })?;
+        proxy_request_to_request_builder(proxy_request)
     } else {
-        format!("{}/{}", base_url, ai_path)
-    };
+        let is_anthropic = provider.is_anthropic();
+        let is_anthropic_sdk = headers.get("X-Anthropic-SDK").is_some();
 
-    let mut request = HTTP_CLIENT
-        .request(method, url)
-        .header("content-type", "application/json")
-        .header("Authorization", format!("Bearer {}", &api_key));
+        let url = if is_anthropic_sdk {
+            let truncated_base_url = base_url.trim_end_matches("/v1");
+            format!("{}/{}", truncated_base_url, ai_path)
+        } else {
+            format!("{}/{}", base_url, ai_path)
+        };
 
-    if is_anthropic {
-        request = request.header("X-API-Key", &api_key);
-    }
+        let mut request = HTTP_CLIENT
+            .request(method, url)
+            .header("content-type", "application/json")
+            .header("Authorization", format!("Bearer {}", &api_key));
 
-    for (header_name, header_value) in headers.iter() {
-        if header_name.to_string().starts_with("anthropic-") {
-            request = request.header(header_name, header_value);
+        if is_anthropic {
+            request = request.header("X-API-Key", &api_key);
         }
-    }
 
-    // Apply custom headers from AI_HTTP_HEADERS environment variable
-    for (header_name, header_value) in AI_HTTP_HEADERS.iter() {
-        request = request.header(header_name.as_str(), header_value.as_str());
-    }
+        for (header_name, header_value) in headers.iter() {
+            if header_name.to_string().starts_with("anthropic-") {
+                request = request.header(header_name, header_value);
+            }
+        }
 
-    let request = request.body(body);
+        // Apply custom headers from AI_HTTP_HEADERS environment variable
+        for (header_name, header_value) in AI_HTTP_HEADERS.iter() {
+            request = request.header(header_name.as_str(), header_value.as_str());
+        }
+
+        request.body(body)
+    };
 
     let response = request.send().await.map_err(to_anyhow)?;
 
@@ -1062,7 +1100,20 @@ async fn proxy(
         ));
     }
 
-    let request = request_config.prepare_request(&provider, &ai_path, method, headers, body)?;
+    let request = if supports_openai_compatible_proxy(&provider) {
+        let credentials = request_config.into_provider_credentials(provider.clone());
+        let query_builder = create_proxy_query_builder(&credentials);
+        let proxy_request = query_builder.build_proxy_request(&ProxyBuildArgs {
+            method: &method,
+            path: &ai_path,
+            headers: &headers,
+            body: &body,
+            credentials: &credentials,
+        })?;
+        proxy_request_to_request_builder(proxy_request)
+    } else {
+        request_config.prepare_request(&provider, &ai_path, method, headers, body)?
+    };
 
     let response = request.send().await.map_err(to_anyhow)?;
 

--- a/docs/windmill-ai-refactor-plan.md
+++ b/docs/windmill-ai-refactor-plan.md
@@ -23,57 +23,42 @@ windmill-worker →  windmill-ai
 
 windmill-common does **NOT** re-export from windmill-ai (would be circular). All consumers update imports.
 
-## Reviewer Note: Keep the Next PR Small
+## Reviewer Note: Keep API Proxy Unification Split
 
-The first merged PR established the crate boundary; it did not yet remove the duplicated API-vs-worker provider paths. The remaining work should stay split by dependency risk, not by the final desired module layout.
+The crate boundary, shared utilities, SSE parsers, image handling, and worker provider implementations are now in `windmill-ai`. The remaining duplication is the API proxy path: `AIRequestConfig::prepare_request`, `windmill-api/src/google.rs`, and `windmill-api/src/bedrock.rs` still own API-specific request transformation.
 
-Do not jump directly from the current state to provider moves, proxy unification, and credential unification in one PR. The riskiest part is the API proxy because it combines request transformation, endpoint selection, auth headers, custom headers, OAuth user injection, Azure URL handling, Anthropic Vertex handling, Bedrock SDK calls, and SSE keepalive behavior.
-
-Pull the shared plumbing forward before moving provider implementations:
-- Move tiny shared utilities first, including `AI_HTTP_HEADERS`, `extract_text_content`, and `should_use_structured_output_tool`.
-- Move SSE parsers next, using the existing `StreamEventSink` abstraction, and update callers to import from `windmill_ai` directly.
-- Leave provider implementations, image upload/download handling, API proxy changes, and credential unification out of that PR.
+Do not jump directly from the current state to full proxy and credential unification in one PR. The API proxy combines request transformation, endpoint selection, auth headers, custom headers, OAuth user injection, Azure URL handling, Anthropic Vertex handling, Bedrock SDK calls, and SSE keepalive behavior. Split the work by risk:
+- Introduce shared proxy request and credential types first, without changing proxy behavior.
+- Move the OpenAI-compatible proxy path into `windmill-ai` next.
+- Move Anthropic/Vertex, Google AI, and Bedrock in separate follow-up PRs.
+- Unify credential resolution only after all proxy request builders use the shared shape.
 
 Avoid adding modules whose only purpose is to re-export moved code. Direct imports from `windmill_ai` make ownership and dependency direction clearer at each call site.
 
 Also do not make `build_proxy_request(raw_body, path)` too narrow. The proxy path needs method, incoming headers, resolved credentials, base URL/platform, organization/user fields, custom headers, and Bedrock/Azure/Vertex-specific context. Introduce a structured `ProxyBuildArgs`/`ProviderCredentials` shape before deleting `AIRequestConfig::prepare_request`, `google.rs`, or `bedrock.rs`.
 
-## Next Phase PR: Shared Plumbing Only
+## Next Phase PR: Proxy Contract Only
 
-Goal: make `windmill-ai` own the provider-independent helper code that later provider moves will need, without changing API proxy behavior or agent request behavior.
+Goal: introduce the shared API proxy contract in `windmill-ai` without changing any API proxy behavior.
 
-Suggested PR title: `refactor(ai): move shared SSE plumbing into windmill-ai`.
+Suggested PR title: `refactor(ai): introduce shared AI proxy request types`.
 
 Scope:
-- Add `windmill-ai/src/utils.rs`.
-- Move the duplicated `AI_HTTP_HEADERS` parsing into `windmill_ai::utils` with identical parsing behavior.
-- Move `extract_text_content` and `should_use_structured_output_tool` from `windmill-worker/src/ai/utils.rs` to `windmill_ai::utils`.
-- Move `windmill-worker/src/ai/sse.rs` to `windmill-ai/src/sse.rs`.
-- Delete `windmill-worker/src/ai/sse.rs` and update callers to import parser types from `windmill_ai::sse`.
-- Update callers of moved utility functions to import from `windmill_ai::utils` directly.
-- Add the minimal new `windmill-ai` dependencies required by `sse.rs` (`eventsource-stream`, `tokio-stream`) and avoid adding worker/queue dependencies.
+- Add `windmill-ai/src/proxy.rs` and export it from `lib.rs`.
+- Define `ProviderCredentials`, `ProxyBuildArgs`, and `ProxyRequest`.
+- Include all context known to be needed by the current API proxy path: method, path, incoming headers, body, provider, base URL, API key, OAuth access token, organization/user fields, platform, 1M context flag, custom headers, region, and AWS credentials.
+- Add a conversion from API-side `AIRequestConfig` to `ProviderCredentials`.
+- Keep `AIRequestConfig::prepare_request` as the behavior owner for now, but have it operate through the shared credential shape.
 
 Out of scope:
-- Do not move provider implementations.
-- Do not move `image_handler`.
-- Do not change `QueryBuilder` method signatures.
-- Do not add `build_proxy_request`.
-- Do not change API proxy routing, request preparation, credential resolution, audit logging, cache behavior, or Bedrock/Google special cases.
+- Do not add `QueryBuilder::build_proxy_request` yet.
+- Do not change API proxy routing, request preparation behavior, credential resolution, audit logging, cache behavior, SSE keepalive behavior, or Bedrock/Google special cases.
 - Do not remove `windmill-api/src/google.rs`, `windmill-api/src/bedrock.rs`, or `AIRequestConfig::prepare_request`.
 
-Implementation checklist:
-1. Add `utils.rs` to `windmill-ai` and export it from `lib.rs`.
-2. Move `AI_HTTP_HEADERS` exactly once, then update `windmill-api/src/ai.rs` and `windmill-worker/src/ai_executor.rs` to import it.
-3. Move the two provider-independent helper functions into `windmill_ai::utils`; leave worker-specific flow/MCP/conversation utilities in `windmill-worker/src/ai/utils.rs`.
-4. Move `sse.rs` into `windmill-ai`, change imports from `crate::ai::{query_builder, types}` to `crate::{query_builder, types}`, and keep behavior unchanged.
-5. Remove worker `ai/sse.rs` and update provider imports to use `windmill_ai::sse` directly.
-6. Run focused grep checks for duplicate `AI_HTTP_HEADERS`, old local helper definitions, and accidental `windmill_queue`/worker dependencies from `windmill-ai`.
-7. Validate with `cargo check -p windmill-ai`, `cargo check -p windmill-worker`, and `cargo check -p windmill-api`. For `bedrock` builds, also check the existing bedrock feature path.
-
-Review expectations:
-- The diff should be mostly moved code and import updates.
-- The behavior should be byte-for-byte equivalent where practical.
-- Tests are only needed if helper behavior changes. For a pure move, existing backend checks plus manual AI streaming verification are enough.
+Validation:
+- `cargo check -p windmill-ai -p windmill-api`
+- `cargo check -p windmill-ai -p windmill-api --features bedrock`
+- Focused grep for stale duplicate proxy contract types once follow-up PRs begin moving behavior.
 
 ## Step-by-Step Plan
 
@@ -133,7 +118,7 @@ pub trait StreamEventSink: Send + Sync {
 
 ---
 
-### Step 4: Move SSE parsers to windmill-ai
+### Step 4: Move SSE parsers to windmill-ai ✅
 
 Move from `windmill-worker/src/ai/sse.rs` to `windmill-ai/src/sse.rs`:
 - `SSEParser` trait
@@ -168,7 +153,7 @@ Move from `windmill-worker/src/ai/image_handler.rs` to `windmill-ai/src/image_ha
 
 ---
 
-### Step 7: Move shared utilities to windmill-ai
+### Step 7: Move shared utilities to windmill-ai ✅
 
 Move `AI_HTTP_HEADERS` lazy_static (currently duplicated in `windmill-api/src/ai.rs` and `windmill-worker/src/ai_executor.rs`) to `windmill_ai::utils`. Both consumers import from windmill-ai.
 
@@ -190,7 +175,7 @@ fn build_proxy_request(
 Where `ProxyBuildArgs` carries the API proxy context that provider implementations need:
 ```rust
 pub struct ProxyBuildArgs<'a> {
-    pub method: http::Method,
+    pub method: &'a http::Method,
     pub path: &'a str,
     pub headers: &'a http::HeaderMap,
     pub body: &'a [u8],
@@ -201,9 +186,10 @@ pub struct ProxyBuildArgs<'a> {
 And `ProxyRequest` contains the transformed request:
 ```rust
 pub struct ProxyRequest {
+    pub method: http::Method,
     pub url: String,
+    pub headers: http::HeaderMap,
     pub body: Vec<u8>,
-    pub headers: Vec<(String, String)>,
 }
 ```
 
@@ -236,24 +222,26 @@ pub struct ProxyRequest {
 
 ### Step 9: Unify credential resolution
 
-Merge `AIRequestConfig` (API-side) and `ProviderWithResource` (worker-side) into a single type in windmill-ai.
+Merge `AIRequestConfig` (API-side) and `ProviderWithResource` (worker-side) into a single credential shape in windmill-ai.
 
 Both currently carry: api_key, base_url, region, platform, custom_headers, AWS credentials. The API's `AIRequestConfig::new` resolves credentials from DB (workspace/instance settings). The worker's `ProviderWithResource` gets credentials from the flow module definition.
 
-Create `windmill_ai::ProviderCredentials` that both can produce:
+Extend `windmill_ai::proxy::ProviderCredentials` as needed so both can produce it:
 ```rust
 pub struct ProviderCredentials {
     pub provider: AIProvider,
-    pub api_key: Option<String>,
     pub base_url: String,
+    pub api_key: Option<String>,
+    pub access_token: Option<String>,
+    pub organization_id: Option<String>,
+    pub user: Option<String>,
     pub platform: AIPlatform,
     pub region: Option<String>,
     pub aws_access_key_id: Option<String>,
     pub aws_secret_access_key: Option<String>,
     pub aws_session_token: Option<String>,
-    pub custom_headers: HashMap<String, String>,
-    pub organization_id: Option<String>,
     pub enable_1m_context: bool,
+    pub custom_headers: HashMap<String, String>,
 }
 ```
 
@@ -265,14 +253,15 @@ The `create_query_builder` factory takes `&ProviderCredentials` instead of `&Pro
 
 ```
 windmill-ai/src/
-├── lib.rs              # re-exports, AI_HTTP_HEADERS
+├── lib.rs              # module exports
 ├── ai_types.rs         # OpenAI-compatible message types
 ├── ai_providers.rs     # AIProvider enum, base URLs, config
 ├── ai_google.rs        # Gemini types and conversions
 ├── ai_bedrock.rs       # Bedrock SDK wrapper (feature: bedrock)
 ├── ai_cache.rs         # Instance AI config revision
-├── types.rs            # ProviderCredentials, TokenUsage, Tool, OpenAPISchema, etc.
-├── query_builder.rs    # QueryBuilder trait, BuildRequestArgs, ParsedResponse, ProxyRequest, StreamEventSink
+├── types.rs            # TokenUsage, Tool, OpenAPISchema, etc.
+├── proxy.rs            # ProviderCredentials, ProxyBuildArgs, ProxyRequest
+├── query_builder.rs    # QueryBuilder trait, BuildRequestArgs, ParsedResponse, StreamEventSink
 ├── sse.rs              # SSE parsers (OpenAI, Anthropic, Gemini, Responses)
 ├── image_handler.rs    # S3 image upload/download
 ├── utils.rs            # extract_text_content, should_use_structured_output_tool

--- a/docs/windmill-ai-refactor-plan.md
+++ b/docs/windmill-ai-refactor-plan.md
@@ -28,8 +28,8 @@ windmill-common does **NOT** re-export from windmill-ai (would be circular). All
 The crate boundary, shared utilities, SSE parsers, image handling, and worker provider implementations are now in `windmill-ai`. The remaining duplication is the API proxy path: `AIRequestConfig::prepare_request`, `windmill-api/src/google.rs`, and `windmill-api/src/bedrock.rs` still own API-specific request transformation.
 
 Do not jump directly from the current state to full proxy and credential unification in one PR. The API proxy combines request transformation, endpoint selection, auth headers, custom headers, OAuth user injection, Azure URL handling, Anthropic Vertex handling, Bedrock SDK calls, and SSE keepalive behavior. Split the work by risk:
-- Introduce shared proxy request and credential types first, without changing proxy behavior.
-- Move the OpenAI-compatible proxy path into `windmill-ai` next.
+- Introduce shared proxy request and credential types first.
+- Move the OpenAI-compatible proxy path into `windmill-ai` next, while keeping provider-native behavior unchanged.
 - Move Anthropic/Vertex, Google AI, and Bedrock in separate follow-up PRs.
 - Unify credential resolution only after all proxy request builders use the shared shape.
 
@@ -37,28 +37,34 @@ Avoid adding modules whose only purpose is to re-export moved code. Direct impor
 
 Also do not make `build_proxy_request(raw_body, path)` too narrow. The proxy path needs method, incoming headers, resolved credentials, base URL/platform, organization/user fields, custom headers, and Bedrock/Azure/Vertex-specific context. Introduce a structured `ProxyBuildArgs`/`ProviderCredentials` shape before deleting `AIRequestConfig::prepare_request`, `google.rs`, or `bedrock.rs`.
 
-## Next Phase PR: Proxy Contract Only
+## Current Phase PR: Proxy Contract + OpenAI-Compatible Proxy
 
-Goal: introduce the shared API proxy contract in `windmill-ai` without changing any API proxy behavior.
+Goal: introduce the shared API proxy contract in `windmill-ai` and move the OpenAI-compatible proxy request builder there without changing provider behavior.
 
-Suggested PR title: `refactor(ai): introduce shared AI proxy request types`.
+Suggested PR title: `refactor(ai): move openai-compatible proxy building to windmill-ai`.
 
 Scope:
 - Add `windmill-ai/src/proxy.rs` and export it from `lib.rs`.
 - Define `ProviderCredentials`, `ProxyBuildArgs`, and `ProxyRequest`.
 - Include all context known to be needed by the current API proxy path: method, path, incoming headers, body, provider, base URL, API key, OAuth access token, organization/user fields, platform, 1M context flag, custom headers, region, and AWS credentials.
 - Add a conversion from API-side `AIRequestConfig` to `ProviderCredentials`.
-- Keep `AIRequestConfig::prepare_request` as the behavior owner for now, but have it operate through the shared credential shape.
+- Add `QueryBuilder::build_proxy_request` with a default unsupported-provider implementation.
+- Implement `build_proxy_request` for OpenAI-compatible providers (`OpenAI`, `AzureOpenAI`, `Mistral`, `DeepSeek`, `Groq`, `OpenRouter`, `TogetherAI`, `CustomAI`).
+- Route workspace and global API proxy requests for OpenAI-compatible providers through `windmill-ai`.
+- Keep FIM transformation in `windmill-api` before calling the proxy builder.
+- Keep `AIRequestConfig::prepare_request` for Anthropic/Vertex and remaining fallback paths.
 
 Out of scope:
-- Do not add `QueryBuilder::build_proxy_request` yet.
-- Do not change API proxy routing, request preparation behavior, credential resolution, audit logging, cache behavior, SSE keepalive behavior, or Bedrock/Google special cases.
+- Do not move Anthropic/Vertex proxy behavior yet.
+- Do not move Google AI or Bedrock proxy behavior yet.
+- Do not change credential resolution, audit logging, cache behavior, SSE keepalive behavior, or Bedrock/Google special cases.
 - Do not remove `windmill-api/src/google.rs`, `windmill-api/src/bedrock.rs`, or `AIRequestConfig::prepare_request`.
 
 Validation:
+- `cargo test -p windmill-ai proxy`
+- `cargo test -p windmill-api maps_request_config_to_provider_credentials`
 - `cargo check -p windmill-ai -p windmill-api`
 - `cargo check -p windmill-ai -p windmill-api --features bedrock`
-- Focused grep for stale duplicate proxy contract types once follow-up PRs begin moving behavior.
 
 ## Step-by-Step Plan
 
@@ -188,7 +194,7 @@ And `ProxyRequest` contains the transformed request:
 pub struct ProxyRequest {
     pub method: http::Method,
     pub url: String,
-    pub headers: http::HeaderMap,
+    pub headers: Vec<(String, String)>,
     pub body: Vec<u8>,
 }
 ```


### PR DESCRIPTION
## Summary

Move the OpenAI-compatible API proxy request-building path into `windmill-ai` as the next slice after #9120. The PR introduces the shared proxy contract, adds a `QueryBuilder::build_proxy_request` hook, and routes OpenAI-compatible workspace/global proxy requests through `windmill-ai` while leaving Anthropic, Google AI, and Bedrock behavior on the existing API paths.

## Changes

- Add `windmill_ai::proxy::{ProviderCredentials, ProxyBuildArgs, ProxyRequest}`.
- Add shared OpenAI-compatible proxy request construction in `windmill-ai`, including URL construction, Azure OpenAI URL handling, auth headers, org/user fields, `AI_HTTP_HEADERS`, and resource custom headers.
- Add `QueryBuilder::build_proxy_request` with implementations for `OpenAI`, `AzureOpenAI`, `Mistral`, `DeepSeek`, `Groq`, `OpenRouter`, `TogetherAI`, and `CustomAI` via the shared helper.
- Add `create_proxy_query_builder` for resolved API proxy credentials.
- Route workspace and global API proxy requests for OpenAI-compatible providers through `windmill-ai`.
- Keep FIM transformation in `windmill-api` before calling the proxy builder.
- Refresh `docs/windmill-ai-refactor-plan.md` to reflect the expanded PR scope and remaining provider-specific follow-ups.

## Out of scope

- Anthropic/Vertex proxy behavior stays in `AIRequestConfig::prepare_request`.
- Google AI stays in `windmill-api/src/google.rs`.
- Bedrock stays in `windmill-api/src/bedrock.rs` and the existing feature-gated API block.
- Credential resolution, audit logging, caching, and SSE keepalive behavior are unchanged.

## Next refactor steps

This PR intentionally stops after moving the lowest-risk OpenAI-compatible proxy path. The remaining proxy work should land in separate reviewable PRs:

1. Move Anthropic proxy request building into `AnthropicQueryBuilder::build_proxy_request`, including standard Anthropic headers and Google Vertex request transformation. After that, delete the Anthropic-specific branch from `AIRequestConfig::prepare_request`.
2. Move Google AI proxy request building into `GoogleAIQueryBuilder::build_proxy_request`, reusing the existing `windmill_ai::ai_google` OpenAI-to-Gemini conversion helpers. After parity, remove `windmill-api/src/google.rs`.
3. Move Bedrock proxy request building into `BedrockQueryBuilder::build_proxy_request` behind the existing `bedrock` feature, preserving bearer-token, IAM, environment-credential, streaming, and non-streaming behavior. After parity, remove `windmill-api/src/bedrock.rs`.
4. Move FIM-to-chat-completions transformation out of `windmill-api/src/ai.rs` once all OpenAI-compatible proxy handling is owned by `windmill-ai`.
5. Once every provider proxy path is routed through `QueryBuilder::build_proxy_request`, remove the remaining `AIRequestConfig::prepare_request` fallback and keep `windmill-api` responsible only for routes, auth, audit logging, cache lookup, response forwarding, and SSE keepalive injection.
6. Unify credential resolution last: reconcile API-side `AIRequestConfig` and worker-side provider resources into the shared `ProviderCredentials` shape only after all provider proxy builders consume that shape.
7. Add provider-specific regression coverage for each moved path: Anthropic standard + Vertex, Google AI, Bedrock bearer/IAM/env, streaming responses, custom headers, OAuth/user injection, and SSE keepalive behavior.

## Test plan

- [x] `git diff --check`
- [x] `cargo test -p windmill-ai proxy`
- [x] `cargo test -p windmill-api maps_request_config_to_provider_credentials`
- [x] `cargo test -p windmill-api-integration-tests --test ai_routes -- --nocapture`
- [x] `cargo test -p windmill-ai proxy::tests -- --nocapture`
- [x] `cargo check -p windmill-ai -p windmill-api`
- [x] `cargo check -p windmill-ai -p windmill-api --features bedrock`
- [x] Backend cargo-watch rebuilt successfully and local server stayed healthy on port 8070
- [x] AI agent integration subset against workspace `integration-tests`: OpenAI, Azure OpenAI, OpenRouter default completions; OpenAI streaming; OpenAI tool calling
- [x] `ai_evals`: `bun test`
- [x] `ai_evals`: `flow-test0-sum-two-numbers --model 4o --backend-validation preview` using `WMILL_AI_EVAL_BACKEND_WORKSPACE=integration-tests`
- [x] `ai_evals`: `script-test1-greet-user --model 4o --backend-validation preview` using `WMILL_AI_EVAL_BACKEND_WORKSPACE=integration-tests`
- [x] `ai_evals`: `global-test1-script-create --model sonnet` using `WMILL_AI_EVAL_BACKEND_WORKSPACE=integration-tests`
