### PR TITLE
feat: workspace protection rule to restrict anonymous app deployment

### DIFF
--- a/backend/.sqlx/query-3e82929b365a6aa7ccc39fc5615c4110e1d740e0cb0509b1c58bc6636d83cafd.json
+++ b/backend/.sqlx/query-3e82929b365a6aa7ccc39fc5615c4110e1d740e0cb0509b1c58bc6636d83cafd.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT policy->>'execution_mode' = 'anonymous' FROM app WHERE path = $1 AND workspace_id = $2",
+  "query": "SELECT policy->>'execution_mode' = 'anonymous' FROM app WHERE path = $1 AND workspace_id = $2 FOR UPDATE",
   "describe": {
     "columns": [
       {
@@ -19,5 +19,5 @@
       null
     ]
   },
-  "hash": "8c6310025b3338863c6a7250dff38538b262d60bc8f839f103e07f6a9cb3dd00"
+  "hash": "3e82929b365a6aa7ccc39fc5615c4110e1d740e0cb0509b1c58bc6636d83cafd"
 }

--- a/backend/.sqlx/query-8c6310025b3338863c6a7250dff38538b262d60bc8f839f103e07f6a9cb3dd00.json
+++ b/backend/.sqlx/query-8c6310025b3338863c6a7250dff38538b262d60bc8f839f103e07f6a9cb3dd00.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT policy->>'execution_mode' = 'anonymous' FROM app WHERE path = $1 AND workspace_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "?column?",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "8c6310025b3338863c6a7250dff38538b262d60bc8f839f103e07f6a9cb3dd00"
+}

--- a/backend/tests/app_anonymous_execution_mode.rs
+++ b/backend/tests/app_anonymous_execution_mode.rs
@@ -1,0 +1,166 @@
+//! Regression test for the admin gate on anonymous app execution mode.
+//!
+//! Any user with write access to an app could set its policy
+//! `execution_mode` to `anonymous` (no login required), exposing the app
+//! publicly without authentication or admin oversight. The fix mirrors the
+//! `custom_path` admin gate: only workspace admins can create an app as
+//! anonymous or flip an existing app to anonymous. To avoid breaking
+//! existing workflows, non-admins can still redeploy an app that is
+//! already anonymous (no exposure change) and can downgrade it back to
+//! `publisher` (exposure reduction).
+//!
+//! Users from the `base` fixture:
+//!   test-user   (admin,    token SECRET_TOKEN)
+//!   test-user-2 (non-admin, token SECRET_TOKEN_2)
+
+use serde_json::json;
+use sqlx::{Pool, Postgres};
+use windmill_test_utils::*;
+
+const ADMIN_TOKEN: &str = "SECRET_TOKEN";
+const USER_TOKEN: &str = "SECRET_TOKEN_2";
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+fn authed(builder: reqwest::RequestBuilder, token: &str) -> reqwest::RequestBuilder {
+    builder.header("Authorization", format!("Bearer {}", token))
+}
+
+fn app_payload(path: &str, execution_mode: &str) -> serde_json::Value {
+    json!({
+        "path": path,
+        "summary": "Test app",
+        "value": {},
+        "policy": { "execution_mode": execution_mode, "triggerables": {} }
+    })
+}
+
+fn policy_update(execution_mode: &str) -> serde_json::Value {
+    json!({
+        "policy": { "execution_mode": execution_mode, "triggerables": {} }
+    })
+}
+
+#[sqlx::test(fixtures("base"))]
+async fn test_anonymous_execution_mode_requires_admin(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let ws = format!("http://localhost:{port}/api/w/test-workspace");
+
+    let app_path = "u/test-user-2/test_app";
+
+    // 1. A non-admin cannot create an app with anonymous execution mode.
+    let resp = authed(client().post(format!("{ws}/apps/create")), USER_TOKEN)
+        .json(&app_payload(app_path, "anonymous"))
+        .send()
+        .await?;
+    let status = resp.status();
+    let body = resp.text().await?;
+    assert_eq!(
+        status, 403,
+        "non-admin creating an anonymous app must be rejected: {body}"
+    );
+    assert!(
+        body.contains("Admin"),
+        "error should mention the admin requirement, got: {body}"
+    );
+
+    // 2. The same create with publisher mode succeeds.
+    let resp = authed(client().post(format!("{ws}/apps/create")), USER_TOKEN)
+        .json(&app_payload(app_path, "publisher"))
+        .send()
+        .await?;
+    assert_eq!(
+        resp.status(),
+        201,
+        "non-admin creating a publisher app must succeed: {}",
+        resp.text().await?
+    );
+
+    // 3. A non-admin cannot flip an existing app to anonymous.
+    let resp = authed(
+        client().post(format!("{ws}/apps/update/{app_path}")),
+        USER_TOKEN,
+    )
+    .json(&policy_update("anonymous"))
+    .send()
+    .await?;
+    let status = resp.status();
+    let body = resp.text().await?;
+    assert_eq!(
+        status, 403,
+        "non-admin flipping an app to anonymous must be rejected: {body}"
+    );
+
+    // 4. An admin can flip the app to anonymous.
+    let resp = authed(
+        client().post(format!("{ws}/apps/update/{app_path}")),
+        ADMIN_TOKEN,
+    )
+    .json(&policy_update("anonymous"))
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        200,
+        "admin flipping an app to anonymous must succeed: {}",
+        resp.text().await?
+    );
+
+    // 5. A non-admin can still redeploy an app that is already anonymous —
+    //    keeping it anonymous does not change its exposure, and blocking it
+    //    would prevent non-admin editors from deploying public apps at all
+    //    (the frontend always sends the full policy on deploy).
+    let resp = authed(
+        client().post(format!("{ws}/apps/update/{app_path}")),
+        USER_TOKEN,
+    )
+    .json(&json!({
+        "value": { "edited": true },
+        "policy": { "execution_mode": "anonymous", "triggerables": {} }
+    }))
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        200,
+        "non-admin redeploying an already-anonymous app must succeed: {}",
+        resp.text().await?
+    );
+
+    // 6. A non-admin can downgrade the app back to publisher (reduces exposure).
+    let resp = authed(
+        client().post(format!("{ws}/apps/update/{app_path}")),
+        USER_TOKEN,
+    )
+    .json(&policy_update("publisher"))
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        200,
+        "non-admin downgrading anonymous to publisher must succeed: {}",
+        resp.text().await?
+    );
+
+    // 7. After the downgrade, flipping back to anonymous requires admin again.
+    let resp = authed(
+        client().post(format!("{ws}/apps/update/{app_path}")),
+        USER_TOKEN,
+    )
+    .json(&policy_update("anonymous"))
+    .send()
+    .await?;
+    let status = resp.status();
+    let body = resp.text().await?;
+    assert_eq!(
+        status, 403,
+        "non-admin re-flipping to anonymous must be rejected: {body}"
+    );
+
+    Ok(())
+}

