### PR TITLE
fix(security): re-pin cached hub scripts to CVE-patched versions (+ HUB_BASE_URL override for cache mode)

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -258,6 +258,15 @@ pub fn main() -> anyhow::Result<()> {
 }
 
 async fn cache_hub_scripts(file_path: Option<String>) -> anyhow::Result<()> {
+    // The `cache` CLI mode never connects to the DB, so HUB_BASE_URL keeps its
+    // compiled default. Allow overriding it via env so the prebuild cache step can
+    // be pointed at a private/staging hub (e.g. a local proxy for testing).
+    if let Ok(hub_base_url) = std::env::var("HUB_BASE_URL") {
+        if !hub_base_url.is_empty() {
+            tracing::info!("Overriding hub base url from env: {hub_base_url}");
+            windmill_common::HUB_BASE_URL.store(std::sync::Arc::new(hub_base_url));
+        }
+    }
     let file_path = file_path.unwrap_or("./hubPaths.json".to_string());
     let mut file = File::open(&file_path)
         .await
@@ -567,6 +576,7 @@ fn print_help() {
     println!("  RUN_UPDATE_CA_CERTIFICATE_AT_START = false  Run system CA update at startup");
     println!("  RUN_UPDATE_CA_CERTIFICATE_PATH = /usr/sbin/update-ca-certificates  Path to CA update tool");
     println!("  SYNC_CACHED_RT = false                 Sync cached resource types to admins workspace on server start");
+    println!("  HUB_BASE_URL = https://hub.windmill.dev  Hub to fetch scripts from in `cache` mode (server/worker use the DB setting instead)");
     println!();
     println!("Notes:");
     println!("- Advanced and less commonly used settings are managed via the database and are omitted here.");

--- a/frontend/src/lib/hubPaths.json
+++ b/frontend/src/lib/hubPaths.json
@@ -1,16 +1,16 @@
 {
 	"gitSyncTest": "hub/28184/git-repo-test-read-write-windmill",
-	"gitInitRepo": "hub/28219/git-sync%3A-init-repository-windmill",
-	"slackErrorHandler": "hub/19741/workspace-or-schedule-error-handler-slack",
+	"gitInitRepo": "hub/28229/git-sync%3A-init-repository-windmill",
+	"slackErrorHandler": "hub/28241/workspace-or-schedule-error-handler-slack",
 	"emailErrorHandler": "hub/19795/workspace-or-error-handler-email",
-	"slackRecoveryHandler": "hub/9080/slack/schedule-recovery-handler-slack",
-	"slackSuccessHandler": "hub/28220/slack/schedule-success-handler-slack",
+	"slackRecoveryHandler": "hub/28239/slack/schedule-recovery-handler-slack",
+	"slackSuccessHandler": "hub/28240/slack/schedule-success-handler-slack",
 	"teamsErrorHandler": "hub/19742/workspace-or-schedule-error-handler-teams",
 	"teamsRecoveryHandler": "hub/11593/schedule-recovery-handler-teams",
 	"teamsSuccessHandler": "hub/11596/schedule-success-handler-teams",
 	"slackReport": "hub/9084/slack",
 	"discordReport": "hub/9085/discord",
-	"smtpReport": "hub/9086/smtp",
-	"appReport": "hub/28076/app-report",
+	"smtpReport": "hub/28242/smtp",
+	"appReport": "hub/28243/app-report",
 	"cloneRepoToS3forGitRepoViewer": "hub/28216/clone_repo_and_upload_to_instance_storage"
 }


### PR DESCRIPTION
## What

Fixes the Mend findings on PR #9279 where hub scripts pre-cached into the image (`windmill cache hubPaths.json`) pulled transitive deps with known CVEs into `cache_nomount/bun/<pkg>@<ver>`.

Two changes:

### 1. Re-pin `frontend/src/lib/hubPaths.json` to patched hub versions
windmill-integrations#133 regenerated the offending lockfiles; the hub minted new versions on approval. The hub serves each `version_id` immutably, so the cache step kept fetching the old vulnerable lockfiles until the pins were bumped:

| key | old → new | fix |
|---|---|---|
| `slackErrorHandler` | 19741 → **28241** | axios 1.7.7→1.16.1, form-data 4.0.0→4.0.5, follow-redirects 1.15.9→1.16.0 |
| `slackRecoveryHandler` | 9080 → **28239** | (same) |
| `slackSuccessHandler` | 28220 → **28240** | (same) |
| `smtpReport` | 9086 → **28242** | nodemailer 6.9.15→8.0.10 |
| `appReport` | 28076 → **28243** | ws 8.18.3→8.21.0; basic-ftp & ip-address dropped (puppeteer-core 25) |
| `gitInitRepo` | 28219 → **28229** | svelte 5.55.5→5.55.8, devalue 5.8.0→5.8.1 (the hub already had a fixed version; the pin was just stale) |

### 2. `HUB_BASE_URL` env override in `cache` mode (`backend/src/main.rs`)
The `cache` CLI step never connects to the DB, so `HUB_BASE_URL` stayed at its compiled default with no way to point it at a private/staging hub. It now reads `HUB_BASE_URL` from the env and stores it into the existing `HUB_BASE_URL` `ArcSwap`. No effect unless set and non-empty; server/worker modes are unchanged (they still use the DB setting). This enabled validating the lockfile fixes against a local fake-hub before they were pushed.

## Validation

End-to-end against the **real hub**: ran `windmill cache` with the updated `hubPaths.json` and scanned `cache_nomount/bun`.

- Before the re-pin: reproduced the Mend findings (axios@1.7.7, nodemailer@6.9.15, ws@8.18.3, svelte@5.55.5, devalue@5.8.0, …).
- After: **clean** — axios 1.16.1, form-data 4.0.5, follow-redirects 1.16.0, nodemailer 8.0.10, ws 8.21.0, svelte 5.55.8/5.55.10, devalue 5.8.1; basic-ftp and ip-address no longer pulled. No vulnerable versions remain.

`cargo check` passes.

## Follow-up
The image must be rebuilt for the new pins to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)