### PR TITLE
feat(apps): add labels input to app editor deploy drawer

### DIFF
--- a/frontend/src/lib/components/apps/editor/AppEditor.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditor.svelte
@@ -69,6 +69,7 @@
 		path,
 		policy,
 		summary,
+		labels,
 		deployedBaseline = undefined,
 		fromHub = false,
 		diffDrawer = undefined,
@@ -885,6 +886,7 @@
 		<AppEditorHeader
 			{newPath}
 			{newApp}
+			{labels}
 			userDraftPath={appDraftPath}
 			{onResetToDeployed}
 			{loadedFromDraft}

--- a/frontend/src/lib/components/apps/editor/AppEditorHeader.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeader.svelte
@@ -88,6 +88,7 @@
 					summary: string
 					policy: any
 					custom_path?: string
+					labels?: string[]
 			  }
 			| undefined
 		version?: number | undefined
@@ -96,6 +97,8 @@
 		bottomPanelHidden?: boolean
 		newApp: boolean
 		newPath?: string
+		/** Initial labels for the app, threaded from the loaded app data via AppEditor. */
+		labels?: string[]
 		/** URL path the draft is keyed under; empty on `/apps/add` (no draft yet). */
 		userDraftPath?: string
 		onSavedNewAppPath?: (path: string) => void
@@ -125,6 +128,7 @@
 		bottomPanelHidden = false,
 		newApp,
 		newPath = '',
+		labels: initialLabels = undefined,
 		userDraftPath = '',
 		onSavedNewAppPath,
 		onShowLeftPanel,
@@ -256,7 +260,8 @@
 					policy,
 					deployment_message: deploymentMsg,
 					custom_path: customPath,
-					preserve_on_behalf_of: preserveOnBehalfOf || undefined
+					preserve_on_behalf_of: preserveOnBehalfOf || undefined,
+					labels
 				}
 			})
 			// New path now exists server-side — drop the autocomplete cache so
@@ -267,7 +272,8 @@
 				value: structuredClone($state.snapshot($app)),
 				path: path,
 				policy: policy,
-				custom_path: customPath
+				custom_path: customPath,
+				labels: $state.snapshot(labels)
 			}
 			closeSaveDrawer()
 			sendUserToast('App deployed successfully')
@@ -310,7 +316,8 @@
 							value: $app,
 							path: newEditedPath || savedApp.path,
 							policy,
-							custom_path: customPath
+							custom_path: customPath,
+							labels
 						})
 					)
 			) {
@@ -361,7 +368,8 @@
 				// it also means that customPath needs to be set to '' instead of undefined to unset it (when admin)
 				custom_path:
 					$userStore?.is_admin || $userStore?.is_super_admin ? (customPath ?? '') : undefined,
-				preserve_on_behalf_of: preserveOnBehalfOf || undefined
+				preserve_on_behalf_of: preserveOnBehalfOf || undefined,
+				labels
 			}
 		})
 		invalidateWorkspacePaths($workspaceStore!)
@@ -370,7 +378,8 @@
 			value: structuredClone($state.snapshot($app)),
 			path: npath,
 			policy,
-			custom_path: customPath
+			custom_path: customPath,
+			labels: $state.snapshot(labels)
 		}
 		const appHistory = await AppService.getAppHistoryByPath({
 			workspace: $workspaceStore!,
@@ -624,7 +633,8 @@
 						value: $app,
 						path: newEditedPath || savedApp.path,
 						policy,
-						custom_path: customPath
+						custom_path: customPath,
+						labels
 					}
 				})
 			},
@@ -723,6 +733,7 @@
 	})
 
 	let customPath = $state(savedApp?.custom_path)
