### PR TITLE
fix(auth): filter resource/variable listings by token scope (WIN-1981)

### DIFF
--- a/backend/windmill-api-auth/src/lib.rs
+++ b/backend/windmill-api-auth/src/lib.rs
@@ -235,6 +235,50 @@ where
     Ok(())
 }
 
+/// Returns a predicate that checks whether `path` is within the token's
+/// scope for `{domain}:{action}:{path}`. For tokens without scope
+/// restrictions (no scopes at all, or only `if_jobs:filter_tags:*` scopes),
+/// the predicate always returns `true`.
+///
+/// Pre-parses the token's scopes once so the returned closure can cheaply
+/// filter large listings without re-parsing on each call.
+pub fn build_scope_path_predicate(
+    authed: &ApiAuthed,
+    domain: &str,
+    action: &str,
+) -> impl Fn(&str) -> bool {
+    // Mirror check_scopes semantics: a token is "scope-restricted" iff it has
+    // at least one non-`if_jobs:filter_tags:` scope. Unparseable scopes still
+    // count as restrictive — they just match nothing.
+    let (is_scoped_token, parsed): (bool, Vec<ScopeDefinition>) = match authed.scopes.as_ref() {
+        Some(scopes) => {
+            let mut is_scoped = false;
+            let parsed = scopes
+                .iter()
+                .filter(|s| !s.starts_with("if_jobs:filter_tags:"))
+                .inspect(|_| is_scoped = true)
+                .filter_map(|s| ScopeDefinition::from_scope_string(s).ok())
+                .collect();
+            (is_scoped, parsed)
+        }
+        None => (false, Vec::new()),
+    };
+    let domain = domain.to_string();
+    let action = action.to_string();
+
+    move |path: &str| -> bool {
+        if !is_scoped_token {
+            return true;
+        }
+        let required =
+            match ScopeDefinition::from_scope_string(&format!("{}:{}:{}", domain, action, path)) {
+                Ok(r) => r,
+                Err(_) => return false,
+            };
+        parsed.iter().any(|s| s.includes(&required))
+    }
+}
+
 pub async fn require_devops_role(db: &DB, email: &str) -> error::Result<()> {
     let is_devops = is_devops_email(db, email).await?;
 
@@ -801,5 +845,67 @@ pub fn require_path_read_access_for_preview(
             "Invalid path format for preview job: {}. Path must start with 'u/' or 'f/'",
             path
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn authed_with_scopes(scopes: Option<Vec<&str>>) -> ApiAuthed {
+        ApiAuthed {
+            scopes: scopes.map(|v| v.into_iter().map(String::from).collect()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn predicate_no_scopes_allows_all() {
+        let authed = authed_with_scopes(None);
+        let allowed = build_scope_path_predicate(&authed, "resources", "read");
+        assert!(allowed("u/alice/anything"));
+        assert!(allowed("u/bob/other"));
+    }
+
+    #[test]
+    fn predicate_tag_filter_only_allows_all() {
+        let authed = authed_with_scopes(Some(vec!["if_jobs:filter_tags:default"]));
+        let allowed = build_scope_path_predicate(&authed, "resources", "read");
+        assert!(allowed("u/alice/foo"));
+    }
+
+    #[test]
+    fn predicate_single_resource_scope_filters_others() {
+        // Regression test for WIN-1981: a token scoped to one resource must
+        // not match unrelated paths in listings (e.g. /resources/list_search).
+        let authed = authed_with_scopes(Some(vec!["resources:read:u/alice/allowed_resource"]));
+        let allowed = build_scope_path_predicate(&authed, "resources", "read");
+        assert!(allowed("u/alice/allowed_resource"));
+        assert!(!allowed("u/alice/other_resource"));
+        assert!(!allowed("u/bob/foo"));
+    }
+
+    #[test]
+    fn predicate_wildcard_scope_matches_subtree() {
+        let authed = authed_with_scopes(Some(vec!["resources:read:f/team/*"]));
+        let allowed = build_scope_path_predicate(&authed, "resources", "read");
+        assert!(allowed("f/team/db"));
+        assert!(allowed("f/team/sub/nested"));
+        assert!(!allowed("f/other/db"));
+    }
+
+    #[test]
+    fn predicate_wrong_domain_is_rejected() {
+        let authed = authed_with_scopes(Some(vec!["variables:read:u/alice/secret"]));
+        let allowed = build_scope_path_predicate(&authed, "resources", "read");
+        assert!(!allowed("u/alice/secret"));
+    }
+
+    #[test]
+    fn predicate_write_implies_read() {
+        let authed = authed_with_scopes(Some(vec!["resources:write:u/alice/foo"]));
+        let allowed = build_scope_path_predicate(&authed, "resources", "read");
+        assert!(allowed("u/alice/foo"));
+        assert!(!allowed("u/alice/bar"));
     }
 }

--- a/backend/windmill-store/src/resources.rs
+++ b/backend/windmill-store/src/resources.rs
@@ -10,8 +10,8 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 
 use windmill_api_auth::{
-    check_scopes, maybe_refresh_folders, require_owner_of_path, require_super_admin, ApiAuthed,
-    Tokened,
+    build_scope_path_predicate, check_scopes, maybe_refresh_folders, require_owner_of_path,
+    require_super_admin, ApiAuthed, Tokened,
 };
 use windmill_common::db::DB;
 use windmill_common::workspaces::{check_deploy_rules, RuleCheckResult};
@@ -194,6 +194,7 @@ async fn list_names(
     Extension(user_db): Extension<UserDB>,
 ) -> JsonResult<Vec<NamePath>> {
     let mut tx = user_db.begin(&authed).await?;
+    let allowed = build_scope_path_predicate(&authed, "resources", "read");
     let rows = sqlx::query!(
         "SELECT value->>'name' as name, path from resource WHERE resource_type = $1 AND workspace_id = $2",
         rt,
@@ -203,6 +204,7 @@ async fn list_names(
     .await?
     .into_iter()
     .filter_map(|x| x.name.map(|name| NamePath { name, path: x.path }))
+    .filter(|np| allowed(&np.path))
     .collect::<Vec<_>>();
     tx.commit().await?;
     Ok(Json(rows))
@@ -225,6 +227,7 @@ async fn list_search_resources(
     #[cfg(not(feature = "enterprise"))]
     let n = 3;
 
+    let allowed = build_scope_path_predicate(&authed, "resources", "read");
     let rows = sqlx::query_as!(
         SearchResource,
         "SELECT path, value from resource WHERE workspace_id = $1 LIMIT $2",
@@ -234,6 +237,7 @@ async fn list_search_resources(
     .fetch_all(&mut *tx)
     .await?
     .into_iter()
+    .filter(|r| allowed(&r.path))
     .collect::<Vec<_>>();
     tx.commit().await?;
     Ok(Json(rows))
@@ -338,9 +342,13 @@ async fn list_resources(
 
     let sql = sqlb.sql().map_err(|e| Error::internal_err(e.to_string()))?;
     let mut tx = user_db.begin(&authed).await?;
+    let allowed = build_scope_path_predicate(&authed, "resources", "read");
     let rows = sqlx::query_as::<_, ListableResource>(&sql)
         .fetch_all(&mut *tx)
-        .await?;
+        .await?
+        .into_iter()
+        .filter(|r| allowed(&r.path))
+        .collect::<Vec<_>>();
 
     tx.commit().await?;
 

--- a/backend/windmill-store/src/variables.rs
+++ b/backend/windmill-store/src/variables.rs
@@ -6,7 +6,10 @@
  * LICENSE-AGPL for a copy of the license.
  */
 
-use windmill_api_auth::{check_scopes, maybe_refresh_folders, require_owner_of_path, ApiAuthed};
+use windmill_api_auth::{
+    build_scope_path_predicate, check_scopes, maybe_refresh_folders, require_owner_of_path,
+    ApiAuthed,
+};
 use windmill_common::db::DB;
 use windmill_common::workspaces::{check_deploy_rules, RuleCheckResult};
 
@@ -188,9 +191,13 @@ async fn list_variables(
 
     let sql = sqlb.sql().map_err(|e| Error::internal_err(e.to_string()))?;
     let mut tx = user_db.begin(&authed).await?;
+    let allowed = build_scope_path_predicate(&authed, "variables", "read");
     let rows = sqlx::query_as::<_, ListableVariable>(&sql)
         .fetch_all(&mut *tx)
-        .await?;
+        .await?
+        .into_iter()
+        .filter(|r| allowed(&r.path))
+        .collect::<Vec<_>>();
 
     tx.commit().await?;
     Ok(Json(rows))


### PR DESCRIPTION
## Summary

A token scoped to a single resource (e.g. `resources:read:u/alice/allowed_resource`) could call:

```http
GET /api/w/{workspace_id}/resources/list_search
Authorization: Bearer <resource-scoped-token>
```

and receive `path` and `value` for **unrelated** resources in the workspace — leaking integration credentials, API keys, database connection strings, and other secrets stored as resource values. Route-level scope authorization only validates `domain:action`, and the per-resource handlers (`get_resource`, `get_resource_value`, …) do enforce `check_scopes(... format!("resources:read:{path}"))`, but `list_search_resources` / `list_resources` / `list_names` did not — so listings ignored the resource-level restriction entirely. The same class of bug existed for `list_variables` (non-secret values).

Fixes WIN-1981.

## Fix

- Add `build_scope_path_predicate(authed, domain, action)` to `windmill-api-auth`. It mirrors `check_scopes` semantics but parses the token's scopes once and returns a closure suitable for filtering many rows.
  - Unscoped tokens → predicate always `true` (no behavior change).
  - Tokens whose only scopes are `if_jobs:filter_tags:*` → also always `true` (consistent with `check_scopes`).
  - Scope-restricted tokens → row is kept only if a token scope `includes` `{domain}:{action}:{row_path}`.
- Apply the predicate to `list_search_resources`, `list_resources`, `list_names` (resources) and `list_variables` (variables).

## Test plan

- [x] Unit tests in `backend/windmill-api-auth/src/lib.rs`: unscoped, tag-filter-only, single-resource (regression for the reported case), wildcard subtree, wrong-domain, write-implies-read — all pass (`cargo test -p windmill-api-auth --lib tests::`).
- [x] `cargo check -p windmill-store` (CE + `--features enterprise`) — clean.
- [x] Backend dev server (cargo watch) recompiles cleanly and `health check completed status="healthy"`.
- [ ] Manual e2e with a resource-scoped token against `/list_search` — happy to add an integration test if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts resource and variable listing endpoints to the token’s path scope to prevent leaking unrelated secrets. Addresses WIN-1981; scoped tokens now only see authorized paths.

- **Bug Fixes**
  - Added `build_scope_path_predicate` in `windmill-api-auth` to mirror `check_scopes` and efficiently filter listings by `{domain}:{action}:{path}`.
  - Applied filtering to `list_search_resources`, `list_resources`, `list_names` (resources) and `list_variables` (variables) in `windmill-store`.
  - Unscoped tokens and `if_jobs:filter_tags:*`-only tokens remain unaffected.

<sup>Written for commit 493f5de975672431a4dd3153b3f2c5783d024ce9. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9302?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

