### PR TITLE
fix(flows): restore Variables and Resources in flow editor prop picker

### DIFF
--- a/frontend/src/lib/components/propertyPicker/PropPicker.svelte
+++ b/frontend/src/lib/components/propertyPicker/PropPicker.svelte
@@ -375,7 +375,7 @@
 		{/if}
 
 		{#if displayContext}
-			{#if $inputMatches?.some((match) => match.word === 'variable')}
+			{#if !$inputMatches?.length || $inputMatches?.some((match) => match.word === 'variable')}
 				<span class={categoryTitleClasses}>Variables</span>
 				<div class={categoryContentClasses}>
 					{#if displayVariable}
@@ -412,7 +412,7 @@
 					{/if}
 				</div>
 			{/if}
-			{#if $inputMatches?.some((match) => match.word === 'resource')}
+			{#if !$inputMatches?.length || $inputMatches?.some((match) => match.word === 'resource')}
 				<span class={categoryTitleClasses}>Resources</span>
 				<div class={categoryContentClasses}>
 					{#if displayResources}


### PR DESCRIPTION
## Summary

The Variables and Resources sections of the flow editor's prop picker stopped appearing in **#6776** ("fix(frontend): update overall design to follow new guidelines", commit `032f0c1f8c`).

Before that PR, the two sections were displayed by default with this guard:

```svelte
{#if !filterActive || $inputMatches?.some((match) => match.word === 'variable')}
```

The design-system overhaul dropped the `!filterActive ||` fallback (and removed the `filterActive` variable altogether), so the sections now only render when the user explicitly types `variable.` or `resource.` in their expression — i.e. effectively never, for users who didn't already know the magic prefix.

This restores the previous default by re-checking that no `$inputMatches` are active, which is the equivalent of the old `!filterActive` clause in the new code shape.

## Test plan

- [ ] Open a flow in the editor, focus a step input, and confirm the **Variables** and **Resources** collapsible sections show up by default in the prop picker
- [ ] Type `flow_input.` and confirm Variables/Resources hide (only flow_input results show — matching the previous "filter active" behavior)
- [ ] Type `variable.` and confirm only the Variables section is shown
- [ ] Type `resource.` and confirm only the Resources section is shown

Fixes WIN-1976