### PR TITLE
fix(cli): accept server-default retry/stop_after_if fields in lint (WIN-2048)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -32,7 +32,7 @@
         "windmill-parser-wasm-rust": "1.647.1",
         "windmill-parser-wasm-ts": "1.695.0",
         "windmill-parser-wasm-yaml": "1.593.0",
-        "windmill-yaml-validator": "1.1.1",
+        "windmill-yaml-validator": "1.1.2",
         "ws": "8.18.0",
         "yaml": "^2.7.0"
       },
@@ -1470,9 +1470,8 @@
       "integrity": "sha512-Gyx4aR2jsJYuDrD3mCNTmz7LWOQQXPw5yKNCC1xRgUOPfjsD/tINAFfsBLwVOSmlQQcFZO+wHm4KtDtXOcnGVw=="
     },
     "node_modules/windmill-yaml-validator": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/windmill-yaml-validator/-/windmill-yaml-validator-1.1.1.tgz",
-      "integrity": "sha512-CVgAwEoBdJhF39q2N012QffhlGPRIyIWd8gj7NnfG+/lMWgH2k5CBLtKIt6cPF8Bxz+6DGC3st1ARSsecDtbTg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/windmill-yaml-validator/-/windmill-yaml-validator-1.1.2.tgz",
       "license": "Apache 2.0",
       "dependencies": {
         "@stoplight/yaml": "^4.3.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -40,7 +40,7 @@
     "windmill-parser-wasm-rust": "1.647.1",
     "windmill-parser-wasm-ts": "1.695.0",
     "windmill-parser-wasm-yaml": "1.593.0",
-    "windmill-yaml-validator": "1.1.1",
+    "windmill-yaml-validator": "1.1.2",
     "ws": "8.18.0",
     "yaml": "^2.7.0"
   },

--- a/openflow.openapi.yaml
+++ b/openflow.openapi.yaml
@@ -152,10 +152,11 @@ components:
               description: Multiplier for exponential backoff
             seconds:
               type: integer
-              minimum: 1
+              minimum: 0
               description: Initial delay in seconds
             random_factor:
               type: integer
+              nullable: true
               minimum: 0
               maximum: 100
               description: Random jitter percentage (0-100) to avoid thundering herd

--- a/windmill-yaml-validator/gen_openflow_schema.sh
+++ b/windmill-yaml-validator/gen_openflow_schema.sh
@@ -94,3 +94,35 @@ for (const file of files) {
 }
 console.log('Added null to nullable enums in generated schemas');
 "
+
+# OpenAPI 3.0 expresses nullable typed fields as { type: \"<T>\", nullable: true },
+# which is not standard JSON Schema. For typed (non-enum) fields, rewrite them to
+# the standard { type: [\"<T>\", \"null\"] } form so any JSON Schema validator accepts
+# null. Enum-nullable fields are handled by the pass above and are left untouched.
+node -e "
+const fs = require('fs');
+const path = require('path');
+
+function convertNullableTypesToArrays(obj) {
+    if (!obj || typeof obj !== 'object') return;
+    if (Array.isArray(obj)) { obj.forEach(convertNullableTypesToArrays); return; }
+    if (obj.nullable === true && typeof obj.type === 'string' && !Array.isArray(obj.enum)) {
+        obj.type = [obj.type, 'null'];
+        delete obj.nullable;
+    }
+    for (const v of Object.values(obj)) convertNullableTypesToArrays(v);
+}
+
+const files = [
+    '${output_dirpath}/openflow.json',
+    '${output_dirpath}/schedule.json',
+    ...fs.readdirSync('${output_dirpath}/triggers').map(f => path.join('${output_dirpath}/triggers', f))
+].filter(f => f.endsWith('.json'));
+
+for (const file of files) {
+    const schema = JSON.parse(fs.readFileSync(file, 'utf8'));
+    convertNullableTypesToArrays(schema);
+    fs.writeFileSync(file, JSON.stringify(schema, null, 2) + '\n');
+}
+console.log('Converted nullable typed fields to type arrays in generated schemas');
+"

--- a/windmill-yaml-validator/package.json
+++ b/windmill-yaml-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windmill-yaml-validator",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "YAML validator for Windmill flow, schedule, and trigger files",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/windmill-yaml-validator/src/validation/__tests__/flow-validator.test.ts
+++ b/windmill-yaml-validator/src/validation/__tests__/flow-validator.test.ts
@@ -88,6 +88,16 @@ describe("WindmillYamlValidator", () => {
           },
         });
       });
