### PR TITLE
feat(fixtures): add cli-sync workspace snapshot/load scripts

### DIFF
--- a/.github/workflows/check-empty-fixture.yml
+++ b/.github/workflows/check-empty-fixture.yml
@@ -1,0 +1,19 @@
+name: Check fixture is empty
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "fixtures/**"
+  pull_request:
+    paths:
+      - "fixtures/**"
+
+jobs:
+  check-empty-fixture:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure fixtures/cli-sync/ has no committed snapshot
+        run: bash fixtures/check-empty.sh

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -17,8 +17,15 @@ All scripts assume:
 - A local Windmill backend running at `http://localhost:8000` (see top-level
   `AGENTS.md` for `cargo run` / `npm run dev`).
 - Default super-admin credentials `admin@windmill.dev` / `changeme`.
-- `bun` is installed and on `PATH`. No `wmill` install required — the scripts
-  invoke `cli/src/main.ts` via `bun run` directly.
+- `bun` and `python3` are installed and on `PATH`. No `wmill` install
+  required — the scripts invoke `cli/src/main.ts` via `bun run` directly.
+  `python3` is used only to build correctly-escaped JSON request bodies.
+
+The login token is passed to the CLI via `--token`, which means it appears in
+`/proc/<pid>/cmdline` for the duration of the `bun run` call. This is fine
+against a local dev instance; if you point the scripts at a real instance,
+the credentials are no more exposed than running `wmill` directly with
+explicit flags, but bear it in mind.
 
 ### `load.sh` — load the fixture into a fresh workspace
 
@@ -47,8 +54,8 @@ Flags:
 ```
 
 Pulls the given workspace into `fixtures/cli-sync/` via `wmill sync pull`.
-The target directory is cleared first (everything except `.gitkeep` and
-`README.md`) so the snapshot reflects exactly what's in the workspace.
+The target directory is cleared first (everything except `wmill.yaml` and
+`.gitkeep`) so the snapshot reflects exactly what's in the workspace.
 
 Flags: same as `load.sh` minus `--workspace` (passed as positional arg).
 

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -34,7 +34,9 @@ the UI.
 Flags:
 - `--base-url <url>` (default `http://localhost:8000`)
 - `--email <email>` (default `admin@windmill.dev`)
-- `--password <pwd>` (default `changeme`)
+- `--password <pwd>` (default `changeme`) — prefer `WMILL_PASSWORD=<pwd>` env
+  var when using a real password, since `--password` ends up in `ps` /
+  shell history.
 - `--workspace <id>` (default `fixture-<random>`)
 - `--dir <path>` (default `fixtures/cli-sync`)
 

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,0 +1,59 @@
+# Fixtures
+
+Helpers for sharing a reproducible test workspace alongside a PR.
+
+The workflow is:
+
+1. While iterating on a PR, snapshot your local test workspace into
+   `fixtures/cli-sync/` so a teammate (or CI) can replay it.
+2. Commit the snapshot on your branch so reviewers can load it locally.
+3. **Before merging**, clear `fixtures/cli-sync/` again. CI fails on `main` /
+   PRs that try to merge a non-empty fixture (see `check-empty.sh`).
+
+## Scripts
+
+All scripts assume:
+
+- A local Windmill backend running at `http://localhost:8000` (see top-level
+  `AGENTS.md` for `cargo run` / `npm run dev`).
+- Default super-admin credentials `admin@windmill.dev` / `changeme`.
+- `bun` is installed and on `PATH`. No `wmill` install required — the scripts
+  invoke `cli/src/main.ts` via `bun run` directly.
+
+### `load.sh` — load the fixture into a fresh workspace
+
+```bash
+./fixtures/load.sh
+```
+
+Logs in as `admin@windmill.dev`, creates a new workspace with a random id
+(`fixture-<8 hex chars>`), and pushes `fixtures/cli-sync/` into it via
+`wmill sync push`. Prints the workspace id at the end so you can open it in
+the UI.
+
+Flags:
+- `--base-url <url>` (default `http://localhost:8000`)
+- `--email <email>` (default `admin@windmill.dev`)
+- `--password <pwd>` (default `changeme`)
+- `--workspace <id>` (default `fixture-<random>`)
+- `--dir <path>` (default `fixtures/cli-sync`)
+
+### `snapshot.sh` — snapshot a workspace into the fixture folder
+
+```bash
+./fixtures/snapshot.sh <workspace-id>
+```
+
+Pulls the given workspace into `fixtures/cli-sync/` via `wmill sync pull`.
+The target directory is cleared first (everything except `.gitkeep` and
+`README.md`) so the snapshot reflects exactly what's in the workspace.
+
+Flags: same as `load.sh` minus `--workspace` (passed as positional arg).
+
+### `check-empty.sh` — fail if the fixture is non-empty
+
+Used by CI to guard `main`. Run it locally before opening a PR for merge:
+
+```bash
+./fixtures/check-empty.sh
+```

