### PR TITLE
chore(system_prompts): point plugin skills sync at plugins/windmill/

### DIFF
--- a/system_prompts/README.md
+++ b/system_prompts/README.md
@@ -35,7 +35,7 @@ python system_prompts/generate.py --plugin-dir ~/windmill-claude-plugin
 
 `--plugin-dir` accepts:
 - the `windmill-claude-plugin` repo root
-- a plugin root such as `plugins/windmill-code-plugin`
+- a plugin root such as `plugins/windmill`
 - a direct `skills/` directory
 
 To regenerate the public docs repo (consumed by context7):

--- a/system_prompts/generate.py
+++ b/system_prompts/generate.py
@@ -1761,10 +1761,9 @@ def resolve_plugin_skills_dir(plugin_dir: Path) -> Path:
     """Resolve the plugin skills directory from a repo root, plugin root, or skills dir."""
     plugin_dir = plugin_dir.expanduser().resolve()
 
-    repo_skills_dir = plugin_dir / "plugins" / "windmill-code-plugin" / "skills"
-    repo_plugin_json = plugin_dir / "plugins" / "windmill-code-plugin" / ".claude-plugin" / "plugin.json"
-    if repo_plugin_json.exists():
-        return repo_skills_dir
+    plugin_root = plugin_dir / "plugins" / "windmill"
+    if (plugin_root / ".claude-plugin" / "plugin.json").exists():
+        return plugin_root / "skills"
 
     plugin_skills_dir = plugin_dir / "skills"
     plugin_json = plugin_dir / ".claude-plugin" / "plugin.json"


### PR DESCRIPTION
## Summary
- Updates `resolve_plugin_skills_dir` to look for `plugins/windmill/` (the renamed plugin folder) instead of `plugins/windmill-code-plugin/`.
- Paired with windmill-labs/windmill-claude-plugin#8, which performs the rename and shortens the slash-command namespace from `/windmill-code-plugin:*` to `/windmill:*`.

## Merge order
windmill-labs/windmill-claude-plugin#8 must merge first. Once that's in, the next nightly sync (or `workflow_dispatch`) will refresh skills into the renamed `plugins/windmill/` folder. Merging this PR before the plugin rename would cause the sync to fall through to `<repo>/skills`, writing to the wrong path.

## Test plan
- [ ] Run `python system_prompts/generate.py --plugin-dir /path/to/windmill-claude-plugin` after the plugin rename is in — confirm it refreshes `plugins/windmill/skills/`.
- [ ] `grep -rn windmill-code-plugin system_prompts/` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)