### PR TITLE
feat: inject active editor into global chat

### DIFF
--- a/ai_evals/README.md
+++ b/ai_evals/README.md
@@ -142,6 +142,15 @@ For `global` mode, `validate` can express draft-level requirements such as:
 - required or forbidden draft counts
 - forbidden draft paths
 
+Global initial fixtures can also seed `liveEditorDrafts` with `type`,
+`storagePath`, `effectivePath`, and `value` fields. These drafts emulate the
+currently open script, flow, or raw app editor so cases can test prompts that
+refer to "this" or the "current" item.
+
+Set `WMILL_AI_EVAL_DISABLE_ACTIVE_EDITOR_CONTEXT=1` to run those cases with
+the old behavior where the live editor is only discoverable through
+`list_workspace_items`.
+
 App fixtures can also include an optional `datatables.json` file at the fixture root.
 
 For `flow` mode, an `initial` fixture can also include a benchmark workspace catalog of
@@ -189,10 +198,14 @@ If `--record` is used, the CLI also appends one compact JSON line to:
 Each recorded line contains:
 
 - run metadata (`createdAt`, `gitSha`, `mode`, `runModel`, `judgeModel`)
-- suite totals (`caseCount`, `attemptCount`, `passedAttempts`, `passRate`, `averageDurationMs`, `averageJudgeScore`)
-- average token usage (`averageTokenUsagePerAttempt`)
-- per-case metrics under `cases[]` (`averageDurationMs`, `averageJudgeScore`, `averageTokenUsagePerAttempt`, pass rate)
+- suite totals (`caseCount`, `attemptCount`, `passedAttempts`, `passRate`, `averageDurationMs`, `averagePassedDurationMs`, `averageJudgeScore`)
+- average token usage (`averageTokenUsagePerAttempt`, `averageTokenUsagePerPassedAttempt`)
+- per-case metrics under `cases[]` (`averageDurationMs`, `averagePassedDurationMs`, `averageJudgeScore`, `averageTokenUsagePerAttempt`, `averageTokenUsagePerPassedAttempt`, pass rate)
 - `failedCaseIds`
+
+The CLI headline duration and token averages use passed attempts only.
+All-attempt averages are still recorded to make failures auditable without
+letting failed attempts skew success cost comparisons.
 
 Example:
 

--- a/ai_evals/adapters/frontend/core/global/globalEvalRunner.ts
+++ b/ai_evals/adapters/frontend/core/global/globalEvalRunner.ts
@@ -12,6 +12,7 @@ import {
   listGlobalDrafts,
 } from "../../../../../frontend/src/lib/components/copilot/chat/global/userDraftAdapter";
 import type { Tool as ProductionTool } from "../../../../../frontend/src/lib/components/copilot/chat/shared";
+import { UserDraft } from "../../../../../frontend/src/lib/userDraft.svelte";
 import type { ModeRunContext } from "../../../../core/types";
 import type { GlobalDraftState } from "../../../../core/validators";
 import type { WindmillBackendSettings } from "../../../../core/windmillBackendSettings";
@@ -27,6 +28,21 @@ const MUTATING_GLOBAL_TOOLS = new Set([
   "deploy_workspace_item",
   "delete_workspace_item",
 ]);
