### PR TITLE
fix(cli): preserve user drafts on sync push and permissioned-as

### DIFF
--- a/backend/tests/dependency_map.rs
+++ b/backend/tests/dependency_map.rs
@@ -451,6 +451,7 @@ def main():
                 preserve_on_behalf_of: None,
                 ws_error_handler_muted: None,
                 labels: None,
+                skip_draft_deletion: None,
             })
             .send()
             .await
@@ -513,6 +514,7 @@ def main():
                 custom_path: None,
                 preserve_on_behalf_of: None,
                 labels: None,
+                skip_draft_deletion: None,
             })
             .send()
             .await

--- a/backend/windmill-api-flows/src/flows.rs
+++ b/backend/windmill-api-flows/src/flows.rs
@@ -558,13 +558,17 @@ async fn create_flow(
         w_id
     ).execute(&mut *tx).await?;
 
-    sqlx::query!(
-        "DELETE FROM draft WHERE path = $1 AND workspace_id = $2 AND typ = 'flow'",
-        nf.path,
-        &w_id
-    )
-    .execute(&mut *tx)
-    .await?;
+    // CLI / git-sync deploys ask us to preserve any existing user draft at this
+    // path instead of wiping it as part of the deploy.
+    if !nf.skip_draft_deletion.unwrap_or(false) {
+        sqlx::query!(
+            "DELETE FROM draft WHERE path = $1 AND workspace_id = $2 AND typ = 'flow'",
+            nf.path,
+            &w_id
+        )
+        .execute(&mut *tx)
+        .await?;
+    }
 
     audit_log(
         &mut *tx,
@@ -1157,13 +1161,17 @@ async fn update_flow(
         })?;
     }
 
-    sqlx::query!(
-        "DELETE FROM draft WHERE path = $1 AND workspace_id = $2 AND typ = 'flow'",
-        flow_path,
-        &w_id
-    )
-    .execute(&mut *tx)
-    .await?;
+    // CLI / git-sync deploys ask us to preserve any existing user draft at this
+    // path instead of wiping it as part of the deploy.
+    if !nf.skip_draft_deletion.unwrap_or(false) {
+        sqlx::query!(
+            "DELETE FROM draft WHERE path = $1 AND workspace_id = $2 AND typ = 'flow'",
+            flow_path,
+            &w_id
+        )
+        .execute(&mut *tx)
+        .await?;
+    }
 
     audit_log(
         &mut *tx,

--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -737,6 +737,9 @@ async fn is_noop_deploy_against_parent(
         // caller-intent flag (auto-resolve parent), not script state
         auto_parent: _,
         labels,
+        // caller-intent flag (preserve user drafts on CLI/git-sync deploys);
+        // transient, never persisted, does not change what the script *is*
+        skip_draft_deletion: _,
     } = ns;
 
     if path != &parent.path {
@@ -925,6 +928,9 @@ async fn create_script_internal<'c>(
         }
     }
     let script_path = ns.path.clone();
+    // Caller-intent: CLI / git-sync deploys ask us to preserve any existing
+    // user draft at this path instead of wiping it as part of the deploy.
+    let skip_draft_deletion = ns.skip_draft_deletion.unwrap_or(false);
     let hash = ScriptHash(hash_script(&ns));
     let authed = maybe_refresh_folders(&ns.path, &w_id, authed, &db).await;
 
@@ -1357,13 +1363,15 @@ async fn create_script_internal<'c>(
 
     let p_path_opt = parent_hashes_and_perms.as_ref().map(|x| x.p_path.clone());
     if let Some(ref p_path) = p_path_opt {
-        sqlx::query!(
-            "DELETE FROM draft WHERE path = $1 AND workspace_id = $2 AND typ = 'script'",
-            p_path,
-            &w_id
-        )
-        .execute(&mut *tx)
-        .await?;
+        if !skip_draft_deletion {
+            sqlx::query!(
+                "DELETE FROM draft WHERE path = $1 AND workspace_id = $2 AND typ = 'script'",
+                p_path,
+                &w_id
+            )
+            .execute(&mut *tx)
+            .await?;
+        }
 
         sqlx::query!(
             "UPDATE capture_config SET path = $1 WHERE path = $2 AND workspace_id = $3 AND is_flow IS FALSE",
@@ -1442,7 +1450,7 @@ async fn create_script_internal<'c>(
                 tx = push_scheduled_job(&db, tx, &schedule, None, None).await?;
             }
         }
