### PR TITLE
Harden UI builder artifact bootstrap

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
 		"generate-backend-client-mac": "openapi-ts --input ../backend/windmill-api/openapi.yaml --output ./src/lib/gen --useOptions --enums javascript",
 		"pretest": "tsc --incremental -p tests/tsconfig.json",
 		"filter-classes": "node filterTailwindClasses.js",
+		"test:ui-builder-bootstrap": "node --test scripts/untar_ui_builder.test.js",
 		"test:unit": "vitest",
 		"test:e2e": "playwright test"
 	},

--- a/frontend/scripts/ui_builder_artifact.json
+++ b/frontend/scripts/ui_builder_artifact.json
@@ -1,0 +1,5 @@
+{
+  "baseUrl": "https://pub-06154ed168a24e73a86ab84db6bf15d8.r2.dev",
+  "version": "6715153",
+  "sha256": "1485930ea5f5309e4bdc09a55aae72eae8230eb74f0928715a0e6fe610703d9b"
+}

--- a/frontend/scripts/untar_ui_builder.js
+++ b/frontend/scripts/untar_ui_builder.js
@@ -1,55 +1,96 @@
-import path from 'path'
-import fs from 'fs'
+import { createHash } from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
+import artifact from './ui_builder_artifact.json' with { type: 'json' }
 
