### PR TITLE
feat(sandbox): pull/extract images with crane instead of podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -311,7 +311,7 @@ COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 # Single static binary — no daemon/store/root needed. See docs/docker-v2-runtime.md.
 ARG CRANE_VERSION=v0.20.6
 RUN arch="$(dpkg --print-architecture)"; \
-    case "$arch" in amd64) crane_arch=x86_64 ;; arm64) crane_arch=arm64 ;; *) crane_arch="$arch" ;; esac; \
+    case "$arch" in amd64) crane_arch=x86_64 ;; arm64) crane_arch=arm64 ;; *) echo >&2 "error: unsupported arch '$arch' for crane"; exit 1 ;; esac; \
     wget -O /tmp/crane.tgz "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_${crane_arch}.tar.gz" \
     && tar -xzf /tmp/crane.tgz -C /usr/local/bin crane \
     && rm /tmp/crane.tgz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -307,6 +307,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends libprotobuf32 l
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 
+# crane: pulls + flattens images for the sandboxed container runtime (`# sandbox <image>`).
+# Single static binary — no daemon/store/root needed. See docs/docker-v2-runtime.md.
+ARG CRANE_VERSION=v0.20.6
+RUN arch="$(dpkg --print-architecture)"; \
+    case "$arch" in amd64) crane_arch=x86_64 ;; arm64) crane_arch=arm64 ;; *) crane_arch="$arch" ;; esac; \
+    wget -O /tmp/crane.tgz "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_${crane_arch}.tar.gz" \
+    && tar -xzf /tmp/crane.tgz -C /usr/local/bin crane \
+    && rm /tmp/crane.tgz \
+    && chmod +x /usr/local/bin/crane
+
 WORKDIR ${APP}
 
 RUN ln -s ${APP}/windmill /usr/local/bin/windmill

--- a/backend/windmill-worker/src/docker_v2.rs
+++ b/backend/windmill-worker/src/docker_v2.rs
@@ -3,8 +3,9 @@
 //! Unlike the legacy `# docker` (dind/daemon) path, this has no daemon and no Docker
 //! API. It splits *pull* from *run*:
 //!
-//! 1. **pull/extract** (podman, rootless): materialize the image's root filesystem
-//!    into `{job_dir}/rootfs` and read its OCI config (Env/Cmd/Entrypoint/WorkingDir).
+//! 1. **pull/extract** (`crane`, no daemon/store/root): materialize the image's root
+//!    filesystem into `{job_dir}/rootfs` and read its OCI config
+//!    (Env/Cmd/Entrypoint/WorkingDir), via a digest-keyed rootfs cache.
 //! 2. **run** (the job's own nsjail sandbox): execute the image command with the
 //!    extracted rootfs bound in as the new root, so the container inherits exactly
 //!    the job's confinement (filesystem mask, pid namespace, network, uid) and can't
@@ -46,18 +47,36 @@ const NSJAIL_CONFIG_RUN_DOCKER_CONTENT: &str = include_str!("../nsjail/run.docke
 const DEFAULT_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 
 lazy_static::lazy_static! {
-    pub static ref PODMAN_PATH: String =
-        std::env::var("PODMAN_PATH").unwrap_or_else(|_| "podman".to_string());
+    /// `crane` (google/go-containerregistry) — pulls + flattens an image to a rootfs
+    /// without a daemon, store, root, or privileged container. We never *run* the
+    /// image via crane (nsjail does the run), so a full container engine is overkill.
+    pub static ref CRANE_PATH: String =
+        std::env::var("CRANE_PATH").unwrap_or_else(|_| "crane".to_string());
+
+    /// `linux/<arch>` for the worker, pinned on every crane call so multi-arch images
+    /// resolve deterministically (and `crane manifest` returns a real manifest, not an
+    /// index).
+    static ref CRANE_PLATFORM: String = format!("linux/{}", match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        other => other,
+    });
+
+    /// Content-addressed cache of flattened rootfs tars, keyed by image digest. crane
+    /// has no persistent store, so this is what gives cross-job dedup (and, since it's
+    /// digest-keyed, automatic freshness when a moving tag changes).
+    static ref ROOTFS_CACHE_DIR: String =
+        format!("{}sandbox_rootfs", *windmill_common::worker::ROOT_CACHE_DIR);
 }
 
 /// Guards against overlapping cache-eviction passes across concurrent jobs.
 static EVICTION_RUNNING: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