+	let labels = $state(untrack(() => initialLabels))
 
 	$effect(() => {
 		if ($openDebugRun == undefined) {
@@ -752,7 +763,8 @@
 		value: $app,
 		path: newEditedPath || savedApp?.path,
 		policy,
-		custom_path: customPath
+		custom_path: customPath,
+		labels
 	}}
 />
 
@@ -849,6 +861,7 @@
 			bind:pathError
 			bind:newEditedPath
 			bind:preserveOnBehalfOf
+			bind:labels
 			hideSecretUrl={false}
 		/>
 	</DrawerContent>

--- a/frontend/src/lib/components/apps/editor/AppEditorHeader.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeader.svelte
@@ -808,7 +808,8 @@
 								value: $app,
 								path: newEditedPath || savedApp.path,
 								policy,
-								custom_path: customPath
+								custom_path: customPath,
+								labels
 							},
 							button: {
 								text: 'Looks good, deploy',

--- a/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
@@ -16,6 +16,7 @@
 	import { isCloudHosted } from '$lib/cloud'
 	import EEOnly from '$lib/components/EEOnly.svelte'
 	import TextInput from '$lib/components/text_input/TextInput.svelte'
+	import LabelsInput from '$lib/components/LabelsInput.svelte'
 	import OnBehalfOfSelector, {
 		type OnBehalfOfChoice
 	} from '$lib/components/OnBehalfOfSelector.svelte'
@@ -38,6 +39,7 @@
 		newPath,
 		hideSecretUrl = false,
 		preserveOnBehalfOf = $bindable(false),
+		labels = $bindable(),
 		rawApp = false,
 		newApp = false
 	}: {
@@ -55,6 +57,7 @@
 		newPath: string
 		hideSecretUrl?: boolean
 		preserveOnBehalfOf?: boolean
+		labels?: string[] | undefined
 		// Raw apps need cross-origin isolation (wm_coep) to be embeddable. Classic
 		// (low-code) apps must NOT get the flag — it would force COEP on the
 		// document and break no-CORP cross-origin subresources (external images,
@@ -201,6 +204,8 @@
 		bind:value={summary}
 	/>
 </div>
+<div class="pt-3"></div>
+<LabelsInput bind:labels class="-mt-4" />
 <div class="py-6"></div>
 <label for="deploymentMsg" class="text-emphasis text-xs font-semibold">Deployment message</label>
 <div class="w-full pt-1">

--- a/frontend/src/lib/components/apps/types.ts
+++ b/frontend/src/lib/components/apps/types.ts
@@ -144,6 +144,8 @@ export interface AppEditorProps {
 	path: string
 	policy: Policy
 	summary: string
+	/** Initial labels for the app, threaded from the loaded app data. */
+	labels?: string[]
 	/** Deployed app value the autosave `discardIf` compares against, so an
 	 * edit reverting to deployed clears the draft instead of leaving a no-op.
 	 * `undefined` for draft-only paths (no deployed baseline). */
@@ -157,6 +159,7 @@ export interface AppEditorProps {
 				summary: string
 				policy: any
 				custom_path?: string
+				labels?: string[]
 		  }
 		| undefined
 	version?: number | undefined

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -71,6 +71,8 @@
 		summary?: string
 		path: string
 		newPath?: string | undefined
+		/** Initial labels for the app, threaded from the loaded app data. */
+		labels?: string[]
 		savedApp?:
 			| {
 					value: any
@@ -82,6 +84,7 @@
 					/** No deployed counterpart exists (draft-only); disables Diff. */
 					no_deployed?: boolean
 					custom_path?: string
+					labels?: string[]
 			  }
 			| undefined
 		diffDrawer?: DiffDrawer | undefined
@@ -132,6 +135,7 @@
 		summary = $bindable(''),
 		path,
 		newPath = undefined,
+		labels = undefined,
 		savedApp = $bindable(undefined),
 		diffDrawer = undefined,
 		onNavigate,
@@ -1602,6 +1606,7 @@
 		{diffDrawer}
 		{newApp}
 		{newPath}
+		{labels}
 		appPath={path}
 		{liveEditorDraftStoragePath}
 		{autosaveWorkspace}

--- a/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
@@ -102,6 +102,7 @@
 					summary: string
 					policy: any
 					custom_path?: string
+					labels?: string[]
 					/** No deployed counterpart exists (draft-only); disables Diff. */
 					no_deployed?: boolean
 			  }
@@ -109,6 +110,8 @@
 		version?: number | undefined
 		newApp: boolean
 		newPath?: string
+		/** Initial labels for the app, threaded from the loaded app data. */
+		labels?: string[]
 		appPath: string
 		runnables: Record<string, Runnable>
 		files: Record<string, string> | undefined
@@ -161,6 +164,7 @@
 		version = $bindable(undefined),
 		newApp,
 		newPath = '',
+		labels: initialLabels = undefined,
 		appPath,
 		runnables,
 		data,
@@ -321,7 +325,8 @@
 						policy,
 						deployment_message: deploymentMsg,
 						custom_path: customPath,
-						preserve_on_behalf_of: preserveOnBehalfOf || undefined
+						preserve_on_behalf_of: preserveOnBehalfOf || undefined,
+						labels
 					},
 					js,
 					css
@@ -335,7 +340,8 @@
 				value: structuredClone(stateSnapshot(app)),
 				path: path,
 				policy: policy,
-				custom_path: customPath
+				custom_path: customPath,
+				labels: $state.snapshot(labels)
 			}
 			closeSaveDrawer()
 			sendUserToast('App deployed successfully')
