### PR TITLE
fix: prevent cross-tenant DNS poisoning via writable /etc in nsjail

### DIFF
--- a/backend/windmill-worker/nsjail/download.py.config.proto
+++ b/backend/windmill-worker/nsjail/download.py.config.proto
@@ -55,6 +55,11 @@ mount {
 	is_bind: true
 }
 
+# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
+# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
+# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
+# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
+# poisoning). Load-bearing despite the /etc bind above -- do not remove.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/download.py.config.proto
+++ b/backend/windmill-worker/nsjail/download.py.config.proto
@@ -55,11 +55,9 @@ mount {
 	is_bind: true
 }
 
-# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
-# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
-# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
-# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
-# poisoning). Load-bearing despite the /etc bind above -- do not remove.
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/download.py.config.proto
+++ b/backend/windmill-worker/nsjail/download.py.config.proto
@@ -56,6 +56,27 @@ mount {
 }
 
 mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
 	src: "/dev/null"
 	dst: "/dev/null"
 	is_bind: true

--- a/backend/windmill-worker/nsjail/download.ruby.config.proto
+++ b/backend/windmill-worker/nsjail/download.ruby.config.proto
@@ -55,6 +55,11 @@ mount {
 	is_bind: true
 }
 
+# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
+# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
+# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
+# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
+# poisoning). Load-bearing despite the /etc bind above -- do not remove.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/download.ruby.config.proto
+++ b/backend/windmill-worker/nsjail/download.ruby.config.proto
@@ -55,11 +55,9 @@ mount {
 	is_bind: true
 }
 
-# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
-# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
-# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
-# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
-# poisoning). Load-bearing despite the /etc bind above -- do not remove.
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/download.ruby.config.proto
+++ b/backend/windmill-worker/nsjail/download.ruby.config.proto
@@ -56,6 +56,27 @@ mount {
 }
 
 mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
 	src: "/dev/null"
 	dst: "/dev/null"
 	is_bind: true

--- a/backend/windmill-worker/nsjail/download.rust.config.proto
+++ b/backend/windmill-worker/nsjail/download.rust.config.proto
@@ -63,6 +63,27 @@ mount {
 }
 
 mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
     src: "/dev/random"
     dst: "/dev/random"
     is_bind: true

--- a/backend/windmill-worker/nsjail/download.rust.config.proto
+++ b/backend/windmill-worker/nsjail/download.rust.config.proto
@@ -62,11 +62,9 @@ mount {
 	is_bind: true
 }
 
-# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
-# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
-# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
-# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
-# poisoning). Load-bearing despite the /etc bind above -- do not remove.
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/download.rust.config.proto
+++ b/backend/windmill-worker/nsjail/download.rust.config.proto
@@ -62,6 +62,11 @@ mount {
 	is_bind: true
 }
 
+# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
+# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
+# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
+# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
+# poisoning). Load-bearing despite the /etc bind above -- do not remove.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/install.r.config.proto
+++ b/backend/windmill-worker/nsjail/install.r.config.proto
@@ -55,6 +55,11 @@ mount {
 	is_bind: true
 }
 
+# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
+# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
+# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
+# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
+# poisoning). Load-bearing despite the /etc bind above -- do not remove.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/install.r.config.proto
+++ b/backend/windmill-worker/nsjail/install.r.config.proto
@@ -55,11 +55,9 @@ mount {
 	is_bind: true
 }
 
-# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
-# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
-# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
-# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
-# poisoning). Load-bearing despite the /etc bind above -- do not remove.
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/install.r.config.proto
+++ b/backend/windmill-worker/nsjail/install.r.config.proto
@@ -56,6 +56,27 @@ mount {
 }
 
 mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
 	src: "/dev/null"
 	dst: "/dev/null"
 	is_bind: true

--- a/backend/windmill-worker/nsjail/lock.ruby.config.proto
+++ b/backend/windmill-worker/nsjail/lock.ruby.config.proto
@@ -55,6 +55,11 @@ mount {
 	is_bind: true
 }
 
+# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
+# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
+# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
+# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
+# poisoning). Load-bearing despite the /etc bind above -- do not remove.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/lock.ruby.config.proto
+++ b/backend/windmill-worker/nsjail/lock.ruby.config.proto
@@ -55,11 +55,9 @@ mount {
 	is_bind: true
 }
 
-# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
-# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
-# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
-# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
-# poisoning). Load-bearing despite the /etc bind above -- do not remove.
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/lock.ruby.config.proto
+++ b/backend/windmill-worker/nsjail/lock.ruby.config.proto
@@ -56,6 +56,27 @@ mount {
 }
 
 mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
 	src: "/dev/null"
 	dst: "/dev/null"
 	is_bind: true

--- a/backend/windmill-worker/nsjail/run.ansible.config.proto
+++ b/backend/windmill-worker/nsjail/run.ansible.config.proto
@@ -124,6 +124,27 @@ mount {
 }
 
 mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
     src: "/dev/random"
     dst: "/dev/random"
     is_bind: true

--- a/backend/windmill-worker/nsjail/run.ansible.config.proto
+++ b/backend/windmill-worker/nsjail/run.ansible.config.proto
@@ -123,6 +123,11 @@ mount {
 	is_bind: true
 }
 
+# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
+# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
+# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
+# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
+# poisoning). Load-bearing despite the /etc bind above -- do not remove.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.ansible.config.proto
+++ b/backend/windmill-worker/nsjail/run.ansible.config.proto
@@ -123,11 +123,9 @@ mount {
 	is_bind: true
 }
 
-# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
-# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
-# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
-# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
-# poisoning). Load-bearing despite the /etc bind above -- do not remove.
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.bash.config.proto
+++ b/backend/windmill-worker/nsjail/run.bash.config.proto
@@ -95,11 +95,9 @@ mount {
 	is_bind: true
 }
 
-# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
-# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
-# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
-# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
-# poisoning). Load-bearing despite the /etc bind above -- do not remove.
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.bash.config.proto
+++ b/backend/windmill-worker/nsjail/run.bash.config.proto
@@ -96,6 +96,27 @@ mount {
 }
 
 mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
     src: "/dev/random"
     dst: "/dev/random"
     is_bind: true

--- a/backend/windmill-worker/nsjail/run.bash.config.proto
+++ b/backend/windmill-worker/nsjail/run.bash.config.proto
@@ -95,6 +95,11 @@ mount {
 	is_bind: true
 }
 
+# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
+# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
+# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
+# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
+# poisoning). Load-bearing despite the /etc bind above -- do not remove.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.bun.config.proto
+++ b/backend/windmill-worker/nsjail/run.bun.config.proto
@@ -153,11 +153,9 @@ mount {
 	is_bind: true
 }
 
-# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
-# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
-# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
-# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
-# poisoning). Load-bearing despite the /etc bind above -- do not remove.
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.bun.config.proto
+++ b/backend/windmill-worker/nsjail/run.bun.config.proto
@@ -153,6 +153,11 @@ mount {
 	is_bind: true
 }
 
+# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
+# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
+# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
+# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
+# poisoning). Load-bearing despite the /etc bind above -- do not remove.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.bun.config.proto
+++ b/backend/windmill-worker/nsjail/run.bun.config.proto
@@ -154,6 +154,27 @@ mount {
 }
 
 mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
     src: "/dev/random"
     dst: "/dev/random"
     is_bind: true

--- a/backend/windmill-worker/nsjail/run.csharp.config.proto
+++ b/backend/windmill-worker/nsjail/run.csharp.config.proto
@@ -91,11 +91,9 @@ mount {
 	is_bind: true
 }
 
-# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
-# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
-# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
-# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
-# poisoning). Load-bearing despite the /etc bind above -- do not remove.
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.csharp.config.proto
+++ b/backend/windmill-worker/nsjail/run.csharp.config.proto
@@ -92,6 +92,27 @@ mount {
 }
 
 mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
     src: "/dev/random"
     dst: "/dev/random"
     is_bind: true

--- a/backend/windmill-worker/nsjail/run.csharp.config.proto
+++ b/backend/windmill-worker/nsjail/run.csharp.config.proto
@@ -91,6 +91,11 @@ mount {
 	is_bind: true
 }
 
+# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
+# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
+# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
+# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
+# poisoning). Load-bearing despite the /etc bind above -- do not remove.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.go.config.proto
+++ b/backend/windmill-worker/nsjail/run.go.config.proto
@@ -85,6 +85,27 @@ mount {
 }
 
 mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
     src: "/dev/random"
     dst: "/dev/random"
     is_bind: true

