### PR TITLE
feat(frontend): add user-level toggle to disable Windmill AI

### DIFF
--- a/frontend/src/lib/aiStore.ts
+++ b/frontend/src/lib/aiStore.ts
@@ -2,6 +2,7 @@ import { writable, get } from 'svelte/store'
 import { workspaceAIClients } from './components/copilot/lib'
 import { type AIProviderModel, type AIProvider, WorkspaceService, type AIConfig } from './gen'
 import {
+	aiUserDisabled,
 	COPILOT_SESSION_MODEL_SETTING_NAME,
 	COPILOT_SESSION_PROVIDER_SETTING_NAME,
 	COPILOT_SESSION_REASONING_SETTING_NAME
@@ -47,6 +48,15 @@ export const copilotInfo = writable<{
 	customPrompts: {},
 	maxTokensPerModel: {},
 	webSearchEnabledProviders: {}
+})
+
+// Apply the per-user opt-out live: toggling it flips `enabled` without re-fetching.
+// Only enable when providers exist (aiModels is populated whenever the config has any).
+aiUserDisabled.subscribe((disabled) => {
+	copilotInfo.update((info) => ({
+		...info,
+		enabled: info.aiModels.length > 0 && !disabled
+	}))
 })
 
 /** Strip the deprecated /thinking suffix from a configured model slot, if present. */
