### PR TITLE
feat: add copy-to-clipboard button to rendered Mermaid diagrams in AI chat

### DIFF
--- a/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { randomUUID } from '$lib/utils/uuid'
 	import { useIsDarkMode } from '$lib/components/DarkModeObserver.svelte'
+	import { Button } from '$lib/components/common'
+	import { copyToClipboard } from '$lib/utils'
+	import { ClipboardCopy } from 'lucide-svelte'
 
 	let { code }: { code: string } = $props()
 
@@ -52,9 +55,22 @@
 </script>
 
 {#if showSvg}
-	<div class="p-2 flex justify-center overflow-x-auto">
-		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-		{@html svg}
+	<div class="relative">
+		<Button
+			wrapperClasses="absolute top-2 right-2 z-20"
+			onclick={() => copyToClipboard(code)}
+			color="light"
+			size="xs2"
+			startIcon={{
+				icon: ClipboardCopy
+			}}
+			iconOnly
+			title="Copy to clipboard"
+		/>
+		<div class="p-2 flex justify-center overflow-x-auto">
+			<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+			{@html svg}
+		</div>
 	</div>
 {:else}
 	<!-- Fallback while loading or when rendering fails: show the raw source -->


### PR DESCRIPTION
## Summary
When the AI chat renders a Mermaid diagram via `MermaidDisplay.svelte`, only the rendered SVG was shown and the raw source was hidden — making it impossible to copy the diagram code. Regular code blocks (`HighlightCode.svelte`) already have a copy button. This adds the same copy-to-clipboard button to rendered Mermaid diagrams.

Fixes WIN-2109

## Changes
- `MermaidDisplay.svelte`: in the `showSvg` branch, wrap the rendered SVG in a `relative` container and add a `Button` (color `light`, size `xs2`, `iconOnly`, `ClipboardCopy` icon) positioned `absolute top-2 right-2 z-20` that calls `copyToClipboard(code)` — mirroring the existing pattern in `HighlightCode.svelte`.

## Screenshots
![mermaid-copy-button](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2109-add-copy-to-clipboard-button-to-rendered-mermaid-diagrams-in/1782806504-mermaid-copy-button.png)

## Test plan
- [x] Rendered a Mermaid diagram and confirmed the copy button appears in the top-right corner of the diagram container
- [x] Clicked the button — no console errors; `copyToClipboard(code)` invoked with the raw source
- [x] `npm run check:fast` shows no new errors related to `MermaidDisplay.svelte`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a copy-to-clipboard button to rendered Mermaid diagrams in AI chat so users can copy the raw diagram source. Matches the code block copy UX and fulfills WIN-2109.

- **New Features**
  - Adds an overlay `Button` in `MermaidDisplay.svelte` (top-right) that calls `copyToClipboard(code)` with `ClipboardCopy` from `lucide-svelte`, keeping the SVG in its scrollable container.

<sup>Written for commit d308ab40f2aa9d665cf5c1e478f177ef85e2f6b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

