### PR TITLE
fix: hide delete button on branchone default node

### DIFF
--- a/frontend/src/lib/components/graph/renderers/nodes/BranchOneStart.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/BranchOneStart.svelte
@@ -34,7 +34,7 @@
 				setTimeout(() => data?.eventHandlers?.select(data.id))
 			}}
 		/>
-		{#if data.insertable}
+		{#if data.insertable && data.branchIndex >= 0}
 			<button
 				title="Delete branch"
 				class="z-50 absolute -translate-y-[100%] top-1 -right-1 rounded-md p-1 center-center text-primary


### PR DESCRIPTION
## Summary
The "Default" node of a branch-one step had a "Delete branch" button it shouldn't have — and clicking it was destructive. The default branch is the structurally-required else branch (stored separately from the `branches[]` array) and cannot be removed.

The default node is built with `branchIndex: -1`. Its delete button called `deleteBranch` with `index: 0`, which in `removeBranch` (branchone `offset = 1`) became `branches.splice(0 - 1, 1)` = `branches.splice(-1, 1)` — silently deleting the **last** explicit branch instead.

## Changes
- `frontend/src/lib/components/graph/renderers/nodes/BranchOneStart.svelte`: gate the delete button on `data.branchIndex >= 0`, so it only renders on explicit branches and never on the default node.

`BranchAllStart.svelte` has no default-node concept (`offset = 0`) and is unaffected.

## Screenshots
Branch-one with the default branch + one explicit branch. The **Default** node (left) has no delete affordance; **Branch 1** (right) keeps its `X` delete button at the top-right:

![branchone-default-no-delete](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-default-branch-node-delete/1782468909-branchone-default-no-delete.png)

## Test plan
- [ ] Open a flow with a branch-one that has the default branch plus two or more explicit branches.
- [ ] Hover the "Default" start node — the red "Delete branch" (X) button no longer appears.
- [ ] Clicking the "Default" node still selects it normally.
- [ ] Delete an explicit branch and confirm the correct branch is removed (not the last one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the Delete branch button on the BranchOne Default node to prevent removing the required else branch and the unintended deletion of the last explicit branch.

- **Bug Fixes**
  - Render the delete button only for explicit branches using `data.insertable && data.branchIndex >= 0` in `frontend/src/lib/components/graph/renderers/nodes/BranchOneStart.svelte`.

<sup>Written for commit 344152ceca13ecbb52d818c62ab2c86f72aa7e42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

