### PR TITLE
fix(frontend): load resource value in JSON editor when resource type is missing

### DIFF
--- a/frontend/src/lib/components/ResourceForm.svelte
+++ b/frontend/src/lib/components/ResourceForm.svelte
@@ -82,12 +82,21 @@
 		args = { content: textFileContent }
 	}
 
+	// The raw JSON editor is the active input whenever the "As JSON" toggle is on,
+	// or no schema-based form can be rendered (e.g. the resource type is missing
+	// from the workspace). In both cases rawCode must be seeded from args.
+	let usesRawEditor = $derived(
+		!loadingSchema &&
+			(viewJsonSchema ||
+				(!resourceTypeInfo?.is_fileset && !(resourceSchema && resourceSchema.properties)))
+	)
+
 	$effect(() => {
 		if (rawCode !== undefined) parseJson()
 	})
 
 	$effect(() => {
-		if (viewJsonSchema && rawCode === undefined) {
+		if (usesRawEditor && rawCode === undefined) {
 			rawCode = JSON.stringify(args, null, 2)
 		}
 	})


### PR DESCRIPTION
## Summary

Fixes WIN-2044 — a regression introduced between v1.695.0 and v1.721.0 where, if a resource's type does not exist in the workspace, the JSON editor no longer loads the resource value (the editor shows up empty).

## Root cause

`ResourceForm.svelte` falls back to the raw JSON editor (`SimpleEditor` bound to `rawCode`) whenever no schema-based form can be rendered — including when the resource type is missing from the workspace — regardless of the "As JSON" toggle.

In v1.695.0 the editor's `catch` block (resource type lookup failed) explicitly seeded `rawCode = JSON.stringify(args, null, 2)`. The refactor to `resource()`/`$derived` (#9121 / #9298 / #9335) dropped that path: the only effect seeding `rawCode` now runs solely when `viewJsonSchema` is `true`. So for a missing resource type, `rawCode` stayed `undefined` and the editor rendered empty.

## Fix

Seed `rawCode` from `args` whenever the raw JSON editor is the active input — i.e. the "As JSON" toggle is on, **or** no schema-based form is available (missing resource type, no fileset, no schema properties) — instead of only when the toggle is on.

## Changes

- `frontend/src/lib/components/ResourceForm.svelte`: add a `usesRawEditor` derived and seed `rawCode` based on it.

## Test plan

- [x] `svelte-check` clean for the modified component
- [x] Reproduced with a resource whose `resource_type` does not exist in the workspace:
  - **Before**: JSON editor empty, value not shown
  - **After**: JSON editor loads the resource value, with the "Resource type … not found" notice still shown

## Screenshots

### Before (empty editor)
![before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2044-resourceform/1781505168-resource-before2.png)

### After (value loaded)
![after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2044-resourceform/1781505170-resource-fixed.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures the JSON editor loads the resource value when the resource type is missing, fixing the empty editor regression. Fixes WIN-2044 and restores behavior from v1.695.0.

- **Bug Fixes**
  - Seed `rawCode` whenever the raw JSON editor is active (toggle on or no schema-based form) via a new `usesRawEditor` derived.
  - Change limited to `frontend/src/lib/components/ResourceForm.svelte`.

<sup>Written for commit 258f813346c84c1826658a2f8f26f18f63bb9570. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

