### PR TITLE
test(nativets): cover deno_telemetry init contract + http trace export E2E

### DIFF
--- a/backend/windmill-runtime-nativets/tests/otel_e2e.rs
+++ b/backend/windmill-runtime-nativets/tests/otel_e2e.rs
@@ -1,0 +1,206 @@
+//! End-to-end coverage for the EE HTTP-tracing path on nativets.
+//!
+//! Pairs with `otel_init.rs` (which pins only the `OTEL_GLOBALS`
+//! population contract). This test exercises the full chain that
+//! actually delivers a span to a collector:
+//!
+//!   `deno_telemetry::init` with EE config (Rust)
+//!     → `globalThis.__bootstrapOtel()` (JS, flips TRACING_ENABLED)
+//!     → user `fetch()` → deno_fetch's `builtinTracer().startSpan`
+//!     → `BatchSpanProcessor` → `HttpExporter` (OTLP/HTTP-binary)
+//!     → our mock OTLP listener captures the request bytes
+//!
+//! Without the v1.702.0 fix (#573 EE / #9163 OSS), the third arrow
+//! panics in a tokio worker. With the fix in place, the span is
+//! emitted and shows up at the listener — which is what the customer
+//! is paying for when they enable HTTP tracing on nativets.
+//!
+//! `#[ignore]`'d: spins a V8 isolate (~seconds) and binds two TCP
+//! listeners. Run with `cargo test -p windmill-runtime-nativets
+//! --test otel_e2e -- --ignored`.
+//!
+//! Owns its own test binary so `OTEL_GLOBALS`'s `OnceCell` doesn't
+//! race with `otel_init.rs`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+
+use windmill_runtime_nativets::{deno_telemetry, transpile_ts, NativeAnnotation, PrewarmedIsolate};
+
+/// Bind 127.0.0.1:0 and spawn an accept loop. Each connection is
+/// read until idle/EOF, the body is appended to `captured`, then we
+/// respond with HTTP 200. Returns the bound port.
+async fn spawn_capturing_http(captured: Arc<Mutex<Vec<Vec<u8>>>>) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                break;
+            };
+            let captured = captured.clone();
+            tokio::spawn(async move {
+                let mut buf = Vec::new();
+                let mut tmp = [0u8; 8192];
+                let _ = tokio::time::timeout(Duration::from_millis(300), async {
+                    loop {
+                        match sock.read(&mut tmp).await {
+                            Ok(0) | Err(_) => break,
+                            Ok(n) => buf.extend_from_slice(&tmp[..n]),
+                        }
+                    }
+                })
+                .await;
+                let _ = sock
+                    .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                    .await;
+                captured.lock().await.push(buf);
+            });
+        }
+    });
+    port
+}
+
+/// Initialize `deno_telemetry` with the exact `OtelConfig` shape that
+/// the EE `load_internal_otel_exporter` ships in production. Keeps
+/// this test in lockstep with the actual call site: if production
+/// drifts away from `tracing_enabled + Capture`, this test breaks
+/// before the customer-facing panic does.
+fn init_with_ee_otel_config() {
+    deno_telemetry::init(
+        deno_telemetry::OtelRuntimeConfig {
+            runtime_name: "windmill-nativets".into(),
+            runtime_version: "0".into(),
+        },
+        deno_telemetry::OtelConfig {
+            tracing_enabled: true,
+            console: deno_telemetry::OtelConsoleConfig::Capture,
+            ..Default::default()
+        },
+    )
+    .expect("deno_telemetry init failed");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "spins V8 + tcp listeners; run with --ignored"]
+async fn fetch_after_init_otel_emits_span_to_collector() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    // 1. Stand up two listeners: one that pretends to be the user's
+    //    fetch target, one that pretends to be the OTLP collector.
+    let fetch_hits: Arc<Mutex<Vec<Vec<u8>>>> = Arc::new(Mutex::new(Vec::new()));
+    let otlp_hits: Arc<Mutex<Vec<Vec<u8>>>> = Arc::new(Mutex::new(Vec::new()));
+    let fetch_port = spawn_capturing_http(fetch_hits.clone()).await;
+    let otlp_port = spawn_capturing_http(otlp_hits.clone()).await;
+
+    // 2. Point the deno_telemetry exporter at the mock collector and
+    //    initialize. Mirrors `load_internal_otel_exporter` in EE.
+    //
+    // SAFETY: test runs in its own process binary; no other thread
+    // reads OTEL_EXPORTER_OTLP_ENDPOINT before init returns.
+    unsafe {
+        std::env::set_var(
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            format!("http://127.0.0.1:{otlp_port}"),
+        );
+    }
+    init_with_ee_otel_config();
+    assert!(
+        deno_telemetry::OTEL_GLOBALS.get().is_some(),
+        "OTEL_GLOBALS missing — load_internal_otel_exporter's config regressed?"
+    );
+
+    // 3. Run user TS that bootstraps OTel and then issues a fetch
+    //    at the mock target. `__bootstrapOtel` is fire-and-forget
+    //    (resolves a dynamic import on the microtask queue); the
+    //    `setTimeout` loop yields a few times so the import resolves
+    //    and the `TRACING_ENABLED` flag is set before fetch runs.
+    let ts = format!(
+        r#"
+declare const globalThis: any;
+export async function main(): Promise<number> {{
+    globalThis.__bootstrapOtel();
+    // Yield multiple microtask + timer turns so the dynamic import
+    // in __bootstrapOtel resolves and TRACING_ENABLED flips before
+    // fetch runs (otherwise deno_fetch skips the span entirely).
+    for (let i = 0; i < 5; i++) {{
+        await new Promise<void>(r => setTimeout(r, 10));
+    }}
+    const resp = await fetch("http://127.0.0.1:{fetch_port}/probe");
+    return resp.status;
+}}
+"#
+    );
+    let js = transpile_ts(ts).expect("transpile failed");
+    let ann = NativeAnnotation { useragent: None, proxy: None };
+
+    let mut iso = PrewarmedIsolate::spawn(String::new(), js, ann, vec![], None);
+    iso.wait_ready().await.expect("isolate failed to pre-warm");
+    let res = iso
+        .start_execution("{}".to_string())
+        .wait()
+        .await
+        .expect("isolate panicked");
+
+    // The exact bug: pre-fix, fetch panics this isolate. Post-fix,
+    // we get back the mock target's 200.
+    let raw = res.result.expect("user script returned an error");
+    assert_eq!(raw.get(), "200", "fetch should return mock target status");
+
+    assert_eq!(
+        fetch_hits.lock().await.len(),
+        1,
+        "fetch target should have been hit exactly once"
+    );
+
+    // 4. Force the BatchSpanProcessor to flush so the exporter posts
+    //    to our mock collector synchronously (default flush interval
+    //    is ~5s; tests can't wait that long).
+    deno_telemetry::flush();
+    // Exporter is async over the OTel runtime; give it a beat to
+    // actually send the HTTP request.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let otlp_captured = otlp_hits.lock().await;
+    assert!(
+        !otlp_captured.is_empty(),
+        "OTLP collector should have received at least one export — \
+         spans aren't reaching the collector after init"
+    );
+
+    // Verify the export carries our fetch span. OTLP is protobuf, so
+    // grep the raw bytes for OTel HTTP semantic-convention markers
+    // that deno_fetch's auto-instrumentation attaches:
+    //   - the target URL ("url.full" attribute)
+    //   - "http.request.method" attribute
+    let combined: Vec<u8> = otlp_captured.iter().flatten().copied().collect();
+    let bytes_contain = |needle: &[u8]| combined.windows(needle.len()).any(|w| w == needle);
+
+    let url_marker = format!("http://127.0.0.1:{fetch_port}/probe");
+    let has_url = bytes_contain(url_marker.as_bytes());
+    let has_method_attr = bytes_contain(b"http.request.method");
+
+    if !(has_url && has_method_attr) {
+        eprintln!(
+            "OTLP bytes ({}): {:?}",
+            combined.len(),
+            String::from_utf8_lossy(&combined)
+        );
+    }
+
+    assert!(
+        has_url,
+        "exported OTLP body should reference the fetched URL ({}); got {} bytes",
+        url_marker,
+        combined.len()
+    );
+    assert!(
+        has_method_attr,
+        "exported OTLP body should carry HTTP semconv attributes (http.request.method); got {} bytes",
+        combined.len()
+    );
+}

