### PR TITLE
feat: add wmill job rerun subcommand

### DIFF
--- a/cli/src/commands/job/job.ts
+++ b/cli/src/commands/job/job.ts
@@ -412,6 +412,27 @@ async function rerun(
   console.log(newIds[0]);
 }
 
+async function restart(
+  opts: GlobalOptions & { step: string; iteration?: number },
+  id: string
+) {
+  log.setSilent(true);
+  opts = await mergeConfigWithConfigFile(opts);
+  const workspace = await resolveWorkspace(opts);
+  await requireLogin(opts);
+
+  const newId = await wmill.restartFlowAtStep({
+    workspace: workspace.workspaceId,
+    id,
+    requestBody: {
+      step_id: opts.step,
+      branch_or_iteration_n: opts.iteration,
+    },
+  });
+
+  console.log(newId);
+}
+
 // Shared list options to avoid repetition between default action and list subcommand
 const listOptions = (cmd: Command) =>
   cmd
@@ -452,6 +473,14 @@ const command = listOptions(new Command()
     "Re-run a completed job with the same args. Prints the new job UUID on stdout."
   )
   .arguments("<id:string>")
-  .action(rerun as any);
+  .action(rerun as any)
+  .command(
+    "restart",
+    "Restart a completed flow at a given top-level step. Prints the new flow job UUID on stdout."
+  )
+  .arguments("<id:string>")
+  .option("--step <stepId:string>", "Top-level step id to restart the flow from", { required: true })
+  .option("--iteration <n:number>", "For a top-level branchall or for-loop step, the iteration to restart at")
+  .action(restart as any);
 
 export default command;

--- a/cli/src/commands/job/job.ts
+++ b/cli/src/commands/job/job.ts
@@ -376,6 +376,42 @@ async function cancel(
   log.info(colors.green(`Job ${id} canceled.`));
 }
 
+async function rerun(
+  opts: GlobalOptions,
+  id: string
+) {
+  log.setSilent(true);
+  opts = await mergeConfigWithConfigFile(opts);
+  const workspace = await resolveWorkspace(opts);
+  await requireLogin(opts);
+
+  const response = await wmill.batchReRunJobs({
+    workspace: workspace.workspaceId,
+    requestBody: {
+      job_ids: [id],
+      script_options_by_path: {},
+      flow_options_by_path: {},
+    },
+  });
+
+  const newIds: string[] = [];
+  const errorLines: string[] = [];
+  for (const line of String(response).split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (trimmed.startsWith("Error:")) errorLines.push(trimmed);
+    else newIds.push(trimmed);
+  }
+
+  for (const err of errorLines) log.error(err);
+
+  if (newIds.length === 0) {
+    throw new Error(`Failed to re-run job ${id}.`);
+  }
+
+  console.log(newIds[0]);
+}
+
 // Shared list options to avoid repetition between default action and list subcommand
 const listOptions = (cmd: Command) =>
   cmd
