### PR TITLE
fix: create windmill_admin without BYPASSRLS on managed dbs

### DIFF
--- a/backend/windmill-api/src/db.rs
+++ b/backend/windmill-api/src/db.rs
@@ -254,10 +254,55 @@ impl Migrate for CustomMigrator {
     }
 }
 
+/// Ensure the `windmill_user` and `windmill_admin` roles exist before migrations run.
+///
+/// The early migrations create these roles inside `DO`/`EXCEPTION` blocks that swallow any
+/// error, and `windmill_admin` is created `WITH BYPASSRLS`. On managed Postgres (Scaleway,
+/// RDS, Azure, ...) the connecting user is not a superuser and cannot create a BYPASSRLS
+/// role, so that creation silently fails and the role never exists — which then makes the
+/// first bare `GRANT ... TO windmill_admin` migration hard-fail. We bootstrap the roles here,
+/// falling back to a plain `windmill_admin` (no BYPASSRLS) when BYPASSRLS is not permitted;
+/// admin access is then enforced by the per-table `FOR ALL TO windmill_admin USING (true)`
+/// policies that the migrations create on every RLS-enabled table.
+async fn ensure_windmill_roles(db: &DB) {
+    let bootstrap = r#"
+DO
+$$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'windmill_user') THEN
+        BEGIN
+            CREATE ROLE windmill_user;
+        EXCEPTION WHEN OTHERS THEN
+            RAISE NOTICE 'Could not create windmill_user role: %', SQLERRM;
+        END;
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'windmill_admin') THEN
+        BEGIN
+            CREATE ROLE windmill_admin WITH BYPASSRLS;
+        EXCEPTION WHEN OTHERS THEN
+            BEGIN
+                CREATE ROLE windmill_admin;
+                RAISE NOTICE 'Created windmill_admin without BYPASSRLS (managed db without superuser)';
+            EXCEPTION WHEN OTHERS THEN
+                RAISE NOTICE 'Could not create windmill_admin role: %', SQLERRM;
+            END;
+        END;
+    END IF;
+END
+$$;
+"#;
+    if let Err(err) = sqlx::query(bootstrap).execute(db).await {
+        tracing::info!("Could not bootstrap windmill roles: {err:#}");
+    }
+}
+
 pub async fn migrate(
     db: &DB,
     mut killpill_rx: tokio::sync::broadcast::Receiver<()>,
 ) -> Result<Option<JoinHandle<()>>, Error> {
+    ensure_windmill_roles(db).await;
+
     let migrator = db.acquire().await?;
     let mut custom_migrator = CustomMigrator { inner: migrator };
 


### PR DESCRIPTION
## Summary

Initial migrations fail on managed Postgres providers (Scaleway, RDS, Azure, ...) with:

```
Error migrating db: while executing migration 20221211192539: error returned from database: role "windmill_admin" does not exist
```

On managed Postgres the connecting user is **not a superuser** and cannot create a role `WITH BYPASSRLS`. The early migrations (`20220123221901/02`, `20220123221903_first`) create `windmill_admin WITH BYPASSRLS` inside `DO`/`EXCEPTION` blocks that swallow the resulting `permission denied to create role` error — so `windmill_admin` is never created (`windmill_user`, a plain role, is created fine). The first **bare** `GRANT ... TO windmill_admin` migration (`20221211192539_grant_usage`) then hard-fails because the role does not exist, aborting all initial migrations.

This bootstraps `windmill_user`/`windmill_admin` once, before the sqlx migration runner, falling back to a plain `windmill_admin` (no BYPASSRLS) when BYPASSRLS isn't permitted. Admin access stays correct in that case: the migrations already create per-table `FOR ALL TO windmill_admin USING (true)` policies on every RLS-enabled table (e.g. `admin_policy`). This matches how managed deployments already run today (the affected instance has 19 windmill DBs whose `windmill_admin` has `rolbypassrls = f`).

## Changes

- Add `ensure_windmill_roles(db)` in `backend/windmill-api/src/db.rs`, called at the start of `migrate()` (servers only — workers wait for migrations). It runs an idempotent `DO` block: create `windmill_user` if missing; create `windmill_admin WITH BYPASSRLS`, and on failure fall back to a plain `CREATE ROLE windmill_admin`. All failures are caught and logged, never fatal.

## Reproduction & verification

Reproduced end-to-end in an isolated Postgres where the connecting user is a non-superuser lacking BYPASSRLS-create privilege (mirrors Scaleway, confirmed against the live Scaleway instance that `CREATE ROLE ... WITH BYPASSRLS` → `permission denied to create role`):

- **Before:** migrations abort at `20221211192539` with `role "windmill_admin" does not exist`.
- **After:** all 558 migrations apply, server starts. `windmill_admin` exists with `rolbypassrls = f`; 31 `admin_policy` entries present. Second startup is a clean no-op (idempotent).
- Local dev backend (superuser, roles already exist) is unaffected — bootstrap is a no-op, health check `healthy`.

## Test plan

- [ ] Fresh install against a managed Postgres / non-superuser role with no `windmill_admin` role: migrations complete successfully
- [ ] Verify `SELECT rolname, rolbypassrls FROM pg_roles WHERE rolname IN ('windmill_user','windmill_admin')` → `windmill_admin` created without BYPASSRLS
- [ ] Admin-scoped query on an RLS table (e.g. `flow`, `v2_job`) returns rows via the policy-based fallback
- [ ] Existing self-hosted install (superuser) startup unaffected — bootstrap is a no-op

Fixes WIN-2042

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failed initial migrations on managed Postgres by bootstrapping `windmill_user` and `windmill_admin` before migrations, creating `windmill_admin` without `BYPASSRLS` when not permitted. Addresses WIN-2042 where migrations error with “role 'windmill_admin' does not exist”.

- **Bug Fixes**
  - Added `ensure_windmill_roles(db)` in `backend/windmill-api/src/db.rs`, called at the start of `migrate()`.
  - Tries `CREATE ROLE windmill_admin WITH BYPASSRLS`; on permission error, falls back to a plain role.
  - Idempotent and non-fatal: errors are logged, not returned.
  - Workers still wait for migrations; superuser/self-hosted setups are unchanged.
  - Admin access remains correct via existing per-table policies.

<sup>Written for commit 57ad009f9f12c876ee09ba2b2a6e7a71dcdb1ca7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

