### PR TITLE
fix: apply script editor timeout to preview/Test runs

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -11751,6 +11751,11 @@ paths:
           in: query
           schema:
             type: boolean
+        - name: timeout
+          description: custom timeout in seconds for this preview run
+          in: query
+          schema:
+            type: integer
         - $ref: "#/components/parameters/NewJobId"
 
       requestBody:

--- a/frontend/src/lib/components/JobLoader.svelte
+++ b/frontend/src/lib/components/JobLoader.svelte
@@ -336,12 +336,14 @@
 		callbacks?: Callbacks,
 		flowPath?: string,
 		modules?: Record<string, import('$lib/gen').ScriptModule> | null,
-		tempScriptRefs?: Record<string, string>
+		tempScriptRefs?: Record<string, string>,
+		timeout?: number
 	): Promise<string> {
 		return abstractRun(
 			() =>
 				JobService.runScriptPreview({
 					workspace: $workspaceStore!,
+					timeout,
 					requestBody: {
 						path,
 						content: code,

--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -2016,6 +2016,7 @@
 			stablePathForCaptures={initialPath || fakeInitialPath}
 			bind:code={script.content}
 			lang={script.language}
+			timeout={script.timeout}
 			kind={script.kind}
 			autoKind={script.auto_kind}
 			{template}

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -158,6 +158,10 @@
 		// succeeded.
 		requireValidAssets?: boolean
 		args: Record<string, any>
+		// Custom timeout (in seconds) from the script settings. Forwarded to the
+		// preview run so "Test" honors the same timeout a deployed run would,
+		// instead of silently falling back to the instance default.
+		timeout?: number
 		selectedTab?: 'main' | 'preprocessor' | 'diagram'
 		hasPreprocessor?: boolean
 		captureTable?: CaptureTable | undefined
@@ -215,6 +219,7 @@
 		customUi = undefined,
 		requireValidAssets = false,
 		args = $bindable(),
+		timeout = undefined,
 		selectedTab = $bindable('main'),
 		hasPreprocessor = $bindable(false),
 		captureTable = $bindable(undefined),
@@ -791,7 +796,9 @@
 				}
 			},
 			undefined,
-			activeModuleTab !== null ? undefined : modules
+			activeModuleTab !== null ? undefined : modules,
+			undefined,
+			timeout
 		)
 		if (job) {
 			onTestJob?.({ jobId: job })


### PR DESCRIPTION
## Summary

The custom **timeout** configured in the script editor settings was only honored for deployed script runs. It is persisted on the script row and passed as `custom_timeout` when running by hash/path, but preview ("Test") runs derived their timeout solely from the `timeout` query param of `/jobs/run/preview` — which the editor never sent. As a result, Test runs silently fell back to the instance default timeout, ignoring the value shown right next to the run button.

This threads the editor's timeout setting through to the preview run so Test honors the same timeout a deployed run would.

## Changes

- `backend/windmill-api/openapi.yaml`: document the `timeout` integer query param on `POST /jobs/run/preview`. The handler `run_preview_script` already reads `RunJobQuery.timeout` and passes it to `push()` as `custom_timeout`; it just wasn't in the spec, so the generated client never offered it. No backend logic change.
- `frontend/src/lib/components/JobLoader.svelte`: `runPreview()` gains an optional `timeout?: number`, forwarded as the `timeout` query param of `runScriptPreview`.
- `frontend/src/lib/components/ScriptEditor.svelte`: new `timeout?: number` prop, passed into `runPreview` from `runTest`.
- `frontend/src/lib/components/ScriptBuilder.svelte`: passes `timeout={script.timeout}` (the editor settings value) into `ScriptEditor`.

The backend already clamps `custom_timeout` against the instance max in `resolve_job_timeout` (`windmill-worker/src/common.rs`), so previews get the same ceiling as deployed runs — exposing this param introduces no new validation gap. When no custom timeout is set the param is omitted and behavior is unchanged.

## Screenshots

No visible UI effect — this change adds no elements and no layout change; it only makes the existing "Test" button honor the already-existing custom-timeout setting. Nothing new to screenshot.

## Test plan

- [ ] In the script editor, enable a custom timeout (e.g. 5s) in settings, then run **Test** with a script that sleeps longer (e.g. 30s) → preview job is cancelled at 5s, not the instance default.
- [ ] With no custom timeout set, **Test** runs to completion under the instance default (no regression).
- [ ] Setting a custom timeout above the instance max still gets clamped to the max (same as deployed runs).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Test runs honor the script editor’s custom timeout, matching deployed runs. Threads the timeout through the editor to the preview API and documents the `timeout` param.

- Bug Fixes
  - Documented `timeout` integer query param on `POST /jobs/run/preview` in `backend/windmill-api/openapi.yaml` (server already reads it as `custom_timeout`).
  - Added optional `timeout` to `JobLoader.runPreview` and forwarded it to `runScriptPreview`.
  - Added `timeout` prop to `ScriptEditor` and passed it from `runTest`.
  - Passed `timeout={script.timeout}` from `ScriptBuilder` into `ScriptEditor`.
  - Behavior: when unset, defaults apply; when set, backend clamps to the instance max.

<sup>Written for commit a888742f09e1862b5fff1ea8ff024f6b5a970b6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

