### PR TITLE
fix: refetch license key from settings when in-memory key is invalid

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1499,6 +1499,11 @@ Windmill Community Edition {GIT_VERSION}
                                     ee_oss::verify_license_key(conn.as_sql()).await;
                                 }
 
+                                // self-throttled; picks up a key fixed on the server without
+                                // waiting for the 12h reload
+                                #[cfg(feature = "enterprise")]
+                                crate::monitor::refetch_license_key_if_invalid(conn).await;
+
                                 // update min version explicitly.
                                 // for sql connection it is the part of monitor_db.
                                 // TODO: pass worker names for min keep-alive alerts (for HTTP connection)

--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -2173,35 +2173,43 @@ async fn resolve_license_key_value(conn: &Connection, quiet: bool) -> anyhow::Re
 
 pub async fn reload_license_key(conn: &Connection) -> anyhow::Result<()> {
     let value = resolve_license_key_value(conn, false).await?;
-    #[cfg(feature = "enterprise")]
-    record_attempted_license_key(&value);
-    set_license_key(value, conn.as_sql()).await;
+    apply_license_key(value, conn).await;
     Ok(())
+}
+
+/// Applies the key and records it as the last accepted value only when
+/// `set_license_key` actually stored it (validation passed, even if expired).
+/// A rejected key is deliberately not recorded: validation can fail transiently
+/// (DB error during the instance-hash check, offline key validated before
+/// base_url is configured), and recording it would stop
+/// `refetch_license_key_if_invalid` from ever retrying an unchanged key.
+async fn apply_license_key(value: String, conn: &Connection) {
+    set_license_key(value.clone(), conn.as_sql()).await;
+    #[cfg(feature = "enterprise")]
+    if (**windmill_common::ee_oss::LICENSE_KEY.load()).as_str() == value {
+        *LAST_ACCEPTED_LICENSE_KEY.lock().unwrap() = Some(value);
+    }
 }
 
 #[cfg(feature = "enterprise")]
 lazy_static::lazy_static! {
     static ref LAST_INVALID_KEY_REFETCH_AT: std::sync::Mutex<Option<Instant>> =
         std::sync::Mutex::new(None);
-    static ref LAST_ATTEMPTED_LICENSE_KEY: std::sync::Mutex<Option<String>> =
+    static ref LAST_ACCEPTED_LICENSE_KEY: std::sync::Mutex<Option<String>> =
         std::sync::Mutex::new(None);
 }
 
 #[cfg(feature = "enterprise")]
 const INVALID_LICENSE_KEY_REFETCH_INTERVAL: Duration = Duration::from_secs(60);
 
-#[cfg(feature = "enterprise")]
-fn record_attempted_license_key(value: &str) {
-    *LAST_ATTEMPTED_LICENSE_KEY.lock().unwrap() = Some(value.to_string());
-}
-
 /// When the in-memory license key is invalid, the key in settings may have moved on
 /// (failed initial load, missed `license_key` notification, or renewed/fixed by
 /// another instance) — without this, the stale in-memory key would keep being
 /// flagged invalid until the next full settings reload (12h by default). Refetch
 /// the latest key at most once per `INVALID_LICENSE_KEY_REFETCH_INTERVAL` and
-/// re-apply it only when it differs from the last attempted value, so an unchanged
-/// invalid key is not re-validated (and re-logged) in a loop.
+/// re-apply it unless it matches the last accepted value (an unchanged key that
+/// validated fine and is invalid for another reason — e.g. expired — is not
+/// re-validated in a loop).
 #[cfg(feature = "enterprise")]
 pub async fn refetch_license_key_if_invalid(conn: &Connection) {
     use windmill_common::ee_oss::LICENSE_KEY_VALID;
@@ -2223,14 +2231,13 @@ pub async fn refetch_license_key_if_invalid(conn: &Connection) {
             return;
         }
     };
-    let changed = LAST_ATTEMPTED_LICENSE_KEY.lock().unwrap().as_deref() != Some(value.as_str());
+    let changed = LAST_ACCEPTED_LICENSE_KEY.lock().unwrap().as_deref() != Some(value.as_str());
     if changed {
         tracing::info!(
-            "License key is invalid but a different key was found in settings, applying it: {}",
+            "In-memory license key is invalid, applying license key from settings: {}",
             truncate_token(&value)
         );
-        record_attempted_license_key(&value);
-        set_license_key(value, conn.as_sql()).await;
+        apply_license_key(value, conn).await;
     }
 }
 

