### PR TITLE
feat(ai-chat): hint /compact in context usage tooltip

### DIFF
--- a/frontend/src/lib/components/copilot/chat/ContextUsageIndicator.svelte
+++ b/frontend/src/lib/components/copilot/chat/ContextUsageIndicator.svelte
@@ -2,9 +2,14 @@
 	import { copilotInfo, copilotSessionModel } from '$lib/aiStore'
 	import { getKnownModelContextWindow } from '../modelConfig'
 	import { getAiChatManager } from './aiChatManagerContext'
+	import { AIMode } from './AIChatManager.svelte'
 	import Tooltip from '$lib/components/meltComponents/Tooltip.svelte'
 
 	const aiChatManager = getAiChatManager()
+
+	// The `/compact` slash command is only wired up in session-chat GLOBAL mode,
+	// so only advertise it where it actually works.
+	let canCompact = $derived(aiChatManager.isSessionChat && aiChatManager.mode === AIMode.GLOBAL)
 
 	let providerModel = $derived(
 		$copilotSessionModel ?? $copilotInfo.defaultModel ?? $copilotInfo.aiModels[0]
@@ -74,6 +79,11 @@
 				</p>
 				{#if ratio !== undefined && ratio >= COMPACTION_TRIGGER_RATIO}
 					<p class="mt-1 text-tertiary">History will be compacted soon to free up space.</p>
+				{/if}
+				{#if canCompact}
+					<p class="mt-1 text-tertiary">
+						Type <span class="font-mono">/compact</span> to summarize and free up space now.
+					</p>
 				{/if}
 			</div>
 		{/snippet}


### PR DESCRIPTION
## Summary

The AI chat now shows a context-usage gauge with a tooltip. Since session chat has a `/compact` command to manually summarize the conversation and free up context, the tooltip now tells users how to invoke it.

## Changes

- `ContextUsageIndicator.svelte`: added a tooltip line — "Type `/compact` to summarize and free up space now." — shown whenever the gauge is visible.
- Gated on `aiChatManager.isSessionChat && aiChatManager.mode === AIMode.GLOBAL`, mirroring the manager's own `/compact` dispatch guards, so the hint only appears where the command actually works (session-chat global mode).

## Screenshots

Tooltip (cropped):

![tooltip-compact-hint-crop](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/improve-context-usage-tooltip/1782459208-tooltip-crop.png)

In context (session chat, hovering the usage gauge):

![tooltip-compact-hint](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/improve-context-usage-tooltip/1782459233-tooltip-context.png)

## Test plan

- [ ] In a GLOBAL-mode AI session chat (dev flag `wm_dev_global_ai=1` + workspace AI provider), send a couple of messages, then hover the usage gauge — confirm the `/compact` hint appears.
- [ ] Open a non-session (in-editor) or non-GLOBAL AI chat and confirm the hint is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)