### PR TITLE
fix(frontend): highlight the runtime-chosen branch in flow graph viewer

### DIFF
--- a/frontend/src/lib/components/flows/map/VirtualItem.svelte
+++ b/frontend/src/lib/components/flows/map/VirtualItem.svelte
@@ -9,7 +9,11 @@
 	import { Database, Square } from 'lucide-svelte'
 	import FlowGraphPreviewButton from './FlowGraphPreviewButton.svelte'
 	import type { Job } from '$lib/gen'
-	import { getNodeColorClasses, aiActionToNodeState } from '$lib/components/graph'
+	import {
+		getNodeColorClasses,
+		aiActionToNodeState,
+		type FlowNodeState
+	} from '$lib/components/graph'
 	import { getGraphContext } from '$lib/components/graph/graphContext'
 
 	interface Props {
@@ -39,6 +43,9 @@
 		job?: Job
 		showJobStatus?: boolean
 		flowHasChanged?: boolean
+		/** When set, overrides the node outline with this run-state's colored outline.
+		 * Used to mark the branch taken at runtime on branchone/branchall nodes. */
+		borderState?: FlowNodeState
 	}
 
 	let {
@@ -67,14 +74,13 @@
 		individualStepTests = false,
 		job,
 		showJobStatus = false,
-		flowHasChanged = false
+		flowHasChanged = false,
+		borderState = undefined
 	}: Props = $props()
 
 	const flowGraphContext = getGraphContext()
 
