### PR TITLE
fix: allow SQL args in managed // materialize scripts

### DIFF
--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -1284,28 +1284,10 @@ async fn create_script_internal<'c>(
             if let Err(e) = windmill_parser::sql_materialize::classify_wrap(&ns.content) {
                 return Err(Error::BadRequest(e.message()));
             }
-            // Managed materialize strips line comments when it wraps the SELECT,
-            // so a `-- $name (TYPE)` declaration is lost while its `$name`
-            // reference survives in the embedded SELECT — it would run unbound.
-            // Managed materialize takes no SQL args (the partition is supplied by
-            // the engine, not bound). Reject declared args with a clear error.
-            if let Ok(sig) = windmill_parser_sql::parse_duckdb_sig(&ns.content) {
-                if !sig.args.is_empty() {
-                    let names = sig
-                        .args
-                        .iter()
-                        .map(|a| format!("${}", a.name))
-                        .collect::<Vec<_>>()
-                        .join(", ");
-                    return Err(Error::BadRequest(format!(
-                        "managed `// materialize` cannot take SQL arguments ({names}): wrapping your \
-                         SELECT drops the `-- $arg` declarations, so they would run unbound. The \
-                         partition is supplied by the engine — reference its value with the \
-                         `{{partition}}` token, or use `// materialize manual` to write the DDL (and \
-                         bind args) yourself."
-                    )));
-                }
-            }
+            // SQL args are supported: managed materialize strips line comments
+            // (including `-- $name (type)` declarations) when it wraps the SELECT,
+            // but the executor parses the signature from the un-wrapped script, so
+            // `$name` references in the SELECT stay bound at run time.
         }
         // `key=` (merge) and `append` are mutually exclusive reconciliation
         // strategies; append (INSERT-only) wins. Surface the conflict rather

--- a/backend/windmill-worker/src/duckdb_executor.rs
+++ b/backend/windmill-worker/src/duckdb_executor.rs
@@ -255,6 +255,14 @@ pub async fn do_duckdb(
         } else {
             None
         };
+        // Parse the signature from the ORIGINAL script: managed materialize wraps
+        // the trailing SELECT and strips line comments, which drops the
+        // `-- $name (type)` arg declarations while their `$name` references
+        // survive in the embedded SELECT. Parsing args here (pre-wrap) keeps them
+        // declared so they are still bound — and s3object args translated to
+        // `s3://` URIs — at run time.
+        let sig = parse_duckdb_sig(query)?.args;
+
         let materialized_query;
         let query: &str = match &materialize {
             Some((Some(rewritten), _)) => {
@@ -263,8 +271,6 @@ pub async fn do_duckdb(
             }
             _ => query,
         };
-
-        let sig = parse_duckdb_sig(query)?.args;
         let mut job_args = build_args_values(job, client, conn).await?;
 
         let reserved_variables =
@@ -1104,6 +1110,40 @@ mod tests {
             cgroup_bytes_to_duckdb_memory_limit(1),
             Some("64MiB".to_string())
         );
+    }
+
+    // Managed `// materialize` may take SQL args (e.g. an s3object uploaded on
+    // the run form). The wrap strips line comments — including the
+    // `-- $name (type)` declarations — so the executor parses the signature from
+    // the original script (done above, before the rewrite) while the `$name`
+    // references survive inside the wrapped SELECT. This pins both halves of that
+    // contract so a regression that drops either is caught.
+    #[test]
+    fn materialize_preserves_sql_args() {
+        let script = "-- materialize ducklake://main/rows\n\
+                      -- $file (s3object)\n\
+                      SELECT * FROM read_json_auto($file)";
+
+        // The signature is recoverable from the original (un-wrapped) script.
+        let sig = parse_duckdb_sig(script).expect("sig parses").args;
+        let file_arg = sig
+            .iter()
+            .find(|a| a.name == "file")
+            .expect("`$file` declared");
+        assert_eq!(file_arg.otyp.as_deref(), Some("s3object"));
+
+        // The wrapped query still references `$file`, so the parsed sig binds it.
+        let (rewritten, _) = build_materialized_query(script, None)
+            .expect("materialize builds")
+            .expect("materialize present");
+        let rewritten = rewritten.expect("managed mode rewrites the query");
+        assert!(
+            rewritten.contains("$file"),
+            "wrapped query must keep the `$file` reference, got:\n{rewritten}"
+        );
+        // The declaration comment is gone (wrap strips line comments) — which is
+        // exactly why the sig must come from the original, not the rewrite.
+        assert!(!rewritten.contains("-- $file"));
     }
 
     // Tests for parse_attach_db_resource function


### PR DESCRIPTION
## Summary

Managed `// materialize` DuckDB scripts could not take SQL arguments — saving one (e.g. `-- $file (s3object)` with `SELECT … read_json_auto($file)`) failed with `Bad request: managed // materialize cannot take SQL arguments`.

The wrap that generates the materialization DDL (`classify_wrap` → `split_statements`) strips all line comments, which drops the `-- $name (type)` **declarations** while the `$name` **references** survive inside the embedded SELECT. The executor was parsing the arg signature from the **rewritten** (comment-stripped) query, so the signature came back empty and `$name` would run unbound (and `s3object` args would never be translated to `s3://` URIs). Rather than fix that, the save path defensively rejected any SQL args.

This parses the signature from the **original** script instead, so the args stay declared and bound at run time, and removes the now-obsolete save-time rejection.

## Changes

- `backend/windmill-worker/src/duckdb_executor.rs`: compute the DuckDB arg signature from the original `query` (before the materialize rewrite shadows it), so `$name` references in the wrapped SELECT bind correctly and `s3object` args are translated to `s3://` URIs. Non-materialize and `// materialize manual` paths are unchanged (their query is never rewritten).
- `backend/windmill-api-scripts/src/scripts.rs`: remove the save-time rejection of SQL args in managed materialize. The `classify_wrap` shape check (setup statements + single trailing SELECT) is kept.
- Add regression test `materialize_preserves_sql_args` pinning both halves of the contract: the signature is recoverable from the original script, and the wrapped query keeps the `$name` reference while dropping the `-- $name` declaration comment.

## Test plan

- [x] `cargo check` on both crates (incl. `duckdb` feature) — clean
- [x] `cargo test materialize_preserves_sql_args` — passes
- [x] Saving the reported script via API returns 201 (was 400 "cannot take SQL arguments")
- [ ] End-to-end run: create a managed `// materialize ducklake://…` script with `-- $file (s3object)` + `read_json_auto($file)`, upload a file via the run form, confirm the partition materializes with the file's rows (needs a live worker + object store)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Managed `// materialize` DuckDB scripts can now use SQL args. We parse args from the original script so `$name` binds correctly and `s3object` args resolve to `s3://` at run time.

- **Bug Fixes**
  - Parse the DuckDB arg signature before the materialize rewrite, preserving `-- $name (type)` declarations while `$name` references stay in the wrapped SELECT.
  - Remove save-time rejection of SQL args in managed materialize; keep the wrap shape check.
  - Add regression test `materialize_preserves_sql_args` to pin arg parsing and wrapped query behavior.

<sup>Written for commit 25e118f0f98b99e8f0fd040266016fe5eeada3b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

