### PR TITLE
fix(frontend): respect forced column order for numeric column names

### DIFF
--- a/frontend/src/lib/components/DisplayResult.svelte
+++ b/frontend/src/lib/components/DisplayResult.svelte
@@ -410,6 +410,23 @@
 		return json
 	}
 
+	// The explicit column order from a leading header row (see
+	// handleArrayOfObjectsHeaders). Returned as an array so the order survives:
+	// baking it into object keys loses integer-like names like "1234", which JS
+	// enumerates first in ascending numeric order.
+	function getForcedColumnOrder(json: any): string[] | undefined {
+		if (
+			Array.isArray(json) &&
+			json.length > 0 &&
+			Array.isArray(json[0]) &&
+			json[0].length > 0 &&
+			json[0].every((item) => typeof item === 'string')
+		) {
+			return json[0]
+		}
+		return undefined
+	}
+
 	type InputObject = { [key: string]: number[] }
 
 	function objectOfArraysToObjects(input: InputObject): any[] {
@@ -643,6 +660,7 @@
 							? 'absolute inset-0 [&>div]:h-full [&>div]:min-h-[10rem]'
 							: ''}
 						objects={handleArrayOfObjectsHeaders(data)}
+						headerOrder={getForcedColumnOrder(data)}
 					/>
 				{:else if !forceJson && resultKind === 'html'}
 					<div class="h-full">

--- a/frontend/src/lib/components/table/AutoDataTable.svelte
+++ b/frontend/src/lib/components/table/AutoDataTable.svelte
@@ -21,10 +21,11 @@
 	import DownloadCsv from './DownloadCsv.svelte'
 	interface Props {
 		objects?: Array<Record<string, any>>
+		headerOrder?: string[]
 		class?: string
 	}
 
-	let { objects = [], class: className }: Props = $props()
+	let { objects = [], headerOrder, class: className }: Props = $props()
 
 	let currentPage = $state(1)
 	let perPage = $state(25)
@@ -37,7 +38,7 @@
 	let headers: string[] = $state([])
 
 	function recomputeObjectsAndHeaders(objects: Array<Record<string, any>>) {
-		;[headers, structuredObjects] = computeStructuredObjectsAndHeaders(objects)
+		;[headers, structuredObjects] = computeStructuredObjectsAndHeaders(objects, headerOrder)
 	}
 
 	function adjustCurrentPage() {

--- a/frontend/src/lib/components/table/tableUtils.test.ts
+++ b/frontend/src/lib/components/table/tableUtils.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { computeStructuredObjectsAndHeaders } from './tableUtils'
+
+describe('computeStructuredObjectsAndHeaders', () => {
+	it('respects an explicit headerOrder when a column name is integer-like (#9183)', () => {
+		// "1234" must keep its specified position instead of jumping to the front,
+		// the way Object.keys() orders integer-like keys.
+		const headerOrder = ['Pokemon name', 'Type', '1234', 'Main strength']
+		const rows = [
+			{ 'Pokemon name': 'Pikachu', Type: 'Electric', '1234': 'nil', 'Main strength': 'Speed' }
+		]
+		const [headers] = computeStructuredObjectsAndHeaders(rows, headerOrder)
+		expect(headers).toEqual(['Pokemon name', 'Type', '1234', 'Main strength'])
+	})
+
+	it('appends keys not present in headerOrder, after the explicit ones', () => {
+		const [headers] = computeStructuredObjectsAndHeaders([{ a: 1, b: 2, c: 3 }], ['a', 'b'])
+		expect(headers).toEqual(['a', 'b', 'c'])
+	})
+
+	it('keeps the existing object-key behavior when no headerOrder is given', () => {
+		const [headers] = computeStructuredObjectsAndHeaders([{ x: 1, y: 2 }])
+		expect(headers).toEqual(['x', 'y'])
+	})
+})

--- a/frontend/src/lib/components/table/tableUtils.ts
+++ b/frontend/src/lib/components/table/tableUtils.ts
@@ -8,7 +8,10 @@ export function isEmail(value: string) {
 	return value?.includes('@')
 }
 
-export function computeStructuredObjectsAndHeaders(objects: Array<Record<string, any>>): [
+export function computeStructuredObjectsAndHeaders(
+	objects: Array<Record<string, any>>,
+	headerOrder?: string[]
+): [
 	string[],
 	{
 		_id: number
@@ -18,7 +21,10 @@ export function computeStructuredObjectsAndHeaders(objects: Array<Record<string,
 	if (Array.isArray(objects)) {
 		let nextId = 1
 
-		let hds: string[] = []
+		// Seed headers from the explicit order when provided. Object key order
+		// can't be trusted here: integer-like keys (e.g. "1234") are enumerated
+		// first in ascending numeric order regardless of insertion order.
+		let hds: string[] = headerOrder ? [...headerOrder] : []
 		let objs = objects.map((obj) => {
 			let rowData = obj && typeof obj == 'object' ? obj : {}
 			if (Array.isArray(rowData)) {


### PR DESCRIPTION
## Summary

The rich table display of a script result doesn't respect "force column order" when a column name is an integer-like string (e.g. `"1234"`): that column always renders first, regardless of the order in the leading header row. Non-integer names (`"1234.5"`, `"01234"`) are unaffected.

Cause: `computeStructuredObjectsAndHeaders` derives the column list from `Object.keys(row)`, and JS enumerates integer-index keys first in ascending numeric order — so the explicit order baked into the row objects by `handleArrayOfObjectsHeaders` is lost. The leading header row already carries the intended order; it just wasn't threaded to the renderer.

## Changes

- `tableUtils.ts`: `computeStructuredObjectsAndHeaders` takes an optional `headerOrder` and seeds the header list from it (appending any keys not in it); without it, behavior is unchanged.
- `AutoDataTable.svelte`: optional `headerOrder` prop, threaded into the recompute.
- `DisplayResult.svelte`: surface the explicit header row via `getForcedColumnOrder(data)` and pass it as `headerOrder`.
- Add `tableUtils.test.ts` covering the integer-like case, stray-key append, and the unchanged no-`headerOrder` path.

## Test plan

- [ ] `cd frontend && npm run test:unit -- tableUtils`
- [ ] `cd frontend && npm run check`
- [ ] Manual: run the issue's repro script and confirm `"1234"` renders between `"Type"` and `"Main strength"`.

Fixes #9183

## Scope

Fixes the displayed table for the forced-header case. Two related surfaces are intentionally left out: CSV export ("Download CSV") still follows object-key order for integer-like names, and a bare array-of-objects (no header row) can't recover integer-key order since `JSON.parse` reorders those keys before this code runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the rich table so forced column order is respected for integer-like column names (e.g. "1234"), preventing them from jumping to the front. Threads the explicit header row to the renderer and updates the table utils to honor it.

- **Bug Fixes**
  - `computeStructuredObjectsAndHeaders` accepts optional `headerOrder` and seeds headers from it; missing keys are appended; behavior unchanged when omitted.
  - `AutoDataTable.svelte` adds an optional `headerOrder` prop and passes it to the utils.
  - `DisplayResult.svelte` extracts the explicit header row and passes it as `headerOrder`.
  - Added unit tests for integer-like keys, stray-key append, and no-`headerOrder` fallback.

<sup>Written for commit 89d37922b3cd489e4c4e28955f2d17a5537d20a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

