### PR TITLE
fix: use transaction for parallel_monitor_lock DELETE in last-iteration path

### DIFF
--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -1054,7 +1054,7 @@ pub async fn update_flow_status_after_job_completion_internal(
                     let r = sqlx::query_scalar!(
                          "DELETE FROM parallel_monitor_lock WHERE parent_flow_id = $1 RETURNING last_ping",
                          flow,
-                     ).fetch_optional(db).await.map_err(|e| {
+                     ).fetch_optional(&mut *tx).await.map_err(|e| {
                          Error::internal_err(format!(
                              "error while deleting parallel_monitor_lock: {e:#}"
                          ))


### PR DESCRIPTION
## Problem

In `worker_flow.rs`, when the **last** iteration of a parallel for-loop completes (`nindex == len`), the code holds a transaction `tx` (begun at line 759) while issuing `DELETE FROM parallel_monitor_lock` on the pool handle `db` (line 1054).

This dual-connection pattern requires **2 simultaneous connections** from the per-worker sqlx pool (default max 5). Under concurrent load this can trigger `pool timed out while waiting for an open connection`.

The non-last-iteration path (line 1081+) already commits `tx` *before* its own `DELETE`, so it never holds two connections. PR #7861 fixed the same dual-connection class elsewhere in this file but missed this specific code path.

## Fix

Run the DELETE on the held transaction instead of acquiring a second pool connection:

```rust
- ).fetch_optional(db).await.map_err(|e| {
+ ).fetch_optional(&mut *tx).await.map_err(|e| {
```

The transaction is committed shortly after (line ~1488), so including the DELETE in `tx` is safe and consistent with the non-last-iteration path's behavior. This is the same pattern PR #7861 applied to other queries in this file.

## Validation

- Backend recompiled cleanly under `cargo watch` (`windmill-worker` built, server reached `health check completed status=healthy`).
- No sqlx offline-cache update needed — the query string is unchanged; only the executor changed (`db` → `&mut *tx`).

Fixes WIN-2099

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the held transaction to delete from parallel_monitor_lock in the last-iteration path, removing the dual-connection pattern and preventing `sqlx` pool timeouts under load; consistent with the non-last-iteration path. Fixes WIN-2099.

<sup>Written for commit 7a338cff290da3c3e79e71ab109c27419693c50b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

