### PR TITLE
fix(frontend): clarify instance data table unavailable on cloud (WIN-2104)

### DIFF
--- a/frontend/src/lib/components/workspaceSettings/DataTableSettings.svelte
+++ b/frontend/src/lib/components/workspaceSettings/DataTableSettings.svelte
@@ -73,6 +73,8 @@
 	import { deepEqual } from 'fast-equals'
 	import { clone } from '$lib/utils'
 	import SettingsFooter from './SettingsFooter.svelte'
+	import Alert from '../common/alert/Alert.svelte'
+	import { isCloudHosted } from '$lib/cloud'
 
 	type Props = {
 		dataTableSettings: DataTableSettingsType
@@ -185,6 +187,14 @@
 	link="https://www.windmill.dev/docs/core_concepts/persistent_storage/data_tables"
 />
 
+{#if isCloudHosted()}
+	<Alert type="info" title="Instance database not available on cloud" class="mb-4" size="xs">
+		On Windmill Cloud, data tables cannot use the Windmill instance database. Select
+		<span class="font-semibold">PostgreSQL</span> and provide an external PostgreSQL resource (e.g. Supabase
+		or Neon) instead.
+	</Alert>
+{/if}
+
 <DataTable>
 	<Head>
 		<tr>
@@ -227,7 +237,12 @@
 									{
 										value: 'instance',
 										label: 'Instance',
-										subtitle: $isCustomInstanceDbEnabled ? undefined : 'Superadmin only'
+										disabled: isCloudHosted(),
+										subtitle: $isCustomInstanceDbEnabled
+											? undefined
+											: isCloudHosted()
+												? 'Not available on cloud'
+												: 'Superadmin only'
 									}
 								]}
 								bind:value={


### PR DESCRIPTION
## What & why

On Windmill Cloud, data tables cannot use the Windmill **instance** database — they require an external PostgreSQL resource (e.g. Supabase, Neon). The database-type picker previously labelled the "Instance" option only as **"Superadmin only"**, which is misleading on cloud where the instance DB can never be enabled regardless of role.

Fixes WIN-2104.

## Changes

`frontend/src/lib/components/workspaceSettings/DataTableSettings.svelte`:
- On cloud, the **"Instance"** database-type option is now **disabled** with the subtitle **"Not available on cloud"** (off-cloud it still reads "Superadmin only" when not enabled).
- Added an info **Alert** at the top of the Data tables settings explaining that on cloud you must select PostgreSQL and provide an external resource.
- Off-cloud behaviour is unchanged.

## Validation

- `svelte-check` — no new errors for the changed file (pre-existing repo-wide `Timeout`/`number` warnings are unrelated).
- Verified both states in the browser with Playwright:
  - **Off-cloud (superadmin, local):** both "PostgreSQL" and "Instance" remain selectable — no regression.
  - **On-cloud (temporarily forced `isCloudHosted()` for the screenshot, then reverted):** alert shown, new data tables default to PostgreSQL, "Instance" greyed out with "Not available on cloud".

### Screenshots (cloud state)

![datatable-cloud-alert](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2104-on-cloud-make-it-clearer-that-instance-level-datatable-is/1782449132-datatable-cloud-alert.png)

![datatable-cloud-dropdown](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2104-on-cloud-make-it-clearer-that-instance-level-datatable-is/1782449134-datatable-cloud-dropdown.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that the instance database can't be used for data tables on Windmill Cloud. Fixes WIN-2104.

- **Bug Fixes**
  - On cloud, disable the "Instance" database option with subtitle "Not available on cloud".
  - Add an info alert explaining to select PostgreSQL and provide an external resource (e.g., Supabase, Neon).
  - Off-cloud behavior remains unchanged.

<sup>Written for commit 639a6083b9bd5ff710ee65a94396c8ba82785871. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