--- a/backend/tests/app_anonymous_execution_mode.rs
+++ b/backend/tests/app_anonymous_execution_mode.rs
@@ -1,20 +1,22 @@
-//! Regression test for the admin gate on anonymous app execution mode.
+//! Test for the `RestrictAnonymousAppDeployment` workspace protection rule.
 //!
-//! Any user with write access to an app could set its policy
-//! `execution_mode` to `anonymous` (no login required), exposing the app
-//! publicly without authentication or admin oversight. The fix mirrors the
-//! `custom_path` admin gate: only workspace admins can create an app as
-//! anonymous or flip an existing app to anonymous. To avoid breaking
-//! existing workflows, non-admins can still redeploy an app that is
-//! already anonymous (no exposure change) and can downgrade it back to
-//! `publisher` (exposure reduction).
+//! By default (no rule), any user with write access can deploy an app with
+//! `execution_mode: anonymous` (no login required) — the historical
+//! behavior. When a workspace protection ruleset enables
+//! `RestrictAnonymousAppDeployment`, only workspace admins and the
+//! ruleset's bypass users/groups can create an anonymous app or flip an
+//! existing app to anonymous. To avoid breaking existing workflows,
+//! restricted users can still redeploy an app that is already anonymous
+//! (no exposure change) and can downgrade it back to `publisher`
+//! (exposure reduction).
 //!
 //! Users from the `base` fixture:
-//!   test-user   (admin,    token SECRET_TOKEN)
+//!   test-user   (admin,     token SECRET_TOKEN)
 //!   test-user-2 (non-admin, token SECRET_TOKEN_2)
 
 use serde_json::json;
 use sqlx::{Pool, Postgres};
+use windmill_common::workspaces::invalidate_protection_rules_cache;
 use windmill_test_utils::*;
 
 const ADMIN_TOKEN: &str = "SECRET_TOKEN";
@@ -43,62 +45,132 @@ fn policy_update(execution_mode: &str) -> serde_json::Value {
     })
 }
 
+/// Single test to avoid interference through the process-global protection
+/// rules cache (keyed by workspace id, shared across parallel tests).
 #[sqlx::test(fixtures("base"))]
