### PR TITLE
test: add datatable tool coverage to global AI evals

### DIFF
--- a/ai_evals/AGENTS.md
+++ b/ai_evals/AGENTS.md
@@ -86,6 +86,16 @@ Global prompts should exercise workspace-level drafting behavior:
 
 Keep deterministic validation focused on the draft contract: required draft type/path, required content snippets, forbidden draft paths, and forbidden mutating tools such as deploy/delete unless the case explicitly asks for them.
 
+Datatable cases are an exception to the draft contract: `list_datatables`,
+`get_datatable_table_schema`, and `exec_datatable_sql` produce no drafts, so
+validate them through tool-use (`requiredToolsUsed` / `forbiddenToolsUsed`) and
+SQL-argument assertions (`toolCallArgs` with `stringIncludesAnyOf`, e.g.
+`['select']`, `['create table']`, `['update', 'insert into']`) plus the judge —
+not through workspace state. Because canned SQL returns the seeded rows of the
+referenced/first table (no real engine), keep SELECT-case judges lenient: assert
+that the model queried and reported back, never specific returned row values.
+Seed data via `workspace.datatables` in the `initial` fixture (see README).
+
 ## Deterministic validation
 
 Use deterministic validation only for hard failures such as:

--- a/ai_evals/AGENTS.md
+++ b/ai_evals/AGENTS.md
@@ -104,10 +104,11 @@ Datatable cases should set `skipJudge: true` and validate through tool-use
 
 `stringIncludesAnyOf` is existential over calls (at least one matching call), so a
 mutation case still passes when the model mixes its UPDATE/INSERT with
-verification SELECTs. Canned SQL has no engine: SELECT returns the seeded rows of
-the referenced/first table and mutations do not persist, so never assert specific
-returned row values, and give mutation cases extra `maxTurns` (a model that
-re-queries to verify sees stale rows and may retry). Seed data via
+verification SELECTs. The in-memory engine (`datatableSqlEngine.ts`) is stateful
+within a case — writes persist, so a model that re-queries to verify its
+CREATE/UPDATE sees the change and does not loop. But the engine is best-effort
+(SELECT returns all rows of the referenced/first table with no WHERE/projection),
+so still never assert specific returned row values. Seed data via
 `workspace.datatables` in the `initial` fixture (see README).
 
 ## Deterministic validation

--- a/ai_evals/AGENTS.md
+++ b/ai_evals/AGENTS.md
@@ -86,15 +86,29 @@ Global prompts should exercise workspace-level drafting behavior:
 
 Keep deterministic validation focused on the draft contract: required draft type/path, required content snippets, forbidden draft paths, and forbidden mutating tools such as deploy/delete unless the case explicitly asks for them.
 
-Datatable cases are an exception to the draft contract: `list_datatables`,
-`get_datatable_table_schema`, and `exec_datatable_sql` produce no drafts, so
-validate them through tool-use (`requiredToolsUsed` / `forbiddenToolsUsed`) and
-SQL-argument assertions (`toolCallArgs` with `stringIncludesAnyOf`, e.g.
-`['select']`, `['create table']`, `['update', 'insert into']`) plus the judge —
-not through workspace state. Because canned SQL returns the seeded rows of the
-referenced/first table (no real engine), keep SELECT-case judges lenient: assert
-that the model queried and reported back, never specific returned row values.
-Seed data via `workspace.datatables` in the `initial` fixture (see README).
+Datatable cases should set `skipJudge: true` and validate through tool-use
+(`requiredToolsUsed` / `forbiddenToolsUsed`) and SQL-argument assertions
+(`toolCallArgs` with `stringIncludesAnyOf`, e.g. `['select']`, `['create table']`,
+`['update', 'insert into']`). Two reasons the judge is unreliable here:
+
+- `list_datatables`, `get_datatable_table_schema`, and `exec_datatable_sql`
+  produce no drafts, and the global judge only sees the drafts artifact — it
+  scores a no-draft conversational answer as empty (same as the
+  `askUserQuestion` cases).
+- Even a case that *does* produce a draft (a script reading the data table via
+  `wmill.datatable()` at runtime) is mis-judged: the judge has no datatable SDK
+  reference and penalizes correct `wmill.datatable()` usage as wrong. Verify the
+  SDK call deterministically instead — `requiredDrafts.valueIncludes: ['wmill.datatable(']`
+  plus forbidding `exec_datatable_sql` (keeping chat-time SQL distinct from
+  runtime SDK use).
+
+`stringIncludesAnyOf` is existential over calls (at least one matching call), so a
+mutation case still passes when the model mixes its UPDATE/INSERT with
+verification SELECTs. Canned SQL has no engine: SELECT returns the seeded rows of
+the referenced/first table and mutations do not persist, so never assert specific
+returned row values, and give mutation cases extra `maxTurns` (a model that
+re-queries to verify sees stale rows and may retry). Seed data via
+`workspace.datatables` in the `initial` fixture (see README).
 
 ## Deterministic validation
 

--- a/ai_evals/README.md
+++ b/ai_evals/README.md
@@ -152,13 +152,18 @@ Global (and flow) initial fixtures can seed `workspace.datatables` so the
 `list_datatables`, `get_datatable_table_schema`, and `exec_datatable_sql` tools
 return seeded data during evals. Each entry is
 `{ datatable_name, schemas: { <schema>: { <table>: { columns, rows? } } } }`.
-SQL runs with no real engine: a `SELECT` returns the canned `rows` of the
-referenced (or first) seeded table, and any other statement returns an empty
-success. Validate datatable cases through tool-use and SQL-argument assertions
-(`requiredToolsUsed`, `stringIncludesAnyOf`) plus the judge — not through data
-state, and not through exact returned row values (canned-SQL fidelity is loose).
-An empty/absent `datatables` seed makes `list_datatables` return `[]`, which is
-what the "no datatable configured" blocking cases rely on.
+SQL runs through a small in-memory engine (`datatableSqlEngine.ts`), not a real
+database. Writes are **stateful within a case**: `CREATE`/`DROP`/`INSERT`/`UPDATE`/
+`DELETE` mutate the seeded datatable in place, so a later `list_datatables`,
+`get_datatable_table_schema`, `SELECT`, or `information_schema` query reflects them
+— this is what stops a model from looping when it re-queries to verify a write.
+The engine is best-effort: `SELECT` returns all rows of the referenced (or first)
+table with no WHERE filtering/projection/joins, `WHERE` on UPDATE/DELETE supports
+`col = value` predicates joined by `AND`, and anything unparseable is a no-op
+success. So validate datatable cases through tool-use and SQL-argument assertions
+(`requiredToolsUsed`, `stringIncludesAnyOf`) — not through exact returned row
+values. An empty/absent `datatables` seed makes `list_datatables` return `[]`,
+which is what the "no datatable configured" blocking cases rely on.
 
 Set `WMILL_AI_EVAL_DISABLE_ACTIVE_EDITOR_CONTEXT=1` to run those cases with
 the old behavior where the live editor is only discoverable through

--- a/ai_evals/README.md
+++ b/ai_evals/README.md
@@ -148,6 +148,18 @@ Global initial fixtures can also seed `liveEditorDrafts` with `type`,
 currently open script, flow, or raw app editor so cases can test prompts that
 refer to "this" or the "current" item.
 
+Global (and flow) initial fixtures can seed `workspace.datatables` so the
+`list_datatables`, `get_datatable_table_schema`, and `exec_datatable_sql` tools
+return seeded data during evals. Each entry is
+`{ datatable_name, schemas: { <schema>: { <table>: { columns, rows? } } } }`.
+SQL runs with no real engine: a `SELECT` returns the canned `rows` of the
+referenced (or first) seeded table, and any other statement returns an empty
+success. Validate datatable cases through tool-use and SQL-argument assertions
+(`requiredToolsUsed`, `stringIncludesAnyOf`) plus the judge — not through data
+state, and not through exact returned row values (canned-SQL fidelity is loose).
+An empty/absent `datatables` seed makes `list_datatables` return `[]`, which is
+what the "no datatable configured" blocking cases rely on.
+
 Set `WMILL_AI_EVAL_DISABLE_ACTIVE_EDITOR_CONTEXT=1` to run those cases with
 the old behavior where the live editor is only discoverable through
 `list_workspace_items`.

