### PR TITLE
feat(raw_apps): tab-based editor surface with split-with-preview

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
 	"version": "1.705.0",
 	"scripts": {
 		"dev": "vite dev",
-		"dev:ui-builder": "mv static/ui_builder static/ui_builder.dev-disabled 2>/dev/null || true ; vite dev",
+		"dev:ui-builder": "mv static/ui_builder static/ui_builder.dev-disabled 2>/dev/null || true ; trap 'mv static/ui_builder.dev-disabled static/ui_builder 2>/dev/null || true' EXIT ; vite dev",
 		"build": "vite build",
 		"build:utils": "vite build --config sharedUtils/vite.sharedUtils.config.js",
 		"preview": "vite preview",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
 	"version": "1.705.0",
 	"scripts": {
 		"dev": "vite dev",
+		"dev:ui-builder": "mv static/ui_builder static/ui_builder.dev-disabled 2>/dev/null || true ; vite dev",
 		"build": "vite build",
 		"build:utils": "vite build --config sharedUtils/vite.sharedUtils.config.js",
 		"preview": "vite preview",

--- a/frontend/scripts/ui_builder_artifact.json
+++ b/frontend/scripts/ui_builder_artifact.json
@@ -1,5 +1,5 @@
 {
 	"baseUrl": "https://pub-06154ed168a24e73a86ab84db6bf15d8.r2.dev",
-	"version": "6715153",
-	"sha256": "1485930ea5f5309e4bdc09a55aae72eae8230eb74f0928715a0e6fe610703d9b"
+	"version": "61b6fdd",
+	"sha256": "d7c316b4429442eed9462756db0fdf13128849b5b9adf4a7b7acc7a26b1a7280"
 }

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { buildWsUrl } from '$lib/wsUrl'
+	import { paneMinPercent } from '$lib/utils/splitpaneSizing'
 	import { processSecretArgs } from './secretArgUtils'
 	import type { Schema, SupportedLanguage } from '$lib/common'
 	import {
@@ -1351,7 +1352,7 @@
 	let splitContainerWidth = $state(0)
 	const TEST_PANE_MIN_PX = 400
 	const testPaneMinPercent = $derived(
-		splitContainerWidth > 0 ? Math.min(80, (TEST_PANE_MIN_PX / splitContainerWidth) * 100) : 0
+		paneMinPercent(splitContainerWidth, TEST_PANE_MIN_PX)
 	)
 
 	// Raw user-controlled test size (what the splitter wrote, or what the

--- a/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
+++ b/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
@@ -5,11 +5,23 @@
 		label: string
 		/** Optional lucide-svelte (or compatible) component rendered at 12px before the label. */
 		icon?: any
+		/** Optional class applied to the icon (e.g. `text-accent` to tint it). */
+		iconClass?: string
+		/** Optional class applied to the label text (e.g. `text-accent` to tint it). */
+		labelClass?: string
 		/** Defaults to true. Set false to hide the × close button. */
 		closable?: boolean
 		/** Pinned tabs are rendered outside the drag zone — 'left' or 'right' of the draggable group. */
 		pinned?: 'left' | 'right'
 	}
+
+	// Per-instance counter so every DraggableTabs gets its own dnd zone `type`.
+	// svelte-dnd-action treats zones sharing a `type` as one connected pool:
+	// two bars rendering the same tab ids (e.g. the mirrored single-view bars)
+	// would let a drag in one bar mark the matching item as a hidden shadow
+	// placeholder in the other and never clear it. Unique types keep them
+	// independent. We never drag tabs between two bars, so this loses nothing.
+	let dndZoneSeq = 0
 </script>
 
 <script lang="ts">
@@ -17,6 +29,7 @@
 	import { X } from 'lucide-svelte'
 	import { twMerge } from 'tailwind-merge'
 	import { createScrollArea, melt } from '@melt-ui/svelte'
+	import { untrack } from 'svelte'
 
 	interface Props {
 		tabs: TabItem[]
@@ -30,19 +43,31 @@
 		trailing?: import('svelte').Snippet
 	}
 
-	let {
-		tabs,
-		activeId,
-		onSelect,
-		onClose,
-		onReorder,
-		class: c = '',
-		trailing
-	}: Props = $props()
+	let { tabs, activeId, onSelect, onClose, onReorder, class: c = '', trailing }: Props = $props()
 
 	const pinnedLeft = $derived(tabs.filter((t) => t.pinned === 'left'))
 	const middle = $derived(tabs.filter((t) => !t.pinned))
 	const pinnedRight = $derived(tabs.filter((t) => t.pinned === 'right'))
+
+	// Unique dnd zone type for this instance (see note in the module block).
+	const dndType = `draggable-tabs-${dndZoneSeq++}`
+
+	// Local copy of the draggable items that the dnd zone owns and renders.
+	// We deliberately do NOT push `handleConsider` updates back to the parent:
+	// mid-drag, svelte-dnd-action injects a hidden "shadow placeholder" item
+	// into `e.detail.items`. If that reached the parent `tabs`, any sibling
+	// DraggableTabs bound to the same `tabs` (e.g. the mirrored single-view
+	// bars) would render the placeholder as a `visibility:hidden` ghost and
+	// keep it after the drag — the disappearing-tab bug. So consider only
+	// updates this local list (live feedback for the dragged bar); we commit
+	// to the parent on finalize, when the placeholder is already gone.
+	let dndMiddle = $state<TabItem[]>(untrack(() => middle))
+	let isDragging = false
+	$effect(() => {
+		const next = middle
+		// Re-sync from props except mid-drag, where the dnd zone owns the list.
+		if (!isDragging) dndMiddle = next
+	})
 
 	// Melt scroll-area: type='always' keeps the custom thumb's gutter present
 	// at all times, so the layout never shifts when content stops/starts
@@ -52,15 +77,14 @@
 		elements: { root, viewport, content, scrollbarX, thumbX }
 	} = createScrollArea({ type: 'always', dir: 'ltr' })
 
-	function rebuild(middleNew: TabItem[]) {
-		onReorder?.([...pinnedLeft, ...middleNew, ...pinnedRight])
-	}
-
 	function handleConsider(e: CustomEvent<DndEvent<TabItem>>) {
-		rebuild(e.detail.items)
+		isDragging = true
+		dndMiddle = e.detail.items
 	}
 	function handleFinalize(e: CustomEvent<DndEvent<TabItem>>) {
-		rebuild(e.detail.items)
+		isDragging = false
+		dndMiddle = e.detail.items
+		onReorder?.([...pinnedLeft, ...e.detail.items, ...pinnedRight])
 	}
 
 	function tabClasses(isActive: boolean) {
@@ -107,15 +131,15 @@
 		role="tab"
 		aria-selected={isActive}
 		tabindex={isActive ? 0 : -1}
-		class={tabClasses(isActive)}
+		class={twMerge(tabClasses(isActive), tab.closable !== false && 'pr-1')}
 		onclick={() => onSelect(tab.id)}
 		onauxclick={(e) => handleAuxClick(e, tab)}
 		onkeydown={(e) => handleKeydown(e, tab)}
 	>
 		{#if Icon}
-			<Icon size={12} />
+			<Icon size={12} class={tab.iconClass} />
 		{/if}
-		<span class="truncate max-w-[180px]">{tab.label}</span>
+		<span class={twMerge('truncate max-w-[180px]', tab.labelClass)}>{tab.label}</span>
 		{#if tab.closable !== false}
 			<button
 				type="button"
@@ -132,9 +156,7 @@
 	</div>
 {/snippet}
 
-<div
-	class={twMerge('flex items-center bg-surface-secondary', c)}
->
+<div class={twMerge('flex items-center bg-surface-secondary', c)}>
 	<div use:melt={$root} class="tabs-root flex-1 min-w-0 relative pt-1 pl-1 pb-1">
 		<div use:melt={$viewport} class="tabs-viewport w-full">
 			<!-- Inner flex wrapper — melt's content element is forced to
@@ -148,15 +170,15 @@
 					<div
 						class="flex items-center"
 						use:dndzone={{
-							items: middle,
+							items: dndMiddle,
 							flipDurationMs: 150,
-							type: 'draggable-tabs',
+							type: dndType,
 							dropTargetStyle: {}
 						}}
 						onconsider={handleConsider}
 						onfinalize={handleFinalize}
 					>
-						{#each middle as tab (tab.id)}
+						{#each dndMiddle as tab (tab.id)}
 							<div>
 								{@render tabButton(tab)}
 							</div>

--- a/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
+++ b/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
@@ -69,13 +69,34 @@
 		if (!isDragging) dndMiddle = next
 	})
 
-	// Melt scroll-area: type='always' keeps the custom thumb's gutter present
-	// at all times, so the layout never shifts when content stops/starts
-	// overflowing. The native horizontal scrollbar is hidden by melt and our
-	// own 4px-tall track sits along the bottom of the strip.
+	// Melt scroll-area: type='hover' reveals the custom 4px horizontal bar
+	// only while the user hovers the tab strip (or scrolls it), then hides it
+	// after `hideDelay`. melt flips the scrollbar's data-state, which our CSS
+	// fades. The bar is absolutely positioned and its gutter is reserved by
+	// the root's bottom padding, so showing/hiding it never shifts the layout.
 	const {
 		elements: { root, viewport, content, scrollbarX, thumbX }
-	} = createScrollArea({ type: 'always', dir: 'ltr' })
+	} = createScrollArea({ type: 'hover', hideDelay: 600, dir: 'ltr' })
+
+	// melt's scroll-area only recomputes the thumb from a ResizeObserver on its
+	// *content* element, never the viewport. So resizing the pane (viewport
+	// shrinks/grows while the fixed-width tabs don't) leaves the thumb size and
+	// overflow state stale — a known melt limitation. We detect viewport width
+	// changes with `bind:clientWidth` below and nudge melt: perturb the content
+	// box by 1px (then revert) so its observer fires and recomputes against the
+	// new viewport. The sentinel is 0×0, so nothing is visible.
+	let viewportWidth = $state(0)
+	let resizeSentinel: HTMLSpanElement | undefined = $state(undefined)
+	$effect(() => {
+		void viewportWidth
+		const el = untrack(() => resizeSentinel)
+		if (!el) return
+		el.style.width = '1px'
+		const raf = requestAnimationFrame(() => {
+			el.style.width = '0px'
+		})
+		return () => cancelAnimationFrame(raf)
+	})
 
 	function handleConsider(e: CustomEvent<DndEvent<TabItem>>) {
 		isDragging = true
@@ -158,7 +179,7 @@
 
 <div class={twMerge('flex items-center bg-surface-secondary', c)}>
 	<div use:melt={$root} class="tabs-root flex-1 min-w-0 relative pt-1 pl-1 pb-1">
-		<div use:melt={$viewport} class="tabs-viewport w-full">
+		<div use:melt={$viewport} bind:clientWidth={viewportWidth} class="tabs-viewport w-full">
 			<!-- Inner flex wrapper — melt's content element is forced to
 				 `display: table` which would stack the tabs vertically. -->
 			<div use:melt={$content}>
@@ -188,6 +209,14 @@
 					{#each pinnedRight as tab (tab.id)}
 						{@render tabButton(tab)}
 					{/each}
+
+					<!-- 0×0 sentinel used to nudge melt's content ResizeObserver
+						 on pane resize (see the $effect above). -->
+					<span
+						bind:this={resizeSentinel}
+						aria-hidden="true"
+						style="display:inline-block;width:0;height:0"
+					></span>
 				</div>
 			</div>
 		</div>
@@ -213,32 +242,39 @@
 	}
 
 	/* 4px-tall custom horizontal scrollbar pinned to the bottom of the
-	   strip. With melt's `type: 'always'` the track is permanently present,
-	   so there's no layout shift when content stops overflowing, and the
-	   appearance is identical on macOS, Linux, and Windows regardless of
-	   the OS scrollbar setting. */
+	   strip. It's absolutely positioned, so showing/hiding it never shifts
+	   the tab layout. Appearance is identical across OSes regardless of the
+	   native scrollbar setting. */
 	:global([data-melt-scroll-area-scrollbar].tabs-scrollbar) {
 		height: 4px;
 		background: transparent;
 		touch-action: none;
 		user-select: none;
+		transition: opacity 0.15s;
+	}
+	/* melt flips the scrollbar's data-state to "hidden" when it shouldn't be
+	   shown (with `type: 'hover'`, whenever the strip isn't hovered/scrolled);
+	   fade the whole bar (thumb included) out then. The thumb's own data-state
+	   is unrelated, so we key off the scrollbar here, not the thumb. */
+	:global([data-melt-scroll-area-scrollbar].tabs-scrollbar[data-state='hidden']) {
+		opacity: 0;
+		pointer-events: none;
 	}
 	:global([data-melt-scroll-area-thumb].tabs-thumb) {
+		/* melt sizes the thumb via inline `height: var(--melt-scroll-area-thumb-height)`,
+		   but only populates the WIDTH var for a horizontal scrollbar — the height
+		   var stays empty, so the inline height collapses to 0 and the thumb is
+		   invisible. Supply the cross-axis size here so the inline `var()` resolves
+		   to the full 4px track height. */
+		--melt-scroll-area-thumb-height: 100%;
 		height: 100%;
 		width: var(--melt-scroll-area-thumb-width);
-		background: rgb(var(--color-text-hint));
+		background: rgb(var(--color-text-hint) / 0.35);
 		border-radius: 2px;
 		position: relative;
 		transition: background-color 0.15s;
 	}
-	/* When the content fits the viewport melt sets data-state="hidden" but
-	   leaves the element at full width — without this rule it looks like a
-	   bar spanning the whole track. Hide it so the strip's bottom row is
-	   empty until there's actually something to scroll. */
-	:global([data-melt-scroll-area-thumb].tabs-thumb[data-state='hidden']) {
-		opacity: 0;
-	}
 	:global([data-melt-scroll-area-thumb].tabs-thumb:hover) {
-		background: rgb(var(--color-text-secondary));
+		background: rgb(var(--color-text-secondary) / 0.6);
 	}
 </style>

--- a/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
+++ b/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
@@ -57,10 +57,14 @@
 
 	function tabClasses(isActive: boolean) {
 		return twMerge(
-			'group inline-flex items-center gap-1.5 px-3 h-8 text-xs select-none cursor-pointer border-r border-border-light whitespace-nowrap focus:outline-none focus-visible:ring-1 focus-visible:ring-border-selected',
+			'group inline-flex items-center gap-1.5 px-3 h-8 text-xs select-none cursor-pointer whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-border-selected focus-visible:ring-inset',
+			// Active tab shares its background with the content area below it
+			// — no border, the boundary "disappears" into the surface.
+			// Inactive tabs sit on the darker tab-strip bg and have a subtle
+			// right separator so they don't blur together.
 			isActive
-				? 'bg-surface text-primary border-b-2 border-b-accent -mb-px'
-				: 'bg-surface-secondary text-secondary hover:bg-surface-hover'
+				? 'bg-surface text-primary'
+				: 'bg-surface-secondary text-secondary border-r border-border-light hover:bg-surface-hover hover:text-primary'
 		)
 	}
 
@@ -127,7 +131,7 @@
 
 <div
 	class={twMerge(
-		'flex items-stretch border-b border-border-light overflow-x-auto bg-surface-secondary',
+		'flex items-stretch overflow-x-auto bg-surface-secondary',
 		c
 	)}
 	role="tablist"

--- a/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
+++ b/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
@@ -15,12 +15,9 @@
 		pinned?: 'left' | 'right'
 	}
 
-	// Per-instance counter so every DraggableTabs gets its own dnd zone `type`.
-	// svelte-dnd-action treats zones sharing a `type` as one connected pool:
-	// two bars rendering the same tab ids (e.g. the mirrored single-view bars)
-	// would let a drag in one bar mark the matching item as a hidden shadow
-	// placeholder in the other and never clear it. Unique types keep them
-	// independent. We never drag tabs between two bars, so this loses nothing.
+	// Per-instance dnd zone `type` so sibling bars (mirrored single-view) don't
+	// share svelte-dnd-action's item pool — otherwise a drag in one ghosts the
+	// matching tab in the other.
 	let dndZoneSeq = 0
 </script>
 
@@ -52,15 +49,9 @@
 	// Unique dnd zone type for this instance (see note in the module block).
 	const dndType = `draggable-tabs-${dndZoneSeq++}`
 
-	// Local copy of the draggable items that the dnd zone owns and renders.
-	// We deliberately do NOT push `handleConsider` updates back to the parent:
-	// mid-drag, svelte-dnd-action injects a hidden "shadow placeholder" item
-	// into `e.detail.items`. If that reached the parent `tabs`, any sibling
-	// DraggableTabs bound to the same `tabs` (e.g. the mirrored single-view
-	// bars) would render the placeholder as a `visibility:hidden` ghost and
-	// keep it after the drag — the disappearing-tab bug. So consider only
-	// updates this local list (live feedback for the dragged bar); we commit
-	// to the parent on finalize, when the placeholder is already gone.
+	// Local list the dnd zone owns. `consider` updates only this (mid-drag it
+	// holds svelte-dnd-action's shadow placeholder); we commit to the parent on
+	// `finalize` so the placeholder never leaks into a sibling bar.
 	let dndMiddle = $state<TabItem[]>(untrack(() => middle))
 	let isDragging = false
 	$effect(() => {
@@ -69,22 +60,14 @@
 		if (!isDragging) dndMiddle = next
 	})
 
-	// Melt scroll-area: type='hover' reveals the custom 4px horizontal bar
-	// only while the user hovers the tab strip (or scrolls it), then hides it
-	// after `hideDelay`. melt flips the scrollbar's data-state, which our CSS
-	// fades. The bar is absolutely positioned and its gutter is reserved by
-	// the root's bottom padding, so showing/hiding it never shifts the layout.
+	// `type: 'hover'` shows the custom bar only while hovering/scrolling the strip.
 	const {
 		elements: { root, viewport, content, scrollbarX, thumbX }
 	} = createScrollArea({ type: 'hover', hideDelay: 600, dir: 'ltr' })
 
-	// melt's scroll-area only recomputes the thumb from a ResizeObserver on its
-	// *content* element, never the viewport. So resizing the pane (viewport
-	// shrinks/grows while the fixed-width tabs don't) leaves the thumb size and
-	// overflow state stale — a known melt limitation. We detect viewport width
-	// changes with `bind:clientWidth` below and nudge melt: perturb the content
-	// box by 1px (then revert) so its observer fires and recomputes against the
-	// new viewport. The sentinel is 0×0, so nothing is visible.
+	// melt only re-measures the thumb when its *content* resizes, not the
+	// viewport — so a pane resize leaves the thumb stale. Detect width changes
+	// via `bind:clientWidth` and nudge melt by perturbing the 0×0 sentinel's box.
 	let viewportWidth = $state(0)
 	let resizeSentinel: HTMLSpanElement | undefined = $state(undefined)
 	$effect(() => {
@@ -210,8 +193,7 @@
 						{@render tabButton(tab)}
 					{/each}
 
-					<!-- 0×0 sentinel used to nudge melt's content ResizeObserver
-						 on pane resize (see the $effect above). -->
+					<!-- resize nudge for melt (see the $effect above) -->
 					<span
 						bind:this={resizeSentinel}
 						aria-hidden="true"
@@ -234,17 +216,11 @@
 </div>
 
 <style>
-	/* The melt viewport hides its own native scrollbar internally; we just
-	   need to give it a height so the content sits flush above the custom
-	   bar that lives at the bottom of the root. */
 	.tabs-viewport {
 		height: 100%;
 	}
 
-	/* 4px-tall custom horizontal scrollbar pinned to the bottom of the
-	   strip. It's absolutely positioned, so showing/hiding it never shifts
-	   the tab layout. Appearance is identical across OSes regardless of the
-	   native scrollbar setting. */
+	/* Custom 4px bar, absolutely positioned so toggling it never shifts layout. */
 	:global([data-melt-scroll-area-scrollbar].tabs-scrollbar) {
 		height: 4px;
 		background: transparent;
@@ -252,20 +228,15 @@
 		user-select: none;
 		transition: opacity 0.15s;
 	}
-	/* melt flips the scrollbar's data-state to "hidden" when it shouldn't be
-	   shown (with `type: 'hover'`, whenever the strip isn't hovered/scrolled);
-	   fade the whole bar (thumb included) out then. The thumb's own data-state
-	   is unrelated, so we key off the scrollbar here, not the thumb. */
+	/* Hide the whole bar when melt marks it hidden (key off the scrollbar, not
+	   the thumb — the thumb's data-state doesn't track overflow). */
 	:global([data-melt-scroll-area-scrollbar].tabs-scrollbar[data-state='hidden']) {
 		opacity: 0;
 		pointer-events: none;
 	}
 	:global([data-melt-scroll-area-thumb].tabs-thumb) {
-		/* melt sizes the thumb via inline `height: var(--melt-scroll-area-thumb-height)`,
-		   but only populates the WIDTH var for a horizontal scrollbar — the height
-		   var stays empty, so the inline height collapses to 0 and the thumb is
-		   invisible. Supply the cross-axis size here so the inline `var()` resolves
-		   to the full 4px track height. */
+		/* melt leaves the thumb-height var empty for a horizontal bar, collapsing
+		   the inline height to 0 — supply it so the thumb fills the 4px track. */
 		--melt-scroll-area-thumb-height: 100%;
 		height: 100%;
 		width: var(--melt-scroll-area-thumb-width);

--- a/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
+++ b/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
@@ -95,7 +95,7 @@
 		return twMerge(
 			'group inline-flex items-center gap-1.5 px-2.5 h-7 text-xs rounded-md select-none cursor-pointer whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-border-selected focus-visible:ring-inset',
 			isActive
-				? 'bg-surface-input text-primary'
+				? 'bg-surface-accent-selected text-accent'
 				: 'bg-transparent text-secondary hover:bg-surface-hover hover:text-primary'
 		)
 	}
@@ -160,7 +160,7 @@
 	</div>
 {/snippet}
 
-<div class={twMerge('flex items-center bg-surface-secondary', c)}>
+<div class={twMerge('flex items-center bg-surface', c)}>
 	<div use:melt={$root} class="tabs-root flex-1 min-w-0 relative pt-1 pl-1 pb-1">
 		<div use:melt={$viewport} bind:clientWidth={viewportWidth} class="tabs-viewport w-full">
 			<!-- Inner flex wrapper — melt's content element is forced to

--- a/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
+++ b/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
@@ -1,0 +1,166 @@
+<script lang="ts" module>
+	export type TabItem = {
+		/** Stable identifier; used as the `[key]` for dnd and the activeId equality check. */
+		id: string
+		label: string
+		/** Optional lucide-svelte (or compatible) component rendered at 12px before the label. */
+		icon?: any
+		/** Defaults to true. Set false to hide the × close button. */
+		closable?: boolean
+		/** Pinned tabs are rendered outside the drag zone — 'left' or 'right' of the draggable group. */
+		pinned?: 'left' | 'right'
+	}
+</script>
+
+<script lang="ts">
+	import { dndzone, type DndEvent } from '@windmill-labs/svelte-dnd-action'
+	import { X } from 'lucide-svelte'
+	import { twMerge } from 'tailwind-merge'
+
+	interface Props {
+		tabs: TabItem[]
+		activeId: string
+		onSelect: (id: string) => void
+		onClose?: (id: string) => void
+		onReorder?: (newOrder: TabItem[]) => void
+		/** Extra classes for the outer tab strip. */
+		class?: string
+		/** Render after the right-pinned tabs (e.g. a "Split with Preview" toggle). */
+		trailing?: import('svelte').Snippet
+	}
+
+	let {
+		tabs,
+		activeId,
+		onSelect,
+		onClose,
+		onReorder,
+		class: c = '',
+		trailing
+	}: Props = $props()
+
+	const pinnedLeft = $derived(tabs.filter((t) => t.pinned === 'left'))
+	const middle = $derived(tabs.filter((t) => !t.pinned))
+	const pinnedRight = $derived(tabs.filter((t) => t.pinned === 'right'))
+
+	function rebuild(middleNew: TabItem[]) {
+		// dnd-action only owns the middle (draggable) slice; reassemble.
+		onReorder?.([...pinnedLeft, ...middleNew, ...pinnedRight])
+	}
+
+	function handleConsider(e: CustomEvent<DndEvent<TabItem>>) {
+		rebuild(e.detail.items)
+	}
+	function handleFinalize(e: CustomEvent<DndEvent<TabItem>>) {
+		rebuild(e.detail.items)
+	}
+
+	function tabClasses(isActive: boolean) {
+		return twMerge(
+			'group inline-flex items-center gap-1.5 px-3 h-8 text-xs select-none cursor-pointer border-r border-border-light whitespace-nowrap focus:outline-none focus-visible:ring-1 focus-visible:ring-border-selected',
+			isActive
+				? 'bg-surface text-primary border-b-2 border-b-accent -mb-px'
+				: 'bg-surface-secondary text-secondary hover:bg-surface-hover'
+		)
+	}
+
+	function handleKeydown(e: KeyboardEvent, tab: TabItem) {
+		if (e.key === 'Delete' || e.key === 'Backspace') {
+			if (tab.closable !== false) {
+				e.preventDefault()
+				onClose?.(tab.id)
+			}
+		} else if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+			const idx = tabs.findIndex((t) => t.id === tab.id)
+			const next = e.key === 'ArrowLeft' ? idx - 1 : idx + 1
+			if (next >= 0 && next < tabs.length) {
+				onSelect(tabs[next].id)
+				e.preventDefault()
+			}
+		} else if (e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault()
+			onSelect(tab.id)
+		}
+	}
+
+	function handleAuxClick(e: MouseEvent, tab: TabItem) {
+		// Middle-click closes (browser convention).
+		if (e.button === 1 && tab.closable !== false) {
+			e.preventDefault()
+			onClose?.(tab.id)
+		}
+	}
+</script>
+
+{#snippet tabButton(tab: TabItem)}
+	{@const isActive = tab.id === activeId}
+	{@const Icon = tab.icon}
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<div
+		role="tab"
+		aria-selected={isActive}
+		tabindex={isActive ? 0 : -1}
+		class={tabClasses(isActive)}
+		onclick={() => onSelect(tab.id)}
+		onauxclick={(e) => handleAuxClick(e, tab)}
+		onkeydown={(e) => handleKeydown(e, tab)}
+	>
+		{#if Icon}
+			<Icon size={12} />
+		{/if}
+		<span class="truncate max-w-[180px]">{tab.label}</span>
+		{#if tab.closable !== false}
+			<button
+				type="button"
+				class="opacity-0 group-hover:opacity-100 focus:opacity-100 rounded hover:bg-surface-hover w-4 h-4 inline-flex items-center justify-center"
+				aria-label={`Close ${tab.label}`}
+				onclick={(e) => {
+					e.stopPropagation()
+					onClose?.(tab.id)
+				}}
+			>
+				<X size={10} />
+			</button>
+		{/if}
+	</div>
+{/snippet}
+
+<div
+	class={twMerge(
+		'flex items-stretch border-b border-border-light overflow-x-auto bg-surface-secondary',
+		c
+	)}
+	role="tablist"
+>
+	{#each pinnedLeft as tab (tab.id)}
+		{@render tabButton(tab)}
+	{/each}
+
+	<div
+		class="flex items-stretch"
+		use:dndzone={{
+			items: middle,
+			flipDurationMs: 150,
+			type: 'draggable-tabs',
+			dropTargetStyle: {}
+		}}
+		onconsider={handleConsider}
+		onfinalize={handleFinalize}
+	>
+		{#each middle as tab (tab.id)}
+			<div>
+				{@render tabButton(tab)}
+			</div>
+		{/each}
+	</div>
+
+	{#each pinnedRight as tab (tab.id)}
+		{@render tabButton(tab)}
+	{/each}
+
+	{#if trailing}
+		<div class="ml-auto flex items-center">
+			{@render trailing()}
+		</div>
+	{/if}
+</div>

--- a/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
+++ b/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
@@ -16,6 +16,7 @@
 	import { dndzone, type DndEvent } from '@windmill-labs/svelte-dnd-action'
 	import { X } from 'lucide-svelte'
 	import { twMerge } from 'tailwind-merge'
+	import { createScrollArea, melt } from '@melt-ui/svelte'
 
 	interface Props {
 		tabs: TabItem[]
@@ -43,8 +44,15 @@
 	const middle = $derived(tabs.filter((t) => !t.pinned))
 	const pinnedRight = $derived(tabs.filter((t) => t.pinned === 'right'))
 
+	// Melt scroll-area: type='always' keeps the custom thumb's gutter present
+	// at all times, so the layout never shifts when content stops/starts
+	// overflowing. The native horizontal scrollbar is hidden by melt and our
+	// own 4px-tall track sits along the bottom of the strip.
+	const {
+		elements: { root, viewport, content, scrollbarX, thumbX }
+	} = createScrollArea({ type: 'always', dir: 'ltr' })
+
 	function rebuild(middleNew: TabItem[]) {
-		// dnd-action only owns the middle (draggable) slice; reassemble.
 		onReorder?.([...pinnedLeft, ...middleNew, ...pinnedRight])
 	}
 
@@ -57,14 +65,10 @@
 
 	function tabClasses(isActive: boolean) {
 		return twMerge(
-			'group inline-flex items-center gap-1.5 px-3 h-8 text-xs select-none cursor-pointer whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-border-selected focus-visible:ring-inset',
-			// Active tab shares its background with the content area below it
-			// — no border, the boundary "disappears" into the surface.
-			// Inactive tabs sit on the darker tab-strip bg and have a subtle
-			// right separator so they don't blur together.
+			'group inline-flex items-center gap-1.5 px-2.5 h-7 text-xs rounded-md select-none cursor-pointer whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-border-selected focus-visible:ring-inset',
 			isActive
-				? 'bg-surface text-primary'
-				: 'bg-surface-secondary text-secondary border-r border-border-light hover:bg-surface-hover hover:text-primary'
+				? 'bg-surface-input text-primary'
+				: 'bg-transparent text-secondary hover:bg-surface-hover hover:text-primary'
 		)
 	}
 
@@ -88,7 +92,6 @@
 	}
 
 	function handleAuxClick(e: MouseEvent, tab: TabItem) {
-		// Middle-click closes (browser convention).
 		if (e.button === 1 && tab.closable !== false) {
 			e.preventDefault()
 			onClose?.(tab.id)
@@ -130,41 +133,90 @@
 {/snippet}
 
 <div
-	class={twMerge(
-		'flex items-stretch overflow-x-auto bg-surface-secondary',
-		c
-	)}
-	role="tablist"
+	class={twMerge('flex items-center bg-surface-secondary', c)}
 >
-	{#each pinnedLeft as tab (tab.id)}
-		{@render tabButton(tab)}
-	{/each}
+	<div use:melt={$root} class="tabs-root flex-1 min-w-0 relative pt-1 pl-1 pb-1">
+		<div use:melt={$viewport} class="tabs-viewport w-full">
+			<!-- Inner flex wrapper — melt's content element is forced to
+				 `display: table` which would stack the tabs vertically. -->
+			<div use:melt={$content}>
+				<div class="flex items-center" role="tablist">
+					{#each pinnedLeft as tab (tab.id)}
+						{@render tabButton(tab)}
+					{/each}
 
-	<div
-		class="flex items-stretch"
-		use:dndzone={{
-			items: middle,
-			flipDurationMs: 150,
-			type: 'draggable-tabs',
-			dropTargetStyle: {}
-		}}
-		onconsider={handleConsider}
-		onfinalize={handleFinalize}
-	>
-		{#each middle as tab (tab.id)}
-			<div>
-				{@render tabButton(tab)}
+					<div
+						class="flex items-center"
+						use:dndzone={{
+							items: middle,
+							flipDurationMs: 150,
+							type: 'draggable-tabs',
+							dropTargetStyle: {}
+						}}
+						onconsider={handleConsider}
+						onfinalize={handleFinalize}
+					>
+						{#each middle as tab (tab.id)}
+							<div>
+								{@render tabButton(tab)}
+							</div>
+						{/each}
+					</div>
+
+					{#each pinnedRight as tab (tab.id)}
+						{@render tabButton(tab)}
+					{/each}
+				</div>
 			</div>
-		{/each}
+		</div>
+
+		<div use:melt={$scrollbarX} class="tabs-scrollbar">
+			<div use:melt={$thumbX} class="tabs-thumb"></div>
+		</div>
 	</div>
 
-	{#each pinnedRight as tab (tab.id)}
-		{@render tabButton(tab)}
-	{/each}
-
 	{#if trailing}
-		<div class="ml-auto flex items-center">
+		<div class="ml-1 pr-1 flex items-center shrink-0">
 			{@render trailing()}
 		</div>
 	{/if}
 </div>
+
+<style>
+	/* The melt viewport hides its own native scrollbar internally; we just
+	   need to give it a height so the content sits flush above the custom
+	   bar that lives at the bottom of the root. */
+	.tabs-viewport {
+		height: 100%;
+	}
+
+	/* 4px-tall custom horizontal scrollbar pinned to the bottom of the
+	   strip. With melt's `type: 'always'` the track is permanently present,
+	   so there's no layout shift when content stops overflowing, and the
+	   appearance is identical on macOS, Linux, and Windows regardless of
+	   the OS scrollbar setting. */
+	:global([data-melt-scroll-area-scrollbar].tabs-scrollbar) {
+		height: 4px;
+		background: transparent;
+		touch-action: none;
+		user-select: none;
+	}
+	:global([data-melt-scroll-area-thumb].tabs-thumb) {
+		height: 100%;
+		width: var(--melt-scroll-area-thumb-width);
+		background: rgb(var(--color-text-hint));
+		border-radius: 2px;
+		position: relative;
+		transition: background-color 0.15s;
+	}
+	/* When the content fits the viewport melt sets data-state="hidden" but
+	   leaves the element at full width — without this rule it looks like a
+	   bar spanning the whole track. Hide it so the strip's bottom row is
+	   empty until there's actually something to scroll. */
+	:global([data-melt-scroll-area-thumb].tabs-thumb[data-state='hidden']) {
+		opacity: 0;
+	}
+	:global([data-melt-scroll-area-thumb].tabs-thumb:hover) {
+		background: rgb(var(--color-text-secondary));
+	}
+</style>

--- a/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
+++ b/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
@@ -95,8 +95,8 @@
 		return twMerge(
 			'group inline-flex items-center gap-1.5 px-2.5 h-7 text-xs rounded-md select-none cursor-pointer whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-border-selected focus-visible:ring-inset',
 			isActive
-				? 'bg-surface-accent-selected text-accent'
-				: 'bg-transparent text-secondary hover:bg-surface-hover hover:text-primary'
+				? 'bg-surface-tertiary text-emphasis'
+				: 'bg-transparent text-hint hover:text-secondary'
 		)
 	}
 

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -197,7 +197,8 @@
 	let logsDiv: HTMLDivElement | undefined = $state(undefined)
 	$effect(() => {
 		if (logsDiv && logs && !logsCollapsed) {
-			setTimeout(() => logsDiv?.scrollTo(0, logsDiv.scrollHeight), 50)
+			const t = setTimeout(() => logsDiv?.scrollTo(0, logsDiv.scrollHeight), 50)
+			return () => clearTimeout(t)
 		}
 	})
 
@@ -370,12 +371,12 @@
 	}
 
 	function reorderTabs(next: TabItem[]) {
-		// In split mode the right bar omits Preview from `next`; re-append it.
-		if (splitWithPreview && !next.some((t) => t.id === PREVIEW_TAB_ID)) {
-			tabs = [...next, previewTab]
-		} else {
-			tabs = next
-		}
+		// Rebuild from the reordered `next` plus any tabs that bar didn't show
+		// (e.g. files when the Preview-only right bar fires in split mode), with
+		// Preview kept pinned at the end — so a reorder can never drop a tab.
+		const seen = new Set(next.map((t) => t.id))
+		const rest = tabs.filter((t) => !seen.has(t.id))
+		tabs = [...next, ...rest].filter((t) => t.id !== PREVIEW_TAB_ID).concat(previewTab)
 	}
 
 	function toggleSplit() {
@@ -1102,7 +1103,6 @@
 	}
 
 	function handleSelectFile(path: string) {
-		console.log('event Select file:', path)
 		// Adding the tab activates it; activateTab posts the selectFile message
 		// to the UI Builder iframe and clears any selected runnable.
 		const id = ensureFileTab(path)
@@ -1469,7 +1469,7 @@
 								</div>
 							</div>
 						</Pane>
-						<Pane bind:size={() => paneBRightSize, () => {}} minSize={0}>
+						<Pane bind:size={() => paneBRightSize, (v) => rememberPaneDrag(100 - v)} minSize={0}>
 							<div class="flex flex-col h-full w-full min-h-0 relative">
 								<DraggableTabs
 									tabs={rightPaneTabs}

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Pane, Splitpanes } from 'svelte-splitpanes'
+	import { paneMinPercent } from '$lib/utils/splitpaneSizing'
 	import RawAppInlineScriptsPanel from './RawAppInlineScriptsPanel.svelte'
 	import type { JobById } from '../apps/types'
 	import RawAppEditorHeader from './RawAppEditorHeader.svelte'
@@ -400,7 +401,20 @@
 	}
 	let yamlEditorDrawer: Drawer | undefined = $state(undefined)
 
-	let sidebarPanelSize = $state(15)
+	// Sidebar uses a dynamic pixel-aware minimum: the user's `%` preference is
+	// honored, but the pane can never shrink below SIDEBAR_PX_MIN — including
+	// when the container itself shrinks. svelte-splitpanes' `minSize` only
+	// blocks splitter drag, so we clamp `sidebarPanelSize` ourselves and use a
+	// getter/setter bind so the user's preference is preserved.
+	let rawSidebarSize = $state(15)
+	let splitContainerWidth = $state(0)
+	const SIDEBAR_PX_MIN = 160
+	const sidebarMinPercent = $derived(
+		paneMinPercent(splitContainerWidth, SIDEBAR_PX_MIN)
+	)
+	const sidebarPanelSize = $derived(
+		Math.max(rawSidebarSize, sidebarMinPercent)
+	)
 
 	// Persisted across opens. Seeded with `defaultSidebarCollapsed` only when
 	// localStorage has no entry yet — callers (like the session preview pane)
@@ -1339,9 +1353,14 @@
 		onApply={handleYamlApply}
 	/>
 
-	<Splitpanes id="o2" class="grow min-h-0 border-t">
-		{#if !sidebarCollapsed.val}
-			<Pane bind:size={sidebarPanelSize} maxSize={20} class="h-full overflow-y-auto relative">
+	<div bind:clientWidth={splitContainerWidth} class="grow min-h-0 flex flex-col">
+		<Splitpanes id="o2" class="grow min-h-0 border-t">
+			{#if !sidebarCollapsed.val}
+				<Pane
+					bind:size={() => sidebarPanelSize, (v) => (rawSidebarSize = v)}
+					minSize={sidebarMinPercent}
+					class="h-full overflow-y-auto relative"
+				>
 				<RawAppSidebar
 					bind:files={
 						() => files,
@@ -1604,6 +1623,7 @@
 			</div>
 		</Pane>
 	</Splitpanes>
+	</div>
 </div>
 
 <style>

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -1048,6 +1048,15 @@
 					'*'
 				)
 			}
+			// Escape inside the preview exits inspect mode — the keydown fires in
+			// the iframe's document, so the parent window listener can't see it.
+			previewIframe?.contentWindow?.addEventListener(
+				'keydown',
+				(e) => {
+					if (e.key === 'Escape' && inspectorEnabled) disableInspector()
+				},
+				true
+			)
 		})
 	})
 	$effect(() => {
@@ -1214,6 +1223,27 @@
 			sendUserToast('Failed to apply entry: ' + (error as Error).message, true)
 		}
 	}
+
+	function disableInspector() {
+		if (!inspectorEnabled) return
+		inspectorEnabled = false
+		previewIframe?.contentWindow?.postMessage({ type: 'inspectorDisable' }, '*')
+	}
+
+	// Escape exits inspect mode. We listen in the capture phase because a global
+	// handler swallows Escape before it bubbles to <svelte:window>. The preview
+	// iframe (separate document) is covered by its own listener on load.
+	$effect(() => {
+		const onEscapeCapture = (e: KeyboardEvent) => {
+			if (e.key === 'Escape' && inspectorEnabled) {
+				disableInspector()
+				e.stopImmediatePropagation()
+				e.preventDefault()
+			}
+		}
+		window.addEventListener('keydown', onEscapeCapture, true)
+		return () => window.removeEventListener('keydown', onEscapeCapture, true)
+	})
 
 	function handleKeydown(e: KeyboardEvent) {
 		// Skip when typing in an input, textarea, or Monaco editor.

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -1099,7 +1099,8 @@
 
 	function clearInspectorSelection() {
 		inspectorElement = undefined
-		iframe?.contentWindow?.postMessage({ type: 'inspectorClear' }, '*')
+		// Inspector lives in the preview iframe, so clear its overlay there.
+		previewIframe?.contentWindow?.postMessage({ type: 'inspectorClear' }, '*')
 	}
 
 	function handleSelectFile(path: string) {

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -217,9 +217,49 @@
 	// bundling, preview state, and editor state survive tab switches.
 	// `splitWithPreview` adds the preview pane alongside the active tab; the
 	// active tab's content visibility doesn't change when split toggles.
+	// The preview iframe always lives in Pane B; its visibility is driven by
+	// the pane size, not a separate flag. Source vs runnable swap inside Pane A.
 	const showSource = $derived(activeTabKind === 'file')
 	const showRunnable = $derived(activeTabKind === 'runnable')
-	const showPreview = $derived(activeTabKind === 'preview' || splitWithPreview)
+
+	// Resizable split is handled by an inner Splitpanes. To preserve iframe
+	// state across single↔split toggles we always render the Splitpanes; sizes
+	// are driven by the active tab + split flag. `paneARatio` remembers the
+	// user's drag preference for next time split is enabled.
+	let paneALeftSize = $state(50)
+	let paneBRightSize = $state(50)
+	let paneARatio = $state(50)
+	$effect(() => {
+		// Snap sizes when the layout mode (preview/file/runnable + split) changes.
+		void activeTabKind
+		void splitWithPreview
+		untrack(() => {
+			if (activeTabKind === 'preview') {
+				paneALeftSize = 0
+				paneBRightSize = 100
+			} else if (splitWithPreview) {
+				paneALeftSize = paneARatio
+				paneBRightSize = 100 - paneARatio
+			} else {
+				paneALeftSize = 100
+				paneBRightSize = 0
+			}
+		})
+	})
+	$effect(() => {
+		// While the user drags in split mode, remember the ratio they picked.
+		void paneALeftSize
+		untrack(() => {
+			if (
+				splitWithPreview &&
+				activeTabKind !== 'preview' &&
+				paneALeftSize > 0 &&
+				paneALeftSize < 100
+			) {
+				paneARatio = paneALeftSize
+			}
+		})
+	})
 
 	function fileTabId(filePath: string) {
 		return FILE_PREFIX + filePath
@@ -1347,69 +1387,89 @@
 					{/snippet}
 				</DraggableTabs>
 				<!--
-					Content area. All three slots stay mounted always; we toggle
-					CSS display so iframes don't lose state on tab switches.
-					Flex layout: in single mode only one slot has display, so
-					it takes the full width. In split mode two are visible and
-					share the space.
+					Content area. Always rendered as a Splitpanes so the iframes
+					never remount on a single↔split toggle. The active tab's
+					slot occupies Pane A (left); the preview iframe sits in
+					Pane B (right). Sizes are driven reactively from the tab +
+					split state. The splitter divider is hidden via CSS when
+					one of the panes is at 0% — the user uses the explicit
+					toggle button in the tab bar to flip between modes.
 				-->
-				<div class="flex flex-1 min-h-0 w-full">
-					<div
-						class="flex-1 min-w-0 relative"
-						style="display: {showSource ? 'block' : 'none'}"
-					>
-						<iframe
-							bind:this={iframe}
-							title="UI builder"
-							src="/ui_builder/index.html"
-							class="w-full h-full block"
-						></iframe>
-					</div>
-					<div
-						class="flex-1 min-w-0 relative"
-						style="display: {showRunnable ? 'block' : 'none'}"
-					>
-						<!-- svelte-ignore a11y_no_static_element_interactions -->
-						<div class="flex h-full w-full">
-							{#if selectedRunnable !== undefined}
-								<RawAppInlineScriptsPanel
-									appPath={path}
-									{selectedRunnable}
-									bind:runnables
-									onSelectionChange={(selection) => {
-										if (selection === null) {
-											codeSelection = undefined
-										} else if (selectedRunnable) {
-											codeSelection = {
-												type: 'app_code_selection',
-												source: selectedRunnable,
-												sourceType: 'backend',
-												title: `${selectedRunnable}:L${selection.startLine}-L${selection.endLine}`,
-												content: selection.content,
-												startLine: selection.startLine,
-												endLine: selection.endLine,
-												startColumn: selection.startColumn,
-												endColumn: selection.endColumn
-											}
-										}
-									}}
-								/>
-							{/if}
-						</div>
-					</div>
-					<div
-						class="flex-1 min-w-0 relative"
-						style="display: {showPreview ? 'block' : 'none'}"
-					>
-						<iframe
-							bind:this={previewIframe}
-							title="App preview"
-							src="/ui_builder/app-preview.html"
-							class="w-full h-full block"
-						></iframe>
-					</div>
+				<div
+					class="flex-1 min-h-0 w-full {splitWithPreview &&
+					activeTabKind !== 'preview'
+						? 'tabs-content-split'
+						: 'tabs-content-single'}"
+				>
+					<Splitpanes>
+						<Pane bind:size={paneALeftSize} minSize={0}>
+							<div
+								class="relative h-full w-full"
+								style="display: {showSource ? 'block' : 'none'}"
+							>
+								<iframe
+									bind:this={iframe}
+									title="UI builder"
+									src="/ui_builder/index.html"
+									class="w-full h-full block"
+								></iframe>
+							</div>
+							<div
+								class="relative h-full w-full"
+								style="display: {showRunnable ? 'block' : 'none'}"
+							>
+								<!-- svelte-ignore a11y_no_static_element_interactions -->
+								<div class="flex h-full w-full">
+									{#if selectedRunnable !== undefined}
+										<RawAppInlineScriptsPanel
+											appPath={path}
+											{selectedRunnable}
+											bind:runnables
+											onSelectionChange={(selection) => {
+												if (selection === null) {
+													codeSelection = undefined
+												} else if (selectedRunnable) {
+													codeSelection = {
+														type: 'app_code_selection',
+														source: selectedRunnable,
+														sourceType: 'backend',
+														title: `${selectedRunnable}:L${selection.startLine}-L${selection.endLine}`,
+														content: selection.content,
+														startLine: selection.startLine,
+														endLine: selection.endLine,
+														startColumn: selection.startColumn,
+														endColumn: selection.endColumn
+													}
+												}
+											}}
+										/>
+									{/if}
+								</div>
+							</div>
+						</Pane>
+						<Pane bind:size={paneBRightSize} minSize={0}>
+							<iframe
+								bind:this={previewIframe}
+								title="App preview"
+								src="/ui_builder/app-preview.html"
+								class="w-full h-full block"
+							></iframe>
+						</Pane>
+					</Splitpanes>
 				</div>
 			</div>
 		</Pane>
 	</Splitpanes>
 </div>
+
+<style>
+	/* Hide the splitter in the inner content-area Splitpanes when we're not
+	   actually in split-with-preview mode (one pane is at 0%). The user
+	   uses the explicit Split toggle in the tab bar to flip modes; a
+	   visible-but-non-functional drag handle would be confusing. */
+	:global(.tabs-content-single .splitpanes__splitter) {
+		visibility: hidden;
+		pointer-events: none;
+		width: 0;
+	}
+</style>

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -1050,10 +1050,14 @@
 			}
 			// Escape inside the preview exits inspect mode — the keydown fires in
 			// the iframe's document, so the parent window listener can't see it.
+			// We also want Escape to dismiss a lingering green "selected" overlay
+			// after the user picked an element (which auto-disables hover).
 			previewIframe?.contentWindow?.addEventListener(
 				'keydown',
 				(e) => {
-					if (e.key === 'Escape' && inspectorEnabled) disableInspector()
+					if (e.key === 'Escape' && (inspectorEnabled || inspectorElement)) {
+						disableInspector()
+					}
 				},
 				true
 			)
@@ -1225,9 +1229,17 @@
 	}
 
 	function disableInspector() {
-		if (!inspectorEnabled) return
+		// Picking an element auto-clears `inspectorEnabled`, so Escape after a
+		// pick gets here with hover already off but the green selection still
+		// up. Bail only when there is genuinely nothing to dismiss.
+		if (!inspectorEnabled && !inspectorElement) return
 		inspectorEnabled = false
+		// `inspectorDisable` only stops hover/click; the green "selected"
+		// overlay from a prior pick persists until we explicitly clear it.
+		// Escape should reset both, so the iframe goes back to its idle look.
 		previewIframe?.contentWindow?.postMessage({ type: 'inspectorDisable' }, '*')
+		previewIframe?.contentWindow?.postMessage({ type: 'inspectorClear' }, '*')
+		inspectorElement = undefined
 	}
 
 	// Escape exits inspect mode. We listen in the capture phase because a global
@@ -1235,7 +1247,7 @@
 	// iframe (separate document) is covered by its own listener on load.
 	$effect(() => {
 		const onEscapeCapture = (e: KeyboardEvent) => {
-			if (e.key === 'Escape' && inspectorEnabled) {
+			if (e.key === 'Escape' && (inspectorEnabled || inspectorElement)) {
 				disableInspector()
 				e.stopImmediatePropagation()
 				e.preventDefault()

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -213,33 +213,33 @@
 				? 'file'
 				: 'runnable'
 	)
-	// What's visible. Both iframes and the runnable panel stay mounted so
-	// bundling, preview state, and editor state survive tab switches.
-	// `splitWithPreview` adds the preview pane alongside the active tab; the
-	// active tab's content visibility doesn't change when split toggles.
-	// The preview iframe always lives in Pane B; its visibility is driven by
-	// the pane size, not a separate flag. Source vs runnable swap inside Pane A.
+	// When split is on, the Preview tab moves out of the bar and lives in
+	// the right pane. The user only sees file/runnable tabs in the bar;
+	// the right pane is always preview. When split is off, the Preview
+	// tab is back in the bar like any other tab.
+	const displayedTabs = $derived(
+		splitWithPreview ? tabs.filter((t) => t.id !== PREVIEW_TAB_ID) : tabs
+	)
 	const showSource = $derived(activeTabKind === 'file')
 	const showRunnable = $derived(activeTabKind === 'runnable')
 
-	// Resizable split is handled by an inner Splitpanes. To preserve iframe
-	// state across single↔split toggles we always render the Splitpanes; sizes
-	// are driven by the active tab + split flag. `paneARatio` remembers the
-	// user's drag preference for next time split is enabled.
-	let paneALeftSize = $state(50)
-	let paneBRightSize = $state(50)
+	// Pane sizes for the inner content-area Splitpanes.
+	// - Single mode + preview active: right pane full (preview full width)
+	// - Single mode + file/runnable active: left pane full
+	// - Split mode: both panes visible at the user's preferred ratio
+	let paneALeftSize = $state(100)
+	let paneBRightSize = $state(0)
 	let paneARatio = $state(50)
 	$effect(() => {
-		// Snap sizes when the layout mode (preview/file/runnable + split) changes.
 		void activeTabKind
 		void splitWithPreview
 		untrack(() => {
-			if (activeTabKind === 'preview') {
-				paneALeftSize = 0
-				paneBRightSize = 100
-			} else if (splitWithPreview) {
+			if (splitWithPreview && activeTabKind !== 'preview') {
 				paneALeftSize = paneARatio
 				paneBRightSize = 100 - paneARatio
+			} else if (activeTabKind === 'preview') {
+				paneALeftSize = 0
+				paneBRightSize = 100
 			} else {
 				paneALeftSize = 100
 				paneBRightSize = 0
@@ -247,7 +247,7 @@
 		})
 	})
 	$effect(() => {
-		// While the user drags in split mode, remember the ratio they picked.
+		// Remember the user's drag ratio while in split mode.
 		void paneALeftSize
 		untrack(() => {
 			if (
@@ -343,7 +343,33 @@
 	}
 
 	function reorderTabs(next: TabItem[]) {
-		tabs = next
+		// `next` is `displayedTabs` after the user dropped a tab.
+		// When split is on, the Preview tab isn't in `next`; re-append it
+		// to preserve its slot in the underlying `tabs` array.
+		if (splitWithPreview && !next.some((t) => t.id === PREVIEW_TAB_ID)) {
+			tabs = [...next, previewTab]
+		} else {
+			tabs = next
+		}
+	}
+
+	function toggleSplit() {
+		if (splitWithPreview) {
+			splitWithPreview = false
+			return
+		}
+		// Going from single → split. The Preview tab is about to disappear
+		// from the bar; if it's currently active, redirect to the last
+		// file/runnable tab (or stay on preview if none exist — left pane
+		// will be empty until the user opens something).
+		if (activeTabId === PREVIEW_TAB_ID) {
+			const lastUserTab = tabs
+				.slice()
+				.reverse()
+				.find((t) => t.id !== PREVIEW_TAB_ID)
+			if (lastUserTab) activeTabId = lastUserTab.id
+		}
+		splitWithPreview = true
 	}
 	let yamlEditorDrawer: Drawer | undefined = $state(undefined)
 
@@ -1306,7 +1332,7 @@
 		<Pane>
 			<div class="flex flex-col h-full w-full min-h-0">
 				<DraggableTabs
-					{tabs}
+					tabs={displayedTabs}
 					activeId={activeTabId}
 					onSelect={(id) => activateTab(id)}
 					onClose={(id) => closeTab(id)}
@@ -1314,21 +1340,19 @@
 				>
 					{#snippet trailing()}
 						<div class="flex items-center gap-1 px-2">
-							{#if activeTabKind !== 'preview'}
-								<button
-									title={splitWithPreview
-										? 'Hide preview pane'
-										: 'Show preview side-by-side'}
-									aria-label="Toggle split with preview"
-									aria-pressed={splitWithPreview}
-									class={splitWithPreview
-										? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
-										: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
-									onclick={() => (splitWithPreview = !splitWithPreview)}
-								>
-									<Columns2 size={14} />
-								</button>
-							{/if}
+							<button
+								title={splitWithPreview
+									? 'Move preview back into a tab'
+									: 'Pin preview to the right'}
+								aria-label="Toggle split with preview"
+								aria-pressed={splitWithPreview}
+								class={splitWithPreview
+									? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
+									: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
+								onclick={toggleSplit}
+							>
+								<Columns2 size={14} />
+							</button>
 							<button
 								class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary px-2 h-7 rounded-md text-xs"
 								title="Switch bundler"

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -1638,14 +1638,15 @@
 </div>
 
 <style>
-	/* Hide the splitter in the inner content-area Splitpanes when we're not
-	   actually in split-with-preview mode (one pane is at 0%). The user
+	/* Remove the splitter from the inner content-area Splitpanes when we're
+	   not actually in split-with-preview mode (one pane is at 0%). The user
 	   uses the explicit Split toggle in the tab bar to flip modes; a
-	   visible-but-non-functional drag handle would be confusing. */
+	   visible-but-non-functional drag handle would be confusing. We use
+	   `display: none` rather than `width: 0` because svelte-splitpanes' own
+	   splitter-width rule otherwise wins and leaves a 1px sliver beside the
+	   preview content. */
 	:global(.tabs-content-single .splitpanes__splitter) {
-		visibility: hidden;
-		pointer-events: none;
-		width: 0;
+		display: none;
 	}
 
 	/* Logs overlay scrollbar — small, themed, matching the previous in-iframe

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -28,7 +28,7 @@
 	import { createAppSelectedContext, type AppCodeSelectionElement } from '../copilot/chat/context'
 	import { rawAppLintStore } from './lintStore'
 	import { dbSchemas } from '$lib/stores'
-	import { MousePointerSquareDashed, RefreshCw, Columns2 } from 'lucide-svelte'
+	import { MousePointerSquareDashed, RefreshCw, Columns2, ChevronDown } from 'lucide-svelte'
 	import DraggableTabs, {
 		type TabItem
 	} from '$lib/components/common/tabs/DraggableTabs.svelte'
@@ -189,6 +189,18 @@
 	let lastBuild: { css: string; js: string } | undefined = undefined
 	let inspectorEnabled = $state(false)
 	let bundlerType: 'esbuild' | 'rolldown' = $state('esbuild')
+
+	// Build/bundler logs forwarded from the UI Builder iframe. We render
+	// them as an overlay inside the preview pane (right side) so they're
+	// visually tied to the build output, not to the source editor.
+	let logs = $state('')
+	let logsCollapsed = $state(false)
+	let logsDiv: HTMLDivElement | undefined = $state(undefined)
+	$effect(() => {
+		if (logsDiv && logs && !logsCollapsed) {
+			setTimeout(() => logsDiv?.scrollTo(0, logsDiv.scrollHeight), 50)
+		}
+	})
 
 	// Tab system — the source side of the editor area. The sidebar stays the
 	// primary navigation; tabs are a secondary surface that's useful when the
@@ -910,6 +922,14 @@
 			return
 		}
 
+		// Build/bundler logs from the UI Builder iframe — render them as
+		// an overlay inside the preview pane (see the panel rendered with
+		// the right Pane below).
+		if (fromUiBuilder && e.data.type === 'setLogs') {
+			logs = String(e.data.logs ?? '')
+			return
+		}
+
 		// Inspector events come exclusively from the preview iframe.
 		if (fromPreview && e.data.type === 'inspectorSelect') {
 			inspectorElement = e.data.element as InspectorElementInfo
@@ -1460,7 +1480,7 @@
 						</div>
 					</Pane>
 					<Pane bind:size={paneBRightSize} minSize={0}>
-						<div class="flex flex-col h-full w-full min-h-0">
+						<div class="flex flex-col h-full w-full min-h-0 relative">
 							<DraggableTabs
 								tabs={rightPaneTabs}
 								activeId={rightPaneActiveId}
@@ -1546,6 +1566,38 @@
 								src="/ui_builder/app-preview.html"
 								class="w-full flex-1 block"
 							></iframe>
+							{#if logs}
+								<div
+									class="absolute right-0 bottom-0 z-20 max-w-[500px] w-full flex flex-col text-xs p-1 border border-border-light rounded-tl-md bg-surface text-primary {logsCollapsed
+										? 'h-6'
+										: 'max-h-60 h-full'}"
+								>
+									<button
+										class="cursor-pointer flex items-center gap-2 w-full text-xs font-normal text-secondary -mt-0.5 px-2 text-left"
+										onclick={() => (logsCollapsed = !logsCollapsed)}
+									>
+										Logs
+										<ChevronDown
+											size={12}
+											class="transition duration-200"
+											style="transform: {logsCollapsed
+												? 'rotate(180deg)'
+												: 'rotate(0deg)'}"
+										/>
+										<span class="text-secondary"
+											>({logs.split('\n').length})</span
+										>
+									</button>
+									<div
+										bind:this={logsDiv}
+										class="logs-scroll grow w-full overflow-auto"
+									>
+										{#if !logsCollapsed}
+											<pre>{logs}</pre>
+										{/if}
+									</div>
+								</div>
+							{/if}
 						</div>
 					</Pane>
 				</Splitpanes>
@@ -1563,5 +1615,22 @@
 		visibility: hidden;
 		pointer-events: none;
 		width: 0;
+	}
+
+	/* Logs overlay scrollbar — small, themed, matching the previous in-iframe
+	   panel's look. */
+	.logs-scroll::-webkit-scrollbar {
+		width: 8px;
+		height: 8px;
+	}
+	.logs-scroll::-webkit-scrollbar-track {
+		background: rgb(var(--color-surface-sunken));
+	}
+	.logs-scroll::-webkit-scrollbar-thumb {
+		background: rgb(var(--color-surface-secondary));
+		border-radius: 4px;
+	}
+	.logs-scroll::-webkit-scrollbar-thumb:hover {
+		background: rgb(var(--color-border-light));
 	}
 </style>

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -294,21 +294,29 @@
 		return filePath.split('/').pop() || filePath
 	}
 
-	function activateTab(id: string) {
+	function activateTab(id: string, opts?: { force?: boolean }) {
 		const tab = tabs.find((t) => t.id === id)
 		if (!tab) return
-		// Clicking the Preview tab while in split mode is a visual no-op —
-		// Preview is already permanently shown in the right pane, and
-		// promoting it to active would trigger the pane-sizing $effect and
-		// collapse the left pane (the bug being fixed here).
-		if (splitWithPreview && id === PREVIEW_TAB_ID) return
+		// Clicking the Preview tab while in split mode is normally a visual
+		// no-op (Preview is already permanently shown in the right pane;
+		// promoting it would collapse the left pane). `force: true` is used
+		// by closeTab's fallback when the only remaining tab IS Preview —
+		// in that case we genuinely have nothing on the left to keep alive.
+		if (!opts?.force && splitWithPreview && id === PREVIEW_TAB_ID) return
 		activeTabId = id
 		if (tab.id === PREVIEW_TAB_ID) {
 			selectedRunnable = undefined
 		} else if (tab.id.startsWith(FILE_PREFIX)) {
 			const filePath = tab.id.slice(FILE_PREFIX.length)
 			selectedRunnable = undefined
-			iframe?.contentWindow?.postMessage({ type: 'selectFile', path: filePath }, '*')
+			// Always update `selectedDocument` — it drives sidebar highlight
+			// and, crucially, is read by `populateFiles` once the iframe
+			// finishes loading so a hydrated tab opens the right file even
+			// when activateTab fires before the iframe's listener exists.
+			selectedDocument = filePath
+			if (iframeLoaded) {
+				iframe?.contentWindow?.postMessage({ type: 'selectFile', path: filePath }, '*')
+			}
 		} else if (tab.id.startsWith(RUNNABLE_PREFIX)) {
 			const key = tab.id.slice(RUNNABLE_PREFIX.length)
 			if (selectedRunnable !== key) selectedRunnable = key
@@ -364,9 +372,11 @@
 		}
 		tabs = tabs.filter((t) => t.id !== id)
 		if (wasActive) {
-			// Fall back to the previous tab, else the preview tab.
+			// Fall back to the previous tab, else the preview tab. Force
+			// activation so the Preview-in-split-mode no-op guard doesn't
+			// leave `activeTabId` pointing at the deleted tab.
 			const fallback = tabs[Math.max(0, idx - 1)] ?? previewTab
-			activateTab(fallback.id)
+			activateTab(fallback.id, { force: true })
 		}
 	}
 
@@ -497,12 +507,10 @@
 	}
 
 	let iframeLoaded = $state(false) // @hmr:keep
-	// Suppresses iframe-sourced events for a short window after we re-push files,
-	// to keep the iframe's boot-time messages from clobbering the user's state.
-	// suppressIframeSetFiles is held across an entire iframe reload (e.g. theme switch);
-	// the timer is reset on every reload so rapid toggles don't clear it prematurely.
+	// Briefly drops the `setActiveDocument` echo VS Code fires while we're
+	// pushing the initial file set — the iframe auto-opens a default editor
+	// during boot which we don't want to treat as a user-driven activation.
 	let suppressSetActiveDocument = false
-	let suppressIframeSetFiles = false
 	let suppressTimer: ReturnType<typeof setTimeout> | undefined
 
 	let sharedUiFiles: Record<string, string> = $state({})
@@ -543,7 +551,6 @@
 			if (suppressTimer !== undefined) clearTimeout(suppressTimer)
 			suppressTimer = setTimeout(() => {
 				suppressSetActiveDocument = false
-				suppressIframeSetFiles = false
 				suppressTimer = undefined
 			}, 500)
 			const doc = untrack(() => selectedDocument)
@@ -959,9 +966,6 @@
 		if (!fromUiBuilder) return
 
 		if (e.data.type === 'setFiles') {
-			// Ignore setFiles from the iframe while it's reloading (e.g. theme switch);
-			// the iframe boots with its default template and would otherwise clobber the user's files.
-			if (suppressIframeSetFiles) return
 			// Normalize Windows-style path separators to Linux-style
 			const normalizedFiles = normalizeFilePaths(e.data.files)
 			// Only mark pending changes if files actually changed (ignore echo from setFilesInIframe)

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -921,11 +921,17 @@
 			return
 		}
 
-		// Build/bundler logs from the UI Builder iframe — render them as
-		// an overlay inside the preview pane (see the panel rendered with
-		// the right Pane below).
+		// Build/bundler logs from the UI Builder iframe — rendered as an
+		// overlay inside the preview pane (see the panel below). Two
+		// shapes are accepted: a full snapshot (`setLogs`) for backwards
+		// compat, and an incremental delta (`appendLogs`) used during
+		// heavy bundler activity to avoid O(n²) postMessage traffic.
 		if (fromUiBuilder && e.data.type === 'setLogs') {
 			logs = String(e.data.logs ?? '')
+			return
+		}
+		if (fromUiBuilder && e.data.type === 'appendLogs') {
+			logs += String(e.data.delta ?? '')
 			return
 		}
 

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -1330,47 +1330,56 @@
 			</Pane>
 		{/if}
 		<Pane>
-			<!--
-				VS Code-style split: each pane is a self-contained "editor
-				group" with its own tab bar at the top. Splitpanes is the
-				topmost element here so the divider runs floor-to-ceiling.
-				Both iframes + RawAppInlineScriptsPanel stay mounted always;
-				`display` toggles + pane sizes do the swapping.
-			-->
-			<div
-				class="h-full w-full {splitWithPreview && activeTabKind !== 'preview'
-					? 'tabs-content-split'
-					: 'tabs-content-single'}"
-			>
-				<Splitpanes>
-					<Pane bind:size={paneALeftSize} minSize={0}>
-						<div class="flex flex-col h-full w-full min-h-0">
-							<DraggableTabs
-								tabs={displayedTabs}
-								activeId={activeTabId}
-								onSelect={(id) => activateTab(id)}
-								onClose={(id) => closeTab(id)}
-								onReorder={(next) => reorderTabs(next)}
+			<div class="flex flex-col h-full w-full min-h-0">
+				<!--
+					Main tab bar — always visible above the Splitpanes, full
+					width. The user can switch tabs (including back from
+					Preview to a file) without losing visibility on the rest
+					of the tab list.
+				-->
+				<DraggableTabs
+					tabs={displayedTabs}
+					activeId={activeTabId}
+					onSelect={(id) => activateTab(id)}
+					onClose={(id) => closeTab(id)}
+					onReorder={(next) => reorderTabs(next)}
+				>
+					{#snippet trailing()}
+						<div class="flex items-center gap-1 px-2">
+							<button
+								title={splitWithPreview
+									? 'Move preview back into a tab'
+									: 'Pin preview to the right'}
+								aria-label="Toggle split with preview"
+								aria-pressed={splitWithPreview}
+								class={splitWithPreview
+									? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
+									: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
+								onclick={toggleSplit}
 							>
-								{#snippet trailing()}
-									<div class="flex items-center gap-1 px-2">
-										<button
-											title={splitWithPreview
-												? 'Move preview back into a tab'
-												: 'Pin preview to the right'}
-											aria-label="Toggle split with preview"
-											aria-pressed={splitWithPreview}
-											class={splitWithPreview
-												? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
-												: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
-											onclick={toggleSplit}
-										>
-											<Columns2 size={14} />
-										</button>
-									</div>
-								{/snippet}
-							</DraggableTabs>
-							<div class="flex-1 min-h-0 w-full relative">
+								<Columns2 size={14} />
+							</button>
+						</div>
+					{/snippet}
+				</DraggableTabs>
+				<!--
+					Content area: Splitpanes below the main tab bar. Both
+					iframes + RawAppInlineScriptsPanel stay mounted always;
+					`display` + pane sizes do the swapping. The right pane
+					carries its own Preview pseudo-header with the
+					preview-affecting toolbar (bundler / inspector /
+					rebuild). The header is rendered whenever the right
+					pane is visible — width 0 hides it implicitly.
+				-->
+				<div
+					class="flex-1 min-h-0 w-full {splitWithPreview &&
+					activeTabKind !== 'preview'
+						? 'tabs-content-split'
+						: 'tabs-content-single'}"
+				>
+					<Splitpanes>
+						<Pane bind:size={paneALeftSize} minSize={0}>
+							<div class="relative h-full w-full">
 								<div
 									class="absolute inset-0"
 									style="display: {showSource ? 'block' : 'none'}"
@@ -1415,92 +1424,84 @@
 									</div>
 								</div>
 							</div>
-						</div>
-					</Pane>
-					<Pane bind:size={paneBRightSize} minSize={0}>
-						<div class="flex flex-col h-full w-full min-h-0">
-							<!--
-								Preview header — the right pane's own "tab bar".
-								Always rendered when the right pane is visible
-								(width 0 hides it without conditionals). Carries
-								the active-tab-styled "Preview" label on the
-								left and the preview-affecting action buttons
-								(bundler, inspector, rebuild) on the right.
-							-->
-							<div
-								class="flex items-stretch bg-surface-secondary flex-shrink-0 h-8"
-							>
+						</Pane>
+						<Pane bind:size={paneBRightSize} minSize={0}>
+							<div class="flex flex-col h-full w-full min-h-0">
 								<div
-									class="inline-flex items-center gap-1.5 px-3 h-8 text-xs bg-surface text-primary"
+									class="flex items-stretch bg-surface-secondary flex-shrink-0 h-8"
 								>
-									<span>Preview</span>
-								</div>
-								<div class="ml-auto flex items-center gap-1 px-2">
-									<button
-										class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary px-2 h-7 rounded-md text-xs"
-										title="Switch bundler"
-										onclick={() => {
-											const next =
-												bundlerType === 'esbuild' ? 'rolldown' : 'esbuild'
-											bundlerType = next
-											iframe?.contentWindow?.postMessage(
-												{ type: 'setBundlerType', bundlerType: next },
-												'*'
-											)
-										}}>{bundlerType}</button
+									<div
+										class="inline-flex items-center gap-1.5 px-3 h-8 text-xs bg-surface text-primary"
 									>
-									<button
-										title={inspectorEnabled
-											? 'Click to disable element inspector'
-											: 'Click to enable element inspector'}
-										class={inspectorEnabled
-											? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
-											: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
-										aria-label="Toggle element inspector"
-										onclick={() => {
-											inspectorEnabled = !inspectorEnabled
-											previewIframe?.contentWindow?.postMessage(
-												{
-													type: inspectorEnabled
-														? 'inspectorEnable'
-														: 'inspectorDisable'
-												},
-												'*'
-											)
-										}}
-									>
-										<MousePointerSquareDashed size={14} />
-									</button>
-									<button
-										class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center"
-										title="Replay the last build into the preview"
-										aria-label="Rebuild"
-										onclick={() => {
-											if (lastBuild) {
+										<span>Preview</span>
+									</div>
+									<div class="ml-auto flex items-center gap-1 px-2">
+										<button
+											class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary px-2 h-7 rounded-md text-xs"
+											title="Switch bundler"
+											onclick={() => {
+												const next =
+													bundlerType === 'esbuild' ? 'rolldown' : 'esbuild'
+												bundlerType = next
+												iframe?.contentWindow?.postMessage(
+													{ type: 'setBundlerType', bundlerType: next },
+													'*'
+												)
+											}}>{bundlerType}</button
+										>
+										<button
+											title={inspectorEnabled
+												? 'Click to disable element inspector'
+												: 'Click to enable element inspector'}
+											class={inspectorEnabled
+												? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
+												: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
+											aria-label="Toggle element inspector"
+											onclick={() => {
+												inspectorEnabled = !inspectorEnabled
 												previewIframe?.contentWindow?.postMessage(
 													{
-														type: 'preview',
-														css: lastBuild.css,
-														js: lastBuild.js
+														type: inspectorEnabled
+															? 'inspectorEnable'
+															: 'inspectorDisable'
 													},
 													'*'
 												)
-											}
-										}}
-									>
-										<RefreshCw size={14} />
-									</button>
+											}}
+										>
+											<MousePointerSquareDashed size={14} />
+										</button>
+										<button
+											class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center"
+											title="Replay the last build into the preview"
+											aria-label="Rebuild"
+											onclick={() => {
+												if (lastBuild) {
+													previewIframe?.contentWindow?.postMessage(
+														{
+															type: 'preview',
+															css: lastBuild.css,
+															js: lastBuild.js
+														},
+														'*'
+													)
+												}
+											}}
+										>
+											<RefreshCw size={14} />
+										</button>
+									</div>
 								</div>
+								<iframe
+									bind:this={previewIframe}
+									title="App preview"
+									src="/ui_builder/app-preview.html"
+									class="w-full flex-1 block"
+								></iframe>
 							</div>
-							<iframe
-								bind:this={previewIframe}
-								title="App preview"
-								src="/ui_builder/app-preview.html"
-								class="w-full flex-1 block"
-							></iframe>
-						</div>
-					</Pane>
-				</Splitpanes>
+						</Pane>
+					</Splitpanes>
+				</div>
 			</div>
 		</Pane>
 	</Splitpanes>

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -256,43 +256,30 @@
 		if (showSource) iframeShouldMount = true
 	})
 
-	// Pane sizes for the inner content-area Splitpanes.
-	// - Single mode + preview active: right pane full (preview full width)
+	// Pane sizes for the inner content-area Splitpanes are a pure function of
+	// the mode + active tab, so they're derived (no effects):
+	// - Split mode + file/runnable active: both panes at the user's ratio
+	// - Preview active: right pane full (preview full width)
 	// - Single mode + file/runnable active: left pane full
-	// - Split mode: both panes visible at the user's preferred ratio
-	let paneALeftSize = $state(100)
-	let paneBRightSize = $state(0)
+	// `paneARatio` holds the user's last manual split drag (see the setter
+	// in the left <Pane bind:size> below). Right size mirrors the left.
 	let paneARatio = $state(50)
-	$effect(() => {
-		void activeTabKind
-		void splitWithPreview
-		untrack(() => {
-			if (splitWithPreview && activeTabKind !== 'preview') {
-				paneALeftSize = paneARatio
-				paneBRightSize = 100 - paneARatio
-			} else if (activeTabKind === 'preview') {
-				paneALeftSize = 0
-				paneBRightSize = 100
-			} else {
-				paneALeftSize = 100
-				paneBRightSize = 0
-			}
-		})
-	})
-	$effect(() => {
-		// Remember the user's drag ratio while in split mode.
-		void paneALeftSize
-		untrack(() => {
-			if (
-				splitWithPreview &&
-				activeTabKind !== 'preview' &&
-				paneALeftSize > 0 &&
-				paneALeftSize < 100
-			) {
-				paneARatio = paneALeftSize
-			}
-		})
-	})
+	const paneALeftSize = $derived(
+		splitWithPreview && activeTabKind !== 'preview'
+			? paneARatio
+			: activeTabKind === 'preview'
+				? 0
+				: 100
+	)
+	const paneBRightSize = $derived(100 - paneALeftSize)
+	// Remember a manual splitter drag. Splitpanes writes the new left size
+	// here; we keep it only when it's a genuine in-between split position
+	// (the 0/100 collapsed/full states are programmatic, not user intent).
+	function rememberPaneDrag(v: number) {
+		if (splitWithPreview && activeTabKind !== 'preview' && v > 0 && v < 100) {
+			paneARatio = v
+		}
+	}
 
 	function fileTabId(filePath: string) {
 		return FILE_PREFIX + filePath
@@ -1401,7 +1388,7 @@
 						: 'tabs-content-single'}"
 				>
 					<Splitpanes>
-						<Pane bind:size={paneALeftSize} minSize={0}>
+						<Pane bind:size={() => paneALeftSize, (v) => rememberPaneDrag(v)} minSize={0}>
 							<div class="flex flex-col h-full w-full min-h-0">
 								<DraggableTabs
 									tabs={leftPaneTabs}
@@ -1471,7 +1458,7 @@
 								</div>
 							</div>
 						</Pane>
-						<Pane bind:size={paneBRightSize} minSize={0}>
+						<Pane bind:size={() => paneBRightSize, () => {}} minSize={0}>
 							<div class="flex flex-col h-full w-full min-h-0 relative">
 								<DraggableTabs
 									tabs={rightPaneTabs}

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -996,6 +996,22 @@
 	}
 
 	let darkMode: boolean = $state(false)
+	// Host's computed `text-xs` size in px. Windmill bumps :root to 18px at
+	// ≥1760px viewports, so this re-evaluates on resize via the listener below.
+	let editorFontSize = $state(12)
+	function recomputeEditorFontSize() {
+		const rootPx = parseFloat(
+			getComputedStyle(document.documentElement).fontSize
+		)
+		// text-xs is 0.75rem
+		editorFontSize = rootPx * 0.75
+	}
+	$effect(() => {
+		recomputeEditorFontSize()
+		const onResize = () => recomputeEditorFontSize()
+		window.addEventListener('resize', onResize)
+		return () => window.removeEventListener('resize', onResize)
+	})
 	$effect(() => {
 		iframe?.addEventListener('load', () => {
 			iframeLoaded = true
@@ -1026,6 +1042,15 @@
 		if (previewIframe && previewIframeLoaded) {
 			previewIframe.contentWindow?.postMessage(
 				{ type: 'setDarkMode', dark: darkMode },
+				'*'
+			)
+		}
+	})
+	$effect(() => {
+		// Match VS Code's editor font size to Windmill's text-xs.
+		if (iframe && iframeLoaded) {
+			iframe.contentWindow?.postMessage(
+				{ type: 'setFontSize', px: editorFontSize },
 				'*'
 			)
 		}

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -28,6 +28,10 @@
 	import { createAppSelectedContext, type AppCodeSelectionElement } from '../copilot/chat/context'
 	import { rawAppLintStore } from './lintStore'
 	import { dbSchemas } from '$lib/stores'
+	import { MousePointerSquareDashed, RefreshCw, Columns2 } from 'lucide-svelte'
+	import DraggableTabs, {
+		type TabItem
+	} from '$lib/components/common/tabs/DraggableTabs.svelte'
 	import { runScriptAndPollResult } from '../jobs/utils'
 	import { RawAppHistoryManager } from './RawAppHistoryManager.svelte'
 	import { sendUserToast } from '$lib/utils'
@@ -180,6 +184,127 @@
 	historyManager.manualSnapshot(files ?? {}, runnables, summary, data)
 
 	let iframe: HTMLIFrameElement | undefined = $state(undefined)
+	let previewIframe: HTMLIFrameElement | undefined = $state(undefined)
+	let previewIframeLoaded = $state(false)
+	let lastBuild: { css: string; js: string } | undefined = undefined
+	let inspectorEnabled = $state(false)
+	let bundlerType: 'esbuild' | 'rolldown' = $state('esbuild')
+
+	// Tab system — the source side of the editor area. The sidebar stays the
+	// primary navigation; tabs are a secondary surface that's useful when the
+	// sidebar is collapsed and on narrow viewports.
+	const PREVIEW_TAB_ID = 'preview'
+	const FILE_PREFIX = 'file:'
+	const RUNNABLE_PREFIX = 'runnable:'
+	const previewTab: TabItem = {
+		id: PREVIEW_TAB_ID,
+		label: 'Preview',
+		closable: false,
+		pinned: 'right'
+	}
+	let tabs: TabItem[] = $state([previewTab])
+	let activeTabId: string = $state(PREVIEW_TAB_ID)
+	let splitWithPreview: boolean = $state(false)
+	const TABS_STORAGE_KEY = $derived(`raw-app-tabs:${$workspaceStore ?? ''}:${path ?? ''}`)
+	const activeTabKind = $derived<'file' | 'runnable' | 'preview'>(
+		activeTabId === PREVIEW_TAB_ID
+			? 'preview'
+			: activeTabId.startsWith(FILE_PREFIX)
+				? 'file'
+				: 'runnable'
+	)
+	// What's visible. Both iframes and the runnable panel stay mounted so
+	// bundling, preview state, and editor state survive tab switches.
+	// `splitWithPreview` adds the preview pane alongside the active tab; the
+	// active tab's content visibility doesn't change when split toggles.
+	const showSource = $derived(activeTabKind === 'file')
+	const showRunnable = $derived(activeTabKind === 'runnable')
+	const showPreview = $derived(activeTabKind === 'preview' || splitWithPreview)
+
+	function fileTabId(filePath: string) {
+		return FILE_PREFIX + filePath
+	}
+	function runnableTabId(key: string) {
+		return RUNNABLE_PREFIX + key
+	}
+	function fileBaseName(filePath: string) {
+		return filePath.split('/').pop() || filePath
+	}
+
+	function activateTab(id: string) {
+		const tab = tabs.find((t) => t.id === id)
+		if (!tab) return
+		activeTabId = id
+		if (tab.id === PREVIEW_TAB_ID) {
+			selectedRunnable = undefined
+		} else if (tab.id.startsWith(FILE_PREFIX)) {
+			const filePath = tab.id.slice(FILE_PREFIX.length)
+			selectedRunnable = undefined
+			iframe?.contentWindow?.postMessage({ type: 'selectFile', path: filePath }, '*')
+		} else if (tab.id.startsWith(RUNNABLE_PREFIX)) {
+			const key = tab.id.slice(RUNNABLE_PREFIX.length)
+			if (selectedRunnable !== key) selectedRunnable = key
+		}
+	}
+
+	function ensureFileTab(filePath: string): string {
+		const id = fileTabId(filePath)
+		if (!tabs.some((t) => t.id === id)) {
+			// Insert before the pinned preview tab.
+			const insertAt = tabs.findIndex((t) => t.pinned === 'right')
+			const newTab: TabItem = {
+				id,
+				label: fileBaseName(filePath),
+				closable: true
+			}
+			tabs = [
+				...tabs.slice(0, insertAt === -1 ? tabs.length : insertAt),
+				newTab,
+				...tabs.slice(insertAt === -1 ? tabs.length : insertAt)
+			]
+		}
+		return id
+	}
+
+	function ensureRunnableTab(key: string): string {
+		const id = runnableTabId(key)
+		if (!tabs.some((t) => t.id === id)) {
+			const insertAt = tabs.findIndex((t) => t.pinned === 'right')
+			const newTab: TabItem = {
+				id,
+				label: key,
+				closable: true
+			}
+			tabs = [
+				...tabs.slice(0, insertAt === -1 ? tabs.length : insertAt),
+				newTab,
+				...tabs.slice(insertAt === -1 ? tabs.length : insertAt)
+			]
+		}
+		return id
+	}
+
+	function closeTab(id: string) {
+		const idx = tabs.findIndex((t) => t.id === id)
+		const tab = tabs[idx]
+		if (!tab || tab.closable === false) return
+		const wasActive = activeTabId === id
+		// Clear runnable selection BEFORE removing the tab so the $effect
+		// doesn't immediately recreate it.
+		if (wasActive && tab.id.startsWith(RUNNABLE_PREFIX)) {
+			selectedRunnable = undefined
+		}
+		tabs = tabs.filter((t) => t.id !== id)
+		if (wasActive) {
+			// Fall back to the previous tab, else the preview tab.
+			const fallback = tabs[Math.max(0, idx - 1)] ?? previewTab
+			activateTab(fallback.id)
+		}
+	}
+
+	function reorderTabs(next: TabItem[]) {
+		tabs = next
+	}
 	let yamlEditorDrawer: Drawer | undefined = $state(undefined)
 
 	let sidebarPanelSize = $state(15)
@@ -686,6 +811,38 @@
 	}
 
 	function listener(e: MessageEvent) {
+		// Two children speak to us now: the UI Builder iframe (source editor)
+		// and the preview iframe (rendered user app). Gate by source so they
+		// can't be confused or spoofed.
+		const fromUiBuilder = e.source === iframe?.contentWindow
+		const fromPreview = e.source === previewIframe?.contentWindow
+		if (!fromUiBuilder && !fromPreview) return
+
+		// Build output: UI Builder finished bundling. Cache it and forward to
+		// the preview iframe so it renders the new app.
+		if (fromUiBuilder && e.data.type === 'preview') {
+			lastBuild = { css: e.data.css, js: e.data.js }
+			previewIframe?.contentWindow?.postMessage(
+				{ type: 'preview', css: e.data.css, js: e.data.js },
+				'*'
+			)
+			return
+		}
+
+		// Inspector events come exclusively from the preview iframe.
+		if (fromPreview && e.data.type === 'inspectorSelect') {
+			inspectorElement = e.data.element as InspectorElementInfo
+			inspectorEnabled = false
+			return
+		}
+		if (fromPreview && e.data.type === 'inspectorClear') {
+			inspectorElement = undefined
+			return
+		}
+
+		// Everything below this point is editor metadata from the UI Builder.
+		if (!fromUiBuilder) return
+
 		if (e.data.type === 'setFiles') {
 			// Ignore setFiles from the iframe while it's reloading (e.g. theme switch);
 			// the iframe boots with its default template and would otherwise clobber the user's files.
@@ -705,12 +862,20 @@
 			if (suppressSetActiveDocument) return
 			// Normalize Windows-style path separators to Linux-style
 			selectedDocument = e.data.path?.replace(/\\/g, '/')
-		} else if (e.data.type === 'inspectorSelect') {
-			// Handle inspector element selection from the iframe preview
-			inspectorElement = e.data.element as InspectorElementInfo
-		} else if (e.data.type === 'inspectorClear') {
-			// Clear the inspector element when user dismisses the selection
-			inspectorElement = undefined
+			// If VS Code switched to a file we don't have a tab for (e.g. via
+			// the file explorer's reveal-in-editor, or our own auto-open of
+			// the main app file at boot), backfill a tab.
+			if (selectedDocument) {
+				const id = fileTabId(selectedDocument)
+				if (!tabs.some((t) => t.id === id)) {
+					ensureFileTab(selectedDocument)
+					// Don't auto-activate — the user's tab choice wins.
+					// But if no file tab is currently active, fall in line.
+					if (activeTabKind === 'preview' && tabs.length === 2) {
+						activateTab(id)
+					}
+				}
+			}
 		} else if (e.data.type === 'editorSelection') {
 			// Handle code selection from the iframe editor
 			const selection = e.data.selection
@@ -756,23 +921,33 @@
 		})
 	})
 	$effect(() => {
-		// Toggling dark mode changes the iframe src, causing it to reload.
-		// Reset iframeLoaded so the populate effect refires after the new load,
-		// and suppress the iframe's initial setFiles (default template) until then.
-		void darkMode
-		untrack(() => {
-			if (iframe && iframeLoaded) {
-				iframeLoaded = false
-				suppressIframeSetFiles = true
-				// Cancel any pending clear from a prior reload — otherwise on rapid
-				// toggles the previous timer can fire mid-reload and drop suppression
-				// before the iframe has finished booting.
-				if (suppressTimer !== undefined) {
-					clearTimeout(suppressTimer)
-					suppressTimer = undefined
-				}
+		previewIframe?.addEventListener('load', () => {
+			previewIframeLoaded = true
+			// Replay the last build so the preview repopulates without
+			// waiting for the user to trigger another bundle.
+			if (lastBuild) {
+				previewIframe?.contentWindow?.postMessage(
+					{ type: 'preview', css: lastBuild.css, js: lastBuild.js },
+					'*'
+				)
 			}
 		})
+	})
+	$effect(() => {
+		// Push dark mode to both children. The UI Builder iframe and the
+		// preview iframe each listen for `setDarkMode` separately.
+		if (iframe && iframeLoaded) {
+			iframe.contentWindow?.postMessage(
+				{ type: 'setDarkMode', dark: darkMode },
+				'*'
+			)
+		}
+		if (previewIframe && previewIframeLoaded) {
+			previewIframe.contentWindow?.postMessage(
+				{ type: 'setDarkMode', dark: darkMode },
+				'*'
+			)
+		}
 	})
 	$effect(() => {
 		iframe && iframeLoaded && files && populateFiles()
@@ -798,15 +973,10 @@
 
 	function handleSelectFile(path: string) {
 		console.log('event Select file:', path)
-		selectedRunnable = undefined
-		// Inspector is cleared by the $effect watching selection changes
-		iframe?.contentWindow?.postMessage(
-			{
-				type: 'selectFile',
-				path: path
-			},
-			'*'
-		)
+		// Adding the tab activates it; activateTab posts the selectFile message
+		// to the UI Builder iframe and clears any selected runnable.
+		const id = ensureFileTab(path)
+		activateTab(id)
 	}
 
 	// Track previous values for change detection
@@ -823,6 +993,93 @@
 			prevSelectedRunnable = selectedRunnable
 			prevSelectedDocument = selectedDocument
 		}
+	})
+
+	// Mirror sidebar runnable selection into the tab system. When the user
+	// picks a runnable from the sidebar, `selectedRunnable` flips via
+	// `bind:selectedRunnable`; ensure a tab for it exists and is active.
+	$effect(() => {
+		const key = selectedRunnable
+		if (!key) return
+		const id = runnableTabId(key)
+		untrack(() => {
+			if (!tabs.some((t) => t.id === id)) ensureRunnableTab(key)
+			if (activeTabId !== id) activeTabId = id
+		})
+	})
+
+	// Hydrate tab state from localStorage on mount.
+	let tabsHydrated = $state(false)
+	onMount(() => {
+		try {
+			const raw = localStorage.getItem(TABS_STORAGE_KEY)
+			if (raw) {
+				const parsed = JSON.parse(raw) as {
+					tabs?: TabItem[]
+					activeTabId?: string
+					splitWithPreview?: boolean
+				}
+				if (Array.isArray(parsed.tabs) && parsed.tabs.length > 0) {
+					// Always re-pin the preview tab — if the stored data lost
+					// its `pinned` marker we'd misrender.
+					const stored = parsed.tabs.filter((t) => t.id !== PREVIEW_TAB_ID)
+					tabs = [...stored, previewTab]
+				}
+				if (parsed.activeTabId && tabs.some((t) => t.id === parsed.activeTabId)) {
+					activateTab(parsed.activeTabId)
+				}
+				if (typeof parsed.splitWithPreview === 'boolean') {
+					splitWithPreview = parsed.splitWithPreview
+				}
+			}
+		} catch (e) {
+			console.warn('Failed to hydrate raw-app tabs from localStorage', e)
+		} finally {
+			tabsHydrated = true
+		}
+	})
+
+	// Persist tab state. Gated on `tabsHydrated` so the initial default state
+	// doesn't overwrite the user's saved layout.
+	$effect(() => {
+		void tabs
+		void activeTabId
+		void splitWithPreview
+		if (!tabsHydrated) return
+		untrack(() => {
+			try {
+				localStorage.setItem(
+					TABS_STORAGE_KEY,
+					JSON.stringify({ tabs, activeTabId, splitWithPreview })
+				)
+			} catch (e) {
+				// Quota or privacy mode — silent, persistence is a nice-to-have.
+			}
+		})
+	})
+
+	// Drop file tabs whose underlying file disappeared (deleted via setFiles
+	// or workspace cleanup). Same for runnable tabs whose key no longer
+	// exists in the runnables map.
+	$effect(() => {
+		void files
+		void runnables
+		untrack(() => {
+			const filesSet = files ?? {}
+			const runnablesSet = runnables ?? {}
+			const stale = tabs.filter((t) => {
+				if (t.id.startsWith(FILE_PREFIX)) {
+					const fp = t.id.slice(FILE_PREFIX.length)
+					return filesSet[fp] === undefined
+				}
+				if (t.id.startsWith(RUNNABLE_PREFIX)) {
+					const k = t.id.slice(RUNNABLE_PREFIX.length)
+					return runnablesSet[k] === undefined
+				}
+				return false
+			})
+			for (const t of stale) closeTab(t.id)
+		})
 	})
 
 	function handleUndo() {
@@ -915,7 +1172,7 @@
 <RawAppBackgroundRunner
 	workspace={$workspaceStore ?? ''}
 	editor
-	{iframe}
+	iframe={previewIframe}
 	bind:jobs
 	bind:jobsById
 	{runnables}
@@ -1007,46 +1264,152 @@
 			</Pane>
 		{/if}
 		<Pane>
-			<div class="h-full w-full relative">
-				<iframe
-					bind:this={iframe}
-					title="UI builder"
-					style="display: {selectedRunnable == undefined ? 'block' : 'none'}"
-					src="/ui_builder/index.html?dark={darkMode}"
-					class="w-full h-full"
-				></iframe>
-				{#if selectedRunnable !== undefined}
-					<!-- svelte-ignore a11y_no_static_element_interactions -->
-					<div class="flex h-full w-full">
-						<RawAppInlineScriptsPanel
-							appPath={path}
-							{selectedRunnable}
-							bind:runnables
-							onSelectionChange={(selection) => {
-								console.log('handle selection', selection)
-
-								if (selection === null) {
-									codeSelection = undefined
-								} else if (selectedRunnable) {
-									codeSelection = {
-										type: 'app_code_selection',
-										source: selectedRunnable,
-										sourceType: 'backend',
-										title: `${selectedRunnable}:L${selection.startLine}-L${selection.endLine}`,
-										content: selection.content,
-										startLine: selection.startLine,
-										endLine: selection.endLine,
-										startColumn: selection.startColumn,
-										endColumn: selection.endColumn
+			<div class="flex flex-col h-full w-full min-h-0">
+				<DraggableTabs
+					{tabs}
+					activeId={activeTabId}
+					onSelect={(id) => activateTab(id)}
+					onClose={(id) => closeTab(id)}
+					onReorder={(next) => reorderTabs(next)}
+				>
+					{#snippet trailing()}
+						<div class="flex items-center gap-1 px-2">
+							{#if activeTabKind !== 'preview'}
+								<button
+									title={splitWithPreview
+										? 'Hide preview pane'
+										: 'Show preview side-by-side'}
+									aria-label="Toggle split with preview"
+									aria-pressed={splitWithPreview}
+									class={splitWithPreview
+										? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
+										: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
+									onclick={() => (splitWithPreview = !splitWithPreview)}
+								>
+									<Columns2 size={14} />
+								</button>
+							{/if}
+							<button
+								class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary px-2 h-7 rounded-md text-xs"
+								title="Switch bundler"
+								onclick={() => {
+									const next =
+										bundlerType === 'esbuild' ? 'rolldown' : 'esbuild'
+									bundlerType = next
+									iframe?.contentWindow?.postMessage(
+										{ type: 'setBundlerType', bundlerType: next },
+										'*'
+									)
+								}}>{bundlerType}</button
+							>
+							<button
+								title={inspectorEnabled
+									? 'Click to disable element inspector'
+									: 'Click to enable element inspector'}
+								class={inspectorEnabled
+									? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
+									: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
+								aria-label="Toggle element inspector"
+								onclick={() => {
+									inspectorEnabled = !inspectorEnabled
+									previewIframe?.contentWindow?.postMessage(
+										{
+											type: inspectorEnabled
+												? 'inspectorEnable'
+												: 'inspectorDisable'
+										},
+										'*'
+									)
+								}}
+							>
+								<MousePointerSquareDashed size={14} />
+							</button>
+							<button
+								class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center"
+								title="Replay the last build into the preview"
+								aria-label="Rebuild"
+								onclick={() => {
+									if (lastBuild) {
+										previewIframe?.contentWindow?.postMessage(
+											{
+												type: 'preview',
+												css: lastBuild.css,
+												js: lastBuild.js
+											},
+											'*'
+										)
 									}
-								}
-							}}
-						/>
+								}}
+							>
+								<RefreshCw size={14} />
+							</button>
+						</div>
+					{/snippet}
+				</DraggableTabs>
+				<!--
+					Content area. All three slots stay mounted always; we toggle
+					CSS display so iframes don't lose state on tab switches.
+					Flex layout: in single mode only one slot has display, so
+					it takes the full width. In split mode two are visible and
+					share the space.
+				-->
+				<div class="flex flex-1 min-h-0 w-full">
+					<div
+						class="flex-1 min-w-0 relative"
+						style="display: {showSource ? 'block' : 'none'}"
+					>
+						<iframe
+							bind:this={iframe}
+							title="UI builder"
+							src="/ui_builder/index.html"
+							class="w-full h-full block"
+						></iframe>
 					</div>
-				{/if}
+					<div
+						class="flex-1 min-w-0 relative"
+						style="display: {showRunnable ? 'block' : 'none'}"
+					>
+						<!-- svelte-ignore a11y_no_static_element_interactions -->
+						<div class="flex h-full w-full">
+							{#if selectedRunnable !== undefined}
+								<RawAppInlineScriptsPanel
+									appPath={path}
+									{selectedRunnable}
+									bind:runnables
+									onSelectionChange={(selection) => {
+										if (selection === null) {
+											codeSelection = undefined
+										} else if (selectedRunnable) {
+											codeSelection = {
+												type: 'app_code_selection',
+												source: selectedRunnable,
+												sourceType: 'backend',
+												title: `${selectedRunnable}:L${selection.startLine}-L${selection.endLine}`,
+												content: selection.content,
+												startLine: selection.startLine,
+												endLine: selection.endLine,
+												startColumn: selection.startColumn,
+												endColumn: selection.endColumn
+											}
+										}
+									}}
+								/>
+							{/if}
+						</div>
+					</div>
+					<div
+						class="flex-1 min-w-0 relative"
+						style="display: {showPreview ? 'block' : 'none'}"
+					>
+						<iframe
+							bind:this={previewIframe}
+							title="App preview"
+							src="/ui_builder/app-preview.html"
+							class="w-full h-full block"
+						></iframe>
+					</div>
+				</div>
 			</div>
-
-			<!-- <div class="bg-red-400 h-full w-full" /> -->
 		</Pane>
 	</Splitpanes>
 </div>

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -213,13 +213,23 @@
 				? 'file'
 				: 'runnable'
 	)
-	// When split is on, the Preview tab moves out of the bar and lives in
-	// the right pane. The user only sees file/runnable tabs in the bar;
-	// the right pane is always preview. When split is off, the Preview
-	// tab is back in the bar like any other tab.
-	const displayedTabs = $derived(
+	// Per-pane tab lists.
+	// - Single mode: BOTH panes mirror the FULL tab list — whichever pane is
+	//   visible (paneA when source is active, paneB when preview is active)
+	//   carries every tab so the user can always switch. This is the fix
+	//   for the bug where activating Preview hid every tab.
+	// - Split mode: each pane shows its own subset (VS Code-style):
+	//   left = file/runnable tabs, right = just the Preview pseudo-header.
+	const leftPaneTabs = $derived<TabItem[]>(
 		splitWithPreview ? tabs.filter((t) => t.id !== PREVIEW_TAB_ID) : tabs
 	)
+	const rightPaneTabs = $derived<TabItem[]>(
+		splitWithPreview ? tabs.filter((t) => t.id === PREVIEW_TAB_ID) : tabs
+	)
+	// In split mode the Preview tab is permanently visible in the right pane;
+	// the right bar always shows it as the active tab regardless of which
+	// file/runnable tab is logically active in the left pane.
+	const rightPaneActiveId = $derived(splitWithPreview ? PREVIEW_TAB_ID : activeTabId)
 	const showSource = $derived(activeTabKind === 'file')
 	const showRunnable = $derived(activeTabKind === 'runnable')
 
@@ -274,6 +284,11 @@
 	function activateTab(id: string) {
 		const tab = tabs.find((t) => t.id === id)
 		if (!tab) return
+		// Clicking the Preview tab while in split mode is a visual no-op —
+		// Preview is already permanently shown in the right pane, and
+		// promoting it to active would trigger the pane-sizing $effect and
+		// collapse the left pane (the bug being fixed here).
+		if (splitWithPreview && id === PREVIEW_TAB_ID) return
 		activeTabId = id
 		if (tab.id === PREVIEW_TAB_ID) {
 			selectedRunnable = undefined
@@ -1330,56 +1345,49 @@
 			</Pane>
 		{/if}
 		<Pane>
-			<div class="flex flex-col h-full w-full min-h-0">
-				<!--
-					Main tab bar — always visible above the Splitpanes, full
-					width. The user can switch tabs (including back from
-					Preview to a file) without losing visibility on the rest
-					of the tab list.
-				-->
-				<DraggableTabs
-					tabs={displayedTabs}
-					activeId={activeTabId}
-					onSelect={(id) => activateTab(id)}
-					onClose={(id) => closeTab(id)}
-					onReorder={(next) => reorderTabs(next)}
-				>
-					{#snippet trailing()}
-						<div class="flex items-center gap-1 px-2">
-							<button
-								title={splitWithPreview
-									? 'Move preview back into a tab'
-									: 'Pin preview to the right'}
-								aria-label="Toggle split with preview"
-								aria-pressed={splitWithPreview}
-								class={splitWithPreview
-									? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
-									: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
-								onclick={toggleSplit}
+			<!--
+				Per-pane tab bars (VS Code-style). Each pane carries its own
+				DraggableTabs instance so the splitter goes floor-to-ceiling
+				through tabs AND content in split mode. In single mode both
+				bars mirror the FULL tab list — whichever pane is visible
+				keeps every tab accessible, fixing the bug where activating
+				Preview previously hid every tab.
+			-->
+			<div
+				class="h-full w-full min-h-0 {splitWithPreview &&
+				activeTabKind !== 'preview'
+					? 'tabs-content-split'
+					: 'tabs-content-single'}"
+			>
+				<Splitpanes>
+					<Pane bind:size={paneALeftSize} minSize={0}>
+						<div class="flex flex-col h-full w-full min-h-0">
+							<DraggableTabs
+								tabs={leftPaneTabs}
+								activeId={activeTabId}
+								onSelect={(id) => activateTab(id)}
+								onClose={(id) => closeTab(id)}
+								onReorder={(next) => reorderTabs(next)}
 							>
-								<Columns2 size={14} />
-							</button>
-						</div>
-					{/snippet}
-				</DraggableTabs>
-				<!--
-					Content area: Splitpanes below the main tab bar. Both
-					iframes + RawAppInlineScriptsPanel stay mounted always;
-					`display` + pane sizes do the swapping. The right pane
-					carries its own Preview pseudo-header with the
-					preview-affecting toolbar (bundler / inspector /
-					rebuild). The header is rendered whenever the right
-					pane is visible — width 0 hides it implicitly.
-				-->
-				<div
-					class="flex-1 min-h-0 w-full {splitWithPreview &&
-					activeTabKind !== 'preview'
-						? 'tabs-content-split'
-						: 'tabs-content-single'}"
-				>
-					<Splitpanes>
-						<Pane bind:size={paneALeftSize} minSize={0}>
-							<div class="relative h-full w-full">
+								{#snippet trailing()}
+									<div class="flex items-center gap-1 px-2">
+										<button
+											title={splitWithPreview
+												? 'Move preview back into a tab'
+												: 'Pin preview to the right'}
+											aria-label="Toggle split with preview"
+											aria-pressed={splitWithPreview}
+											class={splitWithPreview
+												? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
+												: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
+											onclick={toggleSplit}
+										>
+											<Columns2 size={14} />
+										</button>
+									</div>
+								{/snippet}
+							</DraggableTabs>
+							<div class="flex-1 min-h-0 relative">
 								<div
 									class="absolute inset-0"
 									style="display: {showSource ? 'block' : 'none'}"
@@ -1424,18 +1432,19 @@
 									</div>
 								</div>
 							</div>
-						</Pane>
-						<Pane bind:size={paneBRightSize} minSize={0}>
-							<div class="flex flex-col h-full w-full min-h-0">
-								<div
-									class="flex items-stretch bg-surface-secondary flex-shrink-0 h-8"
-								>
-									<div
-										class="inline-flex items-center gap-1.5 px-3 h-8 text-xs bg-surface text-primary"
-									>
-										<span>Preview</span>
-									</div>
-									<div class="ml-auto flex items-center gap-1 px-2">
+						</div>
+					</Pane>
+					<Pane bind:size={paneBRightSize} minSize={0}>
+						<div class="flex flex-col h-full w-full min-h-0">
+							<DraggableTabs
+								tabs={rightPaneTabs}
+								activeId={rightPaneActiveId}
+								onSelect={(id) => activateTab(id)}
+								onClose={(id) => closeTab(id)}
+								onReorder={(next) => reorderTabs(next)}
+							>
+								{#snippet trailing()}
+									<div class="flex items-center gap-1 px-2">
 										<button
 											class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary px-2 h-7 rounded-md text-xs"
 											title="Switch bundler"
@@ -1490,18 +1499,31 @@
 										>
 											<RefreshCw size={14} />
 										</button>
+										<button
+											title={splitWithPreview
+												? 'Move preview back into a tab'
+												: 'Pin preview to the right'}
+											aria-label="Toggle split with preview"
+											aria-pressed={splitWithPreview}
+											class={splitWithPreview
+												? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
+												: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
+											onclick={toggleSplit}
+										>
+											<Columns2 size={14} />
+										</button>
 									</div>
-								</div>
-								<iframe
-									bind:this={previewIframe}
-									title="App preview"
-									src="/ui_builder/app-preview.html"
-									class="w-full flex-1 block"
-								></iframe>
-							</div>
-						</Pane>
-					</Splitpanes>
-				</div>
+								{/snippet}
+							</DraggableTabs>
+							<iframe
+								bind:this={previewIframe}
+								title="App preview"
+								src="/ui_builder/app-preview.html"
+								class="w-full flex-1 block"
+							></iframe>
+						</div>
+					</Pane>
+				</Splitpanes>
 			</div>
 		</Pane>
 	</Splitpanes>

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -29,10 +29,8 @@
 	import { createAppSelectedContext, type AppCodeSelectionElement } from '../copilot/chat/context'
 	import { rawAppLintStore } from './lintStore'
 	import { dbSchemas } from '$lib/stores'
-	import { MousePointerSquareDashed, RefreshCw, Columns2, ChevronDown } from 'lucide-svelte'
-	import DraggableTabs, {
-		type TabItem
-	} from '$lib/components/common/tabs/DraggableTabs.svelte'
+	import { MousePointerSquareDashed, RefreshCw, Columns2, ChevronDown, Eye } from 'lucide-svelte'
+	import DraggableTabs, { type TabItem } from '$lib/components/common/tabs/DraggableTabs.svelte'
 	import { runScriptAndPollResult } from '../jobs/utils'
 	import { RawAppHistoryManager } from './RawAppHistoryManager.svelte'
 	import { sendUserToast } from '$lib/utils'
@@ -212,12 +210,15 @@
 	const previewTab: TabItem = {
 		id: PREVIEW_TAB_ID,
 		label: 'Preview',
+		icon: Eye,
+		iconClass: 'text-accent',
+		labelClass: 'text-accent',
 		closable: false,
 		pinned: 'right'
 	}
 	let tabs: TabItem[] = $state([previewTab])
 	let activeTabId: string = $state(PREVIEW_TAB_ID)
-	let splitWithPreview: boolean = $state(false)
+	let splitWithPreview: boolean = $state(true)
 	const TABS_STORAGE_KEY = $derived(`raw-app-tabs:${$workspaceStore ?? ''}:${path ?? ''}`)
 	const activeTabKind = $derived<'file' | 'runnable' | 'preview'>(
 		activeTabId === PREVIEW_TAB_ID
@@ -302,6 +303,24 @@
 	}
 	function fileBaseName(filePath: string) {
 		return filePath.split('/').pop() || filePath
+	}
+
+	// Pick the file to open by default on a fresh load so the split view
+	// shows the editor + preview instead of a blank full-screen preview.
+	// Prefer the main `App.*` component, then the `index.*` entry, then any
+	// other source file, falling back to whatever exists.
+	function pickDefaultFile(f: Record<string, string> | undefined): string | undefined {
+		if (!f) return undefined
+		const keys = Object.keys(f).filter((p) => !p.endsWith('/'))
+		if (keys.length === 0) return undefined
+		const isSource = (p: string) =>
+			/\.(tsx|jsx|ts|js|svelte|vue)$/i.test(p) && !/package(-lock)?\.json$/i.test(p)
+		return (
+			keys.find((p) => /(^|\/)App\.(tsx|jsx|ts|js|svelte|vue)$/i.test(p)) ??
+			keys.find((p) => /(^|\/)index\.(tsx|jsx|ts|js)$/i.test(p)) ??
+			keys.find(isSource) ??
+			keys[0]
+		)
 	}
 
 	function activateTab(id: string, opts?: { force?: boolean }) {
@@ -429,12 +448,8 @@
 	let rawSidebarSize = $state(15)
 	let splitContainerWidth = $state(0)
 	const SIDEBAR_PX_MIN = 160
-	const sidebarMinPercent = $derived(
-		paneMinPercent(splitContainerWidth, SIDEBAR_PX_MIN)
-	)
-	const sidebarPanelSize = $derived(
-		Math.max(rawSidebarSize, sidebarMinPercent)
-	)
+	const sidebarMinPercent = $derived(paneMinPercent(splitContainerWidth, SIDEBAR_PX_MIN))
+	const sidebarPanelSize = $derived(Math.max(rawSidebarSize, sidebarMinPercent))
 
 	// Persisted across opens. Seeded with `defaultSidebarCollapsed` only when
 	// localStorage has no entry yet — callers (like the session preview pane)
@@ -1048,9 +1063,7 @@
 	// ≥1760px viewports, so this re-evaluates on resize via the listener below.
 	let editorFontSize = $state(12)
 	function recomputeEditorFontSize() {
-		const rootPx = parseFloat(
-			getComputedStyle(document.documentElement).fontSize
-		)
+		const rootPx = parseFloat(getComputedStyle(document.documentElement).fontSize)
 		// text-xs is 0.75rem
 		editorFontSize = rootPx * 0.75
 	}
@@ -1082,25 +1095,16 @@
 		// Push dark mode to both children. The UI Builder iframe and the
 		// preview iframe each listen for `setDarkMode` separately.
 		if (iframe && iframeLoaded) {
-			iframe.contentWindow?.postMessage(
-				{ type: 'setDarkMode', dark: darkMode },
-				'*'
-			)
+			iframe.contentWindow?.postMessage({ type: 'setDarkMode', dark: darkMode }, '*')
 		}
 		if (previewIframe && previewIframeLoaded) {
-			previewIframe.contentWindow?.postMessage(
-				{ type: 'setDarkMode', dark: darkMode },
-				'*'
-			)
+			previewIframe.contentWindow?.postMessage({ type: 'setDarkMode', dark: darkMode }, '*')
 		}
 	})
 	$effect(() => {
 		// Match VS Code's editor font size to Windmill's text-xs.
 		if (iframe && iframeLoaded) {
-			iframe.contentWindow?.postMessage(
-				{ type: 'setFontSize', px: editorFontSize },
-				'*'
-			)
+			iframe.contentWindow?.postMessage({ type: 'setFontSize', px: editorFontSize }, '*')
 		}
 	})
 	$effect(() => {
@@ -1189,6 +1193,14 @@
 		} catch (e) {
 			console.warn('Failed to hydrate raw-app tabs from localStorage', e)
 		} finally {
+			// Fresh app (no saved file tab — only Preview): open a default file
+			// and activate it. With `splitWithPreview` defaulting to true this
+			// renders the editor + preview side-by-side and boots the UI
+			// Builder iframe (which then builds the preview).
+			if (tabs.length === 1) {
+				const def = pickDefaultFile(files)
+				if (def) activateTab(ensureFileTab(def))
+			}
 			tabsHydrated = true
 		}
 	})
@@ -1375,55 +1387,55 @@
 					minSize={sidebarMinPercent}
 					class="h-full overflow-y-auto relative"
 				>
-				<RawAppSidebar
-					bind:files={
-						() => files,
-						(newFiles) => {
-							files = newFiles
-							setFilesInIframe(newFiles ?? {})
+					<RawAppSidebar
+						bind:files={
+							() => files,
+							(newFiles) => {
+								files = newFiles
+								setFilesInIframe(newFiles ?? {})
+							}
 						}
-					}
-					onSelectFile={handleSelectFile}
-					bind:selectedRunnable
-					bind:selectedDocument
-					dataTableRefs={dataTableRefsObjects}
-					onDataTableRefsChange={(newRefs) => {
-						data.tables = newRefs.map(formatDataTableRef)
-					}}
-					defaultDatatable={data.datatable}
-					defaultSchema={data.schema}
-					onDefaultChange={(datatable, schema) => {
-						data.datatable = datatable
-						data.schema = schema
-						// Also sync to aiChatManager
-						aiChatManager.datatableCreationPolicy = {
-							...aiChatManager.datatableCreationPolicy,
-							datatable,
-							schema
-						}
-					}}
-					{runnables}
-					{modules}
-					{historyManager}
-					historySelectedId={historyManager.selectedEntryId}
-					onHistorySelect={handleHistorySelect}
-					onHistorySelectCurrent={() => {
-						// Restore the temporary current state if it exists
-						const tempState = historyManager.getAndClearTemporaryState()
-						if (tempState) {
-							applyEntry(tempState)
-						}
-						// Clear selection to indicate we're at current state
-						historyManager.clearSelection()
-					}}
-					onManualSnapshot={() => {
-						historyManager.manualSnapshot(files ?? {}, runnables, summary, data, true)
-					}}
-				></RawAppSidebar>
-			</Pane>
-		{/if}
-		<Pane>
-			<!--
+						onSelectFile={handleSelectFile}
+						bind:selectedRunnable
+						bind:selectedDocument
+						dataTableRefs={dataTableRefsObjects}
+						onDataTableRefsChange={(newRefs) => {
+							data.tables = newRefs.map(formatDataTableRef)
+						}}
+						defaultDatatable={data.datatable}
+						defaultSchema={data.schema}
+						onDefaultChange={(datatable, schema) => {
+							data.datatable = datatable
+							data.schema = schema
+							// Also sync to aiChatManager
+							aiChatManager.datatableCreationPolicy = {
+								...aiChatManager.datatableCreationPolicy,
+								datatable,
+								schema
+							}
+						}}
+						{runnables}
+						{modules}
+						{historyManager}
+						historySelectedId={historyManager.selectedEntryId}
+						onHistorySelect={handleHistorySelect}
+						onHistorySelectCurrent={() => {
+							// Restore the temporary current state if it exists
+							const tempState = historyManager.getAndClearTemporaryState()
+							if (tempState) {
+								applyEntry(tempState)
+							}
+							// Clear selection to indicate we're at current state
+							historyManager.clearSelection()
+						}}
+						onManualSnapshot={() => {
+							historyManager.manualSnapshot(files ?? {}, runnables, summary, data, true)
+						}}
+					></RawAppSidebar>
+				</Pane>
+			{/if}
+			<Pane>
+				<!--
 				Per-pane tab bars (VS Code-style). Each pane carries its own
 				DraggableTabs instance so the splitter goes floor-to-ceiling
 				through tabs AND content in split mode. In single mode both
@@ -1431,214 +1443,197 @@
 				keeps every tab accessible, fixing the bug where activating
 				Preview previously hid every tab.
 			-->
-			<div
-				class="h-full w-full min-h-0 {splitWithPreview &&
-				activeTabKind !== 'preview'
-					? 'tabs-content-split'
-					: 'tabs-content-single'}"
-			>
-				<Splitpanes>
-					<Pane bind:size={paneALeftSize} minSize={0}>
-						<div class="flex flex-col h-full w-full min-h-0">
-							<DraggableTabs
-								tabs={leftPaneTabs}
-								activeId={activeTabId}
-								onSelect={(id) => activateTab(id)}
-								onClose={(id) => closeTab(id)}
-								onReorder={(next) => reorderTabs(next)}
-							>
-								{#snippet trailing()}
-									<div class="flex items-center gap-1 px-2">
-										<button
-											title={splitWithPreview
-												? 'Move preview back into a tab'
-												: 'Pin preview to the right'}
-											aria-label="Toggle split with preview"
-											aria-pressed={splitWithPreview}
-											class={splitWithPreview
-												? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
-												: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
-											onclick={toggleSplit}
-										>
-											<Columns2 size={14} />
-										</button>
-									</div>
-								{/snippet}
-							</DraggableTabs>
-							<div class="flex-1 min-h-0 relative">
-								<div
-									class="absolute inset-0"
-									style="display: {showSource ? 'block' : 'none'}"
+				<div
+					class="h-full w-full min-h-0 {splitWithPreview && activeTabKind !== 'preview'
+						? 'tabs-content-split'
+						: 'tabs-content-single'}"
+				>
+					<Splitpanes>
+						<Pane bind:size={paneALeftSize} minSize={0}>
+							<div class="flex flex-col h-full w-full min-h-0">
+								<DraggableTabs
+									tabs={leftPaneTabs}
+									activeId={activeTabId}
+									onSelect={(id) => activateTab(id)}
+									onClose={(id) => closeTab(id)}
+									onReorder={(next) => reorderTabs(next)}
 								>
-									{#if iframeShouldMount}
-										<iframe
-											bind:this={iframe}
-											title="UI builder"
-											src="/ui_builder/index.html"
-											class="w-full h-full block"
-										></iframe>
-									{/if}
-								</div>
-								<div
-									class="absolute inset-0"
-									style="display: {showRunnable ? 'block' : 'none'}"
-								>
-									<!-- svelte-ignore a11y_no_static_element_interactions -->
-									<div class="flex h-full w-full">
-										{#if selectedRunnable !== undefined}
-											<RawAppInlineScriptsPanel
-												appPath={path}
-												{selectedRunnable}
-												bind:runnables
-												onSelectionChange={(selection) => {
-													if (selection === null) {
-														codeSelection = undefined
-													} else if (selectedRunnable) {
-														codeSelection = {
-															type: 'app_code_selection',
-															source: selectedRunnable,
-															sourceType: 'backend',
-															title: `${selectedRunnable}:L${selection.startLine}-L${selection.endLine}`,
-															content: selection.content,
-															startLine: selection.startLine,
-															endLine: selection.endLine,
-															startColumn: selection.startColumn,
-															endColumn: selection.endColumn
-														}
-													}
-												}}
-											/>
+									{#snippet trailing()}
+										<div class="flex items-center gap-1 px-2">
+											<button
+												title={splitWithPreview
+													? 'Move preview back into a tab'
+													: 'Pin preview to the right'}
+												aria-label="Toggle split with preview"
+												aria-pressed={splitWithPreview}
+												class={splitWithPreview
+													? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
+													: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
+												onclick={toggleSplit}
+											>
+												<Columns2 size={14} />
+											</button>
+										</div>
+									{/snippet}
+								</DraggableTabs>
+								<div class="flex-1 min-h-0 relative">
+									<div class="absolute inset-0" style="display: {showSource ? 'block' : 'none'}">
+										{#if iframeShouldMount}
+											<iframe
+												bind:this={iframe}
+												title="UI builder"
+												src="/ui_builder/index.html"
+												class="w-full h-full block"
+											></iframe>
 										{/if}
+									</div>
+									<div class="absolute inset-0" style="display: {showRunnable ? 'block' : 'none'}">
+										<!-- svelte-ignore a11y_no_static_element_interactions -->
+										<div class="flex h-full w-full">
+											{#if selectedRunnable !== undefined}
+												<RawAppInlineScriptsPanel
+													appPath={path}
+													{selectedRunnable}
+													bind:runnables
+													onSelectionChange={(selection) => {
+														if (selection === null) {
+															codeSelection = undefined
+														} else if (selectedRunnable) {
+															codeSelection = {
+																type: 'app_code_selection',
+																source: selectedRunnable,
+																sourceType: 'backend',
+																title: `${selectedRunnable}:L${selection.startLine}-L${selection.endLine}`,
+																content: selection.content,
+																startLine: selection.startLine,
+																endLine: selection.endLine,
+																startColumn: selection.startColumn,
+																endColumn: selection.endColumn
+															}
+														}
+													}}
+												/>
+											{/if}
+										</div>
 									</div>
 								</div>
 							</div>
-						</div>
-					</Pane>
-					<Pane bind:size={paneBRightSize} minSize={0}>
-						<div class="flex flex-col h-full w-full min-h-0 relative">
-							<DraggableTabs
-								tabs={rightPaneTabs}
-								activeId={rightPaneActiveId}
-								onSelect={(id) => activateTab(id)}
-								onClose={(id) => closeTab(id)}
-								onReorder={(next) => reorderTabs(next)}
-							>
-								{#snippet trailing()}
-									<div class="flex items-center gap-1 px-2">
-										<button
-											class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary px-2 h-7 rounded-md text-xs"
-											title="Switch bundler"
-											onclick={() => {
-												const next =
-													bundlerType === 'esbuild' ? 'rolldown' : 'esbuild'
-												bundlerType = next
-												iframe?.contentWindow?.postMessage(
-													{ type: 'setBundlerType', bundlerType: next },
-													'*'
-												)
-											}}>{bundlerType}</button
-										>
-										<button
-											title={inspectorEnabled
-												? 'Click to disable element inspector'
-												: 'Click to enable element inspector'}
-											class={inspectorEnabled
-												? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
-												: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
-											aria-label="Toggle element inspector"
-											onclick={() => {
-												inspectorEnabled = !inspectorEnabled
-												previewIframe?.contentWindow?.postMessage(
-													{
-														type: inspectorEnabled
-															? 'inspectorEnable'
-															: 'inspectorDisable'
-													},
-													'*'
-												)
-											}}
-										>
-											<MousePointerSquareDashed size={14} />
-										</button>
-										<button
-											class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center"
-											title="Replay the last build into the preview"
-											aria-label="Rebuild"
-											onclick={() => {
-												if (lastBuild) {
+						</Pane>
+						<Pane bind:size={paneBRightSize} minSize={0}>
+							<div class="flex flex-col h-full w-full min-h-0 relative">
+								<DraggableTabs
+									tabs={rightPaneTabs}
+									activeId={rightPaneActiveId}
+									onSelect={(id) => activateTab(id)}
+									onClose={(id) => closeTab(id)}
+									onReorder={(next) => reorderTabs(next)}
+								>
+									{#snippet trailing()}
+										<div class="flex items-center gap-1 px-2">
+											<button
+												class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary px-2 h-7 rounded-md text-xs"
+												title="Switch bundler"
+												onclick={() => {
+													const next = bundlerType === 'esbuild' ? 'rolldown' : 'esbuild'
+													bundlerType = next
+													iframe?.contentWindow?.postMessage(
+														{ type: 'setBundlerType', bundlerType: next },
+														'*'
+													)
+												}}>{bundlerType}</button
+											>
+											<button
+												title={inspectorEnabled
+													? 'Click to disable element inspector'
+													: 'Click to enable element inspector'}
+												class={inspectorEnabled
+													? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
+													: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
+												aria-label="Toggle element inspector"
+												onclick={() => {
+													inspectorEnabled = !inspectorEnabled
 													previewIframe?.contentWindow?.postMessage(
 														{
-															type: 'preview',
-															css: lastBuild.css,
-															js: lastBuild.js
+															type: inspectorEnabled ? 'inspectorEnable' : 'inspectorDisable'
 														},
 														'*'
 													)
-												}
-											}}
-										>
-											<RefreshCw size={14} />
-										</button>
-										<button
-											title={splitWithPreview
-												? 'Move preview back into a tab'
-												: 'Pin preview to the right'}
-											aria-label="Toggle split with preview"
-											aria-pressed={splitWithPreview}
-											class={splitWithPreview
-												? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
-												: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
-											onclick={toggleSplit}
-										>
-											<Columns2 size={14} />
-										</button>
-									</div>
-								{/snippet}
-							</DraggableTabs>
-							<iframe
-								bind:this={previewIframe}
-								title="App preview"
-								src="/ui_builder/app-preview.html"
-								class="w-full flex-1 block"
-							></iframe>
-							{#if logs}
-								<div
-									class="absolute right-0 bottom-0 z-20 max-w-[500px] w-full flex flex-col text-xs p-1 border border-border-light rounded-tl-md bg-surface text-primary {logsCollapsed
-										? 'h-6'
-										: 'max-h-60 h-full'}"
-								>
-									<button
-										class="cursor-pointer flex items-center gap-2 w-full text-xs font-normal text-secondary -mt-0.5 px-2 text-left"
-										onclick={() => (logsCollapsed = !logsCollapsed)}
-									>
-										Logs
-										<ChevronDown
-											size={12}
-											class="transition duration-200"
-											style="transform: {logsCollapsed
-												? 'rotate(180deg)'
-												: 'rotate(0deg)'}"
-										/>
-										<span class="text-secondary"
-											>({logs.split('\n').length})</span
-										>
-									</button>
+												}}
+											>
+												<MousePointerSquareDashed size={14} />
+											</button>
+											<button
+												class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center"
+												title="Replay the last build into the preview"
+												aria-label="Rebuild"
+												onclick={() => {
+													if (lastBuild) {
+														previewIframe?.contentWindow?.postMessage(
+															{
+																type: 'preview',
+																css: lastBuild.css,
+																js: lastBuild.js
+															},
+															'*'
+														)
+													}
+												}}
+											>
+												<RefreshCw size={14} />
+											</button>
+											<button
+												title={splitWithPreview
+													? 'Move preview back into a tab'
+													: 'Pin preview to the right'}
+												aria-label="Toggle split with preview"
+												aria-pressed={splitWithPreview}
+												class={splitWithPreview
+													? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
+													: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
+												onclick={toggleSplit}
+											>
+												<Columns2 size={14} />
+											</button>
+										</div>
+									{/snippet}
+								</DraggableTabs>
+								<iframe
+									bind:this={previewIframe}
+									title="App preview"
+									src="/ui_builder/app-preview.html"
+									class="w-full flex-1 block"
+								></iframe>
+								{#if logs}
 									<div
-										bind:this={logsDiv}
-										class="logs-scroll grow w-full overflow-auto"
+										class="absolute right-0 bottom-0 z-20 max-w-[500px] w-full flex flex-col text-xs p-1 border border-border-light rounded-tl-md bg-surface text-primary {logsCollapsed
+											? 'h-6'
+											: 'max-h-60 h-full'}"
 									>
-										{#if !logsCollapsed}
-											<pre>{logs}</pre>
-										{/if}
+										<button
+											class="cursor-pointer flex items-center gap-2 w-full text-xs font-normal text-secondary -mt-0.5 px-2 text-left"
+											onclick={() => (logsCollapsed = !logsCollapsed)}
+										>
+											Logs
+											<ChevronDown
+												size={12}
+												class="transition duration-200"
+												style="transform: {logsCollapsed ? 'rotate(180deg)' : 'rotate(0deg)'}"
+											/>
+											<span class="text-secondary">({logs.split('\n').length})</span>
+										</button>
+										<div bind:this={logsDiv} class="logs-scroll grow w-full overflow-auto">
+											{#if !logsCollapsed}
+												<pre>{logs}</pre>
+											{/if}
+										</div>
 									</div>
-								</div>
-							{/if}
-						</div>
-					</Pane>
-				</Splitpanes>
-			</div>
-		</Pane>
-	</Splitpanes>
+								{/if}
+							</div>
+						</Pane>
+					</Splitpanes>
+				</div>
+			</Pane>
+		</Splitpanes>
 	</div>
 </div>
 

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -245,6 +245,16 @@
 	const rightPaneActiveId = $derived(splitWithPreview ? PREVIEW_TAB_ID : activeTabId)
 	const showSource = $derived(activeTabKind === 'file')
 	const showRunnable = $derived(activeTabKind === 'runnable')
+	// Lazy-mount the UI Builder iframe: when Preview is active and no file
+	// has ever been opened, paneA is 0 wide, and mounting the iframe there
+	// makes the VS Code workbench fail with "Unable to figure out browser
+	// width and height". We mount it the first moment showSource becomes
+	// true (paneA is at 100% then, so the workbench measures correctly)
+	// and keep it mounted afterwards so tab switches don't reload.
+	let iframeShouldMount = $state(false)
+	$effect(() => {
+		if (showSource) iframeShouldMount = true
+	})
 
 	// Pane sizes for the inner content-area Splitpanes.
 	// - Single mode + preview active: right pane full (preview full width)
@@ -1460,12 +1470,14 @@
 									class="absolute inset-0"
 									style="display: {showSource ? 'block' : 'none'}"
 								>
-									<iframe
-										bind:this={iframe}
-										title="UI builder"
-										src="/ui_builder/index.html"
-										class="w-full h-full block"
-									></iframe>
+									{#if iframeShouldMount}
+										<iframe
+											bind:this={iframe}
+											title="UI builder"
+											src="/ui_builder/index.html"
+											class="w-full h-full block"
+										></iframe>
+									{/if}
 								</div>
 								<div
 									class="absolute inset-0"

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -28,7 +28,7 @@
 	import { createAppSelectedContext, type AppCodeSelectionElement } from '../copilot/chat/context'
 	import { rawAppLintStore } from './lintStore'
 	import { dbSchemas } from '$lib/stores'
-	import { MousePointerSquareDashed, RefreshCw, Columns2, X } from 'lucide-svelte'
+	import { MousePointerSquareDashed, RefreshCw, Columns2 } from 'lucide-svelte'
 	import DraggableTabs, {
 		type TabItem
 	} from '$lib/components/common/tabs/DraggableTabs.svelte'
@@ -1330,183 +1330,177 @@
 			</Pane>
 		{/if}
 		<Pane>
-			<div class="flex flex-col h-full w-full min-h-0">
-				<DraggableTabs
-					tabs={displayedTabs}
-					activeId={activeTabId}
-					onSelect={(id) => activateTab(id)}
-					onClose={(id) => closeTab(id)}
-					onReorder={(next) => reorderTabs(next)}
-				>
-					{#snippet trailing()}
-						<div class="flex items-center gap-1 px-2">
-							<button
-								title={splitWithPreview
-									? 'Move preview back into a tab'
-									: 'Pin preview to the right'}
-								aria-label="Toggle split with preview"
-								aria-pressed={splitWithPreview}
-								class={splitWithPreview
-									? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
-									: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
-								onclick={toggleSplit}
+			<!--
+				VS Code-style split: each pane is a self-contained "editor
+				group" with its own tab bar at the top. Splitpanes is the
+				topmost element here so the divider runs floor-to-ceiling.
+				Both iframes + RawAppInlineScriptsPanel stay mounted always;
+				`display` toggles + pane sizes do the swapping.
+			-->
+			<div
+				class="h-full w-full {splitWithPreview && activeTabKind !== 'preview'
+					? 'tabs-content-split'
+					: 'tabs-content-single'}"
+			>
+				<Splitpanes>
+					<Pane bind:size={paneALeftSize} minSize={0}>
+						<div class="flex flex-col h-full w-full min-h-0">
+							<DraggableTabs
+								tabs={displayedTabs}
+								activeId={activeTabId}
+								onSelect={(id) => activateTab(id)}
+								onClose={(id) => closeTab(id)}
+								onReorder={(next) => reorderTabs(next)}
 							>
-								<Columns2 size={14} />
-							</button>
-							<button
-								class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary px-2 h-7 rounded-md text-xs"
-								title="Switch bundler"
-								onclick={() => {
-									const next =
-										bundlerType === 'esbuild' ? 'rolldown' : 'esbuild'
-									bundlerType = next
-									iframe?.contentWindow?.postMessage(
-										{ type: 'setBundlerType', bundlerType: next },
-										'*'
-									)
-								}}>{bundlerType}</button
-							>
-							<button
-								title={inspectorEnabled
-									? 'Click to disable element inspector'
-									: 'Click to enable element inspector'}
-								class={inspectorEnabled
-									? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
-									: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
-								aria-label="Toggle element inspector"
-								onclick={() => {
-									inspectorEnabled = !inspectorEnabled
-									previewIframe?.contentWindow?.postMessage(
-										{
-											type: inspectorEnabled
-												? 'inspectorEnable'
-												: 'inspectorDisable'
-										},
-										'*'
-									)
-								}}
-							>
-								<MousePointerSquareDashed size={14} />
-							</button>
-							<button
-								class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center"
-								title="Replay the last build into the preview"
-								aria-label="Rebuild"
-								onclick={() => {
-									if (lastBuild) {
-										previewIframe?.contentWindow?.postMessage(
-											{
-												type: 'preview',
-												css: lastBuild.css,
-												js: lastBuild.js
-											},
-											'*'
-										)
-									}
-								}}
-							>
-								<RefreshCw size={14} />
-							</button>
-						</div>
-					{/snippet}
-				</DraggableTabs>
-				<!--
-					Content area. Always rendered as a Splitpanes so the iframes
-					never remount on a single↔split toggle. The active tab's
-					slot occupies Pane A (left); the preview iframe sits in
-					Pane B (right). Sizes are driven reactively from the tab +
-					split state. The splitter divider is hidden via CSS when
-					one of the panes is at 0% — the user uses the explicit
-					toggle button in the tab bar to flip between modes.
-				-->
-				<div
-					class="flex-1 min-h-0 w-full {splitWithPreview &&
-					activeTabKind !== 'preview'
-						? 'tabs-content-split'
-						: 'tabs-content-single'}"
-				>
-					<Splitpanes>
-						<Pane bind:size={paneALeftSize} minSize={0}>
-							<div
-								class="relative h-full w-full"
-								style="display: {showSource ? 'block' : 'none'}"
-							>
-								<iframe
-									bind:this={iframe}
-									title="UI builder"
-									src="/ui_builder/index.html"
-									class="w-full h-full block"
-								></iframe>
-							</div>
-							<div
-								class="relative h-full w-full"
-								style="display: {showRunnable ? 'block' : 'none'}"
-							>
-								<!-- svelte-ignore a11y_no_static_element_interactions -->
-								<div class="flex h-full w-full">
-									{#if selectedRunnable !== undefined}
-										<RawAppInlineScriptsPanel
-											appPath={path}
-											{selectedRunnable}
-											bind:runnables
-											onSelectionChange={(selection) => {
-												if (selection === null) {
-													codeSelection = undefined
-												} else if (selectedRunnable) {
-													codeSelection = {
-														type: 'app_code_selection',
-														source: selectedRunnable,
-														sourceType: 'backend',
-														title: `${selectedRunnable}:L${selection.startLine}-L${selection.endLine}`,
-														content: selection.content,
-														startLine: selection.startLine,
-														endLine: selection.endLine,
-														startColumn: selection.startColumn,
-														endColumn: selection.endColumn
+								{#snippet trailing()}
+									<div class="flex items-center gap-1 px-2">
+										<button
+											title={splitWithPreview
+												? 'Move preview back into a tab'
+												: 'Pin preview to the right'}
+											aria-label="Toggle split with preview"
+											aria-pressed={splitWithPreview}
+											class={splitWithPreview
+												? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
+												: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
+											onclick={toggleSplit}
+										>
+											<Columns2 size={14} />
+										</button>
+									</div>
+								{/snippet}
+							</DraggableTabs>
+							<div class="flex-1 min-h-0 w-full relative">
+								<div
+									class="absolute inset-0"
+									style="display: {showSource ? 'block' : 'none'}"
+								>
+									<iframe
+										bind:this={iframe}
+										title="UI builder"
+										src="/ui_builder/index.html"
+										class="w-full h-full block"
+									></iframe>
+								</div>
+								<div
+									class="absolute inset-0"
+									style="display: {showRunnable ? 'block' : 'none'}"
+								>
+									<!-- svelte-ignore a11y_no_static_element_interactions -->
+									<div class="flex h-full w-full">
+										{#if selectedRunnable !== undefined}
+											<RawAppInlineScriptsPanel
+												appPath={path}
+												{selectedRunnable}
+												bind:runnables
+												onSelectionChange={(selection) => {
+													if (selection === null) {
+														codeSelection = undefined
+													} else if (selectedRunnable) {
+														codeSelection = {
+															type: 'app_code_selection',
+															source: selectedRunnable,
+															sourceType: 'backend',
+															title: `${selectedRunnable}:L${selection.startLine}-L${selection.endLine}`,
+															content: selection.content,
+															startLine: selection.startLine,
+															endLine: selection.endLine,
+															startColumn: selection.startColumn,
+															endColumn: selection.endColumn
+														}
 													}
-												}
-											}}
-										/>
-									{/if}
+												}}
+											/>
+										{/if}
+									</div>
 								</div>
 							</div>
-						</Pane>
-						<Pane bind:size={paneBRightSize} minSize={0}>
-							<div class="h-full w-full flex flex-col">
-								<!-- VS Code-style split: the preview side gets its own
-								     tab header so the user sees "Preview" as a tab
-								     anchored to the right pane (rather than just an
-								     iframe with no label). The X closes the split
-								     (preview goes back to the main tab bar). -->
-								{#if splitWithPreview && activeTabKind !== 'preview'}
-									<div
-										class="flex items-stretch bg-surface-secondary border-l border-border-light flex-shrink-0"
+						</div>
+					</Pane>
+					<Pane bind:size={paneBRightSize} minSize={0}>
+						<div class="flex flex-col h-full w-full min-h-0">
+							<!--
+								Preview header — the right pane's own "tab bar".
+								Always rendered when the right pane is visible
+								(width 0 hides it without conditionals). Carries
+								the active-tab-styled "Preview" label on the
+								left and the preview-affecting action buttons
+								(bundler, inspector, rebuild) on the right.
+							-->
+							<div
+								class="flex items-stretch bg-surface-secondary flex-shrink-0 h-8"
+							>
+								<div
+									class="inline-flex items-center gap-1.5 px-3 h-8 text-xs bg-surface text-primary"
+								>
+									<span>Preview</span>
+								</div>
+								<div class="ml-auto flex items-center gap-1 px-2">
+									<button
+										class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary px-2 h-7 rounded-md text-xs"
+										title="Switch bundler"
+										onclick={() => {
+											const next =
+												bundlerType === 'esbuild' ? 'rolldown' : 'esbuild'
+											bundlerType = next
+											iframe?.contentWindow?.postMessage(
+												{ type: 'setBundlerType', bundlerType: next },
+												'*'
+											)
+										}}>{bundlerType}</button
 									>
-										<div
-											class="inline-flex items-center gap-1.5 px-3 h-8 text-xs bg-surface text-primary"
-										>
-											<span>Preview</span>
-											<button
-												type="button"
-												class="opacity-60 hover:opacity-100 rounded hover:bg-surface-hover w-4 h-4 inline-flex items-center justify-center"
-												aria-label="Move preview back into a tab"
-												onclick={toggleSplit}
-											>
-												<X size={10} />
-											</button>
-										</div>
-									</div>
-								{/if}
-								<iframe
-									bind:this={previewIframe}
-									title="App preview"
-									src="/ui_builder/app-preview.html"
-									class="w-full flex-1 block"
-								></iframe>
+									<button
+										title={inspectorEnabled
+											? 'Click to disable element inspector'
+											: 'Click to enable element inspector'}
+										class={inspectorEnabled
+											? 'cursor-pointer bg-surface-accent-selected text-accent border border-border-selected w-7 h-7 rounded-md inline-flex items-center justify-center'
+											: 'cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center'}
+										aria-label="Toggle element inspector"
+										onclick={() => {
+											inspectorEnabled = !inspectorEnabled
+											previewIframe?.contentWindow?.postMessage(
+												{
+													type: inspectorEnabled
+														? 'inspectorEnable'
+														: 'inspectorDisable'
+												},
+												'*'
+											)
+										}}
+									>
+										<MousePointerSquareDashed size={14} />
+									</button>
+									<button
+										class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center"
+										title="Replay the last build into the preview"
+										aria-label="Rebuild"
+										onclick={() => {
+											if (lastBuild) {
+												previewIframe?.contentWindow?.postMessage(
+													{
+														type: 'preview',
+														css: lastBuild.css,
+														js: lastBuild.js
+													},
+													'*'
+												)
+											}
+										}}
+									>
+										<RefreshCw size={14} />
+									</button>
+								</div>
 							</div>
-						</Pane>
-					</Splitpanes>
-				</div>
+							<iframe
+								bind:this={previewIframe}
+								title="App preview"
+								src="/ui_builder/app-preview.html"
+								class="w-full flex-1 block"
+							></iframe>
+						</div>
+					</Pane>
+				</Splitpanes>
 			</div>
 		</Pane>
 	</Splitpanes>

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -28,7 +28,7 @@
 	import { createAppSelectedContext, type AppCodeSelectionElement } from '../copilot/chat/context'
 	import { rawAppLintStore } from './lintStore'
 	import { dbSchemas } from '$lib/stores'
-	import { MousePointerSquareDashed, RefreshCw, Columns2 } from 'lucide-svelte'
+	import { MousePointerSquareDashed, RefreshCw, Columns2, X } from 'lucide-svelte'
 	import DraggableTabs, {
 		type TabItem
 	} from '$lib/components/common/tabs/DraggableTabs.svelte'
@@ -1472,12 +1472,38 @@
 							</div>
 						</Pane>
 						<Pane bind:size={paneBRightSize} minSize={0}>
-							<iframe
-								bind:this={previewIframe}
-								title="App preview"
-								src="/ui_builder/app-preview.html"
-								class="w-full h-full block"
-							></iframe>
+							<div class="h-full w-full flex flex-col">
+								<!-- VS Code-style split: the preview side gets its own
+								     tab header so the user sees "Preview" as a tab
+								     anchored to the right pane (rather than just an
+								     iframe with no label). The X closes the split
+								     (preview goes back to the main tab bar). -->
+								{#if splitWithPreview && activeTabKind !== 'preview'}
+									<div
+										class="flex items-stretch bg-surface-secondary border-l border-border-light flex-shrink-0"
+									>
+										<div
+											class="inline-flex items-center gap-1.5 px-3 h-8 text-xs bg-surface text-primary"
+										>
+											<span>Preview</span>
+											<button
+												type="button"
+												class="opacity-60 hover:opacity-100 rounded hover:bg-surface-hover w-4 h-4 inline-flex items-center justify-center"
+												aria-label="Move preview back into a tab"
+												onclick={toggleSplit}
+											>
+												<X size={10} />
+											</button>
+										</div>
+									</div>
+								{/if}
+								<iframe
+									bind:this={previewIframe}
+									title="App preview"
+									src="/ui_builder/app-preview.html"
+									class="w-full flex-1 block"
+								></iframe>
+							</div>
 						</Pane>
 					</Splitpanes>
 				</div>

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -219,7 +219,6 @@
 	let tabs: TabItem[] = $state([previewTab])
 	let activeTabId: string = $state(PREVIEW_TAB_ID)
 	let splitWithPreview: boolean = $state(true)
-	const TABS_STORAGE_KEY = $derived(`raw-app-tabs:${$workspaceStore ?? ''}:${path ?? ''}`)
 	const activeTabKind = $derived<'file' | 'runnable' | 'preview'>(
 		activeTabId === PREVIEW_TAB_ID
 			? 'preview'
@@ -1166,62 +1165,15 @@
 		})
 	})
 
-	// Hydrate tab state from localStorage on mount.
-	let tabsHydrated = $state(false)
+	// Open a sensible default file on mount so the split view shows the editor
+	// + preview (and boots the UI Builder iframe) instead of a blank preview.
+	// Tab/split layout is intentionally NOT persisted — each open starts fresh
+	// (split mode, default file).
 	onMount(() => {
-		try {
-			const raw = localStorage.getItem(TABS_STORAGE_KEY)
-			if (raw) {
-				const parsed = JSON.parse(raw) as {
-					tabs?: TabItem[]
-					activeTabId?: string
-					splitWithPreview?: boolean
-				}
-				if (Array.isArray(parsed.tabs) && parsed.tabs.length > 0) {
-					// Always re-pin the preview tab — if the stored data lost
-					// its `pinned` marker we'd misrender.
-					const stored = parsed.tabs.filter((t) => t.id !== PREVIEW_TAB_ID)
-					tabs = [...stored, previewTab]
-				}
-				if (parsed.activeTabId && tabs.some((t) => t.id === parsed.activeTabId)) {
-					activateTab(parsed.activeTabId)
-				}
-				if (typeof parsed.splitWithPreview === 'boolean') {
-					splitWithPreview = parsed.splitWithPreview
-				}
-			}
-		} catch (e) {
-			console.warn('Failed to hydrate raw-app tabs from localStorage', e)
-		} finally {
-			// Fresh app (no saved file tab — only Preview): open a default file
-			// and activate it. With `splitWithPreview` defaulting to true this
-			// renders the editor + preview side-by-side and boots the UI
-			// Builder iframe (which then builds the preview).
-			if (tabs.length === 1) {
-				const def = pickDefaultFile(files)
-				if (def) activateTab(ensureFileTab(def))
-			}
-			tabsHydrated = true
+		if (tabs.length === 1) {
+			const def = pickDefaultFile(files)
+			if (def) activateTab(ensureFileTab(def))
 		}
-	})
-
-	// Persist tab state. Gated on `tabsHydrated` so the initial default state
-	// doesn't overwrite the user's saved layout.
-	$effect(() => {
-		void tabs
-		void activeTabId
-		void splitWithPreview
-		if (!tabsHydrated) return
-		untrack(() => {
-			try {
-				localStorage.setItem(
-					TABS_STORAGE_KEY,
-					JSON.stringify({ tabs, activeTabId, splitWithPreview })
-				)
-			} catch (e) {
-				// Quota or privacy mode — silent, persistence is a nice-to-have.
-			}
-		})
 	})
 
 	// Drop file tabs whose underlying file disappeared (deleted via setFiles

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -226,43 +226,29 @@
 				? 'file'
 				: 'runnable'
 	)
-	// Per-pane tab lists.
-	// - Single mode: BOTH panes mirror the FULL tab list — whichever pane is
-	//   visible (paneA when source is active, paneB when preview is active)
-	//   carries every tab so the user can always switch. This is the fix
-	//   for the bug where activating Preview hid every tab.
-	// - Split mode: each pane shows its own subset (VS Code-style):
-	//   left = file/runnable tabs, right = just the Preview pseudo-header.
+	// Single mode: both bars mirror the full list (the visible pane carries
+	// every tab). Split mode: left = files/runnables, right = Preview only.
 	const leftPaneTabs = $derived<TabItem[]>(
 		splitWithPreview ? tabs.filter((t) => t.id !== PREVIEW_TAB_ID) : tabs
 	)
 	const rightPaneTabs = $derived<TabItem[]>(
 		splitWithPreview ? tabs.filter((t) => t.id === PREVIEW_TAB_ID) : tabs
 	)
-	// In split mode the Preview tab is permanently visible in the right pane;
-	// the right bar always shows it as the active tab regardless of which
-	// file/runnable tab is logically active in the left pane.
+	// In split mode the right bar always highlights Preview, regardless of the
+	// left pane's active file/runnable.
 	const rightPaneActiveId = $derived(splitWithPreview ? PREVIEW_TAB_ID : activeTabId)
 	const showSource = $derived(activeTabKind === 'file')
 	const showRunnable = $derived(activeTabKind === 'runnable')
-	// Lazy-mount the UI Builder iframe: when Preview is active and no file
-	// has ever been opened, paneA is 0 wide, and mounting the iframe there
-	// makes the VS Code workbench fail with "Unable to figure out browser
-	// width and height". We mount it the first moment showSource becomes
-	// true (paneA is at 100% then, so the workbench measures correctly)
-	// and keep it mounted afterwards so tab switches don't reload.
+	// Mount the UI Builder iframe the first time a file is shown (paneA has
+	// width then; mounting it at 0-width breaks the VS Code workbench), and
+	// keep it mounted so tab switches don't reload it.
 	let iframeShouldMount = $state(false)
 	$effect(() => {
 		if (showSource) iframeShouldMount = true
 	})
 
-	// Pane sizes for the inner content-area Splitpanes are a pure function of
-	// the mode + active tab, so they're derived (no effects):
-	// - Split mode + file/runnable active: both panes at the user's ratio
-	// - Preview active: right pane full (preview full width)
-	// - Single mode + file/runnable active: left pane full
-	// `paneARatio` holds the user's last manual split drag (see the setter
-	// in the left <Pane bind:size> below). Right size mirrors the left.
+	// Inner pane sizes are a pure function of mode + active tab → derived.
+	// `paneARatio` is the user's last manual split drag (set by rememberPaneDrag).
 	let paneARatio = $state(50)
 	const paneALeftSize = $derived(
 		splitWithPreview && activeTabKind !== 'preview'
@@ -272,9 +258,8 @@
 				: 100
 	)
 	const paneBRightSize = $derived(100 - paneALeftSize)
-	// Remember a manual splitter drag. Splitpanes writes the new left size
-	// here; we keep it only when it's a genuine in-between split position
-	// (the 0/100 collapsed/full states are programmatic, not user intent).
+	// Keep a manual drag only when it's a genuine in-between split (0/100 are
+	// the programmatic collapsed/full states, not user intent).
 	function rememberPaneDrag(v: number) {
 		if (splitWithPreview && activeTabKind !== 'preview' && v > 0 && v < 100) {
 			paneARatio = v
@@ -291,10 +276,7 @@
 		return filePath.split('/').pop() || filePath
 	}
 
-	// Pick the file to open by default on a fresh load so the split view
-	// shows the editor + preview instead of a blank full-screen preview.
-	// Prefer the main `App.*` component, then the `index.*` entry, then any
-	// other source file, falling back to whatever exists.
+	// Default file to open on load: prefer App.*, then index.*, then any source file.
 	function pickDefaultFile(f: Record<string, string> | undefined): string | undefined {
 		if (!f) return undefined
 		const keys = Object.keys(f).filter((p) => !p.endsWith('/'))
@@ -312,11 +294,8 @@
 	function activateTab(id: string, opts?: { force?: boolean }) {
 		const tab = tabs.find((t) => t.id === id)
 		if (!tab) return
-		// Clicking the Preview tab while in split mode is normally a visual
-		// no-op (Preview is already permanently shown in the right pane;
-		// promoting it would collapse the left pane). `force: true` is used
-		// by closeTab's fallback when the only remaining tab IS Preview —
-		// in that case we genuinely have nothing on the left to keep alive.
+		// In split mode Preview is always shown on the right, so clicking it is a
+		// no-op (would collapse the left pane). `force` lets closeTab fall back to it.
 		if (!opts?.force && splitWithPreview && id === PREVIEW_TAB_ID) return
 		activeTabId = id
 		if (tab.id === PREVIEW_TAB_ID) {
@@ -324,10 +303,8 @@
 		} else if (tab.id.startsWith(FILE_PREFIX)) {
 			const filePath = tab.id.slice(FILE_PREFIX.length)
 			selectedRunnable = undefined
-			// Always update `selectedDocument` — it drives sidebar highlight
-			// and, crucially, is read by `populateFiles` once the iframe
-			// finishes loading so a hydrated tab opens the right file even
-			// when activateTab fires before the iframe's listener exists.
+			// `populateFiles` reads this on iframe load, so set it even if the
+			// iframe isn't ready yet (the postMessage below is then skipped).
 			selectedDocument = filePath
 			if (iframeLoaded) {
 				iframe?.contentWindow?.postMessage({ type: 'selectFile', path: filePath }, '*')
@@ -380,25 +357,20 @@
 		const tab = tabs[idx]
 		if (!tab || tab.closable === false) return
 		const wasActive = activeTabId === id
-		// Clear runnable selection BEFORE removing the tab so the $effect
-		// doesn't immediately recreate it.
+		// Clear selection before removal so the cleanup $effect doesn't recreate it.
 		if (wasActive && tab.id.startsWith(RUNNABLE_PREFIX)) {
 			selectedRunnable = undefined
 		}
 		tabs = tabs.filter((t) => t.id !== id)
 		if (wasActive) {
-			// Fall back to the previous tab, else the preview tab. Force
-			// activation so the Preview-in-split-mode no-op guard doesn't
-			// leave `activeTabId` pointing at the deleted tab.
+			// Fall back to the previous tab (force, in case it's Preview in split).
 			const fallback = tabs[Math.max(0, idx - 1)] ?? previewTab
 			activateTab(fallback.id, { force: true })
 		}
 	}
 
 	function reorderTabs(next: TabItem[]) {
-		// `next` is `displayedTabs` after the user dropped a tab.
-		// When split is on, the Preview tab isn't in `next`; re-append it
-		// to preserve its slot in the underlying `tabs` array.
+		// In split mode the right bar omits Preview from `next`; re-append it.
 		if (splitWithPreview && !next.some((t) => t.id === PREVIEW_TAB_ID)) {
 			tabs = [...next, previewTab]
 		} else {
@@ -411,10 +383,8 @@
 			splitWithPreview = false
 			return
 		}
-		// Going from single → split. The Preview tab is about to disappear
-		// from the bar; if it's currently active, redirect to the last
-		// file/runnable tab (or stay on preview if none exist — left pane
-		// will be empty until the user opens something).
+		// single → split: if Preview is active, move focus to the last
+		// file/runnable tab (it's leaving the left bar).
 		if (activeTabId === PREVIEW_TAB_ID) {
 			const lastUserTab = tabs
 				.slice()
@@ -426,11 +396,8 @@
 	}
 	let yamlEditorDrawer: Drawer | undefined = $state(undefined)
 
-	// Sidebar uses a dynamic pixel-aware minimum: the user's `%` preference is
-	// honored, but the pane can never shrink below SIDEBAR_PX_MIN — including
-	// when the container itself shrinks. svelte-splitpanes' `minSize` only
-	// blocks splitter drag, so we clamp `sidebarPanelSize` ourselves and use a
-	// getter/setter bind so the user's preference is preserved.
+	// Sidebar: honor the user's `%` but never shrink below SIDEBAR_PX_MIN.
+	// (svelte-splitpanes' minSize only blocks drag, so we clamp ourselves.)
 	let rawSidebarSize = $state(15)
 	let splitContainerWidth = $state(0)
 	const SIDEBAR_PX_MIN = 160
@@ -1152,10 +1119,8 @@
 		})
 	})
 
-	// Open a sensible default file on mount so the split view shows the editor
-	// + preview (and boots the UI Builder iframe) instead of a blank preview.
-	// Tab/split layout is intentionally NOT persisted — each open starts fresh
-	// (split mode, default file).
+	// Open a default file on mount (boots the iframe; avoids a blank preview).
+	// Layout isn't persisted — each open starts fresh in split mode.
 	onMount(() => {
 		if (tabs.length === 1) {
 			const def = pickDefaultFile(files)
@@ -1163,9 +1128,7 @@
 		}
 	})
 
-	// Drop file tabs whose underlying file disappeared (deleted via setFiles
-	// or workspace cleanup). Same for runnable tabs whose key no longer
-	// exists in the runnables map.
+	// Drop tabs whose file/runnable no longer exists.
 	$effect(() => {
 		void files
 		void runnables

--- a/frontend/src/lib/utils/splitpaneSizing.ts
+++ b/frontend/src/lib/utils/splitpaneSizing.ts
@@ -1,34 +1,9 @@
 /**
- * Helpers for using `svelte-splitpanes` with pixel-aware minimum widths.
- *
- * `svelte-splitpanes` only takes percentages for its `size`/`minSize`/`maxSize`
- * props, so when we need a pane to never shrink below a pixel threshold
- * (e.g. a sidebar that's unreadable under 160 px) we have to convert the
- * threshold into a percentage of the splitpane container's current width.
- *
- * Pattern at call sites:
- *
- * ```svelte
- * <div bind:clientWidth={containerWidth} class="h-full">
- *   <Splitpanes>
- *     <Pane minSize={paneMinPercent(containerWidth, 160)}>...</Pane>
- *   </Splitpanes>
- * </div>
- * ```
+ * `svelte-splitpanes` only takes percentages, so convert a pixel `minSize`
+ * threshold into a % of the container's current width (pair with
+ * `bind:clientWidth`). Capped at `cap`%; returns 0 until the width is known.
  */
-
-/**
- * Returns the percentage of `containerWidth` that corresponds to `minPx`,
- * capped at `cap` percent (default 80) so callers can't accidentally make
- * the pane fill the container in very narrow viewports.
- *
- * Returns 0 when the container width isn't yet known (initial render).
- */
-export function paneMinPercent(
-	containerWidth: number,
-	minPx: number,
-	cap: number = 80
-): number {
+export function paneMinPercent(containerWidth: number, minPx: number, cap: number = 80): number {
 	if (containerWidth <= 0) return 0
 	return Math.min(cap, (minPx / containerWidth) * 100)
 }

--- a/frontend/src/lib/utils/splitpaneSizing.ts
+++ b/frontend/src/lib/utils/splitpaneSizing.ts
@@ -1,0 +1,34 @@
+/**
+ * Helpers for using `svelte-splitpanes` with pixel-aware minimum widths.
+ *
+ * `svelte-splitpanes` only takes percentages for its `size`/`minSize`/`maxSize`
+ * props, so when we need a pane to never shrink below a pixel threshold
+ * (e.g. a sidebar that's unreadable under 160 px) we have to convert the
+ * threshold into a percentage of the splitpane container's current width.
+ *
+ * Pattern at call sites:
+ *
+ * ```svelte
+ * <div bind:clientWidth={containerWidth} class="h-full">
+ *   <Splitpanes>
+ *     <Pane minSize={paneMinPercent(containerWidth, 160)}>...</Pane>
+ *   </Splitpanes>
+ * </div>
+ * ```
+ */
+
+/**
+ * Returns the percentage of `containerWidth` that corresponds to `minPx`,
+ * capped at `cap` percent (default 80) so callers can't accidentally make
+ * the pane fill the container in very narrow viewports.
+ *
+ * Returns 0 when the container width isn't yet known (initial render).
+ */
+export function paneMinPercent(
+	containerWidth: number,
+	minPx: number,
+	cap: number = 80
+): number {
+	if (containerWidth <= 0) return 0
+	return Math.min(cap, (minPx / containerWidth) * 100)
+}


### PR DESCRIPTION
## Summary

Restructures the raw-app editor around a custom tab system. Each open file is a tab; each selected runnable is a tab; the live preview is a pinned tab on the right. A "Split with Preview" toggle pairs the active tab with the preview side-by-side. The UI Builder iframe becomes a single-file editor engine driven by host postMessages; the preview iframe and the build-log overlay are owned by Windmill so they can be themed and positioned natively.

**Companion PR: [windmill-labs/windmill-code-ui-builder#7](https://github.com/windmill-labs/windmill-code-ui-builder/pull/7) — UI-Builder-side changes (external preview hosting, runtime theme + font sync, log forwarding). Both PRs must land together.**

## Demo

https://github.com/user-attachments/assets/5463406e-993b-441b-b649-179144a46093



## Changes

- **New `DraggableTabs` component** (`frontend/src/lib/components/common/tabs/DraggableTabs.svelte`): generic, reusable tab strip with drag-reorder (`@windmill-labs/svelte-dnd-action`), middle-click + keyboard close, pinned-left/right slots, and a custom Melt `createScrollArea({ type: 'always' })` for a consistent 4 px scrollbar across platforms (no `scrollbar-gutter` on horizontal bars).
- **VS Code-style per-pane tab bars** in `RawAppEditor.svelte`: two `DraggableTabs` instances, one per pane. In split mode the splitter goes floor-to-ceiling through the bars and content; in single mode both bars mirror the full tab list so the visible pane always carries every tab (fixes the bug where activating Preview previously hid the tab strip).
- **External preview iframe**: Windmill now renders `/ui_builder/app-preview.html` directly in the right pane. UI Builder forwards `preview` build output and `setLogs` messages to the host; inspector + bundler + rebuild toolbar moved into the right tab bar's trailing slot.
- **Host-driven theme + font**: forward `setDarkMode` + `setFontSize` postMessages to the UI Builder iframe so the VS Code workbench tracks Windmill's dark mode and `text-xs` font size dynamically (re-evaluated on viewport resize across the 1760 px breakpoint).
- **Logs overlay on the preview pane**: `bg-surface` / `text-secondary` panel anchored bottom-right of the right pane, with the same themed scrollbar as before.
- **Pixel-aware sidebar minSize**: extracted helper `frontend/src/lib/utils/splitpaneSizing.ts` (`paneMinPercent(containerWidth, minPx)`) and a derived clamp `Math.max(rawSidebarSize, sidebarMinPercent)` with a getter/setter `bind:size` — sidebar honours the user's % drag preference but never shrinks below 160 px even when the outer container shrinks. Same helper applied to `ScriptEditor.svelte`'s test pane.

## Test plan

- [ ] Open a raw app. Click `App.tsx` → file tab opens. Click `Preview` → preview pane fills the viewport AND the right bar carries the full tab list (no disappearing tabs).
- [ ] Toggle "Split with Preview" → splitter spans tabs + content, floor-to-ceiling. Drag the splitter, ratio persists; toggle off then on, ratio restored.
- [ ] Click `Preview` in the right bar while split is on → no-op (left pane does not collapse).
- [ ] Drag a file tab to reorder; reload the page → tab order restored from localStorage.
- [ ] Toggle Windmill dark mode → VS Code editor + preview iframe both flip immediately on first load (companion PR fix).
- [ ] Resize the browser narrow → sidebar floor at 160 px; viewport ≥ 1760 px → editor font is 13.5 px (matches `text-xs`).
- [ ] Trigger a rebuild → logs panel appears bottom-right of the preview pane (not inside the editor iframe).