### PR TITLE
feat: make C# dotnet target framework configurable via DOTNET_TARGET_FRAMEWORK

### DIFF
--- a/backend/windmill-worker/src/csharp_executor.rs
+++ b/backend/windmill-worker/src/csharp_executor.rs
@@ -57,8 +57,12 @@ const DOTNET_ROOT_DEFAULT: &str = "C:\\Program Files\\dotnet";
 const DOTNET_ROOT_DEFAULT: &str = "/usr/share/dotnet";
 
 #[cfg(feature = "csharp")]
+const DOTNET_TARGET_FRAMEWORK_DEFAULT: &str = "net9.0";
+
+#[cfg(feature = "csharp")]
 lazy_static::lazy_static! {
     static ref DOTNET_ROOT: String = std::env::var("DOTNET_ROOT").unwrap_or_else(|_| DOTNET_ROOT_DEFAULT.to_string());
+    static ref DOTNET_TARGET_FRAMEWORK: String = std::env::var("DOTNET_TARGET_FRAMEWORK").unwrap_or_else(|_| DOTNET_TARGET_FRAMEWORK_DEFAULT.to_string());
 }
 
 #[cfg(feature = "csharp")]
@@ -212,6 +216,7 @@ fn gen_cs_proj(
         )
     };
 
+    let target_framework = DOTNET_TARGET_FRAMEWORK.as_str();
     write_file(
         job_dir,
         "Main.csproj",
@@ -219,7 +224,7 @@ fn gen_cs_proj(
             r#"<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>{target_framework}</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <StartupObject>WindmillScriptCSharpInternal.Wrapper</StartupObject>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>

--- a/backend/windmill-worker/src/csharp_executor.rs
+++ b/backend/windmill-worker/src/csharp_executor.rs
@@ -515,9 +515,10 @@ pub async fn handle_csharp_job(
 
     let ws_suffix = crate::workspace_registry_cache_suffix(&job.workspace_id).await;
     let mut hash = calculate_hash(&format!(
-        "{}{}",
+        "{}{}{}",
         inner_content,
-        requirements_o.unwrap_or(&String::new())
+        requirements_o.unwrap_or(&String::new()),
+        DOTNET_TARGET_FRAMEWORK.as_str()
     ));
     hash.push_str(&ws_suffix);
     let bin_path = format!("{}/{hash}", *CSHARP_CACHE_DIR);


### PR DESCRIPTION
## Summary

The C# executor hardcoded `<TargetFramework>net9.0</TargetFramework>` in the generated `Main.csproj`, so workers could only build/run C# scripts against .NET 9. This makes the target framework configurable via a new `DOTNET_TARGET_FRAMEWORK` worker env var, defaulting to `net9.0` (no behavior change for existing setups).

Motivation: a customer POC requires pricing libraries that only target .NET 8 (and later .NET 10). They installed the .NET 8 SDK on their workers, but the hardcoded `net9.0` in the csproj forced the build/target to .NET 9 regardless. Their attempt to set a `TargetFramework=net8.0` env var did not work, because an explicit `<TargetFramework>` value in the project's `PropertyGroup` takes precedence over environment variables in MSBuild property resolution. Feeding the value directly into the generated csproj fixes this.

## Changes

- Add `DOTNET_TARGET_FRAMEWORK_DEFAULT` const (`net9.0`) and a `DOTNET_TARGET_FRAMEWORK` `lazy_static` env var, mirroring the adjacent `DOTNET_ROOT` pattern.
- Interpolate the configured value into the `<TargetFramework>` of the generated `Main.csproj` in `gen_cs_proj`.
- Because both the `dotnet restore` (lockfile) and `dotnet publish` (build) paths share `gen_cs_proj`, the single change covers the whole pipeline.

Note: a recent enough SDK (9 or 10) can down-target older frameworks, so the recommended setup is to keep the newest SDK as `dotnet` and set `DOTNET_TARGET_FRAMEWORK` per worker group — but a pinned SDK 8 + `net8.0` also works.

## Test plan

- [ ] With `DOTNET_TARGET_FRAMEWORK` unset, confirm generated `Main.csproj` still carries `net9.0` and existing C# scripts compile/run unchanged.
- [ ] Set `DOTNET_TARGET_FRAMEWORK=net8.0` on a worker (csharp feature, .NET 8 SDK installed), run a C# script, and confirm the csproj carries `net8.0` and the script compiles/runs.
- [ ] `cargo check -p windmill-worker --features csharp` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the C# executor’s target framework configurable via `DOTNET_TARGET_FRAMEWORK` (default `net9.0`). The value is written into `<TargetFramework>` in the generated `Main.csproj` and included in the binary cache key, enabling .NET 8–10 and preventing cross-framework cache collisions.

<sup>Written for commit 5a6b2d0a3d998ed63c6af7c69188339a4b01b118. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

