### PR TITLE
fix(frontend): use ban icon for canceled jobs instead of hourglass

### DIFF
--- a/frontend/src/lib/components/runs/JobStatusIcon.svelte
+++ b/frontend/src/lib/components/runs/JobStatusIcon.svelte
@@ -1,7 +1,16 @@
 <script lang="ts">
 	import Badge from '$lib/components/common/badge/Badge.svelte'
 	import { forLater } from '$lib/forLater'
-	import { Calendar, Check, FastForward, Hourglass, Play, ShieldQuestion, X } from 'lucide-svelte'
+	import {
+		Ban,
+		Calendar,
+		Check,
+		FastForward,
+		Hourglass,
+		Play,
+		ShieldQuestion,
+		X
+	} from 'lucide-svelte'
 	import type { Job } from '$lib/gen'
 
 	interface Props {
@@ -20,7 +29,7 @@
 		</Badge>
 	{:else if job.canceled && 'success' in job}
 		<Badge color="gray" {roundedFull} baseClass={roundedFull ? '' : '!px-1.5'} title="Canceled">
-			<Hourglass size={14} />
+			<Ban size={14} />
 		</Badge>
 	{:else if 'success' in job && job.success}
 		{#if job.is_skipped}

--- a/frontend/src/lib/components/runs/RunRow.svelte
+++ b/frontend/src/lib/components/runs/RunRow.svelte
@@ -103,7 +103,7 @@
 			{#if job}
 				{#if ('started_at' in job && job.started_at) || ('completed_at' in job && job.completed_at)}
 					{#if 'completed_at' in job && job.completed_at}
-						{isJobRecent ? 'Ended' : ''}
+						{isJobRecent ? (job.canceled ? 'Canceled' : 'Ended') : ''}
 						<TimeAgo bind:isRecent={isJobRecent} agoOnlyIfRecent date={job.completed_at ?? ''} />
 					{:else if 'started_at' in job && job.started_at}
 						{isJobRecent ? 'Started' : ''}
@@ -156,12 +156,12 @@
 						{/if}
 						<JobKindIcon size={14} />
 					</div>
-						{#snippet text()}
-							<span>
-								{#if job && job.job_kind}
-									{getJobKindDisplayLabel(job.job_kind, job.script_path)}
-								{/if}
-								{#if job && job.is_flow_step && job.parent_job}
+					{#snippet text()}
+						<span>
+							{#if job && job.job_kind}
+								{getJobKindDisplayLabel(job.job_kind, job.script_path)}
+							{/if}
+							{#if job && job.is_flow_step && job.parent_job}
 								<br /> Step of flow
 								<a href={`${base}/run/${job.parent_job}?workspace=${job.workspace_id}`}>
 									{truncateRev(job.parent_job, 10)}


### PR DESCRIPTION
## Summary

PR #9452 changed how canceled jobs render on the Runs page — from a red `X` to a gray **Hourglass** — to distinguish them from failed jobs. However, an hourglass is the universal "waiting / pending" glyph, so users read canceled jobs as *still running*. A customer reported seeing "all Cancelled Jobs with a 'waiting clock'" where they previously saw a terminal state.

This keeps #9452's intent (canceled stays visually distinct from red-`X` failures) but swaps the misleading hourglass for a lucide **`Ban`** icon (a circle with a diagonal slash), the standard "canceled / blocked" symbol. It also makes the row's time label read **"Canceled"** instead of "Ended" for recently-completed canceled jobs, consistent with the icon.

Before / after (gray Ban for canceled, red X for failure stays distinct):
![icon comparison](https://files.catbox.moe/gm7fbe.png)

## Changes

- `JobStatusIcon.svelte`: canceled completed jobs (`job.canceled && 'success' in job`) now render a gray `Ban` icon instead of `Hourglass` (tooltip "Canceled" unchanged). `Hourglass` is still used by the suspended and default/waiting branches.
- `RunRow.svelte`: the completed-job time label shows "Canceled" instead of "Ended" when `job.canceled` and the job is recent. (The non-recent path already showed only the timestamp; the persistent indicator is the icon.)
- A whitespace-only reindent of an adjacent `{#snippet text()}` block was applied by the prettier formatter on save.

## Test plan

- [ ] Open the Runs page, filter to a recently-canceled job → status icon shows the `Ban` (circle-with-slash) glyph, not an hourglass
- [ ] The time column reads "Canceled <time> ago" for recently-completed canceled jobs
- [ ] A still-cancelling (non-completed) job continues to show "Cancelling job..." text and the running icon until it completes
- [ ] Suspended and scheduled jobs still render the hourglass / calendar icons unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the hourglass on canceled jobs with a gray ban icon to clearly indicate a terminal state and avoid confusion with “pending.” Also show “Canceled” in the time label for recent canceled jobs; failed jobs still use the red X.

- Bug Fixes
  - `JobStatusIcon.svelte`: use `Ban` from `lucide-svelte` for completed canceled jobs; keep `Hourglass` for suspended/pending.
  - `RunRow.svelte`: show “Canceled” in the time column when a recent job is canceled.

<sup>Written for commit bef352c40f1400df4dbc68f82798b8e0688a11b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

