### PR TITLE
fix(frontend): show AI skills settings only when global mode enabled

### DIFF
--- a/frontend/src/lib/components/copilot/chat/global/gate.ts
+++ b/frontend/src/lib/components/copilot/chat/global/gate.ts
@@ -11,8 +11,8 @@
  * When the mode is ready to ship to everyone, replace every call to
  * `isGlobalAiEnabled()` with `true` and delete this file. The references are
  * intentionally narrow (chat mode visibility, custom prompt settings, the
- * `change_mode` tool enum, and the `/global_drafts` dev route) so the rip-out
- * is a small grep.
+ * `change_mode` tool enum, the AI skills workspace settings tab, and the
+ * `/global_drafts` dev route) so the rip-out is a small grep.
  */
 const STORAGE_KEY = 'wm_dev_global_ai'
 

--- a/frontend/src/lib/components/workspaceSettings/AISettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/AISettings.svelte
@@ -14,6 +14,7 @@
 	import TestAiKey from '../copilot/TestAIKey.svelte'
 	import Label from '../Label.svelte'
 	import AiSkillsSettings from './AiSkillsSettings.svelte'
+	import { isGlobalAiEnabled } from '../copilot/chat/global/gate'
 	import SettingsPageHeader from '../settings/SettingsPageHeader.svelte'
 	import ResourcePicker from '../ResourcePicker.svelte'
 	import Toggle from '../Toggle.svelte'
@@ -589,7 +590,7 @@
 		</SettingCard>
 	{/if}
 
-	{#if promptScope === 'workspace'}
+	{#if promptScope === 'workspace' && isGlobalAiEnabled()}
 		<AiSkillsSettings />
 	{/if}
 </div>


### PR DESCRIPTION
## Summary

The workspace **AI Skills** settings tab was rendered whenever the AI settings page was in `workspace` prompt scope. But AI skills are only ever consumed by the **GLOBAL** chat mode's system prompt (`AIChatManager` injects them into `prepareGlobalSystemMessage`), and global mode itself is dev-gated by `isGlobalAiEnabled()` (localStorage `wm_dev_global_ai`). So the tab was offering management of something the user can't actually use unless global mode is enabled.

This gates the tab on the same flag, keeping the two consistent behind a single source of truth.

## Changes

- `frontend/src/lib/components/workspaceSettings/AISettings.svelte`: render `<AiSkillsSettings />` only when `promptScope === 'workspace' && isGlobalAiEnabled()` (added the `isGlobalAiEnabled` import).
- `frontend/src/lib/components/copilot/chat/global/gate.ts`: add "the AI skills workspace settings tab" to the gate's rip-out inventory comment, so the eventual grep-and-delete when global mode ships stays complete.

## Test plan

- [ ] Workspace Settings → AI tab, no `wm_dev_global_ai` in localStorage: the "AI Skills" section is **absent**.
- [ ] Run `localStorage.setItem('wm_dev_global_ai', '1')`, reload: the "AI Skills" section **renders** under workspace scope.
- [ ] Confirm it stays hidden for instance/global prompt scopes (unchanged — already only rendered under `workspace` scope).

## Screenshots

Not captured: in this dev environment the backend is down (DB host alias `db` unreachable for the sqlx build), so login can't complete and the settings page can't be reached in-browser. The change is a client-side conditional-render gate with no other visible effect; it compiles clean (no vite/svelte errors) and the gate logic is identical to existing call sites (`SessionPicker`, `WorkspaceItemDrillPicker`, `sessions/+page.svelte`). Will attach before/after screenshots once the backend is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)