### PR TITLE
fix(backend): purge workspace_diff cache on workspace delete

### DIFF
--- a/backend/.sqlx/query-03c8a797ae734ff76e227259ae011ef6d35f892fe95448c58ec13dea58eee3fa.json
+++ b/backend/.sqlx/query-03c8a797ae734ff76e227259ae011ef6d35f892fe95448c58ec13dea58eee3fa.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM skip_workspace_diff_tally WHERE workspace_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "03c8a797ae734ff76e227259ae011ef6d35f892fe95448c58ec13dea58eee3fa"
+}

--- a/backend/.sqlx/query-126cf6d54f8d2c916cd799f6663892119a94d66637062d1bf5a5fe97d89f8096.json
+++ b/backend/.sqlx/query-126cf6d54f8d2c916cd799f6663892119a94d66637062d1bf5a5fe97d89f8096.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) FROM workspace_diff\n         WHERE source_workspace_id = 'wm-fork-test-workspace'\n            OR fork_workspace_id = 'wm-fork-test-workspace'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "126cf6d54f8d2c916cd799f6663892119a94d66637062d1bf5a5fe97d89f8096"
+}

--- a/backend/.sqlx/query-353c6a648720e118c0d82ef055c60033f1969fb39155e7e07bb6730505e254b7.json
+++ b/backend/.sqlx/query-353c6a648720e118c0d82ef055c60033f1969fb39155e7e07bb6730505e254b7.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) FROM skip_workspace_diff_tally WHERE workspace_id = 'wm-fork-test-workspace'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "353c6a648720e118c0d82ef055c60033f1969fb39155e7e07bb6730505e254b7"
+}

--- a/backend/.sqlx/query-5c2d1ae706e997bbca27dadb99cc0d55ffba53bc23ae69181a0d671c640b9ba7.json
+++ b/backend/.sqlx/query-5c2d1ae706e997bbca27dadb99cc0d55ffba53bc23ae69181a0d671c640b9ba7.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO skip_workspace_diff_tally (workspace_id) VALUES ('wm-fork-test-workspace')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "5c2d1ae706e997bbca27dadb99cc0d55ffba53bc23ae69181a0d671c640b9ba7"
+}

--- a/backend/.sqlx/query-5eaf2e0bbede9dd80a70f2b37538239273443c7d56a1f7732988208fe3c9c58f.json
+++ b/backend/.sqlx/query-5eaf2e0bbede9dd80a70f2b37538239273443c7d56a1f7732988208fe3c9c58f.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM workspace_diff WHERE source_workspace_id = $1 OR fork_workspace_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5eaf2e0bbede9dd80a70f2b37538239273443c7d56a1f7732988208fe3c9c58f"
+}

--- a/backend/.sqlx/query-ba7d01509662be936c000aab4ff60f57be839ae365e5cbbb4838a7b622d1771a.json
+++ b/backend/.sqlx/query-ba7d01509662be936c000aab4ff60f57be839ae365e5cbbb4838a7b622d1771a.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO workspace_diff\n         (source_workspace_id, fork_workspace_id, path, kind, ahead, behind, has_changes)\n         VALUES ('wm-fork-test-workspace', 'test-workspace', 'f/shared/other', 'script', 0, 1, true)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "ba7d01509662be936c000aab4ff60f57be839ae365e5cbbb4838a7b622d1771a"
+}

--- a/backend/.sqlx/query-ca1a39a56d36802418048ddad1301f16394c719ef55494b5f286bc402292c420.json
+++ b/backend/.sqlx/query-ca1a39a56d36802418048ddad1301f16394c719ef55494b5f286bc402292c420.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO workspace_diff\n         (source_workspace_id, fork_workspace_id, path, kind, ahead, behind, has_changes, exists_in_source, exists_in_fork)\n         VALUES ('test-workspace', 'wm-fork-test-workspace', 'f/shared/leaky', 'script', 1, 0, true, true, true)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "ca1a39a56d36802418048ddad1301f16394c719ef55494b5f286bc402292c420"
+}

--- a/backend/migrations/20260616210529_cleanup_orphaned_workspace_diff.down.sql
+++ b/backend/migrations/20260616210529_cleanup_orphaned_workspace_diff.down.sql
@@ -1,0 +1,3 @@
+-- Irreversible data cleanup: deleted orphaned rows and reset cached verdicts
+-- cannot be reconstructed. No-op on rollback.
+SELECT 1;