--- a/backend/windmill-worker/nsjail/run.go.config.proto
+++ b/backend/windmill-worker/nsjail/run.go.config.proto
@@ -84,11 +84,9 @@ mount {
 	is_bind: true
 }
 
-# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
-# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
-# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
-# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
-# poisoning). Load-bearing despite the /etc bind above -- do not remove.
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.go.config.proto
+++ b/backend/windmill-worker/nsjail/run.go.config.proto
@@ -84,6 +84,11 @@ mount {
 	is_bind: true
 }
 
+# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
+# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
+# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
+# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
+# poisoning). Load-bearing despite the /etc bind above -- do not remove.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.java.config.proto
+++ b/backend/windmill-worker/nsjail/run.java.config.proto
@@ -92,11 +92,9 @@ mount {
     is_bind: true
 }
 
-# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
-# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
-# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
-# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
-# poisoning). Load-bearing despite the /etc bind above -- do not remove.
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.java.config.proto
+++ b/backend/windmill-worker/nsjail/run.java.config.proto
@@ -93,6 +93,27 @@ mount {
 }
 
 mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
     src: "/dev/random"
     dst: "/dev/random"
     is_bind: true

--- a/backend/windmill-worker/nsjail/run.java.config.proto
+++ b/backend/windmill-worker/nsjail/run.java.config.proto
@@ -92,6 +92,11 @@ mount {
     is_bind: true
 }
 
+# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
+# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
+# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
+# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
+# poisoning). Load-bearing despite the /etc bind above -- do not remove.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.nu.config.proto
+++ b/backend/windmill-worker/nsjail/run.nu.config.proto
@@ -90,6 +90,27 @@ mount {
 }
 
 mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
     src: "/dev/random"
     dst: "/dev/random"
     is_bind: true

--- a/backend/windmill-worker/nsjail/run.nu.config.proto
+++ b/backend/windmill-worker/nsjail/run.nu.config.proto
@@ -89,11 +89,9 @@ mount {
 	is_bind: true
 }
 
-# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
-# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
-# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
-# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
-# poisoning). Load-bearing despite the /etc bind above -- do not remove.
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.nu.config.proto
+++ b/backend/windmill-worker/nsjail/run.nu.config.proto
@@ -89,6 +89,11 @@ mount {
 	is_bind: true
 }
 
+# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
+# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
+# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
+# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
+# poisoning). Load-bearing despite the /etc bind above -- do not remove.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.php.config.proto
+++ b/backend/windmill-worker/nsjail/run.php.config.proto
@@ -78,6 +78,11 @@ mount {
 	is_bind: true
 }
 
+# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
+# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
+# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
+# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
+# poisoning). Load-bearing despite the /etc bind above -- do not remove.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.php.config.proto
+++ b/backend/windmill-worker/nsjail/run.php.config.proto
@@ -79,6 +79,27 @@ mount {
 }
 
 mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
     src: "/dev/random"
     dst: "/dev/random"
     is_bind: true

--- a/backend/windmill-worker/nsjail/run.php.config.proto
+++ b/backend/windmill-worker/nsjail/run.php.config.proto
@@ -78,11 +78,9 @@ mount {
 	is_bind: true
 }
 
-# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
-# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
-# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
-# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
-# poisoning). Load-bearing despite the /etc bind above -- do not remove.
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.powershell.config.proto
+++ b/backend/windmill-worker/nsjail/run.powershell.config.proto
@@ -91,11 +91,9 @@ mount {
 	is_bind: true
 }
 
-# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
-# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
-# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
-# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
-# poisoning). Load-bearing despite the /etc bind above -- do not remove.
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.powershell.config.proto
+++ b/backend/windmill-worker/nsjail/run.powershell.config.proto
@@ -92,6 +92,27 @@ mount {
 }
 
 mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
     src: "/dev/random"
     dst: "/dev/random"
     is_bind: true

--- a/backend/windmill-worker/nsjail/run.powershell.config.proto
+++ b/backend/windmill-worker/nsjail/run.powershell.config.proto
@@ -91,6 +91,11 @@ mount {
 	is_bind: true
 }
 
+# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
+# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
+# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
+# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
+# poisoning). Load-bearing despite the /etc bind above -- do not remove.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.python3.config.proto
+++ b/backend/windmill-worker/nsjail/run.python3.config.proto
@@ -108,6 +108,27 @@ mount {
 }
 
 mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
     dst: "/dev/shm"
     fstype: "tmpfs"
     rw: true

