### PR TITLE
tighten security from vuln report

### DIFF
--- a/backend/.sqlx/query-d4af472614e1b6af8defa40a79d5f584c8b114ef24fdb67a5eefb40ce17acdef.json
+++ b/backend/.sqlx/query-d4af472614e1b6af8defa40a79d5f584c8b114ef24fdb67a5eefb40ce17acdef.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE v2_job_status s\n                SET flow_status = JSONB_SET(s.flow_status, ARRAY['modules', s.flow_status->>'step', 'progress'], $1)\n                FROM v2_job j\n                WHERE s.id = $2 AND j.id = s.id AND j.workspace_id = $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Jsonb",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d4af472614e1b6af8defa40a79d5f584c8b114ef24fdb67a5eefb40ce17acdef"
+}

--- a/backend/windmill-api-jobs/src/job_metrics.rs
+++ b/backend/windmill-api-jobs/src/job_metrics.rs
@@ -180,13 +180,22 @@ async fn set_job_progress(
     // If flow_job_id exists, than we should modify flow_status of corresponding module
     // Individual jobs and flows are handled differently
     if let Some(flow_job_id) = flow_job_id {
+        // `v2_job_status` has no workspace_id column and the root db handle
+        // bypasses RLS (the per-row policy on the table is also inert today —
+        // `ENABLE ROW LEVEL SECURITY` was never set). Scope the update by
+        // joining `v2_job` so the URL's workspace_id confines tampering to the
+        // caller's workspace; without this, an authed member of any workspace
+        // could overwrite the flow `progress` UI field of a flow in another
+        // workspace given just the flow UUID.
         // TODO: Return error if trying to set completed job?
         sqlx::query!(
-            "UPDATE v2_job_status
-                SET flow_status = JSONB_SET(flow_status, ARRAY['modules', flow_status->>'step', 'progress'], $1)
-                WHERE id = $2",
+            "UPDATE v2_job_status s
+                SET flow_status = JSONB_SET(s.flow_status, ARRAY['modules', s.flow_status->>'step', 'progress'], $1)
+                FROM v2_job j
+                WHERE s.id = $2 AND j.id = s.id AND j.workspace_id = $3",
             serde_json::json!(percent.clamp(0, 99)),
-            flow_job_id
+            flow_job_id,
+            w_id,
         )
         .execute(&db)
         .await?;

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -3294,15 +3294,6 @@ async fn set_environment_variable(
 ) -> Result<String> {
     require_admin(authed.is_admin, &authed.username)?;
 
-    // Reserved for built-in `%%WM_*%%` contextual variables that SQL executors
-    // substitute raw into queries — see windmill_common::variables.
-    if windmill_common::variables::is_reserved_wm_env_name(&name) {
-        return Err(Error::BadRequest(format!(
-            "Environment variable name `{}` is reserved for built-in `WM_*` contextual variables",
-            name
-        )));
-    }
-
     let mut tx = db.begin().await?;
 
     match value {

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -3294,6 +3294,15 @@ async fn set_environment_variable(
 ) -> Result<String> {
     require_admin(authed.is_admin, &authed.username)?;
 
+    // Reserved for built-in `%%WM_*%%` contextual variables that SQL executors
+    // substitute raw into queries — see windmill_common::variables.
+    if windmill_common::variables::is_reserved_wm_env_name(&name) {
+        return Err(Error::BadRequest(format!(
+            "Environment variable name `{}` is reserved for built-in `WM_*` contextual variables",
+            name
+        )));
+    }
+
     let mut tx = db.begin().await?;
 
     match value {

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -2589,6 +2589,21 @@ async fn upload_s3_file_from_app(
     request: axum::extract::Request,
 ) -> JsonResult<AppUploadFileResponse> {
     let policy = if let Some(file_key_regex) = query.force_viewer_file_key_regex {
+        // `force_viewer_*` lets the caller supply a synthetic upload policy that
+        // bypasses the deployed app's file_key_regex / resource restrictions.
+        // It is intended for the app editor's preview path, so it must enforce
+        // the same guards as `execute_component`'s preview mode (PR #9235):
+        // authed caller, not an operator, and `apps:write` scope to make sure
+        // an `apps:run`-scoped token cannot pick its own policy.
+        let authed = opt_authed.as_ref().ok_or_else(|| {
+            Error::NotAuthorized("App S3 preview upload requires authentication".to_string())
+        })?;
+        if authed.is_operator {
+            return Err(Error::NotAuthorized(
+                "Operators cannot run app S3 previews for security reasons".to_string(),
+            ));
+        }
+        check_scopes(authed, || format!("apps:write:{}", &path.0))?;
         Some(Policy {
             execution_mode: ExecutionMode::Viewer,
             triggerables: None,
@@ -3100,6 +3115,20 @@ async fn download_s3_file_from_app(
     let force_viewer_allowed_s3_keys = if let Some(force_viewer_allowed_s3_keys) =
         query.force_viewer_allowed_s3_keys.clone()
     {
+        // `force_viewer_allowed_s3_keys` lets the caller supply a synthetic
+        // allowlist that bypasses the deployed app policy. Apply the same
+        // preview-mode guard as `execute_component` (PR #9235): authed, not an
+        // operator, `apps:write` scope so an `apps:run`-scoped token cannot
+        // pick its own allowlist.
+        let authed = opt_authed.as_ref().ok_or_else(|| {
+            Error::NotAuthorized("App S3 preview download requires authentication".to_string())
+        })?;
+        if authed.is_operator {
+            return Err(Error::NotAuthorized(
+                "Operators cannot run app S3 previews for security reasons".to_string(),
+            ));
+        }
+        check_scopes(authed, || format!("apps:write:{}", path))?;
         Some(serde_json::from_str::<Vec<S3Key>>(&force_viewer_allowed_s3_keys).unwrap_or_default())
     } else {
         None

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -2603,7 +2603,7 @@ async fn upload_s3_file_from_app(
                 "Operators cannot run app S3 previews for security reasons".to_string(),
             ));
         }
-        check_scopes(authed, || format!("apps:write:{}", &path.0))?;
+        check_scopes(authed, || format!("apps:write:{}", path.to_path()))?;
         Some(Policy {
             execution_mode: ExecutionMode::Viewer,
             triggerables: None,

--- a/backend/windmill-common/src/variables.rs
+++ b/backend/windmill-common/src/variables.rs
@@ -19,16 +19,6 @@ use serde::{Deserialize, Serialize};
 
 lazy_static::lazy_static! {
     pub static ref SECRET_SALT: Option<String> = std::env::var("SECRET_SALT").ok();
-    static ref RESERVED_WM_VAR_NAME: regex::Regex = regex::Regex::new(r"^WM_[A-Z_]+$").unwrap();
-}
-
-/// Names matching this pattern are reserved for built-in `%%WM_*%%` contextual
-/// variables that SQL executors substitute raw (no escaping) into queries. A
-/// workspace admin must not be able to plant a custom env under such a name —
-/// it would shadow the built-in and inject arbitrary text into another
-/// member's SQL job, with audit attribution to that member.
-pub fn is_reserved_wm_env_name(name: &str) -> bool {
-    RESERVED_WM_VAR_NAME.is_match(name)
 }
 
 #[derive(Serialize, Clone)]
@@ -462,9 +452,10 @@ async fn get_cached_workspace_envs(conn: &Connection, w_id: &str) -> Vec<(String
     let custom_envs = if let Some(cached_envs) = cached_envs_o {
         cached_envs
     } else {
-        let raw_envs = match conn {
+        let custom_envs = match conn {
             Connection::Sql(db) => sqlx::query_as::<_, (String, String)>(
-                "SELECT name, value FROM workspace_env WHERE workspace_id = $1",
+                // Skip names that would shadow a built-in `%%WM_*%%` contextual var.
+                "SELECT name, value FROM workspace_env WHERE workspace_id = $1 AND name !~ '^WM_[A-Z_]+$'",
             )
             .bind(w_id)
             .fetch_all(db)
@@ -475,13 +466,6 @@ async fn get_cached_workspace_envs(conn: &Connection, w_id: &str) -> Vec<(String
                 .await
                 .unwrap_or_default(),
         };
-        // Defense-in-depth: drop any pre-existing custom env that matches the
-        // reserved `WM_*` pattern so it cannot shadow a built-in contextual
-        // variable in SQL substitution (see is_reserved_wm_env_name).
-        let custom_envs: Vec<(String, String)> = raw_envs
-            .into_iter()
-            .filter(|(name, _)| !is_reserved_wm_env_name(name))
-            .collect();
         CUSTOM_ENVS_CACHE.insert(
             w_id.to_string(),
             (chrono::Utc::now().timestamp(), custom_envs.clone()),

--- a/backend/windmill-common/src/variables.rs
+++ b/backend/windmill-common/src/variables.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 
 lazy_static::lazy_static! {
     pub static ref SECRET_SALT: Option<String> = std::env::var("SECRET_SALT").ok();
+    static ref RESERVED_WM_VAR_NAME: regex::Regex = regex::Regex::new(r"^WM_[A-Z_]+$").unwrap();
 }
 
 #[derive(Serialize, Clone)]
@@ -452,10 +453,9 @@ async fn get_cached_workspace_envs(conn: &Connection, w_id: &str) -> Vec<(String
     let custom_envs = if let Some(cached_envs) = cached_envs_o {
         cached_envs
     } else {
-        let custom_envs = match conn {
+        let raw_envs = match conn {
             Connection::Sql(db) => sqlx::query_as::<_, (String, String)>(
-                // Skip names that would shadow a built-in `%%WM_*%%` contextual var.
-                "SELECT name, value FROM workspace_env WHERE workspace_id = $1 AND name !~ '^WM_[A-Z_]+$'",
+                "SELECT name, value FROM workspace_env WHERE workspace_id = $1",
             )
             .bind(w_id)
             .fetch_all(db)
@@ -466,6 +466,13 @@ async fn get_cached_workspace_envs(conn: &Connection, w_id: &str) -> Vec<(String
                 .await
                 .unwrap_or_default(),
         };
+        // Applied here (not in the SQL branch alone) so agent workers going
+        // through `Connection::Http` are covered too — drop any name that
+        // would shadow a built-in `%%WM_*%%` contextual var.
+        let custom_envs: Vec<(String, String)> = raw_envs
+            .into_iter()
+            .filter(|(name, _)| !RESERVED_WM_VAR_NAME.is_match(name))
+            .collect();
         CUSTOM_ENVS_CACHE.insert(
             w_id.to_string(),
             (chrono::Utc::now().timestamp(), custom_envs.clone()),

--- a/backend/windmill-common/src/variables.rs
+++ b/backend/windmill-common/src/variables.rs
@@ -19,6 +19,16 @@ use serde::{Deserialize, Serialize};
 
 lazy_static::lazy_static! {
     pub static ref SECRET_SALT: Option<String> = std::env::var("SECRET_SALT").ok();
+    static ref RESERVED_WM_VAR_NAME: regex::Regex = regex::Regex::new(r"^WM_[A-Z_]+$").unwrap();
+}
+
+/// Names matching this pattern are reserved for built-in `%%WM_*%%` contextual
+/// variables that SQL executors substitute raw (no escaping) into queries. A
+/// workspace admin must not be able to plant a custom env under such a name —
+/// it would shadow the built-in and inject arbitrary text into another
+/// member's SQL job, with audit attribution to that member.
+pub fn is_reserved_wm_env_name(name: &str) -> bool {
+    RESERVED_WM_VAR_NAME.is_match(name)
 }
 
 #[derive(Serialize, Clone)]
@@ -452,7 +462,7 @@ async fn get_cached_workspace_envs(conn: &Connection, w_id: &str) -> Vec<(String
     let custom_envs = if let Some(cached_envs) = cached_envs_o {
         cached_envs
     } else {
-        let custom_envs = match conn {
+        let raw_envs = match conn {
             Connection::Sql(db) => sqlx::query_as::<_, (String, String)>(
                 "SELECT name, value FROM workspace_env WHERE workspace_id = $1",
             )
@@ -465,6 +475,13 @@ async fn get_cached_workspace_envs(conn: &Connection, w_id: &str) -> Vec<(String
                 .await
                 .unwrap_or_default(),
         };
+        // Defense-in-depth: drop any pre-existing custom env that matches the
+        // reserved `WM_*` pattern so it cannot shadow a built-in contextual
+        // variable in SQL substitution (see is_reserved_wm_env_name).
+        let custom_envs: Vec<(String, String)> = raw_envs
+            .into_iter()
+            .filter(|(name, _)| !is_reserved_wm_env_name(name))
+            .collect();
         CUSTOM_ENVS_CACHE.insert(
             w_id.to_string(),
             (chrono::Utc::now().timestamp(), custom_envs.clone()),


### PR DESCRIPTION
Fixes WIN-1964

## Context

Triages and addresses the four findings from Moran's Q1 2026 vulnerability report against v1.704.1-14 (commit 4b1bea8aed). All four are Low severity, auth-gated bugs.

## Triage summary

| # | Finding | Status |
|---|---------|--------|
| 1 | SQL injection via unescaped `%%WM_*%%` substitution in SQL executors | **Fixed** |
| 2 | App policy bypass via `force_viewer_*` query params in `apps_u` S3 handlers | **Fixed** (upload + download) |
| 3 | `/path_autocomplete/list_paths` returns workspace-wide path names | **Won't fix** — documented as intentional in `backend/windmill-api/src/path_autocomplete.rs:30-33`; reporter agrees this is design intent, not a vuln |
| 4 | Cross-workspace tampering of `v2_job_status.flow_status->progress` via `/job_metrics/set_progress/{id}` | **Fixed** (concrete bug). Structural RLS gap on `v2_job_status` / `v2_job_runtime` left as a separate follow-up — see "Known follow-up" below |

## Changes

### #1 — Reserve `WM_*` prefix for workspace_env names
- `windmill-common/src/variables.rs`: new `is_reserved_wm_env_name()` helper. `get_cached_workspace_envs` filters out names matching `^WM_[A-Z_]+$` so any pre-existing planted entries are inert.
- `windmill-api-workspaces/src/workspaces.rs::set_environment_variable`: reject reserved `WM_*` names at the admin set endpoint.

Closes the admin → member attribution-forgery primitive: a workspace admin could plant `workspace_env.name = 'WM_FOO'` and have its value substituted raw into any other member's SQL job referencing `%%WM_FOO%%`, with audit attribution to the member.

### #2 — Apply preview-mode guard to S3 sibling handlers
Apply the same authed + non-operator + scope guard PR #9235 added to `execute_component` to the two sibling `apps_u` S3 handlers that accept `force_viewer_*` synthetic-policy params:
- `upload_s3_file_from_app` (gates `force_viewer_file_key_regex`)
- `download_s3_file_from_app` (gates `force_viewer_allowed_s3_keys`)

`delete_s3_file_from_app` is naturally gated because it consumes a JWT delete token issued by `upload`, so the upload guard cascades.

### #4 — Scope `set_job_progress` UPDATE by workspace_id
`v2_job_status` has no `workspace_id` column and is updated via the root db handle (the per-row policy on the table is also inert today — `ENABLE ROW LEVEL SECURITY` was never set). The UPDATE in `set_job_progress` filtered only by `id`, so any authed member of any workspace could overwrite another workspace's flow `progress` UI field given just the flow UUID.

Fixed by joining `v2_job` and confining the update to the URL's `w_id`.

## Known follow-up (out of scope here)

The structural RLS gap the reporter calls out — `v2_job_status` and `v2_job_runtime` declare a `CREATE POLICY admin_policy` but never `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` (same anti-pattern as PR #9202 / GHSA-8mv7-hmrg-96xv) — is a broader cleanup. Enabling RLS on those tables needs:
1. Companion `windmill_user` row policies (these tables only have `admin_policy` today, so enabling RLS would break user_db queries that JOIN to them — there is at least one such path in `windmill-api/src/jobs.rs`).
2. Cross-checking every user_db query that touches `v2_job_status` / `v2_job_runtime`.

The concrete `set_progress` tampering primitive is closed by this PR; the structural fix is tracked separately.

## Validation

- `cargo check` clean (live + `SQLX_OFFLINE=true`)
- Backend hot-reloaded clean: `health check completed status="healthy"`
- `.sqlx/` regenerated; EE caches restored from `origin/main` (0 net deletions)

## Notes on the report itself

Overall the report is high-quality:
- Honest severity downgrades (`CRITICAL_REVIEW.md` mentioned in the email).
- Correctly identified PR #9235's pattern and pointed out the three sibling handlers.
- Correctly identified the `ENABLE ROW LEVEL SECURITY`/`CREATE POLICY` anti-pattern.
- Correctly flagged #3 as inconsistency vs. vulnerability after reading the source comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened workspace env substitution, S3 app preview handlers, and job progress updates to resolve Q1 2026 vuln report findings #1, #2, and #4. Addresses WIN-1964; finding #3 is intentional and unchanged.

- **Bug Fixes**
  - SQL executors: filtered reserved `WM_*` names in the workspace env cache across both SQL and HTTP agent-worker paths to block raw `%%WM_*%%` injection.
  - App S3 preview: added preview-mode guard to `upload_s3_file_from_app` and `download_s3_file_from_app` when using `force_viewer_*` (auth required, not operator, require `apps:write`; normalized scope path).
  - Job metrics: scoped `set_job_progress` by joining `v2_job` and requiring `workspace_id` to prevent cross-workspace progress tampering.

<sup>Written for commit 42ac1568103bb6bbf5dfd02d1729518dad2cf517. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9264?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

