### PR TITLE
feat: support temp_script_refs in wmill dev for local relative imports

### DIFF
--- a/cli/src/commands/dev/dev.ts
+++ b/cli/src/commands/dev/dev.ts
@@ -228,6 +228,33 @@ export async function dev(opts: GlobalOptions & SyncOptions & DevOpts) {
   const ignore = await ignoreF(opts);
   const codebases = await listSyncCodebases(opts);
 
+  // Resolve relative imports from local (not-yet-deployed) content so dev-page
+  // previews use locally-edited workspace scripts instead of the deployed
+  // versions. Diverged local scripts are uploaded to temp storage once here
+  // and the resulting path -> hash refs ride along on every preview run.
+  // Computed as a startup snapshot, like `wmill app dev`; restart `wmill dev`
+  // to pick up later edits to imported workspace scripts. Uses the "all"
+  // target because the previewed item can change at runtime (picker /
+  // loadWmPath), so there is no single anchor node. Degrades gracefully
+  // (undefined) on older backends without the /raw_temp endpoints.
+  let tempScriptRefs: Record<string, string> | undefined = undefined;
+  {
+    const { buildPreviewTempScriptRefs } = await import(
+      "../generate-metadata/generate-metadata.ts"
+    );
+    tempScriptRefs = await buildPreviewTempScriptRefs(
+      workspace,
+      opts,
+      codebases,
+      { kind: "all" },
+    );
+    if (tempScriptRefs) {
+      log.info(
+        `Resolved ${Object.keys(tempScriptRefs).length} locally-edited script(s) for preview relative imports (snapshot — restart wmill dev to refresh)`
+      );
+    }
+  }
+
   const changesTimeouts: Record<string, ReturnType<typeof setTimeout>> = {};
   function watchChanges() {
     return new Promise<void>((_resolve, _reject) => {
@@ -314,6 +341,7 @@ export async function dev(opts: GlobalOptions & SyncOptions & DevOpts) {
           flow: localFlow,
           uriPath: localPath,
           path: wmFlowPath,
+          temp_script_refs: tempScriptRefs,
         };
         log.info("Updated " + wmFlowPath);
         broadcastChanges(currentLastEdit);
@@ -337,6 +365,7 @@ export async function dev(opts: GlobalOptions & SyncOptions & DevOpts) {
           language: lang,
           tag: typed?.tag,
           lock: typed?.lock,
+          temp_script_refs: tempScriptRefs,
         };
         log.info("Updated " + wmPath);
         broadcastChanges(currentLastEdit);
@@ -350,7 +379,7 @@ export async function dev(opts: GlobalOptions & SyncOptions & DevOpts) {
     language: string;
     tag?: string;
     lock?: string;
-
+    temp_script_refs?: Record<string, string>;
   };
 
   type LastEditFlow = {
@@ -358,6 +387,7 @@ export async function dev(opts: GlobalOptions & SyncOptions & DevOpts) {
     flow: OpenFlow;
     uriPath: string;
     path: string;
+    temp_script_refs?: Record<string, string>;
   };
 
   // Load a resource by its windmill path (e.g., "u/admin/my_script" or "f/my_flow")
@@ -399,6 +429,7 @@ export async function dev(opts: GlobalOptions & SyncOptions & DevOpts) {
         flow: localFlow,
         uriPath: flowDir,
         path: wmPath,
+        temp_script_refs: tempScriptRefs,
       };
       currentLastEdit = edit;
       return edit;
@@ -421,6 +452,7 @@ export async function dev(opts: GlobalOptions & SyncOptions & DevOpts) {
           language: lang,
           tag: typed?.tag,
           lock: typed?.lock,
+          temp_script_refs: tempScriptRefs,
         };
         currentLastEdit = edit;
         return edit;

--- a/cli/src/commands/generate-metadata/generate-metadata.ts
+++ b/cli/src/commands/generate-metadata/generate-metadata.ts
@@ -97,8 +97,10 @@ async function walkLocalAppItems(
  * or app), so a preview run resolves relative imports from not-yet-deployed
  * local content instead of the deployed scripts. Walks all local scripts so
  * transitive relative-import targets can be uploaded, then for flow/app adds
- * that item's node. Degrades gracefully (returns undefined) on older backends
- * without the /raw_temp endpoints.
+ * that item's node. The "all" target skips per-node filtering and returns refs
+ * for every uploaded script — used by `wmill dev`, where the previewed item
+ * changes at runtime. Degrades gracefully (returns undefined) on older
+ * backends without the /raw_temp endpoints.
  */
 export async function buildPreviewTempScriptRefs(
   workspace: Workspace,
@@ -107,7 +109,8 @@ export async function buildPreviewTempScriptRefs(
   target:
     | { kind: "script"; path: string }
     | { kind: "flow"; folder: string }
-    | { kind: "app"; folder: string; rawApp: boolean },
+    | { kind: "app"; folder: string; rawApp: boolean }
+    | { kind: "all" },
 ): Promise<Record<string, string> | undefined> {
   try {
     const rawWorkspaceDependencies = await getRawWorkspaceDependencies(true);
@@ -129,8 +132,11 @@ export async function buildPreviewTempScriptRefs(
       );
     }
 
-    let nodePath: string;
-    if (target.kind === "script") {
+    let nodePath: string | undefined;
+    if (target.kind === "all") {
+      // No anchor node — refs are collected tree-wide below
+      nodePath = undefined;
+    } else if (target.kind === "script") {
       nodePath = scriptPathToRemotePath(target.path);
     } else if (target.kind === "flow") {
       const folder = target.folder.endsWith(SEP)
@@ -157,7 +163,9 @@ export async function buildPreviewTempScriptRefs(
 
     tree.propagateStaleness();
     await uploadScripts(tree, workspace);
-    const refs = tree.getTempScriptRefs(nodePath);
+    const refs = nodePath !== undefined
+      ? tree.getTempScriptRefs(nodePath)
+      : tree.getAllTempScriptRefs();
     return refs && Object.keys(refs).length > 0 ? refs : undefined;
   } catch (e) {
     // Degrade gracefully (preview still runs against deployed versions) but do

--- a/cli/src/utils/dependency_tree.ts
+++ b/cli/src/utils/dependency_tree.ts
@@ -354,6 +354,22 @@ export class DoubleLinkedDependencyTree {
   }
 
   /**
+   * Returns path → contentHash for ALL uploaded nodes, regardless of which
+   * script imports them. Superset of getTempScriptRefs(path) for every path —
+   * used by `wmill dev`, where the previewed item changes at runtime so no
+   * single anchor node exists. Must be called after uploadScripts().
+   */
+  getAllTempScriptRefs(): Record<string, string> {
+    const result: Record<string, string> = {};
+    for (const [path, node] of this.nodes.entries()) {
+      if (node.contentHash) {
+        result[path] = node.contentHash;
+      }
+    }
+    return result;
+  }
+
+  /**
    * Persist workspace dep hashes to wmill-lock.yaml so getRawWorkspaceDependencies
    * considers them up-to-date on the next run.
    */

--- a/cli/test/dependency_tree_unit.test.ts
+++ b/cli/test/dependency_tree_unit.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import * as path from "node:path";
+import { DoubleLinkedDependencyTree } from "../src/utils/dependency_tree.ts";
+
+// addNode consults wmill-lock.yaml from cwd for workspace deps; run inside a
+// temp dir so the test never reads/writes the repo's own lock file.
+async function withTempDir(
+  fn: () => Promise<void>,
+): Promise<void> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "wmill_deptree_test_"));
+  const originalCwd = process.cwd();
+  try {
+    process.chdir(tempDir);
+    await fn();
+  } finally {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true });
+  }
+}
+
+async function buildTree(): Promise<DoubleLinkedDependencyTree> {
+  const tree = new DoubleLinkedDependencyTree();
+  // main imports lib; other is unrelated
+  await tree.addNode(
+    "f/test/main",
+    `import { x } from "./lib.ts"`,
+    "bun",
+    "",
+    ["f/test/lib"],
+    "script",
+    "f/test/main",
+    "f/test/main.ts",
+    true,
+  );
+  await tree.addNode(
+    "f/test/lib",
+    "export const x = 1",
+    "bun",
+    "",
+    [],
+    "script",
+    "f/test/lib",
+    "f/test/lib.ts",
+    true,
+  );
+  await tree.addNode(
+    "f/other/standalone",
+    "export const y = 2",
+    "bun",
+    "",
+    [],
+    "script",
+    "f/other/standalone",
+    "f/other/standalone.ts",
+    true,
+  );
+  return tree;
+}
+
+test("getAllTempScriptRefs returns refs for every uploaded node", async () => {
+  await withTempDir(async () => {
+    const tree = await buildTree();
+    // Simulate uploadScripts marking all three as uploaded
+    tree.setContentHash("f/test/main", "hash_main");
+    tree.setContentHash("f/test/lib", "hash_lib");
+    tree.setContentHash("f/other/standalone", "hash_standalone");
+
+    expect(tree.getAllTempScriptRefs()).toEqual({
+      "f/test/main": "hash_main",
+      "f/test/lib": "hash_lib",
+      "f/other/standalone": "hash_standalone",
+    });
+  });
+});
+
+test("getAllTempScriptRefs skips nodes without a content hash", async () => {
+  await withTempDir(async () => {
+    const tree = await buildTree();
+    // Only lib diverged from deployed
+    tree.setContentHash("f/test/lib", "hash_lib");
+
+    expect(tree.getAllTempScriptRefs()).toEqual({ "f/test/lib": "hash_lib" });
+  });
+});
+
+test("getAllTempScriptRefs is a superset of getTempScriptRefs for any node", async () => {
+  await withTempDir(async () => {
+    const tree = await buildTree();
+    tree.setContentHash("f/test/lib", "hash_lib");
+    tree.setContentHash("f/other/standalone", "hash_standalone");
+
+    const all = tree.getAllTempScriptRefs();
+    for (const node of ["f/test/main", "f/test/lib", "f/other/standalone"]) {
+      const perNode = tree.getTempScriptRefs(node);
+      for (const [k, v] of Object.entries(perNode)) {
+        expect(all[k]).toBe(v);
+      }
+    }
+    // And the per-node view of main only sees its own transitive import
+    expect(tree.getTempScriptRefs("f/test/main")).toEqual({
+      "f/test/lib": "hash_lib",
+    });
+  });
+});

--- a/frontend/src/lib/components/Dev.svelte
+++ b/frontend/src/lib/components/Dev.svelte
@@ -184,6 +184,9 @@
 		isCodebase?: boolean
 		tag?: string
 		modules?: { [key: string]: import('$lib/gen').ScriptModule } | null
+		// path -> temp-storage hash of locally-edited workspace scripts, sent by
+		// `wmill dev` so previews resolve relative imports from local content
+		temp_script_refs?: Record<string, string>
 	}
 
 	let currentScript: LastEditScript | undefined = $state(undefined)
@@ -552,7 +555,8 @@
 						undefined,
 						undefined,
 						undefined,
-						currentScript.modules
+						currentScript.modules,
+						currentScript.temp_script_refs
 					)
 				}
 			}
@@ -621,11 +625,16 @@
 		flow: OpenFlow
 		uriPath: string
 		path: string
+		temp_script_refs?: Record<string, string>
 	}
 	let lastUriPath: string | undefined = undefined
