### PR TITLE
fix(frontend): persist session-editor draft path/summary edits + per-line diff tooltips

### DIFF
--- a/frontend/src/lib/components/EditorHeader.svelte
+++ b/frontend/src/lib/components/EditorHeader.svelte
@@ -237,6 +237,7 @@
 			value={summary ?? ''}
 			placeholder="Add a summary..."
 			editable={summaryEditable}
+			commitOnInput
 			size="sm"
 			onSave={handleSummarySave}
 			textClass="text-xs font-semibold text-emphasis leading-tight"

--- a/frontend/src/lib/components/WorkspaceItemRow.svelte
+++ b/frontend/src/lib/components/WorkspaceItemRow.svelte
@@ -50,7 +50,9 @@ doesn't steal focus from a sibling search input (matches the picker).
 		/** Extra left padding (px) for tree-view indentation. Adds to the
 		 * default `px-3` horizontal padding. */
 		indent?: number
-		/** Title tooltip shown on hover; defaults to the secondary text. */
+		/** Full path tooltip for the secondary line; defaults to the secondary
+		 * text. The summary line gets its own tooltip (the full summary) so each
+		 * truncated line reveals its own content on hover. */
 		title?: string
 		/** When set, the row renders as an `<a href target="_blank">` link
 		 * instead of a `<button>`. Used by callers that want native
@@ -104,7 +106,6 @@ doesn't steal focus from a sibling search input (matches the picker).
 		aria-selected={highlighted}
 		aria-current={current ? 'true' : undefined}
 		data-nav-key={navKey}
-		title={title ?? secondary}
 		style={indent ? `padding-left: calc(0.75rem + ${indent}px)` : undefined}
 		class={rootClass}
 		{onclick}
@@ -113,10 +114,17 @@ doesn't steal focus from a sibling search input (matches the picker).
 		<RowIcon {kind} {triggerKind} size={12} />
 		<div class={contentClass}>
 			{#if summary}
-				<div class="text-xs text-primary truncate">{summary}</div>
-				<div class="text-2xs text-secondary font-normal font-mono truncate">{secondary}</div>
+				<div class="text-xs text-primary truncate" title={summary}>{summary}</div>
+				<div
+					class="text-2xs text-secondary font-normal font-mono truncate"
+					title={title ?? secondary}
+				>
+					{secondary}
+				</div>
 			{:else}
-				<div class="text-xs text-primary font-mono truncate">{secondary}</div>
+				<div class="text-xs text-primary font-mono truncate" title={title ?? secondary}>
+					{secondary}
+				</div>
 			{/if}
 		</div>
 		{#if extras}
@@ -133,7 +141,6 @@ doesn't steal focus from a sibling search input (matches the picker).
 		aria-selected={highlighted}
 		aria-current={current ? 'true' : undefined}
 		data-nav-key={navKey}
-		title={title ?? secondary}
 		style={indent ? `padding-left: calc(0.75rem + ${indent}px)` : undefined}
 		class={rootClass}
 		onmousedown={(e) => e.preventDefault()}
@@ -143,10 +150,17 @@ doesn't steal focus from a sibling search input (matches the picker).
 		<RowIcon {kind} {triggerKind} size={12} />
 		<div class={contentClass}>
 			{#if summary}
-				<div class="text-xs text-primary truncate">{summary}</div>
-				<div class="text-2xs text-secondary font-normal font-mono truncate">{secondary}</div>
+				<div class="text-xs text-primary truncate" title={summary}>{summary}</div>
+				<div
+					class="text-2xs text-secondary font-normal font-mono truncate"
+					title={title ?? secondary}
+				>
+					{secondary}
+				</div>
 			{:else}
-				<div class="text-xs text-primary font-mono truncate">{secondary}</div>
+				<div class="text-xs text-primary font-mono truncate" title={title ?? secondary}>
+					{secondary}
+				</div>
 			{/if}
 		</div>
 		{#if extras}

--- a/frontend/src/lib/components/common/EditableInput.svelte
+++ b/frontend/src/lib/components/common/EditableInput.svelte
@@ -31,12 +31,21 @@ this component just proposes new values.
 		/** Shown when `value` is empty, in both idle and editing modes. */
 		placeholder?: string
 		/**
-		 * Called when the user commits a changed value (Enter or blur). Fires
-		 * with the trimmed draft, including `''` if the user cleared the field.
-		 * Not called on Escape, or on blur when the trimmed draft matches the
-		 * prior `value`. Guard against empty in your handler if needed.
+		 * Called when the user commits a changed value (Enter or blur, or every
+		 * keystroke when {@link commitOnInput} is set). Fires with the trimmed
+		 * draft, including `''` if the user cleared the field. Not called on
+		 * Escape, or when the trimmed draft matches the prior `value`. Guard
+		 * against empty in your handler if needed.
 		 */
 		onSave?: (newValue: string) => void
