### PR TITLE
feat: per-user draft review & deploy page (gating, badges, rename, raw-app deploy fixes)

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -7898,6 +7898,11 @@ paths:
         - draft
       parameters:
         - $ref: "#/components/parameters/WorkspaceId"
+        - name: all_users
+          in: query
+          description: List every draft in the workspace (all users), not just the current user's own + legacy rows. Other users' rows come back with `mine=false` (view-only).
+          schema:
+            type: boolean
       responses:
         "200":
           description: the user's drafts
@@ -7930,6 +7935,9 @@ paths:
                     can_write:
                       type: boolean
                       description: Whether the current user may deploy/discard this draft (same check the deploy/discard endpoints enforce).
+                    mine:
+                      type: boolean
+                      description: The row belongs to the current user (own draft or the legacy no-owner row) and is therefore actionable. Always true in the default listing; with `all_users=true`, other users' rows are false (view-only).
                     draft_users:
                       description: |
                         Draft authors at this (path, kind) — the legacy NULL-email row surfaced as a null username.
@@ -7942,7 +7950,7 @@ paths:
                           username:
                             type: string
                             nullable: true
-                  required: [kind, path, draft_only, legacy_draft, created_at, can_write]
+                  required: [kind, path, draft_only, legacy_draft, created_at, can_write, mine]
 
   /w/{workspace}/drafts/get/{kind}/{path}:
     get:

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -7927,7 +7927,22 @@ paths:
                     created_at:
                       type: string
                       format: date-time
-                  required: [kind, path, draft_only, legacy_draft, created_at]
+                    can_write:
+                      type: boolean
+                      description: Whether the current user may deploy/discard this draft (same check the deploy/discard endpoints enforce).
+                    draft_users:
+                      description: |
+                        Draft authors at this (path, kind) — the legacy NULL-email row surfaced as a null username.
+                        Populated only for the shared full-page-editor kinds (script/flow/app/raw_app); omitted for
+                        drawer kinds, which keep their drafts private. Feeds the Draft badge's owner-avatar circles.
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          username:
+                            type: string
+                            nullable: true
+                  required: [kind, path, draft_only, legacy_draft, created_at, can_write]
 
   /w/{workspace}/drafts/get/{kind}/{path}:
     get:

--- a/backend/windmill-api/src/drafts.rs
+++ b/backend/windmill-api/src/drafts.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use windmill_common::{
     db::UserDB,
     error::{Error, Result},
-    user_drafts::{UserDraftItemKind, ENCRYPTED_DRAFT_PREFIX},
+    user_drafts::{DraftUserRef, UserDraftItemKind, ENCRYPTED_DRAFT_PREFIX},
     variables::{build_crypt, encrypt},
 };
 
@@ -50,6 +50,17 @@ pub struct DraftListItem {
     /// row exists at this (path, kind) — the DISTINCT ON prefers an owned row.
     pub legacy_draft: bool,
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// All draft authors at this `(path, kind)`, for the shared full-page-editor
+    /// kinds (script/flow/app/raw_app) only — feeds the home-page-style owner
+    /// circles on the review page. `None` for drawer kinds, which keep their
+    /// drafts private.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub draft_users: Option<sqlx::types::Json<Vec<DraftUserRef>>>,
+    /// Whether the authed user may deploy/discard this draft — the same check
+    /// the deploy/discard endpoints enforce. Computed per row after the query,
+    /// so it defaults to `false` when read from the row.
+    #[sqlx(default)]
+    pub can_write: bool,
 }
 
 /// Every draft the authed user has in this workspace, across all kinds — the
@@ -59,6 +70,7 @@ pub struct DraftListItem {
 async fn list_drafts(
     authed: ApiAuthed,
     Extension(db): Extension<DB>,
+    Extension(user_db): Extension<UserDB>,
     Path(w_id): Path<String>,
 ) -> Result<Json<Vec<DraftListItem>>> {
     // Operators have no drafts of their own (they can't write any, see
@@ -67,11 +79,26 @@ async fn list_drafts(
     if authed.is_operator {
         return Ok(Json(vec![]));
     }
-    let rows = sqlx::query_as::<_, DraftListItem>(&list_drafts_query())
+    let mut rows = sqlx::query_as::<_, DraftListItem>(&list_drafts_query())
         .bind(&w_id)
         .bind(&authed.email)
         .fetch_all(&db)
         .await?;
+    // `can_write` gates the deploy/discard controls on the review page. Run the
+    // exact check the deploy/discard endpoints enforce so the UI never offers an
+    // action that would 403 — `NotAuthorized` means "not writable", any other
+    // error is a real failure and propagates.
+    for row in &mut rows {
+        row.can_write = match require_can_write_path(
+            &authed, &db, &user_db, &w_id, row.kind, &row.path,
+        )
+        .await
+        {
+            Ok(()) => true,
+            Err(Error::NotAuthorized(_)) => false,
+            Err(e) => return Err(e),
+        };
+    }
     Ok(Json(rows))
 }
 
@@ -101,6 +128,17 @@ fn list_drafts_query() -> String {
         ));
     }
     case.push_str("  ELSE true\nEND");
+    // Owner circles, mirroring the home-page list subquery (see apps.rs): every
+    // draft author at this (path, kind), legacy NULL-email row surfaced as a
+    // null username. Restricted to the shared full-page-editor kinds — drawer
+    // kinds keep their drafts private, so we never reveal their authors.
+    let draft_users = r#"CASE WHEN d.typ::text IN ('script', 'flow', 'app', 'raw_app') THEN (
+                      SELECT json_agg(json_build_object('username', COALESCE(u.username, CASE WHEN du.workspace_id = 'admins' THEN du.email END))
+                                      ORDER BY COALESCE(u.username, CASE WHEN du.workspace_id = 'admins' THEN du.email END) NULLS LAST)
+                      FROM draft du
+                      LEFT JOIN usr u ON u.workspace_id = du.workspace_id AND u.email = du.email
+                      WHERE du.workspace_id = d.workspace_id AND du.path = d.path AND du.typ = d.typ
+                    ) ELSE NULL END"#;
     // `(d.email = $2 OR d.email IS NULL)` lists the user's own drafts AND the
     // legacy NULL-email rows; `DISTINCT ON (d.path, d.typ)` with `email IS NULL`
     // last collapses a (path, kind) that has both to the owned row.