--- a/backend/migrations/20260616210529_cleanup_orphaned_workspace_diff.up.sql
+++ b/backend/migrations/20260616210529_cleanup_orphaned_workspace_diff.up.sql
@@ -1,0 +1,18 @@
+-- workspace_diff / skip_workspace_diff_tally are keyed by workspace id with no FK
+-- cascade, so until the matching delete_workspace cleanup landed, deleting a fork
+-- left its cached diff rows behind. Workspace ids are reused (recreating a fork
+-- under the same name), so those orphaned rows leaked onto the new fork and
+-- produced a spurious "changes not visible" warning that hid the deploy button.
+
+-- Drop rows referencing workspaces that no longer exist (leftovers from past deletes).
+DELETE FROM workspace_diff
+WHERE source_workspace_id NOT IN (SELECT id FROM workspace)
+   OR fork_workspace_id NOT IN (SELECT id FROM workspace);
+
+DELETE FROM skip_workspace_diff_tally
+WHERE workspace_id NOT IN (SELECT id FROM workspace);
+
+-- Reused-id victims keep rows pointing at live workspaces, so they can't be told
+-- apart from valid cache. Reset the cached verdict to force a recompute on the next
+-- compare; compare_workspaces re-evaluates NULL rows and corrects or deletes them.
+UPDATE workspace_diff SET has_changes = NULL;

--- a/backend/migrations/20260616210529_cleanup_orphaned_workspace_diff.up.sql
+++ b/backend/migrations/20260616210529_cleanup_orphaned_workspace_diff.up.sql
@@ -12,7 +12,20 @@ WHERE source_workspace_id NOT IN (SELECT id FROM workspace)
 DELETE FROM skip_workspace_diff_tally
 WHERE workspace_id NOT IN (SELECT id FROM workspace);
 
--- Reused-id victims keep rows pointing at live workspaces, so they can't be told
--- apart from valid cache. Reset the cached verdict to force a recompute on the next
--- compare; compare_workspaces re-evaluates NULL rows and corrects or deletes them.
+-- Reused-id victims keep a skip-tally row pointing at a LIVE workspace, so the
+-- orphan cleanup above can't reach them. compare_workspaces consults
+-- skip_workspace_diff_tally first and short-circuits to an empty comparison, so a
+-- stale skip row would also defeat the has_changes reset below. A genuinely
+-- skipped workspace is excluded from tallying and therefore never has
+-- workspace_diff rows — so a skip row that coexists with workspace_diff rows for
+-- that id is provably leaked from a previous occupant of a reused id. Drop those.
+DELETE FROM skip_workspace_diff_tally s
+WHERE EXISTS (
+    SELECT 1 FROM workspace_diff d WHERE d.fork_workspace_id = s.workspace_id
+);
+
+-- Remaining reused-id victims keep workspace_diff rows pointing at live
+-- workspaces, so they can't be told apart from valid cache. Reset the cached
+-- verdict to force a recompute on the next compare; compare_workspaces
+-- re-evaluates NULL rows and corrects or deletes them.
 UPDATE workspace_diff SET has_changes = NULL;

--- a/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
+++ b/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
@@ -1336,3 +1336,101 @@ async fn test_compare_workspaces_fork_only_folder_visibility(
 
     Ok(())
 }
