### PR TITLE
fix: persist on-behalf-of user across app deploy paths

### DIFF
--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -2135,6 +2135,40 @@ describe('global AI tools', () => {
 		expect(getBackendDraft('raw_app', 'f/apps/report', { workspace: WORKSPACE })).toBeUndefined()
 	})
 
+	it('forwards preserve_on_behalf_of when the deployed policy carries an on_behalf_of', async () => {
+		// Without the flag the backend resets the policy's on_behalf_of to the
+		// deploying user; this chat path has no on-behalf-of selector, so it must
+		// preserve whatever the carried policy already holds.
+		vi.mocked(AppService.existsApp).mockResolvedValueOnce(true)
+		seedBackendDraft(
+			'raw_app',
+			'f/apps/obo',
+			{
+				summary: 'On-behalf app',
+				files: { '/index.tsx': 'console.log("obo")' },
+				runnables: {},
+				data: { tables: [] },
+				policy: {
+					execution_mode: 'publisher',
+					on_behalf_of: 'u/alice',
+					on_behalf_of_email: 'alice@windmill.dev'
+				}
+			},
+			{ workspace: WORKSPACE }
+		)
+		vi.mocked(AppService.getAppByPath).mockResolvedValueOnce({} as any)
+
+		await callGlobalTool('deploy_workspace_item', { type: 'app', path: 'f/apps/obo' })
+
+		expect(AppService.updateAppRaw).toHaveBeenCalledWith(
+			expect.objectContaining({
+				formData: expect.objectContaining({
+					app: expect.objectContaining({ preserve_on_behalf_of: true })
+				})
+			})
+		)
+	})
+
 	it('notifies the session preview (as raw_app) after deploying a raw app', async () => {
 		const onDeployed = vi.fn()
 		setDeployedInSessionHandler(onDeployed)

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -3932,7 +3932,11 @@ async function deployDraft(
 								value: rawAppValue,
 								summary,
 								policy,
-								deployment_message: deploymentMessage
+								deployment_message: deploymentMessage,
+								// Preserve the policy's on_behalf_of: this chat deploy path has no
+								// on-behalf-of selector, so without the flag the backend resets it to
+								// the deploying user (gated server-side by can_preserve_on_behalf_of).
+								preserve_on_behalf_of: policy.on_behalf_of ? true : undefined
 							},
 							js: bundle.js,
 							css: bundle.css
@@ -3948,7 +3952,9 @@ async function deployDraft(
 								summary,
 								policy,
 								deployment_message: deploymentMessage,
-								custom_path: appValue.custom_path
+								custom_path: appValue.custom_path,
+								// Preserve the policy's on_behalf_of (see update branch above).
+								preserve_on_behalf_of: policy.on_behalf_of ? true : undefined
 							},
 							js: bundle.js,
 							css: bundle.css

--- a/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
@@ -187,6 +187,11 @@
 		onOpenOthersDrafts
 	}: Props = $props()
 
+	// Set by the on-behalf-of selector when the publisher picks a user other than
+	// themselves. Forwarded as `preserve_on_behalf_of` so the backend keeps the
+	// policy's on_behalf_of instead of resetting it to the deploying user.
+	let preserveOnBehalfOf = $state(false)
+
 	// The AutosaveIndicator watches these; in the sessions preview they're the
 	// session's (workspace, path), else the full-page editor's own values.
 	const indicatorWorkspace = $derived(autosaveWorkspace ?? $workspaceStore)
@@ -315,7 +320,8 @@
 						summary: summary,
 						policy,
 						deployment_message: deploymentMsg,
-						custom_path: customPath
+						custom_path: customPath,
+						preserve_on_behalf_of: preserveOnBehalfOf || undefined
 					},
 					js,
 					css
@@ -434,6 +440,7 @@
 					policy,
 					path: npath,
 					deployment_message: deploymentMsg,
+					preserve_on_behalf_of: preserveOnBehalfOf || undefined,
 					// custom_path requires admin so to accept update without it, we need to send as undefined when non-admin (when undefined, it will be ignored)
 					// it also means that customPath needs to be set to '' instead of undefined to unset it (when admin)
 					custom_path:
@@ -674,6 +681,7 @@
 			bind:customPathError
 			bind:pathError
 			bind:newEditedPath
+			bind:preserveOnBehalfOf
 		/>
 	</DrawerContent>
 </Drawer>

--- a/frontend/src/lib/rawAppDeploy.ts
+++ b/frontend/src/lib/rawAppDeploy.ts
@@ -75,7 +75,11 @@ export async function deployRawAppDraft(
 					summary,
 					policy,
 					deployment_message: deploymentMessage,
-					custom_path: isAdmin ? (value.custom_path ?? '') : undefined
+					custom_path: isAdmin ? (value.custom_path ?? '') : undefined,
+					// Preserve the policy's on_behalf_of: this draft-deploy path has no
+					// on-behalf-of selector, so without the flag the backend resets it to
+					// the deploying user (gated server-side by can_preserve_on_behalf_of).
+					preserve_on_behalf_of: policy.on_behalf_of ? true : undefined
 				},
 				js: bundle.js,
 				css: bundle.css
