### PR TITLE
fix(cli): wmill sync pull updates wmill-lock.yaml for raw apps

### DIFF
--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -2858,7 +2858,7 @@ export async function pull(
       await generateAppLocksInternal(
         change,
         true,
-        true,
+        false,
         workspace,
         opts,
         true,


### PR DESCRIPTION
## Summary

`wmill sync pull` was failing to refresh `wmill-lock.yaml` entries for raw apps. The hashes for raw-app inline scripts/backend runnables stayed stale after pulling remote changes, even though the loop was visibly logging `Updating lock metadata for raw app …`.

The raw-apps loop in `pull()` was passing `dryRun: true` to `generateAppLocksInternal`, which makes the function return without ever calling `updateMetadataGlobalLock`. The sibling normal-apps loop directly below already passes `dryRun: false` — this was a copy/paste leftover from the push side, where `dryRun: true` is intentional (push only consumes the staleness return value).

History: commit `99b1ae2e0` introduced the buggy `dryRun: true`; `cd4151a84` later fixed the sibling `rawApp` flag but missed `dryRun`.

## Changes

- Flip `dryRun` from `true` to `false` in the raw-apps loop of `pull()` (`cli/src/commands/sync/sync.ts:2861`) so locks are actually written.

## Test plan

- [ ] In a workspace with a raw app, edit a backend runnable on the remote, run `wmill sync pull` locally, and confirm the raw app's hash in `wmill-lock.yaml` changes.
- [ ] Immediately run `wmill sync push --dry-run` and confirm the raw app is reported as up-to-date (no stale-lock warning).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `wmill sync pull` not updating `wmill-lock.yaml` for raw apps. Lock metadata now persists, so hashes for inline scripts and backend runnables refresh after pulling and subsequent pushes show up-to-date.

- **Bug Fixes**
  - Set `dryRun: false` when calling `generateAppLocksInternal` for raw apps during pull, ensuring `updateMetadataGlobalLock` runs and writes the lock.

<sup>Written for commit 42de9b6ff8a67f9a096ea2c018e2509d3d77fce6. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9289?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

