### PR TITLE
feat: apply step timeout to 'Test this step' preview

### DIFF
--- a/frontend/src/lib/components/ModuleTest.svelte
+++ b/frontend/src/lib/components/ModuleTest.svelte
@@ -56,6 +56,16 @@
 		runTestWithStepArgs()
 	}
 
+	// A step's timeout is an InputTransform. Only a static numeric value can be applied
+	// to a single-step preview; dynamic expressions are evaluated server-side and only
+	// take effect when running the full flow.
+	function staticTimeout(timeout: FlowModule['timeout']): number | undefined {
+		if (timeout?.type === 'static' && typeof timeout.value === 'number') {
+			return timeout.value
+		}
+		return undefined
+	}
+
 	export async function runTest(args: any) {
 		// Not defined if JobProgressBar not loaded
 		if (jobProgressReset) jobProgressReset()
@@ -68,6 +78,7 @@
 		}
 
 		const val = mod.value
+		const timeout = staticTimeout(mod.timeout)
 		// let jobId: string | undefined = undefined
 		let callbacks: Callbacks = {
 			done: (x) => {
@@ -86,7 +97,8 @@
 				callbacks,
 				$pathStore,
 				undefined,
-				devTempScriptRefs?.()
+				devTempScriptRefs?.(),
+				timeout
 			)
 		} else if (val.type == 'script') {
 			const script = val.hash
@@ -101,7 +113,10 @@
 				script.lock,
 				val.hash ?? script.hash,
 				callbacks,
-				$pathStore
+				$pathStore,
+				undefined,
+				undefined,
+				timeout
 			)
 		} else if (val.type == 'flow') {
 			await jobLoader?.runFlowByPath(val.path, args, callbacks)

--- a/frontend/src/lib/components/flows/content/FlowModuleTimeout.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleTimeout.svelte
@@ -108,9 +108,14 @@
 		{/if}
 	</Label>
 
-	<div class="mt-4">
-		<Alert title="Only used when testing the full flow" type="info">
-			<p class="text-xs"> The timeout will be ignored when running "Test this step" </p>
-		</Alert>
-	</div>
+	{#if flowModule.timeout && flowModule.timeout.type !== 'static'}
+		<div class="mt-4">
+			<Alert title="Dynamic timeout only used when testing the full flow" type="info">
+				<p class="text-xs">
+					A dynamic timeout expression is evaluated when running the full flow. It is ignored when
+					running "Test this step" — only a static timeout value applies there.
+				</p>
+			</Alert>
+		</div>
+	{/if}
 </Section>


### PR DESCRIPTION
## Summary

A flow module's per-step **timeout** (configured under Step settings → Advanced → Runtime → Timeout) was previously ignored when running **"Test this step"**. Single-step previews ran with no timeout, so a step that would be killed in the full flow would run unbounded when tested in isolation.

This wires the static step timeout into the single-step preview request. The backend `run_preview_script` already accepts and applies a `timeout` query param, and `JobLoader.runPreview` already forwards it — only `ModuleTest.runTest` was not passing it.

A step timeout is an `InputTransform`. Only a **static numeric** value can be applied to a single-step preview; **dynamic** (`javascript`) timeout expressions are evaluated server-side and still only take effect in a full-flow run.

## Changes

- `ModuleTest.svelte`: add a `staticTimeout()` helper that extracts the numeric value from a static timeout `InputTransform`, and pass it as the `timeout` argument to `jobLoader.runPreview(...)` for both `rawscript` and `script` module types.
- `FlowModuleTimeout.svelte`: the alert that said *"The timeout will be ignored when running 'Test this step'"* now shows **only when the timeout is a dynamic expression** (where it genuinely still doesn't apply to single-step previews). For a static timeout the alert is gone, since the timeout now applies.

## Test plan

- [x] `npm run check:fast` — no new errors in the changed files (pre-existing `Timeout`/`number` errors elsewhere are unrelated).
- [x] Manual E2E: flow with a Bash step `sleep 30`, static step timeout = 5s, then "Test this step":
  - The preview request fired as `POST /api/w/admins/jobs/run/preview?timeout=5`.
  - The job was terminated at ~6s with `job process terminated due to timeout after exceeding job-specific duration limit` (logs show "Terminating child processes…"). Without this change it would have run the full 30s.

## Screenshots

"Test this step" on a `sleep 30` Bash step with a 5-second static step timeout — the job is killed at the timeout:

![bash-timeout-result](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/step-timeout-preview/1782467569-bash-timeout-result.png)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply per-step timeout to “Test this step” so previews respect static numeric timeouts and don’t run unbounded. Dynamic timeout expressions still only apply in full-flow runs.

- **New Features**
  - Pass static numeric step timeout to preview requests for `rawscript` and `script`.
  - Show the timeout info alert only for dynamic expressions; hide it for static values.

<sup>Written for commit 92bd638a895dcaf084da61a445961382f5292488. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