+
+/// Regression test: deleting a fork must purge its `workspace_diff` and
+/// `skip_workspace_diff_tally` rows. These tables are keyed by workspace id with
+/// no FK cascade, and a fork id is reused when a fork is deleted and recreated
+/// under the same name. If the cached diff rows survive the delete, they leak
+/// onto the next fork sharing that id and produce a spurious "changes not
+/// visible" warning that hides the deploy button (WIN-2066).
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn test_delete_fork_purges_workspace_diff(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let client = windmill_api_client::create_client(
+        &format!("http://localhost:{port}"),
+        "SECRET_TOKEN".to_string(),
+    );
+    let base_url = format!("http://localhost:{port}/api");
+
+    // Create the fork so the caller owns it (delete is authorized for fork owners).
+    let fork_response = client
+        .client()
+        .post(&format!(
+            "{base_url}/w/test-workspace/workspaces/create_fork"
+        ))
+        .json(&json!({
+            "id": "wm-fork-test-workspace",
+            "name": "Test Fork",
+            "color": "#0000ff"
+        }))
+        .send()
+        .await?;
+    assert!(
+        fork_response.status().is_success(),
+        "Fork creation should succeed: {}",
+        fork_response.status()
+    );
+
+    // Seed cached diff state for the fork: as the fork side of a pair, as the
+    // source side of a pair, and a skip-tally row.
+    sqlx::query!(
+        "INSERT INTO workspace_diff
+         (source_workspace_id, fork_workspace_id, path, kind, ahead, behind, has_changes, exists_in_source, exists_in_fork)
+         VALUES ('test-workspace', 'wm-fork-test-workspace', 'f/shared/leaky', 'script', 1, 0, true, true, true)"
+    )
+    .execute(&db)
+    .await?;
+    sqlx::query!(
+        "INSERT INTO workspace_diff
+         (source_workspace_id, fork_workspace_id, path, kind, ahead, behind, has_changes)
+         VALUES ('wm-fork-test-workspace', 'test-workspace', 'f/shared/other', 'script', 0, 1, true)"
+    )
+    .execute(&db)
+    .await?;
+    sqlx::query!(
+        "INSERT INTO skip_workspace_diff_tally (workspace_id) VALUES ('wm-fork-test-workspace')"
+    )
+    .execute(&db)
+    .await?;
+
+    // Delete the fork through the real handler.
+    let delete_response = client
+        .client()
+        .delete(&format!("{base_url}/workspaces/delete/wm-fork-test-workspace"))
+        .send()
+        .await?;
+    assert!(
+        delete_response.status().is_success(),
+        "Fork deletion should succeed: {}",
+        delete_response.status()
+    );
+
+    let leftover_diffs = sqlx::query_scalar!(
+        "SELECT COUNT(*) FROM workspace_diff
+         WHERE source_workspace_id = 'wm-fork-test-workspace'
+            OR fork_workspace_id = 'wm-fork-test-workspace'"
+    )
+    .fetch_one(&db)
+    .await?;
+    assert_eq!(
+        leftover_diffs,
+        Some(0),
+        "workspace_diff rows referencing the deleted fork must be purged"
+    );
+
+    let leftover_skip = sqlx::query_scalar!(
+        "SELECT COUNT(*) FROM skip_workspace_diff_tally WHERE workspace_id = 'wm-fork-test-workspace'"
+    )
+    .fetch_one(&db)
+    .await?;
+    assert_eq!(
+        leftover_skip,
+        Some(0),
+        "skip_workspace_diff_tally row for the deleted fork must be purged"
+    );
+
+    Ok(())
+}

--- a/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
+++ b/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
@@ -1434,3 +1434,90 @@ async fn test_delete_fork_purges_workspace_diff(db: Pool<Postgres>) -> anyhow::R
 
     Ok(())
 }
