### PR TITLE
feat(ai-chat): wire llms.txt docs lookup tools into global chat mode

### DIFF
--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -870,3 +870,27 @@
   judgeChecklist:
     - fetches the logs for the requested job id
     - explains the failure from the returned logs (connection refused to the upstream API)
+
+- id: global-test29-docs-lookup-scheduling
+  prompt: |-
+    How do I schedule a script to run every Monday at 9am in Windmill?
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - list_docs_pages
+      - read_docs_page
+    forbiddenToolsUsed:
+      - deploy_workspace_item
+      - delete_workspace_item
+      - write_script
+  # Answering a product-docs question produces no draft, so the global judge
+  # (which only sees the drafts artifact) would score it empty — validate the
+  # docs-lookup contract via tool use: browse the index first, then read a page.
+  skipJudge: true
+  judgeChecklist:
+    - lists the documentation pages before reading one
+    - reads the scheduling documentation page rather than answering from memory
+    - cites the canonical windmill.dev/docs scheduling URL in the answer

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -2020,6 +2020,25 @@ describe('session-only preview tools gating', () => {
 	})
 })
 
+describe('documentation lookup tools', () => {
+	it('exposes list_docs_pages and read_docs_page in both the session and non-session tool sets', () => {
+		// The docs tools are read-only references, not session-preview tools, so
+		// they must be present regardless of `sessionPreview`.
+		for (const sessionPreview of [false, true]) {
+			const names = globalToolsFor({ sessionPreview }).map((t) => t.def.function.name)
+			expect(names).toContain('list_docs_pages')
+			expect(names).toContain('read_docs_page')
+		}
+	})
+
+	it('instructs the model to look up product docs and cite the Source page URL', () => {
+		const content = prepareGlobalSystemMessage().content as string
+		expect(content).toContain('list_docs_pages')
+		expect(content).toContain('read_docs_page')
+		expect(content).toContain('Source page')
+	})
+})
+
 describe('prepareGlobalUserMessage', () => {
 	it('injects the active editor reference without contents', () => {
 		__resetUserDraftForTesting()

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -74,6 +74,7 @@ import {
 } from '../shared'
 import type { ContextElement } from '../context'
 import { getDatatableTools } from '../datatableTools'
+import { listDocsPagesTool, readDocsPageTool } from '../docs/core'
 import { UserDraft, type UserDraftMeta } from '$lib/userDraft.svelte'
 import { emptySchema } from '$lib/utils'
 import { inferArgs } from '$lib/infer'
@@ -638,6 +639,12 @@ Rules:
 - After writing or substantially editing a script / flow / app draft, show it via open_preview(kind, path) so the user sees the editor and live preview right next to the chat. First check whether it is already shown: if unsure, call get_preview_status. Only call open_preview (or offer to) when no preview is open or it is showing a different item — don't re-open a preview already showing the item you just edited.`
 		: ''
 	}
+
+Documentation:
+- To answer questions about Windmill product features, concepts, or syntax, look them up in the official docs with list_docs_pages and read_docs_page rather than relying on memory.
+- Call list_docs_pages FIRST to see the full index of documentation pages with their titles, URLs and descriptions. Then call read_docs_page on the 1 to 3 most relevant pages. If read_docs_page returns a list of section headings instead of the full page, call it again with the same path and a \`section\` argument to read the relevant section.
+- Base documentation answers ONLY on what you read. Do not invent features, flags, syntax, or behavior you did not see in the docs.
+- When you cite a docs page, use the exact "Source page" URL printed at the top of each read_docs_page result — never reconstruct a URL from a link inside the page body. If the docs do not cover the question, say so rather than inventing an answer.
 
 Flows:
 - read_workspace_item returns compact flow JSON. Inline script bodies appear as "inline_script.<moduleId>".
@@ -1469,6 +1476,8 @@ export const globalTools: Tool<{}>[] = [
 		}
 	},
 	createSearchHubScriptsTool(false),
+	listDocsPagesTool,
+	readDocsPageTool,
 	{
 		def: createToolDef(
 			askUserQuestionSchema,


### PR DESCRIPTION
## Summary

The GLOBAL mode of the Windmill AI chat (the workspace-level assistant) previously had no way to look up product documentation — it could author scripts/flows and search hub scripts, but had no docs-lookup tool. This PR gives it the two self-hosted llms.txt documentation tools (`list_docs_pages` / `read_docs_page`) that already exist and are wired into ASK mode, so the workspace assistant can answer product questions from the official windmill.dev docs and cite canonical URLs instead of relying on the model's memory.

These tools run client-side and fetch directly from `windmill.dev` (the docs index `llms.txt` and individual `/docs/*.md` pages); they do not use the external Inkeep RAG service. No backend, ASK-mode, or Inkeep behavior is changed.

> This PR is stacked on top of [#9578](https://github.com/windmill-labs/windmill/pull/9578) (`custom-ai-docs-tool`), which adds and tests the shared docs tools. Its base is set to `custom-ai-docs-tool` so the diff is scoped to just this change; GitHub will auto-retarget it to `main` once #9578 merges.

## Changes

- **`frontend/.../chat/global/core.ts`**
  - Import `listDocsPagesTool` / `readDocsPageTool` from `../docs/core` and add them to the `globalTools` array, next to the other read-only reference tools (after `createSearchHubScriptsTool`).
  - Add a concise **Documentation:** section to the global system prompt (`buildGlobalSystemPrompt`): call `list_docs_pages` first, `read_docs_page` the 1–3 most relevant pages (using `section` for large pages), answer only from what was read, and cite the exact **"Source page"** URL printed at the top of each result. Mirrors `LLMSTXT_TOOL_SECTION` from ASK mode.
  - The `globalToolsFor()` SESSION_PREVIEW filter only excludes `open_preview`/`get_preview_status`, so the new tools are included in both the session and non-session tool sets — no filter change required.
- **`frontend/.../chat/global/core.test.ts`** — new `describe('documentation lookup tools')` asserting the tools appear in both `globalToolsFor` variants and that the system prompt mentions them and the "Source page" citation rule.
- **`ai_evals/cases/global.yaml`** — new no-draft case `global-test29-docs-lookup-scheduling` validating the docs-lookup contract via tool use (`requiredToolsUsed: [list_docs_pages, read_docs_page]`, `skipJudge: true`), following the existing read-only-tool conventions.

## Test plan

- [x] Verified live in a browser (chrome-devtools MCP) against the global chat in Global mode with `claude-sonnet-4-6`. Asked: *"How do I schedule a script to run every Monday at 9am?"* The assistant called both tools and the network tab showed the real fetches:
  - `GET https://www.windmill.dev/llms.txt` → 200 (`list_docs_pages`)
  - `GET https://www.windmill.dev/docs/core_concepts/scheduling.md` → 200 (`read_docs_page`)
  - The answer used Windmill's extended cron syntax (`0 0 9 * * MON`) and cited the canonical URL `https://www.windmill.dev/docs/core_concepts/scheduling`.
- [ ] `npm run check` (frontend type-check) — run by maintainer per repo convention.
- [ ] `vitest` on `global/core.test.ts` — the new `documentation lookup tools` block is deterministic (no network).
- [ ] `ai_evals` global benchmark `global-test29-docs-lookup-scheduling` (requires live `windmill.dev` access at run time, same as the ASK-mode docs tools).