### PR TITLE
feat(jobs): auto-grant approvers a run-detail view link on the approval page

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -13598,6 +13598,12 @@ paths:
                           type: integer
                         approver:
                           type: string
+                  view_token:
+                    type: string
+                    description: >-
+                      Share-read-link token for the flow. An authenticated workspace
+                      member can append it as a `view_token` query param on the run
+                      page to read a flow they don't otherwise have access to.
 
   /w/{workspace}/jobs_u/resume/{id}/{resume_id}/{signature}:
     get:
@@ -13849,6 +13855,13 @@ paths:
                       required:
                         - resume_id
                         - approver
+                  view_token:
+                    type: string
+                    description: >-
+                      Share-read-link token for the parent flow. An authenticated
+                      workspace member can append it as a `view_token` query param
+                      on the run page to read a flow they don't otherwise have
+                      access to.
                 required:
                   - job
                   - approvers

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -3204,6 +3204,12 @@ struct ApprovalInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     hide_cancel: Option<bool>,
     approvers: Vec<Approval>,
+    /// Share-read-link token for the flow, minted only for callers allowed to view this
+    /// approval. Lets an authenticated workspace-member approver open the run details of
+    /// a flow they don't otherwise have read access to (the run page reads it as a
+    /// `view_token` query param).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    view_token: Option<String>,
 }
 
 /// Whether `opt_authed` is allowed to approve — and therefore view — this approval step.
@@ -3426,6 +3432,7 @@ async fn get_approval_info(
             user_auth_required,
             hide_cancel: None,
             approvers: vec![],
+            view_token: None,
         }));
     }
 
@@ -3443,6 +3450,12 @@ async fn get_approval_info(
     })
     .collect();
 
+    // Possession of view rights over this approval is sufficient to mint a
+    // share-read-link token for the flow: it only grants read (no resume), and only to
+    // an authenticated workspace member, so it never widens what the approver can do.
+    let hmac = generate_view_token(&w_id, row.id, &db).await?;
+    let view_token = Some(format!("{}.{hmac}", row.id));
+
     Ok(Json(ApprovalInfo {
         flow_id: row.id,
         form_schema,
@@ -3454,6 +3467,7 @@ async fn get_approval_info(
         user_auth_required,
         hide_cancel,
         approvers,
+        view_token,
     }))
 }
 
