### PR TITLE
fix: forbid superadmin job tokens from global user and token management

### DIFF
--- a/backend/tests/wm_token_superadmin_guard.rs
+++ b/backend/tests/wm_token_superadmin_guard.rs
@@ -1,0 +1,178 @@
+//! A WM_TOKEN (job JWT) running as a superadmin must not be able to perform
+//! global user/token management — promotion, password reset, user creation,
+//! token creation/impersonation. A non-admin `wm_deployers` member can mint
+//! such a token implicitly via an app/flow `on_behalf_of`, so trusting it would
+//! let them establish *persistent* superadmin. A real superadmin who needs this
+//! from a script must use a dedicated superadmin API token (which only a real
+//! superadmin can create), not `$WM_TOKEN`.
+//!
+//! The fixture provides `test@windmill.dev` (instance superadmin, token
+//! `SECRET_TOKEN`) and `test2@windmill.dev` (non-superadmin, `SECRET_TOKEN_2`).
+
+use serde_json::json;
+use sqlx::{Pool, Postgres};
+use windmill_common::auth::create_jwt_token;
+use windmill_common::db::Authed;
+use windmill_test_utils::*;
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+fn authed(builder: reqwest::RequestBuilder, token: &str) -> reqwest::RequestBuilder {
+    builder.header("Authorization", format!("Bearer {}", token))
+}
+
+/// Mint a WM_TOKEN: an internally-signed job JWT (note the `job_id` claim) for
+/// `email`, exactly as a running app/flow job is issued.
+async fn wm_token(email: &str, is_admin: bool) -> String {
+    let authed = Authed {
+        email: email.to_string(),
+        username: "runner".to_string(),
+        is_admin,
+        is_operator: false,
+        groups: vec![],
+        folders: vec![],
+        scopes: None,
+        token_prefix: None,
+    };
+    create_jwt_token(
+        authed,
+        "test-workspace",
+        3600,
+        Some(uuid::Uuid::new_v4()),
+        Some("app".to_string()),
+        None,
+        None,
+    )
+    .await
+    .expect("mint wm_token")
+}
+
+#[sqlx::test(fixtures("preserve_on_behalf_of"))]
+async fn test_wm_token_cannot_manage_superadmin_users(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    // The server decodes WM_TOKENs with the same in-process JWT secret, so
+    // setting it once lets us mint a valid one below.
+    set_jwt_secret().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base = format!("http://localhost:{port}/api/users");
+
+    // A superadmin-capable WM_TOKEN — the exact thing a deployer obtains via an
+    // app on_behalf_of pointed at a superadmin.
+    let sa_wm = wm_token("test@windmill.dev", true).await;
+
+    // 1. Cannot mint a (superadmin) token.
+    let resp = authed(client().post(format!("{base}/tokens/create")), &sa_wm)
+        .json(&json!({}))
+        .send()
+        .await?;
+    assert_eq!(
+        resp.status(),
+        401,
+        "superadmin WM_TOKEN must not create tokens: {}",
+        resp.text().await?
+    );
+
+    // 2. Cannot impersonate (mint a token as another user).
+    let resp = authed(client().post(format!("{base}/tokens/impersonate")), &sa_wm)
+        .json(&json!({ "impersonate_email": "test2@windmill.dev" }))
+        .send()
+        .await?;
+    assert_eq!(
+        resp.status(),
+        401,
+        "superadmin WM_TOKEN must not impersonate: {}",
+        resp.text().await?
+    );
+
+    // 3. Cannot promote a user to superadmin.
+    let resp = authed(
+        client().post(format!("{base}/update/test2@windmill.dev")),
+        &sa_wm,
+    )
+    .json(&json!({ "is_super_admin": true }))
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        401,
+        "superadmin WM_TOKEN must not promote users: {}",
+        resp.text().await?
+    );
+
+    // 4. Cannot reset its own (the superadmin's) password.
+    let resp = authed(client().post(format!("{base}/setpassword")), &sa_wm)
+        .json(&json!({ "password": "hunter2" }))
+        .send()
+        .await?;
+    assert_eq!(
+        resp.status(),
+        401,
+        "superadmin WM_TOKEN must not reset passwords: {}",
+        resp.text().await?
+    );
+
+    // 4b. Cannot delete a user.
+    let resp = authed(
+        client().delete(format!("{base}/delete/test2@windmill.dev")),
+        &sa_wm,
+    )
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        401,
+        "superadmin WM_TOKEN must not delete users: {}",
+        resp.text().await?
+    );
+
+    // 4c. Cannot change a user's login type.
+    let resp = authed(
+        client().post(format!("{base}/set_login_type/test2@windmill.dev")),
+        &sa_wm,
+    )
+    .json(&json!({ "login_type": "password" }))
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        401,
+        "superadmin WM_TOKEN must not change login type: {}",
+        resp.text().await?
+    );
+
+    // 5. Escape hatch / no false positive: a real superadmin API token
+    //    (SECRET_TOKEN, no job_id) can still create tokens.
+    let resp = authed(
+        client().post(format!("{base}/tokens/create")),
+        "SECRET_TOKEN",
+    )
+    .json(&json!({ "label": "ci" }))
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        201,
+        "a real superadmin token must still create tokens: {}",
+        resp.text().await?
+    );
+
+    // 6. No collateral: a non-superadmin WM_TOKEN can still create its own
+    //    token — the guard only fires for superadmin-capable job tokens.
+    let user_wm = wm_token("test2@windmill.dev", false).await;
+    let resp = authed(client().post(format!("{base}/tokens/create")), &user_wm)
+        .json(&json!({ "label": "from-script" }))
+        .send()
+        .await?;
+    assert_eq!(
+        resp.status(),
+        201,
+        "non-superadmin WM_TOKEN must still create its own token: {}",
+        resp.text().await?
+    );
+
+    Ok(())
+}

