### PR TITLE
fix(frontend): restore flow graph pane height in editor

### DIFF
--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -1070,7 +1070,7 @@
 		<ScriptEditorDrawer bind:this={$scriptEditorDrawer} />
 		<FlowEditorDrawer bind:this={$flowEditorDrawer} />
 
-		<div bind:this={flowBuilderRoot} class="flex flex-col flex-1 h-screen">
+		<div bind:this={flowBuilderRoot} class="flex flex-col h-screen">
 			<!-- Nav between steps-->
 			<div
 				bind:clientWidth={topbarWidth}


### PR DESCRIPTION
## Summary

The flow editor graph pane collapsed to height 0 (the left `Splitpanes` pane had `height: 0` while its sibling and the container were full height), hiding the flow graph. This restores the graph to fill the editor height.

## Root cause

`FlowBuilder`'s root div used `flex flex-col flex-1 h-screen`. The `flex-1` (`flex: 1 1 0%`) sets `flex-basis: 0%`, which **overrides** `h-screen` (`height: 100vh`) for main-axis sizing — so the div's height came from flex-grow (an *indefinite* height) rather than the `100vh` anchor.

Every descendant down to the graph relies on `height: 100%` (`#flow-editor` `h-full` → `.splitpanes` `height: 100%` → left `Pane` `h-full`), and `height: 100%` only resolves against a *definite* parent height. With the anchor neutralized, the whole chain collapsed to 0. The right pane survived only because its settings form is intrinsically tall (content-sized via flex `stretch`, which doesn't need a definite parent).

The `flex-1` was inert until the AIChat layout unification (`cbba8297cd`) wrapped `FlowBuilder` inside `AiChatLayout`'s `flex flex-col` column, which activated it.

## Changes

- `frontend/src/lib/components/FlowBuilder.svelte`: drop `flex-1` from the root div (`flex flex-col flex-1 h-screen` → `flex flex-col h-screen`), matching the working `ScriptBuilder.svelte` pattern used in the same `AiChatLayout`. With `flex-basis: auto`, `h-screen` is the definite height anchor the percentage chain needs.

## Screenshots

![flow-graph-fixed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-flow-graph-pane-height/1781531345-flow-graph-fixed.png)

## Test plan

- [ ] Open a flow at `/flows/edit/<path>` and confirm the graph pane fills the editor height
- [ ] Toggle the AI chat pane open/closed and confirm the splitpanes graph still sizes correctly
- [ ] Open a flow in a session view (AI disabled path) and confirm the editor fills its pane
- [ ] Confirm the script editor (shares `AiChatLayout`) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where the flow editor’s graph pane collapsed to 0 height. Removes `flex-1` from the `FlowBuilder` root so `h-screen` sets a definite height and the graph fills the editor, matching `ScriptBuilder` behavior.

<sup>Written for commit b6af92a64596c419aaccc28d9d439ded9c75278f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

