### PR TITLE
fix(frontend): open customer portal in popup synchronously to bypass Safari blocker

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -154,6 +154,7 @@ no_auth = ["windmill-api/no_auth"]
 operator = ["dep:windmill-operator"]
 test_job_debouncing = []
 private_registry_test = []
+dev_override = ["windmill-common/dev_override"]
 # Languages
 python = ["windmill-worker/python", "windmill-api/python", "windmill-test-utils/python"]
 rust = ["windmill-worker/rust"]

--- a/frontend/src/lib/components/InstanceSetting.svelte
+++ b/frontend/src/lib/components/InstanceSetting.svelte
@@ -123,11 +123,19 @@
 
 	export async function openCustomerPortal() {
 		opening = true
+		const newWindow = window.open('', '_blank')
 		try {
 			const url = await SettingService.createCustomerPortalSession({
 				licenseKey: $values['license_key'] || undefined
 			})
-			window.open(url, '_blank')
+			if (newWindow) {
+				newWindow.location.href = url
+			} else {
+				window.location.href = url
+			}
+		} catch (err) {
+			newWindow?.close()
+			throw err
 		} finally {
 			opening = false
 		}


### PR DESCRIPTION
## Summary
- Safari blocks `window.open()` called after an `await` because the call is no longer tied to the user gesture, so clicking "Open customer portal" in instance settings silently did nothing on Safari.
- Open a blank tab synchronously on click, then assign `location.href` once the portal URL resolves. If the synchronous open is blocked too, fall back to navigating the current tab.

## Test plan
- [ ] Click "Open customer portal" in instance settings on Safari — portal opens in a new tab
- [ ] Same flow on Chrome/Firefox — still opens in a new tab as before
- [ ] If the API call fails, the blank tab is closed and the error surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Safari blocking the customer portal by creating the tab synchronously, then redirecting it once the URL is ready. Keeps the new-tab behavior on other browsers.

- **Bug Fixes**
  - Open a blank tab immediately on click, then set its URL after the portal session resolves to preserve the user gesture on Safari.
  - If the popup is blocked, navigate the current tab; on API failure, close the blank tab and show the error.

- **Refactors**
  - Wire `dev_override` feature flag in the backend via `windmill-common/dev_override`.

<sup>Written for commit fc77e63a866b0f5a65b78bf56108a12533fc3f72. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9242?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

