### PR TITLE
feat: ducklake time-travel UX (snapshot history + AT VERSION reads)

### DIFF
--- a/backend/windmill-common/src/query_builders.rs
+++ b/backend/windmill-common/src/query_builders.rs
@@ -220,11 +220,16 @@ struct CountPayload {
 }
 
 /// `WM_INTERNAL_DB_DUCKLAKE_SNAPSHOTS` payload — lists the time-travel history
-/// (catalog commit log) of a ducklake. Snapshots are catalog-wide in DuckLake,
-/// so this lists every commit; any `AT (VERSION => n)` read targets one of them.
+/// of a ducklake table. DuckLake snapshots are catalog-wide commits, so without
+/// a `table` this lists every commit; with one it is scoped to snapshots where
+/// that table exists (see `expand_ducklake_snapshots`).
 #[derive(Deserialize)]
 struct DucklakeSnapshotsPayload {
     ducklake: String,
+    /// Schema-qualified table name (e.g. `main.events_daily`) to scope the
+    /// history to. Snapshots predating the table's creation are excluded — a
+    /// time-travel read can't target a version where the table didn't exist.
+    table: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -397,9 +402,27 @@ fn expand_ducklake_snapshots(json_str: &str, db_type: DbType) -> Result<String, 
     let payload: DucklakeSnapshotsPayload = serde_json::from_str(json_str)
         .map_err(|e| format!("Invalid DUCKLAKE_SNAPSHOTS payload: {}", e))?;
     // `dl` is the alias `wrap_ducklake_query` attaches and `USE`s below.
-    let query =
-        "SELECT snapshot_id, snapshot_time FROM ducklake_snapshots('dl') ORDER BY snapshot_id DESC"
-            .to_string();
+    let query = match &payload.table {
+        // Scope to snapshots from the table's first creation onward. A DuckLake
+        // table created at snapshot N can't be read before N (the catalog-wide
+        // list would otherwise offer impossible versions). The creation snapshot
+        // is the earliest whose `changes.tables_created` names the table;
+        // COALESCE to 0 (show all) if it is never found.
+        Some(table) => {
+            let table = escape_sql_literal(table);
+            format!(
+                "SELECT snapshot_id, snapshot_time FROM ducklake_snapshots('dl') \
+                 WHERE snapshot_id >= COALESCE((\
+                   SELECT min(snapshot_id) FROM ducklake_snapshots('dl') \
+                   WHERE list_contains(changes.tables_created, '{table}')), 0) \
+                 ORDER BY snapshot_id DESC"
+            )
+        }
+        None => {
+            "SELECT snapshot_id, snapshot_time FROM ducklake_snapshots('dl') ORDER BY snapshot_id DESC"
+                .to_string()
+        }
+    };
     Ok(maybe_wrap_ducklake(query, Some(&payload.ducklake)))
 }
 
@@ -3304,6 +3327,17 @@ mod tests {
         assert!(result.contains("ATTACH 'ducklake://analytics' AS dl;USE dl;"));
         assert!(result.contains("ducklake_snapshots('dl')"));
         assert!(result.contains("ORDER BY snapshot_id DESC"));
+        // Unscoped: no per-table existence filter.
+        assert!(!result.contains("tables_created"));
+    }
+
+    #[test]
+    fn test_expand_ducklake_snapshots_scoped_to_table() {
+        let json = r#"{"ducklake": "analytics", "table": "main.events_daily"}"#;
+        let result = expand_ducklake_snapshots(json, DbType::Duckdb).unwrap();
+        // Scoped to snapshots from the table's first creation onward.
+        assert!(result.contains("list_contains(changes.tables_created, 'main.events_daily')"));
+        assert!(result.contains("snapshot_id >= COALESCE"));
     }
 
     #[test]

