### PR TITLE
feat(frontend): hide primary storage row until added in workspace storage settings

### DIFF
--- a/frontend/src/lib/components/ResourcePicker.svelte
+++ b/frontend/src/lib/components/ResourcePicker.svelte
@@ -26,6 +26,7 @@
 		placeholder?: string | undefined
 		selectInputClass?: string
 		class?: string
+		error?: boolean
 		onClear?: () => void
 		excludedValues?: string[]
 		datatableAsPgResource?: boolean
@@ -47,6 +48,7 @@
 		placeholder = undefined,
 		selectInputClass = '',
 		class: className = '',
+		error = false,
 		onClear = undefined,
 		excludedValues = undefined,
 		datatableAsPgResource = false,
@@ -236,6 +238,7 @@
 			}}
 			items={collection}
 			clearable
+			{error}
 			class="text-clip grow min-w-0"
 			inputClass={selectInputClass}
 			placeholder={placeholder ?? `${resourceType ?? 'any'} resource`}

--- a/frontend/src/lib/components/workspaceSettings/StorageSettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/StorageSettings.svelte
@@ -129,6 +129,9 @@
 	let hasUnsavedChanges = $derived.by(() => {
 		return !deepEqual(s3ResourceSettings, s3ResourceSavedSettings)
 	})
+
+	// A visible storage row without a selected resource can't be saved.
+	let hasMissingResource = $derived(tableRows.some(([, item]) => emptyString(item.resourcePath)))
 </script>
 
 <Portal name="workspace-settings">
@@ -361,6 +364,7 @@
 		class="mt-5 mb-5"
 		inline
 		{hasUnsavedChanges}
+		disabled={hasMissingResource}
 		onSave={editWindmillLFSSettings}
 		onDiscard={() => onDiscard?.()}
 		saveLabel="Save storage settings"

--- a/frontend/src/lib/components/workspaceSettings/StorageSettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/StorageSettings.svelte
@@ -69,20 +69,29 @@
 	}
 
 	// Primary storage exists once it has been saved with a resource. Until then the row is
-	// hidden and the user is offered an "Add primary storage" button instead.
+	// hidden and the user is offered an "Add primary storage" button instead. Visibility is an
+	// explicit toggle (driven by Add/Delete) so editing or clearing the resource picker doesn't
+	// make the row vanish.
 	let primaryStorageSaved: boolean = $derived(!emptyString(s3ResourceSavedSettings.resourcePath))
-	let addingPrimary: boolean = $state(false)
-	let showPrimaryRow: boolean = $derived(primaryStorageSaved || addingPrimary)
+	let showPrimaryRow: boolean = $state(primaryStorageSaved)
 
-	// Any discard (footer or the page-level "discard all changes") resets the whole settings
-	// object to the saved clone. Collapse a revealed-but-unsaved primary row when that happens.
+	// The parent reassigns the whole settings object on load and on every discard (footer or the
+	// page-level "discard all changes"). Re-sync the row to the saved state when that happens.
 	let prevSettings = s3ResourceSettings
 	$effect(() => {
 		if (s3ResourceSettings !== prevSettings) {
 			prevSettings = s3ResourceSettings
-			addingPrimary = false
+			showPrimaryRow = primaryStorageSaved
 		}
 	})
+
+	function clearPrimaryStorage() {
+		s3ResourceSettings.resourceType = 's3'
+		s3ResourceSettings.resourcePath = undefined
+		s3ResourceSettings.publicResource = undefined
+		s3ResourceSettings.advancedPermissions = defaultS3AdvancedPermissions(!!$enterpriseLicense)
+		showPrimaryRow = false
+	}
 
 	let tableRows: [string | null, S3ResourceSettingsItem][] = $derived([
 		...(showPrimaryRow
@@ -276,6 +285,8 @@
 									}
 								}}
 							/>
+						{:else if (s3ResourceSettings.secondaryStorage?.length ?? 0) === 0}
+							<CloseButton small on:close={clearPrimaryStorage} />
 						{/if}
 					</Cell>
 				</Row>
@@ -320,7 +331,7 @@
 								size="sm"
 								btnClasses="max-w-fit mt-2"
 								variant="default"
-								on:click={() => (addingPrimary = true)}
+								on:click={() => (showPrimaryRow = true)}
 							>
 								<Plus /> Add primary storage
 							</Button>

--- a/frontend/src/lib/components/workspaceSettings/StorageSettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/StorageSettings.svelte
@@ -213,6 +213,7 @@
 										class="flex-1"
 										bind:value={tableRow[1].resourcePath}
 										resourceType={tableRow[1].resourceType}
+										error={emptyString(tableRow[1].resourcePath)}
 									/>
 								{/if}
 							</div>

