### PR TITLE
fix: avoid crypto.randomUUID in WorkspaceItemDrillPicker

### DIFF
--- a/frontend/src/lib/components/WorkspaceItemDrillPicker.svelte
+++ b/frontend/src/lib/components/WorkspaceItemDrillPicker.svelte
@@ -20,6 +20,7 @@ Clicking a row drills *down*; the chevron-left in the header walks one level
 	import WorkspaceItemRow from '$lib/components/WorkspaceItemRow.svelte'
 	import SearchItems from '$lib/components/SearchItems.svelte'
 	import { onMount, untrack } from 'svelte'
+	import { generateRandomString } from '$lib/utils'
 	import {
 		dirKey,
 		getCachedItems,
@@ -65,7 +66,7 @@ Clicking a row drills *down*; the chevron-left in the header walks one level
 
 	let searchInput: TextInput | undefined = $state()
 	let pickerRoot: HTMLElement | undefined = $state()
-	const instanceId = crypto.randomUUID()
+	const instanceId = generateRandomString(8)
 	const listboxId = `pkr-list-${instanceId}`
 	const idFor = (key: string) => `pkr-${instanceId}-${key.replace(/[^a-zA-Z0-9-]/g, '_')}`
 


### PR DESCRIPTION
## Summary
`crypto.randomUUID()` is only available in secure contexts (HTTPS or localhost). On plain-HTTP deployments it is `undefined` and throws at component init, breaking `WorkspaceItemDrillPicker`. This swaps it for the existing `generateRandomString` helper, which uses `Math.random()` and works everywhere.

## Changes
- Replace `crypto.randomUUID()` with `generateRandomString(8)` for the per-instance DOM-ID prefix
- Import `generateRandomString` from `$lib/utils`

## Test plan
- [ ] Picker opens, drills down, and keyboard navigation works on a normal HTTPS/localhost build
- [ ] On a plain-HTTP deployment, the picker renders without a `crypto.randomUUID is not a function` console error