-async fn test_anonymous_execution_mode_requires_admin(db: Pool<Postgres>) -> anyhow::Result<()> {
+async fn test_restrict_anonymous_app_deployment_rule(db: Pool<Postgres>) -> anyhow::Result<()> {
     initialize_tracing().await;
+    invalidate_protection_rules_cache("test-workspace");
 
     let server = ApiServer::start(db.clone()).await?;
     let port = server.addr.port();
     let ws = format!("http://localhost:{port}/api/w/test-workspace");
 
-    let app_path = "u/test-user-2/test_app";
+    // ========================================
+    // 1. Default behavior (no rule): a non-admin can create an anonymous
+    //    app and flip an app to anonymous, as before.
+    // ========================================
 
-    // 1. A non-admin cannot create an app with anonymous execution mode.
     let resp = authed(client().post(format!("{ws}/apps/create")), USER_TOKEN)
-        .json(&app_payload(app_path, "anonymous"))
-        .send()
-        .await?;
-    let status = resp.status();
-    let body = resp.text().await?;
-    assert_eq!(
-        status, 403,
-        "non-admin creating an anonymous app must be rejected: {body}"
-    );
-    assert!(
-        body.contains("Admin"),
-        "error should mention the admin requirement, got: {body}"
-    );
-
-    // 2. The same create with publisher mode succeeds.
-    let resp = authed(client().post(format!("{ws}/apps/create")), USER_TOKEN)
-        .json(&app_payload(app_path, "publisher"))
+        .json(&app_payload("u/test-user-2/anon_default", "anonymous"))
         .send()
         .await?;
     assert_eq!(
         resp.status(),
         201,
-        "non-admin creating a publisher app must succeed: {}",
+        "without the rule, non-admin creating an anonymous app must succeed: {}",
         resp.text().await?
     );
 
-    // 3. A non-admin cannot flip an existing app to anonymous.
+    let resp = authed(client().post(format!("{ws}/apps/create")), USER_TOKEN)
+        .json(&app_payload("u/test-user-2/test_app", "publisher"))
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 201, "{}", resp.text().await?);
+
     let resp = authed(
-        client().post(format!("{ws}/apps/update/{app_path}")),
+        client().post(format!("{ws}/apps/update/u/test-user-2/test_app")),
         USER_TOKEN,
     )
     .json(&policy_update("anonymous"))
     .send()
     .await?;
+    assert_eq!(
+        resp.status(),
+        200,
+        "without the rule, non-admin flipping an app to anonymous must succeed: {}",
+        resp.text().await?
+    );
+
+    // back to publisher for the gated scenarios below
+    let resp = authed(
+        client().post(format!("{ws}/apps/update/u/test-user-2/test_app")),
+        USER_TOKEN,
+    )
+    .json(&policy_update("publisher"))
+    .send()
+    .await?;
+    assert_eq!(resp.status(), 200, "{}", resp.text().await?);
+
+    // ========================================
+    // 2. Admin enables the RestrictAnonymousAppDeployment rule.
+    // ========================================
+
+    let resp = authed(
+        client().post(format!("{ws}/workspaces/protection_rules")),
+        ADMIN_TOKEN,
+    )
+    .json(&json!({
+        "name": "no-public-apps",
+        "rules": ["RestrictAnonymousAppDeployment"],
+        "bypass_users": [],
+        "bypass_groups": []
+    }))
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        200,
+        "admin should create the protection rule: {}",
+        resp.text().await?
+    );
+
+    // ========================================
+    // 3. With the rule, a non-admin cannot create an anonymous app...
+    // ========================================
+
+    let resp = authed(client().post(format!("{ws}/apps/create")), USER_TOKEN)
+        .json(&app_payload("u/test-user-2/anon_blocked", "anonymous"))
+        .send()
+        .await?;
     let status = resp.status();
     let body = resp.text().await?;
     assert_eq!(
         status, 403,
-        "non-admin flipping an app to anonymous must be rejected: {body}"
+        "with the rule, non-admin creating an anonymous app must be rejected: {body}"
+    );
+    assert!(
+        body.contains("no-public-apps"),
+        "error should name the blocking ruleset, got: {body}"
     );
 
-    // 4. An admin can flip the app to anonymous.
+    // ... nor flip an existing app to anonymous ...
     let resp = authed(
-        client().post(format!("{ws}/apps/update/{app_path}")),
+        client().post(format!("{ws}/apps/update/u/test-user-2/test_app")),
+        USER_TOKEN,
+    )
+    .json(&policy_update("anonymous"))
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        403,
+        "with the rule, non-admin flipping an app to anonymous must be rejected"
+    );
+
+    // ... while a publisher create still works.
+    let resp = authed(client().post(format!("{ws}/apps/create")), USER_TOKEN)
+        .json(&app_payload("u/test-user-2/pub_ok", "publisher"))
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 201, "{}", resp.text().await?);
+
+    // ========================================
+    // 4. An admin is never blocked by the rule.
+    // ========================================
+
+    let resp = authed(
+        client().post(format!("{ws}/apps/update/u/test-user-2/test_app")),
         ADMIN_TOKEN,
     )
     .json(&policy_update("anonymous"))