-// Check if we're in node_modules (installed as dependency)
-if (process.cwd().includes('node_modules')) {
-	console.log('Skipping postinstall - running as dependency');
-	process.exit(0);
+export function shouldSkipPostinstall(cwd = process.cwd(), initCwd = process.env.INIT_CWD ?? '') {
+	if (cwd.includes('node_modules')) {
+		return true
+	}
+
+	return Boolean(initCwd && initCwd !== cwd)
 }
 
-// Check if we're in the root project
-if (process.env.INIT_CWD && process.env.INIT_CWD !== process.cwd()) {
-	console.log('Skipping postinstall - not root project');
-	process.exit(0);
+export function getTarballName(selectedArtifact = artifact) {
+	return `ui_builder-${selectedArtifact.version}.tar.gz`
 }
 
-// Your actual postinstall logic here
-console.log('Running postinstall for root project');
+export function getTarballUrl(selectedArtifact = artifact) {
+	return `${selectedArtifact.baseUrl}/${getTarballName(selectedArtifact)}`
+}
 
+export async function computeSha256(buffer) {
+	return createHash('sha256').update(buffer).digest('hex')
+}
 
-import { x } from 'tar'
-
-const tarUrl = 'https://pub-06154ed168a24e73a86ab84db6bf15d8.r2.dev/ui_builder-6715153.tar.gz'
-const outputTarPath = path.join(process.cwd(), 'ui_builder.tar.gz')
-const extractTo = path.join(process.cwd(), 'static/ui_builder/')
-
-import { fileURLToPath } from 'url'
-import { dirname } from 'path'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-
-// Download the tar file
-const response = await fetch(tarUrl)
-const buffer = await response.arrayBuffer()
-await fs.promises.writeFile(outputTarPath, Buffer.from(buffer))
-
-
-// Create extract directory if it doesn't exist
-try {
-	await fs.promises.mkdir(extractTo, { recursive: true })
-} catch (err) {
-	if (err.code !== 'EEXIST') {
-		throw err
+export async function verifyArtifactIntegrity(buffer, selectedArtifact = artifact) {
+	const actualSha256 = await computeSha256(buffer)
+	if (actualSha256 !== selectedArtifact.sha256) {
+		throw new Error(
+			`UI builder artifact checksum mismatch: expected ${selectedArtifact.sha256}, got ${actualSha256}`
+		)
 	}
 }
 
-await x({
-	file: outputTarPath,
-	cwd: extractTo,
-	sync: false,
-	gzip: true
-})
+async function downloadArtifact(fetchImpl = fetch, selectedArtifact = artifact) {
+	const tarballUrl = getTarballUrl(selectedArtifact)
+	const response = await fetchImpl(tarballUrl)
 
-await fs.promises.unlink(outputTarPath)
+	if (!response.ok) {
+		throw new Error(`Failed to download UI builder artifact from ${tarballUrl}: ${response.status} ${response.statusText}`)
+	}
+
+	const buffer = Buffer.from(await response.arrayBuffer())
+	await verifyArtifactIntegrity(buffer, selectedArtifact)
+	return buffer
+}
+
+async function extractArtifact(buffer, cwd = process.cwd()) {
+	const { x } = await import('tar')
+	const outputTarPath = path.join(cwd, 'ui_builder.tar.gz')
+	const extractTo = path.join(cwd, 'static/ui_builder/')
+
+	await fs.promises.mkdir(extractTo, { recursive: true })
+	await fs.promises.writeFile(outputTarPath, buffer)
+
+	try {
+		await x({
+			file: outputTarPath,
+			cwd: extractTo,
+			sync: false,
+			gzip: true,
+			preservePaths: false
+		})
+	} finally {
+		await fs.promises.rm(outputTarPath, { force: true })
+	}
+}
+
+export async function installUiBuilder(fetchImpl = fetch, cwd = process.cwd(), selectedArtifact = artifact) {
+	const buffer = await downloadArtifact(fetchImpl, selectedArtifact)
+	await extractArtifact(buffer, cwd)
+}
+
+async function main() {
+	if (shouldSkipPostinstall()) {
+		if (process.cwd().includes('node_modules')) {
+			console.log('Skipping postinstall - running as dependency')
+			return
+		}
+
+		console.log('Skipping postinstall - not root project')
+		return
+	}
+
+	console.log('Running postinstall for root project')
+	await installUiBuilder()
+}
+
+const entrypoint = process.argv[1] ? path.resolve(process.argv[1]) : null
+const isMainModule = entrypoint === fileURLToPath(import.meta.url)
+
+if (isMainModule) {
+	await main()
+}

--- a/frontend/scripts/untar_ui_builder.test.js
+++ b/frontend/scripts/untar_ui_builder.test.js
@@ -1,0 +1,52 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+	computeSha256,
+	getTarballUrl,
+	shouldSkipPostinstall,
+	verifyArtifactIntegrity
+} from './untar_ui_builder.js'
+
+test('shouldSkipPostinstall skips dependency installs inside node_modules', () => {
+	assert.equal(shouldSkipPostinstall('/tmp/node_modules/windmill/frontend', ''), true)
+})
+
+test('shouldSkipPostinstall skips when INIT_CWD differs from the current project', () => {
+	assert.equal(shouldSkipPostinstall('/tmp/windmill/frontend', '/tmp/windmill'), true)
+})
+
+test('shouldSkipPostinstall runs at the root project', () => {
+	assert.equal(shouldSkipPostinstall('/tmp/windmill/frontend', '/tmp/windmill/frontend'), false)
+})
+
+test('getTarballUrl builds the pinned artifact URL', () => {
+	assert.equal(
+		getTarballUrl({
+			baseUrl: 'https://artifacts.example.com',
+			version: '1234567',
+			sha256: 'ignored'
+		}),
+		'https://artifacts.example.com/ui_builder-1234567.tar.gz'
+	)
+})
+
+test('computeSha256 matches the expected digest', async () => {
+	const digest = await computeSha256(Buffer.from('windmill-ui-builder'))
+	assert.equal(digest, 'c747f031910fa8af923cda9b52204531666fe1c9b7c2213888dacb38b812175f')
+})
+
+test('verifyArtifactIntegrity throws on checksum mismatch', async () => {
+	await assert.rejects(
+		() =>
+			verifyArtifactIntegrity(
+				Buffer.from('artifact-bytes'),
+				{
+					baseUrl: 'https://artifacts.example.com',
+					version: '1234567',
+					sha256: 'deadbeef'
+				}
+			),
+		/checksum mismatch/
+	)
+})

--- a/frontend/use_latest_ui_builder.sh
+++ b/frontend/use_latest_ui_builder.sh
@@ -1,20 +1,26 @@
 #!/bin/bash
 
-# Auto-detect operating system
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  IS_MAC=true
-else
-  IS_MAC=false
-fi
-
 cd ~/windmill-code-ui-builder
 HASH=$(git rev-parse --short HEAD)
 HASH=${HASH::-1}
+ARTIFACT_URL="https://pub-06154ed168a24e73a86ab84db6bf15d8.r2.dev/ui_builder-${HASH}.tar.gz"
+TMP_FILE=$(mktemp)
 
 echo "Using UI Builder hash: ${HASH}"
+curl -fsSL "$ARTIFACT_URL" -o "$TMP_FILE"
+SHA256=$(shasum -a 256 "$TMP_FILE" | awk '{print $1}')
+rm -f "$TMP_FILE"
+echo "Using UI Builder sha256: ${SHA256}"
 
-if [ "$IS_MAC" = true ]; then
-  sed -i '' "s/ui_builder-[^.]*\.tar\.gz/ui_builder-${HASH}.tar.gz/" ../windmill/frontend/scripts/untar_ui_builder.js
-else
-  sed -i "s/ui_builder-[^.]*\.tar\.gz/ui_builder-${HASH}.tar.gz/" ../windmill/frontend/scripts/untar_ui_builder.js
-fi
+python3 - "$HASH" "$SHA256" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+version, sha256 = sys.argv[1], sys.argv[2]
+artifact_path = Path("../windmill/frontend/scripts/ui_builder_artifact.json")
+artifact = json.loads(artifact_path.read_text())
+artifact["version"] = version
+artifact["sha256"] = sha256
+artifact_path.write_text(json.dumps(artifact, indent=2) + "\n")
+PY


### PR DESCRIPTION
## Summary
- pin the UI builder bootstrap artifact in source control with both its version and SHA-256 digest
- verify the downloaded artifact before extraction so frontend bootstrap fails closed on tampering or mismatched uploads
- update the maintainer helper script to refresh both the artifact version and checksum together
- add a focused bootstrap test that exercises the skip logic, URL construction, hashing, and checksum mismatch path

## Why
The frontend bootstrap currently downloads and extracts a remote tarball during postinstall, but it only pins the filename and does not verify artifact integrity before extraction. This change keeps the existing workflow while reducing the trust surface and making future artifact bumps explicit and reviewable.

## Testing
- npm run test:ui-builder-bootstrap


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the UI builder bootstrap artifact by version and SHA-256 and verifies integrity before extraction to fail closed on tampering. Adds tests and a helper script update to keep version and checksum in sync.

- New Features
  - Pinned artifact metadata in `frontend/scripts/ui_builder_artifact.json` (`baseUrl`, `version`, `sha256`).
  - Verified SHA-256 of the downloaded tarball before extraction; aborts on mismatch or bad HTTP status.
  - Extracted utilities for skip logic, URL building, hashing, and integrity checks; added a clear main entry.
  - Added focused tests for skip logic, URL construction, hashing, and checksum mismatch via `node:test`; added `npm run test:ui-builder-bootstrap`.
  - Updated `frontend/use_latest_ui_builder.sh` to fetch the artifact, compute SHA-256, and update `ui_builder_artifact.json` with both version and checksum.

<sup>Written for commit f5804ba7ca0f0003c6ed59193b09805b233f4f2f. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9187?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

