### PR TITLE
fix(mcp): sanitize and enrich nested resource schemas

### DIFF
--- a/backend/windmill-api/src/mcp/core.rs
+++ b/backend/windmill-api/src/mcp/core.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 use std::collections::HashMap;
 use windmill_common::{db::UserDB, utils::StripPath, DB};
+use windmill_mcp::common::schema::enrich_resource_schemas;
 use windmill_mcp::common::transform::apply_key_transformation;
 use windmill_mcp::common::types::{
     FlowInfo, HubScriptInfo, ResourceInfo, ResourceType, SchemaType, ScriptInfo,
@@ -203,71 +204,13 @@ impl McpBackend for WindmillBackend {
             schema_obj.properties.insert(new_key, value);
         }
 
-        for (_key, prop_value) in schema_obj.properties.iter_mut() {
-            if let Value::Object(prop_map) = prop_value {
-                if let Some(format_value) = prop_map.get("format") {
-                    if let Value::String(format_str) = format_value {
-                        if format_str.starts_with("resource-") {
-                            let resource_type_key =
-                                format_str.split("-").last().unwrap_or_default().to_string();
-                            let resource_type = resources_types
-                                .iter()
-                                .find(|rt| rt.name == resource_type_key);
-                            let resource_type_obj = resource_type.cloned();
-
-                            if let Some(resource_cache) = resources_cache.get(&resource_type_key) {
-                                let resources_count = resource_cache.len();
-                                let description = match resource_type_obj {
-                                    Some(resource_type_obj) => format!(
-                                        "This is a resource named `{}` with the following description: `{}`.\\nThe path of the resource should be used to specify the resource.\\n{}",
-                                        resource_type_obj.name,
-                                        resource_type_obj.description.as_deref().unwrap_or("No description"),
-                                        if resources_count == 0 {
-                                            "This resource does not have any available instances, you should create one from your windmill workspace."
-                                        } else if resources_count > 1 {
-                                            "This resource has multiple available instances, you should precisely select the one you want to use."
-                                        } else {
-                                            "There is 1 resource available."
-                                        }
-                                    ),
-                                    None => "An object parameter.".to_string(),
-                                };
-                                prop_map.insert(
-                                    "type".to_string(),
-                                    Value::String("string".to_string()),
-                                );
-                                prop_map
-                                    .insert("description".to_string(), Value::String(description));
-                                if resources_count > 0 {
-                                    let resources_description = resource_cache
-                                        .iter()
-                                        .map(|resource| {
-                                            format!(
-                                                "{}: $res:{}",
-                                                resource
-                                                    .description
-                                                    .as_deref()
-                                                    .unwrap_or("No title"),
-                                                resource.path
-                                            )
-                                        })
-                                        .collect::<Vec<String>>()
-                                        .join("\\n");
-
-                                    prop_map.insert(
-                                        "description".to_string(),
-                                        Value::String(format!(
-                                            "{}\\nHere are the available resources, in the format title:path. Title can be empty. Path should be used to specify the resource:\\n{}",
-                                            prop_map.get("description").unwrap_or(&Value::String("No description".to_string())),
-                                            resources_description
-                                        )),
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+        // Enrich every resource reference in the schema — including those
+        // inside `items`, nested `properties`, etc. — with a description
+        // listing the available resources. Both shapes are handled:
+        //   { type: "object", format: "resource-<name>" }   (top-level scalar)
+        //   { type: "resource", resourceType: "<name>" }    (inside list items)
+        for prop_value in schema_obj.properties.values_mut() {
+            enrich_resource_schemas(prop_value, resources_cache, resources_types);
         }
 
         schema_obj

--- a/backend/windmill-mcp/src/common/schema.rs
+++ b/backend/windmill-mcp/src/common/schema.rs
@@ -116,6 +116,17 @@ fn apply_resource_enrichment(
     };
     prop_map.insert("type".to_string(), Value::String("string".to_string()));
     prop_map.insert("description".to_string(), Value::String(description));
+    // Drop the Windmill-internal keys we just consumed so the node is clean
+    // regardless of whether `make_schema_compatible` runs after us. (Its strip
+    // only fires while `type == "resource"`, which is no longer true here.)
+    prop_map.remove("resourceType");
+    if prop_map
+        .get("format")
+        .and_then(Value::as_str)
+        .is_some_and(|s| s.starts_with("resource-"))
+    {
+        prop_map.remove("format");
+    }
     if resources_count > 0 {
         let resources_description = resource_cache
             .iter()
@@ -145,8 +156,8 @@ fn apply_resource_enrichment(
 
 /// Walk a schema and enrich every Windmill-resource reference (in either shape,
 /// at any nesting depth) with `type: "string"` and a description listing
-/// available resources. Leftover non-standard keys (`format: resource-*`,
-/// `resourceType`) are cleaned up by `make_schema_compatible` afterwards.
+/// available resources. The non-standard keys (`format: resource-*`,
+/// `resourceType`) consumed by the enrichment are stripped in place.
 pub fn enrich_resource_schemas(
     node: &mut Value,
     resources_cache: &HashMap<String, Vec<ResourceInfo>>,
@@ -702,6 +713,7 @@ mod tests {
         enrich_resource_schemas(&mut node, &cache, &types);
 
         assert_eq!(node["type"], json!("string"));
+        assert!(node.get("format").is_none());
         let desc = node["description"].as_str().unwrap();
         assert!(desc.contains("c_aws_account"));
         assert!(desc.contains("$res:f/platform/aws_dev"));
@@ -719,12 +731,12 @@ mod tests {
         enrich_resource_schemas(&mut node, &cache, &types);
 
         // The items schema should be rewritten to string with a description
-        // listing the available resources.
+        // listing the available resources, and the Windmill-internal
+        // resourceType key should be stripped.
         assert_eq!(node["items"]["type"], json!("string"));
+        assert!(node["items"].get("resourceType").is_none());
         let desc = node["items"]["description"].as_str().unwrap();
         assert!(desc.contains("$res:f/platform/aws_dev"));
-        // The Windmill-internal resourceType key is left behind — make_schema_compatible
-        // strips it afterwards.
     }
 
     #[test]

--- a/backend/windmill-mcp/src/common/schema.rs
+++ b/backend/windmill-mcp/src/common/schema.rs
@@ -2,11 +2,11 @@
 //!
 //! Contains functions for converting Windmill schemas into MCP-compatible formats.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
-use serde_json::Value;
+use serde_json::{Map, Value};
 
-use super::types::SchemaType;
+use super::types::{ResourceInfo, ResourceType, SchemaType};
 use windmill_common::scripts::Schema;
 
 /// Convert a Windmill Schema to a SchemaType
@@ -22,22 +22,164 @@ pub fn convert_schema_to_schema_type(schema: Option<Schema>) -> SchemaType {
     schema_obj
 }
 
-/// Extract resource type keys from a schema
-///
-/// Scans the schema properties for fields with format "resource-{type}"
-/// and returns a set of all unique resource type names found.
-pub fn extract_resource_types_from_schema(schema: &SchemaType) -> HashSet<String> {
-    let mut resource_types = HashSet::new();
-    for (_key, prop_value) in schema.properties.iter() {
-        if let Value::Object(prop_map) = prop_value {
-            if let Some(Value::String(format_str)) = prop_map.get("format") {
-                if let Some(rt) = format_str.strip_prefix("resource-") {
-                    resource_types.insert(rt.to_string());
-                }
+/// If `node` is a schema describing a Windmill resource reference, return the
+/// resource type name. Recognizes both on-disk shapes:
+///   - Form A (top-level scalar): `{ type: "object", format: "resource-<name>" }`
+///   - Form B (inside `items`):    `{ type: "resource", resourceType: "<name>" }`
+fn resource_type_of_schema_node(node: &Value) -> Option<String> {
+    let obj = node.as_object()?;
+    if let Some(Value::String(fmt)) = obj.get("format") {
+        if let Some(name) = fmt.strip_prefix("resource-") {
+            return Some(name.to_string());
+        }
+    }
+    if obj.get("type").and_then(Value::as_str) == Some("resource") {
+        if let Some(Value::String(name)) = obj.get("resourceType") {
+            return Some(name.clone());
+        }
+    }
+    None
+}
+
+/// Recursively collect resource type names referenced at any depth in `node`.
+fn collect_resource_types(node: &Value, out: &mut HashSet<String>) {
+    if let Some(rt) = resource_type_of_schema_node(node) {
+        out.insert(rt);
+    }
+    let Some(obj) = node.as_object() else { return };
+    if let Some(Value::Object(props)) = obj.get("properties") {
+        for v in props.values() {
+            collect_resource_types(v, out);
+        }
+    }
+    if let Some(items) = obj.get("items") {
+        collect_resource_types(items, out);
+    }
+    if let Some(additional) = obj.get("additionalProperties") {
+        if additional.is_object() {
+            collect_resource_types(additional, out);
+        }
+    }
+    for kw in ["allOf", "oneOf", "anyOf"] {
+        if let Some(Value::Array(arr)) = obj.get(kw) {
+            for s in arr {
+                collect_resource_types(s, out);
             }
         }
     }
+}
+
+/// Extract resource type keys referenced anywhere in a schema (top-level
+/// properties, nested objects, array items, additionalProperties, and
+/// allOf/oneOf/anyOf subschemas). Recognizes both the `format: resource-<name>`
+/// and `type: resource` + `resourceType` shapes.
+pub fn extract_resource_types_from_schema(schema: &SchemaType) -> HashSet<String> {
+    let mut resource_types = HashSet::new();
+    for prop_value in schema.properties.values() {
+        collect_resource_types(prop_value, &mut resource_types);
+    }
     resource_types
+}
+
+/// Rewrite a single schema node that points to a Windmill resource: set
+/// `type: "string"` and inject a description listing the available resources.
+/// Mirrors the top-level behavior that used to live in
+/// `transform_schema_for_resources`. No-op if the resource type isn't in the
+/// pre-fetched cache.
+fn apply_resource_enrichment(
+    prop_map: &mut Map<String, Value>,
+    resource_type_key: &str,
+    resources_cache: &HashMap<String, Vec<ResourceInfo>>,
+    resources_types: &[ResourceType],
+) {
+    let Some(resource_cache) = resources_cache.get(resource_type_key) else {
+        return;
+    };
+    let resource_type = resources_types
+        .iter()
+        .find(|rt| rt.name == resource_type_key);
+    let resources_count = resource_cache.len();
+    let description = match resource_type {
+        Some(rt) => format!(
+            "This is a resource named `{}` with the following description: `{}`.\\nThe path of the resource should be used to specify the resource.\\n{}",
+            rt.name,
+            rt.description.as_deref().unwrap_or("No description"),
+            if resources_count == 0 {
+                "This resource does not have any available instances, you should create one from your windmill workspace."
+            } else if resources_count > 1 {
+                "This resource has multiple available instances, you should precisely select the one you want to use."
+            } else {
+                "There is 1 resource available."
+            }
+        ),
+        None => "An object parameter.".to_string(),
+    };
+    prop_map.insert("type".to_string(), Value::String("string".to_string()));
+    prop_map.insert("description".to_string(), Value::String(description));
+    if resources_count > 0 {
+        let resources_description = resource_cache
+            .iter()
+            .map(|resource| {
+                format!(
+                    "{}: $res:{}",
+                    resource.description.as_deref().unwrap_or("No title"),
+                    resource.path
+                )
+            })
+            .collect::<Vec<String>>()
+            .join("\\n");
+        let prior_description = prop_map
+            .get("description")
+            .and_then(Value::as_str)
+            .unwrap_or("No description")
+            .to_string();
+        prop_map.insert(
+            "description".to_string(),
+            Value::String(format!(
+                "{}\\nHere are the available resources, in the format title:path. Title can be empty. Path should be used to specify the resource:\\n{}",
+                prior_description, resources_description
+            )),
+        );
+    }
+}
+
+/// Walk a schema and enrich every Windmill-resource reference (in either shape,
+/// at any nesting depth) with `type: "string"` and a description listing
+/// available resources. Leftover non-standard keys (`format: resource-*`,
+/// `resourceType`) are cleaned up by `make_schema_compatible` afterwards.
+pub fn enrich_resource_schemas(
+    node: &mut Value,
+    resources_cache: &HashMap<String, Vec<ResourceInfo>>,
+    resources_types: &[ResourceType],
+) {
+    if let Some(rt_key) = resource_type_of_schema_node(node) {
+        if let Value::Object(obj) = node {
+            apply_resource_enrichment(obj, &rt_key, resources_cache, resources_types);
+        }
+    }
+    let Some(obj) = node.as_object_mut() else {
+        return;
+    };
+    if let Some(Value::Object(props)) = obj.get_mut("properties") {
+        for v in props.values_mut() {
+            enrich_resource_schemas(v, resources_cache, resources_types);
+        }
+    }
+    if let Some(items) = obj.get_mut("items") {
+        enrich_resource_schemas(items, resources_cache, resources_types);
+    }
+    if let Some(additional) = obj.get_mut("additionalProperties") {
+        if additional.is_object() {
+            enrich_resource_schemas(additional, resources_cache, resources_types);
+        }
+    }
+    for kw in ["allOf", "oneOf", "anyOf"] {
+        if let Some(Value::Array(arr)) = obj.get_mut(kw) {
+            for s in arr.iter_mut() {
+                enrich_resource_schemas(s, resources_cache, resources_types);
+            }
+        }
+    }
 }
 
 /// Transform a JSON schema for maximum MCP client compatibility.
@@ -46,6 +188,7 @@ pub fn extract_resource_types_from_schema(schema: &SchemaType) -> HashSet<String
 /// - Converting `integer` type to `number` (some clients don't support integer)
 /// - Removing invalid non-array `enum` values
 /// - Stripping non-standard keywords (`originalType`, `format` with `resource-*` prefix)
+/// - Rewriting the Windmill pseudo-type `type: "resource"` to `type: "string"`
 /// - Fixing contradictory schemas (`type: "string"` with `properties` → `type: "object"`)
 /// - Removing `default: null` when the type doesn't include `null`
 /// - Adding `type: "object"` to empty schemas that have no type
@@ -62,6 +205,15 @@ pub fn make_schema_compatible(schema: &mut Value) {
         .is_some_and(|s| s.starts_with("resource-"))
     {
         obj.remove("format");
+    }
+
+    // 2b. Rewrite Windmill pseudo-type `resource` to `string`. The parser emits
+    // this shape (with a sibling `resourceType` key) for `list[ResourceType]`
+    // params; "resource" is not in the JSON Schema 2020-12 type enum and is
+    // rejected by strict validators (e.g. Anthropic's tool registration).
+    if obj.get("type").and_then(|v| v.as_str()) == Some("resource") {
+        obj.insert("type".to_string(), Value::String("string".to_string()));
+        obj.remove("resourceType");
     }
 
     // 3. Fix contradictory type: if `properties` is present, type must be "object"
@@ -151,8 +303,27 @@ pub fn make_schema_compatible(schema: &mut Value) {
 
 #[cfg(test)]
 mod tests {
-    use super::make_schema_compatible;
+    use super::*;
+    use crate::common::types::{ResourceInfo, ResourceType};
     use serde_json::json;
+    use std::collections::HashMap;
+
+    fn aws_resources() -> (HashMap<String, Vec<ResourceInfo>>, Vec<ResourceType>) {
+        let mut cache = HashMap::new();
+        cache.insert(
+            "c_aws_account".to_string(),
+            vec![ResourceInfo {
+                path: "f/platform/aws_dev".to_string(),
+                description: Some("Dev account".to_string()),
+                resource_type: "c_aws_account".to_string(),
+            }],
+        );
+        let types = vec![ResourceType {
+            name: "c_aws_account".to_string(),
+            description: Some("AWS account".to_string()),
+        }];
+        (cache, types)
+    }
 
     #[test]
     fn converts_nested_integer_types() {
@@ -357,6 +528,96 @@ mod tests {
     }
 
     #[test]
+    fn rewrites_resource_pseudo_type_to_string() {
+        let mut schema = json!({
+            "type": "resource",
+            "resourceType": "c_aws_account"
+        });
+
+        make_schema_compatible(&mut schema);
+
+        assert_eq!(schema["type"], json!("string"));
+        assert!(schema.get("resourceType").is_none());
+    }
+
+    #[test]
+    fn rewrites_resource_pseudo_type_inside_array_items() {
+        // Phocas repro: list[ResourceType] parameter. Anthropic rejected this
+        // with "tools.<N>.custom.input_schema: JSON schema is invalid" because
+        // "resource" is not in the draft 2020-12 type enum.
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "accounts": {
+                    "type": "array",
+                    "items": {
+                        "type": "resource",
+                        "resourceType": "c_aws_account"
+                    }
+                }
+            }
+        });
+
+        make_schema_compatible(&mut schema);
+
+        assert_eq!(
+            schema["properties"]["accounts"]["items"]["type"],
+            json!("string")
+        );
+        assert!(schema["properties"]["accounts"]["items"]
+            .get("resourceType")
+            .is_none());
+    }
+
+    #[test]
+    fn rewrites_resource_pseudo_type_inside_nested_properties() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "db": {
+                            "type": "resource",
+                            "resourceType": "postgresql"
+                        }
+                    }
+                }
+            }
+        });
+
+        make_schema_compatible(&mut schema);
+
+        assert_eq!(
+            schema["properties"]["config"]["properties"]["db"]["type"],
+            json!("string")
+        );
+        assert!(schema["properties"]["config"]["properties"]["db"]
+            .get("resourceType")
+            .is_none());
+    }
+
+    #[test]
+    fn strips_nested_resource_format_inside_array_items() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "dbs": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "format": "resource-postgresql"
+                    }
+                }
+            }
+        });
+
+        make_schema_compatible(&mut schema);
+
+        assert!(schema["properties"]["dbs"]["items"].get("format").is_none());
+    }
+
+    #[test]
     fn adds_type_to_schema_with_properties_but_no_type() {
         let mut schema = json!({
             "properties": {
@@ -367,5 +628,144 @@ mod tests {
         make_schema_compatible(&mut schema);
 
         assert_eq!(schema["type"], json!("object"));
+    }
+
+    #[test]
+    fn extract_resource_types_top_level_form_a() {
+        let schema: SchemaType = serde_json::from_value(json!({
+            "type": "object",
+            "properties": {
+                "db": { "type": "object", "format": "resource-postgresql" }
+            },
+            "required": []
+        }))
+        .unwrap();
+
+        let types = extract_resource_types_from_schema(&schema);
+        assert!(types.contains("postgresql"));
+        assert_eq!(types.len(), 1);
+    }
+
+    #[test]
+    fn extract_resource_types_inside_array_items_form_b() {
+        let schema: SchemaType = serde_json::from_value(json!({
+            "type": "object",
+            "properties": {
+                "accounts": {
+                    "type": "array",
+                    "items": { "type": "resource", "resourceType": "c_aws_account" }
+                }
+            },
+            "required": []
+        }))
+        .unwrap();
+
+        let types = extract_resource_types_from_schema(&schema);
+        assert!(types.contains("c_aws_account"));
+    }
+
+    #[test]
+    fn extract_resource_types_inside_nested_properties_and_one_of() {
+        let schema: SchemaType = serde_json::from_value(json!({
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "db": { "type": "resource", "resourceType": "postgresql" }
+                    }
+                },
+                "either": {
+                    "oneOf": [
+                        { "type": "object", "format": "resource-mysql" },
+                        { "type": "string" }
+                    ]
+                }
+            },
+            "required": []
+        }))
+        .unwrap();
+
+        let types = extract_resource_types_from_schema(&schema);
+        assert!(types.contains("postgresql"));
+        assert!(types.contains("mysql"));
+    }
+
+    #[test]
+    fn enrich_top_level_form_a_resource() {
+        let (cache, types) = aws_resources();
+        let mut node = json!({
+            "type": "object",
+            "format": "resource-c_aws_account"
+        });
+
+        enrich_resource_schemas(&mut node, &cache, &types);
+
+        assert_eq!(node["type"], json!("string"));
+        let desc = node["description"].as_str().unwrap();
+        assert!(desc.contains("c_aws_account"));
+        assert!(desc.contains("$res:f/platform/aws_dev"));
+    }
+
+    #[test]
+    fn enrich_inside_array_items_form_b() {
+        // Phocas repro: items use the parser-style `type: resource` form.
+        let (cache, types) = aws_resources();
+        let mut node = json!({
+            "type": "array",
+            "items": { "type": "resource", "resourceType": "c_aws_account" }
+        });
+
+        enrich_resource_schemas(&mut node, &cache, &types);
+
+        // The items schema should be rewritten to string with a description
+        // listing the available resources.
+        assert_eq!(node["items"]["type"], json!("string"));
+        let desc = node["items"]["description"].as_str().unwrap();
+        assert!(desc.contains("$res:f/platform/aws_dev"));
+        // The Windmill-internal resourceType key is left behind — make_schema_compatible
+        // strips it afterwards.
+    }
+
+    #[test]
+    fn enrich_is_noop_when_resource_type_not_in_cache() {
+        let mut node = json!({
+            "type": "object",
+            "format": "resource-unknown_type"
+        });
+        let before = node.clone();
+
+        enrich_resource_schemas(&mut node, &HashMap::new(), &[]);
+
+        assert_eq!(node, before);
+    }
+
+    #[test]
+    fn enrich_deeply_nested_resource() {
+        let (cache, types) = aws_resources();
+        let mut node = json!({
+            "type": "object",
+            "properties": {
+                "outer": {
+                    "type": "object",
+                    "properties": {
+                        "inner": {
+                            "type": "array",
+                            "items": {
+                                "type": "resource",
+                                "resourceType": "c_aws_account"
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        enrich_resource_schemas(&mut node, &cache, &types);
+
+        assert_eq!(
+            node["properties"]["outer"]["properties"]["inner"]["items"]["type"],
+            json!("string")
+        );
     }
 }

--- a/backend/windmill-mcp/src/common/schema.rs
+++ b/backend/windmill-mcp/src/common/schema.rs
@@ -206,8 +206,11 @@ pub fn enrich_resource_schemas(
 pub fn make_schema_compatible(schema: &mut Value) {
     let Value::Object(obj) = schema else { return };
 
-    // 1. Strip non-standard keywords that aren't part of JSON Schema
+    // 1. Strip non-standard keywords that aren't part of JSON Schema. The
+    // Windmill-internal `resourceType` is dropped unconditionally so it can't
+    // leak through even on enrichment cache-miss paths.
     obj.remove("originalType");
+    obj.remove("resourceType");
 
     // 2. Strip non-standard format values (resource-* is Windmill-internal)
     if obj
@@ -224,7 +227,6 @@ pub fn make_schema_compatible(schema: &mut Value) {
     // rejected by strict validators (e.g. Anthropic's tool registration).
     if obj.get("type").and_then(|v| v.as_str()) == Some("resource") {
         obj.insert("type".to_string(), Value::String("string".to_string()));
-        obj.remove("resourceType");
     }
 
     // 3. Fix contradictory type: if `properties` is present, type must be "object"


### PR DESCRIPTION
## Summary

Fixes an issue reported by Phocas: Anthropic rejected every Windmill MCP tool registration with `400 tools.<N>.custom.input_schema: JSON schema is invalid. It must match JSON Schema draft 2020-12.` whenever a script had a `list[ResourceType]` parameter (e.g. `accounts: list[c_aws_account]`).

The Windmill parser emits two different shapes for resource refs in script schemas:
- **Form A** (top-level scalar): `{ type: "object", format: "resource-<name>" }`
- **Form B** (inside list items): `{ type: "resource", resourceType: "<name>" }` — `"resource"` is **not** in the JSON Schema 2020-12 type enum, so strict validators (Anthropic's tool registration) reject it.

The MCP server's `make_schema_compatible` only handled Form A. The `transform_schema_for_resources` enrichment (which injects a description listing available `$res:<path>` values for the LLM) only walked the top-level `properties` map, so nested resource refs got no enrichment either.

## Changes

- `make_schema_compatible` now also rewrites `type: "resource"` → `type: "string"` and strips the sibling `resourceType` key.
- Extracted `resource_type_of_schema_node` helper that recognizes both Form A and Form B in one place.
- `extract_resource_types_from_schema` now recurses through `properties`, `items`, `additionalProperties`, and `allOf`/`oneOf`/`anyOf` so resource pre-fetch covers nested refs.
- Added `enrich_resource_schemas` — recursive walker that applies the existing top-level enrichment (set `type: "string"`, inject description listing available resources) at any depth and for both shapes. `transform_schema_for_resources` in `windmill-api/src/mcp/core.rs` now delegates to it; the top-level invalid-char key transformation is preserved unchanged.
- 8 new unit tests covering the Phocas repro (array-of-resource items), nested objects, `oneOf` branches, deep nesting, and cache-miss no-op.

## Example

A script param `accounts: list[c_aws_account]` (Form B inside `items`) now produces:

```json
{
  "accounts": {
    "type": "array",
    "items": {
      "type": "string",
      "description": "This is a resource named `c_aws_account` ... Here are the available resources ...\nDev account: $res:f/platform/aws_dev\nProd account: $res:f/platform/aws_prod"
    }
  }
}
```

The LLM is expected to fill `{ "accounts": ["$res:f/platform/aws_dev", ...] }`; the existing `$res:` resolution path then materializes the dicts before running the script.

## Test plan

- [ ] `cargo test -p windmill-mcp --lib common::schema` — 23 tests pass (8 new)
- [ ] Manual: expose a script with `accounts: list[c_aws_account]` via the MCP OAuth server to Claude Code; confirm tool registers without 400 and that Claude can pick resource paths from the description.
- [ ] Manual: existing top-level scalar resource refs still get their description listing available `$res:` paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic tool registration failures by making resource schemas valid JSON Schema 2020-12 and enriching them at any depth. Nested `list[ResourceType]` params now validate and show available `$res:` paths.

- **Bug Fixes**
  - Rewrite `type: "resource"` → `type: "string"`, strip `resourceType` unconditionally, and remove `format: resource-*` in the schema sanitizer.
  - Enrich resource refs recursively in `properties`, `items`, `additionalProperties`, and `allOf`/`oneOf`/`anyOf`, adding a description with available instances; also strip `resourceType`/`format` inline during enrichment.
  - Added `enrich_resource_schemas`; updated `extract_resource_types_from_schema` to recurse; centralized detection via `resource_type_of_schema_node`.
  - `windmill-api/src/mcp/core.rs` now delegates enrichment to `enrich_resource_schemas`.
  - New tests cover arrays of resources, nested objects, union branches, deep nesting, and no-op when cache is empty.

<sup>Written for commit b8de91b4d96142311b82d58596b5db8994c6ffae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

