### PR TITLE
fix: require auth to view approval details when user_auth_required

### DIFF
--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -1236,6 +1236,59 @@ async fn require_job_update_read_access(
     require_job_read_access(db, user_db, authed, w_id, job_id, &created_by, view_token).await
 }
 
+/// Whether a validated approval token should grant the job-read bypass. The token alone
+/// is sufficient unless the current approval step has `user_auth_required`, in which case
+/// only an authorized approver may read the job (and thus its args/flow inputs).
+async fn approval_token_grants_view(
+    db: &DB,
+    w_id: &str,
+    flow_id: Uuid,
+    opt_authed: &Option<ApiAuthed>,
+) -> error::Result<bool> {
+    #[derive(sqlx::FromRow)]
+    struct FlowAuthRow {
+        script_path: Option<String>,
+        email: String,
+        flow_status: Option<serde_json::Value>,
+    }
+    let row = sqlx::query_as::<_, FlowAuthRow>(
+        "SELECT j.runnable_path as script_path, j.permissioned_as_email as email, s.flow_status
+         FROM v2_job j
+         LEFT JOIN v2_job_status s ON s.id = j.id
+         WHERE j.id = $1 AND j.workspace_id = $2",
+    )
+    .bind(flow_id)
+    .bind(w_id)
+    .fetch_optional(db)
+    .await?;
+    let Some(row) = row else {
+        return Ok(false);
+    };
+
+    // approval_conditions are stored at the top of flow_status for both classic and WAC flows.
+    let approval_conditions = row
+        .flow_status
+        .as_ref()
+        .and_then(|v| v.get("approval_conditions").cloned())
+        .and_then(|v| serde_json::from_value::<ApprovalConditions>(v).ok());
+
+    let user_auth_required = approval_conditions
+        .as_ref()
+        .map(|ac| ac.user_auth_required)
+        .unwrap_or(false);
+
+    if !user_auth_required {
+        return Ok(true);
+    }
+
+    Ok(can_approve_step(
+        opt_authed,
+        &approval_conditions,
+        row.script_path.as_deref(),
+        row.email.as_str(),
+    ))
+}
+
 async fn get_job(
     OptViewToken(view_token): OptViewToken,
     OptAuthed(opt_authed): OptAuthed,
@@ -1254,17 +1307,31 @@ async fn get_job(
     // so the approval page can render job metadata without login. The approval
     // URL usually carries the flow id directly — try that first and only
     // resolve the parent flow if the direct check fails.
-    let has_valid_approval_token = if let Some(ref token) = approval_token {
+    let approved_flow_id: Option<Uuid> = if let Some(ref token) = approval_token {
         if validate_approval_token(&db, token, id, &w_id).await.is_ok() {
-            true
+            Some(id)
         } else if let Ok(flow_id) = get_flow_id_for_job(&db, id).await {
-            flow_id != id
+            if flow_id != id
                 && validate_approval_token(&db, token, flow_id, &w_id)
                     .await
                     .is_ok()
+            {
+                Some(flow_id)
+            } else {
+                None
+            }
         } else {
-            false
+            None
         }
+    } else {
+        None
+    };
+
+    // A valid token grants the read bypass, but only to an authorized approver when the
+    // current approval step requires auth — otherwise the token (which lives in the shareable
+    // approval URL) would leak the flow inputs to anyone holding the link.
+    let has_valid_approval_token = if let Some(flow_id) = approved_flow_id {
+        approval_token_grants_view(&db, &w_id, flow_id, &opt_authed).await?
     } else {
         false
     };
@@ -3132,6 +3199,43 @@ struct ApprovalInfo {
     approvers: Vec<Approval>,
 }
 
+/// Whether `opt_authed` is allowed to approve — and therefore view — this approval step.
+/// Mirrors the authorization performed at the resume boundary: workspace admins and owners
+/// of the runnable always qualify; otherwise the approval conditions (user_auth_required /
+/// user_groups_required / self_approval_disabled) decide. When the step does not require auth,
+/// an anonymous (token-only) caller qualifies.
+fn can_approve_step(
+    opt_authed: &Option<ApiAuthed>,
+    approval_conditions: &Option<ApprovalConditions>,
+    script_path: Option<&str>,
+    trigger_email: &str,
+) -> bool {
+    match opt_authed {
+        Some(authed) => {
+            if authed.is_admin {
+                return true;
+            }
+            let is_owner = script_path
+                .map(|p| require_owner_of_path(authed, p).is_ok())
+                .unwrap_or(false);
+            if is_owner {
+                return true;
+            }
+            conditionally_require_authed_user(
+                Some(authed.clone()),
+                approval_conditions.clone(),
+                trigger_email,
+            )
+            .is_ok()
+        }
+        // Not logged in — only acceptable when the step does not require auth.
+        None => !approval_conditions
+            .as_ref()
+            .map(|ac| ac.user_auth_required)
+            .unwrap_or(false),
+    }
+}
+
 async fn get_approval_info(
     OptAuthed(opt_authed): OptAuthed,
     Extension(db): Extension<DB>,
@@ -3290,32 +3394,33 @@ async fn get_approval_info(
         .map(|ac| ac.user_auth_required)
         .unwrap_or(false);
 
-    // Determine if current user can approve
-    let can_approve = if let Some(ref authed) = opt_authed {
-        if authed.is_admin {
-            true
-        } else {
-            let is_owner = row
-                .script_path
-                .as_deref()
-                .map(|p| require_owner_of_path(authed, p).is_ok())
-                .unwrap_or(false);
-            if is_owner {
-                true
-            } else {
-                let trigger_email = row.email.as_str();
-                conditionally_require_authed_user(
-                    Some(authed.clone()),
-                    approval_conditions.clone(),
-                    trigger_email,
-                )
-                .is_ok()
-            }
-        }
-    } else {
-        // Not logged in — can approve only if no auth required
-        !user_auth_required
-    };
+    // Determine if current user can approve this step.
+    let can_approve = can_approve_step(
+        &opt_authed,
+        &approval_conditions,
+        row.script_path.as_deref(),
+        row.email.as_str(),
+    );
+
+    // When the step requires auth, the approval details must be revealed only to authorized
+    // approvers — a valid token alone is not sufficient. Return a stripped response that lets
+    // the frontend render the sign-in / not-authorized state without leaking the form,
+    // description, prefilled args, or other approvers' identities.
+    let can_view = !user_auth_required || can_approve;
+    if !can_view {
+        return Ok(Json(ApprovalInfo {
+            flow_id: row.id,
+            form_schema: None,
+            description: None,
+            default_args: None,
+            enums: None,
+            approval_conditions,
+            can_approve: false,
+            user_auth_required,
+            hide_cancel: None,
+            approvers: vec![],
+        }));
+    }
 
     // Get existing approvers
     let approvers: Vec<Approval> = sqlx::query_as::<_, (i32, Option<String>)>(
@@ -9102,4 +9207,91 @@ async fn get_otel_traces(
     .await?;
 
     Ok(Json(traces))
+}
+
+#[cfg(test)]
+mod approval_view_gate_tests {
+    use super::*;
+
+    fn authed(username: &str, is_admin: bool, groups: Vec<String>) -> ApiAuthed {
+        ApiAuthed {
+            email: format!("{username}@example.com"),
+            username: username.to_string(),
+            is_admin,
+            is_operator: false,
+            groups,
+            folders: vec![],
+            scopes: None,
+            username_override: None,
+            token_prefix: None,
+            read_only: false,
+        }
+    }
+
+    fn conds(user_auth_required: bool, groups: Vec<String>) -> ApprovalConditions {
+        ApprovalConditions {
+            user_auth_required,
+            user_groups_required: groups,
+            self_approval_disabled: false,
+        }
+    }
+
+    // Mirrors the view gate applied in get_approval_info and get_job:
+    // details are revealed only when the step doesn't require auth OR the caller
+    // is an authorized approver.
+    fn can_view(
+        opt_authed: &Option<ApiAuthed>,
+        approval_conditions: &Option<ApprovalConditions>,
+        script_path: Option<&str>,
+        trigger_email: &str,
+    ) -> bool {
+        let user_auth_required = approval_conditions
+            .as_ref()
+            .map(|c| c.user_auth_required)
+            .unwrap_or(false);
+        !user_auth_required
+            || can_approve_step(opt_authed, approval_conditions, script_path, trigger_email)
+    }
+
+    #[test]
+    fn anonymous_cannot_view_when_auth_required() {
+        // The regression: an unauthenticated holder of the approval token must see nothing.
+        let c = Some(conds(true, vec![]));
+        assert!(!can_view(&None, &c, Some("f/team/flow"), "trigger@example.com"));
+    }
+
+    #[test]
+    fn anonymous_can_view_when_no_auth_required() {
+        // Unchanged behaviour: token alone is sufficient when auth isn't required.
+        let c = Some(conds(false, vec![]));
+        assert!(can_view(&None, &c, Some("f/team/flow"), "trigger@example.com"));
+        // No approval conditions at all also allows token-only view.
+        assert!(can_view(&None, &None, Some("f/team/flow"), "trigger@example.com"));
+    }
+
+    #[test]
+    fn admin_can_view_when_auth_required() {
+        let c = Some(conds(true, vec!["approvers".to_string()]));
+        let a = Some(authed("alice", true, vec![]));
+        assert!(can_view(&a, &c, Some("f/team/flow"), "trigger@example.com"));
+    }
+
+    #[test]
+    fn owner_can_view_when_auth_required() {
+        let c = Some(conds(true, vec!["approvers".to_string()]));
+        let a = Some(authed("bob", false, vec![]));
+        // bob owns u/bob/flow regardless of group membership.
+        assert!(can_view(&a, &c, Some("u/bob/flow"), "trigger@example.com"));
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn group_membership_decides_view_when_auth_required() {
+        let c = Some(conds(true, vec!["approvers".to_string()]));
+        let member = Some(authed("carol", false, vec!["approvers".to_string()]));
+        let outsider = Some(authed("dave", false, vec!["other".to_string()]));
+        // Use a non-owned folder path so ownership doesn't short-circuit the check.
+        assert!(can_view(&member, &c, Some("f/team/flow"), "trigger@example.com"));
+        assert!(!can_view(&outsider, &c, Some("f/team/flow"), "trigger@example.com"));
+    }
 }

--- a/frontend/src/routes/approve/[workspace]/[job]/+page.svelte
+++ b/frontend/src/routes/approve/[workspace]/[job]/+page.svelte
@@ -142,6 +142,10 @@
 		}
 	}
 
+	// When the step requires auth and the caller isn't an authorized approver, the backend
+	// strips the approval details (form, description, args, approvers) and getJob is denied.
+	// Hide the empty detail scaffolding and show only the sign-in / not-authorized state.
+	let isLocked = $derived(!!approvalInfo?.user_auth_required && !approvalInfo?.can_approve)
 	let isWac = $derived(!!(job as any)?.workflow_as_code_status)
 	let filteredArgs = $derived.by(() => {
 		if (!job?.args) return job?.args
@@ -219,44 +223,47 @@
 			{/if}
 		</div>
 	{:else if approvalInfo}
-		<div class="flex flex-row justify-between flex-wrap sm:flex-nowrap gap-x-4">
-			<div class="w-full">
-				<h2 class="text-sm font-semibold text-emphasis">Approvers</h2>
-				<div class="mt-2 text-xs font-normal text-primary">
-					{#if approvalInfo.approvers?.length > 0}
-						<ul>
-							{#each approvalInfo.approvers as a}
-								<li>
-									<p>
-										{a.approver}
-										<Tooltip>Unique id of approval: {a.resume_id}</Tooltip>
-									</p>
-								</li>
-							{/each}
-						</ul>
-					{:else}
-						<p class="text-xs text-secondary">
-							No current approvers for this step (approval steps can require more than one approval)
-						</p>
+		{#if !isLocked}
+			<div class="flex flex-row justify-between flex-wrap sm:flex-nowrap gap-x-4">
+				<div class="w-full">
+					<h2 class="text-sm font-semibold text-emphasis">Approvers</h2>
+					<div class="mt-2 text-xs font-normal text-primary">
+						{#if approvalInfo.approvers?.length > 0}
+							<ul>
+								{#each approvalInfo.approvers as a}
+									<li>
+										<p>
+											{a.approver}
+											<Tooltip>Unique id of approval: {a.resume_id}</Tooltip>
+										</p>
+									</li>
+								{/each}
+							</ul>
+						{:else}
+							<p class="text-xs text-secondary">
+								No current approvers for this step (approval steps can require more than one
+								approval)
+							</p>
+						{/if}
+					</div>
+				</div>
+				<div class="w-full">
+					{#if job && job.raw_flow}
+						<FlowMetadata {job} {scheduleEditor} />
 					{/if}
 				</div>
 			</div>
-			<div class="w-full">
-				{#if job && job.raw_flow}
-					<FlowMetadata {job} {scheduleEditor} />
-				{/if}
-			</div>
-		</div>
 
-		{#if !completed}
-			<h2 class="mt-4 mb-2 text-sm font-semibold text-emphasis">
-				{isWac ? 'Workflow' : 'Flow'} arguments
-			</h2>
-			<JobArgs
-				id={job?.id}
-				workspace={job?.workspace_id ?? $workspaceStore ?? 'no_w'}
-				args={filteredArgs}
-			/>
+			{#if !completed}
+				<h2 class="mt-4 mb-2 text-sm font-semibold text-emphasis">
+					{isWac ? 'Workflow' : 'Flow'} arguments
+				</h2>
+				<JobArgs
+					id={job?.id}
+					workspace={job?.workspace_id ?? $workspaceStore ?? 'no_w'}
+					args={filteredArgs}
+				/>
+			{/if}
 		{/if}
 
 		<div class="mt-8"></div>
@@ -337,16 +344,18 @@
 			{/if}
 		</div>
 
-		<div class="mt-4 flex flex-row flex-wrap justify-between">
-			<a
-				class="text-accent text-xs"
-				target="_blank"
-				rel="noreferrer"
-				href="{base}/run/{job?.id}?workspace={job?.workspace_id}"
-			>
-				Open run details (require auth) <ExternalLink size={12} class="inline" />
-			</a>
-		</div>
+		{#if !isLocked}
+			<div class="mt-4 flex flex-row flex-wrap justify-between">
+				<a
+					class="text-accent text-xs"
+					target="_blank"
+					rel="noreferrer"
+					href="{base}/run/{job?.id}?workspace={job?.workspace_id}"
+				>
+					Open run details (require auth) <ExternalLink size={12} class="inline" />
+				</a>
+			</div>
+		{/if}
 
 		{#if job && job.raw_flow && !completed}
 			<h2 class="mt-10 text-sm font-semibold text-emphasis mb-2">Flow details</h2>


### PR DESCRIPTION
## Summary

When a flow approval step is configured with `user_auth_required: true`, opening the approval URL while unauthenticated (e.g. an incognito window, or anyone the link is forwarded to) still revealed sensitive approval details — flow inputs, the resume form, the description, and the flow graph. This is a problem for flows handling sensitive operations (SSO escalations, etc.) where the inputs can contain customer names or other private data.

The root cause: `user_auth_required` was only enforced at the *resume/approve action* boundary — it stopped an anonymous visitor from clicking **Approve**, but never gated *reading* the approval details. The approval URL carries a `?token=…` (`generate_approval_token(workspace, flow)`), and that token was treated as a full read capability on two endpoints, so the data leaked via the UI **and** directly via `curl`.

This was specific to the newer token-based approval page (`/approve/{workspace}/{job}?token=…`); the legacy HMAC page already enforced auth and had not regressed.

Per product decision, the gate is **authorized approvers only**: when a step requires auth, approval details are revealed only to callers who pass the approval rules (admin, owner of the runnable, or a member of `user_groups_required` with self-approval respected). Unauthenticated **and** authenticated-but-unauthorized callers see only a sign-in / not-authorized state.

## Changes

**Backend (`backend/windmill-api/src/jobs.rs`)**
- Extracted the inline approver check into a pure `can_approve_step(...)` helper, shared by both endpoints. View gate: `can_view = !user_auth_required || can_approve`.
- `get_approval_info`: when `!can_view`, return a **stripped** `ApprovalInfo` (no `form_schema` / `description` / `default_args` / `enums` / approver identities) — only enough for the frontend to render the sign-in state.
- `get_job`: the approval-token read bypass (`has_valid_approval_token`) is now conditional on a new `approval_token_grants_view(...)` — it still works for legitimate approvers (incl. operators without broad job-read), but no longer grants anonymous access when the step requires auth.
- Added `#[cfg(test)] mod approval_view_gate_tests` covering the gate matrix.

**Frontend (`frontend/src/routes/approve/[workspace]/[job]/+page.svelte`)**
- Added an `isLocked` derived to hide empty Approvers / Flow-arguments / run-details scaffolding for the stripped/unauthorized response, leaving only the login prompt. The existing login flow re-fetches full data once the session cookie is present.

The legacy HMAC approval page (`get_suspended_job_flow`) already enforces `conditionally_require_authed_user` and was left unchanged.

## Test plan

- [x] Backend unit tests pass (`approval_view_gate_tests`): anonymous-blocked-when-auth-required, anonymous-allowed-when-not, admin/owner override; group-membership case under `#[cfg(feature="enterprise")]`.
- [x] Live API e2e against a real suspended flow with sensitive args (`customer_name`, `ssn`):
  - Anonymous + `user_auth_required`: `approval_info` stripped (no form/desc/args/approvers); `get_job` denied (no flow inputs).
  - Admin approver + `user_auth_required`: `approval_info` full (`can_approve: true`); `get_job` returns args.
  - Anonymous, **no** `user_auth_required`: still fully viewable via token (no regression).
- [ ] Manual UI: open the approval URL in an incognito window for a `user_auth_required` step → only sign-in state, no form/args/description/graph/run-details link. Sign in as an authorized approver → full details render and approve/deny work. Repeat for a classic flow and a WAC flow.
- [ ] Sanity-check a step with `user_auth_required: false` still renders fully for an anonymous token holder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lock down approval details for approval steps with `user_auth_required: true`. Approval URLs with `?token` no longer reveal form, inputs, or flow details unless the viewer is an authorized approver.

- **Bug Fixes**
  - Enforce a view gate: details are visible only if auth is not required or the user can approve (admins, owners, or meets `user_groups_required` with self-approval rules).
  - Added `can_approve_step(...)` and applied it to `get_approval_info` and `get_job`.
  - Approval token bypass now uses `approval_token_grants_view(...)`; tokens no longer grant anonymous read when auth is required.
  - When unauthorized, backend returns a stripped `ApprovalInfo` (no form/description/args/enums/approvers).
  - Frontend hides approvers/args/run-details/flow metadata when locked via `isLocked`; signing in refetches full data.
  - Added unit tests for anonymous/admin/owner/group cases and token behavior.

<sup>Written for commit ac7da886f1876a3a3e29ce58ab73b2d89237a8e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

