### PR TITLE
fix: allow hyphens in postgresql database name validation

### DIFF
--- a/backend/windmill-api-settings/src/lib.rs
+++ b/backend/windmill-api-settings/src/lib.rs
@@ -1275,8 +1275,8 @@ async fn setup_custom_instance_pg_database_inner(
     // Validate name to ensure it only contains alphanumeric characters
     // Prevents SQL injection on the instance database
     lazy_static::lazy_static! {
-        // Must start with a letter, then alphanumeric/underscore
-        static ref VALID_NAME: regex::Regex = regex::Regex::new(r"^[a-zA-Z][a-zA-Z0-9_]*$").unwrap();
+        // Must start with a letter, then alphanumeric/underscore/hyphen
+        static ref VALID_NAME: regex::Regex = regex::Regex::new(r"^[a-zA-Z][a-zA-Z0-9_-]*$").unwrap();
     }
     let dbname = dbname.trim();
     if dbname.is_empty() {
@@ -1292,7 +1292,7 @@ async fn setup_custom_instance_pg_database_inner(
     }
     if !VALID_NAME.is_match(dbname) {
         return Err(error::Error::BadRequest(
-            "Database name must start with a letter and contain only alphanumeric characters or underscores".to_string(),
+            "Database name must start with a letter and contain only alphanumeric characters, underscores, or hyphens".to_string(),
         ));
     }
     // Additional check: block PostgreSQL reserved/special names

--- a/backend/windmill-common/src/lib.rs
+++ b/backend/windmill-common/src/lib.rs
@@ -811,7 +811,7 @@ impl PgDatabase {
 }
 
 /// Validate a database name to prevent SQL injection.
-/// Must start with a letter, contain only alphanumeric characters or underscores, and be <= 63 chars.
+/// Must start with a letter, contain only alphanumeric characters, underscores, or hyphens, and be <= 63 chars.
 pub fn validate_dbname(dbname: &str) -> error::Result<()> {
     let dbname = dbname.trim();
     if dbname.is_empty() {
@@ -835,10 +835,11 @@ pub fn validate_dbname(dbname: &str) -> error::Result<()> {
     }
     if !dbname
         .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '_')
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
     {
         return Err(error::Error::BadRequest(
-            "Database name must contain only alphanumeric characters or underscores".to_string(),
+            "Database name must contain only alphanumeric characters, underscores, or hyphens"
+                .to_string(),
         ));
     }
     Ok(())

--- a/backend/windmill-common/src/lib.rs
+++ b/backend/windmill-common/src/lib.rs
@@ -528,6 +528,31 @@ mod classify_python_logging_line_tests {
     }
 }
 
+#[cfg(test)]
+mod validate_dbname_tests {
+    use super::validate_dbname;
+
+    #[test]
+    fn accepts_letters_digits_underscores_and_hyphens() {
+        assert!(validate_dbname("mydb").is_ok());
+        assert!(validate_dbname("my_db").is_ok());
+        assert!(validate_dbname("my-database").is_ok());
+        assert!(validate_dbname("My-Db_1").is_ok());
+    }
+
+    #[test]
+    fn rejects_invalid_names() {
+        // Must start with a letter (hyphen/digit/underscore leads are rejected).
+        assert!(validate_dbname("-db").is_err());
+        assert!(validate_dbname("1db").is_err());
+        assert!(validate_dbname("_db").is_err());
+        // No other special characters or whitespace.
+        assert!(validate_dbname("my db").is_err());
+        assert!(validate_dbname("my;db").is_err());
+        assert!(validate_dbname("").is_err());
+    }
+}
+
 #[derive(Serialize, Debug)]
 pub struct PrepareQueryColumnInfo {
     pub name: String,

--- a/frontend/src/lib/components/workspaceSettings/CustomInstanceDbWizardModal.svelte
+++ b/frontend/src/lib/components/workspaceSettings/CustomInstanceDbWizardModal.svelte
@@ -146,7 +146,7 @@
 									title: 'Database name is valid',
 									status: status?.logs.valid_dbname,
 									description:
-										'The database name must be alphanumeric (underscores allowed) and cannot be named the same as the Windmill database (usually "windmill")'
+										'The database name must be alphanumeric (underscores and hyphens allowed) and cannot be named the same as the Windmill database (usually "windmill")'
 								},
 								{
 									title:


### PR DESCRIPTION
## Summary

`validate_dbname()` and the `setup_custom_instance_pg_database_inner` regex rejected database names containing hyphens (e.g. `my-database`). PostgreSQL permits hyphens in database names when the identifier is double-quoted, and the codebase already double-quotes every database-name interpolation. The rejection blocked data-table operations (import, create, drop) backed by a PostgreSQL database whose name contains hyphens.

This widens both validators to allow `-` (still requiring a leading ASCII letter), and updates the matching doc comment, error messages, and frontend wizard description.

Fixes WIN-2098.

## Changes

- `backend/windmill-common/src/lib.rs`: `validate_dbname()` now accepts `-`; doc comment and error message updated. Added a unit-test module covering hyphen acceptance and rejection of invalid leads/characters.
- `backend/windmill-api-settings/src/lib.rs`: `VALID_NAME` regex changed from `^[a-zA-Z][a-zA-Z0-9_]*$` to `^[a-zA-Z][a-zA-Z0-9_-]*$`; comment and error message updated.
- `frontend/src/lib/components/workspaceSettings/CustomInstanceDbWizardModal.svelte`: validation description text now mentions hyphens.

## Safety

Hyphens are inert at every database-name usage site:
- **Double-quoted identifiers** — `CREATE DATABASE "{}"`, `DROP DATABASE IF EXISTS "{}"`, `GRANT ... ON DATABASE "{}"` (`windmill-common/src/lib.rs:883,932`; `windmill-api-settings/src/lib.rs`; `workspaces.rs:2110`).
- **Single-quoted string literal** — `pg_terminate_backend ... WHERE datname = '{}'` with `.replace('\'', "''")` escaping (`windmill-common/src/lib.rs:872-873`).
- **Parameterized queries** — existence checks and `global_settings` updates bind via `$N`.
- **CLI argv** — `pg_dump`/`psql` receive the name as a non-shell argv entry; the required leading letter precludes it being parsed as a flag.

Reserved-name and main-DB guards are exact-match comparisons, unaffected by hyphens. A leading hyphen is still rejected (must start with a letter).

## Test plan

- [x] Backend compiles and runs (verified via `cargo watch` pane; `/api/version` returns 200).
- [x] `cargo test -p windmill-common --lib validate_dbname_tests` passes (2/2): `my-database` accepted; `-db`, `1db`, `_db`, `my db`, `my;db`, `""` rejected.
- [x] Local code review (branch-diff-reviewer): good to merge, SQL-injection safety confirmed across all interpolation sites.
- [ ] Manual: as superadmin, open the custom instance DB wizard (workspace settings → custom instance database) and create a database with a hyphenated name such as `my-data-table`; the "Database name is valid" check passes and the DB is created.

## Frontend note

The only frontend change is a one-line description string inside the superadmin custom-instance-DB wizard's step list, which renders only after a DB-setup attempt produces a status. No screenshot is attached because surfacing it requires triggering a real database creation; the change is description-only text with no layout/behavior impact and was verified by inspection.