### PR TITLE
feat: add workspace datatable tools to global AI chat mode

### DIFF
--- a/frontend/src/lib/components/copilot/chat/datatableTools.test.ts
+++ b/frontend/src/lib/components/copilot/chat/datatableTools.test.ts
@@ -83,10 +83,13 @@ describe('list_datatables', () => {
 		})
 	})
 
-	it('returns a friendly message when no datatables are configured', async () => {
+	it('explains that configuring a datatable is a blocking prerequisite when none exist', async () => {
 		listMock.mockResolvedValue([])
 		const result = await run('list_datatables')
-		expect(result).toContain('No datatables are configured in this workspace.')
+		expect(result).toContain('No datatables are configured in this workspace')
+		expect(result).toContain('Workspace settings → Data Tables')
+		expect(result).toContain('blocked')
+		expect(result).toContain('Do not call exec_datatable_sql')
 	})
 
 	it('surfaces backend errors as a readable message', async () => {
@@ -180,5 +183,18 @@ describe('exec_datatable_sql', () => {
 		runSqlMock.mockRejectedValue(new Error('syntax error'))
 		const parsed = JSON.parse(await run('exec_datatable_sql', { datatable_name: 'main', sql: 'SLECT' }))
 		expect(parsed).toEqual({ success: false, error: 'syntax error' })
+	})
+
+	it('turns the backend "datatable not found" error into an actionable, blocking message', async () => {
+		runSqlMock.mockRejectedValue(new Error('Internal: datatable main not found @workspaces.rs:565:20'))
+		const parsed = JSON.parse(
+			await run('exec_datatable_sql', { datatable_name: 'main', sql: 'CREATE TABLE t (id int)' })
+		)
+		expect(parsed.success).toBe(false)
+		expect(parsed.error).toContain('not configured in this workspace')
+		expect(parsed.error).toContain('Workspace settings → Data Tables')
+		expect(parsed.error).toContain('do not retry')
+		// The raw internal error is not surfaced to the model.
+		expect(parsed.error).not.toContain('workspaces.rs')
 	})
 })

--- a/frontend/src/lib/components/copilot/chat/datatableTools.test.ts
+++ b/frontend/src/lib/components/copilot/chat/datatableTools.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { listMock, schemaMock, runSqlMock } = vi.hoisted(() => ({
+	listMock: vi.fn(),
+	schemaMock: vi.fn(),
+	runSqlMock: vi.fn()
+}))
+
+vi.mock('./shared', () => ({
+	createToolDef: (_schema: unknown, name: string, description: string) => ({
+		type: 'function',
+		function: { name, description, parameters: {} }
+	})
+}))
+
+vi.mock('$lib/gen', () => ({
+	WorkspaceService: {
+		listDataTableTables: listMock,
+		getDataTableTableSchema: schemaMock
+	}
+}))
+
+vi.mock('$lib/components/jobs/utils', () => ({
+	runScriptAndPollResult: runSqlMock
+}))
+
+import { getDatatableTools } from './datatableTools'
+
+function createToolCallbacks() {
+	return {
+		setToolStatus: vi.fn(),
+		removeToolStatus: vi.fn()
+	}
+}
+
+function getTool(name: string) {
+	const tool = getDatatableTools().find((entry) => entry.def.function.name === name)
+	if (!tool) {
+		throw new Error(`${name} tool not found`)
+	}
+	return tool
+}
+
+function run(name: string, args: Record<string, unknown> = {}) {
+	return getTool(name).fn({
+		args,
+		workspace: 'test-workspace',
+		helpers: {},
+		toolCallbacks: createToolCallbacks(),
+		toolId: `tool-${name}`
+	})
+}
+
+beforeEach(() => {
+	listMock.mockReset()
+	schemaMock.mockReset()
+	runSqlMock.mockReset()
+})
+
+describe('list_datatables', () => {
+	it('aggregates the table count across schemas and returns metadata verbatim', async () => {
+		const metadata = [
+			{ datatable_name: 'main', schemas: { public: ['users', 'orders'], analytics: ['events'] } },
+			{ datatable_name: 'warehouse', schemas: { public: ['facts'] } }
+		]
+		listMock.mockResolvedValue(metadata)
+
+		const tool = getTool('list_datatables')
+		const callbacks = createToolCallbacks()
+		const result = await tool.fn({
+			args: {},
+			workspace: 'test-workspace',
+			helpers: {},
+			toolCallbacks: callbacks,
+			toolId: 'tool-list'
+		})
+
+		expect(listMock).toHaveBeenCalledWith({ workspace: 'test-workspace' })
+		expect(JSON.parse(result)).toEqual(metadata)
+		// 2 + 1 + 1 = 4 tables across 2 datatables
+		expect(callbacks.setToolStatus).toHaveBeenCalledWith('tool-list', {
+			content: 'Listed 2 datatable(s) with 4 table(s)'
+		})
+	})
+
+	it('returns a friendly message when no datatables are configured', async () => {
+		listMock.mockResolvedValue([])
+		const result = await run('list_datatables')
+		expect(result).toContain('No datatables are configured in this workspace.')
+	})
+
+	it('surfaces backend errors as a readable message', async () => {
+		listMock.mockRejectedValue(new Error('boom'))
+		const result = await run('list_datatables')
+		expect(result).toContain('Error listing datatables: boom')
+	})
+})
+
+describe('get_datatable_table_schema', () => {
+	it('returns the columns for one table', async () => {
+		schemaMock.mockResolvedValue({
+			datatable_name: 'main',
+			schema_name: 'public',
+			table_name: 'users',
+			columns: { id: 'int4', email: 'text' }
+		})
+
+		const result = await run('get_datatable_table_schema', {
+			datatable_name: 'main',
+			schema_name: 'public',
+			table_name: 'users'
+		})
+
+		expect(schemaMock).toHaveBeenCalledWith({
+			workspace: 'test-workspace',
+			datatableName: 'main',
+			schemaName: 'public',
+			tableName: 'users'
+		})
+		expect(JSON.parse(result)).toEqual({
+			datatable_name: 'main',
+			schema_name: 'public',
+			table_name: 'users',
+			columns: { id: 'int4', email: 'text' }
+		})
+	})
+})
+
+describe('exec_datatable_sql', () => {
+	it('requires confirmation', () => {
+		expect(getTool('exec_datatable_sql').requiresConfirmation).toBe(true)
+	})
+
+	it('returns all rows when the result is at or below the cap', async () => {
+		const rows = Array.from({ length: 100 }, (_, i) => ({ id: i }))
+		runSqlMock.mockResolvedValue(rows)
+
+		const result = await run('exec_datatable_sql', {
+			datatable_name: 'main',
+			sql: 'SELECT * FROM t'
+		})
+
+		const parsed = JSON.parse(result)
+		expect(parsed.success).toBe(true)
+		expect(parsed.rowCount).toBe(100)
+		expect(parsed.result).toHaveLength(100)
+		expect(parsed.note).toBeUndefined()
+		expect(runSqlMock).toHaveBeenCalledWith({
+			workspace: 'test-workspace',
+			requestBody: {
+				language: 'postgresql',
+				content: 'SELECT * FROM t',
+				args: { database: 'datatable://main' }
+			}
+		})
+	})
+
+	it('truncates results above the cap and reports the full count', async () => {
+		const rows = Array.from({ length: 150 }, (_, i) => ({ id: i }))
+		runSqlMock.mockResolvedValue(rows)
+
+		const parsed = JSON.parse(await run('exec_datatable_sql', { datatable_name: 'main', sql: 'SELECT 1' }))
+		expect(parsed.rowCount).toBe(150)
+		expect(parsed.result).toHaveLength(100)
+		expect(parsed.note).toBe('Showing first 100 of 150 rows')
+	})
+
+	it('treats a non-array result (e.g. DDL) as zero rows', async () => {
+		runSqlMock.mockResolvedValue(undefined)
+		const parsed = JSON.parse(
+			await run('exec_datatable_sql', {
+				datatable_name: 'main',
+				sql: 'CREATE TABLE t (id serial primary key)'
+			})
+		)
+		expect(parsed).toEqual({ success: true, rowCount: 0, result: [] })
+	})
+
+	it('returns a failure object when the SQL job errors', async () => {
+		runSqlMock.mockRejectedValue(new Error('syntax error'))
+		const parsed = JSON.parse(await run('exec_datatable_sql', { datatable_name: 'main', sql: 'SLECT' }))
+		expect(parsed).toEqual({ success: false, error: 'syntax error' })
+	})
+})

--- a/frontend/src/lib/components/copilot/chat/datatableTools.ts
+++ b/frontend/src/lib/components/copilot/chat/datatableTools.ts
@@ -55,7 +55,9 @@ export async function execDatatableSql(
 	workspace: string,
 	datatableName: string,
 	sql: string
-): Promise<{ success: boolean; result?: Record<string, any>[]; error?: string }> {
+): Promise<
+	{ success: true; result: Record<string, any>[] } | { success: false; error: string }
+> {
 	try {
 		const result = await runScriptAndPollResult({
 			workspace,
@@ -237,25 +239,23 @@ export function getDatatableTools(): Tool<{}>[] {
 				try {
 					const result = await execDatatableSql(workspace, parsedArgs.datatable_name, parsedArgs.sql)
 					if (result.success) {
-						if (result.result) {
-							const rowCount = result.result.length
-							toolCallbacks.setToolStatus(toolId, { content: `Query returned ${rowCount} row(s)` })
-							if (rowCount > MAX_ROWS) {
-								return JSON.stringify(
-									{
-										success: true,
-										rowCount,
-										result: result.result.slice(0, MAX_ROWS),
-										note: `Showing first ${MAX_ROWS} of ${rowCount} rows`
-									},
-									null,
-									2
-								)
-							}
-							return JSON.stringify({ success: true, rowCount, result: result.result }, null, 2)
+						// Successful runs always carry a `result` array (empty for DDL/DML), so
+						// SELECT rows and zero-row statements share one reporting path.
+						const rowCount = result.result.length
+						toolCallbacks.setToolStatus(toolId, { content: `Query returned ${rowCount} row(s)` })
+						if (rowCount > MAX_ROWS) {
+							return JSON.stringify(
+								{
+									success: true,
+									rowCount,
+									result: result.result.slice(0, MAX_ROWS),
+									note: `Showing first ${MAX_ROWS} of ${rowCount} rows`
+								},
+								null,
+								2
+							)
 						}
-						toolCallbacks.setToolStatus(toolId, { content: 'Query executed successfully' })
-						return JSON.stringify({ success: true, message: 'Query executed successfully' })
+						return JSON.stringify({ success: true, rowCount, result: result.result }, null, 2)
 					} else {
 						const raw = result.error || 'Unknown error'
 						const errorMsg = isDatatableNotConfiguredError(raw)

--- a/frontend/src/lib/components/copilot/chat/datatableTools.ts
+++ b/frontend/src/lib/components/copilot/chat/datatableTools.ts
@@ -74,6 +74,33 @@ export async function execDatatableSql(
 	}
 }
 
+// ============= Error helpers =============
+
+/**
+ * The backend returns "datatable <name> not found" when no datatable with that
+ * name is configured in the workspace settings. That is a hard, blocking
+ * prerequisite (not a transient failure), so we surface an explicit, actionable
+ * message instead of the raw internal error.
+ */
+function isDatatableNotConfiguredError(error: string | null | undefined): boolean {
+	return typeof error === 'string' && /datatable\s+\S+\s+not found/i.test(error)
+}
+
+function datatableNotConfiguredMessage(datatableName: string): string {
+	return (
+		`Datatable "${datatableName}" is not configured in this workspace, so this operation cannot run. ` +
+		`Datatables are not created by SQL — they must be set up first by the user in the workspace settings ` +
+		`(Workspace settings → Data Tables) before any table can be queried or created. ` +
+		`This is a required, blocking prerequisite: do not retry on this or another name. ` +
+		`Tell the user they need to configure a datatable (e.g. named "${datatableName}") in their workspace settings, then try again.`
+	)
+}
+
+const NO_DATATABLES_CONFIGURED_MESSAGE =
+	'No datatables are configured in this workspace. Datatable operations (querying data, creating or altering tables) are blocked until a datatable exists. ' +
+	'Datatables are not created by SQL — the user must set one up in the workspace settings (Workspace settings → Data Tables) first. ' +
+	'Do not call exec_datatable_sql or assume a "main" datatable exists; instead tell the user this is a required prerequisite and ask them to configure a datatable in their workspace settings.'
+
 // ============= Tool definitions =============
 
 const getListDatatablesSchema = memo(() => z.object({}))
@@ -138,8 +165,10 @@ export function getDatatableTools(): Tool<{}>[] {
 				try {
 					const metadata = await listDatatables(workspace)
 					if (metadata.length === 0) {
-						toolCallbacks.setToolStatus(toolId, { content: 'No datatables configured' })
-						return 'No datatables are configured in this workspace.'
+						toolCallbacks.setToolStatus(toolId, {
+							content: 'No datatables configured — set one up in workspace settings'
+						})
+						return NO_DATATABLES_CONFIGURED_MESSAGE
 					}
 					const totalTables = metadata.reduce(
 						(acc, datatable) =>
@@ -186,7 +215,10 @@ export function getDatatableTools(): Tool<{}>[] {
 						2
 					)
 				} catch (e) {
-					const errorMsg = `Error getting table schema: ${e instanceof Error ? e.message : String(e)}`
+					const raw = e instanceof Error ? e.message : String(e)
+					const errorMsg = isDatatableNotConfiguredError(raw)
+						? datatableNotConfiguredMessage(parsedArgs.datatable_name)
+						: `Error getting table schema: ${raw}`
 					toolCallbacks.setToolStatus(toolId, { content: errorMsg, error: errorMsg })
 					return errorMsg
 				}
@@ -225,12 +257,18 @@ export function getDatatableTools(): Tool<{}>[] {
 						toolCallbacks.setToolStatus(toolId, { content: 'Query executed successfully' })
 						return JSON.stringify({ success: true, message: 'Query executed successfully' })
 					} else {
-						const errorMsg = result.error || 'Unknown error'
+						const raw = result.error || 'Unknown error'
+						const errorMsg = isDatatableNotConfiguredError(raw)
+							? datatableNotConfiguredMessage(parsedArgs.datatable_name)
+							: raw
 						toolCallbacks.setToolStatus(toolId, { content: `Error: ${errorMsg}`, error: errorMsg })
 						return JSON.stringify({ success: false, error: errorMsg })
 					}
 				} catch (e) {
-					const errorMsg = e instanceof Error ? e.message : String(e)
+					const raw = e instanceof Error ? e.message : String(e)
+					const errorMsg = isDatatableNotConfiguredError(raw)
+						? datatableNotConfiguredMessage(parsedArgs.datatable_name)
+						: raw
 					toolCallbacks.setToolStatus(toolId, { content: `Error: ${errorMsg}`, error: errorMsg })
 					return JSON.stringify({ success: false, error: errorMsg })
 				}

--- a/frontend/src/lib/components/copilot/chat/datatableTools.ts
+++ b/frontend/src/lib/components/copilot/chat/datatableTools.ts
@@ -1,0 +1,240 @@
+import { z } from 'zod'
+import { WorkspaceService } from '$lib/gen'
+import type { DataTableTables } from '$lib/gen/types.gen'
+import { runScriptAndPollResult } from '$lib/components/jobs/utils'
+import { createToolDef, type Tool } from './shared'
+
+/**
+ * Workspace-scoped datatable tools, with no app whitelist and no creation policy.
+ *
+ * Datatables are workspace-level managed PostgreSQL databases. The backend
+ * endpoints used here (`list_datatable_tables`, `get_datatable_table_schema`)
+ * and SQL execution (`datatable://<name>`) are gated only by workspace
+ * membership, so these tools need no app context and operate directly on the
+ * workspace. This is the unrestricted counterpart to the app-mode datatable
+ * tools in `app/core.ts`, which additionally filter by the app's whitelist.
+ */
+
+// ============= Utility =============
+
+/** Memoize a factory function - the factory is only called once, on first access */
+const memo = <T>(factory: () => T): (() => T) => {
+	let cached: T | undefined
+	return () => (cached ??= factory())
+}
+
+// ============= Pure workspace-scoped operations =============
+
+/** List all datatables configured in the workspace, with their schema/table names. */
+export async function listDatatables(workspace: string): Promise<DataTableTables[]> {
+	return await WorkspaceService.listDataTableTables({ workspace })
+}
+
+/** Get the columns (column_name -> compact_type) of one datatable table. */
+export async function getDatatableColumns(
+	workspace: string,
+	datatableName: string,
+	schemaName: string,
+	tableName: string
+): Promise<Record<string, string>> {
+	const schema = await WorkspaceService.getDataTableTableSchema({
+		workspace,
+		datatableName,
+		schemaName,
+		tableName
+	})
+	return schema.columns
+}
+
+/**
+ * Execute an arbitrary SQL statement against a datatable.
+ * Supports SELECT/INSERT/UPDATE/DELETE as well as DDL (CREATE/ALTER/DROP).
+ * Returns rows for SELECT-like queries, an empty array otherwise.
+ */
+export async function execDatatableSql(
+	workspace: string,
+	datatableName: string,
+	sql: string
+): Promise<{ success: boolean; result?: Record<string, any>[]; error?: string }> {
+	try {
+		const result = await runScriptAndPollResult({
+			workspace,
+			requestBody: {
+				language: 'postgresql',
+				content: sql,
+				args: { database: `datatable://${datatableName}` }
+			}
+		})
+		if (Array.isArray(result)) {
+			return { success: true, result }
+		}
+		return { success: true, result: [] }
+	} catch (e) {
+		return { success: false, error: e instanceof Error ? e.message : String(e) }
+	}
+}
+
+// ============= Tool definitions =============
+
+const getListDatatablesSchema = memo(() => z.object({}))
+const getListDatatablesToolDef = memo(() =>
+	createToolDef(
+		getListDatatablesSchema(),
+		'list_datatables',
+		'List datatables configured in the workspace with schema and table names only. Does not include column definitions. Use this directly for table-list or available-tables summaries. Only call get_datatable_table_schema when column names/types are required.'
+	)
+)
+
+const getGetDatatableTableSchemaSchema = memo(() =>
+	z.object({
+		datatable_name: z.string().describe('The datatable name to inspect, e.g. "main".'),
+		schema_name: z.string().describe('The schema name, e.g. "public".'),
+		table_name: z.string().describe('The table name to inspect.')
+	})
+)
+const getGetDatatableTableSchemaToolDef = memo(() =>
+	createToolDef(
+		getGetDatatableTableSchemaSchema(),
+		'get_datatable_table_schema',
+		'Get column definitions for one datatable table. Do not call this for row counts or table-list summaries; list_datatables is enough for those.'
+	)
+)
+
+const getExecDatatableSqlSchema = memo(() =>
+	z.object({
+		datatable_name: z
+			.string()
+			.describe(
+				'The name of the datatable to query (e.g., "main"). Must be one of the datatables configured in the workspace.'
+			),
+		sql: z
+			.string()
+			.describe(
+				'The SQL query to execute. Supports SELECT, INSERT, UPDATE, DELETE, CREATE TABLE, ALTER TABLE, DROP TABLE, etc. For SELECT queries, results are returned as an array of objects. A newly created table will appear in list_datatables automatically.'
+			)
+	})
+)
+const getExecDatatableSqlToolDef = memo(() =>
+	createToolDef(
+		getExecDatatableSqlSchema(),
+		'exec_datatable_sql',
+		'Execute a SQL query on a workspace datatable. Use this to explore data, test queries, create/alter tables, or make changes. Creating a table is a normal CREATE TABLE statement — no registration step is needed.'
+	)
+)
+
+/** Maximum rows returned to the model for a SELECT query. */
+const MAX_ROWS = 100
+
+/**
+ * The unrestricted workspace datatable tools, for registration in global mode.
+ * Helper-free: each tool reads `workspace` directly from the tool call params.
+ */
+export function getDatatableTools(): Tool<{}>[] {
+	return [
+		{
+			def: getListDatatablesToolDef(),
+			fn: async ({ workspace, toolId, toolCallbacks }) => {
+				toolCallbacks.setToolStatus(toolId, { content: 'Listing datatables...' })
+				try {
+					const metadata = await listDatatables(workspace)
+					if (metadata.length === 0) {
+						toolCallbacks.setToolStatus(toolId, { content: 'No datatables configured' })
+						return 'No datatables are configured in this workspace.'
+					}
+					const totalTables = metadata.reduce(
+						(acc, datatable) =>
+							acc +
+							Object.values(datatable.schemas).reduce((sum, tables) => sum + tables.length, 0),
+						0
+					)
+					toolCallbacks.setToolStatus(toolId, {
+						content: `Listed ${metadata.length} datatable(s) with ${totalTables} table(s)`
+					})
+					return JSON.stringify(metadata, null, 2)
+				} catch (e) {
+					const errorMsg = `Error listing datatables: ${e instanceof Error ? e.message : String(e)}`
+					toolCallbacks.setToolStatus(toolId, { content: errorMsg, error: errorMsg })
+					return errorMsg
+				}
+			}
+		},
+		{
+			def: getGetDatatableTableSchemaToolDef(),
+			fn: async ({ args, workspace, toolId, toolCallbacks }) => {
+				const parsedArgs = getGetDatatableTableSchemaSchema().parse(args)
+				toolCallbacks.setToolStatus(toolId, {
+					content: `Getting schema for ${parsedArgs.datatable_name}.${parsedArgs.schema_name}.${parsedArgs.table_name}...`
+				})
+				try {
+					const columns = await getDatatableColumns(
+						workspace,
+						parsedArgs.datatable_name,
+						parsedArgs.schema_name,
+						parsedArgs.table_name
+					)
+					toolCallbacks.setToolStatus(toolId, {
+						content: `Retrieved schema for ${parsedArgs.schema_name}.${parsedArgs.table_name}`
+					})
+					return JSON.stringify(
+						{
+							datatable_name: parsedArgs.datatable_name,
+							schema_name: parsedArgs.schema_name,
+							table_name: parsedArgs.table_name,
+							columns
+						},
+						null,
+						2
+					)
+				} catch (e) {
+					const errorMsg = `Error getting table schema: ${e instanceof Error ? e.message : String(e)}`
+					toolCallbacks.setToolStatus(toolId, { content: errorMsg, error: errorMsg })
+					return errorMsg
+				}
+			}
+		},
+		{
+			def: getExecDatatableSqlToolDef(),
+			requiresConfirmation: true,
+			confirmationMessage: 'Execute SQL on datatable',
+			showDetails: true,
+			fn: async ({ args, workspace, toolId, toolCallbacks }) => {
+				const parsedArgs = getExecDatatableSqlSchema().parse(args)
+				toolCallbacks.setToolStatus(toolId, {
+					content: `Executing SQL on "${parsedArgs.datatable_name}"...`
+				})
+				try {
+					const result = await execDatatableSql(workspace, parsedArgs.datatable_name, parsedArgs.sql)
+					if (result.success) {
+						if (result.result) {
+							const rowCount = result.result.length
+							toolCallbacks.setToolStatus(toolId, { content: `Query returned ${rowCount} row(s)` })
+							if (rowCount > MAX_ROWS) {
+								return JSON.stringify(
+									{
+										success: true,
+										rowCount,
+										result: result.result.slice(0, MAX_ROWS),
+										note: `Showing first ${MAX_ROWS} of ${rowCount} rows`
+									},
+									null,
+									2
+								)
+							}
+							return JSON.stringify({ success: true, rowCount, result: result.result }, null, 2)
+						}
+						toolCallbacks.setToolStatus(toolId, { content: 'Query executed successfully' })
+						return JSON.stringify({ success: true, message: 'Query executed successfully' })
+					} else {
+						const errorMsg = result.error || 'Unknown error'
+						toolCallbacks.setToolStatus(toolId, { content: `Error: ${errorMsg}`, error: errorMsg })
+						return JSON.stringify({ success: false, error: errorMsg })
+					}
+				} catch (e) {
+					const errorMsg = e instanceof Error ? e.message : String(e)
+					toolCallbacks.setToolStatus(toolId, { content: `Error: ${errorMsg}`, error: errorMsg })
+					return JSON.stringify({ success: false, error: errorMsg })
+				}
+			}
+		}
+	]
+}

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -178,12 +178,26 @@ describe('global AI tools', () => {
 		vi.clearAllMocks()
 	})
 
-	it('returns the datatable SQL SDK reference for the "datatable" instruction subject', async () => {
+	it('defaults the datatable instruction subject to the TypeScript SQL SDK', async () => {
 		const result = await callGlobalTool('get_instructions', { subject: 'datatable' })
 		expect(result).toContain('wmill.datatable(')
 		expect(result).toContain('TypeScript Datatable API')
-		expect(result).toContain('Python Datatable API')
 		expect(result).toContain('fetchOne')
+		// Defaults to TypeScript only — no Python noise.
+		expect(result).not.toContain('Python Datatable API')
+	})
+
+	it('returns only the requested language SDK for the datatable subject', async () => {
+		const ts = await callGlobalTool('get_instructions', { subject: 'datatable', language: 'bun' })
+		expect(ts).toContain('TypeScript Datatable API')
+		expect(ts).not.toContain('Python Datatable API')
+
+		const py = await callGlobalTool('get_instructions', {
+			subject: 'datatable',
+			language: 'python3'
+		})
+		expect(py).toContain('Python Datatable API')
+		expect(py).not.toContain('TypeScript Datatable API')
 	})
 
 	it('redacts variable draft values when reading workspace items', async () => {

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -178,6 +178,14 @@ describe('global AI tools', () => {
 		vi.clearAllMocks()
 	})
 
+	it('returns the datatable SQL SDK reference for the "datatable" instruction subject', async () => {
+		const result = await callGlobalTool('get_instructions', { subject: 'datatable' })
+		expect(result).toContain('wmill.datatable(')
+		expect(result).toContain('TypeScript Datatable API')
+		expect(result).toContain('Python Datatable API')
+		expect(result).toContain('fetchOne')
+	})
+
 	it('redacts variable draft values when reading workspace items', async () => {
 		await callGlobalTool('write_variable', {
 			path: 'f/secrets/api_key',

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -164,7 +164,7 @@ const getInstructionsSchema = z.object({
 	language: scriptLangSchema
 		.optional()
 		.describe(
-			'Required when subject is script. Use the existing script language when modifying, or the requested target language when creating.'
+			'The target language. Required when subject is script. For subject "datatable" it selects which SDK to return (e.g. "bun" for TypeScript, "python3" for Python) and defaults to TypeScript if omitted. Use the existing language when modifying, or the requested target language when creating. Other subjects ignore it.'
 		)
 })
 
@@ -592,7 +592,7 @@ Data Tables:
 - Use list_datatables to discover the available datatables and their tables. Reuse an existing table rather than creating a duplicate.
 - Use get_datatable_table_schema only when you need a table's column names/types; list_datatables is enough for table-list or availability summaries.
 - Use exec_datatable_sql to explore data, run queries, mutate rows, or change schema (CREATE/ALTER/DROP). Creating a table is a normal CREATE TABLE statement — it appears in list_datatables afterward, with no registration step.
-- When writing runnable code (inline app runnables, scripts, flow modules) that reads or writes datatable data at runtime, it accesses a datatable via wmill.datatable(); call get_instructions with subject "datatable" for the SQL SDK reference.`
+- When writing runnable code (inline app runnables, scripts, flow modules) that reads or writes datatable data at runtime, it accesses a datatable via wmill.datatable(). Default to TypeScript (bun) unless the user asked for another language. Call get_instructions with subject "datatable" and language "bun" for the TypeScript SQL SDK reference (or language "python3" for Python) — it returns only that language so you get just what you need.`
 
 const DEFAULT_LIST_TYPES = ['script', 'flow'] as const satisfies readonly WorkspaceItemType[]
 
@@ -1323,7 +1323,9 @@ function getResourceInstructions(): string {
 ${getResourcePrompt()}`
 }
 
-function getDatatableInstructions(): string {
+function getDatatableInstructions(language?: ScriptLang): string {
+	// Default to the TypeScript SDK so we return only what's needed, not both.
+	const lang = language ?? 'bun'
 	return `# Datatable SQL SDK reference
 
 Datatables are workspace-scoped managed PostgreSQL databases. In chat, explore and shape them with the \`list_datatables\`, \`get_datatable_table_schema\`, and \`exec_datatable_sql\` tools. The reference below is for code you author inside runnables (inline app runnables, scripts, or flow rawscript modules) that reads or writes datatable data at runtime.
@@ -1331,7 +1333,7 @@ Datatables are workspace-scoped managed PostgreSQL databases. In chat, explore a
 - A runnable accesses a datatable via \`wmill.datatable()\` (the default "main") or \`wmill.datatable('<name>')\`, referencing tables as \`schema.table\`.
 - Use parameterized queries (the tagged template in TypeScript, \`$1\`/\`$2\` placeholders in Python) — never interpolate untrusted values into SQL strings.
 
-${getDatatableSdkReference()}`
+${getDatatableSdkReference(lang)}`
 }
 
 function getInstructions(subject: InstructionSubject, language?: ScriptLang): string {
@@ -1345,7 +1347,7 @@ function getInstructions(subject: InstructionSubject, language?: ScriptLang): st
 		case 'app':
 			return getAppInstructions()
 		case 'datatable':
-			return getDatatableInstructions()
+			return getDatatableInstructions(language)
 	}
 }
 

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -623,8 +623,8 @@ Raw apps:
 - Use deploy_workspace_item after explicit user deploy intent; raw app deploy bundles JS/CSS before saving.
 
 Data Tables:
-- Datatables are workspace-scoped managed PostgreSQL databases, shared across the workspace (not owned by any single app).
-- Use list_datatables to discover the available datatables and their tables. Reuse an existing table rather than creating a duplicate.
+- Datatables are workspace-scoped managed PostgreSQL databases, shared across the workspace (not owned by any single app). They must be configured by the user in their workspace settings (Workspace settings → Data Tables); they cannot be created via SQL.
+- Use list_datatables to discover the available datatables and their tables. Reuse an existing table rather than creating a duplicate. If list_datatables reports none, this is a blocking prerequisite — tell the user to set up a datatable in their workspace settings and stop; do not assume a "main" datatable exists or call exec_datatable_sql.
 - Use get_datatable_table_schema only when you need a table's column names/types; list_datatables is enough for table-list or availability summaries.
 - Use exec_datatable_sql to explore data, run queries, mutate rows, or change schema (CREATE/ALTER/DROP). Creating a table is a normal CREATE TABLE statement — it appears in list_datatables afterward, with no registration step.
 - When writing runnable code (inline app runnables, scripts, flow modules) that reads or writes datatable data at runtime, it accesses a datatable via wmill.datatable(). Default to TypeScript (bun) unless the user asked for another language. Call get_instructions with subject "datatable" and language "bun" for the TypeScript SQL SDK reference (or language "python3" for Python) — it returns only that language so you get just what you need.`

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -62,6 +62,7 @@ import {
 	type ToolDisplayAction
 } from '../shared'
 import type { ContextElement } from '../context'
+import { getDatatableTools } from '../datatableTools'
 import { UserDraft, type UserDraftMeta } from '$lib/userDraft.svelte'
 import { emptySchema } from '$lib/utils'
 import { inferArgs } from '$lib/infer'
@@ -571,7 +572,14 @@ Raw apps:
 - Use write_app_file, patch_app_file, and delete_app_file for frontend files.
 - Use write_app_runnable and delete_app_runnable for backend runnables.
 - Use init_app only after confirming framework, path, and summary with the user.
-- Use deploy_workspace_item after explicit user deploy intent; raw app deploy bundles JS/CSS before saving.`
+- Use deploy_workspace_item after explicit user deploy intent; raw app deploy bundles JS/CSS before saving.
+
+Data Tables:
+- Datatables are workspace-scoped managed PostgreSQL databases, shared across the workspace (not owned by any single app).
+- Use list_datatables to discover the available datatables and their tables. Reuse an existing table rather than creating a duplicate.
+- Use get_datatable_table_schema only when you need a table's column names/types; list_datatables is enough for table-list or availability summaries.
+- Use exec_datatable_sql to explore data, run queries, mutate rows, or change schema (CREATE/ALTER/DROP). Creating a table is a normal CREATE TABLE statement — it appears in list_datatables afterward, with no registration step.
+- From a runnable, access a datatable via wmill.datatable() (the default "main") or wmill.datatable('<name>'), referencing tables as schema.table.`
 
 const DEFAULT_LIST_TYPES = ['script', 'flow'] as const satisfies readonly WorkspaceItemType[]
 
@@ -1794,7 +1802,9 @@ export const globalTools: Tool<{}>[] = [
 			'Check whether the side-panel preview is open in this AI session and which item (kind + path) it is showing. Call this before offering or calling open_preview so you do not re-open a preview that is already showing the item you just edited. Only meaningful inside a session.'
 		),
 		fn: async (ctx) => getSessionPreviewStatus(sessionIdFromCtx(ctx))
-	}
+	},
+	// Workspace-scoped datatable tools (unrestricted: no whitelist, no creation policy)
+	...getDatatableTools()
 ]
 
 // Tools that only make sense inside an AI session (they drive the session's

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -47,7 +47,13 @@ import {
 	validateEditableFlowJson
 } from '../flow/editableFlowJson'
 import { createInlineScriptSession } from '../flow/inlineScriptsUtils'
-import { getFlowPrompt, getRawAppPrompt, getResourcePrompt, getScriptPrompt } from '$system_prompts'
+import {
+	getDatatableSdkReference,
+	getFlowPrompt,
+	getRawAppPrompt,
+	getResourcePrompt,
+	getScriptPrompt
+} from '$system_prompts'
 import type {
 	ChatCompletionSystemMessageParam,
 	ChatCompletionUserMessageParam
@@ -115,6 +121,13 @@ const INSTRUCTION_SUBJECTS = [
 	'resource',
 	'app'
 ] as const satisfies readonly WorkspaceItemType[]
+// `datatable` is not a workspace item type, but the model can request the
+// datatable SDK reference (the wmill.datatable() runnable API) the same way.
+const INSTRUCTION_SUBJECTS_EXTRA = ['datatable'] as const
+const ALL_INSTRUCTION_SUBJECTS = [
+	...INSTRUCTION_SUBJECTS,
+	...INSTRUCTION_SUBJECTS_EXTRA
+] as const
 const MAX_LIST_LIMIT = 100
 type ActiveGlobalEditorType = Extract<WorkspaceItemType, 'script' | 'flow' | 'app'>
 type LiveEditorDraftKind = Parameters<typeof UserDraft.getLiveEditorDraft>[0]
@@ -140,13 +153,13 @@ export type GlobalUserMessageOptions = {
 }
 
 const itemTypeSchema = z.enum(ITEM_TYPES)
-const instructionSubjectSchema = z.enum(INSTRUCTION_SUBJECTS)
+const instructionSubjectSchema = z.enum(ALL_INSTRUCTION_SUBJECTS)
 const triggerKindSchema = z.enum(TRIGGER_KINDS)
 const scriptLangSchema = z.enum($ScriptLang.enum)
 
 const getInstructionsSchema = z.object({
 	subject: instructionSubjectSchema.describe(
-		"The workspace item type to get authoring instructions for (script, flow, resource, app). Schedules, triggers, and variables don't need instructions — their tool schemas describe everything."
+		"What to get authoring instructions for: a workspace item type (script, flow, resource, app) or \"datatable\" for the wmill.datatable() SQL SDK used inside runnables. Schedules, triggers, and variables don't need instructions — their tool schemas describe everything."
 	),
 	language: scriptLangSchema
 		.optional()
@@ -579,7 +592,7 @@ Data Tables:
 - Use list_datatables to discover the available datatables and their tables. Reuse an existing table rather than creating a duplicate.
 - Use get_datatable_table_schema only when you need a table's column names/types; list_datatables is enough for table-list or availability summaries.
 - Use exec_datatable_sql to explore data, run queries, mutate rows, or change schema (CREATE/ALTER/DROP). Creating a table is a normal CREATE TABLE statement — it appears in list_datatables afterward, with no registration step.
-- From a runnable, access a datatable via wmill.datatable() (the default "main") or wmill.datatable('<name>'), referencing tables as schema.table.`
+- When writing runnable code (inline app runnables, scripts, flow modules) that reads or writes datatable data at runtime, it accesses a datatable via wmill.datatable(); call get_instructions with subject "datatable" for the SQL SDK reference.`
 
 const DEFAULT_LIST_TYPES = ['script', 'flow'] as const satisfies readonly WorkspaceItemType[]
 
@@ -1271,7 +1284,7 @@ function getFlowInstructions(): string {
 ${getFlowPrompt()}`
 }
 
-type InstructionSubject = (typeof INSTRUCTION_SUBJECTS)[number]
+type InstructionSubject = (typeof ALL_INSTRUCTION_SUBJECTS)[number]
 
 function getAppInstructions(): string {
 	return `# Global draft app instructions
@@ -1310,6 +1323,17 @@ function getResourceInstructions(): string {
 ${getResourcePrompt()}`
 }
 
+function getDatatableInstructions(): string {
+	return `# Datatable SQL SDK reference
+
+Datatables are workspace-scoped managed PostgreSQL databases. In chat, explore and shape them with the \`list_datatables\`, \`get_datatable_table_schema\`, and \`exec_datatable_sql\` tools. The reference below is for code you author inside runnables (inline app runnables, scripts, or flow rawscript modules) that reads or writes datatable data at runtime.
+
+- A runnable accesses a datatable via \`wmill.datatable()\` (the default "main") or \`wmill.datatable('<name>')\`, referencing tables as \`schema.table\`.
+- Use parameterized queries (the tagged template in TypeScript, \`$1\`/\`$2\` placeholders in Python) — never interpolate untrusted values into SQL strings.
+
+${getDatatableSdkReference()}`
+}
+
 function getInstructions(subject: InstructionSubject, language?: ScriptLang): string {
 	switch (subject) {
 		case 'script':
@@ -1320,6 +1344,8 @@ function getInstructions(subject: InstructionSubject, language?: ScriptLang): st
 			return getResourceInstructions()
 		case 'app':
 			return getAppInstructions()
+		case 'datatable':
+			return getDatatableInstructions()
 	}
 }
 
@@ -1328,7 +1354,7 @@ export const globalTools: Tool<{}>[] = [
 		def: createToolDef(
 			getInstructionsSchema,
 			'get_instructions',
-			'Get authoring guidance for scripts, flows, resources, or apps.'
+			'Get authoring guidance for scripts, flows, resources, apps, or the datatable SQL SDK (wmill.datatable()) used inside runnables.'
 		),
 		fn: async ({ args, toolId, toolCallbacks }) => {
 			const parsed = getInstructionsSchema.parse(args)

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -572,20 +572,7 @@ const initAppSchema = z.object({
 		.enum(FRAMEWORK_KEYS)
 		.describe(
 			'Frontend framework template. Confirm with the user before calling — never default silently. react19 is recommended for new apps.'
-		),
-	data: z
-		.object({
-			datatable: z.string().optional().describe('Default datatable name (e.g. "main").'),
-			schema: z.string().optional().describe('Default schema (PostgreSQL schema, optional).'),
-			tables: z
-				.array(z.string())
-				.optional()
-				.describe(
-					'Initially-whitelisted tables, in the format "<datatable>/<table>" or "<datatable>/<schema>:<table>".'
-				)
-		})
-		.optional()
-		.describe('Optional datatable configuration. Omit unless the user asked to wire one up.')
+		)
 })
 
 const buildGlobalSystemPrompt = (
@@ -2746,12 +2733,11 @@ async function initApp(
 		path: string
 		summary?: string
 		framework: FrameworkKey
-		data?: { datatable?: string; schema?: string; tables?: string[] }
 	},
 	ctx: WriteDraftCtx
 ): Promise<string> {
 	const { workspace, toolId, toolCallbacks } = ctx
-	const { path, summary, framework, data } = args
+	const { path, summary, framework } = args
 
 	if (getGlobalDraft(workspace, 'app', path)) {
 		throw new Error(
@@ -2772,14 +2758,7 @@ async function initApp(
 	const value: AppDraftValue = {
 		summary,
 		files: { ...template },
-		runnables: { [STARTER_RUNNABLE_KEY]: { ...STARTER_RUNNABLE } },
-		...(data && {
-			data: {
-				tables: data.tables ?? [],
-				datatable: data.datatable,
-				schema: data.schema
-			}
-		})
+		runnables: { [STARTER_RUNNABLE_KEY]: { ...STARTER_RUNNABLE } }
 	}
 	await recomputeAppPolicy(value)
 	const stored = saveAppDraft(workspace, path, value)

--- a/system_prompts/auto-generated/index.d.ts
+++ b/system_prompts/auto-generated/index.d.ts
@@ -3,5 +3,5 @@ export declare function getScriptPrompt(language: string): string;
 export declare function getFlowPrompt(): string;
 export declare function getResourcePrompt(): string;
 export declare function getRawAppPrompt(): string;
-export declare function getDatatableSdkReference(): string;
+export declare function getDatatableSdkReference(language?: string): string;
 export declare function getWorkflowAsCodePrompt(language?: string): string;

--- a/system_prompts/auto-generated/index.ts
+++ b/system_prompts/auto-generated/index.ts
@@ -54,8 +54,22 @@ export function getRawAppPrompt(): string {
   return prompts.RAW_APP_BASE;
 }
 
-// Helper to get datatable SDK reference for app mode
-export function getDatatableSdkReference(): string {
+// Helper to get the datatable SQL SDK reference (wmill.datatable()).
+// Pass a language to get only that SDK; omit it to get both.
+export function getDatatableSdkReference(language?: string): string {
+  if (language == null) {
+    return [
+      prompts.DATATABLE_SDK_TYPESCRIPT,
+      prompts.DATATABLE_SDK_PYTHON
+    ].filter(Boolean).join('\n\n');
+  }
+  if (TS_SDK_LANGUAGES.includes(language)) {
+    return prompts.DATATABLE_SDK_TYPESCRIPT;
+  }
+  if (PY_SDK_LANGUAGES.includes(language)) {
+    return prompts.DATATABLE_SDK_PYTHON;
+  }
+  // Unknown language: return both rather than nothing.
   return [
     prompts.DATATABLE_SDK_TYPESCRIPT,
     prompts.DATATABLE_SDK_PYTHON

--- a/system_prompts/generate.py
+++ b/system_prompts/generate.py
@@ -2463,8 +2463,22 @@ export function getRawAppPrompt(): string {
   return prompts.RAW_APP_BASE;
 }
 
-// Helper to get datatable SDK reference for app mode
-export function getDatatableSdkReference(): string {
+// Helper to get the datatable SQL SDK reference (wmill.datatable()).
+// Pass a language to get only that SDK; omit it to get both.
+export function getDatatableSdkReference(language?: string): string {
+  if (language == null) {
+    return [
+      prompts.DATATABLE_SDK_TYPESCRIPT,
+      prompts.DATATABLE_SDK_PYTHON
+    ].filter(Boolean).join('\\n\\n');
+  }
+  if (TS_SDK_LANGUAGES.includes(language)) {
+    return prompts.DATATABLE_SDK_TYPESCRIPT;
+  }
+  if (PY_SDK_LANGUAGES.includes(language)) {
+    return prompts.DATATABLE_SDK_PYTHON;
+  }
+  // Unknown language: return both rather than nothing.
   return [
     prompts.DATATABLE_SDK_TYPESCRIPT,
     prompts.DATATABLE_SDK_PYTHON
@@ -2501,7 +2515,7 @@ export declare function getScriptPrompt(language: string): string;
 export declare function getFlowPrompt(): string;
 export declare function getResourcePrompt(): string;
 export declare function getRawAppPrompt(): string;
-export declare function getDatatableSdkReference(): string;
+export declare function getDatatableSdkReference(language?: string): string;
 export declare function getWorkflowAsCodePrompt(language?: string): string;
 """
     (OUTPUT_GENERATED_DIR / "index.d.ts").write_text(index_dts_content)


### PR DESCRIPTION
## Summary

Adds datatable tooling to the **global mode** AI chat so the assistant can discover, inspect, query, and mutate workspace datatables directly, and authors correct `wmill.datatable()` runnable code. Previously global mode had no datatable capability — it could only scaffold an app draft that *declared* a datatable config, but couldn't actually interact with datatables.

Unlike the app-mode datatable tools, these are **unrestricted by design**: no app whitelist and no creation policy. This is intentional — datatables are workspace-scoped and the backend endpoints are gated only by workspace membership, so there's no enforcement boundary to mirror (the app-mode whitelist is purely an authoring-UX scoping construct, not a security boundary at any layer). `exec_datatable_sql` is gated with a confirmation prompt instead.

## Changes

- New `frontend/src/lib/components/copilot/chat/datatableTools.ts`:
  - Pure workspace-scoped ops (`listDatatables`, `getDatatableColumns`, `execDatatableSql`) wrapping the existing `WorkspaceService.listDataTableTables` / `getDataTableTableSchema` endpoints and `runScriptAndPollResult` (SQL via `datatable://<name>`).
  - `getDatatableTools()` exposing three helper-free `Tool<{}>`: `list_datatables`, `get_datatable_table_schema`, `exec_datatable_sql` (same names as app mode).
  - No whitelist, no creation policy. `exec_datatable_sql` drops the app-mode `new_table` registration param (not needed — created tables appear in `list_datatables` automatically) and is marked `requiresConfirmation: true` so every statement is confirmed before running.
- `frontend/src/lib/components/copilot/chat/global/core.ts`:
  - Import + spread the three tools into the base `globalTools` array (available in both session and side-panel global chats) + a policy-free "Data Tables" system-prompt section that instructs TypeScript-by-default for runnable code.
  - New `get_instructions(subject: "datatable", language?)` subject returning the authoritative `wmill.datatable()` SQL SDK reference. It is **language-aware**: passing `bun`/`deno`/etc. returns only the TypeScript SDK, `python3` only the Python SDK, and it defaults to TypeScript when omitted — so the model gets just what it needs instead of both. `datatable` is decoupled from `WorkspaceItemType` since it isn't a workspace item.
- `system_prompts`:
  - `getDatatableSdkReference(language?)` is now language-aware (TS-only / Python-only / both), mirroring `getWorkflowAsCodePrompt`. Edited the generator (`generate.py`) and regenerated `auto-generated/index.ts` + `index.d.ts`. The TS/Python SDK building blocks (`DATATABLE_SDK_TYPESCRIPT` / `DATATABLE_SDK_PYTHON`) already existed separately; this just exposes them selectively (previously an unused combined export).
- `init_app`'s optional `data` arg left untouched.
- Tests: `datatableTools.test.ts` (net-new pure logic — `totalTables` aggregation, `MAX_ROWS = 100` truncation boundary, result shaping, empty/error paths) and `global/core.test.ts` cases asserting `get_instructions(datatable)` defaults to TS-only and `language: "python3"` returns Python-only.

## Test plan

- [x] `vitest` — `datatableTools.test.ts` (9 tests) + `global/core.test.ts` datatable-instructions cases, all passing
- [x] Manual end-to-end in the browser (global chat, gemini-2.5-flash) against a real datatable: the model ran `list_datatables` → `exec_datatable_sql` (CREATE / INSERT / SELECT) → `get_datatable_table_schema`, with each mutating statement gated by the confirmation prompt; SELECT returned the inserted rows and `get_datatable_table_schema` resolved columns with no whitelist gate. DB-verified the writes, then reverted all test fixtures.
- [ ] `npm run check` (frontend type-check) in CI
- [ ] Reviewer sign-off on the intentional removal of the whitelist / creation-policy guardrails for global mode (mitigated by per-statement confirmation)

## Follow-up (not in this PR)

`getRawAppPrompt()`'s "## Data Tables" section (surfaced via `get_instructions(subject: "app")`) still tells the model *"whitelisted tables only / register in `data.tables` first / unlisted queries fail at runtime."* That framing predates global mode's no-whitelist approach and isn't actually runtime-enforced. It's a shared prompt (CLI/app contexts), so adjusting it is a separate, broader change.