### PR TITLE
feat(ai-chat): surface raw apps in the @-mention context picker

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatInput.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatInput.svelte
@@ -230,7 +230,9 @@
 		// Workspace items are fetched on-demand and not in availableContext,
 		// so skip the availableContext check for them
 		const isWorkspaceItem =
-			contextElement.type === 'workspace_script' || contextElement.type === 'workspace_flow'
+			contextElement.type === 'workspace_script' ||
+			contextElement.type === 'workspace_flow' ||
+			contextElement.type === 'workspace_app'
 		if (
 			!isWorkspaceItem &&
 			!availableContext.find(

--- a/frontend/src/lib/components/copilot/chat/ChatContextPicker.svelte
+++ b/frontend/src/lib/components/copilot/chat/ChatContextPicker.svelte
@@ -4,17 +4,19 @@ AI chat `@`-mention dropdown. Mounts the generic `DrillPicker` with a
 unified tree:
 
   Diffs / Modules / Databases / Workspace
-                                     ├── All / Flows / Scripts
+                                     ├── All / Flows / Scripts / Apps
                                      │       └── f/scope/sub/leaf …
 
 The Diffs / Modules / Databases branches are synthesized from the chat's
 in-memory `availableContext`. The Workspace branch delegates to
 `buildWorkspaceTree` so the picker shares the workspace caching machinery
-with the standalone picker used by `EditorHeader`.
+with the standalone picker used by `EditorHeader`. The Apps branch only
+appears in GLOBAL chat and lists raw (code-based) apps; visual apps are
+excluded.
 
 On a workspace-leaf pick, emits a reference-only `WorkspaceScriptElement` /
-`WorkspaceFlowElement` (path + title + summary). Content is materialized
-at message-prep time by `AIChatManager` — see PR #9216.
+`WorkspaceFlowElement` / `WorkspaceAppElement` (path + title + summary).
+Content is materialized at message-prep time by `AIChatManager` — see PR #9216.
 -->
 <script lang="ts">
 	import { workspaceStore } from '$lib/stores'
@@ -35,6 +37,7 @@ at message-prep time by `AIChatManager` — see PR #9216.
 	import {
 		ContextIconMap,
 		type ContextElement,
+		type WorkspaceAppElement,
 		type WorkspaceFlowElement,
 		type WorkspaceScriptElement
 	} from './context'
@@ -90,13 +93,25 @@ at message-prep time by `AIChatManager` — see PR #9216.
 	}
 
 	// Workspace state shared with WorkspaceItemDrillPicker via the loader.
-	// Chat surfaces flows and scripts only — apps aren't useful as @-mention
-	// context because they're frontends, not callable units.
-	const WORKSPACE_KINDS: WorkspaceItemKind[] = ['flow', 'script']
+	// Flows and scripts everywhere; raw apps only in GLOBAL chat, where the
+	// raw-app tool surface lets the model act on the reference. Visual apps stay
+	// excluded — they're frontends, not code units (filtered out below, where the
+	// 'app' kind is narrowed to raw apps before tree-building).
+	const WORKSPACE_KINDS = $derived<WorkspaceItemKind[]>(
+		aiChatManager.mode === AIMode.GLOBAL ? ['flow', 'script', 'app'] : ['flow', 'script']
+	)
 	const loader = useWorkspaceItemsLoader(
 		() => $workspaceStore,
 		() => WORKSPACE_KINDS
 	)
+
+	// The 'app' listing returns visual and raw apps together; keep only raw apps
+	// so the picker never surfaces a frontend-only app that the chat can't use.
+	const loadedForTree = $derived.by(() => {
+		const loaded = loader.loaded
+		if (!loaded.app) return loaded
+		return { ...loaded, app: loaded.app.filter((a) => a.raw_app) }
+	})
 
 	function contextLeaf(c: ContextElement): DrillLeaf<ChatLeafData> {
 		const displayLabel =
@@ -246,7 +261,7 @@ at message-prep time by `AIChatManager` — see PR #9216.
 			if (modules) branches.push(modules)
 			if (dbs) branches.push(dbs)
 			const wsChildren = buildWorkspaceTree({
-				loaded: loader.loaded,
+				loaded: loadedForTree,
 				kinds: WORKSPACE_KINDS,
 				loadingKind: loader.loadingKind
 			}) as DrillNode<ChatLeafData>[]
@@ -292,8 +307,17 @@ at message-prep time by `AIChatManager` — see PR #9216.
 					deletable: true
 				}
 				onSelectWorkspaceItem(element)
+			} else if (d.kind === 'app') {
+				// Only raw apps reach here (the tree is narrowed in `loadedForTree`).
+				const element: WorkspaceAppElement & { deletable: boolean } = {
+					type: 'workspace_app',
+					path: d.path,
+					title: d.path,
+					summary: d.summary,
+					deletable: true
+				}
+				onSelectWorkspaceItem(element)
 			}
