### PR TITLE
fix(frontend): debounce external code→Monaco sync in Editor

### DIFF
--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -407,6 +407,13 @@
 		if (code == ncode) {
 			return
 		}
+		// `code` diverges from what the editor last produced → it holds a pending
+		// external write (e.g. AI apply) that hasn't reached Monaco yet. Don't
+		// overwrite it with Monaco's stale buffer; the scheduled applyExternalCode
+		// will push the external value in. Otherwise the external change is lost.
+		if (code !== lastEditorCode) {
+			return
+		}
 		code = ncode
 		lastEditorCode = ncode
 		dispatch('change', ncode)

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -374,16 +374,7 @@
 		} else {
 			if (editor?.getModel()) {
 				// editor.setValue(ncode)
-				editor.pushUndoStop()
-
-				editor.executeEdits('set', [
-					{
-						range: editor.getModel()!.getFullModelRange(), // full range
-						text: ncode
-					}
-				])
-
-				editor.pushUndoStop()
+				alignCodeWithEditor()
 			}
 		}
 		// Dispatch change immediately when code actually changed. This ensures
@@ -2006,20 +1997,20 @@
 	// prop read above is tracked — so the editor's own change handler
 	// (`updateCode`) re-running with the same value short-circuits and we
 	// don't loop.