--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -2145,7 +2145,7 @@ pub async fn reload_request_size(conn: &Connection) {
     }
 }
 
-pub async fn reload_license_key(conn: &Connection) -> anyhow::Result<()> {
+async fn resolve_license_key_value(conn: &Connection, quiet: bool) -> anyhow::Result<String> {
     let q = load_value_from_global_settings_with_conn(conn, LICENSE_KEY_SETTING, true)
         .await
         .map_err(|err| anyhow::anyhow!("Error reloading license key: {}", err.to_string()))?;
@@ -2157,17 +2157,81 @@ pub async fn reload_license_key(conn: &Connection) -> anyhow::Result<()> {
 
     if let Some(q) = q {
         if let Ok(v) = serde_json::from_value::<String>(q.clone()) {
-            tracing::info!(
-                "Loaded setting LICENSE_KEY from db config: {}",
-                truncate_token(&v)
-            );
+            if !quiet {
+                tracing::info!(
+                    "Loaded setting LICENSE_KEY from db config: {}",
+                    truncate_token(&v)
+                );
+            }
             value = v;
         } else {
             tracing::error!("Could not parse LICENSE_KEY found: {:#?}", &q);
         }
     };
+    Ok(value)
+}
+
+pub async fn reload_license_key(conn: &Connection) -> anyhow::Result<()> {
+    let value = resolve_license_key_value(conn, false).await?;
+    #[cfg(feature = "enterprise")]
+    record_attempted_license_key(&value);
     set_license_key(value, conn.as_sql()).await;
     Ok(())
+}
+
+#[cfg(feature = "enterprise")]
+lazy_static::lazy_static! {
+    static ref LAST_INVALID_KEY_REFETCH_AT: std::sync::Mutex<Option<Instant>> =
+        std::sync::Mutex::new(None);
+    static ref LAST_ATTEMPTED_LICENSE_KEY: std::sync::Mutex<Option<String>> =
+        std::sync::Mutex::new(None);
+}
+
+#[cfg(feature = "enterprise")]
+const INVALID_LICENSE_KEY_REFETCH_INTERVAL: Duration = Duration::from_secs(60);
+
+#[cfg(feature = "enterprise")]
+fn record_attempted_license_key(value: &str) {
+    *LAST_ATTEMPTED_LICENSE_KEY.lock().unwrap() = Some(value.to_string());
+}
+
+/// When the in-memory license key is invalid, the key in settings may have moved on
+/// (failed initial load, missed `license_key` notification, or renewed/fixed by
+/// another instance) — without this, the stale in-memory key would keep being
+/// flagged invalid until the next full settings reload (12h by default). Refetch
+/// the latest key at most once per `INVALID_LICENSE_KEY_REFETCH_INTERVAL` and
+/// re-apply it only when it differs from the last attempted value, so an unchanged
+/// invalid key is not re-validated (and re-logged) in a loop.
+#[cfg(feature = "enterprise")]
+pub async fn refetch_license_key_if_invalid(conn: &Connection) {
+    use windmill_common::ee_oss::LICENSE_KEY_VALID;
+
+    if LICENSE_KEY_VALID.load(std::sync::atomic::Ordering::Relaxed) {
+        return;
+    }
+    {
+        let mut last = LAST_INVALID_KEY_REFETCH_AT.lock().unwrap();
+        if last.is_some_and(|t| t.elapsed() < INVALID_LICENSE_KEY_REFETCH_INTERVAL) {
+            return;
+        }
+        *last = Some(Instant::now());
+    }
+    let value = match resolve_license_key_value(conn, true).await {
+        Ok(v) => v,
+        Err(err) => {
+            tracing::error!("Failed to refetch license key while invalid: {err:#}");
+            return;
+        }
+    };
+    let changed = LAST_ATTEMPTED_LICENSE_KEY.lock().unwrap().as_deref() != Some(value.as_str());
+    if changed {
+        tracing::info!(
+            "License key is invalid but a different key was found in settings, applying it: {}",
+            truncate_token(&value)
+        );
+        record_attempted_license_key(&value);
+        set_license_key(value, conn.as_sql()).await;
+    }
 }
 
 pub async fn reload_option_setting_with_tracing<T: FromStr + DeserializeOwned>(
@@ -2623,6 +2687,7 @@ pub async fn monitor_db(
         #[cfg(feature = "enterprise")]
         if !initial_load {
             verify_license_key(conn.as_sql()).await;
+            refetch_license_key_if_invalid(conn).await;
         }
     };
 


### PR DESCRIPTION
## Summary

When the in-memory license key is invalid, an instance previously looped on "invalid key" until the `license_key` setting changed (and the change notification reached it) or the full settings reload fired (12h by default). If the initial key load failed transiently, the key was rejected for a transient reason (e.g. DB error during the offline instance-hash check, offline key validated before `base_url` was configured), or a settings-change notification was missed, the instance stayed unlicensed even though a perfectly good key sat in the database.

Now, while the in-memory key is invalid, the monitor loop refetches the latest key from settings at most once per 60s and re-applies it. One extra `global_settings` SELECT per minute, only while invalid — instances with a valid key do nothing extra.

## Changes

- `backend/src/monitor.rs`
  - Extracted the fetch/env-fallback half of `reload_license_key` into `resolve_license_key_value` (with a `quiet` flag so the periodic refetch doesn't re-log the loaded key).
  - New `refetch_license_key_if_invalid(conn)` (enterprise-gated): no-op while `LICENSE_KEY_VALID` is true; otherwise throttled to one settings fetch per 60s, re-applying the fetched key unless it matches the last **accepted** key.
  - Keys are recorded as "last accepted" only when `set_license_key` actually stored them (validation passed, even if expired). A rejected key is deliberately not recorded so transient validation failures stay retryable; an unchanged key that validated fine but is invalid for another reason (expired, over CU cap) is not re-validated in a loop.
  - Wired into `monitor_db`'s license verification step (servers and workers, every monitor tick, self-throttled).
- `backend/src/main.rs`
  - Agent (HTTP connection) loop: same refetch on its 30s tick (previously agents only reloaded the key every 12h).

No EE-repo changes: `set_license_key` was already the EE entry point.

## Test plan

Manually verified end-to-end with an EE build (`--features enterprise,private,license`) on a dev DB, simulating a missed notification by disabling the `notify_global_setting_change` trigger:

- [x] Start with a garbage key in `global_settings` → key rejected at startup, instance invalid.
- [x] Rejected key is re-attempted exactly once per 60s (log timestamps 13:32:29 / 13:33:29 / 13:34:29), not on every 10s monitor tick — no DB/validation spam.
- [x] `UPDATE global_settings SET value = '<valid key>'` via direct SQL with the notify trigger disabled (no notification row created) → instance picked up the key at the next 60s window (`In-memory license key is invalid, applying license key from settings: wmill__rub*****`) and all license errors stopped; `/api/version` served as EE.
- [x] `cargo check`, `cargo check --features enterprise,private` both clean.

## Notes

- Local review (fresh-context subagent) flagged that the original version recorded the attempted key before validation, which would have suppressed retries after a transient validation failure — fixed in the second commit (record only accepted keys) and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes instances getting stuck with an invalid in-memory license key by refetching the latest key from settings at most once every 60s until the key becomes valid, instead of waiting for the 12h settings reload. Adds no extra load when the key is valid.

- **Bug Fixes**
  - Added `refetch_license_key_if_invalid` (EE), throttled to 60s; wired into `monitor_db` and the agent HTTP loop.
  - Extracted key-load logic to `resolve_license_key_value` with quiet logging for periodic fetches.
  - Only record the "last accepted" key when validation succeeds; rejected keys aren’t recorded to allow retries after transient failures.
  - Re-apply a fetched key only if it differs from the last accepted value to avoid re-validation loops (e.g., expired keys).
  - Impact: at most one extra `global_settings` SELECT per minute, only while the key is invalid.

<sup>Written for commit dfd194701267b359f1aa38fd13b5ff6c3f4c52d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

