### PR TITLE
fix(auth): add scope checks to scripts/flows list_tokens endpoints

### DIFF
--- a/backend/windmill-api-flows/src/flows.rs
+++ b/backend/windmill-api-flows/src/flows.rs
@@ -1358,10 +1358,12 @@ async fn update_flow(
 }
 
 async fn list_tokens(
+    authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Path((w_id, path)): Path<(String, StripPath)>,
 ) -> JsonResult<Vec<TruncatedTokenWithEmail>> {
     let path = path.to_path();
+    check_scopes(&authed, || format!("flows:read:{}", path))?;
     list_tokens_internal(&db, &w_id, &path, true).await
 }
 

--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -1828,10 +1828,12 @@ async fn get_script_by_path(
 }
 
 async fn list_tokens(
+    authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Path((w_id, path)): Path<(String, StripPath)>,
 ) -> JsonResult<Vec<TruncatedTokenWithEmail>> {
     let path = path.to_path();
+    check_scopes(&authed, || format!("scripts:read:{}", path))?;
     list_tokens_internal(&db, &w_id, &path, false).await
 }
 


### PR DESCRIPTION
## Problem

The `list_tokens` handlers in `scripts.rs` and `flows.rs` did not extract `ApiAuthed` or call `check_scopes` — they accepted only the raw `DB` pool. Any authenticated token for the workspace, regardless of its scope restrictions, could enumerate token metadata (label, prefix, scopes, owner email, timestamps) for any script or flow path. This bypassed the path-scoped read checks correctly enforced by sibling endpoints like `get_script_by_path` and `get_flow_by_path`.

`list_tokens_internal` queries the `token` table, which is not subject to the workspace RLS that governs script/flow visibility, so the missing `check_scopes` call was the actual gap.

## Fix

Both handlers now extract `authed: ApiAuthed` and call `check_scopes` before querying:

- `backend/windmill-api-scripts/src/scripts.rs` — `check_scopes(&authed, || format!("scripts:read:{}", path))?;` (mirrors `get_script_history`)
- `backend/windmill-api-flows/src/flows.rs` — `check_scopes(&authed, || format!("flows:read:{}", path))?;` (mirrors `get_flow_by_path`)

## Validation

- Backend compiles cleanly under `cargo watch` and starts (health check healthy).
- Manual end-to-end against the running backend:
  - Created a token scoped only to `jobs:run:scripts`.
  - `GET /api/w/admins/scripts/list_tokens/u/admin/hub_sync` → **403** with the scoped token (`Required scope: scripts:read`), **200** with the admin token.
  - `GET /api/w/admins/flows/list_tokens/...` → **403** with the scoped token (`Required scope: flows:read`), **200** with the admin token.

## Note

Kept the raw `db` pool (rather than switching to `user_db`) since `list_tokens_internal` queries the `token` table directly; the `check_scopes` call is the critical and sufficient fix here.

Fixes WIN-2047

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added missing scope checks to scripts/flows `list_tokens` endpoints to enforce path-based read permissions. Prevents tokens without `scripts:read:<path>` or `flows:read:<path>` from enumerating token metadata. Fixes WIN-2047.

- **Bug Fixes**
  - Extract `ApiAuthed` and call `check_scopes` with `scripts:read:<path>` / `flows:read:<path>` before querying.
  - Aligns `list_tokens` with `get_script_by_path` and `get_flow_by_path` to close a read-bypass on token listing.

<sup>Written for commit 2db16f1828a44413f76250026816cd96b686644c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

