### PR TITLE
feat(openapi): add compatibility classifier

### DIFF
--- a/scripts/openapi-compat/README.md
+++ b/scripts/openapi-compat/README.md
@@ -1,0 +1,33 @@
+# OpenAPI Compatibility Classifier
+
+This utility compares two dereferenced OpenAPI JSON files and reports changes that can break generated clients or strict validators.
+
+It was added for the release-safety question in issue 8719. The classifier is intentionally conservative for request-side changes and configurable for response-side required fields.
+
+## Run
+
+```bash
+node scripts/openapi-compat/classify-openapi-changes.mjs before.json after.json
+```
+
+By default, adding required fields to response schemas is reported as a warning. If you want strict generated-client compatibility, treat those as breaking:
+
+```bash
+node scripts/openapi-compat/classify-openapi-changes.mjs before.json after.json --response-required=breaking
+```
+
+The command exits with code 1 when it finds breaking changes and prints a JSON report.
+
+## What It Detects
+
+- removed operations
+- removed parameters
+- optional parameters becoming required
+- new required parameters
+- request body becoming required
+- new required request schema fields
+- enum value removals
+- removed component schemas
+- new required response fields, warning by default or breaking in strict mode
+
+The script expects JSON. Use `backend/windmill-api/openapi-deref.json` or another dereferenced OpenAPI JSON artifact when comparing releases.

