### PR TITLE
fix(settings): skip workspaced-route duplicate checks on cloud

### DIFF
--- a/backend/windmill-api-settings/src/lib.rs
+++ b/backend/windmill-api-settings/src/lib.rs
@@ -59,7 +59,7 @@ use windmill_common::{
     instance_config::{self, ApplyMode, InstanceConfig},
     server::Smtp,
 };
-use windmill_common::{error::to_anyhow, PgDatabase};
+use windmill_common::{error::to_anyhow, worker::CLOUD_HOSTED, PgDatabase};
 
 /// Unauthenticated settings routes.
 ///
@@ -545,7 +545,10 @@ async fn run_setting_pre_write_hook(
                 )));
             };
 
-            if !*workspaced_route {
+            // Cloud always scopes app custom paths by workspace_id (see
+            // `custom_path_exists` in apps.rs), so duplicates across workspaces
+            // are expected and this setting has no runtime effect on cloud.
+            if !*workspaced_route && !*CLOUD_HOSTED {
                 #[derive(Debug, Deserialize, Serialize)]
                 #[allow(unused)]
                 struct DuplicateApp {
@@ -608,7 +611,11 @@ async fn run_setting_pre_write_hook(
                 )));
             };
 
-            if !*workspaced_route {
+            // Cloud always scopes routes by workspace_id (see
+            // `route_path_key_exists` in windmill-trigger-http), so duplicates
+            // across workspaces are expected and this setting has no runtime
+            // effect on cloud.
+            if !*workspaced_route && !*CLOUD_HOSTED {
                 #[derive(Debug, Deserialize, Serialize)]
                 #[allow(unused)]
                 struct DuplicateRoute {

--- a/backend/windmill-common/src/error.rs
+++ b/backend/windmill-common/src/error.rs
@@ -370,3 +370,53 @@ where
         Self(err.into())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn json_err_message_error_and_details() {
+        let v = json!({
+            "error": "Duplicate HTTP route paths detected",
+            "details": [
+                { "route_path": "a", "workspace_id": "admins", "http_method": "post" },
+                { "route_path": "a", "workspace_id": "starter", "http_method": "post" },
+            ],
+        });
+        let rendered = Error::JsonErr(v).to_string();
+        assert_eq!(
+            rendered,
+            "Duplicate HTTP route paths detected\n\
+             - route_path=a, workspace_id=admins, http_method=post\n\
+             - route_path=a, workspace_id=starter, http_method=post"
+        );
+    }
+
+    #[test]
+    fn json_err_message_error_only() {
+        let v = json!({ "error": "Something went wrong" });
+        assert_eq!(Error::JsonErr(v).to_string(), "Something went wrong");
+    }
+
+    #[test]
+    fn json_err_message_truncates_long_details() {
+        let details: Vec<_> = (0..8).map(|i| json!({ "k": i })).collect();
+        let v = json!({ "error": "boom", "details": details });
+        let rendered = Error::JsonErr(v).to_string();
+        assert!(rendered.starts_with("boom\n- k=0\n- k=1\n- k=2\n- k=3\n- k=4"));
+        assert!(rendered.ends_with("... (3 more)"));
+        // Items beyond the cap aren't enumerated.
+        assert!(!rendered.contains("- k=5"));
+    }
+
+    #[test]
+    fn json_err_message_fallback_to_pretty_json() {
+        let v = json!([1, 2, 3]);
+        // Non-object payload falls back to pretty JSON instead of leaking
+        // Rust `Debug` syntax.
+        let rendered = Error::JsonErr(v).to_string();
+        assert_eq!(rendered, "[\n  1,\n  2,\n  3\n]");
+    }
+}

--- a/backend/windmill-common/src/error.rs
+++ b/backend/windmill-common/src/error.rs
@@ -72,7 +72,7 @@ pub enum Error {
     ExecutionRawError(Box<serde_json::value::RawValue>),
     #[error("Error: {error:#} @{location:#}")]
     Anyhow { error: anyhow::Error, location: String },
-    #[error("Error: {0:#?}")]
+    #[error("{}", format_json_err_message(.0))]
     JsonErr(serde_json::Value),
     #[error("{0}")]
     AIError(String),
@@ -256,6 +256,7 @@ impl IntoResponse for Error {
             Self::SqlErr { .. }
             | Self::BadRequest(_)
             | Self::AIError(_)
+            | Self::JsonErr(_)
             | Self::QuotaExceeded(_) => axum::http::StatusCode::BAD_REQUEST,
             Self::BadGateway(_) => axum::http::StatusCode::BAD_GATEWAY,
             Self::Generic(status_code, _) => status_code,
@@ -278,6 +279,59 @@ impl IntoResponse for Error {
             .body(body)
             .unwrap()
     }
+}
+
+/// Render a `JsonErr` payload as a readable message suitable for direct
+/// display in a toast: surface the `error` field as the headline, append a
+/// short summary of `details` (e.g. duplicate paths) when present, and fall
+/// back to pretty JSON for unknown shapes. Avoids the Rust `Debug` output
+/// (`Object { "error": String("..."), ... }`) that previously leaked to users.
+fn format_json_err_message(v: &serde_json::Value) -> String {
+    if let Some(obj) = v.as_object() {
+        let headline = obj
+            .get("error")
+            .and_then(|e| e.as_str())
+            .map(|s| s.to_string());
+        let details_summary = obj.get("details").and_then(|d| {
+            let arr = d.as_array()?;
+            if arr.is_empty() {
+                return None;
+            }
+            let preview = arr
+                .iter()
+                .take(5)
+                .map(|item| match item {
+                    serde_json::Value::Object(o) => {
+                        let parts: Vec<String> = o
+                            .iter()
+                            .map(|(k, val)| match val {
+                                serde_json::Value::String(s) => format!("{k}={s}"),
+                                _ => format!("{k}={val}"),
+                            })
+                            .collect();
+                        format!("- {}", parts.join(", "))
+                    }
+                    serde_json::Value::String(s) => format!("- {s}"),
+                    other => format!("- {other}"),
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            let suffix = if arr.len() > 5 {
+                format!("\n... ({} more)", arr.len() - 5)
+            } else {
+                String::new()
+            };
+            Some(format!("{preview}{suffix}"))
+        });
+
+        match (headline, details_summary) {
+            (Some(h), Some(d)) => return format!("{h}\n{d}"),
+            (Some(h), None) => return h,
+            (None, Some(d)) => return d,
+            (None, None) => {}
+        }
+    }
+    serde_json::to_string_pretty(v).unwrap_or_else(|_| v.to_string())
 }
 
 pub trait OrElseNotFound<T> {

--- a/frontend/src/lib/components/toast.ts
+++ b/frontend/src/lib/components/toast.ts
@@ -1,12 +1,27 @@
 const pathRegex = /\b(u|f)(\/[^\/\s]+){2,}\b/g
 
+function escapeHtml(s: string): string {
+	return s
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&#39;')
+}
+
 export function processMessage(message: string | undefined): string {
 	let msg = !message
 		? 'Error without message'
 		: typeof message != 'string'
 			? JSON.stringify(message, null, 2)
 			: message
-	return msg.replaceAll(pathRegex, (path) => {
+	// Preserve newlines: the toast renders via {@html}, where consecutive
+	// whitespace (including \n) collapses to a single space. Escape the raw
+	// message first to avoid injecting HTML from server-side error bodies,
+	// then convert \n to <br /> so multi-line errors stay readable.
+	const hasNewline = msg.includes('\n')
+	let html = hasNewline ? escapeHtml(msg).replaceAll('\n', '<br />') : msg
+	return html.replaceAll(pathRegex, (path) => {
 		return `<span class="bg-surface-secondary p-1 text-xs font-mono whitespace-nowrap rounded-md">${path}</span>`
 	})
 }

--- a/frontend/src/lib/components/toast.ts
+++ b/frontend/src/lib/components/toast.ts
@@ -15,12 +15,13 @@ export function processMessage(message: string | undefined): string {
 		: typeof message != 'string'
 			? JSON.stringify(message, null, 2)
 			: message
-	// Preserve newlines: the toast renders via {@html}, where consecutive
-	// whitespace (including \n) collapses to a single space. Escape the raw
-	// message first to avoid injecting HTML from server-side error bodies,
-	// then convert \n to <br /> so multi-line errors stay readable.
-	const hasNewline = msg.includes('\n')
-	let html = hasNewline ? escapeHtml(msg).replaceAll('\n', '<br />') : msg
+	// Toast renders via {@html}, so escape unconditionally — server error
+	// bodies can contain arbitrary content (e.g. `<` from a SQL fragment in
+	// an error message), and the path regex below only ever inserts a safe
+	// `<span>` around a `u/...` or `f/...` capture that itself cannot match
+	// any HTML metacharacter. Convert `\n` to `<br />` so multi-line errors
+	// stay readable in the toast (without this, HTML collapses newlines).
+	let html = escapeHtml(msg).replaceAll('\n', '<br />')
 	return html.replaceAll(pathRegex, (path) => {
 		return `<span class="bg-surface-secondary p-1 text-xs font-mono whitespace-nowrap rounded-md">${path}</span>`
 	})


### PR DESCRIPTION
## Summary

Fixes WIN-1983.

Cloud super-admins were unable to save instance settings: any save would return

```
{
  "error": "Duplicate HTTP route paths detected",
  "details": [{ "route_path": "...", "workspace_id": "...", "http_method": "..." }, ...]
}
```

and the toast showed an `Internal Server Error` 500 with a wall of Rust `Debug` output (`Object { "error": String(...), ... }`).

## Root cause

The pre-write validation hooks in `backend/windmill-api-settings/src/lib.rs` for `APP_WORKSPACED_ROUTE_SETTING` and `HTTP_ROUTE_WORKSPACED_ROUTE_SETTING` query the DB for cross-workspace duplicates and refuse to write `false`. On cloud, however, the runtime route/app-path lookups (`route_path_key_exists` in `windmill-trigger-http/src/handler.rs`, `custom_path_exists` in `windmill-api/src/apps.rs`) are already hard-coded to scope by `workspace_id` regardless of these settings — so duplicates across workspaces are expected on cloud and the validation has no runtime meaning. When the bulk `set_instance_config` endpoint computed a diff that included one of these keys with `false`, the hook fired and blocked the entire save.

Separately, `Error::JsonErr` rendered via `#[error("Error: {0:#?}")]`, leaking Rust's `Debug` syntax into the response body, and fell through to the catch-all 500 branch in `IntoResponse`.

## Fix

1. **`fix(settings)`** — Short-circuit the duplicate check when `CLOUD_HOSTED` is true. The value still writes to `global_settings`, but the spurious validation no longer fires.
2. **`fix(error)`** — `JsonErr` now returns **400 Bad Request** (every current call site is a client/validation error) and renders the JSON payload as readable text: the `error` field becomes the headline, `details` entries are summarised as `- key=value` lines, and unknown shapes fall back to pretty JSON. The frontend toast now reads:

   ```
   Duplicate HTTP route paths detected
   - route_path=a, workspace_id=admins, http_method=post
   - route_path=a, workspace_id=starter, http_method=post
   ```

## Test plan

- [x] Backend rebuilds cleanly
- [x] Verified locally with seeded duplicate `http_trigger` rows: `POST /api/settings/global/http_route_workspaced_route {"value": false}` returns 400 + readable body
- [ ] Validate on a cloud-mode instance: with duplicate routes/apps across workspaces, saving instance settings with `http_route_workspaced_route: false` and/or `app_workspaced_route: false` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)