### PR TITLE
fix(nsjail): make ansible collections mount non-mandatory

### DIFF
--- a/backend/windmill-worker/nsjail/run.ansible.config.proto
+++ b/backend/windmill-worker/nsjail/run.ansible.config.proto
@@ -98,6 +98,7 @@ mount {
     src: "{JOB_DIR}/ansible_collections/"
     dst: "/tmp/ansible_collections/"
     is_bind: true
+    mandatory: false
 }
 
 mount {


### PR DESCRIPTION
## Summary

Follow-up to #9507 (WIN-2024), found while doing end-to-end verification of that fix.

The ansible nsjail config has a bind mount for `{JOB_DIR}/ansible_collections/`, but that directory is only created when the script declares `dependencies.galaxy.collections` **and** `ansible-galaxy` actually installs something into the job dir (collections bundled with the `ansible` community package are skipped with "already installed"). For any playbook without galaxy-installed collections, the source path doesn't exist and nsjail aborts with `Failed to mount mandatory point: '/tmp/ansible_collections/'` → `Launching child process failed`.

This was previously masked by the `/root/.local/share/uv/tools/ansible` mandatory mount failing first (fixed in #9507): with that fix alone, collection-less ansible scripts still cannot run under nsjail. Same fix, same idiom as the sibling `requirements.yml` mount which is already `mandatory: false`.

## Changes

- Add `mandatory: false` to the `{JOB_DIR}/ansible_collections/` mount block in `backend/windmill-worker/nsjail/run.ansible.config.proto`

## End-to-end verification (done locally)

Reproduced the production setup on a dev box: installed ansible exactly like the Docker image (`uv tool install ansible` with `UV_TOOL_DIR=/usr/local/uv`, `UV_TOOL_BIN_DIR=/usr/local/bin`, `UV_PYTHON_INSTALL_DIR=/tmp/windmill/cache/py_runtime`; `/root/.local/share/uv/tools/` absent), ran a standalone worker (`MODE=worker DISABLE_NSJAIL=false`, `--features python`) and executed an ansible script through the full API → worker → nsjail path:

- **Before #9507** (mandatory uv tools mount): job fails with `Failed to mount mandatory point: '/root/.local/share/uv/tools/ansible'` → `Launching child process failed` — exact production failure reproduced.
- **With #9507 only**: job fails with `Failed to mount mandatory point: '/tmp/ansible_collections/'` — this PR's bug.
- **With both fixes**: job succeeds under `isolation=nsjail`; playbook runs from the `/usr/local/uv` install via the `/usr` mount and returns its result (`{"a": 2, "b": true, "c": "Hello"}`).
- **Mount semantics sanity check** (direct nsjail run): with `mandatory: false`, a mount whose source exists is mounted with its content visible inside the jail; a mount whose source is missing is skipped without aborting the launch.

## Test plan

- [x] E2E before/after on a worker with nsjail enabled (see above)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Ansible collections bind mount in the nsjail config non-mandatory so playbooks without galaxy-installed collections run under isolation. Prevents nsjail aborts when `{JOB_DIR}/ansible_collections/` is missing; follow-up to WIN-2024 after the `uv` tools mount fix.

<sup>Written for commit 100bce7d93882c35ac132ff0dca4fed3c31bbac4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

