### PR TITLE
fix(ai_evals): adapt global eval harness to DB-backed user drafts

### DIFF
--- a/ai_evals/adapters/frontend/core/global/globalEvalRunner.ts
+++ b/ai_evals/adapters/frontend/core/global/globalEvalRunner.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../../../frontend/src/lib/components/copilot/chat/global/core";
 import {
   clearGlobalDrafts,
+  getGlobalDraft,
   listGlobalDrafts,
 } from "../../../../../frontend/src/lib/components/copilot/chat/global/userDraftAdapter";
 import type { Tool as ProductionTool } from "../../../../../frontend/src/lib/components/copilot/chat/shared";
@@ -18,6 +19,7 @@ import type { GlobalDraftState } from "../../../../core/validators";
 import type { WindmillBackendSettings } from "../../../../core/windmillBackendSettings";
 import {
   registerBenchmarkWorkspaceRunnables,
+  seedBenchmarkDraft,
   unregisterBenchmarkWorkspaceRunnables,
   type BenchmarkWorkspaceRunnables,
 } from "../../mockBackend";
@@ -94,7 +96,7 @@ export async function runGlobalEval(
       tools: getGlobalEvalTools(),
       helpers: {},
       apiKey,
-      getOutput: () => ({ drafts: listGlobalDrafts(workspaceRoot) }),
+      getOutput: () => collectGlobalDraftState(workspaceRoot),
       onAssistantMessageStart: options.runContext?.onAssistantMessageStart,
       onAssistantToken: options.runContext?.onAssistantChunk,
       onAssistantMessageEnd: options.runContext?.onAssistantMessageEnd,
@@ -130,6 +132,32 @@ export async function runGlobalEval(
   }
 }
 
