### PR TITLE
fix(backend): grant script_trigger access to windmill roles (WIN-2076)

### DIFF
--- a/backend/migrations/20260619112847_grant_script_trigger_to_windmill_roles.down.sql
+++ b/backend/migrations/20260619112847_grant_script_trigger_to_windmill_roles.down.sql
@@ -1,0 +1,4 @@
+REVOKE ALL ON script_trigger FROM windmill_user;
+REVOKE ALL ON script_trigger FROM windmill_admin;
+REVOKE ALL ON SEQUENCE script_trigger_id_seq FROM windmill_user;
+REVOKE ALL ON SEQUENCE script_trigger_id_seq FROM windmill_admin;

--- a/backend/migrations/20260619112847_grant_script_trigger_to_windmill_roles.up.sql
+++ b/backend/migrations/20260619112847_grant_script_trigger_to_windmill_roles.up.sql
@@ -1,0 +1,14 @@
+-- The script_trigger table (migration 20260423050000_script_trigger) was
+-- created relying on ALTER DEFAULT PRIVILEGES to grant access to windmill_user
+-- and windmill_admin. Those default privileges only apply to objects created by
+-- the role that set them (migration 20250205131523), so deployments whose
+-- migration runner is a different role leave script_trigger ungranted. Direct
+-- application writes run as the invoking role (clear_script_triggers and
+-- insert_script_trigger in windmill-common/src/assets.rs, every script save)
+-- and fail with "permission denied for table script_trigger". Grant explicitly
+-- to guarantee access regardless of who ran the migrations (same fix as
+-- notify_event in 20260619091631).
+GRANT ALL ON script_trigger TO windmill_user;
+GRANT ALL ON script_trigger TO windmill_admin;
+GRANT ALL ON SEQUENCE script_trigger_id_seq TO windmill_user;
+GRANT ALL ON SEQUENCE script_trigger_id_seq TO windmill_admin;


### PR DESCRIPTION
## Problem

Saving a script fails with:

```
Error while saving the script: SqlErr: error returned from database: permission denied for table script_trigger @assets.rs:115:5
```

## Root cause

The `script_trigger` table (migration `20260423050000_script_trigger`) was created relying on `ALTER DEFAULT PRIVILEGES` (migration `20250205131523`) to grant access to `windmill_user` / `windmill_admin`. Default privileges only apply to objects created by the role that set them, so deployments whose migration runner is a different role (non-superuser / managed PG) leave `script_trigger` ungranted.

Every script save runs `clear_script_triggers` and `insert_script_trigger` (`windmill-common/src/assets.rs`) as the invoking role, which then hits `permission denied for table script_trigger`.

This is the exact same class of bug as `notify_event` (WIN-2074 / #9665).

## Fix

Add an explicit `GRANT ALL` on `script_trigger` and its sequence to `windmill_user` and `windmill_admin`, matching the `notify_event` fix and the `asset` table precedent (`20250714110352`).

## Validation

Reproduced and verified against the local DB by simulating a non-superuser migration runner:

```
REVOKE ALL ON script_trigger ... ;   -- simulate ungranted state
SET ROLE windmill_user; DELETE FROM script_trigger ...   -- ERROR: permission denied for table script_trigger  (reproduces the issue)
<apply up migration>
SET ROLE windmill_user; DELETE FROM script_trigger ...   -- DELETE 0  (fixed)
SET ROLE windmill_user; INSERT INTO script_trigger ...    -- gets past table+sequence perms (only FK error on a fake workspace)
```

The down migration (`REVOKE`) also applies cleanly.

Grant-only migration — no Rust/SQL query changes, so no sqlx offline cache update or recompile required.

Fixes WIN-2076

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grant explicit access on the `script_trigger` table and `script_trigger_id_seq` to `windmill_user` and `windmill_admin` to fix "permission denied" errors when saving scripts. Ensures `clear_script_triggers` and `insert_script_trigger` work regardless of which role ran migrations; addresses WIN-2076.

<sup>Written for commit f4585de53a04c944a00145598858d9571d05ef24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

