### PR TITLE
feat: add metadata generation model setting

### DIFF
--- a/backend/windmill-api-integration-tests/tests/workspaces.rs
+++ b/backend/windmill-api-integration-tests/tests/workspaces.rs
@@ -709,7 +709,9 @@ async fn test_get_copilot_settings_state_reports_instance_ai_fallback_flags(
                 "resource_path": "u/test-user/openai_instance",
                 "models": ["gpt-4o-mini"]
             }
-        }
+        },
+        "default_model": { "provider": "openai", "model": "gpt-4o-mini" },
+        "metadata_model": { "provider": "openai", "model": "gpt-4o-mini" }
     });
     let workspace_ai_config = json!({
         "providers": {
@@ -747,6 +749,10 @@ async fn test_get_copilot_settings_state_reports_instance_ai_fallback_flags(
     );
     assert_eq!(
         settings["instance_ai_summary"]["providers"][0]["models"][0],
+        "gpt-4o-mini"
+    );
+    assert_eq!(
+        settings["instance_ai_summary"]["metadata_model"]["model"],
         "gpt-4o-mini"
     );
 

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -340,6 +340,8 @@ pub struct InstanceAISummary {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_model: Option<InstanceAIModelSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_model: Option<InstanceAIModelSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub code_completion_model: Option<InstanceAIModelSummary>,
 }
 
@@ -825,6 +827,7 @@ pub fn build_instance_ai_summary(config: Option<&serde_json::Value>) -> Option<I
     Some(InstanceAISummary {
         providers: provider_summaries,
         default_model: extract_instance_ai_model_summary(config, "default_model"),
+        metadata_model: extract_instance_ai_model_summary(config, "metadata_model"),
         code_completion_model: extract_instance_ai_model_summary(config, "code_completion_model"),
     })
 }

--- a/backend/windmill-api/openapi-deref.json
+++ b/backend/windmill-api/openapi-deref.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "1.708.0",
+    "version": "1.713.1",
     "title": "Windmill API",
     "contact": {
       "name": "Windmill Team",
@@ -15229,6 +15229,10 @@
                       },
                       "deployment_message": {
                         "type": "string"
+                      },
+                      "skip_draft_deletion": {
+                        "type": "boolean",
+                        "description": "When true (set by the CLI / git sync), deploying this flow does not delete an existing user draft at the same path."
                       }
                     }
                   }
@@ -15295,6 +15299,10 @@
                     "properties": {
                       "deployment_message": {
                         "type": "string"
+                      },
+                      "skip_draft_deletion": {
+                        "type": "boolean",
+                        "description": "When true (set by the CLI / git sync), deploying this flow does not delete an existing user draft at the same path."
                       }
                     }
                   }
@@ -16069,6 +16077,10 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "skip_draft_deletion": {
+                    "type": "boolean",
+                    "description": "When true (set by the CLI / git sync), deploying this app does not delete an existing user draft at the same path."
                   }
                 },
                 "required": [
@@ -16146,6 +16158,10 @@
                         "items": {
                           "type": "string"
                         }
+                      },
+                      "skip_draft_deletion": {
+                        "type": "boolean",
+                        "description": "When true (set by the CLI / git sync), deploying this app does not delete an existing user draft at the same path."
                       }
                     },
                     "required": [
@@ -16679,6 +16695,10 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "skip_draft_deletion": {
+                    "type": "boolean",
+                    "description": "When true (set by the CLI / git sync), deploying this app does not delete an existing user draft at the same path."
                   }
                 }
               }
@@ -16750,6 +16770,10 @@
                         "items": {
                           "type": "string"
                         }
+                      },
+                      "skip_draft_deletion": {
+                        "type": "boolean",
+                        "description": "When true (set by the CLI / git sync), deploying this app does not delete an existing user draft at the same path."
                       }
                     }
                   },
@@ -28210,6 +28234,52 @@
         }
       }
     },