--- a/ai_evals/adapters/frontend/datatableSqlEngine.test.ts
+++ b/ai_evals/adapters/frontend/datatableSqlEngine.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'bun:test'
+import { applyDatatableSql, type BenchmarkDatatableSeed } from './datatableSqlEngine'
+
+function makeDatatable(): BenchmarkDatatableSeed {
+	return {
+		datatable_name: 'main',
+		schemas: {
+			public: {
+				orders: {
+					columns: { id: 'int4', customer_id: 'int4', total: 'numeric', status: 'text' },
+					rows: [
+						{ id: 1, customer_id: 1, total: 42.5, status: 'shipped' },
+						{ id: 2, customer_id: 2, total: 19.99, status: 'pending' },
+						{ id: 3, customer_id: 1, total: 88, status: 'shipped' }
+					]
+				},
+				customers: {
+					columns: { id: 'int4', name: 'text' },
+					rows: [{ id: 1, name: 'Alice' }]
+				}
+			}
+		}
+	}
+}
+
+describe('SELECT', () => {
+	it('returns the referenced table rows', () => {
+		const dt = makeDatatable()
+		expect(applyDatatableSql(dt, 'SELECT id, name FROM customers').rows).toEqual([
+			{ id: 1, name: 'Alice' }
+		])
+	})
+
+	it('falls back to the first table when no known table is referenced', () => {
+		const dt = makeDatatable()
+		expect(applyDatatableSql(dt, 'select 1').rows).toHaveLength(3)
+	})
+
+	it('resolves a schema-qualified table', () => {
+		const dt = makeDatatable()
+		expect(applyDatatableSql(dt, 'SELECT * FROM public.customers').rows).toEqual([
+			{ id: 1, name: 'Alice' }
+		])
+	})
+})
+
+describe('CREATE TABLE', () => {
+	it('adds a table with parsed columns, skipping table constraints and FK clauses', () => {
+		const dt = makeDatatable()
+		const result = applyDatatableSql(
+			dt,
+			'CREATE TABLE public.refunds (\n  order_id int4 NOT NULL REFERENCES public.orders(id),\n  amount numeric(10,2),\n  PRIMARY KEY (order_id)\n)'
+		)
+		expect(result.rows).toEqual([])
+		expect(dt.schemas.public.refunds).toEqual({
+			columns: { order_id: 'int4', amount: 'numeric(10,2)' },
+			rows: []
+		})
+	})
+
+	it('defaults an unqualified table to the public schema', () => {
+		const dt = makeDatatable()
+		applyDatatableSql(dt, 'CREATE TABLE notes (id int4, body text)')
+		expect(dt.schemas.public.notes.columns).toEqual({ id: 'int4', body: 'text' })
+	})
+
+	it('is a no-op for an existing table with IF NOT EXISTS', () => {
+		const dt = makeDatatable()
+		applyDatatableSql(dt, 'CREATE TABLE IF NOT EXISTS public.orders (x int4)')
+		expect(Object.keys(dt.schemas.public.orders.columns)).toContain('status')
+	})
+})
+
+describe('DROP TABLE', () => {
+	it('removes the table', () => {
+		const dt = makeDatatable()
+		applyDatatableSql(dt, 'DROP TABLE IF EXISTS public.customers')
+		expect(dt.schemas.public.customers).toBeUndefined()
+	})
+})
+
+describe('INSERT', () => {
+	it('appends a row using an explicit column list', () => {
+		const dt = makeDatatable()
+		applyDatatableSql(dt, "INSERT INTO customers (id, name) VALUES (2, 'Bob')")
+		expect(dt.schemas.public.customers.rows).toContainEqual({ id: 2, name: 'Bob' })
+	})
+
+	it('infers columns from the table when none are given, and appends multiple tuples', () => {
+		const dt = makeDatatable()
+		applyDatatableSql(dt, "INSERT INTO customers VALUES (2, 'Bob'), (3, 'Carol')")
+		expect(dt.schemas.public.customers.rows).toHaveLength(3)
+	})
+
+	it('returns the inserted rows when RETURNING is present', () => {
+		const dt = makeDatatable()
+		const result = applyDatatableSql(
+			dt,
+			"INSERT INTO customers (id, name) VALUES (2, 'Bob') RETURNING *"
+		)
+		expect(result.rows).toEqual([{ id: 2, name: 'Bob' }])
+	})
+})
+
+describe('UPDATE', () => {
+	it('updates only the rows matching an equality WHERE', () => {
+		const dt = makeDatatable()
+		const result = applyDatatableSql(
+			dt,
+			"UPDATE public.orders SET status = 'shipped' WHERE id = 2"
+		)
+		expect(result.rows).toEqual([])
+		expect(dt.schemas.public.orders.rows?.find((r) => r.id === 2)?.status).toBe('shipped')
+		expect(dt.schemas.public.orders.rows?.find((r) => r.id === 1)?.status).toBe('shipped')
+	})
+
+	it('strips a Postgres cast in the WHERE value', () => {
+		const dt = makeDatatable()
+		applyDatatableSql(dt, "UPDATE orders SET status = 'done' WHERE id = 2::int4")
+		expect(dt.schemas.public.orders.rows?.find((r) => r.id === 2)?.status).toBe('done')
+	})
+
+	it('matches multiple AND predicates including a numeric literal', () => {
+		const dt = makeDatatable()
+		applyDatatableSql(
+			dt,
+			"UPDATE orders SET status = 'done' WHERE customer_id = 2 AND total = 19.99"
+		)
+		expect(dt.schemas.public.orders.rows?.find((r) => r.id === 2)?.status).toBe('done')
+		expect(dt.schemas.public.orders.rows?.find((r) => r.id === 1)?.status).toBe('shipped')
+	})
+
+	it('updates every row when there is no WHERE', () => {
+		const dt = makeDatatable()
+		applyDatatableSql(dt, "UPDATE orders SET status = 'archived'")
+		expect(dt.schemas.public.orders.rows?.every((r) => r.status === 'archived')).toBe(true)
+	})
+
+	it('returns the affected rows when RETURNING is present', () => {
+		const dt = makeDatatable()
+		const result = applyDatatableSql(
+			dt,
+			"UPDATE orders SET status = 'shipped' WHERE id = 2 RETURNING *"
+		)
+		expect(result.rows).toHaveLength(1)
+		expect(result.rows[0]).toMatchObject({ id: 2, status: 'shipped' })
+	})
+
+	it('affects no rows when the WHERE clause cannot be parsed', () => {
+		const dt = makeDatatable()
+		applyDatatableSql(dt, "UPDATE orders SET status = 'x' WHERE total > 20")
+		expect(dt.schemas.public.orders.rows?.some((r) => r.status === 'x')).toBe(false)
+	})
+})
+
+describe('DELETE', () => {
+	it('removes only the matching rows', () => {
+		const dt = makeDatatable()
+		applyDatatableSql(dt, 'DELETE FROM orders WHERE id = 2')
+		expect(dt.schemas.public.orders.rows?.map((r) => r.id)).toEqual([1, 3])
+	})
+
+	it('returns the removed rows when RETURNING is present', () => {
+		const dt = makeDatatable()
+		const result = applyDatatableSql(dt, 'DELETE FROM orders WHERE id = 2 RETURNING *')
+		expect(result.rows).toEqual([{ id: 2, customer_id: 2, total: 19.99, status: 'pending' }])
+	})
+})
+
+describe('writes are reflected by later reads', () => {
+	it('UPDATE then SELECT sees the new value (the verify-loop fix)', () => {
+		const dt = makeDatatable()
+		applyDatatableSql(dt, "UPDATE orders SET status = 'shipped' WHERE id = 2")
+		const seen = applyDatatableSql(dt, 'SELECT * FROM orders').rows
+		expect(seen.find((r) => r.id === 2)?.status).toBe('shipped')
+	})
+
+	it('INSERT then SELECT sees the new row', () => {
+		const dt = makeDatatable()
+		applyDatatableSql(dt, "INSERT INTO customers (id, name) VALUES (9, 'Zed')")
+		const seen = applyDatatableSql(dt, 'SELECT * FROM customers').rows
+		expect(seen).toContainEqual({ id: 9, name: 'Zed' })
+	})
+
+	it('CREATE then SELECT on the new table returns its (empty) rows', () => {
+		const dt = makeDatatable()
+		applyDatatableSql(dt, 'CREATE TABLE public.refunds (order_id int4, amount numeric)')
+		expect(applyDatatableSql(dt, 'SELECT * FROM refunds').rows).toEqual([])
+	})
+})
+
+describe('system-catalog queries reflect the current tables/columns', () => {
+	it('lists current tables (including a freshly created one) via information_schema.tables', () => {
+		const dt = makeDatatable()
+		applyDatatableSql(dt, 'CREATE TABLE public.refunds (order_id int4)')
+		const rows = applyDatatableSql(
+			dt,
+			"SELECT table_name FROM information_schema.tables WHERE table_name = 'refunds'"
+		).rows
+		expect(rows.map((r) => r.table_name)).toContain('refunds')
+	})
+
+	it('does not list a dropped table', () => {
+		const dt = makeDatatable()
+		applyDatatableSql(dt, 'DROP TABLE public.customers')
+		const rows = applyDatatableSql(dt, 'SELECT table_name FROM information_schema.tables').rows
+		expect(rows.map((r) => r.table_name)).not.toContain('customers')
+	})
+
+	it('reports columns via information_schema.columns', () => {
+		const dt = makeDatatable()
+		const rows = applyDatatableSql(
+			dt,
+			"SELECT column_name FROM information_schema.columns WHERE table_name = 'orders'"
+		).rows
+		expect(rows.map((r) => r.column_name)).toContain('status')
+	})
+})
+
+describe('parser robustness (string/paren-aware splitting)', () => {
+	it('does not treat the word "returning" inside a string value as a RETURNING clause', () => {
+		const dt = makeDatatable()
+		const result = applyDatatableSql(
+			dt,
+			"INSERT INTO customers (id, name) VALUES (5, 'is returning soon')"
+		)
+		expect(result.rows).toEqual([])
+		expect(dt.schemas.public.customers.rows).toContainEqual({ id: 5, name: 'is returning soon' })
+	})
+
+	it('does not split on the word "where" inside a SET string value', () => {
+		const dt = makeDatatable()
+		applyDatatableSql(dt, "UPDATE orders SET status = 'ship where ordered' WHERE id = 2")
+		expect(dt.schemas.public.orders.rows?.find((r) => r.id === 2)?.status).toBe('ship where ordered')
+		expect(dt.schemas.public.orders.rows?.find((r) => r.id === 1)?.status).toBe('shipped')
+	})
+
+	it('keeps INSERT tuples intact when a value contains a function call', () => {
+		const dt = makeDatatable()
+		applyDatatableSql(dt, "INSERT INTO customers (id, name) VALUES (6, coalesce(NULL, 'x'))")
+		expect(dt.schemas.public.customers.rows).toHaveLength(2)
+		expect(dt.schemas.public.customers.rows?.[1]).toMatchObject({ id: 6 })
+	})
+
+	it('CREATE TABLE ignores a trailing semicolon-separated statement', () => {
+		const dt = makeDatatable()
+		applyDatatableSql(
+			dt,
+			'CREATE TABLE public.refunds (id int4, amount numeric); INSERT INTO refunds VALUES (1, 5)'
+		)
+		expect(dt.schemas.public.refunds.columns).toEqual({ id: 'int4', amount: 'numeric' })
+		expect(dt.schemas.public.refunds.rows).toEqual([])
+	})
+})
+
+describe('unparseable statements are a safe no-op', () => {
+	it('returns [] and does not throw', () => {
+		const dt = makeDatatable()
+		expect(applyDatatableSql(dt, 'VACUUM ANALYZE').rows).toEqual([])
+		expect(applyDatatableSql(dt, 'GRANT SELECT ON orders TO someone').rows).toEqual([])
+	})
+})

