### PR TITLE
fix(nsjail): gate unix-symlink test behind cfg(unix) for Windows

### DIFF
--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -1234,6 +1234,7 @@ mod nsjail_tmp_mount_tests {
     /// `job_dir` before the resolver runs), the resolver must refuse the
     /// bind mount and fall back to tmpfs — never bind-mount the symlink
     /// target into the sandbox as /tmp.
+    #[cfg(unix)]
     #[tokio::test]
     async fn disk_backed_refuses_preexisting_symlink_at_jail_tmp() {
         let tmp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

- Windows build was failing with `E0433: could not find unix in os` on `backend/windmill-worker/src/common.rs:1246` after #9272.
- The offending line is inside the `disk_backed_refuses_preexisting_symlink_at_jail_tmp` test, which calls `std::os::unix::fs::symlink` to plant a symlink at `jail_tmp` and verify the resolver refuses to bind-mount it.
- The symlink-planting attack vector is Unix-specific (Windows uses different symlink APIs and the nsjail feature itself is Linux-only), so the cleanest fix is gating the test with `#[cfg(unix)]` — matching the existing pattern used by `php_executor`, `bun_executor`, `rust_executor`, `java_executor`, `go_executor`, and `csharp_executor`.

The companion `disk_backed_reuses_jail_tmp_across_sequential_calls` test only uses portable APIs (`std::fs::create_dir`), so it remains unconditionally compiled.

Fixes WIN-1972

## Test plan

- [x] All 9 `nsjail_tmp_mount_tests` still pass on Linux (`cargo test -p windmill-worker --lib nsjail_tmp_mount_tests`).
- [ ] Verify the Windows CI build passes once this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows builds by gating the Unix-only symlink test behind `#[cfg(unix)]` in `windmill-worker` `nsjail_tmp_mount_tests`. This avoids E0433 from `std::os::unix::fs::symlink` on Windows, keeps Linux tests unchanged, and fixes WIN-1972.

<sup>Written for commit 60a1c6c8e601da3609ecb3d308a662126f94cc64. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9280?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