+    "/workers/workspace_fairness_events": {
+      "get": {
+        "summary": "list last 100 workspace-fairness cap/uncap events (cloud-only)",
+        "operationId": "getWorkspaceFairnessEvents",
+        "tags": [
+          "worker"
+        ],
+        "responses": {
+          "200": {
+            "description": "workspace fairness events (empty on non-cloud)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "operation": {
+                        "type": "string"
+                      },
+                      "workspace_id": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "parameters": {
+                        "type": "object",
+                        "nullable": true,
+                        "additionalProperties": true
+                      }
+                    },
+                    "required": [
+                      "timestamp",
+                      "operation"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/configs/list_worker_groups": {
       "get": {
         "summary": "list worker groups",
@@ -33130,6 +33200,10 @@
             "type": "boolean",
             "description": "If true, all steps run on the same worker for better performance"
           },
+          "preserve_step_tags": {
+            "type": "boolean",
+            "description": "If true and the flow runs on a custom worker tag, steps that declare their own non-empty tag run on it instead of inheriting the flow tag. Steps without their own tag still inherit the flow tag."
+          },
           "concurrent_limit": {
             "type": "number",
             "description": "Maximum number of concurrent executions of this flow"
@@ -35312,6 +35386,9 @@
           "default_model": {
             "$ref": "#/components/schemas/AIProviderModel"
           },
+          "metadata_model": {
+            "$ref": "#/components/schemas/AIProviderModel"
+          },
           "code_completion_model": {
             "$ref": "#/components/schemas/AIProviderModel"
           },
@@ -35359,6 +35436,9 @@
             }
           },
           "default_model": {
+            "$ref": "#/components/schemas/AIProviderModel"
+          },
+          "metadata_model": {
             "$ref": "#/components/schemas/AIProviderModel"
           },
           "code_completion_model": {
@@ -35837,6 +35917,10 @@
             "items": {
               "type": "string"
             }
+          },
+          "skip_draft_deletion": {
+            "type": "boolean",
+            "description": "When true (set by the CLI / git sync), deploying this script does not delete an existing user draft at the same path."
           }
         },
         "required": [
@@ -40538,6 +40622,13 @@
           },
           "tag": {
             "$ref": "#/components/schemas/CustomInstanceDbTag"
+          },
+          "used_by_workspaces": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Workspaces that reference this database via a ducklake catalog or datatable database with resource_type 'instance'. Computed at request time, not persisted."
           }
         }
       },