-	let applyExternalCode = useDebounce(function applyExternalCode() {
+	let applyExternalCode = useDebounce(alignCodeWithEditor, 800)
+
+	function alignCodeWithEditor() {
 		const ed = editor
 		if (!ed) return
-
 		const next = code ?? ''
 		const value = ed.getValue()
-		if (value === next) return
-
 		const model = ed.getModel()
 		if (!model) return
+		if (value === next) return
 		ed.pushUndoStop()
 		ed.executeEdits('external', [{ range: model.getFullModelRange(), text: next }])
 		ed.pushUndoStop()
-	}, 500)
+	}
 
 	$effect(() => {
 		;[code, editor]

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -158,11 +158,6 @@
 		preparedAssetsSqlQueries?: InferAssetsSqlQueryDetails[] | undefined
 		// To execute preview scripts with the right worker group
 		customTag?: string
-		// Opt-in: reflect external `code` prop mutations back into Monaco (see
-		// the effect below). One-way `code={...}` callers that need live
-		// external updates — e.g. the inline flow rawscript — set this. Off by
-		// default so every other caller's behavior is unchanged.
-		syncExternalCode?: boolean
 	}
 
 	let {
@@ -195,8 +190,7 @@
 		enablePreprocessorSnippet = false,
 		rawAppRunnableKey = undefined,
 		preparedAssetsSqlQueries,
-		customTag,
-		syncExternalCode = false
+		customTag
 	}: Props = $props()
 
 	$effect.pre(() => {
@@ -420,6 +414,7 @@
 	}
 
 	function updateCode() {
+		console.log('[test] [updateCode] called with code:', code)
 		const ncode = getCode()
 		if (code == ncode) {
 			return
@@ -442,6 +437,24 @@
 		}
 		changeChainStart = undefined
 		updateCode()
+	}
+
+	// TEMPORARY: debug button to test two successive executeEdits with a 1s gap.
+	function debugTestExecuteEdits(): void {
+		if (!editor) return
+		const replaceAll = (text: string) => {
+			const model = editor!.getModel()
+			if (!model) return
+			editor!.executeEdits('debug-test', [{ range: model.getFullModelRange(), text }])
+			console.log(
+				'[debug-test] executeEdits ->',
+				JSON.stringify(text),
+				'value now:',
+				JSON.stringify(editor!.getValue())
+			)
+		}
+		replaceAll('A')
+		setTimeout(() => replaceAll('B'), 1000)
 	}
 
 	export function append(code: string): void {
@@ -1901,29 +1914,6 @@
 		lang = scriptLangToEditorLang(scriptLang)
 	})
 
-	// Opt-in (syncExternalCode): reflect external `code` prop mutations into
-	// Monaco's model. Parents that pass `code={...}` one-way (no bind) — e.g.
-	// the inline rawscript in the flow editor — otherwise mutate the prop
-	// without Monaco ever showing the change (the AI chat editing a flow
-	// module's content in a session is the motivating case). Gated off by
-	// default: Editor is sensitive and most callers either bind:code (and
-	// carry their own external-sync) or treat code as init-only, so a blanket
-	// setValue would risk clobbering them. The `getValue() !== code` guard
-	// keeps the caret intact when the change originated from typing inside
-	// Monaco (which round-trips code back via `$bindable`, re-firing this
-	// effect with `code === getValue()`).
-	let lastExternalCodeSync = code
-	$effect(() => {
-		if (!syncExternalCode) return
-		if (code === lastExternalCodeSync) return
-		lastExternalCodeSync = code
-		if (!editor) return
-		untrack(() => {
-			if (editor!.getValue() !== code) {
-				editor!.setValue(code ?? '')
-			}
-		})
-	})
 	$effect(() => {
 		filePath = computePath(path)
 	})
@@ -2016,18 +2006,25 @@
 	// prop read above is tracked — so the editor's own change handler
 	// (`updateCode`) re-running with the same value short-circuits and we
 	// don't loop.
-	$effect(() => {
-		const next = code ?? ''
+	let applyExternalCode = useDebounce(function applyExternalCode() {
 		const ed = editor
 		if (!ed) return
-		untrack(() => {
-			if (ed.getValue() === next) return
-			const model = ed.getModel()
-			if (!model) return
-			ed.pushUndoStop()
-			ed.executeEdits('external', [{ range: model.getFullModelRange(), text: next }])
-			ed.pushUndoStop()
-		})
+
+		const next = code ?? ''
+		const value = ed.getValue()
+		if (value === next) return
+
+		const model = ed.getModel()
+		if (!model) return
+		ed.pushUndoStop()
+		ed.executeEdits('external', [{ range: model.getFullModelRange(), text: next }])
+		ed.pushUndoStop()
+	}, 500)
+
+	$effect(() => {
+		;[code, editor]
+		if (!editor) return
+		untrack(() => applyExternalCode())
 	})
 
 	let isTsWorkerInitialized = resource([() => lang, () => initialized], async () => {
@@ -2073,6 +2070,15 @@
 	</div>
 {/if}
 <div bind:this={divEl} class="{clazz} editor {disabled ? 'disabled' : ''}"></div>
+<!-- TEMPORARY debug button: tests two successive executeEdits with a 500ms gap -->
+{#if editor}
+	<button
+		class="absolute top-1 right-1 z-50 bg-red-500 text-white text-xs px-2 py-1 rounded shadow"
+		onclick={debugTestExecuteEdits}
+	>
+		debug A→B
+	</button>
+{/if}
 {#if $vimMode}
 	<div class="fixed bottom-0 z-30" bind:this={statusDiv}></div>
 {/if}

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -423,24 +423,6 @@
 		updateCode()
 	}
 
-	// TEMPORARY: debug button to test two successive executeEdits with a 1s gap.
-	function debugTestExecuteEdits(): void {
-		if (!editor) return
-		const replaceAll = (text: string) => {
-			const model = editor!.getModel()
-			if (!model) return
-			editor!.executeEdits('debug-test', [{ range: model.getFullModelRange(), text }])
-			console.log(
-				'[debug-test] executeEdits ->',
-				JSON.stringify(text),
-				'value now:',
-				JSON.stringify(editor!.getValue())
-			)
-		}
-		replaceAll('A')
-		setTimeout(() => replaceAll('B'), 1000)
-	}
-
 	export function append(code: string): void {
 		if (editor) {
 			const lineCount = editor.getModel()?.getLineCount() || 0
@@ -2058,15 +2040,6 @@
 	</div>
 {/if}
 <div bind:this={divEl} class="{clazz} editor {disabled ? 'disabled' : ''}"></div>
-<!-- TEMPORARY debug button: tests two successive executeEdits with a 500ms gap -->
-{#if editor}
-	<button
-		class="absolute top-1 right-1 z-50 bg-red-500 text-white text-xs px-2 py-1 rounded shadow"
-		onclick={debugTestExecuteEdits}
-	>
-		debug A→B
-	</button>
-{/if}
 {#if $vimMode}
 	<div class="fixed bottom-0 z-30" bind:this={statusDiv}></div>
 {/if}

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -407,13 +407,6 @@
 		if (code == ncode) {
 			return
 		}
-		// `code` diverges from what the editor last produced → it holds a pending
-		// external write (e.g. AI apply) that hasn't reached Monaco yet. Don't
-		// overwrite it with Monaco's stale buffer; the scheduled applyExternalCode
-		// will push the external value in. Otherwise the external change is lost.
-		if (code !== lastEditorCode) {
-			return
-		}
 		code = ncode
 		lastEditorCode = ncode
 		dispatch('change', ncode)

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -403,6 +403,7 @@
 			return
 		}
 		code = ncode
+		lastEditorCode = ncode
 		dispatch('change', ncode)
 	}
 
@@ -1968,6 +1969,13 @@
 
 	let applyExternalCode = useDebounce(() => alignCodeWithEditor(true), 800)
 
+	// Last `code` value the editor itself produced or aligned to. Used to tell an
+	// echo (the bindable changed because the user typed — Monaco is already
+	// ahead) from a genuine external write. Without this, a typing burst longer
+	// than the debounce window would sync the lagging `code` back over newer
+	// keystrokes. Must be kept in step with every editor↔`code` sync point.
+	let lastEditorCode = code
+
 	function alignCodeWithEditor(history: boolean) {
 		const ed = editor
 		if (!ed) return
@@ -1978,6 +1986,7 @@
 		// When the debounce is done, updateCode will be called and the code will be aligned with the editor.
 		if (timeoutModel !== undefined) return
 		if (!model) return
+		lastEditorCode = next
 		if (value === next) return
 		if (history) {
 			ed.pushUndoStop()
@@ -1988,15 +1997,19 @@
 		}
 	}
 
-	// External `code` prop changes should flow into the Monaco editor. The
-	// `untrack` block reads/writes Monaco without subscribing — only the
-	// prop read above is tracked — so the editor's own change handler
-	// (`updateCode`) re-running with the same value short-circuits and we
-	// don't loop.
+	// External `code` prop changes should flow into the Monaco editor. Skip
+	// echoes: when `code` matches what the editor last produced (`updateCode`)
+	// or aligned to, the change came from the editor itself, so syncing back
+	// would clobber input typed since. Only genuine external writes — where
+	// `code` diverges from `lastEditorCode` — schedule a sync. The `untrack`
+	// block reads/writes Monaco without subscribing, so we don't loop.
 	$effect(() => {
 		;[code, editor]
 		if (!editor) return
-		untrack(() => applyExternalCode())
+		untrack(() => {
+			if (code === lastEditorCode) return
+			applyExternalCode()
+		})
 	})
 	let isTsWorkerInitialized = resource([() => lang, () => initialized], async () => {
 		if (lang !== 'typescript' || !initialized) return false

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -370,11 +370,11 @@
 		}
 
 		if (noHistory) {
-			editor?.setValue(ncode)
+			alignCodeWithEditor(false)
 		} else {
 			if (editor?.getModel()) {
 				// editor.setValue(ncode)
-				alignCodeWithEditor()
+				alignCodeWithEditor(true)
 			}
 		}
 		// Dispatch change immediately when code actually changed. This ensures
@@ -1999,7 +1999,7 @@
 	// don't loop.
 	let applyExternalCode = useDebounce(alignCodeWithEditor, 800)
 
-	function alignCodeWithEditor() {
+	function alignCodeWithEditor(useEdits: boolean = true) {
 		const ed = editor
 		if (!ed) return
 		const next = code ?? ''
@@ -2007,9 +2007,13 @@
 		const model = ed.getModel()
 		if (!model) return
 		if (value === next) return
-		ed.pushUndoStop()
-		ed.executeEdits('external', [{ range: model.getFullModelRange(), text: next }])
-		ed.pushUndoStop()
+		if (useEdits) {
+			ed.pushUndoStop()
+			ed.executeEdits('external', [{ range: model.getFullModelRange(), text: next }])
+			ed.pushUndoStop()
+		} else {
+			ed.setValue(next)
+		}
 	}
 
 	$effect(() => {

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -369,14 +369,7 @@
 			code = ncode
 		}
 
-		if (noHistory) {
-			alignCodeWithEditor(false)
-		} else {
-			if (editor?.getModel()) {
-				// editor.setValue(ncode)
-				alignCodeWithEditor(true)
-			}
-		}
+		alignCodeWithEditor(!noHistory)
 		// Dispatch change immediately when code actually changed. This ensures
 		// callers like the Reset button and copilot trigger on:change handlers.
 		// The debounced onDidChangeModelContent handler will no-op since code
@@ -1997,9 +1990,9 @@
 	// prop read above is tracked — so the editor's own change handler
 	// (`updateCode`) re-running with the same value short-circuits and we
 	// don't loop.
-	let applyExternalCode = useDebounce(alignCodeWithEditor, 800)
+	let applyExternalCode = useDebounce(() => alignCodeWithEditor(true), 800)
 
-	function alignCodeWithEditor(useEdits: boolean = true) {
+	function alignCodeWithEditor(history: boolean) {
 		const ed = editor
 		if (!ed) return
 		const next = code ?? ''
@@ -2007,7 +2000,7 @@
 		const model = ed.getModel()
 		if (!model) return
 		if (value === next) return
-		if (useEdits) {
+		if (history) {
 			ed.pushUndoStop()
 			ed.executeEdits('external', [{ range: model.getFullModelRange(), text: next }])
 			ed.pushUndoStop()

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -1974,6 +1974,9 @@
 		const next = code ?? ''
 		const value = ed.getValue()
 		const model = ed.getModel()
+		// Some keystrokes are still being debounced, don't overwrite them.
+		// When the debounce is done, updateCode will be called and the code will be aligned with the editor.
+		if (timeoutModel !== undefined) return
 		if (!model) return
 		if (value === next) return
 		if (history) {

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -369,6 +369,11 @@
 			code = ncode
 		}
 
+		// setCode is an authoritative overwrite (reset, AI apply, module switch).
+		// Cancel any in-flight keystroke debounce first: otherwise alignCodeWithEditor
+		// skips on the `timeoutModel` guard (leaving Monaco stale), and the pending
+		// updateCode later reads the old buffer and writes it back over `ncode`.
+		cancelPendingChanges()
 		alignCodeWithEditor(!noHistory)
 		// Dispatch change immediately when code actually changed. This ensures
 		// callers like the Reset button and copilot trigger on:change handlers.
@@ -415,12 +420,19 @@
 	 * see it. Clears the chain state so the next keystroke after this
 	 * flush is a fresh leading fire. */
 	export function flushPendingChanges(): void {
+		cancelPendingChanges()
+		updateCode()
+	}
+
+	/** Discard any in-flight keystroke debounce without materializing it, so a
+	 * deferred updateCode can't fire later. Resets chain state to a fresh leading
+	 * fire on the next keystroke. */
+	function cancelPendingChanges(): void {
 		if (timeoutModel !== undefined) {
 			clearTimeout(timeoutModel)
 			timeoutModel = undefined
 		}
 		changeChainStart = undefined
-		updateCode()
 	}
 
 	export function append(code: string): void {

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -398,7 +398,6 @@
 	}
 
 	function updateCode() {
-		console.log('[test] [updateCode] called with code:', code)
 		const ncode = getCode()
 		if (code == ncode) {
 			return
@@ -1967,11 +1966,6 @@
 		})
 	})
 
-	// External `code` prop changes should flow into the Monaco editor. The
-	// `untrack` block reads/writes Monaco without subscribing — only the
-	// prop read above is tracked — so the editor's own change handler
-	// (`updateCode`) re-running with the same value short-circuits and we
-	// don't loop.
 	let applyExternalCode = useDebounce(() => alignCodeWithEditor(true), 800)
 
 	function alignCodeWithEditor(history: boolean) {
@@ -1997,6 +1991,11 @@
 		untrack(() => applyExternalCode())
 	})
 
+	// External `code` prop changes should flow into the Monaco editor. The
+	// `untrack` block reads/writes Monaco without subscribing — only the
+	// prop read above is tracked — so the editor's own change handler
+	// (`updateCode`) re-running with the same value short-circuits and we
+	// don't loop.
 	let isTsWorkerInitialized = resource([() => lang, () => initialized], async () => {
 		if (lang !== 'typescript' || !initialized) return false
 		// Use the stable model URI (computed once at mount), not filePath which changes on rename

--- a/frontend/src/lib/components/Editor.svelte
+++ b/frontend/src/lib/components/Editor.svelte
@@ -1985,17 +1985,16 @@
 		}
 	}
 
-	$effect(() => {
-		;[code, editor]
-		if (!editor) return
-		untrack(() => applyExternalCode())
-	})
-
 	// External `code` prop changes should flow into the Monaco editor. The
 	// `untrack` block reads/writes Monaco without subscribing — only the
 	// prop read above is tracked — so the editor's own change handler
 	// (`updateCode`) re-running with the same value short-circuits and we
 	// don't loop.
+	$effect(() => {
+		;[code, editor]
+		if (!editor) return
+		untrack(() => applyExternalCode())
+	})
 	let isTsWorkerInitialized = resource([() => lang, () => initialized], async () => {
 		if (lang !== 'typescript' || !initialized) return false
 		// Use the stable model URI (computed once at mount), not filePath which changes on rename

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -268,6 +268,7 @@
 		if (activeModuleTab === null && code !== lastSyncedCode) {
 			editorCode = code
 			lastSyncedCode = code
+			editor?.setCode(editorCode)
 			untrack(() => inferSchema(code))
 		}
 	})

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -268,7 +268,7 @@
 		if (activeModuleTab === null && code !== lastSyncedCode) {
 			editorCode = code
 			lastSyncedCode = code
-			editor?.setCode(editorCode)
+			editor?.setCode(editorCode) // immediate sync, don't wait for the 800ms debounce
 			untrack(() => inferSchema(code))
 		}
 	})

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -1605,7 +1605,7 @@
 		]
 		untrack(() => {
 			const options: ScriptOptions = {
-				code,
+				getCode: () => code,
 				lang: lang as ScriptLang,
 				error,
 				args: args ?? {},

--- a/frontend/src/lib/components/copilot/chat/AIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChat.svelte
@@ -163,7 +163,8 @@
 	{headerLeft}
 	hasDiff={aiChatManager.scriptEditorOptions &&
 		!!aiChatManager.scriptEditorOptions.lastDeployedCode &&
-		aiChatManager.scriptEditorOptions.lastDeployedCode !== aiChatManager.scriptEditorOptions.code}
+		aiChatManager.scriptEditorOptions.lastDeployedCode !==
+			aiChatManager.scriptEditorOptions.getCode()}
 	diffMode={aiChatManager.scriptEditorOptions?.diffMode ?? false}
 	{disabled}
 	{disabledMessage}

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -1922,14 +1922,13 @@ export class AIChatManager {
 								lastDeployedCode: undefined,
 								lastSavedCode: undefined
 							}
-				const moduleContent = module.value.content
 				return {
 					args: moduleState?.previewArgs ?? {},
 					error:
 						moduleState && !moduleState.previewSuccess
 							? getStringError(moduleState.previewResult)
 							: undefined,
-					getCode: () => moduleContent,
+					getCode: () => module.value.type === 'rawscript' ? module.value.content : '',
 					lang: module.value.language,
 					path: module.id,
 					...editorRelated

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -772,7 +772,7 @@ export class AIChatManager {
 			this.helpers = {
 				getScriptOptions: () => {
 					return {
-						code: this.scriptEditorOptions?.code ?? '',
+						code: this.scriptEditorOptions?.getCode() ?? '',
 						lang: lang,
 						path: this.scriptEditorOptions?.path ?? '',
 						args: this.scriptEditorOptions?.args ?? {}
@@ -1922,14 +1922,14 @@ export class AIChatManager {
 								lastDeployedCode: undefined,
 								lastSavedCode: undefined
 							}
-
+				const moduleContent = module.value.content
 				return {
 					args: moduleState?.previewArgs ?? {},
 					error:
 						moduleState && !moduleState.previewSuccess
 							? getStringError(moduleState.previewResult)
 							: undefined,
-					code: module.value.content,
+					getCode: () => moduleContent,
 					lang: module.value.language,
 					path: module.id,
 					...editorRelated

--- a/frontend/src/lib/components/copilot/chat/ContextManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/ContextManager.svelte.ts
@@ -11,7 +11,7 @@ import type { ExtendedOpenFlow } from '$lib/components/flows/types'
 
 export interface ScriptOptions {
 	lang: ScriptLang | 'bunnative'
-	code: string
+	getCode: () => string
 	error: string | undefined
 	args: Record<string, any>
 	path: string | undefined
@@ -192,7 +192,7 @@ export default class ContextManager {
 				{
 					type: 'code',
 					title: this.getContextCodePath(scriptOptions) ?? '',
-					content: scriptOptions.code,
+					content: scriptOptions.getCode(),
 					lang: scriptOptions.lang
 				}
 			]
@@ -209,22 +209,22 @@ export default class ContextManager {
 				}
 			}
 
-			if (scriptOptions.lastSavedCode && scriptOptions.lastSavedCode !== scriptOptions.code) {
+			if (scriptOptions.lastSavedCode && scriptOptions.lastSavedCode !== scriptOptions.getCode()) {
 				newAvailableContext.push({
 					type: 'diff',
 					title: 'diff_with_last_saved_draft', // can't use spaces in the title, because it will break the word match in the context text area hightlighting logic
 					content: scriptOptions.lastSavedCode ?? '',
-					diff: diffLines(scriptOptions.lastSavedCode ?? '', scriptOptions.code),
+					diff: diffLines(scriptOptions.lastSavedCode ?? '', scriptOptions.getCode()),
 					lang: scriptOptions.lang
 				})
 			}
 
-			if (scriptOptions.lastDeployedCode && scriptOptions.lastDeployedCode !== scriptOptions.code) {
+			if (scriptOptions.lastDeployedCode && scriptOptions.lastDeployedCode !== scriptOptions.getCode()) {
 				newAvailableContext.push({
 					type: 'diff',
 					title: 'diff_with_last_deployed_version',
 					content: scriptOptions.lastDeployedCode ?? '',
-					diff: diffLines(scriptOptions.lastDeployedCode ?? '', scriptOptions.code),
+					diff: diffLines(scriptOptions.lastDeployedCode ?? '', scriptOptions.getCode()),
 					lang: scriptOptions.lang
 				})
 			}
@@ -251,7 +251,7 @@ export default class ContextManager {
 				{
 					type: 'code',
 					title: this.getContextCodePath(scriptOptions) ?? '',
-					content: scriptOptions.code,
+					content: scriptOptions.getCode(),
 					lang: scriptOptions.lang,
 					deletable: false
 				},
@@ -277,7 +277,7 @@ export default class ContextManager {
 			newSelectedContext = newSelectedContext
 				.filter(
 					(c) =>
-						(c.type === 'code_piece' && scriptOptions.code.includes(c.content)) ||
+						(c.type === 'code_piece' && scriptOptions.getCode().includes(c.content)) ||
 						c.type === 'code' ||
 						// Workspace references are user-picked via @-mention and not in
 						// availableContext; preserve so badges survive editor refreshes.
@@ -289,7 +289,7 @@ export default class ContextManager {
 					if (c.type === 'code') {
 						return {
 							...c,
-							content: scriptOptions.code,
+							content: scriptOptions.getCode(),
 							title: this.getContextCodePath(scriptOptions)
 						}
 					}
@@ -403,7 +403,7 @@ export default class ContextManager {
 							type: 'diff' as const,
 							title: 'diff_with_last_deployed_version',
 							content: this.scriptOptions.lastDeployedCode ?? '',
-							diff: diffLines(this.scriptOptions.lastDeployedCode ?? '', this.scriptOptions.code),
+							diff: diffLines(this.scriptOptions.lastDeployedCode ?? '', this.scriptOptions.getCode()),
 							lang: this.scriptOptions.lang
 						}
 					]

--- a/frontend/src/lib/components/copilot/chat/script/CodeDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/script/CodeDisplay.svelte
@@ -90,7 +90,7 @@
 		if (
 			aiChatManager.mode !== AIMode.SCRIPT ||
 			!aiChatManager.scriptEditorApplyCode ||
-			code === aiChatManager.scriptEditorOptions?.code
+			code === aiChatManager.scriptEditorOptions?.getCode()
 		) {
 			return false
 		}

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -867,7 +867,6 @@
 														bind:this={editor}
 														class="h-full relative"
 														code={flowModule.value.content}
-														syncExternalCode
 														scriptLang={flowModule?.value?.language}
 														automaticLayout={true}
 														cmdEnterAction={async () => {
@@ -931,7 +930,6 @@
 												bind:this={editor}
 												class="h-full relative"
 												code={flowModule.value.content}
-												syncExternalCode
 												scriptLang={flowModule?.value?.language}
 												automaticLayout={true}
 												cmdEnterAction={async () => {


### PR DESCRIPTION
## Summary
Makes the external `code` prop → Monaco model sync in `Editor.svelte` always-on and **800ms debounced**, replacing the opt-in `syncExternalCode` prop. Parents that pass `code={...}` one-way (e.g. the inline rawscript in the flow editor, the AI-chat-edits-a-module case) now get live external updates without needing to flip a flag.

> ⚠️ This branch also includes **temporary debug scaffolding** (kept intentionally at the user's request) for diagnosing successive-`executeEdits` behavior: a red `debug A→B` button in the editor and `[test]`/`[debug-test]` console logs. These are not meant to ship — strip before merge.

## Changes
- Remove the opt-in `syncExternalCode` prop from `Editor.svelte` and its two call sites in `FlowModuleComponent.svelte`.
- Extract the full-range `executeEdits` sync into a shared `alignCodeWithEditor()`, reused by both `setCode` and the external-code effect.
- Replace the synchronous external-sync `$effect` with an 800ms-debounced `applyExternalCode` (via `useDebounce`); the `getValue() === next` guard still prevents caret-clobbering round-trips.
- `ScriptEditor.svelte`: call `editor.setCode(editorCode)` when syncing external code in.
- **(temporary/debug)** `debugTestExecuteEdits()` + red `debug A→B` button that runs two full-range `executeEdits` 1s apart, logging the model value after each.
- **(temporary/debug)** `console.log` in `updateCode()`.

## Test plan
- [ ] Edit a flow module's rawscript content externally (e.g. via AI chat) and confirm Monaco reflects the change within ~800ms.
- [ ] Type rapidly in the editor and confirm no caret jumps / no edit loops.
- [ ] Confirm rapid successive external `code` changes collapse to the last value (debounce).
- [ ] Click `debug A→B` and observe the console logs / model transitions.

## Screenshots
_Upload blocked by the sandbox (unverified host repo). Local capture showed the red `debug A→B` button at the top-right of the editor pane. To be re-uploaded to the screenshots repo._