### PR TITLE
fix(embeddings): retry HuggingFace model downloads with backoff

### DIFF
--- a/backend/windmill-api-embeddings/src/lib.rs
+++ b/backend/windmill-api-embeddings/src/lib.rs
@@ -3,11 +3,11 @@ use anyhow::{anyhow, Error, Result};
 #[cfg(feature = "embedding")]
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
 #[cfg(feature = "embedding")]
+use windmill_common::utils::HTTP_CLIENT_PERMISSIVE as HTTP_CLIENT;
+#[cfg(feature = "embedding")]
 use windmill_common::DEFAULT_HUB_BASE_URL;
 #[cfg(feature = "embedding")]
 use windmill_common::HUB_BASE_URL;
-#[cfg(feature = "embedding")]
-use windmill_common::utils::HTTP_CLIENT_PERMISSIVE as HTTP_CLIENT;
 
 use axum::Router;
 
@@ -159,23 +159,52 @@ pub struct ModelInstance {
 
 #[cfg(feature = "embedding")]
 impl ModelInstance {
+    async fn get_hf_file(
+        repo_api: &hf_hub::api::tokio::ApiRepo,
+        filename: &str,
+    ) -> Result<PathBuf> {
+        // HuggingFace downloads have no built-in retry, so a single transient
+        // network blip would fail the whole image build. Retry with exponential
+        // backoff (1s, 2s, 4s, 8s, capped at 8s) up to MAX_ATTEMPTS times.
+        const MAX_ATTEMPTS: u32 = 5;
+        let mut attempt: u32 = 0;
+        loop {
+            attempt += 1;
+            match repo_api.get(filename).await {
+                Ok(path) => return Ok(path),
+                Err(e) => {
+                    if attempt >= MAX_ATTEMPTS {
+                        return Err(anyhow!(
+                            "Failed to get {} from hugging face after {} attempts: {}",
+                            filename,
+                            attempt,
+                            e
+                        ));
+                    }
+                    let delay_secs = 1u64 << (attempt - 1).min(3);
+                    tracing::warn!(
+                        "Failed to get {} from hugging face (attempt {}/{}): {}. Retrying in {}s...",
+                        filename,
+                        attempt,
+                        MAX_ATTEMPTS,
+                        e,
+                        delay_secs
+                    );
+                    tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+                }
+            }
+        }
+    }
+
     pub async fn load_model_files() -> Result<(PathBuf, PathBuf, PathBuf)> {
         let api = Api::new()?;
         let repo_api = api.model("thenlper/gte-small".to_string());
 
-        let (config_filename, tokenizer_filename, weights_filename) =
-            (
-                repo_api
-                    .get("config.json")
-                    .await
-                    .map_err(|e| anyhow!("Failed to get config.json from hugging face: {}", e))?,
-                repo_api.get("tokenizer.json").await.map_err(|e| {
-                    anyhow!("Failed to get tokenizer.json from hugging face: {}", e)
-                })?,
-                repo_api.get("model.safetensors").await.map_err(|e| {
-                    anyhow!("Failed to get model.safetensors from hugging face: {}", e)
-                })?,
-            );
+        let (config_filename, tokenizer_filename, weights_filename) = (
+            Self::get_hf_file(&repo_api, "config.json").await?,
+            Self::get_hf_file(&repo_api, "tokenizer.json").await?,
+            Self::get_hf_file(&repo_api, "model.safetensors").await?,
+        );
 
         Ok((config_filename, tokenizer_filename, weights_filename))
     }


### PR DESCRIPTION
## Summary

The embedding-model caching step downloaded the `thenlper/gte-small` files (`config.json`, `tokenizer.json`, `model.safetensors`) from HuggingFace with **no retry**, so a single transient network blip aborted the whole image build:

```
Caching embedding model...
Error: Failed to get model.safetensors from hugging face: request error: error sending request for url (https://huggingface.co/thenlper/gte-small/resolve/main/model.safetensors)
```

## Fix

Route the three `hf-hub` `.get(...)` calls through a small `get_hf_file` retry wrapper in `ModelInstance` (`backend/windmill-api-embeddings/src/lib.rs`):

- up to 5 attempts, exponential backoff (1s → 2s → 4s → 8s, capped)
- each failed attempt logged via `tracing::warn!`
- the error is surfaced only after the final attempt

No new crate dependency (uses `tokio::time::sleep`, already a dep). The existing `reqwest-retry` middleware in the codebase only wraps a `reqwest::Client`, which doesn't apply to `hf-hub`'s own download path, hence the small local loop.

## Validation
- `SQLX_OFFLINE=true cargo check -p windmill-api-embeddings --features embedding` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds retries with exponential backoff to `hf-hub` downloads for `thenlper/gte-small` embedding files to prevent build failures from transient network issues. Each file download now retries and only errors after the final attempt.

- **Bug Fixes**
  - Wraps each `hf-hub` fetch in `get_hf_file` with up to 5 attempts and 1s→2s→4s→8s backoff (capped).
  - Logs each failed attempt; surfaces error only after the last attempt.
  - Updates `ModelInstance::load_model_files` to use the retry helper; no new deps (uses `tokio::time::sleep`).

<sup>Written for commit 8932a175a90cb9cfccd5289cfcc7f36a770de45f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

