### PR TITLE
fix: enable DynSelect fields in the schedule editor

### DIFF
--- a/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
@@ -1311,7 +1311,8 @@
 							<br />
 							This is only available for individual script. For flows, retries can be set on each flow
 							step in the flow editor.
-						{/snippet}
+						</Tooltip>
+					{/snippet}
 					{#if itemKind !== 'script'}
 						<Alert type="info" title="Only available for scripts" class="mb-2">
 							Error Handler and Retries are only available for scripts. For flows, use the built-in <a

--- a/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
@@ -986,6 +986,9 @@
 										showReset
 										onlyMaskPassword
 										disabled={!can_write}
+										helperScript={runnable?.path
+											? { source: 'deployed', path: runnable.path, runnable_kind: is_flow ? 'flow' : 'script' }
+											: undefined}
 										schema={$state.snapshot(schema)}
 										bind:isValid
 										bind:args
@@ -1308,8 +1311,7 @@
 							<br />
 							This is only available for individual script. For flows, retries can be set on each flow
 							step in the flow editor.
-						</Tooltip>
-					{/snippet}
+						{/snippet}
 					{#if itemKind !== 'script'}
 						<Alert type="info" title="Only available for scripts" class="mb-2">
 							Error Handler and Retries are only available for scripts. For flows, use the built-in <a


### PR DESCRIPTION
## Summary

Scheduling a script or flow that has a `dynselect`/`dynmultiselect` field showed *"Dynamic input (dynselect) is not available in this mode, write value directly"* instead of the options dropdown (#7151).

`DynamicInput` renders the dynamic `<Select>` only when given a `helperScript` (the script that resolves the options); the prop flows parent → `SchemaForm` → `ArgInput` → `DynamicInput`. `RunForm` passes it, but the schedule editor's `<SchemaForm>` did not, so the field always fell back to manual entry.

## Changes

`frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte`: pass `helperScript` to the runnable-args `<SchemaForm>`, derived from the scheduled runnable (mirroring `RunForm`):

```svelte
helperScript={runnable?.path
	? { source: 'deployed', path: runnable.path, runnable_kind: is_flow ? 'flow' : 'script' }
	: undefined}
```

The schedule editor runs in workspace context, so the helper script executes and populates the dropdown, exactly as it does in the run form.

## Test plan

- [ ] Create or edit a schedule for a script/flow that has a `dynselect` field → the field shows its options dropdown instead of the "not available in this mode" fallback.
- [ ] `cd frontend && npm run check`

## Notes

- Scoped to the scheduled runnable's arguments (the reported case). The error/recovery/success **handler** argument forms (`ErrorOrRecoveryHandler`) render their own `SchemaForm` without `helperScript`, so a handler *script* using dynselect would still fall back — a separate surface, left as a possible follow-up.
- When the args form is shown for a draft with no loaded runnable, `helperScript` is `undefined` and the field falls back (there is no deployed runnable to resolve the helper against).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dynselect/dynmultiselect fields in the schedule editor by passing the runnable’s `helperScript` to the args `SchemaForm`. Options now load like in `RunForm`, so users can pick from a dropdown instead of typing values.

<sup>Written for commit 87cf8bb33e1a4ae421487b9f04dfad8a75260924. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

