### PR TITLE
refactor(cli): wmill sync git-deploy stops committing, caller owns commit+push

### DIFF
--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -2503,14 +2503,8 @@ export async function pull(
     }
 
     if (opts.onlyCreateBranch) {
-      gitSyncDeployPush({
-        items: deployItems,
-        authorName: process.env["WM_USERNAME"] || "windmill",
-        authorEmail: process.env["WM_EMAIL"] || "windmill@windmill.dev",
-        committerName: opts.gitCommitterName,
-        committerEmail: opts.gitCommitterEmail,
-        onlyCreateBranch: true,
-      });
+      // Branch is checked out locally; the caller pushes it. Symmetric with
+      // the non-onlyCreateBranch path: CLI does branch + pull, never push.
       return;
     }
   }
@@ -2982,19 +2976,11 @@ export async function pull(
     log.warn(`Failed to pull shared UI folder: ${e}`);
   }
 
-  // Git-sync deployment-callback mode: commit the pulled files and push the
-  // current branch (the wm_deploy/fork branch checked out above, or the base
-  // branch in workspace-wide mode).
-  if (opts.gitDeployItems !== undefined && !opts.onlyCreateBranch) {
-    const deployItems: GitSyncDeployItem[] = JSON.parse(opts.gitDeployItems);
-    gitSyncDeployPush({
-      items: deployItems,
-      authorName: process.env["WM_USERNAME"] || "windmill",
-      authorEmail: process.env["WM_EMAIL"] || "windmill@windmill.dev",
-      committerName: opts.gitCommitterName,
-      committerEmail: opts.gitCommitterEmail,
-    });
-  }
+  // Git-sync deployment-callback mode stops here: branch checkout + pull have
+  // happened, but commit + push are the caller's job. The hub script does
+  // them in-process with `set_gpg_signing_secret` so the agent's pre-warmed
+  // passphrase cache is still warm at sign time (WIN-1974). `gitSyncDeployPush`
+  // stays exported for callers that want the same commit/push behavior.
 }
 
 // Internal git-sync deployment-callback entrypoint. Invoked only by the

--- a/cli/test/gitsync_promotion.test.ts
+++ b/cli/test/gitsync_promotion.test.ts
@@ -6,10 +6,11 @@
  * `use_individual_branch` is set — NOT straight to the cloned base branch
  * (e.g. a protected `main`, which fails with GH006).
  *
- * The CLI's `wmill sync pull --git-deploy-items ...` now owns that branch
- * checkout + commit + push (previously hub-script-only, hence untestable).
- * This drives it against a real local bare repo so the regression is caught
- * deterministically, with no network and no GitHub.
+ * Contract: `wmill sync git-deploy` does branch checkout + pull only. Commit
+ * + push are the caller's job — the hub script does them in the same process
+ * as `set_gpg_signing_secret` so the GPG agent's passphrase cache is still
+ * warm at sign time (WIN-1974). This test replicates the caller half (git
+ * add + commit + push) inline so the full promotion regression stays caught.
  */
 
 import { expect, test } from "bun:test";
@@ -121,6 +122,23 @@ test.skipIf(shouldSkipOnCI())(
         { path_type: "script", path: "f/promo/foo", commit_msg: "deploy foo" },
       ]);
 
+      // Caller-half: stage anything the CLI's pull dropped, commit on the
+      // current branch (which the CLI just checked out), and push. Mirrors
+      // what the hub script does in production after `wmill sync git-deploy`.
+      const commitAndPush = (work: string) => {
+        git(work, "config", "user.email", "test@windmill.dev");
+        git(work, "config", "user.name", "test");
+        git(work, "add", "-A");
+        try {
+          git(work, "diff", "--cached", "--quiet");
+          // Exit 0 = nothing staged; nothing to commit. Still push the
+          // (possibly new) branch ref so the assertions see it.
+        } catch {
+          git(work, "commit", "-m", "deploy foo");
+        }
+        git(work, "push", "--porcelain", "-u", "origin", "HEAD");
+      };
+
       // --- Case A: use_individual_branch=true -> wm_deploy branch, main untouched ---
       const workA = await mkdtemp(join(tmpdir(), "wmill_promo_a_"));
       git(workA, "clone", `file://${bareDir}`, ".");
@@ -141,6 +159,7 @@ test.skipIf(shouldSkipOnCI())(
         workA,
       );
       expect(resA.code).toBe(0);
+      commitAndPush(workA);
 
       const branchesA = remoteBranches(bareDir);
       const expectedBranch = `refs/heads/wm_deploy/${ws}/script/f__promo__foo`;
@@ -167,6 +186,8 @@ test.skipIf(shouldSkipOnCI())(
         workB,
       );
       expect(resB.code).toBe(0);
