### PR TITLE
feat: gate session fork creation on CE workspace cap

### DIFF
--- a/frontend/src/lib/components/LocalDraftBanner.svelte
+++ b/frontend/src/lib/components/LocalDraftBanner.svelte
@@ -3,7 +3,7 @@
 	import DiffDrawer from '$lib/components/DiffDrawer.svelte'
 	import { classes } from '$lib/components/common/alert/model'
 	import { type Value } from '$lib/utils'
-	import { AlertCircle } from 'lucide-svelte'
+	import { AlertCircle, Diff } from 'lucide-svelte'
 	import { twMerge } from 'tailwind-merge'
 	import { slide } from 'svelte/transition'
 
@@ -84,7 +84,8 @@
 		<div class="flex flex-row items-center gap-2 shrink-0">
 			<Button
 				unifiedSize="sm"
-				variant="subtle"
+				variant="default"
+				startIcon={{ icon: Diff }}
 				btnClasses={classes.warning.titleClass}
 				on:click={showDiff}>Show diff</Button
 			>

--- a/frontend/src/lib/components/sessions/SessionForkBar.svelte
+++ b/frontend/src/lib/components/sessions/SessionForkBar.svelte
@@ -2,6 +2,7 @@
 	import {
 		Archive,
 		ArrowRight,
+		Diff,
 		GitCompareArrows,
 		GitFork,
 		GitMerge,
@@ -189,9 +190,9 @@
 		</div>
 		<div class="flex items-center gap-1 shrink-0">
 			<Button
-				variant="subtle"
+				variant="default"
 				unifiedSize="xs"
-				startIcon={{ icon: GitCompareArrows }}
+				startIcon={{ icon: Diff }}
 				disabled={totalDiffs === 0}
 				title="{totalDiffs} modified item{totalDiffs === 1 ? '' : 's'}"
 				onclick={() => diffDrawer?.open()}

--- a/frontend/src/lib/components/sessions/WorkspaceFamilyPicker.svelte
+++ b/frontend/src/lib/components/sessions/WorkspaceFamilyPicker.svelte
@@ -1,11 +1,17 @@
 <script lang="ts">
 	import { tick, type Snippet } from 'svelte'
-	import { userWorkspaces, workspaceStore, type UserWorkspace } from '$lib/stores'
+	import {
+		enterpriseLicense,
+		userWorkspaces,
+		workspaceStore,
+		type UserWorkspace
+	} from '$lib/stores'
 	import { findWorkspaceDescendants } from '$lib/utils/workspaceHierarchy'
 	import { isRuleActive } from '$lib/workspaceProtectionRules.svelte'
 	import { isCloudHosted } from '$lib/cloud'
 	import { random_adj } from '$lib/components/random_positive_adjetive'
 	import DropdownV2 from '$lib/components/DropdownV2.svelte'
+	import EEOnly from '$lib/components/EEOnly.svelte'
 	import InputError from '$lib/components/InputError.svelte'
 	import TextInput from '$lib/components/text_input/TextInput.svelte'
 	import { Building, Check, GitFork, Plus } from 'lucide-svelte'
@@ -56,11 +62,19 @@
 	const root = $derived(findRoot(effectiveId, $userWorkspaces))
 	const forks = $derived(root ? findWorkspaceDescendants(root.id, $userWorkspaces) : [])
 
-	// Same gate as the sidebar WorkspaceMenu / SessionWorkspaceBar.
+	// Structural gate, same as the sidebar WorkspaceMenu / SessionWorkspaceBar:
+	// when closed (cloud / DisableWorkspaceForking rule / admins workspace) the
+	// fork affordance is hidden entirely.
 	const forksGateOpen = $derived(
 		!isCloudHosted() && !isRuleActive('DisableWorkspaceForking') && $workspaceStore !== 'admins'
 	)
-	const showCreateFork = $derived(allowCreateFork && forksGateOpen && !!onCreateFork && !!root)
+	// Forking workspaces requires an enterprise license. The interactive
+	// create-fork row is only shown when licensed; otherwise (structural gate
+	// open but unlicensed) we surface a disabled EE upsell row instead — never
+	// stage a fork the backend would reject.
+	const forkAffordanceOpen = $derived(allowCreateFork && forksGateOpen && !!onCreateFork && !!root)
+	const showCreateFork = $derived(forkAffordanceOpen && !!$enterpriseLicense)
+	const showForkUpsell = $derived(forkAffordanceOpen && !$enterpriseLicense)
 
 	let dropdownOpen = $state(false)
 	let creatingFork = $state(false)
@@ -270,6 +284,15 @@
 						<span>Create new fork…</span>
 					</button>
 				{/if}
+				<div class="my-1 border-t border-border-light shrink-0"></div>
+			{:else if showForkUpsell}
+				<div class={`${rowBase} opacity-60 cursor-not-allowed`} aria-disabled="true">
+					<Plus size={14} class="shrink-0 text-tertiary" />
+					<span>Create new fork…</span>
+					<span class="ml-auto shrink-0">
+						<EEOnly>Workspace forking requires an enterprise license</EEOnly>
+					</span>
+				</div>
 				<div class="my-1 border-t border-border-light shrink-0"></div>
 			{/if}
 

--- a/frontend/src/lib/components/sessions/WorkspaceFamilyPicker.svelte
+++ b/frontend/src/lib/components/sessions/WorkspaceFamilyPicker.svelte
@@ -11,7 +11,6 @@
 	import { isCloudHosted } from '$lib/cloud'
 	import { random_adj } from '$lib/components/random_positive_adjetive'
 	import DropdownV2 from '$lib/components/DropdownV2.svelte'
-	import EEOnly from '$lib/components/EEOnly.svelte'
 	import InputError from '$lib/components/InputError.svelte'
 	import TextInput from '$lib/components/text_input/TextInput.svelte'
 	import { Building, Check, GitFork, Plus } from 'lucide-svelte'
@@ -68,13 +67,23 @@
 	const forksGateOpen = $derived(
 		!isCloudHosted() && !isRuleActive('DisableWorkspaceForking') && $workspaceStore !== 'admins'
 	)
-	// Forking workspaces requires an enterprise license. The interactive
-	// create-fork row is only shown when licensed; otherwise (structural gate
-	// open but unlicensed) we surface a disabled EE upsell row instead — never
-	// stage a fork the backend would reject.
+	// A fork is a new workspace, so it's subject to the community-edition cap on
+	// the number of non-'admins' workspaces (backend _check_nb_of_workspaces,
+	// run only on community builds). An enterprise license lifts the cap. We
+	// mirror the backend count with the client-side workspace list to hide the
+	// affordance once the cap is reached; the server still enforces the real
+	// (instance-wide) check on commit, so this is purely UX.
+	const CE_MAX_NON_ADMIN_WORKSPACES = 2
+	const nonAdminWorkspaceCount = $derived($userWorkspaces.filter((w) => w.id !== 'admins').length)
+	const ceWorkspaceCapReached = $derived(
+		!$enterpriseLicense && nonAdminWorkspaceCount >= CE_MAX_NON_ADMIN_WORKSPACES
+	)
+	// The interactive create-fork row is shown unless the cap is reached;
+	// otherwise (structural gate open but cap hit) we surface a disabled row
+	// explaining the limit — never stage a fork the backend would reject.
 	const forkAffordanceOpen = $derived(allowCreateFork && forksGateOpen && !!onCreateFork && !!root)
-	const showCreateFork = $derived(forkAffordanceOpen && !!$enterpriseLicense)
-	const showForkUpsell = $derived(forkAffordanceOpen && !$enterpriseLicense)
+	const showCreateFork = $derived(forkAffordanceOpen && !ceWorkspaceCapReached)
+	const showForkUpsell = $derived(forkAffordanceOpen && ceWorkspaceCapReached)
 
 	let dropdownOpen = $state(false)
 	let creatingFork = $state(false)
@@ -286,12 +295,15 @@
 				{/if}
 				<div class="my-1 border-t border-border-light shrink-0"></div>
 			{:else if showForkUpsell}
-				<div class={`${rowBase} opacity-60 cursor-not-allowed`} aria-disabled="true">
+				<div
+					class={`${rowBase} opacity-60 cursor-not-allowed`}
+					aria-disabled="true"
+					title="Community edition is limited to {CE_MAX_NON_ADMIN_WORKSPACES +
+						1} workspaces. Archive a workspace or upgrade to an enterprise license to create more forks."
+				>
 					<Plus size={14} class="shrink-0 text-tertiary" />
 					<span>Create new fork…</span>
