### PR TITLE
fix(frontend): stop live activity flickering when user has multiple tabs

### DIFF
--- a/frontend/src/lib/components/sidebar/MultiplayerMenu.svelte
+++ b/frontend/src/lib/components/sidebar/MultiplayerMenu.svelte
@@ -46,11 +46,18 @@
 
 		function setPeers() {
 			if (!awareness) return
-			$awarenessStore = Object.fromEntries(
-				Array.from(awareness.getStates().values())
-					.filter((x) => x.name)
-					.map((x) => [x.name, x.url])
-			)
+			const states = Array.from(awareness.getStates().values()).filter((x) => x.name)
+			const peerMap: Record<string, string> = {}
+			for (const state of states) {
+				if (state.name === $userStore?.username) {
+					// For current user, always use this tab's URL to avoid multi-tab flickering
+					peerMap[state.name] = $page.url.pathname
+				} else if (!Object.hasOwn(peerMap, state.name)) {
+					// For other users, keep first seen URL per username (stable dedup)
+					peerMap[state.name] = state.url
+				}
+			}
+			$awarenessStore = peerMap
 		}
 
 		setPeers()

--- a/frontend/src/lib/components/sidebar/MultiplayerMenu.svelte
+++ b/frontend/src/lib/components/sidebar/MultiplayerMenu.svelte
@@ -52,7 +52,7 @@
 				if (state.name === $userStore?.username) {
 					// For current user, always use this tab's URL to avoid multi-tab flickering
 					peerMap[state.name] = $page.url.pathname
-				} else if (!Object.hasOwn(peerMap, state.name)) {
+				} else if (!Object.prototype.hasOwnProperty.call(peerMap, state.name)) {
 					// For other users, keep first seen URL per username (stable dedup)
 					peerMap[state.name] = state.url
 				}


### PR DESCRIPTION
## Summary

Fixes WIN-2034.

Each browser tab creates its own Yjs awareness client with a unique `clientID` but the same `name` (username). `setPeers()` in `MultiplayerMenu.svelte` built the username → URL map with `Object.fromEntries`, which keeps the *last* duplicate key in iteration order — so when a user had multiple tabs open, their displayed URL in the Live Activity sidebar oscillated between tabs on every awareness change, causing visible flickering.

## Changes

- `setPeers()` now builds the peer map explicitly:
  - the **current user** always shows this tab's own `$page.url.pathname`, eliminating self-flickering entirely
  - **other users** with multiple tabs are deduped to the first-seen awareness state (stable, since Yjs awareness updates preserve `Map` insertion order), instead of last-wins oscillation
- Uses `Object.hasOwn` for the dedup check so usernames colliding with `Object.prototype` members (e.g. `constructor`) aren't dropped

## Test plan

- [x] `svelte-check` passes for the changed file (remaining repo errors are pre-existing on main)
- [x] E2E before/after repro against the real component: drove the frontend with Playwright (system Chromium), mocking the EE license endpoint, the multiplayer sign endpoint, and the `/ws_mp/` y-websocket server, then injected awareness states with duplicate usernames simulating multiple tabs:
  - **Before (main)**: current user's row on `/runs` oscillated `"Editing a flow"` ↔ `"Exploring variables"` (the other tab's URL) across 10 awareness-churn rounds
  - **After (this PR)**: current user's row stayed `"Exploring runs"` across all rounds; a second user (`alice`) with two tabs rendered as exactly one stable row
- [ ] With a real EE instance: open the same workspace as the same user in two tabs on different pages and confirm the Live Activity entry stays pinned to each tab's own page

## Screenshots

Live Activity after the fix — current user (`admin@windmill.dev`, on `/runs`) shows "Exploring runs" despite a second simulated tab on `/variables`; `alice` with two simulated tabs shows a single stable row:

![live-activity-stable](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2034-fix-live-activity-flickering-when-user-has-multiple-tabs/1781213540-live-activity-stable.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Live Activity flickering when a user has multiple tabs by making the peer map stable and tab-aware. Addresses WIN-2034.

- **Bug Fixes**
  - Reworked `setPeers()` in `MultiplayerMenu.svelte` to pin this tab’s `$page.url.pathname` for the current user and dedupe other users to their first-seen tab.
  - Use `Object.prototype.hasOwnProperty.call` for the dedup check to ensure TS lib compatibility and handle usernames colliding with `Object.prototype` keys.

<sup>Written for commit f8ca9b15dbd371bfeba920014f9315327454a9aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