+		/**
+		 * Fire `onSave` on every keystroke (still trimmed, still de-duped against
+		 * the prior `value`) instead of only on Enter/blur. Use when the parent
+		 * autosaves the field and the user expects edits to land live rather than
+		 * on focus-out. Escape no longer discards (live commits already
+		 * propagated). Off by default to preserve the commit-on-blur contract.
+		 */
+		commitOnInput?: boolean
 		/** When false, the component renders as plain text (not clickable). Default true. */
 		editable?: boolean
 		/** TextInput size in editing mode. Idle mode is unaffected (text only). */
@@ -57,6 +66,7 @@ this component just proposes new values.
 		value,
 		placeholder = '',
 		onSave,
+		commitOnInput = false,
 		editable = true,
 		size = 'sm',
 		class: className = '',
@@ -104,6 +114,15 @@ this component just proposes new values.
 		if (e.key === 'Enter') save()
 		else if (e.key === 'Escape') editing = false
 	}
+
+	// Live commit: propagate each keystroke to the parent (trimmed, de-duped)
+	// so an autosaving field updates as you type instead of only on focus-out.
+	// Reads the DOM value directly so it's correct regardless of the `bind:value`
+	// update order.
+	function handleLiveInput(e: Event) {
+		const next = (e.currentTarget as HTMLInputElement).value.trim()
+		if (next !== (value ?? '')) onSave?.(next)
+	}
 </script>
 
 {#if editing}
@@ -120,6 +139,7 @@ this component just proposes new values.
 				placeholder,
 				onblur: save,
 				onkeydown: handleKeydown,
+				oninput: commitOnInput ? handleLiveInput : undefined,
 				spellcheck: false,
 				size: 1,
 				style: 'padding: 2px !important; grid-area: 1 / 1'

--- a/frontend/src/lib/components/sessions/RawAppEditorView.svelte
+++ b/frontend/src/lib/components/sessions/RawAppEditorView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from 'svelte'
 	import RawAppEditor from '$lib/components/raw_apps/RawAppEditor.svelte'
 	import DiffDrawer from '$lib/components/DiffDrawer.svelte'
 	import type { WorkspaceItem } from '$lib/components/workspacePicker'
@@ -28,6 +29,23 @@
 	} = $props()
 
 	let diffDrawer: DiffDrawer | undefined = $state()
