### PR TITLE
fix(ai): enforce RLS and scope check on user-supplied X-Resource-Path

### DIFF
--- a/backend/windmill-api-integration-tests/tests/ai_routes.rs
+++ b/backend/windmill-api-integration-tests/tests/ai_routes.rs
@@ -10,6 +10,10 @@ fn authed(builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
     builder.header("Authorization", "Bearer SECRET_TOKEN")
 }
 
+fn authed_with(builder: reqwest::RequestBuilder, token: &str) -> reqwest::RequestBuilder {
+    builder.header("Authorization", format!("Bearer {token}"))
+}
+
 fn assert_2xx(status: u16, body: &str, endpoint: &str) {
     assert!(
         (200..300).contains(&status),
@@ -102,6 +106,128 @@ async fn test_ai_proxy_endpoints(db: Pool<Postgres>) -> anyhow::Result<()> {
         resp.status().as_u16(),
         &resp.text().await?,
         "POST /ai/proxy/chat/completions",
+    );
+
+    Ok(())
+}
+
+/// Regression test for WIN-1971: the AI proxy's X-Resource-Path header must
+/// honour resource RLS so that a low-privilege user cannot point the proxy
+/// at a resource they are not allowed to read.
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn test_ai_proxy_x_resource_path_enforces_rls(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    std::env::set_var("ALLOW_PRIVATE_AI_BASE_URLS", "true");
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+
+    let mock_port = start_mock_ai_api().await;
+    let mock_url = format!("http://127.0.0.1:{mock_port}/v1");
+
+    // Resource owned by test-user (admin). With default extra_perms {} the
+    // RLS `see_own` policy restricts SELECT to user `test-user`.
+    sqlx::query(
+        "INSERT INTO resource (workspace_id, path, value, resource_type, extra_perms, created_by) \
+         VALUES ('test-workspace', 'u/test-user/restricted_openai', $1::jsonb, 'openai', '{}', 'test-user')",
+    )
+    .bind(json!({
+        "api_key": "sk-secret-restricted",
+        "base_url": mock_url,
+    }))
+    .execute(&db)
+    .await?;
+
+    // Sanity-check: normal resource API rejects test-user-3 (non-admin) for the restricted path.
+    let resp = authed_with(
+        client().get(format!(
+            "http://localhost:{port}/api/w/test-workspace/resources/get/u/test-user/restricted_openai"
+        )),
+        "SECRET_TOKEN_3",
+    )
+    .send()
+    .await?;
+    assert!(
+        resp.status().as_u16() >= 400,
+        "normal resource API should deny test-user-3 reading restricted resource, got {}",
+        resp.status()
+    );
+
+    // The vulnerability: as a non-admin user, point X-Resource-Path at the
+    // restricted resource. Must be rejected before the proxy fetches/uses it.
+    let resp = authed_with(
+        client()
+            .post(format!(
+                "http://localhost:{port}/api/w/test-workspace/ai/proxy/chat/completions"
+            ))
+            .header("X-Provider", "openai")
+            .header("X-Resource-Path", "u/test-user/restricted_openai")
+            .json(&json!({
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "hi"}]
+            })),
+        "SECRET_TOKEN_3",
+    )
+    .send()
+    .await?;
+    let status = resp.status().as_u16();
+    let body = resp.text().await?;
+    assert!(
+        status >= 400,
+        "non-admin user should be rejected when X-Resource-Path points at a resource they cannot read, got {status}: {body}",
+    );
+
+    // A resource the non-admin owns must still work through X-Resource-Path.
+    sqlx::query(
+        "INSERT INTO resource (workspace_id, path, value, resource_type, extra_perms, created_by) \
+         VALUES ('test-workspace', 'u/test-user-3/own_openai', $1::jsonb, 'openai', '{}', 'test-user-3')",
+    )
+    .bind(json!({
+        "api_key": "sk-self",
+        "base_url": mock_url,
+    }))
+    .execute(&db)
+    .await?;
+
+    let resp = authed_with(
+        client()
+            .post(format!(
+                "http://localhost:{port}/api/w/test-workspace/ai/proxy/chat/completions"
+            ))
+            .header("X-Provider", "openai")
+            .header("X-Resource-Path", "u/test-user-3/own_openai")
+            .json(&json!({
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "hi"}]
+            })),
+        "SECRET_TOKEN_3",
+    )
+    .send()
+    .await?;
+    assert_2xx(
+        resp.status().as_u16(),
+        &resp.text().await?,
+        "non-admin with X-Resource-Path on owned resource",
+    );
+
+    // Admin must still be able to use X-Resource-Path on any resource.
+    let resp = authed(
+        client()
+            .post(format!(
+                "http://localhost:{port}/api/w/test-workspace/ai/proxy/chat/completions"
+            ))
+            .header("X-Provider", "openai")
+            .header("X-Resource-Path", "u/test-user/restricted_openai")
+            .json(&json!({
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "hi"}]
+            })),
+    )
+    .send()
+    .await?;
+    assert_2xx(
+        resp.status().as_u16(),
+        &resp.text().await?,
+        "admin with X-Resource-Path on restricted resource",
     );
 
     Ok(())

--- a/backend/windmill-api/src/ai.rs
+++ b/backend/windmill-api/src/ai.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "bedrock")]
 use crate::bedrock;
 use crate::db::{ApiAuthed, DB};
+use crate::utils::check_scopes;
 
 #[cfg(feature = "bedrock")]
 use axum::routing::get;
