### PR TITLE
oauth: add docusign provider

### DIFF
--- a/backend/oauth_connect.json
+++ b/backend/oauth_connect.json
@@ -170,5 +170,12 @@
       "full_api_access"
     ],
     "extra_params": {}
+  },
+  "docusign": {
+    "auth_url": "https://account.docusign.com/oauth/auth",
+    "token_url": "https://account.docusign.com/oauth/token",
+    "scopes": [
+      "signature"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Adds the Docusign Authorization Code OAuth entry to `backend/oauth_connect.json` so users can connect a Docusign account through Windmill's OAuth flow.

Pairs with the integrations PR adding the Docusign integration to the Hub: windmill-labs/windmill-integrations#128

## Changes

```json
"docusign": {
  "auth_url": "https://account.docusign.com/oauth/auth",
  "token_url": "https://account.docusign.com/oauth/token",
  "scopes": ["signature"]
}
```

Endpoints are the **production** URLs (`account.docusign.com`). Operators who want to test against the Docusign developer sandbox can override locally to `account-d.docusign.com`.

`extra_params` and `req_body_auth` are omitted — Docusign accepts `Authorization: Basic` for the token exchange (verified against the demo endpoint during the integration's smoke test).

The `docusign` icon already exists in `frontend/src/lib/components/icons/index.ts` (`APP_TO_ICON_COMPONENT`), so no frontend changes are needed.

## Operator follow-up

Each Windmill instance still needs its own Docusign Integration Key + Secret registered with redirect URI `https://<instance>/oauth/callback/docusign`. Add the secret as `OAUTH_DOCUSIGN_CLIENT_ID` / `OAUTH_DOCUSIGN_CLIENT_SECRET` (or via the admin UI, depending on deployment).

## Test plan

- [ ] Code review of the OAuth entry
- [ ] Register a Docusign Integration Key on the test Windmill instance
- [ ] Verify "Connect Docusign" flow lands on the consent page and returns an access token
- [ ] Verify a Hub Docusign script (e.g. `list_envelopes`) runs with the resulting resource

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Docusign as an OAuth provider so users can connect their Docusign accounts via Windmill’s OAuth flow. Uses production endpoints with the `signature` scope and supports the Hub integration.

- **New Features**
  - Added `docusign` to `backend/oauth_connect.json` with `auth_url`, `token_url`, and `scopes: ["signature"]`.
  - Defaults to `account.docusign.com`; sandbox can override to `account-d.docusign.com`. Token exchange uses Basic auth (no extra params).

- **Migration**
  - Register a Docusign Integration Key and Secret with redirect URI `https://<instance>/oauth/callback/docusign`.
  - Set `OAUTH_DOCUSIGN_CLIENT_ID` and `OAUTH_DOCUSIGN_CLIENT_SECRET` (or configure via the admin UI).

<sup>Written for commit 9a78a1445d4e06e3e413747367cb46b4913b8218. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