+const DISABLE_ACTIVE_EDITOR_CONTEXT_ENV =
+  "WMILL_AI_EVAL_DISABLE_ACTIVE_EDITOR_CONTEXT";
+
+const LIVE_EDITOR_ITEM_KINDS = {
+  script: "script",
+  flow: "flow",
+  app: "raw_app",
+} as const;
+
+export interface GlobalLiveEditorDraftFixture {
+  type: keyof typeof LIVE_EDITOR_ITEM_KINDS;
+  storagePath?: string;
+  effectivePath?: string;
+  value?: unknown;
+}
 
 export interface GlobalEvalResult {
   success: boolean;
@@ -41,6 +57,7 @@ export interface GlobalEvalResult {
 
 export interface GlobalEvalOptions {
   workspaceFixtures?: BenchmarkWorkspaceRunnables;
+  liveEditorDrafts?: GlobalLiveEditorDraftFixture[];
   model?: string;
   maxIterations?: number;
   provider?: AIProvider;
@@ -60,13 +77,20 @@ export async function runGlobalEval(
 
   clearGlobalDrafts(workspaceRoot);
   registerBenchmarkWorkspaceRunnables(workspaceRoot, options.workspaceFixtures ?? {});
+  seedLiveEditorDrafts(workspaceRoot, options.liveEditorDrafts ?? []);
 
   try {
     const model = options.model ?? "claude-haiku-4-5-20251001";
+    const injectActiveEditorContext =
+      process.env[DISABLE_ACTIVE_EDITOR_CONTEXT_ENV] !== "1";
     const rawResult = await runEval({
       userPrompt,
       systemMessage: prepareGlobalSystemMessage(),
-      userMessage: prepareGlobalUserMessage(userPrompt),
+      userMessage: prepareGlobalUserMessage(
+        userPrompt,
+        [],
+        injectActiveEditorContext ? { workspace: workspaceRoot } : {},
+      ),
       tools: getGlobalEvalTools(),
       helpers: {},
       apiKey,
@@ -98,10 +122,41 @@ export async function runGlobalEval(
     };
   } finally {
     clearGlobalDrafts(workspaceRoot);
+    clearLiveEditorDrafts(workspaceRoot, options.liveEditorDrafts ?? []);
     unregisterBenchmarkWorkspaceRunnables(workspaceRoot);
     if (!options.workspaceRoot) {
       await rm(workspaceRoot, { recursive: true, force: true });
     }
+  }
+}
+
+function seedLiveEditorDrafts(
+  workspace: string,
+  fixtures: GlobalLiveEditorDraftFixture[],
+): void {
+  for (const fixture of fixtures) {
+    const itemKind = LIVE_EDITOR_ITEM_KINDS[fixture.type];
+    const storagePath = fixture.storagePath ?? fixture.effectivePath ?? "";
+    if (fixture.value !== undefined) {
+      UserDraft.save(itemKind, storagePath, fixture.value, { workspace });
+    }
+    UserDraft.setLiveEditorDraft({
+      workspace,
+      itemKind,
+      storagePath,
+      effectivePath: fixture.effectivePath ?? fixture.storagePath,
+    });
+  }
+}
+
+function clearLiveEditorDrafts(
+  workspace: string,
+  fixtures: GlobalLiveEditorDraftFixture[],
+): void {
+  for (const fixture of fixtures) {
+    const itemKind = LIVE_EDITOR_ITEM_KINDS[fixture.type];
+    const storagePath = fixture.storagePath ?? fixture.effectivePath ?? "";
+    UserDraft.clearLiveEditorDraft(itemKind, { workspace, storagePath });
   }
 }
 

--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -341,3 +341,92 @@
     - updates the total calculation to apply 8% tax
     - returns subtotal, tax, and total from the updated flow logic
     - leaves the result as an AI draft only
+
+- id: global-test12-current-live-script-edit
+  prompt: |-
+    The script I have open formats greetings.
+    Can you update this script so it uppercases the name before greeting them and ends with an exclamation mark?
+    Keep it as draft work.
+  initial: ai_evals/fixtures/frontend/global/initial/current_greeting_live_script.json
+  runtime:
+    maxTurns: 8
+  validate:
+    draftCountExactly: 1
+    requiredDrafts:
+      - type: script
+        path: f/evals/global/current_greeting
+        language: bun
+        valueIncludes:
+          - toUpperCase
+          - "!"
+    forbiddenDrafts:
+      - type: script
+        path: f/evals/global/format_greeting
+      - type: script
+        path: f/evals/global/format_greeting_archive
+  toolExpect:
+    requiredToolsUsed:
+      - read_workspace_item
+    forbiddenToolsUsed:
+      - deploy_workspace_item
+      - delete_workspace_item
+  judgeChecklist:
+    - resolves "this script" to the active live editor script instead of another similarly named workspace script
+    - updates the greeting logic to uppercase the provided name
+    - returns a greeting ending with an exclamation mark
+    - leaves the result as a draft only
+
+- id: global-test13-current-live-flow-edit
+  prompt: |-
+    I have the invoice flow open.
+    In the current flow, update the total calculation to add 8% tax and return subtotal, tax, and total.
+    Keep the change as a draft.
+  initial: ai_evals/fixtures/frontend/global/initial/current_invoice_live_flow.json
+  runtime:
+    maxTurns: 10
+  validate:
+    draftCountExactly: 1
+    requiredDrafts:
+      - type: flow
+        path: f/evals/global/current_invoice_flow
+        valueIncludes:
+          - calculate_total
+          - tax
+          - total
+    forbiddenDrafts:
+      - type: flow
+        path: f/evals/global/process_invoice
+      - type: flow
+        path: f/evals/global/process_refund
+  toolExpect:
+    requiredToolsUsed:
+      - read_workspace_item
+    forbiddenToolsUsed:
+      - deploy_workspace_item
+      - delete_workspace_item
+  judgeChecklist:
+    - resolves "current flow" to the active live editor flow
+    - does not edit the similarly named deployed invoice or refund flows
+    - updates the calculate_total logic to apply 8% tax
+    - returns subtotal, tax, and total from the updated flow logic
+    - leaves the result as a draft only
+
+- id: global-test14-current-without-live-editor-asks-question
+  prompt: |-
+    Please update this script so it returns `ok`.
+    Keep it as a draft.
+  runtime:
+    maxTurns: 4
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    forbiddenToolsUsed:
+      - write_script
+      - edit_script
+      - write_flow
+      - deploy_workspace_item
+      - delete_workspace_item
+  skipJudge: true
+  judgeChecklist:
+    - asks which script to update when the user refers to "this script" without selected or active editor context
+    - does not guess a path or create a new script draft

--- a/ai_evals/cli/index.ts
+++ b/ai_evals/cli/index.ts
@@ -211,7 +211,7 @@ async function handleRun(input: {
   const summaries: Array<{
     label: string;
     passRate: number;
-    averageDurationMs: number;
+    averagePassedDurationMs: number | null;
   }> = [];
 
   for (const [index, model] of models.entries()) {
@@ -259,7 +259,7 @@ async function handleRun(input: {
     summaries.push({
       label: `${model.id} (${runModel})`,
       passRate: result.passRate,
-      averageDurationMs: result.averageDurationMs,
+      averagePassedDurationMs: result.averagePassedDurationMs ?? null,
     });
   }
 
@@ -267,7 +267,7 @@ async function handleRun(input: {
     process.stdout.write("\nModel summary\n");
     for (const summary of summaries) {
       process.stdout.write(
-        `- ${summary.label}: ${formatPercent(summary.passRate)} | ${Math.round(summary.averageDurationMs)}ms\n`,
+        `- ${summary.label}: ${formatPercent(summary.passRate)} | passed avg ${formatNullableDuration(summary.averagePassedDurationMs)}\n`,
       );
     }
   }
@@ -349,6 +349,10 @@ function resolveRequestedModels(
 
 function formatPercent(value: number): string {
   return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatNullableDuration(value: number | null): string {
+  return value === null ? "n/a" : `${Math.round(value)}ms`;
 }
 
 void main().catch((error) => {

--- a/ai_evals/core/cases.test.ts
+++ b/ai_evals/core/cases.test.ts
@@ -203,6 +203,34 @@ describe("loadCases", () => {
     });
   });
 
+  it("loads global active-editor eval cases", async () => {
+    const globalCases = await loadCases("global");
+    const scriptCase = globalCases.find(
+      (entry) => entry.id === "global-test12-current-live-script-edit"
+    );
+    const flowCase = globalCases.find(
+      (entry) => entry.id === "global-test13-current-live-flow-edit"
+    );
+
+    expect(scriptCase?.initialPath).toContain(
+      "ai_evals/fixtures/frontend/global/initial/current_greeting_live_script.json"
+    );
+    expect(scriptCase?.toolExpect).toMatchObject({
+      requiredToolsUsed: ["read_workspace_item"],
+    });
+    expect(flowCase?.initialPath).toContain(
+      "ai_evals/fixtures/frontend/global/initial/current_invoice_live_flow.json"
+    );
+    expect(flowCase?.validate).toMatchObject({
+      requiredDrafts: [
+        {
+          type: "flow",
+          path: "f/evals/global/current_invoice_flow",
+        },
+      ],
+    });
+  });
+
   it("loads tool expectations for workspace mutation cases", async () => {
     const scriptCases = await loadCases("script");
     const caseEntry = scriptCases.find(

--- a/ai_evals/core/results.test.ts
+++ b/ai_evals/core/results.test.ts
@@ -1,0 +1,242 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "bun:test";
+import {
+  appendHistoryRecord,
+  buildRunResult,
+  formatRunSummary,
+} from "./results";
+import type { BenchmarkCaseResult } from "./types";
+
+function caseResult(
+  attempts: BenchmarkCaseResult["attempts"],
+): BenchmarkCaseResult {
+  return {
+    id: "case-1",
+    prompt: "Do the thing",
+    attempts,
+  };
+}
+
+describe("benchmark results", () => {
+  it("keeps success cost metrics separate from failed attempts", () => {
+    const result = buildRunResult({
+      mode: "global",
+      runs: 1,
+      runModel: "model-under-test",
+      judgeModel: "judge-model",
+      caseResults: [
+        caseResult([
+          {
+            attempt: 1,
+            passed: true,
+            durationMs: 1000,
+            assistantMessageCount: 1,
+            toolCallCount: 1,
+            toolsUsed: ["edit_script"],
+            skillsInvoked: [],
+            checks: [{ name: "edited", passed: true }],
+            judgeScore: 100,
+            judgeSummary: "ok",
+            error: null,
+            tokenUsage: { prompt: 100, completion: 20, total: 120 },
+          },
+          {
+            attempt: 2,
+            passed: false,
+            durationMs: 100,
+            assistantMessageCount: 1,
+            toolCallCount: 0,
+            toolsUsed: [],
+            skillsInvoked: [],
+            checks: [{ name: "edited", passed: false }],
+            judgeScore: 10,
+            judgeSummary: "missed",
+            error: "failed",
+            tokenUsage: { prompt: 10, completion: 5, total: 15 },
+          },
+        ]),
+      ],
+    });
+
+    expect(result.attemptCount).toBe(2);
+    expect(result.passedAttempts).toBe(1);
+    expect(result.passRate).toBe(0.5);
+    expect(result.averageDurationMs).toBe(550);
+    expect(result.averagePassedDurationMs).toBe(1000);
+    expect(result.totalTokenUsage).toEqual({
+      prompt: 110,
+      completion: 25,
+      total: 135,
+    });
+    expect(result.totalPassedTokenUsage).toEqual({
+      prompt: 100,
+      completion: 20,
+      total: 120,
+    });
+    expect(result.averageTokenUsagePerAttempt).toEqual({
+      prompt: 55,
+      completion: 12.5,
+      total: 67.5,
+    });
+    expect(result.averageTokenUsagePerPassedAttempt).toEqual({
+      prompt: 100,
+      completion: 20,
+      total: 120,
+    });
+
+    const summary = formatRunSummary(result);
+    expect(summary).toContain("Average duration (passed): 1000ms");
+    expect(summary).toContain("Average tokens (passed): 120 total");
+    expect(summary).toContain("Average duration (all attempts): 550ms");
+  });
+
+  it("reports passed averages as unavailable when no attempt passes", () => {
+    const result = buildRunResult({
+      mode: "global",
+      runs: 1,
+      runModel: "model-under-test",
+      judgeModel: "judge-model",
+      caseResults: [
+        caseResult([
+          {
+            attempt: 1,
+            passed: false,
+            durationMs: 100,
+            assistantMessageCount: 1,
+            toolCallCount: 0,
+            toolsUsed: [],
+            skillsInvoked: [],
+            checks: [{ name: "edited", passed: false }],
+            judgeScore: 10,
+            judgeSummary: "missed",
+            error: "failed",
+            tokenUsage: { prompt: 10, completion: 5, total: 15 },
+          },
+        ]),
+      ],
+    });
+
+    expect(result.averagePassedDurationMs).toBeNull();
+    expect(result.totalPassedTokenUsage).toBeNull();
+    expect(result.averageTokenUsagePerPassedAttempt).toBeNull();
+    expect(formatRunSummary(result)).toContain(
+      "Average duration (passed): n/a",
+    );
+  });
+
+  it("normalizes passed token averages by passed attempts", () => {
+    const result = buildRunResult({
+      mode: "global",
+      runs: 1,
+      runModel: "model-under-test",
+      judgeModel: "judge-model",
+      caseResults: [
+        caseResult([
+          {
+            attempt: 1,
+            passed: true,
+            durationMs: 1000,
+            assistantMessageCount: 1,
+            toolCallCount: 1,
+            toolsUsed: ["edit_script"],
+            skillsInvoked: [],
+            checks: [{ name: "edited", passed: true }],
+            judgeScore: 100,
+            judgeSummary: "ok",
+            error: null,
+            tokenUsage: { prompt: 100, completion: 20, total: 120 },
+          },
+          {
+            attempt: 2,
+            passed: true,
+            durationMs: 1200,
+            assistantMessageCount: 1,
+            toolCallCount: 1,
+            toolsUsed: ["edit_script"],
+            skillsInvoked: [],
+            checks: [{ name: "edited", passed: true }],
+            judgeScore: 100,
+            judgeSummary: "ok",
+            error: null,
+            tokenUsage: null,
+          },
+        ]),
+      ],
+    });
+
+    expect(result.passedAttempts).toBe(2);
+    expect(result.totalPassedTokenUsage).toEqual({
+      prompt: 100,
+      completion: 20,
+      total: 120,
+    });
+    expect(result.averageTokenUsagePerPassedAttempt).toEqual({
+      prompt: 50,
+      completion: 10,
+      total: 60,
+    });
+  });
+
+  it("records passed-attempt metrics in history", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "windmill-ai-evals-"));
+    try {
+      const historyPath = join(tempDir, "history.jsonl");
+      const result = buildRunResult({
+        mode: "global",
+        runs: 1,
+        runModel: "model-under-test",
+        judgeModel: "judge-model",
+        caseResults: [
+          caseResult([
+            {
+              attempt: 1,
+              passed: true,
+              durationMs: 1000,
+              assistantMessageCount: 1,
+              toolCallCount: 1,
+              toolsUsed: ["edit_script"],
+              skillsInvoked: [],
+              checks: [{ name: "edited", passed: true }],
+              judgeScore: 100,
+              judgeSummary: "ok",
+              error: null,
+              tokenUsage: { prompt: 100, completion: 20, total: 120 },
+            },
+            {
+              attempt: 2,
+              passed: false,
+              durationMs: 100,
+              assistantMessageCount: 1,
+              toolCallCount: 0,
+              toolsUsed: [],
+              skillsInvoked: [],
+              checks: [{ name: "edited", passed: false }],
+              judgeScore: 10,
+              judgeSummary: "missed",
+              error: "failed",
+              tokenUsage: { prompt: 10, completion: 5, total: 15 },
+            },
+          ]),
+        ],
+      });
+
+      await appendHistoryRecord(result, historyPath);
+      const record = JSON.parse(await readFile(historyPath, "utf8"));
+
+      expect(record.averageDurationMs).toBe(550);
+      expect(record.averagePassedDurationMs).toBe(1000);
+      expect(record.averageTokenUsagePerAttempt.total).toBe(67.5);
+      expect(record.averageTokenUsagePerPassedAttempt.total).toBe(120);
+      expect(record.cases[0].averageDurationMs).toBe(550);
+      expect(record.cases[0].averagePassedDurationMs).toBe(1000);
+      expect(record.cases[0].averageTokenUsagePerAttempt.total).toBe(67.5);
+      expect(record.cases[0].averageTokenUsagePerPassedAttempt.total).toBe(
+        120,
+      );
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/ai_evals/core/results.ts
+++ b/ai_evals/core/results.ts
@@ -4,11 +4,19 @@ import { execFileSync } from "node:child_process";
 import { getAiEvalsRoot, getRepoRoot } from "./cases";
 import type {
   BenchmarkArtifactFile,
+  BenchmarkAttemptResult,
   BenchmarkCaseResult,
   BenchmarkRunResult,
   BenchmarkTokenUsage,
   EvalMode,
 } from "./types";
+
+type AttemptAggregate = {
+  attemptCount: number;
+  durationTotal: number;
+  tokenUsageAttemptCount: number;
+  tokenUsageTotal: BenchmarkTokenUsage | null;
+};
 
 export async function writeRunResult(
   result: BenchmarkRunResult,
@@ -77,36 +85,12 @@ export function buildRunResult(input: {
   judgeModel: string | null;
   caseResults: BenchmarkCaseResult[];
 }): BenchmarkRunResult {
-  const attemptCount = input.caseResults.reduce(
-    (sum, entry) => sum + entry.attempts.length,
-    0,
-  );
-  const passedAttempts = input.caseResults.reduce(
-    (sum, entry) =>
-      sum + entry.attempts.filter((attempt) => attempt.passed).length,
-    0,
-  );
-  const durationTotal = input.caseResults.reduce(
-    (sum, entry) =>
-      sum +
-      entry.attempts.reduce((inner, attempt) => inner + attempt.durationMs, 0),
-    0,
-  );
-  const tokenUsageTotal = input.caseResults.reduce<BenchmarkTokenUsage | null>(
-    (sum, entry) => {
-      for (const attempt of entry.attempts) {
-        if (!attempt.tokenUsage) {
-          continue;
-        }
-        sum ??= { prompt: 0, completion: 0, total: 0 };
-        sum.prompt += attempt.tokenUsage.prompt;
-        sum.completion += attempt.tokenUsage.completion;
-        sum.total += attempt.tokenUsage.total;
-      }
-      return sum;
-    },
-    null,
-  );
+  const attempts = input.caseResults.flatMap((entry) => entry.attempts);
+  const passedAttemptResults = attempts.filter((attempt) => attempt.passed);
+  const attemptAggregate = aggregateAttempts(attempts);
+  const passedAttemptAggregate = aggregateAttempts(passedAttemptResults);
+  const attemptCount = attemptAggregate.attemptCount;
+  const passedAttempts = passedAttemptAggregate.attemptCount;
 
   return {
     version: 1,
@@ -120,16 +104,19 @@ export function buildRunResult(input: {
     attemptCount,
     passedAttempts,
     passRate: attemptCount === 0 ? 0 : passedAttempts / attemptCount,
-    averageDurationMs: attemptCount === 0 ? 0 : durationTotal / attemptCount,
-    totalTokenUsage: tokenUsageTotal,
+    averageDurationMs:
+      attemptCount === 0 ? 0 : attemptAggregate.durationTotal / attemptCount,
+    averagePassedDurationMs: averageDuration(passedAttemptAggregate),
+    totalTokenUsage: attemptAggregate.tokenUsageTotal,
+    totalPassedTokenUsage: passedAttemptAggregate.tokenUsageTotal,
     averageTokenUsagePerAttempt:
-      attemptCount === 0 || !tokenUsageTotal
+      attemptCount === 0
         ? null
-        : {
-            prompt: tokenUsageTotal.prompt / attemptCount,
-            completion: tokenUsageTotal.completion / attemptCount,
-            total: tokenUsageTotal.total / attemptCount,
-          },
+        : averageTokenUsage(attemptAggregate, attemptCount),
+    averageTokenUsagePerPassedAttempt: averageTokenUsage(
+      passedAttemptAggregate,
+      passedAttempts,
+    ),
     cases: input.caseResults,
   };
 }
@@ -138,8 +125,24 @@ export function formatRunSummary(result: BenchmarkRunResult): string {
   const lines = [
     `${result.mode} benchmark complete`,
     `Pass rate: ${formatPercent(result.passRate)} (${result.passedAttempts}/${result.attemptCount})`,
-    `Average duration: ${Math.round(result.averageDurationMs)}ms`,
+    `Average duration (passed): ${formatNullableDuration(result.averagePassedDurationMs ?? null)}`,
   ];
+
+  if (result.averageTokenUsagePerPassedAttempt) {
+    lines.push(
+      `Average tokens (passed): ${formatTokenUsage(result.averageTokenUsagePerPassedAttempt)}`,
+    );
+  }
+  if (result.passedAttempts < result.attemptCount) {
+    lines.push(
+      `Average duration (all attempts): ${Math.round(result.averageDurationMs)}ms`,
+    );
+    if (result.averageTokenUsagePerAttempt) {
+      lines.push(
+        `Average tokens (all attempts): ${formatTokenUsage(result.averageTokenUsagePerAttempt)}`,
+      );
+    }
+  }
 
   const failures = collectFailures(result);
   if (failures.length > 0) {
@@ -170,6 +173,60 @@ function collectFailures(result: BenchmarkRunResult): string[] {
   }
 
   return failures;
+}
+
+function aggregateAttempts(attempts: BenchmarkAttemptResult[]): AttemptAggregate {
+  const aggregate: AttemptAggregate = {
+    attemptCount: attempts.length,
+    durationTotal: 0,
+    tokenUsageAttemptCount: 0,
+    tokenUsageTotal: null,
+  };
+
+  for (const attempt of attempts) {
+    aggregate.durationTotal += attempt.durationMs;
+    if (!attempt.tokenUsage) {
+      continue;
+    }
+    aggregate.tokenUsageAttemptCount += 1;
+    aggregate.tokenUsageTotal ??= { prompt: 0, completion: 0, total: 0 };
+    aggregate.tokenUsageTotal.prompt += attempt.tokenUsage.prompt;
+    aggregate.tokenUsageTotal.completion += attempt.tokenUsage.completion;
+    aggregate.tokenUsageTotal.total += attempt.tokenUsage.total;
+  }
+
+  return aggregate;
+}
+
+function averageDuration(aggregate: AttemptAggregate): number | null {
+  return aggregate.attemptCount === 0
+    ? null
+    : aggregate.durationTotal / aggregate.attemptCount;
+}
+
+function averageTokenUsage(
+  aggregate: AttemptAggregate,
+  denominator: number,
+): BenchmarkTokenUsage | null {
+  if (denominator === 0 || !aggregate.tokenUsageTotal) {
+    return null;
+  }
+  return {
+    prompt: aggregate.tokenUsageTotal.prompt / denominator,
+    completion: aggregate.tokenUsageTotal.completion / denominator,
+    total: aggregate.tokenUsageTotal.total / denominator,
+  };
+}
+
+function formatNullableDuration(value: number | null): string {
+  return value === null ? "n/a" : `${Math.round(value)}ms`;
+}
+
+function formatTokenUsage(value: BenchmarkTokenUsage): string {
+  const total = Math.round(value.total);
+  const prompt = Math.round(value.prompt);
+  const completion = Math.round(value.completion);
+  return `${total} total (${prompt} prompt, ${completion} completion)`;
 }
 
 function defaultFileName(mode: EvalMode): string {
@@ -252,12 +309,15 @@ function toHistoryRecord(result: BenchmarkRunResult) {
     passedAttempts: result.passedAttempts,
     passRate: result.passRate,
     averageDurationMs: result.averageDurationMs,
+    averagePassedDurationMs: result.averagePassedDurationMs ?? null,
     averageJudgeScore:
       judgeScores.length === 0
         ? null
         : judgeScores.reduce((sum, score) => sum + score, 0) /
           judgeScores.length,
     averageTokenUsagePerAttempt: result.averageTokenUsagePerAttempt ?? null,
+    averageTokenUsagePerPassedAttempt:
+      result.averageTokenUsagePerPassedAttempt ?? null,
     failedCaseIds: Array.from(
       new Set(
         result.cases
@@ -268,31 +328,15 @@ function toHistoryRecord(result: BenchmarkRunResult) {
       ),
     ),
     cases: result.cases.map((caseResult) => {
-      const attemptCount = caseResult.attempts.length;
-      const passedAttempts = caseResult.attempts.filter(
-        (attempt) => attempt.passed,
-      ).length;
-      const totalDurationMs = caseResult.attempts.reduce(
-        (sum, attempt) => sum + attempt.durationMs,
-        0,
+      const attemptAggregate = aggregateAttempts(caseResult.attempts);
+      const passedAttemptAggregate = aggregateAttempts(
+        caseResult.attempts.filter((attempt) => attempt.passed),
       );
+      const attemptCount = attemptAggregate.attemptCount;
+      const passedAttempts = passedAttemptAggregate.attemptCount;
       const judgeScores = caseResult.attempts.flatMap((attempt) =>
         typeof attempt.judgeScore === "number" ? [attempt.judgeScore] : [],
       );
-      const totalTokenUsage =
-        caseResult.attempts.reduce<BenchmarkTokenUsage | null>(
-          (sum, attempt) => {
-            if (!attempt.tokenUsage) {
-              return sum;
-            }
-            sum ??= { prompt: 0, completion: 0, total: 0 };
-            sum.prompt += attempt.tokenUsage.prompt;
-            sum.completion += attempt.tokenUsage.completion;
-            sum.total += attempt.tokenUsage.total;
-            return sum;
-          },
-          null,
-        );
 
       return {
         id: caseResult.id,
@@ -300,20 +344,23 @@ function toHistoryRecord(result: BenchmarkRunResult) {
         passedAttempts,
         passRate: attemptCount === 0 ? 0 : passedAttempts / attemptCount,
         averageDurationMs:
-          attemptCount === 0 ? 0 : totalDurationMs / attemptCount,
+          attemptCount === 0
+            ? 0
+            : attemptAggregate.durationTotal / attemptCount,
+        averagePassedDurationMs: averageDuration(passedAttemptAggregate),
         averageJudgeScore:
           judgeScores.length === 0
             ? null
             : judgeScores.reduce((sum, score) => sum + score, 0) /
               judgeScores.length,
         averageTokenUsagePerAttempt:
-          attemptCount === 0 || !totalTokenUsage
+          attemptCount === 0
             ? null
-            : {
-                prompt: totalTokenUsage.prompt / attemptCount,
-                completion: totalTokenUsage.completion / attemptCount,
-                total: totalTokenUsage.total / attemptCount,
-              },
+            : averageTokenUsage(attemptAggregate, attemptCount),
+        averageTokenUsagePerPassedAttempt: averageTokenUsage(
+          passedAttemptAggregate,
+          passedAttempts,
+        ),
       };
     }),
   };

--- a/ai_evals/core/types.ts
+++ b/ai_evals/core/types.ts
@@ -326,8 +326,11 @@ export interface BenchmarkRunResult {
   passedAttempts: number;
   passRate: number;
   averageDurationMs: number;
+  averagePassedDurationMs?: number | null;
   totalTokenUsage?: BenchmarkTokenUsage | null;
+  totalPassedTokenUsage?: BenchmarkTokenUsage | null;
   averageTokenUsagePerAttempt?: BenchmarkTokenUsage | null;
+  averageTokenUsagePerPassedAttempt?: BenchmarkTokenUsage | null;
   artifactsPath?: string | null;
   cases: BenchmarkCaseResult[];
 }

--- a/ai_evals/fixtures/frontend/global/initial/current_greeting_live_script.json
+++ b/ai_evals/fixtures/frontend/global/initial/current_greeting_live_script.json
@@ -1,0 +1,66 @@
+{
+  "workspace": {
+    "scripts": [
+      {
+        "path": "f/evals/global/format_greeting",
+        "summary": "Format a deployed greeting",
+        "description": "Returns a plain greeting for a provided name.",
+        "language": "bun",
+        "schema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": ["name"]
+        },
+        "content": "export async function main(name: string) {\n  return `Hello, ${name}`\n}\n"
+      },
+      {
+        "path": "f/evals/global/format_greeting_archive",
+        "summary": "Archived greeting formatter",
+        "description": "Older greeting formatter kept for reference.",
+        "language": "bun",
+        "schema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": ["name"]
+        },
+        "content": "export async function main(name: string) {\n  return `Hi, ${name}`\n}\n"
+      }
+    ]
+  },
+  "liveEditorDrafts": [
+    {
+      "type": "script",
+      "storagePath": "f/evals/global/current_greeting",
+      "effectivePath": "f/evals/global/current_greeting",
+      "value": {
+        "path": "f/evals/global/current_greeting",
+        "summary": "Open greeting formatter",
+        "description": "Formats a greeting in the live editor.",
+        "language": "bun",
+        "schema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": ["name"]
+        },
+        "content": "export async function main(name: string) {\n  return `Hello, ${name}`\n}\n",
+        "is_template": false,
+        "kind": "script"
+      }
+    }
+  ]
+}

--- a/ai_evals/fixtures/frontend/global/initial/current_invoice_live_flow.json
+++ b/ai_evals/fixtures/frontend/global/initial/current_invoice_live_flow.json
@@ -1,0 +1,118 @@
+{
+  "workspace": {
+    "flows": [
+      {
+        "path": "f/evals/global/process_invoice",
+        "summary": "Deployed invoice processor",
+        "description": "Calculates invoice totals from a subtotal.",
+        "schema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "subtotal": {
+              "type": "number"
+            }
+          },
+          "required": ["subtotal"]
+        },
+        "value": {
+          "modules": [
+            {
+              "id": "calculate_total",
+              "summary": "Calculate total from subtotal",
+              "value": {
+                "type": "rawscript",
+                "language": "bun",
+                "content": "export async function main(subtotal: number) {\n  return { subtotal, total: subtotal }\n}\n",
+                "input_transforms": {
+                  "subtotal": {
+                    "type": "javascript",
+                    "expr": "flow_input.subtotal"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "path": "f/evals/global/process_refund",
+        "summary": "Refund processor",
+        "description": "Calculates refund totals.",
+        "schema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "subtotal": {
+              "type": "number"
+            }
+          },
+          "required": ["subtotal"]
+        },
+        "value": {
+          "modules": [
+            {
+              "id": "calculate_total",
+              "summary": "Calculate refund total",
+              "value": {
+                "type": "rawscript",
+                "language": "bun",
+                "content": "export async function main(subtotal: number) {\n  return { subtotal, total: subtotal }\n}\n",
+                "input_transforms": {
+                  "subtotal": {
+                    "type": "javascript",
+                    "expr": "flow_input.subtotal"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "liveEditorDrafts": [
+    {
+      "type": "flow",
+      "storagePath": "f/evals/global/current_invoice_flow",
+      "effectivePath": "f/evals/global/current_invoice_flow",
+      "value": {
+        "path": "f/evals/global/current_invoice_flow",
+        "summary": "Open invoice processor",
+        "schema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "subtotal": {
+              "type": "number"
+            }
+          },
+          "required": ["subtotal"]
+        },
+        "value": {
+          "modules": [
+            {
+              "id": "calculate_total",
+              "summary": "Calculate total from subtotal",
+              "value": {
+                "type": "rawscript",
+                "language": "bun",
+                "content": "export async function main(subtotal: number) {\n  return { subtotal, total: subtotal }\n}\n",
+                "input_transforms": {
+                  "subtotal": {
+                    "type": "javascript",
+                    "expr": "flow_input.subtotal"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "edited_by": "",
+        "edited_at": "",
+        "archived": false,
+        "extra_perms": {}
+      }
+    }
+  ]
+}

--- a/ai_evals/modes/global.ts
+++ b/ai_evals/modes/global.ts
@@ -1,5 +1,8 @@
 import { readFile } from "node:fs/promises";
-import { runGlobalEval } from "../adapters/frontend/core/global/globalEvalRunner";
+import {
+  runGlobalEval,
+  type GlobalLiveEditorDraftFixture,
+} from "../adapters/frontend/core/global/globalEvalRunner";
 import type { BenchmarkWorkspaceRunnables } from "../adapters/frontend/mockBackend";
 import type { FrontendEvalModelConfig } from "../core/models";
 import type { BenchmarkArtifactFile, GlobalValidationSpec, ModeRunner } from "../core/types";
@@ -9,6 +12,7 @@ import { getFrontendApiKey } from "./frontendCommon";
 
 export interface GlobalInitialFixture {
   workspace?: BenchmarkWorkspaceRunnables;
+  liveEditorDrafts?: GlobalLiveEditorDraftFixture[];
 }
 
 export function createGlobalModeRunner(
@@ -31,6 +35,7 @@ export function createGlobalModeRunner(
         getFrontendApiKey(modelConfig.provider),
         {
           workspaceFixtures: initial?.workspace,
+          liveEditorDrafts: initial?.liveEditorDrafts,
           maxIterations: context.evalCase?.runtime?.maxTurns,
           provider: modelConfig.provider,
           model: modelConfig.model,
@@ -73,6 +78,7 @@ async function loadGlobalInitialFixture(path: string): Promise<GlobalInitialFixt
   const parsed = JSON.parse(await readFile(path, "utf8")) as GlobalInitialFixture;
   return {
     workspace: parsed.workspace ?? {},
+    liveEditorDrafts: parsed.liveEditorDrafts ?? [],
   };
 }
 

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -681,7 +681,11 @@ export class AIChatManager {
 					} else if (this.mode === AIMode.NAVIGATOR) {
 						return prepareNavigatorUserMessage(pendingPrompt)
 					} else if (this.mode === AIMode.GLOBAL) {
-						return prepareGlobalUserMessage(pendingPrompt, this.contextManager.getSelectedContext())
+						return prepareGlobalUserMessage(
+							pendingPrompt,
+							this.contextManager.getSelectedContext(),
+							{ workspace: get(workspaceStore) }
+						)
 					}
 					return undefined
 				},
@@ -898,7 +902,9 @@ export class AIChatManager {
 					userMessage = prepareApiUserMessage(oldInstructions)
 					break
 				case AIMode.GLOBAL:
-					userMessage = prepareGlobalUserMessage(oldInstructions, oldSelectedContext)
+					userMessage = prepareGlobalUserMessage(oldInstructions, oldSelectedContext, {
+						workspace: get(workspaceStore)
+					})
 					break
 				case AIMode.APP:
 					userMessage = prepareAppUserMessage(

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -1337,6 +1337,7 @@ describe('prepareGlobalSystemMessage', () => {
 		expect(content).toContain(
 			'Use discard_local_draft to remove an unsaved local draft, including the matching open editor draft'
 		)
+		expect(content).toContain('If the user message includes an ACTIVE EDITOR section')
 		expect(content).not.toContain('AI draft')
 		expect(content).not.toContain('UserDraft')
 		expect(content).not.toContain('localStorage')
@@ -1359,6 +1360,27 @@ describe('prepareGlobalSystemMessage', () => {
 })
 
 describe('prepareGlobalUserMessage', () => {
+	it('injects the active editor reference without contents', () => {
+		__resetUserDraftForTesting()
+		localStorage.clear()
+		UserDraft.setLiveEditorDraft({
+			workspace: WORKSPACE,
+			itemKind: 'script',
+			storagePath: '',
+			effectivePath: 'f/scripts/live_greeting'
+		})
+
+		const message = prepareGlobalUserMessage('Update this script', [], { workspace: WORKSPACE })
+
+		expect(message.content).toContain('## ACTIVE EDITOR')
+		expect(message.content).toContain('type: script')
+		expect(message.content).toContain('path: f/scripts/live_greeting')
+		expect(message.content).toContain('isLiveDraft: true')
+		expect(message.content).toContain('## INSTRUCTIONS:\nUpdate this script')
+		expect(message.content).not.toContain('When the user says')
+		expect(message.content).not.toContain('content')
+	})
+
 	it('includes selected workspace item references without contents', () => {
 		const message = prepareGlobalUserMessage('Update these items', [
 			{

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -113,6 +113,28 @@ const INSTRUCTION_SUBJECTS = [
 	'app'
 ] as const satisfies readonly WorkspaceItemType[]
 const MAX_LIST_LIMIT = 100
+type ActiveGlobalEditorType = Extract<WorkspaceItemType, 'script' | 'flow' | 'app'>
+type LiveEditorDraftKind = Parameters<typeof UserDraft.getLiveEditorDraft>[0]
+
+const ACTIVE_GLOBAL_EDITOR_DRAFTS: readonly {
+	itemKind: LiveEditorDraftKind
+	type: ActiveGlobalEditorType
+}[] = [
+	{ itemKind: 'script', type: 'script' },
+	{ itemKind: 'flow', type: 'flow' },
+	{ itemKind: 'raw_app', type: 'app' }
+]
+
+export type GlobalActiveEditorContext = {
+	type: ActiveGlobalEditorType
+	path: string
+	isLiveDraft: true
+}
+
+export type GlobalUserMessageOptions = {
+	workspace?: string
+	activeEditor?: GlobalActiveEditorContext
+}
 
 const itemTypeSchema = z.enum(ITEM_TYPES)
 const instructionSubjectSchema = z.enum(INSTRUCTION_SUBJECTS)
@@ -499,7 +521,7 @@ Use tools to inspect workspace items and create local drafts for scripts, flows,
 Rules:
 - Draft tools create or update local drafts only; they do not deploy or mutate deployed workspace items.
 - Use list_workspace_items to find items and read_workspace_item before changing an existing item. For triggers, pass trigger_kind.
-- If the user refers to the open editor, use the item marked isLiveDraft=true.
+- If the user message includes an ACTIVE EDITOR section, treat it as the currently open item and use it for references like "this", "current", or "open editor".
 - Use deploy_workspace_item only after the user explicitly asks to deploy. It persists a local draft to the workspace.
 - Use discard_local_draft to remove an unsaved local draft, including the matching open editor draft. Use delete_workspace_item only to delete a deployed workspace item.
 - Variable values are never readable. For secrets, create a secret variable and reference it from resources as "$var:path/to/variable".
@@ -3000,14 +3022,35 @@ export function prepareGlobalSystemMessage(
 	}
 }
 
+export function getActiveGlobalEditorContext(
+	workspace: string
+): GlobalActiveEditorContext | undefined {
+	for (const { itemKind, type } of ACTIVE_GLOBAL_EDITOR_DRAFTS) {
+		const liveDraft = UserDraft.getLiveEditorDraft(itemKind, { workspace })
+		const path = liveDraft?.effectivePath || liveDraft?.storagePath
+		if (!path) continue
+		return { type, path, isLiveDraft: true }
+	}
+}
+
 export function prepareGlobalUserMessage(
 	instructions: string,
-	selectedContext: ContextElement[] = []
+	selectedContext: ContextElement[] = [],
+	options: GlobalUserMessageOptions = {}
 ): ChatCompletionUserMessageParam {
 	const selectedWorkspaceItems = selectedContext.filter(
 		(context) => context.type === 'workspace_script' || context.type === 'workspace_flow'
 	)
+	const activeEditor =
+		options.activeEditor ?? (options.workspace ? getActiveGlobalEditorContext(options.workspace) : undefined)
 	let content = ''
+
+	if (activeEditor) {
+		content += '## ACTIVE EDITOR\n'
+		content += `type: ${activeEditor.type}\n`
+		content += `path: ${activeEditor.path}\n`
+		content += `isLiveDraft: true\n\n`
+	}
 
 	if (selectedWorkspaceItems.length > 0) {
 		content += '## SELECTED CONTEXT\n'


### PR DESCRIPTION
## Summary
Inject the active live editor into global AI chat user messages so references like "this", "current", and "open editor" resolve directly to the mounted script, flow, or raw app draft.

The user message now carries a single data-only `ACTIVE EDITOR` section when an editor is active. The system prompt contains the instruction for how to interpret that section.

## Changes
- Add active editor context generation for global AI chat user messages.
- Treat active editor context as singular: at most one currently open script, flow, or raw app editor is injected.
- Move the "this/current/open editor" resolution rule into the global system prompt.
- Wire global chat sends and pending prompts to pass the current workspace for active editor lookup.
- Extend global ai_evals fixtures to seed live editor drafts.
- Add global eval cases for current live script edits, current live flow edits, and no-active-editor ambiguity.
- Add an eval ablation flag, `WMILL_AI_EVAL_DISABLE_ACTIVE_EDITOR_CONTEXT=1`, to compare old list-tool-only behavior.
- Report CLI headline duration/token averages from passed attempts only, while still recording all-attempt averages for failure audit.

## Validation
- [x] `npm run test:unit -- src/lib/components/copilot/chat/global/core.test.ts --run` - 36 tests passed.
- [x] `npm run check:fast` - no problems found.
- [x] `npm run check` - 0 errors, existing warnings only.
- [x] `bun test core/results.test.ts core/cases.test.ts` from `ai_evals/` - 15 tests passed.
- [x] `bun run cli -- cases global` from `ai_evals/` - lists 14 global cases including the 3 new active-editor cases.
- [x] `git diff --check` - passed.

## Eval Reporting Semantics
- Pass rate includes every attempt, including failures.
- Headline duration/token averages use passed attempts only: `averagePassedDurationMs` and `averageTokenUsagePerPassedAttempt`.
- All-attempt averages are still written as `averageDurationMs` and `averageTokenUsagePerAttempt` so failed attempts remain auditable without skewing success cost comparisons.
- If no attempt passes, passed duration/token averages are reported as `n/a`/`null`.

## Eval Results
Ran each positive active-editor case 3 times against the local backend with `haiku` and `WMILL_AI_EVAL_BACKEND_WORKSPACE=integration-tests`.

Result files:
- New behavior: `ai_evals/results/2026-05-28T13-34-45.236Z__global.json`
- Old behavior ablation: `ai_evals/results/2026-05-28T13-35-52.554Z__global.json`

| Case | Old behavior: no injected active editor | New behavior: injected active editor | Takeaway |
| --- | --- | --- | --- |
| `global-test12-current-live-script-edit` | 0/3 passed; failed avg 12.9s, 19,025 tokens, 0 tool calls | 3/3 passed; passed avg 13.2s, 57,882 tokens, 2 tool calls | correctness win: old behavior never edited the active script |
| `global-test13-current-live-flow-edit` | 3/3 passed; passed avg 16.1s, 117,634 tokens, 5 tool calls | 3/3 passed; passed avg 16.6s, 78,315 tokens, 3 tool calls | comparable passing case: -33.4% tokens, -40% tool calls, duration roughly flat (+2.6%) |

Overall passed-attempt headline:
- New behavior: 6/6 passed, 14.9s average passed duration, 68,099 average passed tokens.
- Old behavior: 3/6 passed, 16.1s average passed duration, 117,634 average passed tokens.

Interpretation:
- The old script run has no successful attempt, so its low failed-token number is not a valid success-cost comparison.
- The apples-to-apples passing flow case shows the cost win: active-editor injection avoids the extra `list_workspace_items` discovery step and cuts tokens by roughly one third.

Negative guard:
- [x] `global-test14-current-without-live-editor-asks-question` passed: 0 drafts, 0 tools, 2.2s, 18,983 tokens.

## Notes
- `bun run typecheck` in `ai_evals/` is currently blocked by unrelated existing CLI/shared-tsconfig errors, so it is not used as a PR signal here.
- Review skipped per request.
