### PR TITLE
chore: remove alpha/beta warnings from tested frontend features

### DIFF
--- a/frontend/src/lib/components/AutoscalingConfigEditor.svelte
+++ b/frontend/src/lib/components/AutoscalingConfigEditor.svelte
@@ -14,7 +14,6 @@
 	import { ConfigService } from '$lib/gen'
 	import Select from './select/Select.svelte'
 	import ScriptPicker from './ScriptPicker.svelte'
-	import Badge from './common/badge/Badge.svelte'
 	import { sendUserToast } from '$lib/toast'
 
 	interface Props {
@@ -66,9 +65,6 @@
 	description="Autoscaling automatically adjusts the number of workers based on your workload demands."
 	{eeOnly}
 >
-	{#snippet labelExtra()}
-		<Badge color="gray">Beta</Badge>
-	{/snippet}
 	{#snippet header()}
 		<div class="ml-2">
 			<Toggle

--- a/frontend/src/lib/components/Dev.svelte
+++ b/frontend/src/lib/components/Dev.svelte
@@ -1094,7 +1094,7 @@
 									left: '',
 									right: 'bundle relative paths for preview',
 									rightTooltip:
-										'(Beta) Instead of only sending the current file for preview and rely on already deployed code for the common logic, bundle all code that is imported in relative paths'
+										'Instead of only sending the current file for preview and rely on already deployed code for the common logic, bundle all code that is imported in relative paths'
 								}}
 							/>
 						{:else if currentScript?.language == 'python3'}

--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -96,24 +96,6 @@
 	import { buildForkEditUrl } from '$lib/utils/editInFork'
 	import OnBehalfOfSelector, { type OnBehalfOfChoice } from './OnBehalfOfSelector.svelte'
 	import WacExportDrawer from './scripts/WacExportDrawer.svelte'
-	import Modal from './common/modal/Modal.svelte'
-
-	const WAC_ALPHA_ACK_KEY = 'windmill_wac_alpha_ack'
-	let wacAlphaModalOpen = $state(false)
-
-	function showWacAlphaModalIfNeeded() {
-		if (
-			typeof sessionStorage !== 'undefined' &&
-			sessionStorage.getItem(WAC_ALPHA_ACK_KEY) !== 'true'
-		) {
-			wacAlphaModalOpen = true
-		}
-	}
-
-	function acknowledgeWacAlpha() {
-		sessionStorage.setItem(WAC_ALPHA_ACK_KEY, 'true')
-		wacAlphaModalOpen = false
-	}
 
 	let {
 		script = $bindable(),
@@ -378,7 +360,6 @@
 					language: 'python3'
 				}
 			}
-			showWacAlphaModalIfNeeded()
 		} else if (template === 'wac_typescript') {
 			script.modules = {
 				'helper.ts': {
@@ -386,7 +367,6 @@
 					language: 'bun'
 				}
 			}
-			showWacAlphaModalIfNeeded()
 		}
 		initContent(script.language, script.kind, template)
 	}
@@ -1268,9 +1248,6 @@
 															} as ButtonType.Icon}
 														>
 															<span class="truncate">{label}</span>
-															{#if lang === 'rlang'}
-																<span class="text-primary !text-xs"> BETA </span>
-															{/if}
 														</Button>
 														{#snippet text()}
 															{label} is only available with an enterprise license
@@ -1318,7 +1295,6 @@
 														}
 													}
 													initContent('bun', script.kind, template)
-													showWacAlphaModalIfNeeded()
 												}}
 											>
 												WAC TypeScript
@@ -1343,7 +1319,6 @@
 														}
 													}
 													initContent('python3', script.kind, template)
-													showWacAlphaModalIfNeeded()
 												}}
 											>
 												WAC Python
@@ -2085,26 +2060,3 @@
 {/if}
 
 <WacExportDrawer bind:this={wacExportDrawer} />
