### PR TITLE
fix(security): sandbox the PowerShell module install step under nsjail

### DIFF
--- a/backend/windmill-worker/nsjail/install.powershell.config.proto
+++ b/backend/windmill-worker/nsjail/install.powershell.config.proto
@@ -1,0 +1,123 @@
+name: "powershell install"
+
+mode: ONCE
+hostname: "powershell"
+log_level: ERROR
+time_limit: {TIMEOUT}
+
+disable_rl: true
+
+cwd: "/tmp"
+
+clone_newnet: false
+clone_newuser: {CLONE_NEWUSER}
+
+skip_setsid: true
+keep_caps: false
+keep_env: true
+mount_proc: true
+
+mount {
+    src: "/bin"
+    dst: "/bin"
+	is_bind: true
+}
+
+mount {
+  src: "/proc/self/fd"
+  dst: "/dev/fd"
+  is_symlink: true
+  mandatory: false
+}
+
+mount {
+    src: "/opt/microsoft"
+    dst: "/opt/microsoft"
+	is_bind: true
+}
+
+mount {
+    src: "/lib"
+    dst: "/lib"
+	is_bind: true
+}
+
+
+mount {
+    src: "/lib64"
+    dst: "/lib64"
+	is_bind: true
+    mandatory: false
+}
+
+
+mount {
+    src: "/usr"
+    dst: "/usr"
+	is_bind: true
+}
+
+mount {
+	src: "/dev/null"
+	dst: "/dev/null"
+	is_bind: true
+	rw: true
+}
+
+{TMP_MOUNT_BLOCK}
+
+mount {
+    src: "/etc"
+    dst: "/etc"
+	is_bind: true
+}
+
+# Container runtimes bind exactly these 3 files as separate submounts over
+# /etc; nsjail's ro remount of /etc is non-recursive so they stay writable.
+# Load-bearing -- do not remove as redundant with the /etc bind above.
+mount {
+    src: "/etc/resolv.conf"
+    dst: "/etc/resolv.conf"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hosts"
+    dst: "/etc/hosts"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/etc/hostname"
+    dst: "/etc/hostname"
+    is_bind: true
+    mandatory: false
+}
+
+mount {
+    src: "/dev/random"
+    dst: "/dev/random"
+    is_bind: true
+}
+
+mount {
+    src: "/dev/urandom"
+    dst: "/dev/urandom"
+    is_bind: true
+}
+
+iface_no_lo: true
+
+# Writable, unlike the run step: the install step downloads modules into the
+# shared PowerShell cache here.
+mount {
+    src: "{CACHE_DIR}"
+    dst: "{CACHE_DIR}"
+    is_bind: true
+    rw: true
+    mandatory: false
+}
+
+envar: "HOME=/tmp"

--- a/backend/windmill-worker/src/pwsh_executor.rs
+++ b/backend/windmill-worker/src/pwsh_executor.rs
@@ -18,6 +18,8 @@ use crate::SYSTEM_ROOT;
 
 const NSJAIL_CONFIG_RUN_POWERSHELL_CONTENT: &str =
     include_str!("../nsjail/run.powershell.config.proto");