@@ -111,12 +183,15 @@ async fn test_anonymous_execution_mode_requires_admin(db: Pool<Postgres>) -> any
         resp.text().await?
     );
 
-    // 5. A non-admin can still redeploy an app that is already anonymous —
-    //    keeping it anonymous does not change its exposure, and blocking it
-    //    would prevent non-admin editors from deploying public apps at all
-    //    (the frontend always sends the full policy on deploy).
+    // ========================================
+    // 5. A restricted user can still redeploy an app that is already
+    //    anonymous — keeping it anonymous does not change its exposure, and
+    //    blocking it would prevent non-admin editors from deploying public
+    //    apps at all (the frontend always sends the full policy on deploy).
+    // ========================================
+
     let resp = authed(
-        client().post(format!("{ws}/apps/update/{app_path}")),
+        client().post(format!("{ws}/apps/update/u/test-user-2/test_app")),
         USER_TOKEN,
     )
     .json(&json!({
@@ -128,13 +203,17 @@ async fn test_anonymous_execution_mode_requires_admin(db: Pool<Postgres>) -> any
     assert_eq!(
         resp.status(),
         200,
-        "non-admin redeploying an already-anonymous app must succeed: {}",
+        "restricted user redeploying an already-anonymous app must succeed: {}",
         resp.text().await?
     );
 
-    // 6. A non-admin can downgrade the app back to publisher (reduces exposure).
+    // ========================================
+    // 6. A restricted user can downgrade the app back to publisher
+    //    (reduces exposure), but cannot re-flip it to anonymous.
+    // ========================================
+
     let resp = authed(
-        client().post(format!("{ws}/apps/update/{app_path}")),
+        client().post(format!("{ws}/apps/update/u/test-user-2/test_app")),
         USER_TOKEN,
     )
     .json(&policy_update("publisher"))
@@ -143,23 +222,57 @@ async fn test_anonymous_execution_mode_requires_admin(db: Pool<Postgres>) -> any
     assert_eq!(
         resp.status(),
         200,
-        "non-admin downgrading anonymous to publisher must succeed: {}",
+        "restricted user downgrading anonymous to publisher must succeed: {}",
         resp.text().await?
     );
 
-    // 7. After the downgrade, flipping back to anonymous requires admin again.
     let resp = authed(
-        client().post(format!("{ws}/apps/update/{app_path}")),
+        client().post(format!("{ws}/apps/update/u/test-user-2/test_app")),
         USER_TOKEN,
     )
     .json(&policy_update("anonymous"))
     .send()
     .await?;
-    let status = resp.status();
-    let body = resp.text().await?;
     assert_eq!(
-        status, 403,
-        "non-admin re-flipping to anonymous must be rejected: {body}"
+        resp.status(),
+        403,
+        "restricted user re-flipping to anonymous must be rejected"
+    );
+
+    // ========================================
+    // 7. Bypass users are exempt from the rule.
+    // ========================================
+
+    let resp = authed(
+        client().post(format!("{ws}/workspaces/protection_rules/no-public-apps")),
+        ADMIN_TOKEN,
+    )
+    .json(&json!({
+        "rules": ["RestrictAnonymousAppDeployment"],
+        "bypass_users": ["test-user-2"],
+        "bypass_groups": []
+    }))
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        200,
+        "admin should update the protection rule: {}",
+        resp.text().await?
+    );
+
+    let resp = authed(
+        client().post(format!("{ws}/apps/update/u/test-user-2/test_app")),
+        USER_TOKEN,
+    )
+    .json(&policy_update("anonymous"))
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        200,
+        "bypass user flipping an app to anonymous must succeed: {}",
+        resp.text().await?
     );
 
     Ok(())

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -28245,6 +28245,7 @@ components:
         - DisableDirectDeployment
         - DisableWorkspaceForking
         - RestrictDeployToDeployers
+        - RestrictAnonymousAppDeployment
     RuleBypasserGroups:
       type: array
       description: Groups that can bypass this ruleset

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -1348,6 +1348,9 @@ async fn create_app_internal<'a>(
             ));
         }
     }