-    } else {
+    } else if !skip_draft_deletion {
         sqlx::query!(
             "DELETE FROM draft WHERE path = $1 AND workspace_id = $2 AND typ = 'script'",
             ns.path,

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -9751,6 +9751,9 @@ paths:
                       type: boolean
                     deployment_message:
                       type: string
+                    skip_draft_deletion:
+                      type: boolean
+                      description: "When true (set by the CLI / git sync), deploying this flow does not delete an existing user draft at the same path."
       responses:
         "201":
           description: flow created
@@ -9792,6 +9795,9 @@ paths:
                   properties:
                     deployment_message:
                       type: string
+                    skip_draft_deletion:
+                      type: boolean
+                      description: "When true (set by the CLI / git sync), deploying this flow does not delete an existing user draft at the same path."
 
       responses:
         "200":
@@ -10290,6 +10296,9 @@ paths:
                   type: array
                   items:
                     type: string
+                skip_draft_deletion:
+                  type: boolean
+                  description: "When true (set by the CLI / git sync), deploying this app does not delete an existing user draft at the same path."
               required:
                 - path
                 - value
@@ -10342,6 +10351,9 @@ paths:
                       type: array
                       items:
                         type: string
+                    skip_draft_deletion:
+                      type: boolean
+                      description: "When true (set by the CLI / git sync), deploying this app does not delete an existing user draft at the same path."
                   required:
                     - path
                     - value
@@ -10660,6 +10672,9 @@ paths:
                   type: array
                   items:
                     type: string
+                skip_draft_deletion:
+                  type: boolean
+                  description: "When true (set by the CLI / git sync), deploying this app does not delete an existing user draft at the same path."
       responses:
         "200":
           description: app updated
@@ -10706,6 +10721,9 @@ paths:
                       type: array
                       items:
                         type: string
+                    skip_draft_deletion:
+                      type: boolean
+                      description: "When true (set by the CLI / git sync), deploying this app does not delete an existing user draft at the same path."
                 js:
                   type: string
                 css:
@@ -21883,6 +21901,9 @@ components:
           type: array
           items:
             type: string
+        skip_draft_deletion:
+          type: boolean
+          description: "When true (set by the CLI / git sync), deploying this script does not delete an existing user draft at the same path."
 
       required:
         - path

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -306,6 +306,11 @@ pub struct CreateApp {
     pub preserve_on_behalf_of: Option<bool>,
     #[serde(default)]
     pub labels: Option<Vec<String>>,
+    /// Caller-intent flag (set by the CLI / git sync): when true, deploying
+    /// this app must NOT delete an existing user draft at the same path.
+    /// Transient — never persisted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_draft_deletion: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -319,6 +324,11 @@ pub struct EditApp {
     pub preserve_on_behalf_of: Option<bool>,
     #[serde(default)]
     pub labels: Option<Vec<String>>,
+    /// Caller-intent flag (set by the CLI / git sync): when true, deploying
+    /// this app must NOT delete an existing user draft at the same path.
+    /// Transient — never persisted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_draft_deletion: Option<bool>,
 }
 
 #[derive(Serialize, FromRow)]
@@ -1338,13 +1348,17 @@ async fn create_app_internal<'a>(
             ));
         }
     }
-    sqlx::query!(
-        "DELETE FROM draft WHERE path = $1 AND workspace_id = $2 AND typ = 'app'",
-        &app.path,
-        &w_id
-    )
-    .execute(&mut *tx)
-    .await?;
+    // CLI / git-sync deploys ask us to preserve any existing user draft at this
+    // path instead of wiping it as part of the deploy.
+    if !app.skip_draft_deletion.unwrap_or(false) {
+        sqlx::query!(
+            "DELETE FROM draft WHERE path = $1 AND workspace_id = $2 AND typ = 'app'",
+            &app.path,
+            &w_id
+        )
+        .execute(&mut *tx)
+        .await?;
+    }
     let id = sqlx::query_scalar!(
         "INSERT INTO app
             (workspace_id, path, summary, policy, versions, draft_only, custom_path, labels)
@@ -1943,13 +1957,17 @@ async fn update_app_internal<'a>(
             )));
         }
     };
