### PR TITLE
fix(cli): include __mod/ folder in gitSyncIncludePattern for scripts

### DIFF
--- a/cli/src/utils/git.ts
+++ b/cli/src/utils/git.ts
@@ -275,7 +275,13 @@ export function gitSyncIncludePattern(
     case "emailtrigger":
       return `${path}.email_trigger.*`;
     default:
-      return `${path}.*`;
+      // Scripts: `${path}.*` matches the dotted layout
+      // (`${path}.script.yaml` etc.), `${path}__mod/**` matches the folder
+      // layout used by scripts with companion modules
+      // (`${path}__mod/script.ts`, `${path}__mod/helper.ts`, ...). Without the
+      // second pattern the module files are filtered out of the pull and the
+      // subsequent `git add '${path}**'` fails with "pathspec did not match".
+      return `${path}.*,${path}__mod/**`;
   }
 }
 

--- a/cli/test/git_unit.test.ts
+++ b/cli/test/git_unit.test.ts
@@ -219,8 +219,10 @@ describe("composeGitSyncCommitHeader", () => {
 // =============================================================================
 
 describe("gitSyncIncludePattern", () => {
-  test("script falls through to <path>.*", () => {
-    expect(gitSyncIncludePattern("script", "f/foo/bar")).toBe("f/foo/bar.*");
+  test("script includes __mod/ folder for module scripts", () => {
+    expect(gitSyncIncludePattern("script", "f/foo/bar")).toBe(
+      "f/foo/bar.*,f/foo/bar__mod/**"
+    );
   });
   test("flow/app expand to dotted + __ folder patterns", () => {
     expect(gitSyncIncludePattern("flow", "f/x")).toBe("f/x.flow/*,f/x__flow/*");

--- a/cli/test/gitsync_promotion.test.ts
+++ b/cli/test/gitsync_promotion.test.ts
@@ -577,6 +577,177 @@ test.skipIf(shouldSkipOnCI())(
 );
 
 /**
+ * Regression test for WIN-2052: a script with companion modules
+ * (workflows-as-code) is stored on disk under a `__mod/` folder
+ * (`<path>__mod/script.ts`, `<path>__mod/script.yaml`, `<path>__mod/<module>`)
+ * — NOT under the dotted `<path>.script.*` layout a module-less script uses.
+ *
+ * Root cause: `gitSyncIncludePattern`'s script (default) case returned only
+ * `<path>.*`, which the `ignoreF` extra-includes filter (minimatch) does NOT
+ * match against any `__mod/` file (literal dot, no dot after the name). So the
+ * pull filtered out every module file, the wm_deploy branch was created with
+ * nothing staged, and production's `git add '<path>**'` failed with "pathspec
+ * did not match any files". The fix adds `<path>__mod/**` to the pattern.
+ *
+ * The nested `utils/math.ts` module guards the `**` (vs `*`) choice: a single
+ * star would not match files in module subdirectories.
+ *
+ * Without the fix this test fails: the branch exists but the `__mod/` files
+ * (entry point + modules) are absent from it.
+ */
+test.skipIf(shouldSkipOnCI())(
+  "git-sync promotion: use_individual_branch lands a module script's __mod/ files on the wm_deploy branch",
+  async () => {
+    await withTestBackend(async (backend) => {
+      const ws = backend.workspace; // "test"
+      await addWorkspace(
+        {
+          remote: backend.baseUrl,
+          workspaceId: ws,
+          name: ws,
+          token: backend.token,
+        } as any,
+        { force: true, configDir: backend.testConfigDir },
+      );
+
+      // --- 1. Bare "remote" seeded with an initial `main` commit ---
+      const bareDir = await mkdtemp(join(tmpdir(), "wmill_promo_mod_bare_"));
+      execFileSync("git", ["init", "--bare", "--initial-branch=main", bareDir]);
+      const seedDir = await mkdtemp(join(tmpdir(), "wmill_promo_mod_seed_"));
+      git(seedDir, "init", "--initial-branch=main");
+      git(seedDir, "config", "user.email", "seed@windmill.dev");
+      git(seedDir, "config", "user.name", "seed");
+      await writeFile(join(seedDir, "README.md"), "# promo module test\n");
+      git(seedDir, "add", "-A");
+      git(seedDir, "commit", "-m", "seed");
+      git(seedDir, "remote", "add", "origin", `file://${bareDir}`);
+      git(seedDir, "push", "-u", "origin", "main");
+      const seedMain = remoteHead(bareDir, "main");
+
+      // --- 2. Workspace content: a script WITH companion modules (one flat,
+      //        one nested) — this is what triggers the `__mod/` folder layout. ---
+      await backend.apiRequest!(`/api/w/${ws}/folders/create`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "promo", owners: [], extra_perms: {} }),
+      });
+      const scriptRes = await backend.apiRequest!(`/api/w/${ws}/scripts/create`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          path: "f/promo/mod_script",
+          summary: "",
+          description: "",
+          content: "export async function main() { return 1 }",
+          language: "bun",
+          modules: {
+            "helper.ts": {
+              content: "export function help() { return 2 }\n",
+              language: "bun",
+            },
+            "utils/math.ts": {
+              content: "export function add(a: number, b: number) { return a + b }\n",
+              language: "bun",
+            },
+          },
+        }),
+      });
+      expect(scriptRes.status).toBe(201);
+
+      // --- 3. git_repository resource + git-sync config (scripts included) ---
+      await backend.apiRequest!(`/api/w/${ws}/resources/create`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          path: "u/test/promo_repo",
+          resource_type: "git_repository",
+          value: { url: `file://${bareDir}`, branch: "main", token: "" },
+        }),
+      });
+      await backend.updateGitSyncConfig!({
+        git_sync_settings: {
+          repositories: [
+            {
+              git_repo_resource_path: "u/test/promo_repo",
+              script_path: "f/**",
+              use_individual_branch: true,
+              group_by_folder: false,
+              settings: {
+                include_path: ["f/**"],
+                include_type: ["script"],
+              },
+            },
+          ],
+        },
+      });
+
+      // A script always has path_type "script" — modules are a property of the
+      // script, not a distinct object kind — so this hits gitSyncIncludePattern's
+      // default case, the one the fix amends.
+      const deployItems = JSON.stringify([
+        {
+          path_type: "script",
+          path: "f/promo/mod_script",
+          commit_msg: "deploy mod_script",
+        },
+      ]);
+
+      const work = await mkdtemp(join(tmpdir(), "wmill_promo_mod_work_"));
+      git(work, "clone", `file://${bareDir}`, ".");
+      await writeFile(
+        join(work, "wmill.yaml"),
+        "defaultTs: bun\nincludes:\n  - f/**\nexcludes: []\n",
+      );
+      const res = await backend.runCLICommand(
+        [
+          "sync",
+          "git-deploy",
+          "--repository",
+          "u/test/promo_repo",
+          "--use-individual-branch",
+          "--git-deploy-items",
+          deployItems,
+        ],
+        work,
+      );
+      expect(res.code).toBe(0);
+
+      // Caller-half (mirrors the hub script): stage what the pull wrote, commit
+      // on the checked-out wm_deploy branch, push.
+      git(work, "config", "user.email", "test@windmill.dev");
+      git(work, "config", "user.name", "test");
+      git(work, "add", "-A");
+      try {
+        git(work, "diff", "--cached", "--quiet");
+      } catch {
+        git(work, "commit", "-m", "deploy mod_script");
+      }
+      git(work, "push", "--porcelain", "-u", "origin", "HEAD");
+
+      const branch = `wm_deploy/${ws}/script/f__promo__mod_script`;
+      expect(remoteBranches(bareDir)).toContain(`refs/heads/${branch}`);
+      // The regression: every `__mod/` file MUST be present on the branch — the
+      // entry point, the flat module, and the nested module. Without the fix the
+      // extra-includes pattern matches none of them, the pull writes nothing, and
+      // these files are absent (and `git add` would have failed in production).
+      for (const f of [
+        "f/promo/mod_script__mod/script.ts",
+        "f/promo/mod_script__mod/helper.ts",
+        "f/promo/mod_script__mod/utils/math.ts",
+      ]) {
+        expect(fileExistsOnBranch(bareDir, branch, f)).toBe(true);
+      }
+      // Base branch untouched (individual-branch never pushes to the base).
+      expect(remoteHead(bareDir, "main")).toBe(seedMain);
+
+      await rm(bareDir, { recursive: true, force: true });
+      await rm(seedDir, { recursive: true, force: true });
+      await rm(work, { recursive: true, force: true });
+    });
+  },
+);
+
+/**
  * Regression test for WIN-1997: forking a workspace with git sync configured
  * must publish a `wm-fork/<branch>/<id>` branch to the remote.
  *


### PR DESCRIPTION
## Problem

Scripts with companion modules (e.g. workflows-as-code) use a `__mod/` folder layout on disk: `path__mod/script.ts`, `path__mod/script.yaml`, etc. The `gitSyncIncludePattern()` function returned `${path}.*` for scripts (the `default` case), which does not match files inside the `__mod/` directory.

During git-sync deployment, the `extraIncludes` filter in `ignoreF()` uses this pattern, so all module files were excluded from the pull. The subsequent `git add '${path}**'` then failed with `fatal: pathspec did not match any files` because nothing was written to disk.

Flows and apps already handle their dual-layout patterns correctly (e.g. `${path}.flow/*,${path}__flow/*`), but scripts were missing the analogous `__mod` pattern.

## Fix

Change the `default` case of `gitSyncIncludePattern` from `${path}.*` to `${path}.*,${path}__mod/**`, mirroring the existing dual-layout handling for flows (`.flow/*,__flow/*`) and apps (`.app/*,__app/*`). The `__mod` suffix is the module folder convention used throughout the CLI (`MODULE_SUFFIX = "__mod"` in `cli/src/utils/resource_folders.ts`).

## Scope

- `cli/src/utils/git.ts` — added the `__mod/**` pattern to the script (default) case
- `cli/test/git_unit.test.ts` — updated the corresponding unit test

## Validation

`bun test test/git_unit.test.ts` — **33 pass, 0 fail**.

Fixes WIN-2052

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include the `__mod/` folder in the CLI’s `gitSyncIncludePattern` for scripts so module files are pulled during git-sync and the “pathspec did not match any files” error is avoided. Aligns script handling with flows/apps and addresses WIN-2052.

- **Bug Fixes**
  - Updated `gitSyncIncludePattern` default to return `${path}.*,${path}__mod/**`.
  - Updated tests: unit test expects the new pattern; added an e2e promotion test to ensure `__mod/` files land on `wm_deploy/...` branches.

<sup>Written for commit c71a8fa955fd3628a15231ed4596defa229d4531. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

