### PR TITLE
fix(frontend): strip server-managed fields from value diffs

### DIFF
--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -707,7 +707,16 @@
 		const currentDraftTriggers = structuredClone(triggersState.getDraftTriggersSnapshot())
 
 		const deployed = deployedValue ?? savedScript
-		const current = { ...script, draft_triggers: currentDraftTriggers }
+		// `script` comes from the full DB row (since #9351), so it carries `lock`/`extra_perms`
+		// while the deployed side is trimmed in `syncWithDeployed` — null them here to match
+		// that strip. They stay in the shared `cleanValueProperties` so version-to-version and
+		// folder workspace/fork diffs still surface lockfile / sharing-permission changes.
+		const current = {
+			...script,
+			lock: undefined,
+			extra_perms: undefined,
+			draft_triggers: currentDraftTriggers
+		}
 		if (current.assets && !current.assets.length) delete current.assets
 
 		diffDrawer?.openDrawer()

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -289,9 +289,12 @@ describe('cleanValueProperties', () => {
 		'parent_hash',
 		'draft',
 		'draft_only',
+		'draft_saved_at',
+		'draft_created_at',
+		'is_draft',
+		'other_drafts_users',
 		'created_at',
 		'created_by',
-		'extra_perms',
 		'workspace_id',
 		'parent_hashes',
 		'lock_error_logs'
@@ -315,8 +318,7 @@ describe('cleanValueProperties', () => {
 			content: 'export function main() {}',
 			schema: { properties: { x: { type: 'string' } } },
 			language: 'bun',
-			created_at: '2024-01-01',
-			extra_perms: { 'u/foo': true }
+			created_at: '2024-01-01'
 		}
 		const cleaned = cleanValueProperties(input) as any
 		expect(cleaned.summary).toBe('my script')
@@ -325,12 +327,19 @@ describe('cleanValueProperties', () => {
 		expect(cleaned.schema).toEqual({ properties: { x: { type: 'string' } } })
 		expect(cleaned.language).toBe('bun')
 		expect(cleaned).not.toHaveProperty('created_at')
-		expect(cleaned).not.toHaveProperty('extra_perms')
 	})
 
 	it('preserves lock so version-to-version diffs still surface lockfile changes', () => {
 		const cleaned = cleanValueProperties({ summary: 'hi', lock: 'resolved deps' } as any) as any
 		expect(cleaned.lock).toBe('resolved deps')
+	})
+
+	it('preserves extra_perms so folder workspace/fork diffs still surface permission changes', () => {
+		const cleaned = cleanValueProperties({
+			summary: 'hi',
+			extra_perms: { 'u/foo': true }
+		} as any) as any
+		expect(cleaned.extra_perms).toEqual({ 'u/foo': true })
 	})
 
 	it('returns non-object values unchanged', () => {

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getQueryStmtCountHeuristic } from './utils'
+import { cleanValueProperties, getQueryStmtCountHeuristic } from './utils'
 
 describe('getQueryStmtCountHeuristic', () => {
 	describe('basic statements', () => {
@@ -281,5 +281,66 @@ DELETE FROM logs WHERE timestamp < NOW() - INTERVAL '30 days'
 			`
 			expect(getQueryStmtCountHeuristic(query)).toBe(3)
 		})
+	})
+})
+
+describe('cleanValueProperties', () => {
+	const serverManagedKeys = [
+		'parent_hash',
+		'draft',
+		'draft_only',
+		'created_at',
+		'created_by',
+		'extra_perms',
+		'workspace_id',
+		'parent_hashes',
+		'lock_error_logs'
+	]
+
+	it('strips every server-managed bookkeeping key', () => {
+		const input: any = { summary: 'hi' }
+		for (const key of serverManagedKeys) {
+			input[key] = 'noise'
+		}
+		const cleaned = cleanValueProperties(input) as any
+		for (const key of serverManagedKeys) {
+			expect(cleaned).not.toHaveProperty(key)
+		}
+	})
+
+	it('preserves user-editable keys', () => {
+		const input: any = {
+			summary: 'my script',
+			description: 'does things',
+			content: 'export function main() {}',
+			schema: { properties: { x: { type: 'string' } } },
+			language: 'bun',
+			created_at: '2024-01-01',
+			extra_perms: { 'u/foo': true }
+		}
+		const cleaned = cleanValueProperties(input) as any
+		expect(cleaned.summary).toBe('my script')
+		expect(cleaned.description).toBe('does things')
+		expect(cleaned.content).toBe('export function main() {}')
+		expect(cleaned.schema).toEqual({ properties: { x: { type: 'string' } } })
+		expect(cleaned.language).toBe('bun')
+		expect(cleaned).not.toHaveProperty('created_at')
+		expect(cleaned).not.toHaveProperty('extra_perms')
+	})
+
+	it('preserves lock so version-to-version diffs still surface lockfile changes', () => {
+		const cleaned = cleanValueProperties({ summary: 'hi', lock: 'resolved deps' } as any) as any
+		expect(cleaned.lock).toBe('resolved deps')
+	})
+
+	it('returns non-object values unchanged', () => {
+		expect(cleanValueProperties('hello' as any)).toBe('hello')
+		expect(cleanValueProperties(42 as any)).toBe(42)
+	})
+
+	it('does not mutate the input object', () => {
+		const input: any = { summary: 'hi', created_at: '2024-01-01' }
+		cleanValueProperties(input)
+		expect(input).toHaveProperty('created_at')
 	})
 })

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1296,13 +1296,31 @@ function replaceFalseWithUndefinedRec(obj: any) {
 	return obj
 }
 
+// Keys that are server-managed bookkeeping, never user-editable, and therefore
+// must not surface in any value diff or unsaved-change comparison. `getScriptByPath`
+// (and the flow/app equivalents) return the full DB row, so the editing object
+// carries these while the deployed side is fetched trimmed — leaving them in would
+// render as spurious metadata diff.
+const CLEANED_VALUE_KEYS = new Set([
+	'parent_hash',
+	'draft',
+	'draft_only',
+	'created_at',
+	'created_by',
+	'extra_perms',
+	'workspace_id',
+	'parent_hashes',
+	'lock',
+	'lock_error_logs'
+])
+
 export function cleanValueProperties(obj: Value) {
 	if (typeof obj !== 'object') {
 		return obj
 	} else {
 		let newObj: any = {}
 		for (const key of Object.keys(obj)) {
-			if (key !== 'parent_hash' && key !== 'draft' && key !== 'draft_only') {
+			if (!CLEANED_VALUE_KEYS.has(key)) {
 				newObj[key] = structuredClone(stateSnapshot(obj[key]))
 			}
 		}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1300,7 +1300,9 @@ function replaceFalseWithUndefinedRec(obj: any) {
 // must not surface in any value diff or unsaved-change comparison. `getScriptByPath`
 // (and the flow/app equivalents) return the full DB row, so the editing object
 // carries these while the deployed side is fetched trimmed — leaving them in would
-// render as spurious metadata diff.
+// render as spurious metadata diff. `lock` is deliberately NOT in this set: it was
+// part of the comparison before the full-DB-row loader landed and version-to-version
+// diffs (e.g. WorkspaceItemDiffViewer) legitimately surface lockfile changes.
 const CLEANED_VALUE_KEYS = new Set([
 	'parent_hash',
 	'draft',
@@ -1310,7 +1312,6 @@ const CLEANED_VALUE_KEYS = new Set([
 	'extra_perms',
 	'workspace_id',
 	'parent_hashes',
-	'lock',
 	'lock_error_logs'
 ])
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1300,16 +1300,23 @@ function replaceFalseWithUndefinedRec(obj: any) {
 // must not surface in any value diff or unsaved-change comparison. `getScriptByPath`
 // (and the flow/app equivalents) return the full DB row, so the editing object
 // carries these while the deployed side is fetched trimmed — leaving them in would
-// render as spurious metadata diff. `lock` is deliberately NOT in this set: it was
-// part of the comparison before the full-DB-row loader landed and version-to-version
-// diffs (e.g. WorkspaceItemDiffViewer) legitimately surface lockfile changes.
+// render as spurious metadata diff.
+//
+// `lock` and `extra_perms` are deliberately NOT in this set: both are legitimate,
+// user-meaningful fields in some diff contexts (lockfile changes in version-to-version
+// diffs, folder sharing-permission changes in workspace/fork diffs). The script-editor
+// noise they would otherwise cause is stripped at the source instead (the deployed side
+// in `ScriptBuilder.syncWithDeployed`, the current side in `ScriptBuilder.openDiffDrawer`).
 const CLEANED_VALUE_KEYS = new Set([
 	'parent_hash',
 	'draft',
 	'draft_only',
+	'draft_saved_at',
+	'draft_created_at',
+	'is_draft',
+	'other_drafts_users',
 	'created_at',
 	'created_by',
-	'extra_perms',
 	'workspace_id',
 	'parent_hashes',
 	'lock_error_logs'


### PR DESCRIPTION
## Summary

The script editor's **Deployed ⟷ Current** diff (Metadata tab) showed a lot of spurious changes the user never made — `created_at`, `created_by`, `extra_perms`, a large multi-line `lock_error_logs` dump, the `lock` blob, and draft-overlay bookkeeping — making the diff effectively unusable for spotting real metadata changes.

**Root cause.** Since #9351 (DB-backed user drafts), the script-edit loader fetches the full `Script` DB row (+ draft overlay) via `getScriptByPath` instead of the trimmed `NewScript`-shaped `getScriptByPathWithDraft`. The editing object (`current` side of the diff) therefore carries server-managed bookkeeping fields that `NewScript` never had. The deployed side is trimmed in `ScriptBuilder.syncWithDeployed`, so the two sides no longer line up and every bookkeeping field renders as a diff. `cleanValueProperties` — the shared normalizer both sides pass through — only stripped `parent_hash`/`draft`/`draft_only`, so it didn't catch them.

## Fix

Two complementary layers:

**1. Pure-noise fields → stripped in the shared `cleanValueProperties`.** These are never user-editable and meaningless in *any* diff context, so stripping them globally is safe and also fixes the draft⟷current diff, `hasUnsavedChanges`, and flow/app diff viewers:
`created_at`, `created_by`, `workspace_id`, `parent_hashes`, `lock_error_logs`, and the draft-overlay bookkeeping `draft_saved_at`, `draft_created_at`, `is_draft`, `other_drafts_users`.

**2. Context-meaningful fields → stripped at the script-editor source, kept in the shared helper.** `lock` and `extra_perms` are legitimate, user-meaningful fields in *some* diff contexts:
- `lock` — version-to-version diffs (`WorkspaceItemDiffViewer`) surface lockfile changes.
- `extra_perms` — folder sharing-permission changes in workspace/fork diffs (the backend's `compare_two_folders` treats folder `extra_perms` as a real change; `getItemValue` includes it for folders).

So they stay in `cleanValueProperties`, and the script-editor noise they would otherwise cause is removed at the source: `ScriptBuilder.openDiffDrawer` nulls `lock`/`extra_perms` on the `current` side, mirroring the existing deployed-side strip in `syncWithDeployed`.

## Changes

- `frontend/src/lib/utils.ts`: extract the skip-list into `CLEANED_VALUE_KEYS`; add the pure-noise fields above. `lock`/`extra_perms` deliberately excluded, with a comment recording why.
- `frontend/src/lib/components/ScriptBuilder.svelte`: `openDiffDrawer` nulls `lock`/`extra_perms` on the `current` side to match the deployed side.
- `frontend/src/lib/utils.test.ts`: unit tests for `cleanValueProperties` — each noise key stripped, user-editable keys + `lock` + `extra_perms` preserved, non-object passthrough, no input mutation.

## Screenshots

After the fix — editing the summary of a deployed script shows only the real change in the Metadata tab, with no `lock`/`extra_perms`/`created_at`/`draft_saved_at` noise:

![diff-metadata-summary-only](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/gl/fix-script-diff-metadata-noise/1781591739-diff-metadata-summary-only.png)

## Test plan

- [x] `npm run check:fast` — no type errors
- [x] `vitest run src/lib/utils.test.ts` — 62 passing (incl. new `cleanValueProperties` cases)
- [x] Deployed script → open Diff → Metadata: no edits shows "No changes detected"; summary edit shows only that change (verified in browser)
- [ ] Folder workspace/fork diff where only `extra_perms` changes still surfaces the change (needs EE two-workspace setup; covered by unit test asserting `extra_perms` is preserved)