### PR TITLE
feat: bounded-cascade selective execution for pipelines (UI + CLI)

### DIFF
--- a/cli/src/commands/pipeline/boundedCascade.test.ts
+++ b/cli/src/commands/pipeline/boundedCascade.test.ts
@@ -1,0 +1,146 @@
+// Mirror of
+// frontend/src/lib/components/assets/AssetGraph/boundedCascade.test.ts — keep
+// the two engines in sync.
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import {
+  type BCGraph,
+  assetUriToNodeId,
+  boundedSet,
+  buildLineageDag,
+  resolveToken,
+  scriptNodeId,
+  scriptsOf,
+  topoOrder,
+  validStarts,
+} from "./boundedCascade.ts";
+
+type W = [script: string, asset: string];
+type S = [script: string, asset: string];
+type R = [script: string, asset: string];
+
+function graph(opts: {
+  scripts?: string[];
+  writes?: W[];
+  reads?: R[];
+  subs?: S[];
+  native?: Array<[kind: string, script: string]>;
+}): BCGraph {
+  const { scripts = [], writes = [], reads = [], subs = [], native = [] } = opts;
+  return {
+    assets: [],
+    runnables: scripts.map((p) => ({ path: p, usage_kind: "script" as const })),
+    edges: [
+      ...writes.map(([s, a]) => ({
+        runnable_kind: "script",
+        runnable_path: s,
+        asset_kind: "datatable",
+        asset_path: a,
+        access_type: "w" as const,
+      })),
+      ...reads.map(([s, a]) => ({
+        runnable_kind: "script",
+        runnable_path: s,
+        asset_kind: "datatable",
+        asset_path: a,
+        access_type: "r" as const,
+      })),
+    ],
+    triggers: [
+      ...subs.map(([s, a]) => ({
+        trigger_kind: "asset" as const,
+        asset_kind: "datatable",
+        asset_path: a,
+        runnable_kind: "script",
+        runnable_path: s,
+      })),
+      ...native.map(([kind, s]) => ({
+        trigger_kind: kind,
+        runnable_kind: "script",
+        runnable_path: s,
+      })),
+    ],
+  };
+}
+
+const sn = scriptNodeId;
+const sorted = (it: Iterable<string>) => [...it].sort();
+
+// a → x → b → y → c → z → d (linear chain through assets)
+const chain = () =>
+  graph({
+    scripts: ["a", "b", "c", "d"],
+    writes: [
+      ["a", "x"],
+      ["b", "y"],
+      ["c", "z"],
+    ],
+    subs: [
+      ["b", "x"],
+      ["c", "y"],
+      ["d", "z"],
+    ],
+  });
+
+Deno.test("boundedSet stops at a single end node", () => {
+  const res = boundedSet(buildLineageDag(chain()), sn("a"), [sn("c")]);
+  assertEquals(sorted(scriptsOf(res.nodes)), ["a", "b", "c"]);
+  assertEquals(res.nodes.has("datatable:z"), false);
+});
+
+Deno.test("boundedSet supports an asset as the end bound", () => {
+  const res = boundedSet(buildLineageDag(chain()), sn("a"), ["datatable:y"]);
+  assertEquals(sorted(scriptsOf(res.nodes)), ["a", "b"]);
+});
+
+Deno.test("boundedSet drops ends not downstream of start", () => {
+  const res = boundedSet(buildLineageDag(chain()), sn("c"), [sn("a")]);
+  assertEquals(res.droppedEnds, [sn("a")]);
+  assertEquals([...res.nodes], [sn("c")]);
+});
+
+Deno.test("validStarts: schedule and manual roots, not events or subscribers", () => {
+  const g = graph({
+    scripts: ["a", "sub", "sched", "kfk"],
+    writes: [["a", "x"]],
+    subs: [["sub", "x"], ["sched", "x"]],
+    native: [["schedule", "sched"], ["kafka", "kfk"]],
+  });
+  const starts = validStarts(g);
+  assertEquals(starts.has(sn("a")), true); // manual root
+  assertEquals(starts.has(sn("sched")), true); // schedule overrides subscriber
+  assertEquals(starts.has(sn("sub")), false); // pure subscriber
+  assertEquals(starts.has(sn("kfk")), false); // event-only
+});
+
+Deno.test("assetUriToNodeId maps s3 → s3object, others verbatim", () => {
+  assertEquals(assetUriToNodeId("s3://b/k"), "s3object:b/k");
+  assertEquals(assetUriToNodeId("datatable://main/users"), "datatable:main/users");
+  assertEquals(assetUriToNodeId("nope"), undefined);
+});
+
+Deno.test("resolveToken: short name, full path, and asset URI", () => {
+  const g = graph({ scripts: ["f/p/stage"], writes: [["f/p/stage", "main/staged"]] });
+  // asset must exist in graph.assets for URI resolution
+  g.assets = [{ kind: "datatable", path: "main/staged" }];
+  assertEquals(resolveToken(g, "stage"), sn("f/p/stage"));
+  assertEquals(resolveToken(g, "f/p/stage"), sn("f/p/stage"));
+  assertEquals(resolveToken(g, "datatable://main/staged"), "datatable:main/staged");
+  assertEquals(resolveToken(g, "missing"), undefined);
+});
+
+Deno.test("topoOrder sorts the bounded scripts and flags cycles", () => {
+  const { order, cyclic } = topoOrder(chain(), new Set(["a", "b", "c"]));
+  assertEquals(order, ["a", "b", "c"]);
+  assertEquals(cyclic, []);
+});
+
+Deno.test("topoOrder orders a pure reader after its producer", () => {
+  // a writes x; c only *reads* x (no `// on x`). c must run after a.
+  const g = graph({
+    scripts: ["a", "c"],
+    writes: [["a", "x"]],
+    reads: [["c", "x"]],
+  });
+  const { order } = topoOrder(g, new Set(["a", "c"]));
+  assertEquals(order, ["a", "c"]);
+});

--- a/cli/src/commands/pipeline/boundedCascade.ts
+++ b/cli/src/commands/pipeline/boundedCascade.ts
@@ -1,0 +1,238 @@
+// Bounded-cascade graph engine for `wmill pipeline run --to`.
+//
+// MIRROR of frontend/src/lib/components/assets/AssetGraph/boundedCascade.ts —
+// the two have no shared import path (frontend is a separate package), so keep
+// them in sync. The grammar is intentionally tiny: there is no dbt-style
+// `--select` string. The user names a start (a schedule / manual root) and one
+// or more end nodes; the run is the "path between" them:
+//
+//     descendants(start) ∩ (ancestors(ends) ∪ ends) ∪ {start}
+//
+// Node ids: assets `${kind}:${path}` (e.g. `datatable:main/raw`); runnables
+// `script:${path}`. Operates on the asset-graph payload shape used by
+// pipeline.ts.
+
+export type BCGraph = {
+  runnables: { path: string; usage_kind: "script" | "flow" | "job" }[];
+  assets: { kind: string; path: string }[];
+  edges: {
+    runnable_kind: string;
+    runnable_path: string;
+    asset_kind: string;
+    asset_path: string;
+    access_type?: "r" | "w" | "rw";
+  }[];
+  triggers: (
+    | {
+        trigger_kind: "asset";
+        asset_kind: string;
+        asset_path: string;
+        runnable_kind: string;
+        runnable_path: string;
+      }
+    | { trigger_kind: string; runnable_kind: string; runnable_path: string }
+  )[];
+};
+
+export const SCRIPT_PREFIX = "script:";
+export const scriptNodeId = (path: string): string => `${SCRIPT_PREFIX}${path}`;
+export const isScriptNode = (id: string): boolean => id.startsWith(SCRIPT_PREFIX);
+export const scriptPathOf = (id: string): string => id.slice(SCRIPT_PREFIX.length);
+const assetNodeId = (kind: string, path: string): string => `${kind}:${path}`;
+
+// Native trigger kinds that fan out per-event — never bounded-run starts.
+// `webhook` / `data_upload` have no trigger row in the graph payload, so a root
+// whose only entry is one of those reads as a manual root.
+const EVENT_TRIGGER_KINDS = new Set([
+  "kafka",
+  "mqtt",
+  "nats",
+  "postgres",
+  "sqs",
+  "gcp",
+  "email",
+]);
+
+/** Resolve an asset URI (`datatable://x`, `s3://b/k`, …) to its node id. */
+export function assetUriToNodeId(uri: string): string | undefined {
+  const m = uri.match(/^([a-z0-9_]+):\/\/(.+)$/i);
+  if (!m) return undefined;
+  const prefix = m[1].toLowerCase();
+  const kind = prefix === "s3" ? "s3object" : prefix;
+  return `${kind}:${m[2]}`;
+}
+
+export type LineageDag = {
+  down: Map<string, Set<string>>;
+  up: Map<string, Set<string>>;
+  nodes: Set<string>;
+};
+
+function addEdge(dag: LineageDag, a: string, b: string) {
+  if (a === b) return;
+  dag.nodes.add(a);
+  dag.nodes.add(b);
+  (dag.down.get(a) ?? dag.down.set(a, new Set()).get(a)!).add(b);
+  (dag.up.get(b) ?? dag.up.set(b, new Set()).get(b)!).add(a);
+}
+
+/** Unified upstream→downstream lineage DAG over scripts ∪ assets. */
+export function buildLineageDag(g: BCGraph): LineageDag {
+  const dag: LineageDag = { down: new Map(), up: new Map(), nodes: new Set() };
+  for (const r of g.runnables ?? []) {
+    if (r.usage_kind === "script") dag.nodes.add(scriptNodeId(r.path));
+  }
+  for (const a of g.assets ?? []) dag.nodes.add(assetNodeId(a.kind, a.path));
+  for (const e of g.edges ?? []) {
+    if (e.runnable_kind !== "script") continue;
+    const aid = assetNodeId(e.asset_kind, e.asset_path);
+    const access = e.access_type ?? "r";
+    if (access === "w" || access === "rw") {
+      addEdge(dag, scriptNodeId(e.runnable_path), aid); // producer
+    } else if (access === "r") {
+      addEdge(dag, aid, scriptNodeId(e.runnable_path)); // pure reader
+    }
+  }
+  for (const t of g.triggers ?? []) {
+    if (t.trigger_kind !== "asset" || t.runnable_kind !== "script") continue;
+    const at = t as Extract<BCGraph["triggers"][number], { trigger_kind: "asset" }>;
+    addEdge(dag, assetNodeId(at.asset_kind, at.asset_path), scriptNodeId(at.runnable_path));
+  }
+  return dag;
+}
+
+function closure(adj: Map<string, Set<string>>, start: string): Set<string> {
+  const seen = new Set<string>();
+  const queue = [start];
+  while (queue.length > 0) {
+    const cur = queue.shift()!;
+    for (const n of adj.get(cur) ?? []) {
+      if (seen.has(n)) continue;
+      seen.add(n);
+      queue.push(n);
+    }
+  }
+  return seen;
+}
+
+export const descendants = (dag: LineageDag, n: string): Set<string> => closure(dag.down, n);
+export const ancestors = (dag: LineageDag, n: string): Set<string> => closure(dag.up, n);
+
+export type BoundedResult = {
+  nodes: Set<string>;
+  reachableEnds: string[];
+  droppedEnds: string[];
+};
+
+/** Path-between node set for `start` and `ends` (inclusive). */
+export function boundedSet(dag: LineageDag, start: string, ends: string[]): BoundedResult {
+  const downSet = new Set(descendants(dag, start));
+  downSet.add(start);
+  const reachableEnds = ends.filter((e) => downSet.has(e));
+  const droppedEnds = ends.filter((e) => !downSet.has(e));
+  if (reachableEnds.length === 0) {
+    return { nodes: new Set([start]), reachableEnds, droppedEnds };
+  }
+  const upClosure = new Set<string>();
+  for (const e of reachableEnds) {
+    upClosure.add(e);
+    for (const a of ancestors(dag, e)) upClosure.add(a);
+  }
+  const nodes = new Set<string>();
+  for (const n of downSet) if (upClosure.has(n)) nodes.add(n);
+  nodes.add(start);
+  return { nodes, reachableEnds, droppedEnds };
+}
+
+/** Script node ids eligible to start a bounded run. */
+export function validStarts(g: BCGraph): Set<string> {
+  const subscribers = new Set<string>();
+  const scheduleScripts = new Set<string>();
+  const eventScripts = new Set<string>();
+  for (const t of g.triggers ?? []) {
+    if (t.runnable_kind !== "script") continue;
+    if (t.trigger_kind === "asset") subscribers.add(t.runnable_path);
+    else if (t.trigger_kind === "schedule") scheduleScripts.add(t.runnable_path);
+    else if (EVENT_TRIGGER_KINDS.has(t.trigger_kind)) eventScripts.add(t.runnable_path);
+  }
+  const out = new Set<string>();
+  for (const r of g.runnables ?? []) {
+    if (r.usage_kind !== "script") continue;
+    const p = r.path;
+    if (scheduleScripts.has(p)) out.add(scriptNodeId(p));
+    else if (!subscribers.has(p) && !eventScripts.has(p)) out.add(scriptNodeId(p));
+  }
+  return out;
+}
+
+/** Project a node-id set to the script paths it contains. */
+export function scriptsOf(nodes: Iterable<string>): string[] {
+  const out: string[] = [];
+  for (const id of nodes) if (isScriptNode(id)) out.push(scriptPathOf(id));
+  return out;
+}
+
+/**
+ * Resolve a CLI `--to` / `--from` token to a node id, or undefined if it
+ * matches nothing. Asset URIs (`kind://path`) resolve to the asset node; a bare
+ * token matches a runnable by exact path or by short (last-segment) name.
+ */
+export function resolveToken(g: BCGraph, token: string): string | undefined {
+  if (token.includes("://")) {
+    const id = assetUriToNodeId(token);
+    return id && g.assets.some((a) => `${a.kind}:${a.path}` === id) ? id : undefined;
+  }
+  const scripts = (g.runnables ?? []).filter((r) => r.usage_kind === "script");
+  const exact = scripts.find((r) => r.path === token);
+  if (exact) return scriptNodeId(exact.path);
+  const byShort = scripts.filter((r) => (r.path.split("/").pop() ?? r.path) === token);
+  return byShort.length === 1 ? scriptNodeId(byShort[0].path) : undefined;
+}
+
+/**
+ * Topological order of `scripts` over the in-set producer→subscriber edges
+ * (assets collapsed). Scripts on a cycle are returned in `cyclic` and excluded
+ * from `order`. Serial-run friendly: every script comes after its in-set
+ * upstreams.
+ */
+export function topoOrder(
+  g: BCGraph,
+  scripts: Set<string>,
+): { order: string[]; cyclic: string[] } {
+  const dag = buildLineageDag(g);
+  const down = new Map<string, Set<string>>();
+  const indegree = new Map<string, number>();
+  for (const s of scripts) indegree.set(s, 0);
+  // One-hop (through a single asset) script→script edges, restricted to the set.
+  for (const s of scripts) {
+    const sid = scriptNodeId(s);
+    const oneHop = new Set<string>();
+    for (const asset of dag.down.get(sid) ?? []) {
+      for (const sub of dag.down.get(asset) ?? []) {
+        if (isScriptNode(sub)) {
+          const p = scriptPathOf(sub);
+          if (p !== s && scripts.has(p)) oneHop.add(p);
+        }
+      }
+    }
+    if (oneHop.size > 0) {
+      down.set(s, oneHop);
+      for (const p of oneHop) indegree.set(p, (indegree.get(p) ?? 0) + 1);
+    }
+  }
+  const ready = [...scripts].filter((s) => (indegree.get(s) ?? 0) === 0);
+  const remaining = new Map(indegree);
+  const order: string[] = [];
+  while (ready.length > 0) {
+    const n = ready.shift()!;
+    order.push(n);
+    for (const p of down.get(n) ?? []) {
+      const d = (remaining.get(p) ?? 0) - 1;
+      remaining.set(p, d);
+      if (d === 0) ready.push(p);
+    }
+  }
+  const orderedSet = new Set(order);
+  const cyclic = [...scripts].filter((s) => !orderedSet.has(s));
+  return { order, cyclic };
+}

