### PR TITLE
fix(nsjail): precompile python stdlib + raise download rlimit_as

### DIFF
--- a/.github/DockerfileBackendTests
+++ b/.github/DockerfileBackendTests
@@ -28,7 +28,7 @@ ENV PATH="${PATH}:/usr/local/go/bin"
 ENV GO_PATH=/usr/local/go/bin/go
 
 # UV
-RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.24/uv-installer.sh | sh && mv /usr/local/cargo/bin/uv /usr/local/bin/uv
+RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.25/uv-installer.sh | sh && mv /usr/local/cargo/bin/uv /usr/local/bin/uv
 
 ENV TZ=Etc/UTC
 

--- a/.github/workflows/backend-test-windows.yml
+++ b/.github/workflows/backend-test-windows.yml
@@ -74,7 +74,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6.2.1
         with:
-          version: "0.9.24"
+          version: "0.9.25"
 
       - uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -62,7 +62,7 @@ jobs:
           node-version: "20"
       - uses: astral-sh/setup-uv@v6.2.1
         with:
-          version: "0.9.24"
+          version: "0.9.25"
       - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.3"

--- a/Dockerfile
+++ b/Dockerfile
@@ -233,11 +233,14 @@ ENV PATH="${PATH}:/usr/local/go/bin"
 ENV GO_PATH=/usr/local/go/bin/go
 
 # Install UV
-RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.24/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
+RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.25/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
 
 # Preinstall python runtimes to temp build location (will copy with world-writable perms later)
-RUN UV_CACHE_DIR=/tmp/build_cache/uv UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install 3.11
-RUN UV_CACHE_DIR=/tmp/build_cache/uv UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY
+# --compile-bytecode precompiles the stdlib to .pyc so jobs don't recompile it on every run
+# under the read-only nsjail runtime mount (uv >= 0.9.25). The copy below MUST preserve
+# timestamps or Python's mtime-based .pyc invalidation discards these compiled files.
+RUN UV_CACHE_DIR=/tmp/build_cache/uv UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install 3.11 --compile-bytecode
+RUN UV_CACHE_DIR=/tmp/build_cache/uv UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY --compile-bytecode
 
 
 RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
@@ -259,7 +262,7 @@ RUN export GOCACHE=/tmp/build_cache/go && \
 # chmod a+rw adds read+write WITHOUT removing execute bits (755->777, 644->666)
 # Note: uv python install only creates py_runtime, not uv cache - we create uv/go dirs for runtime
 RUN mkdir -p /tmp/windmill/cache && \