+
+	// Path typed in the editor header, surfaced when it differs from the stored
+	// path. Mirror it into the runtime draft as `draft_path` so the rename
+	// mutates runtime.rawApp.val → the autosave sig changes → the draft is saved
+	// (and the home/review/Drafts lists show the friendly name). Mirrors the
+	// full-page /apps_raw/edit route. Guarded: only write a real typed path and
+	// only on an actual change, so the initial `undefined` never clobbers the
+	// draft_path seeded by loadRawApp nor fires a spurious save.
+	let pendingDraftPath = $state<string | undefined>(undefined)
+	$effect(() => {
+		const dp = pendingDraftPath
+		if (dp === undefined) return
+		untrack(() => {
+			const val = runtime.rawApp.val
+			if (val && val.draft_path !== dp) val.draft_path = dp
+		})
+	})
 
 	async function reloadDeployed() {
 		await runtime.loadRawApp(workspaceId, path, true, true)
@@ -76,7 +94,8 @@
 				bind:runnables={runtime.rawApp.val.runnables}
 				bind:data={runtime.rawApp.val.data}
 				bind:summary={runtime.rawApp.val.summary}
-				newPath={runtime.rawApp.val.path}
+				bind:pendingDraftPath
+				newPath={runtime.rawApp.val.draft_path ?? runtime.rawApp.val.path}
 				{path}
 				autosaveWorkspace={workspaceId}
 				autosavePath={path}

--- a/frontend/src/lib/components/sessions/RawAppEditorView.svelte
+++ b/frontend/src/lib/components/sessions/RawAppEditorView.svelte
@@ -34,16 +34,25 @@
 	// path. Mirror it into the runtime draft as `draft_path` so the rename
 	// mutates runtime.rawApp.val → the autosave sig changes → the draft is saved
 	// (and the home/review/Drafts lists show the friendly name). Mirrors the
-	// full-page /apps_raw/edit route. Guarded: only write a real typed path and
-	// only on an actual change, so the initial `undefined` never clobbers the
-	// draft_path seeded by loadRawApp nor fires a spurious save.
+	// full-page /apps_raw/edit route.
 	let pendingDraftPath = $state<string | undefined>(undefined)
+	// The header collapses both "not yet bound" and "reverted to baseline" to
+	// `undefined`. `surfacedDraftPath` tells them apart: the initial undefined
+	// (before the header binds) must not clobber the `draft_path` seeded by
+	// loadRawApp, but a revert/clear after a real typed path must drop the stale
+	// friendly name — mirroring the script codec's `else delete draft_path`.
+	let surfacedDraftPath = false
 	$effect(() => {
 		const dp = pendingDraftPath
-		if (dp === undefined) return
 		untrack(() => {
 			const val = runtime.rawApp.val
-			if (val && val.draft_path !== dp) val.draft_path = dp
+			if (!val) return
+			if (dp !== undefined) {
+				surfacedDraftPath = true
+				if (val.draft_path !== dp) val.draft_path = dp
+			} else if (surfacedDraftPath && val.draft_path !== undefined) {
+				val.draft_path = undefined
+			}
 		})
 	})
 

--- a/frontend/src/lib/components/sessions/SessionEditorTarget.svelte
+++ b/frontend/src/lib/components/sessions/SessionEditorTarget.svelte
@@ -49,7 +49,7 @@
 
 	function buildCodec(): DraftSyncCodec<any> {
 		if (kind === 'flow') return makeFlowCodec(runtime)
-		if (kind === 'script') return makeScriptCodec(runtime)
+		if (kind === 'script') return makeScriptCodec(runtime, () => path)
 		return makeRawAppCodec(runtime)
 	}
 

--- a/frontend/src/lib/components/sessions/appDraftCodec.test.ts
+++ b/frontend/src/lib/components/sessions/appDraftCodec.test.ts
@@ -59,3 +59,22 @@ describe('appDraftCodec — custom_path round-trip', () => {
 		expect(applyDraftToRuntimeRawApp(base, dv).custom_path).toBe('existing')
 	})
 })
+
+describe('appDraftCodec — draft_path round-trip', () => {
+	it('serializes draft_path so a path edit changes the draft (and its sig)', () => {
+		const draft = runtimeRawAppToDraft(runtime({ draft_path: 'u/admin/friendly' }))
+		expect(draft.draft_path).toBe('u/admin/friendly')
+		// The autosave keys on JSON.stringify(draft); without draft_path a rename
+		// would be invisible and never persist.
+		expect(JSON.stringify(draft)).toContain('u/admin/friendly')
+	})
+
+	it('survives a full runtime → draft → runtime round-trip', () => {
+		const original = runtime({ draft_path: 'u/admin/renamed' })
+		const back = applyDraftToRuntimeRawApp(
+			runtime({ draft_path: undefined }),
+			runtimeRawAppToDraft(original)
+		)
+		expect(back.draft_path).toBe('u/admin/renamed')
+	})
+})

--- a/frontend/src/lib/components/sessions/appDraftCodec.ts
+++ b/frontend/src/lib/components/sessions/appDraftCodec.ts
@@ -11,6 +11,11 @@ export type RawAppDraft = {
 	summary: string
 	policy?: any
 	custom_path?: string
+	// User-typed path while the app is parked at a `…/draft_<uuid>` storage path.
+	// Must round-trip through the draft so the home/review/Drafts lists render the
+	// friendly name (they read `value->>'draft_path'`) — and so editing the path
+	// in the editor changes the persisted draft and triggers an autosave.
+	draft_path?: string
 }
 
 // The shape `runtime.rawApp.val` actually holds (see SessionRuntime in
