### PR TITLE
chore: add playwright mcp for frontend verification

### DIFF
--- a/.agents/skills/svelte-frontend/SKILL.md
+++ b/.agents/skills/svelte-frontend/SKILL.md
@@ -78,3 +78,7 @@ Use the Svelte MCP tools when working on Svelte code:
 2. **get-documentation**: Fetch relevant sections based on use_cases
 3. **svelte-autofixer**: MUST use on all Svelte code before finalizing — keep calling until no issues
 4. **playground-link**: Only after user confirms and code was NOT written to project files
+
+## Verifying in the Browser
+
+After changing Svelte code, use the **Playwright MCP** (`mcp__playwright__*`) to drive the running frontend and confirm the change works. See AGENTS.md → "Verifying Frontend Changes" for the full flow. Use `playwright` (headless) on devboxes; `playwright-headed` when a display is available.

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,16 @@
     "svelte": {
       "type": "http",
       "url": "https://mcp.svelte.dev/mcp"
+    },
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest", "--browser", "chromium", "--headless"]
+    },
+    "playwright-headed": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest", "--browser", "chromium"]
     }
   }
 }

--- a/.webmux.yaml
+++ b/.webmux.yaml
@@ -47,6 +47,7 @@ profiles:
       For this window specifically, backend is running on: ${BACKEND_PORT} and frontend is running on: ${FRONTEND_PORT}.
       To connect to the database, use this connection string: ${DATABASE_URL}
       Because we are running backend with cargo watch, to verify your changes, just check the logs in the backend pane. No need for cargo check.
+      For UI verification, use the Playwright MCP (`mcp__playwright__*`) — the `playwright` server is headless and works without a display. Navigate to http://localhost:${FRONTEND_PORT}, log in as admin@windmill.dev / changeme.
       IMPORTANT: Read docs/autonomous-mode.md before starting any work.
     panes:
       - id: agent
@@ -76,6 +77,7 @@ profiles:
       On this window specifically, frontend is running on: ${FRONTEND_PORT}.
       To connect to the database, use this connection string: ${DATABASE_URL}
       Because we are running frontend with npm run dev, to verify your changes, just check the logs in the frontend pane. No need for npm run build.
+      For UI verification, use the Playwright MCP (`mcp__playwright__*`) — the `playwright` server is headless and works without a display. Navigate to http://localhost:${FRONTEND_PORT}, log in as admin@windmill.dev / changeme.
       IMPORTANT: Read docs/autonomous-mode.md before starting any work.
     panes:
       - id: agent
@@ -124,7 +126,9 @@ oneshot:
     Take the task to its real conclusion without pausing:
       1. Make the change.
       2. Validate it (run the relevant tests, typecheck, build, or quick
-         manual check).
+         manual check). For UI changes, drive the running frontend with
+         the Playwright MCP (`mcp__playwright__*`, headless) and confirm
+         the change works end-to-end before moving on.
       3. Commit.
       4. Push.
       5. Open a pull request.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,26 @@ Open-source platform for internal tools, workflows, API integrations, background
 - **Instance settings**: navigate to `/#superadmin-settings`
 - **Migrations**: use `cargo sqlx migrate add -r <name>` from `backend/` to create new migrations (never generate timestamps manually)
 
+## Verifying Frontend Changes
+
+After modifying frontend code, drive the running dev server with the **Playwright MCP** to verify the change in a real browser — don't claim a UI change works without exercising it.
+
+Two MCP servers are registered in `.mcp.json`:
+- `playwright` — headless Chromium, default for devboxes (no display required)
+- `playwright-headed` — windowed Chromium, when a display is available
+
+**One-time setup:** run `npx playwright install chromium` to download the browser binary (Playwright won't fetch it automatically on first use).
+
+Typical flow:
+1. Ensure backend (`cargo run`) and frontend (`REMOTE=http://localhost:8000 npm run dev`) are running
+2. `mcp__playwright__browser_navigate` to the relevant page (login at `admin@windmill.dev` / `changeme`)
+3. `mcp__playwright__browser_snapshot` to inspect the accessibility tree (preferred over screenshots for reading the DOM)
+4. `mcp__playwright__browser_click` / `browser_fill_form` / `browser_type` to interact
+5. `mcp__playwright__browser_take_screenshot` for visual confirmation
+6. `mcp__playwright__browser_console_messages` / `browser_network_requests` to surface errors
+
+If you cannot exercise a UI change (no dev server, etc.), say so explicitly rather than claiming success.
+
 ## Banned Patterns
 
 ### `$bindable(default_value)` on optional props


### PR DESCRIPTION
## Summary
Register a Playwright MCP server in `.mcp.json` so any agent (Claude Code, Codex, etc.) working on Windmill can drive a real browser to verify frontend changes — and document when/how to use it.

## Changes
- `.mcp.json`: add two stdio servers — `playwright` (headless Chromium, default for devboxes) and `playwright-headed` (windowed, when a display is available). Both use `npx -y @playwright/mcp@latest --browser chromium`.
- `AGENTS.md`: new "Verifying Frontend Changes" section with one-time setup (`npx playwright install chromium`) and the typical navigate → snapshot → interact → screenshot flow.
- `.agents/skills/svelte-frontend/SKILL.md`: pointer to the AGENTS.md section so the guidance fires whenever the svelte skill is loaded.
- `.webmux.yaml`: Playwright note added to the `full` and `frontendOnly` profile prompts (with `${FRONTEND_PORT}` + login), and to the `oneshot` validation step so UI changes get exercised before a PR is opened.

## Test plan
- [ ] Run `npx playwright install chromium` once on the devbox
- [ ] Restart Claude Code (or other MCP client) so the new servers in `.mcp.json` are picked up
- [ ] Call `mcp__playwright__browser_navigate` against the running frontend and confirm a snapshot/screenshot comes back

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Playwright MCP servers so agents can drive a real Chromium browser to verify frontend changes end-to-end. Updates docs and dev prompts to make UI verification part of the default flow.

- **New Features**
  - `.mcp.json`: register `playwright` (headless) and `playwright-headed` via `npx -y @playwright/mcp@latest --browser chromium`.
  - `AGENTS.md`: add “Verifying Frontend Changes” with setup and common actions.
  - `.agents/skills/svelte-frontend/SKILL.md`: point to using Playwright MCP after Svelte changes.
  - `.webmux.yaml`: mention Playwright in profile prompts and require it in oneshot validation.

- **Migration**
  - Run `npx playwright install chromium` once to install the browser binary.

<sup>Written for commit a0b2d84d710a1c1fa7a6df38078f351def3bd5f3. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9269?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

