### PR TITLE
Remove repeated text in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ https://github.com/user-attachments/assets/d80de1d9-64de-4d89-aacd-6df23fa81fc4
 
 ## Main Concepts
 
-1. Define a minimal and generic script in Python, TypeScript, Go or Bash that solves a specific task. The code can be defined in the provided Web IDE or synchronized with your own GitHub repo (e.g. through VS Code extension): [provided Web IDE](https://www.windmill.dev/docs/code_editor) or [synchronized with your own GitHub repo](https://www.windmill.dev/docs/advanced/cli/sync) (e.g. through [VS Code](https://www.windmill.dev/docs/cli_local_dev/vscode-extension) extension):
+1. Define a minimal and generic script in Python, TypeScript, Go or Bash that solves a specific task. The code can be defined in the [provided Web IDE](https://www.windmill.dev/docs/code_editor) or [synchronized with your own GitHub repo](https://www.windmill.dev/docs/advanced/cli/sync) (e.g. through [VS Code](https://www.windmill.dev/docs/cli_local_dev/vscode-extension) extension):
 
 ![Step 1](./imgs/windmill-editor.png)
 


### PR DESCRIPTION
Removes repeated text in README.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove duplicated wording in README “Main Concepts” step 1 to improve readability.
Links are now inline as “[provided Web IDE]” and “[synchronized with your own GitHub repo]” for clearer, shorter text.

<sup>Written for commit b4af87f65d90355cf85e83eebb18a1f2910b512d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