@@ -24,6 +29,7 @@ export type RuntimeRawApp = {
 	data: RawAppData
 	policy: any
 	custom_path?: string
+	draft_path?: string
 }
 
 // Strip runtime-only metadata (just `path`, the storage key) when persisting
@@ -36,7 +42,8 @@ export function runtimeRawAppToDraft(raw: RuntimeRawApp): RawAppDraft {
 		runnables: raw.runnables,
 		data: raw.data,
 		policy: raw.policy,
-		custom_path: raw.custom_path
+		custom_path: raw.custom_path,
+		draft_path: raw.draft_path
 	}
 }
 
@@ -50,6 +57,7 @@ export function applyDraftToRuntimeRawApp(raw: RuntimeRawApp, dv: RawAppDraft): 
 		runnables: dv.runnables,
 		data: dv.data,
 		policy: dv.policy ?? raw.policy,
-		custom_path: dv.custom_path ?? raw.custom_path
+		custom_path: dv.custom_path ?? raw.custom_path,
+		draft_path: dv.draft_path ?? raw.draft_path
 	}
 }

--- a/frontend/src/lib/components/sessions/flowDraftSig.test.ts
+++ b/frontend/src/lib/components/sessions/flowDraftSig.test.ts
@@ -19,4 +19,15 @@ describe('flowDraftSig', () => {
 			flowDraftSig({ value: { modules: [1] }, summary: 's' })
 		)
 	})
+
+	it('changes when only draft_path changes (path rename triggers a save)', () => {
+		const base = { value: { modules: [] }, summary: 's', draft_path: 'u/admin/draft_abc' }
+		const renamed = { ...base, draft_path: 'u/admin/friendly' }
+		expect(flowDraftSig(base)).not.toBe(flowDraftSig(renamed))
+	})
+
+	it('changes when only path changes', () => {
+		const base = { value: { modules: [] }, summary: 's', path: 'u/admin/a' }
+		expect(flowDraftSig(base)).not.toBe(flowDraftSig({ ...base, path: 'u/admin/b' }))
+	})
 })

--- a/frontend/src/lib/components/sessions/flowDraftSig.ts
+++ b/frontend/src/lib/components/sessions/flowDraftSig.ts
@@ -2,19 +2,26 @@
 //
 // The inbound (draft → editor) and outbound (editor → draft) effects compare
 // this signature to skip no-op work. It MUST include every top-level field the
-// editor can change on its own — `summary` and `description` — otherwise a
-// change to only that field produces an identical signature and never
-// propagates or persists.
+// editor can change on its own — `summary`, `description`, and the path —
+// otherwise a change to only that field produces an identical signature and
+// never propagates or persists. The Path widget writes a rename into
+// `draft_path` (FlowBuilder mirrors the typed path there while the flow is
+// parked at its `…/draft_<uuid>` storage `path`); without it here the rename
+// moves no signature and the draft is never saved.
 export function flowDraftSig(x: {
 	value?: unknown
 	schema?: unknown
 	summary?: unknown
 	description?: unknown
+	path?: unknown
+	draft_path?: unknown
 }): string {
 	return JSON.stringify({
 		value: x.value,
 		schema: x.schema,
 		summary: x.summary,
-		description: x.description
+		description: x.description,
+		path: x.path,
+		draft_path: x.draft_path
 	})
 }

