### PR TITLE
fix: show schedule args as raw JSON when input schema unavailable

### DIFF
--- a/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
@@ -129,15 +129,16 @@
 	// When the runnable input schema cannot be rendered (unavailable, empty, or
 	// without properties) but the schedule already has stored args, fall back to a
 	// raw JSON editor so existing args remain visible instead of implying the
-	// runnable takes no argument.
+	// runnable takes no argument. The editor's code is initialized once and the
+	// fallback stays visible until a renderable schema appears, so emptying the
+	// JSON while editing does not make the editor disappear from under the user.
 	let rawArgsEditorCode: string | undefined = $state(undefined)
+	let showRawArgsFallback = $derived(!hasRenderableSchema && rawArgsEditorCode !== undefined)
 	$effect(() => {
-		if (!hasRenderableSchema && hasArgs) {
-			if (rawArgsEditorCode === undefined) {
-				rawArgsEditorCode = JSON.stringify($state.snapshot(args), null, 2)
-			}
-		} else {
+		if (hasRenderableSchema) {
 			rawArgsEditorCode = undefined
+		} else if (hasArgs && rawArgsEditorCode === undefined) {
+			rawArgsEditorCode = JSON.stringify($state.snapshot(args), null, 2)
 		}
 	})
 
@@ -764,8 +765,8 @@
 		<div class="flex flex-col gap-8">
 			{#snippet rawArgsFallback()}
 				<Alert type="warning" size="xs" title="Input schema unavailable" class="mb-2">
-					The {is_flow ? 'flow' : 'script'} input schema could not be rendered. The stored
-					arguments are shown below as raw JSON.
+					The {is_flow ? 'flow' : 'script'} input schema could not be rendered. The stored arguments
+					are shown below as raw JSON.
 				</Alert>
 				{#await import('$lib/components/JsonEditor.svelte')}
 					<Loader2 class="animate-spin" />
@@ -984,7 +985,7 @@
 										bind:args
 									/>
 								{/await}
-							{:else if hasArgs}
+							{:else if showRawArgsFallback}
 								{@render rawArgsFallback()}
 							{:else}
 								<div class="text-xs text-secondary">
@@ -996,7 +997,7 @@
 								You cannot see the the {is_flow ? 'flow' : 'script'} input form as you do not have access
 								to it.
 							</div>
-							{#if hasArgs}
+							{#if showRawArgsFallback}
 								{@render rawArgsFallback()}
 							{/if}
 						{:else}

--- a/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
@@ -121,6 +121,30 @@
 	let selectedPermissionedAs = $state<string | undefined>(undefined)
 	let preservePermissionedAs = $state(false)
 
+	let schema = $derived(draftSchema ?? runnable?.schema)
+	let hasRenderableSchema = $derived(
+		!!schema?.properties && Object.keys(schema.properties).length > 0
+	)
+	let hasArgs = $derived(args != undefined && Object.keys(args).length > 0)
+	// When the runnable input schema cannot be rendered (unavailable, empty, or
+	// without properties) but the schedule already has stored args, fall back to a
+	// raw JSON editor so existing args remain visible instead of implying the
+	// runnable takes no argument.
+	let rawArgsEditorCode: string | undefined = $state(undefined)
+	$effect(() => {
+		if (!hasRenderableSchema && hasArgs) {
+			if (rawArgsEditorCode === undefined) {
+				rawArgsEditorCode = JSON.stringify($state.snapshot(args), null, 2)
+			}
+		} else {
+			rawArgsEditorCode = undefined
+		}
+	})
+
+	function updateRawArgs({ detail }: { detail: any }) {
+		args = detail ?? {}
+	}
+
 	const saveDisabled = $derived(
 		!allowSchedule ||
 			pathError != '' ||
@@ -738,6 +762,21 @@
 			}}
 		/>
 		<div class="flex flex-col gap-8">
+			{#snippet rawArgsFallback()}
+				<Alert type="warning" size="xs" title="Input schema unavailable" class="mb-2">
+					The {is_flow ? 'flow' : 'script'} input schema could not be rendered. The stored
+					arguments are shown below as raw JSON.
+				</Alert>
+				{#await import('$lib/components/JsonEditor.svelte')}
+					<Loader2 class="animate-spin" />
+				{:then Module}
+					<Module.default
+						code={rawArgsEditorCode}
+						disabled={!can_write}
+						on:changeValue={updateRawArgs}
+					/>
+				{/await}
+			{/snippet}
 			<Section label="Metadata">
 				<div class="flex flex-col gap-6">
 					<label class="flex flex-col gap-1">
@@ -932,8 +971,7 @@
 				<div class={!hideTarget ? 'mt-6' : ''}>
 					{#if !loading}
 						{#if runnable || draftSchema}
-							{@const schema = draftSchema ?? runnable?.schema}
-							{#if schema && schema.properties && Object.keys(schema.properties).length > 0}
+							{#if hasRenderableSchema}
 								{#await import('$lib/components/SchemaForm.svelte')}
 									<Loader2 class="animate-spin" />
 								{:then Module}
@@ -946,6 +984,8 @@
 										bind:args
 									/>
 								{/await}
+							{:else if hasArgs}
+								{@render rawArgsFallback()}
 							{:else}
 								<div class="text-xs text-secondary">
 									This {is_flow ? 'flow' : 'script'} takes no argument
@@ -956,6 +996,9 @@
 								You cannot see the the {is_flow ? 'flow' : 'script'} input form as you do not have access
 								to it.
 							</div>
+							{#if hasArgs}
+								{@render rawArgsFallback()}
+							{/if}
 						{:else}
 							<div class="text-xs text-secondary my-2">
 								Pick a {is_flow ? 'flow' : 'script'} and fill its argument here


### PR DESCRIPTION
## Summary

Fixes GIT-889. When editing a schedule whose target script/flow input schema is unavailable, empty, or has no `properties`, the schedule editor previously rendered "This flow/script takes no argument" and hid any existing `schedule.args`. Those args are still passed at runtime, so the UI was misleading and gave no way to review or edit them.

`SchemaForm` remains the primary UI whenever a renderable input schema is available. This PR only changes the fallback path: when the schema cannot be rendered but the schedule already has stored args, the editor now shows a warning plus a raw JSON editor exposing those args.

## Changes

- `frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte`:
  - Added `schema` / `hasRenderableSchema` / `hasArgs` derived state (replacing the inline `{@const schema}`), so the schema-form decision is reused.
  - Added a `rawArgsFallback` snippet that renders an `Alert` ("Input schema unavailable") and a lazily-imported `JsonEditor` bound to the stored args (`disabled` when the user lacks write access).
  - Render the fallback when a runnable/draft schema exists but is not renderable and args are present, and also in the "no access to the runnable" branch when args are present.
  - `rawArgsEditorCode` is initialized once via an `$effect` and the fallback is latched open (`showRawArgsFallback`) until a renderable schema appears, so clearing the JSON while editing does not make the editor disappear. A reactive `$derived` would feed regenerated JSON back into `JsonEditor`'s `code` prop on every keystroke and reset the cursor; the editor owns its own state after mount (same pattern as `FlowModuleMock.svelte`).

## Test plan

- [ ] Open a schedule with non-empty `args` pointing at a runnable whose input schema has no renderable `properties` → see the warning + raw JSON editor with the stored args, instead of "takes no argument".
- [ ] Edit the JSON → saved schedule args update accordingly.
- [ ] Clearing the JSON content mid-edit does not make the editor vanish.
- [ ] A runnable with a real input schema still renders `SchemaForm` (unchanged).
- [ ] A runnable with no schema and no stored args still shows "takes no argument" (unchanged).

> Note: browser verification was not performed in this worktree — the backend has never been built here and the dev frontend proxies to a local backend that isn't running. Validated via `svelte-check` (no new errors) and the Svelte autofixer (no issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)