### PR TITLE
fix(frontend): bundle oauth_connect.json into packaged components

### DIFF
--- a/frontend/publish.sh
+++ b/frontend/publish.sh
@@ -1,2 +1,8 @@
+#!/usr/bin/env bash
+# Abort if the package build fails — otherwise npm publish ships the stale
+# package/ directory left over from the last successful build.
+set -euo pipefail
+cd "$(dirname "$0")"
+
 npm run package
 npm publish

--- a/frontend/scripts/fix-svelte-module-imports.js
+++ b/frontend/scripts/fix-svelte-module-imports.js
@@ -1,22 +1,36 @@
-// Rewrite extension-less runes-module imports in the svelte-package output.
+// Make the svelte-package output self-contained for consumers.
 //
-// Source files import runes modules (`foo.svelte.ts`) as `$lib/foo.svelte`,
-// which Vite resolves inside this repo by appending `.ts`. svelte-package
-// emits those modules as `foo.svelte.js` but keeps the import specifier as
-// `../foo.svelte`, which consumers of @windmill-labs/components cannot
-// resolve (their bundler looks for a `.svelte` component file that does not
-// exist). Append `.js` to any relative `.svelte` specifier whose target only
-// exists as `<specifier>.js` in the package output.
-import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'fs'
+// 1. Runes-module imports: source files import runes modules (`foo.svelte.ts`)
+//    as `$lib/foo.svelte`, which Vite resolves inside this repo by appending
+//    `.ts`. svelte-package emits those modules as `foo.svelte.js` but keeps
+//    the import specifier as `../foo.svelte`, which consumers of
+//    @windmill-labs/components cannot resolve (their bundler looks for a
+//    `.svelte` component file that does not exist). Append `.js` to any
+//    relative `.svelte` specifier whose target only exists as
+//    `<specifier>.js` in the package output.
+//
+// 2. OAuth connect registry: the `$oauth_connect_registry` alias
+//    (svelte.config.js) points at `backend/oauth_connect.json`, so the
+//    packaged output imports `../../../../backend/oauth_connect.json` — a
+//    path that escapes the package root and does not exist in the published
+//    tarball. Copy the registry into the package and rewrite those imports
+//    to point at it (mirrors how package-system-prompts.js bundles
+//    `$system_prompts`).
+import { copyFileSync, existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'fs'
 import { fileURLToPath } from 'url'
-import { dirname, join, resolve } from 'path'
+import { dirname, join, relative, resolve } from 'path'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
 const packageDir = resolve(__dirname, '..', 'package')
+const oauthConnectSrc = resolve(__dirname, '..', '..', 'backend', 'oauth_connect.json')
+const oauthConnectDest = join(packageDir, 'oauth_connect.json')
 
-const IMPORT_SPECIFIER_RE = /(\bfrom\s*|\bimport\s*\(?\s*)(['"])(\.\.?\/[^'"]*\.svelte)\2/g
+copyFileSync(oauthConnectSrc, oauthConnectDest)
+
+const IMPORT_SPECIFIER_RE = /(\bfrom\s*|\bimport\s*\(?\s*)(['"])(\.\.?\/[^'"]*\.(?:svelte|json))\2/g
+const OAUTH_CONNECT_RE = /^(\.\.\/)+backend\/oauth_connect\.json$/
 
 function* walk(dir) {
 	for (const entry of readdirSync(dir)) {
@@ -29,6 +43,11 @@ function* walk(dir) {
 	}
 }
 
+function relativeSpecifier(fromFile, toFile) {
+	const spec = relative(dirname(fromFile), toFile).replaceAll('\\', '/')
+	return spec.startsWith('.') ? spec : `./${spec}`
+}
+
 let rewrittenFiles = 0
 let rewrittenImports = 0
 
@@ -36,6 +55,14 @@ for (const file of walk(packageDir)) {
 	const content = readFileSync(file, 'utf-8')
 	let changed = false
 	const updated = content.replace(IMPORT_SPECIFIER_RE, (match, prefix, quote, specifier) => {
+		if (OAUTH_CONNECT_RE.test(specifier)) {
+			changed = true
+			rewrittenImports++
+			return `${prefix}${quote}${relativeSpecifier(file, oauthConnectDest)}${quote}`
+		}
+		if (!specifier.endsWith('.svelte')) {
+			return match
+		}
 		const target = resolve(dirname(file), specifier)
 		// A real `.svelte` component file: leave the import alone.
 		if (existsSync(target)) {


### PR DESCRIPTION
## Summary

Follow-up to #9533, fixing the last import in the packaged `@windmill-labs/components` that escapes the package root.

The `$oauth_connect_registry` alias (svelte.config.js) points at `backend/oauth_connect.json`, so svelte-package emits imports like `../../../../backend/oauth_connect.json` — a path that doesn't exist in the published tarball. Consumer builds fail on it:

```
[UNRESOLVED_IMPORT] Could not resolve '../../../../backend/oauth_connect.json'
in node_modules/@windmill-labs/components/package/components/AppConnectInner.svelte
```

This affects three importers (`AppConnectInner.svelte`, `InstanceSettings.svelte`, `AuthSettings.svelte`) and has been present in every published version; it surfaces whenever a consumer's bundler reaches `AppConnectInner` through the import graph (e.g. FlowWrapper → AiChatLayout → CreatedResourceActionDrawers).

This PR also re-lands the `publish.sh` hardening that was pushed to the #9533 branch after it merged (and therefore never landed): without `set -e`, a failed `npm run package` lets `npm publish` silently ship the stale `package/` directory from the previous build — which is exactly how the bad 1.722.0 release happened.

## Changes

- `frontend/scripts/fix-svelte-module-imports.js`: copy `backend/oauth_connect.json` to `package/oauth_connect.json` (mirroring how `package-system-prompts.js` bundles `$system_prompts`) and rewrite `(../)+backend/oauth_connect.json` specifiers to a per-file relative path into the package. Existing runes-module rewriting is unchanged and the script stays idempotent.
- `frontend/publish.sh`: `set -euo pipefail` + cd to the script dir, so a failed package build aborts the publish instead of shipping stale output.

No visible UI effect (build/packaging tooling only), so no screenshots.

## Test plan

- [x] `npm run package` succeeds; rewrite count is 489 imports in 344 files (486 runes-module from #9533 + the 3 registry imports)
- [x] `package/components/AppConnectInner.svelte` now imports `'../oauth_connect.json'`; no `backend/oauth_connect` specifier remains in the output (one comment mention only)
- [x] `npm pack --dry-run` lists `package/oauth_connect.json` (7.6kB)
- [x] Downstream consumer verification: a vite lib build (react SDK) that previously failed with `UNRESOLVED_IMPORT` on this path now builds cleanly against the rebuilt package, with no consumer-side workarounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unresolved imports in the packaged `@windmill-labs/components` by bundling `oauth_connect.json` and rewriting references, and hardens the publish script to prevent stale releases.

- **Bug Fixes**
  - Bundle `backend/oauth_connect.json` into the package and rewrite `backend/oauth_connect.json` import specifiers to a package-local path; extends the import rewriter to cover `.json` while preserving the existing `.svelte` → `.svelte.js` behavior.
  - Update `publish.sh` to `set -euo pipefail` and `cd` to the script directory so a failed `npm run package` aborts publishing instead of shipping stale output.

<sup>Written for commit 0b77630ad032fa1217548ee74b23b3832efa1b36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

