### PR TITLE
fix(ResourceEditor): don't reset state when `selected` reverts to undefined

### DIFF
--- a/frontend/src/lib/components/ResourceEditor.svelte
+++ b/frontend/src/lib/components/ResourceEditor.svelte
@@ -207,9 +207,9 @@
 
 	// Bootstrap: ensure selected is set on mount (edit or new)
 	$effect(() => {
-		if (selected !== undefined) return
 		if (!effectiveWorkspace) return
 		untrack(() => {
+			if (selected !== undefined) return
 			selected = effectiveWorkspace
 			if (!initialPath) {
 				// New resource


### PR DESCRIPTION
## Summary
- The ResourceEditor bootstrap effect tracked `selected` via its early-return check, so any time `selected` flipped back to `undefined` it would re-run and reinitialize `states[effectiveWorkspace]` to empty — wiping user input.
- This is reproducible via the React SDK: `reactify` re-syncs all Svelte props on every React render, and since `selected` isn't passed through the wrapper, `$props()` reverts it to its `$bindable()` default each time the consumer calls `setState` in their `onChange`. The visible effect is that every keystroke in the resource form immediately blanks the resource back to `{}`.
- Fix: move the `selected !== undefined` check inside the existing `untrack` block so the effect only tracks `effectiveWorkspace`. Bootstrap still runs once on mount; subsequent `selected` flips no longer retrigger it.

## Test plan
- [ ] In the Svelte app, open the resource editor (create + edit modes) and confirm normal save/edit flows still work.
- [ ] In a React SDK consumer (`windmill-react-sdk` `ResourceEditor`), type into a resource form field and confirm the value persists through React re-renders instead of being wiped.
- [ ] Switch workspace while a resource is open and confirm `selected`/state behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent ResourceEditor from resetting form state when `selected` briefly becomes undefined during React renders. The bootstrap effect now only tracks `effectiveWorkspace`, fixing wiped fields in `windmill-react-sdk`.

- **Bug Fixes**
  - Moved the `selected !== undefined` check inside `untrack` in `ResourceEditor.svelte`.
  - Bootstrap runs once on mount; later `selected` flips no longer reinitialize `states[effectiveWorkspace]`.

<sup>Written for commit 2a1776ef7d19aadfa46ad076aace68dce4e6401c. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9295?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

