### PR TITLE
fix(frontend): make run-page flow graph scrollable (#3830)

### DIFF
--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -1072,7 +1072,7 @@
 {/if}
 <div
 	style={`height: ${height}px; max-height: ${maxHeight}px;`}
-	class="overflow-clip relative {outerDivClass}"
+	class="overflow-y-auto overflow-x-clip relative {outerDivClass}"
 	bind:clientWidth={debouncedWidth}
 	bind:this={flowContainer}
 >

--- a/frontend/src/lib/components/graph/FlowGraphV2.svelte
+++ b/frontend/src/lib/components/graph/FlowGraphV2.svelte
@@ -1297,7 +1297,7 @@
 {/if}
 <div
 	style={`height: ${height}px; max-height: ${maxHeight}px;`}
-	class="overflow-clip relative {outerDivClass}"
+	class="overflow-y-auto overflow-x-clip relative {outerDivClass}"
 	bind:clientWidth={debouncedWidth}
 	bind:this={flowContainer}
 >


### PR DESCRIPTION
On the run page the flow graph is rendered without a maxHeight, so its height grows to the full content height. The wrapper used overflow-clip and was itself capped by max-h-screen, so once the graph was taller than the viewport the overflow was clipped with no way to reach the lower nodes.

Switch the wrapper to overflow-y-auto overflow-x-clip so a vertical scrollbar appears only when the content overflows. The flow editor passes maxHeight equal to its container, so its graph never overflows and is unaffected.

Fixes #3830

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the run page flow graph vertically scrollable so users can reach nodes below the viewport. Previously overflow was clipped once the graph exceeded the screen; now a vertical scrollbar appears only when content overflows. Fixes #3830.

- **Details**
  - In `FlowGraphV2`, switch wrapper class to `overflow-y-auto overflow-x-clip` (height/max-height styles unchanged); horizontal overflow remains clipped.
  - Effect: the run page shows a vertical scrollbar when needed; the flow editor is unchanged because it sets `maxHeight` to its container.

<sup>Written for commit 5d63bb183c655fa410ffd5c0d79e287c66e3aae3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

