### PR TITLE
fix(frontend): global AI chat fails to read back drafts after write

### DIFF
--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -138,10 +138,10 @@ const ACTIVE_GLOBAL_EDITOR_DRAFTS: readonly {
 	itemKind: LiveEditorDraftKind
 	type: ActiveGlobalEditorType
 }[] = [
-		{ itemKind: 'script', type: 'script' },
-		{ itemKind: 'flow', type: 'flow' },
-		{ itemKind: 'raw_app', type: 'app' }
-	]
+	{ itemKind: 'script', type: 'script' },
+	{ itemKind: 'flow', type: 'flow' },
+	{ itemKind: 'raw_app', type: 'app' }
+]
 
 export type GlobalActiveEditorContext = {
 	type: ActiveGlobalEditorType
@@ -351,14 +351,8 @@ const getJobLogsSchema = z.object({
 })
 
 const listRunsSchema = z.object({
-	path: z
-		.string()
-		.optional()
-		.describe('Filter to runs of this exact script or flow path.'),
-	created_by: z
-		.string()
-		.optional()
-		.describe('Filter by the username that started the run.'),
+	path: z.string().optional().describe('Filter to runs of this exact script or flow path.'),
+	created_by: z.string().optional().describe('Filter by the username that started the run.'),
 	label: z.string().optional().describe('Filter by job label.'),
 	success: z
 		.boolean()
@@ -656,13 +650,14 @@ Rules:
 - After creating or editing a script or flow draft, run test_run_script, test_run_flow, or test_run_step with representative args before reporting that it works. These tools prefer local drafts, so testing does not require deployment.
 - Use list_runs to find recent runs (optionally filtered by path, creator, label, or status), then get_job_logs with a returned id to inspect a specific run's logs — without starting a new test run.
 - When a required decision is ambiguous, use askUserQuestion with two to ten clear proposed answer strings instead of guessing. The user can also type a custom answer when none of the proposed answers fit.
-- Keep context targeted.${previewTools
+- Keep context targeted.${
+	previewTools
 		? `
 - After writing or substantially editing a script / flow / app draft, show it via open_preview(kind, path) so the user sees the editor and live preview right next to the chat. First check whether it is already shown: if unsure, call get_preview_status. Only call open_preview (or offer to) when no preview is open or it is showing a different item — don't re-open a preview already showing the item you just edited.
 - When debugging a running raw app, call get_app_runtime_logs to read the live preview's browser console output. It needs the raw app preview open (open_preview kind="raw_app").
 - get_app_runtime_logs only shows the app's browser console. For the server-side logs of a backend runnable the app invoked (a backend.<id> call), call list_app_runs to get that run's job_id from the live preview, then get_job_logs with it. Use this when a backend call errors or returns something unexpected.`
 		: ''
-	}
+}
 
 Flows:
 - read_workspace_item returns compact flow JSON. Inline script bodies appear as "inline_script.<moduleId>".
@@ -891,11 +886,11 @@ function buildPersistedRunnable(
 ): PersistedRunnable {
 	const fields = input.staticInputs
 		? Object.fromEntries(
-			Object.entries(input.staticInputs).map(([k, v]) => [
-				k,
-				{ type: 'static', value: v, fieldType: 'object' }
-			])
-		)
+				Object.entries(input.staticInputs).map(([k, v]) => [
+					k,
+					{ type: 'static', value: v, fieldType: 'object' }
+				])
+			)
 		: (existing?.fields ?? {})
 
 	if (input.type === 'inline') {
@@ -2046,7 +2041,7 @@ export const globalTools: Tool<{}>[] = [
 			const result = await getSessionRuntimeLogs(parsed.limit ?? 10, sessionIdFromCtx(ctx))
 			ctx.toolCallbacks.setToolStatus(ctx.toolId, {
 				content: result.uiMessage,
-				result: result.toolResult,
+				result: result.toolResult
 			})
 			return result.aiResult
 		}
@@ -2055,7 +2050,7 @@ export const globalTools: Tool<{}>[] = [
 		def: createToolDef(
 			listAppRunsSchema,
 			'list_app_runs',
-			"List the backend runnable executions (jobs) the raw app preview currently open in this AI session has triggered, newest first."
+			'List the backend runnable executions (jobs) the raw app preview currently open in this AI session has triggered, newest first.'
 		),
 		showDetails: true,
 		fn: async (ctx) => {
@@ -2378,10 +2373,15 @@ function getRequiredGlobalDraft(
 
 function finishDraftWrite(stored: WorkspaceItem, existed: boolean, ctx: WriteDraftCtx): string {
 	const verb = existed ? 'Updated' : 'Created'
+	// Don't echo the flow value back: the model just sent it in the write call,
+	// so reflecting the (large) compact flow JSON only burns tokens. Variables
+	// echo a redacted item; everything else round-trips its small payload.
 	const serializedItem =
-		stored.type === 'variable' || stored.type === 'flow'
-			? serializeWorkspaceItemForRead(stored)
-			: stored
+		stored.type === 'flow'
+			? undefined
+			: stored.type === 'variable'
+				? serializeWorkspaceItemForRead(stored)
+				: stored
 
 	ctx.toolCallbacks.setToolStatus(ctx.toolId, {
 		content: `${verb} ${stored.type} "${stored.path}" as a draft`,
@@ -2530,9 +2530,9 @@ async function writeScheduleDraft(args: NewSchedule, ctx: WriteDraftCtx): Promis
 		? existingDraft
 		: backendExists
 			? ((await ScheduleService.getSchedule({
-				workspace,
-				path: args.path
-			})) as ScheduleDraftConfig)
+					workspace,
+					path: args.path
+				})) as ScheduleDraftConfig)
 			: undefined
 	const draft = mergeDraftConfig<ScheduleDraftConfig>(base, args as DraftConfig, args.path)
 

--- a/frontend/src/lib/userDraft.svelte.ts
+++ b/frontend/src/lib/userDraft.svelte.ts
@@ -120,6 +120,35 @@ const liveEditorDrafts = new Map<string, LiveEditorDraft>()
  * Consumed by `acquireEntry`; cleared by the matching `restartSync`. */
 const pendingSuspensions = new Set<string>()
 
+/**
+ * Synchronous read-through cache for values written via `save` while no live
+ * editor entry exists. That branch persists through the debounced
+ * `UserDraftDbSyncer` (async, fire-and-forget), so without this a same-tab
+ * `save(...)` followed by `get(...)` would miss its own write: the global AI
+ * chat writes a draft then immediately reads it back to return the result and
+ * would otherwise throw "Could not read written draft". A live entry shadows
+ * the cache (the entry is authoritative) and a release drops the key; a delete
+ * (`remove`/`discard`) evicts it.
+ */
+const writtenCache = new Map<
+	string,
+	{ workspace: string; itemKind: UserDraftItemKind; path: string; val: unknown }
+>()
+
+function rememberWrite(
+	workspace: string,
+	itemKind: UserDraftItemKind,
+	path: string,
+	val: unknown
+): void {
+	const mk = mapKey(workspace, itemKind, path)
+	if (val === undefined) {
+		writtenCache.delete(mk)
+	} else {
+		writtenCache.set(mk, { workspace, itemKind, path, val: snapshotDraftValue(val) })
+	}
+}
+
 function resolveWorkspace(opts?: UserDraftOptions): string {
 	const ws = opts?.workspace ?? get(workspaceStore)
 	if (!ws) {
@@ -207,8 +236,10 @@ export const UserDraft = {
 			// and POSTs it.
 			entry.state.val = value
 		} else {
-			// No live handle: push straight to the syncer. The next editor
-			// mount re-fetches the draft from the backend.
+			// No live handle: remember the value so a same-tab read-after-write
+			// observes it synchronously (the syncer POST below is debounced),
+			// then persist. The next editor mount re-fetches from the backend.
+			rememberWrite(ws, itemKind, path, value)
 			void UserDraftDbSyncer.save({ workspace: ws, itemKind, path, value })
 		}
 	},
@@ -225,8 +256,10 @@ export const UserDraft = {
 		const ws = resolveWorkspace(opts)
 		const mk = mapKey(ws, itemKind, path)
 		const entry = entries.get(mk)
-		if (!entry) return undefined
-		return snapshotDraftValue(entry.state.val as V | undefined)
+		if (entry) return snapshotDraftValue(entry.state.val as V | undefined)
+		const cached = writtenCache.get(mk)
+		if (cached) return snapshotDraftValue(cached.val as V | undefined)
+		return undefined
 	},
 
 	/**
@@ -237,8 +270,8 @@ export const UserDraft = {
 		const ws = resolveWorkspace(opts)
 		const mk = mapKey(ws, itemKind, path)
 		const entry = entries.get(mk)
-		if (!entry) return false
-		return entry.state.val !== undefined
+		if (entry) return entry.state.val !== undefined
+		return writtenCache.get(mk)?.val !== undefined
 	},
 
 	remove(itemKind: UserDraftItemKind, path: string, opts?: UserDraftOptions): void {
@@ -251,6 +284,7 @@ export const UserDraft = {
 			entry.skipNextSync = true
 			entry.state.val = undefined
 		}
+		writtenCache.delete(mk)
 		void UserDraftDbSyncer.save({ workspace: ws, itemKind, path, value: null })
 	},
 
@@ -319,15 +353,30 @@ export const UserDraft = {
 		const ws = resolveWorkspace(opts)
 		const itemKinds = opts?.itemKinds ?? USER_DRAFT_ITEM_KINDS
 		const out: UserDraftEntry<V>[] = []
+		const seen = new Set<string>()
 		for (const entry of entries.values()) {
 			if (entry.workspace !== ws || !itemKinds.includes(entry.itemKind)) continue
 			const val = untrack(() => entry.state.val as V | undefined)
 			if (val === undefined) continue
+			seen.add(mapKey(entry.workspace, entry.itemKind, entry.path))
 			out.push({
 				workspace: entry.workspace,
 				itemKind: entry.itemKind,
 				path: entry.path,
 				value: snapshotDraftValue(val)
+			})
+		}
+		// Drafts written without a live entry (e.g. global AI chat) live only in
+		// `writtenCache`; surface them too so the list matches what `get` returns.
+		for (const cached of writtenCache.values()) {
+			if (cached.workspace !== ws || !itemKinds.includes(cached.itemKind)) continue
+			const mk = mapKey(cached.workspace, cached.itemKind, cached.path)
+			if (seen.has(mk)) continue
+			out.push({
+				workspace: cached.workspace,
+				itemKind: cached.itemKind,
+				path: cached.path,
+				value: snapshotDraftValue(cached.val as V | undefined)
 			})
 		}
 		return out
@@ -391,6 +440,10 @@ export const UserDraft = {
 			entry.skipNextSync = true
 			entry.state.val = safeFallback
 		}
+		// The draft is deleted server-side (the `null` POST below); the fallback
+		// only resets the live handle's UI. Drop the cache so a no-entry read
+		// reports "no draft" rather than the discarded value.
+		writtenCache.delete(mk)
 		void UserDraftDbSyncer.save({ workspace: ws, itemKind, path, value: null, auto: opts?.auto })
 	},
 
@@ -695,6 +748,10 @@ function releaseEntry(mk: string): void {
 	if (!entry) return
 	entry.count--
 	if (entry.count <= 0) {
+		// The live entry was authoritative while mounted; once gone, drop any
+		// cached write for this key so a later read falls back to the server
+		// rather than a value the editor may have changed in the meantime.
+		writtenCache.delete(mk)
 		entry.destroyRoot?.()
 		entries.delete(mk)
 	}
@@ -742,4 +799,5 @@ function makeHandle<V>(
 export function __resetUserDraftForTesting(): void {
 	entries.clear()
 	liveEditorDrafts.clear()
+	writtenCache.clear()
 }


### PR DESCRIPTION
## Summary

The global AI chat's draft-write tools (`write_flow`, `set_flow_module_code`, `write_script`, `write_resource`, `write_variable`, schedule/trigger writes) write a draft and then immediately read it back to build the tool result. When the target entity isn't open in an editor — the normal case for the global chat — that read-back returned `undefined` and the tool threw **`Could not read written draft …`**.

Root cause is an asymmetry in `UserDraft`: with no live editor entry, `save` only forwarded the value to the **debounced** `UserDraftDbSyncer` (an async server POST) and created nothing in memory, while `get` read only the in-memory `entries` map. So a same-tab `save(...)` → `get(...)` couldn't observe its own write until a future editor mount re-fetched it from the backend.

This regressed when the global chat was moved onto the DB-backed `UserDraft` system; **29 of 67 tests in `global/core.test.ts` were failing** (every write-then-read-back tool).

## Changes

- **`userDraft.svelte.ts`** — added a synchronous write-through cache (`writtenCache`) so a write is observable without a live entry:
  - `save` (no-live-entry branch) records the value before the debounced POST.
  - `get` / `has` / `list` fall back to the cache (a live entry still shadows it — the entry stays authoritative).
  - Evicted on `remove` / `discard` (a delete must read back as "no draft") and on `releaseEntry` (so a later read falls back to the server, not a value the editor may have since changed — this also bounds the cache).
  - Cleared in `__resetUserDraftForTesting`.
- **`global/core.ts`** — `finishDraftWrite` no longer echoes the flow value back in the tool result (`flow → item: undefined`). This is a latent bug the fix unmasked: `write_flow` always threw before, so that branch never actually ran, and a test pins that flows "must not echo the flow value back to the model" (the model just sent it — pure token waste). Variables still echo a redacted item; other kinds round-trip their small payload.
- The remaining `global/core.ts` hunks are Prettier reformatting applied by the repo formatter on save (no behavioral change).

## Test plan

- [x] `global/core.test.ts`: **29 failing → 0**, full suite 67/67 green (covers write-then-read for variable, resource, script, flow, schedule, trigger, app, and `set_flow_module_code`).
- [x] `core.test.ts:1361` pins the `finishDraftWrite` flow-no-echo contract; the variable-redaction test still passes.
- [x] `svelte-check`: 0 errors on both changed files.
- [ ] Optional live check: in the global AI chat, ask it to write a flow/script/resource draft for a path with no open editor → tool returns success (no "Could not read written draft"); for a flow the result omits the echoed flow JSON, a variable shows the redacted item.

## Screenshots

No visible UI surface — this is AI-chat tool/draft-store logic. Behavior is fully captured by the in-repo unit tests above; an end-to-end browser demo would require a configured LLM provider.

## Follow-up (non-blocking)

No dedicated `userDraft.svelte.test.ts` exists; the new `list`/`has` fallbacks and `releaseEntry` eviction are covered transitively via the global chat tests. A small sibling test asserting (a) `list`/`has` surface a no-entry write, (b) a live entry shadows the cache, (c) `releaseEntry` drops the cached value would lock the lifecycle invariants in directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes global chat draft-write tools failing to read back drafts when the target item isn’t open. Adds a write-through cache in `UserDraft` so same-tab read-after-write works, and stops echoing flow JSON in tool results.

- **Bug Fixes**
  - `userDraft.svelte.ts`: Add sync write-through cache for saves without a live entry; `get`/`has`/`list` fall back to it. Evicted on `remove`/`discard` and `releaseEntry`. Cleared in `__resetUserDraftForTesting`.
  - `global/core.ts`: `finishDraftWrite` no longer includes flow value in the tool result (variables still return a redacted item; others unchanged). Remaining changes are formatting only.
  - Tests: All write-then-read cases in `global/core.test.ts` now pass (29→0; suite 67/67).

<sup>Written for commit 084f2c9d0a3ce179588922b183ec73a71fcbe4af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

