### PR TITLE
fix(nativets): respect custom CA certs in in-process fetch runtime

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -15206,6 +15206,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "lazy_static",
+ "rcgen",
  "regex",
  "reqwest 0.13.1",
  "rustls 0.23.35",

--- a/backend/windmill-runtime-nativets/Cargo.toml
+++ b/backend/windmill-runtime-nativets/Cargo.toml
@@ -48,6 +48,9 @@ futures.workspace = true
 sqlx.workspace = true
 rustls.workspace = true
 
+[dev-dependencies]
+rcgen = "0.13.2"
+
 [build-dependencies]
 deno_fetch.workspace = true
 deno_webidl.workspace = true

--- a/backend/windmill-runtime-nativets/src/cert_tests.rs
+++ b/backend/windmill-runtime-nativets/src/cert_tests.rs
@@ -135,6 +135,39 @@ fn multiple_ca_env_vars_pointing_at_same_file_dedupe_to_one_root() {
 }
 
 #[test]
+fn worker_config_env_var_adds_custom_root() {
+    // A CA configured only through the worker-group config (DB `env_vars_static`
+    // / allowlisted forwarded vars) lands in `WORKER_CONFIG.env_vars`, not the
+    // worker's own process env. Child Deno/Bun jobs receive it via `.envs(...)`;
+    // nativets must pick it up from the same place. Regression for the in-process
+    // path missing that source.
+    use windmill_common::worker::WORKER_CONFIG;
+
+    let path = write_test_ca("workercfg");
+    with_cleared_ca_env(|| {
+        let prev = WORKER_CONFIG.load_full();
+        let mut cfg = (*prev).clone();
+        cfg.env_vars.insert(
+            "SSL_CERT_FILE".to_string(),
+            path.to_string_lossy().into_owned(),
+        );
+        WORKER_CONFIG.store(std::sync::Arc::new(cfg));
+
+        let provider = build_native_root_cert_store_provider();
+        // restore before asserting so a failure can't leak the mutated global
+        WORKER_CONFIG.store(prev);
+
+        let provider = provider.expect("worker-config CA must produce a provider");
+        let store = provider.get_or_try_init().expect("store init");
+        assert_eq!(
+            store.len(),
+            deno_tls::create_default_root_cert_store().len() + 1
+        );
+    });
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
 fn deno_cert_adds_custom_root() {
     let path = write_test_ca("deno");
     with_cleared_ca_env(|| {

--- a/backend/windmill-runtime-nativets/src/cert_tests.rs
+++ b/backend/windmill-runtime-nativets/src/cert_tests.rs
@@ -99,6 +99,42 @@ fn ssl_cert_file_adds_custom_root() {
 }
 
 #[test]
+fn node_extra_ca_certs_adds_custom_root() {
+    let path = write_test_ca("node");
+    with_cleared_ca_env(|| {
+        std::env::set_var("NODE_EXTRA_CA_CERTS", &path);
+        let provider = build_native_root_cert_store_provider()
+            .expect("provider must be Some for NODE_EXTRA_CA_CERTS");
+        let store = provider.get_or_try_init().expect("store init");
+        assert_eq!(
+            store.len(),
+            deno_tls::create_default_root_cert_store().len() + 1
+        );
+    });
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn multiple_ca_env_vars_pointing_at_same_file_dedupe_to_one_root() {
+    // The tracing proxy points SSL_CERT_FILE, NODE_EXTRA_CA_CERTS and DENO_CERT at
+    // the same bundle; the path dedupe in build_native_root_cert_store_provider
+    // loads it once, so the store grows by exactly one (rustls' add does not dedupe).
+    let path = write_test_ca("dupe");
+    with_cleared_ca_env(|| {
+        std::env::set_var("SSL_CERT_FILE", &path);
+        std::env::set_var("NODE_EXTRA_CA_CERTS", &path);
+        std::env::set_var("DENO_CERT", &path);
+        let provider = build_native_root_cert_store_provider().expect("provider must be Some");
+        let store = provider.get_or_try_init().expect("store init");
+        assert_eq!(
+            store.len(),
+            deno_tls::create_default_root_cert_store().len() + 1
+        );
+    });
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
 fn deno_cert_adds_custom_root() {
     let path = write_test_ca("deno");
     with_cleared_ca_env(|| {

--- a/backend/windmill-runtime-nativets/src/cert_tests.rs
+++ b/backend/windmill-runtime-nativets/src/cert_tests.rs
@@ -1,0 +1,115 @@
+//! Regression tests for custom CA support in the in-process nativets fetch
+//! runtime (WIN-2055).
+//!
+//! `deno_fetch` with `root_cert_store_provider: None` trusts only the Mozilla
+//! webpki roots, so scripts calling internal APIs fronted by a corporate CA
+//! failed with `invalid peer certificate: UnknownIssuer`. The provider built by
+//! `build_native_root_cert_store_provider` merges CAs from `DENO_CERT` /
+//! `SSL_CERT_FILE` / `NODE_EXTRA_CA_CERTS` / `DENO_TLS_CA_STORE=system` into the
+//! default store. These tests pin that behaviour.
+
+use crate::{build_native_root_cert_store_provider, load_pem_certs_from_path};
+
+/// The CA-related env vars the provider inspects. Cleared around each test so a
+/// CI runner that happens to set one of them can't perturb the result.
+const CA_ENV_VARS: &[&str] = &[
+    "DENO_CERT",
+    "SSL_CERT_FILE",
+    "NODE_EXTRA_CA_CERTS",
+    "DENO_TLS_CA_STORE",
+];
+
+fn write_test_ca(suffix: &str) -> std::path::PathBuf {
+    let cert = rcgen::generate_simple_self_signed(vec!["windmill-test-ca".to_string()])
+        .expect("generate self-signed cert");
+    let pem = cert.cert.pem();
+    let path = std::env::temp_dir().join(format!(
+        "windmill-nativets-ca-{}-{}.pem",
+        std::process::id(),
+        suffix
+    ));
+    std::fs::write(&path, pem).expect("write cert");
+    path
+}
+
+/// Serializes the env-mutating tests against each other — env is process-global,
+/// so concurrent `set_var`/`remove_var` would otherwise interleave.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn with_cleared_ca_env<T>(f: impl FnOnce() -> T) -> T {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let saved: Vec<(&str, Option<String>)> = CA_ENV_VARS
+        .iter()
+        .map(|k| (*k, std::env::var(k).ok()))
+        .collect();
+    for k in CA_ENV_VARS {
+        std::env::remove_var(k);
+    }
+    let out = f();
+    for (k, v) in saved {
+        match v {
+            Some(v) => std::env::set_var(k, v),
+            None => std::env::remove_var(k),
+        }
+    }
+    out
+}
+
+#[test]
+fn load_pem_certs_parses_self_signed_cert() {
+    let path = write_test_ca("load");
+    let certs = load_pem_certs_from_path(path.to_str().unwrap()).expect("load certs");
+    assert_eq!(certs.len(), 1, "expected exactly one cert in the bundle");
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn load_pem_certs_errors_on_missing_file() {
+    let missing = std::env::temp_dir().join("windmill-nativets-does-not-exist.pem");
+    assert!(load_pem_certs_from_path(missing.to_str().unwrap()).is_err());
+}
+
+#[test]
+fn no_ca_env_yields_no_provider() {
+    // serialize against the env-mutating tests via the shared guard
+    with_cleared_ca_env(|| {
+        assert!(
+            build_native_root_cert_store_provider().is_none(),
+            "without any CA env var the provider must stay None (default-only behaviour)"
+        );
+    });
+}
+
+#[test]
+fn ssl_cert_file_adds_custom_root() {
+    let path = write_test_ca("ssl");
+    with_cleared_ca_env(|| {
+        std::env::set_var("SSL_CERT_FILE", &path);
+        let provider = build_native_root_cert_store_provider()
+            .expect("a custom CA was configured, provider must be Some");
+        let store = provider.get_or_try_init().expect("store init");
+        let default_len = deno_tls::create_default_root_cert_store().len();
+        assert_eq!(
+            store.len(),
+            default_len + 1,
+            "custom CA should be added on top of the Mozilla defaults"
+        );
+    });
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn deno_cert_adds_custom_root() {
+    let path = write_test_ca("deno");
+    with_cleared_ca_env(|| {
+        std::env::set_var("DENO_CERT", &path);
+        let provider =
+            build_native_root_cert_store_provider().expect("provider must be Some for DENO_CERT");
+        let store = provider.get_or_try_init().expect("store init");
+        assert_eq!(
+            store.len(),
+            deno_tls::create_default_root_cert_store().len() + 1
+        );
+    });
+    let _ = std::fs::remove_file(&path);
+}

--- a/backend/windmill-runtime-nativets/src/lib.rs
+++ b/backend/windmill-runtime-nativets/src/lib.rs
@@ -228,6 +228,12 @@ lazy_static! {
     /// layer. `deno_fetch` with `root_cert_store_provider: None` falls back to
     /// the Mozilla webpki roots only, so corporate CAs fail with `UnknownIssuer`.
     /// We read those env vars here and merge the certs into the default store.
+    ///
+    /// Snapshotted once for the process lifetime, like the Deno executor's
+    /// `DENO_CERT`/`DENO_TLS_CA_STORE` lazy statics (`deno_executor.rs`): the
+    /// fetch root store is shared across all (potentially prewarmed) isolates, so
+    /// per-job CA reconfiguration is out of scope. A later `WORKER_CONFIG` reload
+    /// is not picked up until the process restarts.
     static ref NATIVE_ROOT_CERT_STORE_PROVIDER: Option<Arc<dyn RootCertStoreProvider>> =
         build_native_root_cert_store_provider();
 }
@@ -240,6 +246,26 @@ impl RootCertStoreProvider for NativeRootCertStoreProvider {
     fn get_or_try_init(&self) -> Result<&RootCertStore, JsErrorBox> {
         Ok(&self.store)
     }
+}
+
+/// Resolve a CA-related env var the same way the child executors see it: the
+/// worker's own process env, then the worker-group config (`env_vars_allowlist`
+/// forwarded values + DB `env_vars_static` literals, resolved into
+/// `WORKER_CONFIG.env_vars`). Child Deno/Bun jobs receive that config map via
+/// `.envs(...)`, so nativets must consult it too or a CA set only through worker
+/// config would silently not apply in-process.
+fn resolve_ca_env_var(name: &str) -> Option<String> {
+    if let Ok(v) = std::env::var(name) {
+        if !v.is_empty() {
+            return Some(v);
+        }
+    }
+    windmill_common::worker::WORKER_CONFIG
+        .load()
+        .env_vars
+        .get(name)
+        .filter(|v| !v.is_empty())
+        .cloned()
 }
 
 /// Build a root cert store seeded with the Mozilla webpki roots plus any custom
@@ -256,7 +282,7 @@ fn build_native_root_cert_store_provider() -> Option<Arc<dyn RootCertStoreProvid
     // RootCertStore::add does not dedupe — we'd otherwise trust the same root N times.
     let mut seen_paths = std::collections::HashSet::new();
     for var in ["DENO_CERT", "SSL_CERT_FILE", "NODE_EXTRA_CA_CERTS"] {
-        let Some(path) = std::env::var(var).ok().filter(|p| !p.is_empty()) else {
+        let Some(path) = resolve_ca_env_var(var).filter(|p| !p.is_empty()) else {
             continue;
         };
         if !seen_paths.insert(path.clone()) {
@@ -281,8 +307,7 @@ fn build_native_root_cert_store_provider() -> Option<Arc<dyn RootCertStoreProvid
     // and orders the stores — this is purely additive: the Mozilla defaults are
     // always seeded above, and `system` augments them. That is a strict superset
     // of the public roots, which is what the corporate-CA use case needs.
-    if std::env::var("DENO_TLS_CA_STORE")
-        .ok()
+    if resolve_ca_env_var("DENO_TLS_CA_STORE")
         .map(|v| v.split(',').any(|s| s.trim() == "system"))
         .unwrap_or(false)
     {

--- a/backend/windmill-runtime-nativets/src/lib.rs
+++ b/backend/windmill-runtime-nativets/src/lib.rs
@@ -18,6 +18,9 @@ pub use dedicated::{ExecutingIsolate, PrewarmedIsolate, PrewarmedResult};
 #[cfg(test)]
 mod smoke_tests;
 
+#[cfg(test)]
+mod cert_tests;
+
 use std::{
     borrow::Cow,
     cell::RefCell,
@@ -35,8 +38,10 @@ use deno_core::{
     v8::{self, IsolateHandle},
     Extension, JsRuntime, OpState, PollEventLoopOptions, RuntimeOptions,
 };
+use deno_error::JsErrorBox;
 use deno_fetch::FetchPermissions;
 use deno_net::NetPermissions;
+use deno_tls::{rustls::pki_types::CertificateDer, rustls::RootCertStore, RootCertStoreProvider};
 use deno_web::{BlobStore, TimersPermission};
 use itertools::Itertools;
 use lazy_static::lazy_static;
@@ -212,6 +217,90 @@ lazy_static::lazy_static! {
 lazy_static! {
     static ref RE_PROXY: Regex =
         Regex::new(r"^(https?)://(([^:@\s]+):([^:@\s]+)@)?([^:@\s]+)(:(\d+))?$").unwrap();
+}
+
+lazy_static! {
+    /// Root cert store for the in-process nativets fetch runtime.
+    ///
+    /// Unlike the Deno/Bun executors, nativets never spawns a child process, so
+    /// the CA env vars those executors forward (`DENO_CERT`, `DENO_TLS_CA_STORE`,
+    /// `SSL_CERT_FILE`/`NODE_EXTRA_CA_CERTS`) are never consumed by deno's CLI
+    /// layer. `deno_fetch` with `root_cert_store_provider: None` falls back to
+    /// the Mozilla webpki roots only, so corporate CAs fail with `UnknownIssuer`.
+    /// We read those env vars here and merge the certs into the default store.
+    static ref NATIVE_ROOT_CERT_STORE_PROVIDER: Option<Arc<dyn RootCertStoreProvider>> =
+        build_native_root_cert_store_provider();
+}
+
+struct NativeRootCertStoreProvider {
+    store: RootCertStore,
+}
+
+impl RootCertStoreProvider for NativeRootCertStoreProvider {
+    fn get_or_try_init(&self) -> Result<&RootCertStore, JsErrorBox> {
+        Ok(&self.store)
+    }
+}
+
+/// Build a root cert store seeded with the Mozilla webpki roots plus any custom
+/// CAs configured via env. Returns `None` when no custom CA is configured, which
+/// preserves the previous default-only behaviour.
+fn build_native_root_cert_store_provider() -> Option<Arc<dyn RootCertStoreProvider>> {
+    let mut store = deno_tls::create_default_root_cert_store();
+    let mut added = 0usize;
+
+    // File-path env vars, each pointing at a PEM bundle of one or more certs.
+    // `DENO_CERT` mirrors the Deno CLI; `SSL_CERT_FILE` is the OpenSSL standard
+    // also honoured by Bun/Node (via NODE_EXTRA_CA_CERTS).
+    for var in ["DENO_CERT", "SSL_CERT_FILE", "NODE_EXTRA_CA_CERTS"] {
+        let Some(path) = std::env::var(var).ok().filter(|p| !p.is_empty()) else {
+            continue;
+        };
+        match load_pem_certs_from_path(&path) {
+            Ok(certs) => {
+                for cert in certs {
+                    if let Err(e) = store.add(cert) {
+                        tracing::warn!("nativets: failed to add cert from {var}={path}: {e}");
+                    } else {
+                        added += 1;
+                    }
+                }
+            }
+            Err(e) => tracing::warn!("nativets: failed to read CA file {var}={path}: {e}"),
+        }
+    }
+
+    // `DENO_TLS_CA_STORE=system` (comma-separated, may also contain `mozilla`)
+    // pulls in the OS trust store, matching the Deno CLI semantics forwarded by
+    // the Deno executor.
+    if std::env::var("DENO_TLS_CA_STORE")
+        .ok()
+        .map(|v| v.split(',').any(|s| s.trim() == "system"))
+        .unwrap_or(false)
+    {
+        match deno_tls::deno_native_certs::load_native_certs() {
+            Ok(certs) => {
+                for cert in certs {
+                    if store.add(CertificateDer::from(cert.0)).is_ok() {
+                        added += 1;
+                    }
+                }
+            }
+            Err(e) => tracing::warn!("nativets: failed to load system CA store: {e}"),
+        }
+    }
+
+    if added == 0 {
+        return None;
+    }
+    tracing::info!("nativets: loaded {added} custom CA cert(s) into fetch root store");
+    Some(Arc::new(NativeRootCertStoreProvider { store }))
+}
+
+fn load_pem_certs_from_path(path: &str) -> anyhow::Result<Vec<CertificateDer<'static>>> {
+    let file = std::fs::File::open(path)?;
+    let mut reader = std::io::BufReader::new(file);
+    deno_tls::load_certs(&mut reader).map_err(|e| anyhow::anyhow!(e))
 }
 
 // ── Public interface ─────────────────────────────────────────────────
@@ -433,7 +522,7 @@ pub(crate) fn create_nativets_runtime(
     let ext = Extension { name: "windmill", ops: ops.into(), ..Default::default() };
 
     let fetch_options = deno_fetch::Options {
-        root_cert_store_provider: None,
+        root_cert_store_provider: NATIVE_ROOT_CERT_STORE_PROVIDER.clone(),
         user_agent: ann.useragent.unwrap_or_else(|| "windmill/beta".to_string()),
         proxy: ann.proxy.map(|x| deno_tls::Proxy::Http {
             url: x.0,

--- a/backend/windmill-runtime-nativets/src/lib.rs
+++ b/backend/windmill-runtime-nativets/src/lib.rs
@@ -251,11 +251,17 @@ fn build_native_root_cert_store_provider() -> Option<Arc<dyn RootCertStoreProvid
 
     // File-path env vars, each pointing at a PEM bundle of one or more certs.
     // `DENO_CERT` mirrors the Deno CLI; `SSL_CERT_FILE` is the OpenSSL standard
-    // also honoured by Bun/Node (via NODE_EXTRA_CA_CERTS).
+    // also honoured by Bun/Node (via NODE_EXTRA_CA_CERTS). Dedupe by path because
+    // the tracing proxy points several of these at the same bundle, and rustls'
+    // RootCertStore::add does not dedupe — we'd otherwise trust the same root N times.
+    let mut seen_paths = std::collections::HashSet::new();
     for var in ["DENO_CERT", "SSL_CERT_FILE", "NODE_EXTRA_CA_CERTS"] {
         let Some(path) = std::env::var(var).ok().filter(|p| !p.is_empty()) else {
             continue;
         };
+        if !seen_paths.insert(path.clone()) {
+            continue;
+        }
         match load_pem_certs_from_path(&path) {
             Ok(certs) => {
                 for cert in certs {
@@ -271,8 +277,10 @@ fn build_native_root_cert_store_provider() -> Option<Arc<dyn RootCertStoreProvid
     }
 
     // `DENO_TLS_CA_STORE=system` (comma-separated, may also contain `mozilla`)
-    // pulls in the OS trust store, matching the Deno CLI semantics forwarded by
-    // the Deno executor.
+    // pulls in the OS trust store. Unlike the Deno CLI — where the list selects
+    // and orders the stores — this is purely additive: the Mozilla defaults are
+    // always seeded above, and `system` augments them. That is a strict superset
+    // of the public roots, which is what the corporate-CA use case needs.
     if std::env::var("DENO_TLS_CA_STORE")
         .ok()
         .map(|v| v.split(',').any(|s| s.trim() == "system"))


### PR DESCRIPTION
## Summary
Native TS (nativets) workers ignored custom CA certificates and failed with `invalid peer certificate: UnknownIssuer` when calling internal APIs fronted by a corporate CA. PR #9549 only addressed the MITM tracing-proxy cert file, which is injected into **child-process** jobs — nativets runs in-process and never spawns a child, so the CA env vars the Deno/Bun executors forward (`DENO_CERT`, `DENO_TLS_CA_STORE`, `SSL_CERT_FILE`/`NODE_EXTRA_CA_CERTS`) were never consumed.

Root cause: `create_nativets_runtime()` built `deno_fetch::Options` with `root_cert_store_provider: None`. With `None`, `deno_fetch` trusts only the Mozilla webpki roots — it does **not** read any CA env vars (those are Deno CLI features, not embedded `deno_core` features). This is the long-standing GitHub issue #1564.

Fix: provide a `RootCertStoreProvider` that seeds the default Mozilla roots and merges in custom CAs configured via `DENO_CERT`, `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS` (PEM bundle paths) and `DENO_TLS_CA_STORE=system` (OS trust store). When no custom CA is configured the provider stays `None`, preserving the previous default-only behavior exactly.

Fixes WIN-2055.

## Changes
- `windmill-runtime-nativets/src/lib.rs`: add `build_native_root_cert_store_provider()` + `NativeRootCertStoreProvider`, read CA env vars (matching what the Deno/Bun executors forward), and wire the provider into `create_nativets_runtime`'s fetch options.
- `windmill-runtime-nativets/src/cert_tests.rs`: regression tests — PEM parsing, missing-file error, `None` when no CA env set, and a `+1` root delta for `SSL_CERT_FILE` and `DENO_CERT`. Env mutation is serialized behind a mutex and saved/restored per test.
- `windmill-runtime-nativets/Cargo.toml`: add `rcgen` dev-dependency for generating test certs.

## Test plan
- [x] `cargo check -p windmill-runtime-nativets`
- [x] `cargo test -p windmill-runtime-nativets cert_tests` (5 passing)
- [ ] On an instance with a corporate-CA-fronted internal endpoint, set the worker's `SSL_CERT_FILE`/`DENO_CERT` to the corporate bundle, run a nativets script that `fetch`es that internal HTTPS URL, and confirm it succeeds instead of `UnknownIssuer`.
- [ ] With no CA env var set, confirm a nativets `fetch` to a normal public HTTPS endpoint still works (provider stays `None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect custom CA certificates in the in‑process NativeTS fetch runtime so corporate‑CA HTTPS calls succeed instead of UnknownIssuer. Also reads CA env vars from worker‑group config to match Deno/Bun executors; fixes WIN‑2055.

- **Bug Fixes**
  - Provide and wire a `RootCertStoreProvider` into `deno_fetch` for NativeTS.
  - Merge custom CAs from `DENO_CERT`, `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, and `DENO_TLS_CA_STORE=system` on top of Mozilla roots; dedupe identical file paths; `system` is additive; fall back unchanged when unset.
  - Resolve CA env vars from `WORKER_CONFIG.env_vars` in addition to the process env so worker‑group config applies in‑process.
  - Add regression tests for PEM parsing, missing‑file errors, env‑var dedupe, worker‑config envs, and custom CA handling.

- **Dependencies**
  - Add `rcgen` (dev) for generating test certificates.

<sup>Written for commit e5c0292153231b4d5a68874f2ab0dd1a7fbb8c22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