--- a/cli/src/commands/pipeline/boundedCascade.ts
+++ b/cli/src/commands/pipeline/boundedCascade.ts
@@ -112,6 +112,9 @@ function closure(adj: Map<string, Set<string>>, start: string): Set<string> {
       queue.push(n);
     }
   }
+  // A cycle back to `start` would have re-added it; the contract excludes
+  // the node itself.
+  seen.delete(start);
   return seen;
 }
 

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -8,6 +8,18 @@ import { requireLogin } from "../../core/auth.ts";
 import { resolveWorkspace } from "../../core/context.ts";
 import * as log from "../../core/log.ts";
 import { GlobalOptions } from "../../types.ts";
+import {
+  type BCGraph,
+  boundedSet,
+  buildLineageDag,
+  descendants,
+  resolveToken,
+  scriptNodeId,
+  scriptPathOf,
+  scriptsOf,
+  topoOrder,
+  validStarts,
+} from "./boundedCascade.ts";
 
 // Mirrors the asset-graph endpoint payload (backend/windmill-api-assets).
 // TODO: the checked-in generated client (cli/gen, last regenerated 2025-04)
@@ -269,6 +281,171 @@ async function show(
   console.log(lines.join("\n"));
 }
 
+// Poll a launched job to a terminal state. Modest fixed cadence; capped so a
+// wedged job can't hang the CLI forever.
+async function waitJob(workspace: string, id: string): Promise<boolean> {
+  const MAX_RETRIES = 6000; // ~10min at 100ms
+  for (let i = 0; i < MAX_RETRIES; i++) {
+    try {
+      const r = await wmill.getCompletedJobResultMaybe({
+        workspace,
+        id,
+        getStarted: false,
+      });
+      if (r.completed) return r.success !== false;
+    } catch {
+      // transient — retry
+    }
+    await new Promise((res) => setTimeout(res, 100));
+  }
+  throw new Error(`Timed out waiting for job ${id}`);
+}
+
+// Bounded-cascade run: start at a schedule / manual root, fan downstream, but
+// stop at the `--to` end node(s). Scripts run in topological order; each is
+// launched with `_wmill_skip_asset_dispatch` so the CLI owns the whole closure
+// (the backend dispatcher never double-fires the deployed part). With no
+// `--to`, runs the full downstream of `--from` (parity with the canvas cascade).
+async function run(
+  opts: GlobalOptions & {
+    from?: string;
+    to?: string[];
+    dryRun?: boolean;
+    json?: boolean;
+  },
+  folder: string,
+) {
+  if (opts.json) log.setSilent(true);
+  const workspace = await resolveWorkspace(opts);
+  await requireLogin(opts);
+
+  const f = folder.replace(/^f\//, "").replace(/\/$/, "");
+  const graph = await apiGet<BCGraph>(
+    `/w/${workspace.workspaceId}/assets/graph?folder=${encodeURIComponent(f)}&asset_kinds=${ASSET_KINDS}`,
+  );
+
+  // Resolve the start: explicit --from (must be a valid start) or the folder's
+  // sole valid start.
+  const starts = validStarts(graph);
+  let start: string;
+  if (opts.from) {
+    const resolved = resolveToken(graph, opts.from);
+    if (!resolved) {
+      // Distinguish "no match" from "ambiguous short name" (resolveToken
+      // returns undefined for both) so the hint is actionable.
+      const matches = graph.runnables.filter(
+        (r) => r.usage_kind === "script" && (r.path.split("/").pop() ?? r.path) === opts.from,
+      );
+      if (matches.length > 1) {
+        throw new Error(
+          `--from '${opts.from}' matches multiple scripts (${matches.map((r) => r.path).sort().join(", ")}) — pass the full path.`,
+        );
+      }
+      throw new Error(`--from '${opts.from}' matched no script in f/${f}.`);
+    }
+    if (!starts.has(resolved)) {
+      throw new Error(
+        `--from '${opts.from}' is not a valid bounded-run start. Starts must be schedule-triggered or manual roots; event-triggered scripts (kafka/webhook/…) fan out per-event and can't be bounded.`,
+      );
+    }
+    start = resolved;
+  } else if (starts.size === 1) {
+    start = [...starts][0];
+  } else if (starts.size === 0) {
+    throw new Error(
+      `No schedule or manual root in f/${f} to start a bounded run from.`,
+    );
+  } else {
+    throw new Error(
+      `f/${f} has ${starts.size} possible starts — pass --from <script>. Candidates: ${scriptsOf(starts).sort().join(", ")}`,
+    );
+  }
+
+  // Resolve --to end node(s): split on comma, resolve each, warn on misses.
+  const toTokens = (opts.to ?? []).flatMap((t) => t.split(",")).map((t) => t.trim()).filter(
+    Boolean,
+  );
+  const ends: string[] = [];
+  for (const tok of toTokens) {
+    const id = resolveToken(graph, tok);
+    if (!id) {
+      log.warn(`--to '${tok}' matched no node in f/${f} — ignored.`);
+      continue;
+    }
+    ends.push(id);
+  }
+  // A bound was requested but nothing resolved — refuse rather than silently
+  // running the whole pipeline.
+  if (toTokens.length > 0 && ends.length === 0) {
+    throw new Error(`None of the --to end node(s) matched a node in f/${f}.`);
+  }
+
+  const dag = buildLineageDag(graph);
+  let selectedScripts: Set<string>;
+  if (ends.length === 0) {
+    // No bound → full downstream of start (the unbounded cascade).
+    const all = new Set(descendants(dag, start));
+    all.add(start);
+    selectedScripts = new Set(scriptsOf(all));
+  } else {
+    const res = boundedSet(dag, start, ends);
+    for (const d of res.droppedEnds) {
+      log.warn(`end '${scriptPathOf(d) || d}' is not downstream of the start — ignored.`);
+    }
+    selectedScripts = new Set(scriptsOf(res.nodes));
+  }
+
+  const { order, cyclic } = topoOrder(graph, selectedScripts);
+  if (cyclic.length > 0) {
+    log.warn(`Skipping ${cyclic.length} script(s) on a dependency cycle: ${cyclic.sort().join(", ")}`);
+  }
+
+  if (opts.json) {
+    console.log(
+      JSON.stringify({
+        start: scriptPathOf(start),
+        ends: ends.map((e) => (e.startsWith("script:") ? scriptPathOf(e) : e)),
+        order,
+        cyclic,
+      }),
+    );
+  }
+
+  if (order.length === 0) {
+    if (!opts.json) log.info("Nothing to run.");
+    return;
+  }
+
+  if (opts.dryRun) {
+    if (!opts.json) {
+      log.info(
+        colors.bold(`Bounded run plan — ${order.length} script${order.length === 1 ? "" : "s"}`) +
+          colors.dim(` (from ${shortName(scriptPathOf(start))})`),
+      );
+      order.forEach((p, i) => log.info(`  ${i + 1}. ${p}`));
+    }
+    return;
+  }
+
+  // Execute in topological order, stopping on the first failure.
+  for (const path of order) {
+    if (!opts.json) log.info(colors.gray(`▶ running ${path}…`));
+    const id = await wmill.runScriptByPath({
+      workspace: workspace.workspaceId,
+      path,
+      requestBody: { _wmill_skip_asset_dispatch: true },
+    });
+    const ok = await waitJob(workspace.workspaceId, id);
+    if (!ok) {
+      throw new Error(`Bounded run failed at ${path} (job ${id}).`);
+    }
+    if (!opts.json) log.info(colors.green(`  ✓ ${path}`));
+  }
+  if (!opts.json) {
+    log.info(colors.green.bold(`Bounded run complete — ${order.length} script(s) succeeded.`));
+  }
+}
+
 const command = new Command()
   .description(
     "inspect asset-driven pipelines (scripts marked `// pipeline`, wired by `// on <spec>` annotations)",
@@ -282,6 +459,23 @@ const command = new Command()
   )
   .arguments("<folder:string>")
   .option("--json", "Output the raw asset graph as JSON")
-  .action(show as any);
+  .action(show as any)
+  .command(
+    "run",
+    "run a bounded cascade: from a schedule/manual root, fan downstream up to the --to end node(s)",
+  )
+  .arguments("<folder:string>")
+  .option(
+    "--from <script:string>",
+    "Start script (short name or path). Defaults to the folder's sole schedule/manual root.",
+  )
+  .option(
+    "--to <node:string>",
+    "End node(s) to stop at — script names/paths or asset URIs (e.g. datatable://main/staged). Repeatable or comma-separated. Omit to run the full downstream.",
+    { collect: true },
+  )
+  .option("--dry-run", "Print the topological run plan without executing.")
+  .option("--json", "Output the plan as JSON (for piping to jq).")
+  .action(run as any);
 
 export default command;

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -292,7 +292,10 @@ async function waitJob(workspace: string, id: string): Promise<boolean> {
         id,
         getStarted: false,
       });
-      if (r.completed) return r.success !== false;
+      // A completed job without an explicit `success: true` is a failure
+      // (mirrors the frontend `waitJobTerminal`): the cascade only advances on
+      // a confirmed success.
+      if (r.completed) return r.success === true;
     } catch {
       // transient — retry
     }
