### PR TITLE
fix(jobs): authorization bypass in only_result job updates (WIN-1980)

### DIFF
--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -7217,6 +7217,7 @@ async fn get_job_update(
             None,
             false,
             &mut false,
+            &mut false,
         )
         .await?,
     ))
@@ -7307,6 +7308,10 @@ pub fn start_job_update_sse_stream(
         // Latched once the early_return node's failure is observed alongside a
         // failure_module — subsequent polls then skip the redundant per-node lookup.
         let mut early_return_suppressed = false;
+        // Latched once we've verified the job was created by "anonymous" — for
+        // unauthenticated SSE streams, this gates access and is checked once per
+        // stream rather than once per poll (created_by cannot change).
+        let mut anonymous_verified = false;
 
         // Send initial update immediately
         let mut running = running;
@@ -7331,6 +7336,7 @@ pub fn start_job_update_sse_stream(
             early_return.as_deref(),
             has_failure_module,
             &mut early_return_suppressed,
+            &mut anonymous_verified,
         )
         .await
         {
@@ -7451,6 +7457,7 @@ pub fn start_job_update_sse_stream(
                 early_return.as_deref(),
                 has_failure_module,
                 &mut early_return_suppressed,
+                &mut anonymous_verified,
             )
             .await
             {
@@ -7584,7 +7591,33 @@ async fn get_job_update_data(
     early_return: Option<&str>,
     has_failure_module: bool,
     early_return_suppressed: &mut bool,
+    anonymous_verified: &mut bool,
 ) -> error::Result<JobUpdate> {
+    // Unauthenticated callers may only read jobs whose creator is "anonymous".
+    // The non-only_result branch enforces this via `record.created_by` from its
+    // main query, but the only_result branch below fetches solely the result by
+    // (workspace_id, job_id), so we guard here to cover both paths. The
+    // `anonymous_verified` flag is preserved across SSE poll iterations so the
+    // lookup only happens once per stream — `created_by` cannot change for a
+    // given job once it has been created.
+    if opt_authed.is_none() && !*anonymous_verified {
+        let created_by = sqlx::query_scalar!(
+            "SELECT created_by FROM v2_job WHERE id = $1 AND workspace_id = $2",
+            job_id,
+            w_id,
+        )
+        .fetch_optional(db)
+        .await?
+        .ok_or_else(|| Error::NotFound(format!("Job not found: {}", job_id)))?;
+
+        if created_by != "anonymous" {
+            return Err(Error::BadRequest(
+                "As a non logged in user, you can only see jobs ran by anonymous users".to_string(),
+            ));
+        }
+        *anonymous_verified = true;
+    }
+
     let tags = if log_view {
         log_job_view(
             db,
@@ -7656,23 +7689,6 @@ async fn get_job_update_data(
                     r.stream_job,
                 )
             } else {
-                // `j.created_by` from the LEFT JOIN below gates unauthenticated access —
-                // only jobs created by "anonymous" are readable, matching the non-only_result
-                // branch and adjacent unauthenticated endpoints. Folded into the existing
-                // queries to avoid an extra round-trip on the SSE polling loop.
-                let check_unauthed = |created_by: Option<String>| -> error::Result<()> {
-                    if opt_authed.is_none() {
-                        let created_by = created_by
-                            .ok_or_else(|| Error::NotFound(format!("Job not found: {}", job_id)))?;
-                        if created_by != "anonymous" {
-                            return Err(Error::BadRequest(
-                                "As a non logged in user, you can only see jobs ran by anonymous users"
-                                    .to_string(),
-                            ));
-                        }
-                    }
-                    Ok(())
-                };
                 if running.is_some_and(|x| !x) {
                     let r = sqlx::query!(
                         "
@@ -7690,12 +7706,10 @@ async fn get_job_update_data(
                             jq.running as \"running: Option<bool>\",
                             rs.stream AS \"result_stream: Option<String>\",
                             rs.offset AS stream_offset,
-                            CASE WHEN $4 THEN NULL ELSE (COALESCE(js.flow_status, jc.flow_status)->>'stream_job')::uuid END as stream_job,
-                            j.created_by AS \"created_by?\"
+                            CASE WHEN $4 THEN NULL ELSE (COALESCE(js.flow_status, jc.flow_status)->>'stream_job')::uuid END as stream_job
                         FROM (
                             SELECT $1::uuid as job_id, $2::text as workspace_id
                         ) base
-                        LEFT JOIN v2_job j ON j.id = base.job_id AND j.workspace_id = base.workspace_id
                         LEFT JOIN v2_job_completed jc ON jc.id = base.job_id AND jc.workspace_id = base.workspace_id
                         LEFT JOIN v2_job_queue jq ON jq.id = base.job_id AND jq.workspace_id = base.workspace_id
                         LEFT JOIN v2_job_status js ON js.id = base.job_id
@@ -7706,8 +7720,6 @@ async fn get_job_update_data(
                         stream_offset.unwrap_or(0),
                         ignore_flow_stream_job_id,
                     ).fetch_optional(db).await?;
-                    let created_by = r.as_ref().and_then(|r| r.created_by.clone());
-                    check_unauthed(created_by)?;
                     if let Some(r) = r {
                         let running = r.running.as_ref().map(|x| *x);
                         (
@@ -7737,12 +7749,10 @@ async fn get_job_update_data(
                             rs.stream AS \"result_stream: Option<String>\",
                             rs.offset AS stream_offset,
                             COALESCE(js.flow_status, jc.flow_status) as \"flow_status: sqlx::types::Json<Box<RawValue>>\",
-                            CASE WHEN $4 THEN NULL ELSE (COALESCE(js.flow_status, jc.flow_status)->>'stream_job')::uuid END as stream_job,
-                            j.created_by AS \"created_by?\"
+                            CASE WHEN $4 THEN NULL ELSE (COALESCE(js.flow_status, jc.flow_status)->>'stream_job')::uuid END as stream_job
                         FROM (
                             SELECT $2::uuid as job_id, $1::text as workspace_id
                         ) base
-                        LEFT JOIN v2_job j ON j.id = base.job_id AND j.workspace_id = base.workspace_id
                         LEFT JOIN v2_job_completed jc ON jc.id = base.job_id AND jc.workspace_id = base.workspace_id
                         LEFT JOIN v2_job_status js ON js.id = base.job_id
                         LEFT JOIN result_stream rs ON rs.job_id = base.job_id
@@ -7754,8 +7764,6 @@ async fn get_job_update_data(
                     )
                     .fetch_optional(db)
                     .await?;
-                    let created_by = q.as_ref().and_then(|r| r.created_by.clone());
-                    check_unauthed(created_by)?;
                     if let Some(r) = q {
                         (
                             r.result.map(|x| x.0),

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -7585,27 +7585,6 @@ async fn get_job_update_data(
     has_failure_module: bool,
     early_return_suppressed: &mut bool,
 ) -> error::Result<JobUpdate> {
-    // Unauthenticated callers may only read jobs whose creator is "anonymous".
-    // The non-only_result branch enforces this via `record.created_by` from its
-    // main query, but the only_result branch below fetches solely the result by
-    // (workspace_id, job_id), so we hoist the guard here to cover both paths.
-    if opt_authed.is_none() {
-        let created_by = sqlx::query_scalar!(
-            "SELECT created_by FROM v2_job WHERE id = $1 AND workspace_id = $2",
-            job_id,
-            w_id,
-        )
-        .fetch_optional(db)
-        .await?
-        .ok_or_else(|| Error::NotFound(format!("Job not found: {}", job_id)))?;
-
-        if created_by != "anonymous" {
-            return Err(Error::BadRequest(
-                "As a non logged in user, you can only see jobs ran by anonymous users".to_string(),
-            ));
-        }
-    }
-
     let tags = if log_view {
         log_job_view(
             db,
@@ -7677,6 +7656,23 @@ async fn get_job_update_data(
                     r.stream_job,
                 )
             } else {
+                // `j.created_by` from the LEFT JOIN below gates unauthenticated access —
+                // only jobs created by "anonymous" are readable, matching the non-only_result
+                // branch and adjacent unauthenticated endpoints. Folded into the existing
+                // queries to avoid an extra round-trip on the SSE polling loop.
+                let check_unauthed = |created_by: Option<String>| -> error::Result<()> {
+                    if opt_authed.is_none() {
+                        let created_by = created_by
+                            .ok_or_else(|| Error::NotFound(format!("Job not found: {}", job_id)))?;
+                        if created_by != "anonymous" {
+                            return Err(Error::BadRequest(
+                                "As a non logged in user, you can only see jobs ran by anonymous users"
+                                    .to_string(),
+                            ));
+                        }
+                    }
+                    Ok(())
+                };
                 if running.is_some_and(|x| !x) {
                     let r = sqlx::query!(
                         "
@@ -7694,10 +7690,12 @@ async fn get_job_update_data(
                             jq.running as \"running: Option<bool>\",
                             rs.stream AS \"result_stream: Option<String>\",
                             rs.offset AS stream_offset,
-                            CASE WHEN $4 THEN NULL ELSE (COALESCE(js.flow_status, jc.flow_status)->>'stream_job')::uuid END as stream_job
+                            CASE WHEN $4 THEN NULL ELSE (COALESCE(js.flow_status, jc.flow_status)->>'stream_job')::uuid END as stream_job,
+                            j.created_by AS \"created_by?\"
                         FROM (
                             SELECT $1::uuid as job_id, $2::text as workspace_id
                         ) base
+                        LEFT JOIN v2_job j ON j.id = base.job_id AND j.workspace_id = base.workspace_id
                         LEFT JOIN v2_job_completed jc ON jc.id = base.job_id AND jc.workspace_id = base.workspace_id
                         LEFT JOIN v2_job_queue jq ON jq.id = base.job_id AND jq.workspace_id = base.workspace_id
                         LEFT JOIN v2_job_status js ON js.id = base.job_id
@@ -7708,6 +7706,8 @@ async fn get_job_update_data(
                         stream_offset.unwrap_or(0),
                         ignore_flow_stream_job_id,
                     ).fetch_optional(db).await?;
+                    let created_by = r.as_ref().and_then(|r| r.created_by.clone());
+                    check_unauthed(created_by)?;
                     if let Some(r) = r {
                         let running = r.running.as_ref().map(|x| *x);
                         (
@@ -7737,10 +7737,12 @@ async fn get_job_update_data(
                             rs.stream AS \"result_stream: Option<String>\",
                             rs.offset AS stream_offset,
                             COALESCE(js.flow_status, jc.flow_status) as \"flow_status: sqlx::types::Json<Box<RawValue>>\",
-                            CASE WHEN $4 THEN NULL ELSE (COALESCE(js.flow_status, jc.flow_status)->>'stream_job')::uuid END as stream_job
+                            CASE WHEN $4 THEN NULL ELSE (COALESCE(js.flow_status, jc.flow_status)->>'stream_job')::uuid END as stream_job,
+                            j.created_by AS \"created_by?\"
                         FROM (
                             SELECT $2::uuid as job_id, $1::text as workspace_id
                         ) base
+                        LEFT JOIN v2_job j ON j.id = base.job_id AND j.workspace_id = base.workspace_id
                         LEFT JOIN v2_job_completed jc ON jc.id = base.job_id AND jc.workspace_id = base.workspace_id
                         LEFT JOIN v2_job_status js ON js.id = base.job_id
                         LEFT JOIN result_stream rs ON rs.job_id = base.job_id
@@ -7752,6 +7754,8 @@ async fn get_job_update_data(
                     )
                     .fetch_optional(db)
                     .await?;
+                    let created_by = q.as_ref().and_then(|r| r.created_by.clone());
+                    check_unauthed(created_by)?;
                     if let Some(r) = q {
                         (
                             r.result.map(|x| x.0),

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -7593,31 +7593,6 @@ async fn get_job_update_data(
     early_return_suppressed: &mut bool,
     anonymous_verified: &mut bool,
 ) -> error::Result<JobUpdate> {
-    // Unauthenticated callers may only read jobs whose creator is "anonymous".
-    // The non-only_result branch enforces this via `record.created_by` from its
-    // main query, but the only_result branch below fetches solely the result by
-    // (workspace_id, job_id), so we guard here to cover both paths. The
-    // `anonymous_verified` flag is preserved across SSE poll iterations so the
-    // lookup only happens once per stream — `created_by` cannot change for a
-    // given job once it has been created.
-    if opt_authed.is_none() && !*anonymous_verified {
-        let created_by = sqlx::query_scalar!(
-            "SELECT created_by FROM v2_job WHERE id = $1 AND workspace_id = $2",
-            job_id,
-            w_id,
-        )
-        .fetch_optional(db)
-        .await?
-        .ok_or_else(|| Error::NotFound(format!("Job not found: {}", job_id)))?;
-
-        if created_by != "anonymous" {
-            return Err(Error::BadRequest(
-                "As a non logged in user, you can only see jobs ran by anonymous users".to_string(),
-            ));
-        }
-        *anonymous_verified = true;
-    }
-
     let tags = if log_view {
         log_job_view(
             db,
@@ -7638,6 +7613,32 @@ async fn get_job_update_data(
     let ignore_flow_stream_job_id = is_flow.is_some_and(|x| !x) || flow_stream_job_id.is_some();
 
     if only_result.unwrap_or(false) {
+        // Unauthenticated callers may only read jobs whose creator is "anonymous".
+        // The non-only_result branch enforces this via `record.created_by` from its
+        // main query, but the only_result branch below fetches solely the result by
+        // (workspace_id, job_id), so we guard here to close the gap. The
+        // `anonymous_verified` flag is preserved across SSE poll iterations so the
+        // lookup only happens once per stream — `created_by` cannot change for a
+        // given job once it has been created.
+        if opt_authed.is_none() && !*anonymous_verified {
+            let created_by = sqlx::query_scalar!(
+                "SELECT created_by FROM v2_job WHERE id = $1 AND workspace_id = $2",
+                job_id,
+                w_id,
+            )
+            .fetch_optional(db)
+            .await?
+            .ok_or_else(|| Error::NotFound(format!("Job not found: {}", job_id)))?;
+
+            if created_by != "anonymous" {
+                return Err(Error::BadRequest(
+                    "As a non logged in user, you can only see jobs ran by anonymous users"
+                        .to_string(),
+                ));
+            }
+            *anonymous_verified = true;
+        }
+
         let (result, running, mut result_stream, mut new_stream_offset, new_flow_stream_job_id) =
             if let Some(tags) = tags {
                 let r = sqlx::query!(

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -7585,6 +7585,27 @@ async fn get_job_update_data(
     has_failure_module: bool,
     early_return_suppressed: &mut bool,
 ) -> error::Result<JobUpdate> {
+    // Unauthenticated callers may only read jobs whose creator is "anonymous".
+    // The non-only_result branch enforces this via `record.created_by` from its
+    // main query, but the only_result branch below fetches solely the result by
+    // (workspace_id, job_id), so we hoist the guard here to cover both paths.
+    if opt_authed.is_none() {
+        let created_by = sqlx::query_scalar!(
+            "SELECT created_by FROM v2_job WHERE id = $1 AND workspace_id = $2",
+            job_id,
+            w_id,
+        )
+        .fetch_optional(db)
+        .await?
+        .ok_or_else(|| Error::NotFound(format!("Job not found: {}", job_id)))?;
+
+        if created_by != "anonymous" {
+            return Err(Error::BadRequest(
+                "As a non logged in user, you can only see jobs ran by anonymous users".to_string(),
+            ));
+        }
+    }
+
     let tags = if log_view {
         log_job_view(
             db,


### PR DESCRIPTION
## Summary

Fixes an unauthenticated authorization bypass 

The public `jobs_u/getupdate/{id}` and `jobs_u/getupdate_sse/{id}` endpoints accept `only_result=true`. In that branch, `get_job_update_data` previously fetched the job result by `(workspace_id, job_id)` and skipped the `created_by == "anonymous"` check that the non-`only_result` path and adjacent unauthenticated endpoints (`get_completed_job_result`, etc.) apply. An unauthenticated caller who learned a private job UUID could retrieve that job's output — which may contain user data, third-party API responses, or secrets.

The fix hoists the guard to the top of `get_job_update_data` so both branches are covered with a single lookup of `v2_job.created_by`.

Fixes WIN-1980

## Test plan

Reproduced against the running dev instance (workspace `test`, job created by `admin`):

- [x] `GET /api/w/test/jobs_u/getupdate/{id}?only_result=true` (unauthed, non-anon job) → before fix returned the result; after fix returns `Bad request: As a non logged in user, you can only see jobs ran by anonymous users`
- [x] `GET /api/w/test/jobs_u/getupdate/{id}` (unauthed, non-anon job) — still correctly denied (regression check)
- [x] After flipping the job's `created_by` to `anonymous` in `v2_job`, the unauthed `only_result=true` call returns the result as expected
- [x] Unauthed `only_result=true` for a non-existent job returns `Not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an auth bypass that let unauthenticated users read private job results via `only_result=true` on `jobs_u/getupdate/{id}` and `jobs_u/getupdate_sse/{id}`. Unauthenticated calls now work only for jobs created by `anonymous`, with the check verified once per SSE stream (WIN-1980).

- **Bug Fixes**
  - Scoped the `created_by == "anonymous"` guard to the `only_result` branch of `get_job_update_data` and added an `anonymous_verified` SSE latch, so both `only_result` paths enforce the rule without duplicating checks in the default path.
  - Behavior: unauthenticated requests for non-anonymous jobs now fail; anonymous jobs still work. Performance: authenticated calls unchanged; unauth one-shot adds one query; unauth SSE does one query at stream start, none per poll.

<sup>Written for commit 5b9b45fb8fa8d6e2051b3e7ba83a1043e5118d0d. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9301?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



