### PR TITLE
fix(mcp): resolve MCP resource token via caller RLS + SSRF-guard url

### DIFF
--- a/backend/tests/fixtures/mcp_token_exfil.sql
+++ b/backend/tests/fixtures/mcp_token_exfil.sql
@@ -1,0 +1,29 @@
+-- Fixture for the MCP token-exfiltration regression test (GHSA-8m2p-2crh-9h3w).
+--
+-- Models a malicious developer (test-user-3, a plain workspace member) who:
+--   - owns an MCP resource they are allowed to read, and
+--   - points that resource's `token` field at a secret variable living in a
+--     folder they have NO access to (`f/locked`, only test-user/admin owns it).
+--
+-- The secret variable `f/locked/secret_token` itself is inserted by the test in
+-- Rust (so it is encrypted with the real workspace key); this fixture only sets
+-- up the locked folder, the resource, and their permissions.
+
+-- Folder the developer cannot read (empty extra_perms, owned by admin only).
+INSERT INTO folder (workspace_id, name, display_name, owners, extra_perms, created_by)
+VALUES ('test-workspace', 'locked', 'Locked Folder', '{"u/test-user"}', '{}', 'test-user');
+
+-- MCP resource owned by the developer (so RLS lets them read the resource),
+-- whose token references the locked secret. The URL is a non-resolvable public
+-- host so that, for an authorized caller, resolution succeeds but the later
+-- connection/SSRF step fails deterministically without network access.
+INSERT INTO resource (workspace_id, path, value, description, resource_type, extra_perms, created_by)
+VALUES (
+    'test-workspace',
+    'u/test-user-3/evil_mcp',
+    '{"name": "evil", "url": "https://mcp.invalid.windmill.test", "token": "$var:f/locked/secret_token"}',
+    'MCP resource whose token points at a locked secret',
+    'mcp',
+    '{}',
+    'test-user-3'
+);

--- a/backend/tests/fixtures/mcp_token_exfil.sql
+++ b/backend/tests/fixtures/mcp_token_exfil.sql
@@ -1,4 +1,4 @@
--- Fixture for the MCP token-exfiltration regression test (GHSA-8m2p-2crh-9h3w).
+-- Fixture for the MCP token-exfiltration regression test.
 --
 -- Models a malicious developer (test-user-3, a plain workspace member) who:
 --   - owns an MCP resource they are allowed to read, and

