### PR TITLE
fix(ai-chat): stop echoing app draft value in global chat write tool results

### DIFF
--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -783,6 +783,40 @@ describe('global AI tools', () => {
 		expect(getBackendDraft('raw_app', 'u/admin/live_app', { workspace: WORKSPACE })).toBeUndefined()
 	})
 
+	it('does not echo the app value back to the model on write', async () => {
+		const sentinel = 'SENTINEL_DO_NOT_ECHO_DEADBEEF'
+		seedBackendDraft(
+			'raw_app',
+			'',
+			{
+				summary: 'Echo check',
+				files: { '/src/App.tsx': `export default function App() { return '${sentinel}' }` },
+				runnables: {},
+				data: { tables: [] }
+			},
+			{ workspace: WORKSPACE }
+		)
+		UserDraft.setLiveEditorDraft({
+			workspace: WORKSPACE,
+			itemKind: 'raw_app',
+			storagePath: '',
+			effectivePath: 'u/admin/echo_app'
+		})
+
+		const raw = await callGlobalTool('write_app_file', {
+			path: 'u/admin/echo_app',
+			file_path: '/src/New.tsx',
+			content: 'export default function New() { return null }'
+		})
+
+		const parsed = JSON.parse(raw)
+		expect(parsed.success).toBe(true)
+		expect(parsed.item).toBeUndefined()
+		// Neither the pre-existing file body nor the just-written one is resent.
+		expect(raw).not.toContain(sentinel)
+		expect(raw).not.toContain('function New')
+	})
+
 	it('discards a draft without deleting the workspace item', async () => {
 		await callGlobalTool('write_script', {
 			path: 'f/scripts/discard-me',

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -2399,13 +2399,13 @@ function draftWriteFailure(result: DraftPersistResult, ctx: WriteDraftCtx): stri
 function finishAppDraftWrite(
 	result: DraftPersistResult,
 	ctx: WriteDraftCtx,
-	onSaved: (item: WorkspaceItem) => { content: string; message: string }
+	onSaved: () => { content: string; message: string }
 ): string {
 	const failure = draftWriteFailure(result, ctx)
 	if (failure) return failure
-	const { content, message } = onSaved(result.item)
+	const { content, message } = onSaved()
 	ctx.toolCallbacks.setToolStatus(ctx.toolId, { content, result: 'Saved as draft' })
-	return JSON.stringify({ success: true, message, item: result.item }, null, 2)
+	return JSON.stringify({ success: true, message }, null, 2)
 }
 
 function finishDraftWrite(


### PR DESCRIPTION
## Problem

`finishAppDraftWrite` — the shared return path for every global-chat raw-app write tool (`write_app_file`, `patch_app_file`, `write_app_runnable`, `delete_app_file`, `delete_app_runnable`, `init_app`) — returned:

```ts
return JSON.stringify({ success: true, message, item: result.item }, null, 2)
```

`result.item.value` is the **entire app draft** — every frontend file body plus inline runnable contents. So each write echoed the whole app back into the conversation. On a large app this overflows the model's context window after only a few edits.

Measured on the `analytics_dashboard` benchmark fixture (a ~5,000-line data module → `seedData.ts` is 102,916 chars): a multi-file rename made ~12 patches and the request died with `400 prompt is too long: 210,525 tokens > 200,000`. After this fix the same task completes well under the window.

## Root cause — a regression

[#9530](https://github.com/windmill-labs/windmill/pull/9530) ("stop echoing draft values in global chat write tool results") removed `item:` from these results. The DB-backed-draft refactor [#9601](https://github.com/windmill-labs/windmill/pull/9601) reintroduced it by routing all app writes through this new shared helper with `item: result.item` re-added.

## Fix

Return only `{ success, message }`, matching the flow write tools (which already follow the "must not echo the value back to the model" invariant). `result` is still consulted for conflict/error detection; only the value echo is dropped. All six call sites already ignore the `onSaved` item argument, so its signature is simplified to take none.

Adds a regression test asserting an app write result does not contain the saved file bodies and has no `item` field.

## Scope

One isolated change to `global/core.ts` + a test. No behavior change other than the tool-result payload; the saved draft itself is unaffected. No user-visible UI surface (this is an AI-chat tool-result payload), so no screenshots apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)