### PR TITLE
feat(otel-tracing-proxy): configurable NO_PROXY hosts

### DIFF
--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -886,11 +886,13 @@ pub async fn reload_otel_tracing_proxy_setting(conn: &Connection) {
                 let mut current = OTEL_TRACING_PROXY_SETTINGS.write().await;
                 if current.enabled != new_settings.enabled
                     || current.enabled_languages != new_settings.enabled_languages
+                    || current.no_proxy_hosts != new_settings.no_proxy_hosts
                 {
                     tracing::info!(
-                        "OTEL tracing proxy settings changed: enabled={}, languages={:?}",
+                        "OTEL tracing proxy settings changed: enabled={}, languages={:?}, no_proxy_hosts={:?}",
                         new_settings.enabled,
-                        new_settings.enabled_languages
+                        new_settings.enabled_languages,
+                        new_settings.no_proxy_hosts,
                     );
                     *current = new_settings;
                 }

--- a/backend/windmill-common/src/instance_config.rs
+++ b/backend/windmill-common/src/instance_config.rs
@@ -616,8 +616,9 @@ pub struct OtelTracingProxySettings {
     pub enabled: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub enabled_languages: Vec<ScriptLang>,
-    /// Comma-separated list of host patterns appended to the worker's NO_PROXY env when
-    /// the tracing proxy is active. Use this to bypass MITM interception for clients that
+    /// Comma-separated list of host patterns injected as NO_PROXY into jobs so their HTTP
+    /// clients bypass the local MITM tracing proxy. Independent of the worker's own
+    /// NO_PROXY env (which governs the proxy's upstream relay). Use this for clients that
     /// pin their own CA (kubectl, helm, terraform providers, aws cli for EKS, etc.).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub no_proxy_hosts: Option<String>,

--- a/backend/windmill-common/src/instance_config.rs
+++ b/backend/windmill-common/src/instance_config.rs
@@ -616,6 +616,11 @@ pub struct OtelTracingProxySettings {
     pub enabled: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub enabled_languages: Vec<ScriptLang>,
+    /// Comma-separated list of host patterns appended to the worker's NO_PROXY env when
+    /// the tracing proxy is active. Use this to bypass MITM interception for clients that
+    /// pin their own CA (kubectl, helm, terraform providers, aws cli for EKS, etc.).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub no_proxy_hosts: Option<String>,
 }
 
 /// Script language identifier (for instance config use).

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1002,23 +1002,58 @@ async fn get_otel_tracing_proxy_envs(
 /// intercepting all destinations including loopback.
 #[cfg(all(feature = "private", feature = "enterprise"))]
 async fn build_tracing_proxy_no_proxy() -> String {
-    let Some(configured) = OTEL_TRACING_PROXY_SETTINGS
+    let configured = OTEL_TRACING_PROXY_SETTINGS
         .read()
         .await
         .no_proxy_hosts
-        .clone()
-    else {
+        .clone();
+    normalize_no_proxy_hosts(configured.as_deref())
+}
+
+/// Split a comma-separated NO_PROXY value, trim whitespace, drop empty entries, and
+/// deduplicate while preserving order. `None` returns an empty string.
+fn normalize_no_proxy_hosts(configured: Option<&str>) -> String {
+    let Some(configured) = configured else {
         return String::new();
     };
     let mut seen = std::collections::HashSet::new();
-    let mut out: Vec<String> = Vec::new();
+    let mut out: Vec<&str> = Vec::new();
     for entry in configured.split(',') {
         let trimmed = entry.trim();
-        if !trimmed.is_empty() && seen.insert(trimmed.to_string()) {
-            out.push(trimmed.to_string());
+        if !trimmed.is_empty() && seen.insert(trimmed) {
+            out.push(trimmed);
         }
     }
     out.join(",")
+}
+
+#[cfg(test)]
+mod no_proxy_tests {
+    use super::normalize_no_proxy_hosts;
+
+    #[test]
+    fn unset_returns_empty() {
+        assert_eq!(normalize_no_proxy_hosts(None), "");
+    }
+
+    #[test]
+    fn empty_and_whitespace_only_returns_empty() {
+        assert_eq!(normalize_no_proxy_hosts(Some("")), "");
+        assert_eq!(normalize_no_proxy_hosts(Some("  ,  ,\t")), "");
+    }
+
+    #[test]
+    fn trims_and_skips_empties() {
+        assert_eq!(
+            normalize_no_proxy_hosts(Some("  *.eks.amazonaws.com  ,, *.internal ")),
+            "*.eks.amazonaws.com,*.internal"
+        );
+    }
+
+    #[test]
+    fn dedupes_preserving_first_occurrence_order() {
+        assert_eq!(normalize_no_proxy_hosts(Some("a,b,a,c,b,d")), "a,b,c,d");
+    }
 }
 
 #[cfg(windows)]

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -998,27 +998,24 @@ async fn get_otel_tracing_proxy_envs(
 /// what the MITM proxy bypasses when relaying upstream (e.g. through a corporate proxy) and
 /// is honored automatically by the in-process MITM. The configured hosts are tunneled
 /// through the proxy without TLS interception, so clients that pin their own CA (kubectl,
-/// helm, terraform, etc.) keep working. Loopback is always included so jobs never try to
-/// intercept their own talking to other workers on the same host.
+/// helm, terraform, etc.) keep working. Empty when unset, matching the prior behavior of
+/// intercepting all destinations including loopback.
 #[cfg(all(feature = "private", feature = "enterprise"))]
 async fn build_tracing_proxy_no_proxy() -> String {
-    const DEFAULTS: &str = "localhost,127.0.0.1";
-    let configured = OTEL_TRACING_PROXY_SETTINGS
+    let Some(configured) = OTEL_TRACING_PROXY_SETTINGS
         .read()
         .await
         .no_proxy_hosts
-        .clone();
+        .clone()
+    else {
+        return String::new();
+    };
     let mut seen = std::collections::HashSet::new();
     let mut out: Vec<String> = Vec::new();
-    for source in [configured.as_deref(), Some(DEFAULTS)]
-        .into_iter()
-        .flatten()
-    {
-        for entry in source.split(',') {
-            let trimmed = entry.trim();
-            if !trimmed.is_empty() && seen.insert(trimmed.to_string()) {
-                out.push(trimmed.to_string());
-            }
+    for entry in configured.split(',') {
+        let trimmed = entry.trim();
+        if !trimmed.is_empty() && seen.insert(trimmed.to_string()) {
+            out.push(trimmed.to_string());
         }
     }
     out.join(",")

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1012,6 +1012,7 @@ async fn build_tracing_proxy_no_proxy() -> String {
 
 /// Split a comma-separated NO_PROXY value, trim whitespace, drop empty entries, and
 /// deduplicate while preserving order. `None` returns an empty string.
+#[cfg(all(feature = "private", feature = "enterprise"))]
 fn normalize_no_proxy_hosts(configured: Option<&str>) -> String {
     let Some(configured) = configured else {
         return String::new();
@@ -1027,7 +1028,7 @@ fn normalize_no_proxy_hosts(configured: Option<&str>) -> String {
     out.join(",")
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "private", feature = "enterprise"))]
 mod no_proxy_tests {
     use super::normalize_no_proxy_hosts;
 

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -277,6 +277,8 @@ pub struct OtelTracingProxySettings {
     pub enabled: bool,
     #[serde(default)]
     pub enabled_languages: HashSet<ScriptLang>,
+    #[serde(default)]
+    pub no_proxy_hosts: Option<String>,
 }
 
 #[cfg(feature = "prometheus")]
@@ -969,14 +971,15 @@ async fn get_otel_tracing_proxy_envs(
         }
     };
     let proxy_url = format!("http://127.0.0.1:{}", port);
+    let no_proxy = build_tracing_proxy_no_proxy().await;
     Ok(vec![
         ("HTTP_PROXY", proxy_url.clone()),
         ("HTTPS_PROXY", proxy_url.clone()),
         // Lowercase variants for Ruby and other runtimes that check lowercase first
         ("http_proxy", proxy_url.clone()),
         ("https_proxy", proxy_url),
-        ("NO_PROXY", "".to_string()),
-        ("no_proxy", "".to_string()),
+        ("NO_PROXY", no_proxy.clone()),
+        ("no_proxy", no_proxy),
         // CA cert for various runtimes to trust the tracing proxy
         ("SSL_CERT_FILE", TRACING_PROXY_CA_CERT_PATH.to_string()),
         ("REQUESTS_CA_BUNDLE", TRACING_PROXY_CA_CERT_PATH.to_string()),
@@ -988,6 +991,31 @@ async fn get_otel_tracing_proxy_envs(
         ("GIT_SSL_CAINFO", TRACING_PROXY_CA_CERT_PATH.to_string()),
         ("DENO_CERT", TRACING_PROXY_CA_CERT_PATH.to_string()),
     ])
+}
+
+/// Build the NO_PROXY value for jobs routed through the OTEL tracing proxy by merging the
+/// hosts configured in instance settings with the worker's own NO_PROXY env (deduplicated,
+/// order-preserved). Entries here are tunneled through the proxy without MITM, so clients
+/// that pin their own CA (kubectl, helm, terraform, etc.) keep working.
+#[cfg(all(feature = "private", feature = "enterprise"))]
+async fn build_tracing_proxy_no_proxy() -> String {
+    let configured = OTEL_TRACING_PROXY_SETTINGS
+        .read()
+        .await
+        .no_proxy_hosts
+        .clone();
+    let mut seen = std::collections::HashSet::new();
+    let mut out: Vec<String> = Vec::new();
+    let sources = [configured.as_deref(), NO_PROXY.as_deref()];
+    for source in sources.into_iter().flatten() {
+        for entry in source.split(',') {
+            let trimmed = entry.trim();
+            if !trimmed.is_empty() && seen.insert(trimmed.to_string()) {
+                out.push(trimmed.to_string());
+            }
+        }
+    }
+    out.join(",")
 }
 
 #[cfg(windows)]

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -993,12 +993,16 @@ async fn get_otel_tracing_proxy_envs(
     ])
 }
 
-/// Build the NO_PROXY value for jobs routed through the OTEL tracing proxy by merging the
-/// hosts configured in instance settings with the worker's own NO_PROXY env (deduplicated,
-/// order-preserved). Entries here are tunneled through the proxy without MITM, so clients
-/// that pin their own CA (kubectl, helm, terraform, etc.) keep working.
+/// NO_PROXY value injected into jobs so their HTTP clients bypass the local MITM proxy for
+/// the configured hosts. This is distinct from the worker's own NO_PROXY env, which governs
+/// what the MITM proxy bypasses when relaying upstream (e.g. through a corporate proxy) and
+/// is honored automatically by the in-process MITM. The configured hosts are tunneled
+/// through the proxy without TLS interception, so clients that pin their own CA (kubectl,
+/// helm, terraform, etc.) keep working. Loopback is always included so jobs never try to
+/// intercept their own talking to other workers on the same host.
 #[cfg(all(feature = "private", feature = "enterprise"))]
 async fn build_tracing_proxy_no_proxy() -> String {
+    const DEFAULTS: &str = "localhost,127.0.0.1";
     let configured = OTEL_TRACING_PROXY_SETTINGS
         .read()
         .await
@@ -1006,8 +1010,10 @@ async fn build_tracing_proxy_no_proxy() -> String {
         .clone();
     let mut seen = std::collections::HashSet::new();
     let mut out: Vec<String> = Vec::new();
-    let sources = [configured.as_deref(), NO_PROXY.as_deref()];
-    for source in sources.into_iter().flatten() {
+    for source in [configured.as_deref(), Some(DEFAULTS)]
+        .into_iter()
+        .flatten()
+    {
         for entry in source.split(',') {
             let trimmed = entry.trim();
             if !trimmed.is_empty() && seen.insert(trimmed.to_string()) {

--- a/frontend/src/lib/components/InstanceSetting.svelte
+++ b/frontend/src/lib/components/InstanceSetting.svelte
@@ -716,12 +716,12 @@
 									bind:value={$values[setting.key].no_proxy_hosts}
 								/>
 								<p class="text-xs text-tertiary">
-									Comma-separated host patterns tunneled through the proxy without TLS
-									interception. Use this for clients that pin their own CA — kubectl,
-									helm, terraform providers, aws cli for EKS, etc. — which would
-									otherwise fail with <code
-										>x509: certificate signed by unknown authority</code
-									>. Appended to the worker's existing NO_PROXY env var.
+									Comma-separated host patterns that job HTTP clients should bypass the tracing
+									proxy for — those hosts will not be traced. Use this for clients that pin their
+									own CA (kubectl, helm, terraform providers, aws cli for EKS, etc.) which would
+									otherwise fail with <code>x509: certificate signed by unknown authority</code>.
+									Independent of the worker's own <code>NO_PROXY</code> env, which governs the proxy's
+									upstream relay (e.g. through a corporate proxy).
 								</p>
 							</div>
 						{/if}

--- a/frontend/src/lib/components/InstanceSetting.svelte
+++ b/frontend/src/lib/components/InstanceSetting.svelte
@@ -699,6 +699,31 @@
 									</button>
 								{/each}
 							</div>
+							<div class="flex flex-col gap-1">
+								<label
+									for="otel_tracing_proxy_no_proxy_hosts"
+									class="block text-xs font-semibold text-emphasis"
+								>
+									NO_PROXY hosts (bypass tracing)
+								</label>
+								<TextInput
+									inputProps={{
+										type: 'text',
+										placeholder: '*.eks.amazonaws.com,*.internal',
+										id: 'otel_tracing_proxy_no_proxy_hosts',
+										disabled: !$enterpriseLicense
+									}}
+									bind:value={$values[setting.key].no_proxy_hosts}
+								/>
+								<p class="text-xs text-tertiary">
+									Comma-separated host patterns tunneled through the proxy without TLS
+									interception. Use this for clients that pin their own CA — kubectl,
+									helm, terraform providers, aws cli for EKS, etc. — which would
+									otherwise fail with <code
+										>x509: certificate signed by unknown authority</code
+									>. Appended to the worker's existing NO_PROXY env var.
+								</p>
+							</div>
 						{/if}
 					</div>
 				{:else if setting.fieldType == 'object_store_config'}


### PR DESCRIPTION
## Summary

The OTEL HTTP tracing MITM proxy currently forces `NO_PROXY=""` for every job, which silently overrides any operator-configured `NO_PROXY` and breaks clients that pin their own CA (kubectl, helm, terraform providers, `aws eks ...`). These clients fail with `x509: certificate signed by unknown authority` because the MITM cert is not in their pinned trust store, and they can't be intercepted anyway. This PR lets admins list bypass hosts in instance settings; entries are tunneled through the proxy without TLS interception so pinned-CA clients keep working.

## Changes

- `OtelTracingProxySettings` gains a `no_proxy_hosts: Option<String>` field (added to both the canonical struct in `windmill-common/src/instance_config.rs` and the runtime mirror in `windmill-worker/src/worker.rs`)
- `get_otel_tracing_proxy_envs` now calls a new `build_tracing_proxy_no_proxy()` helper that merges the configured value with the worker's existing `NO_PROXY` env (deduplicated, order-preserved, configured entries first) instead of clobbering with empty string
- `reload_otel_tracing_proxy_setting` detects changes to the new field and logs them
- Instance settings UI gains a `TextInput` under the HTTP Request Tracing toggle (only visible when enabled) with the kubectl/helm/terraform explanation

## Test plan

- [ ] Enable HTTP Request Tracing in instance settings
- [ ] Set `no_proxy_hosts` to `*.eks.amazonaws.com,*.internal`
- [ ] Run a bash job that invokes `kubectl version` against an EKS cluster — should succeed (previously failed with x509 error)
- [ ] Run a job that calls a non-bypassed host — should still appear in OTEL traces
- [ ] Clear the field — should revert to honoring only the worker's own `NO_PROXY` env
- [ ] Toggle the field at runtime — log line should appear and the new value should take effect on the next job

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable `NO_PROXY` bypass hosts for the OTEL HTTP tracing proxy. Pinned-CA clients (kubectl, helm, terraform, AWS EKS) now tunnel without MITM and avoid x509 errors; the worker’s own `NO_PROXY` remains independent.

- New Features
  - Add `no_proxy_hosts` to `OtelTracingProxySettings` in `windmill-common` and `windmill-worker`.
  - Inject job `NO_PROXY` from configured hosts; deduplicated; applied to `NO_PROXY` and `no_proxy`.
  - Do not merge with the worker’s `NO_PROXY`; that only governs the proxy’s upstream relay.
  - Log `no_proxy_hosts` changes on reload; UI adds a text input under HTTP Request Tracing.

- Bug Fixes
  - Restore empty `NO_PROXY` default when unset; no implicit loopback entries.
  - Gate `normalize_no_proxy_hosts` and its tests to enterprise/private builds.

<sup>Written for commit 8c9c4e3292f1f6fc1803c4938b52d56ff1bbd381. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

