### PR TITLE
fix: preserve object-store config when switching storage tabs

### DIFF
--- a/frontend/src/lib/components/ObjectStoreConfigSettings.svelte
+++ b/frontend/src/lib/components/ObjectStoreConfigSettings.svelte
@@ -46,6 +46,9 @@
 		serviceAccountKey: Record<string, string> | undefined
 	}
 
+	type BucketConfig = S3Config | AzureConfig | AwsOidcConfig | GcsConfig
+	type BucketType = BucketConfig['type']
+
 	interface Props {
 		bucket_config?: S3Config | AzureConfig | AwsOidcConfig | GcsConfig | undefined
 	}
@@ -61,6 +64,41 @@
 	)
 
 	let loading = $state(false)
+
+	// Cache each storage type's config so switching tabs (e.g. S3 -> Azure -> S3)
+	// restores what was entered/loaded instead of resetting it to an empty config,
+	// which previously wiped a saved bucket and persisted the empty value on save
+	// (#6611).
+	let bucketConfigByType = $state<Partial<Record<BucketType, BucketConfig>>>({})
+
+	function defaultBucketConfig(type: BucketType): BucketConfig {
+		switch (type) {
+			case 'S3':
+				return {
+					type: 'S3',
+					bucket: '',
+					region: '',
+					access_key: '',
+					secret_key: '',
+					endpoint: '',
+					allow_http: true
+				}
+			case 'Azure':
+				return {
+					type: 'Azure',
+					accountName: '',
+					containerName: '',
+					useSSL: false,
+					tenantId: '',
+					clientId: '',
+					accessKey: ''
+				}
+			case 'AwsOidc':
+				return { type: 'AwsOidc', bucket: '', region: '', roleArn: '' }
+			case 'Gcs':
+				return { type: 'Gcs', bucket: '', serviceAccountKey: {} }
+		}
+	}
 
 	async function testConnection() {
 		loading = true
@@ -449,40 +487,14 @@
 		<Tabs
 			selected={bucket_config?.type ?? 'S3'}
 			on:selected={(e) => {
-				if (e.detail === 'S3' && bucket_config?.type !== 'S3') {
-					bucket_config = {
-						type: 'S3',
-						bucket: '',
-						region: '',
-						access_key: '',
-						secret_key: '',
-						endpoint: '',
-						allow_http: true
-					}
-				} else if (e.detail === 'Azure' && bucket_config?.type !== 'Azure') {
-					bucket_config = {
-						type: 'Azure',
-						accountName: '',
-						containerName: '',
-						useSSL: false,
-						tenantId: '',
-						clientId: '',
-						accessKey: ''
-					}
-				} else if (e.detail === 'Gcs' && bucket_config?.type !== 'Gcs') {
-					bucket_config = {
-						type: 'Gcs',
-						bucket: '',
-						serviceAccountKey: {}
-					}
-				} else if (e.detail === 'AwsOidc' && bucket_config?.type !== 'AwsOidc') {
-					bucket_config = {
-						type: 'AwsOidc',
-						bucket: '',
-						region: '',
-						roleArn: ''
-					}
+				const target = e.detail as BucketType
+				if (!bucket_config || bucket_config.type === target) {
+					return
 				}
+				// Remember the config we're leaving so returning to its tab restores it,
+				// then restore the target tab's config (or a default on first visit).
+				bucketConfigByType[bucket_config.type] = bucket_config
+				bucket_config = bucketConfigByType[target] ?? defaultBucketConfig(target)
 			}}
 		>
 			<Tab value="S3" label="S3" />


### PR DESCRIPTION
## Summary

In Instance Settings → object storage, switching the storage-type tab (S3 / Azure / AWS OIDC / GCS) resets the config. The `<Tabs on:selected>` handler rebuilt `bucket_config` as a fresh empty object of the target type on every switch, so switching **S3 → Azure → S3** returns a blank S3 config. Because the config is two-way bound into the instance settings, saving afterwards persists the empty value, clearing a configured bucket (#6611 — the issue's reproduction: switch to the Azure tab and back to S3, and the S3 bucket field is empty).

## Changes

`frontend/src/lib/components/ObjectStoreConfigSettings.svelte`:
- Cache each storage type's config (`bucketConfigByType`) and, on tab switch, save the config being left and restore the target tab's cached config (or a default on first visit), so toggling tabs no longer discards entered or loaded values.
- Extract the per-type empty defaults into a `defaultBucketConfig(type)` helper (previously inlined in the handler).

## Test plan

- [ ] Configure an S3 bucket, switch to the Azure tab and back to S3 → the S3 fields are preserved (previously cleared).
- [ ] Enter values under one storage type, switch to another and back → values are preserved for both.
- [ ] First visit to a tab still shows an empty default config.
- [ ] `cd frontend && npm run check`

## Notes

Scoped to the tab-switch reset (the confirmed reproduction). The issue also reports the bucket showing empty on first load when configured via `instance_settings.json`; that is a separate settings-hydration path and is not addressed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes object storage settings so switching between S3, Azure, AWS OIDC, and GCS tabs no longer resets the config. Values are preserved per tab, preventing accidental clearing on save.

- Bug Fixes
  - Cache config by storage type and restore on tab switch; fall back to a default on first visit.
  - Add `defaultBucketConfig(type)` helper to centralize per-type defaults.

<sup>Written for commit bef0cf72aa2f8cd54c5f60a6caf512e4ac267b02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