--- a/backend/windmill-runtime-nativets/tests/otel_init.rs
+++ b/backend/windmill-runtime-nativets/tests/otel_init.rs
@@ -1,0 +1,88 @@
+//! Regression test for the deno_telemetry 0.31 nativets-fetch panic.
+//!
+//! Setup: when EE's `load_internal_otel_exporter` runs (HTTP tracing
+//! enabled), it calls `deno_telemetry::init` and then flips
+//! `DENO_OTEL_INITIALIZED=true` so `js_eval` will run
+//! `globalThis.__bootstrapOtel()` inside the nativets JsRuntime. That
+//! bootstrap unconditionally sets JS-side `TRACING_ENABLED=true`, which
+//! makes `deno_fetch`'s `fetch()` call `builtinTracer().startSpan(...)`
+//! — and `OtelTracer::builtin()` does `OTEL_GLOBALS.get().unwrap()`.
+//!
+//! In deno_telemetry 0.31, `init` was given an early-return guard: if
+//! `tracing_enabled`, `metrics_enabled`, and `console` are all
+//! off/Ignore, it returns `Ok(())` *without populating OTEL_GLOBALS*.
+//! v1.700.0 was passing `OtelConfig::default()` (all off) — so the JS
+//! bootstrap proceeded but the Rust-side OnceCell was empty, and the
+//! first `fetch()` panicked the tokio worker in a context that cannot
+//! unwind. Fixed in v1.702.0 by passing `tracing_enabled: true` +
+//! `console: Capture` from `load_internal_otel_exporter` (PRs #573 EE
+//! / #9163 OSS), matching the JS bootstrap shape `[1, 0, 1, 0]`.
+//!
+//! This test pins that contract directly against `deno_telemetry::
+//! init` — the function the EE call site invokes — so the next time
+//! the dep is bumped and someone is tempted to "simplify" the config
+//! back to `OtelConfig::default()`, CI catches it.
+//!
+//! Lives in `tests/` (not `src/`) so it gets its own test binary and
+//! its own process — `OTEL_GLOBALS` is a `OnceCell`, so sharing it
+//! with the smoke tests in `src/smoke_tests.rs` would race.
+
+use windmill_runtime_nativets::deno_telemetry;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ee_otel_init_config_populates_otel_globals() {
+    // deno_telemetry::init builds an HttpExporter (uses rustls) — it
+    // needs a process-wide CryptoProvider, which the real binary
+    // installs in setup_deno_runtime / main. Mirror that here.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    // Pre-condition: nothing else in this test binary has touched the
+    // OnceCell, so it must be empty.
+    assert!(
+        deno_telemetry::OTEL_GLOBALS.get().is_none(),
+        "OTEL_GLOBALS must start empty in a fresh test process"
+    );
+
+    // Step 1: reproduce the footgun. `OtelConfig::default()` has
+    // tracing/metrics off and `console = Ignore`, which trips the
+    // 0.31 early-return — Ok(()) but OnceCell stays empty.
+    deno_telemetry::init(
+        deno_telemetry::OtelRuntimeConfig {
+            runtime_name: "windmill-nativets-test".into(),
+            runtime_version: "0".into(),
+        },
+        deno_telemetry::OtelConfig::default(),
+    )
+    .expect("init with default config returns Ok (early-return)");
+
+    assert!(
+        deno_telemetry::OTEL_GLOBALS.get().is_none(),
+        "deno_telemetry 0.31 contract: init with all-disabled config \
+         must NOT populate OTEL_GLOBALS — if this changes on a future \
+         bump, load_internal_otel_exporter can drop the explicit \
+         tracing_enabled/console fields."
+    );
+
+    // Step 2: re-call init with the exact config shape that the EE
+    // `load_internal_otel_exporter` ships — this is what production
+    // hits, so the test exercises the actual prod call path.
+    deno_telemetry::init(
+        deno_telemetry::OtelRuntimeConfig {
+            runtime_name: "windmill-nativets".into(),
+            runtime_version: "0".into(),
+        },
+        deno_telemetry::OtelConfig {
+            tracing_enabled: true,
+            console: deno_telemetry::OtelConsoleConfig::Capture,
+            ..Default::default()
+        },
+    )
+    .expect("init with tracing_enabled config must succeed on a fresh OnceCell");
+
+    assert!(
+        deno_telemetry::OTEL_GLOBALS.get().is_some(),
+        "load_internal_otel_exporter's OtelConfig must populate \
+         OTEL_GLOBALS so OtelTracer::builtin() does not panic on \
+         .unwrap() once __bootstrapOtel flips JS-side TRACING_ENABLED"
+    );
+}


