### PR TITLE
fix(backend): validate ansible vault_id entries before config generation

### DIFF
--- a/backend/parsers/windmill-parser-yaml/src/lib.rs
+++ b/backend/parsers/windmill-parser-yaml/src/lib.rs
@@ -50,7 +50,7 @@ pub fn parse_ansible_sig(inner_content: &str) -> anyhow::Result<MainArgSignature
                                         has_default: default.is_some(),
                                         default,
                                         oidx: None,
-                                    otyp_inferred: false,
+                                        otyp_inferred: false,
                                     })
                                 }
                             }
@@ -69,7 +69,7 @@ pub fn parse_ansible_sig(inner_content: &str) -> anyhow::Result<MainArgSignature
                             has_default: inv.default.is_some(),
                             default: inv.default.map(|v| json!(format!("$res:{}", v))),
                             oidx: None,
-                        otyp_inferred: false,
+                            otyp_inferred: false,
                         });
                     }
                 }
@@ -83,7 +83,7 @@ pub fn parse_ansible_sig(inner_content: &str) -> anyhow::Result<MainArgSignature
                                 has_default: false,
                                 default: None,
                                 oidx: None,
-                            otyp_inferred: false,
+                                otyp_inferred: false,
                             });
                         }
                     }
@@ -435,6 +435,25 @@ pub fn parse_delegate_to_git_repo(inner_content: &str) -> anyhow::Result<Delegat
     Ok(DelegateWithSSHAuth { delegate_to_git_repo_details: None, git_ssh_identity })
 }
 
+/// Each `vault_id` entry is interpolated verbatim into the generated `ansible.cfg`
+/// (`vault_identity_list = <a>,<b>,...`). A newline or other config-meaningful
+/// character would let a script inject arbitrary `[defaults]` directives (e.g.
+/// `library`, `action_plugins`) and execute attacker-controlled code on the worker,
+/// and a `,` would smuggle in an extra entry. Restrict entries to the `label@source`
+/// charset so neither is possible.
+pub fn validate_vault_id(value: &str) -> anyhow::Result<()> {
+    let is_valid = !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '/' | '@'));
+    if !is_valid {
+        return Err(anyhow!(
+            "Invalid vault_id `{value}`: expected `label@filename` using only letters, digits and the characters `.`, `_`, `-`, `/`, `@`"
+        ));
+    }
+    Ok(())
+}
+
 pub fn parse_ansible_reqs(
     inner_content: &str,
 ) -> anyhow::Result<(String, Option<AnsibleRequirements>, String)> {
@@ -528,6 +547,7 @@ pub fn parse_ansible_reqs(
                         let Yaml::String(filename) = f else {
                             return Err(anyhow!("The elements of the vault_id field should be strings in the format: `label@filename`"));
                         };
+                        validate_vault_id(filename)?;
                         ret.vault_id.push(filename.to_string());
                     }
                 }
@@ -1050,5 +1070,56 @@ delegate_to_git_repo:
             d.inventories_location.as_deref(),
             Some("inventories/{{ env }}")
         );
+    }
+
+    #[test]
+    fn test_parse_vault_id_valid() {
+        let p = r#"
+---
+vault_id:
+  - dev@vault_pass_dev.txt
+  - prod@./secrets/prod-pass
+---
+- name: Test
+  hosts: all
+"#;
+        let (_, reqs, _) = parse_ansible_reqs(p).unwrap();
+        assert_eq!(
+            reqs.unwrap().vault_id,
+            vec![
+                "dev@vault_pass_dev.txt".to_string(),
+                "prod@./secrets/prod-pass".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_vault_id_rejects_newline_injection() {
+        let p = "---\nvault_id:\n  - \"default@/tmp/wm/x\\nlibrary = /tmp/wm/evil_modules\"\n---\n- name: Test\n  hosts: all\n";
+        assert!(parse_ansible_reqs(p).is_err());
+    }
+
+    #[test]
+    fn test_parse_vault_id_rejects_comma() {
+        let p = r#"
+---
+vault_id:
+  - "a@b,c@d"
+---
+- name: Test
+  hosts: all
+"#;
+        assert!(parse_ansible_reqs(p).is_err());
+    }
+
+    #[test]
+    fn test_validate_vault_id() {
+        assert!(validate_vault_id("default@/tmp/wm/pass").is_ok());
+        assert!(validate_vault_id("dev@pass.txt").is_ok());
+        assert!(validate_vault_id("").is_err());
+        assert!(validate_vault_id("a@b\nlibrary = /evil").is_err());
+        assert!(validate_vault_id("a@b,c@d").is_err());
+        assert!(validate_vault_id("a@b c").is_err());
+        assert!(validate_vault_id("a@b=c").is_err());
     }
 }

--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -1805,4 +1805,31 @@ mod tests {
         assert!(validate_relative_path("", "playbook").is_err());
         assert!(validate_relative_path("   ", "playbook").is_err());
     }
+
+    #[test]
+    fn test_create_ansible_cfg_writes_valid_vault_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let job_dir = dir.path().to_str().unwrap();
+        let reqs = AnsibleRequirements {
+            vault_id: vec!["dev@vault_pass.txt".to_string()],
+            ..Default::default()
+        };
+        create_ansible_cfg(Some(&reqs), job_dir, false).unwrap();
+        let cfg = std::fs::read_to_string(dir.path().join("ansible.cfg")).unwrap();
+        assert!(cfg.contains("vault_identity_list = dev@vault_pass.txt"));
+        assert!(!cfg.contains("library"));
+    }
+
+    #[test]
+    fn test_create_ansible_cfg_rejects_vault_id_injection() {
+        let dir = tempfile::tempdir().unwrap();
+        let job_dir = dir.path().to_str().unwrap();
+        let reqs = AnsibleRequirements {
+            vault_id: vec!["default@/tmp/wm/x\nlibrary = /tmp/wm/evil_modules".to_string()],
+            ..Default::default()
+        };
+        // Defense-in-depth boundary: a poisoned entry must error before any config is written.
+        assert!(create_ansible_cfg(Some(&reqs), job_dir, false).is_err());
+        assert!(!dir.path().join("ansible.cfg").exists());
+    }
 }