--- a/frontend/src/lib/components/sessions/sessionDraftCodecs.test.ts
+++ b/frontend/src/lib/components/sessions/sessionDraftCodecs.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// `sessionDraftCodecs` statically imports `initFlowState`, which pulls the flow
+// editor's Monaco chain (unloadable under vitest). The script codec never calls
+// it; stub the module so the import resolves.
+vi.mock('$lib/components/flows/flowState', () => ({ initFlowState: () => Promise.resolve() }))
+
+import { makeScriptCodec } from './sessionDraftCodecs'
+import type { SessionRuntime } from './sessionRuntime.svelte'
+import type { NewScript } from '$lib/gen'
+
+// Minimal runtime stub: the script codec only touches `runtime.scriptStore.val`.
+function runtimeWith(script: Partial<NewScript> & { path: string }): SessionRuntime {
+	return { scriptStore: { val: script as NewScript } } as unknown as SessionRuntime
+}
+
+const STORAGE = 'u/admin/draft_abc'
+
+describe('makeScriptCodec — draft_path (path rename)', () => {
+	it('writes draft_path when the typed path differs from the storage key', () => {
+		const codec = makeScriptCodec(
+			runtimeWith({ path: 'u/admin/friendly', content: 'c', summary: 's' }),
+			() => STORAGE
+		)
+		const draft = codec.storeToDraft(undefined) as (NewScript & { draft_path?: string }) | undefined
+		expect(draft?.draft_path).toBe('u/admin/friendly')
+	})
+
+	it('drops draft_path when the typed path equals the storage key', () => {
+		const codec = makeScriptCodec(
+			runtimeWith({ path: STORAGE, content: 'c', summary: 's' }),
+			() => STORAGE
+		)
+		const draft = codec.storeToDraft(undefined) as (NewScript & { draft_path?: string }) | undefined
+		expect(draft?.draft_path).toBeUndefined()
+	})
+
+	it('signature changes on a rename, so the outbound sync persists it', () => {
+		const before = makeScriptCodec(runtimeWith({ path: STORAGE, content: 'c' }), () => STORAGE)
+		const after = makeScriptCodec(
+			runtimeWith({ path: 'u/admin/renamed', content: 'c' }),
+			() => STORAGE
+		)
+		expect(before.sig(before.storeToDraft(undefined)!)).not.toBe(
+			after.sig(after.storeToDraft(undefined)!)
+		)
+	})
+})

--- a/frontend/src/lib/components/sessions/sessionDraftCodecs.ts
+++ b/frontend/src/lib/components/sessions/sessionDraftCodecs.ts
@@ -35,15 +35,32 @@ export function makeFlowCodec(runtime: SessionRuntime): DraftSyncCodec<Flow> {
 	}
 }
 
-export function makeScriptCodec(runtime: SessionRuntime): DraftSyncCodec<NewScript> {
+// `NewScript` has no `draft_path` of its own; the session editor parks a rename
+// there so the home/Drafts lists (which read `draft_path`) show the typed name.
+type ScriptDraft = NewScript & { draft_path?: string }
+
+export function makeScriptCodec(
+	runtime: SessionRuntime,
+	// The draft's storage key (the URL path). A never-deployed script is parked
+	// here at `…/draft_<uuid>` while the user's typed name lives in `script.path`.
+	storagePath: () => string
+): DraftSyncCodec<ScriptDraft> {
 	return {
 		itemKind: 'script',
 		// Must include every field write_script can set — not just content —
 		// else a summary-only/language-only change yields an identical signature
 		// and the inbound/outbound sync skips it (the chat's change is then
 		// invisible in the open editor and clobbered by the next content save).
+		// `draft_path` carries a rename: ScriptBuilder binds the Path widget
+		// straight to `script.path` (no separate draft field like flow/raw_app),
+		// so without it here a rename moves no signature and never autosaves.
 		sig: (d) =>
-			JSON.stringify({ content: d.content ?? '', summary: d.summary, language: d.language }),
+			JSON.stringify({
+				content: d.content ?? '',
+				summary: d.summary,
+				language: d.language,
+				draft_path: d.draft_path
+			}),
 		debounceMs: DEBOUNCE_MS,
 		applyDraftToStore(incoming) {
 			const script = runtime.scriptStore.val
@@ -58,7 +75,16 @@ export function makeScriptCodec(runtime: SessionRuntime): DraftSyncCodec<NewScri
 			if (!script) return undefined
 			// Merge over the existing entry so fields the preview doesn't edit
 			// (set by the chat) survive a content-only save.
-			return { ...(current ?? script), ...script }
+			const merged: ScriptDraft = { ...(current ?? script), ...script }
+			// Surface a rename to the home/Drafts lists, which read `draft_path`
+			// (the typed `script.path` is the draft *value*'s path, not its storage
+			// key). Mirror flow/raw_app: set it only when the typed path differs
+			// from the storage key, and drop it once it matches again so a revert
+			// doesn't leave a stale friendly name behind.
+			const typed = script.path
+			if (typed && typed !== storagePath()) merged.draft_path = typed
+			else delete merged.draft_path
+			return merged
 		}
 	}
 }

--- a/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
@@ -105,6 +105,7 @@ export interface SessionRuntime {
 					summary: string
 					path: string
 					custom_path?: string
+					draft_path?: string
 			  }
 			| undefined
 	}
