### PR TITLE
feat(frontend): show approval wait as a distinct segment in flow timeline

### DIFF
--- a/frontend/src/lib/components/FlowStatusViewerInner.svelte
+++ b/frontend/src/lib/components/FlowStatusViewerInner.svelte
@@ -1180,15 +1180,25 @@
 	export type FlowModuleForTimeline = {
 		id: string
 		type: FlowModuleValue['type']
+		suspend?: boolean
 	}
 
 	function allModulesForTimeline(
 		modules: FlowModule[],
 		expandedSubflows: Record<string, { modules: FlowModule[]; groups?: any[] }>
 	): FlowModuleForTimeline[] {
-		const ids = dfs(modules, (x) => ({ id: x.id, type: x.value.type }) as FlowModuleForTimeline, {
-			skipToolNodes: true
-		})
+		const ids = dfs(
+			modules,
+			(x) =>
+				({
+					id: x.id,
+					type: x.value.type,
+					suspend: x.suspend != undefined
+				}) as FlowModuleForTimeline,
+			{
+				skipToolNodes: true
+			}
+		)
 
 		function rec(
 			ids: FlowModuleForTimeline[],
@@ -1208,7 +1218,8 @@
 									fms,
 									(x) => ({
 										id: x.id.startsWith('subflow:') ? x.id : buildSubflowKey(x.id, nprefix),
-										type: x.value.type
+										type: x.value.type,
+										suspend: x.suspend != undefined
 									}),
 									{ skipToolNodes: true }
 								),

--- a/frontend/src/lib/components/FlowTimeline.svelte
+++ b/frontend/src/lib/components/FlowTimeline.svelte
@@ -72,6 +72,66 @@
 	}
 
 	const barHeight = 32
+
+	// Whole approval-wait machinery below is inert unless a step actually has a suspend config,
+	// so large suspend-free flows pay nothing for the flatten/sort and the per-tick recompute.
+	const hasSuspendModule = $derived(flowModules.some((m) => m.suspend))
+
+	// Push times of every job on the timeline, ascending. Used to locate when the step
+	// that follows an approval step started — i.e. the moment the approval was granted.
+	const allCreatedAts = $derived(
+		hasSuspendModule
+			? Object.values(items ?? {})
+					.flat()
+					.map((j) => j.created_at)
+					.filter((t): t is number => t != undefined)
+					.sort((a, b) => a - b)
+			: []
+	)
+
+	// Heuristic: the grant moment is approximated by the next job pushed anywhere on the
+	// timeline. Exact for sequential flows; for an approval step inside one branch of a
+	// parallel branchall a concurrent sibling job can land first and understate the wait.
+	function nextCreatedAtAfter(t: number): number | undefined {
+		return allCreatedAts.find((c) => c > t)
+	}
+
+	// For a completed suspend/approval step, the time spent waiting for the approval is the
+	// gap between the step finishing and the next step being pushed (or now, if still waiting).
+	function approvalWait(b: {
+		started_at?: number
+		duration_ms?: number
+	}): { start: number; len: number; running: boolean } | undefined {
+		if (b.started_at == undefined || b.duration_ms == undefined) {
+			return undefined
+		}
+		const end = b.started_at + b.duration_ms
+		const next = nextCreatedAtAfter(end)
+		const waitEnd = next ?? (flowDone ? undefined : now)
+		if (waitEnd == undefined) {
+			return undefined
+		}
+		const len = waitEnd - end
+		if (len < 100) {
+			return undefined
+		}
+		return { start: end, len, running: next == undefined }
+	}
+
+	// Approval wait per module id, computed once and consumed by both the rows and the legend.
+	const approvalWaitByModule = $derived.by(() => {
+		const result: Record<string, { start: number; len: number; running: boolean }> = {}
+		for (const m of flowModules) {
+			if (!m.suspend) continue
+			const sub = (items?.[m.id] ?? []).filter((x) => x.created_at && x.started_at)
+			if (sub.length !== 1) continue
+			const aw = approvalWait(sub[0])
+			if (aw) result[m.id] = aw
+		}
+		return result
+	})
+
+	const hasApprovalWait = $derived(Object.keys(approvalWaitByModule).length > 0)
 </script>
 
 <OnChange
@@ -95,6 +155,12 @@
 					<div class="h-2.5 w-2.5 rounded-sm bg-blue-500/90"></div>
 					<span>Execution</span>
 				</div>
