### PR TITLE
fix(cli): include lock-relevant script content in lock cache key

### DIFF
--- a/cli/src/utils/metadata.ts
+++ b/cli/src/utils/metadata.ts
@@ -574,6 +574,49 @@ export function extractWorkspaceDepsAnnotation(
   return { mode, external, inline };
 }
 
+// Mirrors backend ScriptLang::as_comment_lit (windmill-types/src/scripts.rs)
+// for the languages that can reach the lock cache.
+const LANG_COMMENT_LIT: Partial<Record<ScriptLanguage, string>> = {
+  python3: "#",
+  ansible: "#",
+  powershell: "#",
+  bun: "//",
+  nativets: "//",
+  deno: "//",
+  go: "//",
+  php: "//",
+  rust: "//!",
+};
+
+/**
+ * Returns the leading comment/blank-line block of the script, verbatim.
+ *
+ * Backend annotation parsing (PythonAnnotations / TypeScriptAnnotations via
+ * the `annotations!` macro, and `# py:` version lines) only reads this leading
+ * block, and those annotations (e.g. `# py311`, `# py: <spec>`, `//npm`,
+ * `# no_cache`) change the generated lockfile even when workspace
+ * dependencies fully specify the requirements. With workspace deps the
+ * backend runs in manual mode and ignores the script body, so two scripts
+ * sharing the same header, annotation, and deps resolve to the same lockfile.
+ */
+export function extractLockRelevantHeader(
+  scriptContent: string,
+  language: ScriptLanguage
+): string {
+  const comment = LANG_COMMENT_LIT[language];
+  // Unknown language: be conservative and treat the whole content as relevant.
+  if (!comment) return scriptContent;
+  const headerLines: string[] = [];
+  for (const line of scriptContent.split("\n")) {
+    if (line.trim() === "" || line.startsWith(comment)) {
+      headerLines.push(line);
+    } else {
+      break;
+    }
+  }
+  return headerLines.join("\n");
+}
+
 export async function computeLockCacheKey(
   scriptContent: string,
   language: ScriptLanguage,
@@ -589,7 +632,26 @@ export async function computeLockCacheKey(
   const tempRefsStr = tempScriptRefs
     ? Object.keys(tempScriptRefs).sort().map((k) => `${k}=${tempScriptRefs[k]}`).join(";")
     : "";
-  return await generateHash(`${language}|${annotationStr}|${depsStr}|${tempRefsStr}`);
+  // The lock only ignores the script body when the backend resolves it in
+  // manual workspace-deps mode: either the script has a manual annotation
+  // (external refs are fetched server-side by name when not in the raw map),
+  // or it has no annotation but its language matches a default workspace deps
+  // file (callers like updateModuleLocks pass the unfiltered map, so
+  // re-filter here). In every other case — extra mode (appends the script's
+  // scanned imports), deno/rust/ansible modules that only see deps of other
+  // languages, relative-import resolution via tempScriptRefs — the backend
+  // scans the script's own content, so it must be in the key.
+  const isManualWorkspaceDeps = annotation
+    ? annotation.mode === "manual"
+    : Object.keys(
+        filterWorkspaceDependencies(rawWorkspaceDependencies, scriptContent, language)
+      ).length > 0;
+  const contentStr = isManualWorkspaceDeps
+    ? extractLockRelevantHeader(scriptContent, language)
+    : scriptContent;
+  return await generateHash(
+    `${language}|${annotationStr}|${depsStr}|${tempRefsStr}|${contentStr}`
+  );
 }
 
 const lockCache = new Map<string, string>();

--- a/cli/test/lock_cache_unit.test.ts
+++ b/cli/test/lock_cache_unit.test.ts
@@ -110,10 +110,77 @@ function extractWorkspaceDepsAnnotation(
   return { mode, external, inline };
 }
 
+const LANG_COMMENT_LIT: Record<string, string | undefined> = {
+  python3: "#",
+  ansible: "#",
+  powershell: "#",
+  bun: "//",
+  nativets: "//",
+  deno: "//",
+  go: "//",
+  php: "//",
+  rust: "//!",
+};
+
+function extractLockRelevantHeader(scriptContent: string, language: string): string {
+  const comment = LANG_COMMENT_LIT[language];
+  if (!comment) return scriptContent;
+  const headerLines: string[] = [];
+  for (const line of scriptContent.split("\n")) {
+    if (line.trim() === "" || line.startsWith(comment)) {
+      headerLines.push(line);
+    } else {
+      break;
+    }
+  }
+  return headerLines.join("\n");
+}
+
+const workspaceDependenciesLanguages: { language: string; filename: string }[] = [
+  { language: "bun", filename: "package.json" },
+  { language: "python3", filename: "requirements.in" },
+  { language: "php", filename: "composer.json" },
+  { language: "go", filename: "go.mod" },
+  { language: "powershell", filename: "modules.json" },
+];
+
+function workspaceDependenciesPathToLanguageAndFilename(
+  path: string,
+): { name: string | undefined; language: string } | undefined {
+  const relativePath = path.replace("dependencies/", "");
+  for (const { filename, language } of workspaceDependenciesLanguages) {
+    if (relativePath.endsWith(filename)) {
+      return {
+        name: relativePath === filename ? undefined : relativePath.replace("." + filename, ""),
+        language,
+      };
+    }
+  }
+}
+
+function filterWorkspaceDependencies(
+  rawWorkspaceDependencies: Record<string, string>,
+  scriptContent: string,
+  language: string,
+): Record<string, string> {
+  const wda = extractWorkspaceDepsAnnotation(scriptContent, language);
+  const filtered: Record<string, string> = {};
+  for (const [depPath, depContent] of Object.entries(rawWorkspaceDependencies)) {
+    const depInfo = workspaceDependenciesPathToLanguageAndFilename(depPath);
+    if (depInfo && depInfo.language === language) {
+      if ((wda && wda.external.includes(depInfo.name ?? "default")) || (wda == null && depInfo.name == undefined)) {
+        filtered[depPath] = depContent;
+      }
+    }
+  }
+  return filtered;
+}
+
 async function computeLockCacheKey(
   scriptContent: string,
   language: string,
   rawWorkspaceDependencies: Record<string, string>,
+  tempScriptRefs?: Record<string, string>,
 ): Promise<string> {
   const annotation = extractWorkspaceDepsAnnotation(scriptContent, language);
   const annotationStr = annotation
@@ -123,7 +190,18 @@ async function computeLockCacheKey(
   const depsStr = sortedDepsKeys
     .map((k) => `${k}=${rawWorkspaceDependencies[k]}`)
     .join(";");
-  const content = `${language}|${annotationStr}|${depsStr}`;
+  const tempRefsStr = tempScriptRefs
+    ? Object.keys(tempScriptRefs).sort().map((k) => `${k}=${tempScriptRefs[k]}`).join(";")
+    : "";
+  const isManualWorkspaceDeps = annotation
+    ? annotation.mode === "manual"
+    : Object.keys(
+        filterWorkspaceDependencies(rawWorkspaceDependencies, scriptContent, language),
+      ).length > 0;
+  const contentStr = isManualWorkspaceDeps
+    ? extractLockRelevantHeader(scriptContent, language)
+    : scriptContent;
+  const content = `${language}|${annotationStr}|${depsStr}|${tempRefsStr}|${contentStr}`;
   const buf = new TextEncoder().encode(content);
   return Buffer.from(await crypto.subtle.digest("SHA-256", buf)).toString("hex");
 }
@@ -337,6 +415,148 @@ test("different language → different key", async () => {
 test("dep key order does not matter", async () => {
   const code = "print('hello')";
   expect(await computeLockCacheKey(code, "python3", { a: "1", b: "2" })).toEqual(await computeLockCacheKey(code, "python3", { b: "2", a: "1" }));
+});
+
+// -- Lock-relevant header (GIT-891 regression) -------------------------------
+// Annotations in the leading comment block (python version pins, //npm, ...)
+// change the generated lockfile even when workspace deps are identical, so
+// they must be part of the cache key.
+
+test("header extraction: leading comments + blanks, stops at code", () => {
+  const code = `# py311
+
+# no_cache
+import pandas
+# trailing comment`;
+  expect(extractLockRelevantHeader(code, "python3")).toEqual("# py311\n\n# no_cache");
+});
+
+test("header extraction: no leading comments → empty header", () => {
+  expect(extractLockRelevantHeader("import pandas\n# py311", "python3")).toEqual("");
+});
+
+test("python: different py version annotation, same deps → different key", async () => {
+  const deps = { "dependencies/requirements.in": "requests==2.31.0" };
+  const codeA = `# py310
+# requirements: default
+print("hello")`;
+  const codeB = `# requirements: default
+print("hello")`;
+  expect(await computeLockCacheKey(codeA, "python3", deps)).not.toEqual(
+    await computeLockCacheKey(codeB, "python3", deps),
+  );
+});
+
+test("python: different '# py:' specifier, same deps → different key", async () => {
+  const deps = { "dependencies/requirements.in": "requests==2.31.0" };
+  const codeA = `# py: >=3.12
+print("hello")`;
+  const codeB = `# py: >=3.10
+print("hello")`;
+  expect(await computeLockCacheKey(codeA, "python3", deps)).not.toEqual(
+    await computeLockCacheKey(codeB, "python3", deps),
+  );
+});
+
+test("bun: //npm annotation, same deps → different key", async () => {
+  const deps = { "dependencies/package.json": '{"dependencies":{"axios":"^1.6.0"}}' };
+  const codeA = `//npm
+export function main() {}`;
+  const codeB = `export function main() {}`;
+  expect(await computeLockCacheKey(codeA, "bun", deps)).not.toEqual(
+    await computeLockCacheKey(codeB, "bun", deps),
+  );
+});
+
+test("same header, different body → same key (cache still shared)", async () => {
+  const deps = { "dependencies/requirements.in": "requests==2.31.0" };
+  const codeA = `# py311
+# requirements: default
+print("hello")`;
+  const codeB = `# py311
+# requirements: default
+print("world")`;
+  expect(await computeLockCacheKey(codeA, "python3", deps)).toEqual(
+    await computeLockCacheKey(codeB, "python3", deps),
+  );
+});
+
+// -- tempScriptRefs: full content is part of the key -------------------------
+// With tempScriptRefs the backend resolves the script's own imports, so two
+// scripts with different bodies must not share a lock.
+
+test("tempScriptRefs: different body, same refs → different key", async () => {
+  const refs = { "f/lib/util": "abc123" };
+  const codeA = `import { a } from "./util.ts"\nexport function main() {}`;
+  const codeB = `import axios from "axios"\nexport function main() {}`;
+  expect(await computeLockCacheKey(codeA, "bun", {}, refs)).not.toEqual(
+    await computeLockCacheKey(codeB, "bun", {}, refs),
+  );
+});
+
+test("tempScriptRefs: same content + refs → same key", async () => {
+  const refs = { "f/lib/util": "abc123" };
+  const code = `import { a } from "./util.ts"\nexport function main() {}`;
+  expect(await computeLockCacheKey(code, "bun", {}, refs)).toEqual(
+    await computeLockCacheKey(code, "bun", {}, refs),
+  );
+});
+
+test("tempScriptRefs: different ref hash → different key", async () => {
+  const code = `import { a } from "./util.ts"\nexport function main() {}`;
+  expect(await computeLockCacheKey(code, "bun", {}, { "f/lib/util": "abc123" })).not.toEqual(
+    await computeLockCacheKey(code, "bun", {}, { "f/lib/util": "def456" }),
+  );
+});
+
+test("matching deps + tempScriptRefs: same header, different body → same key", async () => {
+  // Manual workspace-deps mode ignores the script body (and relative imports),
+  // so the cache can still be shared across scripts.
+  const deps = { "dependencies/package.json": '{"dependencies":{"axios":"^1.6.0"}}' };
+  const refs = { "dependencies/package.json": "abc123" };
+  const codeA = `import axios from "axios"\nexport function main() { return 1 }`;
+  const codeB = `import axios from "axios"\nexport function main() { return 2 }`;
+  expect(await computeLockCacheKey(codeA, "bun", deps, refs)).toEqual(
+    await computeLockCacheKey(codeB, "bun", deps, refs),
+  );
+});
+
+// -- Non-matching deps: the backend scans the script content -----------------
+// updateModuleLocks passes the unfiltered workspace deps map, so e.g. a deno
+// module reaches the cache with a python requirements.in in the map. The
+// backend ignores those deps and locks from the script's own imports, so the
+// content must be in the key.
+
+test("deno + non-matching deps: different content → different key", async () => {
+  const deps = { "dependencies/requirements.in": "requests==2.31.0" };
+  const codeA = `import { x } from "npm:left-pad"\nexport function main() {}`;
+  const codeB = `import { y } from "npm:axios"\nexport function main() {}`;
+  expect(await computeLockCacheKey(codeA, "deno", deps)).not.toEqual(
+    await computeLockCacheKey(codeB, "deno", deps),
+  );
+});
+
+test("bun + only python deps in map: different content → different key", async () => {
+  const deps = { "dependencies/requirements.in": "requests==2.31.0" };
+  const codeA = `import leftPad from "left-pad"\nexport function main() {}`;
+  const codeB = `import axios from "axios"\nexport function main() {}`;
+  expect(await computeLockCacheKey(codeA, "bun", deps)).not.toEqual(
+    await computeLockCacheKey(codeB, "bun", deps),
+  );
+});
+
+test("python extra mode with external ref: different imports → different key", async () => {
+  // Extra mode appends the script's scanned imports to the workspace deps.
+  const deps = { "dependencies/utils.requirements.in": "rich==13.0.0" };
+  const codeA = `# extra_requirements: utils
+import pandas
+def main(): pass`;
+  const codeB = `# extra_requirements: utils
+import numpy
+def main(): pass`;
+  expect(await computeLockCacheKey(codeA, "python3", deps)).not.toEqual(
+    await computeLockCacheKey(codeB, "python3", deps),
+  );
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Fixes WIN-2032 (GIT-891): the CLI's in-memory lockfile cache (used by `generate-metadata` / sync relocking when workspace dependencies or temp script refs are present) keyed only on `language + workspace-deps annotation + raw deps + tempScriptRefs` and **ignored the script content entirely**. Scripts whose content actually affects the generated lock silently received another script's cached lockfile.

Root cause: #7787 deliberately removed script content from the key ("use annotation parser for lock cache key instead of full script content") so that N scripts sharing the same workspace deps resolve in a single backend dependency job. But the annotation parser misses several content-derived inputs the backend uses:

- **Leading-comment annotations** change the lock even in manual workspace-deps mode: `# py310`/`# py311`/…, `# py: <specifier>` (drive `PyV::resolve` → uv resolution), `# no_cache`, `//npm` (npm vs bun lock format). Two python scripts on the same `requirements.in` where one pins `# py310` shared one cache entry → the other got a lock resolved for the wrong python version.
- **Unfiltered deps maps**: `updateModuleLocks` passes the *unfiltered* workspace deps map to `fetchScriptLock`, so e.g. two **deno** modules with completely different imports plus any stray `dependencies/requirements.in` in the repo got the same key → identical (wrong) locks. The backend ignores deps of other languages and locks from the script's own imports.
- **tempScriptRefs preview path**: with temp refs the backend resolves the script's own relative imports, so the lock depends on the full content.

## Changes

- `cli/src/utils/metadata.ts`: `computeLockCacheKey` now includes a content component:
  - **manual workspace-deps mode** (manual annotation, or no annotation + a language-matched default deps file in the map): the **leading comment/blank-line header**, verbatim. The backend's `annotations!` macro and `# py:` scan only read this region, and manual mode ignores the body by design — so cross-script cache sharing (the perf goal of #7787) is preserved for the common case.
  - **everything else** (extra mode, language-mismatched deps maps, tempScriptRefs-only): the **full script content**, since the backend scans the script's imports.
  - new `extractLockRelevantHeader` helper + `LANG_COMMENT_LIT` mirroring backend `ScriptLang::as_comment_lit`; deps are re-filtered inside the key computation because some callers pass the unfiltered map.
- `cli/test/lock_cache_unit.test.ts`: mirror updated in sync (intentional pre-existing pattern — the real module graph is unresolvable under `bun test`); 12 new tests covering header extraction, `# py3xx`/`# py:`/`//npm` annotation differences, language-mismatched deps maps, extra mode, tempScriptRefs content sensitivity, and the negative direction (same header + manual deps still share a key).

## Validation

- `UNIT_ONLY=1 bun test test/*_unit*`: 825 pass, 0 fail (41 in `lock_cache_unit.test.ts`, was 37).
- `bunx tsc --noEmit`: only pre-existing errors in unrelated files (missing generated client / cliffy types), none in changed files.
- **E2E before/after** against a local backend (`generate-metadata`, 4 bun scripts on one `dependencies/package.json`; script `a` has a `//npm` header, `b`/`c`/`d` differ only in body):
  - **before**: 1 dependency job total — `b` silently reused `a`'s cached lock despite the differing `//npm` annotation (bug).
  - **after**: 2 dependency jobs — `a` gets its own (header differs), `b`/`c`/`d` share one (cache sharing preserved).
- Fresh-context review (`local-review`) validated the manual-mode body-independence claim against the backend per language (bun/python/php/powershell early-return paths, go server-side error) and found no issues.

## Notes / judgment calls

- The alternative — always hashing full content — would be trivially safe but defeats the cache's purpose (one backend uv/bun resolution per script instead of one per deps file). The header rule keeps sharing while being over-inclusive only in the safe direction (extra cache misses, never wrong locks).
- Remaining pre-existing asymmetries (server-side deps resolved by name are keyed by annotation name only; `hub/` external-ref blacklist) predate this PR and are bounded by the cache being per-process.

## Test plan

- [x] `cd cli && UNIT_ONLY=1 bun test test/*_unit*`
- [x] E2E: relock multiple scripts sharing workspace deps with differing lock-relevant headers → one dependency job per distinct header, identical-header scripts still share

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WIN-2032 (GIT-891) by adding script content to the CLI lock cache key so `generate-metadata` and sync relocking don’t reuse the wrong lockfile. Preserves cache sharing for scripts that truly match.

- **Bug Fixes**
  - Updated `computeLockCacheKey` to include content:
    - Manual workspace-deps → use leading comment/blank-line header only.
    - Otherwise (extra mode, mismatched deps, `tempScriptRefs`) → use full content.
  - Re-filter workspace deps inside key computation to ignore other languages.
  - Added `extractLockRelevantHeader` and `LANG_COMMENT_LIT` to mirror backend parsing (`# py*`, `# py:`, `//npm`, etc.).
  - Expanded unit tests to cover header parsing and content-sensitive cases, ensuring scripts with different lock-relevant headers no longer share a cache entry.

<sup>Written for commit d8282dcb0235ef3f90f31961f4f2e8eba86b48d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