-    sqlx::query!(
-        "DELETE FROM draft WHERE path = $1 AND workspace_id = $2 AND typ = 'app'",
-        path,
-        &w_id
-    )
-    .execute(&mut *tx)
-    .await?;
+    // CLI / git-sync deploys ask us to preserve any existing user draft at this
+    // path instead of wiping it as part of the deploy.
+    if !ns.skip_draft_deletion.unwrap_or(false) {
+        sqlx::query!(
+            "DELETE FROM draft WHERE path = $1 AND workspace_id = $2 AND typ = 'app'",
+            path,
+            &w_id
+        )
+        .execute(&mut *tx)
+        .await?;
+    }
     audit_log(
         &mut *tx,
         &authed,

--- a/backend/windmill-common/src/scripts.rs
+++ b/backend/windmill-common/src/scripts.rs
@@ -393,6 +393,7 @@ pub async fn clone_script<'c>(
         modules: s.modules,
         auto_parent: None,
         labels: s.labels,
+        skip_draft_deletion: None,
     };
 
     let new_hash = hash_script(&ns);

--- a/backend/windmill-types/src/flows.rs
+++ b/backend/windmill-types/src/flows.rs
@@ -110,6 +110,11 @@ pub struct NewFlow {
     pub ws_error_handler_muted: Option<bool>,
     #[serde(default)]
     pub labels: Option<Vec<String>>,
+    /// Caller-intent flag (set by the CLI / git sync): when true, deploying
+    /// this flow must NOT delete an existing user draft at the same path.
+    /// Transient — never persisted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_draft_deletion: Option<bool>,
 }
 
 impl NewFlow {

--- a/backend/windmill-types/src/scripts.rs
+++ b/backend/windmill-types/src/scripts.rs
@@ -540,9 +540,19 @@ pub struct NewScript {
     pub auto_parent: Option<bool>,
     #[serde(default)]
     pub labels: Option<Vec<String>>,
+    /// Caller-intent flag (set by the CLI / git sync): when true, deploying
+    /// this script must NOT delete an existing user draft at the same path.
+    /// Transient — never persisted. Deliberately excluded from `impl Hash`
+    /// below (it must not affect the version hash) and from the no-op
+    /// comparison in the deploy handler (it isn't part of what the script
+    /// *is*). See `is_noop_deploy_against_parent`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_draft_deletion: Option<bool>,
 }
 
 // IMPORTANT: update this Hash impl when adding fields to NewScript
+// (exception: caller-intent flags like `skip_draft_deletion` are intentionally
+// omitted — they must not influence the computed version hash)
 impl Hash for NewScript {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.path.hash(state);

--- a/cli/src/commands/app/app.ts
+++ b/cli/src/commands/app/app.ts
@@ -192,6 +192,8 @@ export async function pushApp(
           deployment_message: message,
           ...localAppBody,
           ...preserveFields,
+          // Preserve any user draft at this path (see backend skip_draft_deletion).
+          skip_draft_deletion: true,
         },
       });
     }
@@ -205,6 +207,8 @@ export async function pushApp(
         deployment_message: message,
         ...localAppBody,
         ...preserveFields,
+        // Preserve any user draft at this path (see backend skip_draft_deletion).
+        skip_draft_deletion: true,
       },
     });
   }
@@ -480,6 +484,8 @@ const command = new Command()
           on_behalf_of_email: email,
         } as any,
         preserve_on_behalf_of: true,
+        // Preserve any user draft at this path (see backend skip_draft_deletion).
+        skip_draft_deletion: true,
       },
     });
     log.info(colors.green(`Updated permissioned_as for app ${appPath} to ${email}`));

--- a/cli/src/commands/app/raw_apps.ts
+++ b/cli/src/commands/app/raw_apps.ts
@@ -466,6 +466,8 @@ export async function pushRawApp(
             summary: localApp.summary,
             policy: appForPolicy.policy,
             deployment_message: message,
+            // Preserve any user draft at this path (see backend skip_draft_deletion).
+            skip_draft_deletion: true,
             ...(localApp.custom_path
               ? { custom_path: localApp.custom_path }
               : {}),
@@ -486,6 +488,8 @@ export async function pushRawApp(
           summary: localApp.summary,
           policy: appForPolicy.policy,
           deployment_message: message,
+          // Preserve any user draft at this path (see backend skip_draft_deletion).
+          skip_draft_deletion: true,
           ...(localApp.custom_path
             ? { custom_path: localApp.custom_path }
             : {}),

--- a/cli/src/commands/flow/flow.ts
+++ b/cli/src/commands/flow/flow.ts
@@ -224,6 +224,8 @@ export async function pushFlow(
           deployment_message: message,
           ...localFlowBody,
           ...preserveFields,
+          // Preserve any user draft at this path (see backend skip_draft_deletion).
+          skip_draft_deletion: true,
         },
       });
     }
