### PR TITLE
fix(python): split PIP_TRUSTED_HOST by whitespace to support multiple hosts

### DIFF
--- a/backend/windmill-worker/nsjail/download_deps.py.sh
+++ b/backend/windmill-worker/nsjail/download_deps.py.sh
@@ -2,7 +2,8 @@
 
 INDEX_URL_ARG=$([ -z "$INDEX_URL" ] && echo ""|| echo "--index-url $INDEX_URL" )
 EXTRA_INDEX_URL_ARG=$([ -z "$EXTRA_INDEX_URL" ] && echo ""|| echo "--extra-index-url $EXTRA_INDEX_URL" )
-TRUSTED_HOST_ARG=$([ -z "$TRUSTED_HOST" ] &&  echo "" || echo "$TRUSTED_HOST" | tr ' ' '\n' | sed 's/^/--trusted-host /' | tr '\n' ' ')
+TRUSTED_HOST_ARG=""
+for h in $TRUSTED_HOST; do TRUSTED_HOST_ARG="$TRUSTED_HOST_ARG --trusted-host $h"; done
 
 if [ ! -z "$INDEX_URL" ]
 then

--- a/backend/windmill-worker/nsjail/download_deps.py.sh
+++ b/backend/windmill-worker/nsjail/download_deps.py.sh
@@ -2,7 +2,7 @@
 
 INDEX_URL_ARG=$([ -z "$INDEX_URL" ] && echo ""|| echo "--index-url $INDEX_URL" )
 EXTRA_INDEX_URL_ARG=$([ -z "$EXTRA_INDEX_URL" ] && echo ""|| echo "--extra-index-url $EXTRA_INDEX_URL" )
-TRUSTED_HOST_ARG=$([ -z "$TRUSTED_HOST" ] &&  echo "" || echo "--trusted-host $TRUSTED_HOST")
+TRUSTED_HOST_ARG=$([ -z "$TRUSTED_HOST" ] &&  echo "" || echo "$TRUSTED_HOST" | tr ' ' '\n' | sed 's/^/--trusted-host /' | tr '\n' ' ')
 
 if [ ! -z "$INDEX_URL" ]
 then

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -361,7 +361,9 @@ pub async fn uv_pip_compile(
             args.extend(["--index-url", url]);
         }
         if let Some(host) = TRUSTED_HOST.as_ref() {
-            args.extend(["--trusted-host", host]);
+            host.split_whitespace().for_each(|h| {
+                args.extend(["--trusted-host", h]);
+            });
         }
         if let Some(cert_path) = INDEX_CERT.as_ref() {
             args.extend(["--cert", cert_path]);
@@ -2192,7 +2194,9 @@ async fn spawn_uv_install(
             command_args.extend(["--index-url", url]);
         }
         if let Some(host) = TRUSTED_HOST.as_ref() {
-            command_args.extend(["--trusted-host", &host]);
+            host.split_whitespace().for_each(|h| {
+                command_args.extend(["--trusted-host", h]);
+            });
         }
         if *NATIVE_CERT {
             command_args.extend(["--native-tls"]);


### PR DESCRIPTION
## Problem

When `PIP_TRUSTED_HOST` contains multiple space-separated hostnames (e.g. `host1.example.com host2.example.com`), the entire string was passed as a single `--trusted-host` argument:

```
--trusted-host "host1.example.com host2.example.com"
```

pip's documented `PIP_TRUSTED_HOST` convention expects one `--trusted-host` flag per host:

```
--trusted-host host1.example.com --trusted-host host2.example.com
```

## Fix

Split the value on whitespace and emit a separate `--trusted-host` flag per host, mirroring the existing `pip_extra_index_url` handling in the same file.

- `backend/windmill-worker/src/python_executor.rs` — both the `uv pip compile` (`args`) and `uv pip install` (`command_args`) paths now iterate over `host.split_whitespace()`.
- `backend/windmill-worker/nsjail/download_deps.py.sh` — the nsjail dep-download script builds one `--trusted-host` per whitespace-separated host.

## Validation

- Backend compiles cleanly under `cargo watch` (`health check completed`, no errors/warnings).
- Verified the shell pipeline output for empty, single, and multi-host inputs:
  - `""` → `` (empty)
  - `"host1.example.com"` → `--trusted-host host1.example.com`
  - `"host1.example.com host2.example.com"` → `--trusted-host host1.example.com --trusted-host host2.example.com`

Behavior for the single-host case is unchanged.

Fixes WIN-2077

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split PIP_TRUSTED_HOST by whitespace and emit one --trusted-host per host in the `uv pip compile`/`uv pip install` paths and the nsjail dep-download script, using shell word-splitting in nsjail to handle arbitrary whitespace and skip empty entries. This matches pip’s convention and fixes multi-host installs (WIN-2077) while leaving single-host behavior unchanged.

<sup>Written for commit 14f16680471a017af7485f2bb4c5b5d381c4712d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