+	// Kept outside the flow object so the flow round-trip back to `wmill dev`
+	// (updateFlow -> handleFlowRoundTrip) never serializes refs into flow.yaml
+	let flowTempScriptRefs: Record<string, string> | undefined = undefined
 	async function replaceFlow(lastEdit: LastEditFlow) {
 		mode = 'flow'
 		lastUriPath = lastEdit.uriPath
+		flowTempScriptRefs = lastEdit.temp_script_refs
 		pathStore.set(lastEdit.path)
 		// sendUserToast(JSON.stringify(lastEdit.flow), true)
 		// return
@@ -700,7 +709,8 @@
 		modulesTestStates,
 		outputPickerOpenFns,
 		preserveOnBehalfOf: writable(false),
-		savedOnBehalfOfEmail: writable<string | undefined>(undefined)
+		savedOnBehalfOfEmail: writable<string | undefined>(undefined),
+		devTempScriptRefs: () => flowTempScriptRefs
 	})
 	setContext<PropPickerContext>('PropPickerContext', {
 		flowPropPickerConfig: writable<FlowPropPickerConfig | undefined>(undefined),

--- a/frontend/src/lib/components/FlowPreviewContent.svelte
+++ b/frontend/src/lib/components/FlowPreviewContent.svelte
@@ -132,7 +132,8 @@
 		initialPathStore,
 		fakeInitialPath,
 		customUi,
-		executionCount
+		executionCount,
+		devTempScriptRefs
 	} = $state(getContext<FlowEditorContext>('FlowEditorContext'))
 	const dispatch = createEventDispatcher()
 
@@ -193,7 +194,14 @@
 			flowProgressBar?.reset()
 			const newFlow = extractFlow(previewMode)
 			args = await processSecretArgs(args, flowStore.val.schema as any)
-			newJobId = await runFlowPreview(args, newFlow, $pathStore, restartedFrom, conversationId)
+			newJobId = await runFlowPreview(
+				args,
+				newFlow,
+				$pathStore,
+				restartedFrom,
+				conversationId,
+				devTempScriptRefs?.()
+			)
 			jobId = newJobId
 			isRunning = true
 			if (inputSelected) {

--- a/frontend/src/lib/components/JobLoader.svelte
+++ b/frontend/src/lib/components/JobLoader.svelte
@@ -335,7 +335,8 @@
 		hash?: string,
 		callbacks?: Callbacks,
 		flowPath?: string,
-		modules?: Record<string, import('$lib/gen').ScriptModule> | null
+		modules?: Record<string, import('$lib/gen').ScriptModule> | null,
+		tempScriptRefs?: Record<string, string>
 	): Promise<string> {
 		return abstractRun(
 			() =>
@@ -350,7 +351,8 @@
 						lock,
 						script_hash: hash,
 						flow_path: flowPath,
-						modules: modules ?? undefined
+						modules: modules ?? undefined,
+						temp_script_refs: tempScriptRefs
 					}
 				}),
 			callbacks