+    if matches!(app.policy.execution_mode, ExecutionMode::Anonymous) {
+        require_admin(authed.is_admin, &authed.username)?;
+    }
     // CLI / git-sync deploys ask us to preserve any existing user draft at this
     // path instead of wiping it as part of the deploy.
     if !app.skip_draft_deletion.unwrap_or(false) {
@@ -1866,6 +1869,22 @@ async fn update_app_internal<'a>(
         }
 
         if let Some(mut npolicy) = ns.policy {
+            if matches!(npolicy.execution_mode, ExecutionMode::Anonymous) && !authed.is_admin {
+                // Non-admins may keep deploying an app that is already public,
+                // but only admins can flip an app to anonymous (public) access.
+                let already_anonymous = sqlx::query_scalar!(
+                    "SELECT policy->>'execution_mode' = 'anonymous' FROM app WHERE path = $1 AND workspace_id = $2",
+                    path,
+                    w_id
+                )
+                .fetch_optional(&mut *tx)
+                .await?
+                .flatten()
+                .unwrap_or(false);
+                if !already_anonymous {
+                    require_admin(authed.is_admin, &authed.username)?;
+                }
+            }
             let should_preserve = ns.preserve_on_behalf_of.unwrap_or(false)
                 && windmill_common::can_preserve_on_behalf_of(&authed)
                 && npolicy.on_behalf_of.is_some();

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -1886,8 +1886,11 @@ async fn update_app_internal<'a>(
                 // Restricted users may keep deploying an app that is already
                 // public, but flipping an app to anonymous (public) access is
                 // gated by the RestrictAnonymousAppDeployment protection rule.
+                // FOR UPDATE locks the row until this transaction's policy
+                // UPDATE commits, so a concurrent admin downgrade cannot be
+                // silently overwritten by a stale redeploy keeping anonymous.
                 let already_anonymous = sqlx::query_scalar!(
-                    "SELECT policy->>'execution_mode' = 'anonymous' FROM app WHERE path = $1 AND workspace_id = $2",
+                    "SELECT policy->>'execution_mode' = 'anonymous' FROM app WHERE path = $1 AND workspace_id = $2 FOR UPDATE",
                     path,
                     w_id
                 )

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -65,7 +65,9 @@ use windmill_common::{
     },
     variables::{build_crypt, build_crypt_with_key_suffix, encrypt},
     worker::{to_raw_value, CLOUD_HOSTED},
-    workspaces::{check_deploy_rules, RuleCheckResult},
+    workspaces::{
+        check_deploy_rules, check_user_against_rule, ProtectionRuleKind, RuleCheckResult,
+    },
     HUB_BASE_URL,
 };
 #[cfg(feature = "parquet")]
@@ -1349,7 +1351,18 @@ async fn create_app_internal<'a>(
         }
     }
     if matches!(app.policy.execution_mode, ExecutionMode::Anonymous) {
-        require_admin(authed.is_admin, &authed.username)?;
+        if let RuleCheckResult::Blocked(msg) = check_user_against_rule(
+            w_id,
+            &ProtectionRuleKind::RestrictAnonymousAppDeployment,
+            &authed.username,
+            &authed.groups,
+            authed.is_admin,
+            &db,
+        )
+        .await?
+        {
+            return Err(Error::PermissionDenied(msg));
+        }
     }
     // CLI / git-sync deploys ask us to preserve any existing user draft at this
     // path instead of wiping it as part of the deploy.
@@ -1870,8 +1883,9 @@ async fn update_app_internal<'a>(
 
         if let Some(mut npolicy) = ns.policy {
             if matches!(npolicy.execution_mode, ExecutionMode::Anonymous) && !authed.is_admin {
-                // Non-admins may keep deploying an app that is already public,
-                // but only admins can flip an app to anonymous (public) access.
+                // Restricted users may keep deploying an app that is already
+                // public, but flipping an app to anonymous (public) access is
+                // gated by the RestrictAnonymousAppDeployment protection rule.
                 let already_anonymous = sqlx::query_scalar!(
                     "SELECT policy->>'execution_mode' = 'anonymous' FROM app WHERE path = $1 AND workspace_id = $2",
                     path,
@@ -1882,7 +1896,18 @@ async fn update_app_internal<'a>(
                 .flatten()
                 .unwrap_or(false);
                 if !already_anonymous {
-                    require_admin(authed.is_admin, &authed.username)?;
+                    if let RuleCheckResult::Blocked(msg) = check_user_against_rule(
+                        w_id,
+                        &ProtectionRuleKind::RestrictAnonymousAppDeployment,
+                        &authed.username,
+                        &authed.groups,
+                        authed.is_admin,
+                        &db,
+                    )
+                    .await?
+                    {
+                        return Err(Error::PermissionDenied(msg));
+                    }
                 }
             }
             let should_preserve = ns.preserve_on_behalf_of.unwrap_or(false)

--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -68,6 +68,7 @@ bitflags::bitflags! {
         const DISABLE_DIRECT_DEPLOYMENT =           1 << 0;
         const DISABLE_WORKSPACE_FORKING =           1 << 1;
         const RESTRICT_DEPLOY_TO_DEPLOYERS =        1 << 2;
+        const RESTRICT_ANONYMOUS_APP_DEPLOYMENT =   1 << 3;
     }
 }
 
@@ -78,6 +79,7 @@ pub enum ProtectionRuleKind {
     DisableDirectDeployment,
     DisableWorkspaceForking,
     RestrictDeployToDeployers,
+    RestrictAnonymousAppDeployment,
 }
 
 impl ProtectionRuleKind {
@@ -92,6 +94,9 @@ impl ProtectionRuleKind {
             ProtectionRuleKind::RestrictDeployToDeployers => {
                 ProtectionRules::RESTRICT_DEPLOY_TO_DEPLOYERS
             }
+            ProtectionRuleKind::RestrictAnonymousAppDeployment => {
+                ProtectionRules::RESTRICT_ANONYMOUS_APP_DEPLOYMENT
+            }
         }
     }
 
@@ -103,6 +108,9 @@ impl ProtectionRuleKind {
             ProtectionRuleKind::DisableWorkspaceForking => "Forking this workspace is forbidden",
             ProtectionRuleKind::RestrictDeployToDeployers => {
                 "Only workspace admins and members of wm_deployers can deploy to this workspace"
+            }
+            ProtectionRuleKind::RestrictAnonymousAppDeployment => {
+                "Making an app publicly accessible without login (anonymous execution mode) is restricted in this workspace"
             }
         }
     }

