### PR TITLE
Fix: set explicit cursor color in light editor theme

### DIFF
--- a/frontend/src/lib/components/vscode.ts
+++ b/frontend/src/lib/components/vscode.ts
@@ -255,6 +255,7 @@ export async function initializeVscode(caller?: string, htmlContainer?: HTMLElem
 				colors: {
 					'editor.background': '#FFFFFF',
 					'editor.foreground': '#2d3748',
+					'editorCursor.foreground': '#2d3748',
 					'editorLineNumber.foreground': '#C2C9D1',
 					'editorLineNumber.activeForeground': '#989DA5',
 					'editorGutter.background': '#FFFFFF00'


### PR DESCRIPTION
## Summary

The light Monaco editor theme (`myTheme`) in `frontend/src/lib/components/vscode.ts` did not explicitly define `editorCursor.foreground`, causing the cursor to be invisible against the white background.

The dark theme (`nord`) already sets this property to `#D8DEE9`. This PR adds the equivalent for the light theme, using `#2d3748` (the same value as `editor.foreground`).

## Change

One line added to the light theme's `colors` object:

```diff
colors: {
    'editor.background': '#FFFFFF',
    'editor.foreground': '#2d3748',
+   'editorCursor.foreground': '#2d3748',
    'editorLineNumber.foreground': '#C2C9D1',
    'editorLineNumber.activeForeground': '#989DA5',
    'editorGutter.background': '#FFFFFF00'
}
```

Fixes #8876

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the cursor color in the light Monaco editor theme (`myTheme`) to keep it visible on white backgrounds by adding `editorCursor.foreground: #2d3748` in `frontend/src/lib/components/vscode.ts`. Fixes #8876.

<sup>Written for commit 912377b89b17fe2a0de9447718d7e56871493091. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

