### PR TITLE
fix: opt out of Deno minimum-dependency-age for private npm registries

### DIFF
--- a/.github/workflows/backend-test-windows.yml
+++ b/.github/workflows/backend-test-windows.yml
@@ -58,7 +58,9 @@ jobs:
 
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          # Pin to the Deno version shipped in the runtime image (Dockerfile) so CI
+          # tests what production runs, instead of floating on the latest v2.x.
+          deno-version: 2.2.1
 
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -50,7 +50,9 @@ jobs:
           dotnet-version: "9.0.x"
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          # Pin to the Deno version shipped in the runtime image (Dockerfile) so CI
+          # tests what production runs, instead of floating on the latest v2.x.
+          deno-version: 2.2.1
       - uses: actions/setup-go@v2
         with:
           go-version: 1.21.5

--- a/backend/windmill-worker/src/deno_executor.rs
+++ b/backend/windmill-worker/src/deno_executor.rs
@@ -434,7 +434,11 @@ try {{
     if let Some(ref npmrc_content) = npmrc {
         if !npmrc_content.trim().is_empty() {
             write_file(job_dir, ".npmrc", npmrc_content)?;
-            write_file(job_dir, "deno.json", "{}")?;
+            // minimumDependencyAge=0 opts out of Deno's supply-chain guard that rejects
+            // npm packages published within the last ~24h. Private/internal registries
+            // routinely serve just-published versions, so the guard would break them.
+            // Older Deno ignores the unknown field, so this is safe across versions.
+            write_file(job_dir, "deno.json", r#"{"minimumDependencyAge":"0"}"#)?;
         }
     }
 


### PR DESCRIPTION
## Summary

CI's `test_deno_job_private_npmrc` started failing because the backend-test workflows install Deno with `deno-version: v2.x` (unpinned), so CI silently floated onto a Deno release that ships the new **minimum dependency age** supply-chain guard. That guard rejects any npm package version published in the last ~24h:

```
error: Could not find npm package '@windmill-test/private-pkg' matching '*'.
A newer matching version was found, but it was not used because it was newer than
the specified minimum dependency date of 2026-06-24 17:03:54 UTC.
```

The test publishes its private package to a local verdaccio registry *during the run*, so the package is always "too new" and gets rejected. This is not a random flake — it recurs whenever CI's floating Deno is past the version that turned this on. It's also a latent prod bug: private/internal registries routinely serve just-published versions, so once the shipped runtime Deno is bumped past this version, real users installing fresh private packages would hit the same wall.

## Changes

- `backend/windmill-worker/src/deno_executor.rs`: on the private-registry (`npmrc`) path, the per-job `deno.json` now emits `{"minimumDependencyAge":"0"}` instead of `{}`, opting out of the guard. Older Deno ignores the unknown field, so this is safe across versions.
- `.github/workflows/backend-test.yml` & `backend-test-windows.yml`: pin `deno-version` from `v2.x` to `2.2.1`, matching the runtime image (`Dockerfile:281`), so CI tests what production runs instead of floating onto new Deno releases.

## Test plan

- [ ] `test_deno_job_private_npmrc` passes on the Linux backend-test CI job
- [ ] `test_deno_job_private_npmrc` passes on the Windows backend-test CI job
- [ ] Both jobs report Deno 2.2.1 in the `deno --version` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opt out of Deno’s new minimum dependency age check for private npm registries and pin CI to the runtime Deno version. Prevents failures when installing freshly published private packages in CI and production.

- **Bug Fixes**
  - When a job uses a private `npmrc`, write `deno.json` with `{"minimumDependencyAge":"0"}` so Deno accepts just-published packages; older Deno ignores the field.

- **Dependencies**
  - Pin `deno-version` in backend test workflows to `2.2.1` (matches the runtime image) instead of floating on `v2.x`.

<sup>Written for commit ea14ba227ad5369acdeeafac9381f5a70780af92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