--- a/fixtures/check-empty.sh
+++ b/fixtures/check-empty.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 DIR="${1:-$SCRIPT_DIR/cli-sync}"
 
-ALLOWED_RE='^fixtures/cli-sync/(\.gitkeep|README\.md|wmill\.yaml)$'
+ALLOWED_RE='^fixtures/cli-sync/(\.gitkeep|wmill\.yaml)$'
 
 # Use `git ls-files` so we only check tracked files. Untracked local snapshots
 # are fine — devs may keep them locally between sessions.

--- a/fixtures/check-empty.sh
+++ b/fixtures/check-empty.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Fail if fixtures/cli-sync/ contains anything beyond the fixture scaffold
+# (wmill.yaml, README.md, .gitkeep). Used by CI to guard `main` against
+# accidentally merging PRs with a test workspace snapshot still committed.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DIR="${1:-$SCRIPT_DIR/cli-sync}"
+
+ALLOWED_RE='^fixtures/cli-sync/(\.gitkeep|README\.md|wmill\.yaml)$'
+
+# Use `git ls-files` so we only check tracked files. Untracked local snapshots
+# are fine — devs may keep them locally between sessions.
+EXTRA=$(cd "$REPO_ROOT" && git ls-files fixtures/cli-sync \
+  | grep -vE "$ALLOWED_RE" || true)
+
+if [[ -n "$EXTRA" ]]; then
+  echo "✗ fixtures/cli-sync/ contains committed snapshot files:" >&2
+  echo "$EXTRA" | sed 's/^/    /' >&2
+  echo >&2
+  echo "  Run fixtures/snapshot.sh against an empty workspace or" >&2
+  echo "  remove the files before merging." >&2
+  exit 1
+fi
+
+echo "✓ fixtures/cli-sync/ is clean"

