### PR TITLE
fix(frontend): open draft-only apps in editor from home list

### DIFF
--- a/frontend/src/lib/components/common/table/AppRow.svelte
+++ b/frontend/src/lib/components/common/table/AppRow.svelte
@@ -102,7 +102,9 @@
 {/if}
 
 <Row
-	href="{base}/apps{app.raw_app ? '_raw' : ''}/get/{app.path}"
+	href={app.draft_only
+		? `${base}/apps${app.raw_app ? '_raw' : ''}/edit/${app.path}`
+		: `${base}/apps${app.raw_app ? '_raw' : ''}/get/${app.path}`}
 	kind="app"
 	{marked}
 	path={(app as any).draft_path ?? app.path}


### PR DESCRIPTION
## Summary

A draft-only app — one that exists only in the `draft` table because it was created and exited without ever being deployed — failed to load when opened from the home list. The row linked to the viewer `/get/` route, whose backend `get_app_lite` handler 404s when there is no deployed `app_version`, so the page showed an "App not found" error instead of opening.

This routes `draft_only` apps to the `/edit/` route instead, matching the behavior already present in `ScriptRow.svelte` and `FlowRow.svelte`. Covers both raw and regular draft-only apps.

## Changes

- `frontend/src/lib/components/common/table/AppRow.svelte`: the row's `href` now points to `/apps{_raw}/edit/<path>` when `app.draft_only`, otherwise the viewer `/apps{_raw}/get/<path>` as before. The `raw_app` suffix logic is preserved for both branches.

## Screenshots

Home list — draft-only raw app row now links to the editor (`/apps_raw/edit/...`):

![draft_home_list](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/draft-app-load-error/1781605268-draft_home_list.png)

Clicking it opens the editor and loads the draft (previously this 404'd via the viewer route):

![draft_raw_EDIT_new](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/draft-app-load-error/1781605268-draft_raw_EDIT_new.png)

## Test plan

- [ ] Create an app, save it as a draft only (never deploy), exit the editor
- [ ] From the home list, click the draft-only app row → opens the editor (`/apps/edit/<path>`) instead of 404ing
- [ ] Same for a raw app → opens `/apps_raw/edit/<path>`
- [ ] A normally deployed app still opens the viewer (`/apps/get/<path>` / `/apps_raw/get/<path>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)