### PR TITLE
feat(ai-chat): link workspace paths and show tool item references

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -51,6 +51,7 @@
 				"jszip": "^3.10.1",
 				"lru-cache": "^11.1.0",
 				"lucide-svelte": "^0.540.0",
+				"mdast-util-find-and-replace": "^3.0.2",
 				"minimatch": "^10.0.1",
 				"monaco-editor": "npm:@codingame/monaco-vscode-editor-api@=25.0.0",
 				"monaco-languageclient": "10.6.0",
@@ -844,7 +845,6 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
 			"integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -856,7 +856,6 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
 			"integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -867,7 +866,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
 			"integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -1357,7 +1355,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
 			"integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -1514,7 +1511,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1531,7 +1527,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1548,7 +1543,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1565,7 +1559,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1582,7 +1575,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1599,7 +1591,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1616,7 +1607,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1633,7 +1623,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1650,7 +1639,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1667,7 +1655,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1684,7 +1671,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1701,7 +1687,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1718,7 +1703,6 @@
 			"cpu": [
 				"wasm32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -1735,7 +1719,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1752,7 +1735,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2058,7 +2040,6 @@
 			"version": "0.10.1",
 			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
 			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -6834,7 +6815,7 @@
 			"version": "1.21.7",
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
 			"integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"bin": {
 				"jiti": "bin/jiti.js"
@@ -7333,7 +7314,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7354,7 +7334,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7375,7 +7354,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7396,7 +7374,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7417,7 +7394,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7438,7 +7414,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7459,7 +7434,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7480,7 +7454,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7501,7 +7474,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7522,7 +7494,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7543,7 +7514,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -12112,21 +12082,6 @@
 				}
 			}
 		},
-		"node_modules/svelte-check/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/svelte-eslint-parser": {
 			"version": "0.43.0",
 			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-0.43.0.tgz",
@@ -12857,7 +12812,7 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -72,6 +72,7 @@
 				"svelte-exmarkdown": "^5.0.0",
 				"svelte-infinite-loading": "^1.4.0",
 				"tailwind-merge": "^1.13.2",
+				"unist-util-visit": "^5.0.0",
 				"vscode": "npm:@codingame/monaco-vscode-extension-api@=25.0.0",
 				"vscode-languageclient": "~9.0.1",
 				"vscode-uri": "~3.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -125,6 +125,7 @@
 		"lru-cache": "^11.1.0",
 		"lucide-svelte": "^0.540.0",
 		"mdast-util-find-and-replace": "^3.0.2",
+		"unist-util-visit": "^5.0.0",
 		"minimatch": "^10.0.1",
 		"monaco-editor": "npm:@codingame/monaco-vscode-editor-api@=25.0.0",
 		"monaco-languageclient": "10.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -124,6 +124,7 @@
 		"jszip": "^3.10.1",
 		"lru-cache": "^11.1.0",
 		"lucide-svelte": "^0.540.0",
+		"mdast-util-find-and-replace": "^3.0.2",
 		"minimatch": "^10.0.1",
 		"monaco-editor": "npm:@codingame/monaco-vscode-editor-api@=25.0.0",
 		"monaco-languageclient": "10.6.0",

--- a/frontend/src/lib/components/ResourceEditorDrawer.svelte
+++ b/frontend/src/lib/components/ResourceEditorDrawer.svelte
@@ -31,6 +31,10 @@
 		drawer?.openDrawer?.()
 	}
 