@@ -110,6 +148,7 @@ fn list_drafts_query() -> String {
                   d.typ AS kind,
                   d.created_at,
                   d.value ->> 'summary' AS summary,
+                  {draft_users} AS draft_users,
                   -- Friendly typed path, by kind (mirrors the home-page list
                   -- endpoints): scripts bind the Path widget to `script.path`,
                   -- so it round-trips through the draft JSON's own `path`;

--- a/backend/windmill-api/src/drafts.rs
+++ b/backend/windmill-api/src/drafts.rs
@@ -9,7 +9,7 @@
 use crate::db::{ApiAuthed, DB};
 
 use axum::{
-    extract::{Extension, Path},
+    extract::{Extension, Path, Query},
     routing::{get, post},
     Json, Router,
 };
@@ -61,6 +61,19 @@ pub struct DraftListItem {
     /// so it defaults to `false` when read from the row.
     #[sqlx(default)]
     pub can_write: bool,
+    /// The listed row belongs to the authed user (own draft or the legacy
+    /// no-owner row) and is therefore actionable by them. Always `true` in the
+    /// default (own-drafts) listing; only meaningful with `all_users=true`,
+    /// where other users' rows surface as `false` (view-only — you can't deploy
+    /// someone else's draft).
+    pub mine: bool,
+}
+
+#[derive(Deserialize)]
+pub struct ListDraftsQuery {
+    /// List every draft in the workspace (all users), not just the authed
+    /// user's own + legacy rows. Other users' rows come back with `mine=false`.
+    pub all_users: Option<bool>,
 }
 
 /// Every draft the authed user has in this workspace, across all kinds — the
@@ -72,6 +85,7 @@ async fn list_drafts(
     Extension(db): Extension<DB>,
     Extension(user_db): Extension<UserDB>,
     Path(w_id): Path<String>,
+    Query(query): Query<ListDraftsQuery>,
 ) -> Result<Json<Vec<DraftListItem>>> {
     // Operators have no drafts of their own (they can't write any, see
     // `require_can_write_path`), so this list is always empty for them. They
@@ -79,7 +93,8 @@ async fn list_drafts(
     if authed.is_operator {
         return Ok(Json(vec![]));
     }
-    let mut rows = sqlx::query_as::<_, DraftListItem>(&list_drafts_query())
+    let all_users = query.all_users.unwrap_or(false);
+    let mut rows = sqlx::query_as::<_, DraftListItem>(&list_drafts_query(all_users))
         .bind(&w_id)
         .bind(&authed.email)
         .fetch_all(&db)
@@ -106,8 +121,9 @@ async fn list_drafts(
 /// `deployed_table()` (shared single source — can't drift from the access
 /// check). Table names come from the closed enum, never user input. Kinds
 /// with no path-keyed table get no arm and fall to `ELSE true`.
-/// `$1` = workspace_id, `$2` = email.
-fn list_drafts_query() -> String {
+/// `$1` = workspace_id, `$2` = email. With `all_users` the owner filter is
+/// dropped so every workspace draft is listed (others' rows get `mine=false`).
+fn list_drafts_query(all_users: bool) -> String {
     let mut case = String::from("CASE d.typ::text\n");
     for kind in UserDraftItemKind::ALL {
         let Some(table) = kind.deployed_table() else {
@@ -139,9 +155,17 @@ fn list_drafts_query() -> String {
                       LEFT JOIN usr u ON u.workspace_id = du.workspace_id AND u.email = du.email
                       WHERE du.workspace_id = d.workspace_id AND du.path = d.path AND du.typ = d.typ
                     ) ELSE NULL END"#;
-    // `(d.email = $2 OR d.email IS NULL)` lists the user's own drafts AND the
-    // legacy NULL-email rows; `DISTINCT ON (d.path, d.typ)` with `email IS NULL`
-    // last collapses a (path, kind) that has both to the owned row.
+    // Default lists the user's own drafts AND the legacy NULL-email rows; with
+    // `all_users` the filter is dropped to list every workspace draft.
+    let owner_filter = if all_users {
+        ""
+    } else {
+        " AND (d.email = $2 OR d.email IS NULL)"
+    };
+    // `DISTINCT ON (d.path, d.typ)` keeps one row per item; the ORDER BY
+    // priority below picks the user's own row first, then the legacy NULL row,
+    // then (only with `all_users`) another user's row. `mine`/`legacy_draft`
+    // describe that kept row.
     format!(
         r#"SELECT DISTINCT ON (d.path, d.typ)
                   d.path,
@@ -163,10 +187,12 @@ fn list_drafts_query() -> String {
                     d.path
                   ) AS draft_path,
                   (d.email IS NULL) AS legacy_draft,
+                  (d.email = $2 OR d.email IS NULL) AS mine,
                   {case} AS draft_only
            FROM draft d
-           WHERE d.workspace_id = $1 AND (d.email = $2 OR d.email IS NULL)
-           ORDER BY d.path, d.typ, (d.email IS NULL)"#
+           WHERE d.workspace_id = $1{owner_filter}
+           ORDER BY d.path, d.typ,
+                    CASE WHEN d.email = $2 THEN 0 WHEN d.email IS NULL THEN 1 ELSE 2 END"#
     )
 }
 

--- a/backend/windmill-api/src/drafts.rs
+++ b/backend/windmill-api/src/drafts.rs
@@ -94,27 +94,48 @@ async fn list_drafts(
         return Ok(Json(vec![]));
     }
     let all_users = query.all_users.unwrap_or(false);
-    let mut rows = sqlx::query_as::<_, DraftListItem>(&list_drafts_query(all_users))
+    let rows = sqlx::query_as::<_, DraftListItem>(&list_drafts_query(all_users))
         .bind(&w_id)
         .bind(&authed.email)
         .fetch_all(&db)
         .await?;
-    // `can_write` gates the deploy/discard controls on the review page. Run the
-    // exact check the deploy/discard endpoints enforce so the UI never offers an
-    // action that would 403 — `NotAuthorized` means "not writable", any other
-    // error is a real failure and propagates.
-    for row in &mut rows {
-        row.can_write = match require_can_write_path(
-            &authed, &db, &user_db, &w_id, row.kind, &row.path,
-        )
-        .await
-        {
-            Ok(()) => true,
-            Err(Error::NotAuthorized(_)) => false,
-            Err(e) => return Err(e),
-        };
+    // Per-row permission gating:
+    //  - own drafts (incl. legacy no-owner rows, `mine = true`): the actionable
+    //    gate is write permission — run the exact check deploy/discard enforce so
+    //    the UI never offers an action that would 403.
+    //  - other users' drafts (only present with `all_users`, `mine = false`): the
+    //    UI never lets you act on them (`isSelectable` requires `mine`), so skip
+    //    the write probe (`can_write = false`) and instead require READ access —
+    //    otherwise the broadened listing would disclose the path/summary/authors
+    //    of items the caller can't see. Unreadable rows are dropped, mirroring the
+    //    `require_can_read_path` gate on `/drafts/get`.
+    let mut out = Vec::with_capacity(rows.len());
+    for mut row in rows {
+        if row.mine {
+            row.can_write =
+                match require_can_write_path(&authed, &db, &user_db, &w_id, row.kind, &row.path)
+                    .await
+                {
+                    Ok(()) => true,
+                    Err(Error::NotAuthorized(_)) => false,
+                    Err(e) => return Err(e),
+                };
+            out.push(row);
+        } else {
+            // `require_can_read_path` denies with `NotFound` (it hides existence)
+            // and, for some paths, `NotAuthorized` — both mean "not visible to the
+            // caller", so drop the row. Any other error is a real failure.
+            match require_can_read_path(&authed, &user_db, &w_id, row.kind, &row.path).await {
+                Ok(()) => {
+                    row.can_write = false;
+                    out.push(row);
+                }
+                Err(Error::NotFound(_)) | Err(Error::NotAuthorized(_)) => {}
+                Err(e) => return Err(e),
+            }
+        }
     }
-    Ok(Json(rows))
+    Ok(Json(out))
 }
 
 /// Build the `list_drafts` SQL, generating the `draft_only` CASE from

--- a/frontend/src/lib/components/CompareDrafts.svelte
+++ b/frontend/src/lib/components/CompareDrafts.svelte
@@ -487,8 +487,8 @@
 					{oldSummary}
 					{newSummary}
 					renamed={!draftItem.draft_only &&
-						oldSummary != null &&
-						newSummary != null &&
+						!!oldSummary &&
+						!!newSummary &&
 						oldSummary !== newSummary}
 				/>
 			{/snippet}

--- a/frontend/src/lib/components/CompareDrafts.svelte
+++ b/frontend/src/lib/components/CompareDrafts.svelte
@@ -497,13 +497,15 @@
 				{@const draftItem = item as unknown as Row}
 				{#if draftItem.kind === 'resource' || draftItem.kind === 'variable' || draftItem.kind === 'resource_type'}
 					<!-- drawer-only items show their path as the title; keep this line empty -->
-				{:else if draftItem.draft_path && draftItem.draft_path !== draftItem.path}
-					<!-- Path rename: the draft moves the item to a new path. Strike the
-					     deployed path and show the draft's target path. -->
+				{:else if !draftItem.draft_only && draftItem.draft_path && draftItem.draft_path !== draftItem.path}
+					<!-- Path rename: a *deployed* item's draft moves it to a new path. Strike
+					     the deployed path and show the draft's target path. Draft-only items are
+					     excluded — their storage path is an auto-generated `draft_{uuid}` and
+					     `draft_path` is just the pretty name, not a rename. -->
 					<span class="line-through">{draftItem.path}</span>
 					{draftItem.draft_path}
 				{:else}
-					{draftItem.path}
+					{draftItem.draft_path ?? draftItem.path}
 				{/if}
 			{/snippet}
 

--- a/frontend/src/lib/components/CompareDrafts.svelte
+++ b/frontend/src/lib/components/CompareDrafts.svelte
@@ -15,7 +15,7 @@
 	import { AppService, FlowService, ScriptService, type WorkspaceItemDiff } from '$lib/gen'
 	import { sendUserToast } from '$lib/toast'
 	import { getDraftDiffValues, deployDraft, discardDraft } from '$lib/utils_draft_deploy'
-	import { type DraftItem } from '$lib/workspaceDrafts.svelte'
+	import { type DraftItem, useWorkspaceDrafts } from '$lib/workspaceDrafts.svelte'
 	import type { Kind as LayoutKind } from '$lib/utils_deployable'
 	import { userStore } from '$lib/stores'
 
@@ -73,6 +73,10 @@
 		key: string
 		can_write: boolean
 		draft_users?: { username?: string | null }[]
+		/** The row is my own draft (or the legacy no-owner row) — only then is it
+		 * actionable. Other users' rows (shown when "Show all drafts" is on) are
+		 * view-only: you can't deploy/discard someone else's draft. */
+		mine: boolean
 	}
 	function getItemKey(kind: string, path: string): string {
 		return `${kind}:${path}`
@@ -103,12 +107,25 @@
 		return kind as LayoutKind
 	}
 
-	// The list (and the Draft Count) come from the shared Workspace Drafts module,
-	// owned by the page and passed in via `draftItems`; deploy/discard invalidate
-	// that resource, so the list refetches and deployed items drop off without a
-	// manual reload here.
+	// "Show all drafts" widens the list from my own (+ legacy) to every user's
+	// drafts in the workspace. Off by default. The default view reuses the page's
+	// shared Workspace Drafts resource (passed in via `draftItems`); the "all
+	// users" superset is fetched lazily here via its own resource — only while the
+	// toggle is on (workspace() is undefined otherwise, so no fetch) — and shares
+	// the same invalidation, so a deploy/discard refetches both.
+	let showAll = $state(false)
+	const allDrafts = useWorkspaceDrafts(
+		() => (showAll ? currentWorkspaceId : undefined),
+		() => true
+	)
+	const sourceItems = $derived(showAll ? allDrafts.items : draftItems)
+	const loading = $derived(showAll ? allDrafts.loading : draftsLoading)
+
+	// The list (and, in the default view, the Draft Count) come from the Workspace
+	// Drafts module; deploy/discard invalidate the resource, so the list refetches
+	// and deployed items drop off without a manual reload here.
 	const items: Row[] = $derived(
-		draftItems.map((d) => ({
+		sourceItems.map((d) => ({
 			...d,
 			key: getItemKey(d.kind, d.path),
 			kind: toLayoutKind(d.kind),
@@ -130,16 +147,25 @@
 			.filter((u): u is string => !!u && u !== currentUsername)
 	}
 
-	// "My drafts only" hides the legacy no-owner (workspace-level) rows, leaving
-	// strictly the drafts I authored. Off by default — the legacy rows may still
-	// need deploying.
-	let myDraftsOnly = $state(false)
-	const visibleItems = $derived(myDraftsOnly ? items.filter((i) => !i.legacy_draft) : items)
+	// The backend already returns exactly the rows for the current view (own +
+	// legacy, or every user's with "Show all drafts"), so there's no client-side
+	// filtering — `visibleItems` is just the mapped list.
+	const visibleItems = $derived(items)
 
-	// A row is actionable when it isn't already deployed this session and the user
-	// has write permission (the server enforces the same; this keeps the UI honest).
+	// A row is actionable when it isn't already deployed this session, the user has
+	// write permission, AND it's their own draft (you can't deploy someone else's
+	// draft — those show view-only in the "all drafts" view). The server enforces
+	// the same; this keeps the UI honest.
 	function isSelectable(item: Row): boolean {
-		return deploymentStatus[item.key]?.status !== 'deployed' && item.can_write
+		return deploymentStatus[item.key]?.status !== 'deployed' && item.can_write && item.mine
+	}
+
+	// Why a row can't be deployed/discarded (drives the disabled-checkbox tooltip
+	// and the Discard button's title). `undefined` ⇒ actionable.
+	function blockedReason(item: Row): string | undefined {
+		if (!item.mine) return 'This draft belongs to another user'
+		if (!item.can_write) return "You don't have write permission on this path"
+		return undefined
 	}
 
 	// The Draft Items list only carries the *deployed* summary, so the draft's
@@ -190,6 +216,7 @@
 		untrack(() => {
 			for (const item of current) {
 				if (
+					item.mine &&
 					!item.draft_only &&
 					(['script', 'flow', 'app'].includes(item.draftKind) || item.raw_app) &&
 					!summaryCache[item.key]
@@ -418,26 +445,24 @@
 			{deploymentStatus}
 			{allSelected}
 			selectablePredicate={(item) => isSelectable(item as unknown as Row)}
-			selectBlockedReason={(item) =>
-				(item as unknown as Row).can_write
-					? undefined
-					: "You don't have write permission on this path"}
+			selectBlockedReason={(item) => blockedReason(item as unknown as Row)}
 			onToggleItem={toggleItem}
 			onSelectAll={selectAll}
 			onDeselectAll={deselectAll}
-			emptyMessage={draftsLoading
+			emptyMessage={loading
 				? 'Loading drafts…'
-				: myDraftsOnly
-					? 'No drafts you authored in this workspace'
-					: 'No drafts in this workspace'}
+				: showAll
+					? 'No drafts in this workspace'
+					: 'No drafts you authored in this workspace'}
 		>
 			{#snippet selectAllActions()}
 				<Toggle
-					bind:checked={myDraftsOnly}
+					bind:checked={showAll}
 					size="xs"
 					options={{
-						right: 'Only my drafts',
-						rightTooltip: 'Hide legacy workspace drafts that have no owner'
+						right: 'Show all drafts',
+						rightTooltip:
+							"Show every user's drafts in this workspace, not just yours. Others' drafts are view-only — you can only deploy or discard your own."
 					}}
 				/>
 			{/snippet}
@@ -523,7 +548,7 @@
 					path={draftItem.path}
 					allowFork={false}
 				/>
-				{#if others.length > 0}
+				{#if draftItem.mine && others.length > 0}
 					<Popover openOnHover debounceDelay={50}>
 						{#snippet trigger()}
 							<AlertTriangle size={16} class="text-yellow-500" />
@@ -538,6 +563,7 @@
 					</Popover>
 				{/if}
 				{#if deploymentStatus[draftItem.key]?.status !== 'deployed'}
+					{@const discardBlock = blockedReason(draftItem)}
 					<Button
 						unifiedSize="xs"
 						variant="subtle"
@@ -550,10 +576,8 @@
 						unifiedSize="xs"
 						variant="subtle"
 						destructive
-						disabled={!draftItem.can_write}
-						title={!draftItem.can_write
-							? "You don't have write permission on this path"
-							: undefined}
+						disabled={!!discardBlock}
+						title={discardBlock}
 						startIcon={{ icon: Undo2 }}
 						onClick={() => (discardTarget = draftItem)}
 					>

--- a/frontend/src/lib/components/CompareDrafts.svelte
+++ b/frontend/src/lib/components/CompareDrafts.svelte
@@ -2,11 +2,13 @@
 	import WorkspaceDeployLayout from './WorkspaceDeployLayout.svelte'
 	import DiffDrawer from './DiffDrawer.svelte'
 	import WorkspaceDeployItemSummary from './WorkspaceDeployItemSummary.svelte'
+	import DraftBadge from './DraftBadge.svelte'
+	import Toggle from './Toggle.svelte'
+	import Popover from './meltComponents/Popover.svelte'
 	import { Badge } from './common'
-	import Tooltip from './meltComponents/Tooltip.svelte'
 	import Button from './common/button/Button.svelte'
 	import ConfirmationModal from './common/confirmationModal/ConfirmationModal.svelte'
-	import { ArrowRight, DiffIcon, GitFork, Pencil, Undo2 } from 'lucide-svelte'
+	import { AlertTriangle, ArrowRight, DiffIcon, GitFork, Pencil, Undo2 } from 'lucide-svelte'
 	import { untrack } from 'svelte'
 	import CompareModeToggle, { type CompareMode } from './CompareModeToggle.svelte'
 	import { editUrlFor } from './sessions/forkEditUrl'
@@ -15,6 +17,7 @@
 	import { getDraftDiffValues, deployDraft, discardDraft } from '$lib/utils_draft_deploy'
 	import { type DraftItem } from '$lib/workspaceDrafts.svelte'
 	import type { Kind as LayoutKind } from '$lib/utils_deployable'
+	import { userStore } from '$lib/stores'
 
 	interface Props {
 		currentWorkspaceId: string
@@ -68,6 +71,8 @@
 		legacy_draft: boolean
 		raw_app: boolean
 		key: string
+		can_write: boolean
+		draft_users?: { username?: string | null }[]
 	}
 	function getItemKey(kind: string, path: string): string {
 		return `${kind}:${path}`
@@ -113,13 +118,37 @@
 		}))
 	)
 
+	const currentUsername = $derived($userStore?.username)
+
+	// Other real users (not me, not the legacy NULL-email row) who also drafted
+	// this path. Only the shared full-page-editor kinds carry draft_users, so this
+	// is naturally empty for drawer kinds. Deploying only deploys my own draft, so
+	// a non-empty list warrants the triangle warning.
+	function otherDraftUsers(row: Row): string[] {
+		return (row.draft_users ?? [])
+			.map((u) => u.username)
+			.filter((u): u is string => !!u && u !== currentUsername)
+	}
+
+	// "My drafts only" hides the legacy no-owner (workspace-level) rows, leaving
+	// strictly the drafts I authored. Off by default — the legacy rows may still
+	// need deploying.
+	let myDraftsOnly = $state(false)
+	const visibleItems = $derived(myDraftsOnly ? items.filter((i) => !i.legacy_draft) : items)
+
+	// A row is actionable when it isn't already deployed this session and the user
+	// has write permission (the server enforces the same; this keeps the UI honest).
+	function isSelectable(item: Row): boolean {
+		return deploymentStatus[item.key]?.status !== 'deployed' && item.can_write
+	}
+
 	// The Draft Items list only carries the *deployed* summary, so the draft's
 	// (new) display name isn't known yet. Fetch each item's draft blob once and
 	// cache both names — mirrors CompareWorkspaces' fetchSummaries (eager on load,
 	// keyed by row key) so the rename rendering is shared and consistent. Only
 	// non-`draft_only` items can show a rename: a `draft_only` item has no deployed
-	// side to diff the name against. Raw apps live on a separate route and aren't
-	// fetchable here, so they're skipped (no rename shown, same as before).
+	// side to diff the name against. Raw apps are fetched via the apps endpoint too
+	// (it auto-detects raw from the deployed row and overlays the raw_app draft).
 	const summaryCache = $state<
 		Record<string, { deployed?: string; draft?: string; loading?: boolean }>
 	>({})
@@ -162,8 +191,7 @@
 			for (const item of current) {
 				if (
 					!item.draft_only &&
-					!item.raw_app &&
-					['script', 'flow', 'app'].includes(item.draftKind) &&
+					(['script', 'flow', 'app'].includes(item.draftKind) || item.raw_app) &&
 					!summaryCache[item.key]
 				) {
 					void fetchDraftSummary(item)
@@ -197,29 +225,23 @@
 	})
 
 	$effect(() => {
-		if (!hasAutoSelected && items.length > 0) {
-			selectedItems = items
-				.filter((i) => deploymentStatus[i.key]?.status !== 'deployed')
-				.map((i) => i.key)
+		if (!hasAutoSelected && visibleItems.length > 0) {
+			selectedItems = visibleItems.filter(isSelectable).map((i) => i.key)
 			hasAutoSelected = true
 		}
 	})
 
-	// Selected items still in the live list and deployable. Derived (not a pruning
-	// effect) so the "Deploy N drafts" button stays reactive to the Workspace
-	// Drafts resource: deploy/discard drop items, and stale keys left in
+	// Selected items still in the visible list and deployable. Derived (not a
+	// pruning effect) so the "Deploy N drafts" button stays reactive to the
+	// Workspace Drafts resource: deploy/discard drop items, and stale keys left in
 	// selectedItems are simply ignored here (and by deploySelected).
 	let selectedCount = $derived(
-		items.filter(
-			(i) => selectedItems.includes(i.key) && deploymentStatus[i.key]?.status !== 'deployed'
-		).length
+		visibleItems.filter((i) => selectedItems.includes(i.key) && isSelectable(i)).length
 	)
 
 	let allSelected = $derived(
-		items.length > 0 &&
-			items
-				.filter((i) => deploymentStatus[i.key]?.status !== 'deployed')
-				.every((i) => selectedItems.includes(i.key))
+		visibleItems.filter(isSelectable).length > 0 &&
+			visibleItems.filter(isSelectable).every((i) => selectedItems.includes(i.key))
 	)
 
 	function toggleItem(item: { key: string }) {
@@ -231,9 +253,7 @@
 	}
 
 	function selectAll() {
-		selectedItems = items
-			.filter((i) => deploymentStatus[i.key]?.status !== 'deployed')
-			.map((i) => i.key)
+		selectedItems = visibleItems.filter(isSelectable).map((i) => i.key)
 	}
 
 	function deselectAll() {
@@ -272,8 +292,9 @@
 	async function deploySelected() {
 		deploying = true
 		// Snapshot the items to deploy: deployDraft invalidates the Workspace Drafts
-		// resource, so `items` can change mid-loop — iterate a stable copy.
-		const toDeploy = items.filter((i) => selectedItems.includes(i.key))
+		// resource, so `items` can change mid-loop — iterate a stable copy. Guard on
+		// isSelectable so a non-writable row can never be deployed via a stale key.
+		const toDeploy = visibleItems.filter((i) => selectedItems.includes(i.key) && isSelectable(i))
 		let deployedAny = false
 		for (const item of toDeploy) {
 			deploymentStatus[item.key] = { status: 'loading' }
@@ -302,6 +323,10 @@
 
 	// --- Discard ---
 	let discardTarget = $state<Row | undefined>(undefined)
+	// Other real users with a draft at the target path: discarding only removes
+	// MY draft (+ the legacy NULL row), so a draft_only item isn't truly deleted
+	// while they still hold one — reword the confirmation to say so.
+	const discardOthers = $derived(discardTarget ? otherDraftUsers(discardTarget) : [])
 
 	async function confirmDiscard() {
 		const item = discardTarget
@@ -388,16 +413,35 @@
 <div class="flex flex-col gap-4">
 	<div class="bg-surface-tertiary p-4 rounded-md border">
 		<WorkspaceDeployLayout
-			{items}
+			items={visibleItems}
 			{selectedItems}
 			{deploymentStatus}
 			{allSelected}
-			selectablePredicate={(item) => deploymentStatus[item.key]?.status !== 'deployed'}
+			selectablePredicate={(item) => isSelectable(item as unknown as Row)}
+			selectBlockedReason={(item) =>
+				(item as unknown as Row).can_write
+					? undefined
+					: "You don't have write permission on this path"}
 			onToggleItem={toggleItem}
 			onSelectAll={selectAll}
 			onDeselectAll={deselectAll}
-			emptyMessage={draftsLoading ? 'Loading drafts…' : 'No drafts in this workspace'}
+			emptyMessage={draftsLoading
+				? 'Loading drafts…'
+				: myDraftsOnly
+					? 'No drafts you authored in this workspace'
+					: 'No drafts in this workspace'}
 		>
+			{#snippet selectAllActions()}
+				<Toggle
+					bind:checked={myDraftsOnly}
+					size="xs"
+					options={{
+						right: 'Only my drafts',
+						rightTooltip: 'Hide legacy workspace drafts that have no owner'
+					}}
+				/>
+			{/snippet}
+
 			{#snippet header()}
 				{#if isFork}
 					<div class="flex flex-wrap gap-1 items-center bg-surface-tertiary pb-4">
@@ -449,20 +493,47 @@
 				/>
 			{/snippet}
 
+			{#snippet itemPath(item)}
+				{@const draftItem = item as unknown as Row}
+				{#if draftItem.kind === 'resource' || draftItem.kind === 'variable' || draftItem.kind === 'resource_type'}
+					<!-- drawer-only items show their path as the title; keep this line empty -->
+				{:else if draftItem.draft_path && draftItem.draft_path !== draftItem.path}
+					<!-- Path rename: the draft moves the item to a new path. Strike the
+					     deployed path and show the draft's target path. -->
+					<span class="line-through">{draftItem.path}</span>
+					{draftItem.draft_path}
+				{:else}
+					{draftItem.path}
+				{/if}
+			{/snippet}
+
 			{#snippet itemActions(item)}
 				{@const draftItem = item as unknown as Row}
+				{@const others = otherDraftUsers(draftItem)}
 				<Badge color="gray" size="xs">{kindLabel(draftItem.draftKind)}</Badge>
-				{#if draftItem.draft_only}
-					<Badge color="indigo" size="xs">New</Badge>
-				{/if}
-				{#if draftItem.legacy_draft}
-					<Tooltip>
-						<Badge color="yellow" size="xs">Legacy draft</Badge>
-						{#snippet text()}
-							A legacy draft predates the per-user drafts migration: it isn't tied to any user
-							(workspace-level, email NULL), so everyone with access to this path sees it.
+				<DraftBadge
+					is_draft={true}
+					draft_only={draftItem.draft_only}
+					draft_users={draftItem.draft_users ?? []}
+					{currentUsername}
+					workspace={currentWorkspaceId}
+					itemKind={draftItem.draftKind}
+					path={draftItem.path}
+					allowFork={false}
+				/>
+				{#if others.length > 0}
+					<Popover openOnHover debounceDelay={50}>
+						{#snippet trigger()}
+							<AlertTriangle size={16} class="text-yellow-500" />
 						{/snippet}
-					</Tooltip>
+						{#snippet content()}
+							<div class="text-xs p-3 max-w-xs text-primary">
+								{others.length} other {others.length === 1 ? 'user' : 'users'} ({others.join(', ')})
+								{others.length === 1 ? 'has' : 'have'} a draft of this item. Deploying only deploys your
+								draft; theirs are left untouched.
+							</div>
+						{/snippet}
+					</Popover>
 				{/if}
 				{#if deploymentStatus[draftItem.key]?.status !== 'deployed'}
 					<Button
@@ -477,6 +548,10 @@
 						unifiedSize="xs"
 						variant="subtle"
 						destructive
+						disabled={!draftItem.can_write}
+						title={!draftItem.can_write
+							? "You don't have write permission on this path"
+							: undefined}
 						startIcon={{ icon: Undo2 }}
 						onClick={() => (discardTarget = draftItem)}
 					>
@@ -505,15 +580,21 @@
 
 <ConfirmationModal
 	open={discardTarget !== undefined}
-	title={discardTarget?.draft_only ? 'Delete item' : 'Discard draft'}
-	confirmationText={discardTarget?.draft_only ? 'Delete' : 'Discard'}
+	title={discardTarget?.draft_only && discardOthers.length === 0 ? 'Delete item' : 'Discard draft'}
+	confirmationText={discardTarget?.draft_only && discardOthers.length === 0 ? 'Delete' : 'Discard'}
 	onConfirmed={confirmDiscard}
 	onCanceled={() => (discardTarget = undefined)}
 >
-	{#if discardTarget?.draft_only}
+	{#if discardTarget?.draft_only && discardOthers.length === 0}
 		<p>
 			<span class="font-mono font-medium text-primary">{discardTarget?.path}</span> exists only as a
 			draft. Discarding it will permanently delete the item. This cannot be undone.
+		</p>
+	{:else if discardOthers.length > 0}
+		<p>
+			Discard your draft of
+			<span class="font-mono font-medium text-primary">{discardTarget?.path}</span>? Other users
+			still have a draft here, so the item won't be deleted.
 		</p>
 	{:else}
 		<p>

--- a/frontend/src/lib/components/CompareDrafts.svelte
+++ b/frontend/src/lib/components/CompareDrafts.svelte
@@ -349,16 +349,34 @@
 	}
 
 	// --- Discard ---
+	// Only one discard is destructive: removing the last draft of a never-deployed
+	// item (draft_only, and no other user still holds a draft) permanently deletes
+	// the item, so it gets a confirmation. Every other discard just reverts to the
+	// deployed version or removes your own copy while another draft remains — those
+	// run immediately (the row already carries the ⚠️ for the multi-user case).
 	let discardTarget = $state<Row | undefined>(undefined)
-	// Other real users with a draft at the target path: discarding only removes
-	// MY draft (+ the legacy NULL row), so a draft_only item isn't truly deleted
-	// while they still hold one — reword the confirmation to say so.
-	const discardOthers = $derived(discardTarget ? otherDraftUsers(discardTarget) : [])
 
-	async function confirmDiscard() {
-		const item = discardTarget
-		discardTarget = undefined
-		if (!item) return
+	function isDestructiveDiscard(item: Row): boolean {
+		// A deployed counterpart exists → discard just reverts, never deletes.
+		if (!item.draft_only) return false
+		// draft_only → discarding deletes the item, UNLESS another real user still
+		// holds a draft of it. Guard on `currentUsername`: if we don't yet know who
+		// "me" is, `otherDraftUsers` would count my own row as someone else's, so
+		// fall back to treating it as a delete (confirm) rather than risk a silent
+		// deletion.
+		if (!currentUsername) return true
+		return otherDraftUsers(item).length === 0
+	}
+
+	function onDiscardClick(item: Row) {
+		if (isDestructiveDiscard(item)) {
+			discardTarget = item
+		} else {
+			void doDiscard(item)
+		}
+	}
+
+	async function doDiscard(item: Row) {
 		const res = await discardDraft(
 			item.draftKind,
 			item.path,
@@ -373,6 +391,12 @@
 		} else {
 			sendUserToast(`Failed to discard ${item.path}: ${res.error}`, true)
 		}
+	}
+
+	function confirmDiscard() {
+		const item = discardTarget
+		discardTarget = undefined
+		if (item) void doDiscard(item)
 	}
 
 	// Editor URL for a draft item, scoped to the current workspace. Raw apps live
@@ -579,7 +603,7 @@
 						disabled={!!discardBlock}
 						title={discardBlock}
 						startIcon={{ icon: Undo2 }}
-						onClick={() => (discardTarget = draftItem)}
+						onClick={() => onDiscardClick(draftItem)}
 					>
 						Discard draft
 					</Button>
@@ -604,29 +628,18 @@
 	<DiffDrawer bind:this={diffDrawer} {isFlow} />
 </div>
 
+<!-- Only the destructive discard (deleting the last draft of a never-deployed
+     item) opens this modal; non-destructive discards run without confirmation. -->
 <ConfirmationModal
 	open={discardTarget !== undefined}
-	title={discardTarget?.draft_only && discardOthers.length === 0 ? 'Delete item' : 'Discard draft'}
-	confirmationText={discardTarget?.draft_only && discardOthers.length === 0 ? 'Delete' : 'Discard'}
+	title="Delete item"
+	confirmationText="Delete"
 	onConfirmed={confirmDiscard}
 	onCanceled={() => (discardTarget = undefined)}
 >
-	{#if discardTarget?.draft_only && discardOthers.length === 0}
-		<p>
-			<span class="font-mono font-medium text-primary">{discardTarget?.path}</span> exists only as a
-			draft. Discarding it will permanently delete the item. This cannot be undone.
-		</p>
-	{:else if discardOthers.length > 0}
-		<p>
-			Discard your draft of
-			<span class="font-mono font-medium text-primary">{discardTarget?.path}</span>? Other users
-			still have a draft here, so the item won't be deleted.
-		</p>
-	{:else}
-		<p>
-			Discard the draft of
-			<span class="font-mono font-medium text-primary">{discardTarget?.path}</span>? The deployed
-			version is unaffected.
-		</p>
-	{/if}
+	<p>
+		<span class="font-mono font-medium text-primary"
+			>{discardTarget?.draft_path ?? discardTarget?.path}</span
+		> exists only as a draft. Discarding it will permanently delete the item. This cannot be undone.
+	</p>
 </ConfirmationModal>

--- a/frontend/src/lib/components/DraftBadge.svelte
+++ b/frontend/src/lib/components/DraftBadge.svelte
@@ -29,6 +29,9 @@
 		workspace?: string
 		itemKind?: UserDraftItemKind
 		path?: string
+		/** Offer "Fork" alongside "View JSON" on other users' rows. The deploy
+		 * page sets this false: forking a new item is meaningless there. */
+		allowFork?: boolean
 	}
 
 	let {
@@ -38,7 +41,8 @@
 		currentUsername = undefined,
 		workspace = undefined,
 		itemKind = undefined,
-		path = undefined
+		path = undefined,
+		allowFork = true
 	}: Props = $props()
 
 	// Authed user lands first; everyone else keeps the backend's ordering.
@@ -163,7 +167,14 @@
 </script>
 
 {#if showBadge}
-	<Popover openOnHover={true} debounceDelay={50} enableFlyTransition>
+	<!-- inline-flex/items-center so the trigger button hugs the badge and lines up
+	     with sibling badges (a plain button is taller, dropping the pill ~2px). -->
+	<Popover
+		openOnHover={true}
+		debounceDelay={50}
+		enableFlyTransition
+		class="inline-flex items-center"
+	>
 		{#snippet trigger()}
 			<Badge small color="indigo">
 				{#if orderedUsers.length > 0}
@@ -244,7 +255,7 @@
 										View JSON
 									</Button>
 									<!-- Operators can't create items, so Fork is hidden (View JSON stays, it's read-only). -->
-									{#if !$userStore?.operator}
+									{#if allowFork && !$userStore?.operator}
 										<Button
 											variant="subtle"
 											size="xs3"

--- a/frontend/src/lib/components/WorkspaceDeployLayout.svelte
+++ b/frontend/src/lib/components/WorkspaceDeployLayout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Loader2 } from 'lucide-svelte'
 	import { Badge } from './common'
+	import Checkbox from './common/checkbox/Checkbox.svelte'
 	import Row from './common/table/Row.svelte'
 	import Tooltip from './Tooltip.svelte'
 	import type { Snippet } from 'svelte'
@@ -98,12 +99,10 @@
 					class:opacity-50={!hasSelectableItems}
 					class:cursor-pointer={hasSelectableItems}
 				>
-					<input
-						type="checkbox"
+					<Checkbox
 						disabled={!hasSelectableItems}
 						checked={allSelected}
-						onchange={allSelected ? onDeselectAll : onSelectAll}
-						class="rounded max-w-4 w-full"
+						onChange={allSelected ? onDeselectAll : onSelectAll}
 					/> Select all
 				</label>
 			{:else}

--- a/frontend/src/lib/components/WorkspaceDeployLayout.svelte
+++ b/frontend/src/lib/components/WorkspaceDeployLayout.svelte
@@ -18,6 +18,10 @@
 		items: DeployableItem[]
 		selectedItems: string[]
 		selectablePredicate?: (item: DeployableItem) => boolean
+		/** For a non-deployed item that isn't selectable, return a reason string to
+		 * render a disabled checkbox + hover tooltip (instead of greying the row);
+		 * return undefined to keep the default greyed-out, no-checkbox treatment. */
+		selectBlockedReason?: (item: DeployableItem) => string | undefined
 		deploymentStatus: Record<string, { status: 'loading' | 'deployed' | 'failed'; error?: string }>
 		allSelected?: boolean
 		emptyMessage?: string
@@ -26,7 +30,11 @@
 		// Snippets for customization
 		header?: Snippet
 		alerts?: Snippet
+		/** Rendered on the right of the "Select all" row (e.g. a filter toggle). */
+		selectAllActions?: Snippet
 		itemSummary?: Snippet<[DeployableItem]>
+		/** Overrides the secondary path line per item (e.g. to strike a renamed path). */
+		itemPath?: Snippet<[DeployableItem]>
 		itemActions?: Snippet<[DeployableItem]>
 		footer?: Snippet
 
@@ -40,12 +48,15 @@
 		items,
 		selectedItems,
 		selectablePredicate = () => true,
+		selectBlockedReason,
 		deploymentStatus,
 		allSelected = false,
 		emptyMessage = 'No items to deploy',
 		header,
 		alerts,
+		selectAllActions,
 		itemSummary,
+		itemPath,
 		itemActions,
 		footer,
 		onToggleItem,
@@ -76,24 +87,35 @@
 		{@render alerts()}
 	{/if}
 
-	{#if items.length > 0}
-		<!-- Select all row -->
+	<!-- Controls row: "Select all" (when there are items) + optional right-side
+	     actions (e.g. a filter toggle). Renders when there are items OR actions are
+	     provided, so a filter that empties the list doesn't take its own toggle with it. -->
+	{#if items.length > 0 || selectAllActions}
 		<div class="px-4 py-2 flex items-center justify-between">
-			<label
-				class="flex items-center gap-2 text-secondary text-xs"
-				class:opacity-50={!hasSelectableItems}
-				class:cursor-pointer={hasSelectableItems}
-			>
-				<input
-					type="checkbox"
-					disabled={!hasSelectableItems}
-					checked={allSelected}
-					onchange={allSelected ? onDeselectAll : onSelectAll}
-					class="rounded max-w-4 w-full"
-				/> Select all
-			</label>
+			{#if items.length > 0}
+				<label
+					class="flex items-center gap-2 text-secondary text-xs"
+					class:opacity-50={!hasSelectableItems}
+					class:cursor-pointer={hasSelectableItems}
+				>
+					<input
+						type="checkbox"
+						disabled={!hasSelectableItems}
+						checked={allSelected}
+						onchange={allSelected ? onDeselectAll : onSelectAll}
+						class="rounded max-w-4 w-full"
+					/> Select all
+				</label>
+			{:else}
+				<span></span>
+			{/if}
+			{#if selectAllActions}
+				{@render selectAllActions()}
+			{/if}
 		</div>
+	{/if}
 
+	{#if items.length > 0}
 		<!-- Items list -->
 		<div class="overflow-y-auto">
 			<div class="border rounded-md bg-surface-tertiary">
@@ -102,12 +124,15 @@
 					{@const isSelected = selectedItems.includes(item.key)}
 					{@const status = deploymentStatus[item.key]}
 					{@const isDeployed = status?.status === 'deployed'}
+					{@const blockedReason =
+						!isSelectable && !isDeployed ? selectBlockedReason?.(item) : undefined}
 
 					<Row
 						isSelectable={isSelectable && !isDeployed}
+						selectDisabledReason={blockedReason}
 						selectOnRowClick={true}
 						alignWithSelectable={true}
-						disabled={!isSelectable}
+						disabled={blockedReason ? false : !isSelectable}
 						selected={isSelected && !isDeployed}
 						onSelect={() => handleSelect(item)}
 						path={item.kind !== 'resource' &&
@@ -126,6 +151,17 @@
 								{@render itemSummary(item)}
 							{:else}
 								{item.path}
+							{/if}
+						{/snippet}
+						{#snippet pathDisplay()}
+							{#if itemPath}
+								{@render itemPath(item)}
+							{:else}
+								{item.kind !== 'resource' &&
+								item.kind !== 'variable' &&
+								item.kind !== 'resource_type'
+									? item.path
+									: ''}
 							{/if}
 						{/snippet}
 						{#snippet actions()}

--- a/frontend/src/lib/components/apps/editor/AppEditorHeader.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeader.svelte
@@ -193,6 +193,20 @@
 		})
 	})
 
+	// Mirror the summary onto the autosaved App so a draft persists it (the
+	// autosave stores the bare App value, which has no summary of its own — it
+	// lives in the `app` table column, set only on deploy). Without this the
+	// summary is lost when reopening a draft or deploying it from the Review &
+	// Deploy page. Parallels `draft_path`.
+	$effect(() => {
+		const s = $summary
+		const a = $app
+		if (!a) return
+		untrack(() => {
+			if (a.summary !== s) a.summary = s
+		})
+	})
+
 	const { history, jobsDrawerOpen, refreshComponents } =
 		getContext<AppEditorContext>('AppEditorContext')
 

--- a/frontend/src/lib/components/apps/types.ts
+++ b/frontend/src/lib/components/apps/types.ts
@@ -207,6 +207,15 @@ export type App = {
 	 * clears the whole draft.
 	 */
 	draft_path?: string
+	/**
+	 * App summary persisted on the autosaved App so a draft round-trips it — the
+	 * autosave stores the bare App value, which otherwise drops the summary (it
+	 * normally lives in the `app` table column, set only on deploy). Mirrors
+	 * `draft_path`: draft-only metadata; the deployed summary column is
+	 * authoritative, and the Review & Deploy page reads it from the draft and
+	 * sends it as the summary on deploy.
+	 */
+	summary?: string
 }
 
 export type ConnectingInput = {

--- a/frontend/src/lib/components/common/checkbox/Checkbox.svelte
+++ b/frontend/src/lib/components/common/checkbox/Checkbox.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { twMerge } from 'tailwind-merge'
+
+	interface Props {
+		/** Controlled checked state. */
+		checked?: boolean
+		disabled?: boolean
+		/** Native title attribute (hover hint). */
+		title?: string | undefined
+		/** Extra classes merged onto the input. */
+		class?: string | undefined
+		/** Change handler (controlled — the parent owns `checked`). */
+		onChange?: (e: Event & { currentTarget: EventTarget & HTMLInputElement }) => void
+	}
+
+	let {
+		checked = false,
+		disabled = false,
+		title = undefined,
+		class: className = undefined,
+		onChange
+	}: Props = $props()
+</script>
+
+<input
+	type="checkbox"
+	{checked}
+	{disabled}
+	{title}
+	onchange={onChange}
+	class={twMerge(
+		'rounded max-w-4 w-full',
+		// When disabled, grey it and let hover fall through to a wrapping trigger
+		// (e.g. a tooltip explaining why it can't be selected).
+		disabled ? 'opacity-50 cursor-not-allowed pointer-events-none' : '',
+		className
+	)}
+/>

--- a/frontend/src/lib/components/common/table/Row.svelte
+++ b/frontend/src/lib/components/common/table/Row.svelte
@@ -7,6 +7,7 @@
 	import { goto } from '$lib/navigation'
 	import { triggerableByAI } from '$lib/actions/triggerableByAI.svelte'
 	import Tooltip from '../../meltComponents/Tooltip.svelte'
+	import Checkbox from '../checkbox/Checkbox.svelte'
 
 	interface Props {
 		marked: string | undefined
@@ -163,15 +164,10 @@
 	onkeydown={clickToSelect ? handleRowKeydown : undefined}
 >
 	{#if isSelectable}
-		<input type="checkbox" checked={selected} onchange={onSelect} class="rounded max-w-4 w-full" />
+		<Checkbox checked={selected} onChange={onSelect} />
 	{:else if selectDisabledReason}
 		<Tooltip class="cursor-not-allowed">
-			<input
-				type="checkbox"
-				disabled
-				checked={false}
-				class="rounded max-w-4 w-full opacity-50 pointer-events-none"
-			/>
+			<Checkbox disabled checked={false} />
 			{#snippet text()}{selectDisabledReason}{/snippet}
 		</Tooltip>
 	{:else if alignWithSelectable}

--- a/frontend/src/lib/components/common/table/Row.svelte
+++ b/frontend/src/lib/components/common/table/Row.svelte
@@ -6,6 +6,7 @@
 	import { twMerge } from 'tailwind-merge'
 	import { goto } from '$lib/navigation'
 	import { triggerableByAI } from '$lib/actions/triggerableByAI.svelte'
+	import Tooltip from '../../meltComponents/Tooltip.svelte'
 
 	interface Props {
 		marked: string | undefined
@@ -14,6 +15,10 @@
 		disabled?: boolean
 		canFavorite?: boolean
 		isSelectable?: boolean
+		/** When the row is not selectable, render a disabled checkbox with this
+		 * reason as a hover tooltip (instead of an empty slot) — explains why the
+		 * row can't be selected without greying the whole row via `disabled`. */
+		selectDisabledReason?: string
 		/** When true, clicking anywhere on the row card (except interactive
 		 * children — checkbox, buttons, links) toggles selection. Opt-in so
 		 * existing tables that don't want it are unaffected. */
@@ -52,6 +57,9 @@
 		badges?: import('svelte').Snippet
 		actions?: import('svelte').Snippet
 		customSummary?: import('svelte').Snippet
+		/** Overrides the secondary path line (e.g. to strike a renamed path).
+		 * Falls back to the plain `path` string when not provided. */
+		pathDisplay?: import('svelte').Snippet
 		onSelect?: (
 			e: Event & {
 				currentTarget: EventTarget & HTMLInputElement
@@ -66,6 +74,7 @@
 		disabled = false,
 		canFavorite = true,
 		isSelectable = false,
+		selectDisabledReason = undefined,
 		selectOnRowClick = false,
 		alignWithSelectable = false,
 		errorHandlerMuted = false,
@@ -81,6 +90,7 @@
 		badges,
 		actions,
 		customSummary,
+		pathDisplay,
 		onSelect = () => {}
 	}: Props = $props()
 
@@ -154,6 +164,16 @@
 >
 	{#if isSelectable}
 		<input type="checkbox" checked={selected} onchange={onSelect} class="rounded max-w-4 w-full" />
+	{:else if selectDisabledReason}
+		<Tooltip class="cursor-not-allowed">
+			<input
+				type="checkbox"
+				disabled
+				checked={false}
+				class="rounded max-w-4 w-full opacity-50 pointer-events-none"
+			/>
+			{#snippet text()}{selectDisabledReason}{/snippet}
+		</Tooltip>
 	{:else if alignWithSelectable}
 		<div class="rounded max-w-4 w-full"></div>
 	{/if}
@@ -208,7 +228,11 @@
 			{/if}
 		</div>
 		<div class="text-hint text-3xs truncate text-left font-normal" title={path}>
-			{path}
+			{#if pathDisplay}
+				{@render pathDisplay()}
+			{:else}
+				{path}
+			{/if}
 		</div>
 	</div>
 {/snippet}

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -42,6 +42,7 @@ import {
 	type FrameworkKey
 } from '$lib/components/raw_apps/templates'
 import { DEFAULT_DATA as DEFAULT_RAW_APP_DATA } from '$lib/components/raw_apps/dataTableRefUtils'
+import { appSourceToDraftValue } from '$lib/components/raw_apps/rawAppDraftValue'
 import {
 	applyEditableFlowJsonToFlow,
 	buildEditableFlowJson,
@@ -1070,38 +1071,6 @@ function getInlineRunnableContent(
 		)
 	}
 	return { content: runnable.inlineScript?.content ?? '', runnable }
-}
-
-function normalizeRawAppData(value: Record<string, any>): AppDraftValue['data'] {
-	if (value.data?.creation) {
-		return {
-			tables: value.data.tables ?? [],
-			datatable: value.data.creation.datatable,
-			schema: value.data.creation.schema
-		}
-	}
-	if (value.data) {
-		return value.data
-	}
-	if (value.datatables) {
-		return { ...DEFAULT_RAW_APP_DATA, tables: value.datatables }
-	}
-	if (value.dataTableRefs) {
-		return { ...DEFAULT_RAW_APP_DATA, tables: value.dataTableRefs }
-	}
-	return { ...DEFAULT_RAW_APP_DATA }
-}
-
-function appSourceToDraftValue(app: any, fallback?: any): AppDraftValue {
-	const value = (app.value ?? {}) as Record<string, any>
-	return {
-		summary: app.summary ?? '',
-		files: { ...(value.files ?? {}) },
-		runnables: { ...(value.runnables ?? {}) },
-		data: normalizeRawAppData(value),
-		policy: app.policy ?? fallback?.policy,
-		custom_path: app.custom_path ?? fallback?.custom_path
-	}
 }
 
 async function loadAppValueForRead(path: string, workspace: string): Promise<AppDraftValue> {

--- a/frontend/src/lib/components/raw_apps/rawAppDraftValue.ts
+++ b/frontend/src/lib/components/raw_apps/rawAppDraftValue.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared projection of a raw-app *source* into the flat `AppDraftValue` the
+ * deploy paths consume. Used by BOTH the global AI chat
+ * (`copilot/chat/global/core.ts`) and the Review & Deploy page
+ * (`rawAppDeploy.ts`) so the two can't drift — a past divergence here silently
+ * dropped a draft's files and broke deploys with "Raw app bundle requires
+ * /index.ts".
+ */
+import type { AppDraftValue } from '$lib/components/copilot/chat/global/workspaceItems'
+import { DEFAULT_DATA as DEFAULT_RAW_APP_DATA } from '$lib/components/raw_apps/dataTableRefUtils'
+
+/** Collapse the historical `data` shapes a raw-app source might carry into the
+ * canonical `AppDraftValue['data']`. */
+export function normalizeRawAppData(value: Record<string, any>): AppDraftValue['data'] {
+	if (value.data?.creation) {
+		return {
+			tables: value.data.tables ?? [],
+			datatable: value.data.creation.datatable,
+			schema: value.data.creation.schema
+		}
+	}
+	if (value.data) {
+		return value.data
+	}
+	if (value.datatables) {
+		return { ...DEFAULT_RAW_APP_DATA, tables: value.datatables }
+	}
+	if (value.dataTableRefs) {
+		return { ...DEFAULT_RAW_APP_DATA, tables: value.dataTableRefs }
+	}
+	return { ...DEFAULT_RAW_APP_DATA }
+}
+
+/**
+ * Project a raw-app source into a flat `AppDraftValue`. Handles both shapes:
+ *  - a deployed app nests its source under `value` (`app.value.files`);
+ *  - a `RawAppDraft` already carries `files`/`runnables`/`data` at the top level.
+ * Falling back to the object itself when there's no nested `value` keeps a
+ * draft's bundle from being dropped.
+ */
+export function appSourceToDraftValue(app: any, fallback?: any): AppDraftValue {
+	const value = (app.value ?? app) as Record<string, any>
+	return {
+		summary: app.summary ?? '',
+		files: { ...(value.files ?? {}) },
+		runnables: { ...(value.runnables ?? {}) },
+		data: normalizeRawAppData(value),
+		policy: app.policy ?? fallback?.policy,
+		custom_path: app.custom_path ?? fallback?.custom_path
+	}
+}

--- a/frontend/src/lib/rawAppDeploy.ts
+++ b/frontend/src/lib/rawAppDeploy.ts
@@ -6,9 +6,8 @@
  * This mirrors how the global AI chat deploys raw apps
  * (`copilot/chat/global/core.ts` → deployDraft, case 'app'): read the item with
  * its draft, normalise to an AppDraftValue, recompute the policy, bundle the
- * files, then createAppRaw/updateAppRaw. The two pure transforms
- * (appSourceToDraftValue / normalizeRawAppData) are re-implemented here to avoid
- * importing the heavy chat module.
+ * files, then createAppRaw/updateAppRaw. The source→AppDraftValue projection is
+ * shared via `rawAppDraftValue` so the two deploy paths can't drift.
  */
 import { get } from 'svelte/store'
 import { AppService } from '$lib/gen'
@@ -18,36 +17,7 @@ import { bundleRawAppDraft } from '$lib/components/copilot/chat/global/rawAppBun
 import type { AppDraftValue } from '$lib/components/copilot/chat/global/workspaceItems'
 import { updateRawAppPolicy } from '$lib/components/raw_apps/rawAppPolicy'
 import { DEFAULT_DATA as DEFAULT_RAW_APP_DATA } from '$lib/components/raw_apps/dataTableRefUtils'
-
-function normalizeRawAppData(value: Record<string, any>): AppDraftValue['data'] {
-	if (value.data?.creation) {
-		return {
-			tables: value.data.tables ?? [],
-			datatable: value.data.creation.datatable,
-			schema: value.data.creation.schema
-		}
-	}
-	if (value.data) return value.data
-	if (value.datatables) return { ...DEFAULT_RAW_APP_DATA, tables: value.datatables }
-	if (value.dataTableRefs) return { ...DEFAULT_RAW_APP_DATA, tables: value.dataTableRefs }
-	return { ...DEFAULT_RAW_APP_DATA }
-}
-
-function appSourceToDraftValue(app: any, fallback?: any): AppDraftValue {
-	// A deployed app nests its source under `value` (`app.value.files`); a
-	// `RawAppDraft` carries `files`/`runnables`/`data` at the top level. Fall back
-	// to the object itself so a draft's bundle isn't dropped (which shipped no
-	// files → "Raw app bundle requires /index.ts").
-	const value = (app.value ?? app) as Record<string, any>
-	return {
-		summary: app.summary ?? '',
-		files: { ...(value.files ?? {}) },
-		runnables: { ...(value.runnables ?? {}) },
-		data: normalizeRawAppData(value),
-		policy: app.policy ?? fallback?.policy,
-		custom_path: app.custom_path ?? fallback?.custom_path
-	}
-}
+import { appSourceToDraftValue } from '$lib/components/raw_apps/rawAppDraftValue'
 
 /**
  * Promote a raw app's draft to deployed. Throws on failure (caller wraps into a

--- a/frontend/src/lib/rawAppDeploy.ts
+++ b/frontend/src/lib/rawAppDeploy.ts
@@ -34,7 +34,11 @@ function normalizeRawAppData(value: Record<string, any>): AppDraftValue['data'] 
 }
 
 function appSourceToDraftValue(app: any, fallback?: any): AppDraftValue {
-	const value = (app.value ?? {}) as Record<string, any>
+	// A deployed app nests its source under `value` (`app.value.files`); a
+	// `RawAppDraft` carries `files`/`runnables`/`data` at the top level. Fall back
+	// to the object itself so a draft's bundle isn't dropped (which shipped no
+	// files → "Raw app bundle requires /index.ts").
+	const value = (app.value ?? app) as Record<string, any>
 	return {
 		summary: app.summary ?? '',
 		files: { ...(value.files ?? {}) },

--- a/frontend/src/lib/rawAppDeploy.ts
+++ b/frontend/src/lib/rawAppDeploy.ts
@@ -33,8 +33,11 @@ export async function deployRawAppDraft(
 	// the raw_app draft kind server-side instead of 404ing.
 	const app = await AppService.getAppByPath({ workspace, path, getDraft: true, rawApp: true })
 	const draft = (app as any).draft
-	// Honor a renamed draft path; the URL `path` below stays the existing item key.
-	const targetPath = draft?.path ?? path
+	// Deploy at the draft's intended path. A raw-app draft carries the user-typed
+	// path in `draft_path` (a never-deployed app is parked at a synthetic
+	// `u/{user}/draft_{uuid}` storage key); the URL `path` below stays that storage
+	// key. Falls back to `path` for an unrenamed draft on a deployed app.
+	const targetPath = draft?.draft_path ?? draft?.path ?? path
 	const value = appSourceToDraftValue(draft ?? app, app)
 
 	const policy = (await updateRawAppPolicy(

--- a/frontend/src/lib/utils_draft_deploy.ts
+++ b/frontend/src/lib/utils_draft_deploy.ts
@@ -339,28 +339,28 @@ export async function deployDraft(
 		} else if (kind === 'app') {
 			// `raw_app` is handled above; only visual apps reach here.
 			const r = (await AppService.getAppByPath({ workspace, path, getDraft: true })) as any
-			const d = r.draft ?? {
-				value: r.value,
-				summary: r.summary,
-				policy: r.policy,
-				path: r.path,
-				custom_path: r.custom_path
-			}
-			// custom_path requires admin on app update. Non-admins send undefined so
-			// the backend preserves the existing route (no RequireAdmin 403). For
-			// admins, fall back to the *deployed* route (`r.custom_path`) when the
-			// draft doesn't carry one — the visual-app draft value usually omits
-			// custom_path, and sending `''` would clear the existing route. An
-			// explicit '' in the draft still clears (`'' ?? x === ''`).
+			// A visual-app draft is stored as the *bare* app value (grid/theme/...,
+			// plus a `draft_path` when the path was renamed) — NOT wrapped in
+			// { value, summary, policy } like script/flow drafts. So the deploy value
+			// is the draft object itself; fall back to the deployed value when there's
+			// no draft. `draft_path` and `summary` are draft-only fields mirrored onto
+			// the App value (the editor drops them on deploy), so strip them from the
+			// value and apply them as the deploy path / summary column.
+			const draft = r.draft as Record<string, any> | undefined
+			const { draft_path: draftPath, summary: draftSummary, ...appValue } = draft ?? r.value ?? {}
+			// Policy isn't carried in the app draft, so it comes from the deployed app
+			// (or a default). custom_path requires admin on update; non-admins send
+			// undefined so the backend preserves the existing route. The draft has no
+			// custom_path, so admins fall back to the deployed route (`''` when none).
 			const isAdmin = !!(get(userStore)?.is_admin || get(userStore)?.is_super_admin)
 			const requestBody = {
-				value: d.value,
-				summary: d.summary ?? '',
-				policy: d.policy ?? { execution_mode: 'publisher' },
+				value: appValue,
+				summary: draftSummary ?? r.summary ?? '',
+				policy: r.policy ?? { execution_mode: 'publisher' },
 				// Honor the draft's intended path; `draft_path` holds the user-typed path
 				// for a never-deployed app parked at a `u/{user}/draft_{uuid}` storage key.
-				path: d.draft_path ?? d.path ?? path,
-				custom_path: isAdmin ? (d.custom_path ?? r.custom_path) : undefined
+				path: draftPath ?? r.path ?? path,
+				custom_path: isAdmin ? (r.custom_path ?? '') : undefined
 			}
 			// Same as flows: draft-only apps have no app row → create;
 			// drafts on a deployed app update it.

--- a/frontend/src/lib/utils_draft_deploy.ts
+++ b/frontend/src/lib/utils_draft_deploy.ts
@@ -305,8 +305,11 @@ export async function deployDraft(
 			const r = (await FlowService.getFlowByPath({ workspace, path, getDraft: true })) as any
 			const d = r.draft ?? r
 			const requestBody = {
-				// Honor a renamed draft path; the URL `path` stays the existing item key.
-				path: d.path ?? path,
+				// Deploy at the draft's intended path: flow/app/raw-app drafts keep the
+				// user-typed path in `draft_path` (a never-deployed item is parked at a
+				// synthetic `u/{user}/draft_{uuid}` storage key). The URL `path` stays
+				// that storage key.
+				path: d.draft_path ?? d.path ?? path,
 				summary: d.summary ?? '',
 				description: d.description ?? '',
 				value: d.value,
@@ -327,7 +330,12 @@ export async function deployDraft(
 				await FlowService.updateFlow({ workspace, path, requestBody })
 			}
 			// Then deploy any draft trigger edits, so they aren't dropped with the draft.
-			await deployDraftTriggers(d.draft_triggers, workspace, d.path ?? path, draftOnly)
+			await deployDraftTriggers(
+				d.draft_triggers,
+				workspace,
+				d.draft_path ?? d.path ?? path,
+				draftOnly
+			)
 		} else if (kind === 'app') {
 			// `raw_app` is handled above; only visual apps reach here.
 			const r = (await AppService.getAppByPath({ workspace, path, getDraft: true })) as any
@@ -349,7 +357,9 @@ export async function deployDraft(
 				value: d.value,
 				summary: d.summary ?? '',
 				policy: d.policy ?? { execution_mode: 'publisher' },
-				path: d.path ?? path,
+				// Honor the draft's intended path; `draft_path` holds the user-typed path
+				// for a never-deployed app parked at a `u/{user}/draft_{uuid}` storage key.
+				path: d.draft_path ?? d.path ?? path,
 				custom_path: isAdmin ? (d.custom_path ?? r.custom_path) : undefined
 			}
 			// Same as flows: draft-only apps have no app row → create;

--- a/frontend/src/lib/workspaceDrafts.svelte.ts
+++ b/frontend/src/lib/workspaceDrafts.svelte.ts
@@ -34,6 +34,14 @@ export interface DraftItem {
 	legacy_draft: boolean
 	/** App is a raw app (deploys via the raw-app endpoints). Always false for non-apps. */
 	raw_app: boolean
+	/** Current user may deploy/discard this draft — matches the server-side check.
+	 * Defaults to true when the field is absent (older backend) so a frontend
+	 * running ahead of the API doesn't disable every action; the deploy/discard
+	 * endpoints enforce permission regardless. */
+	can_write: boolean
+	/** Draft authors at this (path, kind); populated only for the shared
+	 * full-page-editor kinds (script/flow/app/raw_app). Feeds the badge circles. */
+	draft_users?: { username?: string | null }[]
 }
 
 export async function getDraftItems(workspace: string): Promise<DraftItem[]> {
@@ -45,7 +53,9 @@ export async function getDraftItems(workspace: string): Promise<DraftItem[]> {
 		draft_path: r.draft_path,
 		draft_only: r.draft_only,
 		legacy_draft: r.legacy_draft,
-		raw_app: r.kind === 'raw_app'
+		raw_app: r.kind === 'raw_app',
+		can_write: r.can_write ?? true,
+		draft_users: r.draft_users
 	}))
 }
 

--- a/frontend/src/lib/workspaceDrafts.svelte.ts
+++ b/frontend/src/lib/workspaceDrafts.svelte.ts
@@ -42,10 +42,18 @@ export interface DraftItem {
 	/** Draft authors at this (path, kind); populated only for the shared
 	 * full-page-editor kinds (script/flow/app/raw_app). Feeds the badge circles. */
 	draft_users?: { username?: string | null }[]
+	/** The row is the current user's own draft (or the legacy no-owner row), so
+	 * they can deploy/discard it. Always true in the default listing; only the
+	 * `allUsers` listing surfaces other users' rows as `false` (view-only).
+	 * Defaults to true when the field is absent (older backend). */
+	mine: boolean
 }
 
-export async function getDraftItems(workspace: string): Promise<DraftItem[]> {
-	const rows = await DraftService.listDrafts({ workspace })
+export async function getDraftItems(
+	workspace: string,
+	allUsers: boolean = false
+): Promise<DraftItem[]> {
+	const rows = await DraftService.listDrafts({ workspace, allUsers: allUsers || undefined })
 	return rows.map((r) => ({
 		kind: r.kind,
 		path: r.path,
@@ -55,7 +63,8 @@ export async function getDraftItems(workspace: string): Promise<DraftItem[]> {
 		legacy_draft: r.legacy_draft,
 		raw_app: r.kind === 'raw_app',
 		can_write: r.can_write ?? true,
-		draft_users: r.draft_users
+		draft_users: r.draft_users,
+		mine: r.mine ?? true
 	}))
 }
 
@@ -81,13 +90,16 @@ export interface WorkspaceDraftsHandle {
  * Re-fetches on mount, when `workspace` changes, and when
  * `invalidateWorkspaceDrafts(workspace)` is called while mounted.
  */
-export function useWorkspaceDrafts(workspace: () => string | undefined): WorkspaceDraftsHandle {
+export function useWorkspaceDrafts(
+	workspace: () => string | undefined,
+	allUsers: () => boolean = () => false
+): WorkspaceDraftsHandle {
 	const res = resource(
 		() => {
 			const ws = workspace()
-			return { ws, v: ws ? (versions[ws] ?? 0) : 0 }
+			return { ws, all: allUsers(), v: ws ? (versions[ws] ?? 0) : 0 }
 		},
-		async ({ ws }) => (ws ? getDraftItems(ws) : [])
+		async ({ ws, all }) => (ws ? getDraftItems(ws, all) : [])
 	)
 	return {
 		get items() {

--- a/frontend/src/routes/(root)/(logged)/apps/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps/edit/[...path]/+page.svelte
@@ -219,7 +219,9 @@
 		isNewApp = !!backendApp.no_deployed
 		if (backendApp.no_deployed) {
 			backendApp = {
-				summary: '',
+				// Draft-only app: the summary rides on the autosaved App value
+				// (no deployed column to read it from).
+				summary: savedDraftApp?.summary ?? '',
 				value: (savedDraftApp ?? {}) as App,
 				path: page.params.path ?? '',
 				// `execution_mode` required; matches the new-app seed above.
@@ -236,7 +238,13 @@
 				no_deployed: true
 			} as unknown as typeof backendApp
 		} else if (savedDraftApp) {
-			backendApp = { ...backendApp, value: savedDraftApp } as typeof backendApp
+			// Deployed app with a draft: swap in the draft value and honor a draft
+			// summary edit (falls back to the deployed summary when the draft has none).
+			backendApp = {
+				...backendApp,
+				value: savedDraftApp,
+				summary: savedDraftApp.summary ?? backendApp.summary
+			} as typeof backendApp
 		}
 		if (backendApp.is_draft) {
 			loadedFromDraft = true


### PR DESCRIPTION
## Summary

Reworks the **Review & Deploy drafts** page (`/forks/compare?mode=draft`) for the per-user (DB-backed) drafts model, and fixes several raw-app/flow/app draft-deploy bugs uncovered along the way.

The deploy page now scopes and gates drafts per user, lets you switch between your own drafts and the whole workspace's, surfaces ownership with the home-page `DraftBadge`, warns when multiple users drafted the same item, and (critically) deploys flow/app/raw-app drafts to their intended path with their bundle intact.

## Changes

**Backend** (`windmill-api/src/drafts.rs`, `openapi.yaml`)
- `/drafts/list` returns `can_write` (per-row, via the existing `require_can_write_path` — same check deploy/discard enforce) and `draft_users` (home-page `json_agg`, shared full-page-editor kinds only). Reuses main's `legacy_draft`.
- New `all_users` query param drops the owner filter to list every draft in the workspace, plus a per-row `mine` flag (own draft or legacy no-owner row). `DISTINCT ON` prefers the user's own row, then the legacy row, then another user's — so `mine`/`legacy_draft` describe the kept row. Additive, backward-compatible.

**Frontend — deploy page** (`CompareDrafts.svelte`)
- **"Show all drafts"** toggle (default off), inline with "Select all": off → your own drafts (+ legacy no-owner rows); on → every user's drafts in the workspace. The all-users superset is fetched lazily (only while the toggle is on), so the page's fork draft-count stays scoped to your own.
- Other users' drafts are **view-only**: disabled checkbox + Discard with a *"belongs to another user"* tooltip; Show diff stays enabled. Selection, select-all and the deploy count only ever include your own drafts; the ⚠️ triangle shows on owned rows only.
- Legacy no-owner drafts (`email IS NULL`, pre-per-user migration) are listed for **every** user (not just admins) and are deployable/discardable by anyone with write permission on the path — they have no owner to scope them to, so showing them keeps an orphaned draft from being stranded. The `?` badge marks them as unknown-owner.
- Permission gating: a draft you can't write shows a **disabled checkbox + explanation tooltip** and a disabled Discard (row not greyed); Show diff stays enabled; non-writable rows are excluded from select-all/deploy.
- Reuses the home-page `DraftBadge` (owner circles + popover) instead of a bespoke badge.
- Multi-user **⚠️ triangle** when another real user drafted the same path ("only your draft deploys").
- Rename display: strikethrough for **summary** renames (title) and **path** renames (`draft_path`, path line); no false strikethrough for summary-less items or draft-only auto-`uuid` paths.
- Discard modal reworded when others hold a draft.

**Frontend — shared components** (`WorkspaceDeployLayout.svelte`, `Row.svelte`)
- New **opt-in** snippet/prop hooks: `selectAllActions`, `itemPath`/`pathDisplay`, `selectDisabledReason`, `selectBlockedReason`. Defaults reproduce prior behavior, so `CompareWorkspaces`/`DeployWorkspace` are unaffected. `DraftBadge` gains `allowFork`.

**Frontend — raw-app/flow/app deploy fixes** (`rawAppDeploy.ts`, `utils_draft_deploy.ts`, new shared `raw_apps/rawAppDraftValue.ts`)
- Extracted the source→`AppDraftValue` projection into a single shared module used by both the AI chat (`core.ts`) and the deploy page, so they can't drift (the drift caused the bugs below).
- Fix: raw-app drafts store `files` at the top level — deploy now reads them (was reading `.value.files` → empty bundle → *"Raw app bundle requires /index.ts"*).
- Fix: never-deployed/renamed flow, app and raw-app drafts now deploy at their **`draft_path`** (the pretty path) instead of the temporary `u/{user}/draft_{uuid}` storage path.

## Test plan

- [ ] A draft on a path you lack write permission on shows a disabled checkbox + "no write permission" tooltip and disabled Discard, and is excluded from select-all/deploy.
- [ ] "Show all drafts" off shows only your own drafts (+ legacy); on adds every other user's drafts as view-only (disabled deploy/discard, tooltip), with Show diff still working and the deploy count counting only your own.
- [ ] A path drafted by another user shows the ⚠️ triangle; the discard confirmation reads "the item won't be deleted".
- [ ] Summary rename → `~~old~~ new` in the title; path rename → `~~old path~~ new path` on the path line; summary-less / draft-only items show no spurious strikethrough.
- [ ] **Deploying a never-deployed raw-app draft and a renamed flow/app/raw-app draft lands the item at the pretty `draft_path` with its bundle intact** (the core deploy bug), and the temp-uuid draft is cleaned up.
- [ ] `CompareWorkspaces` / `DeployWorkspace` deploy pages unchanged.

## Screenshots

Exercised against a seeded `fix-app` workspace covering every case, viewed as a **non-admin** user (`test`) so the permission gating is visible, plus an admin view to show the other side of per-user scoping.

**1. Default view — "Show all drafts" off (non-admin `test`)** — your own drafts (+ legacy `?`), kind + `DraftBadge` owner circles, renames, "Select all" + the "Show all drafts" toggle on one row:
![show all off](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-ed82c2ca/1781694916-showall-off.png)

**2. "Show all drafts" on** — every user's drafts appear; admin's `My flow` (AD badge) comes in **view-only** (disabled checkbox + greyed Discard) while your own rows stay selectable:
![show all on](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-ed82c2ca/1781694916-showall-on.png)

**3. View-only tooltip** — hovering the foreign draft's disabled checkbox explains why it can't be selected (*"This draft belongs to another user"*); Show diff still works:
![view-only tooltip](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-ed82c2ca/1781694916-showall-viewonly-tooltip.png)

**4. Permission gating** — `f/locked/secret` has a disabled checkbox (hover tooltip *"You don't have write permission on this path"*) and a disabled Discard; the row is not greyed and Show diff still works:
![permission gating](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-ed82c2ca/1781682198-pr-02-locked-tooltip.png)

**5. Multi-user draft** — owner circles (TE + AD) and the ⚠️ triangle popover: *"1 other user (admin) has a draft of this item. Deploying only deploys your draft; theirs are left untouched."*:
![triangle popover](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-ed82c2ca/1781682198-pr-03-triangle-popover.png)

**6. Discard wording** — when another real user also has a draft: *"Discard your draft of `f/shared/shared_flow`? Other users still have a draft here, so the item won't be deleted."*:
![discard modal](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-ed82c2ca/1781682198-pr-05-discard-modal.png)

**7. Admin view (per-user scoping)** — same workspace as `admin`: the default view shows admin's *own* drafts plus the shared legacy rows (legacy is visible to everyone, not admin-only), and the ⚠️ triangle shows on the shared path. Deploy/discard always act on *your own* draft, so another user's draft stays **view-only even for an admin** — the write-permission bypass removes the *can't-write* gating but not the *ownership* gating; an admin can't deploy someone else's draft from here:
![admin view](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-ed82c2ca/1781682198-pr-06-admin-view.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
