### PR TITLE
Bug fix: git sync fails on app build on import due to binary versions not matching

### DIFF
--- a/cli/src/commands/app/bundle.ts
+++ b/cli/src/commands/app/bundle.ts
@@ -171,18 +171,18 @@ export async function ensureNodeModules(appDir?: string): Promise<void> {
 export async function createBundle(
   options: BundleOptions = {}
 ): Promise<BundleResult> {
-   // Pin esbuild's native binary to the one shipped alongside the pinned host
-   // (cli/package.json -> "esbuild": "0.28.0"). Otherwise service start resolves
-   // a floating @esbuild/<platform> that npm/bun may have bumped to a newer
-   // patch -> "Cannot start service: Host version X does not match binary version Y".
-   if (!process.env.ESBUILD_BINARY_PATH) {
-     try {
-       const require = createRequire(import.meta.url);
-       process.env.ESBUILD_BINARY_PATH = require.resolve(
-         `@esbuild/${process.platform}-${process.arch}/bin/esbuild`
-       );
-     } catch { /* fall back to esbuild's default resolution */ }
-   }
+  // Pin esbuild's native binary to the one shipped alongside the pinned host
+  // (cli/package.json -> "esbuild": "0.28.0"). Otherwise service start resolves
+  // a floating @esbuild/<platform> that npm/bun may have bumped to a newer
+  // patch -> "Cannot start service: Host version X does not match binary version Y".
+  if (!process.env.ESBUILD_BINARY_PATH) {
+    try {
+      const require = createRequire(import.meta.url);
+      process.env.ESBUILD_BINARY_PATH = require.resolve(
+        `@esbuild/${process.platform}-${process.arch}/bin/esbuild`
+      );
+    } catch { /* fall back to esbuild's default resolution */ }
+  }
   
   // Dynamically import esbuild
   const esbuild = await import("esbuild");

--- a/cli/src/commands/app/bundle.ts
+++ b/cli/src/commands/app/bundle.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import process from "node:process";
 import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
 import * as log from "../../core/log.ts";
 import { colors } from "@cliffy/ansi/colors";
 import * as windmillUtils from "@windmill-labs/shared-utils";
@@ -170,6 +171,19 @@ export async function ensureNodeModules(appDir?: string): Promise<void> {
 export async function createBundle(
   options: BundleOptions = {}
 ): Promise<BundleResult> {
+   // Pin esbuild's native binary to the one shipped alongside the pinned host
+   // (cli/package.json -> "esbuild": "0.28.0"). Otherwise service start resolves
+   // a floating @esbuild/<platform> that npm/bun may have bumped to a newer
+   // patch -> "Cannot start service: Host version X does not match binary version Y".
+   if (!process.env.ESBUILD_BINARY_PATH) {
+     try {
+       const require = createRequire(import.meta.url);
+       process.env.ESBUILD_BINARY_PATH = require.resolve(
+         `@esbuild/${process.platform}-${process.arch}/bin/esbuild`
+       );
+     } catch { /* fall back to esbuild's default resolution */ }
+   }
+  
   // Dynamically import esbuild
   const esbuild = await import("esbuild");
 


### PR DESCRIPTION
## Problem

Raw-app bundling during `wmill sync push` (e.g. GitHub code sync) fails with:

```
✘ [ERROR] Cannot start service: Host version "0.28.0" does not match binary version "0.28.1"
```

This is a follow-up to #8765 (commit `e36d440`), which pinned the esbuild **host**
to `0.28.0`. As far as I can tell, that patch was incomplete: it fixes the JS package version,
not the native binary, so the two can still drift.

## Root cause

In `cli/src/commands/app/bundle.ts`, `createBundle()` does `await import("esbuild")`
(host = pinned `0.28.0`), then `esbuild.build()`. At service start, esbuild resolves
its native binary `@esbuild/<platform>` via normal module resolution, which nothing
ties to the host version. On a worker where npm/bun has a newer `@esbuild/linux-x64`
(e.g. `0.28.1`) resolvable, esbuild picks it up → host/binary mismatch → crash.

I observed on our workers that **every** esbuild binary on disk at startup is
`0.28.0`; the `0.28.1` is pulled in fresh at bundle time. Hence, currently pinning the app's
deps or clearing caches doesn't help.

## Fix

Set `ESBUILD_BINARY_PATH` to the binary co-located with the pinned host before the
service starts, so host and binary always come from the same package:

```ts
if (!process.env.ESBUILD_BINARY_PATH) {
  try {
    const nodeRequire = createRequire(import.meta.url);
    process.env.ESBUILD_BINARY_PATH = nodeRequire.resolve(
      `@esbuild/${process.platform}-${process.arch}/bin/esbuild`
    );
  } catch { /* fall back to esbuild's default resolution */ }
}
```

- Guarded on `!process.env.ESBUILD_BINARY_PATH`, so an explicit override still wins.
- `try/catch` makes it a safe no-op (e.g. Deno dev mode) — falls back to current behaviour.
- This is also deployable today as a worker env var, which is how I verified the approach
  resolves the crash on a live instance.

### Possible alternative / belt-and-suspenders

If however the float happens at CLI **install** time rather than bundle time,
pinning the `@esbuild/*` platform packages in `build-npm.ts` `optionalDependencies`
would lock it at the manifest level instead. Happy to switch to that if preferred.

## Validation — please double-check before merging

I validated this as far as I can, but **I could not build Windmill locally** — I only have
a MacBook and no way to build + run windmill locally to validate the patch worked, so **I haven't exercised the full
`sync push` path against this exact build**. 

However I did confirm:

- the host/binary mismatch and that all on-disk binaries were `0.28.0` (logs from an affected worker);
- the equivalent runtime override (`ESBUILD_BINARY_PATH`) fixes the crash on a live instance.

What I'd appreciate a second pair of eyes on: 
that `require.resolve` picks the bundled `0.28.0` binary in a real `windmill` build.


> Transparency: this patch and description were written with AI assistance. I've reviewed
> the logic and reasoning, but given I can't build locally, treat the code as needing a
> maintainer pass rather than pre-verified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes app bundling failures during `wmill sync push` by forcing `esbuild` to use the co-located native binary that matches the pinned host version. Prevents host/binary mismatch errors on workers.

- **Bug Fixes**
  - Sets `ESBUILD_BINARY_PATH` in `createBundle()` to the resolved `@esbuild/<platform>/bin/esbuild` next to the pinned `esbuild` host.
  - Respects an existing `ESBUILD_BINARY_PATH` and falls back to default resolution if resolve fails.

<sup>Written for commit 1cef043869965b4754c46b61cbe26c09f5ac57f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

