### PR TITLE
fix: hide GCS service account key behind a reveal in object storage settings

### DIFF
--- a/frontend/src/lib/components/ObjectStoreConfigSettings.svelte
+++ b/frontend/src/lib/components/ObjectStoreConfigSettings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Database, HardDrive, Loader2, Trash2 } from 'lucide-svelte'
+	import { Database, Eye, EyeOff, HardDrive, Loader2, Trash2 } from 'lucide-svelte'
 	import { onDestroy } from 'svelte'
 	import Toggle from './Toggle.svelte'
 	import { Button, Tab, Tabs } from './common'
@@ -227,6 +227,16 @@
 		stopPolling()
 		stopUsagePolling()
 	})
+
+	// The GCS service account key JSON contains the secret `private_key`, so the
+	// editor that reveals it in plain text is hidden behind an explicit opt-in
+	// rather than rendered on page load whenever a key is already configured.
+	let showServiceAccountKey = $state(false)
+	let hasServiceAccountKey = $derived(
+		bucket_config?.type === 'Gcs' &&
+			!!bucket_config.serviceAccountKey &&
+			Object.keys(bucket_config.serviceAccountKey).length > 0
+	)
 
 	let simpleEditor: SimpleEditor | undefined = $state(undefined)
 	let serviceAccountKeyCode = $state(
@@ -681,27 +691,57 @@
 				</Label>
 				<Label label="Service Account Key">
 					<span class="text-primary text-2xs">JSON content of the service account key file</span>
-					<SimpleEditor
-						bind:this={simpleEditor}
-						lang="json"
-						bind:code={serviceAccountKeyCode}
-						on:change={(e) => {
-							if (bucket_config?.type === 'Gcs') {
-								if (e.detail.code === undefined || e.detail.code === '') {
-									bucket_config = { ...bucket_config, serviceAccountKey: undefined }
-									return
+					{#if hasServiceAccountKey && !showServiceAccountKey}
+						<div class="flex items-center gap-3 mt-1">
+							<span class="text-tertiary text-xs">
+								A service account key is configured and hidden as it contains a private key.
+							</span>
+							<Button
+								spacingSize="sm"
+								size="xs"
+								variant="border"
+								startIcon={{ icon: Eye }}
+								on:click={() => (showServiceAccountKey = true)}
+							>
+								Show sensitive values
+							</Button>
+						</div>
+					{:else}
+						{#if hasServiceAccountKey}
+							<div class="flex justify-end mb-1">
+								<Button
+									spacingSize="sm"
+									size="xs"
+									variant="border"
+									startIcon={{ icon: EyeOff }}
+									on:click={() => (showServiceAccountKey = false)}
+								>
+									Hide
+								</Button>
+							</div>
+						{/if}
+						<SimpleEditor
+							bind:this={simpleEditor}
+							lang="json"
+							bind:code={serviceAccountKeyCode}
+							on:change={(e) => {
+								if (bucket_config?.type === 'Gcs') {
+									if (e.detail.code === undefined || e.detail.code === '') {
+										bucket_config = { ...bucket_config, serviceAccountKey: undefined }
+										return
+									}
+									try {
+										const parsed = JSON.parse(e.detail.code ?? '{}')
+										lastEditorSyncedJson = JSON.stringify(parsed)
+										bucket_config = { ...bucket_config, serviceAccountKey: parsed }
+									} catch (_) {
+										bucket_config = { ...bucket_config, serviceAccountKey: undefined }
+									}
 								}
-								try {
-									const parsed = JSON.parse(e.detail.code ?? '{}')
-									lastEditorSyncedJson = JSON.stringify(parsed)
-									bucket_config = { ...bucket_config, serviceAccountKey: parsed }
-								} catch (_) {
-									bucket_config = { ...bucket_config, serviceAccountKey: undefined }
-								}
-							}
-						}}
-						class="h-80"
-					/>
+							}}
+							class="h-80"
+						/>
+					{/if}
 				</Label>
 			{:else}
 				<div>Unknown bucket type {bucket_config['type']}</div>


### PR DESCRIPTION
## Summary

Fixes WIN-2106.

In Instance settings → Object Storage, when GCS is configured the service account key JSON — including its secret `private_key` — was rendered unmasked in the editor on every page load. S3 `secret_key` and Azure `accessKey` use `type="password"` inputs, but the GCS key is a multiline JSON object pasted whole, so it was the exception.

Rather than masking just the `private_key` inside the JSON (which requires a fragile mask/restore round-trip), this gates the **whole editor** behind an explicit reveal. When a key is already configured, the editor is hidden by default and a **Show sensitive values** button reveals it; a **Hide** button collapses it again. Because the editor isn't rendered while hidden, the `private_key` is not in the DOM on load.

`bucket_config.serviceAccountKey` keeps the real value whether or not the editor is mounted, so saving any other field while the key is hidden round-trips the credential untouched — no masking/sentinel logic, and no data-loss edge cases.

This is visual-only protection (the key is still in the settings payload sent to the browser); it guards against on-screen exposure on the superadmin-only settings page, consistent with the issue's intent.

## Changes

- `frontend/src/lib/components/ObjectStoreConfigSettings.svelte`:
  - When a service account key is already configured, hide the JSON editor by default behind a "Show sensitive values" reveal (Eye icon), with a "Hide" button (EyeOff icon) to collapse it again.
  - A fresh/empty config still shows the editor directly so the key can be pasted.
  - `on:change` is the plain parse-and-store (no mask/restore), since the editor only ever holds real values.

## Test plan

Verified end-to-end with Playwright against a local EE instance (GCS config seeded via DB):

- [x] Key configured → editor hidden on load; notice + "Show sensitive values" button shown; `private_key` not in the DOM
- [x] Click "Show sensitive values" → full JSON editor (with real key) appears, plus a "Hide" button
- [x] Click "Hide" → editor unmounts, reveal button returns (round-trips both ways)
- [x] Edit an unrelated field (bucket) while hidden and save → real `private_key` preserved (verified in the Review-changes diff: real key present, no sentinel)
- [x] Fresh config (no key) → editor shown directly for pasting
- [x] `npm run check:fast` — no new type errors in the changed file

## Screenshots

Service account key hidden by default (with reveal button):

![gcs-hidden](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2106-mask-gcs-service-account-key-in-object-storage-instance/1782477992-gcs-hidden.png)

After clicking "Show sensitive values" (editor revealed, with Hide button):

![gcs-revealed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2106-mask-gcs-service-account-key-in-object-storage-instance/1782477992-gcs-revealed.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)