--- a/ai_evals/adapters/frontend/datatableSqlEngine.ts
+++ b/ai_evals/adapters/frontend/datatableSqlEngine.ts
@@ -1,0 +1,541 @@
+/**
+ * A deliberately small, best-effort SQL engine for the benchmark datatable mock.
+ *
+ * This is NOT a real SQL implementation — it exists only so that writes a model
+ * issues during an eval (`CREATE TABLE`, `INSERT`, `UPDATE`, `DELETE`, `DROP`)
+ * become visible to its later reads (`list_datatables`, `get_datatable_table_schema`,
+ * `SELECT`). Without that, a model that re-queries to verify a write sees stale
+ * seed data, concludes the write failed, and loops until it exhausts its turns.
+ *
+ * It parses only the common statement shapes models produce. Anything it cannot
+ * parse is a no-op success (it never throws) — behavioral evals assert that the
+ * right statement was issued, not its exact data effects. Notable limits:
+ *  - `SELECT` returns all rows of the referenced (or first) table — no WHERE
+ *    filtering, projection, joins, or aggregation.
+ *  - `WHERE` supports `col = value` predicates joined by `AND` only; an
+ *    unparseable WHERE on UPDATE/DELETE affects zero rows (never the whole table).
+ */
+
+/** One seeded datatable table: its columns (col -> compact_type) and optional rows. */
+export interface BenchmarkDatatableTableSeed {
+	columns: Record<string, string>
+	rows?: Record<string, unknown>[]
+}
+
+/** A seeded datatable: `datatable_name` plus a `schema -> table -> seed` map. */
+export interface BenchmarkDatatableSeed {
+	datatable_name: string
+	schemas: {
+		[schema: string]: {
+			[table: string]: BenchmarkDatatableTableSeed
+		}
+	}
+}
+
+export interface DatatableSqlResult {
+	rows: Record<string, unknown>[]
+}
+
+const DEFAULT_SCHEMA = 'public'
+
+type ParsedRef = { schema: string; table: string }
+type Predicate = { column: string; value: unknown }
+
+/**
+ * Apply one SQL statement to `datatable` IN PLACE and return the result rows.
+ * SELECT returns the referenced/first table's rows; a mutation returns its
+ * affected rows when it has a RETURNING clause, otherwise `[]`.
+ */
+export function applyDatatableSql(
+	datatable: BenchmarkDatatableSeed,
+	sql: string
+): DatatableSqlResult {
+	const statement = stripTrailingSemicolon(sql.trim())
+	if (/^\s*(with|select)\b/i.test(statement)) {
+		return { rows: selectRows(datatable, statement) }
+	}
+	if (/^\s*create\s+table\b/i.test(statement)) {
+		return { rows: applyCreateTable(datatable, statement) }
+	}
+	if (/^\s*drop\s+table\b/i.test(statement)) {
+		return { rows: applyDropTable(datatable, statement) }
+	}
+	if (/^\s*insert\s+into\b/i.test(statement)) {
+		return { rows: applyInsert(datatable, statement) }
+	}
+	if (/^\s*update\b/i.test(statement)) {
+		return { rows: applyUpdate(datatable, statement) }
+	}
+	if (/^\s*delete\s+from\b/i.test(statement)) {
+		return { rows: applyDelete(datatable, statement) }
+	}
+	return { rows: [] }
+}
+
+// ============= Reads =============
+
+function selectRows(
+	datatable: BenchmarkDatatableSeed,
+	sql: string
+): Record<string, unknown>[] {
+	const fromRef = sql.match(/\bfrom\s+([a-zA-Z_"][\w."]*)/i)?.[1]
+	if (fromRef) {
+		const catalog = catalogRows(datatable, fromRef)
+		if (catalog) {
+			return catalog
+		}
+	}
+	const table = fromRef ? resolveTable(datatable, fromRef) : undefined
+	const seed = table ?? firstTable(datatable)
+	return seed?.rows ?? []
+}
+
+/**
+ * Synthesize rows for a system-catalog query so a model verifying a `CREATE`/`DROP`
+ * via `information_schema.tables` / `.columns` (or `pg_tables`) sees the current
+ * tables/columns instead of fallback data. WHERE is not applied, so the model gets
+ * the full set and finds (or no longer finds) the table it just changed.
+ * Returns `undefined` for non-catalog refs so normal table resolution proceeds.
+ */
+function catalogRows(
+	datatable: BenchmarkDatatableSeed,
+	ref: string
+): Record<string, unknown>[] | undefined {
+	const normalized = ref.toLowerCase().replace(/"/g, '')
+	const name = normalized.split('.').pop()
+	const isCatalog = normalized.includes('information_schema.') || normalized.startsWith('pg_')
+	if (!isCatalog) {
+		return undefined
+	}
+	const tables = allTables(datatable)
+	if (name === 'tables' || name === 'pg_tables') {
+		return tables.map(({ schema, table }) => ({
+			table_schema: schema,
+			table_name: table,
+			schemaname: schema,
+			tablename: table
+		}))
+	}
+	if (name === 'columns') {
+		return tables.flatMap(({ schema, table, seed }) =>
+			Object.entries(seed.columns).map(([column, type]) => ({
+				table_schema: schema,
+				table_name: table,
+				column_name: column,
+				data_type: type
+			}))
+		)
+	}
+	return undefined
+}
+
+function allTables(
+	datatable: BenchmarkDatatableSeed
+): { schema: string; table: string; seed: BenchmarkDatatableTableSeed }[] {
+	return Object.entries(datatable.schemas).flatMap(([schema, tables]) =>
+		Object.entries(tables).map(([table, seed]) => ({ schema, table, seed }))
+	)
+}
+
+// ============= DDL =============
+
+function applyCreateTable(
+	datatable: BenchmarkDatatableSeed,
+	sql: string
+): Record<string, unknown>[] {
+	const head = sql.match(
+		/^\s*create\s+table\s+(?:if\s+not\s+exists\s+)?([a-zA-Z_"][\w."]*)/i
+	)
+	// The first top-level paren group is the column-definition list; using it (rather
+	// than a greedy `(...)` capture) ignores any trailing `;`-separated statement.
+	const columnText = extractParenGroups(sql)[0]
+	if (!head || columnText === undefined) {
+		return []
+	}
+	const { schema, table } = parseRef(head[1])
+	const existing = datatable.schemas[schema]?.[table]
+	if (existing) {
+		return []
+	}
+	const columns: Record<string, string> = {}
+	for (const rawDef of splitTopLevel(columnText)) {
+		const def = rawDef.trim()
+		if (!def || isTableConstraint(def)) {
+			continue
+		}
+		const tokens = def.split(/\s+/)
+		const column = unquoteIdentifier(tokens[0])
+		if (!column) {
+			continue
+		}
+		columns[column] = tokens[1] ?? 'text'
+	}
+	if (!datatable.schemas[schema]) {
+		datatable.schemas[schema] = {}
+	}
+	datatable.schemas[schema][table] = { columns, rows: [] }
+	return []
+}
+
+function applyDropTable(
+	datatable: BenchmarkDatatableSeed,
+	sql: string
+): Record<string, unknown>[] {
+	const match = sql.match(
+		/^\s*drop\s+table\s+(?:if\s+exists\s+)?([a-zA-Z_"][\w."]*)/i
+	)
+	if (!match) {
+		return []
+	}
+	const { schema, table } = parseRef(match[1])
+	if (datatable.schemas[schema]?.[table]) {
+		delete datatable.schemas[schema][table]
+	}
+	return []
+}
+
+// ============= DML =============
+
+function applyInsert(
+	datatable: BenchmarkDatatableSeed,
+	sql: string
+): Record<string, unknown>[] {
+	const { body, returning } = splitOffReturning(sql)
+	const match = body.match(
+		/^\s*insert\s+into\s+([a-zA-Z_"][\w."]*)\s*(?:\(([^)]*)\))?\s*values\s*([\s\S]+)$/i
+	)
+	if (!match) {
+		return []
+	}
+	const table = resolveTable(datatable, match[1])
+	if (!table) {
+		return []
+	}
+	const columns = match[2]
+		? splitTopLevel(match[2]).map((entry) => unquoteIdentifier(entry.trim()))
+		: Object.keys(table.columns)
+	const inserted: Record<string, unknown>[] = []
+	for (const tuple of extractParenGroups(match[3])) {
+		const values = splitTopLevel(tuple).map((entry) => parseValue(entry))
+		const row: Record<string, unknown> = {}
+		columns.forEach((column, index) => {
+			row[column] = values[index]
+		})
+		inserted.push(row)
+	}
+	table.rows ??= []
+	table.rows.push(...inserted)
+	return returning ? inserted : []
+}
+
+function applyUpdate(
+	datatable: BenchmarkDatatableSeed,
+	sql: string
+): Record<string, unknown>[] {
+	const { body, returning } = splitOffReturning(sql)
+	const match = body.match(/^\s*update\s+([a-zA-Z_"][\w."]*)\s+set\s+([\s\S]+)$/i)
+	if (!match) {
+		return []
+	}
+	const table = resolveTable(datatable, match[1])
+	if (!table) {
+		return []
+	}
+	let assignmentText = match[2]
+	let whereText: string | undefined
+	const whereMatch = maskForClauseScan(assignmentText).match(/\swhere\s/i)
+	if (whereMatch && whereMatch.index !== undefined) {
+		whereText = assignmentText.slice(whereMatch.index + whereMatch[0].length)
+		assignmentText = assignmentText.slice(0, whereMatch.index)
+	}
+	const predicates = parsePredicates(whereText)
+	if (predicates === null) {
+		return []
+	}
+	const assignments: Record<string, unknown> = {}
+	for (const entry of splitTopLevel(assignmentText)) {
+		const pair = entry.match(/^\s*([a-zA-Z_"][\w."]*)\s*=\s*([\s\S]+?)\s*$/)
+		if (pair) {
+			assignments[lastIdentifier(pair[1])] = parseValue(pair[2])
+		}
+	}
+	const affected = (table.rows ?? []).filter((row) => rowMatches(row, predicates))
+	for (const row of affected) {
+		Object.assign(row, assignments)
+	}
+	return returning ? affected : []
+}
+
+function applyDelete(
+	datatable: BenchmarkDatatableSeed,
+	sql: string
+): Record<string, unknown>[] {
+	const { body, returning } = splitOffReturning(sql)
+	const match = body.match(/^\s*delete\s+from\s+([a-zA-Z_"][\w."]*)\s*([\s\S]*)$/i)
+	if (!match) {
+		return []
+	}
+	const table = resolveTable(datatable, match[1])
+	if (!table) {
+		return []
+	}
+	const whereText = match[2].replace(/^\s*where\s+/i, '').trim() || undefined
+	const predicates = parsePredicates(whereText)
+	if (predicates === null) {
+		return []
+	}
+	const rows = table.rows ?? []
+	const removed = rows.filter((row) => rowMatches(row, predicates))
+	table.rows = rows.filter((row) => !rowMatches(row, predicates))
+	return returning ? removed : []
+}
+
+// ============= Parsing helpers =============
+
+function resolveTable(
+	datatable: BenchmarkDatatableSeed,
+	ref: string
+): BenchmarkDatatableTableSeed | undefined {
+	const { schema, table } = parseRef(ref)
+	const direct = datatable.schemas[schema]?.[table]
+	if (direct) {
+		return direct
+	}
+	// Bare table name: fall back to searching every schema for a matching table.
+	if (!ref.includes('.')) {
+		for (const tables of Object.values(datatable.schemas)) {
+			if (tables[table]) {
+				return tables[table]
+			}
+		}
+	}
+	return undefined
+}
+
+function firstTable(
+	datatable: BenchmarkDatatableSeed
+): BenchmarkDatatableTableSeed | undefined {
+	for (const tables of Object.values(datatable.schemas)) {
+		for (const seed of Object.values(tables)) {
+			return seed
+		}
+	}
+	return undefined
+}
+
+function parseRef(ref: string): ParsedRef {
+	const parts = ref.split('.').map(unquoteIdentifier)
+	if (parts.length >= 2) {
+		return { schema: parts[parts.length - 2], table: parts[parts.length - 1] }
+	}
+	return { schema: DEFAULT_SCHEMA, table: parts[0] }
+}
+
+/** A WHERE clause with no parseable form returns `null`; absent WHERE returns `[]` (match all). */
+function parsePredicates(whereText: string | undefined): Predicate[] | null {
+	if (whereText === undefined || whereText.trim() === '') {
+		return []
+	}
+	const predicates: Predicate[] = []
+	for (const part of whereText.split(/\s+and\s+/i)) {
+		const match = part.match(/^\s*([a-zA-Z_"][\w."]*)\s*=\s*([\s\S]+?)\s*$/)
+		if (!match) {
+			return null
+		}
+		predicates.push({ column: lastIdentifier(match[1]), value: parseValue(match[2]) })
+	}
+	return predicates
+}
+
+function rowMatches(row: Record<string, unknown>, predicates: Predicate[]): boolean {
+	return predicates.every((predicate) => looseEquals(row[predicate.column], predicate.value))
+}
+
+function looseEquals(left: unknown, right: unknown): boolean {
+	if (left === null || left === undefined) {
+		return right === null || right === undefined
+	}
+	if (typeof left === 'number' && typeof right === 'number') {
+		return left === right
+	}
+	return String(left) === String(right)
+}
+
+function parseValue(raw: string): unknown {
+	// Drop a trailing Postgres cast (e.g. `2::int4`) before interpreting the literal.
+	const token = raw.trim().replace(/::\s*[a-zA-Z_][\w]*(\([^)]*\))?\s*$/, '').trim()
+	const stringMatch = token.match(/^'([\s\S]*)'$/)
+	if (stringMatch) {
+		return stringMatch[1].replace(/''/g, "'")
+	}
+	if (/^-?\d+(\.\d+)?$/.test(token)) {
+		return Number(token)
+	}
+	if (/^true$/i.test(token)) {
+		return true
+	}
+	if (/^false$/i.test(token)) {
+		return false
+	}
+	if (/^null$/i.test(token)) {
+		return null
+	}
+	return token
+}
+
+function splitOffReturning(sql: string): { body: string; returning: boolean } {
+	const match = maskForClauseScan(sql).match(/\sreturning\s/i)
+	if (!match || match.index === undefined) {
+		return { body: sql, returning: false }
+	}
+	return { body: sql.slice(0, match.index), returning: true }
+}
+
+/**
+ * A same-length copy of `sql` with the contents of single-quoted strings and
+ * parenthesized groups blanked to spaces, so a top-level keyword scan
+ * (WHERE / RETURNING) cannot match inside a string literal or a subquery. Index
+ * positions in the result map 1:1 back onto the original.
+ */
+function maskForClauseScan(sql: string): string {
+	let masked = ''
+	let depth = 0
+	let inString = false
+	for (let i = 0; i < sql.length; i++) {
+		const char = sql[i]
+		if (inString) {
+			if (char === "'") {
+				if (sql[i + 1] === "'") {
+					masked += '  '
+					i++
+					continue
+				}
+				inString = false
+			}
+			masked += ' '
+			continue
+		}
+		if (char === "'") {
+			inString = true
+			masked += ' '
+		} else if (char === '(') {
+			depth++
+			masked += ' '
+		} else if (char === ')') {
+			depth = Math.max(0, depth - 1)
+			masked += ' '
+		} else {
+			masked += depth > 0 ? ' ' : char
+		}
+	}
+	return masked
+}
+
+/**
+ * Inner text of each top-level `( ... )` group in `input`, honoring nested parens
+ * (e.g. `now()`, `numeric(10,2)`) and single-quoted strings. Used for the CREATE
+ * column-definition group and INSERT value tuples.
+ */
+function extractParenGroups(input: string): string[] {
+	const groups: string[] = []
+	let depth = 0
+	let inString = false
+	let current = ''
+	for (let i = 0; i < input.length; i++) {
+		const char = input[i]
+		if (inString) {
+			current += char
+			if (char === "'") {
+				if (input[i + 1] === "'") {
+					current += input[++i]
+				} else {
+					inString = false
+				}
+			}
+			continue
+		}
+		if (char === "'") {
+			inString = true
+			current += char
+		} else if (char === '(') {
+			depth++
+			if (depth === 1) {
+				current = ''
+			} else {
+				current += char
+			}
+		} else if (char === ')') {
+			depth = Math.max(0, depth - 1)
+			if (depth === 0) {
+				groups.push(current)
+				current = ''
+			} else {
+				current += char
+			}
+		} else if (depth > 0) {
+			current += char
+		}
+	}
+	return groups
+}
+
+/** Split on commas that are not inside parentheses or single-quoted strings. */
+function splitTopLevel(input: string): string[] {
+	const parts: string[] = []
+	let depth = 0
+	let inString = false
+	let current = ''
+	for (let i = 0; i < input.length; i++) {
+		const char = input[i]
+		if (inString) {
+			current += char
+			if (char === "'") {
+				if (input[i + 1] === "'") {
+					current += input[++i]
+				} else {
+					inString = false
+				}
+			}
+			continue
+		}
+		if (char === "'") {
+			inString = true
+			current += char
+		} else if (char === '(') {
+			depth++
+			current += char
+		} else if (char === ')') {
+			depth = Math.max(0, depth - 1)
+			current += char
+		} else if (char === ',' && depth === 0) {
+			parts.push(current)
+			current = ''
+		} else {
+			current += char
+		}
+	}
+	if (current.trim() !== '') {
+		parts.push(current)
+	}
+	return parts
+}
+
+function isTableConstraint(def: string): boolean {
+	return /^(primary\s+key|foreign\s+key|constraint|unique|check|exclude|like)\b/i.test(def)
+}
+
+function unquoteIdentifier(identifier: string): string {
+	const trimmed = identifier.trim()
+	const quoted = trimmed.match(/^"([\s\S]*)"$/)
+	return quoted ? quoted[1] : trimmed
+}
+
+/** For a qualified reference like `orders.id`, keep only the final identifier. */
+function lastIdentifier(reference: string): string {
+	const parts = reference.split('.')
+	return unquoteIdentifier(parts[parts.length - 1])
+}
+
+function stripTrailingSemicolon(sql: string): string {
+	return sql.replace(/;\s*$/, '')
+}