@@ -600,7 +601,8 @@ function createRuntime(session: Session): SessionRuntime {
 					policy: draftValue?.policy ?? result.policy,
 					summary: draftValue?.summary ?? result.summary ?? '',
 					path: result.path,
-					custom_path: draftValue?.custom_path ?? result.custom_path
+					custom_path: draftValue?.custom_path ?? result.custom_path,
+					draft_path: draftValue?.draft_path
 				}
 				// Seed the per-tab last_sync from the server draft's timestamp so
 				// later saves attach a matching last_sync and the server can reject

--- a/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
@@ -451,7 +451,15 @@ function createRuntime(session: Session): SessionRuntime {
 								)
 							) as NewScript)
 						: {
-								path,
+								// Seed from the draft's own path (a rename lives in `draft_path`,
+								// else `path`), not the storage key. Otherwise re-seeding a renamed
+								// never-deployed draft (e.g. a script→script switch re-runs loadScript
+								// with the draft still in memory) resets the path to `draft_<uuid>`,
+								// and the next autosave drops `draft_path` — clobbering the rename.
+								path:
+									(aiDraft as NewScript & { draft_path?: string }).draft_path ??
+									aiDraft.path ??
+									path,
 								summary: aiDraft.summary ?? '',
 								content: '',
 								description: '',


### PR DESCRIPTION
## Summary

Fixes a set of session-editor (`/sessions`, dev flag `wm_dev_global_ai=1`) draft-autosave gaps and a tooltip issue. In the session editor's two-way draft sync, edits to a draft's **path** never autosaved (the per-kind dedup signature omitted the path), and the header **summary** only committed on focus-out instead of as you type. Extends the earlier raw-app path fix to flows and scripts, and makes the shared summary input commit live.

## Changes

- **Persist draft path edits (raw-app, flow, script).** The session sync (`useUserDraftSync`) dedups on a per-kind signature; the path was missing from it, so a rename moved no signature and never autosaved.
  - Flow: added `path` + `draft_path` to `flowDraftSig` (FlowBuilder already mirrors the typed path into `flowStore.val.draft_path`).
  - Script: scripts bind the Path widget straight to `script.path` and never wrote `draft_path`, so the script codec now derives `draft_path` from the typed path vs the storage key (dropping it on revert) and includes it in the signature — so the rename both autosaves and shows the typed name in the home/Drafts lists. `SessionEditorTarget` passes the storage path into the codec. Contained to the session codec; no change to the shared `ScriptBuilder` or full-page editor.
  - Raw-app: the path fix from the earlier commit (`draft_path` round-trips through the codec).
- **Summary commits live, not on blur.** `EditableInput` only fired `onSave` on Enter/blur. Added an opt-in `commitOnInput` that fires `onSave` (trimmed, de-duped) on each keystroke, and enabled it on the summary in the shared `EditorHeader` — which flow, script, and raw-app all use — so summary edits autosave as you type. Off by default; other `EditableInput` callers are unchanged.
- **Per-line tooltips in workspace item diff rows.** `WorkspaceItemRow` moved the single row-level `title` onto each text line: the summary line shows the full summary on hover, the path line the full path.

## Test plan

Frontend-only; pure-logic codecs are unit-tested (Svelte components are not unit-tested in this repo).

- [x] `flowDraftSig.test.ts` — signature changes on `path`/`draft_path` (rename triggers a save)
- [x] `sessionDraftCodecs.test.ts` (new) — script codec writes/drops `draft_path` vs the storage key; signature changes on rename
- [x] `appDraftCodec.test.ts` — raw-app `draft_path` round-trip
- [x] `npm run check` — 0 errors; all 52 sessions unit tests pass
- [x] Summary live-commit verified in a real browser (full-page flow editor): typing into the header summary propagated to the parent (`title={summary}`) while still in edit mode, no blur
- [ ] In `/sessions`, rename a never-deployed draft (raw-app, flow, script) in the header → Drafts drawer + home/review lists show the friendly name (not `draft_<uuid>`) without a manual save, and the rename survives a reload
- [ ] Edit a summary in the editor header → autosaves live as you type (not only on blur)

## Screenshots

No visual/layout change — the effects are behavioral (autosave timing, draft-path persistence, native `title` tooltip text on hover), none of which a static screenshot captures (native tooltips don't render in headless captures). The summary live-commit was confirmed in a real browser as noted in the test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)