### PR TITLE
fix: strip hash from diff comparisons to avoid spurious deployed-vs-draft diffs

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1289,7 +1289,7 @@ export function cleanValueProperties(obj: Value) {
 	} else {
 		let newObj: any = {}
 		for (const key of Object.keys(obj)) {
-			if (key !== 'parent_hash' && key !== 'draft' && key !== 'draft_only') {
+			if (key !== 'parent_hash' && key !== 'hash' && key !== 'draft' && key !== 'draft_only') {
 				newObj[key] = structuredClone(stateSnapshot(obj[key]))
 			}
 		}


### PR DESCRIPTION
## Summary

A script/flow/app `hash` is a **content-derived version id** computed by the backend on deploy. The diff helper `cleanValueProperties()` in `frontend/src/lib/utils.ts` already strips `parent_hash`, `draft`, and `draft_only` before comparing values — but **not** `hash`. As a result, every deployed-vs-draft comparison reports the `hash` as a difference, producing a noisy, spurious `hash:` line in the diff.

This surfaces in the script editor's **Show diff → Metadata** tab (both the regular `/scripts/edit` editor and the AI-session preview panel), where users see a `hash:` entry even when nothing of substance changed.

The fix adds `key !== 'hash'` to the exclusion list, consistent with the existing `parent_hash` handling. `hash` is a derived artifact of the content — the real content fields (`content`, `lock`, `schema`, `language`, …) are still compared and still drive change detection, so nothing legitimate is masked.

## Changes

- `frontend/src/lib/utils.ts`: add `key !== 'hash'` to the key-exclusion list in `cleanValueProperties()` (next to `parent_hash`).

## How to reproduce the bug (before this fix)

1. Open a **deployed** script in the editor: `/scripts/edit/<path>` (a script that already has a deployed version with a `hash`).
2. Make any small change that creates a draft difference — e.g. edit the **summary** (or any metadata/content), so the in-editor `current` differs from the deployed version.
3. Open the **Deploy** dropdown → **Show diff**.
4. Select the **Deployed <> Current** comparison and the **Metadata** tab.
5. **Before the fix:** the metadata YAML includes a `hash:` line (noise) alongside the real change. Because the deployed `hash` and the draft's (stale/absent) `hash` differ, it shows up as a spurious diff on essentially every deployed-vs-draft comparison.
6. **After the fix:** the `hash:` line is gone from the metadata; only genuine differences (e.g. the `summary` change) remain.

## Test plan

- [x] `cd frontend && npm run check:fast` passes (no type errors).
- [x] Manual browser verification (Playwright): deployed `u/admin/test`, changed its summary to create a draft diff, then **Show diff → Deployed <> Current → Metadata**. The only highlighted difference is the `summary` line (`modified for diff` → `draft summary change v2`); the metadata YAML runs `…schema → summary → tag` with **no `hash:` line anywhere** (neither as a diff line nor as unchanged context).
- [ ] (nice-to-have, not in this PR) Add a `cleanValueProperties` unit test asserting `hash` is stripped, mirroring `parent_hash`.
