### PR TITLE
fix(frontend): group live pipeline runs in the activity panel

### DIFF
--- a/frontend/src/lib/components/assets/AssetGraph/pipelineHistory.svelte.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/pipelineHistory.svelte.ts
@@ -43,6 +43,10 @@ export function usePipelineHistory(
 	// Generation counter: a folder/days change mid-flight must not write a
 	// stale response into the new scope (mirrors the page's bodyFetchGen).
 	let gen = 0
+	// Edges-only refetches fire one-per-new-id during a cascade; `gen` only
+	// guards scope changes, so this sequences same-scope calls — a slower
+	// earlier response must not overwrite a newer one.
+	let edgeSeq = 0
 
 	async function load(ws: string, prefix: string, days: number) {
 		const myGen = ++gen
@@ -105,17 +109,16 @@ export function usePipelineHistory(
 		}
 	}
 
-	// Edges-only refetch (one cheap query, no completed-jobs paging). The
-	// `dispatch_event` rows that group a cascade are written server-side only
-	// once the producer COMPLETES, so a run launched live (manual or scheduled)
-	// has no edges in this one-shot preload — its producer and just-dispatched
-	// children would show as separate rows. The page calls this when the live
-	// poll surfaces new jobs so fresh cascades group with their producer.
+	// Edges-only refetch (one cheap query, no completed-jobs paging): the
+	// `dispatch_event` rows that group a cascade are written server-side when a
+	// producer completes, so a run launched live has none in the one-shot
+	// preload. The page calls this when the live poll surfaces new jobs.
 	async function loadEdges(ws: string, prefix: string, days: number) {
 		// Skip while a full load owns `edges`; that load sets fresher edges and
 		// a concurrent write here could clobber it with a slightly older window.
 		if (loading) return
 		const myGen = gen
+		const mySeq = ++edgeSeq
 		const cutoff = new Date(Date.now() - days * 24 * 3600 * 1000).toISOString()
 		try {
 			const edgeRows = (await JobService.listAssetDispatchEdges({
@@ -123,7 +126,8 @@ export function usePipelineHistory(
 				pathStart: prefix,
 				createdAfter: cutoff
 			})) as DispatchEdge[]
-			if (gen !== myGen) return
+			// Drop a stale-scope write, or one a newer refetch already superseded.
+			if (gen !== myGen || mySeq !== edgeSeq) return
 			edges = edgeRows
 		} catch (e) {
 			console.warn('failed to refetch pipeline dispatch edges', e)

--- a/frontend/src/lib/components/assets/AssetGraph/pipelineHistory.svelte.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/pipelineHistory.svelte.ts
@@ -105,6 +105,31 @@ export function usePipelineHistory(
 		}
 	}
 
+	// Edges-only refetch (one cheap query, no completed-jobs paging). The
+	// `dispatch_event` rows that group a cascade are written server-side only
+	// once the producer COMPLETES, so a run launched live (manual or scheduled)
+	// has no edges in this one-shot preload — its producer and just-dispatched
+	// children would show as separate rows. The page calls this when the live
+	// poll surfaces new jobs so fresh cascades group with their producer.
+	async function loadEdges(ws: string, prefix: string, days: number) {
+		// Skip while a full load owns `edges`; that load sets fresher edges and
+		// a concurrent write here could clobber it with a slightly older window.
+		if (loading) return
+		const myGen = gen
+		const cutoff = new Date(Date.now() - days * 24 * 3600 * 1000).toISOString()
+		try {
+			const edgeRows = (await JobService.listAssetDispatchEdges({
+				workspace: ws,
+				pathStart: prefix,
+				createdAfter: cutoff
+			})) as DispatchEdge[]
+			if (gen !== myGen) return
+			edges = edgeRows
+		} catch (e) {
+			console.warn('failed to refetch pipeline dispatch edges', e)
+		}
+	}
+
 	$effect(() => {
 		const ws = getWorkspace()
 		const prefix = getPathPrefix()
@@ -142,6 +167,13 @@ export function usePipelineHistory(
 			const prefix = getPathPrefix()
 			if (!ws || !prefix || !getEnabled()) return
 			void load(ws, prefix, getDays())
+		},
+		/** Re-pull just the dispatch edges (see `loadEdges`). */
+		refetchEdges() {
+			const ws = getWorkspace()
+			const prefix = getPathPrefix()
+			if (!ws || !prefix || !getEnabled()) return
+			void loadEdges(ws, prefix, getDays())
 		}
 	}
 }

--- a/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
@@ -1589,6 +1589,23 @@
 		for (const e of activeRunnables.events) byId.set(e.id, e)
 		return Array.from(byId.values()).sort((a, b) => b.at.localeCompare(a.at))
 	})
+	// The activity panel groups a cascade by its dispatch edges, but those
+	// edges are written server-side only when a producer completes — so a run
+	// launched live (the user just hit Run) has no edge in the one-shot history
+	// preload, and its producer + freshly-dispatched children would show as
+	// separate ungrouped rows. The live poll's id set changes the instant a new
+	// job appears (a dispatched child is a new id), which is exactly when fresh
+	// edges exist; re-pull them then so live cascades group like historic ones.
+	let lastLiveEventSig = ''
+	$effect(() => {
+		const sig = activeRunnables.events
+			.map((e) => e.id)
+			.sort()
+			.join(',')
+		if (sig === lastLiveEventSig) return
+		lastLiveEventSig = sig
+		pipelineHistory.refetchEdges()
+	})
 	// Node run-count/status badges, derived from the SAME merged event set the
 	// Activity panel shows (historic preload + live poll) so the graph badges
 	// and the panel never disagree. `activityEvents` is newest-first, so the

--- a/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
@@ -1589,13 +1589,11 @@
 		for (const e of activeRunnables.events) byId.set(e.id, e)
 		return Array.from(byId.values()).sort((a, b) => b.at.localeCompare(a.at))
 	})
