### PR TITLE
fix(frontend): use direct parent for nested-loop test-step args

### DIFF
--- a/frontend/src/lib/components/flows/stepsInputArgs.svelte.ts
+++ b/frontend/src/lib/components/flows/stepsInputArgs.svelte.ts
@@ -102,7 +102,10 @@ export class StepsInputArgs {
 		}
 		let parentModule: FlowModule | undefined = undefined
 		if (modules.length > 1) {
-			parentModule = modules[modules.length - 1]
+			// dfs returns [module, direct_parent, grandparent, ...], so the direct
+			// parent is modules[1]. Using the last element would pick the outermost
+			// ancestor and miss inner-loop iter values for nested loops.
+			parentModule = modules[1]
 		}
 		const stepPropPicker = getStepPropPicker(
 			flowState,
@@ -177,7 +180,10 @@ export class StepsInputArgs {
 		}
 		let parentModule: FlowModule | undefined = undefined
 		if (modules.length > 1) {
-			parentModule = modules[modules.length - 1]
+			// dfs returns [module, direct_parent, grandparent, ...], so the direct
+			// parent is modules[1]. Using the last element would pick the outermost
+			// ancestor and miss inner-loop iter values for nested loops.
+			parentModule = modules[1]
 		}
 		const stepPropPicker = getStepPropPicker(
 			flowState,


### PR DESCRIPTION
## Summary

When a step is inside a nested for-loop (a loop within another loop), the **Test this step** tab pre-filled `flow_input.iter.value` with the *outer* (parent) loop's iteration value instead of the *inner* (direct-parent) loop's value. Runtime behavior was already correct — only the test-step arg initialization was wrong.

Root cause: `evalArg()` and `updateStepArgs()` in `stepsInputArgs.svelte.ts` selected the parent module via `modules[modules.length - 1]` from `dfs(id, flow, true)`. `dfs` returns `[module, direct_parent, grandparent, ...]` (innermost → outermost), so that index resolved to the **outermost** ancestor. `getStepPropPicker` → `getFlowInput` then computed `flow_input` using only the outer loop's context, missing the inner loop's `iter` entirely.

By contrast `FlowModuleComponent.svelte` receives the direct parent through its `parentModule` prop, so the prop-picker panel already showed correct values — the bug was isolated to test-step arg initialization.

Fix: select the direct parent with `modules[1]`. For non-nested cases (`modules.length === 2`), `modules[1] === modules[modules.length - 1]`, so behavior is unchanged there; steps not in any container (`length <= 1`) don't enter the guard.

## Changes
- `frontend/src/lib/components/flows/stepsInputArgs.svelte.ts`: in both `evalArg()` and `updateStepArgs()`, select the parent module as `modules[1]` (direct parent) instead of `modules[modules.length - 1]` (outermost ancestor).

## Verification

Built a flow with a nested for-loop: outer loop over `[1, 2, 3]` → inner loop over `["x", "y", "z"]` → a Bun step whose `inner` arg is `flow_input.iter.value`. After running the flow, opened the inner step's **Test this step** tab:

| Before (buggy) | After (fixed) |
|---|---|
| `inner = 2` (outer loop value) | `inner = "z"` (inner loop value) |

### Screenshots

**Before** — `inner` evaluated to `2` (an outer-loop value):

![before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/diego/win-2096-fix-nested-loop-iter-value-in-test-this-step-tab-showing/1782381751-r5-buggy.png)

**After** — `inner` evaluated to `"z"` (an inner-loop value):

![after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/diego/win-2096-fix-nested-loop-iter-value-in-test-this-step-tab-showing/1782381754-r6-fixed.png)

## Test plan
- [x] `npm run check:fast` passes
- [x] Nested-loop step's **Test this step** tab shows the inner loop's iter value
- [x] Verified before/after by temporarily reverting the fix (shows outer value `2`) and restoring it (shows inner value `"z"`)
- [ ] Non-nested loop step still initializes test args correctly (unchanged code path)

Fixes WIN-2096