-
-<Modal bind:open={wacAlphaModalOpen} title="Workflow-as-Code (Alpha)" kind="X">
-	<div class="flex flex-col gap-4 pr-4">
-		<p class="text-sm text-secondary">
-			Workflow-as-Code is in <strong>alpha</strong> — use in production at your own risk. It is an
-			alternative to the Flow editor for advanced users. Feedback welcome on
-			<a
-				href="https://github.com/windmill-labs/windmill/issues"
-				target="_blank"
-				class="text-blue-600 dark:text-blue-400 hover:underline">GitHub</a
-			>
-			or
-			<a
-				href="https://discord.com/invite/V7PM2YHsPB"
-				target="_blank"
-				class="text-blue-600 dark:text-blue-400 hover:underline">Discord</a
-			>.
-		</p>
-		<div class="flex justify-end">
-			<Button size="sm" on:click={acknowledgeWacAlpha}>Acknowledge</Button>
-		</div>
-	</div>
-</Modal>

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -11,13 +11,7 @@
 		type ScriptModule
 	} from '$lib/gen'
 	import { enterpriseLicense, userStore, workspaceStore } from '$lib/stores'
-	import {
-		copyToClipboard,
-		emptySchema,
-		getLocalSetting,
-		sendUserToast,
-		storeLocalSetting
-	} from '$lib/utils'
+	import { copyToClipboard, emptySchema, sendUserToast } from '$lib/utils'
 	import Editor from './Editor.svelte'
 	import { inferArgs, inferAssets, inferAnsibleExecutionMode } from '$lib/infer'
 	import { isWorkflowAsCode } from '$lib/components/graph/wacToFlow'
@@ -41,7 +35,6 @@
 	import Popover from './meltComponents/Popover.svelte'
 	import DiffEditor from './DiffEditor.svelte'
 	import {
-		AlertTriangle,
 		Bug,
 		Copy,
 		CornerDownLeft,
@@ -582,8 +575,6 @@
 	let ansibleGitSshIdentity = $state<string[]>([])
 
 	// Debug mode state
-	const DEBUG_BETA_WARNING_KEY = 'debug_beta_warning_confirmed'
-	let showDebugBetaWarning = $state(false)
 	let debugMode = $state(false)
 	let debugBreakpoints = new SvelteSet<number>()
 	let breakpointDecorations: string[] = $state([])
@@ -1028,19 +1019,8 @@
 			clearAllBreakpoints()
 			updateCurrentLineDecoration(undefined)
 		} else {
-			// Entering debug mode - check if beta warning was confirmed
-			if (getLocalSetting(DEBUG_BETA_WARNING_KEY) !== 'true') {
-				showDebugBetaWarning = true
-			} else {
-				debugMode = true
-			}
+			debugMode = true
 		}
-	}
-
-	function confirmDebugBetaWarning(): void {
-		storeLocalSetting(DEBUG_BETA_WARNING_KEY, 'true')
-		showDebugBetaWarning = false
-		debugMode = true
 	}
 
 	// Subscribe to debug state changes for current line highlighting
@@ -1387,28 +1367,6 @@
 			on:click={() => copyToClipboard(collabUrl())}
 		/>
 	</div>
-</Modal>
-
-<Modal title="Debug Feature (Beta)" bind:open={showDebugBetaWarning}>
-	<div class="flex items-start gap-3">
-		<div class="flex-shrink-0">
-			<div
-				class="flex h-10 w-10 items-center justify-center rounded-full bg-yellow-100 dark:bg-yellow-800/50"
-			>
-				<AlertTriangle class="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
-			</div>
-		</div>
-		<div class="text-secondary text-sm">
-			<p
-				>The Debug feature is currently in <strong>beta</strong>. You may encounter unexpected
-				behavior or limitations.</p
-			>
-			<p class="mt-2">By continuing, you acknowledge that this feature is experimental.</p>
-		</div>
-	</div>
-	{#snippet actions()}
-		<Button size="sm" on:click={confirmDebugBetaWarning}>Continue</Button>
-	{/snippet}
 </Modal>
 
 <div class="border-b shadow-sm px-1 pr-4" bind:clientWidth={width}>

--- a/frontend/src/lib/components/flows/CreateActionsFlow.svelte
+++ b/frontend/src/lib/components/flows/CreateActionsFlow.svelte
@@ -142,13 +142,6 @@
 				onmouseenter={() => (wacHovered = true)}
 				onmouseleave={() => (wacHovered = false)}
 			>
-				<!-- Alpha badge -->
-				<div
-					class="absolute top-2 right-2 z-10 px-2 py-0.5 rounded-full bg-purple-500 text-white text-2xs font-bold uppercase tracking-wide"
-				>
-					Alpha
-				</div>
-
 				<!-- Default state -->
 				<div
 					class="flex flex-col items-center gap-3 p-6 absolute inset-0 transition-all duration-300"

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -79,9 +79,8 @@
 		signDebugRequest,
 		getDebugErrorMessage
 	} from '$lib/components/debug'