--- a/ai_evals/adapters/frontend/mockBackend.ts
+++ b/ai_evals/adapters/frontend/mockBackend.ts
@@ -6,6 +6,9 @@ import type {
 	ScriptLang
 } from '../../../frontend/src/lib/gen/types.gen'
 import { buildScriptLintResult } from './core/script/preview'
+import { applyDatatableSql, type BenchmarkDatatableSeed } from './datatableSqlEngine'
+
+export type { BenchmarkDatatableSeed, BenchmarkDatatableTableSeed } from './datatableSqlEngine'
 
 const BENCHMARK_TIMESTAMP = '1970-01-01T00:00:00.000Z'
 
@@ -24,26 +27,6 @@ export interface BenchmarkWorkspaceFlow {
 	description?: string
 	schema?: Record<string, unknown>
 	value: Flow['value']
-}
-
-/** One seeded datatable table: its columns (col -> compact_type) and optional canned rows. */
-export interface BenchmarkDatatableTableSeed {
-	columns: Record<string, string>
-	rows?: Record<string, unknown>[]
-}
-
-/**
- * A seeded datatable: `datatable_name` plus a `schema -> table -> seed` map.
- * Mirrors the production shape so `list_datatables` / `get_datatable_table_schema`
- * project from the same structure.
- */
-export interface BenchmarkDatatableSeed {
-	datatable_name: string
-	schemas: {
-		[schema: string]: {
-			[table: string]: BenchmarkDatatableTableSeed
-		}
-	}
 }
 
 export interface BenchmarkWorkspaceRunnables {
@@ -73,7 +56,12 @@ export function registerBenchmarkWorkspaceRunnables(
 	runnables: BenchmarkWorkspaceRunnables
 ): void {
 	benchmarkWorkspaces.add(workspace)
-	benchmarkWorkspaceRunnables.set(workspace, runnables)
+	// Datatables are mutated in place by exec_datatable_sql (a write must be visible
+	// to later reads), so store an isolated deep copy — never mutate the caller's seed.
+	benchmarkWorkspaceRunnables.set(workspace, {
+		...runnables,
+		datatables: runnables.datatables ? structuredClone(runnables.datatables) : undefined
+	})
 }
 
 export function unregisterBenchmarkWorkspace(workspace: string): void {
@@ -186,7 +174,7 @@ export function getBenchmarkCompletedJob(
 	return structuredClone(entry.job)
 }
 
-// ============= Datatables (canned SQL, no engine) =============
+// ============= Datatables (best-effort in-memory SQL) =============
 
 /**
  * Project the seeded datatables down to the `list_datatable_tables` response:
@@ -238,19 +226,22 @@ export function getBenchmarkDatatableSchema(input: {
 }
 
 /**
- * Execute SQL against a seeded datatable with NO real engine: a SELECT returns
- * the canned rows of the referenced (or first) seeded table; any other
- * statement (CREATE/INSERT/UPDATE/DELETE/...) returns `[]` success. Creates a
- * benchmark completed job and returns its id, like `runBenchmarkScriptPreview`.
+ * Execute SQL against a seeded datatable through the best-effort in-memory engine
+ * (`applyDatatableSql`). Writes (CREATE/INSERT/UPDATE/DELETE/DROP) mutate the
+ * stored datatable in place so a later list/schema/SELECT reflects them; SELECT
+ * (and RETURNING) yield rows, other statements yield `[]`. Creates a benchmark
+ * completed job and returns its id, like `runBenchmarkScriptPreview`.
  */
 export function runBenchmarkDatatableSql(input: {
 	workspace: string
 	datatableName: string
 	sql: string
 }): string {
-	const rows = /^\s*select/i.test(input.sql)
-		? resolveBenchmarkDatatableSelectRows(input.workspace, input.datatableName, input.sql)
-		: []
+	const runnables = benchmarkWorkspaceRunnables.get(input.workspace)
+	const datatable = (runnables?.datatables ?? []).find(
+		(entry) => entry.datatable_name === input.datatableName
+	)
+	const rows = datatable ? applyDatatableSql(datatable, input.sql).rows : []
 	return createBenchmarkCompletedJob({
 		workspace: input.workspace,
 		jobKind: 'preview',
@@ -258,37 +249,6 @@ export function runBenchmarkDatatableSql(input: {
 		args: { database: `datatable://${input.datatableName}` },
 		result: rows
 	})
-}
-
-/**
- * Best-effort row resolution for a canned SELECT: match the table named in the
- * first FROM clause, else fall back to the first seeded table. Row fidelity is
- * intentionally loose — SELECT cases judge behavior (queried + reported back),
- * not exact cell values (see datatable-evals-plan.md).
- */
-function resolveBenchmarkDatatableSelectRows(
-	workspace: string,
-	datatableName: string,
-	sql: string
-): Record<string, unknown>[] {
-	const runnables = benchmarkWorkspaceRunnables.get(workspace)
-	const datatable = (runnables?.datatables ?? []).find(
-		(entry) => entry.datatable_name === datatableName
-	)
-	if (!datatable) {
-		return []
-	}
-	const tables = Object.values(datatable.schemas).flatMap((schemaTables) =>
-		Object.entries(schemaTables).map(([table, seed]) => ({ table, seed }))
-	)
-	if (tables.length === 0) {
-		return []
-	}
-	const referenced = sql.match(/\bfrom\s+([a-zA-Z_][\w.]*)/i)?.[1]?.split('.').pop()?.toLowerCase()
-	const matched = referenced
-		? tables.find((entry) => entry.table.toLowerCase() === referenced)
-		: undefined
-	return (matched ?? tables[0]).seed.rows ?? []
 }
 
 /**

--- a/ai_evals/adapters/frontend/mockBackend.ts
+++ b/ai_evals/adapters/frontend/mockBackend.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from 'node:crypto'
 import type { CompletedJob, Flow, Script } from '../../../frontend/src/lib/gen'
-import type { ScriptLang } from '../../../frontend/src/lib/gen/types.gen'
+import type {
+	DataTableTables,
+	DataTableTableSchema,
+	ScriptLang
+} from '../../../frontend/src/lib/gen/types.gen'
 import { buildScriptLintResult } from './core/script/preview'
 
 const BENCHMARK_TIMESTAMP = '1970-01-01T00:00:00.000Z'
@@ -22,9 +26,30 @@ export interface BenchmarkWorkspaceFlow {
 	value: Flow['value']
 }
 
+/** One seeded datatable table: its columns (col -> compact_type) and optional canned rows. */
+export interface BenchmarkDatatableTableSeed {
+	columns: Record<string, string>
+	rows?: Record<string, unknown>[]
+}
+
+/**
+ * A seeded datatable: `datatable_name` plus a `schema -> table -> seed` map.
+ * Mirrors the production shape so `list_datatables` / `get_datatable_table_schema`
+ * project from the same structure.
+ */
+export interface BenchmarkDatatableSeed {
+	datatable_name: string
+	schemas: {
+		[schema: string]: {
+			[table: string]: BenchmarkDatatableTableSeed
+		}
+	}
+}
+
 export interface BenchmarkWorkspaceRunnables {
 	scripts?: BenchmarkWorkspaceScript[]
 	flows?: BenchmarkWorkspaceFlow[]
+	datatables?: BenchmarkDatatableSeed[]
 }
 
 type BenchmarkCompletedJob = CompletedJob & { type: 'CompletedJob' }
@@ -159,6 +184,127 @@ export function getBenchmarkCompletedJob(
 		return null
 	}
 	return structuredClone(entry.job)
+}
+
+// ============= Datatables (canned SQL, no engine) =============
+
+/**
+ * Project the seeded datatables down to the `list_datatable_tables` response:
+ * `datatable_name` + `schema -> table_names`, with no column detail.
+ * Returns `null` for a non-benchmark workspace so callers can fall through to
+ * the real backend; an empty seed yields `[]`.
+ */
+export function listBenchmarkDatatables(workspace: string): DataTableTables[] | null {
+	const runnables = benchmarkWorkspaceRunnables.get(workspace)
+	if (!runnables) {
+		return null
+	}
+	return (runnables.datatables ?? []).map((datatable) => ({
+		datatable_name: datatable.datatable_name,
+		schemas: Object.fromEntries(
+			Object.entries(datatable.schemas).map(([schema, tables]) => [schema, Object.keys(tables)])
+		)
+	}))
+}
+
+export function getBenchmarkDatatableSchema(input: {
+	workspace: string
+	datatableName: string
+	schemaName: string
+	tableName: string
+}): DataTableTableSchema {
+	const runnables = benchmarkWorkspaceRunnables.get(input.workspace)
+	const datatable = (runnables?.datatables ?? []).find(
+		(entry) => entry.datatable_name === input.datatableName
+	)
+	if (!datatable) {
+		// Message MUST match the production `isDatatableNotConfiguredError` regex
+		// (/datatable\s+\S+\s+not found/i in datatableTools.ts) so the
+		// get_datatable_table_schema not-configured mapping is actually exercised.
+		throw new Error(`datatable "${input.datatableName}" not found`)
+	}
+	const table = datatable.schemas?.[input.schemaName]?.[input.tableName]
+	if (!table) {
+		throw new Error(
+			`table "${input.schemaName}.${input.tableName}" not found in datatable "${input.datatableName}"`
+		)
+	}
+	return {
+		datatable_name: input.datatableName,
+		schema_name: input.schemaName,
+		table_name: input.tableName,
+		columns: table.columns
+	}
+}
+
+/**
+ * Execute SQL against a seeded datatable with NO real engine: a SELECT returns
+ * the canned rows of the referenced (or first) seeded table; any other
+ * statement (CREATE/INSERT/UPDATE/DELETE/...) returns `[]` success. Creates a
+ * benchmark completed job and returns its id, like `runBenchmarkScriptPreview`.
+ */
+export function runBenchmarkDatatableSql(input: {
+	workspace: string
+	datatableName: string
+	sql: string
+}): string {
+	const rows = /^\s*select/i.test(input.sql)
+		? resolveBenchmarkDatatableSelectRows(input.workspace, input.datatableName, input.sql)
+		: []
+	return createBenchmarkCompletedJob({
+		workspace: input.workspace,
+		jobKind: 'preview',
+		success: true,
+		args: { database: `datatable://${input.datatableName}` },
+		result: rows
+	})
+}
+
+/**
+ * Best-effort row resolution for a canned SELECT: match the table named in the
+ * first FROM clause, else fall back to the first seeded table. Row fidelity is
+ * intentionally loose — SELECT cases judge behavior (queried + reported back),
+ * not exact cell values (see datatable-evals-plan.md).
+ */
+function resolveBenchmarkDatatableSelectRows(
+	workspace: string,
+	datatableName: string,
+	sql: string
+): Record<string, unknown>[] {
+	const runnables = benchmarkWorkspaceRunnables.get(workspace)
+	const datatable = (runnables?.datatables ?? []).find(
+		(entry) => entry.datatable_name === datatableName
+	)
+	if (!datatable) {
+		return []
+	}
+	const tables = Object.values(datatable.schemas).flatMap((schemaTables) =>
+		Object.entries(schemaTables).map(([table, seed]) => ({ table, seed }))
+	)
+	if (tables.length === 0) {
+		return []
+	}
+	const referenced = sql.match(/\bfrom\s+([a-zA-Z_][\w.]*)/i)?.[1]?.split('.').pop()?.toLowerCase()
+	const matched = referenced
+		? tables.find((entry) => entry.table.toLowerCase() === referenced)
+		: undefined
+	return (matched ?? tables[0]).seed.rows ?? []
+}
+
+/**
+ * Mirror `JobService.getCompletedJobResultMaybe` for benchmark workspaces — the
+ * shape `pollJobResult` consumes. The job is created synchronously before
+ * polling, so it is always present and completed.
+ */
+export function getBenchmarkCompletedJobResultMaybe(input: {
+	workspace: string
+	id: string
+}): { success: boolean; completed: boolean; result: unknown } {
+	const job = getBenchmarkCompletedJob(input.workspace, input.id)
+	if (!job) {
+		throw new Error(`Job "${input.id}" not found in benchmark workspace`)
+	}
+	return { success: job.success, completed: true, result: job.result }
 }
 
 export function runBenchmarkScriptPreview(input: {

--- a/ai_evals/adapters/frontend/mockBackendDatatables.test.ts
+++ b/ai_evals/adapters/frontend/mockBackendDatatables.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import {
+	getBenchmarkCompletedJobResultMaybe,
+	getBenchmarkDatatableSchema,
+	listBenchmarkDatatables,
+	registerBenchmarkWorkspaceRunnables,
+	resetBenchmarkMockBackend,
+	runBenchmarkDatatableSql,
+	type BenchmarkWorkspaceRunnables
+} from './mockBackend'
+
+const WORKSPACE = 'benchmark-datatable-ws'
+
+// Mirrors the production `isDatatableNotConfiguredError` regex in
+// datatableTools.ts. The schema mock's "not configured" message MUST match it,
+// otherwise the not-configured mapping in get_datatable_table_schema is silently
+// untested.
+const NOT_CONFIGURED_RE = /datatable\s+\S+\s+not found/i
+
+const SEED: BenchmarkWorkspaceRunnables = {
+	datatables: [
+		{
+			datatable_name: 'main',
+			schemas: {
+				public: {
+					orders: {
+						columns: { id: 'int', total: 'numeric' },
+						rows: [
+							{ id: 1, total: 10 },
+							{ id: 2, total: 20 }
+						]
+					},
+					customers: {
+						columns: { id: 'int', name: 'text' },
+						rows: [{ id: 1, name: 'alice' }]
+					}
+				}
+			}
+		}
+	]
+}
+
+beforeEach(() => resetBenchmarkMockBackend())
+afterEach(() => resetBenchmarkMockBackend())
+
+describe('listBenchmarkDatatables', () => {
+	it('returns null for a non-benchmark workspace (caller falls through to real backend)', () => {
+		expect(listBenchmarkDatatables('unregistered')).toBeNull()
+	})
+
+	it('returns [] for a registered workspace with no datatables seed', () => {
+		registerBenchmarkWorkspaceRunnables(WORKSPACE, {})
+		expect(listBenchmarkDatatables(WORKSPACE)).toEqual([])
+	})
+
+	it('projects seeded datatables to schema -> table names only (no columns)', () => {
+		registerBenchmarkWorkspaceRunnables(WORKSPACE, SEED)
+		expect(listBenchmarkDatatables(WORKSPACE)).toEqual([
+			{ datatable_name: 'main', schemas: { public: ['orders', 'customers'] } }
+		])
+	})
+})
+
+describe('getBenchmarkDatatableSchema', () => {
+	beforeEach(() => registerBenchmarkWorkspaceRunnables(WORKSPACE, SEED))
+
+	it('returns the columns for a seeded table', () => {
+		expect(
+			getBenchmarkDatatableSchema({
+				workspace: WORKSPACE,
+				datatableName: 'main',
+				schemaName: 'public',
+				tableName: 'orders'
+			})
+		).toEqual({
+			datatable_name: 'main',
+			schema_name: 'public',
+			table_name: 'orders',
+			columns: { id: 'int', total: 'numeric' }
+		})
+	})
+
+	it('throws a not-configured error matching the production regex for an unknown datatable', () => {
+		let error: Error | undefined
+		try {
+			getBenchmarkDatatableSchema({
+				workspace: WORKSPACE,
+				datatableName: 'ghost',
+				schemaName: 'public',
+				tableName: 'orders'
+			})
+		} catch (e) {
+			error = e as Error
+		}
+		expect(error).toBeDefined()
+		expect(error!.message).toMatch(NOT_CONFIGURED_RE)
+	})
+
+	it('throws a table-not-found error that does NOT match the datatable-not-configured regex', () => {
+		// The datatable IS configured; only the table is missing. Production maps
+		// this to a generic "error getting schema", not the blocking message.
+		let error: Error | undefined
+		try {
+			getBenchmarkDatatableSchema({
+				workspace: WORKSPACE,
+				datatableName: 'main',
+				schemaName: 'public',
+				tableName: 'ghost'
+			})
+		} catch (e) {
+			error = e as Error
+		}
+		expect(error).toBeDefined()
+		expect(error!.message).not.toMatch(NOT_CONFIGURED_RE)
+	})
+})
+
+describe('runBenchmarkDatatableSql + getBenchmarkCompletedJobResultMaybe', () => {
+	beforeEach(() => registerBenchmarkWorkspaceRunnables(WORKSPACE, SEED))
+
+	function exec(sql: string): { success: boolean; completed: boolean; result: unknown } {
+		const jobId = runBenchmarkDatatableSql({ workspace: WORKSPACE, datatableName: 'main', sql })
+		return getBenchmarkCompletedJobResultMaybe({ workspace: WORKSPACE, id: jobId })
+	}
+
+	it('returns the canned rows of the table named in a SELECT FROM clause', () => {
+		expect(exec('SELECT * FROM customers')).toEqual({
+			success: true,
+			completed: true,
+			result: [{ id: 1, name: 'alice' }]
+		})
+	})
+
+	it('falls back to the first seeded table when the SELECT references no known table', () => {
+		expect(exec('select 1').result).toEqual([
+			{ id: 1, total: 10 },
+			{ id: 2, total: 20 }
+		])
+	})
+
+	it('returns [] success for DDL and DML statements', () => {
+		expect(exec('CREATE TABLE foo (id int)').result).toEqual([])
+		expect(exec('INSERT INTO orders VALUES (3, 30)').result).toEqual([])
+		expect(exec('update orders set total = 0').result).toEqual([])
+	})
+
+	it('throws for an unknown job id', () => {
+		expect(() =>
+			getBenchmarkCompletedJobResultMaybe({ workspace: WORKSPACE, id: 'does-not-exist' })
+		).toThrow()
+	})
+})

--- a/ai_evals/adapters/frontend/mockBackendDatatables.test.ts
+++ b/ai_evals/adapters/frontend/mockBackendDatatables.test.ts
@@ -138,10 +138,33 @@ describe('runBenchmarkDatatableSql + getBenchmarkCompletedJobResultMaybe', () =>
 		])
 	})
 
-	it('returns [] success for DDL and DML statements', () => {
+	it('returns [] success for DDL and DML statements without RETURNING', () => {
 		expect(exec('CREATE TABLE foo (id int)').result).toEqual([])
 		expect(exec('INSERT INTO orders VALUES (3, 30)').result).toEqual([])
 		expect(exec('update orders set total = 0').result).toEqual([])
+	})
+
+	it('reflects a write in a later SELECT, isolated from the shared seed', () => {
+		exec('UPDATE orders SET total = 999 WHERE id = 1')
+		expect((exec('SELECT * FROM orders').result as Record<string, unknown>[])).toContainEqual({
+			id: 1,
+			total: 999
+		})
+		// Registration deep-clones the seed, so the shared SEED const stays pristine.
+		expect(SEED.datatables![0].schemas.public.orders.rows).toContainEqual({ id: 1, total: 10 })
+	})
+
+	it('reflects a CREATE in list_datatables and get_datatable_table_schema', () => {
+		exec('CREATE TABLE public.refunds (order_id int4, amount numeric)')
+		expect(listBenchmarkDatatables(WORKSPACE)?.[0].schemas.public).toContain('refunds')
+		expect(
+			getBenchmarkDatatableSchema({
+				workspace: WORKSPACE,
+				datatableName: 'main',
+				schemaName: 'public',
+				tableName: 'refunds'
+			}).columns
+		).toEqual({ order_id: 'int4', amount: 'numeric' })
 	})
 
 	it('throws for an unknown job id', () => {

--- a/ai_evals/adapters/frontend/vitestAdapter.test.ts
+++ b/ai_evals/adapters/frontend/vitestAdapter.test.ts
@@ -34,15 +34,19 @@ vi.mock('$lib/gen', async () => {
 	const actual = await vi.importActual<any>('$lib/gen')
 	const {
 		getBenchmarkCompletedJob,
+		getBenchmarkCompletedJobResultMaybe,
+		getBenchmarkDatatableSchema,
 		getBenchmarkFlowByPath,
 		getBenchmarkScriptByHash,
 		getBenchmarkScriptByPath,
 		hasBenchmarkWorkspace,
+		listBenchmarkDatatables,
 		listBenchmarkFlows,
 		listBenchmarkScripts,
 		createBenchmarkHttpTrigger,
 		createBenchmarkSchedule,
 		previewBenchmarkSchedule,
+		runBenchmarkDatatableSql,
 		runBenchmarkFlowByPath,
 		runBenchmarkScriptPreview
 	} = await import('./mockBackend')
@@ -149,13 +153,27 @@ vi.mock('$lib/gen', async () => {
 					args?: Record<string, unknown>
 					path?: string
 				}
-			}) =>
-				hasBenchmarkWorkspace(data.workspace)
-					? runBenchmarkScriptPreview({
-							workspace: data.workspace,
-							requestBody: data.requestBody ?? {}
-						})
-					: actual.JobService.runScriptPreview(data),
+			}) => {
+				if (!hasBenchmarkWorkspace(data.workspace)) {
+					return actual.JobService.runScriptPreview(data)
+				}
+				const requestBody = data.requestBody ?? {}
+				const database = requestBody.args?.database
+				// Datatable SQL runs as a `postgresql` preview against `datatable://<name>`.
+				// Execute it through the canned-SQL mock instead of linting it as a script.
+				if (
+					requestBody.language === 'postgresql' &&
+					typeof database === 'string' &&
+					database.startsWith('datatable://')
+				) {
+					return runBenchmarkDatatableSql({
+						workspace: data.workspace,
+						datatableName: database.slice('datatable://'.length),
+						sql: requestBody.content ?? ''
+					})
+				}
+				return runBenchmarkScriptPreview({ workspace: data.workspace, requestBody })
+			},
 			runFlowByPath: async (data: {
 				workspace: string
 				path: string
@@ -177,7 +195,31 @@ vi.mock('$lib/gen', async () => {
 					return job
 				}
 				return actual.JobService.getJob(data)
-			}
+			},
+			getCompletedJobResultMaybe: async (data: { workspace: string; id: string }) =>
+				hasBenchmarkWorkspace(data.workspace)
+					? getBenchmarkCompletedJobResultMaybe({ workspace: data.workspace, id: data.id })
+					: actual.JobService.getCompletedJobResultMaybe(data)
+		}),
+		WorkspaceService: wrapService(actual.WorkspaceService, {
+			listDataTableTables: async (data: { workspace: string }) =>
+				hasBenchmarkWorkspace(data.workspace)
+					? (listBenchmarkDatatables(data.workspace) ?? [])
+					: actual.WorkspaceService.listDataTableTables(data),
+			getDataTableTableSchema: async (data: {
+				workspace: string
+				datatableName: string
+				schemaName: string
+				tableName: string
+			}) =>
+				hasBenchmarkWorkspace(data.workspace)
+					? getBenchmarkDatatableSchema({
+							workspace: data.workspace,
+							datatableName: data.datatableName,
+							schemaName: data.schemaName,
+							tableName: data.tableName
+						})
+					: actual.WorkspaceService.getDataTableTableSchema(data)
 		}),
 		ScheduleService: wrapService(actual.ScheduleService, {
 			existsSchedule: async (data: { workspace: string; path: string }) =>

--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -766,8 +766,8 @@
     Mark order number 2 as shipped in our workspace data table.
   initial: ai_evals/fixtures/frontend/global/initial/datatable_orders_seed.json
   runtime:
-    # Canned SQL does not persist mutations, so a model that re-queries to verify
-    # sees stale rows and may retry; give it headroom to issue the UPDATE and wrap up.
+    # Headroom for inspect-schema -> UPDATE -> verify; the in-memory engine now
+    # persists the write, so verification confirms on the first try (no loop).
     maxTurns: 12
   validate:
     draftCountExactly: 0

--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -663,3 +663,147 @@
     - does not assume a data table named "main" (or any other name) exists
     - does not run SQL against a guessed data table or fabricate order rows
     - tells the user they need to set up a data table in the workspace settings first
+
+- id: global-test21-datatable-list-summarize
+  prompt: |-
+    What tables do we have in our workspace data table? Just give me the list.
+  initial: ai_evals/fixtures/frontend/global/initial/datatable_orders_seed.json
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - list_datatables
+    forbiddenToolsUsed:
+      - get_datatable_table_schema
+      - exec_datatable_sql
+      - deploy_workspace_item
+      - delete_workspace_item
+  judgeChecklist:
+    - lists the tables available in the workspace data table (orders and customers)
+    - answers from the data table listing rather than fabricating table names
+    - does not fetch column details or run SQL just to produce a table list
+
+- id: global-test22-datatable-inspect-columns
+  prompt: |-
+    What columns does the orders table have in our workspace data table?
+  initial: ai_evals/fixtures/frontend/global/initial/datatable_orders_seed.json
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - get_datatable_table_schema
+    forbiddenToolsUsed:
+      - deploy_workspace_item
+      - delete_workspace_item
+  judgeChecklist:
+    - inspects the orders table schema in the workspace data table
+    - reports the orders columns (such as id, customer_id, total, status, created_at)
+    - answers from the retrieved schema rather than guessing the columns
+
+- id: global-test23-datatable-query-select
+  prompt: |-
+    Show me the orders in our workspace data table, including their status and total.
+  initial: ai_evals/fixtures/frontend/global/initial/datatable_orders_seed.json
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - exec_datatable_sql
+    forbiddenToolsUsed:
+      - write_script
+      - deploy_workspace_item
+      - delete_workspace_item
+    toolCallArgs:
+      - tool: exec_datatable_sql
+        field: sql
+        stringIncludesAnyOf:
+          - select
+  judgeChecklist:
+    - runs a SELECT query against the orders table in the workspace data table
+    - reports the orders returned by the query back to the user instead of fabricating data
+    - does not tell the user to set up a data table, since one already exists
+
+- id: global-test24-datatable-create-table
+  prompt: |-
+    Add a new table called refunds to our workspace data table, with an order id and a refund amount.
+  initial: ai_evals/fixtures/frontend/global/initial/datatable_orders_seed.json
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - exec_datatable_sql
+    forbiddenToolsUsed:
+      - write_script
+      - deploy_workspace_item
+      - delete_workspace_item
+    toolCallArgs:
+      - tool: exec_datatable_sql
+        field: sql
+        stringIncludesAnyOf:
+          - create table
+  judgeChecklist:
+    - creates the refunds table with a plain CREATE TABLE statement on the data table
+    - includes an order id and a refund amount column
+    - treats creating the table as a normal SQL statement and does not claim a separate registration step is needed
+    - does not write a script to create the table
+
+- id: global-test25-datatable-mutate-rows
+  prompt: |-
+    Mark order number 2 as shipped in our workspace data table.
+  initial: ai_evals/fixtures/frontend/global/initial/datatable_orders_seed.json
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - exec_datatable_sql
+    forbiddenToolsUsed:
+      - write_script
+      - deploy_workspace_item
+      - delete_workspace_item
+    toolCallArgs:
+      - tool: exec_datatable_sql
+        field: sql
+        stringIncludesAnyOf:
+          - update
+          - insert into
+  judgeChecklist:
+    - runs an UPDATE on the orders table setting the status of order id 2 to shipped
+    - targets only order number 2 rather than rewriting the whole table
+    - confirms the change back to the user
+
+- id: global-test26-datatable-script-sdk
+  prompt: |-
+    Write a script that reads our workspace data table and returns the total revenue across all orders.
+    Leave it as an AI draft only; do not deploy or save it.
+  initial: ai_evals/fixtures/frontend/global/initial/datatable_orders_seed.json
+  runtime:
+    maxTurns: 10
+  validate:
+    draftCountExactly: 1
+    requiredDrafts:
+      - type: script
+        valueIncludes:
+          - wmill.datatable(
+  toolExpect:
+    requiredToolsUsed:
+      - get_instructions
+      - write_script
+    forbiddenToolsUsed:
+      - exec_datatable_sql
+      - deploy_workspace_item
+      - delete_workspace_item
+  judgeChecklist:
+    - writes a script (not a chat-time SQL execution) that reads the workspace data table at runtime
+    - uses the wmill.datatable() SDK to query the orders table and sum the order totals
+    - returns the total revenue from the script
+    - leaves the result as an AI draft and does not deploy or save it

--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -635,6 +635,7 @@
       - write_script
       - deploy_workspace_item
       - delete_workspace_item
+  skipJudge: true
   judgeChecklist:
     - checks which data tables exist in the workspace before acting
     - recognizes that no data table is configured in this workspace
@@ -657,6 +658,7 @@
       - write_script
       - deploy_workspace_item
       - delete_workspace_item
+  skipJudge: true
   judgeChecklist:
     - checks which data tables exist in the workspace before querying
     - recognizes that no data table is configured in this workspace
@@ -680,6 +682,7 @@
       - exec_datatable_sql
       - deploy_workspace_item
       - delete_workspace_item
+  skipJudge: true
   judgeChecklist:
     - lists the tables available in the workspace data table (orders and customers)
     - answers from the data table listing rather than fabricating table names
@@ -699,6 +702,7 @@
     forbiddenToolsUsed:
       - deploy_workspace_item
       - delete_workspace_item
+  skipJudge: true
   judgeChecklist:
     - inspects the orders table schema in the workspace data table
     - reports the orders columns (such as id, customer_id, total, status, created_at)
@@ -724,6 +728,7 @@
         field: sql
         stringIncludesAnyOf:
           - select
+  skipJudge: true
   judgeChecklist:
     - runs a SELECT query against the orders table in the workspace data table
     - reports the orders returned by the query back to the user instead of fabricating data
@@ -749,6 +754,7 @@
         field: sql
         stringIncludesAnyOf:
           - create table
+  skipJudge: true
   judgeChecklist:
     - creates the refunds table with a plain CREATE TABLE statement on the data table
     - includes an order id and a refund amount column
@@ -760,7 +766,9 @@
     Mark order number 2 as shipped in our workspace data table.
   initial: ai_evals/fixtures/frontend/global/initial/datatable_orders_seed.json
   runtime:
-    maxTurns: 6
+    # Canned SQL does not persist mutations, so a model that re-queries to verify
+    # sees stale rows and may retry; give it headroom to issue the UPDATE and wrap up.
+    maxTurns: 12
   validate:
     draftCountExactly: 0
   toolExpect:
@@ -776,6 +784,7 @@
         stringIncludesAnyOf:
           - update
           - insert into
+  skipJudge: true
   judgeChecklist:
     - runs an UPDATE on the orders table setting the status of order id 2 to shipped
     - targets only order number 2 rather than rewriting the whole table
@@ -802,6 +811,11 @@
       - exec_datatable_sql
       - deploy_workspace_item
       - delete_workspace_item
+  # The judge has no datatable SDK reference and wrongly penalizes correct
+  # wmill.datatable() tagged-template usage, so rely on the deterministic checks:
+  # required get_instructions + write_script, forbidden exec_datatable_sql, and a
+  # draft that contains wmill.datatable(.
+  skipJudge: true
   judgeChecklist:
     - writes a script (not a chat-time SQL execution) that reads the workspace data table at runtime
     - uses the wmill.datatable() SDK to query the orders table and sum the order totals

--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -618,3 +618,48 @@
     - creates a Slack resource draft that references the secret variable instead of embedding the token
     - keeps both drafts under a sensible eval/global Slack-related path
     - does not create schedules, triggers, or deployed workspace changes
+
+- id: global-test19-datatable-not-configured-asks-to-set-up
+  prompt: |-
+    Here are two newsletter signups: alice@example.com and bob@example.com.
+    Save them into a workspace data table for me.
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - list_datatables
+    forbiddenToolsUsed:
+      - exec_datatable_sql
+      - write_script
+      - deploy_workspace_item
+      - delete_workspace_item
+  judgeChecklist:
+    - checks which data tables exist in the workspace before acting
+    - recognizes that no data table is configured in this workspace
+    - explains that a data table must first be set up by the user in the workspace settings (Data Tables) and is not created via SQL
+    - does not run SQL, write a script, or invent a data table to work around the missing configuration
+    - tells the user to configure a data table and then try again
+
+- id: global-test20-datatable-no-hallucinated-main
+  prompt: |-
+    Pull the latest rows from the orders table in our data table so I can see recent orders.
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - list_datatables
+    forbiddenToolsUsed:
+      - exec_datatable_sql
+      - write_script
+      - deploy_workspace_item
+      - delete_workspace_item
+  judgeChecklist:
+    - checks which data tables exist in the workspace before querying
+    - recognizes that no data table is configured in this workspace
+    - does not assume a data table named "main" (or any other name) exists
+    - does not run SQL against a guessed data table or fabricate order rows
+    - tells the user they need to set up a data table in the workspace settings first

--- a/ai_evals/core/types.ts
+++ b/ai_evals/core/types.ts
@@ -156,10 +156,12 @@ export interface ToolCallArgumentRule {
   stringStartsWithAnyOf?: string[];
   stringMustNotStartWithAnyOf?: string[];
   /**
-   * Case-insensitive "contains": the value must include at least one of these
-   * substrings. Use instead of `stringStartsWithAnyOf` when the meaningful token
-   * can appear anywhere in the value (e.g. a SQL keyword whose position/case
-   * varies), to avoid brittle false negatives.
+   * Case-insensitive "contains", existential over calls: at least one recorded
+   * call to `tool` must have `field` containing one of these substrings. Other
+   * calls to the same tool may do anything. Use instead of `stringStartsWithAnyOf`
+   * (which is universal over calls) when the meaningful token can appear anywhere
+   * in the value and the model may make additional, unrelated calls to the same
+   * tool — e.g. SQL where a mutation is mixed with verification SELECTs.
    */
   stringIncludesAnyOf?: string[];
 }

--- a/ai_evals/core/types.ts
+++ b/ai_evals/core/types.ts
@@ -155,6 +155,13 @@ export interface ToolCallArgumentRule {
   field: string;
   stringStartsWithAnyOf?: string[];
   stringMustNotStartWithAnyOf?: string[];
+  /**
+   * Case-insensitive "contains": the value must include at least one of these
+   * substrings. Use instead of `stringStartsWithAnyOf` when the meaningful token
+   * can appear anywhere in the value (e.g. a SQL keyword whose position/case
+   * varies), to avoid brittle false negatives.
+   */
+  stringIncludesAnyOf?: string[];
 }
 
 export interface ToolValidationSpec {

--- a/ai_evals/core/validators.test.ts
+++ b/ai_evals/core/validators.test.ts
@@ -174,7 +174,42 @@ describe("validateToolExpectations", () => {
     expect(checks.every((check) => check.passed)).toBe(true);
   });
 
-  it("rejects a value missing every stringIncludesAnyOf substring", () => {
+  it("accepts stringIncludesAnyOf when only one of several calls matches", () => {
+    // Existential: a mutation mixed with verification SELECTs still passes.
+    const checks = validateToolExpectations({
+      run: {
+        success: true,
+        actual: {},
+        assistantMessageCount: 1,
+        toolCallCount: 2,
+        toolsUsed: ["exec_datatable_sql"],
+        toolCallDetails: [
+          {
+            name: "exec_datatable_sql",
+            arguments: { sql: "UPDATE orders SET status = 'shipped' WHERE id = 2" },
+          },
+          {
+            name: "exec_datatable_sql",
+            arguments: { sql: "SELECT * FROM orders WHERE id = 2" },
+          },
+        ],
+        skillsInvoked: [],
+      },
+      toolExpect: {
+        toolCallArgs: [
+          {
+            tool: "exec_datatable_sql",
+            field: "sql",
+            stringIncludesAnyOf: ["insert into", "update"],
+          },
+        ],
+      },
+    });
+
+    expect(checks.every((check) => check.passed)).toBe(true);
+  });
+
+  it("rejects stringIncludesAnyOf when no call matches any substring", () => {
     const checks = validateToolExpectations({
       run: {
         success: true,
@@ -204,7 +239,7 @@ describe("validateToolExpectations", () => {
     });
 
     expect(checks).toContainEqual({
-      name: "exec_datatable_sql.sql contains a required substring",
+      name: "exec_datatable_sql.sql includes a required substring",
       passed: false,
       details:
         'accepted substrings: insert into, update; values: "DROP TABLE orders"',

--- a/ai_evals/core/validators.test.ts
+++ b/ai_evals/core/validators.test.ts
@@ -140,6 +140,76 @@ describe("validateToolExpectations", () => {
       details: "tools used: write_script, deploy_workspace_item",
     });
   });
+
+  it("accepts a stringIncludesAnyOf substring regardless of case or position", () => {
+    const checks = validateToolExpectations({
+      run: {
+        success: true,
+        actual: {},
+        assistantMessageCount: 1,
+        toolCallCount: 1,
+        toolsUsed: ["exec_datatable_sql"],
+        toolCallDetails: [
+          {
+            name: "exec_datatable_sql",
+            arguments: {
+              sql: "WITH recent AS (SELECT * FROM orders) SELECT count(*) FROM recent",
+            },
+          },
+        ],
+        skillsInvoked: [],
+      },
+      toolExpect: {
+        requiredToolsUsed: ["exec_datatable_sql"],
+        toolCallArgs: [
+          {
+            tool: "exec_datatable_sql",
+            field: "sql",
+            stringIncludesAnyOf: ["select"],
+          },
+        ],
+      },
+    });
+
+    expect(checks.every((check) => check.passed)).toBe(true);
+  });
+
+  it("rejects a value missing every stringIncludesAnyOf substring", () => {
+    const checks = validateToolExpectations({
+      run: {
+        success: true,
+        actual: {},
+        assistantMessageCount: 1,
+        toolCallCount: 1,
+        toolsUsed: ["exec_datatable_sql"],
+        toolCallDetails: [
+          {
+            name: "exec_datatable_sql",
+            arguments: {
+              sql: "DROP TABLE orders",
+            },
+          },
+        ],
+        skillsInvoked: [],
+      },
+      toolExpect: {
+        toolCallArgs: [
+          {
+            tool: "exec_datatable_sql",
+            field: "sql",
+            stringIncludesAnyOf: ["insert into", "update"],
+          },
+        ],
+      },
+    });
+
+    expect(checks).toContainEqual({
+      name: "exec_datatable_sql.sql contains a required substring",
+      passed: false,
+      details:
+        'accepted substrings: insert into, update; values: "DROP TABLE orders"',
+    });
+  });
 });
 
 describe("validateGlobalState", () => {

--- a/ai_evals/core/validators.ts
+++ b/ai_evals/core/validators.ts
@@ -224,16 +224,19 @@ export function validateToolExpectations(input: {
     }
 
     if (rule.stringIncludesAnyOf && rule.stringIncludesAnyOf.length > 0) {
+      // Existential: at least one call must contain one of the substrings.
+      // Other calls to the same tool may do anything — this suits SQL, where a
+      // model mixes the requested statement (e.g. an UPDATE) with verification
+      // SELECTs that would otherwise fail an "all calls" check.
       const needles = rule.stringIncludesAnyOf.map((needle) => needle.toLowerCase());
-      const invalidValues = values.filter(
+      const hasMatch = values.some(
         (value) =>
-          typeof value !== "string" ||
-          !needles.some((needle) => value.toLowerCase().includes(needle))
+          typeof value === "string" && needles.some((needle) => value.toLowerCase().includes(needle))
       );
       checks.push(
         check(
-          `${rule.tool}.${rule.field} contains a required substring`,
-          invalidValues.length === 0,
+          `${rule.tool}.${rule.field} includes a required substring`,
+          hasMatch,
           `accepted substrings: ${rule.stringIncludesAnyOf.join(", ")}; values: ${summarizeToolValues(values)}`
         )
       );

--- a/ai_evals/core/validators.ts
+++ b/ai_evals/core/validators.ts
@@ -222,6 +222,22 @@ export function validateToolExpectations(input: {
         )
       );
     }
+
+    if (rule.stringIncludesAnyOf && rule.stringIncludesAnyOf.length > 0) {
+      const needles = rule.stringIncludesAnyOf.map((needle) => needle.toLowerCase());
+      const invalidValues = values.filter(
+        (value) =>
+          typeof value !== "string" ||
+          !needles.some((needle) => value.toLowerCase().includes(needle))
+      );
+      checks.push(
+        check(
+          `${rule.tool}.${rule.field} contains a required substring`,
+          invalidValues.length === 0,
+          `accepted substrings: ${rule.stringIncludesAnyOf.join(", ")}; values: ${summarizeToolValues(values)}`
+        )
+      );
+    }
   }
 
   return checks;

--- a/ai_evals/fixtures/frontend/global/initial/datatable_orders_seed.json
+++ b/ai_evals/fixtures/frontend/global/initial/datatable_orders_seed.json
@@ -1,0 +1,39 @@
+{
+  "workspace": {
+    "datatables": [
+      {
+        "datatable_name": "main",
+        "schemas": {
+          "public": {
+            "orders": {
+              "columns": {
+                "id": "int4",
+                "customer_id": "int4",
+                "total": "numeric",
+                "status": "text",
+                "created_at": "timestamptz"
+              },
+              "rows": [
+                { "id": 1, "customer_id": 1, "total": 42.5, "status": "shipped", "created_at": "2026-05-01T10:00:00Z" },
+                { "id": 2, "customer_id": 2, "total": 19.99, "status": "pending", "created_at": "2026-05-02T11:30:00Z" },
+                { "id": 3, "customer_id": 1, "total": 88, "status": "shipped", "created_at": "2026-05-03T09:15:00Z" }
+              ]
+            },
+            "customers": {
+              "columns": {
+                "id": "int4",
+                "name": "text",
+                "email": "text",
+                "tier": "text"
+              },
+              "rows": [
+                { "id": 1, "name": "Alice", "email": "alice@example.com", "tier": "gold" },
+                { "id": 2, "name": "Bob", "email": "bob@example.com", "tier": "silver" }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds black-box AI-eval coverage for the workspace datatable tools (`list_datatables`, `get_datatable_table_schema`, `exec_datatable_sql`) introduced in #9395, in `ai_evals` global mode. Those tools were previously **non-functional in evals** — none of their backend calls were mocked, so the tools would hit the real backend with a temp-dir workspace and error. This PR adds the mock infrastructure (including a small stateful in-memory SQL engine), a new validator rule, and a difficulty ladder of behavioral cases, validated by a cross-model live smoke.

Test/fixture/docs only — confined to `ai_evals/`. No `backend/` or `frontend/` runtime code changes.

## Changes

**Mock infra**
- `mockBackend.ts`: seeded-datatable helpers (`listBenchmarkDatatables`, `getBenchmarkDatatableSchema`, `runBenchmarkDatatableSql`, `getBenchmarkCompletedJobResultMaybe`). The schema not-found error message matches the production `isDatatableNotConfiguredError` regex so the blocking-error mapping is actually exercised. Datatables are deep-cloned on registration so writes can't leak into the caller's fixture.
- `datatableSqlEngine.ts`: a deliberately small, best-effort in-memory SQL engine. **Writes are stateful within a case** — `CREATE`/`DROP`/`INSERT`/`UPDATE`/`DELETE` mutate the seeded datatable in place, so a later `list_datatables`, `get_datatable_table_schema`, `SELECT`, or `information_schema` query reflects them. This is what stops a model from looping when it re-queries to verify a write. It never throws; anything it can't parse is a no-op success. Limits (documented): `SELECT` returns all rows of the referenced/first table (no WHERE filtering/projection/joins); `WHERE` on UPDATE/DELETE supports `col = value` joined by `AND`.
- `vitestAdapter.test.ts`: wraps `WorkspaceService` (list/schema) and `JobService` (branches `runScriptPreview` for `datatable://` postgres jobs, adds `getCompletedJobResultMaybe`).
- New `stringIncludesAnyOf` validator rule (`core/types.ts` + `core/validators.ts`): case-insensitive "contains", **existential over calls** (≥1 matching call) so a mutation case still passes when the model mixes its UPDATE/INSERT with verification SELECTs.

**Cases**
- Blocking (`global-test19/20`): no datatable configured → the model checks `list_datatables`, refuses to hallucinate a `main` datatable or run SQL, and tells the user to set one up. Mirrors the behavior hardened in #9395.
- Difficulty ladder (`global-test21–26`): list, inspect columns, query (SELECT), create table, mutate rows, and a stretch "write a script that reads the datatable via `wmill.datatable()` at runtime" case. Seeded by the new `datatable_orders_seed.json` fixture.
- All datatable cases use `skipJudge: true` — the global judge only sees the drafts artifact (so it scores no-draft conversational answers as empty) and has no datatable SDK reference (so it wrongly fails correct `wmill.datatable()` usage). They rely on tool-use + SQL-arg + draft-content assertions instead.

**Tests & docs**
- Unit tests for the SQL engine (`datatableSqlEngine.test.ts`, incl. parser-robustness edge cases), the mock helpers, and the validator rule.
- `ai_evals/README.md` + `ai_evals/AGENTS.md` document the `workspace.datatables` seed, the stateful-write semantics, and the datatable-case validation rules.

## Live smoke (global mode, against a local backend)

Ran the full datatable suite (`global-test19`–`26`) across five models, **after** the write-reflecting engine landed:

| Case | haiku | opus | gpt-5.5 | gemini-3.1-pro | deepseek |
|---|---|---|---|---|---|
| 19 not-configured | ✅ | ✅ | ✅ | ✅ | ✅ |
| 20 no-hallucinate | ✅ | ✅ | ✅ | ✅ | ✅ |
| 21 list | ✅ | ✅ | ✅ | ✅ | ✅ |
| 22 inspect columns | ✅ | ✅ | ✅ | ✅ | ✅ |
| 23 query (SELECT) | ✅ | ✅ | ✅ | ✅ | ✅ |
| 24 create table | ✅ | ✅ | ✅ | ✅ | ✅ |
| 25 mutate rows | ✅ | ✅ | ✅ | ✅ | ✅ |
| 26 script via SDK | ✅ | ✅ | ❌ no write_script | ✅ | ✅ |
| **Total** | **8/8** | **8/8** | **7/8** | **8/8** | **8/8** |

- **24/25 (create/mutate) now pass on every model.** Before the engine, gpt-5.5 and deepseek issued the correct CREATE/UPDATE but looped verifying a write the mock never persisted, exhausting their turns. The stateful engine makes verification succeed on the first try.
- **The one remaining failure (test26 on gpt-5.5) is a real model signal, not a mock artifact:** gpt-5.5 inlined the script in chat instead of calling `write_script`. The eval correctly differentiates it — not something to paper over in the harness.

## Test plan

- [ ] `cd ai_evals && bun test` → 131 pass, 1 skip, 0 fail
- [ ] Live (backend on :8080, reusing the `integration-tests` workspace): `WMILL_AI_EVAL_BACKEND_URL=http://127.0.0.1:8080 WMILL_AI_EVAL_BACKEND_WORKSPACE=integration-tests bun run cli -- run global global-test19-datatable-not-configured-asks-to-set-up ... global-test26-datatable-script-sdk --model haiku`

🤖 Generated with [Claude Code](https://claude.com/claude-code)