### PR TITLE
fix(python): re-verify wheel RECORD on local cache reuse (once per worker)

### DIFF
--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -2040,6 +2040,15 @@ Returned from server: py_version - {:?}, py_version_v2 - {:?}
 
 lazy_static::lazy_static! {
     static ref PIP_SECRET_VARIABLE: Regex = Regex::new(r"\$\{PIP_SECRET:([^\s\}]+)\}").unwrap();
+
+    /// venv paths whose wheel RECORD this process has already verified against
+    /// disk. A cache entry is only damaged out-of-band (disk-pressure eviction,
+    /// an interrupted extraction on a shared cache volume, or a corrupt entry
+    /// that predates this worker), never spontaneously while we keep running, so
+    /// re-verifying it once per process is enough — every later reuse trusts the
+    /// in-memory marker and pays only the original single stat.
+    static ref VERIFIED_VENVS: tokio::sync::Mutex<HashSet<String>> =
+        tokio::sync::Mutex::new(HashSet::new());
 }
 
 /// Spawn process of uv install
@@ -2479,8 +2488,53 @@ pub async fn handle_python_reqs(
             req.replace(' ', "").replace('/', "").replace(':', "")
         );
         if metadata(venv_p.clone() + "/.valid.windmill").await.is_ok() {
-            req_paths.push(venv_p);
-            in_cache.push(req.to_string());
+            // The .valid.windmill marker is written once at creation time, after
+            // verify_wheel_record passes on the install/pull paths. It is an empty
+            // file with no binding to the directory contents, so a file dropped
+            // out-of-band afterwards (disk-pressure eviction, interrupted tar
+            // extraction on a shared cache volume, or a corrupt entry that
+            // predates this worker) leaves the marker intact while the wheel is
+            // incomplete. Re-verify the RECORD once per process so such an entry
+            // is repaired rather than trusted; VERIFIED_VENVS makes every later
+            // reuse skip the scan and pay only the single stat above.
+            let already_verified = VERIFIED_VENVS.lock().await.contains(&venv_p);
+            let verify_res = if already_verified {
+                Ok(())
+            } else {
+                verify_wheel_record(&venv_p).await
+            };
+            match verify_res {
+                Ok(()) => {
+                    if !already_verified {
+                        VERIFIED_VENVS.lock().await.insert(venv_p.clone());
+                    }
+                    req_paths.push(venv_p);
+                    in_cache.push(req.to_string());
+                }
+                Err(verify_err) => {
+                    tracing::warn!(
+                        workspace_id = %w_id,
+                        job_id = %job_id,
+                        "Local cache for {venv_p} failed wheel RECORD verification, will reinstall: {verify_err}"
+                    );
+                    append_logs(
+                        &job_id,
+                        w_id,
+                        format!(
+                            "\n[!] cached wheel for {req} failed integrity check, reinstalling: {verify_err}\n"
+                        ),
+                        conn,
+                    )
+                    .await;
+                    if let Err(rm_err) = tokio::fs::remove_dir_all(&venv_p).await {
+                        tracing::warn!(
+                            workspace_id = %w_id,
+                            "could not remove broken cache dir {venv_p}: {rm_err}"
+                        );
+                    }
+                    req_with_penv.push((req.to_string(), venv_p));
+                }
+            }
         } else {
             // There is no valid or no wheel at all. Regardless of if there is content or not, we will overwrite it with --reinstall flag
             req_with_penv.push((req.to_string(), venv_p));
@@ -3445,5 +3499,89 @@ mod tests {
         );
         assert_eq!(kept, lines(&["# py: 3.11", "requests==2.0"]));
         assert_eq!(ignored, lines(&["pyyaml==6.0"]));
+    }
+
+    /// Materialize a fake installed wheel: every file in `files` is created, and
+    /// `record_entries` is written verbatim as the RECORD (so a test can list a
+    /// path in RECORD without creating it, to simulate out-of-band loss).
+    fn write_fake_wheel(root: &std::path::Path, files: &[&str], record_entries: &[&str]) {
+        for f in files {
+            let full = root.join(f);
+            std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+            std::fs::write(full, b"x").unwrap();
+        }
+        let dist_info = root.join("pkg-1.0.0.dist-info");
+        std::fs::create_dir_all(&dist_info).unwrap();
+        std::fs::write(
+            dist_info.join("RECORD"),
+            record_entries.join("\n") + "\n",
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_verify_wheel_record_ok_when_all_present() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fake_wheel(
+            dir.path(),
+            &["pkg/__init__.py", "pkg/mod.py"],
+            &[
+                "pkg/__init__.py,sha256=aaa,1",
+                "pkg/mod.py,sha256=bbb,1",
+                "pkg-1.0.0.dist-info/RECORD,,",
+            ],
+        );
+        assert!(verify_wheel_record(dir.path().to_str().unwrap())
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_verify_wheel_record_err_when_file_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        // RECORD lists pkg/mod.py but we never create it: the exact failure mode
+        // the customer hit (wmill/s3_reader.py present in RECORD, gone on disk).
+        write_fake_wheel(
+            dir.path(),
+            &["pkg/__init__.py"],
+            &[
+                "pkg/__init__.py,sha256=aaa,1",
+                "pkg/mod.py,sha256=bbb,1",
+                "pkg-1.0.0.dist-info/RECORD,,",
+            ],
+        );
+        let err = verify_wheel_record(dir.path().to_str().unwrap())
+            .await
+            .unwrap_err();
+        assert!(err.contains("pkg/mod.py"), "unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn test_verify_wheel_record_err_when_no_dist_info() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("loose.py"), b"x").unwrap();
+        assert!(verify_wheel_record(dir.path().to_str().unwrap())
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn test_verify_wheel_record_skips_absolute_and_escaping_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        // Absolute and `..` RECORD entries are not package-relative and must be
+        // skipped rather than reported missing.
+        write_fake_wheel(
+            dir.path(),
+            &["pkg/__init__.py"],
+            &[
+                "pkg/__init__.py,sha256=aaa,1",
+                "/etc/passwd,sha256=ccc,1",
+                "../outside.py,sha256=ddd,1",
+                "pkg-1.0.0.dist-info/RECORD,,",
+            ],
+        );
+        assert!(verify_wheel_record(dir.path().to_str().unwrap())
+            .await
+            .is_ok());
     }
 }


### PR DESCRIPTION
## Summary

A customer hit `ModuleNotFoundError: No module named 'wmill.s3_reader'` on `wmill==1.739.0`. The published PyPI wheel is **correct** (verified: it contains `s3_reader.py` and lists it in RECORD, identical layout to 1.738.0). The fault was a **corrupt local worker cache entry** at `/tmp/windmill/cache/python_3_11/wmill==1.739.0/` that was missing `s3_reader.py`.

We already have an integrity guard, `verify_wheel_record` (PR #9090, since v1.699.0), which runs on the S3-tar pull path and the local-install path and refuses to write `.valid.windmill` / push a tar when RECORD-listed files are missing. But the **reuse fast path** in `handle_python_reqs` only checked that the `.valid.windmill` marker file exists — it never re-verified. The marker is an empty file with no binding to the directory's contents, so once a file is lost out-of-band (disk-pressure eviction, interrupted extraction on a shared cache volume, or a bad entry that predates the worker), the broken dir is trusted on every subsequent job forever.

This re-verifies the wheel RECORD on the **first reuse of each cache entry per worker process** and repairs it (wipe + reinstall) on failure. Corruption is always out-of-band and never recurs mid-process, so an in-memory `VERIFIED_VENVS` set makes every later reuse skip the scan — the warm-cache hot path keeps paying only its original single stat, avoiding a per-job stat-storm over large wheels (torch/tensorflow).

## Changes

- `windmill-worker/src/python_executor.rs`: on the local-cache reuse path, run `verify_wheel_record` the first time this process reuses a given venv; on success record it in a new `VERIFIED_VENVS` set and trust it thereafter; on failure log to the job, remove the dir, and route it to reinstall (mirrors the existing S3-pull repair path).
- Added 4 unit tests for `verify_wheel_record` (all-present → Ok; RECORD file missing → Err; no `.dist-info` → Err; absolute/`..` entries skipped).

## Operator remediation (independent of this PR)

For the affected instance now: Clean Cache on the worker group (or `rm -rf .../wmill==1.739.0`), and if Instance Object Storage is configured, delete the corrupt `tar/.../python_3_11/wmill==1.739.0.tar` so peers don't re-pull it.

## Test plan

- [ ] `cargo test -p windmill-worker --features python verify_wheel_record` (4 pass)
- [ ] `cargo check -p windmill-worker` and `--features enterprise,parquet` both clean
- [ ] Manual: run a Python job to warm the cache, delete one file listed in the package's `*.dist-info/RECORD` while leaving `.valid.windmill`, rerun → expect a `cached wheel for <req> failed integrity check, reinstalling` log line, a reinstall, and success
- [ ] Manual: a normal warm-cache rerun still logs `env deps from local cache: ...` with no spurious reinstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-verifies Python wheel RECORD when reusing local cache entries, once per worker. This repairs corrupt venvs and prevents `ModuleNotFoundError` from stale `.valid.windmill` markers while keeping the warm-cache path fast.

- **Bug Fixes**
  - On local-cache reuse, call `verify_wheel_record` the first time a venv is reused; cache success in `VERIFIED_VENVS` to skip future scans.
  - On failure, log to the job, remove the broken dir, and reinstall (mirrors the S3-pull repair path).
  - Added unit tests for `verify_wheel_record`: all-present, missing file, missing `.dist-info`, and skipping absolute/`..` entries.

<sup>Written for commit 2a5c72bf466d2f4a556a20865897df0ae3dc692b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

