### PR TITLE
fix(cli): push whole raw app instead of treating frontend files as scripts

### DIFF
--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -297,12 +297,8 @@ export async function handleFile(
   if (
     !isAppInlineScriptPath(path) &&
     !isFlowInlineScriptPath(path) &&
-    // Exclude EVERY file inside a raw_app folder, not just backend/ runnables.
-    // Frontend source files with a script extension (e.g. src/lib/util.ts) are
-    // part of the raw app's bundle (pushed via pushRawApp), never standalone
-    // scripts. Treating them as scripts here would push a bogus script at a
-    // truncated path AND short-circuit (return true) so the raw app itself
-    // never gets pushed — a silent no-op that still reports success.
+    // Raw-app files (frontend included) belong to the app bundle, never
+    // standalone scripts — pushed via pushRawApp, not here.
     !isRawAppPath(path) &&
     (!isScriptModulePath(path) || moduleEntryPoint) &&
     exts.some((exts) => path.endsWith(exts))

--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -297,7 +297,13 @@ export async function handleFile(
   if (
     !isAppInlineScriptPath(path) &&
     !isFlowInlineScriptPath(path) &&
-    !isRawAppBackendPath(path) &&
+    // Exclude EVERY file inside a raw_app folder, not just backend/ runnables.
+    // Frontend source files with a script extension (e.g. src/lib/util.ts) are
+    // part of the raw app's bundle (pushed via pushRawApp), never standalone
+    // scripts. Treating them as scripts here would push a bogus script at a
+    // truncated path AND short-circuit (return true) so the raw app itself
+    // never gets pushed — a silent no-op that still reports success.
+    !isRawAppPath(path) &&
     (!isScriptModulePath(path) || moduleEntryPoint) &&
     exts.some((exts) => path.endsWith(exts))
   ) {

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -4066,10 +4066,11 @@ export async function push(
                 continue;
               }
               if (
-                change.path.endsWith(".script.json") ||
-                change.path.endsWith(".script.yaml") ||
-                change.path.endsWith(".lock") ||
-                isFileResource(change.path)
+                !isRawAppFile(change.path) &&
+                (change.path.endsWith(".script.json") ||
+                  change.path.endsWith(".script.yaml") ||
+                  change.path.endsWith(".lock") ||
+                  isFileResource(change.path))
               ) {
                 continue;
               } else if (

--- a/cli/test/raw_app_sync.test.ts
+++ b/cli/test/raw_app_sync.test.ts
@@ -382,6 +382,81 @@ excludes: []`, "utf-8");
     });
 });
 
+test("Raw App: frontend .ts file sorting first does not short-circuit the app push", async () => {
+    // Regression: in the push apply loop, raw-app changes are collapsed to a
+    // single representative change (changes[0]). Because every file inside a
+    // raw_app folder shares the same sort order, changes[0] is just the
+    // alphabetically-first changed path. When that path was a frontend file
+    // with a script extension (e.g. "Api.ts", which sorts before "App.tsx"),
+    // handleFile() mistook it for a standalone script: it pushed a bogus script
+    // at the truncated path (f/test/<app>) AND returned true, so the loop
+    // `continue`d and pushRawApp() never ran. Result: the whole raw app silently
+    // failed to deploy while the CLI still reported success.
+    await withTestBackend(async (backend, tempDir) => {
+      const testWorkspace = {
+        remote: backend.baseUrl,
+        workspaceId: backend.workspace,
+        name: "raw_app_ts_first_test",
+        token: backend.token
+      };
+      await addWorkspace(testWorkspace, { force: true, configDir: backend.testConfigDir });
+
+      await writeFile(`${tempDir}/wmill.yaml`, `defaultTs: bun
+includes:
+  - "**"
+excludes: []`, "utf-8");
+
+      const appDir = path.join(tempDir, "f", "test", "ts_first_app.raw_app");
+      await mkdir(path.join(tempDir, "f", "test"), { recursive: true });
+      await createRawAppOnDisk(appDir);
+
+      // A frontend .ts file whose name sorts before "App.tsx".
+      const apiTsPath = path.join(appDir, "Api.ts");
+      await writeFile(apiTsPath, "export const API = '/api/v1'\n", "utf-8");
+
+      // Initial push: create the raw app on the backend.
+      const pushResult1 = await backend.runCLICommand(
+        ['sync', 'push', '--yes'],
+        tempDir, "raw_app_ts_first_test"
+      );
+      expect(pushResult1.code).toEqual(0);
+
+      // Edit App.tsx (and the .ts file that sorts first) and push again.
+      const appTsxPath = path.join(appDir, "App.tsx");
+      const appTsxContent = await readFileContent(appTsxPath);
+      await writeFile(
+        appTsxPath,
+        appTsxContent.replace("hello world", "REGRESSION MARKER"),
+        "utf-8"
+      );
+      await writeFile(apiTsPath, "export const API = '/api/v2'\n", "utf-8");
+
+      const pushResult2 = await backend.runCLICommand(
+        ['sync', 'push', '--yes'],
+        tempDir, "raw_app_ts_first_test"
+      );
+      expect(pushResult2.code).toEqual(0);
+
+      // The App.tsx edit must have landed on the remote app's bundled files.
+      const appResp = await backend.apiRequest!(
+        `/api/w/${backend.workspace}/apps/get/p/f/test/ts_first_app`
+      );
+      expect(appResp.status).toEqual(200);
+      const appJson = await appResp.json();
+      const files = appJson?.value?.files ?? {};
+      expect(files["/App.tsx"]).toContain("REGRESSION MARKER");
+      // The first-sorting .ts file is part of the app bundle, with fresh content.
+      expect(files["/Api.ts"]).toContain("/api/v2");
+
+      // And no bogus standalone script was created at the truncated path
+      // (f/test/ts_first_app.raw_app/Api.ts -> f/test/ts_first_app).
+      const scriptResp = await backend.apiRequest!(
+        `/api/w/${backend.workspace}/scripts/get/p/f/test/ts_first_app`
+      );
+      expect(scriptResp.status).toEqual(404);
+    });
+});
+
 test("Raw App: delete file and push", async () => {
     await withTestBackend(async (backend, tempDir) => {
       // Set up workspace


### PR DESCRIPTION
## Summary

`wmill sync push` of a `*.raw_app` could report success while deploying **nothing** — `App.tsx` edits never landed and the same diff reappeared every run. Hit both local push and server-side git-sync.

**Cause:** raw-app changes collapse to one representative (the alphabetically-first path). `handleFile()` excluded only `backend/` files, so a frontend script-ext file (e.g. `src/lib/util.ts`, `Api.ts`) got pushed as a standalone script at a truncated path and short-circuited — `pushRawApp()` never ran.

## Changes

- `handleFile()`: exclude **all** raw-app files (`isRawAppPath`), not just `backend/`.
- Guard in the push "added" branch so a raw-app `.lock`/`.script.*` representative reaches `pushRawApp`.
- Regression test in `cli/test/raw_app_sync.test.ts`.

## Test plan

- [x] e2e: edit now lands, no bogus script created
- [x] `raw_app_sync.test.ts`: 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)