### PR TITLE
chore: add gpt-5.5 eval model

### DIFF
--- a/ai_evals/README.md
+++ b/ai_evals/README.md
@@ -88,15 +88,18 @@ Today:
 - `sonnet`
 - `opus`
 - `4o`
+- `gpt-5.5`
 - `gemini-flash`
 - `gemini-pro`
 - `gemini-3-flash-preview`
 - `gemini-3.1-pro-preview`
+- `deepseek-v4-flash`
+- `deepseek-v4-pro`
 
 Notes:
 
-- the command also prints accepted alias spellings such as `gpt-4o`, `claude-opus-4.6`, and `claude-haiku-4.5`
-- frontend modes (`flow`, `script`, `app`, `global`) can use Anthropic, OpenAI, and Gemini-backed aliases
+- the command also prints accepted alias spellings such as `gpt-4o`, `gpt-55`, `claude-opus-4.6`, and `claude-haiku-4.5`
+- frontend modes (`flow`, `script`, `app`, `global`) can use Anthropic, OpenAI, Gemini, and DeepSeek-backed aliases
 - `cli` mode always uses the Anthropic agent SDK, so only Anthropic aliases are valid there
 - the judge model is separate and currently defaults to `claude-sonnet-4-6`
 

--- a/ai_evals/core/models.test.ts
+++ b/ai_evals/core/models.test.ts
@@ -2,6 +2,21 @@ import { describe, expect, it } from "bun:test";
 import { resolveEvalModel } from "./models";
 
 describe("resolveEvalModel", () => {
+  it("supports GPT-5.5 aliases for frontend evals", () => {
+    expect(resolveEvalModel("flow", "gpt-5.5").frontend).toEqual({
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+    expect(resolveEvalModel("app", "gpt-55").frontend).toEqual({
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+    expect(resolveEvalModel("script", "5.5").frontend).toEqual({
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+  });
+
   it("supports Gemini aliases for frontend evals", () => {
     expect(resolveEvalModel("flow", "gemini").frontend).toEqual({
       provider: "googleai",

--- a/ai_evals/core/models.ts
+++ b/ai_evals/core/models.ts
@@ -88,6 +88,15 @@ export const EVAL_MODELS: EvalModelSpec[] = [
     },
   },
   {
+    id: "gpt-5.5",
+    label: "GPT-5.5",
+    aliases: ["gpt-5.5", "gpt-55", "5.5"],
+    frontend: {
+      provider: "openai",
+      model: "gpt-5.5",
+    },
+  },
+  {
     id: "gemini-flash",
     label: "Gemini 2.5 Flash",
     aliases: ["gemini", "gemini-flash", "gemini-2.5-flash"],


### PR DESCRIPTION
## Summary
Add GPT-5.5 as an OpenAI-backed frontend model option for `ai_evals` so the benchmark runner can exercise the latest OpenAI model across flow, script, app, and global modes.

## Changes
- Add `gpt-5.5` to `EVAL_MODELS` with aliases `gpt-5.5`, `gpt-55`, and `5.5`
- Add resolver coverage for the new GPT-5.5 aliases
- Update the `ai_evals` README model list and provider notes

## GPT-5.5 eval results
All evals used `runModel: openai:gpt-5.5` against `http://127.0.0.1:8060` with `WMILL_AI_EVAL_BACKEND_WORKSPACE=integration-tests`.

| Suite | Cases | Result | Avg duration | Avg tokens | Result artifact |
| --- | --- | --- | ---: | ---: | --- |
| `script` | `script-test1-greet-user`, `script-test2-create-current-script-schedule`, `script-test3-create-current-script-http-trigger` | 3/3 passed | 36,312 ms | 66,137 | `ai_evals/results/2026-05-29T10-21-48.033Z__script.json` |
| `flow` | `flow-test0-sum-two-numbers`, `flow-test1-reuse-existing-script` | 2/2 passed | 32,709 ms | 126,102 | `ai_evals/results/2026-05-29T10-22-46.868Z__flow.json` |
| `app` | `app-test1-counter-create` | 1/1 passed | 41,156 ms | 56,380 | `ai_evals/results/2026-05-29T10-23-46.496Z__app.json` |

Per-case highlights:
- `script-test1-greet-user`: passed, judge 100, 34,235 ms, 56,216 tokens
- `script-test2-create-current-script-schedule`: passed deterministic checks, 53,671 ms, 71,136 tokens
- `script-test3-create-current-script-http-trigger`: passed deterministic checks, 21,030 ms, 71,059 tokens
- `flow-test0-sum-two-numbers`: passed, judge 98, 23,411 ms, 148,643 tokens
- `flow-test1-reuse-existing-script`: passed, judge 100, 42,007 ms, 103,561 tokens
- `app-test1-counter-create`: passed, judge 100, 41,156 ms, 56,380 tokens

## Test plan
- [x] `bun test core/models.test.ts`
- [x] `bun run cli -- models`
- [x] `WMILL_AI_EVAL_BACKEND_URL=http://127.0.0.1:8060 WMILL_AI_EVAL_BACKEND_WORKSPACE=integration-tests bun run cli -- run script --model gpt-5.5`
- [x] `WMILL_AI_EVAL_BACKEND_URL=http://127.0.0.1:8060 WMILL_AI_EVAL_BACKEND_WORKSPACE=integration-tests bun run cli -- run flow flow-test0-sum-two-numbers flow-test1-reuse-existing-script --model gpt-5.5`
- [x] `WMILL_AI_EVAL_BACKEND_URL=http://127.0.0.1:8060 WMILL_AI_EVAL_BACKEND_WORKSPACE=integration-tests bun run cli -- run app app-test1-counter-create --model gpt-5.5`
- [x] Local review skill: no issues found

Note: `bun run typecheck` currently fails on unrelated existing TypeScript errors in `ai_evals/modes/cli.ts` and the sibling `cli/` tree.