### PR TITLE
feat: add schema browsing support for duckdb database manager

### DIFF
--- a/backend/windmill-common/src/query_builders.rs
+++ b/backend/windmill-common/src/query_builders.rs
@@ -1739,7 +1739,7 @@ struct PrimaryKeyConstraintPayload {
 fn db_supports_schemas(db_type: DbType) -> bool {
     matches!(
         db_type,
-        DbType::Postgresql | DbType::Snowflake | DbType::Bigquery
+        DbType::Postgresql | DbType::Snowflake | DbType::Bigquery | DbType::Duckdb
     )
 }
 
@@ -2434,7 +2434,7 @@ fn make_load_table_metadata_query(
                     "table_schema = current_schema()".to_string()
                 };
                 Ok(format!(
-                    "{}\nFROM information_schema.columns c\nWHERE {} AND TABLE_NAME = '{}'",
+                    "{}\nFROM information_schema.columns c\nWHERE table_catalog = current_database() AND {} AND TABLE_NAME = '{}'",
                     select_cols,
                     schema_filter,
                     escape_sql_literal(tname)
@@ -3748,7 +3748,7 @@ mod tests {
         );
         assert_eq!(
             table_ref("users", Some("myschema"), DbType::Duckdb),
-            r#""users""#
+            r#""myschema"."users""#
         );
     }
 
@@ -3870,6 +3870,13 @@ mod tests {
         let marker = r#"-- WM_INTERNAL_DB_DROP_TABLE {"table":"users","schema":"myschema"}"#;
         let sql = expand_code(marker, &ScriptLang::Mysql);
         assert_eq!(sql, "DROP TABLE `users`;");
+    }
+
+    #[test]
+    fn test_expand_drop_table_duckdb_with_schema() {
+        let marker = r#"-- WM_INTERNAL_DB_DROP_TABLE {"table":"users","schema":"myschema"}"#;
+        let sql = expand_code(marker, &ScriptLang::DuckDb);
+        assert_eq!(sql, "DROP TABLE \"myschema\".\"users\";");
     }
 
     #[test]

--- a/backend/windmill-common/src/query_builders.rs
+++ b/backend/windmill-common/src/query_builders.rs
@@ -2395,8 +2395,12 @@ fn expand_load_table_metadata(json_str: &str, db_type: DbType) -> Result<Expande
         return Ok(ExpandedQuery::with_language(code, ScriptLang::Bun));
     }
 
-    let query =
-        make_load_table_metadata_query(db_type, p.table.as_deref(), p.database_name.as_deref())?;
+    let query = make_load_table_metadata_query(
+        db_type,
+        p.table.as_deref(),
+        p.database_name.as_deref(),
+        p.ducklake.is_some(),
+    )?;
     Ok(ExpandedQuery::sql(maybe_wrap_ducklake(
         query,
         p.ducklake.as_deref(),
@@ -2407,12 +2411,12 @@ fn make_load_table_metadata_query(
     db_type: DbType,
     table: Option<&str>,
     database_name: Option<&str>,
+    is_ducklake: bool,
 ) -> Result<String, String> {
     match db_type {
         DbType::Duckdb => {
             // For ducklake, the ducklake ATTACH is handled by the ducklake wrapper.
-            let mut q = String::from(
-                "SELECT
+            let select_cols = "SELECT
     COLUMN_NAME as field,
     DATA_TYPE as DataType,
     COLUMN_DEFAULT as DefaultValue,
@@ -2420,14 +2424,34 @@ fn make_load_table_metadata_query(
     false as IsIdentity,
     CASE WHEN IS_NULLABLE = true THEN 'YES' ELSE 'NO' END as IsNullable,
     false as IsEnum,
-    TABLE_NAME as table_name
-FROM information_schema.columns c
-WHERE table_schema = current_schema()",
-            );
+    TABLE_NAME as table_name";
             if let Some(t) = table {
-                q.push_str(&format!(" AND TABLE_NAME = '{}'", escape_sql_literal(t)));
+                let parts: Vec<&str> = t.split('.').collect();
+                let tname = parts[parts.len() - 1];
+                let schema_filter = if parts.len() > 1 {
+                    format!("table_schema = '{}'", escape_sql_literal(parts[0]))
+                } else {
+                    "table_schema = current_schema()".to_string()
+                };
+                Ok(format!(
+                    "{}\nFROM information_schema.columns c\nWHERE {} AND TABLE_NAME = '{}'",
+                    select_cols,
+                    schema_filter,
+                    escape_sql_literal(tname)
+                ))
+            } else if is_ducklake {
+                // Ducklake schema browsing is not supported in the frontend: keep the
+                // single-schema behavior so table keys stay unqualified.
+                Ok(format!(
+                    "{}\nFROM information_schema.columns c\nWHERE table_schema = current_schema()",
+                    select_cols
+                ))
+            } else {
+                Ok(format!(
+                    "{},\n    TABLE_SCHEMA as schema_name\nFROM information_schema.columns c\nWHERE table_catalog = current_database() AND table_schema NOT IN ('information_schema', 'pg_catalog')",
+                    select_cols
+                ))
             }
-            Ok(q)
         }
         DbType::Mysql => {
             let explicit_db = database_name.filter(|s| !s.is_empty());
@@ -4348,6 +4372,25 @@ mod tests {
         let sql = expand_code(marker, &ScriptLang::DuckDb);
         assert!(sql.contains("COLUMN_NAME as field"));
         assert!(sql.contains("TABLE_NAME = 'users'"));
+        assert!(sql.contains("table_schema = current_schema()"));
+    }
+
+    #[test]
+    fn test_expand_load_table_metadata_duckdb_schema_table() {
+        let marker = r#"-- WM_INTERNAL_DB_LOAD_TABLE_METADATA {"table":"myschema.users"}"#;
+        let sql = expand_code(marker, &ScriptLang::DuckDb);
+        assert!(sql.contains("TABLE_NAME = 'users'"));
+        assert!(sql.contains("table_schema = 'myschema'"));
+    }
+
+    #[test]
+    fn test_expand_load_table_metadata_duckdb_all_tables() {
+        let marker = r#"-- WM_INTERNAL_DB_LOAD_TABLE_METADATA {}"#;
+        let sql = expand_code(marker, &ScriptLang::DuckDb);
+        assert!(sql.contains("TABLE_SCHEMA as schema_name"));
+        assert!(sql.contains("TABLE_NAME as table_name"));
+        assert!(sql.contains("table_catalog = current_database()"));
+        assert!(sql.contains("table_schema NOT IN ('information_schema', 'pg_catalog')"));
     }
 
     #[test]
@@ -4356,6 +4399,15 @@ mod tests {
         let sql = expand_code(marker, &ScriptLang::DuckDb);
         assert!(sql.starts_with("ATTACH 'ducklake://lake' AS dl;USE dl;\n"));
         assert!(sql.contains("TABLE_NAME = 'users'"));
+    }
+
+    #[test]
+    fn test_expand_load_table_metadata_ducklake_all_tables_stays_single_schema() {
+        let marker = r#"-- WM_INTERNAL_DB_LOAD_TABLE_METADATA {"ducklake":"lake"}"#;
+        let sql = expand_code(marker, &ScriptLang::DuckDb);
+        assert!(sql.starts_with("ATTACH 'ducklake://lake' AS dl;USE dl;\n"));
+        assert!(sql.contains("table_schema = current_schema()"));
+        assert!(!sql.contains("schema_name"));
     }
 
     // -----------------------------------------------------------------------

--- a/frontend/src/lib/components/DBManager.svelte
+++ b/frontend/src/lib/components/DBManager.svelte
@@ -162,7 +162,13 @@
 		if (!selected.schemaKey && schemaKeys.length) {
 			let schemaKey =
 				initialSchemaKey ??
-				('public' in dbSchema.schema ? 'public' : 'dbo' in dbSchema.schema ? 'dbo' : schemaKeys[0])
+				('public' in dbSchema.schema
+					? 'public'
+					: 'dbo' in dbSchema.schema
+						? 'dbo'
+						: 'main' in dbSchema.schema
+							? 'main'
+							: schemaKeys[0])
 			let tableKey =
 				initialTableKey && dbSchema.schema?.[schemaKey]?.[initialTableKey]
 					? initialTableKey

--- a/frontend/src/lib/components/apps/components/display/dbtable/metadata.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/metadata.ts
@@ -356,7 +356,11 @@ export async function getTablesByResource(
 			const paths: string[] = []
 			for (const key in s?.schema) {
 				for (const subKey in s.schema[key]) {
-					paths.push(`${subKey}`)
+					if (key === 'main') {
+						paths.push(`${subKey}`)
+					} else {
+						paths.push(`${key}.${subKey}`)
+					}
 				}
 			}
 

--- a/frontend/src/lib/components/apps/components/display/dbtable/utils.ts
+++ b/frontend/src/lib/components/apps/components/display/dbtable/utils.ts
@@ -235,6 +235,44 @@ return schema
 		},
 		argName: 'database'
 	},
+	duckdb: {
+		code: `SELECT table_schema, table_name, column_name, data_type as udt_name, column_default, is_nullable FROM information_schema.columns WHERE table_catalog = current_database() AND table_schema NOT IN ('information_schema', 'pg_catalog')`,
+		processingFn: (rows) => {
+			const schemas = rows.reduce((acc, a) => {
+				const table_schema = a.table_schema
+				delete a.table_schema
+				acc[table_schema] = acc[table_schema] || []
+				if (a.table_name || a.column_name) acc[table_schema].push(a)
+				return acc
+			}, {})
+
+			const data = {}
+			for (const key in schemas) {
+				data[key] = schemas[key].reduce((acc, a) => {
+					const table_name = a.table_name
+					delete a.table_name
+					acc[table_name] = acc[table_name] || {}
+					const p: {
+						type: string
+						required: boolean
+						default?: string
+					} = {
+						type: a.udt_name,
+						required: a.is_nullable === 'NO'
+					}
+					if (a.column_default) {
+						p.default = a.column_default
+					}
+					acc[table_name][a.column_name] = p
+					return acc
+				}, {})
+			}
+
+			return data
+		},
+		lang: 'duckdb',
+		argName: 'database'
+	},
 	mssql: {
 		argName: 'database',
 		code: `select TABLE_SCHEMA, TABLE_NAME, DATA_TYPE, COLUMN_NAME, COLUMN_DEFAULT from information_schema.columns where table_schema != 'sys'`,
@@ -381,7 +419,12 @@ export function getPrimaryKeys(tableMetadata?: TableMetadata): string[] {
 }
 
 export function dbSupportsSchemas(dbType: DbType): boolean {
-	return dbType === 'postgresql' || dbType === 'snowflake' || dbType === 'bigquery'
+	return (
+		dbType === 'postgresql' ||
+		dbType === 'snowflake' ||
+		dbType === 'bigquery' ||
+		dbType === 'duckdb'
+	)
 }
 
 export function datatypeHasLength(datatype: string): boolean {


### PR DESCRIPTION
Fixes WIN-2033

## Summary

The DuckDB database manager previously had no schema browsing, unlike PostgreSQL, Snowflake and BigQuery, even though DuckDB natively supports schemas (default `main`). This PR makes the DuckDB DB manager schema-aware across the frontend and the backend marker-query builders, while keeping Ducklake (which shares the `duckdb` language path but intentionally has no schema browsing in the UI) on its existing single-schema behavior.

## Changes

- `frontend/.../dbtable/utils.ts`: added `'duckdb'` to `dbSupportsSchemas()`, and added a `duckdb` entry to `legacyScripts` with a schema-aware `information_schema.columns` query (grouped by `table_schema` → `table_name`, `lang: 'duckdb'`, `argName: 'database'`) so the initial schema tree loads.
- `backend/windmill-common/src/query_builders.rs`:
  - `LOAD_TABLE_METADATA` all-tables mode for DuckDB now returns `table_schema as schema_name` and lists all non-system schemas (`table_schema NOT IN ('information_schema', 'pg_catalog')`) instead of only `current_schema()`. A `table_catalog = current_database()` filter was added because DuckDB's `information_schema` spans **all attached catalogs** (system/temp/other ATTACHes would otherwise leak in).
  - Single-table mode parses dot-notation (`schema.table`) like the other DB types, with `current_schema()` as the fallback, and also catalog-filters.
  - Ducklake all-tables keeps the old single-schema query (new `is_ducklake` param) so its table keys stay unqualified — the frontend disables schema browsing for ducklake (`dbFeatures.ts`).
  - `db_supports_schemas()` (backend twin of the frontend function) now includes `DbType::Duckdb`, so `DROP_TABLE`/`CREATE_TABLE`/`ALTER_TABLE` markers schema-qualify their target. Without this, deleting/creating/altering a table in a non-`main` schema would silently target `main` (found by local review).
- `frontend/.../dbtable/metadata.ts`: `getTablesByResource` duckdb case now qualifies non-`main` schemas as `schema.table` (mirrors the PostgreSQL/`public` convention).
- `frontend/src/lib/components/DBManager.svelte`: default-schema fallback chain gains `'main'` (after `public`/`dbo`).

## Validation

- `cargo test -p windmill-common --lib query_builders`: 180 passed (6 new/updated DuckDB tests covering all-tables, schema-qualified single-table, ducklake unchanged-behavior, and schema-qualified DROP TABLE).
- `cargo check`: clean.
- `npm run check`: 0 errors.
- Live marker expansion verified against the running dev backend via `POST /internal_db/expand_marker` for plain duckdb (all-tables + qualified single-table) and ducklake.
- All generated SQL executed against a real DuckDB (CLI v-local): schema-aware metadata rows come back correctly; the `table_catalog = current_database()` filter correctly excludes same-named tables in other attached catalogs; schema-qualified DDL works under ducklake's `ATTACH ...;USE dl;` wrapper.

## Limitations / not verified

- Full browser E2E could not be exercised on this devbox: the dev backend is built without the `duckdb` cargo feature (and the available FFI lib is version 1 while the code requires ≥ 2), and the dev workers don't pick up native DB tags at all, so no DB-manager flow (duckdb or otherwise) can run jobs in this environment. Validation relied on the unit tests + live marker-expansion API + real DuckDB CLI execution listed above.
- Manual check recommended on an environment with the duckdb worker feature: against a DuckDB database with a non-`main` schema, confirm the schema tree lists both schemas, table selection loads columns/rows, and create/alter/delete table inside the non-`main` schema affects the right schema. Also confirm a ducklake connection still lists its tables unqualified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)