### PR TITLE
fix(ci): prevent windows backend tests from running out of disk space

### DIFF
--- a/.github/workflows/backend-test-windows.yml
+++ b/.github/workflows/backend-test-windows.yml
@@ -98,6 +98,21 @@ jobs:
           vcpkg.exe install openssl:x64-windows-static
           vcpkg.exe integrate install
 
+      - name: Free disk space (post-vcpkg)
+        shell: pwsh
+        run: |
+          # vcpkg leaves multi-GB of buildtrees/downloads after installing openssl;
+          # we only need the installed/ dir for linking.
+          $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
+          foreach ($sub in @("buildtrees", "downloads", "packages")) {
+            $path = Join-Path $vcpkgRoot $sub
+            if (Test-Path $path) {
+              Write-Host "Removing $path"
+              Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $path
+            }
+          }
+          Get-PSDrive C | Select-Object Used,Free | Format-Table -AutoSize
+
       - name: Get runtime paths
         id: runtime-paths
         shell: pwsh
@@ -119,6 +134,10 @@ jobs:
           cargo build --release -p windmill_duckdb_ffi_internal
           New-Item -ItemType Directory -Path ..\target\debug -Force
           Copy-Item target\release\windmill_duckdb_ffi_internal.dll ..\target\debug\
+          # duckdb is bundled (~2GB of build artifacts); the DLL is the only
+          # thing we need from this excluded-crate target dir.
+          Remove-Item -Recurse -Force -ErrorAction SilentlyContinue target
+          Get-PSDrive C | Select-Object Used,Free | Format-Table -AutoSize
 
       - name: Print runtime versions and env
         shell: pwsh
@@ -136,6 +155,10 @@ jobs:
           echo "USERPROFILE=$env:USERPROFILE"
           echo "HOME=$env:HOME"
 
+      - name: Disk space before cargo test
+        shell: pwsh
+        run: Get-PSDrive C | Select-Object Used,Free | Format-Table -AutoSize
+
       - name: cargo test
         working-directory: backend
         timeout-minutes: 60
@@ -144,13 +167,16 @@ jobs:
           RUST_LOG: "off"
           RUST_LOG_STYLE: never
           CARGO_NET_GIT_FETCH_WITH_CLI: true
-          CARGO_BUILD_JOBS: 12
+          # 16-vcpu runners with disabled PDB still hit LNK1180 ("insufficient
+          # disk space") at link time with 12 parallel link jobs: each test
+          # binary link spikes several hundred MB of transient I/O. Capping at
+          # 8 trades ~25% wall time for headroom on the ~75GB runner disk.
+          CARGO_BUILD_JOBS: 8
           # backend/Cargo.toml sets split-debuginfo = "unpacked", which on
           # windows-msvc is coerced to "packed": every test-binary link spawns
-          # the mspdbsrv.exe PDB type server and writes a large .pdb. With 12
-          # parallel link jobs this races the type-server cap (LNK1318 "LIMIT
-          # (12)") and exhausts the runner disk (LNK1180). CI needs no debug
-          # info, so disable PDB generation for the dev/test profiles here.
+          # the mspdbsrv.exe PDB type server and writes a large .pdb. CI needs
+          # no debug info, so disable PDB generation for the dev/test profiles
+          # here (avoids both LNK1318 type-server limit and PDB disk usage).
           CARGO_PROFILE_DEV_SPLIT_DEBUGINFO: "off"
           CARGO_PROFILE_TEST_SPLIT_DEBUGINFO: "off"
           # Tests' poll-time stack frames (deep nested async fn chains in


### PR DESCRIPTION
## Summary

The Windows backend test job (`backend-test-windows.yml`) has been failing with `LNK1180: insufficient disk space to complete link` (see [run 26436484689](https://github.com/windmill-labs/windmill/actions/runs/26436484689/job/77820392156)). The previous fix (#9201) disabled PDB generation, which helped but wasn't enough — the runner still ran out of disk during parallel test-binary linking, and cargo couldn't even unpack `wasm-encoder` (`os error 112` / "not enough space").

This PR reclaims disk space across the job and lowers link-time pressure:

- Drop `vcpkg` buildtrees/downloads/packages after openssl install (we only need `installed/`).
- Delete `backend/windmill-duckdb-ffi-internal/target` after extracting the DLL — duckdb's bundled build is ~2 GB and we only need the compiled DLL.
- Cap `CARGO_BUILD_JOBS` from 12 → 8 to reduce concurrent link-time temp disk usage (each test-binary link spikes several hundred MB on Windows).
- Add disk-space prints (`Get-PSDrive C`) after vcpkg cleanup, after DuckDB build, and right before `cargo test` to make future regressions visible in logs.

Fixes WIN-1989.

## Test plan

- [ ] Trigger via `workflow_dispatch` on the merged commit (or push to `ci-windows-tests`) and verify the run reaches the end of `cargo test`.
- [ ] Confirm the disk-space prints show meaningful headroom (>5 GB free) before `cargo test` begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Windows backend CI tests from running out of disk space by reclaiming space and reducing parallel link pressure. Adds disk-space checks and stabilizes `cargo test` on Windows; fixes WIN-1989.

- **Bug Fixes**
  - Clean up `vcpkg` (`buildtrees`, `downloads`, `packages`) after installing `openssl`.
  - Remove `backend/windmill-duckdb-ffi-internal/target` after copying `windmill_duckdb_ffi_internal.dll`.
  - Cap `CARGO_BUILD_JOBS` to 8 to limit transient link-time I/O.
  - Print free disk space after `vcpkg` cleanup, after DuckDB build, and before `cargo test` to spot regressions.

<sup>Written for commit ed44d3c5ceb3de03f1987548fe0de0327901290e. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9325?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

