### PR TITLE
feat: use metadata model for small AI tasks

### DIFF
--- a/frontend/src/lib/components/copilot/CronGen.svelte
+++ b/frontend/src/lib/components/copilot/CronGen.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { ExternalLink, Wand2 } from 'lucide-svelte'
 	import Button from '../common/button/Button.svelte'
-	import { getNonStreamingCompletion } from './lib'
+	import { getNonStreamingMetadataCompletion } from './lib'
 	import Popover from '$lib/components/meltComponents/Popover.svelte'
 	import { sendUserToast } from '$lib/toast'
 
@@ -54,7 +54,7 @@
 				}
 			]
 
-			const response = await getNonStreamingCompletion(messages, abortController)
+			const response = await getNonStreamingMetadataCompletion(messages, abortController)
 
 			if (response.startsWith('ERROR:')) {
 				throw response.replace('ERROR:', '').trim()

--- a/frontend/src/lib/components/copilot/IteratorGen.svelte
+++ b/frontend/src/lib/components/copilot/IteratorGen.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Check, Loader2, Wand2 } from 'lucide-svelte'
 	import Button from '../common/button/Button.svelte'
-	import { getNonStreamingCompletion } from './lib'
+	import { getNonStreamingMetadataCompletion } from './lib'
 	import { sendUserToast } from '$lib/toast'
 	import type { Flow, InputTransform } from '$lib/gen'
 	import ManualPopover from '../ManualPopover.svelte'
@@ -68,7 +68,7 @@ ${YAML.stringify(availableData)}</available>
 Reply with the most probable answer, do not explain or discuss.
 Use javascript object dot notation to access the properties.
 Only output the expression, do not explain or discuss.`
-			generatedContent = await getNonStreamingCompletion(
+			generatedContent = await getNonStreamingMetadataCompletion(
 				[
 					{
 						role: 'user',

--- a/frontend/src/lib/components/copilot/PredicateGen.svelte
+++ b/frontend/src/lib/components/copilot/PredicateGen.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Wand2 } from 'lucide-svelte'
 	import Button from '../common/button/Button.svelte'
-	import { getNonStreamingCompletion } from './lib'
+	import { getNonStreamingMetadataCompletion } from './lib'
 	import { sendUserToast } from '$lib/toast'
 	import { createEventDispatcher, getContext } from 'svelte'
 	import type { FlowEditorContext } from '../flows/types'
@@ -66,7 +66,7 @@ Here's a summary of the available data:
 ${YAML.stringify(availableData)}</available>
 If the branching is made inside a for-loop, the iterator value is accessible as flow_input.iter.value
 Only return the expression without any wrapper. Do not explain or discuss.`