--- a/scripts/openapi-compat/classify-openapi-changes.mjs
+++ b/scripts/openapi-compat/classify-openapi-changes.mjs
@@ -1,0 +1,368 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+const HTTP_METHODS = new Set(["get", "put", "post", "delete", "patch", "options", "head", "trace"]);
+
+export function pointer(parts) {
+  return parts
+    .map((part) =>
+      String(part)
+        .replaceAll("~", "~0")
+        .replaceAll("/", "~1"),
+    )
+    .join("/");
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function get(obj, parts) {
+  return parts.reduce((current, part) => (current === undefined || current === null ? undefined : current[part]), obj);
+}
+
+function collectOperations(spec) {
+  const operations = new Map();
+  for (const [pathName, pathItem] of Object.entries(spec.paths ?? {})) {
+    for (const [method, operation] of Object.entries(pathItem ?? {})) {
+      if (!HTTP_METHODS.has(method)) continue;
+      operations.set(`${method.toUpperCase()} ${pathName}`, {
+        pathName,
+        method,
+        pathItem,
+        operation,
+      });
+    }
+  }
+  return operations;
+}
+
+function collectParameters(pathItem, operation) {
+  const parameters = new Map();
+  for (const parameter of [...asArray(pathItem?.parameters), ...asArray(operation?.parameters)]) {
+    if (!parameter || parameter.$ref) continue;
+    parameters.set(`${parameter.in}:${parameter.name}`, parameter);
+  }
+  return parameters;
+}
+
+function collectRequiredSchemaProperties(schema, basePath = []) {
+  const required = [];
+  if (!isObject(schema)) return required;
+
+  for (const field of asArray(schema.required)) {
+    required.push([...basePath, field]);
+  }
+
+  for (const [name, child] of Object.entries(schema.properties ?? {})) {
+    required.push(...collectRequiredSchemaProperties(child, [...basePath, name]));
+  }
+
+  if (isObject(schema.items)) {
+    required.push(...collectRequiredSchemaProperties(schema.items, [...basePath, "*"]));
+  }
+
+  return required;
+}
+
+function collectEnums(schema, basePath = []) {
+  const enums = [];
+  if (!isObject(schema)) return enums;
+
+  if (Array.isArray(schema.enum)) {
+    enums.push({ path: basePath, values: schema.enum.map(String) });
+  }
+
+  for (const [name, child] of Object.entries(schema.properties ?? {})) {
+    enums.push(...collectEnums(child, [...basePath, name]));
+  }
+
+  if (isObject(schema.items)) {
+    enums.push(...collectEnums(schema.items, [...basePath, "*"]));
+  }
+
+  return enums;
+}
+
+function jsonPointer(path) {
+  return `/${pointer(path)}`;
+}
+
+function makeFinding({ severity, kind, location, message, before, after }) {
+  return { severity, kind, location, message, before, after };
+}
+
+function requestBodySchema(operation) {
+  const body = operation?.requestBody;
+  const content = body?.content ?? {};
+  return (
+    content["application/json"]?.schema ??
+    content["application/x-www-form-urlencoded"]?.schema ??
+    content["multipart/form-data"]?.schema
+  );
+}
+
+function responseSchemas(operation) {
+  const schemas = [];
+  for (const [status, response] of Object.entries(operation?.responses ?? {})) {
+    const schema = response?.content?.["application/json"]?.schema;
+    if (schema) schemas.push({ status, schema });
+  }
+  return schemas;
+}
+
+function diffRequiredProperties({ beforeSchema, afterSchema, location, responseRequiredSeverity, schemaRequiredSeverity }) {
+  const findings = [];
+  const beforeRequired = new Set(collectRequiredSchemaProperties(beforeSchema).map(jsonPointer));
+  const afterRequired = new Set(collectRequiredSchemaProperties(afterSchema).map(jsonPointer));
+
+  for (const requiredPath of afterRequired) {
+    if (!beforeRequired.has(requiredPath)) {
+      const isResponse = location.includes("/responses/");
+      const isComponent = location.includes("/components/schemas/");
+      findings.push(
+        makeFinding({
+          severity: isResponse ? responseRequiredSeverity : isComponent ? schemaRequiredSeverity : "breaking",
+          kind: isResponse
+            ? "response_required_field_added"
+            : isComponent
+              ? "schema_required_field_added"
+              : "request_required_field_added",
+          location: `${location}${requiredPath}`,
+          message: `Required schema field was added at ${requiredPath}`,
+        }),
+      );
+    }
+  }
+
+  return findings;
+}
+
+function diffEnums({ beforeSchema, afterSchema, location }) {
+  const findings = [];
+  const beforeEnums = new Map(collectEnums(beforeSchema).map((entry) => [jsonPointer(entry.path), entry.values]));
+  const afterEnums = new Map(collectEnums(afterSchema).map((entry) => [jsonPointer(entry.path), entry.values]));
+
+  for (const [enumPath, beforeValues] of beforeEnums) {
+    const afterValues = afterEnums.get(enumPath);
+    if (!afterValues) continue;
+    const removed = beforeValues.filter((value) => !afterValues.includes(value));
+    if (removed.length > 0) {
+      findings.push(
+        makeFinding({
+          severity: "breaking",
+          kind: "enum_values_removed",
+          location: `${location}${enumPath}`,
+          message: `Enum values removed: ${removed.join(", ")}`,
+          before: beforeValues,
+          after: afterValues,
+        }),
+      );
+    }
+  }
+
+  return findings;
+}
+
+function diffOperations(before, after, options) {
+  const findings = [];
+  const beforeOperations = collectOperations(before);
+  const afterOperations = collectOperations(after);
+
+  for (const [operationKey, beforeEntry] of beforeOperations) {
+    const afterEntry = afterOperations.get(operationKey);
+    const operationLocation = `/paths/${pointer([beforeEntry.pathName])}/${beforeEntry.method}`;
+
+    if (!afterEntry) {
+      findings.push(
+        makeFinding({
+          severity: "breaking",
+          kind: "operation_removed",
+          location: operationLocation,
+          message: `${operationKey} was removed`,
+        }),
+      );
+      continue;
+    }
+
+    const beforeParameters = collectParameters(beforeEntry.pathItem, beforeEntry.operation);
+    const afterParameters = collectParameters(afterEntry.pathItem, afterEntry.operation);
+    for (const [parameterKey, beforeParameter] of beforeParameters) {
+      const afterParameter = afterParameters.get(parameterKey);
+      if (!afterParameter) {
+        findings.push(
+          makeFinding({
+            severity: "breaking",
+            kind: "parameter_removed",
+            location: `${operationLocation}/parameters/${parameterKey}`,
+            message: `${operationKey} parameter ${parameterKey} was removed`,
+          }),
+        );
+      } else if (!beforeParameter.required && afterParameter.required) {
+        findings.push(
+          makeFinding({
+            severity: "breaking",
+            kind: "parameter_became_required",
+            location: `${operationLocation}/parameters/${parameterKey}`,
+            message: `${operationKey} parameter ${parameterKey} became required`,
+          }),
+        );
+      }
+    }
+
+    for (const [parameterKey, afterParameter] of afterParameters) {
+      if (!beforeParameters.has(parameterKey) && afterParameter.required) {
+        findings.push(
+          makeFinding({
+            severity: "breaking",
+            kind: "required_parameter_added",
+            location: `${operationLocation}/parameters/${parameterKey}`,
+            message: `${operationKey} added required parameter ${parameterKey}`,
+          }),
+        );
+      }
+    }
+
+    const beforeRequestBody = beforeEntry.operation?.requestBody;
+    const afterRequestBody = afterEntry.operation?.requestBody;
+    if (!beforeRequestBody?.required && afterRequestBody?.required) {
+      findings.push(
+        makeFinding({
+          severity: "breaking",
+          kind: "request_body_became_required",
+          location: `${operationLocation}/requestBody`,
+          message: `${operationKey} request body became required`,
+        }),
+      );
+    }
+
+    findings.push(
+      ...diffRequiredProperties({
+        beforeSchema: requestBodySchema(beforeEntry.operation),
+        afterSchema: requestBodySchema(afterEntry.operation),
+        location: `${operationLocation}/requestBody`,
+        responseRequiredSeverity: options.responseRequiredSeverity,
+        schemaRequiredSeverity: options.schemaRequiredSeverity,
+      }),
+    );
+    findings.push(
+      ...diffEnums({
+        beforeSchema: requestBodySchema(beforeEntry.operation),
+        afterSchema: requestBodySchema(afterEntry.operation),
+        location: `${operationLocation}/requestBody`,
+      }),
+    );
+
+    const beforeResponses = new Map(responseSchemas(beforeEntry.operation).map((entry) => [entry.status, entry.schema]));
+    const afterResponses = new Map(responseSchemas(afterEntry.operation).map((entry) => [entry.status, entry.schema]));
+    for (const [status, beforeSchema] of beforeResponses) {
+      const afterSchema = afterResponses.get(status);
+      if (!afterSchema) continue;
+      findings.push(
+        ...diffRequiredProperties({
+          beforeSchema,
+          afterSchema,
+          location: `${operationLocation}/responses/${status}`,
+          responseRequiredSeverity: options.responseRequiredSeverity,
+          schemaRequiredSeverity: options.schemaRequiredSeverity,
+        }),
+      );
+      findings.push(...diffEnums({ beforeSchema, afterSchema, location: `${operationLocation}/responses/${status}` }));
+    }
+  }
+
+  return findings;
+}
+
+function diffComponentSchemas(before, after, options) {
+  const findings = [];
+  const beforeSchemas = before.components?.schemas ?? {};
+  const afterSchemas = after.components?.schemas ?? {};
+
+  for (const [schemaName, beforeSchema] of Object.entries(beforeSchemas)) {
+    const afterSchema = afterSchemas[schemaName];
+    if (!afterSchema) {
+      findings.push(
+        makeFinding({
+          severity: "breaking",
+          kind: "schema_removed",
+          location: `/components/schemas/${pointer([schemaName])}`,
+          message: `Schema ${schemaName} was removed`,
+        }),
+      );
+      continue;
+    }
+
+    findings.push(
+      ...diffRequiredProperties({
+        beforeSchema,
+        afterSchema,
+        location: `/components/schemas/${pointer([schemaName])}`,
+        responseRequiredSeverity: options.responseRequiredSeverity,
+        schemaRequiredSeverity: options.schemaRequiredSeverity,
+      }),
+    );
+    findings.push(...diffEnums({ beforeSchema, afterSchema, location: `/components/schemas/${pointer([schemaName])}` }));
+  }
+
+  return findings;
+}
+
+export function classifyOpenApiChanges(before, after, options = {}) {
+  const normalizedOptions = {
+    responseRequiredSeverity: options.responseRequiredSeverity ?? "warning",
+    schemaRequiredSeverity: options.schemaRequiredSeverity ?? options.responseRequiredSeverity ?? "warning",
+  };
+  const findings = [
+    ...diffOperations(before, after, normalizedOptions),
+    ...diffComponentSchemas(before, after, normalizedOptions),
+  ];
+
+  const counts = findings.reduce(
+    (acc, finding) => {
+      acc[finding.severity] = (acc[finding.severity] ?? 0) + 1;
+      return acc;
+    },
+    { breaking: 0, warning: 0 },
+  );
+
+  return {
+    breaking: counts.breaking,
+    warnings: counts.warning,
+    findings,
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const strictResponse = args.includes("--response-required=breaking");
+  const positional = args.filter((arg) => !arg.startsWith("--"));
+
+  if (positional.length !== 2) {
+    console.error(
+      "Usage: classify-openapi-changes.mjs <before.json> <after.json> [--response-required=breaking]",
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  const before = JSON.parse(await readFile(positional[0], "utf8"));
+  const after = JSON.parse(await readFile(positional[1], "utf8"));
+  const result = classifyOpenApiChanges(before, after, {
+    responseRequiredSeverity: strictResponse ? "breaking" : "warning",
+  });
+
+  console.log(JSON.stringify(result, null, 2));
+  if (result.breaking > 0) {
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await main();
+}

--- a/scripts/openapi-compat/classify-openapi-changes.mjs
+++ b/scripts/openapi-compat/classify-openapi-changes.mjs
@@ -97,14 +97,14 @@ function makeFinding({ severity, kind, location, message, before, after }) {
   return { severity, kind, location, message, before, after };
 }
 
-function requestBodySchema(operation) {
+function requestBodySchemas(operation) {
   const body = operation?.requestBody;
   const content = body?.content ?? {};
-  return (
-    content["application/json"]?.schema ??
-    content["application/x-www-form-urlencoded"]?.schema ??
-    content["multipart/form-data"]?.schema
-  );
+  const schemas = [];
+  for (const [mediaType, media] of Object.entries(content)) {
+    if (media?.schema) schemas.push({ mediaType, schema: media.schema });
+  }
+  return schemas;
 }
 
 function responseSchemas(operation) {
@@ -114,6 +114,30 @@ function responseSchemas(operation) {
     if (schema) schemas.push({ status, schema });
   }
   return schemas;
+}
+
+function diffRequestBodySchemas({ beforeOperation, afterOperation, operationLocation, options }) {
+  const findings = [];
+  const beforeSchemas = new Map(requestBodySchemas(beforeOperation).map((entry) => [entry.mediaType, entry.schema]));
+  const afterSchemas = new Map(requestBodySchemas(afterOperation).map((entry) => [entry.mediaType, entry.schema]));
+
+  for (const [mediaType, beforeSchema] of beforeSchemas) {
+    const afterSchema = afterSchemas.get(mediaType);
+    if (!afterSchema) continue;
+    const location = `${operationLocation}/requestBody/content/${pointer([mediaType])}`;
+    findings.push(
+      ...diffRequiredProperties({
+        beforeSchema,
+        afterSchema,
+        location,
+        responseRequiredSeverity: options.responseRequiredSeverity,
+        schemaRequiredSeverity: options.schemaRequiredSeverity,
+      }),
+    );
+    findings.push(...diffEnums({ beforeSchema, afterSchema, location }));
+  }
+
+  return findings;
 }
 
 function diffRequiredProperties({ beforeSchema, afterSchema, location, responseRequiredSeverity, schemaRequiredSeverity }) {
@@ -242,19 +266,11 @@ function diffOperations(before, after, options) {
     }
 
     findings.push(
-      ...diffRequiredProperties({
-        beforeSchema: requestBodySchema(beforeEntry.operation),
-        afterSchema: requestBodySchema(afterEntry.operation),
-        location: `${operationLocation}/requestBody`,
-        responseRequiredSeverity: options.responseRequiredSeverity,
-        schemaRequiredSeverity: options.schemaRequiredSeverity,
-      }),
-    );
-    findings.push(
-      ...diffEnums({
-        beforeSchema: requestBodySchema(beforeEntry.operation),
-        afterSchema: requestBodySchema(afterEntry.operation),
-        location: `${operationLocation}/requestBody`,
+      ...diffRequestBodySchemas({
+        beforeOperation: beforeEntry.operation,
+        afterOperation: afterEntry.operation,
+        operationLocation,
+        options,
       }),
     );
 

--- a/scripts/openapi-compat/classify-openapi-changes.test.mjs
+++ b/scripts/openapi-compat/classify-openapi-changes.test.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { classifyOpenApiChanges } from "./classify-openapi-changes.mjs";
+
+function spec(operation) {
+  return {
+    openapi: "3.0.0",
+    paths: {
+      "/w/{workspace}/flow_conversations/{conversation_id}/messages": {
+        get: operation,
+      },
+    },
+    components: {
+      schemas: {
+        FlowConversationMessage: {
+          type: "object",
+          required: ["id"],
+          properties: {
+            id: { type: "string" },
+            status: { type: "string", enum: ["queued", "running", "done"] },
+          },
+        },
+      },
+    },
+  };
+}
+
+test("detects removed query parameters", () => {
+  const before = spec({
+    parameters: [
+      { name: "workspace", in: "path", required: true },
+      { name: "after_id", in: "query", required: false },
+    ],
+    responses: { 200: { description: "ok" } },
+  });
+  const after = spec({
+    parameters: [{ name: "workspace", in: "path", required: true }],
+    responses: { 200: { description: "ok" } },
+  });
+
+  const result = classifyOpenApiChanges(before, after);
+
+  assert.equal(result.breaking, 1);
+  assert.equal(result.findings[0].kind, "parameter_removed");
+  assert.match(result.findings[0].message, /after_id/);
+});
+
+test("detects newly required request body fields", () => {
+  const before = spec({
+    requestBody: {
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            required: ["path"],
+            properties: {
+              path: { type: "string" },
+              args: { type: "object" },
+            },
+          },
+        },
+      },
+    },
+    responses: { 200: { description: "ok" } },
+  });
+  const after = spec({
+    requestBody: {
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            required: ["path", "args"],
+            properties: {
+              path: { type: "string" },
+              args: { type: "object" },
+            },
+          },
+        },
+      },
+    },
+    responses: { 200: { description: "ok" } },
+  });
+
+  const result = classifyOpenApiChanges(before, after);
+
+  assert.equal(result.breaking, 1);
+  assert.equal(result.findings[0].kind, "request_required_field_added");
+  assert.match(result.findings[0].location, /args/);
+});
+
+test("classifies response required fields as warnings by default", () => {
+  const before = spec({
+    responses: {
+      200: {
+        description: "ok",
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["id"],
+              properties: { id: { type: "string" }, created_seq: { type: "number" } },
+            },
+          },
+        },
+      },
+    },
+  });
+  const after = spec({
+    responses: {
+      200: {
+        description: "ok",
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["id", "created_seq"],
+              properties: { id: { type: "string" }, created_seq: { type: "number" } },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const result = classifyOpenApiChanges(before, after);
+
+  assert.equal(result.breaking, 0);
+  assert.equal(result.warnings, 1);
+  assert.equal(result.findings[0].kind, "response_required_field_added");
+});
+
+test("can treat response required fields as breaking in strict mode", () => {
+  const before = {
+    openapi: "3.0.0",
+    paths: {},
+    components: {
+      schemas: {
+        UsedTriggers: {
+          type: "object",
+          required: ["email"],
+          properties: { email: { type: "string" }, azure_used: { type: "number" } },
+        },
+      },
+    },
+  };
+  const after = {
+    openapi: "3.0.0",
+    paths: {},
+    components: {
+      schemas: {
+        UsedTriggers: {
+          type: "object",
+          required: ["email", "azure_used"],
+          properties: { email: { type: "string" }, azure_used: { type: "number" } },
+        },
+      },
+    },
+  };
+
+  const result = classifyOpenApiChanges(before, after, { responseRequiredSeverity: "breaking" });
+
+  assert.equal(result.breaking, 1);
+  assert.equal(result.findings[0].kind, "schema_required_field_added");
+});
+
+test("detects enum narrowing", () => {
+  const before = spec({ responses: { 200: { description: "ok" } } });
+  const after = structuredClone(before);
+  after.components.schemas.FlowConversationMessage.properties.status.enum = ["running", "done"];
+
+  const result = classifyOpenApiChanges(before, after);
+
+  assert.equal(result.breaking, 1);
+  assert.equal(result.findings[0].kind, "enum_values_removed");
+  assert.deepEqual(result.findings[0].before, ["queued", "running", "done"]);
+});

--- a/scripts/openapi-compat/classify-openapi-changes.test.mjs
+++ b/scripts/openapi-compat/classify-openapi-changes.test.mjs
@@ -88,6 +88,40 @@ test("detects newly required request body fields", () => {
   assert.match(result.findings[0].location, /args/);
 });
 
+test("checks every matching request body media type", () => {
+  const before = spec({
+    requestBody: {
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            required: ["path"],
+            properties: { path: { type: "string" }, token: { type: "string" } },
+          },
+        },
+        "application/x-www-form-urlencoded": {
+          schema: {
+            type: "object",
+            required: ["path"],
+            properties: { path: { type: "string" }, token: { type: "string" } },
+          },
+        },
+      },
+    },
+    responses: { 200: { description: "ok" } },
+  });
+  const after = structuredClone(before);
+  after.paths["/w/{workspace}/flow_conversations/{conversation_id}/messages"].get.requestBody.content[
+    "application/x-www-form-urlencoded"
+  ].schema.required.push("token");
+
+  const result = classifyOpenApiChanges(before, after);
+
+  assert.equal(result.breaking, 1);
+  assert.equal(result.findings[0].kind, "request_required_field_added");
+  assert.match(result.findings[0].location, /application~1x-www-form-urlencoded/);
+});
+
 test("classifies response required fields as warnings by default", () => {
   const before = spec({
     responses: {


### PR DESCRIPTION
## Why

This adds a small OpenAPI compatibility classifier for the release-safety question in #8719.

The concrete cases from that thread are exactly the kind of drift this checks for: removed query params like `after_id`, new required fields such as `created_seq`, and response-side required fields such as `azure_used` where teams may want either a warning or strict generated-client enforcement.

## What changed

- adds `scripts/openapi-compat/classify-openapi-changes.mjs`
- compares two dereferenced OpenAPI JSON files
- detects removed operations, removed params, params becoming required, newly required params, request bodies becoming required, new required request fields, enum narrowing, and removed component schemas
- reports response-side required fields as warnings by default
- supports `--response-required=breaking` for stricter generated-client compatibility
- adds Node tests for the main compatibility cases
- documents usage and the expected JSON input shape

The script prints JSON and exits with code 1 when breaking changes are found, so it can be wired into CI later without changing existing workflows in this PR.

## Checks

- `node --test scripts/openapi-compat/*.test.mjs`
- `node --check scripts/openapi-compat/classify-openapi-changes.mjs && node --check scripts/openapi-compat/classify-openapi-changes.test.mjs`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OpenAPI compatibility classifier to compare two dereferenced specs and flag breaking changes, improving release safety and CI enforcement. Addresses the release-safety needs in #8719.

- **New Features**
  - Compares two dereferenced OpenAPI JSON files via `scripts/openapi-compat/classify-openapi-changes.mjs`.
  - Detects: removed operations/parameters, parameters becoming required, new required parameters, request body becoming required, new required request fields, enum narrowing, and removed component schemas.
  - Treats new required response fields as warnings by default; use `--response-required=breaking` for strict generated-client compatibility.
  - Prints a JSON report and exits with code 1 on breaking changes for CI integration; includes tests and usage docs.

- **Bug Fixes**
  - Checks all request body media types when diffing schemas (not just `application/json`).

<sup>Written for commit dabf6fb93b02dec0f0cee4546221ce446f897b84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

