### PR TITLE
fix: advance postgres replication slot lsn via periodic standby status updates

### DIFF
--- a/backend/windmill-api-integration-tests/Cargo.toml
+++ b/backend/windmill-api-integration-tests/Cargo.toml
@@ -15,6 +15,7 @@ enterprise = ["windmill-test-utils/enterprise", "dep:base64", "windmill-git-sync
 deno_core = ["windmill-test-utils/deno_core"]
 mcp = ["windmill-test-utils/mcp", "dep:rmcp"]
 run_inline = ["dep:windmill-worker", "windmill-test-utils/run_inline", "windmill-test-utils/duckdb"]
+postgres_trigger = ["windmill-test-utils/postgres_trigger"]
 
 [dependencies]
 windmill-test-utils.workspace = true

--- a/backend/windmill-api-integration-tests/tests/trigger_e2e.rs
+++ b/backend/windmill-api-integration-tests/tests/trigger_e2e.rs
@@ -370,6 +370,175 @@ async fn test_postgres_e2e(db: Pool<Postgres>) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Regression test for the replication-slot LSN freeze bug.
+///
+/// Before the fix the Postgres trigger consumer only sent a standby status
+/// update in response to a `PrimaryKeepAlive` with `reply=true` — never on a
+/// timer and never after processing `XLogData`. The bound jobs ran fine but
+/// the slot's `confirmed_flush_lsn`/`restart_lsn` never advanced, so retained
+/// WAL grew unbounded until it exceeded `max_slot_wal_keep_size`.
+///
+/// This asserts the slot's `confirmed_flush_lsn` advances to at least the WAL
+/// position recorded *before* the change events, proving feedback is sent.
+/// Against the pre-fix code this loop times out (LSN frozen at slot creation);
+/// with the fix the periodic status update advances it within ~10s.
+///
+/// Requires PostgreSQL with `wal_level=logical` (see `test_postgres_e2e`).
+///
+/// Run:
+/// ```bash
+/// cargo test --test trigger_e2e test_postgres_slot_lsn_advances \
+///     --features postgres_trigger -- --ignored --nocapture
+/// ```
+#[ignore = "requires PostgreSQL with wal_level=logical"]
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn test_postgres_slot_lsn_advances(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let script_path = "f/test/pg_lsn_handler";
+    insert_test_script(&db, script_path).await?;
+
+    // Replication slots are server-wide so use a random suffix.
+    let suffix: u32 = rand::random();
+    let slot_name = format!("test_lsn_slot_{suffix}");
+    let pub_name = format!("test_lsn_pub_{suffix}");
+
+    sqlx::query("CREATE TABLE lsn_trigger_table (id serial PRIMARY KEY, data text)")
+        .execute(&db)
+        .await?;
+    sqlx::query(&format!(
+        "CREATE PUBLICATION {pub_name} FOR TABLE lsn_trigger_table"
+    ))
+    .execute(&db)
+    .await?;
+    sqlx::query(&format!(
+        "SELECT pg_create_logical_replication_slot('{slot_name}', 'pgoutput')"
+    ))
+    .execute(&db)
+    .await?;
+
+    let test_db_name: String = sqlx::query_scalar("SELECT current_database()")
+        .fetch_one(&db)
+        .await?;
+
+    insert_resource(
+        &db,
+        "u/test-user/pg_lsn_res",
+        "postgresql",
+        json!({
+            "user": "postgres",
+            "password": "changeme",
+            "host": "localhost",
+            "port": 5432,
+            "dbname": test_db_name,
+            "sslmode": "disable"
+        }),
+    )
+    .await?;
+
+    sqlx::query(
+        r#"
+        INSERT INTO postgres_trigger (
+            path, script_path, is_flow, workspace_id, edited_by, permissioned_as,
+            postgres_resource_path, replication_slot_name, publication_name
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        "#,
+    )
+    .bind("f/test/pg_lsn_trigger")
+    .bind(script_path)
+    .bind(false)
+    .bind("test-workspace")
+    .bind("test-user")
+    .bind("u/test-user")
+    .bind("u/test-user/pg_lsn_res")
+    .bind(&slot_name)
+    .bind(&pub_name)
+    .execute(&db)
+    .await?;
+
+    let _server = ApiServer::start_with_listeners(db.clone()).await?;
+    // Give the listener time to open the replication stream.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // WAL position before any change events. A correctly behaving consumer
+    // must report a flushed LSN at or beyond this once it has processed the
+    // change traffic below.
+    let before_lsn: String = sqlx::query_scalar("SELECT pg_current_wal_lsn()::text")
+        .fetch_one(&db)
+        .await?;
+
+    // Sustained change traffic — this is what makes the bug bite in
+    // production. While data keeps flowing, Postgres does not volunteer a
+    // reply-requested keepalive until it is about to hit `wal_sender_timeout`
+    // (default 60s, so ~30s of silence). The pre-fix consumer only ever
+    // replied to those keepalives, so under continuous load the slot stayed
+    // frozen. The fix sends a standby status update every 10s regardless of
+    // traffic, so the slot advances well before the keepalive path would.
+    let inserter_db = db.clone();
+    let inserter = tokio::spawn(async move {
+        let mut i = 0;
+        loop {
+            let _ = sqlx::query("INSERT INTO lsn_trigger_table (data) VALUES ($1)")
+                .bind(format!("row {i}"))
+                .execute(&inserter_db)
+                .await;
+            i += 1;
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    });
+
+    // Sanity: the bound job still runs (this passed even with the bug).
+    let job = poll_for_trigger_job(&db, script_path, "postgres", Duration::from_secs(30)).await?;
+    assert!(job.args.is_some(), "job should have args");
+
+    // Post-fix advances within ~10s (the status-update interval). Pre-fix
+    // cannot advance before the first forced reply-keepalive (~30s with the
+    // default 60s wal_sender_timeout), so a 20s deadline cleanly separates the
+    // two while leaving generous margin on both sides.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    let advanced = loop {
+        let advanced: Option<bool> = sqlx::query_scalar(
+            r#"
+            SELECT confirmed_flush_lsn >= $1::pg_lsn
+            FROM pg_replication_slots
+            WHERE slot_name = $2
+            "#,
+        )
+        .bind(&before_lsn)
+        .bind(&slot_name)
+        .fetch_one(&db)
+        .await?;
+
+        if advanced == Some(true) {
+            break true;
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            break false;
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    };
+
+    inserter.abort();
+
+    if !advanced {
+        let current: Option<String> = sqlx::query_scalar(
+            "SELECT confirmed_flush_lsn::text FROM pg_replication_slots WHERE slot_name = $1",
+        )
+        .bind(&slot_name)
+        .fetch_one(&db)
+        .await?;
+        panic!(
+            "replication slot {slot_name} confirmed_flush_lsn did not advance within 20s: \
+             before={before_lsn}, current={current:?} — WAL retention would grow unbounded"
+        );
+    }
+
+    Ok(())
+}
+
 // ============================================================================
 // Kafka Trigger E2E (Enterprise)
 // ============================================================================

--- a/backend/windmill-test-utils/Cargo.toml
+++ b/backend/windmill-test-utils/Cargo.toml
@@ -18,6 +18,7 @@ mcp = ["windmill-api/mcp"]
 agent_worker_server = ["dep:windmill-api-agent-workers"]
 run_inline = ["windmill-api/run_inline"]
 duckdb = ["windmill-worker/duckdb"]
+postgres_trigger = ["windmill-api/postgres_trigger"]
 
 [dependencies]
 windmill-api = { workspace = true, default-features = false }

--- a/backend/windmill-trigger-postgres/src/listener.rs
+++ b/backend/windmill-trigger-postgres/src/listener.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, pin::Pin, sync::Arc};
+use std::{collections::HashMap, pin::Pin, sync::Arc, time::Duration};
 
 use bytes::{BufMut, Bytes, BytesMut};
 use chrono::TimeZone;
@@ -23,7 +23,7 @@ use super::{
     relation::RelationConverter,
     replication_message::{
         LogicalReplicationMessage::{Begin, Commit, Delete, Insert, Relation, Type, Update},
-        PrimaryKeepAliveBody, ReplicationMessage,
+        ReplicationMessage,
     },
     resolve_postgres_resource, Postgres, PostgresConfig, PostgresTrigger,
     ERROR_PUBLICATION_NAME_NOT_EXISTS,
@@ -100,10 +100,11 @@ impl PostgresSimpleClient {
         ))
     }
 
-    async fn send_status_update(
-        primary_keep_alive: PrimaryKeepAliveBody,
-        copy_both_stream: &mut Pin<&mut CopyBothDuplex<Bytes>>,
-    ) {
+    /// Sends a Standby Status Update ('r') reporting `lsn` as the WAL position
+    /// written, flushed and applied. Postgres only advances the replication
+    /// slot's `confirmed_flush_lsn`/`restart_lsn` (and releases retained WAL)
+    /// when it receives this with a flushed LSN past the current position.
+    async fn send_status_update(lsn: u64, copy_both_stream: &mut Pin<&mut CopyBothDuplex<Bytes>>) {
         let mut buf = BytesMut::new();
         let ts = chrono::Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap();
         let ts = chrono::Utc::now()
@@ -112,13 +113,16 @@ impl PostgresSimpleClient {
             .unwrap_or(0);
 
         buf.put_u8(b'r');
-        buf.put_u64(primary_keep_alive.wal_end);
-        buf.put_u64(primary_keep_alive.wal_end);
-        buf.put_u64(primary_keep_alive.wal_end);
+        buf.put_u64(lsn);
+        buf.put_u64(lsn);
+        buf.put_u64(lsn);
         buf.put_i64(ts);
         buf.put_u8(0);
-        copy_both_stream.send(buf.freeze()).await.unwrap();
-        tracing::debug!("Send update status message");
+        if let Err(err) = copy_both_stream.send(buf.freeze()).await {
+            tracing::warn!("Failed to send standby status update to postgres: {err}");
+        } else {
+            tracing::debug!("Sent standby status update with lsn {lsn}");
+        }
     }
 }
 
@@ -212,8 +216,35 @@ impl Listener for PostgresTrigger {
             "Starting to listen for postgres trigger {}",
             &listening_trigger.path
         );
+
+        // Highest WAL position received (and processed) so far. Reported back
+        // to Postgres via standby status updates so the replication slot can
+        // advance and retained WAL gets released. Without periodic updates the
+        // slot's LSNs stay frozen and WAL grows unbounded.
+        let mut last_lsn: u64 = 0;
+        let mut status_interval = tokio::time::interval(Duration::from_secs(10));
+        status_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // First tick resolves immediately; consume it so the periodic cadence
+        // starts one full interval from now.
+        status_interval.tick().await;
+
         loop {
-            let message = logical_replication_stream.next().await;
+            let next = tokio::select! {
+                _ = status_interval.tick() => None,
+                message = logical_replication_stream.next() => Some(message),
+            };
+
+            let message = match next {
+                None => {
+                    PostgresSimpleClient::send_status_update(
+                        last_lsn,
+                        &mut logical_replication_stream,
+                    )
+                    .await;
+                    continue;
+                }
+                Some(message) => message,
+            };
             let message = match message {
                 Some(message) => message,
                 None => {
@@ -264,15 +295,17 @@ impl Listener for PostgresTrigger {
 
             match logical_message {
                 ReplicationMessage::PrimaryKeepAlive(primary_keep_alive) => {
+                    last_lsn = last_lsn.max(primary_keep_alive.wal_end);
                     if primary_keep_alive.reply {
                         PostgresSimpleClient::send_status_update(
-                            primary_keep_alive,
+                            last_lsn,
                             &mut logical_replication_stream,
                         )
                         .await;
                     }
                 }
                 ReplicationMessage::XLogData(x_log_data) => {
+                    last_lsn = last_lsn.max(x_log_data.wal_end);
                     let logical_replication_message = match x_log_data
                         .parse(&logical_replication_settings)
                     {


### PR DESCRIPTION
## Summary

Postgres triggers using logical replication never advanced the replication slot's `confirmed_flush_lsn`/`restart_lsn`. Bound jobs ran fine, but retained WAL grew unbounded until it exceeded `max_slot_wal_keep_size` (reported on CE v1.686.0 / Aurora PG 14.17).

**Root cause (application logic, not a dependency change):** the consumer in `windmill-trigger-postgres` only sent a Standby Status Update in response to a `PrimaryKeepAlive` with `reply=true` — never on a timer and never after processing `XLogData`. Under sustained change traffic Postgres does not volunteer a reply-requested keepalive until it is about to hit `wal_sender_timeout` (~30s with the 60s default), so the slot stayed frozen and WAL accumulated. Postgres only advances a slot when it receives a status update with a higher flushed LSN.

This is **not** caused by the recent `imor → MaterializeInc` rust-postgres fork swap (`0a5f8dcd48`, 2026-05-11). The reporter's v1.686.0 (2026-04-17) predates that swap and ran the old `imor` fork; the buggy consume loop has been unchanged since the crate was introduced and is fork-independent.

## Changes

- `windmill-trigger-postgres/src/listener.rs`:
  - The consume loop now multiplexes the replication stream against a 10s `tokio::time::interval` via `tokio::select!`. On each tick it sends a Standby Status Update.
  - Tracks the highest received WAL position (`last_lsn`, monotonic via `.max()`) from both `XLogData` and `PrimaryKeepAlive`, and reports it in every status update (periodic **and** keepalive-reply).
  - `send_status_update` now takes an explicit `lsn: u64` instead of a `PrimaryKeepAliveBody`, and logs a warning instead of `panic!`-ing if the feedback send fails (a genuine disconnect is still caught on the next stream read).
- Added `test_postgres_slot_lsn_advances` e2e regression test (`trigger_e2e.rs`) that drives sustained change traffic and asserts `confirmed_flush_lsn` advances within 20s.
- Wired the `postgres_trigger` feature through `windmill-test-utils` and `windmill-api-integration-tests` so the Postgres trigger e2e tests are actually runnable (pre-existing gap — the documented `--features postgres_trigger` was not exposed by the test crate).

## Validation

- `cargo check -p windmill-trigger-postgres` clean; 96 crate unit tests pass.
- E2E reproduced both ways against a local Postgres with `wal_level=logical`:
  - **Pre-fix:** `test_postgres_slot_lsn_advances` FAILS — `confirmed_flush_lsn` frozen *behind* the pre-traffic WAL position after 20s of continuous traffic (reproduces the reported production symptom).
  - **Post-fix:** PASSES in ~11s — slot advances within one ~10s status-update interval.
- Local code review (fresh-context): good to merge, no blocking issues.

## Test plan

- [ ] CI green
- [ ] `cargo test --test trigger_e2e test_postgres_slot_lsn_advances --features postgres_trigger -- --ignored --nocapture` passes on a Postgres with `wal_level=logical`
- [ ] (optional) confirm the same test times out when checked out against the pre-fix `listener.rs`
- [ ] Verify on the reporter's Aurora setup that slot LSNs advance and retained WAL is released

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where logical replication slots never advanced by sending periodic standby status updates and tracking the latest LSN, preventing unbounded WAL retention. Adds an e2e test and wires the `postgres_trigger` feature so the test actually runs.

- **Bug Fixes**
  - In `windmill-trigger-postgres`, send a standby status update every 10s via `tokio::select`, and on keepalive replies.
  - Track the highest received WAL position (`last_lsn`) from both `XLogData` and keepalives; report it in all status updates.
  - Change `send_status_update` to accept `lsn: u64` and log a warning instead of panicking on send failure.
  - Add an e2e regression test that drives sustained changes and asserts `confirmed_flush_lsn` advances within 20s; expose `postgres_trigger` in `windmill-test-utils` and `windmill-api-integration-tests` to enable it.

<sup>Written for commit 68a1649e33e4829500e92068b788e3ee2cfdab62. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9227?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

