### PR TITLE
Refresh slim image runtime packages

### DIFF
--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -39,7 +39,7 @@ ENV PATH=/usr/local/bin:/root/.local/bin:/tmp/.local/bin:$PATH
 
 # Install system dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates wget curl git jq unzip unixodbc xmlsec1 gnupg lsb-release libgnutls30 \
+    && apt-get install -y --no-install-recommends ca-certificates wget curl git jq unzip unixodbc xmlsec1 gnupg lsb-release libgnutls30 libgcrypt20 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -57,7 +57,8 @@ ENV TZ=Etc/UTC
 RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.24/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
 
 # Preinstall python runtime to temp location (will copy with world-writable perms later)
-RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY
+RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY \
+    && UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv pip install --system --break-system-packages --python $LATEST_STABLE_PY --upgrade pip setuptools
 
 # Copy to final location with world-writable permissions for arbitrary UID support
 RUN mkdir -p /tmp/windmill/cache && \

--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -26,7 +26,7 @@ RUN make
 FROM ${DEBIAN_IMAGE}
 
 ARG APP=/usr/src/app
-ARG LATEST_STABLE_PY=3.11.10
+ARG LATEST_STABLE_PY=3.12.12
 
 # UV configuration
 ENV UV_CACHE_DIR=/tmp/windmill/cache/uv
@@ -57,8 +57,7 @@ ENV TZ=Etc/UTC
 RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.24/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
 
 # Preinstall python runtime to temp location (will copy with world-writable perms later)
-RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY \
-    && UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv pip install --system --break-system-packages --python $LATEST_STABLE_PY --upgrade pip setuptools
+RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY
 
 # Copy to final location with world-writable permissions for arbitrary UID support
 RUN mkdir -p /tmp/windmill/cache && \

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -39,7 +39,7 @@ ENV PATH=/usr/local/bin:/root/.local/bin:/tmp/.local/bin:$PATH
 
 # Install system dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates wget curl git jq unzip unixodbc xmlsec1 gnupg lsb-release libgnutls30 \
+    && apt-get install -y --no-install-recommends ca-certificates wget curl git jq unzip unixodbc xmlsec1 gnupg lsb-release libgnutls30 libgcrypt20 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -57,7 +57,8 @@ ENV TZ=Etc/UTC
 RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.24/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
 
 # Preinstall python runtime to temp location (will copy with world-writable perms later)
-RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY
+RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY \
+    && UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv pip install --system --break-system-packages --python $LATEST_STABLE_PY --upgrade pip setuptools
 
 # Copy to final location with world-writable permissions for arbitrary UID support
 RUN mkdir -p /tmp/windmill/cache && \

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -26,7 +26,7 @@ RUN make
 FROM ${DEBIAN_IMAGE}
 
 ARG APP=/usr/src/app
-ARG LATEST_STABLE_PY=3.11.10
+ARG LATEST_STABLE_PY=3.12.12
 
 # UV configuration
 ENV UV_CACHE_DIR=/tmp/windmill/cache/uv
@@ -57,8 +57,7 @@ ENV TZ=Etc/UTC
 RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.24/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
 
 # Preinstall python runtime to temp location (will copy with world-writable perms later)
-RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY \
-    && UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv pip install --system --break-system-packages --python $LATEST_STABLE_PY --upgrade pip setuptools
+RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY
 
 # Copy to final location with world-writable permissions for arbitrary UID support
 RUN mkdir -p /tmp/windmill/cache && \

--- a/docker/RHEL8/Dockerfile
+++ b/docker/RHEL8/Dockerfile
@@ -1,6 +1,5 @@
 ARG DEBIAN_IMAGE=debian:bookworm-slim
 ARG RUST_IMAGE=registry.access.redhat.com/ubi8/ubi:latest
-ARG PYTHON_IMAGE=python:3.11.10-slim-bookworm
 
 FROM ${RUST_IMAGE} AS rust_base
 

--- a/docker/RHEL9/Dockerfile
+++ b/docker/RHEL9/Dockerfile
@@ -1,6 +1,5 @@
 ARG DEBIAN_IMAGE=debian:bookworm-slim
 ARG RUST_IMAGE=registry.access.redhat.com/ubi9/ubi:latest
-ARG PYTHON_IMAGE=python:3.11.10-slim-bookworm
 
 FROM ${RUST_IMAGE} AS rust_base
 


### PR DESCRIPTION
## Summary

This keeps the slim Docker images on the targeted package-refresh path, without doing a broad `apt-get upgrade`.

Changes:
- Add `libgcrypt20` to the explicit Debian package install list in `docker/DockerfileSlim` and `docker/DockerfileSlimEe` so slim image rebuilds pick up the current Bookworm package line.
- After `uv python install`, refresh `pip` and `setuptools` inside the uv-managed Python runtime before copying it into `/tmp/windmill/cache/py_runtime`.

## Why

Container scanners were still flagging the uv-managed Python runtime's bundled `pip`/`setuptools`, plus Debian `libgcrypt20`, in the slim image. This targets those specific packages while preserving the reproducible-build preference discussed in Slack: no blind system-wide upgrade.

## Validation

Validated the two changed pieces in a Debian Bookworm container:

- `apt-get install --no-install-recommends ... libgnutls30 libgcrypt20` resolves successfully.
- `UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv pip install --system --break-system-packages --python 3.11.10 --upgrade pip setuptools` successfully updates the uv-managed runtime from bundled `pip 24.1.2` / `setuptools 70.3.0` to current PyPI versions.

I did not run a full Windmill image build locally because the complete slim build pulls the dev Windmill image and extra CLIs, but the modified install steps were tested directly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes slim Docker images to add `libgcrypt20` and align the pre-baked `uv` Python runtime to 3.12.12 without a full `apt-get upgrade`. Reduces scanner findings and stops default jobs from re-downloading Python.

- **Dependencies**
  - Add `libgcrypt20` to the install list in docker/DockerfileSlim and docker/DockerfileSlimEe.
  - Set `LATEST_STABLE_PY` to `3.12.12` to match the backend default; drop the explicit `uv pip install --upgrade pip setuptools` step.
  - Remove unused `PYTHON_IMAGE` ARG from RHEL8/RHEL9 Dockerfiles.

<sup>Written for commit 2996fcef7a9692040bda1be9cde9de07c1b4061a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

