### PR TITLE
feat(copilot): improve global-mode path selection + add path-selection evals

### DIFF
--- a/ai_evals/adapters/frontend/core/global/globalEvalRunner.ts
+++ b/ai_evals/adapters/frontend/core/global/globalEvalRunner.ts
@@ -1,9 +1,7 @@
 import { mkdtemp, rm } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
-import { get } from "svelte/store";
 import type { AIProvider } from "$lib/gen/types.gen";
-import { userStore, type UserExt } from "$lib/stores";
 import {
   globalTools,
   prepareGlobalSystemMessage,
@@ -55,36 +53,15 @@ export interface GlobalLiveEditorDraftFixture {
 // Identity the global system prompt builds paths from. Production reads
 // `userStore` (whoami) to fill `u/{username}/...`; the eval harness never logs
 // in, so without this the prompt sees an empty username (`u//...`) and no
-// path-selection case is meaningful. Seeded per-case via the initial fixture.
+// path-selection case is meaningful. Seeded per-case via the initial fixture and
+// passed straight to `prepareGlobalSystemMessage` (no global-store mutation).
 export interface GlobalUserFixture {
   username: string;
   is_admin?: boolean;
-  is_super_admin?: boolean;
-  operator?: boolean;
   /** Folders the user can write to (the writable set whoami returns). */
   folders?: string[];
   /** Folders the user can read; read-only folders = folders_read \ folders. */
   folders_read?: string[];
-  /** Folders the user owns (subset of folders). */
-  folders_owners?: string[];
-}
-
-function buildEvalUserExt(user: GlobalUserFixture): UserExt {
-  return {
-    email: `${user.username}@windmill.dev`,
-    username: user.username,
-    is_admin: user.is_admin ?? true,
-    is_super_admin: user.is_super_admin ?? false,
-    operator: user.operator ?? false,
-    created_at: "2024-01-01T00:00:00.000Z",
-    groups: ["all"],
-    pgroups: ["g/all"],
-    folders: user.folders ?? [],
-    folders_owners: user.folders_owners ?? user.folders ?? [],
-    // folders_read is consumed at runtime / by the Phase 2 prompt injection but
-    // is not part of the typed UserExt surface, so attach it via the cast below.
-    ...(user.folders_read ? { folders_read: user.folders_read } : {}),
-  } as UserExt;
 }
 
 export interface GlobalEvalResult {
@@ -124,22 +101,15 @@ export async function runGlobalEval(
   registerBenchmarkWorkspaceRunnables(workspaceRoot, options.workspaceFixtures ?? {});
   seedLiveEditorDrafts(workspaceRoot, options.liveEditorDrafts ?? []);
 
-  // `userStore` is a process-global singleton; the system message is built
-  // synchronously below (no await between set and read), so the seeded identity
-  // is captured atomically. Cross-case races are still possible under parallel
-  // execution, so path-selection cases must run with concurrency=1 (--verbose).
-  const previousUser = get(userStore);
-  if (options.user) {
-    userStore.set(buildEvalUserExt(options.user));
-  }
-
   try {
     const model = options.model ?? "claude-haiku-4-5-20251001";
     const injectActiveEditorContext =
       process.env[DISABLE_ACTIVE_EDITOR_CONTEXT_ENV] !== "1";
+    // Pass the seeded identity straight to the prompt builder rather than mutating
+    // the process-global `userStore`, so concurrent cases never race on it.
     const rawResult = await runEval({
       userPrompt,
-      systemMessage: prepareGlobalSystemMessage(),
+      systemMessage: prepareGlobalSystemMessage(undefined, { user: options.user }),
       userMessage: prepareGlobalUserMessage(
         userPrompt,
         [],
@@ -176,7 +146,6 @@ export async function runGlobalEval(
       finalContextTokens: rawResult.finalContextTokens,
     };
   } finally {
-    userStore.set(previousUser);
     clearGlobalDrafts(workspaceRoot);
     clearLiveEditorDrafts(workspaceRoot, options.liveEditorDrafts ?? []);
     unregisterBenchmarkWorkspaceRunnables(workspaceRoot);

--- a/ai_evals/adapters/frontend/core/global/globalEvalRunner.ts
+++ b/ai_evals/adapters/frontend/core/global/globalEvalRunner.ts
@@ -1,7 +1,9 @@
 import { mkdtemp, rm } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
+import { get } from "svelte/store";
 import type { AIProvider } from "$lib/gen/types.gen";
+import { userStore, type UserExt } from "$lib/stores";
 import {
   globalTools,
   prepareGlobalSystemMessage,
@@ -50,6 +52,41 @@ export interface GlobalLiveEditorDraftFixture {
   value?: unknown;
 }
 
+// Identity the global system prompt builds paths from. Production reads
+// `userStore` (whoami) to fill `u/{username}/...`; the eval harness never logs
+// in, so without this the prompt sees an empty username (`u//...`) and no
+// path-selection case is meaningful. Seeded per-case via the initial fixture.
+export interface GlobalUserFixture {
+  username: string;
+  is_admin?: boolean;
+  is_super_admin?: boolean;
+  operator?: boolean;
+  /** Folders the user can write to (the writable set whoami returns). */
+  folders?: string[];
+  /** Folders the user can read; read-only folders = folders_read \ folders. */
+  folders_read?: string[];
+  /** Folders the user owns (subset of folders). */
+  folders_owners?: string[];
+}
+
+function buildEvalUserExt(user: GlobalUserFixture): UserExt {
+  return {
+    email: `${user.username}@windmill.dev`,
+    username: user.username,
+    is_admin: user.is_admin ?? true,
+    is_super_admin: user.is_super_admin ?? false,
+    operator: user.operator ?? false,
+    created_at: "2024-01-01T00:00:00.000Z",
+    groups: ["all"],
+    pgroups: ["g/all"],
+    folders: user.folders ?? [],
+    folders_owners: user.folders_owners ?? user.folders ?? [],
+    // folders_read is consumed at runtime / by the Phase 2 prompt injection but
+    // is not part of the typed UserExt surface, so attach it via the cast below.
+    ...(user.folders_read ? { folders_read: user.folders_read } : {}),
+  } as UserExt;
+}
+
 export interface GlobalEvalResult {
   success: boolean;
   state: GlobalDraftState;
@@ -65,6 +102,7 @@ export interface GlobalEvalResult {
 export interface GlobalEvalOptions {
   workspaceFixtures?: BenchmarkWorkspaceRunnables;
   liveEditorDrafts?: GlobalLiveEditorDraftFixture[];
+  user?: GlobalUserFixture;
   model?: string;
   maxIterations?: number;
   provider?: AIProvider;
@@ -85,6 +123,15 @@ export async function runGlobalEval(
   clearGlobalDrafts(workspaceRoot);
   registerBenchmarkWorkspaceRunnables(workspaceRoot, options.workspaceFixtures ?? {});
   seedLiveEditorDrafts(workspaceRoot, options.liveEditorDrafts ?? []);
+
+  // `userStore` is a process-global singleton; the system message is built
+  // synchronously below (no await between set and read), so the seeded identity
+  // is captured atomically. Cross-case races are still possible under parallel
+  // execution, so path-selection cases must run with concurrency=1 (--verbose).
+  const previousUser = get(userStore);
+  if (options.user) {
+    userStore.set(buildEvalUserExt(options.user));
+  }
 
   try {
     const model = options.model ?? "claude-haiku-4-5-20251001";
@@ -129,6 +176,7 @@ export async function runGlobalEval(
       finalContextTokens: rawResult.finalContextTokens,
     };
   } finally {
+    userStore.set(previousUser);
     clearGlobalDrafts(workspaceRoot);
     clearLiveEditorDrafts(workspaceRoot, options.liveEditorDrafts ?? []);
     unregisterBenchmarkWorkspaceRunnables(workspaceRoot);

--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -1113,3 +1113,112 @@
     - renames the formatCurrency definition, imports, and all call sites to formatMoney
     - leaves the unrelated formatCurrencyPrecise helper unchanged
     - leaves the result as an AI draft only
+
+# --- Path selection (u/<user> vs f/<folder>) ---
+# These cases probe how the assistant picks a workspace path when the user gives
+# none. They depend on the seeded `user` fixture (username / is_admin / folders)
+# so the system prompt's `u/{username}` is well-formed. Assertions encode the
+# DESIRED behavior, so they are expected to fail/behave inconsistently against the
+# current prompt (which has no working folder-discovery mechanism) and to pass once
+# the folder hint/tool + prompt fix land. Run with --verbose (concurrency=1): the
+# seeded userStore is a process-global singleton.
+
+- id: global-path1-bare-name-defaults-to-personal
+  prompt: |-
+    Stage a quick draft helper that takes a string and returns it trimmed of
+    leading and trailing whitespace. Just keep it as a draft.
+  initial: ai_evals/fixtures/frontend/global/initial/user_admin_empty.json
+  runtime:
+    maxTurns: 8
+  validate:
+    draftCountExactly: 1
+    requiredDrafts:
+      - type: script
+        pathStartsWith: u/admin/
+  toolExpect:
+    requiredToolsUsed:
+      - write_script
+    forbiddenToolsUsed:
+      - deploy_workspace_item
+      - delete_workspace_item
+  skipJudge: true
+  judgeChecklist:
+    - stages a single script draft for a trim helper
+    - defaults the path to the current user's personal scope (u/admin/...) since no path or folder was given
+    - does not invent an f/<folder> path
+    - leaves the result as a draft only
+
+- id: global-path2-match-existing-folder
+  prompt: |-
+    Draft a flow for the marketing team's weekly campaign report.
+    It should take a week number and return a short summary string.
+    Keep it as a draft only.
+  initial: ai_evals/fixtures/frontend/global/initial/user_admin_folders.json
+  runtime:
+    maxTurns: 10
+  validate:
+    draftCountExactly: 1
+    requiredDrafts:
+      - type: flow
+        pathStartsWith: f/marketing/
+  toolExpect:
+    requiredToolsUsed:
+      - write_flow
+    forbiddenToolsUsed:
+      - deploy_workspace_item
+      - delete_workspace_item
+  skipJudge: true
+  judgeChecklist:
+    - drafts a flow for the marketing campaign report
+    - places it in the existing marketing folder (f/marketing/...) rather than the personal scope or an invented folder
+    - leaves the result as a draft only
+
+- id: global-path3-shared-intent-unknown-folder-asks
+  prompt: |-
+    Put together a draft onboarding checklist flow for the People Ops team to use
+    when a new hire joins. Keep it as a draft.
+  initial: ai_evals/fixtures/frontend/global/initial/user_admin_folders.json
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - askUserQuestion
+    forbiddenToolsUsed:
+      - write_flow
+      - write_script
+      - deploy_workspace_item
+      - delete_workspace_item
+  skipJudge: true
+  judgeChecklist:
+    - recognizes the request implies shared/team work but names no existing folder (none of marketing/data_engineering/shared_utils fit People Ops)
+    - asks which folder to use instead of guessing or inventing one
+    - does not create a draft until the folder is known
+
+- id: global-path4-nonadmin-avoids-readonly-folder
+  prompt: |-
+    Draft a small flow that returns today's date as an ISO string, and stage it in
+    one of our shared team folders. Keep it as a draft.
+  initial: ai_evals/fixtures/frontend/global/initial/user_bob_nonadmin_teams.json
+  runtime:
+    maxTurns: 10
+  validate:
+    draftCountExactly: 1
+    requiredDrafts:
+      - type: flow
+        pathStartsWith: f/team_a/
+    forbiddenDrafts:
+      - type: flow
+        pathStartsWith: f/team_b/
+  toolExpect:
+    requiredToolsUsed:
+      - write_flow
+    forbiddenToolsUsed:
+      - deploy_workspace_item
+      - delete_workspace_item
+  skipJudge: true
+  judgeChecklist:
+    - drafts a flow that returns the current date as an ISO string
+    - places it in team_a (writable by this non-admin user) and not team_b (read-only)
+    - leaves the result as a draft only

--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -1115,13 +1115,12 @@
     - leaves the result as an AI draft only
 
 # --- Path selection (u/<user> vs f/<folder>) ---
-# These cases probe how the assistant picks a workspace path when the user gives
-# none. They depend on the seeded `user` fixture (username / is_admin / folders)
-# so the system prompt's `u/{username}` is well-formed. Assertions encode the
-# DESIRED behavior, so they are expected to fail/behave inconsistently against the
-# current prompt (which has no working folder-discovery mechanism) and to pass once
-# the folder hint/tool + prompt fix land. Run with --verbose (concurrency=1): the
-# seeded userStore is a process-global singleton.
+# These cases assert how the assistant picks a workspace path when the user gives
+# none: a bare name defaults to the personal scope `u/<user>/`, an existing folder
+# whose purpose matches is used, a non-admin targets a writable folder and never a
+# read-only one, and shared intent with no matching folder asks rather than invents.
+# Each depends on the seeded `user` fixture (username / is_admin / folders /
+# folders_read) so the prompt's folder guidance and `u/{username}` are well-formed.
 
 - id: global-path1-bare-name-defaults-to-personal
   prompt: |-

--- a/ai_evals/fixtures/frontend/global/initial/user_admin_empty.json
+++ b/ai_evals/fixtures/frontend/global/initial/user_admin_empty.json
@@ -1,0 +1,7 @@
+{
+  "user": {
+    "username": "admin",
+    "is_admin": true,
+    "is_super_admin": true
+  }
+}

--- a/ai_evals/fixtures/frontend/global/initial/user_admin_empty.json
+++ b/ai_evals/fixtures/frontend/global/initial/user_admin_empty.json
@@ -1,7 +1,6 @@
 {
   "user": {
     "username": "admin",
-    "is_admin": true,
-    "is_super_admin": true
+    "is_admin": true
   }
 }

--- a/ai_evals/fixtures/frontend/global/initial/user_admin_folders.json
+++ b/ai_evals/fixtures/frontend/global/initial/user_admin_folders.json
@@ -1,0 +1,8 @@
+{
+  "user": {
+    "username": "admin",
+    "is_admin": true,
+    "folders": ["marketing", "data_engineering", "shared_utils"],
+    "folders_read": ["marketing", "data_engineering", "shared_utils"]
+  }
+}

--- a/ai_evals/fixtures/frontend/global/initial/user_bob_nonadmin_teams.json
+++ b/ai_evals/fixtures/frontend/global/initial/user_bob_nonadmin_teams.json
@@ -2,7 +2,6 @@
   "user": {
     "username": "bob",
     "is_admin": false,
-    "is_super_admin": false,
     "folders": ["team_a"],
     "folders_read": ["team_a", "team_b"]
   }

--- a/ai_evals/fixtures/frontend/global/initial/user_bob_nonadmin_teams.json
+++ b/ai_evals/fixtures/frontend/global/initial/user_bob_nonadmin_teams.json
@@ -1,0 +1,9 @@
+{
+  "user": {
+    "username": "bob",
+    "is_admin": false,
+    "is_super_admin": false,
+    "folders": ["team_a"],
+    "folders_read": ["team_a", "team_b"]
+  }
+}

--- a/ai_evals/modes/global.ts
+++ b/ai_evals/modes/global.ts
@@ -4,6 +4,7 @@ import { loadAppFixtureForEval } from "../adapters/frontend/core/app/appFixtureL
 import {
   runGlobalEval,
   type GlobalLiveEditorDraftFixture,
+  type GlobalUserFixture,
 } from "../adapters/frontend/core/global/globalEvalRunner";
 import type { BenchmarkWorkspaceRunnables } from "../adapters/frontend/mockBackend";
 import type { FrontendEvalModelConfig } from "../core/models";
@@ -15,6 +16,7 @@ import { getFrontendApiKey } from "./frontendCommon";
 export interface GlobalInitialFixture {
   workspace?: BenchmarkWorkspaceRunnables;
   liveEditorDrafts?: GlobalLiveEditorDraftFixture[];
+  user?: GlobalUserFixture;
 }
 
 export function createGlobalModeRunner(
@@ -38,6 +40,7 @@ export function createGlobalModeRunner(
         {
           workspaceFixtures: initial?.workspace,
           liveEditorDrafts: initial?.liveEditorDrafts,
+          user: initial?.user,
           maxIterations: context.evalCase?.runtime?.maxTurns,
           provider: modelConfig.provider,
           model: modelConfig.model,
@@ -104,6 +107,7 @@ async function loadGlobalInitialFixture(path: string): Promise<GlobalInitialFixt
   return {
     workspace: parsed.workspace ?? {},
     liveEditorDrafts: parsed.liveEditorDrafts ?? [],
+    user: parsed.user,
   };
 }
 

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -23358,6 +23358,10 @@ components:
           type: array
           items:
             type: string
+        folders_read:
+          type: array
+          items:
+            type: string
         folders_owners:
           type: array
           items:
@@ -23377,6 +23381,7 @@ components:
         - operator
         - disabled
         - folders
+        - folders_read
         - folders_owners
 
     UserSource:

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -2496,6 +2496,83 @@ describe('prepareGlobalSystemMessage', () => {
 		expect(content).not.toContain('frontend AI draft store')
 	})
 
+	describe('folder guidance', () => {
+		const guidanceOf = (user: {
+			username: string
+			is_admin?: boolean
+			folders?: string[]
+			folders_read?: string[]
+		}) => prepareGlobalSystemMessage(undefined, { user }).content as string
+
+		it('lists the writable folders for a non-admin', () => {
+			const content = guidanceOf({
+				username: 'bob',
+				is_admin: false,
+				folders: ['marketing', 'data_engineering'],
+				folders_read: ['marketing', 'data_engineering']
+			})
+			expect(content).toContain(
+				'Folders you can write to in this workspace: `f/marketing`, `f/data_engineering`.'
+			)
+			expect(content).not.toContain('You can see but NOT write to')
+		})
+
+		it('flags read-only folders a non-admin cannot write to', () => {
+			const content = guidanceOf({
+				username: 'bob',
+				is_admin: false,
+				folders: ['team_a'],
+				folders_read: ['team_a', 'team_b']
+			})
+			expect(content).toContain('Folders you can write to in this workspace: `f/team_a`.')
+			expect(content).toContain(
+				'You can see but NOT write to: `f/team_b` — never create or deploy items there.'
+			)
+		})
+
+		it('points a non-admin with no writable folders at the personal scope', () => {
+			const content = guidanceOf({ username: 'bob', is_admin: false, folders: [] })
+			expect(content).toContain(
+				'You have no shared folders you can write to in this workspace, so use `u/bob/<name>`.'
+			)
+		})
+
+		it('gives an admin permission-agnostic guidance with a non-exhaustive hint', () => {
+			const content = guidanceOf({
+				username: 'admin',
+				is_admin: true,
+				folders: ['marketing', 'data_engineering']
+			})
+			expect(content).toContain('As a workspace admin you can write to any existing folder.')
+			expect(content).toContain(
+				'Folders here include `f/marketing`, `f/data_engineering` (you can also write to others not listed).'
+			)
+			expect(content).toContain('If the user names a folder, use it; otherwise ask them.')
+			expect(content).not.toContain('Folders you can write to in this workspace')
+		})
+
+		it('omits the folder hint for an admin with no associated folders', () => {
+			const content = guidanceOf({ username: 'admin', is_admin: true, folders: [] })
+			expect(content).toContain(
+				'- As a workspace admin you can write to any existing folder. If the user names a folder, use it; otherwise ask them.'
+			)
+			expect(content).not.toContain('Folders here include')
+		})
+
+		it('caps the folder list and notes the remainder', () => {
+			const folders = Array.from({ length: 45 }, (_, i) => `f${i}`)
+			const content = guidanceOf({ username: 'bob', is_admin: false, folders })
+			expect(content).toContain('(+5 more)')
+		})
+
+		it('emits no folder guidance when no user is available', () => {
+			const content = prepareGlobalSystemMessage().content as string
+			expect(content).not.toContain('Folders you can write to in this workspace')
+			expect(content).not.toContain('As a workspace admin you can write to any existing folder')
+			expect(content).not.toContain('You have no shared folders you can write to')
+		})
+	})
+
 	it('exposes separate tools for discarding drafts and deleting workspace items', () => {
 		const discard = getGlobalTool('discard_local_draft')
 		const deleteItem = getGlobalTool('delete_workspace_item')

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -682,15 +682,17 @@ type FolderPromptContext = { folders: string[]; foldersRead: string[]; isAdmin: 
 
 // Renders the folders the current user can act on into the system prompt so the
 // model can pick an `f/<folder>/...` path without a discovery round-trip (there
-// is no folder-listing tool). `folders` is the writable set from whoami; for a
-// non-admin that is exactly what they can write to, so read-only folders are
-// listed separately as off-limits. Capped so a folder-heavy workspace can't
-// dominate the prompt.
+// is no folder-listing tool). For a non-admin, `folders` (from whoami) is exactly
+// the writable set, so read-only folders are listed separately as off-limits.
+// Admins bypass folder ACLs and can write anywhere, but `folders` only carries
+// their explicitly-permissioned subset, so for admins it is offered as a
+// non-exhaustive hint alongside permission-agnostic guidance (the complete set
+// needs a folder-listing tool — follow-up).
+// Capped so a folder-heavy workspace can't dominate the prompt.
 function buildFolderGuidance(username: string, ctx?: FolderPromptContext): string {
 	if (!ctx) return ''
 	const MAX = 40
 	const writable = ctx.folders ?? []
-	const readOnly = (ctx.foldersRead ?? []).filter((f) => !writable.includes(f))
 	const fmt = (names: string[]) => {
 		const shown = names
 			.slice(0, MAX)
@@ -698,6 +700,14 @@ function buildFolderGuidance(username: string, ctx?: FolderPromptContext): strin
 			.join(', ')
 		return names.length > MAX ? `${shown} (+${names.length - MAX} more)` : shown
 	}
+	if (ctx.isAdmin) {
+		const known =
+			writable.length > 0
+				? ` Folders here include ${fmt(writable)} (you can also write to others not listed).`
+				: ''
+		return `- As a workspace admin you can write to any existing folder.${known} If the user names a folder, use it; otherwise ask them.`
+	}
+	const readOnly = (ctx.foldersRead ?? []).filter((f) => !writable.includes(f))
 	const lines: string[] = []
 	if (writable.length > 0) {
 		lines.push(

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -678,22 +678,62 @@ const initAppSchema = z.object({
 		)
 })
 
+type FolderPromptContext = { folders: string[]; foldersRead: string[]; isAdmin: boolean }
+
+// Renders the folders the current user can act on into the system prompt so the
+// model can pick an `f/<folder>/...` path without a discovery round-trip (there
+// is no folder-listing tool). `folders` is the writable set from whoami; for a
+// non-admin that is exactly what they can write to, so read-only folders are
+// listed separately as off-limits. Capped so a folder-heavy workspace can't
+// dominate the prompt.
+function buildFolderGuidance(username: string, ctx?: FolderPromptContext): string {
+	if (!ctx) return ''
+	const MAX = 40
+	const writable = ctx.folders ?? []
+	const readOnly = (ctx.foldersRead ?? []).filter((f) => !writable.includes(f))
+	const fmt = (names: string[]) => {
+		const shown = names
+			.slice(0, MAX)
+			.map((n) => `\`f/${n}\``)
+			.join(', ')
+		return names.length > MAX ? `${shown} (+${names.length - MAX} more)` : shown
+	}
+	const lines: string[] = []
+	if (writable.length > 0) {
+		lines.push(
+			`- Folders you can write to in this workspace: ${fmt(writable)}. For shared/team work, pick the one whose purpose matches the request; if none clearly fits, ask which folder to use (askUserQuestion) rather than inventing one.`
+		)
+	} else {
+		lines.push(
+			`- You have no shared folders you can write to in this workspace, so use \`u/${username}/<name>\`. If shared placement is needed, ask the user to create or grant access to a folder first.`
+		)
+	}
+	if (readOnly.length > 0) {
+		lines.push(
+			`- You can see but NOT write to: ${fmt(readOnly)} — never create or deploy items there.`
+		)
+	}
+	return lines.join('\n')
+}
+
 const buildGlobalSystemPrompt = (
 	username: string,
-	previewTools: boolean
-) => `You are Windmill's global workspace assistant.
+	previewTools: boolean,
+	folderCtx?: FolderPromptContext
+) => {
+	const folderGuidance = buildFolderGuidance(username, folderCtx)
+	const folderGuidanceBlock = folderGuidance ? `\n${folderGuidance}` : ''
+	return `You are Windmill's global workspace assistant.
 
 The current user's workspace username is "${username}".
 
 Use tools to inspect workspace items and create per-user drafts (saved server-side, visible only to this user — not deployed) for scripts, flows, schedules, triggers, resources, variables, and raw apps.
 
 Path conventions:
-- Every workspace path has exactly three segments and starts with one of two namespaces:
-  - \`u/${username}/<name>\` — the current user's personal scope. Default for ad-hoc, exploratory, or scratch work.
-  - \`f/<folder>/<name>\` — a shared folder scope. The folder must already exist; bare \`f/<name>\` is INVALID and will fail.
-- When the user gives a bare name without a namespace prefix (e.g. "create a flow called myflow"), default to \`u/${username}/<name>\`. Do NOT invent \`f/<name>\` — that is a structurally invalid path.
-- If the request implies shared / team work but doesn't name a specific folder (e.g. "the marketing flow"), ask which folder to use rather than guessing. Call \`list_workspace_items\` with \`type: ['folder']\` (or rely on the user's hint) before assuming a folder exists.
-- Only use an \`f/<folder>/<name>\` path when the user explicitly named the folder or you confirmed it exists.
+- A workspace path starts with one of two namespaces; its trailing <name> may itself contain "/", so a path has three or more segments:
+  - \`u/${username}/<name>\` — your personal scope. Default for ad-hoc, exploratory, or scratch work.
+  - \`f/<folder>/<name>\` — a shared folder scope; the <folder> must already exist (a bare \`f/<name>\` with no folder segment is INVALID and will fail).
+- Default a bare name with no namespace prefix (e.g. "create a flow called myflow") to \`u/${username}/<name>\`. Never invent an \`f/<folder>/...\` path for a folder that does not exist.${folderGuidanceBlock}
 
 Rules:
 - Draft tools create or update drafts only; they do not deploy or mutate deployed workspace items.
@@ -741,6 +781,7 @@ Data Tables:
 - Use get_datatable_table_schema only when you need a table's column names/types; list_datatables is enough for table-list or availability summaries.
 - Use exec_datatable_sql to explore data, run queries, mutate rows, or change schema (CREATE/ALTER/DROP). Creating a table is a normal CREATE TABLE statement — it appears in list_datatables afterward, with no registration step.
 - When writing runnable code (inline app runnables, scripts, flow modules) that reads or writes datatable data at runtime, it accesses a datatable via wmill.datatable(). Default to TypeScript (bun) unless the user asked for another language. Call get_instructions with subject "datatable" and language "bun" for the TypeScript SQL SDK reference (or language "python3" for Python) — it returns only that language so you get just what you need.`
+}
 
 const DEFAULT_LIST_TYPES = ['script', 'flow'] as const satisfies readonly WorkspaceItemType[]
 
@@ -3864,8 +3905,17 @@ export function prepareGlobalSystemMessage(
 	customPrompt?: string,
 	opts?: { previewTools?: boolean }
 ): ChatCompletionSystemMessageParam {
-	const username = get(userStore)?.username ?? ''
-	let content = buildGlobalSystemPrompt(username, opts?.previewTools ?? false)
+	const user = get(userStore)
+	const username = user?.username ?? ''
+	const folderCtx: FolderPromptContext | undefined = user
+		? {
+				folders: user.folders ?? [],
+				foldersRead:
+					((user as { folders_read?: string[] }).folders_read ?? user.folders ?? []),
+				isAdmin: user.is_admin ?? false
+			}
+		: undefined
+	let content = buildGlobalSystemPrompt(username, opts?.previewTools ?? false, folderCtx)
 	if (customPrompt?.trim()) {
 		content = `${content}\n\nUSER GIVEN INSTRUCTIONS:\n${customPrompt.trim()}`
 	}

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -3913,15 +3913,20 @@ async function deleteWorkspaceItem(
 
 export function prepareGlobalSystemMessage(
 	customPrompt?: string,
-	opts?: { previewTools?: boolean }
+	opts?: {
+		previewTools?: boolean
+		// Identity the path-convention guidance is built from. Production omits it
+		// (read from userStore); callers that must not touch the process-global
+		// store (the eval harness) pass it explicitly instead.
+		user?: { username: string; is_admin?: boolean; folders?: string[]; folders_read?: string[] }
+	}
 ): ChatCompletionSystemMessageParam {
-	const user = get(userStore)
+	const user = opts?.user ?? get(userStore)
 	const username = user?.username ?? ''
 	const folderCtx: FolderPromptContext | undefined = user
 		? {
 				folders: user.folders ?? [],
-				foldersRead:
-					((user as { folders_read?: string[] }).folders_read ?? user.folders ?? []),
+				foldersRead: user.folders_read ?? user.folders ?? [],
 				isAdmin: user.is_admin ?? false
 			}
 		: undefined

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -27,6 +27,7 @@ export interface UserExt {
 	groups: string[]
 	pgroups: string[]
 	folders: string[]
+	folders_read: string[]
 	folders_owners: string[]
 	is_service_account?: boolean
 	impersonating_email?: string


### PR DESCRIPTION
## Summary

Global mode (the workspace-wide AI chat) had no working way to pick an `f/<folder>/…` path when the user doesn't give one. The system prompt told the model to discover folders by calling `list_workspace_items` with `type: ['folder']`, but that type isn't accepted (it throws), there is no folder-listing tool, and the prompt's "every workspace path has exactly three segments" was factually wrong (names can contain `/`). In practice the model couldn't target an existing folder, didn't ask when shared intent had no matching folder, and invented non-existent folders.

This PR (1) adds `ai_evals` coverage that reproduces the issue, and (2) fixes the prompt to inject the user's folders directly from `userStore` (no extra backend call) and corrects the path conventions.

## Changes

- **Prompt (`frontend/.../copilot/chat/global/core.ts`)**:
  - Rewrote the Path-conventions block — removed the broken `list_workspace_items type:['folder']` instruction, corrected "exactly three segments" → "three or more (the trailing name may contain `/`)".
  - New `buildFolderGuidance` injects folder context from `userStore`:
    - **Non-admins**: their writable folders, plus read-only folders flagged as off-limits.
    - **Admins**: "you can write to any existing folder; if the user names one, use it, otherwise ask" + their explicitly-permissioned folders as a **non-exhaustive hint** (an admin's `userStore.folders` is only the explicit-perms subset since admins bypass folder ACLs; the complete set needs a folder-listing tool — see follow-ups).
  - Capped at 40 folders.
- **Eval harness (`ai_evals/adapters/frontend/core/global/globalEvalRunner.ts`, `ai_evals/modes/global.ts`)**: the harness never seeded `userStore`, so the prompt saw an empty username (`u//<name>`). Added a `user` field to the case `initial` fixture that seeds `userStore` (username / is_admin / folders / folders_read) before the system message is built. `userStore` is a process-global singleton → run these cases with `--verbose` (concurrency 1).
- **Eval cases (`ai_evals/cases/global.yaml` + 3 fixtures)**: 4 `global-path*` cases.

## Test plan / results

`sonnet`, baseline (before) vs this PR (after the prompt fix):

| Case | Baseline | This PR | Result |
|---|---|---|---|
| path1 — bare name → personal | `u/admin/...` | `u/admin/...` | ✅ → ✅ |
| path2 — `marketing` folder exists | `u/admin/...` | `f/marketing/...` | ❌ → ✅ |
| path3 — shared intent, no matching folder | invented `f/people_ops` | `u/admin/...` (still not "ask") | ❌ → ❌ |
| path4 — non-admin, `team_b` read-only | invented `f/team` | `f/team_a/...` | ❌ → ✅ |

**Pass rate 1/4 → 3/4.** path2/path4 also collapsed from 5–7 tool calls (futile discovery loops) to just `get_instructions` + `write_flow`. (Folder handling was iterated: a plain folder list scored 3/4 but misled superadmins; the admin-aware hybrid keeps 3/4 *and* gives superadmins correct guidance.)

Reproduce:
```bash
cd ai_evals
WMILL_AI_EVAL_BACKEND_URL=<backend-url> WMILL_AI_EVAL_BACKEND_WORKSPACE=<workspace> \
  bun run cli -- run global \
  global-path1-bare-name-defaults-to-personal \
  global-path2-match-existing-folder \
  global-path3-shared-intent-unknown-folder-asks \
  global-path4-nonadmin-avoids-readonly-folder \
  --model sonnet --verbose
```

- [ ] `npm run check` (frontend types)
- [ ] re-run the 4 `global-path*` cases and confirm 3/4 (path3 is a known follow-up)

### No visible UI
The only `frontend/` change is an LLM system-prompt string — there is no rendered UI change to screenshot. It is verified behaviorally through `ai_evals` (above).

## Follow-ups

- **path3 (ask vs default for shared intent)**: for "an onboarding flow for the People Ops team" (shared intent, no matching folder), the model defaults to `u/admin` instead of calling `askUserQuestion`. Needs a stronger ask-for-shared-intent rule; re-run path3 after.
- **`list_folders` tool for complete admin folder set**: the injected admin hint is the *explicit-perms* subset; a dedicated folder-listing tool hitting `/folders/list` returns all folders for admins (they bypass ACLs). Needs mock-backend folder support to evaluate.
- **(local only, not in this PR)** a temporary CE workspace-cap bypass in `windmill-api-workspaces/src/workspaces.rs` was used to stand up test workspaces; it is intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)