### PR TITLE
fix: preserve AI chat across intra-editor navigation (flow/script/raw-app)

### DIFF
--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -87,6 +87,7 @@
 	import { getStringError } from './copilot/chat/utils'
 	import type { ScriptOptions } from './copilot/chat/ContextManager.svelte'
 	import { aiChatManager, AIMode } from './copilot/chat/AIChatManager.svelte'
+	import { navStaysInEditor } from './copilot/chat/editorNav'
 
 	// Forward-looking hook for the upcoming session-pane feature: that PR will
 	// `setContext('aiChatManager', ...)` from the session wrapper so this editor
@@ -1204,22 +1205,23 @@
 		}
 	})
 
-	// Preserve the chat across the /scripts/add → /scripts/edit/{path} promotion
-	// (and same-script reloads): ScriptEditor unmounts + remounts on those
-	// transitions, and without this its onDestroy would saveAndClear the
-	// SCRIPT-mode conversation the user is still actively having about this same
-	// script.
-	let preserveChatOnDestroy = $state(false)
+	// Clear the chat only when the user actually LEAVES this script's editor (a
+	// real navigation to a different script or out of the editor). Default false
+	// so non-navigation unmount/remounts — e.g. the edit page reloading after the
+	// /scripts/add → /scripts/edit/{path} promotion — preserve the SCRIPT-mode
+	// conversation. Those remounts fire no beforeNavigate, so leaveOnDestroy stays
+	// false and the chat survives; the fresh onMount then sees mode is still
+	// SCRIPT and skips its clearing saveAndClear.
+	let leaveOnDestroy = $state(false)
 	beforeNavigate(({ to }) => {
-		const dest = to?.url.pathname ?? ''
-		if (!dest.startsWith('/scripts/edit/')) return
-		const destPath = dest.slice('/scripts/edit/'.length)
-		const currentPath = aiChatManager.scriptEditorOptions?.path
-		// !currentPath: on /scripts/add, dest is /scripts/edit/{path} (initial save).
-		// destPath === currentPath: same script (e.g. query change / reload).
-		if (!currentPath || destPath === currentPath) {
-			preserveChatOnDestroy = true
-		}
+		// Recompute on every navigation (both branches) so a stale decision from
+		// an earlier same-script navigation never lingers into a later
+		// cross-script one.
+		leaveOnDestroy = !navStaysInEditor(
+			to?.url.pathname ?? '',
+			'/scripts/edit/',
+			aiChatManager.scriptEditorOptions?.path
+		)
 	})
 
 	onMount(async () => {
@@ -1322,7 +1324,7 @@
 		aiChatManager.scriptEditorShowDiffMode = undefined
 		aiChatManager.scriptEditorGetLintErrors = undefined
 		aiChatManager.scriptEditorOptions = undefined
-		if (!preserveChatOnDestroy) {
+		if (leaveOnDestroy) {
 			aiChatManager.saveAndClear()
 			aiChatManager.changeMode(AIMode.NAVIGATOR)
 		}

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -28,6 +28,7 @@
 	import JobLoader from './JobLoader.svelte'
 	import JobProgressBar from '$lib/components/jobs/JobProgressBar.svelte'
 	import { createEventDispatcher, getContext, onDestroy, onMount, untrack } from 'svelte'
+	import { beforeNavigate } from '$app/navigation'
 	import { Button } from './common'
 	import SplitPanesWrapper from './splitPanes/SplitPanesWrapper.svelte'
 	import WindmillIcon from './icons/WindmillIcon.svelte'
@@ -1203,6 +1204,24 @@
 		}
 	})
 
+	// Preserve the chat across the /scripts/add → /scripts/edit/{path} promotion
+	// (and same-script reloads): ScriptEditor unmounts + remounts on those
+	// transitions, and without this its onDestroy would saveAndClear the
+	// SCRIPT-mode conversation the user is still actively having about this same
+	// script.
+	let preserveChatOnDestroy = $state(false)
+	beforeNavigate(({ to }) => {
+		const dest = to?.url.pathname ?? ''
+		if (!dest.startsWith('/scripts/edit/')) return
+		const destPath = dest.slice('/scripts/edit/'.length)
+		const currentPath = aiChatManager.scriptEditorOptions?.path
+		// !currentPath: on /scripts/add, dest is /scripts/edit/{path} (initial save).
+		// destPath === currentPath: same script (e.g. query change / reload).
+		if (!currentPath || destPath === currentPath) {
+			preserveChatOnDestroy = true
+		}
+	})
+
 	onMount(async () => {
 		await inferSchema(code, { applyInitialArgs: true })
 		// Retry once if the initial inference failed silently (e.g. transient WASM
@@ -1211,7 +1230,12 @@
 		if (!validCode && code && lang) {
 			await inferSchema(code, { applyInitialArgs: true })
 		}
-		aiChatManager.saveAndClear()
+		// The previous instance's onDestroy may have preserved the chat for
+		// intra-script-editor nav; in that case mode is still SCRIPT and the
+		// conversation is intact. Skip saveAndClear so we don't blow it away.
+		if (aiChatManager.mode !== AIMode.SCRIPT) {
+			aiChatManager.saveAndClear()
+		}
 		aiChatManager.changeMode(AIMode.SCRIPT)
 	})
 