--- a/backend/windmill-worker/nsjail/run.python3.config.proto
+++ b/backend/windmill-worker/nsjail/run.python3.config.proto
@@ -107,6 +107,11 @@ mount {
 	is_bind: true
 }
 
+# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
+# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
+# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
+# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
+# poisoning). Load-bearing despite the /etc bind above -- do not remove.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.python3.config.proto
+++ b/backend/windmill-worker/nsjail/run.python3.config.proto
@@ -107,11 +107,9 @@ mount {
 	is_bind: true
 }
 
-# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
-# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
-# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
-# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
-# poisoning). Load-bearing despite the /etc bind above -- do not remove.
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.r.config.proto
+++ b/backend/windmill-worker/nsjail/run.r.config.proto
@@ -92,11 +92,9 @@ mount {
     is_bind: true
 }
 
-# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
-# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
-# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
-# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
-# poisoning). Load-bearing despite the /etc bind above -- do not remove.
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.r.config.proto
+++ b/backend/windmill-worker/nsjail/run.r.config.proto
@@ -92,6 +92,11 @@ mount {
     is_bind: true
 }
 
+# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
+# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
+# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
+# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
+# poisoning). Load-bearing despite the /etc bind above -- do not remove.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.r.config.proto
+++ b/backend/windmill-worker/nsjail/run.r.config.proto
@@ -93,6 +93,27 @@ mount {
 }
 
 mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
     src: "/sys/devices/system/cpu"
     dst: "/sys/devices/system/cpu"
     is_bind: true

--- a/backend/windmill-worker/nsjail/run.ruby.config.proto
+++ b/backend/windmill-worker/nsjail/run.ruby.config.proto
@@ -92,11 +92,9 @@ mount {
     is_bind: true
 }
 
-# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
-# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
-# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
-# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
-# poisoning). Load-bearing despite the /etc bind above -- do not remove.
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.ruby.config.proto
+++ b/backend/windmill-worker/nsjail/run.ruby.config.proto
@@ -93,6 +93,27 @@ mount {
 }
 
 mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
     src: "/dev/random"
     dst: "/dev/random"
     is_bind: true

--- a/backend/windmill-worker/nsjail/run.ruby.config.proto
+++ b/backend/windmill-worker/nsjail/run.ruby.config.proto
@@ -92,6 +92,11 @@ mount {
     is_bind: true
 }
 
+# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
+# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
+# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
+# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
+# poisoning). Load-bearing despite the /etc bind above -- do not remove.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.rust.config.proto
+++ b/backend/windmill-worker/nsjail/run.rust.config.proto
@@ -85,6 +85,27 @@ mount {
 }
 
 mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
     src: "/dev/random"
     dst: "/dev/random"
     is_bind: true

--- a/backend/windmill-worker/nsjail/run.rust.config.proto
+++ b/backend/windmill-worker/nsjail/run.rust.config.proto
@@ -84,11 +84,9 @@ mount {
 	is_bind: true
 }
 
-# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
-# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
-# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
-# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
-# poisoning). Load-bearing despite the /etc bind above -- do not remove.
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"

--- a/backend/windmill-worker/nsjail/run.rust.config.proto
+++ b/backend/windmill-worker/nsjail/run.rust.config.proto
@@ -84,6 +84,11 @@ mount {
 	is_bind: true
 }
 