### PR DESCRIPTION
## Summary

Tests-only follow-up to the deno_telemetry 0.31 nativets-fetch panic fix that landed in #9163 (OSS) / windmill-ee-private#573 (EE). The fix itself is already on `main`, but neither PR added integration coverage — the next deno_telemetry bump could regress the same way and we'd only learn about it from a customer.

These two tests pin the contract directly against `deno_telemetry::init` so CI catches it at the source.

**Bug recap.** In v1.700.0 the `deno_telemetry` bump (0.12 → 0.31) added an early-return to `init`: passing `OtelConfig::default()` returns `Ok(())` without populating `OTEL_GLOBALS`. EE's `load_internal_otel_exporter` was passing exactly that default and then setting `DENO_OTEL_INITIALIZED=true`, so the nativets JS bootstrap flipped `TRACING_ENABLED=true` while the Rust-side OnceCell stayed empty. Every subsequent user `fetch()` hit `OtelTracer::builtin()` → `OTEL_GLOBALS.get().unwrap()` → panic in a tokio worker that cannot unwind. v1.702.0 fixed it by passing `tracing_enabled: true` + `console: Capture` (matching the JS bootstrap `[1, 0, 1, 0]`).

## Changes

- `backend/windmill-runtime-nativets/tests/otel_init.rs` — contract test (non-ignored, runs on every CI). Demonstrates that `deno_telemetry::init(rt_config, OtelConfig::default())` returns `Ok(())` without populating `OTEL_GLOBALS` (the 0.31 footgun), and that the actual EE production config (`tracing_enabled + Capture`) does populate it. A future "simplification" back to the default that would re-introduce the panic will fail CI before reaching the customer.

- `backend/windmill-runtime-nativets/tests/otel_e2e.rs` — end-to-end test (`#[ignore]`'d; spins V8 + tcp listeners). Stands up a mock OTLP collector and a mock fetch target, calls `deno_telemetry::init` with the EE config, spawns a nativets isolate that runs `__bootstrapOtel()` + `fetch(...)`, flushes, and asserts the OTLP collector received an export carrying `http.request.method` plus the fetched URL. Covers the full chain `init → JS bootstrap → fetch → BatchSpanProcessor → HttpExporter → OTLP listener`.

Each test lives in its own `tests/` binary so the `OTEL_GLOBALS` `OnceCell` doesn't race with the smoke tests in `src/smoke_tests.rs`.

## Test plan

- [x] `cargo test -p windmill-runtime-nativets --test otel_init` — passes against current `main`.
- [x] `cargo test -p windmill-runtime-nativets --test otel_e2e -- --ignored` — passes against current `main`; OTLP collector receives an export with `http.request.method = GET`, `url.full = http://127.0.0.1:<port>/probe`, `http.response.status_code = 200`.
- [x] Verified `otel_init.rs` fails when `load_internal_otel_exporter` is reverted to `OtelConfig::default()` (the v1.700.x bug shape).