### PR TITLE
feat(ai-chat): let global chat edit the user's personal instructions

### DIFF
--- a/frontend/src/lib/aiStore.ts
+++ b/frontend/src/lib/aiStore.ts
@@ -204,3 +204,12 @@ export function getCombinedCustomPrompt(mode: string): string | undefined {
 
 	return prompts.join('\n\n')
 }
+
+// Like getCombinedCustomPrompt but keeps the workspace and user slices separate so the
+// Global system prompt can label them distinctly — only the user slice is editable by the
+// update_user_instructions tool.
+export function getCustomPromptParts(mode: string): { workspace?: string; user?: string } {
+	const workspace = get(copilotInfo).customPrompts?.[mode]?.trim() || undefined
+	const user = getUserCustomPrompts()[mode]?.trim() || undefined
+	return { workspace, user }
+}

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -73,6 +73,9 @@ import {
 	getCurrentModel,
 	tryGetCurrentModel,
 	getCombinedCustomPrompt,
+	getCustomPromptParts,
+	getUserCustomPrompts,
+	setUserCustomPrompts,
 	isWebSearchEnabledForProvider
 } from '$lib/aiStore'
 import type { WorkspaceMutationTarget } from './workspaceTools'
@@ -821,8 +824,7 @@ export class AIChatManager {
 			this.tools = [searchDocsTool, readDocsPageTool, ...this.apiTools]
 			this.helpers = {}
 		} else if (mode === AIMode.GLOBAL) {
-			const customPrompt = getCombinedCustomPrompt(mode)
-			this.systemMessage = prepareGlobalSystemMessage(customPrompt, {
+			this.systemMessage = prepareGlobalSystemMessage(getCustomPromptParts(mode), {
 				previewTools: this.isSessionChat,
 				skills: this.globalSkills
 			})
@@ -831,7 +833,18 @@ export class AIChatManager {
 				...(this.isSessionChat ? { sessionId: this.sessionId } : {}),
 				testActiveFlow: async (args?: Record<string, any>) =>
 					this.flowAiChatHelpers?.testFlow(args),
-				attachedFiles: this.attachedFiles
+				attachedFiles: this.attachedFiles,
+				getUserInstructions: () => getUserCustomPrompts()[AIMode.GLOBAL] ?? '',
+				setUserInstructions: (instructions: string) => {
+					const prompts = getUserCustomPrompts()
+					if (instructions.trim()) {
+						prompts[AIMode.GLOBAL] = instructions
+					} else {
+						delete prompts[AIMode.GLOBAL]
+					}
+					setUserCustomPrompts(prompts)
+					this.rebuildGlobalSystemMessage()
+				}
 			} satisfies GlobalToolHelpers
 			void this.refreshGlobalSkills()
 		} else if (mode === AIMode.APP) {
@@ -853,11 +866,24 @@ export class AIChatManager {
 		}
 		this.globalSkills = skills
 		if (this.mode === AIMode.GLOBAL) {
-			this.systemMessage = prepareGlobalSystemMessage(getCombinedCustomPrompt(AIMode.GLOBAL), {
+			this.systemMessage = prepareGlobalSystemMessage(getCustomPromptParts(AIMode.GLOBAL), {
 				previewTools: this.isSessionChat,
 				skills
 			})
 		}
+	}
+
+	// Rebuild the GLOBAL system message in place so an updated user instruction (persisted by
+	// the update_user_instructions tool) is picked up on the next chat-loop iteration, which
+	// re-reads this.systemMessage via a getter.
+	rebuildGlobalSystemMessage = () => {
+		if (this.mode !== AIMode.GLOBAL) {
+			return
+		}
+		this.systemMessage = prepareGlobalSystemMessage(getCustomPromptParts(AIMode.GLOBAL), {
+			previewTools: this.isSessionChat,
+			skills: this.globalSkills
+		})
 	}
 
 	private expandGlobalSkillCommand = (instructions: string): string => {

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
@@ -61,6 +61,9 @@ vi.mock('$lib/aiStore', () => ({
 	getCurrentModel: mocks.getCurrentModel,
 	tryGetCurrentModel: mocks.tryGetCurrentModel,
 	getCombinedCustomPrompt: () => '',
+	getCustomPromptParts: () => ({}),
+	getUserCustomPrompts: () => ({}),
+	setUserCustomPrompts: () => {},
 	isWebSearchEnabledForProvider: mocks.isWebSearchEnabledForProvider
 }))
 

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -3018,6 +3018,156 @@ describe('session-only preview tools gating', () => {
 		expect(on).toContain('get_app_runtime_logs')
 		expect(on).toContain('list_app_runs')
 	})
+
+	// The instruction headers are matched by their distinctive parenthetical so the
+	// guidance bullet (which references both block names) doesn't false-positive.
+	const WS_HEADER = 'WORKSPACE INSTRUCTIONS (configured by a workspace admin'
+	const USER_HEADER = "USER INSTRUCTIONS (this user's personal instructions"
+
+	it('renders only the workspace block when given workspace instructions', () => {
+		const content = prepareGlobalSystemMessage({ workspace: 'Always be terse.' }).content as string
+		expect(content).toContain(WS_HEADER)
+		expect(content).toContain('Always be terse.')
+		expect(content).not.toContain(USER_HEADER)
+	})
+
+	it('renders the user block with the edit-tool mention when given user instructions', () => {
+		const content = prepareGlobalSystemMessage({ user: 'Prefer Bun for new scripts.' })
+			.content as string
+		expect(content).toContain(USER_HEADER)
+		expect(content).toContain('update_user_instructions')
+		expect(content).toContain('Prefer Bun for new scripts.')
+		expect(content).not.toContain(WS_HEADER)
+	})
+
+	it('renders the workspace block before the user block when both are present', () => {
+		const content = prepareGlobalSystemMessage({ workspace: 'WS rule.', user: 'User rule.' })
+			.content as string
+		expect(content).toContain(WS_HEADER)
+		expect(content.indexOf(USER_HEADER)).toBeGreaterThan(content.indexOf(WS_HEADER))
+	})
+
+	it('omits both instruction headers when none are provided', () => {
+		const content = prepareGlobalSystemMessage().content as string
+		expect(content).not.toContain(WS_HEADER)
+		expect(content).not.toContain(USER_HEADER)
+	})
+})
+
+describe('update_user_instructions', () => {
+	function makeHelpers(initial = '') {
+		let value = initial
+		return {
+			getUserInstructions: () => value,
+			setUserInstructions: vi.fn((v: string) => {
+				value = v
+			})
+		}
+	}
+
+	it('appends to empty instructions', async () => {
+		const helpers = makeHelpers('')
+		const res = await callGlobalTool(
+			'update_user_instructions',
+			{ operation: 'append', text: 'Prefer Bun for new scripts.' },
+			toolCallbacks,
+			helpers
+		)
+		expect(helpers.setUserInstructions).toHaveBeenCalledWith('Prefer Bun for new scripts.')
+		expect(res).toContain('Added a personal instruction')
+	})
+
+	it('appends to existing instructions joined by a blank line', async () => {
+		const helpers = makeHelpers('Existing rule.')
+		await callGlobalTool(
+			'update_user_instructions',
+			{ operation: 'append', text: 'Another rule.' },
+			toolCallbacks,
+			helpers
+		)
+		expect(helpers.setUserInstructions).toHaveBeenCalledWith('Existing rule.\n\nAnother rule.')
+	})
+
+	it('returns only a short confirmation, not the resulting instructions', async () => {
+		const helpers = makeHelpers('Existing rule.')
+		const res = await callGlobalTool(
+			'update_user_instructions',
+			{ operation: 'append', text: 'Another rule.' },
+			toolCallbacks,
+			helpers
+		)
+		expect(res).not.toContain('Existing rule.')
+		expect(res).not.toContain('Another rule.')
+	})
+
+	it('replaces an exact match', async () => {
+		const helpers = makeHelpers('Prefer Bun.\n\nUse tabs.')
+		await callGlobalTool(
+			'update_user_instructions',
+			{ operation: 'replace', old_string: 'Prefer Bun.', new_string: 'Prefer Deno.' },
+			toolCallbacks,
+			helpers
+		)
+		expect(helpers.setUserInstructions).toHaveBeenCalledWith('Prefer Deno.\n\nUse tabs.')
+	})
+
+	it('removes the matched text when new_string is empty', async () => {
+		const helpers = makeHelpers('Keep this.\n\nDrop this.')
+		await callGlobalTool(
+			'update_user_instructions',
+			{ operation: 'replace', old_string: '\n\nDrop this.', new_string: '' },
+			toolCallbacks,
+			helpers
+		)
+		expect(helpers.setUserInstructions).toHaveBeenCalledWith('Keep this.')
+	})
+
+	it('clears all instructions when the whole text is replaced with empty', async () => {
+		const helpers = makeHelpers('Only rule.')
+		const res = await callGlobalTool(
+			'update_user_instructions',
+			{ operation: 'replace', old_string: 'Only rule.', new_string: '' },
+			toolCallbacks,
+			helpers
+		)
+		expect(helpers.setUserInstructions).toHaveBeenCalledWith('')
+		expect(res).toContain('Cleared your personal instructions')
+	})
+
+	it('errors without writing when old_string is not found, and echoes the current text for recovery', async () => {
+		const helpers = makeHelpers('Existing rule.')
+		const res = await callGlobalTool(
+			'update_user_instructions',
+			{ operation: 'replace', old_string: 'missing', new_string: 'x' },
+			toolCallbacks,
+			helpers
+		)
+		expect(helpers.setUserInstructions).not.toHaveBeenCalled()
+		expect(res).toContain('not found')
+		expect(res).toContain('Existing rule.')
+	})
+
+	it('rejects a result over the length cap without writing', async () => {
+		const helpers = makeHelpers('')
+		const res = await callGlobalTool(
+			'update_user_instructions',
+			{ operation: 'append', text: 'a'.repeat(5001) },
+			toolCallbacks,
+			helpers
+		)
+		expect(helpers.setUserInstructions).not.toHaveBeenCalled()
+		expect(res).toContain('over the 5000')
+	})
+
+	it('fails gracefully when the context does not provide instruction helpers', async () => {
+		const res = await callGlobalTool(
+			'update_user_instructions',
+			{ operation: 'append', text: 'x' },
+			toolCallbacks,
+			{}
+		)
+		expect(res).toContain('cannot modify user instructions')
+	})
 })
 
 describe('prepareGlobalUserMessage', () => {

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -190,6 +190,43 @@ const askUserQuestionSchema = z.object({
 		.describe('Two to ten mutually exclusive proposed answer strings.')
 })
 
+// Matches the per-mode cap enforced by the prompt-settings UI (AIPromptsModal) and
+// the backend workspace prompt (MAX_CUSTOM_PROMPT_LENGTH).
+export const MAX_USER_INSTRUCTIONS_LENGTH = 5000
+
+const updateUserInstructionsSchema = z.object({
+	operation: z
+		.enum(['append', 'replace'])
+		.describe(
+			'What to do with your personal Global instructions. \'append\' adds a new instruction to the end (use for "remember this" / "always do X"). \'replace\' performs an exact find-and-replace to edit or remove existing text (use for "change X" / "stop doing Y"); set new_string to "" to remove.'
+		),
+	text: z
+		.string()
+		.min(1)
+		.optional()
+		.describe("Required when operation is 'append': the instruction to add. Ignored for 'replace'."),
+	old_string: z
+		.string()
+		.min(1)
+		.optional()
+		.describe(
+			"Required when operation is 'replace': exact text to find in your current personal instructions. Ignored for 'append'."
+		),
+	new_string: z
+		.string()
+		.optional()
+		.describe(
+			"Required when operation is 'replace': replacement text. Use an empty string to delete the matched text. Ignored for 'append'."
+		),
+	replace_all: z
+		.boolean()
+		.optional()
+		.default(false)
+		.describe(
+			"For operation 'replace': when true, replace every exact match; when false, old_string must match exactly once."
+		)
+})
+
 const listWorkspaceItemsSchema = z.object({
 	types: z
 		.array(itemTypeSchema)
@@ -763,6 +800,7 @@ Rules:
 - After creating or editing a script or flow draft, run test_run_script, test_run_flow, or test_run_step with representative args before reporting that it works. These tools prefer drafts, so testing does not require deployment.
 - Use list_runs to find recent runs (optionally filtered by path, creator, label, or status), then get_job_logs with a returned id to inspect a specific run's logs — without starting a new test run.
 - When a required decision is ambiguous, use askUserQuestion with two to ten clear proposed answer strings instead of guessing. The user can also type a custom answer when none of the proposed answers fit.
+- When the user asks you to remember a lasting preference, always/never do something, or change/stop a behavior going forward, call update_user_instructions to persist it. It edits only the USER INSTRUCTIONS block (not WORKSPACE INSTRUCTIONS). Keep each instruction concise; do not use it for one-off requests scoped to the current task.
 - Keep context targeted.${
 	previewTools
 		? `
@@ -1677,6 +1715,79 @@ export const globalTools: Tool<{}>[] = [
 	},
 	{
 		def: createToolDef(
+			updateUserInstructionsSchema,
+			'update_user_instructions',
+			'Modify your own persistent personal instructions for the Global assistant. Use when the user asks you to remember a preference, always/never do something, or change/stop a behavior. Edits only the user-level instructions (the USER INSTRUCTIONS block, not workspace-level); changes persist in this browser and take effect on your next message.'
+		),
+		showDetails: true,
+		fn: async ({ args, toolId, toolCallbacks, helpers }) => {
+			const parsed = updateUserInstructionsSchema.parse(args)
+			const h = helpers as GlobalToolHelpers
+			if (!h?.getUserInstructions || !h?.setUserInstructions) {
+				const message = 'This chat context cannot modify user instructions.'
+				toolCallbacks.setToolStatus(toolId, { content: message, error: message })
+				return message
+			}
+
+			const current = h.getUserInstructions()
+			let next: string
+			if (parsed.operation === 'append') {
+				const text = parsed.text?.trim()
+				if (!text) {
+					const message = "operation 'append' requires a non-empty text."
+					toolCallbacks.setToolStatus(toolId, { content: message, error: message })
+					return message
+				}
+				next = current.trim() ? `${current.trim()}\n\n${text}` : text
+			} else {
+				if (parsed.old_string === undefined || parsed.new_string === undefined) {
+					const message = "operation 'replace' requires old_string and new_string."
+					toolCallbacks.setToolStatus(toolId, { content: message, error: message })
+					return message
+				}
+				try {
+					next = findAndReplace(
+						current,
+						parsed.old_string,
+						parsed.new_string,
+						parsed.replace_all ?? false,
+						'personal instructions'
+					).trim()
+				} catch (e) {
+					const detail = e instanceof Error ? e.message : String(e)
+					// Echo the current text on this rare recovery path so the model can rebuild a
+					// correct old_string. The system prompt's USER INSTRUCTIONS block can be stale
+					// within a turn that already made a successful edit, but `current` is always live.
+					const hint = current.trim()
+						? `Your current personal instructions are:\n${current.trim()}`
+						: "You have no personal instructions yet; use operation 'append' to add one."
+					const message = `${detail} ${hint}`
+					toolCallbacks.setToolStatus(toolId, { content: detail, error: detail })
+					return message
+				}
+			}
+
+			if (next.length > MAX_USER_INSTRUCTIONS_LENGTH) {
+				const message = `Resulting instructions would be ${next.length} characters, over the ${MAX_USER_INSTRUCTIONS_LENGTH} limit. Make them more concise.`
+				toolCallbacks.setToolStatus(toolId, { content: message, error: message })
+				return message
+			}
+
+			h.setUserInstructions(next)
+
+			const summary = next
+				? parsed.operation === 'append'
+					? 'Added a personal instruction'
+					: 'Updated your personal instructions'
+				: 'Cleared your personal instructions'
+			toolCallbacks.setToolStatus(toolId, { content: summary, result: summary })
+			// Return only a short confirmation. The updated text is re-injected into the system
+			// prompt on the next iteration, so echoing it back here would waste context.
+			return `${summary}. It takes effect from your next message and is editable in the Global chat settings.`
+		}
+	},
+	{
+		def: createToolDef(
 			listWorkspaceItemsSchema,
 			'list_workspace_items',
 			'List workspace items and drafts. Returns metadata only.'
@@ -2273,6 +2384,11 @@ export type SessionToolHelpers = { sessionId?: string }
 export type GlobalToolHelpers = SessionToolHelpers & {
 	testActiveFlow?: (args?: Record<string, any>) => Promise<string | undefined>
 	attachedFiles?: AttachedFilesStore
+	// Read/write the user-level Global instructions. `setUserInstructions` persists the
+	// value and rebuilds the system message so the change applies on the next chat-loop
+	// iteration. Backed by the update_user_instructions tool.
+	getUserInstructions?: () => string
+	setUserInstructions?: (instructions: string) => void
 }
 
 function sessionIdFromCtx(ctx: { helpers?: unknown }): string | undefined {
@@ -4050,7 +4166,7 @@ async function deleteWorkspaceItem(
 }
 
 export function prepareGlobalSystemMessage(
-	customPrompt?: string,
+	instructions?: { workspace?: string; user?: string },
 	opts?: {
 		previewTools?: boolean
 		// Identity the path-convention guidance is built from. Production omits it
@@ -4075,8 +4191,11 @@ export function prepareGlobalSystemMessage(
 		folderCtx,
 		opts?.skills ?? []
 	)
-	if (customPrompt?.trim()) {
-		content = `${content}\n\nUSER GIVEN INSTRUCTIONS:\n${customPrompt.trim()}`
+	if (instructions?.workspace?.trim()) {
+		content = `${content}\n\nWORKSPACE INSTRUCTIONS (configured by a workspace admin, shared by everyone in this workspace — you cannot modify these):\n${instructions.workspace.trim()}`
+	}
+	if (instructions?.user?.trim()) {
+		content = `${content}\n\nUSER INSTRUCTIONS (this user's personal instructions — update them with the update_user_instructions tool when the user asks you to remember, change, or stop something):\n${instructions.user.trim()}`
 	}
 
 	return {


### PR DESCRIPTION
## Summary

Lets the **global-mode** AI chat modify the user's own system prompt. When the user says things like "remember this", "always prefer Bun for new scripts", or "stop doing X", the assistant calls a new `update_user_instructions` tool that persists the change to the user-level Global custom prompt (the same per-user prompt configurable in the AI chat settings). The change is re-injected into the system prompt and takes effect on the next message.

Frontend-only — the user-level prompt already lives in `localStorage` and the global system prompt is assembled client-side, so no backend/API/migration changes are needed.

## Changes

- **`update_user_instructions` tool** (`global/core.ts`): two operations — `append` adds a new instruction; `replace` does an exact find/replace to edit or remove existing text (reuses the shared `findAndReplace` helper, so it errors on 0/ambiguous matches). Enforces the 5000-char cap (matches `AIPromptsModal` and backend `MAX_CUSTOM_PROMPT_LENGTH`). Returns only a short confirmation to the model — the updated text is already in the system prompt next turn, so it isn't echoed — except on a not-found `replace`, where it echoes the live current text so the model can rebuild a correct `old_string`.
- **Helpers**: `GlobalToolHelpers` gains `getUserInstructions` / `setUserInstructions`. `AIChatManager` wires them to the `localStorage` user-prompt store (`getUserCustomPrompts`/`setUserCustomPrompts`, deleting the key when cleared) and calls a new `rebuildGlobalSystemMessage()` so the edit applies on the next chat-loop iteration (the loop re-reads `systemMessage` via a getter).
- **Workspace vs user split in the system prompt**: new `getCustomPromptParts` in `aiStore.ts` keeps the two slices separate; `prepareGlobalSystemMessage` now renders them under distinct headers — `WORKSPACE INSTRUCTIONS (…you cannot modify these)` and `USER INSTRUCTIONS (…update them with update_user_instructions)` — so only the user block is presented as editable. Other modes keep the existing combined prompt.
- **Guidance**: a Rules bullet tells the model when to call the tool and that it edits only the user block.
- **Tests**: `global/core.test.ts` covers append (empty/existing), replace, remove, clear, not-found recovery (echoes current text), over-cap rejection without write, missing-helpers, and the 4 system-prompt split-rendering cases; `AIChatManager.test.ts` mock extended with the new `aiStore` exports.

## Notes / limitations

- **Per-browser**: instructions persist in `localStorage`, so they don't follow the user across devices. Durable cross-device memory would need new per-user server-side storage (deliberately out of scope here).
- **Screenshots skipped** (per reviewer request): the system-prompt split is LLM-only (not visible), and the persisted value surfaces in the **pre-existing** AI Prompts settings field. The only new visible surface is the in-chat tool-execution display, which only renders when the LLM actually invokes the tool (requires a configured AI provider). Logic is covered by unit tests.

## Test plan

- [ ] `cd frontend && npm run check`
- [ ] `cd frontend && npx vitest run src/lib/components/copilot/chat/global/core.test.ts src/lib/components/copilot/chat/AIChatManager.test.ts`
- [ ] In the Global AI chat, say "always prefer Bun for new scripts" → confirm `update_user_instructions` fires, the value persists across reload, and appears/editable in the Global chat prompt settings
- [ ] Ask it to "stop preferring Bun" → confirm the replace/clear path removes it
- [ ] With a workspace-level prompt set, confirm the chat treats it as read-only (only edits the user block)