### PR TITLE
fix: prevent path traversal via log_file_index in log endpoints

### DIFF
--- a/backend/windmill-api-jobs/src/jobs_export.rs
+++ b/backend/windmill-api-jobs/src/jobs_export.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 use windmill_common::{
     db::UserDB,
     error,
-    jobs::{JobKind, JobStatus, JobTriggerKind},
+    jobs::{is_safe_log_file_path, JobKind, JobStatus, JobTriggerKind},
     scripts::ScriptLang,
     utils::{paginate, paginate_without_limits, require_admin, Pagination},
 };
@@ -327,6 +327,20 @@ pub async fn import_completed_jobs(
     Json(jobs): Json<Vec<ExportableCompletedJob>>,
 ) -> error::Result<String> {
     require_admin(authed.is_admin, &authed.username)?;
+
+    // log_file_index is read back by the log endpoints as paths under the windmill
+    // log directory; an attacker-supplied traversal here would become an arbitrary
+    // file read. Reject anything that could escape the log directory at ingestion.
+    for job in &jobs {
+        if let Some(file_index) = &job.log_file_index {
+            if file_index.iter().any(|p| !is_safe_log_file_path(p)) {
+                return Err(error::Error::BadRequest(format!(
+                    "Invalid log_file_index for job {}: entries must be relative paths without '..'",
+                    job.id
+                )));
+            }
+        }
+    }
 
     let mut tx = user_db.begin(&authed).await?;
 

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -34,8 +34,8 @@ use windmill_common::db::UserDbWithAuthed;
 use windmill_common::error::JsonResult;
 use windmill_common::flow_status::{JobResult, RestartedFrom};
 use windmill_common::jobs::{
-    format_completed_job_result, format_result, is_valid_entrypoint_name, DynamicInput,
-    ENTRYPOINT_OVERRIDE,
+    format_completed_job_result, format_result, is_safe_log_file_path, is_valid_entrypoint_name,
+    DynamicInput, ENTRYPOINT_OVERRIDE,
 };
 #[cfg(feature = "run_inline")]
 use windmill_common::jobs::{
@@ -1912,11 +1912,16 @@ async fn get_logs_from_disk(
     if log_offset > 0 {
         if let Some(file_index) = log_file_index.clone() {
             for file_p in &file_index {
-                if !tokio::fs::metadata(format!("{}/{file_p}", *WINDMILL_DIR))
-                    .await
-                    .is_ok()
-                {
+                if !is_safe_log_file_path(file_p) {
                     return None;
+                }
+                let local_file = format!("{}/{file_p}", *WINDMILL_DIR);
+                // Defense in depth: refuse to read through a symlink so a planted
+                // symlink under the log directory cannot exfiltrate arbitrary files.
+                match tokio::fs::symlink_metadata(&local_file).await {
+                    Ok(meta) if meta.file_type().is_symlink() => return None,
+                    Ok(_) => {}
+                    Err(_) => return None,
                 }
             }
 

--- a/backend/windmill-common/src/jobs.rs
+++ b/backend/windmill-common/src/jobs.rs
@@ -283,6 +283,19 @@ pub fn format_completed_job_result(mut cj: CompletedJob) -> CompletedJob {
     cj
 }
 
+/// `log_file_index` is normally written by the worker as job-id-scoped relative
+/// paths under the windmill log directory. Any code path that lets a request
+/// control this value (e.g. job import) must reject entries that could escape
+/// that directory, otherwise the log-reading endpoints become an arbitrary file
+/// read primitive. Rejects path traversal (`..`) and absolute paths; on-disk
+/// readers additionally refuse symlinks (see `get_logs_from_disk`).
+pub fn is_safe_log_file_path(file_p: &str) -> bool {
+    !file_p.is_empty()
+        && !file_p.starts_with('/')
+        && !file_p.starts_with('\\')
+        && !file_p.split(['/', '\\']).any(|c| c == "..")
+}
+
 pub async fn get_logs_from_disk(
     log_offset: i32,
     logs: &str,
@@ -291,11 +304,16 @@ pub async fn get_logs_from_disk(
     if log_offset > 0 {
         if let Some(file_index) = log_file_index.clone() {
             for file_p in &file_index {
-                if !tokio::fs::metadata(format!("{}/{file_p}", *WINDMILL_DIR))
-                    .await
-                    .is_ok()
-                {
+                if !is_safe_log_file_path(file_p) {
                     return None;
+                }
+                let local_file = format!("{}/{file_p}", *WINDMILL_DIR);
+                // Defense in depth: refuse to read through a symlink so a planted
+                // symlink under the log directory cannot exfiltrate arbitrary files.
+                match tokio::fs::symlink_metadata(&local_file).await {
+                    Ok(meta) if meta.file_type().is_symlink() => return None,
+                    Ok(_) => {}
+                    Err(_) => return None,
                 }
             }
 
@@ -439,3 +457,30 @@ pub struct WorkerInternalServerInlineUtils {
 // The server cannot call the worker functions directly because they are independent crates
 pub static WORKER_INTERNAL_SERVER_INLINE_UTILS: OnceCell<WorkerInternalServerInlineUtils> =
     OnceCell::new();
+
+#[cfg(test)]
+mod tests {
+    use super::is_safe_log_file_path;
+
+    #[test]
+    fn safe_log_file_paths_are_accepted() {
+        // Legit worker-written entries are job-id-scoped relative paths.
+        assert!(is_safe_log_file_path(
+            "0190d3e2-0000-7000-8000-000000000000/0.txt"
+        ));
+        assert!(is_safe_log_file_path("logs/abc/chunk1.log"));
+        assert!(is_safe_log_file_path("file..with..dots.txt"));
+    }
+
+    #[test]
+    fn traversal_and_absolute_paths_are_rejected() {
+        assert!(!is_safe_log_file_path(""));
+        assert!(!is_safe_log_file_path("../../../../etc/passwd"));
+        assert!(!is_safe_log_file_path("a/../../etc/passwd"));
+        assert!(!is_safe_log_file_path(".."));
+        assert!(!is_safe_log_file_path("/etc/passwd"));
+        assert!(!is_safe_log_file_path("/proc/self/environ"));
+        assert!(!is_safe_log_file_path("\\windows\\path"));
+        assert!(!is_safe_log_file_path("a\\..\\..\\b"));
+    }
+}

--- a/backend/windmill-object-store/src/lib.rs
+++ b/backend/windmill-object-store/src/lib.rs
@@ -52,6 +52,7 @@ use tokio::task;
 #[cfg(feature = "parquet")]
 use windmill_common::error::to_anyhow;
 #[cfg(feature = "parquet")]
+use windmill_common::jobs::is_safe_log_file_path;
 use windmill_common::utils::rd_string;
 #[cfg(all(feature = "parquet", feature = "private"))]
 pub mod job_s3_helpers_ee;
@@ -1296,6 +1297,9 @@ pub async fn get_logs_from_store(
 ) -> Option<impl futures::Stream<Item = Result<bytes::Bytes, object_store::Error>>> {
     if log_offset > 0 {
         if let Some(file_index) = log_file_index.clone() {
+            if file_index.iter().any(|p| !is_safe_log_file_path(p)) {
+                return None;
+            }
             if let Some(os) = get_object_store().await {
                 let logs = logs.to_string();
                 let stream = async_stream::stream! {


### PR DESCRIPTION
## Summary

Hardens the job-log reading endpoints against a path-traversal / arbitrary-file-read primitive. `log_file_index` is normally written by the worker as job-id-scoped relative paths under the windmill log directory, but it was passed unsanitized to filesystem/object-store sinks that build paths under `WINDMILL_DIR`. A workspace admin could set arbitrary `log_file_index` values via the job-import endpoint (`import_completed_jobs`, gated only by `require_admin`), then read them back through `GET /jobs/get_logs/{id}`.

On self-hosted instances **without** an object store configured (the default CE / docker-compose), this allowed reading arbitrary files the server process can access (e.g. `/etc/passwd`, and via `/proc/self/environ` the `DATABASE_URL`). This is an incomplete-fix follow-up to the `get_log_file` hardening (CVE-2026-29059): the structurally-identical sibling sinks `get_logs_from_disk` / `get_logs_from_store` never received the same guards.

This was reproduced on a self-hosted CE build. It does **not** reproduce on object-store-backed deployments (e.g. app.windmill.dev / EE+S3): there the store path runs first and S3 is a flat keyspace with no filesystem traversal — verified empirically. The defect is still fixed here for self-hosters and as defense-in-depth for the store path.

## Changes

- Add `is_safe_log_file_path` in `windmill-common` — rejects empty strings, absolute paths (leading `/` or `\`), and any `..` path component.
- Apply it at the attacker-controlled ingress (`import_completed_jobs`): reject the whole import with `400 BadRequest` if any `log_file_index` entry is unsafe.
- Apply it at all three read sinks: `get_logs_from_disk` (windmill-api and windmill-common copies) and `get_logs_from_store` (windmill-object-store, parquet-gated).
- Add a symlink-refusal check (`symlink_metadata`) to both disk sinks, mirroring `get_log_file`, so a planted symlink under the log dir can't exfiltrate files.
- Unit tests for the validator (accept set: UUID-scoped/nested/dotted paths; reject set: traversal, absolute, `/proc`, backslash variants).

## Test plan

- [x] `cargo check` on all four touched crates (core + `enterprise,parquet` for object-store)
- [x] `cargo test -p windmill-common` — new validator tests pass
- [ ] As a workspace admin, `POST /jobs/completed/import` with `log_file_index: ["../../../../etc/passwd"]` returns `400` ("entries must be relative paths") instead of ingesting
- [ ] A normal completed job whose logs were offloaded to disk still streams full logs via the log endpoints (no regression for legitimate UUID-scoped paths)
- [ ] EE/parquet build: object-store log retrieval still works for legitimate keys

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents path traversal via `log_file_index` in log endpoints to block arbitrary file reads. Validates input on import and guards all log readers, with symlink refusal on disk.

- **Bug Fixes**
  - Added `is_safe_log_file_path` in `windmill-common` to reject empty, absolute, or `..` paths.
  - Validated `log_file_index` in `import_completed_jobs`; bad imports now return 400.
  - Applied checks in `get_logs_from_disk` (`windmill-api`, `windmill-common`) and `get_logs_from_store` (`windmill-object-store`).
  - Refused symlinks in disk readers via `symlink_metadata`.
  - Added unit tests for the validator.

<sup>Written for commit dc2b18f91bcca3a861d5ae9a8602b1135041c2bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