--- a/frontend/src/lib/components/workspaceSettings/StorageSettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/StorageSettings.svelte
@@ -68,8 +68,26 @@
 			'Which resource the workspace storage will point to. Note that all users of the workspace will be able to access the workspace storage regardless of the resource visibility.'
 	}
 
+	// Primary storage exists once it has been saved with a resource. Until then the row is
+	// hidden and the user is offered an "Add primary storage" button instead.
+	let primaryStorageSaved: boolean = $derived(!emptyString(s3ResourceSavedSettings.resourcePath))
+	let addingPrimary: boolean = $state(false)
+	let showPrimaryRow: boolean = $derived(primaryStorageSaved || addingPrimary)
+
+	// Any discard (footer or the page-level "discard all changes") resets the whole settings
+	// object to the saved clone. Collapse a revealed-but-unsaved primary row when that happens.
+	let prevSettings = s3ResourceSettings
+	$effect(() => {
+		if (s3ResourceSettings !== prevSettings) {
+			prevSettings = s3ResourceSettings
+			addingPrimary = false
+		}
+	})
+
 	let tableRows: [string | null, S3ResourceSettingsItem][] = $derived([
-		[null, s3ResourceSettings],
+		...(showPrimaryRow
+			? ([[null, s3ResourceSettings]] as [string | null, S3ResourceSettingsItem][])
+			: []),
 		...(s3ResourceSettings.secondaryStorage ?? [])
 	])
 	let secondaryStorageIsDirty: Record<string, boolean> = $derived(
@@ -144,7 +162,7 @@
 			</tr>
 		</Head>
 		<tbody class="divide-y bg-surface-tertiary">
-			{#each tableRows as tableRow, idx}
+			{#each tableRows as tableRow}
 				<Row>
 					<Cell first class="w-48 relative">
 						{#if tableRow[0] === null}
@@ -161,27 +179,27 @@
 						<div class="flex gap-2">
 							<div class="relative">
 								{#if tableRow[1].resourceType === 'filesystem'}
-								<Select
-									items={[{ value: 'filesystem', label: 'Filesystem' }]}
-									value={'filesystem'}
-									disabled
-									id="storage-resource-type-select"
-									class="w-40"
-								/>
-							{:else}
-								<Select
-									items={[
-										{ value: 's3', label: 'S3' },
-										{ value: 'azure_blob', label: 'Azure Blob' },
-										{ value: 's3_aws_oidc', label: 'AWS OIDC' },
-										{ value: 'azure_workload_identity', label: 'Azure Workload Identity' },
-										{ value: 'gcloud_storage', label: 'Google Cloud Storage' }
-									]}
-									bind:value={tableRow[1].resourceType}
-									id="storage-resource-type-select"
-									class="w-40"
-								/>
-							{/if}
+									<Select
+										items={[{ value: 'filesystem', label: 'Filesystem' }]}
+										value={'filesystem'}
+										disabled
+										id="storage-resource-type-select"
+										class="w-40"
+									/>
+								{:else}
+									<Select
+										items={[
+											{ value: 's3', label: 'S3' },
+											{ value: 'azure_blob', label: 'Azure Blob' },
+											{ value: 's3_aws_oidc', label: 'AWS OIDC' },
+											{ value: 'azure_workload_identity', label: 'Azure Workload Identity' },
+											{ value: 'gcloud_storage', label: 'Google Cloud Storage' }
+										]}
+										bind:value={tableRow[1].resourceType}
+										id="storage-resource-type-select"
+										class="w-40"
+									/>
+								{/if}
 							</div>
 							<div class="flex flex-1">
 								{#if tableRow[1].resourceType === 'filesystem'}
@@ -223,19 +241,15 @@
 									class="cursor-not-allowed"
 								>
 									{#snippet trigger()}
-
-											<ExploreAssetButton asset={{ kind: 's3object', path: '' }} disabled />
-
-																	{/snippet}
+										<ExploreAssetButton asset={{ kind: 's3object', path: '' }} disabled />
+									{/snippet}
 									{#snippet content()}
-
-											{#if emptyString(tableRow[1].resourcePath)}
-												Please select a storage resource
-											{:else if isDirty(tableRow[0])}
-												Please save your changes
-											{/if}
-
-																	{/snippet}
+										{#if emptyString(tableRow[1].resourcePath)}
+											Please select a storage resource
+										{:else if isDirty(tableRow[0])}
+											Please save your changes
+										{/if}
+									{/snippet}
 								</Popover>
 							{:else}
 								<ExploreAssetButton
@@ -251,8 +265,13 @@
 								small
 								on:close={() => {
 									if (s3ResourceSettings.secondaryStorage) {
-										s3ResourceSettings.secondaryStorage.splice(idx - 1, 1)
-										s3ResourceSettings.secondaryStorage = [...s3ResourceSettings.secondaryStorage]
+										const realIdx = s3ResourceSettings.secondaryStorage.findIndex(
+											(s) => s === tableRow
+										)
+										if (realIdx !== -1) {
+											s3ResourceSettings.secondaryStorage.splice(realIdx, 1)
+											s3ResourceSettings.secondaryStorage = [...s3ResourceSettings.secondaryStorage]
+										}
 									}
 								}}
 							/>
@@ -295,7 +314,16 @@
 						</Button>
 					{/snippet}
 					<div class="flex justify-center w-full">
-						{#if !s3ResourceSettings.resourcePath}
+						{#if !showPrimaryRow}
+							<Button
+								size="sm"
+								btnClasses="max-w-fit mt-2"
+								variant="default"
+								on:click={() => (addingPrimary = true)}
+							>
+								<Plus /> Add primary storage
+							</Button>
+						{:else if !s3ResourceSettings.resourcePath}
 							<Popover
 								class="cursor-not-allowed"
 								openOnHover


### PR DESCRIPTION
## Summary
In the workspace **Object storage (S3/Azure Blob/GCS)** settings, the **Primary storage** row was always rendered, even when no primary storage was configured. This makes the empty state confusing — it looks like a primary storage already exists.

Now, when no primary storage has been saved, the Primary storage row is hidden and the action button reads **"Add primary storage"** instead of "Add secondary storage". Clicking it reveals the editable primary row so the user can pick a resource and save. Once a primary storage exists, the button reverts to the existing "Add secondary storage" behavior. The primary row can also be removed via the same delete button used for secondary rows (only when no secondary storages exist), and an empty storage resource picker is highlighted with a red border.

## Changes
- Add a `showPrimaryRow` state (initialized from whether a primary is saved, and re-synced to the saved state whenever the parent reassigns the settings object — i.e. on load and on every discard path). The Primary row renders only when this is true.
- Render an **"Add primary storage"** button when no primary row is shown; clicking it reveals the editable primary row. Once primary storage is present, the existing "Add secondary storage" button (and its disabled/popover state) is shown.
- Add a **delete button** to the primary row (the same `CloseButton` used for secondary rows), shown only when there are no secondary storages. Clicking it clears the primary storage fields and collapses the row back to the "Add primary storage" button (persisted on save). Saving an empty primary maps to no `large_file_storage`, cleanly removing it.
- Highlight the storage **resource picker with a red border when empty**, via a new `error` prop forwarded from `ResourcePicker` to its inner `Select` (reusing the design-system `inputBorderClass` error styling).
- **Disable the "Save storage settings" button when any visible row is missing its resource** (`disabled={hasMissingResource}` on the footer). Deleting the primary (which hides its row) still leaves Save enabled so the removal can be persisted.
- Fix the secondary-storage delete handler: it used `idx - 1`, assuming the primary row was always at table index 0, which breaks now that the primary row can be absent. It now finds the real index in `secondaryStorage` by reference.

## Screenshots
Default (no primary storage configured) — row hidden, "Add primary storage" button:

![storage_settings_default](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/primary-storage-conditional/1781958014-storage_settings_default.png)

Primary row revealed — empty resource picker shows a red border, and the row has a delete button (no secondary storages present):

![storage_primary_delete](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/primary-storage-conditional/1781962987-storage_primary_delete.png)

Empty resource picker highlighted in red (secondary row example):

![storage_redborder](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/primary-storage-conditional/1781962587-storage_redborder.png)

## Test plan
- [ ] On a workspace with **no** primary storage: open Workspace settings → Object storage (S3) and confirm the Primary storage row is hidden and an "Add primary storage" button is shown.
- [ ] Click "Add primary storage" and confirm the editable primary row appears (with a red border on the empty resource picker) and the button switches to "Add secondary storage".
- [ ] Confirm the primary row has a delete (X) button when there are no secondary storages, and that it disappears once a secondary storage is added.
- [ ] Click the primary delete button and confirm the row collapses back to "Add primary storage" and a "Discard changes"/Save appears; save and confirm the storage is removed.
- [ ] Pick a resource and save; reopen and confirm the primary row is shown by default (saved state) and the resource picker no longer has a red border.
- [ ] Reveal the primary row, make a change, then discard via the footer "Discard changes" and via the page-level "discard all changes" — confirm the row collapses back to the "Add primary storage" button in both cases.
- [ ] With a saved secondary storage present, add and delete a secondary row and confirm the correct entry is removed.
- [ ] With a resource selected on the primary, add an empty secondary row and confirm "Save storage settings" is disabled until the secondary's resource is set (or the row is removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

