### PR TITLE
fix(frontend): prevent duplicate asset node ids crashing flow graph

### DIFF
--- a/frontend/src/lib/components/graph/renderers/nodes/AssetNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/AssetNode.svelte
@@ -63,7 +63,7 @@
 					type: 'asset' as const,
 					parentId: node.id,
 					data: { asset, displayedAccessType: 'r' },
-					id: `${node.id}-asset-in-${asset.kind}-${asset.path}`,
+					id: `${node.id}-asset-in-${asset.kind}-${asset.path}-${i}`,
 					width: inputAssetWidth,
 					position: {
 						x:
@@ -100,7 +100,7 @@
 					type: 'asset' as const,
 					parentId: node.id,
 					data: { asset, displayedAccessType: 'w' },
-					id: `${node.id}-asset-out-${asset.kind}-${asset.path}`,
+					id: `${node.id}-asset-out-${asset.kind}-${asset.path}-${i}`,
 					width: outputAssetWidth,
 					position: {
 						x:
@@ -136,7 +136,7 @@
 			allAssetNodes.push(...(inputAssetNodes ?? []), ...(outputAssetNodes ?? []))
 
 			// If there are more than 3 assets, we create an overflow node
-			if (overflowedInputAssets.length)
+			if (overflowedInputAssets.length) {
 				allAssetNodes.push({
 					type: 'assetsOverflowed',
 					data: { overflowedAssets: overflowedInputAssets, displayedAccessType: 'r' },
@@ -148,14 +148,15 @@
 						y: READ_ASSET_Y_OFFSET
 					}
 				} satisfies Node & AssetsOverflowedN)
-			allAssetEdges.push({
-				id: `${node.id}-assets-overflowed-in-edge`,
-				source: `${node.id}-assets-overflowed-in`,
-				target: node.id,
-				type: 'empty',
-				data: { class: '!opacity-35 dark:!opacity-20' }
-			})
-			if (overflowedOutputAssets.length)
+				allAssetEdges.push({
+					id: `${node.id}-assets-overflowed-in-edge`,
+					source: `${node.id}-assets-overflowed-in`,
+					target: node.id,
+					type: 'empty',
+					data: { class: '!opacity-35 dark:!opacity-20' }
+				})
+			}
+			if (overflowedOutputAssets.length) {
 				allAssetNodes.push({
 					type: 'assetsOverflowed',
 					data: { overflowedAssets: overflowedOutputAssets, displayedAccessType: 'w' },
@@ -167,13 +168,14 @@
 						y: WRITE_ASSET_Y_OFFSET
 					}
 				} satisfies Node & AssetsOverflowedN)
-			allAssetEdges.push({
-				id: `${node.id}-assets-overflowed-out-edge`,
-				source: node.id,
-				target: `${node.id}-assets-overflowed-out`,
-				type: 'empty',
-				data: { class: '!opacity-35 dark:!opacity-25' }
-			})
+				allAssetEdges.push({
+					id: `${node.id}-assets-overflowed-out-edge`,
+					source: node.id,
+					target: `${node.id}-assets-overflowed-out`,
+					type: 'empty',
+					data: { class: '!opacity-35 dark:!opacity-25' }
+				})
+			}
 		}
 
 		let ret: ReturnType<typeof computeAssetNodes> = {
@@ -274,8 +276,8 @@
 					<Tooltip class={'pr-1 flex items-center justify-center'}>
 						<AlertTriangle size={16} class="text-orange-500" />
 						{#snippet text()}
-												Could not find resource
-											{/snippet}
+							Could not find resource
+						{/snippet}
 					</Tooltip>
 				{:else if isSelected && assetCanBeExplored(data.asset, cachedResourceMetadata) && !$userStore?.operator}
 					<div transition:slide={{ axis: 'x', duration: 100 }}>
@@ -291,29 +293,27 @@
 				{/if}
 			</div>
 			{#snippet text()}
-					
-					{#if usageCount !== undefined}
-						Used in {pluralize(usageCount, 'step')}<br />
-					{/if}
-					<a
-						href={undefined}
-						class={twMerge(
-							'text-xs',
-							data.asset.kind === 'resource' ? 'text-accent cursor-pointer' : 'text-hint'
-						)}
-						onclick={() => {
-							if (data.asset.kind === 'resource')
-								flowGraphAssetsCtx?.val.resourceEditorDrawer?.initEdit(data.asset.path)
-						}}
-					>
-						{data.asset.path}
-					</a><br />
-					<span class="text-hint text-xs">
-						{formatAssetKind({ ...data.asset, metadata: cachedResourceMetadata })}</span
-					>
-					<AssetColumnBadges columns={assetColumns} disableTooltip />
-				
-					{/snippet}
+				{#if usageCount !== undefined}
+					Used in {pluralize(usageCount, 'step')}<br />
+				{/if}
+				<a
+					href={undefined}
+					class={twMerge(
+						'text-xs',
+						data.asset.kind === 'resource' ? 'text-accent cursor-pointer' : 'text-hint'
+					)}
+					onclick={() => {
+						if (data.asset.kind === 'resource')
+							flowGraphAssetsCtx?.val.resourceEditorDrawer?.initEdit(data.asset.path)
+					}}
+				>
+					{data.asset.path}
+				</a><br />
+				<span class="text-hint text-xs">
+					{formatAssetKind({ ...data.asset, metadata: cachedResourceMetadata })}</span
+				>
+				<AssetColumnBadges columns={assetColumns} disableTooltip />
+			{/snippet}
 		</Tooltip>
 	{/snippet}
 </NodeWrapper>

--- a/frontend/src/lib/components/graph/renderers/nodes/assetNode.test.ts
+++ b/frontend/src/lib/components/graph/renderers/nodes/assetNode.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock heavy transitive imports pulled in by AssetNode.svelte's instance script
+vi.mock('monaco-editor', () => ({}))
+vi.mock('$lib/components/meltComponents', () => ({ Tooltip: {} }))
+vi.mock('../../../ExploreAssetButton.svelte', () => ({
+	default: {},
+	assetCanBeExplored: () => false
+}))
+vi.mock('$lib/components/icons/AssetGenericIcon.svelte', () => ({ default: {} }))
+vi.mock('$lib/components/assets/AssetColumnBadges.svelte', () => ({ default: {} }))
+vi.mock('./NodeWrapper.svelte', () => ({ default: {} }))
+
+import { computeAssetNodes } from './AssetNode.svelte'
+
+function nodeWithAssets(id: string, assets: any[]) {
+	return { id, position: { x: 0, y: 0 }, data: { assets } }
+}
+
+describe('computeAssetNodes (WIN-1998)', () => {
+	it('produces unique node and edge ids when a module lists the same asset twice', () => {
+		// Two assets with identical kind+path (e.g. read twice, or r + rw) — both
+		// display as inputs. Before the fix these collided on the same node id and
+		// crashed SvelteFlow with `each_key_duplicate`.
+		const dup = { kind: 'resource', path: 'f/foo/bar', access_type: 'r' }
+		const { newAssetNodes, newAssetEdges } = computeAssetNodes([
+			nodeWithAssets('moduleA', [{ ...dup }, { ...dup }])
+		])
+
+		const nodeIds = newAssetNodes.map((n) => n.id)
+		expect(new Set(nodeIds).size).toBe(nodeIds.length)
+
+		const edgeIds = newAssetEdges.map((e) => e.id)
+		expect(new Set(edgeIds).size).toBe(edgeIds.length)
+	})
+
+	it('does not emit overflow edges when there is no overflow node (<=3 assets)', () => {
+		const { newAssetNodes, newAssetEdges } = computeAssetNodes([
+			nodeWithAssets('moduleB', [{ kind: 'resource', path: 'f/a/x', access_type: 'r' }])
+		])
+
+		// No overflow node should be created for a single asset...
+		expect(newAssetNodes.some((n) => n.type === 'assetsOverflowed')).toBe(false)
+		// ...and therefore no dangling edge should reference a missing overflow node.
+		const nodeIdSet = new Set(newAssetNodes.map((n) => n.id).concat('moduleB'))
+		for (const e of newAssetEdges) {
+			expect(nodeIdSet.has(e.source as string)).toBe(true)
+			expect(nodeIdSet.has(e.target as string)).toBe(true)
+		}
+	})
+})


### PR DESCRIPTION
## Summary

Fixes WIN-1998 — a flow with steps that reuse the same script/flow path (e.g. an IaC flow calling `f/idp/iac/common/terraform-apply` from six branches) crashed the flow graph at render time with:

```
Uncaught Error: https://svelte.dev/e/each_key_duplicate
```

### Root cause

`computeAssetNodes` in `AssetNode.svelte` builds the asset visual nodes shown above/below a step. Each asset node id was `${node.id}-asset-in-${asset.kind}-${asset.path}` (and `-out-` for outputs) — with **no index**. When a module's resolved asset list contains the same `(kind, path)` twice (e.g. a resource read in multiple places, or one `r` + one `rw` entry — both pass the input filter), two asset nodes get the **same id**. SvelteFlow keys its `{#each}` over nodes by id, so the duplicate id throws `each_key_duplicate` and the whole graph fails to render.

### Fix

- Append the loop index `i` to the input/output asset node ids so they are always unique. The `-asset-in-`/`-asset-out-` prefix is preserved, so the `startsWith` matching in `noteUtils`/`moveManager` still works.
- Drive-by correctness fix in the same function: the `assets-overflowed-*` **edges** were pushed *outside* the `if (overflowed…length)` guard, so every step with ≤3 assets emitted a dangling edge pointing at a non-existent overflow node. Moved those edge pushes inside their guards.

### Decision notes

- Chose to append the index (cheap, guaranteed-unique, prefix-preserving) over deduping the asset list, since dedup would also need to merge access types and risks hiding legitimately distinct assets.

## Test plan

- [x] Added `assetNode.test.ts` regression test that imports the real `computeAssetNodes`:
  - asserts unique node/edge ids when a module lists the same asset twice (fails on pre-fix code with the duplicate id, passes after)
  - asserts no dangling overflow edges for a single-asset step
- [x] Verified the regression test **fails without** the id fix and **passes with** it
- [x] All existing graph tests pass (`vitest run src/lib/components/graph/` — 23 passed)
- [x] `npm run check:fast` reports no new errors in the changed files (the 69 reported errors are pre-existing and unrelated, e.g. `Timeout`/`number`)

Note: not exercised in a live browser — reproducing the exact crash requires a flow whose backend-resolved asset list contains duplicate `(kind, path)` entries. The deterministic unit test reproduces the precise `each_key_duplicate` condition instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WIN-1998 by preventing the flow graph from crashing when a step lists the same asset (same kind+path) multiple times. Ensures asset nodes have unique ids and avoids dangling overflow edges.

- **Bug Fixes**
  - Append the loop index to input/output asset node ids to avoid Svelte `{#each}` duplicate-key errors while preserving the `-asset-in-`/`-asset-out-` prefixes used by existing matching.
  - Create overflow edges only when an overflow node exists, preventing dangling edges for steps with ≤3 assets.

<sup>Written for commit 6319e31ceeae4ff8ee8db90cccd743e69d5d6718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9367?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

