### PR TITLE
fix: isolate windows job children from worker CTRL_BREAK_EVENT

### DIFF
--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -909,6 +909,20 @@ pub async fn start_child_process(
     use process_wrap::tokio::*;
     let mut cmd = TokioCommandWrap::from(cmd);
 
+    // On Windows, always put the child in its own console process group so a
+    // CTRL_BREAK_EVENT sent to the worker's group (e.g. by Nomad on scale-in) is not
+    // delivered to it. Otherwise the whole child tree dies instantly with
+    // STATUS_CONTROL_C_EXIT (0xC000013A) before the worker can drain running jobs.
+    // This is independent of the JobObject grouping below, which dotnet opts out of
+    // (disable_process_group) but still needs console-signal isolation. process-wrap
+    // requires CreationFlags to be wrapped before JobObject.
+    #[cfg(windows)]
+    {
+        use process_wrap::tokio::CreationFlags;
+        use windows::Win32::System::Threading::CREATE_NEW_PROCESS_GROUP;
+        cmd.wrap(CreationFlags(CREATE_NEW_PROCESS_GROUP));
+    }
+
     if !*DISABLE_PROCESS_GROUP && !disable_process_group {
         #[cfg(unix)]
         {


### PR DESCRIPTION
## Summary

On Windows, Nomad scales a worker in by sending `CTRL_BREAK_EVENT` to the worker's **console process group**. The worker handles this gracefully (shutdown monitor in `windmill-common/src/lib.rs`), but job **child processes share the worker's console group**, so they receive the same event and the default handler kills the entire child tree instantly with `STATUS_CONTROL_C_EXIT` (`0xC000013A` / `-1073741510`) — before `MAX_WAIT_FOR_SIGTERM` / Nomad's `kill_timeout` can drain running jobs. Symptom in logs: `"shutdown monitor received ctrl-break"` immediately followed (~200ms) by `"all running jobs have completed"`, when the jobs were in fact killed mid-run rather than finishing.

The fix spawns every Windows job child in **its own console process group** via `CREATE_NEW_PROCESS_GROUP`, so a `CTRL_BREAK_EVENT` directed at the worker's group is not delivered to it. The worker keeps its own graceful handler; only the children become signal-isolated, letting the worker actually drain in-flight jobs on scale-in.

## Changes

- `backend/windmill-worker/src/common.rs` (`start_child_process`): on Windows, always wrap the command with `process_wrap`'s `CreationFlags(CREATE_NEW_PROCESS_GROUP)`.
- This is applied **unconditionally on Windows**, independent of the existing `JobObject` wrap (which stays gated behind `!DISABLE_PROCESS_GROUP && !disable_process_group`). The two concerns are distinct:
  - **JobObject** = resource grouping / group-kill. dotnet/csharp opts out of this (`disable_process_group: true`, added in `1892895cd9`) because Windows job-object nesting conflicts with dotnet's own job objects.
  - **CREATE_NEW_PROCESS_GROUP** = console-signal isolation only, benign for dotnet. It must cover **all** children — including csharp/dotnet, which is exactly the case in the original report (`dotnet` host → `Mule2.exe`).
- `process_wrap` requires `CreationFlags` to be wrapped before `JobObject`; the wrap order preserves this.

## Notes / caveats

- **Windows-only code path** — it could not be compiled or exercised on the Linux dev host. Verified at the type/feature level: both `windows` crate deps unify to `0.61.3` (so `PROCESS_CREATION_FLAGS` matches), `creation-flags` + `job-object` are in `process-wrap`'s default features, and the wrap ordering is correct. The Linux build is unaffected (all additions are `#[cfg(windows)]`).
- Job cancellation/timeout is unaffected: it goes through `taskkill /PID <pid> /T /F` (PID-tree based), which is independent of the console process group.
- For the csharp run path (no JobObject), if a job exceeds the drain timeout and the worker force-exits, the child can now orphan (previously `CTRL_BREAK` cleaned it up). This matches the intended graceful-shutdown trade-off and other executors' behavior.

## Test plan

- [ ] On a Windows worker: start a long-lived job, send `CTRL_BREAK_EVENT` to the worker's console group (or trigger a Nomad scale-in), and confirm the in-flight child survives and the worker drains gracefully — instead of the child dying immediately with `0xC000013A`.
- [ ] Confirm normal cancellation + timeout still terminate the child tree (`taskkill /T /F`) for a regular job and for a dotnet/csharp job (the `disable_process_group=true` path).
- [ ] Confirm no orphaned child processes remain after a clean worker shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On Windows, job children now run in their own console process group so `CTRL_BREAK_EVENT` sent to the worker (e.g., on Nomad scale-in) doesn’t kill them. This prevents premature `STATUS_CONTROL_C_EXIT` and allows the worker to drain in-flight jobs.

- **Bug Fixes**
  - Wrap child processes with `CreationFlags(CREATE_NEW_PROCESS_GROUP)` in `start_child_process` using `process_wrap`.
  - Applied for all Windows children, independent of JobObject/`disable_process_group` (dotnet path included); wrap order preserved.
  - Cancellation/timeout behavior unchanged (`taskkill /T /F`), Linux paths untouched.

<sup>Written for commit c7e01a32eb8cae623da9b4dea253db76e69a72ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

