### PR TITLE
fix: actually isolate windows job children from CTRL_BREAK_EVENT + reap on worker death

### DIFF
--- a/backend/windmill-worker/Cargo.toml
+++ b/backend/windmill-worker/Cargo.toml
@@ -146,7 +146,7 @@ hyper-util = { workspace = true, optional = true }
 rcgen = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.61", features = ["Win32_System_JobObjects", "Win32_System_Threading"] }
+windows = { version = "0.61", features = ["Win32_System_JobObjects", "Win32_System_Threading", "Win32_System_Diagnostics_ToolHelp"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -748,9 +748,9 @@ lazy_static! {
 const MEMORY_LIMIT_1CU: usize = 2 * 1024 * 1024 * 1024;
 
 /// Wrapper that holds a Windows Job Object handle alongside the child process.
-/// The job object is set to KILL_ON_JOB_CLOSE (and optionally a memory limit), so
-/// when the worker process dies the handle closes and the OS reaps the whole child
-/// tree — preventing orphans when the worker is force-killed (e.g. a second
+/// The job object carries KILL_ON_JOB_CLOSE and/or a memory limit. With
+/// KILL_ON_JOB_CLOSE, the worker process dying closes the handle and the OS reaps the
+/// whole child tree — preventing orphans when the worker is force-killed (e.g. a second
 /// CTRL_BREAK_EVENT or Nomad's kill_timeout) before a job has drained.
 #[cfg(windows)]
 struct WindowsJobChild {
@@ -812,14 +812,15 @@ impl process_wrap::tokio::TokioChildWrapper for WindowsJobChild {
     }
 }
 
-/// Create a Windows Job Object set to KILL_ON_JOB_CLOSE (so the child tree is reaped
-/// when the worker drops the handle / dies), optionally with a memory limit, and
-/// assign the process to it. Assigning post-spawn (rather than via process-wrap's
+/// Create a Windows Job Object and assign the process to it, optionally with
+/// KILL_ON_JOB_CLOSE (so the child tree is reaped when the worker drops the handle /
+/// dies) and/or a memory limit. Assigning post-spawn (rather than via process-wrap's
 /// suspend/resume JobObject wrap) keeps the dotnet-safe behavior that csharp relies on.
 #[cfg(windows)]
-fn assign_reaping_job_object(
+fn assign_job_object(
     pid: u32,
     memory_limit: Option<usize>,
+    kill_on_close: bool,
 ) -> Result<Win32JobHandle, std::io::Error> {
     use windows::Win32::System::JobObjects::*;
     use windows::Win32::System::Threading::{OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE};
@@ -830,7 +831,9 @@ fn assign_reaping_job_object(
         })?;
 
         let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
-        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        if kill_on_close {
+            info.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        }
         if let Some(memory_limit) = memory_limit {
             info.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_JOB_MEMORY;
             info.JobMemoryLimit = memory_limit;
@@ -956,31 +959,36 @@ pub async fn start_child_process(
         .spawn()
         .map_err(|err| tentatively_improve_error(err.into(), executable))?;
 
-    // On Windows, assign the child to a KILL_ON_JOB_CLOSE job object (folding in the
-    // LIMIT_WINDOWS_TO_1CU memory cap when set). When the worker drops the handle or
-    // dies, the OS reaps the whole child tree, so jobs aren't orphaned if the worker is
-    // force-killed (second CTRL_BREAK_EVENT, or Nomad exceeding kill_timeout) before they
-    // drain. Assigning post-spawn does not touch the creation flags (so it composes with
-    // CREATE_NEW_PROCESS_GROUP above) and is the dotnet-safe path csharp already uses.
+    // On Windows, assign the child to a job object. KILL_ON_JOB_CLOSE makes the OS reap
+    // the whole child tree when the worker drops the handle or dies, so jobs aren't
+    // orphaned if the worker is force-killed (second CTRL_BREAK_EVENT, or Nomad exceeding
+    // kill_timeout) before they drain; it is gated on the DISABLE_PROCESS_GROUP escape
+    // hatch alongside CREATE_NEW_PROCESS_GROUP above. The LIMIT_WINDOWS_TO_1CU memory cap
+    // is independent of that hatch (it's its own opt-in), so it's applied whenever set.
+    // Assigning post-spawn does not touch the creation flags (so it composes with
+    // CREATE_NEW_PROCESS_GROUP) and is the dotnet-safe path csharp already uses.
     #[cfg(windows)]
-    if !*DISABLE_PROCESS_GROUP {
-        if let Some(pid) = child.inner().id() {
-            let memory_limit =
-                (*windmill_common::worker::LIMIT_WINDOWS_TO_1CU).then_some(MEMORY_LIMIT_1CU);
-            match assign_reaping_job_object(pid, memory_limit) {
-                Ok(job_handle) => {
-                    if memory_limit.is_some() {
-                        tracing::info!(
-                            "Applied 2GB memory limit (LIMIT_WINDOWS_TO_1CU) to child process {pid}"
-                        );
+    {
+        let kill_on_close = !*DISABLE_PROCESS_GROUP;
+        let memory_limit =
+            (*windmill_common::worker::LIMIT_WINDOWS_TO_1CU).then_some(MEMORY_LIMIT_1CU);
+        if kill_on_close || memory_limit.is_some() {
+            if let Some(pid) = child.inner().id() {
+                match assign_job_object(pid, memory_limit, kill_on_close) {
+                    Ok(job_handle) => {
+                        if memory_limit.is_some() {
+                            tracing::info!(
+                                "Applied 2GB memory limit (LIMIT_WINDOWS_TO_1CU) to child process {pid}"
+                            );
+                        }
+                        return Ok(Box::new(WindowsJobChild {
+                            inner: child,
+                            _job_handle: job_handle,
+                        }));
                     }
-                    return Ok(Box::new(WindowsJobChild {
-                        inner: child,
-                        _job_handle: job_handle,
-                    }));
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to assign child process {pid} to job object: {e}");
+                    Err(e) => {
+                        tracing::warn!("Failed to assign child process {pid} to job object: {e}");
+                    }
                 }
             }
         }

--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -748,17 +748,20 @@ lazy_static! {
 const MEMORY_LIMIT_1CU: usize = 2 * 1024 * 1024 * 1024;
 
 /// Wrapper that holds a Windows Job Object handle alongside the child process.
-/// The job object enforces memory limits and is closed when the child is dropped.
+/// The job object is set to KILL_ON_JOB_CLOSE (and optionally a memory limit), so
+/// when the worker process dies the handle closes and the OS reaps the whole child
+/// tree — preventing orphans when the worker is force-killed (e.g. a second
+/// CTRL_BREAK_EVENT or Nomad's kill_timeout) before a job has drained.
 #[cfg(windows)]
-struct MemoryLimitedChild {
+struct WindowsJobChild {
     inner: Box<dyn TokioChildWrapper>,
     _job_handle: Win32JobHandle,
 }
 
 #[cfg(windows)]
-impl std::fmt::Debug for MemoryLimitedChild {
+impl std::fmt::Debug for WindowsJobChild {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MemoryLimitedChild").finish()
+        f.debug_struct("WindowsJobChild").finish()
     }
 }
 
@@ -781,7 +784,7 @@ impl Drop for Win32JobHandle {
 }
 
 #[cfg(windows)]
-impl process_wrap::tokio::TokioChildWrapper for MemoryLimitedChild {
+impl process_wrap::tokio::TokioChildWrapper for WindowsJobChild {
     fn inner(&self) -> &tokio::process::Child {
         self.inner.inner()
     }
@@ -789,7 +792,11 @@ impl process_wrap::tokio::TokioChildWrapper for MemoryLimitedChild {
         self.inner.inner_mut()
     }
     fn into_inner(self: Box<Self>) -> tokio::process::Child {
-        self.inner.into_inner()
+        // Leak the job handle: with KILL_ON_JOB_CLOSE, closing the last handle reaps
+        // the (still-running) child, so extracting the inner Child must not close it.
+        let WindowsJobChild { inner, _job_handle } = *self;
+        std::mem::forget(_job_handle);
+        inner.into_inner()
     }
     fn start_kill(&mut self) -> std::io::Result<()> {
         self.inner.start_kill()
@@ -805,9 +812,15 @@ impl process_wrap::tokio::TokioChildWrapper for MemoryLimitedChild {
     }
 }
 
-/// Create a Windows Job Object with a memory limit and assign the process to it.
+/// Create a Windows Job Object set to KILL_ON_JOB_CLOSE (so the child tree is reaped
+/// when the worker drops the handle / dies), optionally with a memory limit, and
+/// assign the process to it. Assigning post-spawn (rather than via process-wrap's
+/// suspend/resume JobObject wrap) keeps the dotnet-safe behavior that csharp relies on.
 #[cfg(windows)]
-fn apply_job_memory_limit(pid: u32, memory_limit: usize) -> Result<Win32JobHandle, std::io::Error> {
+fn assign_reaping_job_object(
+    pid: u32,
+    memory_limit: Option<usize>,
+) -> Result<Win32JobHandle, std::io::Error> {
     use windows::Win32::System::JobObjects::*;
     use windows::Win32::System::Threading::{OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE};
 
@@ -817,8 +830,11 @@ fn apply_job_memory_limit(pid: u32, memory_limit: usize) -> Result<Win32JobHandl
         })?;
 
         let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
-        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_JOB_MEMORY;
-        info.JobMemoryLimit = memory_limit;
+        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        if let Some(memory_limit) = memory_limit {
+            info.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_JOB_MEMORY;
+            info.JobMemoryLimit = memory_limit;
+        }
 
         SetInformationJobObject(
             job,
@@ -909,15 +925,19 @@ pub async fn start_child_process(
     use process_wrap::tokio::*;
     let mut cmd = TokioCommandWrap::from(cmd);
 
-    // On Windows, always put the child in its own console process group so a
-    // CTRL_BREAK_EVENT sent to the worker's group (e.g. by Nomad on scale-in) is not
-    // delivered to it. Otherwise the whole child tree dies instantly with
-    // STATUS_CONTROL_C_EXIT (0xC000013A) before the worker can drain running jobs.
-    // This is independent of the JobObject grouping below, which dotnet opts out of
-    // (disable_process_group) but still needs console-signal isolation. process-wrap
-    // requires CreationFlags to be wrapped before JobObject.
+    // On Windows, put the child in its own console process group so a CTRL_BREAK_EVENT
+    // sent to the worker's group (e.g. by Nomad on scale-in) is not delivered to it.
+    // Otherwise the whole child tree dies instantly with STATUS_CONTROL_C_EXIT
+    // (0xC000013A) before the worker can drain running jobs.
+    //
+    // This deliberately does NOT use process-wrap's JobObject wrap: its pre_spawn calls
+    // command.creation_flags(CREATE_SUSPENDED | get_wrap::<CreationFlags>()), but
+    // get_wrap returns None mid-spawn (process-wrap 8.2.1 takes the wrappers out of
+    // `self` before running pre_spawn), so it silently overwrites and drops
+    // CREATE_NEW_PROCESS_GROUP. Job-object grouping is done post-spawn below instead,
+    // which also matches the dotnet-safe assignment csharp already relies on.
     #[cfg(windows)]
-    {
+    if !*DISABLE_PROCESS_GROUP {
         use process_wrap::tokio::CreationFlags;
         use windows::Win32::System::Threading::CREATE_NEW_PROCESS_GROUP;
         cmd.wrap(CreationFlags(CREATE_NEW_PROCESS_GROUP));
@@ -930,31 +950,37 @@ pub async fn start_child_process(
 
             cmd.wrap(ProcessGroup::leader());
         }
-        #[cfg(windows)]
-        {
-            cmd.wrap(JobObject);
-        }
     }
 
     let child: Box<dyn TokioChildWrapper> = cmd
         .spawn()
         .map_err(|err| tentatively_improve_error(err.into(), executable))?;
 
+    // On Windows, assign the child to a KILL_ON_JOB_CLOSE job object (folding in the
+    // LIMIT_WINDOWS_TO_1CU memory cap when set). When the worker drops the handle or
+    // dies, the OS reaps the whole child tree, so jobs aren't orphaned if the worker is
+    // force-killed (second CTRL_BREAK_EVENT, or Nomad exceeding kill_timeout) before they
+    // drain. Assigning post-spawn does not touch the creation flags (so it composes with
+    // CREATE_NEW_PROCESS_GROUP above) and is the dotnet-safe path csharp already uses.
     #[cfg(windows)]
-    if *windmill_common::worker::LIMIT_WINDOWS_TO_1CU {
+    if !*DISABLE_PROCESS_GROUP {
         if let Some(pid) = child.inner().id() {
-            match apply_job_memory_limit(pid, MEMORY_LIMIT_1CU) {
+            let memory_limit =
+                (*windmill_common::worker::LIMIT_WINDOWS_TO_1CU).then_some(MEMORY_LIMIT_1CU);
+            match assign_reaping_job_object(pid, memory_limit) {
                 Ok(job_handle) => {
-                    tracing::info!(
-                        "Applied 2GB memory limit (LIMIT_WINDOWS_TO_1CU) to child process {pid}"
-                    );
-                    return Ok(Box::new(MemoryLimitedChild {
+                    if memory_limit.is_some() {
+                        tracing::info!(
+                            "Applied 2GB memory limit (LIMIT_WINDOWS_TO_1CU) to child process {pid}"
+                        );
+                    }
+                    return Ok(Box::new(WindowsJobChild {
                         inner: child,
                         _job_handle: job_handle,
                     }));
                 }
                 Err(e) => {
-                    tracing::warn!("Failed to apply memory limit to child process {pid}: {e}");
+                    tracing::warn!("Failed to assign child process {pid} to job object: {e}");
                 }
             }
         }

--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -812,6 +812,49 @@ impl process_wrap::tokio::TokioChildWrapper for WindowsJobChild {
     }
 }
 
+/// Resume all threads of a process created with CREATE_SUSPENDED. We create the child
+/// suspended so it can be assigned to its job object before running any code; otherwise
+/// a child that forks a helper at startup could create it before the assignment and
+/// leave it outside the job (escaping KILL_ON_JOB_CLOSE reaping / the memory cap).
+/// (Ported from process-wrap's resume_threads.)
+#[cfg(windows)]
+fn resume_process(pid: u32) -> Result<(), std::io::Error> {
+    use windows::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32,
+    };
+    use windows::Win32::System::Threading::{OpenThread, ResumeThread, THREAD_SUSPEND_RESUME};
+
+    unsafe {
+        let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("CreateToolhelp32Snapshot: {e}"),
+            )
+        })?;
+        let mut entry = THREADENTRY32 {
+            dwSize: std::mem::size_of::<THREADENTRY32>() as u32,
+            cntUsage: 0,
+            th32ThreadID: 0,
+            th32OwnerProcessID: 0,
+            tpBasePri: 0,
+            tpDeltaPri: 0,
+            dwFlags: 0,
+        };
+        let mut res = Thread32First(snapshot, &mut entry);
+        while res.is_ok() {
+            if entry.th32OwnerProcessID == pid {
+                if let Ok(thread) = OpenThread(THREAD_SUSPEND_RESUME, false, entry.th32ThreadID) {
+                    ResumeThread(thread);
+                    let _ = windows::Win32::Foundation::CloseHandle(thread);
+                }
+            }
+            res = Thread32Next(snapshot, &mut entry);
+        }
+        let _ = windows::Win32::Foundation::CloseHandle(snapshot);
+    }
+    Ok(())
+}
+
 /// Create a Windows Job Object and assign the process to it, optionally with
 /// KILL_ON_JOB_CLOSE (so the child tree is reaped when the worker drops the handle /
 /// dies) and/or a memory limit. Assigning post-spawn (rather than via process-wrap's
@@ -942,8 +985,12 @@ pub async fn start_child_process(
     #[cfg(windows)]
     if !*DISABLE_PROCESS_GROUP {
         use process_wrap::tokio::CreationFlags;
-        use windows::Win32::System::Threading::CREATE_NEW_PROCESS_GROUP;
-        cmd.wrap(CreationFlags(CREATE_NEW_PROCESS_GROUP));
+        use windows::Win32::System::Threading::{CREATE_NEW_PROCESS_GROUP, CREATE_SUSPENDED};
+        // Also create the child suspended so it can be placed in its job object (below)
+        // before it runs any code; otherwise a child that forks a helper at startup could
+        // create it before the assignment and leave it outside the job. Resumed right
+        // after the job assignment.
+        cmd.wrap(CreationFlags(CREATE_NEW_PROCESS_GROUP | CREATE_SUSPENDED));
     }
 
     if !*DISABLE_PROCESS_GROUP && !disable_process_group {
@@ -974,7 +1021,16 @@ pub async fn start_child_process(
             (*windmill_common::worker::LIMIT_WINDOWS_TO_1CU).then_some(MEMORY_LIMIT_1CU);
         if kill_on_close || memory_limit.is_some() {
             if let Some(pid) = child.inner().id() {
-                match assign_job_object(pid, memory_limit, kill_on_close) {
+                let assigned = assign_job_object(pid, memory_limit, kill_on_close);
+                // When kill_on_close, the child was created suspended (CREATE_SUSPENDED
+                // above) so it could be placed in the job before running. Resume it now —
+                // unconditionally of assign success, so a failed assign never leaves it hung.
+                if kill_on_close {
+                    if let Err(e) = resume_process(pid) {
+                        tracing::error!("Failed to resume child process {pid}: {e}");
+                    }
+                }
+                match assigned {
                     Ok(job_handle) => {
                         if memory_limit.is_some() {
                             tracing::info!(


### PR DESCRIPTION
## Summary

Follow-up to #9562. While building Windows test coverage for that fix, I found **#9562 as merged does not actually protect the non-csharp executors** — and fixed it properly here, also folding in job-tree reaping so children aren't orphaned when the worker is force-killed.

### What was broken

#9562 wrapped the command with `CreationFlags(CREATE_NEW_PROCESS_GROUP)` and then, for non-csharp executors, with process-wrap's `JobObject`. But **process-wrap 8.2.1 has a bug**: `TokioCommandWrap::spawn()` does `std::mem::take(&mut self.wrappers)` *before* running the `pre_spawn` hooks, so when `JobObject::pre_spawn` calls `core.get_wrap::<CreationFlags>()` it queries an **empty** map, gets `None`, and calls `command.creation_flags(CREATE_SUSPENDED)` — **overwriting `CREATE_NEW_PROCESS_GROUP`**. The child stays in the worker's console group and is still killed by the scale-in `CTRL_BREAK_EVENT` (`STATUS_CONTROL_C_EXIT` / `0xC000013A`).


> Note: this is unfixed as of the latest process-wrap (9.1.0) — the `mem::take` in `spawn_with` still makes `get_wrap::<CreationFlags>()` return `None` during `pre_spawn`, so a version bump does not help. The post-spawn approach here avoids the wrapper composition entirely.

Net: only csharp (which opts out of the `JobObject` wrap) was ever actually fixed. Python/Bun/Go/Bash/etc. still died on Nomad scale-in.

### The fix (unified Windows path)

On Windows, **don't use process-wrap's `JobObject` wrap at all**:
- Set `CREATE_NEW_PROCESS_GROUP` via the `CreationFlags` wrap **alone** — nothing left to clobber it, so isolation holds for every executor.
- Assign a **`KILL_ON_JOB_CLOSE` job object post-spawn** for all Windows children (folding in the `LIMIT_WINDOWS_TO_1CU` memory cap). Post-spawn `AssignProcessToJobObject` is the dotnet-safe pattern csharp already used for memory limits, and it doesn't touch creation flags so it composes with the process group. When the worker drops the handle or is force-killed, the OS reaps the whole child tree — no orphans if the worker dies (second `CTRL_BREAK_EVENT`, or Nomad exceeding `kill_timeout`) before a job drains.

`disable_process_group` is now unix-only in effect; the global `DISABLE_PROCESS_GROUP` remains the escape hatch.

## Changes

- `backend/windmill-worker/src/common.rs` (`start_child_process`): unified Windows handling per above.
- `apply_job_memory_limit` → `assign_reaping_job_object` (always sets `KILL_ON_JOB_CLOSE`, memory limit optional).
- The child is created **suspended** (`CREATE_NEW_PROCESS_GROUP | CREATE_SUSPENDED`), assigned to the job object, then resumed (`resume_process`, ported from process-wrap), so it is inside the job before running any code — an early-forked grandchild can't escape the reaping/memory cap.
- `MemoryLimitedChild` → `WindowsJobChild`; `into_inner` leaks the job handle so extracting a live child doesn't reap it.

## Validation

Because this is Windows-only and can't be exercised on a Linux dev host, I built a harness that replicates `start_child_process`'s exact wrapper composition and runs a scenario matrix on a real Windows Server (GitHub Actions `windows-latest`): **[rubenfiszel/win-ctrl-break-harness](https://github.com/rubenfiszel/win-ctrl-break-harness)**.

Matrix (all green):
- **N (negative control)** — an *unprotected* child must die on the break → proves the signal is genuinely delivered (rules out false-greens).
- **A** — reproduces the merged bug: with the `JobObject` wrap, the child still dies despite `CREATE_NEW_PROCESS_GROUP`.
- **I** — the fix: process-grouped child **survives** the break and completes.
- **J / K** — the fix reaps the whole tree (incl. grandchild) on hard-kill, with and without the 1CU memory limit.
- B–H cover csharp, normal completion, taskkill/cancel, and the original ticket repro.

A full windmill-on-Windows build was deemed unnecessary: the harness builds the identical wrapper composition, so it exercises the real OS semantics.

## Test plan

- [x] Harness matrix green on `windows-latest` incl. negative control (CI in the harness repo)
- [ ] Optional: confirm on a Windows worker that Python/Bun/Go jobs now survive a scale-in `CTRL_BREAK_EVENT` and that no child processes are orphaned after a force-kill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows child process handling by isolating children from CTRL_BREAK_EVENT and reaping their trees if the worker dies. We stop using `process-wrap`’s JobObject, create children suspended, assign a `KILL_ON_JOB_CLOSE` job, then resume; the 1CU memory cap is independent of the escape hatch.

- **Bug Fixes**
  - Avoid `process-wrap` 8.2.1 bug that clobbered `CREATE_NEW_PROCESS_GROUP`; all executors survive scale-in breaks.
  - Close the post-spawn race: start with `CREATE_SUSPENDED`, assign the job, then resume; the job reaps the full tree on worker death. Process-group and kill-on-close are gated by `DISABLE_PROCESS_GROUP`, while `LIMIT_WINDOWS_TO_1CU` is applied independently.

- **Refactors**
  - Unified Windows path in `start_child_process` without the `process-wrap` `JobObject`.
  - Renamed `apply_job_memory_limit` → `assign_job_object` and `MemoryLimitedChild` → `WindowsJobChild`; `into_inner` leaks the job handle to avoid killing a live child. Added `Win32_System_Diagnostics_ToolHelp` to `windows` for thread resume.

<sup>Written for commit 71e58a72cd8e454694b43833530f314251620a95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Behavioral note

`KILL_ON_JOB_CLOSE` reaps a job's leftover descendants when its direct child completes (the wrapper drops) — cleaner than `main`, but more aggressive than Linux, where a backgrounded grandchild can outlive its job. Intended for the no-orphans goal; flag if Linux parity is preferred.
