### PR TITLE
feat(raw_apps): surface UI Builder build errors over the preview pane

### DIFF
--- a/frontend/scripts/ui_builder_artifact.json
+++ b/frontend/scripts/ui_builder_artifact.json
@@ -1,5 +1,5 @@
 {
 	"baseUrl": "https://pub-06154ed168a24e73a86ab84db6bf15d8.r2.dev",
-	"version": "b4f6219",
-	"sha256": "69575342aab968fc32a89d3410c21bf888b0f00ce5c68fe80936d3adc1359b36"
+	"version": "00c9834",
+	"sha256": "5757e5b9cbf79c20d507dc4c588640368e84b873cb48f3806ca8c67fd1aa625f"
 }

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -197,10 +197,7 @@
 	// visually tied to the build output, not to the source editor.
 	let logs = $state('')
 
-	// Last build error from the UI Builder, or undefined if the most recent
-	// build succeeded. Rendered as a banner overlay over the preview iframe
-	// (same pane as `logs`) so failures appear where the user is looking for
-	// the rendered output, not on top of the source files.
+	// Latest UI Builder error; cleared on next successful build.
 	let buildError = $state<string | undefined>(undefined)
 	let logsCollapsed = $state(false)
 	let logsDiv: HTMLDivElement | undefined = $state(undefined)
@@ -236,9 +233,7 @@
 				? 'file'
 				: 'runnable'
 	)
-	// While a build error is showing, tint the Preview tab red so the
-	// failure is also visible when Preview isn't the active tab (its overlay
-	// lives inside the preview pane and would otherwise be hidden).
+	// Tint the Preview tab red so the error is visible when Preview isn't active.
 	function tintPreviewOnError(t: TabItem): TabItem {
 		if (t.id !== PREVIEW_TAB_ID || !buildError) return t
 		const errClass = 'text-red-600 dark:text-red-400'
@@ -954,10 +949,7 @@
 			return
 		}
 