@@ -46175,6 +46266,10 @@
           "same_worker": {
             "type": "boolean",
             "description": "If true, all steps run on the same worker for better performance"
+          },
+          "preserve_step_tags": {
+            "type": "boolean",
+            "description": "If true and the flow runs on a custom worker tag, steps that declare their own non-empty tag run on it instead of inheriting the flow tag. Steps without their own tag still inherit the flow tag."
           },
           "concurrent_limit": {
             "type": "number",

--- a/backend/windmill-api/openapi-deref.yaml
+++ b/backend/windmill-api/openapi-deref.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 1.708.0
+  version: 1.713.1
   title: Windmill API
   contact:
     name: Windmill Team
@@ -2057,6 +2057,14 @@ paths:
                       enum: &ref_22
                         - ducklake
                         - datatable
+                    used_by_workspaces:
+                      type: array
+                      items:
+                        type: string
+                      description: >-
+                        Workspaces that reference this database via a ducklake
+                        catalog or datatable database with resource_type
+                        'instance'. Computed at request time, not persisted.
   /settings/setup_custom_instance_pg_database/{name}:
     post:
       summary: >-
@@ -4842,6 +4850,10 @@ paths:
                         required: &ref_44
                           - model
                           - provider
+                      metadata_model:
+                        type: object
+                        properties: *ref_43
+                        required: *ref_44
                       code_completion_model:
                         type: object
                         properties: *ref_43
@@ -5825,6 +5837,10 @@ paths:
                             - provider
                             - models
                       default_model:
+                        type: object
+                        properties: *ref_43
+                        required: *ref_44
+                      metadata_model:
                         type: object
                         properties: *ref_43
                         required: *ref_44
@@ -11364,6 +11380,13 @@ paths:
                             description: >-
                               If true, all steps run on the same worker for
                               better performance
+                          preserve_step_tags:
+                            type: boolean
+                            description: >-
+                              If true and the flow runs on a custom worker tag,
+                              steps that declare their own non-empty tag run on
+                              it instead of inheriting the flow tag. Steps
+                              without their own tag still inherit the flow tag.
                           concurrent_limit:
                             type: number
                             description: >-
@@ -12619,6 +12642,11 @@ paths:
                   type: array
                   items:
                     type: string
+                skip_draft_deletion:
+                  type: boolean
+                  description: >-
+                    When true (set by the CLI / git sync), deploying this script
+                    does not delete an existing user draft at the same path.
               required: &ref_105
                 - path
                 - summary
@@ -15461,6 +15489,12 @@ paths:
                       type: boolean
                     deployment_message:
                       type: string
+                    skip_draft_deletion:
+                      type: boolean
+                      description: >-
+                        When true (set by the CLI / git sync), deploying this
+                        flow does not delete an existing user draft at the same
+                        path.
       responses:
         '201':
           description: flow created
@@ -15507,6 +15541,12 @@ paths:
                   properties:
                     deployment_message:
                       type: string
+                    skip_draft_deletion:
+                      type: boolean
+                      description: >-
+                        When true (set by the CLI / git sync), deploying this
+                        flow does not delete an existing user draft at the same
+                        path.
       responses:
         '200':
           description: flow updated
@@ -16244,6 +16284,11 @@ paths:
                   type: array
                   items:
                     type: string
+                skip_draft_deletion:
+                  type: boolean
+                  description: >-
+                    When true (set by the CLI / git sync), deploying this app
+                    does not delete an existing user draft at the same path.
               required:
                 - path
                 - value
@@ -16303,6 +16348,12 @@ paths:
                       type: array
                       items:
                         type: string
+                    skip_draft_deletion:
+                      type: boolean
+                      description: >-
+                        When true (set by the CLI / git sync), deploying this
+                        app does not delete an existing user draft at the same
+                        path.
                   required:
                     - path
                     - value
@@ -16740,6 +16791,11 @@ paths:
                   type: array
                   items:
                     type: string
+                skip_draft_deletion:
+                  type: boolean
+                  description: >-
+                    When true (set by the CLI / git sync), deploying this app
+                    does not delete an existing user draft at the same path.
       responses:
         '200':
           description: app updated
@@ -16796,6 +16852,12 @@ paths:
                       type: array
                       items:
                         type: string
+                    skip_draft_deletion:
+                      type: boolean
+                      description: >-
+                        When true (set by the CLI / git sync), deploying this
+                        app does not delete an existing user draft at the same
+                        path.
                 js:
                   type: string
                 css:
@@ -17954,6 +18016,13 @@ paths:
                       description: >-
                         If true, all steps run on the same worker for better
                         performance
+                    preserve_step_tags:
+                      type: boolean
+                      description: >-
+                        If true and the flow runs on a custom worker tag, steps
+                        that declare their own non-empty tag run on it instead
+                        of inheriting the flow tag. Steps without their own tag
+                        still inherit the flow tag.
                     concurrent_limit:
                       type: number
                       description: Maximum number of concurrent executions of this flow
@@ -30256,6 +30325,37 @@ paths:
                 type: object
                 additionalProperties:
                   type: integer
+  /workers/workspace_fairness_events:
+    get:
+      summary: list last 100 workspace-fairness cap/uncap events (cloud-only)
+      operationId: getWorkspaceFairnessEvents
+      tags:
+        - worker
+      responses:
+        '200':
+          description: workspace fairness events (empty on non-cloud)
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    timestamp:
+                      type: string
+                      format: date-time
+                    operation:
+                      type: string
+                    workspace_id:
+                      type: string
+                      nullable: true
+                    parameters:
+                      type: object
+                      nullable: true
+                      additionalProperties: true
+                  required:
+                    - timestamp
+                    - operation
   /configs/list_worker_groups:
     get:
       summary: list worker groups

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -21542,6 +21542,8 @@ components:
             $ref: "#/components/schemas/AIProviderConfig"
         default_model:
           $ref: "#/components/schemas/AIProviderModel"
+        metadata_model:
+          $ref: "#/components/schemas/AIProviderModel"
         code_completion_model:
           $ref: "#/components/schemas/AIProviderModel"
         custom_prompts:
@@ -21576,6 +21578,8 @@ components:
           items:
             $ref: "#/components/schemas/InstanceAIProviderSummary"
         default_model:
+          $ref: "#/components/schemas/AIProviderModel"
+        metadata_model:
           $ref: "#/components/schemas/AIProviderModel"
         code_completion_model:
           $ref: "#/components/schemas/AIProviderModel"

--- a/backend/windmill-api/src/ai.rs
+++ b/backend/windmill-api/src/ai.rs
@@ -377,6 +377,8 @@ pub struct AIConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_model: Option<ProviderModel>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_model: Option<ProviderModel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub code_completion_model: Option<ProviderModel>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_prompts: Option<HashMap<String, String>>,

--- a/frontend/src/lib/aiStore.ts
+++ b/frontend/src/lib/aiStore.ts
@@ -21,6 +21,7 @@ export const copilotInfo = writable<{
 	enabled: boolean
 	codeCompletionModel?: AIProviderModel
 	defaultModel?: AIProviderModel
+	metadataModel?: AIProviderModel
 	aiModels: AIProviderModel[]
 	customPrompts?: Record<string, string>
 	maxTokensPerModel?: Record<string, number>
@@ -28,6 +29,7 @@ export const copilotInfo = writable<{
 	enabled: false,
 	codeCompletionModel: undefined,
 	defaultModel: undefined,
+	metadataModel: undefined,
 	aiModels: [],
 	customPrompts: {},
 	maxTokensPerModel: {}
@@ -65,6 +67,7 @@ export function setCopilotInfo(aiConfig: AIConfig) {
 			enabled: true,
 			codeCompletionModel: aiConfig.code_completion_model,
 			defaultModel: aiConfig.default_model,
+			metadataModel: aiConfig.metadata_model,
 			aiModels: aiModels,
 			customPrompts: aiConfig.custom_prompts ?? {},
 			maxTokensPerModel: aiConfig.max_tokens_per_model ?? {}
@@ -76,6 +79,7 @@ export function setCopilotInfo(aiConfig: AIConfig) {
 			enabled: false,
 			codeCompletionModel: undefined,
 			defaultModel: undefined,
+			metadataModel: undefined,
 			aiModels: [],
 			customPrompts: {},
 			maxTokensPerModel: {}
@@ -86,6 +90,15 @@ export function setCopilotInfo(aiConfig: AIConfig) {
 export function getCurrentModel(): AIProviderModel {
 	const model =
 		get(copilotSessionModel) ?? get(copilotInfo).defaultModel ?? get(copilotInfo).aiModels[0]
+	if (!model) {
+		throw new Error('No model selected')
+	}
+	return model
+}
+
+export function getMetadataModel(): AIProviderModel {
+	const info = get(copilotInfo)
+	const model = info.metadataModel ?? info.defaultModel ?? info.aiModels[0]
 	if (!model) {
 		throw new Error('No model selected')
 	}

--- a/frontend/src/lib/components/copilot/MetadataGen.svelte
+++ b/frontend/src/lib/components/copilot/MetadataGen.svelte
@@ -3,7 +3,7 @@
 	import { isInitialCode } from '$lib/script_helpers'
 	import { Check, Loader2, Wand2 } from 'lucide-svelte'
 	import { metadataCompletionEnabled } from '$lib/stores'
-	import { copilotInfo } from '$lib/aiStore'
+	import { copilotInfo, getMetadataModel } from '$lib/aiStore'
 	import { onDestroy, untrack } from 'svelte'
 	import { sendUserToast } from '$lib/toast'
 	import { twMerge } from 'tailwind-merge'
@@ -174,7 +174,9 @@ Generate a tool name for the script below:
 					content: config.user.replace(`{${config.placeholderName}}`, placeholderContent)
 				}
 			]
-			const response = await getCompletion(messages, abortController)
+			const response = await getCompletion(messages, abortController, undefined, {
+				forceModelProvider: getMetadataModel()
+			})
 			generatedContent = ''
 			for await (const chunk of response) {
 				generatedContent += getResponseFromEvent(chunk)

--- a/frontend/src/lib/components/copilot/chat/openai-responses.ts
+++ b/frontend/src/lib/components/copilot/chat/openai-responses.ts
@@ -14,10 +14,7 @@ import {
 import { processToolCall, type Tool, type ToolCallbacks } from './shared'
 import type { ResponseStream } from 'openai/lib/responses/ResponseStream.mjs'
 import type { AIProviderModel } from '$lib/gen'
-import {
-	openAIResponsesUsageToChatTokenUsage,
-	type ChatTokenUsage
-} from './tokenUsage'
+import { openAIResponsesUsageToChatTokenUsage, type ChatTokenUsage } from './tokenUsage'
 
 interface ParsedCompletionResult {
 	shouldContinue: boolean
@@ -172,13 +169,22 @@ export async function getOpenAIResponsesCompletion(
 export async function* getOpenAIResponsesCompletionStream(
 	messages: ChatCompletionMessageParam[],
 	abortController: AbortController,
-	tools?: OpenAI.Chat.Completions.ChatCompletionTool[]
+	tools?: OpenAI.Chat.Completions.ChatCompletionTool[],
+	options?: {
+		forceModelProvider?: AIProviderModel
+		openaiClient?: OpenAI
+	}
 ): AsyncGenerator<OpenAI.Chat.Completions.ChatCompletionChunk> {
-	const { provider, config } = getProviderAndCompletionConfig({ messages, stream: true, tools })
+	const { provider, config } = getProviderAndCompletionConfig({
+		messages,
+		stream: true,
+		tools,
+		forceModelProvider: options?.forceModelProvider
+	})
 	const { instructions, input } = convertMessagesToResponsesInput(messages)
 	const responsesConfig = convertCompletionConfigToResponsesConfig(config)
 
-	const openaiClient = workspaceAIClients.getOpenaiClient()
+	const openaiClient = options?.openaiClient ?? workspaceAIClients.getOpenaiClient()
 
 	const runner = openaiClient.responses.stream(
 		{

--- a/frontend/src/lib/components/copilot/lib.ts
+++ b/frontend/src/lib/components/copilot/lib.ts
@@ -895,7 +895,10 @@ export async function getCompletion(
 	// Use Responses API for OpenAI and Azure OpenAI
 	if ((provider === 'openai' || provider === 'azure_openai') && !options?.forceCompletions) {
 		try {
-			const stream = getOpenAIResponsesCompletionStream(messages, abortController, tools) as any
+			const stream = getOpenAIResponsesCompletionStream(messages, abortController, tools, {
+				forceModelProvider: options?.forceModelProvider,
+				openaiClient: options?.openaiClient
+			}) as any
 			return stream
 		} catch (error) {
 			console.error('Error using Responses API:', error)

--- a/frontend/src/lib/components/workspaceSettings/AISettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/AISettings.svelte
@@ -68,6 +68,7 @@
 	let aiProviders: Exclude<AIConfig['providers'], undefined> = $state({})
 	let codeCompletionModel: string | undefined = $state(undefined)
 	let defaultModel: string | undefined = $state(undefined)
+	let metadataModel: string | undefined = $state(undefined)
 	let customPrompts: Record<string, string> = $state({})
 	let maxTokensPerModel: Record<string, number> = $state({})
 	let usingOpenaiClientCredentialsOauth = $state(false)
@@ -77,6 +78,7 @@
 	let initialAiProviders: Exclude<AIConfig['providers'], undefined> = $state({})
 	let initialCodeCompletionModel: string | undefined = $state(undefined)
 	let initialDefaultModel: string | undefined = $state(undefined)
+	let initialMetadataModel: string | undefined = $state(undefined)
 	let initialCustomPrompts: Record<string, string> = $state({})
 	let initialMaxTokensPerModel: Record<string, number> = $state({})
 	let initialPrompts: Record<string, string> = $state({})
@@ -89,6 +91,7 @@
 	function applyConfig(config: AIConfig | undefined) {
 		aiProviders = clone(config?.providers ?? {})
 		defaultModel = config?.default_model?.model
+		metadataModel = config?.metadata_model?.model
 		codeCompletionModel = config?.code_completion_model?.model
 		customPrompts = clone(config?.custom_prompts ?? {})
 		maxTokensPerModel = clone(config?.max_tokens_per_model ?? {})
@@ -102,6 +105,7 @@
 	function storeInitialState() {
 		initialAiProviders = clone(aiProviders)
 		initialDefaultModel = defaultModel
+		initialMetadataModel = metadataModel
 		initialCodeCompletionModel = codeCompletionModel
 		initialCustomPrompts = clone(customPrompts)
 		initialMaxTokensPerModel = clone(maxTokensPerModel)
@@ -116,6 +120,7 @@
 	export function discard() {
 		aiProviders = clone(initialAiProviders)
 		defaultModel = initialDefaultModel
+		metadataModel = initialMetadataModel
 		codeCompletionModel = initialCodeCompletionModel
 		customPrompts = clone(initialCustomPrompts)
 		maxTokensPerModel = clone(initialMaxTokensPerModel)
@@ -149,6 +154,7 @@
 	let dirty = $derived(
 		JSON.stringify(aiProviders) !== JSON.stringify(initialAiProviders) ||
 			defaultModel !== initialDefaultModel ||
+			metadataModel !== initialMetadataModel ||
 			codeCompletionModel !== initialCodeCompletionModel ||
 			JSON.stringify(customPrompts) !== JSON.stringify(initialCustomPrompts) ||
 			JSON.stringify(maxTokensPerModel) !== JSON.stringify(initialMaxTokensPerModel)
@@ -200,6 +206,7 @@
 		if (Object.keys(aiProviders).length < 1) {
 			codeCompletionModel = undefined
 			defaultModel = undefined
+			metadataModel = undefined
 		}
 	})
 
@@ -239,6 +246,10 @@
 			defaultModel && modelProviderMap[defaultModel]
 				? { model: defaultModel, provider: modelProviderMap[defaultModel] }
 				: undefined
+		const metadata_model =
+			metadataModel && modelProviderMap[metadataModel]
+				? { model: metadataModel, provider: modelProviderMap[metadataModel] }
+				: undefined
 		const custom_prompts: Record<string, string> = Object.entries(customPrompts)
 			.filter(([_, prompt]) => prompt.trim().length > 0)
 			.reduce((acc, [mode, prompt]) => ({ ...acc, [mode]: prompt }), {})
@@ -248,6 +259,7 @@
 					providers: aiProviders,
 					code_completion_model,
 					default_model,
+					metadata_model,
 					custom_prompts: Object.keys(custom_prompts).length > 0 ? custom_prompts : undefined,
 					max_tokens_per_model:
 						Object.keys(maxTokensPerModel).length > 0 ? maxTokensPerModel : undefined
@@ -258,6 +270,7 @@
 	function isSaveDisabled(): boolean {
 		return (
 			!Object.values(aiProviders).every((p) => p.resource_path) ||
+			(metadataModel != undefined && metadataModel.length === 0) ||
 			(codeCompletionModel != undefined && codeCompletionModel.length === 0) ||
 			(Object.keys(aiProviders).length > 0 && !defaultModel)
 		)
@@ -397,6 +410,14 @@
 												codeCompletionModel = undefined
 											}
 										}
+										if (metadataModel) {
+											const currentMetadataModel = Object.values(aiProviders).find(
+												(p) => metadataModel && p.models.includes(metadataModel)
+											)
+											if (!currentMetadataModel) {
+												metadataModel = undefined
+											}
+										}
 									}
 								}}
 							/>
@@ -474,6 +495,23 @@
 					placeholder="Select a default model"
 					size="sm"
 					class="max-w-lg"
+				/>
+			{/key}
+		</SettingCard>
+
+		<SettingCard
+			label="Metadata generation model"
+			description="Used for automatic summaries, descriptions, and tool names. If unset, the default chat model is used."
+		>
+			{#key Object.keys(aiProviders).length}
+				<Select
+					items={safeSelectItems(selectedAiModels)}
+					bind:value={metadataModel}
+					disabled={false}
+					placeholder="Use default chat model"
+					size="sm"
+					class="max-w-lg"
+					clearable
 				/>
 			{/key}
 		</SettingCard>

--- a/frontend/src/lib/components/workspaceSettings/InstanceFallbackSettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/InstanceFallbackSettings.svelte
@@ -36,7 +36,7 @@
 			</p>
 
 			<div class="flex flex-col gap-3">
-				{#each sortedInstanceProviders as providerSummary}
+				{#each sortedInstanceProviders as providerSummary (providerSummary.provider)}
 					<div class="rounded-md border bg-surface p-3 flex flex-col gap-2">
 						<div class="flex items-center gap-2">
 							<span class="text-xs font-medium">
@@ -45,7 +45,7 @@
 							<Badge color="blue">Instance</Badge>
 						</div>
 						<div class="flex flex-wrap gap-1">
-							{#each providerSummary.models as model}
+							{#each providerSummary.models as model (model)}
 								<Badge color="gray">{model}</Badge>
 							{/each}
 						</div>
@@ -59,6 +59,18 @@
 					<span class="text-primary font-medium">{instanceAiSummary.default_model.model}</span>
 					<span class="text-tertiary">
 						({getProviderLabel(instanceAiSummary.default_model.provider)})
+					</span>
+				</div>
+			{/if}
+
+			{#if instanceAiSummary.metadata_model}
+				<div class="text-xs text-secondary">
+					Metadata generation model:
+					<span class="text-primary font-medium">
+						{instanceAiSummary.metadata_model.model}
+					</span>
+					<span class="text-tertiary">
+						({getProviderLabel(instanceAiSummary.metadata_model.provider)})
 					</span>
 				</div>
 			{/if}


### PR DESCRIPTION
## Summary
Adds a workspace and instance AI setting for a dedicated metadata generation model, so async names, summaries, descriptions, and tool names can use a different model from interactive chat while falling back to the default chat model when unset.

## Changes
- Add `metadata_model` to AI config schemas, OpenAPI artifacts, and instance AI summaries.
- Add the `Metadata generation model` selector to workspace and instance AI settings.
- Route metadata generation through the configured metadata model instead of the active chat model.
- Make the OpenAI/Azure Responses API path respect forced model selection.
- Extend integration coverage for instance AI summary metadata model reporting.

## Test plan
- [x] `npm run generate-backend-client`
- [x] `npm run check:fast`
- [x] `npm run check`
- [x] Targeted `rustfmt` on changed Rust files
- [x] `sh backend/windmill-api/build_openapi.sh`
- [x] Backend watcher rebuilt and reported healthy
- [x] Browser-verified instance and workspace AI settings on local dev server