### PR TITLE
feat(ai): add list_runs and get_job_logs tools to global chat mode

### DIFF
--- a/ai_evals/adapters/frontend/mockBackend.ts
+++ b/ai_evals/adapters/frontend/mockBackend.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import type { CompletedJob, Flow, Script } from '../../../frontend/src/lib/gen'
+import type { CompletedJob, Flow, Job, Script } from '../../../frontend/src/lib/gen'
 import type {
 	DataTableTables,
 	DataTableTableSchema,
@@ -29,17 +29,35 @@ export interface BenchmarkWorkspaceFlow {
 	value: Flow['value']
 }
 
+export interface BenchmarkWorkspaceJob {
+	/** Stable id so a case prompt can reference a specific run (e.g. for get_job_logs). */
+	id?: string
+	jobKind?: CompletedJob['job_kind']
+	scriptPath?: string
+	createdBy?: string
+	label?: string
+	success?: boolean
+	logs?: string
+}
+
 export interface BenchmarkWorkspaceRunnables {
 	scripts?: BenchmarkWorkspaceScript[]
 	flows?: BenchmarkWorkspaceFlow[]
 	datatables?: BenchmarkDatatableSeed[]
+	jobs?: BenchmarkWorkspaceJob[]
 }
 
 type BenchmarkCompletedJob = CompletedJob & { type: 'CompletedJob' }
 
 const benchmarkWorkspaces = new Set<string>()
 const benchmarkWorkspaceRunnables = new Map<string, BenchmarkWorkspaceRunnables>()
+// Keyed by `${workspace}::${jobId}` so concurrent attempts (or distinct cases)
+// can seed the same fixed job id without clobbering each other's entry.
 const benchmarkJobs = new Map<string, { workspace: string; job: BenchmarkCompletedJob }>()
+
+function benchmarkJobKey(workspace: string, jobId: string): string {
+	return `${workspace}::${jobId}`
+}
 
 export function resetBenchmarkMockBackend(): void {
 	benchmarkWorkspaces.clear()
@@ -62,6 +80,19 @@ export function registerBenchmarkWorkspaceRunnables(
 		...runnables,
 		datatables: runnables.datatables ? structuredClone(runnables.datatables) : undefined
 	})
+	// Seed any fixture jobs so list_runs / get_job_logs have data to return.
+	for (const seed of runnables.jobs ?? []) {
+		createBenchmarkCompletedJob({
+			workspace,
+			id: seed.id,
+			jobKind: seed.jobKind ?? 'script',
+			success: seed.success,
+			scriptPath: seed.scriptPath,
+			createdBy: seed.createdBy,
+			label: seed.label,
+			logs: seed.logs
+		})
+	}
 }
 
 export function unregisterBenchmarkWorkspace(workspace: string): void {
@@ -131,14 +162,17 @@ export function createBenchmarkCompletedJob(input: {
 	scriptPath?: string
 	scriptHash?: string
 	args?: Record<string, unknown>
+	id?: string
+	createdBy?: string
+	label?: string
 }): string {
-	const jobId = `benchmark-job-${randomUUID()}`
+	const jobId = input.id ?? `benchmark-job-${randomUUID()}`
 	const now = new Date().toISOString()
 	const job: BenchmarkCompletedJob = {
 		type: 'CompletedJob',
 		id: jobId,
 		workspace_id: input.workspace,
-		created_by: 'ai-evals',
+		created_by: input.createdBy ?? 'ai-evals',
 		created_at: now,
 		started_at: now,
 		completed_at: now,
@@ -156,10 +190,11 @@ export function createBenchmarkCompletedJob(input: {
 		is_skipped: false,
 		email: 'ai-evals@local',
 		visible_to_owner: true,
-		tag: 'benchmark'
+		tag: 'benchmark',
+		labels: input.label ? [input.label] : undefined
 	}
 
-	benchmarkJobs.set(jobId, { workspace: input.workspace, job })
+	benchmarkJobs.set(benchmarkJobKey(input.workspace, jobId), { workspace: input.workspace, job })
 	return jobId
 }
 
@@ -167,11 +202,40 @@ export function getBenchmarkCompletedJob(
 	workspace: string,
 	jobId: string
 ): BenchmarkCompletedJob | null {
-	const entry = benchmarkJobs.get(jobId)
-	if (!entry || entry.workspace !== workspace) {
+	const entry = benchmarkJobs.get(benchmarkJobKey(workspace, jobId))
+	if (!entry) {
 		return null
 	}
 	return structuredClone(entry.job)
+}
+
+/**
+ * List seeded/recorded jobs for a benchmark workspace, most recent first —
+ * the shape `JobService.listJobs` returns. Returns `null` for a non-benchmark
+ * workspace so the caller can fall through to the real backend. Server-side
+ * filters (path/creator/status/limit) are intentionally not applied: global
+ * eval cases assert on the recorded `list_runs` tool call, not on filtering.
+ */
+export function listBenchmarkJobs(workspace: string): Job[] | null {
+	if (!hasBenchmarkWorkspace(workspace)) {
+		return null
+	}
+	return [...benchmarkJobs.values()]
+		.filter((entry) => entry.workspace === workspace)
+		.map((entry) => structuredClone(entry.job) as Job)
+		.sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''))
+}
+
+/**
+ * Mirror `JobService.getJobLogs` (response is the raw log string). Throws a
+ * "not found" error for an unknown id, matching the backend 404.
+ */
+export function getBenchmarkJobLogs(workspace: string, jobId: string): string {
+	const job = getBenchmarkCompletedJob(workspace, jobId)
+	if (!job) {
+		throw new Error(`Job Logs not found for "${jobId}"`)
+	}
+	return job.logs ?? ''
 }
 
 // ============= Datatables (best-effort in-memory SQL) =============

--- a/ai_evals/adapters/frontend/vitestAdapter.test.ts
+++ b/ai_evals/adapters/frontend/vitestAdapter.test.ts
@@ -37,11 +37,13 @@ vi.mock('$lib/gen', async () => {
 		getBenchmarkCompletedJobResultMaybe,
 		getBenchmarkDatatableSchema,
 		getBenchmarkFlowByPath,
+		getBenchmarkJobLogs,
 		getBenchmarkScriptByHash,
 		getBenchmarkScriptByPath,
 		hasBenchmarkWorkspace,
 		listBenchmarkDatatables,
 		listBenchmarkFlows,
+		listBenchmarkJobs,
 		listBenchmarkScripts,
 		createBenchmarkHttpTrigger,
 		createBenchmarkSchedule,
@@ -199,7 +201,15 @@ vi.mock('$lib/gen', async () => {
 			getCompletedJobResultMaybe: async (data: { workspace: string; id: string }) =>
 				hasBenchmarkWorkspace(data.workspace)
 					? getBenchmarkCompletedJobResultMaybe({ workspace: data.workspace, id: data.id })
-					: actual.JobService.getCompletedJobResultMaybe(data)
+					: actual.JobService.getCompletedJobResultMaybe(data),
+			listJobs: async (data: { workspace: string }) =>
+				hasBenchmarkWorkspace(data.workspace)
+					? (listBenchmarkJobs(data.workspace) ?? [])
+					: actual.JobService.listJobs(data),
+			getJobLogs: async (data: { workspace: string; id: string }) =>
+				hasBenchmarkWorkspace(data.workspace)
+					? getBenchmarkJobLogs(data.workspace, data.id)
+					: actual.JobService.getJobLogs(data)
 		}),
 		WorkspaceService: wrapService(actual.WorkspaceService, {
 			listDataTableTables: async (data: { workspace: string }) =>

--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -821,3 +821,52 @@
     - uses the wmill.datatable() SDK to query the orders table and sum the order totals
     - returns the total revenue from the script
     - leaves the result as an AI draft and does not deploy or save it
+
+- id: global-test27-list-recent-runs
+  prompt: |-
+    What are the most recent runs in this workspace? Give me a quick rundown of what ran and whether it succeeded.
+  initial: ai_evals/fixtures/frontend/global/initial/jobs_seed.json
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - list_runs
+    forbiddenToolsUsed:
+      - deploy_workspace_item
+      - delete_workspace_item
+      - write_script
+  # Read-only job inspection produces no draft, so the global judge (which only
+  # sees the drafts artifact) would score it empty — validate via tool use.
+  skipJudge: true
+  judgeChecklist:
+    - lists the recent runs from the workspace rather than fabricating them
+    - summarizes each run's path and success/failure from the returned data
+
+- id: global-test28-fetch-failed-run-logs
+  prompt: |-
+    The run with id 01920000-0000-7000-8000-0000000000f1 failed. Pull its logs and tell me what went wrong.
+  initial: ai_evals/fixtures/frontend/global/initial/jobs_seed.json
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - get_job_logs
+    forbiddenToolsUsed:
+      - deploy_workspace_item
+      - delete_workspace_item
+      - write_script
+    toolCallArgs:
+      - tool: get_job_logs
+        field: id
+        stringIncludesAnyOf:
+          - 01920000-0000-7000-8000-0000000000f1
+  # Same as above — no draft is produced, so rely on the deterministic tool-use
+  # and argument checks rather than the judge.
+  skipJudge: true
+  judgeChecklist:
+    - fetches the logs for the requested job id
+    - explains the failure from the returned logs (connection refused to the upstream API)

--- a/ai_evals/fixtures/frontend/global/initial/jobs_seed.json
+++ b/ai_evals/fixtures/frontend/global/initial/jobs_seed.json
@@ -1,0 +1,30 @@
+{
+  "workspace": {
+    "jobs": [
+      {
+        "id": "01920000-0000-7000-8000-0000000000f1",
+        "scriptPath": "f/etl/sync_customers",
+        "jobKind": "script",
+        "createdBy": "alice",
+        "success": false,
+        "logs": "Starting customer sync...\nFetched 0 records\nERROR: connection refused to https://api.upstream.example.com\n  at fetchCustomers (sync_customers.ts:42)\nJob failed with exit code 1"
+      },
+      {
+        "id": "01920000-0000-7000-8000-0000000000f2",
+        "scriptPath": "f/reports/daily_digest",
+        "jobKind": "script",
+        "createdBy": "bob",
+        "success": true,
+        "logs": "Generating daily digest...\nDigest emailed to 12 recipients\nDone in 1.2s"
+      },
+      {
+        "id": "01920000-0000-7000-8000-0000000000f3",
+        "scriptPath": "f/billing/charge_invoices",
+        "jobKind": "flow",
+        "createdBy": "alice",
+        "success": true,
+        "logs": "Processing invoices...\nCharged 8 invoices totalling $1,240.00\nDone"
+      }
+    ]
+  }
+}

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -67,7 +67,40 @@ vi.mock('$lib/gen', async () => {
 				success: true,
 				result: { ok: true },
 				logs: 'test logs'
-			}))
+			})),
+			getJobLogs: vi.fn(async () => 'job log line 1\njob log line 2'),
+			listJobs: vi.fn(async () => [
+				{
+					type: 'CompletedJob',
+					id: 'completed-1',
+					job_kind: 'script',
+					script_path: 'f/team/runner',
+					created_by: 'alice',
+					created_at: '2026-06-09T10:00:00Z',
+					started_at: '2026-06-09T10:00:01Z',
+					duration_ms: 1200,
+					success: true,
+					canceled: false,
+					is_flow_step: false,
+					tag: 'default',
+					// fields that must be stripped from the summary
+					logs: 'verbose logs',
+					args: { secret: 'do-not-leak' },
+					result: { value: 42 }
+				},
+				{
+					type: 'QueuedJob',
+					id: 'queued-1',
+					job_kind: 'flow',
+					script_path: 'f/team/pipeline',
+					created_by: 'bob',
+					created_at: '2026-06-09T10:05:00Z',
+					running: true,
+					canceled: false,
+					is_flow_step: false,
+					tag: 'default'
+				}
+			])
 		}),
 		FlowService: wrapService(actual.FlowService, {
 			existsFlowByPath: vi.fn(async () => false),
@@ -238,6 +271,69 @@ describe('global AI tools', () => {
 		expect(names).toContain('test_run_script')
 		expect(names).toContain('test_run_flow')
 		expect(names).toContain('test_run_step')
+		expect(names).toContain('get_job_logs')
+		expect(names).toContain('list_runs')
+	})
+
+	it('lists recent runs with compact summaries and forwarded filters', async () => {
+		const result = await callGlobalTool('list_runs', {
+			path: 'f/team/runner',
+			created_by: 'alice',
+			success: true,
+			limit: 10
+		})
+
+		expect(JobService.listJobs).toHaveBeenCalledWith({
+			workspace: WORKSPACE,
+			scriptPathExact: 'f/team/runner',
+			createdBy: 'alice',
+			label: undefined,
+			success: true,
+			running: undefined,
+			perPage: 10
+		})
+
+		const runs = JSON.parse(result)
+		expect(runs).toHaveLength(2)
+		expect(runs[0]).toMatchObject({
+			id: 'completed-1',
+			status: 'success',
+			path: 'f/team/runner',
+			duration_ms: 1200
+		})
+		expect(runs[1]).toMatchObject({ id: 'queued-1', status: 'running' })
+		// Heavy / sensitive fields must not leak into the summary.
+		expect(result).not.toContain('verbose logs')
+		expect(result).not.toContain('do-not-leak')
+	})
+
+	it('defaults list_runs to 30 results when no limit is given', async () => {
+		await callGlobalTool('list_runs', {})
+		expect(JobService.listJobs).toHaveBeenCalledWith(
+			expect.objectContaining({ workspace: WORKSPACE, perPage: 30 })
+		)
+	})
+
+	it('fetches job logs by id', async () => {
+		const result = await callGlobalTool('get_job_logs', {
+			id: 'job-123',
+			remove_ansi_warnings: true
+		})
+
+		expect(JobService.getJobLogs).toHaveBeenCalledWith({
+			workspace: WORKSPACE,
+			id: 'job-123',
+			removeAnsiWarnings: true
+		})
+		expect(result).toBe('job log line 1\njob log line 2')
+	})
+
+	it('reports when a job has no logs', async () => {
+		vi.mocked(JobService.getJobLogs).mockResolvedValueOnce('   ')
+
+		const result = await callGlobalTool('get_job_logs', { id: 'job-empty' })
+
+		expect(result).toBe('No logs available for this job.')
 	})
 
 	it('searches hub scripts without fetching script contents', async () => {

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -314,11 +314,8 @@ describe('global AI tools', () => {
 		)
 	})
 
-	it('fetches job logs by id', async () => {
-		const result = await callGlobalTool('get_job_logs', {
-			id: 'job-123',
-			remove_ansi_warnings: true
-		})
+	it('fetches job logs by id and always suppresses the backend ansi hint line', async () => {
+		const result = await callGlobalTool('get_job_logs', { id: 'job-123' })
 
 		expect(JobService.getJobLogs).toHaveBeenCalledWith({
 			workspace: WORKSPACE,

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -305,6 +305,12 @@ describe('global AI tools', () => {
 		// Heavy / sensitive fields must not leak into the summary.
 		expect(result).not.toContain('verbose logs')
 		expect(result).not.toContain('do-not-leak')
+		// The result must be surfaced to the tool display, otherwise the details
+		// panel shows "No result yet" even though the call succeeded.
+		expect(toolCallbacks.setToolStatus).toHaveBeenCalledWith(
+			'test-list_runs',
+			expect.objectContaining({ result })
+		)
 	})
 
 	it('defaults list_runs to 30 results when no limit is given', async () => {
@@ -323,6 +329,12 @@ describe('global AI tools', () => {
 			removeAnsiWarnings: true
 		})
 		expect(result).toBe('job log line 1\njob log line 2')
+		// The logs must be surfaced as the tool result so the details panel shows
+		// them rather than "No result yet".
+		expect(toolCallbacks.setToolStatus).toHaveBeenCalledWith(
+			'test-get_job_logs',
+			expect.objectContaining({ result: 'job log line 1\njob log line 2' })
+		)
 	})
 
 	it('reports when a job has no logs', async () => {

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -141,10 +141,10 @@ const ACTIVE_GLOBAL_EDITOR_DRAFTS: readonly {
 	itemKind: LiveEditorDraftKind
 	type: ActiveGlobalEditorType
 }[] = [
-	{ itemKind: 'script', type: 'script' },
-	{ itemKind: 'flow', type: 'flow' },
-	{ itemKind: 'raw_app', type: 'app' }
-]
+		{ itemKind: 'script', type: 'script' },
+		{ itemKind: 'flow', type: 'flow' },
+		{ itemKind: 'raw_app', type: 'app' }
+	]
 
 export type GlobalActiveEditorContext = {
 	type: ActiveGlobalEditorType
@@ -633,12 +633,11 @@ Rules:
 - After creating or editing a script or flow draft, run test_run_script, test_run_flow, or test_run_step with representative args before reporting that it works. These tools prefer local drafts, so testing does not require deployment.
 - Use list_runs to find recent runs (optionally filtered by path, creator, label, or status), then get_job_logs with a returned id to inspect a specific run's logs — without starting a new test run.
 - When a required decision is ambiguous, use askUserQuestion with two to ten clear proposed answer strings instead of guessing. The user can also type a custom answer when none of the proposed answers fit.
-- Keep context targeted.${
-	previewTools
+- Keep context targeted.${previewTools
 		? `
 - After writing or substantially editing a script / flow / app draft, show it via open_preview(kind, path) so the user sees the editor and live preview right next to the chat. First check whether it is already shown: if unsure, call get_preview_status. Only call open_preview (or offer to) when no preview is open or it is showing a different item — don't re-open a preview already showing the item you just edited.`
 		: ''
-}
+	}
 
 Flows:
 - read_workspace_item returns compact flow JSON. Inline script bodies appear as "inline_script.<moduleId>".
@@ -867,11 +866,11 @@ function buildPersistedRunnable(
 ): PersistedRunnable {
 	const fields = input.staticInputs
 		? Object.fromEntries(
-				Object.entries(input.staticInputs).map(([k, v]) => [
-					k,
-					{ type: 'static', value: v, fieldType: 'object' }
-				])
-			)
+			Object.entries(input.staticInputs).map(([k, v]) => [
+				k,
+				{ type: 'static', value: v, fieldType: 'object' }
+			])
+		)
 		: (existing?.fields ?? {})
 
 	if (input.type === 'inline') {
@@ -1755,7 +1754,7 @@ export const globalTools: Tool<{}>[] = [
 		def: createToolDef(
 			getJobLogsSchema,
 			'get_job_logs',
-			'Fetch the logs of a job by its id. Use this to inspect the output of an existing run (e.g. a job id from the runs page or a flow step) rather than starting a new test run.'
+			'Fetch the logs of a job by its id. Use this to inspect the output of an existing run.'
 		),
 		showDetails: true,
 		fn: async ({ args, workspace, toolId, toolCallbacks }) => {
@@ -2440,9 +2439,9 @@ async function writeScheduleDraft(args: NewSchedule, ctx: WriteDraftCtx): Promis
 		? existingDraft
 		: backendExists
 			? ((await ScheduleService.getSchedule({
-					workspace,
-					path: args.path
-				})) as ScheduleDraftConfig)
+				workspace,
+				path: args.path
+			})) as ScheduleDraftConfig)
 			: undefined
 	const draft = mergeDraftConfig<ScheduleDraftConfig>(base, args as DraftConfig, args.path)
 

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -1746,8 +1746,12 @@ export const globalTools: Tool<{}>[] = [
 				perPage: parsed.limit ?? 30
 			})
 			const runs = jobs.map(summarizeRun)
-			toolCallbacks.setToolStatus(toolId, { content: `Listed ${runs.length} run(s)` })
-			return JSON.stringify(runs, null, 2)
+			const result = JSON.stringify(runs, null, 2)
+			toolCallbacks.setToolStatus(toolId, {
+				content: `Listed ${runs.length} run(s)`,
+				result
+			})
+			return result
 		}
 	},
 	{
@@ -1771,13 +1775,14 @@ export const globalTools: Tool<{}>[] = [
 				removeAnsiWarnings: true
 			})
 			const hasLogs = typeof logs === 'string' && logs.trim().length > 0
+			const result = hasLogs ? logs : 'No logs available for this job.'
 			toolCallbacks.setToolStatus(toolId, {
 				content: hasLogs
 					? `Fetched logs for job ${parsed.id}`
 					: `No logs available for job ${parsed.id}`,
-				logs: hasLogs ? logs : undefined
+				result
 			})
-			return hasLogs ? logs : 'No logs available for this job.'
+			return result
 		}
 	},
 	{

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -23,6 +23,7 @@ import type {
 	CreateVariable,
 	Flow,
 	FlowValue,
+	Job,
 	ListableApp,
 	ListableResource,
 	ListableVariable,
@@ -348,6 +349,38 @@ const searchResourceTypesSchema = z.object({
 		.describe('Max number of resource types to return. Defaults to 5.')
 })
 
+const getJobLogsSchema = z.object({
+	id: z.string().describe('The UUID of the job to fetch logs for.'),
+	remove_ansi_warnings: z
+		.boolean()
+		.optional()
+		.describe('Strip ANSI escape codes and truncation warnings from the returned logs.')
+})
+
+const listRunsSchema = z.object({
+	path: z
+		.string()
+		.optional()
+		.describe('Filter to runs of this exact script or flow path.'),
+	created_by: z
+		.string()
+		.optional()
+		.describe('Filter by the username that started the run.'),
+	label: z.string().optional().describe('Filter by job label.'),
+	success: z
+		.boolean()
+		.optional()
+		.describe('Only completed runs with this outcome (true = succeeded, false = failed).'),
+	running: z.boolean().optional().describe('Only currently running runs.'),
+	limit: z
+		.number()
+		.int()
+		.min(1)
+		.max(100)
+		.optional()
+		.describe('Max number of runs to return, most recent first. Defaults to 30.')
+})
+
 const deleteWorkspaceItemSchema = z.object({
 	type: itemTypeSchema,
 	path: z.string().describe('Workspace path of the item to delete.'),
@@ -602,6 +635,7 @@ Rules:
 - Use search_resource_types before write_resource.
 - Use get_instructions before writing scripts, flows, resources, or apps. For scripts, pass the target language.
 - After creating or editing a script or flow draft, run test_run_script, test_run_flow, or test_run_step with representative args before reporting that it works. These tools prefer local drafts, so testing does not require deployment.
+- Use list_runs to find recent runs (optionally filtered by path, creator, label, or status), then get_job_logs with a returned id to inspect a specific run's logs — without starting a new test run.
 - When a required decision is ambiguous, use askUserQuestion with two to ten clear proposed answer strings instead of guessing. The user can also type a custom answer when none of the proposed answers fit.
 - Keep context targeted.${
 	previewTools
@@ -742,6 +776,36 @@ function variableToItem(variable: ListableVariable): WorkspaceItem {
 		path: variable.path,
 		summary: variable.description,
 		isDraft: false
+	}
+}
+
+// Compact metadata for one run. The raw Job carries args/result/logs/raw_code
+// which can be huge — list_runs returns only what's needed to identify a run.
+function summarizeRun(job: Job): Record<string, unknown> {
+	const base = {
+		id: job.id,
+		job_kind: job.job_kind,
+		path: job.script_path,
+		created_by: job.created_by,
+		created_at: job.created_at,
+		started_at: job.started_at,
+		schedule_path: job.schedule_path,
+		is_flow_step: job.is_flow_step,
+		tag: job.tag,
+		worker: job.worker
+	}
+	if ('success' in job) {
+		// CompletedJob
+		return {
+			...base,
+			status: job.canceled ? 'canceled' : job.success ? 'success' : 'failure',
+			duration_ms: job.duration_ms
+		}
+	}
+	// QueuedJob (running or still waiting in the queue)
+	return {
+		...base,
+		status: job.running ? 'running' : 'queued'
 	}
 }
 
@@ -1666,6 +1730,57 @@ export const globalTools: Tool<{}>[] = [
 		confirmationMessage: 'Run flow step test',
 		showDetails: true,
 		autoCollapseDetails: false
+	},
+	{
+		def: createToolDef(
+			listRunsSchema,
+			'list_runs',
+			"List recent runs (jobs), most recent first. Optionally filter by path, creator, label, or status. Returns compact metadata only — use get_job_logs with a returned id to read a run's logs."
+		),
+		showDetails: true,
+		fn: async ({ args, workspace, toolId, toolCallbacks }) => {
+			const parsed = listRunsSchema.parse(args)
+			toolCallbacks.setToolStatus(toolId, { content: 'Listing runs...' })
+			const jobs = await JobService.listJobs({
+				workspace,
+				scriptPathExact: parsed.path,
+				createdBy: parsed.created_by,
+				label: parsed.label,
+				success: parsed.success,
+				running: parsed.running,
+				perPage: parsed.limit ?? 30
+			})
+			const runs = jobs.map(summarizeRun)
+			toolCallbacks.setToolStatus(toolId, { content: `Listed ${runs.length} run(s)` })
+			return JSON.stringify(runs, null, 2)
+		}
+	},
+	{
+		def: createToolDef(
+			getJobLogsSchema,
+			'get_job_logs',
+			'Fetch the logs of a job by its id. Use this to inspect the output of an existing run (e.g. a job id from the runs page or a flow step) rather than starting a new test run.'
+		),
+		showDetails: true,
+		fn: async ({ args, workspace, toolId, toolCallbacks }) => {
+			const parsed = getJobLogsSchema.parse(args)
+			toolCallbacks.setToolStatus(toolId, {
+				content: `Fetching logs for job ${parsed.id}...`
+			})
+			const logs = await JobService.getJobLogs({
+				workspace,
+				id: parsed.id,
+				removeAnsiWarnings: parsed.remove_ansi_warnings
+			})
+			const hasLogs = typeof logs === 'string' && logs.trim().length > 0
+			toolCallbacks.setToolStatus(toolId, {
+				content: hasLogs
+					? `Fetched logs for job ${parsed.id}`
+					: `No logs available for job ${parsed.id}`,
+				logs: hasLogs ? logs : undefined
+			})
+			return hasLogs ? logs : 'No logs available for this job.'
+		}
 	},
 	{
 		def: createToolDef(

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -350,11 +350,7 @@ const searchResourceTypesSchema = z.object({
 })
 
 const getJobLogsSchema = z.object({
-	id: z.string().describe('The UUID of the job to fetch logs for.'),
-	remove_ansi_warnings: z
-		.boolean()
-		.optional()
-		.describe('Strip ANSI escape codes and truncation warnings from the returned logs.')
+	id: z.string().describe('The UUID of the job to fetch logs for.')
 })
 
 const listRunsSchema = z.object({
@@ -1770,7 +1766,10 @@ export const globalTools: Tool<{}>[] = [
 			const logs = await JobService.getJobLogs({
 				workspace,
 				id: parsed.id,
-				removeAnsiWarnings: parsed.remove_ansi_warnings
+				// Always suppress the "to remove ansi colors, use: sed ..." hint the
+				// backend otherwise prepends — it is noise for the model and is not
+				// actual ANSI stripping (the raw logs are returned either way).
+				removeAnsiWarnings: true
 			})
 			const hasLogs = typeof logs === 'string' && logs.trim().length > 0
 			toolCallbacks.setToolStatus(toolId, {


### PR DESCRIPTION
## Summary

The global-mode AI assistant could create, edit, test, and deploy workspace items but had no way to inspect existing runs. This adds two read-only, job-inspection tools — `list_runs` and `get_job_logs` — mirroring the equivalents already available in api mode (the auto-generated MCP tools `listJobs` and `getJobLogs`). They let the assistant find recent runs and read a specific run's logs without starting a new test run.

## Changes

- **`list_runs`** — lists recent runs (jobs), most recent first, via `JobService.listJobs` (`GET /w/{workspace}/jobs/list`). Optional filters: `path` (exact script/flow path), `created_by`, `label`, `success`, `running`, and `limit` (1–100, default 30). Returns **compact metadata only** — a new `summarizeRun` helper deliberately strips the heavy/sensitive fields the raw `Job` carries (`args`, `result`, `logs`, `raw_code`, `raw_flow`) and derives a `status` (`success`/`failure`/`canceled` for completed jobs, `running`/`queued` for queued ones).
- **`get_job_logs`** — fetches a single job's logs by id via `JobService.getJobLogs` (`GET /w/{workspace}/jobs_u/get_logs/{id}`). It always passes `remove_ansi_warnings: true` so the backend's "to remove ansi colors, use: sed …" hint line (noise for the model, and not actual ANSI stripping) is suppressed; the param is intentionally not exposed as a tool argument. Surfaces a clear "No logs available" message when a job has none.
- Both tools are wired into `globalTools` with the standard `createToolDef(schema, name, description)` + `fn` pattern, are read-only (no confirmation), and set `showDetails: true`.
- Added a rule to the global system prompt directing the model to use `list_runs` to find runs, then `get_job_logs` with a returned id to read logs.
- Added unit tests in `global/core.test.ts` covering registration, filter forwarding, the `limit` default, the compact-summary shape for completed + queued runs, the sensitive/heavy-field stripping, log retrieval, and the no-logs branch.

No new server surface: both tools wrap already-authenticated, workspace-scoped endpoints, so they inherit the same per-job read access control as the api-mode tools.

## AI evals

Added two `global` benchmark cases in `ai_evals/` that exercise the new tools end-to-end through the production chat path (`global-test27-list-recent-runs`, `global-test28-fetch-failed-run-logs`), plus the harness support they need: a `jobs` seed in the workspace fixture and `JobService.listJobs`/`getJobLogs` mock overrides (`mockBackend.ts` + `vitestAdapter.test.ts`). Both are read-only and produce no draft, so they validate via `toolExpect` (required/forbidden tools + the `get_job_logs` `id` argument) with `skipJudge: true`.

Ran across **all four providers / the full model matrix — 100% pass (2/2 each)**:

| Provider | Models | Result |
|---|---|---|
| Anthropic | haiku, sonnet, opus | ✅ 2/2 each |
| OpenAI | gpt-4o, gpt-5.5 | ✅ 2/2 each |
| Google | gemini-3-flash-preview, gemini-3.1-pro-preview | ✅ 2/2 each |
| DeepSeek | deepseek-v4-flash, deepseek-v4-pro | ✅ 2/2 each |

Each model invoked the tools correctly (e.g. fetched the failed run's logs by id and explained the connection-refused failure from the seeded log). A datatable case was re-run to confirm the `benchmarkJobs` keying change didn't regress the job-polling path.

## Test plan

- [x] `npx vitest run src/lib/components/copilot/chat/global/core.test.ts` → 61 passed
- [x] `ai_evals` global cases pass for `list_runs` + `get_job_logs` across all 4 providers (table above)
- [x] In the global AI chat, ask to "list my recent runs" and confirm it calls `list_runs` and returns compact metadata (no args/results/logs in the listing)
- [x] Ask to "show the logs for run <id>" and confirm `get_job_logs` returns the log text in the tool status
- [x] Confirm a job with no logs surfaces the "No logs available" message rather than an empty panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)