### PR TITLE
docs: replace dead 0x0.st with gh-based PR screenshot recipe

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -55,18 +55,44 @@ The body MUST be explicit about what changed. Structure:
 
 The harness/tooling that invoked the skill may add its own attribution trailer; the skill itself does not prescribe one.
 
+## Screenshots (required for frontend changes)
+
+If `git diff main...HEAD --name-only` matches `^frontend/`, the PR body **must** include
+screenshots of the affected UI. Skip only when there is no visible UI effect (types,
+tests, build config) — and say so in the body.
+
+1. Verify the change in the browser (AGENTS.md → "Verifying Frontend Changes").
+2. Screenshot each affected page with `mcp__playwright__browser_take_screenshot` (save to a file).
+3. Host each image and get its Markdown embed by pushing to the public
+   `windmill-labs/agent-screenshots-internal` repo. **Pipe base64 through stdin** —
+   passing it as `-f content=…` fails with `argument list too long` on real images:
+
+   ```bash
+   REPO=windmill-labs/agent-screenshots-internal
+   DEST="shots/$(git branch --show-current)/$(date +%s)-screenshot.png"
+   base64 -w0 screenshot.png | jq -Rs --arg m "add $DEST" '{message:$m, content:.}' \
+     | gh api -X PUT "repos/$REPO/contents/$DEST" --input - >/dev/null
+   echo "![screenshot](https://raw.githubusercontent.com/$REPO/main/$DEST)"
+   ```
+4. Put the printed `![…](…)` lines under a `## Screenshots` heading in the PR body.
+
+Requires `gh` (`repo` scope), `jq`, `base64` — all in the devShell. The host repo is
+public so the URLs render for reviewers without a token. (GitHub's drag-and-drop
+uploader needs a browser session and can't be driven from a token.)
+
 ## Execution Steps
 
 1. Run `git status` to check for uncommitted changes
 2. Run `git log main..HEAD --oneline` to see all commits in this branch
 3. Run `git diff main...HEAD` to see the full diff against main
 4. **Invoke the `local-review` skill** before creating the PR (`/local-review` in Claude Code, `$local-review` in Codex, `pi --skill local-review` / `/skill:local-review` in Pi). If issues are found, fix them and commit before proceeding. Do not skip this step.
-5. Check if remote branch exists and is up to date:
+5. **Screenshots for frontend changes**: if `git diff main...HEAD --name-only` matches `^frontend/`, capture and embed screenshots of the affected UI per "Screenshots" above before writing the PR body (skip only if there is no visible UI effect).
+6. Check if remote branch exists and is up to date:
    ```bash
    git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || echo "no upstream"
    ```
-6. Push to remote if needed: `git push -u origin HEAD`
-7. Create draft PR using gh CLI:
+7. Push to remote if needed: `git push -u origin HEAD`
+8. Create draft PR using gh CLI:
    ```bash
    gh pr create --draft --title "<type>: <description>" --body "$(cat <<'EOF'
    ## Summary
@@ -82,7 +108,7 @@ The harness/tooling that invoked the skill may add its own attribution trailer; 
    EOF
    )"
    ```
-8. Return the PR URL to the user
+9. Return the PR URL to the user
 
 ## EE Companion PR (when `*_ee.rs` files were modified)
 

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -69,16 +69,27 @@ tests, build config) — and say so in the body.
 
    ```bash
    REPO=windmill-labs/agent-screenshots-internal
-   DEST="shots/$(git branch --show-current)/$(date +%s)-screenshot.png"
-   base64 -w0 screenshot.png | jq -Rs --arg m "add $DEST" '{message:$m, content:.}' \
+   IMG=screenshot.png                                          # repeat per page
+   DEST="shots/$(git branch --show-current)/$(date +%s)-$(basename "$IMG")"
+   base64 -w0 "$IMG" | jq -Rs --arg m "add $DEST" '{message:$m, content:.}' \
      | gh api -X PUT "repos/$REPO/contents/$DEST" --input - >/dev/null
-   echo "![screenshot](https://raw.githubusercontent.com/$REPO/main/$DEST)"
+   echo "![$(basename "$IMG" .png)](https://raw.githubusercontent.com/$REPO/main/$DEST)"
    ```
