### PR TITLE
feat(frontend): change windmill logo color to violet

### DIFF
--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -1,15 +1,15 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="/logo.svg" />
 		<style type="text/css">
 			.st2 {
-				fill: #bcd4fc;
+				fill: #c4b5fd;
 			}
 
 			.st3 {
-				fill: #3b82f6;
+				fill: #8b5cf6;
 			}
 
 			/* Background color for dark mode */

--- a/frontend/src/lib/components/icons/WindmillIcon.svelte
+++ b/frontend/src/lib/components/icons/WindmillIcon.svelte
@@ -57,13 +57,13 @@
 				fill: #ffffff;
 			}
 			.st2 {
-				fill: #bcd4fc;
+				fill: #c4b5fd;
 			}
 			.st2-gray {
 				fill: #cccccc;
 			}
 			.st3 {
-				fill: #3b82f6;
+				fill: #8b5cf6;
 			}
 			.st4 {
 				fill: #b3b3b3;

--- a/frontend/src/lib/components/icons/WindmillIcon2.svelte
+++ b/frontend/src/lib/components/icons/WindmillIcon2.svelte
@@ -162,27 +162,27 @@
 		<g>
 			<!-- Use color or fallback to defaults (white or blue) -->
 			<polygon
-				fill={lessSaturatedColor || (white ? '#cccccc' : '#bcd4fc')}
+				fill={lessSaturatedColor || (white ? '#cccccc' : '#c4b5fd')}
 				points="134.78,14.22 114.31,48.21 101.33,69.75 158.22,69.75 177.97,36.95 191.67,14.22"
 			/>
 			<polygon
-				fill={color || (white ? '#ffffff' : '#3b82f6')}
+				fill={color || (white ? '#ffffff' : '#8b5cf6')}
 				points="227.55,69.75 186.61,69.75 101.33,69.75 129.78,119.02 158.16,119.02 228.61,119.02 256,119.02"
 			/>
 			<polygon
-				fill={color || (white ? '#ffffff' : '#3b82f6')}
+				fill={color || (white ? '#ffffff' : '#8b5cf6')}
 				points="136.93,132.47 116.46,167.93 73.82,241.78 130.71,241.78 144.9,217.2 180.13,156.18 193.82,132.46"
 			/>
 			<polygon
-				fill={color || (white ? '#ffffff' : '#3b82f6')}
+				fill={color || (white ? '#ffffff' : '#8b5cf6')}
 				points="121.7,131.95 101.23,96.49 58.59,22.63 30.15,71.91 44.34,96.49 79.57,157.5 93.26,181.22"
 			/>
 			<polygon
-				fill={lessSaturatedColor || (white ? '#cccccc' : '#bcd4fc')}
+				fill={lessSaturatedColor || (white ? '#cccccc' : '#c4b5fd')}
 				points="64.81,131.95 25.15,131.21 0,130.74 28.44,180.01 66.73,180.72 93.26,181.21"
 			/>
 			<polygon
-				fill={lessSaturatedColor || (white ? '#cccccc' : '#bcd4fc')}
+				fill={lessSaturatedColor || (white ? '#cccccc' : '#c4b5fd')}
 				points="165.38,181.74 184.58,216.46 196.75,238.47 225.19,189.2 206.66,155.69 193.83,132.46"
 			/>
 		</g>

--- a/frontend/static/logo.svg
+++ b/frontend/static/logo.svg
@@ -5,8 +5,8 @@
 <style type="text/css">
 	.st0{fill:#FFFFFF;}
 	.st1{opacity:0.4;fill:#FFFFFF;}
-	.st2{fill:#BCD4FC;}
-	.st3{fill:#3B82F6;}
+	.st2{fill:#C4B5FD;}
+	.st3{fill:#8B5CF6;}
 	.st4{fill:#B3B3B3;}
 	.st5{fill:url(#SVGID_1_);}
 	.st6{fill:url(#SVGID_00000021089067129159788970000008246765442136188072_);}


### PR DESCRIPTION
## Summary

- Swap the Windmill logo accent colors from blue to violet across all four logo surfaces.
- Primary fill: `#3B82F6` (blue-500) → `#8B5CF6` (violet-500)
- Secondary fill: `#BCD4FC` → `#C4B5FD` (violet-300) — matches the lightness of the original light-blue tone

Fixes WIN-1952

### Files changed
- `frontend/static/logo.svg` — the canonical asset, also used as the favicon (`app.html` `<link rel="icon">`) and as the default image in apps (`components.ts`).
- `frontend/src/lib/components/icons/WindmillIcon.svelte` — inline-SVG icon component.
- `frontend/src/lib/components/icons/WindmillIcon2.svelte` — alternate icon component (default fallback fills).
- `frontend/src/app.html` — inline loading-screen SVG and its CSS classes.

The `white` variants of both icon components are untouched — they remain white-on-white / gray-on-gray for use over the brand color.

### Notes
- No EE files reference the logo colors.
- Other `#3b82f6` usages in the codebase (audit-logs timeline, file-upload UI, tutorial inline icons) are unrelated to the logo and were intentionally left alone.

## Test plan

- [ ] Verify the favicon renders violet in the browser tab
- [ ] Verify the loading screen (visible briefly on first page load) shows the violet logo
- [ ] Verify the in-app sidebar / header `WindmillIcon` renders violet
- [ ] Verify the white variant (`white={true}`) still renders correctly (used on colored backgrounds)
- [ ] Confirm app-builder default image (`/logo.svg`) renders violet in the app editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Windmill logo accents from blue to violet across the app to match the updated brand. Primary `#3B82F6` → `#8B5CF6`, secondary `#BCD4FC` → `#C4B5FD`. Completes WIN-1952.

- **New Features**
  - Updated `frontend/static/logo.svg` (also used as favicon and default app image).
  - Updated `WindmillIcon.svelte` and `WindmillIcon2.svelte` fills; white variants unchanged.
  - Updated inline loading-screen SVG styles in `frontend/src/app.html`.

<sup>Written for commit e5deee8a206041896b116d5c7f63623d2846dd28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

