### PR TITLE
fix(frontend): session Drafts drawer uses raw_app kind for the raw-app diff

### DIFF
--- a/frontend/src/lib/components/sessions/DraftDiffDrawer.svelte
+++ b/frontend/src/lib/components/sessions/DraftDiffDrawer.svelte
@@ -75,10 +75,11 @@
 
 	async function loadValues(d: DiffRow): Promise<{ before: unknown; after: unknown }> {
 		const draftOnly = draftOnlyByKey[`${d.kind}/${d.path}`] ?? false
-		// getDraftDiffValues works on the draft itemKind ('app' for raw apps too);
-		// map the deploy-style display kind back to it.
-		const kind: DraftKind =
-			d.kind === 'raw_app' ? 'app' : ((DRAFT_KIND_BY_DEPLOY_KIND[d.kind] ?? d.kind) as DraftKind)
+		// getDraftDiffValues keys on the draft itemKind: `raw_app` must stay
+		// `raw_app` (the helper sends rawApp:true only for that exact kind, which a
+		// never-deployed raw app needs, else it hits the normal app endpoint and
+		// 404s). Only the trigger display kinds map back from their deploy-style names.
+		const kind = (DRAFT_KIND_BY_DEPLOY_KIND[d.kind] ?? d.kind) as DraftKind
 		const { deployed, draft } = await getDraftDiffValues(kind, d.path, workspaceId, draftOnly)
 		// draft_only items have never been deployed → render as "added" (empty
 		// before), matching how the fork drawer renders added items.

--- a/frontend/src/lib/components/sessions/DraftDiffDrawer.svelte
+++ b/frontend/src/lib/components/sessions/DraftDiffDrawer.svelte
@@ -61,7 +61,18 @@
 				const baseKind = it.raw_app ? 'raw_app' : it.kind
 				const kind = DEPLOY_KIND_BY_DRAFT_KIND[baseKind] ?? baseKind
 				donly[`${kind}/${it.path}`] = it.draft_only
-				return { kind, path: it.path, status: it.draft_only ? 'added' : 'modified' }
+				// A never-deployed app/raw_app is parked at a synthetic `…/draft_<uuid>`
+				// storage path with the user's typed name in `draft_path`; show that
+				// (matches the home list) while `path` stays the storage key for loading.
+				// `summary` comes straight from the draft row, so it shows for every kind
+				// up front instead of only after the diff value loads.
+				return {
+					kind,
+					path: it.path,
+					displayPath: it.draft_path ?? it.path,
+					summary: it.summary,
+					status: it.draft_only ? 'added' : 'modified'
+				}
 			})
 			draftOnlyByKey = donly
 		} catch (e) {

--- a/frontend/src/lib/components/sessions/WorkspaceDiffDrawer.svelte
+++ b/frontend/src/lib/components/sessions/WorkspaceDiffDrawer.svelte
@@ -8,6 +8,13 @@
 		status: DiffStatus
 		ahead?: number
 		behind?: number
+		/** Human-facing path; defaults to `path`. Lets a draft parked at a
+		 * synthetic storage path (`…/draft_<uuid>`) show its friendly typed path
+		 * while keys, value-loading and edit links stay keyed on `path`. */
+		displayPath?: string
+		/** Summary supplied by the data source. Preferred over the one derived
+		 * from the loaded diff value, and shown before that value loads. */
+		summary?: string
 	}
 </script>
 
