### PR TITLE
fix: skipped suspend step no longer parks the flow forever

### DIFF
--- a/backend/tests/suspend_resume.rs
+++ b/backend/tests/suspend_resume.rs
@@ -628,4 +628,54 @@ mod suspend_resume {
         );
         Ok(())
     }
+
+    /// A step that declares a `suspend` but is skipped via `skip_if` never arms
+    /// its approval, so it must not gate the following step. Before the fix,
+    /// `needs_resume` treated the skipped step's `Success` status as a real
+    /// suspend and parked the flow forever waiting for a resume that never came.
+    #[cfg(feature = "deno_core")]
+    #[sqlx::test(fixtures("base"))]
+    async fn skipped_suspend_step_does_not_block_next_step(
+        db: Pool<Postgres>,
+    ) -> anyhow::Result<()> {
+        initialize_tracing().await;
+
+        let server = ApiServer::start(db.clone()).await?;
+
+        let flow: FlowValue = serde_json::from_value(json!({
+            "modules": [
+                {
+                    "id": "a",
+                    "skip_if": { "type": "javascript", "expr": "true" },
+                    "suspend": { "required_events": 1, "timeout": 86400 },
+                    "value": {
+                        "type": "rawscript",
+                        "language": "deno",
+                        "content": "export async function main() { return 1 }",
+                        "input_transforms": {},
+                    },
+                },
+                {
+                    "id": "b",
+                    "value": {
+                        "type": "rawscript",
+                        "language": "deno",
+                        "content": "export async function main() { return 42 }",
+                        "input_transforms": {},
+                    },
+                },
+            ],
+        }))
+        .unwrap();
+
+        let result =
+            RunJob::from(JobPayload::RawFlow { value: flow, path: None, restarted_from: None })
+                .run_until_complete(&db, false, server.addr.port())
+                .await
+                .json_result()
+                .unwrap();
+
+        assert_eq!(result, json!(42));
+        Ok(())
+    }
 }

--- a/backend/tests/suspend_resume.rs
+++ b/backend/tests/suspend_resume.rs
@@ -630,9 +630,8 @@ mod suspend_resume {
     }
 
     /// A step that declares a `suspend` but is skipped via `skip_if` never arms
-    /// its approval, so it must not gate the following step. Before the fix,
-    /// `needs_resume` treated the skipped step's `Success` status as a real
-    /// suspend and parked the flow forever waiting for a resume that never came.
+    /// its approval, so it must not gate the following step. If it did, the flow
+    /// would park forever waiting for a resume event that is never dispatched.
     #[cfg(feature = "deno_core")]
     #[sqlx::test(fixtures("base"))]
     async fn skipped_suspend_step_does_not_block_next_step(

--- a/backend/windmill-worker/src/worker_flow.rs
+++ b/backend/windmill-worker/src/worker_flow.rs
@@ -6211,8 +6211,15 @@ fn needs_resume(flow: &FlowValue, status: &FlowStatus) -> Option<(Suspend, Uuid)
         return None;
     }
 
-    if let &FlowStatusModule::Success { job, .. } = status.modules.get(prev)? {
-        Some((suspend.unwrap(), job))
+    if let &FlowStatusModule::Success { job, skipped, .. } = status.modules.get(prev)? {
+        // A step skipped via skip_if never ran, so its suspend/approval was never
+        // armed and no resume event will ever arrive. Gating the next step on it
+        // would park the flow forever.
+        if skipped {
+            None
+        } else {
+            Some((suspend.unwrap(), job))
+        }
     } else {
         None
     }


### PR DESCRIPTION
## Summary

A flow step that declares a `suspend` (approval gate) but is skipped via `skip_if` was leaving the flow **stuck waiting for a resume that would never arrive** — surfacing as a flow "occasionally stuck on a step with a predicate" (reported on v1.711.0).

Suspend gates the *next* step: before pushing step N, `needs_resume()` checks whether step N-1 declared a non-zero `suspend` and finished as `Success`. A step skipped via `skip_if` is also recorded as `FlowStatusModule::Success` (with `skipped: true`), so `needs_resume` treated a *skipped* approval gate as a real one and parked the flow waiting for an event that nothing ever sends — until the suspend timeout (up to 24h).

The bug is most visible when the skipped suspend step is followed by a branch/sub-flow: the flow appears stuck on the *following* predicate node with a generic resume button, while none of the branch/sub-flow steps actually ran.

## Changes

- `backend/windmill-worker/src/worker_flow.rs` — `needs_resume()` now binds and honors the `skipped` flag; a suspend declared on a skipped step no longer gates the next step.
- `backend/tests/suspend_resume.rs` — regression test `skipped_suspend_step_does_not_block_next_step`: step `a` has both `skip_if: true` and `suspend.required_events: 1`, step `b` returns `42`; asserts the flow completes with `42` instead of hanging.

## Test plan

- [x] New regression test passes with the fix (`cargo test --features deno_core,quickjs --test suspend_resume skipped_suspend_step_does_not_block_next_step`)
- [x] Same test **times out (60s)** without the fix — confirms it captures the hang
- [x] Live repro on dev instance: skipped suspend step → before fix the next step is `WaitingForEvents`/parked; after fix the flow completes
- [x] No regression: a non-skipped suspend step still correctly parks the next step (normal approval-gate behavior preserved)
- [x] Customer flow shape reproduced (plan-only run with skipped suspend gate → branchone): completes cleanly, and `branchone` correctly selects the `default` path when the predicate is false

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where a step with `suspend` that was skipped via `skip_if` parked the flow waiting for a resume that would never come. Skipped approval gates are now ignored, so the next step runs as expected.

- **Bug Fixes**
  - `needs_resume()` now checks the `skipped` flag and does not gate the next step when the previous step was skipped.
  - Added regression test `skipped_suspend_step_does_not_block_next_step` to ensure the flow completes and returns `42` instead of hanging.

<sup>Written for commit 0d2ce911a2bdb4be84ee556e7a0c1247dd63e149. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