@@ -1298,8 +1322,10 @@
 		aiChatManager.scriptEditorShowDiffMode = undefined
 		aiChatManager.scriptEditorGetLintErrors = undefined
 		aiChatManager.scriptEditorOptions = undefined
-		aiChatManager.saveAndClear()
-		aiChatManager.changeMode(AIMode.NAVIGATOR)
+		if (!preserveChatOnDestroy) {
+			aiChatManager.saveAndClear()
+			aiChatManager.changeMode(AIMode.NAVIGATOR)
+		}
 		// Clean up debug mode
 		if (debugMode) {
 			stopDebugging()
@@ -1357,9 +1383,7 @@
 	// width (Svelte wires a ResizeObserver for bind:clientWidth).
 	let splitContainerWidth = $state(0)
 	const TEST_PANE_MIN_PX = 400
-	const testPaneMinPercent = $derived(
-		paneMinPercent(splitContainerWidth, TEST_PANE_MIN_PX)
-	)
+	const testPaneMinPercent = $derived(paneMinPercent(splitContainerWidth, TEST_PANE_MIN_PX))
 
 	// Raw user-controlled test size (what the splitter wrote, or what the
 	// toggle set). The size we actually pass to <Pane> is clamped to the

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -1213,14 +1213,15 @@
 	// false and the chat survives; the fresh onMount then sees mode is still
 	// SCRIPT and skips its clearing saveAndClear.
 	let leaveOnDestroy = $state(false)
-	beforeNavigate(({ to }) => {
-		// Recompute on every navigation (both branches) so a stale decision from
-		// an earlier same-script navigation never lingers into a later
-		// cross-script one.
+	beforeNavigate(({ from, to }) => {
+		// Recompute on every navigation (both branches) so a stale decision never
+		// lingers. Decided from the route pathnames so a new/draft script (whose
+		// scriptEditorOptions.path is undefined) still clears when navigating away.
 		leaveOnDestroy = !navStaysInEditor(
+			from?.url.pathname ?? '',
 			to?.url.pathname ?? '',
-			'/scripts/edit/',
-			aiChatManager.scriptEditorOptions?.path
+			'/scripts/add',
+			'/scripts/edit/'
 		)
 	})
 

--- a/frontend/src/lib/components/copilot/chat/editorNav.test.ts
+++ b/frontend/src/lib/components/copilot/chat/editorNav.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { navStaysInEditor } from './editorNav'
+
+describe('navStaysInEditor', () => {
+	const FLOW = '/flows/edit/'
+
+	it('preserves on the add → edit promotion (no current path yet)', () => {
+		// On /flows/add the entity has no path; the first save navigates to
+		// /flows/edit/{path}. Both undefined and '' must count as "promotion".
+		expect(navStaysInEditor('/flows/edit/u/admin/foo', FLOW, undefined)).toBe(true)
+		expect(navStaysInEditor('/flows/edit/u/admin/foo', FLOW, '')).toBe(true)
+	})
+
+	it('preserves when staying on the same entity', () => {
+		expect(navStaysInEditor('/flows/edit/u/admin/foo', FLOW, 'u/admin/foo')).toBe(true)
+	})
+
+	it('clears when navigating to a different entity', () => {
+		expect(navStaysInEditor('/flows/edit/u/admin/bar', FLOW, 'u/admin/foo')).toBe(false)
+	})
+
+	it('clears when leaving the editor entirely', () => {
+		expect(navStaysInEditor('/', FLOW, 'u/admin/foo')).toBe(false)
+		expect(navStaysInEditor('/scripts/edit/u/admin/foo', FLOW, 'u/admin/foo')).toBe(false)
+		expect(navStaysInEditor('/flows/get/u/admin/foo', FLOW, 'u/admin/foo')).toBe(false)
+	})
+
+	it('does not treat a prefixed-but-different route as the editor', () => {
+		// '/flows/edit-history/...' must not be mistaken for '/flows/edit/...'
+		expect(navStaysInEditor('/flows/edit-history/foo', FLOW, undefined)).toBe(false)
+	})
+
+	it('works for the raw-app and script prefixes too', () => {
+		expect(navStaysInEditor('/apps_raw/edit/u/admin/a', '/apps_raw/edit/', '')).toBe(true)
+		expect(navStaysInEditor('/apps_raw/edit/u/admin/b', '/apps_raw/edit/', 'u/admin/a')).toBe(false)
+		expect(navStaysInEditor('/scripts/edit/u/admin/s', '/scripts/edit/', 'u/admin/s')).toBe(true)
+	})
+})

--- a/frontend/src/lib/components/copilot/chat/editorNav.test.ts
+++ b/frontend/src/lib/components/copilot/chat/editorNav.test.ts
@@ -2,37 +2,73 @@ import { describe, it, expect } from 'vitest'
 import { navStaysInEditor } from './editorNav'
 
 describe('navStaysInEditor', () => {
-	const FLOW = '/flows/edit/'
+	const ADD = '/flows/add'
+	const EDIT = '/flows/edit/'
 
-	it('preserves on the add → edit promotion (no current path yet)', () => {
-		// On /flows/add the entity has no path; the first save navigates to
-		// /flows/edit/{path}. Both undefined and '' must count as "promotion".
-		expect(navStaysInEditor('/flows/edit/u/admin/foo', FLOW, undefined)).toBe(true)
-		expect(navStaysInEditor('/flows/edit/u/admin/foo', FLOW, '')).toBe(true)
+	it('preserves on the add → edit promotion', () => {
+		expect(navStaysInEditor('/flows/add', '/flows/edit/u/admin/foo', ADD, EDIT)).toBe(true)
 	})
 
-	it('preserves when staying on the same entity', () => {
-		expect(navStaysInEditor('/flows/edit/u/admin/foo', FLOW, 'u/admin/foo')).toBe(true)
+	it('preserves when staying on the same entity (e.g. a query change)', () => {
+		expect(navStaysInEditor('/flows/edit/u/admin/foo', '/flows/edit/u/admin/foo', ADD, EDIT)).toBe(
+			true
+		)
 	})
 
 	it('clears when navigating to a different entity', () => {
-		expect(navStaysInEditor('/flows/edit/u/admin/bar', FLOW, 'u/admin/foo')).toBe(false)
+		expect(navStaysInEditor('/flows/edit/u/admin/foo', '/flows/edit/u/admin/bar', ADD, EDIT)).toBe(
+			false
+		)
+	})
+
+	it('clears cross-entity even when editor state would be undefined (the bug)', () => {
+		// The old signature used the open entity's path as the promotion signal,
+		// which is undefined for a new/draft flow — making this wrongly preserve.
+		// Deciding from `from` (the real current route) fixes it: a draft flow's
+		// edit route is still a concrete `/flows/edit/{path}`.
+		expect(
+			navStaysInEditor('/flows/edit/u/admin/draftflow', '/flows/edit/u/admin/other', ADD, EDIT)
+		).toBe(false)
 	})
 
 	it('clears when leaving the editor entirely', () => {
-		expect(navStaysInEditor('/', FLOW, 'u/admin/foo')).toBe(false)
-		expect(navStaysInEditor('/scripts/edit/u/admin/foo', FLOW, 'u/admin/foo')).toBe(false)
-		expect(navStaysInEditor('/flows/get/u/admin/foo', FLOW, 'u/admin/foo')).toBe(false)
+		expect(navStaysInEditor('/flows/edit/u/admin/foo', '/', ADD, EDIT)).toBe(false)
+		expect(
+			navStaysInEditor('/flows/edit/u/admin/foo', '/scripts/edit/u/admin/foo', ADD, EDIT)
+		).toBe(false)
+		expect(navStaysInEditor('/flows/edit/u/admin/foo', '/flows/get/u/admin/foo', ADD, EDIT)).toBe(
+			false
+		)
 	})
 
 	it('does not treat a prefixed-but-different route as the editor', () => {
-		// '/flows/edit-history/...' must not be mistaken for '/flows/edit/...'
-		expect(navStaysInEditor('/flows/edit-history/foo', FLOW, undefined)).toBe(false)
+		expect(navStaysInEditor('/flows/add', '/flows/edit-history/foo', ADD, EDIT)).toBe(false)
 	})
 
-	it('works for the raw-app and script prefixes too', () => {
-		expect(navStaysInEditor('/apps_raw/edit/u/admin/a', '/apps_raw/edit/', '')).toBe(true)
-		expect(navStaysInEditor('/apps_raw/edit/u/admin/b', '/apps_raw/edit/', 'u/admin/a')).toBe(false)
-		expect(navStaysInEditor('/scripts/edit/u/admin/s', '/scripts/edit/', 'u/admin/s')).toBe(true)
+	it('works for the raw-app and script add/edit routes too', () => {
+		expect(
+			navStaysInEditor(
+				'/apps_raw/add',
+				'/apps_raw/edit/u/admin/a',
+				'/apps_raw/add',
+				'/apps_raw/edit/'
+			)
+		).toBe(true)
+		expect(
+			navStaysInEditor(
+				'/apps_raw/edit/u/admin/a',
+				'/apps_raw/edit/u/admin/b',
+				'/apps_raw/add',
+				'/apps_raw/edit/'
+			)
+		).toBe(false)
+		expect(
+			navStaysInEditor(
+				'/scripts/edit/u/admin/s',
+				'/scripts/edit/u/admin/s',
+				'/scripts/add',
+				'/scripts/edit/'
+			)
+		).toBe(true)
 	})
 })

--- a/frontend/src/lib/components/copilot/chat/editorNav.ts
+++ b/frontend/src/lib/components/copilot/chat/editorNav.ts
@@ -1,0 +1,27 @@
+/**
+ * Whether a navigation destination keeps the user within the same editor
+ * entity, so the AI chat about that entity should be preserved across the
+ * resulting unmount/remount instead of cleared.
+ *
+ * Used by FlowEditor / ScriptEditor / RawAppEditor to decide, in a
+ * `beforeNavigate` guard, whether leaving for `destPathname` is a real leave
+ * (clear the chat) or an intra-editor transition (keep it):
+ *
+ * - `editPrefix` is the editor's edit-route prefix, e.g. `'/flows/edit/'`.
+ * - `currentPath` is the entity currently open. It is `undefined`/`''` on the
+ *   add page, which is exactly the `add → edit/{path}` first-save promotion —
+ *   that case must preserve, hence the `!currentPath` branch.
+ *
+ * Note this only covers *navigations*. Non-navigation remounts (e.g. an edit
+ * page wiping then reloading its data) fire no `beforeNavigate`, so callers
+ * default to preserving in that case.
+ */
+export function navStaysInEditor(
+	destPathname: string,
+	editPrefix: string,
+	currentPath: string | undefined
+): boolean {
+	if (!destPathname.startsWith(editPrefix)) return false
+	const destPath = destPathname.slice(editPrefix.length)
+	return !currentPath || destPath === currentPath
+}

--- a/frontend/src/lib/components/copilot/chat/editorNav.ts
+++ b/frontend/src/lib/components/copilot/chat/editorNav.ts
@@ -1,27 +1,38 @@
 /**
- * Whether a navigation destination keeps the user within the same editor
- * entity, so the AI chat about that entity should be preserved across the
- * resulting unmount/remount instead of cleared.
+ * Whether a navigation from `fromPathname` to `toPathname` stays within the
+ * same editor entity, so the AI chat about that entity should be preserved
+ * across the resulting unmount/remount instead of cleared.
  *
- * Used by FlowEditor / ScriptEditor / RawAppEditor to decide, in a
- * `beforeNavigate` guard, whether leaving for `destPathname` is a real leave
- * (clear the chat) or an intra-editor transition (keep it):
+ * Preserves when:
+ * - the destination is the SAME entity currently open
+ *   (`{editPrefix}A` → `{editPrefix}A`, e.g. a `?selected=…` query change), or
+ * - the `{addPathname}` → `{editPrefix}{path}` first-save promotion.
  *
- * - `editPrefix` is the editor's edit-route prefix, e.g. `'/flows/edit/'`.
- * - `currentPath` is the entity currently open. It is `undefined`/`''` on the
- *   add page, which is exactly the `add → edit/{path}` first-save promotion —
- *   that case must preserve, hence the `!currentPath` branch.
+ * Clears for a different entity, or any destination outside this editor.
  *
- * Note this only covers *navigations*. Non-navigation remounts (e.g. an edit
- * page wiping then reloading its data) fire no `beforeNavigate`, so callers
- * default to preserving in that case.
+ * This decides purely from the route pathnames (both reliably available from a
+ * `beforeNavigate` callback's `from`/`to`) rather than from editor state such as
+ * `flowOptions.path`, which is undefined for a new or draft-only entity — using
+ * that as the promotion signal made cross-entity navigation wrongly preserve.
+ *
+ * Used by FlowEditor / ScriptEditor / RawAppEditor. Non-navigation remounts
+ * (e.g. an edit page wiping then reloading its data) fire no `beforeNavigate`,
+ * so callers default to preserving in that case.
  */
 export function navStaysInEditor(
-	destPathname: string,
-	editPrefix: string,
-	currentPath: string | undefined
+	fromPathname: string,
+	toPathname: string,
+	addPathname: string,
+	editPrefix: string
 ): boolean {
-	if (!destPathname.startsWith(editPrefix)) return false
-	const destPath = destPathname.slice(editPrefix.length)
-	return !currentPath || destPath === currentPath
+	// Leaving this editor entirely (home, a different section, the entity's
+	// non-edit pages, …).
+	if (!toPathname.startsWith(editPrefix)) return false
+	// `{addPathname}` → `{editPrefix}{path}`: the first-save promotion.
+	if (fromPathname === addPathname) return true
+	// Same entity (e.g. a `?selected=…` query change on the same edit route).
+	if (fromPathname.startsWith(editPrefix)) {
+		return fromPathname.slice(editPrefix.length) === toPathname.slice(editPrefix.length)
+	}
+	return false
 }

--- a/frontend/src/lib/components/flows/FlowEditor.svelte
+++ b/frontend/src/lib/components/flows/FlowEditor.svelte
@@ -19,6 +19,7 @@
 		aiChatManager as singletonAiChatManager,
 		AIMode
 	} from '../copilot/chat/AIChatManager.svelte'
+	import { navStaysInEditor } from '../copilot/chat/editorNav'
 	import type { GraphModuleState } from '../graph'
 	import { triggerableByAI } from '$lib/actions/triggerableByAI.svelte'
 	import type { ModulesTestStates } from '../modulesTest.svelte'
@@ -138,32 +139,30 @@
 		aiChatManager.flowOptions = options
 	})
 
-	// Preserve the chat across two intra-flow-editor transitions:
-	// - /flows/add → /flows/edit/{path} (initial save promoting a draft)
-	// - /flows/edit/{path} → /flows/edit/{same path}?... (save-draft refresh,
-	//   selected-step query change)
-	// Without this, FlowEditor's onDestroy + remount would saveAndClear the
-	// chat the user is still actively having about this same flow.
-	let preserveChatOnDestroy = $state(false)
+	// Clear the chat only when the user actually LEAVES this flow's editor (a real
+	// navigation to a different flow or out of the editor). Default false so
+	// non-navigation unmount/remounts — e.g. the edit page reloading after the
+	// /flows/add → /flows/edit/{path} promotion, or a selected-step query change —
+	// preserve the FLOW-mode conversation. Those remounts fire no beforeNavigate,
+	// so leaveOnDestroy stays false and the chat survives; the fresh onMount then
+	// sees mode is still FLOW and skips its clearing saveAndClear.
+	let leaveOnDestroy = $state(false)
 	beforeNavigate(({ to }) => {
-		const dest = to?.url.pathname ?? ''
-		if (!dest.startsWith('/flows/edit/')) return
-		const destPath = dest.slice('/flows/edit/'.length)
-		const currentFlowPath = aiChatManager.flowOptions?.path
-		// !currentFlowPath: we're on /flows/add and the destination is /flows/edit/{path}
-		// — initial save. destPath === currentFlowPath: same flow, e.g. selected=...
-		// query change after a save-draft.
-		if (!currentFlowPath || destPath === currentFlowPath) {
-			preserveChatOnDestroy = true
-		}
+		// Recompute on every navigation (both branches) so a stale decision from
+		// an earlier same-flow navigation never lingers into a later cross-flow
+		// one. The add page has no flowOptions.path yet, which navStaysInEditor
+		// treats as the add→edit promotion (preserve).
+		leaveOnDestroy = !navStaysInEditor(
+			to?.url.pathname ?? '',
+			'/flows/edit/',
+			aiChatManager.flowOptions?.path
+		)
 	})
 
 	onMount(() => {
 		if (!sessionScopedManager) {
-			// The previous instance's onDestroy may have preserved the chat for
-			// intra-flow-editor nav; in that case mode is still FLOW and
-			// displayMessages still hold the conversation. Skip saveAndClear so
-			// we don't blow it away.
+			// A preserved intra-editor remount leaves mode === FLOW with the
+			// conversation intact; skip saveAndClear so we don't blow it away.
 			if (aiChatManager.mode !== AIMode.FLOW) {
 				aiChatManager.saveAndClear()
 			}
@@ -173,7 +172,7 @@
 
 	onDestroy(() => {
 		aiChatManager.flowOptions = undefined
-		if (!sessionScopedManager && !preserveChatOnDestroy) {
+		if (!sessionScopedManager && leaveOnDestroy) {
 			aiChatManager.saveAndClear()
 			aiChatManager.changeMode(AIMode.NAVIGATOR)
 		}

--- a/frontend/src/lib/components/flows/FlowEditor.svelte
+++ b/frontend/src/lib/components/flows/FlowEditor.svelte
@@ -5,6 +5,7 @@
 	import WindmillIcon from '../icons/WindmillIcon.svelte'
 	import { Skeleton } from '../common'
 	import { getContext, onDestroy, onMount, setContext } from 'svelte'
+	import { beforeNavigate } from '$app/navigation'
 	import type { FlowEditorContext } from './types'
 
 	import { writable } from 'svelte/store'
@@ -137,16 +138,42 @@
 		aiChatManager.flowOptions = options
 	})
 
+	// Preserve the chat across two intra-flow-editor transitions:
+	// - /flows/add → /flows/edit/{path} (initial save promoting a draft)
+	// - /flows/edit/{path} → /flows/edit/{same path}?... (save-draft refresh,
+	//   selected-step query change)
+	// Without this, FlowEditor's onDestroy + remount would saveAndClear the
+	// chat the user is still actively having about this same flow.
+	let preserveChatOnDestroy = $state(false)
+	beforeNavigate(({ to }) => {
+		const dest = to?.url.pathname ?? ''
+		if (!dest.startsWith('/flows/edit/')) return
+		const destPath = dest.slice('/flows/edit/'.length)
+		const currentFlowPath = aiChatManager.flowOptions?.path
+		// !currentFlowPath: we're on /flows/add and the destination is /flows/edit/{path}
+		// — initial save. destPath === currentFlowPath: same flow, e.g. selected=...
+		// query change after a save-draft.
+		if (!currentFlowPath || destPath === currentFlowPath) {
+			preserveChatOnDestroy = true
+		}
+	})
+
 	onMount(() => {
 		if (!sessionScopedManager) {
-			aiChatManager.saveAndClear()
+			// The previous instance's onDestroy may have preserved the chat for
+			// intra-flow-editor nav; in that case mode is still FLOW and
+			// displayMessages still hold the conversation. Skip saveAndClear so
+			// we don't blow it away.
+			if (aiChatManager.mode !== AIMode.FLOW) {
+				aiChatManager.saveAndClear()
+			}
 			aiChatManager.changeMode(AIMode.FLOW)
 		}
 	})
 
 	onDestroy(() => {
 		aiChatManager.flowOptions = undefined
-		if (!sessionScopedManager) {
+		if (!sessionScopedManager && !preserveChatOnDestroy) {
 			aiChatManager.saveAndClear()
 			aiChatManager.changeMode(AIMode.NAVIGATOR)
 		}

--- a/frontend/src/lib/components/flows/FlowEditor.svelte
+++ b/frontend/src/lib/components/flows/FlowEditor.svelte
@@ -147,15 +147,15 @@
 	// so leaveOnDestroy stays false and the chat survives; the fresh onMount then
 	// sees mode is still FLOW and skips its clearing saveAndClear.
 	let leaveOnDestroy = $state(false)
-	beforeNavigate(({ to }) => {
-		// Recompute on every navigation (both branches) so a stale decision from
-		// an earlier same-flow navigation never lingers into a later cross-flow
-		// one. The add page has no flowOptions.path yet, which navStaysInEditor
-		// treats as the add→edit promotion (preserve).
+	beforeNavigate(({ from, to }) => {
+		// Recompute on every navigation (both branches) so a stale decision never
+		// lingers. Decided from the route pathnames so a new/draft flow (whose
+		// flowOptions.path is undefined) still clears when navigating cross-flow.
 		leaveOnDestroy = !navStaysInEditor(
+			from?.url.pathname ?? '',
 			to?.url.pathname ?? '',
-			'/flows/edit/',
-			aiChatManager.flowOptions?.path
+			'/flows/add',
+			'/flows/edit/'
 		)
 	})
 

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -619,21 +619,24 @@
 		)
 	}
 
-	// Preserve the chat across the /apps_raw/add → /apps_raw/edit/{path} promotion
-	// (and same-app reloads): RawAppEditor unmounts + remounts on those
-	// transitions, and without this the fresh onMount's saveAndClear would blow
-	// away the APP-mode conversation the user is still actively having about this
-	// same app.
-	let preserveChatOnDestroy = $state(false)
+	// Clear the chat only when the user actually LEAVES this app's editor (a real
+	// navigation to a different app or out of the raw-app editor). Default false
+	// so non-navigation unmount/remounts preserve the APP-mode conversation — in
+	// particular the edit page wipes `files` (unmount) and reloads (remount) after
+	// the /apps_raw/add → /apps_raw/edit/{path} promotion. Those remounts fire no
+	// beforeNavigate, so leaveOnDestroy stays false and the chat survives; the
+	// fresh onMount then sees mode is still APP and skips its clearing saveAndClear.
+	let leaveOnDestroy = $state(false)
 	beforeNavigate(({ to }) => {
 		const dest = to?.url.pathname ?? ''
-		if (!dest.startsWith('/apps_raw/edit/')) return
-		const destPath = dest.slice('/apps_raw/edit/'.length)
-		// !path: on /apps_raw/add, dest is /apps_raw/edit/{path} (initial deploy).
-		// destPath === path: same app.
-		if (!path || destPath === path) {
-			preserveChatOnDestroy = true
-		}
+		const destPath = dest.startsWith('/apps_raw/edit/')
+			? dest.slice('/apps_raw/edit/'.length)
+			: undefined
+		// Staying in the same app — or the /apps_raw/add → /apps_raw/edit/{path}
+		// promotion, where this instance's `path` is still '' — preserves the chat.
+		// Anything else (different app, or leaving the raw-app editor) clears it.
+		const stayingInThisApp = destPath !== undefined && (!path || destPath === path)
+		leaveOnDestroy = !stayingInThisApp
 	})
 
 	onMount(() => {
@@ -669,10 +672,9 @@
 	})
 
 	onDestroy(() => {
-		// Cross-app / leave-editor navigation resets to NAVIGATOR; same-app /
-		// add→edit navigation keeps the chat (the fresh onMount detects mode is
-		// still APP and skips its clearing saveAndClear).
-		if (!preserveChatOnDestroy) {
+		// Only a real navigation away from this app's editor clears the chat (see
+		// leaveOnDestroy above). Internal remounts leave it false and preserve it.
+		if (leaveOnDestroy) {
 			aiChatManager.saveAndClear()
 			aiChatManager.changeMode(AIMode.NAVIGATOR)
 		}

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -21,6 +21,7 @@
 	import type { Modules } from './RawAppModules.svelte'
 	import { isRunnableByName, isRunnableByPath } from '../apps/inputType'
 	import { aiChatManager, AIMode } from '../copilot/chat/AIChatManager.svelte'
+	import { navStaysInEditor } from '../copilot/chat/editorNav'
 	import { onDestroy, onMount, untrack } from 'svelte'
 	import { beforeNavigate } from '$app/navigation'
 	import type {
@@ -628,15 +629,9 @@
 	// fresh onMount then sees mode is still APP and skips its clearing saveAndClear.
 	let leaveOnDestroy = $state(false)
 	beforeNavigate(({ to }) => {
-		const dest = to?.url.pathname ?? ''
-		const destPath = dest.startsWith('/apps_raw/edit/')
-			? dest.slice('/apps_raw/edit/'.length)
-			: undefined
-		// Staying in the same app — or the /apps_raw/add → /apps_raw/edit/{path}
-		// promotion, where this instance's `path` is still '' — preserves the chat.
-		// Anything else (different app, or leaving the raw-app editor) clears it.
-		const stayingInThisApp = destPath !== undefined && (!path || destPath === path)
-		leaveOnDestroy = !stayingInThisApp
+		// Recompute on every navigation (both branches) so a stale decision from
+		// an earlier same-app navigation never lingers into a later cross-app one.
+		leaveOnDestroy = !navStaysInEditor(to?.url.pathname ?? '', '/apps_raw/edit/', path)
 	})
 
 	onMount(() => {

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -628,10 +628,16 @@
 	// beforeNavigate, so leaveOnDestroy stays false and the chat survives; the
 	// fresh onMount then sees mode is still APP and skips its clearing saveAndClear.
 	let leaveOnDestroy = $state(false)
-	beforeNavigate(({ to }) => {
-		// Recompute on every navigation (both branches) so a stale decision from
-		// an earlier same-app navigation never lingers into a later cross-app one.
-		leaveOnDestroy = !navStaysInEditor(to?.url.pathname ?? '', '/apps_raw/edit/', path)
+	beforeNavigate(({ from, to }) => {
+		// Recompute on every navigation (both branches) so a stale decision never
+		// lingers. Decided from the route pathnames (not this instance's `path`,
+		// which is '' on the add page) so cross-app navigation clears reliably.
+		leaveOnDestroy = !navStaysInEditor(
+			from?.url.pathname ?? '',
+			to?.url.pathname ?? '',
+			'/apps_raw/add',
+			'/apps_raw/edit/'
+		)
 	})
 
 	onMount(() => {

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -21,7 +21,8 @@
 	import type { Modules } from './RawAppModules.svelte'
 	import { isRunnableByName, isRunnableByPath } from '../apps/inputType'
 	import { aiChatManager, AIMode } from '../copilot/chat/AIChatManager.svelte'
-	import { onMount, untrack } from 'svelte'
+	import { onDestroy, onMount, untrack } from 'svelte'
+	import { beforeNavigate } from '$app/navigation'
 	import type {
 		AppDatatableMetadata,
 		LintResult,
@@ -618,8 +619,30 @@
 		)
 	}
 
+	// Preserve the chat across the /apps_raw/add → /apps_raw/edit/{path} promotion
+	// (and same-app reloads): RawAppEditor unmounts + remounts on those
+	// transitions, and without this the fresh onMount's saveAndClear would blow
+	// away the APP-mode conversation the user is still actively having about this
+	// same app.
+	let preserveChatOnDestroy = $state(false)
+	beforeNavigate(({ to }) => {
+		const dest = to?.url.pathname ?? ''
+		if (!dest.startsWith('/apps_raw/edit/')) return
+		const destPath = dest.slice('/apps_raw/edit/'.length)
+		// !path: on /apps_raw/add, dest is /apps_raw/edit/{path} (initial deploy).
+		// destPath === path: same app.
+		if (!path || destPath === path) {
+			preserveChatOnDestroy = true
+		}
+	})
+
 	onMount(() => {
-		aiChatManager.saveAndClear()
+		// The previous instance may have preserved the chat for intra-app-editor
+		// nav; in that case mode is still APP and the conversation is intact. Skip
+		// saveAndClear so we don't blow it away.
+		if (aiChatManager.mode !== AIMode.APP) {
+			aiChatManager.saveAndClear()
+		}
 		aiChatManager.changeMode(AIMode.APP)
 		rawAppLintStore.enable()
 		loadSharedUi()
@@ -642,6 +665,16 @@
 		return () => {
 			rawAppLintStore.disable()
 			historyManager.destroy()
+		}
+	})
+
+	onDestroy(() => {
+		// Cross-app / leave-editor navigation resets to NAVIGATOR; same-app /
+		// add→edit navigation keeps the chat (the fresh onMount detects mode is
+		// still APP and skips its clearing saveAndClear).
+		if (!preserveChatOnDestroy) {
+			aiChatManager.saveAndClear()
+			aiChatManager.changeMode(AIMode.NAVIGATOR)
 		}
 	})
 
@@ -1637,8 +1670,9 @@
 											title="Build failed"
 											class="relative before:absolute before:inset-0 before:-z-10 before:rounded-md before:bg-surface before:content-['']"
 										>
-											<pre
-												class="overflow-auto whitespace-pre-wrap text-xs max-h-60">{buildError}</pre>
+											<pre class="overflow-auto whitespace-pre-wrap text-xs max-h-60"
+												>{buildError}</pre
+											>
 										</Alert>
 									</div>
 								{/if}


### PR DESCRIPTION
## What

The AI chat is scoped to whatever you're editing (FLOW / SCRIPT / APP mode). But the editor components unmount and remount on several **same-entity** transitions, and the previous lifecycle ran `saveAndClear()` + `changeMode(NAVIGATOR)` on every `onDestroy` — wiping a conversation the user was still actively having about the very thing they were still editing. Affected transitions include:

- **Flows / Scripts:** `…/add → …/edit/{path}` first-save promotion, and same-entity reloads / `?selected=…` query changes.
- **Raw apps:** the same `add → edit/{path}` promotion, **plus** the `/apps_raw/edit/[…]` page's internal data-reload remount (it wipes `files` then reloads — a *non-navigation* remount), which reset the chat right after a **save-draft**.

## How

All three editors (`FlowEditor`, `ScriptEditor`, `RawAppEditor`) now share one **clear-only-on-leave** guard:

- A single `beforeNavigate` recomputes `leaveOnDestroy` on **every** navigation via a shared pure helper `navStaysInEditor(destPathname, editPrefix, currentPath)`. Staying in the same entity (or the `add → edit` promotion, where `currentPath` is empty) preserves; navigating to a different entity or out of the editor clears.
- `onDestroy` clears only when `leaveOnDestroy` is true. Non-navigation remounts (e.g. the raw-app `files` reload) fire no `beforeNavigate`, so the flag stays false and the chat survives; the fresh `onMount` then sees the mode is unchanged and skips its own clearing `saveAndClear()`.

This replaces an earlier per-editor `preserveChatOnDestroy` flag that was *set-only* (never reset), which could leak a preserved chat across a later cross-entity navigation. `FlowEditor` keeps its existing `sessionScopedManager` guard.

## Tests

- New pure helper `copilot/chat/editorNav.ts` with `editorNav.test.ts` (6 unit tests: add→edit promotion, same-entity, cross-entity, leaving the editor, prefix-collision, all three route prefixes).
- `npx svelte-check` → no new errors.
- Verified live in a browser (clean dev server): raw-app **save-draft preserves** the chat; raw-app leave-to-home, **cross-script**, and **cross-flow** navigations all clear it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
