### PR TITLE
fix: pipeline annotation false-positives from body comments

### DIFF
--- a/backend/parsers/windmill-parser/src/asset_parser.rs
+++ b/backend/parsers/windmill-parser/src/asset_parser.rs
@@ -584,7 +584,14 @@ pub fn parse_pipeline_annotations(code: &str) -> PipelineAnnotations {
 
         if let Some(after_kw) = consume_keyword(rest, "tag") {
             let name = after_kw.trim();
-            if !name.is_empty() && out.tag.is_none() {
+            // Worker tags are single-word identifiers (e.g. `heavy`, `gpu`).
+            // A value with whitespace or beyond the `script.tag` column width
+            // is almost certainly a regular comment starting with "# tag ...".
+            if !name.is_empty()
+                && !name.contains(char::is_whitespace)
+                && name.len() <= 50
+                && out.tag.is_none()
+            {
                 out.tag = Some(name.to_string());
             }
             continue;
@@ -1071,6 +1078,22 @@ mod pipeline_annotation_tests {
     #[test]
     fn tag_empty_is_skipped() {
         let out = parse_pipeline_annotations("// tag   ");
+        assert!(out.tag.is_none());
+    }
+
+    #[test]
+    fn tag_with_whitespace_is_skipped() {
+        // A regular English comment starting with "# tag " must not be
+        // mistaken for a worker-tag annotation (worker tags are single words).
+        let out =
+            parse_pipeline_annotations("# tag this function so we remember to refactor it later");
+        assert!(out.tag.is_none());
+    }
+
+    #[test]
+    fn tag_too_long_is_skipped() {
+        let long = "x".repeat(51);
+        let out = parse_pipeline_annotations(&format!("// tag {long}"));
         assert!(out.tag.is_none());
     }
 

--- a/backend/parsers/windmill-parser/src/asset_parser.rs
+++ b/backend/parsers/windmill-parser/src/asset_parser.rs
@@ -487,9 +487,13 @@ fn parse_kv_opts(s: &str) -> BTreeMap<String, String> {
     out
 }
 
-// Scan raw source for pipeline annotations. Language-agnostic: any line
-// whose first non-whitespace tokens are a comment prefix (`//`, `#`, or
-// `--`) followed by one of the recognized keywords:
+// Scan the leading comment header for pipeline annotations. Only the
+// contiguous block of comment lines at the top of the file is considered
+// (blank lines tolerated, scan stops at the first line of actual code) so
+// that ordinary comments in the body can't false-positive as annotations.
+// Language-agnostic: any header line whose first non-whitespace tokens are
+// a comment prefix (`//`, `#`, or `--`) followed by one of the recognized
+// keywords:
 //   - `pipeline`                 → opt-in marker (must be alone on the line)
 //   - `on <trigger-spec>`        → asset / native trigger edge (including
 //                                  the marker-only `on schedule` form)
@@ -527,6 +531,9 @@ pub fn parse_pipeline_annotations(code: &str) -> PipelineAnnotations {
 
     for raw_line in code.lines() {
         let line = raw_line.trim_start();
+        if line.is_empty() {
+            continue;
+        }
         let rest = if let Some(r) = line.strip_prefix("//") {
             r
         } else if let Some(r) = line.strip_prefix("--") {
@@ -534,7 +541,11 @@ pub fn parse_pipeline_annotations(code: &str) -> PipelineAnnotations {
         } else if let Some(r) = line.strip_prefix('#') {
             r
         } else {
-            continue;
+            // Annotations live in the leading comment header. Stop at the first
+            // line of actual code so comments inside the body (e.g. a regular
+            // `# tag ...` prose comment) can't false-positive as annotations.
+            // Mirrors BashAnnotations::sandbox_image / ssh_target.
+            break;
         };
         let rest = rest.trim_start();
 
@@ -1095,6 +1106,40 @@ mod pipeline_annotation_tests {
         let long = "x".repeat(51);
         let out = parse_pipeline_annotations(&format!("// tag {long}"));
         assert!(out.tag.is_none());
+    }
+
+    #[test]
+    fn annotations_in_body_are_ignored() {
+        // Only the leading comment header is scanned. A regular `# tag ...`
+        // prose comment buried in the body — the WIN-2090 false-positive that
+        // crashed the `script.tag` INSERT — must not be treated as an
+        // annotation once real code has started.
+        let code = concat!(
+            "import pandas as pd\n",
+            "\n",
+            "def main():\n",
+            "    # tag each row with its source so downstream steps can filter\n",
+            "    # on s3://should/not/parse\n",
+            "    return pd.DataFrame()\n",
+        );
+        let out = parse_pipeline_annotations(code);
+        assert!(out.tag.is_none());
+        assert!(out.triggers.is_empty());
+    }
+
+    #[test]
+    fn header_allows_blank_lines_before_code() {
+        // Blank lines (e.g. after a shebang) don't end the header; the first
+        // line of real code does.
+        let code = concat!(
+            "#!/usr/bin/env python\n",
+            "\n",
+            "# tag heavy\n",
+            "import os\n",
+            "# tag light\n",
+        );
+        let out = parse_pipeline_annotations(code);
+        assert_eq!(out.tag.as_deref(), Some("heavy"));
     }
 
     #[test]

--- a/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.test.ts
@@ -37,6 +37,28 @@ describe('parsePipelineAnnotations: tag', () => {
 	})
 })
 
+describe('parsePipelineAnnotations: header scan', () => {
+	it('ignores annotations in the body once code has started', () => {
+		const code = [
+			'import pandas as pd',
+			'',
+			'def main():',
+			'    # tag each row with its source so downstream steps can filter',
+			'    # on s3://should/not/parse',
+			'    return pd.DataFrame()'
+		].join('\n')
+		const out = parsePipelineAnnotations(code)
+		expect(out.tag).toBeUndefined()
+		expect(out.triggerAssets).toHaveLength(0)
+	})
+
+	it('tolerates blank lines before code but stops at the first code line', () => {
+		const code = ['#!/usr/bin/env python', '', '# tag heavy', 'import os', '# tag light'].join('\n')
+		const out = parsePipelineAnnotations(code)
+		expect(out.tag).toBe('heavy')
+	})
+})
+
 describe('parsePipelineAnnotations: retry', () => {
 	it('parses count only', () => {
 		const out = parsePipelineAnnotations('// retry 3')

--- a/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.test.ts
@@ -25,6 +25,16 @@ describe('parsePipelineAnnotations: tag', () => {
 		const out = parsePipelineAnnotations('// tagged heavy')
 		expect(out.tag).toBeUndefined()
 	})
+
+	it('skips a tag value containing whitespace (regular comment false-positive)', () => {
+		const out = parsePipelineAnnotations('# tag this function so we remember to refactor it later')
+		expect(out.tag).toBeUndefined()
+	})
+
+	it('skips a tag value longer than 50 chars', () => {
+		const out = parsePipelineAnnotations('// tag ' + 'x'.repeat(51))
+		expect(out.tag).toBeUndefined()
+	})
 })
 
 describe('parsePipelineAnnotations: retry', () => {

--- a/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.ts
@@ -291,8 +291,13 @@ export function parsePipelineAnnotations(code: string): PipelineAnnotations {
 	}
 
 	for (const rawLine of code.split('\n')) {
+		// Annotations live in the leading comment header: skip blank lines but
+		// stop at the first line of actual code, so comments inside the body
+		// (e.g. a regular `# tag ...` prose comment) can't false-positive.
+		// Mirrors the Rust parse_pipeline_annotations header scan.
+		if (rawLine.trim() === '') continue
 		const rest = stripCommentPrefix(rawLine)
-		if (rest === undefined) continue
+		if (rest === undefined) break
 		const inner = rest.trimStart()
 
 		const afterPipeline = consumeKeyword(inner, 'pipeline')

--- a/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.ts
@@ -323,7 +323,10 @@ export function parsePipelineAnnotations(code: string): PipelineAnnotations {
 		const afterTag = consumeKeyword(inner, 'tag')
 		if (afterTag !== undefined) {
 			const name = afterTag.trim()
-			if (name && !out.tag) {
+			// Worker tags are single-word identifiers; a value with whitespace
+			// or beyond the script.tag column width is almost certainly a
+			// regular comment starting with "# tag ...".
+			if (name && !out.tag && !/\s/.test(name) && name.length <= 50) {
 				out.tag = name
 			}
 			continue


### PR DESCRIPTION
## Problem

`parse_pipeline_annotations` scanned **every** comment line in a script, anywhere in the file. Any body comment whose text happened to match an annotation grammar (`on`, `freshness`, `tag`, `retry`, `partitioned`, …) was misinterpreted as a pipeline annotation.

The most visible symptom was `# tag`: in Python, an ordinary comment starting with `# tag ...` (a common English word) was read as a worker-tag override. If the text exceeded 50 chars the INSERT into `script` failed with `value too long for type character varying(50)`; shorter ones silently overrode the script's worker tag.

## Fix

The real issue is broader than the `tag` keyword, so the fix is at the scan level rather than per-keyword.

Windmill's other comment-directive parsers (`BashAnnotations::sandbox_image`, `ssh_target`) already scan **only the leading comment header** and stop at the first line of real code. `parse_pipeline_annotations` was the outlier scanning the whole file.

This PR aligns it (and its TS mirror) with that convention:
- skip blank lines (e.g. after a shebang),
- **break at the first non-comment line**, so comments inside the body can never false-positive — for *any* annotation, not just `tag`.

As cheap defense for prose that sits in the header itself, the `tag` value is additionally rejected when it contains whitespace or exceeds 50 chars (worker tags are single-word identifiers).

### Files
- `backend/parsers/windmill-parser/src/asset_parser.rs`
- `frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.ts`

## Tests

New regression cases on both sides: body comments after code are ignored, blank lines before code are tolerated, and the `tag` whitespace/over-length guards. Verified no existing fixture/test places an annotation after a code line.

- Backend: `cargo test -p windmill-parser` → 82 passed + parity fixture suite passed.
- Frontend: `vitest run parsePipelineAnnotations*.test.ts` → 41 passed (incl. parity suite).

Fixes WIN-2090

🤖 Generated with [Claude Code](https://claude.com/claude-code)