### PR TITLE
fix(git-sync): bump default sync script to hub/28229 for extra_perms support

### DIFF
--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -157,7 +157,7 @@ pub enum ObjectType {
     WorkspaceDependencies,
 }
 
-pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28217/sync-script-to-git-repo-windmill";
+pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28229/sync-script-to-git-repo-windmill";
 
 /// Prefix used to identify fork workspaces. A workspace whose id starts with this string is a
 /// fork of another workspace.


### PR DESCRIPTION
## Summary

`LATEST_GIT_SYNC_SCRIPT_PATH` still pointed at `hub/28217/sync-script-to-git-repo-windmill`. The git-sync deployment callback runs that hub script, which bundles its own `wmill` CLI independently of the backend version. Script `28217` predates PR #9162 (extra_perms / granular ACL sync), so even on a v1.703.3 backend an auto-managed git-sync repo would run a CLI that does **not** pass `preserve_extra_perms=true` — ACL-only changes on flows/scripts/apps produced a byte-identical export and no git commit ("permissions sync not working").

This bumps the auto-managed default to `hub/28229`, which bundles the CLI with extra_perms support.

## Changes

- Bump `LATEST_GIT_SYNC_SCRIPT_PATH` from `hub/28217/...` to `hub/28229/...` in `backend/windmill-common/src/workspaces.rs`

## Notes

- Only the auto-managed default is affected (`script_path = None`). Repos pinned to an explicit older `script_path` still need a manual update.
- No paired min-version bump needed: the only gate (`is_script_meets_min_version(28103)`) stays satisfied since `28229 >= 28103`, and ids are monotonically increasing.
- No other references to `28217` exist in the OSS or EE trees.

## Test plan

- [ ] On an EE instance with an auto-managed git-sync repo (no pinned `script_path`), change extra permissions on a flow in the UI
- [ ] Confirm the resulting git-sync job runs `hub/28229/sync-script-to-git-repo-windmill`
- [ ] Confirm the flow's `extra_perms` change is committed to the git repo
- [ ] Confirm debouncing still applies (the `28103` min-version gate remains satisfied)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped the default git-sync script to `hub/28229` so auto‑managed repos use a CLI that preserves `extra_perms` and commits ACL‑only changes. Fixes missing commits when only permissions change.

- **Bug Fixes**
  - Update `LATEST_GIT_SYNC_SCRIPT_PATH` from `hub/28217/...` to `hub/28229/...`.
  - Applies to auto-managed repos (no pinned `script_path`); pinned repos need a manual update.

<sup>Written for commit e2139971c4a40bd4892759813e248a69320b0ccd. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9223?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

