### PR TITLE
feat: clear conflict error + force delete when reusing a fork workspace id

### DIFF
--- a/backend/.sqlx/query-ebc8f4840335dc3f4c8274fcf106825ecfdf7fbca59ea26541c5b4c0350b5502.json
+++ b/backend/.sqlx/query-ebc8f4840335dc3f4c8274fcf106825ecfdf7fbca59ea26541c5b4c0350b5502.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT deleted FROM workspace WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "deleted",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "ebc8f4840335dc3f4c8274fcf106825ecfdf7fbca59ea26541c5b4c0350b5502"
+}

--- a/backend/windmill-api-integration-tests/tests/workspaces.rs
+++ b/backend/windmill-api-integration-tests/tests/workspaces.rs
@@ -646,6 +646,68 @@ async fn test_workspace_endpoints(db: Pool<Postgres>) -> anyhow::Result<()> {
             .unwrap();
         assert_eq!(resp.json::<bool>().await?, true);
 
+        // --- create_fork over an existing (active) workspace id: clear 400, not a raw SQL 500 ---
+        let resp = authed(client().post(format!("{new_ws_base}/create_fork")))
+            .json(&json!({
+                "id": "wm-fork-renamed",
+                "name": "Conflicting Fork"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 400, "create_fork over active workspace");
+        let body = resp.text().await?;
+        assert!(
+            body.contains("already exists"),
+            "create_fork conflict body: {body}"
+        );
+
+        // --- create_fork over an archived workspace id: error must mention it is archived ---
+        let resp = authed(client().post(format!(
+            "http://localhost:{port}/api/w/wm-fork-renamed/workspaces/archive"
+        )))
+        .send()
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), 200, "archive fork: {}", resp.text().await?);
+
+        let resp = authed(client().post(format!("{new_ws_base}/create_fork")))
+            .json(&json!({
+                "id": "wm-fork-renamed",
+                "name": "Conflicting Fork"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 400, "create_fork over archived workspace");
+        let body = resp.text().await?;
+        assert!(
+            body.contains("archived"),
+            "create_fork archived-conflict body: {body}"
+        );
+
+        // --- hard delete frees up the id for a new fork ---
+        let resp = authed(client().delete(format!("{global_base}/delete/wm-fork-renamed")))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200, "delete fork: {}", resp.text().await?);
+
+        let resp = authed(client().post(format!("{new_ws_base}/create_fork")))
+            .json(&json!({
+                "id": "wm-fork-renamed",
+                "name": "Recreated Fork"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            200,
+            "create_fork after hard delete: {}",
+            resp.text().await?
+        );
+
         // clean up renamed fork
         let resp = authed(client().delete(format!("{global_base}/delete/wm-fork-renamed")))
             .send()

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -3640,6 +3640,27 @@ pub async fn check_w_id_conflict<'c>(tx: &mut Transaction<'c, Postgres>, w_id: &
     return Ok(());
 }
 
+/// Reject fork creation when the target workspace id is already taken,
+/// distinguishing archived workspaces: archiving is a soft delete that keeps
+/// the id reserved, which users frequently mistake for a permanent delete.
+async fn check_fork_w_id_conflict(db: &DB, w_id: &str) -> Result<()> {
+    let deleted = sqlx::query_scalar!("SELECT deleted FROM workspace WHERE id = $1", w_id)
+        .fetch_optional(db)
+        .await?;
+    match deleted {
+        Some(true) => Err(Error::BadRequest(format!(
+            "Workspace '{w_id}' already exists but is archived (archiving does not free up the workspace id). \
+             To reuse this id, permanently delete the archived workspace first — its owner or a superadmin \
+             can do so from the fork creation dialog, the superadmin workspaces page, or the CLI \
+             (`wmill workspace delete-fork`) — or choose a different fork id."
+        ))),
+        Some(false) => Err(Error::BadRequest(format!(
+            "Workspace '{w_id}' already exists. Delete the existing fork first or choose a different fork id."
+        ))),
+        None => Ok(()),
+    }
+}
+
 lazy_static::lazy_static! {
 
     pub static ref CREATE_WORKSPACE_REQUIRE_SUPERADMIN: bool = {
@@ -4795,6 +4816,10 @@ async fn create_workspace_fork_branch(
 
     validate_fork_workspace_id(&nw.id)?;
 
+    // Fail before creating any git branch so a name conflict doesn't leave a
+    // dangling branch on the synced repos.
+    check_fork_w_id_conflict(&db, &nw.id).await?;
+
     Ok(Json(
         handle_fork_branch_creation(&authed.email, &authed.username, &db, &w_id, &nw.id).await?,
     ))
@@ -4933,6 +4958,12 @@ async fn create_workspace_fork(
         )));
     }
 
+    validate_fork_workspace_id(&nw.id)?;
+    // Check the id conflict before the CE workspace-count limit so that
+    // re-using a taken (possibly archived) fork id reports the actual
+    // conflict instead of a misleading "maximum number of workspaces" error.
+    check_fork_w_id_conflict(&db, &nw.id).await?;
+
     #[cfg(not(feature = "enterprise"))]
     _check_nb_of_workspaces(&db).await?;
 
@@ -4953,8 +4984,6 @@ async fn create_workspace_fork(
     }
 
     let mut tx: Transaction<'_, Postgres> = db.begin().await?;
-
-    validate_fork_workspace_id(&nw.id)?;
 
     let forked_id = nw.id;
 

--- a/cli/src/commands/workspace/fork.ts
+++ b/cli/src/commands/workspace/fork.ts
@@ -100,7 +100,10 @@ async function createWorkspaceFork(
   }
 
   if (alreadyExists) {
-    throw new Error(`This forked workspace '${workspaceId}' (${workspaceName}) already exists. Choose a different id`);
+    throw new Error(
+      `This forked workspace '${workspaceId}' (${workspaceName}) already exists, possibly archived (archiving keeps the id reserved). ` +
+      `Permanently delete it with \`wmill workspace delete-fork ${workspaceId}\` to reuse the id, or choose a different id`,
+    );
   }
 
   // --- Datatable cloning (matches ForkDatatableSection.svelte) ---

--- a/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
+++ b/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
@@ -95,6 +95,7 @@
 	let deletingExistingFork = $state(false)
 
 	async function deleteExistingFork(): Promise<void> {
+		if (deletingExistingFork) return
 		const prefixedId = `${WM_FORK_PREFIX}${id}`
 		deletingExistingFork = true
 		try {
@@ -709,6 +710,7 @@
 	open={deleteExistingForkOpen}
 	title="Permanently delete existing fork"
 	confirmationText="Delete permanently"
+	loading={deletingExistingFork}
 	on:canceled={() => {
 		deleteExistingForkOpen = false
 	}}

--- a/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
+++ b/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
@@ -26,8 +26,9 @@
 	import ToggleButtonGroup from '$lib/components/common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import ToggleButton from '$lib/components/common/toggleButton-v2/ToggleButton.svelte'
 	import { AI_PROVIDERS } from '$lib/components/copilot/lib'
-	import { LoaderCircle } from 'lucide-svelte'
+	import { LoaderCircle, Trash2 } from 'lucide-svelte'
 	import PrefixedInput from '../PrefixedInput.svelte'
+	import ConfirmationModal from '../common/confirmationModal/ConfirmationModal.svelte'
 	import TextInput from '../text_input/TextInput.svelte'
 	import { jobManager } from '$lib/services/JobManager'
 	import Alert from '../common/alert/Alert.svelte'
@@ -68,9 +69,17 @@
 
 	async function validateName(id: string): Promise<void> {
 		checking = true
-		let exists = await WorkspaceService.existsWorkspace({ requestBody: { id } })
+		// For forks the actual workspace id is prefixed: checking the bare id
+		// would report the name as free even when `wm-fork-<id>` is taken
+		// (e.g. by an archived fork, which keeps its id reserved).
+		const effectiveId = isFork ? `${WM_FORK_PREFIX}${id}` : id
+		let exists =
+			id != '' && (await WorkspaceService.existsWorkspace({ requestBody: { id: effectiveId } }))
+		forkIdTaken = isFork && exists
 		if (exists) {
-			errorId = 'ID already exists'
+			errorId = isFork
+				? `A workspace with id '${effectiveId}' already exists. It may be an archived fork: archiving keeps the id reserved.`
+				: 'ID already exists'
 		} else if (id != '' && !/^\w+(-\w+)*$/.test(id)) {
 			errorId = 'ID can only contain letters, numbers and dashes and must not finish by a dash'
 		} else {
@@ -80,6 +89,25 @@
 	}
 
 	const WM_FORK_PREFIX = 'wm-fork-'
+
+	let forkIdTaken = $state(false)
+	let deleteExistingForkOpen = $state(false)
+	let deletingExistingFork = $state(false)
+
+	async function deleteExistingFork(): Promise<void> {
+		const prefixedId = `${WM_FORK_PREFIX}${id}`
+		deletingExistingFork = true
+		try {
+			await WorkspaceService.deleteWorkspace({ workspace: prefixedId })
+			sendUserToast(`Permanently deleted workspace ${prefixedId}`)
+			deleteExistingForkOpen = false
+			await validateName(id)
+		} catch (e: any) {
+			sendUserToast(`Failed to delete workspace ${prefixedId}: ${e?.body?.toString() ?? e}`, true)
+		} finally {
+			deletingExistingFork = false
+		}
+	}
 
 	let forkCreationLoading = $state(false)
 	let forkCreationError = $state('')
@@ -465,6 +493,22 @@
 				{/if}
 				{#if errorId}
 					<span class="text-red-500 text-2xs font-normal">{errorId}</span>
+					{#if forkIdTaken}
+						<div class="flex flex-row items-center gap-2 pt-1">
+							<Button
+								destructive
+								size="xs"
+								startIcon={{ icon: Trash2 }}
+								disabled={deletingExistingFork}
+								on:click={() => (deleteExistingForkOpen = true)}
+							>
+								Permanently delete existing fork
+							</Button>
+							<span class="text-2xs text-secondary">
+								Frees up the id so you can reuse it (fork owner or superadmin only)
+							</span>
+						</div>
+					{/if}
 				{/if}
 			</label>
 			<Label label="Workspace color">
@@ -660,3 +704,23 @@
 		{/if}
 	</div>
 </div>
+
+<ConfirmationModal
+	open={deleteExistingForkOpen}
+	title="Permanently delete existing fork"
+	confirmationText="Delete permanently"
+	on:canceled={() => {
+		deleteExistingForkOpen = false
+	}}
+	on:confirmed={() => {
+		deleteExistingFork()
+	}}
+>
+	<div class="flex flex-col w-full space-y-4">
+		<span>
+			This will permanently delete the workspace '{WM_FORK_PREFIX}{id}' and all of its content
+			(scripts, flows, apps, variables, resources, runs). This cannot be undone. Unlike archiving,
+			this frees up the workspace id for a new fork.
+		</span>
+	</div>
+</ConfirmationModal>

--- a/frontend/src/routes/(root)/(logged)/forks/compare/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/forks/compare/+page.svelte
@@ -264,7 +264,8 @@
 		Archive forked workspace <span class="font-mono font-medium text-primary"
 			>{currentWorkspaceId}</span
 		>? It will be hidden from the workspace picker; a superadmin can restore it from instance
-		settings later.
+		settings later. Its content is kept and its workspace id stays reserved — use Delete fork
+		instead if you want to reuse the id for a new fork.
 	</p>
 </ConfirmationModal>
 


### PR DESCRIPTION
## Summary

Re-creating a workspace fork with a name whose `wm-fork-<id>` is already taken — most commonly by an **archived** fork, since archiving is a soft delete that keeps the id reserved — failed with a raw 500 (`SqlErr: duplicate key value violates unique constraint "workspace_pkey"`). Worse, the fork creation dialog reported the id as free because it checked the **unprefixed** id against `existsWorkspace`. Users hitting this concluded their "deleted" fork had been mysteriously recovered, when in fact it had only been archived and the id was still occupied.

This PR makes the conflict explicit and gives users a way to force-delete the existing fork to reuse the id:

- a clear 400 on fork creation distinguishing archived vs active id conflicts, raised in `create_workspace_fork_branch` too so no dangling git branch is created on conflict
- the fork dialog now validates the prefixed id, surfaces the conflict, and offers a **Permanently delete existing fork** action (backend already authorizes fork owners and superadmins on `deleteWorkspace`)

| Conflict surfaced in dialog | Force-delete confirmation |
|---|---|
| ![conflict](https://files.catbox.moe/kbz55k.png) | ![confirm](https://files.catbox.moe/r8p5gu.png) |

## Changes

- **backend** (`windmill-api-workspaces/src/workspaces.rs`): new `check_fork_w_id_conflict` helper; called in `create_workspace_fork` (before the CE workspace-count check, so the conflict isn't masked by the "maximum number of workspaces" error) and in `create_workspace_fork_branch` (before any git branch is pushed). Archived conflicts get a dedicated message explaining that archiving keeps the id reserved and how to permanently delete.
- **frontend** (`CreateWorkspaceInner.svelte`): `validateName` now checks `wm-fork-<id>` when forking (previously checked the bare id — always reported free); on conflict, shows a destructive "Permanently delete existing fork" button with a confirmation modal (loading + re-entrancy guarded) that calls `deleteWorkspace` and re-validates.
- **frontend** (`forks/compare/+page.svelte`): archive-fork confirmation copy now states content is kept and the id stays reserved, pointing to Delete fork for id reuse.
- **cli** (`fork.ts`): the `workspace fork` conflict error now mentions the archived-id possibility and the `wmill workspace delete-fork` escape hatch.
- **tests** (`windmill-api-integration-tests/tests/workspaces.rs`): create_fork over an active id → 400 "already exists"; over an archived id → 400 mentioning "archived"; hard delete frees the id and re-creation succeeds.
- **sqlx**: one new offline cache entry for `SELECT deleted FROM workspace WHERE id = $1` (zero net deletions vs main).

## Test plan

- [x] `cargo check -p windmill-api-workspaces` and `cargo check -p windmill-api-integration-tests --tests --features enterprise` pass
- [x] `cargo test -p windmill-api-integration-tests --test workspaces --features enterprise` — 4 passed, including the new conflict assertions
- [x] `npm run check:fast` — 70 pre-existing errors before and after (none in touched files; verified by stashing the diff)
- [x] Manual API: archive fork → create same name → 400 with archived message; unarchive → create → 400 with active-conflict message (not the CE cap message); hard delete → create → fresh fork without old content
- [x] Manual UI (Playwright, headless system Chromium): conflict error renders in the fork dialog, force-delete button + modal work, workspace is gone afterwards and the error clears
- [ ] Verify the force-delete toast shows a legible backend error when attempted by a non-owner/non-superadmin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return clear 400 errors when a forked workspace id like `wm-fork-<id>` is already taken (active or archived), and allow owners/superadmins to permanently delete the existing fork to reuse the id. Fix UI validation to check the prefixed id and add early backend checks (including branch creation) to prevent dangling git branches and raw 500s.

- **New Features**
  - API reports fork id conflicts with specific messages for archived vs active workspaces.
  - Fork dialog validates `wm-fork-<id>` and offers a “Permanently delete existing fork” flow with confirmation and a double-submit guard; archive modal clarifies the id stays reserved.
  - CLI `workspace fork` error explains the archived case and suggests `wmill workspace delete-fork`.

- **Bug Fixes**
  - Replaces duplicate-key 500 with a 400 and checks conflicts before the CE workspace-count limit.
  - Preflight conflict check in branch creation prevents pushing a git branch on conflict.
  - Tests cover active/archived/hard-delete flows; adds `sqlx` offline cache for `SELECT deleted FROM workspace WHERE id = $1`.

<sup>Written for commit 5ef4bce27584a99a6bd288e58c3665ed8621e1c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

