### PR TITLE
fix(cli): fall back to esbuild-wasm on native host/binary mismatch

### DIFF
--- a/cli/build-npm.ts
+++ b/cli/build-npm.ts
@@ -28,6 +28,9 @@ rmSync(outDir, { recursive: true, force: true });
 // Build with bun — bundle everything except esbuild (platform-specific binary),
 // svelte (optional, only needed for `wmill app bundle/dev`), and parser packages
 // (loaded at runtime via init() with readFileSync for the .wasm binary).
+// esbuild-wasm is not a dependency at all: the host/binary-mismatch fallback in
+// esbuild_loader.ts downloads and caches the whole esbuild-wasm package at
+// runtime, so it stays out of the bundle and the published dependencies.
 console.log("Bundling with bun build...");
 const buildResult = Bun.spawnSync([
   "bun", "build", "src/main.ts",

--- a/cli/src/commands/app/bundle.ts
+++ b/cli/src/commands/app/bundle.ts
@@ -6,6 +6,7 @@ import * as log from "../../core/log.ts";
 import { colors } from "@cliffy/ansi/colors";
 import * as windmillUtils from "@windmill-labs/shared-utils";
 import { readTextFile, readTextFileSync } from "../../utils/utils.ts";
+import { getEsbuild, stopEsbuild } from "./esbuild_loader.ts";
 export interface BundleOptions {
   entryPoint?: string;
   outDir?: string;
@@ -170,8 +171,9 @@ export async function ensureNodeModules(appDir?: string): Promise<void> {
 export async function createBundle(
   options: BundleOptions = {}
 ): Promise<BundleResult> {
-  // Dynamically import esbuild
-  const esbuild = await import("esbuild");
+  // Native esbuild with a transparent esbuild-wasm fallback on host/binary
+  // version mismatch (see esbuild_loader.ts).
+  const esbuild = await getEsbuild();
 
   // Detect frameworks to determine default entry point.
   // Use the entryPoint's directory if provided, otherwise fall back to cwd.
@@ -286,6 +288,10 @@ export async function createBundle(
     outfile,
     sourcemap,
     minify,
+    // Keep outputs in memory: esbuild-wasm cannot write to the filesystem
+    // ("write" option unavailable), and the dist files were discarded after the
+    // read anyway. Native esbuild supports write:false + outputFiles too.
+    write: false as const,
     define: {
       "process.env.NODE_ENV": production ? '"production"' : '"development"',
     },
@@ -307,29 +313,24 @@ export async function createBundle(
 
     log.info(colors.green("✅ Bundle created successfully"));
 
-    // Read the generated files
-    const jsPath = path.join(process.cwd(), outfile);
-    const cssPath = path.join(process.cwd(), outDir, "bundle.css");
+    const outputFiles = result.outputFiles ?? [];
+    const jsFile = outputFiles.find((f) => f.path.endsWith(".js"));
+    const cssFile = outputFiles.find((f) => f.path.endsWith(".css"));
 
-    if (!fs.existsSync(jsPath)) {
-      throw new Error(`Expected JS bundle at ${jsPath} but file not found`);
+    if (!jsFile) {
+      throw new Error("Expected a JS bundle in esbuild output but none found");
     }
-
-    const jsContent = readTextFileSync(jsPath);
-    const cssContent = fs.existsSync(cssPath)
-      ? readTextFileSync(cssPath)
-      : "";
 
     try {
       fs.rmSync(distDir, { recursive: true });
     } catch {
       //ignore
     }
-    return { js: jsContent, css: cssContent };
-    
+    return { js: jsFile.text, css: cssFile?.text ?? "" };
+
   } finally {
-    // Stop esbuild
-    await esbuild.stop();
+    // Stop the native esbuild service so the process can exit (no-op for wasm).
+    await stopEsbuild();
   }
 }
 

--- a/cli/src/commands/app/bundle.ts
+++ b/cli/src/commands/app/bundle.ts
@@ -6,7 +6,7 @@ import * as log from "../../core/log.ts";
 import { colors } from "@cliffy/ansi/colors";
 import * as windmillUtils from "@windmill-labs/shared-utils";
 import { readTextFile, readTextFileSync } from "../../utils/utils.ts";
-import { getEsbuild, stopEsbuild } from "./esbuild_loader.ts";
+import { getEsbuild, stopEsbuild } from "../../utils/esbuild_loader.ts";
 export interface BundleOptions {
   entryPoint?: string;
   outDir?: string;

--- a/cli/src/commands/app/dev.ts
+++ b/cli/src/commands/app/dev.ts
@@ -437,7 +437,11 @@ async function dev(opts: DevOptions, appFolder?: string) {
   const rawApp = (await yamlParseFile(rawAppPath)) as any;
   const appPath = rawApp?.custom_path ?? "u/unknown/newapp";
 
-  // Dynamically import esbuild only when the dev command is called
+  // Dynamically import esbuild only when the dev command is called.
+  // Native-only here (no esbuild-wasm fallback): dev is a local interactive
+  // command that relies on context()/watch, whose semantics under wasm are
+  // untested. The host/binary-mismatch fallback is scoped to createBundle, the
+  // path that runs on workers/CI via `wmill sync push`.
   const esbuild = await import("esbuild");
 
   const host = opts.host ?? DEFAULT_HOST;

--- a/cli/src/commands/app/dev.ts
+++ b/cli/src/commands/app/dev.ts
@@ -438,10 +438,10 @@ async function dev(opts: DevOptions, appFolder?: string) {
   const appPath = rawApp?.custom_path ?? "u/unknown/newapp";
 
   // Dynamically import esbuild only when the dev command is called.
-  // Native-only here (no esbuild-wasm fallback): dev is a local interactive
-  // command that relies on context()/watch, whose semantics under wasm are
-  // untested. The host/binary-mismatch fallback is scoped to createBundle, the
-  // path that runs on workers/CI via `wmill sync push`.
+  // Native-only here (no esbuild-wasm fallback via getEsbuild): dev is a local
+  // interactive command that relies on context()/watch, whose semantics under
+  // wasm are untested. The host/binary-mismatch fallback covers the bundling
+  // paths that run on workers/CI via `wmill sync push`.
   const esbuild = await import("esbuild");
 
   const host = opts.host ?? DEFAULT_HOST;

--- a/cli/src/commands/app/esbuild_loader.ts
+++ b/cli/src/commands/app/esbuild_loader.ts
@@ -1,0 +1,188 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import process from "node:process";
+import { createGunzip } from "node:zlib";
+import { Readable } from "node:stream";
+import { pathToFileURL } from "node:url";
+import * as tar from "tar-stream";
+import * as log from "../../core/log.ts";
+
+// esbuild splits into a JS host package and a per-platform native binary
+// (@esbuild/<platform>). They must be the same version. A broken or incremental
+// install can leave the on-disk binary at a different version than the pinned
+// host, which crashes service start with
+//   Cannot start service: Host version "X" does not match binary version "Y"
+// The running code can't fix what npm/bun put on disk, so when that happens we
+// fall back to esbuild-wasm, whose binary is a single version-pinned .wasm. To
+// keep that 14MB out of every CLI install, the esbuild-wasm package is not a
+// dependency: it is downloaded once and cached on disk, on the fallback path
+// only. We download the whole package (not just the .wasm) because esbuild-wasm
+// reads the app's files from disk by spawning `node bin/esbuild`, which needs
+// bin/esbuild + esbuild.wasm + wasm_exec*.js co-located on disk.
+
+type Esbuild = typeof import("esbuild");
+
+// Version to fall back to if the native host's version can't be read. Keep in
+// sync with the "esbuild" pin in cli/package.json.
+const FALLBACK_VERSION = "0.28.0";
+
+let cached: Esbuild | undefined;
+
+/**
+ * Returns a working esbuild module, preferring the native binary and falling
+ * back to esbuild-wasm only when the native host/binary versions don't match.
+ * The result is memoized for the process.
+ */
+export async function getEsbuild(): Promise<Esbuild> {
+  if (cached) return cached;
+
+  // Escape hatch: skip native entirely (e.g. a host known to have a broken
+  // install, or to exercise the fallback path).
+  if (process.env.WINDMILL_FORCE_ESBUILD_WASM) {
+    cached = await loadWasmEsbuild(await nativeHostVersion());
+    return cached;
+  }
+
+  try {
+    const esbuild = await import("esbuild");
+    // The native service only starts on the first call; force it with the most
+    // trivial op so any breakage (host/binary version mismatch, a dead service)
+    // surfaces now rather than mid-build. The mismatch detail is printed to the
+    // child's stderr while the thrown error is generic ("service was stopped"),
+    // so we fall back on ANY smoke-test failure rather than matching a string.
+    await esbuild.transform("");
+    cached = esbuild;
+    return esbuild;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    log.warn(
+      `native esbuild is not usable; falling back to esbuild-wasm (${msg.trim()})`
+    );
+  }
+
+  cached = await loadWasmEsbuild(await nativeHostVersion());
+  return cached;
+}
+
+/**
+ * Stops the esbuild service (native or wasm — both spawn a child process) so the
+ * process can exit. Safe to call repeatedly; the service restarts lazily on the
+ * next build.
+ */
+export async function stopEsbuild(): Promise<void> {
+  await cached?.stop();
+}
+
+async function nativeHostVersion(): Promise<string> {
+  try {
+    return (await import("esbuild")).version ?? FALLBACK_VERSION;
+  } catch {
+    return FALLBACK_VERSION;
+  }
+}
+
+async function loadWasmEsbuild(version: string): Promise<Esbuild> {
+  const pkgDir = await ensureWasmPackage(version);
+  const mainJs = path.join(pkgDir, "lib", "main.js");
+  // The Node build (lib/main.js) reads app files from disk by spawning
+  // `node bin/esbuild`, so it works with on-disk entry points and node_modules,
+  // unlike the browser build.
+  return (await import(pathToFileURL(mainJs).href)) as unknown as Esbuild;
+}
+
+/**
+ * Returns a directory containing an extracted esbuild-wasm package (with
+ * lib/main.js). Uses an explicit override, then an on-disk cache, then downloads
+ * and extracts the npm tarball.
+ */
+async function ensureWasmPackage(version: string): Promise<string> {
+  // Explicit local override wins (air-gapped / self-hosted workers): a path to
+  // an already-extracted esbuild-wasm package directory.
+  const override = process.env.WINDMILL_ESBUILD_WASM_PATH;
+  if (override) return override;
+
+  const destDir = path.join(cacheDir(), `esbuild-wasm-${version}`);
+  if (fs.existsSync(path.join(destDir, "lib", "main.js"))) {
+    return destDir;
+  }
+
+  const url = process.env.WINDMILL_ESBUILD_WASM_URL ??
+    `https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-${version}.tgz`;
+  log.info(`Downloading esbuild-wasm@${version} from ${url} ...`);
+  const res = await fetch(url);
+  if (!res.ok || !res.body) {
+    throw new Error(
+      `Failed to download esbuild-wasm@${version} (${res.status} ${res.statusText}). ` +
+        `Set WINDMILL_ESBUILD_WASM_PATH to an extracted esbuild-wasm package dir, ` +
+        `point WINDMILL_ESBUILD_WASM_URL at a reachable tarball, or repair the native esbuild install.`
+    );
+  }
+
+  // Extract to a temp dir and rename into place so a crash or a concurrent
+  // writer can't leave a half-extracted package behind.
+  const tmpDir = `${destDir}.${process.pid}.tmp`;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  await extractTarball(res.body, tmpDir);
+  if (!fs.existsSync(path.join(tmpDir, "lib", "main.js"))) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    throw new Error(`esbuild-wasm@${version} tarball did not contain lib/main.js`);
+  }
+  try {
+    fs.renameSync(tmpDir, destDir);
+  } catch {
+    // Another process won the race, or rename across devices failed; clean up
+    // and let the existsSync check below decide whether the cache is usable.
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+  if (!fs.existsSync(path.join(destDir, "lib", "main.js"))) {
+    throw new Error(`Failed to cache esbuild-wasm@${version} at ${destDir}`);
+  }
+  return destDir;
+}
+
+// Extracts an npm tarball (gzipped tar) into destDir, stripping the leading
+// "package/" path component that npm tarballs use.
+async function extractTarball(
+  body: ReadableStream<Uint8Array>,
+  destDir: string
+): Promise<void> {
+  const extract = tar.extract();
+  extract.on("entry", (header, stream, next) => {
+    if (header.type !== "file") {
+      stream.resume();
+      stream.on("end", next);
+      return;
+    }
+    const rel = header.name.replace(/^[^/]+\//, "");
+    const outPath = path.join(destDir, rel);
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    const ws = fs.createWriteStream(outPath, { mode: header.mode ?? 0o644 });
+    stream.pipe(ws);
+    ws.on("finish", next);
+    ws.on("error", next);
+    stream.on("error", next);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    extract.on("finish", resolve);
+    extract.on("error", reject);
+    Readable.fromWeb(body as unknown as Parameters<typeof Readable.fromWeb>[0])
+      .pipe(createGunzip())
+      .on("error", reject)
+      .pipe(extract)
+      .on("error", reject);
+  });
+}
+
+function cacheDir(): string {
+  const explicit = process.env.WINDMILL_CACHE_DIR;
+  if (explicit) return explicit;
+  const xdg = process.env.XDG_CACHE_HOME;
+  if (xdg) return path.join(xdg, "windmill");
+  try {
+    return path.join(os.homedir(), ".cache", "windmill");
+  } catch {
+    return path.join(os.tmpdir(), "windmill");
+  }
+}

--- a/cli/src/commands/script/script.ts
+++ b/cli/src/commands/script/script.ts
@@ -58,6 +58,7 @@ import { SyncCodebase, listSyncCodebases } from "../../utils/codebase.ts";
 import { pollJobWithQueueLogging } from "../../utils/job_polling.ts";
 import fs from "node:fs";
 import { createTarBlob, type TarEntry } from "../../utils/tar.ts";
+import { getEsbuild } from "../../utils/esbuild_loader.ts";
 
 import { execSync } from "node:child_process";
 import { NewScript, Script, ScriptModule } from "../../../gen/types.gen.ts";
@@ -328,7 +329,7 @@ export async function handleFile(
         }).toString();
         log.info("Custom bundler executed for " + path);
       } else {
-        const esbuild = await import("esbuild");
+        const esbuild = await getEsbuild();
 
         log.info(`Started bundling ${path} ...`);
         const startTime = performance.now();
@@ -1565,7 +1566,7 @@ async function preview(
         maxBuffer: 1024 * 1024 * 50,
       }).toString();
     } else {
-      const esbuild = await import("esbuild");
+      const esbuild = await getEsbuild();
 
       if (!opts.silent) {
         log.info(`Bundling ${filePath} for preview...`);

--- a/cli/src/utils/esbuild_loader.ts
+++ b/cli/src/utils/esbuild_loader.ts
@@ -28,20 +28,35 @@ type Esbuild = typeof import("esbuild");
 const FALLBACK_VERSION = "0.28.0";
 
 let cached: Esbuild | undefined;
+let inFlight: Promise<Esbuild> | undefined;
+// Distinguishes concurrent extraction temp dirs within a process.
+let extractCounter = 0;
 
 /**
  * Returns a working esbuild module, preferring the native binary and falling
  * back to esbuild-wasm only when the native host/binary versions don't match.
- * The result is memoized for the process.
+ * Memoized for the process: concurrent first callers (e.g. a parallel
+ * `wmill sync push`) share one probe/download instead of each running their own.
  */
-export async function getEsbuild(): Promise<Esbuild> {
-  if (cached) return cached;
+export function getEsbuild(): Promise<Esbuild> {
+  if (cached) return Promise.resolve(cached);
+  if (inFlight) return inFlight;
+  inFlight = acquireEsbuild()
+    .then((esbuild) => {
+      cached = esbuild;
+      return esbuild;
+    })
+    .finally(() => {
+      inFlight = undefined;
+    });
+  return inFlight;
+}
 
+async function acquireEsbuild(): Promise<Esbuild> {
   // Escape hatch: skip native entirely (e.g. a host known to have a broken
   // install, or to exercise the fallback path).
   if (process.env.WINDMILL_FORCE_ESBUILD_WASM) {
-    cached = await loadWasmEsbuild(await nativeHostVersion());
-    return cached;
+    return loadWasmEsbuild(await nativeHostVersion());
   }
 
   try {
@@ -52,7 +67,6 @@ export async function getEsbuild(): Promise<Esbuild> {
     // child's stderr while the thrown error is generic ("service was stopped"),
     // so we fall back on ANY smoke-test failure rather than matching a string.
     await esbuild.transform("");
-    cached = esbuild;
     return esbuild;
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -61,8 +75,7 @@ export async function getEsbuild(): Promise<Esbuild> {
     );
   }
 
-  cached = await loadWasmEsbuild(await nativeHostVersion());
-  return cached;
+  return loadWasmEsbuild(await nativeHostVersion());
 }
 
 /**
@@ -119,9 +132,10 @@ async function ensureWasmPackage(version: string): Promise<string> {
     );
   }
 
-  // Extract to a temp dir and rename into place so a crash or a concurrent
-  // writer can't leave a half-extracted package behind.
-  const tmpDir = `${destDir}.${process.pid}.tmp`;
+  // Extract to a unique temp dir and rename into place so a crash or a
+  // concurrent writer can't leave a half-extracted package behind, and so two
+  // extractions never share an in-progress directory.
+  const tmpDir = `${destDir}.${process.pid}.${extractCounter++}.tmp`;
   fs.rmSync(tmpDir, { recursive: true, force: true });
   await extractTarball(res.body, tmpDir);
   if (!fs.existsSync(path.join(tmpDir, "lib", "main.js"))) {

--- a/cli/src/utils/esbuild_loader.ts
+++ b/cli/src/utils/esbuild_loader.ts
@@ -6,7 +6,7 @@ import { createGunzip } from "node:zlib";
 import { Readable } from "node:stream";
 import { pathToFileURL } from "node:url";
 import * as tar from "tar-stream";
-import * as log from "../../core/log.ts";
+import * as log from "../core/log.ts";
 
 // esbuild splits into a JS host package and a per-platform native binary
 // (@esbuild/<platform>). They must be the same version. A broken or incremental
@@ -141,6 +141,25 @@ async function ensureWasmPackage(version: string): Promise<string> {
   return destDir;
 }
 
+/**
+ * Resolves a tar entry to an absolute path inside destDir, stripping the leading
+ * "package/" component that npm tarballs use. Returns null if the entry would
+ * escape destDir (tar-slip), since WINDMILL_ESBUILD_WASM_URL allows untrusted
+ * tarball sources.
+ */
+export function resolveTarEntryPath(
+  destDir: string,
+  entryName: string
+): string | null {
+  const rel = entryName.replace(/^[^/]+\//, "");
+  const root = path.resolve(destDir);
+  const outPath = path.resolve(root, rel);
+  if (outPath !== root && !outPath.startsWith(root + path.sep)) {
+    return null;
+  }
+  return outPath;
+}
+
 // Extracts an npm tarball (gzipped tar) into destDir, stripping the leading
 // "package/" path component that npm tarballs use.
 async function extractTarball(
@@ -154,8 +173,15 @@ async function extractTarball(
       stream.on("end", next);
       return;
     }
-    const rel = header.name.replace(/^[^/]+\//, "");
-    const outPath = path.join(destDir, rel);
+    const outPath = resolveTarEntryPath(destDir, header.name);
+    if (!outPath) {
+      // Reject tar-slip entries that would write outside the cache dir.
+      stream.resume();
+      stream.on("end", () =>
+        next(new Error(`unsafe path in esbuild-wasm tarball: ${header.name}`))
+      );
+      return;
+    }
     fs.mkdirSync(path.dirname(outPath), { recursive: true });
     const ws = fs.createWriteStream(outPath, { mode: header.mode ?? 0o644 });
     stream.pipe(ws);

--- a/cli/src/utils/local_path_scripts.ts
+++ b/cli/src/utils/local_path_scripts.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { stat } from "node:fs/promises";
 import { readTextFile } from "./utils.ts";
+import { getEsbuild } from "./esbuild_loader.ts";
 import type { SyncCodebase } from "./codebase.ts";
 import { parseMetadataFileIfExists } from "./metadata.ts";
 import { inferContentTypeFromFilePath } from "./script_common.ts";
@@ -43,7 +44,7 @@ async function bundleSingleFileCodebaseScript(
     ).toString();
   }
 
-  const esbuild = await import("esbuild");
+  const esbuild = await getEsbuild();
   const out = await esbuild.build({
     entryPoints: [filePath],
     // Inline rawscripts are executed through the standard module wrapper,

--- a/cli/test/esbuild_loader_unit.test.ts
+++ b/cli/test/esbuild_loader_unit.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Unit tests for esbuild_loader pure logic (no backend, no network).
+ */
+
+import { expect, test, describe } from "bun:test";
+import { resolveTarEntryPath } from "../src/utils/esbuild_loader.ts";
+import { sep, resolve } from "node:path";
+
+describe("resolveTarEntryPath", () => {
+  const dest = resolve("/tmp/cache/esbuild-wasm-0.28.0");
+
+  test("strips the leading package/ component and resolves inside dest", () => {
+    expect(resolveTarEntryPath(dest, "package/lib/main.js")).toBe(
+      dest + sep + "lib" + sep + "main.js"
+    );
+    expect(resolveTarEntryPath(dest, "package/esbuild.wasm")).toBe(
+      dest + sep + "esbuild.wasm"
+    );
+  });
+
+  test("rejects tar-slip entries that escape the dest dir", () => {
+    expect(resolveTarEntryPath(dest, "package/../../etc/passwd")).toBeNull();
+    expect(resolveTarEntryPath(dest, "package/../../../outside")).toBeNull();
+  });
+
+  test("rejects entries that only share a prefix with dest", () => {
+    // ".../esbuild-wasm-0.28.0-evil" must not be treated as inside dest
+    expect(resolveTarEntryPath(dest, "evil/../../esbuild-wasm-0.28.0-evil/x"))
+      .toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

App bundling during `wmill sync push` (e.g. GitHub code sync) can crash on a worker with:

```
✘ [ERROR] Cannot start service: Host version "0.28.0" does not match binary version "0.28.1"
```

esbuild splits into a JS host package and a per-platform native binary (`@esbuild/<platform>`) that must be the same version. A broken or incremental install can leave the on-disk binary at a different version than the pinned host. The running code can't fix what npm/bun put on disk — so when the native service refuses to start, `createBundle` transparently falls back to **esbuild-wasm**, whose binary is a single version-pinned `.wasm`. Host and binary then come from the same package by construction, so nothing on the consumer host can make them drift.

Native esbuild stays the default and the fast path; wasm only triggers when native can't run (or when forced).

### Keeping the 14MB out of the install

`esbuild-wasm` is **not** a dependency. The fallback downloads the package once and caches it on disk, on the fallback path only. So the happy path pays nothing (native speed, no download), the published CLI doesn't grow, and a broken worker pays a one-time download then uses the cache.

Note: it downloads the **whole esbuild-wasm package** (not just the `.wasm`). esbuild-wasm reads the app's files from disk by spawning `node bin/esbuild`, which needs `bin/esbuild` + `esbuild.wasm` + `wasm_exec*.js` co-located — the browser build that can take a bare `.wasm` module has no filesystem access and can't bundle a real app. The version downloaded is read from the native host's `esbuild.version`, so the wasm matches the broken host exactly.

## Changes

- New `cli/src/commands/app/esbuild_loader.ts`:
  - `getEsbuild()` — native-first; a `transform("")` smoke test forces the native service to start so any breakage surfaces at load time. On **any** smoke-test failure it falls back (the host/binary mismatch text is printed to the child's stderr while the thrown error is the generic `The service was stopped` — so we gate on the smoke test, not a string match). Memoized per process.
  - `stopEsbuild()` — stops the esbuild service (native or wasm; both are child-process services) so the process can exit.
  - Fallback acquisition: `WINDMILL_ESBUILD_WASM_PATH` (extracted package dir override) → on-disk cache → download `WINDMILL_ESBUILD_WASM_URL` (default npm registry tarball). Tarball is gunzipped + untarred (via the already-bundled `tar-stream` + `node:zlib`) into a temp dir and renamed into place (atomic; a partial/corrupt cache self-heals). `WINDMILL_FORCE_ESBUILD_WASM=1` skips native entirely.
- `cli/src/commands/app/bundle.ts`: `createBundle()` uses `getEsbuild()`/`stopEsbuild()` and reads results from in-memory `outputFiles` with `write:false` (esbuild-wasm rejects `write:true`; native supports `write:false` too, and the dist files were deleted after the read anyway).
- `cli/src/commands/app/dev.ts`: comment documenting dev mode is intentionally native-only (relies on `context()`/watch; the crash matters on workers via `sync push`, not local dev).
- `cli/build-npm.ts`: comment explaining `esbuild-wasm` is not a dependency and is fetched at runtime.

## Test plan (verified end-to-end against the real built+packed `windmill-cli`)

- [x] `bun run build-npm.ts` + `npm pack` + install into a clean project: generated `package.json` has **no** `esbuild-wasm`, no esbuild `.wasm` shipped (only the ~3.5MB CLI), `npm install` pulls native `@esbuild/<platform>` but not esbuild-wasm.
- [x] Native path on a real `.raw_app`: builds successfully, no warning, no download.
- [x] **Auto-fallback**: with the native `@esbuild` binary swapped to a mismatched version, `wmill app lint` detects native is unusable, warns, downloads+extracts esbuild-wasm, and builds successfully.
- [x] Forced wasm cold (`WINDMILL_FORCE_ESBUILD_WASM=1`): downloads + extracts + builds.
- [x] Forced/auto wasm warm: reuses the cached package, no re-download.
- [x] Corrupt/partial cache self-heals (extract is atomic via temp+rename).
- [x] Healthy native does **not** false-trigger the fallback (no download).
- [x] Runs under plain `node` (not just bun), i.e. the published artifact.
- [x] `cli` lint unit suite (exercises `createBundle`): 14 pass / 0 fail.
- [ ] On a worker with a genuinely mismatched native install, confirm `wmill sync push` auto-falls back and succeeds.
- [ ] Confirm a svelte raw app bundles on the wasm fallback path (esbuild plugin API is identical, but worth exercising once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review fixes (commit 13f8c9a)

- **[P0] tar-slip in tarball extraction** — `extractTarball` now resolves each entry through `resolveTarEntryPath()` and rejects any entry that would escape the cache dir (`WINDMILL_ESBUILD_WASM_URL` allows untrusted sources). Added `test/esbuild_loader_unit.test.ts` covering the guard.
- **[P2] Incomplete sync-push coverage** — routed the other esbuild bundling sites through `getEsbuild()`: codebase bundling on push (`script.ts:331`), codebase preview (`script.ts:1568`), and inline-rawscript bundling (`local_path_scripts.ts:46`). All already used `write:false`+`outputFiles`, so it's a drop-in. Dev mode stays native-only (documented).
- Moved the loader to `src/utils/esbuild_loader.ts` since it's now shared across `app/`, `script/`, and `utils/`.

(The earlier Codex P1 about `browser.js`/`write` was from an older revision — the current code uses the Node build `lib/main.js` with `write:false`, as Pi noted.)
