### PR TITLE
fix(backend): Windows build broken by #[cfg] on tokio::select! branch (#9400 regression)

### DIFF
--- a/backend/windmill-common/src/lib.rs
+++ b/backend/windmill-common/src/lib.rs
@@ -282,10 +282,22 @@ pub async fn shutdown_signal(
         Ok(())
     }
 
-    #[cfg(windows)]
+    // Defined for the whole non-unix scope (not just windows) so it can be a
+    // plain `tokio::select!` branch: that macro does not accept `#[cfg(...)]`
+    // attributes on individual branches. On non-windows non-unix targets the
+    // future never resolves, so the branch is effectively inert there.
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     async fn ctrl_break() -> std::io::Result<()> {
-        tokio::signal::windows::ctrl_break()?.recv().await;
-        Ok(())
+        #[cfg(windows)]
+        {
+            tokio::signal::windows::ctrl_break()?.recv().await;
+            Ok(())
+        }
+        #[cfg(not(windows))]
+        {
+            std::future::pending::<()>().await;
+            Ok(())
+        }
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -306,7 +318,6 @@ pub async fn shutdown_signal(
         _ = tokio::signal::ctrl_c() => {
             tracing::info!("shutdown monitor received ctrl-c");
         },
-        #[cfg(windows)]
         _ = ctrl_break() => {
             tracing::info!("shutdown monitor received ctrl-break");
         },
@@ -331,7 +342,6 @@ pub async fn shutdown_signal(
             _ = tokio::signal::ctrl_c() => {
                 tracing::error!("2nd shutdown monitor received ctrl-c")
             },
-            #[cfg(windows)]
             _ = ctrl_break() => {
                 tracing::error!("2nd shutdown monitor received ctrl-break")
             },


### PR DESCRIPTION
## Problem

`windmill-common` fails to compile on Windows on current `main`:

```
error: no rules expected `}`
  --> windmill-common\src\lib.rs
   |   tokio::select! { ... }
   |   no rules expected this token in macro call
note: while trying to match `;`  (tokio .../macros/select.rs: `; $else:expr`)
error: could not compile `windmill-common` (lib) due to 2 previous errors
```

**Root cause:** #9400 (WIN-2003, "handle CTRL_BREAK_EVENT for graceful shutdown on Windows") added the `ctrl_break()` handler as a `#[cfg(windows)]` branch *inside* the two Windows-path `tokio::select!` blocks in `shutdown_signal`. `tokio::select!` does **not** accept `#[cfg(...)]` attributes on individual branches.

**Why CI missed it:** the only PR-triggered job that builds the backend on Windows is `cli-tests.yml`'s `test-windows`, which is gated to `cli/**` paths. #9400 was backend-only, so it never ran. `backend-test-windows.yml` only runs on `workflow_dispatch` / the `ci-windows-tests` branch / `v*` tags — not on PRs. The break surfaced on the next `cli/`-touching PR (#9402, WIN-2005).

## Fix

Define `ctrl_break()` for the whole `not(any(target_os = "linux", target_os = "macos"))` scope instead of just `windows`:
- On Windows: awaits the real `CTRL_BREAK` signal (unchanged behavior).
- On other non-unix targets: a never-resolving `std::future::pending()`, so the branch is inert there.

The `select!` branches then become plain (no per-branch `#[cfg]`), which the macro accepts. Behavior on every platform is unchanged.

## Validation

Cross-compiling here is blocked by a missing MinGW C toolchain (`ring`'s build script), and a Linux build can't catch this (the blocks are `cfg`'d out on Linux — macros in disabled code are never expanded, which is why Linux CI was green). So I validated the macro grammar directly against `tokio 1.46.1` in a minimal standalone project:

- **Broken form** (`#[cfg(windows)]` on a branch) → reproduces the exact `no rules expected this token in macro call` error.
- **Fixed form** (this PR's shape) → compiles clean, no warnings.

## Follow-up suggestion (not in this PR)

Consider making backend changes to core crates run a Windows compile check on PRs (e.g. add a paths filter / lightweight `cargo check --target *-pc-windows-*` job), so backend-only regressions like this are caught before merge instead of by the next CLI PR.

Fixes WIN-2003 (Windows build regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows build regression (WIN-2003) in `windmill-common` by moving the `ctrl_break()` handler out of `tokio::select!` branches and defining it for non-unix targets. Restores Windows compilation with no behavior changes.

- **Bug Fixes**
  - Define `ctrl_break()` under `#[cfg(not(any(target_os = "linux", target_os = "macos")))]`; on Windows it awaits CTRL_BREAK, on other non-unix it uses `std::future::pending()`.
  - Remove per-branch `#[cfg]` from `tokio::select!` to satisfy macro rules and fix the compile error.

<sup>Written for commit 9428dcf8942a6451421e5c0c330c73f1f2f51e76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

