### PR TITLE
fix(cli): break main.ts ⇄ utils.ts circular import causing TDZ crash on Windows CI

### DIFF
--- a/.github/change-versions-mac.sh
+++ b/.github/change-versions-mac.sh
@@ -7,7 +7,7 @@ VERSION=$1
 echo "Updating versions to: $VERSION"
 
 sed -i '' -e "/^version =/s/= .*/= \"$VERSION\"/" ${root_dirpath}/backend/Cargo.toml
-sed -i '' -e "/^export const VERSION =/s/= .*/= \"v$VERSION\";/"  ${root_dirpath}/cli/src/main.ts
+sed -i '' -e "/^export const VERSION =/s/= .*/= \"v$VERSION\";/"  ${root_dirpath}/cli/src/core/constants.ts
 sed -i '' -e "/^export const VERSION =/s/= .*/= \"v$VERSION\";/" ${root_dirpath}/benchmarks/lib.ts
 sed -i '' -e "/version: /s/: .*/: $VERSION/" ${root_dirpath}/backend/windmill-api/openapi.yaml
 sed -i '' -e "/version: /s/: .*/: $VERSION/" ${root_dirpath}/openflow.openapi.yaml

--- a/.github/change-versions.sh
+++ b/.github/change-versions.sh
@@ -7,7 +7,7 @@ VERSION=$1
 echo "Updating versions to: $VERSION"
 
 sed -i -e "/^version =/s/= .*/= \"$VERSION\"/" ${root_dirpath}/backend/Cargo.toml
-sed -i -e "/^export const VERSION =/s/= .*/= \"$VERSION\";/" ${root_dirpath}/cli/src/main.ts
+sed -i -e "/^export const VERSION =/s/= .*/= \"$VERSION\";/" ${root_dirpath}/cli/src/core/constants.ts
 sed -i -e "/^export const VERSION =/s/= .*/= \"v$VERSION\";/" ${root_dirpath}/benchmarks/lib.ts
 sed -i -e "/version: /s/: .*/: $VERSION/" ${root_dirpath}/backend/windmill-api/openapi.yaml
 sed -i -e "/version: /s/: .*/: $VERSION/" ${root_dirpath}/openflow.openapi.yaml

--- a/cli/src/core/constants.ts
+++ b/cli/src/core/constants.ts
@@ -4,3 +4,10 @@
  */
 
 export const WM_FORK_PREFIX = "wm-fork";
+
+// CLI version — source of truth. Release tooling (.github/change-versions*.sh)
+// rewrites this line. Kept here, rather than in main.ts, so low-level modules
+// (e.g. utils.ts) can read it without importing main.ts and creating a circular
+// dependency (main → workspace → utils → main) that triggers a TDZ.
+// Re-exported from main.ts for backwards compatibility.
+export const VERSION = "1.715.0";

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -89,10 +89,14 @@ export {
   token,
 };
 
-export const VERSION = "1.715.0";
-
-// Re-exported from constants.ts to maintain backwards compatibility
-export { WM_FORK_PREFIX } from "./core/constants.ts";
+// VERSION and WM_FORK_PREFIX are defined in constants.ts (which keeps its
+// imports minimal) and re-exported here for backwards compatibility. VERSION is
+// also imported below for internal use. Defining VERSION in constants.ts rather
+// than here lets utils.ts read it without importing main.ts, which previously
+// created a circular dependency (main → workspace → utils → main) and a TDZ
+// crash ("Cannot access 'workspace' before initialization") on some load orders.
+import { VERSION } from "./core/constants.ts";
+export { VERSION, WM_FORK_PREFIX } from "./core/constants.ts";
 
 // Re-implementation of cliffy's internal `checkVersion` so the help path
 // can wrap it in try/catch. `_check_version` is not in cliffy's package

--- a/cli/src/utils/utils.ts
+++ b/cli/src/utils/utils.ts
@@ -11,7 +11,7 @@ import { readdir, readFile } from "node:fs/promises";
 import { fetchVersion } from "../core/context.ts";
 import { updateGlobalVersions } from "../commands/sync/global.ts";
 import { isRawAppPath } from "./resource_folders.ts";
-import { VERSION } from "../main.ts";
+import { VERSION } from "../core/constants.ts";
 
 export function deepEqual<T>(a: T, b: T): boolean {
   if (a === b) return true;


### PR DESCRIPTION
## Problem

CLI tests were failing on Windows CI (56 failures) with an unhandled error during module load:

```
ReferenceError: Cannot access 'workspace' before initialization.
    at cli/src/main.ts
```

(see [failing run](https://github.com/windmill-labs/windmill/actions/runs/26887844865/job/79305047299?pr=9430))

## Root cause

A circular import: `cli/src/utils/utils.ts` imported `VERSION` from `cli/src/main.ts`, while `main.ts` transitively imports `utils.ts` (`main.ts` → `workspace.ts` → `utils.ts` → `main.ts`).

When the module graph is entered through `workspace.ts` first (which the Windows test runner's load order does), `utils.ts` pulls in `main.ts` while `workspace.ts` is still paused mid-initialization. `main.ts`'s top-level command tree then executes before `workspace.ts` finished its `export default`, so the `workspace` binding is still in its temporal dead zone at:

```ts
.command("workspace", workspace)   // main.ts:186
```

It reproduces deterministically on **any** platform:

```sh
cd cli && bun -e 'await import("./src/commands/workspace/workspace.ts")'
# ReferenceError: Cannot access 'workspace' before initialization.
```

## Fix

Break the cycle by moving `VERSION` out of `main.ts` into `cli/src/core/constants.ts` (already the designated "minimal imports" module, home of `WM_FORK_PREFIX`):

- `constants.ts` now owns `export const VERSION` (single source of truth).
- `main.ts` imports it for internal use and re-exports it for backwards compatibility — `main.VERSION` is unchanged for any consumer.
- `utils.ts` reads `VERSION` from `constants.ts` instead of `main.ts`, so the low-level util no longer depends on the top-level entry module.
- `.github/change-versions.sh` / `change-versions-mac.sh` now rewrite the `VERSION` line in `constants.ts` (the `^export const VERSION =` regex is unchanged, only the target file moved).

## Verification

All module load orders now succeed:

```
bun -e 'await import("./src/commands/workspace/workspace.ts")'  → OK
bun -e 'await import("./src/utils/utils.ts")'                   → OK
bun -e 'await import("./src/main.ts")'  → OK, VERSION=1.715.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a circular import between `cli/src/main.ts` and `cli/src/utils/utils.ts` that caused a TDZ crash on Windows CI. Moves `VERSION` to `cli/src/core/constants.ts` to break the cycle and re-exports it from `main.ts`.

- **Bug Fixes**
  - `utils.ts` now imports `VERSION` from `core/constants.ts` (no `main.ts` dependency).
  - `main.ts` re-exports `VERSION` and `WM_FORK_PREFIX` from `core/constants.ts`.
  - `.github/change-versions*.sh` now updates `constants.ts` instead of `main.ts`.
  - Module load order is stable; Windows CLI tests no longer crash.

<sup>Written for commit 0fc7ebfc20735849a5598edc125691e43dfcdd4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

