### PR TITLE
feat(backend): auto-reconnect postgres trigger listener with backoff (WIN-2073)

### DIFF
--- a/backend/windmill-trigger-postgres/src/listener.rs
+++ b/backend/windmill-trigger-postgres/src/listener.rs
@@ -7,10 +7,12 @@ use pg_escape::{quote_identifier, quote_literal};
 use rust_postgres::{Client, CopyBothDuplex, SimpleQueryMessage};
 use tokio::sync::RwLock;
 use tokio_stream::StreamExt;
+use windmill_api_auth::ApiAuthed;
 use windmill_common::{
     db::UserDB,
     error::{to_anyhow, Error, Result},
     jobs::JobTriggerKind,
+    utils::{report_critical_error, report_recovered_critical_error},
     worker::to_raw_value,
     DB,
 };
@@ -30,6 +32,10 @@ use super::{
 };
 
 const ERROR_REPLICATION_SLOT_NOT_EXISTS: &str = r#"The replication slot associated with this trigger no longer exists. Recreate a new replication slot or select an existing one in the advanced tab, or delete and recreate a new trigger"#;
+
+// Wait this long between reconnection attempts after a connection failure or a
+// dropped replication stream. Matches the Kafka trigger listener's backoff.
+const RECONNECT_DELAY_SECS: u64 = 30;
 
 pub struct LogicalReplicationSettings {
     pub streaming: bool,
@@ -126,9 +132,70 @@ impl PostgresSimpleClient {
     }
 }
 