--- a/backend/tests/mcp_token_exfil.rs
+++ b/backend/tests/mcp_token_exfil.rs
@@ -1,0 +1,112 @@
+//! Regression test for the MCP token-exfiltration vulnerability
+//! (GHSA-8m2p-2crh-9h3w).
+//!
+//! `GET /api/w/{w}/resources/mcp_tools/{path}` builds an MCP client from a
+//! resource whose `token` field is a `$var:` reference. Before the fix the token
+//! was resolved with `get_secret_value_as_admin` on the bare DB pool — no RLS,
+//! no audit — so any workspace member who could read an MCP *resource* could
+//! point its token at *any* secret variable in the workspace (e.g. one in an
+//! admin-only folder) and have it decrypted and shipped as a bearer token.
+//!
+//! The fix resolves the token through the caller's permissioned path
+//! (`get_value_internal` over the authed `user_db`), so the variable RLS — the
+//! same gate as `variables/get_value` — applies and the secret read is audited.
+//!
+//! This test pins, against the `mcp_token_exfil` fixture:
+//!   - a plain developer (test-user-3) who can read the MCP resource but has no
+//!     access to the locked secret is DENIED (401) at token resolution, before
+//!     any connection is attempted, and the secret never leaks;
+//!   - an admin (test-user) clears the variable-RLS gate, the token resolves,
+//!     and the request only fails later at the connect/SSRF step — proving the
+//!     legitimate path still resolves the token (no over-blocking).
+//!
+//! SSRF rejection of an author-controlled URL is covered by the unit test in
+//! `windmill-mcp` (`from_resource_rejects_ssrf_url`).
+#![cfg(feature = "mcp")]
+
+use sqlx::{Pool, Postgres};
+use windmill_test_utils::*;
+
+const SECRET_VALUE: &str = "S3CRET-MCP-TOKEN-VALUE";
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+async fn get(base: &str, path: &str, token: &str) -> (reqwest::StatusCode, String) {
+    let resp = client()
+        .get(format!("{base}/{path}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .expect("request");
+    let status = resp.status();
+    let body = resp.text().await.expect("body");
+    (status, body)
+}
+
+#[sqlx::test(fixtures("base", "mcp_token_exfil"))]
+async fn test_mcp_token_not_exfiltrated(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    // Insert the locked secret variable with a real, workspace-key-encrypted
+    // value so an authorized read genuinely decrypts it.
+    let mc = windmill_common::variables::build_crypt(&db, "test-workspace").await?;
+    let encrypted = windmill_common::variables::encrypt(&mc, SECRET_VALUE);
+    // Runtime-checked query (not the `query!` macro) so no offline `.sqlx` cache
+    // entry is needed for this test-only insert.
+    sqlx::query(
+        "INSERT INTO variable (workspace_id, path, value, is_secret, description, extra_perms)
+         VALUES ('test-workspace', 'f/locked/secret_token', $1, true, 'Locked secret', '{}')",
+    )
+    .bind(&encrypted)
+    .execute(&db)
+    .await?;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base = format!("http://localhost:{port}/api/w/test-workspace/resources/mcp_tools");
+    let path = "u/test-user-3/evil_mcp";
+
+    // ---- CORE REGRESSION: the developer can read the resource but must NOT be
+    //      able to resolve the locked secret. They are denied (401) at the
+    //      variable-RLS gate, before any MCP connection is attempted, and the
+    //      secret never appears in the response.
+    let (status, body) = get(&base, path, "SECRET_TOKEN_3").await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::UNAUTHORIZED,
+        "developer must be denied resolving a secret they can't read (got {status}): {body}"
+    );
+    assert!(
+        !body.contains(SECRET_VALUE),
+        "the locked secret must never leak to the developer: {body}"
+    );
+    assert!(
+        body.contains("don't have access"),
+        "denial should come from the variable-RLS gate, not a connection error: {body}"
+    );
+    // Pre-fix, the token was decrypted as admin and the handler proceeded to the
+    // connection step; that path must no longer be reached for the developer.
+    assert!(
+        !body.contains("Failed to connect to MCP server"),
+        "developer must be blocked before the connection step (would mean the token was resolved): {body}"
+    );
+
+    // ---- NO OVER-BLOCKING: an admin clears the variable-RLS gate, so the token
+    //      resolves and the request only fails later at the connect/SSRF step.
+    //      A different failure mode (not 401, reaches the connection) proves the
+    //      legitimate read still works.
+    let (status, body) = get(&base, path, "SECRET_TOKEN").await;
+    assert_ne!(
+        status,
+        reqwest::StatusCode::UNAUTHORIZED,
+        "admin must clear the variable-RLS gate (got {status}): {body}"
+    );
+    assert!(
+        body.contains("Failed to connect to MCP server"),
+        "admin should resolve the token and only fail at the connect/SSRF step: {body}"
+    );
+
+    Ok(())
+}

--- a/backend/tests/mcp_token_exfil.rs
+++ b/backend/tests/mcp_token_exfil.rs
@@ -1,5 +1,4 @@
-//! Regression test for the MCP token-exfiltration vulnerability
-//! (GHSA-8m2p-2crh-9h3w).
+//! Regression test for the MCP token-exfiltration vulnerability.
 //!
 //! `GET /api/w/{w}/resources/mcp_tools/{path}` builds an MCP client from a
 //! resource whose `token` field is a `$var:` reference. Before the fix the token

--- a/backend/windmill-api/src/mcp_tools.rs
+++ b/backend/windmill-api/src/mcp_tools.rs
@@ -65,7 +65,7 @@ pub(crate) async fn get_mcp_tools(
 
             if let Some(info) = token_info {
                 if let (Some(account_id), Some(true)) = (info.account_id, info.is_expired) {
-                    let refresh_tx = user_db.begin(&authed).await?;
+                    let refresh_tx = user_db.clone().begin(&authed).await?;
                     if let Err(e) = crate::oauth2_oss::_refresh_token(
                         refresh_tx,
                         token_var_path,
@@ -87,7 +87,7 @@ pub(crate) async fn get_mcp_tools(
 
     // Resolve the token through the caller's permissioned (RLS + audit) path so
     // a developer cannot exfiltrate a secret they are not allowed to read by
-    // pointing an MCP resource's token at it (GHSA-8m2p-2crh-9h3w).
+    // pointing an MCP resource's token at it.
     let token = if let Some(token_path) = &mcp_resource.token {
         let token_var_path = token_path.trim_start_matches("$var:");
         if token_var_path.trim().is_empty() {

--- a/backend/windmill-api/src/mcp_tools.rs
+++ b/backend/windmill-api/src/mcp_tools.rs
@@ -5,11 +5,11 @@ use axum::{
 use serde_json::value::RawValue;
 use windmill_api_auth::{check_scopes, ApiAuthed};
 use windmill_common::{
-    db::{UserDB, DB},
+    db::{DbWithOptAuthed, UserDB, DB},
     error::{Error, JsonResult, Result},
     utils::{not_found_if_none, StripPath},
 };
-use windmill_store::resources::explain_resource_perm_error;
+use windmill_store::{resources::explain_resource_perm_error, variables::get_value_internal};
 
 pub(crate) async fn get_mcp_tools(
     authed: ApiAuthed,
@@ -85,7 +85,23 @@ pub(crate) async fn get_mcp_tools(
         }
     }
 
-    let client = windmill_mcp::McpClient::from_resource(mcp_resource, &db, &w_id)
+    // Resolve the token through the caller's permissioned (RLS + audit) path so
+    // a developer cannot exfiltrate a secret they are not allowed to read by
+    // pointing an MCP resource's token at it (GHSA-8m2p-2crh-9h3w).
+    let token = if let Some(token_path) = &mcp_resource.token {
+        let token_var_path = token_path.trim_start_matches("$var:");
+        if token_var_path.trim().is_empty() {
+            None
+        } else {
+            let db_authed =
+                DbWithOptAuthed::from_authed(&authed, db.clone(), Some(user_db.clone()));
+            Some(get_value_internal(&db_authed, &w_id, token_var_path, false).await?)
+        }
+    } else {
+        None
+    };
+
+    let client = windmill_mcp::McpClient::from_resource(mcp_resource, token)
         .await
         .map_err(|e| Error::ExecutionErr(format!("Failed to connect to MCP server: {}", e)))?;
 

--- a/backend/windmill-mcp/Cargo.toml
+++ b/backend/windmill-mcp/Cargo.toml
@@ -29,3 +29,6 @@ http = { workspace = true, optional = true }
 tokio-util = { workspace = true, features = ["rt"], optional = true }
 tokio = { workspace = true, optional = true }
 futures.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/backend/windmill-mcp/src/client/mod.rs
+++ b/backend/windmill-mcp/src/client/mod.rs
@@ -38,7 +38,7 @@ impl McpClient {
     /// `Authorization` header. It MUST be resolved by the caller through the
     /// permissioned (RLS + audit) variable path — `from_resource` never reads
     /// secrets itself, so a caller cannot trick it into decrypting a variable
-    /// they are not allowed to read (GHSA-8m2p-2crh-9h3w).
+    /// they are not allowed to read.
     pub async fn from_resource(resource: McpResource, token: Option<String>) -> Result<Self> {
         // The resource URL is author-controlled and we send a (potentially
         // secret) bearer token to it, so it must be validated against SSRF
@@ -224,8 +224,8 @@ impl McpClient {
 mod tests {
     use super::*;
 
-    /// Regression test for GHSA-8m2p-2crh-9h3w: `from_resource` must refuse to
-    /// connect to a URL that targets a private/internal address (here the AWS
+    /// Regression test: `from_resource` must refuse to connect to a URL that
+    /// targets a private/internal address (here the AWS
     /// instance-metadata endpoint), so a resource author cannot use the MCP
     /// client as an SSRF primitive against internal services. The guard runs
     /// before any connection attempt, so this fails fast without network access.

--- a/backend/windmill-mcp/src/client/mod.rs
+++ b/backend/windmill-mcp/src/client/mod.rs
@@ -22,8 +22,6 @@ use rmcp::{
 };
 use serde_json::{json, Value};
 use std::str::FromStr;
-use windmill_common::variables::get_secret_value_as_admin;
-use windmill_common::DB;
 
 /// MCP client for communicating with external MCP servers
 pub struct McpClient {
@@ -34,18 +32,29 @@ pub struct McpClient {
 }
 
 impl McpClient {
-    /// Create a new MCP client from a resource configuration
-    pub async fn from_resource(resource: McpResource, db: &DB, w_id: &str) -> Result<Self> {
+    /// Create a new MCP client from a resource configuration.
+    ///
+    /// `token`, when present, is the already-resolved bearer token sent as an
+    /// `Authorization` header. It MUST be resolved by the caller through the
+    /// permissioned (RLS + audit) variable path — `from_resource` never reads
+    /// secrets itself, so a caller cannot trick it into decrypting a variable
+    /// they are not allowed to read (GHSA-8m2p-2crh-9h3w).
+    pub async fn from_resource(resource: McpResource, token: Option<String>) -> Result<Self> {
+        // The resource URL is author-controlled and we send a (potentially
+        // secret) bearer token to it, so it must be validated against SSRF
+        // before we connect (e.g. cloud metadata endpoints, internal services).
+        windmill_common::ssrf::validate_url_for_ssrf(&resource.url)
+            .await
+            .map_err(|e| anyhow::anyhow!("MCP server URL is not allowed: {}", e))?;
+
         // Build custom reqwest client with headers if provided
         let mut headers = HeaderMap::new();
-        if let Some(token_path) = &resource.token {
-            if !token_path.trim().is_empty() {
-                let value =
-                    get_secret_value_as_admin(db, w_id, token_path.trim_start_matches("$var:"))
-                        .await?;
+        if let Some(token) = token {
+            let token = token.trim();
+            if !token.is_empty() {
                 headers.insert(
                     HeaderName::from_static("authorization"),
-                    HeaderValue::from_str(format!("Bearer {}", value).as_str())?,
+                    HeaderValue::from_str(format!("Bearer {}", token).as_str())?,
                 );
             }
         }
@@ -208,5 +217,34 @@ impl McpClient {
                     .collect(),
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for GHSA-8m2p-2crh-9h3w: `from_resource` must refuse to
+    /// connect to a URL that targets a private/internal address (here the AWS
+    /// instance-metadata endpoint), so a resource author cannot use the MCP
+    /// client as an SSRF primitive against internal services. The guard runs
+    /// before any connection attempt, so this fails fast without network access.
+    #[tokio::test]
+    async fn from_resource_rejects_ssrf_url() {
+        let resource = McpResource {
+            name: "evil".to_string(),
+            url: "http://169.254.169.254".to_string(),
+            token: None,
+            headers: None,
+        };
+
+        let msg = match McpClient::from_resource(resource, None).await {
+            Ok(_) => panic!("a link-local metadata URL must be rejected before connecting"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            msg.contains("not allowed") && msg.contains("private"),
+            "error should explain the URL was rejected as private/internal, got: {msg}"
+        );
     }
 }

--- a/backend/windmill-mcp/src/client/mod.rs
+++ b/backend/windmill-mcp/src/client/mod.rs
@@ -73,6 +73,12 @@ impl McpClient {
 
         let reqwest_client = reqwest::Client::builder()
             .default_headers(headers)
+            // Don't follow redirects: the SSRF check above only validates the
+            // initial (author-controlled) URL, so following a redirect could
+            // still reach a private/internal address with the bearer token
+            // attached. The MCP streamable-HTTP endpoint is a direct endpoint
+            // and does not legitimately rely on redirects.
+            .redirect(reqwest::redirect::Policy::none())
             .build()
             .context("Failed to build HTTP client")?;
 

--- a/backend/windmill-worker/src/ai/utils.rs
+++ b/backend/windmill-worker/src/ai/utils.rs
@@ -7,6 +7,8 @@ use std::{
 };
 use uuid::Uuid;
 use windmill_ai::types::*;
+#[cfg(feature = "mcp")]
+use windmill_common::client::AuthedClient;
 use windmill_common::flows::FlowModuleValue;
 use windmill_common::{
     db::DB,
@@ -546,7 +548,7 @@ pub async fn load_mcp_tools(
     db: &DB,
     workspace_id: &str,
     mcp_configs: Vec<McpResourceConfig>,
-    auth_token: &str,
+    client: &AuthedClient,
 ) -> Result<(HashMap<String, Arc<McpClient>>, Vec<Tool>), Error> {
     let mut all_mcp_tools = Vec::new();
     let mut mcp_clients = HashMap::new();
@@ -573,27 +575,47 @@ pub async fn load_mcp_tools(
 
         let resource_name = mcp_resource.name.clone();
 
-        // Check if token needs refresh before creating MCP client
-        if let Some(ref token_path) = mcp_resource.token {
+        // Resolve the token through the job's permissioned (RLS + audit) path so
+        // the AI agent cannot exfiltrate a secret its identity is not allowed to
+        // read by pointing an MCP resource's token at it (GHSA-8m2p-2crh-9h3w).
+        let token = if let Some(ref token_path) = mcp_resource.token {
             let token_var_path = token_path.trim_start_matches("$var:");
-            if let Err(e) =
-                refresh_token_if_expired(db, workspace_id, token_var_path, auth_token).await
-            {
-                tracing::warn!(
-                    "Failed to refresh token for MCP resource {}: {}. Proceeding with possibly expired token.",
-                    resource_name, e
-                );
+            if token_var_path.trim().is_empty() {
+                None
+            } else {
+                // Refresh first (best-effort) so the value we read is current.
+                if let Err(e) =
+                    refresh_token_if_expired(db, workspace_id, token_var_path, &client.token).await
+                {
+                    tracing::warn!(
+                        "Failed to refresh token for MCP resource {}: {}. Proceeding with possibly expired token.",
+                        resource_name, e
+                    );
+                }
+                Some(
+                    client
+                        .get_variable_value(token_var_path)
+                        .await
+                        .map_err(|e| {
+                            Error::internal_err(format!(
+                                "Failed to resolve token variable {} for MCP resource {}: {}",
+                                token_var_path, resource_name, e
+                            ))
+                        })?,
+                )
             }
-        }
+        } else {
+            None
+        };
 
         // Create new MCP client for this execution
         tracing::debug!("Creating fresh MCP client for {}", resource_name);
-        let client = McpClient::from_resource(mcp_resource, db, workspace_id)
+        let mcp_conn = McpClient::from_resource(mcp_resource, token)
             .await
             .context("Failed to create MCP client")?;
 
         // Get raw MCP tools from client
-        let raw_mcp_tools = client.available_tools();
+        let raw_mcp_tools = mcp_conn.available_tools();
 
         // Convert to Windmill Tool format
         let converted_tools =
@@ -616,7 +638,7 @@ pub async fn load_mcp_tools(
         all_mcp_tools.extend(filtered_tools);
 
         // Store client for later use and cleanup
-        let mcp_client = Arc::new(client);
+        let mcp_client = Arc::new(mcp_conn);
         mcp_clients.insert(resource_name, mcp_client);
     }
 
@@ -663,7 +685,7 @@ pub async fn load_mcp_tools<T>(
     _db: &DB,
     _workspace_id: &str,
     _mcp_configs: Vec<McpResourceConfig>,
-    _auth_token: &str,
+    _client: &windmill_common::client::AuthedClient,
 ) -> Result<(HashMap<String, Arc<T>>, Vec<Tool>), Error> {
     Ok((HashMap::new(), Vec::new()))
 }

--- a/backend/windmill-worker/src/ai/utils.rs
+++ b/backend/windmill-worker/src/ai/utils.rs
@@ -577,7 +577,7 @@ pub async fn load_mcp_tools(
 
         // Resolve the token through the job's permissioned (RLS + audit) path so
         // the AI agent cannot exfiltrate a secret its identity is not allowed to
-        // read by pointing an MCP resource's token at it (GHSA-8m2p-2crh-9h3w).
+        // read by pointing an MCP resource's token at it.
         let token = if let Some(ref token_path) = mcp_resource.token {
             let token_var_path = token_path.trim_start_matches("$var:");
             if token_var_path.trim().is_empty() {

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -432,7 +432,7 @@ pub async fn handle_ai_agent_job(
 
     let mcp_clients = if !mcp_configs.is_empty() {
         let (clients, mcp_tools) =
-            load_mcp_tools(db, &job.workspace_id, mcp_configs, &client.token).await?;
+            load_mcp_tools(db, &job.workspace_id, mcp_configs, client).await?;
         tools.extend(mcp_tools);
         clients
     } else {


### PR DESCRIPTION
## Summary

Security fix for a workspace variable exfiltration + SSRF issue via the MCP `mcp_tools` resource indirection.

`McpClient::from_resource` resolved the resource's `token` field (a `$var:` reference) with `get_secret_value_as_admin` on the **bare DB pool** — no RLS, no audit — then sent the decrypted secret as an `Authorization: Bearer` header to the resource author-controlled `url` with **no SSRF check**. Any developer-role user could:
- read a secret variable in a folder they have no access to (e.g. an admin-only folder), by pointing an MCP resource's token at it, and
- use the request as an SSRF primitive against internal services (e.g. `http://169.254.169.254`).

Reachable via `GET /api/w/{w}/resources/mcp_tools/{path}` and via the AI-agent path (`load_mcp_tools`).

## Changes

- `windmill-mcp` `from_resource` no longer reads secrets itself: it now takes an **already-resolved** `token: Option<String>`, and validates the resource URL with `windmill_common::ssrf::validate_url_for_ssrf` **before** connecting.
- API handler (`mcp_tools.rs`): resolves the token through the caller's permissioned path — `get_value_internal` over `DbWithOptAuthed::from_authed(&authed, db, user_db)` — applying the same variable RLS as `/variables/get_value` and auditing the secret read. An unauthorized read now returns 401 before any connection.
- Worker AI-agent path (`ai/utils.rs`): resolves the token via `AuthedClient::get_variable_value` (the permissioned `/variables/get_value` endpoint carrying the job's own identity token), instead of the bare-pool admin read. `load_mcp_tools` now takes `&AuthedClient`.
- Removed the only vulnerable `get_secret_value_as_admin` usage (the helper remains for its legitimate admin callers elsewhere).

## Test plan

- [x] `cargo test -p windmill-mcp` — new unit test `from_resource_rejects_ssrf_url` (rejects `169.254.169.254` before connecting, no network needed)
- [x] `cargo test --features mcp,oauth2 --test mcp_token_exfil` — integration regression test: a developer who can read the MCP resource but not the locked secret gets **401** (denied at the variable-RLS gate, before connecting); an admin clears the gate, the token resolves, and the request only fails later at the connect/SSRF step (no over-blocking). Fails pre-fix.
- [x] `cargo check --features mcp,oauth2 -p windmill-api` and `cargo check --features quickjs -p windmill-worker` (non-mcp stub path) both compile cleanly.
- [ ] EE-only: confirm a `variables.decrypt_secret` audit row is emitted on authorized reads (audit logging is a no-op in OSS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)