+      it("should validate a flow with default retry and stop_after_if fields (WIN-2048)", () => {
+        // The server serialises unset retry/stop_after_if defaults as
+        // seconds: 0, random_factor: null and error_message: null. These must
+        // round-trip through the linter without errors.
+        const validFlow = readSample("valid-default-retry-stop-after-if.yaml");
+
+        const result = validator.validate(validFlow, { type: "flow" });
+
+        expect(result.errors).toHaveLength(0);
+      });
     });
 
     describe("invalid flows", () => {

--- a/windmill-yaml-validator/src/validation/__tests__/test-samples/valid-default-retry-stop-after-if.yaml
+++ b/windmill-yaml-validator/src/validation/__tests__/test-samples/valid-default-retry-stop-after-if.yaml
@@ -1,0 +1,27 @@
+# Mirrors the YAML the server emits for a module with a constant retry and a
+# stop_after_if without an error message. These defaults (seconds: 0,
+# random_factor: null, error_message: null) used to be rejected by the linter.
+summary: Flow with default retry and stop_after_if
+value:
+  modules:
+    - id: script_step
+      value:
+        type: rawscript
+        input_transforms: {}
+        content: |
+          export async function main() {
+            return "ok";
+          }
+        language: deno
+      retry:
+        constant:
+          attempts: 2
+          seconds: 5
+        exponential:
+          attempts: 0
+          multiplier: 1
+          seconds: 0
+          random_factor: null
+      stop_after_if:
+        expr: "false"
+        error_message: null

--- a/windmill-yaml-validator/src/validation/__tests__/test-samples/valid-default-retry-stop-after-if.yaml
+++ b/windmill-yaml-validator/src/validation/__tests__/test-samples/valid-default-retry-stop-after-if.yaml
@@ -15,13 +15,14 @@ value:
         language: deno
       retry:
         constant:
-          attempts: 2
-          seconds: 5
+          attempts: 1
+          seconds: 60
         exponential:
           attempts: 0
           multiplier: 1
-          seconds: 0
           random_factor: null
+          seconds: 0
       stop_after_if:
-        expr: "false"
         error_message: null
+        expr: result == 404
+        skip_if_stopped: true


### PR DESCRIPTION
## Problem

`wmill push --lint` rejected valid flow YAML that the server emits for a module with a constant retry and a `stop_after_if` without an error message. Three schema rejections:

1. `error_message must be string` — unset `Option<String>` serialises as `null`
2. `exponential/seconds must be >= 1` — the default `ExponentialDelay` has `seconds: 0`
3. `exponential/random_factor must be integer` — unset `Option<i8>` serialises as `null`

The schema was simply **wrong vs the Rust types**. These are valid values: `random_factor: null` appears on any legitimately-configured exponential retry without jitter, and the backend's own `validate_retry` only requires `seconds > 0` when `exponential.attempts > 0`, so `seconds: 0` is otherwise valid.

This is the linter half of WIN-2048. The serialization root-cause fix (stopping the backend from emitting these defaults in the first place) is in #9583. The linter change is still needed independently — for the valid-value cases above and for flows already stored with the defaults baked in before #9583 lands.

## Fix

- **`openflow.openapi.yaml`**: `exponential.seconds` `minimum: 1` → `0`; add `nullable: true` to `exponential.random_factor`.
- **`windmill-yaml-validator/gen_openflow_schema.sh`**: new pass rewriting typed (non-enum) `{ type: "<T>", nullable: true }` → standard JSON Schema `{ type: ["<T>", "null"] }`. (`error_message` was already accepted because AJV v8 supports `nullable` natively; this makes the generated schemas standard/portable rather than relying on that.)
- **Version bumps**: `windmill-yaml-validator` `1.1.1` → `1.1.2` + the CLI dependency.
- **Regression test**: a flow sample mirroring the exact server-emitted YAML, asserting zero lint errors.

## Validation

`npm test` in `windmill-yaml-validator` → 44 passed (incl. the new regression test). The 18 pre-existing failures are unrelated (`permissioned_as` trigger samples) and identical on the pristine tree.

## Merge prerequisite ⚠️

`windmill-yaml-validator@1.1.2` must be **published to npm** before this lands so the CLI dependency resolves. The `cli/package-lock.json` entry's `resolved` URL points at the `1.1.2` tarball and the stale `integrity` hash was dropped — re-run `npm install` in `cli/` after publish to repopulate it. (CLI CI uses non-frozen `bun install`, which resolves `1.1.2` from `package.json` once published.)

Related: WIN-2048

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `wmill push --lint` rejecting server-emitted flow YAML by aligning the schema/validator with backend defaults. Accepts `seconds: 0`, `random_factor: null`, and `error_message: null` for retry/stop_after_if (WIN-2048).

- **Bug Fixes**
  - OpenFlow schema: `exponential.seconds` minimum `1` → `0`; `exponential.random_factor` is now nullable.
  - Schema generation: rewrite typed `{ type: "<T>", nullable: true }` to standard `{ type: ["<T>", "null"] }` so any JSON Schema validator accepts `null`.
  - Added a regression test mirroring the server-emitted YAML; lints with zero errors.

- **Dependencies**
  - Bump `windmill-yaml-validator` to `1.1.2` and update the CLI dependency.
  - Publish `windmill-yaml-validator@1.1.2` before merge, then run `npm install` in `cli/` to refresh the lockfile.

<sup>Written for commit db3b68c5151cb9ba38fa69d502d63e63eb374fb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

