### PR TITLE
feat(frontend): show AI sessions in narrow-screen burger menu

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
+++ b/frontend/src/lib/components/copilot/chat/AiChatLayout.svelte
@@ -50,6 +50,23 @@
 	})
 </script>
 
+{#snippet burgerRow()}
+	<div
+		class={classNames(
+			'py-0.5 px-4 sm:px-4 shadow-sm max-w-7xl md:hidden justify-start flex',
+			noBorder || $userStore?.operator ? 'hidden' : ''
+		)}
+	>
+		<Button
+			variant="subtle"
+			unifiedSize="lg"
+			onClick={() => onMenuOpen?.()}
+			startIcon={{ icon: Menu }}
+			iconOnly
+		/>
+	</div>
+{/snippet}
+
 {#if !disableAi}
 	<CreatedResourceActionDrawers />
 	<Splitpanes horizontal={false} class="flex-1 min-h-0">
@@ -64,20 +81,7 @@
 			>
 				<main class="flex-1 flex flex-col min-h-0">
 					<div class="relative w-full flex-1 flex flex-col min-h-0">
-						<div
-							class={classNames(
-								'py-0.5 px-4 sm:px-4 shadow-sm max-w-7xl md:hidden justify-start flex',
-								noBorder || $userStore?.operator ? 'hidden' : ''
-							)}
-						>
-							<Button
-								variant="subtle"
-								unifiedSize="lg"
-								onClick={() => onMenuOpen?.()}
-								startIcon={{ icon: Menu }}
-								iconOnly
-							/>
-						</div>
+						{@render burgerRow()}
 						<div class="flex-1 min-h-0">
 							{@render children?.()}
 						</div>
@@ -103,6 +107,9 @@
 			'transition-all ease-in-out duration-200'
 		)}
 	>
-		{@render children?.()}
+		{@render burgerRow()}
+		<div class="flex-1 min-h-0 flex flex-col">
+			{@render children?.()}
+		</div>
 	</div>
 {/if}

--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -602,6 +602,13 @@
 										/>
 									</div>
 
+									<!-- w-40 cap: the drawer is max-w-min, and long session titles
+									     (nowrap before truncation) would otherwise inflate its
+									     min-content width to the full text width. -->
+									<div class="w-40">
+										<SessionPicker isCollapsed={false} />
+									</div>
+
 									<SidebarContent
 										isCollapsed={false}
 										numUnacknowledgedCriticalAlerts={isCriticalAlertsUiMuted


### PR DESCRIPTION
## Summary

On narrow viewports (< 768px) the sidebar collapses into a burger-menu drawer, which never included the AI sessions picker — sessions were unreachable from the navigation entirely. This adds the existing `SessionPicker` (expanded mode) to the drawer, mirroring the wide sidebar's placement between the Ask AI button block and the main navigation. It also fixes the `/sessions` page itself, which rendered no burger button at all in narrow mode (the `disableAi` branch of `AiChatLayout` lacked the burger row), leaving users stranded there with no navigation.

Scope is intentionally minimal: only the access path. No unread indicator on the burger button, no responsive work on the `/sessions` page content, and the hover-revealed per-session actions are reused unchanged.

## Changes

- Render `<SessionPicker isCollapsed={false} />` in the narrow-layout slide-over drawer in `+layout.svelte`
- Wrap it in a `w-40` container: the drawer sizes itself with `max-w-min`, and long session titles (nowrap before truncation) would otherwise inflate the drawer's min-content width to the full text width — observed ballooning to full viewport width during verification
- Extract the burger-menu row in `AiChatLayout` into a snippet and render it in both branches, so the `disableAi` branch (the `/sessions` route) gets the burger button like every other page

What comes for free from reusing `SessionPicker`: the `isGlobalAiEnabled()` dev gate (section hidden when the flag is off), drawer auto-close on session click (`goto` → `beforeNavigate` → `menuOpen = false`), scrollable list, rename/archive/delete, filter popover, and the new-session button.

## Test plan

- [ ] With `wm_dev_global_ai=1` in localStorage, shrink the viewport below 768px, open the burger menu: an "AI sessions" section appears between Ask AI and Home
- [ ] Sessions with long titles truncate within the drawer instead of widening it
- [ ] Clicking a session navigates to `/sessions?session_name=...` and closes the drawer
- [ ] On `/sessions` itself, the burger button appears at the top and opens the drawer; the active session is highlighted
- [ ] Hitting "+" (new session) from the drawer closes it and lands on the new session — including when already on `/sessions` with the same transient session (same-URL goto)
- [ ] `ScriptWrapper`/`FlowWrapper` (which pass `noPadding`) still hide the burger row as before
- [ ] Without the dev flag, the section is absent from the drawer

## Screenshots

Drawer at 420px viewport with seeded sessions (titles truncate, drawer stays at w-40):

![drawer-with-sessions-w40](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/show-sessions-in-narrow-setup/1781107627-drawer-with-sessions-w40.png)

Empty state (no sessions yet):

![drawer-open-narrow](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/show-sessions-in-narrow-setup/1781107627-drawer-open-narrow.png)

`/sessions` page now showing the burger button in narrow mode:

![sessions-page-burger](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/show-sessions-in-narrow-setup/1781108219-sessions-page-burger.png)

Drawer opened from `/sessions` (active session highlighted):

![sessions-page-drawer-open](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/show-sessions-in-narrow-setup/1781108219-sessions-page-drawer-open.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)