### PR TITLE
fix(frontend): seed detached user-draft handles so new-item drawers render

### DIFF
--- a/frontend/src/lib/userDraft.svelte.ts
+++ b/frontend/src/lib/userDraft.svelte.ts
@@ -477,6 +477,11 @@ export const UserDraft = {
 		const handles = $state<UserDraftHandle<V>[]>([])
 		const acquired = new Set<string>()
 		const handleCache = new Map<string, UserDraftHandle<V>>()
+		// `defaultValue` reference last used to seed each detached (empty-path)
+		// handle. The reference is stable within an editing session but swapped
+		// for a fresh clone each time the caller restarts (e.g. reopening the
+		// new-item drawer) — so a change here means "re-seed", not "live edit".
+		const detachedSeeds = new Map<string, unknown>()
 
 		function reconcile() {
 			const specs = getSpecs()
@@ -493,10 +498,24 @@ export const UserDraft = {
 				// `POST /drafts/update/kind/` (permanent "Save failed").
 				// Hand out a detached, local-only handle instead.
 				if (!spec.path) {
+					seen.add(mk)
 					let handle = handleCache.get(mk)
+					// Drop the cached handle when the caller hands in a fresh
+					// `defaultValue` reference (reopening the new-item drawer seeds a
+					// new clone) so the rebuilt handle re-seeds instead of replaying
+					// the previous session's edits. Stable reference within a session
+					// means live edits are never clobbered.
+					if (handle && detachedSeeds.get(mk) !== spec.defaultValue) {
+						handleCache.delete(mk)
+						handle = undefined
+					}
 					if (!handle) {
-						handle = makeDetachedHandle<V>()
+						// Seed with `defaultValue` so consumers (e.g. the new-variable
+						// drawer, whose path is empty until the user types one) get a
+						// populated cell to bind their form to instead of `undefined`.
+						handle = makeDetachedHandle<V>(spec.defaultValue)
 						handleCache.set(mk, handle)
+						detachedSeeds.set(mk, spec.defaultValue)
 					}
 					next.push(handle)
 					continue
@@ -527,6 +546,16 @@ export const UserDraft = {
 					releaseEntry(mk)
 					acquired.delete(mk)
 					handleCache.delete(mk)
+				}
+			}
+
+			// Detached handles (empty-path) live only in `handleCache` — they're
+			// never in `acquired`. Drop any that fell out of the specs so they
+			// don't leak and a later reappearance rebuilds from scratch.
+			for (const mk of [...handleCache.keys()]) {
+				if (!acquired.has(mk) && !seen.has(mk)) {
+					handleCache.delete(mk)
+					detachedSeeds.delete(mk)
 				}
 			}
 
@@ -705,8 +734,8 @@ function releaseEntry(mk: string): void {
  * `bind:` but is wired to nothing (no entry, no sync, no POSTs). For views
  * that bind an editor value with no draftable item behind it.
  */
-function makeDetachedHandle<V>(): UserDraftHandle<V> {
-	let val = $state<V | undefined>(undefined)
+function makeDetachedHandle<V>(defaultValue?: V): UserDraftHandle<V> {
+	let val = $state<V | undefined>(snapshotDraftValue(defaultValue))
 	return {
 		get draft(): V | undefined {
 			return val


### PR DESCRIPTION
## Summary

Fixes **WIN-2054** — the "Add a variable" drawer opened empty (only a title and a disabled Save button, no form fields).

### Root cause

Regression from #9351 (db-backed user drafts). `VariableEditor` renders its form behind `{#if current}` where `current = states[ws]?.draft`. For a **new** item, `editPath` is `undefined`, so the draft spec's `path` is empty. In `UserDraft.useMany`, an empty path routes through the "detached, local-only handle" branch (meant for read-only views with no draftable item). That branch called `makeDetachedHandle()` whose cell was initialized to `undefined` and **ignored the spec's `defaultValue`** — so `current` stayed `undefined` and the form never rendered.

### Fix

- Seed the detached handle with the spec's `defaultValue` (deep-cloned, mirroring how real entries seed).
- Re-seed when the caller supplies a **fresh `defaultValue` reference** — reopening the drawer pushes a newly cloned default, so the handle rebuilds clean instead of replaying the previous session's edits. The reference is stable within a single editing session, so live user edits are never clobbered.
- Drop detached handles that fall out of the specs so they don't leak.

## Changes

- `frontend/src/lib/userDraft.svelte.ts`:
  - `makeDetachedHandle` now accepts and seeds a `defaultValue`.
  - `useMany`'s empty-path branch tracks the seed reference (`detachedSeeds`) and rebuilds the handle when it changes; releases detached handles no longer in the specs.

## Test plan

Verified end-to-end with Playwright against the running dev server:

- [x] "Add a variable" drawer now renders the full form (Path, Secret, Value, Description).
- [x] Creating a variable saves correctly (`u/admin/test_var_2054` created).
- [x] Closing and reopening "New variable" in the same session shows a **fresh** form (a different random path suggestion, empty value) — no stale data from the previous open.
- [x] Editing an existing variable still works (title + path render; secret value loads on demand as before).
- [x] `svelte-check` reports no new errors in the changed file (remaining errors are pre-existing `Timeout`-vs-`number` across the repo).

## Screenshots

"Add a variable" drawer after the fix — form renders fully:

![after-fix](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2054-the-add-a-variable-drawer-is-broken-when-opened-its-empty/1781603222-after-fix.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WIN-2054 by seeding detached user-draft handles with the spec `defaultValue` so "Add a variable" and other new-item drawers render their forms. Also re-seeds on reopen and cleans up unused handles to prevent stale data and leaks.

- **Bug Fixes**
  - `makeDetachedHandle` now accepts `defaultValue`; `UserDraft.useMany` seeds detached (empty-path) handles so forms bind to a real value.
  - Track the `defaultValue` reference and rebuild the handle when it changes to start fresh on reopen.
  - Drop detached handles that fall out of the specs to avoid leaks.

<sup>Written for commit 34de395d2134b73193e1b010cf6ff332e5c24431. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

