### PR TITLE
fix(frontend): reset deleteWorkspaceForkModal on confirm in SidebarContent

### DIFF
--- a/frontend/src/lib/components/sidebar/SidebarContent.svelte
+++ b/frontend/src/lib/components/sidebar/SidebarContent.svelte
@@ -881,6 +881,7 @@
 			deleteWorkspaceForkModal = false
 		}}
 		on:confirmed={() => {
+			deleteWorkspaceForkModal = false
 			deleteFork()
 		}}
 	>


### PR DESCRIPTION
## Problem

After confirming deletion of a forked workspace via the sidebar menu, the `deleteWorkspaceForkModal` state was never reset to `false`. The `on:canceled` handler resets it, but the `on:confirmed` handler did not. Since `SidebarContent` persists in the layout across workspace switches, the stale `true` state caused the delete-fork modal to immediately appear when a new fork workspace was created.

## Fix

Add `deleteWorkspaceForkModal = false` before calling `deleteFork()` in the `on:confirmed` handler (`frontend/src/lib/components/sidebar/SidebarContent.svelte`). This matches the existing `on:canceled` handler and the pattern already used in `forks/compare/+page.svelte` and `SessionWrapper.svelte`.

The reset is synchronous `$state`, applied before the async `deleteFork()` call, so it takes effect immediately and is safe.

## Validation

- `npm run check:fast` — ✓ No problems found
- Change is a one-line state reset matching an established codebase pattern.

Fixes WIN-2057

🤖 Generated with [Claude Code](https://claude.com/claude-code)