--- a/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
@@ -18,7 +18,7 @@
 	import OnBehalfOfSelector, {
 		type OnBehalfOfChoice
 	} from '$lib/components/OnBehalfOfSelector.svelte'
-	import { canUserBypassRuleKind } from '$lib/workspaceProtectionRules.svelte'
+	import { canUserBypassRuleKind, protectionRulesState } from '$lib/workspaceProtectionRules.svelte'
 
 	const WM_DEPLOYERS_GROUP = 'wm_deployers'
 
@@ -61,9 +61,15 @@
 	} = $props()
 
 	let isDeployer = $derived($userStore?.groups?.includes(WM_DEPLOYERS_GROUP) ?? false)
+	// Admins always pass the backend check. For everyone else, fail closed
+	// while the workspace protection rules are still loading so the toggle
+	// is never briefly enabled for a user the rules will end up restricting.
+	let rulesetsLoaded = $derived(protectionRulesState.rulesets !== undefined)
 	let canSetAnonymous = $derived(
-		!!$userStore?.is_super_admin ||
-			canUserBypassRuleKind('RestrictAnonymousAppDeployment', $userStore ?? undefined)
+		!!$userStore?.is_admin ||
+			!!$userStore?.is_super_admin ||
+			(rulesetsLoaded &&
+				canUserBypassRuleKind('RestrictAnonymousAppDeployment', $userStore ?? undefined))
 	)
 	let canPreserve = $derived(!!$userStore?.is_admin || !!$userStore?.is_super_admin || isDeployer)
 	let savedOnBehalfOfEmail = $derived(savedApp?.policy?.on_behalf_of_email)
@@ -258,7 +264,7 @@
 	<h2>Public URL</h2>
 
 	<div class="my-6">