@@ -237,6 +239,8 @@ export async function pushFlow(
           deployment_message: message,
           ...localFlowBody,
           ...preserveFields,
+          // Preserve any user draft at this path (see backend skip_draft_deletion).
+          skip_draft_deletion: true,
         },
       });
     } catch (e) {
@@ -964,6 +968,8 @@ const command = new Command()
         path: flowPath,
         on_behalf_of_email: email,
         preserve_on_behalf_of: true,
+        // Preserve any user draft at this path (see backend skip_draft_deletion).
+        skip_draft_deletion: true,
       } as any,
     });
     log.info(colors.green(`Updated permissioned_as for flow ${flowPath} to ${email}`));

--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -758,6 +758,9 @@ async function createScript(
   workspace: Workspace
 ): Promise<number> {
   const start = performance.now();
+  // Preserve any user draft at this path: a CLI / git-sync deploy must not wipe
+  // an in-progress draft the way a UI "deploy from draft" intentionally does.
+  body = { ...body, skip_draft_deletion: true };
   // skip_if_noop asks the backend to treat deploys identical to the parent
   // (same content, lockfile, and metadata) as a no-op, so the CLI does not
   // produce phantom git-sync / promotion commits on re-pushes.
@@ -1796,6 +1799,8 @@ async function setPermissionedAs(
       parent_hash: remote.hash,
       on_behalf_of_email: email,
       preserve_on_behalf_of: true,
+      // Preserve any user draft at this path (see backend skip_draft_deletion).
+      skip_draft_deletion: true,
     },
   });
   log.info(colors.green(`Updated permissioned_as for script ${scriptPath} to ${email}`));


### PR DESCRIPTION
## Summary

`wmill sync push` (and the `set-permissioned-as` commands) deploy scripts/flows/apps through the **same create/update API endpoints the UI "Deploy" button uses**. Every one of those deploy paths runs `DELETE FROM draft` for the item's path inside the transaction. That's correct for a UI *deploy-from-draft* (the draft becomes the deployed version, so the "unsaved changes" marker is cleared) — but when a CLI/git-sync push touches a path, it **silently destroys whatever in-progress draft a teammate has there**, even though the push had nothing to do with that draft.

This fix makes CLI deploys preserve drafts while leaving UI deploys unchanged.

## Approach

Mirror the existing `deployment_message` pattern: a transient, deploy-control body field **`skip_draft_deletion`** that the CLI sets to `true` on its deploy paths. When set, the backend skips the `DELETE FROM draft`; the deploy itself proceeds normally. UI deploys never send it (defaults to `false`), so their behavior is identical to before.

## Changes

**Backend**
- Added `skip_draft_deletion: Option<bool>` to `NewScript`, `NewFlow`, `CreateApp`, `EditApp` (`#[serde(default, skip_serializing_if = "Option::is_none")]`).
- Guarded the 6 deploy-path `DELETE FROM draft` sites: `create_script_internal` (both parent/no-parent branches), `create_flow`, `update_flow`, `create_app_internal`, `update_app_internal`. The script snapshot and raw-app endpoints route through these same internal functions, so they inherit the guard.
- Deliberately **excluded** the flag from the `NewScript` `Hash` impl (it must not affect version identity) and bound it to `_` in the no-op drift-guard destructure (caller intent, not script state).
- The dedicated draft-delete endpoint and entity-deletion (`delete_script`/`delete_flow`/`delete_app`, bulk delete) draft deletions are left untouched.

**CLI**
- Sets `skip_draft_deletion: true` on the sync push helpers (`createScript`, `pushFlow`, `pushApp`, `pushRawApp`) and on the `set-permissioned-as` redeploys for script/flow/app.

**openapi.yaml**
- Added the field to the 6 request schemas + the `NewScript` component. `cli/gen` and `frontend/src/lib/gen` are gitignored and regenerated from the spec at build time.

## Test plan

Verified end-to-end against a running backend (script, flow, and app each with a saved draft):
- [x] Push **with** `skip_draft_deletion=true` → draft survives (count 1), deploy succeeds
- [x] Push **without** the flag (legacy/UI path) → draft deleted (count 0)
- [x] Backend compiles and serves; CLI typecheck shows no new errors
- [ ] Manual UI check: "deploy from draft" in the editor still clears the draft (default-off path unchanged)
- [ ] Exercise a bundled/codebase script (snapshot endpoint) and a raw app via `wmill sync push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)