### PR TITLE
fix(cli): prevent !inline-corruption in flow push/pull

### DIFF
--- a/cli/src/commands/flow/flow.ts
+++ b/cli/src/commands/flow/flow.ts
@@ -174,10 +174,14 @@ export async function pushFlow(
     await replaceInlineScripts([localFlow.value.preprocessor_module], fileReader, log, localPath, SEP, undefined, missingFiles);
   }
   if (missingFiles.length > 0) {
-    log.warn(colors.yellow(
-      `Warning: missing inline script file(s): ${missingFiles.join(", ")}. ` +
-      `The flow will be pushed with unresolved !inline references.`
-    ));
+    // Hard-fail rather than push the literal `!inline path` text as
+    // rawscript.content. That string would be persisted in flow_version.value
+    // and round-trip as the script body on the next pull, overwriting the
+    // user's local handler with the directive — see GIT-871 / #9140.
+    throw new Error(
+      `Cannot push flow ${remotePath}: missing inline script file(s): ${missingFiles.join(", ")}. ` +
+      `Either restore the file(s) or remove the !inline reference(s) from flow.yaml before pushing.`
+    );
   }
 
   const hasOnBehalfOf = (localFlow as any).has_on_behalf_of ?? !!localFlow.on_behalf_of_email;

--- a/cli/src/commands/flow/flow_metadata.ts
+++ b/cli/src/commands/flow/flow_metadata.ts
@@ -266,19 +266,29 @@ export async function generateFlowLockInternal(
           return tree.isStale(treePath);
         })
       : changedScripts;
+    const missingFiles: string[] = [];
     await replaceInlineScripts(
       flowValue.value.modules,
       fileReader,
       log,
       folder + SEP!,
       SEP,
-      locksToRemove
+      locksToRemove,
+      missingFiles
     );
     if (flowValue.value.failure_module) {
-      await replaceInlineScripts([flowValue.value.failure_module], fileReader, log, folder + SEP!, SEP, locksToRemove);
+      await replaceInlineScripts([flowValue.value.failure_module], fileReader, log, folder + SEP!, SEP, locksToRemove, missingFiles);
     }
     if (flowValue.value.preprocessor_module) {
-      await replaceInlineScripts([flowValue.value.preprocessor_module], fileReader, log, folder + SEP!, SEP, locksToRemove);
+      await replaceInlineScripts([flowValue.value.preprocessor_module], fileReader, log, folder + SEP!, SEP, locksToRemove, missingFiles);
+    }
+    if (missingFiles.length > 0) {
+      // Abort before updateFlow rather than push the literal `!inline path`
+      // string as rawscript.content (GIT-871 / #9140).
+      throw new Error(
+        `Cannot regenerate lock for flow ${remote_path}: missing inline script file(s): ${missingFiles.join(", ")}. ` +
+        `Either restore the file(s) or remove the !inline reference(s) from flow.yaml before retrying.`
+      );
     }
 
     //removeChangedLocks

