### PR TITLE
fix: restore libargon2-1 for PHP runtime in server image (WIN-2101)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -163,7 +163,7 @@ ENV PATH /usr/local/bin:/root/.local/bin:/tmp/.local/bin:$PATH
 
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends netbase tzdata ca-certificates wget curl jq unzip build-essential unixodbc xmlsec1 tini gnupg \
+    && apt-get install -y --no-install-recommends netbase tzdata ca-certificates wget curl jq unzip build-essential unixodbc xmlsec1 tini gnupg libargon2-1 \
     && if echo "$features" | grep -q "ee"; then apt-get install -y --no-install-recommends libsasl2-modules-gssapi-mit krb5-user; fi \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Problem

The apt-package trim in #9783 removed `software-properties-common` / `lsb-release` from the server Docker image. Those packages were transitively pulling in `libargon2-1`, which provides `libargon2.so.1`.

The PHP CLI binary is copied wholesale from `php:8.3.30-cli-bookworm` (`Dockerfile:295`) and dynamically links `libargon2.so.1` (used for argon2 `password_hash`). With the transitive dependency gone, every PHP job now fails at process startup:

```
/usr/bin/php: error while loading shared libraries: libargon2.so.1: cannot open shared object file: No such file or directory
```

This surfaced as the `test_php` integration test failing with exit code 127.

## Fix

Explicitly install `libargon2-1` in the main apt install layer so the PHP runtime no longer depends on an incidental transitive package.

## Validation

Reproduced and verified against `debian:bookworm-slim` (the final runtime base) using the exact PHP binary the Dockerfile copies, with the post-trim package set:

- **Without the fix** — reproduces the reported error:
  ```
  libargon2.so.1 => not found
  php: error while loading shared libraries: libargon2.so.1: ...
  ```
- **With `libargon2-1`** — `ldd` reports all libraries resolved, `php --version` works, and `password_hash(..., PASSWORD_ARGON2I)` produces a valid `$argon2i$...` hash. `libargon2.so.1` was the only missing library, so this is the complete fix.

Fixes WIN-2101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly install `libargon2-1` in the server Docker image to restore `libargon2.so.1` for the PHP runtime. Fixes PHP jobs failing at startup and the `test_php` integration after the apt trim; addresses WIN-2101.

<sup>Written for commit 727029e76e926f856904bdf586f4db4a05cd504b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

