### PR TITLE
fix(api): type /scripts/list response as ListableScript

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -7813,7 +7813,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Script"
+                  $ref: "#/components/schemas/ListableScript"
 
   /w/{workspace}/scripts/list_paths:
     get:
@@ -21770,6 +21770,72 @@ components:
         - workspace_id
         - language
         - content
+
+    ListableScript:
+      type: object
+      description: |
+        A script as returned by the list endpoint. This is a lighter
+        representation than `Script` and omits heavy fields such as `content`.
+      properties:
+        hash:
+          type: string
+        path:
+          type: string
+        summary:
+          type: string
+        description:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        archived:
+          type: boolean
+        extra_perms:
+          type: object
+          additionalProperties:
+            type: boolean
+        language:
+          $ref: "#/components/schemas/ScriptLang"
+        kind:
+          type: string
+          enum: [script, failure, trigger, command, approval, preprocessor]
+        starred:
+          type: boolean
+        tag:
+          type: string
+        has_draft:
+          type: boolean
+        draft_only:
+          type: boolean
+        has_deploy_errors:
+          type: boolean
+        ws_error_handler_muted:
+          type: boolean
+        auto_kind:
+          type: string
+        use_codebase:
+          type: boolean
+        deployment_msg:
+          type: string
+        labels:
+          type: array
+          items:
+            type: string
+        inherited_labels:
+          type: array
+          items:
+            type: string
+      required:
+        - hash
+        - path
+        - summary
+        - created_at
+        - archived
+        - extra_perms
+        - language
+        - kind
+        - starred
+        - has_deploy_errors
 
     Script:
       type: object

--- a/frontend/src/lib/components/apps/editor/settingsPanel/mainInput/WorkspaceScriptList.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/mainInput/WorkspaceScriptList.svelte
@@ -6,7 +6,7 @@
 	import SearchItems from '$lib/components/SearchItems.svelte'
 	import NoItemFound from '$lib/components/home/NoItemFound.svelte'
 	import RowIcon from '$lib/components/common/table/RowIcon.svelte'
-	import { type Script, ScriptService } from '$lib/gen'
+	import { type ListableScript, ScriptService } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
 	import { emptyString } from '$lib/utils'
 	import { Skeleton } from '$lib/components/common'
@@ -18,8 +18,8 @@
 
 	let { filter = $bindable(''), children }: Props = $props()
 
-	let scripts: Script[] | undefined = $state(undefined)
-	let filteredItems: (Script & { marked?: string })[] = $state([])
+	let scripts: ListableScript[] | undefined = $state(undefined)
+	let filteredItems: (ListableScript & { marked?: string })[] = $state([])
 	let prefilteredItems = $derived(scripts ?? [])
 
 	const dispatch = createEventDispatcher()

--- a/frontend/src/lib/components/copilot/StepGenQuick.svelte
+++ b/frontend/src/lib/components/copilot/StepGenQuick.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { workspaceStore } from '$lib/stores'
-	import { ScriptService, type Script } from '$lib/gen'
+	import { ScriptService, type ListableScript } from '$lib/gen'
 
 	import { Wand2, Loader2 } from 'lucide-svelte'
 	import SearchItems from '../SearchItems.svelte'
@@ -8,14 +8,14 @@
 	import { createEventDispatcher, onMount, untrack } from 'svelte'
 	import TextInput from '../text_input/TextInput.svelte'
 
-	let scripts: Script[] | undefined = $state(undefined)
+	let scripts: ListableScript[] | undefined = $state(undefined)
 	interface Props {
 		funcDesc: string
 		trigger?: boolean
 		loading?: boolean
 		preFilter: string
 		disableAi?: boolean
-		filteredItems?: (Script & { marked?: string })[] | (Item & { marked?: string })[]
+		filteredItems?: (ListableScript & { marked?: string })[] | (Item & { marked?: string })[]
 	}
 
 	let {

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -26,6 +26,7 @@ import type {
 	Job,
 	ListableApp,
 	ListableResource,
+	ListableScript,
 	ListableVariable,
 	NewSchedule,
 	NewScript,
@@ -704,13 +705,16 @@ function itemMatches(
 	)
 }
 
-function scriptToItem(script: Script | NewScript, includeValue: boolean): WorkspaceItem {
+function scriptToItem(
+	script: Script | NewScript | ListableScript,
+	includeValue: boolean
+): WorkspaceItem {
 	return {
 		type: 'script',
 		path: script.path,
 		summary: script.summary,
 		language: script.language,
-		value: includeValue ? script.content : undefined,
+		value: includeValue && 'content' in script ? script.content : undefined,
 		isDraft: false
 	}
 }

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -31,7 +31,7 @@ import {
 	type FlowValue,
 	type FlowModule,
 	type ScriptLang,
-	type Script,
+	type ListableScript,
 	type Flow
 } from '$lib/gen'
 import uFuzzy from '@leeoniya/ufuzzy'
@@ -1343,7 +1343,7 @@ export class WorkspaceRunnablesSearch {
 	private uf: uFuzzy
 	private scriptsWorkspace: string | undefined = undefined
 	private flowsWorkspace: string | undefined = undefined
-	private scripts: Script[] | undefined = undefined
+	private scripts: ListableScript[] | undefined = undefined
 	private flows: Flow[] | undefined = undefined
 	private scriptCache: Map<string, Awaited<ReturnType<typeof ScriptService.getScriptByPath>>> =
 		new Map()

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -6,6 +6,7 @@
 		AppService,
 		FlowService,
 		type ListableApp,
+		type ListableScript,
 		type Script,
 		ScriptService,
 		type Flow,
@@ -65,7 +66,7 @@
 		hash?: string
 	}
 
-	type TableScript = TableItem<Script, 'script'>
+	type TableScript = TableItem<ListableScript, 'script'>
 	type TableFlow = TableItem<Flow, 'flow'>
 	type TableApp = TableItem<ListableApp, 'app'>
 	type TableRawApp = TableItem<ListableRawApp, 'raw_app'>
@@ -94,7 +95,7 @@
 			withoutDescription: true
 		})
 
