### PR TITLE
feat: auto-generate AI session names

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -815,6 +815,7 @@ export class AIChatManager {
 	// this to commit/materialise the workspace (creating a staged fork via
 	// the API) so the first message targets the correct workspace.
 	beforeSend?: () => Promise<void> | void
+	afterFirstTurnSaved?: () => Promise<void> | void
 
 	sendRequest = async (
 		options: {
@@ -858,6 +859,7 @@ export class AIChatManager {
 				return
 			}
 		}
+		const isFirstUserTurn = !this.displayMessages.some((message) => message.role === 'user')
 		try {
 			const oldSelectedContext = this.contextManager?.getSelectedContext() ?? []
 			if (this.mode === AIMode.SCRIPT || this.mode === AIMode.FLOW) {
@@ -1044,6 +1046,11 @@ export class AIChatManager {
 				this.acceptPendingFlowEdits()
 			}
 			await this.historyManager.saveChat(this.displayMessages, this.messages)
+			if (isFirstUserTurn && this.afterFirstTurnSaved) {
+				void Promise.resolve(this.afterFirstTurnSaved()).catch((e) => {
+					console.error('AIChatManager afterFirstTurnSaved hook failed', e)
+				})
+			}
 		} catch (err) {
 			console.error(err)
 			this.flagLastMessageAsError()

--- a/frontend/src/lib/components/sessions/SessionWrapper.svelte
+++ b/frontend/src/lib/components/sessions/SessionWrapper.svelte
@@ -34,7 +34,7 @@
 		getEffectiveWorkspaceId,
 		moveSessionToNewFork,
 		moveSessionToWorkspace,
-		persistSessions,
+		renameSession,
 		selectSession,
 		sessionState,
 		setSessionArchived,
@@ -294,10 +294,7 @@
 					bind:this={summaryInput}
 					value={session.summary ?? ''}
 					placeholder="Untitled session"
-					onSave={(v) => {
-						session.summary = v
-						persistSessions()
-					}}
+					onSave={(v) => renameSession(session.id, v)}
 					class="text-sm font-semibold"
 					inputClass="!text-sm !font-semibold"
 				/>

--- a/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
@@ -22,6 +22,7 @@ import {
 	ensureChatIdsSeeded,
 	materializeTransient,
 	sessionState,
+	setGeneratedSessionSummary,
 	setSessionChatId,
 	setSessionTarget,
 	type Session,
@@ -34,6 +35,9 @@ import {
 	setGetPreviewStatusHandler,
 	setOpenPreviewHandler
 } from '$lib/components/copilot/chat/global/core'
+import { getNonStreamingCompletion } from '$lib/components/copilot/lib'
+import type { DisplayMessage } from '$lib/components/copilot/chat/shared'
+import type { ChatCompletionMessageParam } from 'openai/resources/index.mjs'
 
 export interface SessionRuntime {
 	readonly sessionId: string
@@ -138,6 +142,70 @@ function emptyFlow(): Flow {
 	}
 }
 
+const GENERATED_SUMMARY_TIMEOUT_MS = 15000
+const GENERATED_SUMMARY_MAX_TRANSCRIPT_CHARS = 4000
+const GENERATED_SUMMARY_MAX_LENGTH = 60
+
+function buildSummaryTranscript(displayMessages: DisplayMessage[]): string {
+	return displayMessages
+		.filter((message) => message.role === 'user' || message.role === 'assistant')
+		.slice(0, 6)
+		.map((message) => `${message.role}: ${message.content}`)
+		.join('\n\n')
+		.slice(0, GENERATED_SUMMARY_MAX_TRANSCRIPT_CHARS)
+}
+
+function normalizeGeneratedSummary(summary: string | undefined): string | undefined {
+	const firstLine = summary
+		?.split('\n')
+		.map((line) => line.trim())
+		.find((line) => line.length > 0)
+	if (!firstLine) return undefined
+	const title = firstLine
+		.replace(/^title:\s*/i, '')
+		.replace(/^[-*]\s*/, '')
+		.replace(/^["'`]+|["'`]+$/g, '')
+		.replace(/[.!?]+$/g, '')
+		.replace(/\s+/g, ' ')
+		.trim()
+	if (!/[A-Za-z0-9]/.test(title)) return undefined
+	if (title.length <= GENERATED_SUMMARY_MAX_LENGTH) return title
+	return title.slice(0, GENERATED_SUMMARY_MAX_LENGTH).trim()
+}
+
+async function generateSessionSummary(displayMessages: DisplayMessage[]): Promise<string | undefined> {
+	const transcript = buildSummaryTranscript(displayMessages)
+	if (!transcript) return undefined
+	const abortController = new AbortController()
+	const timeout = setTimeout(() => abortController.abort(), GENERATED_SUMMARY_TIMEOUT_MS)
+	const messages: ChatCompletionMessageParam[] = [
+		{
+			role: 'system',
+			content:
+				'Name this AI chat session. Return only a concise title, 2 to 6 words, no quotes, no period.'
+		},
+		{
+			role: 'user',
+			content: `Conversation:\n${transcript}`
+		}
+	]
+	try {
+		return normalizeGeneratedSummary(await getNonStreamingCompletion(messages, abortController))
+	} finally {
+		clearTimeout(timeout)
+	}
+}
+
+async function generateAndApplySessionSummary(sessionId: string, manager: AIChatManager) {
+	const session = sessionState.sessions.find((s) => s.id === sessionId)
+	if (!session || session.summarySource !== 'placeholder') return
+	const chatId = session.chatId
+	if (!chatId) return
+	const title = await generateSessionSummary([...manager.displayMessages])
+	if (!title) return
+	setGeneratedSessionSummary(sessionId, title, chatId)
+}
+
 function createRuntime(session: Session): SessionRuntime {
 	const manager = new AIChatManager()
 	manager.disabledModes = { navigator: true }
@@ -173,6 +241,7 @@ function createRuntime(session: Session): SessionRuntime {
 			)
 		}
 	}
+	manager.afterFirstTurnSaved = () => generateAndApplySessionSummary(session.id, manager)
 
 	const flowStore: StateStore<Flow> = $state({ val: emptyFlow() })
 	const flowStateStore: { val: Record<string, any> } = $state({ val: {} })

--- a/frontend/src/lib/components/sessions/sessionState.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionState.svelte.ts
@@ -95,6 +95,8 @@ export type PendingFork = {
 	name: string
 }
 
+export type SessionSummarySource = 'placeholder' | 'generated' | 'manual'
+
 export type Session = {
 	id: string
 	name: string
@@ -113,6 +115,7 @@ export type Session = {
 	chatId?: string
 	target?: SessionTarget
 	summary?: string
+	summarySource?: SessionSummarySource
 	createdAt: number
 	// User-archived sessions are hidden from the sidebar by default
 	// (toggleable via the picker filter). Archive is reversible — distinct
@@ -153,6 +156,15 @@ function loadSessions(): Session[] {
 					}
 					if (s.target?.kind === 'rawapp') {
 						s.target.kind = 'raw_app'
+						mutated = true
+					}
+					if (
+						s.summarySource !== undefined &&
+						s.summarySource !== 'placeholder' &&
+						s.summarySource !== 'generated' &&
+						s.summarySource !== 'manual'
+					) {
+						s.summarySource = 'manual'
 						mutated = true
 					}
 				}
@@ -238,6 +250,7 @@ export function createSession(): Session {
 		id: createLongHash(),
 		name: `session-${next}`,
 		summary,
+		summarySource: 'placeholder',
 		pending_workspace_id: pending && pending.length > 0 ? pending : undefined,
 		createdAt: Date.now(),
 		transient: true
@@ -343,7 +356,10 @@ export function setSessionTarget(id: string, target: SessionTarget, summary?: st
 	const s = sessionState.sessions.find((x) => x.id === id)
 	if (!s) return
 	s.target = target
-	if (!s.summary && summary) s.summary = summary
+	if (!s.summary && summary) {
+		s.summary = summary
+		s.summarySource = 'generated'
+	}
 	persistSessions()
 }
 
@@ -356,7 +372,25 @@ export function renameSession(id: string, newSummary: string) {
 	const s = sessionState.sessions.find((x) => x.id === id)
 	if (!s) return
 	s.summary = trimmed.length > 0 ? trimmed : undefined
+	s.summarySource = 'manual'
 	persistSessions()
+}
+
+export function setGeneratedSessionSummary(
+	id: string,
+	newSummary: string,
+	expectedChatId?: string
+): boolean {
+	const trimmed = newSummary.trim()
+	if (!trimmed) return false
+	const s = sessionState.sessions.find((x) => x.id === id)
+	if (!s) return false
+	if (expectedChatId && s.chatId !== expectedChatId) return false
+	if (s.summarySource !== 'placeholder') return false
+	s.summary = trimmed
+	s.summarySource = 'generated'
+	persistSessions()
+	return true
 }
 
 // Create a new fork workspace via the API, refresh the user-workspaces

--- a/frontend/src/lib/components/sessions/sessionState.test.ts
+++ b/frontend/src/lib/components/sessions/sessionState.test.ts
@@ -4,6 +4,8 @@ import {
 	commitSessionWorkspace,
 	deriveForkStatus,
 	isForkSession,
+	renameSession,
+	setGeneratedSessionSummary,
 	sessionState,
 	type Session
 } from './sessionState.svelte'
@@ -191,6 +193,52 @@ describe('commitSessionWorkspace — workspaceStore sync (non-fork branch)', () 
 			const i = sessionState.sessions.findIndex((x) => x.id === id)
 			if (i >= 0) sessionState.sessions.splice(i, 1)
 			workspaceStore.set(prev)
+		}
+	})
+})
+
+describe('session summary generation guards', () => {
+	it('applies a generated summary only while the placeholder is still untouched', () => {
+		const id = 'test-generated-summary'
+		sessionState.sessions.push({
+			id,
+			name: 'generated-summary',
+			createdAt: 0,
+			chatId: 'chat-1',
+			summary: 'Bright session',
+			summarySource: 'placeholder'
+		} as Session)
+		try {
+			expect(setGeneratedSessionSummary(id, 'Build invoice workflow', 'chat-1')).toBe(true)
+			const s = sessionState.sessions.find((x) => x.id === id)
+			expect(s?.summary).toBe('Build invoice workflow')
+			expect(s?.summarySource).toBe('generated')
+		} finally {
+			const i = sessionState.sessions.findIndex((x) => x.id === id)
+			if (i >= 0) sessionState.sessions.splice(i, 1)
+		}
+	})
+
+	it('does not overwrite a manual rename or a different chat id', () => {
+		const id = 'test-generated-summary-manual'
+		sessionState.sessions.push({
+			id,
+			name: 'generated-summary-manual',
+			createdAt: 0,
+			chatId: 'chat-1',
+			summary: 'Bright session',
+			summarySource: 'placeholder'
+		} as Session)
+		try {
+			expect(setGeneratedSessionSummary(id, 'Wrong chat title', 'chat-2')).toBe(false)
+			renameSession(id, 'My chosen title')
+			expect(setGeneratedSessionSummary(id, 'Generated title', 'chat-1')).toBe(false)
+			const s = sessionState.sessions.find((x) => x.id === id)
+			expect(s?.summary).toBe('My chosen title')
+			expect(s?.summarySource).toBe('manual')
+		} finally {
+			const i = sessionState.sessions.findIndex((x) => x.id === id)
+			if (i >= 0) sessionState.sessions.splice(i, 1)
 		}
 	})
 })


### PR DESCRIPTION
## Summary
Automatically replaces the placeholder name for a new `/sessions` AI chat with a concise AI-generated title after the first completed chat turn. The URL slug remains stable, and manual renames are protected from being overwritten by the background generation.

## Changes
- Add `summarySource` tracking for session names (`placeholder`, `generated`, `manual`).
- Add an async `afterFirstTurnSaved` hook in `AIChatManager` and wire session runtimes to call the existing non-streaming AI proxy for title generation.
- Guard generated-title application by session id, chat id, and summary source so stale responses or manual renames are ignored.
- Route session header renames through the canonical `renameSession` helper.
- Add unit tests for generated-title guard behavior.

## Test plan
- [x] `npm run check:fast`
- [x] `npm run test:unit -- sessionState.test.ts --run`
- [x] `npm run check`
- [x] `git diff --check`
- [x] Browser smoke test: log in, enable sessions flag, create a session, verify generated-summary state updates the visible session title
- [x] Fresh-context local review: no issues found

## Notes
- Actual first-prompt title generation depends on configured AI provider availability; this PR is opened as draft for review before merge.
- Follow-up: let users decide which model to use for small background AI tasks like session-name generation.