### PR TITLE
feat: browser confirmation on page exit with unsaved changes

### DIFF
--- a/frontend/src/lib/components/common/confirmationModal/UnsavedConfirmationModal.svelte
+++ b/frontend/src/lib/components/common/confirmationModal/UnsavedConfirmationModal.svelte
@@ -38,6 +38,26 @@
 	let open = $state(false)
 	let goingTo: URL | undefined = $state(undefined)
 
+	// Mirrors the modal condition: dirty when values differ, or when either
+	// value is missing (e.g. a never-saved draft). Also refreshes
+	// savedValue/modifiedValue for the diff drawer.
+	function hasUnsavedChanges(): boolean {
+		const state = getInitialAndModifiedValues?.()
+		savedValue = state?.savedValue
+		modifiedValue = state?.modifiedValue
+
+		if (savedValue && modifiedValue) {
+			const draftOrDeployed = cleanValueProperties((savedValue.draft || savedValue) ?? {})
+			const current = cleanValueProperties(modifiedValue ?? {})
+
+			return (
+				orderedJsonStringify(replaceFalseWithUndefined(draftOrDeployed)) !==
+				orderedJsonStringify(replaceFalseWithUndefined(current))
+			)
+		}
+		return true
+	}
+
 	beforeNavigate(async (newNavigationState) => {
 		if (
 			!bypassBeforeNavigate &&
@@ -49,37 +69,31 @@
 		) {
 			goingTo = newNavigationState.to.url
 
-			const state = getInitialAndModifiedValues?.()
-			savedValue = state?.savedValue
-			modifiedValue = state?.modifiedValue
-
-			async function openModal() {
+			if (hasUnsavedChanges()) {
 				newNavigationState.cancel()
 				open = true
-			}
-			if (savedValue && modifiedValue) {
-				const draftOrDeployed = cleanValueProperties((savedValue.draft || savedValue) ?? {})
-				const current = cleanValueProperties(modifiedValue ?? {})
-
-				if (
-					orderedJsonStringify(replaceFalseWithUndefined(draftOrDeployed)) ===
-					orderedJsonStringify(replaceFalseWithUndefined(current))
-				) {
-					if (!tabMode) {
-						bypassBeforeNavigate = true
-					}
-					additionalExitAction?.()
-				} else {
-					await openModal()
-				}
 			} else {
-				await openModal()
+				if (!tabMode) {
+					bypassBeforeNavigate = true
+				}
+				additionalExitAction?.()
 			}
 		} else if (bypassBeforeNavigate) {
 			bypassBeforeNavigate = false
 		}
 	})
+
+	function onBeforeUnload(event: BeforeUnloadEvent) {
+		if (!bypassBeforeNavigate && getInitialAndModifiedValues && hasUnsavedChanges()) {
+			// Triggers the browser's native "leave site?" confirmation
+			event.preventDefault()
+			// Required by some browsers (legacy mechanism)
+			event.returnValue = true
+		}
+	}
 </script>
+
+<svelte:window onbeforeunload={onBeforeUnload} />
 
 {#if open}
 	<div


### PR DESCRIPTION

<img width="488" height="360" alt="Screenshot 2026-06-10 at 11 14 31" src="https://github.com/user-attachments/assets/11daeb58-94f4-4aa3-a857-d0e1711f0c85" />


## Summary

The "Unsaved changes detected" modal (`UnsavedConfirmationModal`) only intercepts in-app (SvelteKit) navigation via `beforeNavigate`. Closing the tab, reloading, or navigating to an external URL silently dropped unsaved changes — e.g. on workspace settings tabs.

This PR hooks the same dirty-check into the window `beforeunload` event, so the browser shows its native "leave site?" confirmation exactly when the in-app modal would have appeared.

## Changes

- `UnsavedConfirmationModal.svelte`: extracted the dirty-check (diff between saved and modified values, with "missing values ⇒ dirty" fallback matching the existing modal behavior) into a shared `hasUnsavedChanges()` used by `beforeNavigate` — behavior unchanged — and by a new `onBeforeUnload` handler registered with `<svelte:window onbeforeunload>` that calls `event.preventDefault()` when dirty.
- Applies everywhere the modal is used: workspace settings, script/flow/app editors.

## Test plan

Verified with a headless-Chromium Playwright script against the dev stack (frontend :3120, backend :8120):

- [x] Workspace settings → Webhook tab, pristine: synthetic `beforeunload` is NOT default-prevented (no spurious prompt)
- [x] After editing the webhook URL: `beforeunload` IS default-prevented
- [x] Real navigation away from the site triggers the native `beforeunload` dialog (captured via Playwright `dialog` event, `type === 'beforeunload'`)
- [x] Regression: switching settings tabs with unsaved changes still opens the in-app "Unsaved changes detected" modal
- [x] `npm run check:fast` (only pre-existing unrelated error in `ChatContextPicker.svelte`) and Svelte autofixer clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)