### PR TITLE
fix(git-sync): bump sync script to hub/28238 to publish fork branches

### DIFF
--- a/.github/workflows/git-sync-test.yml
+++ b/.github/workflows/git-sync-test.yml
@@ -8,6 +8,7 @@ on:
       - "backend/windmill-git-sync/**"
       - "backend/windmill-api-integration-tests/tests/git_sync*"
       - "backend/ee-repo-ref.txt"
+      - "backend/windmill-common/src/workspaces.rs"
       - "integration_tests/test/git_sync_test.py"
       - ".github/workflows/git-sync-test.yml"
   pull_request:
@@ -16,6 +17,7 @@ on:
       - "backend/windmill-git-sync/**"
       - "backend/windmill-api-integration-tests/tests/git_sync*"
       - "backend/ee-repo-ref.txt"
+      - "backend/windmill-common/src/workspaces.rs"
       - "integration_tests/test/git_sync_test.py"
       - ".github/workflows/git-sync-test.yml"
 
@@ -49,7 +51,7 @@ jobs:
           echo "$CHANGED_FILES"
 
           # Direct git sync file changes — always relevant
-          if echo "$CHANGED_FILES" | grep -qE '^(backend/windmill-git-sync/|backend/windmill-api-integration-tests/tests/git_sync|integration_tests/test/git_sync|\.github/workflows/git-sync-test\.yml)'; then
+          if echo "$CHANGED_FILES" | grep -qE '^(backend/windmill-git-sync/|backend/windmill-api-integration-tests/tests/git_sync|backend/windmill-common/src/workspaces\.rs|integration_tests/test/git_sync|\.github/workflows/git-sync-test\.yml)'; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "Relevant: direct git sync file changes"
             exit 0

--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -157,7 +157,7 @@ pub enum ObjectType {
     WorkspaceDependencies,
 }
 
-pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28236/sync-script-to-git-repo-windmill";
+pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28238/sync-script-to-git-repo-windmill";
 
 /// Prefix used to identify fork workspaces. A workspace whose id starts with this string is a
 /// fork of another workspace.


### PR DESCRIPTION
## Summary

`test_workspace_fork_creates_branch` in `git_sync_e2e` fails: forking a git-sync-configured workspace checks out the `wm-fork/<branch>/<id>` branch locally but never pushes it to the remote.

Root cause: the fork-branch deployment callback runs the hub script `sync-script-to-git-repo-windmill`, which imports `windmill-cli` as a **pinned npm dependency** and runs it **in-process** (`wmill.parse(...)`) — it does *not* shell out to a PATH `wmill`, so the local `cli/src` checkout is never exercised. `hub/28236` pinned `windmill-cli@1.706.1`, whose `git-deploy --only-create-branch` path returns early without pushing. For a fork the hub script's own `git_push` is gated behind `if (!only_create_branch)`, so neither side pushes.

#9366 fixed the CLI and shipped it as `windmill-cli@1.712.0` (first published version where the `only_create_branch` path actually calls `gitSyncDeployPush({onlyCreateBranch:true})`), but it did not bump the hub script, so the running callback still used `1.706.1`. This affected production fork-branch creation too, not just the e2e.

## Changes
- Bump `LATEST_GIT_SYNC_SCRIPT_PATH` to `hub/28238/sync-script-to-git-repo-windmill`. hub/28238 is identical to 28236 except it pins `windmill-cli@1.712.0` in both content and lockfile (verified against the live hub).
- Add `backend/windmill-common/src/workspaces.rs` to the `git-sync-test` path-gate (both `paths:` filters and the `check-relevance` grep) so future script-path bumps trigger the e2e — a `workspaces.rs`-only change was previously not covered.

## Test plan
- [ ] `git_sync_e2e` runs (not skipped) and `test_workspace_fork_creates_branch` passes
- [ ] Fork branch `wm-fork/<branch>/<id>` appears on the remote after forking

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes fork branch publishing in git-sync by updating the hub sync script to `hub/28238`. Also makes sure the e2e runs when this script path changes.

- **Dependencies**
  - Set `LATEST_GIT_SYNC_SCRIPT_PATH` to `hub/28238/sync-script-to-git-repo-windmill` (pins `windmill-cli@1.712.0`) so `wm-fork/<branch>/<id>` branches are pushed to the remote.

- **Bug Fixes**
  - Added `backend/windmill-common/src/workspaces.rs` to the git-sync test path filters to prevent skipping the e2e when the script path changes.

<sup>Written for commit 17aa95d96afd319476f19ae33ac9941f5b9a2241. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9372?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

