### PR TITLE
fix: resolve absolute-path imports in monaco ts editor

### DIFF
--- a/frontend/src/lib/ata/index.ts
+++ b/frontend/src/lib/ata/index.ts
@@ -136,7 +136,7 @@ export const setupTypeAcquisition = (config: ATABootstrapConfig) => {
 					: '/' + config.scriptPath + (f.raw.startsWith('../') ? '/../' : '/.') + f.raw
 				let url = config.root + path
 				let localPath = f.raw
-				if (f.raw.startsWith('.') && !f.raw.endsWith('.ts')) {
+				if ((f.raw.startsWith('.') || f.raw.startsWith('/')) && !f.raw.endsWith('.ts')) {
 					url += '.ts'
 					localPath += '.ts'
 				}

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -1658,13 +1658,18 @@
 				}
 			}
 
+			const absolutePathExtraLibs = new Map<string, { dispose: () => void }>()
 			const addLocalFile = async (code: string, _path: string) => {
 				let p = new URL(_path, uri).href
-				// if (_path?.startsWith('/')) {
-				// 	p = 'file://' + p
-				// }
 				let nuri = mUri.parse(p)
 				console.log('adding local file', _path, nuri.toString())
+				// Monaco's TS service resolves relative imports against the importer's URI (finding the
+				// model), but absolute paths like "/u/admin/foo" are looked up as raw paths and miss the
+				// `file://` model. Register them as extra libs so TS can resolve them.
+				if (_path.startsWith('/')) {
+					absolutePathExtraLibs.get(_path)?.dispose()
+					absolutePathExtraLibs.set(_path, typescriptDefaults.addExtraLib(code, _path))
+				}
 				if (editor) {
 					let localModel = meditor.getModel(nuri)
 					if (localModel) {

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -1662,6 +1662,7 @@
 			}
 
 			const addLocalFile = async (code: string, _path: string) => {
+				if (destroyed) return
 				let p = new URL(_path, uri).href
 				let nuri = mUri.parse(p)
 				console.log('adding local file', _path, nuri.toString())

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -204,6 +204,7 @@
 	let lastWsAttempt: Date = new Date()
 	let nbWsAttempt = 0
 	let disposeMethod: (() => void) | undefined
+	const absolutePathExtraLibs = new Map<string, { dispose: () => void }>()
 	const dispatch = createEventDispatcher()
 	// let graphqlService: MonacoGraphQLAPI | undefined = undefined
 
@@ -1644,6 +1645,8 @@
 			(scriptLang == 'bun' || scriptLang == 'tsx' || scriptLang == 'bunnative') &&
 			ata == undefined
 		) {
+			absolutePathExtraLibs.forEach((d) => d.dispose())
+			absolutePathExtraLibs.clear()
 			const hostname = getHostname()
 
 			const addLibraryToRuntime = async (code: string, _path: string) => {
@@ -1658,7 +1661,6 @@
 				}
 			}
 
-			const absolutePathExtraLibs = new Map<string, { dispose: () => void }>()
 			const addLocalFile = async (code: string, _path: string) => {
 				let p = new URL(_path, uri).href
 				let nuri = mUri.parse(p)
@@ -1788,6 +1790,8 @@
 		timeoutModel && clearTimeout(timeoutModel)
 		loadTimeout && clearTimeout(loadTimeout)
 		aiChatEditorHandler?.clear()
+		absolutePathExtraLibs.forEach((d) => d.dispose())
+		absolutePathExtraLibs.clear()
 	})
 
 	async function genRoot(hostname: string) {


### PR DESCRIPTION
## Summary

Fixes Monaco editor showing "Cannot find module '/u/admin/foo'" errors on Windmill absolute-path imports in Bun TypeScript scripts. The imports work at runtime (the Bun loader auto-appends `.ts`) — this was a UI-only issue caused by ATA skipping absolute paths and Monaco's TS service not resolving absolute paths against `file://` model URIs.

## Changes

- `frontend/src/lib/ata/index.ts`: extend the `.ts`-extension auto-append in the local-deps fetch path to cover absolute imports (`/foo`), not just relative ones (`./foo`). Without this, the backend `tokened_raw` endpoint 400s the fetch because it requires a `.ts` suffix.
- `frontend/src/lib/components/Editor.svelte`: when ATA hands back content for an absolute-path import, also register it via `typescriptDefaults.addExtraLib(code, _path)`. Monaco's TS service resolves relative imports against the importer's URI (finding the `file:///…` model) but treats absolute paths as raw filesystem paths and misses the model. Registering as an extra lib keyed by the raw path bridges that gap.
- Track these extra libs in a component-scoped `Map<path, IDisposable>` so re-fetches dispose the old entry, and so script/path switches and editor teardown clean up the global TS-service registry.

## Test plan

- [ ] Open a Bun TypeScript script with `import x from '/u/admin/to_import'` and verify Monaco no longer flags "Cannot find module"
- [ ] Verify hover and go-to-definition still work on the imported symbol
- [ ] Edit the importer to use a different absolute import (e.g. `/u/admin/other`) and confirm the old import's types do not leak
- [ ] Switch between two scripts that import different absolute paths and confirm completions/types track the currently-open script
- [ ] Existing relative imports (`./foo`, `../bar`) continue to resolve as before

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Monaco TypeScript editor so absolute-path imports like "/u/admin/foo" resolve in Bun scripts. Removes false "Cannot find module" errors and keeps hovers and go-to-definition working.

- **Bug Fixes**
  - Extend ATA to append ".ts" for absolute imports (`/foo`) so local fetches succeed.
  - Register absolute-path files via `typescriptDefaults.addExtraLib(code, path)`; dispose on reset/switch/teardown and skip late ATA local-file callbacks after teardown.

<sup>Written for commit c52a9c296b2bf43c6361a1142b19c7cfebf046bc. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9213?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