-	import { AlertTriangle, Bug, Terminal } from 'lucide-svelte'
-	import Modal from '$lib/components/common/modal/Modal.svelte'
-	import { getLocalSetting, sendUserToast, storeLocalSetting } from '$lib/utils'
+	import { Bug, Terminal } from 'lucide-svelte'
+	import { sendUserToast } from '$lib/utils'
 
 	const {
 		selectionManager,
@@ -400,8 +399,6 @@
 	)
 
 	// Debug mode state
-	const DEBUG_BETA_WARNING_KEY = 'debug_beta_warning_confirmed'
-	let showDebugBetaWarning = $state(false)
 	let debugMode = $state(false)
 	let debugBreakpoints = new SvelteSet<number>()
 	let breakpointDecorations: string[] = $state([])
@@ -621,23 +618,10 @@
 			clearAllBreakpoints()
 			updateCurrentLineDecoration(undefined)
 		} else {
-			// Entering debug mode - check if beta warning was confirmed
-			if (getLocalSetting(DEBUG_BETA_WARNING_KEY) !== 'true') {
-				showDebugBetaWarning = true
-			} else {
-				debugMode = true
-				// Switch to test tab when entering debug mode
-				selected = 'test'
-			}
+			debugMode = true
+			// Switch to test tab when entering debug mode
+			selected = 'test'
 		}
-	}
-
-	function confirmDebugBetaWarning(): void {
-		storeLocalSetting(DEBUG_BETA_WARNING_KEY, 'true')
-		showDebugBetaWarning = false
-		debugMode = true
-		// Switch to test tab when entering debug mode
-		selected = 'test'
 	}
 
 	// Subscribe to debug state changes for current line highlighting
@@ -1540,25 +1524,3 @@
 {:else}
 	Incorrect flow module type
 {/if}
