### PR TITLE
Use runtime nsjail packages in slim EE image

### DIFF
--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -83,7 +83,7 @@ COPY --from=docker:29-dind /usr/local/bin/docker /usr/local/bin/
 
 # nsjail runtime deps and binary
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libprotobuf-dev libnl-route-3-dev \
+    && apt-get install -y --no-install-recommends libprotobuf32 libnl-route-3-200 libnl-3-200 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 


### PR DESCRIPTION
## Summary

Replace final-stage nsjail development packages in `docker/DockerfileSlimEe` with the runtime libraries that the built `/bin/nsjail` binary actually links against on Debian Bookworm.

This keeps the nsjail build stage unchanged, keeps the air-gapped Windmill caches intact, and avoids `apt-get upgrade` so the slim EE image remains reproducible.

## Mend impact

The previous final-stage `libprotobuf-dev` / `libnl-route-3-dev` install pulled development headers, including `linux-libc-dev`, into the shipped image. The runtime package install should reduce `linux-libc-dev` and related dev-package vulnerability noise in Mend scans, especially total and medium package findings. This does not claim to eliminate all reachable critical/high findings.

## Validation

- Confirmed the proposed packages exist for Debian Bookworm `linux/amd64`: `libprotobuf32`, `libnl-route-3-200`, `libnl-3-200`.
- Built the `nsjail` Dockerfile stage for `linux/amd64`: `docker build --platform linux/amd64 --target nsjail -f docker/DockerfileSlimEe -t windmill-nsjail-runtime-test:amd64 .`.
- Copied the built `nsjail` binary into a fresh `debian:bookworm-slim` `linux/amd64` container with only the proposed runtime packages installed; `ldd` resolved `libprotobuf.so.32`, `libnl-route-3.so.200`, `libnl-3.so.200`, plus the base C++/C/zlib libraries, and `nsjail --help` ran.
- Verified that installing only the proposed runtime packages does not install `linux-libc-dev`, `libprotobuf-dev`, `libnl-3-dev`, or `libnl-route-3-dev`.
- Ran `git diff --check -- docker/DockerfileSlimEe`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the slim EE image to nsjail runtime libraries instead of dev packages in `docker/DockerfileSlimEe`. This removes dev headers, keeps the image reproducible, and should reduce Mend vulnerability noise.

- **Dependencies**
  - Replace `libprotobuf-dev` and `libnl-route-3-dev` with `libprotobuf32`, `libnl-route-3-200`, `libnl-3-200` (Debian Bookworm).

<sup>Written for commit 0e055432f06a8861b499d67036f8c550945d6a01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