-/// podman pull policy from the `sandbox_image_pull_policy` instance setting. `newer`
-/// (the default when unset/invalid) re-pulls only when the registry digest changed —
-/// one cheap manifest check per job, no transfer if unchanged — so moving tags like
-/// `:latest` don't go stale. `missing` is fastest (tags can go stale); `always`
-/// re-checks every job.
+/// `sandbox_image_pull_policy` instance setting. With the digest-keyed cache, `newer`
+/// (default) re-resolves the digest each job (cheap manifest fetch) so moving tags
+/// like `:latest` stay fresh while unchanged digests reuse the cache. `missing` skips
+/// the registry when a digest is already cached for the ref; `never` only uses the
+/// cache (errors if absent); `always` == `newer` here.
 async fn pull_policy() -> String {
     let p = SANDBOX_IMAGE_PULL_POLICY.read().await.clone();
     match p.as_deref() {
@@ -99,15 +118,19 @@ async fn resolve_image_ref(image: &str) -> String {
     }
 }
 
-/// If the `sandbox_registry_auth` instance setting holds a docker/podman `auth.json`
-/// blob, write it to a per-job authfile (0600, removed with the job) and return its
-/// path to pass to `podman --authfile`. Returns `None` when unset.
-async fn write_auth_file(job_dir: &str) -> Result<Option<String>, Error> {
+/// If the `sandbox_registry_auth` instance setting holds a docker `auth.json` blob,
+/// write it to a per-job `DOCKER_CONFIG` dir (`{job_dir}/.docker/config.json`, 0600,
+/// removed with the job) and return the dir to pass to crane via `DOCKER_CONFIG`.
+/// Returns `None` when unset. (docker `config.json` and podman `auth.json` share the
+/// `{"auths": {...}}` schema, so the same blob works.)
+async fn write_auth_dir(job_dir: &str) -> Result<Option<String>, Error> {
     let auth = SANDBOX_REGISTRY_AUTH.read().await.clone();
     let Some(auth) = auth.filter(|a| !a.trim().is_empty()) else {
         return Ok(None);
     };
-    let path = format!("{job_dir}/registry_auth.json");
+    let dir = format!("{job_dir}/.docker");
+    tokio::fs::create_dir_all(&dir).await?;
+    let path = format!("{dir}/config.json");
     // Create 0600 from the start (registry credentials) — no world-readable window.
     #[cfg(unix)]
     {
@@ -123,7 +146,7 @@ async fn write_auth_file(job_dir: &str) -> Result<Option<String>, Error> {
     }
     #[cfg(not(unix))]
     tokio::fs::write(&path, auth).await?;
-    Ok(Some(path))
+    Ok(Some(dir))
 }
 
 /// The subset of an image's OCI config we apply to the run.
@@ -174,87 +197,164 @@ fn render_envars(env: &[(String, String)]) -> String {
         .join("\n")
 }
 
-async fn podman(args: &[&str]) -> Result<std::process::Output, Error> {
-    Command::new(PODMAN_PATH.as_str())
-        .args(args)
-        .output()
+/// Run `crane` with the optional per-job `DOCKER_CONFIG` auth dir.
+async fn crane(args: &[&str], auth_dir: Option<&str>) -> Result<std::process::Output, Error> {
+    let mut cmd = Command::new(CRANE_PATH.as_str());
+    cmd.args(args);
+    if let Some(dir) = auth_dir {
+        cmd.env("DOCKER_CONFIG", dir);
+    }
+    cmd.output()
         .await
-        .map_err(|e| Error::ExecutionErr(format!("failed to run podman {}: {e}", args.join(" "))))
+        .map_err(|e| Error::ExecutionErr(format!("failed to run crane {}: {e}", args.join(" "))))
 }
 
-/// Pull (if needed) and unpack `image` into `{job_dir}/rootfs`, returning its OCI
-/// config. Uses podman rootless: `create` (auto-pulls) + `export | tar -x`, with the
-/// config read from the resulting container (== image config, no command override).
+/// `crane config` output: the image config (Env/Cmd/Entrypoint/WorkingDir) is nested
+/// under the top-level `config` key.
+#[derive(Deserialize, Default)]
+struct CraneConfig {
+    #[serde(default)]
+    config: OciConfig,
+}
+
+/// Filesystem-safe cache key for a digest (`sha256:ab..` -> `sha256_ab..`).
+fn digest_key(digest: &str) -> String {
+    digest.replace([':', '/'], "_")
+}
+
+/// Filesystem-safe, collision-resistant key for an image ref (the ref->digest file).
+fn ref_key(image: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    image.hash(&mut h);
+    let safe: String = image
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let safe = &safe[safe.len().saturating_sub(80)..];
+    format!("{safe}_{:016x}", h.finish())
+}
+
+/// Resolve the image ref to a content digest, honoring the pull policy + a ref->digest
+/// cache. `missing`/`never` reuse a cached digest without hitting the registry (`never`
+/// errors if absent); `newer`/`always` always re-resolve via `crane digest`.
+async fn resolve_digest(
+    image: &str,
+    policy: &str,
+    auth_dir: Option<&str>,
+) -> Result<String, Error> {
+    let refs_dir = format!("{}/refs", *ROOTFS_CACHE_DIR);
+    let ref_file = format!("{refs_dir}/{}", ref_key(image));
+
+    if matches!(policy, "missing" | "never") {
+        if let Ok(d) = tokio::fs::read_to_string(&ref_file).await {
+            let d = d.trim().to_string();
+            if !d.is_empty()
+                && tokio::fs::metadata(format!("{}/{}.tar", *ROOTFS_CACHE_DIR, digest_key(&d)))
+                    .await
+                    .is_ok()
+            {
+                return Ok(d);
+            }
+        }
+        if policy == "never" {
+            return Err(Error::ExecutionErr(format!(
+                "image {image} is not in the sandbox cache and SANDBOX_IMAGE_PULL_POLICY=never"
+            )));
+        }
+    }
+
+    let out = crane(&["digest", "--platform", &CRANE_PLATFORM, image], auth_dir).await?;
+    if !out.status.success() {
+        return Err(Error::ExecutionErr(format!(
+            "failed to resolve image {image}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        )));
+    }
+    let digest = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    let _ = tokio::fs::create_dir_all(&refs_dir).await;
+    let _ = tokio::fs::write(&ref_file, &digest).await;
+    Ok(digest)
+}
+
+/// Pull (if not cached) and unpack `image` into `{job_dir}/rootfs`, returning its OCI
+/// config. Uses `crane export`/`config` (no daemon/store/root) with a content-addressed
+/// rootfs+config cache keyed by digest for cross-job dedup.
 async fn extract_image(image: &str, job_dir: &str) -> Result<OciConfig, Error> {
     let rootfs = format!("{job_dir}/rootfs");
     tokio::fs::create_dir_all(&rootfs).await?;
+    tokio::fs::create_dir_all(&*ROOTFS_CACHE_DIR).await?;
 
-    // `podman create` (no command) pulls the image per the configured policy and
-    // records the image's own Cmd/Entrypoint, which we then read back from the
-    // container config. `--` guards against an `image` ref that starts with `-` being
-    // parsed as a flag (e.g. `--authfile=...`) — the ref is attacker-controlled in
-    // the untrusted case.
-    let pull = format!("--pull={}", pull_policy().await);
-    let mut create_args = vec!["create", &pull];
-    let authfile = write_auth_file(job_dir).await?;
-    if let Some(authfile) = authfile.as_deref() {
-        create_args.push("--authfile");
-        create_args.push(authfile);
+    let auth_dir = write_auth_dir(job_dir).await?;
+    let auth = auth_dir.as_deref();
+    let digest = resolve_digest(image, &pull_policy().await, auth).await?;
+    let key = digest_key(&digest);
+    let tar = format!("{}/{key}.tar", *ROOTFS_CACHE_DIR);
+    let cfg = format!("{}/{key}.json", *ROOTFS_CACHE_DIR);
+
+    // Cache miss: fetch + flatten the image with crane (no daemon/store/root) into the
+    // content-addressed cache. A digest hit reuses the cached tar — no download.
+    if tokio::fs::metadata(&tar).await.is_err() {
+        // Reject oversized images before downloading any layer.
+        enforce_image_size_limit(image, auth).await?;
+
+        // Export to a per-job temp file then atomically rename, so a concurrent job
+        // pulling the same digest never sees a half-written tar.
+        let job_token = std::path::Path::new(job_dir)
+            .file_name()
+            .map(|x| x.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let tmp = format!("{tar}.tmp.{job_token}");
+        let exported = crane(
+            &["export", "--platform", &CRANE_PLATFORM, image, &tmp],
+            auth,
+        )
+        .await?;
+        if !exported.status.success() {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            return Err(Error::ExecutionErr(format!(
+                "failed to export image {image}: {}",
+                String::from_utf8_lossy(&exported.stderr)
+            )));
+        }
+        let config = crane(&["config", "--platform", &CRANE_PLATFORM, image], auth).await?;
+        if !config.status.success() {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            return Err(Error::ExecutionErr(format!(
+                "failed to read image {image} config: {}",
+                String::from_utf8_lossy(&config.stderr)
+            )));
+        }
+        let _ = tokio::fs::write(&cfg, &config.stdout).await;
+        tokio::fs::rename(&tmp, &tar).await?;
     }
-    create_args.push("--");
-    create_args.push(image);
-    let created = podman(&create_args).await?;
-    if !created.status.success() {
-        return Err(Error::ExecutionErr(format!(
-            "failed to pull/create image {image}: {}",
-            String::from_utf8_lossy(&created.stderr)
-        )));
-    }
-    let container_id = String::from_utf8_lossy(&created.stdout).trim().to_string();
 
-    // Always clean up the container, even on a later failure.
-    let result = extract_created(image, &container_id, &rootfs).await;
-    let _ = podman(&["rm", "-f", &container_id]).await;
-    result
-}
+    // Read the image config (Env/Cmd/Entrypoint/WorkingDir); tolerate a missing/old
+    // config sidecar by falling back to defaults.
+    let config: OciConfig = match tokio::fs::read(&cfg).await {
+        Ok(bytes) => {
+            serde_json::from_slice::<CraneConfig>(&bytes)
+                .map_err(|e| {
+                    Error::ExecutionErr(format!("failed to parse image {image} config: {e}"))
+                })?
+                .config
+        }
+        Err(_) => OciConfig::default(),
+    };
 
-async fn extract_created(
-    image: &str,
-    container_id: &str,
-    rootfs: &str,
-) -> Result<OciConfig, Error> {
-    // Reject oversized images before paying the (large) extraction cost.
-    enforce_image_size_limit(image).await?;
-
-    let inspected = podman(&["inspect", container_id, "--format", "{{json .Config}}"]).await?;
-    if !inspected.status.success() {
-        return Err(Error::ExecutionErr(format!(
-            "failed to inspect image {image}: {}",
-            String::from_utf8_lossy(&inspected.stderr)
-        )));
-    }
-    let config: OciConfig = serde_json::from_slice(&inspected.stdout)
-        .map_err(|e| Error::ExecutionErr(format!("failed to parse image {image} config: {e}")))?;
-
-    // Flatten the image's layers into a rootfs directory. Go through a tar on disk
-    // (in the job dir, cleaned up with the job) rather than a shell pipe. Extracted
-    // as the worker user, so the rootfs is owned by the worker user — which the
-    // single-uid jail maps to uid 0 inside.
-    let tar_path = format!("{rootfs}.tar");
-    let exported = podman(&["export", container_id, "--output", &tar_path]).await?;
-    if !exported.status.success() {
-        let _ = tokio::fs::remove_file(&tar_path).await;
-        return Err(Error::ExecutionErr(format!(
-            "failed to export image {image}: {}",
-            String::from_utf8_lossy(&exported.stderr)
-        )));
-    }
+    // Materialize the flattened rootfs for this job. Extracted as the worker user, so
+    // the rootfs is worker-owned — which the single-uid jail maps to uid 0 inside.
     let untar = Command::new("tar")
-        .args(["-xf", &tar_path, "-C", rootfs])
+        .args(["-xf", &tar, "-C", &rootfs])
         .output()
         .await
         .map_err(|e| Error::ExecutionErr(format!("failed to run tar: {e}")))?;
-    let _ = tokio::fs::remove_file(&tar_path).await;
     if !untar.status.success() {
         return Err(Error::ExecutionErr(format!(
             "failed to unpack image {image}: {}",
@@ -265,54 +365,64 @@ async fn extract_created(
     Ok(config)
 }
 
-/// Reject the image if its on-disk (uncompressed) size exceeds
-/// `SANDBOX_IMAGE_MAX_SIZE_MB`. No-op when the limit is 0 (unset).
-async fn enforce_image_size_limit(image: &str) -> Result<(), Error> {
+/// Manifest descriptor (`crane manifest`), for the pre-download size guard.
+#[derive(Deserialize, Default)]
+struct CraneDescriptor {
+    #[serde(default)]
+    size: u64,
+}
+#[derive(Deserialize, Default)]
+struct CraneManifest {
+    #[serde(default)]
+    layers: Vec<CraneDescriptor>,
+    #[serde(default)]
+    config: CraneDescriptor,
+}
+
+/// Reject the image if its compressed download size exceeds `SANDBOX_IMAGE_MAX_SIZE_MB`,
+/// BEFORE downloading any layer (`crane manifest` is a small metadata fetch). No-op
+/// when the limit is 0 (unset).
+async fn enforce_image_size_limit(image: &str, auth_dir: Option<&str>) -> Result<(), Error> {
     let max = max_image_size_mb().await;
     if max == 0 {
         return Ok(());
     }
-    let out = podman(&["image", "inspect", image, "--format", "{{.Size}}"]).await?;
+    let out = crane(
+        &["manifest", "--platform", &CRANE_PLATFORM, image],
+        auth_dir,
+    )
+    .await?;
     if !out.status.success() {
         // Don't silently bypass the guard — surface it so an operator can see the
         // size limit isn't being enforced for this image.
         tracing::warn!(
-            "sandbox image size guard: `podman image inspect {image}` failed, not \
-            enforcing SANDBOX_IMAGE_MAX_SIZE_MB: {}",
+            "sandbox image size guard: `crane manifest {image}` failed, not enforcing \
+            SANDBOX_IMAGE_MAX_SIZE_MB: {}",
             String::from_utf8_lossy(&out.stderr)
         );
         return Ok(());
     }
-    let bytes: u64 = String::from_utf8_lossy(&out.stdout)
-        .trim()
-        .parse()
-        .unwrap_or(0);
+    let manifest: CraneManifest = match serde_json::from_slice(&out.stdout) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!("sandbox image size guard: cannot parse `crane manifest` json: {e}");
+            return Ok(());
+        }
+    };
+    let bytes = manifest.config.size + manifest.layers.iter().map(|l| l.size).sum::<u64>();
     let mb = bytes / 1_000_000;
     if mb > max {
         return Err(Error::ExecutionErr(format!(
-            "image {image} is {mb} MB, over the SANDBOX_IMAGE_MAX_SIZE_MB limit of {max} MB"
+            "image {image} is {mb} MB (compressed), over the SANDBOX_IMAGE_MAX_SIZE_MB limit of {max} MB"
         )));
     }
     Ok(())
 }
 
-#[derive(Deserialize)]
-struct PodmanImage {
-    #[serde(rename = "Id")]
-    id: String,
-    // `default`: podman tags Size/Created `omitempty`, so a degenerate image with a
-    // zero value drops the key — without this the whole array would fail to parse.
-    #[serde(default, rename = "Size")]
-    size: u64,
-    #[serde(default, rename = "Created")]
-    created: i64,
-}
-
-/// Best-effort eviction: while the summed size of podman's images exceeds
-/// `SANDBOX_IMAGE_CACHE_MAX_MB`, remove the oldest (by created time, an LRU proxy).
-/// No-op when the limit is 0 (unset). Skipped if another pass is already running.
-/// Images currently backing a container (e.g. a concurrent job mid-extract) fail
-/// `rmi` and stop the pass, so in-use images are never removed.
+/// Best-effort eviction: while the cached rootfs tars exceed `SANDBOX_IMAGE_CACHE_MAX_MB`,
+/// remove the oldest by mtime (true LRU). No-op when the limit is 0 (unset). Skipped if
+/// another pass is already running. The per-job extracted rootfs lives in the job dir
+/// (cleaned with the job), so only the content-addressed tar+config cache is pruned.
 async fn enforce_image_cache_limit() {
     use std::sync::atomic::Ordering;
     let max_mb = image_cache_max_mb().await;
@@ -335,42 +445,39 @@ async fn enforce_image_cache_limit() {
     }
     let _reset = ResetOnDrop;
     let max_bytes = max_mb.saturating_mul(1_000_000);
+
+    // (path, size, mtime) for every cached rootfs tar.
+    async fn list_tars() -> Vec<(std::path::PathBuf, u64, std::time::SystemTime)> {
+        let mut out = Vec::new();
+        let Ok(mut rd) = tokio::fs::read_dir(&*ROOTFS_CACHE_DIR).await else {
+            return out;
+        };
+        while let Ok(Some(e)) = rd.next_entry().await {
+            let p = e.path();
+            if p.extension().and_then(|x| x.to_str()) != Some("tar") {
+                continue;
+            }
+            if let Ok(m) = e.metadata().await {
+                let mtime = m.modified().unwrap_or(std::time::UNIX_EPOCH);
+                out.push((p, m.len(), mtime));
+            }
+        }
+        out
+    }
+
     loop {
-        let Ok(out) = podman(&["images", "--format", "json"]).await else {
-            break;
-        };
-        if !out.status.success() {
-            break;
-        }
-        let mut imgs: Vec<PodmanImage> = match serde_json::from_slice(&out.stdout) {
-            Ok(v) => v,
-            Err(e) => {
-                // Don't silently disable eviction on a schema hiccup — surface it.
-                tracing::warn!(
-                    "sandbox image cache eviction: cannot parse `podman images` json: {e}"
-                );
-                break;
-            }
-        };
-        let total: u64 = imgs.iter().map(|i| i.size).sum();
-        if total <= max_bytes || imgs.is_empty() {
+        let mut tars = list_tars().await;
+        let total: u64 = tars.iter().map(|(_, s, _)| *s).sum();
+        if total <= max_bytes || tars.is_empty() {
             break;
         }
-        imgs.sort_by_key(|i| i.created);
-        let victim = imgs[0].id.clone();
-        match podman(&["rmi", &victim]).await {
-            Ok(rm) if rm.status.success() => {
-                tracing::info!("sandbox image cache eviction: removed {victim}");
-            }
-            Ok(rm) => {
-                tracing::warn!(
-                    "sandbox image cache eviction: cannot remove {victim} (in use?): {}",
-                    String::from_utf8_lossy(&rm.stderr)
-                );
-                break;
-            }
-            Err(_) => break,
+        tars.sort_by_key(|(_, _, mtime)| *mtime);
+        let victim = tars[0].0.clone();
+        if tokio::fs::remove_file(&victim).await.is_err() {
+            break; // can't reclaim — stop rather than spin on the same victim
         }
+        let _ = tokio::fs::remove_file(victim.with_extension("json")).await;
+        tracing::info!("sandbox image cache eviction: removed {}", victim.display());
     }
     // `_reset` drops here and clears EVICTION_RUNNING.
 }
@@ -454,7 +561,7 @@ pub async fn handle_docker_v2_job(
     let config = extract_image(image, job_dir).await?;
     let rootfs = format!("{job_dir}/rootfs");
 
-    // Best-effort: keep podman's image store under its size cap (overlaps the run).
+    // Best-effort: keep the cached rootfs tars under their size cap (overlaps the run).
     tokio::spawn(enforce_image_cache_limit());
 
     // Resolve the script args from the bash signature, like the bash executor.

--- a/backend/windmill-worker/src/docker_v2.rs
+++ b/backend/windmill-worker/src/docker_v2.rs
@@ -294,75 +294,106 @@ async fn extract_image(image: &str, job_dir: &str) -> Result<OciConfig, Error> {
     let auth_dir = write_auth_dir(job_dir).await?;
     let auth = auth_dir.as_deref();
     let digest = resolve_digest(image, &pull_policy().await, auth).await?;
+    // Pin every subsequent fetch to the resolved digest, not the (mutable) tag, so the
+    // content can't diverge from the digest we cache under if the tag moves mid-fetch.
+    let pinned = format!("{}@{digest}", image.split('@').next().unwrap_or(image));
     let key = digest_key(&digest);
     let tar = format!("{}/{key}.tar", *ROOTFS_CACHE_DIR);
     let cfg = format!("{}/{key}.json", *ROOTFS_CACHE_DIR);
+    let size_file = format!("{}/{key}.size", *ROOTFS_CACHE_DIR);
+    let token = std::path::Path::new(job_dir)
+        .file_name()
+        .map(|x| x.to_string_lossy().into_owned())
+        .unwrap_or_default();
 
-    // Cache miss: fetch + flatten the image with crane (no daemon/store/root) into the
-    // content-addressed cache. A digest hit reuses the cached tar — no download.
-    if tokio::fs::metadata(&tar).await.is_err() {
-        // Reject oversized images before downloading any layer.
-        enforce_image_size_limit(image, auth).await?;
+    // Enforce the size cap on EVERY job (not just cache misses), using a cached size so
+    // a cache reuse needs no registry call — lowering the limit rejects cached images too.
+    enforce_image_size_limit(&pinned, &size_file, auth).await?;
 
-        // Export to a per-job temp file then atomically rename, so a concurrent job
-        // pulling the same digest never sees a half-written tar.
-        let job_token = std::path::Path::new(job_dir)
-            .file_name()
-            .map(|x| x.to_string_lossy().into_owned())
-            .unwrap_or_default();
-        let tmp = format!("{tar}.tmp.{job_token}");
-        let exported = crane(
-            &["export", "--platform", &CRANE_PLATFORM, image, &tmp],
-            auth,
-        )
-        .await?;
-        if !exported.status.success() {
-            let _ = tokio::fs::remove_file(&tmp).await;
+    // Materialize the flattened rootfs. The cache tar can be evicted concurrently, so up
+    // to two attempts: hardlink the cache tar into the job dir (pins the inode against
+    // eviction) before extracting; if it vanished first, re-fetch.
+    let job_tar = format!("{job_dir}/rootfs.tar");
+    for attempt in 0..2 {
+        if tokio::fs::metadata(&tar).await.is_err() {
+            fetch_into_cache(&pinned, &tar, &cfg, &token, auth).await?;
+        }
+        let config = read_oci_config(&cfg).await;
+        let _ = tokio::fs::remove_file(&job_tar).await;
+        match tokio::fs::hard_link(&tar, &job_tar).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound && attempt == 0 => {
+                continue; // evicted between the check and the link — re-fetch
+            }
+            Err(e) => return Err(Error::ExecutionErr(format!("failed to stage rootfs: {e}"))),
+        }
+        // Extract as the worker user (rootfs is worker-owned → uid 0 inside the jail).
+        let untar = Command::new("tar")
+            .args(["-xf", &job_tar, "-C", &rootfs])
+            .output()
+            .await
+            .map_err(|e| Error::ExecutionErr(format!("failed to run tar: {e}")))?;
+        let _ = tokio::fs::remove_file(&job_tar).await;
+        if !untar.status.success() {
             return Err(Error::ExecutionErr(format!(
-                "failed to export image {image}: {}",
-                String::from_utf8_lossy(&exported.stderr)
+                "failed to unpack image {image}: {}",
+                String::from_utf8_lossy(&untar.stderr)
             )));
         }
-        let config = crane(&["config", "--platform", &CRANE_PLATFORM, image], auth).await?;
-        if !config.status.success() {
-            let _ = tokio::fs::remove_file(&tmp).await;
-            return Err(Error::ExecutionErr(format!(
-                "failed to read image {image} config: {}",
-                String::from_utf8_lossy(&config.stderr)
-            )));
-        }
-        let _ = tokio::fs::write(&cfg, &config.stdout).await;
-        tokio::fs::rename(&tmp, &tar).await?;
+        return Ok(config);
     }
+    Err(Error::ExecutionErr(format!(
+        "failed to materialize rootfs for {image} (cache evicted twice)"
+    )))
+}
 
-    // Read the image config (Env/Cmd/Entrypoint/WorkingDir); tolerate a missing/old
-    // config sidecar by falling back to defaults.
-    let config: OciConfig = match tokio::fs::read(&cfg).await {
-        Ok(bytes) => {
-            serde_json::from_slice::<CraneConfig>(&bytes)
-                .map_err(|e| {
-                    Error::ExecutionErr(format!("failed to parse image {image} config: {e}"))
-                })?
-                .config
-        }
-        Err(_) => OciConfig::default(),
-    };
-
-    // Materialize the flattened rootfs for this job. Extracted as the worker user, so
-    // the rootfs is worker-owned — which the single-uid jail maps to uid 0 inside.
-    let untar = Command::new("tar")
-        .args(["-xf", &tar, "-C", &rootfs])
-        .output()
-        .await
-        .map_err(|e| Error::ExecutionErr(format!("failed to run tar: {e}")))?;
-    if !untar.status.success() {
+/// Fetch + flatten `pinned` (a `name@digest` ref) into the cache: export the rootfs tar
+/// and write the OCI config sidecar, both via tmp+rename so concurrent readers never see
+/// a torn file. The tar is published last (a present tar implies a present config).
+async fn fetch_into_cache(
+    pinned: &str,
+    tar: &str,
+    cfg: &str,
+    token: &str,
+    auth: Option<&str>,
+) -> Result<(), Error> {
+    let tar_tmp = format!("{tar}.tmp.{token}");
+    let cfg_tmp = format!("{cfg}.tmp.{token}");
+    let exported = crane(
+        &["export", "--platform", &CRANE_PLATFORM, pinned, &tar_tmp],
+        auth,
+    )
+    .await?;
+    if !exported.status.success() {
+        let _ = tokio::fs::remove_file(&tar_tmp).await;
         return Err(Error::ExecutionErr(format!(
-            "failed to unpack image {image}: {}",
-            String::from_utf8_lossy(&untar.stderr)
+            "failed to export image {pinned}: {}",
+            String::from_utf8_lossy(&exported.stderr)
         )));
     }
+    let config = crane(&["config", "--platform", &CRANE_PLATFORM, pinned], auth).await?;
+    if !config.status.success() {
+        let _ = tokio::fs::remove_file(&tar_tmp).await;
+        return Err(Error::ExecutionErr(format!(
+            "failed to read image {pinned} config: {}",
+            String::from_utf8_lossy(&config.stderr)
+        )));
+    }
+    let _ = tokio::fs::write(&cfg_tmp, &config.stdout).await;
+    let _ = tokio::fs::rename(&cfg_tmp, cfg).await;
+    tokio::fs::rename(&tar_tmp, tar).await?;
+    Ok(())
+}
 
-    Ok(config)
+/// Read the cached OCI config (Env/Cmd/Entrypoint/WorkingDir); tolerate a missing or torn
+/// sidecar by falling back to defaults (the run still works off the body + image FS).
+async fn read_oci_config(cfg: &str) -> OciConfig {
+    match tokio::fs::read(cfg).await {
+        Ok(bytes) => serde_json::from_slice::<CraneConfig>(&bytes)
+            .map(|c| c.config)
+            .unwrap_or_default(),
+        Err(_) => OciConfig::default(),
+    }
 }
 
 /// Manifest descriptor (`crane manifest`), for the pre-download size guard.
@@ -379,50 +410,71 @@ struct CraneManifest {
     config: CraneDescriptor,
 }
 
-/// Reject the image if its compressed download size exceeds `SANDBOX_IMAGE_MAX_SIZE_MB`,
-/// BEFORE downloading any layer (`crane manifest` is a small metadata fetch). No-op
-/// when the limit is 0 (unset).
-async fn enforce_image_size_limit(image: &str, auth_dir: Option<&str>) -> Result<(), Error> {
+/// Reject the image if its compressed download size exceeds `SANDBOX_IMAGE_MAX_SIZE_MB`.
+/// Runs on EVERY job (so lowering the limit rejects already-cached images too); the size
+/// is read from a `{digest}.size` sidecar when present (no registry call on cache reuse)
+/// and otherwise fetched once via `crane manifest` (before any layer download) and cached.
+/// No-op when the limit is 0 (unset).
+async fn enforce_image_size_limit(
+    pinned: &str,
+    size_file: &str,
+    auth_dir: Option<&str>,
+) -> Result<(), Error> {
     let max = max_image_size_mb().await;
     if max == 0 {
         return Ok(());
     }
-    let out = crane(
-        &["manifest", "--platform", &CRANE_PLATFORM, image],
-        auth_dir,
-    )
-    .await?;
-    if !out.status.success() {
-        // Don't silently bypass the guard — surface it so an operator can see the
-        // size limit isn't being enforced for this image.
-        tracing::warn!(
-            "sandbox image size guard: `crane manifest {image}` failed, not enforcing \
-            SANDBOX_IMAGE_MAX_SIZE_MB: {}",
-            String::from_utf8_lossy(&out.stderr)
-        );
-        return Ok(());
-    }
-    let manifest: CraneManifest = match serde_json::from_slice(&out.stdout) {
-        Ok(m) => m,
-        Err(e) => {
-            tracing::warn!("sandbox image size guard: cannot parse `crane manifest` json: {e}");
-            return Ok(());
+    let bytes = match tokio::fs::read_to_string(size_file)
+        .await
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+    {
+        Some(b) => b,
+        None => {
+            let out = crane(
+                &["manifest", "--platform", &CRANE_PLATFORM, pinned],
+                auth_dir,
+            )
+            .await?;
+            if !out.status.success() {
+                // Don't silently bypass the guard — surface it so an operator can see the
+                // size limit isn't being enforced for this image.
+                tracing::warn!(
+                    "sandbox image size guard: `crane manifest {pinned}` failed, not enforcing \
+                    SANDBOX_IMAGE_MAX_SIZE_MB: {}",
+                    String::from_utf8_lossy(&out.stderr)
+                );
+                return Ok(());
+            }
+            let manifest: CraneManifest = match serde_json::from_slice(&out.stdout) {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::warn!(
+                        "sandbox image size guard: cannot parse `crane manifest` json: {e}"
+                    );
+                    return Ok(());
+                }
+            };
+            let b = manifest.config.size + manifest.layers.iter().map(|l| l.size).sum::<u64>();
+            let _ = tokio::fs::write(size_file, b.to_string()).await;
+            b
         }
     };
-    let bytes = manifest.config.size + manifest.layers.iter().map(|l| l.size).sum::<u64>();
     let mb = bytes / 1_000_000;
     if mb > max {
         return Err(Error::ExecutionErr(format!(
-            "image {image} is {mb} MB (compressed), over the SANDBOX_IMAGE_MAX_SIZE_MB limit of {max} MB"
+            "image {pinned} is {mb} MB (compressed), over the SANDBOX_IMAGE_MAX_SIZE_MB limit of {max} MB"
         )));
     }
     Ok(())
 }
 
 /// Best-effort eviction: while the cached rootfs tars exceed `SANDBOX_IMAGE_CACHE_MAX_MB`,
-/// remove the oldest by mtime (true LRU). No-op when the limit is 0 (unset). Skipped if
-/// another pass is already running. The per-job extracted rootfs lives in the job dir
-/// (cleaned with the job), so only the content-addressed tar+config cache is pruned.
+/// remove the oldest by mtime (creation order — tars are write-once, cache hits don't
+/// touch mtime). No-op when the limit is 0 (unset). Skipped if another pass is already
+/// running. The per-job extracted rootfs lives in the job dir (cleaned with the job), so
+/// only the content-addressed tar+config+size cache is pruned. Also sweeps orphaned
+/// `*.tmp.*` files left by a crashed mid-export.
 async fn enforce_image_cache_limit() {
     use std::sync::atomic::Ordering;
     let max_mb = image_cache_max_mb().await;
@@ -446,7 +498,7 @@ async fn enforce_image_cache_limit() {
     let _reset = ResetOnDrop;
     let max_bytes = max_mb.saturating_mul(1_000_000);
 
-    // (path, size, mtime) for every cached rootfs tar.
+    // (path, size, mtime) for every cached rootfs tar; also sweep orphaned tmp files.
     async fn list_tars() -> Vec<(std::path::PathBuf, u64, std::time::SystemTime)> {
         let mut out = Vec::new();
         let Ok(mut rd) = tokio::fs::read_dir(&*ROOTFS_CACHE_DIR).await else {
@@ -454,6 +506,13 @@ async fn enforce_image_cache_limit() {
         };
         while let Ok(Some(e)) = rd.next_entry().await {
             let p = e.path();
+            let name = e.file_name();
+            let name = name.to_string_lossy();
+            // Reclaim leftover `*.tmp.<token>` files from a crashed mid-export.
+            if name.contains(".tmp.") {
+                let _ = tokio::fs::remove_file(&p).await;
+                continue;
+            }
             if p.extension().and_then(|x| x.to_str()) != Some("tar") {
                 continue;
             }
@@ -476,7 +535,9 @@ async fn enforce_image_cache_limit() {
         if tokio::fs::remove_file(&victim).await.is_err() {
             break; // can't reclaim — stop rather than spin on the same victim
         }
+        // Drop the sibling config + size sidecars too.
         let _ = tokio::fs::remove_file(victim.with_extension("json")).await;
+        let _ = tokio::fs::remove_file(victim.with_extension("size")).await;
         tracing::info!("sandbox image cache eviction: removed {}", victim.display());
     }
     // `_reset` drops here and clears EVICTION_RUNNING.
@@ -724,7 +785,34 @@ pub async fn handle_docker_v2_job(
 
 #[cfg(test)]
 mod tests {
-    use super::{proto_str, registry_qualified, render_envars};
+    use super::{digest_key, proto_str, ref_key, registry_qualified, render_envars};
+
+    #[test]
+    fn digest_key_is_filesystem_safe() {
+        assert_eq!(digest_key("sha256:4d889c14e7d5"), "sha256_4d889c14e7d5");
+        // No `:` or `/` survives (both would break the cache filename).
+        let k = digest_key("sha256:ab/cd:ef");
+        assert!(!k.contains(':') && !k.contains('/'));
+    }
+
+    #[test]
+    fn ref_key_is_safe_and_stable() {
+        // Deterministic for a given ref...
+        assert_eq!(ref_key("ghcr.io/o/i:tag"), ref_key("ghcr.io/o/i:tag"));
+        // ...distinguishes different refs...
+        assert_ne!(ref_key("alpine:latest"), ref_key("alpine:edge"));
+        // ...and is filesystem-safe (no `/` or `:`), incl. for multibyte refs (no panic
+        // on the trailing-80 byte slice since every char maps to single-byte ASCII).
+        for r in [
+            "alpine",
+            "ghcr.io/o/i:tag",
+            "localhost:5000/r@sha256:ab",
+            "rég/imagé:tag",
+        ] {
+            let k = ref_key(r);
+            assert!(!k.contains('/') && !k.contains(':'));
+        }
+    }
 
     #[test]
     fn render_envars_emits_proto_directives() {

--- a/backend/windmill-worker/src/docker_v2.rs
+++ b/backend/windmill-worker/src/docker_v2.rs
@@ -279,7 +279,11 @@ async fn resolve_digest(
     }
     let digest = String::from_utf8_lossy(&out.stdout).trim().to_string();
     let _ = tokio::fs::create_dir_all(&refs_dir).await;
-    let _ = tokio::fs::write(&ref_file, &digest).await;
+    // tmp+rename so a concurrent `missing`/`never` reader never sees a torn ref file.
+    let ref_tmp = format!("{ref_file}.tmp.{}", digest_key(&digest));
+    if tokio::fs::write(&ref_tmp, &digest).await.is_ok() {
+        let _ = tokio::fs::rename(&ref_tmp, &ref_file).await;
+    }
     Ok(digest)
 }
 
@@ -320,10 +324,20 @@ async fn extract_image(image: &str, job_dir: &str) -> Result<OciConfig, Error> {
         }
         let config = read_oci_config(&cfg).await;
         let _ = tokio::fs::remove_file(&job_tar).await;
-        match tokio::fs::hard_link(&tar, &job_tar).await {
+        // Stage the cache tar into the job dir so concurrent eviction can't unlink it out
+        // from under `tar -xf`. Prefer a hardlink (free), but the cache volume and the job
+        // dir are usually on *different* filesystems in the shipped deployments (the cache
+        // is its own volume/PVC) — there `hard_link` returns EXDEV, so fall back to a copy.
+        // `copy` reads through the source inode, so an eviction mid-copy still completes.
+        let staged = match tokio::fs::hard_link(&tar, &job_tar).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(e), // vanished — re-fetch
+            Err(_) => tokio::fs::copy(&tar, &job_tar).await.map(|_| ()),
+        };
+        match staged {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound && attempt == 0 => {
-                continue; // evicted between the check and the link — re-fetch
+                continue; // evicted between the check and the staging — re-fetch
             }
             Err(e) => return Err(Error::ExecutionErr(format!("failed to stage rootfs: {e}"))),
         }

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -694,16 +694,16 @@ lazy_static::lazy_static! {
     /// RAM-backed tmpfs sized by `nsjail_tmpfs_size_mb`.
     pub static ref NSJAIL_TMP_BACKING: Arc<RwLock<Option<String>>> = Arc::new(RwLock::new(None));
 
-    /// Reject a `# sandbox <image>` whose on-disk size exceeds this many MB, before
-    /// extraction. `None`/non-positive = no limit. (`sandbox_image_max_size_mb`.)
+    /// Reject a `# sandbox <image>` whose compressed download size exceeds this many
+    /// MB, before download. `None`/non-positive = no limit. (`sandbox_image_max_size_mb`.)
     pub static ref SANDBOX_IMAGE_MAX_SIZE_MB: Arc<RwLock<Option<i64>>> = Arc::new(RwLock::new(None));
 
-    /// Best-effort cap (MB) on podman's sandbox-image store; oldest images evicted
-    /// after a run when exceeded. `None`/non-positive = unbounded. (`sandbox_image_cache_max_mb`.)
+    /// Best-effort cap (MB) on the worker's cached rootfs tars; oldest evicted after a
+    /// run when exceeded. `None`/non-positive = unbounded. (`sandbox_image_cache_max_mb`.)
     pub static ref SANDBOX_IMAGE_CACHE_MAX_MB: Arc<RwLock<Option<i64>>> = Arc::new(RwLock::new(None));
 
-    /// podman pull policy for sandbox images (`missing`/`newer`/`always`/`never`).
-    /// `None`/unrecognized falls back to `newer`. (`sandbox_image_pull_policy`.)
+    /// Sandbox image pull policy (`missing`/`newer`/`always`/`never`). `None`/unrecognized
+    /// falls back to `newer`. (`sandbox_image_pull_policy`.)
     pub static ref SANDBOX_IMAGE_PULL_POLICY: Arc<RwLock<Option<String>>> = Arc::new(RwLock::new(None));
 
     /// If set, unqualified sandbox image refs (e.g. `alpine`) are pulled from this
@@ -711,8 +711,8 @@ lazy_static::lazy_static! {
     /// (`sandbox_image_default_registry`.)
     pub static ref SANDBOX_IMAGE_DEFAULT_REGISTRY: Arc<RwLock<Option<String>>> = Arc::new(RwLock::new(None));
 
-    /// Optional docker/podman `auth.json` blob for private registries, written to a
-    /// per-job authfile and passed to `podman --authfile`. (`sandbox_registry_auth`.)
+    /// Optional docker `auth.json` blob for private registries, written to a per-job
+    /// `DOCKER_CONFIG` dir for crane. (`sandbox_registry_auth`.)
     pub static ref SANDBOX_REGISTRY_AUTH: Arc<RwLock<Option<String>>> = Arc::new(RwLock::new(None));
 
     /// Optional mirror URL for `uv python install`. Wires to the `UV_PYTHON_INSTALL_MIRROR`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
     volumes:
       - worker_dependency_cache:/tmp/windmill/cache
       - worker_logs:/tmp/windmill/logs
-      ## Sandboxed containers (`# sandbox <image>`) run daemonless via podman + nsjail
+      ## Sandboxed containers (`# sandbox <image>`) run daemonless via crane + nsjail
       ## inside the worker itself — no Docker socket or dind sidecar required.
       ## For the legacy full-compat docker (a bare `# docker`, trusted users only),
       ## mount the host Docker socket by uncommenting the line below. WARNING: this

--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -94,7 +94,7 @@ COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 # Single static binary — no daemon/store/root needed. See docs/docker-v2-runtime.md.
 ARG CRANE_VERSION=v0.20.6
 RUN arch="$(dpkg --print-architecture)"; \
-    case "$arch" in amd64) crane_arch=x86_64 ;; arm64) crane_arch=arm64 ;; *) crane_arch="$arch" ;; esac; \
+    case "$arch" in amd64) crane_arch=x86_64 ;; arm64) crane_arch=arm64 ;; *) echo >&2 "error: unsupported arch '$arch' for crane"; exit 1 ;; esac; \
     wget -O /tmp/crane.tgz "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_${crane_arch}.tar.gz" \
     && tar -xzf /tmp/crane.tgz -C /usr/local/bin crane \
     && rm /tmp/crane.tgz \

--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -90,6 +90,16 @@ RUN apt-get update \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 
+# crane: pulls + flattens images for the sandboxed container runtime (`# sandbox <image>`).
+# Single static binary — no daemon/store/root needed. See docs/docker-v2-runtime.md.
+ARG CRANE_VERSION=v0.20.6
+RUN arch="$(dpkg --print-architecture)"; \
+    case "$arch" in amd64) crane_arch=x86_64 ;; arm64) crane_arch=arm64 ;; *) crane_arch="$arch" ;; esac; \
+    wget -O /tmp/crane.tgz "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_${crane_arch}.tar.gz" \
+    && tar -xzf /tmp/crane.tgz -C /usr/local/bin crane \
+    && rm /tmp/crane.tgz \
+    && chmod +x /usr/local/bin/crane
+
 WORKDIR ${APP}
 
 COPY --from=ghcr.io/windmill-labs/windmill:dev --chmod=755  ${APP}/windmill ${APP}/windmill

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -94,7 +94,7 @@ COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 # Single static binary — no daemon/store/root needed. See docs/docker-v2-runtime.md.
 ARG CRANE_VERSION=v0.20.6
 RUN arch="$(dpkg --print-architecture)"; \
-    case "$arch" in amd64) crane_arch=x86_64 ;; arm64) crane_arch=arm64 ;; *) crane_arch="$arch" ;; esac; \
+    case "$arch" in amd64) crane_arch=x86_64 ;; arm64) crane_arch=arm64 ;; *) echo >&2 "error: unsupported arch '$arch' for crane"; exit 1 ;; esac; \
     wget -O /tmp/crane.tgz "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_${crane_arch}.tar.gz" \
     && tar -xzf /tmp/crane.tgz -C /usr/local/bin crane \
     && rm /tmp/crane.tgz \

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -90,6 +90,16 @@ RUN apt-get update \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 
+# crane: pulls + flattens images for the sandboxed container runtime (`# sandbox <image>`).
+# Single static binary — no daemon/store/root needed. See docs/docker-v2-runtime.md.
+ARG CRANE_VERSION=v0.20.6
+RUN arch="$(dpkg --print-architecture)"; \
+    case "$arch" in amd64) crane_arch=x86_64 ;; arm64) crane_arch=arm64 ;; *) crane_arch="$arch" ;; esac; \
+    wget -O /tmp/crane.tgz "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_${crane_arch}.tar.gz" \
+    && tar -xzf /tmp/crane.tgz -C /usr/local/bin crane \
+    && rm /tmp/crane.tgz \
+    && chmod +x /usr/local/bin/crane
+
 WORKDIR ${APP}
 
 COPY --from=ghcr.io/windmill-labs/windmill-ee:dev --chmod=755  ${APP}/windmill ${APP}/windmill

--- a/docs/docker-v2-runtime.md
+++ b/docs/docker-v2-runtime.md
@@ -36,10 +36,14 @@ python3 -c "import sys; print('hello', sys.argv[1])" "$name"
 
 ## How it works
 
-1. **Pull/extract** (podman, rootless): `podman create --pull=<policy> <image>` +
-   `podman export | tar -x` materializes the image's flattened root filesystem
-   into `{job_dir}/rootfs`, and `podman inspect` reads its OCI config. podman's
-   image store dedups pulls across jobs.
+1. **Pull/extract** ([`crane`](https://github.com/google/go-containerregistry), no
+   daemon/store/root): `crane export <image>` streams the image's flattened root
+   filesystem to a tar (layers + whiteouts applied, like `docker export`) and
+   `crane config` reads its OCI config. The tar + config are cached
+   content-addressed by digest (`crane digest`) so unchanged digests reuse the
+   cache; `tar -x` materializes the per-job `{job_dir}/rootfs`. crane is a single
+   ~25 MB static binary — we never *run* the image with it (nsjail does), so a full
+   container engine like podman isn't needed.
 2. **Run** (the job's nsjail sandbox): nsjail binds each top-level entry of the
    rootfs in place (binding the whole rootfs at `/` trips nsjail's read-only
    remount of its base root in a rootless userns), mounts the standard
@@ -48,8 +52,8 @@ python3 -c "import sys; print('hello', sys.argv[1])" "$name"
    command. The container *is* the jail.
 
 ```
-# sandbox <image>  ─▶  podman create+export ─▶  {job_dir}/rootfs  ─▶  nsjail (chroot rootfs)
-                       podman inspect (OCI config) ──────────────────▶  Env / Cmd / WorkingDir
+# sandbox <image>  ─▶  crane export → digest-keyed rootfs cache → tar -x → {job_dir}/rootfs  ─▶  nsjail (chroot rootfs)
+                       crane config (OCI config) ───────────────────────────────────────────▶  Env / Cmd / WorkingDir
 ```
 
 Because the run is just the job's own nsjail with the image's filesystem as root,
@@ -64,24 +68,27 @@ the container inherits exactly the job's confinement:
 
 ## Image storage, freshness & limits
 
-- **Where pulls live:** podman's rootless graph root (default
-  `$HOME/.local/share/containers/storage`) — persistent, dedups pulls across jobs.
-  The per-job extracted rootfs lives in `{job_dir}/rootfs` and is removed with the
-  job; the transient `rootfs.tar` is removed right after extraction.
-- **Freshness (`SANDBOX_IMAGE_PULL_POLICY`, default `newer`):** `newer` re-pulls
-  only when the registry digest changed (one cheap manifest check per job, no data
-  transfer if unchanged) — so moving tags like `:latest` don't go stale. `missing`
-  is fastest but tags can go stale; `always` re-checks every job. Pinning a digest
+- **Where pulls live:** a content-addressed cache of flattened rootfs tars (+ OCI
+  config sidecars) keyed by image digest, under `{ROOT_CACHE_DIR}/sandbox_rootfs`
+  (persistent, dedups pulls across jobs). The per-job extracted rootfs lives in
+  `{job_dir}/rootfs` and is removed with the job.
+- **Freshness (`SANDBOX_IMAGE_PULL_POLICY`, default `newer`):** the cache is keyed
+  by digest, so a moving tag whose digest changed re-pulls automatically. `newer`
+  (default) / `always` re-resolve the digest each job (one cheap `crane digest`
+  manifest fetch); `missing` reuses a cached digest for the ref without hitting the
+  registry; `never` only uses the cache (errors if absent). Pinning a digest
   (`img@sha256:…`) is immutable and never stale.
 - **Per-image size cap (`SANDBOX_IMAGE_MAX_SIZE_MB`, default 0 = off):** images
-  whose on-disk size exceeds the cap are rejected before extraction.
+  whose *compressed download* size (`crane manifest`) exceeds the cap are rejected
+  **before any layer is downloaded**.
 - **Cache size cap (`SANDBOX_IMAGE_CACHE_MAX_MB`, default 0 = off):** best-effort
-  LRU eviction — after a run, the oldest images are removed until podman's image
-  store is back under the cap. In-use images are never removed.
+  LRU eviction — after a run, the oldest cached rootfs tars are removed until the
+  cache is back under the cap.
 
 ## Requirements
 
-- `podman` (rootless) and `tar` on the worker for image pull/extract.
+- [`crane`](https://github.com/google/go-containerregistry) and `tar` on the worker
+  for image pull/extract (a single static binary — no daemon, root, or privileged).
 - `nsjail` on the worker — **required**. If nsjail is absent, a `# sandbox <image>`
   job errors clearly (use a bare `# docker` + a daemon instead).
 
@@ -98,9 +105,6 @@ the container inherits exactly the job's confinement:
 
 ## Follow-ups
 
-- Content-addressed rootfs cache keyed by image digest (today each job re-exports;
-  podman's image store still dedups the network pull).
-- Pre-pull size guard via `skopeo` manifest inspection (reject before download).
 - Subuid-range nsjail variant for multi-uid images.
 - Per-container isolated networking (slirp/pasta).
 - Support under the non-nsjail `unshare` isolation mode.

--- a/docs/docker-v2-runtime.md
+++ b/docs/docker-v2-runtime.md
@@ -82,8 +82,8 @@ the container inherits exactly the job's confinement:
   whose *compressed download* size (`crane manifest`) exceeds the cap are rejected
   **before any layer is downloaded**.
 - **Cache size cap (`SANDBOX_IMAGE_CACHE_MAX_MB`, default 0 = off):** best-effort
-  LRU eviction — after a run, the oldest cached rootfs tars are removed until the
-  cache is back under the cap.
+  eviction — after a run, the oldest cached rootfs tars (by creation time) are
+  removed until the cache is back under the cap.
 
 ## Requirements
 

--- a/frontend/src/lib/components/instanceSettings.ts
+++ b/frontend/src/lib/components/instanceSettings.ts
@@ -272,7 +272,7 @@ export const settings: Record<string, Setting[]> = {
 			label: 'Sandbox image max size (MB)',
 			key: 'sandbox_image_max_size_mb',
 			description:
-				'Reject a <code># sandbox &lt;image&gt;</code> whose on-disk size exceeds this many MB, before extraction. Leave empty for no limit.',
+				'Reject a <code># sandbox &lt;image&gt;</code> whose compressed download size exceeds this many MB, before any layer is downloaded. Leave empty for no limit.',
 			fieldType: 'number',
 			placeholder: 'no limit',
 			storage: 'setting'
@@ -281,7 +281,7 @@ export const settings: Record<string, Setting[]> = {
 			label: 'Sandbox image cache cap (MB)',
 			key: 'sandbox_image_cache_max_mb',
 			description:
-				"Best-effort cap on the worker's sandbox image store (podman). When exceeded, the oldest images are evicted after a run. Leave empty for unbounded.",
+				"Best-effort cap on the worker's cached sandbox rootfs tars. When exceeded, the oldest are evicted (LRU) after a run. Leave empty for unbounded.",
 			fieldType: 'number',
 			placeholder: 'unbounded',
 			storage: 'setting'
@@ -315,7 +315,7 @@ export const settings: Record<string, Setting[]> = {
 			label: 'Sandbox registry auth',
 			key: 'sandbox_registry_auth',
 			description:
-				'Credentials for private registries used by <code># sandbox</code> images, in docker/podman <code>auth.json</code> format. Written to a per-job authfile (removed with the job) and passed to <code>podman --authfile</code>.',
+				'Credentials for private registries used by <code># sandbox</code> images, in docker <code>config.json</code> / <code>auth.json</code> format. Written to a per-job <code>DOCKER_CONFIG</code> dir (removed with the job) and used by crane for the pull.',
 			fieldType: 'codearea',
 			codeAreaLang: 'json',
 			placeholder:

--- a/frontend/src/lib/components/instanceSettings.ts
+++ b/frontend/src/lib/components/instanceSettings.ts
@@ -281,7 +281,7 @@ export const settings: Record<string, Setting[]> = {
 			label: 'Sandbox image cache cap (MB)',
 			key: 'sandbox_image_cache_max_mb',
 			description:
-				"Best-effort cap on the worker's cached sandbox rootfs tars. When exceeded, the oldest are evicted (LRU) after a run. Leave empty for unbounded.",
+				"Best-effort cap on the worker's cached sandbox rootfs tars. When exceeded, the oldest (by creation time) are evicted after a run. Leave empty for unbounded.",
 			fieldType: 'number',
 			placeholder: 'unbounded',
 			storage: 'setting'


### PR DESCRIPTION
## Summary

Follow-up to #9453. That PR shipped the `# sandbox <image>` runtime but shelled out to **podman** — which was **never added to any Dockerfile**, so the feature can't actually run in the shipped image. And podman is overkill here: the runtime only ever **pulls + flattens** an image (nsjail does the run), so it doesn't need a container engine, store, root, or privileged at all.

This switches the fetch backend to **[`crane`](https://github.com/google/go-containerregistry)** — a single ~25 MB static binary — and **adds it to the images**.

| | podman (before) | crane (now) |
|---|---|---|
| footprint | 150–300 MB + crun/conmon/fuse-overlayfs/slirp4netns/uidmap… | one ~25 MB static binary |
| needs | rootless store, subuid, privileged-in-container | nothing — no daemon/store/root |
| in Dockerfile | **missing** (feature broken in image) | added |

## Changes

- **`docker_v2.rs`**: `crane export` → flattened rootfs tar, `crane config` → OCI config, `crane digest` → a **content-addressed rootfs+config cache** (cross-job dedup + automatic freshness on tag moves), `crane manifest` → a **pre-download** size guard (rejects before any layer is fetched). Private-registry auth via a per-job `DOCKER_CONFIG` dir. Cache eviction prunes the rootfs-tar cache by mtime (true LRU). Pull policy honored via a ref→digest cache (`missing`/`never` reuse without a registry hit).
- **`Dockerfile`, `docker/DockerfileSlim`, `docker/DockerfileSlimEe`**: install the `crane` binary (pinned `v0.20.6`, arch-aware). `DockerfileFull`/`FullEe` and the EE image inherit it via `FROM` the base image.
- **docs / UI / instance-setting descriptions** updated (size cap is now compressed download size; cache is the rootfs-tar cache; auth via `DOCKER_CONFIG`).

The two follow-ups the parent PR listed — *content-addressed rootfs cache* and *pre-pull size guard via manifest inspection* — are **done** here as a consequence of the crane model.

## Test plan

- [x] crane spike: `export` (flattened worker-owned rootfs), `config` (Env/Cmd/Entrypoint/WorkingDir), `manifest --platform` (layer sizes), `digest`, `DOCKER_CONFIG` auth — all confirmed
- [x] e2e on the dev backend: `# sandbox alpine` runs via crane (uid 0, body inside the image); the digest-keyed cache (`sha256_<digest>.tar` + `.json` + `refs/`) is populated
- [x] `cargo check` (full) + `docker_v2` unit tests (`proto_str`, `render_envars`, `registry_qualified`, `sandbox_image`) + frontend `check:fast` all clean
- [ ] **deploy test (in progress):** build the image, run `# sandbox alpine` under docker-compose and minikube to confirm crane + nsjail work in-container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch sandbox image pull/extract to `crane` instead of `podman`, add `crane` to our images, and harden caching and limits. This fixes the shipped sandbox runtime, reduces footprint, and enforces a compressed download size cap with digest-pinned pulls.

- **New Features**
  - Pull/extract via `crane` (no daemon/store/root): uses `crane export`, `config`, `digest`, and `manifest` with `nsjail`; fetches by `name@digest` to keep cache consistent on moving tags.
  - Digest-keyed rootfs+config cache with a ref→digest cache honoring pull policy (`missing`/`newer`/`always`/`never`); `.size` sidecar enforces the compressed cap on every job; atomic ref→digest and config sidecars with tolerant reads.
  - Pre-download size guard using `crane manifest` (compressed size).
  - Evict oldest cached rootfs tars by creation time (mtime) under `sandbox_image_cache_max_mb`; eviction hardening: stage via hardlink, falling back to copy across filesystems; sweep orphaned `*.tmp.*`; remove sidecars with the tar.
  - Private-registry auth via per-job `DOCKER_CONFIG`. Docs and instance setting texts updated.

- **Dependencies**
  - Add `crane` v0.20.6 static binary to `Dockerfile`, `docker/DockerfileSlim`, and `docker/DockerfileSlimEe`; fail fast on unsupported arch. `podman` is no longer required.

<sup>Written for commit 361c93121d7a1d551b935ab776b41164f098b731. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

