### PR TITLE
fix(home): preserve URL filter state on page refresh

### DIFF
--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -329,8 +329,17 @@
 	let allLabels = $derived(
 		Array.from(new Set(combinedItems?.flatMap((x) => itemLabels(x)) ?? [])).sort()
 	)
+	let firstFilterReset = true
+	// Skip the first workspace resolution so that URL-loaded filter values
+	// (set by ListFilters.loadFilterFromUrl on mount) survive the async store
+	// settling. On actual workspace switches firstFilterReset is already false
+	// and the reset runs normally.
 	$effect(() => {
 		if ($workspaceStore) {
+			if (firstFilterReset) {
+				firstFilterReset = false
+				return
+			}
 			ownerFilter = undefined
 			labelFilter = undefined
 		}

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -329,20 +329,17 @@
 	let allLabels = $derived(
 		Array.from(new Set(combinedItems?.flatMap((x) => itemLabels(x)) ?? [])).sort()
 	)
-	let firstFilterReset = true
-	// Skip the first workspace resolution so that URL-loaded filter values
-	// (set by ListFilters.loadFilterFromUrl on mount) survive the async store
-	// settling. On actual workspace switches firstFilterReset is already false
-	// and the reset runs normally.
+	let prevWorkspace: string | undefined = undefined
+	// Clear filters only when the workspace actually changes. The initial
+	// resolution must be left alone so URL-loaded filter values (set by
+	// ListFilters.loadFilterFromUrl on mount) survive the async store settling.
 	$effect(() => {
-		if ($workspaceStore) {
-			if (firstFilterReset) {
-				firstFilterReset = false
-				return
-			}
+		const ws = $workspaceStore
+		if (ws && prevWorkspace !== undefined && ws !== prevWorkspace) {
 			ownerFilter = undefined
 			labelFilter = undefined
 		}
+		prevWorkspace = ws
 	})
 	let preFilteredItems = $derived(
 		ownerFilter != undefined


### PR DESCRIPTION
## Problem

When the Home page is refreshed with an active owner filter (e.g. `?filter=u/alice`), the filter appeared to reset. The URL kept the `?filter=` param but the filter badge showed nothing selected.

## Root cause

`ListFilters.svelte` calls `loadFilterFromUrl()` synchronously at script init, which sets `ownerFilter` via the two-way binding. But `$workspaceStore` resolves **asynchronously** after mount. When it resolved, the following `$effect` in `ItemsList.svelte` fired and reset the filter:

```js
$effect(() => {
  if ($workspaceStore) {
    ownerFilter = undefined   // wiped the URL-loaded value
    labelFilter = undefined
  }
})
```

## Fix

Added a `firstFilterReset` guard — the same pattern already used in this file for `firstWorkspaceRun` (~line 370). The first `$workspaceStore` resolution is skipped so URL-loaded filters survive. Subsequent workspace switches still correctly clear the filter.

## Repro

1. Apply an owner filter on the Home page
2. Reload the page — filter is gone even though `?filter=u/alice` stays in the URL

## Testing

Manually verified: after the fix, the filter badge is restored on page reload and still clears correctly when switching workspaces.

Fixes #9624

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves URL-loaded filters on the Home page after refresh so the badge and results match `?filter=`. Filters now clear only when the workspace actually changes; refresh no longer wipes them.

- **Bug Fixes**
  - In `ItemsList.svelte`, track `prevWorkspace` and reset `ownerFilter`/`labelFilter` only when `$workspaceStore` changes, replacing the first-run guard so `ListFilters.loadFilterFromUrl()` values persist on initial mount.

<sup>Written for commit c3277adcac267c0c6ecb1ebbf3e4b57e45eb926f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

