### PR TITLE
fix(flows): show Python examples in approval-step help drawer

### DIFF
--- a/frontend/src/lib/components/flows/content/SuspendDrawer.svelte
+++ b/frontend/src/lib/components/flows/content/SuspendDrawer.svelte
@@ -81,15 +81,21 @@ def main():
 			<Section label="Default args">
 				As one of the return key of this step, return an object `default_args` that contains the
 				default arguments of the form arguments. e.g:
-				<HighlightCode
-					language={'deno'}
-					code={`//this assumes the Form tab has a string field named "foo" and a checkbox named "bar"
+				<Tabs selected="bun" class="pt-4">
+					<Tab value="bun" label="TypeScript (Bun)" />
+					<Tab value="python" label="Python" />
+
+					{#snippet content()}
+						<TabContent value="bun" class="p-2">
+							<HighlightCode
+								language={'deno'}
+								code={`//this assumes the Form tab has a string field named "foo" and a checkbox named "bar"
 
 import * as wmill from "npm:windmill-client@^1.158.2"
 
 export async function main() {
     // if no argument is passed, if user is logged in, it will use the user's username
-    const urls = await wmill.getResumeUrls("approver1") 
+    const urls = await wmill.getResumeUrls("approver1")
 
     // send the resumeUrls to the recipient or see Prompt section above
 
@@ -100,14 +106,44 @@ export async function main() {
         }
     }
 }`}
-				/>
+							/>
+						</TabContent>
+						<TabContent value="python" class="p-2">
+							<HighlightCode
+								language={'python3'}
+								code={`# this assumes the Form tab has a string field named "foo" and a checkbox named "bar"
+
+import wmill
+
+def main():
+    # if no argument is passed and the user is logged in, it uses the user's username
+    urls = wmill.get_resume_urls()
+
+    # send the resume urls to the recipient or see Prompt section above
+
+    return {
+        "default_args": {
+            "foo": "foo",
+            "bar": True
+        }
+    }`}
+							/>
+						</TabContent>
+					{/snippet}
+				</Tabs>
 			</Section>
 			<Section label="Dynamics enums">
 				As one of the return key of this step, return an object `enums` that contains the default
 				options of the form arguments. e.g:
-				<HighlightCode
-					language={'deno'}
-					code={`
+				<Tabs selected="bun" class="pt-4">
+					<Tab value="bun" label="TypeScript (Bun)" />
+					<Tab value="python" label="Python" />
+
+					{#snippet content()}
+						<TabContent value="bun" class="p-2">
+							<HighlightCode
+								language={'deno'}
+								code={`
 
 //this assumes the Form tab has a string field named "foo"
 
@@ -115,7 +151,7 @@ import * as wmill from "npm:windmill-client@^1.158.2"
 
 export async function main() {
     // if no argument is passed, if user is logged in, it will use the user's username
-    const url = await wmill.getResumeUrls("approver1") 
+    const url = await wmill.getResumeUrls("approver1")
 
     // send the resumeUrls to the recipient or see Prompt section above
 
@@ -125,7 +161,30 @@ export async function main() {
         },
     }
 }`}
-				/>
+							/>
+						</TabContent>
+						<TabContent value="python" class="p-2">
+							<HighlightCode
+								language={'python3'}
+								code={`# this assumes the Form tab has a string field named "foo"
+
+import wmill
+
+def main():
+    # if no argument is passed and the user is logged in, it uses the user's username
+    urls = wmill.get_resume_urls()
+
+    # send the resume urls to the recipient or see Prompt section above
+
+    return {
+        "enums": {
+            "foo": ["choice1", "choice2"]
+        }
+    }`}
+							/>
+						</TabContent>
+					{/snippet}
+				</Tabs>
 			</Section>
 		</div>
 	</DrawerContent>


### PR DESCRIPTION
## Summary

In the Suspend/Approval/Prompt step's help drawer, switching the example language to Python only updated the "Prompt" section — the "Default args" and "Dynamic enums" sections were single hardcoded TypeScript examples with no Python variant, so they stayed JavaScript (#6181).

## Changes

- `SuspendDrawer.svelte`: wrap the "Default args" and "Dynamic enums" examples in the same bun/python `<Tabs>` the "Prompt" section already uses, keeping the existing TypeScript in the bun tab and adding the Python equivalent of each (using `wmill.get_resume_urls()`, matching the existing Python "Prompt" tab).

## Test plan

- [ ] Flow editor → add a Suspend/Approval/Prompt step → open the "Default args & Dynamic enums help" drawer → toggle each section to Python and confirm the Python examples render.

Fixes #6181

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show Python examples in the Suspend/Approval/Prompt step help drawer for “Default args” and “Dynamic enums.” Toggling to Python now updates all sections. Fixes #6181.

- **Bug Fixes**
  - Wrapped both sections in Bun/Python tabs (same as “Prompt”) in `SuspendDrawer.svelte`.
  - Added Python examples using `wmill.get_resume_urls()`; kept existing TypeScript in the Bun tab.

<sup>Written for commit 8c403eb12f09ee953158308c9f251528c3157a72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

