### PR TITLE
fix(ai): enforce resource authz when loading MCP tools in agent worker

### DIFF
--- a/backend/tests/fixtures/mcp_resource_authz.sql
+++ b/backend/tests/fixtures/mcp_resource_authz.sql
@@ -1,0 +1,25 @@
+-- Fixture for the MCP resource-authorization regression test (WIN-2041,
+-- GHSA-7qg3-pr4g-cq5x).
+--
+-- Models a low-privileged developer (test-user-3, a plain workspace member) who
+-- references, from an AI Agent flow, an MCP resource living in a private folder
+-- they have NO access to. The AI agent worker must refuse to load that resource
+-- because the developer's identity lacks resources:read on it.
+
+-- Private folder the developer cannot read (empty extra_perms, owned by admin).
+INSERT INTO folder (workspace_id, name, display_name, owners, extra_perms, created_by)
+VALUES ('test-workspace', 'private', 'Private Folder', '{"u/test-user"}', '{}', 'test-user');
+
+-- MCP resource the developer is NOT allowed to read. The URL is a non-resolvable
+-- public host so that, for an authorized caller, resolution succeeds but the
+-- later connection step fails deterministically without network access.
+INSERT INTO resource (workspace_id, path, value, description, resource_type, extra_perms, created_by)
+VALUES (
+    'test-workspace',
+    'f/private/admin_mcp',
+    '{"name": "admin_mcp", "url": "https://mcp.invalid.windmill.test"}',
+    'Private MCP resource only admin can read',
+    'mcp',
+    '{}',
+    'test-user'
+);

--- a/backend/tests/mcp_resource_authz.rs
+++ b/backend/tests/mcp_resource_authz.rs
@@ -1,17 +1,14 @@
 //! Regression test for the MCP resource-authorization bypass
 //! (WIN-2041, GHSA-7qg3-pr4g-cq5x).
 //!
-//! The regular MCP tools API (`GET /api/w/{w}/resources/mcp_tools/{path}`,
-//! `get_mcp_tools`) enforces `resources:read:{path}` and reads the resource
-//! through an RLS-scoped `user_db` transaction. Before the fix, the AI Agent
-//! worker (`load_mcp_tools`) read the referenced MCP resource straight from the
-//! raw DB pool — no scope check, no RLS — so a low-privileged user who could
-//! edit a flow could make the agent load and use an MCP resource (URL + inline
-//! headers + token) they were not allowed to read: a confused-deputy bypass.
-//!
-//! The fix loads the resource through the job's permissioned client
-//! (`AuthedClient::get_resource_value`), which hits the same RLS + scope gate as
-//! `resources/get_value`.
+//! Invariant: the AI Agent worker (`load_mcp_tools`) must load an MCP resource
+//! only when the job identity is allowed to read it — the same
+//! `resources:read:{path}` + RLS gate the regular MCP tools API (`get_mcp_tools`)
+//! enforces. It loads the resource through the job's permissioned client
+//! (`AuthedClient::get_resource_value`, the `resources/get_value` path), not the
+//! raw DB pool. Otherwise a low-privileged user who can edit a flow could make
+//! the agent load and use an MCP resource (URL + inline headers + token) they are
+//! not allowed to read: a confused-deputy bypass.
 //!
 //! This test pins, against the `mcp_resource_authz` fixture (an MCP resource in
 //! a folder only the admin can read):
@@ -71,8 +68,8 @@ async fn test_mcp_resource_not_loaded_without_authorization(
         msg.contains("don't have access"),
         "denial should come from the resource-RLS gate, not a connection error: {msg}"
     );
