### PR TITLE
fix(bun): pass --preserve-symlinks on unbundled execution

### DIFF
--- a/backend/tests/bun_jobs.rs
+++ b/backend/tests/bun_jobs.rs
@@ -577,6 +577,63 @@ export function main() {
     Ok(())
 }
 
+/// Regression test: a `//nobundling` script that pulls a package whose CJS
+/// internals do bare-specifier `require()` of a sibling dependency.
+///
+/// Before the `--preserve-symlinks` fix, Bun 1.2/1.3+ would follow the
+/// directory symlink in `node_modules/@langchain/core` to its global cache
+/// entry, walk parent dirs from the cache realpath, and fail to find
+/// `node_modules/zod` — producing:
+///   ENOENT while resolving package 'zod/v3' from
+///   '.../cache_nomount/bun/@langchain/core@<ver>@@@1/dist/runnables/base.js'
+///
+/// The fix passes `--preserve-symlinks` so Bun resolves from the
+/// symlink path under `<job_dir>/node_modules/`, where `zod` is a sibling.
+#[sqlx::test(fixtures("base"))]
+async fn test_bun_nobundling_transitive_require(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    let content = r#"//nobundling
+import { ChatPromptTemplate } from "@langchain/core/prompts";
+
+export async function main() {
+    const tpl = ChatPromptTemplate.fromMessages([
+        ["system", "you are a {role}"],
+        ["human", "{input}"],
+    ]);
+    const out = await tpl.formatMessages({ role: "tester", input: "ping" });
+    return out.length;
+}
+"#
+    .to_owned();
+
+    let job = JobPayload::Code(RawCode {
+        hash: None,
+        content,
+        path: None,
+        language: ScriptLang::Bun,
+        lock: None,
+        concurrency_settings: windmill_common::runnable_settings::ConcurrencySettings::default()
+            .into(),
+        debouncing_settings: windmill_common::runnable_settings::DebouncingSettings::default(),
+        cache_ttl: None,
+        cache_ignore_s3_path: None,
+        dedicated_worker: None,
+        modules: None,
+        tag: None,
+    });
+
+    let result = run_job_in_new_worker_until_complete(&db, false, job, port)
+        .await
+        .json_result()
+        .unwrap();
+
+    assert_eq!(result, serde_json::json!(2));
+    Ok(())
+}
+
 // ============================================================================
 // Native Mode Tests (requires deno_core feature)
 // ============================================================================

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -2172,6 +2172,7 @@ try {{
                 "--",
                 &BUN_PATH,
                 "run",
+                "--preserve-symlinks",
                 "-i",
                 "--prefer-offline",
                 "-r",
@@ -2238,6 +2239,7 @@ try {{
             } else {
                 vec![
                     "run",
+                    "--preserve-symlinks",
                     "-i",
                     "--prefer-offline",
                     "-r",
@@ -3895,6 +3897,7 @@ pub async fn start_worker(
             common_bun_proc_envs,
             vec![
                 "run",
+                "--preserve-symlinks",
                 "-i",
                 "--prefer-offline",
                 "-r",


### PR DESCRIPTION
## Summary

Fixes a runtime resolution failure for `//nobundling` Bun scripts (and any unbundled execution) on Bun 1.2/1.3+. Symptom reported by a user running `@langchain/core@1.1.44`:

```
ENOENT while resolving package 'zod/v3' from
'/tmp/windmill/cache_nomount/bun/@langchain/core@1.1.44@@@1/dist/runnables/base.js'
```

`zod` is correctly installed as a sibling of `@langchain/core` in `node_modules/`, but Bun's resolver never sees it.

## Root cause

Bun 1.2/1.3 moved its global package cache to a content-addressed layout (`<pkg>@<ver>@@@<key>`) and the installer now creates a **directory symlink** from `node_modules/<pkg>` to that cache entry. Without `--preserve-symlinks`, Bun follows the symlink and resolves modules from each file's realpath — so a `require('zod/v3')` inside `@langchain/core` walks up from `cache_nomount/bun/...` and never finds `<job_dir>/node_modules/zod`.

The bundled execution path already had `--preserve-symlinks` (added in #4132 because we explicitly symlink the cached bundle file into the job dir). The unbundled paths didn't, because at the time Bun installed via per-file hardlinks and the realpath of node_modules entries was the job dir itself. The installer layout change made the flag necessary on the unbundled paths too.

## Changes

- Add `--preserve-symlinks` to the three unbundled `bun run` invocations in `backend/windmill-worker/src/bun_executor.rs`:
  - nsjail unbundled (`:2175`)
  - non-nsjail unbundled (`:2242`)
  - dedicated worker (always unbundled) (`:3900`)
- Bundled paths are unchanged — they either already had the flag or don't need it (everything is in one bundle, no sibling resolution).

This also fixes a latent first-run race for any normal bun script: on first execution the `build_cache` path runs the script *unbundled* while it builds the bundle for next time, so the same Bun-layout bug could silently affect it.

## Reproduction

Minimal repro mirroring Bun's symlink-to-cache layout (`node_modules/pkg-a` → symlink → `cache/pkg-a@1.0.0`; `pkg-a` imports `pkg-b`):

- `bun run main.ts` → `SyntaxError: Export named 'X' not found in module '<global-cache>/pkg-b@.../index.js'` (resolver bounced to the wrong tree)
- `bun run --preserve-symlinks main.ts` → works

## Test plan

- [ ] `//nobundling` script importing `@langchain/core@1.1.44` runs to completion (the originally reported failure)
- [ ] Same script under nsjail (`is_sandboxing_enabled`) — note: nsjail config doesn't mount `cache_nomount/bun`, so dangling-symlink behavior there is a separate concern not addressed here
- [ ] Dedicated worker for a bun script with non-trivial deps
- [ ] Regression check: a normal (bundled) bun script still runs unchanged on cache hit
- [ ] First-run of a normal bun script (cold cache) — exercises the unbundled path before the bundle is built

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes module resolution failures in unbundled Bun runs by passing `--preserve-symlinks`. Resolves Bun 1.2/1.3+ cache symlink issues that broke `//nobundling` and first-run executions, and adds a regression test for the `@langchain/core` → `zod/v3` case.

- **Bug Fixes**
  - Added `--preserve-symlinks` to all unbundled `bun run` paths (nsjail, non-nsjail, dedicated worker); bundled execution unchanged.
  - Added a regression test for the non-nsjail `//nobundling` path where `@langchain/core` requires `zod/v3`.

<sup>Written for commit d9c5ccfbc22f42013f18da452c4c52bc4dcfc319. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

