### PR TITLE
fix: enforce containment of python module dir for preview jobs

### DIFF
--- a/backend/windmill-api-auth/src/lib.rs
+++ b/backend/windmill-api-auth/src/lib.rs
@@ -996,6 +996,18 @@ pub fn require_path_read_access_for_preview(
         return Ok(());
     };
 
+    // Reject path traversal before any privilege-based short-circuit. A Preview's
+    // path is request-supplied and bypasses the DB `proper_id` CHECK that deployed
+    // runnables get; it then flows to the worker where it builds on-disk module
+    // directories. A `..` segment or an absolute path could let a write escape the
+    // per-job dir.
+    if path.starts_with('/') || path.split('/').any(|seg| seg == "..") || path.contains('\0') {
+        return Err(Error::BadRequest(format!(
+            "Invalid path for preview job: {}",
+            path
+        )));
+    }
+
     if authed.is_admin {
         return Ok(());
     }
@@ -1051,6 +1063,45 @@ mod tests {
             scopes: scopes.map(|v| v.into_iter().map(String::from).collect()),
             ..Default::default()
         }
+    }
+
+    // Regression tests for the Preview path traversal: a Preview's path skips the
+    // DB `proper_id` CHECK and reaches the worker, where it builds on-disk module
+    // dirs. Traversal must be rejected even for admins, who otherwise bypass the
+    // namespace/folder access check.
+    #[test]
+    fn preview_path_rejects_traversal() {
+        let admin = ApiAuthed { is_admin: true, username: "admin".into(), ..Default::default() };
+        for path in [
+            "u/admin/../../../../../../tmp/evil/payload",
+            "../../tmp/evil",
+            "/tmp/evil",
+            "u/admin/ok/../../../../etc/cron.d/x",
+        ] {
+            assert!(
+                require_path_read_access_for_preview(&admin, &Some(path.to_string())).is_err(),
+                "expected traversal path to be rejected: {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn preview_path_allows_legitimate_paths() {
+        let alice = ApiAuthed { username: "alice".into(), ..Default::default() };
+        assert!(require_path_read_access_for_preview(&alice, &None).is_ok());
+        assert!(require_path_read_access_for_preview(&alice, &Some(String::new())).is_ok());
+        assert!(
+            require_path_read_access_for_preview(&alice, &Some("u/alice/my_script".into())).is_ok()
+        );
+
+        let admin = ApiAuthed { is_admin: true, username: "admin".into(), ..Default::default() };
+        assert!(
+            require_path_read_access_for_preview(&admin, &Some("hub/foo/bar/baz".into())).is_ok()
+        );
+        // `..` only as a substring of a segment is a valid name, not traversal.
+        assert!(
+            require_path_read_access_for_preview(&admin, &Some("f/team/my..script".into())).is_ok()
+        );
     }
 
     #[test]

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -37,8 +37,8 @@ use windmill_common::{
     scripts::ScriptLang,
     utils::calculate_hash,
     worker::{
-        copy_dir_recursively, pad_string, split_python_requirements, write_file, Connection,
-        PyVAlias, PythonAnnotations, WORKER_CONFIG,
+        copy_dir_recursively, is_allowed_file_location, pad_string, split_python_requirements,
+        write_file, Connection, PyVAlias, PythonAnnotations, WORKER_CONFIG,
     },
 };
 
@@ -664,10 +664,16 @@ pub fn compute_python_module_dir(script_path: &str) -> String {
         .replace("-", "_")
         .replace("@", ".");
     if dirs_full.len() > 0 {
-        dirs_full
-            .strip_prefix("/")
-            .unwrap_or(&dirs_full)
-            .to_string()
+        let dirs = dirs_full.strip_prefix("/").unwrap_or(&dirs_full);
+        // This directory is appended to job_dir and written to. Neutralize any
+        // `.`/`..` segment so the result stays a relative path inside job_dir: a
+        // Preview path is request-supplied and skips the DB `proper_id` CHECK that
+        // deployed runnables get, and the `@`->`.` rewrite above can also turn a
+        // segment like `@.` into `..`.
+        dirs.split('/')
+            .map(|seg| if seg == "." || seg == ".." { "_" } else { seg })
+            .collect::<Vec<_>>()
+            .join("/")
     } else {
         "tmp".to_string()
     }
@@ -1668,6 +1674,10 @@ async fn prepare_wrapper(
         last
     };
     let module_dir = format!("{}/{}", job_dir, dirs);
+    // Defense-in-depth: `dirs`/`last` derive from the (request-supplied for
+    // previews) script path. compute_python_module_dir already neutralizes `..`,
+    // but assert containment here too so the write can never escape job_dir.
+    is_allowed_file_location(job_dir, &format!("{dirs}/{last}.py"))?;
     tokio::fs::create_dir_all(format!("{module_dir}/")).await?;
 
     let _ = write_file(&module_dir, &format!("{last}.py"), inner_content)?;
@@ -3355,6 +3365,17 @@ mod tests {
         // A folder whose name is a Python keyword would otherwise produce an
         // invalid `from f.in.x import ...`; it is underscore-prefixed.
         assert_eq!(compute_python_module_dir("f/in/script"), "f/_in");
+    }
+
+    #[test]
+    fn test_compute_python_module_dir_neutralizes_traversal() {
+        // A Preview path skips the DB `proper_id` CHECK, so it can carry `..`.
+        // `..`/`.` segments must be neutralized so the dir stays inside job_dir.
+        let dirs = compute_python_module_dir("u/x/../../../../tmp/evil/payload");
+        assert!(!dirs.split('/').any(|s| s == ".." || s == "."));
+        assert_eq!(dirs, "u/x/_/_/_/_/tmp/evil");
+        // The `@`->`.` rewrite must not be able to synthesize a `..` segment.
+        assert_eq!(compute_python_module_dir("u/@./script"), "u/_");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Hardens how preview jobs derive the on-disk Python module directory so it always stays within the per-job working directory. A preview job's `path` is request-supplied and does not go through the same DB constraints as deployed runnables, so it is now validated at the API boundary and again at the worker write site.

## Changes

- `windmill-api-auth`: `require_path_read_access_for_preview` now rejects malformed preview paths (parent-dir segments, absolute paths, NUL) before any privilege-based short-circuit, so the check applies uniformly including to admins.
- `windmill-worker` `compute_python_module_dir`: neutralizes any `.`/`..` path segment to `_` so the computed module dir is always a relative path inside `job_dir`. This is done after the existing `@`->`.` rewrite (which could otherwise synthesize a `..`). The same function feeds `write_module_files`' base dir, so both sinks are covered.
- `windmill-worker` `prepare_wrapper`: asserts containment via `is_allowed_file_location` before writing the module file (defense-in-depth).

## Test plan

- [x] `cargo test -p windmill-api-auth preview_path` — rejects parent-dir/absolute paths even for admins; allows legitimate `u/`, `f/`, `hub/`, empty and `None` paths, plus `..`-as-substring names.
- [x] `cargo test -p windmill-worker --features python compute_python_module_dir` — `..` and `@.`-synthesized `..` segments neutralized; existing cases unchanged.
- [x] Live: preview run with a malformed path returns 400 before enqueue; legitimate path runs as before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents path traversal in preview jobs by containing the Python module directory within each job’s working folder. Satisfies WIN-2062 by blocking arbitrary file writes outside `job_dir` from user-supplied preview paths.

- **Bug Fixes**
  - `windmill-api-auth`: `require_path_read_access_for_preview` rejects absolute paths, `..` segments, and NULs before privilege checks (applies to admins too).
  - `windmill-worker`: `compute_python_module_dir` neutralizes `.`/`..` after the `@`→`.` rewrite to keep paths relative; `prepare_wrapper` enforces containment with `is_allowed_file_location` before writing.
  - Tests added for preview path validation and traversal neutralization; malformed preview paths now 400 before enqueue.

<sup>Written for commit 621c0f9b94ac95e1850bf42087406f370ea7a0a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

