### PR TITLE
feat: publish CLI skills + AGENTS.md to windmill-cli-docs for context7

### DIFF
--- a/.github/workflows/publish-cli-docs.yml
+++ b/.github/workflows/publish-cli-docs.yml
@@ -1,0 +1,61 @@
+name: Publish CLI docs repo
+
+# Regenerates the windmill-cli-docs repo (consumed by context7) from the
+# canonical sources in this repo on every Windmill release.
+#
+# Required secret:
+#   CLI_DOCS_DEPLOY_KEY — ed25519 private key whose public half is registered
+#                        as a write-access deploy key on
+#                        windmill-labs/windmill-cli-docs.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout windmill (source of truth)
+        uses: actions/checkout@v4
+        with:
+          path: windmill
+
+      - name: Checkout windmill-cli-docs (publish target)
+        uses: actions/checkout@v4
+        with:
+          repository: windmill-labs/windmill-cli-docs
+          path: windmill-cli-docs
+          ssh-key: ${{ secrets.CLI_DOCS_DEPLOY_KEY }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Regenerate docs
+        run: |
+          python3 windmill/system_prompts/generate.py \
+            --context7-dir "$GITHUB_WORKSPACE/windmill-cli-docs"
+
+      - name: Commit and push if changed
+        working-directory: windmill-cli-docs
+        env:
+          VERSION_TAG: ${{ github.ref_name }}
+        run: |
+          git config user.name "windmill-bot"
+          git config user.email "bot@windmill.dev"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No doc changes for ${VERSION_TAG}."
+            exit 0
+          fi
+          git commit -m "chore: sync from windmill ${VERSION_TAG}"
+          git tag -f "${VERSION_TAG}"
+          git push origin HEAD
+          git push origin "${VERSION_TAG}" --force

--- a/.github/workflows/publish-cli-docs.yml
+++ b/.github/workflows/publish-cli-docs.yml
@@ -14,6 +14,13 @@ on:
       - "v*"
   workflow_dispatch:
 
+# Serialize pushes to windmill-cli-docs so two release tags landing close
+# together (e.g. a release-please bump + a hotfix) can't race to force-push
+# the docs repo.
+concurrency:
+  group: publish-cli-docs
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -54,17 +61,24 @@ jobs:
           git add -A
           if git diff --cached --quiet; then
             echo "No doc changes for ${REF_NAME}."
-            exit 0
-          fi
-          # Only mirror the version tag when triggered by a tag push.
-          # workflow_dispatch from main would otherwise create a junk tag
-          # named after the branch in the docs repo.
-          if [ "${REF_TYPE}" = "tag" ]; then
-            git commit -m "chore: sync from windmill ${REF_NAME}"
-            git tag -f "${REF_NAME}"
-            git push origin HEAD
-            git push origin "${REF_NAME}" --force
+            committed=false
           else
-            git commit -m "chore: sync from windmill (manual dispatch from ${REF_NAME})"
+            committed=true
+            if [ "${REF_TYPE}" = "tag" ]; then
+              git commit -m "chore: sync from windmill ${REF_NAME}"
+            else
+              git commit -m "chore: sync from windmill (manual dispatch from ${REF_NAME})"
+            fi
             git push origin HEAD
+          fi
+          # Always mirror the version tag on tag pushes, even when content
+          # didn't change — downstream consumers tie snapshots to releases by
+          # tag, and skipping it would leave the docs repo without a tag for
+          # the new Windmill release.
+          # workflow_dispatch from a non-tag ref skips this so we don't
+          # create a junk tag named after a branch.
+          if [ "${REF_TYPE}" = "tag" ]; then
+            git tag -f "${REF_NAME}"
+            git push origin "${REF_NAME}" --force
+            echo "Mirrored tag ${REF_NAME} to windmill-cli-docs (content changed: ${committed})."
           fi

--- a/.github/workflows/publish-cli-docs.yml
+++ b/.github/workflows/publish-cli-docs.yml
@@ -46,16 +46,25 @@ jobs:
       - name: Commit and push if changed
         working-directory: windmill-cli-docs
         env:
-          VERSION_TAG: ${{ github.ref_name }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
         run: |
           git config user.name "windmill-bot"
           git config user.email "bot@windmill.dev"
           git add -A
           if git diff --cached --quiet; then
-            echo "No doc changes for ${VERSION_TAG}."
+            echo "No doc changes for ${REF_NAME}."
             exit 0
           fi
-          git commit -m "chore: sync from windmill ${VERSION_TAG}"
-          git tag -f "${VERSION_TAG}"
-          git push origin HEAD
-          git push origin "${VERSION_TAG}" --force
+          # Only mirror the version tag when triggered by a tag push.
+          # workflow_dispatch from main would otherwise create a junk tag
+          # named after the branch in the docs repo.
+          if [ "${REF_TYPE}" = "tag" ]; then
+            git commit -m "chore: sync from windmill ${REF_NAME}"
+            git tag -f "${REF_NAME}"
+            git push origin HEAD
+            git push origin "${REF_NAME}" --force
+          else
+            git commit -m "chore: sync from windmill (manual dispatch from ${REF_NAME})"
+            git push origin HEAD
+          fi

--- a/system_prompts/README.md
+++ b/system_prompts/README.md
@@ -45,10 +45,13 @@ python system_prompts/generate.py --context7-dir ~/windmill-cli-docs
 ```
 
 `--context7-dir` writes a fully-rendered snapshot (`AGENTS.md`,
-`cli-commands.md`, `skills/<name>/SKILL.md`, `README.md`, `manifest.json`)
-with all template placeholders resolved — suitable for ingestion by docs
-aggregators. In CI this runs from `.github/workflows/publish-cli-docs.yml`
-on every release tag.
+`cli-commands.md`, `skills/<name>/SKILL.md`, `README.md`, `manifest.json`
+with the Windmill `version`) with all template placeholders resolved —
+suitable for ingestion by docs aggregators. In CI this runs from
+`.github/workflows/publish-cli-docs.yml` on every release tag. The
+generator refuses to wipe the target directory unless it's empty or has
+a context7 marker (`context7.json`, `manifest.json`, or a
+`windmill-cli-docs` git remote), so a typo can't delete unrelated files.
 
 This will:
 

--- a/system_prompts/README.md
+++ b/system_prompts/README.md
@@ -38,6 +38,18 @@ python system_prompts/generate.py --plugin-dir ~/windmill-claude-plugin
 - a plugin root such as `plugins/windmill-code-plugin`
 - a direct `skills/` directory
 
+To regenerate the public docs repo (consumed by context7):
+
+```bash
+python system_prompts/generate.py --context7-dir ~/windmill-cli-docs
+```
+
+`--context7-dir` writes a fully-rendered snapshot (`AGENTS.md`,
+`cli-commands.md`, `skills/<name>/SKILL.md`, `README.md`, `manifest.json`)
+with all template placeholders resolved — suitable for ingestion by docs
+aggregators. In CI this runs from `.github/workflows/publish-cli-docs.yml`
+on every release tag.
+
 This will:
 
 1. Parse TypeScript and Python SDK files to extract function signatures

--- a/system_prompts/generate.py
+++ b/system_prompts/generate.py
@@ -1923,35 +1923,144 @@ def generate_context7_repo(
 
 
 def _context7_readme(skills: list[str]) -> str:
-    """Render the README that ships at the root of the docs repo."""
+    """Render the README that ships at the root of the docs repo.
+
+    Doubles as a CLI quickstart for humans landing on the GitHub page and as
+    the top-level entry point context7 indexes first — keep it actionable.
+    """
     skill_lines = "\n".join(f"- `skills/{name}/SKILL.md`" for name in skills)
-    return f"""# Windmill CLI Docs
+    return f"""# Windmill CLI Quickstart
 
-Auto-generated documentation for the [Windmill](https://www.windmill.dev) CLI
-(`wmill`) and its AI-agent guidance. This is the same content that `wmill init`
-materialises into a Windmill project, published as a standalone repo so it can
-be ingested by docs aggregators such as [context7](https://context7.com).
+[`wmill`](https://www.windmill.dev/docs/advanced/cli) is the official command
+line interface for [Windmill](https://www.windmill.dev) — an open-source
+platform for internal tools, workflows, API integrations, background jobs, and
+UIs. Use it to authenticate against a workspace, scaffold local projects,
+sync scripts/flows/apps between your filesystem and a workspace, and run or
+debug jobs from your terminal.
 
-**Do not edit by hand.** This repo is regenerated from
-[windmill-labs/windmill](https://github.com/windmill-labs/windmill) on every
-release. Open issues and PRs in the source repo, not here.
+## Install
 
-## Layout
+```sh
+npm install -g windmill-cli
+wmill --version
+```
 
-- `AGENTS.md` — the top-level prompt the CLI installs into each project.
-- `cli-commands.md` — full reference for every `wmill` command and flag.
-- `skills/<name>/SKILL.md` — one skill per directory; each is a self-contained
-  guide on a specific Windmill workflow (writing a flow, configuring a
-  trigger, etc.).
+Upgrade later with `wmill upgrade`.
 
-## Skills
+## Connect to a workspace
+
+```sh
+wmill workspace add
+```
+
+This walks you through adding a workspace profile — a `(name, remote URL,
+workspace id, token)` tuple stored under `~/.config/windmill`. You can have
+multiple profiles and switch between them with `wmill workspace switch <name>`.
+
+A workspace token is created from the Windmill UI under
+`User Settings → Tokens`. For self-hosted instances, point the remote at your
+own URL (e.g. `https://windmill.example.com`).
+
+## Initialize a project directory
+
+```sh
+wmill init
+```
+
+`wmill init` creates:
+
+- `wmill.yaml` — sync configuration (which folders/types to track).
+- `AGENTS.md` + `CLAUDE.md` — the agent prompt published in this repo.
+- `.claude/skills/` and `.agents/skills/` — per-task guides used by AI coding
+  assistants (Claude Code, Codex, Pi). These are the same `SKILL.md` files
+  you'll find under `skills/` in this repo.
+
+It also offers to bind a workspace profile to the current git branch and to
+import git-sync settings from the backend if any are configured.
+
+## Sync between local files and a workspace
+
+```sh
+wmill sync pull     # workspace → local (writes flows, scripts, apps, etc.)
+wmill sync push     # local → workspace
+```
+
+Sync is idempotent and diff-aware: `wmill sync push --dry-run` previews the
+changes without applying them. Use `--yaml` (recommended) to keep specs as
+YAML rather than JSON.
+
+For individual entities you can also use the type-specific commands:
+
+```sh
+wmill script push   path/to/script.ts
+wmill flow   push   path/to/flow.yaml
+wmill app    push   path/to/app.yaml
+wmill resource push path/to/resource.yaml
+```
+
+## Run, inspect, and debug jobs
+
+```sh
+wmill script run u/me/my_script --data '{{"foo": "bar"}}'
+wmill flow   run u/me/my_flow   --data @inputs.json
+wmill job list --failed --limit 20
+wmill job get  <job_id>
+wmill job logs <job_id>
+```
+
+Logs and flow steps stream as the job runs. For flow failures, `wmill job get`
+shows the step tree with each sub-job's id so you can drill in with
+`wmill job logs <sub_job_id>`.
+
+## Scaffold new entities
+
+```sh
+wmill script new u/me/path --language bun
+wmill flow   new u/me/path --summary "..."
+wmill app    new u/me/path --summary "..." --framework svelte
+```
+
+These create the correct folder layout and a minimal spec file, then print
+next-step hints. Prefer them over hand-creating the folders — they pick the
+right naming conventions for your workspace.
+
+## Triggers and schedules
+
+Triggers (HTTP routes, WebSocket, Kafka, NATS, MQTT, SQS, GCP Pub/Sub, Azure
+Event Hubs, Email, Postgres CDC) and cron schedules are tracked as YAML files
+synced alongside your scripts and flows. See `skills/triggers/SKILL.md` and
+`skills/schedules/SKILL.md` for the full schemas.
+
+## Completion
+
+```sh
+source <(wmill completions bash)        # bash, zsh: source <(wmill completions zsh)
+source (wmill completions fish | psub)  # fish
+```
+
+## Reference
+
+- `cli-commands.md` — every `wmill` command and flag, generated from the
+  source.
+- `AGENTS.md` — the top-level prompt the CLI installs into each project (and
+  the same instructions AI coding assistants follow when working in a
+  Windmill repo).
+- `skills/<name>/SKILL.md` — one self-contained guide per common task.
+
+### Skills index
 
 {skill_lines}
 
-## Source
+## About this repo
 
-Generated by `system_prompts/generate.py --context7-dir` in
-[windmill-labs/windmill](https://github.com/windmill-labs/windmill).
+Auto-generated mirror of the Windmill CLI's bundled AI-agent guidance and
+command reference, published for ingestion by docs aggregators such as
+[context7](https://context7.com).
+
+**Do not edit by hand.** This repo is regenerated from
+[windmill-labs/windmill](https://github.com/windmill-labs/windmill) on every
+release. Open issues and PRs in the source repo, not here. The generator is
+`system_prompts/generate.py --context7-dir`.
 """
 
 

--- a/system_prompts/generate.py
+++ b/system_prompts/generate.py
@@ -1786,8 +1786,22 @@ def generate_plugin_skills(
 # Files in the context7 target directory that must survive a regeneration
 # (everything else is wiped to keep the export deterministic).
 CONTEXT7_PRESERVE = frozenset(
-    {".git", ".github", "LICENSE", "LICENSE.md", "context7.json"}
+    {
+        ".git",
+        ".github",
+        ".gitignore",
+        ".gitattributes",
+        "CODEOWNERS",
+        "LICENSE",
+        "LICENSE.md",
+        "context7.json",
+    }
 )
+
+# Marker files that identify a directory as the context7 docs target.
+# clear_context7_dir refuses to wipe a non-empty dir that has none of these
+# (or a matching git remote), so a typo like `--context7-dir .` fails safe.
+CONTEXT7_MARKERS = ("context7.json", "manifest.json")
 
 
 def extract_agents_md_template() -> str:
@@ -1798,17 +1812,30 @@ def extract_agents_md_template() -> str:
     """
     core_ts_path = SCRIPT_DIR.parent / "cli" / "src" / "guidance" / "core.ts"
     content = core_ts_path.read_text()
-    match = re.search(r"return\s+`([\s\S]*?)`;", content)
+    # Anchor on the function name so adding other template-literal-returning
+    # functions to core.ts can't silently re-target the regex.
+    match = re.search(
+        r"function\s+generateAgentsMdContent\b[\s\S]*?return\s+`([\s\S]*?)`;",
+        content,
+    )
     if not match:
         raise RuntimeError(
             f"Could not extract AGENTS.md template from {core_ts_path}"
         )
-    # Unescape the TS template literal: \` -> `, \\ -> \, \$ -> $
-    return (
-        match.group(1)
-        .replace("\\`", "`")
-        .replace("\\$", "$")
-        .replace("\\\\", "\\")
+    return _unescape_ts_template_literal(match.group(1))
+
+
+def _unescape_ts_template_literal(raw: str) -> str:
+    """Decode TS template-literal escapes in one pass.
+
+    Multi-pass `.replace()` would mangle e.g. `\\\\` -> `\\` -> `` ` `` if the
+    template ever contained a literal backslash followed by a backtick. A
+    single-pass scan is order-independent.
+    """
+    return re.sub(
+        r"\\(.)",
+        lambda m: {"`": "`", "$": "$", "\\": "\\"}.get(m.group(1), m.group(0)),
+        raw,
     )
 
 
@@ -1841,11 +1868,52 @@ def build_skill_desc_map(skills: list[str]) -> dict[str, str]:
     return desc_map
 
 
+def _verify_context7_target(target_dir: Path) -> None:
+    """Refuse to wipe a non-empty dir that doesn't look like the docs repo.
+
+    A typo such as `--context7-dir .`, `~`, or the wrong checkout could
+    otherwise nuke unrelated files. We accept the target if it's empty/new,
+    if it contains a known marker file, or if its git origin points at a
+    `windmill-cli-docs` remote.
+    """
+    if not target_dir.exists() or not any(target_dir.iterdir()):
+        return
+
+    for marker in CONTEXT7_MARKERS:
+        if (target_dir / marker).exists():
+            return
+
+    git_dir = target_dir / ".git"
+    if git_dir.exists():
+        import subprocess
+
+        try:
+            origin = subprocess.run(
+                ["git", "-C", str(target_dir), "config", "--get", "remote.origin.url"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+            if "windmill-cli-docs" in origin:
+                return
+        except subprocess.CalledProcessError:
+            pass
+
+    raise RuntimeError(
+        f"Refusing to overwrite {target_dir}: no context7 marker found.\n"
+        f"Expected one of {list(CONTEXT7_MARKERS)} at the top level, or a git "
+        f"remote 'origin' containing 'windmill-cli-docs'.\n"
+        f"If this is the right directory, add a `context7.json` (or commit one) "
+        f"and retry."
+    )
+
+
 def clear_context7_dir(target_dir: Path) -> None:
     """Wipe the docs repo dir of previously generated content.
 
-    Preserves a small allowlist (.git, .github, LICENSE) so this can run
-    against a real checkout without nuking version control or CI config.
+    Preserves a small allowlist (.git, .github, LICENSE, context7.json, etc.)
+    so this can run against a real checkout without nuking version control or
+    CI config.
     """
     if not target_dir.exists():
         return
@@ -1856,6 +1924,18 @@ def clear_context7_dir(target_dir: Path) -> None:
             shutil.rmtree(entry)
         else:
             entry.unlink()
+
+
+def _read_windmill_version() -> str | None:
+    """Return the Windmill release version (e.g. '1.700.2'), or None if absent.
+
+    Sourced from `version.txt` at the repo root — the same file release-please
+    updates on every release.
+    """
+    version_file = SCRIPT_DIR.parent / "version.txt"
+    if not version_file.exists():
+        return None
+    return version_file.read_text().strip() or None
 
 
 def generate_context7_repo(
@@ -1875,6 +1955,7 @@ def generate_context7_repo(
     """
     target_dir = target_dir.expanduser().resolve()
     target_dir.mkdir(parents=True, exist_ok=True)
+    _verify_context7_target(target_dir)
     clear_context7_dir(target_dir)
 
     skill_desc_map = build_skill_desc_map(skills)
@@ -1913,6 +1994,9 @@ def generate_context7_repo(
             for name in skills
         ],
     }
+    version = _read_windmill_version()
+    if version:
+        manifest["version"] = version
     (target_dir / "manifest.json").write_text(
         json.dumps(manifest, indent=2) + "\n"
     )

--- a/system_prompts/generate.py
+++ b/system_prompts/generate.py
@@ -12,6 +12,7 @@ This script:
 Usage:
     python generate.py
     python generate.py --plugin-dir /path/to/windmill-claude-plugin
+    python generate.py --context7-dir /path/to/windmill-cli-docs
 """
 
 import argparse
@@ -1779,6 +1780,182 @@ def generate_plugin_skills(
 
 
 # =============================================================================
+# Context7 Docs Repo Generation
+# =============================================================================
+
+# Files in the context7 target directory that must survive a regeneration
+# (everything else is wiped to keep the export deterministic).
+CONTEXT7_PRESERVE = frozenset(
+    {".git", ".github", "LICENSE", "LICENSE.md", "context7.json"}
+)
+
+
+def extract_agents_md_template() -> str:
+    """Extract the AGENTS.md template string from cli/src/guidance/core.ts.
+
+    Keeping a single source of truth in TypeScript avoids drift between what
+    `wmill init` writes locally and what we publish for context7 ingestion.
+    """
+    core_ts_path = SCRIPT_DIR.parent / "cli" / "src" / "guidance" / "core.ts"
+    content = core_ts_path.read_text()
+    match = re.search(r"return\s+`([\s\S]*?)`;", content)
+    if not match:
+        raise RuntimeError(
+            f"Could not extract AGENTS.md template from {core_ts_path}"
+        )
+    # Unescape the TS template literal: \` -> `, \\ -> \, \$ -> $
+    return (
+        match.group(1)
+        .replace("\\`", "`")
+        .replace("\\$", "$")
+        .replace("\\\\", "\\")
+    )
+
+
+def render_agents_md_for_docs(
+    skills: list[str], skill_desc_map: dict[str, str]
+) -> str:
+    """Render AGENTS.md exactly as `wmill init` would, for the docs repo."""
+    template = extract_agents_md_template()
+    skills_reference = "\n".join(
+        f"- `.claude/skills/{name}/SKILL.md` - {skill_desc_map[name]}"
+        for name in skills
+        if name in skill_desc_map
+    )
+    return template.replace("${skillsReference}", skills_reference)
+
+
+def build_skill_desc_map(skills: list[str]) -> dict[str, str]:
+    """Map each skill name to its user-facing description.
+
+    Mirrors the logic in `generate_skills_ts_export`: language skills draw from
+    LANGUAGE_METADATA, everything else from SKILL_DEFINITIONS.
+    """
+    desc_map = {s["name"]: s["description"] for s in SKILL_DEFINITIONS}
+    for skill in skills:
+        if skill.startswith("write-script-"):
+            lang_key = skill.replace("write-script-", "")
+            metadata = LANGUAGE_METADATA.get(lang_key)
+            if metadata:
+                desc_map[skill] = metadata["description"]
+    return desc_map
+
+
+def clear_context7_dir(target_dir: Path) -> None:
+    """Wipe the docs repo dir of previously generated content.
+
+    Preserves a small allowlist (.git, .github, LICENSE) so this can run
+    against a real checkout without nuking version control or CI config.
+    """
+    if not target_dir.exists():
+        return
+    for entry in target_dir.iterdir():
+        if entry.name in CONTEXT7_PRESERVE:
+            continue
+        if entry.is_dir():
+            shutil.rmtree(entry)
+        else:
+            entry.unlink()
+
+
+def generate_context7_repo(
+    target_dir: Path,
+    skills: list[str],
+    schema_yaml_content: dict[str, str],
+    cli_commands_md: str,
+) -> Path:
+    """Generate a fully-rendered docs repo suitable for context7 ingestion.
+
+    Layout written to `target_dir`:
+        AGENTS.md              # the prompt agents see in their projects
+        README.md              # stable intro for humans / context7
+        manifest.json          # version + skill list (for indexing)
+        cli-commands.md        # full CLI flag reference
+        skills/<name>/SKILL.md # one rendered skill per file
+    """
+    target_dir = target_dir.expanduser().resolve()
+    target_dir.mkdir(parents=True, exist_ok=True)
+    clear_context7_dir(target_dir)
+
+    skill_desc_map = build_skill_desc_map(skills)
+
+    # AGENTS.md — the same content `wmill init` writes locally.
+    (target_dir / "AGENTS.md").write_text(
+        render_agents_md_for_docs(skills, skill_desc_map)
+    )
+
+    # Full CLI reference at top level.
+    (target_dir / "cli-commands.md").write_text(cli_commands_md)
+
+    # One markdown per skill, with schemas inlined (no template placeholders).
+    skills_dir = target_dir / "skills"
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    for skill_name in skills:
+        skill_dir = skills_dir / skill_name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(
+            render_plugin_skill_content(skill_name, schema_yaml_content)
+        )
+
+    # Stable README so the GitHub repo landing page tells readers (and
+    # context7's crawler) what they're looking at.
+    (target_dir / "README.md").write_text(_context7_readme(skills))
+
+    # Machine-readable index for context7 / downstream consumers.
+    manifest = {
+        "name": "windmill-cli-docs",
+        "description": (
+            "Auto-generated Windmill CLI docs: agent prompt, skills, and "
+            "full CLI reference. Source: github.com/windmill-labs/windmill."
+        ),
+        "skills": [
+            {"name": name, "description": skill_desc_map.get(name, "")}
+            for name in skills
+        ],
+    }
+    (target_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n"
+    )
+
+    print(f"\nGenerated for context7 docs repo:")
+    print(f"  - {target_dir} ({len(skills)} skills + AGENTS.md + cli-commands.md)")
+    return target_dir
+
+
+def _context7_readme(skills: list[str]) -> str:
+    """Render the README that ships at the root of the docs repo."""
+    skill_lines = "\n".join(f"- `skills/{name}/SKILL.md`" for name in skills)
+    return f"""# Windmill CLI Docs
+
+Auto-generated documentation for the [Windmill](https://www.windmill.dev) CLI
+(`wmill`) and its AI-agent guidance. This is the same content that `wmill init`
+materialises into a Windmill project, published as a standalone repo so it can
+be ingested by docs aggregators such as [context7](https://context7.com).
+
+**Do not edit by hand.** This repo is regenerated from
+[windmill-labs/windmill](https://github.com/windmill-labs/windmill) on every
+release. Open issues and PRs in the source repo, not here.
+
+## Layout
+
+- `AGENTS.md` — the top-level prompt the CLI installs into each project.
+- `cli-commands.md` — full reference for every `wmill` command and flag.
+- `skills/<name>/SKILL.md` — one skill per directory; each is a self-contained
+  guide on a specific Windmill workflow (writing a flow, configuring a
+  trigger, etc.).
+
+## Skills
+
+{skill_lines}
+
+## Source
+
+Generated by `system_prompts/generate.py --context7-dir` in
+[windmill-labs/windmill](https://github.com/windmill-labs/windmill).
+"""
+
+
+# =============================================================================
 # Main Entry Point
 # =============================================================================
 
@@ -1797,6 +1974,15 @@ def parse_args() -> argparse.Namespace:
         help=(
             "Optional plugin target. Accepts a windmill-claude-plugin repo root, "
             "a plugin root, or a skills directory, and refreshes standalone skills there."
+        ),
+    )
+    parser.add_argument(
+        "--context7-dir",
+        type=Path,
+        help=(
+            "Optional path to a docs-repo checkout (e.g. windmill-cli-docs). "
+            "Writes AGENTS.md, cli-commands.md, skills/, README.md, and manifest.json "
+            "with all placeholders resolved, suitable for context7 ingestion."
         ),
     )
     return parser.parse_args()
@@ -2116,6 +2302,11 @@ export declare function getWorkflowAsCodePrompt(language?: string): string;
 
     if args.plugin_dir:
         generate_plugin_skills(args.plugin_dir, skills, schema_yaml_content)
+
+    if args.context7_dir:
+        generate_context7_repo(
+            args.context7_dir, skills, schema_yaml_content, cli_commands
+        )
 
     print("\nDone!")
 

--- a/system_prompts/generate.py
+++ b/system_prompts/generate.py
@@ -1798,10 +1798,9 @@ CONTEXT7_PRESERVE = frozenset(
     }
 )
 
-# Marker files that identify a directory as the context7 docs target.
-# clear_context7_dir refuses to wipe a non-empty dir that has none of these
-# (or a matching git remote), so a typo like `--context7-dir .` fails safe.
-CONTEXT7_MARKERS = ("context7.json", "manifest.json")
+# Name written into manifest.json — also used to recognise the docs repo
+# when re-generating into an existing checkout.
+CONTEXT7_REPO_NAME = "windmill-cli-docs"
 
 
 def extract_agents_md_template() -> str:
@@ -1868,20 +1867,37 @@ def build_skill_desc_map(skills: list[str]) -> dict[str, str]:
     return desc_map
 
 
+def _looks_like_windmill_manifest(path: Path) -> bool:
+    """Return True iff `path` is a JSON file whose top-level `name` is ours.
+
+    Used to distinguish a previously-generated docs repo from an unrelated
+    project that happens to have a `manifest.json` (Chrome extensions, npm
+    packages, web app manifests, etc.).
+    """
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    return isinstance(data, dict) and data.get("name") == CONTEXT7_REPO_NAME
+
+
 def _verify_context7_target(target_dir: Path) -> None:
     """Refuse to wipe a non-empty dir that doesn't look like the docs repo.
 
     A typo such as `--context7-dir .`, `~`, or the wrong checkout could
     otherwise nuke unrelated files. We accept the target if it's empty/new,
-    if it contains a known marker file, or if its git origin points at a
-    `windmill-cli-docs` remote.
+    if it has our ownership file, if its `manifest.json` self-identifies as
+    the windmill-cli-docs repo, or if its git origin points at one.
     """
     if not target_dir.exists() or not any(target_dir.iterdir()):
         return
 
-    for marker in CONTEXT7_MARKERS:
-        if (target_dir / marker).exists():
-            return
+    if (target_dir / "context7.json").exists():
+        return
+
+    manifest_path = target_dir / "manifest.json"
+    if manifest_path.exists() and _looks_like_windmill_manifest(manifest_path):
+        return
 
     git_dir = target_dir / ".git"
     if git_dir.exists():
@@ -1894,17 +1910,19 @@ def _verify_context7_target(target_dir: Path) -> None:
                 text=True,
                 check=True,
             ).stdout.strip()
-            if "windmill-cli-docs" in origin:
+            if CONTEXT7_REPO_NAME in origin:
                 return
         except subprocess.CalledProcessError:
             pass
 
     raise RuntimeError(
-        f"Refusing to overwrite {target_dir}: no context7 marker found.\n"
-        f"Expected one of {list(CONTEXT7_MARKERS)} at the top level, or a git "
-        f"remote 'origin' containing 'windmill-cli-docs'.\n"
-        f"If this is the right directory, add a `context7.json` (or commit one) "
-        f"and retry."
+        f"Refusing to overwrite {target_dir}: target does not look like the "
+        f"{CONTEXT7_REPO_NAME} docs repo.\n"
+        f"Expected one of:\n"
+        f"  - a `context7.json` at the top level,\n"
+        f"  - a `manifest.json` whose top-level `name` is {CONTEXT7_REPO_NAME!r},\n"
+        f"  - a git remote `origin` containing '{CONTEXT7_REPO_NAME}'.\n"
+        f"If this is the right directory, add a `context7.json` and retry."
     )
 
 
@@ -1983,8 +2001,10 @@ def generate_context7_repo(
     (target_dir / "README.md").write_text(_context7_readme(skills))
 
     # Machine-readable index for context7 / downstream consumers.
+    # Note: the `name` field is also the marker `_verify_context7_target`
+    # uses to distinguish our `manifest.json` from generic ones.
     manifest = {
-        "name": "windmill-cli-docs",
+        "name": CONTEXT7_REPO_NAME,
         "description": (
             "Auto-generated Windmill CLI docs: agent prompt, skills, and "
             "full CLI reference. Source: github.com/windmill-labs/windmill."


### PR DESCRIPTION
## Summary

Auto-publishes a public docs snapshot of Windmill's CLI guidance — `AGENTS.md`, the full CLI reference, and every rendered skill — to [`windmill-labs/windmill-cli-docs`](https://github.com/windmill-labs/windmill-cli-docs) on each release tag, so [context7](https://context7.com) can index Windmill CLI docs and serve them to AI coding assistants.

## Changes

- **`system_prompts/generate.py`** — new `--context7-dir <path>` flag that writes a fully-rendered docs repo (`AGENTS.md`, `cli-commands.md`, `skills/<name>/SKILL.md`, `README.md`, `manifest.json`) into the target dir. Placeholders (`{{FLOW_SUFFIX}}`, schema yaml, etc.) are all resolved; nothing left for a consumer to template.
- **`AGENTS.md` extraction** — the template string is regex-extracted at generation time from `cli/src/guidance/core.ts` (the canonical source used by `wmill init`), so the published prompt cannot drift from what users see locally.
- **`.github/workflows/publish-cli-docs.yml`** — fires on `v*` tag and `workflow_dispatch`, regenerates the docs repo, force-mirrors the version tag (skipped on non-tag manual dispatches), pushes via the `CLI_DOCS_DEPLOY_KEY` SSH deploy key.
- **`system_prompts/README.md`** — documents the new flag.

## Out of band (already done)

- Created public repo [`windmill-labs/windmill-cli-docs`](https://github.com/windmill-labs/windmill-cli-docs) with initial sync.
- Added ed25519 deploy key (write access) on that repo.
- Stored the private half as `CLI_DOCS_DEPLOY_KEY` secret on this repo.
- Committed `context7.json` (ownership verification) at the docs-repo root — `generate.py` preserves it across regenerations.

## Test plan

- [ ] `python system_prompts/generate.py --context7-dir /tmp/test` writes AGENTS.md, cli-commands.md, skills/, README.md, manifest.json with placeholders resolved
- [ ] `bash system_prompts/check-freshness.sh` still passes (new flag is opt-in)
- [ ] Manual `workflow_dispatch` from `main` after merge: commits to docs repo without creating a junk tag
- [ ] Next `v*` release tag: docs repo gets a matching commit + force-tagged at the version
- [ ] Submit https://github.com/windmill-labs/windmill-cli-docs to context7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes a fully rendered Windmill CLI docs snapshot—`AGENTS.md`, full CLI reference, Quickstart `README.md`, and all skills—to `windmill-labs/windmill-cli-docs` on each release tag. This lets context7 index up-to-date CLI guidance.

- **New Features**
  - `system_prompts/generate.py`: `--context7-dir` writes a complete docs repo (`AGENTS.md`, `cli-commands.md`, `skills/<name>/SKILL.md`, Quickstart `README.md`, `manifest.json` with Windmill `version`), preserves `.git`, `.github`, `.gitignore`, `.gitattributes`, `CODEOWNERS`, `LICENSE`, `context7.json`, and refuses to wipe the target unless it's empty, has a context7 marker, the git remote points to `windmill-cli-docs`, or `manifest.json` declares `name: "windmill-cli-docs"`.
  - `AGENTS.md` is extracted from `cli/src/guidance/core.ts` via an anchored regex with one-pass TS escape decoding, then rendered with `skillsReference`.
  - CI: `.github/workflows/publish-cli-docs.yml` regenerates and pushes to `windmill-labs/windmill-cli-docs` on `v*` tags and `workflow_dispatch` using `CLI_DOCS_DEPLOY_KEY`, serialized via a concurrency group; always mirrors the version tag on tag pushes.
  - Docs: updated `system_prompts/README.md`; the generated repo’s `README.md` is a CLI Quickstart.

- **Bug Fixes**
  - Validate `manifest.json` contents (top-level `name` must be `windmill-cli-docs`) before allowing a wipe of `--context7-dir`.

<sup>Written for commit 0bc1be38c701d33e5dc48805da51366f077322fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

