### PR TITLE
fix(ai): validate token_url for SSRF in OAuth credentials flow

### DIFF
--- a/backend/windmill-ai/src/ai_providers.rs
+++ b/backend/windmill-ai/src/ai_providers.rs
@@ -20,7 +20,7 @@ where
 
 lazy_static::lazy_static! {
     static ref OPENAI_AZURE_BASE_PATH: Option<String> = std::env::var("OPENAI_AZURE_BASE_PATH").ok();
-    static ref ALLOW_PRIVATE_AI_BASE_URLS: bool = std::env::var("ALLOW_PRIVATE_AI_BASE_URLS")
+    pub static ref ALLOW_PRIVATE_AI_BASE_URLS: bool = std::env::var("ALLOW_PRIVATE_AI_BASE_URLS")
         .ok()
         .map(|v| v == "true" || v == "1")
         .unwrap_or(false);

--- a/backend/windmill-api/src/ai.rs
+++ b/backend/windmill-api/src/ai.rs
@@ -305,6 +305,22 @@ async fn get_token_using_oauth(
     resource.client_id = resolve_var(resource.client_id, db, w_id, user_db, authed).await?;
     resource.client_secret = resolve_var(resource.client_secret, db, w_id, user_db, authed).await?;
     resource.token_url = resolve_var(resource.token_url, db, w_id, user_db, authed).await?;
+    // Validate the resolved token_url against SSRF rules before issuing the request,
+    // mirroring the protection applied to base_url in `get_base_url` (same
+    // ALLOW_PRIVATE_AI_BASE_URLS opt-in). Without this a workspace member could
+    // point token_url at an internal/metadata address.
+    if !*windmill_ai::ai_providers::ALLOW_PRIVATE_AI_BASE_URLS {
+        use windmill_common::ssrf::SsrfValidationError;
+        windmill_common::ssrf::validate_url_for_ssrf(&resource.token_url)
+            .await
+            .map_err(|e| match e {
+                e @ SsrfValidationError::Private { .. } => Error::BadRequest(format!(
+                    "{e}. If you need to use private/internal AI endpoints, \
+                     set the ALLOW_PRIVATE_AI_BASE_URLS=true environment variable"
+                )),
+                e => Error::from(e),
+            })?;
+    }
     let mut params = HashMap::new();
     params.insert("grant_type", "client_credentials");
     params.insert("scope", "https://cognitiveservices.azure.com/.default");


### PR DESCRIPTION
## Summary

`get_token_using_oauth` (`backend/windmill-api/src/ai.rs`) resolved the AI OAuth resource's `token_url` and issued a `POST` to it **without any SSRF validation**, while the sibling `base_url` field is validated in `get_base_url` (`backend/windmill-ai/src/ai_providers.rs`). A workspace member with `resources:write` could create a `customai`/`azure_openai` resource whose `token_url` points at an internal or cloud-metadata address (e.g. `http://169.254.169.254/...`) and trigger an outbound request from the server via an AI proxy call with `X-Resource-Path`.

This is an authenticated **blind** SSRF: the response body is never returned to the caller (`error_for_status()` carries only status + URL; the success path deserializes only `access_token`), and redirect following on the AI client is already disabled (#9370). Impact is limited to reaching internal hosts and probing, but it should still be closed.

## Changes

- `windmill-api/src/ai.rs`: validate the resolved `token_url` with `windmill_common::ssrf::validate_url_for_ssrf` before the token request, mirroring the `base_url` handling — same `ALLOW_PRIVATE_AI_BASE_URLS` opt-in and the same actionable error hint for `Private` failures, so private AI deployments behave consistently across both URL fields.
- `windmill-ai/src/ai_providers.rs`: make `ALLOW_PRIVATE_AI_BASE_URLS` `pub` so `windmill-api` reuses the existing flag instead of re-parsing the env var (avoids parsing drift).

By default (flag unset) the check is fully enforced.

## Test plan

- [x] `cargo check -p windmill-api` passes
- [ ] With `ALLOW_PRIVATE_AI_BASE_URLS` unset, an AI OAuth resource whose `token_url` resolves to a private/metadata IP is rejected with a `BadRequest`
- [ ] With `ALLOW_PRIVATE_AI_BASE_URLS=true`, a private `token_url` is allowed (consistent with `base_url`)
- [ ] A normal public `token_url` continues to work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SSRF validation for OAuth `token_url` to block requests to private/metadata hosts. Matches existing `base_url` behavior and respects the `ALLOW_PRIVATE_AI_BASE_URLS` opt-in.

- **Bug Fixes**
  - Validate the resolved `token_url` with SSRF rules before requesting a token.
  - Expose and reuse `ALLOW_PRIVATE_AI_BASE_URLS`; validation is enforced by default, set `ALLOW_PRIVATE_AI_BASE_URLS=true` to allow private endpoints.

<sup>Written for commit defdb6d1c100e44eedd7ea278b972b8c34504b04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

