### PR TITLE
fix: don't show ALLOW_PRIVATE_AI_BASE_URLS hint for malformed AI base URLs

### DIFF
--- a/backend/windmill-ai/src/ai_providers.rs
+++ b/backend/windmill-ai/src/ai_providers.rs
@@ -2,9 +2,9 @@
  * This file contains shared AI provider utilities used by both the API and worker.
  */
 
+use serde::{Deserialize, Deserializer, Serialize};
 use windmill_common::db::DB;
 use windmill_common::error::{Error, Result};
-use serde::{Deserialize, Deserializer, Serialize};
 
 /// Deserializes an Option<String> where empty strings become None.
 /// Use with `#[serde(default, deserialize_with = "empty_string_as_none")]`
@@ -65,13 +65,19 @@ impl AIProvider {
     pub async fn get_base_url(&self, resource_base_url: Option<String>, db: &DB) -> Result<String> {
         if let Some(base_url) = resource_base_url {
             if !*ALLOW_PRIVATE_AI_BASE_URLS {
+                use windmill_common::ssrf::SsrfValidationError;
                 windmill_common::ssrf::validate_url_for_ssrf(&base_url)
                     .await
-                    .map_err(|e| {
-                        Error::BadRequest(format!(
+                    .map_err(|e| match e {
+                        // The env-var hint is only actionable when the URL is
+                        // well-formed but blocked for targeting a private
+                        // address. For a malformed URL or bad scheme, surface
+                        // the real error so users fix the URL (issue #9171).
+                        e @ SsrfValidationError::Private { .. } => Error::BadRequest(format!(
                             "{e}. If you need to use private/internal AI endpoints, \
-                         set the ALLOW_PRIVATE_AI_BASE_URLS=true environment variable"
-                        ))
+                             set the ALLOW_PRIVATE_AI_BASE_URLS=true environment variable"
+                        )),
+                        e => Error::from(e),
                     })?;
             }
             return Ok(base_url);

--- a/backend/windmill-common/src/ssrf.rs
+++ b/backend/windmill-common/src/ssrf.rs
@@ -2,37 +2,85 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use crate::error::Error;
 
+/// Why a URL failed SSRF validation.
+///
+/// The distinction matters for callers that gate private endpoints behind a
+/// flag (e.g. `ALLOW_PRIVATE_AI_BASE_URLS`): a "set this env var" hint is only
+/// actionable for [`SsrfValidationError::Private`]. Surfacing that hint for a
+/// malformed URL or bad scheme sends users down the wrong path (see #9171).
+#[derive(Debug)]
+pub enum SsrfValidationError {
+    /// The URL could not be parsed (e.g. missing `http://` scheme).
+    InvalidUrl(String),
+    /// Scheme is not `http`/`https`.
+    DisallowedScheme(String),
+    /// No host in the URL.
+    MissingHost,
+    /// DNS resolution failed for the host.
+    ResolutionFailed { host: String, source: String },
+    /// Host did not resolve to any address.
+    NoAddresses(String),
+    /// The URL targets (or resolves to) a private/internal address. `resolved`
+    /// is true when the host was a DNS name that resolved to a private IP.
+    Private { resolved: bool },
+}
+
+impl std::fmt::Display for SsrfValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SsrfValidationError::InvalidUrl(e) => write!(f, "Invalid URL: {e}"),
+            SsrfValidationError::DisallowedScheme(s) => write!(
+                f,
+                "URL scheme '{s}' is not allowed, only http and https are permitted"
+            ),
+            SsrfValidationError::MissingHost => write!(f, "URL must have a host"),
+            SsrfValidationError::ResolutionFailed { host, source } => {
+                write!(f, "Failed to resolve host '{host}': {source}")
+            }
+            SsrfValidationError::NoAddresses(host) => {
+                write!(f, "Host '{host}' did not resolve to any addresses")
+            }
+            SsrfValidationError::Private { resolved: false } => {
+                write!(f, "URL targets a private/internal IP address")
+            }
+            SsrfValidationError::Private { resolved: true } => {
+                write!(f, "URL resolves to a private/internal IP address")
+            }
+        }
+    }
+}
+
+impl From<SsrfValidationError> for Error {
+    fn from(e: SsrfValidationError) -> Self {
+        Error::BadRequest(e.to_string())
+    }
+}
+
 /// Validates that a URL is safe to fetch server-side (not targeting private/internal networks).
 ///
 /// Checks:
 /// 1. Scheme must be http or https
 /// 2. Host must be present and not a private/loopback/link-local IP
 /// 3. DNS resolution is checked to prevent DNS rebinding to internal IPs
-pub async fn validate_url_for_ssrf(url: &str) -> Result<(), Error> {
+pub async fn validate_url_for_ssrf(url: &str) -> Result<(), SsrfValidationError> {
     let parsed =
-        url::Url::parse(url).map_err(|e| Error::BadRequest(format!("Invalid URL: {e}")))?;
+        url::Url::parse(url).map_err(|e| SsrfValidationError::InvalidUrl(e.to_string()))?;
 
     // 1. Scheme check
     match parsed.scheme() {
         "http" | "https" => {}
         scheme => {
-            return Err(Error::BadRequest(format!(
-                "URL scheme '{scheme}' is not allowed, only http and https are permitted"
-            )));
+            return Err(SsrfValidationError::DisallowedScheme(scheme.to_string()));
         }
     }
 
     // 2. Host check
-    let host = parsed
-        .host_str()
-        .ok_or_else(|| Error::BadRequest("URL must have a host".to_string()))?;
+    let host = parsed.host_str().ok_or(SsrfValidationError::MissingHost)?;
 
     // 3. If the host is an IP literal, check it directly
     if let Ok(ip) = host.parse::<IpAddr>() {
         if is_private_ip(&ip) {
-            return Err(Error::BadRequest(
-                "URL targets a private/internal IP address".to_string(),
-            ));
+            return Err(SsrfValidationError::Private { resolved: false });
         }
         return Ok(());
     }
@@ -45,20 +93,19 @@ pub async fn validate_url_for_ssrf(url: &str) -> Result<(), Error> {
     let resolve_target = format!("{host}:{port}");
     let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host(&resolve_target)
         .await
-        .map_err(|e| Error::BadRequest(format!("Failed to resolve host '{host}': {e}")))?
+        .map_err(|e| SsrfValidationError::ResolutionFailed {
+            host: host.to_string(),
+            source: e.to_string(),
+        })?
         .collect();
 
     if addrs.is_empty() {
-        return Err(Error::BadRequest(format!(
-            "Host '{host}' did not resolve to any addresses"
-        )));
+        return Err(SsrfValidationError::NoAddresses(host.to_string()));
     }
 
     for addr in &addrs {
         if is_private_ip(&addr.ip()) {
-            return Err(Error::BadRequest(
-                "URL resolves to a private/internal IP address".to_string(),
-            ));
+            return Err(SsrfValidationError::Private { resolved: true });
         }
     }
 
@@ -147,5 +194,33 @@ mod tests {
     async fn test_validate_url_allows_public() {
         // This resolves to a public IP
         assert!(validate_url_for_ssrf("https://google.com").await.is_ok());
+    }
+
+    /// Regression for #9171: a malformed base URL (missing scheme) must report
+    /// `InvalidUrl`/`DisallowedScheme`, not `Private` — only `Private` gets the
+    /// "set ALLOW_PRIVATE_AI_BASE_URLS" hint, which is misleading for a typo'd
+    /// URL and sent the issue reporter down the wrong path.
+    #[tokio::test]
+    async fn test_error_variants_are_discriminated() {
+        // No scheme and no colon → the exact "relative URL without a base"
+        // error from the issue.
+        assert!(matches!(
+            validate_url_for_ssrf("api.example.com/v1").await,
+            Err(SsrfValidationError::InvalidUrl(_))
+        ));
+        // `localhost:11434/v1` parses with `localhost` as the scheme — a very
+        // common Ollama misconfiguration.
+        assert!(matches!(
+            validate_url_for_ssrf("localhost:11434/v1").await,
+            Err(SsrfValidationError::DisallowedScheme(s)) if s == "localhost"
+        ));
+        assert!(matches!(
+            validate_url_for_ssrf("ftp://example.com/foo").await,
+            Err(SsrfValidationError::DisallowedScheme(_))
+        ));
+        assert!(matches!(
+            validate_url_for_ssrf("http://127.0.0.1/foo").await,
+            Err(SsrfValidationError::Private { resolved: false })
+        ));
     }
 }

--- a/backend/windmill-common/src/ssrf.rs
+++ b/backend/windmill-common/src/ssrf.rs
@@ -50,6 +50,10 @@ impl std::fmt::Display for SsrfValidationError {
     }
 }
 
+// Enables `?` from `validate_url_for_ssrf` in functions returning
+// `anyhow::Result` (e.g. the EE SAML metadata loader).
+impl std::error::Error for SsrfValidationError {}
+
 impl From<SsrfValidationError> for Error {
     fn from(e: SsrfValidationError) -> Self {
         Error::BadRequest(e.to_string())


### PR DESCRIPTION
## Summary

Fixes the misleading error in [#9171](https://github.com/windmill-labs/windmill/issues/9171). When a user configured a custom AI provider with a malformed base URL (e.g. `api.example.com/v1`, missing the `http://` scheme), the error was:

> `Invalid URL: relative URL without a base. If you need to use private/internal AI endpoints, set the ALLOW_PRIVATE_AI_BASE_URLS=true environment variable`

The `ALLOW_PRIVATE_AI_BASE_URLS` hint was appended to **every** SSRF-validation failure, including malformed URLs and bad schemes — where enabling that env var does nothing. This sent the issue reporter (and the first responder) down the wrong path (docker-compose / env plumbing) when the actual problem was a typo'd URL.

The hint is now shown **only** when the URL is well-formed but blocked for targeting a private/internal address — the one case where the env var is actually the fix.

## Changes

- `backend/windmill-common/src/ssrf.rs`: `validate_url_for_ssrf` now returns a typed `SsrfValidationError` enum (`InvalidUrl`, `DisallowedScheme`, `MissingHost`, `ResolutionFailed`, `NoAddresses`, `Private { resolved }`) instead of a stringly-typed `Error`. Added `Display` and `impl From<SsrfValidationError> for Error` (preserves the prior `Error::BadRequest` mapping, so the existing MCP caller's `?` is unaffected).
- `backend/windmill-ai/src/ai_providers.rs`: `get_base_url` appends the `ALLOW_PRIVATE_AI_BASE_URLS` hint only for the `Private` variant; all other variants surface their real error.
- Added `test_error_variants_are_discriminated` regression test pinned to #9171.

| Input | Before | After |
|---|---|---|
| `api.example.com/v1` | `Invalid URL: relative URL without a base.` + misleading hint | `Invalid URL: relative URL without a base` |
| `localhost:11434/v1` | scheme error + misleading hint | `URL scheme 'localhost' is not allowed, only http and https are permitted` |
| `http://127.0.0.1/v1` | private-IP error + hint | private-IP error + hint *(unchanged — correct here)* |

## Out of scope (follow-up)

PR #9174 forwards `ALLOW_PRIVATE_AI_BASE_URLS` to `windmill_server` only. `get_base_url` is also called from the **worker** process (`windmill-worker/src/ai_executor.rs`), so a script/flow calling a private AI endpoint will still be blocked after #9174 because `windmill_worker` / `windmill_worker_native` don't receive the var. #9174 should also add it to those services. (Tracked separately; this PR is orthogonal and helps regardless.)

## Test plan

- [x] `cargo check -p windmill-common -p windmill-ai -p windmill-mcp` passes
- [x] `cargo test -p windmill-common --lib ssrf` — all 5 tests pass incl. new regression test
- [ ] In AI custom-provider settings (with `ALLOW_PRIVATE_AI_BASE_URLS` unset): entering `api.example.com/v1` shows the URL error **without** the env-var hint; entering `http://127.0.0.1:11434/v1` still shows the hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a misleading error when users enter malformed or bad-scheme AI base URLs by showing the `ALLOW_PRIVATE_AI_BASE_URLS` hint only when a well-formed URL is blocked for private/internal addresses. This avoids sending users to env setup when the real issue is a typo’d URL.

- **Bug Fixes**
  - `get_base_url` now appends the `ALLOW_PRIVATE_AI_BASE_URLS` hint only for `Private` SSRF failures; other errors show their actual message.
  - Added a regression test covering the cases from issue #9171.

- **Refactors**
  - `validate_url_for_ssrf` now returns a typed `SsrfValidationError` (`InvalidUrl`, `DisallowedScheme`, `MissingHost`, `ResolutionFailed`, `NoAddresses`, `Private { resolved }`).
  - Implemented `Display`, `std::error::Error`, and `From<SsrfValidationError> for Error` to keep existing `Error::BadRequest` behavior and support `anyhow` callers using `?`.

<sup>Written for commit 5cef6d48063dbb35862e5f0c32561861dc40bef7. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9188?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

