### PR TITLE
fix(worker): escape contextual variable values in SQL substitution

### DIFF
--- a/backend/windmill-worker/src/sanitized_sql_params.rs
+++ b/backend/windmill-worker/src/sanitized_sql_params.rs
@@ -33,6 +33,23 @@ fn sanitize_identifier(arg: &Arg, input: &str) -> Result<(), error::Error> {
     }
 }
 
+/// Escape a value for safe interpolation inside a SQL single-quoted string
+/// literal by doubling single quotes (SQL-standard, accepted by every SQL
+/// dialect we target: pg, mysql, mssql, bigquery, snowflake, oracle, duckdb).
+///
+/// Contextual variables are substituted via plain string replacement, so a
+/// value containing a `'` could otherwise break out of the surrounding literal
+/// and inject arbitrary SQL. Most contextual values are charset-constrained
+/// (usernames, paths and ids cannot contain quotes), but emails are not: the
+/// `usr.email` CHECK constraint follows RFC 5321, whose local part allows `'`,
+/// `/`, `*` and `-` — enough to form a complete breakout payload such as
+/// `x'or/**/1=1--@evil.com`. `%%WM_EMAIL%%` / `%%WM_END_USER_EMAIL%%` are the
+/// reachable sinks, the latter from app end users. Escaping is a no-op for the
+/// charset-constrained vars, so this is backwards compatible.
+fn escape_contextual_value(value: &str) -> String {
+    value.replace('\'', "''")
+}
+
 fn replace_contextual_variables(
     code: &mut String,
     contextual_variables: &HashMap<String, String>,
@@ -50,7 +67,7 @@ fn replace_contextual_variables(
             .unwrap();
         let var_value = contextual_variables.get(var_name);
         if let Some(var_value) = var_value {
-            *code = code.replace(&var_pattern, var_value);
+            *code = code.replace(&var_pattern, &escape_contextual_value(var_value));
         }
     }
 }
@@ -127,4 +144,49 @@ pub fn sanitize_and_interpolate_unsafe_sql_args(
     }
 
     Ok((ret, args_to_skip))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contextual_var_with_quote_cannot_break_out_of_literal() {
+        // An email passing the RFC `usr.email` CHECK constraint can carry a
+        // quote-breakout payload. It must stay confined to the string literal.
+        let mut code =
+            "SELECT 1 WHERE email = '%%WM_END_USER_EMAIL%%'".to_string();
+        let mut ctx = HashMap::new();
+        ctx.insert(
+            "WM_END_USER_EMAIL".to_string(),
+            "x'or/**/1=1--@evil.com".to_string(),
+        );
+
+        replace_contextual_variables(&mut code, &ctx);
+
+        // The lone `'` is doubled, so it stays inside the literal instead of
+        // terminating it early and starting an injected clause.
+        assert_eq!(
+            code,
+            "SELECT 1 WHERE email = 'x''or/**/1=1--@evil.com'"
+        );
+    }
+
+    #[test]
+    fn quoteless_contextual_var_is_unchanged() {
+        let mut code = "SELECT '%%WM_USERNAME%%', '%%WM_JOB_ID%%'".to_string();
+        let mut ctx = HashMap::new();
+        ctx.insert("WM_USERNAME".to_string(), "alice".to_string());
+        ctx.insert(
+            "WM_JOB_ID".to_string(),
+            "0195e3b1-0000-0000-0000-000000000000".to_string(),
+        );
+
+        replace_contextual_variables(&mut code, &ctx);
+
+        assert_eq!(
+            code,
+            "SELECT 'alice', '0195e3b1-0000-0000-0000-000000000000'"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`%%WM_*%%` contextual variables are substituted into SQL scripts by the worker executors (`pg`, `mysql`, `mssql`, `bigquery`, `snowflake`, `oracle`, `duckdb`) via plain string replacement in `replace_contextual_variables`, with **no escaping**.

Most contextual values are charset-constrained and cannot carry a quote:
- usernames match `^[a-zA-Z][a-zA-Z_0-9]*$`
- path-derived vars (`WM_FLOW_PATH`, `WM_JOB_PATH`, `WM_SCHEDULE_PATH`, …) are pinned by the `script.path` DB CHECK constraint `^[ufg](\/[\w-]+){2,}$`

But **emails are not**: the `usr.email` CHECK constraint follows the RFC 5321 regex, whose local part allows `'`, `/`, `*` and `-`. That is enough to form a complete, space-free, semicolon-free breakout payload:

```
x'or/**/1=1--@evil.com
```

A value reaching `%%WM_EMAIL%%` or `%%WM_END_USER_EMAIL%%` — the latter sourced from **app end users** via `get_end_user_email` — can break out of the surrounding string literal in an idiomatic script like:

```sql
SELECT * FROM users WHERE email = '%%WM_END_USER_EMAIL%%'
```

and inject arbitrary SQL into the script's **target** database (running under that resource's credentials).

## Fix

Escape contextual values by doubling single quotes (`'` → `''`) before substitution. This is SQL-standard and accepted by every dialect we target, confines the value to the single-quoted string literal, and is a **no-op** for the charset-constrained vars — so it is backwards compatible.

## Relation to GHSA-x6cq-7xr8-53x3

That advisory reported the same raw-splice primitive but via a workspace-admin-controlled custom env var shadowing a reserved name. The merged fix (#9264) filtered the custom-env-var feeder. It did **not** address the underlying unescaped splice, nor the email feeder — which is reachable below workspace-admin (app end users via `WM_END_USER_EMAIL`). This PR fixes the root cause at the substitution site.

## Tests

- breakout payload stays confined to the literal
- quoteless contextual vars are unchanged (backwards-compat)

```
test sanitized_sql_params::tests::contextual_var_with_quote_cannot_break_out_of_literal ... ok
test sanitized_sql_params::tests::quoteless_contextual_var_is_unchanged ... ok
```

## Follow-ups (not in this PR)

- Consider renaming `sanitize_and_interpolate_unsafe_sql_args` now that the splice is escaped.
- MySQL backslash-escaping edge cases inside string literals (a value ending in `\`) are out of scope here; the contextual vars in practice can't carry a backslash, but worth a hardening pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escape `%%WM_*%%` contextual variable values during SQL substitution by doubling single quotes to prevent escaping string literals and SQL injection. Affects all worker SQL executors and keeps quoteless vars unchanged; closes the `%%WM_EMAIL%%`/`%%WM_END_USER_EMAIL%%` vector.

- **Bug Fixes**
  - Escape `'` to `''` before substituting contextual vars in scripts for pg, mysql, mssql, bigquery, snowflake, oracle, and duckdb.
  - Confines email values to string literals; no behavior change for usernames, paths, or IDs.

- **Tests**
  - Added regression tests for a quote-injection payload and for unchanged quoteless values.

<sup>Written for commit ed2e9db631230cbc80ad61e5baa7afd261a33df8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

