### PR TITLE
fix: fork compare visibility for non-admins and stale-token superadmins

### DIFF
--- a/backend/.sqlx/query-2e35598cb9695b726ee1d2cd5c8364503371a5272d88e970b95760555ab33ce2.json
+++ b/backend/.sqlx/query-2e35598cb9695b726ee1d2cd5c8364503371a5272d88e970b95760555ab33ce2.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO script (workspace_id, path, hash, content, summary, description, language, created_by, created_at, archived, schema_validation, ws_error_handler_muted, deleted, extra_perms)\n         VALUES ('wm-fork-stale-super', 'f/folder2/myscript', 333333, 'echo 1', '', '', 'bash', 'test-user-2', NOW(), false, false, false, false, $1)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "2e35598cb9695b726ee1d2cd5c8364503371a5272d88e970b95760555ab33ce2"
+}

--- a/backend/.sqlx/query-31445efb75a7b706f4404c411a4ef6a9ed6d29a02bb7fd08f2ceb0551ecac640.json
+++ b/backend/.sqlx/query-31445efb75a7b706f4404c411a4ef6a9ed6d29a02bb7fd08f2ceb0551ecac640.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO folder (workspace_id, name, display_name, owners, extra_perms, summary, created_by)\n         VALUES ('wm-fork-visibility-test', 'folder2', 'folder2', ARRAY['u/test-user-2']::varchar[], $1, '', 'test-user-2')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "31445efb75a7b706f4404c411a4ef6a9ed6d29a02bb7fd08f2ceb0551ecac640"
+}

--- a/backend/.sqlx/query-31e486e3377e79bfab4e391d6789d081edf45fef34f630372815ec323544acee.json
+++ b/backend/.sqlx/query-31e486e3377e79bfab4e391d6789d081edf45fef34f630372815ec323544acee.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO folder (workspace_id, name, display_name, owners, extra_perms, summary, created_by)\n         VALUES ('test-workspace', 'folder1', 'folder1', ARRAY['u/test-user-2']::varchar[], $1, '', 'test-user-2')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "31e486e3377e79bfab4e391d6789d081edf45fef34f630372815ec323544acee"
+}

--- a/backend/.sqlx/query-3fac8694f59803a42b635ce7dd1e60a7a4f53c3b7ed6592f70ef4fed97b2bc6d.json
+++ b/backend/.sqlx/query-3fac8694f59803a42b635ce7dd1e60a7a4f53c3b7ed6592f70ef4fed97b2bc6d.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) AS \"count!\" FROM workspace_diff\n             WHERE source_workspace_id = 'test-workspace'\n               AND fork_workspace_id = 'wm-fork-rename-test'\n               AND kind = 'script'\n               AND path = 'f/folder2/myscript'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "3fac8694f59803a42b635ce7dd1e60a7a4f53c3b7ed6592f70ef4fed97b2bc6d"
+}

--- a/backend/.sqlx/query-652637b534f7d7b4c429a201247821e9f568b1976ea462a09e779e9a4c490197.json
+++ b/backend/.sqlx/query-652637b534f7d7b4c429a201247821e9f568b1976ea462a09e779e9a4c490197.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO usr (workspace_id, email, username, is_admin, role) VALUES\n         ('wm-fork-visibility-test', 'test2@windmill.dev', 'test-user-2', false, 'User')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "652637b534f7d7b4c429a201247821e9f568b1976ea462a09e779e9a4c490197"
+}

--- a/backend/.sqlx/query-8d64e61fad7bdf0cc4d4cad1a032e570bdfaf885b4f39ef3ab973256e0448ec7.json
+++ b/backend/.sqlx/query-8d64e61fad7bdf0cc4d4cad1a032e570bdfaf885b4f39ef3ab973256e0448ec7.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT username, is_admin, operator FROM usr\n         WHERE workspace_id = $1 AND email = $2 AND disabled = false",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 2,
+        "name": "operator",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "8d64e61fad7bdf0cc4d4cad1a032e570bdfaf885b4f39ef3ab973256e0448ec7"
+}

--- a/backend/.sqlx/query-8eb5866b6279cb386bbeb7c387a7c731317199b28694a9c3e04028ef1f1d7500.json
+++ b/backend/.sqlx/query-8eb5866b6279cb386bbeb7c387a7c731317199b28694a9c3e04028ef1f1d7500.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM skip_workspace_diff_tally",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "8eb5866b6279cb386bbeb7c387a7c731317199b28694a9c3e04028ef1f1d7500"
+}