@@ -444,7 +450,8 @@
 					// custom_path requires admin so to accept update without it, we need to send as undefined when non-admin (when undefined, it will be ignored)
 					// it also means that customPath needs to be set to '' instead of undefined to unset it (when admin)
 					custom_path:
-						$userStore?.is_admin || $userStore?.is_super_admin ? (customPath ?? '') : undefined
+						$userStore?.is_admin || $userStore?.is_super_admin ? (customPath ?? '') : undefined,
+					labels
 				},
 				js,
 				css
@@ -456,7 +463,8 @@
 			value: structuredClone(stateSnapshot(app)),
 			path: npath,
 			policy,
-			custom_path: customPath
+			custom_path: customPath,
+			labels: $state.snapshot(labels)
 		}
 		const appHistory = await AppService.getAppHistoryByPath({
 			workspace: $workspaceStore!,
@@ -579,6 +587,7 @@
 
 	let customPath = $state(savedApp?.custom_path)
 	let customPathError = $state('')
+	let labels = $state(untrack(() => initialLabels))
 
 	let jobsDrawerOpen = $state(false)
 
@@ -592,7 +601,8 @@
 			value: app,
 			path: newEditedPath || savedApp?.path,
 			policy,
-			custom_path: customPath
+			custom_path: customPath,
+			labels
 		})
 	)
 
@@ -682,6 +692,7 @@
 			bind:pathError
 			bind:newEditedPath
 			bind:preserveOnBehalfOf
+			bind:labels
 		/>
 	</DrawerContent>
 </Drawer>

--- a/frontend/src/routes/(root)/(logged)/apps/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps/edit/[...path]/+page.svelte
@@ -33,6 +33,7 @@
 				summary: string
 				policy: any
 				custom_path?: string
+				labels?: string[]
 		  }
 		| undefined = $state(undefined)
 	let redraw = $state(0)
@@ -297,7 +298,8 @@
 			value: backendApp_.value as App,
 			path: backendApp_.path,
 			policy: backendApp_.policy,
-			custom_path: backendApp_.custom_path
+			custom_path: backendApp_.custom_path,
+			labels: backendApp_.labels
 		}
 		// "Load another user's draft" handoff: render their value. Overlay mode (we
 		// have our own draft) hard-locks saves until the user confirms overwriting
@@ -404,7 +406,8 @@
 			value: app_.value as App,
 			path: app_.path,
 			policy: app_.policy,
-			custom_path: app_.custom_path
+			custom_path: app_.custom_path,
+			labels: (app_ as { labels?: string[] }).labels
 		}
 		redraw++
 	}
@@ -473,6 +476,7 @@
 				on:restore={onRestore}
 				summary={app.summary}
 				app={app.value}
+				labels={app.labels}
 				{deployedBaseline}
 				newPath={app.value?.draft_path ?? app.path}
 				path={page.params.path ?? ''}

--- a/frontend/src/routes/(root)/(logged)/apps/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps/edit/[...path]/+page.svelte
@@ -407,7 +407,7 @@
 			path: app_.path,
 			policy: app_.policy,
 			custom_path: app_.custom_path,
-			labels: (app_ as { labels?: string[] }).labels
+			labels: app_.labels
 		}
 		redraw++
 	}

--- a/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
@@ -182,6 +182,10 @@
 			loadedFromDraft = false
 			draftSavedAt = undefined
 			deployedAt = undefined
+			// `labels` is route-level state; reset it too so a fresh draft doesn't
+			// inherit (and then deploy) the previously-opened app's labels. The
+			// import branch re-seeds it via extractRawApp below.
+			labels = undefined
 			// Brand-new raw app: no deployed baseline, so never discard-on-equal.
 			deployedBaseline = undefined
 			// Suspend autosave across the bootstrap: the seed template and the

--- a/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
@@ -57,6 +57,7 @@
 	// let lastVersion = 0
 	let policy: any = $state({})
 	let summary = $state('')
+	let labels = $state<string[] | undefined>(undefined)
 	/** User-typed path from `RawAppEditorHeader` when it differs from
 	 *  `savedApp.path`; mirrored into the draft below as `draft_path` for the
 	 *  home list's friendly name. */
@@ -72,6 +73,7 @@
 				summary: string
 				policy: any
 				custom_path?: string
+				labels?: string[]
 				no_deployed?: boolean
 		  }
 		| undefined = $state(undefined)
@@ -140,6 +142,7 @@
 		if (extractedData) data = extractedData
 		files = app.value.files
 		summary = app.summary
