### PR TITLE
fix: redeploy older app version from deployment history

### DIFF
--- a/frontend/src/lib/components/apps/editor/AppEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditor.svelte
@@ -83,7 +83,8 @@
 		onResetToDeployed,
 		loadedFromDraft = false,
 		othersDraftsCount = 0,
-		onOpenOthersDrafts
+		onOpenOthersDrafts,
+		onRestore
 	}: AppEditorProps = $props()
 
 	migrateApp(untrack(() => app))
@@ -890,7 +891,7 @@
 			{loadedFromDraft}
 			{othersDraftsCount}
 			{onOpenOthersDrafts}
-			on:restore
+			{onRestore}
 			{policy}
 			{fromHub}
 			bind:this={appEditorHeader}

--- a/frontend/src/lib/components/apps/editor/AppEditorHeader.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeader.svelte
@@ -112,6 +112,10 @@
 		loadedFromDraft?: boolean
 		othersDraftsCount?: number
 		onOpenOthersDrafts?: () => void
+		// Restoring an older deployment from the history drawer. A callback prop
+		// (not `on:restore` forwarding): forwarding a `createEventDispatcher`
+		// event up through these runes-mode components silently drops it.
+		onRestore?: (restoredApp: any) => void
 	}
 
 	let {
@@ -137,7 +141,8 @@
 		onResetToDeployed,
 		loadedFromDraft = false,
 		othersDraftsCount = 0,
-		onOpenOthersDrafts
+		onOpenOthersDrafts,
+		onRestore
 	}: Props = $props()
 
 	/** Mirror of the path the user is editing in the pen popover. Initialized
@@ -862,7 +867,7 @@
 
 <Drawer bind:open={historyBrowserDrawerOpen} size="1200px">
 	<DrawerContent title="Deployment History" on:close={() => (historyBrowserDrawerOpen = false)}>
-		<DeploymentHistory on:restore appPath={$appPath} />
+		<DeploymentHistory on:restore={(e) => onRestore?.(e.detail)} appPath={$appPath} />
 	</DrawerContent>
 </Drawer>
 

--- a/frontend/src/lib/components/apps/types.ts
+++ b/frontend/src/lib/components/apps/types.ts
@@ -176,6 +176,10 @@ export interface AppEditorProps {
 	loadedFromDraft?: boolean
 	othersDraftsCount?: number
 	onOpenOthersDrafts?: () => void
+	// Restoring an older deployment from the history drawer. Threaded through
+	// AppEditorHeader as a callback prop rather than `on:restore` forwarding,
+	// which does not propagate through these runes-mode components.
+	onRestore?: (restoredApp: any) => void
 }
 
 export type App = {

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -121,6 +121,10 @@
 		onOpenOthersDrafts?: () => void
 		onRuntimeLogRequester?: (requester: RawAppRuntimeLogRequester | undefined) => void
 		onRunsProvider?: (provider: RawAppRunsProvider | undefined) => void
+		// Restoring an older deployment from the history drawer. A callback prop
+		// (not `on:restore` forwarding): forwarding a `createEventDispatcher`
+		// event up through these runes-mode components silently drops it.
+		onRestore?: (restoredApp: any) => void
 	}
 
 	let {
@@ -148,7 +152,8 @@
 		othersDraftsCount = 0,
 		onOpenOthersDrafts,
 		onRuntimeLogRequester = undefined,
-		onRunsProvider = undefined
+		onRunsProvider = undefined,
+		onRestore
 	}: Props = $props()
 	export const version: number | undefined = undefined
 
@@ -1596,7 +1601,7 @@
 		bind:savedApp
 		bind:summary
 		bind:pendingDraftPath
-		on:restore
+		{onRestore}
 		on:savedNewAppPath
 		{policy}
 		{diffDrawer}

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -125,6 +125,10 @@
 		// (not `on:restore` forwarding): forwarding a `createEventDispatcher`
 		// event up through these runes-mode components silently drops it.
 		onRestore?: (restoredApp: any) => void
+		// Deploy created the app at a new path; the page navigates to it. Callback
+		// prop for the same reason as `onRestore` — `on:savedNewAppPath` forwarding
+		// through these runes-mode components is dropped.
+		onSavedNewAppPath?: (path: string) => void
 	}
 
 	let {
@@ -153,7 +157,8 @@
 		onOpenOthersDrafts,
 		onRuntimeLogRequester = undefined,
 		onRunsProvider = undefined,
-		onRestore
+		onRestore,
+		onSavedNewAppPath
 	}: Props = $props()
 	export const version: number | undefined = undefined
 
@@ -1602,7 +1607,7 @@
 		bind:summary
 		bind:pendingDraftPath
 		{onRestore}
-		on:savedNewAppPath
+		{onSavedNewAppPath}
 		{policy}
 		{diffDrawer}
 		{newApp}

--- a/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
@@ -26,7 +26,7 @@
 		Undo,
 		WandSparkles
 	} from 'lucide-svelte'
-	import { createEventDispatcher, untrack } from 'svelte'
+	import { untrack } from 'svelte'
 	import { orderedJsonStringify, type Value, replaceFalseWithUndefined } from '../../utils'
 	import { random_adj } from '$lib/components/random_positive_adjetive'
 
@@ -155,6 +155,10 @@
 		// (not `on:restore` forwarding): forwarding a `createEventDispatcher`
 		// event up through these runes-mode components silently drops it.
 		onRestore?: (restoredApp: any) => void
+		// Deploy created the app at a new path; the page navigates to it. Callback
+		// prop for the same reason as `onRestore` — `on:savedNewAppPath` forwarding
+		// through these runes-mode components is dropped.
+		onSavedNewAppPath?: (path: string) => void
 	}
 
 	let {
@@ -189,7 +193,8 @@
 		loadedFromDraft = false,
 		othersDraftsCount = 0,
 		onOpenOthersDrafts,
-		onRestore
+		onRestore,
+		onSavedNewAppPath
 	}: Props = $props()
 
 	// Set by the on-behalf-of selector when the publisher picks a user other than
@@ -357,7 +362,7 @@
 					path: appPath
 				})
 			}
-			dispatch('savedNewAppPath', path)
+			onSavedNewAppPath?.(path)
 			onDeploy?.({ path })
 		} catch (e) {
 			sendUserToast(`Error creating app: ${e.body ?? e.message}`, true)
@@ -480,7 +485,7 @@
 			})
 		}
 		if (appPath !== npath) {
-			dispatch('savedNewAppPath', npath)
+			onSavedNewAppPath?.(npath)
 		}
 		onDeploy?.({ path: npath })
 	}
@@ -579,8 +584,6 @@
 			}
 		}
 	])
-
-	const dispatch = createEventDispatcher()
 
 	let customPath = $state(savedApp?.custom_path)
 	let customPathError = $state('')

--- a/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
@@ -151,6 +151,10 @@
 		loadedFromDraft?: boolean
 		othersDraftsCount?: number
 		onOpenOthersDrafts?: () => void
+		// Restoring an older deployment from the history drawer. A callback prop
+		// (not `on:restore` forwarding): forwarding a `createEventDispatcher`
+		// event up through these runes-mode components silently drops it.
+		onRestore?: (restoredApp: any) => void
 	}
 
 	let {
@@ -184,7 +188,8 @@
 		onResetToDeployed,
 		loadedFromDraft = false,
 		othersDraftsCount = 0,
-		onOpenOthersDrafts
+		onOpenOthersDrafts,
+		onRestore
 	}: Props = $props()
 
 	// Set by the on-behalf-of selector when the publisher picks a user other than
@@ -688,7 +693,7 @@
 
 <Drawer bind:open={historyBrowserDrawerOpen} size="1200px">
 	<DrawerContent title="Deployment History" on:close={() => (historyBrowserDrawerOpen = false)}>
-		<DeploymentHistory on:restore {appPath} />
+		<DeploymentHistory on:restore={(e) => onRestore?.(e.detail)} {appPath} />
 	</DrawerContent>
 </Drawer>
 

--- a/frontend/src/routes/(root)/(logged)/apps/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps/edit/[...path]/+page.svelte
@@ -388,9 +388,9 @@
 
 	let diffDrawer: DiffDrawer | undefined = $state()
 
-	function onRestore(ev: any) {
+	function onRestore(restoredApp: any) {
 		sendUserToast('App restored from previous deployment')
-		app = ev.detail
+		app = restoredApp
 		// Re-pin the stale-draft fork base to the current head. A restored value
 		// carries the `parent_version` baked in when that older version was deployed,
 		// which would make the deploy guard (`compareVersions`) falsely report "not on
@@ -470,7 +470,7 @@
 						app.path = url
 					}
 				}}
-				on:restore={onRestore}
+				{onRestore}
 				summary={app.summary}
 				app={app.value}
 				{deployedBaseline}

--- a/frontend/src/routes/(root)/(logged)/apps/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps/edit/[...path]/+page.svelte
@@ -390,6 +390,11 @@
 
 	function onRestore(restoredApp: any) {
 		sendUserToast('App restored from previous deployment')
+		// Drop the stale pre-restore autosave. The remounted AppEditor seeds its
+		// state from `appDraftHandle.draft ?? app`, so without this it keeps showing
+		// the old draft instead of the restored version. Same reason `reloadDeployed`
+		// removes the draft before remounting.
+		UserDraft.remove('app', path)
 		app = restoredApp
 		// Re-pin the stale-draft fork base to the current head. A restored value
 		// carries the `parent_version` baked in when that older version was deployed,

--- a/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
@@ -536,10 +536,10 @@
 	{#key redraw}
 		<div class="h-screen">
 			<RawAppEditor
-				on:savedNewAppPath={(event) => {
+				onSavedNewAppPath={(savedPath) => {
 					draftSync.remove()
-					goto(`/apps_raw/edit/${event.detail}`)
-					newPath = event.detail
+					goto(`/apps_raw/edit/${savedPath}`)
+					newPath = savedPath
 				}}
 				{onRestore}
 				bind:files

--- a/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
@@ -449,9 +449,9 @@
 
 	let diffDrawer: DiffDrawer | undefined = $state(undefined)
 
-	function onRestore(ev: any) {
+	function onRestore(restoredApp: any) {
 		sendUserToast('App restored from previous deployment')
-		let prev = ev.detail
+		let prev = restoredApp
 		extractRawApp(prev)
 		savedApp = {
 			summary: prev.summary,
@@ -541,7 +541,7 @@
 					goto(`/apps_raw/edit/${event.detail}`)
 					newPath = event.detail
 				}}
-				on:restore={onRestore}
+				{onRestore}
 				bind:files
 				bind:runnables
 				bind:data


### PR DESCRIPTION
## Summary

Fixes [GIT-906](https://linear.app/windmilldev/issue/GIT-906) / #9822: in the app editor, **Deployment History → "Redeploy with that version"** did nothing — the older version was never shown in the editor, so pressing **Deploy** afterwards shipped the unchanged current value. ("Restore as fork" worked.)

There were **two** bugs in series; both are still present on `main`.

### Bug 1 — the restore event never reached the page

`DeploymentHistory.svelte` emits its `restore` event via `createEventDispatcher`. The editor relayed it purely through legacy `on:restore` *forwarding* across two runes-mode components:

```
DeploymentHistory → AppEditorHeader (on:restore) → AppEditor (on:restore) → +page (on:restore={onRestore})
```

In Svelte 5 runes mode, this multi-hop `on:event` forwarding is silently dropped, so `onRestore` never ran. The homepage "Deployments" path worked because it has a single, direct `on:restore={handler}` (one hop).

**Fix:** replace the forwarding chain with an `onRestore` callback prop threaded through, mirroring the existing `onResetToDeployed` / `onOpenOthersDrafts` props. The header binds the child dispatch directly: `<DeploymentHistory on:restore={(e) => onRestore?.(e.detail)} ... />`. Applied to low-code and raw app editors.

### Bug 2 — the restored value was ignored on remount (this PR's added commit)

After Bug 1 was fixed, `onRestore` fired (toast shown) but the canvas still displayed the *current* version, and Deploy still shipped it. `AppEditor` seeds its working state from `appDraftHandle.draft ?? app`, preferring the per-path autosave over the freshly restored `app` prop. The `redraw++` remount therefore re-read the stale pre-restore draft. (`reloadDeployed` already clears the draft before remounting for the reset-to-deployed flow — `onRestore` was missing the same step.)

**Fix:** `onRestore` now calls `UserDraft.remove('app', path)` so the remounted editor seeds from the restored value.

Raw apps need only Bug 1's fix: `RawAppEditor` binds `files`/`runnables`/`data` directly (`$bindable`, no draft precedence) and `extractRawApp` mutates that bound state in place, so the restored value is shown without clearing a draft.

## Test plan

- [x] Low-code app: editor → Deployment History → older version → "Redeploy with that version". Editor reloads with that version's content and the "App restored from previous deployment" toast appears.
- [x] Press Deploy afterwards → the restored (older) value is what gets deployed.
- [ ] Raw app via `apps_raw` editor (Bug 1 path; analyzed structurally, not exercised live).
- [ ] Homepage "Deployments" redeploy path still works (unchanged).

## Verification (live, v1.741.0)

Created a low-code app and deployed three versions: v9/v10 with an empty topbar, v11 adding a Text component (`Hello ${ctx.username}`).

- **Before the added commit:** restoring v10 showed the toast but the canvas kept the Text component; DB confirmed the editor value still held `Hello`.
- **After the added commit:** restoring v10 removes the Text component from the canvas (only `topbar` remains), and Deploy ships a new version (v12) whose stored value contains **no** `Hello` — i.e. the restored value was deployed. Confirmed via `app_version` rows in the DB.

`npx svelte-check`: 68 pre-existing errors before and after (all unrelated `Type 'Timeout'` noise) — no new type errors.

![restored version displayed after redeploy](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben-git-906/1782636984-restored-displayed.png)

*Editor after "Redeploy with that version" on v10 — the Text component is gone, showing the restored (older) value.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
