### PR TITLE
fix: read latest db draft for scripts/flows in global mode read tool

### DIFF
--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -647,7 +647,7 @@ function itemMatches(
 	)
 }
 
-function scriptToItem(script: Script, includeValue: boolean): WorkspaceItem {
+function scriptToItem(script: Script | NewScript, includeValue: boolean): WorkspaceItem {
 	return {
 		type: 'script',
 		path: script.path,
@@ -1153,10 +1153,16 @@ async function readWorkspaceItem(
 	triggerKind?: TriggerKind
 ): Promise<WorkspaceItem> {
 	switch (type) {
-		case 'script':
-			return scriptToItem(await ScriptService.getScriptByPath({ workspace, path }), true)
-		case 'flow':
-			return flowToItem(await FlowService.getFlowByPath({ workspace, path }), true)
+		case 'script': {
+			// Prefer the DB draft (newer than the deployed version) when one exists.
+			const script = await ScriptService.getScriptByPathWithDraft({ workspace, path })
+			return scriptToItem(script.draft ?? script, true)
+		}
+		case 'flow': {
+			// Prefer the DB draft (newer than the deployed version) when one exists.
+			const flow = await FlowService.getFlowByPathWithDraft({ workspace, path })
+			return flowToItem(flow.draft ?? flow, true)
+		}
 		case 'schedule':
 			return scheduleToItem(await ScheduleService.getSchedule({ workspace, path }), true)
 		case 'trigger':


### PR DESCRIPTION
## Summary

In global-mode AI chat, the `read_workspace_item` tool previously read scripts and flows via `getScriptByPath` / `getFlowByPath`, which return only the **deployed** version. If a user had a DB draft (a saved-but-not-deployed version newer than the deployed one), the assistant silently read stale, deployed content. Apps already avoided this by using `getAppByPathWithDraft` and preferring `app.draft ?? app`.

This PR brings scripts and flows in line with apps: the read tool now uses the `WithDraft` endpoints and prefers the DB draft when one exists, so the assistant reads the latest persisted state.

Listing (`list_workspace_items`) is intentionally left unchanged for now — it still uses `includeDraftOnly: true` and does not flag DB drafts.

## Changes

- `readWorkspaceItem` (`frontend/src/lib/components/copilot/chat/global/core.ts`): scripts now call `getScriptByPathWithDraft` and flows call `getFlowByPathWithDraft`, each preferring the DB draft (`script.draft ?? script`, `flow.draft ?? flow`).
- `scriptToItem`: widened the param type from `Script` to `Script | NewScript`, since a script's DB draft is a `NewScript`. It only reads `path`/`summary`/`language`/`content`, all present on both types; the listing call (which passes `Script`) is unaffected. `flowToItem` needed no change since a flow's draft is a full `Flow`.

Resulting read precedence: local browser draft (checked first in the tool wrapper) → DB draft → deployed. `isDraft: false` on the returned item is left unchanged, consistent with the existing app read path.

## Test plan

- [ ] Edit a script and save it as a **draft without deploying** (so a DB draft exists, no local browser draft). In global-mode AI chat, ask the assistant to read it and confirm it returns the **draft** content, not the older deployed content.
- [ ] Repeat for a flow.
- [ ] Read a script/flow path that has only a deployed version (no draft) and confirm the deployed content still comes back.
- [ ] Confirm `npm run check` passes (type widening to `Script | NewScript`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)