### PR TITLE
fix(cli): replace sync deprecation placeholder link

### DIFF
--- a/cli/src/commands/sync/pull.ts
+++ b/cli/src/commands/sync/pull.ts
@@ -156,7 +156,7 @@ export async function downloadZip(
 function stub(_opts: GlobalOptions & { override: boolean }, _dir: string) {
   console.log(
     colors.red.underline(
-      'Pull is deprecated. Use "sync pull --raw" instead. See <TODO_LINK_HERE> for more information.'
+      'Pull is deprecated. Use "sync pull --raw" instead. See https://www.windmill.dev/docs/advanced/cli/sync for more information.'
     )
   );
 }

--- a/cli/src/commands/sync/push.ts
+++ b/cli/src/commands/sync/push.ts
@@ -6,7 +6,7 @@ import { GlobalOptions } from "../../types.ts";
 function stub(_opts: GlobalOptions, _dir?: string) {
   log.info(
     colors.red.underline(
-      'Push is deprecated. Use "sync push --raw" instead. See <TODO_LINK_HERE> for more information.'
+      'Push is deprecated. Use "sync push --raw" instead. See https://www.windmill.dev/docs/advanced/cli/sync for more information.'
     )
   );
 }


### PR DESCRIPTION
## Summary
- replace the `TODO_LINK_HERE` placeholder in deprecated `sync pull` / `sync push` CLI messages
- point users to the actual sync docs: `https://www.windmill.dev/docs/advanced/cli/sync`

## Why
The current deprecation message is user-facing and still contains a placeholder, which makes the migration guidance feel unfinished.

## Validation
- verified the only code changes are the two user-facing deprecation strings
- diff reviewed locally

## Environment note
I also attempted broader local CLI verification, but this checkout currently needs generated files/toolchain pieces not present in this machine (`gen/*.ts`, Rust `clang` toolchain for some tests), so I am explicitly not claiming full test-suite coverage for this doc-link-only change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the placeholder link in deprecation messages for "sync pull" and "sync push" with the official docs: https://www.windmill.dev/docs/advanced/cli/sync. Improves migration guidance; no behavior changes.

<sup>Written for commit a95bd16348b9a6d7628bc46f57b0e4b6fe4c30bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

