### PR TITLE
fix: expose parent_hash in MCP createScript tool for updates

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -8014,9 +8014,10 @@ paths:
         Creates a new version of an existing script when called with the same path and the current `parent_hash`.
       operationId: createScript
       x-mcp-tool: true
-      x-mcp-instructions: "To create a script, specify the path (e.g., 'f/my_folder/my_script'), the content (source code), and the language. For TypeScript, use 'bun' unless deno-specific APIs are needed."
+      x-mcp-instructions: "To create a NEW script, specify the path (e.g., 'f/my_folder/my_script'), the content (source code), and the language, and leave parent_hash unset. For TypeScript, use 'bun' unless deno-specific APIs are needed. To UPDATE an existing script, do NOT delete and recreate it: call this tool with the same path and set parent_hash to the script's current hash, which you can read from the `hash` field returned by getScriptByPath. This creates a new version while preserving the script's history."
       x-mcp-tool-include-fields:
         - path
+        - parent_hash
         - content
         - language
         - summary

--- a/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
+++ b/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
@@ -593,7 +593,7 @@ pub fn all_tools() -> Vec<EndpointTool> {
         name: Cow::Borrowed("createScript"),
         description: Cow::Borrowed("create script: Creates a new script when the path does not already exist.
 Creates a new version of an existing script when called with the same path and the current `parent_hash`"),
-        instructions: Cow::Borrowed("To create a script, specify the path (e.g., 'f/my_folder/my_script'), the content (source code), and the language. For TypeScript, use 'bun' unless deno-specific APIs are needed."),
+        instructions: Cow::Borrowed("To create a NEW script, specify the path (e.g., 'f/my_folder/my_script'), the content (source code), and the language, and leave parent_hash unset. For TypeScript, use 'bun' unless deno-specific APIs are needed. To UPDATE an existing script, do NOT delete and recreate it: call this tool with the same path and set parent_hash to the script's current hash, which you can read from the `hash` field returned by getScriptByPath. This creates a new version while preserving the script's history."),
         path: Cow::Borrowed("/w/{workspace}/scripts/create"),
         method: Cow::Borrowed("POST"),
         path_params_schema: None,
@@ -602,6 +602,9 @@ Creates a new version of an existing script when called with the same path and t
         "type": "object",
         "properties": {
                 "path": {
+                        "type": "string"
+                },
+                "parent_hash": {
                         "type": "string"
                 },
                 "summary": {

--- a/frontend/src/lib/mcpEndpointTools.ts
+++ b/frontend/src/lib/mcpEndpointTools.ts
@@ -602,7 +602,7 @@ export const mcpEndpointTools: EndpointTool[] = [
     {
         name: "createScript",
         description: "create script: Creates a new script when the path does not already exist.\nCreates a new version of an existing script when called with the same path and the current `parent_hash`",
-        instructions: "To create a script, specify the path (e.g., 'f/my_folder/my_script'), the content (source code), and the language. For TypeScript, use 'bun' unless deno-specific APIs are needed.",
+        instructions: "To create a NEW script, specify the path (e.g., 'f/my_folder/my_script'), the content (source code), and the language, and leave parent_hash unset. For TypeScript, use 'bun' unless deno-specific APIs are needed. To UPDATE an existing script, do NOT delete and recreate it: call this tool with the same path and set parent_hash to the script's current hash, which you can read from the `hash` field returned by getScriptByPath. This creates a new version while preserving the script's history.",
         path: "/w/{workspace}/scripts/create",
         method: "POST",
         pathParamsSchema: undefined,
@@ -611,6 +611,9 @@ export const mcpEndpointTools: EndpointTool[] = [
         "type": "object",
         "properties": {
                 "path": {
+                        "type": "string"
+                },
+                "parent_hash": {
                         "type": "string"
                 },
                 "summary": {


### PR DESCRIPTION
## Summary

The Windmill MCP exposes a single `createScript` tool (`POST /scripts/create`) for both creating and updating scripts. The API creates a *new version* of an existing script when called with the same `path` plus the current `parent_hash` — and the tool description says so. But the tool's input schema (built from the `x-mcp-tool-include-fields` whitelist in `openapi.yaml`) **omitted `parent_hash`**, so an AI assistant was told it needed `parent_hash` to update yet had no field to supply it. The result: assistants concluded updating was impossible and fell back to **deleting and recreating** scripts (losing version history). The hash was also undiscoverable from the tool list since endpoint tools carry no output schema.

This PR exposes `parent_hash` on the `createScript` tool and rewrites its instructions to direct the assistant to read the current `hash` from `getScriptByPath` and pass it as `parent_hash` to update in place.

## Changes

- `backend/windmill-api/openapi.yaml` (source of truth):
  - Add `parent_hash` to `createScript`'s `x-mcp-tool-include-fields`.
  - Rewrite `x-mcp-instructions`: omit `parent_hash` to create a new script; to update an existing one, read its current `hash` via `getScriptByPath` and pass it as `parent_hash` — explicitly "do NOT delete and recreate."
- `backend/windmill-api/src/mcp/auto_generated_endpoints.rs` (generated): mirror the two `createScript` hunks (`parent_hash` body field + instructions).
- `frontend/src/lib/mcpEndpointTools.ts` (generated): same two `createScript` hunks.

The two generated files are produced from `openapi.yaml` by `generate_mcp_tools.py`. The committed copies had pre-existing drift from the spec (unrelated fields from earlier commits that never regenerated), so only the two `createScript` hunks were applied by hand to keep the diff focused. The hunks match exactly what a full regeneration would emit (`parent_hash` is optional in `NewScript`, positioned between `path` and `summary`, and absent from `required`).

### Why no backend handler change
`/scripts/create` already implements parent-hash-based versioning; this PR only exposes an already-supported parameter to the MCP tool surface. Verified the runtime path: `build_request_body` forwards any body-schema property present in args, so `parent_hash` now reaches the create endpoint. The read path is robust too — `hash` is the 2nd field of the serialized `Script` struct (before `content`), so it survives the 25k-token MCP tool-result truncation even for large scripts.

### No visible UI effect
The changed `frontend/` file is generated data consumed by `McpScopeSelector.svelte`, which renders only each tool's `name`/`description`/`method` — not `instructions` or `bodySchema`. `createScript` was already listed there, so there is no UI delta to screenshot.

## Test plan

- [x] `cargo check -p windmill-api --features mcp` passes (the `mcp` module is feature-gated; the dev backend runs without it).
- [ ] Call `createScript` via MCP with a new `path` and no `parent_hash` → a new script is created.
- [ ] Read an existing script's `hash` via `getScriptByPath`, then call `createScript` with the same `path` and that `parent_hash` → a new version is created (history preserved), not a conflict or duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)