-		// Build error: shown as a banner overlay over the preview iframe
-		// (rendered below alongside the logs panel). `message: undefined`
-		// arrives from the UI Builder on the next successful build, which
-		// clears the banner.
+		// `message: undefined` arrives on the next successful build and clears the banner.
 		if (fromUiBuilder && e.data.type === 'buildError') {
 			buildError = typeof e.data.message === 'string' ? e.data.message : undefined
 			return
@@ -1583,14 +1575,8 @@
 									class="w-full flex-1 block"
 								></iframe>
 								{#if buildError}
-									<!-- top-12 clears the tab bar (h-7 buttons + padding) so the
-									     banner sits over the preview iframe, not over the tabs.
-									     The `before:` pseudo lays a solid `bg-surface` plate behind
-									     the Alert's semi-transparent red (esp. dark mode's
-									     bg-red-900/40) so the preview iframe doesn't show through.
-									     `isolate` pins the stacking context locally so the pseudo's
-									     `-z-10` can't escape behind the preview iframe if `z-20`
-									     ever gets removed in a future refactor. -->
+									<!-- top-12 clears the tab bar; `before:bg-surface` backs the
+									     Alert's translucent red; `isolate` pins the pseudo's stacking context. -->
 									<div class="absolute top-12 left-2 right-2 z-20 isolate" role="alert">
 										<Alert
 											type="error"

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -1587,9 +1587,16 @@
 								></iframe>
 								{#if buildError}
 									<!-- top-12 clears the tab bar (h-7 buttons + padding) so the
-									     banner sits over the preview iframe, not over the tabs. -->
+									     banner sits over the preview iframe, not over the tabs.
+									     The `before:` pseudo lays a solid `bg-surface` plate behind
+									     the Alert's semi-transparent red (esp. dark mode's
+									     bg-red-900/40) so the preview iframe doesn't show through. -->
 									<div class="absolute top-12 left-2 right-2 z-20" role="alert">
-										<Alert type="error" title="Build failed">
+										<Alert
+											type="error"
+											title="Build failed"
+											class="relative before:absolute before:inset-0 before:-z-10 before:rounded-md before:bg-surface before:content-['']"
+										>
 											<pre
 												class="overflow-auto whitespace-pre-wrap text-xs max-h-60">{buildError}</pre>
 										</Alert>

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -6,6 +6,7 @@
 	import RawAppEditorHeader from './RawAppEditorHeader.svelte'
 	import RawAppYamlEditor, { type RawAppYamlUpdate } from './RawAppYamlEditor.svelte'
 	import type Drawer from '../common/drawer/Drawer.svelte'
+	import Alert from '../common/alert/Alert.svelte'
 	import { type Policy, WorkspaceService } from '$lib/gen'
 	import DiffDrawer from '../DiffDrawer.svelte'
 	import { deepEqual } from 'fast-equals'
@@ -1587,11 +1588,11 @@
 								{#if buildError}
 									<!-- top-12 clears the tab bar (h-7 buttons + padding) so the
 									     banner sits over the preview iframe, not over the tabs. -->
-									<div
-										class="absolute top-12 left-2 right-2 z-20 bg-red-500 text-white rounded p-2"
-										role="alert"
-									>
-										<pre class="overflow-auto whitespace-pre-wrap text-xs">{buildError}</pre>
+									<div class="absolute top-12 left-2 right-2 z-20" role="alert">
+										<Alert type="error" title="Build failed">
+											<pre
+												class="overflow-auto whitespace-pre-wrap text-xs max-h-60">{buildError}</pre>
+										</Alert>
 									</div>
 								{/if}
 								{#if logs}

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -195,6 +195,12 @@
 	// them as an overlay inside the preview pane (right side) so they're
 	// visually tied to the build output, not to the source editor.
 	let logs = $state('')
+
+	// Last build error from the UI Builder, or undefined if the most recent
+	// build succeeded. Rendered as a banner overlay over the preview iframe
+	// (same pane as `logs`) so failures appear where the user is looking for
+	// the rendered output, not on top of the source files.
+	let buildError = $state<string | undefined>(undefined)
 	let logsCollapsed = $state(false)
 	let logsDiv: HTMLDivElement | undefined = $state(undefined)
 	$effect(() => {
@@ -229,13 +235,25 @@
 				? 'file'
 				: 'runnable'
 	)
+	// While a build error is showing, tint the Preview tab red so the
+	// failure is also visible when Preview isn't the active tab (its overlay
+	// lives inside the preview pane and would otherwise be hidden).
+	function tintPreviewOnError(t: TabItem): TabItem {
+		if (t.id !== PREVIEW_TAB_ID || !buildError) return t
+		const errClass = 'text-red-600 dark:text-red-400'
+		return { ...t, iconClass: errClass, labelClass: errClass }
+	}
 	// Single mode: both bars mirror the full list (the visible pane carries
 	// every tab). Split mode: left = files/runnables, right = Preview only.
 	const leftPaneTabs = $derived<TabItem[]>(
-		splitWithPreview ? tabs.filter((t) => t.id !== PREVIEW_TAB_ID) : tabs
+		(splitWithPreview ? tabs.filter((t) => t.id !== PREVIEW_TAB_ID) : tabs).map(
+			tintPreviewOnError
+		)
 	)
 	const rightPaneTabs = $derived<TabItem[]>(
-		splitWithPreview ? tabs.filter((t) => t.id === PREVIEW_TAB_ID) : tabs
+		(splitWithPreview ? tabs.filter((t) => t.id === PREVIEW_TAB_ID) : tabs).map(
+			tintPreviewOnError
+		)
 	)
 	// In split mode the right bar always highlights Preview, regardless of the
 	// left pane's active file/runnable.
@@ -938,6 +956,15 @@
 			return
 		}
 
+		// Build error: shown as a banner overlay over the preview iframe
+		// (rendered below alongside the logs panel). `message: undefined`
+		// arrives from the UI Builder on the next successful build, which
+		// clears the banner.
+		if (fromUiBuilder && e.data.type === 'buildError') {
+			buildError = typeof e.data.message === 'string' ? e.data.message : undefined
+			return
+		}
+
 		// Inspector events come exclusively from the preview iframe.
 		if (fromPreview && e.data.type === 'inspectorSelect') {
 			inspectorElement = e.data.element as InspectorElementInfo
@@ -1557,6 +1584,16 @@
 									src="/ui_builder/app-preview.html"
 									class="w-full flex-1 block"
 								></iframe>
+								{#if buildError}
+									<!-- top-12 clears the tab bar (h-7 buttons + padding) so the
+									     banner sits over the preview iframe, not over the tabs. -->
+									<div
+										class="absolute top-12 left-2 right-2 z-20 bg-red-500 text-white rounded p-2"
+										role="alert"
+									>
+										<pre class="overflow-auto whitespace-pre-wrap text-xs">{buildError}</pre>
+									</div>
+								{/if}
 								{#if logs}
 									<div
 										class="absolute right-0 bottom-0 z-20 max-w-[500px] w-full flex flex-col text-xs p-1 border border-border-light rounded-tl-md bg-surface text-primary {logsCollapsed

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -244,17 +244,14 @@
 		const errClass = 'text-red-600 dark:text-red-400'
 		return { ...t, iconClass: errClass, labelClass: errClass }
 	}
+	const tintTabs = (ts: TabItem[]) => ts.map(tintPreviewOnError)
 	// Single mode: both bars mirror the full list (the visible pane carries
 	// every tab). Split mode: left = files/runnables, right = Preview only.
 	const leftPaneTabs = $derived<TabItem[]>(
-		(splitWithPreview ? tabs.filter((t) => t.id !== PREVIEW_TAB_ID) : tabs).map(
-			tintPreviewOnError
-		)
+		tintTabs(splitWithPreview ? tabs.filter((t) => t.id !== PREVIEW_TAB_ID) : tabs)
 	)
 	const rightPaneTabs = $derived<TabItem[]>(
-		(splitWithPreview ? tabs.filter((t) => t.id === PREVIEW_TAB_ID) : tabs).map(
-			tintPreviewOnError
-		)
+		tintTabs(splitWithPreview ? tabs.filter((t) => t.id === PREVIEW_TAB_ID) : tabs)
 	)
 	// In split mode the right bar always highlights Preview, regardless of the
 	// left pane's active file/runnable.
@@ -1590,8 +1587,11 @@
 									     banner sits over the preview iframe, not over the tabs.
 									     The `before:` pseudo lays a solid `bg-surface` plate behind
 									     the Alert's semi-transparent red (esp. dark mode's
-									     bg-red-900/40) so the preview iframe doesn't show through. -->
-									<div class="absolute top-12 left-2 right-2 z-20" role="alert">
+									     bg-red-900/40) so the preview iframe doesn't show through.
+									     `isolate` pins the stacking context locally so the pseudo's
+									     `-z-10` can't escape behind the preview iframe if `z-20`
+									     ever gets removed in a future refactor. -->
+									<div class="absolute top-12 left-2 right-2 z-20 isolate" role="alert">
 										<Alert
 											type="error"
 											title="Build failed"


### PR DESCRIPTION
Companion to [windmill-labs/windmill-code-ui-builder#9](https://github.com/windmill-labs/windmill-code-ui-builder/pull/9), which stops rendering the build-error overlay over the VS Code editor iframe and instead emits a `buildError` postMessage on every build (`message: undefined` on success to clear).

### Changes
Listen for that message on the existing `window` message handler (already source-gated by the UI Builder iframe), store it in a `buildError` `$state`, and surface it in two places:

- **Red banner over the preview iframe**, sibling to the existing logs overlay (`absolute top-12 left-2 right-2 z-20` so it clears the tab bar) — failures appear right where the user looks for the rendered output. The preview iframe itself (`app-preview.html`) is unchanged; we don't forward the error into it.
- **Preview tab tints red** (icon + label → `text-red-600 dark:text-red-400`, the existing error convention in `raw_apps/`). Important in single-tab mode where the preview pane collapses to 0px and the banner would be hidden — the red tab is then the only visible signal. Done by mapping `leftPaneTabs` / `rightPaneTabs` through a small `tintPreviewOnError` helper so the source-of-truth `tabs` array is untouched (DnD, ordering, fallback selection keep using the original `previewTab` object).

The error state is cleared automatically the moment the next successful build's `message: undefined` arrives.

### Shipping order
The new postMessage from the UI Builder needs to be in the bundled artifact for the banner to appear. Until the UI Builder PR lands and is bumped here, the new listener sits inert — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)