### PR TITLE
fix(mcp): validate oauth dynamic client registration redirect_uris

### DIFF
--- a/backend/windmill-api/src/mcp/oauth_server.rs
+++ b/backend/windmill-api/src/mcp/oauth_server.rs
@@ -285,6 +285,34 @@ pub async fn protected_resource_metadata_by_path(
     ))
 }
 
+/// Schemes that a browser executes as script or uses to read local content. The
+/// consent page navigates the user's browser to the registered redirect_uri
+/// (`window.location` / anchor `href`), so accepting any of these turns dynamic
+/// client registration into a stored-XSS / token-exfiltration primitive.
+const DISALLOWED_REDIRECT_URI_SCHEMES: &[&str] =
+    &["javascript", "data", "vbscript", "blob", "file"];
+
+/// Validate a dynamically-registered redirect_uri.
+///
+/// RFC 7591 dynamic client registration is intentionally unauthenticated for MCP
+/// interoperability, so the redirect_uri is the security boundary: it must be an
+/// absolute URI (RFC 6749 §3.1.2) and must not use a browser-executable scheme.
+fn validate_redirect_uri(uri: &str) -> Result<()> {
+    let parsed = url::Url::parse(uri).map_err(|_| {
+        Error::BadRequest(format!(
+            "Invalid redirect_uri (must be an absolute URI): {uri}"
+        ))
+    })?;
+    // `url` normalizes the scheme to lowercase ASCII.
+    if DISALLOWED_REDIRECT_URI_SCHEMES.contains(&parsed.scheme()) {
+        return Err(Error::BadRequest(format!(
+            "redirect_uri scheme '{}' is not allowed",
+            parsed.scheme()
+        )));
+    }
+    Ok(())
+}
+
 /// POST /api/mcp/oauth/server/register - dynamic client registration
 pub async fn oauth_register(
     Extension(db): Extension<DB>,
@@ -294,6 +322,10 @@ pub async fn oauth_register(
         return Err(Error::BadRequest(
             "At least one redirect_uri is required".to_string(),
         ));
+    }
+
+    for uri in &req.redirect_uris {
+        validate_redirect_uri(uri)?;
     }
 
     let client_id = format!("mcp-client-{}", rd_string(16));
@@ -991,4 +1023,47 @@ pub fn gateway_unauthed_service() -> Router {
 /// Mounted at /api/mcp/gateway/oauth/server (inside authenticated section)
 pub fn gateway_authed_service() -> Router {
     Router::new().route("/approve", post(gateway_oauth_approve))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_redirect_uri;
+
+    #[test]
+    fn accepts_legitimate_redirect_uris() {
+        for uri in [
+            "https://app.example.com/oauth/callback",
+            "http://localhost:9876/callback",
+            "http://127.0.0.1:33418/oauth/callback",
+            // Native/editor MCP clients use private-use URI schemes (RFC 8252).
+            "vscode://anthropic.claude/oauth/callback",
+            "cursor://anysphere.cursor/callback",
+        ] {
+            assert!(
+                validate_redirect_uri(uri).is_ok(),
+                "expected {uri} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_browser_executable_and_relative_redirect_uris() {
+        for uri in [
+            // GHSA-q9xg-f2v2-695g: stored-XSS / token exfiltration via consent page.
+            "javascript:fetch('/api/w/admins/tokens/create',{method:'POST'})//",
+            "JavaScript:alert(document.domain)",
+            "data:text/html,<script>alert(1)</script>",
+            "vbscript:msgbox(1)",
+            "blob:https://example.com/uuid",
+            "file:///etc/passwd",
+            // Not an absolute URI (RFC 6749 §3.1.2).
+            "/relative/callback",
+            "not a uri",
+        ] {
+            assert!(
+                validate_redirect_uri(uri).is_err(),
+                "expected {uri} to be rejected"
+            );
+        }
+    }
 }

--- a/frontend/src/routes/(root)/(logged)/oauth/mcp_authorize/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/oauth/mcp_authorize/+page.svelte
@@ -19,6 +19,20 @@
 	let codeChallenge = page.url.searchParams.get('code_challenge') || ''
 	let codeChallengeMethod = page.url.searchParams.get('code_challenge_method') || ''
 
+	// Defense-in-depth (GHSA-q9xg-f2v2-695g): the backend validates redirect_uris at
+	// registration, but this page navigates the browser to `redirectUri`, so reject
+	// browser-executable schemes here too — this also neutralizes any client rows
+	// registered before the backend fix.
+	const DISALLOWED_REDIRECT_SCHEMES = ['javascript:', 'data:', 'vbscript:', 'blob:', 'file:']
+	function isSafeRedirectUri(uri: string): boolean {
+		try {
+			return !DISALLOWED_REDIRECT_SCHEMES.includes(new URL(uri).protocol.toLowerCase())
+		} catch {
+			return false
+		}
+	}
+	let redirectUriValid = isSafeRedirectUri(redirectUri)
+
 	let loading = $state(false)
 	let success = $state(false)
 	let successRedirectUrl = $state('')
@@ -51,6 +65,7 @@
 	}
 
 	function onDeny() {
+		if (!redirectUriValid) return
 		// Redirect to client with error
 		const params = new URLSearchParams({
 			error: 'access_denied',
@@ -63,6 +78,7 @@
 	}
 
 	async function onApprove() {
+		if (!redirectUriValid) return
 		if (!workspaceId) {
 			sendUserToast('Please select a workspace', true)
 			return
@@ -121,7 +137,9 @@
 	}
 </script>
 
-{#if !isGateway && !workspaceId}
+{#if !redirectUriValid}
+	<p class="text-center text-sm text-primary mb-6"> Error: invalid or unsafe redirect_uri </p>
+{:else if !isGateway && !workspaceId}
 	<p class="text-center text-sm text-primary mb-6">Error: missing workspace_id</p>
 {:else}
 	<CenteredModal title={success ? 'Authorization Approved' : 'Authorization Request'}>


### PR DESCRIPTION
## Summary

Security fix for **GHSA-q9xg-f2v2-695g** (private advisory).

`POST /api/mcp/oauth/server/register` is intentionally unauthenticated (RFC 7591 dynamic client registration — required for MCP interop), but it accepted **completely unvalidated** `redirect_uris`. An attacker could register a client with `redirect_uri = javascript:<payload>`; the authorize flow only exact-matches against that attacker-controlled set, and the consent page (`mcp_authorize/+page.svelte`) then does `window.location.href = ${redirectUri}?...` in **both `onApprove` and `onDeny`** → stored XSS in the authenticated Windmill origin → API-token minting via `/api/w/<ws>/tokens/create`. This is the paired "MCP OAuth redirect URI XSS can mint API tokens" report. PKCE does not mitigate it (the attacker is the client).

Root cause is the missing `redirect_uri` validation, **not** the lack of auth on register — requiring auth would break MCP clients that self-register before the user authenticates. Fix constrains the redirect URI instead.

## Changes
- `oauth_register` now rejects non-absolute URIs and the browser-executable schemes `javascript`/`data`/`vbscript`/`blob`/`file` (`validate_redirect_uri`). Default-allow otherwise, preserving `https`, loopback `http`, and native `vscode://`-style schemes (RFC 7591/8252 compatible). Whole registration is rejected if any URI in the list is bad.
- Frontend defense-in-depth: scheme guard on the consent page (`isSafeRedirectUri`) gates `onApprove`/`onDeny` and the template, so any client rows registered **before** this fix can no longer reach the navigation/`<a href>` sink.
- Added `#[cfg(test)] mod tests` covering positive (https, loopback, `vscode://`, `cursor://`) and negative (`javascript:` incl. mixed-case, `data:`, `vbscript:`, `blob:`, `file:`, relative, malformed) cases.

## Affected versions
Introduced with the MCP OAuth server: **>= v1.674.0**, through current (1.703.1). Fixed in next release.

## Test plan
- [x] `cargo test --features quickjs,mcp -p windmill-api oauth_server::tests` — 2/2 pass
- [x] Backend compiles with `--features quickjs,mcp`; `npm run check:fast` clean for the changed page
- [x] Live: unauthenticated register with `javascript:`/`data:`/`file:`/relative → **400**; `https`/loopback `http`/`vscode://` → **201**; mixed list with one bad → **400**
- [ ] Manual: drive a pre-fix malicious client row through authorize → consent page shows "invalid or unsafe redirect_uri", no buttons, no auto-navigation
- [ ] `local-review`: Good to merge, 0 blocking issues

Advisory: GHSA-q9xg-f2v2-695g (do not attach PoC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates MCP OAuth dynamic client registration `redirect_uris` and blocks browser-executable schemes to prevent stored XSS. Adds a consent-page guard to stop navigation to unsafe URIs, including for previously registered clients.

- **Bug Fixes**
  - Backend: Reject non-absolute URIs and the `javascript`, `data`, `vbscript`, `blob`, and `file` schemes. Allow `https`, loopback `http`, and private app schemes (e.g., `vscode://`, `cursor://`). Registration fails if any URI is invalid.
  - Frontend: Consent page validates `redirect_uri` and disables approve/deny and navigation when unsafe.
  - Tests: Added unit tests for accepted and rejected URI cases.

<sup>Written for commit 01dac7fc39bde4cb6103fa40f733360b8e643168. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9197?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

