### PR TITLE
fix(git-sync): bump default sync script to hub/28719 (windmill-cli 1.728.1) for WAC modules

### DIFF
--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -165,7 +165,7 @@ pub enum ObjectType {
     WorkspaceDependencies,
 }
 
-pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28261/sync-script-to-git-repo-windmill";
+pub const LATEST_GIT_SYNC_SCRIPT_PATH: &str = "hub/28719/sync-script-to-git-repo-windmill";
 
 /// Prefix used to identify fork workspaces. A workspace whose id starts with this string is a
 /// fork of another workspace.


### PR DESCRIPTION
## Summary

On-deploy git-sync runs the pinned hub script `sync-script-to-git-repo`, which until now pinned `windmill-cli@1.713.2`. That CLI predates the `gitSyncIncludePattern` `__mod/**` fix (#9606, WIN-2052): the per-item include-derivation only matched the flat script layout (`<path>.script.*`), not the module-folder layout (`<path>__mod/...`) used by workflow-as-code (WAC v2 / module) scripts. Because the include set is an AND filter, every `__mod/` file was filtered out of the deploy pull and never reached the repo — deploying a WAC v2 script left it absent from git.

The CLI code fix shipped in v1.727.0, but on-deploy git-sync doesn't use the instance CLI — it runs the pinned hub script. This points `LATEST_GIT_SYNC_SCRIPT_PATH` at the republished script (windmill-labs/windmill-integrations#155) that pins `windmill-cli@1.728.1`, so the deployed sync job actually runs a CLI containing the fix.

## Changes

- `backend/windmill-common/src/workspaces.rs`: `LATEST_GIT_SYNC_SCRIPT_PATH` `hub/28261` → `hub/28719/sync-script-to-git-repo-windmill` (pins `windmill-cli@1.728.1`)

## Test plan

- [x] Published hub script `version_id` 28719 pins `windmill-cli@1.728.1` (import + embedded lockfile); `bun install --frozen-lockfile` resolves `wmill 1.728.1`
- [x] `windmill-cli@1.728.1` bundle returns `` `${path}.*,${path}__mod/**` `` for scripts (the #9606 fix)
- [ ] Deploy a WAC v2 (module) script in a workspace with on-deploy git-sync enabled and confirm the `<path>__mod/` files land in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch on-deploy git-sync to use `hub/28719/sync-script-to-git-repo-windmill` pinning `windmill-cli@1.728.1`, so WAC v2 module files under `__mod/**` are included in repo sync. Addresses WIN-2052 by using the fixed `gitSyncIncludePattern`.

- **Bug Fixes**
  - Update `LATEST_GIT_SYNC_SCRIPT_PATH` from `hub/28261/...` to `hub/28719/...`.
  - Prevents module-based scripts from being filtered out during deploy; no action needed by users.

<sup>Written for commit 41305a81848443d642b172df85a34defba836144. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

