### PR TITLE
feat(api): add structured endpoint for flow logs (WIN-2102)

### DIFF
--- a/backend/tests/jobs_read_auth.rs
+++ b/backend/tests/jobs_read_auth.rs
@@ -106,6 +106,10 @@ async fn test_single_job_read_authorization(db: Pool<Postgres>) -> anyhow::Resul
         ),
         ("get_flow_all_logs", format!("get_flow_all_logs/{VICTIM}")),
         (
+            "get_flow_all_logs_structured",
+            format!("get_flow_all_logs_structured/{VICTIM}"),
+        ),
+        (
             "completed/get_timing",
             format!("completed/get_timing/{VICTIM}"),
         ),

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -12988,6 +12988,64 @@ paths:
               schema:
                 type: string
 
+  /w/{workspace}/jobs_u/get_flow_all_logs_structured/{id}:
+    get:
+      summary: get all logs for a flow job in a structured format
+      operationId: getFlowAllLogsStructured
+      tags:
+        - job
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - $ref: "#/components/parameters/JobId"
+      responses:
+        "200":
+          description: structured logs of all flow steps, one entry per job
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    job_id:
+                      type: string
+                    label:
+                      type: string
+                      description: human-readable label describing the job's position in the flow tree
+                    kind:
+                      type: string
+                      description: job kind (script, flow, forloopflow, ...)
+                    flow_step_id:
+                      type: string
+                      nullable: true
+                    step_path:
+                      type: string
+                      nullable: true
+                      description: materialized step path (e.g. "a/b")
+                    depth:
+                      type: integer
+                      description: depth in the flow tree (0 for the root flow job)
+                    parent_module_type:
+                      type: string
+                      nullable: true
+                      description: parent module type (forloopflow, branchall, ...)
+                    sibling_index:
+                      type: integer
+                      description: 1-based index of this job among siblings sharing the same step
+                    sibling_count:
+                      type: integer
+                      description: total number of siblings sharing the same step
+                    logs:
+                      type: string
+                  required:
+                    - job_id
+                    - label
+                    - kind
+                    - depth
+                    - sibling_index
+                    - sibling_count
+                    - logs
+
   /w/{workspace}/jobs_u/get_completed_logs_tail/{id}:
     get:
       summary: get completed job logs tail

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -391,6 +391,10 @@ pub fn workspace_unauthed_service() -> Router {
         .route("/get_logs/{id}", get(get_job_logs))
         .route("/get_flow_all_logs/{id}", get(get_flow_all_logs))
         .route(
+            "/get_flow_all_logs_structured/{id}",
+            get(get_flow_all_logs_structured),
+        )
+        .route(
             "/get_completed_logs_tail/{id}",
             get(get_completed_job_logs_tail),
         )
@@ -2210,14 +2214,40 @@ async fn resolve_logs_to_string(
     logs.to_string()
 }
 
-async fn get_flow_all_logs(
-    OptViewToken(view_token): OptViewToken,
-    OptAuthed(opt_authed): OptAuthed,
+/// A single job in a flow's execution tree, with its resolved logs and a
+/// human-readable label describing its position (iteration, branch, subflow…).
+#[derive(Serialize)]
+struct FlowLogEntry {
+    job_id: String,
+    /// Human-readable label, e.g. "Step a (iteration 2/3)" or "Flow".
+    label: String,
+    /// Job kind (script, flow, forloopflow, …).
+    kind: String,
+    /// The flow step id this job corresponds to, if any.
+    flow_step_id: Option<String>,
+    /// Materialized step path (e.g. "a/b") used to locate the step in the flow.
+    step_path: Option<String>,
+    /// Depth in the flow tree (0 for the root flow job).
+    depth: i32,
+    /// The parent module type (forloopflow, branchall, …), if any.
+    parent_module_type: Option<String>,
+    /// 1-based index of this job among its siblings sharing the same step.
+    sibling_index: i32,
+    /// Total number of siblings sharing the same step.
+    sibling_count: i32,
+    /// Resolved logs for this job (pulled from disk/object store as needed).
+    logs: String,
+}
+
+async fn collect_flow_log_entries(
+    view_token: Option<String>,
+    opt_authed: Option<ApiAuthed>,
     opt_tokened: OptTokened,
-    Extension(db): Extension<DB>,
-    Extension(user_db): Extension<UserDB>,
-    Path((w_id, id)): Path<(String, Uuid)>,
-) -> error::Result<Response> {
+    db: &DB,
+    user_db: &UserDB,
+    w_id: &str,
+    id: Uuid,
+) -> error::Result<Vec<FlowLogEntry>> {
     let tags = opt_authed
         .as_ref()
         .map(|authed| get_scope_tags(authed).map(|v| v.iter().map(|s| s.to_string()).collect_vec()))
@@ -2230,17 +2260,17 @@ async fn get_flow_all_logs(
         w_id,
         tags.as_ref().map(|v| v.as_slice())
     )
-    .fetch_optional(&db)
+    .fetch_optional(db)
     .await?;
 
     let root_job = not_found_if_none(root_job, "Job", id.to_string())?;
 
     if let Some(authed) = opt_authed.as_ref() {
         require_job_read_access(
-            &db,
-            &user_db,
+            db,
+            user_db,
             authed,
-            &w_id,
+            w_id,
             &id,
             &root_job.created_by,
             view_token.as_deref(),
@@ -2253,10 +2283,10 @@ async fn get_flow_all_logs(
     }
 
     log_job_view(
-        &db,
+        db,
         opt_authed.as_ref(),
         opt_tokened.token.as_deref(),
-        &w_id,
+        w_id,
         &id,
     )
     .await?;
@@ -2323,10 +2353,10 @@ async fn get_flow_all_logs(
         w_id,
         id,
     )
-    .fetch_all(&db)
+    .fetch_all(db)
     .await?;
 
-    let mut all_logs = String::new();
+    let mut entries = Vec::with_capacity(records.len());
 
     for record in &records {
         let kind = record.kind.as_deref().unwrap_or("");
@@ -2389,16 +2419,87 @@ async fn get_flow_all_logs(
         };
 
         let job_id = record.id.map(|u| u.to_string()).unwrap_or_default();
-        all_logs.push_str(&format!("\n=== {} (Job: {}) ===\n", label, job_id));
         let logs = record.logs.as_deref().unwrap_or("");
         let resolved =
             resolve_logs_to_string(record.log_offset.unwrap_or(0), logs, &record.log_file_index)
                 .await;
-        all_logs.push_str(&resolved);
+
+        entries.push(FlowLogEntry {
+            job_id,
+            label,
+            kind: kind.to_string(),
+            flow_step_id: record.flow_step_id.clone(),
+            step_path: record.path_label.clone(),
+            depth,
+            parent_module_type: if parent_module_type.is_empty() {
+                None
+            } else {
+                Some(parent_module_type.to_string())
+            },
+            sibling_index,
+            sibling_count,
+            logs: resolved,
+        });
+    }
+
+    Ok(entries)
+}
+
+async fn get_flow_all_logs(
+    OptViewToken(view_token): OptViewToken,
+    OptAuthed(opt_authed): OptAuthed,
+    opt_tokened: OptTokened,
+    Extension(db): Extension<DB>,
+    Extension(user_db): Extension<UserDB>,
+    Path((w_id, id)): Path<(String, Uuid)>,
+) -> error::Result<Response> {
+    let entries = collect_flow_log_entries(
+        view_token,
+        opt_authed,
+        opt_tokened,
+        &db,
+        &user_db,
+        &w_id,
+        id,
+    )
+    .await?;
+
+    let mut all_logs = String::new();
+    for entry in &entries {
+        all_logs.push_str(&format!(
+            "\n=== {} (Job: {}) ===\n",
+            entry.label, entry.job_id
+        ));
+        all_logs.push_str(&entry.logs);
         all_logs.push('\n');
     }
 
     Ok(content_plain(Body::from(all_logs)))
+}
+
+/// Structured alternative to `get_flow_all_logs`: returns the same flow log
+/// tree as a JSON array of entries (one per job) instead of a flat text blob,
+/// so callers can render or process logs per-step without parsing delimiters.
+async fn get_flow_all_logs_structured(
+    OptViewToken(view_token): OptViewToken,
+    OptAuthed(opt_authed): OptAuthed,
+    opt_tokened: OptTokened,
+    Extension(db): Extension<DB>,
+    Extension(user_db): Extension<UserDB>,
+    Path((w_id, id)): Path<(String, Uuid)>,
+) -> JsonResult<Vec<FlowLogEntry>> {
+    let entries = collect_flow_log_entries(
+        view_token,
+        opt_authed,
+        opt_tokened,
+        &db,
+        &user_db,
+        &w_id,
+        id,
+    )
+    .await?;
+
+    Ok(Json(entries))
 }
 
 async fn get_args(


### PR DESCRIPTION
## What

Adds `GET /w/{workspace}/jobs_u/get_flow_all_logs_structured/{id}` — a structured JSON alternative to the existing [`get_flow_all_logs`](https://app.windmill.dev/openapi.html#tag/job/GET/w/{workspace}/jobs_u/get_flow_all_logs/{id}) endpoint.

Where the original endpoint returns the whole flow log tree as a single `text/plain` blob with `=== <label> (Job: <id>) ===` delimiters, the new endpoint returns a JSON array with one entry per job in the flow tree:

```json
[
  {
    "job_id": "019eff…",
    "label": "Step a forloop (iteration 1/2)",
    "kind": "flowpreview",
    "flow_step_id": "a",
    "step_path": "a",
    "depth": 1,
    "parent_module_type": "forloopflow",
    "sibling_index": 1,
    "sibling_count": 2,
    "logs": "…"
  }
]
```

This lets callers render or process logs per step without parsing the text delimiters.

## How

- Extracts the shared auth check, recursive-CTE query, and label-building logic from `get_flow_all_logs` into `collect_flow_log_entries`, returning `Vec<FlowLogEntry>`.
- The existing text endpoint now formats those entries and produces **byte-identical** output (verified — see below).
- The new endpoint serializes the same entries as JSON. Same authorization path, so the read-access guarantees are identical.
- OpenAPI spec updated with the new operation (`getFlowAllLogsStructured`).

## Validation

- Backend compiles cleanly (cargo watch) and server is healthy.
- Ran a 2-iteration forloop flow and confirmed the structured endpoint returns the correct tree, and the text endpoint output is unchanged after the refactor.
- Extended the `jobs_read_auth` regression test to also exercise `get_flow_all_logs_structured` — the viewer is still denied (403) and no secret leaks. Test passes.

No frontend UI change (the generated TS client is gitignored and rebuilt at compile time).

Fixes WIN-2102

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a structured JSON endpoint for flow logs so clients can render logs per step without parsing text delimiters. Keeps the existing text endpoint byte-identical and routes both through shared auth/query logic (WIN-2102).

- New Features
  - Added `GET /w/{workspace}/jobs_u/get_flow_all_logs_structured/{id}` returning an array of per-job entries (job_id, label, kind, step path, depth, parent module type, sibling index/count, logs).
  - Extracted shared logic into `collect_flow_log_entries`; legacy `get_flow_all_logs` now formats these entries without changing output.
  - Updated OpenAPI (`getFlowAllLogsStructured`) and extended `jobs_read_auth.rs` to cover the new endpoint and preserve read-access behavior.

<sup>Written for commit 2422237d7410bac1e2e3585bbbaa9d14508b79cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

