### PR TITLE
fix(docker): bump cargo-sweep from ^0.7 to ^0.8

### DIFF
--- a/docker/DockerfileFull
+++ b/docker/DockerfileFull
@@ -3,7 +3,7 @@ FROM ghcr.io/windmill-labs/windmill:dev
 # Rust
 COPY --from=rust:1.93.0 /usr/local/cargo /usr/local/cargo
 COPY --from=rust:1.93.0 /usr/local/rustup /usr/local/rustup
-RUN RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo /usr/local/cargo/bin/cargo install cargo-sweep --version ^0.7
+RUN RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo /usr/local/cargo/bin/cargo install cargo-sweep --version ^0.8
 
 # Ansible
 RUN uv tool install ansible && [ -d "$(uv tool dir)/ansible/bin/" ] && find "$(uv tool dir)/ansible/bin/" -mindepth 1 -maxdepth 1 -type f -executable -regextype posix-extended -regex '^((.+/)?)[^.]+' -print0 | xargs -0 ln -s -t "$UV_TOOL_BIN_DIR/" || true

--- a/docker/DockerfileFullEe
+++ b/docker/DockerfileFullEe
@@ -22,7 +22,7 @@ FROM ghcr.io/windmill-labs/windmill-ee:dev
 # Rust
 COPY --from=rust:1.93.0 /usr/local/cargo /usr/local/cargo
 COPY --from=rust:1.93.0 /usr/local/rustup /usr/local/rustup
-RUN RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo /usr/local/cargo/bin/cargo install cargo-sweep --version ^0.7
+RUN RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo /usr/local/cargo/bin/cargo install cargo-sweep --version ^0.8
 
 # Ansible
 RUN uv tool install ansible && [ -d "$(uv tool dir)/ansible/bin/" ] && find "$(uv tool dir)/ansible/bin/" -mindepth 1 -maxdepth 1 -type f -executable -regextype posix-extended -regex '^((.+/)?)[^.]+' -print0 | xargs -0 ln -s -t "$UV_TOOL_BIN_DIR/" || true


### PR DESCRIPTION
v0.8.0 ships "Update hash algorithm for Rust >= 1.85" — without it the freshness detection used by `cargo sweep --maxsize` is inaccurate on the Rust 1.93 toolchain pulled by these images, so the worker's rust target dir can silently grow past the cap. Also picks up "Don't panic when timestamp file is not found" and "Don't bail if cleaning fails in one project".