### PR TITLE
fix(frontend): render Modal2 dialogs above the AI chat panel

### DIFF
--- a/frontend/src/lib/components/common/modal/Modal2.svelte
+++ b/frontend/src/lib/components/common/modal/Modal2.svelte
@@ -8,6 +8,8 @@
 	import { X } from 'lucide-svelte'
 	import List from '$lib/components/common/layout/List.svelte'
 	import { fade } from 'svelte/transition'
+	import { zIndexes } from '$lib/zIndexes'
+	import { chatState } from '$lib/components/copilot/chat/sharedChatState.svelte'
 
 	interface Props {
 		title: string
@@ -85,6 +87,11 @@
 	function fadeFast(node: HTMLElement) {
 		return fade(node, { duration: 200 })
 	}
+
+	// Elevate above the AI chat panel (zIndexes.aiChat) while chat is open so
+	// the dialog isn't hidden behind it; otherwise keep the default modal
+	// stacking just above disposables (zIndexes.disposables).
+	const overlayZIndex = $derived(chatState.size > 0 ? zIndexes.aiChat + 1 : zIndexes.disposables + 10)
 </script>
 
 <svelte:window onkeydown={handleKeyDown} />
@@ -92,7 +99,8 @@
 {#if isOpen}
 	<Portal name="always-mounted" {target}>
 		<div
-			class={'fixed top-0 bottom-0 left-0 right-0 transition-all z-[1110] overflow-auto bg-black bg-opacity-60 w-full h-full'}
+			class={'fixed top-0 bottom-0 left-0 right-0 transition-all overflow-auto bg-black bg-opacity-60 w-full h-full'}
+			style="z-index: {overlayZIndex}"
 			transition:fadeFast|local
 		>
 			<div class="flex min-h-full items-center justify-center p-8">


### PR DESCRIPTION
## Summary

The AI chat panel renders at `z-index: 1200` (`zIndexes.aiChat`), but `Modal2.svelte` used a hardcoded `z-[1110]` overlay — below the chat panel. As a result, whenever the AI chat was open, the chat window painted on top of any `Modal2`-based dialog (e.g. AI prompt settings, draft-conflict modals, critical alert modal), so the right side of the dialog appeared hidden behind the chat.

The sibling component `Modal.svelte` was already fixed for this exact problem in #8328 by elevating above the chat panel when chat is open. `Modal2` was missed — this PR applies the same approach.

## Changes

- `frontend/src/lib/components/common/modal/Modal2.svelte`: replace the hardcoded `z-[1110]` overlay class with a derived z-index that mirrors `Modal.svelte`:
  - **chat open** → `zIndexes.aiChat + 1` (1201), just above the chat panel (1200)
  - **chat closed** → `zIndexes.disposables + 10` (1110), identical to the previous hardcoded value (no behavioral change)
- Uses the shared `zIndexes` constants instead of magic numbers, and applies the value via inline `style` (Tailwind can't generate arbitrary classes from a runtime value), consistent with how `Modal.svelte` does it.

The elevated overlay (1201) still sits below selects (5000), popover (5001), context menus (6000), Monaco (10000), and tooltips (20000), so dropdowns/tooltips opened inside the dialog continue to layer correctly above it.

## Screenshots

AI chat open + a `Modal2` dialog (AI prompt settings), narrow viewport so the dialog and chat panel overlap horizontally.

**Before** — the chat panel covers the right portion of the dialog (close button + text area obscured):

![before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/chat-alert-modal-overlap/1781702598-before.png)

**After** — the dialog renders fully in front of the dimmed chat panel:

![after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/chat-alert-modal-overlap/1781702598-after.png)

## Test plan

- [x] With the AI chat open, open a `Modal2` dialog → overlay computed `z-index` = 1201, above chat (1200); `elementFromPoint` at the dialog's right edge (in the chat region) resolves inside the dialog, not the chat
- [x] No new console errors introduced
- [ ] Close the AI chat, reopen the same dialog → still renders correctly over page content (1110 path)
- [ ] Open a select/dropdown or tooltip inside the dialog while chat is open → still layers above the dialog

Fixes WIN-2067