### PR TITLE
feat(home): redesign create-new popover and home header

### DIFF
--- a/frontend/src/lib/components/home/CreateActionsMenu.svelte
+++ b/frontend/src/lib/components/home/CreateActionsMenu.svelte
@@ -174,10 +174,9 @@
 >
 	<Button
 		id="create-new-button"
-		btnClasses="text-base"
 		aiId="home-create-new"
 		aiDescription="Create a new script, flow or app"
-		unifiedSize="lg"
+		unifiedSize="md"
 		variant="accent"
 		startIcon={{ icon: Plus }}
 		onClick={() => active?.onSelect()}
@@ -253,7 +252,9 @@
 							</span>
 							<ChevronRight
 								size={16}
-								class="transition-opacity {isActive ? `opacity-100 ${ac.iconText}` : 'opacity-0 text-tertiary'}"
+								class="transition-opacity {isActive
+									? `opacity-100 ${ac.iconText}`
+									: 'opacity-0 text-tertiary'}"
 							/>
 						</button>
 					{/each}

--- a/frontend/src/lib/components/home/CreateActionsMenu.svelte
+++ b/frontend/src/lib/components/home/CreateActionsMenu.svelte
@@ -229,9 +229,7 @@
 				</div>
 
 				<!-- option list -->
-				<div
-					class="flex flex-col gap-0.5 p-2 w-72 shrink-0 border-l border-gray-200 dark:border-gray-700"
-				>
+				<div class="flex flex-col gap-0.5 p-2 w-72 shrink-0">
 					{#each allOptions as option (option.key)}
 						{@const ac = accentClasses[option.accent]}
 						{@const isActive = option.key === activeKey}

--- a/frontend/src/lib/components/home/CreateActionsMenu.svelte
+++ b/frontend/src/lib/components/home/CreateActionsMenu.svelte
@@ -15,7 +15,6 @@
 		Loader2,
 		Workflow,
 		Import,
-		Info,
 		PanelLeftClose
 	} from 'lucide-svelte'
 	import BarsStaggered from '$lib/components/icons/BarsStaggered.svelte'
@@ -24,8 +23,8 @@
 	import { importFlowStore } from '$lib/components/flows/flowStore.svelte'
 	import { importScriptStore } from '$lib/components/scripts/scriptStore.svelte'
 	import { importStore } from '$lib/components/apps/store'
-	import { clickOutside, getLocalSetting, storeLocalSetting } from '$lib/utils'
-	import Popover from '$lib/components/meltComponents/Popover.svelte'
+	import { conditionalMelt, getLocalSetting, storeLocalSetting } from '$lib/utils'
+	import { createDropdownMenu, melt } from '@melt-ui/svelte'
 	import YAML from 'yaml'
 
 	type Variant = {
@@ -228,10 +227,59 @@
 		}
 	}
 
-	let open = $state(false)
 	let activeKey = $state(allOptions[0]?.key)
 	// every option's import action, surfaced together under the bottom "Import" submenu
 	const importActions: Extra[] = allOptions.flatMap((o) => o.extras ?? [])
+
+	// melt dropdown menu: arrow-key nav, typeahead, focus management and outside/escape
+	// close all come for free; we only drive the doc panel off the highlighted item.
+	const {
+		elements: { trigger: menuTrigger, menu, item },
+		states: { open },
+		builders
+	} = createDropdownMenu({
+		positioning: { placement: 'bottom-end', gutter: 8, fitViewport: true, strategy: 'fixed' },
+		loop: true,
+		forceVisible: true
+	})
+
+	// per-row fan-out submenus, anchored toward the page center (popover hugs the right edge)
+	const {
+		elements: { subTrigger: wacSubTrigger, subMenu: wacSubMenu },
+		states: { subOpen: wacSubOpen }
+	} = builders.createSubmenu({
+		positioning: {
+			placement: 'right-start',
+			gutter: 4,
+			flip: true,
+			fitViewport: true,
+			overflowPadding: 8
+		}
+	})
+	const {
+		elements: { subTrigger: importSubTrigger, subMenu: importSubMenu },
+		states: { subOpen: importSubOpen }
+	} = builders.createSubmenu({
+		positioning: {
+			placement: 'right-end',
+			gutter: 4,
+			flip: true,
+			fitViewport: true,
+			overflowPadding: 8
+		}
+	})
+
+	// attach the menu trigger to the design-system <Button>'s DOM node, so it keeps its
+	// styling — melt element stores are callable on a node, exactly like `use:melt`.
+	let triggerEl: HTMLButtonElement | HTMLAnchorElement | undefined = $state(undefined)
+	$effect(() => {
+		const el = triggerEl
+		if (!el) return
+		const applied = conditionalMelt(el, menuTrigger as any) as {
+			destroy?: () => void
+		}
+		return applied?.destroy
+	})
 
 	const SHOW_DOC_SETTING = 'home_create_show_doc'
 	let showDoc = $state(getLocalSetting(SHOW_DOC_SETTING) !== 'false')
@@ -260,7 +308,7 @@
 		importKind = kind
 		importType = 'yaml'
 		importRaw = ''
-		open = false
+		open.set(false)
 		importDrawer?.openDrawer?.()
 	}
 
@@ -285,17 +333,9 @@
 	}
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div
-	class="relative"
-	use:clickOutside={{
-		capture: true,
-		// the language submenu portals to <body>; don't treat clicks inside it as outside
-		exclude: async () => Array.from(document.querySelectorAll('[data-popover]')) as HTMLElement[],
-		onClickOutside: () => (open = false)
-	}}
->
+<div>
 	<Button
+		{...$menuTrigger}
 		id="create-new-button"
 		aiId="home-create-new"
 		aiDescription="Create a new script, flow or app"
@@ -303,197 +343,175 @@
 		variant="accent"
 		startIcon={{ icon: Plus }}
 		endIcon={{ icon: ChevronDown }}
-		onClick={() => (open = !open)}
+		bind:element={triggerEl}
 	>
 		New
 	</Button>
 