--- a/backend/windmill-common/src/query_builders.rs
+++ b/backend/windmill-common/src/query_builders.rs
@@ -172,6 +172,19 @@ pub struct SimpleColumn {
 pub struct SelectOptions {
     pub limit: Option<i64>,
     pub offset: Option<i64>,
+    /// DuckLake time-travel: when set (DuckDB only), the read is pinned to this
+    /// catalog snapshot via `AT (VERSION => n)`. Ignored for other db types.
+    pub version: Option<i64>,
+}
+
+/// DuckLake time-travel suffix appended after a table name in a FROM clause.
+/// `n` is a server-controlled `i64` (a snapshot id), so inlining it is
+/// injection-safe. Empty string when unpinned (reads the latest snapshot).
+fn duckdb_version_suffix(version: Option<i64>) -> String {
+    match version {
+        Some(v) => format!(" AT (VERSION => {})", v),
+        None => String::new(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -190,6 +203,8 @@ struct SelectPayload {
     #[serde(rename = "fixPgIntTypes")]
     fix_pg_int_types: Option<bool>,
     ducklake: Option<String>,
+    /// DuckLake snapshot to time-travel the read to (DuckDB only).
+    version: Option<i64>,
 }
 
 #[derive(Deserialize)]
@@ -200,6 +215,16 @@ struct CountPayload {
     #[serde(rename = "whereClause")]
     where_clause: Option<String>,
     ducklake: Option<String>,
+    /// DuckLake snapshot to time-travel the count to (DuckDB only).
+    version: Option<i64>,
+}
+
+/// `WM_INTERNAL_DB_DUCKLAKE_SNAPSHOTS` payload — lists the time-travel history
+/// (catalog commit log) of a ducklake. Snapshots are catalog-wide in DuckLake,
+/// so this lists every commit; any `AT (VERSION => n)` read targets one of them.
+#[derive(Deserialize)]
+struct DucklakeSnapshotsPayload {
+    ducklake: String,
 }
 
 #[derive(Deserialize)]
@@ -304,6 +329,10 @@ pub fn try_expand_internal_db_query(
             expand_primary_key_constraint(json_str, db_type).map(ExpandedQuery::sql)
         }
         "SNOWFLAKE_PRIMARY_KEYS" => expand_snowflake_primary_keys(json_str).map(ExpandedQuery::sql),
+        // DuckLake time-travel: list a ducklake's snapshot history
+        "DUCKLAKE_SNAPSHOTS" => {
+            expand_ducklake_snapshots(json_str, db_type).map(ExpandedQuery::sql)
+        }
         _ => Err(format!("Unknown WM_INTERNAL_DB operation: {}", op)),
     };
 
@@ -324,7 +353,8 @@ fn expand_select(json_str: &str, db_type: DbType) -> Result<String, String> {
     let payload: SelectPayload =
         serde_json::from_str(json_str).map_err(|e| format!("Invalid SELECT payload: {}", e))?;
 
-    let options = SelectOptions { limit: payload.limit, offset: payload.offset };
+    let options =
+        SelectOptions { limit: payload.limit, offset: payload.offset, version: payload.version };
     let breaking = payload
         .fix_pg_int_types
         .map(|v| BreakingFeatures { fix_pg_int_types: v });
@@ -350,9 +380,27 @@ fn expand_count(json_str: &str, db_type: DbType) -> Result<String, String> {
         &payload.table,
         payload.where_clause.as_deref(),
         &payload.column_defs,
+        payload.version,
     )?;
 
     Ok(maybe_wrap_ducklake(query, payload.ducklake.as_deref()))
+}
+
+/// Expand `DUCKLAKE_SNAPSHOTS` into the catalog's time-travel history. DuckLake
+/// snapshots are catalog-wide commits, so `ducklake_snapshots('dl')` (the alias
+/// `maybe_wrap_ducklake` attaches) lists every version any `AT (VERSION => n)`
+/// read can target, newest first.
+fn expand_ducklake_snapshots(json_str: &str, db_type: DbType) -> Result<String, String> {
+    if db_type != DbType::Duckdb {
+        return Err("DUCKLAKE_SNAPSHOTS is only supported for DuckDB".to_string());
+    }
+    let payload: DucklakeSnapshotsPayload = serde_json::from_str(json_str)
+        .map_err(|e| format!("Invalid DUCKLAKE_SNAPSHOTS payload: {}", e))?;
+    // `dl` is the alias `wrap_ducklake_query` attaches and `USE`s below.
+    let query =
+        "SELECT snapshot_id, snapshot_time FROM ducklake_snapshots('dl') ORDER BY snapshot_id DESC"
+            .to_string();
+    Ok(maybe_wrap_ducklake(query, Some(&payload.ducklake)))
 }
 
 /// Filter columns to primary keys only; fall back to all columns if none are marked.
@@ -950,9 +998,10 @@ pub fn make_select_query(
             );
 
             query.push_str(&format!(
-                "SELECT {} FROM {}\n",
+                "SELECT {} FROM {}{}\n",
                 filtered_columns.join(", "),
-                quote_table_name(table, db_type)
+                quote_table_name(table, db_type),
+                duckdb_version_suffix(options.and_then(|o| o.version))
             ));
             query.push_str(&format!(
                 " WHERE {} {}\n",
@@ -977,6 +1026,8 @@ pub fn make_count_query(
     table: &str,
     where_clause: Option<&str>,
     column_defs: &[ColumnDef],
+    // DuckLake time-travel snapshot (DuckDB only); `None` counts the latest.
+    version: Option<i64>,
 ) -> Result<String, String> {
     let where_prefix = " WHERE ";
     let and_condition = " AND ";
@@ -1118,8 +1169,9 @@ pub fn make_count_query(
                 quicksearch_condition.push_str(" ($quicksearch = '' OR 1 = 1)");
             }
             query.push_str(&format!(
-                "SELECT COUNT(*) as count FROM {}",
-                quote_table_name(table, db_type)
+                "SELECT COUNT(*) as count FROM {}{}",
+                quote_table_name(table, db_type),
+                duckdb_version_suffix(version)
             ));
         }
     }
@@ -2998,7 +3050,7 @@ mod tests {
     #[test]
     fn test_select_snowflake_custom_limit() {
         let cols = vec![col("id", "int")];
-        let opts = SelectOptions { limit: Some(50), offset: Some(10) };
+        let opts = SelectOptions { limit: Some(50), offset: Some(10), version: None };
         let result = make_select_query(
             "my_table",
             &cols,
@@ -3072,7 +3124,7 @@ mod tests {
     #[test]
     fn test_count_postgresql_basic() {
         let cols = vec![col("id", "int4"), col("name", "text")];
-        let result = make_count_query(DbType::Postgresql, "my_table", None, &cols).unwrap();
+        let result = make_count_query(DbType::Postgresql, "my_table", None, &cols, None).unwrap();
 
         assert!(result.contains("-- $1 quicksearch (text)"));
         assert!(result.contains("SELECT COUNT(*) as count FROM \"my_table\""));
@@ -3090,6 +3142,7 @@ mod tests {
             "my_table",
             Some("status = 'active'"),
             &cols,
+            None,
         )
         .unwrap();
 
@@ -3105,7 +3158,7 @@ mod tests {
             c.ignored = Some(true);
             c
         }];
-        let result = make_count_query(DbType::Postgresql, "my_table", None, &cols).unwrap();
+        let result = make_count_query(DbType::Postgresql, "my_table", None, &cols, None).unwrap();
         assert!(result.contains("($1 = '' OR 1 = 1)"));
     }
 
@@ -3116,7 +3169,7 @@ mod tests {
     #[test]
     fn test_count_mysql_basic() {
         let cols = vec![col("id", "int"), col("name", "varchar")];
-        let result = make_count_query(DbType::Mysql, "my_table", None, &cols).unwrap();
+        let result = make_count_query(DbType::Mysql, "my_table", None, &cols, None).unwrap();
 
         assert!(result.contains("-- :quicksearch (text)"));
         assert!(result.contains("SELECT COUNT(*) as count FROM `my_table`"));
@@ -3130,7 +3183,7 @@ mod tests {
     #[test]
     fn test_count_mssql_basic() {
         let cols = vec![col("id", "int"), col("name", "nvarchar")];
-        let result = make_count_query(DbType::MsSqlServer, "my_table", None, &cols).unwrap();
+        let result = make_count_query(DbType::MsSqlServer, "my_table", None, &cols, None).unwrap();
 
         assert!(result.contains("SELECT COUNT(*) as count FROM [my_table]"));
         assert!(result.contains("(@p1 = '' OR CONCAT([id], [name]) LIKE '%' + @p1 + '%')"));
@@ -3143,7 +3196,7 @@ mod tests {
     #[test]
     fn test_count_snowflake_basic() {
         let cols = vec![col("id", "int"), col("name", "text")];
-        let result = make_count_query(DbType::Snowflake, "my_table", None, &cols).unwrap();
+        let result = make_count_query(DbType::Snowflake, "my_table", None, &cols, None).unwrap();
 
         // Two quicksearch params for snowflake with visible columns
         assert!(result.contains("-- ? quicksearch (text)\n-- ? quicksearch (text)"));
@@ -3158,7 +3211,7 @@ mod tests {
             c.ignored = Some(true);
             c
         }];
-        let result = make_count_query(DbType::Snowflake, "my_table", None, &cols).unwrap();
+        let result = make_count_query(DbType::Snowflake, "my_table", None, &cols, None).unwrap();
         // One quicksearch param
         let param_lines: Vec<&str> = result.lines().filter(|l| l.starts_with("-- ?")).collect();
         assert_eq!(param_lines.len(), 1);
@@ -3172,7 +3225,7 @@ mod tests {
     #[test]
     fn test_count_bigquery_basic() {
         let cols = vec![col("id", "INTEGER"), col("name", "STRING")];
-        let result = make_count_query(DbType::Bigquery, "my_table", None, &cols).unwrap();
+        let result = make_count_query(DbType::Bigquery, "my_table", None, &cols, None).unwrap();
 
         assert!(result.contains("-- @quicksearch (string)"));
         assert!(result.contains("SELECT COUNT(*) as count FROM `my_table`"));
@@ -3182,7 +3235,7 @@ mod tests {
     #[test]
     fn test_count_bigquery_json_type() {
         let cols = vec![col("id", "INTEGER"), col("data", "JSON")];
-        let result = make_count_query(DbType::Bigquery, "my_table", None, &cols).unwrap();
+        let result = make_count_query(DbType::Bigquery, "my_table", None, &cols, None).unwrap();
         assert!(result.contains("TO_JSON_STRING(`data`)"));
     }
 
@@ -3193,13 +3246,70 @@ mod tests {
     #[test]
     fn test_count_duckdb_basic() {
         let cols = vec![col("id", "int"), col("name", "text")];
-        let result = make_count_query(DbType::Duckdb, "my_table", None, &cols).unwrap();
+        let result = make_count_query(DbType::Duckdb, "my_table", None, &cols, None).unwrap();
 
         assert!(result.contains("-- $quicksearch (text)"));
         assert!(result.contains("SELECT COUNT(*) as count FROM \"my_table\""));
         assert!(
             result.contains("CONCAT(' ', \"id\", \"name\") LIKE CONCAT('%', $quicksearch, '%')")
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // DuckLake time-travel (AT VERSION) + snapshot history
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_select_duckdb_time_travel() {
+        let cols = vec![col("id", "int"), col("name", "text")];
+        let opts = SelectOptions { limit: None, offset: None, version: Some(42) };
+        let result =
+            make_select_query("orders", &cols, None, DbType::Duckdb, Some(&opts), None).unwrap();
+        // Read is pinned to the catalog snapshot via AT (VERSION => n).
+        assert!(result.contains("FROM \"orders\" AT (VERSION => 42)\n"));
+    }
+
+    #[test]
+    fn test_select_duckdb_no_version_unpinned() {
+        let cols = vec![col("id", "int")];
+        let result = make_select_query("orders", &cols, None, DbType::Duckdb, None, None).unwrap();
+        // Without a version the read targets the latest snapshot — no AT clause.
+        assert!(result.contains("FROM \"orders\"\n"));
+        assert!(!result.contains("AT (VERSION"));
+    }
+
+    #[test]
+    fn test_count_duckdb_time_travel() {
+        let cols = vec![col("id", "int")];
+        let result = make_count_query(DbType::Duckdb, "orders", None, &cols, Some(7)).unwrap();
+        assert!(result.contains("FROM \"orders\" AT (VERSION => 7)"));
+    }
+
+    #[test]
+    fn test_version_ignored_for_non_duckdb() {
+        // AT (VERSION) is DuckLake-only; other dialects must never emit it even
+        // if a version is somehow passed through.
+        let cols = vec![col("id", "int4")];
+        let opts = SelectOptions { limit: None, offset: None, version: Some(5) };
+        let result =
+            make_select_query("orders", &cols, None, DbType::Postgresql, Some(&opts), None)
+                .unwrap();
+        assert!(!result.contains("AT (VERSION"));
+    }
+
+    #[test]
+    fn test_expand_ducklake_snapshots() {
+        let json = r#"{"ducklake": "analytics"}"#;
+        let result = expand_ducklake_snapshots(json, DbType::Duckdb).unwrap();
+        assert!(result.contains("ATTACH 'ducklake://analytics' AS dl;USE dl;"));
+        assert!(result.contains("ducklake_snapshots('dl')"));
+        assert!(result.contains("ORDER BY snapshot_id DESC"));
+    }
+
+    #[test]
+    fn test_expand_ducklake_snapshots_non_duckdb_errors() {
+        let json = r#"{"ducklake": "analytics"}"#;
+        assert!(expand_ducklake_snapshots(json, DbType::Postgresql).is_err());
     }
 
     // -----------------------------------------------------------------------
@@ -3500,7 +3610,7 @@ mod tests {
     #[test]
     fn test_count_mssql_no_where() {
         let cols = vec![col("id", "int")];
-        let result = make_count_query(DbType::MsSqlServer, "my_table", None, &cols).unwrap();
+        let result = make_count_query(DbType::MsSqlServer, "my_table", None, &cols, None).unwrap();
         // MSSQL uses WHERE directly (no AND replacement)
         assert!(result.contains("SELECT COUNT(*) as count FROM [my_table] WHERE "));
     }
@@ -3508,7 +3618,7 @@ mod tests {
     #[test]
     fn test_count_mysql_no_where_uses_where_keyword() {
         let cols = vec![col("id", "int")];
-        let result = make_count_query(DbType::Mysql, "my_table", None, &cols).unwrap();
+        let result = make_count_query(DbType::Mysql, "my_table", None, &cols, None).unwrap();
         // The AND should be replaced with WHERE
         assert!(result.contains("FROM `my_table` WHERE "));
         assert!(!result.contains("FROM `my_table` AND "));

--- a/docs/ducklake-materialization.md
+++ b/docs/ducklake-materialization.md
@@ -171,24 +171,57 @@ This one table drives four things at once:
 
 ## Reproducibility — the beyond-dbt part
 
-Because every materialization records the snapshot it produced, a downstream
-consumer can read the *exact* upstream snapshot its run saw:
+Because every materialization records the snapshot it produced, you can read any
+table *as of* a past version — a capability dbt has no native answer for (dbt
+models are always "whatever's in the warehouse now"). DuckLake gives us this for
+the cost of recording one integer per run, and it covers the three things people
+actually reach for: **debugging** ("what did this table look like at the failing
+run"), **rollback** (re-materialize a consumer from snapshot N), and ad-hoc
+**experimentation** on a historical state.
+
+### How it's surfaced (shipped): explicit, discoverable time-travel
+
+The version is exposed as a *user-driven* surface, not hidden plumbing. A
+consumer pins a read by writing the DuckLake clause directly:
 
 ```sql
-FROM dl.orders_daily AT (VERSION => $WM_UPSTREAM_SNAPSHOT)
+FROM dl.orders_daily AT (VERSION => 42)
 ```
 
-The cascade already threads a `trigger` blob (producer path, partition) to each
-subscriber; add the producer's captured `snapshot_id` to it, and a consumer's
-read is pinned to the upstream state at dispatch time. That makes the *whole
-pipeline* reproducible and time-travelable — something dbt has no native answer
-for (dbt models are always "whatever's in the warehouse now"). It also gives
-rollback (re-point an asset to snapshot N) and "what did this table look like at
-the failing run" debugging, for free off the same captured ids.
+The asset node's **History** tab lists every snapshot (id + time), copies the
+`AT (VERSION => n)` clause or a full `FROM … AT (VERSION => n)`, and previews the
+table at any version. Snapshot ids are captured automatically; the user opts
+into pinning when they want it, and the clause degrades to "latest" if removed,
+so the same script still runs standalone. Mechanically this rides on
+time-travel **reads** (`make_select_query` / `make_count_query` emit the `AT`
+clause when a `version` is threaded through the `WM_INTERNAL_DB_*` markers) plus
+a `DUCKLAKE_SNAPSHOTS` read for the history list — capabilities DuckLake already
+has, no new write path.
 
-This is the differentiator worth leaning on. It is not catch-up to dbt; it is a
-capability dbt structurally cannot offer, and DuckLake gives it to us at the
-cost of recording one integer per run.
+### Deferred: automatic snapshot pinning across the cascade
+
+An earlier sketch had the cascade *automatically* thread each producer's
+`snapshot_id` into the `trigger` blob and inject `AT (VERSION => $WM_UPSTREAM_SNAPSHOT)`
+into consumer reads, so a whole run is pinned to upstream state at dispatch time
+without anyone asking. This is deliberately **not** built, for three reasons:
+
+- **Not critical.** The only thing it adds over the explicit surface above is
+  *automatic per-run consistency* — protection against an upstream
+  re-materializing in the window between dispatch and a consumer reading. That
+  race only bites high-frequency event-driven cascades (rare today), and the
+  read is always a whole, ACID snapshot regardless — never corruption, just
+  "newer than the triggering version". Debugging and rollback are already
+  covered by the explicit surface.
+- **Implicit magic.** Auto-injecting an `AT` clause and stripping it on
+  standalone runs is invisible behaviour to debug when it misfires; the explicit
+  clause is inspectable.
+- **Multi-upstream ambiguity + EE coupling.** A consumer reading two ducklake
+  upstreams needs a per-ref snapshot *map* accumulated across the AND-join — and
+  the join-slot logic is EE. A single `$WM_UPSTREAM_SNAPSHOT` would silently pin
+  every read to one (the firing) producer's snapshot.
+
+If a workload ever shows the consistency race in practice, pinning can be layered
+on top — the capture and the snapshot surfacing built here are its foundation.
 
 It also means **we do not build SCD2 snapshots** (gap #4 in `pipelines-vs-dbt.md`):
 DuckLake time-travel is a strictly better answer for most of what dbt's
@@ -224,8 +257,10 @@ Don't try to give both the full treatment for v1.
    `materialized_partition` rows.
 5. **Surface it** — last-materialized/snapshot/row-count on the asset node;
    missing-partition set feeds the backfill UI.
-6. *v1.x* — snapshot pinning across the cascade (`$WM_UPSTREAM_SNAPSHOT`),
-   rollback, time-travel read helper.
+6. *v1.x* — time-travel UX over the captured snapshots: a per-asset **History**
+   tab (snapshot list + copy `AT (VERSION => n)` + query-at-version preview).
+   Automatic cascade pinning (`$WM_UPSTREAM_SNAPSHOT`) is deferred — see
+   §"Reproducibility" for why.
 
 Steps 1–5 are a thin annotation+template layer plus one metadata table and one
 extra read per run. They deliver managed/incremental/versioned assets,

--- a/docs/ducklake-materialization.md
+++ b/docs/ducklake-materialization.md
@@ -259,9 +259,9 @@ Don't try to give both the full treatment for v1.
 5. **Surface it** — last-materialized/snapshot/row-count on the asset node;
    missing-partition set feeds the backfill UI.
 6. *v1.x* — time-travel UX over the captured snapshots: a per-asset **History**
-   tab (snapshot list + copy `AT (VERSION => n)` + query-at-version preview).
-   Automatic cascade pinning (`$WM_UPSTREAM_SNAPSHOT`) is deferred — see
-   §"Reproducibility" for why.
+   tab — a master-detail snapshot list + query-at-version preview that copies the
+   full `FROM lake.<table> AT (VERSION => n)` clause. Automatic cascade pinning
+   (`$WM_UPSTREAM_SNAPSHOT`) is deferred — see §"Reproducibility" for why.
 
 Steps 1–5 are a thin annotation+template layer plus one metadata table and one
 extra read per run. They deliver managed/incremental/versioned assets,

--- a/docs/ducklake-materialization.md
+++ b/docs/ducklake-materialization.md
@@ -188,9 +188,10 @@ consumer pins a read by writing the DuckLake clause directly:
 FROM dl.orders_daily AT (VERSION => 42)
 ```
 
-The asset node's **History** tab lists every snapshot (id + time), copies the
-`AT (VERSION => n)` clause or a full `FROM … AT (VERSION => n)`, and previews the
-table at any version. Snapshot ids are captured automatically; the user opts
+The asset node's **History** tab is a master-detail view: the snapshot list (id
++ time) on the left selects the version previewed in a read-only grid on the
+right, which surfaces — and copies — the catalog-qualified
+`FROM lake.<table> AT (VERSION => n)` clause. Snapshot ids are captured automatically; the user opts
 into pinning when they want it, and the clause degrades to "latest" if removed,
 so the same script still runs standalone. Mechanically this rides on
 time-travel **reads** (`make_select_query` / `make_count_query` emit the `AT`

--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphDetailsPane.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphDetailsPane.svelte
@@ -984,7 +984,11 @@
 									refreshKey={previewRefreshKey}
 								/>
 							{:else if selection.asset_kind === 'ducklake'}
-								<DucklakeAssetPanel path={selection.path} {workspace} />
+								<!-- Key on path so switching ducklake assets resets the panel's
+								     selected snapshot / tab instead of carrying state across. -->
+								{#key selection.path}
+									<DucklakeAssetPanel path={selection.path} {workspace} />
+								{/key}
 							{:else}
 								<div class="p-3 text-xs text-secondary">
 									No inline preview yet for {selection.asset_kind}. Use the producer/consumer arrows

--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphDetailsPane.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphDetailsPane.svelte
@@ -29,7 +29,7 @@
 	import SummaryPathDisplay from '$lib/components/SummaryPathDisplay.svelte'
 	import S3FilePreview from '$lib/components/S3FilePreview.svelte'
 	import DataTablePreview from './DataTablePreview.svelte'
-	import PartitionStatusGrid from './PartitionStatusGrid.svelte'
+	import DucklakeAssetPanel from './DucklakeAssetPanel.svelte'
 	import AssetRunsPanel from './AssetRunsPanel.svelte'
 	import { Pane, Splitpanes } from 'svelte-splitpanes'
 	import { fade } from 'svelte/transition'
@@ -984,7 +984,7 @@
 									refreshKey={previewRefreshKey}
 								/>
 							{:else if selection.asset_kind === 'ducklake'}
-								<PartitionStatusGrid path={selection.path} {workspace} />
+								<DucklakeAssetPanel path={selection.path} {workspace} />
 							{:else}
 								<div class="p-3 text-xs text-secondary">
 									No inline preview yet for {selection.asset_kind}. Use the producer/consumer arrows

--- a/frontend/src/lib/components/assets/AssetGraph/DucklakeAssetPanel.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/DucklakeAssetPanel.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	// Top pane for a selected ducklake asset: tabs over the three views of a
+	// versioned table — materialized partitions (status grid), snapshot history
+	// (time-travel surface), and a read-only "query at version" scratchpad. The
+	// History tab feeds the Query tab a chosen snapshot via shared state.
+	import ToggleButtonGroup from '$lib/components/common/toggleButton-v2/ToggleButtonGroup.svelte'
+	import ToggleButton from '$lib/components/common/toggleButton-v2/ToggleButton.svelte'
+	import { Table2, History, Play } from 'lucide-svelte'
+	import PartitionStatusGrid from './PartitionStatusGrid.svelte'
+	import DucklakeSnapshotHistory from './DucklakeSnapshotHistory.svelte'
+	import DucklakeVersionPreview from './DucklakeVersionPreview.svelte'
+
+	interface Props {
+		// The materialized ducklake asset path (`<ducklake>/<table>`).
+		path: string
+		workspace: string
+	}
+	let { path, workspace }: Props = $props()
+
+	let tab = $state<'partitions' | 'history' | 'query'>('partitions')
+	// Snapshot the Query tab reads at — set when the user clicks "Query" on a
+	// history row.
+	let selectedVersion = $state<number | undefined>(undefined)
+
+	function onQueryVersion(version: number) {
+		selectedVersion = version
+		tab = 'query'
+	}
+</script>
+
+<div class="flex flex-col h-full">
+	<div class="flex items-center gap-2 px-3 py-2 border-b shrink-0">
+		<ToggleButtonGroup selected={tab} on:selected={(e) => (tab = e.detail)}>
+			{#snippet children({ item })}
+				<ToggleButton size="sm" value="partitions" label="Partitions" icon={Table2} {item} />
+				<ToggleButton size="sm" value="history" label="History" icon={History} {item} />
+				<ToggleButton size="sm" value="query" label="Query" icon={Play} {item} />
+			{/snippet}
+		</ToggleButtonGroup>
+	</div>
+
+	<div class="flex-1 min-h-0">
+		{#if tab === 'partitions'}
+			<PartitionStatusGrid {path} {workspace} />
+		{:else if tab === 'history'}
+			<DucklakeSnapshotHistory {path} {workspace} {onQueryVersion} />
+		{:else}
+			<div class="h-full p-3 overflow-auto">
+				<DucklakeVersionPreview
+					assetUri={`ducklake://${path}`}
+					version={selectedVersion}
+					class="h-full"
+				/>
+			</div>
+		{/if}
+	</div>
+</div>

--- a/frontend/src/lib/components/assets/AssetGraph/DucklakeAssetPanel.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/DucklakeAssetPanel.svelte
@@ -68,19 +68,25 @@
 </script>
 
 <div class="flex flex-col h-full">
-	<div class="flex items-center gap-2 px-3 py-2 border-b shrink-0">
-		<ToggleButtonGroup selected={tab} on:selected={(e) => (tab = e.detail)}>
-			{#snippet children({ item })}
-				<ToggleButton size="sm" value="partitions" label="Partitions" icon={Table2} {item} />
-				<ToggleButton size="sm" value="history" label="History" icon={History} {item} />
-			{/snippet}
-		</ToggleButtonGroup>
-	</div>
+	{#if !qualifiedTable}
+		<!-- Catalog-level ducklake node (no table segment, e.g. `ducklake://main`):
+		     snapshot history / time-travel are per-table, so only the partition
+		     grid applies here. -->
+		<PartitionStatusGrid {path} {workspace} />
+	{:else}
+		<div class="flex items-center gap-2 px-3 py-2 border-b shrink-0">
+			<ToggleButtonGroup selected={tab} on:selected={(e) => (tab = e.detail)}>
+				{#snippet children({ item })}
+					<ToggleButton size="sm" value="partitions" label="Partitions" icon={Table2} {item} />
+					<ToggleButton size="sm" value="history" label="History" icon={History} {item} />
+				{/snippet}
+			</ToggleButtonGroup>
+		</div>
 
-	<div class="flex-1 min-h-0">
-		{#if tab === 'partitions'}
-			<PartitionStatusGrid {path} {workspace} />
-		{:else}
+		<div class="flex-1 min-h-0">
+			{#if tab === 'partitions'}
+				<PartitionStatusGrid {path} {workspace} />
+			{:else}
 			<div class="h-full" bind:clientWidth={paneWidth}>
 				<Splitpanes class="!h-full">
 					<Pane size={listSize} minSize={20}>
@@ -106,4 +112,5 @@
 			</div>
 		{/if}
 	</div>
+	{/if}
 </div>

--- a/frontend/src/lib/components/assets/AssetGraph/DucklakeAssetPanel.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/DucklakeAssetPanel.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
-	// Top pane for a selected ducklake asset: tabs over the three views of a
-	// versioned table — materialized partitions (status grid), snapshot history
-	// (time-travel surface), and a read-only "query at version" scratchpad. The
-	// History tab feeds the Query tab a chosen snapshot via shared state.
+	// Top pane for a selected ducklake asset: tabs over the views of a versioned
+	// table. "Partitions" is the materialization status grid; "History" is a
+	// master-detail time-travel surface — the snapshot list on the left, a
+	// read-only preview of the table at the selected snapshot on the right.
+	//
+	// The snapshot list is fetched here (not in the list child) so both the list
+	// and the preview share one source of truth: `effectiveVersion` derives to
+	// the user's pick, or the newest snapshot until they pick one.
 	import ToggleButtonGroup from '$lib/components/common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import ToggleButton from '$lib/components/common/toggleButton-v2/ToggleButton.svelte'
-	import { Table2, History, Play } from 'lucide-svelte'
+	import { Table2, History } from 'lucide-svelte'
+	import { Pane, Splitpanes } from 'svelte-splitpanes'
+	import { resource } from 'runed'
+	import { fetchDucklakeSnapshots } from '$lib/components/dbOps'
+	import { parseDbInputFromAssetSyntax } from '$lib/utils'
 	import PartitionStatusGrid from './PartitionStatusGrid.svelte'
 	import DucklakeSnapshotHistory from './DucklakeSnapshotHistory.svelte'
 	import DucklakeVersionPreview from './DucklakeVersionPreview.svelte'
@@ -17,15 +25,23 @@
 	}
 	let { path, workspace }: Props = $props()
 
-	let tab = $state<'partitions' | 'history' | 'query'>('partitions')
-	// Snapshot the Query tab reads at — set when the user clicks "Query" on a
-	// history row.
+	let tab = $state<'partitions' | 'history'>('partitions')
+	// The user's explicit snapshot pick (undefined until they click a row).
 	let selectedVersion = $state<number | undefined>(undefined)
 
-	function onQueryVersion(version: number) {
-		selectedVersion = version
-		tab = 'query'
-	}
+	let ducklake = $derived.by(() => {
+		const i = parseDbInputFromAssetSyntax(`ducklake://${path}`)
+		return i && 'ducklake' in i ? i.ducklake : undefined
+	})
+	let snapshots = resource(
+		[() => workspace, () => ducklake],
+		async ([ws, dl]) => {
+			if (!ws || !dl) return []
+			return await fetchDucklakeSnapshots({ workspace: ws, ducklake: dl })
+		}
+	)
+	// Newest snapshot is the default preview until the user selects one.
+	let effectiveVersion = $derived(selectedVersion ?? snapshots.current?.[0]?.snapshot_id)
 </script>
 
 <div class="flex flex-col h-full">
@@ -34,7 +50,6 @@
 			{#snippet children({ item })}
 				<ToggleButton size="sm" value="partitions" label="Partitions" icon={Table2} {item} />
 				<ToggleButton size="sm" value="history" label="History" icon={History} {item} />
-				<ToggleButton size="sm" value="query" label="Query" icon={Play} {item} />
 			{/snippet}
 		</ToggleButtonGroup>
 	</div>
@@ -42,16 +57,28 @@
 	<div class="flex-1 min-h-0">
 		{#if tab === 'partitions'}
 			<PartitionStatusGrid {path} {workspace} />
-		{:else if tab === 'history'}
-			<DucklakeSnapshotHistory {path} {workspace} {onQueryVersion} />
 		{:else}
-			<div class="h-full p-3 overflow-auto">
-				<DucklakeVersionPreview
-					assetUri={`ducklake://${path}`}
-					version={selectedVersion}
-					class="h-full"
-				/>
-			</div>
+			<Splitpanes class="!h-full">
+				<Pane size={42} minSize={25}>
+					<DucklakeSnapshotHistory
+						items={snapshots.current ?? []}
+						loading={snapshots.loading}
+						error={snapshots.error?.message}
+						onRefresh={() => snapshots.refetch()}
+						selectedVersion={effectiveVersion}
+						onSelect={(v) => (selectedVersion = v)}
+					/>
+				</Pane>
+				<Pane size={58} minSize={30}>
+					<div class="h-full p-3 overflow-auto">
+						<DucklakeVersionPreview
+							assetUri={`ducklake://${path}`}
+							version={effectiveVersion}
+							class="h-full"
+						/>
+					</div>
+				</Pane>
+			</Splitpanes>
 		{/if}
 	</div>
 </div>

--- a/frontend/src/lib/components/assets/AssetGraph/DucklakeAssetPanel.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/DucklakeAssetPanel.svelte
@@ -6,7 +6,9 @@
 	//
 	// The snapshot list is fetched here (not in the list child) so both the list
 	// and the preview share one source of truth: `effectiveVersion` derives to
-	// the user's pick, or the newest snapshot until they pick one.
+	// the user's pick, or the newest snapshot until they pick one. The list is
+	// scoped to the table (catalog-wide snapshots predating the table's creation
+	// can't be read), so a selectable version always exists in the table.
 	import ToggleButtonGroup from '$lib/components/common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import ToggleButton from '$lib/components/common/toggleButton-v2/ToggleButton.svelte'
 	import { Table2, History } from 'lucide-svelte'
@@ -29,19 +31,33 @@
 	// The user's explicit snapshot pick (undefined until they click a row).
 	let selectedVersion = $state<number | undefined>(undefined)
 
-	let ducklake = $derived.by(() => {
-		const i = parseDbInputFromAssetSyntax(`ducklake://${path}`)
-		return i && 'ducklake' in i ? i.ducklake : undefined
+	let parsed = $derived(parseDbInputFromAssetSyntax(`ducklake://${path}`))
+	let ducklake = $derived(parsed && 'ducklake' in parsed ? parsed.ducklake : undefined)
+	// Schema-qualified table name (schema defaults to `main`) used to scope the
+	// snapshot list to versions where the table exists.
+	let qualifiedTable = $derived.by(() => {
+		if (!parsed || !('specificTable' in parsed) || !parsed.specificTable) return undefined
+		const schema = 'specificSchema' in parsed ? parsed.specificSchema : undefined
+		return `${schema ?? 'main'}.${parsed.specificTable}`
 	})
+
 	let snapshots = resource(
-		[() => workspace, () => ducklake],
-		async ([ws, dl]) => {
+		[() => workspace, () => ducklake, () => qualifiedTable],
+		async ([ws, dl, table]) => {
 			if (!ws || !dl) return []
-			return await fetchDucklakeSnapshots({ workspace: ws, ducklake: dl })
+			return await fetchDucklakeSnapshots({ workspace: ws, ducklake: dl, table })
 		}
 	)
 	// Newest snapshot is the default preview until the user selects one.
 	let effectiveVersion = $derived(selectedVersion ?? snapshots.current?.[0]?.snapshot_id)
+
+	// Keep the list pane to a roughly fixed width rather than a fixed fraction,
+	// so it stays compact on wide panels instead of sprawling. Falls back to a
+	// usable fraction on narrow ones and before the width is measured.
+	let paneWidth = $state(0)
+	let listSize = $derived(
+		paneWidth > 0 ? Math.max(24, Math.min(46, Math.round((260 / paneWidth) * 100))) : 36
+	)
 </script>
 
 <div class="flex flex-col h-full">
@@ -58,27 +74,29 @@
 		{#if tab === 'partitions'}
 			<PartitionStatusGrid {path} {workspace} />
 		{:else}
-			<Splitpanes class="!h-full">
-				<Pane size={42} minSize={25}>
-					<DucklakeSnapshotHistory
-						items={snapshots.current ?? []}
-						loading={snapshots.loading}
-						error={snapshots.error?.message}
-						onRefresh={() => snapshots.refetch()}
-						selectedVersion={effectiveVersion}
-						onSelect={(v) => (selectedVersion = v)}
-					/>
-				</Pane>
-				<Pane size={58} minSize={30}>
-					<div class="h-full p-3 overflow-auto">
-						<DucklakeVersionPreview
-							assetUri={`ducklake://${path}`}
-							version={effectiveVersion}
-							class="h-full"
+			<div class="h-full" bind:clientWidth={paneWidth}>
+				<Splitpanes class="!h-full">
+					<Pane size={listSize} minSize={20}>
+						<DucklakeSnapshotHistory
+							items={snapshots.current ?? []}
+							loading={snapshots.loading}
+							error={snapshots.error?.message}
+							onRefresh={() => snapshots.refetch()}
+							selectedVersion={effectiveVersion}
+							onSelect={(v) => (selectedVersion = v)}
 						/>
-					</div>
-				</Pane>
-			</Splitpanes>
+					</Pane>
+					<Pane size={100 - listSize} minSize={30}>
+						<div class="h-full p-3 overflow-auto">
+							<DucklakeVersionPreview
+								assetUri={`ducklake://${path}`}
+								version={effectiveVersion}
+								class="h-full"
+							/>
+						</div>
+					</Pane>
+				</Splitpanes>
+			</div>
 		{/if}
 	</div>
 </div>

--- a/frontend/src/lib/components/assets/AssetGraph/DucklakeAssetPanel.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/DucklakeAssetPanel.svelte
@@ -48,8 +48,15 @@
 			return await fetchDucklakeSnapshots({ workspace: ws, ducklake: dl, table })
 		}
 	)
-	// Newest snapshot is the default preview until the user selects one.
-	let effectiveVersion = $derived(selectedVersion ?? snapshots.current?.[0]?.snapshot_id)
+	// Newest snapshot is the default preview until the user picks one. If the
+	// pick is no longer in the list (snapshots refetched, or it was stale from a
+	// previously-viewed asset), fall back to newest rather than reading a version
+	// that isn't in this table.
+	let effectiveVersion = $derived.by(() => {
+		const list = snapshots.current
+		const picked = list?.some((s) => s.snapshot_id === selectedVersion)
+		return picked ? selectedVersion : list?.[0]?.snapshot_id
+	})
 
 	// Keep the list pane to a roughly fixed width rather than a fixed fraction,
 	// so it stays compact on wide panels instead of sprawling. Falls back to a

--- a/frontend/src/lib/components/assets/AssetGraph/DucklakeSnapshotHistory.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/DucklakeSnapshotHistory.svelte
@@ -3,7 +3,7 @@
 	// catalog's DuckLake snapshots, newest first. Selecting a row drives the
 	// adjacent preview pane via `onSelect`; the selected row is highlighted. The
 	// list data + selection default are owned by the parent; the preview pane
-	// carries the copy-able `AT (VERSION => n)` clause.
+	// carries the copy-able `FROM lake.<table> AT (VERSION => n)` clause.
 	import { Button } from '$lib/components/common'
 	import { Loader2, RefreshCw } from 'lucide-svelte'
 	import type { DucklakeSnapshot } from '$lib/components/dbOps'

--- a/frontend/src/lib/components/assets/AssetGraph/DucklakeSnapshotHistory.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/DucklakeSnapshotHistory.svelte
@@ -31,6 +31,16 @@
 		return await fetchDucklakeSnapshots({ workspace: ws, ducklake: dl })
 	})
 
+	// DuckLake serializes `snapshot_time` as microseconds-since-epoch (a numeric
+	// string), not an ISO date — `new Date(µs)` would be Invalid Date. Detect the
+	// µs magnitude and convert to ms; fall back to direct parsing otherwise.
+	function fmtSnapshotTime(t: string | number | undefined): string {
+		if (t == undefined || t === '') return '—'
+		const n = typeof t === 'number' ? t : Number(t)
+		const d = Number.isFinite(n) && n > 1e14 ? new Date(n / 1000) : new Date(t)
+		return isNaN(d.getTime()) ? String(t) : d.toLocaleString()
+	}
+
 	function atClause(version: number): string {
 		return `AT (VERSION => ${version})`
 	}
@@ -76,7 +86,7 @@
 						<div class="flex flex-col min-w-0">
 							<span class="text-xs font-mono">v{s.snapshot_id}</span>
 							<span class="text-3xs text-tertiary">
-								{s.snapshot_time ? new Date(s.snapshot_time).toLocaleString() : '—'}
+								{fmtSnapshotTime(s.snapshot_time)}
 							</span>
 						</div>
 						<div class="flex items-center gap-1 shrink-0">

--- a/frontend/src/lib/components/assets/AssetGraph/DucklakeSnapshotHistory.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/DucklakeSnapshotHistory.svelte
@@ -35,7 +35,10 @@
 		return `AT (VERSION => ${version})`
 	}
 	function fromClause(version: number): string {
-		return `FROM ${tableKey ?? 'table'} ${atClause(version)}`
+		// `lake` matches the alias the duckdb scaffold ATTACHes the ducklake under
+		// (`ATTACH 'ducklake://…' AS lake`), so the copied clause is catalog-qualified
+		// and pastes straight into a consumer script.
+		return `FROM lake.${tableKey ?? 'table'} ${atClause(version)}`
 	}
 </script>
 
@@ -92,7 +95,7 @@
 								startIcon={{ icon: ClipboardCopy }}
 								iconOnly
 								onclick={() => copyToClipboard(fromClause(s.snapshot_id))}
-								title="Copy FROM {tableKey ?? 'table'} AT (VERSION => {s.snapshot_id})"
+								title="Copy {fromClause(s.snapshot_id)}"
 							/>
 							<Button
 								variant="default"

--- a/frontend/src/lib/components/assets/AssetGraph/DucklakeSnapshotHistory.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/DucklakeSnapshotHistory.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	// Time-travel history for a ducklake table: lists the catalog's DuckLake
+	// snapshots (commit log), newest first, and hands the user the exact
+	// `AT (VERSION => n)` syntax to read any of them — copy a clause, copy a full
+	// FROM, or open the version in the Query tab. This is the discoverability
+	// surface: snapshots are captured automatically on every materialize, and
+	// this teaches users they can pin reads against them.
+	import { resource } from 'runed'
+	import { Button } from '$lib/components/common'
+	import { Loader2, RefreshCw, ClipboardCopy, Play } from 'lucide-svelte'
+	import { fetchDucklakeSnapshots } from '$lib/components/dbOps'
+	import { parseDbInputFromAssetSyntax, copyToClipboard } from '$lib/utils'
+
+	interface Props {
+		// The materialized ducklake asset path (`<ducklake>/<table>`).
+		path: string
+		workspace: string
+		// Open the Query tab pinned to the chosen snapshot.
+		onQueryVersion?: (version: number) => void
+	}
+	let { path, workspace, onQueryVersion }: Props = $props()
+
+	let input = $derived(parseDbInputFromAssetSyntax(`ducklake://${path}`))
+	let ducklake = $derived(input && 'ducklake' in input ? input.ducklake : undefined)
+	let table = $derived(input && 'specificTable' in input ? input.specificTable : undefined)
+	let schema = $derived(input && 'specificSchema' in input ? input.specificSchema : undefined)
+	let tableKey = $derived(schema && table ? `${schema}.${table}` : table)
+
+	let snapshots = resource([() => workspace, () => ducklake], async ([ws, dl]) => {
+		if (!ws || !dl) return []
+		return await fetchDucklakeSnapshots({ workspace: ws, ducklake: dl })
+	})
+
+	function atClause(version: number): string {
+		return `AT (VERSION => ${version})`
+	}
+	function fromClause(version: number): string {
+		return `FROM ${tableKey ?? 'table'} ${atClause(version)}`
+	}
+</script>
+
+<div class="flex flex-col h-full">
+	<div class="flex items-center justify-between gap-2 px-3 py-2 border-b shrink-0">
+		<span class="text-xs font-semibold text-secondary">Snapshot history</span>
+		<Button
+			variant="subtle"
+			unifiedSize="sm"
+			startIcon={{ icon: RefreshCw }}
+			iconOnly
+			onclick={() => snapshots.refetch()}
+			title="Refresh"
+		/>
+	</div>
+
+	<div class="flex-1 min-h-0 overflow-auto p-3">
+		{#if snapshots.loading}
+			<div class="flex items-center gap-2 text-tertiary text-xs">
+				<Loader2 size={14} class="animate-spin" /> Loading snapshots…
+			</div>
+		{:else if snapshots.error}
+			<p class="text-xs text-red-600">Failed to load: {snapshots.error.message}</p>
+		{:else if !snapshots.current?.length}
+			<p class="text-xs text-secondary">
+				No snapshots yet. DuckLake records one on every <span class="font-mono">// materialize</span
+				> write; each becomes a version you can time-travel to.
+			</p>
+		{:else}
+			<div class="flex flex-col gap-1.5">
+				{#each snapshots.current as s (s.snapshot_id)}
+					<div
+						class="flex items-center justify-between gap-2 rounded border px-2 py-1.5 hover:bg-surface-hover"
+					>
+						<div class="flex flex-col min-w-0">
+							<span class="text-xs font-mono">v{s.snapshot_id}</span>
+							<span class="text-3xs text-tertiary">
+								{s.snapshot_time ? new Date(s.snapshot_time).toLocaleString() : '—'}
+							</span>
+						</div>
+						<div class="flex items-center gap-1 shrink-0">
+							<Button
+								variant="subtle"
+								unifiedSize="sm"
+								startIcon={{ icon: ClipboardCopy }}
+								onclick={() => copyToClipboard(atClause(s.snapshot_id))}
+								title="Copy AT (VERSION => …) clause"
+							>
+								AT (VERSION)
+							</Button>
+							<Button
+								variant="subtle"
+								unifiedSize="sm"
+								startIcon={{ icon: ClipboardCopy }}
+								iconOnly
+								onclick={() => copyToClipboard(fromClause(s.snapshot_id))}
+								title="Copy FROM {tableKey ?? 'table'} AT (VERSION => {s.snapshot_id})"
+							/>
+							<Button
+								variant="default"
+								unifiedSize="sm"
+								startIcon={{ icon: Play }}
+								onclick={() => onQueryVersion?.(s.snapshot_id)}
+								title="Preview the table at this version"
+							>
+								Query
+							</Button>
+						</div>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+</div>

--- a/frontend/src/lib/components/assets/AssetGraph/DucklakeSnapshotHistory.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/DucklakeSnapshotHistory.svelte
@@ -1,35 +1,24 @@
 <script lang="ts">
-	// Time-travel history for a ducklake table: lists the catalog's DuckLake
-	// snapshots (commit log), newest first, and hands the user the exact
-	// `AT (VERSION => n)` syntax to read any of them — copy a clause, copy a full
-	// FROM, or open the version in the Query tab. This is the discoverability
-	// surface: snapshots are captured automatically on every materialize, and
-	// this teaches users they can pin reads against them.
-	import { resource } from 'runed'
+	// Time-travel snapshot list for a ducklake table (presentational): the
+	// catalog's DuckLake snapshots, newest first. Selecting a row drives the
+	// adjacent preview pane via `onSelect`; the selected row is highlighted. The
+	// list data + selection default are owned by the parent; the preview pane
+	// carries the copy-able `AT (VERSION => n)` clause.
 	import { Button } from '$lib/components/common'
-	import { Loader2, RefreshCw, ClipboardCopy, Play } from 'lucide-svelte'
-	import { fetchDucklakeSnapshots } from '$lib/components/dbOps'
-	import { parseDbInputFromAssetSyntax, copyToClipboard } from '$lib/utils'
+	import { Loader2, RefreshCw } from 'lucide-svelte'
+	import type { DucklakeSnapshot } from '$lib/components/dbOps'
 
 	interface Props {
-		// The materialized ducklake asset path (`<ducklake>/<table>`).
-		path: string
-		workspace: string
-		// Open the Query tab pinned to the chosen snapshot.
-		onQueryVersion?: (version: number) => void
+		items: DucklakeSnapshot[]
+		loading: boolean
+		error?: string
+		onRefresh?: () => void
+		// Snapshot currently shown in the preview pane (highlighted in the list).
+		selectedVersion?: number
+		// Select a snapshot to preview.
+		onSelect?: (version: number) => void
 	}
-	let { path, workspace, onQueryVersion }: Props = $props()
-
-	let input = $derived(parseDbInputFromAssetSyntax(`ducklake://${path}`))
-	let ducklake = $derived(input && 'ducklake' in input ? input.ducklake : undefined)
-	let table = $derived(input && 'specificTable' in input ? input.specificTable : undefined)
-	let schema = $derived(input && 'specificSchema' in input ? input.specificSchema : undefined)
-	let tableKey = $derived(schema && table ? `${schema}.${table}` : table)
-
-	let snapshots = resource([() => workspace, () => ducklake], async ([ws, dl]) => {
-		if (!ws || !dl) return []
-		return await fetchDucklakeSnapshots({ workspace: ws, ducklake: dl })
-	})
+	let { items, loading, error, onRefresh, selectedVersion, onSelect }: Props = $props()
 
 	// DuckLake serializes `snapshot_time` as microseconds-since-epoch (a numeric
 	// string), not an ISO date — `new Date(µs)` would be Invalid Date. Detect the
@@ -39,16 +28,6 @@
 		const n = typeof t === 'number' ? t : Number(t)
 		const d = Number.isFinite(n) && n > 1e14 ? new Date(n / 1000) : new Date(t)
 		return isNaN(d.getTime()) ? String(t) : d.toLocaleString()
-	}
-
-	function atClause(version: number): string {
-		return `AT (VERSION => ${version})`
-	}
-	function fromClause(version: number): string {
-		// `lake` matches the alias the duckdb scaffold ATTACHes the ducklake under
-		// (`ATTACH 'ducklake://…' AS lake`), so the copied clause is catalog-qualified
-		// and pastes straight into a consumer script.
-		return `FROM lake.${tableKey ?? 'table'} ${atClause(version)}`
 	}
 </script>
 
@@ -60,64 +39,39 @@
 			unifiedSize="sm"
 			startIcon={{ icon: RefreshCw }}
 			iconOnly
-			onclick={() => snapshots.refetch()}
+			onclick={() => onRefresh?.()}
 			title="Refresh"
 		/>
 	</div>
 
 	<div class="flex-1 min-h-0 overflow-auto p-3">
-		{#if snapshots.loading}
+		{#if loading && !items.length}
 			<div class="flex items-center gap-2 text-tertiary text-xs">
 				<Loader2 size={14} class="animate-spin" /> Loading snapshots…
 			</div>
-		{:else if snapshots.error}
-			<p class="text-xs text-red-600">Failed to load: {snapshots.error.message}</p>
-		{:else if !snapshots.current?.length}
+		{:else if error}
+			<p class="text-xs text-red-600">Failed to load: {error}</p>
+		{:else if !items.length}
 			<p class="text-xs text-secondary">
-				No snapshots yet. DuckLake records one on every <span class="font-mono">// materialize</span
+				No snapshots yet. DuckLake records one on every <span class="font-mono"
+					>// materialize</span
 				> write; each becomes a version you can time-travel to.
 			</p>
 		{:else}
 			<div class="flex flex-col gap-1.5">
-				{#each snapshots.current as s (s.snapshot_id)}
-					<div
-						class="flex items-center justify-between gap-2 rounded border px-2 py-1.5 hover:bg-surface-hover"
+				{#each items as s (s.snapshot_id)}
+					{@const selected = s.snapshot_id === selectedVersion}
+					<button
+						type="button"
+						class="flex items-center justify-between gap-2 rounded border px-2 py-1.5 text-left {selected
+							? 'border-blue-400 bg-blue-50 dark:border-blue-500 dark:bg-blue-950/30'
+							: 'hover:bg-surface-hover'}"
+						onclick={() => onSelect?.(s.snapshot_id)}
+						title="Preview the table at this version"
 					>
-						<div class="flex flex-col min-w-0">
-							<span class="text-xs font-mono">v{s.snapshot_id}</span>
-							<span class="text-3xs text-tertiary">
-								{fmtSnapshotTime(s.snapshot_time)}
-							</span>
-						</div>
-						<div class="flex items-center gap-1 shrink-0">
-							<Button
-								variant="subtle"
-								unifiedSize="sm"
-								startIcon={{ icon: ClipboardCopy }}
-								onclick={() => copyToClipboard(atClause(s.snapshot_id))}
-								title="Copy AT (VERSION => …) clause"
-							>
-								AT (VERSION)
-							</Button>
-							<Button
-								variant="subtle"
-								unifiedSize="sm"
-								startIcon={{ icon: ClipboardCopy }}
-								iconOnly
-								onclick={() => copyToClipboard(fromClause(s.snapshot_id))}
-								title="Copy {fromClause(s.snapshot_id)}"
-							/>
-							<Button
-								variant="default"
-								unifiedSize="sm"
-								startIcon={{ icon: Play }}
-								onclick={() => onQueryVersion?.(s.snapshot_id)}
-								title="Preview the table at this version"
-							>
-								Query
-							</Button>
-						</div>
-					</div>
+						<span class="text-xs font-mono">v{s.snapshot_id}</span>
+						<span class="text-3xs text-tertiary shrink-0">{fmtSnapshotTime(s.snapshot_time)}</span>
+					</button>
 				{/each}
 			</div>
 		{/if}

--- a/frontend/src/lib/components/assets/AssetGraph/DucklakeVersionPreview.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/DucklakeVersionPreview.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+	// Read-only grid preview of a ducklake table AT a chosen DuckLake snapshot
+	// ("time-travel"). Mirrors DucklakeResultPreview but, instead of scoping to a
+	// partition, pins every read to a catalog version via `AT (VERSION => n)`
+	// (threaded server-side through the SELECT/COUNT markers). This is the
+	// "query this version" scratchpad — the rendered SQL the user would write by
+	// hand is shown above the grid so the affordance is self-documenting.
+	import DBTable from '$lib/components/DBTable.svelte'
+	import { resource } from 'runed'
+	import { workspaceStore } from '$lib/stores'
+	import { loadAllTablesMetaData } from '$lib/components/apps/components/display/dbtable/metadata'
+	import { dbTableOpsWithPreviewScripts } from '$lib/components/dbOps'
+	import type { DbInput } from '$lib/components/dbTypes'
+	import { parseDbInputFromAssetSyntax } from '$lib/utils'
+	import { AlertTriangle, Loader2 } from 'lucide-svelte'
+	import { twMerge } from 'tailwind-merge'
+
+	interface Props {
+		// Full asset URI, e.g. `ducklake://main/orders_daily`.
+		assetUri: string
+		// DuckLake snapshot to pin reads to. Undefined renders nothing (the
+		// parent prompts the user to pick a version from the history first).
+		version?: number
+		class?: string
+	}
+	let { assetUri, version, class: className = '' }: Props = $props()
+
+	let input = $derived<DbInput | undefined>(parseDbInputFromAssetSyntax(assetUri) ?? undefined)
+	let table = $derived(
+		input && 'specificTable' in input ? (input.specificTable as string | undefined) : undefined
+	)
+	let schema = $derived(
+		input && 'specificSchema' in input ? (input.specificSchema as string | undefined) : undefined
+	)
+	let tableKey = $derived(schema && table ? `${schema}.${table}` : table)
+
+	// The hand-written equivalent of what this preview runs — surfaced so the
+	// user learns the syntax they can paste into their own consumer SQL.
+	let exampleSql = $derived(
+		version != undefined && tableKey ? `FROM ${tableKey} AT (VERSION => ${version})` : undefined
+	)
+
+	let colDefs = resource(
+		// Column metadata is the same across snapshots — keyed on `input` only so
+		// switching versions doesn't re-dispatch a metadata preview job (the grid
+		// itself re-reads via `dbTableOps` + the `{#key version}` block).
+		() => [input] as const,
+		async ([_input]) => {
+			if (!_input || !$workspaceStore) return undefined
+			try {
+				return await loadAllTablesMetaData($workspaceStore, _input)
+			} catch {
+				return undefined
+			}
+		}
+	)
+
+	let tableColDefs = $derived.by(() => {
+		const defs = colDefs.current
+		if (!table || !defs) return undefined
+		const direct = defs[`${schema ?? 'main'}.${table}`] ?? defs[table]
+		const found =
+			direct ??
+			(() => {
+				const key = Object.keys(defs).find((k) => k === table || k.endsWith(`.${table}`))
+				return key ? defs[key] : undefined
+			})()
+		return found
+	})
+
+	let dbTableOps = $derived.by(() => {
+		if (!(input && tableColDefs && tableKey && $workspaceStore && version != undefined))
+			return undefined
+		const ops = dbTableOpsWithPreviewScripts({
+			input,
+			tableKey,
+			colDefs: tableColDefs,
+			workspace: $workspaceStore,
+			version
+		})
+		// Historical reads are immutable: drop every mutation handler so DBTable
+		// renders without edit/delete/insert affordances.
+		const readOnly = { ...ops }
+		delete readOnly.onUpdate
+		delete readOnly.onDelete
+		delete readOnly.onInsert
+		return readOnly
+	})
+</script>
+
+<div class={twMerge('flex flex-col min-h-0 relative', className)}>
+	{#if version == undefined}
+		<div class="flex items-center gap-2 p-3 text-2xs text-tertiary">
+			Pick a version from the History tab to query the table as of that snapshot.
+		</div>
+	{:else}
+		{#if exampleSql}
+			<div class="pb-2 text-2xs font-mono text-tertiary truncate" title={exampleSql}>
+				{exampleSql}
+			</div>
+		{/if}
+		{#if colDefs.loading && !colDefs.current}
+			<div class="flex items-center justify-center p-4 text-tertiary">
+				<Loader2 class="animate-spin" size={18} />
+			</div>
+		{:else if !tableColDefs}
+			<div class="flex items-center gap-2 p-3 text-2xs text-tertiary">
+				<AlertTriangle size={14} class="text-amber-500" />
+				Couldn't load this table at version {version}.
+			</div>
+		{:else if dbTableOps}
+			{#key version}
+				<div class="grow min-h-0">
+					<DBTable {dbTableOps} />
+				</div>
+			{/key}
+		{/if}
+	{/if}
+</div>

--- a/frontend/src/lib/components/assets/AssetGraph/DucklakeVersionPreview.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/DucklakeVersionPreview.svelte
@@ -34,10 +34,13 @@
 	)
 	let tableKey = $derived(schema && table ? `${schema}.${table}` : table)
 
-	// The hand-written equivalent of what this preview runs — surfaced so the
-	// user learns the syntax they can paste into their own consumer SQL.
+	// A paste-able consumer-script form of this read — `lake` matches the alias
+	// the duckdb scaffold ATTACHes the ducklake under, so the reference is
+	// catalog-qualified — surfaced so the user learns the time-travel syntax.
 	let exampleSql = $derived(
-		version != undefined && tableKey ? `FROM ${tableKey} AT (VERSION => ${version})` : undefined
+		version != undefined && tableKey
+			? `FROM lake.${tableKey} AT (VERSION => ${version})`
+			: undefined
 	)
 
 	let colDefs = resource(

--- a/frontend/src/lib/components/assets/AssetGraph/DucklakeVersionPreview.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/DucklakeVersionPreview.svelte
@@ -8,8 +8,10 @@
 	import DBTable from '$lib/components/DBTable.svelte'
 	import { resource } from 'runed'
 	import { workspaceStore } from '$lib/stores'
-	import { loadAllTablesMetaData } from '$lib/components/apps/components/display/dbtable/metadata'
-	import { dbTableOpsWithPreviewScripts } from '$lib/components/dbOps'
+	import {
+		fetchDucklakeColumnsAtVersion,
+		dbTableOpsWithPreviewScripts
+	} from '$lib/components/dbOps'
 	import type { DbInput } from '$lib/components/dbTypes'
 	import { parseDbInputFromAssetSyntax, copyToClipboard } from '$lib/utils'
 	import { AlertTriangle, Loader2, ClipboardCopy } from 'lucide-svelte'
@@ -27,6 +29,7 @@
 	let { assetUri, version, class: className = '' }: Props = $props()
 
 	let input = $derived<DbInput | undefined>(parseDbInputFromAssetSyntax(assetUri) ?? undefined)
+	let ducklake = $derived(input?.type === 'ducklake' ? input.ducklake : undefined)
 	let table = $derived(
 		input && 'specificTable' in input ? (input.specificTable as string | undefined) : undefined
 	)
@@ -44,33 +47,30 @@
 			: undefined
 	)
 
-	let colDefs = resource(
-		// Column metadata is the same across snapshots — keyed on `input` only so
-		// switching versions doesn't re-dispatch a metadata preview job (the grid
-		// itself re-reads via `dbTableOps` + the `{#key version}` block).
-		() => [input] as const,
-		async ([_input]) => {
-			if (!_input || !$workspaceStore) return undefined
-			try {
-				return await loadAllTablesMetaData($workspaceStore, _input)
-			} catch {
-				return undefined
-			}
+	// Load the column set *at the pinned version* — a table's schema can differ
+	// across snapshots, so enumerating the current columns against an older
+	// version would reference columns that didn't exist then and break the read.
+	// The result carries the version it was loaded for so the read never uses a
+	// stale column set from the previously-viewed snapshot (the resource keeps
+	// the prior value while re-fetching).
+	let columns = resource(
+		() => [ducklake, tableKey, version] as const,
+		async ([_ducklake, _tableKey, _version]) => {
+			if (!_ducklake || !_tableKey || _version == undefined || !$workspaceStore) return undefined
+			const colDefs = await fetchDucklakeColumnsAtVersion({
+				workspace: $workspaceStore,
+				ducklake: _ducklake,
+				tableKey: _tableKey,
+				version: _version
+			})
+			return { version: _version, colDefs }
 		}
 	)
-
-	let tableColDefs = $derived.by(() => {
-		const defs = colDefs.current
-		if (!table || !defs) return undefined
-		const direct = defs[`${schema ?? 'main'}.${table}`] ?? defs[table]
-		const found =
-			direct ??
-			(() => {
-				const key = Object.keys(defs).find((k) => k === table || k.endsWith(`.${table}`))
-				return key ? defs[key] : undefined
-			})()
-		return found
-	})
+	// Only ready once the loaded columns are for the version currently shown.
+	let ready = $derived(
+		columns.current?.version === version && (columns.current?.colDefs.length ?? 0) > 0
+	)
+	let tableColDefs = $derived(ready ? columns.current!.colDefs : undefined)
 
 	let dbTableOps = $derived.by(() => {
 		if (!(input && tableColDefs && tableKey && $workspaceStore && version != undefined))
@@ -113,21 +113,21 @@
 				/>
 			</div>
 		{/if}
-		{#if colDefs.loading && !colDefs.current}
-			<div class="flex items-center justify-center p-4 text-tertiary">
-				<Loader2 class="animate-spin" size={18} />
-			</div>
-		{:else if !tableColDefs}
-			<div class="flex items-center gap-2 p-3 text-2xs text-tertiary">
-				<AlertTriangle size={14} class="text-amber-500" />
-				Couldn't load this table at version {version}.
-			</div>
-		{:else if dbTableOps}
+		{#if ready && dbTableOps}
 			{#key version}
 				<div class="grow min-h-0">
 					<DBTable {dbTableOps} />
 				</div>
 			{/key}
+		{:else if columns.error}
+			<div class="flex items-center gap-2 p-3 text-2xs text-tertiary">
+				<AlertTriangle size={14} class="text-amber-500" />
+				Couldn't load this table at version {version}.
+			</div>
+		{:else}
+			<div class="flex items-center justify-center p-4 text-tertiary">
+				<Loader2 class="animate-spin" size={18} />
+			</div>
 		{/if}
 	{/if}
 </div>

--- a/frontend/src/lib/components/assets/AssetGraph/DucklakeVersionPreview.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/DucklakeVersionPreview.svelte
@@ -11,8 +11,9 @@
 	import { loadAllTablesMetaData } from '$lib/components/apps/components/display/dbtable/metadata'
 	import { dbTableOpsWithPreviewScripts } from '$lib/components/dbOps'
 	import type { DbInput } from '$lib/components/dbTypes'
-	import { parseDbInputFromAssetSyntax } from '$lib/utils'
-	import { AlertTriangle, Loader2 } from 'lucide-svelte'
+	import { parseDbInputFromAssetSyntax, copyToClipboard } from '$lib/utils'
+	import { AlertTriangle, Loader2, ClipboardCopy } from 'lucide-svelte'
+	import { Button } from '$lib/components/common'
 	import { twMerge } from 'tailwind-merge'
 
 	interface Props {
@@ -94,12 +95,22 @@
 <div class={twMerge('flex flex-col min-h-0 relative', className)}>
 	{#if version == undefined}
 		<div class="flex items-center gap-2 p-3 text-2xs text-tertiary">
-			Pick a version from the History tab to query the table as of that snapshot.
+			Select a snapshot from the list to preview the table as of that version.
 		</div>
 	{:else}
 		{#if exampleSql}
-			<div class="pb-2 text-2xs font-mono text-tertiary truncate" title={exampleSql}>
-				{exampleSql}
+			<div class="flex items-center gap-1 pb-2">
+				<span class="text-2xs font-mono text-tertiary truncate" title={exampleSql}>
+					{exampleSql}
+				</span>
+				<Button
+					variant="subtle"
+					unifiedSize="sm"
+					startIcon={{ icon: ClipboardCopy }}
+					iconOnly
+					onclick={() => copyToClipboard(exampleSql)}
+					title="Copy {exampleSql}"
+				/>
 			</div>
 		{/if}
 		{#if colDefs.loading && !colDefs.current}

--- a/frontend/src/lib/components/assets/AssetGraph/pipelineTemplates.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/pipelineTemplates.ts
@@ -546,6 +546,14 @@ function bodyDuckdb(ctx: TemplateContext): string {
 	}
 	if (ducklakeDb) {
 		lines.push(`ATTACH 'ducklake://${ducklakeDb}' AS lake;`)
+		if (input?.kind === 'ducklake') {
+			// Discoverability hint: every materialize records a DuckLake snapshot,
+			// so a consumer can pin its read to a past version. Snapshot ids live
+			// in the asset's History tab.
+			lines.push(
+				`-- time-travel: read a past snapshot with \`FROM ${`lake.${catalogTableRef(input.path)}`} AT (VERSION => 42)\``
+			)
+		}
 	}
 	if (datatableDb || ducklakeDb) lines.push('')
 

--- a/frontend/src/lib/components/dbOps.ts
+++ b/frontend/src/lib/components/dbOps.ts
@@ -166,13 +166,16 @@ export async function fetchDucklakeColumnsAtVersion({
 	version: number
 }): Promise<ColumnDef[]> {
 	// Quote each identifier part (schema.table) so a dotted/odd table name can't
-	// break the statement. `version` is a number — injection-safe.
+	// break the statement, and double single-quotes in the catalog name so it
+	// can't break out of the ATTACH string literal (mirrors the backend's
+	// `escape_sql_literal`). `version` is a number — injection-safe.
 	const quoted = tableKey
 		.split('.')
 		.map((p) => `"${p.replace(/"/g, '""')}"`)
 		.join('.')
+	const ducklakeLit = ducklake.replace(/'/g, "''")
 	const content =
-		`ATTACH 'ducklake://${ducklake}' AS __dlv__; USE __dlv__; ` +
+		`ATTACH 'ducklake://${ducklakeLit}' AS __dlv__; USE __dlv__; ` +
 		`DESCRIBE SELECT * FROM ${quoted} AT (VERSION => ${version});`
 	const rows = (await runScriptAndPollResult({
 		workspace,

--- a/frontend/src/lib/components/dbOps.ts
+++ b/frontend/src/lib/components/dbOps.ts
@@ -145,20 +145,27 @@ export type DucklakeSnapshot = {
 }
 
 /**
- * List a ducklake's time-travel history (its catalog commit log), newest
- * first. Snapshots are catalog-wide in DuckLake, so every entry is a version
- * an `AT (VERSION => n)` read can target. Runs the `DUCKLAKE_SNAPSHOTS` marker
- * as a duckdb preview job (server-side SQL build + ATTACH), so no raw SQL is
- * constructed in the client.
+ * List a ducklake table's time-travel history, newest first. DuckLake snapshots
+ * are catalog-wide commits; passing `table` (schema-qualified, e.g.
+ * `main.events_daily`) scopes the list to snapshots where the table exists —
+ * otherwise an `AT (VERSION => n)` read could target a version predating the
+ * table's creation and error. Runs the `DUCKLAKE_SNAPSHOTS` marker as a duckdb
+ * preview job (server-side SQL build + ATTACH), so no raw SQL is constructed in
+ * the client.
  */
 export async function fetchDucklakeSnapshots({
 	workspace,
-	ducklake
+	ducklake,
+	table
 }: {
 	workspace: string
 	ducklake: string
+	table?: string
 }): Promise<DucklakeSnapshot[]> {
-	const content = `-- WM_INTERNAL_DB_DUCKLAKE_SNAPSHOTS ${JSON.stringify({ ducklake })}`
+	const content = `-- WM_INTERNAL_DB_DUCKLAKE_SNAPSHOTS ${JSON.stringify({
+		ducklake,
+		...(table ? { table } : {})
+	})}`
 	const rows = await runScriptAndPollResult({
 		workspace,
 		requestBody: { args: {}, language: 'duckdb', content }

--- a/frontend/src/lib/components/dbOps.ts
+++ b/frontend/src/lib/components/dbOps.ts
@@ -46,7 +46,8 @@ export function dbTableOpsWithPreviewScripts({
 	tableKey,
 	colDefs,
 	workspace,
-	whereClause
+	whereClause,
+	version
 }: {
 	input: DbInput
 	tableKey: string
@@ -55,6 +56,9 @@ export function dbTableOpsWithPreviewScripts({
 	// Optional raw SQL predicate AND-ed into the read queries (count + rows).
 	// Caller-trusted — build it with escaped values.
 	whereClause?: string
+	// DuckLake time-travel: when set, reads are pinned to this catalog snapshot
+	// via `AT (VERSION => n)` (DuckDB/ducklake only). Read-only by nature.
+	version?: number
 }): IDbTableOps {
 	const dbType = getDbType(input)
 	const language = getLanguageByResourceType(dbType)
@@ -74,7 +78,8 @@ export function dbTableOpsWithPreviewScripts({
 			const content = makeMarker('COUNT', {
 				table: tableKey,
 				columnDefs: colDefs,
-				...(whereClause ? { whereClause } : {})
+				...(whereClause ? { whereClause } : {}),
+				...(version != undefined ? { version } : {})
 			})
 			const result = await runScriptAndPollResult({
 				workspace,
@@ -88,7 +93,8 @@ export function dbTableOpsWithPreviewScripts({
 				table: tableKey,
 				columnDefs: colDefs,
 				fixPgIntTypes: true,
-				...(whereClause ? { whereClause } : {})
+				...(whereClause ? { whereClause } : {}),
+				...(version != undefined ? { version } : {})
 			})
 			let items = (await runScriptAndPollResult({
 				workspace,
@@ -129,6 +135,33 @@ export function dbTableOpsWithPreviewScripts({
 			})
 		}
 	}
+}
+
+export type DucklakeSnapshot = {
+	snapshot_id: number
+	snapshot_time: string
+}
+
+/**
+ * List a ducklake's time-travel history (its catalog commit log), newest
+ * first. Snapshots are catalog-wide in DuckLake, so every entry is a version
+ * an `AT (VERSION => n)` read can target. Runs the `DUCKLAKE_SNAPSHOTS` marker
+ * as a duckdb preview job (server-side SQL build + ATTACH), so no raw SQL is
+ * constructed in the client.
+ */
+export async function fetchDucklakeSnapshots({
+	workspace,
+	ducklake
+}: {
+	workspace: string
+	ducklake: string
+}): Promise<DucklakeSnapshot[]> {
+	const content = `-- WM_INTERNAL_DB_DUCKLAKE_SNAPSHOTS ${JSON.stringify({ ducklake })}`
+	const rows = await runScriptAndPollResult({
+		workspace,
+		requestBody: { args: {}, language: 'duckdb', content }
+	})
+	return Array.isArray(rows) ? (rows as DucklakeSnapshot[]) : []
 }
 
 export type IDbSchemaOps = {

--- a/frontend/src/lib/components/dbOps.ts
+++ b/frontend/src/lib/components/dbOps.ts
@@ -1,5 +1,6 @@
 import {
 	getLanguageByResourceType,
+	ColumnIdentity,
 	type ColumnDef,
 	type TableMetadata
 } from './apps/components/display/dbtable/utils'
@@ -142,6 +143,51 @@ export type DucklakeSnapshot = {
 	// DuckLake returns this as microseconds-since-epoch serialized as a string
 	// (TIMESTAMP); callers must convert before formatting.
 	snapshot_time: string | number
+}
+
+/**
+ * Column metadata of a ducklake table *at a specific snapshot*. The catalog's
+ * `information_schema` only reflects the current schema, so a time-travel read
+ * pinned to an older version must enumerate the columns that existed *then* —
+ * otherwise a column added in a later snapshot would break the `SELECT … AT
+ * (VERSION => n)`. `DESCRIBE SELECT * FROM … AT (VERSION => n)` gives exactly
+ * that. Returns minimal `ColumnDef`s (field + datatype) — enough for the
+ * read-only preview's SELECT/COUNT and grid headers.
+ */
+export async function fetchDucklakeColumnsAtVersion({
+	workspace,
+	ducklake,
+	tableKey,
+	version
+}: {
+	workspace: string
+	ducklake: string
+	tableKey: string
+	version: number
+}): Promise<ColumnDef[]> {
+	// Quote each identifier part (schema.table) so a dotted/odd table name can't
+	// break the statement. `version` is a number — injection-safe.
+	const quoted = tableKey
+		.split('.')
+		.map((p) => `"${p.replace(/"/g, '""')}"`)
+		.join('.')
+	const content =
+		`ATTACH 'ducklake://${ducklake}' AS __dlv__; USE __dlv__; ` +
+		`DESCRIBE SELECT * FROM ${quoted} AT (VERSION => ${version});`
+	const rows = (await runScriptAndPollResult({
+		workspace,
+		requestBody: { args: {}, language: 'duckdb', content }
+	})) as { column_name: string; column_type: string }[]
+	if (!Array.isArray(rows)) return []
+	return rows.map((r) => ({
+		field: r.column_name,
+		datatype: r.column_type,
+		defaultvalue: '',
+		isprimarykey: false,
+		isidentity: ColumnIdentity.No,
+		isnullable: 'YES' as const,
+		isenum: false
+	}))
 }
 
 /**

--- a/frontend/src/lib/components/dbOps.ts
+++ b/frontend/src/lib/components/dbOps.ts
@@ -139,7 +139,9 @@ export function dbTableOpsWithPreviewScripts({
 
 export type DucklakeSnapshot = {
 	snapshot_id: number
-	snapshot_time: string
+	// DuckLake returns this as microseconds-since-epoch serialized as a string
+	// (TIMESTAMP); callers must convert before formatting.
+	snapshot_time: string | number
 }
 
 /**

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,5 +1,39 @@
 import { describe, it, expect } from 'vitest'
-import { cleanValueProperties, getQueryStmtCountHeuristic } from './utils'
+import {
+	cleanValueProperties,
+	getQueryStmtCountHeuristic,
+	parseDbInputFromAssetSyntax
+} from './utils'
+
+describe('parseDbInputFromAssetSyntax', () => {
+	it('parses a table path', () => {
+		expect(parseDbInputFromAssetSyntax('ducklake://main/orders')).toEqual({
+			type: 'ducklake',
+			ducklake: 'main',
+			specificTable: 'orders',
+			specificSchema: undefined
+		})
+	})
+
+	it('parses a schema-qualified table path', () => {
+		expect(parseDbInputFromAssetSyntax('ducklake://main/analytics.orders')).toEqual({
+			type: 'ducklake',
+			ducklake: 'main',
+			specificTable: 'orders',
+			specificSchema: 'analytics'
+		})
+	})
+
+	it('handles a catalog-only path without throwing (no table segment)', () => {
+		// e.g. `// materialize ducklake` → `ducklake://main` — must not throw.
+		expect(parseDbInputFromAssetSyntax('ducklake://main')).toEqual({
+			type: 'ducklake',
+			ducklake: 'main',
+			specificTable: undefined,
+			specificSchema: undefined
+		})
+	})
+})
 
 describe('getQueryStmtCountHeuristic', () => {
 	describe('basic statements', () => {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -2118,22 +2118,27 @@ export function pick<T extends object, K extends keyof T>(obj: T, keys: readonly
 
 export function parseDbInputFromAssetSyntax(path: string): DbInput | null {
 	const [p1, _p2] = path.split('://')
-	const [p2, _p3] = _p2.split('/')
-	const [p3, p4] = _p3.split('.')
+	const [p2, _p3] = (_p2 ?? '').split('/')
+	// `_p3` is undefined for a catalog-only path (e.g. `ducklake://main`, no
+	// table segment) — guard the split so the helper returns a table-less input
+	// instead of throwing.
+	const [p3, p4] = (_p3 ?? '').split('.')
+	const specificTable = p4 || p3 || undefined
+	const specificSchema = p4 ? p3 : undefined
 	return p1 === 'ducklake'
 		? {
 				type: 'ducklake',
 				ducklake: p2 || 'main',
-				specificTable: p4 ?? p3,
-				specificSchema: p4 ? p3 : undefined
+				specificTable,
+				specificSchema
 			}
 		: p1 === 'datatable'
 			? {
 					type: 'database',
 					resourcePath: `datatable://${p2 || 'main'}`,
 					resourceType: 'postgresql',
-					specificTable: p4 ?? p3,
-					specificSchema: p4 ? p3 : undefined
+					specificTable,
+					specificSchema
 				}
 			: null
 }


### PR DESCRIPTION
## Summary

Makes DuckLake's per-materialization snapshots a **first-class, discoverable time-travel surface**. Every `// materialize` write already records a DuckLake `snapshot_id`; this PR lets users actually *use* those snapshots — read a table as of any past version, see the snapshot history, and copy the exact `AT (VERSION => n)` syntax — covering the three things people reach for: debugging a past run, rolling back, and ad-hoc experimentation on a historical state.

### Scope decision (important)

The original task was to thread each producer's `snapshot_id` automatically through the cascade trigger blob and inject `AT (VERSION => $WM_UPSTREAM_SNAPSHOT)` into consumer reads. After discussion we **deliberately deferred** that automatic cascade pinning and shipped the explicit, user-driven surface instead. Rationale (recorded in `docs/ducklake-materialization.md` → "Reproducibility"):
- The only thing auto-pinning adds over the explicit surface is *automatic per-run consistency* — protection against an upstream re-materializing mid-run. That race only bites high-frequency event-driven cascades (rare today) and is never corruption (DuckLake reads are whole ACID snapshots), so it is **not critical**.
- Auto-injecting/stripping an `AT` clause is invisible magic; the explicit clause is inspectable.
- Multi-upstream consumers need a per-ref snapshot *map* accumulated across the AND-join, which is EE — a single `$WM_UPSTREAM_SNAPSHOT` would silently mis-pin.

This surfacing is the foundation auto-pinning would build on, if a workload ever shows the consistency race in practice.

## Changes

**Backend** (`backend/windmill-common/src/query_builders.rs`)
- `SelectOptions`/`SelectPayload`/`CountPayload` gain an optional `version: Option<i64>`. When set (DuckDB only), `make_select_query`/`make_count_query` emit `FROM <table> AT (VERSION => n)`. `n` is a server-controlled `i64` deserialized by serde, so it's injection-safe; the suffix is emitted only in the `DbType::Duckdb` arms (never leaks into other dialects).
- New `WM_INTERNAL_DB_DUCKLAKE_SNAPSHOTS` marker op → `SELECT snapshot_id, snapshot_time FROM ducklake_snapshots('dl') ORDER BY snapshot_id DESC` (catalog-wide commit log), wrapped with the existing ducklake ATTACH path.
- 6 new unit tests (incl. the negative `test_version_ignored_for_non_duckdb` and unpinned-fallback cases).

**Frontend**
- `dbOps.ts`: threads `version` into the SELECT/COUNT markers; adds `fetchDucklakeSnapshots`.
- New `DucklakeAssetPanel.svelte` — tabbed Partitions / History / Query panel; replaces the bare partition grid on the ducklake asset node (`AssetGraphDetailsPane.svelte`).
- New `DucklakeSnapshotHistory.svelte` — snapshot timeline (id + time), copy `AT (VERSION => n)`, copy full `FROM … AT (VERSION => n)`, and "Query this version".
- New `DucklakeVersionPreview.svelte` — read-only grid of the table at a chosen version, with the equivalent SQL shown above it.
- `pipelineTemplates.ts`: scaffolds a `-- time-travel: …` hint when a ducklake input is read.

**Docs**: `ducklake-materialization.md` rewritten to record the shipped surface + the deferred-cascade-pinning rationale.

## Validation

- ✅ Backend: 6 new `query_builders` unit tests pass (`cargo test -p windmill-common query_builders::`); `windmill-common` compiles; the only runtime consumer (worker) uses the unchanged `try_expand_internal_db_query`; `make_count_query` has no external callers.
- ✅ Frontend: `npm run check` clean on all changed files (the repo's 67 pre-existing `Timeout`-vs-`number` errors are unrelated); svelte-autofixer clean on all 3 new components; dev bundle hot-reloads them without error.
- ✅ `local-review` pass: one P2 (redundant metadata refetch on version switch) found and fixed.

## Screenshots

**Not captured** — and I want to be explicit about why rather than skip silently. The interactive flow can't be exercised on this dev box: there's **no object store / MinIO** configured, so a DuckLake `// materialize` write (which goes through the S3 proxy to `s3://_default_/`) can't run, meaning no real table/snapshots exist to render the History/Query tabs against. I got as far as creating a ducklake-materialize pipeline draft to produce an asset node, but the no-storage environment + the alpha pipeline-insert flow blocked completing it. The rendering logic is covered by type-check + svelte-autofixer; the SQL codegen by unit tests.

## Test plan

On an instance with an object store + a configured ducklake, after ≥2 materialize runs of a table:
- [ ] Select the ducklake asset node → panel shows **Partitions / History / Query** tabs.
- [ ] **History**: snapshots list newest-first with id + timestamp; copy-clause / copy-`FROM` / Query buttons work.
- [ ] **Query**: picking a version renders the grid read-only (no edit/delete/insert), with `FROM … AT (VERSION => n)` shown above; switching versions reloads rows and does **not** re-dispatch a metadata job (P2 fix).
- [ ] A consumer DuckDB script with `FROM dl.t AT (VERSION => n)` reads the pinned snapshot; removing the clause reads latest.
- [ ] Scaffolding a ducklake-input duckdb script emits the `-- time-travel:` hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DuckLake time-travel: browse snapshot history and read any table at a past version via AT (VERSION => n). Improves debugging, rollback, and experiments; automatic cascade pinning is deferred.

- **New Features**
  - Backend: `version` on SELECT/COUNT (DuckDB) emits `FROM <table> AT (VERSION => n)`; `DUCKLAKE_SNAPSHOTS` lists catalog snapshots and can scope to a schema‑qualified table.
  - Frontend: `DucklakeAssetPanel` merges History + Query into a master‑detail tab with a read‑only, version‑pinned grid; the preview shows and lets you copy `FROM lake.<table> AT (VERSION => n)`. `dbOps` threads `version`, adds `fetchDucklakeSnapshots` and `fetchDucklakeColumnsAtVersion`; `pipelineTemplates.ts` adds a time‑travel hint for DuckLake inputs.
  - Docs: Updated to match the History tab UI (master‑detail, copy full FROM) and document the deferred cascade pinning.

- **Bug Fixes**
  - Qualify copied time‑travel clauses with `lake.` and render `snapshot_time` correctly (microseconds → ms).
  - Scope snapshot history to versions where the table exists; keep the list pane compact on wide screens.
  - Load preview columns at the pinned version and gate the preview until columns match the current version.
  - Reset selection on asset switch (panel keyed by path) and fall back to the newest snapshot if a prior pick isn’t available.
  - Handle catalog‑only DuckLake paths (e.g. `ducklake://main`) without crashing; show only Partitions for table‑less nodes.
  - Escape DuckLake catalog names in client‑built DESCRIBE ATTACH strings to prevent breaking out of the string literal.

<sup>Written for commit 6992a6763032988846e8f95e898c436c4d95d4cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

