### PR TITLE
feat(snowflake): derive public key from private key when omitted (WIN-1959)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -15667,6 +15667,7 @@ dependencies = [
  "regex",
  "reqwest 0.13.1",
  "reqwest-middleware",
+ "rsa",
  "rust_decimal",
  "serde",
  "serde_json",

--- a/backend/windmill-worker/Cargo.toml
+++ b/backend/windmill-worker/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 private = ["windmill-worker-volumes/private", "windmill-queue/private", "windmill-common/private", "windmill-dep-map/private", "windmill-runtime-nativets?/private"]
 mcp = ["windmill-ai/mcp", "dep:windmill-mcp"]
 prometheus = ["dep:prometheus", "windmill-common/prometheus"]
-enterprise = ["windmill-queue/enterprise", "windmill-git-sync/enterprise", "windmill-common/enterprise", "windmill-worker-volumes/enterprise", "windmill-runtime-nativets?/enterprise", "dep:pem", "dep:tokio-util", "dep:opentelemetry-proto", "dep:prost", "dep:hudsucker", "dep:rcgen", "dep:hyper-http-proxy", "dep:hyper-tls", "dep:hyper-util"]
+enterprise = ["windmill-queue/enterprise", "windmill-git-sync/enterprise", "windmill-common/enterprise", "windmill-worker-volumes/enterprise", "windmill-runtime-nativets?/enterprise", "dep:pem", "dep:rsa", "dep:tokio-util", "dep:opentelemetry-proto", "dep:prost", "dep:hudsucker", "dep:rcgen", "dep:hyper-http-proxy", "dep:hyper-tls", "dep:hyper-util"]
 mssql = ["dep:tiberius"]
 mssql-kerberos = ["mssql", "tiberius/integrated-auth-gssapi"]  # Linux/Unix integrated auth
 mssql-winauth = ["mssql", "tiberius/winauth"]  # Windows integrated auth
@@ -112,6 +112,7 @@ jsonwebtoken.workspace = true
 sha2.workspace = true
 hmac.workspace = true
 pem = { workspace = true, optional = true }
+rsa = { workspace = true, optional = true }
 urlencoding.workspace = true
 nix.workspace = true
 bytes.workspace = true

--- a/backend/windmill-worker/src/snowflake_executor.rs
+++ b/backend/windmill-worker/src/snowflake_executor.rs
@@ -630,7 +630,12 @@ pub async fn do_snowflake(
         )
         .to_uppercase();
 
-        let public_key_der: Vec<u8> = match database.public_key.as_deref() {
+        let public_key_der: Vec<u8> = match database
+            .public_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
             Some(key) => pem::parse(key.as_bytes())
                 .map_err(|e| Error::ExecutionErr(format!("Failed to parse public key: {e}")))?
                 .into_contents(),
@@ -638,11 +643,16 @@ pub async fn do_snowflake(
                 // Derive the public key from the private key — RSA private keys
                 // contain the public components (n, e).
                 use rsa::pkcs8::{DecodePrivateKey, EncodePublicKey};
-                let pk_pem = database.private_key.as_deref().ok_or_else(|| {
-                    Error::ExecutionErr(
-                        "Either public_key or private_key must be provided".to_string(),
-                    )
-                })?;
+                let pk_pem = database
+                    .private_key
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .ok_or_else(|| {
+                        Error::ExecutionErr(
+                            "Either public_key or private_key must be provided".to_string(),
+                        )
+                    })?;
                 let rsa_priv = rsa::RsaPrivateKey::from_pkcs8_pem(pk_pem)
                     .or_else(|_| {
                         use rsa::pkcs1::DecodeRsaPrivateKey;

--- a/backend/windmill-worker/src/snowflake_executor.rs
+++ b/backend/windmill-worker/src/snowflake_executor.rs
@@ -630,14 +630,40 @@ pub async fn do_snowflake(
         )
         .to_uppercase();
 
-        let public_key = match database.public_key.as_deref() {
-            Some(key) => pem::parse(key.as_bytes()).map_err(|e| {
-                Error::ExecutionErr(format!("Failed to parse public key: {}", e.to_string()))
-            })?,
-            None => return Err(Error::ExecutionErr("Public key is missing".to_string())),
+        let public_key_der: Vec<u8> = match database.public_key.as_deref() {
+            Some(key) => pem::parse(key.as_bytes())
+                .map_err(|e| Error::ExecutionErr(format!("Failed to parse public key: {e}")))?
+                .into_contents(),
+            None => {
+                // Derive the public key from the private key — RSA private keys
+                // contain the public components (n, e).
+                use rsa::pkcs8::{DecodePrivateKey, EncodePublicKey};
+                let pk_pem = database.private_key.as_deref().ok_or_else(|| {
+                    Error::ExecutionErr(
+                        "Either public_key or private_key must be provided".to_string(),
+                    )
+                })?;
+                let rsa_priv = rsa::RsaPrivateKey::from_pkcs8_pem(pk_pem)
+                    .or_else(|_| {
+                        use rsa::pkcs1::DecodeRsaPrivateKey;
+                        rsa::RsaPrivateKey::from_pkcs1_pem(pk_pem)
+                    })
+                    .map_err(|e| {
+                        Error::ExecutionErr(format!(
+                            "Failed to parse private key to derive public key: {e}"
+                        ))
+                    })?;
+                let rsa_pub = rsa::RsaPublicKey::from(&rsa_priv);
+                rsa_pub
+                    .to_public_key_der()
+                    .map_err(|e| {
+                        Error::ExecutionErr(format!("Failed to encode derived public key: {e}"))
+                    })?
+                    .to_vec()
+            }
         };
         let mut public_key_hash = Sha256::new();
-        public_key_hash.update(public_key.contents());
+        public_key_hash.update(&public_key_der);
 
         let public_key_fp = engine::general_purpose::STANDARD.encode(public_key_hash.finalize());
 


### PR DESCRIPTION
## Summary

Snowflake key-pair auth needs a SHA256 fingerprint of the public key for the JWT `iss` claim, but the public key is mathematically derivable from the RSA private key (it contains the public components `n`, `e`). Other tools (e.g. Power BI) only require the private key, so forcing users to supply both is redundant friction.

When `public_key` is omitted on the Snowflake resource, derive it from `private_key` (PKCS#8, falling back to PKCS#1 PEM) instead of returning `"Public key is missing"`.

## Changes

- `backend/windmill-worker/Cargo.toml` — add `rsa` as an optional dependency, gated behind the `enterprise` feature (mirroring how `pem` is gated).
- `backend/windmill-worker/src/snowflake_executor.rs` — when `database.public_key` is `None`, parse the private key (PKCS#8 → PKCS#1 fallback) and encode the derived public key to DER for the fingerprint.

Existing behavior is preserved when `public_key` is provided: same parse path, same SHA256 over the DER contents.

## Follow-up

The Snowflake resource type schema on the Hub should be updated to mark `public_key` as optional. That lives outside this repo.

## Test plan

- [x] `cargo check --features enterprise,private -p windmill-worker` passes
- [ ] Manual: configure a Snowflake resource with only `private_key` (no `public_key`) and run a query — should authenticate successfully via key-pair JWT
- [ ] Manual: existing resources with `public_key` provided continue to work unchanged

Fixes WIN-1959

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Snowflake key-pair auth now works without a `public_key`: if it’s missing or empty, we derive it from the `private_key` and hash it for the JWT `iss`. Addresses WIN-1959 and keeps existing configs unchanged.

- New Features
  - Derive RSA public key from `private_key` (PKCS#8 with PKCS#1 fallback), encode to DER, then hash for the fingerprint.
  - Preserve existing behavior when `public_key` is provided.

- Bug Fixes
  - Treat empty `public_key`/`private_key` values as missing to avoid parse errors.
  - Return a clear error if both keys are absent.

<sup>Written for commit 65deab4b75868854cb17b967c2cbb58d48e309cd. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9251?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