-			// Apps are filtered out via kinds=['flow','script']; ignore.
 		} else {
 			// Runtime context element — added directly.
 			onSelect(d)

--- a/frontend/src/lib/components/copilot/chat/ContextManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/ContextManager.svelte.ts
@@ -77,7 +77,10 @@ export default class ContextManager {
 		}
 		this.workspace = workspace
 		this.selectedContext = currentlySelectedContext.filter(
-			(context) => context.type === 'workspace_script' || context.type === 'workspace_flow'
+			(context) =>
+				context.type === 'workspace_script' ||
+				context.type === 'workspace_flow' ||
+				context.type === 'workspace_app'
 		)
 	}
 
@@ -158,6 +161,7 @@ export default class ContextManager {
 					(c) =>
 						c.type === 'workspace_script' ||
 						c.type === 'workspace_flow' ||
+						c.type === 'workspace_app' ||
 						newAvailableContext.some((ac) => ac.type === c.type && ac.title === c.title)
 				)
 				.map((c) =>
@@ -219,7 +223,10 @@ export default class ContextManager {
 				})
 			}
 
-			if (scriptOptions.lastDeployedCode && scriptOptions.lastDeployedCode !== scriptOptions.getCode()) {
+			if (
+				scriptOptions.lastDeployedCode &&
+				scriptOptions.lastDeployedCode !== scriptOptions.getCode()
+			) {
 				newAvailableContext.push({
 					type: 'diff',
 					title: 'diff_with_last_deployed_version',
@@ -283,6 +290,7 @@ export default class ContextManager {
 						// availableContext; preserve so badges survive editor refreshes.
 						c.type === 'workspace_script' ||
 						c.type === 'workspace_flow' ||
+						c.type === 'workspace_app' ||
 						newAvailableContext.some((ac) => ac.type === c.type && ac.title === c.title)
 				)
 				.map((c) => {
@@ -403,7 +411,10 @@ export default class ContextManager {
 							type: 'diff' as const,
 							title: 'diff_with_last_deployed_version',
 							content: this.scriptOptions.lastDeployedCode ?? '',
-							diff: diffLines(this.scriptOptions.lastDeployedCode ?? '', this.scriptOptions.getCode()),
+							diff: diffLines(
+								this.scriptOptions.lastDeployedCode ?? '',
+								this.scriptOptions.getCode()
+							),
 							lang: this.scriptOptions.lang
 						}
 					]

--- a/frontend/src/lib/components/copilot/chat/context.ts
+++ b/frontend/src/lib/components/copilot/chat/context.ts
@@ -6,7 +6,8 @@ import {
 	FileCode,
 	Code2,
 	TextSelect,
-	Table2
+	Table2,
+	LayoutDashboard
 } from 'lucide-svelte'
 import BarsStaggered from '$lib/components/icons/BarsStaggered.svelte'
 import type { ScriptLang } from '$lib/gen/types.gen'
@@ -25,7 +26,8 @@ export const ContextIconMap = {
 	app_code_selection: TextSelect,
 	app_datatable: Table2,
 	workspace_script: Code2,
-	workspace_flow: BarsStaggered
+	workspace_flow: BarsStaggered,
+	workspace_app: LayoutDashboard
 	// flow_module type is handled with FlowModuleIcon
 }
 
@@ -228,6 +230,16 @@ export interface WorkspaceFlowElement {
 	summary?: string
 }
 
+/** Workspace app context element — reference to a (code-based) raw app in the
+ * workspace. Only raw apps are surfaced: the visual app builder produces a
+ * frontend, not a code unit the chat can act on. */
+export interface WorkspaceAppElement {
+	type: 'workspace_app'
+	path: string
+	title: string
+	summary?: string
+}
+
 export type ContextElement = (
 	| CodeElement
 	| ErrorElement
@@ -242,6 +254,7 @@ export type ContextElement = (
 	| AppDatatableElement
 	| WorkspaceScriptElement
 	| WorkspaceFlowElement
+	| WorkspaceAppElement
 ) & {
 	deletable?: boolean
 }

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -3359,15 +3359,23 @@ describe('prepareGlobalUserMessage', () => {
 				path: 'f/flows/reporting',
 				title: 'f/flows/reporting',
 				summary: 'Reporting flow'
+			},
+			{
+				type: 'workspace_app',
+				path: 'f/apps/dashboard',
+				title: 'f/apps/dashboard',
+				summary: 'Dashboard raw app'
 			}
 		])
 
 		expect(message.content).toContain('## SELECTED CONTEXT')
 		expect(message.content).toContain('- type: script, path: f/scripts/report')
 		expect(message.content).toContain('- type: flow, path: f/flows/reporting')
+		expect(message.content).toContain('- type: raw_app, path: f/apps/dashboard')
 		expect(message.content).toContain('## INSTRUCTIONS:\nUpdate these items')
 		expect(message.content).not.toContain('Report script')
 		expect(message.content).not.toContain('Reporting flow')
+		expect(message.content).not.toContain('Dashboard raw app')
 	})
 
 	it('omits selected context section when no workspace item is selected', () => {

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -4433,7 +4433,10 @@ export function prepareGlobalUserMessage(
 	options: GlobalUserMessageOptions = {}
 ): ChatCompletionUserMessageParam {
 	const selectedWorkspaceItems = selectedContext.filter(
-		(context) => context.type === 'workspace_script' || context.type === 'workspace_flow'
+		(context) =>
+			context.type === 'workspace_script' ||
+			context.type === 'workspace_flow' ||
+			context.type === 'workspace_app'
 	)
 	const activeEditor =
 		options.activeEditor ??
@@ -4450,7 +4453,13 @@ export function prepareGlobalUserMessage(
 	if (selectedWorkspaceItems.length > 0) {
 		content += '## SELECTED CONTEXT\n'
 		for (const context of selectedWorkspaceItems) {
-			content += `- type: ${context.type === 'workspace_script' ? 'script' : 'flow'}, path: ${context.path}\n`
+			const itemType =
+				context.type === 'workspace_script'
+					? 'script'
+					: context.type === 'workspace_flow'
+						? 'flow'
+						: 'raw_app'
+			content += `- type: ${itemType}, path: ${context.path}\n`
 		}
 		content += '\n'
 	}

--- a/frontend/src/lib/components/copilot/chat/shared.test.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.test.ts
@@ -136,14 +136,22 @@ describe('buildContextString', () => {
 				path: 'f/flows/reporting',
 				title: 'f/flows/reporting',
 				summary: 'Reporting flow'
+			},
+			{
+				type: 'workspace_app',
+				path: 'f/apps/dashboard',
+				title: 'f/apps/dashboard',
+				summary: 'Dashboard raw app'
 			}
 		])
 
 		expect(context).toContain('SELECTED WORKSPACE ITEMS:')
 		expect(context).toContain('- type: script, path: f/scripts/report')
 		expect(context).toContain('- type: flow, path: f/flows/reporting')
+		expect(context).toContain('- type: raw_app, path: f/apps/dashboard')
 		expect(context).not.toContain('Report script')
 		expect(context).not.toContain('Reporting flow')
+		expect(context).not.toContain('Dashboard raw app')
 		expect(context).not.toContain('Code:')
 		expect(context).not.toContain('Value:')
 	})

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -422,6 +422,11 @@ export function buildContextString(selectedContext: ContextElement[]): string {
 				workspaceItemsContext = 'SELECTED WORKSPACE ITEMS:\n'
 			}
 			workspaceItemsContext += `- type: flow, path: ${context.path}\n`
+		} else if (context.type === 'workspace_app') {
+			if (!workspaceItemsContext) {
+				workspaceItemsContext = 'SELECTED WORKSPACE ITEMS:\n'
+			}
+			workspaceItemsContext += `- type: raw_app, path: ${context.path}\n`
 		}
 	}
 


### PR DESCRIPTION
## Summary
The global AI chat `@`-mention context picker only listed flows and scripts — the entire `app` kind was excluded (`WORKSPACE_KINDS = ['flow', 'script']`), so raw (code-based) apps never appeared. Raw apps come back from the same `apps/list` endpoint as visual apps, distinguished only by a `raw_app` flag, so they were dropped along with the visual ones.

This surfaces raw apps in the picker as a new `workspace_app` reference, **gated to GLOBAL chat mode** (where the raw-app tool surface lets the model act on the reference) and **filtered to `raw_app === true`** so visual apps stay excluded — they're frontends, not code units the chat can read.

Like the existing `workspace_script` / `workspace_flow` references, the picked item is a reference only; its content is materialized at message-prep time, emitted into the prompt as `- type: raw_app, path: …` for the model's `read_app_file` / `search_app` tools.

## Changes
- `context.ts` — new `WorkspaceAppElement` (`type: 'workspace_app'`), `LayoutDashboard` icon in `ContextIconMap`, added to the `ContextElement` union.
- `ChatContextPicker.svelte` — add `'app'` to `WORKSPACE_KINDS` only in `AIMode.GLOBAL`; `loadedForTree` narrows the `app` listing to `raw_app === true` before tree-building; pick handler emits a `workspace_app` element.
- `ContextManager.svelte.ts` (3 preserve-filters) + `AIChatInput.svelte` (`isWorkspaceItem` guard) — treat `workspace_app` as a user-picked workspace reference like scripts/flows.
- `shared.ts` + `global/core.ts` — serialize the reference as `- type: raw_app, path: …`.
- `shared.test.ts` + `global/core.test.ts` — extend the existing workspace-item serialization tests to cover the new `workspace_app` → `raw_app` output.

## Screenshots
Verified in GLOBAL chat (`raw-app-parser` workspace) via Playwright.

The `@` picker now shows an **Apps** branch (previously only Flows/Scripts):

![1-picker-root.png](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-app-context-picker/1782409513-1-picker-root.png)

Drilling into `Apps › u/admin` lists the raw app `test_app`:

![2-apps-branch-rawapp.png](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-app-context-picker/1782409513-2-apps-branch-rawapp.png)

Selecting it inserts the `@u/admin/test_app` mention:

![3-mention-inserted.png](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-app-context-picker/1782409513-3-mention-inserted.png)

## Test plan
- [ ] In GLOBAL chat, in a workspace with **both** a raw app and a visual app, open the `@` picker → the Apps branch lists **only** the raw app.
- [ ] Pick a raw app → a dashboard-icon badge appears with the app path and `@path` mention is inserted.
- [ ] In a non-global chat (script/flow editor), the `@` picker shows **no** Apps branch.
- [ ] `npx vitest run src/lib/components/copilot/chat/shared.test.ts src/lib/components/copilot/chat/global/core.test.ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)