### PR TITLE
fix(ai): emit token usage in gemini proxy streaming translation

### DIFF
--- a/backend/windmill-ai/src/ai_google.rs
+++ b/backend/windmill-ai/src/ai_google.rs
@@ -676,6 +676,29 @@ pub fn gemini_event_to_openai_sse_chunks(
         *tool_call_index += 1;
     }
 
+    // Gemini reports token counts in `usageMetadata` on its final event. Mirror
+    // OpenAI's `stream_options.include_usage` terminal chunk (top-level `usage`,
+    // empty `choices`) so the frontend's `'usage' in chunk` path records them.
+    if let Some(usage) = &parsed.usage {
+        let prompt_tokens = usage.prompt_token_count.unwrap_or(0);
+        let completion_tokens = usage.candidates_token_count.unwrap_or(0);
+        let total_tokens = usage
+            .total_token_count
+            .unwrap_or(prompt_tokens + completion_tokens);
+        let chunk = serde_json::json!({
+            "id": id,
+            "object": "chat.completion.chunk",
+            "model": model,
+            "choices": [],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": total_tokens,
+            }
+        });
+        chunks.push(format!("data: {}\n\n", chunk));
+    }
+
     chunks
 }
 
@@ -836,8 +859,17 @@ fn openai_tool_call_json(
 mod tests {
     use super::{
         gemini_event_to_openai_sse_chunks, gemini_response_to_openai, parse_gemini_sse_event,
-        sanitize_schema_for_google, GeminiParsedEvent, GeminiToolCallEvent,
+        sanitize_schema_for_google, GeminiParsedEvent, GeminiToolCallEvent, GeminiUsageMetadata,
     };
+
+    /// Strip the `data: ...\n\n` SSE framing and parse the payload as JSON.
+    fn parse_sse_chunk(chunk: &str) -> serde_json::Value {
+        let payload = chunk
+            .strip_prefix("data: ")
+            .and_then(|c| c.strip_suffix("\n\n"))
+            .expect("chunk should be wrapped as SSE data");
+        serde_json::from_str(payload).expect("chunk should be valid JSON")
+    }
 
     #[test]
     fn gemini_response_to_openai_preserves_thought_signature() {
@@ -901,6 +933,94 @@ mod tests {
             "stream-thought-signature"
         );
         assert_eq!(tool_call["index"], 0);
+    }
+
+    #[test]
+    fn gemini_streaming_emits_usage_chunk() {
+        let parsed = GeminiParsedEvent {
+            text: Some("the answer".to_string()),
+            usage: Some(GeminiUsageMetadata {
+                prompt_token_count: Some(12),
+                candidates_token_count: Some(7),
+                total_token_count: Some(19),
+            }),
+            ..Default::default()
+        };
+
+        let mut tool_call_index = 0;
+        let chunks = gemini_event_to_openai_sse_chunks(
+            &parsed,
+            "chatcmpl-test",
+            "gemini-3-flash-preview",
+            &mut tool_call_index,
+        );
+
+        // Mirrors OpenAI's `stream_options.include_usage`: a terminal chunk with
+        // top-level `usage` and empty `choices`.
+        let usage_chunk = chunks
+            .iter()
+            .map(|c| parse_sse_chunk(c))
+            .find(|v| v.get("usage").map(|u| !u.is_null()).unwrap_or(false))
+            .expect("a chunk should carry top-level usage");
+
+        assert_eq!(usage_chunk["usage"]["prompt_tokens"], 12);
+        assert_eq!(usage_chunk["usage"]["completion_tokens"], 7);
+        assert_eq!(usage_chunk["usage"]["total_tokens"], 19);
+        assert_eq!(usage_chunk["choices"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn gemini_streaming_usage_total_falls_back_to_prompt_plus_completion() {
+        let parsed = GeminiParsedEvent {
+            usage: Some(GeminiUsageMetadata {
+                prompt_token_count: Some(5),
+                candidates_token_count: Some(3),
+                total_token_count: None,
+            }),
+            ..Default::default()
+        };
+
+        let mut tool_call_index = 0;
+        let chunks = gemini_event_to_openai_sse_chunks(
+            &parsed,
+            "chatcmpl-test",
+            "gemini-3-flash-preview",
+            &mut tool_call_index,
+        );
+
+        let usage_chunk = chunks
+            .iter()
+            .map(|c| parse_sse_chunk(c))
+            .find(|v| v.get("usage").map(|u| !u.is_null()).unwrap_or(false))
+            .expect("a chunk should carry top-level usage");
+
+        assert_eq!(usage_chunk["usage"]["prompt_tokens"], 5);
+        assert_eq!(usage_chunk["usage"]["completion_tokens"], 3);
+        assert_eq!(usage_chunk["usage"]["total_tokens"], 8);
+    }
+
+    #[test]
+    fn gemini_streaming_without_usage_emits_no_usage_chunk() {
+        let parsed = GeminiParsedEvent {
+            text: Some("the answer".to_string()),
+            ..Default::default()
+        };
+
+        let mut tool_call_index = 0;
+        let chunks = gemini_event_to_openai_sse_chunks(
+            &parsed,
+            "chatcmpl-test",
+            "gemini-3-flash-preview",
+            &mut tool_call_index,
+        );
+
+        assert!(
+            chunks
+                .iter()
+                .map(|c| parse_sse_chunk(c))
+                .all(|v| v.get("usage").map(|u| u.is_null()).unwrap_or(true)),
+            "no usage chunk should be emitted when the event has no usageMetadata"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Gemini (Google AI) streaming chat completions reported **zero** token usage to the copilot frontend, while OpenAI / Anthropic / DeepSeek reported real usage.

The frontend chat loop records token usage only from a streamed chunk's top-level OpenAI `usage` field (`frontend/src/lib/components/copilot/lib.ts:963` → `openAICompletionsUsageToChatTokenUsage`, which reads `prompt_tokens`/`completion_tokens`/`total_tokens`), and it requests `stream_options: { include_usage: true }`. For OpenAI/Anthropic/DeepSeek the `/ai/proxy` is effectively a passthrough so the provider's final usage chunk reaches the frontend.

For Gemini, the proxy reconstructs an OpenAI SSE stream from Google's native SSE in `gemini_event_to_openai_sse_chunks` (`backend/windmill-ai/src/ai_google.rs`). That function emitted chunks for `reasoning_content`, `content`, and `tool_calls` — but **never** a chunk carrying `usage`, even though Google's `usageMetadata` (`promptTokenCount`/`candidatesTokenCount`/`totalTokenCount`) is already parsed into `GeminiParsedEvent.usage`. So the counts were parsed and then dropped during SSE translation, and the frontend recorded 0 tokens. (The non-streaming path `gemini_response_to_openai` already included usage — this was a streaming-only drop.)

## Changes

- In `gemini_event_to_openai_sse_chunks`, when `parsed.usage` is present, append a terminal OpenAI chunk mirroring OpenAI's `stream_options.include_usage` convention: top-level `"usage": { prompt_tokens, completion_tokens, total_tokens }` with `"choices": []`.
- Map `prompt_tokens ← promptTokenCount`, `completion_tokens ← candidatesTokenCount`, `total_tokens ← totalTokenCount` (falling back to `prompt + completion` when `totalTokenCount` is missing; missing counts treated as `0`).
- No usage chunk is emitted for events without `parsed.usage`; existing reasoning/content/tool_call chunks are unchanged.
- Added three unit tests: usage chunk emitted with mapped counts, `total_tokens` fallback to `prompt + completion`, and no spurious usage chunk when the event has no `usageMetadata`.

## Test plan

- [x] Added a regression test asserting the bug (`gemini_streaming_emits_usage_chunk`) — confirmed it **fails** on the pre-fix code (no chunk carries `usage`).
- [x] `cargo test -p windmill-ai` — all 63 tests pass, including the 3 new streaming-usage tests.
- [x] **End-to-end A/B via `ai_evals`** (`global-test1-script-create`, model `gemini-3-flash-preview`, routed through the local backend `/ai/proxy`):
  - Before (backend without this fix): `Average tokens: 0 total (0 prompt, 0 completion)`
  - After (backend with this fix): `Average tokens: 229551 total (226957 prompt, 188 completion)`

  Same eval/model/harness; the only difference is this fix. Confirms Gemini token usage now flows end-to-end through the proxy and the frontend chat loop.