-		scripts = loadedScripts.map((script: Script) => {
+		scripts = loadedScripts.map((script: ListableScript) => {
 			return {
 				canWrite: canWrite(script.path, script.extra_perms, $userStore) && !$userStore?.operator,
 				...script

--- a/frontend/src/lib/components/home/treeViewUtils.ts
+++ b/frontend/src/lib/components/home/treeViewUtils.ts
@@ -1,4 +1,4 @@
-import type { ListableApp, Script, Flow, ListableRawApp } from '$lib/gen'
+import type { ListableApp, ListableScript, Flow, ListableRawApp } from '$lib/gen'
 type TableItem<T, U extends 'script' | 'flow' | 'app' | 'raw_app'> = T & {
 	canWrite: boolean
 	marked?: string
@@ -8,7 +8,7 @@ type TableItem<T, U extends 'script' | 'flow' | 'app' | 'raw_app'> = T & {
 	has_draft?: boolean
 }
 
-type TableScript = TableItem<Script, 'script'>
+type TableScript = TableItem<ListableScript, 'script'>
 type TableFlow = TableItem<Flow, 'flow'>
 type TableApp = TableItem<ListableApp, 'app'>
 type TableRawApp = TableItem<ListableRawApp, 'raw_app'>

--- a/frontend/src/lib/components/search/GlobalSearchModal.svelte
+++ b/frontend/src/lib/components/search/GlobalSearchModal.svelte
@@ -7,7 +7,7 @@
 		type Flow,
 		type ListableApp,
 		type ListableRawApp,
-		type Script,
+		type ListableScript,
 		type SearchJobsIndexResponse
 	} from '$lib/gen'
 	import { clickOutside, isMac, scroll_into_view_if_needed_polyfill } from '$lib/utils'
@@ -479,7 +479,7 @@
 	// 	search_id: string
 	// }
 
-	type TableScript = TableItem<Script, 'script'>
+	type TableScript = TableItem<ListableScript, 'script'>
 	type TableFlow = TableItem<Flow, 'flow'>
 	type TableApp = TableItem<ListableApp, 'app'>
 	type TableRawApp = TableItem<ListableRawApp, 'raw_app'>

--- a/frontend/src/lib/components/workspacePicker.ts
+++ b/frontend/src/lib/components/workspacePicker.ts
@@ -1,4 +1,4 @@
-import type { Flow, ListableApp, Script } from '$lib/gen'
+import type { Flow, ListableApp, ListableScript } from '$lib/gen'
 
 export type WorkspaceItemKind = 'flow' | 'script' | 'app'
 
@@ -116,7 +116,7 @@ export async function loadKind(
 				includeDraftOnly: true,
 				withoutDescription: true
 			})
-			items = scripts.map((s: Script) => ({
+			items = scripts.map((s: ListableScript) => ({
 				path: s.path,
 				summary: s.summary ?? '',
 				kind: 'script' as const


### PR DESCRIPTION
## Summary

`GET /w/{workspace}/scripts/list` is documented as returning the full `Script` schema, but it actually returns a lighter object (`ListableScript`) that omits heavy fields like `content`, `created_by`, `parent_hashes`, `deleted`, `is_template`, and `has_preprocessor`. The OpenAPI docs — and the generated clients — therefore over-promise fields that are never present at runtime. (#5451)

## Changes

- `windmill-api/openapi.yaml`: add a `ListableScript` schema (matching the backend `ListableScript` struct) and point the `/scripts/list` response at `ListableScript[]` instead of `Script[]`.
- Retype the `/scripts/list` consumers from `Script` to `ListableScript` (they only use the lighter fields; full-script fields elsewhere come from separate `getScriptByPath`/`getScriptByHash` fetches and are unchanged):
  `copilot/chat/global/core.ts`, `copilot/chat/shared.ts`, `copilot/StepGenQuick.svelte`, `apps/editor/settingsPanel/mainInput/WorkspaceScriptList.svelte`, `home/ItemsList.svelte`, `home/treeViewUtils.ts`, `search/GlobalSearchModal.svelte`, `workspacePicker.ts`.

## Test plan

- [ ] `cd frontend && npm run generate-backend-client && npm run check` — 0 errors
- [ ] OpenAPI docs (`openapi.html`) show `/scripts/list` returning the lighter `ListableScript` shape

## Scope

Addresses the `/scripts/list` half of #5451. `/users/list` (also flagged there) returns the shared `User` type partially populated, so accurate typing for it is a separate change (the `User` schema is shared with fully-populated responses) and is intentionally left out to keep this focused.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `/w/{workspace}/scripts/list` to return the lighter `ListableScript` type in the OpenAPI spec and generated clients, aligning docs and types with backend behavior and avoiding missing fields at runtime. Addresses #5451.

- **Bug Fixes**
  - Added `ListableScript` schema and set `/scripts/list` to return `ListableScript[]` in `openapi.yaml`.
  - Regenerated clients and retyped consumers to `ListableScript` across script lists, search, copilot, and workspace picker in `frontend` (`$lib/gen`).
  - No behavior change: full script fields still come from `getScriptByPath`/`getScriptByHash`; docs and `@gen` types now match the lighter list response.

<sup>Written for commit 196a111841617febebd35558b59c4690256e6298. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

