### PR TITLE
feat: add global ask user question tool

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -19,8 +19,7 @@ import {
 	type DisplayMessage,
 	type Tool,
 	type ToolCallbacks,
-	type ToolDisplayMessage,
-	type UserQuestionChoice
+	type ToolDisplayMessage
 } from './shared'
 import type {
 	ChatCompletionMessageParam,
@@ -143,10 +142,7 @@ class AIChatManager {
 	cachedDatatables = $state<AppDatatableElement[]>([])
 
 	private confirmationCallback = $state<((value: boolean) => void) | undefined>(undefined)
-	private userQuestionCallbacks = new Map<
-		string,
-		(choice: UserQuestionChoice | undefined) => void
-	>()
+	private userQuestionCallbacks = new Map<string, (choice: string | undefined) => void>()
 	private appDatatablesRefreshTimeout: ReturnType<typeof setTimeout> | undefined = undefined
 
 	allowedModes: Record<AIMode, boolean> = $derived({
@@ -235,14 +231,14 @@ class AIChatManager {
 
 	requestUserQuestion = (
 		toolId: string,
-		_question: { question: string; choices: UserQuestionChoice[] }
-	): Promise<UserQuestionChoice | undefined> => {
+		_question: { question: string; choices: string[] }
+	): Promise<string | undefined> => {
 		return new Promise((resolve) => {
 			this.userQuestionCallbacks.set(toolId, resolve)
 		})
 	}
 
-	handleUserQuestionAnswer = (toolId: string, choice: UserQuestionChoice) => {
+	handleUserQuestionAnswer = (toolId: string, choice: string) => {
 		const callback = this.userQuestionCallbacks.get(toolId)
 		if (!callback) {
 			return
@@ -252,11 +248,11 @@ class AIChatManager {
 			if (message.role === 'tool' && message.tool_call_id === toolId && message.userQuestion) {
 				return {
 					...message,
-					content: 'User answered question',
+					content: `User answered question: ${choice}`,
 					isLoading: false,
 					userQuestion: {
 						...message.userQuestion,
-						selectedChoiceId: choice.id
+						selectedChoice: choice
 					}
 				}
 			}

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -19,7 +19,8 @@ import {
 	type DisplayMessage,
 	type Tool,
 	type ToolCallbacks,
-	type ToolDisplayMessage
+	type ToolDisplayMessage,
+	type UserQuestionChoice
 } from './shared'
 import type {
 	ChatCompletionMessageParam,
@@ -142,6 +143,10 @@ class AIChatManager {
 	cachedDatatables = $state<AppDatatableElement[]>([])
 
 	private confirmationCallback = $state<((value: boolean) => void) | undefined>(undefined)
+	private userQuestionCallbacks = new Map<
+		string,
+		(choice: UserQuestionChoice | undefined) => void
+	>()
 	private appDatatablesRefreshTimeout: ReturnType<typeof setTimeout> | undefined = undefined
 
 	allowedModes: Record<AIMode, boolean> = $derived({
@@ -226,6 +231,40 @@ class AIChatManager {
 			this.confirmationCallback(confirmed)
 			this.confirmationCallback = undefined
 		}
+	}
+
+	requestUserQuestion = (
+		toolId: string,
+		_question: { question: string; choices: UserQuestionChoice[] }
+	): Promise<UserQuestionChoice | undefined> => {
+		return new Promise((resolve) => {
+			this.userQuestionCallbacks.set(toolId, resolve)
+		})
+	}
+
+	handleUserQuestionAnswer = (toolId: string, choice: UserQuestionChoice) => {
+		const callback = this.userQuestionCallbacks.get(toolId)
+		if (!callback) {
+			return
+		}
+
+		this.displayMessages = this.displayMessages.map((message) => {
+			if (message.role === 'tool' && message.tool_call_id === toolId && message.userQuestion) {
+				return {
+					...message,
+					content: 'User answered question',
+					isLoading: false,
+					userQuestion: {
+						...message.userQuestion,
+						selectedChoiceId: choice.id
+					}
+				}
+			}
+			return message
+		})
+
+		callback(choice)
+		this.userQuestionCallbacks.delete(toolId)
 	}
 
 	setAiChatInput(aiChatInput: AIChatInput | null) {
@@ -838,7 +877,8 @@ class AIChatManager {
 							this.displayMessages = [...this.displayMessages]
 						}
 					},
-					requestConfirmation: this.requestConfirmation
+					requestConfirmation: this.requestConfirmation,
+					requestUserQuestion: this.requestUserQuestion
 				}
 			}
 
@@ -869,6 +909,10 @@ class AIChatManager {
 			this.confirmationCallback(false)
 			this.confirmationCallback = undefined
 		}
+		for (const resolveQuestion of this.userQuestionCallbacks.values()) {
+			resolveQuestion(undefined)
+		}
+		this.userQuestionCallbacks.clear()
 		const cancelReason = reason ?? 'user_cancelled'
 		console.log('cancelling request:', {
 			reason: cancelReason,
@@ -1207,7 +1251,10 @@ class AIChatManager {
 					...message,
 					isLoading: false,
 					content: messageText,
-					error: messageText
+					error: messageText,
+					userQuestion: message.userQuestion
+						? { ...message.userQuestion, canceled: true }
+						: undefined
 				}
 			}
 			return message

--- a/frontend/src/lib/components/copilot/chat/AskUserQuestionDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AskUserQuestionDisplay.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	import { CheckCircle2, CircleHelp, Loader2, XCircle } from 'lucide-svelte'
+	import Button from '$lib/components/common/button/Button.svelte'
+	import { aiChatManager } from './AIChatManager.svelte'
+	import type { UserQuestionChoice, UserQuestionDisplay } from './shared'
+
+	interface Props {
+		toolCallId: string
+		userQuestion: UserQuestionDisplay
+		disabled?: boolean
+	}
+
+	let { toolCallId, userQuestion, disabled = false }: Props = $props()
+
+	const selectedChoice = $derived(
+		userQuestion.selectedChoiceId
+			? userQuestion.choices.find((choice) => choice.id === userQuestion.selectedChoiceId)
+			: undefined
+	)
+	const isComplete = $derived(Boolean(selectedChoice) || Boolean(userQuestion.canceled))
+	const optionsDisabled = $derived(disabled || isComplete)
+
+	function selectChoice(choice: UserQuestionChoice) {
+		if (optionsDisabled) {
+			return
+		}
+		aiChatManager.handleUserQuestionAnswer(toolCallId, choice)
+	}
+</script>
+
+<div class="rounded-md border border-gray-200 bg-surface p-3 text-sm dark:border-gray-700">
+	<div class="flex items-start gap-2">
+		{#if userQuestion.canceled}
+			<XCircle class="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+		{:else if selectedChoice}
+			<CheckCircle2 class="mt-0.5 h-4 w-4 shrink-0 text-green-500" />
+		{:else}
+			<CircleHelp class="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
+		{/if}
+		<p class="min-w-0 flex-1 whitespace-pre-wrap font-medium text-primary"
+			>{userQuestion.question}</p
+		>
+	</div>
+
+	<div class="mt-3 flex flex-col gap-2">
+		{#each userQuestion.choices as choice (choice.id)}
+			{@const isSelected = selectedChoice?.id === choice.id}
+			<Button
+				variant="default"
+				unifiedSize="sm"
+				selected={isSelected}
+				disabled={optionsDisabled}
+				onClick={() => selectChoice(choice)}
+				startIcon={isSelected ? { icon: CheckCircle2 } : undefined}
+				btnClasses="!h-auto min-h-[40px] !items-start !justify-start !px-3 !py-2 !text-left !whitespace-normal"
+			>
+				<span class="flex min-w-0 flex-col items-start gap-0.5">
+					<span class="max-w-full break-words font-medium">{choice.label}</span>
+					{#if choice.description}
+						<span class="max-w-full break-words text-xs text-secondary">{choice.description}</span>
+					{/if}
+				</span>
+			</Button>
+		{/each}
+	</div>
+
+	{#if userQuestion.canceled}
+		<div class="mt-2 text-xs text-secondary">Canceled</div>
+	{:else if disabled}
+		<div class="mt-2 flex items-center gap-1.5 text-xs text-secondary">
+			<Loader2 class="h-3 w-3 animate-spin" />
+			Waiting for selection
+		</div>
+	{/if}
+</div>

--- a/frontend/src/lib/components/copilot/chat/AskUserQuestionDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AskUserQuestionDisplay.svelte
@@ -3,7 +3,7 @@
 	import { CheckCircle2, CircleHelp, Loader2, XCircle } from 'lucide-svelte'
 	import Button from '$lib/components/common/button/Button.svelte'
 	import { aiChatManager } from './AIChatManager.svelte'
-	import type { UserQuestionChoice, UserQuestionDisplay } from './shared'
+	import type { UserQuestionDisplay } from './shared'
 
 	interface Props {
 		toolCallId: string
@@ -15,11 +15,7 @@
 
 	let choiceButtons = $state<(HTMLButtonElement | undefined)[]>([])
 
-	const selectedChoice = $derived(
-		userQuestion.selectedChoiceId
-			? userQuestion.choices.find((choice) => choice.id === userQuestion.selectedChoiceId)
-			: undefined
-	)
+	const selectedChoice = $derived(userQuestion.selectedChoice)
 	const isComplete = $derived(Boolean(selectedChoice) || Boolean(userQuestion.canceled))
 	const optionsDisabled = $derived(disabled || isComplete)
 
@@ -37,14 +33,14 @@
 		choiceButtons[index]?.focus()
 	}
 
-	function selectChoice(choice: UserQuestionChoice) {
+	function selectChoice(choice: string) {
 		if (optionsDisabled) {
 			return
 		}
 		aiChatManager.handleUserQuestionAnswer(toolCallId, choice)
 	}
 
-	function handleChoiceKeydown(event: KeyboardEvent, choice: UserQuestionChoice, index: number) {
+	function handleChoiceKeydown(event: KeyboardEvent, choice: string, index: number) {
 		if (optionsDisabled) {
 			return
 		}
@@ -80,14 +76,14 @@
 		{:else}
 			<CircleHelp class="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
 		{/if}
-		<p class="min-w-0 flex-1 whitespace-pre-wrap font-medium text-primary"
+		<p class="min-w-0 flex-1 whitespace-pre-wrap text-xs font-medium text-primary"
 			>{userQuestion.question}</p
 		>
 	</div>
 
 	<div class="mt-3 flex flex-col gap-2">
-		{#each userQuestion.choices as choice, index (choice.id)}
-			{@const isSelected = selectedChoice?.id === choice.id}
+		{#each userQuestion.choices as choice, index (index)}
+			{@const isSelected = selectedChoice === choice}
 			<Button
 				variant="default"
 				unifiedSize="sm"
@@ -100,10 +96,7 @@
 				btnClasses="!h-auto min-h-[40px] !items-start !justify-start !px-3 !py-2 !text-left !whitespace-normal"
 			>
 				<span class="flex min-w-0 flex-col items-start gap-0.5">
-					<span class="max-w-full break-words font-medium">{choice.label}</span>
-					{#if choice.description}
-						<span class="max-w-full break-words text-xs text-secondary">{choice.description}</span>
-					{/if}
+					<span class="max-w-full break-words text-2xs font-medium">{choice}</span>
 				</span>
 			</Button>
 		{/each}

--- a/frontend/src/lib/components/copilot/chat/AskUserQuestionDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AskUserQuestionDisplay.svelte
@@ -67,7 +67,10 @@
 	}
 </script>
 
-<div class="rounded-md border border-gray-200 bg-surface p-3 text-sm dark:border-gray-700">
+<div
+	class="rounded-md border border-gray-200 bg-surface p-3 text-sm dark:border-gray-700"
+	data-chat-keyboard-scope="ask-user-question"
+>
 	<div class="flex items-start gap-2">
 		{#if userQuestion.canceled}
 			<XCircle class="mt-0.5 h-4 w-4 shrink-0 text-red-500" />

--- a/frontend/src/lib/components/copilot/chat/AskUserQuestionDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AskUserQuestionDisplay.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount, tick } from 'svelte'
-	import { CheckCircle2, CircleHelp, Loader2, XCircle } from 'lucide-svelte'
+	import { CircleHelp } from 'lucide-svelte'
 	import Button from '$lib/components/common/button/Button.svelte'
 	import { aiChatManager } from './AIChatManager.svelte'
 	import type { UserQuestionDisplay } from './shared'
@@ -8,19 +8,14 @@
 	interface Props {
 		toolCallId: string
 		userQuestion: UserQuestionDisplay
-		disabled?: boolean
 	}
 
-	let { toolCallId, userQuestion, disabled = false }: Props = $props()
+	let { toolCallId, userQuestion }: Props = $props()
 
 	let choiceButtons = $state<(HTMLButtonElement | undefined)[]>([])
 
-	const selectedChoice = $derived(userQuestion.selectedChoice)
-	const isComplete = $derived(Boolean(selectedChoice) || Boolean(userQuestion.canceled))
-	const optionsDisabled = $derived(disabled || isComplete)
-
 	onMount(() => {
-		if (optionsDisabled || userQuestion.choices.length === 0) {
+		if (userQuestion.choices.length === 0) {
 			return
 		}
 
@@ -34,17 +29,10 @@
 	}
 
 	function selectChoice(choice: string) {
-		if (optionsDisabled) {
-			return
-		}
 		aiChatManager.handleUserQuestionAnswer(toolCallId, choice)
 	}
 
 	function handleChoiceKeydown(event: KeyboardEvent, choice: string, index: number) {
-		if (optionsDisabled) {
-			return
-		}
-
 		if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
 			event.preventDefault()
 			event.stopPropagation()
@@ -72,13 +60,7 @@
 	data-chat-keyboard-scope="ask-user-question"
 >
 	<div class="flex items-start gap-2">
-		{#if userQuestion.canceled}
-			<XCircle class="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
-		{:else if selectedChoice}
-			<CheckCircle2 class="mt-0.5 h-4 w-4 shrink-0 text-green-500" />
-		{:else}
-			<CircleHelp class="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
-		{/if}
+		<CircleHelp class="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
 		<p class="min-w-0 flex-1 whitespace-pre-wrap text-xs font-medium text-primary"
 			>{userQuestion.question}</p
 		>
@@ -86,16 +68,12 @@
 
 	<div class="mt-3 flex flex-col gap-2">
 		{#each userQuestion.choices as choice, index (index)}
-			{@const isSelected = selectedChoice === choice}
 			<Button
 				variant="default"
 				unifiedSize="sm"
 				bind:element={choiceButtons[index]}
-				selected={isSelected}
-				disabled={optionsDisabled}
 				onClick={() => selectChoice(choice)}
 				onkeydown={(event) => handleChoiceKeydown(event, choice, index)}
-				startIcon={isSelected ? { icon: CheckCircle2 } : undefined}
 				btnClasses="!h-auto min-h-[40px] !items-start !justify-start !px-3 !py-2 !text-left !whitespace-normal"
 			>
 				<span class="flex min-w-0 flex-col items-start gap-0.5">
@@ -104,13 +82,4 @@
 			</Button>
 		{/each}
 	</div>
-
-	{#if userQuestion.canceled}
-		<div class="mt-2 text-xs text-secondary">Canceled</div>
-	{:else if disabled}
-		<div class="mt-2 flex items-center gap-1.5 text-xs text-secondary">
-			<Loader2 class="h-3 w-3 animate-spin" />
-			Waiting for selection
-		</div>
-	{/if}
 </div>

--- a/frontend/src/lib/components/copilot/chat/AskUserQuestionDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AskUserQuestionDisplay.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount, tick } from 'svelte'
 	import { CheckCircle2, CircleHelp, Loader2, XCircle } from 'lucide-svelte'
 	import Button from '$lib/components/common/button/Button.svelte'
 	import { aiChatManager } from './AIChatManager.svelte'
@@ -12,6 +13,8 @@
 
 	let { toolCallId, userQuestion, disabled = false }: Props = $props()
 
+	let choiceButtons = $state<(HTMLButtonElement | undefined)[]>([])
+
 	const selectedChoice = $derived(
 		userQuestion.selectedChoiceId
 			? userQuestion.choices.find((choice) => choice.id === userQuestion.selectedChoiceId)
@@ -20,11 +23,51 @@
 	const isComplete = $derived(Boolean(selectedChoice) || Boolean(userQuestion.canceled))
 	const optionsDisabled = $derived(disabled || isComplete)
 
+	onMount(() => {
+		if (optionsDisabled || userQuestion.choices.length === 0) {
+			return
+		}
+
+		void tick().then(() => {
+			focusChoice(0)
+		})
+	})
+
+	function focusChoice(index: number) {
+		choiceButtons[index]?.focus()
+	}
+
 	function selectChoice(choice: UserQuestionChoice) {
 		if (optionsDisabled) {
 			return
 		}
 		aiChatManager.handleUserQuestionAnswer(toolCallId, choice)
+	}
+
+	function handleChoiceKeydown(event: KeyboardEvent, choice: UserQuestionChoice, index: number) {
+		if (optionsDisabled) {
+			return
+		}
+
+		if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+			event.preventDefault()
+			event.stopPropagation()
+			focusChoice((index + 1) % userQuestion.choices.length)
+			return
+		}
+
+		if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+			event.preventDefault()
+			event.stopPropagation()
+			focusChoice((index - 1 + userQuestion.choices.length) % userQuestion.choices.length)
+			return
+		}
+
+		if (event.key === 'Enter') {
+			event.preventDefault()
+			event.stopPropagation()
+			selectChoice(choice)
+		}
 	}
 </script>
 
@@ -43,14 +86,16 @@
 	</div>
 
 	<div class="mt-3 flex flex-col gap-2">
-		{#each userQuestion.choices as choice (choice.id)}
+		{#each userQuestion.choices as choice, index (choice.id)}
 			{@const isSelected = selectedChoice?.id === choice.id}
 			<Button
 				variant="default"
 				unifiedSize="sm"
+				bind:element={choiceButtons[index]}
 				selected={isSelected}
 				disabled={optionsDisabled}
 				onClick={() => selectChoice(choice)}
+				onkeydown={(event) => handleChoiceKeydown(event, choice, index)}
 				startIcon={isSelected ? { icon: CheckCircle2 } : undefined}
 				btnClasses="!h-auto min-h-[40px] !items-start !justify-start !px-3 !py-2 !text-left !whitespace-normal"
 			>

--- a/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
@@ -31,18 +31,18 @@
 	)
 
 	const activeUserQuestion = $derived(
-		message.userQuestion && !message.userQuestion.selectedChoice && !message.userQuestion.canceled
+		message.userQuestion &&
+			message.isLoading &&
+			!message.error &&
+			!message.userQuestion.selectedChoice &&
+			!message.userQuestion.canceled
 			? message.userQuestion
 			: undefined
 	)
 </script>
 
 {#if activeUserQuestion}
-	<AskUserQuestionDisplay
-		toolCallId={message.tool_call_id}
-		userQuestion={activeUserQuestion}
-		disabled={!message.isLoading || Boolean(message.error)}
-	/>
+	<AskUserQuestionDisplay toolCallId={message.tool_call_id} userQuestion={activeUserQuestion} />
 {:else}
 	<div
 		class="bg-surface border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden font-mono text-xs"

--- a/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
@@ -31,7 +31,7 @@
 	)
 
 	const activeUserQuestion = $derived(
-		message.userQuestion && !message.userQuestion.selectedChoiceId && !message.userQuestion.canceled
+		message.userQuestion && !message.userQuestion.selectedChoice && !message.userQuestion.canceled
 			? message.userQuestion
 			: undefined
 	)

--- a/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
@@ -6,6 +6,7 @@
 	import { twMerge } from 'tailwind-merge'
 	import ToolContentDisplay from './ToolContentDisplay.svelte'
 	import ToolMessageActions from './ToolMessageActions.svelte'
+	import AskUserQuestionDisplay from './AskUserQuestionDisplay.svelte'
 
 	interface Props {
 		message: ToolDisplayMessage
@@ -28,111 +29,125 @@
 			? message.actions
 			: []
 	)
+
+	const activeUserQuestion = $derived(
+		message.userQuestion && !message.userQuestion.selectedChoiceId && !message.userQuestion.canceled
+			? message.userQuestion
+			: undefined
+	)
 </script>
 
-<div
-	class="bg-surface border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden font-mono text-xs"
->
-	<!-- Collapsible Header -->
-	<button
-		class={twMerge(
-			'w-full p-2 bg-surface-secondary hover:bg-surface-hover transition-colors flex items-center justify-between text-left border-b border-gray-200 dark:border-gray-700',
-			message.needsConfirmation ? 'opacity-80' : ''
-		)}
-		onclick={() => (isExpanded = !isExpanded)}
-		disabled={!message.showDetails && !message.isStreamingArguments}
+{#if activeUserQuestion}
+	<AskUserQuestionDisplay
+		toolCallId={message.tool_call_id}
+		userQuestion={activeUserQuestion}
+		disabled={!message.isLoading || Boolean(message.error)}
+	/>
+{:else}
+	<div
+		class="bg-surface border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden font-mono text-xs"
 	>
-		<div class="flex items-center gap-2 flex-1">
-			{#if message.showDetails || message.isStreamingArguments}
-				{#if isExpanded}
-					<ChevronDown class="w-3 h-3 text-secondary" />
-				{:else}
-					<ChevronRight class="w-3 h-3 text-secondary" />
+		<!-- Collapsible Header -->
+		<button
+			class={twMerge(
+				'w-full p-2 bg-surface-secondary hover:bg-surface-hover transition-colors flex items-center justify-between text-left border-b border-gray-200 dark:border-gray-700',
+				message.needsConfirmation ? 'opacity-80' : ''
+			)}
+			onclick={() => (isExpanded = !isExpanded)}
+			disabled={!message.showDetails && !message.isStreamingArguments}
+		>
+			<div class="flex items-center gap-2 flex-1">
+				{#if message.showDetails || message.isStreamingArguments}
+					{#if isExpanded}
+						<ChevronDown class="w-3 h-3 text-secondary" />
+					{:else}
+						<ChevronRight class="w-3 h-3 text-secondary" />
+					{/if}
 				{/if}
-			{/if}
 
-			{#if message.isLoading && !message.needsConfirmation}
-				<Loader2 class="w-3.5 h-3.5 animate-spin text-blue-500" />
-			{:else if message.error}
-				<span class="text-red-500">✗</span>
-			{:else if !message.isLoading && !message.error}
-				<span class="text-green-500">✓</span>
-			{/if}
-			<span class="text-primary font-medium text-2xs">
-				{message.content}
-			</span>
-		</div>
-	</button>
+				{#if message.isLoading && !message.needsConfirmation}
+					<Loader2 class="w-3.5 h-3.5 animate-spin text-blue-500" />
+				{:else if message.error}
+					<span class="text-red-500">✗</span>
+				{:else if !message.isLoading && !message.error}
+					<span class="text-green-500">✓</span>
+				{/if}
+				<span class="text-primary font-medium text-2xs">
+					{message.content}
+				</span>
+			</div>
+		</button>
 
-	<!-- Expanded Content -->
-	{#if isExpanded}
-		<div class="p-2 bg-surface space-y-3">
-			<!-- Parameters Section - show if we have parameters, or if confirmation is needed (even with empty params) -->
-			{#if hasParameters || message.needsConfirmation}
-				<div class={message.needsConfirmation ? 'opacity-80' : ''}>
-					<ToolContentDisplay
-						title="Parameters"
-						content={message.parameters}
-						streaming={message.isStreamingArguments}
-						toolName={message.toolName}
-						showFade={message.showFade}
-					/>
-				</div>
-			{/if}
+		<!-- Expanded Content -->
+		{#if isExpanded}
+			<div class="p-2 bg-surface space-y-3">
+				<!-- Parameters Section - show if we have parameters, or if confirmation is needed (even with empty params) -->
+				{#if hasParameters || message.needsConfirmation}
+					<div class={message.needsConfirmation ? 'opacity-80' : ''}>
+						<ToolContentDisplay
+							title="Parameters"
+							content={message.parameters}
+							streaming={message.isStreamingArguments}
+							toolName={message.toolName}
+							showFade={message.showFade}
+						/>
+					</div>
+				{/if}
 
-			<!-- Confirmation Footer -->
-			{#if message.needsConfirmation}
-				<div
-					class={twMerge(
-						'mt-3 pt-3 flex flex-row items-center justify-end gap-2',
-						hasParameters ? 'border-t border-gray-200 dark:border-gray-700' : ''
-					)}
-				>
-					<Button
-						variant="default"
-						size="xs"
-						on:click={() => {
-							if (message.tool_call_id) {
-								aiChatManager.handleToolConfirmation(message.tool_call_id, false)
-							}
-						}}
-						startIcon={{ icon: XCircle }}
-						destructive
-					></Button>
-					<Button
-						variant="accent"
-						size="xs"
-						on:click={() => {
-							if (message.tool_call_id) {
-								aiChatManager.handleToolConfirmation(message.tool_call_id, true)
-							}
-						}}
-						startIcon={{ icon: Play }}
+				<!-- Confirmation Footer -->
+				{#if message.needsConfirmation}
+					<div
+						class={twMerge(
+							'mt-3 pt-3 flex flex-row items-center justify-end gap-2',
+							hasParameters ? 'border-t border-gray-200 dark:border-gray-700' : ''
+						)}
 					>
-						Run
-					</Button>
-				</div>
+						<Button
+							variant="default"
+							size="xs"
+							on:click={() => {
+								if (message.tool_call_id) {
+									aiChatManager.handleToolConfirmation(message.tool_call_id, false)
+								}
+							}}
+							startIcon={{ icon: XCircle }}
+							destructive
+						></Button>
+						<Button
+							variant="accent"
+							size="xs"
+							on:click={() => {
+								if (message.tool_call_id) {
+									aiChatManager.handleToolConfirmation(message.tool_call_id, true)
+								}
+							}}
+							startIcon={{ icon: Play }}
+						>
+							Run
+						</Button>
+					</div>
 
-				<!-- Logs and Result - hide while streaming -->
-			{:else if !message.isStreamingArguments}
-				<ToolContentDisplay
-					title="Logs"
-					content={message.logs}
-					loading={message.isLoading}
-					showWhileLoading={false}
-				/>
-
-				{#if visibleActions.length > 0}
-					<ToolMessageActions actions={visibleActions} />
-				{:else}
+					<!-- Logs and Result - hide while streaming -->
+				{:else if !message.isStreamingArguments}
 					<ToolContentDisplay
-						title="Result"
-						content={message.result}
-						error={message.error}
+						title="Logs"
+						content={message.logs}
 						loading={message.isLoading}
+						showWhileLoading={false}
 					/>
+
+					{#if visibleActions.length > 0}
+						<ToolMessageActions actions={visibleActions} />
+					{:else}
+						<ToolContentDisplay
+							title="Result"
+							content={message.result}
+							error={message.error}
+							loading={message.isLoading}
+						/>
+					{/if}
 				{/if}
-			{/if}
-		</div>
-	{/if}
-</div>
+			</div>
+		{/if}
+	</div>
+{/if}

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -203,7 +203,7 @@ describe('global AI tools', () => {
 		expect(item.value.value).toBeUndefined()
 	})
 
-	it('asks the user a multiple-choice question and returns the selected choice', async () => {
+	it('asks the user a multiple-choice question and returns the selected answer', async () => {
 		const callbacks: ToolCallbacks = {
 			setToolStatus: vi.fn(),
 			removeToolStatus: vi.fn(),
@@ -214,40 +214,26 @@ describe('global AI tools', () => {
 			'askUserQuestion',
 			{
 				question: 'Which script language should be used?',
-				choices: [
-					{ label: 'TypeScript', value: 'bun', description: 'Use Bun runtime.' },
-					{ label: 'Python', value: 'python3', description: 'Use Python 3.' }
-				]
+				choices: ['bun', 'python3']
 			},
 			callbacks
 		)
 
-		expect(JSON.parse(raw)).toEqual({
-			success: true,
-			answer: 'python3',
-			choice: {
-				id: 'python3',
-				label: 'Python',
-				value: 'python3',
-				description: 'Use Python 3.'
-			}
-		})
+		expect(raw).toBe('python3')
 		expect(callbacks.requestUserQuestion).toHaveBeenCalledWith(
 			'test-askUserQuestion',
 			expect.objectContaining({
 				question: 'Which script language should be used?',
-				choices: expect.arrayContaining([
-					expect.objectContaining({ id: 'bun', label: 'TypeScript' }),
-					expect.objectContaining({ id: 'python3', label: 'Python' })
-				])
+				choices: ['bun', 'python3']
 			})
 		)
 		expect(callbacks.setToolStatus).toHaveBeenLastCalledWith(
 			'test-askUserQuestion',
 			expect.objectContaining({
-				content: 'User answered question',
+				content: 'User answered question: python3',
 				isLoading: false,
-				userQuestion: expect.objectContaining({ selectedChoiceId: 'python3' })
+				result: 'python3',
+				userQuestion: expect.objectContaining({ selectedChoice: 'python3' })
 			})
 		)
 	})

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -70,12 +70,16 @@ function getGlobalTool(name: string): Tool<{}> {
 	return tool
 }
 
-async function callGlobalTool(name: string, args: Record<string, unknown>): Promise<string> {
+async function callGlobalTool(
+	name: string,
+	args: Record<string, unknown>,
+	callbacks: ToolCallbacks = toolCallbacks
+): Promise<string> {
 	return getGlobalTool(name).fn({
 		args,
 		workspace: WORKSPACE,
 		helpers: {},
-		toolCallbacks,
+		toolCallbacks: callbacks,
 		toolId: `test-${name}`
 	})
 }
@@ -197,5 +201,54 @@ describe('global AI tools', () => {
 			groups: [{ summary: 'Main', start_id: 'start', end_id: 'start' }]
 		})
 		expect(item.value.value).toBeUndefined()
+	})
+
+	it('asks the user a multiple-choice question and returns the selected choice', async () => {
+		const callbacks: ToolCallbacks = {
+			setToolStatus: vi.fn(),
+			removeToolStatus: vi.fn(),
+			requestUserQuestion: vi.fn(async (_toolId, question) => question.choices[1])
+		}
+
+		const raw = await callGlobalTool(
+			'askUserQuestion',
+			{
+				question: 'Which script language should be used?',
+				choices: [
+					{ label: 'TypeScript', value: 'bun', description: 'Use Bun runtime.' },
+					{ label: 'Python', value: 'python3', description: 'Use Python 3.' }
+				]
+			},
+			callbacks
+		)
+
+		expect(JSON.parse(raw)).toEqual({
+			success: true,
+			answer: 'python3',
+			choice: {
+				id: 'python3',
+				label: 'Python',
+				value: 'python3',
+				description: 'Use Python 3.'
+			}
+		})
+		expect(callbacks.requestUserQuestion).toHaveBeenCalledWith(
+			'test-askUserQuestion',
+			expect.objectContaining({
+				question: 'Which script language should be used?',
+				choices: expect.arrayContaining([
+					expect.objectContaining({ id: 'bun', label: 'TypeScript' }),
+					expect.objectContaining({ id: 'python3', label: 'Python' })
+				])
+			})
+		)
+		expect(callbacks.setToolStatus).toHaveBeenLastCalledWith(
+			'test-askUserQuestion',
+			expect.objectContaining({
+				content: 'User answered question',
+				isLoading: false,
+				userQuestion: expect.objectContaining({ selectedChoiceId: 'python3' })
+			})
+		)
 	})
 })

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -58,8 +58,7 @@ import {
 	type CreatedResourceTriggerKind,
 	type Tool,
 	type ToolCallbacks,
-	type ToolDisplayAction,
-	type UserQuestionChoice
+	type ToolDisplayAction
 } from '../shared'
 import {
 	resourceRequestSchema,
@@ -118,25 +117,10 @@ const askUserQuestionSchema = z.object({
 		.min(1)
 		.describe('The concise question to show to the user before continuing.'),
 	choices: z
-		.array(
-			z.object({
-				id: z.string().min(1).optional().describe('Optional stable identifier for this choice.'),
-				label: z.string().min(1).describe('Short option text shown to the user.'),
-				value: z
-					.string()
-					.min(1)
-					.optional()
-					.describe('Optional value returned to the assistant. Defaults to label.'),
-				description: z
-					.string()
-					.min(1)
-					.optional()
-					.describe('Optional one-sentence detail shown under the label.')
-			})
-		)
+		.array(z.string().min(1).describe('Short answer text shown to the user and returned as-is.'))
 		.min(2)
 		.max(6)
-		.describe('Two to six mutually exclusive choices.')
+		.describe('Two to six mutually exclusive answer strings.')
 })
 
 const listWorkspaceItemsSchema = z.object({
@@ -497,7 +481,7 @@ Important rules:
 - Use search_resource_types before write_resource to discover the resource_type name and the JSON Schema its value must match.
 - Use get_instructions before writing a script, flow, resource, or app. For scripts, pass the target language; when modifying, use the language from the item you read.
 - Schedules, triggers, and variables do not need get_instructions — their tool schemas describe every field.
-- When a required decision is ambiguous, use askUserQuestion with two to six clear choices instead of guessing.
+- When a required decision is ambiguous, use askUserQuestion with two to six clear answer strings instead of guessing.
 - A workspace item is { type, path, summary?, language?, triggerKind?, value, isDraft }. For scripts, value is the source code string. For flows, read_workspace_item returns value as the compact flow object { modules, schema, preprocessor_module, failure_module, groups }; write_flow takes the same flow fields as top-level tool arguments plus path/summary. For schedules/triggers/resources/variables, value is the full request body for that type. For apps, value is { files, runnables, data?, policy?, custom_path? } with frontend file contents and backend runnable definitions.
 - Apps (raw apps): use list_workspace_items with types: ['app'] to find them, read_workspace_item with type 'app' for a metadata summary (file paths + runnable list, no contents), then read_app_file to read individual files. Edit with write_app_file / patch_app_file / delete_app_file for frontend files and write_app_runnable / delete_app_runnable for backend runnables. Frontend file paths start with "/" (e.g. /index.tsx). Backend inline runnables are addressed as "backend/<key>/main.{ts|py}". /wmill.d.ts is generated and cannot be written.
 - To create a new raw app, use init_app. Before calling it, confirm framework (react19 / react18 / svelte5 / vue), path, and summary with the user — do not silently default to react19, even though it is the recommended choice.
@@ -509,29 +493,6 @@ const DEFAULT_LIST_TYPES = ['script', 'flow'] as const satisfies readonly Worksp
 
 function getRequestedTypes(types: WorkspaceItemType[] | undefined): WorkspaceItemType[] {
 	return types && types.length > 0 ? types : [...DEFAULT_LIST_TYPES]
-}
-
-function normalizeUserQuestionChoices(
-	choices: z.infer<typeof askUserQuestionSchema>['choices']
-): UserQuestionChoice[] {
-	const seen = new Set<string>()
-	return choices.map((choice, index) => {
-		const fallbackId = choice.value ?? choice.label ?? `choice_${index + 1}`
-		const baseId = (choice.id ?? fallbackId).trim().replace(/\s+/g, '_') || `choice_${index + 1}`
-		let id = baseId
-		let suffix = 2
-		while (seen.has(id)) {
-			id = `${baseId}_${suffix}`
-			suffix += 1
-		}
-		seen.add(id)
-		return {
-			id,
-			label: choice.label,
-			value: choice.value,
-			description: choice.description
-		}
-	})
 }
 
 function itemMatches(
@@ -1267,7 +1228,7 @@ export const globalTools: Tool<{}>[] = [
 			const parsed = askUserQuestionSchema.parse(args)
 			const userQuestion = {
 				question: parsed.question,
-				choices: normalizeUserQuestionChoices(parsed.choices)
+				choices: parsed.choices
 			}
 
 			toolCallbacks.setToolStatus(toolId, {
@@ -1299,21 +1260,16 @@ export const globalTools: Tool<{}>[] = [
 				return JSON.stringify({ success: false, error: message })
 			}
 
-			const result = {
-				success: true,
-				answer: selectedChoice.value ?? selectedChoice.label,
-				choice: selectedChoice
-			}
 			toolCallbacks.setToolStatus(toolId, {
-				content: 'User answered question',
+				content: `User answered question: ${selectedChoice}`,
 				userQuestion: {
 					...userQuestion,
-					selectedChoiceId: selectedChoice.id
+					selectedChoice
 				},
-				result,
+				result: selectedChoice,
 				isLoading: false
 			})
-			return JSON.stringify(result)
+			return selectedChoice
 		}
 	},
 	{

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -58,7 +58,8 @@ import {
 	type CreatedResourceTriggerKind,
 	type Tool,
 	type ToolCallbacks,
-	type ToolDisplayAction
+	type ToolDisplayAction,
+	type UserQuestionChoice
 } from '../shared'
 import {
 	resourceRequestSchema,
@@ -109,6 +110,33 @@ const getInstructionsSchema = z.object({
 		.describe(
 			'Required when subject is script. Use the existing script language when modifying, or the requested target language when creating.'
 		)
+})
+
+const askUserQuestionSchema = z.object({
+	question: z
+		.string()
+		.min(1)
+		.describe('The concise question to show to the user before continuing.'),
+	choices: z
+		.array(
+			z.object({
+				id: z.string().min(1).optional().describe('Optional stable identifier for this choice.'),
+				label: z.string().min(1).describe('Short option text shown to the user.'),
+				value: z
+					.string()
+					.min(1)
+					.optional()
+					.describe('Optional value returned to the assistant. Defaults to label.'),
+				description: z
+					.string()
+					.min(1)
+					.optional()
+					.describe('Optional one-sentence detail shown under the label.')
+			})
+		)
+		.min(2)
+		.max(6)
+		.describe('Two to six mutually exclusive choices.')
 })
 
 const listWorkspaceItemsSchema = z.object({
@@ -469,6 +497,7 @@ Important rules:
 - Use search_resource_types before write_resource to discover the resource_type name and the JSON Schema its value must match.
 - Use get_instructions before writing a script, flow, resource, or app. For scripts, pass the target language; when modifying, use the language from the item you read.
 - Schedules, triggers, and variables do not need get_instructions — their tool schemas describe every field.
+- When a required decision is ambiguous, use askUserQuestion with two to six clear choices instead of guessing.
 - A workspace item is { type, path, summary?, language?, triggerKind?, value, isDraft }. For scripts, value is the source code string. For flows, read_workspace_item returns value as the compact flow object { modules, schema, preprocessor_module, failure_module, groups }; write_flow takes the same flow fields as top-level tool arguments plus path/summary. For schedules/triggers/resources/variables, value is the full request body for that type. For apps, value is { files, runnables, data?, policy?, custom_path? } with frontend file contents and backend runnable definitions.
 - Apps (raw apps): use list_workspace_items with types: ['app'] to find them, read_workspace_item with type 'app' for a metadata summary (file paths + runnable list, no contents), then read_app_file to read individual files. Edit with write_app_file / patch_app_file / delete_app_file for frontend files and write_app_runnable / delete_app_runnable for backend runnables. Frontend file paths start with "/" (e.g. /index.tsx). Backend inline runnables are addressed as "backend/<key>/main.{ts|py}". /wmill.d.ts is generated and cannot be written.
 - To create a new raw app, use init_app. Before calling it, confirm framework (react19 / react18 / svelte5 / vue), path, and summary with the user — do not silently default to react19, even though it is the recommended choice.
@@ -480,6 +509,29 @@ const DEFAULT_LIST_TYPES = ['script', 'flow'] as const satisfies readonly Worksp
 
 function getRequestedTypes(types: WorkspaceItemType[] | undefined): WorkspaceItemType[] {
 	return types && types.length > 0 ? types : [...DEFAULT_LIST_TYPES]
+}
+
+function normalizeUserQuestionChoices(
+	choices: z.infer<typeof askUserQuestionSchema>['choices']
+): UserQuestionChoice[] {
+	const seen = new Set<string>()
+	return choices.map((choice, index) => {
+		const fallbackId = choice.value ?? choice.label ?? `choice_${index + 1}`
+		const baseId = (choice.id ?? fallbackId).trim().replace(/\s+/g, '_') || `choice_${index + 1}`
+		let id = baseId
+		let suffix = 2
+		while (seen.has(id)) {
+			id = `${baseId}_${suffix}`
+			suffix += 1
+		}
+		seen.add(id)
+		return {
+			id,
+			label: choice.label,
+			value: choice.value,
+			description: choice.description
+		}
+	})
 }
 
 function itemMatches(
@@ -1203,6 +1255,65 @@ export const globalTools: Tool<{}>[] = [
 					: parsed.subject
 			toolCallbacks.setToolStatus(toolId, { content: `Loaded ${label} instructions` })
 			return getInstructions(parsed.subject, parsed.language)
+		}
+	},
+	{
+		def: createToolDef(
+			askUserQuestionSchema,
+			'askUserQuestion',
+			'Ask the user a multiple-choice question and wait for their selection before continuing.'
+		),
+		fn: async ({ args, toolId, toolCallbacks }) => {
+			const parsed = askUserQuestionSchema.parse(args)
+			const userQuestion = {
+				question: parsed.question,
+				choices: normalizeUserQuestionChoices(parsed.choices)
+			}
+
+			toolCallbacks.setToolStatus(toolId, {
+				content: parsed.question,
+				userQuestion,
+				isLoading: true
+			})
+
+			if (!toolCallbacks.requestUserQuestion) {
+				const message = 'This chat context cannot ask interactive questions.'
+				toolCallbacks.setToolStatus(toolId, {
+					content: message,
+					userQuestion: { ...userQuestion, canceled: true },
+					isLoading: false,
+					error: message
+				})
+				return JSON.stringify({ success: false, error: message })
+			}
+
+			const selectedChoice = await toolCallbacks.requestUserQuestion(toolId, userQuestion)
+			if (!selectedChoice) {
+				const message = 'Question cancelled by user'
+				toolCallbacks.setToolStatus(toolId, {
+					content: message,
+					userQuestion: { ...userQuestion, canceled: true },
+					isLoading: false,
+					error: message
+				})
+				return JSON.stringify({ success: false, error: message })
+			}
+
+			const result = {
+				success: true,
+				answer: selectedChoice.value ?? selectedChoice.label,
+				choice: selectedChoice
+			}
+			toolCallbacks.setToolStatus(toolId, {
+				content: 'User answered question',
+				userQuestion: {
+					...userQuestion,
+					selectedChoiceId: selectedChoice.id
+				},
+				result,
+				isLoading: false
+			})
+			return JSON.stringify(result)
 		}
 	},
 	{

--- a/frontend/src/lib/components/copilot/chat/shared.test.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.test.ts
@@ -68,6 +68,39 @@ describe('createToolDef', () => {
 		expect(parameters?.properties?.config?.anyOf?.length).toBeGreaterThan(1)
 	})
 
+	it('disables strict mode for schemas with optional properties', async () => {
+		const { createToolDef } = await import('./shared')
+		const toolDef = createToolDef(
+			z.object({
+				subject: z.string(),
+				language: z.string().optional()
+			}),
+			'get_instructions',
+			'Get instructions'
+		)
+
+		const parameters = toolDef.function.parameters as any
+		expect(toolDef.function.strict).toBe(false)
+		expect(parameters.required).toEqual(['subject'])
+		expect(parameters.properties.language.type).toBe('string')
+	})
+
+	it('keeps strict mode for schemas without optional properties', async () => {
+		const { createToolDef } = await import('./shared')
+		const toolDef = createToolDef(
+			z.object({
+				question: z.string(),
+				choices: z.array(z.string())
+			}),
+			'askUserQuestion',
+			'Ask a question'
+		)
+
+		const parameters = toolDef.function.parameters as any
+		expect(toolDef.function.strict).toBe(true)
+		expect(parameters.required).toEqual(['question', 'choices'])
+	})
+
 	it('does not expose runnable target fields on workspace mutation tools', async () => {
 		const { createWorkspaceMutationTools } = await import('./workspaceTools')
 		const [scheduleTool, triggerTool] = createWorkspaceMutationTools()

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -485,17 +485,10 @@ export type CreatedResourceAction = {
 
 export type ToolDisplayAction = CreatedResourceAction
 
-export type UserQuestionChoice = {
-	id: string
-	label: string
-	value?: string
-	description?: string
-}
-
 export type UserQuestionDisplay = {
 	question: string
-	choices: UserQuestionChoice[]
-	selectedChoiceId?: string
+	choices: string[]
+	selectedChoice?: string
 	canceled?: boolean
 }
 
@@ -702,7 +695,7 @@ export interface ToolCallbacks {
 	requestUserQuestion?: (
 		toolId: string,
 		question: UserQuestionDisplay
-	) => Promise<UserQuestionChoice | undefined>
+	) => Promise<string | undefined>
 }
 
 export function createToolDef(

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -485,6 +485,20 @@ export type CreatedResourceAction = {
 
 export type ToolDisplayAction = CreatedResourceAction
 
+export type UserQuestionChoice = {
+	id: string
+	label: string
+	value?: string
+	description?: string
+}
+
+export type UserQuestionDisplay = {
+	question: string
+	choices: UserQuestionChoice[]
+	selectedChoiceId?: string
+	canceled?: boolean
+}
+
 export type ToolDisplayMessage = {
 	role: 'tool'
 	tool_call_id: string
@@ -500,6 +514,7 @@ export type ToolDisplayMessage = {
 	toolName?: string
 	showFade?: boolean
 	actions?: ToolDisplayAction[]
+	userQuestion?: UserQuestionDisplay
 }
 
 export type AssistantDisplayMessage = BaseDisplayMessage & {
@@ -684,6 +699,10 @@ export interface ToolCallbacks {
 	setToolStatus: (id: string, metadata?: Partial<ToolDisplayMessage>) => void
 	removeToolStatus: (id: string) => void
 	requestConfirmation?: (toolId: string) => Promise<boolean>
+	requestUserQuestion?: (
+		toolId: string,
+		question: UserQuestionDisplay
+	) => Promise<UserQuestionChoice | undefined>
 }
 
 export function createToolDef(

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -709,16 +709,65 @@ export function createToolDef(
 	delete parameters.$schema
 	if (!parameters.required) parameters.required = []
 	normalizeToolParameterSchema(parameters)
+	const effectiveStrict = strict && !hasOptionalObjectProperties(parameters)
 
 	return {
 		type: 'function',
 		function: {
-			strict,
+			strict: effectiveStrict,
 			name,
 			description,
 			parameters
 		}
 	}
+}
+
+function hasOptionalObjectProperties(schema: Record<string, any> | undefined): boolean {
+	if (!schema || typeof schema !== 'object') {
+		return false
+	}
+
+	if (schema.properties && typeof schema.properties === 'object') {
+		const required = new Set(Array.isArray(schema.required) ? schema.required : [])
+		const propertyKeys = Object.keys(schema.properties)
+		if (propertyKeys.some((key) => !required.has(key))) {
+			return true
+		}
+		for (const key of propertyKeys) {
+			if (hasOptionalObjectProperties(schema.properties[key])) {
+				return true
+			}
+		}
+	}
+
+	if (schema.items) {
+		if (Array.isArray(schema.items)) {
+			if (schema.items.some((item) => hasOptionalObjectProperties(item))) {
+				return true
+			}
+		} else if (hasOptionalObjectProperties(schema.items)) {
+			return true
+		}
+	}
+
+	if (
+		schema.additionalProperties &&
+		typeof schema.additionalProperties === 'object' &&
+		hasOptionalObjectProperties(schema.additionalProperties)
+	) {
+		return true
+	}
+
+	for (const key of ['allOf', 'anyOf', 'oneOf']) {
+		if (
+			Array.isArray(schema[key]) &&
+			schema[key].some((subSchema: Record<string, any>) => hasOptionalObjectProperties(subSchema))
+		) {
+			return true
+		}
+	}
+
+	return false
 }
 
 const searchHubScriptsSchema = z.object({

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -709,7 +709,7 @@ export function createToolDef(
 	delete parameters.$schema
 	if (!parameters.required) parameters.required = []
 	normalizeToolParameterSchema(parameters)
-	const effectiveStrict = strict && !hasOptionalObjectProperties(parameters)
+	const effectiveStrict = strict && !hasOptionalProperties(parameters)
 
 	return {
 		type: 'function',
@@ -722,7 +722,7 @@ export function createToolDef(
 	}
 }
 
-function hasOptionalObjectProperties(schema: Record<string, any> | undefined): boolean {
+function hasOptionalProperties(schema: Record<string, any> | undefined): boolean {
 	if (!schema || typeof schema !== 'object') {
 		return false
 	}
@@ -734,7 +734,7 @@ function hasOptionalObjectProperties(schema: Record<string, any> | undefined): b
 			return true
 		}
 		for (const key of propertyKeys) {
-			if (hasOptionalObjectProperties(schema.properties[key])) {
+			if (hasOptionalProperties(schema.properties[key])) {
 				return true
 			}
 		}
@@ -742,10 +742,10 @@ function hasOptionalObjectProperties(schema: Record<string, any> | undefined): b
 
 	if (schema.items) {
 		if (Array.isArray(schema.items)) {
-			if (schema.items.some((item) => hasOptionalObjectProperties(item))) {
+			if (schema.items.some((item) => hasOptionalProperties(item))) {
 				return true
 			}
-		} else if (hasOptionalObjectProperties(schema.items)) {
+		} else if (hasOptionalProperties(schema.items)) {
 			return true
 		}
 	}
@@ -753,7 +753,7 @@ function hasOptionalObjectProperties(schema: Record<string, any> | undefined): b
 	if (
 		schema.additionalProperties &&
 		typeof schema.additionalProperties === 'object' &&
-		hasOptionalObjectProperties(schema.additionalProperties)
+		hasOptionalProperties(schema.additionalProperties)
 	) {
 		return true
 	}
@@ -761,7 +761,7 @@ function hasOptionalObjectProperties(schema: Record<string, any> | undefined): b
 	for (const key of ['allOf', 'anyOf', 'oneOf']) {
 		if (
 			Array.isArray(schema[key]) &&
-			schema[key].some((subSchema: Record<string, any>) => hasOptionalObjectProperties(subSchema))
+			schema[key].some((subSchema: Record<string, any>) => hasOptionalProperties(subSchema))
 		) {
 			return true
 		}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -492,7 +492,7 @@
 		}
 
 		const skipSelector =
-			'[role="menu"], [role="menuitem"], [role="dialog"], [role="listbox"], [role="combobox"], [aria-expanded="true"], [data-menu]'
+			'[role="menu"], [role="menuitem"], [role="dialog"], [role="listbox"], [role="combobox"], [aria-expanded="true"], [data-menu], [data-chat-keyboard-scope]'
 		if (target) {
 			const tag = target.tagName
 			const isEditable =


### PR DESCRIPTION
## Summary
Adds an `askUserQuestion` tool to global mode chat so the assistant can pause for a user decision, render a compact multiple-choice UI, and continue with the selected answer.

https://github.com/user-attachments/assets/bafee3e7-f2e3-422c-be24-13208ff63c5d

## Changes
- Added global `askUserQuestion` with two to six plain string choices.
- The tool now returns the selected string directly to the LLM.
- The completed tool status now collapses to `User answered question: {answer}`.
- Added `AskUserQuestionDisplay` for the active pending question UI.
  - title uses `text-xs`
  - answers use `text-2xs`
  - no `selected: ...` footer
  - first answer auto-focuses
  - arrow keys move between answers
  - Enter submits the focused answer
- Scoped ask-question keyboard handling so the homepage capture-phase list navigation ignores arrow/Enter events from the question UI.
- Kept `AskUserQuestionDisplay` pending-only: answered, canceled, and error states now fall back to the normal collapsed tool status instead of unreachable selected/canceled UI.
- Added chat-manager callback plumbing for answering and canceling pending questions.
- Added a provider compatibility fix in `createToolDef`: schemas with optional properties now disable strict mode, while fully required schemas stay strict. This was caught by OpenAI/GPT-4o during `ai_evals`.

## Validation
- [x] Svelte autofixer on changed Svelte components
- [x] `npx vitest run src/lib/components/copilot/chat/shared.test.ts src/lib/components/copilot/chat/global/core.test.ts`
- [x] `git diff --check`
- [x] `ai_evals` global provider smoke:
  - `haiku` / Anthropic: `global-test1-script-create` passed, 100%
  - `4o` / OpenAI: `global-test1-script-create` passed, 100%
  - `gemini-flash` / GoogleAI: `global-test1-script-create` passed, 100%

## Notes
- PR branch was rebased onto `origin/main`; conflicts are resolved and GitHub reports the PR as mergeable.
- `npm run check:fast` is currently blocked by unrelated main-side type errors in `SuperadminSettingsInner.svelte` and `TokensTable.svelte`.
- The local backend on `:8110` is blocked by unrelated `windmill-api-auth` compile errors after the rebase, so `ai_evals` used the running local backend on `:8080` with `WMILL_AI_EVAL_BACKEND_WORKSPACE=admins`.