+	export function closeDrawer(): void {
+		drawer?.closeDrawer?.()
+	}
+
 	export async function initNew(
 		resourceType: string,
 		nDefaultValues?: Record<string, any>
@@ -45,10 +49,10 @@
 	let mode: 'edit' | 'new' = $derived(!path ? 'new' : 'edit')
 </script>
 
-<Drawer bind:this={drawer} size="50rem" {disableChatOffset}>
+<Drawer bind:this={drawer} size="50rem" {disableChatOffset} on:close>
 	<DrawerContent
 		title={mode == 'edit' ? 'Edit ' + path : 'Add a resource'}
-		on:close={drawer?.closeDrawer}
+		on:close={() => drawer?.closeDrawer()}
 	>
 		{#await import('./ResourceEditor.svelte')}
 			<Loader2 class="animate-spin" />

--- a/frontend/src/lib/components/VariableEditor.svelte
+++ b/frontend/src/lib/components/VariableEditor.svelte
@@ -136,6 +136,10 @@
 		drawer?.openDrawer()
 	}
 
+	export function closeDrawer(): void {
+		drawer?.closeDrawer()
+	}
+
 	async function loadSecret(): Promise<void> {
 		if (!editPath || !selected) return
 		const getV = await VariableService.getVariable({
@@ -196,10 +200,10 @@
 	}
 </script>
 
-<Drawer bind:this={drawer} size="50rem">
+<Drawer bind:this={drawer} size="50rem" on:close>
 	<DrawerContent
 		title={edit ? `Update variable at ${initialPath}` : 'Add a variable'}
-		on:close={drawer?.closeDrawer}
+		on:close={() => drawer?.closeDrawer()}
 	>
 		<div class="flex flex-col gap-8">
 			{#if !can_write}

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -62,6 +62,11 @@ import { getCurrentModel, tryGetCurrentModel, getCombinedCustomPrompt } from '$l
 import type { WorkspaceMutationTarget } from './workspaceTools'
 import { globalTools, prepareGlobalSystemMessage, prepareGlobalUserMessage } from './global/core'
 import { isGlobalAiEnabled } from './global/gate'
+import {
+	resolveMentionedItems,
+	workspaceItemRegistry,
+	type WorkspaceItemEntry
+} from './workspaceItems.svelte'
 
 // If the estimated token usage is greater than the model context window - the threshold, we delete the oldest message
 const MAX_TOKENS_THRESHOLD_PERCENTAGE = 0.05
@@ -156,6 +161,42 @@ class AIChatManager {
 	})
 
 	open = $derived(chatState.size > 0)
+
+	/**
+	 * Workspace scripts / flows / apps that have been referenced in the conversation.
+	 *
+	 * Computed from assistant message text and tool parameters/results, then resolved
+	 * against the workspace item registry. Useful for picker UIs that want to surface
+	 * "items mentioned in this chat".
+	 *
+	 * Only items currently loaded in the registry are returned — call
+	 * `workspaceItemRegistry.ensureLoaded(workspace)` first if you need full coverage.
+	 */
+	mentionedItems: WorkspaceItemEntry[] = $derived.by(() => {
+		const ws = get(workspaceStore)
+		if (!ws) return []
+		// Touch the registry's reactive state so this $derived re-runs once data lands.
+		workspaceItemRegistry.isLoaded(ws)
+		const texts: string[] = []
+		for (const m of this.displayMessages) {
+			if (m.role === 'assistant' || m.role === 'user') {
+				if (m.content) texts.push(m.content)
+			} else if (m.role === 'tool') {
+				if (m.content) texts.push(m.content)
+				if (m.parameters) {
+					try {
+						texts.push(
+							typeof m.parameters === 'string' ? m.parameters : JSON.stringify(m.parameters)
+						)
+					} catch {}
+				}
+				if (typeof m.result === 'string') {
+					texts.push(m.result)
+				}
+			}
+		}
+		return resolveMentionedItems(texts, ws)
+	})
 
 	checkTokenUsageOverLimit = (messages: ChatCompletionMessageParam[]) => {
 		const estimatedTokens = messages.reduce((acc, message) => {

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -146,6 +146,53 @@ class AIChatManager {
 	/** Cached datatables for app context (fetched asynchronously) */
 	cachedDatatables = $state<AppDatatableElement[]>([])
 
+	/**
+	 * Inline-drawer request for a workspace item referenced from a chat message.
+	 *
+	 * Consumed by the drawer host mounted in AiChatLayout, which calls the matching
+	 * editor's open method.
+	 *
+	 * `version` increments on every request so re-clicking after the drawer was closed
+	 * via the X button (which doesn't reset this state) still re-triggers the effect.
+	 */
+	workspaceItemDrawer = $state<
+		| {
+				kind: WorkspaceItemEntry['kind']
+				path: string
+				version: number
+				open: boolean
+		  }
+		| undefined
+	>(undefined)
+
+	/**
+	 * Toggle the inline drawer for a workspace item.
+	 *
+	 * Behavior:
+	 * - If a drawer for the same kind+path is currently open, close it.
+	 * - Otherwise, set up state to open (or re-open) the drawer.
+	 */
+	toggleWorkspaceItemDrawer(target: { kind: WorkspaceItemEntry['kind']; path: string }): void {
+		const cur = this.workspaceItemDrawer
+		const sameTarget = cur?.kind === target.kind && cur.path === target.path
+		if (cur?.open && sameTarget) {
+			this.workspaceItemDrawer = { ...cur, open: false, version: cur.version + 1 }
+			return
+		}
+		this.workspaceItemDrawer = {
+			kind: target.kind,
+			path: target.path,
+			version: (cur?.version ?? 0) + 1,
+			open: true
+		}
+	}
+
+	/** Mark the inline drawer as closed (called by the host when the drawer's own X is hit). */
+	markWorkspaceItemDrawerClosed(): void {
+		if (!this.workspaceItemDrawer?.open) return
+		this.workspaceItemDrawer = { ...this.workspaceItemDrawer, open: false }
+	}
+
 	private confirmationCallback = $state<((value: boolean) => void) | undefined>(undefined)
 	private appDatatablesRefreshTimeout: ReturnType<typeof setTimeout> | undefined = undefined
 

--- a/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
+++ b/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
@@ -11,6 +11,7 @@
 	import Button from '$lib/components/common/button/Button.svelte'
 	import { Menu } from 'lucide-svelte'
 	import CreatedResourceActionDrawers from './CreatedResourceActionDrawers.svelte'
+	import WorkspaceItemDrawerHost from './WorkspaceItemDrawerHost.svelte'
 
 	interface Props {
 		noPadding?: boolean
@@ -50,6 +51,7 @@
 
 {#if !disableAi}
 	<CreatedResourceActionDrawers />
+	<WorkspaceItemDrawerHost />
 	<Splitpanes horizontal={false} class="flex-1 min-h-0">
 		<Pane size={100 - chatState.size} minSize={50} class="flex flex-col grow min-h-0 ">
 			<div

--- a/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
+++ b/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
@@ -4,27 +4,50 @@
 	import type { DisplayMessage } from './shared'
 	import CodeDisplay from './script/CodeDisplay.svelte'
 	import LinkRenderer from './LinkRenderer.svelte'
+	import { workspaceStore } from '$lib/stores'
+	import { remarkWindmillPaths, workspaceItemRegistry } from './workspaceItems.svelte'
 
 	interface Props {
-		message: DisplayMessage;
+		message: DisplayMessage
 	}
 
-	let { message }: Props = $props();
-</script>
+	let { message }: Props = $props()
 
-<div
-	class="prose prose-sm dark:prose-invert w-full max-w-full leading-snug space-y-2 prose-ul:!pl-6"
->
-	<Markdown
-		md={message.content}
-		plugins={[
+	// Trigger the lazy load once we mount in a workspace context. The registry dedups
+	// concurrent calls across messages, so this is cheap to call repeatedly.
+	$effect(() => {
+		const ws = $workspaceStore
+		if (ws) workspaceItemRegistry.ensureLoaded(ws)
+	})
+
+	const plugins = $derived.by(() => {
+		const ws = $workspaceStore ?? ''
+		// Subscribe to the registry's reactive state so this derivation re-runs once the
+		// workspace items finish loading — otherwise messages that mounted before the load
+		// completed would stay as plain text forever (the underlying `parse` in
+		// svelte-exmarkdown only re-runs when the `plugins` reference changes).
+		workspaceItemRegistry.isLoaded(ws)
+		return [
 			gfmPlugin(),
+			{
+				remarkPlugin: remarkWindmillPaths({
+					resolve: (path) => workspaceItemRegistry.resolve(ws, path),
+					workspace: ws || undefined
+				}),
+				renderer: {}
+			},
 			{
 				renderer: {
 					pre: CodeDisplay,
 					a: LinkRenderer
 				}
 			}
-		]}
-	/>
+		]
+	})
+</script>
+
+<div
+	class="prose prose-sm dark:prose-invert w-full max-w-full leading-snug space-y-2 prose-ul:!pl-6"
+>
+	<Markdown md={message.content} {plugins} />
 </div>

--- a/frontend/src/lib/components/copilot/chat/LinkRenderer.svelte
+++ b/frontend/src/lib/components/copilot/chat/LinkRenderer.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte'
-	import { Code2, ExternalLink, LayoutDashboard } from 'lucide-svelte'
-	import BarsStaggered from '$lib/components/icons/BarsStaggered.svelte'
-	import type { WindmillItemKind } from './workspaceItems.svelte'
+	import { ExternalLink, PanelRight } from 'lucide-svelte'
+	import RowIcon from '$lib/components/common/table/RowIcon.svelte'
+	import { aiChatManager } from './AIChatManager.svelte'
+	import { hasInlineDrawer, type WindmillItemKind } from './workspaceItems.svelte'
 
 	type Props = {
 		href?: string
@@ -11,10 +12,10 @@
 		'data-wm-path'?: string
 		title?: string
 	}
-	let { href, children, 'data-wm-kind': wmKind, title }: Props = $props()
+	let { href, children, 'data-wm-kind': wmKind, 'data-wm-path': wmPath, title }: Props = $props()
 
-	// Fallback to URL-based detection if the data attribute didn't make it through
-	// (hast/rehype can rename custom properties on some pipelines).
+	// Fallback to URL-based detection for scripts/flows/apps. Other kinds rely on the
+	// data attribute set by the remark plugin.
 	const kind = $derived.by((): WindmillItemKind | undefined => {
 		if (wmKind) return wmKind
 		if (!href) return undefined
@@ -23,33 +24,41 @@
 		if (href.startsWith('/apps/get/')) return 'app'
 		return undefined
 	})
+	const drawerable = $derived(kind ? hasInlineDrawer(kind) : false)
 </script>
 
 {#if href}
 	{#if kind}
-		<a
-			{href}
-			target="_blank"
-			rel="noopener noreferrer"
-			title={title || href}
-			class="group inline-flex items-baseline gap-1 px-1 rounded hover:bg-surface-hover text-primary no-underline font-mono text-[0.9em] align-baseline"
-		>
-			<span class="inline-flex self-center shrink-0">
-				{#if kind === 'script'}
-					<Code2 size={12} class="text-blue-500" />
-				{:else if kind === 'flow'}
-					<BarsStaggered size={12} style="" class="!fill-current text-teal-500" />
-				{:else if kind === 'app'}
-					<LayoutDashboard size={12} class="text-orange-500" />
-				{/if}
-			</span>
-			{@render children?.()}
-			<span
-				class="inline-flex self-center shrink-0 text-tertiary opacity-0 group-hover:opacity-100 transition-opacity"
+		<span class="group inline-flex items-baseline">
+			<a
+				{href}
+				target="_blank"
+				rel="noopener noreferrer"
+				title={title || wmPath || href}
+				class="inline-flex items-baseline gap-1 px-1 rounded hover:bg-surface-hover text-primary no-underline font-mono text-[0.9em] align-baseline"
 			>
-				<ExternalLink size={10} />
-			</span>
-		</a>
+				<span class="inline-flex self-center shrink-0">
+					<RowIcon {kind} size={12} />
+				</span>
+				{@render children?.()}
+				<span
+					class="inline-flex self-center shrink-0 text-tertiary opacity-0 group-hover:opacity-100 transition-opacity"
+				>
+					<ExternalLink size={10} />
+				</span>
+			</a>
+			{#if drawerable && wmPath}
+				<button
+					type="button"
+					onclick={() => aiChatManager.toggleWorkspaceItemDrawer({ kind, path: wmPath })}
+					title="Open in drawer"
+					aria-label="Open {wmPath} in drawer"
+					class="ml-0.5 inline-flex self-center shrink-0 rounded p-0.5 text-tertiary hover:bg-surface-hover opacity-0 group-hover:opacity-100 transition-opacity"
+				>
+					<PanelRight size={11} />
+				</button>
+			{/if}
+		</span>
 	{:else}
 		<a {href} target="_blank" rel="noopener noreferrer" {title}>
 			{@render children?.()}

--- a/frontend/src/lib/components/copilot/chat/LinkRenderer.svelte
+++ b/frontend/src/lib/components/copilot/chat/LinkRenderer.svelte
@@ -1,15 +1,53 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte'
+	import { Code2, LayoutDashboard } from 'lucide-svelte'
+	import BarsStaggered from '$lib/components/icons/BarsStaggered.svelte'
+	import type { WindmillItemKind } from './workspaceItems.svelte'
 
 	type Props = {
 		href?: string
 		children?: Snippet
+		'data-wm-kind'?: WindmillItemKind
+		'data-wm-path'?: string
+		title?: string
 	}
-	let { href, children }: Props = $props()
+	let { href, children, 'data-wm-kind': wmKind, title }: Props = $props()
+
+	// Fallback to URL-based detection if the data attribute didn't make it through
+	// (hast/rehype can rename custom properties on some pipelines).
+	const kind = $derived.by((): WindmillItemKind | undefined => {
+		if (wmKind) return wmKind
+		if (!href) return undefined
+		if (href.startsWith('/scripts/get/')) return 'script'
+		if (href.startsWith('/flows/get/')) return 'flow'
+		if (href.startsWith('/apps/get/')) return 'app'
+		return undefined
+	})
 </script>
 
 {#if href}
-	<a {href} target="_blank" rel="noopener noreferrer">
-		{@render children?.()}
-	</a>
+	{#if kind}
+		<a
+			{href}
+			target="_blank"
+			rel="noopener noreferrer"
+			title={title || href}
+			class="inline-flex items-baseline gap-1 px-1 rounded bg-surface-secondary hover:bg-surface-hover border border-gray-200 dark:border-gray-700 text-primary no-underline font-mono text-[0.9em] align-baseline"
+		>
+			<span class="inline-flex self-center shrink-0 text-secondary">
+				{#if kind === 'script'}
+					<Code2 size={12} />
+				{:else if kind === 'flow'}
+					<BarsStaggered size={12} style="" class="!fill-current" />
+				{:else if kind === 'app'}
+					<LayoutDashboard size={12} />
+				{/if}
+			</span>
+			{@render children?.()}
+		</a>
+	{:else}
+		<a {href} target="_blank" rel="noopener noreferrer" {title}>
+			{@render children?.()}
+		</a>
+	{/if}
 {/if}

--- a/frontend/src/lib/components/copilot/chat/LinkRenderer.svelte
+++ b/frontend/src/lib/components/copilot/chat/LinkRenderer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte'
-	import { Code2, LayoutDashboard } from 'lucide-svelte'
+	import { Code2, ExternalLink, LayoutDashboard } from 'lucide-svelte'
 	import BarsStaggered from '$lib/components/icons/BarsStaggered.svelte'
 	import type { WindmillItemKind } from './workspaceItems.svelte'
 
@@ -32,18 +32,23 @@
 			target="_blank"
 			rel="noopener noreferrer"
 			title={title || href}
-			class="inline-flex items-baseline gap-1 px-1 rounded bg-surface-secondary hover:bg-surface-hover border border-gray-200 dark:border-gray-700 text-primary no-underline font-mono text-[0.9em] align-baseline"
+			class="group inline-flex items-baseline gap-1 px-1 rounded hover:bg-surface-hover text-primary no-underline font-mono text-[0.9em] align-baseline"
 		>
-			<span class="inline-flex self-center shrink-0 text-secondary">
+			<span class="inline-flex self-center shrink-0">
 				{#if kind === 'script'}
-					<Code2 size={12} />
+					<Code2 size={12} class="text-blue-500" />
 				{:else if kind === 'flow'}
-					<BarsStaggered size={12} style="" class="!fill-current" />
+					<BarsStaggered size={12} style="" class="!fill-current text-teal-500" />
 				{:else if kind === 'app'}
-					<LayoutDashboard size={12} />
+					<LayoutDashboard size={12} class="text-orange-500" />
 				{/if}
 			</span>
 			{@render children?.()}
+			<span
+				class="inline-flex self-center shrink-0 text-tertiary opacity-0 group-hover:opacity-100 transition-opacity"
+			>
+				<ExternalLink size={10} />
+			</span>
 		</a>
 	{:else}
 		<a {href} target="_blank" rel="noopener noreferrer" {title}>

--- a/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
@@ -1,11 +1,28 @@
 <script lang="ts">
-	import { Loader2, ChevronDown, ChevronRight, XCircle, Play } from 'lucide-svelte'
+	import {
+		Loader2,
+		ChevronDown,
+		ChevronRight,
+		XCircle,
+		Play,
+		Code2,
+		LayoutDashboard,
+		ExternalLink
+	} from 'lucide-svelte'
 	import { Button } from '$lib/components/common'
 	import { aiChatManager } from './AIChatManager.svelte'
 	import type { ToolDisplayMessage } from './shared'
 	import { twMerge } from 'tailwind-merge'
 	import ToolContentDisplay from './ToolContentDisplay.svelte'
 	import ToolMessageActions from './ToolMessageActions.svelte'
+	import BarsStaggered from '$lib/components/icons/BarsStaggered.svelte'
+	import { workspaceStore } from '$lib/stores'
+	import {
+		extractCandidatePaths,
+		itemHref,
+		workspaceItemRegistry,
+		type WorkspaceItemEntry
+	} from './workspaceItems.svelte'
 
 	interface Props {
 		message: ToolDisplayMessage
@@ -28,6 +45,55 @@
 			? message.actions
 			: []
 	)
+
+	$effect(() => {
+		const ws = $workspaceStore
+		if (ws) workspaceItemRegistry.ensureLoaded(ws)
+	})
+
+	/**
+	 * Resolve workspace item paths referenced by the tool's parameters.
+	 *
+	 * Looks at direct string fields (`path`, `script_path`, `flow_path`, `app_path`) first —
+	 * those are the canonical shapes used by tool schemas. Falls back to a regex sweep over
+	 * the stringified parameters to catch tools that embed paths in less obvious fields.
+	 */
+	const referencedItems = $derived.by((): WorkspaceItemEntry[] => {
+		const ws = $workspaceStore
+		if (!ws) return []
+		// Touch reactive state so we re-run when the registry populates.
+		workspaceItemRegistry.isLoaded(ws)
+		const params = message.parameters
+		if (!params || typeof params !== 'object') return []
+
+		const candidates = new Set<string>()
+		const PATH_KEYS = ['path', 'script_path', 'flow_path', 'app_path', 'runnable_path']
+		for (const key of PATH_KEYS) {
+			const value = (params as Record<string, unknown>)[key]
+			if (typeof value === 'string' && value.length > 0) {
+				candidates.add(value)
+			}
+		}
+		// Fallback: sweep stringified params for any path-shaped tokens we may have missed.
+		try {
+			const stringified = JSON.stringify(params)
+			for (const candidate of extractCandidatePaths(stringified)) {
+				candidates.add(candidate)
+			}
+		} catch {}
+
+		const resolved: WorkspaceItemEntry[] = []
+		const seen = new Set<string>()
+		for (const candidate of candidates) {
+			if (seen.has(candidate)) continue
+			const entry = workspaceItemRegistry.resolve(ws, candidate)
+			if (entry) {
+				resolved.push(entry)
+				seen.add(candidate)
+			}
+		}
+		return resolved
+	})
 </script>
 
 <div
@@ -61,6 +127,32 @@
 			<span class="text-primary font-medium text-2xs">
 				{message.content}
 			</span>
+			{#if referencedItems.length > 0}
+				<div class="flex flex-row flex-wrap items-center gap-1 ml-1 min-w-0">
+					{#each referencedItems as item (item.path)}
+						<a
+							href={itemHref(item, $workspaceStore ?? undefined)}
+							target="_blank"
+							rel="noopener noreferrer"
+							onclick={(e) => e.stopPropagation()}
+							title={item.summary || item.path}
+							class="inline-flex items-center gap-1 px-1 py-0.5 rounded bg-surface-secondary hover:bg-surface-hover border border-gray-200 dark:border-gray-700 text-primary no-underline font-mono text-2xs max-w-[14rem] truncate"
+						>
+							<span class="inline-flex shrink-0 text-secondary">
+								{#if item.kind === 'script'}
+									<Code2 class="w-3 h-3" />
+								{:else if item.kind === 'flow'}
+									<BarsStaggered size={12} style="" class="!fill-current" />
+								{:else}
+									<LayoutDashboard class="w-3 h-3" />
+								{/if}
+							</span>
+							<span class="truncate">{item.path}</span>
+							<ExternalLink class="w-2.5 h-2.5 shrink-0 text-tertiary" />
+						</a>
+					{/each}
+				</div>
+			{/if}
 		</div>
 	</button>
 

--- a/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
@@ -5,9 +5,8 @@
 		ChevronRight,
 		XCircle,
 		Play,
-		Code2,
-		LayoutDashboard,
-		ExternalLink
+		ExternalLink,
+		PanelRight
 	} from 'lucide-svelte'
 	import { Button } from '$lib/components/common'
 	import { aiChatManager } from './AIChatManager.svelte'
@@ -15,10 +14,11 @@
 	import { twMerge } from 'tailwind-merge'
 	import ToolContentDisplay from './ToolContentDisplay.svelte'
 	import ToolMessageActions from './ToolMessageActions.svelte'
-	import BarsStaggered from '$lib/components/icons/BarsStaggered.svelte'
+	import RowIcon from '$lib/components/common/table/RowIcon.svelte'
 	import { workspaceStore } from '$lib/stores'
 	import {
 		extractCandidatePaths,
+		hasInlineDrawer,
 		itemHref,
 		workspaceItemRegistry,
 		type WorkspaceItemEntry
@@ -100,15 +100,17 @@
 	class="bg-surface border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden font-mono text-xs"
 >
 	<!-- Collapsible Header -->
-	<button
+	<div
 		class={twMerge(
-			'w-full p-2 bg-surface-secondary hover:bg-surface-hover transition-colors flex items-center justify-between text-left border-b border-gray-200 dark:border-gray-700',
+			'border-b border-gray-200 dark:border-gray-700 bg-surface-secondary',
 			message.needsConfirmation ? 'opacity-80' : ''
 		)}
-		onclick={() => (isExpanded = !isExpanded)}
-		disabled={!message.showDetails && !message.isStreamingArguments}
 	>
-		<div class="flex items-start gap-2 flex-1 min-w-0">
+		<button
+			class="w-full p-2 hover:bg-surface-hover transition-colors flex items-start gap-2 text-left"
+			onclick={() => (isExpanded = !isExpanded)}
+			disabled={!message.showDetails && !message.isStreamingArguments}
+		>
 			{#if message.showDetails || message.isStreamingArguments}
 				<span class="shrink-0 mt-0.5">
 					{#if isExpanded}
@@ -128,41 +130,51 @@
 					<span class="text-green-500">✓</span>
 				{/if}
 			</span>
-			<div class="flex flex-col gap-1 min-w-0 flex-1">
-				<span class="text-primary font-medium text-2xs">
-					{message.content}
-				</span>
-				{#if referencedItems.length > 0}
-					<div class="flex flex-row flex-wrap items-center gap-1 min-w-0">
-						{#each referencedItems as item (item.path)}
-							<a
-								href={itemHref(item, $workspaceStore ?? undefined)}
-								target="_blank"
-								rel="noopener noreferrer"
-								onclick={(e) => e.stopPropagation()}
-								title={item.summary || item.path}
-								class="group inline-flex items-center gap-1 px-1 py-0.5 rounded hover:bg-surface-hover text-primary no-underline font-mono text-2xs max-w-full min-w-0"
+			<span class="text-primary font-medium text-2xs flex-1 min-w-0">
+				{message.content}
+			</span>
+		</button>
+		{#if referencedItems.length > 0}
+			<!-- Chip row lives outside the toggle button so we can include real <button>s
+				 for the "open in drawer" affordance without nesting interactive elements. -->
+			<div class="flex flex-row flex-wrap items-center gap-1 px-2 pb-2 -mt-1 min-w-0">
+				{#each referencedItems as item (item.path)}
+					<span class="group inline-flex items-center min-w-0 max-w-full">
+						<a
+							href={itemHref(item, $workspaceStore ?? undefined)}
+							target="_blank"
+							rel="noopener noreferrer"
+							title={item.summary || item.path}
+							class="inline-flex items-center gap-1 px-1 py-0.5 rounded hover:bg-surface-hover text-primary no-underline font-mono text-2xs min-w-0"
+						>
+							<span class="inline-flex shrink-0">
+								<RowIcon kind={item.kind} size={12} />
+							</span>
+							<span class="truncate">{item.path}</span>
+							<ExternalLink
+								class="w-2.5 h-2.5 shrink-0 text-tertiary opacity-0 group-hover:opacity-100 transition-opacity"
+							/>
+						</a>
+						{#if hasInlineDrawer(item.kind)}
+							<button
+								type="button"
+								onclick={() =>
+									aiChatManager.toggleWorkspaceItemDrawer({
+										kind: item.kind,
+										path: item.path
+									})}
+								title="Open in drawer"
+								aria-label="Open {item.path} in drawer"
+								class="ml-0.5 inline-flex self-center shrink-0 rounded p-0.5 text-tertiary hover:bg-surface-hover opacity-0 group-hover:opacity-100 transition-opacity"
 							>
-								<span class="inline-flex shrink-0">
-									{#if item.kind === 'script'}
-										<Code2 class="w-3 h-3 text-blue-500" />
-									{:else if item.kind === 'flow'}
-										<BarsStaggered size={12} style="" class="!fill-current text-teal-500" />
-									{:else}
-										<LayoutDashboard class="w-3 h-3 text-orange-500" />
-									{/if}
-								</span>
-								<span class="truncate">{item.path}</span>
-								<ExternalLink
-									class="w-2.5 h-2.5 shrink-0 text-tertiary opacity-0 group-hover:opacity-100 transition-opacity"
-								/>
-							</a>
-						{/each}
-					</div>
-				{/if}
+								<PanelRight class="w-2.5 h-2.5" />
+							</button>
+						{/if}
+					</span>
+				{/each}
 			</div>
-		</div>
-	</button>
+		{/if}
+	</div>
 
 	<!-- Expanded Content -->
 	{#if isExpanded}

--- a/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
@@ -108,51 +108,59 @@
 		onclick={() => (isExpanded = !isExpanded)}
 		disabled={!message.showDetails && !message.isStreamingArguments}
 	>
-		<div class="flex items-center gap-2 flex-1">
+		<div class="flex items-start gap-2 flex-1 min-w-0">
 			{#if message.showDetails || message.isStreamingArguments}
-				{#if isExpanded}
-					<ChevronDown class="w-3 h-3 text-secondary" />
-				{:else}
-					<ChevronRight class="w-3 h-3 text-secondary" />
-				{/if}
+				<span class="shrink-0 mt-0.5">
+					{#if isExpanded}
+						<ChevronDown class="w-3 h-3 text-secondary" />
+					{:else}
+						<ChevronRight class="w-3 h-3 text-secondary" />
+					{/if}
+				</span>
 			{/if}
 
-			{#if message.isLoading && !message.needsConfirmation}
-				<Loader2 class="w-3.5 h-3.5 animate-spin text-blue-500" />
-			{:else if message.error}
-				<span class="text-red-500">✗</span>
-			{:else if !message.isLoading && !message.error}
-				<span class="text-green-500">✓</span>
-			{/if}
-			<span class="text-primary font-medium text-2xs">
-				{message.content}
+			<span class="shrink-0 mt-0.5">
+				{#if message.isLoading && !message.needsConfirmation}
+					<Loader2 class="w-3.5 h-3.5 animate-spin text-blue-500" />
+				{:else if message.error}
+					<span class="text-red-500">✗</span>
+				{:else if !message.isLoading && !message.error}
+					<span class="text-green-500">✓</span>
+				{/if}
 			</span>
-			{#if referencedItems.length > 0}
-				<div class="flex flex-row flex-wrap items-center gap-1 ml-1 min-w-0">
-					{#each referencedItems as item (item.path)}
-						<a
-							href={itemHref(item, $workspaceStore ?? undefined)}
-							target="_blank"
-							rel="noopener noreferrer"
-							onclick={(e) => e.stopPropagation()}
-							title={item.summary || item.path}
-							class="inline-flex items-center gap-1 px-1 py-0.5 rounded bg-surface-secondary hover:bg-surface-hover border border-gray-200 dark:border-gray-700 text-primary no-underline font-mono text-2xs max-w-[14rem] truncate"
-						>
-							<span class="inline-flex shrink-0 text-secondary">
-								{#if item.kind === 'script'}
-									<Code2 class="w-3 h-3" />
-								{:else if item.kind === 'flow'}
-									<BarsStaggered size={12} style="" class="!fill-current" />
-								{:else}
-									<LayoutDashboard class="w-3 h-3" />
-								{/if}
-							</span>
-							<span class="truncate">{item.path}</span>
-							<ExternalLink class="w-2.5 h-2.5 shrink-0 text-tertiary" />
-						</a>
-					{/each}
-				</div>
-			{/if}
+			<div class="flex flex-col gap-1 min-w-0 flex-1">
+				<span class="text-primary font-medium text-2xs">
+					{message.content}
+				</span>
+				{#if referencedItems.length > 0}
+					<div class="flex flex-row flex-wrap items-center gap-1 min-w-0">
+						{#each referencedItems as item (item.path)}
+							<a
+								href={itemHref(item, $workspaceStore ?? undefined)}
+								target="_blank"
+								rel="noopener noreferrer"
+								onclick={(e) => e.stopPropagation()}
+								title={item.summary || item.path}
+								class="group inline-flex items-center gap-1 px-1 py-0.5 rounded hover:bg-surface-hover text-primary no-underline font-mono text-2xs max-w-full min-w-0"
+							>
+								<span class="inline-flex shrink-0">
+									{#if item.kind === 'script'}
+										<Code2 class="w-3 h-3 text-blue-500" />
+									{:else if item.kind === 'flow'}
+										<BarsStaggered size={12} style="" class="!fill-current text-teal-500" />
+									{:else}
+										<LayoutDashboard class="w-3 h-3 text-orange-500" />
+									{/if}
+								</span>
+								<span class="truncate">{item.path}</span>
+								<ExternalLink
+									class="w-2.5 h-2.5 shrink-0 text-tertiary opacity-0 group-hover:opacity-100 transition-opacity"
+								/>
+							</a>
+						{/each}
+					</div>
+				{/if}
+			</div>
 		</div>
 	</button>
 

--- a/frontend/src/lib/components/copilot/chat/WorkspaceItemDrawerHost.svelte
+++ b/frontend/src/lib/components/copilot/chat/WorkspaceItemDrawerHost.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import VariableEditor from '$lib/components/VariableEditor.svelte'
+	import ResourceEditorDrawer from '$lib/components/ResourceEditorDrawer.svelte'
+	import { aiChatManager } from './AIChatManager.svelte'
+
+	/**
+	 * Hosts the workspace-item drawers next to the chat. When a chat pill asks to open
+	 * one, the host calls the matching editor's open method; when the pill is clicked
+	 * again (toggle) or the chat manager wants to close, the host calls `closeDrawer`.
+	 *
+	 * Both editors are mounted unconditionally on purpose. Their internal `<Drawer>`
+	 * wires close handling at mount time, and the resources page (which has worked for
+	 * a long time) uses the same always-mounted pattern. Conditional mounting via
+	 * `{#if}` was racy — the `on:close` handler captured an undefined reference and the
+	 * X button stopped closing the drawer. The drawer markup stays hidden until
+	 * `openDrawer()` is called, and the heavy editor body is still loaded lazily via
+	 * `import()` inside `ResourceEditorDrawer`, so this isn't expensive.
+	 */
+
+	let variableEditor: VariableEditor | undefined = $state()
+	let resourceEditor: ResourceEditorDrawer | undefined = $state()
+
+	let lastVersion = -1
+
+	$effect(() => {
+		const t = aiChatManager.workspaceItemDrawer
+		if (!t) return
+		// React on every version bump (covers open, re-open, and toggle-close).
+		if (t.version === lastVersion) return
+		lastVersion = t.version
+		if (!t.open) {
+			variableEditor?.closeDrawer()
+			resourceEditor?.closeDrawer()
+			return
+		}
+		if (t.kind === 'variable' && variableEditor) {
+			variableEditor.editVariable(t.path)
+		} else if (t.kind === 'resource' && resourceEditor) {
+			resourceEditor.initEdit(t.path)
+		}
+	})
+</script>
+
+<VariableEditor
+	bind:this={variableEditor}
+	on:close={() => aiChatManager.markWorkspaceItemDrawerClosed()}
+/>
+<ResourceEditorDrawer
+	bind:this={resourceEditor}
+	on:close={() => aiChatManager.markWorkspaceItemDrawerClosed()}
+/>

--- a/frontend/src/lib/components/copilot/chat/workspaceItems.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/workspaceItems.svelte.ts
@@ -1,9 +1,42 @@
-import { AppService, FlowService, ScriptService } from '$lib/gen'
+import {
+	AppService,
+	AzureTriggerService,
+	EmailTriggerService,
+	FlowService,
+	GcpTriggerService,
+	HttpTriggerService,
+	KafkaTriggerService,
+	MqttTriggerService,
+	NatsTriggerService,
+	PostgresTriggerService,
+	ResourceService,
+	ScheduleService,
+	ScriptService,
+	SqsTriggerService,
+	VariableService,
+	WebsocketTriggerService
+} from '$lib/gen'
 import { findAndReplace } from 'mdast-util-find-and-replace'
 import { visit } from 'unist-util-visit'
 import type { Root, InlineCode, Link } from 'mdast'
 
-export type WindmillItemKind = 'script' | 'flow' | 'app'
+export type WindmillItemKind =
+	| 'script'
+	| 'flow'
+	| 'app'
+	| 'variable'
+	| 'resource'
+	| 'schedule'
+	| 'http_trigger'
+	| 'websocket_trigger'
+	| 'kafka_trigger'
+	| 'nats_trigger'
+	| 'postgres_trigger'
+	| 'mqtt_trigger'
+	| 'sqs_trigger'
+	| 'gcp_trigger'
+	| 'azure_trigger'
+	| 'email_trigger'
 
 export interface WorkspaceItemEntry {
 	kind: WindmillItemKind
@@ -30,16 +63,60 @@ export const WINDMILL_PATH_REGEX =
  */
 const WINDMILL_PATH_EXACT_REGEX = /^[uf]\/[A-Za-z0-9_.\-]+\/[A-Za-z0-9_./\-]*[A-Za-z0-9_\-]$/
 
-const itemKindToRoute: Record<WindmillItemKind, string> = {
-	script: '/scripts/get',
-	flow: '/flows/get',
-	app: '/apps/get'
+/**
+ * URL builder per kind.
+ *
+ * - For scripts/flows/apps we link to the dedicated `/get/{path}` page.
+ * - For everything else, link to the relevant list page with a hash fragment that the
+ *   list page reads on mount to pop the editor drawer open. Hash format mirrors what
+ *   each list page already expects (`#<path>` for most, `#/resource/<path>` for the
+ *   resources page).
+ */
+const itemKindToHref: Record<WindmillItemKind, (path: string) => string> = {
+	script: (p) => `/scripts/get/${p}`,
+	flow: (p) => `/flows/get/${p}`,
+	app: (p) => `/apps/get/${p}`,
+	variable: (p) => `/variables#${p}`,
+	resource: (p) => `/resources#/resource/${p}`,
+	schedule: (p) => `/schedules#${p}`,
+	http_trigger: (p) => `/routes#${p}`,
+	websocket_trigger: (p) => `/websocket_triggers/#${p}`,
+	kafka_trigger: (p) => `/kafka_triggers/#${p}`,
+	nats_trigger: (p) => `/nats_triggers/#${p}`,
+	postgres_trigger: (p) => `/postgres_triggers/#${p}`,
+	mqtt_trigger: (p) => `/mqtt_triggers/#${p}`,
+	sqs_trigger: (p) => `/sqs_triggers/#${p}`,
+	gcp_trigger: (p) => `/gcp_triggers/#${p}`,
+	azure_trigger: (p) => `/azure_triggers/#${p}`,
+	email_trigger: (p) => `/email_triggers/#${p}`
 }
 
-/** Build the in-app URL for a resolved workspace item. */
+/** Kinds whose items can be opened in an inline drawer from the chat. */
+const DRAWERABLE_KINDS = new Set<WindmillItemKind>(['variable', 'resource'])
+
+/** Whether the chat pill should expose an "open in drawer" affordance for this kind. */
+export function hasInlineDrawer(kind: WindmillItemKind): boolean {
+	return DRAWERABLE_KINDS.has(kind)
+}
+
+/**
+ * Build the in-app URL for a resolved workspace item.
+ *
+ * The workspace query param goes before the hash so the SvelteKit router still applies
+ * it; the hash fragment is consumed client-side by the list page on mount to open the
+ * matching drawer.
+ */
 export function itemHref(entry: WorkspaceItemEntry, workspace?: string): string {
-	const base = `${itemKindToRoute[entry.kind]}/${entry.path}`
-	return workspace ? `${base}?workspace=${workspace}` : base
+	const raw = itemKindToHref[entry.kind](entry.path)
+	if (!workspace) return raw
+	const hashIdx = raw.indexOf('#')
+	if (hashIdx === -1) {
+		return raw.includes('?') ? `${raw}&workspace=${workspace}` : `${raw}?workspace=${workspace}`
+	}
+	const pathPart = raw.slice(0, hashIdx)
+	const hashPart = raw.slice(hashIdx)
+	const sep = pathPart.includes('?') ? '&' : '?'
+	return `${pathPart}${sep}workspace=${workspace}${hashPart}`
 }
 
 /**
@@ -54,22 +131,78 @@ class WorkspaceItemRegistry {
 	#inflight: Map<string, Promise<void>> = new Map()
 
 	private async load(workspace: string): Promise<void> {
-		const [scripts, flows, apps] = await Promise.all([
+		// Fire every list endpoint in parallel. `.catch(() => [])` keeps a single failing
+		// endpoint from poisoning the whole snapshot — the registry just records empty
+		// for that kind, the rest still resolve.
+		const [
+			scripts,
+			flows,
+			apps,
+			variables,
+			resources,
+			schedules,
+			httpTriggers,
+			wsTriggers,
+			kafkaTriggers,
+			natsTriggers,
+			pgTriggers,
+			mqttTriggers,
+			sqsTriggers,
+			gcpTriggers,
+			azureTriggers,
+			emailTriggers
+		] = await Promise.all([
 			ScriptService.listScripts({ workspace }).catch(() => []),
 			FlowService.listFlows({ workspace }).catch(() => []),
-			AppService.listApps({ workspace }).catch(() => [])
+			AppService.listApps({ workspace }).catch(() => []),
+			VariableService.listVariable({ workspace }).catch(() => []),
+			ResourceService.listResource({ workspace }).catch(() => []),
+			ScheduleService.listSchedules({ workspace }).catch(() => []),
+			HttpTriggerService.listHttpTriggers({ workspace }).catch(() => []),
+			WebsocketTriggerService.listWebsocketTriggers({ workspace }).catch(() => []),
+			KafkaTriggerService.listKafkaTriggers({ workspace }).catch(() => []),
+			NatsTriggerService.listNatsTriggers({ workspace }).catch(() => []),
+			PostgresTriggerService.listPostgresTriggers({ workspace }).catch(() => []),
+			MqttTriggerService.listMqttTriggers({ workspace }).catch(() => []),
+			SqsTriggerService.listSqsTriggers({ workspace }).catch(() => []),
+			GcpTriggerService.listGcpTriggers({ workspace }).catch(() => []),
+			AzureTriggerService.listAzureTriggers({ workspace }).catch(() => []),
+			EmailTriggerService.listEmailTriggers({ workspace }).catch(() => [])
 		])
 
 		const map = new Map<string, WorkspaceItemEntry>()
-		for (const s of scripts) {
-			map.set(s.path, { kind: 'script', path: s.path, summary: s.summary })
+		const add = (
+			items: Array<{ path: string; summary?: string | null }>,
+			kind: WindmillItemKind
+		) => {
+			for (const it of items) {
+				// First writer wins — scripts/flows/apps are checked first so they win over
+				// triggers if a path collides (extremely unlikely but possible across kinds).
+				if (!map.has(it.path)) {
+					map.set(it.path, { kind, path: it.path, summary: it.summary ?? undefined })
+				}
+			}
 		}
-		for (const f of flows) {
-			map.set(f.path, { kind: 'flow', path: f.path, summary: f.summary })
-		}
-		for (const a of apps) {
-			map.set(a.path, { kind: 'app', path: a.path, summary: a.summary })
-		}
+		// Order matters because of first-writer-wins on path collisions. Resources are
+		// added before variables: Windmill auto-creates a companion variable at the same
+		// path for every resource, and a path written by the user almost always means the
+		// resource, not the hidden variable.
+		add(scripts, 'script')
+		add(flows, 'flow')
+		add(apps, 'app')
+		add(resources, 'resource')
+		add(variables, 'variable')
+		add(schedules, 'schedule')
+		add(httpTriggers, 'http_trigger')
+		add(wsTriggers, 'websocket_trigger')
+		add(kafkaTriggers, 'kafka_trigger')
+		add(natsTriggers, 'nats_trigger')
+		add(pgTriggers, 'postgres_trigger')
+		add(mqttTriggers, 'mqtt_trigger')
+		add(sqsTriggers, 'sqs_trigger')
+		add(gcpTriggers, 'gcp_trigger')
+		add(azureTriggers, 'azure_trigger')
+		add(emailTriggers, 'email_trigger')
 
 		// Build a new outer map to trigger reactivity on consumers using $derived.
 		const next = new Map(this.#byWorkspace)

--- a/frontend/src/lib/components/copilot/chat/workspaceItems.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/workspaceItems.svelte.ts
@@ -1,0 +1,185 @@
+import { AppService, FlowService, ScriptService } from '$lib/gen'
+import { findAndReplace } from 'mdast-util-find-and-replace'
+import type { Root } from 'mdast'
+
+export type WindmillItemKind = 'script' | 'flow' | 'app'
+
+export interface WorkspaceItemEntry {
+	kind: WindmillItemKind
+	path: string
+	summary?: string
+}
+
+/**
+ * Matches Windmill paths of the form `u/<owner>/<path>` or `f/<folder>/<path>`.
+ *
+ * Owners may contain `[A-Za-z0-9._-]`; the trailing path can include dots and slashes
+ * (sub-paths, version segments) but must end on an alphanumeric / underscore / hyphen —
+ * this prevents the regex from gobbling sentence punctuation like the period in
+ * "look at f/foo/bar."
+ *
+ * The negative lookbehind prevents matches embedded in URLs or longer identifiers.
+ */
+export const WINDMILL_PATH_REGEX =
+	/(?<![A-Za-z0-9/_.\-])([uf]\/[A-Za-z0-9_.\-]+\/[A-Za-z0-9_./\-]*[A-Za-z0-9_\-])/g
+
+const itemKindToRoute: Record<WindmillItemKind, string> = {
+	script: '/scripts/get',
+	flow: '/flows/get',
+	app: '/apps/get'
+}
+
+/** Build the in-app URL for a resolved workspace item. */
+export function itemHref(entry: WorkspaceItemEntry, workspace?: string): string {
+	const base = `${itemKindToRoute[entry.kind]}/${entry.path}`
+	return workspace ? `${base}?workspace=${workspace}` : base
+}
+
+/**
+ * Reactive registry that caches script/flow/app paths per workspace.
+ *
+ * - Loads lazily on first call to `ensureLoaded`
+ * - Dedups concurrent in-flight loads
+ * - Exposes a reactive map (`$state`) so consumers re-render once data lands
+ */
+class WorkspaceItemRegistry {
+	#byWorkspace: Map<string, Map<string, WorkspaceItemEntry>> = $state(new Map())
+	#inflight: Map<string, Promise<void>> = new Map()
+
+	private async load(workspace: string): Promise<void> {
+		const [scripts, flows, apps] = await Promise.all([
+			ScriptService.listScripts({ workspace }).catch(() => []),
+			FlowService.listFlows({ workspace }).catch(() => []),
+			AppService.listApps({ workspace }).catch(() => [])
+		])
+
+		const map = new Map<string, WorkspaceItemEntry>()
+		for (const s of scripts) {
+			map.set(s.path, { kind: 'script', path: s.path, summary: s.summary })
+		}
+		for (const f of flows) {
+			map.set(f.path, { kind: 'flow', path: f.path, summary: f.summary })
+		}
+		for (const a of apps) {
+			map.set(a.path, { kind: 'app', path: a.path, summary: a.summary })
+		}
+
+		// Build a new outer map to trigger reactivity on consumers using $derived.
+		const next = new Map(this.#byWorkspace)
+		next.set(workspace, map)
+		this.#byWorkspace = next
+	}
+
+	/** Ensure the workspace items are loaded. Returns the in-flight promise if any. */
+	ensureLoaded(workspace: string): Promise<void> {
+		if (!workspace) return Promise.resolve()
+		if (this.#byWorkspace.has(workspace)) return Promise.resolve()
+		let pending = this.#inflight.get(workspace)
+		if (!pending) {
+			pending = this.load(workspace).finally(() => this.#inflight.delete(workspace))
+			this.#inflight.set(workspace, pending)
+		}
+		return pending
+	}
+
+	/** Synchronously resolve a path. Returns undefined if the workspace isn't loaded yet. */
+	resolve(workspace: string, path: string): WorkspaceItemEntry | undefined {
+		if (!workspace) return undefined
+		return this.#byWorkspace.get(workspace)?.get(path)
+	}
+
+	/** Whether the registry has data for the given workspace. */
+	isLoaded(workspace: string): boolean {
+		return this.#byWorkspace.has(workspace)
+	}
+
+	/** Drop the cached data for a workspace (or all workspaces). */
+	invalidate(workspace?: string): void {
+		if (workspace) {
+			if (!this.#byWorkspace.has(workspace)) return
+			const next = new Map(this.#byWorkspace)
+			next.delete(workspace)
+			this.#byWorkspace = next
+		} else {
+			this.#byWorkspace = new Map()
+		}
+	}
+
+	/** All items known for the workspace; empty if not yet loaded. */
+	items(workspace: string): WorkspaceItemEntry[] {
+		const map = this.#byWorkspace.get(workspace)
+		return map ? [...map.values()] : []
+	}
+}
+
+export const workspaceItemRegistry = new WorkspaceItemRegistry()
+
+/** Extract every Windmill-looking path from raw text (no resolution against the registry). */
+export function extractCandidatePaths(text: string | undefined | null): string[] {
+	if (!text) return []
+	const seen = new Set<string>()
+	for (const match of text.matchAll(WINDMILL_PATH_REGEX)) {
+		seen.add(match[1])
+	}
+	return [...seen]
+}
+
+/**
+ * Resolve every Windmill path mentioned in the given texts against the registry.
+ * Returns deduped entries (one per unique path).
+ */
+export function resolveMentionedItems(
+	texts: Array<string | undefined | null>,
+	workspace: string
+): WorkspaceItemEntry[] {
+	if (!workspace) return []
+	const seen = new Map<string, WorkspaceItemEntry>()
+	for (const text of texts) {
+		for (const candidate of extractCandidatePaths(text)) {
+			if (seen.has(candidate)) continue
+			const entry = workspaceItemRegistry.resolve(workspace, candidate)
+			if (entry) seen.set(candidate, entry)
+		}
+	}
+	return [...seen.values()]
+}
+
+/**
+ * Remark plugin that rewrites Windmill path tokens (`u/...`, `f/...`) into link nodes,
+ * but only when the path resolves to a known workspace item.
+ *
+ * Skips text inside link / inline code / code nodes (find-and-replace only visits Text nodes,
+ * which already excludes inlineCode/code; the explicit `ignore` covers links).
+ */
+export function remarkWindmillPaths(options: {
+	resolve: (path: string) => WorkspaceItemEntry | undefined
+	workspace?: string
+}) {
+	return () => (tree: Root) => {
+		findAndReplace(
+			tree,
+			[
+				WINDMILL_PATH_REGEX,
+				(_match: string, path: string) => {
+					const entry = options.resolve(path)
+					if (!entry) return false
+					return {
+						type: 'link',
+						url: itemHref(entry, options.workspace),
+						title: entry.summary || null,
+						data: {
+							hProperties: {
+								'data-wm-kind': entry.kind,
+								'data-wm-path': entry.path,
+								target: '_blank',
+								rel: 'noopener noreferrer'
+							}
+						},
+						children: [{ type: 'text', value: path }]
+					}
+				}
+			],
+			{ ignore: ['link', 'linkReference'] }
+		)
+	}
+}

--- a/frontend/src/lib/components/copilot/chat/workspaceItems.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/workspaceItems.svelte.ts
@@ -1,6 +1,7 @@
 import { AppService, FlowService, ScriptService } from '$lib/gen'
 import { findAndReplace } from 'mdast-util-find-and-replace'
-import type { Root } from 'mdast'
+import { visit } from 'unist-util-visit'
+import type { Root, InlineCode, Link } from 'mdast'
 
 export type WindmillItemKind = 'script' | 'flow' | 'app'
 
@@ -22,6 +23,12 @@ export interface WorkspaceItemEntry {
  */
 export const WINDMILL_PATH_REGEX =
 	/(?<![A-Za-z0-9/_.\-])([uf]\/[A-Za-z0-9_.\-]+\/[A-Za-z0-9_./\-]*[A-Za-z0-9_\-])/g
+
+/**
+ * Anchored variant of {@link WINDMILL_PATH_REGEX} for use against a whole string —
+ * matches when the entire input is exactly a path (after trimming).
+ */
+const WINDMILL_PATH_EXACT_REGEX = /^[uf]\/[A-Za-z0-9_.\-]+\/[A-Za-z0-9_./\-]*[A-Za-z0-9_\-]$/
 
 const itemKindToRoute: Record<WindmillItemKind, string> = {
 	script: '/scripts/get',
@@ -144,12 +151,41 @@ export function resolveMentionedItems(
 	return [...seen.values()]
 }
 
+/** Build the link node used to replace a resolved path token. */
+function buildPathLinkNode(
+	entry: WorkspaceItemEntry,
+	displayPath: string,
+	workspace: string | undefined
+): Link {
+	return {
+		type: 'link',
+		url: itemHref(entry, workspace),
+		title: entry.summary || null,
+		data: {
+			hProperties: {
+				'data-wm-kind': entry.kind,
+				'data-wm-path': entry.path,
+				target: '_blank',
+				rel: 'noopener noreferrer'
+			}
+		},
+		children: [{ type: 'text', value: displayPath }]
+	}
+}
+
 /**
  * Remark plugin that rewrites Windmill path tokens (`u/...`, `f/...`) into link nodes,
  * but only when the path resolves to a known workspace item.
  *
- * Skips text inside link / inline code / code nodes (find-and-replace only visits Text nodes,
- * which already excludes inlineCode/code; the explicit `ignore` covers links).
+ * Handles two cases:
+ * 1. Bare path tokens in regular text — handled by `findAndReplace`, which only visits Text
+ *    nodes (so fenced code and inline code are naturally skipped). We additionally `ignore`
+ *    existing `link` nodes so we don't break autolinked URLs.
+ * 2. Inline-code spans whose entire content is a single path — handled by a second pass via
+ *    `unist-util-visit`. LLMs often wrap identifiers in backticks (`` `u/admin/foo` ``);
+ *    when the inline code is *just* a path we treat the backticks as styling and replace
+ *    the node with a link pill. Mixed inline-code content (e.g. `` `f/foo + extra text` ``)
+ *    is left untouched.
  */
 export function remarkWindmillPaths(options: {
 	resolve: (path: string) => WorkspaceItemEntry | undefined
@@ -163,23 +199,19 @@ export function remarkWindmillPaths(options: {
 				(_match: string, path: string) => {
 					const entry = options.resolve(path)
 					if (!entry) return false
-					return {
-						type: 'link',
-						url: itemHref(entry, options.workspace),
-						title: entry.summary || null,
-						data: {
-							hProperties: {
-								'data-wm-kind': entry.kind,
-								'data-wm-path': entry.path,
-								target: '_blank',
-								rel: 'noopener noreferrer'
-							}
-						},
-						children: [{ type: 'text', value: path }]
-					}
+					return buildPathLinkNode(entry, path, options.workspace)
 				}
 			],
 			{ ignore: ['link', 'linkReference'] }
 		)
+
+		visit(tree, 'inlineCode', (node: InlineCode, index, parent) => {
+			if (!parent || typeof index !== 'number') return
+			const value = node.value.trim()
+			if (!WINDMILL_PATH_EXACT_REGEX.test(value)) return
+			const entry = options.resolve(value)
+			if (!entry) return
+			parent.children[index] = buildPathLinkNode(entry, value, options.workspace) as any
+		})
 	}
 }

--- a/frontend/src/lib/components/copilot/chat/workspaceItems.test.ts
+++ b/frontend/src/lib/components/copilot/chat/workspaceItems.test.ts
@@ -7,7 +7,20 @@ import type { Root as MdastRoot, Link, Text } from 'mdast'
 vi.mock('$lib/gen', () => ({
 	ScriptService: { listScripts: vi.fn() },
 	FlowService: { listFlows: vi.fn() },
-	AppService: { listApps: vi.fn() }
+	AppService: { listApps: vi.fn() },
+	VariableService: { listVariable: vi.fn() },
+	ResourceService: { listResource: vi.fn() },
+	ScheduleService: { listSchedules: vi.fn() },
+	HttpTriggerService: { listHttpTriggers: vi.fn() },
+	WebsocketTriggerService: { listWebsocketTriggers: vi.fn() },
+	KafkaTriggerService: { listKafkaTriggers: vi.fn() },
+	NatsTriggerService: { listNatsTriggers: vi.fn() },
+	PostgresTriggerService: { listPostgresTriggers: vi.fn() },
+	MqttTriggerService: { listMqttTriggers: vi.fn() },
+	SqsTriggerService: { listSqsTriggers: vi.fn() },
+	GcpTriggerService: { listGcpTriggers: vi.fn() },
+	AzureTriggerService: { listAzureTriggers: vi.fn() },
+	EmailTriggerService: { listEmailTriggers: vi.fn() }
 }))
 
 import {
@@ -62,13 +75,48 @@ describe('WINDMILL_PATH_REGEX', () => {
 })
 
 describe('itemHref', () => {
-	it('routes by kind and appends ?workspace when provided', () => {
+	it('routes script/flow/app to /get/{path}', () => {
 		expect(itemHref({ kind: 'script', path: 'f/a/b' })).toBe('/scripts/get/f/a/b')
 		expect(itemHref({ kind: 'flow', path: 'f/a/b' }, 'admins')).toBe(
 			'/flows/get/f/a/b?workspace=admins'
 		)
 		expect(itemHref({ kind: 'app', path: 'u/me/dash' }, 'ws1')).toBe(
 			'/apps/get/u/me/dash?workspace=ws1'
+		)
+	})
+
+	it('routes variable / resource / schedule to list page with hash to pop the drawer', () => {
+		expect(itemHref({ kind: 'variable', path: 'u/me/secret' })).toBe('/variables#u/me/secret')
+		expect(itemHref({ kind: 'resource', path: 'u/me/db' }, 'ws1')).toBe(
+			'/resources?workspace=ws1#/resource/u/me/db'
+		)
+		expect(itemHref({ kind: 'schedule', path: 'f/etl/daily' })).toBe('/schedules#f/etl/daily')
+	})
+
+	it('routes each trigger kind with hash for drawer auto-open', () => {
+		const cases: Array<[WorkspaceItemEntry['kind'], string]> = [
+			['http_trigger', '/routes#f/a/b'],
+			['websocket_trigger', '/websocket_triggers/#f/a/b'],
+			['kafka_trigger', '/kafka_triggers/#f/a/b'],
+			['nats_trigger', '/nats_triggers/#f/a/b'],
+			['postgres_trigger', '/postgres_triggers/#f/a/b'],
+			['mqtt_trigger', '/mqtt_triggers/#f/a/b'],
+			['sqs_trigger', '/sqs_triggers/#f/a/b'],
+			['gcp_trigger', '/gcp_triggers/#f/a/b'],
+			['azure_trigger', '/azure_triggers/#f/a/b'],
+			['email_trigger', '/email_triggers/#f/a/b']
+		]
+		for (const [kind, expected] of cases) {
+			expect(itemHref({ kind, path: 'f/a/b' })).toBe(expected)
+		}
+	})
+
+	it('puts workspace query param before the hash so the router applies it', () => {
+		expect(itemHref({ kind: 'variable', path: 'u/me/secret' }, 'ws1')).toBe(
+			'/variables?workspace=ws1#u/me/secret'
+		)
+		expect(itemHref({ kind: 'http_trigger', path: 'f/a/b' }, 'ws1')).toBe(
+			'/routes?workspace=ws1#f/a/b'
 		)
 	})
 })

--- a/frontend/src/lib/components/copilot/chat/workspaceItems.test.ts
+++ b/frontend/src/lib/components/copilot/chat/workspaceItems.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkRehype from 'remark-rehype'
+import type { Root as MdastRoot, Link, Text } from 'mdast'
 
 vi.mock('$lib/gen', () => ({
 	ScriptService: { listScripts: vi.fn() },
@@ -6,7 +10,13 @@ vi.mock('$lib/gen', () => ({
 	AppService: { listApps: vi.fn() }
 }))
 
-import { extractCandidatePaths, WINDMILL_PATH_REGEX } from './workspaceItems.svelte'
+import {
+	extractCandidatePaths,
+	itemHref,
+	remarkWindmillPaths,
+	WINDMILL_PATH_REGEX,
+	type WorkspaceItemEntry
+} from './workspaceItems.svelte'
 
 describe('WINDMILL_PATH_REGEX', () => {
 	it('matches simple folder and user paths', () => {
@@ -48,5 +58,184 @@ describe('WINDMILL_PATH_REGEX', () => {
 
 	it('exposes a global regex', () => {
 		expect(WINDMILL_PATH_REGEX.global).toBe(true)
+	})
+})
+
+describe('itemHref', () => {
+	it('routes by kind and appends ?workspace when provided', () => {
+		expect(itemHref({ kind: 'script', path: 'f/a/b' })).toBe('/scripts/get/f/a/b')
+		expect(itemHref({ kind: 'flow', path: 'f/a/b' }, 'admins')).toBe(
+			'/flows/get/f/a/b?workspace=admins'
+		)
+		expect(itemHref({ kind: 'app', path: 'u/me/dash' }, 'ws1')).toBe(
+			'/apps/get/u/me/dash?workspace=ws1'
+		)
+	})
+})
+
+const SAMPLE_ENTRIES: Record<string, WorkspaceItemEntry> = {
+	'f/marketing/send_email': {
+		kind: 'script',
+		path: 'f/marketing/send_email',
+		summary: 'Send marketing email'
+	},
+	'u/admin/cleanup_old_jobs': {
+		kind: 'flow',
+		path: 'u/admin/cleanup_old_jobs',
+		summary: 'Cleanup old jobs'
+	},
+	'f/ops/dashboard': { kind: 'app', path: 'f/ops/dashboard', summary: 'Ops dashboard' }
+}
+
+function buildProcessor(workspace?: string) {
+	return unified()
+		.use(remarkParse)
+		.use(remarkWindmillPaths({ resolve: (p) => SAMPLE_ENTRIES[p], workspace }))
+}
+
+function findLinks(tree: MdastRoot): Link[] {
+	const out: Link[] = []
+	const walk = (node: any) => {
+		if (!node) return
+		if (node.type === 'link') out.push(node as Link)
+		if (Array.isArray(node.children)) node.children.forEach(walk)
+	}
+	walk(tree)
+	return out
+}
+
+function findText(tree: MdastRoot): Text[] {
+	const out: Text[] = []
+	const walk = (node: any) => {
+		if (!node) return
+		if (node.type === 'text') out.push(node as Text)
+		if (Array.isArray(node.children)) node.children.forEach(walk)
+	}
+	walk(tree)
+	return out
+}
+
+describe('remarkWindmillPaths (mdast)', () => {
+	it('rewrites known script / flow / app paths to link nodes with hProperties', () => {
+		const processor = buildProcessor('admins')
+		const tree = processor.runSync(
+			processor.parse(
+				'Use f/marketing/send_email and u/admin/cleanup_old_jobs, also try f/ops/dashboard.'
+			)
+		) as MdastRoot
+
+		const links = findLinks(tree)
+		expect(links).toHaveLength(3)
+
+		const byPath = Object.fromEntries(
+			links.map((l) => [(l.children[0] as Text).value, l])
+		) as Record<string, Link>
+
+		expect(byPath['f/marketing/send_email'].url).toBe(
+			'/scripts/get/f/marketing/send_email?workspace=admins'
+		)
+		expect(byPath['u/admin/cleanup_old_jobs'].url).toBe(
+			'/flows/get/u/admin/cleanup_old_jobs?workspace=admins'
+		)
+		expect(byPath['f/ops/dashboard'].url).toBe('/apps/get/f/ops/dashboard?workspace=admins')
+
+		expect(byPath['f/marketing/send_email'].title).toBe('Send marketing email')
+
+		const props = byPath['f/marketing/send_email'].data?.hProperties as Record<string, string>
+		expect(props['data-wm-kind']).toBe('script')
+		expect(props['data-wm-path']).toBe('f/marketing/send_email')
+		expect(props.target).toBe('_blank')
+		expect(props.rel).toBe('noopener noreferrer')
+	})
+
+	it('leaves unknown paths as plain text', () => {
+		const processor = buildProcessor()
+		const tree = processor.runSync(
+			processor.parse('Looking for f/nope/missing or u/ghost/script')
+		) as MdastRoot
+		expect(findLinks(tree)).toHaveLength(0)
+		const joined = findText(tree)
+			.map((t) => t.value)
+			.join('')
+		expect(joined).toContain('f/nope/missing')
+		expect(joined).toContain('u/ghost/script')
+	})
+
+	it('rewrites standalone inline-code paths into link pills', () => {
+		const processor = buildProcessor('admins')
+		const tree = processor.runSync(
+			processor.parse('Open `f/marketing/send_email` to see it.')
+		) as MdastRoot
+		const links = findLinks(tree)
+		expect(links).toHaveLength(1)
+		expect(links[0].url).toBe('/scripts/get/f/marketing/send_email?workspace=admins')
+		expect((links[0].data?.hProperties as Record<string, string>)['data-wm-kind']).toBe('script')
+	})
+
+	it('leaves inline code alone when it contains more than just a path', () => {
+		const processor = buildProcessor()
+		const tree = processor.runSync(
+			processor.parse('Like `f/marketing/send_email and friends` should stay code.')
+		) as MdastRoot
+		expect(findLinks(tree)).toHaveLength(0)
+	})
+
+	it('does not rewrite paths inside fenced code blocks', () => {
+		const processor = buildProcessor()
+		const tree = processor.runSync(
+			processor.parse('```\nf/marketing/send_email stays in the block\n```\n')
+		) as MdastRoot
+		expect(findLinks(tree)).toHaveLength(0)
+	})
+
+	it('leaves inline code untouched when the wrapped path is unknown', () => {
+		const processor = buildProcessor()
+		const tree = processor.runSync(processor.parse('Try `f/nope/missing` instead.')) as MdastRoot
+		expect(findLinks(tree)).toHaveLength(0)
+	})
+
+	it('does not rewrite paths inside existing links (e.g. autolinked URLs)', () => {
+		const processor = buildProcessor()
+		// Markdown-explicit link with a URL containing what looks like a Windmill path.
+		const tree = processor.runSync(
+			processor.parse('See [docs](https://example.com/f/marketing/send_email).')
+		) as MdastRoot
+		const links = findLinks(tree)
+		expect(links).toHaveLength(1)
+		// Original docs link preserved, no synthetic Windmill link added.
+		expect(links[0].url).toBe('https://example.com/f/marketing/send_email')
+		expect(links[0].data?.hProperties).toBeUndefined()
+	})
+
+	it('handles bold / italic wrapped paths', () => {
+		const processor = buildProcessor()
+		const tree = processor.runSync(
+			processor.parse('Run **f/marketing/send_email** today, or _u/admin/cleanup_old_jobs_.')
+		) as MdastRoot
+		const links = findLinks(tree)
+		expect(links).toHaveLength(2)
+		expect(new Set(links.map((l) => (l.children[0] as Text).value))).toEqual(
+			new Set(['f/marketing/send_email', 'u/admin/cleanup_old_jobs'])
+		)
+	})
+
+	it('preserves data attributes through remark-rehype', () => {
+		const processor = buildProcessor('admins').use(remarkRehype, { allowDangerousHtml: true })
+		const hast: any = processor.runSync(processor.parse('Use f/marketing/send_email today.'))
+		// Walk hast tree to find <a> element.
+		const links: any[] = []
+		const walk = (node: any) => {
+			if (!node) return
+			if (node.type === 'element' && node.tagName === 'a') links.push(node)
+			if (Array.isArray(node.children)) node.children.forEach(walk)
+		}
+		walk(hast)
+		expect(links).toHaveLength(1)
+		expect(links[0].properties.href).toBe('/scripts/get/f/marketing/send_email?workspace=admins')
+		// hast normalizes target/rel as standard attrs; data-* stays kebab-case.
+		expect(links[0].properties['dataWmKind'] ?? links[0].properties['data-wm-kind']).toBe('script')
+		expect(links[0].properties['dataWmPath'] ?? links[0].properties['data-wm-path']).toBe(
+			'f/marketing/send_email'
+		)
 	})
 })

--- a/frontend/src/lib/components/copilot/chat/workspaceItems.test.ts
+++ b/frontend/src/lib/components/copilot/chat/workspaceItems.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('$lib/gen', () => ({
+	ScriptService: { listScripts: vi.fn() },
+	FlowService: { listFlows: vi.fn() },
+	AppService: { listApps: vi.fn() }
+}))
+
+import { extractCandidatePaths, WINDMILL_PATH_REGEX } from './workspaceItems.svelte'
+
+describe('WINDMILL_PATH_REGEX', () => {
+	it('matches simple folder and user paths', () => {
+		expect(extractCandidatePaths('Use f/marketing/send_email today')).toEqual([
+			'f/marketing/send_email'
+		])
+		expect(extractCandidatePaths('Check u/admin/cleanup')).toEqual(['u/admin/cleanup'])
+	})
+
+	it('matches paths with sub-folders and dotted segments', () => {
+		expect(extractCandidatePaths('Pipeline f/etl/jobs/ingest_users.v2 runs nightly')).toEqual([
+			'f/etl/jobs/ingest_users.v2'
+		])
+	})
+
+	it('matches usernames containing dots (e.g. firstname.lastname)', () => {
+		expect(extractCandidatePaths('Owned by u/jane.doe/report')).toEqual(['u/jane.doe/report'])
+	})
+
+	it('strips trailing sentence punctuation', () => {
+		expect(extractCandidatePaths('Look at f/foo/bar.')).toEqual(['f/foo/bar'])
+		expect(extractCandidatePaths('Try f/foo/bar, please')).toEqual(['f/foo/bar'])
+		expect(extractCandidatePaths('Is f/foo/bar?')).toEqual(['f/foo/bar'])
+	})
+
+	it('skips matches inside URLs', () => {
+		expect(extractCandidatePaths('See https://example.com/u/me/script for context')).toEqual([])
+	})
+
+	it('does not match incomplete paths', () => {
+		expect(extractCandidatePaths('I tried f/folder/ but nothing')).toEqual([])
+		expect(extractCandidatePaths('Just u/me')).toEqual([])
+	})
+
+	it('returns multiple unique paths from one string', () => {
+		const paths = extractCandidatePaths('Run f/a/one then f/b/two and again f/a/one')
+		expect(paths.sort()).toEqual(['f/a/one', 'f/b/two'])
+	})
+
+	it('exposes a global regex', () => {
+		expect(WINDMILL_PATH_REGEX.global).toBe(true)
+	})
+})


### PR DESCRIPTION
## Summary

Improves AI chat UX by detecting Windmill paths (`u/...`, `f/...`) in assistant messages and tool calls, then rendering them as clickable pills with the matching kind icon. The lookup is backed by a per-workspace cache that loads lazily, dedupes concurrent loads, and is reactive so messages re-render once data arrives.

## Changes

- **New `workspaceItems.svelte.ts`**
  - `WorkspaceItemRegistry`: per-workspace `$state` cache of script / flow / app paths; lazy `ensureLoaded`, dedup of concurrent loads, `invalidate`, `items`.
  - `WINDMILL_PATH_REGEX` + `extractCandidatePaths`: detect paths in free-form text. Skips URL-embedded matches via lookbehind and stops before trailing sentence punctuation.
  - `remarkWindmillPaths`: remark plugin (via `mdast-util-find-and-replace`, added to `package.json`) that rewrites resolvable tokens into link nodes — unresolved tokens stay plain text. Ignores `link`/`linkReference` parents; inline-code / code-blocks are naturally skipped since find-and-replace only visits `text` nodes.
  - `resolveMentionedItems`: pure helper used by the chat manager to list mentions.
- **`AssistantMessage.svelte`**: plugs the remark plugin into the existing `<Markdown>` and triggers `ensureLoaded`. The `plugins` derivation reads `workspaceItemRegistry.isLoaded(ws)` so it re-runs (and svelte-exmarkdown re-parses) once the load lands — addresses a reactivity hole flagged in review.
- **`LinkRenderer.svelte`**: detects Windmill-kind links by URL prefix (`/scripts/get/`, `/flows/get/`, `/apps/get/`) and renders them as pills with Code2 / BarsStaggered / LayoutDashboard icons. Regular external links keep the original behavior.
- **`ToolExecutionDisplay.svelte`**: scans `message.parameters` for canonical fields (`path`, `script_path`, `flow_path`, `app_path`, `runnable_path`), falls back to a regex sweep, and shows each resolved item in the tool header as a clickable chip + `ExternalLink` (click is `stopPropagation`'d so it doesn't toggle the row).
- **`AIChatManager.svelte.ts`**: new `mentionedItems: WorkspaceItemEntry[]` derived from all displayed messages so picker UIs can surface "items mentioned in this chat".
- **Tests**: `workspaceItems.test.ts` covers the regex / `extractCandidatePaths` for simple paths, sub-folders, dotted usernames, trailing punctuation, URL embedding, incomplete paths, and dedupe.

## Test plan

- [ ] In a workspace with at least one script, flow, and app, send an AI prompt that produces an assistant reply containing each kind plus a non-existent path; verify the three known paths become pills with the correct icon and the unknown one stays as plain text.
- [ ] With network throttling (Slow 3G), confirm a reply that renders before `listScripts/listFlows/listApps` finish still becomes pills once the registry loads (no manual refresh).
- [ ] Trigger a tool that takes a path (e.g. `get_runnable_details`, `run_script`) and confirm the referenced-items row appears in the tool header, opens in a new tab, and clicking the chip does not collapse the tool body.
- [ ] Verify regular external links (`[click](https://example.com)`) and code-block / inline-code content (`` `f/foo/bar` ``) are NOT rewritten.
- [ ] Switch workspaces mid-chat and confirm fresh mentions resolve against the new workspace (no stale entries leak through).

## Follow-ups
- `AIChatManager.mentionedItems` is exposed but has no UI consumer yet — intended to back the workspace-item picker mentioned in the task description.