+   Derive `$DEST` from the file name (as above) so distinct pages never collide — a
+   fixed name would make same-second uploads reuse one path, and the second `PUT`
+   then 422s (the Contents API needs the existing file's `sha` to overwrite).
 4. Put the printed `![…](…)` lines under a `## Screenshots` heading in the PR body.
 
 Requires `gh` (`repo` scope), `jq`, `base64` — all in the devShell. The host repo is
-public so the URLs render for reviewers without a token. (GitHub's drag-and-drop
-uploader needs a browser session and can't be driven from a token.)
+public (so the raw URLs render for reviewers without a token) and its history is
+permanent — **never screenshot pages that show secrets or sensitive values** (workspace
+variables, resource values, instance settings, OAuth/SMTP config); deleting the file
+can't undo an accidental capture. (GitHub's drag-and-drop uploader needs a browser
+session and can't be driven from a token.)
+
+If `gh` can't push to the host repo (e.g. a CI token scoped only to `windmill`), do
+**not** fail the PR or skip silently — hand the upload to the user, who has push access,
+and continue once they confirm it's done.
 
 ## Execution Steps
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ Typical flow:
 5. `mcp__playwright__browser_take_screenshot` for visual confirmation
 6. `mcp__playwright__browser_console_messages` / `browser_network_requests` to surface errors
 
+**Attach the screenshots to the PR.** For any change under `frontend/`, embed screenshots of the affected UI in the PR body — the `pr` skill requires this and carries the upload recipe.
+
 If you cannot exercise a UI change (no dev server, etc.), say so explicitly rather than claiming success.
 
 ## Banned Patterns

--- a/docs/autonomous-mode.md
+++ b/docs/autonomous-mode.md
@@ -73,4 +73,9 @@ In your final summary, provide:
 - **Terminal recordings** of CLI changes (via asciinema)
 - Any known limitations or follow-up work needed
 
-Upload images via pastebin (e.g., `curl -F 'file=@screenshot.png' https://0x0.st`) and include the URLs in the PR description or comments.
+### Attaching images to a PR
+
+Embed screenshots, Mermaid diagrams, and asciinema frames by uploading them to the
+public `windmill-labs/agent-screenshots-internal` repo and pasting the
+`raw.githubusercontent.com` URL into the PR. The upload recipe lives in the `pr`
+skill (`.agents/skills/pr/SKILL.md` → "Screenshots"); reuse it for any image type.


### PR DESCRIPTION
## Summary

The autonomous-agent workflow instructed agents to upload PR screenshots via the `0x0.st` pastebin, which has since **disabled uploads** (returns HTTP 503). As a result agents could no longer attach screenshots, diagrams, or casts to PRs.

This replaces it with a token-friendly recipe: push the image to the public `windmill-labs/agent-screenshots-internal` repo via `gh api` and embed the tokenless `raw.githubusercontent.com` URL, which renders inline in PRs and never expires. (GitHub's native drag-and-drop attachment uploader requires a browser session and can't be driven from a token.)

The recipe is single-sourced in the `pr` skill so it works across all three CLIs (Claude/Codex/Pi), and for any change under `frontend/` the `pr` skill now requires screenshots of the affected UI by default.

## Changes

- **`.agents/skills/pr/SKILL.md`** — canonical home: add the upload recipe + a "screenshots required for frontend changes" rule and execution step.
- **`AGENTS.md`** → "Verifying Frontend Changes" — one-line rule in the always-loaded baseline pointing at the skill.
- **`docs/autonomous-mode.md`** — replace the dead `0x0.st` line with a one-line pointer to the skill recipe (still covers diagrams/asciinema casts).

## Test plan

- [x] Verified end-to-end against `windmill-labs/agent-screenshots-internal`: upload via `gh api`, tokenless raw URL returns `HTTP 200, content-type=image/png`, renders inline; re-run is idempotent.
- [x] Confirmed the naive `-f content=$(base64 …)` form fails with `argument list too long` on a 480 KB image, while the stdin form succeeds — hence the `base64 | jq -Rs | gh api --input -` pipeline.
- [ ] Docs-only change: no `frontend/` code touched, so no screenshots required for this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced broken `0x0.st` uploads with a GitHub `gh api` recipe to host PR screenshots, diagrams, and casts via `windmill-labs/agent-screenshots-internal`, and hardened it with collision-safe paths, secret-safety guidance, and a CI fallback. Added a `frontend/` rule requiring screenshots embedded via `raw.githubusercontent.com`.

- **New Features**
  - Added and hardened upload recipe in `.agents/skills/pr/SKILL.md`: stdin base64 pipeline; unique `$DEST` per image to avoid collisions; public-hosting “no secrets” warning; fallback when `gh` can’t push (hand off to user).
  - Enforced screenshot requirement for `frontend/` changes in the `pr` skill and execution steps (capture before drafting the PR).
  - Updated `AGENTS.md` and `docs/autonomous-mode.md` to point to the recipe and remove `0x0.st`.

<sup>Written for commit d870aaf88ad2a1b756d5b49327b8223ffa02bee1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