+      commitAndPush(workB);
+
       expect(remoteHead(bareDir, "main")).not.toBe(seedMain);
       expect(
         remoteBranches(bareDir).filter((b) => b.includes("wm_deploy")).length,


### PR DESCRIPTION
Splits commit+push out of `wmill sync git-deploy` so the deployment-callback flow has a single boundary between the CLI and the hub script. The hub script does GPG setup and `git commit` in the same process — the WIN-1974 invariant — and the CLI's subcommand stops at branch checkout + pull.

## Why

PR #9230 introduced `wmill sync git-deploy` and gave the CLI ownership of branch + pull + commit + push. That created a script ↔ CLI process boundary between the GPG agent pre-warm in the hub script and the `git commit` in the CLI. By commit time the agent's passphrase cache wasn't reliably valid for the spawned `git`, and signing failed with `gpg failed to sign the data` (WIN-1974 — Traveloka, customer-confirmed).

#9282 ships the immediate customer fix (`LATEST_GIT_SYNC_SCRIPT_PATH = hub/28235`, in-script commit logic from hub/28217). This PR is the forward fix that keeps the testable parts (`wm_deploy`/fork branch selection, include-set derivation, promotion overrides) in the CLI **and** keeps GPG signing in the same process as the dummy sign.

## What changes

- `cli/src/commands/sync/sync.ts`:
  - Removes the `gitSyncDeployPush` call from `pull()`'s git-deploy path (both the `--only-create-branch` fast-return and the post-pull commit).
  - `gitSyncDeployPush` stays exported in `cli/src/utils/git.ts` — callers that want the same commit/push semantics can still import it.
- `cli/test/gitsync_promotion.test.ts`: the e2e test now does `git add -A` + `git commit` + `git push` itself after `runCLICommand([sync, git-deploy, ...])`. That mirrors what the new hub script will do in production. Same regression coverage as before:
  - Case A (`use_individual_branch=true`): `wm_deploy/<workspace>/...` branch created, `main` untouched.
  - Case B (workspace-wide): `main` updated, no new `wm_deploy`.

## What this doesn't change

- `gitSyncCommitMessage` (the pure commit-message-builder helper) stays untouched and unit-tested in `cli/test/git_unit.test.ts`.
- Branch checkout (`computeGitSyncDeployBranch` + `checkoutGitSyncDeployBranch`), include-set derivation (`deriveGitSyncDeployIncludes`), and promotion-override resolution all stay in the CLI.
- Other callers of `gitSyncDeployPush` (none in-tree today) are unaffected — the function exists, just isn't wired into the `git-deploy` subcommand.

## Verification

- `cd cli && npm run check` — no new type errors. Pre-existing TarAsZip errors at `sync.ts:2578` and `sync.ts:3307` are present on `main` (also surface on #9282).
- `cd cli && npm run test:unit` — 789/789 pass.
- The e2e `cli/test/gitsync_promotion.test.ts` skips on CI (uses `withTestBackend`, requires the cargo backend); needs a local run with the backend available.

## Companion change

A new hub script (option-C) that calls `wmill sync git-deploy` for branch + pull and does GPG setup + `git_push` in-script is staged at `/tmp/git-sync-diff/sync-script-to-git-repo-windmill.option-C.ts` (locally on Ruben's machine). It pins `windmill-cli@1.706.1`, which is the version that includes this PR's change. Sequence:

1. Merge this PR into `main`.
2. Release `windmill-cli@1.706.1` (the release workflow publishes to npm + JSR).
3. Upload `sync-script-to-git-repo-windmill.option-C.ts` to hub.windmill.dev.
4. Bump `LATEST_GIT_SYNC_SCRIPT_PATH` in #9282 (or in a follow-up) to the new hub id.

## Test plan

- [x] Type-check passes.
- [x] CLI unit tests pass.
- [ ] Local backend: e2e `gitsync_promotion.test.ts` passes.
- [ ] Once `1.706.1` is released and the new hub script is uploaded: trigger a GPG-protected deploy and confirm the commit lands signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`wmill sync git-deploy` now stops at branch checkout and pull; commit and push are moved to the caller to keep GPG signing in the same process and avoid WIN-1974 signing failures.

- **Refactors**
  - Removed the in-command commit/push; `gitSyncDeployPush` stays exported for optional use.
  - Updated e2e to `git add/commit/push` after `wmill sync git-deploy`, mirroring the hub script.
  - No changes to commit message builder or branch/include derivation.

- **Migration**
  - After calling `wmill sync git-deploy`, run `git add -A && git commit && git push` in the same process as GPG setup.
  - Branch selection behavior is unchanged (individual vs workspace-wide).

<sup>Written for commit 33cfc99ce532cc692d9e205526ae922bc6a1caaa. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9284?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

