### PR TITLE
fix(triggers): prevent Zoom challenge handler from being used as a signing oracle

### DIFF
--- a/backend/windmill-trigger-http/src/http_trigger_auth.rs
+++ b/backend/windmill-trigger-http/src/http_trigger_auth.rs
@@ -337,6 +337,20 @@ mod zoom {
                 return Ok(None);
             }
 
+            // Prevent this challenge endpoint from being used as a signing oracle.
+            // Legitimate Zoom validation tokens are short random hex strings that
+            // never contain colons. The exploit requires crafting a plainToken in the
+            // `v0:{timestamp}:{body}` webhook-signing format (always containing colons)
+            // to obtain a valid signature for an arbitrary body. Reject any token that
+            // does not look like a legitimate Zoom validation token.
+            if zoom_request_body.payload.plain_token.contains(':')
+                || zoom_request_body.payload.plain_token.len() > 128
+            {
+                return Err(AuthenticationError::InvalidChallengeResponse(
+                    "Zoom: invalid plainToken format".to_string(),
+                ));
+            }
+
             let hmac_signature = calculate_hmac_signature(
                 HmacAlgorithm::Sha256,
                 &signature_config_data.secret_key,
@@ -1538,6 +1552,52 @@ mod tests {
             .handle_challenge_request(&HeaderMap::new(), &config_data, payload)
             .unwrap();
         assert!(response.is_none());
+    }
+
+    #[test]
+    fn test_zoom_challenge_normal_token_succeeds() {
+        // A legitimate Zoom validation token is a short random alphanumeric string.
+        let payload = r#"{"event":"endpoint.url_validation","event_ts":1234567890,"payload":{"plainToken":"qgg8vlvZRS6UYooatFL8Aw"}}"#;
+
+        let handler = WebhookType::Zoom.get_webhook_handler().unwrap();
+        let config_data = SignatureConfigData { secret_key: "zoom_secret" };
+        let response = handler
+            .handle_challenge_request(&HeaderMap::new(), &config_data, payload)
+            .unwrap();
+        assert!(response.is_some());
+    }
+
+    #[test]
+    fn test_zoom_challenge_token_with_colons_rejected() {
+        // Exploit attempt: a plainToken crafted in the `v0:{ts}:{body}` signing format
+        // would let an attacker obtain a valid webhook signature for an arbitrary body.
+        let payload = r#"{"event":"endpoint.url_validation","event_ts":1234567890,"payload":{"plainToken":"v0:1234567890:{\"forged\":\"body\"}"}}"#;
+
+        let handler = WebhookType::Zoom.get_webhook_handler().unwrap();
+        let config_data = SignatureConfigData { secret_key: "zoom_secret" };
+        let result = handler.handle_challenge_request(&HeaderMap::new(), &config_data, payload);
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::InvalidChallengeResponse(_))
+        ));
+    }
+
+    #[test]
+    fn test_zoom_challenge_token_too_long_rejected() {
+        // A plainToken exceeding 128 chars cannot be a legitimate Zoom validation token.
+        let long_token = "a".repeat(129);
+        let payload = format!(
+            r#"{{"event":"endpoint.url_validation","event_ts":1234567890,"payload":{{"plainToken":"{}"}}}}"#,
+            long_token
+        );
+
+        let handler = WebhookType::Zoom.get_webhook_handler().unwrap();
+        let config_data = SignatureConfigData { secret_key: "zoom_secret" };
+        let result = handler.handle_challenge_request(&HeaderMap::new(), &config_data, &payload);
+        assert!(matches!(
+            result,
+            Err(AuthenticationError::InvalidChallengeResponse(_))
+        ));
     }
 
     // --- Custom webhook end-to-end ---


### PR DESCRIPTION
## Problem

The Zoom URL-validation challenge handler in `handle_challenge_request` (`backend/windmill-trigger-http/src/http_trigger_auth.rs`) would HMAC-sign **any** arbitrary `plainToken` value and return the result, without verifying any signature first.

Normal Zoom webhook verification checks `HMAC-SHA256(secret, "v0:{timestamp}:{raw_payload}")`. An attacker could therefore craft a `plainToken` in that exact format (e.g. `"v0:1234567890:{forged_body}"`), submit it as a URL-validation challenge, and receive back a valid webhook signature — then replay it on a subsequent request with an arbitrary body to bypass authentication.

The Twitch handler is not vulnerable because it verifies the HMAC signature *before* returning any challenge response. The Zoom handler can't do that, since Zoom's protocol includes no signature on challenge requests.

## Fix

After the `endpoint.url_validation` event-type check, reject any `plainToken` that contains a `:` or exceeds 128 characters. Legitimate Zoom validation tokens are short random alphanumeric/hex strings that never contain colons, while the exploit fundamentally requires the colon-bearing `v0:{ts}:{body}` signing format.

## Tests

Added three tests to the existing suite (all 82 tests in the crate pass):
- `test_zoom_challenge_normal_token_succeeds` — a normal short token still produces a challenge response
- `test_zoom_challenge_token_with_colons_rejected` — a `v0:{ts}:{body}`-style token is rejected with `InvalidChallengeResponse`
- `test_zoom_challenge_token_too_long_rejected` — a token over 128 chars is rejected

```
cargo test -p windmill-trigger-http --lib http_trigger_auth
# test result: ok. 82 passed; 0 failed
```

## Scope

- `backend/windmill-trigger-http/src/http_trigger_auth.rs`

Fixes WIN-2008

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Zoom URL-validation to prevent the challenge handler from acting as a signing oracle. Fixes WIN-2008.

- **Bug Fixes**
  - Reject `plainToken` containing `:` or longer than 128 chars with `InvalidChallengeResponse`.
  - Blocks `v0:{ts}:{body}`-style tokens from obtaining valid HMACs.
  - Added tests: normal token accepted; colon token rejected; long token rejected.

<sup>Written for commit 13289bd3025fe1d3881628051634afce4d3c727c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

