### PR TITLE
fix(backend): dedup folder labels to prevent each_key_duplicate crash

### DIFF
--- a/backend/migrations/20260614075900_dedup_folder_labels.down.sql
+++ b/backend/migrations/20260614075900_dedup_folder_labels.down.sql
@@ -1,0 +1,6 @@
+-- Restore the original passthrough definition (the one-time data cleanup is not reverted).
+CREATE OR REPLACE FUNCTION folder_labels(w_id text, item_path text) RETURNS text[]
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+    SELECT labels FROM folder
+    WHERE workspace_id = w_id AND item_path LIKE 'f/%' AND name = split_part(item_path, '/', 2)
+$$;

--- a/backend/migrations/20260614075900_dedup_folder_labels.up.sql
+++ b/backend/migrations/20260614075900_dedup_folder_labels.up.sql
@@ -1,0 +1,33 @@
+-- Folder labels are exposed verbatim as `inherited_labels` (via folder_labels) and
+-- rendered in keyed `{#each}` blocks in the UI, which throw `each_key_duplicate` on a
+-- repeated key. The write paths now dedup, but make the read resilient regardless of
+-- how a row was populated, and clean up any duplicates already persisted.
+
+-- Dedup while preserving first-seen order.
+CREATE OR REPLACE FUNCTION folder_labels(w_id text, item_path text) RETURNS text[]
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+    SELECT (
+        SELECT array_agg(l ORDER BY first_ord)
+        FROM (
+            SELECT u.l, min(u.ord) AS first_ord
+            FROM unnest(f.labels) WITH ORDINALITY AS u(l, ord)
+            GROUP BY u.l
+        ) deduped
+    )
+    FROM folder f
+    WHERE f.workspace_id = w_id AND item_path LIKE 'f/%' AND f.name = split_part(item_path, '/', 2)
+$$;
+
+-- One-time cleanup of rows that already contain duplicate labels, so direct reads of
+-- folder.labels (folder list, editor) are also safe.
+UPDATE folder
+SET labels = (
+    SELECT array_agg(l ORDER BY first_ord)
+    FROM (
+        SELECT u.l, min(u.ord) AS first_ord
+        FROM unnest(labels) WITH ORDINALITY AS u(l, ord)
+        GROUP BY u.l
+    ) deduped
+)
+WHERE labels IS NOT NULL
+  AND cardinality(labels) <> (SELECT count(DISTINCT x) FROM unnest(labels) AS x);

--- a/backend/windmill-api-groups/src/folders.rs
+++ b/backend/windmill-api-groups/src/folders.rs
@@ -86,6 +86,14 @@ pub struct UpdateFolder {
     pub labels: Option<Vec<String>>,
 }
 
+// Folder labels are surfaced verbatim as `inherited_labels` and rendered in keyed
+// `{#each}` blocks; a repeated label is a duplicate key that crashes the list views.
+// The UI dedups on entry but API/CLI/git-sync writes do not, so normalize on write.
+fn dedup_labels(labels: &mut Vec<String>) {
+    let mut seen = std::collections::HashSet::new();
+    labels.retain(|l| seen.insert(l.clone()));
+}
+
 #[derive(Deserialize)]
 pub struct Owner {
     pub owner: String,
@@ -226,8 +234,11 @@ async fn create_folder(
     Extension(webhook): Extension<WebhookShared>,
     Extension(cache): Extension<Arc<AuthCache>>,
     Path(w_id): Path<String>,
-    Json(ng): Json<NewFolder>,
+    Json(mut ng): Json<NewFolder>,
 ) -> Result<String> {
+    if let Some(labels) = ng.labels.as_mut() {
+        dedup_labels(labels);
+    }
     if let RuleCheckResult::Blocked(msg) = check_deploy_rules(
         &w_id,
         AuditAuthorable::username(&authed),
@@ -471,7 +482,8 @@ async fn update_folder(
         );
     }
 
-    if let Some(labels) = ng.labels.as_ref() {
+    if let Some(labels) = ng.labels.as_mut() {
+        dedup_labels(labels);
         if labels.is_empty() {
             // normalize cleared labels to NULL so the field stays out of API/tarball output
             sqlb.set("labels", "NULL");


### PR DESCRIPTION
## Problem

Folder labels (added in `20260610151334_folder_labels`) are exposed verbatim as `inherited_labels` via the `folder_labels()` SQL function, and rendered in keyed `{#each ... (label)}` blocks across the home/list views (`InheritedLabels.svelte`, `LabelsInput.svelte`, `ItemsList.svelte`). A **repeated label** is a duplicate key, which makes Svelte throw [`each_key_duplicate`](https://svelte.dev/e/each_key_duplicate) and white-screen the page.

The `LabelsInput` UI dedups labels on entry, but **non-UI write paths do not**: a direct API call, `wmill` CLI folder push, or git-sync applying a `folder.yaml` with `labels: [foo, foo]` persists duplicates verbatim (`create_folder` inserted as-is; `update_folder` rebuilt the array literal element-by-element).

This is the same failure class as the home tree-view key collision fixed in #9561, but data-driven rather than name-collision-driven.

## Fix

- **Write-side**: `create_folder` and `update_folder` now dedup labels (order-preserving) before persisting — duplicates can no longer be stored.
- **Read-side migration**: `folder_labels()` dedups on read (first-seen order preserved), so inherited labels are safe regardless of how a row was populated.
- **One-time cleanup**: the migration dedups any already-persisted duplicate label arrays, so direct `folder.labels` reads (folder list, editor) are also safe. Only rows that actually contain duplicates are rewritten.

## Validation

- `cargo check -p windmill-api-groups` passes.
- Migration up/down applied against a local DB inside a rolled-back transaction:
  - read-side: `folder_labels` on `{b,a,b,c,a}` returns `{b,a,c}`; no folder match returns `NULL`.
  - cleanup: pre-existing `{b,a,b,c,a}` → `{b,a,c}`, clean `{x,y}` untouched, `NULL` untouched.
- No `.sqlx` regen needed — `folder_labels()` is invoked via `sql_builder` strings, not compile-checked `query!` macros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicate folder labels to prevent Svelte `each_key_duplicate` crashes in list views. Write paths and `folder_labels()` now avoid duplicates, and existing duplicate arrays are cleaned up.

- **Bug Fixes**
  - Dedup labels (order-preserving) in `create_folder` and `update_folder` so duplicates can’t be stored.
  - `folder_labels()` now dedups on read to keep `inherited_labels` safe.

- **Migration**
  - One-time SQL cleanup to normalize existing duplicate `folder.labels`; only updates rows with duplicates.
  - Down migration restores the original passthrough `folder_labels()` (cleanup is not reverted).

<sup>Written for commit 5be91bb4d3f655610a1cbac514d9d60c0e3cb7f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

