### PR TITLE
fix: scope SimpleEditor webview paste to focused editor instance

### DIFF
--- a/frontend/src/lib/components/SimpleEditor.svelte
+++ b/frontend/src/lib/components/SimpleEditor.svelte
@@ -61,6 +61,7 @@
 	let divEl: HTMLDivElement | null = null
 	let editor = $state<meditor.IStandaloneCodeEditor | null>(null)
 	let model: meditor.ITextModel
+	let pasteListenerCleanup: (() => void) | undefined = undefined
 
 	let statusDiv = $state<Element | null>(null)
 	let width = $state(0)
@@ -370,10 +371,32 @@
 			editor.addCommand(KeyMod.CtrlCmd | KeyCode.KeyX, function () {
 				document.execCommand('cut')
 			})
-			editor.addCommand(KeyMod.CtrlCmd | KeyCode.KeyV, async function () {
-				inputEl?.focus()
-				document.execCommand('paste')
-			})
+			// Paste is handled by a listener scoped to THIS editor's DOM node.
+			// `editor.addCommand` registers a *global* keybinding in the shared
+			// standalone services, so with multiple SimpleEditor instances the
+			// last-registered handler wins and paste lands in the wrong editor.
+			const pasteTarget = divEl
+			const onPaste = (e: ClipboardEvent) => {
+				if (!editor || !editor.hasTextFocus()) return
+				const text = e.clipboardData?.getData('text/plain')
+				if (!text) return
+				e.preventDefault()
+				e.stopPropagation()
+				editor.executeEdits('paste', [
+					{
+						range: editor.getSelection() ?? {
+							startLineNumber: 1,
+							startColumn: 1,
+							endLineNumber: 1,
+							endColumn: 1
+						},
+						text,
+						forceMoveMarkers: true
+					}
+				])
+			}
+			pasteTarget?.addEventListener('paste', onPaste, true)
+			pasteListenerCleanup = () => pasteTarget?.removeEventListener('paste', onPaste, true)
 		}
 
 		let timeoutModel: number | undefined = undefined
@@ -583,6 +606,7 @@
 	onDestroy(() => {
 		try {
 			valueAfterDispose = getCode()
+			pasteListenerCleanup?.()
 			vimDisposable?.dispose()
 			model && model.dispose()
 			editor && editor.dispose()
@@ -599,38 +623,8 @@
 	}
 
 	updatePlaceholderVisibility(code ?? '')
-
-	let inputEl = $state<HTMLInputElement | null>(null)
-	let pasteValue = $state('')
-	$effect(() => {
-		if (inputEl && pasteValue) {
-			untrack(() => {
-				editor?.executeEdits('paste', [
-					{
-						range: editor?.getSelection() ?? {
-							startLineNumber: 1,
-							startColumn: 1,
-							endLineNumber: 1,
-							endColumn: 1
-						},
-						text: pasteValue,
-						forceMoveMarkers: true
-					}
-				])
-				pasteValue = ''
-			})
-		}
-	})
 </script>
 
-{#if parent.window !== window}
-	<input
-		style="height: 0; width: 0; opacity: 0; position: absolute; top: 0; left: 0; z-index: -1;"
-		type="text"
-		bind:this={inputEl}
-		bind:value={pasteValue}
-	/>
-{/if}
 <EditorTheme />
 {#if !editor || suggestion}
 	<FakeMonacoPlaceHolder


### PR DESCRIPTION
## Summary

In the VS Code extension webview (`window.parent !== window`), pasting into a Monaco editor embedded in a form input pasted into the **last-mounted** SimpleEditor instead of the focused one.

Root cause: `editor.addCommand(Ctrl/Cmd+V, …)` registers a **global** keybinding in the shared codingame `monaco-vscode` standalone services, not a per-editor command. With multiple SimpleEditor instances (one per arg input), the last-registered handler won for all of them, and its closure captured the wrong instance's hidden `<input>`/`editor`. So the paste always landed in the last editor regardless of focus.

This is independent of the separate `createModelReference` / `file:` console errors (different root cause).

## Changes

- Removed the global `editor.addCommand(Ctrl/Cmd+V)` handler and the hidden `<input>` + `pasteValue` `$state` + paste `$effect` machinery.
- Added a per-instance native `paste` listener attached in **capture phase** to this instance's `divEl`, gated on `editor.hasTextFocus()`, that reads `clipboardData` `text/plain`, `preventDefault()` + `stopPropagation()` (so Monaco doesn't double-handle), and `executeEdits` into this editor at its current selection.
- Wired listener cleanup into the existing `onDestroy`.
- Copy/Cut left as global `document.execCommand` commands — they're stateless and unaffected by the wrong-instance bug. Change stays inside the existing `window.parent !== window` block, so non-webview behavior is unchanged.

## Test plan

- [ ] In the VS Code extension webview, open a script/flow whose args render **2+** SimpleEditors; focus one, paste → lands in the focused editor (not the last-mounted); repeat for the other
- [ ] Paste happens exactly once (no duplication) and replaces the current selection
- [ ] Ctrl/Cmd+C and Ctrl/Cmd+X still work in the webview
- [ ] In a normal (non-webview) browser tab, Ctrl/Cmd+V still pastes normally