### PR TITLE
fix: preserve fork parent linkage on workspace id change

### DIFF
--- a/backend/.sqlx/query-40a8cf5e87bb489fd172689e9a6f0f1075b878f9916145929b3cd3b1a53b777e.json
+++ b/backend/.sqlx/query-40a8cf5e87bb489fd172689e9a6f0f1075b878f9916145929b3cd3b1a53b777e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE workspace SET parent_workspace_id = $1 WHERE parent_workspace_id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "40a8cf5e87bb489fd172689e9a6f0f1075b878f9916145929b3cd3b1a53b777e"
+}

--- a/backend/.sqlx/query-42322020ff9cc7dd7ebafc1cb4122ba3d670cc36bdbc6451f29b8f22f8cff688.json
+++ b/backend/.sqlx/query-42322020ff9cc7dd7ebafc1cb4122ba3d670cc36bdbc6451f29b8f22f8cff688.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT p.id AS \"id!\", p.deleted AS \"deleted!\"\n         FROM workspace f\n         JOIN workspace p ON p.id = f.parent_workspace_id\n         WHERE f.id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "deleted!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "42322020ff9cc7dd7ebafc1cb4122ba3d670cc36bdbc6451f29b8f22f8cff688"
+}

--- a/backend/.sqlx/query-a54efa4a7466e61fd54d8fe293cb775225dcb430026cebe15ba4994ac636514d.json
+++ b/backend/.sqlx/query-a54efa4a7466e61fd54d8fe293cb775225dcb430026cebe15ba4994ac636514d.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO workspace (id, name, owner, deleted, premium, parent_workspace_id)\n         SELECT $1, $2, owner, false, premium,\n                CASE WHEN $4 THEN parent_workspace_id ELSE NULL END\n         FROM workspace WHERE id = $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a54efa4a7466e61fd54d8fe293cb775225dcb430026cebe15ba4994ac636514d"
+}

