### PR TITLE
chore: watch WIN and GIT teams in webmux linear integration

### DIFF
--- a/.webmux.yaml
+++ b/.webmux.yaml
@@ -106,3 +106,4 @@ integrations:
         dir: ../windmill-ee-private__worktrees
   linear:
     enabled: true
+    watchTeams: [WIN,GIT]


### PR DESCRIPTION
## Summary
Adds the `WIN` and `GIT` Linear teams to the `watchTeams` list in webmux's Linear integration so issues from both teams are surfaced.

## Changes
- `.webmux.yaml`: set `integrations.linear.watchTeams: [WIN, GIT]`

## Test plan
- [ ] Reload webmux and confirm issues from both `WIN` and `GIT` Linear teams appear in the integration view

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `.webmux.yaml` to watch Linear teams `WIN` and `GIT` so their issues show in the integration view. Sets `integrations.linear.watchTeams` to `[WIN, GIT]`.

<sup>Written for commit a318027f8722ad14b29dd0dd834fcf89de62e813. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9215?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

