### PR TITLE
test: provision migrated db for mutual-resource recursion test (WIN-1958)

### DIFF
--- a/backend/windmill-store/src/resources.rs
+++ b/backend/windmill-store/src/resources.rs
@@ -2634,12 +2634,14 @@ mod tests {
     // Regression test for WIN-1957: two resources whose values reference each
     // other via `$res:` must NOT recurse forever (stack overflow / process
     // crash). With the depth guard the resolution terminates with an error.
-    #[tokio::test]
-    async fn test_transform_json_value_mutual_resource_recursion_terminates() {
-        let db_url = std::env::var("DATABASE_URL")
-            .unwrap_or("postgres://postgres:changeme@localhost:5432/windmill".to_string());
-        let pool = sqlx::PgPool::connect(&db_url).await.unwrap();
-
+    //
+    // This test needs the real `workspace`/`resource` schema, so it uses
+    // `#[sqlx::test]` which provisions a migrated ephemeral database per test
+    // (the bare `DATABASE_URL` database in CI has no migrations applied, which
+    // previously made the workspace INSERT panic with `relation "workspace"
+    // does not exist` — WIN-1958).
+    #[sqlx::test(migrations = "../migrations")]
+    async fn test_transform_json_value_mutual_resource_recursion_terminates(pool: DB) {
         let w_id = format!("dostest{}", Uuid::new_v4().simple());
 
         sqlx::query("INSERT INTO workspace (id, name, owner) VALUES ($1, $1, 'test@windmill.dev')")
@@ -2671,16 +2673,8 @@ mod tests {
         )
         .await;
 
-        // Clean up before asserting so a failed assertion doesn't leave rows.
-        let _ = sqlx::query("DELETE FROM resource WHERE workspace_id = $1")
-            .bind(&w_id)
-            .execute(&pool)
-            .await;
-        let _ = sqlx::query("DELETE FROM workspace WHERE id = $1")
-            .bind(&w_id)
-            .execute(&pool)
-            .await;
-
+        // The ephemeral test database is dropped automatically, so no manual
+        // row cleanup is required.
         let err = result.expect_err("mutually recursive resources should error, not crash");
         assert!(
             err.to_string().contains("interpolation depth"),


### PR DESCRIPTION
## Summary

Fixes WIN-1958. The regression test `test_transform_json_value_mutual_resource_recursion_terminates` (added in #9243 / commit `26f3cbef25` for WIN-1957) connected to the bare `DATABASE_URL` database and `INSERT`ed into the `workspace`/`resource` tables. In CI, that database is an empty `postgres` service with **no migrations applied**, so the workspace `INSERT` panicked:

```
called `Result::unwrap()` on an `Err` value: Database(PgDatabaseError { code: "42P01",
message: "relation \"workspace\" does not exist", ... })
```

The other tests in this module never touch real tables (they pass plain values that error out anyway), so only this one was broken.

The fix converts the test to the codebase's standard `#[sqlx::test(migrations = "../migrations")]` pattern — a migrated ephemeral database is provisioned per test and auto-dropped afterwards — matching `backend/windmill-common/tests/notify_events.rs`. The test logic and assertions are unchanged; only the DB-provisioning mechanism changed.

## Changes

- `backend/windmill-store/src/resources.rs`: replace `#[tokio::test]` + raw `sqlx::PgPool::connect(DATABASE_URL)` with `#[sqlx::test(migrations = "../migrations")]` taking a `pool: DB`.
- Remove the now-unnecessary manual `DELETE FROM resource/workspace` cleanup (the ephemeral DB is dropped automatically).

## Test plan

- [x] `cargo test -p windmill-store --lib resources::tests::test_transform_json_value_mutual_resource_recursion_terminates` passes locally (provisions a migrated ephemeral DB; WIN-1957 recursion-depth assertion preserved).
- [x] Branch-diff code review: no issues (bugs, security, AGENTS.md compliance).
- [ ] CI `Backend only integration tests` passes (the empty `DATABASE_URL` postgres service no longer causes a panic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provision a migrated ephemeral DB for the mutual-resource recursion test to prevent CI panics from missing tables. Fixes WIN-1958 and preserves the WIN-1957 regression behavior.

- **Bug Fixes**
  - Switched to `#[sqlx::test(migrations = "../migrations")]` in `backend/windmill-store/src/resources.rs` to provision a migrated per-test DB.
  - Removed manual `DATABASE_URL` connection and cleanup; the ephemeral DB is auto-dropped.
  - CI no longer fails with “relation 'workspace' does not exist”; test logic and assertions are unchanged.

<sup>Written for commit ca9a68ce392dbfb5c434d67ed7b86b8a4d627f9f. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9247?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