+const NSJAIL_CONFIG_INSTALL_POWERSHELL_CONTENT: &str =
+    include_str!("../nsjail/install.powershell.config.proto");
 
 lazy_static::lazy_static! {
     static ref RE_POWERSHELL_IMPORTS: Regex = Regex::new(r#"^\s*Import-Module\s+(?:-Name\s+)?"?([^\s"]+)"?(?:\s+-RequiredVersion\s+"?([^\s"]+)"?)?"#).unwrap();
@@ -563,12 +565,51 @@ pub async fn handle_powershell_job(
                 &powershell_repo_pat.unwrap_or_default(),
             )
             .replace("{modules}", &modules_list);
-        let mut cmd = Command::new(POWERSHELL_PATH.as_str());
-        cmd.args(&["-Command", &install_string])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+        // Sandbox the install step under nsjail when sandboxing is enabled, matching
+        // the run step. The install step previously always ran with full worker
+        // privileges; the install nsjail config mounts the module cache rw so
+        // Save-PSResource can still write to it.
+        let install_jailed = is_sandboxing_enabled();
+        let mut cmd = if install_jailed {
+            let nsjail_timeout =
+                resolve_nsjail_timeout(db, &job.workspace_id, job.id, job.timeout).await;
+            let nsjail_proto = format!("{}.pwsh_install.config.proto", job.id);
+            let config_content = NSJAIL_CONFIG_INSTALL_POWERSHELL_CONTENT
+                .replace("{CLONE_NEWUSER}", &(!*DISABLE_NUSER).to_string())
+                .replace("{CACHE_DIR}", &*POWERSHELL_CACHE_DIR)
+                .replace(
+                    "{TMP_MOUNT_BLOCK}",
+                    &resolve_nsjail_tmp_mount_block(job_dir).await,
+                )
+                .replace("{TIMEOUT}", &nsjail_timeout);
+            write_file(job_dir, &nsjail_proto, &config_content)?;
+            let mut cmd = Command::new(NSJAIL_PATH.as_str());
+            cmd.current_dir(job_dir).args(&[
+                "--config",
+                &nsjail_proto,
+                "--",
+                POWERSHELL_PATH.as_str(),
+                "-Command",
+                &install_string,
+            ]);
+            cmd
+        } else {
+            let mut cmd = Command::new(POWERSHELL_PATH.as_str());
+            cmd.args(&["-Command", &install_string]);
+            cmd
+        };
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
-        let child = start_child_process(cmd, POWERSHELL_PATH.as_str(), false).await?;
+        let child = start_child_process(
+            cmd,
+            if install_jailed {
+                NSJAIL_PATH.as_str()
+            } else {
+                POWERSHELL_PATH.as_str()
+            },
+            false,
+        )
+        .await?;
 
         handle_child(
             &job.id,


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up from the WIN-2049 audit. The PowerShell **module-install** step ran `pwsh -Command <install_string>` directly (`start_child_process`) with **no nsjail wrapping**, unlike the **run** step which gates on `is_sandboxing_enabled()`. So even on sandboxing-enabled workers, module install executed with full worker privileges. (The actual injection that made this dangerous is already fixed in #9587 — this closes the remaining "if escaping ever regressed, it'd be unsandboxed" gap.)

## Change

- New `nsjail/install.powershell.config.proto`, modeled on the proven `run.powershell.config.proto`, with two differences: the module cache (`{CACHE_DIR}`) is mounted **rw** (so `Save-PSResource` can populate it), and the per-job `main.ps1`/`wrapper.ps1`/`result*` and shared mounts are dropped (not needed for install).
- `pwsh_executor.rs`: when `is_sandboxing_enabled()`, run the install via `nsjail --config … -- pwsh -Command …` instead of spawning pwsh directly. When sandboxing is disabled, behavior is unchanged.

## Validation
- `cargo check -p windmill-worker` clean.
- Local nsjail smoke test (this devbox has nsjail + pwsh): the proto is valid, nsjail starts, pwsh launches **inside** the jail (`/proc/1` is the jailed pwsh, not host init), and a write to the rw cache mount lands on the host cache dir — confirming `Save-PSResource` will be able to write modules.

## Why draft / what's NOT validated
I could not validate end-to-end **module download from PSGallery / a private PSResource repo through the cloud tracing proxy** from this environment (no PSGallery egress here). The proto mirrors the run step's network setup (`clone_newnet: false`, `/etc` + resolv.conf bound), but actual install-through-proxy should be exercised on a real worker before merge. Specifically worth checking:
- PSGallery / `Save-PSResource` succeeds inside the jail (DNS, TLS to the proxy/registry).
- Private repo install (the `Register-PSResourceRepository` + PAT path).
- Init/periodic scripts that install modules (this gates only on `is_sandboxing_enabled()`, not `is_regular_job`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sandboxes the PowerShell module install step under `nsjail` when sandboxing is enabled, aligning it with the run step and removing an unsandboxed execution gap. Keeps the module cache writable so `Save-PSResource` continues to work.

- **Bug Fixes**
  - Added `nsjail/install.powershell.config.proto` modeled on the run config; mounts `{CACHE_DIR}` as rw and drops per-job script/result mounts.
  - Updated `pwsh_executor.rs` to run install via `nsjail` when `is_sandboxing_enabled()`; behavior unchanged when sandboxing is off.
  - Smoke tested locally (jailed `pwsh`, cache writes succeed). Please validate end-to-end installs via proxy (PSGallery and private repo) on a real worker.

<sup>Written for commit fd54cc694decf6bdcce102cca69185452e47becb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

