### PR TITLE
feat(frontend): add rebuild dependency map button to workspace settings

### DIFF
--- a/frontend/src/lib/components/workspaceSettings/WorkspaceDependenciesSettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/WorkspaceDependenciesSettings.svelte
@@ -12,7 +12,7 @@
 	import DrawerContent from '$lib/components/common/drawer/DrawerContent.svelte'
 	import HighlightCode from '$lib/components/HighlightCode.svelte'
 	import { workspaceStore, userStore } from '$lib/stores'
-	import { Plus, FileText, Search, Code2, Edit, Eye } from 'lucide-svelte'
+	import { Plus, FileText, Search, Code2, Edit, Eye, RefreshCw } from 'lucide-svelte'
 	import { WorkspaceDependenciesService, WorkspaceService } from '$lib/gen'
 	import type { WorkspaceDependencies, ScriptLang } from '$lib/gen'
 	import { untrack } from 'svelte'
@@ -24,6 +24,7 @@
 	let workspaceDependencies: WorkspaceDependencies[] | undefined = $state()
 	let filteredItems: (WorkspaceDependencies & { marked?: string })[] | undefined = $state()
 	let workspaceDependenciesEditor: WorkspaceDependenciesEditor | undefined = $state()
+	let rebuildingDependencyMap = $state(false)
 
 	// View modal state
 	let viewDrawer: Drawer | undefined = $state()
@@ -77,6 +78,20 @@
 			})
 		}
 	})
+
+	async function rebuildDependencyMap(): Promise<void> {
+		if (!$workspaceStore) return
+		rebuildingDependencyMap = true
+		try {
+			const status = await WorkspaceService.rebuildDependencyMap({ workspace: $workspaceStore })
+			sendUserToast(status)
+		} catch (error) {
+			console.error('Error rebuilding dependency map:', error)
+			sendUserToast(`Failed to rebuild dependency map: ${error.message}`, true)
+		} finally {
+			rebuildingDependencyMap = false
+		}
+	}
 
 	async function createNewWorkspaceDependencies() {
 		await workspaceDependenciesEditor?.initNew()
@@ -270,7 +285,7 @@
 	<ListFilters bind:selectedFilter={languageFilter} filters={languages} />
 </div>
 
-<div class="relative overflow-x-auto pb-40 pr-4">
+<div class="relative overflow-x-auto pb-8 pr-4">
 	{#if !filteredItems}
 		<Skeleton layout={[0.5, [2], 1]} />
 		{#each new Array(3) as _}
@@ -410,6 +425,29 @@
 		</DataTable>
 	{/if}
 </div>
+
+{#if $userStore?.is_admin || $userStore?.is_super_admin}
+	<div class="border-t pt-8 mt-16 pb-12 pr-4 flex items-start justify-between gap-4">
+		<div class="flex flex-col gap-0.5 min-w-0">
+			<span class="text-xs font-medium text-secondary">Rebuild dependency map</span>
+			<span class="text-xs text-tertiary max-w-2xl">
+				Rebuilds the workspace dependency map from scratch. This should almost never be needed —
+				only if dependency tracking has gotten out of sync, e.g. after orphaned references are
+				reported in the logs.
+			</span>
+		</div>
+		<Button
+			size="xs"
+			variant="border"
+			color="light"
+			startIcon={{ icon: RefreshCw }}
+			disabled={rebuildingDependencyMap}
+			onClick={rebuildDependencyMap}
+		>
+			Rebuild
+		</Button>
+	</div>
+{/if}
 
 <Drawer bind:this={viewDrawer} size="900px">
 	<DrawerContent title="View Requirement - {viewPath}" on:close={viewDrawer?.closeDrawer}>


### PR DESCRIPTION
## Summary
Adds a "Rebuild dependency map" control to the Enforced Dependencies tab of workspace settings. The backend endpoint (`POST /api/w/{workspace}/workspaces/rebuild_dependency_map`) and the generated client (`WorkspaceService.rebuildDependencyMap`) already existed, and our own orphan-healing log message tells users to "rebuild maps in workspace settings" — but no UI had been shipped. This wires it up.

Rebuilding the dependency map is a rarely-needed maintenance escape hatch, distinct from managing enforced dependencies. So it's presented as a small, discrete row below a divider (muted label + caveat that it should almost never be needed) rather than a primary action in the Enforced Dependencies header.

## Changes
- `frontend/src/lib/components/workspaceSettings/WorkspaceDependenciesSettings.svelte`:
  - Import `RefreshCw` from `lucide-svelte`.
  - Add a `rebuildingDependencyMap` loading flag.
  - Add a `rebuildDependencyMap()` handler that calls `WorkspaceService.rebuildDependencyMap({ workspace: $workspaceStore })`, shows the returned status string via `sendUserToast(...)`, and toasts the error message (error styling) on failure; resets the loading flag in `finally`.
  - Add a discrete row below a `border-t` divider: a muted "Rebuild dependency map" label, a tertiary-text caveat ("This should almost never be needed — only if dependency tracking has gotten out of sync, e.g. after orphaned references are reported in the logs"), and a small `border`/`light` "Rebuild" button. Gated on `$userStore?.is_admin || $userStore?.is_super_admin` (the endpoint 403s for non-admins) and `disabled` while in-flight.
  - Reduce the dependency list's bottom padding (`pb-40` → `pb-8`) so the row sits flush below it.

No backend, OpenAPI, or client-regeneration changes — the API surface is unchanged.

## Test plan
- [ ] As a workspace admin on a self-hosted instance, go to Workspace settings → Enforced Dependencies, scroll to the "Rebuild dependency map" row, click "Rebuild", confirm a success toast shows the backend status string and the button is disabled while in-flight.
- [ ] Confirm the row is hidden for non-admin users.
- [ ] Confirm an induced failure surfaces the red error toast.

> Verified locally via Playwright: the discrete row renders below the enforced-dependencies list with its muted label, caveat, and small button; clicking it produced a green Success toast (backend returns \`"Success"\`). \`npm run check:fast\` clean for the changed file; svelte autofixer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)