### PR TITLE
chore: bump uv to 0.11.24 in images and CI

### DIFF
--- a/.github/DockerfileBackendTests
+++ b/.github/DockerfileBackendTests
@@ -28,7 +28,7 @@ ENV PATH="${PATH}:/usr/local/go/bin"
 ENV GO_PATH=/usr/local/go/bin/go
 
 # UV
-RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.25/uv-installer.sh | sh && mv /usr/local/cargo/bin/uv /usr/local/bin/uv
+RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.11.24/uv-installer.sh | sh && mv /usr/local/cargo/bin/uv /usr/local/bin/uv
 
 ENV TZ=Etc/UTC
 

--- a/.github/workflows/backend-test-windows.yml
+++ b/.github/workflows/backend-test-windows.yml
@@ -74,7 +74,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6.2.1
         with:
-          version: "0.9.25"
+          version: "0.11.24"
 
       - uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -62,7 +62,7 @@ jobs:
           node-version: "20"
       - uses: astral-sh/setup-uv@v6.2.1
         with:
-          version: "0.9.25"
+          version: "0.11.24"
       - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.3"

--- a/Dockerfile
+++ b/Dockerfile
@@ -233,7 +233,7 @@ ENV PATH="${PATH}:/usr/local/go/bin"
 ENV GO_PATH=/usr/local/go/bin/go
 
 # Install UV
-RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.25/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
+RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.11.24/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
 
 # Preinstall python runtimes to temp build location (will copy with world-writable perms later)
 # --compile-bytecode precompiles the stdlib to .pyc so jobs don't recompile it on every run

--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -54,7 +54,7 @@ RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmo
 ENV TZ=Etc/UTC
 
 # Install UV
-RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.25/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
+RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.11.24/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
 
 # Preinstall python runtime to temp location (will copy with world-writable perms later)
 # --compile-bytecode precompiles the stdlib to .pyc so jobs don't recompile it on every run

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -54,7 +54,7 @@ RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmo
 ENV TZ=Etc/UTC
 
 # Install UV
-RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.25/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
+RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.11.24/uv-installer.sh | sh && mv /root/.local/bin/uv /usr/local/bin/uv
 
 # Preinstall python runtime to temp location (will copy with world-writable perms later)
 # --compile-bytecode precompiles the stdlib to .pyc so jobs don't recompile it on every run


### PR DESCRIPTION
## Summary

Fixes WIN-2094.

Investigation + bump of `uv` from `0.9.25` → `0.11.24` (latest) everywhere it is pinned in OSS shipping images and CI. The dev `nix` shell already resolves to uv `0.11.18` via `nixos-unstable`, so prod images were the only laggard. The EE repo has no separate uv pins (it builds on the OSS slim images).

I reviewed the uv `0.10.0` and `0.11.0` breaking-change notes against every flag/env Windmill passes (`backend/windmill-worker/src/python_executor.rs`) and validated each flag against a local uv `0.11.18`.

## Changes

- `Dockerfile`, `docker/DockerfileSlim`, `docker/DockerfileSlimEe`, `.github/DockerfileBackendTests`: bump the `uv-installer.sh` release to `0.11.24`
- `.github/workflows/backend-test.yml`, `.github/workflows/backend-test-windows.yml`: bump `astral-sh/setup-uv` pinned `version` to `0.11.24`

## Breaking-change / behavior review

**No code changes required.** Every flag Windmill passes to `uv pip compile` / `uv pip install` / `uv python install` (`--strip-extras`, `--python-preference only-managed|only-system`, `--exclude-newer`, `--index-strategy`, `--no-config`, `--compile-bytecode`, `--link-mode=copy`, `--system`, `--target`, `--reinstall`, `--cert`, `--trusted-host`, `--extra-index-url`, `--index-url`, `--native-tls`, `-p`) still parses and behaves identically on `0.11.18` (verified: unknown-flag errors are never raised; only "file not found"/"no venv" errors, which prove the args were accepted).

Relevant upstream changes and why they don't break us:

- **`0.11.0` TLS stack (most notable):** uv now uses `rustls-platform-verifier` (delegates cert validation to the OS trust store) instead of eagerly loading roots via `rustls-native-certs` + `webpki`. Windmill's explicit cert plumbing is unaffected — `--cert`/`SSL_CERT_FILE` (`INDEX_CERT`), `--trusted-host` (`TRUSTED_HOST`), and `--extra-index-url`/`--index-url` all still work. For self-hosted users with a custom CA *in the OS trust store*, the new default is generally more permissive (the store is now honored by default). Empty `SSL_CERT_FILE` is now ignored, which we never set empty (only set when `INDEX_CERT` is present).
- **`--native-tls` deprecation:** uv `0.11` emits `warning: The --native-tls flag is deprecated ... Use --system-certs instead`, but `--native-tls` still works identically. Windmill passes it when `PY_NATIVE_CERT`/`UV_NATIVE_TLS=true`. **Kept as-is on purpose** — switching to `--system-certs` would break any older uv supplied via `UV_PATH` (`--system-certs` only exists in ≥ 0.11). Follow-up: migrate to `--system-certs` once the minimum supported uv is firmly ≥ 0.11.
- **`0.10.0` changes** (`uv venv --clear`, `default=true` index conflicts, unnamed `explicit` index errors, alternative-impl Python names, `uv tool` global pins, dropped Docker base images / PPC64 / py3.8 image, exclude-newer lockfile invalidation, `uv format` Ruff bump): none apply — Windmill doesn't use `uv venv`/lockfiles/config-file indexes (`--no-config`), installs CPython, and builds its own images rather than consuming uv's.

## Test plan

- [x] Confirmed `0.11.24` release + installer URL exist (`uv-installer.sh` 302s to the asset)
- [x] Validated every Windmill uv flag parses on uv `0.11.18` (no `unexpected argument` errors)
- [x] Confirmed `--native-tls` still works (deprecation warning only)
- [ ] CI: backend tests (Linux + Windows) pass with uv `0.11.24`
- [ ] Build & smoke-test a slim image: run a Python script (deps resolve + install) and an Ansible job (full image)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped `uv` to 0.11.24 across Docker images and CI to align with dev and remove old pins. Fixes WIN-2094.

- **Dependencies**
  - Updated installer URLs in `Dockerfile`, `docker/DockerfileSlim`, `docker/DockerfileSlimEe`, and `.github/DockerfileBackendTests`.
  - Pinned `astral-sh/setup-uv` to 0.11.24 in Linux and Windows backend test workflows.
  - No code changes; existing flags still work. `--native-tls` is deprecated but still supported; we’ll switch to `--system-certs` once the minimum `uv` is ≥ 0.11.

<sup>Written for commit 6f293d29dc3b2af92822dc18db3adec671478022. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

