### PR TITLE
chore: bump nixpkgs for uv 0.9.25

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764517877,
-        "narHash": "sha256-pp3uT4hHijIC8JUK5MEqeAWmParJrgBVzHLNfJDZxg4=",
+        "lastModified": 1768377964,
+        "narHash": "sha256-RU35vQnfg9NwJUviGCfMH9ChgHANoNSiRaAn4/wINT4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2d293cbfa5a793b4c50d17c05ef9e385b90edf6c",
+        "rev": "cadda13afe838615fb74b0a9720905920559c535",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Update the nixpkgs lock to a revision that provides uv 0.9.25, matching the Dockerfile requirement for `uv python install --compile-bytecode`.

This keeps the Python runtime bytecode precompilation path working in nix develop without changing worker code.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `nixpkgs` to a revision that provides `uv` 0.9.25. This matches the Dockerfile and keeps Python bytecode precompilation (`uv python install --compile-bytecode`) working in `nix develop`.

<sup>Written for commit 29777119b9f8c98335536eaf80b56aa8a79acdb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

