### PR TITLE
ci: disable PDB generation in Windows backend tests

### DIFF
--- a/.github/workflows/backend-test-windows.yml
+++ b/.github/workflows/backend-test-windows.yml
@@ -145,6 +145,14 @@ jobs:
           RUST_LOG_STYLE: never
           CARGO_NET_GIT_FETCH_WITH_CLI: true
           CARGO_BUILD_JOBS: 12
+          # backend/Cargo.toml sets split-debuginfo = "unpacked", which on
+          # windows-msvc is coerced to "packed": every test-binary link spawns
+          # the mspdbsrv.exe PDB type server and writes a large .pdb. With 12
+          # parallel link jobs this races the type-server cap (LNK1318 "LIMIT
+          # (12)") and exhausts the runner disk (LNK1180). CI needs no debug
+          # info, so disable PDB generation for the dev/test profiles here.
+          CARGO_PROFILE_DEV_SPLIT_DEBUGINFO: "off"
+          CARGO_PROFILE_TEST_SPLIT_DEBUGINFO: "off"
           # Tests' poll-time stack frames (deep nested async fn chains in
           # debug builds) reach ~1.8MB. 4MB gives ~2x headroom against flaky
           # overflows under parallel-test contention.


### PR DESCRIPTION
## Summary

The `Backend integration tests (Windows)` job has been recurringly failing on release tag pushes (`v1.703.1`, `v1.703.2`) at the linking stage — not a code or test regression.

Root cause: `backend/Cargo.toml` sets `split-debuginfo = "unpacked"` for `[profile.dev]`. On `windows-msvc` this is coerced to `"packed"`, so every test-binary link spawns the shared `mspdbsrv.exe` PDB type server and writes a large `.pdb`. With `CARGO_BUILD_JOBS: 12`, the 12 concurrent links race the type-server concurrency cap (`LNK1318 ... LIMIT (12)`) and the accumulated PDBs exhaust the runner disk (`LNK1180: insufficient disk space`).

CI does not need debug info, so this disables PDB generation for the dev/test profiles in the Windows job only — scoped via env, no impact on `Cargo.toml`, local dev, or other platforms/jobs.

## Changes

- Add `CARGO_PROFILE_DEV_SPLIT_DEBUGINFO: "off"` and `CARGO_PROFILE_TEST_SPLIT_DEBUGINFO: "off"` to the `cargo test` step env in `.github/workflows/backend-test-windows.yml`, with a comment explaining the LNK1318/LNK1180 root cause.

## Test plan

- [ ] `Backend integration tests (Windows)` workflow runs green on this branch (manual `workflow_dispatch` or next `v*` tag): `cargo test` step links all test binaries without LNK1318/LNK1180 and finishes within the 60-minute timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable PDB generation in the Windows backend test job to stop recurring link failures and disk exhaustion. Scoped to CI for Windows tests only; no changes to `Cargo.toml` or other jobs.

- **Bug Fixes**
  - Set `CARGO_PROFILE_DEV_SPLIT_DEBUGINFO=off` and `CARGO_PROFILE_TEST_SPLIT_DEBUGINFO=off` in `.github/workflows/backend-test-windows.yml`.
  - Prevents `mspdbsrv.exe` contention (LNK1318) and disk errors (LNK1180) from 12 parallel links on `windows-msvc`.
  - No impact on local development or non-Windows platforms.

<sup>Written for commit 63986d0636b469fa23329b3e76c6b186e1a60b86. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9201?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

