### PR TITLE
fix: reject symlink traversal in job-dir path validation

### DIFF
--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -2903,6 +2903,12 @@ mod tests {
         assert!(is_allowed_file_location(job_dir_str, "repo/payload").is_err());
         assert!(is_allowed_file_location(job_dir_str, "repo/sub/payload").is_err());
 
+        // A dangling symlink (target does not exist yet) is still caught:
+        // `symlink_metadata` does not follow the link.
+        let dangling = job_dir.join("dangling");
+        std::os::unix::fs::symlink(base.join("nonexistent"), &dangling).unwrap();
+        assert!(is_allowed_file_location(job_dir_str, "dangling/payload").is_err());
+
         let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -693,8 +693,6 @@ pub fn is_allowed_file_location(job_dir: &str, user_defined_path: &str) -> error
 
     let full_path = job_dir.join(&user_path);
 
-    // let normalized_job_dir = std::fs::canonicalize(job_dir)?;
-    // let normalized_full_path = std::fs::canonicalize(&full_path)?;
     let normalized_job_dir = normalize_path(job_dir);
     let normalized_full_path = normalize_path(&full_path);
 
@@ -704,6 +702,30 @@ pub fn is_allowed_file_location(job_dir: &str, user_defined_path: &str) -> error
             "Path is outside the allowed job directory.",
         )
         .into());
+    }
+
+    // The lexical check above (which also rejects `..` and absolute paths) cannot
+    // see symlinks. A symlink planted inside the job dir - e.g. by an earlier
+    // Ansible `git_repos` clone whose tracked content includes one - would let a
+    // later `git clone` or file write follow it out of the job dir while still
+    // passing the textual `starts_with` check. Reject any already-existing
+    // component of the user path that is a symlink. Components that don't exist
+    // yet are safe: `..` is excluded above, so the path can only descend.
+    let mut current = normalized_job_dir.clone();
+    for component in user_path.components() {
+        if let Component::Normal(c) = component {
+            current.push(c);
+            if std::fs::symlink_metadata(&current)
+                .map(|m| m.file_type().is_symlink())
+                .unwrap_or(false)
+            {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "Path traverses a symlink, which is not allowed.",
+                )
+                .into());
+            }
+        }
     }
 
     Ok(normalized_full_path)
@@ -2825,6 +2847,61 @@ mod tests {
             "temp/bak dirs leaked: {:?}",
             leftovers
         );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn test_is_allowed_file_location_allows_plain_relative() {
+        let base = std::env::temp_dir().join(format!("wm_allowed_loc_ok_{}", uuid::Uuid::new_v4()));
+        let job_dir = base.join("job");
+        std::fs::create_dir_all(&job_dir).unwrap();
+        let job_dir_str = job_dir.to_str().unwrap();
+
+        let out = is_allowed_file_location(job_dir_str, "repo/sub/playbook.yml").unwrap();
+        assert_eq!(out, normalize_path(&job_dir.join("repo/sub/playbook.yml")));
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn test_is_allowed_file_location_rejects_parent_and_absolute() {
+        let base =
+            std::env::temp_dir().join(format!("wm_allowed_loc_esc_{}", uuid::Uuid::new_v4()));
+        let job_dir = base.join("job");
+        std::fs::create_dir_all(&job_dir).unwrap();
+        let job_dir_str = job_dir.to_str().unwrap();
+
+        assert!(is_allowed_file_location(job_dir_str, "../escape").is_err());
+        assert!(is_allowed_file_location(job_dir_str, "a/../../escape").is_err());
+        assert!(is_allowed_file_location(job_dir_str, "/etc/passwd").is_err());
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    // Regression for GHSA-v934-cvpf-6fjw: a symlink planted inside the job dir
+    // (e.g. by an earlier `git_repos` clone) must not let a later target traverse
+    // it out of the job dir, even though the lexical path stays "inside".
+    #[cfg(unix)]
+    #[test]
+    fn test_is_allowed_file_location_rejects_symlink_traversal() {
+        let base =
+            std::env::temp_dir().join(format!("wm_allowed_loc_symlink_{}", uuid::Uuid::new_v4()));
+        let job_dir = base.join("job");
+        std::fs::create_dir_all(&job_dir).unwrap();
+        // Stand-in for the shared cache dir living outside the job dir.
+        let outside = base.join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        let job_dir_str = job_dir.to_str().unwrap();
+
+        // Plant `job/repo` -> `../outside`, as a malicious first clone would.
+        let planted = job_dir.join("repo");
+        std::os::unix::fs::symlink(&outside, &planted).unwrap();
+
+        // Both the symlink itself and any path traversing it are rejected.
+        assert!(is_allowed_file_location(job_dir_str, "repo").is_err());
+        assert!(is_allowed_file_location(job_dir_str, "repo/payload").is_err());
+        assert!(is_allowed_file_location(job_dir_str, "repo/sub/payload").is_err());
 
         let _ = std::fs::remove_dir_all(&base);
     }

--- a/backend/windmill-common/src/worker.rs
+++ b/backend/windmill-common/src/worker.rs
@@ -704,15 +704,21 @@ pub fn is_allowed_file_location(job_dir: &str, user_defined_path: &str) -> error
         .into());
     }
 
