### PR TITLE
fix(apps): relock no longer reverts raw app to a stale version

### DIFF
--- a/backend/.sqlx/query-afb0762c88d9232b79090f2e5966e78437a5e4d3b5e2341ec5f7725a28870270.json
+++ b/backend/.sqlx/query-afb0762c88d9232b79090f2e5966e78437a5e4d3b5e2341ec5f7725a28870270.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE app SET versions = array_append(versions, $1::bigint) WHERE path = $2 AND workspace_id = $3 AND versions[array_upper(versions, 1)] = $1::bigint",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "afb0762c88d9232b79090f2e5966e78437a5e4d3b5e2341ec5f7725a28870270"
+}

--- a/backend/windmill-worker/src/worker_lockfiles.rs
+++ b/backend/windmill-worker/src/worker_lockfiles.rs
@@ -2070,6 +2070,32 @@ pub async fn handle_app_dependency_job(
         .and_then(|x| x.get("temp_script_refs"))
         .and_then(|v| serde_json::from_str(v.get()).ok());
 
+    // The version captured at job creation can be stale (the app may have been
+    // redeployed since). Relock the current latest instead, mirroring the flow
+    // dependency handler.
+    let id = if triggered_by_relative_import {
+        let latest_version = sqlx::query_scalar!(
+            "SELECT id FROM app_version WHERE app_id = (SELECT id FROM app WHERE path = $1 AND workspace_id = $2) ORDER BY created_at DESC LIMIT 1",
+            job_path,
+            job.workspace_id
+        )
+        .fetch_optional(db)
+        .await?;
+        match latest_version {
+            Some(latest_version) if latest_version != id => {
+                tracing::info!(
+                    "App version changed since dependency job was queued ({} -> {}), using latest",
+                    id,
+                    latest_version
+                );
+                latest_version
+            }
+            _ => id,
+        }
+    } else {
+        id
+    };
+
     sqlx::query!(
         "DELETE FROM workspace_runnable_dependencies WHERE app_path = $1 AND workspace_id = $2",
         job_path,
@@ -2163,13 +2189,14 @@ pub async fn handle_app_dependency_job(
             .execute(db)
             .await?;
 
-        // NOTE: Temporary solution.
-        // Ideally we do this for every job regardless whether it was triggered by relative import or by creation/update of the app.
-        // NOTE: For now is not solving any problem but at some point we will introduce latest version caching
-        // and when we do this will be last operation that will make new version appear as the latest and will trigger cache invalidation for all worker.
+        // Re-publish the relocked version as latest for cache invalidation, but
+        // only if it is still the latest: the guard makes this a single atomic,
+        // never-demoting statement. Without it, a concurrent deploy that landed a
+        // newer version (e.g. same git-sync push) would be reverted, pointing a
+        // raw app's bundle_secret at a version with no bundle (404 / white screen).
         if triggered_by_relative_import {
             sqlx::query!(
-                "UPDATE app SET versions = array_append(versions, $1::bigint) WHERE path = $2 AND workspace_id = $3",
+                "UPDATE app SET versions = array_append(versions, $1::bigint) WHERE path = $2 AND workspace_id = $3 AND versions[array_upper(versions, 1)] = $1::bigint",
                 id,
                 &job_path,
                 &job.workspace_id


### PR DESCRIPTION
## Problem

A customer (EE v1.713.0) pushing a **raw code app** from a dev workspace to a prod workspace via a GitHub Action (`wmill sync push`) saw a **white screen** in prod. The browser 404'd on the app bundle:

```
GET /api/w/vm-prod/apps_u/get_data/v/<secret>.css  -> 404
GET /api/w/vm-prod/apps_u/get_data/v/<secret>.js   -> 404
```

Manually redeploying the app in prod fixed it; re-merging from dev recreated it every time.

## Root cause

The raw app's backend imports a workspace script (`import f.easm.package_version`). The push deploys that script **and** the app in the same batch.

1. The script's dependency job snapshots the app's **old** version `V_old` (`trigger_dependents.rs` enqueues an `AppDependencies` job with the latest version at that moment).
2. The app push then creates **`V_new`** and uploads the JS/CSS bundle keyed to `V_new`.
3. The relock job runs in `handle_app_dependency_job` and, because it was `triggered_by_relative_import`, re-appends `V_old` to `app.versions` — making `V_old` the latest again.

`get_app` computes `bundle_secret` from `app.versions.last()`, so the served HTML requests the bundle for `V_old`, which has no stored bundle → 404 / white screen. A manual single-app redeploy makes a fresh bundled version the true latest (no concurrent script relock racing it), which is why it temporarily fixed the issue.

This is the same class of stale-version race fixed for **flows** in #8673; the analogous guard was never applied to the app handler added in #6564.

## Fix

In `handle_app_dependency_job`, when triggered by a relative import:

1. **Re-query the current latest version** and relock that one instead of the stale snapshot captured at job-creation time (mirrors the flow dependency handler).
2. **Guard the re-publish `array_append`** with `AND versions[array_upper(versions, 1)] = $1::bigint` so it becomes a single atomic, **never-demoting** statement: it can only re-append the version that is *already* latest, never revert to an older one. A relock never creates a new `app_version`, so there is never a version to legitimately promote here — the append is purely a (future) cache-invalidation marker.

The guard is what makes this race-free, not just narrower: it is evaluated under the row lock against the latest committed `versions` array, so even if a newer version lands *during* the (slow) lock computation, the append is a no-op rather than a revert.

## Why this is airtight (no 404 regardless of interleavings)

- Every raw-app version added to `versions` by a deploy is committed atomically with its bundle (`process_app_multipart!` requires the js upload before commit; S3 put precedes the commit), so **`versions.last()` set by a deploy always has a bundle**.
- A relock never inserts a new `app_version`, and its guarded append cannot change the *value* of `versions.last()` (it only ever re-appends the already-last element).
- Therefore `versions.last()` is always a deploy-created version, which always has a bundle ⇒ `bundle_secret` always resolves.

## Validation

- `cargo check -p windmill-worker` passes against a live DB and with `SQLX_OFFLINE=true` (offline cache entry added for the new guarded query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)