### PR TITLE
fix(flows): stop serializing default retry/stop_after_if fields (WIN-2048)

### DIFF
--- a/backend/windmill-types/src/flows.rs
+++ b/backend/windmill-types/src/flows.rs
@@ -322,6 +322,7 @@ impl Step {
 pub struct StopAfterIf {
     pub expr: String,
     pub skip_if_stopped: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
     /// When stopping with an error (`error_message` set), embed the stopping
     /// step's own result inside the raised error object (as `error.result`)
@@ -338,7 +339,9 @@ pub struct RetryIf {
 #[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq)]
 #[serde(default)]
 pub struct Retry {
+    #[serde(skip_serializing_if = "is_default")]
     pub constant: ConstantDelay,
+    #[serde(skip_serializing_if = "is_default")]
     pub exponential: ExponentialDelay,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_if: Option<RetryIf>,
@@ -1280,5 +1283,48 @@ mod tests {
 
         let output = serde_json::to_string(&val).unwrap();
         assert!(!output.contains("tag"));
+    }
+
+    #[test]
+    fn retry_omits_default_constant_and_exponential() {
+        // A constant-only retry must not materialize a default exponential block
+        // on serialization (and vice-versa). Round-trips through Retry used to
+        // emit seconds:0 / random_factor:null, which the CLI linter rejected.
+        let input = json!({ "constant": { "attempts": 1, "seconds": 60 } });
+        let retry: Retry = serde_json::from_value(input).unwrap();
+
+        // Deserialization still fills in defaults in memory.
+        assert_eq!(retry.exponential, ExponentialDelay::default());
+
+        let output = serde_json::to_value(&retry).unwrap();
+        assert!(output.get("constant").is_some());
+        assert!(output.get("exponential").is_none());
+
+        // A fully-default retry serializes to an empty object.
+        let empty = serde_json::to_value(&Retry::default()).unwrap();
+        assert_eq!(empty, json!({}));
+    }
+
+    #[test]
+    fn stop_after_if_omits_null_error_message() {
+        let input = json!({ "expr": "result == 404", "skip_if_stopped": true });
+        let stop: StopAfterIf = serde_json::from_value(input).unwrap();
+        assert!(stop.error_message.is_none());
+
+        let output = serde_json::to_value(&stop).unwrap();
+        assert!(output.get("error_message").is_none());
+
+        // A set error message still round-trips.
+        let with_msg = StopAfterIf {
+            expr: "true".to_string(),
+            skip_if_stopped: false,
+            error_message: Some("boom".to_string()),
+            error_include_result: false,
+        };
+        let output = serde_json::to_value(&with_msg).unwrap();
+        assert_eq!(
+            output.get("error_message").and_then(|v| v.as_str()),
+            Some("boom")
+        );
     }
 }


### PR DESCRIPTION
## Problem

`wmill pull` produced flow YAML containing redundant default fields. For a module with a **constant-only** retry and a `stop_after_if` without an error message, pull restored:

```yaml
retry:
  constant: { attempts: 1, seconds: 60 }
  exponential: { attempts: 0, multiplier: 1, random_factor: null, seconds: 0 }  # never configured
stop_after_if:
  error_message: null   # never set
  expr: result == 404
  skip_if_stopped: true
```

The frontend stores a constant-only retry as exactly `{ constant: {...} }` (no `exponential`). But `Retry.constant`/`Retry.exponential` are **non-`Option`** fields with `#[serde(default)]`, and `StopAfterIf.error_message` is an `Option` with no `skip_serializing_if`. So any re-serialisation through these structs — notably the **dependency/lock job**, which deserialises and re-writes the flow value — materialised a full default `exponential` block (`seconds: 0`, `random_factor: null`) and a `null` `error_message`, baking them into stored data and surfacing them on every pull.

## Fix

In `backend/windmill-types/src/flows.rs`:
- skip-serialise `Retry.constant` / `Retry.exponential` when equal to their default (reusing `more_serde::is_default`);
- skip-serialise `StopAfterIf.error_message` when `None`.

Deserialisation is unchanged (`#[serde(default)]` refills the in-memory structs), so the worker retry logic and the frontend (which already optional-chains these fields) are unaffected.

## Validation

- `cargo test -p windmill-types --lib flows::tests` → 8 passed, incl. 2 new tests (`retry_omits_default_constant_and_exponential`, `stop_after_if_omits_null_error_message`).
- End-to-end against a running backend: a flow created **with** an explicit default `exponential` block + `error_message: null` comes back **clean** after its dependency/lock job re-serialises the value.
- Flow behaviour tests (`tests/retry.rs`) fail identically with and without this change — the failures are pre-existing/environmental (sandboxed deno step can't reach the test's host HTTP callback on this devbox), not caused by the serde change.

## Related

The linter side of WIN-2048 — making `wmill push --lint` accept these values (which still legitimately appear on configured exponential retries with no jitter, and on already-stored flows that predate this fix) — is split into a separate PR: #9594.

Fixes WIN-2048

🤖 Generated with [Claude Code](https://claude.com/claude-code)