### PR TITLE
fix(frontend): use sidebar worker icon for runs queue indicator

### DIFF
--- a/frontend/src/lib/components/runs/RunsQueue.svelte
+++ b/frontend/src/lib/components/runs/RunsQueue.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Tweened } from 'svelte/motion'
 	import { Button } from '../common'
-	import { Bot, Hourglass, ListFilterPlus, X } from 'lucide-svelte'
+	import { ServerCog, Hourglass, ListFilterPlus, X } from 'lucide-svelte'
 	import RunOption from './RunOption.svelte'
 	import { Popover } from '../meltComponents'
 
@@ -29,7 +29,7 @@
 		<Popover contentClasses="p-4" openOnHover debounceDelay={100}>
 			{#snippet trigger()}
 				<div class="relative">
-					<Bot size={16} />
+					<ServerCog size={16} />
 					{#if queue_count && ($queue_count ?? 0) > 0}
 						<div
 							class="absolute top-0 right-0 translate-x-1/2 -translate-y-1/2 bg-yellow-500 rounded-full text-white text-2xs h-4 min-w-4 px-1"


### PR DESCRIPTION
## Summary
The "Waiting for workers" indicator in the Runs page top bar used the `Bot` icon, which didn't match the sidebar's **Workers** menu entry (which uses `ServerCog`). This swaps it to `ServerCog` so the worker icon is consistent across the app.

## Changes
- `frontend/src/lib/components/runs/RunsQueue.svelte`: replace the `Bot` lucide icon with `ServerCog` (import + usage site) for the "Waiting for workers" queue popover trigger.

While auditing, I confirmed the other `Bot` usages are correct and left them untouched — they represent service accounts (a service account *is* a bot) and AI agents/MCP/AI tools (Bot = AI), not workers. The runs page worker *filter* already used `ServerCog`.

## Screenshots
![runs-worker-icon](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-worker-icon/1782459199-v2-runs-worker-icon.png)

## Test plan
- [ ] Open the Runs page with at least one job queued waiting for a worker
- [ ] Confirm the queue indicator renders the `ServerCog` icon (matching the Workers item in the sidebar) with the yellow count badge still at the top-right
- [ ] Hover to confirm the "Waiting for workers" popover still triggers