### PR TITLE
feat: make ALLOW_PRIVATE_AI_BASE_URLS configurable via .env

### DIFF
--- a/.env
+++ b/.env
@@ -11,3 +11,5 @@ WM_IMAGE=ghcr.io/windmill-labs/windmill:main
 # To rotate logs, set the following variables:
 #LOG_MAX_SIZE=10m
 #LOG_MAX_FILE=3
+# Allow windmill-server to use private/self-hosted AI base URLs (e.g. local Ollama, private OpenAI-compatible endpoints)
+#ALLOW_PRIVATE_AI_BASE_URLS=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
     environment:
       - DATABASE_URL=${DATABASE_URL}
       - MODE=server
+      - ALLOW_PRIVATE_AI_BASE_URLS=${ALLOW_PRIVATE_AI_BASE_URLS:-false}
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
With this change configuration of private ai models is more clear where to configure parameter

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `ALLOW_PRIVATE_AI_BASE_URLS` configurable via `.env` and pass it through `docker-compose.yml`. This lets `windmill-server` opt in to private/self-hosted AI base URLs (e.g., local Ollama or OpenAI-compatible endpoints).

- **Migration**
  - Set `ALLOW_PRIVATE_AI_BASE_URLS=true` in `.env` to enable private/self-hosted endpoints (defaults to `false`).
  - `docker-compose.yml` now forwards `ALLOW_PRIVATE_AI_BASE_URLS` to `windmill-server` with a fallback of `false`.

<sup>Written for commit fda6ef84e2b5ef9d902c69f8e6c3e6c0892c34b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