+
+/// Regression test: creating a fork must start with clean diff state even when
+/// the (reusable) fork id was previously occupied by a deleted fork. Stale
+/// `workspace_diff` / `skip_workspace_diff_tally` rows left behind by an earlier
+/// occupant would otherwise leak onto the new fork — a stale skip row suppresses
+/// comparison entirely, and stale diff rows produce a spurious "changes not
+/// visible" warning that hides the deploy button (WIN-2066).
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn test_create_fork_purges_stale_diff_state(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let client = windmill_api_client::create_client(
+        &format!("http://localhost:{port}"),
+        "SECRET_TOKEN".to_string(),
+    );
+    let base_url = format!("http://localhost:{port}/api");
+
+    // Simulate leftovers from a previously deleted fork that reused this id:
+    // diff rows on both sides plus a skip-tally row, with no workspace yet.
+    sqlx::query!(
+        "INSERT INTO workspace_diff
+         (source_workspace_id, fork_workspace_id, path, kind, ahead, behind, has_changes, exists_in_source, exists_in_fork)
+         VALUES ('test-workspace', 'wm-fork-test-workspace', 'f/shared/leaky', 'script', 1, 0, true, true, true)"
+    )
+    .execute(&db)
+    .await?;
+    sqlx::query!(
+        "INSERT INTO workspace_diff
+         (source_workspace_id, fork_workspace_id, path, kind, ahead, behind, has_changes)
+         VALUES ('wm-fork-test-workspace', 'test-workspace', 'f/shared/other', 'script', 0, 1, true)"
+    )
+    .execute(&db)
+    .await?;
+    sqlx::query!(
+        "INSERT INTO skip_workspace_diff_tally (workspace_id) VALUES ('wm-fork-test-workspace')"
+    )
+    .execute(&db)
+    .await?;
+
+    // Create the fork reusing that id; the conflict check passes because no
+    // workspace row exists for it.
+    let fork_response = client
+        .client()
+        .post(&format!(
+            "{base_url}/w/test-workspace/workspaces/create_fork"
+        ))
+        .json(&json!({
+            "id": "wm-fork-test-workspace",
+            "name": "Test Fork",
+            "color": "#0000ff"
+        }))
+        .send()
+        .await?;
+    assert!(
+        fork_response.status().is_success(),
+        "Fork creation should succeed: {}",
+        fork_response.status()
+    );
+
+    let leftover_diffs = sqlx::query_scalar!(
+        "SELECT COUNT(*) FROM workspace_diff
+         WHERE source_workspace_id = 'wm-fork-test-workspace'
+            OR fork_workspace_id = 'wm-fork-test-workspace'"
+    )
+    .fetch_one(&db)
+    .await?;
+    assert_eq!(
+        leftover_diffs,
+        Some(0),
+        "stale workspace_diff rows must be purged on fork creation"
+    );
+
+    let leftover_skip = sqlx::query_scalar!(
+        "SELECT COUNT(*) FROM skip_workspace_diff_tally WHERE workspace_id = 'wm-fork-test-workspace'"
+    )
+    .fetch_one(&db)
+    .await?;
+    assert_eq!(
+        leftover_skip,
+        Some(0),
+        "stale skip_workspace_diff_tally row must be purged on fork creation"
+    );
+
+    Ok(())
+}

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -3661,6 +3661,30 @@ async fn check_fork_w_id_conflict(db: &DB, w_id: &str) -> Result<()> {
     }
 }
 
