### PR TITLE
fix(typescript-client): add npm support metadata

### DIFF
--- a/typescript-client/package.json
+++ b/typescript-client/package.json
@@ -4,6 +4,15 @@
   "version": "1.723.0",
   "author": "Ruben Fiszel",
   "license": "Apache 2.0",
+  "homepage": "https://github.com/windmill-labs/windmill/tree/main/typescript-client#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/windmill-labs/windmill.git",
+    "directory": "typescript-client"
+  },
+  "bugs": {
+    "url": "https://github.com/windmill-labs/windmill/issues"
+  },
   "sideEffects": false,
   "devDependencies": {
     "@types/node": "^20.17.16",


### PR DESCRIPTION
This adds the missing npm support metadata for the published `windmill-client` package.

It points the package homepage to the package README, keeps the repository link scoped to the monorepo package directory, and adds the GitHub issues URL.

Checks run:
- `node -e "const p=require('./typescript-client/package.json'); if(p.homepage!=='https://github.com/windmill-labs/windmill/tree/main/typescript-client#readme'||p.repository?.url!=='git+https://github.com/windmill-labs/windmill.git'||p.repository?.directory!=='typescript-client'||p.bugs?.url!=='https://github.com/windmill-labs/windmill/issues') process.exit(1); console.log(JSON.stringify({homepage:p.homepage,repository:p.repository,bugs:p.bugs}, null, 2))"`
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`
