### PR TITLE
fix(auth): require workspace membership for g/ owner tokens (WIN-1986)

### DIFF
--- a/backend/.sqlx/query-ce9492ecccdcf4747990a94208dc54efefdeb8261142cc75010a51f209c099a2.json
+++ b/backend/.sqlx/query-ce9492ecccdcf4747990a94208dc54efefdeb8261142cc75010a51f209c099a2.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS(\n                                                    SELECT 1 FROM group_\n                                                    WHERE workspace_id = $1 AND name = $2\n                                                ) AND EXISTS(\n                                                    SELECT 1 FROM usr\n                                                    WHERE workspace_id = $1\n                                                      AND email = $3\n                                                      AND disabled = false\n                                                )",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "?column?",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "ce9492ecccdcf4747990a94208dc54efefdeb8261142cc75010a51f209c099a2"
+}

--- a/backend/windmill-api-auth/src/auth.rs
+++ b/backend/windmill-api-auth/src/auth.rs
@@ -302,18 +302,10 @@ impl AuthCache {
                                             None
                                         }
                                     } else if prefix == "g" {
-                                        // Checking that the group exists in the
-                                        // target workspace is necessary but not
-                                        // sufficient: the `all` group is
-                                        // provisioned in every workspace, so an
-                                        // attacker with token-table write access
-                                        // could pair owner=g/all with any
-                                        // workspace_id and authenticate as a
-                                        // group user there without being a
-                                        // workspace member. Additionally require
-                                        // that the token holder (by email) is a
-                                        // non-disabled member of the target
-                                        // workspace, mirroring the u/ branch.
+                                        // Group existence alone is not enough: `all` exists in every
+                                        // workspace, so owner=g/all would otherwise authenticate any
+                                        // forged token against any workspace. Also require the email
+                                        // to be a workspace member (WIN-1986).
                                         let group_check = if super_admin {
                                             true
                                         } else {

--- a/backend/windmill-api-auth/src/auth.rs
+++ b/backend/windmill-api-auth/src/auth.rs
@@ -302,13 +302,34 @@ impl AuthCache {
                                             None
                                         }
                                     } else if prefix == "g" {
-                                        let group_exists = if super_admin {
+                                        // Checking that the group exists in the
+                                        // target workspace is necessary but not
+                                        // sufficient: the `all` group is
+                                        // provisioned in every workspace, so an
+                                        // attacker with token-table write access
+                                        // could pair owner=g/all with any
+                                        // workspace_id and authenticate as a
+                                        // group user there without being a
+                                        // workspace member. Additionally require
+                                        // that the token holder (by email) is a
+                                        // non-disabled member of the target
+                                        // workspace, mirroring the u/ branch.
+                                        let group_check = if super_admin {
                                             true
                                         } else {
                                             sqlx::query_scalar!(
-                                                "SELECT EXISTS(SELECT 1 FROM group_ WHERE workspace_id = $1 AND name = $2)",
+                                                "SELECT EXISTS(
+                                                    SELECT 1 FROM group_
+                                                    WHERE workspace_id = $1 AND name = $2
+                                                ) AND EXISTS(
+                                                    SELECT 1 FROM usr
+                                                    WHERE workspace_id = $1
+                                                      AND email = $3
+                                                      AND disabled = false
+                                                )",
                                                 &w_id.as_ref().unwrap(),
                                                 name,
+                                                &email,
                                             )
                                             .fetch_one(&self.db)
                                             .await
@@ -317,7 +338,7 @@ impl AuthCache {
                                             .unwrap_or(false)
                                         };
 
-                                        if group_exists {
+                                        if group_check {
                                             let groups = vec![name.to_string()];
                                             let folders = get_folders_for_user(
                                                 &w_id.unwrap(),
@@ -345,7 +366,7 @@ impl AuthCache {
                                             })
                                         } else {
                                             tracing::warn!(
-                                                "Token owner g/{} is not a group in workspace {}; rejecting auth",
+                                                "Token owner g/{} is not a valid group/workspace-member combination for workspace {}; rejecting auth",
                                                 name,
                                                 w_id.as_deref().unwrap_or("")
                                             );

--- a/backend/windmill-api-integration-tests/tests/permissions.rs
+++ b/backend/windmill-api-integration-tests/tests/permissions.rs
@@ -854,3 +854,79 @@ async fn test_operator_cannot_create_update(db: Pool<Postgres>) -> anyhow::Resul
 
     Ok(())
 }
+
+/// Regression test for WIN-1986: WIN-1978's `g/<groupname>` fix only
+/// validated that the group exists in the target workspace, but the
+/// default `all` group is provisioned in every workspace. An attacker
+/// with token-table write access could therefore pair `owner=g/all` with
+/// any workspace_id and authenticate as a group user there without being
+/// a workspace member. The fix additionally requires the token holder's
+/// email to be a non-disabled member of the target workspace.
+#[ignore]
+#[cfg(feature = "deno_core")]
+#[sqlx::test(migrations = "../migrations", fixtures("base", "permissions_test"))]
+async fn test_forged_g_all_owner_rejects_non_member(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base_url = format!("http://localhost:{}/api", port);
+
+    // The `all` group is provisioned for `test-workspace` by base.sql,
+    // matching production behaviour. Insert a token whose email is NOT
+    // a member of `test-workspace`, with owner=g/all and workspace_id
+    // pointing at the target workspace. This simulates an attacker who
+    // mutated the `token` table to forge cross-workspace access.
+    let forged_token = "FORGED_GALL_NONMEMBER";
+    let forged_hash = windmill_common::utils::calculate_hash(forged_token);
+    let forged_prefix = &forged_token[..10.min(forged_token.len())];
+    sqlx::query!(
+        "INSERT INTO token (token_hash, token_prefix, email, label, super_admin, owner, workspace_id)
+         VALUES ($1, $2, 'outsider@example.com', 'forged-gall', false, 'g/all', 'test-workspace')",
+        forged_hash,
+        forged_prefix,
+    )
+    .execute(&db)
+    .await?;
+
+    let client = create_client_for_user(port, forged_token).await;
+    let resp = client
+        .get(&format!("{base_url}/w/test-workspace/scripts/list"))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status() == reqwest::StatusCode::UNAUTHORIZED
+            || resp.status() == reqwest::StatusCode::FORBIDDEN,
+        "Forged g/all owner with non-member email must be rejected against test-workspace; got {}",
+        resp.status()
+    );
+
+    // Legitimate sanity check: a g/<group> token whose email IS a
+    // workspace member should still authenticate. Alice is in
+    // test-workspace per the permissions_test fixture.
+    let alice_gall_token = "ALICE_GALL_TOKEN_OK";
+    let alice_gall_hash = windmill_common::utils::calculate_hash(alice_gall_token);
+    let alice_gall_prefix = &alice_gall_token[..10.min(alice_gall_token.len())];
+    sqlx::query!(
+        "INSERT INTO token (token_hash, token_prefix, email, label, super_admin, owner, workspace_id)
+         VALUES ($1, $2, 'alice@windmill.dev', 'gall-ok', false, 'g/all', 'test-workspace')",
+        alice_gall_hash,
+        alice_gall_prefix,
+    )
+    .execute(&db)
+    .await?;
+
+    let alice_client = create_client_for_user(port, alice_gall_token).await;
+    let resp = alice_client
+        .get(&format!("{base_url}/w/test-workspace/scripts/list"))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "g/all token for a real workspace member should authenticate; got {}",
+        resp.status()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes WIN-1986

## Summary
- WIN-1978's `g/<groupname>` owner check only verified group existence, but the default `all` group is provisioned in every workspace — so a forged `owner=g/all` token paired with any `workspace_id` still authenticated as a group user there, regardless of workspace membership.
- The `g/` branch now additionally requires the token holder's email to be a non-disabled member of the target workspace, mirroring the `u/` branch's `usr` lookup.
- Adds an integration regression in `permissions.rs` that asserts a forged non-member `g/all` token is rejected and a legitimate `g/all` token for a real workspace member still authenticates.

## Vulnerability recap
With write access to the `token` table (e.g. via a metadata-DB compromise), an attacker could set `owner='g/all'` and `workspace_id='target-ws'` on a token they control and bypass the workspace boundary because `group_ WHERE name='all'` exists in every workspace by default. After this change, the additional `usr WHERE email=$3 AND workspace_id=$1 AND disabled=false` check rejects the forged token.

## Test plan
- [ ] `cargo test -p windmill-api-integration-tests --features deno_core test_forged_g_all_owner_rejects_non_member -- --ignored`
- [ ] Manual: insert a `token` row with `owner='g/all'`, `workspace_id='<target>'`, and an `email` not present in `<target>`'s `usr` table; verify `GET /api/w/<target>/users/whoami` returns 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces workspace membership for `g/<group>` tokens to close a cross-workspace auth gap (WIN-1986). Forged `owner=g/all` tokens now fail unless the token email is a member of the target workspace.

- **Bug Fixes**
  - Require both group existence and a non-disabled `usr` matching the token email in the target workspace before accepting `g/<group>` owner tokens.
  - Blocks forged `owner='g/all'` with arbitrary `workspace_id`; adds an integration test rejecting non-members and accepting real members.

- **Refactors**
  - Shortened the `g/` owner-check comment in `auth.rs` for clarity.

<sup>Written for commit d8b47f611f644d561463bef806fbc24e07e5c23f. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9313?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

