### PR TITLE
ci: check out windmill-ee-private for the Claude PR reviewer

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,6 +37,44 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Make the EE source (the *_ee.rs files in the companion repo) available so the
+      # reviewer can see EE-only code (e.g. windmill-queue/src/jobs_ee.rs), not just the
+      # CE surface. The EE ref is read from the PR head's backend/ee-repo-ref.txt (via the
+      # API, so it reflects the PR's EE pin regardless of which ref is checked out here).
+      - name: Check EE access
+        id: ee
+        env:
+          EE_TOKEN: ${{ secrets.WINDMILL_EE_PRIVATE_ACCESS }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          if [ -z "$EE_TOKEN" ] || [ -z "$PR_NUMBER" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          HEAD_SHA=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq .head.sha)
+          REF=$(gh api "repos/${{ github.repository }}/contents/backend/ee-repo-ref.txt?ref=$HEAD_SHA" --jq .content | base64 -d | tr -d '[:space:]')
+          if [ -z "$REF" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "ee_repo_ref=$REF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout EE repository
+        if: steps.ee.outputs.available == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: windmill-labs/windmill-ee-private
+          path: ./windmill-ee-private
+          ref: ${{ steps.ee.outputs.ee_repo_ref }}
+          token: ${{ secrets.WINDMILL_EE_PRIVATE_ACCESS }}
+          fetch-depth: 1
+
+      - name: Substitute EE code
+        if: steps.ee.outputs.available == 'true'
+        run: ./backend/substitute_ee_code.sh --copy --dir ./windmill-ee-private
+
       - name: Run Claude PR Action
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Summary

The Claude review workflow (`claude.yml`) used a plain `actions/checkout`, so the EE source — the `*_ee.rs` files that live in `windmill-ee-private` and are symlinked/gitignored here — was **absent** from its checkout. The reviewer could only see the CE surface and missed EE-only code (e.g. `windmill-queue/src/jobs_ee.rs`). The Codex and Pi review workflows already check out the EE repo; this brings Claude in line.

## Changes
- `claude.yml`: before running the action, read the **PR head's** `backend/ee-repo-ref.txt` via the API (so it reflects the PR's EE pin regardless of the checked-out ref), check out `windmill-labs/windmill-ee-private` at that ref, and run `substitute_ee_code.sh --copy`. Gated on `WINDMILL_EE_PRIVATE_ACCESS` being present (no-op if the secret is absent).

## Test plan
- [ ] `/ai` on an EE PR (one that touches a `*_ee.rs` file) and confirm the review reasons about the EE code, not just the CE diff.
- [ ] `/ai` on a CE-only PR / an issue still works (EE step no-ops cleanly when there's no PR or no token).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Claude PR review see EE code by checking out `windmill-ee-private` at the PR’s pinned ref and copying `*_ee.rs` into the workspace. This fixes missed EE-only changes and aligns Claude with the Codex/Pi workflows.

- **Bug Fixes**
  - In `claude.yml`, read the PR head’s `backend/ee-repo-ref.txt` via API, then (when `WINDMILL_EE_PRIVATE_ACCESS` is set) checkout `windmill-labs/windmill-ee-private` at that ref using `actions/checkout@v4` and run `./backend/substitute_ee_code.sh --copy --dir ./windmill-ee-private`.
  - No-op when the secret or PR number is missing, keeping CE-only paths unchanged; runs before `anthropics/claude-code-action@v1`.

<sup>Written for commit b21810c97deb72c3d3a20a45d1b628a4c40d0dd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