-					<span class="ml-auto shrink-0">
-						<EEOnly>Workspace forking requires an enterprise license</EEOnly>
-					</span>
+					<span class="ml-auto shrink-0 text-2xs text-tertiary"> Workspace limit reached </span>
 				</div>
 				<div class="my-1 border-t border-border-light shrink-0"></div>
 			{/if}

--- a/frontend/src/lib/components/sessions/sessionState.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionState.svelte.ts
@@ -297,14 +297,20 @@ export async function commitSessionWorkspace(
 
 	if (s.pending_fork) {
 		const fork = s.pending_fork
-		// Defense-in-depth against a stale pending_fork (e.g. staged before the
-		// instance dropped its enterprise license, or any future entry point):
-		// forking requires a license, so block the commit with an explicit error
-		// rather than letting materializeFork hit a backend rejection. Keep the
-		// pending fork set so the block persists until the user picks a non-fork
-		// workspace (setSessionPendingWorkspace clears it).
-		if (!get(enterpriseLicense)) {
-			throw new Error('Forking requires an enterprise license — pick a workspace to run in')
+		// Defense-in-depth against a stale pending_fork (e.g. staged before
+		// another workspace was created, or any future entry point): a fork is a
+		// new workspace, and community edition caps the number of non-'admins'
+		// workspaces (backend _check_nb_of_workspaces). An enterprise license
+		// lifts the cap. Block the commit with an explicit error rather than
+		// letting materializeFork hit a backend rejection. Keep the pending fork
+		// set so the block persists until the user picks a non-fork workspace
+		// (setSessionPendingWorkspace clears it).
+		const CE_MAX_NON_ADMIN_WORKSPACES = 2
+		const nonAdminWorkspaceCount = get(userWorkspaces).filter((w) => w.id !== 'admins').length
+		if (!get(enterpriseLicense) && nonAdminWorkspaceCount >= CE_MAX_NON_ADMIN_WORKSPACES) {
+			throw new Error(
+				`Community edition is limited to ${CE_MAX_NON_ADMIN_WORKSPACES + 1} workspaces — archive a workspace or pick one to run in`
+			)
 		}
 		const newId = await materializeFork(fork)
 		if (!newId) {

--- a/frontend/src/lib/components/sessions/sessionState.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionState.svelte.ts
@@ -3,6 +3,7 @@ import { get } from 'svelte/store'
 import { createLongHash } from '$lib/editorLangUtils'
 import { random_adj } from '$lib/components/random_positive_adjetive'
 import {
+	enterpriseLicense,
 	userWorkspaces,
 	usersWorkspaceStore,
 	workspaceStore,
@@ -296,6 +297,15 @@ export async function commitSessionWorkspace(
 
 	if (s.pending_fork) {
 		const fork = s.pending_fork
+		// Defense-in-depth against a stale pending_fork (e.g. staged before the
+		// instance dropped its enterprise license, or any future entry point):
+		// forking requires a license, so block the commit with an explicit error
+		// rather than letting materializeFork hit a backend rejection. Keep the
+		// pending fork set so the block persists until the user picks a non-fork
+		// workspace (setSessionPendingWorkspace clears it).
+		if (!get(enterpriseLicense)) {
+			throw new Error('Forking requires an enterprise license — pick a workspace to run in')
+		}
 		const newId = await materializeFork(fork)
 		if (!newId) {
 			// Real failure (not a recovered duplicate). Drop the pending

--- a/frontend/src/lib/components/sessions/sessionState.test.ts
+++ b/frontend/src/lib/components/sessions/sessionState.test.ts
@@ -7,8 +7,8 @@ import {
 	sessionState,
 	type Session
 } from './sessionState.svelte'
-import { workspaceStore, type UserWorkspace } from '$lib/stores'
-import type { WorkspaceComparison } from '$lib/gen'
+import { enterpriseLicense, workspaceStore, type UserWorkspace } from '$lib/stores'
+import { WorkspaceService, type WorkspaceComparison } from '$lib/gen'
 
 // Force createWorkspaceFork to fail so we can pin commitSessionWorkspace's
 // failure contract (the invariant the beforeSend abort fix relies on).
@@ -121,6 +121,10 @@ describe('deriveForkStatus', () => {
 describe('commitSessionWorkspace — fork-creation failure', () => {
 	it('returns undefined and drops pending_fork (so beforeSend aborts the send)', async () => {
 		const id = 'test-commit-fork-fail'
+		// Forking is licensed here so the commit reaches materializeFork (which is
+		// mocked to fail); the unlicensed path is covered separately below.
+		const prevLicense = get(enterpriseLicense)
+		enterpriseLicense.set('test-license')
 		sessionState.sessions.push({
 			id,
 			name: 'fork-fail',
@@ -138,6 +142,35 @@ describe('commitSessionWorkspace — fork-creation failure', () => {
 		} finally {
 			const i = sessionState.sessions.findIndex((x) => x.id === id)
 			if (i >= 0) sessionState.sessions.splice(i, 1)
+			enterpriseLicense.set(prevLicense)
+		}
+	})
+})
+
+describe('commitSessionWorkspace — unlicensed fork guard', () => {
+	it('throws and never calls createWorkspaceFork without an enterprise license', async () => {
+		const id = 'test-commit-fork-unlicensed'
+		const prevLicense = get(enterpriseLicense)
+		enterpriseLicense.set(undefined)
+		vi.mocked(WorkspaceService.createWorkspaceFork).mockClear()
+		sessionState.sessions.push({
+			id,
+			name: 'fork-unlicensed',
+			createdAt: 0,
+			pending_fork: { parent_workspace_id: 'parent_ws', id: 'wm-fork-ee', name: 'ee' }
+		} as Session)
+		try {
+			await expect(commitSessionWorkspace(id, 'parent_ws')).rejects.toThrow(/enterprise license/)
+			expect(WorkspaceService.createWorkspaceFork).not.toHaveBeenCalled()
+			// pending_fork is preserved so the block persists until the user picks a
+			// non-fork workspace (which clears it via setSessionPendingWorkspace).
+			const s = sessionState.sessions.find((x) => x.id === id)
+			expect(s?.pending_fork).toBeDefined()
+			expect(s?.workspace_id).toBeUndefined()
+		} finally {
+			const i = sessionState.sessions.findIndex((x) => x.id === id)
+			if (i >= 0) sessionState.sessions.splice(i, 1)
+			enterpriseLicense.set(prevLicense)
 		}
 	})
 })

--- a/frontend/src/lib/components/sessions/sessionState.test.ts
+++ b/frontend/src/lib/components/sessions/sessionState.test.ts
@@ -7,7 +7,12 @@ import {
 	sessionState,
 	type Session
 } from './sessionState.svelte'
-import { enterpriseLicense, workspaceStore, type UserWorkspace } from '$lib/stores'
+import {
+	enterpriseLicense,
+	usersWorkspaceStore,
+	workspaceStore,
+	type UserWorkspace
+} from '$lib/stores'
 import { WorkspaceService, type WorkspaceComparison } from '$lib/gen'
 
 // Force createWorkspaceFork to fail so we can pin commitSessionWorkspace's
@@ -147,20 +152,33 @@ describe('commitSessionWorkspace — fork-creation failure', () => {
 	})
 })
 
-describe('commitSessionWorkspace — unlicensed fork guard', () => {
-	it('throws and never calls createWorkspaceFork without an enterprise license', async () => {
-		const id = 'test-commit-fork-unlicensed'
+// Set the workspace list to a given number of non-'admins' workspaces so the
+// commit-path's CE workspace-cap check (mirror of backend _check_nb_of_workspaces)
+// can be exercised. Returns a restore fn.
+function withNonAdminWorkspaces(count: number): () => void {
+	const prev = get(usersWorkspaceStore)
+	const workspaces = Array.from({ length: count }, (_, i) => ws(`ws_${i}`))
+	usersWorkspaceStore.set({ email: 't@t', workspaces } as never)
+	return () => usersWorkspaceStore.set(prev)
+}
+
+describe('commitSessionWorkspace — CE workspace-cap fork guard', () => {
+	it('throws and never calls createWorkspaceFork when the CE workspace cap is reached', async () => {
+		const id = 'test-commit-fork-capped'
 		const prevLicense = get(enterpriseLicense)
 		enterpriseLicense.set(undefined)
+		// At/above the cap (2 non-'admins' workspaces) the backend would reject, so
+		// the client guard blocks the commit before materializeFork.
+		const restoreWs = withNonAdminWorkspaces(2)
 		vi.mocked(WorkspaceService.createWorkspaceFork).mockClear()
 		sessionState.sessions.push({
 			id,
-			name: 'fork-unlicensed',
+			name: 'fork-capped',
 			createdAt: 0,
-			pending_fork: { parent_workspace_id: 'parent_ws', id: 'wm-fork-ee', name: 'ee' }
+			pending_fork: { parent_workspace_id: 'parent_ws', id: 'wm-fork-capped', name: 'capped' }
 		} as Session)
 		try {
-			await expect(commitSessionWorkspace(id, 'parent_ws')).rejects.toThrow(/enterprise license/)
+			await expect(commitSessionWorkspace(id, 'parent_ws')).rejects.toThrow(/limited to/)
 			expect(WorkspaceService.createWorkspaceFork).not.toHaveBeenCalled()
 			// pending_fork is preserved so the block persists until the user picks a
 			// non-fork workspace (which clears it via setSessionPendingWorkspace).
@@ -170,6 +188,36 @@ describe('commitSessionWorkspace — unlicensed fork guard', () => {
 		} finally {
 			const i = sessionState.sessions.findIndex((x) => x.id === id)
 			if (i >= 0) sessionState.sessions.splice(i, 1)
+			restoreWs()
+			enterpriseLicense.set(prevLicense)
+		}
+	})
+
+	it('lets an unlicensed user under the cap proceed to createWorkspaceFork', async () => {
+		const id = 'test-commit-fork-under-cap'
+		const prevLicense = get(enterpriseLicense)
+		enterpriseLicense.set(undefined)
+		// Below the cap (1 non-'admins' workspace) CE still allows a fork — the
+		// guard must NOT fire. createWorkspaceFork is mocked to reject, so the
+		// commit falls through to the failure contract (undefined, pending dropped).
+		const restoreWs = withNonAdminWorkspaces(1)
+		vi.mocked(WorkspaceService.createWorkspaceFork).mockClear()
+		sessionState.sessions.push({
+			id,
+			name: 'fork-under-cap',
+			createdAt: 0,
+			pending_fork: { parent_workspace_id: 'parent_ws', id: 'wm-fork-ok', name: 'ok' }
+		} as Session)
+		try {
+			const committed = await commitSessionWorkspace(id, 'parent_ws')
+			expect(committed).toBeUndefined()
+			expect(WorkspaceService.createWorkspaceFork).toHaveBeenCalled()
+			const s = sessionState.sessions.find((x) => x.id === id)
+			expect(s?.pending_fork).toBeUndefined()
+		} finally {
+			const i = sessionState.sessions.findIndex((x) => x.id === id)
+			if (i >= 0) sessionState.sessions.splice(i, 1)
+			restoreWs()
 			enterpriseLicense.set(prevLicense)
 		}
 	})


### PR DESCRIPTION
## Summary

Forking a workspace is **not** an enterprise-only feature — CE (community edition / no enterprise license) simply caps the **number of workspaces**. The backend `_check_nb_of_workspaces` rejects creating a new workspace once there are ≥ 2 non-`admins` workspaces (3 total, incl. `admins`), and a fork *is* a new workspace. Previously CE users could stage a fork in the sessions workspace picker even when already at the cap; it would only fail later, server-side, after they committed by sending their first message.

This gates the session "Create new fork" affordance on the **CE workspace cap** (mirroring the backend), not on the enterprise license: licensed instances are uncapped, unlicensed instances allow forks only while under the cap.

## Changes

- **`WorkspaceFamilyPicker.svelte`** (session-only picker, used by both `SessionWorkspaceBar` and `SessionForkBar`): split the structural gate (`forkAffordanceOpen` = cloud / `DisableWorkspaceForking` rule / `admins`) from the cap check. `ceWorkspaceCapReached = !$enterpriseLicense && nonAdminWorkspaceCount >= 2`. `showCreateFork` keeps the interactive row; `showForkUpsell` renders a disabled, non-keyboard-focusable row (`aria-disabled`) with a *"Workspace limit reached"* hint and a tooltip explaining the CE 3-workspace limit and that archiving a workspace or an enterprise license lifts it.
- **`sessionState.svelte.ts`** → `commitSessionWorkspace`: before `materializeFork`, when a `pending_fork` is committed while unlicensed **and** at the cap, throw *"Community edition is limited to 3 workspaces — archive a workspace or pick one to run in"*. `pending_fork` is preserved so the block persists until the user picks a non-fork workspace (which clears it via `setSessionPendingWorkspace`). The throw propagates through `beforeSend` and aborts the send.
- **`sessionState.test.ts`**: added a CE-cap fork-guard test (at cap → throws, `createWorkspaceFork` never called, `pending_fork`/`workspace_id` intact) and an under-cap test (unlicensed but below cap → fork proceeds). Updated the existing fork-creation-failure test to set a license so it still reaches `materializeFork`. All restore store state in `finally`.
- Minor adjacent polish on the same sessions surface: the diff-drawer button in `SessionForkBar.svelte` and `LocalDraftBanner.svelte` is now `variant="default"` with the `Diff` (+/-) icon and the modified-item count, to make the diff entry point more prominent.

Untouched: backend (remains the hard, instance-wide enforcement boundary), sidebar `WorkspaceMenu`, and `SessionForkBar.forksAllowed` (existing-fork review still works in CE).

### Known limitation (preflight only)

The client cap check counts `$userWorkspaces` (the current user's membership-scoped list), whereas the backend cap is instance-wide. On a multi-user CE instance a user who can't see every workspace may be offered a fork that the server then rejects — at which point the pending fork is dropped gracefully. The frontend has no instance-wide count available to a non-superadmin, so this gate is intentionally best-effort *preflight UX*; `_check_nb_of_workspaces` remains the source of truth and fails closed.

## Test plan

- [x] `npm run check:fast` — no problems
- [x] `vitest sessionState.test.ts` — 20 passed (incl. new cap guard + under-cap tests)
- [x] Svelte autofixer — no issues
- [x] Browser (Playwright): **licensed** path renders the enabled interactive "Create new fork…" row; **unlicensed + at cap** renders the disabled "Workspace limit reached" row while root + existing forks stay selectable
- [ ] Manual check on a real CE instance: confirm the disabled row is not keyboard-focusable and arrow-key nav lands correctly; confirm a `pending_fork` staged at the cap surfaces the thrown error rather than silently retrying

🤖 Generated with [Claude Code](https://claude.com/claude-code)