-    cp -r /tmp/build_cache/* /tmp/windmill/cache/ && \
+    cp -r --preserve=timestamps /tmp/build_cache/* /tmp/windmill/cache/ && \
     chmod -R a+rw /tmp/windmill/cache && \
     rm -rf /tmp/build_cache && \
     mkdir -p -m 777 /tmp/windmill/cache/uv /tmp/windmill/cache/go /tmp/windmill/cache/rustup /tmp/windmill/cache/cargo

--- a/backend/windmill-worker/nsjail/download.py.config.proto
+++ b/backend/windmill-worker/nsjail/download.py.config.proto
@@ -5,7 +5,14 @@ hostname: "python"
 log_level: ERROR
 time_limit: 900
 
-rlimit_as: 2048
+# uv's --compile-bytecode spawns a bytecode-compile thread pool sized to the
+# host's CPU count. Each thread reserves virtual address space for its stack, so
+# on high-core machines the aggregate overruns a low rlimit_as and installs fail
+# intermittently with "OS can't spawn worker thread: Resource temporarily
+# unavailable (os error 11)" / "memory allocation failed". A low cap (was 2048)
+# is the address-space companion to the fd exhaustion fixed below; raised well
+# above the run sandbox's 4096 to give the compile pool headroom on large nodes.
+rlimit_as: 8192
 rlimit_cpu: 1000
 rlimit_fsize: 1024
 # uv's --compile-bytecode spawns a Python interpreter that compiles .py files

--- a/backend/windmill-worker/src/python_versions.rs
+++ b/backend/windmill-worker/src/python_versions.rs
@@ -537,6 +537,11 @@ impl PyV {
                 &v,
                 "--python-preference=only-managed",
                 "--no-bin",
+                // Compile the runtime's stdlib to bytecode at install time. The
+                // runtime is mounted read-only into the job nsjail, so without
+                // precompiled .pyc Python would recompile ~stdlib from source on
+                // every job (and can never persist it). Requires uv >= 0.9.25.
+                "--compile-bytecode",
             ])
             // TODO: Do we need these?
             .envs([

--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -54,14 +54,17 @@ RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmo
 ENV TZ=Etc/UTC
 
 # Install UV
-RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.24/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
+RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.25/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
 
 # Preinstall python runtime to temp location (will copy with world-writable perms later)
-RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY
+# --compile-bytecode precompiles the stdlib to .pyc so jobs don't recompile it on every run
+# under the read-only nsjail runtime mount (uv >= 0.9.25). The copy below MUST preserve
+# timestamps or Python's mtime-based .pyc invalidation discards these compiled files.
+RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY --compile-bytecode
 
 # Copy to final location with world-writable permissions for arbitrary UID support
 RUN mkdir -p /tmp/windmill/cache && \
-    cp -r /tmp/build_cache/* /tmp/windmill/cache/ && \
+    cp -r --preserve=timestamps /tmp/build_cache/* /tmp/windmill/cache/ && \
     chmod -R a+rw /tmp/windmill/cache && \
     rm -rf /tmp/build_cache && \
     mkdir -p -m 777 /tmp/windmill/cache/uv

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -54,14 +54,17 @@ RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmo
 ENV TZ=Etc/UTC
 
 # Install UV
-RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.24/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
+RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.25/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
 
 # Preinstall python runtime to temp location (will copy with world-writable perms later)
-RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY
+# --compile-bytecode precompiles the stdlib to .pyc so jobs don't recompile it on every run
+# under the read-only nsjail runtime mount (uv >= 0.9.25). The copy below MUST preserve
+# timestamps or Python's mtime-based .pyc invalidation discards these compiled files.
+RUN UV_PYTHON_INSTALL_DIR=/tmp/build_cache/py_runtime uv python install $LATEST_STABLE_PY --compile-bytecode
 
 # Copy to final location with world-writable permissions for arbitrary UID support
 RUN mkdir -p /tmp/windmill/cache && \
-    cp -r /tmp/build_cache/* /tmp/windmill/cache/ && \
+    cp -r --preserve=timestamps /tmp/build_cache/* /tmp/windmill/cache/ && \
     chmod -R a+rw /tmp/windmill/cache && \
     rm -rf /tmp/build_cache && \
     mkdir -p -m 777 /tmp/windmill/cache/uv


### PR DESCRIPTION
## Summary

Two address-space / bytecode follow-ups to #9393 and #9414 that together remove the per-job stdlib recompilation penalty and stop the python dependency-install sandbox from failing on multi-core nodes.

**Issue 1 — `rlimit_as: 2048` too low for `uv --compile-bytecode` (companion to #9414).**
#9393 added `uv pip install --compile-bytecode` inside the python download nsjail; #9414 raised that sandbox's `rlimit_nofile`. But its **address-space** limit was still `rlimit_as: 2048` MB (the *run* sandbox uses 4096). uv's compile thread pool is sized to the host CPU count, and on multi-core nodes the thread stacks + mmaps overrun 2 GB, so installs fail **intermittently**:
```
thread 'uv-compile' panicked ... OS can't spawn worker thread: Resource temporarily unavailable (os error 11)
memory allocation of 16 bytes failed
Aborted
```
Raised `rlimit_as` to **8192** (well above the run sandbox's 4096) to give the compile pool headroom on large nodes.

**Issue 2 — managed runtime stdlib wasn't bytecode-compiled (incomplete follow-up to #9393).**
The managed Python runtime (installed via `uv python install`) shipped **without** stdlib `.pyc`. Its dir is mounted **read-only** into the job nsjail, so Python recompiled ~240 stdlib modules from source **on every job** and could never persist them. `--compile-bytecode` from #9393 only covered user deps, not the interpreter's own stdlib.

Fix: install the managed runtime with `uv python install --compile-bytecode` (added to uv in **0.9.25**), at both build time (Dockerfiles) and runtime (`python_versions.rs`). This required bumping uv **0.9.24 → 0.9.25**. The build-time bake copy also had to change `cp -r` → `cp -r --preserve=timestamps`: Python's default `.pyc` invalidation is **mtime-based**, so a non-preserving copy shifts the source `.py` mtimes and silently discards every compiled file.

## Changes
- `backend/windmill-worker/nsjail/download.py.config.proto`: `rlimit_as` 2048 → 8192 (+ comment).
- `backend/windmill-worker/src/python_versions.rs`: add `--compile-bytecode` to the runtime `uv python install`.
- `Dockerfile`, `docker/DockerfileSlim`, `docker/DockerfileSlimEe`: add `--compile-bytecode` to the build-time `uv python install`, and change the runtime-bake copy to `cp -r --preserve=timestamps` so the precompiled `.pyc` stay valid.
- Bump uv `0.9.24 → 0.9.25` everywhere it's pinned: the three runtime Dockerfiles, `.github/DockerfileBackendTests`, and the `setup-uv` step in `backend-test.yml` / `backend-test-windows.yml`.

## Verification (e2e benchmarks)

Reproduced both mechanisms faithfully on a 24-core box (`ulimit -v` == nsjail `rlimit_as`; a read-only stdlib dir == the read-only nsjail runtime mount).

**Issue 1** — ran the *exact* download-sandbox `uv pip install ... --compile-bytecode` (botocore, many files) under each cap, 5 trials each:

| `rlimit_as` | result |
|---|---|
| 2048 MB (old) | **5/5 FAIL** — `uv-installer/src/compile.rs` panic, "memory allocation of N bytes failed", Aborted (core dumped) |
| 8192 MB (new) | **5/5 pass** |

**Issue 2** — cold `import requests` under a read-only runtime, baked the old way vs the new way (15 runs each):

| bake | stdlib `.pyc` | cold `import requests` |
|---|---|---|
| OLD (no `--compile-bytecode`, `cp -r`) | 35 | **170.0 ms** mean |
| NEW (`--compile-bytecode` + `--preserve=timestamps`) | 1081 | **51.6 ms** mean / 49.7 ms best |

~3.3× faster, matching the reported 0.36s → 0.075s direction. The tight NEW timing also confirms the timestamp-preserving copy keeps the `.pyc` valid (otherwise it would recompile and be as slow as OLD). Also confirmed uv `0.9.24 → 0.9.25` is a purely additive bump (no breaking changes for our `pip compile` / `pip install` / `python install` / `python find` / `venv` use cases).

## Test plan
- [ ] Build `Dockerfile` / `DockerfileSlim` / `DockerfileSlimEe` and confirm `/tmp/windmill/cache/py_runtime/**/__pycache__/*.pyc` exist with mtimes matching their source `.py`.
- [ ] On a high-core node, run a python dep-install job and confirm no intermittent "os error 11" / "memory allocation failed".
- [ ] Under NSJAIL, confirm a cold `import requests` no longer recompiles the stdlib per job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Precompiled the managed Python stdlib and raised the `nsjail` download sandbox `rlimit_as` to stabilize installs on multi-core hosts and remove per-job stdlib recompilation. This speeds up cold imports and prevents intermittent install failures.

- **Bug Fixes**
  - Added `--compile-bytecode` to `uv python install` at build and runtime so the managed stdlib ships with `.pyc`. Copied with `cp -r --preserve=timestamps` to keep `.pyc` valid under the read-only runtime mount.
  - Increased download sandbox `rlimit_as` from 2048 MB to 8192 MB to avoid thread allocation failures during `uv --compile-bytecode` on high-core machines.

- **Dependencies**
  - Bumped `uv` from `0.9.24` to `0.9.25` across Dockerfiles and CI to enable `--compile-bytecode`.

<sup>Written for commit 6c85b970993c581ce604b220565c2275973089a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

