### PR TITLE
fix: require pinned sha for inline raw_code in viewer app run mode

### DIFF
--- a/backend/tests/app_preview_auth.rs
+++ b/backend/tests/app_preview_auth.rs
@@ -259,13 +259,12 @@ async fn test_app_preview_authorization(db: Pool<Postgres>) -> anyhow::Result<()
         "rejection must be the jobs:run scope gate, got: {body}"
     );
 
-    // 9. RUN-MODE REGRESSION (CVE-2026-22683 residual): against a *deployed*
-    //    Viewer-mode app, run mode (no `force_viewer_static_fields`) must NOT let
-    //    a caller substitute arbitrary inline `raw_code`. Pre-fix the
-    //    `rawscript/<sha>` lookup fell back to the Viewer default triggerable, so
-    //    the operator's code was enqueued and ran as them (200 + job UUID, the
-    //    exact preview class blocked in step 1). Post-fix the unpinned sha is
-    //    rejected by the policy.
+    // 9. RUN-MODE REGRESSION (CVE-2026-22683 residual): in run mode (no
+    //    `force_viewer_static_fields`) against a deployed Viewer-mode app,
+    //    caller-supplied inline `raw_code` whose `rawscript/<sha>` is not pinned
+    //    in the app's `triggerables_v2` must be rejected by the policy — it must
+    //    not resolve via the Viewer default triggerable and run as the caller
+    //    (the same preview-class execution an operator is denied in step 1).
     let run_mode_raw_code = json!({
         "args": {},
         "component": "comp",
@@ -309,6 +308,40 @@ async fn test_app_preview_authorization(db: Pool<Postgres>) -> anyhow::Result<()
     assert_eq!(
         status, 400,
         "run-mode unpinned raw_code must be rejected for any caller, not just operators (got {status}): {body}"
+    );
+
+    // 11. The pin requirement also covers `raw_code` carrying an `app_script`
+    //     `id`. The id resolves to `rawscript/<code_sha256>` of any app_script row
+    //     by number (no app scoping), so without the pin a caller could run a
+    //     script belonging to another app against this Viewer app. Here `999777`
+    //     belongs to `u/test-user/private`, not to the targeted `vapp`, and its
+    //     sha is absent from `vapp`'s empty `triggerables_v2` — it must be
+    //     rejected, not fall back to the Viewer default.
+    let resp = authed(
+        client().post(format!("{base}/u/test-user/vapp")),
+        "OPERATOR_TOKEN",
+    )
+    .json(&json!({
+        "args": {},
+        "component": "comp",
+        "id": 999777,
+        "raw_code": {
+            "language": "deno",
+            "content": "export function main() { return 1; }",
+            "path": "x"
+        }
+    }))
+    .send()
+    .await?;
+    let status = resp.status();
+    let body = resp.text().await?;
+    assert_eq!(
+        status, 400,
+        "run-mode raw_code with an unpinned app_script id must be rejected against a Viewer app (got {status}): {body}"
+    );
+    assert!(
+        body.contains("forbidden by policy"),
+        "rejection must be the content-hash pin (unpinned app_script sha), got: {body}"
     );
 
     Ok(())

--- a/backend/tests/app_preview_auth.rs
+++ b/backend/tests/app_preview_auth.rs
@@ -17,7 +17,12 @@
 //!     must not over-block the legitimate editor flow),
 //!   - preview is confined to paths the caller can read (defense-in-depth
 //!     against scoped tokens / cross-namespace preview), and
-//!   - run mode (no `force_viewer_static_fields`) is unaffected by the guard.
+//!   - run mode (no `force_viewer_static_fields`) is unaffected by the preview
+//!     guard, and
+//!   - run mode against a deployed Viewer app rejects caller-supplied inline
+//!     `raw_code` whose sha is not publisher-pinned (CVE-2026-22683 residual:
+//!     the Viewer default-triggerable fallback let any caller / an operator run
+//!     arbitrary code as themselves, bypassing the content-hash pin).
 
 use serde_json::json;
 use sqlx::{Pool, Postgres};
@@ -252,6 +257,58 @@ async fn test_app_preview_authorization(db: Pool<Postgres>) -> anyhow::Result<()
     assert!(
         body.contains("jobs:run"),
         "rejection must be the jobs:run scope gate, got: {body}"
+    );
+
+    // 9. RUN-MODE REGRESSION (CVE-2026-22683 residual): against a *deployed*
+    //    Viewer-mode app, run mode (no `force_viewer_static_fields`) must NOT let
+    //    a caller substitute arbitrary inline `raw_code`. Pre-fix the
+    //    `rawscript/<sha>` lookup fell back to the Viewer default triggerable, so
+    //    the operator's code was enqueued and ran as them (200 + job UUID, the
+    //    exact preview class blocked in step 1). Post-fix the unpinned sha is
+    //    rejected by the policy.
+    let run_mode_raw_code = json!({
+        "args": {},
+        "component": "comp",
+        "raw_code": {
+            "language": "bash",
+            "content": "id; echo RCE_$(whoami)",
+            "path": "x"
+        }
+    });
+    let resp = authed(
+        client().post(format!("{base}/u/test-user/vapp")),
+        "OPERATOR_TOKEN",
+    )
+    .json(&run_mode_raw_code)
+    .send()
+    .await?;
+    let status = resp.status();
+    let body = resp.text().await?;
+    assert_eq!(
+        status, 400,
+        "run-mode inline raw_code against a Viewer app must be rejected, not run as the caller (got {status}): {body}"
+    );
+    assert!(
+        body.contains("forbidden by policy"),
+        "rejection must be the content-hash pin (unpinned rawscript), got: {body}"
+    );
+
+    // 10. The content-pin fix is not operator-specific: even a regular
+    //     non-operator member (who could run their own code via
+    //     `/jobs/run/preview`) must not be able to substitute unpinned code into
+    //     someone else's deployed Viewer app — the deployed-app integrity break.
+    let resp = authed(
+        client().post(format!("{base}/u/test-user/vapp")),
+        "SECRET_TOKEN_2",
+    )
+    .json(&run_mode_raw_code)
+    .send()
+    .await?;
+    let status = resp.status();
+    let body = resp.text().await?;
+    assert_eq!(
+        status, 400,
+        "run-mode unpinned raw_code must be rejected for any caller, not just operators (got {status}): {body}"
     );
 
     Ok(())

--- a/backend/tests/fixtures/app_preview_auth.sql
+++ b/backend/tests/fixtures/app_preview_auth.sql
@@ -32,3 +32,11 @@ INSERT INTO app (id, workspace_id, path, summary, policy, versions) VALUES
 	(999002, 'test-workspace', 'u/test-user-2/ownapp', 'own app', '{}'::jsonb, '{}');
 INSERT INTO app_script (id, app, hash, code, code_sha256) VALUES
 	(999778, 999002, repeat('c', 64), 'export function main(){ return "ok" }', repeat('d', 64));
+
+-- A deployed empty Viewer-mode app owned by `test-user` with NO runnables pinned
+-- in `triggerables_v2`. Used to assert run mode rejects caller-supplied inline
+-- `raw_code` whose sha is not publisher-pinned (the CVE-2026-22683 residual:
+-- the Viewer default fallback let any caller / an operator run arbitrary code).
+INSERT INTO app (id, workspace_id, path, summary, policy, versions) VALUES
+	(999003, 'test-workspace', 'u/test-user/vapp', 'empty viewer app',
+	 '{"execution_mode": "viewer", "triggerables_v2": {}}'::jsonb, '{}');

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -2333,6 +2333,13 @@ async fn execute_component(
                 &policy
             };
 
+            // Caller-supplied inline code (no deployed `app_script` row). Its
+            // `rawscript/<sha>` key must be explicitly present in the policy
+            // triggerables below — it must never resolve via the Viewer default
+            // fallback, or any caller could substitute code the publisher never
+            // authorized (and run it as themselves).
+            let is_inline_raw_code = payload.raw_code.is_some() && payload.id.is_none();
+
             // Compute the path for the triggerables map:
             // - flow: `flow/<payload.path>`
             // - script: `script/<payload.path>`
@@ -2370,7 +2377,14 @@ async fn execute_component(
                 .get(path) // start with `path` in case we can avoid the next` format!`.
                 .or_else(|| triggerables_v2.get(&format!("{}:{}", payload.component, &path)))
                 .or(match policy.execution_mode {
-                    ExecutionMode::Viewer => Some(&policy_triggerables_default),
+                    // A Viewer app may invoke any deployed runnable it references
+                    // (resolved as the caller), but caller-supplied inline code
+                    // must match a publisher-pinned `rawscript/<sha>` entry —
+                    // otherwise an unauthorized caller (e.g. an operator, who is
+                    // barred from `/jobs/run/preview`) could run arbitrary code.
+                    ExecutionMode::Viewer if !is_inline_raw_code => {
+                        Some(&policy_triggerables_default)
+                    }
                     _ => None,
                 })
                 .ok_or_else(|| Error::BadRequest(format!("Path {path} forbidden by policy")))?;

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -2333,12 +2333,14 @@ async fn execute_component(
                 &policy
             };
 
-            // Caller-supplied inline code (no deployed `app_script` row). Its
-            // `rawscript/<sha>` key must be explicitly present in the policy
-            // triggerables below — it must never resolve via the Viewer default
-            // fallback, or any caller could substitute code the publisher never
-            // authorized (and run it as themselves).
-            let is_inline_raw_code = payload.raw_code.is_some() && payload.id.is_none();
+            // Caller-supplied inline code (`raw_code`), with or without an
+            // `app_script` id. Its resolved `rawscript/<sha>` key must be present
+            // in the policy triggerables below — it must never resolve via the
+            // Viewer default fallback. Without `id` the caller supplies the code
+            // verbatim; with `id` it selects any `app_script` row by number (no
+            // app/workspace scoping), so both let a caller run code the publisher
+            // never pinned for this app.
+            let is_inline_raw_code = payload.raw_code.is_some();
 
             // Compute the path for the triggerables map:
             // - flow: `flow/<payload.path>`
@@ -2377,11 +2379,12 @@ async fn execute_component(
                 .get(path) // start with `path` in case we can avoid the next` format!`.
                 .or_else(|| triggerables_v2.get(&format!("{}:{}", payload.component, &path)))
                 .or(match policy.execution_mode {
-                    // A Viewer app may invoke any deployed runnable it references
-                    // (resolved as the caller), but caller-supplied inline code
-                    // must match a publisher-pinned `rawscript/<sha>` entry —
-                    // otherwise an unauthorized caller (e.g. an operator, who is
-                    // barred from `/jobs/run/preview`) could run arbitrary code.
+                    // A Viewer app may invoke any deployed `script`/`flow` it
+                    // references (resolved as the caller), but caller-supplied
+                    // inline `raw_code` must match a publisher-pinned
+                    // `rawscript/<sha>` entry — otherwise an unauthorized caller
+                    // (e.g. an operator, barred from `/jobs/run/preview`) could
+                    // run code the publisher never pinned for this app.
                     ExecutionMode::Viewer if !is_inline_raw_code => {
                         Some(&policy_triggerables_default)
                     }

--- a/backend/windmill-object-store/src/lib.rs
+++ b/backend/windmill-object-store/src/lib.rs
@@ -53,6 +53,7 @@ use tokio::task;
 use windmill_common::error::to_anyhow;
 #[cfg(feature = "parquet")]
 use windmill_common::jobs::is_safe_log_file_path;
+#[cfg(feature = "parquet")]
 use windmill_common::utils::rd_string;
 #[cfg(all(feature = "parquet", feature = "private"))]
 pub mod job_s3_helpers_ee;


### PR DESCRIPTION
## Summary

Closes an authorization / content-hash-pin bypass in the app `execute_component` run-mode path (private advisory GHSA-qc46-mqh5-9f3p, an incomplete-fix residual of CVE-2026-22683).

In run mode (`force_viewer_static_fields` omitted), caller-supplied inline `raw_code` (no `app_script` id) against a **Viewer-mode** app fell back to the default triggerable via `ExecutionMode::Viewer => Some(&policy_triggerables_default)`, short-circuiting the `triggerables_v2` content-hash pin. Effect: a caller could submit arbitrary code into someone else's deployed Viewer app and have it run as themselves. The notable case is an **operator** — operators are otherwise hard-blocked from running arbitrary code (`/jobs/run/preview` → "Operators cannot run preview jobs") — gaining inline code execution.

Severity in practice is **at most medium**: the job runs as the *caller's own* identity (no publisher/admin escalation within Windmill's permission model), and the non-operator leg is not a new capability (members can already run their own code via `/jobs/run/preview`). The teeth are only at the worker-OS layer on default CE (`isolation=none`, root), which nsjail + non-root workers mitigate.

## Changes

- `backend/windmill-api/src/apps.rs`: compute `is_inline_raw_code = payload.raw_code.is_some() && payload.id.is_none()` and deny the `ExecutionMode::Viewer` default-triggerable fallback for that case, so caller-supplied inline code must match a publisher-pinned `rawscript/<sha>` entry. Deployed `script`/`flow` paths, `app_script`-backed inline scripts (`id`), and legacy pinned inline scripts are unaffected (they resolve before the fallback).
- `backend/tests/app_preview_auth.rs` + fixture: deployed empty Viewer app (`999003`) and two regression cases — operator and non-operator member posting inline `raw_code` in run mode, both now `400 ... forbidden by policy`.

## Test plan

- [ ] `cargo test --test app_preview_auth` passes (operator and member run-mode `raw_code` → 400; existing preview/run-mode cases still green)
- [ ] A real deployed Viewer app still executes its legitimately-pinned components (deployed `script`/`flow` refs and `app_script`-backed inline scripts)
- [ ] A hand-crafted `execute_component` run-mode request with unpinned inline `raw_code` returns 400

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a pinned content hash for all inline `raw_code` in Viewer app run mode (with or without `app_script` id), closing a fallback that let unpinned code run via the default triggerable. This blocks arbitrary code injection into deployed Viewer apps; only publisher-pinned `rawscript/<sha>` entries are allowed.

- **Bug Fixes**
  - In `execute_component`, disable the Viewer default-triggerable fallback when `raw_code` is present; require a `triggerables_v2` pin for the resolved `rawscript/<sha>` (covers plain inline and `app_script`-backed code).
  - Allowed paths remain: deployed `script`/`flow` refs; unpinned inline code now returns 400.
  - Fixed OSS build by gating `rd_string` behind the `parquet` feature; added regression tests and a minimal Viewer app fixture (operator/member inline runs, with/without `id`, now return 400).

<sup>Written for commit 664a61f41f818528468551451cadd1fe7cdb627f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