+# Shadow kubelet-injected /etc submounts with read-only file binds. The /etc
+# bind above is read-only, but on Kubernetes /etc/hosts, /etc/resolv.conf and
+# /etc/hostname are separate bind-mounts layered on /etc, and nsjail's
+# read-only remount is non-recursive, leaving them writable (cross-tenant DNS
+# poisoning). Load-bearing despite the /etc bind above -- do not remove.
 mount {
     src: "/etc/resolv.conf"
     dst: "/etc/resolv.conf"


### PR DESCRIPTION
## Summary

A reported vulnerability (DNS poisoning persistence via writable `/etc/hosts`) was **verified valid**. A sandboxed job can append entries to `/etc/hosts` / `/etc/resolv.conf`; because a Windmill worker pod is long-lived and reused across all workspaces, the poison persists for the pod lifetime and affects every other tenant's jobs on that pod (credential theft, supply-chain via `pypi.org`, blanket DNS MITM via `resolv.conf`).

This PR fixes the **nsjail sandbox path** (the hardened mode used on Windmill Cloud) by adding explicit read-only per-file binds for `/etc/resolv.conf`, `/etc/hosts`, and `/etc/hostname` to all 18 nsjail config protos.

## Root cause

The nsjail protos mount the whole `/etc` directory read-only (`is_bind: true`, no `rw: true`). That is sufficient for ordinary `/etc` files, **but not on Kubernetes**: the kubelet injects `/etc/hosts`, `/etc/hostname`, and `/etc/resolv.conf` as *separate bind-mounts layered on top of `/etc`*. nsjail recursively binds `/etc` and then applies its read-only remount **non-recursively** — the classic `mount(MS_REMOUNT|MS_RDONLY)` syscall does not propagate read-only to submounts — so those three kubelet-injected files remain **read-write inside the jail**. This exactly matches the report's empirical observation: a well-isolated sandbox (read-only rootfs, no caps) where `/etc/hosts` is nonetheless writable and persists cross-tenant.

## Reproduction (root-cause mount semantics)

Run inside `unshare -Urm` (touches only `/tmp`):

```
STEP A — simulate nsjail: recursive bind of /etc + NON-recursive ro remount
  write to a normal file under read-only /etc  -> blocked (EROFS)  ✅ ro works for real /etc files
  write to /etc/hosts (kubelet submount)        -> *** WRITABLE — VULNERABILITY CONFIRMED ***
  underlying pod-level kubelet file now contains the injected "1.3.3.7 attacker.com"
     -> poison persists at the POD level, visible to every other job/tenant

STEP B — apply the fix: explicit read-only file bind of /etc/hosts after the /etc mount
  write to /etc/hosts after fix                 -> blocked (EROFS)  ✅ FIX WORKS
```

A leaf-file bind has no submounts, so nsjail's read-only remount is fully effective on it; the explicit binds shadow the writable kubelet submounts with a read-only view of the same content. `mandatory: false` keeps jobs working on images that lack one of these files.

## Changes

- 18 files in `backend/windmill-worker/nsjail/*.config.proto`: added read-only binds for `/etc/resolv.conf`, `/etc/hosts`, `/etc/hostname` immediately after the existing `/etc` mount (read access for DNS is preserved; only writes are blocked).

## Scope / known limitations (follow-up)

- This fixes the **nsjail** isolation mode (Cloud / `job_isolation=nsjail_sandboxing` / `DISABLE_NSJAIL=false`).
- The **`none`** and **`unshare`** modes (`UNSHARE_ISOLATION_FLAGS` default `--user --map-root-user --pid --fork --mount-proc`, **no `--mount`**) have *no mount namespace at all*, so resolver files there remain writable. Closing that requires adding mount-namespace isolation and is intentionally out of scope for this targeted fix — flagging for a separate change/decision (e.g. document those modes as unsafe for multi-tenant, or add a private `/etc` overlay).

## Test plan

- [ ] Run a Python job under nsjail and confirm `open("/etc/hosts","a")` raises `OSError: [Errno 30] Read-only file system`
- [ ] Confirm DNS still resolves (read access to `/etc/resolv.conf`/`/etc/hosts` preserved) and `pip`/dependency install still works
- [ ] Confirm jobs still start on a minimal image lacking `/etc/hostname` (validates `mandatory: false`)
- [ ] Smoke-test one job per language family (python/bun/bash/go/java/ruby/php) for nsjail startup with the new mounts

https://claude.ai/code/session_01HY5oZW22XyZwkjYYj9c9M3

---
_Generated by [Claude Code](https://claude.ai/code/session_01HY5oZW22XyZwkjYYj9c9M3)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents cross-tenant DNS poisoning in nsjail sandboxes by binding /etc/resolv.conf, /etc/hosts, and /etc/hostname as read-only across all 18 nsjail configs. DNS read access is preserved; writes are blocked so poison cannot persist.

- **Bug Fixes**
  - Added explicit read-only file binds for /etc/resolv.conf, /etc/hosts, /etc/hostname in all nsjail config protos (mandatory: false), with a shortened 3-line comment explaining why these binds are required to prevent future removal.
  - Addresses Kubernetes submounts that remained writable despite a read-only /etc remount.
  - Scope: fixes nsjail mode; `none` and `unshare` modes remain writable and need a separate follow-up.

<sup>Written for commit 6d65381fdff8ccaf0ad004b2b524224dc7ebfd0c. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9194?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