-		{#if !canSetAnonymous}
+		{#if rulesetsLoaded && !canSetAnonymous}
 			<Alert type="warning" title="Restricted by a workspace protection rule" size="xs">
 				Making this app publicly accessible without login is restricted to workspace admins and
 				bypass users by a workspace protection rule

--- a/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
@@ -18,6 +18,7 @@
 	import OnBehalfOfSelector, {
 		type OnBehalfOfChoice
 	} from '$lib/components/OnBehalfOfSelector.svelte'
+	import { canUserBypassRuleKind } from '$lib/workspaceProtectionRules.svelte'
 
 	const WM_DEPLOYERS_GROUP = 'wm_deployers'
 
@@ -60,6 +61,10 @@
 	} = $props()
 
 	let isDeployer = $derived($userStore?.groups?.includes(WM_DEPLOYERS_GROUP) ?? false)
+	let canSetAnonymous = $derived(
+		!!$userStore?.is_super_admin ||
+			canUserBypassRuleKind('RestrictAnonymousAppDeployment', $userStore ?? undefined)
+	)
 	let canPreserve = $derived(!!$userStore?.is_admin || !!$userStore?.is_super_admin || isDeployer)
 	let savedOnBehalfOfEmail = $derived(savedApp?.policy?.on_behalf_of_email)
 	let savedOnBehalfOf = $derived(savedApp?.policy?.on_behalf_of)
@@ -253,9 +258,10 @@
 	<h2>Public URL</h2>
 
 	<div class="my-6">
-		{#if !($userStore?.is_admin || $userStore?.is_super_admin)}
-			<Alert type="warning" title="Admin only" size="xs">
-				Public app access can only be configured by workspace admins
+		{#if !canSetAnonymous}
+			<Alert type="warning" title="Restricted by a workspace protection rule" size="xs">
+				Making this app publicly accessible without login is restricted to workspace admins and
+				bypass users by a workspace protection rule
 			</Alert>
 			<div class="mb-2"></div>
 		{/if}
@@ -270,7 +276,7 @@
 					policy.execution_mode = e.detail ? 'anonymous' : 'publisher'
 					setPublishState()
 				}}
-				disabled={!savedApp || !($userStore?.is_admin || $userStore?.is_super_admin)}
+				disabled={!savedApp || (!canSetAnonymous && policy.execution_mode != 'anonymous')}
 			/>
 		</div>
 		{#if !savedApp}

--- a/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
@@ -253,6 +253,12 @@
 	<h2>Public URL</h2>
 
 	<div class="my-6">
+		{#if !($userStore?.is_admin || $userStore?.is_super_admin)}
+			<Alert type="warning" title="Admin only" size="xs">
+				Public app access can only be configured by workspace admins
+			</Alert>
+			<div class="mb-2"></div>
+		{/if}
 		<div class="flex gap-2 items-center mb-2">
 			<Toggle
 				options={{
@@ -264,7 +270,7 @@
 					policy.execution_mode = e.detail ? 'anonymous' : 'publisher'
 					setPublishState()
 				}}
-				disabled={!savedApp}
+				disabled={!savedApp || !($userStore?.is_admin || $userStore?.is_super_admin)}
 			/>
 		</div>
 		{#if !savedApp}

--- a/frontend/src/lib/components/workspaceSettings/RulesetEditor.svelte
+++ b/frontend/src/lib/components/workspaceSettings/RulesetEditor.svelte
@@ -37,6 +37,7 @@
 	let disableDirectDeployment = $state(hasRule('DisableDirectDeployment'))
 	let disableFork = $state(hasRule('DisableWorkspaceForking'))
 	let restrictDeployToDeployers = $state(hasRule('RestrictDeployToDeployers'))
+	let restrictAnonymousAppDeployment = $state(hasRule('RestrictAnonymousAppDeployment'))
 	let selectedGroups = $state<string[]>(
 		untrack(() => rule)?.bypass_groups?.map((g) => g.replace('g/', '')) ?? []
 	)
@@ -49,6 +50,7 @@
 	let initialDisableDirectDeployment = $state(hasRule('DisableDirectDeployment'))
 	let initialDisableFork = $state(hasRule('DisableWorkspaceForking'))
 	let initialRestrictDeployToDeployers = $state(hasRule('RestrictDeployToDeployers'))
+	let initialRestrictAnonymousAppDeployment = $state(hasRule('RestrictAnonymousAppDeployment'))
 	let initialSelectedGroups = $state<string[]>(
 		untrack(() => rule)?.bypass_groups
 			? untrack(() => rule)!.bypass_groups.map((g) => g.replace('g/', ''))
@@ -115,12 +117,14 @@
 					disableDirectDeployment ||
 					disableFork ||
 					restrictDeployToDeployers ||
+					restrictAnonymousAppDeployment ||
 					selectedGroups.length > 0 ||
 					selectedUsers.length > 0
 			: name !== initialName ||
 					disableDirectDeployment !== initialDisableDirectDeployment ||
 					disableFork !== initialDisableFork ||
 					restrictDeployToDeployers !== initialRestrictDeployToDeployers ||
+					restrictAnonymousAppDeployment !== initialRestrictAnonymousAppDeployment ||
 					JSON.stringify([...selectedGroups].sort()) !==
 						JSON.stringify([...initialSelectedGroups].sort()) ||
 					JSON.stringify([...selectedUsers].sort()) !==
@@ -160,6 +164,9 @@
 						...(disableFork ? ['DisableWorkspaceForking' as ProtectionRuleKind] : []),
 						...(restrictDeployToDeployers
 							? ['RestrictDeployToDeployers' as ProtectionRuleKind]
+							: []),
+						...(restrictAnonymousAppDeployment
+							? ['RestrictAnonymousAppDeployment' as ProtectionRuleKind]
 							: [])
 					],
 					bypass_groups: selectedGroups,
@@ -188,6 +195,9 @@
 						...(disableFork ? ['DisableWorkspaceForking' as ProtectionRuleKind] : []),
 						...(restrictDeployToDeployers
 							? ['RestrictDeployToDeployers' as ProtectionRuleKind]
+							: []),
+						...(restrictAnonymousAppDeployment
+							? ['RestrictAnonymousAppDeployment' as ProtectionRuleKind]
 							: [])
 					],
 					bypass_groups: selectedGroups,
@@ -202,6 +212,7 @@
 			initialDisableDirectDeployment = disableDirectDeployment
 			initialDisableFork = disableFork
 			initialRestrictDeployToDeployers = restrictDeployToDeployers
+			initialRestrictAnonymousAppDeployment = restrictAnonymousAppDeployment
 			initialSelectedGroups = clone(selectedGroups)
 			initialSelectedUsers = clone(selectedUsers)
 
@@ -333,6 +344,20 @@
 				<div class="text-xs text-secondary ml-6">
 					Only workspace admins and members of <code>wm_deployers</code> can deploy to this workspace.
 					Non-deployers can still fork, browse, and request a review.
+				</div>
+			</div>
+
+			<!-- Restrict anonymous app deployment -->
+			<div class="flex flex-col gap-2">
+				<Toggle
+					bind:checked={restrictAnonymousAppDeployment}
+					options={{
+						right: 'Restrict public app access'
+					}}
+				/>
+				<div class="text-xs text-secondary ml-6">
+					Only workspace admins and bypass users can make an app publicly accessible without login
+					(anonymous execution mode). Apps that are already public can still be redeployed.
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Fixes WIN-2026

## Summary

Any user with write access to an app can toggle its execution mode to `anonymous` (no login required), making the app publicly accessible without authentication or oversight. This PR adds an opt-in **workspace protection rule** — `RestrictAnonymousAppDeployment` — to gate that action. **By default (rule not enabled), behavior is unchanged**: any writer can still deploy anonymous apps, exactly as before.

When a workspace protection ruleset enables the rule, only workspace admins and the ruleset's bypass users/groups can create an anonymous app or flip an existing app to anonymous.

**Judgment call on the update path**: the frontend sends the full `policy` object on *every* deploy, so a flat "anonymous ⇒ blocked" check would lock restricted editors out of deploying apps that are already public. The update gate therefore only blocks the *transition into* anonymous mode (checked against the app's current policy in the same transaction): restricted users can still redeploy an already-anonymous app (no exposure change) and downgrade it to `publisher` (exposure reduction), but cannot flip an app to public.

## Changes

- `backend/windmill-common/src/workspaces.rs`: new `RESTRICT_ANONYMOUS_APP_DEPLOYMENT` bitflag + `ProtectionRuleKind::RestrictAnonymousAppDeployment` variant with its message.
- `backend/windmill-api/src/apps.rs`:
  - `create_app_internal`: creating an app with `execution_mode: anonymous` runs `check_user_against_rule` for the new kind (admins always pass; bypass users/groups pass; everyone passes when no ruleset enables the rule).
  - `update_app_internal`: flipping an app's policy to `anonymous` runs the same check, unless the app is already anonymous. Missing row / missing `execution_mode` fail closed (gate applies).
- `backend/windmill-api/openapi.yaml`: new `ProtectionRuleKind` enum value (frontend + CLI clients are generated from this; gen dirs are gitignored).
- `frontend/src/lib/components/workspaceSettings/RulesetEditor.svelte`: new "Restrict public app access" toggle in the protection-rules editor.
- `frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte`: the "No login required" toggle is disabled (with an explanatory alert) when the rule is active and the user can't bypass it, reusing `canUserBypassRuleKind` from the existing protection-rules state (loaded on boot in `+layout.svelte`). Restricted users can still toggle an already-public app back to login-required.
- `backend/tests/app_anonymous_execution_mode.rs`: integration test covering default behavior (no rule → non-admin can deploy anonymous apps), rule enforcement (create + flip blocked with 403 naming the ruleset, publisher create OK), admin exemption, redeploy-while-anonymous, publisher downgrade, and bypass-user exemption.

## Validation

- `cargo test --test app_anonymous_execution_mode` passes (1 passed, covering all scenarios above).
- UI verified end-to-end in headless Chromium against the dev stack:
  - no rule, non-admin: toggle enabled, no alert (previous behavior) — https://files.catbox.moe/256gle.png
  - rule enabled, non-admin: toggle disabled + "Restricted by a workspace protection rule" alert — https://files.catbox.moe/il8k6m.png
  - rule enabled, admin: toggle enabled, no alert — https://files.catbox.moe/10kcj2.png
  - ruleset editor with the new "Restrict public app access" toggle — https://files.catbox.moe/063j2z.png
- `npm run check:fast` reports only pre-existing errors (unrelated `setTimeout`/`Timeout` type errors present on baseline).
- Backend compiles cleanly; no new SQL queries beyond the current-policy lookup already cached in `.sqlx/`.

## Notes

- The rule integrates with the existing protection-ruleset machinery: 60s server-side cache (invalidated on rule CRUD), per-ruleset bypass users/groups, `wm_deployers` semantics unaffected.
- CLI `protection-rules` commands pass kinds through generated types, so no CLI command changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)