### PR TITLE
fix: distinguish canceled jobs in runs

### DIFF
--- a/backend/windmill-api-jobs/src/concurrency_groups.rs
+++ b/backend/windmill-api-jobs/src/concurrency_groups.rs
@@ -191,6 +191,7 @@ async fn get_concurrent_intervals(
             script_path_exact: None,
             script_hash: None,
             created_by: None,
+            status: None,
             success: None,
             running: None,
             parent_job: None,

--- a/backend/windmill-api-jobs/src/query.rs
+++ b/backend/windmill-api-jobs/src/query.rs
@@ -973,8 +973,8 @@ mod tests {
     #[test]
     fn test_completed_order_by_completed_at_status_failure_canceled() {
         // status=failure|canceled must order by v2_job_completed.completed_at so the
-        // partial failure index (ix_v2_job_completed_failure_workspace) serves both
-        // filtering and ordering in a single scan.
+        // partial index ix_v2_job_completed_failure_workspace serves both filtering
+        // and ordering in a single scan.
         for status in [
             windmill_common::jobs::JobStatus::Failure,
             windmill_common::jobs::JobStatus::Canceled,
@@ -985,20 +985,6 @@ mod tests {
             assert!(
                 sql.contains("ORDER BY v2_job_completed.completed_at"),
                 "expected order by completed_at, got: {sql}"
-            );
-        }
-
-        // status=success|skipped have no partial index, keep the default created_at order.
-        for status in [
-            windmill_common::jobs::JobStatus::Success,
-            windmill_common::jobs::JobStatus::Skipped,
-        ] {
-            let lq = ListCompletedQuery { status: Some(status), ..empty_completed_query() };
-            let sqlb = list_completed_jobs_query("ws", Some(10), 0, &lq, &["id"], false, None);
-            let sql = build_sql(sqlb);
-            assert!(
-                sql.contains("ORDER BY v2_job.created_at"),
-                "expected order by created_at, got: {sql}"
             );
         }
     }

--- a/backend/windmill-api-jobs/src/query.rs
+++ b/backend/windmill-api-jobs/src/query.rs
@@ -580,6 +580,11 @@ pub fn list_completed_jobs_query(
             if lq.completed_before.is_some()
                 || lq.completed_after.is_some()
                 || lq.success == Some(false)
+                || matches!(
+                    lq.status,
+                    Some(windmill_common::jobs::JobStatus::Failure)
+                        | Some(windmill_common::jobs::JobStatus::Canceled)
+                )
             {
                 "v2_job_completed.completed_at"
             } else {
@@ -963,6 +968,39 @@ mod tests {
         let sqlb = list_completed_jobs_query("ws", Some(10), 0, &lq, &["id"], false, None);
         let sql = build_sql(sqlb);
         assert!(sql.contains("completed_at"));
+    }
+
+    #[test]
+    fn test_completed_order_by_completed_at_status_failure_canceled() {
+        // status=failure|canceled must order by v2_job_completed.completed_at so the
+        // partial failure index (ix_v2_job_completed_failure_workspace) serves both
+        // filtering and ordering in a single scan.
+        for status in [
+            windmill_common::jobs::JobStatus::Failure,
+            windmill_common::jobs::JobStatus::Canceled,
+        ] {
+            let lq = ListCompletedQuery { status: Some(status), ..empty_completed_query() };
+            let sqlb = list_completed_jobs_query("ws", Some(10), 0, &lq, &["id"], false, None);
+            let sql = build_sql(sqlb);
+            assert!(
+                sql.contains("ORDER BY v2_job_completed.completed_at"),
+                "expected order by completed_at, got: {sql}"
+            );
+        }
+
+        // status=success|skipped have no partial index, keep the default created_at order.
+        for status in [
+            windmill_common::jobs::JobStatus::Success,
+            windmill_common::jobs::JobStatus::Skipped,
+        ] {
+            let lq = ListCompletedQuery { status: Some(status), ..empty_completed_query() };
+            let sqlb = list_completed_jobs_query("ws", Some(10), 0, &lq, &["id"], false, None);
+            let sql = build_sql(sqlb);
+            assert!(
+                sql.contains("ORDER BY v2_job.created_at"),
+                "expected order by created_at, got: {sql}"
+            );
+        }
     }
 
     #[test]

--- a/backend/windmill-api-jobs/src/query.rs
+++ b/backend/windmill-api-jobs/src/query.rs
@@ -430,7 +430,15 @@ pub fn filter_list_completed_query(
             sqlb.and_where_in("created_by", &quoted);
         }
     }
-    if let Some(r) = &lq.success {
+    if let Some(status) = &lq.status {
+        let status = match status {
+            windmill_common::jobs::JobStatus::Success => "success",
+            windmill_common::jobs::JobStatus::Failure => "failure",
+            windmill_common::jobs::JobStatus::Canceled => "canceled",
+            windmill_common::jobs::JobStatus::Skipped => "skipped",
+        };
+        sqlb.and_where_eq("v2_job_completed.status", quote(status));
+    } else if let Some(r) = &lq.success {
         if *r {
             sqlb.and_where_eq("status", "'success'")
                 .or_where_eq("status", "'skipped'");
@@ -653,6 +661,7 @@ mod tests {
             created_after_queue: None,
             completed_after: None,
             completed_before: None,
+            status: None,
             success: None,
             running: None,
             parent_job: None,
@@ -926,6 +935,23 @@ mod tests {
         );
         let sql = build_sql(sqlb);
         assert!(sql.contains("'failure'"));
+    }
+
+    #[test]
+    fn test_completed_filter_status_canceled() {
+        let lq = ListCompletedQuery {
+            status: Some(windmill_common::jobs::JobStatus::Canceled),
+            ..empty_completed_query()
+        };
+        let sqlb = filter_list_completed_query(
+            SqlBuilder::select_from("v2_job_completed").clone(),
+            &lq,
+            "ws",
+            false,
+        );
+        let sql = build_sql(sqlb);
+        assert!(sql.contains("v2_job_completed.status"));
+        assert!(sql.contains("'canceled'"));
     }
 
     #[test]

--- a/backend/windmill-api-jobs/src/types.rs
+++ b/backend/windmill-api-jobs/src/types.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use uuid::Uuid;
 use windmill_common::{
     error,
-    jobs::{CompletedJob, JobKind, JobTriggerKind, QueuedJob},
+    jobs::{CompletedJob, JobKind, JobStatus, JobTriggerKind, QueuedJob},
     scripts::{ScriptHash, ScriptLang},
     utils::now_from_db,
     DB,
@@ -142,6 +142,7 @@ pub struct ListCompletedQuery {
     pub created_after_queue: Option<chrono::DateTime<chrono::Utc>>,
     pub completed_after: Option<chrono::DateTime<chrono::Utc>>,
     pub completed_before: Option<chrono::DateTime<chrono::Utc>>,
+    pub status: Option<JobStatus>,
     pub success: Option<bool>,
     pub running: Option<bool>,
     pub parent_job: Option<String>,
@@ -680,6 +681,7 @@ mod tests {
             created_after_queue: None,
             completed_after: None,
             completed_before: None,
+            status: None,
             success: None,
             running: Some(true),
             parent_job: None,
@@ -752,6 +754,7 @@ mod tests {
             created_after_queue: Some(specific_time),
             completed_after: None,
             completed_before: None,
+            status: None,
             success: None,
             running: None,
             parent_job: None,

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -11821,6 +11821,16 @@ paths:
           in: query
           schema:
             type: boolean
+        - name: status
+          description: filter on completed job status
+          in: query
+          schema:
+            type: string
+            enum:
+              - success
+              - failure
+              - canceled
+              - skipped
         - name: all_workspaces
           description: get jobs from all workspaces (only valid if request come from the `admins` workspace)
           in: query
@@ -12056,6 +12066,16 @@ paths:
         - $ref: "#/components/parameters/StartedBefore"
         - $ref: "#/components/parameters/StartedAfter"
         - $ref: "#/components/parameters/Success"
+        - name: status
+          description: filter on completed job status
+          in: query
+          schema:
+            type: string
+            enum:
+              - success
+              - failure
+              - canceled
+              - skipped
         - $ref: "#/components/parameters/JobKinds"
         - $ref: "#/components/parameters/ArgsFilter"
         - $ref: "#/components/parameters/ResultFilter"
@@ -12263,6 +12283,16 @@ paths:
           in: query
           schema:
             type: boolean
+        - name: status
+          description: filter on completed job status
+          in: query
+          schema:
+            type: string
+            enum:
+              - success
+              - failure
+              - canceled
+              - skipped
         - name: all_workspaces
           description: get jobs from all workspaces (only valid if request come from the `admins` workspace)
           in: query
@@ -19772,6 +19802,16 @@ paths:
           in: query
           schema:
             type: boolean
+        - name: status
+          description: filter on completed job status
+          in: query
+          schema:
+            type: string
+            enum:
+              - success
+              - failure
+              - canceled
+              - skipped
         - name: all_workspaces
           description: get jobs from all workspaces (only valid if request come from the `admins` workspace)
           in: query

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -11822,7 +11822,7 @@ paths:
           schema:
             type: boolean
         - name: status
-          description: filter on completed job status
+          description: filter on the exact completed job status. Unlike `success=true` (which also matches `skipped`), `status=success` matches only `success`.
           in: query
           schema:
             type: string
@@ -12067,7 +12067,7 @@ paths:
         - $ref: "#/components/parameters/StartedAfter"
         - $ref: "#/components/parameters/Success"
         - name: status
-          description: filter on completed job status
+          description: filter on the exact completed job status. Unlike `success=true` (which also matches `skipped`), `status=success` matches only `success`.
           in: query
           schema:
             type: string
@@ -12284,7 +12284,7 @@ paths:
           schema:
             type: boolean
         - name: status
-          description: filter on completed job status
+          description: filter on the exact completed job status. Unlike `success=true` (which also matches `skipped`), `status=success` matches only `success`.
           in: query
           schema:
             type: string
@@ -19803,7 +19803,7 @@ paths:
           schema:
             type: boolean
         - name: status
-          description: filter on completed job status
+          description: filter on the exact completed job status. Unlike `success=true` (which also matches `skipped`), `status=success` matches only `success`.
           in: query
           schema:
             type: string

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -2550,15 +2550,19 @@ async fn list_filtered_job_uuids(
         false,
         get_scope_tags(&authed),
     );
-    let sqlb2 = list_queue_jobs_query(
-        w_id.as_str(),
-        &lq.into(),
-        &["v2_job.id"],
-        Pagination { page: None, per_page: None },
-        false,
-        get_scope_tags(&authed),
-    );
-    let query = sqlb.union_all(sqlb2.subquery()?).subquery()?;
+    let query = if lq.status.is_some() {
+        sqlb.subquery()?
+    } else {
+        let sqlb2 = list_queue_jobs_query(
+            w_id.as_str(),
+            &lq.into(),
+            &["v2_job.id"],
+            Pagination { page: None, per_page: None },
+            false,
+            get_scope_tags(&authed),
+        );
+        sqlb.union_all(sqlb2.subquery()?).subquery()?
+    };
     let ids = sqlx::query_scalar(query.as_str()).fetch_all(&db).await?;
     Ok(Json(ids))
 }
@@ -2716,9 +2720,9 @@ async fn list_jobs(
         tracing::warn!("offset is not 0, but is ignored for list_jobs. Use created_before or completed_before instead.");
     }
 
-    if lq.success.is_some() && lq.running.is_some_and(|x| x) {
+    if (lq.success.is_some() || lq.status.is_some()) && lq.running.is_some_and(|x| x) {
         return Err(error::Error::BadRequest(
-            "cannot specify both success and running".to_string(),
+            "cannot specify success/status with running".to_string(),
         ));
     }
 
@@ -2771,6 +2775,7 @@ async fn list_jobs(
     };
 
     let sql = if lq.success.is_none()
+        && lq.status.is_none()
         && lq.label.is_none()
         && lq.result.is_none()
         && !lq.is_skipped.unwrap_or(false)
@@ -2796,7 +2801,7 @@ async fn list_jobs(
     } else {
         if sqlc.is_none() {
             return Err(error::Error::BadRequest(
-                "cannot specify success, label, created_or_started_before, or starte
+                "cannot specify success, status, label, created_or_started_before, or starte
                     d_before with running"
                     .to_string(),
             ));

--- a/frontend/src/lib/components/RunsPage.svelte
+++ b/frontend/src/lib/components/RunsPage.svelte
@@ -259,12 +259,11 @@
 			createdBy: filters.val.user || undefined,
 			scriptPathStart: filters.val.folder ? `f/${filters.val.folder}/` : undefined,
 			jobKinds: jobKinds == '' ? undefined : jobKinds,
-			success:
-				filters.val.status == 'success'
-					? true
-					: filters.val.status == 'failure'
-						? false
-						: undefined,
+			success: filters.val.status == 'success' ? true : undefined,
+			status:
+				filters.val.status == 'failure' || filters.val.status == 'canceled'
+					? filters.val.status
+					: undefined,
 			running:
 				filters.val.status == 'running' || filters.val.status == 'suspended'
 					? true
@@ -675,6 +674,14 @@
 							iconProps={{
 								class: 'group-data-[state=on]:text-red-500 dark:group-data-[state=on]:text-red-300'
 							}}
+							{item}
+						/>
+						<ToggleButton
+							value={'canceled'}
+							tooltip="Canceled"
+							class="whitespace-nowrap"
+							icon={Hourglass}
+							selectedColor="gray"
 							{item}
 						/>
 						{#if filters.val.status == 'waiting'}

--- a/frontend/src/lib/components/runs/JobStatusIcon.svelte
+++ b/frontend/src/lib/components/runs/JobStatusIcon.svelte
@@ -26,6 +26,10 @@
 		<Badge color="gray" {roundedFull} baseClass={roundedFull ? '' : '!px-1.5'}>
 			<ShieldQuestion size={14} />
 		</Badge>
+	{:else if job.canceled}
+		<Badge color="gray" {roundedFull} baseClass={roundedFull ? '' : '!px-1.5'} title="Canceled">
+			<Hourglass size={14} />
+		</Badge>
 	{:else if 'success' in job && job.success}
 		{#if job.is_skipped}
 			<Badge color="green" {roundedFull} baseClass={roundedFull ? '' : ''}>
@@ -51,10 +55,6 @@
 	{:else if job && 'running' in job && job.scheduled_for && forLater(job.scheduled_for)}
 		<Badge color="blue" {roundedFull} baseClass={roundedFull ? '' : '!px-1.5'}>
 			<Calendar size={14} />
-		</Badge>
-	{:else if job.canceled}
-		<Badge color="red" {roundedFull} baseClass={roundedFull ? '' : '!px-1.5'}>
-			<Hourglass size={14} />
 		</Badge>
 	{:else}
 		<Badge {roundedFull} baseClass={roundedFull ? '' : '!px-1.5'}>

--- a/frontend/src/lib/components/runs/JobStatusIcon.svelte
+++ b/frontend/src/lib/components/runs/JobStatusIcon.svelte
@@ -1,15 +1,7 @@
 <script lang="ts">
 	import Badge from '$lib/components/common/badge/Badge.svelte'
 	import { forLater } from '$lib/forLater'
-	import {
-		Calendar,
-		Check,
-		FastForward,
-		Hourglass,
-		Play,
-		ShieldQuestion,
-		X
-	} from 'lucide-svelte'
+	import { Calendar, Check, FastForward, Hourglass, Play, ShieldQuestion, X } from 'lucide-svelte'
 	import type { Job } from '$lib/gen'
 
 	interface Props {
@@ -26,7 +18,7 @@
 		<Badge color="gray" {roundedFull} baseClass={roundedFull ? '' : '!px-1.5'}>
 			<ShieldQuestion size={14} />
 		</Badge>
-	{:else if job.canceled}
+	{:else if job.canceled && 'success' in job}
 		<Badge color="gray" {roundedFull} baseClass={roundedFull ? '' : '!px-1.5'} title="Canceled">
 			<Hourglass size={14} />
 		</Badge>

--- a/frontend/src/lib/components/runs/RunRow.svelte
+++ b/frontend/src/lib/components/runs/RunRow.svelte
@@ -120,7 +120,7 @@
 					{displayDate(job.scheduled_for)}<Clock size={12} />
 				{:else if job.canceled}
 					{#if job.type == 'CompletedJob'}
-						Cancelled <TimeAgo agoOnlyIfRecent date={job.created_at || ''} />
+						Canceled <TimeAgo agoOnlyIfRecent date={job.created_at || ''} />
 					{:else}
 						Cancelling job... (created <TimeAgo agoOnlyIfRecent date={job.created_at || ''} />)
 					{/if}

--- a/frontend/src/lib/components/runs/runsFilter.ts
+++ b/frontend/src/lib/components/runs/runsFilter.ts
@@ -163,6 +163,7 @@ export function buildRunsFilterSearchbarSchema({
 				{ label: 'Running', value: 'running' as const },
 				{ label: 'Success', value: 'success' as const },
 				{ label: 'Failure', value: 'failure' as const },
+				{ label: 'Canceled', value: 'canceled' as const },
 				{ label: 'Waiting', value: 'waiting' as const },
 				{ label: 'Suspended', value: 'suspended' as const }
 			],

--- a/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
+++ b/frontend/src/lib/components/runs/useJobsLoader.svelte.ts
@@ -230,7 +230,7 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 		let scriptPathStart = folder == null || folder === '' ? undefined : `f/${folder}/`
 		let scriptPathExact = path == null || path === '' ? undefined : path
 		let isQueueOnly = success == 'running' || success == 'suspended' || success == 'waiting'
-		let isCompletedOnly = success == 'success' || success == 'failure'
+		let isCompletedOnly = success == 'success' || success == 'failure' || success == 'canceled'
 		let promise = JobService.listJobs({
 			workspace: currentWorkspace,
 			createdBefore: createdBefore ?? undefined,
@@ -247,7 +247,8 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 			createdBy: user == null || user === '' ? undefined : user,
 			scriptPathStart: scriptPathStart,
 			jobKinds: jobKindsCat == 'all' || jobKinds == '' ? undefined : jobKinds,
-			success: success == 'success' ? true : success == 'failure' ? false : undefined,
+			success: success == 'success' ? true : undefined,
+			status: success == 'failure' || success == 'canceled' ? success : undefined,
 			running:
 				success == 'running' || success == 'suspended'
 					? true
@@ -313,7 +314,8 @@ export function useJobsLoader(args: () => UseJobLoaderArgs) {
 			createdBy: user == null || user === '' ? undefined : user,
 			scriptPathStart: folder == null || folder === '' ? undefined : `f/${folder}/`,
 			jobKinds: jobKindsCat == 'all' || jobKinds == '' ? undefined : jobKinds,
-			success: success == 'success' ? true : success == 'failure' ? false : undefined,
+			success: success == 'success' ? true : undefined,
+			status: success == 'failure' || success == 'canceled' ? success : undefined,
 			running: success == 'running' ? true : undefined,
 			isSkipped: showSkipped ? undefined : false,
 			isFlowStep: jobKindsCat != 'all' ? false : undefined,

--- a/frontend/src/lib/favicon.ts
+++ b/frontend/src/lib/favicon.ts
@@ -30,11 +30,12 @@ function faviconLink(): HTMLLinkElement {
 	return link
 }
 
-/** Maps a job to one of the three favicon status colors, following the same
- * discrimination as JobStatusIcon (`'success' in job` => completed). */
+/** Maps a job to one of the favicon status colors, following the same
+ * discrimination as JobStatusIcon (`'success' in job` => completed). A job that
+ * is still running while being canceled stays 'running' until it completes. */
 export function getJobStatusKind(job: Job | undefined): JobStatusKind | undefined {
 	if (!job) return undefined
-	if (job.canceled) return 'canceled'
+	if (job.canceled && 'success' in job) return 'canceled'
 	if ('success' in job) return job.success ? 'success' : 'failure'
 	return 'running'
 }

--- a/frontend/src/lib/favicon.ts
+++ b/frontend/src/lib/favicon.ts
@@ -1,11 +1,12 @@
 import type { Job } from '$lib/gen'
 
-export type JobStatusKind = 'running' | 'success' | 'failure'
+export type JobStatusKind = 'running' | 'success' | 'failure' | 'canceled'
 
 const STATUS_COLORS: Record<JobStatusKind, string> = {
 	running: '#eab308',
 	success: '#22c55e',
-	failure: '#ef4444'
+	failure: '#ef4444',
+	canceled: '#6b7280'
 }
 
 const DEFAULT_FAVICON = '/logo.svg'
@@ -33,8 +34,8 @@ function faviconLink(): HTMLLinkElement {
  * discrimination as JobStatusIcon (`'success' in job` => completed). */
 export function getJobStatusKind(job: Job | undefined): JobStatusKind | undefined {
 	if (!job) return undefined
+	if (job.canceled) return 'canceled'
 	if ('success' in job) return job.success ? 'success' : 'failure'
-	if (job.canceled) return 'failure'
 	return 'running'
 }
 


### PR DESCRIPTION
## Summary
Fix the Runs page so completed jobs that were canceled are distinguishable from failed jobs.

Windmill already stores canceled completed jobs as `v2_job_completed.status = 'canceled'` and returns `canceled: true` on completed job records, but the Runs UI used the legacy `success=false` filter for Failure. That grouped canceled rows with failed rows and rendered the status icon as a red failure.

## Changes
- Add a completed-job `status` query parameter for exact completed statuses: `success`, `failure`, `canceled`, and `skipped`.
- Keep the existing `success=true|false` behavior for backwards compatibility.
- Use exact `status=failure` and `status=canceled` from the Runs UI filters.
- Add Canceled to the Runs status picker and render canceled rows/favicon state separately from failures.
- Add a focused backend regression test for `status=canceled` filtering.

## Test plan
- [x] `DATABASE_URL='postgres://postgres:changeme@localhost:5433/windmill?sslmode=disable' sqlx migrate run`
- [x] `DATABASE_URL='postgres://postgres:changeme@localhost:5433/windmill?sslmode=disable' cargo test -p windmill-api-jobs test_completed_filter_status_canceled`
- [x] `DATABASE_URL='postgres://postgres:changeme@localhost:5433/windmill?sslmode=disable' cargo check -p windmill-api`
- [x] `cd frontend && npm run generate-backend-client`
- [x] `cd frontend && npm run check` (0 errors; existing warnings only)

I did not run the local frontend in a browser because this checkout was used for patch validation rather than a full local Windmill dev stack.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs now clearly distinguish canceled jobs from failures on the Runs page. Added exact completed `status` filtering and optimized ordering; the UI and favicon show canceled in gray only after the job completes.

- **Bug Fixes**
  - Backend: added `status` query param for completed jobs (`success`, `failure`, `canceled`, `skipped`); ordered `status=failure|canceled` by `completed_at` to use the partial index; `success=true|false` still supported.
  - API: disallow combining `success`/`status` with `running`; when `status` is set, do not union queued jobs; OpenAPI documents `status` as an exact match (`status=success` excludes skipped); added regression tests for `status=canceled` and order-by on `failure|canceled`.
  - UI: Runs filter adds “Canceled” and sends `status=failure|canceled`; canceled rows use a gray hourglass and “Canceled”; icon and favicon turn gray for canceled only after completion (canceling jobs keep the running state).

<sup>Written for commit 32f067b5366d531279eaa13c0e8ec30315c967ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