--- a/frontend/src/lib/components/ModuleTest.svelte
+++ b/frontend/src/lib/components/ModuleTest.svelte
@@ -32,8 +32,15 @@
 		onJobDone
 	}: Props = $props()
 
-	const { flowStore, flowStateStore, pathStore, stepsInputArgs, previewArgs, modulesTestStates } =
-		getContext<FlowEditorContext>('FlowEditorContext')
+	const {
+		flowStore,
+		flowStateStore,
+		pathStore,
+		stepsInputArgs,
+		previewArgs,
+		modulesTestStates,
+		devTempScriptRefs
+	} = getContext<FlowEditorContext>('FlowEditorContext')
 
 	let jobLoader: JobLoader | undefined = $state(undefined)
 	let jobProgressReset: () => void = () => {}
@@ -77,7 +84,9 @@
 				undefined,
 				undefined,
 				callbacks,
-				$pathStore
+				$pathStore,
+				undefined,
+				devTempScriptRefs?.()
 			)
 		} else if (val.type == 'script') {
 			const script = val.hash

--- a/frontend/src/lib/components/flows/types.ts
+++ b/frontend/src/lib/components/flows/types.ts
@@ -94,6 +94,10 @@ export type FlowEditorContext = {
 	outputPickerOpenFns: Record<string, () => void>
 	preserveOnBehalfOf: Writable<boolean>
 	savedOnBehalfOfEmail: Writable<string | undefined>
+	// Only set by the local dev page (Dev.svelte): path -> temp-storage hash of
+	// locally-edited workspace scripts, passed as temp_script_refs on preview
+	// runs so relative imports resolve from local (not-yet-deployed) content
+	devTempScriptRefs?: () => Record<string, string> | undefined
 }
 
 export type FlowGraphAssetContext = StateStore<{

--- a/frontend/src/lib/components/flows/utils.svelte.ts
+++ b/frontend/src/lib/components/flows/utils.svelte.ts
@@ -184,7 +184,8 @@ export async function runFlowPreview(
 	flow: OpenFlow & { tag?: string },
 	path: string,
 	restartedFrom: RestartedFrom | undefined,
-	conversationId?: string | undefined
+	conversationId?: string | undefined,
+	tempScriptRefs?: Record<string, string>
 ) {
 	const newFlow = flow
 	return await JobService.runFlowPreview({
@@ -194,7 +195,8 @@ export async function runFlowPreview(
 			value: newFlow.value,
 			path: path,
 			tag: newFlow.tag,
-			restarted_from: restartedFrom
+			restarted_from: restartedFrom,
+			temp_script_refs: tempScriptRefs
 		},
 		memoryId: conversationId
 	})


### PR DESCRIPTION
## Summary

Fixes WIN-2038.

When using `wmill dev`, previews of scripts/flows with relative imports to scripts that haven't been deployed yet (or have local edits) failed or used stale deployed code, because the dev page's `runScriptPreview` / `runFlowPreview` calls didn't include `temp_script_refs`. This was already supported in `wmill script preview`, `wmill flow preview`, and `wmill app dev` via `buildPreviewTempScriptRefs()`.

This PR computes the refs at `wmill dev` startup (mirroring the `wmill app dev` snapshot pattern), sends them through the WebSocket → browser chain, and plumbs them into the preview API calls.

**Design note:** unlike `wmill app dev`, the previewed item in `wmill dev` can change at runtime (path picker / `loadWmPath`), so there is no single anchor node to filter refs by. Instead a new `{ kind: "all" }` target on `buildPreviewTempScriptRefs` returns the refs for *all* locally-diverged scripts (uploaded once at startup), and the same map rides on every preview run. This is a superset of the per-target map for any node, and the backend only looks up the imports it actually needs, so extra entries are inert. It also means imports added live in the dev page editor still resolve, as long as the target script existed at startup.

**Known limitation (same as `wmill app dev`):** the refs are a startup snapshot — restart `wmill dev` to pick up later edits to imported workspace scripts. This is surfaced in the startup log line.

## Changes

- `cli/src/utils/dependency_tree.ts`: new `getAllTempScriptRefs()` returning path → contentHash for every uploaded node.
- `cli/src/commands/generate-metadata/generate-metadata.ts`: `buildPreviewTempScriptRefs` accepts `{ kind: "all" }` (no anchor node; tree-wide refs).
- `cli/src/commands/dev/dev.ts`: computes the refs once at startup (graceful degradation on older backends without `/raw_temp`), adds `temp_script_refs` to `LastEditScript` / `LastEditFlow` and to all four WS message construction sites (`loadPaths` / `loadWmPath` × script / flow).
- `frontend/src/lib/components/Dev.svelte`: stores the refs from WS messages; passes them on script Test runs; exposes them to the flow editor tree via a new optional `devTempScriptRefs` getter on `FlowEditorContext`. Flow refs are deliberately kept **outside** the flow object so the flow.yaml round-trip back to the CLI is never polluted.
- `frontend/src/lib/components/flows/types.ts`: optional `devTempScriptRefs` on `FlowEditorContext` (only set by the dev page; regular flow editor unaffected).
- `frontend/src/lib/components/JobLoader.svelte`: `runPreview` takes optional `tempScriptRefs` → `temp_script_refs` in the request body.
- `frontend/src/lib/components/flows/utils.svelte.ts` + `FlowPreviewContent.svelte`: whole-flow / up-to previews pass the refs to `JobService.runFlowPreview`.
- `frontend/src/lib/components/ModuleTest.svelte`: single-step (rawscript) tests in the dev page pass the refs too.
- `cli/test/dependency_tree_unit.test.ts`: unit tests for `getAllTempScriptRefs` (all-uploaded, partial, superset-of-per-node semantics).

## Test plan

- [x] CLI unit tests: `UNIT_ONLY=1 bun test test/*_unit*` — 856 pass (includes 3 new tests).
- [x] `bunx tsc --noEmit` in `cli/` — no new errors (pre-existing errors untouched).
- [x] `npm run check` in `frontend/` — 0 errors.
- [x] Manual end-to-end (local backend + frontend): created a workspace folder with `f/devtest/lib.ts` (never deployed) and `f/devtest/main.ts` importing `./lib.ts`; ran `wmill dev` → startup logs `Resolved 2 locally-edited script(s) for preview relative imports`; script Test on the dev page returns `hello from LOCAL lib, world` and the `/jobs/run/preview` request body contains `temp_script_refs`.
- [x] Manual flow preview: flow with an inline script importing `../lib.ts` — Test flow succeeds with `hello from LOCAL lib, flowworld`; `/jobs/run/preview_flow` body contains `temp_script_refs`; the flow.yaml written back by the dev round-trip contains no `temp_script_refs` key.
- [ ] Against an older backend without `/raw_temp`: `wmill dev` prints the yellow fallback warning and previews still run against deployed versions (not exercised locally — degradation path is the existing shared `buildPreviewTempScriptRefs` catch).

## Screenshots

Script preview on the dev page resolving a relative import from a never-deployed local script:

![script-preview-local-import](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/hugo/win-2038-support-temp_script_refs-in-wmill-dev-for-local-relative/1781268469-script-preview-local-import.png)

Flow preview with an inline script importing the same local lib:

![flow-preview-local-import](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/hugo/win-2038-support-temp_script_refs-in-wmill-dev-for-local-relative/1781268471-flow-preview-local-import.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `temp_script_refs` to `wmill dev` so script and flow previews resolve relative imports from local, not-yet-deployed files. Fixes WIN-2038 to eliminate stale code in dev previews.

- **New Features**
  - Compute refs once at `wmill dev` startup using `buildPreviewTempScriptRefs({ kind: "all" })`, send via WS, and include in all preview runs (scripts, flows, module tests).
  - CLI: add `getAllTempScriptRefs`; include refs in `LastEditScript`/`LastEditFlow` and WS messages; graceful fallback on older backends without `/raw_temp`.
  - Frontend: store refs in the dev page and pass them to `JobService.runPreview`/`runFlowPreview`; expose `devTempScriptRefs` in `FlowEditorContext` without touching `flow.yaml`.
  - Tests: unit tests for `getAllTempScriptRefs`.
  - Limitation: refs are a startup snapshot; restart `wmill dev` to pick up later edits to imported workspace scripts.

<sup>Written for commit d9213b06c8ae5a3fb19446f9cb5e6afdfc813e5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

