### PR TITLE
fix(cli): handle __flow suffix in flow preview path derivation

### DIFF
--- a/cli/src/commands/flow/flow.ts
+++ b/cli/src/commands/flow/flow.ts
@@ -652,7 +652,7 @@ async function preview(
   // the anchor for relative-import resolution: inline scripts in this flow are
   // treated as living at "<flow_wm_path>/<step_id>", so "./util" resolves to
   // "<flow_wm_path_parent>/util" — matching the keys in temp_script_refs.
-  const flowWmPath = flowPath.substring(0, flowPath.indexOf(".flow")).replaceAll(SEP, "/");
+  const flowWmPath = stripFlowSuffix(flowPath).replaceAll(SEP, "/");
 
   if (opts.step) {
     await previewStep(opts.step, localFlow, flowWmPath, workspace, input, tempScriptRefs, opts.silent);
@@ -795,6 +795,19 @@ async function previewStep(
     log.info(colors.bold.underline.green(`Step '${stepId}' completed`));
     log.info(JSON.stringify(result, null, 2));
   }
+}
+
+// Strip the `.flow`/`__flow` directory suffix to recover the flow's logical
+// Windmill path. Workspaces with nonDottedPaths use `__flow`; the default
+// uses `.flow`. A previous version used `indexOf(".flow")` which returned -1
+// (and thus `substring(0, -1) === ""`) for `__flow` folders and for the
+// `dirname("flow.yaml") === "."` fallback — producing an empty path that
+// broke relative-import resolution downstream.
+function stripFlowSuffix(flowPath: string): string {
+  const stripped = flowPath.endsWith(SEP) ? flowPath.slice(0, -SEP.length) : flowPath;
+  if (stripped.endsWith(".flow")) return stripped.slice(0, -".flow".length);
+  if (stripped.endsWith("__flow")) return stripped.slice(0, -"__flow".length);
+  return stripped;
 }
 
 function findStepInFlowValue(flowValue: any, stepId: string): any | undefined {


### PR DESCRIPTION
## Summary

Follow-up to #9326 / #9330. `flow preview` derives the flow's Windmill path from the on-disk directory name using `flowPath.indexOf(".flow")`, which returns `-1` for `__flow`-suffixed directories. `substring(0, -1)` then returns `""`, producing an empty `path:` (and `flow_path:` for `--step`) in the request body. This breaks `temp_script_refs` lookup — relative imports inside inline scripts silently fall back to the deployed script content instead of resolving against locally-edited files (PR #9233's whole point).

## When does this matter?

The bug only surfaces when all three conditions stack:
1. The workspace uses `nonDottedPaths: true` in `wmill.yaml` (so flows live in `__flow` instead of `.flow` directories — see `cli/src/utils/resource_folders.ts:29-34`).
2. An inline script in the flow does a relative import (`import "./util"`, `from ../foo import bar`, etc.) to a sibling local script.
3. The local content of that sibling has changed and not been deployed yet.

In that case the worker resolves the import against the wrong base, never hits `temp_script_refs`, and runs against the deployed version — silently using stale code. For workspaces using the default `.flow` suffix, the path derivation happens to work; for `__flow` workspaces without relative imports, the empty path is sent but there's nothing to look up.

Latent on `main` since at least #9233 (in the whole-flow `preview` line) and re-introduced in the `flowWmPath` variable hoisted by #9330 (where it now also feeds the `--step` dispatcher).

## Changes

`cli/src/commands/flow/flow.ts`:
- Add a `stripFlowSuffix` helper that handles `.flow`, `__flow`, and the bare-`flow.yaml`-via-`dirname(".") === "."` fallback explicitly, instead of relying on `indexOf(".flow")`.
- Use it in the single place that derives `flowWmPath` — feeding both the whole-flow `runFlowPreview({ path: flowWmPath, ... })` call and the new `--step` dispatcher's `path:` / `flow_path:` arguments.

## Test plan

- [x] `bunx tsc --noEmit` from `cli/` — same 36-line baseline as `main`.
- [x] **Isolated `.flow` fixture** (default): flow at `f/cli_smoke/myflow.flow` with inline step `a` doing `import { tag } from "../util.ts"` and a local sibling `f/cli_smoke/util.ts`.
  - `wmill flow preview f/cli_smoke/myflow.flow --step a -d '{"x":5}'` → `"dotted-LOCAL:500"` ✓ (the local util's output; before this fix on `main`, hits this code path correctly because `.flow` happens to work).
- [x] **Isolated `__flow` fixture** (`nonDottedPaths: true`): same flow but at `f/cli_smoke/myflow__flow`.
  - `wmill flow preview f/cli_smoke/myflow__flow --step a -d '{"x":5}'` → `"underscored-LOCAL:500"` ✓ (the local util's output — this is the case `main` gets wrong; on `main` the empty `path` makes the worker fetch the deployed util.ts and either 404 or silently use the wrong content).
- [ ] Suggested follow-up (not blocking): unit test on `stripFlowSuffix` covering `.flow`, `__flow`, trailing/no trailing separator, and the `.` fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI flow preview path derivation for `__flow` directories so relative imports in inline scripts resolve against local files, not deployed code. Applies to both whole-flow preview and `--step`.

- **Bug Fixes**
  - Added `stripFlowSuffix` to handle `.flow`, `__flow`, and `flow.yaml` dirname fallback.
  - Uses it to derive `flowWmPath`, preventing empty `path`/`flow_path` with `nonDottedPaths: true` and restoring correct `temp_script_refs` resolution.

<sup>Written for commit dc6cc8328b3f7a429f68f48213cd6247215a3714. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9333?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

