### PR TITLE
fix: prevent silent audit-partition outage via monitor watchdog + alert

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1446,19 +1446,45 @@ Windmill Community Edition {GIT_VERSION}
                                     } else {
                                         None
                                     };
-                                    monitor_db(
-                                        &conn,
-                                        &base_internal_url,
-                                        server_mode,
-                                        worker_mode,
-                                        false,
-                                        tx.clone(),
-                                        Some(MonitorIteration {
-                                            rd_shift,
-                                            iter: monitor_iteration,
-                                        }),
+                                    // Hard cap on a single monitor pass. monitor_db runs all its
+                                    // periodic tasks under one join!, so a single task stuck on a
+                                    // non-DB await (statement_timeout only bounds DB statements)
+                                    // would otherwise freeze the whole loop indefinitely — silently
+                                    // stopping critical maintenance like audit-partition creation.
+                                    // Larger than statement_timeout (5min) so a slow-but-progressing
+                                    // statement is never killed prematurely.
+                                    const MONITOR_DB_TIMEOUT: Duration = Duration::from_secs(600);
+                                    let monitor_timed_out = tokio::time::timeout(
+                                        MONITOR_DB_TIMEOUT,
+                                        monitor_db(
+                                            &conn,
+                                            &base_internal_url,
+                                            server_mode,
+                                            worker_mode,
+                                            false,
+                                            tx.clone(),
+                                            Some(MonitorIteration {
+                                                rd_shift,
+                                                iter: monitor_iteration,
+                                            }),
+                                        ),
                                     )
-                                    .await;
+                                    .await
+                                    .is_err();
+                                    if monitor_timed_out {
+                                        windmill_common::utils::report_critical_error(
+                                            format!(
+                                                "monitor task did not finish within {}s and was aborted; \
+                                                 a background maintenance task is likely stuck. \
+                                                 Continuing to the next iteration.",
+                                                MONITOR_DB_TIMEOUT.as_secs()
+                                            ),
+                                            db.clone(),
+                                            None,
+                                            None,
+                                        )
+                                        .await;
+                                    }
                                     monitor_iteration += 1;
                                     if let Some(handle) = warn_handle {
                                         handle.abort();

--- a/backend/src/monitor.rs
+++ b/backend/src/monitor.rs
@@ -4417,11 +4417,19 @@ async fn audit_log_retention_days() -> i64 {
     }
 }
 
+/// Number of days ahead (including today) for which an audit partition must
+/// always exist. A missing partition in this window means audit inserts fail
+/// once that date is reached — and because some callers (notably login) write
+/// the audit row in the same transaction as their own work, that failure
+/// poisons the whole transaction, so a missing partition is a hard outage, not
+/// just a dropped audit row.
+const AUDIT_PARTITION_LOOKAHEAD_DAYS: i64 = 3;
+
 async fn manage_audit_partitions(db: &DB, retention_days: i64) {
     let today = chrono::Utc::now().date_naive();
 
-    // Create partitions for today and the next 3 days
-    for days_ahead in 0..=3i64 {
+    // Create partitions for today and the next few days
+    for days_ahead in 0..=AUDIT_PARTITION_LOOKAHEAD_DAYS {
         let date = today + chrono::Duration::days(days_ahead);
         let next_date = date + chrono::Duration::days(1);
         let partition_name = format!("audit_{}", date.format("%Y%m%d"));
@@ -4437,9 +4445,6 @@ async fn manage_audit_partitions(db: &DB, retention_days: i64) {
         }
     }
 
-    // Drop expired partitions
-    let cutoff_date = today - chrono::Duration::days(retention_days);
-
     let partitions = sqlx::query_scalar::<_, String>(
         "SELECT c.relname::text \
          FROM pg_inherits i \
@@ -4449,28 +4454,62 @@ async fn manage_audit_partitions(db: &DB, retention_days: i64) {
     .fetch_all(db)
     .await;
 
-    match partitions {
-        Ok(partitions) => {
-            for partition_name in partitions {
-                if let Some(date_str) = partition_name.strip_prefix("audit_") {
-                    if let Ok(date) = chrono::NaiveDate::parse_from_str(date_str, "%Y%m%d") {
-                        if date < cutoff_date {
-                            let quoted_name =
-                                format!("\"{}\"", partition_name.replace('"', "\"\""));
-                            let sql = format!("DROP TABLE IF EXISTS {quoted_name}");
-                            match sqlx::query(&sql).execute(db).await {
-                                Ok(_) => tracing::info!(
-                                    "Dropped expired audit partition {partition_name}"
-                                ),
-                                Err(e) => tracing::error!(
-                                    "Error dropping audit partition {partition_name}: {e:?}"
-                                ),
-                            }
+    let partitions = match partitions {
+        Ok(partitions) => partitions,
+        Err(e) => {
+            tracing::error!("Error listing audit partitions: {e:?}");
+            return;
+        }
+    };
+
+    // Verify the lookahead window is actually covered. If a create above failed
+    // (or this loop has not run for several days), alert loudly instead of
+    // letting it surface days later as failed audit inserts and broken logins.
+    let existing: std::collections::HashSet<&str> = partitions.iter().map(|s| s.as_str()).collect();
+    let missing: Vec<String> = (0..=AUDIT_PARTITION_LOOKAHEAD_DAYS)
+        .map(|days_ahead| {
+            format!(
+                "audit_{}",
+                (today + chrono::Duration::days(days_ahead)).format("%Y%m%d")
+            )
+        })
+        .filter(|name| !existing.contains(name.as_str()))
+        .collect();
+    if !missing.is_empty() {
+        report_critical_error(
+            format!(
+                "Audit log partitions missing after maintenance run: {}. \
+                 Audit inserts will fail once these dates are reached, which also \
+                 breaks logins (the login audit row shares the login transaction). \
+                 Check for earlier 'Error creating audit partition' logs and verify \
+                 the audit-partition maintenance loop is still running.",
+                missing.join(", ")
+            ),
+            db.clone(),
+            None,
+            None,
+        )
+        .await;
+    }
+
+    // Drop expired partitions
+    let cutoff_date = today - chrono::Duration::days(retention_days);
+    for partition_name in &partitions {
+        if let Some(date_str) = partition_name.strip_prefix("audit_") {
+            if let Ok(date) = chrono::NaiveDate::parse_from_str(date_str, "%Y%m%d") {
+                if date < cutoff_date {
+                    let quoted_name = format!("\"{}\"", partition_name.replace('"', "\"\""));
+                    let sql = format!("DROP TABLE IF EXISTS {quoted_name}");
+                    match sqlx::query(&sql).execute(db).await {
+                        Ok(_) => {
+                            tracing::info!("Dropped expired audit partition {partition_name}")
                         }
+                        Err(e) => tracing::error!(
+                            "Error dropping audit partition {partition_name}: {e:?}"
+                        ),
                     }
                 }
             }
         }
-        Err(e) => tracing::error!("Error listing audit partitions: {e:?}"),
     }
 }


### PR DESCRIPTION
## Summary

Fixes a production incident where every user was locked out (`Not authorized: Unauthorized`) because the daily `audit_<YYYYMMDD>` partition was never created.

Root cause chain:
- The background monitor loop runs ~25 periodic tasks under a single `join!`. `statement_timeout` (5min) only bounds DB statements, so any task stuck on a non-DB await freezes the whole pass **indefinitely** — silently halting audit-partition creation, with no error logged.
- Once the missing partition's date is reached, `INSERT INTO audit_partitioned` fails with `no partition of relation "audit_partitioned" found for row`.
- Login writes its `users.login` audit row in the **same transaction** as the session-token insert. The failed insert poisons that transaction, so the session is never persisted → every login returns `Unauthorized`. (The audit helper swallows the error and returns `Ok`, which is correct intent, but can't un-poison the caller's tx.)
- Restarting the pods ran the startup partition-create path, which fixed login but caused a DB load spike as the backlog flushed.

This PR addresses the two structural gaps that turned a stuck background task into a customer-visible outage three days later.

## Changes

- **Watchdog** (`backend/src/main.rs`): wrap `monitor_db()` in a 600s `tokio::time::timeout` (> the 5min `statement_timeout`, so slow-but-progressing statements aren't killed early). On timeout it reports a critical error and continues to the next iteration, so a single stuck task can no longer freeze the whole monitor loop. Because the `join!` polls concurrently, the partition `CREATE` still completes and commits before the cap even if a sibling task is wedged.
- **Missing-partition alert** (`backend/src/monitor.rs`): after creating partitions, `manage_audit_partitions` verifies the full lookahead window (`today … today+3`) actually exists and raises a critical alert naming any missing partitions — turning a silent latent outage into an early page. Reuses the existing partition listing (single fetch) and a named `AUDIT_PARTITION_LOOKAHEAD_DAYS` const so the create loop and the check can't drift.

Lookahead stays at 3 days (buffer widening was considered and rejected — with the watchdog + alert in place, 3 days is sufficient lead time; the buffer only delays an outage, it doesn't prevent one).

No public API / OpenAPI / EE surface touched.

## Test plan

- [ ] `cargo check` and `cargo check --features enterprise,private` pass (verified locally)
- [ ] On a server-mode instance, confirm the hourly pass still creates today + 3 days of partitions (`\dt audit_*` in psql) and no spurious `critical_error` row appears in `alerts` under normal operation
- [ ] Drop one lookahead partition out-of-band; confirm the next hourly `manage_audit_partitions` run inserts a `critical_error` alert naming the missing partition
- [ ] (Reasoned, not manually triggered) watchdog timeout path: cancellation drops all `join!` tasks at an await point; maintenance tasks are idempotent and re-run next iteration, so no partial state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a silent halt of audit-partition creation that could lock out all users by adding a monitor watchdog and an alert for missing partitions.

- **Bug Fixes**
  - Wrapped `monitor_db` in a 600s timeout (longer than the 5m DB `statement_timeout`). On timeout, logs a critical error and moves to the next iteration to avoid freezing the monitor loop.
  - After creating partitions, verifies the lookahead window (`today..today+3`, via `AUDIT_PARTITION_LOOKAHEAD_DAYS`). Raises a `critical_error` alert listing any missing partitions.

<sup>Written for commit 6364f6157c595024d9ede4fd81ecdf104ce5f75f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