-    // Pre-fix, the resource was read as admin and the worker proceeded to build
-    // the MCP client; that step must no longer be reached for the developer.
+    // An unauthorized caller must be blocked before MCP client creation, so no
+    // resource material (URL, headers, token) is ever loaded for them.
     assert!(
         !msg.contains("Failed to create MCP client"),
         "developer must be blocked before the connection step (would mean the resource was loaded): {msg}"

--- a/backend/tests/mcp_resource_authz.rs
+++ b/backend/tests/mcp_resource_authz.rs
@@ -1,0 +1,105 @@
+//! Regression test for the MCP resource-authorization bypass
+//! (WIN-2041, GHSA-7qg3-pr4g-cq5x).
+//!
+//! The regular MCP tools API (`GET /api/w/{w}/resources/mcp_tools/{path}`,
+//! `get_mcp_tools`) enforces `resources:read:{path}` and reads the resource
+//! through an RLS-scoped `user_db` transaction. Before the fix, the AI Agent
+//! worker (`load_mcp_tools`) read the referenced MCP resource straight from the
+//! raw DB pool — no scope check, no RLS — so a low-privileged user who could
+//! edit a flow could make the agent load and use an MCP resource (URL + inline
+//! headers + token) they were not allowed to read: a confused-deputy bypass.
+//!
+//! The fix loads the resource through the job's permissioned client
+//! (`AuthedClient::get_resource_value`), which hits the same RLS + scope gate as
+//! `resources/get_value`.
+//!
+//! This test pins, against the `mcp_resource_authz` fixture (an MCP resource in
+//! a folder only the admin can read):
+//!   - a plain developer (test-user-3) is DENIED loading the private resource,
+//!     before any MCP connection is attempted, and the resource never leaks;
+//!   - an admin (test-user) clears the gate, the resource resolves, and loading
+//!     only fails later at the connect step — proving no over-blocking.
+#![cfg(feature = "mcp")]
+
+use sqlx::{Pool, Postgres};
+use windmill_common::client::AuthedClient;
+use windmill_test_utils::*;
+use windmill_worker::{load_mcp_tools, McpResourceConfig};
+
+fn config() -> Vec<McpResourceConfig> {
+    vec![McpResourceConfig {
+        resource_path: "$res:f/private/admin_mcp".to_string(),
+        include_tools: None,
+        exclude_tools: None,
+    }]
+}
+
+// The Ok variant ((HashMap<_, Arc<McpClient>>, Vec<Tool>)) does not implement
+// Debug, so `expect_err` is unavailable — extract the error explicitly.
+async fn load_err(db: &Pool<Postgres>, client: &AuthedClient, ctx: &str) -> String {
+    match load_mcp_tools(db, "test-workspace", config(), client).await {
+        Ok(_) => panic!("{ctx}"),
+        Err(e) => e.to_string(),
+    }
+}
+
+#[sqlx::test(fixtures("base", "mcp_resource_authz"))]
+async fn test_mcp_resource_not_loaded_without_authorization(
+    db: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let base_internal_url = format!("http://localhost:{}", server.addr.port());
+
+    // ---- CORE REGRESSION: the developer cannot read the private MCP resource,
+    //      so the worker must refuse to load it — before any MCP connection is
+    //      attempted, and without the resource ever leaking.
+    let dev_client = AuthedClient::new(
+        base_internal_url.clone(),
+        "test-workspace".to_string(),
+        "SECRET_TOKEN_3".to_string(),
+        None,
+    );
+    let msg = load_err(
+        &db,
+        &dev_client,
+        "developer must be denied loading a resource they can't read",
+    )
+    .await;
+    assert!(
+        msg.contains("don't have access"),
+        "denial should come from the resource-RLS gate, not a connection error: {msg}"
+    );
+    // Pre-fix, the resource was read as admin and the worker proceeded to build
+    // the MCP client; that step must no longer be reached for the developer.
+    assert!(
+        !msg.contains("Failed to create MCP client"),
+        "developer must be blocked before the connection step (would mean the resource was loaded): {msg}"
+    );
+
+    // ---- NO OVER-BLOCKING: an admin clears the resource-RLS gate, so the
+    //      resource resolves and loading only fails later at the connect step.
+    let admin_client = AuthedClient::new(
+        base_internal_url,
+        "test-workspace".to_string(),
+        "SECRET_TOKEN".to_string(),
+        None,
+    );
+    let msg = load_err(
+        &db,
+        &admin_client,
+        "the fixture URL is non-resolvable, so the connect step must fail",
+    )
+    .await;
+    assert!(
+        !msg.contains("don't have access"),
+        "admin must clear the resource-RLS gate, not be denied: {msg}"
+    );
+    assert!(
+        msg.contains("Failed to create MCP client"),
+        "admin should resolve the resource and only fail at the connect step: {msg}"
+    );
+
+    Ok(())
+}

--- a/backend/windmill-worker/src/ai/utils.rs
+++ b/backend/windmill-worker/src/ai/utils.rs
@@ -557,21 +557,20 @@ pub async fn load_mcp_tools(
         tracing::debug!("Loading MCP tools from resource: {}", config.resource_path);
 
         let path = config.resource_path.trim_start_matches("$res:");
-        let mcp_resource = {
-            // Fetch the resource from database
-            let resource= sqlx::query_scalar!(
-                "SELECT value as \"value: sqlx::types::Json<Box<RawValue>>\" FROM resource WHERE path = $1 AND workspace_id = $2",
-                &path,
-                &workspace_id
-            )
-            .fetch_optional(db)
-            .await?
-            .ok_or_else(|| Error::NotFound(format!("Could not find the resource {}, update the resource path in the workspace settings", config.resource_path)))?
-            .ok_or_else(|| Error::BadRequest(format!("Empty resource value for {}", config.resource_path)))?;
-
-            serde_json::from_str::<McpResource>(resource.0.get())
-                .context("Failed to parse MCP resource")?
-        };
+        // Load the resource through the job's permissioned (RLS + scope) path so
+        // a flow author cannot make the agent use an MCP resource their identity
+        // is not allowed to read (resources:read:{path}). Reading through the raw
+        // db pool here would bypass the authorization enforced by the regular MCP
+        // tools API (get_mcp_tools) and act as a confused deputy.
+        let mcp_resource = client
+            .get_resource_value::<McpResource>(path)
+            .await
+            .map_err(|e| {
+                Error::internal_err(format!(
+                    "Failed to load MCP resource {}: {}",
+                    config.resource_path, e
+                ))
+            })?;
 
         let resource_name = mcp_resource.name.clone();
 

--- a/backend/windmill-worker/src/lib.rs
+++ b/backend/windmill-worker/src/lib.rs
@@ -22,6 +22,12 @@ mod r_executor;
 
 mod ai;
 mod ai_executor;
+
+// Exposed for the MCP resource-authorization regression test
+// (tests/mcp_resource_authz.rs): the AI agent worker must load MCP resources
+// through the job's permissioned client, not the raw DB pool.
+#[cfg(feature = "mcp")]
+pub use ai::utils::{load_mcp_tools, McpResourceConfig};
 mod bun_executor;
 pub mod common;
 mod config;


### PR DESCRIPTION
## Summary

Fixes **WIN-2041** / GHSA-7qg3-pr4g-cq5x — an authorization bypass (confused deputy, CWE-862) in AI Agent MCP tool loading.

The regular MCP tools API (`get_mcp_tools` in `windmill-api/src/mcp_tools.rs`) enforces `resources:read:{path}` via `check_scopes` and reads the resource through an RLS-scoped `user_db` transaction. The AI Agent worker path (`load_mcp_tools` in `windmill-worker/src/ai/utils.rs`) instead read the referenced MCP resource straight from the raw DB pool — no scope check, no RLS. A low-privileged user who can create/edit a flow could therefore reference an MCP resource they are not allowed to read (`$res:f/private/admin_mcp`) and have the agent runtime load and use it (its URL, inline headers, and token).

The token field was already resolved through the job's permissioned client, but the resource object itself was not. This PR loads the resource through the same permissioned path (`AuthedClient::get_resource_value`), which routes through `/api/w/{w}/resources/get_value/{path}` and enforces the identical RLS + `resources:read` gate. The returned value is non-interpolated, so the existing `$var:` token-resolution logic is unchanged.

## Changes

- `windmill-worker/src/ai/utils.rs`: `load_mcp_tools` now resolves the MCP resource via `client.get_resource_value::<McpResource>(path)` (the job's permissioned, RLS + scope-enforced path) instead of a raw `db` query.
- `windmill-worker/src/lib.rs`: narrow, `#[cfg(feature = "mcp")]`-gated re-export of `load_mcp_tools` / `McpResourceConfig` so the regression test can reach them.
- `tests/mcp_resource_authz.rs` + `tests/fixtures/mcp_resource_authz.sql`: regression test pinning both directions of the gate.

## Test plan

- [x] `cargo check -p windmill-worker --features mcp` — clean, no warnings
- [x] `cargo test --features mcp --test mcp_resource_authz` — passes (green)
- [x] Reverted the fix locally and reran the test — it fails (red), with the developer reaching the MCP connect step, proving the bypass is genuinely caught
- [x] `cargo test --features mcp --test mcp_token_exfil` — related existing test still passes
- [x] local-review (branch-diff-reviewer) — "Good to merge", 0 issues

The negative case asserts a non-admin (`test-user-3`) is denied with a "don't have access" error and never reaches the MCP connection step; the no-over-blocking case asserts an admin clears the gate and only fails later at the connect step against a non-resolvable host (deterministic, no network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops an authorization bypass by enforcing resource checks when the agent worker loads MCP tools. Addresses WIN-2041 by ensuring only permitted users can resolve MCP resources.

- Bug Fixes
  - `load_mcp_tools` now loads MCP resources via `AuthedClient::get_resource_value` (RLS + `resources:read:{path}`) instead of querying the raw DB.
  - Added regression test `tests/mcp_resource_authz.rs` + fixture to assert: a low-priv user is denied before any MCP client is created; an admin clears the gate and only fails at the connect step (using a non-resolvable host).
  - `#[cfg(feature = "mcp")]` re-export of `load_mcp_tools` and `McpResourceConfig` in `windmill-worker` to enable the test.

<sup>Written for commit 38e39e8b371902841f7409f6afe70264a8404d13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