+/// Resolves the Postgres resource, validates that the configured publication and
+/// replication slot still exist, and opens a fresh logical replication stream.
+///
+/// Returns `Error::BadConfig` when the publication or slot is missing (an
+/// unrecoverable misconfiguration). Any other error is treated as transient
+/// (connection refused, network interruption, ...) and is retried by the caller.
+/// The resource is re-resolved on every call so credential rotations are picked
+/// up across reconnections.
+async fn connect_logical_replication_stream(
+    authed: &ApiAuthed,
+    db: &DB,
+    listening_trigger: &ListeningTrigger<PostgresConfig>,
+) -> Result<(CopyBothDuplex<Bytes>, LogicalReplicationSettings)> {
+    let ListeningTrigger { workspace_id, trigger_config, .. } = listening_trigger;
+    let PostgresConfig { postgres_resource_path, publication_name, replication_slot_name, .. } =
+        trigger_config;
+
+    let database = resolve_postgres_resource(
+        authed,
+        Some(UserDB::new(db.clone())),
+        db,
+        postgres_resource_path,
+        workspace_id,
+    )
+    .await?;
+
+    let client = PostgresSimpleClient::new(&database).await?;
+
+    let publication = client
+        .execute_query(&format!(
+            "SELECT pubname FROM pg_publication WHERE pubname = {}",
+            quote_literal(publication_name)
+        ))
+        .await
+        .map_err(to_anyhow)?;
+
+    if !publication.row_exist() {
+        return Err(Error::BadConfig(
+            ERROR_PUBLICATION_NAME_NOT_EXISTS.to_string(),
+        ));
+    }
+
+    let replication_slot = client
+        .execute_query(&format!(
+            "SELECT slot_name FROM pg_replication_slots WHERE slot_name = {}",
+            quote_literal(replication_slot_name)
+        ))
+        .await
+        .map_err(to_anyhow)?;
+
+    if !replication_slot.row_exist() {
+        return Err(Error::BadConfig(
+            ERROR_REPLICATION_SLOT_NOT_EXISTS.to_string(),
+        ));
+    }
+
+    client
+        .get_logical_replication_stream(publication_name, replication_slot_name)
+        .await
+}
+
 #[async_trait::async_trait]
 impl Listener for PostgresTrigger {
-    type Consumer = (CopyBothDuplex<Bytes>, LogicalReplicationSettings);
+    type Consumer = ApiAuthed;
     type Extra = ();
     type ExtraState = ();
     const JOB_TRIGGER_KIND: JobTriggerKind = JobTriggerKind::Postgres;
@@ -140,65 +207,13 @@ impl Listener for PostgresTrigger {
         _err_message: Arc<RwLock<Option<String>>>,
         _killpill_rx: tokio::sync::broadcast::Receiver<()>,
     ) -> Result<Option<Self::Consumer>> {
-        let ListeningTrigger::<Self::TriggerConfig> { workspace_id, trigger_config, .. } =
-            listening_trigger;
-
-        let PostgresConfig {
-            postgres_resource_path, publication_name, replication_slot_name, ..
-        } = trigger_config;
-
+        // The actual replication connection is established (and retried) inside
+        // `consume`. Here we only resolve the auth context that connection needs.
         let authed = listening_trigger
             .authed(db, &Self::TRIGGER_KIND.to_string())
             .await?;
 
-        let database = resolve_postgres_resource(
-            &authed,
-            Some(UserDB::new(db.clone())),
-            &db,
-            postgres_resource_path,
-            workspace_id,
-        )
-        .await?;
-
-        let client = PostgresSimpleClient::new(&database).await?;
-
-        let publication = client
-            .execute_query(&format!(
-                "SELECT pubname FROM pg_publication WHERE pubname = {}",
-                quote_literal(&publication_name)
-            ))
-            .await
-            .map_err(to_anyhow)?;
-
-        if !publication.row_exist() {
-            return Err(Error::BadConfig(
-                ERROR_PUBLICATION_NAME_NOT_EXISTS.to_string(),
-            ));
-        }
-
-        let replication_slot = client
-            .execute_query(&format!(
-                "SELECT slot_name FROM pg_replication_slots WHERE slot_name = {}",
-                quote_literal(&replication_slot_name)
-            ))
-            .await
-            .map_err(to_anyhow)?;
-
-        if !replication_slot.row_exist() {
-            return Err(Error::BadConfig(
-                ERROR_REPLICATION_SLOT_NOT_EXISTS.to_string(),
-            ));
-        }
-
-        let (logical_replication_stream, logical_replication_settings) = client
-            .get_logical_replication_stream(&publication_name, &replication_slot_name)
-            .await
-            .map_err(to_anyhow)?;
-
-        Ok(Some((
-            logical_replication_stream,
-            logical_replication_settings,
-        )))
+        Ok(Some(authed))
     }
     async fn consume(
         &self,
@@ -209,218 +224,327 @@ impl Listener for PostgresTrigger {
         _killpill_rx: tokio::sync::broadcast::Receiver<()>,
         _extra_state: Option<&Self::ExtraState>,
     ) {
-        let (logical_replication_stream, logical_replication_settings) = consumer;
-        pin_mut!(logical_replication_stream);
-        let mut relations = RelationConverter::new();
-        tracing::info!(
-            "Starting to listen for postgres trigger {}",
-            &listening_trigger.path
-        );
-
-        // Highest WAL position received (and processed) so far. Reported back
-        // to Postgres via standby status updates so the replication slot can
-        // advance and retained WAL gets released. Without periodic updates the
-        // slot's LSNs stay frozen and WAL grows unbounded.
-        let mut last_lsn: u64 = 0;
-        let mut status_interval = tokio::time::interval(Duration::from_secs(10));
-        status_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        // First tick resolves immediately; consume it so the periodic cadence
-        // starts one full interval from now.
-        status_interval.tick().await;
+        let authed = consumer;
+        // Consecutive failed connection attempts. Reset to 0 once the replication
+        // stream is (re)established.
+        let mut tries = 0_usize;
 
         loop {
-            let next = tokio::select! {
-                _ = status_interval.tick() => None,
-                message = logical_replication_stream.next() => Some(message),
-            };
-
-            let message = match next {
-                None => {
-                    PostgresSimpleClient::send_status_update(
-                        last_lsn,
-                        &mut logical_replication_stream,
-                    )
-                    .await;
-                    continue;
-                }
-                Some(message) => message,
-            };
-            let message = match message {
-                Some(message) => message,
-                None => {
-                    tracing::error!(
-                        "Stream for postgres trigger {} closed",
-                        &listening_trigger.path
-                    );
-                    if let None = self
-                        .update_ping_and_loop_ping_status(
-                            db,
-                            listening_trigger,
-                            err_message.clone(),
-                            Some("Stream closed".to_string()),
-                        )
-                        .await
-                    {
+            let (logical_replication_stream, logical_replication_settings) =
+                match connect_logical_replication_stream(&authed, db, listening_trigger).await {
+                    Ok(stream) => stream,
+                    // Publication or replication slot missing: retrying cannot fix
+                    // this, so disable the trigger as before.
+                    Err(Error::BadConfig(err)) => {
+                        self.disable_with_error(db, listening_trigger, err).await;
                         return;
                     }
-                    return;
-                }
-            };
+                    // Transient failure (connection refused, network drop, ...):
+                    // back off and retry instead of permanently disabling.
+                    Err(err) => {
+                        let status = format!(
+                            "Failed to connect (attempt {}), retrying in {} seconds: {}",
+                            tries + 1,
+                            RECONNECT_DELAY_SECS,
+                            err
+                        );
+                        if let None = self
+                            .update_ping_and_loop_ping_status(
+                                db,
+                                listening_trigger,
+                                err_message.clone(),
+                                Some(status),
+                            )
+                            .await
+                        {
+                            return;
+                        }
 
-            let message = match message {
-                Ok(message) => message,
-                Err(err) => {
-                    let err = format!(
-                        "Postgres trigger named {} had an error while receiving a message : {}",
-                        &listening_trigger.path,
-                        err.to_string()
-                    );
-                    self.disable_with_error(db, listening_trigger, err).await;
-                    return;
-                }
-            };
+                        tracing::error!(
+                            "Failed to connect postgres trigger {} (attempt {}), retrying in {} seconds: {}",
+                            &listening_trigger.path,
+                            tries + 1,
+                            RECONNECT_DELAY_SECS,
+                            err
+                        );
 
-            let logical_message = match ReplicationMessage::parse(message) {
-                Ok(logical_message) => logical_message,
-                Err(err) => {
-                    let err = format!(
-                        "Postgres trigger named: {} had an error while parsing message: {}",
-                        &listening_trigger.path,
-                        err.to_string()
-                    );
-                    self.disable_with_error(db, listening_trigger, err).await;
-                    return;
-                }
-            };
+                        if tries % 10 == 0 && listening_trigger.trigger_mode {
+                            report_critical_error(
+                                format!(
+                                    "Failed to connect postgres trigger {} (attempt {}), retrying in {} seconds. This alert will repeat every 10 failed attempts. Error: {}",
+                                    &listening_trigger.path,
+                                    tries + 1,
+                                    RECONNECT_DELAY_SECS,
+                                    err
+                                ),
+                                db.clone(),
+                                Some(&listening_trigger.workspace_id),
+                                Some(&format!("postgres_trigger:{}", &listening_trigger.path)),
+                            )
+                            .await;
+                        }
 
-            match logical_message {
-                ReplicationMessage::PrimaryKeepAlive(primary_keep_alive) => {
-                    last_lsn = last_lsn.max(primary_keep_alive.wal_end);
-                    if primary_keep_alive.reply {
+                        tries += 1;
+                        tokio::time::sleep(Duration::from_secs(RECONNECT_DELAY_SECS)).await;
+                        continue;
+                    }
+                };
+
+            // Connected: clear the error/ping status, and if we had been retrying,
+            // report that the trigger recovered.
+            if let None = self
+                .update_ping_and_loop_ping_status(db, listening_trigger, err_message.clone(), None)
+                .await
+            {
+                return;
+            }
+            if tries > 0 {
+                if listening_trigger.trigger_mode {
+                    report_recovered_critical_error(
+                        format!("Postgres trigger {} reconnected", &listening_trigger.path),
+                        db.clone(),
+                        Some(&listening_trigger.workspace_id),
+                        Some(&format!("postgres_trigger:{}", &listening_trigger.path)),
+                    )
+                    .await;
+                }
+                tries = 0;
+            }
+
+            pin_mut!(logical_replication_stream);
+            let mut relations = RelationConverter::new();
+            tracing::info!(
+                "Starting to listen for postgres trigger {}",
+                &listening_trigger.path
+            );
+
+            // Highest WAL position received (and processed) so far. Reported back
+            // to Postgres via standby status updates so the replication slot can
+            // advance and retained WAL gets released. Without periodic updates the
+            // slot's LSNs stay frozen and WAL grows unbounded.
+            let mut last_lsn: u64 = 0;
+            let mut status_interval = tokio::time::interval(Duration::from_secs(10));
+            status_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            // First tick resolves immediately; consume it so the periodic cadence
+            // starts one full interval from now.
+            status_interval.tick().await;
+
+            'stream: loop {
+                let next = tokio::select! {
+                    _ = status_interval.tick() => None,
+                    message = logical_replication_stream.next() => Some(message),
+                };
+
+                let message = match next {
+                    None => {
                         PostgresSimpleClient::send_status_update(
                             last_lsn,
                             &mut logical_replication_stream,
                         )
                         .await;
+                        continue;
                     }
-                }
-                ReplicationMessage::XLogData(x_log_data) => {
-                    last_lsn = last_lsn.max(x_log_data.wal_end);
-                    let logical_replication_message = match x_log_data
-                        .parse(&logical_replication_settings)
-                    {
-                        Ok(logical_replication_message) => logical_replication_message,
-                        Err(err) => {
-                            tracing::error!("Postgres trigger named: {} had an error while trying to parse incomming stream message: {}", &listening_trigger.path, err.to_string());
-                            continue;
+                    Some(message) => message,
+                };
+                let message = match message {
+                    Some(message) => message,
+                    None => {
+                        tracing::error!(
+                            "Stream for postgres trigger {} closed, reconnecting in {} seconds",
+                            &listening_trigger.path,
+                            RECONNECT_DELAY_SECS
+                        );
+                        if let None = self
+                            .update_ping_and_loop_ping_status(
+                                db,
+                                listening_trigger,
+                                err_message.clone(),
+                                Some(format!(
+                                    "Stream closed, reconnecting in {} seconds",
+                                    RECONNECT_DELAY_SECS
+                                )),
+                            )
+                            .await
+                        {
+                            return;
                         }
-                    };
+                        tokio::time::sleep(Duration::from_secs(RECONNECT_DELAY_SECS)).await;
+                        break 'stream;
+                    }
+                };
 
-                    let json = match logical_replication_message {
-                        Relation(relation_body) => {
-                            relations.add_relation(relation_body);
-                            None
+                let message = match message {
+                    Ok(message) => message,
+                    Err(err) => {
+                        tracing::error!(
+                        "Postgres trigger {} had an error while receiving a message, reconnecting in {} seconds: {}",
+                        &listening_trigger.path,
+                        RECONNECT_DELAY_SECS,
+                        err.to_string()
+                    );
+                        if let None = self
+                            .update_ping_and_loop_ping_status(
+                                db,
+                                listening_trigger,
+                                err_message.clone(),
+                                Some(format!(
+                                    "Error receiving message, reconnecting in {} seconds: {}",
+                                    RECONNECT_DELAY_SECS, err
+                                )),
+                            )
+                            .await
+                        {
+                            return;
                         }
-                        Begin | Type | Commit => None,
-                        Insert(insert) => Some((
-                            insert.o_id,
-                            Ok(None),
-                            relations.row_to_json((insert.o_id, insert.tuple)),
-                            "insert",
-                        )),
-                        Update(update) => {
-                            let old_row = update
-                                .old_tuple
-                                .map(|old_tuple| relations.row_to_json((update.o_id, old_tuple)))
-                                .transpose();
-                            let row = relations.row_to_json((update.o_id, update.new_tuple));
-                            Some((update.o_id, old_row, row, "update"))
+                        tokio::time::sleep(Duration::from_secs(RECONNECT_DELAY_SECS)).await;
+                        break 'stream;
+                    }
+                };
+
+                let logical_message = match ReplicationMessage::parse(message) {
+                    Ok(logical_message) => logical_message,
+                    Err(err) => {
+                        let err = format!(
+                            "Postgres trigger named: {} had an error while parsing message: {}",
+                            &listening_trigger.path,
+                            err.to_string()
+                        );
+                        self.disable_with_error(db, listening_trigger, err).await;
+                        return;
+                    }
+                };
+
+                match logical_message {
+                    ReplicationMessage::PrimaryKeepAlive(primary_keep_alive) => {
+                        last_lsn = last_lsn.max(primary_keep_alive.wal_end);
+                        if primary_keep_alive.reply {
+                            PostgresSimpleClient::send_status_update(
+                                last_lsn,
+                                &mut logical_replication_stream,
+                            )
+                            .await;
                         }
-                        Delete(delete) => {
-                            let row = delete
-                                .old_tuple
-                                .unwrap_or_else(|| delete.key_tuple.unwrap());
-                            Some((
-                                delete.o_id,
+                    }
+                    ReplicationMessage::XLogData(x_log_data) => {
+                        last_lsn = last_lsn.max(x_log_data.wal_end);
+                        let logical_replication_message = match x_log_data
+                            .parse(&logical_replication_settings)
+                        {
+                            Ok(logical_replication_message) => logical_replication_message,
+                            Err(err) => {
+                                tracing::error!("Postgres trigger named: {} had an error while trying to parse incomming stream message: {}", &listening_trigger.path, err.to_string());
+                                continue;
+                            }
+                        };
+
+                        let json = match logical_replication_message {
+                            Relation(relation_body) => {
+                                relations.add_relation(relation_body);
+                                None
+                            }
+                            Begin | Type | Commit => None,
+                            Insert(insert) => Some((
+                                insert.o_id,
                                 Ok(None),
-                                relations.row_to_json((delete.o_id, row)),
-                                "delete",
-                            ))
-                        }
-                    };
-                    match json {
-                        Some((o_id, Ok(old_row), Ok(row), transaction_type)) => {
-                            let relation = match relations.get_relation(o_id) {
-                                Ok(relation) => relation,
-                                Err(err) => {
-                                    tracing::error!(
-                                        "Postgres trigger named: {}, error: {}",
-                                        &listening_trigger.path,
-                                        err.to_string()
-                                    );
-                                    continue;
-                                }
-                            };
-                            let database_info = HashMap::from([
-                                ("schema_name".to_string(), to_raw_value(&relation.namespace)),
-                                ("table_name".to_string(), to_raw_value(&relation.name)),
-                                (
-                                    "transaction_type".to_string(),
-                                    to_raw_value(&transaction_type),
-                                ),
-                                ("old_row".to_string(), to_raw_value(&old_row)),
-                                ("row".to_string(), to_raw_value(&row)),
-                            ]);
-                            let _ = self
-                                .handle_event(
-                                    db,
-                                    listening_trigger,
-                                    database_info,
-                                    HashMap::new(),
-                                    None,
-                                )
-                                .await;
-                        }
-                        Some((o_id, old_row, row, transaction_type)) => {
-                            let relation = match relations.get_relation(o_id) {
-                                Ok(relation) => relation,
-                                Err(err) => {
-                                    tracing::error!(
-                                        "Postgres trigger named: {}, error: {}",
-                                        &listening_trigger.path,
-                                        err.to_string()
-                                    );
-                                    continue;
-                                }
-                            };
-
-                            if let Err(err) = old_row {
-                                tracing::error!(
-                                    transaction_type = ?transaction_type,
-                                    schema = %relation.namespace,
-                                    table = %relation.name,
-                                    error = %err,
-                                    "Failed to decode OLD row for {} transaction on {}.{}",
-                                    transaction_type,
-                                    relation.namespace,
-                                    relation.name,
-                                );
+                                relations.row_to_json((insert.o_id, insert.tuple)),
+                                "insert",
+                            )),
+                            Update(update) => {
+                                let old_row = update
+                                    .old_tuple
+                                    .map(|old_tuple| {
+                                        relations.row_to_json((update.o_id, old_tuple))
+                                    })
+                                    .transpose();
+                                let row = relations.row_to_json((update.o_id, update.new_tuple));
+                                Some((update.o_id, old_row, row, "update"))
                             }
-
-                            if let Err(err) = row {
-                                tracing::error!(
-                                    transaction_type = ?transaction_type,
-                                    schema = %relation.namespace,
-                                    table = %relation.name,
-                                    error = %err,
-                                    "Failed to decode NEW row for {} transaction on {}.{}",
-                                    transaction_type,
-                                    relation.namespace,
-                                    relation.name,
-                                );
+                            Delete(delete) => {
+                                let row = delete
+                                    .old_tuple
+                                    .unwrap_or_else(|| delete.key_tuple.unwrap());
+                                Some((
+                                    delete.o_id,
+                                    Ok(None),
+                                    relations.row_to_json((delete.o_id, row)),
+                                    "delete",
+                                ))
                             }
+                        };
+                        match json {
+                            Some((o_id, Ok(old_row), Ok(row), transaction_type)) => {
+                                let relation = match relations.get_relation(o_id) {
+                                    Ok(relation) => relation,
+                                    Err(err) => {
+                                        tracing::error!(
+                                            "Postgres trigger named: {}, error: {}",
+                                            &listening_trigger.path,
+                                            err.to_string()
+                                        );
+                                        continue;
+                                    }
+                                };
+                                let database_info = HashMap::from([
+                                    ("schema_name".to_string(), to_raw_value(&relation.namespace)),
+                                    ("table_name".to_string(), to_raw_value(&relation.name)),
+                                    (
+                                        "transaction_type".to_string(),
+                                        to_raw_value(&transaction_type),
+                                    ),
+                                    ("old_row".to_string(), to_raw_value(&old_row)),
+                                    ("row".to_string(), to_raw_value(&row)),
+                                ]);
+                                let _ = self
+                                    .handle_event(
+                                        db,
+                                        listening_trigger,
+                                        database_info,
+                                        HashMap::new(),
+                                        None,
+                                    )
+                                    .await;
+                            }
+                            Some((o_id, old_row, row, transaction_type)) => {
+                                let relation = match relations.get_relation(o_id) {
+                                    Ok(relation) => relation,
+                                    Err(err) => {
+                                        tracing::error!(
+                                            "Postgres trigger named: {}, error: {}",
+                                            &listening_trigger.path,
+                                            err.to_string()
+                                        );
+                                        continue;
+                                    }
+                                };
+
+                                if let Err(err) = old_row {
+                                    tracing::error!(
+                                        transaction_type = ?transaction_type,
+                                        schema = %relation.namespace,
+                                        table = %relation.name,
+                                        error = %err,
+                                        "Failed to decode OLD row for {} transaction on {}.{}",
+                                        transaction_type,
+                                        relation.namespace,
+                                        relation.name,
+                                    );
+                                }
+
+                                if let Err(err) = row {
+                                    tracing::error!(
+                                        transaction_type = ?transaction_type,
+                                        schema = %relation.namespace,
+                                        table = %relation.name,
+                                        error = %err,
+                                        "Failed to decode NEW row for {} transaction on {}.{}",
+                                        transaction_type,
+                                        relation.namespace,
+                                        relation.name,
+                                    );
+                                }
+                            }
+                            _ => {}
                         }
-                        _ => {}
                     }
                 }
             }

--- a/backend/windmill-trigger-postgres/src/listener.rs
+++ b/backend/windmill-trigger-postgres/src/listener.rs
@@ -290,27 +290,11 @@ impl Listener for PostgresTrigger {
                     }
                 };
 
-            // Connected: clear the error/ping status, and if we had been retrying,
-            // report that the trigger recovered.
-            if let None = self
-                .update_ping_and_loop_ping_status(db, listening_trigger, err_message.clone(), None)
-                .await
-            {
-                return;
-            }
-            if tries > 0 {
-                if listening_trigger.trigger_mode {
-                    report_recovered_critical_error(
-                        format!("Postgres trigger {} reconnected", &listening_trigger.path),
-                        db.clone(),
-                        Some(&listening_trigger.workspace_id),
-                        Some(&format!("postgres_trigger:{}", &listening_trigger.path)),
-                    )
-                    .await;
-                }
-                tries = 0;
-            }
-
+            // The retry counter is reset (and recovery reported, ping cleared) only
+            // once the stream actually delivers a message in the inner loop. A
+            // connection that drops before making any progress therefore keeps
+            // counting toward the reconnection alert instead of ping-ponging
+            // silently.
             pin_mut!(logical_replication_stream);
             let mut relations = RelationConverter::new();
             tracing::info!(
@@ -349,18 +333,14 @@ impl Listener for PostgresTrigger {
                 let message = match message {
                     Some(message) => message,
                     None => {
-                        tracing::error!(
-                            "Stream for postgres trigger {} closed, reconnecting in {} seconds",
-                            &listening_trigger.path,
-                            RECONNECT_DELAY_SECS
-                        );
                         if let None = self
                             .update_ping_and_loop_ping_status(
                                 db,
                                 listening_trigger,
                                 err_message.clone(),
                                 Some(format!(
-                                    "Stream closed, reconnecting in {} seconds",
+                                    "Stream closed (attempt {}), reconnecting in {} seconds",
+                                    tries + 1,
                                     RECONNECT_DELAY_SECS
                                 )),
                             )
@@ -368,6 +348,27 @@ impl Listener for PostgresTrigger {
                         {
                             return;
                         }
+                        tracing::error!(
+                            "Stream for postgres trigger {} closed (attempt {}), reconnecting in {} seconds",
+                            &listening_trigger.path,
+                            tries + 1,
+                            RECONNECT_DELAY_SECS
+                        );
+                        if tries % 10 == 0 && listening_trigger.trigger_mode {
+                            report_critical_error(
+                                format!(
+                                    "Postgres trigger {} stream closed (attempt {}), reconnecting in {} seconds. This alert will repeat every 10 failed attempts.",
+                                    &listening_trigger.path,
+                                    tries + 1,
+                                    RECONNECT_DELAY_SECS
+                                ),
+                                db.clone(),
+                                Some(&listening_trigger.workspace_id),
+                                Some(&format!("postgres_trigger:{}", &listening_trigger.path)),
+                            )
+                            .await;
+                        }
+                        tries += 1;
                         tokio::time::sleep(Duration::from_secs(RECONNECT_DELAY_SECS)).await;
                         break 'stream;
                     }
@@ -376,30 +377,78 @@ impl Listener for PostgresTrigger {
                 let message = match message {
                     Ok(message) => message,
                     Err(err) => {
-                        tracing::error!(
-                        "Postgres trigger {} had an error while receiving a message, reconnecting in {} seconds: {}",
-                        &listening_trigger.path,
-                        RECONNECT_DELAY_SECS,
-                        err.to_string()
-                    );
                         if let None = self
                             .update_ping_and_loop_ping_status(
                                 db,
                                 listening_trigger,
                                 err_message.clone(),
                                 Some(format!(
-                                    "Error receiving message, reconnecting in {} seconds: {}",
-                                    RECONNECT_DELAY_SECS, err
+                                    "Error receiving message (attempt {}), reconnecting in {} seconds: {}",
+                                    tries + 1,
+                                    RECONNECT_DELAY_SECS,
+                                    err
                                 )),
                             )
                             .await
                         {
                             return;
                         }
+                        tracing::error!(
+                            "Postgres trigger {} had an error while receiving a message (attempt {}), reconnecting in {} seconds: {}",
+                            &listening_trigger.path,
+                            tries + 1,
+                            RECONNECT_DELAY_SECS,
+                            err.to_string()
+                        );
+                        if tries % 10 == 0 && listening_trigger.trigger_mode {
+                            report_critical_error(
+                                format!(
+                                    "Postgres trigger {} error while receiving a message (attempt {}), reconnecting in {} seconds. This alert will repeat every 10 failed attempts. Error: {}",
+                                    &listening_trigger.path,
+                                    tries + 1,
+                                    RECONNECT_DELAY_SECS,
+                                    err
+                                ),
+                                db.clone(),
+                                Some(&listening_trigger.workspace_id),
+                                Some(&format!("postgres_trigger:{}", &listening_trigger.path)),
+                            )
+                            .await;
+                        }
+                        tries += 1;
                         tokio::time::sleep(Duration::from_secs(RECONNECT_DELAY_SECS)).await;
                         break 'stream;
                     }
                 };
+
+                // First successful read after a (re)connection means the stream is
+                // making progress: clear the error status, report recovery, and
+                // reset the retry counter. Deferred to here (rather than on connect)
+                // so a stream that drops before delivering anything keeps counting
+                // toward the reconnection alert.
+                if tries > 0 {
+                    if let None = self
+                        .update_ping_and_loop_ping_status(
+                            db,
+                            listening_trigger,
+                            err_message.clone(),
+                            None,
+                        )
+                        .await
+                    {
+                        return;
+                    }
+                    if listening_trigger.trigger_mode {
+                        report_recovered_critical_error(
+                            format!("Postgres trigger {} reconnected", &listening_trigger.path),
+                            db.clone(),
+                            Some(&listening_trigger.workspace_id),
+                            Some(&format!("postgres_trigger:{}", &listening_trigger.path)),
+                        )
+                        .await;
+                    }
+                    tries = 0;
+                }
 
                 let logical_message = match ReplicationMessage::parse(message) {
                     Ok(logical_message) => logical_message,


### PR DESCRIPTION
## Problem

The Postgres trigger listener permanently disabled itself on connection errors. On a closed replication stream it returned silently; on a receive error it called `disable_with_error()`. A transient network interruption (e.g. a cloud provider maintenance window) therefore permanently killed the trigger, requiring a manual re-enable.

In contrast, the Kafka trigger listener (`windmill-trigger-kafka/src/listener_ee.rs`) already has a retry loop with 30s backoff that handles transient failures gracefully.

## Fix

Restructure `PostgresTrigger`'s `Listener` impl to mirror the Kafka pattern:

- **`Consumer` type** changed from a live `(CopyBothDuplex<Bytes>, LogicalReplicationSettings)` to `ApiAuthed`. `get_consumer` now only resolves the auth context; the live replication connection is established inside `consume`, so the very first connection attempt also benefits from retry.
- **New helper `connect_logical_replication_stream`** holds the logic that used to live in `get_consumer`: resolve the Postgres resource, validate the publication and replication slot exist, and open the replication stream. The resource is re-resolved on every attempt, so credential rotations are picked up across reconnections.
- **`consume` now wraps an outer reconnect loop**:
  - On connection failure: log, update ping status, report a critical error every 10 attempts (trigger mode only), sleep 30s, increment a `tries` counter, and retry.
  - On successful reconnect after prior failures: call `report_recovered_critical_error()` and reset `tries`.
  - In the inner message loop: on stream close or receive error, update ping status, back off 30s, and `break` to the outer loop to reconnect instead of disabling.
- **`disable_with_error()` is kept only for unrecoverable cases**: missing publication / replication slot (`Error::BadConfig`) and unparsable replication messages.

### Reconnect flow

```mermaid
flowchart TD
  A[consume] --> B[connect_logical_replication_stream]
  B -->|Ok stream| C[clear status / report recovered if tries>0]
  B -->|Err BadConfig: pub/slot missing| D[disable_with_error + stop]
  B -->|Err transient| E[update ping, alert every 10, sleep 30s, tries+1] --> B
  C --> F[inner message loop]
  F -->|stream closed / recv error| G[update ping, sleep 30s] --> B
  F -->|parse error| D
```

## Notes / decisions

- A deleted Postgres resource now causes retries (with an alert every 10 attempts) rather than an immediate disable, since it is not an `Error::BadConfig`. This is intentionally more graceful: the trigger recovers automatically if the resource is recreated.
- Inner-loop disconnects (stream close / receive error) sleep 30s before reconnecting, matching Kafka's battle-tested behavior. Retained WAL means no events are lost during the gap, only delayed.

## Validation

- `cargo check -p windmill-trigger-postgres` — clean (no errors/warnings).
- Full backend binary rebuilt and restarted cleanly under `cargo watch` (built with `--features quickjs`, which exercises the downstream `windmill-api` / binary consumers of the trait).
- No new `sqlx` macros introduced (only existing helpers + `simple_query`), so no offline-cache regeneration needed.
- A full runtime test of the reconnect path was not performed: the local dev Postgres runs with `wal_level=replica`, and enabling logical replication would require restarting the Postgres instance the running backend depends on. The logic is a direct port of the proven Kafka reconnect pattern.

Fixes WIN-2073

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds auto-reconnect with a 30s backoff to the Postgres trigger listener and improves alerting. Counts reconnects on stream drops and reports recovery only after messages flow, aligning with the Kafka/SQS pattern and fulfilling WIN-2073.

- **New Features**
  - Reconnect loop in `consume` with 30s backoff on connect failure, stream close, or receive error.
  - Reconnect attempts are counted; critical alert on the first failure and every 10 after. Ping status is updated during failures, and recovery is reported only once the reconnected stream delivers a message.

- **Refactors**
  - `Consumer` now `ApiAuthed`; first connection attempt benefits from retry.
  - Added `connect_logical_replication_stream` to validate publication/slot and open the stream; resource is re-resolved each attempt to pick up credential rotations.
  - Disabling kept only for unrecoverable cases (`Error::BadConfig` for missing publication/slot, or unparsable messages). Deleted resources now trigger retries instead of immediate disable.

<sup>Written for commit 008838fe2de9408428514bbec8799dca0a9838fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

