### PR TITLE
fix: omit temperature for claude fable 5

### DIFF
--- a/frontend/src/lib/components/copilot/lib.test.ts
+++ b/frontend/src/lib/components/copilot/lib.test.ts
@@ -21,6 +21,13 @@ type AssistantMessageWithReasoning = ChatCompletionMessageParam & {
 }
 
 describe('modelConfig', () => {
+	it('flags Fable 5 model IDs via includes matching', () => {
+		expect(modelDisallowsSamplingParams('claude-fable-5')).toBe(true)
+		expect(modelDisallowsSamplingParams('claude-fable-5@20260611')).toBe(true)
+		expect(modelDisallowsSamplingParams('claude-fable-5/thinking')).toBe(true)
+		expect(modelDisallowsSamplingParams('anthropic/claude-fable-5')).toBe(true)
+	})
+
 	it('flags Opus 4.7 model IDs via includes matching', () => {
 		expect(modelDisallowsSamplingParams('claude-opus-4-7')).toBe(true)
 		expect(modelDisallowsSamplingParams('claude-opus-4-7@20260416')).toBe(true)
@@ -38,6 +45,12 @@ describe('modelConfig', () => {
 	it('omits deterministic temperature for Anthropic Opus 4.7 chat requests', () => {
 		expect(
 			getDefaultChatTemperature({ provider: 'anthropic', model: 'claude-opus-4-7' })
+		).toBeUndefined()
+	})
+
+	it('omits deterministic temperature for Anthropic Fable 5 chat requests', () => {
+		expect(
+			getDefaultChatTemperature({ provider: 'anthropic', model: 'claude-fable-5' })
 		).toBeUndefined()
 	})
 

--- a/frontend/src/lib/components/copilot/modelConfig.ts
+++ b/frontend/src/lib/components/copilot/modelConfig.ts
@@ -11,6 +11,7 @@ export function modelDisallowsSamplingParams(model: string) {
 	// The o-series match requires a digit after the "o" (o1/o3/o4-mini) so it
 	// does not catch unrelated ids like Mistral's "open-mistral-*" or "optimus-*".
 	return (
+		normalizedModel.includes('claude-fable-5') ||
 		normalizedModel.includes('claude-opus-4-7') ||
 		normalizedModel.includes('claude-opus-4-8') ||
 		baseModel.startsWith('gpt-5') ||


### PR DESCRIPTION
## Summary
Add `claude-fable-5` to the copilot model list that omits sampling parameters so chat requests do not send `temperature` for that model.

## Changes
- Treat `claude-fable-5` model IDs as sampling-parameter incompatible.
- Add regression coverage for bare, versioned, suffixed, and provider-prefixed Fable 5 model IDs.
- Add coverage that `getDefaultChatTemperature` returns `undefined` for Anthropic Fable 5.

## Test plan
- [x] `npm run test:unit -- lib/components/copilot/lib.test.ts`
- [ ] `npm run check:fast` (blocked by unrelated existing `ChatContextPicker.svelte:62` type error)

Local review was skipped per request.