### PR TITLE
fix(security): block operators from inline preview job execution (GHSA-pp5h-96x3-3wqq)

### DIFF
--- a/backend/tests/fixtures/inline_preview_auth.sql
+++ b/backend/tests/fixtures/inline_preview_auth.sql
@@ -1,0 +1,14 @@
+-- Fixture for the inline preview authorization regression test (GHSA-pp5h-96x3-3wqq).
+-- Layered on top of `base` (which provides test-workspace and the non-operator
+-- `test-user-2`/SECRET_TOKEN_2). Adds an Operator member so we can assert that
+-- Operators cannot reach the arbitrary-code inline preview path
+-- (`POST /jobs/run_inline/preview`).
+
+INSERT INTO password(email, password_hash, login_type, super_admin, verified, name)
+    VALUES ('operator@windmill.dev', 'not-a-real-hash', 'password', false, true, 'Operator User');
+
+INSERT INTO usr(workspace_id, email, username, is_admin, operator, role) VALUES
+	('test-workspace', 'operator@windmill.dev', 'operator-user', false, true, 'Operator');
+
+INSERT INTO token(token_hash, token_prefix, token, email, label, super_admin) VALUES
+	(encode(sha256('OPERATOR_TOKEN'::bytea), 'hex'), 'OPERATOR_T', 'OPERATOR_TOKEN', 'operator@windmill.dev', 'operator token', false);

