### PR TITLE
fix: sidebar rendering expanded-but-empty at sub-pixel widths near 768px

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
+++ b/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
@@ -15,6 +15,7 @@
 	interface Props {
 		noPadding?: boolean
 		isCollapsed?: boolean
+		isMobile?: boolean
 		children: any
 		onMenuOpen?: () => void
 		disableAi?: boolean
@@ -22,6 +23,7 @@
 	let {
 		noPadding: noBorder = false,
 		isCollapsed = false,
+		isMobile = false,
 		children,
 		onMenuOpen,
 		disableAi
@@ -56,7 +58,7 @@
 				id="content"
 				class={classNames(
 					'w-full flex-1 flex flex-col overflow-y-auto min-h-0',
-					noBorder || $userStore?.operator ? '!pl-0' : isCollapsed ? 'md:pl-12' : 'md:pl-40',
+					noBorder || $userStore?.operator || isMobile ? '!pl-0' : isCollapsed ? 'pl-12' : 'pl-40',
 					'transition-all ease-in-out duration-200'
 				)}
 			>

--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -598,7 +598,7 @@
 						id="sidebar"
 						class={classNames(
 							'flex flex-col fixed inset-y-0 transition-all ease-in-out duration-200 z-40 ',
-							isCollapsed ? 'md:w-12' : 'md:w-40',
+							isCollapsed ? 'w-12' : 'w-40',
 							devOnly ? '!hidden' : ''
 						)}
 					>

--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -824,6 +824,7 @@
 				{children}
 				noPadding={devOnly}
 				{isCollapsed}
+				isMobile={innerWidth < 768}
 				onMenuOpen={() => {
 					menuOpen = true
 				}}


### PR DESCRIPTION
## Summary

At fractional viewport widths just below 768px (e.g. 767.8px, common with non-integer device-pixel-ratios or browser zoom), the left sidebar rendered as an expanded shell with no width/content — "part mobile, part desktop".

Root cause: the desktop vs. mobile sidebar is selected in **JS** via `{#if innerWidth < 768} ... {:else}`. `window.innerWidth` **rounds** fractional widths, so at 767.8px JS rounds to 768 and mounts the desktop `#sidebar`. But that element's width was set **only** via Tailwind `md:w-12`/`md:w-40` (`@media (min-width:768px)`), which evaluates against the **actual fractional** layout viewport — at 767.8px the media query is false, so no width class applies and the sidebar collapses to zero/auto width while still showing as expanded.

The same dual-breakpoint mismatch existed for the main content left-offset (`AiChatLayout`), which used `md:pl-12`/`md:pl-40` while sidebar presence is JS-gated.

## Changes

- `+layout.svelte`: drop the now-redundant `md:` prefix on the desktop `#sidebar` width (`md:w-12`/`md:w-40` → `w-12`/`w-40`). The branch is already JS-gated at `innerWidth >= 768`, so width should track that decision, not a separate CSS media query.
- `AiChatLayout.svelte`: add an `isMobile` prop; gate the content left-padding on it with unprefixed `pl-12`/`pl-40` instead of `md:pl-12`/`md:pl-40`.
- `+layout.svelte`: pass `isMobile={innerWidth < 768}` so the content offset flips on the exact same JS condition as the sidebar. Other `AiChatLayout` callers (`ScriptWrapper`, `FlowWrapper`) pass `noPadding`, so they hit the `!pl-0` branch and are unaffected.

## Test plan

- [ ] Resize a desktop browser (or use browser zoom / non-integer DPR) so the viewport sits right around the 767–768px boundary, on a non-operator account: sidebar renders at full `w-40` (or `w-12` collapsed) with menu items visible — no expanded-but-empty strip.
- [ ] In that same narrow band, confirm page content is not overlapped by the sidebar (content offset and sidebar width flip together).
- [ ] Wide desktop viewport: sidebar + content offset both correct, collapse toggle still works.
- [ ] Mobile viewport <768px: hamburger drawer, no fixed sidebar, content has no left padding.
- [ ] Operator account and `?nomenubar=true` / app-dev (`noPadding`) views unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sidebar showing an expanded empty strip near 768px by aligning the JS breakpoint with sidebar width and content padding. Sidebar and content now flip together to prevent overlap.

- **Bug Fixes**
  - `+layout.svelte`: Remove `md:` from sidebar width (`md:w-12`/`md:w-40` → `w-12`/`w-40`) so it follows `innerWidth >= 768`.
  - `AiChatLayout.svelte`: Add `isMobile` and pass `innerWidth < 768`; switch `md:pl-*` to `pl-*` gated by `isMobile` to sync content offset with the sidebar.

<sup>Written for commit f12aed750f8fa495678df277c689873170eb1f6d. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9191?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