--- a/backend/windmill-api-integration-tests/tests/workspaces.rs
+++ b/backend/windmill-api-integration-tests/tests/workspaces.rs
@@ -646,6 +646,20 @@ async fn test_workspace_endpoints(db: Pool<Postgres>) -> anyhow::Result<()> {
             .unwrap();
         assert_eq!(resp.json::<bool>().await?, true);
 
+        // Regression: changing a fork's workspace id must preserve its parent
+        // linkage. Dropping it leaves a wm-fork- workspace with no parent — a
+        // "fork of nothing" that can no longer be compared or merged.
+        let parent: Option<String> =
+            sqlx::query_scalar("SELECT parent_workspace_id FROM workspace WHERE id = $1")
+                .bind("wm-fork-renamed")
+                .fetch_one(&db)
+                .await?;
+        assert_eq!(
+            parent.as_deref(),
+            Some("new-test-ws"),
+            "renamed fork must keep its parent_workspace_id"
+        );
+
         // --- create_fork over an existing (active) workspace id: clear 400, not a raw SQL 500 ---
         let resp = authed(client().post(format!("{new_ws_base}/create_fork")))
             .json(&json!({

--- a/backend/windmill-api-workspaces/src/deployment_requests.rs
+++ b/backend/windmill-api-workspaces/src/deployment_requests.rs
@@ -717,16 +717,27 @@ async fn create_deployment_request_comment(
 // ---- helpers ------------------------------------------------------------
 
 async fn parent_of_fork(db: &DB, w_id: &str) -> Result<String> {
-    sqlx::query_scalar!(
-        "SELECT parent_workspace_id FROM workspace WHERE id = $1",
+    // Resolve the fork's parent and require it to still exist and be active. A
+    // parent that is archived (soft-deleted) can no longer be accessed, so a
+    // diff or deployment request against it targets an unreachable workspace.
+    let parent = sqlx::query!(
+        "SELECT p.id AS \"id!\", p.deleted AS \"deleted!\"
+         FROM workspace f
+         JOIN workspace p ON p.id = f.parent_workspace_id
+         WHERE f.id = $1",
         w_id,
     )
     .fetch_optional(db)
-    .await?
-    .flatten()
-    .ok_or_else(|| {
-        Error::BadRequest(format!(
+    .await?;
+
+    match parent {
+        None => Err(Error::BadRequest(format!(
             "workspace {w_id} is not a fork (no parent_workspace_id)"
-        ))
-    })
+        ))),
+        Some(p) if p.deleted => Err(Error::BadRequest(format!(
+            "parent workspace {} of fork {w_id} is archived",
+            p.id
+        ))),
+        Some(p) => Ok(p.id),
+    }
 }

--- a/backend/windmill-api-workspaces/src/workspaces_extra.rs
+++ b/backend/windmill-api-workspaces/src/workspaces_extra.rs
@@ -65,13 +65,22 @@ pub(crate) async fn change_workspace_id(
         old_id, rw.new_id
     );
 
-    // Create new workspace with new id and name
+    // Create new workspace with new id and name. A fork that keeps a wm-fork-
+    // id must carry its parent_workspace_id over, otherwise it becomes a
+    // parentless "fork of nothing" with no source to compare or merge against.
+    // A non-fork target id means the workspace is being promoted out of a fork,
+    // so the parent pointer is intentionally cleared.
     info!("Creating new workspace row");
+    let new_is_fork = rw.new_id.starts_with(WM_FORK_PREFIX);
     sqlx::query!(
-        "INSERT INTO workspace SELECT $1, $2, owner, false, premium FROM workspace WHERE id = $3",
+        "INSERT INTO workspace (id, name, owner, deleted, premium, parent_workspace_id)
+         SELECT $1, $2, owner, false, premium,
+                CASE WHEN $4 THEN parent_workspace_id ELSE NULL END
+         FROM workspace WHERE id = $3",
         &rw.new_id,
         &rw.new_name,
-        &old_id
+        &old_id,
+        new_is_fork
     )
     .execute(&mut *tx)
     .await?;
@@ -341,6 +350,18 @@ pub(crate) async fn change_workspace_id(
     .await?;
     sqlx::query!(
         "UPDATE workspace_fork_deployment_request SET fork_workspace_id = $1 WHERE fork_workspace_id = $2",
+        &rw.new_id,
+        &old_id
+    )
+    .execute(&mut *tx)
+    .await?;
+
+    // Re-parent child forks: any fork whose parent_workspace_id was the old id
+    // must follow the renamed parent to the new id, otherwise it is left
+    // pointing at the soft-deleted old shell (whose data has moved here).
+    info!("Re-parenting child forks to the new workspace id");
+    sqlx::query!(
+        "UPDATE workspace SET parent_workspace_id = $1 WHERE parent_workspace_id = $2",
         &rw.new_id,
         &old_id
     )

--- a/frontend/src/lib/components/ForkWorkspaceBanner.svelte
+++ b/frontend/src/lib/components/ForkWorkspaceBanner.svelte
@@ -12,10 +12,14 @@
 	let comparison: WorkspaceComparison | undefined = $state(undefined)
 	let error: string | undefined = $state(undefined)
 
-	let isFork = $derived($workspaceStore?.startsWith('wm-fork-') ?? false)
 	let currentWorkspaceData = $derived($userWorkspaces.find((w) => w.id === $workspaceStore))
 	let parentWorkspaceId = $derived(currentWorkspaceData?.parent_workspace_id)
 	let parentWorkspaceData = $derived($userWorkspaces.find((w) => w.id === parentWorkspaceId))
+	// A fork must have a parent to compare/merge against. Treating the wm-fork-
+	// prefix alone as "is a fork" renders a parentless "Fork of ()" banner when
+	// the parent linkage was dropped (e.g. by a workspace id change), so require
+	// both, matching the forks/compare page.
+	let isFork = $derived(($workspaceStore?.startsWith('wm-fork-') ?? false) && !!parentWorkspaceId)
 
 	// Drafts in this fork. When the fork is otherwise in sync with its parent, a
 	// user with only pending drafts should still get the draft CTA (mirrors the


### PR DESCRIPTION
## Summary

Changing a fork's workspace id produced a "fork of nothing". `change_workspace_id` uses a move-and-archive: it inserts a new `workspace` row, moves the data over, and soft-deletes the old row. The insert projected only `id, name, owner, deleted, premium` — dropping `parent_workspace_id` — so the renamed fork was left with no parent, and child forks pointing at the old id were never re-parented. The UI compounded this because `ForkWorkspaceBanner` treated the `wm-fork-` prefix alone as "is a fork", rendering a parentless `Fork of ()` banner with no source to compare or merge against.

This restores the parent linkage across a rename and hardens the surrounding paths.

## Changes

- **`change_workspace_id`**: the new workspace row now carries `parent_workspace_id`. It is preserved when the new id is a `wm-fork-` id, and intentionally cleared when the new id is a non-fork id (promotion out of a fork).
- **`change_workspace_id`**: re-parent child forks via `UPDATE workspace SET parent_workspace_id = new WHERE parent_workspace_id = old`, so a fork-of-a-fork follows the renamed parent instead of dangling at the soft-deleted old shell (whose data has moved to the new id).
- **`parent_of_fork`** (deployment requests): join to the parent and reject an archived or missing parent with a clear error, instead of silently returning a soft-deleted workspace id that the diff/deployment flow can't reach.
- **`ForkWorkspaceBanner`**: require both the `wm-fork-` prefix and a parent (matching the `forks/compare` page), so a parentless fork never renders `Fork of ()`.
- **Regression test**: after a fork rename, assert the renamed fork keeps its `parent_workspace_id`.

## Test plan

- [x] `cargo check -p windmill-api-workspaces`
- [x] `cargo check --tests -p windmill-api-integration-tests --features enterprise,private` (regression test compiles)
- [x] `npm run check` (full) and Svelte autofixer (no issues)
- [x] Integration regression: renamed fork keeps its parent (`windmill-api-integration-tests/tests/workspaces.rs`)
- [ ] Follow-up coverage (not in this PR, non-blocking): child-fork re-parenting on a parent rename; `parent_of_fork` archived-parent rejection
- [ ] Manual: on a `wm-fork-` workspace whose parent was dropped by a prior id change, confirm the banner no longer shows `Fork of ()`; a normal fork still shows the compare/merge banner; renaming a parent with a child fork keeps the child resolving its parent

## Screenshots

The visible effect is suppression of the parentless `Fork of ()` banner. I could not capture it in-browser: the available dev instance is CE with no fork workspaces, and reproducing the state needs an orphaned `wm-fork-` workspace — which this backend fix now prevents from being created. Verified instead via full typecheck, the Svelte autofixer (no issues), and parity with the proven `forks/compare` page `isFork` logic. A normal (non-fork) workspace loads cleanly with no banner and no console errors from the component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes loss of fork parent when renaming a workspace. Preserves fork lineage and prevents broken compare/merge flows and the “Fork of ()” banner.

- **Bug Fixes**
  - Backend: `change_workspace_id` now copies `parent_workspace_id` when the new id keeps the `wm-fork-` prefix, clears it when promoting to a non-fork, and re-parents child forks from old → new id.
  - Backend: `parent_of_fork` validates the parent exists and is not archived (joins to parent; returns clear errors).
  - Frontend: `ForkWorkspaceBanner` only shows for forks that have both `wm-fork-` prefix and a valid parent.
  - Tests: adds an integration regression test to ensure a renamed fork keeps its `parent_workspace_id`.

<sup>Written for commit 299c8a4884e42390428edb757567cac1f52b4adc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

