### PR TITLE
fix(frontend): make packaged runes-module imports resolvable by consumers

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --ignore-path .gitignore --check --plugin-search-dir=. . && eslint --ignore-path .gitignore .",
 		"format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. .",
-		"package": "svelte-package -o package && node scripts/package-system-prompts.js",
+		"package": "svelte-package -o package && node scripts/package-system-prompts.js && node scripts/fix-svelte-module-imports.js",
 		"generate-backend-client": "openapi-ts --input ../backend/windmill-api/openapi.yaml --output ./src/lib/gen --useOptions --enums javascript --format false",
 		"generate-backend-client-mac": "openapi-ts --input ../backend/windmill-api/openapi.yaml --output ./src/lib/gen --useOptions --enums javascript",
 		"pretest": "tsc --incremental -p tests/tsconfig.json",

--- a/frontend/scripts/fix-svelte-module-imports.js
+++ b/frontend/scripts/fix-svelte-module-imports.js
@@ -1,0 +1,60 @@
+// Rewrite extension-less runes-module imports in the svelte-package output.
+//
+// Source files import runes modules (`foo.svelte.ts`) as `$lib/foo.svelte`,
+// which Vite resolves inside this repo by appending `.ts`. svelte-package
+// emits those modules as `foo.svelte.js` but keeps the import specifier as
+// `../foo.svelte`, which consumers of @windmill-labs/components cannot
+// resolve (their bundler looks for a `.svelte` component file that does not
+// exist). Append `.js` to any relative `.svelte` specifier whose target only
+// exists as `<specifier>.js` in the package output.
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, join, resolve } from 'path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+const packageDir = resolve(__dirname, '..', 'package')
+
+const IMPORT_SPECIFIER_RE = /(\bfrom\s*|\bimport\s*\(?\s*)(['"])(\.\.?\/[^'"]*\.svelte)\2/g
+
+function* walk(dir) {
+	for (const entry of readdirSync(dir)) {
+		const full = join(dir, entry)
+		if (statSync(full).isDirectory()) {
+			yield* walk(full)
+		} else if (/\.(js|svelte|ts)$/.test(entry)) {
+			yield full
+		}
+	}
+}
+
+let rewrittenFiles = 0
+let rewrittenImports = 0
+
+for (const file of walk(packageDir)) {
+	const content = readFileSync(file, 'utf-8')
+	let changed = false
+	const updated = content.replace(IMPORT_SPECIFIER_RE, (match, prefix, quote, specifier) => {
+		const target = resolve(dirname(file), specifier)
+		// A real `.svelte` component file: leave the import alone.
+		if (existsSync(target)) {
+			return match
+		}
+		// A runes module emitted as `.svelte.js`: make the extension explicit.
+		if (existsSync(target + '.js')) {
+			changed = true
+			rewrittenImports++
+			return `${prefix}${quote}${specifier}.js${quote}`
+		}
+		return match
+	})
+	if (changed) {
+		writeFileSync(file, updated)
+		rewrittenFiles++
+	}
+}
+
+console.log(
+	`fix-svelte-module-imports: rewrote ${rewrittenImports} import(s) in ${rewrittenFiles} file(s)`
+)


### PR DESCRIPTION
## Summary

Consumers of the published `@windmill-labs/components` package cannot resolve imports of Svelte 5 runes modules. Source files import them as `$lib/foo.svelte` (resolved by Vite inside this repo by appending `.ts`), but `svelte-package` emits the modules as `foo.svelte.js` while keeping the specifier as `../foo.svelte`. A consumer's bundler then looks for a `.svelte` component file that doesn't exist and fails, e.g.:

```
Failed to resolve import "../userDraft.svelte" from
"node_modules/@windmill-labs/components/package/components/FlowBuilder.svelte"
```

This affects every component in the package that imports any of the 58 `*.svelte.ts` modules under `src/lib` (FlowBuilder, ScriptBuilder, ScriptEditor, …), so the whitelabel SDK cannot consume any package built from ≥1.720.0.

This adds a post-packaging step that rewrites those specifiers to be explicit: for every relative import ending in `.svelte` whose target does not exist on disk but `<target>.js` does, append `.js`. Real `.svelte` component imports are untouched (target exists → skipped), and matches inside comments or template-string literals are inert because no `.js` target exists for them. The rewrite is idempotent.

## Changes

- New `frontend/scripts/fix-svelte-module-imports.js`: walks `package/` (`.js`, `.svelte`, `.d.ts`) and rewrites relative runes-module specifiers from `X.svelte` to `X.svelte.js` (covers `from`, side-effect, and dynamic imports). Logs the rewrite count.
- `frontend/package.json`: run the script as the last step of `npm run package`.

No visible UI effect (build/packaging script only), so no screenshots.

## Test plan

- [x] `npm run package` succeeds; script reports `rewrote 486 import(s) in 341 file(s)`
- [x] `package/components/FlowBuilder.svelte` now imports `'../userDraft.svelte.js'`
- [x] Audit of the output: all 5116 remaining relative `.svelte` specifiers point at real component files; the only extension-less leftovers are a JSDoc example and a raw-app template string literal, both correctly skipped
- [x] Consumed the rebuilt package from the react-sdk dev app (no resolver workarounds): page loads with no resolution errors, flow editor renders, and a flow test run works end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken Svelte 5 runes-module imports in the published `@windmill-labs/components` by rewriting generated relative `.svelte` specifiers to `.svelte.js` when needed. Consumers can now resolve modules and use the package without bundler errors.

- **Bug Fixes**
  - Added `frontend/scripts/fix-svelte-module-imports.js` to scan `package/` and change `X.svelte` to `X.svelte.js` only when `.svelte` is missing and `.svelte.js` exists; real `.svelte` components are untouched.
  - Hooked the script into `npm run package` as the final step.

<sup>Written for commit 4dbb1e8b71ff99c6d4385953377c06256136a87c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

