### PR TITLE
fix: drop archived items from fork compare (spurious 'not visible' warning)

### DIFF
--- a/backend/.sqlx/query-0a568f630e069118fe302099a709e89cc4a702158899f7fdc66d0922e8fb9b29.json
+++ b/backend/.sqlx/query-0a568f630e069118fe302099a709e89cc4a702158899f7fdc66d0922e8fb9b29.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT path FROM flow WHERE workspace_id = $1 AND path = ANY($2) AND archived = false",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "path",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "0a568f630e069118fe302099a709e89cc4a702158899f7fdc66d0922e8fb9b29"
+}

--- a/backend/.sqlx/query-4c81384b579bad74b64c72ca053839f316fe5412f99f3d3bbbdc0c65f55ab794.json
+++ b/backend/.sqlx/query-4c81384b579bad74b64c72ca053839f316fe5412f99f3d3bbbdc0c65f55ab794.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT has_changes FROM workspace_diff\n         WHERE path = 'f/shared/renamed_away' AND kind = 'script' AND source_workspace_id = 'test-workspace'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "has_changes",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "4c81384b579bad74b64c72ca053839f316fe5412f99f3d3bbbdc0c65f55ab794"
+}

--- a/backend/.sqlx/query-a60306f2bae0702363787c4cf7c1267af8e42a3b6aa382f1dd483bec7219c67c.json
+++ b/backend/.sqlx/query-a60306f2bae0702363787c4cf7c1267af8e42a3b6aa382f1dd483bec7219c67c.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO script (workspace_id, path, hash, content, summary, description, language, created_by, created_at, archived, schema_validation, ws_error_handler_muted, deleted)\n         VALUES ('wm-fork-test-workspace', 'f/shared/renamed_away', 67890, 'def main(): return 1', '', '', 'python3', 'test@windmill.dev', NOW(), true, false, false, false)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "a60306f2bae0702363787c4cf7c1267af8e42a3b6aa382f1dd483bec7219c67c"
+}

--- a/backend/.sqlx/query-c4966cf071a8504f578eed5518134db7b001d740d524075f19b91bae6fdb41b9.json
+++ b/backend/.sqlx/query-c4966cf071a8504f578eed5518134db7b001d740d524075f19b91bae6fdb41b9.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT DISTINCT path FROM script WHERE workspace_id = $1 AND path = ANY($2) AND archived = false",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "path",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "c4966cf071a8504f578eed5518134db7b001d740d524075f19b91bae6fdb41b9"
+}

--- a/backend/.sqlx/query-e9c2e8c50fc45576453885340800c3a44de6e32651a9a71c1aef49da2696a04f.json
+++ b/backend/.sqlx/query-e9c2e8c50fc45576453885340800c3a44de6e32651a9a71c1aef49da2696a04f.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO workspace_diff\n         (source_workspace_id, fork_workspace_id, path, kind, ahead, behind, has_changes, exists_in_source, exists_in_fork)\n         VALUES ('test-workspace', 'wm-fork-test-workspace', 'f/shared/renamed_away', 'script', 1, 0, true, false, true)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "e9c2e8c50fc45576453885340800c3a44de6e32651a9a71c1aef49da2696a04f"
+}

--- a/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
+++ b/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
@@ -634,6 +634,69 @@ async fn test_compare_workspaces_comprehensive(db: Pool<Postgres>) -> anyhow::Re
         "Non-existent item should be deleted from workspace_diff"
     );
 
