### PR TITLE
fix(backend): clean up unique_ext_jwt_token on workspace deletion

### DIFF
--- a/backend/.sqlx/query-9efca0a4f5ce030f90224951e6e0ea01a3ffac15dd96ed7d8cc237a0c4e06a9a.json
+++ b/backend/.sqlx/query-9efca0a4f5ce030f90224951e6e0ea01a3ffac15dd96ed7d8cc237a0c4e06a9a.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM unique_ext_jwt_token WHERE workspace_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9efca0a4f5ce030f90224951e6e0ea01a3ffac15dd96ed7d8cc237a0c4e06a9a"
+}

--- a/backend/windmill-api-workspaces/src/workspaces_extra.rs
+++ b/backend/windmill-api-workspaces/src/workspaces_extra.rs
@@ -847,6 +847,13 @@ pub(crate) async fn delete_workspace(
         .execute(&mut *tx)
         .await?;
 
+    sqlx::query!(
+        "DELETE FROM unique_ext_jwt_token WHERE workspace_id = $1",
+        &w_id
+    )
+    .execute(&mut *tx)
+    .await?;
+
     sqlx::query!("DELETE FROM http_trigger WHERE workspace_id = $1", &w_id)
         .execute(&mut *tx)
         .await?;


### PR DESCRIPTION
## Problem

When a workspace is deleted, rows in `unique_ext_jwt_token` that reference the deleted workspace's ID were not removed. The `workspace_id` column (added in migration `20260409145556`) has no FK constraint on the `workspace` table, and `delete_workspace` did not include a DELETE for this table. As a result, orphaned external JWT token records continued to appear in the superadmin **External JWTs** listing after a workspace was deleted.

## Fix

Add `DELETE FROM unique_ext_jwt_token WHERE workspace_id = $1` to `delete_workspace` in `backend/windmill-api-workspaces/src/workspaces_extra.rs`, alongside the other per-table cleanup statements (right after the `token` cleanup). This mirrors the existing pattern used for all other workspace-scoped tables in that function.

A new sqlx offline query cache entry was generated for the added query.

## Validation

- `cargo sqlx prepare --workspace -- --workspace --features all_sqlx_features` compiled the full workspace successfully (full `cargo check`) and validated the new query against the live DB schema.
- Confirmed the sqlx diff contains only the single new cache file for the added DELETE (no EE caches dropped; unrelated local enum drift excluded).

Fixes WIN-2078

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delete external JWT tokens when a workspace is removed to prevent orphaned records in the superadmin External JWTs view (Fixes WIN-2078). Added a cleanup DELETE in delete_workspace for unique_ext_jwt_token and updated the sqlx offline cache.

<sup>Written for commit f229a21e046257f988c890aa42ca0db634525bf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

