### PR TITLE
perf(dynselect): only retrigger when helper args actually change

### DIFF
--- a/frontend/src/lib/components/DynamicInput.svelte
+++ b/frontend/src/lib/components/DynamicInput.svelte
@@ -22,10 +22,10 @@
 	import { safeSelectItems } from './select/utils.svelte'
 	import Tooltip from './Tooltip.svelte'
 	import { Loader2 } from 'lucide-svelte'
-	import { emptySchema, type DynamicInput } from '$lib/utils'
+	import { type DynamicInput } from '$lib/utils'
 	import { deepEqual } from 'fast-equals'
 	import { untrack } from 'svelte'
-	import { inferArgs } from '$lib/infer'
+	import { parseEntrypointArgs } from '$lib/infer'
 
 	interface Props {
 		value?: any
@@ -130,26 +130,21 @@
 
 	// Parameter names declared by the helper function. When known, we restrict
 	// the change-detection to only those keys so typing in unrelated form fields
-	// no longer retriggers the dynselect job.
+	// no longer retriggers the dynselect job. `undefined` means we couldn't
+	// determine the signature → fall back to a full-args comparison.
 	let helperParams = $state<Set<string> | undefined>(undefined)
 
 	$effect(() => {
 		const script = helperScript
 		const ep = entrypoint
-		helperParams = undefined
-		if (!script || script.source !== 'inline') return
+		if (!script || script.source !== 'inline') {
+			helperParams = undefined
+			return
+		}
 		let cancelled = false
-		;(async () => {
-			try {
-				const schema = emptySchema()
-				await inferArgs(script.lang, script.code, schema, ep || undefined)
-				if (!cancelled) {
-					helperParams = new Set(Object.keys(schema.properties ?? {}))
-				}
-			} catch {
-				if (!cancelled) helperParams = undefined
-			}
-		})()
+		void parseEntrypointArgs(script.lang, script.code, ep || undefined).then((params) => {
+			if (!cancelled) helperParams = params
+		})
 		return () => {
 			cancelled = true
 		}

--- a/frontend/src/lib/components/DynamicInput.svelte
+++ b/frontend/src/lib/components/DynamicInput.svelte
@@ -49,7 +49,9 @@
 	})
 
 	let resultJobLoader: JobLoader | undefined = $state()
-	let _items = usePromise(getItemsFromOptions, { clearValueOnRefresh: false })
+	// loadInit:false — the $effect below owns the first refresh once
+	// resultJobLoader is bound; without this the promise is kicked off twice.
+	let _items = usePromise(getItemsFromOptions, { clearValueOnRefresh: false, loadInit: false })
 	let items = $derived(_items.value)
 
 	let filterText: string = $state('')

--- a/frontend/src/lib/components/DynamicInput.svelte
+++ b/frontend/src/lib/components/DynamicInput.svelte
@@ -22,9 +22,10 @@
 	import { safeSelectItems } from './select/utils.svelte'
 	import Tooltip from './Tooltip.svelte'
 	import { Loader2 } from 'lucide-svelte'
-	import { type DynamicInput } from '$lib/utils'
+	import { emptySchema, type DynamicInput } from '$lib/utils'
 	import { deepEqual } from 'fast-equals'
 	import { untrack } from 'svelte'
+	import { inferArgs } from '$lib/infer'
 
 	interface Props {
 		value?: any
@@ -125,9 +126,48 @@
 		}, 1000)
 	})
 
