### PR TITLE
fix(flows): skip_if evaluates wrong previous_result during retry

### DIFF
--- a/backend/tests/retry.rs
+++ b/backend/tests/retry.rs
@@ -262,6 +262,65 @@ def main(last, port):
         Ok(())
     }
 
+    /* `skip_if` evaluation goes through windmill-jseval and requires `quickjs` */
+    #[cfg(all(feature = "deno_core", feature = "quickjs"))]
+    #[sqlx::test(fixtures("base"))]
+    async fn test_skip_if_sees_previous_step_result_on_retry(
+        db: Pool<Postgres>,
+    ) -> anyhow::Result<()> {
+        initialize_tracing().await;
+
+        /* step `b` fails on its first attempt and succeeds on retry. Its `skip_if`
+         * references the previous step's result: when re-evaluated for the retry,
+         * `previous_result` must still be step `a`'s result, not the error of step
+         * `b`'s failed attempt (which would wrongly flip `skip_if` to true and skip
+         * the retry) */
+        let value = serde_json::from_value(json!({
+            "modules": [{
+                "id": "a",
+                "value": {
+                    "input_transforms": {},
+                    "type": "rawscript",
+                    "language": "deno",
+                    "content": "export function main() { return \"ok\" }",
+                },
+            }, {
+                "id": "b",
+                "skip_if": { "expr": "results.a?.error !== undefined" },
+                "value": {
+                    "input_transforms": {
+                        "index": { "type": "static", "value": 1 },
+                        "port": { "type": "javascript", "expr": "flow_input.port" },
+                    },
+                    "type": "rawscript",
+                    "language": "deno",
+                    "content": inner_step(),
+                },
+                "retry": { "constant": { "attempts": 1, "seconds": 0 } },
+            }],
+        }))
+        .unwrap();
+
+        let (attempts, responses) = [
+            /* fail step `b` once, then pass on retry */
+            (1, None),
+            (1, Some(42)),
+        ]
+        .into_iter()
+        .unzip::<_, _, Vec<_>, Vec<_>>();
+        let server = Server::start(responses).await;
+        let result = RunJob::from(JobPayload::RawFlow { value, path: None, restarted_from: None })
+            .arg("port", json!(server.addr.port()))
+            .run_until_complete(&db, false, server.addr.port())
+            .await
+            .json_result()
+            .unwrap();
+
+        assert_eq!(server.close().await, attempts);
+        assert_eq!(json!(42), result);
+        Ok(())
+    }
+
     #[cfg(feature = "python")]
     #[sqlx::test(fixtures("base"))]
     async fn test_with_failure_module(db: Pool<Postgres>) -> anyhow::Result<()> {

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -3701,10 +3701,12 @@ async fn push_next_flow_job(
                 status_module = FlowStatusModule::WaitingForPriorSteps { id: status_module.id() };
 
                 // The failed attempt's error has already been consumed by `evaluate_retry`
-                // above. Restore `previous_result` to what the original attempt saw (the
-                // preceding step's result, or the flow args for the first step) so that
-                // predicates re-evaluated for the retry (skip_if, loop iterator
-                // expressions, ...) don't see the failed attempt's error instead.
+                // above. Restore `previous_result` to the preceding step's result (or the
+                // flow args for the first step) so that predicates re-evaluated for the
+                // retry (skip_if, loop iterator expressions, ...) don't see the failed
+                // attempt's error instead. Like the suspend/restart path above, this
+                // falls back to `"{}"` when the preceding step has no Success status
+                // (e.g. it failed with continue_on_error).
                 if !matches!(step, Step::FailureStep) {
                     arc_last_job_result = if matches!(step, Step::Step { idx: 0, .. })
                         || step.is_preprocessor_step()

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -3268,7 +3268,7 @@ async fn push_next_flow_job(
     }
 
     // Compute and initialize last_job_result
-    let arc_last_job_result = if status_module.is_failure() {
+    let mut arc_last_job_result = if status_module.is_failure() {
         // if job is being retried, pass the result of its previous failure
         last_job_result.unwrap_or_else(|| Arc::new(to_raw_value(&json!("{}"))))
     } else if matches!(step, Step::Step { idx: 0, .. }) || step.is_preprocessor_step() {
@@ -3699,6 +3699,28 @@ async fn push_next_flow_job(
                  .context("update flow retry")?;
 
                 status_module = FlowStatusModule::WaitingForPriorSteps { id: status_module.id() };
+
+                // The failed attempt's error has already been consumed by `evaluate_retry`
+                // above. Restore `previous_result` to what the original attempt saw (the
+                // preceding step's result, or the flow args for the first step) so that
+                // predicates re-evaluated for the retry (skip_if, loop iterator
+                // expressions, ...) don't see the failed attempt's error instead.
+                if !matches!(step, Step::FailureStep) {
+                    arc_last_job_result = if matches!(step, Step::Step { idx: 0, .. })
+                        || step.is_preprocessor_step()
+                    {
+                        Arc::new(to_raw_value(&flow_job.args))
+                    } else {
+                        match get_previous_job_result(db, flow_job.workspace_id.as_str(), &status)
+                            .warn_after_seconds(3)
+                            .await?
+                        {
+                            None => Arc::new(to_raw_value(&json!("{}"))),
+                            Some(previous_job_result) => Arc::new(previous_job_result),
+                        }
+                    };
+                }
+
                 // we get the args from the last failed job
                 status.retry.failed_jobs.last()
             /* Start the failure module ... */


### PR DESCRIPTION
Fixes WIN-2035

## Summary

When a flow step has both `skip_if` and `retry`, the `skip_if` condition is re-evaluated when the retry is scheduled — but `previous_result` at that point still holds the **failed attempt's error**, not the preceding step's output. Since the JS results proxy short-circuits `results.<prev_step_id>` to `previous_result` (`windmill-jseval/src/lib.rs` proxy setup), any `skip_if` expression referencing the previous step (e.g. `results.a?.error !== undefined`) sees the error object and can wrongly skip the retry. The same stale value also fed loop iterator expression re-evaluation on retried loop modules.

## Changes

- `backend/windmill-worker/src/worker_flow.rs`: after the retry transition (`status_module = WaitingForPriorSteps`), reassign `arc_last_job_result` to the preceding step's actual result via the existing `get_previous_job_result` helper, mirroring the canonical `previous_result` computation at the top of `push_next_flow_job` (flow args for the first step / preprocessor, `"{}"` fallback when the preceding step has no `Success` status). This runs **after** `evaluate_retry`, so `retry_if` conditions still correctly see the error.
- Guarded with `!matches!(step, Step::FailureStep)`: failure-module retries intentionally keep the error as `previous_result`.
- Step args on retry are unaffected — they are still sourced from the failed job (`get_args_from_id`), so input transforms are not re-evaluated.
- `backend/tests/retry.rs`: regression test `test_skip_if_sees_previous_step_result_on_retry` — step `b` fails once then succeeds, with `skip_if: results.a?.error !== undefined`. Without the fix the retry is wrongly skipped (server sees one connection, flow result is the error object); with the fix the retry runs and the flow returns `42`. Gated on `deno_core + quickjs` (skip_if eval requires `quickjs`), both enabled in CI's backend test run.

## Validation

- `cargo check -p windmill-worker` — clean.
- New regression test verified **before/after**: fails on the unfixed code (`left: [1] right: [1, 1]` — retry skipped), passes with the fix.
- Full `backend/tests/retry.rs` suite (`--features deno_core,quickjs,python`): all 5 tests pass, including loop-retry (`test_pass`) and failure-module retry (`test_with_failure_module`). (3 python-dependent tests initially failed locally due to a corrupted local Python runtime cache, identically with and without the fix; repairing the cache made the suite fully green.)

## Notes

- Pre-existing edge case kept as-is (also true for the suspend/restart path which uses the same helper): if the preceding step failed with `continue_on_error`, the restored `previous_result` is `"{}"` rather than that step's error object. The code comment documents this.

## Test plan

- [x] Regression test fails without the fix, passes with it
- [x] Full retry test suite green with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WIN-2035: ensure `skip_if` (and loop expressions) on retry evaluate against the previous step’s result, not the failed attempt’s error, so valid retries are not skipped.

- **Bug Fixes**
  - In `backend/windmill-worker/src/worker_flow.rs`, after scheduling a retry, reset `previous_result` to the preceding step’s result (or flow args for first/preprocessor) to avoid leaking the failed attempt’s error into `skip_if`.
  - Guarded for failure modules (they still expose the error). `retry_if` and retry args remain unchanged.
  - Added regression test `test_skip_if_sees_previous_step_result_on_retry` in `backend/tests/retry.rs`.

<sup>Written for commit 7e93c879aa7af5c33971082bae9506996296ddaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

