### PR TITLE
test: add global chat eval coverage

### DIFF
--- a/ai_evals/README.md
+++ b/ai_evals/README.md
@@ -56,7 +56,7 @@ bun run cli -- run flow flow-test4-order-processing-loop --model opus
 bun run cli -- run flow flow-test0-sum-two-numbers --models haiku,opus,4o
 bun run cli -- run flow flow-test0-sum-two-numbers --runs 3 --verbose
 bun run cli -- run flow --record
-GEMINI_API_KEY=... bun run cli -- run app app-test1-counter-create --model gemini-pro
+GEMINI_API_KEY=... bun run cli -- run app app-test1-counter-create --model gemini-3-flash-preview
 WMILL_AI_EVAL_BACKEND_URL=http://127.0.0.1:8000 bun run cli -- run flow --backend-validation preview
 bun run cli -- run global global-test1-script-create
 bun run cli -- run cli bun-hello-script
@@ -89,8 +89,6 @@ Today:
 - `opus`
 - `4o`
 - `gpt-5.5`
-- `gemini-flash`
-- `gemini-pro`
 - `gemini-3-flash-preview`
 - `gemini-3.1-pro-preview`
 - `deepseek-v4-flash`

--- a/ai_evals/adapters/frontend/core/shared/providerConfig.test.ts
+++ b/ai_evals/adapters/frontend/core/shared/providerConfig.test.ts
@@ -21,9 +21,9 @@ describe("proxy helpers", () => {
 
 describe("resolveEvalModelProvider", () => {
   it("infers googleai from Gemini model ids", () => {
-    expect(resolveEvalModelProvider("gemini-2.5-flash")).toEqual({
+    expect(resolveEvalModelProvider("gemini-3-flash-preview")).toEqual({
       provider: "googleai",
-      model: "gemini-2.5-flash",
+      model: "gemini-3-flash-preview",
     });
   });
 
@@ -35,9 +35,11 @@ describe("resolveEvalModelProvider", () => {
   });
 
   it("preserves an explicit provider", () => {
-    expect(resolveEvalModelProvider("gemini-2.5-pro", "googleai")).toEqual({
+    expect(
+      resolveEvalModelProvider("gemini-3.1-pro-preview", "googleai"),
+    ).toEqual({
       provider: "googleai",
-      model: "gemini-2.5-pro",
+      model: "gemini-3.1-pro-preview",
     });
   });
 });

--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -430,3 +430,191 @@
   judgeChecklist:
     - asks which script to update when the user refers to "this script" without selected or active editor context
     - does not guess a path or create a new script draft
+
+- id: global-test15-human-postgres-resource
+  prompt: |-
+    I'm wiring the eval reporting database into this workspace.
+    Can you stage a Postgres connection for it in the shared evals/global folder?
+    Use host `reports-db.internal`, port 5432, database `evals_reporting`, user `report_reader`, and password `pg-redacted-reporting-password`.
+    Keep the credentials safe.
+    This is just draft work for now.
+  runtime:
+    maxTurns: 10
+  validate:
+    draftCountExactly: 2
+    requiredDrafts:
+      - type: variable
+        pathStartsWith: f/evals/global/
+        pathIncludes:
+          - evals
+          - global
+          - report
+          - password
+        valueIncludes:
+          - "true"
+          - report
+      - type: resource
+        pathStartsWith: f/evals/global/
+        pathIncludes:
+          - evals
+          - global
+          - report
+        valueIncludes:
+          - postgres
+          - reports-db.internal
+          - "5432"
+          - evals_reporting
+          - report_reader
+          - "$var:"
+        valueExcludes:
+          - pg-redacted-reporting-password
+  toolExpect:
+    requiredToolsUsed:
+      - write_variable
+      - search_resource_types
+      - write_resource
+    forbiddenToolsUsed:
+      - write_schedule
+      - write_trigger
+      - deploy_workspace_item
+      - delete_workspace_item
+    toolCallArgs:
+      - tool: write_variable
+        field: value
+        stringStartsWithAnyOf:
+          - pg-redacted-reporting-password
+  skipJudge: true
+  judgeChecklist:
+    - creates a Postgres resource draft for the eval reporting database
+    - creates a secret variable draft for the database password
+    - puts the drafts in sensible eval/global reporting-related paths
+    - uses the requested host, port, database, and user
+    - references the secret variable from the resource instead of embedding the password
+    - leaves the work as a draft only
+
+- id: global-test16-human-visible-variable
+  prompt: |-
+    We keep reusing a 30 day trial cutoff in eval notification jobs.
+    Can you stage that as a normal workspace variable in the shared evals/global folder, with a short description so people know what it controls?
+    It is not a secret.
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 1
+    requiredDrafts:
+      - type: variable
+        pathStartsWith: f/evals/global/
+        pathIncludes:
+          - evals
+          - global
+          - trial
+        valueIncludes:
+          - "30"
+          - "false"
+          - trial
+  toolExpect:
+    requiredToolsUsed:
+      - write_variable
+    forbiddenToolsUsed:
+      - write_resource
+      - write_schedule
+      - write_trigger
+      - deploy_workspace_item
+      - delete_workspace_item
+  judgeChecklist:
+    - creates exactly one non-secret variable draft for the trial cutoff
+    - stores the value 30
+    - chooses a sensible eval/global path related to trials or notifications
+    - includes a useful description of what the value controls
+    - does not create resources, schedules, triggers, or deployed workspace changes
+
+- id: global-test17-human-schedule-existing-helper
+  prompt: |-
+    The workspace already has a report digest helper.
+    Can you stage a weekday 8:30 AM UTC run for it with `dry_run` turned on?
+    I only want the schedule draft for review.
+  initial: ai_evals/fixtures/frontend/global/initial/report_digest_script.json
+  runtime:
+    maxTurns: 8
+  validate:
+    draftCountExactly: 1
+    requiredDrafts:
+      - type: schedule
+        pathIncludes:
+          - digest
+        valueIncludes:
+          - f/evals/global/send_report_digest
+          - UTC
+          - dry_run
+          - "true"
+  toolExpect:
+    requiredToolsUsed:
+      - list_workspace_items
+      - write_schedule
+    forbiddenToolsUsed:
+      - write_script
+      - write_flow
+      - write_resource
+      - write_variable
+      - write_trigger
+      - deploy_workspace_item
+      - delete_workspace_item
+  judgeChecklist:
+    - finds the existing report digest helper rather than creating a new script or flow
+    - creates one schedule draft for that helper
+    - schedules it for weekdays around 08:30 UTC
+    - passes dry_run as true
+    - leaves only the schedule draft for review
+
+- id: global-test18-human-slack-resource-with-secret
+  prompt: |-
+    I'm preparing Slack notifications for eval failures.
+    Can you stage a Slack connection in the shared evals/global folder?
+    The bot token is `xoxb-redacted-test-token`; keep it safe.
+    Don't deploy anything yet.
+  runtime:
+    maxTurns: 8
+  validate:
+    draftCountExactly: 2
+    requiredDrafts:
+      - type: variable
+        pathStartsWith: f/evals/global/
+        pathIncludes:
+          - evals
+          - global
+          - slack
+          - token
+        valueIncludes:
+          - "true"
+      - type: resource
+        pathStartsWith: f/evals/global/
+        pathIncludes:
+          - evals
+          - global
+          - slack
+        valueIncludes:
+          - slack
+          - "$var:"
+        valueExcludes:
+          - xoxb-redacted-test-token
+  toolExpect:
+    requiredToolsUsed:
+      - write_variable
+      - search_resource_types
+      - write_resource
+    forbiddenToolsUsed:
+      - write_schedule
+      - write_trigger
+      - deploy_workspace_item
+      - delete_workspace_item
+    toolCallArgs:
+      - tool: write_variable
+        field: value
+        stringStartsWithAnyOf:
+          - xoxb-redacted-test-token
+  skipJudge: true
+  judgeChecklist:
+    - creates a secret variable draft for the Slack bot token placeholder
+    - creates a Slack resource draft that references the secret variable instead of embedding the token
+    - keeps both drafts under a sensible eval/global Slack-related path
+    - does not create schedules, triggers, or deployed workspace changes

--- a/ai_evals/core/models.test.ts
+++ b/ai_evals/core/models.test.ts
@@ -18,14 +18,6 @@ describe("resolveEvalModel", () => {
   });
 
   it("supports Gemini aliases for frontend evals", () => {
-    expect(resolveEvalModel("flow", "gemini").frontend).toEqual({
-      provider: "googleai",
-      model: "gemini-2.5-flash",
-    });
-    expect(resolveEvalModel("app", "gemini-pro").frontend).toEqual({
-      provider: "googleai",
-      model: "gemini-2.5-pro",
-    });
     expect(
       resolveEvalModel("script", "gemini-3-flash-preview").frontend,
     ).toEqual({
@@ -52,8 +44,8 @@ describe("resolveEvalModel", () => {
   });
 
   it("rejects Gemini aliases for cli evals", () => {
-    expect(() => resolveEvalModel("cli", "gemini")).toThrow(
-      "Model gemini-flash is not supported for cli mode",
+    expect(() => resolveEvalModel("cli", "gemini-3-flash-preview")).toThrow(
+      "Model gemini-3-flash-preview is not supported for cli mode",
     );
   });
 });

--- a/ai_evals/core/models.ts
+++ b/ai_evals/core/models.ts
@@ -97,24 +97,6 @@ export const EVAL_MODELS: EvalModelSpec[] = [
     },
   },
   {
-    id: "gemini-flash",
-    label: "Gemini 2.5 Flash",
-    aliases: ["gemini", "gemini-flash", "gemini-2.5-flash"],
-    frontend: {
-      provider: "googleai",
-      model: "gemini-2.5-flash",
-    },
-  },
-  {
-    id: "gemini-pro",
-    label: "Gemini 2.5 Pro",
-    aliases: ["gemini-pro", "gemini-2.5-pro"],
-    frontend: {
-      provider: "googleai",
-      model: "gemini-2.5-pro",
-    },
-  },
-  {
     id: "gemini-3-flash-preview",
     label: "Gemini 3 Flash Preview",
     aliases: ["gemini-3-flash-preview", "gemini-3-flash"],

--- a/ai_evals/fixtures/frontend/global/initial/report_digest_script.json
+++ b/ai_evals/fixtures/frontend/global/initial/report_digest_script.json
@@ -1,0 +1,23 @@
+{
+  "workspace": {
+    "scripts": [
+      {
+        "path": "f/evals/global/send_report_digest",
+        "summary": "Build and send the eval report digest",
+        "description": "Returns a dry-run summary for eval report digest notifications.",
+        "language": "bun",
+        "schema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "dry_run": {
+              "type": "boolean"
+            }
+          },
+          "required": ["dry_run"]
+        },
+        "content": "export async function main(dry_run: boolean) {\n  return { dry_run, sent: !dry_run, message: dry_run ? 'Preview digest' : 'Digest sent' }\n}\n"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Add global chat ai_evals coverage for resources, variables, and schedules while keeping prompts human-like and draft-focused. Also remove deprecated Gemini 2.5 aliases from the ai_evals model registry.

Conflict note: rebased on current `origin/main` and kept the new `gpt-5.5` eval model while removing only the deprecated `gemini-flash` / `gemini-pro` aliases.

## Changes
- Add a Postgres resource case where the user provides credentials naturally and the LLM is expected to keep the password safe by creating/referencing a secret variable.
- Add a non-secret trial cutoff variable case.
- Add a schedule case for an existing workspace helper script.
- Add a Slack connection case where the user provides a bot token naturally and the LLM is expected to create a secret variable plus resource reference without embedding the token.
- Add a report digest script fixture used by the schedule case.
- Remove deprecated `gemini-flash` / `gemini-pro` model aliases and update ai_evals README/tests to use Gemini 3 aliases.

## Test plan
- [x] `cd ai_evals && bun test` (86 pass, 1 skip)
- [x] `cd ai_evals && bun run cli -- models`
- [x] `cd ai_evals && bun run cli -- cases global` (18 global cases)
- [x] `rg -n "gemini-flash|gemini-pro|gemini-2\\.5|Gemini 2\\.5" ai_evals` (no matches)
- [x] `WMILL_AI_EVAL_BACKEND_URL=http://127.0.0.1:8030 WMILL_AI_EVAL_BACKEND_WORKSPACE=integration-tests bun run cli -- run global global-test15-human-postgres-resource global-test16-human-visible-variable global-test17-human-schedule-existing-helper global-test18-human-slack-resource-with-secret --models haiku,sonnet,opus,4o,gpt-5.5,gemini-3-flash-preview,gemini-3.1-pro-preview,deepseek-v4-flash,deepseek-v4-pro`
- [ ] `cd ai_evals && bun run typecheck` fails on existing broader CLI/ai_evals TS issues, starting with `modes/cli.ts(83,11): overwriteProjectGuidance does not exist in type WriteAiGuidanceOptions`, followed by unrelated `../cli` type-only import/API errors.

## Model sweep
Ran the four new global cases on the rebased branch with deprecated Gemini 2.5 models removed, `gpt-5.5` retained from `main`, and DeepSeek env loaded:

```bash
WMILL_AI_EVAL_BACKEND_URL=http://127.0.0.1:8030 \
WMILL_AI_EVAL_BACKEND_WORKSPACE=integration-tests \
bun run cli -- run global \
  global-test15-human-postgres-resource \
  global-test16-human-visible-variable \
  global-test17-human-schedule-existing-helper \
  global-test18-human-slack-resource-with-secret \
  --models haiku,sonnet,opus,4o,gpt-5.5,gemini-3-flash-preview,gemini-3.1-pro-preview,deepseek-v4-flash,deepseek-v4-pro
```

| Model | Result |
|---|---:|
| haiku | 4/4 |
| sonnet | 2/4 |
| opus | 3/4 |
| 4o | 1/4 |
| gpt-5.5 | 4/4 |
| gemini-3-flash-preview | 4/4 |
| gemini-3.1-pro-preview | 4/4 |
| deepseek-v4-flash | 2/4 |
| deepseek-v4-pro | 4/4 |

Notable failures from the sweep:
- `sonnet` failed both secret-resource cases by not producing the expected secret variable plus resource `$var:` reference flow.
- `opus` reached max turns on the Slack secret-resource case.
- `4o` only passed the visible-variable case; it missed the expected Postgres/resource drafts, schedule draft/tool use, and Slack resource draft/tool use.
- `deepseek-v4-flash` passed visible variable and schedule, but failed the two secret-resource cases.

Follow-up: this PR adds the eval coverage and records the current model behavior; improvements to raise the lower-scoring model results will be made in a follow-up PR.