+    // ==============================================================
+    // Stale Archived Cache Test (regression)
+    // ==============================================================
+    //
+    // Unlike the lazy_test above (has_changes = NULL → always re-evaluated), a
+    // cached `has_changes = true` row is trusted without re-running the per-kind
+    // comparison. It can go stale: after a rename the old path keeps only
+    // archived versions, and for lock-gen languages the `has_changes = NULL`
+    // reset is deferred to the dependency job — so until that runs the archived
+    // old path lingers as a live "ahead" change carrying `exists_in_fork = true`.
+    // The visibility check treats archived as non-existent and finds nothing, so
+    // even this superadmin used to get `all_ahead_items_visible = false`. The fix
+    // re-validates such rows and drops the archived (== non-existent) item.
+    sqlx::query!(
+        "INSERT INTO script (workspace_id, path, hash, content, summary, description, language, created_by, created_at, archived, schema_validation, ws_error_handler_muted, deleted)
+         VALUES ('wm-fork-test-workspace', 'f/shared/renamed_away', 67890, 'def main(): return 1', '', '', 'python3', 'test@windmill.dev', NOW(), true, false, false, false)"
+    )
+    .execute(&db)
+    .await?;
+    sqlx::query!(
+        "INSERT INTO workspace_diff
+         (source_workspace_id, fork_workspace_id, path, kind, ahead, behind, has_changes, exists_in_source, exists_in_fork)
+         VALUES ('test-workspace', 'wm-fork-test-workspace', 'f/shared/renamed_away', 'script', 1, 0, true, false, true)"
+    )
+    .execute(&db)
+    .await?;
+
+    let comparison3: serde_json::Value = client
+        .client()
+        .get(&format!(
+            "{base_url}/w/test-workspace/workspaces/compare/wm-fork-test-workspace"
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    // The archived item must be dropped (not surfaced) and must not trip the
+    // "changes not visible to your user" warning for a superadmin.
+    assert_eq!(
+        comparison3["all_ahead_items_visible"].as_bool(),
+        Some(true),
+        "archived (renamed-away) item must not trip the 'changes not visible' warning: {comparison3}"
+    );
+    assert!(
+        !comparison3["diffs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|d| d["path"] == "f/shared/renamed_away"),
+        "archived item should be dropped, not surfaced as a diff: {comparison3}"
+    );
+    let stale_archived = sqlx::query!(
+        "SELECT has_changes FROM workspace_diff
+         WHERE path = 'f/shared/renamed_away' AND kind = 'script' AND source_workspace_id = 'test-workspace'"
+    )
+    .fetch_optional(&db)
+    .await?;
+    assert!(
+        stale_archived.is_none(),
+        "stale archived diff row should be re-evaluated and deleted"
+    );
+
     Ok(())
 }
 

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -6290,13 +6290,67 @@ async fn compare_workspaces(
     .fetch_all(&db)
     .await?;
 
+    // A cached `has_changes = true` row is trusted without re-running the
+    // per-kind comparison, but that verdict can go stale: an item archived or
+    // deleted after it was cached still carries `exists_in_*=true` here. The
+    // common offender is the old path after a rename — for lock-gen languages
+    // (Python/TS/…) the `has_changes=NULL` reset is deferred to the dependency
+    // job, so until that runs (or if it fails) the archived old path looks like
+    // a live ahead change. Treat archived as non-existent: re-validate such rows
+    // against the live tables and, if the item no longer exists on a side the
+    // cache claims, re-evaluate it below so it gets corrected or removed.
+    //
+    // Only scripts/flows can hit this (they have `archived`; other kinds reset
+    // synchronously on delete). Probe both sides in one batched query per kind
+    // (mirroring `query_visible_items`) rather than per row, to keep the hot
+    // compare path off an O(number of cached diffs) sequence of round trips.
+    let (live_source, live_fork) = {
+        let mut cached_source: HashMap<&str, Vec<&str>> = HashMap::new();
+        let mut cached_fork: HashMap<&str, Vec<&str>> = HashMap::new();
+        for item in &diff_items {
+            if item.has_changes == Some(true) && (item.kind == "script" || item.kind == "flow") {
+                if item.exists_in_source.unwrap_or(false) {
+                    cached_source
+                        .entry(item.kind.as_str())
+                        .or_default()
+                        .push(item.path.as_str());
+                }
+                if item.exists_in_fork.unwrap_or(false) {
+                    cached_fork
+                        .entry(item.kind.as_str())
+                        .or_default()
+                        .push(item.path.as_str());
+                }
+            }
+        }
+        (
+            existing_runnables(&db, &source_workspace_id, &cached_source).await?,
+            existing_runnables(&db, &fork_workspace_id, &cached_fork).await?,
+        )
+    };
+
     let mut confirmed_diffs = vec![];
     for item in diff_items {
         if let Some(has_changes) = item.has_changes {
-            if has_changes {
-                confirmed_diffs.push(item);
+            if !has_changes {
+                // Defensive: rows that compared equal are normally deleted, so
+                // this is rarely hit. Not a diff — skip.
+                continue;
             }
-            continue;
+            // Stale only applies to script/flow (others aren't in the probed
+            // sets); a row whose claimed-existing side has no live version is
+            // stale and falls through to re-evaluation.
+            let key = (item.kind.clone(), item.path.clone());
+            let fork_stale = item.exists_in_fork.unwrap_or(false) && !live_fork.contains(&key);
+            let source_stale =
+                item.exists_in_source.unwrap_or(false) && !live_source.contains(&key);
+            let probed = item.kind == "script" || item.kind == "flow";
+            if !(probed && (fork_stale || source_stale)) {
+                // Cache is still valid (or not a probed kind) — trust it.
+                confirmed_diffs.push(item);
+                continue;
+            }
+            // Stale cache: fall through to re-evaluate (and correct/delete) below.
         }
 
         let item_comparison = match item.kind.as_str() {
@@ -6719,6 +6773,50 @@ async fn query_visible_items<'c>(
     }
 
     Ok(visible)
+}
+
+/// Batched existence probe used to detect stale `workspace_diff` cache rows.
+///
+/// Given candidate paths grouped by kind, returns the set of `(kind, path)`
+/// that currently have a *deployable* (non-archived) version in the workspace,
+/// mirroring the existence semantics of `compare_two_scripts` /
+/// `compare_two_flows`. Only scripts and flows are probed — they're the only
+/// kinds with `archived`, and the only ones whose diff-row reset can lag behind
+/// the actual change (deferred dependency job for lock-gen languages); other
+/// kinds reset synchronously on delete, so their cache is trusted (and they're
+/// never passed in). One query per kind keeps the compare path off a per-row
+/// sequence of round trips. Runs on `&db` (no RLS) — this is a pure existence
+/// check; authorization stays in `filter_visible_diffs` / `query_visible_items`.
+async fn existing_runnables(
+    db: &DB,
+    workspace_id: &str,
+    items_by_kind: &HashMap<&str, Vec<&str>>,
+) -> Result<HashSet<(String, String)>> {
+    let mut existing = HashSet::new();
+    for (kind, paths) in items_by_kind {
+        let paths_vec: Vec<String> = paths.iter().map(|s| s.to_string()).collect();
+        let found: Vec<String> = match *kind {
+            "script" => sqlx::query_scalar!(
+                "SELECT DISTINCT path FROM script WHERE workspace_id = $1 AND path = ANY($2) AND archived = false",
+                workspace_id,
+                &paths_vec
+            )
+            .fetch_all(db)
+            .await?,
+            "flow" => sqlx::query_scalar!(
+                "SELECT path FROM flow WHERE workspace_id = $1 AND path = ANY($2) AND archived = false",
+                workspace_id,
+                &paths_vec
+            )
+            .fetch_all(db)
+            .await?,
+            _ => vec![],
+        };
+        for path in found {
+            existing.insert((kind.to_string(), path));
+        }
+    }
+    Ok(existing)
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

In the fork/merge **Compare workspaces** view, a superadmin could see the alert *"This fork has changes not visible to your user … Only a user with access to the whole context may deploy or update this fork"* and be blocked from deploying — even though a superadmin can see everything by construction.

**Root cause.** `compare_workspaces` caches its per-item verdict in `workspace_diff` (`has_changes`, `exists_in_*`) and trusts a cached `has_changes = true` row without re-running the per-kind comparison. That cache can go stale: the **old path after a rename** keeps only `archived` versions, and for lock-gen languages (Python/TS/…) the `has_changes = NULL` reset is **deferred to the dependency job** (`scripts.rs` returns `hdm = None` when `needs_lock_gen`). Until that job runs — or permanently if it's slow/fails — the archived old path lingers as a `has_changes = true, exists_in_fork = true` row.

`filter_visible_diffs` then asks `query_visible_items` (which treats `archived` as non-existent) whether the user can see that path; it returns nothing — even under a superadmin's RLS-bypassing `windmill_admin` role — so the item is misread as *hidden*, flipping `all_ahead_items_visible` to `false` and tripping the warning + deploy block.

**Principle:** archived scripts/flows are **non-existent** for diff purposes (which is exactly what `compare_two_scripts`/`compare_two_flows` already do). The stale cached row violated that by surfacing an archived item as a live "ahead" change.

## Changes

- `compare_workspaces` (`backend/windmill-api-workspaces/src/workspaces.rs`): when a cached `has_changes = true` row is encountered, cheaply re-validate it with the new `runnable_still_exists` helper — if the item no longer exists (`archived = false`) on a side the cache claims, fall through and re-evaluate via `compare_two_*`, which **deletes** (or corrects) the stale row. So an archived/renamed-away item is dropped entirely: no phantom diff, no false warning — for admins and non-admins, and symmetrically for both the source (parent) and fork sides.
- The staleness probe is **batched** (`existing_runnables`): one `SELECT … path = ANY($2) AND archived = false` per kind per side builds the live-paths set up front, so the compare path adds at most 2 queries per side total regardless of diff count — not one probe per row. Scoped to `script`/`flow` (the only kinds with `archived`; others reset synchronously on delete). Runs on `&db` (existence probe, not an authz check — authorization stays in `filter_visible_diffs`/`query_visible_items`, left unchanged).
- Regression coverage folded into the existing `test_compare_workspaces_comprehensive` (it already builds a parent + fork as superadmin and exercises diff-row (re)evaluation): seeds an archived script + a stale `has_changes = true, exists_in_fork = true` diff row and asserts it's dropped (not surfaced as a diff, physically deleted from `workspace_diff`) and `all_ahead_items_visible` stays `true`.
- Regenerated the `.sqlx` offline cache (`--all-targets`): two `EXISTS` probes from the helper + the new test's seed/verify queries.

> Note: a first iteration instead dropped `archived = false` from `query_visible_items`; that only suppressed the warning and left the archived item showing as a phantom deployable diff. Reverted in favor of treating archived as non-existent at the source, per review.

## Test plan

- [x] `test_compare_workspaces_comprehensive` (now covering the stale-archived case) passes; existing fork-compare tests still pass.
- [x] Verified on the running dev backend across both directions (archived in fork / in parent / in both → dropped; live-on-one-side divergences → preserved) and roles (superadmin → no warning; non-admin → archived dropped but still warned about a genuinely-hidden live item).
- [ ] Manual e2e: as a fork member, rename a lock-gen-language (Python/TS) script before its dependency job runs, open the fork/merge compare view — confirm the old path doesn't appear as an ahead change and no "changes not visible" warning fires.