@@ -91,7 +95,9 @@ export async function deployRawAppDraft(
 					summary,
 					policy,
 					deployment_message: deploymentMessage,
-					custom_path: value.custom_path
+					custom_path: value.custom_path,
+					// Preserve the policy's on_behalf_of (see update branch above).
+					preserve_on_behalf_of: policy.on_behalf_of ? true : undefined
 				},
 				js: bundle.js,
 				css: bundle.css

--- a/frontend/src/lib/utils_draft_deploy.ts
+++ b/frontend/src/lib/utils_draft_deploy.ts
@@ -370,15 +370,20 @@ export async function deployDraft(
 			// undefined so the backend preserves the existing route. The draft has no
 			// custom_path, so admins fall back to the deployed route (`''` when none).
 			const isAdmin = !!(get(userStore)?.is_admin || get(userStore)?.is_super_admin)
+			const policy = r.policy ?? { execution_mode: 'publisher' }
 			const requestBody = {
 				value: appValue,
 				summary: draftSummary ?? r.summary ?? '',
-				policy: r.policy ?? { execution_mode: 'publisher' },
+				policy,
 				// Honor the draft's intended path; `draft_path` holds the user-typed path
 				// for a never-deployed app parked at a `u/{user}/draft_{uuid}` storage key.
 				path: draftPath ?? r.path ?? path,
 				custom_path: isAdmin ? (r.custom_path ?? '') : undefined,
-				deployment_message: deploymentMessage
+				deployment_message: deploymentMessage,
+				// The draft carries no on-behalf-of selector — the policy comes straight
+				// from the deployed app. Preserve its on_behalf_of (the backend resets it
+				// to the deploying user without this flag, gated by can_preserve_on_behalf_of).
+				preserve_on_behalf_of: policy?.on_behalf_of ? true : undefined
 			}
 			// Same as flows: draft-only apps have no app row → create;
 			// drafts on a deployed app update it.


### PR DESCRIPTION
## Summary

When deploying an app, an admin/`wm_deployers` member can set "App executed on behalf of \<user\>". That choice was silently lost on subsequent deploys — it reset to the deploying user — unlike every other deploy setting.

Root cause: the shared backend handler (`create_app_internal`/`update_app_internal` in `apps.rs`) resets the policy's `on_behalf_of` to the authed user on every deploy **unless** the request sends `preserve_on_behalf_of: true` (gated server-side by `can_preserve_on_behalf_of`, so non-privileged callers can't escalate). Three frontend deploy surfaces never sent that flag:

1. **Raw-app editor deploy drawer** (`RawAppEditorHeader.svelte`) — reused the shared `AppEditorHeaderDeploy` component but never wired up the `preserveOnBehalfOf` bindable nor forwarded the flag. The classic (low-code) app header already did this; the raw-app header was missing it. *(Originally reported bug.)*
2. **Draft-deploy path** ("Review & deploy drafts" UI) — `deployDraft` (visual apps) and `deployRawAppDraft` (raw apps) carry the deployed policy forward but omitted the flag, resetting `on_behalf_of` for **both** app types. No on-behalf-of selector on this surface, so it was a quieter latent gap.
3. **Global AI-chat deploy** (`copilot/chat/global/core.ts`) — same gap on the chat `deploy_workspace_item` raw-app path.

## Changes

- `RawAppEditorHeader.svelte`: declare `preserveOnBehalfOf`, bind it to `AppEditorHeaderDeploy`, send `preserve_on_behalf_of` on create and update — a faithful mirror of the classic-app header.
- `utils_draft_deploy.ts`, `rawAppDeploy.ts`, `copilot/chat/global/core.ts`: send `preserve_on_behalf_of: policy.on_behalf_of ? true : undefined` on the draft-deploy and AI-chat paths so the carried policy's on-behalf-of survives.
- `core.test.ts`: regression test asserting the AI-chat path forwards the flag when the policy carries an `on_behalf_of`.

Backend struct fields, the `can_preserve_on_behalf_of` gate, and generated client types already supported the flag — this is purely the missing frontend wiring.

## Test plan

- [x] Raw-app editor: deploy with on-behalf-of = another user → policy persists (`u/alice`); redeploy without touching the selector → still `u/alice` (versions `{9,10}`)
- [x] Raw-app **draft** deploy via "Review & deploy drafts" → keeps `u/alice` (version `11`)
- [x] AI-chat path covered by a new unit test (`core.test.ts`, 104 passing)
- [x] Visual-app draft path shares the same `createApp`/`updateApp` + `preserve_on_behalf_of` mechanism verified above
- [ ] As a non-`wm_deployers`/non-admin user, on-behalf-of still resets to self (enforced server-side, unchanged)

Verified end-to-end against a local backend with a second workspace user (`alice`): across editor redeploy and draft deploy, `policy.on_behalf_of` stayed `u/alice` / `alice@windmill.dev`.

## Screenshots

Raw-app deploy drawer after redeploy — the on-behalf-of selector retains `u/alice`:

![obo-preserved](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/deploy-behalf-user-persist/1782317111-obo-preserved.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)