### PR TITLE
fix: re-pin stale-draft fork base when restoring an app deployment

### DIFF
--- a/frontend/src/routes/(root)/(logged)/apps/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps/edit/[...path]/+page.svelte
@@ -391,6 +391,13 @@
 	function onRestore(ev: any) {
 		sendUserToast('App restored from previous deployment')
 		app = ev.detail
+		// Re-pin the stale-draft fork base to the current head. A restored value
+		// carries the `parent_version` baked in when that older version was deployed,
+		// which would make the deploy guard (`compareVersions`) falsely report "not on
+		// latest". Restore targets the live app, so `versions` holds the current head.
+		const versions = (app as { versions?: number[] } | undefined)?.versions
+		const head = Array.isArray(versions) ? versions[versions.length - 1] : undefined
+		if (head != null && app?.value) (app.value as App).parent_version = head
 		const app_ = structuredClone(stateSnapshot(app!))
 		savedApp = {
 			summary: app_.summary,


### PR DESCRIPTION
## Problem

Follow-up to #9768. While auditing the stale-draft guard for false positives, I found one more: **restoring a version from an app's Deployment History falsely trips the deploy-time "not on latest" guard.**

`onRestore` sets the editor value directly (`app = ev.detail`) without going through `loadApp`, so it never refreshes the fork base used by the stale-draft check. Deployed app values carry the `parent_version` that was baked in when that version was deployed (the editor deploys `$app` verbatim, including its pinned base). So the restored value's `parent_version` points at an older head, and `compareVersions` compares that outdated base against the current head, concluding the editor is "not on latest" and surfacing a spurious override/diff confirmation on deploy.

It is warn-level (the user can still confirm and deploy), not a hard block.

## Fix

Re-pin `parent_version` to the current head in `onRestore`, mirroring the two existing re-pin sites (the `loadApp` seed and the after-deploy re-pin in `AppEditorHeader`). A restore targets the live app, so the response's `versions` array holds the current head.

## Verification

- Confirmed the root cause empirically against a local instance: an app deployed twice stores `parent_version` of the previous head inside the deployed value (e.g. head `v28`'s value carries `parent_version: 27`). Restoring that value makes the guard compute `onLatest = (27 === 28) = false`; after the re-pin it is `(28 === 28) = true`.
- `npm run check:fast` clean.

The flow equivalent is already safe: flow history-restore redeploys and fully reloads via `loadFlow()`, and flow deploy navigates away from the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a false “not on latest” warning when restoring an app deployment by re-pinning the fork base to the current head.

On restore, we now set the restored app’s `parent_version` to the latest entry in `versions`, preventing the spurious override/diff prompt on deploy.

<sup>Written for commit ab7909cf017e8053f91439c6d0082c33bda71595. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

