### PR TITLE
refactor: move anthropic proxy building

### DIFF
--- a/backend/windmill-ai/src/providers/anthropic.rs
+++ b/backend/windmill-ai/src/providers/anthropic.rs
@@ -1,13 +1,15 @@
 use crate::{
     ai_google::parse_data_url,
-    ai_providers::AIProvider,
+    ai_providers::{AIPlatform, AIProvider},
     image_handler::prepare_messages_for_api,
+    proxy::{add_user_to_body, ProxyBuildArgs, ProxyRequest},
     query_builder::{BuildRequestArgs, ParsedResponse, QueryBuilder, StreamEventSink},
     sse::{AnthropicSSEParser, SSEParser},
     types::*,
-    utils::{extract_text_content, should_use_structured_output_tool},
+    utils::{extract_text_content, should_use_structured_output_tool, AI_HTTP_HEADERS},
 };
 use async_trait::async_trait;
+use http::Method;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 use windmill_common::{client::AuthedClient, error::Error};
@@ -379,6 +381,117 @@ impl AnthropicQueryBuilder {
         self.platform == AIPlatform::GoogleVertexAi
     }
 
+    fn transform_proxy_body_for_vertex(body: &[u8]) -> Result<(String, Vec<u8>), Error> {
+        let mut json_body: std::collections::HashMap<String, serde_json::Value> =
+            serde_json::from_slice(body).map_err(|e| {
+                Error::internal_err(format!("Failed to parse Anthropic request: {}", e))
+            })?;
+
+        let model = json_body
+            .remove("model")
+            .and_then(|v| v.as_str().map(str::to_string))
+            .ok_or_else(|| {
+                Error::BadRequest("Missing 'model' field in Anthropic request".to_string())
+            })?;
+
+        json_body.insert(
+            "anthropic_version".to_string(),
+            serde_json::Value::String(ANTHROPIC_VERSION_VERTEX.to_string()),
+        );
+
+        let transformed_body = serde_json::to_vec(&json_body).map_err(|e| {
+            Error::internal_err(format!("Failed to serialize Vertex request: {}", e))
+        })?;
+
+        Ok((model, transformed_body))
+    }
+
+    fn build_anthropic_proxy_request(
+        &self,
+        args: &ProxyBuildArgs<'_>,
+    ) -> Result<ProxyRequest, Error> {
+        let credentials = args.credentials;
+        let body = if let Some(user) = credentials.user.as_ref() {
+            add_user_to_body(args.body, user)?
+        } else {
+            args.body.to_vec()
+        };
+
+        let base_url = credentials.base_url.trim_end_matches('/');
+        let is_vertex = self.is_vertex();
+        let is_anthropic_sdk = args.headers.get("X-Anthropic-SDK").is_some();
+
+        let (url, body) = if is_vertex && *args.method != Method::GET {
+            let (model, transformed_body) = Self::transform_proxy_body_for_vertex(&body)?;
+            (
+                format!("{}/{}:streamRawPredict", base_url, model),
+                transformed_body,
+            )
+        } else if is_anthropic_sdk {
+            let truncated_base_url = base_url.trim_end_matches("/v1");
+            (format!("{}/{}", truncated_base_url, args.path), body)
+        } else {
+            (format!("{}/{}", base_url, args.path), body)
+        };
+
+        let mut headers = vec![("content-type".to_string(), "application/json".to_string())];
+
+        for (header_name, header_value) in args.headers.iter() {
+            if header_name.as_str().starts_with("anthropic-") {
+                if is_vertex && header_name.as_str() == "anthropic-version" {
+                    continue;
+                }
+                headers.push((
+                    header_name.as_str().to_string(),
+                    header_value
+                        .to_str()
+                        .map_err(|e| {
+                            Error::BadRequest(format!(
+                                "Invalid Anthropic header value for {}: {}",
+                                header_name, e
+                            ))
+                        })?
+                        .to_string(),
+                ));
+            }
+        }
+
+        if is_anthropic_sdk && credentials.enable_1m_context {
+            headers.push((
+                "anthropic-beta".to_string(),
+                "context-1m-2025-08-07".to_string(),
+            ));
+        }
+
+        if let Some(api_key) = credentials.api_key.as_ref() {
+            headers.push(("authorization".to_string(), format!("Bearer {}", api_key)));
+            if !is_vertex {
+                headers.push(("X-API-Key".to_string(), api_key.clone()));
+            }
+        }
+
+        if let Some(access_token) = credentials.access_token.as_ref() {
+            headers.push((
+                "authorization".to_string(),
+                format!("Bearer {}", access_token),
+            ));
+        }
+
+        if let Some(org_id) = credentials.organization_id.as_ref() {
+            headers.push(("OpenAI-Organization".to_string(), org_id.clone()));
+        }
+
+        for (header_name, header_value) in AI_HTTP_HEADERS.iter() {
+            headers.push((header_name.clone(), header_value.clone()));
+        }
+
+        for (header_name, header_value) in &credentials.custom_headers {
+            headers.push((header_name.clone(), header_value.clone()));
+        }
+
+        Ok(ProxyRequest { method: args.method.clone(), url, headers, body })
+    }
+
     async fn build_text_request(
         &self,
         args: &BuildRequestArgs<'_>,
@@ -510,6 +623,10 @@ impl QueryBuilder for AnthropicQueryBuilder {
         matches!(_output_type, OutputType::Text)
     }
 
+    fn build_proxy_request(&self, args: &ProxyBuildArgs<'_>) -> Result<ProxyRequest, Error> {
+        self.build_anthropic_proxy_request(args)
+    }
+
     async fn build_request(
         &self,
         args: &BuildRequestArgs<'_>,
@@ -605,5 +722,171 @@ impl QueryBuilder for AnthropicQueryBuilder {
             }
             headers
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        proxy::{ProviderCredentials, ProxyBuildArgs},
+        query_builder::QueryBuilder,
+    };
+    use http::{HeaderMap, HeaderValue, Method};
+    use std::collections::HashMap;
+
+    fn credentials(platform: AIPlatform) -> ProviderCredentials {
+        ProviderCredentials {
+            provider: AIProvider::Anthropic,
+            base_url: "https://api.anthropic.com/v1".to_string(),
+            api_key: Some("api-key".to_string()),
+            access_token: None,
+            organization_id: None,
+            user: None,
+            region: None,
+            aws_access_key_id: None,
+            aws_secret_access_key: None,
+            aws_session_token: None,
+            platform,
+            enable_1m_context: false,
+            custom_headers: HashMap::new(),
+        }
+    }
+
+    fn has_header(headers: &[(String, String)], name: &str, value: &str) -> bool {
+        headers
+            .iter()
+            .any(|(header_name, header_value)| header_name == name && header_value == value)
+    }
+
+    #[test]
+    fn builds_standard_anthropic_proxy_request() {
+        let credentials = credentials(AIPlatform::Standard);
+        let builder =
+            AnthropicQueryBuilder::new(AIProvider::Anthropic, AIPlatform::Standard, false);
+        let method = Method::POST;
+        let mut headers = HeaderMap::new();
+        headers.insert("anthropic-version", HeaderValue::from_static("2023-06-01"));
+        let body = br#"{"model":"claude-sonnet-4","messages":[]}"#;
+
+        let request = builder
+            .build_proxy_request(&ProxyBuildArgs {
+                method: &method,
+                path: "messages",
+                headers: &headers,
+                body,
+                credentials: &credentials,
+            })
+            .unwrap();
+
+        assert_eq!(request.method, Method::POST);
+        assert_eq!(request.url, "https://api.anthropic.com/v1/messages");
+        assert_eq!(request.body, body.to_vec());
+        assert!(has_header(
+            &request.headers,
+            "authorization",
+            "Bearer api-key"
+        ));
+        assert!(has_header(&request.headers, "X-API-Key", "api-key"));
+        assert!(has_header(
+            &request.headers,
+            "anthropic-version",
+            "2023-06-01"
+        ));
+    }
+
+    #[test]
+    fn builds_anthropic_sdk_proxy_request_with_context_beta() {
+        let mut credentials = credentials(AIPlatform::Standard);
+        credentials.enable_1m_context = true;
+        let builder = AnthropicQueryBuilder::new(AIProvider::Anthropic, AIPlatform::Standard, true);
+        let method = Method::POST;
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Anthropic-SDK", HeaderValue::from_static("typescript"));
+        let body = br#"{"model":"claude-sonnet-4","messages":[]}"#;
+
+        let request = builder
+            .build_proxy_request(&ProxyBuildArgs {
+                method: &method,
+                path: "v1/messages",
+                headers: &headers,
+                body,
+                credentials: &credentials,
+            })
+            .unwrap();
+
+        assert_eq!(request.url, "https://api.anthropic.com/v1/messages");
+        assert!(has_header(
+            &request.headers,
+            "anthropic-beta",
+            "context-1m-2025-08-07"
+        ));
+    }
+
+    #[test]
+    fn builds_vertex_anthropic_proxy_request() {
+        let mut credentials = credentials(AIPlatform::GoogleVertexAi);
+        credentials.base_url = "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/us-central1/publishers/anthropic/models".to_string();
+        credentials.user = Some("user-1".to_string());
+        let builder =
+            AnthropicQueryBuilder::new(AIProvider::Anthropic, AIPlatform::GoogleVertexAi, false);
+        let method = Method::POST;
+        let mut headers = HeaderMap::new();
+        headers.insert("anthropic-version", HeaderValue::from_static("2023-06-01"));
+        headers.insert("anthropic-beta", HeaderValue::from_static("some-beta"));
+
+        let request = builder
+            .build_proxy_request(&ProxyBuildArgs {
+                method: &method,
+                path: "messages",
+                headers: &headers,
+                body: br#"{"model":"claude-sonnet-4","messages":[]}"#,
+                credentials: &credentials,
+            })
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+
+        assert_eq!(
+            request.url,
+            "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/us-central1/publishers/anthropic/models/claude-sonnet-4:streamRawPredict"
+        );
+        assert_eq!(body["anthropic_version"], ANTHROPIC_VERSION_VERTEX);
+        assert_eq!(body["user"], "user-1");
+        assert!(body.get("model").is_none());
+        assert!(has_header(
+            &request.headers,
+            "authorization",
+            "Bearer api-key"
+        ));
+        assert!(!request
+            .headers
+            .iter()
+            .any(|(header_name, _)| header_name == "X-API-Key"));
+        assert!(!request
+            .headers
+            .iter()
+            .any(|(header_name, _)| header_name == "anthropic-version"));
+        assert!(has_header(&request.headers, "anthropic-beta", "some-beta"));
+    }
+
+    #[test]
+    fn rejects_vertex_proxy_request_without_model() {
+        let credentials = credentials(AIPlatform::GoogleVertexAi);
+        let builder =
+            AnthropicQueryBuilder::new(AIProvider::Anthropic, AIPlatform::GoogleVertexAi, false);
+        let method = Method::POST;
+        let headers = HeaderMap::new();
+
+        let err = builder
+            .build_proxy_request(&ProxyBuildArgs {
+                method: &method,
+                path: "messages",
+                headers: &headers,
+                body: br#"{"messages":[]}"#,
+                credentials: &credentials,
+            })
+            .unwrap_err();
+
+        assert!(matches!(err, Error::BadRequest(message) if message.contains("Missing 'model'")));
     }
 }