--- a/backend/.sqlx/query-903c01dbda5996417a81f7fd76fb21a3566667ec1a9463c7464c5cd788d89270.json
+++ b/backend/.sqlx/query-903c01dbda5996417a81f7fd76fb21a3566667ec1a9463c7464c5cd788d89270.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO workspace_diff\n         (source_workspace_id, fork_workspace_id, path, kind, ahead, behind, has_changes)\n         VALUES ('test-workspace', 'wm-fork-visibility-test', 'f/folder2/myscript', 'script', 1, 0, NULL)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "903c01dbda5996417a81f7fd76fb21a3566667ec1a9463c7464c5cd788d89270"
+}

--- a/backend/.sqlx/query-90c765e384170c2e9f9bc244c7578991315969faf7b845c93678c7ef63b8b8cb.json
+++ b/backend/.sqlx/query-90c765e384170c2e9f9bc244c7578991315969faf7b845c93678c7ef63b8b8cb.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM skip_workspace_diff_tally WHERE workspace_id IN ('test-workspace', 'wm-fork-visibility-test')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "90c765e384170c2e9f9bc244c7578991315969faf7b845c93678c7ef63b8b8cb"
+}

--- a/backend/.sqlx/query-9b88e522ecbe9fa67ef83e79ec5eb5c9c87999a877fcb7f23be75d991bba6e49.json
+++ b/backend/.sqlx/query-9b88e522ecbe9fa67ef83e79ec5eb5c9c87999a877fcb7f23be75d991bba6e49.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT last_locked_at FROM concurrency_locks WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "last_locked_at",
+        "type_info": "Timestamp"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9b88e522ecbe9fa67ef83e79ec5eb5c9c87999a877fcb7f23be75d991bba6e49"
+}

--- a/backend/.sqlx/query-a420ea939b0bfe58b89f29c9eacf2d3fbbe0a140cddad3762e0b4147eb84c0b4.json
+++ b/backend/.sqlx/query-a420ea939b0bfe58b89f29c9eacf2d3fbbe0a140cddad3762e0b4147eb84c0b4.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO folder (workspace_id, name, display_name, owners, extra_perms, summary, created_by)\n         VALUES ('wm-fork-stale-super', 'folder2', 'folder2', ARRAY['u/test-user-2']::varchar[], $1, '', 'test-user-2')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a420ea939b0bfe58b89f29c9eacf2d3fbbe0a140cddad3762e0b4147eb84c0b4"
+}

--- a/backend/.sqlx/query-b8cf0655ecb679c8437ea897a28ec86cd9f3b485a1bacccbd2e5ac5266ac6f01.json
+++ b/backend/.sqlx/query-b8cf0655ecb679c8437ea897a28ec86cd9f3b485a1bacccbd2e5ac5266ac6f01.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO usr (workspace_id, email, username, is_admin, role)\n         VALUES ('wm-fork-rename-test', 'test2@windmill.dev', 'test-user-2', false, 'User')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "b8cf0655ecb679c8437ea897a28ec86cd9f3b485a1bacccbd2e5ac5266ac6f01"
+}

--- a/backend/.sqlx/query-d94636ff736f9cfefb3c001acab6fb7fe3573e3aa71441d04b7cd7bba685b371.json
+++ b/backend/.sqlx/query-d94636ff736f9cfefb3c001acab6fb7fe3573e3aa71441d04b7cd7bba685b371.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO script (workspace_id, path, hash, content, summary, description, language, created_by, created_at, archived, schema_validation, ws_error_handler_muted, deleted, extra_perms)\n         VALUES ('wm-fork-visibility-test', 'f/folder2/myscript', 222222, 'def main():\n    return 1', '', '', 'python3', 'test-user-2', NOW(), false, false, false, false, $1)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d94636ff736f9cfefb3c001acab6fb7fe3573e3aa71441d04b7cd7bba685b371"
+}

--- a/backend/.sqlx/query-e48bf61e59268f95ec389ef30eac15271cbba1601c589a6e0f3399875438aae9.json
+++ b/backend/.sqlx/query-e48bf61e59268f95ec389ef30eac15271cbba1601c589a6e0f3399875438aae9.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE password SET super_admin = true WHERE email = 'test2@windmill.dev'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "e48bf61e59268f95ec389ef30eac15271cbba1601c589a6e0f3399875438aae9"
+}

--- a/backend/.sqlx/query-f83cf3c87a1e80d4a0a7f236c4fa472a4f9ae49e9c2e601c41cd7229ecde765a.json
+++ b/backend/.sqlx/query-f83cf3c87a1e80d4a0a7f236c4fa472a4f9ae49e9c2e601c41cd7229ecde765a.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO workspace_diff\n         (source_workspace_id, fork_workspace_id, path, kind, ahead, behind, has_changes)\n         VALUES ('test-workspace', 'wm-fork-stale-super', 'f/folder2/myscript', 'script', 1, 0, NULL)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "f83cf3c87a1e80d4a0a7f236c4fa472a4f9ae49e9c2e601c41cd7229ecde765a"
+}

