### PR TITLE
fix: resolve release CI failures (pypi bundle, flow serde test, cli windows)

### DIFF
--- a/backend/windmill-api-flows/src/flows.rs
+++ b/backend/windmill-api-flows/src/flows.rs
@@ -2109,8 +2109,7 @@ mod tests {
               },
               "stop_after_if": {
                   "expr": "foo = 'bar'",
-                  "skip_if_stopped": false,
-                  "error_message": null
+                  "skip_if_stopped": false
               }
             },
             {
@@ -2131,8 +2130,7 @@ mod tests {
               },
               "stop_after_if": {
                   "expr": "previous.isEmpty()",
-                  "skip_if_stopped": false,
-                  "error_message": null
+                  "skip_if_stopped": false
               }
             }
           ],
@@ -2145,8 +2143,7 @@ mod tests {
             },
             "stop_after_if": {
                 "expr": "previous.isEmpty()",
-                "skip_if_stopped": false,
-                "error_message": null
+                "skip_if_stopped": false
             }
           },
         });

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -21167,8 +21167,6 @@ components:
     # NOTE: Not so many generators and validators support this format:
     # $ref: "../../openflow.openapi.yaml#/components/schemas"
     # This is why it is better to inline each of schemas for better compat
-    # Do not change next line. It is used by python-client for pre-processing
-    # -- INLINE START --
     UserDraftOverlay:
       type: object
       description: |
@@ -21244,6 +21242,8 @@ components:
         - trigger_nextcloud
         - trigger_google
         - trigger_github
+    # Do not change next line. It is used by python-client for pre-processing
+    # -- INLINE START --
     OpenFlow:
       $ref: "../../openflow.openapi.yaml#/components/schemas/OpenFlow"
     FlowValue:

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -2099,7 +2099,8 @@ export function preservePendingScriptLocks(
 ): void {
   // A multi-module script keeps its metadata in the folder layout
   // `…__mod/script.{yaml,json}` instead of `….script.{yaml,json}`.
-  const modMeta = getModuleFolderSuffix() + SEP + "script";
+  // Map keys are always forward-slash normalized, on every platform.
+  const modMeta = getModuleFolderSuffix() + "/script";
   for (const metaKey of Object.keys(remote)) {
     const isYaml =
       metaKey.endsWith(".script.yaml") || metaKey.endsWith(modMeta + ".yaml");
@@ -2134,9 +2135,9 @@ export function preservePendingScriptLocks(
 
     // Derive the lock-file key from the `!inline` reference itself, not from the
     // metadata path: a multi-module script keeps its lock at `…__mod/script.lock`,
-    // which a `.script.yaml -> .script.lock` rewrite would miss. The reference is
-    // always forward-slash; map keys use the OS separator.
-    const lockKey = localLock.slice("!inline ".length).replaceAll("/", SEP);
+    // which a `.script.yaml -> .script.lock` rewrite would miss. The reference and
+    // the map keys are both forward-slash, so no separator rewrite is needed.
+    const lockKey = localLock.slice("!inline ".length);
     if (local[lockKey] === undefined) continue; // committed lock already gone
 
     remoteParsed["lock"] = localLock;


### PR DESCRIPTION
## Summary

Fixes three independent failures observed on the latest release commit (`1.725.1`): **Publish python-client (pypi)**, **Backend `flowmodule_serde` test**, and **CLI Tests `test-windows`**.

### 1. pypi — broken OpenAPI bundle
`UserDraftOverlay` / `UserDraftItemKind` were added *inside* the `# -- INLINE START/END --` markers in `openapi.yaml`. The python-client build (`python-client/build.sh`) replaces that entire block with a wildcard import of `openflow.openapi.yaml`'s schemas — which don't define these two — so every `$ref: "#/components/schemas/UserDraftOverlay"` on the trigger `get` endpoints became unresolvable and the redocly bundler aborted (`Can't resolve $ref`, exit 1).

These two are genuine windmill-api schemas, not openflow-mirrored ones, so the fix is to move them **outside** the INLINE markers. Verified by reproducing the build's `sed` transform + `redocly bundle` locally → exit 0, no unresolved refs.

### 2. backend — `flows::tests::flowmodule_serde`
`StopAfterIf.error_message` is now skipped when `None` (commit e1e2a24b6a), but the test's expected JSON still contained `"error_message": null` in three `stop_after_if` blocks. Removed those keys. `cargo test -p windmill-api-flows flowmodule_serde` passes.

### 3. cli — `test-windows`
`preservePendingScriptLocks` mixed the OS path separator (`SEP` = `\` on Windows) into map keys that are always forward-slash normalized everywhere else in `sync.ts`. On Windows the `__mod/script` suffix match and the `!inline` lock-file lookup both failed, so the committed lock wasn't preserved. Switched to forward slashes — **this also fixes real Windows git-sync deploys**, not just the test. All 5 unit tests pass.

## Validation
- `redocly bundle` of the python-client-transformed spec → exit 0
- `SQLX_OFFLINE=true cargo test -p windmill-api-flows flowmodule_serde` → pass
- `UNIT_ONLY=1 bun test test/pending_script_lock_unit.test.ts` → 5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three release CI failures: PyPI OpenAPI bundle, backend flow serde test, and Windows CLI. The release pipeline passes again and Windows git-sync deploys work.

- **Bug Fixes**
  - OpenAPI: moved `UserDraftOverlay` and `UserDraftItemKind` outside the `# -- INLINE START/END --` block so `python-client` preprocessing doesn’t drop them; `redocly bundle` now resolves all refs.
  - Backend test: updated `flowmodule_serde` expected JSON to omit `"error_message"` when null in `stop_after_if`.
  - CLI (Windows): normalized to forward slashes in `preservePendingScriptLocks` for module suffix and `!inline` lock lookup; preserves pending locks on Windows.

<sup>Written for commit 31036fd4f03e53e2fd2961022b244df231ee183d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

