### PR TITLE
fix: serialize concurrent python wheel-cache installs to prevent flaky ModuleNotFoundError

### DIFF
--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -2367,6 +2367,35 @@ async fn verify_wheel_record(venv_p: &str) -> Result<(), String> {
     }
 }
 
+lazy_static::lazy_static! {
+    /// Per-target-directory install locks. The wheel cache
+    /// (`ROOT_CACHE_DIR/python_<v>/<pkg>==<ver>`) is shared by every job on a
+    /// worker, and `uv pip install --reinstall --target <dir>` transiently
+    /// empties that directory while it runs. Two jobs installing the same
+    /// package concurrently would clobber each other's files — and a job that
+    /// imports from the dir mid-reinstall hits a flaky `ModuleNotFoundError`
+    /// (e.g. wmill's `httpx` vanishing during a WAC run). We serialize installs
+    /// per target dir and re-check the `.valid.windmill` marker once the lock is
+    /// held, so a waiter reuses the freshly populated cache instead of
+    /// reinstalling over it.
+    static ref PY_INSTALL_LOCKS: std::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>> =
+        std::sync::Mutex::new(HashMap::new());
+}
+
+/// Returns the install lock guarding `venv_p`, creating it on first use.
+fn py_install_lock_for(venv_p: &str) -> Arc<tokio::sync::Mutex<()>> {
+    let mut locks = PY_INSTALL_LOCKS.lock().unwrap();
+    locks
+        .entry(venv_p.to_string())
+        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+        .clone()
+}
+
+/// A venv dir is usable iff its install wrote the `.valid.windmill` marker.
+async fn is_venv_valid(venv_p: &str) -> bool {
+    metadata(format!("{venv_p}/.valid.windmill")).await.is_ok()
+}
+
 /// uv pip install, include cached or pull from S3
 pub async fn handle_python_reqs(
     requirements: Vec<String>,
@@ -2726,6 +2755,34 @@ pub async fn handle_python_reqs(
             );
 
             let start = std::time::Instant::now();
+
+            // Serialize population of this shared cache dir against other jobs.
+            // `--reinstall` (and the S3 tar extraction below) rewrite `venv_p` in
+            // place, so a concurrent installer must not run while another job is
+            // still populating it.
+            let install_lock = py_install_lock_for(&venv_p);
+            let _install_guard = install_lock.lock().await;
+            // Another job may have finished the install while we waited on the
+            // lock — reuse its result instead of reinstalling over a dir other
+            // jobs may now be importing from.
+            if is_venv_valid(&venv_p).await {
+                print_success(
+                    false,
+                    false,
+                    &job_id,
+                    &w_id,
+                    &req,
+                    req_tl,
+                    counter_arc,
+                    total_to_install,
+                    start,
+                    &conn,
+                )
+                .await;
+                pids.lock().await.get_mut(i).and_then(|e| e.take());
+                return Ok(());
+            }
+
             #[cfg(all(feature = "enterprise", feature = "parquet"))]
             if is_not_pro {
                 if let Some(os) = windmill_object_store::get_object_store().await {
@@ -3311,6 +3368,36 @@ pub async fn start_worker(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn py_install_lock_serializes_same_target_only() {
+        // The shared wheel cache race fix relies on: same target dir -> same lock
+        // (serialized installs), different target dir -> independent locks. If this
+        // keying ever regresses, concurrent `--reinstall` could clobber a dir a job
+        // is importing from, reintroducing the flaky ModuleNotFoundError.
+        let a1 = py_install_lock_for("/cache/python_3_12/wmill==1.0.0");
+        let a2 = py_install_lock_for("/cache/python_3_12/wmill==1.0.0");
+        let b = py_install_lock_for("/cache/python_3_12/httpx==0.27.0");
+
+        assert!(
+            Arc::ptr_eq(&a1, &a2),
+            "same target dir must share one install lock"
+        );
+        assert!(
+            !Arc::ptr_eq(&a1, &b),
+            "different target dirs must use independent install locks"
+        );
+
+        let _held = a1.lock().await;
+        assert!(
+            a2.try_lock().is_err(),
+            "installs into the same target dir must be mutually exclusive"
+        );
+        assert!(
+            b.try_lock().is_ok(),
+            "installs into different target dirs must not block each other"
+        );
+    }
 
     #[test]
     fn test_compute_python_module_dir_nested_path() {


### PR DESCRIPTION
## Summary

`test_python_wac_v2_step_inline_fast_path` (and the other wmill-importing Python tests) intermittently failed in CI with `ModuleNotFoundError: No module named 'httpx'` — the WAC wrapper imports the `wmill` SDK, which imports `httpx`, but `httpx` was missing from the worker's shared Python wheel cache.

### Root cause

The wheel cache `ROOT_CACHE_DIR/python_<v>/<pkg>==<ver>` is **shared by every job on a worker**. Installs run `uv pip install <pkg> --no-deps --reinstall --target <that shared dir>`, and `--reinstall` **transiently empties the target directory** while it runs. The `.valid.windmill` marker check that decides "already cached?" is a TOCTOU gate with no per-target lock.

When several jobs install the same package concurrently (e.g. multiple WAC tests all needing `wmill`/`httpx`), a second installer's `--reinstall` wipes the dir out from under a job that is importing from it — surfacing as a flaky `ModuleNotFoundError` (`httpx`, `httpx._exceptions`, `wmill`, `wmill.s3_reader`, …). The unit test process runs all backend tests in one process sharing `/tmp/windmill/cache`, so the race is easy to hit in CI.

### Fix

Serialize population of each target dir with a process-wide keyed lock and re-check the `.valid.windmill` marker once the lock is held. A waiter that loses the race reuses the freshly populated cache instead of reinstalling over a dir other jobs may be importing from. `--reinstall` now only runs when no valid install exists yet, so no concurrent importer can ever observe a half-populated dir. Installs of *different* packages stay fully parallel (different lock keys).

## Changes

- `backend/windmill-worker/src/python_executor.rs`:
  - Add `PY_INSTALL_LOCKS` (a `std::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>`) plus `py_install_lock_for()` and `is_venv_valid()` helpers.
  - In `handle_python_reqs`, acquire the per-target lock at the start of each install task and skip the reinstall if the dir became valid while waiting.
  - Add unit test `py_install_lock_serializes_same_target_only` guarding the lock keying (same target → serialized, different target → independent).

## Test plan

- [x] Reproduced on the unfixed build: cold wheel-cache loop over the 4 wmill-importing tests run concurrently → **8/10 iterations failed** with httpx/wmill `ModuleNotFoundError`.
- [x] With the fix: same loop → **0/12 iterations failed**.
- [x] `cargo test -p windmill-worker py_install_lock_serializes_same_target_only` passes.
- [x] Compiles with the CI feature set `enterprise,deno_core,duckdb,license,python,rust,scoped_cache,parquet,private,quickjs,mcp,run_inline` and with a minimal `python,deno_core,quickjs,rust` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize per-target Python wheel-cache installs to stop concurrent `uv` reinstalls from wiping shared dirs. This removes flaky `ModuleNotFoundError` for `httpx`/`wmill` in CI and keeps imports stable.

- **Bug Fixes**
  - Added process-wide keyed locks (`PY_INSTALL_LOCKS`) to serialize installs per target dir.
  - Re-check `.valid.windmill` after acquiring the lock; skip reinstall if already valid.
  - Different package targets remain parallel; only same target is serialized.
  - Added unit test `py_install_lock_serializes_same_target_only`.
  - Changes in `backend/windmill-worker/src/python_executor.rs`.

<sup>Written for commit e9f016cf66bb9309bb905a6b5102896d0e710f8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

