### PR TITLE
fix(debugger): add non-root user support to Dockerfile

### DIFF
--- a/debugger/Dockerfile
+++ b/debugger/Dockerfile
@@ -51,6 +51,14 @@ COPY dap_websocket_server.py .
 # Expose the default port
 EXPOSE 5679
 
+# Create a non-root user 'windmill' with UID and GID 1000 (mirrors main Windmill image)
+RUN addgroup --gid 1000 windmill && \
+    adduser --disabled-password --gecos "" --uid 1000 --gid 1000 windmill
+
+# Ensure cache and work directories are writable by any UID
+RUN mkdir -p /tmp/windmill/cache /tmp/windmill/cache_nomount /tmp/.cache && \
+    chmod -R 777 /tmp/windmill /tmp/.cache /app
+
 # Health check
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:5679/health || exit 1


### PR DESCRIPTION
## Summary

- Adds a `windmill` user (UID/GID 1000) to `debugger/Dockerfile`, mirroring the pattern from the main `Dockerfile` (lines 316-325).
- Makes `/tmp/windmill`, `/tmp/.cache`, and `/app` world-writable so the image runs under Kubernetes `securityContext.runAsNonRoot` / `runAsUser: 1000` without Bun, pip, or windmill cache write failures.
- Image does NOT switch to `USER windmill` by default (matches main image behavior); directories are world-writable so `--user 1000` works.

Fixes WIN-1969

## Test plan

- [ ] `docker build -t windmill-debugger debugger/` succeeds
- [ ] `docker run --user 1000:1000 -p 5679:5679 windmill-debugger` starts without permission errors
- [ ] Health endpoint responds: `curl http://localhost:5679/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add non-root user support to the debugger image by creating a windmill user (UID/GID 1000) and making cache and /app directories world-writable so it can run under Kubernetes runAsNonRoot/runAsUser:1000 without permission errors (Fixes WIN-1969).
Matches the main image pattern and keeps root as default; pass --user 1000 when needed.

<sup>Written for commit fb7be355cf9ac7cc90d52dd3b6a69b599952c09b. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9277?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