--- a/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
+++ b/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
@@ -798,6 +798,243 @@ async fn test_compare_workspaces_trigger_and_schedule(db: Pool<Postgres>) -> any
     Ok(())
 }
 
+/// End-to-end regression for WIN-1975 against the real EE tally path.
+/// Reproduces the reporter's exact steps with the API: fork → create script
+/// in folder1 → rename to folder2 → compare. Folder2 only exists in the
+/// fork, so before the fix the source-scoped authed in `filter_visible_diffs`
+/// hid the script and the response set `all_ahead_items_visible = false`.
+///
+/// Gated on `private` because the OSS build of `handle_deployment_metadata`
+/// is a no-op (`windmill-git-sync/src/git_sync_oss.rs`) — without it the
+/// `workspace_diff` rows never get written and the test would assert against
+/// an empty diff set.
+#[cfg(feature = "private")]
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn test_compare_workspaces_rename_visibility_ee_e2e(
+    db: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base_url = format!("http://localhost:{port}/api");
+    let admin = windmill_api_client::create_client(
+        &format!("http://localhost:{port}"),
+        "SECRET_TOKEN".to_string(),
+    );
+    let non_admin = windmill_api_client::create_client(
+        &format!("http://localhost:{port}"),
+        "SECRET_TOKEN_2".to_string(),
+    );
+
+    // The base fixture pre-populates `skip_workspace_diff_tally` for every
+    // workspace existing at migration time — that bypasses the diff
+    // accounting. Clear it so tally + compare run normally for this test.
+    sqlx::query!("DELETE FROM skip_workspace_diff_tally")
+        .execute(&db)
+        .await?;
+
+    // ------ Fork the existing test-workspace.
+    let resp = admin
+        .client()
+        .post(&format!(
+            "{base_url}/w/test-workspace/workspaces/create_fork"
+        ))
+        .json(&json!({
+            "id": "wm-fork-rename-test",
+            "name": "Rename Fork",
+            "color": "#0000ff"
+        }))
+        .send()
+        .await?;
+    assert!(
+        resp.status().is_success(),
+        "fork creation failed: {}",
+        resp.status()
+    );
+
+    // Non-admin user must be a member of both workspaces. They already are in
+    // test-workspace (base fixture); add them to the fork. Same username as
+    // the source so RLS extra_perms keys still resolve.
+    sqlx::query!(
+        "INSERT INTO usr (workspace_id, email, username, is_admin, role)
+         VALUES ('wm-fork-rename-test', 'test2@windmill.dev', 'test-user-2', false, 'User')"
+    )
+    .execute(&db)
+    .await?;
+
+    // ------ Non-admin creates folder1 in the fork (owner = self).
+    let resp = non_admin
+        .client()
+        .post(&format!("{base_url}/w/wm-fork-rename-test/folders/create"))
+        .json(&json!({"name": "folder1", "owners": [], "summary": ""}))
+        .send()
+        .await?;
+    assert!(
+        resp.status().is_success(),
+        "folder1 create failed: {} — {}",
+        resp.status(),
+        resp.text().await?
+    );
+
+    // ------ Deploy a script in folder1 (initial deploy, no parent_hash).
+    let resp = non_admin
+        .client()
+        .post(&format!("{base_url}/w/wm-fork-rename-test/scripts/create"))
+        .json(&json!({
+            "path": "f/folder1/myscript",
+            "summary": "renamed test",
+            "description": "",
+            // Use bash so we don't trigger the dependency-job code path —
+            // create_script defers `handle_deployment_metadata` (and the
+            // tally) to the dep job for languages that need lock generation
+            // (Deno/Bun/Python/etc), which never runs in this test.
+            "content": "echo 1",
+            "language": "bash",
+            "schema": {"type": "object", "properties": {}, "required": []},
+            "deployment_message": "initial",
+        }))
+        .send()
+        .await?;
+    let status = resp.status();
+    let initial_hash = resp.text().await?;
+    assert!(
+        status.is_success(),
+        "initial script create failed: {} — {}",
+        status,
+        initial_hash
+    );
+
+    // ------ Create folder2 in fork.
+    let resp = non_admin
+        .client()
+        .post(&format!("{base_url}/w/wm-fork-rename-test/folders/create"))
+        .json(&json!({"name": "folder2", "owners": [], "summary": ""}))
+        .send()
+        .await?;
+    assert!(
+        resp.status().is_success(),
+        "folder2 create failed: {}",
+        resp.status()
+    );
+
+    // ------ Rename: re-deploy the same script at the new path with the old
+    // hash as parent_hash. This is exactly what the script editor sends when
+    // the user changes the path field and clicks Deploy. The EE tally upserts
+    // a workspace_diff row for both the new path AND the renamed_from path.
+    let resp = non_admin
+        .client()
+        .post(&format!("{base_url}/w/wm-fork-rename-test/scripts/create"))
+        .json(&json!({
+            "path": "f/folder2/myscript",
+            "summary": "renamed test",
+            "description": "",
+            // Use bash so we don't trigger the dependency-job code path —
+            // create_script defers `handle_deployment_metadata` (and the
+            // tally) to the dep job for languages that need lock generation
+            // (Deno/Bun/Python/etc), which never runs in this test.
+            "content": "echo 1",
+            "language": "bash",
+            "schema": {"type": "object", "properties": {}, "required": []},
+            // The API returns hash as hex (ScriptHash Serialize impl); pass it
+            // through verbatim — the backend deserializer parses hex back.
+            "parent_hash": initial_hash.trim().trim_matches('"'),
+            "deployment_message": "rename to folder2",
+        }))
+        .send()
+        .await?;
+    assert!(
+        resp.status().is_success(),
+        "rename failed: {} — {}",
+        resp.status(),
+        resp.text().await?
+    );
+
+    // The tally is fired via `tokio::spawn` in `handle_deployment_metadata`
+    // (windmill-git-sync/src/git_sync_ee.rs) — wait specifically for the
+    // renamed script row to appear so we don't race the actual case under
+    // test.
+    let mut script_diff_written = false;
+    for _ in 0..40 {
+        let row_count: i64 = sqlx::query_scalar!(
+            "SELECT COUNT(*) AS \"count!\" FROM workspace_diff
+             WHERE source_workspace_id = 'test-workspace'
+               AND fork_workspace_id = 'wm-fork-rename-test'
+               AND kind = 'script'
+               AND path = 'f/folder2/myscript'"
+        )
+        .fetch_one(&db)
+        .await?;
+        if row_count >= 1 {
+            script_diff_written = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    assert!(
+        script_diff_written,
+        "tally never wrote the renamed-script row to workspace_diff"
+    );
+
+    // ------ Compare as the non-admin who owns folder2 in the fork. With the
+    // bug, the source-scoped authed has no folder2 entry → fork visibility
+    // query hides f/folder2/myscript → all_ahead_items_visible flips to
+    // false. With the fix, the fork-scoped authed sees folder2 and the
+    // visibility check passes.
+    let comparison: serde_json::Value = non_admin
+        .client()
+        .get(&format!(
+            "{base_url}/w/test-workspace/workspaces/compare/wm-fork-rename-test"
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    assert_eq!(
+        comparison["all_ahead_items_visible"].as_bool(),
+        Some(true),
+        "non-admin owner of fork-only folder should see ahead items as visible; got {comparison}"
+    );
+
+    let diffs = comparison["diffs"].as_array().unwrap();
+    assert!(
+        diffs
+            .iter()
+            .any(|d| d["path"] == "f/folder2/myscript" && d["kind"] == "script"),
+        "renamed script at f/folder2/myscript should appear in diffs; got {diffs:?}"
+    );
+    // The renamed_from row (f/folder1/myscript) must NOT appear: both sides'
+    // archived=false views show it missing, so compare_two_scripts returns
+    // has_changes=false and the row is deleted. Keep an explicit assertion
+    // so a future regression that leaks the old path is caught here.
+    assert!(
+        !diffs
+            .iter()
+            .any(|d| d["path"] == "f/folder1/myscript" && d["kind"] == "script"),
+        "renamed-from path f/folder1/myscript should be cleaned up; got {diffs:?}"
+    );
+
+    // ------ Also confirm the superadmin path still works (this used to be
+    // the only path that worked because RLS bypass masked the bug).
+    let comparison: serde_json::Value = admin
+        .client()
+        .get(&format!(
+            "{base_url}/w/test-workspace/workspaces/compare/wm-fork-rename-test"
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(
+        comparison["all_ahead_items_visible"].as_bool(),
+        Some(true),
+        "superadmin must always see all ahead items: {comparison}"
+    );
+
+    Ok(())
+}
+
 /// Regression test for WIN-1975. A non-admin user creating a script in a fork-
 /// only folder used to get the spurious
 /// "this fork has changes not visible to your user" warning because

--- a/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
+++ b/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
@@ -797,3 +797,134 @@ async fn test_compare_workspaces_trigger_and_schedule(db: Pool<Postgres>) -> any
 
     Ok(())
 }
+
+/// Regression test for WIN-1975. A non-admin user creating a script in a fork-
+/// only folder used to get the spurious
+/// "this fork has changes not visible to your user" warning because
+/// `filter_visible_diffs` ran every RLS query with the source-workspace
+/// authed, so any item only reachable via fork-specific folders/groups was
+/// hidden from the visibility check.
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn test_compare_workspaces_fork_only_folder_visibility(
+    db: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let client_user_2 = windmill_api_client::create_client(
+        &format!("http://localhost:{port}"),
+        "SECRET_TOKEN_2".to_string(),
+    );
+    let base_url = format!("http://localhost:{port}/api");
+
+    // ----- Set up parent workspace folder1 owned by test-user-2, then fork it.
+    sqlx::query!(
+        "INSERT INTO folder (workspace_id, name, display_name, owners, extra_perms, summary, created_by)
+         VALUES ('test-workspace', 'folder1', 'folder1', ARRAY['u/test-user-2']::varchar[], $1, '', 'test-user-2')",
+        json!({"u/test-user-2": true})
+    )
+    .execute(&db)
+    .await?;
+
+    // Create fork via the API so cloning + workspace_settings.deploy_to wiring
+    // matches what production sees.
+    let client_admin = windmill_api_client::create_client(
+        &format!("http://localhost:{port}"),
+        "SECRET_TOKEN".to_string(),
+    );
+    let fork_response = client_admin
+        .client()
+        .post(&format!(
+            "{base_url}/w/test-workspace/workspaces/create_fork"
+        ))
+        .json(&json!({
+            "id": "wm-fork-visibility-test",
+            "name": "Test Fork",
+            "color": "#0000ff"
+        }))
+        .send()
+        .await?;
+    assert!(
+        fork_response.status().is_success(),
+        "Fork creation failed: {}",
+        fork_response.status()
+    );
+
+    // test-user-2 must be a member of the fork. The fork's clone copies the
+    // creator's usr row only — add test-user-2 manually so they can hit the
+    // compare endpoint and own a fork-only folder.
+    sqlx::query!(
+        "INSERT INTO usr (workspace_id, email, username, is_admin, role) VALUES
+         ('wm-fork-visibility-test', 'test2@windmill.dev', 'test-user-2', false, 'User')"
+    )
+    .execute(&db)
+    .await?;
+
+    // ----- Fork-only folder2 (does not exist in source) owned by test-user-2.
+    sqlx::query!(
+        "INSERT INTO folder (workspace_id, name, display_name, owners, extra_perms, summary, created_by)
+         VALUES ('wm-fork-visibility-test', 'folder2', 'folder2', ARRAY['u/test-user-2']::varchar[], $1, '', 'test-user-2')",
+        json!({"u/test-user-2": true})
+    )
+    .execute(&db)
+    .await?;
+
+    // Script in the fork-only folder with empty extra_perms (typical: scripts
+    // inherit access through their containing folder, not direct perms).
+    sqlx::query!(
+        "INSERT INTO script (workspace_id, path, hash, content, summary, description, language, created_by, created_at, archived, schema_validation, ws_error_handler_muted, deleted, extra_perms)
+         VALUES ('wm-fork-visibility-test', 'f/folder2/myscript', 222222, 'def main():\n    return 1', '', '', 'python3', 'test-user-2', NOW(), false, false, false, false, $1)",
+        json!({})
+    )
+    .execute(&db)
+    .await?;
+
+    // Seed workspace_diff to mirror what the tally would write.
+    sqlx::query!(
+        "INSERT INTO workspace_diff
+         (source_workspace_id, fork_workspace_id, path, kind, ahead, behind, has_changes)
+         VALUES ('test-workspace', 'wm-fork-visibility-test', 'f/folder2/myscript', 'script', 1, 0, NULL)"
+    )
+    .execute(&db)
+    .await?;
+
+    // Clear the skip flag added by the bootstrap migration so compare actually
+    // runs against this fork (it short-circuits otherwise).
+    sqlx::query!(
+        "DELETE FROM skip_workspace_diff_tally WHERE workspace_id IN ('test-workspace', 'wm-fork-visibility-test')"
+    )
+    .execute(&db)
+    .await?;
+
+    let comparison: serde_json::Value = client_user_2
+        .client()
+        .get(&format!(
+            "{base_url}/w/test-workspace/workspaces/compare/wm-fork-visibility-test"
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    assert_eq!(
+        comparison["all_ahead_items_visible"].as_bool(),
+        Some(true),
+        "ahead items should be visible to the fork-only folder owner; full response: {comparison}"
+    );
+    assert_eq!(
+        comparison["all_behind_items_visible"].as_bool(),
+        Some(true),
+        "behind items should be visible (no behind items here)"
+    );
+
+    let diffs = comparison["diffs"].as_array().unwrap();
+    assert!(
+        diffs
+            .iter()
+            .any(|d| d["path"] == "f/folder2/myscript" && d["kind"] == "script"),
+        "fork-only script should appear in diffs; got {diffs:?}"
+    );
+
+    Ok(())
+}

--- a/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
+++ b/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
@@ -798,6 +798,114 @@ async fn test_compare_workspaces_trigger_and_schedule(db: Pool<Postgres>) -> any
     Ok(())
 }
 
+/// Regression for the "superadmin-still-sees-the-warning" case in WIN-1975.
+///
+/// `compare_workspaces` historically trusted `authed.is_admin` for RLS — but
+/// that flag is derived from the *token's* cached `super_admin` column at
+/// auth time (windmill-api-auth/src/auth.rs), not from a live
+/// `password.super_admin` read. A user who is *currently* an instance
+/// superadmin can have a token from before the promotion (or via a session
+/// refresh race) where `token.super_admin = false`. If they're also not a
+/// workspace admin in the source workspace (only in the fork),
+/// `authed.is_admin` lands as `false` and source-scoped RLS gets applied to
+/// fork-side visibility queries — same bug as the regular non-admin case.
+///
+/// With the fix, `load_workspace_authed` re-checks `is_super_admin_email`
+/// against `password.super_admin` at request time, so the fork-scoped authed
+/// gets `is_admin = true` and RLS bypass kicks back in for the fork queries.
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn test_compare_workspaces_stale_superadmin_token(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base_url = format!("http://localhost:{port}/api");
+
+    // Promote test-user-2 to instance superadmin AFTER their token was issued
+    // (base.sql inserts SECRET_TOKEN_2 with super_admin=false). The token row
+    // keeps super_admin=false; password.super_admin flips to true.
+    sqlx::query!("UPDATE password SET super_admin = true WHERE email = 'test2@windmill.dev'")
+        .execute(&db)
+        .await?;
+
+    let stale_super = windmill_api_client::create_client(
+        &format!("http://localhost:{port}"),
+        "SECRET_TOKEN_2".to_string(),
+    );
+
+    // Fork test-workspace.
+    let resp = stale_super
+        .client()
+        .post(&format!(
+            "{base_url}/w/test-workspace/workspaces/create_fork"
+        ))
+        .json(&json!({
+            "id": "wm-fork-stale-super",
+            "name": "Stale Super Fork",
+            "color": "#0000ff"
+        }))
+        .send()
+        .await?;
+    assert!(
+        resp.status().is_success(),
+        "fork creation failed: {} — {}",
+        resp.status(),
+        resp.text().await?
+    );
+
+    // Fork-only folder + script, with empty extra_perms so the only way to
+    // see them is via fork's folder-based RLS or admin bypass.
+    sqlx::query!(
+        "INSERT INTO folder (workspace_id, name, display_name, owners, extra_perms, summary, created_by)
+         VALUES ('wm-fork-stale-super', 'folder2', 'folder2', ARRAY['u/test-user-2']::varchar[], $1, '', 'test-user-2')",
+        json!({"u/test-user-2": true})
+    )
+    .execute(&db)
+    .await?;
+    sqlx::query!(
+        "INSERT INTO script (workspace_id, path, hash, content, summary, description, language, created_by, created_at, archived, schema_validation, ws_error_handler_muted, deleted, extra_perms)
+         VALUES ('wm-fork-stale-super', 'f/folder2/myscript', 333333, 'echo 1', '', '', 'bash', 'test-user-2', NOW(), false, false, false, false, $1)",
+        json!({})
+    )
+    .execute(&db)
+    .await?;
+    sqlx::query!(
+        "INSERT INTO workspace_diff
+         (source_workspace_id, fork_workspace_id, path, kind, ahead, behind, has_changes)
+         VALUES ('test-workspace', 'wm-fork-stale-super', 'f/folder2/myscript', 'script', 1, 0, NULL)"
+    )
+    .execute(&db)
+    .await?;
+    sqlx::query!("DELETE FROM skip_workspace_diff_tally")
+        .execute(&db)
+        .await?;
+
+    let comparison: serde_json::Value = stale_super
+        .client()
+        .get(&format!(
+            "{base_url}/w/test-workspace/workspaces/compare/wm-fork-stale-super"
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    assert_eq!(
+        comparison["all_ahead_items_visible"].as_bool(),
+        Some(true),
+        "current superadmin with stale token should still see ahead items: {comparison}"
+    );
+    let diffs = comparison["diffs"].as_array().unwrap();
+    assert!(
+        diffs
+            .iter()
+            .any(|d| d["path"] == "f/folder2/myscript" && d["kind"] == "script"),
+        "fork-only script should appear in diffs; got {diffs:?}"
+    );
+
+    Ok(())
+}
+
 /// End-to-end regression for WIN-1975 against the real EE tally path.
 /// Reproduces the reporter's exact steps with the API: fork → create script
 /// in folder1 → rename to folder2 → compare. Folder2 only exists in the

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -6372,11 +6372,23 @@ async fn compare_workspaces(
         }
     }
 
+    // The authed in `authed` is loaded for the source workspace (the one in the
+    // URL path). Its `folders`/`groups`/`is_admin` reflect membership in the
+    // source workspace only. Using it as the RLS context when querying the
+    // fork's tables would hide items the user can only see via fork-specific
+    // permissions (e.g. a folder the user owns in the fork but that does not
+    // exist in the source), causing the spurious
+    // "this fork has changes not visible to your user" warning. Build a
+    // matching authed for the fork so each side's visibility check uses the
+    // right RLS context.
+    let fork_authed = load_workspace_authed(&db, &authed, &fork_workspace_id).await?;
     let visible_diffs = filter_visible_diffs(
         &confirmed_diffs,
         &source_workspace_id,
         &fork_workspace_id,
-        user_db.begin(&authed).await?,
+        &authed,
+        &fork_authed,
+        &user_db,
     )
     .await?;
 
@@ -6443,11 +6455,90 @@ async fn compare_workspaces(
     }));
 }
 
+/// Build an `ApiAuthed` for the same user but scoped to a different workspace.
+///
+/// Reloads `is_admin`, `groups`, and `folders` from the target workspace's
+/// `usr` / `group_` / `folder` tables (keyed by the caller's email) so the
+/// returned authed can be used as the RLS context for queries against that
+/// workspace. `is_admin` is OR'd with the user's superadmin status so cross-
+/// workspace superadmins keep their RLS bypass.
+///
+/// If the user is not a member of `workspace_id`, returns an authed with no
+/// folders/groups/operator/admin (except for superadmins, who stay admin) —
+/// i.e. they will only see what RLS explicitly allows for unknown users.
+async fn load_workspace_authed(
+    db: &DB,
+    base_authed: &ApiAuthed,
+    workspace_id: &str,
+) -> Result<ApiAuthed> {
+    let mut conn = db
+        .acquire()
+        .await
+        .map_err(|e| Error::internal_err(e.to_string()))?;
+
+    let is_super_admin =
+        windmill_common::auth::is_super_admin_email(db, &base_authed.email).await?;
+
+    let user_row = sqlx::query!(
+        "SELECT username, is_admin, operator FROM usr
+         WHERE workspace_id = $1 AND email = $2 AND disabled = false",
+        workspace_id,
+        &base_authed.email
+    )
+    .fetch_optional(&mut *conn)
+    .await?;
+
+    let Some(user_row) = user_row else {
+        return Ok(ApiAuthed {
+            email: base_authed.email.clone(),
+            username: base_authed.username.clone(),
+            is_admin: is_super_admin,
+            is_operator: false,
+            groups: vec![],
+            folders: vec![],
+            scopes: base_authed.scopes.clone(),
+            username_override: base_authed.username_override.clone(),
+            token_prefix: base_authed.token_prefix.clone(),
+            read_only: base_authed.read_only,
+        });
+    };
+
+    let groups = windmill_common::auth::get_groups_for_user(
+        workspace_id,
+        &user_row.username,
+        &base_authed.email,
+        &mut *conn,
+    )
+    .await?;
+    let folders = windmill_common::auth::get_folders_for_user(
+        workspace_id,
+        &user_row.username,
+        &groups,
+        &mut *conn,
+    )
+    .await?;
+
+    Ok(ApiAuthed {
+        email: base_authed.email.clone(),
+        username: user_row.username,
+        is_admin: is_super_admin || user_row.is_admin,
+        is_operator: user_row.operator,
+        groups,
+        folders,
+        scopes: base_authed.scopes.clone(),
+        username_override: base_authed.username_override.clone(),
+        token_prefix: base_authed.token_prefix.clone(),
+        read_only: base_authed.read_only,
+    })
+}
+
 async fn filter_visible_diffs(
     confirmed_diffs: &[WorkspaceDiffRow],
     source_workspace_id: &str,
     fork_workspace_id: &str,
-    mut tx: Transaction<'static, Postgres>,
+    source_authed: &ApiAuthed,
+    fork_authed: &ApiAuthed,
+    user_db: &UserDB,
 ) -> Result<Vec<WorkspaceDiffRow>> {
     // Step 1: Group paths by (workspace, kind)
     let mut source_items: HashMap<&str, Vec<&str>> = HashMap::new();
@@ -6462,9 +6553,23 @@ async fn filter_visible_diffs(
         }
     }
 
-    // Step 2: Batch query for each (workspace, kind) combination
-    let source_visible = query_visible_items(&mut tx, source_workspace_id, &source_items).await?;
-    let fork_visible = query_visible_items(&mut tx, fork_workspace_id, &fork_items).await?;
+    // Step 2: Batch query for each (workspace, kind) combination, each in its
+    // own transaction so RLS uses the right authed for each side. The fork's
+    // authed picks up fork-only folders/groups; without this split the fork
+    // queries would run with the source workspace's permissions and miss any
+    // item the user can only reach through fork-specific permissions.
+    let source_visible = {
+        let mut tx = user_db.clone().begin(source_authed).await?;
+        let visible = query_visible_items(&mut tx, source_workspace_id, &source_items).await?;
+        tx.commit().await?;
+        visible
+    };
+    let fork_visible = {
+        let mut tx = user_db.clone().begin(fork_authed).await?;
+        let visible = query_visible_items(&mut tx, fork_workspace_id, &fork_items).await?;
+        tx.commit().await?;
+        visible
+    };
 
     // Step 3: Filter diffs based on visibility
     let visible_diffs: Vec<WorkspaceDiffRow> = confirmed_diffs


### PR DESCRIPTION
Fixes WIN-1975

## Summary

`compare_workspaces` (`GET /api/w/{source}/workspaces/compare/{fork}`) was
running every RLS-scoped visibility query with the **source workspace's**
authed context, even when querying the **fork's** tables. Any item the user
could only reach through fork-specific permissions (e.g. a folder they
created in the fork that doesn't exist in the source) was therefore hidden
from the visibility check, and the comparison response set
`all_ahead_items_visible = false`. The frontend rendered this as the
"This fork has changes not visible to your user — only a user with access
to the whole context may deploy or update this fork" warning even though
the user had full access to the changes in the fork.

The reporter's repro (create a script in folder1 in a fork → change its
path to folder2 → merge): after the path change the renamed script lives
under `f/folder2`, which only exists in the fork. The user owns folder2 in
the fork but `authed.folders` was loaded from the source workspace, so the
fork-side script was filtered out of `visible_diffs`.

### How this hits superadmins too

The reporter is an instance superadmin. The bug still reproduces for
superadmins via stale `token.super_admin`:

- `token.super_admin` is snapshotted from `password.super_admin` at token
  creation time (`create_session_token`, `create_token_internal`) and is
  **never re-read** during auth (`auth.rs:218-417`).
- Default session lifetime is 3 days and `INVALIDATE_OLD_SESSIONS` defaults
  to false, so any token issued *before* the user was promoted to
  superadmin keeps `super_admin = false`. API tokens are even longer-lived.
- Auth computes `authed.is_admin = usr.is_admin || token.super_admin`. If
  the user is *currently* a superadmin but the token is stale **and** they
  aren't a workspace admin in the source workspace, `authed.is_admin` is
  `false` and RLS bypass doesn't apply — same code path as the regular
  non-admin case.

`load_workspace_authed` re-reads `password.super_admin` via
`is_super_admin_email` at request time, so the fork-scoped authed gets the
correct admin status independently of the token's cached flag.

Reproduced this scenario live against the running backend and committed a
dedicated regression test (`test_compare_workspaces_stale_superadmin_token`)
that fails on `origin/main` with the exact reported symptom
(`all_ahead_items_visible: false`, diffs list empty) and passes with the fix.

## Changes

- `compare_workspaces` now loads a fork-scoped `ApiAuthed` (groups, folders,
  `is_admin` recomputed from live `password.super_admin` + fork `usr` row)
  for the same user and passes both authed contexts to
  `filter_visible_diffs`.
- `filter_visible_diffs` opens two separate `user_db.begin()` transactions
  — one per workspace — so each visibility query runs with the correct RLS
  context.
- Adds 3 regression tests:
  - `test_compare_workspaces_fork_only_folder_visibility` — focused
    regression seeding `workspace_diff` directly (OSS-safe), covers the
    plain non-admin case.
  - `test_compare_workspaces_stale_superadmin_token` — reproduces the
    superadmin-with-stale-token failure mode the actual reporter is hitting.
  - `test_compare_workspaces_rename_visibility_ee_e2e` (gated on `private`)
    — full end-to-end through the API + EE tally: fork creation, folder
    creation, script deploy, path rename, compare. Mirrors the reporter's
    exact steps.

## Test plan

- [x] `cargo test -p windmill-api-integration-tests --test workspace_comparison
      --features private,enterprise`: 5/5 pass.
- [x] Reverted my fix and re-ran each new test against `origin/main`
      `workspaces.rs` — every new test fails, confirming they catch the bug.
- [x] `cargo check --features enterprise,private` clean across the workspace.
- [x] `SQLX_OFFLINE=true cargo check ...` compiles cleanly (sqlx cache
      complete; one new file added, no EE caches dropped).
- [ ] Manual repro: as a non-admin user in a fork, create folder2 (owner =
      self) and a script inside it, then call the compare endpoint —
      `all_ahead_items_visible` should now be `true`.
- [ ] Manual repro for the stale-superadmin-token case: promote a user to
      superadmin after they've logged in, then have them call compare against
      a fork-only item — should now show as visible.