### PR TITLE
feat: handle CTRL_BREAK_EVENT for graceful shutdown on Windows (WIN-2003)

### DIFF
--- a/backend/windmill-common/src/lib.rs
+++ b/backend/windmill-common/src/lib.rs
@@ -282,6 +282,12 @@ pub async fn shutdown_signal(
         Ok(())
     }
 
+    #[cfg(windows)]
+    async fn ctrl_break() -> std::io::Result<()> {
+        tokio::signal::windows::ctrl_break()?.recv().await;
+        Ok(())
+    }
+
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     tokio::select! {
         _ = terminate() => {
@@ -297,7 +303,13 @@ pub async fn shutdown_signal(
 
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     tokio::select! {
-        _ = tokio::signal::ctrl_c() => {},
+        _ = tokio::signal::ctrl_c() => {
+            tracing::info!("shutdown monitor received ctrl-c");
+        },
+        #[cfg(windows)]
+        _ = ctrl_break() => {
+            tracing::info!("shutdown monitor received ctrl-break");
+        },
         _ = rx.recv() => {
             tracing::info!("shutdown monitor received killpill");
         },
@@ -318,6 +330,10 @@ pub async fn shutdown_signal(
         tokio::select! {
             _ = tokio::signal::ctrl_c() => {
                 tracing::error!("2nd shutdown monitor received ctrl-c")
+            },
+            #[cfg(windows)]
+            _ = ctrl_break() => {
+                tracing::error!("2nd shutdown monitor received ctrl-break")
             },
         }
 


### PR DESCRIPTION
## Problem

On Windows, `shutdown_signal` in `windmill-common/src/lib.rs` only registered `tokio::signal::ctrl_c()` (CTRL_C_EVENT) for the non-Linux/macOS code paths. `CTRL_BREAK_EVENT` — the default kill signal sent by Nomad's `raw_exec` driver on Windows — had no handler, so the worker process terminated immediately without graceful shutdown, interrupting running jobs.

## Fix

Added a `ctrl_break()` helper (mirroring the existing Unix `terminate()` helper) inside `shutdown_signal`:

```rust
#[cfg(windows)]
async fn ctrl_break() -> std::io::Result<()> {
    tokio::signal::windows::ctrl_break()?.recv().await;
    Ok(())
}
```

and registered it as an additional `#[cfg(windows)]` branch in both Windows `tokio::select!` blocks (the main shutdown monitor and the force-exit handler). `tokio::signal::windows::ctrl_break()` is available because the tokio workspace dependency already uses `features = ["full"]`.

Also gave the previously-empty `ctrl_c()` branch in the first Windows block a `tracing::info!` log for consistency with the other branches.

## Scope

- `backend/windmill-common/src/lib.rs`

## Validation

- The change is `#[cfg(windows)]`-gated, so it is not compiled by the Linux dev build. I attempted a `cargo check -p windmill-common --target x86_64-pc-windows-gnu` cross-compile, but it failed building the transitive `ring` crate's C code because the `x86_64-w64-mingw32-gcc` cross-compiler is not installed on this box (and no passwordless sudo to add it) — this is a toolchain limitation, unrelated to the change.
- The added code mirrors the existing, working Unix `terminate()` helper and uses the standard, documented `tokio::signal::windows` API. `#[cfg(windows)]` attributes on `tokio::select!` branches are valid macro syntax.
- Marked as draft pending a CI Windows build to confirm compilation.

Fixes WIN-2003

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle `CTRL_BREAK_EVENT` in Windows shutdown to allow graceful worker shutdown when Nomad `raw_exec` sends a break signal, preventing abrupt job interruption. Fixes WIN-2003.

- **Bug Fixes**
  - Added `ctrl_break()` using `tokio::signal::windows::ctrl_break()` and registered it in both Windows `tokio::select!` blocks.
  - Added logs for `ctrl_c` and `ctrl_break` events.
  - Windows-only change in `backend/windmill-common/src/lib.rs` guarded with `#[cfg(windows)]`.

<sup>Written for commit 1327252d3f1afdbd59ef67373be4eb8d386d21b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