-	// The activity panel groups a cascade by its dispatch edges, but those
-	// edges are written server-side only when a producer completes — so a run
-	// launched live (the user just hit Run) has no edge in the one-shot history
-	// preload, and its producer + freshly-dispatched children would show as
-	// separate ungrouped rows. The live poll's id set changes the instant a new
-	// job appears (a dispatched child is a new id), which is exactly when fresh
-	// edges exist; re-pull them then so live cascades group like historic ones.
+	// Keep dispatch edges live so freshly-launched runs group (see `loadEdges`).
+	// The poll's id set changes the instant a new job appears (a dispatched
+	// child is a new id) — exactly when fresh edges exist — so re-pull then.
+	// Keyed on ids, not status, so queued→done ticks don't refetch;
+	// `lastLiveEventSig` is a plain `let` so writing it can't retrigger this.
 	let lastLiveEventSig = ''
 	$effect(() => {
 		const sig = activeRunnables.events


### PR DESCRIPTION
## Summary

In the data-pipeline activity panel, runs launched **manually through the UI** (and their downstream cascade) showed up as separate ungrouped rows, while scheduled/historic cascades grouped correctly.

The panel groups runs into cascades by connected components of the **dispatch-edge graph**. Run *events* are kept live by the `activeRunnables` poll, but the `edges` came only from `usePipelineHistory`'s **one-shot preload** (refetched solely on workspace/folder/days change). Since `dispatch_event` rows are written server-side *when a producer completes*, a run you launch and watch live has its producer + freshly-dispatched children appear as live events with **no edge connecting them** → union-find puts each in its own component → flat ungrouped rows.

The fix keeps the dispatch edges live: an edges-only refetch is triggered whenever the live poll's event id-set changes (a newly-dispatched child is a new id, which is exactly when fresh edges exist), so live cascades converge to grouped just like historic ones.

## Changes

- `pipelineHistory.svelte.ts`: add a lightweight edges-only `refetchEdges()` (single query, no completed-jobs paging; skips while a full `load()` is in flight; guarded by the same generation counter so stale-scope writes are dropped).
- `pipeline/[folder]/+page.svelte`: add an `$effect` that re-pulls edges when the live poll's event id-set changes, so a just-launched producer and its dispatched children collapse into one grouped cascade row.

## Screenshots

Live verification on the local `data-pipelines/orders` pipeline — triggered manual (`run`) producer runs and confirmed each appears as a grouped cascade (`run · 7 runs`, `run · 12 runs`) with expanded members, matching the older `schedule · 19 runs` group below. Before this fix these rendered as flat standalone rows.

![pipeline-activity-grouped-live](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/pipeline-activity-live-edge-grouping/1781879224-pipeline-activity-grouped-live.png)

## Test plan

- [ ] Open a pipeline folder in view mode, hit Run on a producer that cascades into children, and confirm the producer + freshly-dispatched children collapse into a single grouped cascade row in the Activity panel once the live poll surfaces them (rather than separate rows).
- [ ] Confirm the manual (`run`) cascade groups identically to a scheduled cascade.
- [ ] Switch the activity window (e.g. 1h → 30d) and change folders while a run is live; confirm edges stay scoped to the selected folder/window and don't show stale grouping.
- [ ] `npm run check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ungrouped live cascades in the Activity panel by live-refetching dispatch edges when new run events appear. Manual runs now group like scheduled runs.

- **Bug Fixes**
  - Added edges-only dispatch-edge refetch in pipeline history with same-scope sequencing (`edgeSeq`); exposed `refetchEdges()`.
  - Trigger refetch when the live poll’s event id set changes, with guards to avoid clobbering full loads and to respect workspace/folder/window scope.

<sup>Written for commit ab0705dfd7abe76faf0423cc274bfc34f0e59e77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

