### PR TITLE
docs(skills): decouple safe local commands from destructive sync push

### DIFF
--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -3182,6 +3182,14 @@ function removeSuffix(str: string, suffix: string) {
   return str.slice(0, str.length - suffix.length);
 }
 
+// Shown after a `wmill sync push --dry-run` preview that has changes. `sync push`
+// deploys to the remote workspace and is destructive (it overwrites and prunes
+// remote items that differ from or are absent locally), so the preview reminds
+// the caller — especially an AI agent that ran the dry-run to inspect changes —
+// to get explicit user confirmation before applying it for real.
+const SYNC_PUSH_DESTRUCTIVE_WARNING =
+  "`wmill sync push` is destructive: applying it deploys these changes to the remote workspace and overwrites or deletes remote items that differ from or are absent locally — this is not automatically reversible. If you are an AI agent, do NOT run `wmill sync push` (without --dry-run) until the user has explicitly confirmed this deploy, unless your custom instructions explicitly allow bypassing that confirmation.";
+
 export async function push(
   opts: GlobalOptions & SyncOptions & { repository?: string; branch?: string; acceptOverridingPermissionedAsWithSelf?: boolean },
 ) {
@@ -3717,6 +3725,9 @@ export async function push(
           : {}),
       })),
       total: changes.length,
+      ...(changes.length > 0
+        ? { warning: SYNC_PUSH_DESTRUCTIVE_WARNING }
+        : {}),
     };
     console.log(JSON.stringify(result, null, 2));
     return;