+/// A fork id is reusable: it is freed when a fork is deleted and can be claimed
+/// again under the same name. `workspace_diff` and `skip_workspace_diff_tally`
+/// are keyed by workspace id with no FK cascade, so a freshly created fork could
+/// inherit cached diff state from a previous occupant of its id — a stale skip
+/// row suppresses comparison entirely, and stale workspace_diff rows produce a
+/// spurious "changes not visible" warning that hides the deploy button. Clear
+/// both so a new fork always starts with clean diff state, regardless of how the
+/// id was freed.
+async fn purge_stale_fork_diff_state(db: &DB, fork_id: &str) -> Result<()> {
+    sqlx::query!(
+        "DELETE FROM workspace_diff WHERE source_workspace_id = $1 OR fork_workspace_id = $1",
+        fork_id
+    )
+    .execute(db)
+    .await?;
+    sqlx::query!(
+        "DELETE FROM skip_workspace_diff_tally WHERE workspace_id = $1",
+        fork_id
+    )
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
 lazy_static::lazy_static! {
 
     pub static ref CREATE_WORKSPACE_REQUIRE_SUPERADMIN: bool = {
@@ -4864,6 +4888,7 @@ async fn create_workspace_fork_branch(
     // Fail before creating any git branch so a name conflict doesn't leave a
     // dangling branch on the synced repos.
     check_fork_w_id_conflict(&db, &nw.id).await?;
+    purge_stale_fork_diff_state(&db, &nw.id).await?;
 
     Ok(Json(
         handle_fork_branch_creation(&authed.email, &authed.username, &db, &w_id, &nw.id).await?,
@@ -5008,6 +5033,7 @@ async fn create_workspace_fork(
     // re-using a taken (possibly archived) fork id reports the actual
     // conflict instead of a misleading "maximum number of workspaces" error.
     check_fork_w_id_conflict(&db, &nw.id).await?;
+    purge_stale_fork_diff_state(&db, &nw.id).await?;
 
     #[cfg(not(feature = "enterprise"))]
     _check_nb_of_workspaces(&db).await?;

--- a/backend/windmill-api-workspaces/src/workspaces_extra.rs
+++ b/backend/windmill-api-workspaces/src/workspaces_extra.rs
@@ -868,6 +868,25 @@ pub(crate) async fn delete_workspace(
         .execute(&mut *tx)
         .await?;
 
+    // workspace_diff and skip_workspace_diff_tally are keyed by workspace id with no
+    // FK cascade. A fork id is reused when a fork is deleted and recreated under the
+    // same name, so leaving these rows behind leaks the previous fork's cached diff
+    // verdicts onto the new fork — causing a spurious "changes not visible" warning
+    // that hides the deploy button.
+    sqlx::query!(
+        "DELETE FROM workspace_diff WHERE source_workspace_id = $1 OR fork_workspace_id = $1",
+        &w_id
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query!(
+        "DELETE FROM skip_workspace_diff_tally WHERE workspace_id = $1",
+        &w_id
+    )
+    .execute(&mut *tx)
+    .await?;
+
     sqlx::query!("DELETE FROM workspace WHERE id = $1", &w_id)
         .execute(&mut *tx)
         .await?;


### PR DESCRIPTION
## Summary

Fixes WIN-2066. A user who deleted a fork and recreated it under the same name got a persistent "This fork is behind of its parent and some of the changes are not visible by you" warning with no deploy button — even though the fork had been hard-deleted (so the name was free, no conflict).

Root cause: `workspace_diff` and `skip_workspace_diff_tally` are keyed by workspace id with **no FK cascade**, and `delete_workspace` purged ~40 other per-workspace tables but missed these two. Because a fork id is reused when a fork is deleted and recreated under the same name, the previous fork's cached diff state survived the delete and leaked onto the new fork. `compare_workspaces` then either trusted stale `workspace_diff` rows (→ spurious not-visible warning, deploy hidden) or short-circuited on a stale `skip_workspace_diff_tally` row (→ empty comparison).

The `change_workspace_id` (rename) path already migrates both tables; the delete and create paths were missing the cleanup.

## Changes

- **`delete_workspace`**: purge `workspace_diff` (either side) and `skip_workspace_diff_tally` inside the existing delete transaction. (`workspace_fork_deployment_request` is already cleaned via `ON DELETE CASCADE`.)
- **Fork creation** (`create_workspace_fork` + `create_workspace_fork_branch`): new `purge_stale_fork_diff_state` helper clears any inherited `workspace_diff`/`skip_workspace_diff_tally` rows for the new fork id right after the conflict check — a fresh fork always starts with clean diff state regardless of how the id was freed.
- **Migration `20260616210529_cleanup_orphaned_workspace_diff`** (backfills existing affected instances):
  - delete rows referencing workspaces that no longer exist;
  - delete stale `skip_workspace_diff_tally` rows that **coexist with `workspace_diff` rows** for the same id — a properly-skipped workspace is excluded from tallying and so never has diff rows, so the presence of diff rows proves the skip row is leaked from a reused id (and a stale skip row would otherwise defeat the reset below by short-circuiting `compare_workspaces`);
  - `UPDATE workspace_diff SET has_changes = NULL` so reused-id victims recompute and self-heal on the next compare (mirrors precedent migrations `20251113112115` / `20260129165755`).
- Two integration regression tests covering both the delete and create paths.

## Test plan

- [x] `cargo test -p windmill-api-integration-tests --features enterprise,private,deno_core --test workspace_comparison purges` — `test_delete_fork_purges_workspace_diff` and `test_create_fork_purges_stale_diff_state` both pass (tests run the edited migration via `migrations = "../migrations"`)
- [x] Migration applies cleanly; verified end-to-end via the running API: seeded `workspace_diff`/`skip_workspace_diff_tally` rows → 0 after `DELETE /api/workspaces/delete/{id}`
- [x] Offline build (`SQLX_OFFLINE=true`) of the test target succeeds — new queries reuse existing cache strings
- [ ] Manual: create a fork, make a change, delete it, recreate a fork with the same name, open the compare view → deploy button shown, no "changes not visible" warning
- [ ] Existing affected instances: after the migration, open compare on a previously-broken fork → warning gone once the NULL-reset rows recompute

🤖 Generated with [Claude Code](https://claude.com/claude-code)