### PR TITLE
fix: stabilize global ai eval smoke path

### DIFF
--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -3,6 +3,7 @@
     Create a draft Bun script at `f/evals/global/greet_user`.
     It should take a string `name` input and return `Hello, ${name}!`.
     Leave it as an AI draft only; do not deploy or save it.
+  initial: ai_evals/fixtures/frontend/global/initial/user_admin_evals_folder.json
   runtime:
     maxTurns: 10
   validate:

--- a/ai_evals/core/cases.test.ts
+++ b/ai_evals/core/cases.test.ts
@@ -212,6 +212,9 @@ describe("loadCases", () => {
         },
       ],
     });
+    expect(caseEntry?.initialPath).toContain(
+      "ai_evals/fixtures/frontend/global/initial/user_admin_evals_folder.json"
+    );
     expect(caseEntry?.toolExpect).toMatchObject({
       requiredToolsUsed: ["write_script"],
       forbiddenToolsUsed: ["deploy_workspace_item", "delete_workspace_item"],

--- a/ai_evals/fixtures/frontend/global/initial/user_admin_evals_folder.json
+++ b/ai_evals/fixtures/frontend/global/initial/user_admin_evals_folder.json
@@ -1,0 +1,8 @@
+{
+  "user": {
+    "username": "admin",
+    "is_admin": true,
+    "folders": ["evals"],
+    "folders_read": ["evals"]
+  }
+}

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -2757,6 +2757,18 @@ describe('prepareGlobalSystemMessage', () => {
 		expect(content).not.toContain('frontend AI draft store')
 	})
 
+	it('honors user-supplied shared folder paths without asking first', () => {
+		const content = prepareGlobalSystemMessage(undefined, {
+			user: { username: 'admin', is_admin: true, folders: ['evals'] }
+		}).content as string
+
+		expect(content).toContain(
+			'If the user supplies a fully qualified `f/<folder>/...` path, use that exact path'
+		)
+		expect(content).toContain('Do not ask for folder confirmation')
+		expect(content).toContain('substitute a `u/admin/...` path unless a tool rejects it')
+	})
+
 	describe('folder guidance', () => {
 		const guidanceOf = (user: {
 			username: string

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -748,6 +748,7 @@ Path conventions:
 - A workspace path starts with one of two namespaces; its trailing <name> may itself contain "/", so a path has three or more segments:
   - \`u/${username}/<name>\` — your personal scope. Default for ad-hoc, exploratory, or scratch work.
   - \`f/<folder>/<name>\` — a shared folder scope; the <folder> must already exist (a bare \`f/<name>\` with no folder segment is INVALID and will fail).
+- If the user supplies a fully qualified \`f/<folder>/...\` path, use that exact path; they have already chosen the folder. Do not ask for folder confirmation or substitute a \`u/${username}/...\` path unless a tool rejects it.
 - Default a bare name with no namespace prefix (e.g. "create a flow called myflow") to \`u/${username}/<name>\`. Never invent an \`f/<folder>/...\` path for a folder that does not exist.${folderGuidanceBlock}
 
 Rules:


### PR DESCRIPTION
## Summary
Stabilizes the global AI eval smoke test by making the requested shared path unambiguous for provider models. The failing run showed Gemini treating `f/evals/...` as blocked by unknown folder context and falling back to `u//...`; this seeds the smoke case with an `admin` user and writable `evals` folder, and clarifies the global assistant prompt to honor fully qualified `f/<folder>/...` paths supplied by the user.

## Changes
- Add a `user_admin_evals_folder` fixture and use it for `global-test1-script-create`.
- Update global chat path guidance to use user-supplied fully qualified shared paths without asking first or substituting a personal path unless a tool rejects it.
- Add regression coverage for the eval fixture wiring and prompt guidance.

## Test plan
- [x] `bun test core/cases.test.ts`
- [x] `vitest run src/lib/components/copilot/chat/global/core.test.ts -t "prepareGlobalSystemMessage" --project server --config vite.config.js`
- [x] `npm run check:fast`
- [x] Local review completed with no issues

## Screenshots
Not applicable: this changes AI prompt/eval fixture behavior only and has no visible UI surface.