### PR TITLE
chore(claude): harden main-branch guard and gate claude.ai MCP tools

### DIFF
--- a/.claude/hooks/guard-main-branch.sh
+++ b/.claude/hooks/guard-main-branch.sh
@@ -16,6 +16,23 @@ command="$(echo "$input" | jq -r '.tool_input.command // empty')"
 if [[ "$command" =~ ^git\ (push|reset|revert|checkout|merge|rebase|commit|add) ]]; then
   branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
   if [[ "$branch" == "main" ]]; then
-    echo "BLOCK: You are on the main branch. Create or switch to a feature branch first."
+    echo "BLOCK: You are on the main branch. Create or switch to a feature branch first." >&2
+    exit 2
+  fi
+fi
+
+# Block force-push targeting main from any branch.
+if [[ "$command" =~ ^git[[:space:]]+push([[:space:]]|$) ]]; then
+  has_force=false
+  if [[ "$command" =~ (--force([[:space:]]|=|$)|--force-with-lease|[[:space:]]-f([[:space:]]|$)) ]]; then
+    has_force=true
+  fi
+  # `+ref` refspec syntax is also a force push.
+  if [[ "$command" =~ [[:space:]]\+[A-Za-z] ]]; then
+    has_force=true
+  fi
+  if $has_force && [[ "$command" =~ (^|[[:space:]:])\+?main([[:space:]]|$) ]]; then
+    echo "BLOCK: Force-push to main is not allowed via Claude. Run it yourself if you really mean to." >&2
+    exit 2
   fi
 fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -72,7 +72,13 @@
       "Bash(chown:*)",
       "Bash(truncate:*)",
       "Bash(shred:*)",
-      "Bash(unlink:*)"
+      "Bash(unlink:*)",
+      "mcp__claude_ai_Stripe",
+      "mcp__claude_ai_Gmail",
+      "mcp__claude_ai_Google_Calendar",
+      "mcp__claude_ai_Google_Drive",
+      "mcp__claude_ai_Slack",
+      "mcp__claude_ai_Linear"
     ]
   },
   "enableAllProjectMcpServers": true,


### PR DESCRIPTION
## Summary
- **Hook hardening** (`.claude/hooks/guard-main-branch.sh`): switch both block paths from advisory `echo` (exit 0) to `echo >&2` + `exit 2`, so Claude Code actually refuses the tool call instead of just logging a message the model can ignore.
- **Force-push protection**: extend the hook to block `git push --force` / `-f` / `--force-with-lease` / `+ref` targeting `main` from *any* branch. Previously the hook only fired when the current branch was `main`.
- **MCP gating** (`.claude/settings.json`): move several MCP connectors to `permissions.ask` so they require explicit approval.

## Test plan
- [ ] From a feature branch, attempt `git push --force origin main` → hook refuses with exit 2 (verified locally against 10 variants including `+main`, `--force-with-lease`, `feature:main --force`).
- [ ] Attempt any git write while on `main` → hook refuses with exit 2.
- [ ] Trigger one of the gated MCP tools in an interactive session → prompts for approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)