### PR TITLE
fix: inherit container NO_PROXY into MITM tracing proxy job exclusions

### DIFF
--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -1077,6 +1077,15 @@ async fn get_otel_tracing_proxy_envs(
 /// through the proxy without TLS interception, so clients that pin their own CA (kubectl,
 /// helm, terraform, etc.) keep working. Empty when unset, matching the prior behavior of
 /// intercepting all destinations including loopback.
+///
+/// The worker's own `NO_PROXY` env is merged in so that enabling HTTP request tracing never
+/// silently narrows exclusions an operator already configured at the container level: hosts
+/// reachable directly before tracing was turned on stay reachable directly afterwards. The
+/// upstream-relay side (`build_no_proxy_intercept`) already honors the container `NO_PROXY`;
+/// this keeps the injected-into-jobs side symmetric. Note that job runtimes match `NO_PROXY`
+/// by hostname/suffix, not by resolving against CIDR ranges, so CIDR-only entries (e.g.
+/// `10.0.0.0/8`) carry over but won't match a hostname target — operators still need an
+/// explicit host/suffix entry for those.
 #[cfg(all(feature = "private", feature = "enterprise"))]
 async fn build_tracing_proxy_no_proxy() -> String {
     let configured = OTEL_TRACING_PROXY_SETTINGS
@@ -1084,22 +1093,23 @@ async fn build_tracing_proxy_no_proxy() -> String {
         .await
         .no_proxy_hosts
         .clone();
-    normalize_no_proxy_hosts(configured.as_deref())
+    normalize_no_proxy_hosts([configured.as_deref(), NO_PROXY.as_deref()])
 }
 
-/// Split a comma-separated NO_PROXY value, trim whitespace, drop empty entries, and
-/// deduplicate while preserving order. `None` returns an empty string.
+/// Split comma-separated NO_PROXY sources, trim whitespace, drop empty entries, and
+/// deduplicate while preserving first-occurrence order. Sources are concatenated in the
+/// order given (earlier sources win on ordering). Returns an empty string when all sources
+/// are `None`/empty.
 #[cfg(all(feature = "private", feature = "enterprise"))]
-fn normalize_no_proxy_hosts(configured: Option<&str>) -> String {
-    let Some(configured) = configured else {
-        return String::new();
-    };
+fn normalize_no_proxy_hosts<'a>(sources: impl IntoIterator<Item = Option<&'a str>>) -> String {
     let mut seen = std::collections::HashSet::new();
     let mut out: Vec<&str> = Vec::new();
-    for entry in configured.split(',') {
-        let trimmed = entry.trim();
-        if !trimmed.is_empty() && seen.insert(trimmed) {
-            out.push(trimmed);
+    for source in sources.into_iter().flatten() {
+        for entry in source.split(',') {
+            let trimmed = entry.trim();
+            if !trimmed.is_empty() && seen.insert(trimmed) {
+                out.push(trimmed);
+            }
         }
     }
     out.join(",")
@@ -1111,26 +1121,58 @@ mod no_proxy_tests {
 
     #[test]
     fn unset_returns_empty() {
-        assert_eq!(normalize_no_proxy_hosts(None), "");
+        assert_eq!(normalize_no_proxy_hosts([None]), "");
+        assert_eq!(normalize_no_proxy_hosts([None, None]), "");
     }
 
     #[test]
     fn empty_and_whitespace_only_returns_empty() {
-        assert_eq!(normalize_no_proxy_hosts(Some("")), "");
-        assert_eq!(normalize_no_proxy_hosts(Some("  ,  ,\t")), "");
+        assert_eq!(normalize_no_proxy_hosts([Some("")]), "");
+        assert_eq!(normalize_no_proxy_hosts([Some("  ,  ,\t")]), "");
     }
 
     #[test]
     fn trims_and_skips_empties() {
         assert_eq!(
-            normalize_no_proxy_hosts(Some("  *.eks.amazonaws.com  ,, *.internal ")),
+            normalize_no_proxy_hosts([Some("  *.eks.amazonaws.com  ,, *.internal ")]),
             "*.eks.amazonaws.com,*.internal"
         );
     }
 
     #[test]
     fn dedupes_preserving_first_occurrence_order() {
-        assert_eq!(normalize_no_proxy_hosts(Some("a,b,a,c,b,d")), "a,b,c,d");
+        assert_eq!(normalize_no_proxy_hosts([Some("a,b,a,c,b,d")]), "a,b,c,d");
+    }
+
+    #[test]
+    fn merges_configured_with_container_no_proxy() {
+        // Configured tracing hosts come first, then the container NO_PROXY is appended.
+        assert_eq!(
+            normalize_no_proxy_hosts([
+                Some("gitlab.internal"),
+                Some("localhost,127.0.0.1,10.0.0.0/8,.cluster.local")
+            ]),
+            "gitlab.internal,localhost,127.0.0.1,10.0.0.0/8,.cluster.local"
+        );
+    }
+
+    #[test]
+    fn merges_dedupe_across_sources() {
+        // Entries present in both sources are not duplicated.
+        assert_eq!(
+            normalize_no_proxy_hosts([Some("localhost,gitlab.internal"), Some("localhost,.svc")]),
+            "localhost,gitlab.internal,.svc"
+        );
+    }
+
+    #[test]
+    fn container_no_proxy_carries_over_when_unconfigured() {
+        // Tracing setting unset but container NO_PROXY present: exclusions still carry over,
+        // so enabling tracing does not silently drop them.
+        assert_eq!(
+            normalize_no_proxy_hosts([None, Some(".cluster.local,gitlab.internal")]),
+            ".cluster.local,gitlab.internal"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
When HTTP request tracing is enabled, the `NO_PROXY` injected into traced jobs (so their HTTP clients bypass the local MITM tracing proxy) was built solely from the `no_proxy_hosts` instance setting. It did not inherit the worker container's own `NO_PROXY`. Enabling tracing therefore silently dropped every exclusion an operator had already configured at the container level, funneling those hosts into the MITM proxy (and on to any upstream corporate proxy), which breaks reachability to internal hosts (e.g. an internal GitLab during git sync).

The upstream-relay side (`build_no_proxy_intercept`) already honors the container `NO_PROXY`; this makes the injected-into-jobs side symmetric.

## Changes
- `build_tracing_proxy_no_proxy` now merges the worker container `NO_PROXY` (`windmill_common::NO_PROXY`) with the configured `no_proxy_hosts` setting.
- Generalized `normalize_no_proxy_hosts` from a single `Option<&str>` to an iterator of sources, concatenating in order with first-occurrence dedup (configured hosts keep ordering precedence, container hosts append after).
- Added unit tests for cross-source merge ordering, cross-source dedup, and container-only carryover when the tracing setting is unset.

Note: job runtimes match `NO_PROXY` by hostname/suffix, not by resolving against CIDR ranges, so CIDR-only entries (e.g. `10.0.0.0/8`) carry over but won't match a hostname target. Operators still need an explicit host/suffix entry for those (documented in the function doc comment).

## Test plan
- [ ] `cargo test -p windmill-worker --features enterprise,private no_proxy_tests` passes (7 tests)
- [ ] On an EE worker with HTTP request tracing enabled and a container `NO_PROXY` set (e.g. `.cluster.local,gitlab.internal`), a traced job calling one of those hosts reaches it directly instead of failing through the MITM/upstream proxy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes traced job proxy exclusions by inheriting the worker container `NO_PROXY` when HTTP request tracing is enabled, so existing exclusions are kept and internal hosts remain reachable.

- **Bug Fixes**
  - Merge container `NO_PROXY` with instance `no_proxy_hosts` when building traced-job `NO_PROXY`.
  - Generalize `normalize_no_proxy_hosts` to accept multiple sources, trim, de-duplicate, and preserve first-seen order.
  - Add unit tests for merge order, cross-source dedup, and container-only carryover.

<sup>Written for commit 83e1e37a6e7d778e0d174427c890772394fbd913. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

