### PR TITLE
feat: add UV_PYTHON_INSTALL_MIRROR env and instance setting

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -58,7 +58,7 @@ use windmill_common::{
         RESTART_COORDINATION_SETTING, RETENTION_PERIOD_SECS_SETTING, RUBY_REPOS_SETTING,
         SAML_METADATA_SETTING, SCIM_TOKEN_SETTING, SMTP_SETTING, STORE_AUDIT_LOGS_S3_SETTING,
         TEAMS_SETTING, TIMEOUT_WAIT_RESULT_SETTING, UV_EXCLUDE_NEWER_SETTING,
-        UV_INDEX_STRATEGY_SETTING, WORKSPACE_REGISTRIES_SETTING,
+        UV_INDEX_STRATEGY_SETTING, UV_PYTHON_INSTALL_MIRROR_SETTING, WORKSPACE_REGISTRIES_SETTING,
     },
     scripts::ScriptLang,
     stats_oss::schedule_stats,
@@ -131,7 +131,8 @@ use crate::monitor::{
     reload_otel_tracing_proxy_setting, reload_pip_index_url_setting,
     reload_retention_period_setting, reload_scim_token_setting, reload_smtp_config,
     reload_store_audit_logs_s3_setting, reload_uv_exclude_newer_setting,
-    reload_uv_index_strategy_setting, reload_worker_config, MonitorIteration,
+    reload_uv_index_strategy_setting, reload_uv_python_install_mirror_setting,
+    reload_worker_config, MonitorIteration,
 };
 
 #[cfg(feature = "parquet")]
