### PR TITLE
fix(frontend): improve AI chat markdown and typing dots in dark mode

### DIFF
--- a/frontend/src/lib/assets/app.css
+++ b/frontend/src/lib/assets/app.css
@@ -71,6 +71,26 @@
 		list-style-type: '- ';
 		padding-left: 3rem;
 	}
+
+	/* The '- ' list markers, horizontal rules and blockquote bars otherwise
+	   fall through to Tailwind Typography's default bullet/border colors, which
+	   are nearly invisible on dark backgrounds (e.g. the AI chat). Use
+	   theme-aware tokens so they stay readable in both light and dark mode. */
+	.prose-xs ul > li::marker,
+	.prose ul > li::marker {
+		color: rgb(var(--color-text-secondary));
+	}
+
+	.prose-xs hr,
+	.prose hr {
+		border-top-color: rgb(var(--color-border-normal));
+	}
+
+	.prose-xs blockquote,
+	.prose blockquote {
+		border-left-color: rgb(var(--color-border-normal));
+	}
+
 	.prose a {
 		@apply text-accent no-underline;
 	}

--- a/frontend/src/lib/components/copilot/chat/ChatTypingIndicator.svelte
+++ b/frontend/src/lib/components/copilot/chat/ChatTypingIndicator.svelte
@@ -38,16 +38,15 @@
 	aria-label="AI is generating a response"
 >
 	<span class={compact ? 'inline-flex items-end gap-0.5' : 'inline-flex items-end gap-1'}>
-		<span
-			class={(compact ? 'w-1 h-1' : 'w-1.5 h-1.5') + ' rounded-full bg-blue-500 chat-typing-dot'}
+		<span class={(compact ? 'w-1 h-1' : 'w-1.5 h-1.5') + ' rounded-full bg-accent chat-typing-dot'}
 		></span>
 		<span
 			class={(compact ? 'w-1 h-1' : 'w-1.5 h-1.5') +
-				' rounded-full bg-blue-500 chat-typing-dot chat-typing-dot-2'}
+				' rounded-full bg-accent chat-typing-dot chat-typing-dot-2'}
 		></span>
 		<span
 			class={(compact ? 'w-1 h-1' : 'w-1.5 h-1.5') +
-				' rounded-full bg-blue-500 chat-typing-dot chat-typing-dot-3'}
+				' rounded-full bg-accent chat-typing-dot chat-typing-dot-3'}
 		></span>
 	</span>
 	<span class={(compact ? 'text-[10px]' : 'text-2xs') + ' text-tertiary tabular-nums leading-none'}


### PR DESCRIPTION
## Summary

In the AI chat (and markdown elsewhere), several separator elements were nearly invisible in dark mode, and the typing indicator used an off-brand blue. Windmill renders unordered-list bullets as a literal `- ` marker, but the marker / `<hr>` / blockquote colors fell through to Tailwind Typography's `prose-invert` defaults (`gray-600`/`gray-700`), which wash out on the dark chat surface. The three typing-indicator dots were hardcoded `bg-blue-500` rather than the theme accent used by the chat message boxes.

This swaps those hardcoded colors for Windmill's theme-aware tokens, so they stay readable in both light and dark mode and stay consistent with the rest of the UI.

## Changes

- `app.css`: color markdown list `-` markers with `--color-text-secondary`, and `<hr>` + blockquote bars with `--color-border-normal`. Applied globally on `.prose`/`.prose-xs`, so it fixes every prose markdown renderer (AI chat, apps chat, app markdown component, display results, GFM markdown), not just the AI chat.
- `ChatTypingIndicator.svelte`: the three loading dots now use `bg-accent` (the same accent token the chat message boxes use) instead of the hardcoded `bg-blue-500`, so they match in both themes.

## Verification

Verified in the running app with Playwright (computed styles + screenshots) on the real dark surface:

| Element | Before (dark) | After (dark) |
|---|---|---|
| list `-` markers | `gray-600` #4b5563 (invisible) | `text-secondary` #a9b0ba |
| `<hr>` | `gray-700` #374151 (invisible) | `border-normal` #a9b0ba |
| blockquote bar | `gray-700` #374151 (invisible) | `border-normal` #a9b0ba |
| typing dots | `blue-500` #3b82f6 (off-brand) | `accent` #c7cefc — exact match to message box |

In light mode the dots become the brand indigo `#2652df` (exact match to the message box) and markers go from a faint `gray-300` to `text-secondary` — an improvement, no regression. Table borders were already visible and left unchanged.

> Note: triggering a live AI response with lists/hr/blockquote and an active "generating" state isn't deterministic, so the screenshots below are faithful reproductions rendered with the **actual production component classes and the live compiled CSS** on the real dark surface — the colors are pixel-accurate.

### Dark mode (before / after)
![dark mode before and after](https://files.catbox.moe/cv0oeb.png)

### Light mode (no regression)
![light mode before and after](https://files.catbox.moe/8ir6ap.png)

## Test plan

- [ ] Open the AI chat in dark mode and send a prompt that returns a bulleted list, a `---` rule, and a `>` blockquote — confirm markers, rule, and quote bar are clearly visible
- [ ] While the AI is generating, confirm the three typing dots match the accent color of the user message boxes
- [ ] Switch to light mode and confirm the same elements render correctly with no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves dark mode readability for markdown separators and aligns chat typing dots with the theme accent. Applies globally to all `.prose` markdown views for consistent visibility in both themes.

- **Bug Fixes**
  - Set list `-` markers to `--color-text-secondary`, and `<hr>` + blockquote bars to `--color-border-normal` for `.prose`/`.prose-xs`.
  - Updated typing indicator dots in `ChatTypingIndicator.svelte` to use `bg-accent` instead of `bg-blue-500`.

<sup>Written for commit 350c4bff52e2b4699f9f7a398e8591629cc13c86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