--- a/cli/src/commands/flow/flow_metadata.ts
+++ b/cli/src/commands/flow/flow_metadata.ts
@@ -284,7 +284,10 @@ export async function generateFlowLockInternal(
     }
     if (missingFiles.length > 0) {
       // Abort before updateFlow rather than push the literal `!inline path`
-      // string as rawscript.content (GIT-871 / #9140).
+      // string as rawscript.content (GIT-871 / #9140). Note: at this point
+      // replaceInlineScripts has already mutated `flowValue.value` in place
+      // for the modules that *did* resolve. All current callers re-throw on
+      // this error; do not catch and reuse `flowValue` without re-parsing.
       throw new Error(
         `Cannot regenerate lock for flow ${remote_path}: missing inline script file(s): ${missingFiles.join(", ")}. ` +
         `Either restore the file(s) or remove the !inline reference(s) from flow.yaml before retrying.`
@@ -314,18 +317,23 @@ export async function generateFlowLockInternal(
     const lockAssigner = newPathAssigner(opts.defaultTs ?? "bun", {
       skipInlineScriptSuffix: getNonDottedPaths(),
     });
+    // flowValue.value here is the backend's response from updateFlow, so a
+    // rawscript whose content is `!inline ...` is corruption (GIT-871) — fail
+    // fast rather than writing the literal directive back to a script file.
+    const extractOpts = { skipInlineScriptSuffix: getNonDottedPaths(), failOnInlineDirective: true };
     const inlineScripts = extractInlineScriptsForFlows(
       flowValue.value.modules,
       currentMapping,
       SEP,
       opts.defaultTs,
-      lockAssigner
+      lockAssigner,
+      extractOpts
     );
     if (flowValue.value.failure_module) {
-      inlineScripts.push(...extractInlineScriptsForFlows([flowValue.value.failure_module], currentMapping, SEP, opts.defaultTs, lockAssigner));
+      inlineScripts.push(...extractInlineScriptsForFlows([flowValue.value.failure_module], currentMapping, SEP, opts.defaultTs, lockAssigner, extractOpts));
     }
     if (flowValue.value.preprocessor_module) {
-      inlineScripts.push(...extractInlineScriptsForFlows([flowValue.value.preprocessor_module], currentMapping, SEP, opts.defaultTs, lockAssigner));
+      inlineScripts.push(...extractInlineScriptsForFlows([flowValue.value.preprocessor_module], currentMapping, SEP, opts.defaultTs, lockAssigner, extractOpts));
     }
     inlineScripts.forEach((s) => {
       writeIfChanged(process.cwd() + SEP + folder + SEP + s.path, s.content);

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -950,7 +950,7 @@ function ZipFSElement(
                 SEP,
                 defaultTs,
                 assigner,
-                { skipInlineScriptSuffix: getNonDottedPaths() },
+                { skipInlineScriptSuffix: getNonDottedPaths(), failOnInlineDirective: true },
               );
               if (flow.value.failure_module) {
                 inlineScripts.push(...extractInlineScriptsForFlows(
@@ -959,7 +959,7 @@ function ZipFSElement(
                   SEP,
                   defaultTs,
                   assigner,
-                  { skipInlineScriptSuffix: getNonDottedPaths() },
+                  { skipInlineScriptSuffix: getNonDottedPaths(), failOnInlineDirective: true },
                 ));
               }
               if (flow.value.preprocessor_module) {
@@ -969,7 +969,7 @@ function ZipFSElement(
                   SEP,
                   defaultTs,
                   assigner,
-                  { skipInlineScriptSuffix: getNonDottedPaths() },
+                  { skipInlineScriptSuffix: getNonDottedPaths(), failOnInlineDirective: true },
                 ));
               }
             } catch (error) {

--- a/cli/test/inline_scripts_failure_preprocessor_unit.test.ts
+++ b/cli/test/inline_scripts_failure_preprocessor_unit.test.ts
@@ -574,3 +574,68 @@ describe("extractInlineScripts with mapping preserves file paths", () => {
     expect(lockScript!.path).toBe("my.inline_script.lock");
   });
 });
+
+// ---------------------------------------------------------------------------
+// failOnInlineDirective option (GIT-871 / #9140)
+// ---------------------------------------------------------------------------
+
+describe("failOnInlineDirective option", () => {
+  test("default behavior: yaml-parsed module with !inline content extracts without throwing", () => {
+    // Simulates flow_metadata / dev callers: yaml-parsed local flow whose
+    // rawscript.content is the literal `!inline foo.ts` directive (the
+    // legitimate on-disk shape after extraction).
+    const mod = makeRawscriptModule("a", "!inline a.inline_script.ts", "bun");
+    expect(() =>
+      extractInlineScripts([mod], {}, "/", "bun"),
+    ).not.toThrow();
+  });
+
+  test("yaml-parsed !inline content round-trips as the script's body", () => {
+    const mod = makeRawscriptModule("a", "!inline a.inline_script.ts", "bun");
+    const scripts = extractInlineScripts([mod], {}, "/", "bun");
+    const script = scripts.find((s) => !s.is_lock);
+    expect(script).toBeDefined();
+    expect(script!.content).toBe("!inline a.inline_script.ts");
+  });
+
+  test("opt-in: failOnInlineDirective=true throws on !inline content", () => {
+    // Simulates the sync-pull call site: rawscript came from the backend's
+    // flow_version.value, so `!inline ...` content means the row is corrupt.
+    const mod = makeRawscriptModule("failure", "!inline Handle_error.ts", "bun");
+    expect(() =>
+      extractInlineScripts([mod], {}, "/", "bun", undefined, {
+        failOnInlineDirective: true,
+      }),
+    ).toThrow(/corrupted inline script/);
+  });
+
+  test("opt-in: real script content still extracts cleanly", () => {
+    const mod = makeRawscriptModule(
+      "failure",
+      'export function main() { return 1; }',
+      "bun",
+    );
+    expect(() =>
+      extractInlineScripts([mod], {}, "/", "bun", undefined, {
+        failOnInlineDirective: true,
+      }),
+    ).not.toThrow();
+  });
+
+  test("opt-in: throws for nested rawscript inside branchall", () => {
+    const inner = makeRawscriptModule("inner", "!inline poisoned.ts", "bun");
+    const outer: FlowModule = {
+      id: "branch",
+      value: {
+        type: "branchall" as const,
+        branches: [{ summary: "b1", expr: "true", modules: [inner], skip_failure: false, parallel: false }],
+        parallel: false,
+      },
+    };
+    expect(() =>
+      extractInlineScripts([outer], {}, "/", "bun", undefined, {
+        failOnInlineDirective: true,
+      }),
+    ).toThrow(/corrupted inline script/);
+  });
+});

--- a/cli/test/sync_pull_push.test.ts
+++ b/cli/test/sync_pull_push.test.ts
@@ -111,6 +111,10 @@ kind: script
 function createFlowFixture(name: string): Record<string, { path: string; content: string }> {
   const flowSuffix = getFolderSuffix("flow");
   const metadataFile = getMetadataFileName("flow", "yaml");
+  // !inline paths are resolved relative to the flow folder (see
+  // pushFlow's fileReader in cli/src/commands/flow/flow.ts), so the
+  // path inside the directive must NOT include the flow folder prefix.
+  const scriptFile = "a.ts";
 
   return {
     metadata: {
@@ -122,7 +126,7 @@ value:
     - id: a
       value:
         type: rawscript
-        content: "!inline ${name}${flowSuffix}/a.ts"
+        content: "!inline ${scriptFile}"
         language: bun
         input_transforms: {}
 schema:
@@ -133,7 +137,7 @@ schema:
 `,
     },
     inlineScript: {
-      path: `${name}${flowSuffix}/a.ts`,
+      path: `${name}${flowSuffix}/${scriptFile}`,
       content: `export async function main() {\n  return "Hello from flow ${name}";\n}`,
     },
   };

--- a/cli/windmill-utils-internal/src/inline-scripts/extractor.ts
+++ b/cli/windmill-utils-internal/src/inline-scripts/extractor.ts
@@ -27,6 +27,19 @@ function extractRawscriptInline(
   const path = mappedPath ?? basePath + ext;
   const language = rawscript.language;
   const content = rawscript.content;
+  // Defensive guard: a rawscript whose content is itself an `!inline ...`
+  // directive is a sign the backend was poisoned by a prior push that sent
+  // the unresolved directive as the script body (GIT-871 / #9140). Refuse
+  // to write that text back to disk — it would silently overwrite the
+  // user's local handler with the literal directive on every pull.
+  if (typeof content === "string" && content.startsWith("!inline ")) {
+    throw new Error(
+      `Refusing to extract corrupted inline script for module '${id}': ` +
+      `rawscript.content is the literal string \`${content.split("\n")[0]}\` ` +
+      `instead of script source. The backend's flow_version.value is corrupt — ` +
+      `re-push from a known-good local copy to repair it.`
+    );
+  }
   const r = [{ path: path, content: content, language, is_lock: false}];
   rawscript.content = "!inline " + path.replaceAll(separator, "/");
   const lock = rawscript.lock;

--- a/cli/windmill-utils-internal/src/inline-scripts/extractor.ts
+++ b/cli/windmill-utils-internal/src/inline-scripts/extractor.ts
@@ -20,19 +20,21 @@ function extractRawscriptInline(
   rawscript: RawScript,
   mapping: Record<string, string>,
   separator: string,
-  assigner: PathAssigner
+  assigner: PathAssigner,
+  failOnInlineDirective: boolean
 ): InlineScript[] {
   const [basePath, ext] = assigner.assignPath(summary ?? id, rawscript.language);
   const mappedPath = mapping[id];
   const path = mappedPath ?? basePath + ext;
   const language = rawscript.language;
   const content = rawscript.content;
-  // Defensive guard: a rawscript whose content is itself an `!inline ...`
-  // directive is a sign the backend was poisoned by a prior push that sent
-  // the unresolved directive as the script body (GIT-871 / #9140). Refuse
-  // to write that text back to disk — it would silently overwrite the
-  // user's local handler with the literal directive on every pull.
-  if (typeof content === "string" && content.startsWith("!inline ")) {
+  // Opt-in defensive guard: when extracting from backend-shaped data (i.e.
+  // sync pull), a rawscript whose content is itself an `!inline ...` directive
+  // means the backend was poisoned by a prior push that sent the unresolved
+  // directive as the script body (GIT-871 / #9140). Refuse to write it back
+  // to disk. Off by default because callers that operate on YAML-parsed local
+  // flows (flow_metadata, dev) legitimately see `!inline foo.ts` as content.
+  if (failOnInlineDirective && typeof content === "string" && content.startsWith("!inline ")) {
     throw new Error(
       `Refusing to extract corrupted inline script for module '${id}': ` +
       `rawscript.content is the literal string \`${content.split("\n")[0]}\` ` +
@@ -63,6 +65,15 @@ function extractRawscriptInline(
 export interface ExtractInlineScriptsOptions {
   /** When true, skip the .inline_script. suffix in file names */
   skipInlineScriptSuffix?: boolean;
+  /**
+   * When true, throw if a `rawscript.content` is itself an `!inline ...`
+   * directive. Set this only at the sync-pull call site, where the input
+   * comes from the backend's `flow_version.value` and `!inline ...` content
+   * means the row is corrupt (GIT-871 / #9140). Leave off for callers that
+   * pass YAML-parsed local flows — the directive is the legitimate on-disk
+   * shape there.
+   */
+  failOnInlineDirective?: boolean;
 }
 
 /**
@@ -87,6 +98,7 @@ export function extractInlineScripts(
 ): InlineScript[] {
   // Create pathAssigner only if not provided (top-level call), but reuse it for nested calls
   const assigner = pathAssigner ?? newPathAssigner(defaultTs ?? "bun", { skipInlineScriptSuffix: options?.skipInlineScriptSuffix });
+  const failOnInlineDirective = options?.failOnInlineDirective ?? false;
 
   return modules.flatMap((m) => {
     if (m.value.type == "rawscript") {
@@ -96,7 +108,8 @@ export function extractInlineScripts(
         m.value,
         mapping,
         separator,
-        assigner
+        assigner,
+        failOnInlineDirective
       );
     } else if (m.value.type == "forloopflow") {
       return extractInlineScripts(
@@ -104,11 +117,12 @@ export function extractInlineScripts(
         mapping,
         separator,
         defaultTs,
-        assigner
+        assigner,
+        options
       );
     } else if (m.value.type == "branchall") {
       return m.value.branches.flatMap((b) =>
-        extractInlineScripts(b.modules, mapping, separator, defaultTs, assigner)
+        extractInlineScripts(b.modules, mapping, separator, defaultTs, assigner, options)
       );
     } else if (m.value.type == "whileloopflow") {
       return extractInlineScripts(
@@ -116,7 +130,8 @@ export function extractInlineScripts(
         mapping,
         separator,
         defaultTs,
-        assigner
+        assigner,
+        options
       );
     } else if (m.value.type == "branchone") {
       return [
@@ -126,7 +141,8 @@ export function extractInlineScripts(
             mapping,
             separator,
             defaultTs,
-            assigner
+            assigner,
+            options
           )
         ),
         ...extractInlineScripts(
@@ -134,7 +150,8 @@ export function extractInlineScripts(
           mapping,
           separator,
           defaultTs,
-          assigner
+          assigner,
+          options
         ),
       ];
     } else if (m.value.type == "aiagent") {
@@ -151,7 +168,8 @@ export function extractInlineScripts(
           toolValue,
           mapping,
           separator,
-          assigner
+          assigner,
+          failOnInlineDirective
         );
       });
     } else {


### PR DESCRIPTION
## Summary

Fixes [GIT-871](https://linear.app/windmilldev/issue/GIT-871) / windmill-labs/windmill#9140: `wmill sync pull` was overwriting users' error-handler scripts with the literal text `!inline Handle_error.ts`.

Root cause: a previous push had silently sent the unresolved `!inline ...` directive as `rawscript.content` to the backend (because `replaceInlineScripts` couldn't find the local file — typically a casing mismatch from PR #8940 + a push from a case-sensitive environment like Linux CI). The `flow_version.value` row got poisoned, and every subsequent pull faithfully wrote that string back to disk as the "script body."

This PR closes both ends of that loop:
1. **Push side** — refuse to push when any inline-script file is missing, so corrupt content can never reach the backend in the first place.
2. **Extractor side** — refuse to write `!inline ...` content to a script file on pull. If a workspace is already poisoned, the user gets a clear error pointing at the corruption instead of silently losing their handler again.

## Changes

- `cli/src/commands/flow/flow.ts` — `pushFlow` now throws on `missingFiles.length > 0` (was a warn-and-continue).
- `cli/src/commands/flow/flow_metadata.ts` — `regenerateFlowMetadata` (post-pull lock regeneration, which also calls `updateFlow`) now collects `missingFiles` across `modules` + `failure_module` + `preprocessor_module` and aborts before `updateFlow` if any are missing. This was a second corruption vector.
- `cli/windmill-utils-internal/src/inline-scripts/extractor.ts` — `extractRawscriptInline` throws when `rawscript.content` is itself an `!inline ...` string, instead of writing it to disk.

## Test plan

- [ ] Existing inline-script unit tests still pass: `bun test test/inline_scripts_failure_preprocessor_unit.test.ts test/yaml_inline_tag.test.ts test/app_inline_script_ordering_unit.test.ts` (verified locally — 34/34 pass).
- [ ] Manually simulate the broken state: in a flow folder, edit `flow.yaml` so `failure_module` references `!inline missing.ts` with no corresponding file. Run `wmill sync push` → expect a clear error mentioning `missing.ts`, no API call made.
- [ ] Manually simulate a poisoned backend: `UPDATE flow_version SET value = jsonb_set(value, '{failure_module,value,content}', '"!inline Handle_error.ts"') WHERE ...`. Run `wmill sync pull` → expect a clear error from the extractor instead of `Handle_error.ts` being overwritten.
- [ ] Recovery path: re-push from a known-good local copy (after fixing the extractor error path) — backend `flow_version.value` is repaired, subsequent pulls round-trip cleanly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents "!inline" corruption during flow sync by failing fast on missing inline files and adding an opt-in extractor guard used on pull/lock regen. Fixes Linear GIT-871; stops `wmill sync pull` from overwriting handlers with literal "!inline ...".

- **Bug Fixes**
  - Push: `pushFlow` now throws when any inline file is missing to avoid poisoning `flow_version.value`.
  - Lock regen: `generateFlowLockInternal` aggregates missing files across `modules`, `failure_module`, and `preprocessor_module` and aborts before `updateFlow`.
  - Pull/regen: extractor guard is opt-in via `failOnInlineDirective`; enabled for `sync pull` and lock regeneration, throwing if backend `rawscript.content` is an `!inline ...` string.
  - Local flows unchanged (no guard); tests updated so `!inline` paths are relative to the flow folder.

<sup>Written for commit ea8565764294b0728e5ad537dc6cffc29e6b4720. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

