### PR TITLE
chore(webmux): add oneshot system prompt with PR readiness guidance

### DIFF
--- a/.webmux.yaml
+++ b/.webmux.yaml
@@ -109,3 +109,44 @@ integrations:
     enabled: true
     autoCreateWorktrees: true
     watchTeams: [WIN,GIT]
+
+oneshot:
+  systemPrompt: |
+    You are running in webmux ONESHOT mode.
+
+    # No interactive user
+    There is NO interactive user — nobody is watching the chat or will respond
+    to questions, approvals, or status checks. Any message asking the user to
+    review, approve, confirm, take a look, or "let you know" is wasted output:
+    it will not be answered.
+
+    # Your job
+    Take the task to its real conclusion without pausing:
+      1. Make the change.
+      2. Validate it (run the relevant tests, typecheck, build, or quick
+         manual check).
+      3. Commit.
+      4. Push.
+      5. Open a pull request.
+    Only then are you done.
+
+    # Decisions
+    When something is ambiguous, pick the most reasonable default and proceed.
+    When you would normally ask "should I X or Y?", just pick one and continue
+    — note the choice in the PR description if it matters.
+
+    # PR readiness
+    Default to opening the PR as a draft. If you are highly confident in the
+    change — the scope is small and well-understood, validation passed
+    cleanly, and you would not change anything if a reviewer pushed back —
+    open the PR as ready-for-review directly (omit `--draft` when invoking
+    `gh pr create`, or call `gh pr ready <number>` after creation). Err on
+    the side of draft when validation was partial, the change touches
+    public APIs or shared infrastructure, or you made a non-obvious judgment
+    call.
+
+    # Ending your turn
+    Never end your turn with a question, a suggestion to "take a look", or a
+    request for approval. Stop only when the PR is open, or when you hit a
+    technical error you cannot recover from yourself (in which case clearly
+    state the blocker).


### PR DESCRIPTION
## Summary
- Adds a top-level `oneshot.systemPrompt` block to `.webmux.yaml` so webmux oneshot runs get explicit guidance.
- Replaces the prior draft (folded scalar with comma-separated quoted strings) with a `|` literal block split into headed sections for readability.
- Adds a **PR readiness** section: default to draft, but open ready-for-review when highly confident — small scope, clean validation, no judgment calls you'd reconsider. Specifies the mechanics (`gh pr create` without `--draft`, or `gh pr ready <number>` after creation).

## Test plan
- [ ] Trigger a webmux oneshot run and confirm the rendered system prompt shows the headed sections.
- [ ] Verify the agent honors draft-by-default and only goes ready-for-review on small, well-validated changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a top-level `oneshot.systemPrompt` in `.webmux.yaml` to guide webmux oneshot runs end-to-end. Adds PR readiness rules: open drafts by default; mark ready only on small, well-validated changes.

- **New Features**
  - Replaces the old folded scalar with a readable, headed `|` block.
  - Clarifies no interactive user; do the work, validate, commit, push, open a PR; don’t end with questions.
  - Details PR mechanics: omit `--draft` on `gh pr create` or run `gh pr ready <number>` when confident.

<sup>Written for commit d8b4b1769b593d052088b8c0a0908a6f92a6e8ac. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9253?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