--- a/backend/tests/wm_token_superadmin_guard.rs
+++ b/backend/tests/wm_token_superadmin_guard.rs
@@ -1,6 +1,7 @@
 //! A WM_TOKEN (job JWT) running as a superadmin must not be able to perform
 //! global user/token management — promotion, password reset, user creation,
-//! token creation/impersonation. A non-admin `wm_deployers` member can mint
+//! token creation/impersonation, offboarding, or exporting the user table.
+//! A non-admin `wm_deployers` member can mint
 //! such a token implicitly via an app/flow `on_behalf_of`, so trusting it would
 //! let them establish *persistent* superadmin. A real superadmin who needs this
 //! from a script must use a dedicated superadmin API token (which only a real
@@ -141,6 +142,33 @@ async fn test_wm_token_cannot_manage_superadmin_users(db: Pool<Postgres>) -> any
         resp.status(),
         401,
         "superadmin WM_TOKEN must not change login type: {}",
+        resp.text().await?
+    );
+
+    // 4d. Cannot offboard a global user (deletes user, tokens, password, invites,
+    //     instance-group membership and reassigns their assets).
+    let resp = authed(
+        client().post(format!("{base}/offboard/test2@windmill.dev")),
+        &sa_wm,
+    )
+    .json(&json!({}))
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        401,
+        "superadmin WM_TOKEN must not offboard users: {}",
+        resp.text().await?
+    );
+
+    // 4e. Cannot export the global user table (leaks every user's password_hash).
+    let resp = authed(client().get(format!("{base}/export")), &sa_wm)
+        .send()
+        .await?;
+    assert_eq!(
+        resp.status(),
+        401,
+        "superadmin WM_TOKEN must not export global users: {}",
         resp.text().await?
     );
 

--- a/backend/windmill-api-auth/src/lib.rs
+++ b/backend/windmill-api-auth/src/lib.rs
@@ -205,6 +205,33 @@ pub async fn require_super_admin(db: &DB, email: &str) -> error::Result<()> {
     }
 }
 
