### PR TITLE
chore(docker): use nsjail runtime packages instead of dev packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -300,7 +300,7 @@ ENV CARGO_HOME="/tmp/windmill/cache/cargo"
 ENV LD_LIBRARY_PATH="."
 
 # nsjail runtime deps and binary
-RUN apt-get update && apt-get install -y libprotobuf-dev libnl-route-3-dev \
+RUN apt-get update && apt-get install -y --no-install-recommends libprotobuf32 libnl-route-3-200 libnl-3-200 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 

--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -83,7 +83,7 @@ COPY --from=docker:29-dind /usr/local/bin/docker /usr/local/bin/
 
 # nsjail runtime deps and binary
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libprotobuf-dev libnl-route-3-dev \
+    && apt-get install -y --no-install-recommends libprotobuf32 libnl-route-3-200 libnl-3-200 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -83,7 +83,7 @@ COPY --from=docker:29-dind /usr/local/bin/docker /usr/local/bin/
 
 # nsjail runtime deps and binary
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libprotobuf-dev libnl-route-3-dev \
+    && apt-get install -y --no-install-recommends libprotobuf32 libnl-route-3-200 libnl-3-200 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 


### PR DESCRIPTION
Swap the final-stage nsjail dependencies (libprotobuf-dev, libnl-route-3-dev) for their runtime-only counterparts (libprotobuf32, libnl-route-3-200, libnl-3-200) across the root Dockerfile, DockerfileSlim, and DockerfileSlimEe. nsjail is already compiled in the build stage, so the final image only needs the runtime shared libraries. This shrinks the images and reduces CVE scan noise from unused dev packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced nsjail dev packages with runtime libs in final Docker stages to shrink images and reduce CVE noise. Swaps `libprotobuf-dev` and `libnl-route-3-dev` for `libprotobuf32`, `libnl-route-3-200`, and `libnl-3-200` across all images.

- **Dependencies**
  - Updated `Dockerfile`, `docker/DockerfileSlim`, and `docker/DockerfileSlimEe`.
  - Rationale: nsjail is built in an earlier stage; final images only need runtime shared libs.

<sup>Written for commit c1522a6fc5a976e1409a8455e73d09b3f6d55252. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