+				{#if hasApprovalWait}
+					<div class="flex gap-1.5 items-center">
+						<div class="h-2.5 w-2.5 rounded-sm bg-purple-400/80"></div>
+						<span>Approval wait</span>
+					</div>
+				{/if}
 				{#if max && min}
 					<span class="font-mono">{msToSec(max - min, 1)}s</span>
 				{/if}
@@ -113,7 +179,7 @@
 				/>
 			</div>
 		{/if}
-		{#each flowModules as { id: k, type: typ } (k)}
+		{#each flowModules as { id: k, type: typ, suspend: isSuspend } (k)}
 			{@const subItems = items?.[k]?.filter((x) => x.created_at && x.started_at)}
 			<div class="relative px-3 py-1.5">
 				<div class="flex items-center justify-between mb-0.5">
@@ -161,6 +227,7 @@
 												? 0
 												: now - b?.created_at
 										: 0}
+									{@const aw = isSuspend ? approvalWaitByModule[k] : undefined}
 									<div class="flex w-full py-0.5 items-center" {style}>
 										<TimelineBar
 											position="left"
@@ -175,7 +242,7 @@
 										/>
 										{#if b.started_at}
 											<TimelineBar
-												position={waitingLen < 100 ? 'center' : 'right'}
+												position={aw || waitingLen < 100 ? 'center' : 'right'}
 												id={b?.id}
 												{total}
 												{min}
@@ -183,6 +250,20 @@
 												started_at={b.started_at}
 												len={b.started_at ? (b?.duration_ms ?? now - b?.started_at) : 0}
 												running={b?.duration_ms == undefined}
+											/>
+										{/if}
+										{#if aw}
+											<TimelineBar
+												position="right"
+												id={b?.id}
+												{total}
+												{min}
+												concat
+												colorClass="bg-purple-400/80"
+												tooltip={`Waiting for approval — ${msToSec(aw.len, 1)}s`}
+												started_at={aw.start}
+												len={aw.len}
+												running={aw.running}
 											/>
 										{/if}
 									</div>
@@ -196,7 +277,6 @@
 			</div>
 		{/each}
 	</div>
-
 {:else}
 	<Loader2 class="animate-spin" />
 {/if}

--- a/frontend/src/lib/components/TimelineBar.svelte
+++ b/frontend/src/lib/components/TimelineBar.svelte
@@ -15,6 +15,10 @@
 		concat?: boolean
 		gray?: boolean
 		spacerClass?: string
+		/** Overrides the default gray/blue bar color (e.g. to mark an approval wait). */
+		colorClass?: string
+		/** Tooltip label shown on hover instead of the default job link. */
+		tooltip?: string
 	}
 
 	let {
@@ -27,7 +31,9 @@
 		running,
 		concat = false,
 		gray = false,
-		spacerClass = ''
+		spacerClass = '',
+		colorClass = undefined,
+		tooltip = undefined
 	}: Props = $props()
 </script>
 
@@ -37,20 +43,26 @@
 	{/if}
 	<Popover
 		style="width: {(len / total) * 100}%"
-		class="h-5 relative {gray
-			? 'bg-gray-300 dark:bg-gray-600'
-			: running
-				? 'bg-blue-400/90'
-				: 'bg-blue-500/90'} {position == 'left'
+		class="h-5 relative {colorClass
+			? colorClass
+			: gray
+				? 'bg-gray-300 dark:bg-gray-600'
+				: running
+					? 'bg-blue-400/90'
+					: 'bg-blue-500/90'} {position == 'left'
 			? 'rounded-l-md'
 			: position == 'right'
 				? 'rounded-r-md'
 				: 'rounded-md'} center-center text-white text-2xs whitespace-nowrap hover:outline outline-1 outline-black"
 	>
 		{#snippet text()}
-			<a href="{base}/run/{id}" class="inline-flex items-center gap-1" target="_blank"
-				>{id} <ExternalLink size={14} /></a
-			>
+			{#if tooltip}
+				<span>{tooltip}</span>
+			{:else}
+				<a href="{base}/run/{id}" class="inline-flex items-center gap-1" target="_blank"
+					>{id} <ExternalLink size={14} /></a
+				>
+			{/if}
 		{/snippet}
 		{#if len > 0}
 			{@const narrow = len / total < 0.09}


### PR DESCRIPTION
## Summary

In the flow run timeline, each step renders a gray "Wait" (queue) segment and a blue "Execution" segment. For approval/suspend steps, the time the flow spends parked waiting for a human to approve was previously **invisible** — the flow job is suspended in the backend and the next step's job is only created once approval is granted, so that wait fell into an unrendered gap between two rows. On a flow whose total duration is dominated by approval time, the timeline gave no indication of where the time went.

This PR surfaces that gap as a distinct purple **"Approval wait"** segment on the approval step's timeline row, with a tooltip showing the duration and a matching legend entry (shown only when an approval wait exists).

## Changes

- `FlowStatusViewerInner.svelte`: `FlowModuleForTimeline` gains a `suspend` flag, populated from the module's `suspend` config in both the top-level and subflow paths.
- `FlowTimeline.svelte`: for a suspend step with a single completed job, compute the approval wait as the gap between the step finishing and the next job pushed anywhere on the timeline (the grant moment), extending to `now` while still waiting. Rendered as a purple segment after the execution bar, plus a conditional legend entry. The per-module result is memoized in one `$derived` map consumed by both the rows and the legend.
- `TimelineBar.svelte`: add optional `colorClass` (bar color override) and `tooltip` (custom hover text) props.

### Known limitations

- The grant moment is approximated by the next job pushed anywhere on the timeline. Exact for sequential flows; for an approval step inside one branch of a parallel `branchall`, a concurrent sibling job can land first and understate the wait. (Documented in a code comment.)
- The segment is anchored to the next step being pushed. The normal pattern — approval gating a subsequent step — is fully covered, including after completion. The niche case where approval is immediately followed by a skipped step / stop-early (so no job is ever pushed after the grant) shows the bar live while parked but not after the flow completes. A last/terminal suspend step is *not* affected: the backend does not park on it (verified — it completes immediately), so there is correctly no wait to show.

## Screenshots

**Completed run — approval step `a` shows a purple "Approval wait" segment (58.4s) distinct from wait/execution; `b` runs instantly after approval:**
![approval-timeline](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/flow-branch-approval-timeline/1782291840-approval-timeline.png)

**Live while parked — the purple segment renders and grows toward "now" while the flow is suspended (here 42.0s, "Suspended (2 of 2)"):**
![approval-parked-live](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/flow-branch-approval-timeline/1782304367-approval-parked-live.png)

## Test plan

- [x] Run a flow with a top-level approval/suspend step, leave it parked for a noticeable interval, approve, and confirm a purple "Approval wait" segment appears with a "Waiting for approval — Ns" tooltip
- [x] Confirm the purple legend entry only appears when an approval wait exists
- [x] While parked (not yet approved), confirm the purple bar renders and grows live toward "now"
- [x] Confirm a non-suspend step followed by a gap does not get a purple bar