### PR TITLE
fix(frontend): ensure type:object in test_run_flow tool schema for Anthropic (WIN-2087)

### DIFF
--- a/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
@@ -135,7 +135,8 @@
 			await acceptPendingFlowEditsIfEnabled()
 		},
 		getFlowInputsSchema: async () => {
-			return flowStore.val.schema ?? {}
+			const s = flowStore.val.schema ?? {}
+			return { type: 'object', properties: {}, required: [], ...s }
 		},
 
 		updateExprsToSet: (id: string, inputTransforms: Record<string, InputTransform>) => {

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -936,7 +936,9 @@ export async function buildSchemaForTool(
 			throw new Error(`Invalid flow inputs schema: ${invalidProperties.join(', ')}`)
 		}
 
-		toolDef.function.parameters = { ...schema, additionalProperties: false }
+		// Anthropic requires input_schema.type to be present; flows with no inputs
+		// can produce a sparse schema (e.g. { order: [] }) lacking it.
+		toolDef.function.parameters = { type: 'object', ...schema, additionalProperties: false }
 
 		// recursively normalize provider-incompatible schema fragments
 		normalizeToolParameterSchema(toolDef.function.parameters)


### PR DESCRIPTION
## Problem

When a flow has no defined inputs, the flow schema may lack a `"type": "object"` field (e.g. `{ "order": [] }`). `buildSchemaForTool` (`frontend/src/lib/components/copilot/chat/shared.ts`) spread this schema into the tool parameters as-is, so when the resulting `test_run_flow` tool definition reached the Anthropic API it was rejected:

```
400 invalid_request_error: tools.N.custom.input_schema.type: Field required
```

The existing fallback in `anthropic.ts` only triggers when `parameters` is falsy, but the sparse schema is truthy — so it never kicked in.

## Fix

- `shared.ts`: default `type: 'object'` before spreading the schema. If the schema already has `type: 'object'`, the spread overwrites harmlessly.
- `FlowAIChat.svelte` (`getFlowInputsSchema`): backfill `type`/`properties`/`required` as a defense-in-depth measure so the schema is always well-formed at the source.

## Validation

- `npm run check:fast` — no new errors in the modified files (the 67 reported errors are pre-existing `Timeout` vs `number` node-types issues across the codebase, unrelated to this change).
- End-to-end exercise of the AI chat against the live Anthropic API requires a configured API key and a no-input flow triggering `test_run_flow`; not run here. The change is a minimal, well-understood schema fix matching the documented root cause.

Fixes WIN-2087

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the `test_run_flow` tool schema always includes `type: 'object'` to satisfy Anthropic’s requirements and stop 400 errors on flows with no inputs. Addresses WIN-2087.

- **Bug Fixes**
  - `shared.ts`: In `buildSchemaForTool`, default `{ type: 'object' }` before spreading the flow schema and set `additionalProperties: false`.
  - `FlowAIChat.svelte`: In `getFlowInputsSchema`, backfill `type`, `properties`, and `required` to always return a well-formed schema.

<sup>Written for commit ffb4ccf01aefd9ef0b907a38e875d8ab49fe7945. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

