### PR TITLE
Surface backend preview logs in AI eval failures

### DIFF
--- a/ai_evals/core/previewFailureDetails.test.ts
+++ b/ai_evals/core/previewFailureDetails.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'bun:test'
+import { formatPreviewFailureDetails } from './previewFailureDetails'
+
+describe('formatPreviewFailureDetails', () => {
+	it('includes runtime logs and result excerpts for failed preview jobs', () => {
+		const details = formatPreviewFailureDetails({
+			workspaceId: 'ai-evals-crud-a1',
+			jobId: 'job-123',
+			logs: '\nTypeError: Cannot read properties of undefined\n    at listRecipes\n',
+			result: { error: 'frontend called missing backend runnable' }
+		})
+
+		expect(details).toContain('workspace=ai-evals-crud-a1')
+		expect(details).toContain('job=job-123')
+		expect(details).toContain('TypeError: Cannot read properties of undefined')
+		expect(details).toContain('frontend called missing backend runnable')
+	})
+
+	it('bounds noisy logs so check summaries stay readable', () => {
+		const details = formatPreviewFailureDetails({
+			workspaceId: 'workspace',
+			jobId: 'job',
+			logs: 'x'.repeat(100),
+			maxCharacters: 20
+		})
+
+		expect(details).toContain(`logs=${'x'.repeat(19)}…`)
+		expect(details.length).toBeLessThan(80)
+	})
+})

--- a/ai_evals/core/previewFailureDetails.ts
+++ b/ai_evals/core/previewFailureDetails.ts
@@ -1,0 +1,48 @@
+export interface PreviewFailureDetailsInput {
+	workspaceId: string
+	jobId: string
+	logs?: string | null
+	result?: unknown
+	maxCharacters?: number
+}
+
+export function formatPreviewFailureDetails(input: PreviewFailureDetailsInput): string {
+	const parts = [`workspace=${input.workspaceId}`, `job=${input.jobId}`]
+	const maxCharacters = input.maxCharacters ?? 1200
+	const logExcerpt = normalizeExcerpt(input.logs, maxCharacters)
+	const resultExcerpt = normalizeExcerpt(formatResult(input.result), maxCharacters)
+
+	if (logExcerpt) {
+		parts.push(`logs=${logExcerpt}`)
+	}
+	if (resultExcerpt) {
+		parts.push(`result=${resultExcerpt}`)
+	}
+
+	return parts.join('; ')
+}
+
+function formatResult(result: unknown): string | null {
+	if (result == null) {
+		return null
+	}
+	if (typeof result === 'string') {
+		return result
+	}
+	try {
+		return JSON.stringify(result)
+	} catch {
+		return String(result)
+	}
+}
+
+function normalizeExcerpt(value: string | null | undefined, maxCharacters: number): string | null {
+	const normalized = value?.replace(/\s+/g, ' ').trim()
+	if (!normalized) {
+		return null
+	}
+	if (normalized.length <= maxCharacters) {
+		return normalized
+	}
+	return `${normalized.slice(0, maxCharacters - 1)}…`
+}

--- a/ai_evals/modes/flow.ts
+++ b/ai_evals/modes/flow.ts
@@ -4,6 +4,7 @@ import type { FrontendEvalModelConfig } from "../core/models";
 import type { FlowValidationSpec } from "../core/types";
 import { validateFlowState, type FlowState } from "../core/validators";
 import type { BenchmarkArtifactFile, ModeRunner } from "../core/types";
+import { formatPreviewFailureDetails } from "../core/previewFailureDetails";
 import { runFlowEval } from "../adapters/frontend/core/flow/flowEvalRunner";
 import type { FlowWorkspaceFixtures } from "../adapters/frontend/core/flow/fileHelpers";
 import { BackendPreviewClient } from "../adapters/frontend/backendPreview";
@@ -116,7 +117,12 @@ export function createFlowModeRunner(
                 passed: completedJob.success,
                 details: completedJob.success
                   ? `workspace=${workspaceId}`
-                  : `workspace=${workspaceId}; job=${completedJob.id}`,
+                  : formatPreviewFailureDetails({
+                      workspaceId,
+                      jobId: completedJob.id,
+                      logs: completedJob.logs,
+                      result: completedJob.result,
+                    }),
               },
             ],
             artifactFiles: [

--- a/ai_evals/modes/script.ts
+++ b/ai_evals/modes/script.ts
@@ -3,6 +3,7 @@ import type { BackendValidationSettings } from "../core/backendValidation";
 import type { FrontendEvalModelConfig } from "../core/models";
 import { validateScriptState } from "../core/validators";
 import type { BenchmarkArtifactFile, ModeRunner } from "../core/types";
+import { formatPreviewFailureDetails } from "../core/previewFailureDetails";
 import { BackendPreviewClient } from "../adapters/frontend/backendPreview";
 import { runScriptEval } from "../adapters/frontend/core/script/scriptEvalRunner";
 import type { ScriptEvalState } from "../adapters/frontend/core/script/fileHelpers";
@@ -89,7 +90,12 @@ export function createScriptModeRunner(
                 passed: completedJob.success,
                 details: completedJob.success
                   ? `workspace=${workspaceId}`
-                  : `workspace=${workspaceId}; job=${completedJob.id}`,
+                  : formatPreviewFailureDetails({
+                      workspaceId,
+                      jobId: completedJob.id,
+                      logs: completedJob.logs,
+                      result: completedJob.result,
+                    }),
               },
             ],
             artifactFiles: [


### PR DESCRIPTION
## Summary
- add a small formatter that promotes backend preview logs/result excerpts into failed AI eval check details
- use it for script and flow backend-preview failures while preserving the full `backend-preview.json` artifact
- add regression coverage for stacktrace/result excerpts and bounded noisy logs

Related to #9296.

## Why
Windmill already captures backend preview job logs in artifacts, but the failed benchmark check only showed the workspace/job id. For agent-generation regressions, especially CRUD/app failures, the stacktrace is the signal the model and maintainer need first. This keeps the artifact as the source of truth while making failures immediately actionable in the eval summary.

## Verification
- `git diff --check`
- manual Node TS import smoke test for `formatPreviewFailureDetails`

I could not run the Bun test suite locally because this environment does not have `bun`, `npm`, or `pnpm` installed. The PR includes `ai_evals/core/previewFailureDetails.test.ts` for CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces backend preview logs and result snippets in failed eval check details for script and flow modes, making failures actionable at a glance. Supports Linear #9296 by exposing stacktraces in the eval summary while keeping `backend-preview.json` intact and truncating noisy logs.

- **New Features**
  - Added `formatPreviewFailureDetails` to format workspace, job ID, and bounded log/result excerpts (default 1200 chars).
  - Integrated into `script` and `flow` mode runners to populate failure details.
  - Added unit tests for stacktrace/result excerpts and log truncation.

<sup>Written for commit 75ad9ecd998d352bcd7d150e5ccd71cec10faa3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

