### PR TITLE
fix(cli): preserve committed script.lock on transient NULL lock during git-sync deploy

### DIFF
--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -2097,9 +2097,14 @@ export function preservePendingScriptLocks(
   remote: Record<string, string>,
   local: Record<string, string>,
 ): void {
+  // A multi-module script keeps its metadata in the folder layout
+  // `…__mod/script.{yaml,json}` instead of `….script.{yaml,json}`.
+  const modMeta = getModuleFolderSuffix() + SEP + "script";
   for (const metaKey of Object.keys(remote)) {
-    const isYaml = metaKey.endsWith(".script.yaml");
-    const isJson = metaKey.endsWith(".script.json");
+    const isYaml =
+      metaKey.endsWith(".script.yaml") || metaKey.endsWith(modMeta + ".yaml");
+    const isJson =
+      metaKey.endsWith(".script.json") || metaKey.endsWith(modMeta + ".json");
     if (!isYaml && !isJson) continue;
 
     const localMeta = local[metaKey];
@@ -2125,9 +2130,13 @@ export function preservePendingScriptLocks(
 
     // The local side must reference an inline lock backed by a committed file.
     const localLock = localParsed["lock"];
-    if (typeof localLock !== "string" || !localLock.startsWith("!inline")) continue;
+    if (typeof localLock !== "string" || !localLock.startsWith("!inline ")) continue;
 
-    const lockKey = metaKey.replace(/\.(yaml|json)$/, ".lock");
+    // Derive the lock-file key from the `!inline` reference itself, not from the
+    // metadata path: a multi-module script keeps its lock at `…__mod/script.lock`,
+    // which a `.script.yaml -> .script.lock` rewrite would miss. The reference is
+    // always forward-slash; map keys use the OS separator.
+    const lockKey = localLock.slice("!inline ".length).replaceAll("/", SEP);
     if (local[lockKey] === undefined) continue; // committed lock already gone
 
     remoteParsed["lock"] = localLock;

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -2077,6 +2077,67 @@ export async function isCaseInsensitiveFilesystem(
   return result;
 }
 
+// A script's `lock` is NULL on the remote only while the server is still
+// (re)generating it — e.g. an importer relock is in flight after a dependent
+// relative-import module changed, or the script's own first lock job has not
+// settled yet. NULL means "lock pending", NOT "this script has no lock": a
+// genuinely lock-free script (no dependencies, or a codebase script) serializes
+// `lock: ''` (empty string), which keeps its metadata key. The git-sync deploy
+// mirror reads the workspace inside that window and would otherwise mirror the
+// transient NULL as a deletion of the committed `.script.lock` (and strip the
+// `lock: '!inline …'` line from the metadata), corrupting the mirror until the
+// relock writes the identical lock back seconds later (issue #9588).
+//
+// When pulling (remote -> local), if the remote reports a pending (NULL) lock
+// for a script whose committed lock still exists locally, carry the local lock
+// onto the remote map so the diff is a no-op for both the lock file and the
+// metadata `lock` line. An empty-string lock ('') is left untouched, so a real
+// "dependencies removed" transition still deletes the obsolete lock.
+export function preservePendingScriptLocks(
+  remote: Record<string, string>,
+  local: Record<string, string>,
+): void {
+  for (const metaKey of Object.keys(remote)) {
+    const isYaml = metaKey.endsWith(".script.yaml");
+    const isJson = metaKey.endsWith(".script.json");
+    if (!isYaml && !isJson) continue;
+
+    const localMeta = local[metaKey];
+    if (localMeta === undefined) continue; // script not committed locally
+
+    let remoteParsed: any;
+    let localParsed: any;
+    try {
+      remoteParsed = isYaml
+        ? yamlParseContent(metaKey, remote[metaKey])
+        : JSON.parse(remote[metaKey]);
+      localParsed = isYaml ? yamlParseContent(metaKey, localMeta) : JSON.parse(localMeta);
+    } catch {
+      continue;
+    }
+    if (typeof remoteParsed !== "object" || remoteParsed === null) continue;
+    if (typeof localParsed !== "object" || localParsed === null) continue;
+
+    // Only a NULL/absent remote lock is "pending". An empty-string lock ('') is
+    // a real "no dependencies" state and must still propagate as a deletion.
+    const remoteLock = remoteParsed["lock"];
+    if (remoteLock !== undefined && remoteLock !== null) continue;
+
+    // The local side must reference an inline lock backed by a committed file.
+    const localLock = localParsed["lock"];
+    if (typeof localLock !== "string" || !localLock.startsWith("!inline")) continue;
+
+    const lockKey = metaKey.replace(/\.(yaml|json)$/, ".lock");
+    if (local[lockKey] === undefined) continue; // committed lock already gone
+
+    remoteParsed["lock"] = localLock;
+    remote[metaKey] = isYaml
+      ? yamlStringify(remoteParsed, yamlOptions)
+      : JSON.stringify(remoteParsed, null, 2);
+    remote[lockKey] = local[lockKey];
+  }
+}
+
 async function compareDynFSElement(
   els1: DynFSElement,
   els2: DynFSElement | undefined,
@@ -2136,6 +2197,12 @@ async function compareDynFSElement(
         );
       }
     }
+  }
+
+  // Pull only (remote is els1): keep a committed `.script.lock` when the remote
+  // lock is transiently NULL (a relock is mid-flight). See #9588.
+  if (isEls1Remote === true) {
+    preservePendingScriptLocks(m1, m2);
   }
 
   const changes: Change[] = [];

--- a/cli/test/pending_script_lock_unit.test.ts
+++ b/cli/test/pending_script_lock_unit.test.ts
@@ -69,6 +69,27 @@ test("NULL lock without a committed local lock file is a no-op", () => {
   expect(remote[LOCK]).toBeUndefined();
 });
 
+test("NULL remote lock preserves a multi-module (__mod) script lock", () => {
+  // Multi-module layout: metadata at <dir>/script.yaml, lock at <dir>/script.lock,
+  // and the inline reference points into the __mod folder.
+  const meta = "f/foo/bar__mod/script.yaml";
+  const lock = "f/foo/bar__mod/script.lock";
+  const lockRef = "!inline f/foo/bar__mod/script.lock";
+  const remote: Record<string, string> = {
+    [meta]: yamlStringify({ summary: "bar" }),
+  };
+  const local: Record<string, string> = {
+    [meta]: yamlStringify({ summary: "bar", lock: lockRef }),
+    [lock]: LOCK_CONTENT,
+  };
+
+  preservePendingScriptLocks(remote, local);
+
+  expect(remote[lock]).toBe(LOCK_CONTENT);
+  const parsed = yamlParseContent(meta, remote[meta]) as Record<string, unknown>;
+  expect(parsed["lock"]).toBe(lockRef);
+});
+
 test("deleted remote script does not resurrect its lock", () => {
   // Script removed remotely: no remote metadata key at all.
   const remote: Record<string, string> = {};

--- a/cli/test/pending_script_lock_unit.test.ts
+++ b/cli/test/pending_script_lock_unit.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Pending-lock preservation (issue #9588)
+ *
+ * A git-sync deploy mirror must not delete a committed `.script.lock` when the
+ * server reports the script's lock as NULL — that NULL is transient (a relock
+ * is mid-flight), not a real "no dependencies" state. A genuinely lock-free
+ * script serializes `lock: ''` and must still drop its obsolete lock.
+ */
+
+import { expect, test } from "bun:test";
+import { stringify as yamlStringify } from "yaml";
+import { yamlParseContent } from "../src/utils/yaml.ts";
+import { preservePendingScriptLocks } from "../src/commands/sync/sync.ts";
+
+const META = "f/foo/bar.script.yaml";
+const LOCK = "f/foo/bar.script.lock";
+const LOCK_REF = "!inline f/foo/bar.script.lock";
+const LOCK_CONTENT = "//deps\nsome-lock-content\n";
+
+function localMaps() {
+  return {
+    [META]: yamlStringify({ summary: "bar", lock: LOCK_REF }),
+    [LOCK]: LOCK_CONTENT,
+  };
+}
+
+test("NULL remote lock preserves the committed lock file and metadata line", () => {
+  // Remote during the race: lock key absent (NULL), no lock file emitted.
+  const remote: Record<string, string> = {
+    [META]: yamlStringify({ summary: "bar" }),
+  };
+  const local = localMaps();
+
+  preservePendingScriptLocks(remote, local);
+
+  // Lock file is carried onto the remote, so the diff sees no deletion.
+  expect(remote[LOCK]).toBe(LOCK_CONTENT);
+  // Metadata regains the inline lock reference, so no metadata edit either.
+  const parsed = yamlParseContent(META, remote[META]) as Record<string, unknown>;
+  expect(parsed["lock"]).toBe(LOCK_REF);
+});
+
+test("empty-string remote lock still removes the obsolete committed lock", () => {
+  // Dependencies genuinely removed: lock is '' (present, computed, no deps).
+  const remote: Record<string, string> = {
+    [META]: yamlStringify({ summary: "bar", lock: "" }),
+  };
+  const local = localMaps();
+
+  preservePendingScriptLocks(remote, local);
+
+  // Unchanged: no lock file injected, so the diff still deletes the local lock.
+  expect(remote[LOCK]).toBeUndefined();
+  const parsed = yamlParseContent(META, remote[META]) as Record<string, unknown>;
+  expect(parsed["lock"]).toBe("");
+});
+
+test("NULL lock without a committed local lock file is a no-op", () => {
+  const remote: Record<string, string> = {
+    [META]: yamlStringify({ summary: "bar" }),
+  };
+  // Local has the metadata but no committed lock file (nothing to preserve).
+  const local: Record<string, string> = {
+    [META]: yamlStringify({ summary: "bar", lock: LOCK_REF }),
+  };
+
+  preservePendingScriptLocks(remote, local);
+
+  expect(remote[LOCK]).toBeUndefined();
+});
+
+test("deleted remote script does not resurrect its lock", () => {
+  // Script removed remotely: no remote metadata key at all.
+  const remote: Record<string, string> = {};
+  const local = localMaps();
+
+  preservePendingScriptLocks(remote, local);
+
+  expect(remote[LOCK]).toBeUndefined();
+  expect(remote[META]).toBeUndefined();
+});


### PR DESCRIPTION
Fixes #9588
Fixes WIN-2050

## Problem

When a script is deployed via the workspace Git sync **deploy mirror** while one of its relative-import dependencies also changed in the same push, the mirror commit can **delete the script's committed `.script.lock`** and strip the `lock: '!inline …'` line from `*.script.yaml`.

Root cause is a race: the server holds the script's `lock` at `NULL` while the importer-relock dependency job is still running. The git-sync deploy job reads the workspace inside that ~1s window, sees no lock, and mirrors the transient `NULL` as a deletion. Seconds later the dependency job writes the final (byte-identical) lock server-side — so the only lasting damage is in the git mirror. For repos that treat committed locks as the source of truth, this breaks every subsequent CI run until the lock is restored.

## Fix

`NULL` lock means **"lock pending"**, not **"this script has no lock"** — a genuinely lock-free script (no dependencies, or a codebase script) serializes `lock: ''` (empty string), which keeps its metadata key.

During a pull (remote → local, which is what the deploy mirror runs), `preservePendingScriptLocks` carries the local committed lock onto the remote map whenever the remote reports a `NULL`/absent lock for a script whose committed `.script.lock` still exists locally. The diff then becomes a no-op for **both** the lock file and the metadata `lock` line, so the mirror commit no longer deletes it.

An empty-string lock (`''`) — the real "dependencies removed" transition — is left untouched, so genuine lock removals still propagate. Scripts deleted remotely are not affected (no remote metadata key → no preservation). The guard is gated to the pull direction only (`isEls1Remote === true`); push is unchanged.

## Testing

- New deterministic unit test `cli/test/pending_script_lock_unit.test.ts` (4 cases): NULL lock preserved, empty-string lock still deleted, NULL with no local lock file is a no-op, deleted remote script does not resurrect its lock — all pass.
- Existing `git_unit`, `wmill_lock_unit`, `lint_locks_unit`, `lockfile_format_pinning_unit`, `gitsync_converter_unit` suites pass (88 tests).
- `tsc --noEmit`: no new type errors (16 pre-existing, unchanged).

CLI-only change; no backend or EE files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents git-sync deploy from deleting committed `.script.lock` and stripping `lock` from `*.script.yaml` when the server reports a transient NULL lock during relock. Keeps mirrors stable and unblocks CI; aligns with WIN-2050.

- Bug Fixes
  - On pull (remote → local), preserve the committed lock and metadata when the remote lock is NULL, so the diff is a no-op; supports `__mod` multi-module layout and Windows path separators.
  - Real removals still propagate: `lock: ''` continues to delete the lock; script deletions are unchanged.

<sup>Written for commit 15030c39f3a7a83801a8365d7ba9cc922b8cbfdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

