### PR TITLE
feat(ai): persist global chat script/flow drafts to the workspace DB

### DIFF
--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -939,6 +939,51 @@ describe('global AI tools', () => {
 		).rejects.toThrow('trigger_kind is required')
 	})
 
+	it('preserves editor metadata in the DB draft when the AI edits an open live script', async () => {
+		// The live editor's buffer holds the FULL script, including metadata the
+		// user changed in the editor (concurrency, tag, description, …).
+		UserDraft.save(
+			'script',
+			'',
+			{
+				path: 'u/admin/meta_script',
+				summary: 'Live script',
+				description: 'keep me',
+				content: 'export async function main() {\n\treturn 1\n}',
+				schema: {},
+				is_template: false,
+				language: 'bun',
+				kind: 'script',
+				concurrent_limit: 7,
+				tag: 'custom-tag'
+			},
+			{ workspace: WORKSPACE }
+		)
+		UserDraft.setLiveEditorDraft({
+			workspace: WORKSPACE,
+			itemKind: 'script',
+			storagePath: '',
+			effectivePath: 'u/admin/meta_script'
+		})
+
+		await callGlobalTool('write_script', {
+			path: 'u/admin/meta_script',
+			summary: 'Live script',
+			language: 'bun',
+			content: 'export async function main() {\n\treturn 2\n}'
+		})
+
+		// The AI only changes value; the editor's metadata is carried through to
+		// the DB draft, not wiped.
+		expect(dbScriptDraft('u/admin/meta_script')).toMatchObject({
+			path: 'u/admin/meta_script',
+			content: 'export async function main() {\n\treturn 2\n}',
+			concurrent_limit: 7,
+			tag: 'custom-tag',
+			description: 'keep me'
+		})
+	})
+
 	it('discards a draft-only item that has no separate draft row', async () => {
 		// An item that exists ONLY as a draft_only row, with no draft-table entry
 		// (e.g. created elsewhere) — the row itself is the draft content.

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -208,6 +208,11 @@ const WORKSPACE = 'global-core-test'
 // implementations re-wired in beforeEach.
 
 type SimRow = Record<string, any>
+// Mimic the generated client's ApiError shape so the code's `status === 404`
+// not-found discrimination behaves the same against the sim.
+function notFound(message: string): Error {
+	return Object.assign(new Error(message), { status: 404 })
+}
 const scriptRows = new Map<string, SimRow>()
 const scriptDrafts = new Map<string, SimRow>()
 const flowRows = new Map<string, SimRow>()
@@ -246,13 +251,13 @@ function resetDbSim(): void {
 	})
 	setImpl(ScriptService.getScriptByPathWithDraft, async ({ path }: any) => {
 		const row = scriptRows.get(path)
-		if (!row) throw new Error(`script "${path}" not found`)
+		if (!row) throw notFound(`script "${path}" not found`)
 		const draft = scriptDrafts.get(path)
 		return { ...row, draft, draft_created_at: draft ? DRAFT_TS : undefined }
 	})
 	setImpl(ScriptService.getScriptByPath, async ({ path }: any) => {
 		const row = scriptRows.get(path)
-		if (!row) throw new Error(`script "${path}" not found`)
+		if (!row) throw notFound(`script "${path}" not found`)
 		return row
 	})
 	setImpl(ScriptService.deleteScriptByPath, async ({ path }: any) => {
@@ -295,13 +300,13 @@ function resetDbSim(): void {
 	})
 	setImpl(FlowService.getFlowByPathWithDraft, async ({ path }: any) => {
 		const row = flowRows.get(path)
-		if (!row) throw new Error(`flow "${path}" not found`)
+		if (!row) throw notFound(`flow "${path}" not found`)
 		const draft = flowDrafts.get(path)
 		return { ...row, draft, draft_created_at: draft ? DRAFT_TS : undefined }
 	})
 	setImpl(FlowService.getFlowByPath, async ({ path }: any) => {
 		const row = flowRows.get(path)
-		if (!row) throw new Error(`flow "${path}" not found`)
+		if (!row) throw notFound(`flow "${path}" not found`)
 		return row
 	})
 	setImpl(FlowService.deleteFlowByPath, async ({ path }: any) => {

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -166,6 +166,10 @@ vi.mock('./rawAppBundlerBridge', () => ({
 	}))
 }))
 
+vi.mock('$lib/workspaceDrafts.svelte', () => ({
+	invalidateWorkspaceDrafts: vi.fn()
+}))
+
 import {
 	globalTools,
 	globalToolsFor,
@@ -176,6 +180,7 @@ import {
 	setOpenPreviewHandler
 } from './core'
 import { UserDraft, __resetUserDraftForTesting } from '$lib/userDraft.svelte'
+import { invalidateWorkspaceDrafts } from '$lib/workspaceDrafts.svelte'
 import { clearGlobalDrafts } from './userDraftAdapter'
 import { bundleRawAppDraft } from './rawAppBundlerBridge'
 import {
@@ -927,6 +932,70 @@ describe('global AI tools', () => {
 				path: 'f/routes/missing-kind'
 			})
 		).rejects.toThrow('trigger_kind is required')
+	})
+
+	it('discards a draft-only item that has no separate draft row', async () => {
+		// An item that exists ONLY as a draft_only row, with no draft-table entry
+		// (e.g. created elsewhere) — the row itself is the draft content.
+		await ScriptService.createScript({
+			workspace: WORKSPACE,
+			requestBody: {
+				path: 'f/scripts/orphan',
+				summary: 'Orphan',
+				content: 'export async function main() { return 1 }',
+				language: 'bun',
+				draft_only: true
+			} as any
+		})
+		expect(dbScriptDraft('f/scripts/orphan')).toBeUndefined()
+
+		const raw = await callGlobalTool('discard_local_draft', {
+			type: 'script',
+			path: 'f/scripts/orphan'
+		})
+
+		expect(JSON.parse(raw)).toMatchObject({ success: true, type: 'script', path: 'f/scripts/orphan' })
+		// draft_only with no deployed version -> the whole item is removed.
+		expect(ScriptService.deleteScriptByPath).toHaveBeenCalledWith({
+			workspace: WORKSPACE,
+			path: 'f/scripts/orphan'
+		})
+	})
+
+	it('deploys a chat-created script draft and clears the draft', async () => {
+		const content = 'export async function main() { return 1 }'
+		await callGlobalTool('write_script', {
+			path: 'f/scripts/to-deploy',
+			summary: 'Deploy me',
+			language: 'bun',
+			content
+		})
+		expect(dbScriptDraft('f/scripts/to-deploy')).toBeDefined()
+
+		vi.mocked(invalidateWorkspaceDrafts).mockClear()
+		const raw = await callGlobalTool('deploy_workspace_item', {
+			type: 'script',
+			path: 'f/scripts/to-deploy'
+		})
+
+		expect(JSON.parse(raw)).toMatchObject({ success: true, type: 'script', path: 'f/scripts/to-deploy' })
+		// Deploy writes a real (non-draft_only) version; the backend clears the draft.
+		const createCalls = vi.mocked(ScriptService.createScript).mock.calls
+		const lastCreate = createCalls[createCalls.length - 1]?.[0] as any
+		expect(lastCreate.requestBody.draft_only).toBeFalsy()
+		expect(lastCreate.requestBody.content).toBe(content)
+		expect(dbScriptDraft('f/scripts/to-deploy')).toBeUndefined()
+		expect(invalidateWorkspaceDrafts).toHaveBeenCalledWith(WORKSPACE)
+	})
+
+	it('invalidates workspace draft counts after writing a draft', async () => {
+		await callGlobalTool('write_script', {
+			path: 'f/scripts/counted',
+			summary: '',
+			language: 'bun',
+			content: 'export async function main() {}'
+		})
+		expect(invalidateWorkspaceDrafts).toHaveBeenCalledWith(WORKSPACE)
 	})
 
 	it('preserves existing script metadata when writing over an existing item', async () => {

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -45,6 +45,7 @@ vi.mock('$lib/gen', async () => {
 		ScriptService: wrapService(actual.ScriptService, {
 			existsScriptByPath: vi.fn(async () => false),
 			createScript: vi.fn(async () => 'created'),
+			deleteScriptByPath: vi.fn(async () => 'deleted'),
 			getScriptByPath: vi.fn(async () => {
 				throw new Error('getScriptByPath mock not configured')
 			}),
@@ -57,6 +58,10 @@ vi.mock('$lib/gen', async () => {
 			queryHubScripts: vi.fn(async () => []),
 			getHubScriptContentByPath: vi.fn(async () => ''),
 			listScripts: vi.fn(async () => [])
+		}),
+		DraftService: wrapService(actual.DraftService, {
+			createDraft: vi.fn(async () => 'created'),
+			deleteDraft: vi.fn(async () => 'deleted')
 		}),
 		JobService: wrapService(actual.JobService, {
 			runScriptPreview: vi.fn(async () => 'job-script-preview'),
@@ -106,6 +111,7 @@ vi.mock('$lib/gen', async () => {
 			existsFlowByPath: vi.fn(async () => false),
 			createFlow: vi.fn(async () => 'created'),
 			updateFlow: vi.fn(async () => 'updated'),
+			deleteFlowByPath: vi.fn(async () => 'deleted'),
 			getFlowByPath: vi.fn(async () => {
 				throw new Error('getFlowByPath mock not configured')
 			}),
@@ -174,6 +180,7 @@ import { clearGlobalDrafts } from './userDraftAdapter'
 import { bundleRawAppDraft } from './rawAppBundlerBridge'
 import {
 	AppService,
+	DraftService,
 	FlowService,
 	HttpTriggerService,
 	JobService,
@@ -185,6 +192,136 @@ import {
 import type { Tool, ToolCallbacks } from '../shared'
 
 const WORKSPACE = 'global-core-test'
+
+// ---------------------------------------------------------------------------
+// In-memory simulation of the workspace DB drafts for scripts & flows.
+//
+// Script and flow chat drafts are now persisted to the DB (via DraftService and
+// a backing draft_only row), and read back through getXByPathWithDraft /
+// listX. We model just enough of that here so write -> read -> list -> discard
+// -> deploy round-trips behave like the real backend. Stores are reset and the
+// implementations re-wired in beforeEach.
+
+type SimRow = Record<string, any>
+const scriptRows = new Map<string, SimRow>()
+const scriptDrafts = new Map<string, SimRow>()
+const flowRows = new Map<string, SimRow>()
+const flowDrafts = new Map<string, SimRow>()
+const DRAFT_TS = '2026-06-09T00:00:00Z'
+
+function dbScriptDraft(path: string): any {
+	return scriptDrafts.get(path)
+}
+function dbFlowDraft(path: string): any {
+	return flowDrafts.get(path)
+}
+
+// The generated client methods are typed to return CancelablePromise; the sim
+// returns plain promises, so route mockImplementation through `as any`.
+function setImpl(fn: unknown, impl: (...args: any[]) => any): void {
+	vi.mocked(fn as any).mockImplementation(impl as any)
+}
+
+function resetDbSim(): void {
+	scriptRows.clear()
+	scriptDrafts.clear()
+	flowRows.clear()
+	flowDrafts.clear()
+
+	setImpl(ScriptService.existsScriptByPath, async ({ path }: any) => scriptRows.has(path))
+	setImpl(ScriptService.createScript, async ({ requestBody }: any) => {
+		const draftOnly = requestBody.draft_only === true
+		scriptRows.set(requestBody.path, {
+			...requestBody,
+			hash: `h:${requestBody.path}`,
+			draft_only: draftOnly
+		})
+		if (!draftOnly) scriptDrafts.delete(requestBody.path) // deploy clears the draft, like the backend
+		return 'created'
+	})
+	setImpl(ScriptService.getScriptByPathWithDraft, async ({ path }: any) => {
+		const row = scriptRows.get(path)
+		if (!row) throw new Error(`script "${path}" not found`)
+		const draft = scriptDrafts.get(path)
+		return { ...row, draft, draft_created_at: draft ? DRAFT_TS : undefined }
+	})
+	setImpl(ScriptService.getScriptByPath, async ({ path }: any) => {
+		const row = scriptRows.get(path)
+		if (!row) throw new Error(`script "${path}" not found`)
+		return row
+	})
+	setImpl(ScriptService.deleteScriptByPath, async ({ path }: any) => {
+		scriptRows.delete(path)
+		scriptDrafts.delete(path)
+		return 'deleted'
+	})
+	setImpl(ScriptService.listScripts, async ({ pathStart }: any) =>
+		[...scriptRows.values()]
+			.filter((row) => !pathStart || row.path.startsWith(pathStart))
+			.map((row) => ({ ...row, has_draft: scriptDrafts.has(row.path) }))
+	)
+
+	setImpl(FlowService.existsFlowByPath, async ({ path }: any) => flowRows.has(path))
+	setImpl(FlowService.createFlow, async ({ requestBody }: any) => {
+		const draftOnly = requestBody.draft_only === true
+		flowRows.set(requestBody.path, {
+			edited_by: '',
+			edited_at: '',
+			archived: false,
+			extra_perms: {},
+			...requestBody,
+			draft_only: draftOnly
+		})
+		if (!draftOnly) flowDrafts.delete(requestBody.path)
+		return 'created'
+	})
+	setImpl(FlowService.updateFlow, async ({ path, requestBody }: any) => {
+		flowRows.set(path, {
+			edited_by: '',
+			edited_at: '',
+			archived: false,
+			extra_perms: {},
+			...requestBody,
+			path,
+			draft_only: false
+		})
+		flowDrafts.delete(path)
+		return 'updated'
+	})
+	setImpl(FlowService.getFlowByPathWithDraft, async ({ path }: any) => {
+		const row = flowRows.get(path)
+		if (!row) throw new Error(`flow "${path}" not found`)
+		const draft = flowDrafts.get(path)
+		return { ...row, draft, draft_created_at: draft ? DRAFT_TS : undefined }
+	})
+	setImpl(FlowService.getFlowByPath, async ({ path }: any) => {
+		const row = flowRows.get(path)
+		if (!row) throw new Error(`flow "${path}" not found`)
+		return row
+	})
+	setImpl(FlowService.deleteFlowByPath, async ({ path }: any) => {
+		flowRows.delete(path)
+		flowDrafts.delete(path)
+		return 'deleted'
+	})
+	setImpl(FlowService.listFlows, async ({ pathStart }: any) =>
+		[...flowRows.values()]
+			.filter((row) => !pathStart || row.path.startsWith(pathStart))
+			.map((row) => ({ ...row, has_draft: flowDrafts.has(row.path) }))
+	)
+
+	setImpl(DraftService.createDraft, async ({ requestBody }: any) => {
+		const { path, typ, value } = requestBody
+		if (typ === 'script') scriptDrafts.set(path, value)
+		else if (typ === 'flow') flowDrafts.set(path, value)
+		return 'created'
+	})
+	setImpl(DraftService.deleteDraft, async ({ path, kind }: any) => {
+		if (kind === 'script') scriptDrafts.delete(path)
+		else if (kind === 'flow') flowDrafts.delete(path)
+		return 'deleted'
+	})
+}
 
 const toolCallbacks: ToolCallbacks = {
 	setToolStatus: vi.fn(),
@@ -240,6 +377,7 @@ describe('global AI tools', () => {
 		localStorage.clear()
 		clearGlobalDrafts(WORKSPACE)
 		vi.clearAllMocks()
+		resetDbSim()
 	})
 
 	it('defaults the datatable instruction subject to the TypeScript SQL SDK', async () => {
@@ -534,7 +672,7 @@ describe('global AI tools', () => {
 		expect(VariableService.updateVariable).not.toHaveBeenCalled()
 	})
 
-	it('writes script drafts into UserDraft', async () => {
+	it('writes script drafts into the workspace DB', async () => {
 		const content = 'export async function main() {\n\treturn "hello"\n}'
 
 		await callGlobalTool('write_script', {
@@ -544,14 +682,21 @@ describe('global AI tools', () => {
 			content
 		})
 
-		expect(UserDraft.get<any>('script', 'f/scripts/hello', { workspace: WORKSPACE })).toMatchObject(
-			{
-				path: 'f/scripts/hello',
-				summary: 'Hello script',
-				language: 'bun',
-				content
-			}
+		// A brand-new script gets a draft_only backing row plus a DB draft.
+		expect(ScriptService.createScript).toHaveBeenCalledWith(
+			expect.objectContaining({
+				workspace: WORKSPACE,
+				requestBody: expect.objectContaining({ path: 'f/scripts/hello', draft_only: true })
+			})
 		)
+		expect(dbScriptDraft('f/scripts/hello')).toMatchObject({
+			path: 'f/scripts/hello',
+			summary: 'Hello script',
+			language: 'bun',
+			content
+		})
+		// Not written to localStorage when no live editor is open.
+		expect(UserDraft.get('script', 'f/scripts/hello', { workspace: WORKSPACE })).toBeUndefined()
 	})
 
 	it('applies path_prefix to local drafts before enforcing the result limit', async () => {
@@ -712,7 +857,7 @@ describe('global AI tools', () => {
 		expect(UserDraft.get('raw_app', 'u/admin/live_app', { workspace: WORKSPACE })).toBeUndefined()
 	})
 
-	it('discards a local draft without deleting the workspace item', async () => {
+	it('discards a draft-only script by deleting the whole item', async () => {
 		await callGlobalTool('write_script', {
 			path: 'f/scripts/discard-me',
 			summary: 'Temporary draft',
@@ -720,7 +865,7 @@ describe('global AI tools', () => {
 			content: 'export async function main() { return 1 }'
 		})
 
-		expect(UserDraft.get('script', 'f/scripts/discard-me', { workspace: WORKSPACE })).toBeDefined()
+		expect(dbScriptDraft('f/scripts/discard-me')).toBeDefined()
 
 		const raw = await callGlobalTool('discard_local_draft', {
 			type: 'script',
@@ -733,9 +878,46 @@ describe('global AI tools', () => {
 			path: 'f/scripts/discard-me'
 		})
 		expect(raw).toContain('The deployed workspace item was not changed')
-		expect(
-			UserDraft.get('script', 'f/scripts/discard-me', { workspace: WORKSPACE })
-		).toBeUndefined()
+		// The script only ever existed as a draft, so the whole item is removed.
+		expect(ScriptService.deleteScriptByPath).toHaveBeenCalledWith({
+			workspace: WORKSPACE,
+			path: 'f/scripts/discard-me'
+		})
+		expect(dbScriptDraft('f/scripts/discard-me')).toBeUndefined()
+	})
+
+	it('discards a draft on a deployed script by deleting only the draft row', async () => {
+		// Seed a deployed script (no draft_only) with a DB draft.
+		await ScriptService.createScript({
+			workspace: WORKSPACE,
+			requestBody: {
+				path: 'f/scripts/deployed-with-draft',
+				summary: 'Deployed',
+				content: 'export async function main() { return 0 }',
+				language: 'bun'
+			} as any
+		})
+		await DraftService.createDraft({
+			workspace: WORKSPACE,
+			requestBody: {
+				path: 'f/scripts/deployed-with-draft',
+				typ: 'script',
+				value: { path: 'f/scripts/deployed-with-draft', content: 'draft', language: 'bun' }
+			}
+		})
+
+		await callGlobalTool('discard_local_draft', {
+			type: 'script',
+			path: 'f/scripts/deployed-with-draft'
+		})
+
+		expect(DraftService.deleteDraft).toHaveBeenCalledWith({
+			workspace: WORKSPACE,
+			path: 'f/scripts/deployed-with-draft',
+			kind: 'script'
+		})
+		expect(ScriptService.deleteScriptByPath).not.toHaveBeenCalled()
+		expect(dbScriptDraft('f/scripts/deployed-with-draft')).toBeUndefined()
 	})
 
 	it('requires trigger_kind when discarding a trigger draft', async () => {
@@ -747,8 +929,7 @@ describe('global AI tools', () => {
 		).rejects.toThrow('trigger_kind is required')
 	})
 
-	it('preserves existing script metadata and seeds freshness on first script write', async () => {
-		vi.mocked(ScriptService.existsScriptByPath).mockResolvedValueOnce(true)
+	it('preserves existing script metadata when writing over an existing item', async () => {
 		vi.mocked(ScriptService.getScriptByPathWithDraft).mockResolvedValueOnce({
 			path: 'f/scripts/existing',
 			hash: 'deployed-hash',
@@ -767,6 +948,7 @@ describe('global AI tools', () => {
 				kind: 'script'
 			}
 		} as any)
+		vi.mocked(ScriptService.existsScriptByPath).mockResolvedValueOnce(true)
 
 		await callGlobalTool('write_script', {
 			path: 'f/scripts/existing',
@@ -775,9 +957,9 @@ describe('global AI tools', () => {
 			content: 'new content'
 		})
 
-		expect(
-			UserDraft.get<any>('script', 'f/scripts/existing', { workspace: WORKSPACE })
-		).toMatchObject({
+		// The DB draft keeps the existing item's lineage/metadata, applying only
+		// the new path/summary/content/language.
+		expect(dbScriptDraft('f/scripts/existing')).toMatchObject({
 			path: 'f/scripts/existing',
 			parent_hash: 'deployed-hash',
 			summary: 'new summary',
@@ -785,15 +967,11 @@ describe('global AI tools', () => {
 			content: 'new content',
 			language: 'bun'
 		})
-		expect(UserDraft.getMeta('script', 'f/scripts/existing', { workspace: WORKSPACE })).toEqual({
-			remoteRev: 'deployed-hash',
-			remoteDraftRev: '2026-05-22T10:00:00Z'
-		})
+		// Existing item -> no new draft_only row is created.
+		expect(ScriptService.createScript).not.toHaveBeenCalled()
 	})
 
-	it('preserves existing flow metadata and seeds freshness on first flow write', async () => {
-		vi.mocked(FlowService.existsFlowByPath).mockResolvedValueOnce(true)
-		vi.mocked(FlowService.getFlowLatestVersion).mockResolvedValueOnce({ id: 42 } as any)
+	it('preserves existing flow metadata when writing over an existing item', async () => {
 		vi.mocked(FlowService.getFlowByPathWithDraft).mockResolvedValueOnce({
 			path: 'f/flows/existing',
 			summary: 'deployed summary',
@@ -817,6 +995,7 @@ describe('global AI tools', () => {
 				extra_perms: {}
 			}
 		} as any)
+		vi.mocked(FlowService.existsFlowByPath).mockResolvedValueOnce(true)
 
 		await callGlobalTool('write_flow', {
 			path: 'f/flows/existing',
@@ -824,16 +1003,13 @@ describe('global AI tools', () => {
 			modules: JSON.stringify([{ id: 'step', value: { type: 'identity' } }])
 		})
 
-		expect(UserDraft.get<any>('flow', 'f/flows/existing', { workspace: WORKSPACE })).toMatchObject({
+		expect(dbFlowDraft('f/flows/existing')).toMatchObject({
 			path: 'f/flows/existing',
 			summary: 'new summary',
 			description: 'db draft description',
 			value: { modules: [{ id: 'step', value: { type: 'identity' } }] }
 		})
-		expect(UserDraft.getMeta('flow', 'f/flows/existing', { workspace: WORKSPACE })).toEqual({
-			remoteRev: 42,
-			remoteDraftRev: '2026-05-22T10:00:00Z'
-		})
+		expect(FlowService.createFlow).not.toHaveBeenCalled()
 	})
 
 	it('preserves editor schedule fields when writing over an existing schedule', async () => {
@@ -1489,9 +1665,10 @@ describe('global AI tools', () => {
 		expect(result).toContain('test logs')
 	})
 
-	it('test_run_script previews deployed script content when no local draft exists', async () => {
-		vi.mocked(ScriptService.getScriptByPath).mockResolvedValueOnce({
+	it('test_run_script previews deployed script content when no draft exists', async () => {
+		vi.mocked(ScriptService.getScriptByPathWithDraft).mockResolvedValueOnce({
 			path: 'f/scripts/deployed-test',
+			hash: 'deployed-hash',
 			summary: 'Deployed test script',
 			content: 'def main(name):\n    return name',
 			language: 'python3'
@@ -1504,7 +1681,7 @@ describe('global AI tools', () => {
 			})
 		)
 
-		expect(ScriptService.getScriptByPath).toHaveBeenCalledWith({
+		expect(ScriptService.getScriptByPathWithDraft).toHaveBeenCalledWith({
 			workspace: WORKSPACE,
 			path: 'f/scripts/deployed-test'
 		})
@@ -1545,13 +1722,17 @@ describe('global AI tools', () => {
 		})
 	})
 
-	it('test_run_flow previews deployed flow content when no local draft exists', async () => {
+	it('test_run_flow previews deployed flow content when no draft exists', async () => {
 		const modules = [{ id: 'deployed_start', value: { type: 'identity' } }]
-		vi.mocked(FlowService.getFlowByPath).mockResolvedValueOnce({
+		vi.mocked(FlowService.getFlowByPathWithDraft).mockResolvedValueOnce({
 			path: 'f/flows/deployed-test',
 			summary: 'Deployed test flow',
 			value: { modules },
-			schema: {}
+			schema: {},
+			edited_by: '',
+			edited_at: '',
+			archived: false,
+			extra_perms: {}
 		} as any)
 
 		await withCompletedTestJob(() =>
@@ -1561,7 +1742,7 @@ describe('global AI tools', () => {
 			})
 		)
 
-		expect(FlowService.getFlowByPath).toHaveBeenCalledWith({
+		expect(FlowService.getFlowByPathWithDraft).toHaveBeenCalledWith({
 			workspace: WORKSPACE,
 			path: 'f/flows/deployed-test'
 		})
@@ -1935,9 +2116,9 @@ describe('prepareGlobalSystemMessage', () => {
 		const message = prepareGlobalSystemMessage()
 		const content = message.content
 
-		expect(content).toContain('Draft tools create or update local drafts only')
+		expect(content).toContain('Draft tools create or update drafts only')
 		expect(content).toContain(
-			'Use discard_local_draft to remove an unsaved local draft, including the matching open editor draft'
+			'Use discard_local_draft to remove an unsaved draft, including the matching open editor draft'
 		)
 		expect(content).toContain(
 			'After creating or editing a script or flow draft, run test_run_script, test_run_flow, or test_run_step'
@@ -1954,7 +2135,7 @@ describe('prepareGlobalSystemMessage', () => {
 		const deleteItem = getGlobalTool('delete_workspace_item')
 
 		expect(discard.def.function.description).toBe(
-			'Discard a local draft only. Does not mutate deployed workspace items, but clears the matching open editor draft if one is mounted.'
+			'Discard a draft only. Does not mutate deployed workspace items, but clears the matching open editor draft if one is mounted. For scripts and flows this deletes the workspace draft (and the whole item if it only ever existed as a draft).'
 		)
 		expect(deleteItem.def.function.description).toBe(
 			'Delete a deployed workspace item. Mutates the workspace.'

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -1048,6 +1048,48 @@ describe('global AI tools', () => {
 		expect(invalidateWorkspaceDrafts).toHaveBeenCalledWith(WORKSPACE)
 	})
 
+	it("deploys the draft's metadata, not the deployed item's", async () => {
+		// Deployed version with one set of metadata.
+		await ScriptService.createScript({
+			workspace: WORKSPACE,
+			requestBody: {
+				path: 'f/scripts/meta-deploy',
+				summary: 'deployed',
+				content: 'export async function main() { return 0 }',
+				language: 'bun',
+				concurrent_limit: 1,
+				tag: 'old-tag'
+			} as any
+		})
+		// A DB draft (e.g. saved from the editor) with DIFFERENT metadata + new value.
+		await DraftService.createDraft({
+			workspace: WORKSPACE,
+			requestBody: {
+				path: 'f/scripts/meta-deploy',
+				typ: 'script',
+				value: {
+					path: 'f/scripts/meta-deploy',
+					summary: 'drafted',
+					content: 'export async function main() { return 1 }',
+					language: 'bun',
+					concurrent_limit: 9,
+					tag: 'new-tag'
+				}
+			}
+		})
+
+		await callGlobalTool('deploy_workspace_item', { type: 'script', path: 'f/scripts/meta-deploy' })
+
+		const createCalls = vi.mocked(ScriptService.createScript).mock.calls
+		const deployBody = (createCalls[createCalls.length - 1]?.[0] as any).requestBody
+		expect(deployBody).toMatchObject({
+			path: 'f/scripts/meta-deploy',
+			content: 'export async function main() { return 1 }',
+			concurrent_limit: 9,
+			tag: 'new-tag'
+		})
+	})
+
 	it('preserves existing script metadata when writing over an existing item', async () => {
 		vi.mocked(ScriptService.getScriptByPathWithDraft).mockResolvedValueOnce({
 			path: 'f/scripts/existing',

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -1,6 +1,7 @@
 import {
 	AppService,
 	AzureTriggerService,
+	DraftService,
 	FlowService,
 	GcpTriggerService,
 	HttpTriggerService,
@@ -448,7 +449,7 @@ const testRunScriptSchema = z.object({
 const testRunScriptToolDef = createToolDef(
 	testRunScriptSchema,
 	'test_run_script',
-	'Execute a preview-style test run of a script by path, preferring local draft content when it exists.',
+	'Execute a preview-style test run of a script by path, preferring draft content when it exists.',
 	{ strict: false }
 )
 
@@ -460,7 +461,7 @@ const testRunFlowSchema = z.object({
 const testRunFlowToolDef = createToolDef(
 	testRunFlowSchema,
 	'test_run_flow',
-	'Execute a preview-style test run of a flow by path, preferring local draft content when it exists.',
+	'Execute a preview-style test run of a flow by path, preferring draft content when it exists.',
 	{ strict: false }
 )
 
@@ -473,7 +474,7 @@ const testRunStepSchema = z.object({
 const testRunStepToolDef = createToolDef(
 	testRunStepSchema,
 	'test_run_step',
-	'Execute a test run of one step in a flow by path, preferring local draft flow/script content when it exists.',
+	'Execute a test run of one step in a flow by path, preferring draft flow/script content when it exists.',
 	{ strict: false }
 )
 
@@ -611,7 +612,7 @@ const buildGlobalSystemPrompt = (
 
 The current user's workspace username is "${username}".
 
-Use tools to inspect workspace items and create local drafts for scripts, flows, schedules, triggers, resources, variables, and raw apps.
+Use tools to inspect workspace items and create drafts for scripts, flows, schedules, triggers, resources, variables, and raw apps.
 
 Path conventions:
 - Every workspace path has exactly three segments and starts with one of two namespaces:
@@ -622,15 +623,15 @@ Path conventions:
 - Only use an \`f/<folder>/<name>\` path when the user explicitly named the folder or you confirmed it exists.
 
 Rules:
-- Draft tools create or update local drafts only; they do not deploy or mutate deployed workspace items.
+- Draft tools create or update drafts only; they do not deploy or mutate deployed workspace items. Script and flow drafts are saved to the workspace (visible in the Drafts UI); other types are browser-local drafts.
 - Use list_workspace_items to find items and read_workspace_item before changing an existing item. For triggers, pass trigger_kind.
 - If the user message includes an ACTIVE EDITOR section, treat it as the currently open item and use it for references like "this", "current", or "open editor".
-- Use deploy_workspace_item only after the user explicitly asks to deploy. It persists a local draft to the workspace.
-- Use discard_local_draft to remove an unsaved local draft, including the matching open editor draft. Use delete_workspace_item only to delete a deployed workspace item.
+- Use deploy_workspace_item only after the user explicitly asks to deploy. It persists a draft to the workspace.
+- Use discard_local_draft to remove an unsaved draft, including the matching open editor draft. Use delete_workspace_item only to delete a deployed workspace item.
 - Variable values are never readable. For secrets, create a secret variable and reference it from resources as "$var:path/to/variable".
 - Use search_resource_types before write_resource.
 - Use get_instructions before writing scripts, flows, resources, or apps. For scripts, pass the target language.
-- After creating or editing a script or flow draft, run test_run_script, test_run_flow, or test_run_step with representative args before reporting that it works. These tools prefer local drafts, so testing does not require deployment.
+- After creating or editing a script or flow draft, run test_run_script, test_run_flow, or test_run_step with representative args before reporting that it works. These tools prefer drafts, so testing does not require deployment.
 - Use list_runs to find recent runs (optionally filtered by path, creator, label, or status), then get_job_logs with a returned id to inspect a specific run's logs — without starting a new test run.
 - When a required decision is ambiguous, use askUserQuestion with two to ten clear proposed answer strings instead of guessing. The user can also type a custom answer when none of the proposed answers fit.
 - Keep context targeted.${previewTools
@@ -1215,12 +1216,16 @@ async function readWorkspaceItem(
 		case 'script': {
 			// Prefer the DB draft (newer than the deployed version) when one exists.
 			const script = await ScriptService.getScriptByPathWithDraft({ workspace, path })
-			return scriptToItem(script.draft ?? script, true)
+			const item = scriptToItem(script.draft ?? script, true)
+			item.isDraft = !!script.draft
+			return item
 		}
 		case 'flow': {
 			// Prefer the DB draft (newer than the deployed version) when one exists.
 			const flow = await FlowService.getFlowByPathWithDraft({ workspace, path })
-			return flowToItem(flow.draft ?? flow, true)
+			const item = flowToItem(flow.draft ?? flow, true)
+			item.isDraft = !!flow.draft
+			return item
 		}
 		case 'schedule':
 			return scheduleToItem(await ScheduleService.getSchedule({ workspace, path }), true)
@@ -1276,7 +1281,11 @@ async function listWorkspaceItems(
 			includeDraftOnly: true,
 			withoutDescription: true
 		})
-		for (const script of scripts) items.push(scriptToItem(script, false))
+		for (const script of scripts) {
+			const item = scriptToItem(script, false)
+			item.isDraft = script.draft_only === true || script.has_draft === true
+			items.push(item)
+		}
 	}
 
 	if (types.includes('flow')) {
@@ -1287,7 +1296,11 @@ async function listWorkspaceItems(
 			includeDraftOnly: true,
 			withoutDescription: true
 		})
-		for (const flow of flows) items.push(flowToItem(flow, false))
+		for (const flow of flows) {
+			const item = flowToItem(flow, false)
+			item.isDraft = flow.draft_only === true || flow.has_draft === true
+			items.push(item)
+		}
 	}
 
 	if (types.includes('schedule')) {
@@ -1375,7 +1388,7 @@ function getFlowInstructions(): string {
 - \`read_workspace_item\` and \`patch_flow_json\` operate on a **compact view** of the flow: every rawscript module's \`value.content\` is replaced with the placeholder \`"inline_script.<moduleId>"\` so inline script bodies don't bloat tool I/O. Schema, groups, preprocessor_module and failure_module are all shown in this view.
 - Inline rawscript content is **not** part of the JSON \`patch_flow_json\` sees. Edits to inline bodies happen via dedicated tools:
   - \`read_flow_module_code(path, module_id)\` — returns the raw inline script content for one module.
-  - \`set_flow_module_code(path, module_id, code)\` — overwrites that module's inline script content; saves to the local draft.
+  - \`set_flow_module_code(path, module_id, code)\` — overwrites that module's inline script content; saves to the draft.
 - Use \`patch_flow_json\` for *structural* edits: module ids, paths, input_transforms, branch arrangement, summaries, preprocessor/failure swaps, schema/groups. Use \`set_flow_module_code\` for changes inside a specific rawscript body.
 - \`write_flow\` is for full overwrites / create-from-scratch. Its \`modules\`, \`preprocessor_module\`, and \`failure_module\` arguments use **non-compact** flow modules (rawscript content is the actual code, not a placeholder).
 
@@ -1527,7 +1540,7 @@ export const globalTools: Tool<{}>[] = [
 		def: createToolDef(
 			listWorkspaceItemsSchema,
 			'list_workspace_items',
-			'List workspace items and local drafts. Returns metadata only.'
+			'List workspace items and drafts. Returns metadata only.'
 		),
 		fn: async ({ args, workspace, toolId, toolCallbacks }) => {
 			const parsed = listWorkspaceItemsSchema.parse(args)
@@ -1546,7 +1559,13 @@ export const globalTools: Tool<{}>[] = [
 				byKey.set(getWorkspaceItemKey(item.type, item.path, item.triggerKind), item)
 			}
 
+			// Script/flow drafts are DB-backed and already surface through the
+			// list endpoints above (includeDraftOnly), so their stale localStorage
+			// entries are NOT merged. We still merge apps (localStorage-backed) and
+			// any live editor buffer (the live-editor special case wins over the DB
+			// draft, even in listings).
 			for (const draft of listGlobalDrafts(workspace)) {
+				if (draft.type !== 'app' && draft.isLiveDraft !== true) continue
 				if (!types.includes(draft.type)) continue
 				if (parsed.path_prefix && !draft.path.startsWith(parsed.path_prefix)) continue
 				byKey.set(getWorkspaceItemKey(draft.type, draft.path, draft.triggerKind), {
@@ -1569,7 +1588,7 @@ export const globalTools: Tool<{}>[] = [
 		def: createToolDef(
 			readWorkspaceItemSchema,
 			'read_workspace_item',
-			'Read one workspace item or local draft.'
+			'Read one workspace item or draft.'
 		),
 		fn: async ({ args, workspace, toolId, toolCallbacks }) => {
 			const parsed = readWorkspaceItemSchema.parse(args)
@@ -1578,10 +1597,17 @@ export const globalTools: Tool<{}>[] = [
 				toolCallbacks.setToolStatus(toolId, { content: message, error: message })
 				return JSON.stringify({ success: false, error: message })
 			}
-			const draft = getGlobalDraft(workspace, parsed.type, parsed.path, parsed.trigger_kind)
+			// Scripts/flows are DB-backed: only short-circuit to localStorage when a
+			// live editor is mounted (its buffer wins). Otherwise fall through to
+			// readWorkspaceItem, which already prefers the DB draft. Apps and the
+			// other types keep returning their localStorage draft first.
+			const draft =
+				parsed.type === 'script' || parsed.type === 'flow'
+					? liveDraftItem(workspace, parsed.type, parsed.path)
+					: getGlobalDraft(workspace, parsed.type, parsed.path, parsed.trigger_kind)
 			if (draft) {
 				toolCallbacks.setToolStatus(toolId, {
-					content: `Read local draft ${parsed.type} "${parsed.path}"`
+					content: `Read draft ${parsed.type} "${parsed.path}"`
 				})
 				return JSON.stringify(serializeWorkspaceItemForRead(draft), null, 2)
 			}
@@ -1598,7 +1624,7 @@ export const globalTools: Tool<{}>[] = [
 		def: createToolDef(
 			writeScriptSchema,
 			'write_script',
-			'Create or overwrite a local draft script.'
+			'Create or overwrite a draft script.'
 		),
 		showDetails: true,
 		streamArguments: true,
@@ -1609,7 +1635,7 @@ export const globalTools: Tool<{}>[] = [
 		}
 	},
 	{
-		def: createToolDef(writeFlowSchema, 'write_flow', 'Create or overwrite a local draft flow.'),
+		def: createToolDef(writeFlowSchema, 'write_flow', 'Create or overwrite a draft flow.'),
 		showDetails: true,
 		streamArguments: true,
 		showFade: true,
@@ -1669,7 +1695,7 @@ export const globalTools: Tool<{}>[] = [
 		def: createToolDef(
 			editScriptSchema,
 			'edit_script',
-			'Find/replace exact text in a script and save a local draft.'
+			'Find/replace exact text in a script and save a draft.'
 		),
 		showDetails: true,
 		streamArguments: true,
@@ -1683,7 +1709,7 @@ export const globalTools: Tool<{}>[] = [
 		def: createToolDef(
 			patchFlowJsonSchema,
 			'patch_flow_json',
-			'Find/replace exact text in compact flow JSON and save a local draft.'
+			'Find/replace exact text in compact flow JSON and save a draft.'
 		),
 		showDetails: true,
 		streamArguments: true,
@@ -1789,13 +1815,13 @@ export const globalTools: Tool<{}>[] = [
 		def: createToolDef(
 			deployWorkspaceItemSchema,
 			'deploy_workspace_item',
-			'Deploy a local draft to the workspace. Mutates the workspace.',
+			'Deploy a draft to the workspace. Mutates the workspace.',
 			{ strict: false }
 		),
 		showDetails: true,
 		showFade: true,
 		requiresConfirmation: true,
-		confirmationMessage: 'Deploy local draft to workspace',
+		confirmationMessage: 'Deploy draft to workspace',
 		fn: async (ctx) => {
 			const parsed = deployWorkspaceItemSchema.parse(ctx.args)
 			return deployDraft(parsed, { ...ctx, sessionId: sessionIdFromCtx(ctx) })
@@ -1820,12 +1846,12 @@ export const globalTools: Tool<{}>[] = [
 		def: createToolDef(
 			discardLocalDraftSchema,
 			'discard_local_draft',
-			'Discard a local draft only. Does not mutate deployed workspace items, but clears the matching open editor draft if one is mounted.'
+			'Discard a draft only. Does not mutate deployed workspace items, but clears the matching open editor draft if one is mounted. For scripts and flows this deletes the workspace draft (and the whole item if it only ever existed as a draft).'
 		),
 		showDetails: true,
 		showFade: true,
 		requiresConfirmation: true,
-		confirmationMessage: 'Discard local draft',
+		confirmationMessage: 'Discard draft',
 		fn: async (ctx) => {
 			const parsed = discardLocalDraftSchema.parse(ctx.args)
 			return discardLocalDraft(parsed, ctx)
@@ -1905,7 +1931,7 @@ export const globalTools: Tool<{}>[] = [
 		def: createToolDef(
 			setFlowModuleCodeSchema,
 			'set_flow_module_code',
-			'Overwrite inline script code in one flow module and save a local draft.'
+			'Overwrite inline script code in one flow module and save a draft.'
 		),
 		showDetails: true,
 		streamArguments: true,
@@ -2257,7 +2283,7 @@ function buildVariableDeployRequestBody(
 
 function startDraftWrite(ctx: WriteDraftCtx, type: WorkspaceItemType, path: string): void {
 	ctx.toolCallbacks.setToolStatus(ctx.toolId, {
-		content: `Saving ${type} "${path}" to local storage…`
+		content: `Saving ${type} "${path}" draft…`
 	})
 }
 
@@ -2281,19 +2307,145 @@ function finishDraftWrite(stored: WorkspaceItem, existed: boolean, ctx: WriteDra
 			? serializeWorkspaceItemForRead(stored)
 			: stored
 
+	// Scripts and flows persist to the workspace DB draft; the remaining item
+	// types are still browser-only localStorage drafts.
+	const dbBacked = stored.type === 'script' || stored.type === 'flow'
+	const where = dbBacked ? 'as a workspace draft' : 'as a browser-only local draft'
+
 	ctx.toolCallbacks.setToolStatus(ctx.toolId, {
-		content: `${verb} ${stored.type} "${stored.path}" in local storage`,
-		result: `Saved to local storage`
+		content: `${verb} ${stored.type} "${stored.path}" ${where}`,
+		result: 'Saved draft'
 	})
 	return JSON.stringify(
 		{
 			success: true,
-			message: `${verb} ${stored.type} "${stored.path}" in local storage (a browser-only local draft, not a workspace draft). It was not deployed.`,
+			message: `${verb} ${stored.type} "${stored.path}" ${where} (not deployed).`,
 			item: serializedItem
 		},
 		null,
 		2
 	)
+}
+
+// ============= DB-backed drafts (scripts & flows) =============
+//
+// Scripts and flows persist their chat drafts to the workspace DB (the `draft`
+// table) so they survive across sessions/devices and show up in Windmill's
+// normal Drafts UI. localStorage stays in play ONLY as the bridge to an open
+// live editor: when one is mounted for the item, reads/writes go through it so
+// the editor reflects the change live. Apps and the remaining item types are
+// unchanged (still localStorage via `userDraftAdapter`).
+
+type DbDraftKind = Extract<WorkspaceItemType, 'script' | 'flow'>
+
+// Returns the localStorage draft ONLY when a live editor is currently mounted
+// for the item (i.e. its draft is the live editor's working buffer). A stale,
+// non-live localStorage draft is ignored so the DB draft stays authoritative.
+function liveDraftItem(
+	workspace: string,
+	type: WorkspaceItemType,
+	path: string,
+	triggerKind?: TriggerKind
+): WorkspaceItem | undefined {
+	const draft = getGlobalDraft(workspace, type, path, triggerKind)
+	return draft?.isLiveDraft ? draft : undefined
+}
+
+// The current chat draft for a script/flow: the live editor buffer if one is
+// open, else the DB draft (`.draft`). `undefined` when no draft exists (or the
+// item doesn't exist at all).
+async function loadDbDraftItem(
+	workspace: string,
+	type: DbDraftKind,
+	path: string
+): Promise<WorkspaceItem | undefined> {
+	const live = liveDraftItem(workspace, type, path)
+	if (live) return live
+	try {
+		if (type === 'script') {
+			const script = await ScriptService.getScriptByPathWithDraft({ workspace, path })
+			if (!script.draft) return undefined
+			const item = scriptToItem(script.draft as NewScript, true)
+			item.isDraft = true
+			return item
+		}
+		const flow = await FlowService.getFlowByPathWithDraft({ workspace, path })
+		if (!flow.draft) return undefined
+		const item = flowToItem(flow.draft as Flow, true)
+		item.isDraft = true
+		return item
+	} catch {
+		// Item doesn't exist (never deployed and no draft row).
+		return undefined
+	}
+}
+
+// Persist a script DB draft, creating the backing `draft_only` row first when
+// the script does not exist yet (mirrors ScriptBuilder: the row is needed so
+// `createDraft` passes the writer check on `f/` paths and so the draft is
+// discoverable via list/getWithDraft).
+async function saveScriptDbDraft(workspace: string, path: string, draft: NewScript): Promise<void> {
+	if (!(await ScriptService.existsScriptByPath({ workspace, path }))) {
+		await ScriptService.createScript({
+			workspace,
+			requestBody: { ...draft, path, draft_only: true }
+		})
+	}
+	await DraftService.createDraft({ workspace, requestBody: { path, typ: 'script', value: draft } })
+}
+
+// Persist a flow DB draft, creating the backing `draft_only` row first when the
+// flow does not exist yet (mirrors FlowBuilder).
+async function saveFlowDbDraft(workspace: string, path: string, draft: Flow): Promise<void> {
+	if (!(await FlowService.existsFlowByPath({ workspace, path }))) {
+		await FlowService.createFlow({
+			workspace,
+			requestBody: {
+				path,
+				summary: draft.summary ?? '',
+				description: draft.description ?? '',
+				value: draft.value,
+				schema: draft.schema ?? emptySchema(),
+				draft_only: true
+			}
+		})
+	}
+	await DraftService.createDraft({ workspace, requestBody: { path, typ: 'flow', value: draft } })
+}
+
+// Delete a script/flow DB draft. If the item exists ONLY as a draft
+// (`draft_only`) it has no deployed version to fall back to, so delete the whole
+// item; otherwise delete just the draft row. Also resets any open editor buffer.
+async function deleteScriptFlowDbDraft(
+	workspace: string,
+	type: DbDraftKind,
+	path: string
+): Promise<void> {
+	let draftOnly = false
+	try {
+		if (type === 'script') {
+			const script = await ScriptService.getScriptByPathWithDraft({ workspace, path })
+			draftOnly = script.draft_only === true
+		} else {
+			const flow = await FlowService.getFlowByPathWithDraft({ workspace, path })
+			draftOnly = flow.draft_only === true
+		}
+	} catch {
+		// No backing row; nothing to delete server-side beyond the editor buffer.
+	}
+
+	if (draftOnly) {
+		if (type === 'script') {
+			await ScriptService.deleteScriptByPath({ workspace, path })
+		} else {
+			await FlowService.deleteFlowByPath({ workspace, path })
+		}
+	} else {
+		await DraftService.deleteDraft({ workspace, path, kind: type })
+	}
+
+	// Reset any open live editor (and clear a stale localStorage buffer).
+	deleteGlobalDraft(workspace, type, path)
 }
 
 async function writeScriptDraft(
@@ -2303,61 +2455,54 @@ async function writeScriptDraft(
 	const { workspace } = ctx
 	startDraftWrite(ctx, 'script', args.path)
 	const storagePath = getGlobalDraftStoragePath(workspace, 'script', args.path)
+	const liveOpen = !!liveDraftItem(workspace, 'script', args.path)
 
-	const existingDraft = UserDraft.get<NewScript>('script', storagePath, { workspace })
-	const backendExists = existingDraft
-		? false
-		: await ScriptService.existsScriptByPath({ workspace, path: args.path })
-
-	if (existingDraft) {
-		const draft: NewScript = {
-			...structuredClone(existingDraft),
-			path: args.path,
-			summary: args.summary ?? existingDraft.summary,
-			content: args.content,
-			language: args.language
+	// Resolve the base to merge edits into (preserving fields the AI never sees):
+	// the live editor buffer if open, else the DB draft, else the deployed script.
+	let base: NewScript | undefined
+	let existed = false
+	if (liveOpen) {
+		base = UserDraft.get<NewScript>('script', storagePath, { workspace })
+		existed = base !== undefined
+	}
+	if (!base) {
+		try {
+			const existing = await ScriptService.getScriptByPathWithDraft({ workspace, path: args.path })
+			existed = true
+			const { draft: dbDraft, draft_created_at: _c, hash, ...deployed } = existing
+			// Link lineage to the latest deployed hash, like the editor does.
+			base = { ...(dbDraft ?? deployed), parent_hash: hash } as NewScript
+		} catch {
+			existed = false
 		}
-		UserDraft.save('script', storagePath, draft, { workspace })
-	} else if (backendExists) {
-		const existing = await ScriptService.getScriptByPathWithDraft({
-			workspace,
-			path: args.path
-		})
-		const base = (existing.draft ?? existing) as NewScript
-		const draft: NewScript = {
-			...structuredClone(base),
-			parent_hash: existing.hash,
-			path: args.path,
-			summary: args.summary ?? base.summary,
-			content: args.content,
-			language: args.language
-		}
-		UserDraft.setDraftAndMeta(
-			'script',
-			storagePath,
-			draft,
-			{ remoteRev: existing.hash, remoteDraftRev: existing.draft_created_at },
-			{ workspace }
-		)
-	} else {
-		const draft: NewScript = {
-			path: args.path,
-			summary: args.summary ?? '',
-			description: '',
-			content: args.content,
-			schema: emptySchema(),
-			is_template: false,
-			language: args.language,
-			kind: 'script'
-		}
-		UserDraft.save('script', storagePath, draft, { workspace })
 	}
 
-	return finishDraftWrite(
-		getRequiredGlobalDraft(workspace, 'script', args.path),
-		existingDraft !== undefined || backendExists,
-		ctx
-	)
+	const draft: NewScript = base
+		? {
+				...structuredClone(base),
+				path: args.path,
+				summary: args.summary ?? base.summary,
+				content: args.content,
+				language: args.language
+			}
+		: {
+				path: args.path,
+				summary: args.summary ?? '',
+				description: '',
+				content: args.content,
+				schema: emptySchema(),
+				is_template: false,
+				language: args.language,
+				kind: 'script'
+			}
+
+	await saveScriptDbDraft(workspace, args.path, draft)
+	// Mirror into the open editor's buffer so it reflects the change live.
+	if (liveOpen) UserDraft.save('script', storagePath, draft, { workspace })
+
+	const item = scriptToItem(draft, true)
+	item.isDraft = true
+	return finishDraftWrite(item, existed, ctx)
 }
 
 async function writeFlowDraft(
@@ -2367,6 +2512,7 @@ async function writeFlowDraft(
 	const { workspace } = ctx
 	startDraftWrite(ctx, 'flow', args.path)
 	const storagePath = getGlobalDraftStoragePath(workspace, 'flow', args.path)
+	const liveOpen = !!liveDraftItem(workspace, 'flow', args.path)
 
 	const draftValue = args.flow
 	const value = structuredClone(draftValue.value)
@@ -2374,59 +2520,49 @@ async function writeFlowDraft(
 		value.groups = structuredClone(draftValue.groups)
 	}
 
-	const existingDraft = UserDraft.get<Flow>('flow', storagePath, { workspace })
-	const backendExists = existingDraft
-		? false
-		: await FlowService.existsFlowByPath({ workspace, path: args.path })
-
-	if (existingDraft) {
-		const draft: Flow = {
-			...structuredClone(existingDraft),
-			path: args.path,
-			summary: args.summary ?? existingDraft.summary,
-			value,
-			schema: draftValue.schema ?? existingDraft.schema
+	let base: Flow | undefined
+	let existed = false
+	if (liveOpen) {
+		base = UserDraft.get<Flow>('flow', storagePath, { workspace })
+		existed = base !== undefined
+	}
+	if (!base) {
+		try {
+			const existing = await FlowService.getFlowByPathWithDraft({ workspace, path: args.path })
+			existed = true
+			const { draft: dbDraft, draft_created_at: _c, ...deployed } = existing
+			base = dbDraft ?? (deployed as Flow)
+		} catch {
+			existed = false
 		}
-		UserDraft.save('flow', storagePath, draft, { workspace })
-	} else if (backendExists) {
-		const [existing, latestVersion] = await Promise.all([
-			FlowService.getFlowByPathWithDraft({ workspace, path: args.path }),
-			FlowService.getFlowLatestVersion({ workspace, path: args.path })
-		])
-		const base = (existing.draft ?? existing) as Flow
-		const draft: Flow = {
-			...structuredClone(base),
-			path: args.path,
-			summary: args.summary ?? base.summary,
-			value,
-			schema: draftValue.schema ?? base.schema
-		}
-		UserDraft.setDraftAndMeta(
-			'flow',
-			storagePath,
-			draft,
-			{ remoteRev: latestVersion.id, remoteDraftRev: existing.draft_created_at },
-			{ workspace }
-		)
-	} else {
-		const draft: Flow = {
-			path: args.path,
-			summary: args.summary ?? '',
-			value,
-			schema: draftValue.schema ?? emptySchema(),
-			edited_by: '',
-			edited_at: '',
-			archived: false,
-			extra_perms: {}
-		}
-		UserDraft.save('flow', storagePath, draft, { workspace })
 	}
 
-	return finishDraftWrite(
-		getRequiredGlobalDraft(workspace, 'flow', args.path),
-		existingDraft !== undefined || backendExists,
-		ctx
-	)
+	const draft: Flow = base
+		? {
+				...structuredClone(base),
+				path: args.path,
+				summary: args.summary ?? base.summary,
+				value,
+				schema: draftValue.schema ?? base.schema
+			}
+		: {
+				path: args.path,
+				summary: args.summary ?? '',
+				value,
+				schema: draftValue.schema ?? emptySchema(),
+				edited_by: '',
+				edited_at: '',
+				archived: false,
+				extra_perms: {}
+			}
+
+	await saveFlowDbDraft(workspace, args.path, draft)
+	// Mirror into the open editor's buffer so it reflects the change live.
+	if (liveOpen) UserDraft.save('flow', storagePath, draft, { workspace })
+
+	const item = flowToItem(draft, true)
+	item.isDraft = true
+	return finishDraftWrite(item, existed, ctx)
 }
 
 async function writeScheduleDraft(args: NewSchedule, ctx: WriteDraftCtx): Promise<string> {
@@ -2565,15 +2701,17 @@ async function loadScriptForEdit(
 	path: string,
 	workspace: string
 ): Promise<{ content: string; language: ScriptLang; summary?: string }> {
-	const draft = getGlobalDraft(workspace, 'script', path)
-	if (draft) {
-		if (typeof draft.value !== 'string' || !draft.language) {
+	// Live editor buffer first; otherwise the DB draft, falling back to deployed.
+	const live = liveDraftItem(workspace, 'script', path)
+	if (live) {
+		if (typeof live.value !== 'string' || !live.language) {
 			throw new Error(`Draft script "${path}" is missing content or language.`)
 		}
-		return { content: draft.value, language: draft.language, summary: draft.summary }
+		return { content: live.value, language: live.language, summary: live.summary }
 	}
-	const script = await ScriptService.getScriptByPath({ workspace, path })
-	return { content: script.content, language: script.language, summary: script.summary }
+	const script = await ScriptService.getScriptByPathWithDraft({ workspace, path })
+	const src = (script.draft ?? script) as NewScript
+	return { content: src.content, language: src.language, summary: src.summary }
 }
 
 async function editScript(
@@ -2600,17 +2738,19 @@ async function loadFlowDraftValue(
 	path: string,
 	workspace: string
 ): Promise<{ flow: FlowDraftValue; summary?: string }> {
-	const draft = getGlobalDraft(workspace, 'flow', path)
-	if (draft) {
-		if (draft.value === undefined || typeof draft.value === 'string') {
+	// Live editor buffer first; otherwise the DB draft, falling back to deployed.
+	const live = liveDraftItem(workspace, 'flow', path)
+	if (live) {
+		if (live.value === undefined || typeof live.value === 'string') {
 			throw new Error(`Draft flow "${path}" has no value.`)
 		}
-		return { flow: draft.value as FlowDraftValue, summary: draft.summary }
+		return { flow: live.value as FlowDraftValue, summary: live.summary }
 	}
-	const flow = await FlowService.getFlowByPath({ workspace, path })
+	const flow = await FlowService.getFlowByPathWithDraft({ workspace, path })
+	const src = (flow.draft ?? flow) as Flow
 	return {
-		flow: { value: flow.value, schema: flow.schema, groups: flow.value.groups ?? null },
-		summary: flow.summary
+		flow: { value: src.value, schema: src.schema, groups: src.value.groups ?? null },
+		summary: src.summary
 	}
 }
 
@@ -2725,12 +2865,15 @@ async function loadScriptForFlowStep(
 	moduleValue: { path: string; hash?: string },
 	workspace: string
 ): Promise<{ content: string; language: ScriptLang }> {
-	const draft = getGlobalDraft(workspace, 'script', moduleValue.path)
-	if (draft) {
-		if (typeof draft.value !== 'string' || !draft.language) {
+	// A live editor buffer or a DB draft at this path takes precedence over the
+	// pinned hash (matches the prior draft-first behavior); else use the hash or
+	// the deployed script.
+	const stepDraft = await loadDbDraftItem(workspace, 'script', moduleValue.path)
+	if (stepDraft) {
+		if (typeof stepDraft.value !== 'string' || !stepDraft.language) {
 			throw new Error(`Draft script "${moduleValue.path}" is missing content or language.`)
 		}
-		return { content: draft.value, language: draft.language }
+		return { content: stepDraft.value, language: stepDraft.language }
 	}
 
 	const script = moduleValue.hash
@@ -2743,7 +2886,8 @@ async function loadDraftFlowPreviewValue(
 	path: string,
 	workspace: string
 ): Promise<FlowValue | undefined> {
-	if (!getGlobalDraft(workspace, 'flow', path)) {
+	// Only override the deployed flow when a draft (live editor or DB) exists.
+	if (!(await loadDbDraftItem(workspace, 'flow', path))) {
 		return undefined
 	}
 	const nestedFlow = await loadFlowDraftValue(path, workspace)
@@ -3234,21 +3378,28 @@ async function discardLocalDraft(
 		throw new Error('trigger_kind is required when discarding a trigger draft.')
 	}
 
-	const draft = getGlobalDraft(workspace, type, path, triggerKind)
+	const draft =
+		type === 'script' || type === 'flow'
+			? await loadDbDraftItem(workspace, type, path)
+			: getGlobalDraft(workspace, type, path, triggerKind)
 	if (!draft) {
-		throw new Error(`No local draft found for ${type} "${path}".`)
+		throw new Error(`No draft found for ${type} "${path}".`)
 	}
 
-	deleteGlobalDraft(workspace, type, path, triggerKind)
+	if (type === 'script' || type === 'flow') {
+		await deleteScriptFlowDbDraft(workspace, type, path)
+	} else {
+		deleteGlobalDraft(workspace, type, path, triggerKind)
+	}
 
 	toolCallbacks.setToolStatus(toolId, {
-		content: `Discarded ${type} "${path}" from local storage`,
-		result: 'Discarded from local storage'
+		content: `Discarded ${type} "${path}" draft`,
+		result: 'Discarded draft'
 	})
 	return JSON.stringify(
 		{
 			success: true,
-			message: `Discarded the local-storage draft for ${type} "${path}". The deployed workspace item was not changed.`,
+			message: `Discarded the draft for ${type} "${path}". The deployed workspace item was not changed.`,
 			type,
 			path,
 			triggerKind
@@ -3274,9 +3425,12 @@ async function deployDraft(
 		throw new Error('trigger_kind is required when deploying a trigger.')
 	}
 
-	const draft = getGlobalDraft(workspace, type, path, triggerKind)
+	const draft =
+		type === 'script' || type === 'flow'
+			? await loadDbDraftItem(workspace, type, path)
+			: getGlobalDraft(workspace, type, path, triggerKind)
 	if (!draft) {
-		throw new Error(`No local draft found for ${type} "${path}".`)
+		throw new Error(`No draft found for ${type} "${path}".`)
 	}
 	if (draft.value === undefined) {
 		throw new Error(`Draft ${type} "${path}" has no value to deploy.`)
@@ -3475,7 +3629,7 @@ async function deployDraft(
 	return JSON.stringify(
 		{
 			success: true,
-			message: `Deployed local draft ${type} "${path}" to the workspace. Draft removed from the local draft system.`,
+			message: `Deployed draft ${type} "${path}" to the workspace. The draft was removed.`,
 			type,
 			path,
 			triggerKind

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -2339,6 +2339,13 @@ function finishDraftWrite(stored: WorkspaceItem, existed: boolean, ctx: WriteDra
 
 type DbDraftKind = Extract<WorkspaceItemType, 'script' | 'flow'>
 
+// A 404 from getXByPathWithDraft means the item genuinely doesn't exist (no
+// deployed version and no draft). Any other error (network, 403, 5xx) is real
+// and must surface rather than be silently swallowed as "no draft".
+function isNotFoundError(e: unknown): boolean {
+	return (e as { status?: number } | undefined)?.status === 404
+}
+
 // Returns the localStorage draft ONLY when a live editor is currently mounted
 // for the item (i.e. its draft is the live editor's working buffer). A stale,
 // non-live localStorage draft is ignored so the DB draft stays authoritative.
@@ -2378,9 +2385,9 @@ async function loadDbDraftItem(
 		const item = flowToItem(src as Flow, true)
 		item.isDraft = true
 		return item
-	} catch {
-		// Item doesn't exist (never deployed and no draft row).
-		return undefined
+	} catch (e) {
+		if (isNotFoundError(e)) return undefined // never deployed and no draft row
+		throw e
 	}
 }
 
@@ -2450,8 +2457,10 @@ async function deleteScriptFlowDbDraft(
 			const flow = await FlowService.getFlowByPathWithDraft({ workspace, path })
 			draftOnly = flow.draft_only === true
 		}
-	} catch {
-		// No backing row; nothing to delete server-side beyond the editor buffer.
+	} catch (e) {
+		// 404 = no backing row; nothing to delete server-side beyond the editor
+		// buffer. Any other error is real and should surface.
+		if (!isNotFoundError(e)) throw e
 	}
 
 	if (draftOnly) {

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -76,6 +76,7 @@ import {
 import type { ContextElement } from '../context'
 import { getDatatableTools } from '../datatableTools'
 import { UserDraft, type UserDraftMeta } from '$lib/userDraft.svelte'
+import { invalidateWorkspaceDrafts } from '$lib/workspaceDrafts.svelte'
 import { emptySchema } from '$lib/utils'
 import { inferArgs } from '$lib/infer'
 import {
@@ -2352,8 +2353,9 @@ function liveDraftItem(
 }
 
 // The current chat draft for a script/flow: the live editor buffer if one is
-// open, else the DB draft (`.draft`). `undefined` when no draft exists (or the
-// item doesn't exist at all).
+// open, else the DB draft (`.draft`), else the `draft_only` row itself (a
+// never-deployed item whose row IS the draft content, even when no separate
+// draft row exists). `undefined` when no draft exists (or the item doesn't).
 async function loadDbDraftItem(
 	workspace: string,
 	type: DbDraftKind,
@@ -2364,14 +2366,16 @@ async function loadDbDraftItem(
 	try {
 		if (type === 'script') {
 			const script = await ScriptService.getScriptByPathWithDraft({ workspace, path })
-			if (!script.draft) return undefined
-			const item = scriptToItem(script.draft as NewScript, true)
+			const src = script.draft ?? (script.draft_only ? script : undefined)
+			if (!src) return undefined
+			const item = scriptToItem(src as NewScript, true)
 			item.isDraft = true
 			return item
 		}
 		const flow = await FlowService.getFlowByPathWithDraft({ workspace, path })
-		if (!flow.draft) return undefined
-		const item = flowToItem(flow.draft as Flow, true)
+		const src = flow.draft ?? (flow.draft_only ? flow : undefined)
+		if (!src) return undefined
+		const item = flowToItem(src as Flow, true)
 		item.isDraft = true
 		return item
 	} catch {
@@ -2399,6 +2403,8 @@ async function saveScriptDbDraft(
 		})
 	}
 	await DraftService.createDraft({ workspace, requestBody: { path, typ: 'script', value: draft } })
+	// Refresh mounted draft-count consumers (Drafts banner, compare page).
+	invalidateWorkspaceDrafts(workspace)
 }
 
 // Persist a flow DB draft, creating the backing `draft_only` row first when the
@@ -2424,6 +2430,7 @@ async function saveFlowDbDraft(
 		})
 	}
 	await DraftService.createDraft({ workspace, requestBody: { path, typ: 'flow', value: draft } })
+	invalidateWorkspaceDrafts(workspace)
 }
 
 // Delete a script/flow DB draft. If the item exists ONLY as a draft
@@ -2459,6 +2466,7 @@ async function deleteScriptFlowDbDraft(
 
 	// Reset any open live editor (and clear a stale localStorage buffer).
 	deleteGlobalDraft(workspace, type, path)
+	invalidateWorkspaceDrafts(workspace)
 }
 
 async function writeScriptDraft(
@@ -3461,6 +3469,9 @@ async function deployDraft(
 
 	switch (type) {
 		case 'script': {
+			// Script deploy writes a complete new version (createScript) — omitted
+			// fields are reset, not inherited. The AI only changes value/summary, so
+			// carry ALL other metadata forward from the currently-deployed version.
 			const existing = (await ScriptService.existsScriptByPath({ workspace, path }))
 				? await ScriptService.getScriptByPath({ workspace, path })
 				: undefined
@@ -3477,6 +3488,7 @@ async function deployDraft(
 			break
 		}
 		case 'flow': {
+			// Flow update is a full replace; carry metadata forward from deployed.
 			const flowDraft = draft.value as FlowDraftValue
 			const existing = (await FlowService.existsFlowByPath({ workspace, path }))
 				? await FlowService.getFlowByPath({ workspace, path })
@@ -3626,6 +3638,9 @@ async function deployDraft(
 	}
 
 	deleteGlobalDraft(workspace, type, path, triggerKind, { preserveLiveDraft: true })
+	// Deploying create/update-deletes the DB draft server-side; refresh mounted
+	// draft-count consumers so the Drafts banner/count drops immediately.
+	invalidateWorkspaceDrafts(workspace)
 
 	// Reload the session preview if it's open on the deployed item. Map the
 	// deploy type to the preview kind — a raw app deploys under 'app' but the

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -2383,9 +2383,16 @@ async function loadDbDraftItem(
 // Persist a script DB draft, creating the backing `draft_only` row first when
 // the script does not exist yet (mirrors ScriptBuilder: the row is needed so
 // `createDraft` passes the writer check on `f/` paths and so the draft is
-// discoverable via list/getWithDraft).
-async function saveScriptDbDraft(workspace: string, path: string, draft: NewScript): Promise<void> {
-	if (!(await ScriptService.existsScriptByPath({ workspace, path }))) {
+// discoverable via list/getWithDraft). `knownExists` lets callers that already
+// know whether the item exists skip the extra existence round-trip.
+async function saveScriptDbDraft(
+	workspace: string,
+	path: string,
+	draft: NewScript,
+	knownExists?: boolean
+): Promise<void> {
+	const exists = knownExists ?? (await ScriptService.existsScriptByPath({ workspace, path }))
+	if (!exists) {
 		await ScriptService.createScript({
 			workspace,
 			requestBody: { ...draft, path, draft_only: true }
@@ -2396,8 +2403,14 @@ async function saveScriptDbDraft(workspace: string, path: string, draft: NewScri
 
 // Persist a flow DB draft, creating the backing `draft_only` row first when the
 // flow does not exist yet (mirrors FlowBuilder).
-async function saveFlowDbDraft(workspace: string, path: string, draft: Flow): Promise<void> {
-	if (!(await FlowService.existsFlowByPath({ workspace, path }))) {
+async function saveFlowDbDraft(
+	workspace: string,
+	path: string,
+	draft: Flow,
+	knownExists?: boolean
+): Promise<void> {
+	const exists = knownExists ?? (await FlowService.existsFlowByPath({ workspace, path }))
+	if (!exists) {
 		await FlowService.createFlow({
 			workspace,
 			requestBody: {
@@ -2461,6 +2474,7 @@ async function writeScriptDraft(
 	// the live editor buffer if open, else the DB draft, else the deployed script.
 	let base: NewScript | undefined
 	let existed = false
+	let backendExists: boolean | undefined
 	if (liveOpen) {
 		base = UserDraft.get<NewScript>('script', storagePath, { workspace })
 		existed = base !== undefined
@@ -2469,11 +2483,13 @@ async function writeScriptDraft(
 		try {
 			const existing = await ScriptService.getScriptByPathWithDraft({ workspace, path: args.path })
 			existed = true
+			backendExists = true
 			const { draft: dbDraft, draft_created_at: _c, hash, ...deployed } = existing
 			// Link lineage to the latest deployed hash, like the editor does.
 			base = { ...(dbDraft ?? deployed), parent_hash: hash } as NewScript
 		} catch {
 			existed = false
+			backendExists = false
 		}
 	}
 
@@ -2496,7 +2512,7 @@ async function writeScriptDraft(
 				kind: 'script'
 			}
 
-	await saveScriptDbDraft(workspace, args.path, draft)
+	await saveScriptDbDraft(workspace, args.path, draft, backendExists)
 	// Mirror into the open editor's buffer so it reflects the change live.
 	if (liveOpen) UserDraft.save('script', storagePath, draft, { workspace })
 
@@ -2522,6 +2538,7 @@ async function writeFlowDraft(
 
 	let base: Flow | undefined
 	let existed = false
+	let backendExists: boolean | undefined
 	if (liveOpen) {
 		base = UserDraft.get<Flow>('flow', storagePath, { workspace })
 		existed = base !== undefined
@@ -2530,10 +2547,12 @@ async function writeFlowDraft(
 		try {
 			const existing = await FlowService.getFlowByPathWithDraft({ workspace, path: args.path })
 			existed = true
+			backendExists = true
 			const { draft: dbDraft, draft_created_at: _c, ...deployed } = existing
 			base = dbDraft ?? (deployed as Flow)
 		} catch {
 			existed = false
+			backendExists = false
 		}
 	}
 
@@ -2556,7 +2575,7 @@ async function writeFlowDraft(
 				extra_perms: {}
 			}
 
-	await saveFlowDbDraft(workspace, args.path, draft)
+	await saveFlowDbDraft(workspace, args.path, draft, backendExists)
 	// Mirror into the open editor's buffer so it reflects the change live.
 	if (liveOpen) UserDraft.save('flow', storagePath, draft, { workspace })
 
@@ -2887,11 +2906,9 @@ async function loadDraftFlowPreviewValue(
 	workspace: string
 ): Promise<FlowValue | undefined> {
 	// Only override the deployed flow when a draft (live editor or DB) exists.
-	if (!(await loadDbDraftItem(workspace, 'flow', path))) {
-		return undefined
-	}
-	const nestedFlow = await loadFlowDraftValue(path, workspace)
-	return flowDraftValueForPreview(nestedFlow.flow)
+	const draftItem = await loadDbDraftItem(workspace, 'flow', path)
+	if (!draftItem) return undefined
+	return flowDraftValueForPreview(draftItem.value as FlowDraftValue)
 }
 
 async function testRunScriptByPath(

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -2359,36 +2359,59 @@ function liveDraftItem(
 	return draft?.isLiveDraft ? draft : undefined
 }
 
-// The current chat draft for a script/flow: the live editor buffer if one is
-// open, else the DB draft (`.draft`), else the `draft_only` row itself (a
-// never-deployed item whose row IS the draft content, even when no separate
-// draft row exists). `undefined` when no draft exists (or the item doesn't).
+// The current chat draft for a script/flow, as its FULL payload (the editor's
+// serialized `NewScript`/`Flow`, with every metadata field): the live editor
+// buffer if one is open, else the DB draft (`.draft`), else the `draft_only` row
+// itself (a never-deployed item whose row IS the draft content, even when no
+// separate draft row exists). `undefined` when no draft exists (or the item
+// doesn't). Deploy uses this so draft-side metadata isn't dropped.
+async function loadDbDraftRaw(
+	workspace: string,
+	type: DbDraftKind,
+	path: string
+): Promise<NewScript | Flow | undefined> {
+	const live = liveDraftItem(workspace, type, path)
+	if (live) {
+		// The live editor's localStorage buffer holds the full serialized payload.
+		const storagePath = getGlobalDraftStoragePath(workspace, type, path)
+		return UserDraft.get<NewScript | Flow>(type, storagePath, { workspace })
+	}
+	try {
+		if (type === 'script') {
+			const script = await ScriptService.getScriptByPathWithDraft({ workspace, path })
+			if (script.draft) return script.draft as NewScript
+			if (script.draft_only) {
+				const { draft: _d, draft_created_at: _c, hash, ...row } = script
+				return { ...row, parent_hash: hash } as NewScript
+			}
+			return undefined
+		}
+		const flow = await FlowService.getFlowByPathWithDraft({ workspace, path })
+		if (flow.draft) return flow.draft as Flow
+		if (flow.draft_only) {
+			const { draft: _d, draft_created_at: _c, ...row } = flow
+			return row as Flow
+		}
+		return undefined
+	} catch (e) {
+		if (isNotFoundError(e)) return undefined // never deployed and no draft row
+		throw e
+	}
+}
+
+// Like `loadDbDraftRaw` but shaped as the compact `WorkspaceItem` used by
+// read / list / existence checks (value-only; metadata stays in the payload).
 async function loadDbDraftItem(
 	workspace: string,
 	type: DbDraftKind,
 	path: string
 ): Promise<WorkspaceItem | undefined> {
-	const live = liveDraftItem(workspace, type, path)
-	if (live) return live
-	try {
-		if (type === 'script') {
-			const script = await ScriptService.getScriptByPathWithDraft({ workspace, path })
-			const src = script.draft ?? (script.draft_only ? script : undefined)
-			if (!src) return undefined
-			const item = scriptToItem(src as NewScript, true)
-			item.isDraft = true
-			return item
-		}
-		const flow = await FlowService.getFlowByPathWithDraft({ workspace, path })
-		const src = flow.draft ?? (flow.draft_only ? flow : undefined)
-		if (!src) return undefined
-		const item = flowToItem(src as Flow, true)
-		item.isDraft = true
-		return item
-	} catch (e) {
-		if (isNotFoundError(e)) return undefined // never deployed and no draft row
-		throw e
-	}
+	const raw = await loadDbDraftRaw(workspace, type, path)
+	if (!raw) return undefined
+	const item =
+		type === 'script' ? scriptToItem(raw as NewScript, true) : flowToItem(raw as Flow, true)
+	item.isDraft = true
+	return item
 }
 
 // Persist a script DB draft, creating the backing `draft_only` row first when
@@ -3479,12 +3502,15 @@ async function deployDraft(
 	switch (type) {
 		case 'script': {
 			// Script deploy writes a complete new version (createScript) — omitted
-			// fields are reset, not inherited. The AI only changes value/summary, so
-			// carry ALL other metadata forward from the currently-deployed version.
+			// fields are reset, not inherited. Carry metadata forward from the FULL
+			// draft payload (so edits made in the editor survive), falling back to
+			// the deployed version; keep the deployed hash for lineage.
 			const existing = (await ScriptService.existsScriptByPath({ workspace, path }))
 				? await ScriptService.getScriptByPath({ workspace, path })
 				: undefined
-			const requestBody = buildScriptDeployRequestBody(path, draft, existing, deploymentMessage)
+			const fullDraft = (await loadDbDraftRaw(workspace, 'script', path)) as NewScript | undefined
+			const metadataSource = { ...existing, ...fullDraft, hash: existing?.hash } as Script
+			const requestBody = buildScriptDeployRequestBody(path, draft, metadataSource, deploymentMessage)
 			// Infer the arg schema from the content so it matches the code, like the editor does.
 			try {
 				const schema = emptySchema()
@@ -3497,16 +3523,20 @@ async function deployDraft(
 			break
 		}
 		case 'flow': {
-			// Flow update is a full replace; carry metadata forward from deployed.
+			// Flow update is a full replace; carry metadata forward from the FULL
+			// draft payload (preserving editor edits), falling back to deployed.
 			const flowDraft = draft.value as FlowDraftValue
 			const existing = (await FlowService.existsFlowByPath({ workspace, path }))
 				? await FlowService.getFlowByPath({ workspace, path })
 				: undefined
+			const fullDraft = (await loadDbDraftRaw(workspace, 'flow', path)) as Flow | undefined
+			const metadataSource =
+				existing || fullDraft ? ({ ...existing, ...fullDraft } as Flow) : undefined
 			const requestBody = buildFlowDeployRequestBody(
 				path,
 				draft.summary,
 				flowDraft,
-				existing,
+				metadataSource,
 				deploymentMessage
 			)
 			if (existing) {


### PR DESCRIPTION
## Summary

In the **global mode** AI chat, script and flow drafts were stored only in browser `localStorage` — invisible outside the browser, absent from Windmill's normal Drafts UI, and lost across sessions/devices. This makes script/flow chat drafts **real workspace DB drafts** (the `draft` table) so they persist and appear everywhere, while keeping `localStorage` only as the bridge to an open **live editor**.

Scope (confirmed with the requester): **scripts and flows only** for DB drafts. Apps stay on `localStorage` for now (writing an app DB draft would require an esbuild bundle to create the backing row on every granular edit). Triggers/resources/variables/schedules are unchanged. No backend/API changes were needed — the `draft` table + `DraftService` already support `script`/`flow`/`app`, and the path/value/summary-only restriction was already satisfied by the existing script/flow/app tool schemas.

## Behavior

| Operation | Live editor open | No live editor |
|---|---|---|
| read / list | localStorage buffer | DB draft (`getXByPathWithDraft().draft`) |
| write / edit / patch | localStorage **and** DB draft | DB draft (creates a `draft_only` row for brand-new items) |
| test run | localStorage | DB draft (falls back to deployed) |
| deploy | localStorage buffer | DB draft (create/update auto-deletes the draft server-side) |
| discard | clear buffer **and** delete DB draft | delete DB draft (or whole item if `draft_only`) |

"Live editor open" reuses the existing `isLiveDraft` flag (`UserDraft.getLiveEditorDraft`).

## Changes

- `write_script` / `write_flow` (and `edit_script`, `patch_flow_json`, `set_flow_module_code`) now persist to the DB draft via `DraftService.createDraft`, creating a `draft_only` backing row for brand-new items (mirrors `ScriptBuilder`/`FlowBuilder`). They additionally mirror into `localStorage` when a live editor is open.
- `read_workspace_item` / `test_run_*` / `deploy_workspace_item` load script/flow drafts via new helpers: live editor buffer when mounted, else the DB draft (`getScriptByPathWithDraft`/`getFlowByPathWithDraft`).
- `discard_local_draft` deletes the DB draft for script/flow — or the whole item when it only ever existed as a draft (`draft_only`) — and resets any open editor buffer.
- `list_workspace_items` no longer merges stale non-live `localStorage` script/flow drafts (DB drafts surface via `listScripts`/`listFlows` `includeDraftOnly`); it still merges apps and any live editor buffer, and marks items carrying a draft as `isDraft`.
- Apps and triggers/resources/variables/schedules are untouched (still `localStorage`).
- Tooling/messages reworded from "local draft" to "draft"/"workspace draft" where accurate.
- `core.test.ts`: added an in-memory DB-draft simulation (`resetDbSim`) wiring `ScriptService`/`FlowService`/`DraftService`, and updated/added tests for the new model.

## Test plan

- [x] `npx vitest run src/lib/components/copilot/chat/global/` → 65 passing (write→DB + draft_only row, live-editor mirror, read prefers DB vs live buffer, discard deletes whole item when draft_only vs draft row otherwise, deployed-content preview when no draft).
- [ ] Manual: ask the global chat to create a script and a flow → confirm they appear in the Drafts UI and survive a page reload.
- [ ] Manual: open one in its live editor, ask the chat to edit it → editor reflects the change live.
- [ ] Manual: ask the chat to deploy a chat-created draft → item deploys, draft disappears; discard a chat-created (never-deployed) draft → whole item removed; discard a draft on an already-deployed item → only the draft is dropped.

## Known follow-ups (accepted for this iteration)

- Apps remain `localStorage`-only.
- Pre-existing non-live `localStorage` script/flow drafts become inert (ignored, GC'd) — not migrated.
- The DB draft stores the base/empty schema; schema is re-inferred on deploy and by the editor on open.
- `loadDbDraftItem`/`deleteScriptFlowDbDraft` treat any `getXByPathWithDraft` error as "not found" — a transient/permission error during deploy/discard would surface as "No draft found" rather than the real error (destructive branches stay on the safe side). Could narrow to 404 later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)