### PR TITLE
chore: trim unused apt packages from server docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -163,14 +163,14 @@ ENV PATH /usr/local/bin:/root/.local/bin:/tmp/.local/bin:$PATH
 
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends netbase tzdata ca-certificates wget curl jq unzip build-essential unixodbc xmlsec1 software-properties-common tini gnupg lsb-release \
+    && apt-get install -y --no-install-recommends netbase tzdata ca-certificates wget curl jq unzip build-essential unixodbc xmlsec1 tini gnupg \
     && if echo "$features" | grep -q "ee"; then apt-get install -y --no-install-recommends libsasl2-modules-gssapi-mit krb5-user; fi \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Install latest PostgreSQL client (pg_dump) from official PostgreSQL apt repository
 RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] https://apt.postgresql.org/pub/repos/apt $(. /etc/os-release; echo "$VERSION_CODENAME")-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends postgresql-client \
     && apt-get clean \
@@ -184,11 +184,11 @@ RUN if [ "$WITH_GIT" = "true" ]; then \
     else echo 'Building the image without git'; fi;
 
 RUN if [ "$WITH_POWERSHELL" = "true" ]; then \
-    if [ "$TARGETPLATFORM" = "linux/amd64" ]; then apt-get update -y && apt install libicu-dev -y && wget -O 'pwsh.deb' "https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell_${POWERSHELL_DEB_VERSION}.deb_amd64.deb" && apt-get clean \
+    if [ "$TARGETPLATFORM" = "linux/amd64" ]; then apt-get update -y && apt install libicu72 -y && wget -O 'pwsh.deb' "https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell_${POWERSHELL_DEB_VERSION}.deb_amd64.deb" && apt-get clean \
     && rm -rf /var/lib/apt/lists/* && \
     dpkg --install 'pwsh.deb' && \
     rm 'pwsh.deb'; \
-    elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then apt-get update -y && apt install libicu-dev -y && wget -O powershell.tar.gz "https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell-${POWERSHELL_VERSION}-linux-arm64.tar.gz" && apt-get clean \
+    elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then apt-get update -y && apt install libicu72 -y && wget -O powershell.tar.gz "https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell-${POWERSHELL_VERSION}-linux-arm64.tar.gz" && apt-get clean \
     && rm -rf /var/lib/apt/lists/* && \
     mkdir -p /opt/microsoft/powershell/7 && \
     tar zxf powershell.tar.gz -C /opt/microsoft/powershell/7 && \


### PR DESCRIPTION
## Summary

Reduces the CVE surface of the Debian-based server image (`Dockerfile`) by removing apt packages that are unused or over-installed, without touching anything the binary or user jobs depend on. This is a contained, no-pipeline-change reduction on the existing Bookworm image (independent of any base-image/hardening work).

Motivation: the base Debian layer itself is small (≈9 HIGH/CRITICAL on `debian:bookworm-slim`); the bulk of the image's CVE surface comes from added packages. `software-properties-common` is the standout — it is never used yet pulls ~102 transitive packages (full `python3` stack, `systemd`, `dbus`, `polkit`, `packagekit`, `gstreamer`, …).

## Changes

- **Remove `software-properties-common`** — `add-apt-repository` is not referenced anywhere; repos are added via direct `echo`/`curl`. Drops its large unused transitive cluster.
- **Remove `lsb-release`** — replace its only use (`$(lsb_release -cs)` for the pgdg repo codename) with `$(. /etc/os-release; echo "$VERSION_CODENAME")`, which yields the same `bookworm` value with no extra package.
- **`libicu-dev` → `libicu72`** in the PowerShell install (amd64 + arm64) — pwsh only needs the runtime ICU lib; `libicu-dev` pulled 19 packages vs 1.
- **Kept** `build-essential` (runtime: native Python C-extension builds) and `gnupg` (runtime: git-sync GPG signing; also build-time `gpg --dearmor`).

## Test plan

- [ ] Multi-arch image build succeeds with `WITH_POWERSHELL=true` on `linux/amd64` and `linux/arm64`
- [ ] `pwsh -c '$PSVersionTable'` runs in the built image (confirms `libicu72` linkage)
- [ ] `pg_dump --version` works (confirms the `bookworm-pgdg` repo line resolved and installed the client)
- [ ] git-sync GPG commit signing still functions (confirms `gnupg` retention)
- [ ] Compare HIGH/CRITICAL CVE count before/after via image scan to quantify the reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trim unused apt packages in the Debian server image to reduce CVE surface and slightly shrink image size. No behavior change to the server or user jobs.

- **Dependencies**
  - Removed `software-properties-common` (unused; dropped large transitive deps).
  - Removed `lsb-release`; use `$(. /etc/os-release; echo "$VERSION_CODENAME")` for the pgdg codename.
  - Replaced `libicu-dev` with `libicu72` for PowerShell on `linux/amd64` and `linux/arm64`.
  - Kept `build-essential` and `gnupg` as required at runtime.

<sup>Written for commit 82a29f19722590d9da24ac26d3f9c23d19dce51c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

