### PR TITLE
style(frontend): change Windmill logo color to red

### DIFF
--- a/frontend/src/lib/components/icons/WindmillIcon.svelte
+++ b/frontend/src/lib/components/icons/WindmillIcon.svelte
@@ -57,13 +57,13 @@
 				fill: #ffffff;
 			}
 			.st2 {
-				fill: #bcd4fc;
+				fill: #fecaca;
 			}
 			.st2-gray {
 				fill: #cccccc;
 			}
 			.st3 {
-				fill: #3b82f6;
+				fill: #ef4444;
 			}
 			.st4 {
 				fill: #b3b3b3;

--- a/frontend/src/lib/components/icons/WindmillIcon2.svelte
+++ b/frontend/src/lib/components/icons/WindmillIcon2.svelte
@@ -162,27 +162,27 @@
 		<g>
 			<!-- Use color or fallback to defaults (white or blue) -->
 			<polygon
-				fill={lessSaturatedColor || (white ? '#cccccc' : '#bcd4fc')}
+				fill={lessSaturatedColor || (white ? '#cccccc' : '#fecaca')}
 				points="134.78,14.22 114.31,48.21 101.33,69.75 158.22,69.75 177.97,36.95 191.67,14.22"
 			/>
 			<polygon
-				fill={color || (white ? '#ffffff' : '#3b82f6')}
+				fill={color || (white ? '#ffffff' : '#ef4444')}
 				points="227.55,69.75 186.61,69.75 101.33,69.75 129.78,119.02 158.16,119.02 228.61,119.02 256,119.02"
 			/>
 			<polygon
-				fill={color || (white ? '#ffffff' : '#3b82f6')}
+				fill={color || (white ? '#ffffff' : '#ef4444')}
 				points="136.93,132.47 116.46,167.93 73.82,241.78 130.71,241.78 144.9,217.2 180.13,156.18 193.82,132.46"
 			/>
 			<polygon
-				fill={color || (white ? '#ffffff' : '#3b82f6')}
+				fill={color || (white ? '#ffffff' : '#ef4444')}
 				points="121.7,131.95 101.23,96.49 58.59,22.63 30.15,71.91 44.34,96.49 79.57,157.5 93.26,181.22"
 			/>
 			<polygon
-				fill={lessSaturatedColor || (white ? '#cccccc' : '#bcd4fc')}
+				fill={lessSaturatedColor || (white ? '#cccccc' : '#fecaca')}
 				points="64.81,131.95 25.15,131.21 0,130.74 28.44,180.01 66.73,180.72 93.26,181.21"
 			/>
 			<polygon
-				fill={lessSaturatedColor || (white ? '#cccccc' : '#bcd4fc')}
+				fill={lessSaturatedColor || (white ? '#cccccc' : '#fecaca')}
 				points="165.38,181.74 184.58,216.46 196.75,238.47 225.19,189.2 206.66,155.69 193.83,132.46"
 			/>
 		</g>


### PR DESCRIPTION
## Summary
- Recolor the Windmill logo from blue (`#3b82f6` / `#bcd4fc`) to red (`#ef4444` / `#fecaca`).
- Touches both `WindmillIcon.svelte` (CSS-class fills) and `WindmillIcon2.svelte` (inline default fills, used when no `color` prop is passed).
- Light gray/white variants (`white` prop, custom icons) and the explicit `color` prop are left untouched.

## Test plan
- [ ] Visually inspect the sidebar/header logo in light and dark mode.
- [ ] Spot-check spots that render `WindmillIcon2` without an explicit `color` to confirm the new default red shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the default Windmill logo color from blue (`#3b82f6`/`#bcd4fc`) to red (`#ef4444`/`#fecaca`) across the app. Updates `WindmillIcon.svelte` class fills and `WindmillIcon2.svelte` inline defaults (used when no `color` prop is provided); the `white` variant and explicit `color` props are unchanged.

<sup>Written for commit 5325105ef3a4881d3a7c061ea9ee3c2f7d28e849. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

