### PR TITLE
fix(api): encode non-ASCII filenames in S3 Content-Disposition

### DIFF
--- a/backend/windmill-api/src/args.rs
+++ b/backend/windmill-api/src/args.rs
@@ -67,6 +67,25 @@ pub struct WebhookArgs {
     pub metadata: WebhookArgsMetadata,
 }
 
+/// Build a `Content-Disposition` header value for an inline S3 object upload.
+///
+/// File names may contain non-ASCII characters (e.g. `这是测试.md`). Emitting them
+/// verbatim in a quoted `filename="..."` produces a header whose bytes are not
+/// valid ASCII; the object store then fails to read the attribute back on
+/// download (`HeaderValue::to_str` -> "Content-Disposition header contained non
+/// UTF-8 characters"), surfacing as a 500 (#7456). For non-ASCII names we use the
+/// RFC 6266 / RFC 5987 `filename*=UTF-8''<percent-encoded>` form, which is pure
+/// ASCII and is decoded back to the original name by clients. ASCII names keep
+/// the existing plain `filename="..."` form unchanged.
+#[cfg_attr(not(feature = "parquet"), allow(dead_code))]
+pub(crate) fn content_disposition_inline(filename: &str) -> String {
+    if filename.is_ascii() {
+        format!("inline; filename=\"{}\"", filename)
+    } else {
+        format!("inline; filename*=UTF-8''{}", urlencoding::encode(filename))
+    }
+}
+
 // capture
 //
 
@@ -127,7 +146,7 @@ impl RawWebhookArgs {
                             (
                                 Attribute::ContentDisposition,
                                 if let Some(filename) = filename {
-                                    format!("inline; filename=\"{}\"", filename)
+                                    content_disposition_inline(&filename)
                                 } else {
                                     "inline".to_string()
                                 },
@@ -740,6 +759,60 @@ mod tests {
                 );
             }
             _ => panic!("Expected a HashMap"),
+        }
+    }
+
+    #[test]
+    fn test_content_disposition_ascii_unchanged() {
+        // ASCII filenames keep the existing plain form — no behavior change.
+        assert_eq!(
+            content_disposition_inline("report.md"),
+            "inline; filename=\"report.md\""
+        );
+        assert_eq!(
+            content_disposition_inline("data_2024.csv"),
+            "inline; filename=\"data_2024.csv\""
+        );
+    }
+
+    #[test]
+    fn test_content_disposition_non_ascii_rfc5987() {
+        // #7456: a non-ASCII name must be RFC 5987 percent-encoded, not embedded raw.
+        assert_eq!(
+            content_disposition_inline("这是测试.md"),
+            "inline; filename*=UTF-8''%E8%BF%99%E6%98%AF%E6%B5%8B%E8%AF%95.md"
+        );
+    }
+
+    #[test]
+    fn test_content_disposition_is_always_ascii() {
+        // The header bytes must be valid ASCII so the object store can read the
+        // attribute back via `HeaderValue::to_str` on download (#7456).
+        for name in [
+            "这是测试.md",
+            "ünïcödé file.txt",
+            "Москва.pdf",
+            "日本語.json",
+        ] {
+            assert!(
+                content_disposition_inline(name).is_ascii(),
+                "Content-Disposition must be ASCII for {:?}",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn test_content_disposition_special_chars_encoded() {
+        // urlencoding percent-encodes space as %20 (not +) and escapes *, ', (, )
+        // etc., so neither the RFC 5987 ext-value nor its `'` delimiter can be
+        // corrupted by the file name.
+        let v = content_disposition_inline("café *'() a.txt");
+        assert!(v.is_ascii(), "{}", v);
+        let value = v.split("UTF-8''").nth(1).unwrap();
+        assert!(!value.contains('+'), "space must be %20, not +: {}", v);
+        for bad in ['\'', '*', '(', ')', ' '] {
+            assert!(!value.contains(bad), "{:?} must be encoded: {}", bad, v);
         }
     }
 }


### PR DESCRIPTION
## Summary

`wmill.load_s3_file` fails with a 500 when an S3 object's name contains non-ASCII characters (e.g. a Chinese file name), as reported in #7456:

> Internal: Error retrieving file: Generic S3 error: Content-Disposition header contained non UTF-8 characters

On a multipart S3 upload the backend stored the object's `Content-Disposition` as `inline; filename="<raw name>"`, embedding the file name verbatim. For a non-ASCII name the stored header is not valid ASCII, so on download the object store fails to read the attribute back (`HeaderValue::to_str`) and the request 500s.

## Changes

`backend/windmill-api/src/args.rs`:
- Add `content_disposition_inline`: ASCII names keep the existing `filename="..."` form unchanged; non-ASCII names use the RFC 6266 / RFC 5987 `filename*=UTF-8''<percent-encoded>` form, which is pure ASCII and is decoded back to the original name by clients. Percent-encoding uses the already-present `urlencoding` dependency.
- Use it at the multipart upload site (`process_multipart`).
- Add unit tests covering the ASCII, non-ASCII, always-ASCII, and special-character cases.

## Test plan

- [ ] `cargo test -p windmill-api content_disposition`
- [ ] `cargo fmt --check`

## Notes

- The app-upload path in `apps.rs` takes a client-supplied `content_disposition` rather than building one from a file name, so it is unaffected by this change.
- This stops new uploads from storing a non-ASCII header; objects already stored with a non-ASCII name keep their header and would need to be re-uploaded, since the failure happens on read inside the object store.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encodes non-ASCII filenames in S3 Content-Disposition to prevent 500s on download; ASCII names are unchanged. Fixes #7456.

- Bug Fixes
  - Add `content_disposition_inline` using RFC 6266/5987 `filename*=UTF-8''<percent-encoded>` for non-ASCII names.
  - Use it in the multipart upload path to store ASCII-only headers.
  - Add unit tests for ASCII, non-ASCII, and special characters.

- Migration
  - Existing objects with raw non-ASCII headers still fail; re-upload to fix.
  - App-upload path (client-supplied `content_disposition`) is unchanged.

<sup>Written for commit ecfccf493a2cf6068149cd92e851fa305d0985db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