+// Build the harness output from the DB-backed drafts. `listGlobalDrafts` returns
+// metadata-only rows for backend drafts (the model's `write_script` etc. persist
+// straight to the backend with no in-tab editor cell), so re-read each such row
+// with `getGlobalDraft` to attach the full value the validators assert on. A row
+// that already carries a value (the production in-tab cell overlay) is kept as-is.
+async function collectGlobalDraftState(
+  workspace: string,
+): Promise<GlobalDraftState> {
+  const items = await listGlobalDrafts(workspace);
+  const drafts = await Promise.all(
+    items.map(async (item) => {
+      if (item.value !== undefined) {
+        return item;
+      }
+      const full = await getGlobalDraft(
+        workspace,
+        item.type,
+        item.path,
+        item.triggerKind,
+      );
+      return full ?? item;
+    }),
+  );
+  return { drafts: drafts as GlobalDraftState["drafts"] };
+}
+
 function seedLiveEditorDrafts(
   workspace: string,
   fixtures: GlobalLiveEditorDraftFixture[],
@@ -138,7 +166,9 @@ function seedLiveEditorDrafts(
     const itemKind = LIVE_EDITOR_ITEM_KINDS[fixture.type];
     const storagePath = fixture.storagePath ?? fixture.effectivePath ?? "";
     if (fixture.value !== undefined) {
-      UserDraft.save(itemKind, storagePath, fixture.value, { workspace });
+      // Seed as a backend draft row, not an in-tab cell: a cell would shadow the
+      // model's DB-backed edit when the output is read back via listGlobalDrafts.
+      seedBenchmarkDraft(workspace, itemKind, storagePath, fixture.value);
     }
     UserDraft.setLiveEditorDraft({
       workspace,

--- a/ai_evals/adapters/frontend/core/shared/baseEvalRunner.ts
+++ b/ai_evals/adapters/frontend/core/shared/baseEvalRunner.ts
@@ -38,8 +38,9 @@ export interface RunEvalParams<THelpers, TOutput> {
   helpers: THelpers;
   /** API key for the provider */
   apiKey: string;
-  /** Function to get the current output state */
-  getOutput: () => TOutput;
+  /** Function to get the current output state. May be async — global mode reads
+   * DB-backed drafts back through the (mocked) backend to build its output. */
+  getOutput: () => TOutput | Promise<TOutput>;
   /** Model and Windmill backend configuration */
   options: EvalRunnerOptions;
   onAssistantMessageStart?: () => void;
@@ -154,7 +155,7 @@ export async function runEval<THelpers, TOutput>(
       if (result.hitMaxIterations) {
         return {
           success: false,
-          output: getOutput(),
+          output: (await getOutput()) as TOutput,
           error: `Reached max turns (${maxIterations})`,
           tokenUsage: result.tokenUsage,
           toolCallsCount,
@@ -170,7 +171,7 @@ export async function runEval<THelpers, TOutput>(
 
       return {
         success: true,
-        output: getOutput(),
+        output: (await getOutput()) as TOutput,
         tokenUsage: result.tokenUsage,
         toolCallsCount,
         toolsCalled,
@@ -191,7 +192,7 @@ export async function runEval<THelpers, TOutput>(
 
       return {
         success: false,
-        output: getOutput(),
+        output: (await getOutput()) as TOutput,
         error: errorMessage,
         tokenUsage: { prompt: 0, completion: 0, total: 0 },
         toolCallsCount,

--- a/ai_evals/adapters/frontend/mockBackend.ts
+++ b/ai_evals/adapters/frontend/mockBackend.ts
@@ -3,7 +3,11 @@ import type { CompletedJob, Flow, Job, Script } from '../../../frontend/src/lib/
 import type {
 	DataTableTables,
 	DataTableTableSchema,
-	ScriptLang
+	GetDraftForUserResponse,
+	ListDraftsResponse,
+	ScriptLang,
+	UpdateDraftResponse,
+	UserDraftItemKind
 } from '../../../frontend/src/lib/gen/types.gen'
 import { buildScriptLintResult } from './core/script/preview'
 import { applyDatatableSql, type BenchmarkDatatableSeed } from './datatableSqlEngine'
@@ -63,6 +67,7 @@ export function resetBenchmarkMockBackend(): void {
 	benchmarkWorkspaces.clear()
 	benchmarkWorkspaceRunnables.clear()
 	benchmarkJobs.clear()
+	benchmarkDrafts.clear()
 }
 
 export function registerBenchmarkWorkspace(workspace: string): void {
@@ -74,6 +79,8 @@ export function registerBenchmarkWorkspaceRunnables(
 	runnables: BenchmarkWorkspaceRunnables
 ): void {
 	benchmarkWorkspaces.add(workspace)
+	// Fresh case: drop any drafts left from a prior run on this workspace id.
+	clearBenchmarkDrafts(workspace)
 	// Datatables are mutated in place by exec_datatable_sql (a write must be visible
 	// to later reads), so store an isolated deep copy — never mutate the caller's seed.
 	benchmarkWorkspaceRunnables.set(workspace, {
@@ -98,6 +105,7 @@ export function registerBenchmarkWorkspaceRunnables(
 export function unregisterBenchmarkWorkspace(workspace: string): void {
 	benchmarkWorkspaces.delete(workspace)
 	benchmarkWorkspaceRunnables.delete(workspace)
+	clearBenchmarkDrafts(workspace)
 	for (const [jobId, entry] of benchmarkJobs.entries()) {
 		if (entry.workspace === workspace) {
 			benchmarkJobs.delete(jobId)
@@ -236,6 +244,110 @@ export function getBenchmarkJobLogs(workspace: string, jobId: string): string {
 		throw new Error(`Job Logs not found for "${jobId}"`)
 	}
 	return job.logs ?? ''
+}
+
+// ============= Drafts (per-user, DB-backed in production) =============
+
+/**
+ * In-memory stand-in for the per-user draft backend (`DraftService`). The global
+ * AI chat now persists and reads drafts through the backend DB instead of an
+ * in-tab `UserDraft` cell, so the eval mocks the three draft endpoints it
+ * exercises (`updateDraft` / `getDraftForUser` / `listDrafts`) and keeps the
+ * saved values here, keyed by workspace + draft kind + storage path. Mirrors the
+ * semantics of the production unit test's mock in
+ * `frontend/src/lib/components/copilot/chat/global/core.test.ts`.
+ */
+const benchmarkDrafts = new Map<
+	string,
+	{ workspace: string; kind: UserDraftItemKind; path: string; value: unknown }
+>()
+
+// Fixed timestamp so artifacts stay deterministic. No eval simulates a
+// concurrent writer, so every save is accepted and the conflict branch is
+// never taken — the syncer just records this as its `last_sync` baseline.
+const BENCHMARK_DRAFT_TIMESTAMP = '1970-01-01T00:00:00.000Z'
+
+function benchmarkDraftKey(workspace: string, kind: string, path: string): string {
+	return `${workspace}::${kind}::${path}`
+}
+
+export function clearBenchmarkDrafts(workspace: string): void {
+	for (const [key, entry] of benchmarkDrafts.entries()) {
+		if (entry.workspace === workspace) {
+			benchmarkDrafts.delete(key)
+		}
+	}
+}
+
+/**
+ * Seed a draft straight into the store — used by the eval's live-editor draft
+ * fixtures, which model "the user already has this draft open/saved". Writing it
+ * here (instead of through `UserDraft.save`) keeps it a backend draft row with no
+ * shadowing in-tab cell, so a model edit that persists to the backend is what the
+ * output read-back captures — not the stale seed.
+ */
+export function seedBenchmarkDraft(
+	workspace: string,
+	kind: UserDraftItemKind,
+	path: string,
+	value: unknown
+): void {
+	benchmarkDrafts.set(benchmarkDraftKey(workspace, kind, path), {
+		workspace,
+		kind,
+		path,
+		value
+	})
+}
+
+/** Mirror `DraftService.updateDraft`: a `null`/omitted value deletes the row. */
+export function updateBenchmarkDraft(input: {
+	workspace: string
+	kind: UserDraftItemKind
+	path: string
+	requestBody?: { value?: unknown }
+}): UpdateDraftResponse {
+	const key = benchmarkDraftKey(input.workspace, input.kind, input.path)
+	const value = input.requestBody?.value
+	if (value == null) {
+		benchmarkDrafts.delete(key)
+	} else {
+		benchmarkDrafts.set(key, {
+			workspace: input.workspace,
+			kind: input.kind,
+			path: input.path,
+			value
+		})
+	}
+	return { status: 'saved', current_timestamp: BENCHMARK_DRAFT_TIMESTAMP }
+}
+
+/** Mirror `DraftService.getDraftForUser`: 404-shaped throw when absent so the
+ * adapter's narrowed catch treats it as "no draft" instead of re-throwing. */
+export function getBenchmarkDraftForUser(input: {
+	workspace: string
+	kind: UserDraftItemKind
+	path: string
+}): GetDraftForUserResponse {
+	const entry = benchmarkDrafts.get(benchmarkDraftKey(input.workspace, input.kind, input.path))
+	if (!entry) {
+		throw Object.assign(new Error(`no draft for "${input.path}"`), { status: 404 })
+	}
+	return { value: entry.value, created_at: BENCHMARK_DRAFT_TIMESTAMP }
+}
+
+/** Mirror `DraftService.listDrafts`: metadata rows (no value) for a workspace. */
+export function listBenchmarkDrafts(workspace: string): ListDraftsResponse {
+	return [...benchmarkDrafts.values()]
+		.filter((entry) => entry.workspace === workspace)
+		.map((entry) => ({
+			kind: entry.kind,
+			path: entry.path,
+			summary: (entry.value as { summary?: string } | null)?.summary,
+			draft_only: true,
+			legacy_draft: false,
+			created_at: BENCHMARK_DRAFT_TIMESTAMP
+		}))
 }
 
 // ============= Datatables (best-effort in-memory SQL) =============

--- a/ai_evals/adapters/frontend/mockBackendDrafts.test.ts
+++ b/ai_evals/adapters/frontend/mockBackendDrafts.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import {
+	clearBenchmarkDrafts,
+	getBenchmarkDraftForUser,
+	listBenchmarkDrafts,
+	resetBenchmarkMockBackend,
+	seedBenchmarkDraft,
+	updateBenchmarkDraft
+} from './mockBackend'
+
+const WORKSPACE = 'benchmark-drafts-ws'
+
+// Drives the in-memory stand-in for the per-user draft backend (`DraftService`)
+// that the global AI-chat eval round-trips its drafts through. Mirrors the
+// production-unit-test mock in
+// `frontend/src/lib/components/copilot/chat/global/core.test.ts`.
+describe('mockBackend drafts', () => {
+	beforeEach(() => resetBenchmarkMockBackend())
+	afterEach(() => resetBenchmarkMockBackend())
+
+	it('round-trips a saved draft through update / get / list', () => {
+		const value = { summary: 'Greet a user', content: 'export async function main() {}' }
+		const res = updateBenchmarkDraft({
+			workspace: WORKSPACE,
+			kind: 'script',
+			path: 'f/evals/greet',
+			requestBody: { value }
+		})
+		expect(res.status).toBe('saved')
+
+		expect(getBenchmarkDraftForUser({ workspace: WORKSPACE, kind: 'script', path: 'f/evals/greet' }).value).toEqual(
+			value
+		)
+
+		const rows = listBenchmarkDrafts(WORKSPACE)
+		expect(rows).toHaveLength(1)
+		expect(rows[0]).toMatchObject({ kind: 'script', path: 'f/evals/greet', summary: 'Greet a user', draft_only: true })
+	})
+
+	it('treats a null value as a delete', () => {
+		updateBenchmarkDraft({
+			workspace: WORKSPACE,
+			kind: 'variable',
+			path: 'f/evals/token',
+			requestBody: { value: { summary: 'token' } }
+		})
+		updateBenchmarkDraft({
+			workspace: WORKSPACE,
+			kind: 'variable',
+			path: 'f/evals/token',
+			requestBody: { value: null }
+		})
+
+		expect(listBenchmarkDrafts(WORKSPACE)).toHaveLength(0)
+		expect(() => getBenchmarkDraftForUser({ workspace: WORKSPACE, kind: 'variable', path: 'f/evals/token' })).toThrow()
+	})
+
+	it('throws a 404-shaped error when no draft exists', () => {
+		try {
+			getBenchmarkDraftForUser({ workspace: WORKSPACE, kind: 'script', path: 'f/evals/missing' })
+			throw new Error('expected a throw')
+		} catch (e) {
+			expect((e as { status?: number }).status).toBe(404)
+		}
+	})
+
+	it('seeds a draft as a backend row that a later edit overwrites', () => {
+		seedBenchmarkDraft(WORKSPACE, 'script', 'f/evals/current', { content: 'seed' })
+		expect(getBenchmarkDraftForUser({ workspace: WORKSPACE, kind: 'script', path: 'f/evals/current' }).value).toEqual({
+			content: 'seed'
+		})
+
+		// A model edit persists the same path and must win over the seed.
+		updateBenchmarkDraft({
+			workspace: WORKSPACE,
+			kind: 'script',
+			path: 'f/evals/current',
+			requestBody: { value: { content: 'edited' } }
+		})
+		expect(getBenchmarkDraftForUser({ workspace: WORKSPACE, kind: 'script', path: 'f/evals/current' }).value).toEqual({
+			content: 'edited'
+		})
+	})
+
+	it('clears only the targeted workspace', () => {
+		seedBenchmarkDraft(WORKSPACE, 'script', 'f/a', { content: 'a' })
+		seedBenchmarkDraft('other-ws', 'script', 'f/b', { content: 'b' })
+
+		clearBenchmarkDrafts(WORKSPACE)
+
+		expect(listBenchmarkDrafts(WORKSPACE)).toHaveLength(0)
+		expect(listBenchmarkDrafts('other-ws')).toHaveLength(1)
+	})
+})

--- a/ai_evals/adapters/frontend/vitestAdapter.test.ts
+++ b/ai_evals/adapters/frontend/vitestAdapter.test.ts
@@ -36,12 +36,14 @@ vi.mock('$lib/gen', async () => {
 		getBenchmarkCompletedJob,
 		getBenchmarkCompletedJobResultMaybe,
 		getBenchmarkDatatableSchema,
+		getBenchmarkDraftForUser,
 		getBenchmarkFlowByPath,
 		getBenchmarkJobLogs,
 		getBenchmarkScriptByHash,
 		getBenchmarkScriptByPath,
 		hasBenchmarkWorkspace,
 		listBenchmarkDatatables,
+		listBenchmarkDrafts,
 		listBenchmarkFlows,
 		listBenchmarkJobs,
 		listBenchmarkScripts,
@@ -50,7 +52,8 @@ vi.mock('$lib/gen', async () => {
 		previewBenchmarkSchedule,
 		runBenchmarkDatatableSql,
 		runBenchmarkFlowByPath,
-		runBenchmarkScriptPreview
+		runBenchmarkScriptPreview,
+		updateBenchmarkDraft
 	} = await import('./mockBackend')
 
 	function wrapService<T extends object>(target: T, overrides: Record<string, unknown>): T {
@@ -66,6 +69,25 @@ vi.mock('$lib/gen', async () => {
 
 	return {
 		...actual,
+		DraftService: wrapService(actual.DraftService, {
+			updateDraft: async (data: {
+				workspace: string
+				kind: any
+				path: string
+				requestBody?: { value?: unknown }
+			}) =>
+				hasBenchmarkWorkspace(data.workspace)
+					? updateBenchmarkDraft(data)
+					: actual.DraftService.updateDraft(data),
+			getDraftForUser: async (data: { workspace: string; kind: any; path: string }) =>
+				hasBenchmarkWorkspace(data.workspace)
+					? getBenchmarkDraftForUser(data)
+					: actual.DraftService.getDraftForUser(data),
+			listDrafts: async (data: { workspace: string }) =>
+				hasBenchmarkWorkspace(data.workspace)
+					? listBenchmarkDrafts(data.workspace)
+					: actual.DraftService.listDrafts(data)
+		}),
 		ScriptService: wrapService(actual.ScriptService, {
 			listScripts: async (data: { workspace: string }) =>
 				hasBenchmarkWorkspace(data.workspace)


### PR DESCRIPTION
## Summary

Every `global`-mode `ai_evals` case was broken on `main`. The DB-backed user-draft migration (#9601, "adapt AI-chat/sessions drafts to DB-backed model") changed the production global AI chat to persist and read drafts through the backend (`DraftService` over `OpenAPI.BASE`) instead of an in-process `UserDraft` cell. The eval harness still drove the in-process store and passed a temp-dir path as the "workspace" without configuring `OpenAPI.BASE`/auth, so the save→read round-trip hit the real request layer and failed:

```
TypeError: Failed to parse URL from /api/w//tmp/.../drafts/list
```

Result: 0% pass rate and an empty `global-drafts.json`, even though the model called `write_script` with correct arguments. This is a harness bug — the last `ai_evals` commit predated the migration, so the harness was never adapted. `cli` mode is unaffected (no `UserDraft`).

This blocker was documented in #9640.

## Approach

Mock the draft backend in the vitest bridge (Approach 2), mirroring how every other `$lib/gen` service is already mocked in-memory keyed by the benchmark workspace — and exactly how the production unit test `frontend/src/lib/components/copilot/chat/global/core.test.ts` mocks `DraftService`. **No production frontend draft code is changed.**

## Changes

- **`mockBackend.ts`** — added an in-memory per-workspace draft store standing in for `DraftService`, with `updateBenchmarkDraft` / `getBenchmarkDraftForUser` / `listBenchmarkDrafts` (matching the generated `UpdateDraftResponse` / `GetDraftForUserResponse` / `ListDraftsResponse` shapes; 404-shaped throw so the adapter's narrowed catch treats a miss as "no draft"), plus `seedBenchmarkDraft` and `clearBenchmarkDrafts`. The store is reset per case via `register`/`unregister`/`reset`.
- **`vitestAdapter.test.ts`** — wired `DraftService.{updateDraft,getDraftForUser,listDrafts}` into the `$lib/gen` mock, routed to the store for benchmark workspaces and falling through to the real service otherwise (same `wrapService` pattern as the other services).
- **`globalEvalRunner.ts`** — `getOutput` now reads the DB-backed drafts: `listGlobalDrafts` returns metadata-only rows for backend drafts, so each is re-read with `getGlobalDraft` to attach the full value the validators assert on. Live-editor fixtures are now seeded straight into the backend store (`seedBenchmarkDraft`) instead of an in-tab `UserDraft.save` cell — a cell would shadow the model's DB-backed edit on read-back, capturing the stale seed instead of the edit.
- **`baseEvalRunner.ts`** — `getOutput` is now `() => TOutput | Promise<TOutput>` and awaited (global mode reads drafts back through the mocked backend asynchronously). Also fixes a pre-existing type error from the un-awaited `listGlobalDrafts` promise.
- **`mockBackendDrafts.test.ts`** — new `bun:test` unit suite for the store (round-trip, null-as-delete, 404 shape, seed-then-overwrite, per-workspace isolation).

## Test plan

- [x] `bun run cli -- run global global-test1-script-create --model haiku` → 100% pass; `global-drafts.json` contains a script draft at `f/evals/global/greet_user` with full content; deterministic checks pass ("global produced at least one draft", "global includes script draft f/evals/global/greet_user", "uses write_script", value-includes `name`/`Hello`).
- [x] Spot-checked `global-test6-secret-variable-draft` (skipJudge, variable draft), `global-test12-current-live-script-edit`, `global-test13-current-live-flow-edit` — all pass; live-edit cases now capture the model's edit (`name.toUpperCase()!`, `tax = subtotal * 0.08`) rather than the stale seed.
- [x] `bun run typecheck` — 0 new errors in touched files (the 203 remaining are pre-existing `../cli/` baseline noise); resolves 1 pre-existing harness type error.
- [x] `bun test` adapter suite — 61 pass / 0 fail (including the 5 new draft-store tests).