+	// Parameter names declared by the helper function. When known, we restrict
+	// the change-detection to only those keys so typing in unrelated form fields
+	// no longer retriggers the dynselect job.
+	let helperParams = $state<Set<string> | undefined>(undefined)
+
+	$effect(() => {
+		const script = helperScript
+		const ep = entrypoint
+		helperParams = undefined
+		if (!script || script.source !== 'inline') return
+		let cancelled = false
+		;(async () => {
+			try {
+				const schema = emptySchema()
+				await inferArgs(script.lang, script.code, schema, ep || undefined)
+				if (!cancelled) {
+					helperParams = new Set(Object.keys(schema.properties ?? {}))
+				}
+			} catch {
+				if (!cancelled) helperParams = undefined
+			}
+		})()
+		return () => {
+			cancelled = true
+		}
+	})
+
+	function filterArgs(args: Record<string, any> | undefined) {
+		if (!args || !helperParams) return args
+		const filtered: Record<string, any> = {}
+		for (const k of helperParams) {
+			if (k in args) filtered[k] = args[k]
+		}
+		return filtered
+	}
+
 	$effect(() => {
 		;[filterText, entrypoint, helperScript]
-		if (resultJobLoader && (open || neverLoaded || !deepEqual(lastArgs, nargs))) {
+		if (
+			resultJobLoader &&
+			(open || neverLoaded || !deepEqual(filterArgs(lastArgs), filterArgs(nargs)))
+		) {
 			neverLoaded = false
 			lastArgs = $state.snapshot(otherArgs)
 			_items.refresh()

--- a/frontend/src/lib/components/DynamicInput.svelte
+++ b/frontend/src/lib/components/DynamicInput.svelte
@@ -25,7 +25,7 @@
 	import { type DynamicInput } from '$lib/utils'
 	import { deepEqual } from 'fast-equals'
 	import { untrack } from 'svelte'
-	import { parseEntrypointArgs } from '$lib/infer'
+	import { getHelperEntrypointArgs } from '$lib/infer'
 
 	interface Props {
 		value?: any
@@ -137,12 +137,12 @@
 	$effect(() => {
 		const script = helperScript
 		const ep = entrypoint
-		if (!script || script.source !== 'inline') {
+		if (!script) {
 			helperParams = undefined
 			return
 		}
 		let cancelled = false
-		void parseEntrypointArgs(script.lang, script.code, ep || undefined).then((params) => {
+		void getHelperEntrypointArgs(script, ep || undefined).then((params) => {
 			if (!cancelled) helperParams = params
 		})
 		return () => {

--- a/frontend/src/lib/infer.ts
+++ b/frontend/src/lib/infer.ts
@@ -7,7 +7,13 @@ import {
 } from '$lib/gen'
 import { get, writable } from 'svelte/store'
 import type { Schema, SupportedLanguage } from './common.js'
-import { emptySchema, getHubFlowIdFromPath, isHubFlowPath, sortObject } from './utils.js'
+import {
+	type DynamicInput,
+	emptySchema,
+	getHubFlowIdFromPath,
+	isHubFlowPath,
+	sortObject
+} from './utils.js'
 import { tick } from 'svelte'
 
 import initTsParser, { parse_deno, parse_outputs } from 'windmill-parser-wasm-ts'
@@ -323,6 +329,45 @@ export async function parseEntrypointArgs(
 	} catch {
 		return undefined
 	}
+}
+
+const helperEntrypointCache = new Map<string, Set<string> | undefined>()
+
+/**
+ * Resolves a {@link DynamicInput.HelperScript} to its entrypoint parameter
+ * names. For deployed helpers it fetches the script (or the flow's inline
+ * dyn-select code) once and caches the result per workspace+path+entrypoint.
+ */
+export async function getHelperEntrypointArgs(
+	helper: DynamicInput.HelperScript,
+	entrypoint?: string
+): Promise<Set<string> | undefined> {
+	if (helper.source === 'inline') {
+		return parseEntrypointArgs(helper.lang, helper.code, entrypoint)
+	}
+	const workspace = get(workspaceStore)
+	if (!workspace) return undefined
+	const cacheKey = `${workspace}::${helper.runnable_kind}::${helper.path}::${entrypoint ?? ''}`
+	if (helperEntrypointCache.has(cacheKey)) return helperEntrypointCache.get(cacheKey)
+	let result: Set<string> | undefined
+	try {
+		if (helper.runnable_kind === 'script') {
+			const script = await ScriptService.getScriptByPath({ workspace, path: helper.path })
+			result = await parseEntrypointArgs(script.language, script.content ?? '', entrypoint)
+		} else {
+			const flow = await FlowService.getFlowByPath({ workspace, path: helper.path })
+			const schema = flow.schema as Record<string, unknown> | undefined
+			const code = schema?.['x-windmill-dyn-select-code']
+			const lang = schema?.['x-windmill-dyn-select-lang']
+			if (typeof code === 'string' && typeof lang === 'string') {
+				result = await parseEntrypointArgs(lang as SupportedLanguage, code, entrypoint)
+			}
+		}
+	} catch {
+		result = undefined
+	}
+	helperEntrypointCache.set(cacheKey, result)
+	return result
 }
 
 export async function inferArgs(

--- a/frontend/src/lib/infer.ts
+++ b/frontend/src/lib/infer.ts
@@ -286,6 +286,45 @@ const SQL_LANGUAGES = [
 	'duckdb'
 ]
 
+/**
+ * Returns the parameter names of `entrypoint` in `code` (or `main` if not given),
+ * or `undefined` if the function can't be found, the code can't be parsed, the
+ * language isn't supported here, or the signature contains rest/keyword args
+ * (in which case the callee should fall back to a conservative full comparison).
+ *
+ * Lighter than {@link inferArgs} — does not touch any schema.
+ */
+export async function parseEntrypointArgs(
+	language: SupportedLanguage | 'bunnative' | undefined,
+	code: string,
+	entrypoint?: string
+): Promise<Set<string> | undefined> {
+	if (!code) return undefined
+	try {
+		let sig: MainArgSignature
+		if (language === 'python3') {
+			await initWasmPython()
+			sig = JSON.parse(parse_python(code, entrypoint))
+		} else if (
+			language === 'deno' ||
+			language === 'nativets' ||
+			language === 'bun' ||
+			language === 'bunnative'
+		) {
+			await initWasmTs()
+			sig = JSON.parse(parse_deno(code, entrypoint))
+		} else {
+			return undefined
+		}
+		if (sig.type === 'Invalid') return undefined
+		if (sig.star_args || sig.star_kwargs) return undefined
+		if (!Array.isArray(sig.args) || sig.args.length === 0) return undefined
+		return new Set(sig.args.map((a) => a.name))
+	} catch {
+		return undefined
+	}
+}
+
 export async function inferArgs(
 	language: SupportedLanguage | 'bunnative' | undefined,
 	code: string,

--- a/frontend/src/lib/infer.ts
+++ b/frontend/src/lib/infer.ts
@@ -324,7 +324,11 @@ export async function parseEntrypointArgs(
 		}
 		if (sig.type === 'Invalid') return undefined
 		if (sig.star_args || sig.star_kwargs) return undefined
-		if (!Array.isArray(sig.args) || sig.args.length === 0) return undefined
+		if (!Array.isArray(sig.args)) return undefined
+		// The parser sets auto_kind when no matching entrypoint function was
+		// found — empty args in that case means "unknown signature", not
+		// "function takes no params", so we fall back to a full comparison.
+		if (sig.args.length === 0 && sig.auto_kind != null) return undefined
 		return new Set(sig.args.map((a) => a.name))
 	} catch {
 		return undefined


### PR DESCRIPTION
## Summary

- **Smart retrigger** — `DynamicInput.svelte` now parses the helper's entrypoint signature with the existing WASM parsers and restricts the change-detection to keys the helper actually consumes. Typing into unrelated form fields no longer queues a dynselect job every second. Falls back to the previous full-args comparison whenever the signature can't be determined (parse error, `*args`/`**kwargs`, function not found, unsupported language).
- **Deployed helpers supported** — new `getHelperEntrypointArgs` in `infer.ts` dispatches on `HelperScript.source`: inline parses immediately; deployed fetches the script (or the flow's inline `x-windmill-dyn-select-code`) once and caches per `(workspace, kind, path, entrypoint)`.
- **Drive-by: double-call on mount** — `usePromise` defaulted to `loadInit: true`, so `refresh()` ran before the `JobLoader` child was bound (firing a no-op pending promise) and the `$effect` then fired a second `refresh()` once `bind:this` resolved. Pass `loadInit: false` so the effect owns the single first call.

## Test plan
- [ ] `/scripts/edit/u/admin/dynselect_smart` (helper `listCities(filterText, country)`): changing `country` retriggers; typing into `note` does not.
- [ ] `/scripts/edit/u/admin/dynselect_static` (helper `listFruits(filterText)`): typing into `name` does not retrigger; using the dropdown filter does.
- [ ] `/scripts/get/<hash>` for both scripts — same behavior as the edit view (deployed-helper code path).
- [ ] Edit the inline helper code in `EditableSchemaForm` — once a parse completes, the new param set takes effect with no flicker.
- [ ] Helper with a syntax error or `**kwargs` — falls back to the pre-existing full-args comparison.
- [ ] Open a dynselect input — verify exactly one backend job is queued on mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)