### PR TITLE
fix: require super admin for object storage config test endpoint

### DIFF
--- a/backend/windmill-api-settings/src/lib.rs
+++ b/backend/windmill-api-settings/src/lib.rs
@@ -249,12 +249,14 @@ use windmill_object_store::build_object_store_from_settings;
 
 #[cfg(feature = "parquet")]
 pub async fn test_s3_bucket(
-    _authed: ApiAuthed,
+    authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Json(test_s3_bucket): Json<ObjectSettings>,
 ) -> error::Result<String> {
     use bytes::Bytes;
     use futures::StreamExt;
+
+    require_super_admin(&db, &authed.email).await?;
 
     let client = build_object_store_from_settings(test_s3_bucket, Some(&db))
         .await?


### PR DESCRIPTION
## Summary

Gate the object storage config test endpoint (`POST /api/settings/test_object_storage_config`) on super admin, matching the other instance-settings test handlers in the same module.

This handler was the only one in `windmill-api-settings` that didn't gate on `require_super_admin` — its `_authed` argument was unused. Its siblings (`test_smtp`, `object_storage_usage`, `compute_object_storage_usage`, ...) all require super admin as their first step. This brings it in line with that convention so only super admins can drive the instance object-storage connectivity test.

## Changes

- `test_s3_bucket`: rename the unused `_authed` to `authed` and add `require_super_admin(&db, &authed.email).await?` before building the object-store client (`backend/windmill-api-settings/src/lib.rs`).

## Test plan

- [ ] In Superadmin Settings → instance object storage, "Test connection" as a super admin still succeeds (list/put/get/delete against the bucket as before).
- [ ] The same request from a non-super-admin authenticated user now returns the super-admin authorization error instead of running the test.

## Notes

- Behind `#[cfg(feature = "parquet")]` (object-store builds); verified with `cargo check -p windmill-api-settings --features parquet`.
- No SQL or API-shape changes; no frontend changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces super admin access on the object storage config test endpoint (`POST /api/settings/test_object_storage_config`) to match other instance settings tests and reduce SSRF risk. Non‑super‑admins can no longer trigger the S3 connectivity test (addresses WIN‑2059).

- **Bug Fixes**
  - Add `require_super_admin(&db, &authed.email)` in `test_s3_bucket` and rename `_authed` to `authed` in `backend/windmill-api-settings/src/lib.rs`.
  - No API, SQL, or frontend changes; gated behind `parquet`.

<sup>Written for commit 49881cb62f947c5ededd9c95015a3acfd3730569. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

