### PR TITLE
fix(ai-chat): strip unclosed <summary> tag leaking into compaction summary

### DIFF
--- a/frontend/src/lib/components/copilot/chat/compactionPrompt.test.ts
+++ b/frontend/src/lib/components/copilot/chat/compactionPrompt.test.ts
@@ -56,6 +56,15 @@ chronological thinking the model should not keep
 		expect(formatCompactSummary('plain summary</summary>')).toBe('plain summary')
 	})
 
+	it('does not leak analysis scratchpad that mentions a literal <summary> tag', () => {
+		const raw = `<analysis>scratchpad mentions <summary> before output</analysis>
+<summary>real summary</summary>`
+		const formatted = formatCompactSummary(raw)
+		expect(formatted).toBe('real summary')
+		expect(formatted).not.toContain('scratchpad')
+		expect(formatted).not.toContain('before output')
+	})
+
 	it('strips every analysis block, not just the first, when the summary is untagged', () => {
 		const raw = '<analysis>first</analysis>\nkept one\n<analysis>second</analysis>\nkept two'
 		const formatted = formatCompactSummary(raw)

--- a/frontend/src/lib/components/copilot/chat/compactionPrompt.test.ts
+++ b/frontend/src/lib/components/copilot/chat/compactionPrompt.test.ts
@@ -34,6 +34,28 @@ chronological thinking the model should not keep
 		expect(formatCompactSummary(raw)).toBe('a\n\nb')
 	})
 