+		labels = app.labels
 		// lastVersion = app.version
 		policy = app.policy
 		// Prefer the saved `draft_path` so the topbar shows the pending name, not
@@ -355,6 +358,7 @@
 			path: backendApp_.path,
 			policy: backendApp_.policy,
 			custom_path: backendApp_.custom_path,
+			labels: backendApp_.labels,
 			no_deployed: backendApp_.no_deployed
 		}
 		// Extract the effective raw app into the editor's local pieces. The bundle
@@ -458,7 +462,8 @@
 			value: structuredClone(stateSnapshot(prev.value)),
 			path: prev.path,
 			policy: structuredClone(stateSnapshot(policy)),
-			custom_path: prev.custom_path
+			custom_path: prev.custom_path,
+			labels: prev.labels
 		}
 		redraw++
 	}
@@ -548,6 +553,7 @@
 				bind:summary
 				bind:pendingDraftPath
 				{newPath}
+				{labels}
 				path={page.params.path ?? ''}
 				liveEditorDraftStoragePath={path}
 				{policy}


### PR DESCRIPTION
## Summary

The labels feature (`c4c9ef5fd`) added backend/API support for labels on apps and wired the `LabelsInput` component into the script editor, flow editor, schedule editor, resource form and variable form — but the **app editor** was left out. It had no `LabelsInput`, no labels state, and the `createApp()`/`updateApp()` calls never sent `labels`, so apps created or edited via the UI could not be labeled despite full backend support.

This PR threads the deployed app's labels through to the deploy drawer and back, for **both** the low-code app editor and the raw-app editor (which shares the same deploy drawer component, so it's wired symmetrically to avoid leaking a non-functional input).

Fixes WIN-2107

## Changes

- **`AppEditorHeaderDeploy.svelte`**: import `LabelsInput`, add a bindable `labels` prop, render `<LabelsInput bind:labels class="-mt-4" />` after the summary field (matching `ScriptBuilder.svelte` / `FlowSettings.svelte`).
- **`AppEditorHeader.svelte`**: add a `labels` reactive state seeded from the loaded app data, include it in the `createApp`/`updateApp` request bodies, the `savedApp` snapshot, and the diff/deploy comparison values; thread it bindably to `AppEditorHeaderDeploy`.
- **`AppEditor.svelte`** + **`apps/types.ts`**: accept and forward the `labels` prop; add `labels` to `AppEditorProps` and the `savedApp` shape.
- **`apps/edit/[...path]/+page.svelte`**: thread `app.labels` into `AppEditor`; include `labels` in the load and restore `savedApp` snapshots.
- **Raw apps** (`RawAppEditor.svelte`, `RawAppEditorHeader.svelte`, `apps_raw/edit/[...path]/+page.svelte`): the same wiring through to `createAppRaw`/`updateAppRaw` form data and the raw `currentDiffValue`.

## Known limitation

Like `deployment_message`, labels are a deploy-time field and are **not** persisted into the autosaved draft (the draft stores only the App `value`). In-drawer label edits that aren't deployed are not tracked by the unsaved-changes guard. This is intentional given labels live in the `app` table column (separate from the value JSON), not in the draft value.

## Screenshots

Deploy drawer of an existing app, showing the `production` label pre-populated from the saved app data after a deploy + reload round-trip:

![labels-drawer](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2107-add-labels-input-to-app-editor-deploy-drawer/1782635526-labels-drawer.png)

## Test plan

- [x] Type check (`npm run check:fast`) — no new errors from these changes
- [x] Create a new low-code app, open the Deploy drawer, add a label, deploy → verified `labels = {production}` persisted in the `app` table
- [x] Reload the deployed app, reopen the Deploy drawer → the `production` badge is pre-populated from the loaded app data
- [ ] Repeat the add-label + deploy + reload flow for a raw app via `/apps_raw/edit/...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a labels input to the app editor deploy drawer so users can add and edit labels at deploy time for both low‑code and raw apps. Prefills from existing app labels and threads them through create/update and diff flows. Fixes WIN-2107.

- **New Features**
  - Added `LabelsInput` after the summary in the deploy drawer.
  - Threaded labels through app and raw editors and the deploy flow.
  - Included labels in create/update API calls and `savedApp` snapshots.

- **Bug Fixes**
  - Deploy drawer Diff now includes label changes, so the approval preview matches the deployed payload.
  - Reset raw-app labels when seeding a new draft to prevent labels bleeding from previously opened apps.

<sup>Written for commit f854aa1718b92167626c6e55b5713bf476a2a2d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

