### PR TITLE
fix(drafts): preserve original timestamp when migrating localStorage drafts

### DIFF
--- a/backend/.sqlx/query-c8fb2a1491f90951a6d2e4e9c56d288eb60f6c6644a73cdf949de0159215a7f7.json
+++ b/backend/.sqlx/query-c8fb2a1491f90951a6d2e4e9c56d288eb60f6c6644a73cdf949de0159215a7f7.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "INSERT INTO draft (workspace_id, email, path, typ, value, created_at)\n               VALUES ($1, $2, $3, $4, $5::text::json, now())\n               ON CONFLICT (workspace_id, path, typ, email) WHERE email IS NOT NULL\n               DO UPDATE SET value = EXCLUDED.value, created_at = now()\n               WHERE $7::bool = true\n                  OR $6::timestamptz IS NULL\n                  OR draft.created_at <= $6::timestamptz\n               RETURNING created_at",
+  "query": "INSERT INTO draft (workspace_id, email, path, typ, value, created_at)\n               VALUES ($1, $2, $3, $4, $5::text::json, COALESCE($8::timestamptz, now()))\n               ON CONFLICT (workspace_id, path, typ, email) WHERE email IS NOT NULL\n               DO UPDATE SET value = EXCLUDED.value, created_at = EXCLUDED.created_at\n               WHERE $7::bool = true\n                  OR $6::timestamptz IS NULL\n                  OR draft.created_at <= $6::timestamptz\n               RETURNING created_at",
   "describe": {
     "columns": [
       {
@@ -49,12 +49,13 @@
         },
         "Text",
         "Timestamptz",
-        "Bool"
+        "Bool",
+        "Timestamptz"
       ]
     },
     "nullable": [
       false
     ]
   },
-  "hash": "e0cc7528f34cca1a65bcff355805057b1c974a9a947bda133c155503dac1f545"
+  "hash": "c8fb2a1491f90951a6d2e4e9c56d288eb60f6c6644a73cdf949de0159215a7f7"
 }

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -7999,6 +7999,10 @@ paths:
                 legacy:
                   type: boolean
                   description: Delete-only. Target the legacy workspace-level row (email NULL) instead of the current user's row. Used to discard a legacy draft from the review page.
+                created_at:
+                  type: string
+                  format: date-time
+                  description: Upsert-only override for the stored creation timestamp. Normal saves omit it (stamped server-side); the localStorage→DB migration passes the draft's original write time so migrated drafts keep their age.
       responses:
         "200":
           description: save result

--- a/backend/windmill-api/src/drafts.rs
+++ b/backend/windmill-api/src/drafts.rs
@@ -152,6 +152,12 @@ pub struct SaveDraftRequest {
     /// the email-scoped delete otherwise can't reach.
     #[serde(default)]
     pub legacy: bool,
+    /// Upsert-only override for the stored `created_at`. Normal saves omit it
+    /// and the row is stamped `now()`; the localStorage→DB migration passes the
+    /// draft's original write time (or epoch 0 when unknown) so migrated drafts
+    /// keep their age instead of all resurfacing to the top as freshly created.
+    #[serde(default)]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Serialize, Debug)]
@@ -194,11 +200,13 @@ async fn update_draft(
         };
         // Upsert. The conflict check rides on the DO UPDATE WHERE clause —
         // when the row is newer than `last_sync`, RETURNING yields nothing.
+        // `created_at` defaults to `now()` but the migration overrides it ($8)
+        // so a migrated draft keeps its original age instead of jumping to top.
         sqlx::query_scalar!(
             r#"INSERT INTO draft (workspace_id, email, path, typ, value, created_at)
-               VALUES ($1, $2, $3, $4, $5::text::json, now())
+               VALUES ($1, $2, $3, $4, $5::text::json, COALESCE($8::timestamptz, now()))
                ON CONFLICT (workspace_id, path, typ, email) WHERE email IS NOT NULL
-               DO UPDATE SET value = EXCLUDED.value, created_at = now()
+               DO UPDATE SET value = EXCLUDED.value, created_at = EXCLUDED.created_at
                WHERE $7::bool = true
                   OR $6::timestamptz IS NULL
                   OR draft.created_at <= $6::timestamptz
@@ -210,6 +218,7 @@ async fn update_draft(
             serialized,
             req.last_sync,
             req.force,
+            req.created_at,
         )
         .fetch_optional(&db)
         .await?

--- a/frontend/src/lib/userDraftDbMigration.ts
+++ b/frontend/src/lib/userDraftDbMigration.ts
@@ -248,11 +248,16 @@ export async function migrateUserDraftsToDb(): Promise<void> {
 				}
 				continue
 			}
+			// Preserve the draft's original age: stamp `created_at` with the LS
+			// write time (epoch 0 when unknown) so migrated drafts don't all
+			// resurface to the top as freshly created. Same value as `last_sync`,
+			// which still drives the conflict check.
+			const writtenAt = new Date(lastWrittenAt ?? 0).toISOString()
 			const res = await DraftService.updateDraft({
 				workspace: parsed.workspace,
 				kind: parsed.itemKind,
 				path,
-				requestBody: { value, last_sync: new Date(lastWrittenAt ?? 0).toISOString() }
+				requestBody: { value, last_sync: writtenAt, created_at: writtenAt }
 			})
 			if (res.status === 'conflict') {
 				console.info(


### PR DESCRIPTION
## Summary

The one-off localStorage→DB user-draft migration upserts each draft via `POST /drafts/update`, whose SQL hardcoded `created_at = now()` on both insert and conflict-update. As a result every migrated draft was stamped with the migration time and resurfaced to the top as if freshly created — confusing post-migration ordering.

This change lets the migration preserve each draft's real age: it stores either the draft's original write time or epoch 1970 when that's unknown.

## Changes

- **backend/windmill-api/src/drafts.rs**: add an optional `created_at` override to `SaveDraftRequest`. The upsert now stamps `COALESCE($8::timestamptz, now())` and `created_at = EXCLUDED.created_at`. Normal saves omit the field → still `now()` (no behavior change); the migration supplies the stored timestamp. The conflict-check `WHERE` clause is untouched.
- **frontend/src/lib/userDraftDbMigration.ts**: send `created_at` (= `lastWrittenAt`, or epoch 0 when unknown — the same value already used for `last_sync`).
- **backend/windmill-api/openapi.yaml**: document the new upsert-only `created_at` field; regenerated the frontend client.
- **backend/.sqlx**: regenerated query cache for the changed upsert (EE caches preserved, zero net deletions).

No visible UI surface — the frontend change is migration logic in a `.ts` file, so no screenshots apply.

## Test plan

- [x] Backend compiles (`cargo check --workspace --all-features`) and runs.
- [x] Live API: upsert with `created_at: 2020-01-01` stores that timestamp (`current_timestamp` echoes it back); upsert without it stores `now()`.
- [ ] With legacy localStorage drafts present (distinct `lastWrittenAt`, one missing), load a workspace so `migrateUserDraftsToDb` runs; confirm migrated drafts keep relative ordering by original write time (unknown-age at the bottom) instead of jumping to the top.
- [ ] A normal draft save + re-save still advances `created_at` to the current time (override only affects the migration path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)