### PR TITLE
fix(nsjail): make ansible uv tools mount non-mandatory

### DIFF
--- a/backend/windmill-worker/nsjail/run.ansible.config.proto
+++ b/backend/windmill-worker/nsjail/run.ansible.config.proto
@@ -44,6 +44,7 @@ mount {
     src: "/root/.local/share/uv/tools/ansible"
     dst: "/root/.local/share/uv/tools/ansible"
     is_bind: true
+    mandatory: false
 }
 
 mount {


### PR DESCRIPTION
## Summary

Fixes WIN-2024.

The ansible nsjail config has a bind mount for `/root/.local/share/uv/tools/ansible`, the old default `uv tool dir` path. Since the Docker images now set `UV_TOOL_DIR=/usr/local/uv`, ansible is installed at `/usr/local/uv/ansible/` and the old path no longer exists. Because nsjail mounts default to `mandatory: true`, the missing source path makes nsjail abort with `Launching child process failed` for every ansible job.

Adding `mandatory: false` makes the mount a no-op on current images while keeping compatibility for deployments that still have ansible at the legacy uv path. The actual install location at `/usr/local/uv/ansible/` is already exposed inside the jail via the existing `/usr` bind mount.

## Changes

- Add `mandatory: false` to the `/root/.local/share/uv/tools/ansible` mount block in `backend/windmill-worker/nsjail/run.ansible.config.proto`, matching the established idiom used for other optional mounts in the same file (`/lib64`, `requirements.yml`, `/etc/resolv.conf`, etc.)

## Test plan

- [ ] On an image with `UV_TOOL_DIR=/usr/local/uv` (where `/root/.local/share/uv/tools/ansible` does not exist), run an ansible script on a worker with nsjail enabled and confirm it executes instead of failing with `Launching child process failed`
- [ ] On an older image that still has the legacy uv tools path, confirm ansible jobs still run (the mount still applies when the path exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent nsjail from aborting Ansible jobs by setting `mandatory: false` on the legacy bind mount `/root/.local/share/uv/tools/ansible` in `backend/windmill-worker/nsjail/run.ansible.config.proto`. Fixes WIN-2024 and supports images using `UV_TOOL_DIR=/usr/local/uv` while keeping compatibility with older images.

<sup>Written for commit ed5e6b159e906f538cea4cf1e921d72c03d2d4c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