@@ -107,7 +117,8 @@ export function setCopilotInfo(aiConfig: AIConfig) {
 		})
 
 		copilotInfo.set({
-			enabled: true,
+			// Providers are configured; the per-user opt-out is the only thing that can gate it off.
+			enabled: !get(aiUserDisabled),
 			// Strip the deprecated /thinking suffix from the configured model slots too,
 			// otherwise a workspace whose default still carries it sends an invalid model id.
 			codeCompletionModel: stripModelSuffix(aiConfig.code_completion_model),

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -1981,7 +1981,7 @@
 		$copilotInfo.enabled && initialized && editor && untrack(() => editor && addChatHandler(editor))
 	})
 	$effect(() => {
-		!$codeCompletionSessionEnabled && autocompletor?.dispose()
+		;(!$codeCompletionSessionEnabled || !$copilotInfo.enabled) && autocompletor?.dispose()
 	})
 	$effect(() => {
 		if (yContent && awareness && model && editor) {

--- a/frontend/src/lib/components/copilot/chat/AIButton.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIButton.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { base } from '$lib/base'
 	import { copilotInfo } from '$lib/aiStore'
+	import { aiUserDisabled } from '$lib/stores'
 	import Popover from '$lib/components/meltComponents/Popover.svelte'
 	import DarkPopover from '$lib/components/Popover.svelte'
 	import { ExternalLink, WandSparkles } from 'lucide-svelte'
@@ -36,14 +37,18 @@
 		{/snippet}
 		{#snippet content()}
 			<div class="block text-primary p-4">
-				<p class="text-sm"
-					>Enable Windmill AI in the <a
-						href="{base}/workspace_settings?tab=ai"
-						target="_blank"
-						class="inline-flex flex-row items-center gap-1"
-						>workspace settings <ExternalLink size={16} /></a
-					></p
-				>
+				{#if $aiUserDisabled}
+					<p class="text-sm">Windmill AI is disabled in your account settings.</p>
+				{:else}
+					<p class="text-sm"
+						>Enable Windmill AI in the <a
+							href="{base}/workspace_settings?tab=ai"
+							target="_blank"
+							class="inline-flex flex-row items-center gap-1"
+							>workspace settings <ExternalLink size={16} /></a
+						></p
+					>
+				{/if}
 			</div>
 		{/snippet}
 	</Popover>

--- a/frontend/src/lib/components/copilot/chat/AIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChat.svelte
@@ -2,7 +2,7 @@
 	import AIChatDisplay from './AIChatDisplay.svelte'
 	import { untrack } from 'svelte'
 	import { type ScriptLang } from '$lib/gen'
-	import { dbSchemas, userStore, workspaceStore } from '$lib/stores'
+	import { aiUserDisabled, dbSchemas, userStore, workspaceStore } from '$lib/stores'
 	import { AIMode } from './AIChatManager.svelte'
 	import { getAiChatManager } from './aiChatManagerContext'
 
@@ -50,9 +50,11 @@
 		forceDisabled
 			? forceDisabledMessage
 			: !hasCopilot
-				? isAdmin
-					? `Enable Windmill AI in your [workspace settings](${base}/workspace_settings?tab=ai) to use this chat`
-					: 'Ask an admin to enable Windmill AI in this workspace to use this chat'
+				? $aiUserDisabled
+					? 'Windmill AI is disabled in your account settings'
+					: isAdmin
+						? `Enable Windmill AI in your [workspace settings](${base}/workspace_settings?tab=ai) to use this chat`
+						: 'Ask an admin to enable Windmill AI in this workspace to use this chat'
 				: aiChatManager.mode === AIMode.SCRIPT &&
 					  aiChatManager.scriptEditorOptions?.lang &&
 					  !SUPPORTED_CHAT_SCRIPT_LANGUAGES.includes(aiChatManager.scriptEditorOptions.lang)

--- a/frontend/src/lib/components/sessions/SessionPicker.svelte
+++ b/frontend/src/lib/components/sessions/SessionPicker.svelte
@@ -46,6 +46,7 @@
 	import DropdownV2 from '$lib/components/DropdownV2.svelte'
 	import { visibleWorkspaceIds } from './sessionScope.svelte'
 	import { isGlobalAiEnabled } from '$lib/components/copilot/chat/global/gate'
+	import { copilotInfo } from '$lib/aiStore'
 	import { userWorkspaces, usersWorkspaceStore, workspaceStore } from '$lib/stores'
 	import { WorkspaceService } from '$lib/gen'
 	import { sendUserToast } from '$lib/toast'
@@ -317,8 +318,9 @@
 	)
 </script>
 
-{#if !globalEnabled}
-	<!-- Sessions hidden until the global-ai dev gate is enabled. -->
+{#if !globalEnabled || !$copilotInfo.enabled}
+	<!-- Sessions hidden until the global-ai dev gate is enabled, and whenever AI is
+	     unavailable (no provider configured or disabled in the user's AI settings). -->
 {:else if isCollapsed}
 	<div class="px-2 pt-3 pb-2 border-b border-light dark:border-gray-700">
 		<Menubar>

--- a/frontend/src/lib/components/settings/AIUserSettings.svelte
+++ b/frontend/src/lib/components/settings/AIUserSettings.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import {
+		AI_USER_DISABLED_SETTING_NAME,
+		aiUserDisabled,
 		codeCompletionSessionEnabled,
 		metadataCompletionEnabled,
 		stepInputCompletionEnabled
@@ -14,6 +16,7 @@
 	})
 
 	function loadSettings() {
+		$aiUserDisabled = (getLocalSetting(AI_USER_DISABLED_SETTING_NAME) ?? 'false') == 'true'
 		$codeCompletionSessionEnabled =
 			(getLocalSetting('codeCompletionSessionEnabled') ?? 'true') == 'true'
 		$metadataCompletionEnabled = (getLocalSetting('metadataCompletionEnabled') ?? 'true') == 'true'
@@ -25,6 +28,12 @@
 		store.set(value)
 		storeLocalSetting(setting, value.toString())
 	}
+
+	// The toggle reads as enablement; the stored flag is the inverse (opt-out).
+	function updateAiEnabled(enabled: boolean) {
+		$aiUserDisabled = !enabled
+		storeLocalSetting(AI_USER_DISABLED_SETTING_NAME, (!enabled).toString())
+	}
 </script>
 
 <div class="border border-border-light rounded-md p-4 h-full">
@@ -33,35 +42,52 @@
 	<div class="flex flex-col gap-4">
 		<Toggle
 			on:change={(e) => {
-				updateSetting(codeCompletionSessionEnabled, e.detail, 'codeCompletionSessionEnabled')
+				updateAiEnabled(e.detail)
 			}}
-			checked={$codeCompletionSessionEnabled}
+			checked={!$aiUserDisabled}
 			options={{
-				right: 'Code completion',
-				rightTooltip: 'AI completion in the code editors'
+				right: 'Windmill AI',
+				rightTooltip:
+					'Enable Windmill AI for your account on this device. Turning this off hides the AI chat, code completion, metadata completion and flow step input completion.'
 			}}
 		/>
 
-		<Toggle
-			on:change={(e) => {
-				updateSetting(metadataCompletionEnabled, e.detail, 'metadataCompletionEnabled')
-			}}
-			checked={$metadataCompletionEnabled}
-			options={{
-				right: 'Metadata completion',
-				rightTooltip: 'AI completion for summaries and descriptions'
-			}}
-		/>
-		<Toggle
-			on:change={(e) => {
-				updateSetting(stepInputCompletionEnabled, e.detail, 'stepInputCompletionEnabled')
-			}}
-			checked={$stepInputCompletionEnabled}
-			options={{
-				right: 'Flow step input completion',
-				rightTooltip: 'AI completion for flow step inputs'
-			}}
-		/>
+		<div class="flex flex-col gap-4 pl-2 border-l border-border-light">
+			<Toggle
+				disabled={$aiUserDisabled}
+				on:change={(e) => {
+					updateSetting(codeCompletionSessionEnabled, e.detail, 'codeCompletionSessionEnabled')
+				}}
+				checked={$codeCompletionSessionEnabled}
+				options={{
+					right: 'Code completion',
+					rightTooltip: 'AI completion in the code editors'
+				}}
+			/>
+
+			<Toggle
+				disabled={$aiUserDisabled}
+				on:change={(e) => {
+					updateSetting(metadataCompletionEnabled, e.detail, 'metadataCompletionEnabled')
+				}}
+				checked={$metadataCompletionEnabled}
+				options={{
+					right: 'Metadata completion',
+					rightTooltip: 'AI completion for summaries and descriptions'
+				}}
+			/>
+			<Toggle
+				disabled={$aiUserDisabled}
+				on:change={(e) => {
+					updateSetting(stepInputCompletionEnabled, e.detail, 'stepInputCompletionEnabled')
+				}}
+				checked={$stepInputCompletionEnabled}
+				options={{
+					right: 'Flow step input completion',
+					rightTooltip: 'AI completion for flow step inputs'
+				}}
+			/>
+		</div>
 	</div>
 
 	<UserAIPromptsSettings />

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -130,6 +130,13 @@ export const codeCompletionSessionEnabled = writable<boolean>(
 	getLocalSetting(CODE_COMPLETION_SETTING_NAME) != 'false'
 )
 
+export const AI_USER_DISABLED_SETTING_NAME = 'aiUserDisabled'
+// Master per-user (per-device) opt-out for all Windmill AI features. Initialized at
+// module load so it applies on startup, not only once the settings panel mounts.
+export const aiUserDisabled = writable<boolean>(
+	getLocalSetting(AI_USER_DISABLED_SETTING_NAME) === 'true'
+)
+
 export const usedTriggerKinds = writable<string[]>([])
 
 export let globalDbManagerDrawer: StateStore<DbManagerUriState | undefined> = { val: undefined }


### PR DESCRIPTION
## Summary

Adds a per-user master toggle to disable Windmill AI from the **AI user settings** panel (account settings). When turned off, it hides all AI surfaces — the AI chat panel/button, code completion, metadata completion, flow step input completion, and the AI Sessions sidebar section — by folding into the single `copilotInfo.enabled` gate that those surfaces already read.

The preference is **frontend-only, stored in `localStorage`** (per-device), matching the three existing AI user toggles in the same panel. It hides AI client-side; it does not block the `/ai/proxy` endpoint server-side.

## Changes

- **`stores.ts`** — new `aiUserDisabled` writable + `AI_USER_DISABLED_SETTING_NAME`, initialized from `localStorage` at module load so the opt-out applies on startup (not only once the settings panel mounts).
- **`aiStore.ts`** — `setCopilotInfo` sets `enabled: !get(aiUserDisabled)` when providers are configured; an `aiUserDisabled.subscribe(...)` flips `copilotInfo.enabled` live on toggle without re-fetching.
- **`AIUserSettings.svelte`** — master **"Windmill AI"** toggle at the top of the panel; the three feature sub-toggles are moved into an indented, left-bordered group and rendered `disabled` (greyed) while the master is off.
- **`AIButton.svelte` / `AIChat.svelte`** — when AI is off because the user disabled it, the empty-state reads "Windmill AI is disabled in your account settings" instead of the misleading "enable in workspace settings".
- **`Editor.svelte`** — the inline code-completion provider is now disposed when `copilotInfo.enabled` goes false (previously only on `!codeCompletionSessionEnabled`), so completions stop firing immediately when the master toggle is flipped off mid-session.
- **`SessionPicker.svelte`** — the AI Sessions sidebar section is hidden when `copilotInfo.enabled` is false (AI disabled or no provider configured). The "Ask AI" button is intentionally kept.

## Screenshots

| AI enabled (default) | AI disabled (sub-toggles greyed, chat disabled) | Persisted across reload |
| --- | --- | --- |
| ![ai-toggle-on](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/disable-ai-user-toggle/1781531765-ai-toggle-on.png) | ![ai-toggle-off](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/disable-ai-user-toggle/1781531765-ai-toggle-off.png) | ![ai-disabled-reload](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/disable-ai-user-toggle/1781531765-ai-disabled-reload.png) |

AI disabled — AI Sessions sidebar section hidden, **Ask AI** button kept:

![ai-sessions-hidden-sidebar](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/disable-ai-user-toggle/1781544868-ai-sessions-hidden-sidebar.png)

## Test plan

- [ ] Open user AI settings with AI configured → AI chat panel and the three sub-toggles are active.
- [ ] Turn **Windmill AI** off → sub-toggles grey out, AI chat input/Send disabled with "disabled in your account settings" message, and the AI Sessions sidebar section disappears (Ask AI button stays) — all live, without reload.
- [ ] In a script editor with code completion attached, flip the master toggle off → inline completions stop firing without leaving the editor.
- [ ] Reload the page with the toggle off → AI stays gated from startup and the account-settings message persists.
- [ ] Turn it back on → chat, completion, metadata, step-input AI, and the AI Sessions section all return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)