### PR TITLE
fix(cli): stop re-prompting on wmill refresh prompts

### DIFF
--- a/cli/src/guidance/writer.ts
+++ b/cli/src/guidance/writer.ts
@@ -207,13 +207,19 @@ async function reconcileIncludingFile(options: {
 }
 
 function referencesIncludeLine(content: string, includeLine: string): boolean {
-  // Match only when the include sits on a line by itself (allowing leading
-  // and trailing whitespace). Earlier we split on `\s+`, but that
-  // false-positives on commented-out includes like `<!-- @AGENTS.cli.md -->`
-  // where the middle token equals the include. CRLF is handled by the
-  // `\r?\n` split.
+  // Match when the include appears as a whitespace-separated token on any
+  // line that isn't an HTML comment. We can't require the include to be on a
+  // line by itself: our own CLAUDE.md default is `Instructions are in
+  // @AGENTS.md` (one sentence), and a strict equality check made `wmill
+  // refresh prompts` re-prompt every run on files wmill itself wrote.
+  // Skipping comment-bearing lines keeps `<!-- @AGENTS.cli.md -->` from
+  // false-positiving.
   for (const line of content.split(/\r?\n/)) {
-    if (line.trim() === includeLine) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("<!--") || trimmed.endsWith("-->")) {
+      continue;
+    }
+    if (trimmed.split(/\s+/).includes(includeLine)) {
       return true;
     }
   }

--- a/cli/test/guidance_writer_unit.test.ts
+++ b/cli/test/guidance_writer_unit.test.ts
@@ -391,6 +391,13 @@ describe("writeAiGuidanceFiles — referencesAgentsCli (via reconciliation)", ()
     ["between blank lines", "before\n\n@AGENTS.cli.md\n\nafter"],
     ["leading whitespace then include", "  @AGENTS.cli.md\n"],
     ["CRLF line endings", "line one\r\n@AGENTS.cli.md\r\nline three"],
+    // Mid-sentence include: this is how our own CLAUDE.md default looks
+    // ("Instructions are in @AGENTS.md"). A strict line-equality check made
+    // `wmill refresh prompts` re-prompt every run on files wmill wrote.
+    ["mid-sentence include", "Instructions are in @AGENTS.cli.md\n"],
+    // `>` blockquote prefix doesn't disable Claude's `@`-import expansion,
+    // so we treat it as a reference too.
+    ["blockquoted include", "> @AGENTS.cli.md"],
   ])("treats %s as a reference (no append)", async (_label, content) => {
     await withTempDir(async (tempDir) => {
       await writeFile(join(tempDir, "AGENTS.md"), content, "utf8");
@@ -406,7 +413,6 @@ describe("writeAiGuidanceFiles — referencesAgentsCli (via reconciliation)", ()
     ["@AGENTS-cli-md (lookalike)", "@AGENTS-cli-md"],
     ["@AGENTS.cli.md without surrounding whitespace", "foo@AGENTS.cli.md"],
     ["commented-out include", "<!-- @AGENTS.cli.md -->"],
-    ["blockquoted include", "> @AGENTS.cli.md"],
   ])("does not treat %s as a reference (append happens)", async (_label, content) => {
     await withTempDir(async (tempDir) => {
       await writeFile(join(tempDir, "AGENTS.md"), content, "utf8");


### PR DESCRIPTION
## Summary

`wmill refresh prompts` (and the implicit refresh inside `wmill init`) was re-firing the "existing AGENTS.md / CLAUDE.md doesn't reference managed guidance" migration prompt on every invocation, even on files wmill itself had just written.

Root cause: `referencesIncludeLine` in `cli/src/guidance/writer.ts` required the include token (`@AGENTS.cli.md` or `@AGENTS.md`) to be the entire line after trimming. The wmill-default `CLAUDE.md` template (`CLAUDE_MD_DEFAULT`) is `Instructions are in @AGENTS.md\n` — the include sits mid-sentence — so the check returned `false` and the prompt fired even though the link was already correct.

## Changes

- `cli/src/guidance/writer.ts` — relax `referencesIncludeLine` to accept the include as a whitespace-separated token on any non-comment line. Skip lines containing `<!--` / `-->` so commented-out includes don't false-positive.
- `cli/test/guidance_writer_unit.test.ts` — add a `mid-sentence include` positive case (regression for the wmill-default `CLAUDE.md`). Move `blockquoted include` from negative to positive — Claude resolves `@`-imports regardless of markdown blockquote context.

## Test plan

- [x] `bun test test/guidance_writer_unit.test.ts` — 51 pass
- [ ] In a fresh workspace, run `wmill init` then `wmill refresh prompts` twice — the second run should not re-prompt.
- [ ] With a hand-edited `AGENTS.md` containing `> @AGENTS.cli.md`, confirm no prompt fires.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix repeated migration prompts in `wmill refresh prompts` and the implicit refresh in `wmill init` by recognizing `@AGENTS.md`/`@AGENTS.cli.md` references even when they appear mid-sentence. This stops re-prompting on files `wmill` just wrote.

- **Bug Fixes**
  - Relaxed `referencesIncludeLine` to match include tokens on any non-comment line; ignore `<!-- ... -->`.
  - Added tests for mid-sentence includes and treated blockquoted `> @...` includes as valid.

<sup>Written for commit 1a0bef762dfb5d830e214ec65287a197438aaaa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9357?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