+/// Forbid sensitive global user/token management when authenticated as a
+/// superadmin *via a job token* (`WM_TOKEN`).
+///
+/// A `WM_TOKEN`'s identity is derived from an app/flow `on_behalf_of`, which a
+/// non-admin `wm_deployers` member can point at a superadmin. Trusting it for
+/// these operations would let them establish *persistent* superadmin (promote a
+/// user, reset a superadmin's password, mint a superadmin token, ...). `job_id`
+/// is set only for `WM_TOKEN`s; regular session/API tokens have it `None`, so a
+/// real superadmin who needs this from a script uses a dedicated superadmin API
+/// token (which only a real superadmin can create) instead of `$WM_TOKEN`.
+pub async fn forbid_superadmin_job_token(
+    db: &DB,
+    email: &str,
+    job_id: Option<uuid::Uuid>,
+) -> error::Result<()> {
+    if job_id.is_some() && is_super_admin_email(db, email).await? {
+        return Err(Error::NotAuthorized(
+            "This operation cannot be performed with a job token ($WM_TOKEN) that runs as a \
+             superadmin. If a script genuinely needs to do this, create a dedicated superadmin \
+             token from the User settings drawer (the 'Tokens' section), store it as a secret, \
+             and use that token explicitly instead of $WM_TOKEN."
+                .to_owned(),
+        ));
+    }
+    Ok(())
+}
+
 pub fn check_scopes<F>(authed: &ApiAuthed, required: F) -> error::Result<()>
 where
     F: FnOnce() -> String,

--- a/backend/windmill-api-users/src/users.rs
+++ b/backend/windmill-api-users/src/users.rs
@@ -27,7 +27,7 @@ use axum::{
     Json, Router,
 };
 use hyper::{header::LOCATION, StatusCode};
-use windmill_api_auth::require_super_admin;
+use windmill_api_auth::{forbid_superadmin_job_token, require_super_admin, OptJobAuthed};
 use windmill_common::usernames::{
     generate_instance_wide_unique_username, get_instance_username_or_create_pending,
 };
