### PR TITLE
feat(frontend): harmonize diff button placement in script and raw app editors

### DIFF
--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -102,7 +102,6 @@
 	import DraftTriggersConfirmationModal from './common/confirmationModal/DraftTriggersConfirmationModal.svelte'
 	import { Triggers } from './triggers/triggers.svelte'
 	import type { ScriptBuilderProps } from './script_builder'
-	import type { DiffDrawerI } from './diff_drawer'
 	import WorkerTagSelect from './WorkerTagSelect.svelte'
 	import type { ButtonType } from './common/button/model'
 	import DebounceLimit from './flows/DebounceLimit.svelte'
@@ -832,8 +831,7 @@
 
 	function computeDropdownItems(
 		initialPath: string,
-		savedScript: NewScriptWithDraftAndDraftTriggers | undefined,
-		diffDrawer: DiffDrawerI | undefined
+		savedScript: NewScriptWithDraftAndDraftTriggers | undefined
 	) {
 		let dropdownItems: { label: string; onClick: () => void }[] =
 			initialPath != '' && customUi?.topBar?.extraDeployOptions != false
@@ -2091,7 +2089,7 @@
 				<DeployButton
 					loading={!fullyLoaded}
 					{loadingSave}
-					dropdownItems={computeDropdownItems(initialPath, savedScript, diffDrawer)}
+					dropdownItems={computeDropdownItems(initialPath, savedScript)}
 					on:save={({ detail }) => handleEditScript(false, detail)}
 				/>
 			</div>

--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -55,6 +55,7 @@
 		Bug,
 		CheckCircle,
 		Code,
+		DiffIcon,
 		EllipsisVertical,
 		Plus,
 		Rocket,
@@ -804,8 +805,30 @@
 	// Inside an AI session pane (which injects an aiChatManager via context) the
 	// extra deploy-dropdown options — Deploy & Stay here, Fork, Edit in workspace
 	// fork, Exit & See details, Export — don't make sense: the session always
-	// stays put and is already scoped to a fork. Only "Show diff" is kept.
+	// stays put and is already scoped to a fork. Diff is exposed as a standalone
+	// top-bar button (rendered independently of the session pane), not here.
 	const inSessionPane = !!getContext('aiChatManager')
+
+	async function openDiffDrawer() {
+		if (!savedScript) {
+			return
+		}
+		await syncWithDeployed()
+
+		const currentDraftTriggers = structuredClone(triggersState.getDraftTriggersSnapshot())
+
+		const deployed = deployedValue ?? savedScript
+		const current = { ...script, draft_triggers: currentDraftTriggers }
+		if (current.assets && !current.assets.length) delete current.assets
+
+		diffDrawer?.openDrawer()
+		diffDrawer?.setDiff({
+			mode: 'normal',
+			deployed,
+			draft: savedScript['draft'],
+			current
+		})
+	}
 
 	function computeDropdownItems(
 		initialPath: string,
@@ -839,35 +862,6 @@
 												}
 											]
 										: [])
