### PR TITLE
fix(apps): realign legacy raw-app drafts to raw_app draft kind

### DIFF
--- a/backend/migrations/20260624105229_realign_legacy_raw_app_draft_kind.down.sql
+++ b/backend/migrations/20260624105229_realign_legacy_raw_app_draft_kind.down.sql
@@ -1,0 +1,3 @@
+-- Irreversible data backfill: once a raw app's draft is retyped to 'raw_app' it
+-- is indistinguishable from one saved as 'raw_app' by the per-kind code, so the
+-- original typ='app' state cannot be reconstructed. No-op on revert.

--- a/backend/migrations/20260624105229_realign_legacy_raw_app_draft_kind.up.sql
+++ b/backend/migrations/20260624105229_realign_legacy_raw_app_draft_kind.up.sql
@@ -1,0 +1,35 @@
+-- The pre-per-user `DRAFT_TYPE` enum had only ('script','flow','app'): a raw
+-- app's draft was therefore stored as typ='app'. The new model splits app vs
+-- raw_app into distinct draft kinds chosen from the deployed app's `raw_app`
+-- flag, so a raw app's pre-migration draft is invisible to the per-kind lookups
+-- (editor overlay, migrate-legacy, get-for-user), which all query typ='raw_app'.
+-- Realign every such draft (any owner, including the legacy NULL-email row) to
+-- 'raw_app' when the deployed app at that path is a raw app.
+
+-- Drop, don't retype, a stale 'app' row when a 'raw_app' draft already exists
+-- for the same owner (the newer 'raw_app' row, saved with the per-kind code, is
+-- authoritative) — retyping would collide on the draft_pkey_with_user /
+-- draft_pkey_legacy partial unique indexes over (workspace_id, path, typ, email).
+DELETE FROM draft d
+USING app a
+JOIN app_version av ON av.id = a.versions[array_upper(a.versions, 1)]
+WHERE d.typ = 'app'
+  AND a.workspace_id = d.workspace_id
+  AND a.path = d.path
+  AND av.raw_app IS TRUE
+  AND EXISTS (
+    SELECT 1 FROM draft d2
+    WHERE d2.workspace_id = d.workspace_id
+      AND d2.path = d.path
+      AND d2.typ = 'raw_app'
+      AND d2.email IS NOT DISTINCT FROM d.email
+  );
+
+UPDATE draft d
+SET typ = 'raw_app'
+FROM app a
+JOIN app_version av ON av.id = a.versions[array_upper(a.versions, 1)]
+WHERE d.typ = 'app'
+  AND a.workspace_id = d.workspace_id
+  AND a.path = d.path
+  AND av.raw_app IS TRUE;


### PR DESCRIPTION
## Summary

After the per-user drafts migration, a deployed **React / raw app** with a pre-existing draft could no longer have its legacy draft resolved: the home-row Draft badge actions ("Migrate" → *Assign to self* / *Delete*, plus *View Diff* / *Load*) and the editor draft overlay all failed with `Not found: no legacy draft at <path>`.

**Root cause.** The original `DRAFT_TYPE` enum (migration `20230429082953_add_drafts`) had only `('script','flow','app')` — there was no `raw_app`. So any raw app's draft saved before the per-user drafts migration was stored with `typ='app'`. The newer schema (`20260528143710_draft_user_sync_schema`) split apps into two distinct draft kinds (`app` vs `raw_app`), and the per-kind code now derives the kind from the deployed app's `app_version.raw_app` flag and queries a single `typ`:

- `get_app` overlay (`backend/windmill-api/src/apps.rs`) → `kind = RawApp` for a raw app
- `migrate_legacy_draft` (`backend/windmill-api/src/drafts.rs`)
- `get_draft_for_user` / overlay helpers (`backend/windmill-common/src/user_drafts.rs`)

Because the legacy draft is stored as `typ='app'` but these lookups query `typ='raw_app'`, the draft is invisible to them. (The home **list** endpoint matches `typ IN ('app','raw_app')`, which is why the Draft badge still *appeared* — making the failure look like a broken button.)

This only affects the `app`/`raw_app` split; `script` and `flow` drafts never had a type change and are unaffected.

## Changes

- New one-time data migration `backend/migrations/20260624105229_realign_legacy_raw_app_draft_kind.{up,down}.sql`:
  - Retypes `draft` rows from `typ='app'` → `typ='raw_app'` (any owner, including the legacy `email IS NULL` row) when the deployed app at that path is a raw app (`app_version.raw_app IS TRUE` on the latest version).
  - First DELETEs a stale `typ='app'` row when a `typ='raw_app'` row already exists for the same owner (the newer row, written by the per-kind code, is authoritative), to avoid colliding on the `draft_pkey_with_user` / `draft_pkey_legacy` partial unique indexes.
  - Down migration is a documented no-op (irreversible backfill, matching the sibling `backfill_legacy_draft_emails` migration).

No runtime code change is needed: the new frontend always writes `raw_app` for raw apps, so no new mis-typed rows are created — this is a one-time correction of pre-migration data, delivered to already-migrated instances on their next upgrade.

## Test plan

- [x] Reproduced on a faithful DB state (deployed raw app + legacy draft `typ='app'`, `email NULL`): `POST /drafts/migrate_legacy/raw_app/f/aps/my_app {action: assign_to_self}` returned **HTTP 404** `Not found: no legacy draft at f/aps/my_app`.
- [x] Applied the migration (`sqlx migrate run`) — the draft row was retyped `app` → `raw_app`.
- [x] After migration: the same request returned **HTTP 200** and reassigned the draft to the admin (`email` set).
- [x] Full UI flow on the home apps table: hover Draft badge → **Migrate** → **Assign to self** → toast "Legacy draft assigned to you"; the badge switched from the `?` legacy marker to the owner's initials. (Screenshots below.)
- [x] `cargo check -p windmill-api` passes (the `migrate!` macro embeds the new migration cleanly).
- [x] Migration verified idempotent and index-safe (re-run is a no-op; `EXISTS … email IS NOT DISTINCT FROM …` guard covers both NULL- and non-NULL-email rows).

## Screenshots

_The migrate flow on the home apps table (UI demonstration of the fixed behavior; no frontend files changed in this PR)._

**Migrate legacy draft modal** (opened from the Draft badge → Migrate)

![migrate-modal](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/legacy-draft-app-migration/1782302949-migrate-modal.png)

**After Assign to self** — toast confirms, badge shows owner initials

![after-assign](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/legacy-draft-app-migration/1782302949-after-assign.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken legacy drafts for deployed raw apps by retyping old `draft.typ='app'` rows to `typ='raw_app'`. Restores Draft badge actions and the editor overlay for raw apps created before the per-user drafts migration.

- **Bug Fixes**
  - Retype legacy drafts to `raw_app` when the latest `app_version.raw_app` is true.
  - Delete stale `app` drafts if a matching `raw_app` draft exists to avoid unique index conflicts.
  - Idempotent one-time migration; no runtime code changes.

<sup>Written for commit a8c24865365f2ccdc724122e94127098410a61a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