-
-<Modal title="Debug Feature (Beta)" bind:open={showDebugBetaWarning}>
-	<div class="flex items-start gap-3">
-		<div class="flex-shrink-0">
-			<div
-				class="flex h-10 w-10 items-center justify-center rounded-full bg-yellow-100 dark:bg-yellow-800/50"
-			>
-				<AlertTriangle class="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
-			</div>
-		</div>
-		<div class="text-secondary text-sm">
-			<p
-				>The Debug feature is currently in <strong>beta</strong>. You may encounter unexpected
-				behavior or limitations.</p
-			>
-			<p class="mt-2">By continuing, you acknowledge that this feature is experimental.</p>
-		</div>
-	</div>
-	{#snippet actions()}
-		<Button size="sm" on:click={confirmDebugBetaWarning}>Continue</Button>
-	{/snippet}
-</Modal>

--- a/frontend/src/lib/components/instanceSettings/SecretBackendConfig.svelte
+++ b/frontend/src/lib/components/instanceSettings/SecretBackendConfig.svelte
@@ -372,7 +372,7 @@
 				/>
 				<ToggleButton
 					value="HashiCorpVault"
-					label="HashiCorp Vault (Beta)"
+					label="HashiCorp Vault"
 					tooltip={vaultDisabled
 						? 'Requires Enterprise Edition'
 						: 'Store secrets in HashiCorp Vault'}
@@ -390,7 +390,7 @@
 				/>
 				<ToggleButton
 					value="AwsSecretsManager"
-					label="AWS Secrets Manager (Beta)"
+					label="AWS Secrets Manager"
 					tooltip={vaultDisabled
 						? 'Requires Enterprise Edition'
 						: 'Store secrets in AWS Secrets Manager'}
@@ -422,12 +422,7 @@
 			<div class="flex items-center gap-2 mb-4">
 				<Lock class="text-primary" size={20} />
 				<div>
-					<p class="text-sm font-medium text-emphasis"
-						>HashiCorp Vault Configuration <span
-							class="ml-2 px-1.5 py-0.5 text-2xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 rounded"
-							>Beta</span
-						></p
-					>
+					<p class="text-sm font-medium text-emphasis">HashiCorp Vault Configuration</p>
 					<p class="text-xs text-secondary"
 						>Store secrets in an external HashiCorp Vault instance.</p
 					>
@@ -766,12 +761,7 @@ vault write auth/{jwtMount}/role/{$values['secret_backend']?.jwt_role || 'windmi
 			<div class="flex items-center gap-2 mb-4">
 				<Cloud class="text-primary" size={20} />
 				<div>
-					<p class="text-sm font-medium text-emphasis"
-						>AWS Secrets Manager Configuration <span
-							class="ml-2 px-1.5 py-0.5 text-2xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200 rounded"
-							>Beta</span
-						></p
-					>
+					<p class="text-sm font-medium text-emphasis">AWS Secrets Manager Configuration</p>
 					<p class="text-xs text-secondary">Store secrets in AWS Secrets Manager.</p>
 				</div>
 			</div>

--- a/frontend/src/lib/components/raw_apps/RawAppInlineScriptEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppInlineScriptEditor.svelte
@@ -5,12 +5,11 @@
 	import Button from '$lib/components/common/button/Button.svelte'
 	import type { Preview, ScriptLang } from '$lib/gen'
 	import { createEventDispatcher, onDestroy, onMount, untrack } from 'svelte'
-	import { AlertTriangle, Trash2, Bug, Terminal } from 'lucide-svelte'
-	import Modal from '$lib/components/common/modal/Modal.svelte'
+	import { Trash2, Bug, Terminal } from 'lucide-svelte'
 	import { inferArgs, inferAssets } from '$lib/infer'
 	import type { Schema } from '$lib/common'
 	import Editor from '$lib/components/Editor.svelte'
-	import { emptySchema, getLocalSetting, sendUserToast, storeLocalSetting } from '$lib/utils'
+	import { emptySchema, sendUserToast } from '$lib/utils'
 
 	import { scriptLangToEditorLang } from '$lib/scripts'
 	import DiffEditor from '$lib/components/DiffEditor.svelte'
@@ -156,8 +155,6 @@
 	})
 
 	// Debug mode state
-	const DEBUG_BETA_WARNING_KEY = 'debug_beta_warning_confirmed'
-	let showDebugBetaWarning = $state(false)
 	let debugMode = $state(false)
 	let debugBreakpoints = new SvelteSet<number>()
 	let breakpointDecorations: string[] = $state([])
@@ -396,19 +393,8 @@
 			clearAllBreakpoints()
 			updateCurrentLineDecoration(undefined)
 		} else {
-			// Entering debug mode - check if beta warning was confirmed
-			if (getLocalSetting(DEBUG_BETA_WARNING_KEY) !== 'true') {
-				showDebugBetaWarning = true
-			} else {
-				debugMode = true
-			}
+			debugMode = true
 		}
-	}
-
-	function confirmDebugBetaWarning(): void {
-		storeLocalSetting(DEBUG_BETA_WARNING_KEY, 'true')
-		showDebugBetaWarning = false
-		debugMode = true
 	}
 
 	// Subscribe to debug state changes for current line highlighting
@@ -801,25 +787,3 @@
 		</div>
 	</div>
 {/if}