@@ -669,6 +670,7 @@ async fn global_proxy(
 async fn proxy(
     authed: ApiAuthed,
     Extension(db): Extension<DB>,
+    Extension(user_db): Extension<UserDB>,
     Path((w_id, mut ai_path)): Path<(String, String)>,
     method: Method,
     headers: HeaderMap,
@@ -689,6 +691,16 @@ async fn proxy(
         .get("X-Resource-Path")
         .map(|v| v.to_str().unwrap_or("").to_string());
     let is_user_specified_resource = forced_resource_path.is_some();
+
+    // When the caller supplies X-Resource-Path, the resource is treated as if it
+    // were being read through the normal resource API: scope and RLS checks must
+    // apply so that a low-privilege user cannot point the proxy at a restricted
+    // AI resource (e.g. one in a folder they cannot read) to exfiltrate the
+    // resource's provider credentials or use them via the proxy.
+    if let Some(resource_path) = forced_resource_path.as_ref() {
+        check_scopes(&authed, || format!("resources:read:{}", resource_path))?;
+    }
+
     let request_config = match workspace_cache {
         Some(request_cache) if !request_cache.is_expired() && forced_resource_path.is_none() => {
             request_cache.config
@@ -759,13 +771,32 @@ async fn proxy(
                     )
                 };
 
-            let resource = sqlx::query_scalar::<_, Option<sqlx::types::Json<Box<RawValue>>>>(
-                "SELECT value FROM resource WHERE path = $1 AND workspace_id = $2",
-            )
-            .bind(&resource_path)
-            .bind(&resource_workspace)
-            .fetch_optional(&db)
-            .await?
+            // For user-specified resources, fetch through an RLS-scoped
+            // connection so PostgreSQL row-level security enforces the same
+            // folder/group boundaries as the regular resource API. For the
+            // workspace/instance ai_config path, the resource_path was already
+            // validated by an admin/devops user when configuring the workspace,
+            // so the raw pool is used.
+            let resource = if is_user_specified_resource {
+                let mut tx = user_db.clone().begin(&authed).await?;
+                let res = sqlx::query_scalar::<_, Option<sqlx::types::Json<Box<RawValue>>>>(
+                    "SELECT value FROM resource WHERE path = $1 AND workspace_id = $2",
+                )
+                .bind(&resource_path)
+                .bind(&resource_workspace)
+                .fetch_optional(&mut *tx)
+                .await?;
+                tx.commit().await?;
+                res
+            } else {
+                sqlx::query_scalar::<_, Option<sqlx::types::Json<Box<RawValue>>>>(
+                    "SELECT value FROM resource WHERE path = $1 AND workspace_id = $2",
+                )
+                .bind(&resource_path)
+                .bind(&resource_workspace)
+                .fetch_optional(&db)
+                .await?
+            }
             .ok_or_else(|| Error::NotFound(format!("Could not find the resource {}, update the resource path in the workspace settings", resource_path)))?
             .ok_or_else(|| Error::BadRequest(format!("Empty resource value for {}", resource_path)))?;
 


### PR DESCRIPTION
## Summary

Authorization bypass in the workspace AI proxy (`POST /api/w/{workspace}/ai/proxy/{path}`): when the caller supplies the `X-Resource-Path` header, the handler loaded the resource value with the root DB pool and **no** `resources:read:{path}` scope check, so any authenticated workspace user could point the header at a restricted AI resource (including one in a folder they cannot read) and the proxy would use that resource's provider credentials for the outbound AI request. The later auth-aware logic only applied to `$var:` resolution inside the resource, not to the resource lookup itself.

## Fix

For user-supplied resource paths:

1. Require `resources:read:{path}` scope via `check_scopes`.
2. Fetch the resource through `user_db.begin(&authed)` so PostgreSQL row-level security enforces the same folder/group boundary as the regular resource API.

The admin-configured workspace/instance `ai_config` path is unchanged — that resource path was already validated by a privileged user when configuring the workspace. The RLS-scoped `$var:` resolution inside `AIRequestConfig::new` stays in place as defense in depth.

## Repro (before fix)

1. Create an AI resource in a folder a low-privilege user cannot read (e.g. `f/restricted-ai/prod_openai`).
2. Confirm `GET /api/w/{workspace}/resources/get/f/restricted-ai/prod_openai` returns a permission/not-found error for that user.
3. As the same user, call `POST /api/w/{workspace}/ai/proxy/chat/completions` with headers `X-Provider: openai`, `X-Resource-Path: f/restricted-ai/prod_openai`.

Before: proxy succeeds and uses the restricted resource's credentials. After: the request is rejected with a permission/not-found error before the resource is loaded or used.

Fixes WIN-1971

## Test plan

- [ ] Manual repro: low-privilege user with `X-Resource-Path` pointing at a restricted resource gets a permission/not-found error.
- [ ] Manual repro: same user with `X-Resource-Path` pointing at a resource they *can* read still works.
- [ ] Configured workspace AI provider continues to work without `X-Resource-Path` (cache path and direct fetch).
- [ ] `cargo check -p windmill-api` passes (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an authorization bypass in the workspace AI proxy by enforcing scope checks and RLS when clients set the `X-Resource-Path` header. Only users with read access to a resource can use its credentials. Addresses WIN-1971.

- **Bug Fixes**
  - Require `resources:read:{path}` via `check_scopes` when `X-Resource-Path` is provided.
  - Load user-specified resources through `user_db.begin(&authed)` so PostgreSQL RLS applies; keep root pool for admin-configured `ai_config`.
  - Keep RLS-scoped `$var:` resolution in `AIRequestConfig::new`.
  - Return permission/not-found errors for restricted resources, matching the resource API behavior.
  - Add integration test covering RLS enforcement for `X-Resource-Path` (non-admin denied on restricted, non-admin allowed on own, admin allowed, default flow unchanged).

<sup>Written for commit 40fc72de0b3b4e19c87a44c0c287e94b27967941. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9276?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

