### PR TITLE
fix(frontend): show AI sessions when AI unconfigured, with disabled chat

### DIFF
--- a/frontend/src/lib/components/sessions/SessionPicker.svelte
+++ b/frontend/src/lib/components/sessions/SessionPicker.svelte
@@ -46,7 +46,6 @@
 	import DropdownV2 from '$lib/components/DropdownV2.svelte'
 	import { visibleWorkspaceIds } from './sessionScope.svelte'
 	import { isGlobalAiEnabled } from '$lib/components/copilot/chat/global/gate'
-	import { copilotInfo } from '$lib/aiStore'
 	import { userWorkspaces, usersWorkspaceStore, workspaceStore } from '$lib/stores'
 	import { WorkspaceService } from '$lib/gen'
 	import { sendUserToast } from '$lib/toast'
@@ -318,9 +317,11 @@
 	)
 </script>
 
-{#if !globalEnabled || !$copilotInfo.enabled}
-	<!-- Sessions hidden until the global-ai dev gate is enabled, and whenever AI is
-	     unavailable (no provider configured or disabled in the user's AI settings). -->
+{#if !globalEnabled}
+	<!-- Sessions hidden until the global-ai dev gate is enabled. When AI is
+	     unavailable (no provider configured or disabled in the user's settings)
+	     the section still shows — the per-session chat input is disabled with an
+	     explanatory message, mirroring the sidebar AI chat. -->
 {:else if isCollapsed}
 	<div class="px-2 pt-3 pb-2 border-b border-light dark:border-gray-700">
 		<Menubar>


### PR DESCRIPTION
## Summary
Previously the **AI sessions** sidebar section was hidden entirely when AI was not configured at the workspace level (no provider configured, or AI disabled in the user's account settings). This PR keeps the section visible in that case and lets the per-session chat input fall into its disabled state with an explanatory message — mirroring how the sidebar AI chat already behaves.

The disabled-input + message UI is already implemented in `AIChat.svelte` (driven by `!$copilotInfo.enabled`), so opening a session in an unconfigured workspace now degrades gracefully instead of the entry vanishing.

## Changes
- `frontend/src/lib/components/sessions/SessionPicker.svelte`: drop the `|| !$copilotInfo.enabled` half of the visibility gate (keep the `!globalEnabled` dev-flag gate). Remove the now-unused `copilotInfo` import and update the surrounding comment.

## Screenshots
AI sessions section now visible in a workspace with **no AI provider configured** ("Testing"), and the session chat input disabled with the config message:

![sessions-sidebar-visible](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-c6d92d91/1781709473-sessions-sidebar-visible.png)

![sessions-disabled-chat](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-c6d92d91/1781709473-sessions-disabled-chat.png)

## Test plan
- [ ] With the global-ai dev flag on (`localStorage wm_dev_global_ai=1`) and **no AI provider** configured for the workspace: the "AI sessions" section appears, a session opens, and the chat input is disabled with the expected message (admin → workspace-settings enable link; non-admin → "ask an admin"; account-disabled → that variant).
- [ ] With AI configured: sessions work as before (input enabled).
- [ ] With the dev flag off: the section is still hidden entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)