### PR TITLE
fix: atomic bundle cache writes to prevent parallel cold-load race

### DIFF
--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -1023,22 +1023,74 @@ pub fn atomic_copy_file(origin: &str, final_path: &str) -> error::Result<()> {
     Ok(())
 }
 
-/// Publish a fully-populated `tmp_dir` to `final_dir` atomically. If a concurrent
-/// populate already published `final_dir` (rename fails because the destination
-/// exists and is non-empty), discard our byte-identical copy and treat it as a
-/// success so cold-load directory caches are race-free too.
+/// Publish a fully-populated `tmp_dir` to `final_dir`, always ending with a
+/// complete freshly-built directory at `final_dir` and never exposing a
+/// partially-populated one to a concurrent reader gating on
+/// `metadata(final_dir)`.
+///
+/// These dir caches are content-addressed (the path embeds a hash of the
+/// inputs), so every concurrent publisher writes byte-identical content and a
+/// *complete* `final_dir` is immutable-correct. The hard part is a *stale or
+/// partial* `final_dir` left behind by a populate that was hard-killed on a
+/// pre-atomic binary: POSIX `rename` cannot replace a non-empty directory, so a
+/// naive "trust whatever is there" would serve that partial dir forever (no
+/// self-heal). Instead we move the stale dir aside and swap our complete copy
+/// in, so we are strictly safer than an in-place re-extract in every case.
+///
+/// Invariants for a concurrent reader: `final_dir` is only ever observed as
+/// (a) absent, (b) the *unchanged* pre-existing dir, or (c) a complete fresh
+/// publish. We never mutate `final_dir` in place, so a reader can never see a
+/// newly-created partial. The brief window where the stale dir is moved aside
+/// makes `final_dir` momentarily absent — that degrades to a benign cache miss
+/// (re-pull/recompute), never to reading corrupt or partial content.
 pub fn atomic_publish_dir(tmp_dir: &str, final_dir: &str) -> error::Result<()> {
-    match fs::rename(tmp_dir, final_dir) {
-        Ok(()) => Ok(()),
-        Err(e) => {
-            let _ = fs::remove_dir_all(tmp_dir);
-            if Path::new(final_dir).exists() {
-                Ok(())
-            } else {
-                Err(e.into())
-            }
-        }
+    // Fast path: nothing at `final_dir` yet (the common cold-load case). A
+    // single atomic rename; also succeeds if `final_dir` is an empty dir.
+    if fs::rename(tmp_dir, final_dir).is_ok() {
+        return Ok(());
     }
+
+    // `final_dir` does not exist and the rename failed for a real reason
+    // (ENOSPC, EACCES, EROFS, ...). There is nothing safe to fall back to.
+    if !Path::new(final_dir).exists() {
+        let _ = fs::remove_dir_all(tmp_dir);
+        return Err(error::Error::ExecutionErr(format!(
+            "could not publish cache dir {final_dir}: no destination and rename failed"
+        )));
+    }
+
+    // `final_dir` is non-empty: either a complete prior/peer publish (identical
+    // content) or a stale partial. We can't cheaply tell them apart, so always
+    // replace it with our known-complete copy. Move the old dir aside first so
+    // the swap is two renames with no in-place mutation.
+    let bak_dir = format!("{}.bak.{}", final_dir, Uuid::new_v4());
+    if fs::rename(final_dir, &bak_dir).is_err() {
+        // A concurrent publisher moved `final_dir` in the same window. Content
+        // is identical; trust the peer's result if it has reappeared.
+        let _ = fs::remove_dir_all(tmp_dir);
+        return if Path::new(final_dir).exists() {
+            Ok(())
+        } else {
+            Err(error::Error::ExecutionErr(format!(
+                "could not publish cache dir {final_dir}: lost swap race and destination vanished"
+            )))
+        };
+    }
+
+    if let Err(e) = fs::rename(tmp_dir, final_dir) {
+        // Publishing the fresh copy failed (e.g. disk full). Restore the dir we
+        // moved aside so we never leave `final_dir` missing on our account.
+        let _ = fs::rename(&bak_dir, final_dir);
+        let _ = fs::remove_dir_all(tmp_dir);
+        let _ = fs::remove_dir_all(&bak_dir);
+        return Err(e.into());
+    }
+
+    // Fresh copy is live at `final_dir`; drop the stale one. Best-effort: a
+    // leftover `*.bak.*` is inert disk junk, never read (consumers address the
+    // exact `final_dir`), same as a leftover `*.tmp.*`.
+    let _ = fs::remove_dir_all(&bak_dir);
+    Ok(())
 }
 
 #[cfg(all(feature = "enterprise", feature = "parquet"))]
@@ -2463,10 +2515,72 @@ mod tests {
         let leftovers: Vec<_> = std::fs::read_dir(&base)
             .unwrap()
             .filter_map(|e| e.ok())
-            .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+            .filter(|e| {
+                let n = e.file_name();
+                let n = n.to_string_lossy();
+                n.contains(".tmp.") || n.contains(".bak.")
+            })
             .map(|e| e.path())
             .collect();
-        assert!(leftovers.is_empty(), "temp dirs leaked: {:?}", leftovers);
+        assert!(
+            leftovers.is_empty(),
+            "temp/bak dirs leaked: {:?}",
+            leftovers
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    // R1 regression: a *pre-existing, partial* `final_dir` (the state a populate
+    // hard-killed on a pre-atomic binary leaves behind) must be REPLACED by the
+    // complete fresh copy, not trusted. Guards the one real downside identified
+    // for the dir-cache paths (PHP `vendor/`, Java deps): without trust-but-
+    // replace this dir would be served incomplete forever, until cache clear.
+    #[test]
+    fn test_atomic_publish_dir_replaces_stale_partial() {
+        let base =
+            std::env::temp_dir().join(format!("wm_atomic_stale_test_{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&base).unwrap();
+        let final_dir = base.join("cache_dir");
+
+        // Simulate a crashed pre-atomic populate: a non-empty but incomplete dir
+        // (only main.js, missing meta.txt) sitting at the final path.
+        std::fs::create_dir_all(&final_dir).unwrap();
+        std::fs::write(final_dir.join("main.js"), b"PARTIAL").unwrap();
+
+        // A fresh, complete temp dir.
+        let tmp = base.join(format!("cache_dir.tmp.{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::write(tmp.join("main.js"), b"export function main() {}").unwrap();
+        std::fs::write(tmp.join("meta.txt"), b"v1").unwrap();
+
+        atomic_publish_dir(tmp.to_str().unwrap(), final_dir.to_str().unwrap()).unwrap();
+
+        // The stale partial must be gone: complete content present, and the old
+        // truncated main.js overwritten.
+        assert!(
+            final_dir.join("meta.txt").is_file(),
+            "stale partial was trusted instead of replaced"
+        );
+        assert_eq!(
+            std::fs::read(final_dir.join("main.js")).unwrap(),
+            b"export function main() {}"
+        );
+        let leftovers: Vec<_> = std::fs::read_dir(&base)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                let n = e.file_name();
+                let n = n.to_string_lossy();
+                n.contains(".tmp.") || n.contains(".bak.")
+            })
+            .map(|e| e.path())
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "temp/bak dirs leaked: {:?}",
+            leftovers
+        );
 
         let _ = std::fs::remove_dir_all(&base);
     }

--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -970,6 +970,77 @@ pub fn copy_dir_recursively(src: &Path, dst: &Path) -> error::Result<()> {
     Ok(())
 }
 
+/// Write `bytes` to `final_path` atomically: write to a sibling temp file then
+/// `rename` into place. A concurrent reader that gates on `metadata(final_path)`
+/// therefore only ever observes a fully-written file (`rename` is atomic on a
+/// POSIX same-filesystem path). Safe under a thundering herd: concurrent renames
+/// to the same path are last-writer-wins and every writer produces identical
+/// bytes. This prevents the cold-load race where a parallel for-loop spawns N
+/// `//native` sandboxes that each observe a partially-written bundle.
+pub fn atomic_write_file_bytes(
+    final_path: &str,
+    bytes: &[u8],
+    executable: bool,
+) -> error::Result<()> {
+    #[cfg(not(unix))]
+    let _ = executable;
+    let tmp_path = format!("{}.tmp.{}", final_path, Uuid::new_v4());
+    let write = || -> error::Result<()> {
+        let mut file = File::create(&tmp_path)?;
+        file.write_all(bytes)?;
+        #[cfg(unix)]
+        if executable {
+            use std::os::unix::fs::PermissionsExt;
+            file.set_permissions(std::fs::Permissions::from_mode(0o755))?;
+        }
+        file.flush()?;
+        Ok(())
+    };
+    if let Err(e) = write() {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+    if let Err(e) = fs::rename(&tmp_path, final_path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e.into());
+    }
+    Ok(())
+}
+
+/// Copy `origin` to `final_path` atomically via a sibling temp file + `rename`,
+/// preserving `std::fs::copy` permission semantics. Same atomicity guarantee as
+/// [`atomic_write_file_bytes`].
+pub fn atomic_copy_file(origin: &str, final_path: &str) -> error::Result<()> {
+    let tmp_path = format!("{}.tmp.{}", final_path, Uuid::new_v4());
+    if let Err(e) = fs::copy(origin, &tmp_path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e.into());
+    }
+    if let Err(e) = fs::rename(&tmp_path, final_path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e.into());
+    }
+    Ok(())
+}
+
+/// Publish a fully-populated `tmp_dir` to `final_dir` atomically. If a concurrent
+/// populate already published `final_dir` (rename fails because the destination
+/// exists and is non-empty), discard our byte-identical copy and treat it as a
+/// success so cold-load directory caches are race-free too.
+pub fn atomic_publish_dir(tmp_dir: &str, final_dir: &str) -> error::Result<()> {
+    match fs::rename(tmp_dir, final_dir) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = fs::remove_dir_all(tmp_dir);
+            if Path::new(final_dir).exists() {
+                Ok(())
+            } else {
+                Err(e.into())
+            }
+        }
+    }
+}
+
 #[cfg(all(feature = "enterprise", feature = "parquet"))]
 pub async fn extract_tar(tar: bytes::Bytes, folder: &str) -> error::Result<()> {
     use std::time::Instant;
@@ -997,19 +1068,7 @@ pub async fn extract_tar(tar: bytes::Bytes, folder: &str) -> error::Result<()> {
 }
 #[cfg(all(feature = "enterprise", feature = "parquet"))]
 pub fn write_binary_file(main_path: &str, byts: &mut bytes::Bytes) -> error::Result<()> {
-    use std::fs::File;
-    use std::io::Write;
-
-    let mut file = File::create(main_path)?;
-    file.write_all(byts)?;
-    #[cfg(unix)]
-    {
-        use std::fs::Permissions;
-        use std::os::unix::fs::PermissionsExt;
-        file.set_permissions(Permissions::from_mode(0o755))?;
-    }
-    file.flush()?;
-    Ok(())
+    atomic_write_file_bytes(main_path, byts, true)
 }
 
 #[cfg(not(windows))]
@@ -2289,5 +2348,126 @@ mod tests {
         let content = "//sandbox\nexport function main() {}";
         let annotations = TypeScriptAnnotations::parse(content);
         assert!(annotations.sandbox);
+    }
+
+    // Regression: a parallel for-loop cold-loading a //native bundle spawns
+    // many sandboxes that each gate on `metadata(bundle).is_ok()` then read it.
+    // The pre-fix non-atomic `File::create + write_all` made the path visible
+    // while still empty/truncated, so concurrent readers saw a stub bundle
+    // (`module.main is not a function`) or a truncated one (`Unexpected end of
+    // input`). With atomic temp+rename publish, a visible path is always a
+    // complete file. This test fails against the old non-atomic implementation.
+    #[test]
+    fn test_atomic_write_file_bytes_concurrent_cold_load() {
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+        use std::sync::{Arc, Barrier};
+
+        let dir =
+            std::env::temp_dir().join(format!("wm_atomic_write_test_{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let final_path = dir.join("bundle.js");
+        let final_path_str = final_path.to_str().unwrap().to_string();
+
+        // Wide payload so a hypothetical non-atomic writer has a large
+        // partial-read window for the reader to catch.
+        let payload = vec![b'x'; 4 * 1024 * 1024];
+        let expected_len = payload.len();
+
+        for _ in 0..12 {
+            let _ = std::fs::remove_file(&final_path);
+
+            let stop = Arc::new(AtomicBool::new(false));
+            let partial_reads = Arc::new(AtomicUsize::new(0));
+            let barrier = Arc::new(Barrier::new(2));
+
+            let reader = {
+                let stop = stop.clone();
+                let partial_reads = partial_reads.clone();
+                let barrier = barrier.clone();
+                let path = final_path_str.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    while !stop.load(Ordering::Relaxed) {
+                        if std::fs::metadata(&path).is_ok() {
+                            if let Ok(content) = std::fs::read(&path) {
+                                if content.len() != expected_len {
+                                    partial_reads.fetch_add(1, Ordering::Relaxed);
+                                }
+                            }
+                        }
+                        std::thread::yield_now();
+                    }
+                })
+            };
+
+            barrier.wait();
+            atomic_write_file_bytes(&final_path_str, &payload, false).unwrap();
+            stop.store(true, Ordering::Relaxed);
+            reader.join().unwrap();
+
+            assert_eq!(
+                partial_reads.load(Ordering::Relaxed),
+                0,
+                "a concurrent reader observed a partially-written bundle"
+            );
+            assert_eq!(std::fs::read(&final_path).unwrap().len(), expected_len);
+
+            let leftovers: Vec<_> = std::fs::read_dir(&dir)
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+                .map(|e| e.path())
+                .collect();
+            assert!(leftovers.is_empty(), "temp files leaked: {:?}", leftovers);
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Under a thundering herd of cold-loads, N populators each build their own
+    // temp dir and publish to the same final dir. Every publish must succeed
+    // (loser-of-the-race discards its byte-identical copy), the final dir must
+    // be complete, and no temp dirs may leak.
+    #[test]
+    fn test_atomic_publish_dir_thundering_herd() {
+        use std::sync::{Arc, Barrier};
+
+        let base =
+            std::env::temp_dir().join(format!("wm_atomic_dir_test_{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&base).unwrap();
+        let final_dir = base.join("cache_dir");
+        let final_dir_str = final_dir.to_str().unwrap().to_string();
+
+        let n = 8;
+        let barrier = Arc::new(Barrier::new(n));
+        let mut handles = vec![];
+        for _ in 0..n {
+            let barrier = barrier.clone();
+            let final_dir_str = final_dir_str.clone();
+            let base = base.clone();
+            handles.push(std::thread::spawn(move || {
+                let tmp = base.join(format!("cache_dir.tmp.{}", uuid::Uuid::new_v4()));
+                std::fs::create_dir_all(&tmp).unwrap();
+                std::fs::write(tmp.join("main.js"), b"export function main() {}").unwrap();
+                std::fs::write(tmp.join("meta.txt"), b"v1").unwrap();
+                barrier.wait();
+                atomic_publish_dir(tmp.to_str().unwrap(), &final_dir_str).unwrap();
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        assert!(final_dir.join("main.js").is_file());
+        assert!(final_dir.join("meta.txt").is_file());
+        let leftovers: Vec<_> = std::fs::read_dir(&base)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+            .map(|e| e.path())
+            .collect();
+        assert!(leftovers.is_empty(), "temp dirs leaked: {:?}", leftovers);
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -1002,6 +1002,14 @@ pub fn atomic_write_file_bytes(
     }
     if let Err(e) = fs::rename(&tmp_path, final_path) {
         let _ = fs::remove_file(&tmp_path);
+        // Content-addressed cache: if the destination now exists, a concurrent
+        // publisher already wrote byte-identical content via its own
+        // tmp+rename, so the cache is correct. This also covers Windows, where
+        // `rename` can refuse to replace a destination that an in-flight reader
+        // has open even though that destination is already valid.
+        if Path::new(final_path).exists() {
+            return Ok(());
+        }
         return Err(e.into());
     }
     Ok(())
@@ -1018,79 +1026,48 @@ pub fn atomic_copy_file(origin: &str, final_path: &str) -> error::Result<()> {
     }
     if let Err(e) = fs::rename(&tmp_path, final_path) {
         let _ = fs::remove_file(&tmp_path);
+        // See `atomic_write_file_bytes`: a content-addressed destination that
+        // now exists is already correct (peer publish / Windows open-file).
+        if Path::new(final_path).exists() {
+            return Ok(());
+        }
         return Err(e.into());
     }
     Ok(())
 }
 
-/// Publish a fully-populated `tmp_dir` to `final_dir`, always ending with a
-/// complete freshly-built directory at `final_dir` and never exposing a
-/// partially-populated one to a concurrent reader gating on
-/// `metadata(final_dir)`.
+/// Publish a fully-populated `tmp_dir` to `final_dir` via a single atomic
+/// `rename`, so a concurrent reader gating on `metadata(final_dir)` never
+/// observes a half-populated directory: `final_dir` is only ever absent or
+/// complete (we never extract/copy in place).
 ///
-/// These dir caches are content-addressed (the path embeds a hash of the
-/// inputs), so every concurrent publisher writes byte-identical content and a
-/// *complete* `final_dir` is immutable-correct. The hard part is a *stale or
-/// partial* `final_dir` left behind by a populate that was hard-killed on a
-/// pre-atomic binary: POSIX `rename` cannot replace a non-empty directory, so a
-/// naive "trust whatever is there" would serve that partial dir forever (no
-/// self-heal). Instead we move the stale dir aside and swap our complete copy
-/// in, so we are strictly safer than an in-place re-extract in every case.
+/// These dir caches are content-addressed (PHP `vendor/{hash}`, Java deps —
+/// the path embeds a hash of the inputs), so every concurrent publisher builds
+/// byte-identical content. If `rename` fails and `final_dir` already exists, a
+/// peer published the identical content (or, on Windows, `rename` refused to
+/// replace an existing directory that is nonetheless already valid): treat the
+/// existing dir as the correct cache.
 ///
-/// Invariants for a concurrent reader: `final_dir` is only ever observed as
-/// (a) absent, (b) the *unchanged* pre-existing dir, or (c) a complete fresh
-/// publish. We never mutate `final_dir` in place, so a reader can never see a
-/// newly-created partial. The brief window where the stale dir is moved aside
-/// makes `final_dir` momentarily absent — that degrades to a benign cache miss
-/// (re-pull/recompute), never to reading corrupt or partial content.
+/// Deliberately simple — no destroy-then-recreate swap. The accepted residual
+/// is that a *stale partial* `final_dir` left by a populate hard-killed on a
+/// pre-atomic binary is trusted rather than rebuilt. That is a finite,
+/// self-draining migration hazard (post-fix code only ever renames a complete
+/// `tmp_dir` into place, so it cannot create that state), it is confined to the
+/// PHP/Java dependency caches (never the `//native` path this PR targets), and
+/// it clears on cache eviction. A swap that rebuilds it introduces
+/// concurrent-publisher edge cases that are a worse trade on a critical path.
 pub fn atomic_publish_dir(tmp_dir: &str, final_dir: &str) -> error::Result<()> {
-    // Fast path: nothing at `final_dir` yet (the common cold-load case). A
-    // single atomic rename; also succeeds if `final_dir` is an empty dir.
-    if fs::rename(tmp_dir, final_dir).is_ok() {
-        return Ok(());
+    match fs::rename(tmp_dir, final_dir) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = fs::remove_dir_all(tmp_dir);
+            if Path::new(final_dir).exists() {
+                Ok(())
+            } else {
+                Err(e.into())
+            }
+        }
     }
-
-    // `final_dir` does not exist and the rename failed for a real reason
-    // (ENOSPC, EACCES, EROFS, ...). There is nothing safe to fall back to.
-    if !Path::new(final_dir).exists() {
-        let _ = fs::remove_dir_all(tmp_dir);
-        return Err(error::Error::ExecutionErr(format!(
-            "could not publish cache dir {final_dir}: no destination and rename failed"
-        )));
-    }
-
-    // `final_dir` is non-empty: either a complete prior/peer publish (identical
-    // content) or a stale partial. We can't cheaply tell them apart, so always
-    // replace it with our known-complete copy. Move the old dir aside first so
-    // the swap is two renames with no in-place mutation.
-    let bak_dir = format!("{}.bak.{}", final_dir, Uuid::new_v4());
-    if fs::rename(final_dir, &bak_dir).is_err() {
-        // A concurrent publisher moved `final_dir` in the same window. Content
-        // is identical; trust the peer's result if it has reappeared.
-        let _ = fs::remove_dir_all(tmp_dir);
-        return if Path::new(final_dir).exists() {
-            Ok(())
-        } else {
-            Err(error::Error::ExecutionErr(format!(
-                "could not publish cache dir {final_dir}: lost swap race and destination vanished"
-            )))
-        };
-    }
-
-    if let Err(e) = fs::rename(tmp_dir, final_dir) {
-        // Publishing the fresh copy failed (e.g. disk full). Restore the dir we
-        // moved aside so we never leave `final_dir` missing on our account.
-        let _ = fs::rename(&bak_dir, final_dir);
-        let _ = fs::remove_dir_all(tmp_dir);
-        let _ = fs::remove_dir_all(&bak_dir);
-        return Err(e.into());
-    }
-
-    // Fresh copy is live at `final_dir`; drop the stale one. Best-effort: a
-    // leftover `*.bak.*` is inert disk junk, never read (consumers address the
-    // exact `final_dir`), same as a leftover `*.tmp.*`.
-    let _ = fs::remove_dir_all(&bak_dir);
-    Ok(())
 }
 
 #[cfg(all(feature = "enterprise", feature = "parquet"))]
@@ -2531,41 +2508,54 @@ mod tests {
         let _ = std::fs::remove_dir_all(&base);
     }
 
-    // R1 regression: a *pre-existing, partial* `final_dir` (the state a populate
-    // hard-killed on a pre-atomic binary leaves behind) must be REPLACED by the
-    // complete fresh copy, not trusted. Guards the one real downside identified
-    // for the dir-cache paths (PHP `vendor/`, Java deps): without trust-but-
-    // replace this dir would be served incomplete forever, until cache clear.
+    // Contract guard: when `final_dir` ALREADY exists (a complete prior/peer
+    // publish — content-addressed, so identical bytes), concurrent publishers
+    // must all return Ok via the exists-fallback and must never corrupt or
+    // partially-overwrite the existing dir. Covers the preexisting+concurrent
+    // case; documents the accepted simple-form behavior (an existing dir is
+    // trusted, not rebuilt).
     #[test]
-    fn test_atomic_publish_dir_replaces_stale_partial() {
+    fn test_atomic_publish_dir_existing_is_trusted_not_corrupted() {
+        use std::sync::{Arc, Barrier};
+
         let base =
-            std::env::temp_dir().join(format!("wm_atomic_stale_test_{}", uuid::Uuid::new_v4()));
+            std::env::temp_dir().join(format!("wm_atomic_exist_test_{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&base).unwrap();
         let final_dir = base.join("cache_dir");
+        let final_dir_str = final_dir.to_str().unwrap().to_string();
 
-        // Simulate a crashed pre-atomic populate: a non-empty but incomplete dir
-        // (only main.js, missing meta.txt) sitting at the final path.
+        // A complete dir already published at the final path.
         std::fs::create_dir_all(&final_dir).unwrap();
-        std::fs::write(final_dir.join("main.js"), b"PARTIAL").unwrap();
+        std::fs::write(final_dir.join("main.js"), b"export function main() {}").unwrap();
+        std::fs::write(final_dir.join("meta.txt"), b"v1").unwrap();
 
-        // A fresh, complete temp dir.
-        let tmp = base.join(format!("cache_dir.tmp.{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&tmp).unwrap();
-        std::fs::write(tmp.join("main.js"), b"export function main() {}").unwrap();
-        std::fs::write(tmp.join("meta.txt"), b"v1").unwrap();
+        let n = 8;
+        let barrier = Arc::new(Barrier::new(n));
+        let mut handles = vec![];
+        for _ in 0..n {
+            let barrier = barrier.clone();
+            let final_dir_str = final_dir_str.clone();
+            let base = base.clone();
+            handles.push(std::thread::spawn(move || {
+                let tmp = base.join(format!("cache_dir.tmp.{}", uuid::Uuid::new_v4()));
+                std::fs::create_dir_all(&tmp).unwrap();
+                std::fs::write(tmp.join("main.js"), b"export function main() {}").unwrap();
+                std::fs::write(tmp.join("meta.txt"), b"v1").unwrap();
+                barrier.wait();
+                // Every publisher must succeed (exists-fallback), none error.
+                atomic_publish_dir(tmp.to_str().unwrap(), &final_dir_str).unwrap();
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
 
-        atomic_publish_dir(tmp.to_str().unwrap(), final_dir.to_str().unwrap()).unwrap();
-
-        // The stale partial must be gone: complete content present, and the old
-        // truncated main.js overwritten.
-        assert!(
-            final_dir.join("meta.txt").is_file(),
-            "stale partial was trusted instead of replaced"
-        );
+        // Existing dir intact and complete — never partially overwritten.
         assert_eq!(
             std::fs::read(final_dir.join("main.js")).unwrap(),
             b"export function main() {}"
         );
+        assert_eq!(std::fs::read(final_dir.join("meta.txt")).unwrap(), b"v1");
         let leftovers: Vec<_> = std::fs::read_dir(&base)
             .unwrap()
             .filter_map(|e| e.ok())

--- a/backend/windmill-worker/src/bun_executor.rs
+++ b/backend/windmill-worker/src/bun_executor.rs
@@ -1109,7 +1109,11 @@ async fn pull_codebase(w_id: &str, id: &str, job_dir: &str) -> Result<PulledCode
                 let bytes = attempt_fetch_bytes(os, &path).await?;
                 tracing::info!("loading {bun_cache_path} from object store");
 
-                std::fs::write(&bun_cache_path, &bytes)?;
+                windmill_common::worker::atomic_write_file_bytes(
+                    &bun_cache_path,
+                    bytes.as_ref(),
+                    false,
+                )?;
                 extract_saved_codebase(job_dir, &bun_cache_path, is_tar, &dst, false)?;
             }
         }

--- a/backend/windmill-worker/src/global_cache.rs
+++ b/backend/windmill-worker/src/global_cache.rs
@@ -159,7 +159,16 @@ pub async fn load_cache(bin_path: &str, _remote_path: &str, is_dir: bool) -> (bo
 
             if let Ok(mut x) = windmill_object_store::attempt_fetch_bytes(os, _remote_path).await {
                 if is_dir {
-                    if let Err(e) = windmill_common::worker::extract_tar(x, bin_path).await {
+                    // Extract into a sibling temp dir then atomically publish it,
+                    // so a concurrent cold-load gating on metadata(bin_path) never
+                    // observes a half-extracted cache directory.
+                    let tmp_dir = format!("{}.tmp.{}", bin_path, uuid::Uuid::new_v4());
+                    let res = match windmill_common::worker::extract_tar(x, &tmp_dir).await {
+                        Ok(()) => windmill_common::worker::atomic_publish_dir(&tmp_dir, bin_path),
+                        Err(e) => Err(e),
+                    };
+                    if let Err(e) = res {
+                        let _ = tokio::fs::remove_dir_all(&tmp_dir).await;
                         tracing::error!("could not write tar archive locally: {e:?}");
                         return (
                             false,
@@ -268,12 +277,21 @@ pub async fn save_cache(
 
     if true {
         if is_dir {
-            windmill_common::worker::copy_dir_recursively(
+            // Populate a sibling temp dir then atomically publish it, so a
+            // concurrent `load_cache`/`exists_in_cache` metadata() check never
+            // observes a half-copied cache directory.
+            let tmp_dir = format!("{}.tmp.{}", local_cache_path, uuid::Uuid::new_v4());
+            if let Err(e) = windmill_common::worker::copy_dir_recursively(
                 &PathBuf::from(origin),
-                &PathBuf::from(local_cache_path),
-            )?;
+                &PathBuf::from(&tmp_dir),
+            )
+            .and_then(|_| windmill_common::worker::atomic_publish_dir(&tmp_dir, local_cache_path))
+            {
+                let _ = std::fs::remove_dir_all(&tmp_dir);
+                return Err(e);
+            }
         } else {
-            std::fs::copy(origin, local_cache_path)?;
+            windmill_common::worker::atomic_copy_file(origin, local_cache_path)?;
         }
         Ok(format!(
             "\nwrote cached binary: {} (backed by EE distributed object store: {_cached_to_s3})\n",


### PR DESCRIPTION
## Summary

When a flow runs a `forloopflow` with `parallel: true` over a `//native` script and the worker's bundle cache is cold (post-sync, post-bounce, post-pod-redeploy), a fraction of the spawned sandboxes crash inside the loader wrapper **before user `main()` runs** — `TypeError: module.main is not a function` at `<anon>:34:51` or `SyntaxError: Unexpected end of input` at `file:///eval.ts`. The flow's `failure_module` catches the throw, but earlier steps in that iteration have already committed side effects, leaving a half-applied state needing manual cleanup. The race is probabilistic and curable by a warmup run — classic cache-population race signature.

**Root cause:** the bundle cache is populated non-atomically. `write_binary_file` did `File::create(path)` → `write_all` → `flush`; `save_cache`/`pull_codebase` did `std::fs::copy` / `std::fs::write`; dir caches extracted/copied straight into the final path. `File::create` makes the path **visible and zero-length immediately**. A concurrent cold-load sandbox gating on `metadata(path).is_ok()` (`load_cache` / `exists_in_cache` / `pull_codebase`) then observes the path as "present" mid-write and reads a stub (no `main` export) or a truncated bundle. The first fully-successful write makes every later run safe — exactly the observed warmup-cures-it, 60%→0% behavior.

This supersedes #9185, which fixed the two highest-priority single-file sites but missed the codebase single-file write and the dir-mode cold-load/producer paths, and shipped no regression test.

## Changes

- **New atomic publish helpers** in `backend/windmill-common/src/worker.rs` (non-feature-gated, reusable, testable): `atomic_write_file_bytes`, `atomic_copy_file`, `atomic_publish_dir`. All write to a sibling `*.tmp.{uuid}` path in the same directory (same filesystem → `rename` is atomic on POSIX) then `rename` into place; temp is cleaned up on every error path. `atomic_publish_dir` treats a lost publish race (rename onto an existing non-empty dir → ENOTEMPTY) as success and discards its byte-identical copy.
- **`write_binary_file`** now delegates to `atomic_write_file_bytes` — fixes the exact reported `//native` `load_cache` consumer race.
- **`save_cache`** (`global_cache.rs`): non-dir branch uses `atomic_copy_file`; dir branch populates a temp dir then `atomic_publish_dir` — fixes the producer-side race for both single-file and dir caches.
- **`load_cache`** (`global_cache.rs`): the `is_dir` cold-load now extracts into a temp dir then `atomic_publish_dir` — fixes the codebase-dir cold-load race.
- **`pull_codebase`** (`bun_executor.rs`): the codebase `std::fs::write(&bun_cache_path, ...)` now uses `atomic_write_file_bytes` — the single-file site #9185 missed.
- **Regression tests** in `worker.rs`: `test_atomic_write_file_bytes_concurrent_cold_load` (concurrent reader asserts it never observes a partial bundle; fails against the old non-atomic impl) and `test_atomic_publish_dir_thundering_herd` (8 racing populators all succeed, final dir complete, no temp leaks).

Single-flight dedup of the N concurrent object-store fetches is intentionally **out of scope** — it's a throughput optimization, not a correctness fix; atomic publish fully closes the race.

## Test plan

- [x] `cargo test -p windmill-common --lib worker::tests::test_atomic` — both regression tests pass
- [x] `cargo check --features enterprise,parquet` — clean (covers the feature-gated call sites)
- [x] `/local-review` against main — no issues
- [ ] Deploy a `//native` codebase script; run a flow with a parallel for-loop (16+ iterations) against a cold worker cache (clear `ROOT_CACHE_DIR`, restart worker); confirm no iteration fails with `module.main is not a function` / `Unexpected end of input`
- [ ] Repeat on an EE object-store-backed dir cache (parquet/enterprise build) cleared locally to exercise the `load_cache` tar-extract + `atomic_publish_dir` path; confirm race-free and no leftover `.tmp.<uuid>` dirs under the cache root

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make cache writes atomic to stop the parallel cold-load race that caused `module.main is not a function` and truncated bundles in `//native` runs. Writers now use tmp+rename with a content-addressed exists fallback so workers only see complete files and dirs (POSIX and Windows).

- **Bug Fixes**
  - Added `atomic_write_file_bytes`, `atomic_copy_file`, and `atomic_publish_dir` with sibling tmp + atomic `rename` and an exists-fallback on rename failure (handles concurrent publishers and Windows open-dest); cleans up temps on error.
  - Switched `write_binary_file`, `save_cache` (file via `atomic_copy_file`; dir via tmp + `atomic_publish_dir`), `load_cache` (dir extract to tmp then publish), and `pull_codebase` to use the atomic helpers.
  - Simplified `atomic_publish_dir` to a single `rename` with exists-fallback; an already-present dir is treated as success to avoid herd errors and temp leaks.
  - Added regression test `test_atomic_publish_dir_existing_is_trusted_not_corrupted` in addition to the concurrent cold-load and thundering-herd tests.

<sup>Written for commit b8433035c8c6cef002457fb3d87612b1461e551a. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9186?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

