### PR TITLE
add adobe acrobat sign icon

### DIFF
--- a/frontend/src/lib/components/icons/AdobeAcrobatSignIcon.svelte
+++ b/frontend/src/lib/components/icons/AdobeAcrobatSignIcon.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	interface Props {
+		height?: string;
+		width?: string;
+	}
+
+	let { height = '24px', width = '24px' }: Props = $props();
+</script>
+
+<svg {width} {height} viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+	<rect x="1.5" y="1.5" width="21" height="21" rx="4.5" fill="#EB1000" />
+	<path
+		fill="#fff"
+		fill-rule="evenodd"
+		d="M10.7 5.8h2.6L17.6 16h-2.7l-.86-2.3h-4.08L9.1 16H6.4L10.7 5.8Zm1.3 2.9-1.4 3.7h2.8L12 8.7Z"
+	/>
+	<path
+		d="M6.6 18.7c1.5.85 2.9.2 4.1-.45s2.5-1.05 4-.2"
+		stroke="#fff"
+		stroke-width="1.15"
+		stroke-linecap="round"
+		fill="none"
+	/>
+</svg>

--- a/frontend/src/lib/components/icons/index.ts
+++ b/frontend/src/lib/components/icons/index.ts
@@ -27,6 +27,7 @@ import QRCodeIcon from './QRCodeIcon.svelte'
 import LinkedinIcon from './LinkedinIcon.svelte'
 import HubspotIcon from './HubspotIcon.svelte'
 import DatadogIcon from './DatadogIcon.svelte'
+import AdobeAcrobatSignIcon from './AdobeAcrobatSignIcon.svelte'
 import StripeIcon from './StripeIcon.svelte'
 import TelegramIcon from './TelegramIcon.svelte'
 import FunkwhaleIcon from './FunkwhaleIcon.svelte'
@@ -244,6 +245,7 @@ export const APP_TO_ICON_COMPONENT = {
 	linkedin: LinkedinIcon,
 	hubspot: HubspotIcon,
 	datadog: DatadogIcon,
+	adobe_acrobat_sign: AdobeAcrobatSignIcon,
 	stripe: StripeIcon,
 	telegram: TelegramIcon,
 	funkwhale: FunkwhaleIcon,


### PR DESCRIPTION
Adds the icon for the **Adobe Acrobat Sign** hub integration.

- New `AdobeAcrobatSignIcon.svelte` (Acrobat red `#EB1000` mark with a white "A" + signature stroke; matches the sibling icon convention — Svelte 5 runes, `height`/`width` props).
- Registers `adobe_acrobat_sign: AdobeAcrobatSignIcon` in `APP_TO_ICON_COMPONENT` (`frontend/src/lib/components/icons/index.ts`). Both `windmill` and `windmillhub` consume this shared map.

Pairs with the integration PR: windmill-labs/windmill-integrations#143 (bearer / Integration Key auth, REST API v6, 20 actions — smoke-tested live). No `oauth_connect.json` / `AuthSettings.svelte` changes are needed: Adobe Sign's OAuth authorize endpoints are shard-specific with no region-agnostic host, so the integration uses a plain bearer token rather than a Windmill-driven OAuth flow (the region-agnostic discovery host resolves the shard in-script).

Draft because the icon glyph is a hand-authored approximation of the Acrobat Sign mark — happy to swap in the exact brand SVG if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Adobe Acrobat Sign icon and wires it into the shared icon map so the integration displays correctly in both apps. Pairs with windmill-labs/windmill-integrations#143.

- **New Features**
  - Added `AdobeAcrobatSignIcon.svelte` with `height`/`width` props.
  - Registered `adobe_acrobat_sign: AdobeAcrobatSignIcon` in `APP_TO_ICON_COMPONENT`.

<sup>Written for commit 05309d9f312f183ecf5b4a07645ae8a978d8d993. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

