### PR TITLE
fix: validate workspace env var names to prevent worker JS injection

### DIFF
--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -33,7 +33,7 @@ use windmill_common::db::UserDB;
 use windmill_common::global_settings::HTTP_ROUTE_WORKSPACED_ROUTE;
 use windmill_common::users::username_to_permissioned_as;
 use windmill_common::variables::{
-    build_crypt, decrypt, encrypt, SECRET_SALT, WORKSPACE_CRYPT_CACHE,
+    build_crypt, decrypt, encrypt, is_valid_workspace_env_name, SECRET_SALT, WORKSPACE_CRYPT_CACHE,
 };
 use windmill_common::worker::{to_raw_value, CLOUD_HOSTED};
 use windmill_common::workspaces::GitRepositorySettings;
@@ -3298,6 +3298,15 @@ async fn set_environment_variable(
 
     match value {
         Some(value) => {
+            // The name is interpolated verbatim into generated worker code
+            // (e.g. the NativeTS/bunnative `const <name> = ...;` prologue), so
+            // it must be a strict identifier to prevent code injection.
+            if !is_valid_workspace_env_name(&name) {
+                return Err(Error::BadRequest(format!(
+                    "Invalid environment variable name {name:?}: must match ^[A-Za-z_][A-Za-z0-9_]*$ \
+                     (letters, digits and underscores, not starting with a digit)"
+                )));
+            }
             sqlx::query!(
                 "INSERT INTO workspace_env (workspace_id, name, value) VALUES ($1, $2, $3) ON CONFLICT (workspace_id, name) DO UPDATE SET value = EXCLUDED.value",
                 &w_id,

--- a/backend/windmill-common/src/variables.rs
+++ b/backend/windmill-common/src/variables.rs
@@ -229,6 +229,18 @@ lazy_static::lazy_static! {
     pub static ref CUSTOM_ENVS_CACHE: Cache<String, (i64, Vec<(String, String)>)> = Cache::new(100);
     pub static ref WORKSPACE_CRYPT_CACHE: Cache<String, (i64, MagicCrypt256)> = Cache::new(1000);
 
+    static ref VALID_WORKSPACE_ENV_NAME: regex::Regex =
+        regex::Regex::new(r"^[A-Za-z_][A-Za-z0-9_]*$").unwrap();
+}
+
+/// Workspace custom environment variable names are interpolated verbatim into
+/// generated worker code (e.g. the NativeTS/bunnative `const <name> = ...;`
+/// prologue). A name MUST therefore be restricted to a conventional identifier
+/// so an attacker-controlled name cannot break out of the declaration into
+/// arbitrary worker-process JavaScript. This subset is also a valid POSIX
+/// environment variable name.
+pub fn is_valid_workspace_env_name(name: &str) -> bool {
+    name.len() <= 255 && VALID_WORKSPACE_ENV_NAME.is_match(name)
 }
 
 pub async fn get_reserved_variables(
@@ -465,6 +477,23 @@ async fn get_cached_workspace_envs(conn: &Connection, w_id: &str) -> Vec<(String
                 .await
                 .unwrap_or_default(),
         };
+        // Defense-in-depth: never expose a custom env whose name is not a
+        // valid identifier. Names are interpolated verbatim into generated
+        // worker code; this neutralizes any malicious row that may already be
+        // persisted from before name validation was enforced at write time.
+        let custom_envs = custom_envs
+            .into_iter()
+            .filter(|(name, _)| {
+                let valid = is_valid_workspace_env_name(name);
+                if !valid {
+                    tracing::warn!(
+                        workspace_id = %w_id,
+                        "Ignoring workspace env variable with invalid name: {name:?}"
+                    );
+                }
+                valid
+            })
+            .collect::<Vec<(String, String)>>();
         CUSTOM_ENVS_CACHE.insert(
             w_id.to_string(),
             (chrono::Utc::now().timestamp(), custom_envs.clone()),
@@ -554,5 +583,44 @@ pub async fn get_variable_or_self_as<T: Authable + Sync>(
             "Variable not found when resolving `$var:{}`",
             var_path
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_valid_workspace_env_name;
+
+    #[test]
+    fn valid_env_names_are_accepted() {
+        for name in ["FOO", "foo_bar", "_private", "API_KEY_2", "a", "X1"] {
+            assert!(is_valid_workspace_env_name(name), "expected {name:?} valid");
+        }
+    }
+
+    #[test]
+    fn malicious_env_names_are_rejected() {
+        // Regression for GHSA-5f5q-2vg2-r2x4: a workspace env variable name is
+        // interpolated verbatim into the NativeTS/bunnative `const <name> = ...;`
+        // worker prologue. Any name that is not a strict identifier could break
+        // out of the declaration into attacker-controlled worker JavaScript.
+        for name in [
+            "INJ = (globalThis.x = 1); let _y", // breaks out of `const <name> ='...'`
+            "x'];globalThis.y=1;//",            // breaks out of `process.env['<name>']`
+            "1FOO",                             // starts with a digit
+            "FOO-BAR",                          // hyphen
+            "FOO BAR",                          // space
+            "FOO;BAR",
+            "FOO.BAR",
+            "$FOO",
+            "FOO\n BAR",
+            "",
+        ] {
+            assert!(
+                !is_valid_workspace_env_name(name),
+                "expected {name:?} to be rejected"
+            );
+        }
+        // Over-long names are rejected (DB column is varchar(255)).
+        assert!(!is_valid_workspace_env_name(&"A".repeat(256)));
     }
 }


### PR DESCRIPTION
## Summary

Security fix for private advisory **GHSA-5f5q-2vg2-r2x4**.

Workspace custom environment variable **names** were interpolated **raw** into generated NativeTS / bunnative worker JavaScript. The March-2025 Huntr fix escaped variable *values* but the *name* (`k`) is still placed unescaped both in JS-identifier position and inside a single-quoted string:

- `backend/windmill-worker/src/worker.rs:4725` — `const {k} = '{escaped}';\nprocess.env['{k}'] = '{escaped}';`
- `backend/windmill-worker/src/bun_executor.rs:3329` — `process.env['{k}'] = '{escaped}';`

The `require_admin` guard limits *who* can create the env var, not *what* the name contains — and workspace-admin is low-friction (self-service on Cloud, common within orgs), so it is **not** a meaningful barrier. Setting a name like `INJ = (expr); let _x` breaks out of the declaration into attacker-controlled JS that runs in the worker's V8 isolate, including inside NativeTS/bunnative jobs of other workspace members (stored, persistent, audit-evading — the malicious code lives in an env-var name, not any script body).

Scope note: custom envs are strictly `workspace_id`-scoped and each NativeTS job uses a fresh per-job V8 isolate exposing only `deno_fetch`/`deno_net`/`deno_web` ops — there is **no cross-workspace/cross-tenant/host reach** and no runtime capability a NativeTS script body doesn't already have. The downgrade from Critical rests on sandbox + per-job isolate + strict workspace scoping, **not** on the admin precondition. Re-rated **High (~7.1, `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N`)**, not Critical.

## Changes

- Add `is_valid_workspace_env_name` (`windmill-common/src/variables.rs`): enforces `^[A-Za-z_][A-Za-z0-9_]*$` and `len <= 255` (valid JS identifier ∧ POSIX env name).
- Enforce it at the API write boundary in `set_environment_variable` (`windmill-api-workspaces/src/workspaces.rs`) → `400 BadRequest` with a clear message.
- Defense-in-depth: filter out any invalid-named row at the single read chokepoint `get_cached_workspace_envs`, with a `tracing::warn!`. This neutralizes rows persisted before this fix (the value escaping + caching meant a stored bad name kept injecting).
- Regression unit tests covering both documented breakout payloads and edge cases.

## Test plan

- [x] `cargo test -p windmill-common --lib variables::tests` — 2/2 pass
- [x] Backend rebuilds cleanly (cargo watch) and is healthy
- [x] Live API: malicious name → `HTTP 400`; valid name → `HTTP 200` and persists
- [x] `/local-review` — Good to merge, no issues
- [ ] Manual: save env var name `x'];globalThis.y=1;//` in workspace settings UI → expect 400; insert a bad row via psql then run a NativeTS job → expect warn log + script runs without injected code

Relates to advisory GHSA-5f5q-2vg2-r2x4 (PoC withheld).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates workspace env var names to stop JS injection in generated worker code for NativeTS/bunnative. Blocks bad names on write and ignores any pre-existing invalid names at read time. Relates to GHSA-5f5q-2vg2-r2x4.

- Bug Fixes
  - Added `is_valid_workspace_env_name` enforcing `^[A-Za-z_][A-Za-z0-9_]*$` and max length 255.
  - Validates names in the API (`set_environment_variable`); returns HTTP 400 with a clear message.
  - Filters invalid names in `get_cached_workspace_envs` and logs a warning (defense-in-depth).
  - Added regression tests for injection payloads and edge cases.

<sup>Written for commit bf93657fee3867085eebc9197d48cc3e19ed8e7f. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9199?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


