### PR TITLE
feat: clarify session draft bar tracks all workspace draft changes

### DIFF
--- a/frontend/src/lib/components/sessions/SessionDraftBar.svelte
+++ b/frontend/src/lib/components/sessions/SessionDraftBar.svelte
@@ -7,6 +7,7 @@
 	import DraftDiffDrawer from './DraftDiffDrawer.svelte'
 	import SessionDiffButton from './SessionDiffButton.svelte'
 	import { useWorkspaceDrafts } from '$lib/workspaceDrafts.svelte'
+	import Tooltip from '$lib/components/meltComponents/Tooltip.svelte'
 
 	let { session }: { session: Session } = $props()
 
@@ -58,7 +59,13 @@
 	>
 		<div class="flex items-center gap-1.5 min-w-0">
 			<span class="inline-flex shrink-0"><Pencil class="w-3.5 h-3.5 text-secondary" /></span>
-			<span class="truncate text-secondary">{count} draft{count === 1 ? '' : 's'}</span>
+			<Tooltip placement="top" class="truncate text-secondary">
+				{count} draft{count === 1 ? '' : 's'}
+				{#snippet text()}
+					Tracks all unsaved draft changes in this workspace — including edits made outside this
+					chat (e.g. in the editor), not only changes made by the assistant.
+				{/snippet}
+			</Tooltip>
 		</div>
 		<div class="flex items-center gap-1 shrink-0">
 			<SessionDiffButton {count} onclick={() => drawer?.open()} />


### PR DESCRIPTION
## Summary

The AI-sessions draft bar shows a count of deployable draft changes, but it wasn't obvious that this count covers **all** draft changes in the workspace — including edits made outside the chat (e.g. directly in the editor) — not just changes made by the assistant in the current session. This adds an explanatory tooltip to make the scope clear.

## Changes

- `frontend/src/lib/components/sessions/SessionDraftBar.svelte`: wrap the "N drafts" count text in the design-system `meltComponents/Tooltip` so hovering the text reveals the explanation. The count text itself is the trigger (no separate info icon), preserving the existing `truncate text-secondary` styling.

Tooltip copy:
> Tracks all unsaved draft changes in this workspace — including edits made outside this chat (e.g. in the editor), not only changes made by the assistant.

## Screenshots

![draft-tooltip](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/improve-sessions-tooltip/1782124728-draft-tooltip.png)

## Test plan

- [ ] On `/sessions` (requires `wm_dev_global_ai=1` + a workspace AI provider), open a committed session in a workspace that has ≥1 draft
- [ ] Hover the "N drafts" text in the draft bar → tooltip appears with the explanatory copy
- [ ] Confirm the count text still truncates correctly when the bar is narrow
- [ ] Check both `count === 1` (singular "draft") and `count > 1` ("drafts") still render correctly inside the trigger