### PR TITLE
chore(raw_apps): bump bundled ui_builder to b4f6219

### DIFF
--- a/frontend/scripts/ui_builder_artifact.json
+++ b/frontend/scripts/ui_builder_artifact.json
@@ -1,5 +1,5 @@
 {
 	"baseUrl": "https://pub-06154ed168a24e73a86ab84db6bf15d8.r2.dev",
-	"version": "61b6fdd",
-	"sha256": "d7c316b4429442eed9462756db0fdf13128849b5b9adf4a7b7acc7a26b1a7280"
+	"version": "b4f6219",
+	"sha256": "69575342aab968fc32a89d3410c21bf888b0f00ce5c68fe80936d3adc1359b36"
 }


### PR DESCRIPTION
## Summary

Bumps the bundled `ui_builder` artifact pointer to `b4f6219` — the merge of `windmill-labs/windmill-code-ui-builder#8` (review followups: logs forwarding through `appendLogs`, `setOpenFile` serialized chain, `@hmr:keep` on `hasFlushedInitialLogs`, theme-readiness comment reworded).

Generated by inlining `frontend/use_latest_ui_builder.sh`:
- `git rev-parse --short` of `windmill-labs/windmill-code-ui-builder` `main` → `b4f62195` → trimmed to `b4f6219`
- `curl https://pub-06154ed168a24e73a86ab84db6bf15d8.r2.dev/ui_builder-b4f6219.tar.gz` → 25,116,689 bytes
- `sha256` → `69575342aab968fc32a89d3410c21bf888b0f00ce5c68fe80936d3adc1359b36`

## Test plan

- [ ] CI's postinstall (`scripts/untar_ui_builder.js`) successfully fetches + extracts the artifact.
- [ ] Open any raw app and confirm the embedded editor mounts (sha256 mismatch would fail extraction).
- [ ] Spot-check: editor-side status lines (`Change <path> detected, 1s debounce on rebuild`, `updated wmill.ts`, `updated node_modules/`, `updated shared ui (N files)`) reach the host's logs overlay.