### PR TITLE
fix(frontend): add missing graph context in decision tree preview

### DIFF
--- a/frontend/src/lib/components/apps/editor/settingsPanel/decisionTree/DecisionTreePreview.svelte
+++ b/frontend/src/lib/components/apps/editor/settingsPanel/decisionTree/DecisionTreePreview.svelte
@@ -23,11 +23,14 @@
 	import DecisionTreeGraphNode from '../DecisionTreeGraphNode.svelte'
 	import DecisionTreeGraphHeader from '../DecisionTreeGraphHeader.svelte'
 
-	import { type Writable } from 'svelte/store'
+	import { writable, type Writable } from 'svelte/store'
 	import type { AppComponent, DecisionTreeNode } from '../../component'
 	import { getContext, untrack } from 'svelte'
 	import type { AppViewerContext } from '$lib/components/apps/types'
 	import { deleteGridItem } from '../../appUtils'
+	import { setGraphContext } from '$lib/components/graph/graphContext'
+	import { SelectionManager } from '$lib/components/graph/selectionUtils.svelte'
+	import { createFlowDiffManager } from '$lib/components/flows/flowDiffManager.svelte'
 
 	interface Props {
 		nodes: DecisionTreeNode[]
@@ -54,6 +57,13 @@
 
 	const { app, runnableComponents, componentControl, debuggingComponents } =
 		getContext<AppViewerContext>('AppViewerContext')
+
+	setGraphContext({
+		selectionManager: new SelectionManager(),
+		useDataflow: writable(false),
+		showAssets: writable(false),
+		diffManager: createFlowDiffManager()
+	})
 
 	function addSubGrid() {
 		const numberOfPanes = nodes.length
@@ -224,7 +234,7 @@
 						position: { x: -1, y: -1 },
 						data: {
 							node: {
-								label: `Branch ${(positionRelativeToParent  ?? 0) + 1}`,
+								label: `Branch ${(positionRelativeToParent ?? 0) + 1}`,
 								id: branchHeaderId,
 								allowed: undefined,
 								next: [],


### PR DESCRIPTION
## Summary

Fixes WIN-2039.

Opening the Decision Tree graph editor in the App Builder froze the page. `DecisionTreePreview.svelte` renders its nodes through `NodeWrapper.svelte`, which calls `getGraphContext()` (added in 7a5e48787 for drag-and-drop). Because `DecisionTreePreview` never called `setGraphContext()`, `getGraphContext()` returned `undefined`, and destructuring `{ moveManager }` from it threw a `TypeError` during render, freezing the UI. Regression since v1.648.0.

This adds the missing `setGraphContext()` call, mirroring the established pattern in `MiniFlowGraph.svelte` (lines 61-66), so the decision-tree nodes receive a real graph context. The complementary defensive guard in `NodeWrapper.svelte` was already merged in #9602.

## Changes

- `DecisionTreePreview.svelte`: call `setGraphContext({ selectionManager, useDataflow, showAssets, diffManager })` at component init, after the existing `getContext('AppViewerContext')`.
- Add the supporting imports (`writable`, `setGraphContext`, `SelectionManager`, `createFlowDiffManager`).

## Screenshots

The Decision Tree graph editor now opens and renders the graph (Start → node → End with insert buttons) instead of freezing:

![dt-graph-editor](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/diego/win-2039-fixfrontend-add-missing-graph-context-in-decision-tree/1781684375-dt-graph-editor.png)

## Test plan

- [x] `npm run check` passes (0 errors)
- [x] App Builder → add Decision Tree component → settings panel → "Graph editor" opens the drawer and renders the graph without freezing (verified end-to-end in a real browser via Playwright)