@@ -86,6 +93,12 @@
 
 	function itemKey(d: DiffRow): string {
 		return `${d.kind}/${d.path}`
+	}
+
+	// Friendly path for display only; `path` stays the storage key everywhere
+	// keys/loads happen, so a never-deployed draft still loads from `…/draft_<uuid>`.
+	function displayPathOf(d: DiffRow): string {
+		return d.displayPath ?? d.path
 	}
 
 	const KIND_LABELS: Record<string, string> = {
@@ -183,7 +196,7 @@
 		}
 		const folderCache = new Map<string, FolderNode>()
 		for (const d of rows) {
-			const parts = d.path.split('/')
+			const parts = displayPathOf(d).split('/')
 			if (parts.length < 2) {
 				root.children.push({ type: 'file', name: d.path, diff: d })
 				continue
@@ -226,8 +239,8 @@
 	}
 
 	function searchableText(d: DiffRow): string {
-		const parts = [d.path, KIND_LABELS[d.kind] ?? d.kind]
-		const s = summaries[itemKey(d)]
+		const parts = [displayPathOf(d), KIND_LABELS[d.kind] ?? d.kind]
+		const s = summaries[itemKey(d)] ?? d.summary
 		if (s) parts.push(s)
 		return parts.join(' ')
 	}
@@ -433,12 +446,12 @@
 		<WorkspaceItemRow
 			kind={node.diff.kind as any}
 			uniformHeight
-			summary={summaries[key]}
+			summary={summaries[key] ?? node.diff.summary}
 			secondary={node.name}
 			highlighted={key === highlightedKey}
 			navKey={key}
 			indent={depth * 12 + 20}
-			title={node.diff.path}
+			title={displayPathOf(node.diff)}
 			onclick={() => {
 				highlightedKey = key
 				scrollToDiff(node.diff)
@@ -556,6 +569,7 @@
 								{@const StatusIcon = statusIcons[status]}
 								{@const loaded = loadedDiffs[key]}
 								{@const editUrl = editUrlFor?.(d)}
+								{@const dpath = displayPathOf(d)}
 								<details
 									open
 									id={rowId(d)}
@@ -573,14 +587,14 @@
 											{#if editUrl}
 												<ExternalEditLink
 													href={editUrl}
-													title={d.path}
+													title={dpath}
 													class="text-xs text-primary font-mono truncate"
 												>
-													<span class="truncate">{d.path}</span>
+													<span class="truncate">{dpath}</span>
 												</ExternalEditLink>
 											{:else}
-												<div class="text-xs text-primary font-mono truncate" title={d.path}>
-													{d.path}
+												<div class="text-xs text-primary font-mono truncate" title={dpath}>
+													{dpath}
 												</div>
 											{/if}
 										</div>

--- a/frontend/src/lib/components/sessions/WorkspaceDiffDrawer.svelte
+++ b/frontend/src/lib/components/sessions/WorkspaceDiffDrawer.svelte
@@ -198,7 +198,7 @@
 		for (const d of rows) {
 			const parts = displayPathOf(d).split('/')
 			if (parts.length < 2) {
-				root.children.push({ type: 'file', name: d.path, diff: d })
+				root.children.push({ type: 'file', name: displayPathOf(d), diff: d })
 				continue
 			}
 			const scopeKey = parts.slice(0, 2).join('/')


### PR DESCRIPTION
## Summary

Two follow-ups to #9601, both touching the session **Drafts** diff drawer (`DraftDiffDrawer` → shared `WorkspaceDiffDrawer`).

### 1. `raw_app` rows 404'd in the diff

A P1 caught by the Codex auto-review that posted **after** #9601 had already merged (locked conversation), so it landed in `main` unaddressed.

`DraftDiffDrawer` mapped a `raw_app` row back to `app` before calling `getDraftDiffValues()`. That helper sends `rawApp: true` only for the exact kind `raw_app` — which a never-deployed raw app needs. With `app` it queried the normal app endpoint and **404'd** instead of rendering the added diff.

- `DraftDiffDrawer.svelte`: pass the row kind straight through to `getDraftDiffValues()` so `raw_app` stays `raw_app`. Only the trigger display kinds need mapping back from their deploy-style names (they're never `app`).

### 2. Apps/raw apps showed a `draft_<uuid>` path and no summary

A never-deployed app/raw_app is parked at a synthetic `u/.../draft_<uuid>` storage path, with the user's typed name in the draft JSON's `draft_path`. The drawer rendered that UUID path. The `drafts/list` endpoint already returns `draft_path` and `summary` for **every** kind, but `fetchDrafts` dropped them and the drawer relied only on a lazily-derived summary. Scripts looked fine because their storage path is already readable — the symptom only surfaces when `path` diverges from the friendly name.

- `WorkspaceDiffDrawer.svelte`: `DiffRow` gains optional `displayPath` (shown in the file tree, panel header and search, while `path` stays the storage key for value-loading, item keys and edit links) and `summary` (preferred over the value-derived one; shown before the diff loads). A `displayPathOf()` helper centralizes the `displayPath ?? path` fallback.
- `DraftDiffDrawer.svelte`: populate both from the draft list (`draft_path ?? path`, `summary`).

Both fields are **opt-in** via `?? path` / lazy fallback, so `ForkDiffDrawer` — the other consumer of the shared component — is unchanged.

## Test plan

- [x] `check:fast` + full `npm run build` clean
- [x] **Raw-app diff renders** (fix 1): draft-only raw-app row opens as an "added" diff (empty before-side) instead of 404ing.
- [x] **Friendly paths + summaries** (fix 2): verified in a browser session against the `local` workspace — raw/visual app drafts (`rapt_app`, `supported_app`, `testing_app`) render their typed paths instead of `u/admin/draft_<uuid>`, and summaries show across kinds (`snake-game` → "A classic Snake game…"). Scripts unchanged. `ForkDiffDrawer` unchanged.

## Screenshots

Session **Drafts** drawer (`local` workspace): app/raw-app drafts now show their typed paths (`rapt_app`, `supported_app`, `testing_app`) instead of `u/admin/draft_<uuid>`, with summaries across kinds — same layout scripts already had.

![drafts-drawer-friendly-paths](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/raw-app-session-diff-fix/1781620426-drafts-drawer-friendly-paths.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)