### PR TITLE
fix: never mark failure/trigger/approval scripts as auto_kind=lib

### DIFF
--- a/backend/migrations/20260514130526_fix_auto_kind_lib_for_runnable_script_kinds.down.sql
+++ b/backend/migrations/20260514130526_fix_auto_kind_lib_for_runnable_script_kinds.down.sql
@@ -1,0 +1,3 @@
+-- No-op: clearing a stray `auto_kind = 'lib'` value on failure/trigger/approval
+-- scripts is not reversible (the original NULL/'lib' distinction is lost), and
+-- restoring `'lib'` here would re-hide these scripts from their pickers.

--- a/backend/migrations/20260514130526_fix_auto_kind_lib_for_runnable_script_kinds.up.sql
+++ b/backend/migrations/20260514130526_fix_auto_kind_lib_for_runnable_script_kinds.up.sql
@@ -1,0 +1,9 @@
+-- Failure, Trigger, and Approval scripts are runnable entrypoints by
+-- definition. A prior parser regression occasionally classified them as
+-- `auto_kind = 'lib'`, which hid them from the flow error-handler /
+-- trigger / approval pickers. Clear those stray values so existing
+-- affected scripts re-appear without requiring a redeploy.
+UPDATE script
+SET auto_kind = NULL
+WHERE auto_kind = 'lib'
+  AND kind IN ('failure', 'trigger', 'approval');

--- a/backend/tests/script_auto_kind_failure.rs
+++ b/backend/tests/script_auto_kind_failure.rs
@@ -1,0 +1,122 @@
+use std::collections::HashMap;
+
+use sqlx::{Pool, Postgres};
+use windmill_api_client::types::{NewScript, ScriptLang};
+use windmill_test_utils::init_client;
+
+fn quick_ns(content: &str, path: &str, kind: Option<&str>) -> NewScript {
+    NewScript {
+        content: content.into(),
+        language: ScriptLang::Bun,
+        lock: None,
+        parent_hash: None,
+        path: path.into(),
+        concurrent_limit: None,
+        concurrency_time_window_s: None,
+        cache_ttl: None,
+        dedicated_worker: None,
+        description: "".to_string(),
+        draft_only: None,
+        envs: vec![],
+        is_template: None,
+        kind: kind.map(|s| s.to_string()),
+        summary: "".to_string(),
+        tag: None,
+        schema: HashMap::new(),
+        ws_error_handler_muted: Some(false),
+        priority: None,
+        delete_after_secs: None,
+        timeout: None,
+        restart_unless_cancelled: None,
+        deployment_message: None,
+        concurrency_key: None,
+        visible_to_runner_only: None,
+        auto_kind: None,
+        codebase: None,
+        has_preprocessor: None,
+        on_behalf_of_email: None,
+        assets: vec![],
+        modules: None,
+    }
+}
+
+/// Regression: a `failure`-kind script must never be marked `auto_kind = 'lib'`
+/// even if the parser fails to detect a `main` function, because the flow
+/// error-handler picker filters out lib scripts and would otherwise hide it.
+#[sqlx::test(fixtures("base"))]
+async fn failure_kind_script_without_main_is_not_marked_lib(
+    db: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    let (client, _port, _s) = init_client(db.clone()).await;
+
+    // Content with no `main` — TS parser would normally set auto_kind = 'lib'.
+    client
+        .create_script(
+            "test-workspace",
+            &quick_ns(
+                "export function notMain() { return 42 }",
+                "u/test-user/failure_no_main",
+                Some("failure"),
+            ),
+        )
+        .await
+        .unwrap();
+
+    let auto_kind: Option<String> = sqlx::query_scalar(
+        "SELECT auto_kind FROM script \
+         WHERE workspace_id = $1 AND path = $2",
+    )
+    .bind("test-workspace")
+    .bind("u/test-user/failure_no_main")
+    .fetch_one(&db)
+    .await?;
+
+    assert_ne!(
+        auto_kind.as_deref(),
+        Some("lib"),
+        "failure-kind script must not be marked as 'lib' auto_kind, got {:?}",
+        auto_kind
+    );
+
+    Ok(())
+}
+
+/// Sibling: a normal `script` kind WITHOUT main should still be marked `lib`
+/// (so it stays hidden from the regular script picker). Guards against an
+/// over-broad sanitizer accidentally clearing the value for plain scripts.
+#[sqlx::test(fixtures("base"))]
+async fn regular_script_without_main_is_still_marked_lib(
+    db: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    let (client, _port, _s) = init_client(db.clone()).await;
+
+    client
+        .create_script(
+            "test-workspace",
+            &quick_ns(
+                "export function notMain() { return 42 }",
+                "u/test-user/script_no_main",
+                Some("script"),
+            ),
+        )
+        .await
+        .unwrap();
+
+    let auto_kind: Option<String> = sqlx::query_scalar(
+        "SELECT auto_kind FROM script \
+         WHERE workspace_id = $1 AND path = $2",
+    )
+    .bind("test-workspace")
+    .bind("u/test-user/script_no_main")
+    .fetch_one(&db)
+    .await?;
+
+    assert_eq!(
+        auto_kind.as_deref(),
+        Some("lib"),
+        "regular script without main should be marked 'lib', got {:?}",
+        auto_kind
+    );
+
+    Ok(())
+}