@@ -1795,6 +1796,9 @@ async fn process_notify_event(
                 PIP_INDEX_URL_SETTING => reload_pip_index_url_setting(conn).await,
                 UV_INDEX_STRATEGY_SETTING => reload_uv_index_strategy_setting(conn).await,
                 UV_EXCLUDE_NEWER_SETTING => reload_uv_exclude_newer_setting(conn).await,
+                UV_PYTHON_INSTALL_MIRROR_SETTING => {
+                    reload_uv_python_install_mirror_setting(conn).await
+                }
                 BUN_INSTALL_MIN_RELEASE_AGE_SETTING => {
                     reload_bun_install_min_release_age_setting(conn).await
                 }

--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -68,6 +68,7 @@ use windmill_common::{
         REQUIRE_PREEXISTING_USER_FOR_OAUTH_SETTING, RETENTION_PERIOD_SECS_SETTING,
         SAML_METADATA_SETTING, SCIM_TOKEN_SETTING, STORE_AUDIT_LOGS_S3_SETTING,
         TIMEOUT_WAIT_RESULT_SETTING, UV_EXCLUDE_NEWER_SETTING, UV_INDEX_STRATEGY_SETTING,
+        UV_PYTHON_INSTALL_MIRROR_SETTING,
     },
     indexer::load_indexer_config,
     jwt::JWT_SECRET,
@@ -109,7 +110,7 @@ use windmill_worker::{
     NO_DEFAULT_MAVEN, NPMRC, NPM_CONFIG_REGISTRY, NSJAIL_AVAILABLE, NSJAIL_TMPFS_SIZE_MB,
     NUGET_CONFIG, OTEL_TRACING_PROXY_SETTINGS, PIP_EXTRA_INDEX_URL, PIP_INDEX_URL,
     POWERSHELL_REPO_PAT, POWERSHELL_REPO_URL, UNSHARE_PATH, UV_EXCLUDE_NEWER, UV_INDEX_STRATEGY,
-    WORKSPACE_REGISTRIES,
+    UV_PYTHON_INSTALL_MIRROR, WORKSPACE_REGISTRIES,
 };
 
 #[cfg(feature = "parquet")]
@@ -390,6 +391,7 @@ pub async fn initial_load(
         reload_pip_index_url_setting(&conn).await;
         reload_uv_index_strategy_setting(&conn).await;
         reload_uv_exclude_newer_setting(&conn).await;
+        reload_uv_python_install_mirror_setting(&conn).await;
         reload_bun_install_min_release_age_setting(&conn).await;
         reload_npm_config_registry_setting(&conn).await;
         reload_bunfig_install_scopes_setting(&conn).await;
@@ -1623,6 +1625,16 @@ pub async fn reload_uv_exclude_newer_setting(conn: &Connection) {
         UV_EXCLUDE_NEWER_SETTING,
         "UV_EXCLUDE_NEWER",
         UV_EXCLUDE_NEWER.clone(),
+    )
+    .await;
+}
+
+pub async fn reload_uv_python_install_mirror_setting(conn: &Connection) {
+    reload_option_setting_with_tracing(
+        conn,
+        UV_PYTHON_INSTALL_MIRROR_SETTING,
+        "UV_PYTHON_INSTALL_MIRROR",
+        UV_PYTHON_INSTALL_MIRROR.clone(),
     )
     .await;
 }

--- a/backend/windmill-common/src/global_settings.rs
+++ b/backend/windmill-common/src/global_settings.rs
@@ -36,6 +36,7 @@ pub const EXTRA_PIP_INDEX_URL_SETTING: &str = "pip_extra_index_url";
 pub const PIP_INDEX_URL_SETTING: &str = "pip_index_url";
 pub const UV_INDEX_STRATEGY_SETTING: &str = "uv_index_strategy";
 pub const UV_EXCLUDE_NEWER_SETTING: &str = "uv_exclude_newer";
+pub const UV_PYTHON_INSTALL_MIRROR_SETTING: &str = "uv_python_install_mirror";
 pub const BUN_INSTALL_MIN_RELEASE_AGE_SETTING: &str = "bun_install_min_release_age";
 pub const INSTANCE_PYTHON_VERSION_SETTING: &str = "instance_python_version";
 pub const RUFF_CONFIG_SETTING: &str = "ruff_config";
@@ -125,6 +126,7 @@ pub const ENV_SETTINGS: &[&str] = &[
     "PIP_INDEX_URL",
     "PIP_EXTRA_INDEX_URL",
     "PIP_TRUSTED_HOST",
+    "UV_PYTHON_INSTALL_MIRROR",
     "PATH",
     "HOME",
     "DATABASE_CONNECTIONS",

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -155,7 +155,7 @@ use crate::{
     worker_utils::ping_job_status,
     PyV, DISABLE_NUSER, HOME_ENV, NSJAIL_AVAILABLE, NSJAIL_PATH, PATH_ENV, PIP_EXTRA_INDEX_URL,
     PIP_INDEX_URL, PROXY_ENVS, PY_INSTALL_DIR, TRACING_PROXY_CA_CERT_PATH, TZ_ENV, UV_CACHE_DIR,
-    UV_EXCLUDE_NEWER, UV_INDEX_STRATEGY,
+    UV_EXCLUDE_NEWER, UV_INDEX_STRATEGY, UV_PYTHON_INSTALL_MIRROR,
 };
 use windmill_common::client::AuthedClient;
 
@@ -392,6 +392,10 @@ pub async fn uv_pip_compile(
             .args(&args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+
+        if let Some(mirror) = UV_PYTHON_INSTALL_MIRROR.read().await.as_ref() {
+            child_cmd.env("UV_PYTHON_INSTALL_MIRROR", mirror);
+        }
 
         #[cfg(windows)]
         {
@@ -2033,6 +2037,10 @@ async fn spawn_uv_install(
         if let Some(v) = uv_exclude_newer {
             vars.push(("UV_EXCLUDE_NEWER", v));
         }
+        let uv_python_install_mirror = UV_PYTHON_INSTALL_MIRROR.read().await.clone();
+        if let Some(mirror) = uv_python_install_mirror.as_ref() {
+            vars.push(("UV_PYTHON_INSTALL_MIRROR", mirror));
+        }
 
         std::fs::create_dir_all(venv_p)?;
         let nsjail_proto = format!("{req}.config.proto");
@@ -2115,6 +2123,9 @@ async fn spawn_uv_install(
         let mut envs = vec![("PATH", PATH_ENV.as_str())];
         envs.push(("HOME", HOME_ENV.as_str()));
         envs.push(("UV_INDEX_STRATEGY", uv_index_strategy));
+        if let Some(mirror) = uv_python_install_mirror.as_ref() {
+            envs.push(("UV_PYTHON_INSTALL_MIRROR", mirror));
+        }
 
         if let Some(url) = pip_index_url.as_ref() {
             command_args.extend(["--index-url", url]);

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -1999,6 +1999,7 @@ async fn spawn_uv_install(
         .unwrap_or("unsafe-best-match");
     let uv_exclude_newer = (*UV_EXCLUDE_NEWER.read().await).map(|secs| format!("{}s", secs));
     let uv_exclude_newer = uv_exclude_newer.as_deref();
+    let uv_python_install_mirror = UV_PYTHON_INSTALL_MIRROR.read().await.clone();
 
     if is_sandboxing_enabled() {
         tracing::info!(
@@ -2037,7 +2038,6 @@ async fn spawn_uv_install(
         if let Some(v) = uv_exclude_newer {
             vars.push(("UV_EXCLUDE_NEWER", v));
         }
-        let uv_python_install_mirror = UV_PYTHON_INSTALL_MIRROR.read().await.clone();
         if let Some(mirror) = uv_python_install_mirror.as_ref() {
             vars.push(("UV_PYTHON_INSTALL_MIRROR", mirror));
         }

--- a/backend/windmill-worker/src/python_versions.rs
+++ b/backend/windmill-worker/src/python_versions.rs
@@ -25,7 +25,7 @@ use crate::{
     handle_child::handle_child,
     python_executor::{INDEX_CERT, NATIVE_CERT, PYTHON_PATH},
     HOME_ENV, INSTANCE_PYTHON_VERSION, PATH_ENV, PROXY_ENVS, PY_INSTALL_DIR, UV_CACHE_DIR,
-    WIN_ENVS,
+    UV_PYTHON_INSTALL_MIRROR, WIN_ENVS,
 };
 
 impl From<PyV> for PyVAlias {
@@ -545,6 +545,10 @@ impl PyV {
             ])
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+
+        if let Some(mirror) = UV_PYTHON_INSTALL_MIRROR.read().await.as_ref() {
+            child_cmd.env("UV_PYTHON_INSTALL_MIRROR", mirror);
+        }
 
         #[cfg(windows)]
         {

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -686,6 +686,11 @@ lazy_static::lazy_static! {
     /// When `None` (or non-positive), executors fall back to the unified
     /// `DEFAULT_NSJAIL_TMPFS_SIZE_BYTES` (800MB).
     pub static ref NSJAIL_TMPFS_SIZE_MB: Arc<RwLock<Option<i64>>> = Arc::new(RwLock::new(None));
+
+    /// Optional mirror URL for `uv python install`. Wires to the `UV_PYTHON_INSTALL_MIRROR`
+    /// env var when forwarded to uv. Can be set via the `UV_PYTHON_INSTALL_MIRROR` env var
+    /// or the `uv_python_install_mirror` instance setting.
+    pub static ref UV_PYTHON_INSTALL_MIRROR: Arc<RwLock<Option<String>>> = Arc::new(RwLock::new(None));
 }
 
 pub fn sleep_queue() -> u64 {

--- a/frontend/src/lib/components/instanceSettings.ts
+++ b/frontend/src/lib/components/instanceSettings.ts
@@ -475,7 +475,7 @@ export const settings: Record<string, Setting[]> = {
 				'Mirror URL for downloading managed Python interpreters. Wires to <code>UV_PYTHON_INSTALL_MIRROR</code>. See <a href="https://docs.astral.sh/uv/configuration/environment/#uv_python_install_mirror">uv docs</a>.',
 			key: 'uv_python_install_mirror',
 			fieldType: 'text',
-			placeholder: 'https://github.com/astral-sh/python-build-standalone/releases/download',
+			placeholder: 'https://mirror.example.com/python-build-standalone',
 			storage: 'setting'
 		},
 		{

--- a/frontend/src/lib/components/instanceSettings.ts
+++ b/frontend/src/lib/components/instanceSettings.ts
@@ -470,6 +470,15 @@ export const settings: Record<string, Setting[]> = {
 			ee_only: ''
 		},
 		{
+			label: 'UV Python install mirror',
+			description:
+				'Mirror URL for downloading managed Python interpreters. Wires to <code>UV_PYTHON_INSTALL_MIRROR</code>. See <a href="https://docs.astral.sh/uv/configuration/environment/#uv_python_install_mirror">uv docs</a>.',
+			key: 'uv_python_install_mirror',
+			fieldType: 'text',
+			placeholder: 'https://github.com/astral-sh/python-build-standalone/releases/download',
+			storage: 'setting'
+		},
+		{
 			label: 'UV index strategy',
 			description:
 				'Strategy for resolving packages from multiple indexes. See <a href="https://docs.astral.sh/uv/pip/compatibility/#packages-that-exist-on-multiple-indexes">uv docs</a>',
@@ -1110,7 +1119,10 @@ export function buildSearchableSettingItems(
 	return items
 }
 
-/** Registry settings that support per-workspace overrides. Excludes instance_python_version and uv_index_strategy which are instance-wide only. */
+/** Registry settings that support per-workspace overrides. Excludes instance_python_version, uv_index_strategy, and uv_python_install_mirror which are instance-wide only. */
 export const WORKSPACE_REGISTRY_SETTINGS: Setting[] = settings['Registries'].filter(
-	(s) => s.key !== 'instance_python_version' && s.key !== 'uv_index_strategy'
+	(s) =>
+		s.key !== 'instance_python_version' &&
+		s.key !== 'uv_index_strategy' &&
+		s.key !== 'uv_python_install_mirror'
 )


### PR DESCRIPTION
## Summary

Adds support for `UV_PYTHON_INSTALL_MIRROR` as both an environment variable and an instance setting. This lets operators point `uv python install` (and any uv invocation that may auto-download a managed interpreter) at a private mirror of the python-build-standalone releases — important for air-gapped or proxied deployments.

- New `uv_python_install_mirror` instance setting (Registries section, instance-wide only — no per-workspace override)
- Reads `UV_PYTHON_INSTALL_MIRROR` env var as boot fallback; instance setting wins at reload
- Forwarded to uv in:
  - `uv python install` (`python_versions.rs`)
  - `uv pip compile` (`python_executor.rs` venv resolve path)
  - `uv pip install` (both nsjail-sandboxed and direct paths in `python_executor.rs`)
- Wired into the global-settings listener so changes apply without restart

## Test plan

- [x] `cargo check --features quickjs` clean
- [x] Backend boots healthy with `cargo watch`
- [ ] Set instance setting via superadmin UI, confirm `uv python install` honors mirror (manual, env-dependent)
- [ ] Set `UV_PYTHON_INSTALL_MIRROR` env var at worker start, confirm fallback works

Fixes WIN-1966

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for configuring a Python interpreter download mirror via `UV_PYTHON_INSTALL_MIRROR` as an instance setting and env var. This lets `uv` use private mirrors for `uv python install`, `uv pip install`, and `uv pip compile` (WIN-1966).

- **New Features**
  - Added `uv_python_install_mirror` instance setting (Registries; instance-wide only).
  - Reads `UV_PYTHON_INSTALL_MIRROR` at boot; instance setting overrides on reload.
  - Forwarded to `uv` in nsjail and direct paths; hot-reloads without restart.
  - Setting exposed in Instance Settings UI; excluded from per-workspace overrides.

- **Bug Fixes**
  - Hoisted `uv_python_install_mirror` binding so non-sandboxed `uv pip install` forwards `UV_PYTHON_INSTALL_MIRROR`; updated UI placeholder to a neutral example URL.

<sup>Written for commit 1897c309f44d620161ee78cb051231b13b6da876. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9271?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

