### PR TITLE
oauth: complete Coupa managed client-credentials (instance mapping + default scopes)

### DIFF
--- a/backend/oauth_connect.json
+++ b/backend/oauth_connect.json
@@ -133,6 +133,18 @@
   },
   "coupa": {
     "grant_types": ["client_credentials"],
+    "cc_scopes": [
+      "core.supplier.read",
+      "core.supplier.write",
+      "core.purchase_order.read",
+      "core.purchase_order.write",
+      "core.requisition.read",
+      "core.requisition.write",
+      "core.invoice.read",
+      "core.invoice.write",
+      "core.contract.read",
+      "core.expense.read"
+    ],
     "connect_config_template": {
       "display_name": "Coupa",
       "label": "Coupa instance",

--- a/backend/oauth_connect.json
+++ b/backend/oauth_connect.json
@@ -138,7 +138,10 @@
       "label": "Coupa instance",
       "placeholder": "your-instance",
       "token_url": "https://{instance}.coupahost.com/oauth2/token",
-      "strip_suffix": ".coupahost.com"
+      "strip_suffix": ".coupahost.com",
+      "resource_mapping": {
+        "instance_url": "https://{instance}.coupahost.com"
+      }
     }
   },
   "sage_intacct": {


### PR DESCRIPTION
Follow-up to #9559 (zero-setup OAuth client credentials), which registered Coupa. Two small additions so a Coupa connection works end-to-end with no manual fixup:

1. **`resource_mapping`** — Coupa's `connect_config_template` collects an instance name to host-pin the token URL but had no mapping, so the created resource's `instance_url` stayed empty. The hub scripts build every call on `instance_url` (`${instance_url}/api/...`), so without it a connected resource doesn't work. Mirrors ServiceNow.
2. **`cc_scopes`** — prefill the connect dialog's scope field with the `core.*` scopes the Coupa hub scripts exercise: read+write for suppliers/purchase_orders/requisitions/invoices, read-only for contracts/expenses (the shipped scripts only read those). Without a default the user faces an empty scope field and must know Coupa's exact scope strings. Scope names verified against Coupa's scope docs and corroborated in production code; the user can trim to whatever their OIDC client is granted.

Pairs with the hub-side change in windmill-labs/windmill-integrations#147 — the Coupa resource is now fully Windmill-managed (`instance_url` + `token`); scripts use the token as a plain Bearer credential and never exchange it themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)