--- a/backend/windmill-ai/src/proxy.rs
+++ b/backend/windmill-ai/src/proxy.rs
@@ -60,6 +60,10 @@ pub fn supports_openai_compatible_proxy(provider: &AIProvider) -> bool {
     )
 }
 
+pub fn supports_query_builder_proxy(provider: &AIProvider) -> bool {
+    supports_openai_compatible_proxy(provider) || matches!(provider, AIProvider::Anthropic)
+}
+
 pub fn build_openai_compatible_proxy_request(args: &ProxyBuildArgs<'_>) -> Result<ProxyRequest> {
     let credentials = args.credentials;
     let body = if let Some(user) = credentials.user.as_ref() {
@@ -108,7 +112,7 @@ pub fn build_openai_compatible_proxy_request(args: &ProxyBuildArgs<'_>) -> Resul
     Ok(ProxyRequest { method: args.method.clone(), url, headers, body })
 }
 
-fn add_user_to_body(body: &[u8], user: &str) -> Result<Vec<u8>> {
+pub(crate) fn add_user_to_body(body: &[u8], user: &str) -> Result<Vec<u8>> {
     tracing::debug!("Adding user to request body");
     let mut json_body: HashMap<String, Box<RawValue>> = serde_json::from_slice(body)
         .map_err(|e| Error::internal_err(format!("Failed to parse request body: {}", e)))?;
@@ -172,6 +176,14 @@ mod tests {
         assert!(request
             .headers
             .contains(&("OpenAI-Organization".to_string(), "org-id".to_string())));
+    }
+
+    #[test]
+    fn query_builder_proxy_support_includes_anthropic() {
+        assert!(supports_query_builder_proxy(&AIProvider::OpenAI));
+        assert!(supports_query_builder_proxy(&AIProvider::Anthropic));
+        assert!(!supports_query_builder_proxy(&AIProvider::GoogleAI));
+        assert!(!supports_query_builder_proxy(&AIProvider::AWSBedrock));
     }
 
     #[test]

--- a/backend/windmill-api/src/ai.rs
+++ b/backend/windmill-api/src/ai.rs
@@ -21,7 +21,7 @@ use windmill_ai::ai_providers::{
 };
 use windmill_ai::providers::create_proxy_query_builder;
 use windmill_ai::proxy::{
-    supports_openai_compatible_proxy, ProviderCredentials, ProxyBuildArgs, ProxyRequest,
+    supports_query_builder_proxy, ProviderCredentials, ProxyBuildArgs, ProxyRequest,
 };
 use windmill_ai::utils::AI_HTTP_HEADERS;
 use windmill_audit::{audit_oss::audit_log, ActionKind};
@@ -373,7 +373,7 @@ impl AIRequestConfig {
         provider: &AIProvider,
         path: &str,
         method: Method,
-        headers: HeaderMap,
+        _headers: HeaderMap,
         body: Bytes,
     ) -> Result<RequestBuilder> {
         let credentials = self.into_provider_credentials(provider.clone());
@@ -387,30 +387,18 @@ impl AIRequestConfig {
         let base_url = credentials.base_url.trim_end_matches('/');
 
         let is_azure = credentials.provider.is_azure_openai(base_url);
-        let is_anthropic = credentials.provider == AIProvider::Anthropic;
-        let is_anthropic_vertex =
-            is_anthropic && credentials.platform == AIPlatform::GoogleVertexAi;
-        let is_anthropic_sdk = headers.get("X-Anthropic-SDK").is_some();
         let is_google_ai = credentials.provider == AIProvider::GoogleAI;
 
         let base_url = base_url.to_string();
         let base_url = base_url.as_str();
 
         // Build URL based on provider
-        let (url, body) = if is_anthropic_vertex && method != Method::GET {
-            let (model, transformed_body) = transform_anthropic_for_vertex(&body)?;
-            let vertex_url = format!("{}/{}:streamRawPredict", base_url, model);
-            (vertex_url, transformed_body)
-        } else if is_azure {
+        let url = if is_azure {
             let azure_url = AIProvider::build_azure_openai_url(base_url, path);
-            (azure_url, body)
-        } else if is_anthropic_sdk {
-            let truncated_base_url = base_url.trim_end_matches("/v1");
-            let anthropic_url = format!("{}/{}", truncated_base_url, path);
-            (anthropic_url, body)
+            azure_url
         } else {
             let default_url = format!("{}/{}", base_url, path);
-            (default_url, body)
+            default_url
         };
 
         tracing::debug!("AI request URL: {}", url);
@@ -418,21 +406,6 @@ impl AIRequestConfig {
         let mut request = HTTP_CLIENT
             .request(method.clone(), &url)
             .header("content-type", "application/json");
-
-        for (header_name, header_value) in headers.iter() {
-            // Forward anthropic-* headers, but skip anthropic-version for Vertex AI
-            // (Vertex AI requires anthropic_version in the request body, not as a header)
-            if header_name.to_string().starts_with("anthropic-") {
-                if is_anthropic_vertex && header_name.as_str() == "anthropic-version" {
-                    continue;
-                }
-                request = request.header(header_name, header_value);
-            }
-        }
-
-        if is_anthropic_sdk && credentials.enable_1m_context {
-            request = request.header("anthropic-beta", "context-1m-2025-08-07");
-        }
 
         // Add authentication headers
         if let Some(api_key) = credentials.api_key {
@@ -445,10 +418,6 @@ impl AIRequestConfig {
                 request = request.header("x-goog-api-key", api_key.clone())
             } else {
                 request = request.header("authorization", format!("Bearer {}", api_key.clone()))
-            }
-            // For standard Anthropic API, also add X-API-Key header (but not for Vertex AI)
-            if is_anthropic && !is_anthropic_vertex {
-                request = request.header("X-API-Key", api_key);
             }
         }
 
@@ -556,36 +525,6 @@ impl AIConfig {
             .as_ref()
             .is_some_and(|providers| !providers.is_empty())
     }
-}
-
-/// Anthropic API version for Google Vertex AI
-const ANTHROPIC_VERSION_VERTEX: &str = "vertex-2023-10-16";
-
-/// Transforms an Anthropic request for Google Vertex AI:
-/// - Extracts the model from the body (needed for the URL)
-/// - Adds anthropic_version to the body
-fn transform_anthropic_for_vertex(body: &Bytes) -> Result<(String, Bytes)> {
-    let mut json_body: HashMap<String, serde_json::Value> = serde_json::from_slice(body)
-        .map_err(|e| Error::internal_err(format!("Failed to parse Anthropic request: {}", e)))?;
-
-    // Extract and remove model from body
-    let model = json_body
-        .remove("model")
-        .and_then(|v| v.as_str().map(|s| s.to_string()))
-        .ok_or_else(|| {
-            Error::BadRequest("Missing 'model' field in Anthropic request".to_string())
-        })?;
-
-    // Add anthropic_version to body (required for Vertex AI)
-    json_body.insert(
-        "anthropic_version".to_string(),
-        serde_json::Value::String(ANTHROPIC_VERSION_VERTEX.to_string()),
-    );
-
-    let transformed_body = serde_json::to_vec(&json_body)
-        .map_err(|e| Error::internal_err(format!("Failed to serialize Vertex request: {}", e)))?;
-
-    Ok((model, Bytes::from(transformed_body)))
 }
 
 // FIM (Fill-in-the-Middle) simulation for providers that don't support native FIM
@@ -726,7 +665,7 @@ async fn global_proxy(
 
     let base_url = provider.get_base_url(None, &db).await?;
 
-    let request = if supports_openai_compatible_proxy(&provider) {
+    let request = if supports_query_builder_proxy(&provider) {
         let credentials = ProviderCredentials {
             provider: provider.clone(),
             base_url,
@@ -752,30 +691,11 @@ async fn global_proxy(
         })?;
         proxy_request_to_request_builder(proxy_request)
     } else {
-        let is_anthropic = provider.is_anthropic();
-        let is_anthropic_sdk = headers.get("X-Anthropic-SDK").is_some();
-
-        let url = if is_anthropic_sdk {
-            let truncated_base_url = base_url.trim_end_matches("/v1");
-            format!("{}/{}", truncated_base_url, ai_path)
-        } else {
-            format!("{}/{}", base_url, ai_path)
-        };
-
+        let url = format!("{}/{}", base_url, ai_path);
         let mut request = HTTP_CLIENT
             .request(method, url)
             .header("content-type", "application/json")
             .header("Authorization", format!("Bearer {}", &api_key));
-
-        if is_anthropic {
-            request = request.header("X-API-Key", &api_key);
-        }
-
-        for (header_name, header_value) in headers.iter() {
-            if header_name.to_string().starts_with("anthropic-") {
-                request = request.header(header_name, header_value);
-            }
-        }
 
         // Apply custom headers from AI_HTTP_HEADERS environment variable
         for (header_name, header_value) in AI_HTTP_HEADERS.iter() {
@@ -1100,7 +1020,7 @@ async fn proxy(
         ));
     }
 
-    let request = if supports_openai_compatible_proxy(&provider) {
+    let request = if supports_query_builder_proxy(&provider) {
         let credentials = request_config.into_provider_credentials(provider.clone());
         let query_builder = create_proxy_query_builder(&credentials);
         let proxy_request = query_builder.build_proxy_request(&ProxyBuildArgs {


### PR DESCRIPTION
## Summary
Move Anthropic API proxy request construction into `windmill-ai` so the API proxy uses the shared `QueryBuilder::build_proxy_request` path for Anthropic, including standard Anthropic, Anthropic SDK passthrough, and Google Vertex AI transformations.

## Changes
- Add Anthropic `build_proxy_request` support in `AnthropicQueryBuilder`.
- Add `supports_query_builder_proxy` for providers now handled by shared proxy builders.
- Route global and workspace Anthropic proxy requests through the shared query-builder proxy path.
- Remove API-side Anthropic Vertex request transformation from `AIRequestConfig::prepare_request`.
- Add unit coverage for standard Anthropic, Anthropic SDK routing, Vertex body/header transformation, and missing-model errors.

## Test plan
- [x] `cargo test -p windmill-ai anthropic` — 5 passed
- [x] `cargo test -p windmill-api maps_request_config_to_provider_credentials` — 1 passed
- [x] backend cargo-watch rebuild and healthy startup on port 8020
- [x] `cd ai_evals && set -a; source .env; set +a; WMILL_AI_EVAL_BACKEND_URL=http://127.0.0.1:8020 WMILL_AI_EVAL_BACKEND_WORKSPACE=integration-tests bun run cli -- run script script-test1-greet-user --model haiku --backend-validation preview` — pass rate 100% (1/1), judge 100, result `ai_evals/results/2026-05-19T12-05-44.621Z__script.json`
- [x] `cd ai_evals && set -a; source .env; set +a; WMILL_AI_EVAL_BACKEND_URL=http://127.0.0.1:8020 WMILL_AI_EVAL_BACKEND_WORKSPACE=integration-tests bun run cli -- run flow flow-test6-ai-agent-tools --model haiku --backend-validation preview` — pass rate 100% (1/1), judge 82, result `ai_evals/results/2026-05-19T12-06-49.291Z__flow.json`
- [x] `cd integration_tests/ai_agent_tests && set -a; source .env; set +a; WINDMILL_URL=http://127.0.0.1:8020 WINDMILL_WORKSPACE=integration-tests .venv/bin/pytest 'test_completion_params.py::TestCompletionParams::test_default_params[anthropic]' 'test_streaming.py::TestStreaming::test_streaming_enabled[anthropic]' -v -s` — 2 passed