### PR TITLE
fix(frontend): home tree view each_key_duplicate on folder/user name collision

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
+++ b/frontend/src/lib/components/copilot/chat/AssistantMessage.svelte
@@ -3,7 +3,6 @@
 	import { gfmPlugin } from 'svelte-exmarkdown/gfm'
 	import { twMerge } from 'tailwind-merge'
 	import { Brain, ChevronDown, ChevronRight, Loader2 } from 'lucide-svelte'
-	import { slide } from 'svelte/transition'
 	import type { DisplayMessage } from './shared'
 	import CodeDisplay from './script/CodeDisplay.svelte'
 	import LinkRenderer from './LinkRenderer.svelte'

--- a/frontend/src/lib/components/home/TreeViewRoot.svelte
+++ b/frontend/src/lib/components/home/TreeViewRoot.svelte
@@ -37,7 +37,7 @@
 	</div>
 {:else}
 	<div class="border rounded-md bg-surface-tertiary">
-		{#each groupedItems.slice(0, nbDisplayed) as item (item['folderName'] ?? 'user__' + item['username'])}
+		{#each groupedItems.slice(0, nbDisplayed) as item ('folderName' in item ? `f__${item.folderName}` : 'username' in item ? `u__${item.username}` : `i__${item.type}__${item.path}`)}
 			{#if item}
 				<TreeView
 					{isSearching}
@@ -56,7 +56,10 @@
 	{#if groupedItems.length > 15 && nbDisplayed < groupedItems.length}
 		<span class="text-xs font-normal text-secondary"
 			>{nbDisplayed} root nodes out of {groupedItems.length}
-			<button class="ml-4 text-xs font-normal text-primary hover:text-emphasis" onclick={() => (nbDisplayed += 30)}>load 30 more</button></span
+			<button
+				class="ml-4 text-xs font-normal text-primary hover:text-emphasis"
+				onclick={() => (nbDisplayed += 30)}>load 30 more</button
+			></span
 		>
 	{/if}
 {/if}


### PR DESCRIPTION
## Summary

A customer on **1.722.0** reported an uncaught `each_key_duplicate` error that crashes the **home screen** (`Uncaught Error: https://svelte.dev/e/each_key_duplicate`).

I traced the minified frame `5.DgFnad_c.js:10:14454` directly from the released **EE 1.722.0** docker image: at that offset the function is a keyed `{#each}` with collection `groupedItems.slice(0, nbDisplayed)` and key `e => e.folderName ?? 'user__' + e.username` — i.e. **`TreeViewRoot.svelte:40`**, the home **tree view** (only rendered when the user has tree view enabled).

The root keyed each grouped nodes by `folderName ?? 'user__' + username`. That key collides:
- a folder literally named `user__<name>` and a user `<name>` both produce key `user__<name>`;
- any root-level bare item (no `folderName`/`username`) keys to the literal `user__undefined`, so two of them collide.

Either case throws Svelte's `each_key_duplicate` and takes down the whole home page.

**This is not a 1.722.0 regression** — the colliding key has been in place since 2023 (commit `49923331a4`). The label-inheritance feature shipped in 1.722.0 is unrelated; the customer simply runs that version with tree view on.

The fix uses a discriminated-prefix key (`f__`/`u__`/`i__`) that cannot collide across folders, users, and items — the exact scheme already used in `Dev.svelte`.

## Changes
- `frontend/src/lib/components/home/TreeViewRoot.svelte`: replace the root `{#each}` key `folderName ?? 'user__' + username` with `'folderName' in item ? \`f__${item.folderName}\` : 'username' in item ? \`u__${item.username}\` : \`i__${item.type}__${item.path}\``.

## How it was found / verified
- Pulled `ghcr.io/windmill-labs/windmill-ee:1.722.0` (matches the customer's exact chunk hashes `5.DgFnad_c.js` / `DC3MQtHM.js`); no sourcemaps ship, so mapped the frame by reading the minified each at the reported offset.
- Reproduced the exact error in the dev build (`duplicate key \`user__admin\` at indexes 0 and 1`) with a folder `f/user__admin/*` and user `u/admin/*`, tree view enabled.
- Confirmed the fix renders both nodes with no error (screenshot below).

## Screenshots

Home tree view after the fix — `u/admin` and `f/user__admin` both render as distinct root nodes, no crash:

![treeview_after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-each-key-duplicate/1781338335-treeview_after.png)

## Test plan
- [ ] Enable "Tree view" on the home page in a workspace that has both a folder named `user__<name>` and a user `<name>` with items — confirm the page renders without the `each_key_duplicate` console error.
- [ ] Confirm normal workspaces (folders + users, no collision) still render the tree view correctly with no dropped/deduplicated nodes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a home tree view crash caused by duplicate `{#each}` keys when folder/user names collide or when items lack `folderName`/`username`. Also removes an unused import in the copilot assistant message to restore a passing frontend check.

- **Bug Fixes**
  - In `frontend/src/lib/components/home/TreeViewRoot.svelte`, replace the key with `'folderName' in item ? \`f__\${item.folderName}\` : 'username' in item ? \`u__\${item.username}\` : \`i__\${item.type}__\${item.path}\``.
  - In `frontend/src/lib/components/copilot/chat/AssistantMessage.svelte`, remove unused `slide` import to satisfy `svelte-check`.

<sup>Written for commit 18bb979534bded99c43d897de85debe69f611d44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

