### PR TITLE
fix(backend): resolve folder_labels search_path on non-public (PG_SCHEMA) schemas

### DIFF
--- a/backend/migrations/20260624103600_repair_folder_labels_search_path.down.sql
+++ b/backend/migrations/20260624103600_repair_folder_labels_search_path.down.sql
@@ -1,0 +1,3 @@
+-- No-op: this migration only re-pins the function's search_path. Reverting would
+-- mean restoring the hardcoded `SET search_path = public`, which is the very bug
+-- this repairs, so there is nothing to undo.

--- a/backend/migrations/20260624103600_repair_folder_labels_search_path.up.sql
+++ b/backend/migrations/20260624103600_repair_folder_labels_search_path.up.sql
@@ -1,0 +1,22 @@
+-- Repair instances that already applied the folder-labels migrations while the
+-- function hardcoded `SET search_path = public`. On a non-public schema (PG_SCHEMA)
+-- the function was pinned to `public`, so at runtime it read the wrong `folder`
+-- table (or a stray public.folder) instead of the workspace's real one.
+--
+-- `FROM CURRENT` snapshots the migration connection's search_path (the actual
+-- Windmill schema) into the function, keeping the SECURITY DEFINER injection
+-- hardening. On public-schema installs this re-pins to `public`, i.e. a no-op.
+-- Idempotent: redefining with the same body is harmless on already-correct installs.
+CREATE OR REPLACE FUNCTION folder_labels(w_id text, item_path text) RETURNS text[]
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path FROM CURRENT AS $$
+    SELECT (
+        SELECT array_agg(l ORDER BY first_ord)
+        FROM (
+            SELECT u.l, min(u.ord) AS first_ord
+            FROM unnest(f.labels) WITH ORDINALITY AS u(l, ord)
+            GROUP BY u.l
+        ) deduped
+    )
+    FROM folder f
+    WHERE f.workspace_id = w_id AND item_path LIKE 'f/%' AND f.name = split_part(item_path, '/', 2)
+$$;

--- a/backend/windmill-api/src/db.rs
+++ b/backend/windmill-api/src/db.rs
@@ -86,10 +86,10 @@ lazy_static::lazy_static! {
                     ).replace("CREATE INDEX", "CREATE INDEX CONCURRENTLY")),
                     (20260610151334, include_str!(
                         "../../migrations/20260610151334_folder_labels.up.sql"
-                    ).replace(" SET search_path = public", "").to_string()),
+                    ).replace("SET search_path = public", "SET search_path FROM CURRENT").to_string()),
                     (20260614075900, include_str!(
                         "../../migrations/20260614075900_dedup_folder_labels.up.sql"
-                    ).replace(" SET search_path = public", "").to_string()),
+                    ).replace("SET search_path = public", "SET search_path FROM CURRENT").to_string()),
                     ].into_iter().collect();
 }
 

--- a/backend/windmill-api/src/db.rs
+++ b/backend/windmill-api/src/db.rs
@@ -84,6 +84,12 @@ lazy_static::lazy_static! {
                     (20260228000000, include_str!(
                         "../../migrations/20260228000000_v2_job_completed_failure_index.up.sql"
                     ).replace("CREATE INDEX", "CREATE INDEX CONCURRENTLY")),
+                    (20260610151334, include_str!(
+                        "../../migrations/20260610151334_folder_labels.up.sql"
+                    ).replace(" SET search_path = public", "").to_string()),
+                    (20260614075900, include_str!(
+                        "../../migrations/20260614075900_dedup_folder_labels.up.sql"
+                    ).replace(" SET search_path = public", "").to_string()),
                     ].into_iter().collect();
 }
 


### PR DESCRIPTION
## Problem

Migrations `20260610151334_folder_labels` and `20260614075900_dedup_folder_labels` define the `folder_labels(...)` SQL function with `SET search_path = public` in their `CREATE FUNCTION` bodies. The clause is correct in intent — `folder_labels` is `SECURITY DEFINER`, so pinning `search_path` is required to prevent search-path injection (a caller can't shadow `folder`/`split_part` with objects in an earlier schema and have them run with the owner's privileges). The bug is that it's pinned to the **literal `public`** instead of the schema Windmill actually lives in.

On a non-public schema (`PG_SCHEMA`):
- `ALTER TABLE folder ADD COLUMN labels` resolves through the migration connection's `search_path` and adds the column to the real `<schema>.folder`.
- `CREATE FUNCTION ... SET search_path = public` is body-validated (`check_function_bodies = on`) against `public.folder` — a *different* table. If `public.folder` doesn't exist you get `relation "folder" does not exist`; if a stray `public.folder` exists without the column you get the reported `column "labels" does not exist`.

Even when the migration is coaxed into applying (a stray `public.folder` that happens to carry a `labels` column), the function stays pinned to `public` and reads the **wrong table at runtime** — inherited folder labels resolve against the stray table and come back empty/wrong, silently.

This is the same class of bug previously fixed in #5400, re-introduced by the newer folder-labels migrations. It's invisible on the default `public` schema (where `SET search_path = public` is a no-op), which is why it only surfaces on `PG_SCHEMA` deployments.

## Fix

Two parts:

**1. Override the not-yet-applied migrations.** Add both to `OVERRIDDEN_MIGRATIONS` in `backend/windmill-api/src/db.rs`, rewriting `SET search_path = public` to `SET search_path FROM CURRENT`. `FROM CURRENT` snapshots the migration connection's `search_path` (the real Windmill schema — `public` on normal installs, the custom schema otherwise) into the function definition. This resolves the correct schema **and keeps the SECURITY DEFINER pin**, unlike simply stripping the clause (which would inherit the *caller's* search_path at call time and re-open the injection vector for every fresh install). This follows the existing `.replace(...)` override pattern.

**2. Repair already-applied instances.** New migration `20260624103600_repair_folder_labels_search_path` runs `CREATE OR REPLACE FUNCTION folder_labels(...) ... SET search_path FROM CURRENT`. The override in part 1 only helps installs that haven't run the migrations yet (failed/stuck installs + fresh installs); an install that *successfully applied* the broken `= public` form on a custom schema keeps a function pinned to `public` and the override never re-runs for it. The repair migration re-pins it to the correct schema. It's `CREATE OR REPLACE` (idempotent), a **no-op on public installs** (re-pins to `public`), and its `down` is intentionally a no-op (reverting would reinstate the bug).

Both rely on the migration connection's `search_path` already pointing at the Windmill schema on custom-schema installs — the same assumption every existing `public.`-strip override in that map depends on.

## Validation

Exhaustive Postgres harness that reads the real migration files, applies the **exact** `.replace()` the Rust code performs, and runs them across every schema configuration with hard assertions (15/15 passing):

| Scenario | Pin captured | Reads correct table |
|---|---|---|
| public-schema install (normal instances) | `search_path=public` | ✅ |
| custom schema, no `public.folder` | `search_path=<schema>` | ✅ |
| custom schema **+ stray `public.folder`** | `search_path=<schema>` | ✅ (real table, not stray) |
| `search_path = '<schema>, public'` | multi-entry captured | ✅ |
| injection: caller sets `search_path=evil` | — | ✅ ignored, reads pinned schema |

Baseline (original `= public` form) reproduced the failure: errors with `column "labels" does not exist` on custom+stray-without-labels, and silently reads the wrong table on custom+stray-with-labels.

Repair migration: fixes a broken custom instance (wrong table → correct table) and is a verified no-op on a public install.

Fixes WIN-2093