-
-<Modal title="Debug Feature (Beta)" bind:open={showDebugBetaWarning}>
-	<div class="flex items-start gap-3">
-		<div class="flex-shrink-0">
-			<div
-				class="flex h-10 w-10 items-center justify-center rounded-full bg-yellow-100 dark:bg-yellow-800/50"
-			>
-				<AlertTriangle class="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
-			</div>
-		</div>
-		<div class="text-secondary text-sm">
-			<p
-				>The Debug feature is currently in <strong>beta</strong>. You may encounter unexpected
-				behavior or limitations.</p
-			>
-			<p class="mt-2">By continuing, you acknowledge that this feature is experimental.</p>
-		</div>
-	</div>
-	{#snippet actions()}
-		<Button size="sm" on:click={confirmDebugBetaWarning}>Continue</Button>
-	{/snippet}
-</Modal>


### PR DESCRIPTION
## Summary
Several frontend features were gated behind alpha/beta/experimental warnings. They are now considered well-tested, so this PR removes all user-facing alpha/beta/experimental warnings and their associated gating logic. No feature behavior changes — only the warnings are removed.

## Changes
- **Debug Feature (Beta) modal removed** in `ScriptEditor.svelte`, `flows/content/FlowModuleComponent.svelte`, and `raw_apps/RawAppInlineScriptEditor.svelte`. Toggling debug mode now enters directly (no confirmation modal / localStorage gate). Removed `DEBUG_BETA_WARNING_KEY`, `showDebugBetaWarning`, `confirmDebugBetaWarning`, and now-unused imports (`AlertTriangle`, `Modal`, `getLocalSetting`, `storeLocalSetting` where no longer used). The `selected = 'test'` tab switch in the flow module is preserved.
- **Workflow-as-Code (Alpha) modal removed** in `ScriptBuilder.svelte` (`WAC_ALPHA_ACK_KEY`, `wacAlphaModalOpen`, `showWacAlphaModalIfNeeded`, `acknowledgeWacAlpha`, all call sites, and the unused `Modal` import). Removed the purple "Alpha" badge from the WAC card in `flows/CreateActionsFlow.svelte` (hover transition unaffected).
- **Inline beta markers removed**: rlang "BETA" span in `ScriptBuilder.svelte`; "Beta" `<Badge>` (and now-unused `Badge` import) in `AutoscalingConfigEditor.svelte`; "(Beta)" suffixes and badges for HashiCorp Vault & AWS Secrets Manager in `instanceSettings/SecretBackendConfig.svelte`; leading "(Beta) " in the bundle-relative-paths tooltip in `Dev.svelte`.

Excluded (not user-facing feature warnings): the color-alpha param in `utils.ts`, monaco `editor.experimental` in `vscode.ts`, the tanstack-table dependency code comment, and "preview"/"Preview" strings referring to preview-run job tags / CSS preview panes.

## Validation
- `npm run check` (full svelte-check): no new errors/warnings in any modified file (only pre-existing project-wide `Timeout`/`number` setInterval typing errors remain, unrelated to this change).
- Dev server compiles all modified files without error.
- Playwright smoke test (login → workspace → Script Builder & Flow editor): pages render with no runtime/console errors; R language button no longer shows "BETA"; no WAC alpha modal appears.
- Local code review (fresh-context): Good to merge — no dangling references, no orphaned Svelte blocks, no unused imports left behind, no logic regressions.

## Test plan
- [ ] Script Editor / Flow module / raw-app inline script: toggle debug mode → enters directly, no "Debug Feature (Beta)" modal (flow module also switches to Test tab)
- [ ] Script Builder: create WAC Python & TypeScript scripts (templates + WAC dropdown) → no "Workflow-as-Code (Alpha)" modal; rlang enterprise button shows no "BETA"
- [ ] Create-flow actions panel: WAC card has no "Alpha" badge; hover transition still works
- [ ] Autoscaling section: no "Beta" badge; toggle still works
- [ ] Instance Secret Backend settings: HashiCorp Vault & AWS Secrets Manager toggle labels and config headers show no "Beta"
- [ ] Dev preview-bundling toggle tooltip: no leading "(Beta) "

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed all alpha/beta/experimental warnings and gating from tested frontend features. Users can enter debug mode and use WAC templates without confirmation; badges and labels are removed.

- **Refactors**
  - Debug: removed warning modal and local/session storage gates in Script Editor, Flow module, and Raw App editor. Toggle enters directly; Flow module still switches to the Test tab.
  - Workflow-as-Code: removed alpha modal in `ScriptBuilder.svelte` and the Alpha badge in Create Actions Flow. Deleted `WAC_ALPHA_ACK_KEY` and related code.
  - UI text: removed “BETA/Beta” markers for R language, Autoscaling editor, Secret Backends (HashiCorp Vault, AWS Secrets Manager), and the bundle-relative-paths tooltip.
  - Cleanup: dropped unused imports like `Modal`, `Badge`, `AlertTriangle`, `getLocalSetting`, and `storeLocalSetting`.

<sup>Written for commit 9b38f2b250ef79427cb7d4793edbb66ff610c66a. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9196?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

