### PR TITLE
fix(frontend): clarify trigger filters match the message parsed as JSON

### DIFF
--- a/frontend/src/lib/components/triggers/TriggerFilters.svelte
+++ b/frontend/src/lib/components/triggers/TriggerFilters.svelte
@@ -10,12 +10,16 @@
 		filters: { key: string; value: any }[]
 		filterLogic: 'and' | 'or'
 		disabled?: boolean
+		// Set when the runnable receives the payload base64-encoded (e.g. Kafka).
+		// Filters are always evaluated on the decoded JSON, so we clarify the distinction.
+		payloadBase64Encoded?: boolean
 	}
 
 	let {
 		filters = $bindable([]),
 		filterLogic = $bindable(),
-		disabled = false
+		disabled = false,
+		payloadBase64Encoded = false
 	}: Props = $props()
 
 	const filterLogicItems = [
@@ -28,12 +32,20 @@
 			? 'Filters will limit the execution of the trigger to only messages that match any criterion.'
 			: 'Filters will limit the execution of the trigger to only messages that match all criteria.'
 	)
+
+	let filterHelp = $derived(
+		'The JSON filter checks if the value at the key is equal or a superset of the filter value. ' +
+			'Filters are evaluated on the decoded JSON payload, so filter keys reference the original JSON structure (e.g. type, data.status).' +
+			(payloadBase64Encoded
+				? ' The runnable still receives the payload as a base64-encoded string.'
+				: '')
+	)
 </script>
 
 <Section label="Filters">
 	<p class="text-xs mb-1 text-primary">
 		{description}<br />
-		The JSON filter checks if the value at the key is equal or a superset of the filter value.
+		{filterHelp}
 	</p>
 	{#if filters.length > 0}
 		<div class="mt-2 mb-1 max-w-xs">

--- a/frontend/src/lib/components/triggers/TriggerFilters.svelte
+++ b/frontend/src/lib/components/triggers/TriggerFilters.svelte
@@ -11,7 +11,7 @@
 		filterLogic: 'and' | 'or'
 		disabled?: boolean
 		// Set when the runnable receives the payload base64-encoded (e.g. Kafka).
-		// Filters are always evaluated on the decoded JSON, so we clarify the distinction.
+		// Filters always run on the message parsed as JSON, so we clarify the distinction.
 		payloadBase64Encoded?: boolean
 	}
 
@@ -35,9 +35,9 @@
 
 	let filterHelp = $derived(
 		'The JSON filter checks if the value at the key is equal or a superset of the filter value. ' +
-			'Filters are evaluated on the decoded JSON payload, so filter keys reference the original JSON structure (e.g. type, data.status).' +
+			"Filters match against the message parsed as JSON, so filter keys reference the message's own structure (e.g. type, data.status)." +
 			(payloadBase64Encoded
-				? ' The runnable still receives the payload as a base64-encoded string.'
+				? ' The runnable still receives the payload base64-encoded; filters run on the message before that encoding.'
 				: '')
 	)
 </script>

--- a/frontend/src/lib/components/triggers/TriggerFilters.svelte
+++ b/frontend/src/lib/components/triggers/TriggerFilters.svelte
@@ -35,7 +35,7 @@
 
 	let filterHelp = $derived(
 		'The JSON filter checks if the value at the key is equal or a superset of the filter value. ' +
-			"Filters match against the message parsed as JSON, so filter keys reference the message's own structure (e.g. type, data.status)." +
+			'Keys match top-level fields of the message (parsed as JSON); to match a nested field, set an object value (e.g. key data, value {"status": "active"}).' +
 			(payloadBase64Encoded
 				? ' The runnable still receives the payload base64-encoded; filters run on the message before that encoding.'
 				: '')

--- a/frontend/src/lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte
@@ -616,7 +616,12 @@
 						</Label>
 					{/if}
 
-					<TriggerFilters bind:filters bind:filterLogic disabled={!can_write} />
+					<TriggerFilters
+						bind:filters
+						bind:filterLogic
+						disabled={!can_write}
+						payloadBase64Encoded
+					/>
 
 					<div class="min-h-96">
 						<Tabs bind:selected={optionTabSelected}>


### PR DESCRIPTION
## What

Clarifies the filter description in the trigger editor so users understand that **filters are evaluated on the original decoded JSON payload**, while a base64-encoding trigger (Kafka) still delivers the payload to the runnable as a **base64-encoded string**.

Previously `TriggerFilters.svelte` only said *"The JSON filter checks if the value at the key is equal or a superset of the filter value"*. Users who saw base64 in their Kafka scripts assumed filters also operate on base64 and concluded filters couldn't reference JSON keys.

## Changes

- `TriggerFilters.svelte`: builds the help text as a derived string and adds a new optional `payloadBase64Encoded` prop. When set, it appends: *"The runnable still receives the payload as a base64-encoded string."* The shared sentence now also notes filters reference the original JSON structure (e.g. `type`, `data.status`).
- `KafkaTriggerEditorInner.svelte`: passes `payloadBase64Encoded` (Kafka base64-encodes the payload for the runnable via `v2_payload_fn`).

## Judgment call

The issue proposed adding a blanket *"The runnable still receives the payload as base64-encoded"* line to the shared component. That would be **inaccurate for WebSocket triggers**, which are the other consumer of `TriggerFilters` and deliver the raw message to the runnable as a plain string argument (`msg`) — not base64 (binary WS messages are ignored entirely). So the base64 caveat is shown **only** for Kafka via the new prop, keeping the WebSocket text accurate.

This matches the backend: both Kafka (`String::from_utf8(payload)`) and WebSocket (raw text) run `check_filters` on the decoded JSON; only Kafka then base64-encodes the payload for the runnable.

## Validation

- `svelte-autofixer`: no issues
- `npm run check:fast`: no new errors (one pre-existing unrelated error in `ChatContextPicker.svelte`)
- Browser-verified via Playwright:
  - **Kafka** trigger editor → Filters section shows the base64 caveat with correct spacing
  - **WebSocket** trigger editor → Filters section shows the decoded-JSON clarification **without** the base64 line

## Docs

The corresponding documentation clarifications (Kafka + WebSocket filter sections) are made in a separate PR against the `windmilldocs` repo.

Fixes WIN-2029

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies trigger filter help: filters match against the message parsed as JSON; for Kafka, adds a note that the runnable still receives base64 while filters run before encoding. Fixes WIN-2029.

- **Bug Fixes**
  - `TriggerFilters.svelte`: added optional `payloadBase64Encoded` and derived help text; reworded to “parsed as JSON”; clarified keys match top‑level fields and nested matching is via an object value (e.g., key data, value {"status":"active"}); appends base64 note when set.
  - `KafkaTriggerEditorInner.svelte`: passes `payloadBase64Encoded` so Kafka shows the base64 caveat.

<sup>Written for commit 570c5ccf7145fbbd59627ceb0ff90ffc113f17a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

