### PR TITLE
fix(security): add path traversal validation to log_file_index reads and import

### DIFF
--- a/backend/windmill-api-jobs/src/jobs_export.rs
+++ b/backend/windmill-api-jobs/src/jobs_export.rs
@@ -390,6 +390,12 @@ pub async fn import_completed_jobs(
         .execute(&mut *tx)
         .await?;
 
+        if let Some(file_index) = &job.log_file_index {
+            for file_p in file_index {
+                windmill_common::jobs::validate_log_file_index_path(file_p)?;
+            }
+        }
+
         if let Some(logs) = &job.logs {
             sqlx::query!(
                 r#"

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -1912,10 +1912,7 @@ async fn get_logs_from_disk(
     if log_offset > 0 {
         if let Some(file_index) = log_file_index.clone() {
             for file_p in &file_index {
-                if !tokio::fs::metadata(format!("{}/{file_p}", *WINDMILL_DIR))
-                    .await
-                    .is_ok()
-                {
+                if !windmill_common::jobs::is_valid_log_file_on_disk(file_p).await {
                     return None;
                 }
             }

--- a/backend/windmill-common/src/jobs.rs
+++ b/backend/windmill-common/src/jobs.rs
@@ -283,6 +283,51 @@ pub fn format_completed_job_result(mut cj: CompletedJob) -> CompletedJob {
     cj
 }
 
+/// Validate that a `log_file_index` entry is a well-formed log file path and not
+/// an attempt at path traversal. Legitimate entries are produced by the worker as
+/// `logs/{UUID}/{timestamp}_{size}.txt` (see windmill-worker `job_logger_ee.rs`),
+/// but the value is attacker-controllable via the job import endpoint, so it must
+/// be validated before being used to open a file or fetch from object storage.
+pub fn validate_log_file_index_path(file_p: &str) -> error::Result<()> {
+    if file_p.contains("..") {
+        return Err(Error::BadRequest(format!(
+            "Invalid log file path: {file_p}"
+        )));
+    }
+    let parts: Vec<&str> = file_p.split('/').collect();
+    if parts.len() != 3 || parts[0] != "logs" {
+        return Err(Error::BadRequest(format!(
+            "Invalid log file path (expected logs/<uuid>/<file>.txt): {file_p}"
+        )));
+    }
+    uuid::Uuid::parse_str(parts[1]).map_err(|_| {
+        Error::BadRequest(format!(
+            "Invalid log file path: second component must be a valid UUID: {file_p}"
+        ))
+    })?;
+    if !parts[2].ends_with(".txt") {
+        return Err(Error::BadRequest(format!(
+            "Invalid log file path: file must end with .txt: {file_p}"
+        )));
+    }
+    Ok(())
+}
+
+/// Validate a disk-backed log file path and refuse to read through a symlink
+/// (defense in depth, matching `get_log_file`). Returns `true` only if the path
+/// is well-formed and points at a regular existing file; fails closed otherwise.
+pub async fn is_valid_log_file_on_disk(file_p: &str) -> bool {
+    if let Err(e) = validate_log_file_index_path(file_p) {
+        tracing::warn!("Rejected log_file_index path: {e:#}");
+        return false;
+    }
+    let local_file = format!("{}/{file_p}", *WINDMILL_DIR);
+    match tokio::fs::symlink_metadata(&local_file).await {
+        Ok(meta) => !meta.file_type().is_symlink(),
+        Err(_) => false,
+    }
+}
+
 pub async fn get_logs_from_disk(
     log_offset: i32,
     logs: &str,
@@ -291,10 +336,7 @@ pub async fn get_logs_from_disk(
     if log_offset > 0 {
         if let Some(file_index) = log_file_index.clone() {
             for file_p in &file_index {
-                if !tokio::fs::metadata(format!("{}/{file_p}", *WINDMILL_DIR))
-                    .await
-                    .is_ok()
-                {
+                if !is_valid_log_file_on_disk(file_p).await {
                     return None;
                 }
             }
@@ -439,3 +481,47 @@ pub struct WorkerInternalServerInlineUtils {
 // The server cannot call the worker functions directly because they are independent crates
 pub static WORKER_INTERNAL_SERVER_INLINE_UTILS: OnceCell<WorkerInternalServerInlineUtils> =
     OnceCell::new();
+
+#[cfg(test)]
+mod tests {
+    use super::validate_log_file_index_path;
+
+    #[test]
+    fn accepts_well_formed_log_path() {
+        assert!(validate_log_file_index_path(
+            "logs/00000000-0000-0000-0000-000000000000/1700000000000_42.txt"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn rejects_path_traversal() {
+        for p in [
+            "logs/../../../../etc/passwd",
+            "../etc/passwd",
+            "logs/00000000-0000-0000-0000-000000000000/../../../etc/passwd.txt",
+        ] {
+            assert!(
+                validate_log_file_index_path(p).is_err(),
+                "{p} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_paths() {
+        for p in [
+            "/etc/passwd",                                           // absolute, wrong prefix
+            "logs/not-a-uuid/1700000000000_42.txt",                  // invalid uuid
+            "logs/00000000-0000-0000-0000-000000000000/secret.json", // not .txt
+            "logs/00000000-0000-0000-0000-000000000000",             // too few components
+            "logs/00000000-0000-0000-0000-000000000000/a/b.txt",     // too many components
+            "tmp/00000000-0000-0000-0000-000000000000/1700000000000_42.txt", // wrong root
+        ] {
+            assert!(
+                validate_log_file_index_path(p).is_err(),
+                "{p} should be rejected"
+            );
+        }
+    }
+}

--- a/backend/windmill-object-store/src/lib.rs
+++ b/backend/windmill-object-store/src/lib.rs
@@ -1300,6 +1300,10 @@ pub async fn get_logs_from_store(
                 let logs = logs.to_string();
                 let stream = async_stream::stream! {
                     for file_p in file_index {
+                        if let Err(e) = windmill_common::jobs::validate_log_file_index_path(&file_p) {
+                            tracing::warn!("Rejected log_file_index path from object store: {e:#}");
+                            continue;
+                        }
                         let file = os.get(&object_store::path::Path::from(file_p.clone())).await;
                         match file {
                             Ok(file) => {


### PR DESCRIPTION
## Problem

`get_logs_from_disk()` (in both `windmill-api/src/jobs.rs` and `windmill-common/src/jobs.rs`) opened files from the `log_file_index` column as `{WINDMILL_DIR}/{file_p}` with **no path validation**. Likewise `get_logs_from_store()` in `windmill-object-store/src/lib.rs` passed unsanitized paths to the object store.

`import_completed_jobs()` in `windmill-api-jobs/src/jobs_export.rs` lets a **workspace admin** insert arbitrary strings into the `log_file_index` column. Combined, this allowed a workspace admin to read arbitrary files via path traversal (e.g. `../../../../etc/passwd`).

The `get_log_file()` handler was already hardened (`..` checks, UUID validation, symlink defense), but these sibling read paths were missed.

Legitimate `log_file_index` entries follow `logs/{UUID}/{timestamp}_{size}.txt` (set in `windmill-worker/src/job_logger_ee.rs`).

## Fix

- **New shared helpers in `windmill-common/src/jobs.rs`:**
  - `validate_log_file_index_path()` — rejects `..`, requires exactly 3 components, `logs/` prefix, a valid UUID, and a `.txt` suffix (mirrors `get_log_file`).
  - `is_valid_log_file_on_disk()` — validates the format and refuses to read through a symlink (`symlink_metadata`), failing closed.
- **Read sites** now validate before opening / fetching:
  - `windmill-common` `get_logs_from_disk` → `is_valid_log_file_on_disk`
  - `windmill-api` `get_logs_from_disk` → `is_valid_log_file_on_disk`
  - `windmill-object-store` `get_logs_from_store` → `validate_log_file_index_path` (skips bad entries)
- **Write site:** `import_completed_jobs` validates every `log_file_index` entry and returns `BadRequest` if any is malformed, before the INSERT.

The EE indexer (`windmill-indexer/completed_runs_ee.rs`) routes through these same shared functions, so it is covered automatically with no EE-side changes.

## Validation

- `cargo check` clean on `windmill-common`, `windmill-object-store`, `windmill-api-jobs`, `windmill-api`.
- New unit tests in `windmill-common` (`jobs::tests`) cover well-formed paths, traversal attempts, and malformed inputs — all pass.
- Backend (cargo-watch) rebuilt and health-checks green.

## Notes

- At read time, a malformed/tampered entry **fails closed** (treated as not-found) rather than erroring the response; at import (write) time it is rejected outright with `BadRequest`.

Fixes WIN-2040

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add strict validation for `log_file_index` paths to block path traversal and arbitrary file reads across disk and object storage. Implements shared checks and applies them to read and import paths to satisfy WIN-2040.

- **Bug Fixes**
  - Added `validate_log_file_index_path` and `is_valid_log_file_on_disk` in `windmill-common` to enforce `logs/<uuid>/<file>.txt`, deny `..`, and block symlinks.
  - Applied validation in `get_logs_from_disk` (`windmill-common`, `windmill-api`) and `get_logs_from_store` (`windmill-object-store`), skipping bad entries.
  - Validated on write in `import_completed_jobs` (`windmill-api-jobs`), rejecting malformed paths with `BadRequest`; reads fail closed.

<sup>Written for commit 387cd122b856f29affeb34d3690cabae0d7e5284. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

