### PR TITLE
fix(folders): allow hyphens in folder names

### DIFF
--- a/backend/windmill-api-groups/src/folders.rs
+++ b/backend/windmill-api-groups/src/folders.rs
@@ -211,7 +211,7 @@ async fn check_name_conflict<'c>(
 }
 
 lazy_static! {
-    static ref VALID_FOLDER_NAME: Regex = Regex::new(r#"^[a-zA-Z_0-9]+$"#).unwrap();
+    static ref VALID_FOLDER_NAME: Regex = Regex::new(r#"^[a-zA-Z_0-9-]+$"#).unwrap();
 }
 
 async fn create_folder(
@@ -240,7 +240,7 @@ async fn create_folder(
 
     if !VALID_FOLDER_NAME.is_match(&ng.name) {
         return Err(windmill_common::error::Error::BadRequest(format!(
-            "Folder name can only contain alphanumeric characters, underscores"
+            "Folder name can only contain alphanumeric characters, underscores, and hyphens"
         )));
     }
     check_name_conflict(&mut tx, &w_id, &ng.name).await?;
@@ -942,4 +942,23 @@ pub async fn log_folder_permission_change<'c, E: sqlx::Executor<'c, Database = P
     .execute(db)
     .await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn folder_name_allows_hyphens() {
+        // #8474: hyphens are valid in folder names, consistent with owner/path
+        // validation (which already permits them) and with folders created via
+        // the CLI / by deploying to an `f/<folder>/...` path.
+        assert!(VALID_FOLDER_NAME.is_match("folder-name"));
+        assert!(VALID_FOLDER_NAME.is_match("foo_bar"));
+        assert!(VALID_FOLDER_NAME.is_match("Foo123"));
+        // Disallowed characters are still rejected.
+        assert!(!VALID_FOLDER_NAME.is_match("foo/bar"));
+        assert!(!VALID_FOLDER_NAME.is_match("foo bar"));
+        assert!(!VALID_FOLDER_NAME.is_match(""));
+    }
 }

--- a/frontend/src/lib/components/FolderPicker.svelte
+++ b/frontend/src/lib/components/FolderPicker.svelte
@@ -11,7 +11,7 @@
 	import { tick } from 'svelte'
 	import { sendUserToast } from '$lib/toast'
 
-	const VALID_FOLDER_NAME = /^[a-zA-Z_0-9]+$/
+	const VALID_FOLDER_NAME = /^[a-zA-Z_0-9-]+$/
 
 	let folders: { name: string; write: boolean }[] = $state([])
 	let filterText: string = $state('')
@@ -125,7 +125,7 @@
 		!newFolderName
 			? ''
 			: !VALID_FOLDER_NAME.test(newFolderName)
-				? 'Folder name can only contain alphanumeric characters and underscores'
+				? 'Folder name can only contain alphanumeric characters, underscores, and hyphens'
 				: folders.some((f) => f.name === newFolderName)
 					? 'A folder with this name already exists'
 					: ''


### PR DESCRIPTION
## Summary

The "create folder" UI and API reject hyphens in folder names, even though hyphens are valid in paths elsewhere: owner/path validation already permits them (`validate_owner`, `Path.svelte`), and folders with hyphens can be created via the CLI or by deploying to an `f/<folder>/...` path. This inconsistency blocks the common `folder-name` convention (e.g. relative imports like `../folder-name/logic.ts`). (#8474)

## Changes

- `windmill-api-groups/src/folders.rs`: allow `-` in `VALID_FOLDER_NAME` (`^[a-zA-Z_0-9-]+$`), update the error message, and add a regression test.
- `FolderPicker.svelte`: mirror the regex + message in the create-folder form.

The regex is kept as permissive as the existing `validate_owner` / `Path.svelte` validators (which already allow hyphens, including leading/trailing) rather than adding a stricter rule, to avoid reintroducing an inconsistency. Folder names flow into parameterized SQL and paths split only on `/`, so hyphens are inert.

## Test plan

- [ ] `cargo test -p windmill-api-groups folder_name_allows_hyphens`
- [ ] In the UI, create a folder named `my-folder`; confirm it is accepted and created.

Fixes #8474


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow hyphens in folder names across the API and create-folder UI to match existing path/owner validation and CLI behavior. This resolves the inconsistency and enables common `folder-name` conventions (Fixes #8474).

- **Bug Fixes**
  - Backend: relax `VALID_FOLDER_NAME` to `^[a-zA-Z_0-9-]+$`, update error text, and add a regression test.
  - Frontend: mirror the regex in `FolderPicker.svelte` and update the validation message.
  - Result: creating folders like `my-folder` now works in UI and API.

<sup>Written for commit a21f96641c4dd4bb8ed75f21f90bb121e8621376. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

