### PR TITLE
fix(apps): prevent decision tree graph editor crash on missing graph context

### DIFF
--- a/frontend/src/lib/components/graph/renderers/nodes/NodeWrapper.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/NodeWrapper.svelte
@@ -30,7 +30,9 @@
 	let resolvedContextMenuItems: ContextMenuItem[] | undefined = $derived(
 		contextMenuItems ??
 			menuItems?.flatMap((item) => [
-				...(item.separatorTop ? [{ id: `${item.displayName}-divider`, label: '', divider: true }] : []),
+				...(item.separatorTop
+					? [{ id: `${item.displayName}-divider`, label: '', divider: true }]
+					: []),
 				{
 					id: item.displayName,
 					label: item.displayName,
@@ -43,11 +45,11 @@
 			])
 	)
 
-	const { moveManager } = getGraphContext()
+	// NodeWrapper is reused outside the flow graph (e.g. the app decision-tree
+	// editor) where FlowGraphContext is never set, so guard against undefined.
+	const { moveManager } = getGraphContext() ?? {}
 
-	let faded = $derived(
-		nodeId != null && (moveManager?.draggedNodeIds?.has(nodeId) ?? false)
-	)
+	let faded = $derived(nodeId != null && (moveManager?.draggedNodeIds?.has(nodeId) ?? false))
 
 	let darkMode: boolean = $state(false)
 </script>
@@ -72,18 +74,10 @@
 
 {#snippet handles()}
 	{#if enableSourceHandle}
-		<Handle
-			type="source"
-			isConnectable={false}
-			position={Position.Bottom}
-		/>
+		<Handle type="source" isConnectable={false} position={Position.Bottom} />
 	{/if}
 
 	{#if enableTargetHandle}
-		<Handle
-			type="target"
-			isConnectable={false}
-			position={Position.Top}
-		/>
+		<Handle type="target" isConnectable={false} position={Position.Top} />
 	{/if}
 {/snippet}


### PR DESCRIPTION
## Summary

Opening the **Graph Editor** of a Decision Tree component in the low-code app editor crashed with:

```
Uncaught TypeError: Cannot destructure property 'moveManager' of 'getGraphContext(...)' as it is undefined.
    at NodeWrapper (NodeWrapper.svelte:76:10)
```

`NodeWrapper.svelte` is a generic graph-node wrapper used by both the flow graph and the app decision-tree editor. It destructured `moveManager` from `getGraphContext()` unconditionally, but `FlowGraphContext` is only ever set by the flow graph (`FlowGraphV2.svelte` / `MiniFlowGraph.svelte`). The decision-tree preview (`DecisionTreePreview.svelte`) reuses `NodeWrapper` for its Start/End/branch-header nodes without setting that context, so `getGraphContext()` returned `undefined` and the destructure threw.

## Changes

- `frontend/src/lib/components/graph/renderers/nodes/NodeWrapper.svelte`: guard `getGraphContext()` with `?? {}` before destructuring. `moveManager` was already consumed optionally (`moveManager?.draggedNodeIds?.has(...)`), so this fully closes the crash path without affecting the populated-context (flow graph) case. Added a one-line comment recording why the guard is needed.
- The remainder of the diff is an automatic prettier pass on the file (multi-line ternary, `faded` derived, and `<Handle>` elements collapsed) with no behavioral effect.

## Test plan

- [x] App editor → add Decision Tree component → open Graph Editor: the Start → node → End graph renders with **0 console errors** (verified via Playwright; screenshot below).
- [x] Reverted the fix and re-ran the same flow → the exact reported `Cannot destructure property 'moveManager'` error reproduces, confirming the change is necessary and sufficient.
- [x] `npm run check:fast` → "No problems found".
- [ ] Flow editor (which sets the graph context) → drag a node and confirm the `faded` dragging behavior still works.

## Screenshots

![dt-graph-editor](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-170a164e/1781562712-dt-graph-editor.png)