### PR TITLE
fix(cli): harden legacy flow lock migration from #9555

### DIFF
--- a/cli/src/commands/flow/flow_metadata.ts
+++ b/cli/src/commands/flow/flow_metadata.ts
@@ -341,15 +341,26 @@ export async function generateFlowLockInternal(
       writeIfChanged(process.cwd() + SEP + folder + SEP + s.path, s.content);
     });
 
+    // Overwrite `flow.yaml` with the new lockfile references
+    writeIfChanged(
+      process.cwd() + SEP + folder + SEP + "flow.yaml",
+      yamlStringify(flowValue as Record<string, any>, yamlOptions)
+    );
+
     // CLI versions between #8561 and the canonical-lock-name fix named lock
     // files after the content path minus only its last dot segment (e.g.
     // "x.inline_script.deno.lock"). The canonical name strips the full
-    // language extension ("x.inline_script.lock"), so remove the legacy file
-    // once its replacement has been written above.
+    // language extension ("x.inline_script.lock"), so remove the legacy file.
+    // Runs after the flow.yaml rewrite above so an interruption can't leave
+    // flow.yaml referencing an already-deleted legacy file.
     for (const s of inlineScripts) {
       if (s.is_lock) continue;
       const legacyRelPath = legacyLockPathForContent(s.path, s.language);
       if (!legacyRelPath) continue;
+      // A legacy name can coincide with another step's canonical file written
+      // in this run (e.g. deno step "x" vs a step whose summary is "x.deno") —
+      // never delete a path that is part of the current extraction.
+      if (inlineScripts.some((other) => other.path === legacyRelPath)) continue;
       const legacyAbsPath = process.cwd() + SEP + folder + SEP + legacyRelPath;
       if (existsSync(legacyAbsPath)) {
         try {
@@ -360,12 +371,6 @@ export async function generateFlowLockInternal(
         }
       }
     }
-
-    // Overwrite `flow.yaml` with the new lockfile references
-    writeIfChanged(
-      process.cwd() + SEP + folder + SEP + "flow.yaml",
-      yamlStringify(flowValue as Record<string, any>, yamlOptions)
-    );
   }
 
   // In tree mode, workspace deps are tracked via the tree — exclude from hash


### PR DESCRIPTION
## Summary

Follow-up to #9555 addressing the two P2 nits from its automated review, hardening the one-time migration that renames legacy flow inline lock files (`*.inline_script.deno.lock`) to the canonical name (`*.inline_script.lock`).

## Changes

- The legacy lock-file deletion loop now runs **after** the flow.yaml rewrite, so an interruption between the two can no longer leave flow.yaml referencing an already-deleted lock file.
- Added a collision guard: a legacy name that coincides with a file written in the current extraction (e.g. deno step `x` whose legacy lock `x.deno.lock` equals the canonical lock of a step summarized "x.deno") is never deleted.

## Test plan

- [x] `bun test` extractor/inline-script unit suite passes (34 tests)
- [x] Mock-backend E2E of `generateFlowLockInternal`: legacy repo migrates in one run (canonical lock written, legacy removed, flow.yaml updated) with the new ordering
- [ ] Contrived flow where one step's canonical lock path equals another step's legacy lock path: the live file is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the one-time migration that renames legacy inline lock files by rewriting `flow.yaml` before cleanup and guarding against path collisions. Prevents stale lock references and accidental deletion during migration.

- **Bug Fixes**
  - Delete legacy locks after the `flow.yaml` rewrite to avoid broken references on interruption.
  - Skip deleting a legacy path if it matches any path generated in the current extraction.

<sup>Written for commit 1ab4f6c5624933f47cde48be11e174e4870521ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