-								]
-							: []),
-						...(customUi?.topBar?.diff !== false && savedScript && diffDrawer
-							? [
-									{
-										label: 'Show diff',
-										onClick: async () => {
-											if (!savedScript) {
-												return
-											}
-											await syncWithDeployed()
-
-											const currentDraftTriggers = structuredClone(
-												triggersState.getDraftTriggersSnapshot()
-											)
-
-											const deployed = deployedValue ?? savedScript
-											const current = { ...script, draft_triggers: currentDraftTriggers }
-											if (current.assets && !current.assets.length) delete current.assets
-
-											diffDrawer?.openDrawer()
-											diffDrawer?.setDiff({
-												mode: 'normal',
-												deployed,
-												draft: savedScript['draft'],
-												current
-											})
-										}
-									}
 								]
 							: []),
 						...(!inSessionPane &&
@@ -2035,6 +2029,21 @@
 						</Button>
 					{/if}
 				{/snippet}
+				{#snippet diffButton()}
+					{#if customUi?.topBar?.diff != false}
+						<Button
+							variant="default"
+							unifiedSize="md"
+							on:click={() => openDiffDrawer()}
+							disabled={!savedScript || !diffDrawer}
+							iconOnly={compactTopbar}
+							title="Diff"
+							startIcon={{ icon: DiffIcon }}
+						>
+							Diff
+						</Button>
+					{/if}
+				{/snippet}
 				{#if compactTopbar}
 					<DropdownV2 items={getCompactMenuItems} placement="bottom-end">
 						{#snippet buttonReplacement()}
@@ -2048,8 +2057,10 @@
 							/>
 						{/snippet}
 					</DropdownV2>
+					{@render diffButton()}
 					{@render settingsButton()}
 				{:else}
+					{@render diffButton()}
 					{#if customUi?.topBar?.tagEdit != false}
 						{#if $workerTags}
 							{#if $workerTags?.length ?? 0 > 0}

--- a/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
@@ -364,6 +364,29 @@
 		})
 	}
 
+	async function openDiffDrawer() {
+		if (!savedApp) {
+			return
+		}
+
+		// deployedValue should be syncronized when we open Diff
+		await syncWithDeployed()
+
+		diffDrawer?.openDrawer()
+		diffDrawer?.setDiff({
+			mode: 'normal',
+			deployed: deployedValue ?? savedApp,
+			draft: savedApp.draft,
+			current: {
+				summary: summary,
+				value: app,
+				path: newEditedPath || savedApp.draft?.path || savedApp.path,
+				policy,
+				custom_path: customPath
+			}
+		})
+	}
+
 	async function updateApp(npath: string) {
 		if (!app) {
 			sendUserToast(`App hasn't been loaded yet`, true)
@@ -682,33 +705,6 @@
 			action: () => {
 				publishToHubDrawerOpen = true
 			}
-		},
-		{
-			displayName: 'Diff',
-			icon: DiffIcon,
-			action: async () => {
-				if (!savedApp) {
-					return
-				}
-
-				// deployedValue should be syncronized when we open Diff
-				await syncWithDeployed()
-
-				diffDrawer?.openDrawer()
-				diffDrawer?.setDiff({
-					mode: 'normal',
-					deployed: deployedValue ?? savedApp,
-					draft: savedApp.draft,
-					current: {
-						summary: summary,
-						value: app,
-						path: newEditedPath || savedApp.draft?.path || savedApp.path,
-						policy,
-						custom_path: customPath
-					}
-				})
-			},
-			disabled: !savedApp
 		}
 	])
 
@@ -964,6 +960,18 @@
 				></Button>
 			{/snippet}
 		</DropdownV2>
+
+		<Button
+			variant="default"
+			unifiedSize="md"
+			on:click={() => openDiffDrawer()}
+			disabled={!savedApp}
+			iconOnly={compactTopbar}
+			title="Diff"
+			startIcon={{ icon: DiffIcon }}
+		>
+			Diff
+		</Button>
 
 		<div class="{compactTopbar ? 'hidden' : 'hidden md:inline'} relative overflow-visible">
 			<Button

--- a/frontend/src/lib/components/sessions/ScriptEditorView.svelte
+++ b/frontend/src/lib/components/sessions/ScriptEditorView.svelte
@@ -184,7 +184,7 @@
 		ScriptBuilder behaves exactly like /scripts/add — Save draft is enabled and
 		creates it on first save. On that save ScriptBuilder writes savedScript back
 		through the bind and sets its own initialPath to the path, flipping us into
-		edit mode (Save draft + Show diff) without navigating away.
+		edit mode (Save draft + Diff) without navigating away.
 	-->
 	<ScriptBuilder
 		bind:script={runtime.scriptStore.val}


### PR DESCRIPTION
## Summary

The "Diff" button (which opens the full `DiffDrawer` — code + metadata + triggers) lived in a different place in each editor: a `DeployButton` split-dropdown entry in the standalone script editor, and a "more" dropdown item in the raw app editor. This PR harmonizes them to follow the **flow editor's pattern** (`FlowBuilder.svelte`): a standalone top-bar button placed right after the overflow "⋮" menu.

Scope is limited to the **standalone script editor** and the **raw app editor**. Simple/normal apps (`AppEditorHeader.svelte`) are intentionally left unchanged. The inline `EditorBar` diff toggle, Debug/breakpoints, and the in-save-drawer Diff buttons are also untouched.

## Changes

- **Canonical spec** (matching `FlowBuilder`): standalone top-bar `Button`, `variant="default"`, `unifiedSize="md"`, `DiffIcon`, label "Diff", disabled when there's no saved/deployed version, `iconOnly` when the top bar is compact, placed immediately after the overflow menu.
- **`ScriptBuilder.svelte`**: extracted `openDiffDrawer()`, removed the "Show diff" entry from the `DeployButton` split-dropdown, added a `diffButton` snippet rendered in both compact and wide layouts (leads the action cluster). Updated the now-stale `inSessionPane` comment.
- **`RawAppEditorHeader.svelte`**: extracted `openDiffDrawer()`, removed the duplicate `moreItems` "Diff" entry, added the standalone button right after `<DropdownV2>`.

The extracted `openDiffDrawer()` functions preserve the exact prior payload logic (deployed/draft/current, `syncWithDeployed()`, draft-triggers and empty-assets handling for scripts).

## Test plan

- [x] Script editor: Diff button leads the action cluster, disabled on new scripts, enabled on deployed scripts → opens `DiffDrawer`
- [x] Raw App editor: Diff button right after the ⋮ menu → opens side-by-side metadata+content diff
- [x] `npm run check:fast` passes for the changed files
- [x] Verify icon-only collapse when the top bar is narrow (compact) — confirmed in browser for both editors at 640px (single icon-only Diff button, 32px, visible)
- [ ] Verify script diff still works from inside an AI session pane
- [ ] Verify `customUi.topBar.diff = false` still hides the ScriptBuilder button

🤖 Generated with [Claude Code](https://claude.com/claude-code)