@@ -3848,6 +3862,12 @@ pub async fn cancel_suspended_job(
 pub struct SuspendedJobFlow {
     pub job: Job,
     pub approvers: Vec<Approval>,
+    /// Share-read-link token for the parent flow, minted because the caller proved
+    /// possession of the approval secret. Lets an authenticated workspace-member
+    /// approver open the run details of a flow they don't otherwise have read access
+    /// to (the run page reads it as a `view_token` query param).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub view_token: Option<String>,
 }
 
 pub async fn get_suspended_job_flow(
@@ -3932,7 +3952,13 @@ pub async fn get_suspended_job_flow(
     )
     .await?;
 
-    Ok(Json(SuspendedJobFlow { job: flow, approvers }).into_response())
+    // Possession of a valid approval secret is sufficient to mint a share-read-link
+    // token for the parent flow: it only grants read (no resume), and only to an
+    // authenticated workspace member, so it never widens what the approver can do.
+    let hmac = generate_view_token(&w_id, flow_id, &db).await?;
+    let view_token = Some(format!("{flow_id}.{hmac}"));
+
+    Ok(Json(SuspendedJobFlow { job: flow, approvers, view_token }).into_response())
 }
 
 fn conditionally_require_authed_user(

--- a/frontend/src/routes/approve/[workspace]/[job]/+page.svelte
+++ b/frontend/src/routes/approve/[workspace]/[job]/+page.svelte
@@ -151,9 +151,12 @@
 	// Hide the empty detail scaffolding and show only the sign-in / not-authorized state.
 	let isLocked = $derived(!!approvalInfo?.user_auth_required && !approvalInfo?.can_approve)
 	// Carry the share-read-link token so a workspace-member approver can open the run
-	// details of a flow they don't otherwise have read access to.
+	// details of a flow they don't otherwise have read access to. Build from the route
+	// params (not `job`): `getJob` is fire-and-forget and gets denied for exactly the
+	// approver this link serves, leaving `job` undefined — and `page.params.job` is the
+	// flow id the token is minted for anyway.
 	let runDetailsHref = $derived.by(() => {
-		let url = `${base}/run/${job?.id}?workspace=${job?.workspace_id}`
+		let url = `${base}/run/${page.params.job}?workspace=${page.params.workspace}`
 		if (approvalInfo?.view_token) {
 			url += `&view_token=${encodeURIComponent(approvalInfo.view_token)}`
 		}

--- a/frontend/src/routes/approve/[workspace]/[job]/+page.svelte
+++ b/frontend/src/routes/approve/[workspace]/[job]/+page.svelte
@@ -34,6 +34,9 @@
 	let loading = $state(false)
 	let valid = $state(true)
 	let actionTaken: 'approved' | 'denied' | undefined = $state(undefined)
+	// Whether the current visitor is a logged-in member of this workspace — if so we can
+	// surface a clear, ready-to-use run-details link (the view token grants them access).
+	let isWorkspaceMember = $state(false)
 
 	let pollInterval: number | undefined = undefined
 	let scheduleEditor: ScheduleEditor | undefined = $state(undefined)
@@ -57,6 +60,7 @@
 		}
 		loadData()
 		pollInterval = setInterval(loadData, 2000)
+		getUserExt(page.params.workspace ?? '').then((u) => (isWorkspaceMember = !!u))
 	})
 
 	onDestroy(() => {
@@ -355,9 +359,21 @@
 
 		{#if !isLocked}
 			<div class="mt-4 flex flex-row flex-wrap justify-between">
-				<a class="text-accent text-xs" target="_blank" rel="noreferrer" href={runDetailsHref}>
-					Open run details (require auth) <ExternalLink size={12} class="inline" />
-				</a>
+				{#if isWorkspaceMember}
+					<Button
+						size="xs"
+						variant="accent-secondary"
+						href={runDetailsHref}
+						target="_blank"
+						endIcon={{ icon: ExternalLink }}
+					>
+						Open run details
+					</Button>
+				{:else}
+					<a class="text-accent text-xs" target="_blank" rel="noreferrer" href={runDetailsHref}>
+						Open run details (require auth) <ExternalLink size={12} class="inline" />
+					</a>
+				{/if}
 			</div>
 		{/if}
 

--- a/frontend/src/routes/approve/[workspace]/[job]/+page.svelte
+++ b/frontend/src/routes/approve/[workspace]/[job]/+page.svelte
@@ -146,6 +146,15 @@
 	// strips the approval details (form, description, args, approvers) and getJob is denied.
 	// Hide the empty detail scaffolding and show only the sign-in / not-authorized state.
 	let isLocked = $derived(!!approvalInfo?.user_auth_required && !approvalInfo?.can_approve)
+	// Carry the share-read-link token so a workspace-member approver can open the run
+	// details of a flow they don't otherwise have read access to.
+	let runDetailsHref = $derived.by(() => {
+		let url = `${base}/run/${job?.id}?workspace=${job?.workspace_id}`
+		if (approvalInfo?.view_token) {
+			url += `&view_token=${encodeURIComponent(approvalInfo.view_token)}`
+		}
+		return url
+	})
 	let isWac = $derived(!!(job as any)?.workflow_as_code_status)
 	let filteredArgs = $derived.by(() => {
 		if (!job?.args) return job?.args
@@ -346,12 +355,7 @@
 
 		{#if !isLocked}
 			<div class="mt-4 flex flex-row flex-wrap justify-between">
-				<a
-					class="text-accent text-xs"
-					target="_blank"
-					rel="noreferrer"
-					href="{base}/run/{job?.id}?workspace={job?.workspace_id}"
-				>
+				<a class="text-accent text-xs" target="_blank" rel="noreferrer" href={runDetailsHref}>
 					Open run details (require auth) <ExternalLink size={12} class="inline" />
 				</a>
 			</div>

--- a/frontend/src/routes/approve/[workspace]/[job]/[resume]/[hmac]/+page.svelte
+++ b/frontend/src/routes/approve/[workspace]/[job]/[resume]/[hmac]/+page.svelte
@@ -26,6 +26,7 @@
 
 	let job: Job | undefined = $state(undefined)
 	let currentApprovers: { resume_id: number; approver: string }[] = $state([])
+	let viewToken: string | undefined = $state(undefined)
 	let approver = page.url.searchParams.get('approver') ?? undefined
 
 	let completed: boolean = $state(false)
@@ -101,6 +102,7 @@
 		})
 		job = suspendedJobFlow.job as Job
 		currentApprovers = suspendedJobFlow.approvers
+		viewToken = suspendedJobFlow.view_token
 	}
 
 	async function resume() {
@@ -143,6 +145,15 @@
 			.includes(new Number(page.params.resume ?? '').valueOf())
 	)
 	let approvalStep = $derived.by(() => (job?.flow_status?.step ?? 1) - 1)
+	// Carry the share-read-link token so a workspace-member approver can open the run
+	// details of a flow they don't otherwise have read access to.
+	let runDetailsHref = $derived.by(() => {
+		let url = `${base}/run/${job?.id}?workspace=${job?.workspace_id}`
+		if (viewToken) {
+			url += `&view_token=${encodeURIComponent(viewToken)}`
+		}
+		return url
+	})
 	let schema = $derived.by(
 		() => job?.raw_flow?.modules?.[approvalStep]?.suspend?.resume_form?.schema ?? dynamicSchema
 	)
@@ -290,11 +301,7 @@
 		</div>
 
 		<div class="mt-4 flex flex-row flex-wrap justify-between">
-			<a
-				class="text-accent text-xs"
-				target="_blank"
-				rel="noreferrer"
-				href="{base}/run/{job?.id}?workspace={job?.workspace_id}"
+			<a class="text-accent text-xs" target="_blank" rel="noreferrer" href={runDetailsHref}
 				>Open run details (require auth) <ExternalLink size={12} class="inline" /></a
 			>
 		</div>

--- a/frontend/src/routes/approve/[workspace]/[job]/[resume]/[hmac]/+page.svelte
+++ b/frontend/src/routes/approve/[workspace]/[job]/[resume]/[hmac]/+page.svelte
@@ -27,6 +27,9 @@
 	let job: Job | undefined = $state(undefined)
 	let currentApprovers: { resume_id: number; approver: string }[] = $state([])
 	let viewToken: string | undefined = $state(undefined)
+	// Whether the current visitor is a logged-in member of this workspace — if so we can
+	// surface a clear, ready-to-use run-details link (the view token grants them access).
+	let isWorkspaceMember = $state(false)
 	let approver = page.url.searchParams.get('approver') ?? undefined
 
 	let completed: boolean = $state(false)
@@ -61,6 +64,7 @@
 		}
 		getJob()
 		timeout = setInterval(getJob, 1000)
+		getUserExt(page.params.workspace ?? '').then((u) => (isWorkspaceMember = !!u))
 	})
 
 	onDestroy(() => {
@@ -301,9 +305,21 @@
 		</div>
 
 		<div class="mt-4 flex flex-row flex-wrap justify-between">
-			<a class="text-accent text-xs" target="_blank" rel="noreferrer" href={runDetailsHref}
-				>Open run details (require auth) <ExternalLink size={12} class="inline" /></a
-			>
+			{#if isWorkspaceMember}
+				<Button
+					size="xs"
+					variant="accent-secondary"
+					href={runDetailsHref}
+					target="_blank"
+					endIcon={{ icon: ExternalLink }}
+				>
+					Open run details
+				</Button>
+			{:else}
+				<a class="text-accent text-xs" target="_blank" rel="noreferrer" href={runDetailsHref}
+					>Open run details (require auth) <ExternalLink size={12} class="inline" /></a
+				>
+			{/if}
 		</div>
 		{#if job && job.raw_flow && !completed}
 			<h2 class="mt-10 text-sm font-semibold text-emphasis mb-2">Flow details</h2>


### PR DESCRIPTION
## Summary

The runs page was recently made confidential: a member who didn't launch a run can no longer see it unless someone shares a read-only `view_token` link (PR #357b0efcc8 / the "Share" button on the run page). This left a gap on the **approval page** — the "Open run details" link pointed at `/run/{flow_id}` with no token, so a workspace-member approver who didn't launch the flow would hit the 403 "ask for a share link" wall, even though they're already trusted enough to approve/deny it.

This change mints a `view_token` for the parent flow on both approval endpoints and threads it into the "Open run details" link, so an authenticated workspace-member approver can open the run detail of the flow they're approving.

The token only **grants read** (never resume), and is only **consumable by an authenticated workspace member** (`validate_view_token` is reached exclusively via `require_job_read_access`, which requires `ApiAuthed`). So it never widens what the approver can already do, and an anonymous holder of the approval link cannot use it.

## Changes

- **Backend** (`backend/windmill-api/src/jobs.rs`):
  - `get_suspended_job_flow` (legacy `/jobs_u/get_flow/{job}/{resume}/{secret}`): after `verify_suspended_secret` passes, mint `view_token = {flow_id}.{hmac}` and return it in `SuspendedJobFlow`.
  - `get_approval_info` (new `/jobs_u/flow/approval_info/{job_id}`): mint `view_token = {flow_id}.{hmac}` in `ApprovalInfo`, but only on the authorized (`can_view`) path — the locked (`user_auth_required && !can_approve`) early-return returns `view_token: None`.
- **OpenAPI** (`openapi.yaml`): document the new optional `view_token` field on both responses.
- **Frontend** (both approval pages): append `&view_token=…` (URL-encoded) to the "Open run details" link when the token is present.

## Screenshots

A workspace member with **approval rights but no read ACL** on the flow opens the run detail via the approval-page link (would otherwise be a 403):

![run-with-viewtoken](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/approval-share-url/1781881009-run-with-viewtoken.png)

## Test plan

Verified end-to-end against a suspended flow, as a non-admin member who did not launch the flow:

- [x] Both approval endpoints return `view_token` (`{flow_id}.{hmac}`)
- [x] Member reads the flow **without** token → `403` ("ask for a share link")
- [x] Member reads the flow **with** token → `200`
- [x] Both approval pages render the "Open run details" link with the `view_token` query param
- [x] Member clicks the link and sees the run detail (no permission-denied state)
- [x] **Anonymous** caller + token → `400`/blocked (token requires authentication; run not revealed)
- [x] Backend compiles; frontend type-checks (no new errors)

## Notes

- No EE companion PR — all touched files are core (no `*_ee.rs`).
- The generated client under `frontend/src/lib/gen/` is gitignored and regenerated from `openapi.yaml`.
- Optional follow-up suggested in review: a small Rust assertion that `get_approval_info` returns `view_token: None` on the locked path and `Some` otherwise, to lock in the gating.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-grant a read-only `view_token` on approval pages and show a clear “Open run details” button for logged-in workspace members, so approvers can open run details without a 403. Also fixes the run-details link when job data isn’t available.

- **New Features**
  - Backend: Mint `view_token` for the parent flow in `get_approval_info` (only for authorized approvers) and `get_suspended_job_flow` (after secret validation).
  - Frontend: Append `view_token` to the run-detail URL on both approval pages; show a Button for logged-in workspace members and fall back to a link otherwise.
  - OpenAPI: Document optional `view_token` on both responses.

- **Bug Fixes**
  - Build the run-details URL from route params on the new approval page to avoid `/run/undefined` when `getJob` is denied.

<sup>Written for commit e0f2df0e2e1e7c8798dc1bb7e158cf538da74e12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

