### PR TITLE
fix(nsjail): raise python download fd limit for --compile-bytecode (WIN-2009)

### DIFF
--- a/backend/windmill-worker/nsjail/download.py.config.proto
+++ b/backend/windmill-worker/nsjail/download.py.config.proto
@@ -8,7 +8,11 @@ time_limit: 900
 rlimit_as: 2048
 rlimit_cpu: 1000
 rlimit_fsize: 1024
-rlimit_nofile: 64
+# uv's --compile-bytecode spawns a Python interpreter that compiles .py files
+# with parallelism scaling to the host's CPU count, opening many fds at once.
+# A low cap (was 64) is exhausted on high-core machines -> "Too many open files".
+# Matches the runtime configs (run.python3/run.ansible) which already use 10000.
+rlimit_nofile: 10000
 
 envar: "HOME=/user"
 envar: "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH"


### PR DESCRIPTION
## Problem

#9393 added `--compile-bytecode` to the `uv pip install` invocation that runs inside the **python download nsjail** (`download.py.config.proto` / `download_deps.py.sh`). This made `uv` spawn a Python interpreter to bytecode-compile installed `.py` files. That compiler runs with parallelism scaling to the host's CPU count, opening many file descriptors at once.

The python download nsjail capped `rlimit_nofile` at **64**. On high-core machines that cap is exhausted during compilation and every install fails with:

```
error: Failed to bytecode-compile Python file in: .../python_3_12/certifi==2026.5.20
  Caused by: Failed to start Python interpreter to run compile script
  Caused by: Too many open files (os error 24)
```

This is a regression introduced by #9393 for users on nsjail + Python: it only surfaces on workers with enough cores that uv's compile parallelism opens more than 64 fds. Low-core VMs never hit the cap, which is why it wasn't caught.

## Fix

Raise `rlimit_nofile` from 64 → **10000** in `download.py.config.proto`, matching the runtime configs (`run.python3.config.proto` / `run.ansible.config.proto`) that already use 10000.

## Validation

Config-only change to a value embedded via `include_str!` — no Rust logic, no schema, no frontend. The FD-exhaustion path can only be reproduced on a many-core host with sandboxing enabled (single-worker dev box can't trigger uv's high compile parallelism), so this was validated by reasoning + matching the proven runtime-config value rather than a local repro.

Fixes WIN-2009

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the `rlimit_nofile` in the Python download nsjail from 64 to 10000 to prevent "Too many open files" errors when `uv` compiles bytecode with `--compile-bytecode` on high-core workers. Fixes WIN-2009.

- **Bug Fixes**
  - Increase `rlimit_nofile` to 10000 in `download.py.config.proto` to avoid FD exhaustion during `uv pip install`.
  - Aligns with runtime configs (`run.python3` / `run.ansible`); config-only change, no code updates.

<sup>Written for commit 9ef561d6406d407d3c8c1fa1796807159d3a8f59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

