### PR TITLE
test: de-flake asset-dispatch by bypassing cross-DB script-hash caches

### DIFF
--- a/backend/tests/asset_trigger_dispatch.rs
+++ b/backend/tests/asset_trigger_dispatch.rs
@@ -54,6 +54,14 @@ async fn seed_script(
     .bind(language)
     .execute(db)
     .await?;
+    // These tests use #[sqlx::test] isolated DBs that share one workspace id and
+    // reuse script paths, while the same path is seeded with different content
+    // (hence different hashes) across tests. The process-global deployed-script
+    // caches are keyed by (workspace, path)/(workspace, hash), so a concurrent
+    // test resolves a path to a hash that lives in another test's DB and the
+    // dispatch 404s. Disable them so every resolution reads the test's own DB.
+    windmill_common::DEPLOYED_SCRIPT_CACHE_DISABLED
+        .store(true, std::sync::atomic::Ordering::Relaxed);
     Ok(h)
 }
 

--- a/backend/windmill-common/src/lib.rs
+++ b/backend/windmill-common/src/lib.rs
@@ -285,6 +285,16 @@ lazy_static::lazy_static! {
 
 const LATEST_VERSION_ID_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(60);
 
+/// Test hook: disables the process-global deployed-script hash/info caches so
+/// every resolution reads the current DB. Integration tests use `#[sqlx::test]`
+/// isolated DBs that share one workspace id and reuse script paths, so a cache
+/// keyed by `(workspace, path)`/`(workspace, hash)` resolves a path to a hash
+/// that lives in a *different* test's DB — and when the info cache misses for
+/// that foreign hash the lookup 404s in the wrong DB. Always `false` in
+/// production (the caches are TTL/LRU-bounded against real deploys).
+pub static DEPLOYED_SCRIPT_CACHE_DISABLED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 pub async fn shutdown_signal(
     tx: KillpillSender,
     mut rx: tokio::sync::broadcast::Receiver<()>,
@@ -1305,8 +1315,12 @@ pub fn get_latest_deployed_hash_for_path<'e>(
 ) -> impl Future<Output = error::Result<ScriptHashInfo<ScriptRunnableSettingsHandle>>> + Send + 'e {
     async move {
         let cache_key = (w_id.to_string(), script_path.to_string());
+        let use_cache = !DEPLOYED_SCRIPT_CACHE_DISABLED.load(std::sync::atomic::Ordering::Relaxed);
         let mut computed_hash = None;
-        let hash = match DEPLOYED_SCRIPT_HASH_CACHE.get(&cache_key) {
+        let hash = match DEPLOYED_SCRIPT_HASH_CACHE
+            .get(&cache_key)
+            .filter(|_| use_cache)
+        {
             Some(cached_hash)
                 if cached_hash.expires_at > std::time::Instant::now()
                     && db.as_ref().is_none_or(|x| {
@@ -1349,13 +1363,15 @@ pub fn get_latest_deployed_hash_for_path<'e>(
                 };
 
                 let hash = utils::not_found_if_none(hash, "script", script_path)?;
-                DEPLOYED_SCRIPT_HASH_CACHE.insert(
-                    cache_key,
-                    ExpiringLatestVersionId {
-                        id: hash,
-                        expires_at: std::time::Instant::now() + LATEST_VERSION_ID_CACHE_TTL,
-                    },
-                );
+                if use_cache {
+                    DEPLOYED_SCRIPT_HASH_CACHE.insert(
+                        cache_key,
+                        ExpiringLatestVersionId {
+                            id: hash,
+                            expires_at: std::time::Instant::now() + LATEST_VERSION_ID_CACHE_TTL,
+                        },
+                    );
+                }
 
                 hash
             }
@@ -1387,9 +1403,10 @@ pub async fn get_script_info_for_hash<'e, E: sqlx::PgExecutor<'e>>(
     hash: i64,
 ) -> error::Result<ScriptHashInfo<ScriptRunnableSettingsHandle>> {
     let key = (w_id.to_string(), hash);
+    let use_cache = !DEPLOYED_SCRIPT_CACHE_DISABLED.load(std::sync::atomic::Ordering::Relaxed);
 
     let mut computed_hash = None;
-    match DEPLOYED_SCRIPT_INFO_CACHE.get(&key) {
+    match DEPLOYED_SCRIPT_INFO_CACHE.get(&key).filter(|_| use_cache) {
         Some(info)
             if db_authed.as_ref().is_none_or(|x| {
                 let r = HASH_PERMS_CACHE.check_perms_in_cache(x.authed, scripts::ScriptHash(hash));
@@ -1418,7 +1435,9 @@ pub async fn get_script_info_for_hash<'e, E: sqlx::PgExecutor<'e>>(
 
             let info = utils::not_found_if_none(info, "script", &hash.to_string())?;
 
-            DEPLOYED_SCRIPT_INFO_CACHE.insert(key, info.clone());
+            if use_cache {
+                DEPLOYED_SCRIPT_INFO_CACHE.insert(key, info.clone());
+            }
 
             Ok(info)
         }


### PR DESCRIPTION
## Summary

De-flakes the backend integration test `asset_trigger_dispatch::debounce_setting_applied_to_dispatched_subscriber`, which intermittently failed in CI with `assert_eq!(r.dispatched.len(), 2)` getting `left: 1, right: 2` (one subscriber silently dropped).

## Root cause

`seed_script` hashes **path + content** deterministically (intentional, to keep the hash-keyed script-content cache benign across DBs). But the path `u/test-user/sub-s3` is seeded with **different content** in different tests (`"echo debounced"`, `"echo s3-subscriber"`, `"echo retrying"`), producing three distinct hashes that each exist only in their own `#[sqlx::test]` isolated DB.

Two process-global `quick_cache` caches in `windmill-common/src/lib.rs` are shared across all tests (every test uses workspace `test-workspace`):
- `DEPLOYED_SCRIPT_HASH_CACHE` — keyed `(workspace, path)`, 60s TTL
- `DEPLOYED_SCRIPT_INFO_CACHE` — keyed `(workspace, hash)`, LRU

Under concurrency, a sibling test resolves `(test-workspace, sub-s3)` to a **foreign** hash from another test's DB. When the info cache then misses for that hash, `get_script_info_for_hash_inner` 404s against the current test's DB → `push_subscriber` returns `Err` (swallowed and logged in `asset_dispatch.rs`) → that subscriber is dropped → count `1` instead of `2`.

`scoped_cache` (enabled in CI) does **not** isolate these — they are plain `quick_cache`, not the fs-backed caches that `scoped_cache` makes thread-local. So the flake reproduces even in CI.

## Changes

- Add `DEPLOYED_SCRIPT_CACHE_DISABLED: AtomicBool` (default `false`) in `windmill-common/src/lib.rs`, gating both deployed-script caches' read and write. Always `false` in production (a single relaxed atomic load on the hot path).
- Set the flag in the test's `seed_script`, so every test bypasses these caches and reads its own isolated DB. Mirrors the existing `ASSET_PRODUCER_CACHE_DISABLED` pattern already used in this file.

## Test plan

- [x] `cargo test -p windmill --no-default-features --features enterprise,deno_core,duckdb,license,python,rust,scoped_cache,parquet,private,csharp,php,quickjs,mcp,run_inline --test asset_trigger_dispatch` — all 8 tests pass, including the previously-flaking one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky asset dispatch integration test by disabling cross-DB deployed-script caches during tests. Ensures each test resolves scripts from its own DB, preventing dropped subscribers.

- **Bug Fixes**
  - Added `DEPLOYED_SCRIPT_CACHE_DISABLED` `AtomicBool` in `windmill-common` to gate `DEPLOYED_SCRIPT_HASH_CACHE` and `DEPLOYED_SCRIPT_INFO_CACHE` reads/writes.
  - Set the flag in `asset_trigger_dispatch::seed_script` to bypass caches for `#[sqlx::test]` isolated DBs.
  - No production impact: defaults to `false` with a single relaxed atomic load on the hot path.

<sup>Written for commit e974ef18abe9b1451532917b1c002ec3f20575d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

