### PR TITLE
feat(frontend): restore raw app 'open preview in separate window'

### DIFF
--- a/frontend/scripts/ui_builder_artifact.json
+++ b/frontend/scripts/ui_builder_artifact.json
@@ -1,5 +1,5 @@
 {
 	"baseUrl": "https://pub-06154ed168a24e73a86ab84db6bf15d8.r2.dev",
-	"version": "ad76918",
-	"sha256": "4c940570936a391c217a054b74c691587d7f27d012ccddbf5e3b3d25e7c1fe4a"
+	"version": "062d11c",
+	"sha256": "355bf3acfb935080e4a4fa23d0509e03e4bc01aeed622db110663d7ec6c1c438"
 }

--- a/frontend/src/lib/components/raw_apps/RawAppBackgroundRunner.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppBackgroundRunner.svelte
@@ -25,6 +25,16 @@
 		 * job ids.
 		 */
 		gateJobIds?: boolean
+		/**
+		 * Additional trusted message source beyond the bundle iframe: the
+		 * detached preview window opened from the editor ("open preview in a
+		 * separate window"). Its app bundle posts runnable requests to
+		 * `window.opener` (this window), so the bridge must accept its
+		 * `event.source` and reply to it. A getter so it tracks the live handle
+		 * without a reactive prop. Editor-only — the detached window runs the
+		 * same unsandboxed bundle as the inline preview.
+		 */
+		extraSourceWindow?: () => Window | null | undefined
 	}
 
 	let {
@@ -35,23 +45,30 @@
 		jobsById = $bindable({}),
 		editor,
 		workspace,
-		gateJobIds = true
+		gateJobIds = true,
+		extraSourceWindow
 	}: Props = $props()
 
 	// Job ids launched by this app instance — see `gateJobIds`.
 	const launchedJobs = new Set<string>()
 
 	let listener = async (event) => {
-		// Only accept messages from the bundle iframe (opaque origin) so other
-		// frames/extensions can't drive the runnable bridge (WIN-2006). Reject
-		// unconditionally until the iframe is bound — never process a message from
-		// an unknown source.
-		if (!iframe || event.source !== iframe.contentWindow) return
+		// Only accept messages from the bundle iframe (opaque origin) or the
+		// detached preview window we opened, so other frames/extensions can't
+		// drive the runnable bridge (WIN-2006). Reject unconditionally until the
+		// iframe is bound — never process a message from an unknown source.
+		const detachedWindow = extraSourceWindow?.()
+		const sourceWindow = event.source as Window | null
+		if (!iframe || !sourceWindow) return
+		if (sourceWindow !== iframe.contentWindow && sourceWindow !== detachedWindow) return
 
 		const data = event.data
 
+		// Reply to whichever window sent the request (inline iframe or the
+		// detached preview), not a hardcoded target — otherwise the detached
+		// window's calls would hang waiting for a response routed elsewhere.
 		function respond(o: object) {
-			iframe?.contentWindow?.postMessage({ type: data.type + 'Res', ...o, reqId: data.reqId }, '*')
+			sourceWindow?.postMessage({ type: data.type + 'Res', ...o, reqId: data.reqId }, '*')
 		}
 		async function respondWithResult(uuid: string) {
 			let error = false
@@ -170,7 +187,7 @@
 			const jobId = data.jobId
 			const reqId = data.reqId
 			if (gateJobIds && !launchedJobs.has(jobId)) {
-				iframe?.contentWindow?.postMessage(
+				sourceWindow?.postMessage(
 					{ type: 'streamJobRes', reqId, error: true, result: { message: 'Unknown job' } },
 					'*'
 				)
@@ -197,7 +214,7 @@
 
 					if (type === 'error') {
 						eventSource.close()
-						iframe?.contentWindow?.postMessage(
+						sourceWindow?.postMessage(
 							{
 								type: 'streamJobRes',
 								reqId,
@@ -211,7 +228,7 @@
 
 					if (type === 'not_found') {
 						eventSource.close()
-						iframe?.contentWindow?.postMessage(
+						sourceWindow?.postMessage(
 							{
 								type: 'streamJobRes',
 								reqId,
@@ -225,7 +242,7 @@
 
 					// Send stream update if there's new stream data
 					if (update.new_result_stream !== undefined) {
-						iframe?.contentWindow?.postMessage(
+						sourceWindow?.postMessage(
 							{
 								type: 'streamJobUpdate',
 								reqId,
@@ -239,7 +256,7 @@
 					// Check if job is completed
 					if (update.completed) {
 						eventSource.close()
-						iframe?.contentWindow?.postMessage(
+						sourceWindow?.postMessage(
 							{
 								type: 'streamJobRes',
 								reqId,
@@ -257,7 +274,7 @@
 			eventSource.onerror = (error) => {
 				console.warn('SSE stream error:', error)
 				eventSource.close()
-				iframe?.contentWindow?.postMessage(
+				sourceWindow?.postMessage(
 					{
 						type: 'streamJobRes',
 						reqId,

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -998,8 +998,7 @@
 		// blank and the one-shot `load` feed can't survive the tab reloading
 		// itself. Re-feed it here so it repaints. Gated to our own window handle.
 		if (e.data?.type === 'appPreviewReady' && e.source === externalPreviewWindow) {
-			postToExternalPreview({ type: 'setDarkMode', dark: darkMode })
-			syncExternalPreview()
+			feedExternalPreview()
 			return
 		}
 
@@ -1133,6 +1132,15 @@
 		}
 	}
 
+	// Full (re)feed of the detached window: theme first, then the build. Used
+	// when (re)attaching to a window — open, focus-reuse, load, handshake — so
+	// it always matches the editor's current state. Plain rebuilds use
+	// `syncExternalPreview` alone (the theme hasn't changed).
+	function feedExternalPreview() {
+		postToExternalPreview({ type: 'setDarkMode', dark: darkMode })
+		syncExternalPreview()
+	}
+
 	onDestroy(() => {
 		// Don't leave a detached preview behind when the editor unmounts: it
 		// would stop receiving builds and, once refreshed, has no opener to
@@ -1145,7 +1153,7 @@
 		// Reuse an already-open window instead of spawning duplicates.
 		if (externalPreviewWindow && !externalPreviewWindow.closed) {
 			externalPreviewWindow.focus()
-			syncExternalPreview()
+			feedExternalPreview()
 			return
 		}
 		const win = window.open('/ui_builder/app-preview.html', 'windmillRawAppPreview')
@@ -1160,10 +1168,7 @@
 		// regardless of the pinned UI Builder artifact. A manual refresh is
 		// covered separately by the handshake in `listener` (this listener is
 		// bound to the now-stale document and won't fire again).
-		win.addEventListener('load', () => {
-			postToExternalPreview({ type: 'setDarkMode', dark: darkMode })
-			syncExternalPreview()
-		})
+		win.addEventListener('load', () => feedExternalPreview())
 	}
 
 	let getBundleResolve: (({ css, js }: { css: string; js: string }) => void) | undefined = undefined

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -996,8 +996,15 @@
 		// The detached preview window asks for the build every time it (re)loads,
 		// including a manual browser refresh — its app-preview.html shell starts
 		// blank and the one-shot `load` feed can't survive the tab reloading
-		// itself. Re-feed it here so it repaints. Gated to our own window handle.
-		if (e.data?.type === 'appPreviewReady' && e.source === externalPreviewWindow) {
+		// itself. Re-feed it here so it repaints. Gated to our own window handle
+		// AND a same-origin sender: the preview runs user app code that can
+		// navigate the window away, and a cross-origin doc must not be able to
+		// trigger a bundle replay (the build can carry app source/secrets).
+		if (
+			e.data?.type === 'appPreviewReady' &&
+			e.source === externalPreviewWindow &&
+			e.origin === window.location.origin
+		) {
 			feedExternalPreview()
 			return
 		}
@@ -1123,7 +1130,10 @@
 			externalPreviewWindow = null
 			return
 		}
-		externalPreviewWindow.postMessage(msg, '*')
+		// Restrict to our own origin: the detached window loads same-origin
+		// app-preview.html, but user app code can navigate it elsewhere — don't
+		// post the build (potential app source/secrets) to a cross-origin doc.
+		externalPreviewWindow.postMessage(msg, window.location.origin)
 	}
 
 	function syncExternalPreview() {
@@ -1156,7 +1166,12 @@
 			feedExternalPreview()
 			return
 		}
-		const win = window.open('/ui_builder/app-preview.html', 'windmillRawAppPreview')
+		// Scope the window name per app path so two open editors don't fight over
+		// (or take over / close) one shared OS-level preview window.
+		const win = window.open(
+			'/ui_builder/app-preview.html',
+			`windmillRawAppPreview:${encodeURIComponent(path)}`
+		)
 		if (!win) {
 			sendUserToast('Could not open the preview window (popup blocked?)', true)
 			return

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -1154,9 +1154,16 @@
 			return
 		}
 		externalPreviewWindow = win
-		// No load handler: the window feeds itself by posting `appPreviewReady`
-		// to us on every (re)load (handled in `listener`), which — unlike an
-		// opener-side `load` listener — also survives a manual refresh of the tab.
+		// Initial feed: fires once when the freshly opened tab loads. This is the
+		// only feed path against an app-preview.html that predates the
+		// `appPreviewReady` handshake, so the window isn't blank on first open
+		// regardless of the pinned UI Builder artifact. A manual refresh is
+		// covered separately by the handshake in `listener` (this listener is
+		// bound to the now-stale document and won't fire again).
+		win.addEventListener('load', () => {
+			postToExternalPreview({ type: 'setDarkMode', dark: darkMode })
+			syncExternalPreview()
+		})
 	}
 
 	let getBundleResolve: (({ css, js }: { css: string; js: string }) => void) | undefined = undefined

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -29,7 +29,7 @@
 	import type { Modules } from './RawAppModules.svelte'
 	import { isRunnableByName, isRunnableByPath } from '../apps/inputType'
 	import { aiChatManager, AIMode } from '../copilot/chat/AIChatManager.svelte'
-	import { onMount, untrack } from 'svelte'
+	import { onMount, onDestroy, untrack } from 'svelte'
 	import type {
 		AppDatatableMetadata,
 		LintResult,
@@ -993,6 +993,16 @@
 	}
 
 	function listener(e: MessageEvent) {
+		// The detached preview window asks for the build every time it (re)loads,
+		// including a manual browser refresh — its app-preview.html shell starts
+		// blank and the one-shot `load` feed can't survive the tab reloading
+		// itself. Re-feed it here so it repaints. Gated to our own window handle.
+		if (e.data?.type === 'appPreviewReady' && e.source === externalPreviewWindow) {
+			postToExternalPreview({ type: 'setDarkMode', dark: darkMode })
+			syncExternalPreview()
+			return
+		}
+
 		// Two children speak to us now: the UI Builder iframe (source editor)
 		// and the preview iframe (rendered user app). Gate by source so they
 		// can't be confused or spoofed.
@@ -1123,6 +1133,14 @@
 		}
 	}
 
+	onDestroy(() => {
+		// Don't leave a detached preview behind when the editor unmounts: it
+		// would stop receiving builds and, once refreshed, has no opener to
+		// re-feed it — a permanently blank orphan.
+		if (externalPreviewWindow && !externalPreviewWindow.closed) externalPreviewWindow.close()
+		externalPreviewWindow = null
+	})
+
 	function openExternalPreview() {
 		// Reuse an already-open window instead of spawning duplicates.
 		if (externalPreviewWindow && !externalPreviewWindow.closed) {
@@ -1136,12 +1154,9 @@
 			return
 		}
 		externalPreviewWindow = win
-		// app-preview.html registers its message listener synchronously, so by
-		// `load` it's ready to receive the build (same gate the inline iframe uses).
-		win.addEventListener('load', () => {
-			postToExternalPreview({ type: 'setDarkMode', dark: darkMode })
-			syncExternalPreview()
-		})
+		// No load handler: the window feeds itself by posting `appPreviewReady`
+		// to us on every (re)load (handled in `listener`), which — unlike an
+		// opener-side `load` listener — also survives a manual refresh of the tab.
 	}
 
 	let getBundleResolve: (({ css, js }: { css: string; js: string }) => void) | undefined = undefined

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -38,7 +38,14 @@
 	import { createAppSelectedContext, type AppCodeSelectionElement } from '../copilot/chat/context'
 	import { rawAppLintStore } from './lintStore'
 	import { dbSchemas } from '$lib/stores'
-	import { MousePointerSquareDashed, RefreshCw, Columns2, ChevronDown, Eye } from 'lucide-svelte'
+	import {
+		MousePointerSquareDashed,
+		RefreshCw,
+		Columns2,
+		ChevronDown,
+		Eye,
+		SquareArrowOutUpRight
+	} from 'lucide-svelte'
 	import DraggableTabs, { type TabItem } from '$lib/components/common/tabs/DraggableTabs.svelte'
 	import { runScriptAndPollResult } from '../jobs/utils'
 	import { RawAppHistoryManager } from './RawAppHistoryManager.svelte'
@@ -240,6 +247,10 @@
 	let previewIframe: HTMLIFrameElement | undefined = $state(undefined)
 	let previewIframeLoaded = $state(false)
 	let lastBuild: { css: string; js: string } | undefined = undefined
+	// Detached preview tab/window rendering the same app-preview bundle as the
+	// inline pane. Kept live-synced: every build is replayed into it until the
+	// user closes it. Not reactive — it's a window handle, not UI state.
+	let externalPreviewWindow: Window | null = null
 	let inspectorEnabled = $state(false)
 	let bundlerType: 'esbuild' | 'rolldown' = $state('esbuild')
 
@@ -997,6 +1008,7 @@
 				{ type: 'preview', css: e.data.css, js: e.data.js },
 				'*'
 			)
+			syncExternalPreview()
 			return
 		}
 
@@ -1095,6 +1107,41 @@
 				}
 			}
 		}
+	}
+
+	function postToExternalPreview(msg: Record<string, unknown>) {
+		if (!externalPreviewWindow || externalPreviewWindow.closed) {
+			externalPreviewWindow = null
+			return
+		}
+		externalPreviewWindow.postMessage(msg, '*')
+	}
+
+	function syncExternalPreview() {
+		if (lastBuild) {
+			postToExternalPreview({ type: 'preview', css: lastBuild.css, js: lastBuild.js })
+		}
+	}
+
+	function openExternalPreview() {
+		// Reuse an already-open window instead of spawning duplicates.
+		if (externalPreviewWindow && !externalPreviewWindow.closed) {
+			externalPreviewWindow.focus()
+			syncExternalPreview()
+			return
+		}
+		const win = window.open('/ui_builder/app-preview.html', 'windmillRawAppPreview')
+		if (!win) {
+			sendUserToast('Could not open the preview window (popup blocked?)', true)
+			return
+		}
+		externalPreviewWindow = win
+		// app-preview.html registers its message listener synchronously, so by
+		// `load` it's ready to receive the build (same gate the inline iframe uses).
+		win.addEventListener('load', () => {
+			postToExternalPreview({ type: 'setDarkMode', dark: darkMode })
+			syncExternalPreview()
+		})
 	}
 
 	let getBundleResolve: (({ css, js }: { css: string; js: string }) => void) | undefined = undefined
@@ -1226,6 +1273,7 @@
 		if (previewIframe && previewIframeLoaded) {
 			previewIframe.contentWindow?.postMessage({ type: 'setDarkMode', dark: darkMode }, '*')
 		}
+		postToExternalPreview({ type: 'setDarkMode', dark: darkMode })
 	})
 	$effect(() => {
 		// Match VS Code's editor font size to Windmill's text-xs.
@@ -1497,6 +1545,7 @@
 	{runnables}
 	{path}
 	gateJobIds={false}
+	extraSourceWindow={() => externalPreviewWindow}
 />
 <div class="max-h-screen overflow-hidden h-screen min-h-0 flex flex-col">
 	<RawAppEditorHeader
@@ -1760,6 +1809,14 @@
 												}}
 											>
 												<RefreshCw size={14} />
+											</button>
+											<button
+												class="cursor-pointer bg-surface hover:bg-surface-hover border border-border-light text-primary w-7 h-7 rounded-md inline-flex items-center justify-center"
+												title="Open preview in a separate window"
+												aria-label="Open preview in a separate window"
+												onclick={openExternalPreview}
+											>
+												<SquareArrowOutUpRight size={14} />
 											</button>
 											<button
 												title={splitWithPreview

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,11 +1,20 @@
 import { sveltekit } from '@sveltejs/kit/vite'
-import { readFileSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
 import { fileURLToPath } from 'url'
 import mkcert from 'vite-plugin-mkcert'
 
 const file = fileURLToPath(new URL('package.json', import.meta.url))
 const json = readFileSync(file, 'utf8')
 const version = JSON.parse(json)
+
+// The postinstall downloads the pinned UI Builder artifact into static/ui_builder,
+// which SvelteKit serves at /ui_builder. Serve that directly; only proxy to a
+// live UI Builder dev server on :4000 when the bundle is absent (mirrors the
+// backend's static-vs-:4000 fallback). Delete static/ui_builder to develop the
+// builder against :4000.
+const uiBuilderStaticPresent = existsSync(
+	fileURLToPath(new URL('static/ui_builder/app-preview.html', import.meta.url))
+)
 
 const remoteUrl =
 	process.env.REMOTE ??
@@ -84,15 +93,19 @@ const config = {
 				changeOrigin: true,
 				ws: true
 			},
-			'^/ui_builder/.*': {
-				target: 'http://localhost:4000',
-				changeOrigin: true,
-				headers: {
-					'Cross-Origin-Opener-Policy': 'same-origin',
-					'Cross-Origin-Embedder-Policy': 'require-corp',
-					'Cross-Origin-Resource-Policy': 'cross-origin'
-				}
-			}
+			...(uiBuilderStaticPresent
+				? {}
+				: {
+						'^/ui_builder/.*': {
+							target: 'http://localhost:4000',
+							changeOrigin: true,
+							headers: {
+								'Cross-Origin-Opener-Policy': 'same-origin',
+								'Cross-Origin-Embedder-Policy': 'require-corp',
+								'Cross-Origin-Resource-Policy': 'cross-origin'
+							}
+						}
+					})
 		}
 	},
 	preview: { port: 3001 },


### PR DESCRIPTION
> ⚠️ **Merge order — this PR must merge LAST.**
> 1. Merge the companion **windmill-labs/windmill-code-ui-builder#14** first.
> 2. That triggers the UI Builder R2 publish; then bump `frontend/scripts/ui_builder_artifact.json` (`version` = the ui-builder main merge-commit short hash, `sha256` = sha256 of the new `ui_builder-<hash>.tar.gz`).
> 3. Merge this PR (ideally with the artifact bump included).
>
> This PR degrades gracefully without the bump — initial open, live-sync and runnables work today; only **refresh-repaint** and the **favicon** stay inactive until the artifact is bumped.

## Summary

Restores the **"open preview in a separate window"** affordance for raw apps (code UI builder), which disappeared when preview hosting moved from the UI Builder into the Windmill host (ui-builder commit `f52d8e5b`). The detached window live-updates on every rebuild, follows dark mode, executes backend/runnable calls, and repaints itself after a manual browser refresh.

## Changes

- **`RawAppEditor.svelte`**
  - New toolbar button in the preview pane (`SquareArrowOutUpRight`) that opens `/ui_builder/app-preview.html` in a separate window and feeds it the current build.
  - Live-sync: every rebuild is replayed into the detached window; dark-mode changes forwarded. Shared `feedExternalPreview()` (theme + build) used by the open / focus-reuse / load / handshake paths.
  - Reuses/focuses an existing window instead of spawning duplicates.
  - Handles `appPreviewReady` from the detached window so a **manual browser refresh** of that tab repaints it (the one-shot `load` feed can't survive the tab reloading itself).
  - Keeps the `load`-based feed for initial open so it works regardless of the pinned UI Builder artifact.
  - `onDestroy` closes the orphaned window when the editor unmounts.
- **`RawAppBackgroundRunner.svelte`**
  - The runnable bridge now accepts/replies to the detached window in addition to the inline preview iframe (`extraSourceWindow` getter), so backend/runnable calls resolve there. The WIN-2006 source gate is preserved — `event.source` is browser-set/unforgeable and only our own `window.open` handle is trusted; editor-only, unsandboxed path.

## Companion PR

**windmill-labs/windmill-code-ui-builder#14** adds the `appPreviewReady` handshake + favicon to `app-preview.html`. See the merge-order note above.

## Screenshots

Editor with the new button + working inline preview:

![pr-editor-toolbar](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-raw-app-preview/1782307214-pr-editor-toolbar.png)

Detached window executing a runnable (returns 42), proving the backend bridge:

![pr-detached-window](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-raw-app-preview/1782307214-pr-detached-window.png)

## Test plan

- [x] Click the button → detached tab renders the current app on first open
- [x] Edit code → rebuild replays into the detached tab live
- [x] Run a runnable from the detached tab → resolves (returns 42)
- [x] Manually browser-refresh the detached tab → repaints via handshake (with updated artifact)
- [x] Toggle dark mode, then reopen/refocus the detached tab → theme follows
- [x] Navigate away from the editor → orphaned window auto-closes
- [x] Reopen → focuses existing tab, no duplicate