### PR TITLE
fix(health): detect read-only replica via pg_is_in_recovery() (WIN-2085)

### DIFF
--- a/backend/.sqlx/query-282b56cfb8504312ac586cd4c1f3f914cf1651c08b8edd1b06d9a6454ed779bf.json
+++ b/backend/.sqlx/query-282b56cfb8504312ac586cd4c1f3f914cf1651c08b8edd1b06d9a6454ed779bf.json
@@ -1,12 +1,12 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT 1",
+  "query": "SELECT NOT pg_is_in_recovery()",
   "describe": {
     "columns": [
       {
         "ordinal": 0,
         "name": "?column?",
-        "type_info": "Int4"
+        "type_info": "Bool"
       }
     ],
     "parameters": {
@@ -16,5 +16,5 @@
       null
     ]
   },
-  "hash": "e004ebd5b5532a4b85984a62f8ad48a81aa3460c1ca07701f386135d72cdecf5"
+  "hash": "282b56cfb8504312ac586cd4c1f3f914cf1651c08b8edd1b06d9a6454ed779bf"
 }

--- a/backend/windmill-api/src/health.rs
+++ b/backend/windmill-api/src/health.rs
@@ -219,12 +219,16 @@ struct DatabaseCheckResult {
 
 async fn check_database_with_latency(db: &DB) -> DatabaseCheckResult {
     let start = std::time::Instant::now();
+    // `pg_is_in_recovery()` is true on standbys/read-only replicas, so a primary
+    // returns true here. A read-only replica (e.g. after a failover where the
+    // primary became a secondary) reports unhealthy, letting liveness probes
+    // restart the pod instead of silently failing all writes.
     let healthy = tokio::time::timeout(
         HEALTH_CHECK_TIMEOUT,
-        sqlx::query_scalar!("SELECT 1").fetch_one(db),
+        sqlx::query_scalar!("SELECT NOT pg_is_in_recovery()").fetch_one(db),
     )
     .await
-    .map(|r| r.is_ok())
+    .map(|r| matches!(r, Ok(Some(true))))
     .unwrap_or(false);
     let latency_ms = start.elapsed().as_millis() as i64;
 


### PR DESCRIPTION
## Problem

The `/api/health/status` endpoint checked database connectivity with `SELECT 1`, which succeeds even on a read-only standby. After a PostgreSQL failover where the primary becomes a secondary, the health check kept reporting `healthy` while all write operations failed with `cannot execute INSERT in a read-only transaction`. Kubernetes liveness probes therefore never detected the problem and never restarted the pod.

## Fix

`check_database_with_latency()` now runs `SELECT NOT pg_is_in_recovery()` instead of `SELECT 1`:

- `pg_is_in_recovery()` returns `true` on standbys/read-only replicas, so `NOT pg_is_in_recovery()` is `true` on a primary and `false` on a standby.
- Result handling changed from `.is_ok()` on an `i32` to `matches!(r, Ok(Some(true)))`, so the health check is unhealthy both when the query fails and when the DB is in recovery (read-only).

The sqlx offline cache entry was regenerated for the new query (old `query-e004…json` removed, new `query-282b…json` added).

## Validation

- Backend recompiled cleanly under `cargo watch` (no errors/warnings).
- `SELECT NOT pg_is_in_recovery()` runs against the live DB and returns `t` on the primary.
- `GET /api/health/status` returns `{"status":"healthy","database_healthy":true,...}` on the primary.
- On a read-only replica `pg_is_in_recovery()` is `true` → `database_healthy` would be `false`, marking the endpoint unhealthy (cannot exercise an actual standby locally).

## Scope

- `backend/windmill-api/src/health.rs`
- `backend/.sqlx/query-282b56cfb8504312ac586cd4c1f3f914cf1651c08b8edd1b06d9a6454ed779bf.json` (replaces the old `SELECT 1` cache entry)

Fixes WIN-2085

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect read-only PostgreSQL replicas in `/api/health/status` by using `SELECT NOT pg_is_in_recovery()`, so the endpoint turns unhealthy after failover and pods restart. Addresses WIN-2085.

- **Bug Fixes**
  - Replace `SELECT 1` with `SELECT NOT pg_is_in_recovery()` in `check_database_with_latency` and validate `Ok(Some(true))`.
  - Report unhealthy when the query fails, times out, or the DB is in recovery; update `sqlx` offline cache for the new query.

<sup>Written for commit 064eedf3cbffc41ec0ad520a4f0e2c9681d8a729. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

