### PR TITLE
fix: ignore NotFound errors when deleting log files from object store

### DIFF
--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -1640,7 +1640,15 @@ async fn delete_log_files_from_disk_and_store(
                 let mut result = os.delete_stream(stream);
                 while let Some(r) = result.next().await {
                     if let Err(e) = r {
-                        tracing::error!("Failed to delete from object store: {e}");
+                        // Deleting a non-existent object is a successful no-op. S3's
+                        // DeleteObjects ignores missing keys, but GCS returns 404 per
+                        // delete, surfacing as NotFound — skip it to avoid noisy errors.
+                        if !matches!(
+                            e,
+                            windmill_object_store::object_store_reexports::ObjectStoreError::NotFound { .. }
+                        ) {
+                            tracing::error!("Failed to delete from object store: {e}");
+                        }
                     }
                 }
             }

--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -1638,18 +1638,29 @@ async fn delete_log_files_from_disk_and_store(
                     .collect();
                 let stream = futures::stream::iter(s3_paths).boxed();
                 let mut result = os.delete_stream(stream);
+                let mut deleted = 0u64;
+                let mut not_found = 0u64;
+                let mut failed = 0u64;
                 while let Some(r) = result.next().await {
-                    if let Err(e) = r {
+                    match r {
+                        Ok(_) => deleted += 1,
                         // Deleting a non-existent object is a successful no-op. S3's
                         // DeleteObjects ignores missing keys, but GCS returns 404 per
-                        // delete, surfacing as NotFound — skip it to avoid noisy errors.
-                        if !matches!(
-                            e,
-                            windmill_object_store::object_store_reexports::ObjectStoreError::NotFound { .. }
-                        ) {
+                        // delete, surfacing as NotFound — count it separately rather
+                        // than logging it as an error.
+                        Err(windmill_object_store::object_store_reexports::ObjectStoreError::NotFound { .. }) => {
+                            not_found += 1;
+                        }
+                        Err(e) => {
+                            failed += 1;
                             tracing::error!("Failed to delete from object store: {e}");
                         }
                     }
+                }
+                if deleted + not_found + failed > 0 {
+                    tracing::info!(
+                        "object store log cleanup: {deleted} deleted, {not_found} already absent (404), {failed} failed"
+                    );
                 }
             }
         }

--- a/backend/windmill-api-settings/src/log_cleanup.rs
+++ b/backend/windmill-api-settings/src/log_cleanup.rs
@@ -63,6 +63,10 @@ pub struct LogCleanupProgress {
     pub total_jobs: u64,
     pub processed_jobs: u64,
     pub s3_deleted: u64,
+    /// Number of delete calls that returned 404 (object already absent — a no-op
+    /// success). GCS returns 404 per missing key where S3's DeleteObjects stays silent.
+    #[serde(default)]
+    pub s3_not_found: u64,
     /// Number of S3 objects inspected during the orphan scan phase.
     pub orphans_scanned: u64,
     /// Number of orphan S3 objects deleted (no corresponding DB row).
@@ -83,6 +87,7 @@ impl LogCleanupProgress {
             total_jobs: 0,
             processed_jobs: 0,
             s3_deleted: 0,
+            s3_not_found: 0,
             orphans_scanned: 0,
             orphans_deleted: 0,
             errors: 0,
@@ -134,6 +139,13 @@ impl Session {
             p.phase = "done".to_string();
             p.clone()
         };
+        tracing::info!(
+            "log cleanup finished: {} object(s) deleted from object store, {} already absent (404), {} orphans deleted, {} error(s)",
+            snapshot.s3_deleted,
+            snapshot.s3_not_found,
+            snapshot.orphans_deleted,
+            snapshot.errors
+        );
         if let Err(e) = background_task::release(&self.db, TASK_NAME, &self.owner, &snapshot).await
         {
             tracing::warn!("log cleanup: failed to release lease: {e:#}");
@@ -181,9 +193,14 @@ pub async fn get_status(db: &DB) -> error::Result<Option<LogCleanupProgress>> {
 async fn s3_bulk_delete(
     store: &Arc<dyn ObjectStore>,
     paths: Vec<ObjectPath>,
-) -> (u64 /* deleted */, u64 /* errors */) {
+) -> (
+    u64, /* deleted */
+    u64, /* not_found */
+    u64, /* errors */
+) {
     let stream = futures::stream::iter(paths.into_iter().map(Ok)).boxed();
     let mut deleted = 0u64;
+    let mut not_found = 0u64;
     let mut errors = 0u64;
     let mut res = store.delete_stream(stream);
     while let Some(r) = res.next().await {
@@ -191,9 +208,9 @@ async fn s3_bulk_delete(
             Ok(_) => deleted += 1,
             // Deleting a non-existent object is a successful no-op. S3's DeleteObjects
             // ignores missing keys, but GCS returns 404 per delete, surfacing as
-            // NotFound — count it as deleted to avoid noisy errors.
+            // NotFound — track it separately so it isn't reported as an error.
             Err(ObjectStoreError::NotFound { .. }) => {
-                deleted += 1;
+                not_found += 1;
             }
             Err(e) => {
                 errors += 1;
@@ -201,7 +218,7 @@ async fn s3_bulk_delete(
             }
         }
     }
-    (deleted, errors)
+    (deleted, not_found, errors)
 }
 
 /// Delete the given relative paths from the local filesystem under `base_dir`.
@@ -273,7 +290,7 @@ async fn cleanup_service_logs(
             .iter()
             .map(|p| ObjectPath::from(format!("{}{}", LOGS_SERVICE, p)))
             .collect();
-        let (deleted, errors) = s3_bulk_delete(store, s3_paths).await;
+        let (deleted, not_found, errors) = s3_bulk_delete(store, s3_paths).await;
         disk_bulk_delete(&*TMP_WINDMILL_LOGS_SERVICE, &rel_paths).await;
 
         session
@@ -283,6 +300,7 @@ async fn cleanup_service_logs(
                     p.total_service = p.processed_service;
                 }
                 p.s3_deleted = p.s3_deleted.saturating_add(deleted);
+                p.s3_not_found = p.s3_not_found.saturating_add(not_found);
                 p.errors = p.errors.saturating_add(errors);
             })
             .await;
@@ -333,7 +351,7 @@ async fn cleanup_job_logs(
             .iter()
             .map(|p| ObjectPath::from(p.clone()))
             .collect();
-        let (deleted, errors) = s3_bulk_delete(store, s3_paths).await;
+        let (deleted, not_found, errors) = s3_bulk_delete(store, s3_paths).await;
         disk_bulk_delete(&*WINDMILL_DIR, &rel_paths).await;
 
         session
@@ -343,6 +361,7 @@ async fn cleanup_job_logs(
                     p.total_jobs = p.processed_jobs;
                 }
                 p.s3_deleted = p.s3_deleted.saturating_add(deleted);
+                p.s3_not_found = p.s3_not_found.saturating_add(not_found);
                 p.errors = p.errors.saturating_add(errors);
             })
             .await;
@@ -569,11 +588,12 @@ async fn flush_service_orphans(
     batch: &mut Vec<ObjectPath>,
 ) {
     let paths = std::mem::take(batch);
-    let (deleted, errors) = s3_bulk_delete(store, paths).await;
+    let (deleted, not_found, errors) = s3_bulk_delete(store, paths).await;
     session
         .update(|p| {
             p.orphans_deleted = p.orphans_deleted.saturating_add(deleted);
             p.s3_deleted = p.s3_deleted.saturating_add(deleted);
+            p.s3_not_found = p.s3_not_found.saturating_add(not_found);
             p.errors = p.errors.saturating_add(errors);
         })
         .await;
@@ -624,11 +644,12 @@ async fn flush_job_orphans(
         return;
     }
 
-    let (deleted, errors) = s3_bulk_delete(store, to_delete).await;
+    let (deleted, not_found, errors) = s3_bulk_delete(store, to_delete).await;
     session
         .update(|p| {
             p.orphans_deleted = p.orphans_deleted.saturating_add(deleted);
             p.s3_deleted = p.s3_deleted.saturating_add(deleted);
+            p.s3_not_found = p.s3_not_found.saturating_add(not_found);
             p.errors = p.errors.saturating_add(errors);
         })
         .await;

--- a/backend/windmill-api-settings/src/log_cleanup.rs
+++ b/backend/windmill-api-settings/src/log_cleanup.rs
@@ -31,7 +31,9 @@ use windmill_common::tracing_init::{LOGS_SERVICE, TMP_WINDMILL_LOGS_SERVICE};
 use windmill_common::worker::WINDMILL_DIR;
 use windmill_common::{DB, INSTANCE_NAME, JOB_RETENTION_SECS, SERVICE_LOG_RETENTION_SECS};
 
-use windmill_object_store::object_store_reexports::{ObjectStore, Path as ObjectPath};
+use windmill_object_store::object_store_reexports::{
+    Error as ObjectStoreError, ObjectStore, Path as ObjectPath,
+};
 
 pub const TASK_NAME: &str = "log_cleanup";
 
@@ -187,6 +189,12 @@ async fn s3_bulk_delete(
     while let Some(r) = res.next().await {
         match r {
             Ok(_) => deleted += 1,
+            // Deleting a non-existent object is a successful no-op. S3's DeleteObjects
+            // ignores missing keys, but GCS returns 404 per delete, surfacing as
+            // NotFound — count it as deleted to avoid noisy errors.
+            Err(ObjectStoreError::NotFound { .. }) => {
+                deleted += 1;
+            }
             Err(e) => {
                 errors += 1;
                 tracing::warn!("log cleanup: failed to delete object: {e:#}");

--- a/backend/windmill-api-settings/src/log_cleanup.rs
+++ b/backend/windmill-api-settings/src/log_cleanup.rs
@@ -32,7 +32,7 @@ use windmill_common::worker::WINDMILL_DIR;
 use windmill_common::{DB, INSTANCE_NAME, JOB_RETENTION_SECS, SERVICE_LOG_RETENTION_SECS};
 
 use windmill_object_store::object_store_reexports::{
-    Error as ObjectStoreError, ObjectStore, Path as ObjectPath,
+    ObjectStore, ObjectStoreError, Path as ObjectPath,
 };
 
 pub const TASK_NAME: &str = "log_cleanup";

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -1655,6 +1655,9 @@ paths:
                   s3_deleted:
                     type: integer
                     format: int64
+                  s3_not_found:
+                    type: integer
+                    format: int64
                   orphans_scanned:
                     type: integer
                     format: int64

--- a/frontend/src/lib/components/ObjectStoreConfigSettings.svelte
+++ b/frontend/src/lib/components/ObjectStoreConfigSettings.svelte
@@ -141,6 +141,7 @@
 		total_jobs: number
 		processed_jobs: number
 		s3_deleted: number
+		s3_not_found?: number
 		orphans_scanned: number
 		orphans_deleted: number
 		errors: number
@@ -418,6 +419,9 @@
 						</span>
 						<span>
 							S3 deleted: {cleanupStatus.s3_deleted.toLocaleString()}
+							{#if (cleanupStatus.s3_not_found ?? 0) > 0}
+								&middot; already absent (404): {(cleanupStatus.s3_not_found ?? 0).toLocaleString()}
+							{/if}
 							{#if cleanupStatus.errors > 0}
 								&middot; errors: {cleanupStatus.errors.toLocaleString()}
 							{/if}


### PR DESCRIPTION
## Problem

Periodic log cleanup (`monitor.rs`) and manual log cleanup (`log_cleanup.rs`) both delete log files from instance object storage. S3's `DeleteObjects` API silently ignores missing keys, but **GCS returns a 404 for each individual delete**. The `object_store` crate's default `delete_stream` implementation (used by GCS) propagates these as `Error::NotFound`, producing noisy error/warning logs on every cleanup cycle.

The cleanup itself always succeeds — DB records are removed regardless — but operators saw alarming error messages about failed deletes.

## Fix

Treat a `NotFound` delete as a successful no-op (not an error) in both delete handlers, and **report how many of the attempted deletes were 404 no-ops** so the outcome is transparent rather than silent:

- **`backend/src/monitor.rs`** — no longer logs `NotFound` as an error; counts outcomes and emits one info summary per cleanup cycle (only when work occurred):
  `object store log cleanup: N deleted, M already absent (404), K failed`.
- **`backend/windmill-api-settings/src/log_cleanup.rs`** — adds an `s3_not_found` counter to `LogCleanupProgress`, threads it through `s3_bulk_delete` and all four call sites, and logs a final summary when the task finishes:
  `log cleanup finished: N deleted, M already absent (404), … orphans deleted, K errors`.
  The new field uses `#[serde(default)]` so previously-persisted in-flight progress rows still deserialize.

The `object_store` error type is referenced via the existing `windmill_object_store::object_store_reexports` re-export (`ObjectStoreError`) so neither crate needs a new direct dependency.

### Frontend

The manual cleanup status panel (`ObjectStoreConfigSettings.svelte`) now shows the 404 count alongside the existing "S3 deleted" / "errors" line (`already absent (404): M`, only when non-zero). OpenAPI schema and the generated client were updated accordingly.

## Validation

- Backend rebuilt cleanly via the running `cargo watch` (both `windmill` and `windmill-api-settings`), server restarted healthy, no compile errors.
- `npm run generate-backend-client` regenerated the client with the new `s3_not_found` field.
- `npm run check:fast` — no errors in the changed component (the 67 reported errors are pre-existing `Timeout`/`number` issues in unrelated files).

This is logic + observability; reproducing the 404 path at runtime requires GCS returning a 404 during cleanup, which isn't reproducible against the local stack, so verification is the clean compile/type-check plus the new counters/summary logs.

Fixes WIN-2081