### PR TITLE
oauth: add outreach provider

### DIFF
--- a/backend/oauth_connect.json
+++ b/backend/oauth_connect.json
@@ -210,5 +210,19 @@
         "instance_url": "https://{instance}.service-now.com"
       }
     }
+  },
+  "outreach": {
+    "auth_url": "https://api.outreach.io/oauth/authorize",
+    "token_url": "https://api.outreach.io/oauth/token",
+    "scopes": [
+      "accounts.all",
+      "prospects.all",
+      "sequences.all",
+      "sequenceStates.all",
+      "tasks.all",
+      "mailings.read",
+      "mailboxes.read"
+    ],
+    "req_body_auth": true
   }
 }

--- a/frontend/src/lib/components/AuthSettings.svelte
+++ b/frontend/src/lib/components/AuthSettings.svelte
@@ -84,7 +84,8 @@
 		'xero',
 		'apify',
 		'docusign',
-		'salesforce'
+		'salesforce',
+		'outreach'
 	]
 	// Providers whose registry entry (`backend/oauth_connect.json`) carries a
 	// `sandbox` URL block. Each one gets a sibling `<name>_sandbox` dropdown

--- a/frontend/src/lib/components/icons/OutreachIcon.svelte
+++ b/frontend/src/lib/components/icons/OutreachIcon.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	interface Props {
+		size?: number
+		height?: number
+		width?: number
+		color?: string | undefined
+		class?: string
+	}
+
+	let {
+		size = undefined,
+		height: heightProp = 24,
+		width: widthProp = 24,
+		color = undefined,
+		class: clazz = ''
+	}: Props = $props()
+
+	const { width, height } = $derived(
+		size ? { width: size, height: size } : { width: widthProp, height: heightProp }
+	)
+</script>
+
+<svg
+	role="img"
+	{width}
+	{height}
+	viewBox="0 0 32 32"
+	fill={color ?? 'currentColor'}
+	xmlns="http://www.w3.org/2000/svg"
+	class={clazz}
+>
+	<title>outreach-svg</title>
+	<path
+		fill-rule="evenodd"
+		clip-rule="evenodd"
+		d="M19.0362 17.8168C17.867 18.907 16.7368 19.3162 15.6412 19.3162C14.5458 19.3162 13.4584 18.8379 12.7668 18.1935C12.0176 17.4949 11.3297 16.334 11.3297 15.1321C11.3297 13.9297 11.8404 13.0832 12.431 12.5327C13.1845 11.8302 14.3149 11.3345 15.9977 11.3345C17.3263 11.3345 18.547 11.6247 19.65 12.653C20.3687 13.3227 20.5204 14.1086 20.5204 14.6446C20.5204 15.3835 20.2054 16.7265 19.0362 17.8168ZM14.7496 6.10764C11.2185 6.10764 8.55804 6.94044 7.01418 8.37972C5.34752 9.93321 4.69444 11.8019 4.69444 13.9376C4.69444 17.3243 6.53258 20.9559 9.09878 23.3486C9.76884 23.9732 12.0832 25.8924 15.1129 25.8924C18.2128 25.8924 20.5172 24.127 21.9657 22.7767C24.7679 20.164 27.3056 15.6592 27.3056 12.7226C27.3056 11.0712 26.4983 9.94429 25.8805 9.36843C23.4451 7.09767 18.2128 6.10764 14.7496 6.10764Z"
+	/>
+</svg>

--- a/frontend/src/lib/components/icons/index.ts
+++ b/frontend/src/lib/components/icons/index.ts
@@ -70,6 +70,7 @@ import GraphqlIcon from './GraphqlIcon.svelte'
 import NocoDbIcon from './NocoDbIcon.svelte'
 import AzureIcon from './AzureIcon.svelte'
 import OktaIcon from './OktaIcon.svelte'
+import OutreachIcon from './OutreachIcon.svelte'
 import Auth0Icon from './Auth0Icon.svelte'
 import MsSqlServerIcon from './MSSqlServerIcon.svelte'
 import AuthentikIcon from './AuthentikIcon.svelte'
@@ -293,6 +294,7 @@ export const APP_TO_ICON_COMPONENT = {
 	nocodb: NocoDbIcon,
 	azure: AzureIcon,
 	okta: OktaIcon,
+	outreach: OutreachIcon,
 	auth0: Auth0Icon,
 	authentik: AuthentikIcon,
 	authelia: AutheliaIcon,
@@ -512,6 +514,7 @@ export {
 	AzureIcon,
 	MicrosoftIcon,
 	OktaIcon,
+	OutreachIcon,
 	Auth0Icon,
 	AuthentikIcon,
 	AutheliaIcon,


### PR DESCRIPTION
Adds [Outreach](https://www.outreach.io) (sales engagement platform) as a managed OAuth Authorization Code provider, paired with the Outreach hub integration PR (windmill-labs/windmill-integrations — link to follow in a comment).

## Changes
- `backend/oauth_connect.json`: `outreach` entry — `https://api.outreach.io/oauth/authorize` / `https://api.outreach.io/oauth/token`, scopes `accounts.all prospects.all sequences.all sequenceStates.all tasks.all mailings.read mailboxes.read`, `req_body_auth: true` (Outreach docs show client credentials in the form body).
- `frontend/.../AuthSettings.svelte`: `outreach` added to `windmillBuiltinsBase` so the admin OAuth-settings dropdown shows a production tile.
- `frontend/.../icons/OutreachIcon.svelte` + `icons/index.ts` map entry: official Outreach "O" mark (path from their developer portal logo SVG), `currentColor` fill.

## Token refresh
Outreach refreshes with `grant_type=refresh_token` at the **same** `/oauth/token` endpoint used for the code exchange, so Windmill's auto-refresh works (access tokens last 2h).

## Admin follow-up
Register an OAuth app at https://developers.outreach.io (requires an Outreach org admin), set the redirect URI to `https://<instance>/oauth/callback/outreach`, and enter the client id/secret in instance settings.

Note: scope names are derived from Outreach's documented `<resource>.<read|write|delete|all>` convention; not yet exercised live (no self-serve Outreach tenant available — see the paired integrations PR's validation notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Outreach as a managed OAuth (Authorization Code) provider so teams can connect Outreach from the admin settings. Includes a new Outreach tile and icon; tokens auto-refresh.

- **New Features**
  - Added `outreach` provider with `https://api.outreach.io/oauth/authorize` and `https://api.outreach.io/oauth/token`.
  - Uses documented scopes (accounts, prospects, sequences, tasks, mailings.read, mailboxes.read) and `req_body_auth: true`.
  - Added Outreach to the admin OAuth dropdown and included a new `OutreachIcon`.

- **Migration**
  - Register an app at https://developers.outreach.io.
  - Set redirect URI to `https://<instance>/oauth/callback/outreach`.
  - Enter the client ID/secret in instance settings.

<sup>Written for commit bed13e1c328d05bfd296b28e1f203c4917912edc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