-			const result = await getNonStreamingCompletion(
+			const result = await getNonStreamingMetadataCompletion(
 				[
 					{
 						role: 'user',

--- a/frontend/src/lib/components/copilot/RegexGen.svelte
+++ b/frontend/src/lib/components/copilot/RegexGen.svelte
@@ -4,7 +4,7 @@
 	import { base } from '$lib/base'
 	import { Button } from '../common'
 
-	import { getNonStreamingCompletion } from './lib'
+	import { getNonStreamingMetadataCompletion } from './lib'
 	import { sendUserToast } from '$lib/toast'
 	import Popover from '$lib/components/meltComponents/Popover.svelte'
 
@@ -28,7 +28,7 @@
 		genLoading = true
 		abortController = new AbortController()
 		try {
-			const res = await getNonStreamingCompletion(
+			const res = await getNonStreamingMetadataCompletion(
 				[
 					{
 						role: 'system',
@@ -134,7 +134,7 @@
 									onGenerate()
 								}
 							}}
-								placeholder={'Describe what the regex should doww'}
+								placeholder="Describe what the regex should do"
 							/>
 							<Button
 								size="xs"
@@ -153,7 +153,7 @@
 						</div>
 						{#if promptHistory.length > 0}
 							<div class="w-96 flex flex-col gap-1">
-								{#each promptHistory as p}
+								{#each promptHistory as p (p)}
 									<Button
 										size="xs2"
 										color="light"

--- a/frontend/src/lib/components/copilot/ResourceGen.svelte
+++ b/frontend/src/lib/components/copilot/ResourceGen.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { ExternalLink, Wand2 } from 'lucide-svelte'
 	import Button from '../common/button/Button.svelte'
-	import { getNonStreamingCompletion } from './lib'
+	import { getNonStreamingMetadataCompletion } from './lib'
 	import Popover from '$lib/components/meltComponents/Popover.svelte'
 	import { sendUserToast } from '$lib/toast'
 	import { base } from '$lib/base'
@@ -95,7 +95,7 @@
 				}
 			]
 
-			let response = await getNonStreamingCompletion(messages, abortController)
+			let response = await getNonStreamingMetadataCompletion(messages, abortController)
 
 			// Strip markdown fences if present
 			response = response.trim()
@@ -151,7 +151,7 @@
 								generateResource()
 							}
 						}}
-					/>
+					></textarea>
 					<Button
 						size="xs"
 						color="light"

--- a/frontend/src/lib/components/copilot/StepInputGen.svelte
+++ b/frontend/src/lib/components/copilot/StepInputGen.svelte
@@ -3,7 +3,7 @@
 
 	import { Check, Loader2, Wand2 } from 'lucide-svelte'
 	import Button from '../common/button/Button.svelte'
-	import { getNonStreamingCompletion } from './lib'
+	import { getNonStreamingMetadataCompletion } from './lib'
 	import { sendUserToast } from '$lib/toast'
 	import type { Flow, InputTransform } from '$lib/gen'
 	import { createEventDispatcher, getContext, untrack } from 'svelte'
@@ -123,7 +123,7 @@ If none of the available results are appropriate, are already used or are more a
 Reply with the most probable answer, do not explain or discuss.
 Use javascript object dot notation to access the properties.
 Only return the expression without any wrapper.`
-			generatedContent = await getNonStreamingCompletion(
+			generatedContent = await getNonStreamingMetadataCompletion(
 				[
 					{
 						role: 'user',

--- a/frontend/src/lib/components/copilot/StepInputsGen.svelte
+++ b/frontend/src/lib/components/copilot/StepInputsGen.svelte
@@ -7,7 +7,7 @@
 	import type { FlowEditorContext } from '../flows/types'
 	import type { PickableProperties } from '../flows/previousResults'
 	import { getContext } from 'svelte'
-	import { getNonStreamingCompletion } from './lib'
+	import { getNonStreamingMetadataCompletion } from './lib'
 	import { sendUserToast } from '$lib/toast'
 	import Button from '../common/button/Button.svelte'
 	import type { FlowCopilotContext } from './flow'
@@ -89,7 +89,7 @@ Your answer has to be in the following format (one line per input):
 input_name1: expression1
 input_name2: expression2
 ...`
-			generatedContent = await getNonStreamingCompletion(
+			generatedContent = await getNonStreamingMetadataCompletion(
 				[
 					{
 						role: 'user',

--- a/frontend/src/lib/components/copilot/chat/openai-responses.ts
+++ b/frontend/src/lib/components/copilot/chat/openai-responses.ts
@@ -386,17 +386,17 @@ export async function parseOpenAIResponsesCompletion(
 export async function getNonStreamingOpenAIResponsesCompletion(
 	messages: ChatCompletionMessageParam[],
 	abortController: AbortController,
-	testOptions?: {
+	options?: {
 		apiKey?: string
 		workspace?: string
 		resourcePath?: string
-		forceModelProvider: AIProviderModel
+		forceModelProvider?: AIProviderModel
 	}
 ): Promise<string> {
 	const { provider, config } = getProviderAndCompletionConfig({
 		messages,
 		stream: false,
-		forceModelProvider: testOptions?.forceModelProvider
+		forceModelProvider: options?.forceModelProvider
 	})
 
 	const { instructions, input } = convertMessagesToResponsesInput(messages)
@@ -412,22 +412,22 @@ export async function getNonStreamingOpenAIResponsesCompletion(
 		}
 	}
 
-	if (testOptions?.resourcePath) {
+	if (options?.resourcePath) {
 		fetchOptions.headers = {
 			...fetchOptions.headers,
-			'X-Resource-Path': testOptions.resourcePath
+			'X-Resource-Path': options.resourcePath
 		}
-	} else if (testOptions?.apiKey) {
+	} else if (options?.apiKey) {
 		fetchOptions.headers = {
 			...fetchOptions.headers,
-			'X-API-Key': testOptions.apiKey
+			'X-API-Key': options.apiKey
 		}
 	}
 
-	const openaiClient = testOptions?.apiKey
+	const openaiClient = options?.apiKey
 		? createOpenAIProxyClient(getAiProxyBaseURL())
-		: testOptions?.workspace
-			? workspaceAIClients.createOpenaiClient(testOptions.workspace)
+		: options?.workspace
+			? workspaceAIClients.createOpenaiClient(options.workspace)
 			: workspaceAIClients.getOpenaiClient()
 
 	const response = await openaiClient.responses.create(

--- a/frontend/src/lib/components/copilot/lib.ts
+++ b/frontend/src/lib/components/copilot/lib.ts
@@ -24,7 +24,7 @@ import {
 import { convertOpenAIToAnthropicMessages } from './chat/anthropic'
 import type { Stream } from 'openai/core/streaming.mjs'
 import { generateRandomString } from '$lib/utils'
-import { copilotInfo, getCurrentModel } from '$lib/aiStore'
+import { copilotInfo, getCurrentModel, getMetadataModel } from '$lib/aiStore'
 import {
 	emptyChatTokenUsage,
 	openAICompletionsUsageToChatTokenUsage,
@@ -753,18 +753,18 @@ export function getProviderAndCompletionConfig<K extends boolean>({
 export async function getNonStreamingCompletion(
 	messages: ChatCompletionMessageParam[],
 	abortController: AbortController,
-	testOptions?: {
+	options?: {
 		apiKey?: string // testing API KEY using the global ai proxy
 		resourcePath?: string // testing resource path passed as a header to the backend proxy
 		workspace?: string // use a specific workspace proxy when testing a workspace resource
-		forceModelProvider: AIProviderModel
+		forceModelProvider?: AIProviderModel
 	}
 ) {
 	let response: string | undefined = ''
 	const { provider, config } = getProviderAndCompletionConfig({
 		messages,
 		stream: false,
-		forceModelProvider: testOptions?.forceModelProvider
+		forceModelProvider: options?.forceModelProvider
 	})
 
 	// Use Responses API for OpenAI and Azure OpenAI
@@ -773,7 +773,7 @@ export async function getNonStreamingCompletion(
 			const response = await getNonStreamingOpenAIResponsesCompletion(
 				messages,
 				abortController,
-				testOptions
+				options
 			)
 			return response
 		} catch (error) {
@@ -790,30 +790,39 @@ export async function getNonStreamingCompletion(
 			'X-Provider': provider
 		}
 	}
-	if (testOptions?.resourcePath) {
+	if (options?.resourcePath) {
 		fetchOptions.headers = {
 			...fetchOptions.headers,
-			'X-Resource-Path': testOptions.resourcePath
+			'X-Resource-Path': options.resourcePath
 		}
-	} else if (testOptions?.apiKey) {
+	} else if (options?.apiKey) {
 		if (provider === 'customai') {
 			throw new Error('Cannot test API key for Custom AI, only resource path is supported')
 		}
 
 		fetchOptions.headers = {
 			...fetchOptions.headers,
-			'X-API-Key': testOptions.apiKey
+			'X-API-Key': options.apiKey
 		}
 	}
-	const openaiClient = testOptions?.apiKey
+	const openaiClient = options?.apiKey
 		? createOpenAIProxyClient(getAiProxyBaseURL())
-		: testOptions?.workspace
-			? workspaceAIClients.createOpenaiClient(testOptions.workspace)
+		: options?.workspace
+			? workspaceAIClients.createOpenaiClient(options.workspace)
 			: workspaceAIClients.getOpenaiClient()
 
 	const completion = await openaiClient.chat.completions.create(config, fetchOptions)
 	response = completion.choices?.[0]?.message.content || ''
 	return response
+}
+
+export async function getNonStreamingMetadataCompletion(
+	messages: ChatCompletionMessageParam[],
+	abortController: AbortController
+) {
+	return getNonStreamingCompletion(messages, abortController, {
+		forceModelProvider: getMetadataModel()
+	})
 }
 
 export const FIM_MAX_TOKENS = 256

--- a/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
@@ -35,7 +35,7 @@ import {
 	setGetPreviewStatusHandler,
 	setOpenPreviewHandler
 } from '$lib/components/copilot/chat/global/core'
-import { getNonStreamingCompletion } from '$lib/components/copilot/lib'
+import { getNonStreamingMetadataCompletion } from '$lib/components/copilot/lib'
 import type { DisplayMessage } from '$lib/components/copilot/chat/shared'
 import type { ChatCompletionMessageParam } from 'openai/resources/index.mjs'
 
@@ -190,7 +190,9 @@ async function generateSessionSummary(displayMessages: DisplayMessage[]): Promis
 		}
 	]
 	try {
-		return normalizeGeneratedSummary(await getNonStreamingCompletion(messages, abortController))
+		return normalizeGeneratedSummary(
+			await getNonStreamingMetadataCompletion(messages, abortController)
+		)
 	} finally {
 		clearTimeout(timeout)
 	}


### PR DESCRIPTION
## Summary
Use the configured metadata generation model for small AI helper tasks instead of the active chat/session model. This applies the metadata model setting to session title generation and bounded one-shot helpers such as cron, regex, resource JSON, predicate, iterator, and step input suggestions.

## Changes
- Add `getNonStreamingMetadataCompletion()` to centralize metadata-model routing for non-streaming helper calls.
- Route session naming and small copilot UI helpers through the metadata completion wrapper.
- Keep key testing and main chat/code generation on their explicit selected models.
- Fix two Svelte issues found in touched files: key regex prompt history entries and avoid a self-closing `textarea`.

## Test plan
- [x] `npm run check:fast`
- [x] `npm run test:unit -- lib.test.ts sessionState.test.ts --run`
- [x] `npm run check` (passes with existing repo warnings)
- [x] `git diff --check`
- [x] Local review: no issues found
- [x] Browser smoke test `/sessions` on localhost:3060 with global-AI dev flag; fresh session mounted cleanly