+	it('keeps the summary content when <summary> has no closing tag', () => {
+		const raw = '<summary>\n1. Primary Request and Intent: build the thing\n2. Pending Tasks: none'
+		const formatted = formatCompactSummary(raw)
+		expect(formatted).not.toContain('<summary>')
+		expect(formatted).toContain('Primary Request and Intent: build the thing')
+		expect(formatted).toContain('Pending Tasks: none')
+	})
+
+	it('drops the analysis scratchpad even when <summary> is left unclosed', () => {
+		const raw =
+			'<analysis>\nchronological thinking the model should not keep\n</analysis>\n<summary>\nthe real summary'
+		const formatted = formatCompactSummary(raw)
+		expect(formatted).not.toContain('chronological thinking')
+		expect(formatted).not.toContain('<analysis>')
+		expect(formatted).not.toContain('<summary>')
+		expect(formatted).toBe('the real summary')
+	})
+
+	it('strips an orphaned closing summary tag', () => {
+		expect(formatCompactSummary('plain summary</summary>')).toBe('plain summary')
+	})
+
 	it('strips every analysis block, not just the first, when the summary is untagged', () => {
 		const raw = '<analysis>first</analysis>\nkept one\n<analysis>second</analysis>\nkept two'
 		const formatted = formatCompactSummary(raw)

--- a/frontend/src/lib/components/copilot/chat/compactionPrompt.ts
+++ b/frontend/src/lib/components/copilot/chat/compactionPrompt.ts
@@ -100,12 +100,26 @@ export function getCompactionSummaryPrompt(): string {
  * well-formed-but-untagged summary is still usable.
  */
 export function formatCompactSummary(raw: string): string {
-	let formatted = raw.replace(/<analysis>[\s\S]*?<\/analysis>/gi, '')
+	let formatted = raw
 
 	const summaryMatch = formatted.match(/<summary>([\s\S]*?)<\/summary>/i)
 	if (summaryMatch) {
 		formatted = (summaryMatch[1] ?? '').trim()
+	} else {
+		// A truncated response or a weaker model sometimes opens <summary> without
+		// closing it. The text after the opener is still the summary, so keep it
+		// rather than leak the bare tag. With no opener at all, drop paired
+		// <analysis> blocks and treat the remainder as the summary.
+		const openIdx = formatted.search(/<summary>/i)
+		if (openIdx !== -1) {
+			formatted = formatted.slice(openIdx)
+		} else {
+			formatted = formatted.replace(/<analysis>[\s\S]*?<\/analysis>/gi, '')
+		}
 	}
+
+	// An orphaned opener or closer left by either branch must never reach the user.
+	formatted = formatted.replace(/<\/?(?:analysis|summary)>/gi, '')
 
 	// Collapse the blank-line runs left behind by stripping the analysis block.
 	return formatted.replace(/\n{3,}/g, '\n\n').trim()

--- a/frontend/src/lib/components/copilot/chat/compactionPrompt.ts
+++ b/frontend/src/lib/components/copilot/chat/compactionPrompt.ts
@@ -100,7 +100,10 @@ export function getCompactionSummaryPrompt(): string {
  * well-formed-but-untagged summary is still usable.
  */
 export function formatCompactSummary(raw: string): string {
-	let formatted = raw
+	// Strip the analysis scratchpad first: it precedes the summary and may itself
+	// mention <summary>/<analysis> tokens that would otherwise be mistaken for the
+	// real summary boundary.
+	let formatted = raw.replace(/<analysis>[\s\S]*?<\/analysis>/gi, '')
 
 	const summaryMatch = formatted.match(/<summary>([\s\S]*?)<\/summary>/i)
 	if (summaryMatch) {
@@ -108,13 +111,10 @@ export function formatCompactSummary(raw: string): string {
 	} else {
 		// A truncated response or a weaker model sometimes opens <summary> without
 		// closing it. The text after the opener is still the summary, so keep it
-		// rather than leak the bare tag. With no opener at all, drop paired
-		// <analysis> blocks and treat the remainder as the summary.
+		// rather than leak the bare tag.
 		const openIdx = formatted.search(/<summary>/i)
 		if (openIdx !== -1) {
 			formatted = formatted.slice(openIdx)
-		} else {
-			formatted = formatted.replace(/<analysis>[\s\S]*?<\/analysis>/gi, '')
 		}
 	}
 


### PR DESCRIPTION
## Summary

Windmill's AI-chat compaction summarizes the older prefix of a conversation via a tool-less LLM call that is prompted to reply with an `<analysis>` scratchpad followed by a `<summary>…</summary>` block. `formatCompactSummary` then strips the analysis and unwraps the summary before it is stored and rendered.

The unwrap only handled a **paired** `<summary>…</summary>`. When the model emitted `<summary>` with no closing tag — typically a truncated response or a weaker model — the regex failed to match, the function fell through to returning the raw text untouched, and the bare `<summary>` opener leaked into the summary shown to the user.

## Changes

- `formatCompactSummary` (`compactionPrompt.ts`):
  - Strip paired `<analysis>` blocks **first**, before matching `<summary>`. The analysis scratchpad precedes the summary and may itself mention `<summary>`/`<analysis>` tokens; matching the summary first would start inside the scratchpad and capture it.
  - When no paired `<summary>…</summary>` is present but a `<summary>` opener exists, keep everything after the opener as the summary (rather than discarding a good summary over a missing close tag).
  - Added a final safety net that strips any orphaned `<analysis>`/`<summary>` opener-or-closer, so a stray control tag (e.g. a lone `</summary>`) can never reach the user.
- Tests added for: unclosed `<summary>` keeps content + drops the tag; unclosed `<summary>` still discards the `<analysis>` scratchpad; orphaned `</summary>` is stripped; a paired `<analysis>` block that mentions a literal `<summary>` does not leak scratchpad text.

## Test plan

- [ ] `npm run test:unit -- compactionPrompt` passes (4 new cases + 5 existing)
- [ ] In-app: drive a global-assistant conversation past the context window to trigger compaction; confirm the resulting summary display message contains no literal `<summary>`/`<analysis>` tags even when the model truncates mid-block

## Screenshots

No screenshot-able UI surface: this is a pure string-sanitizer fix plus its unit tests. The only visible effect is the *absence* of a leaked `<summary>` tag in the rendered compaction summary, which requires the model to emit malformed (unclosed) output during a real compaction and cannot be triggered deterministically in the browser. Validated by unit tests instead.