### PR TITLE
fix(ResourceEditor): make `selected` resilient + snapshot args for React

### DIFF
--- a/frontend/src/lib/components/ResourceEditor.svelte
+++ b/frontend/src/lib/components/ResourceEditor.svelte
@@ -36,8 +36,13 @@
 		onChange,
 		defaultValues = undefined,
 		workspace = undefined,
-		selected = $bindable()
+		selected: selectedProp = $bindable()
 	}: Props = $props()
+
+	// Fallback to `effectiveWorkspace` insulates against reactify-style
+	// parents that re-spread props without `selected` — otherwise it
+	// transiently resets and the form below remounts on every keystroke.
+	let selected = $derived(selectedProp ?? effectiveWorkspace)
 
 	type ResourceState = {
 		path: string
@@ -205,28 +210,25 @@
 		})
 	)
 
-	// Bootstrap: ensure selected is set on mount (edit or new)
+	// New-resource bootstrap: seed empty state per workspace (edit mode
+	// is seeded by the lazy-fetch effect below).
 	$effect(() => {
-	    selected
-		if (!effectiveWorkspace) return
+		if (!selected) return
+		if (initialPath) return
+		if (selected in initialStates) return
 		untrack(() => {
-			if (selected !== undefined) return
-			selected = effectiveWorkspace
-			if (!initialPath) {
-				// New resource
-				const s: ResourceState = {
-					path: '',
-					description: '',
-					args: (defaultValues && Object.keys(defaultValues).length > 0
-						? defaultValues
-						: {}) as any,
-					labels: undefined,
-					wsSpecific: false
-				}
-				ensureHandle(effectiveWorkspace, s)
-				initialStates[effectiveWorkspace] = structuredClone(s)
-				existedInitially[effectiveWorkspace] = false
+			const s: ResourceState = {
+				path: '',
+				description: '',
+				args: (defaultValues && Object.keys(defaultValues).length > 0
+					? defaultValues
+					: {}) as any,
+				labels: undefined,
+				wsSpecific: false
 			}
+			ensureHandle(selected, s)
+			initialStates[selected] = structuredClone(s)
+			existedInitially[selected] = false
 		})
 	})
 
@@ -330,11 +332,9 @@
 
 	$effect(() => {
 		if (current)
-			// Snapshot args so the deep read establishes nested dependency
-			// tracking (the effect re-runs on mutations inside args, not
-			// just reference changes) and so consumers receive a plain
-			// object instead of a $state proxy — important for React
-			// integrations that diff by reference or JSON.stringify.
+			// $state.snapshot deep-reads (so the effect re-runs on nested
+			// args mutations) and returns a plain object (React consumers
+			// can't diff a $state proxy by reference or JSON.stringify).
 			onChange?.({
 				path: current.path,
 				args: $state.snapshot(current.args) as Record<string, any>,

--- a/frontend/src/lib/components/ResourceEditor.svelte
+++ b/frontend/src/lib/components/ResourceEditor.svelte
@@ -39,11 +39,6 @@
 		selected: selectedProp = $bindable()
 	}: Props = $props()
 
-	// Fallback to `effectiveWorkspace` insulates against reactify-style
-	// parents that re-spread props without `selected` — otherwise it
-	// transiently resets and the form below remounts on every keystroke.
-	let selected = $derived(selectedProp ?? effectiveWorkspace)
-
 	type ResourceState = {
 		path: string
 		description: string
@@ -55,6 +50,10 @@
 	const dispatch = createEventDispatcher()
 
 	let effectiveWorkspace = $derived(workspace ?? $workspaceStore!)
+	// Fallback to `effectiveWorkspace` insulates against reactify-style
+	// parents that re-spread props without `selected` — otherwise it
+	// transiently resets and the form below remounts on every keystroke.
+	let selected = $derived(selectedProp ?? effectiveWorkspace)
 	let initialPath = path
 
 	// Per-workspace handles are driven by `useMany`. We track the workspace


### PR DESCRIPTION
## Summary

Two issues surfaced via the React SDK (reactify wrapper re-spreads Svelte props on every host re-render):

- **Focus loss on every keystroke.** The bindable `selected` prop transiently resets to `undefined` on each re-spread, flipping `current` through `undefined` and unmounting the form. Rename the prop to `selectedProp` and derive `selected = selectedProp ?? effectiveWorkspace` so the fallback insulates the component without any effects.
- **`onChange` payload doesn't reflect nested args changes.** The dispatch passed `current.args` (a `$state` proxy) directly. React consumers diffing by reference or `JSON.stringify` saw the same value forever, and the effect only tracked the `args` reference (not deep mutations). Wrap with `$state.snapshot` to deep-track *and* emit a plain object.

The new-resource bootstrap effect is restructured: it no longer writes `selected` (the derived handles defaulting) and now guards on `selected in initialStates` so workspace flips remain idempotent.

Alternative considered: a dual `$effect` sync between prop and a local `$state` (as in #9297). This version uses a single `$derived` instead — zero effects, no loop surface. The observable delta vs. the dual-effect approach: the bootstrap default no longer propagates back through `bind:selected`, but `ResourceEditorDrawer` (the only current `bind:selected` consumer) already sets `selected` itself before mount, so this isn't load-bearing today.

## Test plan

- [ ] React SDK demo: type into a resource form field — focus survives, displayed args reflect each keystroke.
- [ ] Svelte: open `ResourceEditorDrawer` for an existing resource, edit fields, save — unchanged behavior.
- [ ] Svelte: open `ResourceEditorDrawer` for a workspace-specific resource, flip workspaces via `WsSpecificVersions` — both per-ws drafts retain their state.
- [ ] Svelte: create a new resource via the drawer — saves correctly to the active workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes focus loss and stale `onChange` payloads in `ResourceEditor` when used via the React SDK. Makes `selected` resilient to prop re-spreads and deep-tracks arg changes so React sees plain objects.

- **Bug Fixes**
  - `selected` now derives from `selectedProp ?? effectiveWorkspace` (with `effectiveWorkspace` declared first) to avoid transient `undefined` and preserve focus while typing.
  - New-resource bootstrap seeds per-workspace state without writing `selected`, guarded by `selected in initialStates` for idempotent workspace flips.
  - `onChange` now uses `$state.snapshot(current.args)` so nested arg edits trigger updates and React consumers can diff plain objects.

<sup>Written for commit 74693171b86d31742c2d960db171e0f2049a05e4. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9298?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

