### PR TITLE
fix: pass SSL cert env vars to `uv python install` (WIN-2100)

### DIFF
--- a/backend/windmill-worker/src/python_versions.rs
+++ b/backend/windmill-worker/src/python_versions.rs
@@ -551,6 +551,13 @@ impl PyV {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
+        if let Some(cert_path) = INDEX_CERT.as_ref() {
+            child_cmd.env("SSL_CERT_FILE", cert_path);
+        }
+        if *NATIVE_CERT {
+            child_cmd.env("UV_NATIVE_TLS", "true");
+        }
+
         if let Some(mirror) = UV_PYTHON_INSTALL_MIRROR.read().await.as_ref() {
             child_cmd.env("UV_PYTHON_INSTALL_MIRROR", mirror);
         }


### PR DESCRIPTION
## Problem

When `uv python install` downloads a managed Python runtime, `install_python` in `backend/windmill-worker/src/python_versions.rs` clears the subprocess environment via `env_clear()` and forwards only a subset of variables. `SSL_CERT_FILE` (from `PY_INDEX_CERT`/`PIP_INDEX_CERT`) and `UV_NATIVE_TLS` (from `PY_NATIVE_CERT`) were **not** forwarded, causing `invalid peer certificate: UnknownIssuer` errors in environments with corporate/private CAs.

The sibling `find_python` method in the same file already forwards these variables, as does the pip install path in `python_executor.rs`.

## Fix

Forward `SSL_CERT_FILE` and `UV_NATIVE_TLS` to the `uv python install` subprocess after the existing `.envs(PROXY_ENVS.clone())` call, mirroring the `find_python` pattern. The `INDEX_CERT` and `NATIVE_CERT` imports were already present in the file.

## Validation

- `cargo check -p windmill-worker --features python` — compiles cleanly (only pre-existing unrelated warnings).

Backend-only change, no UI.

Fixes WIN-2100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwarded `SSL_CERT_FILE` and `UV_NATIVE_TLS` to `uv python install` so managed Python downloads honor custom CAs and avoid UnknownIssuer errors. Fixes WIN-2100.

- **Bug Fixes**
  - Add these env vars in `install_python` (after `.envs(PROXY_ENVS.clone())`) when spawning the subprocess.
  - Aligns behavior with `find_python` and the pip path in `python_executor.rs` for consistency.

<sup>Written for commit 3b1aeb0ee417324b748dd5309601a7d1d461fd16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

