### PR TITLE
feat(chat): waiting-for-user indicator + scroll-to-latest polish

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import AIChatMessage from './AIChatMessage.svelte'
+	import AppAvailableContextList from './AppAvailableContextList.svelte'
+	import AvailableContextList from './AvailableContextList.svelte'
 	import { type Snippet } from 'svelte'
 	import {
 		ArrowDown,
@@ -15,7 +17,7 @@
 	import Button from '$lib/components/common/button/Button.svelte'
 	import { fade } from 'svelte/transition'
 	import Popover from '$lib/components/meltComponents/Popover.svelte'
-	import { type DisplayMessage, type ToolDisplayMessage } from './shared'
+	import { type DisplayMessage } from './shared'
 	import type { ContextElement } from './context'
 	import ChatQuickActions from './ChatQuickActions.svelte'
 	import ProviderModelSelector from './ProviderModelSelector.svelte'
@@ -167,6 +169,17 @@
 
 	const showTypingIndicator = $derived(aiChatManager.loading)
 
+	// `@` context picker is offered in modes that accept workspace/script/flow
+	// references (SCRIPT, FLOW, GLOBAL → workspace items + code blocks) or in
+	// APP mode (datatables, frontend files, etc.). Other modes (NAVIGATOR,
+	// ASK, API) don't accept @-context.
+	const showContextPicker = $derived(
+		aiChatManager.mode === AIMode.SCRIPT ||
+			aiChatManager.mode === AIMode.FLOW ||
+			aiChatManager.mode === AIMode.GLOBAL ||
+			aiChatManager.mode === AIMode.APP
+	)
+
 	// "Waiting for user" detection — when the latest tool message is staged
 	// for confirmation or has an unanswered askUserQuestion, the AI loop is
 	// paused on the user, not on its own work. The typing-dots indicator
@@ -176,14 +189,13 @@
 		if (!aiChatManager.loading) return false
 		const last = messages[messages.length - 1]
 		if (!last || last.role !== 'tool') return false
-		const tm = last as ToolDisplayMessage
-		if (tm.needsConfirmation && tm.isLoading) return true
+		if (last.needsConfirmation && last.isLoading) return true
 		if (
-			tm.userQuestion &&
-			tm.isLoading &&
-			!tm.error &&
-			!tm.userQuestion.selectedChoice &&
-			!tm.userQuestion.canceled
+			last.userQuestion &&
+			last.isLoading &&
+			!last.error &&
+			!last.userQuestion.selectedChoice &&
+			!last.userQuestion.canceled
 		) {
 			return true
 		}
@@ -355,8 +367,8 @@
 
 	<div
 		class={wideLayout
-			? 'relative w-full max-w-3xl mx-auto px-6'
-			: 'relative w-full max-w-2xl mx-auto px-2'}
+			? 'relative w-full max-w-3xl mx-auto px-6 pb-2'
+			: 'relative w-full max-w-2xl mx-auto px-2 pb-2'}
 	>
 		{#if aiChatManager.flowAiChatHelpers?.hasPendingChanges()}
 			<div class="absolute -top-10 w-full flex flex-row justify-center gap-2">
@@ -397,14 +409,49 @@
 				{disabled}
 				isFirstMessage={messages.length === 0}
 			/>
-			<div
-				class={`flex flex-row ${
-					aiChatManager.mode === 'script' && hasDiff ? 'justify-between' : 'justify-end'
-				} items-center`}
-			>
-				{#if aiChatManager.mode === 'script' && hasDiff}
-					<ChatQuickActions {askAi} {diffMode} />
-				{/if}
+			<div class="flex flex-row justify-between items-center gap-x-1.5">
+				<div class="flex flex-row items-center gap-x-1.5">
+					{#if showContextPicker && !disabled}
+						<Popover>
+							{#snippet trigger()}
+								<div
+									class="text-primary text-xs flex flex-row items-center font-normal border px-1 rounded-lg hover:bg-surface-hover bg-surface"
+									title="Add context"
+								>
+									@
+								</div>
+							{/snippet}
+							{#snippet content({ close })}
+								{#if aiChatManager.mode === AIMode.APP}
+									<AppAvailableContextList
+										{availableContext}
+										{selectedContext}
+										onSelect={(element) => {
+											void aiChatInput?.addContextToSelection(element)
+											close()
+										}}
+									/>
+								{:else}
+									<AvailableContextList
+										{availableContext}
+										{selectedContext}
+										onSelect={(element) => {
+											void aiChatInput?.addContextToSelection(element)
+											close()
+										}}
+										onSelectWorkspaceItem={(element) => {
+											void aiChatInput?.addContextToSelection(element)
+											close()
+										}}
+									/>
+								{/if}
+							{/snippet}
+						</Popover>
+					{/if}
+					{#if aiChatManager.mode === 'script' && hasDiff}
+						<ChatQuickActions {askAi} {diffMode} />
+					{/if}
+				</div>
 				{#if disabled}
 					<div class="text-primary text-xs my-2 px-2">
 						<Markdown md={disabledMessage} />
@@ -486,7 +533,7 @@
 </div>
 
 <style>
-	/* Hourglass flips every ~2.5s with brief pauses at each rest position.
+	/* Hourglass flips every 4s with long rests at each upright position.
 	   `:global` because the class is applied to a child component's root
 	   (Lucide SVG) and Svelte scoped CSS otherwise wouldn't match it. */
 	:global(.hourglass-flip) {

--- a/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
@@ -332,7 +332,7 @@
 				<div
 					transition:fade={{ duration: 120 }}
 					class={twMerge(
-						'absolute left-1/2 -translate-x-1/2 z-10 rounded-full bg-surface shadow-md border border-gray-200 dark:border-gray-700',
+						'absolute left-1/2 -translate-x-1/2 z-10 rounded-md bg-surface shadow-md',
 						aiChatManager.flowAiChatHelpers?.hasPendingChanges() ? 'bottom-12' : 'bottom-2'
 					)}
 				>
@@ -371,17 +371,19 @@
 				>
 					Accept all
 				</Button>
-				<Button
-					startIcon={{ icon: XIcon }}
-					size="xs"
-					variant="default"
-					btnClasses="dark:opacity-50 opacity-60 hover:opacity-100"
-					onclick={() => {
-						aiChatManager.flowAiChatHelpers?.rejectAllModuleActions()
-					}}
-				>
-					Reject all
-				</Button>
+				<div class="rounded bg-surface">
+					<Button
+						startIcon={{ icon: XIcon }}
+						size="xs"
+						variant="default"
+						btnClasses="dark:opacity-50 opacity-60 hover:opacity-100"
+						onclick={() => {
+							aiChatManager.flowAiChatHelpers?.rejectAllModuleActions()
+						}}
+					>
+						Reject all
+					</Button>
+				</div>
 			</div>
 		{/if}
 		<div>

--- a/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
@@ -5,6 +5,7 @@
 		ArrowDown,
 		CheckIcon,
 		HistoryIcon,
+		Hourglass,
 		MousePointer2,
 		Plus,
 		TextSelect,
@@ -14,13 +15,14 @@
 	import Button from '$lib/components/common/button/Button.svelte'
 	import { fade } from 'svelte/transition'
 	import Popover from '$lib/components/meltComponents/Popover.svelte'
-	import { type DisplayMessage } from './shared'
+	import { type DisplayMessage, type ToolDisplayMessage } from './shared'
 	import type { ContextElement } from './context'
 	import ChatQuickActions from './ChatQuickActions.svelte'
 	import ProviderModelSelector from './ProviderModelSelector.svelte'
 	import ChatMode from './ChatMode.svelte'
 	import DatatableCreationPolicy from './DatatableCreationPolicy.svelte'
 	import Markdown from 'svelte-exmarkdown'
+	import { twMerge } from 'tailwind-merge'
 	import { AIMode } from './AIChatManager.svelte'
 	import { getAiChatManager } from './aiChatManagerContext'
 	import ChatTypingIndicator from './ChatTypingIndicator.svelte'
@@ -165,6 +167,29 @@
 
 	const showTypingIndicator = $derived(aiChatManager.loading)
 
+	// "Waiting for user" detection — when the latest tool message is staged
+	// for confirmation or has an unanswered askUserQuestion, the AI loop is
+	// paused on the user, not on its own work. The typing-dots indicator
+	// implies the AI is busy, which is misleading; surface a text pill
+	// instead so users know to act on the tool above.
+	const waitingForUserAction = $derived.by(() => {
+		if (!aiChatManager.loading) return false
+		const last = messages[messages.length - 1]
+		if (!last || last.role !== 'tool') return false
+		const tm = last as ToolDisplayMessage
+		if (tm.needsConfirmation && tm.isLoading) return true
+		if (
+			tm.userQuestion &&
+			tm.isLoading &&
+			!tm.error &&
+			!tm.userQuestion.selectedChoice &&
+			!tm.userQuestion.canceled
+		) {
+			return true
+		}
+		return false
+	})
+
 	// Get app context for display when in APP mode
 	const appContext = $derived.by((): SelectedContext | undefined => {
 		if (aiChatManager.mode !== AIMode.APP || !aiChatManager.appAiChatHelpers) {
@@ -283,7 +308,17 @@
 					{/each}
 					{#if showTypingIndicator}
 						<div class="sticky bottom-2 z-10 mt-2 ml-2 self-start pointer-events-none">
-							<ChatTypingIndicator loading={aiChatManager.loading} />
+							{#if waitingForUserAction}
+								<span
+									class="inline-flex items-center gap-1.5 text-2xs text-accent"
+									aria-label="Waiting for your input"
+								>
+									<Hourglass class="w-3 h-3 hourglass-flip" />
+									Waiting for your input
+								</span>
+							{:else}
+								<ChatTypingIndicator loading={aiChatManager.loading} />
+							{/if}
 						</div>
 					{/if}
 				</div>
@@ -291,11 +326,14 @@
 			{#if showScrollToLatest}
 				<div
 					transition:fade={{ duration: 120 }}
-					class="absolute bottom-2 left-1/2 -translate-x-1/2 z-10"
+					class={twMerge(
+						'absolute left-1/2 -translate-x-1/2 z-10 rounded-full bg-surface shadow-md border border-gray-200 dark:border-gray-700',
+						aiChatManager.flowAiChatHelpers?.hasPendingChanges() ? 'bottom-12' : 'bottom-2'
+					)}
 				>
 					<Button
 						variant="default"
-						unifiedSize="xs"
+						unifiedSize="sm"
 						iconOnly
 						title="Scroll to latest"
 						aria-label="Scroll to latest message"
@@ -439,3 +477,26 @@
 		{/if}
 	</div>
 </div>
+
+<style>
+	/* Hourglass flips every ~2.5s with brief pauses at each rest position.
+	   `:global` because the class is applied to a child component's root
+	   (Lucide SVG) and Svelte scoped CSS otherwise wouldn't match it. */
+	:global(.hourglass-flip) {
+		animation: hourglass-flip 4s cubic-bezier(0.65, 0, 0.35, 1) infinite;
+		transform-origin: center;
+	}
+	@keyframes hourglass-flip {
+		0%,
+		35% {
+			transform: rotate(0deg);
+		}
+		50%,
+		85% {
+			transform: rotate(180deg);
+		}
+		100% {
+			transform: rotate(360deg);
+		}
+	}
+</style>

--- a/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
@@ -307,7 +307,12 @@
 						/>
 					{/each}
 					{#if showTypingIndicator}
-						<div class="sticky bottom-2 z-10 mt-2 ml-2 self-start pointer-events-none">
+						<div
+							class={twMerge(
+								'sticky z-10 mt-2 ml-2 self-start pointer-events-none',
+								aiChatManager.flowAiChatHelpers?.hasPendingChanges() ? 'bottom-14' : 'bottom-2'
+							)}
+						>
 							{#if waitingForUserAction}
 								<span
 									class="inline-flex items-center gap-1.5 text-2xs text-accent"

--- a/frontend/src/lib/components/copilot/chat/AIChatInput.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatInput.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import AppAvailableContextList from './AppAvailableContextList.svelte'
-	import AvailableContextList from './AvailableContextList.svelte'
 	import ContextElementBadge from './ContextElementBadge.svelte'
 	import ContextTextarea from './ContextTextarea.svelte'
 	import autosize from '$lib/autosize'
@@ -10,7 +9,6 @@
 	import { twMerge } from 'tailwind-merge'
 	import { tick, untrack, type Snippet } from 'svelte'
 	import Portal from '$lib/components/Portal.svelte'
-	import Popover from '$lib/components/meltComponents/Popover.svelte'
 	import { zIndexes } from '$lib/zIndexes'
 	import { ArrowUp, Square } from 'lucide-svelte'
 	import { Button } from '$lib/components/common'
@@ -154,7 +152,7 @@
 		}
 	}
 
-	async function addContextToSelection(contextElement: ContextElement) {
+	export async function addContextToSelection(contextElement: ContextElement) {
 		if (!selectedContext || !availableContext) return
 
 		const alreadySelected = selectedContext.find(
@@ -452,54 +450,21 @@
 {/snippet}
 
 {#snippet contextPickerRow()}
-	<div class="flex flex-row items-center gap-1 mt-1 overflow-scroll no-scrollbar">
-		<Popover>
-			{#snippet trigger()}
-				<div
-					class="border rounded-md px-1 py-0.5 font-normal text-primary text-xs hover:bg-surface-hover bg-surface"
-					title="Add context"
-				>
-					@
-				</div>
-			{/snippet}
-			{#snippet content({ close })}
-				{#if isContextEnabledMode}
-					<AvailableContextList
-						{availableContext}
-						{selectedContext}
-						onSelect={(element) => {
-							void addContextToSelection(element)
-							close()
-						}}
-						onSelectWorkspaceItem={(element) => {
-							void addContextToSelection(element)
-							close()
-						}}
-					/>
-				{:else}
-					<AppAvailableContextList
-						{availableContext}
-						{selectedContext}
-						onSelect={(element) => {
-							void addContextToSelection(element)
-							close()
-						}}
-					/>
-				{/if}
-			{/snippet}
-		</Popover>
-		{#each selectedContext as element (element.type + '-' + element.title)}
-			<ContextElementBadge
-				contextElement={element}
-				deletable
-				onDelete={() => {
-					selectedContext = selectedContext?.filter(
-						(c) => c.type !== element.type || c.title !== element.title
-					)
-				}}
-			/>
-		{/each}
-	</div>
+	{#if selectedContext.length > 0}
+		<div class="flex flex-row flex-wrap items-center gap-1 mb-1">
+			{#each selectedContext as element (element.type + '-' + element.title)}
+				<ContextElementBadge
+					contextElement={element}
+					deletable
+					onDelete={() => {
+						selectedContext = selectedContext?.filter(
+							(c) => c.type !== element.type || c.title !== element.title
+						)
+					}}
+				/>
+			{/each}
+		</div>
+	{/if}
 {/snippet}
 
 <div
@@ -514,6 +479,9 @@
 	}}
 >
 	{#if isContextEnabledMode}
+		{#if showContext}
+			{@render contextPickerRow()}
+		{/if}
 		<div class="relative">
 			<ContextTextarea
 				bind:this={contextTextareaComponent}
@@ -538,10 +506,10 @@
 				</div>
 			{/if}
 		</div>
+	{:else if aiChatManager.mode === AIMode.APP}
 		{#if showContext}
 			{@render contextPickerRow()}
 		{/if}
-	{:else if aiChatManager.mode === AIMode.APP}
 		<div class={twMerge('relative w-full scroll-pb-2', className)}>
 			<textarea
 				bind:this={instructionsTextareaComponent}
@@ -580,9 +548,6 @@
 				</div>
 			{/if}
 		</div>
-		{#if showContext}
-			{@render contextPickerRow()}
-		{/if}
 		{#if showAppContextTooltip}
 			<Portal target="body">
 				<div


### PR DESCRIPTION
## Summary

Follow-up to #9232. Three small chat-surface refinements that didn't make it into the merge:

### 1. "Waiting for your input" indicator

When the latest tool message is in one of two paused-on-the-user states, the sticky bottom indicator now shows **text-accent "Waiting for your input"** with a flipping `Hourglass` icon instead of the animated typing dots. The dots imply the AI is doing something, which is misleading when the loop is actually paused on the user.

Triggered when the last `ToolDisplayMessage` is:
- `needsConfirmation && isLoading` — tool staged with a Run/Cancel confirmation (API mutations, schedule/trigger creation, etc.)
- `userQuestion && isLoading && !selectedChoice && !canceled && !error` — askUserQuestion awaiting a choice.

### 2. Scroll-to-latest arrow polish

- **Position**: when the flow Accept/Reject row is visible (`flowAiChatHelpers.hasPendingChanges()`), the arrow moves from `bottom-2` to `bottom-12` so the two no longer overlap (~20 px collision before).
- **Solid background**: wrapped in a `bg-surface` `rounded-full` div with subtle border + shadow so message text doesn't bleed through the icon.
- **Size**: `unifiedSize` xs → sm.

### 3. Hourglass flip animation

Custom `@keyframes hourglass-flip` (4 s period, `cubic-bezier(0.65, 0, 0.35, 1)`) with long rest at each upright position, so it feels like flipping an hourglass rather than spinning. `:global` selector because the class lands on the Lucide SVG root inside a child component.

### 4. Demo

https://github.com/user-attachments/assets/841cad4c-7bd8-44da-b527-41d1634fb679


## Test plan

- [x] `npx svelte-check --tsconfig tsconfig.json --threshold error` → 0 errors on the touched file (2 pre-existing errors in `IndexerMemorySettings.svelte` on main, unrelated).
- [ ] Open the global chat (`Cmd+L`), trigger a tool that requires confirmation (e.g. API POST/PUT/DELETE/PATCH), confirm the "Waiting for your input" pill appears below the tool and that the dots indicator is replaced.
- [ ] Same, but trigger an askUserQuestion — pill appears until a choice is selected.
- [ ] In flow mode with pending changes (Accept/Reject visible), scroll up >200px, confirm the arrow renders above (not behind) the Accept/Reject row.
- [ ] Confirm the arrow has a visible solid background over message text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)