@@ -1415,11 +1415,13 @@ async fn convert_user_to_group(
 
 async fn update_user(
     authed: ApiAuthed,
+    OptJobAuthed { job_id, .. }: OptJobAuthed,
     Path(email_to_update): Path<String>,
     Extension(db): Extension<DB>,
     Json(eu): Json<EditUser>,
 ) -> Result<String> {
     require_super_admin(&db, &authed.email).await?;
+    forbid_superadmin_job_token(&db, &authed.email, job_id).await?;
     let mut tx = db.begin().await?;
 
     let mut new_super_admin: Option<bool> = None;
@@ -1581,10 +1583,12 @@ async fn update_user(
 
 async fn delete_user(
     authed: ApiAuthed,
+    OptJobAuthed { job_id, .. }: OptJobAuthed,
     Path(email_to_delete): Path<String>,
     Extension(db): Extension<DB>,
 ) -> Result<String> {
     require_super_admin(&db, &authed.email).await?;
+    forbid_superadmin_job_token(&db, &authed.email, job_id).await?;
     let mut tx = db.begin().await?;
 
     sqlx::query!("DELETE FROM token WHERE email = $1", &email_to_delete)
@@ -1877,9 +1881,11 @@ async fn set_login_type(
     Extension(db): Extension<DB>,
     Path(email): Path<String>,
     authed: ApiAuthed,
+    OptJobAuthed { job_id, .. }: OptJobAuthed,
     Json(et): Json<EditLoginType>,
 ) -> Result<String> {
     require_super_admin(&db, &authed.email).await?;
+    forbid_superadmin_job_token(&db, &authed.email, job_id).await?;
     let mut tx = db.begin().await?;
 
     sqlx::query!(
@@ -2159,8 +2165,10 @@ pub async fn create_session_token<'c>(
 async fn create_token(
     Extension(db): Extension<DB>,
     authed: ApiAuthed,
+    OptJobAuthed { job_id, .. }: OptJobAuthed,
     Json(token_config): Json<NewToken>,
 ) -> Result<(StatusCode, String)> {
+    forbid_superadmin_job_token(&db, &authed.email, job_id).await?;
     check_token_create_rate_limit(&authed.username)?;
 
     windmill_api_auth::ensure_scopes_within_caller(&authed, token_config.scopes.as_deref())?;
@@ -2176,6 +2184,7 @@ async fn create_token(
 async fn impersonate(
     Extension(db): Extension<DB>,
     authed: ApiAuthed,
+    OptJobAuthed { job_id, .. }: OptJobAuthed,
     Json(new_token): Json<NewToken>,
 ) -> Result<(StatusCode, String)> {
     use windmill_common::min_version::MIN_VERSION_SUPPORTS_TOKEN_HASH;
@@ -2189,6 +2198,7 @@ async fn impersonate(
         Some(&token)
     };
     require_super_admin(&db, &authed.email).await?;
+    forbid_superadmin_job_token(&db, &authed.email, job_id).await?;
 
     if new_token.impersonate_email.is_none() {
         return Err(Error::BadRequest(
@@ -2744,9 +2754,11 @@ async fn export_global_users() -> JsonResult<String> {
 async fn overwrite_global_users(
     Extension(db): Extension<DB>,
     authed: ApiAuthed,
+    OptJobAuthed { job_id, .. }: OptJobAuthed,
     Json(users): Json<Vec<ExportedGlobalUser>>,
 ) -> Result<String> {
     require_super_admin(&db, &authed.email).await?;
+    forbid_superadmin_job_token(&db, &authed.email, job_id).await?;
     let mut tx = db.begin().await?;
     sqlx::query!("DELETE FROM password")
         .execute(&mut *tx)

--- a/backend/windmill-api-users/src/users.rs
+++ b/backend/windmill-api-users/src/users.rs
@@ -2717,8 +2717,10 @@ struct ExportedGlobalUser {
 async fn export_global_users(
     Extension(db): Extension<DB>,
     authed: ApiAuthed,
+    OptJobAuthed { job_id, .. }: OptJobAuthed,
 ) -> JsonResult<Vec<ExportedGlobalUser>> {
     require_super_admin(&db, &authed.email).await?;
+    forbid_superadmin_job_token(&db, &authed.email, job_id).await?;
     let mut tx = db.begin().await?;
     let users = sqlx::query_as!(
         ExportedGlobalUser,

--- a/backend/windmill-api/src/offboarding.rs
+++ b/backend/windmill-api/src/offboarding.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 
-use crate::db::ApiAuthed;
+use crate::db::{ApiAuthed, OptJobAuthed};
 use crate::secret_backend_ext::rename_vault_secrets_with_prefix;
 use axum::{
     extract::{Extension, Path},
     Json,
 };
 use serde::{Deserialize, Serialize};
-use windmill_api_auth::require_super_admin;
+use windmill_api_auth::{forbid_superadmin_job_token, require_super_admin};
 use windmill_api_users::users::delete_workspace_user_internal;
 use windmill_audit::audit_oss::audit_log;
 use windmill_audit::ActionKind;
@@ -483,11 +483,13 @@ pub(crate) async fn global_offboard_preview(
 
 pub(crate) async fn offboard_global_user(
     authed: ApiAuthed,
+    OptJobAuthed { job_id, .. }: OptJobAuthed,
     Extension(db): Extension<DB>,
     Path(email): Path<String>,
     Json(req): Json<GlobalOffboardRequest>,
 ) -> Result<Json<OffboardResponse>> {
     require_super_admin(&db, &authed.email).await?;
+    forbid_superadmin_job_token(&db, &authed.email, job_id).await?;
 
     let workspaces = sqlx::query!(
         "SELECT workspace_id, username FROM usr WHERE email = $1",

--- a/backend/windmill-api/src/users.rs
+++ b/backend/windmill-api/src/users.rs
@@ -11,7 +11,7 @@ pub use windmill_api_users::users::*;
 
 use std::sync::Arc;
 
-use crate::db::ApiAuthed;
+use crate::db::{ApiAuthed, OptJobAuthed};
 use crate::secret_backend_ext::rename_vault_secrets_with_prefix;
 use argon2::Argon2;
 use axum::{
@@ -21,7 +21,7 @@ use axum::{
 };
 use hyper::StatusCode;
 use serde::Deserialize;
-use windmill_api_auth::require_super_admin;
+use windmill_api_auth::{forbid_superadmin_job_token, require_super_admin};
 use windmill_audit::audit_oss::audit_log;
 use windmill_audit::ActionKind;
 use windmill_common::audit::AuditAuthor;
@@ -71,11 +71,13 @@ pub fn make_unauthed_service() -> Router {
 
 async fn create_user(
     authed: ApiAuthed,
+    OptJobAuthed { job_id, .. }: OptJobAuthed,
     Extension(db): Extension<DB>,
     Extension(webhook): Extension<windmill_common::webhook::WebhookShared>,
     Extension(argon2): Extension<Arc<Argon2<'_>>>,
     Json(nu): Json<NewUser>,
 ) -> Result<(StatusCode, String)> {
+    forbid_superadmin_job_token(&db, &authed.email, job_id).await?;
     crate::users_oss::create_user(authed, db, webhook, argon2, nu).await
 }
 
@@ -141,8 +143,10 @@ async fn set_password(
     Extension(db): Extension<DB>,
     Extension(argon2): Extension<Arc<Argon2<'_>>>,
     authed: ApiAuthed,
+    OptJobAuthed { job_id, .. }: OptJobAuthed,
     Json(ep): Json<EditPassword>,
 ) -> Result<String> {
+    forbid_superadmin_job_token(&db, &authed.email, job_id).await?;
     let email = authed.email.clone();
     crate::users_oss::set_password(db, argon2, authed, &email, ep).await
 }
@@ -152,9 +156,11 @@ async fn set_password_of_user(
     Extension(argon2): Extension<Arc<Argon2<'_>>>,
     Path(email): Path<String>,
     authed: ApiAuthed,
+    OptJobAuthed { job_id, .. }: OptJobAuthed,
     Json(ep): Json<EditPassword>,
 ) -> Result<String> {
     require_super_admin(&db, &authed.email).await?;
+    forbid_superadmin_job_token(&db, &authed.email, job_id).await?;
     crate::users_oss::set_password(db, argon2, authed, &email, ep).await
 }
 
@@ -165,11 +171,13 @@ struct RenameUser {
 
 async fn rename_user(
     authed: ApiAuthed,
+    OptJobAuthed { job_id, .. }: OptJobAuthed,
     Path(user_email): Path<String>,
     Extension(db): Extension<DB>,
     Json(ru): Json<RenameUser>,
 ) -> Result<String> {
     require_super_admin(&db, &authed.email).await?;
+    forbid_superadmin_job_token(&db, &authed.email, job_id).await?;
 
     let mut tx = db.begin().await?;
 


### PR DESCRIPTION
## Summary

A job token (`$WM_TOKEN`) carries an identity derived from an app/flow `on_behalf_of`. Because that run-as identity can be set without being a workspace admin, a job token must not be trusted to perform instance-level user and token management — otherwise it could be used to establish *persistent* elevated state. This adds a guard that rejects such operations when the caller is authenticated via a job token that resolves to a superadmin, while leaving the existing `on_behalf_of` behavior untouched.

## Changes

- Add `forbid_superadmin_job_token(db, email, job_id)` in `windmill-api-auth`. It errors only when the request is authed by a job token (`job_id` is set — regular session/API tokens have it `None`) **and** that identity is superadmin-capable. Normal (non-superadmin) job tokens are unaffected.
- Apply it to the global user/token management endpoints: `update_user` (promotion, including the instance-group role recompute), `set_password` / `set_password_of_user`, `create_user`, `delete_user`, `set_login_type`, `rename_user`, `create_token`, `impersonate`, `overwrite_global_users`, `offboard_global_user`, and `export_global_users`. Offboarding can delete a user along with their tokens, password, invites and instance-group membership; export returns every user's `password_hash` — so both are in scope.
- The rejection message tells a script author how to do this legitimately: create a dedicated superadmin token from the User settings drawer ('Tokens' section) and use it explicitly instead of `$WM_TOKEN`. Only a real superadmin can create such a token, so it's a credential the job-token path cannot mint for itself.
- Add `backend/tests/wm_token_superadmin_guard.rs`.

## Test plan

- [x] `cargo check --features quickjs` (full workspace) clean; `cargo check -p windmill-api --features enterprise` clean
- [x] `cargo test --test wm_token_superadmin_guard` — passes:
  - superadmin `$WM_TOKEN` → 401 on token-create / impersonate / promote / password-reset / delete / set-login-type / offboard / export
  - real superadmin API token (no `job_id`) → 201 (still works)
  - non-superadmin `$WM_TOKEN` → 201 creating its own token (no collateral)
- [x] No new sqlx queries (helper reuses `is_super_admin_email`); offline cache unaffected