### PR TITLE
fix: gate native integration pickers behind non-operator check

### DIFF
--- a/backend/windmill-api-integration-tests/tests/native_triggers.rs
+++ b/backend/windmill-api-integration-tests/tests/native_triggers.rs
@@ -17,8 +17,8 @@ use windmill_native_triggers::{
     decrypt_oauth_data, delete_native_trigger, delete_workspace_integration,
     get_workspace_integration,
     google::{parse_stop_channel_params, should_renew_channel},
-    store_native_trigger, store_workspace_integration, NativeTriggerConfig, OAuthConfig,
-    ServiceName,
+    require_native_integration_use, store_native_trigger, store_workspace_integration,
+    NativeTriggerConfig, OAuthConfig, ServiceName,
 };
 
 // ============================================================================
@@ -328,6 +328,26 @@ async fn test_token_update_persists(db: Pool<Postgres>) -> anyhow::Result<()> {
 // ============================================================================
 // 3. Channel Expiration Renewal — should_renew_channel
 // ============================================================================
+
+#[test]
+fn test_require_native_integration_use_blocks_operators() {
+    // Regression: the integration *use* routes (calendar/drive/repo/event pickers)
+    // must reject read-only operators, who cannot create native triggers and so
+    // must not be able to drive the admin-configured integration's upstream API.
+    let mut operator = test_authed();
+    operator.is_admin = false;
+    operator.is_operator = true;
+    assert!(require_native_integration_use(&operator).is_err());
+
+    // A regular non-admin author (the population that configures triggers) is allowed.
+    let mut author = test_authed();
+    author.is_admin = false;
+    author.is_operator = false;
+    assert!(require_native_integration_use(&author).is_ok());
+
+    // Admins are allowed.
+    assert!(require_native_integration_use(&test_authed()).is_ok());
+}
 
 #[test]
 fn test_should_renew_drive_channel_expired() {

--- a/backend/windmill-native-triggers/src/github/routes.rs
+++ b/backend/windmill-native-triggers/src/github/routes.rs
@@ -2,9 +2,10 @@ use std::sync::Arc;
 
 use axum::{extract::Path, routing::get, Extension, Json, Router};
 use http::Method;
+use windmill_api_auth::ApiAuthed;
 use windmill_common::{error::JsonResult, DB};
 
-use crate::{get_workspace_integration, External, ServiceName};
+use crate::{get_workspace_integration, require_native_integration_use, External, ServiceName};
 
 use super::{GitHub, GithubApiRepoResponse, GithubRepoEntry};
 
@@ -12,10 +13,12 @@ const PER_PAGE: usize = 100;
 const MAX_PAGES: usize = 10;
 
 async fn list_repos(
+    authed: ApiAuthed,
     Extension(handler): Extension<Arc<GitHub>>,
     Extension(db): Extension<DB>,
     Path(workspace_id): Path<String>,
 ) -> JsonResult<Vec<GithubRepoEntry>> {
+    require_native_integration_use(&authed)?;
     get_workspace_integration(&db, &workspace_id, ServiceName::Github).await?;
 
     let mut all_entries = Vec::new();

--- a/backend/windmill-native-triggers/src/google/routes.rs
+++ b/backend/windmill-native-triggers/src/google/routes.rs
@@ -7,9 +7,10 @@ use axum::{
 };
 use http::Method;
 use serde::{Deserialize, Serialize};
+use windmill_api_auth::ApiAuthed;
 use windmill_common::{error::JsonResult, DB};
 
-use crate::{get_workspace_integration, External, ServiceName};
+use crate::{get_workspace_integration, require_native_integration_use, External, ServiceName};
 
 use super::Google;
 
@@ -84,10 +85,12 @@ pub struct DriveFilesQuery {
 }
 
 async fn list_calendars(
+    authed: ApiAuthed,
     Extension(handler): Extension<Arc<Google>>,
     Extension(db): Extension<DB>,
     Path(workspace_id): Path<String>,
 ) -> JsonResult<Vec<GoogleCalendarEntry>> {
+    require_native_integration_use(&authed)?;
     get_workspace_integration(&db, &workspace_id, ServiceName::Google).await?;
 
     let url = format!(
@@ -113,11 +116,13 @@ async fn list_calendars(
 }
 
 async fn list_drive_files(
+    authed: ApiAuthed,
     Extension(handler): Extension<Arc<Google>>,
     Extension(db): Extension<DB>,
     Path(workspace_id): Path<String>,
     Query(query): Query<DriveFilesQuery>,
 ) -> JsonResult<GoogleDriveFilesResponse> {
+    require_native_integration_use(&authed)?;
     get_workspace_integration(&db, &workspace_id, ServiceName::Google).await?;
 
     let drive_query = if query.shared_with_me {
@@ -186,10 +191,12 @@ struct SharedDriveApiEntry {
 }
 
 async fn list_shared_drives(
+    authed: ApiAuthed,
     Extension(handler): Extension<Arc<Google>>,
     Extension(db): Extension<DB>,
     Path(workspace_id): Path<String>,
 ) -> JsonResult<Vec<SharedDriveEntry>> {
+    require_native_integration_use(&authed)?;
     get_workspace_integration(&db, &workspace_id, ServiceName::Google).await?;
 
     let url = format!(

--- a/backend/windmill-native-triggers/src/lib.rs
+++ b/backend/windmill-native-triggers/src/lib.rs
@@ -1226,6 +1226,20 @@ pub async fn store_workspace_integration(
     Ok(())
 }
 
+/// Authorization gate for the integration *use* routes (calendar/drive/repo/event
+/// pickers). A workspace admin configures the integration, but any member who can
+/// create a native trigger needs the pickers to configure one. Operators are
+/// read-only and cannot create triggers, so they must not be able to drive the
+/// admin-configured integration's upstream API and enumerate its data.
+pub fn require_native_integration_use(authed: &ApiAuthed) -> Result<()> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot use workspace integrations".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 pub async fn get_workspace_integration<'c, E: sqlx::Executor<'c, Database = Postgres>>(
     db: E,
     workspace_id: &str,

--- a/backend/windmill-native-triggers/src/nextcloud/routes.rs
+++ b/backend/windmill-native-triggers/src/nextcloud/routes.rs
@@ -7,17 +7,21 @@ use windmill_common::{
     DB,
 };
 
+use windmill_api_auth::ApiAuthed;
+
 use crate::{
     get_workspace_integration,
     nextcloud::{NextCloudEventType, OcsResponse},
-    External, ServiceName,
+    require_native_integration_use, External, ServiceName,
 };
 
 async fn list_available_events<T: External>(
+    authed: ApiAuthed,
     Extension(handler): Extension<Arc<T>>,
     Extension(db): Extension<DB>,
     Path(workspace_id): Path<String>,
 ) -> JsonResult<Vec<NextCloudEventType>> {
+    require_native_integration_use(&authed)?;
     let integration = get_workspace_integration(&db, &workspace_id, ServiceName::Nextcloud).await?;
 
     let base_url = integration


### PR DESCRIPTION
## Summary

Fixes a security report (Alwin / Intigriti): five native-trigger integration **picker** routes had no authorization gate beyond authentication, so any workspace member — including read-only **operators** and viewers — could drive the workspace-admin-configured OAuth integration's upstream API and enumerate its data (Google Drive file/folder listings, GitHub repo names incl. private/org, calendars, NextCloud event surface). Integration *setup* is admin-only (`require_admin`), but the *use* routes had no `ApiAuthed` param and no role/scope check at all.

Affected handlers (HEAD prior to this PR):
- `windmill-native-triggers/src/google/routes.rs` — `list_calendars`, `list_drive_files`, `list_shared_drives`
- `windmill-native-triggers/src/github/routes.rs` — `list_repos`
- `windmill-native-triggers/src/nextcloud/routes.rs` — `list_available_events`

## Authorization model

`require_admin` was considered (the reporter's suggestion) but rejected as too strict: creating a native trigger requires `require_is_writer_on_runnable`, **not** admin, and these pickers are used by non-admin authors in the trigger-config UI. Operators, however, are read-only and cannot create triggers at all, so they have no legitimate use for the pickers — exposing them is pure leak.

The fix gates the pickers at **non-operator** level (admins + regular authors — exactly the population that can create native triggers), via a single shared chokepoint `require_native_integration_use(&authed)`.

## Changes

- Add `require_native_integration_use(authed)` helper in `windmill-native-triggers/src/lib.rs` that rejects `authed.is_operator` with `Error::NotAuthorized` (mirrors the operator-rejection pattern in `apps.rs`).
- Thread `authed: ApiAuthed` into all five picker handlers and call the helper before `get_workspace_integration` / any upstream request.
- `get_workspace_integration`'s signature is left unchanged (it is also called from non-authed runtime/refresh paths), so the gate lives in the handlers.
- Add regression test `test_require_native_integration_use_blocks_operators` asserting operator→rejected, non-admin author→allowed, admin→allowed.

## Test plan

- [x] `cargo check -p windmill-api --features native_trigger`
- [x] `cargo test -p windmill-api-integration-tests --test native_triggers test_require_native_integration_use_blocks_operators`
- [ ] Manual: as an operator member, open the native-trigger creation UI for GitHub/Google/NextCloud and confirm the repo/calendar/drive/event pickers return an authorization error instead of listing the admin's upstream data
- [ ] Manual: as a non-admin author, confirm the pickers still populate normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates native integration pickers behind a non-operator check to prevent read-only operators from driving workspace OAuth integrations and enumerating data. Admins and authors can still use pickers for Google, GitHub, and Nextcloud.

- **Bug Fixes**
  - Added `require_native_integration_use` in `windmill-native-triggers/src/lib.rs` to reject `is_operator`.
  - Threaded `ApiAuthed` into and gated: GitHub `list_repos`; Google `list_calendars`, `list_drive_files`, `list_shared_drives`; Nextcloud `list_available_events`.
  - Added regression test `test_require_native_integration_use_blocks_operators`.

<sup>Written for commit 6b093983e8224e8e2ba4753ced2d01680faaabfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