--- a/backend/tests/inline_preview_auth.rs
+++ b/backend/tests/inline_preview_auth.rs
@@ -1,0 +1,90 @@
+//! Regression test for the inline preview authorization bypass (GHSA-pp5h-96x3-3wqq).
+//!
+//! `POST /api/w/:workspace/jobs/run_inline/preview` -> `run_inline_preview_script`
+//! runs request-supplied code inline (in-process via DuckDB), i.e. it is an
+//! arbitrary-code-execution sibling of `/jobs/run/preview`. The bug was that
+//! this handler was missing the Operator guard that `run_preview_script`
+//! enforces, so an authenticated Operator (a run-only user who must not be able
+//! to run preview jobs) could execute arbitrary code in a single request. This
+//! was the incomplete-fix residual of CVE-2026-22683, whose v1.615.0 patch only
+//! covered the entity-CRUD endpoints and left this direct inline-exec sink open.
+//!
+//! This test pins down:
+//!   - an Operator is rejected by the operator guard (the core fix; pre-fix this
+//!     reached the inline executor instead of returning 401), and
+//!   - a regular non-operator passes the guard (the fix must not over-block the
+//!     legitimate inline preview flow): in the test harness the worker inline
+//!     utils are not registered, so a caller past the guard gets the distinct
+//!     "worker inline functions" error rather than the operator rejection.
+
+use serde_json::json;
+use sqlx::{Pool, Postgres};
+use windmill_test_utils::*;
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+fn authed(builder: reqwest::RequestBuilder, token: &str) -> reqwest::RequestBuilder {
+    builder.header("Authorization", format!("Bearer {}", token))
+}
+
+/// An inline preview request: request-supplied `content` to run via DuckDB.
+fn inline_preview_body() -> serde_json::Value {
+    json!({
+        "language": "duckdb",
+        "content": "SELECT content FROM read_text(['/etc/passwd']);",
+        "args": {}
+    })
+}
+
+const OPERATOR_GUARD_MSG: &str = "Operators cannot run preview jobs";
+
+#[sqlx::test(fixtures("base", "inline_preview_auth"))]
+async fn test_inline_preview_authorization(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let url = format!("http://localhost:{port}/api/w/test-workspace/jobs/run_inline/preview");
+
+    // 1. CORE REGRESSION: an Operator must be rejected by the operator guard.
+    //    Pre-fix this fell through to the inline executor (arbitrary code
+    //    execution); post-fix it returns 401 with the operator guard message.
+    let resp = authed(client().post(&url), "OPERATOR_TOKEN")
+        .json(&inline_preview_body())
+        .send()
+        .await?;
+    let status = resp.status();
+    let body = resp.text().await?;
+    assert_eq!(
+        status, 401,
+        "Operator must be rejected from inline preview (got {status}): {body}"
+    );
+    assert!(
+        body.contains(OPERATOR_GUARD_MSG),
+        "rejection must be the operator guard, got: {body}"
+    );
+
+    // 2. The fix must NOT over-block a legitimate non-operator: a regular member
+    //    passes the operator + scope checks. The test harness does not register
+    //    the worker inline utils, so the request proceeds past the guard and
+    //    fails later with the distinct "worker inline functions" error — proving
+    //    the operator guard did not reject it.
+    let resp = authed(client().post(&url), "SECRET_TOKEN_2")
+        .json(&inline_preview_body())
+        .send()
+        .await?;
+    let status = resp.status();
+    let body = resp.text().await?;
+    assert_ne!(
+        status, 401,
+        "non-operator must not be blocked by the operator guard (got {status}): {body}"
+    );
+    assert!(
+        !body.contains(OPERATOR_GUARD_MSG),
+        "non-operator must not hit the operator guard, got: {body}"
+    );
+
+    Ok(())
+}

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -6315,8 +6315,14 @@ async fn run_inline_preview_script(
     Path(w_id): Path<String>,
     Json(preview): Json<PreviewInline>,
 ) -> error::Result<Response> {
-    // Same arbitrary-code class as run_preview_script: a narrowly-scoped token
-    // must not be able to run request-supplied code through inline preview.
+    // Same arbitrary-code class as run_preview_script: operators are blocked from
+    // running request-supplied code, and a narrowly-scoped token must not escape
+    // its scope through inline preview.
+    if authed.is_operator {
+        return Err(error::Error::NotAuthorized(
+            "Operators cannot run preview jobs for security reasons".to_string(),
+        ));
+    }
     check_scopes(&authed, || format!("jobs:run"))?;
     if let Some(job_id) = job_id {
         register_potential_assets_on_inline_execution(job_id, &w_id, &preview);


### PR DESCRIPTION
## Summary

Fixes the operator-role authorization bypass reported in **GHSA-pp5h-96x3-3wqq** (Fixes WIN-2043).

`POST /api/w/{workspace}/jobs/run_inline/preview` → `run_inline_preview_script` runs request-supplied code inline (in-process, e.g. DuckDB), making it an arbitrary-code-execution sibling of `/jobs/run/preview`. The handler was missing the `is_operator` guard that `run_preview_script` enforces, so an authenticated **operator** — the most restricted workspace role, explicitly documented as unable to run preview jobs — could execute arbitrary code in a single request:

- **File read/write** of any path on the worker (unconditional, even air-gapped).
- **OS command execution as the worker user** via the DuckDB `shellfs` community extension when worker egress is available, plus `DATABASE_URL` theft → control-plane DB takeover.

This is the **incomplete-fix residual of CVE-2026-22683 / GHSA-9q9g-rp9x-244h** (operator missing-authorization, fixed in v1.615.0): that patch covered the entity-CRUD endpoints but left this direct inline-exec sink uncovered.

## Fix

Add the same operator guard that `run_preview_script` already uses, before any execution:

```rust
if authed.is_operator {
    return Err(error::Error::NotAuthorized(
        "Operators cannot run preview jobs for security reasons".to_string(),
    ));
}
```

## Class audit

As the advisory recommends, I censused every preview/inline arbitrary-code endpoint in `jobs.rs`. All already carry the `is_operator` guard:

| Endpoint | Status |
|---|---|
| `run_preview_script` | guarded |
| `run_inline_preview_script` | **fixed here** |
| `run_wait_result_preview_script` | delegates to `run_preview_script` |
| `run_bundle_preview_script` | guarded |
| `run_preview_flow_job` | guarded |
| `run_wait_result_preview_flow` | delegates to `run_preview_flow_job` |
| `run_dynamic_select` (inline variant) | guarded |
| `run_dependencies_job` / `_async` | guarded |

`run_inline_script_by_path` / `run_inline_script_by_hash` run **deployed** scripts (operator-allowed, scope-checked) and correctly remain ungated.

## Validation

Added `backend/tests/inline_preview_auth.rs` (regression test, run with `--features run_inline`):

- Operator → **401** with `Operators cannot run preview jobs` (pre-fix this reached the inline executor).
- Non-operator → passes the guard (proves the fix does not over-block the legitimate flow).

```
test test_inline_preview_authorization ... ok
test result: ok. 1 passed; 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks operators from running inline preview jobs by adding the missing authorization guard to `run_inline_preview_script`, closing GHSA-pp5h-96x3-3wqq. Aligns behavior with `run_preview_script` and satisfies WIN-2043.

- **Bug Fixes**
  - Added `is_operator` guard to `POST /api/w/{workspace}/jobs/run_inline/preview`; returns 401 with "Operators cannot run preview jobs".
  - Added regression test `backend/tests/inline_preview_auth.rs` and fixture to verify operator rejection and non-operator pass-through.
  - Audited related preview/inline endpoints; all already guarded. `run_inline_script_by_path`/`by_hash` remain ungated for deployed scripts (scope-checked).

<sup>Written for commit afbd250e687345fcd4794ece1e8638e929c07ee7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

