### PR TITLE
fix(monitor): cleanup stale server_heartbeat background_task_state rows

### DIFF
--- a/backend/.sqlx/query-8597cd40f80e69edbf1bc7d7402baca32e33e871be454acb5175c11361fe1b0a.json
+++ b/backend/.sqlx/query-8597cd40f80e69edbf1bc7d7402baca32e33e871be454acb5175c11361fe1b0a.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM background_task_state\n         WHERE name LIKE $1\n           AND updated_at < NOW() - INTERVAL '7 days'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "8597cd40f80e69edbf1bc7d7402baca32e33e871be454acb5175c11361fe1b0a"
+}

--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -2706,6 +2706,26 @@ pub async fn monitor_db(
     };
 
     // run every hour (120 iterations * 30s = 3600s)
+    let cleanup_stale_server_heartbeats_f = async {
+        if server_mode && iteration.is_some() && iteration.as_ref().unwrap().should_run(120) {
+            if let Some(db) = conn.as_sql() {
+                match windmill_api::cleanup_stale_server_heartbeats(db).await {
+                    Ok(count) if count > 0 => {
+                        tracing::info!(
+                            "Deleted {} stale server_heartbeat background_task_state rows",
+                            count
+                        );
+                    }
+                    Err(e) => {
+                        tracing::error!("Error cleaning up stale server_heartbeat rows: {:?}", e);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    };
+
+    // run every hour (120 iterations * 30s = 3600s)
     let manage_audit_partitions_f = async {
         if server_mode && iteration.is_some() && iteration.as_ref().unwrap().should_run(120) {
             if let Some(db) = conn.as_sql() {
@@ -2763,6 +2783,7 @@ pub async fn monitor_db(
         native_triggers_sync_f,
         cleanup_notify_events_f,
         check_expiring_tokens_f,
+        cleanup_stale_server_heartbeats_f,
         manage_audit_partitions_f,
         export_audit_logs_to_object_store_f,
         cleanup_scheduled_job_deletions_f,

--- a/backend/windmill-api/src/lib.rs
+++ b/backend/windmill-api/src/lib.rs
@@ -1261,3 +1261,26 @@ pub async fn check_any_server_started(db: &DB, not_before: chrono::DateTime<chro
     .await
     .unwrap_or(false)
 }
+
+/// Delete `server_heartbeat:*` rows that have not been refreshed in a long
+/// time. Each server startup generates a fresh random `INSTANCE_NAME` and
+/// inserts a new row keyed by `server_heartbeat:{instance}`; because that
+/// row is only written once (on startup) and never updated thereafter, the
+/// table grows by one row per server restart and is otherwise never pruned.
+///
+/// The row is only consulted by `check_any_server_started`, which itself
+/// filters on `updated_at > not_before` (the moment a restart was initiated),
+/// so rows older than the cutoff cannot influence any restart decision and
+/// are safe to delete.
+pub async fn cleanup_stale_server_heartbeats(db: &DB) -> anyhow::Result<u64> {
+    let prefix = format!("{SERVER_HEARTBEAT_TASK}:");
+    let res = sqlx::query!(
+        "DELETE FROM background_task_state
+         WHERE name LIKE $1
+           AND updated_at < NOW() - INTERVAL '7 days'",
+        format!("{prefix}%"),
+    )
+    .execute(db)
+    .await?;
+    Ok(res.rows_affected())
+}


### PR DESCRIPTION
## Summary

`announce_server_started` writes a `server_heartbeat:{INSTANCE_NAME}` row in `background_task_state` on each startup. `INSTANCE_NAME` is a random 5-char string generated per process, so the row is written exactly once per startup and a *new* row is inserted on every restart — `background_task_state` grows unboundedly.

This adds an hourly cleanup task in `monitor_db` that deletes `server_heartbeat:*` rows whose `updated_at` is older than 7 days. Those rows cannot influence `check_any_server_started` (which only considers heartbeats refreshed after the restart was initiated), so pruning them is safe.

Fixes WIN-1990.

## Changes

- `backend/windmill-api/src/lib.rs`: new `cleanup_stale_server_heartbeats` helper next to the existing heartbeat code.
- `backend/src/monitor.rs`: new `cleanup_stale_server_heartbeats_f` future, run hourly alongside the other cleanup tasks.

## Test plan

- [x] `cargo check` and `cargo check --features enterprise,private` pass.
- [x] `update_sqlx.sh` regenerated; EE caches preserved.
- [x] Verified on local dev DB: 7 accumulated `server_heartbeat:*` rows pre-fix; after aging one to 8 days old and running the new DELETE, only the 6 fresh rows remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents unbounded growth of `background_task_state` by deleting stale `server_heartbeat:*` rows older than 7 days. Adds an hourly cleanup in the monitor without affecting restart detection. Addresses WIN-1990.

- **Bug Fixes**
  - Added `cleanup_stale_server_heartbeats` in `windmill-api` and scheduled it hourly in `monitor_db`.
  - Deletes only rows older than 7 days; `check_any_server_started` relies on recent entries, so behavior is unchanged.

<sup>Written for commit 754161bc089517597604823c9b667f346b9fb18b. Summary will update on new commits. <a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9338?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

