### PR TITLE
fix(frontend): deploy-page Codex review follow-up (app draft no-op, view-only diff)

### DIFF
--- a/frontend/src/lib/components/CompareDrafts.svelte
+++ b/frontend/src/lib/components/CompareDrafts.svelte
@@ -588,14 +588,19 @@
 				{/if}
 				{#if deploymentStatus[draftItem.key]?.status !== 'deployed'}
 					{@const discardBlock = blockedReason(draftItem)}
-					<Button
-						unifiedSize="xs"
-						variant="subtle"
-						startIcon={{ icon: DiffIcon }}
-						onClick={() => showDiff(draftItem)}
-					>
-						Show diff
-					</Button>
+					<!-- Show diff fetches the *current user's* draft overlay, so it's only
+					     meaningful for your own/legacy rows. Another user's draft (view-only,
+					     `mine=false`) would diff against the wrong draft or 404 — hide it. -->
+					{#if draftItem.mine}
+						<Button
+							unifiedSize="xs"
+							variant="subtle"
+							startIcon={{ icon: DiffIcon }}
+							onClick={() => showDiff(draftItem)}
+						>
+							Show diff
+						</Button>
+					{/if}
 					<Button
 						unifiedSize="xs"
 						variant="subtle"

--- a/frontend/src/lib/components/raw_apps/rawAppDraftValue.ts
+++ b/frontend/src/lib/components/raw_apps/rawAppDraftValue.ts
@@ -1,10 +1,11 @@
 /**
  * Shared projection of a raw-app *source* into the flat `AppDraftValue` the
- * deploy paths consume. Used by BOTH the global AI chat
+ * deploy paths consume. The single source for BOTH the global AI chat
  * (`copilot/chat/global/core.ts`) and the Review & Deploy page
- * (`rawAppDeploy.ts`) so the two can't drift — a past divergence here silently
- * dropped a draft's files and broke deploys with "Raw app bundle requires
- * /index.ts".
+ * (`rawAppDeploy.ts`), so both bundle the identical shape. It must read a
+ * draft's top-level `files` (a `RawAppDraft` carries them there, not under
+ * `value.files`) — otherwise the bundle is empty and deploy fails with "Raw app
+ * bundle requires /index.ts".
  */
 import type { AppDraftValue } from '$lib/components/copilot/chat/global/workspaceItems'
 import { DEFAULT_DATA as DEFAULT_RAW_APP_DATA } from '$lib/components/raw_apps/dataTableRefUtils'

--- a/frontend/src/routes/(root)/(logged)/apps/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps/edit/[...path]/+page.svelte
@@ -197,7 +197,14 @@
 		// there's no deployed row (draft-only path).
 		deployedBaseline = backendApp.no_deployed
 			? undefined
-			: (structuredClone(stateSnapshot(backendApp.value)) as App)
+			: // Carry the deployed summary onto the baseline: the autosave mirrors the
+				// summary onto the live App value, so the `discardIf` no-op comparison must
+				// see the deployed summary here too — otherwise a reverted-to-deployed draft
+				// never compares equal (and a summary-only edit still counts as a change).
+				({
+					...(structuredClone(stateSnapshot(backendApp.value)) as App),
+					summary: backendApp.summary
+				} as App)
 		// `other_drafts_users` only computed when `getDraft`; don't clobber the
 		// known list on a `getDraft:false` reload. See /scripts/edit's loader.
 		if (getDraft) {


### PR DESCRIPTION
Follow-up to #9625, which squash-merged before the Codex review's fixes could land. Codex flagged 3 issues (one P1) that are now in `main`; this PR addresses them.

## Fixes
- **[P1] Visual-app draft no-op detection.** #9625 mirrors the app summary onto the autosaved App value, but the autosave's `discardIf` compares the live value against the deployed baseline — which carried no summary — so a draft reverted to the deployed state never compared equal and a no-op draft was persisted instead of deleted. Carry the deployed summary onto the baseline (`apps/edit/[...path]/+page.svelte`) so the comparison matches; a summary-only edit still counts as a real change.
- **[P2] "Show diff" on view-only rows.** In the "Show all drafts" view, foreign (`mine=false`) rows kept "Show diff" enabled, but `getDraftDiffValues` only fetches the current user's draft overlay → wrong diff for another user's deployed-row draft, 404 for their draft-only row. Hide it for foreign rows (`CompareDrafts.svelte`); own/legacy rows keep it.
- **[P2] Comment references drafting history.** Reword the `rawAppDraftValue` doc comment to state the current invariant (must read a draft's top-level `files`) instead of the past failure, per AGENTS.md.

## Test plan
- [ ] Edit a deployed app's draft, revert the value+summary to deployed → the draft is deleted (no no-op draft persisted); a summary-only change still persists a draft.
- [ ] "Show all drafts" on: another user's draft row offers no "Show diff"; your own/legacy rows still do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)