-	let isMultiSelected = $derived(
-		(flowGraphContext?.selectionManager?.selectedIds?.length ?? 0) > 1
-	)
+	let isMultiSelected = $derived((flowGraphContext?.selectionManager?.selectedIds?.length ?? 0) > 1)
 
 	const outputPickerVisible = $derived(
 		(nodeKind || (inputJson && Object.keys(inputJson).length > 0)) && editMode
@@ -96,6 +102,10 @@
 	// AI action colors take priority over execution state, fallback to _VirtualItem
 	const effectiveState = $derived(aiActionToNodeState(action) ?? outputType ?? '_VirtualItem')
 	let colorClasses = $derived(getNodeColorClasses(effectiveState, selected))
+	// The branch taken at runtime keeps its outline regardless of selection so it stays visible.
+	let outlineClasses = $derived(
+		borderState ? getNodeColorClasses(borderState, true).outline : colorClasses.outline
+	)
 </script>
 
 <VirtualItemWrapper
@@ -109,7 +119,7 @@
 	{#snippet children({ hover })}
 		<div class="flex flex-col w-full">
 			<div
-				class="flex flex-row justify-between {colorClasses.outline} {center
+				class="flex flex-row justify-between {outlineClasses} {center
 					? 'items-center'
 					: 'items-baseline'} w-full overflow-hidden rounded-md p-2 text-2xs module text-primary"
 			>

--- a/frontend/src/lib/components/graph/renderers/nodes/BranchAllStart.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/BranchAllStart.svelte
@@ -6,6 +6,7 @@
 	import { X } from 'lucide-svelte'
 	import type { BranchAllStartN } from '../../graphBuilder.svelte'
 	import { getGraphContext } from '../../graphContext'
+	import { computeBorderStatus } from '../utils'
 	interface Props {
 		data: BranchAllStartN['data']
 		id: string
@@ -14,6 +15,10 @@
 	let { data, id }: Props = $props()
 
 	const { selectionManager } = getGraphContext()
+
+	let borderStatus = $derived(
+		computeBorderStatus(data.branchIndex, 'branchall', data.flowModuleState)
+	)
 </script>
 
 <NodeWrapper nodeId={id}>
@@ -22,6 +27,7 @@
 			label={data.label}
 			selectable
 			selected={selectionManager && selectionManager.isNodeSelected(id)}
+			borderState={borderStatus}
 			on:select={() => {
 				setTimeout(() => data.eventHandlers.select(data.id))
 			}}

--- a/frontend/src/lib/components/graph/renderers/nodes/BranchOneStart.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/BranchOneStart.svelte
@@ -6,6 +6,7 @@
 	import { X } from 'lucide-svelte'
 	import type { BranchOneStartN } from '../../graphBuilder.svelte'
 	import { getGraphContext } from '../../graphContext'
+	import { computeBorderStatus } from '../utils'
 	interface Props {
 		data: BranchOneStartN['data']
 		id: string
@@ -13,6 +14,12 @@
 	const { selectionManager } = getGraphContext()
 
 	let { data, id }: Props = $props()
+
+	// branchIndex is -1 for the default branch and 0-based for explicit branches;
+	// branchChosen is 0 for default and 1-based, hence the +1.
+	let borderStatus = $derived(
+		computeBorderStatus(data.branchIndex + 1, 'branchone', data.flowModuleState)
+	)
 </script>
 
 <NodeWrapper nodeId={id}>
@@ -22,6 +29,7 @@
 			preLabel={data.preLabel}
 			selectable
 			selected={selectionManager && selectionManager.isNodeSelected(id)}
+			borderState={borderStatus}
 			on:select={() => {
 				setTimeout(() => data?.eventHandlers?.select(data.id))
 			}}

--- a/frontend/src/lib/components/graph/renderers/utils.ts
+++ b/frontend/src/lib/components/graph/renderers/utils.ts
@@ -19,7 +19,8 @@ export function computeBorderStatus(
 	} else {
 		let flow_jobs_success = graphModuleState?.flow_jobs_success
 		if (!flow_jobs_success) {
-			return 'WaitingForPriorSteps'
+			// No run yet: leave the branch border neutral instead of forcing a highlight.
+			return undefined
 		} else {
 			let status = flow_jobs_success?.[branchIndex]
 			if (status == undefined) {


### PR DESCRIPTION
## Summary

In the flow graph viewer, the branch a `branchone` actually took at runtime (and each `branchall` branch's status) used to be marked with a colored border on the branch start node. This highlight was lost in the design-system overhaul (#032f0c1f8c), which removed the old `borderColor`/`bgColor` props from `VirtualItem` and left `computeBorderStatus` as dead code. This PR restores the highlight using the new node-color system.

## Changes

- `VirtualItem.svelte`: add an optional `borderState?: FlowNodeState` prop. When set, the node's outline is overridden with that run-state's colored outline (via `getNodeColorClasses`), so it stays visible regardless of editor selection.
- `BranchOneStart.svelte` / `BranchAllStart.svelte`: recompute the per-branch run status with `computeBorderStatus` and pass it as `borderState`.
- `renderers/utils.ts`: for `branchall`, return `undefined` (neutral, no highlight) when there is no run yet instead of `'WaitingForPriorSteps'` — that unmapped state previously fell through to the blue *selected* outline, giving every branchall start node a permanent blue border in the editor.

For `branchone` only the actually-taken branch (including the default branch) is highlighted; the others keep a neutral border. For `branchall` each branch start node reflects its own success/failure/in-progress status.

## Screenshots

**branchone run — only the taken branch (`a equals 2`) is highlighted green:**
![branchone-run-chosen-branch.png](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-branchone-runtime-branch-border/1782291466-branchone-run-chosen-branch.png)

**branchall in the editor (no run) — neutral borders, no spurious blue outline:**
![branchall-editor-no-border.png](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-branchone-runtime-branch-border/1782291466-branchall-editor-no-border.png)

**branchall run — each branch start node shows its status border:**
![branchall-run-status-borders.png](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-branchone-runtime-branch-border/1782291466-branchall-run-status-borders.png)

## Test plan

- [x] Run a `branchone` flow and confirm only the taken branch start node gets a colored border in the run graph
- [x] Open a `branchall` flow in the editor and confirm branch start nodes have a neutral border (no blue selected outline) before any run
- [x] Run a `branchall` flow and confirm each branch start node turns green/red according to its branch status
- [ ] Confirm the default branch of a `branchone` is highlighted when it is the chosen branch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the colored outline that marks the branch taken at runtime in the flow graph viewer for `branchone` and `branchall`. Fixes the spurious blue border in the editor and keeps the runtime highlight visible regardless of selection.

- **Bug Fixes**
  - Added an optional `borderState` prop to `VirtualItem.svelte` to override the node outline using the new node-color system.
  - `BranchOneStart.svelte` and `BranchAllStart.svelte` now compute per-branch run status via `computeBorderStatus` and pass it to `borderState`.
  - Updated `computeBorderStatus` to return `undefined` when there’s no run for `branchall`, removing the unintended blue outline.
  - Behavior: for `branchone`, only the chosen branch (including default) is highlighted; for `branchall`, each branch shows its own success/failure/in-progress status.

<sup>Written for commit 471d0e982740f7d8c07108bf3e13f7fa8c5f23e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

