### PR TITLE
fix: sanitize git credentials from Ansible executor errors and logs (WIN-2079)

### DIFF
--- a/backend/windmill-common/src/git_sync_oss.rs
+++ b/backend/windmill-common/src/git_sync_oss.rs
@@ -15,6 +15,29 @@ pub async fn get_github_app_token_internal(
     ));
 }
 
+lazy_static::lazy_static! {
+    /// Matches a `user:password@` (or `user@`) userinfo component right after the URL scheme.
+    static ref GIT_URL_USERINFO_RE: regex::Regex =
+        regex::Regex::new(r"://[^/@]+@").unwrap();
+}
+
+/// Strip embedded credentials (the `user:password@` userinfo component) from a git URL so it can be
+/// safely included in error messages and logs. Falls back to a regex when the URL does not parse.
+pub fn sanitize_git_url(url: &str) -> String {
+    if let Ok(mut parsed) = Url::parse(url) {
+        if !parsed.username().is_empty() || parsed.password().is_some() {
+            // These setters only fail for cannot-be-a-base URLs, in which case we keep the parsed
+            // string as-is and let the regex fallback below handle stripping.
+            let _ = parsed.set_username("");
+            let _ = parsed.set_password(None);
+        }
+        return GIT_URL_USERINFO_RE
+            .replace(parsed.as_str(), "://***@")
+            .into_owned();
+    }
+    GIT_URL_USERINFO_RE.replace(url, "://***@").into_owned()
+}
+
 pub fn prepend_token_to_github_url(
     github_url: &str,
     installation_token: &str,
@@ -31,4 +54,42 @@ pub fn prepend_token_to_github_url(
         host,
         url.path()
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_git_url;
+
+    #[test]
+    fn strips_username_and_password() {
+        assert_eq!(
+            sanitize_git_url("https://user:p4ssw0rd@github.com/org/repo.git"),
+            "https://github.com/org/repo.git"
+        );
+    }
+
+    #[test]
+    fn strips_token_only_userinfo() {
+        assert_eq!(
+            sanitize_git_url("https://ghp_secrettoken@github.com/org/repo.git"),
+            "https://github.com/org/repo.git"
+        );
+    }
+
+    #[test]
+    fn leaves_credential_free_url_untouched() {
+        assert_eq!(
+            sanitize_git_url("https://github.com/org/repo.git"),
+            "https://github.com/org/repo.git"
+        );
+    }
+
+    #[test]
+    fn strips_credentials_from_unparseable_url() {
+        // scp-like syntax that `url::Url` cannot parse
+        assert_eq!(
+            sanitize_git_url("not a url://user:secret@host/repo"),
+            "not a url://***@host/repo"
+        );
+    }
 }

--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -13,7 +13,7 @@ use tokio::process::Command;
 use uuid::Uuid;
 use windmill_common::{
     error,
-    git_sync_oss::prepend_token_to_github_url,
+    git_sync_oss::{prepend_token_to_github_url, sanitize_git_url},
     worker::{
         is_allowed_file_location, split_python_requirements, to_raw_value, write_file,
         write_file_at_user_defined_location, Connection, PyVAlias, WORKER_CONFIG,
@@ -847,7 +847,7 @@ pub async fn get_git_repo_full_head_commit_hash(
         .first()
         .ok_or(anyhow!(
             "The HEAD commit hash was not found for repo `{}`",
-            &repo.url
+            sanitize_git_url(&repo.url)
         ))?
         .split_whitespace()
         .next()
@@ -1254,7 +1254,12 @@ pub async fn handle_ansible_job(
                     git_ssh_cmd,
                 )
                 .await
-                .map_err(|e| anyhow!("Failed to clone git repo `{}`: {e}", repo.url))?;
+                .map_err(|e| {
+                    anyhow!(
+                        "Failed to clone git repo `{}`: {e}",
+                        sanitize_git_url(&repo.url)
+                    )
+                })?;
             } else {
                 clone_repo(
                     &repo,
@@ -1269,7 +1274,12 @@ pub async fn handle_ansible_job(
                     git_ssh_cmd,
                 )
                 .await
-                .map_err(|e| anyhow!("Failed to clone git repo `{}`: {e}", repo.url))?;
+                .map_err(|e| {
+                    anyhow!(
+                        "Failed to clone git repo `{}`: {e}",
+                        sanitize_git_url(&repo.url)
+                    )
+                })?;
             }
 
             append_logs(
@@ -1316,7 +1326,7 @@ pub async fn handle_ansible_job(
             append_logs(
                 &job.id,
                 &job.workspace_id,
-                format!("\nCloning {}...\n", &repo.url),
+                format!("\nCloning {}...\n", sanitize_git_url(&repo.url)),
                 conn,
             )
             .await;
@@ -1338,13 +1348,18 @@ pub async fn handle_ansible_job(
                     git_ssh_cmd,
                 )
                 .await
-                .map_err(|e| anyhow!("Failed to clone git repo `{}`: {e}", repo.url))?;
+                .map_err(|e| {
+                    anyhow!(
+                        "Failed to clone git repo `{}`: {e}",
+                        sanitize_git_url(&repo.url)
+                    )
+                })?;
             } else {
                 if req_lockfiles.is_some() {
                     append_logs(
                         &job.id,
                         &job.workspace_id,
-                        format!("Warning: `{}` is using latest commit because the lockfile didn't store a commit hash for this repo. Updates to the repo could break the deployed playbook.\n", &repo.url),
+                        format!("Warning: `{}` is using latest commit because the lockfile didn't store a commit hash for this repo. Updates to the repo could break the deployed playbook.\n", sanitize_git_url(&repo.url)),
                         conn,
                     )
                     .await;
@@ -1362,13 +1377,22 @@ pub async fn handle_ansible_job(
                     git_ssh_cmd,
                 )
                 .await
-                .map_err(|e| anyhow!("Failed to clone git repo `{}`: {e}", repo.url))?;
+                .map_err(|e| {
+                    anyhow!(
+                        "Failed to clone git repo `{}`: {e}",
+                        sanitize_git_url(&repo.url)
+                    )
+                })?;
             }
 
             append_logs(
                 &job.id,
                 &job.workspace_id,
-                format!("Cloned {} into {}\n", &repo.url, &repo.target_path),
+                format!(
+                    "Cloned {} into {}\n",
+                    sanitize_git_url(&repo.url),
+                    &repo.target_path
+                ),
                 conn,
             )
             .await;


### PR DESCRIPTION
## Problem

When `delegate_to_git_repo` or `git_repos` git clone fails in the Ansible executor, the full git URL — including embedded credentials (`user:password@` or a PAT) — was interpolated verbatim into error messages and log output. Since this output is surfaced in job logs visible to users, it leaked secrets.

## Fix

Added a `sanitize_git_url(url: &str) -> String` helper in `windmill-common/src/git_sync_oss.rs` (next to `prepend_token_to_github_url`). It strips the userinfo component:

- Primary path: parse with `url::Url`, clear username and password.
- Fallback: for URLs that don't parse, a regex replaces `://user:pass@` → `://***@`.

Applied the helper at all 8 sites in `backend/windmill-worker/src/ansible_executor.rs` where `repo.url` is interpolated into error messages or log output (the HEAD-commit-not-found error, the four `.map_err` clone-failure messages, and the three `format!()` log lines for cloning/warning). Sites where `repo.url` is used as a HashMap key or passed to git as an argument are left untouched, since those are not user-facing output.

## Validation

- `cargo` (via the running `cargo watch`) rebuilt cleanly — worker healthy, no compile errors.
- Added 4 unit tests for `sanitize_git_url` covering user:password, token-only userinfo, credential-free passthrough, and the unparseable-URL regex fallback. All pass:

```
test git_sync_oss::tests::strips_username_and_password ... ok
test git_sync_oss::tests::strips_token_only_userinfo ... ok
test git_sync_oss::tests::leaves_credential_free_url_untouched ... ok
test git_sync_oss::tests::strips_credentials_from_unparseable_url ... ok
```

Fixes WIN-2079

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes embedded credentials in git URLs in Ansible executor errors and logs to prevent secret leaks. Addresses WIN-2079.

- **Bug Fixes**
  - Added `sanitize_git_url` in `windmill-common` to strip `user[:pass]@` from URLs, with a regex fallback for unparseable inputs.
  - Used it for all user-facing URL interpolations in `windmill-worker` Ansible executor (8 sites); functional uses remain unchanged.
  - Added 4 unit tests for typical cases; build passes.

<sup>Written for commit a5dcce7e2070f1fd7464fa083a48d40e107d2131. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

