### PR TITLE
fix: bound resource/variable interpolation recursion depth (WIN-1957)

### DIFF
--- a/backend/windmill-store/src/resources.rs
+++ b/backend/windmill-store/src/resources.rs
@@ -585,6 +585,14 @@ pub async fn get_resource_value_interpolated_internal<'a>(
     }
 }
 
+// Maximum recursion depth for variable/resource interpolation. Each nested
+// object/array level and each `$res:`/`$var:` indirection consumes one unit of
+// depth. This bounds runtime cost and, crucially, prevents a stack overflow
+// from mutually-recursive `$res:` references (e.g. resource A -> `$res:B` and
+// resource B -> `$res:A`), which any workspace member with resource write
+// access could otherwise use to crash the API process.
+pub const MAX_RESOURCE_INTERPOLATION_DEPTH: u8 = 50;
+
 #[async_recursion]
 pub async fn transform_json_value(
     db_with_opt_authed: &DbWithOptAuthed<ApiAuthed>,
@@ -594,6 +602,11 @@ pub async fn transform_json_value(
     token: Option<&str>,
     depth: u8,
 ) -> Result<Value> {
+    if depth >= MAX_RESOURCE_INTERPOLATION_DEPTH {
+        return Err(Error::internal_err(format!(
+            "Maximum resource/variable interpolation depth ({MAX_RESOURCE_INTERPOLATION_DEPTH}) exceeded; this usually indicates a circular `$res:` or `$var:` reference"
+        )));
+    }
     match v {
         Value::String(y) if y.starts_with("$var:") => {
             let path = y.strip_prefix("$var:").unwrap();
@@ -2587,6 +2600,92 @@ mod tests {
         let result = transform_json_value(&dba, "test", input, &None, None, 0).await;
 
         assert!(result.is_err());
+    }
+
+    // Regression test for WIN-1957: deeply nested structures must be bounded so
+    // that interpolation cannot recurse without limit (which would otherwise
+    // overflow the stack).
+    #[tokio::test]
+    async fn test_transform_json_value_bounds_recursion_depth() {
+        let db_url = std::env::var("DATABASE_URL")
+            .unwrap_or("postgres://postgres:changeme@localhost:5432/windmill".to_string());
+        let pool = sqlx::PgPool::connect(&db_url).await.unwrap();
+        let dba = test_db_with_opt_authed(pool);
+
+        // Build an object nested deeper than the allowed interpolation depth.
+        // No `$res:`/`$var:` leaves are involved, so this exercises the depth
+        // guard purely on structural recursion (no DB lookups required).
+        let mut input = Value::String("plain".to_string());
+        for _ in 0..(MAX_RESOURCE_INTERPOLATION_DEPTH as usize + 5) {
+            let mut m = serde_json::Map::new();
+            m.insert("a".to_string(), input);
+            input = Value::Object(m);
+        }
+
+        let result = transform_json_value(&dba, "test", input, &None, None, 0).await;
+
+        let err = result.expect_err("deeply nested value should be rejected");
+        assert!(
+            err.to_string().contains("interpolation depth"),
+            "unexpected error: {err}"
+        );
+    }
+
+    // Regression test for WIN-1957: two resources whose values reference each
+    // other via `$res:` must NOT recurse forever (stack overflow / process
+    // crash). With the depth guard the resolution terminates with an error.
+    #[tokio::test]
+    async fn test_transform_json_value_mutual_resource_recursion_terminates() {
+        let db_url = std::env::var("DATABASE_URL")
+            .unwrap_or("postgres://postgres:changeme@localhost:5432/windmill".to_string());
+        let pool = sqlx::PgPool::connect(&db_url).await.unwrap();
+
+        let w_id = format!("dostest{}", Uuid::new_v4().simple());
+
+        sqlx::query("INSERT INTO workspace (id, name, owner) VALUES ($1, $1, 'test@windmill.dev')")
+            .bind(&w_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        sqlx::query(
+            "INSERT INTO resource (workspace_id, path, value, resource_type) VALUES \
+             ($1, 'f/test/dos_a', $2, 'object'), \
+             ($1, 'f/test/dos_b', $3, 'object')",
+        )
+        .bind(&w_id)
+        .bind(json!("$res:f/test/dos_b"))
+        .bind(json!("$res:f/test/dos_a"))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let dba = test_db_with_opt_authed(pool.clone());
+        let result = transform_json_value(
+            &dba,
+            &w_id,
+            Value::String("$res:f/test/dos_a".to_string()),
+            &None,
+            None,
+            0,
+        )
+        .await;
+
+        // Clean up before asserting so a failed assertion doesn't leave rows.
+        let _ = sqlx::query("DELETE FROM resource WHERE workspace_id = $1")
+            .bind(&w_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM workspace WHERE id = $1")
+            .bind(&w_id)
+            .execute(&pool)
+            .await;
+
+        let err = result.expect_err("mutually recursive resources should error, not crash");
+        assert!(
+            err.to_string().contains("interpolation depth"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -241,6 +241,13 @@ pub fn parse_npm_config(s: &str) -> (String, Option<String>) {
     return (url, token_opt);
 }
 
+// Defense-in-depth bound on worker-side interpolation recursion. `$res:`
+// resolution is delegated to the API (which enforces its own
+// MAX_RESOURCE_INTERPOLATION_DEPTH), so this only bounds nested
+// object/array structure here, but a finite cap guards against pathological
+// inputs regardless of the API-side guard.
+const MAX_INTERPOLATION_DEPTH: u8 = 50;
+
 #[async_recursion]
 pub async fn transform_json_value(
     name: &str,
@@ -251,6 +258,11 @@ pub async fn transform_json_value(
     conn: &Connection,
     depth: u8,
 ) -> error::Result<Value> {
+    if depth >= MAX_INTERPOLATION_DEPTH {
+        return Err(Error::internal_err(format!(
+            "Maximum resource/variable interpolation depth ({MAX_INTERPOLATION_DEPTH}) exceeded for `{name}`; this usually indicates a circular `$res:` or `$var:` reference"
+        )));
+    }
     match v {
         Value::String(y) if y.starts_with("$var:") => {
             let path = y.strip_prefix("$var:").unwrap();


### PR DESCRIPTION
## Summary

Fixes WIN-1957. `transform_json_value` in `windmill-store/src/resources.rs` recursed on every `$res:` indirection (`depth + 1`) with **no depth check** — the `depth: u8` parameter was never inspected. Two resources whose values point at each other (A → `$res:.../B`, B → `$res:.../A`) caused unbounded mutual recursion → stack overflow → API process crash. Any workspace member with resource write access could trigger this DoS, and it is reachable from scripts/flows/apps that resolve resources (`GET /api/w/{workspace}/resources/get_value_interpolated/...`).

## Changes

- Add `MAX_RESOURCE_INTERPOLATION_DEPTH = 50` and guard at the top of the store-side `transform_json_value` (`windmill-store/src/resources.rs`): when `depth >= MAX`, return a clear error before resolving `$res:`/`$var:` or descending into arrays/objects. This breaks the mutual-`$res:` cycle (each hop increments `depth`).
- Add a defense-in-depth `MAX_INTERPOLATION_DEPTH = 50` guard to the worker-side `transform_json_value` (`windmill-worker/src/common.rs`). The worker delegates `$res:` resolution to the API (which now has its own cap), so this only bounds structural nesting, but it caps pathological inputs regardless of the API guard.
- Two regression tests in `windmill-store/src/resources.rs`:
  - `test_transform_json_value_bounds_recursion_depth` — deterministic structural-depth check (deeply nested object, no DB lookups).
  - `test_transform_json_value_mutual_resource_recursion_terminates` — reproduces the exact WIN-1957 PoC (two cross-referencing `$res:` resources in a unique workspace) and asserts it errors instead of crashing; cleans up fixture rows before asserting.

Note: limit chosen as 50 (not the 20 suggested in the report) to match the existing `MAX_FLOW_ENV_LOOKUP_DEPTH` precedent and leave headroom for legitimately nested resource configs while staying far below stack-overflow territory.

## Test plan

- [x] `cargo check --tests -p windmill-store -p windmill-worker` passes
- [x] `cargo test -p windmill-store --lib resources::` — all 14 tests pass, including the 2 new regression tests
- [ ] Manual: create `f/test/a` = `"$res:f/test/b"` and `f/test/b` = `"$res:f/test/a"`, fetch one via the resource API or reference it from a job — confirm a clear "interpolation depth … exceeded" error and that the API process stays up

Fixes WIN-1957

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds resource/variable interpolation recursion to stop circular `$res:` references from crashing the API. Fixes WIN-1957 by returning a clear “depth exceeded” error and capping recursion in both API and worker.

- **Bug Fixes**
  - API/store: add `MAX_RESOURCE_INTERPOLATION_DEPTH = 50` in `transform_json_value` to error when depth is exceeded before resolving `$res:`/`$var:` or descending into arrays/objects.
  - Worker: add defense-in-depth `MAX_INTERPOLATION_DEPTH = 50` to cap structural nesting even if the API is guarded.
  - Tests: add a structural-depth test and a mutual `$res:` cycle test that now fail fast with a clear error instead of causing a crash.

<sup>Written for commit 07fd975b473aa24fb1d8e87302e148c7d98d8722. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9243?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