@@ -305,7 +308,9 @@ async function waitJob(workspace: string, id: string): Promise<boolean> {
 // stop at the `--to` end node(s). Scripts run in topological order; each is
 // launched with `_wmill_skip_asset_dispatch` so the CLI owns the whole closure
 // (the backend dispatcher never double-fires the deployed part). With no
-// `--to`, runs the full downstream of `--from` (parity with the canvas cascade).
+// `--to`, runs the full read-aware downstream of `--from` (every descendant in
+// the lineage DAG, pure readers included — broader than the canvas cascade,
+// which dispatches subscribers only).
 async function run(
   opts: GlobalOptions & {
     from?: string;
@@ -389,7 +394,7 @@ async function run(
   const dag = buildLineageDag(graph);
   let selectedScripts: Set<string>;
   if (ends.length === 0) {
-    // No bound → full downstream of start (the unbounded cascade).
+    // No bound → full read-aware downstream of start (pure readers included).
     const all = new Set(descendants(dag, start));
     all.add(start);
     selectedScripts = new Set(scriptsOf(all));

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -401,7 +401,11 @@ async function run(
   } else {
     const res = boundedSet(dag, start, ends);
     for (const d of res.droppedEnds) {
-      log.warn(`end '${scriptPathOf(d) || d}' is not downstream of the start — ignored.`);
+      // `d` is a node id: `script:<path>` for runnables, `<kind>:<path>` for
+      // assets. Only strip the `script:` prefix from runnables — slicing it off
+      // an asset id (e.g. `datatable:main/raw`) would corrupt the name.
+      const label = d.startsWith("script:") ? scriptPathOf(d) : d;
+      log.warn(`end '${label}' is not downstream of the start — ignored.`);
     }
     selectedScripts = new Set(scriptsOf(res.nodes));
   }

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -350,7 +350,7 @@ async function run(
     }
     if (!starts.has(resolved)) {
       throw new Error(
-        `--from '${opts.from}' is not a valid bounded-run start. Starts must be schedule-triggered or manual roots; event-triggered scripts (kafka/webhook/…) fan out per-event and can't be bounded.`,
+        `--from '${opts.from}' is not a valid bounded-run start. Starts must be schedule-triggered or manual roots; row-backed event triggers (kafka/mqtt/nats/postgres/sqs/gcp/email) fan out per-event and can't be bounded.`,
       );
     }
     start = resolved;

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -391,8 +391,15 @@ async function run(
     throw new Error(`--to could not be resolved: ${details.join("; ")}.`);
   }
 
+  // Readable label for a node id: `script:<path>` → `<path>`; asset ids
+  // (`<kind>:<path>`) are kept verbatim (slicing `script:` off them corrupts
+  // the name).
+  const idLabel = (id: string): string => (id.startsWith("script:") ? scriptPathOf(id) : id);
+
   const dag = buildLineageDag(graph);
   let selectedScripts: Set<string>;
+  let reachableEnds: string[] = [];
+  let droppedEnds: string[] = [];
   if (ends.length === 0) {
     // No bound → full read-aware downstream of start (pure readers included).
     const all = new Set(descendants(dag, start));
@@ -400,12 +407,10 @@ async function run(
     selectedScripts = new Set(scriptsOf(all));
   } else {
     const res = boundedSet(dag, start, ends);
-    for (const d of res.droppedEnds) {
-      // `d` is a node id: `script:<path>` for runnables, `<kind>:<path>` for
-      // assets. Only strip the `script:` prefix from runnables — slicing it off
-      // an asset id (e.g. `datatable:main/raw`) would corrupt the name.
-      const label = d.startsWith("script:") ? scriptPathOf(d) : d;
-      log.warn(`end '${label}' is not downstream of the start — ignored.`);
+    reachableEnds = res.reachableEnds;
+    droppedEnds = res.droppedEnds;
+    for (const d of droppedEnds) {
+      log.warn(`end '${idLabel(d)}' is not downstream of the start — ignored.`);
     }
     selectedScripts = new Set(scriptsOf(res.nodes));
   }
@@ -416,10 +421,15 @@ async function run(
   }
 
   if (opts.json) {
+    // Surface reachable/dropped ends so a machine-readable plan reflects the
+    // same trimming the human-facing warning does — a resolved-but-unreachable
+    // `--to` must not look like a clean plan that silently runs only the start.
     console.log(
       JSON.stringify({
         start: scriptPathOf(start),
-        ends: ends.map((e) => (e.startsWith("script:") ? scriptPathOf(e) : e)),
+        ends: ends.map(idLabel),
+        reachableEnds: reachableEnds.map(idLabel),
+        droppedEnds: droppedEnds.map(idLabel),
         order,
         cyclic,
       }),

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -361,23 +361,29 @@ async function run(
     );
   }
 
-  // Resolve --to end node(s): split on comma, resolve each, warn on misses.
+  // Resolve --to end node(s): split on comma, resolve each. An unresolved or
+  // ambiguous token is a hard error — silently ignoring it would run a
+  // different subset than the user asked for.
   const toTokens = (opts.to ?? []).flatMap((t) => t.split(",")).map((t) => t.trim()).filter(
     Boolean,
   );
   const ends: string[] = [];
+  const unresolved: string[] = [];
   for (const tok of toTokens) {
     const id = resolveToken(graph, tok);
-    if (!id) {
-      log.warn(`--to '${tok}' matched no node in f/${f} — ignored.`);
-      continue;
-    }
-    ends.push(id);
+    if (!id) unresolved.push(tok);
+    else ends.push(id);
   }
-  // A bound was requested but nothing resolved — refuse rather than silently
-  // running the whole pipeline.
-  if (toTokens.length > 0 && ends.length === 0) {
-    throw new Error(`None of the --to end node(s) matched a node in f/${f}.`);
+  if (unresolved.length > 0) {
+    const details = unresolved.map((tok) => {
+      const matches = graph.runnables.filter(
+        (r) => r.usage_kind === "script" && (r.path.split("/").pop() ?? r.path) === tok,
+      );
+      return matches.length > 1
+        ? `'${tok}' (ambiguous: ${matches.map((r) => r.path).sort().join(", ")} — use the full path)`
+        : `'${tok}' (no match in f/${f})`;
+    });
+    throw new Error(`--to could not be resolved: ${details.join("; ")}.`);
   }
 
   const dag = buildLineageDag(graph);

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -6897,6 +6897,11 @@ inspect asset-driven pipelines (scripts marked \`// pipeline\`, wired by \`// on
   - \`--json\` - Output as JSON (for piping to jq)
 - \`pipeline show <folder:string>\` - render a pipeline folder's DAG (sources, lineage, subscriptions) in the terminal
   - \`--json\` - Output the raw asset graph as JSON
+- \`pipeline run <folder:string>\` - run a bounded cascade: from a schedule/manual root, fan downstream up to the --to end node(s)
+  - \`--from <script:string>\` - Start script (short name or path). Defaults to the folder's sole schedule/manual root.
+  - \`--to <node:string>\` - End node(s) to stop at — script names/paths or asset URIs (e.g. datatable://main/staged). Repeatable or comma-separated. Omit to run the full downstream.
+  - \`--dry-run\` - Print the topological run plan without executing.
+  - \`--json\` - Output the plan as JSON (for piping to jq).
 
 ### protection-rules
 

--- a/cli/test/pipeline_bounded_cascade_unit.test.ts
+++ b/cli/test/pipeline_bounded_cascade_unit.test.ts
@@ -1,18 +1,21 @@
+import { expect, test } from "bun:test";
+
 // Mirror of
 // frontend/src/lib/components/assets/AssetGraph/boundedCascade.test.ts — keep
-// the two engines in sync.
-import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+// the two engines in sync. (Bun project → bun:test, not Deno.)
 import {
   type BCGraph,
+  ancestors,
   assetUriToNodeId,
   boundedSet,
   buildLineageDag,
+  descendants,
   resolveToken,
   scriptNodeId,
   scriptsOf,
   topoOrder,
   validStarts,
-} from "./boundedCascade.ts";
+} from "../src/commands/pipeline/boundedCascade.ts";
 
 type W = [script: string, asset: string];
 type S = [script: string, asset: string];
@@ -81,24 +84,24 @@ const chain = () =>
     ],
   });
 
-Deno.test("boundedSet stops at a single end node", () => {
+test("boundedSet stops at a single end node", () => {
   const res = boundedSet(buildLineageDag(chain()), sn("a"), [sn("c")]);
-  assertEquals(sorted(scriptsOf(res.nodes)), ["a", "b", "c"]);
-  assertEquals(res.nodes.has("datatable:z"), false);
+  expect(sorted(scriptsOf(res.nodes))).toEqual(["a", "b", "c"]);
+  expect(res.nodes.has("datatable:z")).toBe(false);
 });
 
-Deno.test("boundedSet supports an asset as the end bound", () => {
+test("boundedSet supports an asset as the end bound", () => {
   const res = boundedSet(buildLineageDag(chain()), sn("a"), ["datatable:y"]);
-  assertEquals(sorted(scriptsOf(res.nodes)), ["a", "b"]);
+  expect(sorted(scriptsOf(res.nodes))).toEqual(["a", "b"]);
 });
 
-Deno.test("boundedSet drops ends not downstream of start", () => {
+test("boundedSet drops ends not downstream of start", () => {
   const res = boundedSet(buildLineageDag(chain()), sn("c"), [sn("a")]);
-  assertEquals(res.droppedEnds, [sn("a")]);
-  assertEquals([...res.nodes], [sn("c")]);
+  expect(res.droppedEnds).toEqual([sn("a")]);
+  expect([...res.nodes]).toEqual([sn("c")]);
 });
 
-Deno.test("validStarts: schedule and manual roots, not events or subscribers", () => {
+test("validStarts: schedule and manual roots, not events or subscribers", () => {
   const g = graph({
     scripts: ["a", "sub", "sched", "kfk"],
     writes: [["a", "x"]],
@@ -106,35 +109,46 @@ Deno.test("validStarts: schedule and manual roots, not events or subscribers", (
     native: [["schedule", "sched"], ["kafka", "kfk"]],
   });
   const starts = validStarts(g);
-  assertEquals(starts.has(sn("a")), true); // manual root
-  assertEquals(starts.has(sn("sched")), true); // schedule overrides subscriber
-  assertEquals(starts.has(sn("sub")), false); // pure subscriber
-  assertEquals(starts.has(sn("kfk")), false); // event-only
+  expect(starts.has(sn("a"))).toBe(true); // manual root
+  expect(starts.has(sn("sched"))).toBe(true); // schedule overrides subscriber
+  expect(starts.has(sn("sub"))).toBe(false); // pure subscriber
+  expect(starts.has(sn("kfk"))).toBe(false); // event-only
 });
 
-Deno.test("assetUriToNodeId maps s3 → s3object, others verbatim", () => {
-  assertEquals(assetUriToNodeId("s3://b/k"), "s3object:b/k");
-  assertEquals(assetUriToNodeId("datatable://main/users"), "datatable:main/users");
-  assertEquals(assetUriToNodeId("nope"), undefined);
+test("assetUriToNodeId maps s3 → s3object, others verbatim", () => {
+  expect(assetUriToNodeId("s3://b/k")).toBe("s3object:b/k");
+  expect(assetUriToNodeId("datatable://main/users")).toBe("datatable:main/users");
+  expect(assetUriToNodeId("nope")).toBe(undefined);
 });
 
-Deno.test("resolveToken: short name, full path, and asset URI", () => {
+test("resolveToken: short name, full path, and asset URI", () => {
   const g = graph({ scripts: ["f/p/stage"], writes: [["f/p/stage", "main/staged"]] });
-  // asset must exist in graph.assets for URI resolution
   g.assets = [{ kind: "datatable", path: "main/staged" }];
-  assertEquals(resolveToken(g, "stage"), sn("f/p/stage"));
-  assertEquals(resolveToken(g, "f/p/stage"), sn("f/p/stage"));
-  assertEquals(resolveToken(g, "datatable://main/staged"), "datatable:main/staged");
-  assertEquals(resolveToken(g, "missing"), undefined);
+  expect(resolveToken(g, "stage")).toBe(sn("f/p/stage"));
+  expect(resolveToken(g, "f/p/stage")).toBe(sn("f/p/stage"));
+  expect(resolveToken(g, "datatable://main/staged")).toBe("datatable:main/staged");
+  expect(resolveToken(g, "missing")).toBe(undefined);
 });
 
-Deno.test("topoOrder sorts the bounded scripts and flags cycles", () => {
+test("topoOrder sorts the bounded scripts and flags cycles", () => {
   const { order, cyclic } = topoOrder(chain(), new Set(["a", "b", "c"]));
-  assertEquals(order, ["a", "b", "c"]);
-  assertEquals(cyclic, []);
+  expect(order).toEqual(["a", "b", "c"]);
+  expect(cyclic).toEqual([]);
 });
 
-Deno.test("topoOrder orders a pure reader after its producer", () => {
+test("descendants/ancestors exclude the start even on a cycle", () => {
+  // a → x → b → y → a (cycle): closures must not contain a.
+  const g = graph({
+    scripts: ["a", "b"],
+    writes: [["a", "x"], ["b", "y"]],
+    subs: [["b", "x"], ["a", "y"]],
+  });
+  const dag = buildLineageDag(g);
+  expect(descendants(dag, sn("a")).has(sn("a"))).toBe(false);
+  expect(ancestors(dag, sn("a")).has(sn("a"))).toBe(false);
+});
+
+test("topoOrder orders a pure reader after its producer", () => {
   // a writes x; c only *reads* x (no `// on x`). c must run after a.
   const g = graph({
     scripts: ["a", "c"],
@@ -142,5 +156,5 @@ Deno.test("topoOrder orders a pure reader after its producer", () => {
     reads: [["c", "x"]],
   });
   const { order } = topoOrder(g, new Set(["a", "c"]));
-  assertEquals(order, ["a", "c"]);
+  expect(order).toEqual(["a", "c"]);
 });

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -1913,15 +1913,18 @@
 								<div class="absolute top-1 left-2 z-10">
 									{#if testIsLoading}
 										{@render cancelTestButton('sm', 'shadow-md')}
-									{:else if (customUi?.previewPanel?.downstreamSubscribers ?? 0) > 0}
+									{:else if (customUi?.previewPanel?.downstreamSubscribers ?? 0) > 0 || customUi?.previewPanel?.onBoundedRun}
 										<!-- Split button: primary "Test" runs just this step
 									     (skips the asset-trigger cascade); the caret
 									     opens a popover with the cascade option labelled
 									     by the downstream count. The active mode is
 									     reflected in both the button label and the
 									     check-mark on the menu item so the user always
-									     knows whether the next run will fan out. -->
-										{@const downstream = customUi!.previewPanel!.downstreamSubscribers!}
+									     knows whether the next run will fan out. A
+									     pure-reader-only root has no subscriber downstream
+									     but still gets `onBoundedRun`, so the split button
+									     also opens for it (with the cascade item hidden). -->
+										{@const downstream = customUi?.previewPanel?.downstreamSubscribers ?? 0}
 										<div class="flex items-stretch shadow-md rounded-md overflow-hidden">
 											<Button
 												on:click={() => runTest()}
@@ -1984,31 +1987,33 @@
 																>
 															</div>
 														</button>
-														<button
-															type="button"
-															class="w-full text-left px-3 py-2 hover:bg-surface-hover flex items-start gap-2"
-															onclick={() => {
-																cascadeDownstream = true
-																close()
-																void runTest()
-															}}
-														>
-															<Zap
-																size={14}
-																class="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400"
-															/>
-															<div class="flex flex-col min-w-0">
-																<span class="font-medium">
-																	Test + trigger {downstream} downstream {cascadeDownstream
-																		? '(current)'
-																		: ''}
-																</span>
-																<span class="text-2xs text-secondary">
-																	Let the asset-trigger cascade fan out to the {downstream}
-																	subscribed script{downstream === 1 ? '' : 's'} after this run succeeds.
-																</span>
-															</div>
-														</button>
+														{#if downstream > 0}
+															<button
+																type="button"
+																class="w-full text-left px-3 py-2 hover:bg-surface-hover flex items-start gap-2"
+																onclick={() => {
+																	cascadeDownstream = true
+																	close()
+																	void runTest()
+																}}
+															>
+																<Zap
+																	size={14}
+																	class="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400"
+																/>
+																<div class="flex flex-col min-w-0">
+																	<span class="font-medium">
+																		Test + trigger {downstream} downstream {cascadeDownstream
+																			? '(current)'
+																			: ''}
+																	</span>
+																	<span class="text-2xs text-secondary">
+																		Let the asset-trigger cascade fan out to the {downstream}
+																		subscribed script{downstream === 1 ? '' : 's'} after this run succeeds.
+																	</span>
+																</div>
+															</button>
+														{/if}
 														{#if customUi?.previewPanel?.onBoundedRun}
 															<button
 																type="button"

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -52,6 +52,7 @@
 		Play,
 		PlayIcon,
 		Plus,
+		Target,
 		Terminal,
 		Pencil,
 		WandSparkles,
@@ -2008,6 +2009,28 @@
 																</span>
 															</div>
 														</button>
+														{#if customUi?.previewPanel?.onBoundedRun}
+															<button
+																type="button"
+																class="w-full text-left px-3 py-2 hover:bg-surface-hover flex items-start gap-2 border-t"
+																onclick={() => {
+																	close()
+																	customUi!.previewPanel!.onBoundedRun!()
+																}}
+															>
+																<Target
+																	size={14}
+																	class="mt-0.5 shrink-0 text-blue-600 dark:text-blue-400"
+																/>
+																<div class="flex flex-col min-w-0">
+																	<span class="font-medium">Run downstream up to…</span>
+																	<span class="text-2xs text-secondary">
+																		Pick end node(s) on the graph, then run only the cascade between
+																		this script and them.
+																	</span>
+																</div>
+															</button>
+														{/if}
 													</div>
 												{/snippet}
 											</Popover>

--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
@@ -497,7 +497,16 @@
 					onEditTrigger,
 					onDeleteTrigger,
 					onOpenWebhook,
-					onOpenDataUpload
+					onOpenDataUpload,
+					// View-mode bounded-run entry: offer it on the trigger node
+					// when its target script is a valid start with downstream.
+					onStartBoundedRun:
+						info.runnable_path &&
+						onStartBoundedRun &&
+						validStartPaths?.has(info.runnable_path) &&
+						(downstreamByScript.get(info.runnable_path) ?? 0) > 0
+							? () => onStartBoundedRun(info.runnable_path!)
+							: undefined
 				}
 			})
 		}

--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
@@ -139,6 +139,24 @@
 		// editor passes it, so the asset-graph page is unaffected. The page
 		// clears it once the pan has had time to settle.
 		panToNodeId?: string | undefined
+		// Script paths eligible to *start* a bounded-cascade run (schedule
+		// roots + manual roots — see boundedCascade.validStarts). When a path is
+		// in this set and `onStartBoundedRun` is wired, its node's cascade menu
+		// gains a "Run downstream up to…" entry.
+		validStartPaths?: ReadonlySet<string>
+		onStartBoundedRun?: (startPath: string) => void
+		// Active bounded-run pick mode. Ids are in *canvas* space (`script:path`
+		// for runnables, `asset:${kind}:${path}` for assets). When set the canvas
+		// dims nodes outside `eligible ∪ {start}`, rings the `bounded` set, marks
+		// `ends`, and routes clicks on eligible nodes to `onPickEnd` instead of
+		// selecting.
+		boundPick?: {
+			start: string
+			eligible: ReadonlySet<string>
+			ends: ReadonlySet<string>
+			bounded: ReadonlySet<string>
+		}
+		onPickEnd?: (canvasNodeId: string) => void
 	}
 	let {
 		graph,
@@ -160,7 +178,11 @@
 		onOpenDataUpload,
 		hoveredPaths,
 		selectedRunPaths,
-		panToNodeId
+		panToNodeId,
+		validStartPaths,
+		onStartBoundedRun,
+		boundPick,
+		onPickEnd
 	}: Props = $props()
 
 	// `${kind}:${path}` ids for the hovered / pinned runs (both script and flow
@@ -325,6 +347,16 @@
 					downstreamCount: downstreamByScript.get(r.path) ?? 0,
 					downstreamUnsavedCount: downstreamUnsavedByScript.get(r.path) ?? 0,
 					runState,
+					// Bounded-cascade entrypoint: only valid starts (schedule /
+					// manual roots) with downstream get the "Run downstream up
+					// to…" menu item.
+					onStartBoundedRun:
+						r.usage_kind === 'script' &&
+						onStartBoundedRun &&
+						validStartPaths?.has(r.path) &&
+						(downstreamByScript.get(r.path) ?? 0) > 0
+							? () => onStartBoundedRun(r.path)
+							: undefined,
 					onRequestRemove: onRunnableMenuRemove
 						? () =>
 								onRunnableMenuRemove({
@@ -573,12 +605,22 @@
 					: assetEmph === 'input'
 						? 'wm-asset-input'
 						: undefined
+			// Bounded-run pick overlay takes precedence over the activity rings
+			// (it's a transient, modal selection). start ring > end mark > in-set
+			// ring > eligible (clickable, no style) > dimmed (out of reach).
+			let boundClass: string | undefined
+			if (boundPick && n.type !== 'add' && n.type !== 'trigger') {
+				if (n.id === boundPick.start) boundClass = 'wm-bound-start'
+				else if (boundPick.ends.has(n.id)) boundClass = 'wm-bound-end'
+				else if (boundPick.bounded.has(n.id)) boundClass = 'wm-bound-in'
+				else if (!boundPick.eligible.has(n.id)) boundClass = 'wm-bound-dim'
+			}
 			return {
 				id: n.id,
 				type: n.type,
 				position: { x: p.x + xCenter + xShift, y: p.y + 40 },
 				data: n.data,
-				class: runClass ?? assetClass,
+				class: boundClass ?? runClass ?? assetClass,
 				selected: n.id === selectedId,
 				// All nodes non-draggable: the layout is sugiyama-computed,
 				// dragging would fight the reactive re-layout. Selection is
@@ -792,6 +834,17 @@
 	}
 
 	function handleNodeClick({ node }: { node: Node }) {
+		// Bounded-run pick mode intercepts clicks: an eligible (downstream)
+		// node toggles as an end bound; the start, dimmed nodes, and
+		// triggers/+ are inert. Selection (details pane) is suppressed so the
+		// modal pick stays focused.
+		if (boundPick && onPickEnd) {
+			if (node.type !== 'asset' && node.type !== 'runnable') return
+			if (node.id === boundPick.start) return
+			if (!boundPick.eligible.has(node.id)) return
+			onPickEnd(node.id)
+			return
+		}
 		if (!onselect) return
 		const data = node.data as any
 		if (node.type === 'asset') {
@@ -869,5 +922,21 @@
 	}
 	:global(.svelte-flow__node.wm-asset-input .drop-shadow-sm) {
 		@apply outline outline-2 outline-gray-400;
+	}
+	/* Bounded-run pick mode. The start is a solid blue ring; chosen end
+	   bounds get a thicker amber ring; nodes inside the path-between set ring
+	   blue; everything out of reach fades back so the matched subset reads at
+	   a glance. */
+	:global(.svelte-flow__node.wm-bound-start .drop-shadow-sm) {
+		@apply outline outline-2 outline-blue-500;
+	}
+	:global(.svelte-flow__node.wm-bound-in .drop-shadow-sm) {
+		@apply outline outline-2 outline-blue-400/70;
+	}
+	:global(.svelte-flow__node.wm-bound-end .drop-shadow-sm) {
+		@apply outline outline-[3px] outline-amber-500;
+	}
+	:global(.svelte-flow__node.wm-bound-dim) {
+		@apply opacity-30;
 	}
 </style>

--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
@@ -17,6 +17,7 @@
 	import PanToNode from './PanToNode.svelte'
 	import { layoutAssetGraph } from './assetGraphLayout'
 	import { buildDownstreamMap } from './graphTraversal'
+	import { buildLineageDownstreamMap } from './boundedCascade'
 	import type { AssetGraphResponse, AssetGraphSelection, NativeTriggerKind } from './types'
 	import type { RunnableRunState } from './activeRunnables.svelte'
 	import type { AssetKind } from '$lib/gen'
@@ -281,6 +282,13 @@
 			downstreamByScript.set(path, set.size)
 			downstreamUnsavedByScript.set(path, [...set].filter((s) => unsavedRunnables.has(s)).length)
 		}
+		// Read-aware downstream presence for the bounded-run gate. The bounded
+		// engine treats pure-read `asset → script` edges as downstream, but the
+		// subscriber-only `downstreamByScript` above does not — so a start whose
+		// only downstream is a pure reader would otherwise be denied the menu
+		// item even though its bounded set is non-empty. Mirror of the engine's
+		// own adjacency (boundedCascade.buildLineageDownstreamMap).
+		const hasLineageDownstream = new Set<string>(buildLineageDownstreamMap(g).keys())
 
 		for (const a of g.assets) {
 			const assetId = `asset:${a.kind}:${a.path}`
@@ -354,7 +362,7 @@
 						r.usage_kind === 'script' &&
 						onStartBoundedRun &&
 						validStartPaths?.has(r.path) &&
-						(downstreamByScript.get(r.path) ?? 0) > 0
+						hasLineageDownstream.has(r.path)
 							? () => onStartBoundedRun(r.path)
 							: undefined,
 					onRequestRemove: onRunnableMenuRemove
@@ -504,7 +512,7 @@
 						info.runnable_path &&
 						onStartBoundedRun &&
 						validStartPaths?.has(info.runnable_path) &&
-						(downstreamByScript.get(info.runnable_path) ?? 0) > 0
+						hasLineageDownstream.has(info.runnable_path)
 							? () => onStartBoundedRun(info.runnable_path!)
 							: undefined
 				}

--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
@@ -415,7 +415,13 @@
 				kind: TriggerNodeKind
 				ref: string
 				missing: boolean
+				// First target script (drives the per-script create/edit flows).
 				runnable_path?: string
+				// Every target script: a single (kind, ref) — e.g. one schedule —
+				// can be shared across scripts and dedupes to one node with N
+				// edges. The bounded-run action must consider all of them, not
+				// just the first.
+				runnable_paths: string[]
 			}
 		>()
 		function recordSourceTrigger(
@@ -428,9 +434,19 @@
 		) {
 			const prev = triggerSourceNodes.get(id)
 			if (!prev) {
-				triggerSourceNodes.set(id, { allUnsaved: unsaved, kind, ref, missing, runnable_path })
+				triggerSourceNodes.set(id, {
+					allUnsaved: unsaved,
+					kind,
+					ref,
+					missing,
+					runnable_path,
+					runnable_paths: runnable_path ? [runnable_path] : []
+				})
 			} else {
 				prev.allUnsaved = prev.allUnsaved && unsaved
+				if (runnable_path && !prev.runnable_paths.includes(runnable_path)) {
+					prev.runnable_paths.push(runnable_path)
+				}
 			}
 		}
 
@@ -489,6 +505,14 @@
 			})
 		}
 		for (const [id, info] of triggerSourceNodes) {
+			// Bounded-run targets among this trigger's scripts: valid starts that
+			// also have read-aware downstream. A shared schedule may have several
+			// targets; only offer the action when exactly one qualifies, so the
+			// run starts from an unambiguous script (rather than the arbitrary
+			// first-seen one). Multi-eligible nodes suppress it rather than guess.
+			const eligibleStarts = onStartBoundedRun
+				? info.runnable_paths.filter((p) => validStartPaths?.has(p) && hasLineageDownstream.has(p))
+				: []
 			nodes.push({
 				id,
 				type: 'trigger',
@@ -507,13 +531,11 @@
 					onOpenWebhook,
 					onOpenDataUpload,
 					// View-mode bounded-run entry: offer it on the trigger node
-					// when its target script is a valid start with downstream.
+					// when exactly one target script is a valid start with
+					// downstream (see eligibleStarts above).
 					onStartBoundedRun:
-						info.runnable_path &&
-						onStartBoundedRun &&
-						validStartPaths?.has(info.runnable_path) &&
-						hasLineageDownstream.has(info.runnable_path)
-							? () => onStartBoundedRun(info.runnable_path!)
+						onStartBoundedRun && eligibleStarts.length === 1
+							? () => onStartBoundedRun(eligibleStarts[0])
 							: undefined
 				}
 			})

--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphDetailsPane.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphDetailsPane.svelte
@@ -165,6 +165,11 @@
 		// cascade option when > 0. The page computes this from the graph
 		// edges + triggers + currently-open path.
 		downstreamSubscribers?: number
+		// Pipeline-only: set when the currently-open script is a valid
+		// bounded-run start (schedule / manual root). Surfaces a "Run downstream
+		// up to…" entry on the Test split's caret that enters the canvas
+		// end-node pick mode rooted at this script. Undefined → no entry.
+		onStartBoundedRun?: () => void
 		// Sister to `requestRunSignal`. When bumped, the bridge calls
 		// `ScriptEditor.runTest({ cascade: true })` — used by the canvas
 		// runnable menu's "Run + trigger N downstream" item when the chosen
@@ -219,6 +224,7 @@
 		onDraftPathChange,
 		requestRemoveSignal,
 		downstreamSubscribers = 0,
+		onStartBoundedRun,
 		requestRunCascadeSignal,
 		focusUploadSignal,
 		mode = 'edit',
@@ -1082,6 +1088,7 @@
 							argsAboveLogs: true,
 							logsResultSideBySide: true,
 							downstreamSubscribers,
+							onBoundedRun: onStartBoundedRun,
 							// Selecting a script node should immediately show
 							// "what happened last time it ran" — pulling the
 							// latest top-level completed job into the preview

--- a/frontend/src/lib/components/assets/AssetGraph/RunnableNode.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/RunnableNode.svelte
@@ -118,21 +118,11 @@
 		}
 	}
 
-	// Kebab menu: the bounded-run entry (a run action available on valid
-	// starts even in view mode, where the on-node Run pill is hidden) plus the
-	// edit-only lifecycle action. The single-step / cascade run options stay on
-	// the Run button's caret popover.
-	let menuItems: Item[] = $derived([
-		...(data.onStartBoundedRun
-			? [
-					{
-						displayName: 'Run downstream up to…',
-						icon: Target,
-						action: () => data.onStartBoundedRun?.()
-					}
-				]
-			: []),
-		...(data.onRequestRemove
+	// Cascade + bounded-run options live on the Run button's caret popover
+	// (when `downstreamCount > 0`), so the kebab menu stays focused on
+	// lifecycle actions only.
+	let menuItems: Item[] = $derived(
+		data.onRequestRemove
 			? [
 					{
 						displayName: data.unsaved ? 'Discard' : 'Delete…',
@@ -141,8 +131,8 @@
 						action: () => data.onRequestRemove?.()
 					}
 				]
-			: [])
-	])
+			: []
+	)
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -332,6 +322,26 @@
 									{/if}
 								</div>
 							</button>
+							{#if data.onStartBoundedRun}
+								<button
+									type="button"
+									class="w-full text-left px-3 py-2 hover:bg-surface-hover flex items-start gap-2 border-t"
+									onclick={(e) => {
+										e.stopPropagation()
+										cascadeMenuOpen = false
+										data.onStartBoundedRun?.()
+									}}
+								>
+									<Target size={14} class="mt-0.5 shrink-0 text-secondary" />
+									<div class="flex flex-col min-w-0">
+										<span class="font-medium">Run downstream up to…</span>
+										<span class="text-2xs text-secondary">
+											Pick end node(s) on the graph, then run only the cascade between this
+											script and them.
+										</span>
+									</div>
+								</button>
+							{/if}
 						</div>
 					{/snippet}
 				</Popover>

--- a/frontend/src/lib/components/assets/AssetGraph/RunnableNode.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/RunnableNode.svelte
@@ -11,6 +11,7 @@
 		Play,
 		RotateCw,
 		Tag,
+		Target,
 		Timer,
 		Trash2,
 		XCircle,
@@ -67,6 +68,10 @@
 			// "Discard" for drafts, "Delete…" (which the page maps to its
 			// archive/delete confirmation flow) for persisted scripts.
 			onRequestRemove?: () => void
+			// Wired only for valid bounded-run starts (schedule / manual roots
+			// with downstream). Enters the page's end-node pick mode for a
+			// bounded cascade rooted at this script.
+			onStartBoundedRun?: () => void
 		}
 		// SvelteFlow injects this when the user clicks the node. Combined with
 		// hover state to drive the run-button visibility (same pattern as
@@ -113,11 +118,21 @@
 		}
 	}
 
-	// Cascade option is surfaced directly on the Run button (via a caret +
-	// popover) when `downstreamCount > 0`, so the kebab menu stays focused
-	// on lifecycle actions only.
-	let menuItems: Item[] = $derived(
-		data.onRequestRemove
+	// Kebab menu: the bounded-run entry (a run action available on valid
+	// starts even in view mode, where the on-node Run pill is hidden) plus the
+	// edit-only lifecycle action. The single-step / cascade run options stay on
+	// the Run button's caret popover.
+	let menuItems: Item[] = $derived([
+		...(data.onStartBoundedRun
+			? [
+					{
+						displayName: 'Run downstream up to…',
+						icon: Target,
+						action: () => data.onStartBoundedRun?.()
+					}
+				]
+			: []),
+		...(data.onRequestRemove
 			? [
 					{
 						displayName: data.unsaved ? 'Discard' : 'Delete…',
@@ -126,8 +141,8 @@
 						action: () => data.onRequestRemove?.()
 					}
 				]
-			: []
-	)
+			: [])
+	])
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/frontend/src/lib/components/assets/AssetGraph/RunnableNode.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/RunnableNode.svelte
@@ -119,8 +119,8 @@
 	}
 
 	// Cascade + bounded-run options live on the Run button's caret popover
-	// (when `downstreamCount > 0`), so the kebab menu stays focused on
-	// lifecycle actions only.
+	// (whenever there's a cascade OR a bounded-run start — see `hasCaret`
+	// below), so the kebab menu stays focused on lifecycle actions only.
 	let menuItems: Item[] = $derived(
 		data.onRequestRemove
 			? [
@@ -243,6 +243,11 @@
 		     + trigger N downstream". Matches the editor Test split button
 		     so the affordance is identical on both surfaces. -->
 		{@const hasCascade = (data.downstreamCount ?? 0) > 0}
+		<!-- The caret popover opens for either a subscriber cascade OR a
+		     bounded-run start. A pure-reader-only root has no subscriber
+		     downstream (`downstreamCount === 0`) but still gets `onStartBoundedRun`
+		     — without this it would have no visible "Run downstream up to…". -->
+		{@const hasCaret = hasCascade || !!data.onStartBoundedRun}
 		<div class="absolute -left-3 top-1/2 -translate-y-1/2 z-10 flex items-stretch">
 			<button
 				type="button"
@@ -250,7 +255,7 @@
 				disabled={running}
 				class={twMerge(
 					'bg-blue-500 hover:bg-blue-600 disabled:opacity-60 text-white grid place-items-center shadow border-2 border-surface-secondary leading-none',
-					hasCascade ? 'rounded-l-full w-6 h-6 border-r-0' : 'rounded-full w-6 h-6'
+					hasCaret ? 'rounded-l-full w-6 h-6 border-r-0' : 'rounded-full w-6 h-6'
 				)}
 				title={`Run ${data.path}${data.unsaved ? ' (draft, runs as preview)' : ''}`}
 			>
@@ -260,7 +265,7 @@
 					<Play size={14} strokeWidth={2.5} class="translate-x-px" />
 				{/if}
 			</button>
-			{#if hasCascade}
+			{#if hasCaret}
 				<Popover
 					placement="bottom-start"
 					bind:isOpen={cascadeMenuOpen}
@@ -292,36 +297,38 @@
 									</span>
 								</div>
 							</button>
-							<button
-								type="button"
-								class="w-full text-left px-3 py-2 hover:bg-surface-hover flex items-start gap-2"
-								onclick={(e) => {
-									close()
-									void runSelf(e, true)
-								}}
-							>
-								<Zap size={14} class="mt-0.5 shrink-0 text-secondary" />
-								<div class="flex flex-col min-w-0">
-									<span class="font-medium">
-										Run + trigger {data.downstreamCount} downstream
-									</span>
-									<span class="text-2xs text-secondary">
-										Let the asset-trigger cascade fan out to the {data.downstreamCount}
-										subscribed script{data.downstreamCount === 1 ? '' : 's'} after this run succeeds.
-									</span>
-									{#if data.unsaved || (data.downstreamUnsavedCount ?? 0) > 0}
-										<span class="text-2xs text-amber-700 dark:text-amber-400">
-											{#if data.unsaved}
-												Unsaved chain — runs as previews in dependency order.
-											{:else}
-												{data.downstreamUnsavedCount} unsaved — chain runs as previews in dependency
-												order.
-											{/if}
-											Deploy to enable automatic triggering.
+							{#if hasCascade}
+								<button
+									type="button"
+									class="w-full text-left px-3 py-2 hover:bg-surface-hover flex items-start gap-2"
+									onclick={(e) => {
+										close()
+										void runSelf(e, true)
+									}}
+								>
+									<Zap size={14} class="mt-0.5 shrink-0 text-secondary" />
+									<div class="flex flex-col min-w-0">
+										<span class="font-medium">
+											Run + trigger {data.downstreamCount} downstream
 										</span>
-									{/if}
-								</div>
-							</button>
+										<span class="text-2xs text-secondary">
+											Let the asset-trigger cascade fan out to the {data.downstreamCount}
+											subscribed script{data.downstreamCount === 1 ? '' : 's'} after this run succeeds.
+										</span>
+										{#if data.unsaved || (data.downstreamUnsavedCount ?? 0) > 0}
+											<span class="text-2xs text-amber-700 dark:text-amber-400">
+												{#if data.unsaved}
+													Unsaved chain — runs as previews in dependency order.
+												{:else}
+													{data.downstreamUnsavedCount} unsaved — chain runs as previews in dependency
+													order.
+												{/if}
+												Deploy to enable automatic triggering.
+											</span>
+										{/if}
+									</div>
+								</button>
+							{/if}
 							{#if data.onStartBoundedRun}
 								<button
 									type="button"
@@ -336,8 +343,8 @@
 									<div class="flex flex-col min-w-0">
 										<span class="font-medium">Run downstream up to…</span>
 										<span class="text-2xs text-secondary">
-											Pick end node(s) on the graph, then run only the cascade between this
-											script and them.
+											Pick end node(s) on the graph, then run only the cascade between this script
+											and them.
 										</span>
 									</div>
 								</button>

--- a/frontend/src/lib/components/assets/AssetGraph/TriggerNode.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/TriggerNode.svelte
@@ -60,7 +60,7 @@
 	import { Handle, Position } from '@xyflow/svelte'
 	import { NODE } from '$lib/components/graph/util'
 	import { twMerge } from 'tailwind-merge'
-	import { AlertTriangle, EllipsisVertical, Trash2 } from 'lucide-svelte'
+	import { AlertTriangle, EllipsisVertical, Target, Trash2 } from 'lucide-svelte'
 	import DropdownV2 from '$lib/components/DropdownV2.svelte'
 	import { stopPropagation, preventDefault } from 'svelte/legacy'
 	import type { Item } from '$lib/utils'
@@ -113,6 +113,12 @@
 			// trigger. Confirmation is the caller's responsibility — the
 			// node just exposes the entry point on the kebab menu.
 			onDeleteTrigger?: (kind: NativeTriggerKind, triggerPath: string) => void
+			// Wired by the canvas only when this trigger's target script is a
+			// valid bounded-run start (schedule / manual root) with downstream.
+			// Entering the page's end-node pick mode rooted at that script — the
+			// View-mode entry point for bounded runs (the script's own Run-button
+			// caret is Edit-only).
+			onStartBoundedRun?: () => void
 		}
 	}
 	let { data }: Props = $props()
@@ -173,8 +179,17 @@
 			!!data.onDeleteTrigger
 	)
 
-	let menuItems: Item[] = $derived(
-		canDelete
+	let menuItems: Item[] = $derived([
+		...(data.onStartBoundedRun
+			? [
+					{
+						displayName: 'Run downstream up to…',
+						icon: Target,
+						action: () => data.onStartBoundedRun?.()
+					}
+				]
+			: []),
+		...(canDelete
 			? [
 					{
 						displayName: 'Delete…',
@@ -182,12 +197,12 @@
 						type: 'delete' as const,
 						action: () => {
 							if (!data.ref || !data.onDeleteTrigger) return
-							data.onDeleteTrigger(data.kind as NativeTriggerKind, data.ref)
+							data.onDeleteTrigger?.(data.kind as NativeTriggerKind, data.ref)
 						}
 					}
 				]
-			: []
-	)
+			: [])
+	])
 
 	function handleMissingClick() {
 		if (!canCreate || !data.runnable_path || !data.onCreateMissingTrigger) return

--- a/frontend/src/lib/components/assets/AssetGraph/boundedCascade.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/boundedCascade.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from 'vitest'
+import type { AssetGraphResponse, AssetGraphTrigger, NativeTriggerKind } from './types'
+import {
+	ancestors,
+	assetUriToNodeId,
+	boundedSet,
+	buildLineageDag,
+	buildLineageDownstreamMap,
+	descendants,
+	scriptNodeId,
+	scriptsOf,
+	validStarts
+} from './boundedCascade'
+import { computeInducedSchedule } from './graphTraversal'
+
+type W = [script: string, asset: string] // producer write edge (datatable)
+type R = [script: string, asset: string] // pure-read edge (datatable)
+type S = [script: string, asset: string] // `// on <asset>` subscription
+
+function graph(opts: {
+	scripts?: string[]
+	writes?: W[]
+	reads?: R[]
+	subs?: S[]
+	native?: Array<[kind: NativeTriggerKind, script: string]>
+}): AssetGraphResponse {
+	const { scripts = [], writes = [], reads = [], subs = [], native = [] } = opts
+	const triggers: AssetGraphTrigger[] = [
+		...subs.map(
+			([s, a]) =>
+				({
+					trigger_kind: 'asset',
+					asset_kind: 'datatable',
+					asset_path: a,
+					runnable_kind: 'script',
+					runnable_path: s
+				}) as const
+		),
+		...native.map(
+			([kind, s]) =>
+				({ trigger_kind: kind, runnable_kind: 'script', runnable_path: s }) as AssetGraphTrigger
+		)
+	]
+	return {
+		assets: [],
+		runnables: scripts.map((p) => ({ path: p, usage_kind: 'script' as const })),
+		edges: [
+			...writes.map(([s, a]) => ({
+				runnable_path: s,
+				runnable_kind: 'script' as const,
+				asset_kind: 'datatable' as const,
+				asset_path: a,
+				access_type: 'w' as const
+			})),
+			...reads.map(([s, a]) => ({
+				runnable_path: s,
+				runnable_kind: 'script' as const,
+				asset_kind: 'datatable' as const,
+				asset_path: a,
+				access_type: 'r' as const
+			}))
+		],
+		triggers
+	}
+}
+
+const sn = scriptNodeId
+const asset = (p: string) => `datatable:${p}`
+
+describe('buildLineageDag', () => {
+	it('links producer → asset → subscriber and asset → reader', () => {
+		// a writes x; b subscribes to x; c reads x.
+		const g = graph({ writes: [['a', 'x']], subs: [['b', 'x']], reads: [['c', 'x']] })
+		const dag = buildLineageDag(g)
+		expect([...(dag.down.get(sn('a')) ?? [])]).toEqual([asset('x')])
+		expect([...(dag.down.get(asset('x')) ?? [])].sort()).toEqual([sn('b'), sn('c')])
+	})
+
+	it('treats rw as production only (no self-cycle through the asset)', () => {
+		const g: AssetGraphResponse = {
+			assets: [],
+			runnables: [{ path: 'u', usage_kind: 'script' }],
+			edges: [
+				{
+					runnable_path: 'u',
+					runnable_kind: 'script',
+					asset_kind: 'datatable',
+					asset_path: 'x',
+					access_type: 'rw'
+				}
+			],
+			triggers: []
+		}
+		const dag = buildLineageDag(g)
+		expect([...(dag.down.get(sn('u')) ?? [])]).toEqual([asset('x')])
+		expect(dag.up.get(sn('u'))).toBeUndefined() // asset is not upstream of its own writer
+	})
+})
+
+describe('ancestors / descendants', () => {
+	it('walks transitively over scripts and assets', () => {
+		// a → x → b → y → c
+		const g = graph({
+			writes: [
+				['a', 'x'],
+				['b', 'y']
+			],
+			subs: [
+				['b', 'x'],
+				['c', 'y']
+			]
+		})
+		const dag = buildLineageDag(g)
+		expect(descendants(dag, sn('a'))).toEqual(new Set([asset('x'), sn('b'), asset('y'), sn('c')]))
+		expect(ancestors(dag, sn('c'))).toEqual(new Set([asset('y'), sn('b'), asset('x'), sn('a')]))
+	})
+})
+
+describe('boundedSet', () => {
+	// a → x → b → y → c → z → d  (linear chain through assets)
+	const chain = () =>
+		graph({
+			writes: [
+				['a', 'x'],
+				['b', 'y'],
+				['c', 'z']
+			],
+			subs: [
+				['b', 'x'],
+				['c', 'y'],
+				['d', 'z']
+			]
+		})
+
+	it('stops at a single end node (script)', () => {
+		const dag = buildLineageDag(chain())
+		const res = boundedSet(dag, sn('a'), [sn('c')])
+		// path a..c includes a,x,b,y,c — not z or d.
+		expect(scriptsOf(res.nodes).sort()).toEqual(['a', 'b', 'c'])
+		expect(res.nodes.has(asset('z'))).toBe(false)
+		expect(res.droppedEnds).toEqual([])
+	})
+
+	it('supports an asset as the end bound', () => {
+		const dag = buildLineageDag(chain())
+		const res = boundedSet(dag, sn('a'), [asset('y')])
+		// up to datatable://y → a, b produced it.
+		expect(scriptsOf(res.nodes).sort()).toEqual(['a', 'b'])
+	})
+
+	it('unions multiple ends', () => {
+		// diamond: a → b and a → c, both → d. Bound to {b, c} excludes d.
+		const g = graph({
+			writes: [
+				['a', 'xa'],
+				['b', 'xb'],
+				['c', 'xc']
+			],
+			subs: [
+				['b', 'xa'],
+				['c', 'xa'],
+				['d', 'xb'],
+				['d', 'xc']
+			]
+		})
+		const dag = buildLineageDag(g)
+		const res = boundedSet(dag, sn('a'), [sn('b'), sn('c')])
+		expect(scriptsOf(res.nodes).sort()).toEqual(['a', 'b', 'c'])
+	})
+
+	it('drops ends not downstream of start', () => {
+		const dag = buildLineageDag(chain())
+		const res = boundedSet(dag, sn('c'), [sn('a')])
+		expect(res.droppedEnds).toEqual([sn('a')])
+		expect(res.reachableEnds).toEqual([])
+		expect([...res.nodes]).toEqual([sn('c')])
+	})
+
+	it('is cycle-safe', () => {
+		// b ↔ c cycle downstream of a; bounding to c terminates.
+		const g = graph({
+			writes: [
+				['a', 'x'],
+				['b', 'y'],
+				['c', 'z']
+			],
+			subs: [
+				['b', 'x'],
+				['c', 'y'],
+				['b', 'z']
+			]
+		})
+		const dag = buildLineageDag(g)
+		const res = boundedSet(dag, sn('a'), [sn('c')])
+		expect(scriptsOf(res.nodes).sort()).toEqual(['a', 'b', 'c'])
+	})
+})
+
+describe('validStarts', () => {
+	it('includes schedule-rooted scripts', () => {
+		const g = graph({ scripts: ['s'], native: [['schedule', 's']] })
+		expect(validStarts(g)).toEqual(new Set([sn('s')]))
+	})
+
+	it('includes manual roots (no trigger, not a subscriber)', () => {
+		const g = graph({ scripts: ['m'] })
+		expect(validStarts(g)).toEqual(new Set([sn('m')]))
+	})
+
+	it('excludes event-only roots', () => {
+		const g = graph({ scripts: ['k'], native: [['kafka', 'k']] })
+		expect(validStarts(g).has(sn('k'))).toBe(false)
+	})
+
+	it('excludes pure asset subscribers but keeps a schedule subscriber', () => {
+		// sub is `// on x`; sched is both a subscriber and schedule-triggered.
+		const g = graph({
+			scripts: ['a', 'sub', 'sched'],
+			writes: [['a', 'x']],
+			subs: [
+				['sub', 'x'],
+				['sched', 'x']
+			],
+			native: [['schedule', 'sched']]
+		})
+		const starts = validStarts(g)
+		expect(starts.has(sn('a'))).toBe(true) // manual root
+		expect(starts.has(sn('sub'))).toBe(false) // event-less but a subscriber
+		expect(starts.has(sn('sched'))).toBe(true) // schedule overrides subscriber
+	})
+})
+
+describe('buildLineageDownstreamMap (read-aware scheduling)', () => {
+	// a writes x; c only *reads* x (no `// on x`). c must still run after a.
+	const g = graph({
+		scripts: ['a', 'c'],
+		writes: [['a', 'x']],
+		reads: [['c', 'x']]
+	})
+
+	it('links a producer to a pure reader of its asset', () => {
+		const map = buildLineageDownstreamMap(g)
+		expect([...(map.get('a') ?? [])]).toEqual(['c'])
+	})
+
+	it('orders the reader after the producer through computeInducedSchedule', () => {
+		const selected = new Set(['a', 'c'])
+		// Subscriber-only map (default) misses the read dep → c is a stray root.
+		const subscriberOnly = computeInducedSchedule(g, selected)
+		expect(subscriberOnly.roots.sort()).toEqual(['a', 'c'])
+		// Read-aware map orders c strictly after a.
+		const readAware = computeInducedSchedule(g, selected, buildLineageDownstreamMap(g))
+		expect(readAware.roots).toEqual(['a'])
+		expect(readAware.indegree.get('c')).toBe(1)
+		expect(readAware.nodes).toEqual(['a', 'c'])
+	})
+})
+
+describe('assetUriToNodeId', () => {
+	it('maps s3 prefix to the s3object kind, others verbatim', () => {
+		expect(assetUriToNodeId('s3://bucket/key')).toBe('s3object:bucket/key')
+		expect(assetUriToNodeId('datatable://prod/users')).toBe('datatable:prod/users')
+		expect(assetUriToNodeId('ducklake://lake/t')).toBe('ducklake:lake/t')
+		expect(assetUriToNodeId('not-a-uri')).toBeUndefined()
+	})
+})

--- a/frontend/src/lib/components/assets/AssetGraph/boundedCascade.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/boundedCascade.test.ts
@@ -114,6 +114,23 @@ describe('ancestors / descendants', () => {
 		expect(descendants(dag, sn('a'))).toEqual(new Set([asset('x'), sn('b'), asset('y'), sn('c')]))
 		expect(ancestors(dag, sn('c'))).toEqual(new Set([asset('y'), sn('b'), asset('x'), sn('a')]))
 	})
+
+	it('excludes the start node even on a cycle back to it', () => {
+		// a → x → b → y → a (cycle): descendants(a) must not contain a.
+		const g = graph({
+			writes: [
+				['a', 'x'],
+				['b', 'y']
+			],
+			subs: [
+				['b', 'x'],
+				['a', 'y']
+			]
+		})
+		const dag = buildLineageDag(g)
+		expect(descendants(dag, sn('a')).has(sn('a'))).toBe(false)
+		expect(ancestors(dag, sn('a')).has(sn('a'))).toBe(false)
+	})
 })
 
 describe('boundedSet', () => {

--- a/frontend/src/lib/components/assets/AssetGraph/boundedCascade.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/boundedCascade.ts
@@ -1,0 +1,232 @@
+import type { AssetGraphResponse, NativeTriggerKind } from './types'
+import { assetKey, isWriteEdge } from './lib'
+
+// Bounded-cascade selective execution: instead of a dbt-style `--select`
+// grammar (a compile-time file selector dbt needs because it has no runtime
+// DAG), Windmill already runs a live cascade. So the primitive here is to
+// *bound* that cascade — start at a pipeline entrypoint, fan downstream, but
+// stop at one or more chosen end node(s). The matched set is the "path
+// between" start and the ends:
+//
+//     descendants(start) ∩ (ancestors(ends) ∪ ends) ∪ {start}
+//
+// Pure module (no Svelte runes) so the graph algebra is unit-testable and can
+// be ported verbatim to the CLI. See `boundedCascade.test.ts`, and the mirror
+// at `cli/src/commands/pipeline/boundedCascade.ts` (keep them in sync).
+
+// Unified lineage-DAG node ids. Assets use `${asset_kind}:${asset_path}`
+// (identical to `assetKey`); runnables are prefixed so a script path can never
+// collide with an asset key. Flows are excluded — they aren't cascade members
+// (mirrors graphTraversal/asset_dispatch).
+export const SCRIPT_PREFIX = 'script:'
+
+export function scriptNodeId(path: string): string {
+	return `${SCRIPT_PREFIX}${path}`
+}
+export function isScriptNode(id: string): boolean {
+	return id.startsWith(SCRIPT_PREFIX)
+}
+export function scriptPathOf(id: string): string {
+	return id.slice(SCRIPT_PREFIX.length)
+}
+
+/** Resolve an asset URI (`datatable://x`, `s3://b/k`, …) to its node id. */
+export function assetUriToNodeId(uri: string): string | undefined {
+	const m = uri.match(/^([a-z0-9_]+):\/\/(.+)$/i)
+	if (!m) return undefined
+	const prefix = m[1].toLowerCase()
+	// `s3` is the URI prefix for the `s3object` asset kind (mirrors the CLI
+	// `assetUri` and the canvas). All other kinds use their name verbatim.
+	const kind = prefix === 's3' ? 's3object' : prefix
+	return `${kind}:${m[2]}`
+}
+
+// Native trigger kinds that fan out *per event*: a single event always flows
+// through the whole reactive downstream, so "run up to X now" is not a
+// meaningful gesture and these are never offered as bounded-run starts.
+// `webhook`/`data_upload` have no trigger row in `/assets/graph`, so a root
+// whose only entry is one of those reads as a *manual* root below.
+const EVENT_TRIGGER_KINDS: ReadonlySet<string> = new Set<NativeTriggerKind>([
+	'kafka',
+	'mqtt',
+	'nats',
+	'postgres',
+	'sqs',
+	'gcp',
+	'email'
+])
+
+export type LineageDag = {
+	/** upstream node id → set of direct downstream node ids. */
+	down: Map<string, Set<string>>
+	/** downstream node id → set of direct upstream node ids. */
+	up: Map<string, Set<string>>
+	/** Every node id (scripts + assets), including isolated ones. */
+	nodes: Set<string>
+}
+
+/**
+ * Build the directed upstream→downstream lineage DAG over scripts ∪ assets:
+ *   - producer script → asset   (write / rw edges)
+ *   - asset → reader script      (pure-read edges — a data dependency)
+ *   - asset → subscriber script  (`// on <asset>` triggers)
+ *
+ * An `rw` edge is treated as production only (script → asset); emitting the
+ * reverse asset → script too would make every upsert a 2-cycle through its own
+ * asset.
+ */
+export function buildLineageDag(g: AssetGraphResponse): LineageDag {
+	const down = new Map<string, Set<string>>()
+	const up = new Map<string, Set<string>>()
+	const nodes = new Set<string>()
+
+	const addEdge = (a: string, b: string) => {
+		if (a === b) return
+		nodes.add(a)
+		nodes.add(b)
+		;(down.get(a) ?? down.set(a, new Set()).get(a)!).add(b)
+		;(up.get(b) ?? up.set(b, new Set()).get(b)!).add(a)
+	}
+
+	// Register every node up front so isolated scripts/assets still appear.
+	for (const r of g.runnables ?? []) {
+		if (r.usage_kind === 'script') nodes.add(scriptNodeId(r.path))
+	}
+	for (const a of g.assets ?? []) nodes.add(`${a.kind}:${a.path}`)
+
+	for (const e of g.edges ?? []) {
+		if (e.runnable_kind !== 'script') continue
+		const aid = assetKey(e)
+		if (isWriteEdge(e)) {
+			addEdge(scriptNodeId(e.runnable_path), aid)
+		} else if ((e.access_type ?? 'r') === 'r') {
+			addEdge(aid, scriptNodeId(e.runnable_path))
+		}
+	}
+	for (const t of g.triggers ?? []) {
+		if (t.trigger_kind !== 'asset' || t.runnable_kind !== 'script') continue
+		addEdge(assetKey(t), scriptNodeId(t.runnable_path))
+	}
+
+	return { down, up, nodes }
+}
+
+/** BFS closure over an adjacency map, excluding `start`. */
+function closure(adj: Map<string, Set<string>>, start: string): Set<string> {
+	const seen = new Set<string>()
+	const queue = [start]
+	while (queue.length > 0) {
+		const cur = queue.shift()!
+		for (const n of adj.get(cur) ?? []) {
+			if (seen.has(n)) continue
+			seen.add(n)
+			queue.push(n)
+		}
+	}
+	return seen
+}
+
+/** Transitive downstream of `n` (excludes `n`). Cycle-safe. */
+export function descendants(dag: LineageDag, n: string): Set<string> {
+	return closure(dag.down, n)
+}
+/** Transitive upstream of `n` (excludes `n`). Cycle-safe. */
+export function ancestors(dag: LineageDag, n: string): Set<string> {
+	return closure(dag.up, n)
+}
+
+export type BoundedResult = {
+	/** Path-between node set (scripts + assets), always including `start`. */
+	nodes: Set<string>
+	/** Ends that are actually reachable downstream of `start`. */
+	reachableEnds: string[]
+	/** Ends passed in that are not downstream of `start` (ignored, surfaced). */
+	droppedEnds: string[]
+}
+
+/**
+ * Nodes on any path from `start` to any of `ends` (inclusive of both). Ends
+ * not reachable from `start` are dropped and reported. With no reachable end
+ * the result is just `{start}` — the caller decides whether to warn or fall
+ * back to the full downstream.
+ */
+export function boundedSet(dag: LineageDag, start: string, ends: string[]): BoundedResult {
+	const desc = descendants(dag, start)
+	const downSet = new Set(desc)
+	downSet.add(start)
+
+	const reachableEnds = ends.filter((e) => downSet.has(e))
+	const droppedEnds = ends.filter((e) => !downSet.has(e))
+	if (reachableEnds.length === 0) {
+		return { nodes: new Set([start]), reachableEnds, droppedEnds }
+	}
+
+	const upClosure = new Set<string>()
+	for (const e of reachableEnds) {
+		upClosure.add(e)
+		for (const a of ancestors(dag, e)) upClosure.add(a)
+	}
+	const nodes = new Set<string>()
+	for (const n of downSet) if (upClosure.has(n)) nodes.add(n)
+	nodes.add(start)
+	return { nodes, reachableEnds, droppedEnds }
+}
+
+/**
+ * Script node ids eligible to *start* a bounded run: schedule-triggered
+ * scripts, or manual roots (not an asset subscriber and not event-triggered).
+ * Event-driven entrypoints are excluded — they have no "run up to X" gesture.
+ */
+export function validStarts(g: AssetGraphResponse): Set<string> {
+	const subscribers = new Set<string>()
+	const scheduleScripts = new Set<string>()
+	const eventScripts = new Set<string>()
+	for (const t of g.triggers ?? []) {
+		if (t.runnable_kind !== 'script') continue
+		if (t.trigger_kind === 'asset') subscribers.add(t.runnable_path)
+		else if (t.trigger_kind === 'schedule') scheduleScripts.add(t.runnable_path)
+		else if (EVENT_TRIGGER_KINDS.has(t.trigger_kind)) eventScripts.add(t.runnable_path)
+	}
+
+	const out = new Set<string>()
+	for (const r of g.runnables ?? []) {
+		if (r.usage_kind !== 'script') continue
+		const p = r.path
+		if (scheduleScripts.has(p)) out.add(scriptNodeId(p))
+		else if (!subscribers.has(p) && !eventScripts.has(p)) out.add(scriptNodeId(p))
+	}
+	return out
+}
+
+/** Project a node-id set to the script paths it contains (run targets). */
+export function scriptsOf(nodes: Iterable<string>): string[] {
+	const out: string[] = []
+	for (const id of nodes) if (isScriptNode(id)) out.push(scriptPathOf(id))
+	return out
+}
+
+/**
+ * Producer→consumer adjacency (script path → downstream script paths) over the
+ * lineage DAG: one hop through a single asset, following BOTH `// on`
+ * subscribers *and* pure-read data dependencies. Unlike
+ * `graphTraversal.buildDownstreamMap` (subscriber-only, which models the
+ * production dispatch), this orders a script that merely reads an upstream
+ * asset after its producer — so a bounded selection containing such a reader
+ * schedules correctly. Mirror of the CLI `topoOrder` adjacency.
+ */
+export function buildLineageDownstreamMap(g: AssetGraphResponse): Map<string, Set<string>> {
+	const dag = buildLineageDag(g)
+	const map = new Map<string, Set<string>>()
+	for (const id of dag.nodes) {
+		if (!isScriptNode(id)) continue
+		const s = scriptPathOf(id)
+		const subs = new Set<string>()
+		for (const asset of dag.down.get(id) ?? []) {
+			for (const sub of dag.down.get(asset) ?? []) {
+				if (isScriptNode(sub) && scriptPathOf(sub) !== s) subs.add(scriptPathOf(sub))
+			}
+		}
+		if (subs.size > 0) map.set(s, subs)
+	}
+	return map
+}

--- a/frontend/src/lib/components/assets/AssetGraph/boundedCascade.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/boundedCascade.ts
@@ -123,6 +123,9 @@ function closure(adj: Map<string, Set<string>>, start: string): Set<string> {
 			queue.push(n)
 		}
 	}
+	// A cycle back to `start` would have re-added it; the contract is to
+	// exclude the node itself.
+	seen.delete(start)
 	return seen
 }
 

--- a/frontend/src/lib/components/assets/AssetGraph/cascadeOrchestrator.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/cascadeOrchestrator.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { runCascade } from './cascadeOrchestrator'
-import type { DownstreamClosure } from './graphTraversal'
+import { runCascade, runSelection } from './cascadeOrchestrator'
+import type { DownstreamClosure, InducedSchedule } from './graphTraversal'
 
 function closure(edges: Array<[from: string, to: string]>, nodes: string[]): DownstreamClosure {
 	const e = new Map<string, Set<string>>()
@@ -159,5 +159,60 @@ describe('runCascade', () => {
 		expect(r.launched).toEqual(['a'])
 		expect(res.statuses.get('b')?.status).toBe('skipped')
 		expect(res.statuses.get('c')?.status).toBe('skipped')
+	})
+})
+
+function schedule(
+	edges: Array<[from: string, to: string]>,
+	nodes: string[],
+	roots: string[]
+): InducedSchedule {
+	const e = new Map<string, Set<string>>()
+	const indegree = new Map<string, number>()
+	for (const n of nodes) indegree.set(n, 0)
+	for (const [from, to] of edges) {
+		const set = e.get(from) ?? new Set()
+		set.add(to)
+		e.set(from, set)
+		indegree.set(to, (indegree.get(to) ?? 0) + 1)
+	}
+	return { nodes, edges: e, indegree, roots, cyclic: [] }
+}
+
+describe('runSelection', () => {
+	it('runs every selected node, seeding all roots', async () => {
+		// two independent roots a, b each → c.
+		const sched = schedule(
+			[
+				['a', 'c'],
+				['b', 'c']
+			],
+			['a', 'b', 'c'],
+			['a', 'b']
+		)
+		const r = fakeRunner()
+		const res = await runSelection({ schedule: sched, ...r })
+		expect(res.ok).toBe(true)
+		expect(r.launched.sort()).toEqual(['a', 'b', 'c'])
+		// c only after both upstreams.
+		expect(r.launched.indexOf('c')).toBeGreaterThan(r.launched.indexOf('a'))
+		expect(r.launched.indexOf('c')).toBeGreaterThan(r.launched.indexOf('b'))
+	})
+
+	it('stops scheduling after a failure', async () => {
+		const sched = schedule([['a', 'b']], ['a', 'b'], ['a'])
+		const r = fakeRunner({ a: 'failure' })
+		const res = await runSelection({ schedule: sched, ...r })
+		expect(res.ok).toBe(false)
+		expect(r.launched).toEqual(['a'])
+		expect(res.statuses.get('b')?.status).toBe('skipped')
+	})
+
+	it('a single-node selection runs that node', async () => {
+		const sched = schedule([], ['a'], ['a'])
+		const r = fakeRunner()
+		const res = await runSelection({ schedule: sched, ...r })
+		expect(res.ok).toBe(true)
+		expect(r.launched).toEqual(['a'])
 	})
 })

--- a/frontend/src/lib/components/assets/AssetGraph/cascadeOrchestrator.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/cascadeOrchestrator.test.ts
@@ -193,7 +193,9 @@ describe('runSelection', () => {
 		const r = fakeRunner()
 		const res = await runSelection({ schedule: sched, ...r })
 		expect(res.ok).toBe(true)
-		expect(r.launched.sort()).toEqual(['a', 'b', 'c'])
+		// Sort a copy for the membership check — mutating `r.launched` here
+		// would invalidate the launch-order assertions below.
+		expect([...r.launched].sort()).toEqual(['a', 'b', 'c'])
 		// c only after both upstreams.
 		expect(r.launched.indexOf('c')).toBeGreaterThan(r.launched.indexOf('a'))
 		expect(r.launched.indexOf('c')).toBeGreaterThan(r.launched.indexOf('b'))

--- a/frontend/src/lib/components/assets/AssetGraph/cascadeOrchestrator.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/cascadeOrchestrator.ts
@@ -1,4 +1,4 @@
-import type { DownstreamClosure } from './graphTraversal'
+import type { DownstreamClosure, InducedSchedule } from './graphTraversal'
 
 // Client-side orchestration of a pipeline chain dev-run ("Run + downstream"
 // over a graph that contains drafts). The backend asset-trigger dispatcher
@@ -100,6 +100,85 @@ export async function runCascade(opts: CascadeRunOptions): Promise<CascadeRunRes
 	}
 
 	schedule(root)
+	while (inFlight.size > 0) {
+		await Promise.race(inFlight)
+	}
+
+	for (const [n, st] of statuses) {
+		if (st.status === 'pending') statuses.set(n, { status: 'skipped' })
+	}
+	emit()
+
+	const ok = !failed && [...statuses.values()].every((s) => s.status === 'success')
+	return { ok, statuses }
+}
+
+export type SelectionRunOptions = {
+	/** Multi-root induced schedule of the selected scripts (computeInducedSchedule). */
+	schedule: InducedSchedule
+	/** Launch one script (preview for drafts, by-path for deployed); returns the job id. */
+	launch: (path: string) => Promise<string>
+	/** Resolve once the job reaches a terminal state. */
+	waitTerminal: (jobId: string) => Promise<'success' | 'failure'>
+	/** Snapshot of all node states, emitted on every transition. */
+	onUpdate?: (statuses: Map<string, CascadeNodeState>) => void
+}
+
+/**
+ * Execute an arbitrary selected set of scripts (e.g. a bounded-cascade
+ * selection) in topological order. Unlike `runCascade` there is no single
+ * privileged root — every `schedule.roots` entry is seeded at once and a node
+ * runs as soon as its in-set upstreams all succeed. Failure stops *scheduling*
+ * (in-flight jobs finish); everything not yet started ends 'skipped'.
+ */
+export async function runSelection(opts: SelectionRunOptions): Promise<CascadeRunResult> {
+	const { schedule, launch, waitTerminal, onUpdate } = opts
+	const statuses = new Map<string, CascadeNodeState>()
+	for (const n of schedule.nodes) statuses.set(n, { status: 'pending' })
+	const remaining = new Map(schedule.indegree)
+	let failed = false
+	const inFlight = new Set<Promise<void>>()
+
+	const emit = () => onUpdate?.(new Map(statuses))
+
+	function schedule_(path: string) {
+		const p = runNode(path).finally(() => inFlight.delete(p))
+		inFlight.add(p)
+	}
+
+	async function runNode(path: string): Promise<void> {
+		statuses.set(path, { status: 'running' })
+		emit()
+		let jobId: string | undefined
+		try {
+			jobId = await launch(path)
+			statuses.set(path, { status: 'running', jobId })
+			emit()
+			const term = await waitTerminal(jobId)
+			statuses.set(path, { status: term, jobId })
+			emit()
+			if (term === 'failure') {
+				failed = true
+				return
+			}
+		} catch (e) {
+			statuses.set(path, {
+				status: 'failure',
+				jobId,
+				error: e instanceof Error ? e.message : String(e)
+			})
+			emit()
+			failed = true
+			return
+		}
+		for (const s of schedule.edges.get(path) ?? []) {
+			const d = (remaining.get(s) ?? 0) - 1
+			remaining.set(s, d)
+			if (d === 0 && !failed) schedule_(s)
+		}
+	}
+
+	for (const r of schedule.roots) schedule_(r)
 	while (inFlight.size > 0) {
 		await Promise.race(inFlight)
 	}

--- a/frontend/src/lib/components/assets/AssetGraph/graphTraversal.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/graphTraversal.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { AssetGraphResponse } from './types'
-import { buildDownstreamMap, computeDownstreamClosure } from './graphTraversal'
+import {
+	buildDownstreamMap,
+	computeDownstreamClosure,
+	computeInducedSchedule
+} from './graphTraversal'
 
 /** Direct (one-hop) subscriber script paths of `scriptPath`. */
 function downstreamSubscribers(g: AssetGraphResponse, scriptPath: string): string[] {
@@ -168,5 +172,56 @@ describe('computeDownstreamClosure', () => {
 		const cl = computeDownstreamClosure(g, 'b')
 		expect(cl.nodes).toEqual([])
 		expect(cl.cyclic).toEqual([])
+	})
+})
+
+describe('computeInducedSchedule', () => {
+	// a → b → c → d linear chain through assets.
+	const chain = () =>
+		graph(
+			[
+				['a', 'xa'],
+				['b', 'xb'],
+				['c', 'xc']
+			],
+			[
+				['b', 'xa'],
+				['c', 'xb'],
+				['d', 'xc']
+			]
+		)
+
+	it('orders a subset topologically and keeps only in-set edges', () => {
+		const sched = computeInducedSchedule(chain(), new Set(['a', 'b', 'c']))
+		expect(sched.nodes).toEqual(['a', 'b', 'c'])
+		expect(sched.roots).toEqual(['a'])
+		expect(sched.indegree.get('b')).toBe(1)
+		expect([...(sched.edges.get('c') ?? [])]).toEqual([]) // d is out of set
+		expect(sched.cyclic).toEqual([])
+	})
+
+	it('a gap in the selected set produces two independent roots', () => {
+		// pick a and c (skip b): with b excluded there is no in-set edge, so both
+		// are roots.
+		const sched = computeInducedSchedule(chain(), new Set(['a', 'c']))
+		expect(sched.roots.sort()).toEqual(['a', 'c'])
+		expect(sched.indegree.get('c')).toBe(0)
+	})
+
+	it('reports cyclic members instead of hanging', () => {
+		// b ↔ c cycle.
+		const g = graph(
+			[
+				['b', 'y'],
+				['c', 'z']
+			],
+			[
+				['c', 'y'],
+				['b', 'z']
+			]
+		)
+		const sched = computeInducedSchedule(g, new Set(['b', 'c']))
+		expect(sched.nodes).toEqual([])
+		expect(sched.cyclic.sort()).toEqual(['b', 'c'])
 	})
 })

--- a/frontend/src/lib/components/assets/AssetGraph/graphTraversal.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/graphTraversal.ts
@@ -117,3 +117,87 @@ export function computeDownstreamClosure(g: AssetGraphResponse, root: string): D
 	}
 	return { nodes: ordered, edges: cleanEdges, indegree: cleanIndegree, cyclic }
 }
+
+export type InducedSchedule = {
+	/** Selected scripts that are schedulable, in a topological order. */
+	nodes: string[]
+	/** In-set dependency edges: `edges.get(p)` = in-set subscribers of `p`. */
+	edges: Map<string, Set<string>>
+	/** In-set upstream count per node. */
+	indegree: Map<string, number>
+	/** Schedulable scripts with no in-set upstream — the schedule's seeds. */
+	roots: string[]
+	/**
+	 * Selected scripts on (or fed only through) a cycle. Excluded from
+	 * `nodes`/`edges`/`indegree`/`roots`; surfaced so callers can warn.
+	 */
+	cyclic: string[]
+}
+
+/**
+ * Topological schedule of an arbitrary *set* of scripts (e.g. a bounded-cascade
+ * selection), respecting only the dependency edges that fall *inside* the set.
+ * Multi-root: every selected script with no in-set upstream is a seed.
+ * Cycle-safe in the same way as `computeDownstreamClosure`.
+ *
+ * `oneHop` is the producer→consumer adjacency (script path → downstream script
+ * paths). It defaults to the `// on` subscriber map — but a bounded run passes
+ * a *read-aware* map (boundedCascade.buildLineageDownstreamMap) so a selected
+ * script that merely *reads* an upstream asset still runs after its producer,
+ * matching the CLI's `topoOrder`. Keep the default subscriber-only: it mirrors
+ * the production asset-trigger dispatch the unbounded cascade simulates.
+ */
+export function computeInducedSchedule(
+	g: AssetGraphResponse,
+	selected: Set<string>,
+	oneHop: Map<string, Set<string>> = buildDownstreamMap(g)
+): InducedSchedule {
+	// In-set edges + indegrees.
+	const edges = new Map<string, Set<string>>()
+	const indegree = new Map<string, number>()
+	for (const n of selected) indegree.set(n, 0)
+	for (const p of selected) {
+		const subs = new Set<string>()
+		for (const s of oneHop.get(p) ?? []) {
+			if (!selected.has(s)) continue
+			subs.add(s)
+			indegree.set(s, (indegree.get(s) ?? 0) + 1)
+		}
+		if (subs.size > 0) edges.set(p, subs)
+	}
+
+	// Kahn from every indegree-0 node.
+	const seeds = [...selected].filter((n) => (indegree.get(n) ?? 0) === 0)
+	const remaining = new Map(indegree)
+	const ready = [...seeds]
+	const ordered: string[] = []
+	while (ready.length > 0) {
+		const n = ready.shift()!
+		ordered.push(n)
+		for (const s of edges.get(n) ?? []) {
+			const d = (remaining.get(s) ?? 0) - 1
+			remaining.set(s, d)
+			if (d === 0) ready.push(s)
+		}
+	}
+
+	const orderedSet = new Set(ordered)
+	const cyclic = [...selected].filter((n) => !orderedSet.has(n))
+	if (cyclic.length === 0) {
+		return { nodes: ordered, edges, indegree, roots: seeds, cyclic }
+	}
+
+	// Strip cyclic nodes from the schedulable structures.
+	const cyclicSet = new Set(cyclic)
+	const cleanEdges = new Map<string, Set<string>>()
+	const cleanIndegree = new Map<string, number>()
+	for (const n of ordered) cleanIndegree.set(n, 0)
+	for (const [p, subs] of edges) {
+		if (cyclicSet.has(p)) continue
+		const kept = new Set([...subs].filter((s) => !cyclicSet.has(s)))
+		if (kept.size > 0) cleanEdges.set(p, kept)
+		for (const s of kept) cleanIndegree.set(s, (cleanIndegree.get(s) ?? 0) + 1)
+	}
+	const roots = ordered.filter((n) => (cleanIndegree.get(n) ?? 0) === 0)
+	return { nodes: ordered, edges: cleanEdges, indegree: cleanIndegree, roots, cyclic }
+}

--- a/frontend/src/lib/components/custom_ui.ts
+++ b/frontend/src/lib/components/custom_ui.ts
@@ -94,6 +94,11 @@ export type PreviewPanelUi = {
 	// "what happened the last time this ran". No-op when a test is already
 	// in progress (we don't clobber a live run).
 	loadLastRunOnMount?: boolean
+	// Pipeline-only: when set, the Test split's caret popover gains a "Run
+	// downstream up to…" entry that calls this, letting the user bound the
+	// cascade from the script they're editing. Wired by the pipeline details
+	// pane only when the open script is a valid bounded-run start.
+	onBoundedRun?: () => void
 }
 
 export type EditorBarUi = {

--- a/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
@@ -2525,6 +2525,9 @@
 								{runsPendingJobId}
 								{activeRunnable}
 								downstreamSubscribers={editedScriptDownstreamCount}
+								onStartBoundedRun={openScriptPath && validStartPaths.has(openScriptPath)
+									? () => startBoundedRun(openScriptPath!)
+									: undefined}
 								onRunCompleted={() => {
 									activeRunnable = undefined
 									activeRunnableJobId = undefined

--- a/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
@@ -36,8 +36,21 @@
 		type PipelineAnnotations
 	} from '$lib/components/assets/AssetGraph/parsePipelineAnnotations'
 	import { resolveGraph } from '$lib/components/assets/AssetGraph/resolveGraph'
-	import { computeDownstreamClosure } from '$lib/components/assets/AssetGraph/graphTraversal'
-	import { runCascade } from '$lib/components/assets/AssetGraph/cascadeOrchestrator'
+	import {
+		computeDownstreamClosure,
+		computeInducedSchedule
+	} from '$lib/components/assets/AssetGraph/graphTraversal'
+	import { runCascade, runSelection } from '$lib/components/assets/AssetGraph/cascadeOrchestrator'
+	import {
+		boundedSet,
+		buildLineageDag,
+		buildLineageDownstreamMap,
+		descendants,
+		isScriptNode,
+		scriptNodeId,
+		scriptsOf,
+		validStarts
+	} from '$lib/components/assets/AssetGraph/boundedCascade'
 	import {
 		diffDeployedGraph,
 		extractCascadeFacts,
@@ -65,8 +78,10 @@
 		History,
 		Loader2,
 		NetworkIcon,
+		Play,
 		RefreshCw,
 		Save,
+		Target,
 		Telescope
 	} from 'lucide-svelte'
 	import {
@@ -1761,6 +1776,137 @@
 		}
 		return rootJobId
 	}
+
+	// ── Bounded-cascade selective execution ──────────────────────────────
+	// "Run downstream up to…" lets the user run a *prefix* of a cascade: start
+	// at a schedule/manual root, fan downstream, but stop at chosen end node(s).
+	// The matched set is the path-between of start and ends over the lineage DAG.
+	// Pick state is in engine node-id space (`script:path`, `${kind}:${path}`);
+	// it is converted to canvas ids only at the canvas boundary.
+	let boundPickStart = $state<string | undefined>(undefined)
+	let boundPickEnds = $state<Set<string>>(new Set())
+
+	// Script paths eligible to start a bounded run, for the canvas menu gate.
+	let validStartPaths = $derived(new Set(scriptsOf(validStarts(displayGraph))))
+
+	// Rebuilt only while a pick is active (cheap to skip otherwise).
+	let boundDag = $derived(boundPickStart ? buildLineageDag(displayGraph) : undefined)
+	let boundEligible = $derived(
+		boundDag && boundPickStart ? descendants(boundDag, boundPickStart) : new Set<string>()
+	)
+	let boundResult = $derived(
+		boundDag && boundPickStart
+			? boundedSet(boundDag, boundPickStart, [...boundPickEnds])
+			: undefined
+	)
+	let boundScripts = $derived(boundResult ? scriptsOf(boundResult.nodes) : [])
+
+	// Engine id → canvas id: scripts keep `script:path`; assets gain the
+	// canvas's `asset:` prefix (AssetGraphCanvas node ids).
+	const toCanvasId = (eid: string): string => (isScriptNode(eid) ? eid : `asset:${eid}`)
+	const fromCanvasId = (cid: string): string =>
+		cid.startsWith('asset:') ? cid.slice('asset:'.length) : cid
+	// Short label for a `script:f/folder/name` start id (last path segment).
+	const shortPath = (scriptId: string): string => {
+		const p = isScriptNode(scriptId) ? scriptId.slice('script:'.length) : scriptId
+		return p.split('/').pop() ?? p
+	}
+	let boundPick = $derived(
+		boundPickStart && boundDag
+			? {
+					start: boundPickStart,
+					eligible: new Set([...boundEligible].map(toCanvasId)),
+					ends: new Set([...boundPickEnds].map(toCanvasId)),
+					bounded: new Set([...(boundResult?.nodes ?? [])].map(toCanvasId))
+				}
+			: undefined
+	)
+
+	function startBoundedRun(path: string) {
+		boundPickStart = scriptNodeId(path)
+		boundPickEnds = new Set()
+	}
+	function pickBoundEnd(canvasNodeId: string) {
+		const eid = fromCanvasId(canvasNodeId)
+		if (eid === boundPickStart) return
+		const next = new Set(boundPickEnds)
+		if (next.has(eid)) next.delete(eid)
+		else next.add(eid)
+		boundPickEnds = next
+	}
+	function cancelBoundedRun() {
+		boundPickStart = undefined
+		boundPickEnds = new Set()
+	}
+	async function confirmBoundedRun() {
+		const scripts = boundScripts
+		cancelBoundedRun()
+		await runBoundedCascade(scripts)
+	}
+	// Run an arbitrary selected set of scripts in topological order. Same
+	// per-hop launch + poll as the draft-aware cascade (it skips the backend
+	// dispatcher so the page owns the whole closure), but multi-root: every
+	// selected script with no in-set upstream is seeded at once.
+	async function runBoundedCascade(scripts: string[]): Promise<void> {
+		if (scripts.length === 0) {
+			sendUserToast('No scripts to run in this selection', true)
+			return
+		}
+		if (cascadeRunningRoot) {
+			sendUserToast(`A chain run from ${cascadeRunningRoot} is still in progress`, true)
+			return
+		}
+		// Read-aware adjacency so a pure-reader member runs after its producer
+		// (parity with the CLI `topoOrder`); see buildLineageDownstreamMap.
+		const schedule = computeInducedSchedule(
+			displayGraph,
+			new Set(scripts),
+			buildLineageDownstreamMap(displayGraph)
+		)
+		if (schedule.cyclic.length > 0) {
+			sendUserToast(
+				`Not running ${schedule.cyclic.length} script(s) on a dependency cycle: ${schedule.cyclic.join(', ')}`,
+				true
+			)
+		}
+		if (schedule.nodes.length === 0) {
+			sendUserToast('No runnable scripts in this selection', true)
+			return
+		}
+		cascadeRunningRoot = schedule.roots[0] ?? scripts[0]
+		let firstJobId: string | undefined
+		try {
+			const res = await runSelection({
+				schedule,
+				launch: async (path) => {
+					const jobId = await launchCascadeScript(path)
+					activeRunnables.arm(`script:${path}`)
+					if (firstJobId === undefined) {
+						firstJobId = jobId
+						runsPendingJobId = jobId
+						runsRefreshKey++
+					}
+					return jobId
+				},
+				waitTerminal: waitJobTerminal
+			})
+			const n = res.statuses.size
+			if (res.ok) {
+				sendUserToast(`Bounded run complete — ${n} script${n === 1 ? '' : 's'} succeeded`)
+			} else {
+				const failed = [...res.statuses.entries()].filter(([, s]) => s.status === 'failure')
+				const skipped = [...res.statuses.values()].filter((s) => s.status === 'skipped').length
+				sendUserToast(
+					`Bounded run failed at ${failed.map(([p]) => p).join(', ')}` +
+						(skipped > 0 ? ` — ${skipped} downstream skipped` : ''),
+					true
+				)
+			}
+		} finally {
+			cascadeRunningRoot = undefined
+		}
+	}
+
 	// Counter bumped when the canvas Run button targets the currently-open
 	// script — the pane intercepts and routes through ScriptEditor.runTest
 	// so logs/result/cancel land in the test panel instead of going off
@@ -2278,8 +2424,42 @@
 							onAddPipelineScript={mode === 'edit' ? handleAddPipelineScript : undefined}
 							onRunnableMenuRemove={mode === 'edit' ? handleRunnableMenuRemove : undefined}
 							onRunProducer={mode === 'edit' ? handleRunProducer : undefined}
+							validStartPaths={isOperator ? undefined : validStartPaths}
+							onStartBoundedRun={isOperator ? undefined : startBoundedRun}
+							{boundPick}
+							onPickEnd={pickBoundEnd}
 							{panToNodeId}
 						/>
+						{#if boundPick}
+							<!-- Bounded-run control bar: overlays the canvas while the
+							     user is picking end node(s). Anchored bottom-center so it
+							     doesn't collide with the top status chip / hide button. -->
+							<div
+								class="absolute bottom-4 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 px-3 py-2 rounded-lg bg-surface shadow-lg border border-gray-200 dark:border-gray-700"
+							>
+								<Target size={15} class="text-blue-500 shrink-0" />
+								<div class="flex flex-col leading-tight">
+									<span class="text-xs font-semibold text-emphasis">
+										{boundPickEnds.size === 0
+											? 'Click end node(s) to bound the run'
+											: `${boundScripts.length} script${boundScripts.length === 1 ? '' : 's'} up to ${boundPickEnds.size} end${boundPickEnds.size === 1 ? '' : 's'}`}
+									</span>
+									<span class="text-2xs text-tertiary">
+										from {boundPickStart ? shortPath(boundPickStart) : ''}
+									</span>
+								</div>
+								<Button variant="subtle" unifiedSize="sm" onclick={cancelBoundedRun}>Cancel</Button>
+								<Button
+									variant="accent"
+									unifiedSize="sm"
+									startIcon={{ icon: Play }}
+									disabled={boundPickEnds.size === 0 || boundScripts.length === 0}
+									onclick={confirmBoundedRun}
+								>
+									Run selection
+								</Button>
+							</div>
+						{/if}
 						{#if mode === 'edit'}
 							<!-- View mode surfaces activity as a full right pane
 							     instead — the overlay would double up. -->

--- a/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
@@ -1788,6 +1788,11 @@
 
 	// Script paths eligible to start a bounded run, for the canvas menu gate.
 	let validStartPaths = $derived(new Set(scriptsOf(validStarts(displayGraph))))
+	// Scripts with read-aware downstream — the same gate the canvas applies
+	// (AssetGraphCanvas `hasLineageDownstream`). A valid start with no downstream
+	// has no end to pick, so the bounded-run entry is suppressed everywhere,
+	// including the details-pane (ScriptEditor) Test caret.
+	let lineageDownstreamPaths = $derived(new Set(buildLineageDownstreamMap(displayGraph).keys()))
 
 	// Rebuilt only while a pick is active (cheap to skip otherwise).
 	let boundDag = $derived(boundPickStart ? buildLineageDag(displayGraph) : undefined)
@@ -2525,7 +2530,9 @@
 								{runsPendingJobId}
 								{activeRunnable}
 								downstreamSubscribers={editedScriptDownstreamCount}
-								onStartBoundedRun={openScriptPath && validStartPaths.has(openScriptPath)
+								onStartBoundedRun={openScriptPath &&
+								validStartPaths.has(openScriptPath) &&
+								lineageDownstreamPaths.has(openScriptPath)
 									? () => startBoundedRun(openScriptPath!)
 									: undefined}
 								onRunCompleted={() => {

--- a/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
@@ -1674,7 +1674,11 @@
 	// edits is not picked up — same as production dispatch).
 	async function launchCascadeScript(path: string): Promise<string> {
 		if (!$workspaceStore) throw new Error('no workspace')
-		const draft = drafts.get(path)
+		// Only run draft content when the displayed graph actually includes
+		// drafts (same condition as `displayGraph`). Otherwise — View mode with
+		// drafts hidden — a bounded run must execute the *deployed* scripts the
+		// user is looking at, not preview jobs from hidden local drafts.
+		const draft = mode === 'edit' || includeDrafts ? drafts.get(path) : undefined
 		if (draft) {
 			if (!draft.script.content || !draft.script.language) {
 				throw new Error(`draft ${path} has no content/language`)

--- a/system_prompts/auto-generated/cli/cli-commands.md
+++ b/system_prompts/auto-generated/cli/cli-commands.md
@@ -419,6 +419,11 @@ inspect asset-driven pipelines (scripts marked `// pipeline`, wired by `// on <s
   - `--json` - Output as JSON (for piping to jq)
 - `pipeline show <folder:string>` - render a pipeline folder's DAG (sources, lineage, subscriptions) in the terminal
   - `--json` - Output the raw asset graph as JSON
+- `pipeline run <folder:string>` - run a bounded cascade: from a schedule/manual root, fan downstream up to the --to end node(s)
+  - `--from <script:string>` - Start script (short name or path). Defaults to the folder's sole schedule/manual root.
+  - `--to <node:string>` - End node(s) to stop at — script names/paths or asset URIs (e.g. datatable://main/staged). Repeatable or comma-separated. Omit to run the full downstream.
+  - `--dry-run` - Print the topological run plan without executing.
+  - `--json` - Output the plan as JSON (for piping to jq).
 
 ### protection-rules
 

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -3017,6 +3017,11 @@ inspect asset-driven pipelines (scripts marked \`// pipeline\`, wired by \`// on
   - \`--json\` - Output as JSON (for piping to jq)
 - \`pipeline show <folder:string>\` - render a pipeline folder's DAG (sources, lineage, subscriptions) in the terminal
   - \`--json\` - Output the raw asset graph as JSON
+- \`pipeline run <folder:string>\` - run a bounded cascade: from a schedule/manual root, fan downstream up to the --to end node(s)
+  - \`--from <script:string>\` - Start script (short name or path). Defaults to the folder's sole schedule/manual root.
+  - \`--to <node:string>\` - End node(s) to stop at — script names/paths or asset URIs (e.g. datatable://main/staged). Repeatable or comma-separated. Omit to run the full downstream.
+  - \`--dry-run\` - Print the topological run plan without executing.
+  - \`--json\` - Output the plan as JSON (for piping to jq).
 
 ### protection-rules
 

--- a/system_prompts/auto-generated/skills/cli-commands/SKILL.md
+++ b/system_prompts/auto-generated/skills/cli-commands/SKILL.md
@@ -424,6 +424,11 @@ inspect asset-driven pipelines (scripts marked `// pipeline`, wired by `// on <s
   - `--json` - Output as JSON (for piping to jq)
 - `pipeline show <folder:string>` - render a pipeline folder's DAG (sources, lineage, subscriptions) in the terminal
   - `--json` - Output the raw asset graph as JSON
+- `pipeline run <folder:string>` - run a bounded cascade: from a schedule/manual root, fan downstream up to the --to end node(s)
+  - `--from <script:string>` - Start script (short name or path). Defaults to the folder's sole schedule/manual root.
+  - `--to <node:string>` - End node(s) to stop at — script names/paths or asset URIs (e.g. datatable://main/staged). Repeatable or comma-separated. Omit to run the full downstream.
+  - `--dry-run` - Print the topological run plan without executing.
+  - `--json` - Output the plan as JSON (for piping to jq).
 
 ### protection-rules
 


### PR DESCRIPTION
## Summary

Selective execution for the asset-graph pipelines (gap #4 in `docs/pipelines-vs-dbt.md`). Instead of porting dbt's compile-time `--select tag:… state:modified+ +x+` grammar — which dbt needs only because it has no runtime DAG — this **bounds the live cascade Windmill already runs**: start at a pipeline entrypoint, fan downstream, but **stop at one or more chosen end node(s)**.

The matched set is the "path between" the start and the ends over a unified asset-graph lineage DAG (scripts ∪ assets):

```
descendants(start) ∩ (ancestors(ends) ∪ ends) ∪ {start}
```

No grammar to parse, no `tag:`/`state:` vocabulary — it maps to a real gesture ("run up to here"). **No backend or parser changes**: it reads the existing `/assets/graph` payload (lineage edges, asset triggers, schedules); `parsePipelineAnnotations.ts` and the Rust parser are untouched.

**Scope** (agreed during planning): bound is a **run-time action** (nothing persisted on the schedule); valid **start** nodes are **schedule-rooted** cascades and **manual roots**. Event triggers with a trigger row in the asset graph (kafka/mqtt/nats/postgres/sqs/gcp/email) fan out per-event and have no "run up to X" gesture, so they're excluded as starts. `webhook`/`data_upload` have no trigger row in `/assets/graph`, so a root entered only via one of those reads as a **manual root** and is a valid start (you can "run up to here" from a data-upload entrypoint).

## Changes

- **Shared graph engine** (`boundedCascade.ts`, mirrored in `frontend/` and `cli/` — no shared import path between the packages): builds the unified lineage DAG, `ancestors`/`descendants`/`boundedSet`/`validStarts`/`scriptsOf`, plus a **read-aware** producer→consumer adjacency so a member that merely *reads* an upstream asset still runs after its producer.
- **Scheduling**: `graphTraversal.computeInducedSchedule` (multi-root Kahn over an arbitrary script set) + `cascadeOrchestrator.runSelection` (seeds all roots, runs in topological order, stops on failure). The bounded path passes the read-aware adjacency; the unbounded "Run + downstream" path keeps the subscriber-only map (mirrors production dispatch).
- **UI**: a "Run downstream up to…" entry on the kebab menu of valid-start nodes opens an end-node **pick mode** — eligible (downstream) nodes are clickable, out-of-reach nodes dim, the bounded path-between set rings blue, chosen ends ring amber. A control bar shows the live "N scripts up to M ends" count and a "Run selection" button. Works in both View and Edit modes.
- **CLI**: `wmill pipeline run <folder> --to <node>[,<node>…] [--from <start>] [--dry-run] [--json]`. `--to` accepts script names/paths or asset URIs (`datatable://main/staged`); `--from` defaults to the folder's sole valid start. Runs each hop with `_wmill_skip_asset_dispatch` in topological order, stopping on failure. `system_prompts/` + `skills.gen.ts` regenerated per AGENTS.md.

## Screenshots

End-node pick mode — bounding `ingest` up to `report` (3 scripts; `audit` excluded, dimmed):

![bound-pick-report](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/pipeline-selective-execution/1782035131-bound-pick-report.png)

A completed bounded run:

![bound-run-green](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/pipeline-selective-execution/1782035133-bound-run-green.png)

## Test plan

- [x] Engine unit tests — frontend (`boundedCascade.test.ts`, 15 cases) and CLI mirror (`boundedCascade.test.ts`, 8 cases): path-between, asset-as-end, multi-end, dropped/unreachable ends, `validStarts` matrix, cycle-safety, **pure-reader ordering**.
- [x] Scheduling — `graphTraversal.test.ts` (`computeInducedSchedule`: topo order, gaps→roots, cycles; read-aware vs subscriber-only) and `cascadeOrchestrator.test.ts` (`runSelection`: multi-root, fail-stops-scheduling, single-node). All 100 AssetGraph vitest tests pass; no regressions.
- [x] UI verified with Playwright: menu appears only on valid starts (schedule/manual root), pick-mode dim/highlight, live bounded count, "Run selection" launches the bounded set in order and **excludes** nodes past the bound. Live run completes green (see screenshots).
- [x] CLI verified live against a seeded pipeline: `--to stage`→2, `--to report`→3, `--to report,audit`→4, asset-URI end, no-`--to`→full downstream, invalid `--from` error, ambiguous `--from` message, unresolved-`--to` error. Live `pipeline run --to report` ran ingest→stage→report and excluded audit.
- [ ] Reviewer: confirm a bounded selection containing a pure-*reader* (reads an upstream asset without `// on`) schedules the reader after its producer in both UI and CLI (regression-tested; the read-aware adjacency was the fix from local review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add bounded-cascade selective execution for pipelines: run a prefix of a cascade from a schedule/manual root up to chosen end node(s) from the canvas and CLI. Reuses the lineage DAG; no backend or parser changes.

- **New Features**
  - UI: “Run downstream up to…” is on the Run button caret for valid starts (Edit), on the trigger-node kebab for schedule/`data_upload` entrypoints (View), and on the ScriptEditor Test caret. Pick eligible end nodes; out-of-reach dims; the path-between set is ringed; a bottom bar shows counts with Run/Cancel. Gated by read-aware downstream; the caret opens even when only the bounded-run is available. For a shared trigger, the action shows only when exactly one target script is eligible.
  - CLI: `wmill pipeline run <folder> --to <node>[,<node>…] [--from <script>] [--dry-run] [--json]`. Accepts script names/paths and asset URIs (e.g. `datatable://main/staged`); defaults `--from` to the sole valid start; warns on ends not downstream. Prints a plan with `--dry-run` or as JSON (includes `reachableEnds` and `droppedEnds`). Executes in topological order, stops on first failure; launches with `_wmill_skip_asset_dispatch`. With no `--to`, runs the full read-aware downstream (pure readers included).
  - Engine & scheduling: shared bounded-DAG engine (`boundedCascade.ts`) in frontend/CLI; read-aware producer→consumer adjacency so pure readers run after producers; `computeInducedSchedule` (multi-root) and `runSelection` for topo-ordered execution; cycle-safe. Unbounded cascade remains subscriber-only.

- **Bug Fixes**
  - UI gate/caret: the caret now opens when a node has only a bounded-run option; “Run downstream up to…” is gated on read-aware lineage, and the ScriptEditor entry requires read-aware downstream. Trigger nodes consider all target scripts and only show the action when exactly one is a valid start with downstream.
  - CLI: waiting treats a completed job without `success: true` as a failure; `--to`/`--from` tokens that are unresolved or ambiguous are rejected; unreachable ends are warned and dropped; asset ends print correctly in warnings; `--from` error text excludes only row-backed event triggers (kafka/mqtt/nats/postgres/sqs/gcp/email).
  - Graph ops/tests: descendant/ancestor closures exclude the start even on cycles; added `computeInducedSchedule`/`runSelection` and read-aware ordering tests; CLI engine tests run under `bun:test`.
  - View mode: bounded runs no longer execute hidden drafts; they run deployed scripts unless drafts are shown.

<sup>Written for commit 8304d74b57ed94039713e8d23e96ed19a98fdd44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

