### PR TITLE
fix(backend): grant notify_event access to windmill roles (WIN-2074)

### DIFF
--- a/backend/migrations/20260619091631_grant_notify_event_to_windmill_roles.down.sql
+++ b/backend/migrations/20260619091631_grant_notify_event_to_windmill_roles.down.sql
@@ -1,0 +1,4 @@
+REVOKE ALL ON notify_event FROM windmill_user;
+REVOKE ALL ON notify_event FROM windmill_admin;
+REVOKE ALL ON SEQUENCE notify_event_id_seq FROM windmill_user;
+REVOKE ALL ON SEQUENCE notify_event_id_seq FROM windmill_admin;

--- a/backend/migrations/20260619091631_grant_notify_event_to_windmill_roles.up.sql
+++ b/backend/migrations/20260619091631_grant_notify_event_to_windmill_roles.up.sql
@@ -1,0 +1,14 @@
+-- The notify_event table (migration 20260203172950_polling_based_events) was
+-- created relying on ALTER DEFAULT PRIVILEGES to grant access to windmill_user
+-- and windmill_admin. Those default privileges only apply to objects created by
+-- the role that set them (migration 20250205131523), so deployments whose
+-- migration runner is a different role leave notify_event ungranted. Trigger
+-- inserts were worked around with SECURITY DEFINER, but direct application
+-- inserts (clear_static_asset_usage in assets.rs, restart_worker_group in
+-- settings) run as the invoking role and fail with "permission denied for table
+-- notify_event". Grant explicitly to guarantee access regardless of who ran the
+-- migrations.
+GRANT ALL ON notify_event TO windmill_user;
+GRANT ALL ON notify_event TO windmill_admin;
+GRANT ALL ON SEQUENCE notify_event_id_seq TO windmill_user;
+GRANT ALL ON SEQUENCE notify_event_id_seq TO windmill_admin;


### PR DESCRIPTION
## Problem

Customers report `Error while saving the script: SqlErr: error returned from database: permission denied for table notify_event @assets.rs:68:5` when saving a script.

## Root cause

The `notify_event` table was introduced in migration `20260203172950_polling_based_events` (the LISTEN/NOTIFY → polling swap). It was created **without an explicit GRANT**, relying instead on the `ALTER DEFAULT PRIVILEGES` set up by migration `20250205131523_grant_all_in_current_schema`.

`ALTER DEFAULT PRIVILEGES` only applies to objects created by the role that ran it. Deployments whose migration runner is a different role (common in self-hosted / managed-Postgres setups, where Windmill connects as a dedicated non-superuser role) end up with a `notify_event` table that `windmill_user` / `windmill_admin` have **no** privileges on.

Trigger-driven inserts were already worked around by making the trigger functions `SECURITY DEFINER` (migration `20260206060555`). But **direct application inserts** that run as the invoking role were never covered:

- `clear_static_asset_usage` / `clear_static_asset_usage_by_script_hash` in `windmill-common/src/assets.rs` (fires on every script save → the reported `assets.rs:68`)
- `restart_worker_group` insert in `windmill-api-settings`

These fail with `permission denied for table notify_event`.

## Fix

Add an explicit `GRANT ALL ON notify_event` + sequence grant to `windmill_user` and `windmill_admin`, matching the existing explicit-grant pattern already used for the `asset` table itself (migration `20250714110352`). Idempotent and additive.

## Validation

Reproduced and fixed against the live dev DB:

```
-- simulate customer (no grants):
REVOKE ALL ON notify_event FROM windmill_user;
SET ROLE windmill_user; INSERT INTO notify_event ...;
ERROR:  permission denied for table notify_event   ← exact customer error

-- after applying migration up.sql:
SET ROLE windmill_user;  INSERT 0 1   ✓
SET ROLE windmill_admin; INSERT 0 1   ✓
```

`cargo sqlx migrate run` applies the migration cleanly. No Rust query changes, so no sqlx offline cache update needed.

Fixes WIN-2074

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly grant `windmill_user` and `windmill_admin` access to the `notify_event` table and `notify_event_id_seq` to stop permission errors on script save and worker group restarts. Fixes WIN-2074.

- **Bug Fixes**
  - Added migration to `GRANT ALL` on `notify_event` and `notify_event_id_seq` for `windmill_user` and `windmill_admin` (with a matching down migration).
  - Ensures direct inserts succeed regardless of which role ran migrations; aligns with the explicit-grant pattern used for `asset`.

<sup>Written for commit 4a85e4220aa2d5fe43eeeb052dc1c7de8aa7785f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

