### PR TITLE
fix: avoid stale localStorage rd when SAML RelayState carries the deep link

### DIFF
--- a/frontend/src/lib/components/Login.svelte
+++ b/frontend/src/lib/components/Login.svelte
@@ -414,8 +414,8 @@
 			sendUserToast('No SAML login available', true)
 			return false
 		}
-		persistRd()
 		let target = saml
+		let relayStateSet = false
 		// Carry the SP-initiated deep link through the IdP round-trip via SAML
 		// RelayState so the ACS redirects straight back to it (bypassing
 		// /user/login). Only same-origin relative paths are passed; the backend
@@ -425,9 +425,17 @@
 				const url = new URL(saml)
 				url.searchParams.set('RelayState', rd)
 				target = url.toString()
+				relayStateSet = true
 			} catch (e) {
 				console.error('Could not set SAML RelayState', e)
 			}
+		}
+		// Only use the localStorage fallback when RelayState is NOT carrying the
+		// deep link. With RelayState the ACS redirects straight to the target and
+		// /user/login never consumes/clears the key, so a persisted value would
+		// go stale and hijack a later plain visit to /user/login.
+		if (!relayStateSet) {
+			persistRd()
 		}
 		window.location.href = target
 		return true


### PR DESCRIPTION
## Summary

Follow-up to #9225 (CI-flagged P2). `redirectSaml()` always called `persistRd()` (writes `localStorage.rd`). Before #9225 the ACS redirected to `/user/login`, whose page consumes and clears that key (`login/+page.svelte:28-31`). Now the ACS redirects **straight to the RelayState deep link**, bypassing `/user/login`, so the persisted `rd` is never consumed/cleared — it goes stale and a later plain visit to `/user/login` silently bounces the user to the old deep link.

## Changes

- `frontend/src/lib/components/Login.svelte` (`redirectSaml`): only call `persistRd()` when RelayState is **not** carrying the deep link (i.e. only on the fallback path — `rd` absent/absolute, or `new URL(saml)` injection threw). When RelayState is set, no `localStorage.rd` write happens, so nothing can go stale.

All fallback paths preserve pre-fix behavior; no legitimate deep link is lost (the frontend guard is a strict subset of what the backend `safe_relay_state_redirect` accepts, and `persistRd()` already early-returns on falsy `rd`).

## Test plan

- [x] `npm run check` — no new errors in `Login.svelte` (71/36 baseline unchanged; pre-existing unrelated)
- [x] Local multi-agent review — good to merge, no issues
- [ ] Manual (requires SAML IdP): SP-initiated deep-link login → lands on deep link; then plain visit to `/user/login` → **not** bounced to the old deep link; absolute-`rd` fallback still routes via localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale redirects after SAML logins by skipping the `localStorage.rd` write when RelayState carries the deep link. Later visits to `/user/login` no longer bounce to an old deep link; fallback behavior is unchanged.

- **Bug Fixes**
  - In `Login.svelte` (`redirectSaml`), only call `persistRd()` when RelayState isn’t set (rd absent/absolute, or URL parse fails).

<sup>Written for commit 14def5d68208331be844e1428df6515418d4231a. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9228?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

