### PR TITLE
docs(cli): add Windmill documentation section to generated AGENTS.cli.md

### DIFF
--- a/cli/src/guidance/core.ts
+++ b/cli/src/guidance/core.ts
@@ -157,5 +157,13 @@ For flow failures, start with \`wmill job get <id>\` to identify the failing ste
 For specific guidance, ALWAYS use the skills listed below. Paths point at \`.agents/skills/\` — Claude Code reads identical copies under \`.claude/skills/\`.
 
 ${skillsReference}
+
+## Windmill Documentation
+
+For Windmill concepts not covered by the skills (triggers, schedules, workers, flows, error handling, etc.), read the official docs:
+
+- Fetch https://www.windmill.dev/llms.txt — a curated index of every docs page with one-line descriptions — to find the right page for any concept.
+- Every docs page is available as raw markdown by appending \`.md\` to its URL, e.g. https://www.windmill.dev/docs/core_concepts/scheduling.md — prefer these over the HTML pages.
+- https://www.windmill.dev/llms-full.txt is the entire documentation as a single ~2.3 MB file — only for bulk indexing/RAG, do NOT load it directly into context.
 `;
 }


### PR DESCRIPTION
## Summary
Adds a "Windmill Documentation" section to the managed `AGENTS.cli.md` guidance that `wmill init` and `wmill refresh prompts` write into user workspaces, so AI coding agents know how to read the official Windmill docs for concepts not covered by the bundled skills.

## Changes
- New `## Windmill Documentation` section at the end of the template in `generateAgentsCliMdContent` (`cli/src/guidance/core.ts`), pointing agents at:
  - `https://www.windmill.dev/llms.txt` — curated llms.txt index of all docs pages to find the right page for any concept
  - raw-markdown docs pages via the `.md` URL suffix (preferred over HTML)
  - `https://www.windmill.dev/llms-full.txt` — full ~2.3 MB docs dump, flagged as bulk-indexing/RAG only (not for direct context loading)
- No generated-file churn: `python system_prompts/generate.py` produces no diff (the template is read at runtime, not snapshotted in `skills.gen.ts`), and the prompts freshness hash in `freshness.ts` is computed from the template at runtime — existing workspaces will get the standard stale-prompts warning prompting `wmill refresh prompts`.

## Test plan
- [x] `wmill init --use-default` in a temp dir (via `bun run cli/src/main.ts`) — generated `AGENTS.cli.md` ends with the new section and carries a fresh `wmill-prompts-hash` marker
- [x] `bun test test/guidance_writer_unit.test.ts` — 51 pass (covers freshness hashing)
- [x] Verified the `system_prompts/generate.py` template-extraction regex still parses the new content (no unescaped backticks / `${`), and all three URLs return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a "Windmill Documentation" section to the `AGENTS.cli.md` generated by `wmill init` and `wmill refresh prompts`, so agents can find official docs for topics not covered by bundled skills. It links to `https://www.windmill.dev/llms.txt`, recommends using `.md` doc URLs for raw markdown, and marks `https://www.windmill.dev/llms-full.txt` as bulk-indexing only.

<sup>Written for commit 5d73bc1990ce2e77ff23ef56c6e0e6bac574db63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