-	{#if open && active}
-		<div class="absolute right-0 top-full z-50 pt-2" role="menu" tabindex="-1">
-			<div
-				class="flex flex-row rounded-lg border border-gray-200 dark:border-gray-700 bg-surface shadow-xl overflow-hidden"
-				style={showDoc ? 'width: 700px;' : ''}
-			>
-				{#if showDoc}
-					<!-- explanation of the highlighted editor -->
-					<div class="flex flex-col gap-3 p-5 flex-1 min-w-0">
-						<div class="flex flex-row items-center gap-3">
-							<div
-								class="w-12 h-12 rounded-xl flex items-center justify-center shrink-0 {activeAc.tile}"
-							>
-								<active.icon size={26} class={activeAc.iconText} />
-							</div>
-							<div class="min-w-0">
-								<div class="flex flex-row items-center gap-2">
-									<h3 class="font-semibold text-primary leading-tight">{active.label}</h3>
-									{#if active.badge}
-										<span
-											class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide {active
-												.badge.class}"
-										>
-											{active.badge.label}
-										</span>
-									{/if}
-								</div>
-								<p class="text-xs text-tertiary">{active.tagline}</p>
-							</div>
-						</div>
-
-						<p class="text-xs text-secondary leading-relaxed">{active.description}</p>
-
-						<ul class="flex flex-col gap-1.5 mt-1">
-							{#each active.bullets as bullet (bullet)}
-								<li class="flex flex-row items-center gap-2 text-xs text-secondary">
-									<ChevronRight size={14} class={activeAc.iconText} />
-									{bullet}
-								</li>
-							{/each}
-						</ul>
-
-						<button
-							class="mt-auto self-start inline-flex items-center gap-1 pt-2 text-[10px] text-tertiary hover:text-secondary transition-colors"
-							title="Hide descriptions"
-							onclick={() => setShowDoc(false)}
-						>
-							<PanelLeftClose size={12} />
-							Hide descriptions
-						</button>
-					</div>
-				{/if}
-
-				<!-- option list -->
-				<div class="flex flex-col gap-0.5 p-2 w-[18rem] shrink-0">
-					{#snippet rowBody(option: Option, ac: (typeof accentClasses)[string])}
-						<div class="w-6 h-6 rounded-md flex items-center justify-center shrink-0 {ac.tile}">
-							<option.icon size={14} class={ac.iconText} />
-						</div>
-						<span class="text-xs font-medium text-primary flex-1 min-w-0 whitespace-nowrap">
-							{option.label}
-						</span>
-						{#if option.badge}
-							<span
-								class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide {option
-									.badge.class}"
-							>
-								{option.badge.label}
-							</span>
-						{/if}
-					{/snippet}
-					{#each allOptions as option (option.key)}
-						{@const ac = accentClasses[option.accent]}
-						{@const isActive = option.key === activeKey}
-						{@const innerClass = `flex-1 min-w-0 flex flex-row items-center gap-2.5 rounded-md px-2 py-1.5 text-left cursor-pointer transition-colors ${isActive ? 'bg-surface-hover' : 'hover:bg-surface-hover'}`}
-						<!-- svelte-ignore a11y_no_static_element_interactions -->
+	{#if $open && active}
+		<div
+			use:melt={$menu}
+			data-arrow-loop
+			class="z-[6000] flex flex-row rounded-lg border border-gray-200 dark:border-gray-700 bg-surface shadow-xl focus:outline-none"
+			style={showDoc ? 'width: 780px;' : ''}
+		>
+			{#if showDoc}
+				<!-- explanation of the highlighted editor -->
+				<div class="flex flex-col gap-3 p-5 flex-1 min-w-0">
+					<div class="flex flex-row items-center gap-3">
 						<div
-							class="flex flex-row items-center gap-1"
-							onmouseenter={() => (activeKey = option.key)}
+							class="w-12 h-12 rounded-xl flex items-center justify-center shrink-0 {activeAc.tile}"
 						>
-							{#if option.variants}
-								<!-- floating-ui anchors the language submenu tight to the row and flips it
-								     toward the page center, since the popover hugs the right viewport edge -->
-								<Popover
-									openOnHover
-									debounceDelay={80}
-									class={innerClass}
-									contentClasses="p-1"
-									floatingConfig={{
-										placement: 'left-start',
-										gutter: 4,
-										flip: true,
-										fitViewport: true,
-										overflowPadding: 8
-									}}
-									triggerAttrs={{ role: 'menuitem' }}
-								>
-									{#snippet trigger()}
-										{@render rowBody(option, ac)}
-										<ChevronRight size={14} class="shrink-0 text-tertiary" />
-									{/snippet}
-									{#snippet content()}
-										<div class="flex flex-col gap-0.5 w-32">
-											{#each option.variants ?? [] as variant (variant.label)}
-												{@const VariantIcon = variant.icon}
-												<button
-													class="flex flex-row items-center gap-2.5 rounded-md px-2 py-1.5 text-left cursor-pointer transition-colors hover:bg-surface-hover"
-													onclick={() => variant.onSelect()}
-													role="menuitem"
-												>
-													<VariantIcon width={14} height={14} />
-													<span class="text-xs font-medium text-primary">{variant.label}</span>
-												</button>
-											{/each}
-										</div>
-									{/snippet}
-								</Popover>
-							{:else}
-								<button
-									class={innerClass}
-									onfocus={() => (activeKey = option.key)}
-									onclick={() => option.onSelect()}
-									role="menuitem"
-								>
-									{@render rowBody(option, ac)}
-								</button>
-							{/if}
+							<active.icon size={26} class={activeAc.iconText} />
 						</div>
-					{/each}
-
-					<!-- bottom import section: one entry whose submenu imports any artifact -->
-					<div class="mx-1 my-1 border-t border-gray-200 dark:border-gray-700"></div>
-					<Popover
-						openOnHover
-						debounceDelay={80}
-						class="w-full flex flex-row items-center gap-2.5 rounded-md px-2 py-1.5 text-left cursor-pointer transition-colors hover:bg-surface-hover"
-						contentClasses="p-1"
-						floatingConfig={{
-							placement: 'left-end',
-							gutter: 4,
-							flip: true,
-							fitViewport: true,
-							overflowPadding: 8
-						}}
-						triggerAttrs={{ role: 'menuitem' }}
-					>
-						{#snippet trigger()}
-							<div
-								class="w-6 h-6 rounded-md flex items-center justify-center shrink-0 bg-gray-100 dark:bg-gray-700"
-							>
-								<Import size={14} class="text-gray-600 dark:text-gray-300" />
-							</div>
-							<span class="text-xs font-medium text-primary flex-1 min-w-0 whitespace-nowrap">
-								Import
-							</span>
-							<ChevronRight size={14} class="shrink-0 text-tertiary" />
-						{/snippet}
-						{#snippet content()}
-							<div class="flex flex-col gap-0.5 w-52">
-								{#each importActions as action (action.label)}
-									<button
-										class="flex flex-row items-center gap-2.5 rounded-md px-2 py-1.5 text-left cursor-pointer transition-colors hover:bg-surface-hover"
-										onclick={() => action.onSelect()}
-										role="menuitem"
+						<div class="min-w-0">
+							<div class="flex flex-row items-center gap-2">
+								<h3 class="font-semibold text-primary leading-tight">{active.label}</h3>
+								{#if active.badge}
+									<span
+										class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide {active
+											.badge.class}"
 									>
-										<Import size={14} class="shrink-0 text-tertiary" />
-										<span class="text-xs font-medium text-primary whitespace-nowrap">
-											{action.label}
-										</span>
+										{active.badge.label}
+									</span>
+								{/if}
+							</div>
+							<p class="text-xs text-tertiary">{active.tagline}</p>
+						</div>
+					</div>
+
+					<p class="text-xs text-secondary leading-relaxed">{active.description}</p>
+
+					<ul class="flex flex-col gap-1.5 mt-1">
+						{#each active.bullets as bullet (bullet)}
+							<li class="flex flex-row items-center gap-2 text-xs text-secondary">
+								<ChevronRight size={14} class={activeAc.iconText} />
+								{bullet}
+							</li>
+						{/each}
+					</ul>
+
+					<button
+						class="mt-auto self-start inline-flex items-center gap-1 pt-2 text-[10px] text-tertiary hover:text-secondary transition-colors"
+						title="Hide descriptions"
+						tabindex={-1}
+						onclick={() => setShowDoc(false)}
+					>
+						<PanelLeftClose size={12} />
+						Hide descriptions
+					</button>
+				</div>
+			{/if}
+
+			<!-- option list -->
+			<div class="flex flex-col gap-0.5 p-2 w-[18rem] shrink-0">
+				{#snippet rowBody(option: Option, ac: (typeof accentClasses)[string])}
+					<div class="w-6 h-6 rounded-md flex items-center justify-center shrink-0 {ac.tile}">
+						<option.icon size={14} class={ac.iconText} />
+					</div>
+					<span class="text-xs font-medium text-primary flex-1 min-w-0 whitespace-nowrap">
+						{option.label}
+					</span>
+					{#if option.badge}
+						<span
+							class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide {option
+								.badge.class}"
+						>
+							{option.badge.label}
+						</span>
+					{/if}
+				{/snippet}
+				{#each allOptions as option (option.key)}
+					{@const ac = accentClasses[option.accent]}
+					{@const rowClass =
+						'w-full flex flex-row items-center gap-2.5 rounded-md px-2 py-1.5 text-left cursor-pointer transition-colors focus:outline-none data-[highlighted]:bg-surface-hover hover:bg-surface-hover'}
+					{#if option.variants}
+						<button
+							use:melt={$wacSubTrigger}
+							class={rowClass}
+							onfocusin={() => (activeKey = option.key)}
+							onpointerenter={() => (activeKey = option.key)}
+						>
+							{@render rowBody(option, ac)}
+							<ChevronRight size={14} class="shrink-0 text-tertiary" />
+						</button>
+						{#if $wacSubOpen}
+							<div
+								use:melt={$wacSubMenu}
+								class="z-[6001] flex flex-col gap-0.5 p-1 w-52 rounded-lg border border-gray-200 dark:border-gray-700 bg-surface shadow-xl focus:outline-none"
+							>
+								{#each option.variants ?? [] as variant (variant.label)}
+									{@const VariantIcon = variant.icon}
+									<button
+										use:melt={$item}
+										class="flex flex-row items-center gap-2.5 rounded-md px-2 py-1.5 text-left cursor-pointer transition-colors focus:outline-none data-[highlighted]:bg-surface-hover hover:bg-surface-hover"
+										onclick={() => variant.onSelect()}
+									>
+										<VariantIcon width={14} height={14} />
+										<span class="text-xs font-medium text-primary">{variant.label}</span>
 									</button>
 								{/each}
 							</div>
-						{/snippet}
-					</Popover>
-
-					{#if !showDoc}
+						{/if}
+					{:else}
 						<button
-							class="mt-1 inline-flex items-center gap-1 px-2 py-1 text-[10px] text-tertiary hover:text-secondary transition-colors"
-							title="Show descriptions"
-							onclick={() => setShowDoc(true)}
+							use:melt={$item}
+							class={rowClass}
+							onfocusin={() => (activeKey = option.key)}
+							onpointerenter={() => (activeKey = option.key)}
+							onclick={() => option.onSelect()}
 						>
-							<Info size={12} />
-							Show descriptions
+							{@render rowBody(option, ac)}
 						</button>
 					{/if}
-				</div>
+				{/each}
+
+				<!-- bottom import section: one entry whose submenu imports any artifact -->
+				<div class="mx-1 my-1 border-t border-gray-200 dark:border-gray-700"></div>
+				<button
+					use:melt={$importSubTrigger}
+					class="w-full flex flex-row items-center gap-2.5 rounded-md px-2 py-1.5 text-left cursor-pointer transition-colors focus:outline-none data-[highlighted]:bg-surface-hover hover:bg-surface-hover"
+				>
+					<div
+						class="w-6 h-6 rounded-md flex items-center justify-center shrink-0 bg-gray-100 dark:bg-gray-700"
+					>
+						<Import size={14} class="text-gray-600 dark:text-gray-300" />
+					</div>
+					<span class="text-xs font-medium text-primary flex-1 min-w-0 whitespace-nowrap">
+						Import
+					</span>
+					<ChevronRight size={14} class="shrink-0 text-tertiary" />
+				</button>
+				{#if $importSubOpen}
+					<div
+						use:melt={$importSubMenu}
+						class="z-[6001] flex flex-col gap-0.5 p-1 w-52 rounded-lg border border-gray-200 dark:border-gray-700 bg-surface shadow-xl focus:outline-none"
+					>
+						{#each importActions as action (action.label)}
+							<button
+								use:melt={$item}
+								class="flex flex-row items-center gap-2.5 rounded-md px-2 py-1.5 text-left cursor-pointer transition-colors focus:outline-none data-[highlighted]:bg-surface-hover hover:bg-surface-hover"
+								onclick={() => action.onSelect()}
+							>
+								<Import size={14} class="shrink-0 text-tertiary" />
+								<span class="text-xs font-medium text-primary whitespace-nowrap">
+									{action.label}
+								</span>
+							</button>
+						{/each}
+					</div>
+				{/if}
+
+				{#if !showDoc}
+					<button
+						class="mt-1 px-2 py-1 text-left text-[10px] text-tertiary/70 hover:text-tertiary hover:underline transition-colors"
+						title="Show descriptions"
+						tabindex={-1}
+						onclick={() => setShowDoc(true)}
+					>
+						Show descriptions
+					</button>
+				{/if}
 			</div>
 		</div>
 	{/if}

--- a/frontend/src/lib/components/home/CreateActionsMenu.svelte
+++ b/frontend/src/lib/components/home/CreateActionsMenu.svelte
@@ -372,7 +372,7 @@
 						{@const ac = accentClasses[option.accent]}
 						{@const isActive = option.key === activeKey}
 						{#if option.badge && !allOptions[i - 1]?.badge}
-							<div class="mx-1 my-1 border-t border-gray-200 dark:border-gray-700"></div>
+							<div class="mx-1 mt-3 mb-3 border-t border-gray-200 dark:border-gray-700"></div>
 						{/if}
 						<button
 							class="flex flex-row items-center gap-3 rounded-md border px-2 py-2 text-left cursor-pointer transition-colors {isActive

--- a/frontend/src/lib/components/home/CreateActionsMenu.svelte
+++ b/frontend/src/lib/components/home/CreateActionsMenu.svelte
@@ -6,7 +6,7 @@
 	import DrawerContent from '$lib/components/common/drawer/DrawerContent.svelte'
 	import Tabs from '$lib/components/common/tabs/Tabs.svelte'
 	import Tab from '$lib/components/common/tabs/Tab.svelte'
-	import { Plus, Code2, LayoutDashboard, ChevronRight, Loader2 } from 'lucide-svelte'
+	import { Plus, Code2, LayoutDashboard, ChevronRight, Loader2, Workflow } from 'lucide-svelte'
 	import BarsStaggered from '$lib/components/icons/BarsStaggered.svelte'
 	import { PythonIcon, TypeScriptIcon } from '$lib/components/common/languageIcons'
 	import { HOME_SHOW_CREATE_FLOW, HOME_SHOW_CREATE_APP } from '$lib/consts'
@@ -50,6 +50,7 @@
 	// kept static so tailwind doesn't purge the badge tones
 	const badgeAdvanced = 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
 	const badgeLegacy = 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
+	const badgeAlpha = 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
 
 	const allOptions: Option[] = [
 		{
@@ -83,10 +84,7 @@
 							'Suspend / approval steps'
 						],
 						onSelect: () => goto(`${base}/flows/add`),
-						extras: [
-							{ label: 'Import flow', onSelect: () => openImport('flow') },
-							{ label: 'Pipeline (alpha)', onSelect: () => goto(`${base}/pipeline`) }
-						]
+						extras: [{ label: 'Import flow', onSelect: () => openImport('flow') }]
 					}
 				] as Option[])
 			: []),
@@ -136,6 +134,22 @@
 							}
 						],
 						extras: [{ label: 'Import Workflow-as-Code', onSelect: () => openImport('wac') }]
+					},
+					{
+						key: 'pipeline',
+						label: 'Data pipelines editor',
+						icon: Workflow,
+						accent: 'indigo',
+						tagline: 'Compose data ingestion & transforms',
+						description:
+							'Visual editor for data pipelines — chain ingestion, transformation and materialization steps with partitions and incremental processing.',
+						bullets: [
+							'Ingest, transform & materialize',
+							'Partitioned & incremental',
+							'Asset-aware lineage'
+						],
+						onSelect: () => goto(`${base}/pipeline`),
+						badge: { label: 'Alpha', class: badgeAlpha }
 					}
 				] as Option[])
 			: []),
@@ -186,6 +200,12 @@
 			iconText: 'text-orange-600 dark:text-orange-400',
 			activeBg: 'bg-orange-50 dark:bg-orange-900/20',
 			activeBorder: 'border-orange-500 dark:border-orange-400'
+		},
+		indigo: {
+			tile: 'bg-indigo-100 dark:bg-indigo-900/40',
+			iconText: 'text-indigo-600 dark:text-indigo-400',
+			activeBg: 'bg-indigo-50 dark:bg-indigo-900/20',
+			activeBorder: 'border-indigo-500 dark:border-indigo-400'
 		}
 	}
 

--- a/frontend/src/lib/components/home/CreateActionsMenu.svelte
+++ b/frontend/src/lib/components/home/CreateActionsMenu.svelte
@@ -25,7 +25,13 @@
 		onSelect: () => void
 		/** optional sub-choices shown in place of the single create button */
 		variants?: Variant[]
+		/** optional pill shown next to the label; class is the full static tailwind tone */
+		badge?: { label: string; class: string }
 	}
+
+	// kept static so tailwind doesn't purge the badge tones
+	const badgeAdvanced = 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
+	const badgeLegacy = 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
 
 	const allOptions: Option[] = [
 		{
@@ -74,6 +80,7 @@
 							'Versioned as a regular script'
 						],
 						onSelect: () => goto(`${base}/scripts/add?wac=typescript`),
+						badge: { label: 'Advanced', class: badgeAdvanced },
 						variants: [
 							{
 								label: 'TypeScript',
@@ -100,7 +107,8 @@
 						description:
 							'Assemble an internal UI from 60+ components wired to your scripts and flows. Best for simple apps or apps that need minimal customization.',
 						bullets: ['60+ ready-made components', 'No code required', 'Backed by scripts & flows'],
-						onSelect: () => goto(`${base}/apps/add`)
+						onSelect: () => goto(`${base}/apps/add`),
+						badge: { label: 'Legacy', class: badgeLegacy }
 					},
 					{
 						key: 'app-fullcode',
@@ -188,7 +196,7 @@
 		<div class="absolute right-0 top-full z-50 pt-2" role="menu" tabindex="-1">
 			<div
 				class="flex flex-row rounded-lg border border-gray-200 dark:border-gray-700 bg-surface shadow-xl overflow-hidden"
-				style="width: 720px;"
+				style="width: 780px;"
 			>
 				<!-- explanation of the highlighted editor -->
 				<div class="flex flex-col gap-3 p-5 flex-1 min-w-0">
@@ -199,7 +207,17 @@
 							<active.icon size={26} class={activeAc.iconText} />
 						</div>
 						<div class="min-w-0">
-							<h3 class="font-semibold text-primary leading-tight">{active.label}</h3>
+							<div class="flex flex-row items-center gap-2">
+								<h3 class="font-semibold text-primary leading-tight">{active.label}</h3>
+								{#if active.badge}
+									<span
+										class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide {active
+											.badge.class}"
+									>
+										{active.badge.label}
+									</span>
+								{/if}
+							</div>
 							<p class="text-xs text-tertiary">{active.tagline}</p>
 						</div>
 					</div>
@@ -229,7 +247,7 @@
 				</div>
 
 				<!-- option list -->
-				<div class="flex flex-col gap-0.5 p-2 w-72 shrink-0">
+				<div class="flex flex-col gap-0.5 p-2 w-[21rem] shrink-0">
 					{#each allOptions as option (option.key)}
 						{@const ac = accentClasses[option.accent]}
 						{@const isActive = option.key === activeKey}
@@ -248,6 +266,14 @@
 							<span class="text-sm font-medium text-primary flex-1 min-w-0 whitespace-nowrap">
 								{option.label}
 							</span>
+							{#if option.badge}
+								<span
+									class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide {option
+										.badge.class}"
+								>
+									{option.badge.label}
+								</span>
+							{/if}
 							<ChevronRight
 								size={16}
 								class="transition-opacity {isActive

--- a/frontend/src/lib/components/home/CreateActionsMenu.svelte
+++ b/frontend/src/lib/components/home/CreateActionsMenu.svelte
@@ -10,10 +10,13 @@
 		Plus,
 		Code2,
 		LayoutDashboard,
+		ChevronDown,
 		ChevronRight,
 		Loader2,
 		Workflow,
-		Import
+		Import,
+		Info,
+		PanelLeftClose
 	} from 'lucide-svelte'
 	import BarsStaggered from '$lib/components/icons/BarsStaggered.svelte'
 	import { PythonIcon, TypeScriptIcon } from '$lib/components/common/languageIcons'
@@ -21,6 +24,8 @@
 	import { importFlowStore } from '$lib/components/flows/flowStore.svelte'
 	import { importScriptStore } from '$lib/components/scripts/scriptStore.svelte'
 	import { importStore } from '$lib/components/apps/store'
+	import { clickOutside, getLocalSetting, storeLocalSetting } from '$lib/utils'
+	import Popover from '$lib/components/meltComponents/Popover.svelte'
 	import YAML from 'yaml'
 
 	type Variant = {
@@ -102,7 +107,7 @@
 						key: 'app-fullcode',
 						label: 'App (full-code)',
 						icon: LayoutDashboard,
-						accent: 'purple',
+						accent: 'orange',
 						tagline: 'Build with React or Svelte',
 						description:
 							'Full control over the UI with React or Svelte and a powerful AI agent. Best for complex apps that need full flexibility.',
@@ -167,7 +172,7 @@
 						key: 'app-lowcode',
 						label: 'App (low-code)',
 						icon: LayoutDashboard,
-						accent: 'orange',
+						accent: 'gray',
 						tagline: 'Drag-and-drop UI builder',
 						description:
 							'Assemble an internal UI from 60+ components wired to your scripts and flows. Best for simple apps or apps that need minimal customization.',
@@ -192,7 +197,7 @@
 			activeBorder: 'border-blue-500 dark:border-blue-400'
 		},
 		teal: {
-			tile: 'bg-teal-100 dark:bg-teal-900/40',
+			tile: 'bg-teal-50 dark:bg-teal-900/20',
 			iconText: 'text-teal-600 dark:text-teal-400',
 			activeBg: 'bg-teal-50 dark:bg-teal-900/20',
 			activeBorder: 'border-teal-500 dark:border-teal-400'
@@ -214,23 +219,29 @@
 			iconText: 'text-indigo-600 dark:text-indigo-400',
 			activeBg: 'bg-indigo-50 dark:bg-indigo-900/20',
 			activeBorder: 'border-indigo-500 dark:border-indigo-400'
+		},
+		gray: {
+			tile: 'bg-gray-100 dark:bg-gray-700',
+			iconText: 'text-gray-600 dark:text-gray-300',
+			activeBg: 'bg-gray-50 dark:bg-gray-800/40',
+			activeBorder: 'border-gray-400 dark:border-gray-500'
 		}
 	}
 
 	let open = $state(false)
 	let activeKey = $state(allOptions[0]?.key)
+	// every option's import action, surfaced together under the bottom "Import" submenu
+	const importActions: Extra[] = allOptions.flatMap((o) => o.extras ?? [])
+
+	const SHOW_DOC_SETTING = 'home_create_show_doc'
+	let showDoc = $state(getLocalSetting(SHOW_DOC_SETTING) !== 'false')
+	function setShowDoc(value: boolean) {
+		showDoc = value
+		// only persist the non-default (hidden) state, so a cleared key means "shown"
+		storeLocalSetting(SHOW_DOC_SETTING, value ? undefined : 'false')
+	}
 	let active = $derived(allOptions.find((o) => o.key === activeKey) ?? allOptions[0])
 	let activeAc = $derived(accentClasses[active.accent])
-
-	let closeTimeout: ReturnType<typeof setTimeout> | undefined
-	function scheduleOpen() {
-		if (closeTimeout) clearTimeout(closeTimeout)
-		open = true
-	}
-	function scheduleClose() {
-		if (closeTimeout) clearTimeout(closeTimeout)
-		closeTimeout = setTimeout(() => (open = false), 120)
-	}
 
 	// shared YAML/JSON import drawer, reused by every "Import …" extra
 	let importDrawer: Drawer | undefined = $state(undefined)
@@ -277,10 +288,12 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
 	class="relative"
-	onmouseenter={scheduleOpen}
-	onmouseleave={scheduleClose}
-	onfocusin={scheduleOpen}
-	onfocusout={scheduleClose}
+	use:clickOutside={{
+		capture: true,
+		// the language submenu portals to <body>; don't treat clicks inside it as outside
+		exclude: async () => Array.from(document.querySelectorAll('[data-popover]')) as HTMLElement[],
+		onClickOutside: () => (open = false)
+	}}
 >
 	<Button
 		id="create-new-button"
@@ -289,7 +302,8 @@
 		unifiedSize="md"
 		variant="accent"
 		startIcon={{ icon: Plus }}
-		onClick={() => active?.onSelect()}
+		endIcon={{ icon: ChevronDown }}
+		onClick={() => (open = !open)}
 	>
 		New
 	</Button>
@@ -298,120 +312,194 @@
 		<div class="absolute right-0 top-full z-50 pt-2" role="menu" tabindex="-1">
 			<div
 				class="flex flex-row rounded-lg border border-gray-200 dark:border-gray-700 bg-surface shadow-xl overflow-hidden"
-				style="width: 780px;"
+				style={showDoc ? 'width: 700px;' : ''}
 			>
-				<!-- explanation of the highlighted editor -->
-				<div class="flex flex-col gap-3 p-5 flex-1 min-w-0">
-					<div class="flex flex-row items-center gap-3">
-						<div
-							class="w-12 h-12 rounded-xl flex items-center justify-center shrink-0 {activeAc.tile}"
-						>
-							<active.icon size={26} class={activeAc.iconText} />
-						</div>
-						<div class="min-w-0">
-							<div class="flex flex-row items-center gap-2">
-								<h3 class="font-semibold text-primary leading-tight">{active.label}</h3>
-								{#if active.badge}
-									<span
-										class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide {active
-											.badge.class}"
-									>
-										{active.badge.label}
-									</span>
-								{/if}
+				{#if showDoc}
+					<!-- explanation of the highlighted editor -->
+					<div class="flex flex-col gap-3 p-5 flex-1 min-w-0">
+						<div class="flex flex-row items-center gap-3">
+							<div
+								class="w-12 h-12 rounded-xl flex items-center justify-center shrink-0 {activeAc.tile}"
+							>
+								<active.icon size={26} class={activeAc.iconText} />
 							</div>
-							<p class="text-xs text-tertiary">{active.tagline}</p>
-						</div>
-					</div>
-
-					<p class="text-sm text-secondary leading-relaxed">{active.description}</p>
-
-					<ul class="flex flex-col gap-1.5 mt-1">
-						{#each active.bullets as bullet (bullet)}
-							<li class="flex flex-row items-center gap-2 text-xs text-secondary">
-								<ChevronRight size={14} class={activeAc.iconText} />
-								{bullet}
-							</li>
-						{/each}
-					</ul>
-
-					{#if active.variants || active.extras}
-						<div class="mt-auto flex flex-col gap-2 pt-2">
-							{#if active.variants}
-								<div class="flex flex-row flex-wrap gap-2">
-									{#each active.variants as variant (variant.label)}
-										{@const VariantIcon = variant.icon}
-										<Button unifiedSize="sm" variant="accent" onClick={() => variant.onSelect()}>
-											<VariantIcon width={16} height={16} />
-											{variant.label}
-										</Button>
-									{/each}
-								</div>
-							{/if}
-							{#if active.extras}
-								<div class="flex flex-row flex-wrap gap-2">
-									{#each active.extras as extra (extra.label)}
-										<Button
-											unifiedSize="sm"
-											variant="default"
-											startIcon={{ icon: Import }}
-											onClick={() => extra.onSelect()}
+							<div class="min-w-0">
+								<div class="flex flex-row items-center gap-2">
+									<h3 class="font-semibold text-primary leading-tight">{active.label}</h3>
+									{#if active.badge}
+										<span
+											class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide {active
+												.badge.class}"
 										>
-											{extra.label}
-										</Button>
-									{/each}
+											{active.badge.label}
+										</span>
+									{/if}
 								</div>
-							{/if}
+								<p class="text-xs text-tertiary">{active.tagline}</p>
+							</div>
 						</div>
-					{/if}
-				</div>
+
+						<p class="text-xs text-secondary leading-relaxed">{active.description}</p>
+
+						<ul class="flex flex-col gap-1.5 mt-1">
+							{#each active.bullets as bullet (bullet)}
+								<li class="flex flex-row items-center gap-2 text-xs text-secondary">
+									<ChevronRight size={14} class={activeAc.iconText} />
+									{bullet}
+								</li>
+							{/each}
+						</ul>
+
+						<button
+							class="mt-auto self-start inline-flex items-center gap-1 pt-2 text-[10px] text-tertiary hover:text-secondary transition-colors"
+							title="Hide descriptions"
+							onclick={() => setShowDoc(false)}
+						>
+							<PanelLeftClose size={12} />
+							Hide descriptions
+						</button>
+					</div>
+				{/if}
 
 				<!-- option list -->
-				<div class="flex flex-col gap-0.5 p-2 w-[21rem] shrink-0">
-					{#each allOptions as option, i (option.key)}
+				<div class="flex flex-col gap-0.5 p-2 w-[18rem] shrink-0">
+					{#snippet rowBody(option: Option, ac: (typeof accentClasses)[string])}
+						<div class="w-6 h-6 rounded-md flex items-center justify-center shrink-0 {ac.tile}">
+							<option.icon size={14} class={ac.iconText} />
+						</div>
+						<span class="text-xs font-medium text-primary flex-1 min-w-0 whitespace-nowrap">
+							{option.label}
+						</span>
+						{#if option.badge}
+							<span
+								class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide {option
+									.badge.class}"
+							>
+								{option.badge.label}
+							</span>
+						{/if}
+					{/snippet}
+					{#each allOptions as option (option.key)}
 						{@const ac = accentClasses[option.accent]}
 						{@const isActive = option.key === activeKey}
-						{#if option.badge && !allOptions[i - 1]?.badge}
-							<div class="mx-1 mt-3 mb-3 border-t border-gray-200 dark:border-gray-700"></div>
-						{/if}
-						<button
-							class="flex flex-row items-center gap-3 rounded-md border px-2 py-2 text-left cursor-pointer transition-colors {isActive
-								? `${ac.activeBg} ${ac.activeBorder}`
-								: 'border-transparent hover:bg-surface-hover'}"
+						{@const innerClass = `flex-1 min-w-0 flex flex-row items-center gap-2.5 rounded-md px-2 py-1.5 text-left cursor-pointer transition-colors ${isActive ? 'bg-surface-hover' : 'hover:bg-surface-hover'}`}
+						<!-- svelte-ignore a11y_no_static_element_interactions -->
+						<div
+							class="flex flex-row items-center gap-1"
 							onmouseenter={() => (activeKey = option.key)}
-							onfocus={() => (activeKey = option.key)}
-							onclick={() => option.onSelect()}
-							role="menuitem"
 						>
-							<div class="w-8 h-8 rounded-md flex items-center justify-center shrink-0 {ac.tile}">
-								<option.icon size={18} class={ac.iconText} />
-							</div>
-							<span class="text-sm font-medium text-primary flex-1 min-w-0 whitespace-nowrap">
-								{option.label}
-							</span>
-							{#if option.badge}
-								<span
-									class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide {option
-										.badge.class}"
+							{#if option.variants}
+								<!-- floating-ui anchors the language submenu tight to the row and flips it
+								     toward the page center, since the popover hugs the right viewport edge -->
+								<Popover
+									openOnHover
+									debounceDelay={80}
+									class={innerClass}
+									contentClasses="p-1"
+									floatingConfig={{
+										placement: 'left-start',
+										gutter: 4,
+										flip: true,
+										fitViewport: true,
+										overflowPadding: 8
+									}}
+									triggerAttrs={{ role: 'menuitem' }}
 								>
-									{option.badge.label}
-								</span>
+									{#snippet trigger()}
+										{@render rowBody(option, ac)}
+										<ChevronRight size={14} class="shrink-0 text-tertiary" />
+									{/snippet}
+									{#snippet content()}
+										<div class="flex flex-col gap-0.5 w-32">
+											{#each option.variants ?? [] as variant (variant.label)}
+												{@const VariantIcon = variant.icon}
+												<button
+													class="flex flex-row items-center gap-2.5 rounded-md px-2 py-1.5 text-left cursor-pointer transition-colors hover:bg-surface-hover"
+													onclick={() => variant.onSelect()}
+													role="menuitem"
+												>
+													<VariantIcon width={14} height={14} />
+													<span class="text-xs font-medium text-primary">{variant.label}</span>
+												</button>
+											{/each}
+										</div>
+									{/snippet}
+								</Popover>
+							{:else}
+								<button
+									class={innerClass}
+									onfocus={() => (activeKey = option.key)}
+									onclick={() => option.onSelect()}
+									role="menuitem"
+								>
+									{@render rowBody(option, ac)}
+								</button>
 							{/if}
-							<ChevronRight
-								size={16}
-								class="transition-opacity {isActive
-									? `opacity-100 ${ac.iconText}`
-									: 'opacity-0 text-tertiary'}"
-							/>
-						</button>
+						</div>
 					{/each}
+
+					<!-- bottom import section: one entry whose submenu imports any artifact -->
+					<div class="mx-1 my-1 border-t border-gray-200 dark:border-gray-700"></div>
+					<Popover
+						openOnHover
+						debounceDelay={80}
+						class="w-full flex flex-row items-center gap-2.5 rounded-md px-2 py-1.5 text-left cursor-pointer transition-colors hover:bg-surface-hover"
+						contentClasses="p-1"
+						floatingConfig={{
+							placement: 'left-end',
+							gutter: 4,
+							flip: true,
+							fitViewport: true,
+							overflowPadding: 8
+						}}
+						triggerAttrs={{ role: 'menuitem' }}
+					>
+						{#snippet trigger()}
+							<div
+								class="w-6 h-6 rounded-md flex items-center justify-center shrink-0 bg-gray-100 dark:bg-gray-700"
+							>
+								<Import size={14} class="text-gray-600 dark:text-gray-300" />
+							</div>
+							<span class="text-xs font-medium text-primary flex-1 min-w-0 whitespace-nowrap">
+								Import
+							</span>
+							<ChevronRight size={14} class="shrink-0 text-tertiary" />
+						{/snippet}
+						{#snippet content()}
+							<div class="flex flex-col gap-0.5 w-52">
+								{#each importActions as action (action.label)}
+									<button
+										class="flex flex-row items-center gap-2.5 rounded-md px-2 py-1.5 text-left cursor-pointer transition-colors hover:bg-surface-hover"
+										onclick={() => action.onSelect()}
+										role="menuitem"
+									>
+										<Import size={14} class="shrink-0 text-tertiary" />
+										<span class="text-xs font-medium text-primary whitespace-nowrap">
+											{action.label}
+										</span>
+									</button>
+								{/each}
+							</div>
+						{/snippet}
+					</Popover>
+
+					{#if !showDoc}
+						<button
+							class="mt-1 inline-flex items-center gap-1 px-2 py-1 text-[10px] text-tertiary hover:text-secondary transition-colors"
+							title="Show descriptions"
+							onclick={() => setShowDoc(true)}
+						>
+							<Info size={12} />
+							Show descriptions
+						</button>
+					{/if}
 				</div>
 			</div>
 		</div>
 	{/if}
 </div>
 
-<!-- shared import drawer (YAML / JSON) for the detail-panel "Import …" actions -->
+<!-- shared import drawer (YAML / JSON) for the bottom "Import" submenu actions -->
 <Drawer bind:this={importDrawer} size="800px">
 	<DrawerContent title={importTitles[importKind]} on:close={() => importDrawer?.closeDrawer?.()}>
 		<Tabs bind:selected={importType}>

--- a/frontend/src/lib/components/home/CreateActionsMenu.svelte
+++ b/frontend/src/lib/components/home/CreateActionsMenu.svelte
@@ -2,14 +2,30 @@
 	import { base } from '$lib/base'
 	import { goto } from '$lib/navigation'
 	import { Button } from '$lib/components/common'
-	import { Plus, Code2, LayoutDashboard, ChevronRight } from 'lucide-svelte'
+	import Drawer from '$lib/components/common/drawer/Drawer.svelte'
+	import DrawerContent from '$lib/components/common/drawer/DrawerContent.svelte'
+	import Tabs from '$lib/components/common/tabs/Tabs.svelte'
+	import Tab from '$lib/components/common/tabs/Tab.svelte'
+	import { Plus, Code2, LayoutDashboard, ChevronRight, Loader2 } from 'lucide-svelte'
 	import BarsStaggered from '$lib/components/icons/BarsStaggered.svelte'
 	import { PythonIcon, TypeScriptIcon } from '$lib/components/common/languageIcons'
 	import { HOME_SHOW_CREATE_FLOW, HOME_SHOW_CREATE_APP } from '$lib/consts'
+	import { importFlowStore } from '$lib/components/flows/flowStore.svelte'
+	import { importScriptStore } from '$lib/components/scripts/scriptStore.svelte'
+	import { importStore } from '$lib/components/apps/store'
+	import YAML from 'yaml'
 
 	type Variant = {
 		label: string
 		icon: typeof PythonIcon
+		onSelect: () => void
+	}
+
+	/** an importable artifact kind handled by the shared YAML/JSON import drawer */
+	type ImportKind = 'flow' | 'wac' | 'app-lowcode' | 'app-fullcode'
+
+	type Extra = {
+		label: string
 		onSelect: () => void
 	}
 
@@ -27,6 +43,8 @@
 		variants?: Variant[]
 		/** optional pill shown next to the label; class is the full static tailwind tone */
 		badge?: { label: string; class: string }
+		/** secondary actions (import from YAML/JSON, pipeline, …) shown in the detail panel */
+		extras?: Extra[]
 	}
 
 	// kept static so tailwind doesn't purge the badge tones
@@ -64,7 +82,11 @@
 							'Branches, loops & error handling',
 							'Suspend / approval steps'
 						],
-						onSelect: () => goto(`${base}/flows/add`)
+						onSelect: () => goto(`${base}/flows/add`),
+						extras: [
+							{ label: 'Import flow', onSelect: () => openImport('flow') },
+							{ label: 'Pipeline (alpha)', onSelect: () => goto(`${base}/pipeline`) }
+						]
 					}
 				] as Option[])
 			: []),
@@ -79,7 +101,8 @@
 						description:
 							'Full control over the UI with React or Svelte and a powerful AI agent. Best for complex apps that need full flexibility.',
 						bullets: ['React or Svelte', 'Full flexibility & control', 'AI-assisted authoring'],
-						onSelect: () => goto(`${base}/apps_raw/add`)
+						onSelect: () => goto(`${base}/apps_raw/add`),
+						extras: [{ label: 'Import full-code app', onSelect: () => openImport('app-fullcode') }]
 					}
 				] as Option[])
 			: []),
@@ -111,7 +134,8 @@
 								icon: PythonIcon,
 								onSelect: () => goto(`${base}/scripts/add?wac=python`)
 							}
-						]
+						],
+						extras: [{ label: 'Import Workflow-as-Code', onSelect: () => openImport('wac') }]
 					}
 				] as Option[])
 			: []),
@@ -127,7 +151,8 @@
 							'Assemble an internal UI from 60+ components wired to your scripts and flows. Best for simple apps or apps that need minimal customization.',
 						bullets: ['60+ ready-made components', 'No code required', 'Backed by scripts & flows'],
 						onSelect: () => goto(`${base}/apps/add`),
-						badge: { label: 'Legacy', class: badgeLegacy }
+						badge: { label: 'Legacy', class: badgeLegacy },
+						extras: [{ label: 'Import low-code app', onSelect: () => openImport('app-lowcode') }]
 					}
 				] as Option[])
 			: [])
@@ -177,6 +202,47 @@
 	function scheduleClose() {
 		if (closeTimeout) clearTimeout(closeTimeout)
 		closeTimeout = setTimeout(() => (open = false), 120)
+	}
+
+	// shared YAML/JSON import drawer, reused by every "Import …" extra
+	let importDrawer: Drawer | undefined = $state(undefined)
+	let importKind: ImportKind = $state('flow')
+	let importType: 'yaml' | 'json' = $state('yaml')
+	let importRaw: string = $state('')
+
+	const importTitles: Record<ImportKind, string> = {
+		flow: 'Import flow',
+		wac: 'Import Workflow-as-Code',
+		'app-lowcode': 'Import low-code app',
+		'app-fullcode': 'Import full-code app'
+	}
+
+	function openImport(kind: ImportKind) {
+		importKind = kind
+		importType = 'yaml'
+		importRaw = ''
+		open = false
+		importDrawer?.openDrawer?.()
+	}
+
+	async function runImport() {
+		const parsed = importType === 'yaml' ? YAML.parse(importRaw) : JSON.parse(importRaw)
+		if (importKind === 'flow') {
+			importFlowStore.set(parsed)
+			await goto(`${base}/flows/add`)
+		} else if (importKind === 'wac') {
+			importScriptStore.set(parsed)
+			await goto(`${base}/scripts/add?import=true`)
+		} else if (importKind === 'app-fullcode') {
+			// /apps_raw/add does a full reload (cross-origin isolation), so the in-memory
+			// store would be lost — hand the payload over via sessionStorage instead.
+			sessionStorage.setItem('rawAppImport', JSON.stringify(parsed))
+			await goto(`${base}/apps_raw/add`)
+		} else {
+			importStore.set(parsed)
+			await goto(`${base}/apps/add`)
+		}
+		importDrawer?.closeDrawer?.()
 	}
 </script>
 
@@ -241,15 +307,28 @@
 						{/each}
 					</ul>
 
-					{#if active.variants}
-						<div class="mt-auto flex flex-row gap-2 pt-2">
-							{#each active.variants as variant (variant.label)}
-								{@const VariantIcon = variant.icon}
-								<Button unifiedSize="sm" variant="accent" onClick={() => variant.onSelect()}>
-									<VariantIcon width={16} height={16} />
-									{variant.label}
-								</Button>
-							{/each}
+					{#if active.variants || active.extras}
+						<div class="mt-auto flex flex-col gap-2 pt-2">
+							{#if active.variants}
+								<div class="flex flex-row flex-wrap gap-2">
+									{#each active.variants as variant (variant.label)}
+										{@const VariantIcon = variant.icon}
+										<Button unifiedSize="sm" variant="accent" onClick={() => variant.onSelect()}>
+											<VariantIcon width={16} height={16} />
+											{variant.label}
+										</Button>
+									{/each}
+								</div>
+							{/if}
+							{#if active.extras}
+								<div class="flex flex-row flex-wrap gap-2">
+									{#each active.extras as extra (extra.label)}
+										<Button unifiedSize="sm" variant="subtle" onClick={() => extra.onSelect()}>
+											{extra.label}
+										</Button>
+									{/each}
+								</div>
+							{/if}
 						</div>
 					{/if}
 				</div>
@@ -295,3 +374,32 @@
 		</div>
 	{/if}
 </div>
+
+<!-- shared import drawer (YAML / JSON) for the detail-panel "Import …" actions -->
+<Drawer bind:this={importDrawer} size="800px">
+	<DrawerContent title={importTitles[importKind]} on:close={() => importDrawer?.closeDrawer?.()}>
+		<Tabs bind:selected={importType}>
+			<Tab value="yaml" label="YAML" />
+			<Tab value="json" label="JSON" />
+			{#snippet content()}
+				<div class="relative pt-2 h-full">
+					{#key importType}
+						{#await import('$lib/components/SimpleEditor.svelte')}
+							<Loader2 class="animate-spin" />
+						{:then Module}
+							<Module.default
+								bind:code={importRaw}
+								lang={importType}
+								class="h-full"
+								fixedOverflowWidgets={false}
+							/>
+						{/await}
+					{/key}
+				</div>
+			{/snippet}
+		</Tabs>
+		{#snippet actions()}
+			<Button size="sm" onClick={runImport}>Import</Button>
+		{/snippet}
+	</DrawerContent>
+</Drawer>

--- a/frontend/src/lib/components/home/CreateActionsMenu.svelte
+++ b/frontend/src/lib/components/home/CreateActionsMenu.svelte
@@ -1,0 +1,264 @@
+<script lang="ts">
+	import { base } from '$lib/base'
+	import { goto } from '$lib/navigation'
+	import { Button } from '$lib/components/common'
+	import { Plus, Code2, LayoutDashboard, ChevronRight } from 'lucide-svelte'
+	import BarsStaggered from '$lib/components/icons/BarsStaggered.svelte'
+	import { PythonIcon, TypeScriptIcon } from '$lib/components/common/languageIcons'
+	import { HOME_SHOW_CREATE_FLOW, HOME_SHOW_CREATE_APP } from '$lib/consts'
+
+	type Variant = {
+		label: string
+		icon: typeof PythonIcon
+		onSelect: () => void
+	}
+
+	type Option = {
+		key: string
+		label: string
+		icon: typeof Code2
+		/** tailwind accent token used for the icon tile / hover border */
+		accent: string
+		tagline: string
+		description: string
+		bullets: string[]
+		onSelect: () => void
+		/** optional sub-choices shown in place of the single create button */
+		variants?: Variant[]
+	}
+
+	const allOptions: Option[] = [
+		{
+			key: 'script',
+			label: 'Script',
+			icon: Code2,
+			accent: 'blue',
+			tagline: 'A single standalone script',
+			description:
+				'Author a script in Python, TypeScript, Go, Bash, SQL, Rust, PHP and more. Windmill auto-generates an input UI, deploys it instantly and exposes it as an API.',
+			bullets: [
+				'20+ languages',
+				'Auto-generated UI from parameters',
+				'Instant deploy & versioning'
+			],
+			onSelect: () => goto(`${base}/scripts/add`)
+		},
+		...(HOME_SHOW_CREATE_FLOW
+			? ([
+					{
+						key: 'flow',
+						label: 'Flow',
+						icon: BarsStaggered,
+						accent: 'teal',
+						tagline: 'Compose scripts into a workflow',
+						description:
+							'Visual builder for chaining scripts together with branches, loops, error handlers, approvals and retries. Each step can be reused from the workspace or the Hub.',
+						bullets: [
+							'Drag-and-drop steps',
+							'Branches, loops & error handling',
+							'Suspend / approval steps'
+						],
+						onSelect: () => goto(`${base}/flows/add`)
+					},
+					{
+						key: 'wac',
+						label: 'Workflow-as-Code',
+						icon: Code2,
+						accent: 'purple',
+						tagline: 'Express a workflow purely in code',
+						description:
+							'Write the whole workflow as a single Python or TypeScript script using the Windmill SDK — parallelism, branching and step orchestration expressed as plain code.',
+						bullets: [
+							'Python or TypeScript',
+							'Full control via the SDK',
+							'Versioned as a regular script'
+						],
+						onSelect: () => goto(`${base}/scripts/add?wac=typescript`),
+						variants: [
+							{
+								label: 'TypeScript',
+								icon: TypeScriptIcon,
+								onSelect: () => goto(`${base}/scripts/add?wac=typescript`)
+							},
+							{
+								label: 'Python',
+								icon: PythonIcon,
+								onSelect: () => goto(`${base}/scripts/add?wac=python`)
+							}
+						]
+					}
+				] as Option[])
+			: []),
+		...(HOME_SHOW_CREATE_APP
+			? ([
+					{
+						key: 'app-lowcode',
+						label: 'App (low-code)',
+						icon: LayoutDashboard,
+						accent: 'orange',
+						tagline: 'Drag-and-drop UI builder',
+						description:
+							'Assemble an internal UI from 60+ components wired to your scripts and flows. Best for simple apps or apps that need minimal customization.',
+						bullets: ['60+ ready-made components', 'No code required', 'Backed by scripts & flows'],
+						onSelect: () => goto(`${base}/apps/add`)
+					},
+					{
+						key: 'app-fullcode',
+						label: 'App (full-code)',
+						icon: Code2,
+						accent: 'purple',
+						tagline: 'Build with React or Svelte',
+						description:
+							'Full control over the UI with React or Svelte and a powerful AI agent. Best for complex apps that need full flexibility.',
+						bullets: ['React or Svelte', 'Full flexibility & control', 'AI-assisted authoring'],
+						onSelect: () => goto(`${base}/apps_raw/add`)
+					}
+				] as Option[])
+			: [])
+	]
+
+	// tailwind needs the full class names statically — map accent token -> classes
+	const accentClasses: Record<
+		string,
+		{ tile: string; iconText: string; activeBg: string; activeBorder: string }
+	> = {
+		blue: {
+			tile: 'bg-blue-100 dark:bg-blue-900/40',
+			iconText: 'text-blue-600 dark:text-blue-400',
+			activeBg: 'bg-blue-50 dark:bg-blue-900/20',
+			activeBorder: 'border-blue-500 dark:border-blue-400'
+		},
+		teal: {
+			tile: 'bg-teal-100 dark:bg-teal-900/40',
+			iconText: 'text-teal-600 dark:text-teal-400',
+			activeBg: 'bg-teal-50 dark:bg-teal-900/20',
+			activeBorder: 'border-teal-500 dark:border-teal-400'
+		},
+		purple: {
+			tile: 'bg-purple-100 dark:bg-purple-900/40',
+			iconText: 'text-purple-600 dark:text-purple-400',
+			activeBg: 'bg-purple-50 dark:bg-purple-900/20',
+			activeBorder: 'border-purple-500 dark:border-purple-400'
+		},
+		orange: {
+			tile: 'bg-orange-100 dark:bg-orange-900/40',
+			iconText: 'text-orange-600 dark:text-orange-400',
+			activeBg: 'bg-orange-50 dark:bg-orange-900/20',
+			activeBorder: 'border-orange-500 dark:border-orange-400'
+		}
+	}
+
+	let open = $state(false)
+	let activeKey = $state(allOptions[0]?.key)
+	let active = $derived(allOptions.find((o) => o.key === activeKey) ?? allOptions[0])
+	let activeAc = $derived(accentClasses[active.accent])
+
+	let closeTimeout: ReturnType<typeof setTimeout> | undefined
+	function scheduleOpen() {
+		if (closeTimeout) clearTimeout(closeTimeout)
+		open = true
+	}
+	function scheduleClose() {
+		if (closeTimeout) clearTimeout(closeTimeout)
+		closeTimeout = setTimeout(() => (open = false), 120)
+	}
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+	class="relative"
+	onmouseenter={scheduleOpen}
+	onmouseleave={scheduleClose}
+	onfocusin={scheduleOpen}
+	onfocusout={scheduleClose}
+>
+	<Button
+		id="create-new-button"
+		btnClasses="text-base"
+		aiId="home-create-new"
+		aiDescription="Create a new script, flow or app"
+		unifiedSize="lg"
+		variant="accent"
+		startIcon={{ icon: Plus }}
+		onClick={() => active?.onSelect()}
+	>
+		New
+	</Button>
+
+	{#if open && active}
+		<div class="absolute left-0 top-full z-50 pt-2" role="menu" tabindex="-1">
+			<div
+				class="flex flex-row rounded-lg border border-gray-200 dark:border-gray-700 bg-surface shadow-xl overflow-hidden"
+				style="width: 720px;"
+			>
+				<!-- Left: option list -->
+				<div
+					class="flex flex-col gap-0.5 p-2 w-72 shrink-0 border-r border-gray-200 dark:border-gray-700"
+				>
+					{#each allOptions as option (option.key)}
+						{@const ac = accentClasses[option.accent]}
+						{@const isActive = option.key === activeKey}
+						<button
+							class="flex flex-row items-center gap-3 rounded-md border px-2 py-2 text-left cursor-pointer transition-colors {isActive
+								? `${ac.activeBg} ${ac.activeBorder}`
+								: 'border-transparent hover:bg-surface-hover'}"
+							onmouseenter={() => (activeKey = option.key)}
+							onfocus={() => (activeKey = option.key)}
+							onclick={() => option.onSelect()}
+							role="menuitem"
+						>
+							<div class="w-8 h-8 rounded-md flex items-center justify-center shrink-0 {ac.tile}">
+								<option.icon size={18} class={ac.iconText} />
+							</div>
+							<span class="text-sm font-medium text-primary flex-1 min-w-0 whitespace-nowrap">
+								{option.label}
+							</span>
+							<ChevronRight
+								size={16}
+								class="transition-opacity {isActive ? `opacity-100 ${ac.iconText}` : 'opacity-0 text-tertiary'}"
+							/>
+						</button>
+					{/each}
+				</div>
+
+				<!-- Right: explanation of the highlighted editor -->
+				<div class="flex flex-col gap-3 p-5 flex-1 min-w-0">
+					<div class="flex flex-row items-center gap-3">
+						<div
+							class="w-12 h-12 rounded-xl flex items-center justify-center shrink-0 {activeAc.tile}"
+						>
+							<active.icon size={26} class={activeAc.iconText} />
+						</div>
+						<div class="min-w-0">
+							<h3 class="font-semibold text-primary leading-tight">{active.label}</h3>
+							<p class="text-xs text-tertiary">{active.tagline}</p>
+						</div>
+					</div>
+
+					<p class="text-sm text-secondary leading-relaxed">{active.description}</p>
+
+					<ul class="flex flex-col gap-1.5 mt-1">
+						{#each active.bullets as bullet (bullet)}
+							<li class="flex flex-row items-center gap-2 text-xs text-secondary">
+								<ChevronRight size={14} class={activeAc.iconText} />
+								{bullet}
+							</li>
+						{/each}
+					</ul>
+
+					{#if active.variants}
+						<div class="mt-auto flex flex-row gap-2 pt-2">
+							{#each active.variants as variant (variant.label)}
+								{@const VariantIcon = variant.icon}
+								<Button unifiedSize="sm" variant="accent" onClick={() => variant.onSelect()}>
+									<VariantIcon width={16} height={16} />
+									{variant.label}
+								</Button>
+							{/each}
+						</div>
+					{/if}
+				</div>
+			</div>
+		</div>
+	{/if}
+</div>

--- a/frontend/src/lib/components/home/CreateActionsMenu.svelte
+++ b/frontend/src/lib/components/home/CreateActionsMenu.svelte
@@ -16,7 +16,7 @@
 	type Option = {
 		key: string
 		label: string
-		icon: typeof Code2
+		icon: typeof Code2 | typeof BarsStaggered
 		/** tailwind accent token used for the icon tile / hover border */
 		accent: string
 		tagline: string
@@ -65,7 +65,26 @@
 							'Suspend / approval steps'
 						],
 						onSelect: () => goto(`${base}/flows/add`)
-					},
+					}
+				] as Option[])
+			: []),
+		...(HOME_SHOW_CREATE_APP
+			? ([
+					{
+						key: 'app-fullcode',
+						label: 'App (full-code)',
+						icon: LayoutDashboard,
+						accent: 'purple',
+						tagline: 'Build with React or Svelte',
+						description:
+							'Full control over the UI with React or Svelte and a powerful AI agent. Best for complex apps that need full flexibility.',
+						bullets: ['React or Svelte', 'Full flexibility & control', 'AI-assisted authoring'],
+						onSelect: () => goto(`${base}/apps_raw/add`)
+					}
+				] as Option[])
+			: []),
+		...(HOME_SHOW_CREATE_FLOW
+			? ([
 					{
 						key: 'wac',
 						label: 'Workflow-as-Code',
@@ -109,17 +128,6 @@
 						bullets: ['60+ ready-made components', 'No code required', 'Backed by scripts & flows'],
 						onSelect: () => goto(`${base}/apps/add`),
 						badge: { label: 'Legacy', class: badgeLegacy }
-					},
-					{
-						key: 'app-fullcode',
-						label: 'App (full-code)',
-						icon: Code2,
-						accent: 'purple',
-						tagline: 'Build with React or Svelte',
-						description:
-							'Full control over the UI with React or Svelte and a powerful AI agent. Best for complex apps that need full flexibility.',
-						bullets: ['React or Svelte', 'Full flexibility & control', 'AI-assisted authoring'],
-						onSelect: () => goto(`${base}/apps_raw/add`)
 					}
 				] as Option[])
 			: [])

--- a/frontend/src/lib/components/home/CreateActionsMenu.svelte
+++ b/frontend/src/lib/components/home/CreateActionsMenu.svelte
@@ -6,7 +6,15 @@
 	import DrawerContent from '$lib/components/common/drawer/DrawerContent.svelte'
 	import Tabs from '$lib/components/common/tabs/Tabs.svelte'
 	import Tab from '$lib/components/common/tabs/Tab.svelte'
-	import { Plus, Code2, LayoutDashboard, ChevronRight, Loader2, Workflow } from 'lucide-svelte'
+	import {
+		Plus,
+		Code2,
+		LayoutDashboard,
+		ChevronRight,
+		Loader2,
+		Workflow,
+		Import
+	} from 'lucide-svelte'
 	import BarsStaggered from '$lib/components/icons/BarsStaggered.svelte'
 	import { PythonIcon, TypeScriptIcon } from '$lib/components/common/languageIcons'
 	import { HOME_SHOW_CREATE_FLOW, HOME_SHOW_CREATE_APP } from '$lib/consts'
@@ -343,7 +351,12 @@
 							{#if active.extras}
 								<div class="flex flex-row flex-wrap gap-2">
 									{#each active.extras as extra (extra.label)}
-										<Button unifiedSize="sm" variant="subtle" onClick={() => extra.onSelect()}>
+										<Button
+											unifiedSize="sm"
+											variant="default"
+											startIcon={{ icon: Import }}
+											onClick={() => extra.onSelect()}
+										>
 											{extra.label}
 										</Button>
 									{/each}
@@ -355,9 +368,12 @@
 
 				<!-- option list -->
 				<div class="flex flex-col gap-0.5 p-2 w-[21rem] shrink-0">
-					{#each allOptions as option (option.key)}
+					{#each allOptions as option, i (option.key)}
 						{@const ac = accentClasses[option.accent]}
 						{@const isActive = option.key === activeKey}
+						{#if option.badge && !allOptions[i - 1]?.badge}
+							<div class="mx-1 my-1 border-t border-gray-200 dark:border-gray-700"></div>
+						{/if}
 						<button
 							class="flex flex-row items-center gap-3 rounded-md border px-2 py-2 text-left cursor-pointer transition-colors {isActive
 								? `${ac.activeBg} ${ac.activeBorder}`

--- a/frontend/src/lib/components/home/CreateActionsMenu.svelte
+++ b/frontend/src/lib/components/home/CreateActionsMenu.svelte
@@ -145,7 +145,7 @@
 					},
 					{
 						key: 'pipeline',
-						label: 'Data pipelines editor',
+						label: 'Data pipelines',
 						icon: Workflow,
 						accent: 'indigo',
 						tagline: 'Compose data ingestion & transforms',

--- a/frontend/src/lib/components/home/CreateActionsMenu.svelte
+++ b/frontend/src/lib/components/home/CreateActionsMenu.svelte
@@ -186,42 +186,12 @@
 	</Button>
 
 	{#if open && active}
-		<div class="absolute left-0 top-full z-50 pt-2" role="menu" tabindex="-1">
+		<div class="absolute right-0 top-full z-50 pt-2" role="menu" tabindex="-1">
 			<div
 				class="flex flex-row rounded-lg border border-gray-200 dark:border-gray-700 bg-surface shadow-xl overflow-hidden"
 				style="width: 720px;"
 			>
-				<!-- Left: option list -->
-				<div
-					class="flex flex-col gap-0.5 p-2 w-72 shrink-0 border-r border-gray-200 dark:border-gray-700"
-				>
-					{#each allOptions as option (option.key)}
-						{@const ac = accentClasses[option.accent]}
-						{@const isActive = option.key === activeKey}
-						<button
-							class="flex flex-row items-center gap-3 rounded-md border px-2 py-2 text-left cursor-pointer transition-colors {isActive
-								? `${ac.activeBg} ${ac.activeBorder}`
-								: 'border-transparent hover:bg-surface-hover'}"
-							onmouseenter={() => (activeKey = option.key)}
-							onfocus={() => (activeKey = option.key)}
-							onclick={() => option.onSelect()}
-							role="menuitem"
-						>
-							<div class="w-8 h-8 rounded-md flex items-center justify-center shrink-0 {ac.tile}">
-								<option.icon size={18} class={ac.iconText} />
-							</div>
-							<span class="text-sm font-medium text-primary flex-1 min-w-0 whitespace-nowrap">
-								{option.label}
-							</span>
-							<ChevronRight
-								size={16}
-								class="transition-opacity {isActive ? `opacity-100 ${ac.iconText}` : 'opacity-0 text-tertiary'}"
-							/>
-						</button>
-					{/each}
-				</div>
-
-				<!-- Right: explanation of the highlighted editor -->
+				<!-- explanation of the highlighted editor -->
 				<div class="flex flex-col gap-3 p-5 flex-1 min-w-0">
 					<div class="flex flex-row items-center gap-3">
 						<div
@@ -257,6 +227,36 @@
 							{/each}
 						</div>
 					{/if}
+				</div>
+
+				<!-- option list -->
+				<div
+					class="flex flex-col gap-0.5 p-2 w-72 shrink-0 border-l border-gray-200 dark:border-gray-700"
+				>
+					{#each allOptions as option (option.key)}
+						{@const ac = accentClasses[option.accent]}
+						{@const isActive = option.key === activeKey}
+						<button
+							class="flex flex-row items-center gap-3 rounded-md border px-2 py-2 text-left cursor-pointer transition-colors {isActive
+								? `${ac.activeBg} ${ac.activeBorder}`
+								: 'border-transparent hover:bg-surface-hover'}"
+							onmouseenter={() => (activeKey = option.key)}
+							onfocus={() => (activeKey = option.key)}
+							onclick={() => option.onSelect()}
+							role="menuitem"
+						>
+							<div class="w-8 h-8 rounded-md flex items-center justify-center shrink-0 {ac.tile}">
+								<option.icon size={18} class={ac.iconText} />
+							</div>
+							<span class="text-sm font-medium text-primary flex-1 min-w-0 whitespace-nowrap">
+								{option.label}
+							</span>
+							<ChevronRight
+								size={16}
+								class="transition-opacity {isActive ? `opacity-100 ${ac.iconText}` : 'opacity-0 text-tertiary'}"
+							/>
+						</button>
+					{/each}
 				</div>
 			</div>
 		</div>

--- a/frontend/src/lib/components/home/ItemsList.svelte
+++ b/frontend/src/lib/components/home/ItemsList.svelte
@@ -506,7 +506,8 @@
 		if (menuItem) {
 			if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
 				const menu = menuItem.closest<HTMLElement>('[role="menu"]')
-				if (menu) {
+				// menus marked data-arrow-loop keep melt's cyclic wrap instead of exiting
+				if (menu && !menu.hasAttribute('data-arrow-loop')) {
 					const items = Array.from(menu.querySelectorAll<HTMLElement>('[role="menuitem"]'))
 					const idx = items.indexOf(menuItem)
 					const isFirst = idx === 0

--- a/frontend/src/routes/(root)/(logged)/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/+page.svelte
@@ -285,11 +285,11 @@
 			<h1 class="text-2xl font-semibold text-emphasis whitespace-nowrap leading-6 tracking-tight">
 				Home
 			</h1>
-			<div class="ml-auto flex flex-row gap-2 items-start">
+			<div class="ml-auto flex flex-row gap-2 items-center">
 				{#if !$userStore?.operator && HOME_SHOW_HUB}
 					<Button
 						variant="default"
-						unifiedSize="sm"
+						unifiedSize="md"
 						startIcon={{ icon: Globe2 }}
 						endIcon={{ icon: ExternalLink }}
 						href={$hubBaseUrlStore}
@@ -301,7 +301,7 @@
 				{/if}
 				<Button
 					variant="default"
-					unifiedSize="sm"
+					unifiedSize="md"
 					startIcon={{ icon: PlugZap }}
 					btnClasses="whitespace-nowrap"
 					onClick={() => homeConnectDrawer?.openDrawer?.()}
@@ -309,7 +309,7 @@
 					CLI / MCP
 				</Button>
 				{#if !$userStore?.operator && showCreateButtons}
-					<div class="ml-4">
+					<div class="ml-2">
 						<CreateActionsMenu />
 					</div>
 				{/if}

--- a/frontend/src/routes/(root)/(logged)/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/+page.svelte
@@ -282,14 +282,10 @@
 			</Alert>
 		{/if}
 		<div class="flex flex-row flex-wrap justify-between items-center gap-3 pb-2 my-4 mr-2 min-h-16">
-			{#if !$userStore?.operator && showCreateButtons}
-				<CreateActionsMenu />
-			{:else}
-				<h1 class="text-2xl font-semibold text-emphasis whitespace-nowrap leading-6 tracking-tight">
-					Home
-				</h1>
-			{/if}
-			<div class="ml-auto flex flex-row gap-2 items-center">
+			<h1 class="text-2xl font-semibold text-emphasis whitespace-nowrap leading-6 tracking-tight">
+				Home
+			</h1>
+			<div class="ml-auto flex flex-row gap-2 items-start">
 				{#if !$userStore?.operator && HOME_SHOW_HUB}
 					<Button
 						variant="default"
@@ -312,6 +308,11 @@
 				>
 					CLI / MCP
 				</Button>
+				{#if !$userStore?.operator && showCreateButtons}
+					<div class="ml-4">
+						<CreateActionsMenu />
+					</div>
+				{/if}
 			</div>
 		</div>
 

--- a/frontend/src/routes/(root)/(logged)/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/+page.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
 	import { AppService, FlowService, type OpenFlow, type Script } from '$lib/gen'
 	import { userStore, workspaceStore } from '$lib/stores'
-	import { Alert, Button, Drawer, DrawerContent, Tab, Tabs } from '$lib/components/common'
+	import { Alert, Button, Drawer, DrawerContent } from '$lib/components/common'
 	import ToggleButtonGroup from '$lib/components/common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import ToggleButton from '$lib/components/common/toggleButton-v2/ToggleButton.svelte'
 	import FlowIcon from '$lib/components/home/FlowIcon.svelte'
-	import PageHeader from '$lib/components/PageHeader.svelte'
-	import CreateActionsFlow from '$lib/components/flows/CreateActionsFlow.svelte'
-	import CreateActionsScript from '$lib/components/scripts/CreateActionsScript.svelte'
+	import CreateActionsMenu from '$lib/components/home/CreateActionsMenu.svelte'
 	import { getScriptByPath } from '$lib/scripts'
 	import type { HubItem } from '$lib/components/flows/pickers/model'
 	import PickHubScript from '$lib/components/flows/pickers/PickHubScript.svelte'
@@ -15,7 +13,6 @@
 	import HighlightCode from '$lib/components/HighlightCode.svelte'
 	import HomeConnectDrawer from '$lib/components/home/HomeConnectDrawer.svelte'
 	import {
-		Building,
 		ExternalLink,
 		GitFork,
 		Globe2,
@@ -28,11 +25,10 @@
 	import { base } from '$lib/base'
 
 	import ItemsList from '$lib/components/home/ItemsList.svelte'
-	import CreateActionsApp from '$lib/components/flows/CreateActionsApp.svelte'
 	import PickHubApp from '$lib/components/flows/pickers/PickHubApp.svelte'
 	import { writable } from 'svelte/store'
 	import type { EditorBreakpoint } from '$lib/components/apps/types'
-	import { HOME_SHOW_HUB, HOME_SHOW_CREATE_FLOW, HOME_SHOW_CREATE_APP } from '$lib/consts'
+	import { HOME_SHOW_HUB } from '$lib/consts'
 	import { setQuery } from '$lib/navigation'
 	import { page } from '$app/state'
 	import { goto, replaceState } from '$app/navigation'
@@ -49,11 +45,7 @@
 
 	type Tab = 'hub' | 'workspace'
 
-	let tab: Tab = $state(
-		window.location.hash == '#workspace' || window.location.hash == '#hub'
-			? (window.location.hash?.replace('#', '') as Tab)
-			: 'workspace'
-	)
+	let tab = $state<Tab>('workspace')
 
 	let subtab: 'flow' | 'script' | 'app' = $state('script')
 
@@ -289,11 +281,28 @@
 				Windmill instance, such as keeping resource types up to date.
 			</Alert>
 		{/if}
-		<PageHeader
-			title="Home"
-			childrenWrapperDivClasses="flex-1 flex flex-row gap-4 flex-wrap justify-end items-center"
-		>
-			{#if $userStore?.operator}
+		<div class="flex flex-row flex-wrap justify-between items-center gap-3 pb-2 my-4 mr-2 min-h-16">
+			{#if !$userStore?.operator && showCreateButtons}
+				<CreateActionsMenu />
+			{:else}
+				<h1 class="text-2xl font-semibold text-emphasis whitespace-nowrap leading-6 tracking-tight">
+					Home
+				</h1>
+			{/if}
+			<div class="ml-auto flex flex-row gap-2 items-center">
+				{#if !$userStore?.operator && HOME_SHOW_HUB}
+					<Button
+						variant="default"
+						unifiedSize="sm"
+						startIcon={{ icon: Globe2 }}
+						endIcon={{ icon: ExternalLink }}
+						href={$hubBaseUrlStore}
+						target="_blank"
+						btnClasses="whitespace-nowrap"
+					>
+						Hub
+					</Button>
+				{/if}
 				<Button
 					variant="default"
 					unifiedSize="sm"
@@ -303,40 +312,13 @@
 				>
 					CLI / MCP
 				</Button>
-			{/if}
-			{#if !$userStore?.operator && showCreateButtons}
-				<CreateActionsScript aiId="create-script-button" aiDescription="Creates a new script" />
-				{#if HOME_SHOW_CREATE_FLOW}<CreateActionsFlow />{/if}
-				{#if HOME_SHOW_CREATE_APP}<CreateActionsApp />{/if}
-			{/if}
-		</PageHeader>
+			</div>
+		</div>
 
 		<TutorialBanner />
 
 		<NoDirectDeployAlert onUpdateCanEditStatus={(v) => (showCreateButtons = v)} />
 
-		{#if !$userStore?.operator}
-			<div class="flex w-full items-center gap-3 pb-2">
-				<div class="min-w-0 flex-1 overflow-auto scrollbar-hidden">
-					<Tabs values={['hub', 'workspace']} hashNavigation bind:selected={tab}>
-						<Tab value="workspace" label="Workspace" icon={Building} />
-						{#if HOME_SHOW_HUB}
-							<Tab value="hub" label="Hub" icon={Globe2} />
-						{/if}
-					</Tabs>
-				</div>
-
-				<Button
-					variant="default"
-					unifiedSize="sm"
-					startIcon={{ icon: PlugZap }}
-					btnClasses="whitespace-nowrap shrink-0"
-					onClick={() => homeConnectDrawer?.openDrawer?.()}
-				>
-					CLI / MCP
-				</Button>
-			</div>
-		{/if}
 		{#if tab == 'hub'}
 			<div class="flex flex-col gap-y-16">
 				<div class="flex flex-col pb-8">


### PR DESCRIPTION
## Summary

Redesigns the home page header and the "create new" entry point. A hover-driven
**New** popover replaces the scattered create buttons, the **Workspace / Hub** tab
switcher is replaced by a Hub link button (the page now shows only the workspace
list), and the header is reorganized around the `Home` title.

## Changes

- **New `CreateActionsMenu` popover** (`frontend/src/lib/components/home/CreateActionsMenu.svelte`):
  - Two-pane (720px) hover menu — **description on the left, option list on the
    right** — Script, Flow, App (full-code), Workflow-as-Code, Data pipelines editor (alpha), App (low-code)
    (gated by the existing `HOME_SHOW_CREATE_*` flags). Both App entries share the
    dashboard icon, distinguished by accent color.
  - **Workflow-as-Code** offers a **Python / TypeScript** choice (buttons with
    language icons) routing to `/scripts/add?wac=python|typescript`.
  - **Workflow-as-Code** is badged **Advanced** and **App (low-code)** **Legacy** (inline pills next to the label and in the description header).
  - **Secondary actions per detail panel** (carried over from the old create menus): Flow → *Import flow* + *Pipeline (alpha)*; Workflow-as-Code → *Import Workflow-as-Code*; App (full/low-code) → *Import full/low-code app*. A shared YAML/JSON import drawer parses the pasted source into the matching store (or `sessionStorage` for the full-reload `apps_raw` route) and navigates.
  - Other options are created by clicking the list row (accent border + chevron +
    pointer cursor signal clickability); no per-option "Create X" button.
  - Option list is split by a separator: the three plain options above, the three badged (Advanced / Alpha / Legacy) ones below. Import actions render as bordered buttons with an import icon.
  - The trigger **New** button uses a larger label (`text-base`); the menu opens
    leftward to stay on screen.
- **Home header** (`+page.svelte`):
  - `Home` title on the left; **Hub**, **CLI / MCP**, and the **New** popover on the
    right. Hub/CLI-MCP are top-aligned with the taller New button, with extra gap
    before New.
  - **CLI / MCP** collapsed from two duplicate operator/non-operator buttons into one.
  - External **Hub** link button (gated by `!operator && HOME_SHOW_HUB`) pointing at
    `$hubBaseUrlStore`.
  - Removed the in-page **Workspace / Hub** tab switcher; the page is pinned to the
    workspace list.

## Known follow-up (intentional, flagged by local review)

Pinning `tab` to `'workspace'` leaves the in-page hub-browser block
(`{#if tab == 'hub'}`) and its three viewer drawers / `viewCode`·`viewFlow`·`viewApp`
functions **unreachable**. They are left in place for now rather than deleting a
large interconnected feature (with many shared imports) in the same change. If we are
not restoring the in-page hub browser, a follow-up should delete that block, the
drawers, the orphaned functions, and their now-unused imports.

## Screenshots

**Header (uniform `md` buttons, New is accent)**

![header](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/worktree-home-plus-new-popover/1782635202-header-md.png)

**New popover (description left, list right, no divider, with Advanced/Legacy badges)**

![popover](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/worktree-home-plus-new-popover/1782636902-reordered.png)

**Workflow-as-Code TS / Python choice**

![wac](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/worktree-home-plus-new-popover/1782634482-wac-final.png)

**Detail-panel secondary actions (Flow / Workflow-as-Code) + import drawer**

![flow-extras](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/worktree-home-plus-new-popover/1782639751-grouped-extras.png)

![wac-extras](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/worktree-home-plus-new-popover/1782637785-wac-extras.png)

![import-drawer](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/worktree-home-plus-new-popover/1782637787-import-drawer.png)

**Data pipelines editor option (alpha)**

![data-pipelines](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/worktree-home-plus-new-popover/1782639082-data-pipelines.png)

## Test plan

- [ ] As a non-operator with edit rights: hover **New** → 720px two-pane popover opens (description left, list right); hovering each option updates the description pane + accent color.
- [ ] Clicking Script / Flow / App rows navigates to `/scripts/add`, `/flows/add`, `/apps/add`, `/apps_raw/add`.
- [ ] Workflow-as-Code **TypeScript** / **Python** buttons navigate to `/scripts/add?wac=typescript|python`.
- [ ] Clicking **New** directly creates the active default (Script).
- [ ] Header shows `Home` on the left and **Hub** / **CLI / MCP** / **New** on the right; Hub opens the hub base URL in a new tab (only when `HOME_SHOW_HUB`), CLI/MCP opens the connect drawer.
- [ ] Home page no longer shows the Workspace/Hub tabs; only the workspace list.
- [ ] Flow panel: **Import flow** opens the YAML/JSON drawer; **Pipeline (alpha)** goes to `/pipeline`.
- [ ] **Import Workflow-as-Code** / **Import full-code app** / **Import low-code app** each open the drawer; pasting a valid export lands pre-filled at `/scripts/add?import=true`, `/apps_raw/add`, `/apps/add` respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
