### PR TITLE
fix(frontend): destroy old WebsocketProvider on workspace switch in MultiplayerMenu

### DIFF
--- a/frontend/src/lib/components/sidebar/MultiplayerMenu.svelte
+++ b/frontend/src/lib/components/sidebar/MultiplayerMenu.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { run } from 'svelte/legacy'
+	import { onDestroy } from 'svelte'
 
 	import { enterpriseLicense, userStore, workspaceStore, awarenessStore } from '$lib/stores'
 
@@ -23,7 +24,17 @@
 			url: $page.url.pathname
 		})
 	}
+	function disconnectWorkspace() {
+		if (wsProvider) {
+			wsProvider.destroy()
+			wsProvider = undefined
+		}
+		connected = false
+		awareness = undefined
+	}
 	async function connectWorkspace(workspace: string) {
+		disconnectWorkspace()
+
 		let token: string | undefined
 		try {
 			token = await signMultiplayerRequest(workspace)
@@ -71,6 +82,10 @@
 	})
 	run(() => {
 		$enterpriseLicense && $workspaceStore && connectWorkspace($workspaceStore)
+	})
+
+	onDestroy(() => {
+		disconnectWorkspace()
 	})
 
 	let peers = $derived(


### PR DESCRIPTION
## Problem

When switching workspaces, `MultiplayerMenu.svelte` created a new `WebsocketProvider` without destroying the old one. The reactive statement that calls `connectWorkspace($workspaceStore)` had no cleanup, and there was no `onDestroy` handler. The leaked provider kept reconnecting, causing alternating websocket traffic between the old and new workspace rooms and flickering in the Live Activity sidebar.

## Fix

In `frontend/src/lib/components/sidebar/MultiplayerMenu.svelte`:

- Added a `disconnectWorkspace()` helper that destroys `wsProvider` (and resets `connected`/`awareness` to avoid stale state).
- Call it at the start of `connectWorkspace()` before creating a new provider — matching the cleanup pattern in `ScriptEditor.svelte` (lines ~1388-1390).
- Added an `onDestroy` lifecycle hook that runs `disconnectWorkspace()` so the provider is torn down when the component unmounts.

## Validation

- `svelte-check` (via `svelte-check --threshold error`) — no errors on the file.
- Svelte MCP autofixer — no issues.
- Loaded the app via Playwright after the change — no console errors; the component renders fine.

The multiplayer feature is gated on `$enterpriseLicense`, so the websocket connect/reconnect path cannot be exercised on a CE dev build. The change is a behavioral lifecycle fix with no visual UI difference; the logic mirrors the established, working pattern in `ScriptEditor.svelte`.

Fixes WIN-2086

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes leaked `WebsocketProvider` in `MultiplayerMenu.svelte` by cleaning up on workspace switch and unmount, stopping reconnect loops and Live Activity flicker. Addresses WIN-2086.

- **Bug Fixes**
  - Added `disconnectWorkspace()` to destroy `wsProvider` and reset `connected`/`awareness`.
  - Call `disconnectWorkspace()` at the start of `connectWorkspace()` before creating a new provider (mirrors `ScriptEditor.svelte`).
  - Added `onDestroy` to run `disconnectWorkspace()` when the component unmounts.

<sup>Written for commit 89e7af811ee5b6ef913622bbe69649c49cd3d1f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

