### PR TITLE
fix(frontend): enable Apply button when env vars change in worker group config

### DIFF
--- a/frontend/src/lib/components/WorkerGroup.svelte
+++ b/frontend/src/lib/components/WorkerGroup.svelte
@@ -198,6 +198,8 @@
 					priority_tags?: Record<string, number>
 					cache_clear?: number
 					init_bash?: string
+					env_vars_static?: Map<string, string>
+					env_vars_allowlist?: string[]
 					additional_python_paths?: string[]
 					pip_local_dependencies?: string[]
 					min_alive_workers_alert_threshold?: number
@@ -268,6 +270,25 @@
 			orderedJsonStringify(replaceFalseWithUndefined(cleaned1)) !==
 			orderedJsonStringify(replaceFalseWithUndefined(cleaned2))
 		)
+	})
+
+	// Env var edits only mutate the local `customEnvVars` array; they aren't synced back into
+	// `nconfig.env_vars_*` until the Apply handler runs, so `hasChanges` can't see them. Detect
+	// those edits separately by reconstructing the original env vars from `config`.
+	let hasEnvVarChanges = $derived.by(() => {
+		let originalEnvVars: typeof customEnvVars = []
+		if (config?.env_vars_allowlist) {
+			for (const key of config.env_vars_allowlist) {
+				originalEnvVars.push({ key, type: 'dynamic' as const, value: undefined })
+			}
+		}
+		if (config?.env_vars_static) {
+			for (const [key, value] of Object.entries(config.env_vars_static)) {
+				originalEnvVars.push({ key, type: 'static' as const, value })
+			}
+		}
+		originalEnvVars.sort((a, b) => (a.key < b.key ? -1 : 1))
+		return JSON.stringify(customEnvVars) !== JSON.stringify(originalEnvVars)
 	})
 	let openDelete = $state(false)
 	let openClean = $state(false)
@@ -1165,7 +1186,10 @@
 								sendUserToast('Configuration set')
 								dispatch('reload')
 							}}
-							disabled={(!hasChanges && nconfig?.dedicated_worker == undefined) || !canEditConfig}
+							disabled={(!hasChanges &&
+								!hasEnvVarChanges &&
+								nconfig?.dedicated_worker == undefined) ||
+								!canEditConfig}
 						>
 							Apply changes
 						</Button>


### PR DESCRIPTION
## Problem

In the worker group config drawer (`WorkerGroup.svelte`), adding or editing environment variables does **not** enable the **Apply changes** button.

`hasChanges` compares the original `config` prop against the local `nconfig` copy, but env var edits only mutate the local `customEnvVars` array — they are not synced back into `nconfig.env_vars_static` / `nconfig.env_vars_allowlist` until the Apply handler runs. This leaves the button stuck disabled despite real changes.

Fixes WIN-2023

## Fix

- Add a `hasEnvVarChanges` derived that reconstructs the original env vars from `config` and compares them to the current `customEnvVars`.
- Include `!hasEnvVarChanges` in the Apply button's `disabled` condition.
- Add `env_vars_static` / `env_vars_allowlist` to the `config` prop type so the new derived type-checks (these fields are already present on `nconfig` and genuinely exist on `config` at runtime).

Since the new derived is read-only, it can only **enable** the button in more cases (when env vars change) and never disables it — so it's safe both in the bug scenario (`hasChanges` false) and otherwise.

## Validation

- `npm run check:fast`: clean for `WorkerGroup.svelte` (only a pre-existing, unrelated error in `ChatContextPicker.svelte`).
- svelte-autofixer: no issues on the added logic.
- **No regression**: with the change, the baseline still keeps Apply *disabled* when there are no changes (matches original behavior).
- **Reactivity verified** in the running app (Playwright): using a temporary debug element, `hasEnvVarChanges` reactively flips `false → true` the moment an env var is added/edited, and back to `false` when the list matches the original.

> Note: env-var editing in the drawer is an EE-gated feature, so on a CE dev instance the inputs are disabled by default. Verification was done by temporarily enabling the env-var editing path locally (reverted before commit) and reading the derived's value directly; the final committed diff contains only the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the Apply changes button when environment variables are added or edited in the worker group config drawer. Fixes WIN-2023 so env var edits can be saved without extra steps.

- **Bug Fixes**
  - Added `hasEnvVarChanges` to compare `customEnvVars` against env vars reconstructed from `config`.
  - Included `hasEnvVarChanges` in the Apply button `disabled` check.
  - Extended `config` prop type to include `env_vars_static` and `env_vars_allowlist` for type safety.

<sup>Written for commit 9eeedb702208fd89f01d98530f81c94654a575d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