--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -1214,6 +1214,22 @@ async fn create_script_internal<'c>(
         }
     };
 
+    // Failure, Trigger, and Approval scripts are runnable entrypoints by
+    // definition. They must never be marked `auto_kind = 'lib'`, or they
+    // disappear from the flow error-handler / trigger / approval pickers
+    // (which filter out lib scripts). Strip a stray `lib` here so a parser
+    // misclassification — e.g. failing to detect `main` after a deno_ast
+    // bump — cannot orphan these scripts in the UI.
+    let auto_kind = if matches!(
+        ns.kind,
+        Some(ScriptKind::Failure) | Some(ScriptKind::Trigger) | Some(ScriptKind::Approval)
+    ) && auto_kind.as_deref() == Some("lib")
+    {
+        None
+    } else {
+        auto_kind
+    };
+
     let ci_test_refs =
         windmill_common::schema::parse_ci_test_annotation(&ns.content, &lang.as_comment_lit());
     let auto_kind = if ci_test_refs.is_some() {


### PR DESCRIPTION
## Summary

Replaces #9167. That PR patched the symptom at the list endpoint (skipping the `auto_kind='lib'` filter when callers request non-script kinds). The root cause is on the write path: `create_script_internal` persists whatever `auto_kind` the TS/Python parser returns, so any parser regression that fails to detect a `main` will tag a `failure`/`trigger`/`approval` script as `lib` — even though those kinds are runnable entrypoints by definition. The bad value then leaks into anywhere `auto_kind` is read directly, not just the picker filter.

This PR fixes it at the source and backfills the affected rows.

## Changes

- **Write-path guard** (`backend/windmill-api-scripts/src/scripts.rs`): after parser inference, if `ns.kind` is `Failure`/`Trigger`/`Approval` and the computed `auto_kind` is `"lib"`, force it to `NULL`. Placed before the CI-test override so it also normalizes a caller-supplied `auto_kind = "lib"`. Regular `Script`/`Preprocessor` behavior unchanged.
- **Backfill migration** (`backend/migrations/20260514130526_…`): one-shot `UPDATE script SET auto_kind = NULL WHERE auto_kind = 'lib' AND kind IN ('failure', 'trigger', 'approval')` so already-affected scripts re-appear in their pickers without requiring a redeploy. Down migration is a no-op (the `lib`/`NULL` distinction is lost, and restoring `lib` would re-hide the scripts).
- **Regression tests** (`backend/tests/script_auto_kind_failure.rs`):
  - `failure`-kind script with no `main` is **not** marked `lib` (verified to fail against `main` without the fix).
  - Regular `script`-kind with no `main` **is** still marked `lib` — guards against an over-broad sanitizer.

## Test plan

- [x] Both regression tests pass with the fix applied
- [x] `failure_kind_script_without_main_is_not_marked_lib` fails on plain `main` (verified by stashing the fix and re-running)
- [x] `cargo check -p windmill-api-scripts` clean
- [x] Migration applies cleanly via `sqlx migrate run`
- [ ] Manual: deploy a TS `failure` script whose content has no `main`, confirm it appears in a flow's error-handler picker
- [ ] Manual: run migration on a DB containing pre-existing `failure`/`trigger`/`approval` rows with `auto_kind='lib'`, confirm they flip to `NULL` and regular `script`-kind rows are untouched

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents runnable `failure`/`trigger`/`approval` scripts from being stored as `auto_kind='lib'`, which hid them from flow error-handler/trigger/approval pickers. Adds a guard on script creation and a migration to clean existing rows so these scripts always appear.

- **Bug Fixes**
  - Write-path guard in `backend/windmill-api-scripts/src/scripts.rs`: if kind is failure/trigger/approval and `auto_kind` is `lib`, store `NULL` instead (applies to inferred and caller-supplied values).
  - Regular `script`/`preprocessor` behavior unchanged.
  - Regression tests added to confirm the guard and that normal scripts without `main` still get `auto_kind='lib'`.

- **Migration**
  - Up: `UPDATE script SET auto_kind = NULL WHERE auto_kind = 'lib' AND kind IN ('failure','trigger','approval')` to unhide affected scripts.
  - Down: no-op, as restoring `lib` would re-hide these scripts.

<sup>Written for commit 2ea15706969f10168dd339fa39ef6256859d30c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

