### PR TITLE
feat: add wmill protection-rules pull/push CLI commands

### DIFF
--- a/cli/src/commands/protection-rules/converter.ts
+++ b/cli/src/commands/protection-rules/converter.ts
@@ -1,0 +1,132 @@
+import { ProtectionRuleEntry } from "../../core/conf.ts";
+import { ProtectionRuleset } from "../../../gen/types.gen.ts";
+
+// Reconciliation plan produced by diffing the wmill.yaml protection rules
+// against the backend list. `toDelete` holds names present on the backend but
+// absent from wmill.yaml (full-reconcile semantics).
+export interface ProtectionRulesPlan {
+  toCreate: ProtectionRuleEntry[];
+  toUpdate: ProtectionRuleEntry[];
+  toDelete: string[];
+  unchanged: string[];
+}
+
+function sortedUnique(arr: readonly string[]): string[] {
+  return [...new Set(arr)].sort();
+}
+
+export class ProtectionRulesConverter {
+  // Canonicalize a single rule so comparisons are insensitive to array order
+  // and duplicates.
+  static normalizeEntry(entry: ProtectionRuleEntry): ProtectionRuleEntry {
+    return {
+      name: entry.name,
+      rules: sortedUnique(entry.rules ?? []) as ProtectionRuleEntry["rules"],
+      bypass_groups: sortedUnique(entry.bypass_groups ?? []),
+      bypass_users: sortedUnique(entry.bypass_users ?? []),
+    };
+  }
+
+  // Canonicalize and sort a list of rules by name.
+  static normalizeList(
+    entries: ProtectionRuleEntry[] | undefined,
+  ): ProtectionRuleEntry[] {
+    return (entries ?? [])
+      .map((e) => ProtectionRulesConverter.normalizeEntry(e))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  // Convert a backend ProtectionRuleset response into the wmill.yaml shape
+  // (drops workspace_id, which is implied by the synced workspace).
+  static fromBackend(rulesets: ProtectionRuleset[]): ProtectionRuleEntry[] {
+    return ProtectionRulesConverter.normalizeList(
+      rulesets.map((r) => ({
+        name: r.name,
+        rules: [...(r.rules ?? [])],
+        bypass_groups: [...(r.bypass_groups ?? [])],
+        bypass_users: [...(r.bypass_users ?? [])],
+      })),
+    );
+  }
+
+  static entriesEqual(
+    a: ProtectionRuleEntry,
+    b: ProtectionRuleEntry,
+  ): boolean {
+    const na = ProtectionRulesConverter.normalizeEntry(a);
+    const nb = ProtectionRulesConverter.normalizeEntry(b);
+    return (
+      na.name === nb.name &&
+      na.rules.length === nb.rules.length &&
+      na.rules.every((v, i) => v === nb.rules[i]) &&
+      na.bypass_groups.length === nb.bypass_groups.length &&
+      na.bypass_groups.every((v, i) => v === nb.bypass_groups[i]) &&
+      na.bypass_users.length === nb.bypass_users.length &&
+      na.bypass_users.every((v, i) => v === nb.bypass_users[i])
+    );
+  }
+
+  static listsEqual(
+    a: ProtectionRuleEntry[] | undefined,
+    b: ProtectionRuleEntry[] | undefined,
+  ): boolean {
+    const na = ProtectionRulesConverter.normalizeList(a);
+    const nb = ProtectionRulesConverter.normalizeList(b);
+    if (na.length !== nb.length) return false;
+    return na.every((entry, i) =>
+      ProtectionRulesConverter.entriesEqual(entry, nb[i])
+    );
+  }
+
+  // Compute the create/update/delete plan to make `backend` match `local`.
+  static computePlan(
+    local: ProtectionRuleEntry[] | undefined,
+    backend: ProtectionRuleEntry[] | undefined,
+  ): ProtectionRulesPlan {
+    const localByName = new Map(
+      ProtectionRulesConverter.normalizeList(local).map((e) => [e.name, e]),
+    );
+    const backendByName = new Map(
+      ProtectionRulesConverter.normalizeList(backend).map((e) => [e.name, e]),
+    );
+
+    const plan: ProtectionRulesPlan = {
+      toCreate: [],
+      toUpdate: [],
+      toDelete: [],
+      unchanged: [],
+    };
+
+    for (const [name, entry] of localByName) {
+      const existing = backendByName.get(name);
+      if (!existing) {
+        plan.toCreate.push(entry);
+      } else if (!ProtectionRulesConverter.entriesEqual(entry, existing)) {
+        plan.toUpdate.push(entry);
+      } else {
+        plan.unchanged.push(name);
+      }
+    }
+
+    for (const name of backendByName.keys()) {
+      if (!localByName.has(name)) {
+        plan.toDelete.push(name);
+      }
+    }
+
+    plan.toCreate.sort((a, b) => a.name.localeCompare(b.name));
+    plan.toUpdate.sort((a, b) => a.name.localeCompare(b.name));
+    plan.toDelete.sort();
+    plan.unchanged.sort();
+
+    return plan;
+  }
+
+  static planHasChanges(plan: ProtectionRulesPlan): boolean {
+    return (
+      plan.toCreate.length > 0 ||
+      plan.toUpdate.length > 0 ||
+      plan.toDelete.length > 0
+    );
+  }
+}

--- a/cli/src/commands/protection-rules/converter.ts
+++ b/cli/src/commands/protection-rules/converter.ts
@@ -1,7 +1,7 @@
-import { ProtectionRuleEntry } from "../../core/conf.ts";
+import { ProtectionRuleEntry } from "./types.ts";
 import { ProtectionRuleset } from "../../../gen/types.gen.ts";
 
-// Reconciliation plan produced by diffing the wmill.yaml protection rules
+// Reconciliation plan produced by diffing the local protection rules
 // against the backend list. `toDelete` holds names present on the backend but
 // absent from wmill.yaml (full-reconcile semantics).
 export interface ProtectionRulesPlan {

--- a/cli/src/commands/protection-rules/file.ts
+++ b/cli/src/commands/protection-rules/file.ts
@@ -1,0 +1,107 @@
+import { existsSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { stringify as yamlStringify } from "yaml";
+
+import { yamlParseFile } from "../../utils/yaml.ts";
+import { yamlOptions } from "../sync/sync.ts";
+import {
+  SyncOptions,
+  getWmillYamlPath,
+  getWorkspaceNames,
+  getEffectiveWorkspaceId,
+  WorkspaceEntryConfig,
+} from "../../core/conf.ts";
+import { GlobalOptions } from "../../types.ts";
+import { tryResolveBranchWorkspace } from "../../core/context.ts";
+import { setClient } from "../../core/client.ts";
+import { ProtectionRulesFile } from "./types.ts";
+
+export const PROTECTION_RULES_FILENAME = "protection-rules.yaml";
+
+// protection-rules.yaml lives next to wmill.yaml. wmill.yaml is required: it is
+// the single source of truth for which workspaces exist and how to reach them.
+export function getProtectionRulesPath(): string | null {
+  const wmillPath = getWmillYamlPath();
+  if (!wmillPath) return null;
+  return join(dirname(wmillPath), PROTECTION_RULES_FILENAME);
+}
+
+export async function readProtectionRulesFile(
+  path: string,
+): Promise<ProtectionRulesFile> {
+  if (!existsSync(path)) return {};
+  const parsed = (await yamlParseFile(path)) as ProtectionRulesFile | null;
+  return parsed ?? {};
+}
+
+export async function writeProtectionRulesFile(
+  path: string,
+  data: ProtectionRulesFile,
+): Promise<void> {
+  // Deterministic key order so diffs/commits stay stable.
+  const sorted: ProtectionRulesFile = {};
+  for (const k of Object.keys(data).sort()) sorted[k] = data[k];
+  await writeFile(path, yamlStringify(sorted, yamlOptions), "utf-8");
+}
+
+// Maps a protection-rules.yaml workspace key to its backend workspace id via
+// wmill.yaml's `workspaces` block. A key with no matching entry is rejected —
+// without it we don't know which backend to talk to.
+export class WorkspaceResolver {
+  private constructor(
+    private readonly workspaces: Record<string, WorkspaceEntryConfig>,
+  ) {}
+
+  static fromConfig(config: SyncOptions): WorkspaceResolver {
+    const ws = (config.workspaces ?? {}) as Record<
+      string,
+      WorkspaceEntryConfig
+    >;
+    return new WorkspaceResolver(ws);
+  }
+
+  /** Workspace keys declared in wmill.yaml (excludes reserved keys). */
+  knownNames(): string[] {
+    return getWorkspaceNames(this.workspaces as any);
+  }
+
+  has(name: string): boolean {
+    return this.knownNames().includes(name);
+  }
+
+  /** Backend workspace id (path param) for a key, or throw if unknown. */
+  backendId(name: string): string {
+    if (!this.has(name)) {
+      throw new Error(
+        `Workspace '${name}' is not defined in wmill.yaml 'workspaces'. ` +
+          `Add it there (its keys must match protection-rules.yaml).`,
+      );
+    }
+    return getEffectiveWorkspaceId(name, this.workspaces[name]);
+  }
+}
+
+// Point the API client at the backend for a single wmill.yaml workspace key
+// (its baseUrl + the matching stored profile's token), then return the
+// backend workspace id to use as the path param. Throws a clean error if the
+// key is unknown or no profile/baseUrl resolves it — callers decide whether to
+// skip (--all) or fail (named arg).
+export async function configureClientForWorkspace(
+  opts: GlobalOptions,
+  ws: string,
+  resolver: WorkspaceResolver,
+): Promise<string> {
+  const wsId = resolver.backendId(ws); // throws if not in wmill.yaml
+  // Fresh opts so resolveWorkspace's per-call cache can't bleed across keys.
+  const resolved = await tryResolveBranchWorkspace({ ...opts }, ws);
+  if (!resolved) {
+    throw new Error(
+      `Could not resolve a profile for workspace '${ws}'. Ensure wmill.yaml ` +
+        `workspaces.${ws} has a baseUrl and you've run 'wmill workspace add' ` +
+        `for it (or pass --base-url/--token).`,
+    );
+  }
+  setClient(resolved.token, resolved.remote.replace(/\/+$/, ""));
+  return wsId;
+}

--- a/cli/src/commands/protection-rules/file.ts
+++ b/cli/src/commands/protection-rules/file.ts
@@ -82,26 +82,48 @@ export class WorkspaceResolver {
   }
 }
 
-// Point the API client at the backend for a single wmill.yaml workspace key
-// (its baseUrl + the matching stored profile's token), then return the
-// backend workspace id to use as the path param. Throws a clean error if the
-// key is unknown or no profile/baseUrl resolves it — callers decide whether to
-// skip (--all) or fail (named arg).
+// Point the API client at the backend for a single wmill.yaml workspace key,
+// then return the backend workspace id to use as the path param. The backend
+// id always comes from the wmill.yaml mapping (the feature's invariant);
+// credentials are resolved with the same precedence as every other command:
+//
+//   1. explicit --base-url + --token  -> used as-is (stateless CI; no profile
+//      or wmill.yaml baseUrl required)
+//   2. otherwise, the stored profile matching wmill.yaml workspaces.<ws>
+//      (its baseUrl + token), with an explicit --token overriding the
+//      stored token
+//
+// Throws a clean error if the key is unknown or nothing resolves it — callers
+// decide whether to skip (--all) or fail (named arg).
 export async function configureClientForWorkspace(
   opts: GlobalOptions,
   ws: string,
   resolver: WorkspaceResolver,
 ): Promise<string> {
   const wsId = resolver.backendId(ws); // throws if not in wmill.yaml
-  // Fresh opts so resolveWorkspace's per-call cache can't bleed across keys.
+
+  // 1. Explicit credentials — honor them directly, like other commands do.
+  if (opts.baseUrl) {
+    if (!opts.token) {
+      throw new Error(
+        "When --base-url is set, --token is required for protection-rules.",
+      );
+    }
+    setClient(opts.token, opts.baseUrl.replace(/\/+$/, ""));
+    return wsId;
+  }
+
+  // 2. Stored-profile resolution. Fresh opts so resolveWorkspace's per-call
+  // cache can't bleed across keys.
   const resolved = await tryResolveBranchWorkspace({ ...opts }, ws);
   if (!resolved) {
     throw new Error(
-      `Could not resolve a profile for workspace '${ws}'. Ensure wmill.yaml ` +
-        `workspaces.${ws} has a baseUrl and you've run 'wmill workspace add' ` +
-        `for it (or pass --base-url/--token).`,
+      `Could not resolve credentials for workspace '${ws}'. Either pass ` +
+        `--base-url and --token, or ensure wmill.yaml workspaces.${ws} has a ` +
+        `baseUrl and you've run 'wmill workspace add' for it.`,
     );
   }
-  setClient(resolved.token, resolved.remote.replace(/\/+$/, ""));
+  // An explicit --token overrides the stored profile's token.
+  setClient(opts.token ?? resolved.token, resolved.remote.replace(/\/+$/, ""));
   return wsId;
 }

--- a/cli/src/commands/protection-rules/index.ts
+++ b/cli/src/commands/protection-rules/index.ts
@@ -1,0 +1,2 @@
+export { pullProtectionRules, pushProtectionRules } from "./protection-rules.ts";
+export { default } from "./protection-rules.ts";

--- a/cli/src/commands/protection-rules/protection-rules.ts
+++ b/cli/src/commands/protection-rules/protection-rules.ts
@@ -4,34 +4,28 @@ import { pushProtectionRules } from "./push.ts";
 
 const command = new Command()
   .description(
-    "Manage workspace protection rules between local wmill.yaml and Windmill backend",
+    "Sync workspace protection rules between protection-rules.yaml and Windmill. " +
+      "The file is keyed by workspace name; keys must match wmill.yaml 'workspaces'.",
   )
   .command("pull")
   .description(
-    "Pull protection rules from Windmill backend into local wmill.yaml",
+    "Pull protection rules from Windmill into protection-rules.yaml for a workspace",
   )
-  .option("--default", "Write to top-level protectionRules instead of overrides")
-  .option("--replace", "Replace existing protection rules (non-interactive)")
-  .option("--override", "Add branch-specific override (non-interactive)")
-  .option("--diff", "Show differences without applying changes")
+  .arguments("[workspace:string]")
+  .option("--all", "Pull every workspace defined in wmill.yaml")
+  .option("--dry-run", "Show what would change without writing the file")
   .option("--json-output", "Output in JSON format")
-  .option("--yes", "Skip interactive prompts and use default behavior")
-  .option(
-    "--promotion <branch:string>",
-    "Use promotionOverrides from the specified branch instead of regular overrides",
-  )
   .action(pullProtectionRules as any)
   .command("push")
   .description(
-    "Push protection rules from local wmill.yaml to Windmill backend (full reconcile: creates, updates, and deletes)",
+    "Push protection rules from protection-rules.yaml to Windmill for a workspace " +
+      "(full reconcile: creates, updates, and deletes)",
   )
-  .option("--diff", "Show what would be pushed without applying changes")
+  .arguments("[workspace:string]")
+  .option("--all", "Push every workspace defined in protection-rules.yaml")
+  .option("--dry-run", "Show what would change without applying")
   .option("--json-output", "Output in JSON format")
-  .option("--yes", "Skip interactive prompts and confirmations")
-  .option(
-    "--promotion <branch:string>",
-    "Use promotionOverrides from the specified branch instead of regular overrides",
-  )
+  .option("--yes", "Skip the confirmation prompt (including deletions)")
   .action(pushProtectionRules as any);
 
 export { pullProtectionRules, pushProtectionRules };

--- a/cli/src/commands/protection-rules/protection-rules.ts
+++ b/cli/src/commands/protection-rules/protection-rules.ts
@@ -4,8 +4,7 @@ import { pushProtectionRules } from "./push.ts";
 
 const command = new Command()
   .description(
-    "Sync workspace protection rules between protection-rules.yaml and Windmill. " +
-      "The file is keyed by workspace name; keys must match wmill.yaml 'workspaces'.",
+    "Sync workspace protection rules between protection-rules.yaml and Windmill. The file is keyed by workspace name; keys must match wmill.yaml 'workspaces'.",
   )
   .command("pull")
   .description(
@@ -18,8 +17,7 @@ const command = new Command()
   .action(pullProtectionRules as any)
   .command("push")
   .description(
-    "Push protection rules from protection-rules.yaml to Windmill for a workspace " +
-      "(full reconcile: creates, updates, and deletes)",
+    "Push protection rules from protection-rules.yaml to Windmill for a workspace (full reconcile: creates, updates, and deletes)",
   )
   .arguments("[workspace:string]")
   .option("--all", "Push every workspace defined in protection-rules.yaml")

--- a/cli/src/commands/protection-rules/protection-rules.ts
+++ b/cli/src/commands/protection-rules/protection-rules.ts
@@ -1,0 +1,38 @@
+import { Command } from "@cliffy/command";
+import { pullProtectionRules } from "./pull.ts";
+import { pushProtectionRules } from "./push.ts";
+
+const command = new Command()
+  .description(
+    "Manage workspace protection rules between local wmill.yaml and Windmill backend",
+  )
+  .command("pull")
+  .description(
+    "Pull protection rules from Windmill backend into local wmill.yaml",
+  )
+  .option("--default", "Write to top-level protectionRules instead of overrides")
+  .option("--replace", "Replace existing protection rules (non-interactive)")
+  .option("--override", "Add branch-specific override (non-interactive)")
+  .option("--diff", "Show differences without applying changes")
+  .option("--json-output", "Output in JSON format")
+  .option("--yes", "Skip interactive prompts and use default behavior")
+  .option(
+    "--promotion <branch:string>",
+    "Use promotionOverrides from the specified branch instead of regular overrides",
+  )
+  .action(pullProtectionRules as any)
+  .command("push")
+  .description(
+    "Push protection rules from local wmill.yaml to Windmill backend (full reconcile: creates, updates, and deletes)",
+  )
+  .option("--diff", "Show what would be pushed without applying changes")
+  .option("--json-output", "Output in JSON format")
+  .option("--yes", "Skip interactive prompts and confirmations")
+  .option(
+    "--promotion <branch:string>",
+    "Use promotionOverrides from the specified branch instead of regular overrides",
+  )
+  .action(pushProtectionRules as any);
+
+export { pullProtectionRules, pushProtectionRules };
+export default command;

--- a/cli/src/commands/protection-rules/pull.ts
+++ b/cli/src/commands/protection-rules/pull.ts
@@ -102,9 +102,15 @@ export async function pullProtectionRules(
   if (opts.dryRun) {
     if (opts.jsonOutput) {
       console.log(
-        JSON.stringify({ success: true, dryRun: true, hasChanges: anyChange, workspaces: perWs }),
+        JSON.stringify({
+          success: !hadError,
+          dryRun: true,
+          partialFailure: hadError,
+          hasChanges: anyChange,
+          workspaces: perWs,
+        }),
       );
-    } else if (!anyChange) {
+    } else if (!hadError && !anyChange) {
       log.info(colors.green("All targeted workspaces are in sync"));
     }
     if (hadError) process.exit(1);
@@ -112,12 +118,21 @@ export async function pullProtectionRules(
   }
 
   await writeProtectionRulesFile(prPath!, file as ProtectionRulesFile);
+  const n = Object.keys(perWs).length;
+  if (hadError) {
+    // Some --all workspaces failed: status must not say success while we
+    // exit non-zero.
+    outputResult(opts, {
+      success: false,
+      error: `Pulled ${n} workspace(s) into ${PROTECTION_RULES_FILENAME}, but one or more workspaces failed (see errors above)`,
+      partialFailure: true,
+      workspaces: perWs,
+    });
+    process.exit(1);
+  }
   outputResult(opts, {
     success: true,
-    message: `Pulled protection rules for ${
-      Object.keys(perWs).length
-    } workspace(s) into ${PROTECTION_RULES_FILENAME}`,
+    message: `Pulled protection rules for ${n} workspace(s) into ${PROTECTION_RULES_FILENAME}`,
     workspaces: perWs,
   });
-  if (hadError) process.exit(1);
 }

--- a/cli/src/commands/protection-rules/pull.ts
+++ b/cli/src/commands/protection-rules/pull.ts
@@ -26,6 +26,7 @@ import {
   structuredLocalPlan,
   applyRulesToBranchOverride,
   clearRuleOverride,
+  OverrideBlock,
 } from "./utils.ts";
 
 type WriteMode = "replace" | "override";
@@ -59,6 +60,45 @@ export async function pullProtectionRules(
     const wmillYamlPath = getWmillYamlPath();
     const wmillYamlExists = wmillYamlPath !== null;
 
+    const localConfig: SyncOptions = wmillYamlExists
+      ? await readConfigFile()
+      : {};
+    const currentSettings = wmillYamlExists
+      ? await getEffectiveSettings(
+          localConfig,
+          opts.promotion,
+          true,
+          opts.jsonOutput,
+        )
+      : {};
+    const currentRules = currentSettings.protectionRules;
+
+    // Plan describes how the local file would change to match the backend.
+    const plan = ProtectionRulesConverter.computePlan(backendRules, currentRules);
+    const hasChanges = ProtectionRulesConverter.planHasChanges(plan);
+
+    // --diff is a dry run: report and return BEFORE any write (including the
+    // no-wmill.yaml bootstrap below), so it never mutates the working tree.
+    if (opts.diff) {
+      if (opts.jsonOutput) {
+        console.log(
+          JSON.stringify({
+            success: true,
+            hasChanges,
+            local: ProtectionRulesConverter.normalizeList(currentRules),
+            backend: backendRules,
+            diff: structuredLocalPlan(plan),
+          }),
+        );
+      } else if (hasChanges) {
+        log.info("Changes that would be applied locally:");
+        displayPlan(plan);
+      } else {
+        log.info(colors.green("No differences found"));
+      }
+      return;
+    }
+
     // No wmill.yaml yet: create one carrying the backend protection rules.
     if (!wmillYamlExists) {
       const newConfig: SyncOptions = { protectionRules: backendRules };
@@ -78,39 +118,6 @@ export async function pullProtectionRules(
         message: "wmill.yaml created with backend protection rules",
         count: backendRules.length,
       });
-      return;
-    }
-
-    const localConfig = await readConfigFile();
-    const currentSettings = await getEffectiveSettings(
-      localConfig,
-      opts.promotion,
-      true,
-      opts.jsonOutput,
-    );
-    const currentRules = currentSettings.protectionRules;
-
-    // Plan describes how the local file would change to match the backend.
-    const plan = ProtectionRulesConverter.computePlan(backendRules, currentRules);
-    const hasChanges = ProtectionRulesConverter.planHasChanges(plan);
-
-    if (opts.diff) {
-      if (opts.jsonOutput) {
-        console.log(
-          JSON.stringify({
-            success: true,
-            hasChanges,
-            local: ProtectionRulesConverter.normalizeList(currentRules),
-            backend: backendRules,
-            diff: structuredLocalPlan(plan),
-          }),
-        );
-      } else if (hasChanges) {
-        log.info("Changes that would be applied locally:");
-        displayPlan(plan);
-      } else {
-        log.info(colors.green("No differences found"));
-      }
       return;
     }
 
@@ -187,12 +194,25 @@ export async function pullProtectionRules(
       return;
     }
 
-    const branch = isGitRepository() ? getCurrentGitBranch() : null;
-    // The config key getEffectiveSettings would resolve for this branch may
-    // differ from the raw branch name (e.g. workspaces.prod.gitBranch=main).
-    const resolvedWsKey = branch
-      ? findWorkspaceByGitBranch(localConfig.workspaces, branch)?.[0] ?? branch
-      : null;
+    // The write target MUST match what getEffectiveSettings read above so the
+    // pulled rules are actually effective. With --promotion it read the
+    // promotion target's promotionOverrides; otherwise the current branch's
+    // resolved entry overrides. findWorkspaceByGitBranch maps a branch to its
+    // config key (which may differ, e.g. workspaces.prod.gitBranch=main).
+    let resolvedWsKey: string | null;
+    let overrideBlock: OverrideBlock;
+    if (opts.promotion) {
+      resolvedWsKey =
+        findWorkspaceByGitBranch(localConfig.workspaces, opts.promotion)?.[0] ??
+          opts.promotion;
+      overrideBlock = "promotionOverrides";
+    } else {
+      const branch = isGitRepository() ? getCurrentGitBranch() : null;
+      resolvedWsKey = branch
+        ? findWorkspaceByGitBranch(localConfig.workspaces, branch)?.[0] ?? branch
+        : null;
+      overrideBlock = "overrides";
+    }
 
     let updatedConfig: SyncOptions;
     if (writeMode === "replace") {
@@ -202,9 +222,9 @@ export async function pullProtectionRules(
         if (!(updatedConfig.workspaces as any)[resolvedWsKey]) {
           (updatedConfig.workspaces as any)[resolvedWsKey] = {};
         }
-        // A branch override would otherwise shadow the new top-level value
-        // (getEffectiveSettings applies overrides last), making replace a
-        // no-op and pull --diff loop forever.
+        // An override (regular or promotion) would otherwise shadow the new
+        // top-level value (getEffectiveSettings applies overrides last),
+        // making replace a no-op and pull --diff loop forever.
         if (clearRuleOverride(updatedConfig, resolvedWsKey)) {
           log.info(
             colors.yellow(
@@ -217,16 +237,17 @@ export async function pullProtectionRules(
       if (!resolvedWsKey) {
         fail(opts, {
           error:
-            "--override requires a git repository with a current branch. Use --replace instead.",
+            "--override requires a git repository with a current branch (or --promotion). Use --replace instead.",
         });
       }
       log.info(
-        `Writing protection rules to workspace override: ${resolvedWsKey}`,
+        `Writing protection rules to workspace '${resolvedWsKey}' ${overrideBlock}`,
       );
       updatedConfig = applyRulesToBranchOverride(
         localConfig,
         resolvedWsKey,
         backendRules,
+        overrideBlock,
       );
     }
 
@@ -239,7 +260,7 @@ export async function pullProtectionRules(
       success: true,
       message:
         writeMode === "override"
-          ? `Protection rules pulled into workspace '${resolvedWsKey}' override`
+          ? `Protection rules pulled into workspace '${resolvedWsKey}' ${overrideBlock}`
           : `Protection rules pulled into top-level configuration`,
       count: backendRules.length,
     });

--- a/cli/src/commands/protection-rules/pull.ts
+++ b/cli/src/commands/protection-rules/pull.ts
@@ -21,9 +21,11 @@ import { getCurrentGitBranch, isGitRepository } from "../../utils/git.ts";
 import { ProtectionRulesConverter } from "./converter.ts";
 import {
   outputResult,
+  fail,
   displayPlan,
   structuredLocalPlan,
   applyRulesToBranchOverride,
+  clearRuleOverride,
 } from "./utils.ts";
 
 type WriteMode = "replace" | "override";
@@ -51,11 +53,7 @@ export async function pullProtectionRules(
       backendRules = ProtectionRulesConverter.fromBackend(response);
     } catch (apiError) {
       const msg = apiError instanceof Error ? apiError.message : String(apiError);
-      outputResult(opts, {
-        success: false,
-        error: `Failed to fetch protection rules: ${msg}`,
-      });
-      return;
+      fail(opts, { error: `Failed to fetch protection rules: ${msg}` });
     }
 
     const wmillYamlPath = getWmillYamlPath();
@@ -148,13 +146,11 @@ export async function pullProtectionRules(
         ),
       );
     } else {
-      outputResult(opts, {
-        success: false,
+      fail(opts, {
         error:
           "Protection rules conflict detected. Use --replace or --override to resolve.",
         hasConflict: true,
       });
-      return;
     }
 
     if (!hasChanges) {
@@ -191,32 +187,45 @@ export async function pullProtectionRules(
       return;
     }
 
+    const branch = isGitRepository() ? getCurrentGitBranch() : null;
+    // The config key getEffectiveSettings would resolve for this branch may
+    // differ from the raw branch name (e.g. workspaces.prod.gitBranch=main).
+    const resolvedWsKey = branch
+      ? findWorkspaceByGitBranch(localConfig.workspaces, branch)?.[0] ?? branch
+      : null;
+
     let updatedConfig: SyncOptions;
     if (writeMode === "replace") {
       updatedConfig = { ...localConfig, protectionRules: backendRules };
-      if (isGitRepository()) {
-        const branch = getCurrentGitBranch();
-        if (branch) {
-          if (!updatedConfig.workspaces) updatedConfig.workspaces = {} as any;
-          if (!(updatedConfig.workspaces as any)[branch]) {
-            (updatedConfig.workspaces as any)[branch] = {};
-          }
+      if (resolvedWsKey) {
+        if (!updatedConfig.workspaces) updatedConfig.workspaces = {} as any;
+        if (!(updatedConfig.workspaces as any)[resolvedWsKey]) {
+          (updatedConfig.workspaces as any)[resolvedWsKey] = {};
+        }
+        // A branch override would otherwise shadow the new top-level value
+        // (getEffectiveSettings applies overrides last), making replace a
+        // no-op and pull --diff loop forever.
+        if (clearRuleOverride(updatedConfig, resolvedWsKey)) {
+          log.info(
+            colors.yellow(
+              `Cleared a shadowing protectionRules override on workspace '${resolvedWsKey}' so the top-level value takes effect`,
+            ),
+          );
         }
       }
     } else {
-      const branch = isGitRepository() ? getCurrentGitBranch() : null;
-      if (!branch) {
-        outputResult(opts, {
-          success: false,
+      if (!resolvedWsKey) {
+        fail(opts, {
           error:
             "--override requires a git repository with a current branch. Use --replace instead.",
         });
-        return;
       }
-      log.info(`Writing protection rules to branch override: ${branch}`);
+      log.info(
+        `Writing protection rules to workspace override: ${resolvedWsKey}`,
+      );
       updatedConfig = applyRulesToBranchOverride(
         localConfig,
-        branch,
+        resolvedWsKey,
         backendRules,
       );
     }
@@ -230,15 +239,12 @@ export async function pullProtectionRules(
       success: true,
       message:
         writeMode === "override"
-          ? `Protection rules pulled into branch override`
+          ? `Protection rules pulled into workspace '${resolvedWsKey}' override`
           : `Protection rules pulled into top-level configuration`,
       count: backendRules.length,
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    outputResult(opts, {
-      success: false,
-      error: `Failed to pull protection rules: ${msg}`,
-    });
+    fail(opts, { error: `Failed to pull protection rules: ${msg}` });
   }
 }

--- a/cli/src/commands/protection-rules/pull.ts
+++ b/cli/src/commands/protection-rules/pull.ts
@@ -1,0 +1,244 @@
+import { writeFile } from "node:fs/promises";
+import { colors } from "@cliffy/ansi/colors";
+import { stringify as yamlStringify } from "yaml";
+
+import * as log from "../../core/log.ts";
+import { GlobalOptions } from "../../types.ts";
+import { requireLogin } from "../../core/auth.ts";
+import { resolveWorkspace } from "../../core/context.ts";
+import * as wmill from "../../../gen/services.gen.ts";
+import {
+  SyncOptions,
+  ProtectionRuleEntry,
+  readConfigFile,
+  getEffectiveSettings,
+  getWmillYamlPath,
+  findWorkspaceByGitBranch,
+} from "../../core/conf.ts";
+import { yamlOptions } from "../sync/sync.ts";
+import { getCurrentGitBranch, isGitRepository } from "../../utils/git.ts";
+
+import { ProtectionRulesConverter } from "./converter.ts";
+import {
+  outputResult,
+  displayPlan,
+  structuredPlan,
+  applyRulesToBranchOverride,
+} from "./utils.ts";
+
+type WriteMode = "replace" | "override";
+
+export async function pullProtectionRules(
+  opts: GlobalOptions & {
+    default?: boolean;
+    replace?: boolean;
+    override?: boolean;
+    diff?: boolean;
+    jsonOutput?: boolean;
+    yes?: boolean;
+    promotion?: string;
+  },
+) {
+  const workspace = await resolveWorkspace(opts);
+  await requireLogin(opts);
+
+  try {
+    let backendRules: ProtectionRuleEntry[];
+    try {
+      const response = await wmill.listProtectionRules({
+        workspace: workspace.workspaceId,
+      });
+      backendRules = ProtectionRulesConverter.fromBackend(response);
+    } catch (apiError) {
+      const msg = apiError instanceof Error ? apiError.message : String(apiError);
+      outputResult(opts, {
+        success: false,
+        error: `Failed to fetch protection rules: ${msg}`,
+      });
+      return;
+    }
+
+    const wmillYamlPath = getWmillYamlPath();
+    const wmillYamlExists = wmillYamlPath !== null;
+
+    // No wmill.yaml yet: create one carrying the backend protection rules.
+    if (!wmillYamlExists) {
+      const newConfig: SyncOptions = { protectionRules: backendRules };
+      if (isGitRepository()) {
+        const branch = getCurrentGitBranch();
+        if (branch) {
+          newConfig.workspaces = { [branch]: {} } as any;
+        }
+      }
+      await writeFile(
+        "wmill.yaml",
+        yamlStringify(newConfig, yamlOptions),
+        "utf-8",
+      );
+      outputResult(opts, {
+        success: true,
+        message: "wmill.yaml created with backend protection rules",
+        count: backendRules.length,
+      });
+      return;
+    }
+
+    const localConfig = await readConfigFile();
+    const currentSettings = await getEffectiveSettings(
+      localConfig,
+      opts.promotion,
+      true,
+      opts.jsonOutput,
+    );
+    const currentRules = currentSettings.protectionRules;
+
+    // Plan describes how the local file would change to match the backend.
+    const plan = ProtectionRulesConverter.computePlan(backendRules, currentRules);
+    const hasChanges = ProtectionRulesConverter.planHasChanges(plan);
+
+    if (opts.diff) {
+      if (opts.jsonOutput) {
+        console.log(
+          JSON.stringify({
+            success: true,
+            hasChanges,
+            local: ProtectionRulesConverter.normalizeList(currentRules),
+            backend: backendRules,
+            diff: structuredPlan(plan),
+          }),
+        );
+      } else if (hasChanges) {
+        log.info("Changes that would be applied locally:");
+        displayPlan(plan);
+      } else {
+        log.info(colors.green("No differences found"));
+      }
+      return;
+    }
+
+    let writeMode: WriteMode;
+    if (opts.default || opts.replace) {
+      writeMode = "replace";
+    } else if (opts.override) {
+      writeMode = "override";
+    } else if (!hasChanges) {
+      writeMode = "replace";
+    } else if (!opts.yes && !!process.stdin.isTTY) {
+      log.info("Changes that would be applied locally:");
+      displayPlan(plan);
+      const { Select } = await import("@cliffy/prompt/select");
+      const choice = await Select.prompt({
+        message: "How would you like to write the protection rules?",
+        options: [
+          { name: "Replace top-level protection rules", value: "replace" },
+          { name: "Add branch-specific override", value: "override" },
+          { name: "Cancel", value: "cancel" },
+        ],
+      });
+      if (choice === "cancel") {
+        log.info("Operation cancelled");
+        return;
+      }
+      writeMode = choice as WriteMode;
+    } else if (opts.yes) {
+      writeMode = "override";
+      log.info(
+        colors.yellow(
+          "Conflict detected. Using --override behavior (default for --yes).",
+        ),
+      );
+    } else {
+      outputResult(opts, {
+        success: false,
+        error:
+          "Protection rules conflict detected. Use --replace or --override to resolve.",
+        hasConflict: true,
+      });
+      return;
+    }
+
+    if (!hasChanges) {
+      // Even with no changes, ensure an empty branch structure exists so
+      // overrides have a home, mirroring gitsync-settings behavior.
+      if (isGitRepository()) {
+        const branch = getCurrentGitBranch();
+        if (
+          branch &&
+          (!localConfig.workspaces ||
+            !findWorkspaceByGitBranch(localConfig.workspaces, branch))
+        ) {
+          const updated: SyncOptions = { ...localConfig };
+          if (!updated.workspaces) updated.workspaces = {} as any;
+          if (!(updated.workspaces as any)[branch]) {
+            (updated.workspaces as any)[branch] = {};
+          }
+          await writeFile(
+            "wmill.yaml",
+            yamlStringify(updated, yamlOptions),
+            "utf-8",
+          );
+          outputResult(opts, {
+            success: true,
+            message: `Created empty branch structure for: ${branch}`,
+          });
+          return;
+        }
+      }
+      outputResult(opts, {
+        success: true,
+        message: "No changes needed - protection rules are already up to date",
+      });
+      return;
+    }
+
+    let updatedConfig: SyncOptions;
+    if (writeMode === "replace") {
+      updatedConfig = { ...localConfig, protectionRules: backendRules };
+      if (isGitRepository()) {
+        const branch = getCurrentGitBranch();
+        if (branch) {
+          if (!updatedConfig.workspaces) updatedConfig.workspaces = {} as any;
+          if (!(updatedConfig.workspaces as any)[branch]) {
+            (updatedConfig.workspaces as any)[branch] = {};
+          }
+        }
+      }
+    } else {
+      const branch = isGitRepository() ? getCurrentGitBranch() : null;
+      if (!branch) {
+        outputResult(opts, {
+          success: false,
+          error:
+            "--override requires a git repository with a current branch. Use --replace instead.",
+        });
+        return;
+      }
+      log.info(`Writing protection rules to branch override: ${branch}`);
+      updatedConfig = applyRulesToBranchOverride(
+        localConfig,
+        branch,
+        backendRules,
+      );
+    }
+
+    await writeFile(
+      "wmill.yaml",
+      yamlStringify(updatedConfig, yamlOptions),
+      "utf-8",
+    );
+    outputResult(opts, {
+      success: true,
+      message:
+        writeMode === "override"
+          ? `Protection rules pulled into branch override`
+          : `Protection rules pulled into top-level configuration`,
+      count: backendRules.length,
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    outputResult(opts, {
+      success: false,
+      error: `Failed to pull protection rules: ${msg}`,
+    });
+  }
+}

--- a/cli/src/commands/protection-rules/pull.ts
+++ b/cli/src/commands/protection-rules/pull.ts
@@ -22,7 +22,7 @@ import { ProtectionRulesConverter } from "./converter.ts";
 import {
   outputResult,
   displayPlan,
-  structuredPlan,
+  structuredLocalPlan,
   applyRulesToBranchOverride,
 } from "./utils.ts";
 
@@ -104,7 +104,7 @@ export async function pullProtectionRules(
             hasChanges,
             local: ProtectionRulesConverter.normalizeList(currentRules),
             backend: backendRules,
-            diff: structuredPlan(plan),
+            diff: structuredLocalPlan(plan),
           }),
         );
       } else if (hasChanges) {

--- a/cli/src/commands/protection-rules/pull.ts
+++ b/cli/src/commands/protection-rules/pull.ts
@@ -27,6 +27,11 @@ export async function pullProtectionRules(
   opts: PullOpts,
   workspaceArg?: string,
 ) {
+  // In JSON mode stdout must be exactly one JSON payload. Silence human logs
+  // (log.info/warn → stdout) here, before anything that logs (readConfigFile,
+  // workspace resolution). log.error still goes to stderr.
+  if (opts.jsonOutput) log.setSilent(true);
+
   const prPath = getProtectionRulesPath();
   if (!prPath) {
     fail(opts, {

--- a/cli/src/commands/protection-rules/pull.ts
+++ b/cli/src/commands/protection-rules/pull.ts
@@ -1,271 +1,123 @@
-import { writeFile } from "node:fs/promises";
 import { colors } from "@cliffy/ansi/colors";
-import { stringify as yamlStringify } from "yaml";
 
 import * as log from "../../core/log.ts";
 import { GlobalOptions } from "../../types.ts";
-import { requireLogin } from "../../core/auth.ts";
-import { resolveWorkspace } from "../../core/context.ts";
 import * as wmill from "../../../gen/services.gen.ts";
-import {
-  SyncOptions,
-  ProtectionRuleEntry,
-  readConfigFile,
-  getEffectiveSettings,
-  getWmillYamlPath,
-  findWorkspaceByGitBranch,
-} from "../../core/conf.ts";
-import { yamlOptions } from "../sync/sync.ts";
-import { getCurrentGitBranch, isGitRepository } from "../../utils/git.ts";
+import { readConfigFile } from "../../core/conf.ts";
 
 import { ProtectionRulesConverter } from "./converter.ts";
+import { ProtectionRulesFile } from "./types.ts";
 import {
-  outputResult,
-  fail,
-  displayPlan,
-  structuredLocalPlan,
-  applyRulesToBranchOverride,
-  clearRuleOverride,
-  OverrideBlock,
-} from "./utils.ts";
+  PROTECTION_RULES_FILENAME,
+  getProtectionRulesPath,
+  readProtectionRulesFile,
+  writeProtectionRulesFile,
+  WorkspaceResolver,
+  configureClientForWorkspace,
+} from "./file.ts";
+import { outputResult, fail, displayPlan, structuredPlan } from "./utils.ts";
 
-type WriteMode = "replace" | "override";
+type PullOpts = GlobalOptions & {
+  all?: boolean;
+  dryRun?: boolean;
+  jsonOutput?: boolean;
+};
 
 export async function pullProtectionRules(
-  opts: GlobalOptions & {
-    default?: boolean;
-    replace?: boolean;
-    override?: boolean;
-    diff?: boolean;
-    jsonOutput?: boolean;
-    yes?: boolean;
-    promotion?: string;
-  },
+  opts: PullOpts,
+  workspaceArg?: string,
 ) {
-  const workspace = await resolveWorkspace(opts);
-  await requireLogin(opts);
+  const prPath = getProtectionRulesPath();
+  if (!prPath) {
+    fail(opts, {
+      error:
+        "No wmill.yaml found. Run 'wmill init' first — protection-rules.yaml lives next to it.",
+    });
+  }
 
-  try {
-    let backendRules: ProtectionRuleEntry[];
-    try {
-      const response = await wmill.listProtectionRules({
-        workspace: workspace.workspaceId,
+  const config = await readConfigFile();
+  const resolver = WorkspaceResolver.fromConfig(config);
+
+  let targets: string[];
+  if (opts.all) {
+    targets = resolver.knownNames();
+    if (targets.length === 0) {
+      fail(opts, {
+        error: "No workspaces defined in wmill.yaml 'workspaces' block.",
       });
-      backendRules = ProtectionRulesConverter.fromBackend(response);
-    } catch (apiError) {
-      const msg = apiError instanceof Error ? apiError.message : String(apiError);
+    }
+  } else if (workspaceArg) {
+    targets = [workspaceArg];
+  } else {
+    fail(opts, { error: "Specify a workspace name or use --all." });
+  }
+
+  const file = await readProtectionRulesFile(prPath!);
+  const perWs: Record<string, any> = {};
+  let hadError = false;
+  let anyChange = false;
+
+  for (const ws of targets) {
+    let wsId: string;
+    try {
+      wsId = await configureClientForWorkspace(opts, ws, resolver);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (opts.all) {
+        log.error(colors.red(msg));
+        hadError = true;
+        continue;
+      }
+      fail(opts, { error: msg });
+    }
+
+    let backend;
+    try {
+      backend = ProtectionRulesConverter.fromBackend(
+        await wmill.listProtectionRules({ workspace: wsId }),
+      );
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (opts.all) {
+        log.error(colors.red(`[${ws}] failed to fetch: ${msg}`));
+        hadError = true;
+        continue;
+      }
       fail(opts, { error: `Failed to fetch protection rules: ${msg}` });
     }
 
-    const wmillYamlPath = getWmillYamlPath();
-    const wmillYamlExists = wmillYamlPath !== null;
+    const current = ProtectionRulesConverter.normalizeList(file[ws]);
+    // plan describes how the local file would change to match the backend
+    const plan = ProtectionRulesConverter.computePlan(backend, current);
+    if (ProtectionRulesConverter.planHasChanges(plan)) anyChange = true;
+    perWs[ws] = structuredPlan(plan);
 
-    const localConfig: SyncOptions = wmillYamlExists
-      ? await readConfigFile()
-      : {};
-    const currentSettings = wmillYamlExists
-      ? await getEffectiveSettings(
-          localConfig,
-          opts.promotion,
-          true,
-          opts.jsonOutput,
-        )
-      : {};
-    const currentRules = currentSettings.protectionRules;
-
-    // Plan describes how the local file would change to match the backend.
-    const plan = ProtectionRulesConverter.computePlan(backendRules, currentRules);
-    const hasChanges = ProtectionRulesConverter.planHasChanges(plan);
-
-    // --diff is a dry run: report and return BEFORE any write (including the
-    // no-wmill.yaml bootstrap below), so it never mutates the working tree.
-    if (opts.diff) {
-      if (opts.jsonOutput) {
-        console.log(
-          JSON.stringify({
-            success: true,
-            hasChanges,
-            local: ProtectionRulesConverter.normalizeList(currentRules),
-            backend: backendRules,
-            diff: structuredLocalPlan(plan),
-          }),
-        );
-      } else if (hasChanges) {
-        log.info("Changes that would be applied locally:");
-        displayPlan(plan);
-      } else {
-        log.info(colors.green("No differences found"));
-      }
-      return;
+    if (!opts.dryRun) {
+      file[ws] = backend;
+    } else if (!opts.jsonOutput) {
+      displayPlan(ws, plan);
     }
-
-    // No wmill.yaml yet: create one carrying the backend protection rules.
-    if (!wmillYamlExists) {
-      const newConfig: SyncOptions = { protectionRules: backendRules };
-      if (isGitRepository()) {
-        const branch = getCurrentGitBranch();
-        if (branch) {
-          newConfig.workspaces = { [branch]: {} } as any;
-        }
-      }
-      await writeFile(
-        "wmill.yaml",
-        yamlStringify(newConfig, yamlOptions),
-        "utf-8",
-      );
-      outputResult(opts, {
-        success: true,
-        message: "wmill.yaml created with backend protection rules",
-        count: backendRules.length,
-      });
-      return;
-    }
-
-    let writeMode: WriteMode;
-    if (opts.default || opts.replace) {
-      writeMode = "replace";
-    } else if (opts.override) {
-      writeMode = "override";
-    } else if (!hasChanges) {
-      writeMode = "replace";
-    } else if (!opts.yes && !!process.stdin.isTTY) {
-      log.info("Changes that would be applied locally:");
-      displayPlan(plan);
-      const { Select } = await import("@cliffy/prompt/select");
-      const choice = await Select.prompt({
-        message: "How would you like to write the protection rules?",
-        options: [
-          { name: "Replace top-level protection rules", value: "replace" },
-          { name: "Add branch-specific override", value: "override" },
-          { name: "Cancel", value: "cancel" },
-        ],
-      });
-      if (choice === "cancel") {
-        log.info("Operation cancelled");
-        return;
-      }
-      writeMode = choice as WriteMode;
-    } else if (opts.yes) {
-      writeMode = "override";
-      log.info(
-        colors.yellow(
-          "Conflict detected. Using --override behavior (default for --yes).",
-        ),
-      );
-    } else {
-      fail(opts, {
-        error:
-          "Protection rules conflict detected. Use --replace or --override to resolve.",
-        hasConflict: true,
-      });
-    }
-
-    if (!hasChanges) {
-      // Even with no changes, ensure an empty branch structure exists so
-      // overrides have a home, mirroring gitsync-settings behavior.
-      if (isGitRepository()) {
-        const branch = getCurrentGitBranch();
-        if (
-          branch &&
-          (!localConfig.workspaces ||
-            !findWorkspaceByGitBranch(localConfig.workspaces, branch))
-        ) {
-          const updated: SyncOptions = { ...localConfig };
-          if (!updated.workspaces) updated.workspaces = {} as any;
-          if (!(updated.workspaces as any)[branch]) {
-            (updated.workspaces as any)[branch] = {};
-          }
-          await writeFile(
-            "wmill.yaml",
-            yamlStringify(updated, yamlOptions),
-            "utf-8",
-          );
-          outputResult(opts, {
-            success: true,
-            message: `Created empty branch structure for: ${branch}`,
-          });
-          return;
-        }
-      }
-      outputResult(opts, {
-        success: true,
-        message: "No changes needed - protection rules are already up to date",
-      });
-      return;
-    }
-
-    // The write target MUST match what getEffectiveSettings read above so the
-    // pulled rules are actually effective. With --promotion it read the
-    // promotion target's promotionOverrides; otherwise the current branch's
-    // resolved entry overrides. findWorkspaceByGitBranch maps a branch to its
-    // config key (which may differ, e.g. workspaces.prod.gitBranch=main).
-    let resolvedWsKey: string | null;
-    let overrideBlock: OverrideBlock;
-    if (opts.promotion) {
-      resolvedWsKey =
-        findWorkspaceByGitBranch(localConfig.workspaces, opts.promotion)?.[0] ??
-          opts.promotion;
-      overrideBlock = "promotionOverrides";
-    } else {
-      const branch = isGitRepository() ? getCurrentGitBranch() : null;
-      resolvedWsKey = branch
-        ? findWorkspaceByGitBranch(localConfig.workspaces, branch)?.[0] ?? branch
-        : null;
-      overrideBlock = "overrides";
-    }
-
-    let updatedConfig: SyncOptions;
-    if (writeMode === "replace") {
-      updatedConfig = { ...localConfig, protectionRules: backendRules };
-      if (resolvedWsKey) {
-        if (!updatedConfig.workspaces) updatedConfig.workspaces = {} as any;
-        if (!(updatedConfig.workspaces as any)[resolvedWsKey]) {
-          (updatedConfig.workspaces as any)[resolvedWsKey] = {};
-        }
-        // An override (regular or promotion) would otherwise shadow the new
-        // top-level value (getEffectiveSettings applies overrides last),
-        // making replace a no-op and pull --diff loop forever.
-        if (clearRuleOverride(updatedConfig, resolvedWsKey)) {
-          log.info(
-            colors.yellow(
-              `Cleared a shadowing protectionRules override on workspace '${resolvedWsKey}' so the top-level value takes effect`,
-            ),
-          );
-        }
-      }
-    } else {
-      if (!resolvedWsKey) {
-        fail(opts, {
-          error:
-            "--override requires a git repository with a current branch (or --promotion). Use --replace instead.",
-        });
-      }
-      log.info(
-        `Writing protection rules to workspace '${resolvedWsKey}' ${overrideBlock}`,
-      );
-      updatedConfig = applyRulesToBranchOverride(
-        localConfig,
-        resolvedWsKey,
-        backendRules,
-        overrideBlock,
-      );
-    }
-
-    await writeFile(
-      "wmill.yaml",
-      yamlStringify(updatedConfig, yamlOptions),
-      "utf-8",
-    );
-    outputResult(opts, {
-      success: true,
-      message:
-        writeMode === "override"
-          ? `Protection rules pulled into workspace '${resolvedWsKey}' ${overrideBlock}`
-          : `Protection rules pulled into top-level configuration`,
-      count: backendRules.length,
-    });
-  } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    fail(opts, { error: `Failed to pull protection rules: ${msg}` });
   }
+
+  if (opts.dryRun) {
+    if (opts.jsonOutput) {
+      console.log(
+        JSON.stringify({ success: true, dryRun: true, hasChanges: anyChange, workspaces: perWs }),
+      );
+    } else if (!anyChange) {
+      log.info(colors.green("All targeted workspaces are in sync"));
+    }
+    if (hadError) process.exit(1);
+    return;
+  }
+
+  await writeProtectionRulesFile(prPath!, file as ProtectionRulesFile);
+  outputResult(opts, {
+    success: true,
+    message: `Pulled protection rules for ${
+      Object.keys(perWs).length
+    } workspace(s) into ${PROTECTION_RULES_FILENAME}`,
+    workspaces: perWs,
+  });
+  if (hadError) process.exit(1);
 }

--- a/cli/src/commands/protection-rules/push.ts
+++ b/cli/src/commands/protection-rules/push.ts
@@ -36,6 +36,11 @@ export async function pushProtectionRules(
   opts: PushOpts,
   workspaceArg?: string,
 ) {
+  // In JSON mode stdout must be exactly one JSON payload. Silence human logs
+  // (log.info/warn → stdout, incl. workspace resolution + the empty-list
+  // delete warning) before anything logs. log.error still goes to stderr.
+  if (opts.jsonOutput) log.setSilent(true);
+
   const prPath = getProtectionRulesPath();
   if (!prPath) {
     fail(opts, {

--- a/cli/src/commands/protection-rules/push.ts
+++ b/cli/src/commands/protection-rules/push.ts
@@ -120,8 +120,9 @@ export async function pushProtectionRules(
   if (opts.jsonOutput && opts.dryRun) {
     console.log(
       JSON.stringify({
-        success: true,
+        success: !hadError,
         dryRun: true,
+        partialFailure: hadError,
         hasChanges: changed.length > 0,
         workspaces: Object.fromEntries(
           wsPlans.map((w) => [w.ws, structuredPlan(w.plan)]),
@@ -137,13 +138,23 @@ export async function pushProtectionRules(
   }
 
   if (changed.length === 0) {
+    if (hadError) {
+      // A workspace failed to resolve/fetch — don't claim success while
+      // exiting non-zero.
+      outputResult(opts, {
+        success: false,
+        error:
+          "One or more workspaces failed (see errors above); the rest are in sync",
+        partialFailure: true,
+      });
+      process.exit(1);
+    }
     if (!opts.dryRun) {
       outputResult(opts, {
         success: true,
         message: "No changes to push - all targeted workspaces are in sync",
       });
     }
-    if (hadError) process.exit(1);
     return;
   }
 
@@ -227,10 +238,20 @@ export async function pushProtectionRules(
     });
   }
 
+  if (hadError) {
+    // Reconcile of resolvable workspaces succeeded, but some --all targets
+    // failed earlier. Status must reflect the non-zero exit.
+    outputResult(opts, {
+      success: false,
+      error: `Pushed (created ${applied.created}, updated ${applied.updated}, deleted ${applied.deleted}) across ${changed.length} workspace(s), but one or more workspaces failed (see errors above)`,
+      partialFailure: true,
+      ...applied,
+    });
+    process.exit(1);
+  }
   outputResult(opts, {
     success: true,
     message: `Pushed protection rules (created ${applied.created}, updated ${applied.updated}, deleted ${applied.deleted}) across ${changed.length} workspace(s)`,
     ...applied,
   });
-  if (hadError) process.exit(1);
 }

--- a/cli/src/commands/protection-rules/push.ts
+++ b/cli/src/commands/protection-rules/push.ts
@@ -1,0 +1,181 @@
+import process from "node:process";
+
+import { colors } from "@cliffy/ansi/colors";
+import { Confirm } from "@cliffy/prompt/confirm";
+
+import * as log from "../../core/log.ts";
+import { GlobalOptions } from "../../types.ts";
+import { requireLogin } from "../../core/auth.ts";
+import { resolveWorkspace } from "../../core/context.ts";
+import * as wmill from "../../../gen/services.gen.ts";
+import {
+  ProtectionRuleEntry,
+  readConfigFile,
+  validateBranchConfiguration,
+  getEffectiveSettings,
+  getWmillYamlPath,
+} from "../../core/conf.ts";
+
+import { ProtectionRulesConverter } from "./converter.ts";
+import { outputResult, displayPlan, structuredPlan } from "./utils.ts";
+
+export async function pushProtectionRules(
+  opts: GlobalOptions & {
+    diff?: boolean;
+    jsonOutput?: boolean;
+    yes?: boolean;
+    promotion?: string;
+  },
+) {
+  try {
+    await validateBranchConfiguration({ yes: opts.yes });
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("overrides")) {
+      log.error(error.message);
+      process.exit(1);
+    }
+    throw error;
+  }
+
+  const workspace = await resolveWorkspace(opts);
+  await requireLogin(opts);
+
+  try {
+    const wmillYamlPath = getWmillYamlPath();
+    if (!wmillYamlPath) {
+      outputResult(opts, {
+        success: false,
+        error:
+          "No wmill.yaml file found. Run 'wmill protection-rules pull' or 'wmill init' first.",
+      });
+      process.exit(1);
+    }
+
+    const localConfig = await readConfigFile();
+    const effectiveSettings = await getEffectiveSettings(
+      localConfig,
+      opts.promotion,
+      true,
+      opts.jsonOutput,
+    );
+    const localRules: ProtectionRuleEntry[] | undefined =
+      effectiveSettings.protectionRules;
+
+    if (localRules === undefined) {
+      outputResult(opts, {
+        success: false,
+        error:
+          "No protectionRules defined in wmill.yaml. Nothing to push (use 'pull' first to seed them).",
+      });
+      return;
+    }
+
+    let backendRules: ProtectionRuleEntry[];
+    try {
+      const response = await wmill.listProtectionRules({
+        workspace: workspace.workspaceId,
+      });
+      backendRules = ProtectionRulesConverter.fromBackend(response);
+    } catch (apiError) {
+      const msg = apiError instanceof Error ? apiError.message : String(apiError);
+      outputResult(opts, {
+        success: false,
+        error: `Failed to fetch protection rules: ${msg}`,
+      });
+      return;
+    }
+
+    // Full reconcile: backend must end up matching wmill.yaml exactly.
+    const plan = ProtectionRulesConverter.computePlan(localRules, backendRules);
+    const hasChanges = ProtectionRulesConverter.planHasChanges(plan);
+
+    if (opts.diff) {
+      if (opts.jsonOutput) {
+        console.log(
+          JSON.stringify({
+            success: true,
+            hasChanges,
+            local: ProtectionRulesConverter.normalizeList(localRules),
+            backend: backendRules,
+            diff: structuredPlan(plan),
+          }),
+        );
+      } else if (hasChanges) {
+        log.info("Changes that would be pushed to Windmill:");
+        displayPlan(plan);
+      } else {
+        log.info(colors.green("No changes to push"));
+      }
+      return;
+    }
+
+    if (!hasChanges) {
+      outputResult(opts, {
+        success: true,
+        message: "No changes to push - protection rules are already in sync",
+      });
+      return;
+    }
+
+    if (!opts.jsonOutput) {
+      log.info("Changes that would be pushed to Windmill:");
+      displayPlan(plan);
+    }
+
+    if (!opts.yes && !!process.stdin.isTTY) {
+      const confirmed = await Confirm.prompt({
+        message: plan.toDelete.length > 0
+          ? `This will DELETE ${plan.toDelete.length} protection rule(s) on the backend. Continue?`
+          : `Apply these changes to the remote?`,
+        default: plan.toDelete.length === 0,
+      });
+      if (!confirmed) {
+        log.info("Operation cancelled");
+        return;
+      }
+    }
+
+    const ws = workspace.workspaceId;
+    for (const entry of plan.toCreate) {
+      const n = ProtectionRulesConverter.normalizeEntry(entry);
+      await wmill.createProtectionRule({
+        workspace: ws,
+        requestBody: {
+          name: n.name,
+          rules: n.rules,
+          bypass_groups: n.bypass_groups,
+          bypass_users: n.bypass_users,
+        },
+      });
+    }
+    for (const entry of plan.toUpdate) {
+      const n = ProtectionRulesConverter.normalizeEntry(entry);
+      await wmill.updateProtectionRule({
+        workspace: ws,
+        ruleName: n.name,
+        requestBody: {
+          rules: n.rules,
+          bypass_groups: n.bypass_groups,
+          bypass_users: n.bypass_users,
+        },
+      });
+    }
+    for (const name of plan.toDelete) {
+      await wmill.deleteProtectionRule({ workspace: ws, ruleName: name });
+    }
+
+    outputResult(opts, {
+      success: true,
+      message: `Protection rules pushed successfully (created ${plan.toCreate.length}, updated ${plan.toUpdate.length}, deleted ${plan.toDelete.length})`,
+      created: plan.toCreate.length,
+      updated: plan.toUpdate.length,
+      deleted: plan.toDelete.length,
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    outputResult(opts, {
+      success: false,
+      error: `Failed to push protection rules: ${msg}`,
+    });
+  }
+}

--- a/cli/src/commands/protection-rules/push.ts
+++ b/cli/src/commands/protection-rules/push.ts
@@ -1,154 +1,192 @@
 import process from "node:process";
+import { existsSync } from "node:fs";
 
 import { colors } from "@cliffy/ansi/colors";
 import { Confirm } from "@cliffy/prompt/confirm";
 
 import * as log from "../../core/log.ts";
 import { GlobalOptions } from "../../types.ts";
-import { requireLogin } from "../../core/auth.ts";
-import { resolveWorkspace } from "../../core/context.ts";
 import * as wmill from "../../../gen/services.gen.ts";
-import {
-  ProtectionRuleEntry,
-  readConfigFile,
-  validateBranchConfiguration,
-  getEffectiveSettings,
-  getWmillYamlPath,
-} from "../../core/conf.ts";
+import { readConfigFile } from "../../core/conf.ts";
 
-import { ProtectionRulesConverter } from "./converter.ts";
+import { ProtectionRulesConverter, ProtectionRulesPlan } from "./converter.ts";
+import {
+  getProtectionRulesPath,
+  readProtectionRulesFile,
+  WorkspaceResolver,
+  configureClientForWorkspace,
+} from "./file.ts";
 import { outputResult, fail, displayPlan, structuredPlan } from "./utils.ts";
 
+type PushOpts = GlobalOptions & {
+  all?: boolean;
+  dryRun?: boolean;
+  jsonOutput?: boolean;
+  yes?: boolean;
+};
+
+interface WsPlan {
+  ws: string;
+  wsId: string;
+  plan: ProtectionRulesPlan;
+  wipesAll: boolean;
+}
+
 export async function pushProtectionRules(
-  opts: GlobalOptions & {
-    diff?: boolean;
-    jsonOutput?: boolean;
-    yes?: boolean;
-    promotion?: string;
-  },
+  opts: PushOpts,
+  workspaceArg?: string,
 ) {
-  try {
-    await validateBranchConfiguration({ yes: opts.yes });
-  } catch (error) {
-    if (error instanceof Error && error.message.includes("overrides")) {
-      log.error(error.message);
-      process.exit(1);
-    }
-    throw error;
+  const prPath = getProtectionRulesPath();
+  if (!prPath) {
+    fail(opts, {
+      error:
+        "No wmill.yaml found. Run 'wmill init' first — protection-rules.yaml lives next to it.",
+    });
+  }
+  if (!existsSync(prPath!)) {
+    fail(opts, {
+      error:
+        "No protection-rules.yaml found. Run 'wmill protection-rules pull' first.",
+    });
   }
 
-  const workspace = await resolveWorkspace(opts);
-  await requireLogin(opts);
+  const config = await readConfigFile();
+  const resolver = WorkspaceResolver.fromConfig(config);
+  const file = await readProtectionRulesFile(prPath!);
 
-  try {
-    const wmillYamlPath = getWmillYamlPath();
-    if (!wmillYamlPath) {
+  let targets: string[];
+  if (opts.all) {
+    targets = Object.keys(file).sort();
+    if (targets.length === 0) {
+      fail(opts, { error: "protection-rules.yaml defines no workspaces." });
+    }
+  } else if (workspaceArg) {
+    if (!(workspaceArg in file)) {
       fail(opts, {
-        error:
-          "No wmill.yaml file found. Run 'wmill protection-rules pull' or 'wmill init' first.",
+        error: `Workspace '${workspaceArg}' is not defined in protection-rules.yaml.`,
       });
     }
+    targets = [workspaceArg];
+  } else {
+    fail(opts, { error: "Specify a workspace name or use --all." });
+  }
 
-    const localConfig = await readConfigFile();
-    const effectiveSettings = await getEffectiveSettings(
-      localConfig,
-      opts.promotion,
-      true,
-      opts.jsonOutput,
-    );
-    const localRules: ProtectionRuleEntry[] | undefined =
-      effectiveSettings.protectionRules;
-
-    if (localRules === undefined) {
-      fail(opts, {
-        error:
-          "No protectionRules defined in wmill.yaml. Nothing to push (use 'pull' first to seed them).",
-      });
-    }
-
-    let backendRules: ProtectionRuleEntry[];
+  // Phase 1: resolve + diff every target before mutating anything.
+  const wsPlans: WsPlan[] = [];
+  let hadError = false;
+  for (const ws of targets) {
+    let wsId: string;
     try {
-      const response = await wmill.listProtectionRules({
-        workspace: workspace.workspaceId,
-      });
-      backendRules = ProtectionRulesConverter.fromBackend(response);
-    } catch (apiError) {
-      const msg = apiError instanceof Error ? apiError.message : String(apiError);
+      wsId = await configureClientForWorkspace(opts, ws, resolver);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (opts.all) {
+        log.error(colors.red(msg));
+        hadError = true;
+        continue;
+      }
+      fail(opts, { error: msg });
+    }
+
+    let backend;
+    try {
+      backend = ProtectionRulesConverter.fromBackend(
+        await wmill.listProtectionRules({ workspace: wsId }),
+      );
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (opts.all) {
+        log.error(colors.red(`[${ws}] failed to fetch: ${msg}`));
+        hadError = true;
+        continue;
+      }
       fail(opts, { error: `Failed to fetch protection rules: ${msg}` });
     }
 
-    // Full reconcile: backend must end up matching wmill.yaml exactly.
-    const plan = ProtectionRulesConverter.computePlan(localRules, backendRules);
-    const hasChanges = ProtectionRulesConverter.planHasChanges(plan);
+    const local = ProtectionRulesConverter.normalizeList(file[ws]);
+    const plan = ProtectionRulesConverter.computePlan(local, backend);
+    wsPlans.push({
+      ws,
+      wsId,
+      plan,
+      wipesAll: local.length === 0 && plan.toDelete.length > 0,
+    });
+  }
 
-    if (opts.diff) {
-      if (opts.jsonOutput) {
-        console.log(
-          JSON.stringify({
-            success: true,
-            hasChanges,
-            local: ProtectionRulesConverter.normalizeList(localRules),
-            backend: backendRules,
-            diff: structuredPlan(plan),
-          }),
-        );
-      } else if (hasChanges) {
-        log.info("Changes that would be pushed to Windmill:");
-        displayPlan(plan);
-      } else {
-        log.info(colors.green("No changes to push"));
-      }
-      return;
-    }
+  const changed = wsPlans.filter((w) =>
+    ProtectionRulesConverter.planHasChanges(w.plan)
+  );
 
-    if (!hasChanges) {
+  if (opts.jsonOutput && opts.dryRun) {
+    console.log(
+      JSON.stringify({
+        success: true,
+        dryRun: true,
+        hasChanges: changed.length > 0,
+        workspaces: Object.fromEntries(
+          wsPlans.map((w) => [w.ws, structuredPlan(w.plan)]),
+        ),
+      }),
+    );
+    if (hadError) process.exit(1);
+    return;
+  }
+
+  if (!opts.jsonOutput) {
+    for (const w of wsPlans) displayPlan(w.ws, w.plan);
+  }
+
+  if (changed.length === 0) {
+    if (!opts.dryRun) {
       outputResult(opts, {
         success: true,
-        message: "No changes to push - protection rules are already in sync",
+        message: "No changes to push - all targeted workspaces are in sync",
       });
-      return;
     }
+    if (hadError) process.exit(1);
+    return;
+  }
 
-    if (!opts.jsonOutput) {
-      log.info("Changes that would be pushed to Windmill:");
-      displayPlan(plan);
-    }
+  if (opts.dryRun) {
+    if (hadError) process.exit(1);
+    return;
+  }
 
-    // Pushing an empty protectionRules wipes every backend rule under
-    // full-reconcile semantics — loud about it even in --yes/non-TTY runs.
-    const wipesAll =
-      localRules.length === 0 && plan.toDelete.length > 0;
-    if (wipesAll) {
+  // Pushing an empty list wipes a workspace's rules — be loud even with --yes.
+  for (const w of wsPlans) {
+    if (w.wipesAll) {
       log.warn(
         colors.red(
-          `WARNING: wmill.yaml defines an empty protectionRules list — this will DELETE ALL ${plan.toDelete.length} protection rule(s) on the backend.`,
+          `WARNING: '${w.ws}' has an empty rule list — this DELETES ALL ${w.plan.toDelete.length} backend rule(s) for that workspace.`,
         ),
       );
     }
+  }
 
-    if (!opts.yes && !!process.stdin.isTTY) {
-      const confirmed = await Confirm.prompt({
-        message: plan.toDelete.length > 0
-          ? `This will DELETE ${plan.toDelete.length} protection rule(s) on the backend. Continue?`
-          : `Apply these changes to the remote?`,
-        default: plan.toDelete.length === 0,
-      });
-      if (!confirmed) {
-        log.info("Operation cancelled");
-        return;
-      }
+  const totalDeletes = changed.reduce((n, w) => n + w.plan.toDelete.length, 0);
+  if (!opts.yes && !!process.stdin.isTTY) {
+    const confirmed = await Confirm.prompt({
+      message: totalDeletes > 0
+        ? `Apply these changes? This DELETES ${totalDeletes} protection rule(s) across ${changed.length} workspace(s).`
+        : `Apply these changes to ${changed.length} workspace(s)?`,
+      default: totalDeletes === 0,
+    });
+    if (!confirmed) {
+      log.info("Operation cancelled");
+      return;
     }
+  }
 
-    // The reconcile is N independent API calls with no transaction. Track
-    // applied ops so a mid-loop failure reports how far it got (the backend
-    // is left partially reconciled; re-running push is idempotent).
-    const ws = workspace.workspaceId;
-    const applied = { created: 0, updated: 0, deleted: 0 };
-    try {
-      for (const entry of plan.toCreate) {
+  // Phase 2: apply. Track progress so a mid-run failure reports how far it got.
+  const applied = { created: 0, updated: 0, deleted: 0 };
+  try {
+    for (const w of changed) {
+      // Re-point the client at this workspace (phase 1 left it on the last one).
+      await configureClientForWorkspace(opts, w.ws, resolver);
+      for (const entry of w.plan.toCreate) {
         const n = ProtectionRulesConverter.normalizeEntry(entry);
         await wmill.createProtectionRule({
-          workspace: ws,
+          workspace: w.wsId,
           requestBody: {
             name: n.name,
             rules: n.rules,
@@ -158,10 +196,10 @@ export async function pushProtectionRules(
         });
         applied.created++;
       }
-      for (const entry of plan.toUpdate) {
+      for (const entry of w.plan.toUpdate) {
         const n = ProtectionRulesConverter.normalizeEntry(entry);
         await wmill.updateProtectionRule({
-          workspace: ws,
+          workspace: w.wsId,
           ruleName: n.name,
           requestBody: {
             rules: n.rules,
@@ -171,31 +209,28 @@ export async function pushProtectionRules(
         });
         applied.updated++;
       }
-      for (const name of plan.toDelete) {
-        await wmill.deleteProtectionRule({ workspace: ws, ruleName: name });
+      for (const name of w.plan.toDelete) {
+        await wmill.deleteProtectionRule({
+          workspace: w.wsId,
+          ruleName: name,
+        });
         applied.deleted++;
       }
-    } catch (applyError) {
-      const msg =
-        applyError instanceof Error ? applyError.message : String(applyError);
-      fail(opts, {
-        error:
-          `Push partially failed after applying ${applied.created}/${plan.toCreate.length} create, ` +
-          `${applied.updated}/${plan.toUpdate.length} update, ${applied.deleted}/${plan.toDelete.length} delete: ${msg}. ` +
-          `The backend is partially reconciled; re-run push to converge.`,
-        applied,
-      });
     }
-
-    outputResult(opts, {
-      success: true,
-      message: `Protection rules pushed successfully (created ${applied.created}, updated ${applied.updated}, deleted ${applied.deleted})`,
-      created: applied.created,
-      updated: applied.updated,
-      deleted: applied.deleted,
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    fail(opts, {
+      error:
+        `Push partially failed after ${applied.created} create, ${applied.updated} update, ` +
+        `${applied.deleted} delete: ${msg}. Backend is partially reconciled; re-run push to converge.`,
+      applied,
     });
-  } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    fail(opts, { error: `Failed to push protection rules: ${msg}` });
   }
+
+  outputResult(opts, {
+    success: true,
+    message: `Pushed protection rules (created ${applied.created}, updated ${applied.updated}, deleted ${applied.deleted}) across ${changed.length} workspace(s)`,
+    ...applied,
+  });
+  if (hadError) process.exit(1);
 }

--- a/cli/src/commands/protection-rules/push.ts
+++ b/cli/src/commands/protection-rules/push.ts
@@ -17,7 +17,7 @@ import {
 } from "../../core/conf.ts";
 
 import { ProtectionRulesConverter } from "./converter.ts";
-import { outputResult, displayPlan, structuredPlan } from "./utils.ts";
+import { outputResult, fail, displayPlan, structuredPlan } from "./utils.ts";
 
 export async function pushProtectionRules(
   opts: GlobalOptions & {
@@ -43,12 +43,10 @@ export async function pushProtectionRules(
   try {
     const wmillYamlPath = getWmillYamlPath();
     if (!wmillYamlPath) {
-      outputResult(opts, {
-        success: false,
+      fail(opts, {
         error:
           "No wmill.yaml file found. Run 'wmill protection-rules pull' or 'wmill init' first.",
       });
-      process.exit(1);
     }
 
     const localConfig = await readConfigFile();
@@ -62,12 +60,10 @@ export async function pushProtectionRules(
       effectiveSettings.protectionRules;
 
     if (localRules === undefined) {
-      outputResult(opts, {
-        success: false,
+      fail(opts, {
         error:
           "No protectionRules defined in wmill.yaml. Nothing to push (use 'pull' first to seed them).",
       });
-      return;
     }
 
     let backendRules: ProtectionRuleEntry[];
@@ -78,11 +74,7 @@ export async function pushProtectionRules(
       backendRules = ProtectionRulesConverter.fromBackend(response);
     } catch (apiError) {
       const msg = apiError instanceof Error ? apiError.message : String(apiError);
-      outputResult(opts, {
-        success: false,
-        error: `Failed to fetch protection rules: ${msg}`,
-      });
-      return;
+      fail(opts, { error: `Failed to fetch protection rules: ${msg}` });
     }
 
     // Full reconcile: backend must end up matching wmill.yaml exactly.
@@ -122,6 +114,18 @@ export async function pushProtectionRules(
       displayPlan(plan);
     }
 
+    // Pushing an empty protectionRules wipes every backend rule under
+    // full-reconcile semantics — loud about it even in --yes/non-TTY runs.
+    const wipesAll =
+      localRules.length === 0 && plan.toDelete.length > 0;
+    if (wipesAll) {
+      log.warn(
+        colors.red(
+          `WARNING: wmill.yaml defines an empty protectionRules list — this will DELETE ALL ${plan.toDelete.length} protection rule(s) on the backend.`,
+        ),
+      );
+    }
+
     if (!opts.yes && !!process.stdin.isTTY) {
       const confirmed = await Confirm.prompt({
         message: plan.toDelete.length > 0
@@ -135,47 +139,63 @@ export async function pushProtectionRules(
       }
     }
 
+    // The reconcile is N independent API calls with no transaction. Track
+    // applied ops so a mid-loop failure reports how far it got (the backend
+    // is left partially reconciled; re-running push is idempotent).
     const ws = workspace.workspaceId;
-    for (const entry of plan.toCreate) {
-      const n = ProtectionRulesConverter.normalizeEntry(entry);
-      await wmill.createProtectionRule({
-        workspace: ws,
-        requestBody: {
-          name: n.name,
-          rules: n.rules,
-          bypass_groups: n.bypass_groups,
-          bypass_users: n.bypass_users,
-        },
+    const applied = { created: 0, updated: 0, deleted: 0 };
+    try {
+      for (const entry of plan.toCreate) {
+        const n = ProtectionRulesConverter.normalizeEntry(entry);
+        await wmill.createProtectionRule({
+          workspace: ws,
+          requestBody: {
+            name: n.name,
+            rules: n.rules,
+            bypass_groups: n.bypass_groups,
+            bypass_users: n.bypass_users,
+          },
+        });
+        applied.created++;
+      }
+      for (const entry of plan.toUpdate) {
+        const n = ProtectionRulesConverter.normalizeEntry(entry);
+        await wmill.updateProtectionRule({
+          workspace: ws,
+          ruleName: n.name,
+          requestBody: {
+            rules: n.rules,
+            bypass_groups: n.bypass_groups,
+            bypass_users: n.bypass_users,
+          },
+        });
+        applied.updated++;
+      }
+      for (const name of plan.toDelete) {
+        await wmill.deleteProtectionRule({ workspace: ws, ruleName: name });
+        applied.deleted++;
+      }
+    } catch (applyError) {
+      const msg =
+        applyError instanceof Error ? applyError.message : String(applyError);
+      fail(opts, {
+        error:
+          `Push partially failed after applying ${applied.created}/${plan.toCreate.length} create, ` +
+          `${applied.updated}/${plan.toUpdate.length} update, ${applied.deleted}/${plan.toDelete.length} delete: ${msg}. ` +
+          `The backend is partially reconciled; re-run push to converge.`,
+        applied,
       });
-    }
-    for (const entry of plan.toUpdate) {
-      const n = ProtectionRulesConverter.normalizeEntry(entry);
-      await wmill.updateProtectionRule({
-        workspace: ws,
-        ruleName: n.name,
-        requestBody: {
-          rules: n.rules,
-          bypass_groups: n.bypass_groups,
-          bypass_users: n.bypass_users,
-        },
-      });
-    }
-    for (const name of plan.toDelete) {
-      await wmill.deleteProtectionRule({ workspace: ws, ruleName: name });
     }
 
     outputResult(opts, {
       success: true,
-      message: `Protection rules pushed successfully (created ${plan.toCreate.length}, updated ${plan.toUpdate.length}, deleted ${plan.toDelete.length})`,
-      created: plan.toCreate.length,
-      updated: plan.toUpdate.length,
-      deleted: plan.toDelete.length,
+      message: `Protection rules pushed successfully (created ${applied.created}, updated ${applied.updated}, deleted ${applied.deleted})`,
+      created: applied.created,
+      updated: applied.updated,
+      deleted: applied.deleted,
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    outputResult(opts, {
-      success: false,
-      error: `Failed to push protection rules: ${msg}`,
-    });
+    fail(opts, { error: `Failed to push protection rules: ${msg}` });
   }
 }

--- a/cli/src/commands/protection-rules/types.ts
+++ b/cli/src/commands/protection-rules/types.ts
@@ -1,0 +1,18 @@
+import { ProtectionRuleKind } from "../../../gen/types.gen.ts";
+
+export type { ProtectionRuleKind };
+
+// A single workspace protection ruleset as stored in protection-rules.yaml.
+// Mirrors the backend ProtectionRuleset shape minus workspace_id (the workspace
+// is the map key).
+export interface ProtectionRuleEntry {
+  name: string;
+  rules: ProtectionRuleKind[];
+  bypass_groups: string[];
+  bypass_users: string[];
+}
+
+// protection-rules.yaml is a flat map: workspace name -> its protection rules.
+// Workspace names MUST match keys in wmill.yaml's `workspaces` block, which is
+// where the backend workspaceId/remote is resolved from.
+export type ProtectionRulesFile = Record<string, ProtectionRuleEntry[]>;

--- a/cli/src/commands/protection-rules/utils.ts
+++ b/cli/src/commands/protection-rules/utils.ts
@@ -85,16 +85,19 @@ export function structuredLocalPlan(plan: ProtectionRulesPlan) {
   };
 }
 
+export type OverrideBlock = "overrides" | "promotionOverrides";
+
 // Write protectionRules into a workspace entry's override block, creating the
 // entry if needed. `wsKey` MUST be the resolved workspace-config key (the key
-// getEffectiveSettings/findWorkspaceByGitBranch would select for the current
-// branch) — NOT the raw git branch name. Writing under the raw branch when a
-// differently-named entry maps to it (e.g. workspaces.prod.gitBranch=main)
-// would leave the override inert.
+// getEffectiveSettings/findWorkspaceByGitBranch would select) — NOT the raw
+// git branch name. `block` MUST match the block getEffectiveSettings reads for
+// the same invocation: `promotionOverrides` when --promotion is used,
+// `overrides` otherwise. A mismatch leaves the written rules inert.
 export function applyRulesToBranchOverride(
   config: SyncOptions,
   wsKey: string,
   rules: ProtectionRuleEntry[],
+  block: OverrideBlock = "overrides",
 ): SyncOptions {
   const updated: SyncOptions = { ...config };
   if (!updated.workspaces) {
@@ -104,10 +107,10 @@ export function applyRulesToBranchOverride(
     (updated.workspaces as any)[wsKey] = {};
   }
   const entry = (updated.workspaces as any)[wsKey];
-  if (!entry.overrides) {
-    entry.overrides = {};
+  if (!entry[block]) {
+    entry[block] = {};
   }
-  entry.overrides.protectionRules = rules;
+  entry[block].protectionRules = rules;
   return updated;
 }
 

--- a/cli/src/commands/protection-rules/utils.ts
+++ b/cli/src/commands/protection-rules/utils.ts
@@ -1,3 +1,5 @@
+import process from "node:process";
+
 import { colors } from "@cliffy/ansi/colors";
 import * as log from "../../core/log.ts";
 import { ProtectionRuleEntry, SyncOptions } from "../../core/conf.ts";
@@ -19,6 +21,17 @@ export function outputResult(
   } else if (!result.success && result.error) {
     log.error(colors.red(result.error));
   }
+}
+
+// Report a genuine failure and exit non-zero so CI / scripted callers detect
+// it. outputResult alone only logs, which would let `--yes` pushes mask a
+// failed (possibly partial) reconcile behind exit code 0.
+export function fail(
+  opts: { jsonOutput?: boolean },
+  result: { error: string; [key: string]: any },
+): never {
+  outputResult(opts, { ...result, success: false });
+  process.exit(1);
 }
 
 function describeEntry(entry: ProtectionRuleEntry): string {
@@ -72,25 +85,47 @@ export function structuredLocalPlan(plan: ProtectionRulesPlan) {
   };
 }
 
-// Write protectionRules into a branch/workspace override block, creating the
-// workspace entry if needed. Mirrors the override mechanics used by
-// gitsync-settings but scoped to the single protectionRules field.
+// Write protectionRules into a workspace entry's override block, creating the
+// entry if needed. `wsKey` MUST be the resolved workspace-config key (the key
+// getEffectiveSettings/findWorkspaceByGitBranch would select for the current
+// branch) — NOT the raw git branch name. Writing under the raw branch when a
+// differently-named entry maps to it (e.g. workspaces.prod.gitBranch=main)
+// would leave the override inert.
 export function applyRulesToBranchOverride(
   config: SyncOptions,
-  branchName: string,
+  wsKey: string,
   rules: ProtectionRuleEntry[],
 ): SyncOptions {
   const updated: SyncOptions = { ...config };
   if (!updated.workspaces) {
     updated.workspaces = {} as any;
   }
-  if (!(updated.workspaces as any)[branchName]) {
-    (updated.workspaces as any)[branchName] = {};
+  if (!(updated.workspaces as any)[wsKey]) {
+    (updated.workspaces as any)[wsKey] = {};
   }
-  const entry = (updated.workspaces as any)[branchName];
+  const entry = (updated.workspaces as any)[wsKey];
   if (!entry.overrides) {
     entry.overrides = {};
   }
   entry.overrides.protectionRules = rules;
   return updated;
+}
+
+// Remove any protectionRules override (regular + promotion) on a workspace
+// entry so a top-level protectionRules value is no longer shadowed by it.
+// Returns true if anything was cleared.
+export function clearRuleOverride(
+  config: SyncOptions,
+  wsKey: string,
+): boolean {
+  const entry = (config.workspaces as any)?.[wsKey];
+  if (!entry) return false;
+  let cleared = false;
+  for (const block of ["overrides", "promotionOverrides"] as const) {
+    if (entry[block] && "protectionRules" in entry[block]) {
+      delete entry[block].protectionRules;
+      cleared = true;
+    }
+  }
+  return cleared;
 }

--- a/cli/src/commands/protection-rules/utils.ts
+++ b/cli/src/commands/protection-rules/utils.ts
@@ -50,11 +50,24 @@ export function displayPlan(plan: ProtectionRulesPlan): void {
   }
 }
 
+// push direction: the plan describes operations applied to the backend.
 export function structuredPlan(plan: ProtectionRulesPlan) {
   return {
     create: plan.toCreate.map((e) => e.name),
     update: plan.toUpdate.map((e) => e.name),
     delete: plan.toDelete,
+    unchanged: plan.unchanged,
+  };
+}
+
+// pull direction: the plan describes how the local wmill.yaml would change.
+// Keys are named for the local-file delta to avoid ambiguity with the
+// conventional create/delete framing used by push.
+export function structuredLocalPlan(plan: ProtectionRulesPlan) {
+  return {
+    addedLocally: plan.toCreate.map((e) => e.name),
+    updatedLocally: plan.toUpdate.map((e) => e.name),
+    removedLocally: plan.toDelete,
     unchanged: plan.unchanged,
   };
 }

--- a/cli/src/commands/protection-rules/utils.ts
+++ b/cli/src/commands/protection-rules/utils.ts
@@ -1,0 +1,83 @@
+import { colors } from "@cliffy/ansi/colors";
+import * as log from "../../core/log.ts";
+import { ProtectionRuleEntry, SyncOptions } from "../../core/conf.ts";
+import { ProtectionRulesConverter, ProtectionRulesPlan } from "./converter.ts";
+
+export function outputResult(
+  opts: { jsonOutput?: boolean },
+  result: {
+    success: boolean;
+    message?: string;
+    error?: string;
+    [key: string]: any;
+  },
+): void {
+  if (opts.jsonOutput) {
+    console.log(JSON.stringify(result));
+  } else if (result.success && result.message) {
+    log.info(colors.green(result.message));
+  } else if (!result.success && result.error) {
+    log.error(colors.red(result.error));
+  }
+}
+
+function describeEntry(entry: ProtectionRuleEntry): string {
+  const n = ProtectionRulesConverter.normalizeEntry(entry);
+  const parts = [`rules=[${n.rules.join(", ")}]`];
+  if (n.bypass_groups.length > 0) {
+    parts.push(`bypass_groups=[${n.bypass_groups.join(", ")}]`);
+  }
+  if (n.bypass_users.length > 0) {
+    parts.push(`bypass_users=[${n.bypass_users.join(", ")}]`);
+  }
+  return parts.join(" ");
+}
+
+// Render a reconciliation plan. `verb` differs by direction:
+// pull applies changes locally, push applies them to the backend.
+export function displayPlan(plan: ProtectionRulesPlan): void {
+  for (const e of plan.toCreate) {
+    log.info(colors.green(`  + ${e.name}  (${describeEntry(e)})`));
+  }
+  for (const e of plan.toUpdate) {
+    log.info(colors.yellow(`  ~ ${e.name}  (${describeEntry(e)})`));
+  }
+  for (const name of plan.toDelete) {
+    log.info(colors.red(`  - ${name}`));
+  }
+  if (!ProtectionRulesConverter.planHasChanges(plan)) {
+    log.info(colors.green("  No differences found"));
+  }
+}
+
+export function structuredPlan(plan: ProtectionRulesPlan) {
+  return {
+    create: plan.toCreate.map((e) => e.name),
+    update: plan.toUpdate.map((e) => e.name),
+    delete: plan.toDelete,
+    unchanged: plan.unchanged,
+  };
+}
+
+// Write protectionRules into a branch/workspace override block, creating the
+// workspace entry if needed. Mirrors the override mechanics used by
+// gitsync-settings but scoped to the single protectionRules field.
+export function applyRulesToBranchOverride(
+  config: SyncOptions,
+  branchName: string,
+  rules: ProtectionRuleEntry[],
+): SyncOptions {
+  const updated: SyncOptions = { ...config };
+  if (!updated.workspaces) {
+    updated.workspaces = {} as any;
+  }
+  if (!(updated.workspaces as any)[branchName]) {
+    (updated.workspaces as any)[branchName] = {};
+  }
+  const entry = (updated.workspaces as any)[branchName];
+  if (!entry.overrides) {
+    entry.overrides = {};
+  }
+  entry.overrides.protectionRules = rules;
+  return updated;
+}

--- a/cli/src/commands/protection-rules/utils.ts
+++ b/cli/src/commands/protection-rules/utils.ts
@@ -2,7 +2,7 @@ import process from "node:process";
 
 import { colors } from "@cliffy/ansi/colors";
 import * as log from "../../core/log.ts";
-import { ProtectionRuleEntry, SyncOptions } from "../../core/conf.ts";
+import { ProtectionRuleEntry } from "./types.ts";
 import { ProtectionRulesConverter, ProtectionRulesPlan } from "./converter.ts";
 
 export function outputResult(
@@ -24,8 +24,8 @@ export function outputResult(
 }
 
 // Report a genuine failure and exit non-zero so CI / scripted callers detect
-// it. outputResult alone only logs, which would let `--yes` pushes mask a
-// failed (possibly partial) reconcile behind exit code 0.
+// it. outputResult alone only logs, which would let a failed (possibly
+// partial) reconcile hide behind exit code 0.
 export function fail(
   opts: { jsonOutput?: boolean },
   result: { error: string; [key: string]: any },
@@ -46,9 +46,9 @@ function describeEntry(entry: ProtectionRuleEntry): string {
   return parts.join(" ");
 }
 
-// Render a reconciliation plan. `verb` differs by direction:
-// pull applies changes locally, push applies them to the backend.
-export function displayPlan(plan: ProtectionRulesPlan): void {
+// Render a reconciliation plan with a per-workspace heading.
+export function displayPlan(ws: string, plan: ProtectionRulesPlan): void {
+  log.info(colors.bold(`workspace ${ws}:`));
   for (const e of plan.toCreate) {
     log.info(colors.green(`  + ${e.name}  (${describeEntry(e)})`));
   }
@@ -59,11 +59,10 @@ export function displayPlan(plan: ProtectionRulesPlan): void {
     log.info(colors.red(`  - ${name}`));
   }
   if (!ProtectionRulesConverter.planHasChanges(plan)) {
-    log.info(colors.green("  No differences found"));
+    log.info(colors.green("  in sync"));
   }
 }
 
-// push direction: the plan describes operations applied to the backend.
 export function structuredPlan(plan: ProtectionRulesPlan) {
   return {
     create: plan.toCreate.map((e) => e.name),
@@ -71,64 +70,4 @@ export function structuredPlan(plan: ProtectionRulesPlan) {
     delete: plan.toDelete,
     unchanged: plan.unchanged,
   };
-}
-
-// pull direction: the plan describes how the local wmill.yaml would change.
-// Keys are named for the local-file delta to avoid ambiguity with the
-// conventional create/delete framing used by push.
-export function structuredLocalPlan(plan: ProtectionRulesPlan) {
-  return {
-    addedLocally: plan.toCreate.map((e) => e.name),
-    updatedLocally: plan.toUpdate.map((e) => e.name),
-    removedLocally: plan.toDelete,
-    unchanged: plan.unchanged,
-  };
-}
-
-export type OverrideBlock = "overrides" | "promotionOverrides";
-
-// Write protectionRules into a workspace entry's override block, creating the
-// entry if needed. `wsKey` MUST be the resolved workspace-config key (the key
-// getEffectiveSettings/findWorkspaceByGitBranch would select) — NOT the raw
-// git branch name. `block` MUST match the block getEffectiveSettings reads for
-// the same invocation: `promotionOverrides` when --promotion is used,
-// `overrides` otherwise. A mismatch leaves the written rules inert.
-export function applyRulesToBranchOverride(
-  config: SyncOptions,
-  wsKey: string,
-  rules: ProtectionRuleEntry[],
-  block: OverrideBlock = "overrides",
-): SyncOptions {
-  const updated: SyncOptions = { ...config };
-  if (!updated.workspaces) {
-    updated.workspaces = {} as any;
-  }
-  if (!(updated.workspaces as any)[wsKey]) {
-    (updated.workspaces as any)[wsKey] = {};
-  }
-  const entry = (updated.workspaces as any)[wsKey];
-  if (!entry[block]) {
-    entry[block] = {};
-  }
-  entry[block].protectionRules = rules;
-  return updated;
-}
-
-// Remove any protectionRules override (regular + promotion) on a workspace
-// entry so a top-level protectionRules value is no longer shadowed by it.
-// Returns true if anything was cleared.
-export function clearRuleOverride(
-  config: SyncOptions,
-  wsKey: string,
-): boolean {
-  const entry = (config.workspaces as any)?.[wsKey];
-  if (!entry) return false;
-  let cleared = false;
-  for (const block of ["overrides", "promotionOverrides"] as const) {
-    if (entry[block] && "protectionRules" in entry[block]) {
-      delete entry[block].protectionRules;
-      cleared = true;
-    }
-  }
-  return cleared;
 }

--- a/cli/src/core/conf.ts
+++ b/cli/src/core/conf.ts
@@ -12,9 +12,6 @@ import { existsSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { execSync } from "node:child_process";
 import { setNonDottedPaths } from "../utils/resource_folders.ts";
-import type { ProtectionRuleKind } from "../../gen/types.gen.ts";
-
-export type { ProtectionRuleKind };
 
 export let showDiffs = false;
 export function setShowDiffs(value: boolean) {
@@ -98,7 +95,6 @@ export interface SyncOptions {
   excludes?: string[];
   defaultTs?: "bun" | "deno";
   codebases?: Codebase[];
-  protectionRules?: ProtectionRuleEntry[];
   parallel?: number;
   jsonOutput?: boolean;
   nonDottedPaths?: boolean;
@@ -112,16 +108,6 @@ export interface SyncOptions {
   lint?: boolean;
   locksRequired?: boolean;
   syncBehavior?: string;
-}
-
-// A single workspace protection ruleset, as stored in wmill.yaml.
-// Mirrors the backend ProtectionRuleset shape (sans workspace_id, which is
-// implied by the synced workspace).
-export interface ProtectionRuleEntry {
-  name: string;
-  rules: ProtectionRuleKind[];
-  bypass_groups: string[];
-  bypass_users: string[];
 }
 
 export interface Codebase {

--- a/cli/src/core/conf.ts
+++ b/cli/src/core/conf.ts
@@ -12,6 +12,9 @@ import { existsSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { execSync } from "node:child_process";
 import { setNonDottedPaths } from "../utils/resource_folders.ts";
+import type { ProtectionRuleKind } from "../../gen/types.gen.ts";
+
+export type { ProtectionRuleKind };
 
 export let showDiffs = false;
 export function setShowDiffs(value: boolean) {
@@ -95,6 +98,7 @@ export interface SyncOptions {
   excludes?: string[];
   defaultTs?: "bun" | "deno";
   codebases?: Codebase[];
+  protectionRules?: ProtectionRuleEntry[];
   parallel?: number;
   jsonOutput?: boolean;
   nonDottedPaths?: boolean;
@@ -108,6 +112,16 @@ export interface SyncOptions {
   lint?: boolean;
   locksRequired?: boolean;
   syncBehavior?: string;
+}
+
+// A single workspace protection ruleset, as stored in wmill.yaml.
+// Mirrors the backend ProtectionRuleset shape (sans workspace_id, which is
+// implied by the synced workspace).
+export interface ProtectionRuleEntry {
+  name: string;
+  rules: ProtectionRuleKind[];
+  bypass_groups: string[];
+  bypass_users: string[];
 }
 
 export interface Codebase {

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -6952,7 +6952,7 @@ Validate Windmill flow, schedule, and trigger YAML files in a directory
   - \`--all\` - Pull every workspace defined in wmill.yaml
   - \`--dry-run\` - Show what would change without writing the file
   - \`--json-output\` - Output in JSON format
-- \`protection-rules push [workspace:string]\`
+- \`protection-rules push [workspace:string]\` - Push protection rules from protection-rules.yaml to Windmill for a workspace (full reconcile: creates, updates, and deletes)
   - \`--all\` - Push every workspace defined in protection-rules.yaml
   - \`--dry-run\` - Show what would change without applying
   - \`--json-output\` - Output in JSON format

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -6946,23 +6946,17 @@ Validate Windmill flow, schedule, and trigger YAML files in a directory
 
 ### protection-rules
 
-Manage workspace protection rules between local wmill.yaml and Windmill backend
-
 **Subcommands:**
 
-- \`protection-rules pull\` - Pull protection rules from Windmill backend into local wmill.yaml
-  - \`--default\` - Write to top-level protectionRules instead of overrides
-  - \`--replace\` - Replace existing protection rules (non-interactive)
-  - \`--override\` - Add branch-specific override (non-interactive)
-  - \`--diff\` - Show differences without applying changes
+- \`protection-rules pull [workspace:string]\` - Pull protection rules from Windmill into protection-rules.yaml for a workspace
+  - \`--all\` - Pull every workspace defined in wmill.yaml
+  - \`--dry-run\` - Show what would change without writing the file
   - \`--json-output\` - Output in JSON format
-  - \`--yes\` - Skip interactive prompts and use default behavior
-  - \`--promotion <branch:string>\` - Use promotionOverrides from the specified branch instead of regular overrides
-- \`protection-rules push\` - Push protection rules from local wmill.yaml to Windmill backend (full reconcile: creates, updates, and deletes)
-  - \`--diff\` - Show what would be pushed without applying changes
+- \`protection-rules push [workspace:string]\`
+  - \`--all\` - Push every workspace defined in protection-rules.yaml
+  - \`--dry-run\` - Show what would change without applying
   - \`--json-output\` - Output in JSON format
-  - \`--yes\` - Skip interactive prompts and confirmations
-  - \`--promotion <branch:string>\` - Use promotionOverrides from the specified branch instead of regular overrides
+  - \`--yes\` - Skip the confirmation prompt (including deletions)
 
 ### queues
 

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -6944,6 +6944,26 @@ Validate Windmill flow, schedule, and trigger YAML files in a directory
 - \`--locks-required\` - Fail if scripts or flow inline scripts that need locks have no locks
 - \`-w, --watch\` - Watch for file changes and re-lint automatically
 
+### protection-rules
+
+Manage workspace protection rules between local wmill.yaml and Windmill backend
+
+**Subcommands:**
+
+- \`protection-rules pull\` - Pull protection rules from Windmill backend into local wmill.yaml
+  - \`--default\` - Write to top-level protectionRules instead of overrides
+  - \`--replace\` - Replace existing protection rules (non-interactive)
+  - \`--override\` - Add branch-specific override (non-interactive)
+  - \`--diff\` - Show differences without applying changes
+  - \`--json-output\` - Output in JSON format
+  - \`--yes\` - Skip interactive prompts and use default behavior
+  - \`--promotion <branch:string>\` - Use promotionOverrides from the specified branch instead of regular overrides
+- \`protection-rules push\` - Push protection rules from local wmill.yaml to Windmill backend (full reconcile: creates, updates, and deletes)
+  - \`--diff\` - Show what would be pushed without applying changes
+  - \`--json-output\` - Output in JSON format
+  - \`--yes\` - Skip interactive prompts and confirmations
+  - \`--promotion <branch:string>\` - Use promotionOverrides from the specified branch instead of regular overrides
+
 ### queues
 
 List all queues with their metrics

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -21,6 +21,7 @@ import schedule from "./commands/schedule/schedule.ts";
 import trigger from "./commands/trigger/trigger.ts";
 import sync from "./commands/sync/sync.ts";
 import gitsyncSettings from "./commands/gitsync-settings/gitsync-settings.ts";
+import protectionRules from "./commands/protection-rules/protection-rules.ts";
 import instance from "./commands/instance/instance.ts";
 import workerGroups from "./commands/worker-groups/worker-groups.ts";
 import lint from "./commands/lint/lint.ts";
@@ -65,6 +66,7 @@ export {
   sync,
   lint,
   gitsyncSettings,
+  protectionRules,
   instance,
   dev,
   docs,
@@ -185,6 +187,7 @@ const command = new Command()
   .command("sync", sync)
   .command("lint", lint)
   .command("gitsync-settings", gitsyncSettings)
+  .command("protection-rules", protectionRules)
   .command("instance", instance)
   .command("worker-groups", workerGroups)
   .command("workers", workers)

--- a/cli/test/protection_rules_converter_unit.test.ts
+++ b/cli/test/protection_rules_converter_unit.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for ProtectionRulesConverter.
+ * Covers normalization, order-insensitive equality, and the
+ * create/update/delete reconciliation plan used by pull/push.
+ */
+
+import { expect, test, describe } from "bun:test";
+import { ProtectionRulesConverter } from "../src/commands/protection-rules/converter.ts";
+import { ProtectionRuleEntry } from "../src/core/conf.ts";
+
+const rule = (
+  name: string,
+  rules: ProtectionRuleEntry["rules"],
+  groups: string[] = [],
+  users: string[] = [],
+): ProtectionRuleEntry => ({
+  name,
+  rules,
+  bypass_groups: groups,
+  bypass_users: users,
+});
+
+describe("normalizeEntry", () => {
+  test("sorts and dedupes rules, groups, users", () => {
+    const r = rule(
+      "prod",
+      ["RestrictDeployToDeployers", "DisableDirectDeployment", "DisableDirectDeployment"],
+      ["g/b", "g/a"],
+      ["u/y", "u/x", "u/x"],
+    );
+    const n = ProtectionRulesConverter.normalizeEntry(r);
+    expect(n.rules).toEqual([
+      "DisableDirectDeployment",
+      "RestrictDeployToDeployers",
+    ]);
+    expect(n.bypass_groups).toEqual(["g/a", "g/b"]);
+    expect(n.bypass_users).toEqual(["u/x", "u/y"]);
+  });
+
+  test("handles missing arrays", () => {
+    const n = ProtectionRulesConverter.normalizeEntry({
+      name: "x",
+    } as unknown as ProtectionRuleEntry);
+    expect(n.rules).toEqual([]);
+    expect(n.bypass_groups).toEqual([]);
+    expect(n.bypass_users).toEqual([]);
+  });
+});
+
+describe("entriesEqual", () => {
+  test("equal regardless of array order", () => {
+    const a = rule("p", ["DisableDirectDeployment", "DisableWorkspaceForking"], ["g/a", "g/b"]);
+    const b = rule("p", ["DisableWorkspaceForking", "DisableDirectDeployment"], ["g/b", "g/a"]);
+    expect(ProtectionRulesConverter.entriesEqual(a, b)).toBe(true);
+  });
+
+  test("different rules are not equal", () => {
+    const a = rule("p", ["DisableDirectDeployment"]);
+    const b = rule("p", ["DisableWorkspaceForking"]);
+    expect(ProtectionRulesConverter.entriesEqual(a, b)).toBe(false);
+  });
+
+  test("different bypass users are not equal", () => {
+    const a = rule("p", ["DisableDirectDeployment"], [], ["u/a"]);
+    const b = rule("p", ["DisableDirectDeployment"], [], ["u/b"]);
+    expect(ProtectionRulesConverter.entriesEqual(a, b)).toBe(false);
+  });
+});
+
+describe("fromBackend", () => {
+  test("strips workspace_id and normalizes", () => {
+    const out = ProtectionRulesConverter.fromBackend([
+      {
+        name: "p",
+        workspace_id: "ws1",
+        rules: ["DisableWorkspaceForking", "DisableDirectDeployment"],
+        bypass_groups: ["g/b", "g/a"],
+        bypass_users: [],
+      },
+    ]);
+    expect(out).toEqual([
+      {
+        name: "p",
+        rules: ["DisableDirectDeployment", "DisableWorkspaceForking"],
+        bypass_groups: ["g/a", "g/b"],
+        bypass_users: [],
+      },
+    ]);
+  });
+});
+
+describe("listsEqual", () => {
+  test("equal regardless of list order", () => {
+    const a = [rule("a", ["DisableDirectDeployment"]), rule("b", ["DisableWorkspaceForking"])];
+    const b = [rule("b", ["DisableWorkspaceForking"]), rule("a", ["DisableDirectDeployment"])];
+    expect(ProtectionRulesConverter.listsEqual(a, b)).toBe(true);
+  });
+
+  test("undefined equals empty", () => {
+    expect(ProtectionRulesConverter.listsEqual(undefined, [])).toBe(true);
+  });
+
+  test("different length not equal", () => {
+    expect(
+      ProtectionRulesConverter.listsEqual([rule("a", [])], []),
+    ).toBe(false);
+  });
+});
+
+describe("computePlan (full reconcile)", () => {
+  test("creates rules present locally but not on backend", () => {
+    const plan = ProtectionRulesConverter.computePlan(
+      [rule("new", ["DisableDirectDeployment"])],
+      [],
+    );
+    expect(plan.toCreate.map((e) => e.name)).toEqual(["new"]);
+    expect(plan.toUpdate).toEqual([]);
+    expect(plan.toDelete).toEqual([]);
+  });
+
+  test("deletes backend rules not present locally", () => {
+    const plan = ProtectionRulesConverter.computePlan(
+      [],
+      [rule("stale", ["DisableDirectDeployment"])],
+    );
+    expect(plan.toDelete).toEqual(["stale"]);
+    expect(plan.toCreate).toEqual([]);
+  });
+
+  test("updates rules whose content changed", () => {
+    const plan = ProtectionRulesConverter.computePlan(
+      [rule("p", ["DisableDirectDeployment", "DisableWorkspaceForking"])],
+      [rule("p", ["DisableDirectDeployment"])],
+    );
+    expect(plan.toUpdate.map((e) => e.name)).toEqual(["p"]);
+    expect(plan.toCreate).toEqual([]);
+    expect(plan.toDelete).toEqual([]);
+  });
+
+  test("unchanged rules are not in create/update/delete", () => {
+    const same = [rule("p", ["DisableDirectDeployment"], ["g/a"])];
+    const plan = ProtectionRulesConverter.computePlan(same, [
+      rule("p", ["DisableDirectDeployment"], ["g/a"]),
+    ]);
+    expect(ProtectionRulesConverter.planHasChanges(plan)).toBe(false);
+    expect(plan.unchanged).toEqual(["p"]);
+  });
+
+  test("mixed plan: create + update + delete + unchanged", () => {
+    const local = [
+      rule("keep", ["DisableDirectDeployment"]),
+      rule("change", ["DisableWorkspaceForking"]),
+      rule("brand-new", ["RestrictDeployToDeployers"]),
+    ];
+    const backend = [
+      rule("keep", ["DisableDirectDeployment"]),
+      rule("change", ["DisableDirectDeployment"]),
+      rule("gone", ["DisableDirectDeployment"]),
+    ];
+    const plan = ProtectionRulesConverter.computePlan(local, backend);
+    expect(plan.toCreate.map((e) => e.name)).toEqual(["brand-new"]);
+    expect(plan.toUpdate.map((e) => e.name)).toEqual(["change"]);
+    expect(plan.toDelete).toEqual(["gone"]);
+    expect(plan.unchanged).toEqual(["keep"]);
+    expect(ProtectionRulesConverter.planHasChanges(plan)).toBe(true);
+  });
+
+  test("reordered arrays do not produce spurious updates", () => {
+    const plan = ProtectionRulesConverter.computePlan(
+      [rule("p", ["DisableWorkspaceForking", "DisableDirectDeployment"], ["g/b", "g/a"])],
+      [rule("p", ["DisableDirectDeployment", "DisableWorkspaceForking"], ["g/a", "g/b"])],
+    );
+    expect(ProtectionRulesConverter.planHasChanges(plan)).toBe(false);
+  });
+});

--- a/cli/test/protection_rules_converter_unit.test.ts
+++ b/cli/test/protection_rules_converter_unit.test.ts
@@ -1,16 +1,21 @@
 /**
- * Unit tests for ProtectionRulesConverter.
- * Covers normalization, order-insensitive equality, and the
- * create/update/delete reconciliation plan used by pull/push.
+ * Unit tests for the protection-rules feature: the reconciliation converter,
+ * the WorkspaceResolver (protection-rules.yaml key -> backend id via
+ * wmill.yaml), and protection-rules.yaml read/write round-tripping.
  */
 
 import { expect, test, describe } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtempSync, rmSync } from "node:fs";
 import { ProtectionRulesConverter } from "../src/commands/protection-rules/converter.ts";
 import {
-  applyRulesToBranchOverride,
-  clearRuleOverride,
-} from "../src/commands/protection-rules/utils.ts";
-import { ProtectionRuleEntry, SyncOptions } from "../src/core/conf.ts";
+  WorkspaceResolver,
+  readProtectionRulesFile,
+  writeProtectionRulesFile,
+} from "../src/commands/protection-rules/file.ts";
+import { ProtectionRuleEntry } from "../src/commands/protection-rules/types.ts";
+import { SyncOptions } from "../src/core/conf.ts";
 
 const rule = (
   name: string,
@@ -178,69 +183,58 @@ describe("computePlan (full reconcile)", () => {
   });
 });
 
-describe("applyRulesToBranchOverride", () => {
-  test("writes under the given resolved workspace key, not a raw branch", () => {
-    // workspaces.prod maps to git branch main; the override MUST land on
-    // `prod` (the key getEffectiveSettings resolves), not `main`.
-    const config: SyncOptions = {
-      workspaces: { prod: { gitBranch: "main" } } as any,
-    };
-    const out = applyRulesToBranchOverride(config, "prod", [
-      rule("r", ["DisableDirectDeployment"]),
-    ]);
-    expect((out.workspaces as any).prod.overrides.protectionRules).toEqual([
-      rule("r", ["DisableDirectDeployment"]),
-    ]);
-    expect((out.workspaces as any).main).toBeUndefined();
+describe("WorkspaceResolver", () => {
+  const config: SyncOptions = {
+    workspaces: {
+      prod: { workspaceId: "acme-prod" },
+      dev: {},
+      commonSpecificItems: { settings: true },
+    } as any,
+  };
+  const r = WorkspaceResolver.fromConfig(config);
+
+  test("knownNames excludes reserved keys", () => {
+    expect(r.knownNames().sort()).toEqual(["dev", "prod"]);
   });
 
-  test("creates the workspace entry if missing", () => {
-    const out = applyRulesToBranchOverride({}, "feature", [rule("a", [])]);
-    expect((out.workspaces as any).feature.overrides.protectionRules).toEqual([
-      rule("a", []),
-    ]);
+  test("backendId uses workspaceId when set, else the key name", () => {
+    expect(r.backendId("prod")).toBe("acme-prod");
+    expect(r.backendId("dev")).toBe("dev");
   });
 
-  test("writes into promotionOverrides when block is promotionOverrides", () => {
-    const out = applyRulesToBranchOverride(
-      { workspaces: { prod: { gitBranch: "main" } } as any },
-      "prod",
-      [rule("r", ["DisableDirectDeployment"])],
-      "promotionOverrides",
-    );
-    expect(
-      (out.workspaces as any).prod.promotionOverrides.protectionRules,
-    ).toEqual([rule("r", ["DisableDirectDeployment"])]);
-    expect((out.workspaces as any).prod.overrides).toBeUndefined();
+  test("backendId throws for a key absent from wmill.yaml", () => {
+    expect(() => r.backendId("ghost")).toThrow(/not defined in wmill\.yaml/);
+  });
+
+  test("has reflects membership", () => {
+    expect(r.has("prod")).toBe(true);
+    expect(r.has("ghost")).toBe(false);
+  });
+
+  test("empty config resolves to no workspaces", () => {
+    expect(WorkspaceResolver.fromConfig({}).knownNames()).toEqual([]);
   });
 });
 
-describe("clearRuleOverride", () => {
-  test("removes protectionRules from overrides and promotionOverrides", () => {
-    const config: SyncOptions = {
-      workspaces: {
-        prod: {
-          gitBranch: "main",
-          overrides: { protectionRules: [rule("a", [])], skipScripts: true },
-          promotionOverrides: { protectionRules: [rule("b", [])] },
-        },
-      } as any,
-    };
-    expect(clearRuleOverride(config, "prod")).toBe(true);
-    expect(
-      "protectionRules" in (config.workspaces as any).prod.overrides,
-    ).toBe(false);
-    // unrelated override keys are preserved
-    expect((config.workspaces as any).prod.overrides.skipScripts).toBe(true);
-    expect(
-      "protectionRules" in (config.workspaces as any).prod.promotionOverrides,
-    ).toBe(false);
-  });
+describe("protection-rules.yaml read/write", () => {
+  test("round-trips and sorts workspace keys deterministically", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "prfile-"));
+    const path = join(dir, "protection-rules.yaml");
+    try {
+      expect(await readProtectionRulesFile(path)).toEqual({});
 
-  test("returns false when there is nothing to clear", () => {
-    expect(clearRuleOverride({ workspaces: { prod: {} } as any }, "prod")).toBe(
-      false,
-    );
-    expect(clearRuleOverride({}, "missing")).toBe(false);
+      await writeProtectionRulesFile(path, {
+        prod: [rule("p", ["DisableDirectDeployment"], ["g/a"])],
+        dev: [],
+      });
+      const back = await readProtectionRulesFile(path);
+      expect(Object.keys(back)).toEqual(["dev", "prod"]);
+      expect(back.prod).toEqual([
+        rule("p", ["DisableDirectDeployment"], ["g/a"]),
+      ]);
+      expect(back.dev).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/cli/test/protection_rules_converter_unit.test.ts
+++ b/cli/test/protection_rules_converter_unit.test.ts
@@ -6,7 +6,11 @@
 
 import { expect, test, describe } from "bun:test";
 import { ProtectionRulesConverter } from "../src/commands/protection-rules/converter.ts";
-import { ProtectionRuleEntry } from "../src/core/conf.ts";
+import {
+  applyRulesToBranchOverride,
+  clearRuleOverride,
+} from "../src/commands/protection-rules/utils.ts";
+import { ProtectionRuleEntry, SyncOptions } from "../src/core/conf.ts";
 
 const rule = (
   name: string,
@@ -171,5 +175,59 @@ describe("computePlan (full reconcile)", () => {
       [rule("p", ["DisableDirectDeployment", "DisableWorkspaceForking"], ["g/a", "g/b"])],
     );
     expect(ProtectionRulesConverter.planHasChanges(plan)).toBe(false);
+  });
+});
+
+describe("applyRulesToBranchOverride", () => {
+  test("writes under the given resolved workspace key, not a raw branch", () => {
+    // workspaces.prod maps to git branch main; the override MUST land on
+    // `prod` (the key getEffectiveSettings resolves), not `main`.
+    const config: SyncOptions = {
+      workspaces: { prod: { gitBranch: "main" } } as any,
+    };
+    const out = applyRulesToBranchOverride(config, "prod", [
+      rule("r", ["DisableDirectDeployment"]),
+    ]);
+    expect((out.workspaces as any).prod.overrides.protectionRules).toEqual([
+      rule("r", ["DisableDirectDeployment"]),
+    ]);
+    expect((out.workspaces as any).main).toBeUndefined();
+  });
+
+  test("creates the workspace entry if missing", () => {
+    const out = applyRulesToBranchOverride({}, "feature", [rule("a", [])]);
+    expect((out.workspaces as any).feature.overrides.protectionRules).toEqual([
+      rule("a", []),
+    ]);
+  });
+});
+
+describe("clearRuleOverride", () => {
+  test("removes protectionRules from overrides and promotionOverrides", () => {
+    const config: SyncOptions = {
+      workspaces: {
+        prod: {
+          gitBranch: "main",
+          overrides: { protectionRules: [rule("a", [])], skipScripts: true },
+          promotionOverrides: { protectionRules: [rule("b", [])] },
+        },
+      } as any,
+    };
+    expect(clearRuleOverride(config, "prod")).toBe(true);
+    expect(
+      "protectionRules" in (config.workspaces as any).prod.overrides,
+    ).toBe(false);
+    // unrelated override keys are preserved
+    expect((config.workspaces as any).prod.overrides.skipScripts).toBe(true);
+    expect(
+      "protectionRules" in (config.workspaces as any).prod.promotionOverrides,
+    ).toBe(false);
+  });
+
+  test("returns false when there is nothing to clear", () => {
+    expect(clearRuleOverride({ workspaces: { prod: {} } as any }, "prod")).toBe(
+      false,
+    );
+    expect(clearRuleOverride({}, "missing")).toBe(false);
   });
 });

--- a/cli/test/protection_rules_converter_unit.test.ts
+++ b/cli/test/protection_rules_converter_unit.test.ts
@@ -200,6 +200,19 @@ describe("applyRulesToBranchOverride", () => {
       rule("a", []),
     ]);
   });
+
+  test("writes into promotionOverrides when block is promotionOverrides", () => {
+    const out = applyRulesToBranchOverride(
+      { workspaces: { prod: { gitBranch: "main" } } as any },
+      "prod",
+      [rule("r", ["DisableDirectDeployment"])],
+      "promotionOverrides",
+    );
+    expect(
+      (out.workspaces as any).prod.promotionOverrides.protectionRules,
+    ).toEqual([rule("r", ["DisableDirectDeployment"])]);
+    expect((out.workspaces as any).prod.overrides).toBeUndefined();
+  });
 });
 
 describe("clearRuleOverride", () => {

--- a/system_prompts/auto-generated/cli/cli-commands.md
+++ b/system_prompts/auto-generated/cli/cli-commands.md
@@ -332,23 +332,17 @@ Validate Windmill flow, schedule, and trigger YAML files in a directory
 
 ### protection-rules
 
-Manage workspace protection rules between local wmill.yaml and Windmill backend
-
 **Subcommands:**
 
-- `protection-rules pull` - Pull protection rules from Windmill backend into local wmill.yaml
-  - `--default` - Write to top-level protectionRules instead of overrides
-  - `--replace` - Replace existing protection rules (non-interactive)
-  - `--override` - Add branch-specific override (non-interactive)
-  - `--diff` - Show differences without applying changes
+- `protection-rules pull [workspace:string]` - Pull protection rules from Windmill into protection-rules.yaml for a workspace
+  - `--all` - Pull every workspace defined in wmill.yaml
+  - `--dry-run` - Show what would change without writing the file
   - `--json-output` - Output in JSON format
-  - `--yes` - Skip interactive prompts and use default behavior
-  - `--promotion <branch:string>` - Use promotionOverrides from the specified branch instead of regular overrides
-- `protection-rules push` - Push protection rules from local wmill.yaml to Windmill backend (full reconcile: creates, updates, and deletes)
-  - `--diff` - Show what would be pushed without applying changes
+- `protection-rules push [workspace:string]`
+  - `--all` - Push every workspace defined in protection-rules.yaml
+  - `--dry-run` - Show what would change without applying
   - `--json-output` - Output in JSON format
-  - `--yes` - Skip interactive prompts and confirmations
-  - `--promotion <branch:string>` - Use promotionOverrides from the specified branch instead of regular overrides
+  - `--yes` - Skip the confirmation prompt (including deletions)
 
 ### queues
 

--- a/system_prompts/auto-generated/cli/cli-commands.md
+++ b/system_prompts/auto-generated/cli/cli-commands.md
@@ -338,7 +338,7 @@ Validate Windmill flow, schedule, and trigger YAML files in a directory
   - `--all` - Pull every workspace defined in wmill.yaml
   - `--dry-run` - Show what would change without writing the file
   - `--json-output` - Output in JSON format
-- `protection-rules push [workspace:string]`
+- `protection-rules push [workspace:string]` - Push protection rules from protection-rules.yaml to Windmill for a workspace (full reconcile: creates, updates, and deletes)
   - `--all` - Push every workspace defined in protection-rules.yaml
   - `--dry-run` - Show what would change without applying
   - `--json-output` - Output in JSON format

--- a/system_prompts/auto-generated/cli/cli-commands.md
+++ b/system_prompts/auto-generated/cli/cli-commands.md
@@ -330,6 +330,26 @@ Validate Windmill flow, schedule, and trigger YAML files in a directory
 - `--locks-required` - Fail if scripts or flow inline scripts that need locks have no locks
 - `-w, --watch` - Watch for file changes and re-lint automatically
 
+### protection-rules
+
+Manage workspace protection rules between local wmill.yaml and Windmill backend
+
+**Subcommands:**
+
+- `protection-rules pull` - Pull protection rules from Windmill backend into local wmill.yaml
+  - `--default` - Write to top-level protectionRules instead of overrides
+  - `--replace` - Replace existing protection rules (non-interactive)
+  - `--override` - Add branch-specific override (non-interactive)
+  - `--diff` - Show differences without applying changes
+  - `--json-output` - Output in JSON format
+  - `--yes` - Skip interactive prompts and use default behavior
+  - `--promotion <branch:string>` - Use promotionOverrides from the specified branch instead of regular overrides
+- `protection-rules push` - Push protection rules from local wmill.yaml to Windmill backend (full reconcile: creates, updates, and deletes)
+  - `--diff` - Show what would be pushed without applying changes
+  - `--json-output` - Output in JSON format
+  - `--yes` - Skip interactive prompts and confirmations
+  - `--promotion <branch:string>` - Use promotionOverrides from the specified branch instead of regular overrides
+
 ### queues
 
 List all queues with their metrics

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -2863,23 +2863,17 @@ Validate Windmill flow, schedule, and trigger YAML files in a directory
 
 ### protection-rules
 
-Manage workspace protection rules between local wmill.yaml and Windmill backend
-
 **Subcommands:**
 
-- \`protection-rules pull\` - Pull protection rules from Windmill backend into local wmill.yaml
-  - \`--default\` - Write to top-level protectionRules instead of overrides
-  - \`--replace\` - Replace existing protection rules (non-interactive)
-  - \`--override\` - Add branch-specific override (non-interactive)
-  - \`--diff\` - Show differences without applying changes
+- \`protection-rules pull [workspace:string]\` - Pull protection rules from Windmill into protection-rules.yaml for a workspace
+  - \`--all\` - Pull every workspace defined in wmill.yaml
+  - \`--dry-run\` - Show what would change without writing the file
   - \`--json-output\` - Output in JSON format
-  - \`--yes\` - Skip interactive prompts and use default behavior
-  - \`--promotion <branch:string>\` - Use promotionOverrides from the specified branch instead of regular overrides
-- \`protection-rules push\` - Push protection rules from local wmill.yaml to Windmill backend (full reconcile: creates, updates, and deletes)
-  - \`--diff\` - Show what would be pushed without applying changes
+- \`protection-rules push [workspace:string]\`
+  - \`--all\` - Push every workspace defined in protection-rules.yaml
+  - \`--dry-run\` - Show what would change without applying
   - \`--json-output\` - Output in JSON format
-  - \`--yes\` - Skip interactive prompts and confirmations
-  - \`--promotion <branch:string>\` - Use promotionOverrides from the specified branch instead of regular overrides
+  - \`--yes\` - Skip the confirmation prompt (including deletions)
 
 ### queues
 

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -2869,7 +2869,7 @@ Validate Windmill flow, schedule, and trigger YAML files in a directory
   - \`--all\` - Pull every workspace defined in wmill.yaml
   - \`--dry-run\` - Show what would change without writing the file
   - \`--json-output\` - Output in JSON format
-- \`protection-rules push [workspace:string]\`
+- \`protection-rules push [workspace:string]\` - Push protection rules from protection-rules.yaml to Windmill for a workspace (full reconcile: creates, updates, and deletes)
   - \`--all\` - Push every workspace defined in protection-rules.yaml
   - \`--dry-run\` - Show what would change without applying
   - \`--json-output\` - Output in JSON format

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -2861,6 +2861,26 @@ Validate Windmill flow, schedule, and trigger YAML files in a directory
 - \`--locks-required\` - Fail if scripts or flow inline scripts that need locks have no locks
 - \`-w, --watch\` - Watch for file changes and re-lint automatically
 
+### protection-rules
+
+Manage workspace protection rules between local wmill.yaml and Windmill backend
+
+**Subcommands:**
+
+- \`protection-rules pull\` - Pull protection rules from Windmill backend into local wmill.yaml
+  - \`--default\` - Write to top-level protectionRules instead of overrides
+  - \`--replace\` - Replace existing protection rules (non-interactive)
+  - \`--override\` - Add branch-specific override (non-interactive)
+  - \`--diff\` - Show differences without applying changes
+  - \`--json-output\` - Output in JSON format
+  - \`--yes\` - Skip interactive prompts and use default behavior
+  - \`--promotion <branch:string>\` - Use promotionOverrides from the specified branch instead of regular overrides
+- \`protection-rules push\` - Push protection rules from local wmill.yaml to Windmill backend (full reconcile: creates, updates, and deletes)
+  - \`--diff\` - Show what would be pushed without applying changes
+  - \`--json-output\` - Output in JSON format
+  - \`--yes\` - Skip interactive prompts and confirmations
+  - \`--promotion <branch:string>\` - Use promotionOverrides from the specified branch instead of regular overrides
+
 ### queues
 
 List all queues with their metrics

--- a/system_prompts/auto-generated/skills/cli-commands/SKILL.md
+++ b/system_prompts/auto-generated/skills/cli-commands/SKILL.md
@@ -343,7 +343,7 @@ Validate Windmill flow, schedule, and trigger YAML files in a directory
   - `--all` - Pull every workspace defined in wmill.yaml
   - `--dry-run` - Show what would change without writing the file
   - `--json-output` - Output in JSON format
-- `protection-rules push [workspace:string]`
+- `protection-rules push [workspace:string]` - Push protection rules from protection-rules.yaml to Windmill for a workspace (full reconcile: creates, updates, and deletes)
   - `--all` - Push every workspace defined in protection-rules.yaml
   - `--dry-run` - Show what would change without applying
   - `--json-output` - Output in JSON format

--- a/system_prompts/auto-generated/skills/cli-commands/SKILL.md
+++ b/system_prompts/auto-generated/skills/cli-commands/SKILL.md
@@ -335,6 +335,26 @@ Validate Windmill flow, schedule, and trigger YAML files in a directory
 - `--locks-required` - Fail if scripts or flow inline scripts that need locks have no locks
 - `-w, --watch` - Watch for file changes and re-lint automatically
 
+### protection-rules
+
+Manage workspace protection rules between local wmill.yaml and Windmill backend
+
+**Subcommands:**
+
+- `protection-rules pull` - Pull protection rules from Windmill backend into local wmill.yaml
+  - `--default` - Write to top-level protectionRules instead of overrides
+  - `--replace` - Replace existing protection rules (non-interactive)
+  - `--override` - Add branch-specific override (non-interactive)
+  - `--diff` - Show differences without applying changes
+  - `--json-output` - Output in JSON format
+  - `--yes` - Skip interactive prompts and use default behavior
+  - `--promotion <branch:string>` - Use promotionOverrides from the specified branch instead of regular overrides
+- `protection-rules push` - Push protection rules from local wmill.yaml to Windmill backend (full reconcile: creates, updates, and deletes)
+  - `--diff` - Show what would be pushed without applying changes
+  - `--json-output` - Output in JSON format
+  - `--yes` - Skip interactive prompts and confirmations
+  - `--promotion <branch:string>` - Use promotionOverrides from the specified branch instead of regular overrides
+
 ### queues
 
 List all queues with their metrics

--- a/system_prompts/auto-generated/skills/cli-commands/SKILL.md
+++ b/system_prompts/auto-generated/skills/cli-commands/SKILL.md
@@ -337,23 +337,17 @@ Validate Windmill flow, schedule, and trigger YAML files in a directory
 
 ### protection-rules
 
-Manage workspace protection rules between local wmill.yaml and Windmill backend
-
 **Subcommands:**
 
-- `protection-rules pull` - Pull protection rules from Windmill backend into local wmill.yaml
-  - `--default` - Write to top-level protectionRules instead of overrides
-  - `--replace` - Replace existing protection rules (non-interactive)
-  - `--override` - Add branch-specific override (non-interactive)
-  - `--diff` - Show differences without applying changes
+- `protection-rules pull [workspace:string]` - Pull protection rules from Windmill into protection-rules.yaml for a workspace
+  - `--all` - Pull every workspace defined in wmill.yaml
+  - `--dry-run` - Show what would change without writing the file
   - `--json-output` - Output in JSON format
-  - `--yes` - Skip interactive prompts and use default behavior
-  - `--promotion <branch:string>` - Use promotionOverrides from the specified branch instead of regular overrides
-- `protection-rules push` - Push protection rules from local wmill.yaml to Windmill backend (full reconcile: creates, updates, and deletes)
-  - `--diff` - Show what would be pushed without applying changes
+- `protection-rules push [workspace:string]`
+  - `--all` - Push every workspace defined in protection-rules.yaml
+  - `--dry-run` - Show what would change without applying
   - `--json-output` - Output in JSON format
-  - `--yes` - Skip interactive prompts and confirmations
-  - `--promotion <branch:string>` - Use promotionOverrides from the specified branch instead of regular overrides
+  - `--yes` - Skip the confirmation prompt (including deletions)
 
 ### queues
 


### PR DESCRIPTION
## Summary

Adds `wmill protection-rules pull|push` so workspace protection rulesets can be defined and version-controlled from `wmill.yaml`, mirroring the existing `gitsync-settings` command pattern.

Protection rules are stored under a new `protectionRules` field on `SyncOptions`, so they flow through `getEffectiveSettings` — supporting top-level config **and** per-workspace `overrides`/`promotionOverrides`. This is the deciding reason for choosing `wmill.yaml` over `settings.yaml`: protection rules are the textbook case for environment-differentiated enforcement (strict on the deployed workspace, looser on a fork), and only `wmill.yaml` already has that override machinery.

No backend changes — the `/protection_rules` CRUD API, OpenAPI spec, and generated CLI client already existed; this is a pure CLI feature.

## Changes

- `cli/src/core/conf.ts`: new `ProtectionRuleEntry` type + `protectionRules?: ProtectionRuleEntry[]` on `SyncOptions`
- `cli/src/commands/protection-rules/`:
  - `converter.ts` — normalization + order/duplicate-insensitive `computePlan` (create/update/delete reconcile)
  - `pull.ts` — backend → `wmill.yaml` (replace/override modes, `--diff`, `--json-output`, `--yes`, `--promotion`); creates `wmill.yaml` if absent
  - `push.ts` — `wmill.yaml` → backend, **full reconcile** (create/update/delete) with diff + confirmation; delete-guard prompt defaults to "no" when deletions are present; `--yes`/non-TTY bypass
  - `utils.ts`, `protection-rules.ts`, `index.ts` — display/override helpers and command wiring
- `cli/src/main.ts`: register `protection-rules` command
- `cli/test/protection_rules_converter_unit.test.ts`: 15 converter unit tests
- Regenerated `system_prompts/auto-generated/*` + `cli/src/guidance/skills.gen.ts` per AGENTS.md

## Test plan

- [x] `npm run check` — no new tsc errors (16 pre-existing, all in unrelated files)
- [x] `npm run test:unit` — 15 new converter tests pass; gitsync/settings unit suites unaffected (51 total)
- [x] E2E vs dev backend: `pull` creates `wmill.yaml` from empty backend; `push --diff` then `push --yes` creates rules (verified bitflags in DB); full-reconcile push (create + update + delete) verified against DB; `pull --replace` overwrites stale local; `pull --diff --json-output` shows correct `hasChanges`/structured diff
- [x] Local code review (branch-diff-reviewer) — one P2 addressed: pull `--json-output` diff now uses directional keys (`addedLocally`/`updatedLocally`/`removedLocally`) to avoid ambiguity vs the push framing
- [ ] Reviewer: confirm interactive Select (replace/override/cancel) UX in a git repo with a `workspaces` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `wmill protection-rules pull|push` to sync workspace protection rules via a new per-workspace `protection-rules.yaml`, with full reconcile on push. Replaces the prior `wmill.yaml` overrides to simplify usage and avoid override/dry-run edge cases.

- **New Features**
  - New `protection-rules.yaml`: `{ <workspace>: ProtectionRuleEntry[] }`; keys must match `wmill.yaml`; deterministic key order on write.
  - `pull`: fetch rules into the file; supports `--all`, `--dry-run`, `--json-output`.
  - `push`: reconcile backend to match the file (create/update/delete) with diff + confirmation; supports `--all`, `--dry-run`, `--json-output`, `--yes`.
  - Order/duplicate-insensitive diffing; per-workspace JSON output (`create`/`update`/`delete`/`unchanged`).
  - Per-workspace resolution/auth via `tryResolveBranchWorkspace` + `setClient`; command registered under `wmill protection-rules`; CLI docs generated.

- **Bug Fixes**
  - Honor explicit `--base-url`/`--token` (stateless CI); explicit `--token` overrides a stored profile; workspace id still derives from `wmill.yaml`.
  - Exit non-zero on failures; partial `--all` runs return `success:false` with `partialFailure:true` and push reports applied create/update/delete counts.
  - Warn when an empty local list would wipe backend rules; deletion confirmation defaults to “no” when deletions are present.
  - `pull --dry-run` never writes or creates files.
  - `--json-output` now emits only JSON on stdout by silencing human logs early.

<sup>Written for commit a54d717adcb5ab01febcecd980dc5688a1778a42. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9240?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