@@ -410,6 +446,12 @@ const command = listOptions(new Command()
   .command("cancel", "Cancel a running or queued job")
   .arguments("<id:string>")
   .option("--reason <reason:string>", "Reason for cancellation")
-  .action(cancel as any);
+  .action(cancel as any)
+  .command(
+    "rerun",
+    "Re-run a completed job with the same args. Prints the new job UUID on stdout."
+  )
+  .arguments("<id:string>")
+  .action(rerun as any);
 
 export default command;

--- a/cli/src/guidance/core.ts
+++ b/cli/src/guidance/core.ts
@@ -65,6 +65,7 @@ When the user reports a script or flow failure, is investigating unexpected outp
 - \`wmill job logs <id>\` — stdout/stderr; for flows, aggregates every step's logs
 - \`wmill job result <id>\` — JSON result of a completed job
 - \`wmill job cancel <id>\` — stop a running or queued job
+- \`wmill job rerun <id>\` — re-run a completed job with the same args (single-job equivalent of the frontend "rerun" button)
 
 For flow failures, start with \`wmill job get <id>\` to identify the failing step and its sub-job ID, then \`wmill job logs <sub-job-id>\` to drill in.
 

--- a/cli/src/guidance/core.ts
+++ b/cli/src/guidance/core.ts
@@ -66,6 +66,7 @@ When the user reports a script or flow failure, is investigating unexpected outp
 - \`wmill job result <id>\` — JSON result of a completed job
 - \`wmill job cancel <id>\` — stop a running or queued job
 - \`wmill job rerun <id>\` — re-run a completed job with the same args (single-job equivalent of the frontend "rerun" button)
+- \`wmill job restart <id> --step <step-id> [--iteration <n>]\` — restart a completed flow at a top-level step (for nested-container restart, use the UI)
 
 For flow failures, start with \`wmill job get <id>\` to identify the failing step and its sub-job ID, then \`wmill job logs <sub-job-id>\` to drill in.
 

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -6940,6 +6940,9 @@ Manage jobs (list, inspect, cancel)
 - \`job cancel <id:string>\` - Cancel a running or queued job
   - \`--reason <reason:string>\` - Reason for cancellation
 - \`job rerun <id:string>\` - Re-run a completed job with the same args. Prints the new job UUID on stdout.
+- \`job restart <id:string>\` - Restart a completed flow at a given top-level step. Prints the new flow job UUID on stdout.
+  - \`--step <stepId:string>\` - Top-level step id to restart the flow from
+  - \`--iteration <n:number>\` - For a top-level branchall or for-loop step, the iteration to restart at
 
 ### jobs
 

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -6939,6 +6939,7 @@ Manage jobs (list, inspect, cancel)
 - \`job logs <id:string>\` - Get job logs. For flows: aggregates all step logs
 - \`job cancel <id:string>\` - Cancel a running or queued job
   - \`--reason <reason:string>\` - Reason for cancellation
+- \`job rerun <id:string>\` - Re-run a completed job with the same args. Prints the new job UUID on stdout.
 
 ### jobs
 

--- a/system_prompts/auto-generated/cli/cli-commands.md
+++ b/system_prompts/auto-generated/cli/cli-commands.md
@@ -326,6 +326,9 @@ Manage jobs (list, inspect, cancel)
 - `job cancel <id:string>` - Cancel a running or queued job
   - `--reason <reason:string>` - Reason for cancellation
 - `job rerun <id:string>` - Re-run a completed job with the same args. Prints the new job UUID on stdout.
+- `job restart <id:string>` - Restart a completed flow at a given top-level step. Prints the new flow job UUID on stdout.
+  - `--step <stepId:string>` - Top-level step id to restart the flow from
+  - `--iteration <n:number>` - For a top-level branchall or for-loop step, the iteration to restart at
 
 ### jobs
 

--- a/system_prompts/auto-generated/cli/cli-commands.md
+++ b/system_prompts/auto-generated/cli/cli-commands.md
@@ -325,6 +325,7 @@ Manage jobs (list, inspect, cancel)
 - `job logs <id:string>` - Get job logs. For flows: aggregates all step logs
 - `job cancel <id:string>` - Cancel a running or queued job
   - `--reason <reason:string>` - Reason for cancellation
+- `job rerun <id:string>` - Re-run a completed job with the same args. Prints the new job UUID on stdout.
 
 ### jobs
 

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -2856,6 +2856,7 @@ Manage jobs (list, inspect, cancel)
 - \`job logs <id:string>\` - Get job logs. For flows: aggregates all step logs
 - \`job cancel <id:string>\` - Cancel a running or queued job
   - \`--reason <reason:string>\` - Reason for cancellation
+- \`job rerun <id:string>\` - Re-run a completed job with the same args. Prints the new job UUID on stdout.
 
 ### jobs
 

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -2857,6 +2857,9 @@ Manage jobs (list, inspect, cancel)
 - \`job cancel <id:string>\` - Cancel a running or queued job
   - \`--reason <reason:string>\` - Reason for cancellation
 - \`job rerun <id:string>\` - Re-run a completed job with the same args. Prints the new job UUID on stdout.
+- \`job restart <id:string>\` - Restart a completed flow at a given top-level step. Prints the new flow job UUID on stdout.
+  - \`--step <stepId:string>\` - Top-level step id to restart the flow from
+  - \`--iteration <n:number>\` - For a top-level branchall or for-loop step, the iteration to restart at
 
 ### jobs
 

--- a/system_prompts/auto-generated/skills/cli-commands/SKILL.md
+++ b/system_prompts/auto-generated/skills/cli-commands/SKILL.md
@@ -331,6 +331,9 @@ Manage jobs (list, inspect, cancel)
 - `job cancel <id:string>` - Cancel a running or queued job
   - `--reason <reason:string>` - Reason for cancellation
 - `job rerun <id:string>` - Re-run a completed job with the same args. Prints the new job UUID on stdout.
+- `job restart <id:string>` - Restart a completed flow at a given top-level step. Prints the new flow job UUID on stdout.
+  - `--step <stepId:string>` - Top-level step id to restart the flow from
+  - `--iteration <n:number>` - For a top-level branchall or for-loop step, the iteration to restart at
 
 ### jobs
 

--- a/system_prompts/auto-generated/skills/cli-commands/SKILL.md
+++ b/system_prompts/auto-generated/skills/cli-commands/SKILL.md
@@ -330,6 +330,7 @@ Manage jobs (list, inspect, cancel)
 - `job logs <id:string>` - Get job logs. For flows: aggregates all step logs
 - `job cancel <id:string>` - Cancel a running or queued job
   - `--reason <reason:string>` - Reason for cancellation
+- `job rerun <id:string>` - Re-run a completed job with the same args. Prints the new job UUID on stdout.
 
 ### jobs
 


### PR DESCRIPTION
## Summary

Adds two CLI subcommands for re-running completed jobs from the command line:

- **`wmill job rerun <id>`** — equivalent of the frontend "Run again with same args" button. Wraps `batchReRunJobs` for the single-job case.
- **`wmill job restart <id> --step <step-id> [--iteration <n>]`** — restart a completed flow at a top-level step. Wraps `restartFlowAtStep`. EE-only feature on the backend.

Both print the new job UUID on stdout so they compose, e.g. `wmill job rerun <id> | xargs wmill job logs`.

## Changes

- `rerun`: sends `{ job_ids: [<id>], script_options_by_path: {}, flow_options_by_path: {} }` (defaults match the frontend button's "with same args" semantics). Parses the newline-separated stream response, surfaces `Error:` lines via `log.error`, exits non-zero if no new UUID was returned.
- `restart`: sends `{ step_id, branch_or_iteration_n? }`. Same wire format / body shape as `FlowRestartButton.svelte`. Required `--step`, optional `--iteration` for top-level branchall / for-loop iteration restart.
- Mentions added to the Debugging Jobs section of `cli/src/guidance/core.ts`.
- Regenerated `system_prompts/auto-generated/` and `cli/src/guidance/skills.gen.ts` via `python system_prompts/generate.py` (required by AGENTS.md since `cli/src/commands/` changed).

### Out of scope

`restartFlowAtStep` also accepts a `nested_path` array for restarting inside nested containers (BranchOne / ForLoop iteration / Subflow). CLI ergonomics for nested paths are awkward (would need either a JSON flag or a repeatable `--nested-step` parser) and demand is low — for nested restart, use the UI.

## Test plan

- [x] `wmill job rerun <id>` against a recently completed script job prints a new job UUID; piping into `wmill job get <id>` shows the new job ran with the same args
- [x] `wmill job rerun <id>` against a flow job works the same way (new flow run id, same args)
- [x] `wmill job --help` lists both `rerun` and `restart`
- [x] `wmill job rerun <unknown-uuid>` exits non-zero with `Failed to re-run job <id>`
- [ ] `wmill job restart <flow-id> --step <step-id>` on an EE backend prints a new flow UUID; flow resumes from the chosen step
- [ ] `wmill job restart <flow-id> --step <step-id> --iteration <n>` resumes a top-level for-loop / branchall at iteration `n`
- [x] `wmill job restart <id>` without `--step` exits non-zero with a usage error
