### PR TITLE
feat(audit): record workspace archive/unarchive/delete in instance audit log

### DIFF
--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -5238,6 +5238,18 @@ async fn archive_workspace(
         ActionKind::Update,
         &w_id,
         Some(&authed.email),
+        Some(audit_params_refs.clone()),
+    )
+    .await?;
+    // Also record under the instance-level "admins" workspace so superadmins can
+    // discover who archived a workspace after it becomes hidden from the UI.
+    audit_log(
+        &mut *tx,
+        &authed,
+        "workspaces.archive",
+        ActionKind::Update,
+        "admins",
+        Some(&w_id),
         Some(audit_params_refs),
     )
     .await?;
@@ -5296,6 +5308,18 @@ async fn unarchive_workspace(
         ActionKind::Update,
         &w_id,
         Some(&authed.email),
+        None,
+    )
+    .await?;
+    // Also record under the instance-level "admins" workspace so superadmins keep
+    // a durable trail of who unarchived a workspace.
+    audit_log(
+        &mut *tx,
+        &authed,
+        "workspaces.unarchive",
+        ActionKind::Update,
+        "admins",
+        Some(&w_id),
         None,
     )
     .await?;

--- a/backend/windmill-api-workspaces/src/workspaces_extra.rs
+++ b/backend/windmill-api-workspaces/src/workspaces_extra.rs
@@ -872,13 +872,16 @@ pub(crate) async fn delete_workspace(
         .execute(&mut *tx)
         .await?;
 
+    // Record under the instance-level "admins" workspace. The per-workspace audit
+    // rows are deleted along with the workspace, so this instance-level entry is the
+    // only durable, superadmin-discoverable record of who deleted the workspace.
     audit_log(
         &mut *tx,
         &authed,
         "workspaces.delete",
         ActionKind::Delete,
-        &w_id,
-        Some(&authed.email),
+        "admins",
+        Some(&w_id),
         None,
     )
     .await?;


### PR DESCRIPTION
## Problem

A user reported they couldn't see a workspace they were a member of. Root cause: the workspace had `deleted = true` (it had been **archived**) — the `user_workspaces` switcher query filters `workspace.deleted = false`, so archived workspaces correctly vanish for everyone. But there was **no durable, discoverable audit trail** of *who* archived/deleted it and *when*:

- `archive_workspace` / `delete_workspace` *did* call `audit_log(...)`, but wrote the entry into the **target workspace's own** audit log.
- Once archived/deleted, that workspace is hidden (or its audit rows are gone entirely), so the record is effectively lost. In the reported case the workspace had **zero** retrievable audit entries.

## Fix

Also record archive / unarchive / delete under the instance-level **`admins`** workspace — Windmill's canonical instance-audit scope. A superadmin querying the `admins` audit view with `all_workspaces=true` sees entries across all workspaces (same gate used by the instance-wide jobs view), so these events stay discoverable regardless of the target workspace's state.

- The **target workspace id** is carried in the audit `resource` field; the **actor** comes from the author (`&authed`).
- `archive` / `unarchive` keep their existing per-workspace entry *and* add the instance-level one.
- `delete` writes only the instance-level entry, since the per-workspace audit rows are deleted in the same transaction anyway.

No new mechanism, no schema change, no migration — reuses the existing `audit_log` helper and the established `admins` convention.

## Files
- `backend/windmill-api-workspaces/src/workspaces.rs` — `archive_workspace`, `unarchive_workspace`
- `backend/windmill-api-workspaces/src/workspaces_extra.rs` — `delete_workspace`

## Validation
- `SQLX_OFFLINE=true cargo check -p windmill-api-workspaces` → clean

> Note: `audit_log` is an EE feature (the OSS function is a no-op stub), so this is effective on EE builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record workspace archive/unarchive/delete events in the instance-level `admins` audit log so superadmins can see who performed these actions even after a workspace is hidden or deleted. No schema changes; reuses the existing `audit_log` flow (EE only).

- **Bug Fixes**
  - Archive/unarchive: keep per-workspace entry and also write to `admins`.
  - Delete: write only to `admins` since per-workspace audit rows are removed.
  - The target workspace id is stored as the audit resource; the actor comes from the author.

<sup>Written for commit d8b65363322ef487db219fe70b9cc77765d8d66d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