--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -22,7 +22,8 @@ use windmill_common::{
 use windmill_queue::MiniPulledJob;
 
 use windmill_parser_yaml::{
-    AnsibleRequirements, GitRepo, PreexistingAnsibleInventory, ResourceOrVariablePath,
+    validate_vault_id, AnsibleRequirements, GitRepo, PreexistingAnsibleInventory,
+    ResourceOrVariablePath,
 };
 use windmill_queue::{append_logs, CanceledBy};
 
@@ -910,6 +911,11 @@ pub fn create_ansible_cfg(
     }
     if let Some(vault_ids) = reqs.as_ref().map(|r| &r.vault_id) {
         if !vault_ids.is_empty() {
+            // Defense in depth: entries are validated at parse time, but re-check here
+            // since they are interpolated raw into ansible.cfg (config-directive injection).
+            for vault_id in vault_ids {
+                validate_vault_id(vault_id)?;
+            }
             let password_files = vault_ids.join(",");
 
             passwords_cfg.push_str(&format!("vault_identity_list = {password_files}\n"));


### PR DESCRIPTION
## Summary

Validates Ansible `vault_id` entries so they conform to the expected `label@filename` format before they are written into the generated `ansible.cfg`. Previously entries were passed through verbatim into `vault_identity_list`, so a malformed entry could affect the rest of the generated config file. This tightens input handling for that field.

## Changes

- Add `validate_vault_id` in `windmill-parser-yaml`, enforcing a strict `label@source` charset (`[A-Za-z0-9._-/@]`, non-empty). Malformed entries are rejected at parse time with a clear, actionable error.
- Re-validate each entry at the config-generation boundary in `create_ansible_cfg` (`windmill-worker`) as defense in depth.
- Add unit tests: valid entries, malformed entries rejected through the parser, and the validator directly.

## Test plan

- [x] `cargo test -p windmill-parser-yaml` passes (8/8)
- [x] `windmill-parser-yaml` + `windmill-worker` compile cleanly
- [ ] Deploy an Ansible script with a valid `vault_id` (e.g. `dev@vault_pass_dev.txt`) and confirm the job runs and the generated `ansible.cfg` has the expected `vault_identity_list` line
- [ ] Deploy one with a malformed `vault_id` and confirm it is rejected with the validation error rather than producing the config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate Ansible `vault_id` entries to the safe `label@filename` format before writing to `ansible.cfg`, blocking config-directive injection and potential worker RCE. Addresses Linear WIN-2064 by tightening validation and adding defense in depth.

- **Bug Fixes**
  - Added `validate_vault_id` in `windmill-parser-yaml` enforcing `[A-Za-z0-9._-/@]` and non-empty; rejects malformed entries with a clear error.
  - Re-validate in `create_ansible_cfg` in `windmill-worker` before interpolating into `vault_identity_list`; errors before any config is written.
  - Tests cover valid entries and boundary cases: newline/comma injection rejected, `ansible.cfg` not created on error, and no stray directives appear.

<sup>Written for commit 679b614ddcfbe6a7b4cfcbe245fa389de40d3411. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

