### PR TITLE
fix: remove data pipelines link from assets page

### DIFF
--- a/frontend/src/routes/(root)/(logged)/assets/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/assets/+page.svelte
@@ -40,8 +40,7 @@
 	import { untrack } from 'svelte'
 	import { VolumeService } from '$lib/gen'
 	import VolumesDrawer from '$lib/components/assets/VolumesDrawer.svelte'
-	import { HardDriveIcon, NetworkIcon } from 'lucide-svelte'
-	import { base } from '$lib/base'
+	import { HardDriveIcon } from 'lucide-svelte'
 
 	interface AssetCursor {
 		created_at?: string
@@ -162,18 +161,7 @@
 			title="Assets"
 			tooltip="Assets show up here whenever you use them in Windmill."
 			documentationLink="https://www.windmill.dev/docs/core_concepts/assets"
-		>
-			<div class="flex justify-end">
-				<Button
-					variant="accent-secondary"
-					unifiedSize="sm"
-					href="{base}/pipeline"
-					startIcon={{ icon: NetworkIcon }}
-				>
-					Pipelines
-				</Button>
-			</div>
-		</PageHeader>
+		/>
 
 		<Section label="All workspace assets" class="mb-20">
 			<div class="flex gap-4">


### PR DESCRIPTION
## Summary
Removes the "Pipelines" navigation button from the assets page header. The assets page no longer surfaces a link into the data pipelines view.

## Changes
- Remove the "Pipelines" `<Button>` (the `accent-secondary` button linking to `/pipeline`) from the `PageHeader` in `frontend/src/routes/(root)/(logged)/assets/+page.svelte`; `PageHeader` is now self-closing since the button was its only child.
- Drop the now-unused `NetworkIcon` (the button's icon) and `base` (used only for the `{base}/pipeline` href) imports. `Button`, `PageHeader`, and `HardDriveIcon` remain as they are still used elsewhere in the file.

Note: this only removes the entry point from the assets page — the `/pipeline` route and its components are untouched.

## Screenshots
![assets-no-pipelines](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/remove-pipelines-from-assets/1782463507-assets-no-pipelines.png)

## Test plan
- [ ] Load `/assets` and confirm the header shows only the "Assets" title (with tooltip) and no "Pipelines" button
- [ ] Confirm the page renders without console errors and the asset list / object-storage cards / refresh still work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the "Pipelines" button from the Assets page header so the Assets view no longer links to data pipelines. Cleaned up unused `NetworkIcon` and `base` imports and made `PageHeader` self-closing; the `/pipeline` route remains unchanged.

<sup>Written for commit 01e9fb197ea4443ceccd504614685bff4065cb2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