@@ -3760,6 +3771,7 @@ export async function push(
 
     if (opts.dryRun) {
       log.info(colors.gray(`Dry run complete.`));
+      log.warn(colors.yellow(`\n⚠ ${SYNC_PUSH_DESTRUCTIVE_WARNING}`));
       return;
     }
 

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -5266,7 +5266,7 @@ Text/HTML/inline parts are placed inline in \`body\` as strings.
 
 ## CLI Commands
 
-\`wmill sync push\` deploys local changes to the workspace and can be destructive to remote state — only suggest/run it when the user explicitly asks to deploy/publish/push, not when they say "run", "try", or "test". \`sync pull\` is read-only and safe to run yourself.
+\`wmill sync push\` deploys local changes to the workspace and can be destructive to remote state — only suggest/run it when the user explicitly asks to deploy/publish/push, not when they say "run", "try", or "test". \`sync pull\` is safe to run yourself — it never mutates remote state, though it does overwrite local files to match the remote (use \`sync pull --dry-run\` to only preview).
 
 \`\`\`bash
 # Push trigger configuration — only when the user explicitly asks to deploy
@@ -5317,7 +5317,7 @@ Windmill uses 6-field cron expressions (includes seconds):
 
 ## CLI Commands
 
-\`wmill sync push\` deploys local changes to the workspace and can be destructive to remote state — only suggest/run it when the user explicitly asks to deploy/publish/push, not when they say "run", "try", or "test". The read-only commands below (\`sync pull\`, \`schedule\`) are safe to run yourself.
+\`wmill sync push\` deploys local changes to the workspace and can be destructive to remote state — only suggest/run it when the user explicitly asks to deploy/publish/push, not when they say "run", "try", or "test". The commands below never mutate remote state, so they're safe to run yourself — note that \`sync pull\` does overwrite local files to match the remote (use \`sync pull --dry-run\` to only preview), while \`schedule\` just lists.
 
 \`\`\`bash
 # Push schedules to Windmill — only when the user explicitly asks to deploy

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -5266,10 +5266,10 @@ Text/HTML/inline parts are placed inline in \`body\` as strings.
 
 ## CLI Commands
 
-After writing, tell the user they can run these commands (do NOT run them yourself):
+\`wmill sync push\` deploys local changes to the workspace and can be destructive to remote state — only suggest/run it when the user explicitly asks to deploy/publish/push, not when they say "run", "try", or "test". \`sync pull\` is read-only and safe to run yourself.
 
 \`\`\`bash
-# Push trigger configuration
+# Push trigger configuration — only when the user explicitly asks to deploy
 wmill sync push
 
 # Pull triggers from Windmill
@@ -5317,10 +5317,10 @@ Windmill uses 6-field cron expressions (includes seconds):
 
 ## CLI Commands
 
-After writing, tell the user they can run these commands (do NOT run them yourself):
+\`wmill sync push\` deploys local changes to the workspace and can be destructive to remote state — only suggest/run it when the user explicitly asks to deploy/publish/push, not when they say "run", "try", or "test". The read-only commands below (\`sync pull\`, \`schedule\`) are safe to run yourself.
 
 \`\`\`bash
-# Push schedules to Windmill
+# Push schedules to Windmill — only when the user explicitly asks to deploy
 wmill sync push
 
 # Pull schedules from Windmill
@@ -5574,7 +5574,8 @@ wmill resource-type list --schema
 # Get specific resource type schema
 wmill resource-type get postgresql
 
-# Push resources (tell the user to run this, do NOT run it yourself)
+# Push resources to Windmill — deploys to the workspace and can be destructive to
+# remote state, so only run it when the user explicitly asks to deploy/publish/push
 wmill sync push
 \`\`\`
 `,

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -563,7 +563,8 @@ wmill resource-type list --schema
 # Get specific resource type schema
 wmill resource-type get postgresql
 
-# Push resources (tell the user to run this, do NOT run it yourself)
+# Push resources to Windmill — deploys to the workspace and can be destructive to
+# remote state, so only run it when the user explicitly asks to deploy/publish/push
 wmill sync push
 \`\`\`
 `;

--- a/system_prompts/auto-generated/skills/resources/SKILL.md
+++ b/system_prompts/auto-generated/skills/resources/SKILL.md
@@ -242,6 +242,7 @@ wmill resource-type list --schema
 # Get specific resource type schema
 wmill resource-type get postgresql
 
-# Push resources (tell the user to run this, do NOT run it yourself)
+# Push resources to Windmill — deploys to the workspace and can be destructive to
+# remote state, so only run it when the user explicitly asks to deploy/publish/push
 wmill sync push
 ```

--- a/system_prompts/auto-generated/skills/schedules/SKILL.md
+++ b/system_prompts/auto-generated/skills/schedules/SKILL.md
@@ -39,7 +39,7 @@ Windmill uses 6-field cron expressions (includes seconds):
 
 ## CLI Commands
 
-`wmill sync push` deploys local changes to the workspace and can be destructive to remote state — only suggest/run it when the user explicitly asks to deploy/publish/push, not when they say "run", "try", or "test". The read-only commands below (`sync pull`, `schedule`) are safe to run yourself.
+`wmill sync push` deploys local changes to the workspace and can be destructive to remote state — only suggest/run it when the user explicitly asks to deploy/publish/push, not when they say "run", "try", or "test". The commands below never mutate remote state, so they're safe to run yourself — note that `sync pull` does overwrite local files to match the remote (use `sync pull --dry-run` to only preview), while `schedule` just lists.
 
 ```bash
 # Push schedules to Windmill — only when the user explicitly asks to deploy

--- a/system_prompts/auto-generated/skills/schedules/SKILL.md
+++ b/system_prompts/auto-generated/skills/schedules/SKILL.md
@@ -39,10 +39,10 @@ Windmill uses 6-field cron expressions (includes seconds):
 
 ## CLI Commands
 
-After writing, tell the user they can run these commands (do NOT run them yourself):
+`wmill sync push` deploys local changes to the workspace and can be destructive to remote state — only suggest/run it when the user explicitly asks to deploy/publish/push, not when they say "run", "try", or "test". The read-only commands below (`sync pull`, `schedule`) are safe to run yourself.
 
 ```bash
-# Push schedules to Windmill
+# Push schedules to Windmill — only when the user explicitly asks to deploy
 wmill sync push
 
 # Pull schedules from Windmill

--- a/system_prompts/auto-generated/skills/triggers/SKILL.md
+++ b/system_prompts/auto-generated/skills/triggers/SKILL.md
@@ -61,7 +61,7 @@ Text/HTML/inline parts are placed inline in `body` as strings.
 
 ## CLI Commands
 
-`wmill sync push` deploys local changes to the workspace and can be destructive to remote state — only suggest/run it when the user explicitly asks to deploy/publish/push, not when they say "run", "try", or "test". `sync pull` is read-only and safe to run yourself.
+`wmill sync push` deploys local changes to the workspace and can be destructive to remote state — only suggest/run it when the user explicitly asks to deploy/publish/push, not when they say "run", "try", or "test". `sync pull` is safe to run yourself — it never mutates remote state, though it does overwrite local files to match the remote (use `sync pull --dry-run` to only preview).
 
 ```bash
 # Push trigger configuration — only when the user explicitly asks to deploy

--- a/system_prompts/auto-generated/skills/triggers/SKILL.md
+++ b/system_prompts/auto-generated/skills/triggers/SKILL.md
@@ -61,10 +61,10 @@ Text/HTML/inline parts are placed inline in `body` as strings.
 
 ## CLI Commands
 
-After writing, tell the user they can run these commands (do NOT run them yourself):
+`wmill sync push` deploys local changes to the workspace and can be destructive to remote state — only suggest/run it when the user explicitly asks to deploy/publish/push, not when they say "run", "try", or "test". `sync pull` is read-only and safe to run yourself.
 
 ```bash
-# Push trigger configuration
+# Push trigger configuration — only when the user explicitly asks to deploy
 wmill sync push
 
 # Pull triggers from Windmill

--- a/system_prompts/base/resources.md
+++ b/system_prompts/base/resources.md
@@ -237,6 +237,7 @@ wmill resource-type list --schema
 # Get specific resource type schema
 wmill resource-type get postgresql
 
-# Push resources (tell the user to run this, do NOT run it yourself)
+# Push resources to Windmill — deploys to the workspace and can be destructive to
+# remote state, so only run it when the user explicitly asks to deploy/publish/push
 wmill sync push
 ```

--- a/system_prompts/base/schedules.md
+++ b/system_prompts/base/schedules.md
@@ -34,10 +34,10 @@ Windmill uses 6-field cron expressions (includes seconds):
 
 ## CLI Commands
 
-After writing, tell the user they can run these commands (do NOT run them yourself):
+`wmill sync push` deploys local changes to the workspace and can be destructive to remote state — only suggest/run it when the user explicitly asks to deploy/publish/push, not when they say "run", "try", or "test". The read-only commands below (`sync pull`, `schedule`) are safe to run yourself.
 
 ```bash
-# Push schedules to Windmill
+# Push schedules to Windmill — only when the user explicitly asks to deploy
 wmill sync push
 
 # Pull schedules from Windmill

--- a/system_prompts/base/schedules.md
+++ b/system_prompts/base/schedules.md
@@ -34,7 +34,7 @@ Windmill uses 6-field cron expressions (includes seconds):
 
 ## CLI Commands
 
-`wmill sync push` deploys local changes to the workspace and can be destructive to remote state — only suggest/run it when the user explicitly asks to deploy/publish/push, not when they say "run", "try", or "test". The read-only commands below (`sync pull`, `schedule`) are safe to run yourself.
+`wmill sync push` deploys local changes to the workspace and can be destructive to remote state — only suggest/run it when the user explicitly asks to deploy/publish/push, not when they say "run", "try", or "test". The commands below never mutate remote state, so they're safe to run yourself — note that `sync pull` does overwrite local files to match the remote (use `sync pull --dry-run` to only preview), while `schedule` just lists.
 
 ```bash
 # Push schedules to Windmill — only when the user explicitly asks to deploy

--- a/system_prompts/base/triggers.md
+++ b/system_prompts/base/triggers.md
@@ -56,10 +56,10 @@ Text/HTML/inline parts are placed inline in `body` as strings.
 
 ## CLI Commands
 
-After writing, tell the user they can run these commands (do NOT run them yourself):
+`wmill sync push` deploys local changes to the workspace and can be destructive to remote state — only suggest/run it when the user explicitly asks to deploy/publish/push, not when they say "run", "try", or "test". `sync pull` is read-only and safe to run yourself.
 
 ```bash
-# Push trigger configuration
+# Push trigger configuration — only when the user explicitly asks to deploy
 wmill sync push
 
 # Pull triggers from Windmill

--- a/system_prompts/base/triggers.md
+++ b/system_prompts/base/triggers.md
@@ -56,7 +56,7 @@ Text/HTML/inline parts are placed inline in `body` as strings.
 
 ## CLI Commands
 
-`wmill sync push` deploys local changes to the workspace and can be destructive to remote state — only suggest/run it when the user explicitly asks to deploy/publish/push, not when they say "run", "try", or "test". `sync pull` is read-only and safe to run yourself.
+`wmill sync push` deploys local changes to the workspace and can be destructive to remote state — only suggest/run it when the user explicitly asks to deploy/publish/push, not when they say "run", "try", or "test". `sync pull` is safe to run yourself — it never mutates remote state, though it does overwrite local files to match the remote (use `sync pull --dry-run` to only preview).
 
 ```bash
 # Push trigger configuration — only when the user explicitly asks to deploy


### PR DESCRIPTION
## Problem

The `schedules`, `triggers`, and `resources` AI-skill templates put every CLI command under a blunt `do NOT run them yourself` directive. This:

- **Conflates two very different risk profiles.** `wmill sync push` mutates remote workspace state and can be destructive (prunes remote items absent locally). But `sync pull`, `schedule`, and `resource list` are read-only/local and harmless. Lumping them together forbids the agent from running even the safe ones.
- **Hard-codes an over-broad execution-policy decision into vendored skills**, creating friction: the agent has to be repeatedly reminded to run safe commands.

`flow-cli.md` already solved this with a nuanced policy — these three files just lagged behind.

## Change

Bring the three templates in line with `flow-cli.md`:

- Keep `wmill sync push` **defensive**: it deploys and can be destructive to remote state, so only suggest/run it when the user explicitly asks to deploy/publish/push (not "run"/"try"/"test").
- Let **read-only commands** (`sync pull`, `schedule`, `resource list`, ...) be run freely.

This preserves the guard on the one command that warrants it while removing friction on the safe paths. Hard capability-gating (whether the env permits `sync push` at all) stays where it belongs — the user's permission layer / CLAUDE.md — rather than being baked into the skill.

Regenerated `system_prompts/auto-generated/` and `cli/src/guidance/skills.gen.ts` via `python system_prompts/generate.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples safe local commands from destructive `wmill sync push` across the `schedules`, `triggers`, and `resources` skills. Adds a dry-run warning in the CLI and clarifies that `sync pull` only modifies local files.

- **New Features**
  - `wmill sync push --dry-run` prints a destructive-action warning and adds a `warning` field to JSON output when changes are detected.

- **Refactors**
  - Gate `wmill sync push` behind explicit deploy/publish/push requests (not for “run/try/test”).
  - Allow safe local commands, and clarify `sync pull` overwrites local files; suggest `sync pull --dry-run` to preview.
  - Regenerated prompts and `cli/src/guidance/skills.gen.ts`.

<sup>Written for commit 4a39f58d237c9f72fa6ff530e1ff353247940225. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