-    // The lexical check above (which also rejects `..` and absolute paths) cannot
-    // see symlinks. A symlink planted inside the job dir - e.g. by an earlier
-    // Ansible `git_repos` clone whose tracked content includes one - would let a
-    // later `git clone` or file write follow it out of the job dir while still
-    // passing the textual `starts_with` check. Reject any already-existing
-    // component of the user path that is a symlink. Components that don't exist
-    // yet are safe: `..` is excluded above, so the path can only descend.
+    // The lexical check above cannot see symlinks: a symlink planted inside the
+    // job dir - e.g. by an earlier Ansible `git_repos` clone whose tracked
+    // content includes one - would let a later `git clone` or file write follow
+    // it out of the job dir while still passing the textual `starts_with` check.
+    // Walk the *normalized* relative path (`..`/`.` already collapsed) so each
+    // step matches the real on-disk resolution, and reject any existing component
+    // that is a symlink. Walking the raw user path would drift on an in-bounds
+    // `..` (e.g. `foo/../link`, which normalizes back inside the job dir) and miss
+    // the real symlinked component. Not-yet-existing components are safe: a path
+    // that does not exist cannot itself be a symlink.
+    let relative = normalized_full_path
+        .strip_prefix(&normalized_job_dir)
+        .unwrap_or(&normalized_full_path);
     let mut current = normalized_job_dir.clone();
-    for component in user_path.components() {
+    for component in relative.components() {
         if let Component::Normal(c) = component {
             current.push(c);
             if std::fs::symlink_metadata(&current)
@@ -2902,6 +2908,12 @@ mod tests {
         assert!(is_allowed_file_location(job_dir_str, "repo").is_err());
         assert!(is_allowed_file_location(job_dir_str, "repo/payload").is_err());
         assert!(is_allowed_file_location(job_dir_str, "repo/sub/payload").is_err());
+
+        // An in-bounds `..` must not bypass the check: `foo/../repo/payload`
+        // normalizes back to `repo/payload` and still traverses the symlink.
+        assert!(is_allowed_file_location(job_dir_str, "foo/../repo/payload").is_err());
+        std::fs::create_dir(job_dir.join("real")).unwrap();
+        assert!(is_allowed_file_location(job_dir_str, "real/../repo/payload").is_err());
 
         // A dangling symlink (target does not exist yet) is still caught:
         // `symlink_metadata` does not follow the link.


### PR DESCRIPTION
## Summary

Hardens `is_allowed_file_location` (the shared job-directory path-confinement helper) so that user-supplied paths cannot traverse a symlink to resolve outside the job directory. The previous check was purely lexical (`normalize_path` + `starts_with`), which is symlink-blind: a symlink already present inside the job dir could redirect a subsequent `git clone` or file write outside it while still passing the textual containment check.

This helper backs the Ansible `git_repos` clone targets, the git SSH identity-file location, and file-resource / inventory writes, so the fix covers all of those call sites in both the dependency-generation and execution paths.

## Changes

- `is_allowed_file_location` now walks each already-existing component of the user path and rejects any that is a symlink (via `std::fs::symlink_metadata`, so dangling links are caught too). Not-yet-existing components remain safe because `..` and absolute paths are still rejected, so the path can only descend.
- Removed the stale commented-out `canonicalize` lines (they required the target to already exist and would have broken the returned-path semantics that downstream callers rely on).
- Added unit tests: plain relative paths still allowed, `..`/absolute still rejected, and symlink traversal (including a dangling symlink) rejected.

## Test plan

- [x] `cargo test -p windmill-common --lib is_allowed_file_location` (unix host — the symlink test is `#[cfg(unix)]`)
- [x] Local review (branch-diff-reviewer): no issues
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks symlink traversal in job-dir path validation so clones and writes cannot escape the job dir, including bypasses using in-bounds `..`. Addresses WIN-2083 by preventing shared cache poisoning via Ansible.

- **Bug Fixes**
  - Walks normalized relative components and rejects any symlink via `std::fs::symlink_metadata` (catches dangling and closes `foo/../repo` drift).
  - Keeps lexical checks for `..` and absolute paths; removes stale `canonicalize` comments without changing semantics.
  - Adds tests for allowed relative paths; rejecting parent/absolute; rejecting symlink traversal incl. dangling and in-bounds `..` cases.

<sup>Written for commit 1241e0941354512f07dce04f01d95fca0ae98c52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