--- a/fixtures/check-empty.sh
+++ b/fixtures/check-empty.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Fail if fixtures/cli-sync/ contains anything beyond the fixture scaffold
-# (wmill.yaml, README.md, .gitkeep). Used by CI to guard `main` against
-# accidentally merging PRs with a test workspace snapshot still committed.
+# (wmill.yaml, .gitkeep). Used by CI to guard `main` against accidentally
+# merging PRs with a test workspace snapshot still committed.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/fixtures/cli-sync/wmill.yaml
+++ b/fixtures/cli-sync/wmill.yaml
@@ -1,0 +1,15 @@
+defaultTs: bun
+includes:
+  - f/**
+excludes: []
+skipVariables: false
+skipResources: false
+skipResourceTypes: false
+skipSecrets: true
+includeSchedules: true
+includeTriggers: true
+includeUsers: false
+includeGroups: false
+includeSettings: false
+includeKey: false
+syncBehavior: v1

--- a/fixtures/load.sh
+++ b/fixtures/load.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Load fixtures/cli-sync/ into a fresh workspace on a local Windmill instance.
+#
+# Requires: bun on PATH. No `wmill` install needed — we invoke
+# cli/src/main.ts directly via `bun run`.
+#
+# Assumes a Windmill backend running at http://localhost:8000 with the
+# default super-admin (admin@windmill.dev / changeme). Override via flags.
+set -euo pipefail
+
+BASE_URL="http://localhost:8000"
+EMAIL="admin@windmill.dev"
+PASSWORD="changeme"
+WORKSPACE=""
+DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-url) BASE_URL="$2"; shift 2 ;;
+    --email) EMAIL="$2"; shift 2 ;;
+    --password) PASSWORD="$2"; shift 2 ;;
+    --workspace) WORKSPACE="$2"; shift 2 ;;
+    --dir) DIR="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,11p' "$0"; exit 0 ;;
+    *) echo "Unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DIR="${DIR:-$SCRIPT_DIR/cli-sync}"
+DIR="$(cd "$DIR" && pwd)"
+CLI_ENTRY="$REPO_ROOT/cli/src/main.ts"
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "✗ bun is required but not found on PATH" >&2
+  exit 1
+fi
+if [[ ! -f "$CLI_ENTRY" ]]; then
+  echo "✗ Cannot find CLI entry at $CLI_ENTRY" >&2
+  exit 1
+fi
+if [[ ! -f "$DIR/wmill.yaml" ]]; then
+  echo "✗ No wmill.yaml in $DIR — is the fixture folder set up?" >&2
+  exit 1
+fi
+
+if [[ -z "$WORKSPACE" ]]; then
+  WORKSPACE="fixture-$(LC_ALL=C tr -dc 'a-f0-9' </dev/urandom | head -c 8)"
+fi
+
+echo "→ Logging in as $EMAIL on $BASE_URL"
+TOKEN="$(curl -sS -f -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -d "$(printf '{"email":"%s","password":"%s"}' "$EMAIL" "$PASSWORD")")"
+if [[ -z "$TOKEN" ]]; then
+  echo "✗ Login failed (empty token)" >&2
+  exit 1
+fi
+
+echo "→ Creating workspace '$WORKSPACE'"
+CREATE_BODY="$(printf '{"id":"%s","name":"%s"}' "$WORKSPACE" "$WORKSPACE")"
+HTTP_CODE="$(curl -sS -o /tmp/wm-fixture-create.out -w '%{http_code}' \
+  -X POST "$BASE_URL/api/workspaces/create" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$CREATE_BODY")"
+if [[ "$HTTP_CODE" != "200" && "$HTTP_CODE" != "201" ]]; then
+  echo "✗ Workspace creation failed (HTTP $HTTP_CODE):" >&2
+  cat /tmp/wm-fixture-create.out >&2
+  echo >&2
+  exit 1
+fi
+rm -f /tmp/wm-fixture-create.out
+
+echo "→ Pushing $DIR to workspace '$WORKSPACE'"
+(
+  cd "$DIR"
+  bun run "$CLI_ENTRY" sync push --yes \
+    --base-url "$BASE_URL" \
+    --workspace "$WORKSPACE" \
+    --token "$TOKEN"
+)
+
+echo
+echo "✓ Fixture loaded into workspace '$WORKSPACE'"
+echo "  Open: ${BASE_URL%/}/?workspace=$WORKSPACE"

--- a/fixtures/load.sh
+++ b/fixtures/load.sh
@@ -10,7 +10,9 @@ set -euo pipefail
 
 BASE_URL="http://localhost:8000"
 EMAIL="admin@windmill.dev"
-PASSWORD="changeme"
+# Prefer WMILL_PASSWORD env var over --password flag — flags leak into
+# /proc/<pid>/cmdline and shell history.
+PASSWORD="${WMILL_PASSWORD:-changeme}"
 WORKSPACE=""
 DIR=""
 
@@ -60,19 +62,20 @@ if [[ -z "$TOKEN" ]]; then
 fi
 
 echo "→ Creating workspace '$WORKSPACE'"
+CREATE_OUT="$(mktemp)"
+trap 'rm -f "$CREATE_OUT"' EXIT
 CREATE_BODY="$(printf '{"id":"%s","name":"%s"}' "$WORKSPACE" "$WORKSPACE")"
-HTTP_CODE="$(curl -sS -o /tmp/wm-fixture-create.out -w '%{http_code}' \
+HTTP_CODE="$(curl -sS -o "$CREATE_OUT" -w '%{http_code}' \
   -X POST "$BASE_URL/api/workspaces/create" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d "$CREATE_BODY")"
 if [[ "$HTTP_CODE" != "200" && "$HTTP_CODE" != "201" ]]; then
   echo "✗ Workspace creation failed (HTTP $HTTP_CODE):" >&2
-  cat /tmp/wm-fixture-create.out >&2
+  cat "$CREATE_OUT" >&2
   echo >&2
   exit 1
 fi
-rm -f /tmp/wm-fixture-create.out
 
 echo "→ Pushing $DIR to workspace '$WORKSPACE'"
 (

--- a/fixtures/load.sh
+++ b/fixtures/load.sh
@@ -24,7 +24,7 @@ while [[ $# -gt 0 ]]; do
     --workspace) WORKSPACE="$2"; shift 2 ;;
     --dir) DIR="$2"; shift 2 ;;
     -h|--help)
-      sed -n '2,11p' "$0"; exit 0 ;;
+      sed -n '2,8p' "$0"; exit 0 ;;
     *) echo "Unknown flag: $1" >&2; exit 2 ;;
   esac
 done
@@ -49,13 +49,25 @@ if [[ ! -f "$DIR/wmill.yaml" ]]; then
 fi
 
 if [[ -z "$WORKSPACE" ]]; then
-  WORKSPACE="fixture-$(LC_ALL=C tr -dc 'a-f0-9' </dev/urandom | head -c 8)"
+  # Use $RANDOM rather than piping /dev/urandom through head -c, which
+  # SIGPIPEs `tr` and aborts the script under `set -o pipefail`.
+  printf -v WORKSPACE 'fixture-%04x%04x' $RANDOM $RANDOM
 fi
+
+# JSON body builder — interpolation via printf '%s' is unsafe for arbitrary
+# emails / passwords / workspace ids. Python is universal enough for a dev
+# script and produces correctly escaped JSON.
+json_object() {
+  python3 -c '
+import json, sys
+print(json.dumps(dict(zip(sys.argv[1::2], sys.argv[2::2]))))
+' "$@"
+}
 
 echo "→ Logging in as $EMAIL on $BASE_URL"
 TOKEN="$(curl -sS -f -X POST "$BASE_URL/api/auth/login" \
   -H "Content-Type: application/json" \
-  -d "$(printf '{"email":"%s","password":"%s"}' "$EMAIL" "$PASSWORD")")"
+  -d "$(json_object email "$EMAIL" password "$PASSWORD")")"
 if [[ -z "$TOKEN" ]]; then
   echo "✗ Login failed (empty token)" >&2
   exit 1
@@ -64,12 +76,11 @@ fi
 echo "→ Creating workspace '$WORKSPACE'"
 CREATE_OUT="$(mktemp)"
 trap 'rm -f "$CREATE_OUT"' EXIT
-CREATE_BODY="$(printf '{"id":"%s","name":"%s"}' "$WORKSPACE" "$WORKSPACE")"
 HTTP_CODE="$(curl -sS -o "$CREATE_OUT" -w '%{http_code}' \
   -X POST "$BASE_URL/api/workspaces/create" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d "$CREATE_BODY")"
+  -d "$(json_object id "$WORKSPACE" name "$WORKSPACE")")"
 if [[ "$HTTP_CODE" != "200" && "$HTTP_CODE" != "201" ]]; then
   echo "✗ Workspace creation failed (HTTP $HTTP_CODE):" >&2
   cat "$CREATE_OUT" >&2

--- a/fixtures/snapshot.sh
+++ b/fixtures/snapshot.sh
@@ -17,7 +17,7 @@ DIR=""
 WORKSPACE=""
 
 if [[ $# -lt 1 || "$1" == "-h" || "$1" == "--help" ]]; then
-  sed -n '2,11p' "$0"
+  sed -n '2,8p' "$0"
   echo
   echo "Usage: $(basename "$0") <workspace-id> [--base-url URL] [--email E] [--password P] [--dir PATH]"
   exit 0
@@ -54,10 +54,20 @@ if [[ ! -f "$DIR/wmill.yaml" ]]; then
   exit 1
 fi
 
+# JSON body builder — interpolation via printf '%s' is unsafe for arbitrary
+# emails / passwords. Python is universal enough for a dev script and
+# produces correctly escaped JSON.
+json_object() {
+  python3 -c '
+import json, sys
+print(json.dumps(dict(zip(sys.argv[1::2], sys.argv[2::2]))))
+' "$@"
+}
+
 echo "→ Logging in as $EMAIL on $BASE_URL"
 TOKEN="$(curl -sS -f -X POST "$BASE_URL/api/auth/login" \
   -H "Content-Type: application/json" \
-  -d "$(printf '{"email":"%s","password":"%s"}' "$EMAIL" "$PASSWORD")")"
+  -d "$(json_object email "$EMAIL" password "$PASSWORD")")"
 if [[ -z "$TOKEN" ]]; then
   echo "✗ Login failed (empty token)" >&2
   exit 1
@@ -69,10 +79,10 @@ fi
 echo "→ Clearing previous snapshot in $DIR"
 (
   cd "$DIR"
-  find . -mindepth 1 \
+  find . -mindepth 1 -maxdepth 1 \
     ! -name 'wmill.yaml' \
     ! -name '.gitkeep' \
-    -print0 | xargs -0 -r rm -rf
+    -exec rm -rf {} +
 )
 
 echo "→ Pulling workspace '$WORKSPACE' into $DIR"

--- a/fixtures/snapshot.sh
+++ b/fixtures/snapshot.sh
@@ -10,7 +10,9 @@ set -euo pipefail
 
 BASE_URL="http://localhost:8000"
 EMAIL="admin@windmill.dev"
-PASSWORD="changeme"
+# Prefer WMILL_PASSWORD env var over --password flag — flags leak into
+# /proc/<pid>/cmdline and shell history.
+PASSWORD="${WMILL_PASSWORD:-changeme}"
 DIR=""
 WORKSPACE=""
 
@@ -62,14 +64,13 @@ if [[ -z "$TOKEN" ]]; then
 fi
 
 # Clear previous snapshot content while preserving the fixture scaffold
-# (wmill.yaml, README.md, .gitkeep). Anything else is removed so the snapshot
-# reflects exactly what is in the workspace.
+# (wmill.yaml, .gitkeep). Anything else is removed so the snapshot reflects
+# exactly what is in the workspace.
 echo "→ Clearing previous snapshot in $DIR"
 (
   cd "$DIR"
   find . -mindepth 1 \
     ! -name 'wmill.yaml' \
-    ! -name 'README.md' \
     ! -name '.gitkeep' \
     -print0 | xargs -0 -r rm -rf
 )

--- a/fixtures/snapshot.sh
+++ b/fixtures/snapshot.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Snapshot a workspace into fixtures/cli-sync/ so it can be committed
+# alongside a PR.
+#
+# Requires: bun on PATH. No `wmill` install needed.
+#
+# Assumes a Windmill backend running at http://localhost:8000 with the
+# default super-admin (admin@windmill.dev / changeme). Override via flags.
+set -euo pipefail
+
+BASE_URL="http://localhost:8000"
+EMAIL="admin@windmill.dev"
+PASSWORD="changeme"
+DIR=""
+WORKSPACE=""
+
+if [[ $# -lt 1 || "$1" == "-h" || "$1" == "--help" ]]; then
+  sed -n '2,11p' "$0"
+  echo
+  echo "Usage: $(basename "$0") <workspace-id> [--base-url URL] [--email E] [--password P] [--dir PATH]"
+  exit 0
+fi
+
+WORKSPACE="$1"; shift
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-url) BASE_URL="$2"; shift 2 ;;
+    --email) EMAIL="$2"; shift 2 ;;
+    --password) PASSWORD="$2"; shift 2 ;;
+    --dir) DIR="$2"; shift 2 ;;
+    *) echo "Unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DIR="${DIR:-$SCRIPT_DIR/cli-sync}"
+DIR="$(cd "$DIR" && pwd)"
+CLI_ENTRY="$REPO_ROOT/cli/src/main.ts"
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "✗ bun is required but not found on PATH" >&2
+  exit 1
+fi
+if [[ ! -f "$CLI_ENTRY" ]]; then
+  echo "✗ Cannot find CLI entry at $CLI_ENTRY" >&2
+  exit 1
+fi
+if [[ ! -f "$DIR/wmill.yaml" ]]; then
+  echo "✗ No wmill.yaml in $DIR — is the fixture folder set up?" >&2
+  exit 1
+fi
+
+echo "→ Logging in as $EMAIL on $BASE_URL"
+TOKEN="$(curl -sS -f -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -d "$(printf '{"email":"%s","password":"%s"}' "$EMAIL" "$PASSWORD")")"
+if [[ -z "$TOKEN" ]]; then
+  echo "✗ Login failed (empty token)" >&2
+  exit 1
+fi
+
+# Clear previous snapshot content while preserving the fixture scaffold
+# (wmill.yaml, README.md, .gitkeep). Anything else is removed so the snapshot
+# reflects exactly what is in the workspace.
+echo "→ Clearing previous snapshot in $DIR"
+(
+  cd "$DIR"
+  find . -mindepth 1 \
+    ! -name 'wmill.yaml' \
+    ! -name 'README.md' \
+    ! -name '.gitkeep' \
+    -print0 | xargs -0 -r rm -rf
+)
+
+echo "→ Pulling workspace '$WORKSPACE' into $DIR"
+(
+  cd "$DIR"
+  bun run "$CLI_ENTRY" sync pull --yes \
+    --base-url "$BASE_URL" \
+    --workspace "$WORKSPACE" \
+    --token "$TOKEN"
+)
+
+echo
+echo "✓ Snapshot of '$WORKSPACE' written to $DIR"
+echo "  Commit the changes to share with reviewers. Run fixtures/check-empty.sh"
+echo "  to verify the dir is empty again before merging."


### PR DESCRIPTION
## Summary

Adds a small fixture mechanism so that while iterating on a PR you can snapshot your local test workspace into `fixtures/cli-sync/`, commit it on the branch for reviewers, and replay it on demand. A CI check on PRs touching `fixtures/**` ensures the fixture folder is empty before merge — preventing accidentally landing snapshots on `main`.

No production code touched — three bash scripts, a minimal `wmill.yaml`, a README, and one CI workflow.

## Changes

- `fixtures/load.sh` — logs in as `admin@windmill.dev` against `http://localhost:8000`, creates a fresh `fixture-<rand>` workspace via `POST /api/workspaces/create`, then runs `bun run cli/src/main.ts sync push` from `fixtures/cli-sync/` into it. No `wmill` install needed (just `bun`).
- `fixtures/snapshot.sh <workspace-id>` — pulls a given workspace into `fixtures/cli-sync/` via `sync pull`, clearing previous snapshot content but preserving `wmill.yaml` / `.gitkeep`.
- `fixtures/check-empty.sh` — exits non-zero if anything other than the scaffold (`wmill.yaml`, `.gitkeep`) is tracked under `fixtures/cli-sync/`. Used by CI; runnable locally too.
- `fixtures/cli-sync/wmill.yaml` — minimal config so the CLI doesn't walk up looking for one.
- `fixtures/README.md` — explains the workflow and flags.
- `.github/workflows/check-empty-fixture.yml` — runs `check-empty.sh` on push to `main` and PRs touching `fixtures/**`.

Both scripts honor `WMILL_PASSWORD` env var to keep credentials off the command line.

## Test plan

- [ ] With `cargo run` up locally, `./fixtures/load.sh` prints a `fixture-<8hex>` workspace id, the create call returns 200/201, and the workspace opens in the UI.
- [ ] Drop a script under `fixtures/cli-sync/f/test/hello.script.yaml` (or via a real workspace), then `./fixtures/snapshot.sh <ws-id>` produces a tree that matches the workspace contents and leaves `wmill.yaml` / `.gitkeep` intact.
- [ ] `./fixtures/check-empty.sh` exits 0 on a clean tree; exits 1 with an explanatory message if anything else is tracked under `fixtures/cli-sync/`.
- [ ] CI workflow `Check fixture is empty` passes on this PR (the fixture is clean here) and fails on a follow-up PR that intentionally adds a tracked snapshot file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lightweight fixture workflow to snapshot a local test workspace into `fixtures/cli-sync/` and reload it on demand. A CI check blocks merging committed snapshots into `main`; no production code changed.

- **Bug Fixes**
  - Build JSON bodies with `python3` to avoid escaping issues and improve login/workspace-create error handling.
  - Generate random workspace IDs without pipelines to avoid SIGPIPE under `pipefail`.
  - Prefer `WMILL_PASSWORD`, pass auth via `--token`, and update the README to match script behavior.

<sup>Written for commit c9a369590f3ab0aeb66b9a165e89e311c2531b36. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9322?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

