### PR TITLE
fix(frontend): prevent MultiSelect crash on undefined value

### DIFF
--- a/frontend/src/lib/components/select/MultiSelect.svelte
+++ b/frontend/src/lib/components/select/MultiSelect.svelte
@@ -72,6 +72,8 @@
 	let wrapperEl: HTMLDivElement | undefined = $state()
 	let searchInputEl: TextInput | undefined = $state()
 
+	let currentValue = $derived(value ?? [])
+
 	$effect(() => searchInputEl?.focus())
 
 	let processedItems: ProcessedItem<Value>[] = $derived.by(() => {
@@ -87,18 +89,20 @@
 	})
 
 	let valueEntry = $derived(
-		value.map((v) => processedItems.find((item) => item.value === v) ?? { value: v, label: v })
+		currentValue.map(
+			(v) => processedItems.find((item) => item.value === v) ?? { value: v, label: v }
+		)
 	)
 
 	function onAddValue(item: ProcessedItem<Value>) {
 		if (item.__is_create && onCreateItem) {
 			onCreateItem(item.value)
 		} else {
-			value = [...value, item.value]
+			value = [...currentValue, item.value]
 		}
 	}
 	function onRemoveValue(item: ProcessedItem<Value>) {
-		value = value.filter((v) => v !== item.value)
+		value = currentValue.filter((v) => v !== item.value)
 	}
 
 	function clearValue() {
@@ -132,7 +136,7 @@
 	<!-- svelte-ignore a11y_click_events_have_key_events -->
 	<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 
-	{#if value.length === 0}
+	{#if currentValue.length === 0}
 		<span class={twMerge('text-xs h-full flex items-center flex-1 text-hint', placeholderClass)}>
 			{placeholder}
 		</span>
@@ -149,7 +153,7 @@
 				{allowClear}
 				onRemove={onRemoveValue}
 				onReorder={reorderable
-					? (oldIdx, newIdx) => (value = reorder(value, oldIdx, newIdx))
+					? (oldIdx, newIdx) => (value = reorder(currentValue, oldIdx, newIdx))
 					: undefined}
 			/>
 		</ul>
@@ -166,7 +170,7 @@
 		{disablePortal}
 		onSelectValue={onAddValue}
 		{open}
-		processedItems={processedItems.filter((item) => !value.includes(item.value))}
+		processedItems={processedItems.filter((item) => !currentValue.includes(item.value))}
 		value={undefined}
 		{disabled}
 		{filterText}
@@ -181,7 +185,7 @@
 		ulClass="options"
 	>
 		{#snippet header()}
-			{#if processedItems.length - value.length > 0 || onCreateItem}
+			{#if processedItems.length - currentValue.length > 0 || onCreateItem}
 				<div class="mx-2 mb-1 mt-2 flex items-center relative">
 					<TextInput
 						bind:this={searchInputEl}


### PR DESCRIPTION
## Summary

The approval/resume page (e.g. `/approve/{workspace}/{job}?token=...`) rendered completely blank for some flows. The production stack trace pointed to `value.length === 0` inside `MultiSelect.svelte`.

Root cause: `value` is a `$bindable()` prop with no default, typed `Value[]`, but `ArgInput.svelte:862,872` renders `<MultiSelect bind:value>` even when `value == undefined` (an enum-array form field with no initial value — exactly the approval form's `default_payload` case). `MultiSelect` then dereferenced `value.length` / `value.map` / `value.filter` on `undefined`, throwing a `TypeError` that crashed the entire page render → user sees nothing.

## Changes

- `frontend/src/lib/components/select/MultiSelect.svelte`: introduce `let currentValue = $derived(value ?? [])` and route every read (`.length`, `.map`, `.filter`, `.includes`, `reorder`) through it. Writes still target the bindable `value` but base off `currentValue`, so an `undefined` initial value becomes a real array on first mutation. This follows the AGENTS.md recommended alternative (`$derived` with nullish coalescing) rather than the banned `$bindable(default_value)` pattern.

## Test plan

- [ ] Open a form (e.g. an approval page or run form) that renders an enum-array argument with no default value via `ArgInput`, so `MultiSelect` mounts with `value === undefined`. Confirm the page renders (placeholder shown, no blank screen / console error).
- [ ] Select an item → it is added. Remove it → placeholder returns. Drag to reorder → order persists.

> Note: browser verification could not be run locally — the Playwright browser binary failed to download in this environment (repeated installs report success but produce no `chrome` executable). Root cause and fix are confirmed from the production minified stack trace (`B1qfC2vM.js`: `_().length===0` → `MultiSelect.svelte:135`) and the `ArgInput` call sites.

Fixes WIN-1996

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in `MultiSelect` when `value` is undefined that caused the approval page to render blank. Reads now use a derived array so the component renders safely and behaves as expected.

- **Bug Fixes**
  - Use `$derived(value ?? [])` as `currentValue` and route all reads (`length`, `map`, `filter`, `includes`, `reorder`) through it.
  - Keep writes targeting the bound `value`; an undefined initial value becomes an array on first mutation.
  - Resolves blank approval page for enum-array fields without defaults via `ArgInput` (Fixes WIN-1996).

<sup>Written for commit af3a92153babb2dd2b54f19c63da9ae0de8b6279. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9364?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

