### PR TITLE
feat(pipeline): local development for data pipelines (CLI --local + pipeline dev preview)

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -21355,6 +21355,54 @@ paths:
                       format: int64
                       description: Number of pipeline-member scripts in the folder
 
+  /w/{workspace}/assets/partitions:
+    get:
+      summary: List materialized partitions for a ducklake asset
+      operationId: listAssetPartitions
+      tags:
+        - asset
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - name: path
+          in: query
+          required: true
+          description: The materialized ducklake asset path (`<ducklake>/<table>`)
+          schema:
+            type: string
+      responses:
+        "200":
+          description: per-partition materialization status
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/MaterializedPartition"
+
+  /w/{workspace}/assets/asset_schemas:
+    get:
+      summary: List captured output-schema versions for a ducklake asset
+      operationId: listAssetSchemas
+      tags:
+        - asset
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - name: path
+          in: query
+          required: true
+          description: The materialized ducklake asset path (`<ducklake>/<table>`)
+          schema:
+            type: string
+      responses:
+        "200":
+          description: captured schema versions, newest first
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AssetSchemaVersion"
+
   /w/{workspace}/volumes/list:
     get:
       summary: List all volumes in the workspace
@@ -29434,6 +29482,65 @@ components:
         - ducklake
         - datatable
         - volume
+    MaterializedPartition:
+      type: object
+      required: [asset_kind, asset_path, partition, status, materialized_at]
+      properties:
+        asset_kind:
+          $ref: "#/components/schemas/AssetKind"
+        asset_path:
+          type: string
+        partition:
+          type: string
+        status:
+          type: string
+          enum: [running, materialized, failed]
+        snapshot_id:
+          type: integer
+          format: int64
+          nullable: true
+        row_count:
+          type: integer
+          format: int64
+          nullable: true
+        job_id:
+          type: string
+          format: uuid
+          nullable: true
+        materialized_at:
+          type: string
+          format: date-time
+        error:
+          type: string
+          nullable: true
+    AssetSchemaVersion:
+      type: object
+      required: [version, columns, captured_at]
+      properties:
+        version:
+          type: integer
+          format: int64
+        columns:
+          type: array
+          items:
+            type: object
+            required: [name, type]
+            properties:
+              name:
+                type: string
+              type:
+                type: string
+        snapshot_id:
+          type: integer
+          format: int64
+          nullable: true
+        job_id:
+          type: string
+          format: uuid
+          nullable: true
+        captured_at:
+          type: string
+          format: date-time
     Asset:
       type: object
       properties:

--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -19,6 +19,7 @@
         "pg-gateway": "0.3.0-beta.4",
         "svelte": "^5.45.2",
         "tar-stream": "^3.1.7",
+        "windmill-parser-wasm-asset": "1.740.0",
         "windmill-parser-wasm-csharp": "1.510.1",
         "windmill-parser-wasm-go": "1.510.1",
         "windmill-parser-wasm-java": "1.510.1",
@@ -287,6 +288,8 @@
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "utility-types": ["utility-types@3.11.0", "", {}, "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw=="],
+
+    "windmill-parser-wasm-asset": ["windmill-parser-wasm-asset@1.740.0", "", {}, "sha512-Dgn5sQ93vJpqTQkv9iAy25+bqH2bUnIMdCfERb2Tia0Ql9T6iHbQhi4yzH9FbGW4Drv9GP46Qyetphqvp8vFOw=="],
 
     "windmill-parser-wasm-csharp": ["windmill-parser-wasm-csharp@1.510.1", "", {}, "sha512-qm09YmnbeYHLwYn1jUnObVzPhYO9NZKMlIO7nlo7zPJBXqksgG5fK/KCtwGw9rChrnz+DsvM9wP5FhrwRLMtwQ=="],
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -20,7 +20,7 @@
         "pg-gateway": "0.3.0-beta.4",
         "svelte": "^5.45.2",
         "tar-stream": "^3.1.7",
-        "windmill-parser-wasm-asset": "^1.728.1",
+        "windmill-parser-wasm-asset": "1.740.0",
         "windmill-parser-wasm-csharp": "1.510.1",
         "windmill-parser-wasm-go": "1.510.1",
         "windmill-parser-wasm-java": "1.510.1",
@@ -1411,9 +1411,9 @@
       }
     },
     "node_modules/windmill-parser-wasm-asset": {
-      "version": "1.728.1",
-      "resolved": "https://registry.npmjs.org/windmill-parser-wasm-asset/-/windmill-parser-wasm-asset-1.728.1.tgz",
-      "integrity": "sha512-73cyU6XM3gYEjFBx3qOKnv+VV1t70eAr6OiT+x0QobjFVNmqZFEdA7ayMYYVCnnix8OZxcsTNEF1hT61w1XiKw=="
+      "version": "1.740.0",
+      "resolved": "https://registry.npmjs.org/windmill-parser-wasm-asset/-/windmill-parser-wasm-asset-1.740.0.tgz",
+      "integrity": "sha512-Dgn5sQ93vJpqTQkv9iAy25+bqH2bUnIMdCfERb2Tia0Ql9T6iHbQhi4yzH9FbGW4Drv9GP46Qyetphqvp8vFOw=="
     },
     "node_modules/windmill-parser-wasm-csharp": {
       "version": "1.510.1",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -20,6 +20,7 @@
         "pg-gateway": "0.3.0-beta.4",
         "svelte": "^5.45.2",
         "tar-stream": "^3.1.7",
+        "windmill-parser-wasm-asset": "^1.728.1",
         "windmill-parser-wasm-csharp": "1.510.1",
         "windmill-parser-wasm-go": "1.510.1",
         "windmill-parser-wasm-java": "1.510.1",
@@ -1408,6 +1409,11 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/windmill-parser-wasm-asset": {
+      "version": "1.728.1",
+      "resolved": "https://registry.npmjs.org/windmill-parser-wasm-asset/-/windmill-parser-wasm-asset-1.728.1.tgz",
+      "integrity": "sha512-73cyU6XM3gYEjFBx3qOKnv+VV1t70eAr6OiT+x0QobjFVNmqZFEdA7ayMYYVCnnix8OZxcsTNEF1hT61w1XiKw=="
     },
     "node_modules/windmill-parser-wasm-csharp": {
       "version": "1.510.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -28,7 +28,7 @@
     "pg-gateway": "0.3.0-beta.4",
     "svelte": "^5.45.2",
     "tar-stream": "^3.1.7",
-    "windmill-parser-wasm-asset": "^1.728.1",
+    "windmill-parser-wasm-asset": "1.740.0",
     "windmill-parser-wasm-csharp": "1.510.1",
     "windmill-parser-wasm-go": "1.510.1",
     "windmill-parser-wasm-java": "1.510.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -28,6 +28,7 @@
     "pg-gateway": "0.3.0-beta.4",
     "svelte": "^5.45.2",
     "tar-stream": "^3.1.7",
+    "windmill-parser-wasm-asset": "^1.728.1",
     "windmill-parser-wasm-csharp": "1.510.1",
     "windmill-parser-wasm-go": "1.510.1",
     "windmill-parser-wasm-java": "1.510.1",

--- a/cli/src/commands/pipeline/boundedCascade.ts
+++ b/cli/src/commands/pipeline/boundedCascade.ts
@@ -121,6 +121,38 @@ function closure(adj: Map<string, Set<string>>, start: string): Set<string> {
 export const descendants = (dag: LineageDag, n: string): Set<string> => closure(dag.down, n);
 export const ancestors = (dag: LineageDag, n: string): Set<string> => closure(dag.up, n);
 
+/**
+ * Nodes reachable from `starts` over the lineage DAG, treating `barriers` as cut
+ * points: a barrier node is neither included NOR traversed through. So a node
+ * reachable ONLY via a barrier is excluded, while one also reachable via another
+ * path stays. Used for whole-pipeline runs to keep event handlers AND their
+ * event-only downstream closure out (subtracting only the handler would leave a
+ * consumer whose producer was skipped, which topoOrder would then run with
+ * missing/stale inputs).
+ */
+export function reachableCutting(
+  dag: LineageDag,
+  starts: Iterable<string>,
+  barriers: Set<string>,
+): Set<string> {
+  const seen = new Set<string>();
+  const queue: string[] = [];
+  for (const s of starts) {
+    if (barriers.has(s) || seen.has(s)) continue;
+    seen.add(s);
+    queue.push(s);
+  }
+  while (queue.length > 0) {
+    const n = queue.shift()!;
+    for (const next of dag.down.get(n) ?? []) {
+      if (barriers.has(next) || seen.has(next)) continue;
+      seen.add(next);
+      queue.push(next);
+    }
+  }
+  return seen;
+}
+
 export type BoundedResult = {
   nodes: Set<string>;
   reachableEnds: string[];

--- a/cli/src/commands/pipeline/boundedCascade.ts
+++ b/cli/src/commands/pipeline/boundedCascade.ts
@@ -168,6 +168,22 @@ export function validStarts(g: BCGraph): Set<string> {
   return out;
 }
 
+/**
+ * Script node ids that carry a row-backed event trigger (kafka/mqtt/nats/
+ * postgres/sqs/gcp/email). These fan out per-event and can't be run with empty
+ * args, so a whole-pipeline run must exclude them even when they're a lineage
+ * descendant of a valid start (not just when they're a root).
+ */
+export function eventTriggerScripts(g: BCGraph): Set<string> {
+  const out = new Set<string>();
+  for (const t of g.triggers ?? []) {
+    if (t.runnable_kind === "script" && EVENT_TRIGGER_KINDS.has(t.trigger_kind)) {
+      out.add(scriptNodeId(t.runnable_path));
+    }
+  }
+  return out;
+}
+
 /** Project a node-id set to the script paths it contains. */
 export function scriptsOf(nodes: Iterable<string>): string[] {
   const out: string[] = [];

--- a/cli/src/commands/pipeline/boundedCascade.ts
+++ b/cli/src/commands/pipeline/boundedCascade.ts
@@ -40,10 +40,14 @@ export const isScriptNode = (id: string): boolean => id.startsWith(SCRIPT_PREFIX
 export const scriptPathOf = (id: string): string => id.slice(SCRIPT_PREFIX.length);
 const assetNodeId = (kind: string, path: string): string => `${kind}:${path}`;
 
-// Native trigger kinds that fan out per-event — never bounded-run starts.
-// `webhook` / `data_upload` have no trigger row in the graph payload, so a root
-// whose only entry is one of those reads as a manual root.
-const EVENT_TRIGGER_KINDS = new Set([
+// Native trigger kinds whose scripts must NOT be auto-run by the CLI cascade:
+// event triggers fan out per external event, and `webhook`/`data_upload` are UI
+// entrypoints that need caller-supplied input (a request body / an uploaded
+// S3Object) — previewing any of them with empty args runs the wrong thing.
+// The deployed graph omits `webhook`/`data_upload` rows, but the local graph
+// emits them, so a `// on data_upload` script would otherwise read as a manual
+// root and get auto-run without its upload argument.
+const NON_AUTORUN_TRIGGER_KINDS = new Set([
   "kafka",
   "mqtt",
   "nats",
@@ -51,6 +55,8 @@ const EVENT_TRIGGER_KINDS = new Set([
   "sqs",
   "gcp",
   "email",
+  "webhook",
+  "data_upload",
 ]);
 
 /** Resolve an asset URI (`datatable://x`, `s3://b/k`, …) to its node id. */
@@ -183,33 +189,33 @@ export function boundedSet(dag: LineageDag, start: string, ends: string[]): Boun
 export function validStarts(g: BCGraph): Set<string> {
   const subscribers = new Set<string>();
   const scheduleScripts = new Set<string>();
-  const eventScripts = new Set<string>();
+  const nonAutorunScripts = new Set<string>();
   for (const t of g.triggers ?? []) {
     if (t.runnable_kind !== "script") continue;
     if (t.trigger_kind === "asset") subscribers.add(t.runnable_path);
     else if (t.trigger_kind === "schedule") scheduleScripts.add(t.runnable_path);
-    else if (EVENT_TRIGGER_KINDS.has(t.trigger_kind)) eventScripts.add(t.runnable_path);
+    else if (NON_AUTORUN_TRIGGER_KINDS.has(t.trigger_kind)) nonAutorunScripts.add(t.runnable_path);
   }
   const out = new Set<string>();
   for (const r of g.runnables ?? []) {
     if (r.usage_kind !== "script") continue;
     const p = r.path;
     if (scheduleScripts.has(p)) out.add(scriptNodeId(p));
-    else if (!subscribers.has(p) && !eventScripts.has(p)) out.add(scriptNodeId(p));
+    else if (!subscribers.has(p) && !nonAutorunScripts.has(p)) out.add(scriptNodeId(p));
   }
   return out;
 }
 
 /**
- * Script node ids that carry a row-backed event trigger (kafka/mqtt/nats/
- * postgres/sqs/gcp/email). These fan out per-event and can't be run with empty
- * args, so a whole-pipeline run must exclude them even when they're a lineage
- * descendant of a valid start (not just when they're a root).
+ * Script node ids that carry a trigger requiring caller-supplied input or
+ * per-event fanout (kafka/mqtt/nats/postgres/sqs/gcp/email/webhook/data_upload).
+ * These can't be run with empty args, so a whole-pipeline run must exclude them
+ * even when they're a lineage descendant of a valid start (not just a root).
  */
-export function eventTriggerScripts(g: BCGraph): Set<string> {
+export function nonAutorunTriggerScripts(g: BCGraph): Set<string> {
   const out = new Set<string>();
   for (const t of g.triggers ?? []) {
-    if (t.runnable_kind === "script" && EVENT_TRIGGER_KINDS.has(t.trigger_kind)) {
+    if (t.runnable_kind === "script" && NON_AUTORUN_TRIGGER_KINDS.has(t.trigger_kind)) {
       out.add(scriptNodeId(t.runnable_path));
     }
   }

--- a/cli/src/commands/pipeline/dev.ts
+++ b/cli/src/commands/pipeline/dev.ts
@@ -11,6 +11,7 @@ import { colors } from "@cliffy/ansi/colors";
 import * as http from "node:http";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { randomBytes } from "node:crypto";
 import process from "node:process";
 import * as open from "open";
 import { WebSocket, WebSocketServer } from "ws";
@@ -159,7 +160,23 @@ async function dev(opts: PipelineDevOpts, folderArg?: string) {
     res.writeHead(200);
     res.end();
   });
-  const wss = new WebSocketServer({ server });
+  // Loopback bind keeps the LAN out, but any browser tab can still open a
+  // `ws://localhost:<port>` connection — and each frame ships the folder's full
+  // script source. Gate the upgrade on an unguessable per-session token (carried
+  // in the dev-page URL) so a stray page on the predictable dev port can't
+  // exfiltrate the source. base64url → safe as a query value.
+  const wsToken = randomBytes(24).toString("base64url");
+  const wss = new WebSocketServer({
+    server,
+    verifyClient: (info) => {
+      try {
+        const u = new URL(info.req.url ?? "", "http://localhost");
+        return u.searchParams.get("token") === wsToken;
+      } catch {
+        return false;
+      }
+    },
+  });
   wss.on("connection", (ws: WebSocket) => {
     clients.add(ws);
     // Push the current bundle immediately so the page renders without waiting
@@ -181,7 +198,8 @@ async function dev(opts: PipelineDevOpts, folderArg?: string) {
   const pageBase = (opts.frontend ?? workspace.remote).replace(/\/?$/, "/");
   const url =
     `${pageBase}pipeline_dev?workspace=${workspace.workspaceId}` +
-    `&wm_token=${workspace.token}&folder=${encodeURIComponent(folder)}&port=${port}`;
+    `&wm_token=${workspace.token}&folder=${encodeURIComponent(folder)}&port=${port}` +
+    `&ws_token=${encodeURIComponent(wsToken)}`;
 
   server.listen(port, LISTEN_HOST, () => {
     log.info(colors.green.bold(`🚀 Pipeline dev server on ws://localhost:${port}/ws`));

--- a/cli/src/commands/pipeline/dev.ts
+++ b/cli/src/commands/pipeline/dev.ts
@@ -23,10 +23,15 @@ import {
   type SyncOptions,
 } from "../../core/conf.ts";
 import { listSyncCodebases } from "../../utils/codebase.ts";
-import { resolveBindPort, BIND_HOST } from "../../utils/port-probe.ts";
+import { resolveBindPort } from "../../utils/port-probe.ts";
 import { buildLocalPipelineGraph, workspaceRoot } from "./localGraph.ts";
 
 const PORT = 3201;
+// Bind loopback only: each WS frame ships the folder's full script source
+// (`scripts[].content` + `temp_script_refs`) with no auth, so it must not be
+// reachable from the LAN. The webview connects via `ws://localhost`, and an SSH
+// `-L` / devbox port-forward targets 127.0.0.1 on the host, so both still work.
+const LISTEN_HOST = "127.0.0.1";
 
 interface PipelineDevOpts extends GlobalOptions, SyncOptions {
   port?: number;
@@ -171,7 +176,7 @@ async function dev(opts: PipelineDevOpts, folderArg?: string) {
     `${workspace.remote}pipeline_dev?workspace=${workspace.workspaceId}` +
     `&wm_token=${workspace.token}&folder=${encodeURIComponent(folder)}&port=${port}`;
 
-  server.listen(port, BIND_HOST, () => {
+  server.listen(port, LISTEN_HOST, () => {
     log.info(colors.green.bold(`🚀 Pipeline dev server on ws://localhost:${port}/ws`));
     log.info(colors.gray(`Open: ${url}`));
     if (opts.open !== false) {

--- a/cli/src/commands/pipeline/dev.ts
+++ b/cli/src/commands/pipeline/dev.ts
@@ -25,6 +25,7 @@ import {
 } from "../../core/conf.ts";
 import { listSyncCodebases } from "../../utils/codebase.ts";
 import { resolveBindPort } from "../../utils/port-probe.ts";
+import { getConfigDirPath } from "../../../windmill-utils-internal/src/config/config.ts";
 import { buildLocalPipelineGraph, workspaceRoot } from "./localGraph.ts";
 
 const PORT = 3201;
@@ -39,6 +40,32 @@ interface PipelineDevOpts extends GlobalOptions, SyncOptions {
   open?: boolean;
   defaultTs?: "bun" | "deno";
   frontend?: string;
+}
+
+// The WS token gates access to local source. Persist it per-port under the
+// user-private config dir (0600) so a `pipeline dev` restart on the same port
+// reuses it — an already-open `/pipeline_dev` page auto-reconnecting with the
+// token from its URL then survives the restart, instead of every upgrade being
+// rejected by `verifyClient` until the freshly printed URL is reopened. Falls
+// back to an ephemeral token if the config dir can't be read/written.
+async function stableWsToken(port: number): Promise<string> {
+  let tokenFile: string | undefined;
+  try {
+    tokenFile = path.join(await getConfigDirPath(), `pipeline-dev-${port}.token`);
+    const existing = fs.readFileSync(tokenFile, "utf-8").trim();
+    if (existing) return existing;
+  } catch {
+    // no reusable token file yet (or config dir unavailable) — mint a fresh one
+  }
+  const token = randomBytes(24).toString("base64url");
+  if (tokenFile) {
+    try {
+      fs.writeFileSync(tokenFile, token, { mode: 0o600 });
+    } catch {
+      // best-effort persistence; fall back to the in-memory token
+    }
+  }
+  return token;
 }
 
 // Resolve the target folder: explicit arg, else auto-detect when cwd sits inside
@@ -165,7 +192,9 @@ async function dev(opts: PipelineDevOpts, folderArg?: string) {
   // script source. Gate the upgrade on an unguessable per-session token (carried
   // in the dev-page URL) so a stray page on the predictable dev port can't
   // exfiltrate the source. base64url → safe as a query value.
-  const wsToken = randomBytes(24).toString("base64url");
+  // Stable per-port across restarts so an already-open page reconnects after a
+  // CLI restart (see stableWsToken), not just after a transient WS drop.
+  const wsToken = await stableWsToken(port);
   const wss = new WebSocketServer({
     server,
     verifyClient: (info) => {

--- a/cli/src/commands/pipeline/dev.ts
+++ b/cli/src/commands/pipeline/dev.ts
@@ -86,11 +86,12 @@ async function dev(opts: PipelineDevOpts, folderArg?: string) {
     // best-effort
   }
 
+  const EMPTY_GRAPH = { runnables: [], assets: [], edges: [], triggers: [] };
   async function buildBundle() {
     const { graph, scripts } = await buildLocalPipelineGraph({
       root,
       folder: folder!,
-      defaultTs: opts.defaultTs,
+      defaultTs: merged.defaultTs,
     });
     return {
       type: "pipeline" as const,
@@ -101,7 +102,15 @@ async function dev(opts: PipelineDevOpts, folderArg?: string) {
     };
   }
 
-  let current = await buildBundle();
+  // Don't let a transient build error (e.g. a half-written file) abort startup —
+  // serve an empty graph and recover on the next save.
+  let current: Awaited<ReturnType<typeof buildBundle>>;
+  try {
+    current = await buildBundle();
+  } catch (e: any) {
+    log.error(colors.red(`Initial graph build failed: ${e.message}`));
+    current = { type: "pipeline", folder, graph: EMPTY_GRAPH, scripts: [], temp_script_refs: tempScriptRefs };
+  }
   log.info(
     colors.blue(
       `Watching f/${folder} — ${current.scripts.length} pipeline script(s)`,

--- a/cli/src/commands/pipeline/dev.ts
+++ b/cli/src/commands/pipeline/dev.ts
@@ -37,6 +37,7 @@ interface PipelineDevOpts extends GlobalOptions, SyncOptions {
   port?: number;
   open?: boolean;
   defaultTs?: "bun" | "deno";
+  frontend?: string;
 }
 
 // Resolve the target folder: explicit arg, else auto-detect when cwd sits inside
@@ -172,8 +173,14 @@ async function dev(opts: PipelineDevOpts, folderArg?: string) {
     ws.on("error", () => clients.delete(ws));
   });
 
+  // The `/pipeline_dev` page is served by the frontend, not the backend. By
+  // default we open it on the workspace remote, but that 404s on a remote whose
+  // deployed frontend predates this route — `--frontend` points the page at a
+  // locally-run frontend (`REMOTE=<remote> npm run dev`) while the API/token
+  // still target the remote. Normalize to a single trailing slash either way.
+  const pageBase = (opts.frontend ?? workspace.remote).replace(/\/?$/, "/");
   const url =
-    `${workspace.remote}pipeline_dev?workspace=${workspace.workspaceId}` +
+    `${pageBase}pipeline_dev?workspace=${workspace.workspaceId}` +
     `&wm_token=${workspace.token}&folder=${encodeURIComponent(folder)}&port=${port}`;
 
   server.listen(port, LISTEN_HOST, () => {
@@ -202,6 +209,10 @@ const command = new Command()
   .arguments("[folder:string]")
   .option("--port <port:number>", "Port for the dev WebSocket server.")
   .option("--no-open", "Do not open the browser automatically.")
+  .option(
+    "--frontend <origin:string>",
+    "Origin serving the /pipeline_dev page (e.g. http://localhost:3000 for a locally-run frontend). Defaults to the workspace remote; use it when the remote's deployed frontend predates the dev page.",
+  )
   .action(dev as any);
 
 export default command;

--- a/cli/src/commands/pipeline/dev.ts
+++ b/cli/src/commands/pipeline/dev.ts
@@ -11,7 +11,7 @@ import { colors } from "@cliffy/ansi/colors";
 import * as http from "node:http";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import process from "node:process";
 import * as open from "open";
 import { WebSocket, WebSocketServer } from "ws";
@@ -56,7 +56,14 @@ async function stableWsToken(
   folder: string,
   port: number,
 ): Promise<string> {
-  const key = `${workspaceId}__${folder}__${port}`.replace(/[^a-zA-Z0-9._-]/g, "_");
+  // Hash the tuple (NUL-delimited so no value can spoof the boundary) → a
+  // collision-resistant, filesystem-safe key. A plain sanitized join would let
+  // different folders collide (`a/b` and `a_b` → same name), which would reuse a
+  // token across folders and reintroduce the cross-folder leak.
+  const key = createHash("sha256")
+    .update(`${workspaceId}\0${folder}\0${port}`)
+    .digest("hex")
+    .slice(0, 32);
   let tokenFile: string | undefined;
   try {
     tokenFile = path.join(await getConfigDirPath(), `pipeline-dev-${key}.token`);

--- a/cli/src/commands/pipeline/dev.ts
+++ b/cli/src/commands/pipeline/dev.ts
@@ -47,21 +47,24 @@ interface PipelineDevOpts extends GlobalOptions, SyncOptions {
 // `/pipeline_dev` page auto-reconnecting with the token from its URL then
 // survives the restart, instead of every upgrade being rejected by
 // `verifyClient` until the freshly printed URL is reopened. Scoped by
-// workspace+folder+port (NOT port alone): a same-session restart reconnects,
-// but a *different* folder on the same port gets a different token, so a stale
-// tab from a prior folder's session can't reconnect and receive another folder's
-// source. Falls back to an ephemeral token if the config dir can't be read/written.
+// remote+workspace+root+folder+port (NOT port alone): a same-session restart
+// reconnects, but any *different* session — another folder, workspace, remote, or
+// local checkout on the same port — gets a different token, so a stale tab can't
+// reconnect and receive another session's source. Falls back to an ephemeral
+// token if the config dir can't be read/written.
 async function stableWsToken(
+  remote: string,
   workspaceId: string,
+  root: string,
   folder: string,
   port: number,
 ): Promise<string> {
   // Hash the tuple (NUL-delimited so no value can spoof the boundary) → a
   // collision-resistant, filesystem-safe key. A plain sanitized join would let
-  // different folders collide (`a/b` and `a_b` → same name), which would reuse a
-  // token across folders and reintroduce the cross-folder leak.
+  // different values collide (`a/b` and `a_b` → same name), which would reuse a
+  // token across sessions and reintroduce the cross-session leak.
   const key = createHash("sha256")
-    .update(`${workspaceId}\0${folder}\0${port}`)
+    .update(`${remote}\0${workspaceId}\0${root}\0${folder}\0${port}`)
     .digest("hex")
     .slice(0, 32);
   let tokenFile: string | undefined;
@@ -207,10 +210,16 @@ async function dev(opts: PipelineDevOpts, folderArg?: string) {
   // script source. Gate the upgrade on an unguessable per-session token (carried
   // in the dev-page URL) so a stray page on the predictable dev port can't
   // exfiltrate the source. base64url → safe as a query value.
-  // Stable across restarts (scoped to workspace+folder+port) so an already-open
-  // page reconnects after a CLI restart (see stableWsToken), not just after a
-  // transient WS drop.
-  const wsToken = await stableWsToken(workspace.workspaceId, folder, port);
+  // Stable across restarts (scoped to remote+workspace+root+folder+port) so an
+  // already-open page reconnects after a CLI restart (see stableWsToken), not
+  // just after a transient WS drop.
+  const wsToken = await stableWsToken(
+    workspace.remote,
+    workspace.workspaceId,
+    root,
+    folder,
+    port,
+  );
   const wss = new WebSocketServer({
     server,
     verifyClient: (info) => {

--- a/cli/src/commands/pipeline/dev.ts
+++ b/cli/src/commands/pipeline/dev.ts
@@ -1,0 +1,193 @@
+// `wmill pipeline dev [folder]` — live-preview a data pipeline from local files.
+//
+// The pipeline analog of `wmill dev` / `wmill app dev`: watch a folder of
+// `// pipeline` scripts, rebuild the asset graph from the working tree on every
+// save, and push it over a WebSocket to the `/pipeline_dev` page, which renders
+// the same graph editor the UI uses and runs the cascade via preview (no deploy).
+// Editing stays in the user's own editor; the page live-reloads.
+
+import { Command } from "@cliffy/command";
+import { colors } from "@cliffy/ansi/colors";
+import * as http from "node:http";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import process from "node:process";
+import * as open from "open";
+import { WebSocket, WebSocketServer } from "ws";
+import * as log from "../../core/log.ts";
+import { GlobalOptions } from "../../types.ts";
+import { requireLogin } from "../../core/auth.ts";
+import { resolveWorkspace } from "../../core/context.ts";
+import {
+  mergeConfigWithConfigFile,
+  type SyncOptions,
+} from "../../core/conf.ts";
+import { listSyncCodebases } from "../../utils/codebase.ts";
+import { resolveBindPort, BIND_HOST } from "../../utils/port-probe.ts";
+import { buildLocalPipelineGraph, workspaceRoot } from "./localGraph.ts";
+
+const PORT = 3201;
+
+interface PipelineDevOpts extends GlobalOptions, SyncOptions {
+  port?: number;
+  open?: boolean;
+  defaultTs?: "bun" | "deno";
+}
+
+// Resolve the target folder: explicit arg, else auto-detect when cwd sits inside
+// `f/<folder>/…` (the supported `cd f/my_pipeline && wmill pipeline dev` form).
+function resolveFolder(root: string, folderArg?: string): string | undefined {
+  if (folderArg) return folderArg.replace(/^f\//, "").replace(/\/$/, "");
+  const rel = path.relative(root, process.cwd()).replaceAll("\\", "/");
+  if (rel === "" || rel.startsWith("..")) return undefined;
+  const segs = rel.split("/");
+  if (segs[0] === "f" && segs[1]) return segs[1];
+  return undefined;
+}
+
+async function dev(opts: PipelineDevOpts, folderArg?: string) {
+  const root = workspaceRoot();
+  const folder = resolveFolder(root, folderArg);
+  if (!folder) {
+    log.error(
+      colors.red(
+        "Could not determine the pipeline folder. Pass it explicitly " +
+          "(`wmill pipeline dev <folder>`) or run from inside an `f/<folder>` directory.",
+      ),
+    );
+    process.exit(1);
+  }
+  const folderDir = path.join(root, "f", folder);
+  if (!fs.existsSync(folderDir)) {
+    log.error(colors.red(`Folder not found on disk: ${folderDir}`));
+    process.exit(1);
+  }
+
+  const workspace = await resolveWorkspace(opts);
+  await requireLogin(opts);
+  const merged = await mergeConfigWithConfigFile(opts);
+  const codebases = await listSyncCodebases(merged);
+
+  // Resolve relative imports from local (not-yet-deployed) content for previews.
+  // Snapshot at startup like `wmill dev`; restart to refresh. Degrades to
+  // undefined on older backends.
+  let tempScriptRefs: Record<string, string> | undefined;
+  try {
+    const { buildPreviewTempScriptRefs } = await import(
+      "../generate-metadata/generate-metadata.ts"
+    );
+    tempScriptRefs = await buildPreviewTempScriptRefs(
+      workspace,
+      merged,
+      codebases,
+      { kind: "all" },
+    );
+  } catch {
+    // best-effort
+  }
+
+  async function buildBundle() {
+    const { graph, scripts } = await buildLocalPipelineGraph({
+      root,
+      folder: folder!,
+      defaultTs: opts.defaultTs,
+    });
+    return {
+      type: "pipeline" as const,
+      folder,
+      graph,
+      scripts,
+      temp_script_refs: tempScriptRefs,
+    };
+  }
+
+  let current = await buildBundle();
+  log.info(
+    colors.blue(
+      `Watching f/${folder} — ${current.scripts.length} pipeline script(s)`,
+    ),
+  );
+
+  const clients = new Set<WebSocket>();
+  function broadcast() {
+    const msg = JSON.stringify(current);
+    for (const ws of clients) {
+      if (ws.readyState === WebSocket.OPEN) ws.send(msg);
+    }
+  }
+
+  // Debounced rebuild on any change under the folder.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const watcher = fs.watch(folderDir, { recursive: true });
+  watcher.on("change", (_ev, filename) => {
+    if (filename && filename.toString().endsWith(".lock")) return;
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(async () => {
+      timer = undefined;
+      try {
+        current = await buildBundle();
+        log.info(colors.cyan(`↻ rebuilt graph (${current.scripts.length} scripts)`));
+        broadcast();
+      } catch (e: any) {
+        log.error(colors.red(`Failed to rebuild pipeline graph: ${e.message}`));
+      }
+    }, 150);
+  });
+  watcher.on("error", (e) => log.error(colors.red(`Watcher error: ${e.message}`)));
+
+  const port = await resolveBindPort(opts.port ?? PORT, "wmill pipeline dev", {
+    info: (m) => log.info(m),
+    warn: (m) => log.warn(m),
+  });
+
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200);
+    res.end();
+  });
+  const wss = new WebSocketServer({ server });
+  wss.on("connection", (ws: WebSocket) => {
+    clients.add(ws);
+    // Push the current bundle immediately so the page renders without waiting
+    // for the first file change.
+    try {
+      ws.send(JSON.stringify(current));
+    } catch {
+      // ignore
+    }
+    ws.on("close", () => clients.delete(ws));
+    ws.on("error", () => clients.delete(ws));
+  });
+
+  const url =
+    `${workspace.remote}pipeline_dev?workspace=${workspace.workspaceId}` +
+    `&wm_token=${workspace.token}&folder=${encodeURIComponent(folder)}&port=${port}`;
+
+  server.listen(port, BIND_HOST, () => {
+    log.info(colors.green.bold(`🚀 Pipeline dev server on ws://localhost:${port}/ws`));
+    log.info(colors.gray(`Open: ${url}`));
+    if (opts.open !== false) {
+      open.default(url).catch((e: any) =>
+        log.warn(colors.yellow(`Failed to open browser: ${e.message}`)),
+      );
+    }
+  });
+
+  process.on("SIGINT", () => {
+    log.info(colors.yellow("\n🛑 Shutting down…"));
+    watcher.close();
+    for (const ws of clients) ws.close();
+    server.close();
+    process.exit(0);
+  });
+}
+
+const command = new Command()
+  .description(
+    "Live-preview a data pipeline from local files: watch an `f/<folder>` of `// pipeline` scripts, push the working-tree graph to the dev page, and run the cascade via preview (no deploy).",
+  )
+  .arguments("[folder:string]")
+  .option("--port <port:number>", "Port for the dev WebSocket server.")
+  .option("--no-open", "Do not open the browser automatically.")
+  .action(dev as any);
+
+export default command;

--- a/cli/src/commands/pipeline/dev.ts
+++ b/cli/src/commands/pipeline/dev.ts
@@ -42,16 +42,24 @@ interface PipelineDevOpts extends GlobalOptions, SyncOptions {
   frontend?: string;
 }
 
-// The WS token gates access to local source. Persist it per-port under the
-// user-private config dir (0600) so a `pipeline dev` restart on the same port
-// reuses it — an already-open `/pipeline_dev` page auto-reconnecting with the
-// token from its URL then survives the restart, instead of every upgrade being
-// rejected by `verifyClient` until the freshly printed URL is reopened. Falls
-// back to an ephemeral token if the config dir can't be read/written.
-async function stableWsToken(port: number): Promise<string> {
+// The WS token gates access to local source. Persist it under the user-private
+// config dir (0600) so a `pipeline dev` restart reuses it — an already-open
+// `/pipeline_dev` page auto-reconnecting with the token from its URL then
+// survives the restart, instead of every upgrade being rejected by
+// `verifyClient` until the freshly printed URL is reopened. Scoped by
+// workspace+folder+port (NOT port alone): a same-session restart reconnects,
+// but a *different* folder on the same port gets a different token, so a stale
+// tab from a prior folder's session can't reconnect and receive another folder's
+// source. Falls back to an ephemeral token if the config dir can't be read/written.
+async function stableWsToken(
+  workspaceId: string,
+  folder: string,
+  port: number,
+): Promise<string> {
+  const key = `${workspaceId}__${folder}__${port}`.replace(/[^a-zA-Z0-9._-]/g, "_");
   let tokenFile: string | undefined;
   try {
-    tokenFile = path.join(await getConfigDirPath(), `pipeline-dev-${port}.token`);
+    tokenFile = path.join(await getConfigDirPath(), `pipeline-dev-${key}.token`);
     const existing = fs.readFileSync(tokenFile, "utf-8").trim();
     if (existing) return existing;
   } catch {
@@ -192,9 +200,10 @@ async function dev(opts: PipelineDevOpts, folderArg?: string) {
   // script source. Gate the upgrade on an unguessable per-session token (carried
   // in the dev-page URL) so a stray page on the predictable dev port can't
   // exfiltrate the source. base64url → safe as a query value.
-  // Stable per-port across restarts so an already-open page reconnects after a
-  // CLI restart (see stableWsToken), not just after a transient WS drop.
-  const wsToken = await stableWsToken(port);
+  // Stable across restarts (scoped to workspace+folder+port) so an already-open
+  // page reconnects after a CLI restart (see stableWsToken), not just after a
+  // transient WS drop.
+  const wsToken = await stableWsToken(workspace.workspaceId, folder, port);
   const wss = new WebSocketServer({
     server,
     verifyClient: (info) => {

--- a/cli/src/commands/pipeline/docs.ts
+++ b/cli/src/commands/pipeline/docs.ts
@@ -165,6 +165,24 @@ export async function generatePipelineDocs(
     : await fetchDeployedGraph(workspace.workspaceId, f);
 
   if (graph.runnables.length === 0) {
+    // The deployed graph is empty — but a user/agent in a working tree may have
+    // local `// pipeline` scripts not yet deployed. Point them at --local rather
+    // than leaving them thinking the folder is empty.
+    if (!opts.local) {
+      try {
+        const localCount =
+          (await buildLocalPipelineGraph({ root, folder: f, defaultTs: opts.defaultTs })).graph
+            .runnables.length;
+        if (localCount > 0) {
+          log.info(
+            `No deployed pipeline scripts in f/${f}, but ${localCount} \`// pipeline\` script(s) exist in the local working tree — run \`wmill pipeline docs ${f} --local\` to document those.`,
+          );
+          return;
+        }
+      } catch {
+        // best-effort hint; fall through to the generic message
+      }
+    }
     log.info(`No pipeline scripts in f/${f}.`);
     return;
   }

--- a/cli/src/commands/pipeline/docs.ts
+++ b/cli/src/commands/pipeline/docs.ts
@@ -160,6 +160,12 @@ export async function generatePipelineDocs(
   const workspace = await resolveWorkspace(opts);
   await requireLogin(opts);
   const f = folder.replace(/^f\//, "").replace(/\/$/, "");
+  // `docs` WRITES PIPELINE.md / AGENTS.md / CLAUDE.md under `f/<folder>`; a `..`
+  // segment would escape the folder and clobber files elsewhere in the tree.
+  if (f.split("/").includes("..")) {
+    log.error(colors.red(`Invalid folder '${folder}': '..' path segments are not allowed.`));
+    return;
+  }
   const root = workspaceRoot();
   // defaultTs (from wmill.yaml) drives .ts → bun/deno inference for the local graph.
   const merged = await mergeConfigWithConfigFile(opts);

--- a/cli/src/commands/pipeline/docs.ts
+++ b/cli/src/commands/pipeline/docs.ts
@@ -209,8 +209,9 @@ export async function generatePipelineDocs(
   await writeFile(path.join(folderDir, "PIPELINE.md"), md, "utf-8");
 
   // PIPELINE.md is ours to own. AGENTS.md / CLAUDE.md are commonly user-authored,
-  // so only write the pointer when the file is absent or already a generated
-  // pointer (contains "@PIPELINE.md") — never clobber hand-written instructions.
+  // so write the pointer only when the file is ABSENT or is byte-for-byte the
+  // exact pointer we generate — never clobber hand-written instructions, even a
+  // file that merely references `@PIPELINE.md` alongside its own content.
   const written = ["PIPELINE.md"];
   const pointers: Array<[string, string]> = [
     ["AGENTS.md", `See @PIPELINE.md for this pipeline's graph, assets, and how to run it.\n`],
@@ -219,12 +220,18 @@ export async function generatePipelineDocs(
   for (const [name, content] of pointers) {
     const p = path.join(folderDir, name);
     if (existsSync(p)) {
+      let existing: string;
       try {
-        if (!readFileSync(p, "utf-8").includes("@PIPELINE.md")) {
-          log.warn(colors.yellow(`Kept existing f/${f}/${name} (not a generated pointer)`));
-          continue;
-        }
+        existing = readFileSync(p, "utf-8");
       } catch {
+        continue;
+      }
+      // Anything other than our exact generated pointer is treated as
+      // hand-written and preserved (writing when identical is a no-op anyway).
+      if (existing.trim() !== content.trim()) {
+        log.warn(
+          colors.yellow(`Kept existing f/${f}/${name} (hand-written — not the generated pointer)`),
+        );
         continue;
       }
     }

--- a/cli/src/commands/pipeline/docs.ts
+++ b/cli/src/commands/pipeline/docs.ts
@@ -5,11 +5,13 @@
 // (`app/generate_agents.ts:regenerateAgentDocs`) but scoped to a pipeline folder.
 
 import { writeFile } from "node:fs/promises";
+import { existsSync, readFileSync } from "node:fs";
 import * as path from "node:path";
 import { OpenAPI } from "../../../gen/index.ts";
 import * as wmill from "../../../gen/services.gen.ts";
 import { requireLogin } from "../../core/auth.ts";
 import { resolveWorkspace } from "../../core/context.ts";
+import { mergeConfigWithConfigFile } from "../../core/conf.ts";
 import * as log from "../../core/log.ts";
 import { colors } from "@cliffy/ansi/colors";
 import { GlobalOptions } from "../../types.ts";
@@ -159,9 +161,11 @@ export async function generatePipelineDocs(
   await requireLogin(opts);
   const f = folder.replace(/^f\//, "").replace(/\/$/, "");
   const root = workspaceRoot();
+  // defaultTs (from wmill.yaml) drives .ts → bun/deno inference for the local graph.
+  const merged = await mergeConfigWithConfigFile(opts);
 
   const graph = opts.local
-    ? (await buildLocalPipelineGraph({ root, folder: f, defaultTs: opts.defaultTs })).graph
+    ? (await buildLocalPipelineGraph({ root, folder: f, defaultTs: merged.defaultTs })).graph
     : await fetchDeployedGraph(workspace.workspaceId, f);
 
   if (graph.runnables.length === 0) {
@@ -171,7 +175,7 @@ export async function generatePipelineDocs(
     if (!opts.local) {
       try {
         const localCount =
-          (await buildLocalPipelineGraph({ root, folder: f, defaultTs: opts.defaultTs })).graph
+          (await buildLocalPipelineGraph({ root, folder: f, defaultTs: merged.defaultTs })).graph
             .runnables.length;
         if (localCount > 0) {
           log.info(
@@ -197,7 +201,29 @@ export async function generatePipelineDocs(
   const md = generatePipelineMarkdown(f, graph, datatableSchemas, !!opts.local);
   const folderDir = path.join(root, "f", f);
   await writeFile(path.join(folderDir, "PIPELINE.md"), md, "utf-8");
-  await writeFile(path.join(folderDir, "AGENTS.md"), `See @PIPELINE.md for this pipeline's graph, assets, and how to run it.\n`, "utf-8");
-  await writeFile(path.join(folderDir, "CLAUDE.md"), `Instructions are in @PIPELINE.md\n`, "utf-8");
-  log.info(colors.green(`✓ Wrote PIPELINE.md, AGENTS.md, CLAUDE.md to f/${f}`));
+
+  // PIPELINE.md is ours to own. AGENTS.md / CLAUDE.md are commonly user-authored,
+  // so only write the pointer when the file is absent or already a generated
+  // pointer (contains "@PIPELINE.md") — never clobber hand-written instructions.
+  const written = ["PIPELINE.md"];
+  const pointers: Array<[string, string]> = [
+    ["AGENTS.md", `See @PIPELINE.md for this pipeline's graph, assets, and how to run it.\n`],
+    ["CLAUDE.md", `Instructions are in @PIPELINE.md\n`],
+  ];
+  for (const [name, content] of pointers) {
+    const p = path.join(folderDir, name);
+    if (existsSync(p)) {
+      try {
+        if (!readFileSync(p, "utf-8").includes("@PIPELINE.md")) {
+          log.warn(colors.yellow(`Kept existing f/${f}/${name} (not a generated pointer)`));
+          continue;
+        }
+      } catch {
+        continue;
+      }
+    }
+    await writeFile(p, content, "utf-8");
+    written.push(name);
+  }
+  log.info(colors.green(`✓ Wrote ${written.join(", ")} to f/${f}`));
 }

--- a/cli/src/commands/pipeline/docs.ts
+++ b/cli/src/commands/pipeline/docs.ts
@@ -1,0 +1,185 @@
+// `wmill pipeline docs <folder>` — generate a PIPELINE.md (+ AGENTS.md / CLAUDE.md
+// pointer) describing a folder's pipeline so an editor or agentic loop has the
+// same context the UI surfaces: the asset DAG, per-script triggers/IO, and the
+// schemas of the datatables the pipeline touches. Mirrors the app docs pattern
+// (`app/generate_agents.ts:regenerateAgentDocs`) but scoped to a pipeline folder.
+
+import { writeFile } from "node:fs/promises";
+import * as path from "node:path";
+import { OpenAPI } from "../../../gen/index.ts";
+import * as wmill from "../../../gen/services.gen.ts";
+import { requireLogin } from "../../core/auth.ts";
+import { resolveWorkspace } from "../../core/context.ts";
+import * as log from "../../core/log.ts";
+import { colors } from "@cliffy/ansi/colors";
+import { GlobalOptions } from "../../types.ts";
+import {
+  type AssetGraph,
+  buildLocalPipelineGraph,
+  workspaceRoot,
+} from "./localGraph.ts";
+
+const ASSET_KINDS = "s3object,ducklake,datatable,volume";
+
+function assetUri(kind: string, p: string): string {
+  const prefix = kind === "s3object" ? "s3" : kind;
+  return `${prefix}://${p}`;
+}
+
+async function fetchDeployedGraph(
+  workspaceId: string,
+  folder: string,
+): Promise<AssetGraph> {
+  const res = await fetch(
+    `${OpenAPI.BASE}/w/${workspaceId}/assets/graph?folder=${encodeURIComponent(folder)}&asset_kinds=${ASSET_KINDS}`,
+    { headers: { Authorization: `Bearer ${OpenAPI.TOKEN}` } },
+  );
+  if (!res.ok) {
+    throw new Error(`GET assets/graph -> ${res.status}: ${await res.text()}`);
+  }
+  return (await res.json()) as AssetGraph;
+}
+
+// Render the pipeline graph as a markdown document.
+function generatePipelineMarkdown(
+  folder: string,
+  graph: AssetGraph,
+  datatableSchemas: any[],
+  local: boolean,
+): string {
+  const writesByScript = new Map<string, string[]>();
+  const readsByScript = new Map<string, string[]>();
+  for (const e of graph.edges) {
+    if (e.runnable_kind !== "script") continue;
+    const uri = assetUri(e.asset_kind, e.asset_path);
+    if (e.access_type === "w" || e.access_type === "rw") {
+      (writesByScript.get(e.runnable_path) ?? writesByScript.set(e.runnable_path, []).get(e.runnable_path)!).push(uri);
+    }
+    if (e.access_type === "r" || e.access_type === "rw" || e.access_type === undefined) {
+      (readsByScript.get(e.runnable_path) ?? readsByScript.set(e.runnable_path, []).get(e.runnable_path)!).push(uri);
+    }
+  }
+  const onByScript = new Map<string, string[]>();
+  const nativeByScript = new Map<string, string[]>();
+  for (const t of graph.triggers) {
+    if (t.runnable_kind !== "script") continue;
+    if (t.trigger_kind === "asset") {
+      const at = t as Extract<AssetGraph["triggers"][number], { trigger_kind: "asset" }>;
+      (onByScript.get(at.runnable_path) ?? onByScript.set(at.runnable_path, []).get(at.runnable_path)!).push(assetUri(at.asset_kind, at.asset_path));
+    } else {
+      (nativeByScript.get(t.runnable_path) ?? nativeByScript.set(t.runnable_path, []).get(t.runnable_path)!).push(t.trigger_kind);
+    }
+  }
+
+  const scripts = graph.runnables.filter((r) => r.usage_kind === "script").map((r) => r.path).sort();
+
+  let md = `# Pipeline \`f/${folder}\`
+
+${local ? "_Built from local working-tree files (`// pipeline` scripts)._" : "_Built from the deployed workspace asset graph._"}
+
+A data pipeline is a folder of scripts marked \`// pipeline\` and wired by asset
+annotations. A script subscribes to upstream data with \`// on <asset-uri>\` and
+produces data by reading/writing assets in its body (\`datatable://\`,
+\`ducklake://\`, \`s3://\`, \`volume://\`). The cascade runs a producer, then every
+downstream subscriber, in topological order.
+
+- **${scripts.length}** script${scripts.length === 1 ? "" : "s"} · **${graph.assets.length}** asset${graph.assets.length === 1 ? "" : "s"}
+
+## Scripts
+
+`;
+
+  for (const s of scripts) {
+    const on = onByScript.get(s) ?? [];
+    const native = nativeByScript.get(s) ?? [];
+    const writes = [...new Set(writesByScript.get(s) ?? [])].sort();
+    const reads = [...new Set(readsByScript.get(s) ?? [])].sort();
+    md += `### \`${s}\`\n\n`;
+    if (native.length) md += `- **Triggers:** ${native.map((n) => `\`${n}\``).join(", ")}\n`;
+    if (on.length) md += `- **On (subscribes to):** ${on.map((u) => `\`${u}\``).join(", ")}\n`;
+    if (reads.length) md += `- **Reads:** ${reads.map((u) => `\`${u}\``).join(", ")}\n`;
+    if (writes.length) md += `- **Writes:** ${writes.map((u) => `\`${u}\``).join(", ")}\n`;
+    if (!native.length && !on.length && !reads.length && !writes.length) {
+      md += `- _No declared triggers or asset IO._\n`;
+    }
+    md += `\n`;
+  }
+
+  // Datatable schemas, restricted to datatables this pipeline references.
+  const referencedDatatables = new Set(
+    graph.assets.filter((a) => a.kind === "datatable").map((a) => a.path.split("/")[0]),
+  );
+  const relevant = (datatableSchemas ?? []).filter((dt: any) => referencedDatatables.has(dt.datatable_name));
+  if (relevant.length > 0) {
+    md += `## Datatable schemas\n\n`;
+    for (const dt of relevant) {
+      md += `### Datatable \`${dt.datatable_name}\`\n\n`;
+      if (dt.error) {
+        md += `> ⚠️ ${dt.error}\n\n`;
+        continue;
+      }
+      for (const [schemaName, tables] of Object.entries(dt.schemas ?? {})) {
+        for (const [tableName, columns] of Object.entries(tables as Record<string, any>)) {
+          const ref = schemaName === "public"
+            ? `${dt.datatable_name}/${tableName}`
+            : `${dt.datatable_name}/${schemaName}:${tableName}`;
+          md += `- \`datatable://${ref}\`\n`;
+          for (const [col, type] of Object.entries(columns as Record<string, any>)) {
+            md += `  - \`${col}\`: ${type}\n`;
+          }
+        }
+      }
+      md += `\n`;
+    }
+  }
+
+  md += `## Working with this pipeline
+
+- **Inspect the graph:** \`wmill pipeline show ${folder} --local\`
+- **Run the cascade locally (no deploy):** \`wmill pipeline run ${folder} --local\`
+  (optionally \`--from <script> --to <script>\` to bound it, \`--dry-run\` to preview the plan)
+- **Live visual preview while editing:** \`wmill pipeline dev ${folder}\`
+- **Deploy:** \`wmill sync push\`
+
+Mark a script as part of this pipeline with a bare \`// pipeline\` comment
+(\`#\` for Python, \`--\` for SQL). Add \`// on <asset-uri>\` lines to subscribe it to
+upstream assets.
+
+---
+*Generated by \`wmill pipeline docs\`.*
+`;
+  return md;
+}
+
+export async function generatePipelineDocs(
+  opts: GlobalOptions & { local?: boolean; defaultTs?: "bun" | "deno" },
+  folder: string,
+) {
+  const workspace = await resolveWorkspace(opts);
+  await requireLogin(opts);
+  const f = folder.replace(/^f\//, "").replace(/\/$/, "");
+  const root = workspaceRoot();
+
+  const graph = opts.local
+    ? (await buildLocalPipelineGraph({ root, folder: f, defaultTs: opts.defaultTs })).graph
+    : await fetchDeployedGraph(workspace.workspaceId, f);
+
+  if (graph.runnables.length === 0) {
+    log.info(`No pipeline scripts in f/${f}.`);
+    return;
+  }
+
+  let datatableSchemas: any[] = [];
+  try {
+    datatableSchemas = await wmill.listDataTableSchemas({ workspace: workspace.workspaceId });
+  } catch (err: any) {
+    log.warn(colors.yellow(`Could not fetch datatable schemas: ${err.message}`));
+  }
+
+  const md = generatePipelineMarkdown(f, graph, datatableSchemas, !!opts.local);
+  const folderDir = path.join(root, "f", f);
+  await writeFile(path.join(folderDir, "PIPELINE.md"), md, "utf-8");
+  await writeFile(path.join(folderDir, "AGENTS.md"), `See @PIPELINE.md for this pipeline's graph, assets, and how to run it.\n`, "utf-8");
+  await writeFile(path.join(folderDir, "CLAUDE.md"), `Instructions are in @PIPELINE.md\n`, "utf-8");
+  log.info(colors.green(`✓ Wrote PIPELINE.md, AGENTS.md, CLAUDE.md to f/${f}`));
+}

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -67,7 +67,14 @@ export type AssetGraph = {
   triggers: GraphTrigger[];
 };
 
-export type LocalScript = { path: string; content: string; language: string };
+export type LocalScript = {
+  path: string;
+  content: string;
+  language: string;
+  // `// tag <worker-tag>` — routes the preview to that worker tag, matching the
+  // deployed pipeline. Undefined → default worker.
+  tag?: string;
+};
 
 // Raw shape of the wasm `parse_assets_<lang>` JSON output (a serialized Rust
 // `ParseAssetsOutput`). `triggers` is internally tagged on `kind`
@@ -88,6 +95,8 @@ type ParseAssetsRaw = {
   // the wasm asset parser). The body (a bare trailing SELECT) writes nothing
   // inferable, so the producer's output edge comes from here, not from `assets`.
   materialize?: { target_kind: string; target_path: string };
+  // `// tag <worker-tag>` — the worker tag the deployed pipeline routes to.
+  tag?: string;
 };
 
 // Mirror `inferAssets` (frontend/src/lib/infer.ts): only ts / py / sql have a
@@ -352,7 +361,9 @@ export async function buildLocalPipelineGraph(args: {
   for (const s of all) {
     const out = await inferScriptAssets(s.content, s.language);
     if (!out.in_pipeline) continue; // not a pipeline member
-    pipelineScripts.push(s);
+    // Carry the parsed `// tag` so previews route to the same worker the
+    // deployed pipeline would (both `pipeline run --local` and `/pipeline_dev`).
+    pipelineScripts.push(out.tag ? { ...s, tag: out.tag } : s);
     const mat = out.materialize;
     runnables.push({
       path: s.path,

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -33,6 +33,10 @@ export type GraphRunnable = {
   path: string;
   usage_kind: "script" | "flow" | "job";
   in_pipeline?: boolean;
+  // `// materialize <asset>` target — the script's declared output, mirrored
+  // from the deployed graph so the UI anchors column lineage / the materialize
+  // badge to it (the producer write-edge is emitted separately).
+  materialize_target?: { kind: string; path: string };
 };
 export type GraphEdge = {
   runnable_kind: string;
@@ -80,6 +84,10 @@ type ParseAssetsRaw = {
     | { kind: "asset"; asset_kind: string; path: string; debounce?: string }
     | { kind: string }
   )[];
+  // `// materialize [manual] <asset> …` — managed-materialize target (emitted by
+  // the wasm asset parser). The body (a bare trailing SELECT) writes nothing
+  // inferable, so the producer's output edge comes from here, not from `assets`.
+  materialize?: { target_kind: string; target_path: string };
 };
 
 // Mirror `inferAssets` (frontend/src/lib/infer.ts): only ts / py / sql have a
@@ -170,8 +178,11 @@ function fallbackParse(content: string, language: string): ParseAssetsRaw {
 }
 
 // Infer a single script's assets + pipeline annotations. Returns the raw
-// `ParseAssetsOutput`. wasm parse errors degrade to the annotation fallback so a
-// syntactically-broken script still shows as a pipeline node if it's annotated.
+// `ParseAssetsOutput` (incl. `materialize`, which the wasm asset parser emits as
+// of windmill-parser-wasm-asset 1.740.0 — kept in lockstep with the frontend's
+// pin so the local graph mirrors the deployed one). wasm parse errors degrade to
+// the annotation fallback so a syntactically-broken script still shows as a
+// pipeline node if it's annotated.
 export async function inferScriptAssets(
   content: string,
   language: string,
@@ -255,7 +266,13 @@ export async function buildLocalPipelineGraph(args: {
     const out = await inferScriptAssets(s.content, s.language);
     if (!out.in_pipeline) continue; // not a pipeline member
     pipelineScripts.push(s);
-    runnables.push({ path: s.path, usage_kind: "script", in_pipeline: true });
+    const mat = out.materialize;
+    runnables.push({
+      path: s.path,
+      usage_kind: "script",
+      in_pipeline: true,
+      ...(mat ? { materialize_target: { kind: mat.target_kind, path: mat.target_path } } : {}),
+    });
 
     for (const a of out.assets ?? []) {
       assetSet.set(`${a.kind}:${a.path}`, { kind: a.kind, path: a.path });
@@ -266,6 +283,33 @@ export async function buildLocalPipelineGraph(args: {
         asset_path: a.path,
         access_type: a.access_type,
       });
+    }
+    // `// materialize <asset>` declares a write output via annotation, not the
+    // SQL body, so body-inference misses it. Translate the parsed materialize
+    // target into the producer's write edge here (mirrors frontend
+    // resolveGraph.ts) so the materialized asset connects to its `// on`
+    // consumers; dedup against any body write.
+    if (mat) {
+      assetSet.set(`${mat.target_kind}:${mat.target_path}`, {
+        kind: mat.target_kind,
+        path: mat.target_path,
+      });
+      const hasWrite = edges.some(
+        (e) =>
+          e.runnable_path === s.path &&
+          e.asset_kind === mat.target_kind &&
+          e.asset_path === mat.target_path &&
+          (e.access_type === "w" || e.access_type === "rw"),
+      );
+      if (!hasWrite) {
+        edges.push({
+          runnable_kind: "script",
+          runnable_path: s.path,
+          asset_kind: mat.target_kind,
+          asset_path: mat.target_path,
+          access_type: "w",
+        });
+      }
     }
     for (const t of out.triggers ?? []) {
       if (t.kind === "asset") {

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -188,13 +188,73 @@ function fallbackParse(content: string, language: string): ParseAssetsRaw {
   return out;
 }
 
+// Comment prefix for `volume:` annotations. Deliberately NOT `commentPrefix`
+// above (which returns `--` for SQL): volume annotations are only recognized for
+// the languages the backend/frontend recognize them for — mirrors
+// `asset_inference.rs:comment_prefix` and `infer.ts:getCommentPrefix` (SQL → none).
+function volumeCommentPrefix(language: string): string | undefined {
+  switch (language) {
+    case "python3":
+    case "bash":
+    case "powershell":
+    case "ansible":
+    case "ruby":
+    case "rlang":
+      return "#";
+    case "deno":
+    case "bun":
+    case "bunnative":
+    case "nativets":
+    case "go":
+      return "//";
+    default:
+      return undefined;
+  }
+}
+
+// `<prefix> volume: <path>` lines in the LEADING comment block, each an `rw`
+// volume asset. Scanning stops at the first non-comment line (blank lines
+// skipped). Exact mirror of frontend `parseVolumeAnnotations` (infer.ts) /
+// backend `parse_volume_annotations` (asset_inference.rs) — the wasm body parser
+// does NOT emit these, so the local graph must supplement them or a `volume:`
+// producer shows disconnected from its `// on volume://…` consumers.
+function parseVolumeAnnotations(
+  content: string,
+  prefix: string,
+): { kind: string; path: string; access_type: "rw" }[] {
+  const out: { kind: string; path: string; access_type: "rw" }[] = [];
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "") continue;
+    if (!trimmed.startsWith(prefix)) break;
+    const after = trimmed.slice(prefix.length).trim();
+    const m = after.match(/^volume:\s*(\S+)/);
+    if (m) out.push({ kind: "volume", path: m[1], access_type: "rw" });
+  }
+  return out;
+}
+
 // Infer a single script's assets + pipeline annotations. Returns the raw
 // `ParseAssetsOutput` (incl. `materialize`, which the wasm asset parser emits as
 // of windmill-parser-wasm-asset 1.740.0 — kept in lockstep with the frontend's
-// pin so the local graph mirrors the deployed one). wasm parse errors degrade to
-// the annotation fallback so a syntactically-broken script still shows as a
-// pipeline node if it's annotated.
+// pin so the local graph mirrors the deployed one), plus `volume:` annotation
+// assets the wasm doesn't surface (merged in below, like the frontend/backend).
+// wasm parse errors degrade to the annotation fallback so a syntactically-broken
+// script still shows as a pipeline node if it's annotated.
 export async function inferScriptAssets(
+  content: string,
+  language: string,
+): Promise<ParseAssetsRaw> {
+  const out = await inferScriptAssetsBody(content, language);
+  const vp = volumeCommentPrefix(language);
+  if (vp) {
+    const vols = parseVolumeAnnotations(content, vp);
+    if (vols.length > 0) out.assets = [...(out.assets ?? []), ...vols];
+  }
+  return out;
+}
+
+async function inferScriptAssetsBody(
   content: string,
   language: string,
 ): Promise<ParseAssetsRaw> {

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -211,10 +211,12 @@ function fallbackParse(content: string, language: string): ParseAssetsRaw {
       continue;
     }
     // `// tag <worker-tag>` — routes the preview; cheap to scan and it affects
-    // execution, so recover it here too (the wasm path already carries it).
-    const tag = line.match(new RegExp(`^\\s*${p}\\s*tag\\s+(.+?)\\s*$`));
+    // execution, so recover it here too (the wasm path already carries it). A
+    // worker tag is a single token — match `\S+` (not `.+`) so trailing prose
+    // (`// tag gpu for heavy jobs`) can't smuggle a bogus multi-word tag.
+    const tag = line.match(new RegExp(`^\\s*${p}\\s*tag\\s+(\\S+)\\s*$`));
     if (tag) {
-      out.tag = tag[1].trim();
+      out.tag = tag[1];
       continue;
     }
     const on = line.match(new RegExp(`^\\s*${p}\\s*on\\s+(.+?)\\s*$`));

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -164,25 +164,32 @@ const NATIVE_KINDS = new Set([
   "data_upload",
 ]);
 function fallbackParse(content: string, language: string): ParseAssetsRaw {
-  const p = commentPrefix(language).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const raw = commentPrefix(language);
+  const p = raw.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const out: ParseAssetsRaw = { in_pipeline: false, triggers: [] };
+  // Annotations live in the LEADING comment header (like the canonical parsers).
+  // Stop at the first non-comment line so a body comment — e.g. `// on s3://…`
+  // inside commented-out code or a heredoc — can't inject a phantom trigger.
   for (const line of content.split("\n")) {
-    const bare = line.match(new RegExp(`^\\s*${p}\\s*pipeline\\s*$`));
-    if (bare) {
+    const trimmed = line.trim();
+    if (trimmed === "") continue;
+    if (!trimmed.startsWith(raw)) break;
+    if (line.match(new RegExp(`^\\s*${p}\\s*pipeline\\s*$`))) {
       out.in_pipeline = true;
       continue;
     }
     const on = line.match(new RegExp(`^\\s*${p}\\s*on\\s+(.+?)\\s*$`));
     if (!on) continue;
-    const spec = on[1].trim();
-    const uri = spec.match(/^([a-z0-9_]+):\/\/(.+)$/i);
+    // The asset/native kind is the FIRST token; trailing `key=value` options
+    // (e.g. `debounce=5s`) are not part of the path.
+    const firstTok = on[1].trim().split(/\s+/)[0];
+    const uri = firstTok.match(/^([a-z0-9_]+):\/\/(.+)$/i);
     if (uri) {
       const prefix = uri[1].toLowerCase();
       const kind = prefix === "s3" ? "s3object" : prefix;
       out.triggers!.push({ kind: "asset", asset_kind: kind, path: uri[2] });
-    } else {
-      const word = spec.split(/\s+/)[0];
-      if (NATIVE_KINDS.has(word)) out.triggers!.push({ kind: word });
+    } else if (NATIVE_KINDS.has(firstTok)) {
+      out.triggers!.push({ kind: firstTok });
     }
   }
   return out;

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -101,6 +101,8 @@ function wasmFnForLanguage(language: string): "parse_assets_ts" | "parse_assets_
     case "deno":
     case "nativets":
       return "parse_assets_ts";
+    case "bunnative":
+      return "parse_assets_ts";
     case "python3":
       return "parse_assets_py";
     case "duckdb":
@@ -120,7 +122,16 @@ const ASSET_WASM_PKG = "windmill-parser-wasm-asset";
 
 // Comment prefix per language, for the no-wasm annotation fallback.
 function commentPrefix(language: string): string {
-  if (language === "python3" || language === "bash" || language === "ansible") return "#";
+  if (
+    language === "python3" ||
+    language === "bash" ||
+    language === "ansible" ||
+    language === "ruby" ||
+    language === "rlang" ||
+    language === "nu" ||
+    language === "powershell"
+  )
+    return "#";
   if (
     language === "postgresql" ||
     language === "mysql" ||
@@ -231,10 +242,19 @@ export async function collectScripts(
       const ext = exts.find((x) => e.name.endsWith(x));
       if (!ext) continue;
       const relFromRoot = path.relative(root, abs).replaceAll("\\", "/");
+      // A bare `.sql` (no dialect) makes inferContentTypeFromFilePath throw —
+      // skip the file rather than letting one unclassifiable file abort the
+      // whole graph build (which would also wedge `pipeline dev` at startup).
+      let language: string;
+      try {
+        language = inferContentTypeFromFilePath(abs, defaultTs);
+      } catch {
+        continue;
+      }
       out.push({
         path: removeExtensionToPath(relFromRoot),
         content: fs.readFileSync(abs, "utf-8"),
-        language: inferContentTypeFromFilePath(abs, defaultTs),
+        language,
       });
     }
   }

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -178,10 +178,11 @@ function commentPrefix(language: string): string {
 
 // Minimal annotation scan for languages without a wasm asset parser (go, bash).
 // Deliberately a SUBSET of the canonical parsers (backend
-// `parse_pipeline_annotations`, frontend `parsePipelineAnnotations.ts`): it only
-// recovers `// pipeline` membership and `// on <asset-uri | native-kind>` so the
-// node and its trigger edges still appear in the graph. Body-inferred I/O for
-// these languages is out of scope (see plan); annotate explicitly to get edges.
+// `parse_pipeline_annotations`, frontend `parsePipelineAnnotations.ts`): it
+// recovers `// pipeline` membership, `// on <asset-uri | native-kind>`, and
+// `// tag <worker-tag>` (routing affects execution) so the node, its trigger
+// edges, and its worker tag still appear. Body-inferred I/O for these languages
+// is out of scope (see plan); annotate explicitly to get edges.
 const NATIVE_KINDS = new Set([
   "schedule",
   "webhook",
@@ -207,6 +208,13 @@ function fallbackParse(content: string, language: string): ParseAssetsRaw {
     if (!trimmed.startsWith(raw)) break;
     if (line.match(new RegExp(`^\\s*${p}\\s*pipeline\\s*$`))) {
       out.in_pipeline = true;
+      continue;
+    }
+    // `// tag <worker-tag>` — routes the preview; cheap to scan and it affects
+    // execution, so recover it here too (the wasm path already carries it).
+    const tag = line.match(new RegExp(`^\\s*${p}\\s*tag\\s+(.+?)\\s*$`));
+    if (tag) {
+      out.tag = tag[1].trim();
       continue;
     }
     const on = line.match(new RegExp(`^\\s*${p}\\s*on\\s+(.+?)\\s*$`));

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -223,13 +223,18 @@ function fallbackParse(content: string, language: string): ParseAssetsRaw {
     if (!on) continue;
     // The asset/native kind is the FIRST token; trailing `key=value` options
     // (e.g. `debounce=5s`) are not part of the path.
-    const firstTok = on[1].trim().split(/\s+/)[0];
+    const rest = on[1].trim();
+    const firstTok = rest.split(/\s+/)[0];
     const uri = firstTok.match(/^([a-z0-9_]+):\/\/(.+)$/i);
     if (uri) {
       const prefix = uri[1].toLowerCase();
       const kind = prefix === "s3" ? "s3object" : prefix;
       out.triggers!.push({ kind: "asset", asset_kind: kind, path: uri[2] });
-    } else if (NATIVE_KINDS.has(firstTok)) {
+    } else if (NATIVE_KINDS.has(firstTok) && rest === firstTok) {
+      // A native marker (`// on data_upload`) must stand alone: the canonical
+      // parser rejects a marker line with trailing content (`// on data_upload
+      // f/foo`, `# on kafka topic`), so match that here to keep local/deployed
+      // parity for the fallback surface.
       out.triggers!.push({ kind: firstTok });
     }
   }

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -1,0 +1,303 @@
+// Build a pipeline asset-graph from LOCAL, not-yet-deployed script files.
+//
+// The deployed asset-graph endpoint (`GET /assets/graph`) only reflects scripts
+// already pushed to the workspace. To get the same graph from the working tree
+// (so `pipeline show --local` / `pipeline run --local` / `pipeline dev` work
+// before deploy), we infer each script's assets + pipeline annotations with the
+// SAME wasm parser the frontend uses (`windmill-parser-wasm-asset`,
+// `frontend/src/lib/infer.ts:inferAssets`). That wasm returns the full serialized
+// Rust `ParseAssetsOutput`: body-inferred `assets` (with r/w/rw access) AND the
+// parsed pipeline annotations (`in_pipeline`, `triggers`, …) in one call — so we
+// reproduce the endpoint payload without a backend round-trip or a TS re-port of
+// the annotation parser.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import process from "node:process";
+import { loadParser } from "../../utils/metadata.ts";
+import { exts, removeExtensionToPath } from "../script/script.ts";
+import { inferContentTypeFromFilePath } from "../../utils/script_common.ts";
+import { getWmillYamlPath } from "../../core/conf.ts";
+
+// Resolve the workspace root (the directory containing wmill.yaml) for reading
+// local files, falling back to the current directory.
+export function workspaceRoot(): string {
+  const yaml = getWmillYamlPath();
+  return yaml ? path.dirname(yaml) : process.cwd();
+}
+
+// Graph payload shape — structurally identical to the backend `/assets/graph`
+// response and a superset of `boundedCascade.ts`'s `BCGraph`. Defined here (the
+// graph module) and re-imported by pipeline.ts so there is one canonical type.
+export type GraphRunnable = {
+  path: string;
+  usage_kind: "script" | "flow" | "job";
+  in_pipeline?: boolean;
+};
+export type GraphEdge = {
+  runnable_kind: string;
+  runnable_path: string;
+  asset_kind: string;
+  asset_path: string;
+  access_type?: "r" | "w" | "rw";
+};
+export type GraphTrigger =
+  | {
+      trigger_kind: "asset";
+      asset_kind: string;
+      asset_path: string;
+      runnable_kind: string;
+      runnable_path: string;
+    }
+  | {
+      trigger_kind: string;
+      path?: string;
+      runnable_kind: string;
+      runnable_path: string;
+      missing?: boolean;
+    };
+export type AssetGraph = {
+  runnables: GraphRunnable[];
+  assets: { kind: string; path: string }[];
+  edges: GraphEdge[];
+  triggers: GraphTrigger[];
+};
+
+export type LocalScript = { path: string; content: string; language: string };
+
+// Raw shape of the wasm `parse_assets_<lang>` JSON output (a serialized Rust
+// `ParseAssetsOutput`). `triggers` is internally tagged on `kind`
+// (`#[serde(tag = "kind", rename_all = "lowercase")]`): asset triggers carry
+// `asset_kind` + `path`; native triggers are bare `{ kind }`.
+type ParseAssetsRaw = {
+  assets?: {
+    kind: string;
+    path: string;
+    access_type?: "r" | "w" | "rw";
+  }[];
+  in_pipeline?: boolean;
+  triggers?: (
+    | { kind: "asset"; asset_kind: string; path: string; debounce?: string }
+    | { kind: string }
+  )[];
+};
+
+// Mirror `inferAssets` (frontend/src/lib/infer.ts): only ts / py / sql have a
+// wasm asset parser. SQL dialects all route to `parse_assets_sql` — the comment-
+// header annotation scan inside it is dialect-independent, so `in_pipeline` /
+// `// on` come through even when body asset detection is duckdb-shaped. Languages
+// with no entry (go, bash, …) fall back to a minimal annotation scan below.
+function wasmFnForLanguage(language: string): "parse_assets_ts" | "parse_assets_py" | "parse_assets_sql" | undefined {
+  switch (language) {
+    case "bun":
+    case "deno":
+    case "nativets":
+      return "parse_assets_ts";
+    case "python3":
+      return "parse_assets_py";
+    case "duckdb":
+    case "postgresql":
+    case "mysql":
+    case "bigquery":
+    case "snowflake":
+    case "mssql":
+    case "oracledb":
+      return "parse_assets_sql";
+    default:
+      return undefined;
+  }
+}
+
+const ASSET_WASM_PKG = "windmill-parser-wasm-asset";
+
+// Comment prefix per language, for the no-wasm annotation fallback.
+function commentPrefix(language: string): string {
+  if (language === "python3" || language === "bash" || language === "ansible") return "#";
+  if (
+    language === "postgresql" ||
+    language === "mysql" ||
+    language === "bigquery" ||
+    language === "snowflake" ||
+    language === "mssql" ||
+    language === "oracledb" ||
+    language === "duckdb"
+  )
+    return "--";
+  return "//";
+}
+
+// Minimal annotation scan for languages without a wasm asset parser (go, bash).
+// Deliberately a SUBSET of the canonical parsers (backend
+// `parse_pipeline_annotations`, frontend `parsePipelineAnnotations.ts`): it only
+// recovers `// pipeline` membership and `// on <asset-uri | native-kind>` so the
+// node and its trigger edges still appear in the graph. Body-inferred I/O for
+// these languages is out of scope (see plan); annotate explicitly to get edges.
+const NATIVE_KINDS = new Set([
+  "schedule",
+  "webhook",
+  "email",
+  "kafka",
+  "mqtt",
+  "nats",
+  "postgres",
+  "sqs",
+  "gcp",
+  "data_upload",
+]);
+function fallbackParse(content: string, language: string): ParseAssetsRaw {
+  const p = commentPrefix(language).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const out: ParseAssetsRaw = { in_pipeline: false, triggers: [] };
+  for (const line of content.split("\n")) {
+    const bare = line.match(new RegExp(`^\\s*${p}\\s*pipeline\\s*$`));
+    if (bare) {
+      out.in_pipeline = true;
+      continue;
+    }
+    const on = line.match(new RegExp(`^\\s*${p}\\s*on\\s+(.+?)\\s*$`));
+    if (!on) continue;
+    const spec = on[1].trim();
+    const uri = spec.match(/^([a-z0-9_]+):\/\/(.+)$/i);
+    if (uri) {
+      const prefix = uri[1].toLowerCase();
+      const kind = prefix === "s3" ? "s3object" : prefix;
+      out.triggers!.push({ kind: "asset", asset_kind: kind, path: uri[2] });
+    } else {
+      const word = spec.split(/\s+/)[0];
+      if (NATIVE_KINDS.has(word)) out.triggers!.push({ kind: word });
+    }
+  }
+  return out;
+}
+
+// Infer a single script's assets + pipeline annotations. Returns the raw
+// `ParseAssetsOutput`. wasm parse errors degrade to the annotation fallback so a
+// syntactically-broken script still shows as a pipeline node if it's annotated.
+export async function inferScriptAssets(
+  content: string,
+  language: string,
+): Promise<ParseAssetsRaw> {
+  const fn = wasmFnForLanguage(language);
+  if (!fn) return fallbackParse(content, language);
+  let raw: string;
+  try {
+    const mod = await loadParser(ASSET_WASM_PKG);
+    raw = mod[fn](content) as string;
+  } catch {
+    return fallbackParse(content, language);
+  }
+  if (raw.startsWith("err:")) return fallbackParse(content, language);
+  try {
+    return JSON.parse(raw) as ParseAssetsRaw;
+  } catch {
+    return fallbackParse(content, language);
+  }
+}
+
+// Recursively collect every local script file under `folderDir`, returning each
+// one's windmill path (relative to `root`, extension stripped), content, and
+// language. Skips lock files and metadata YAMLs.
+export async function collectScripts(
+  folderDir: string,
+  root: string,
+  defaultTs: "bun" | "deno" | undefined,
+): Promise<LocalScript[]> {
+  const out: LocalScript[] = [];
+  function walk(dir: string) {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (e.name.startsWith(".") || e.name === "node_modules") continue;
+      const abs = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        walk(abs);
+        continue;
+      }
+      if (!e.isFile()) continue;
+      const ext = exts.find((x) => e.name.endsWith(x));
+      if (!ext) continue;
+      const relFromRoot = path.relative(root, abs).replaceAll("\\", "/");
+      out.push({
+        path: removeExtensionToPath(relFromRoot),
+        content: fs.readFileSync(abs, "utf-8"),
+        language: inferContentTypeFromFilePath(abs, defaultTs),
+      });
+    }
+  }
+  walk(folderDir);
+  out.sort((a, b) => a.path.localeCompare(b.path));
+  return out;
+}
+
+// Build the full pipeline asset-graph from local files in `f/<folder>/`.
+// Only `// pipeline` scripts become graph nodes (pipeline membership), mirroring
+// the deployed graph endpoint. Returns the graph plus the in-pipeline scripts'
+// content (the dev watcher pushes the latter; the runner re-reads it for preview).
+export async function buildLocalPipelineGraph(args: {
+  root: string;
+  folder: string;
+  defaultTs?: "bun" | "deno";
+}): Promise<{ graph: AssetGraph; scripts: LocalScript[] }> {
+  const folderClean = args.folder.replace(/^f\//, "").replace(/\/$/, "");
+  const folderDir = path.join(args.root, "f", folderClean);
+  const all = await collectScripts(folderDir, args.root, args.defaultTs);
+
+  const runnables: GraphRunnable[] = [];
+  const edges: GraphEdge[] = [];
+  const triggers: GraphTrigger[] = [];
+  const assetSet = new Map<string, { kind: string; path: string }>();
+  const pipelineScripts: LocalScript[] = [];
+
+  for (const s of all) {
+    const out = await inferScriptAssets(s.content, s.language);
+    if (!out.in_pipeline) continue; // not a pipeline member
+    pipelineScripts.push(s);
+    runnables.push({ path: s.path, usage_kind: "script", in_pipeline: true });
+
+    for (const a of out.assets ?? []) {
+      assetSet.set(`${a.kind}:${a.path}`, { kind: a.kind, path: a.path });
+      edges.push({
+        runnable_kind: "script",
+        runnable_path: s.path,
+        asset_kind: a.kind,
+        asset_path: a.path,
+        access_type: a.access_type,
+      });
+    }
+    for (const t of out.triggers ?? []) {
+      if (t.kind === "asset") {
+        const at = t as { kind: "asset"; asset_kind: string; path: string };
+        assetSet.set(`${at.asset_kind}:${at.path}`, {
+          kind: at.asset_kind,
+          path: at.path,
+        });
+        triggers.push({
+          trigger_kind: "asset",
+          asset_kind: at.asset_kind,
+          asset_path: at.path,
+          runnable_kind: "script",
+          runnable_path: s.path,
+        });
+      } else {
+        triggers.push({
+          trigger_kind: t.kind,
+          runnable_kind: "script",
+          runnable_path: s.path,
+        });
+      }
+    }
+  }
+
+  return {
+    graph: {
+      runnables,
+      assets: [...assetSet.values()],
+      edges,
+      triggers,
+    },
+    scripts: pipelineScripts,
+  };
+}

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -33,10 +33,20 @@ export type GraphRunnable = {
   path: string;
   usage_kind: "script" | "flow" | "job";
   in_pipeline?: boolean;
-  // `// materialize <asset>` target — the script's declared output, mirrored
-  // from the deployed graph so the UI anchors column lineage / the materialize
-  // badge to it (the producer write-edge is emitted separately).
+  // Annotation metadata the shared canvas renders as badges / lineage. Mirrors
+  // the deployed graph's runnable node (frontend `AssetGraphRunnableNode`) so the
+  // local-dev graph is the same surface as the deployed one for annotated scripts.
+  partition_kind?: string;
+  freshness?: string;
+  tag?: string;
+  retry?: { count: number; delay?: string };
+  data_tests?: unknown[];
+  column_lineage?: unknown[];
+  // `// materialize <asset>` target + strategy — the script's declared output,
+  // so the UI anchors column lineage / the materialize badge to it (the producer
+  // write-edge is emitted separately).
   materialize_target?: { kind: string; path: string };
+  materialize_strategy?: "replace" | "append" | "merge";
 };
 export type GraphEdge = {
   runnable_kind: string;
@@ -94,9 +104,21 @@ type ParseAssetsRaw = {
   // `// materialize [manual] <asset> …` — managed-materialize target (emitted by
   // the wasm asset parser). The body (a bare trailing SELECT) writes nothing
   // inferable, so the producer's output edge comes from here, not from `assets`.
-  materialize?: { target_kind: string; target_path: string };
+  materialize?: {
+    target_kind: string;
+    target_path: string;
+    manual?: boolean;
+    append?: boolean;
+    unique_key?: string;
+  };
   // `// tag <worker-tag>` — the worker tag the deployed pipeline routes to.
   tag?: string;
+  // Other annotation metadata the deployed graph carries onto its runnable nodes.
+  partition?: { kind: string };
+  freshness?: { duration: string };
+  retry?: { count: number; delay?: string };
+  data_tests?: unknown[];
+  column_lineage?: unknown[];
 };
 
 // Mirror `inferAssets` (frontend/src/lib/infer.ts): only ts / py / sql have a
@@ -365,11 +387,31 @@ export async function buildLocalPipelineGraph(args: {
     // deployed pipeline would (both `pipeline run --local` and `/pipeline_dev`).
     pipelineScripts.push(out.tag ? { ...s, tag: out.tag } : s);
     const mat = out.materialize;
+    // Managed-materialize write strategy, derived like the deployed graph
+    // (append → append; key=<col> → merge; else replace). Manual mode has no
+    // managed strategy.
+    const materialize_strategy =
+      mat && !mat.manual
+        ? mat.append
+          ? "append"
+          : mat.unique_key
+            ? "merge"
+            : "replace"
+        : undefined;
     runnables.push({
       path: s.path,
       usage_kind: "script",
       in_pipeline: true,
+      ...(out.partition ? { partition_kind: out.partition.kind } : {}),
+      ...(out.freshness ? { freshness: out.freshness.duration } : {}),
+      ...(out.tag ? { tag: out.tag } : {}),
+      ...(out.retry ? { retry: out.retry } : {}),
+      ...(out.data_tests && out.data_tests.length > 0 ? { data_tests: out.data_tests } : {}),
+      ...(out.column_lineage && out.column_lineage.length > 0
+        ? { column_lineage: out.column_lineage }
+        : {}),
       ...(mat ? { materialize_target: { kind: mat.target_kind, path: mat.target_path } } : {}),
+      ...(materialize_strategy ? { materialize_strategy } : {}),
     });
 
     for (const a of out.assets ?? []) {

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -40,6 +40,7 @@ import { generatePipelineDocs } from "./docs.ts";
 import {
   type UploadBinding,
   devUploadKey,
+  parseS3Uri,
   parseUploadBinding,
   s3Arg,
   s3ObjectParams,
@@ -187,6 +188,44 @@ async function enrichRootMarkers(
         if (existing.length > 0) nativeByScript.set(p, existing);
       } catch {
         // body fetch is best-effort enrichment only
+      }
+    }),
+  );
+}
+
+// The deployed `/assets/graph` omits `data_upload`/`webhook`/`email` trigger rows
+// (marker-only annotations with no trigger table), so on the deployed `run` path
+// `validStarts`/`nonAutorunTriggerScripts` can't see them and would auto-run such
+// an entrypoint with empty args. Recover them from the script bodies — the same
+// body-scan the deployed `show` path uses (`enrichRootMarkers`) — and inject
+// trigger rows so the run selection cuts them like the `--local` graph does.
+async function enrichDeployedNonAutorunTriggers(
+  workspaceId: string,
+  graph: BCGraph,
+): Promise<void> {
+  const MARKER_KINDS = new Set(["data_upload", "webhook", "email"]);
+  const scripts = (graph.runnables ?? []).filter((r) => r.usage_kind === "script");
+  await Promise.all(
+    scripts.map(async (r) => {
+      const known = new Set(
+        (graph.triggers ?? [])
+          .filter((t) => t.runnable_path === r.path && MARKER_KINDS.has(t.trigger_kind))
+          .map((t) => t.trigger_kind),
+      );
+      try {
+        const script = await wmill.getScriptByPath({ workspace: workspaceId, path: r.path });
+        for (const line of (script.content ?? "").split("\n")) {
+          const m = line.match(/^\s*(?:\/\/|--|#)\s*on\s+(\w+)\s*$/);
+          if (!m || !MARKER_KINDS.has(m[1]) || known.has(m[1])) continue;
+          known.add(m[1]);
+          graph.triggers.push({
+            trigger_kind: m[1],
+            runnable_kind: "script",
+            runnable_path: r.path,
+          });
+        }
+      } catch {
+        // best-effort: a fetch failure just leaves the row absent (prior behaviour)
       }
     }),
   );
@@ -380,22 +419,25 @@ async function resolveUploadArgs(
     if (param in args) {
       throw new Error(`--upload binds ${scriptPath}:${param} more than once.`);
     }
-    let key: string;
+    let obj: { s3: string; storage?: string };
     if (binding.source.startsWith("s3://")) {
-      key = binding.source.slice("s3://".length);
+      // `s3://<storage>/<key>` — keep the named storage (authority) so the worker
+      // downloads from the right store, not `{ s3: "<storage>/<key>" }`.
+      obj = parseS3Uri(binding.source);
     } else {
       const buf = await readFile(binding.source);
       // Key scoped by script + param so distinct sources sharing a basename
       // (across scripts or params) don't clobber each other in the store.
-      key = devUploadKey(scriptPath, param, binding.source);
+      const key = devUploadKey(scriptPath, param, binding.source);
       await wmill.fileUpload({
         workspace: workspaceId,
         fileKey: key,
         requestBody: new Blob([buf]) as any,
       });
       log.info(colors.gray(`  ↑ ${binding.source} → s3://${key}`));
+      obj = { s3: key };
     }
-    Object.assign(args, s3Arg(param, key));
+    Object.assign(args, s3Arg(param, obj));
   }
   return args;
 }
@@ -457,6 +499,10 @@ async function run(
     graph = await apiGet<BCGraph>(
       `/w/${workspace.workspaceId}/assets/graph?folder=${encodeURIComponent(f)}&asset_kinds=${ASSET_KINDS}`,
     );
+    // Recover marker-only `data_upload`/`webhook`/`email` triggers the graph
+    // endpoint can't emit, so input-only entrypoints are cut here as they are
+    // under `--local` (else they'd auto-run empty).
+    await enrichDeployedNonAutorunTriggers(workspace.workspaceId, graph);
   }
 
   // `--upload <script>[:<param>]=<file|s3://key>` binds an object to a
@@ -585,7 +631,6 @@ async function run(
     selectedScripts = new Set(scriptsOf(reachableCutting(dag, [start!], barriers)));
   } else {
     const res = boundedSet(dag, start!, ends);
-    reachableEnds = res.reachableEnds;
     droppedEnds = res.droppedEnds;
     for (const d of droppedEnds) {
       log.warn(`end '${idLabel(d)}' is not downstream of the start — ignored.`);
@@ -596,6 +641,19 @@ async function run(
     selectedScripts = new Set(
       scriptsOf([...res.nodes].filter((n) => reachable.has(n))),
     );
+    // An end that boundedSet reached but the barrier cut removed is NOT satisfied:
+    // report it as dropped (not reachable) and warn, so `--json`/the plan don't
+    // claim a bound was met when its only path ran through a skipped handler.
+    for (const e of res.reachableEnds) {
+      if (reachable.has(e)) {
+        reachableEnds.push(e);
+      } else {
+        droppedEnds.push(e);
+        log.warn(
+          `end '${idLabel(e)}' is only reachable through a skipped input/event handler — not run (bind it with --upload to include it).`,
+        );
+      }
+    }
   }
 
   const { order, cyclic } = topoOrder(graph, selectedScripts);

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -564,10 +564,12 @@ async function run(
   // per-event fanout (kafka/mqtt/nats/postgres/sqs/gcp/email/webhook/data_upload):
   // they can't run with empty args, so no run mode — whole-pipeline, single-root,
   // or bounded — may schedule them, nor a downstream consumer that only such a
-  // handler feeds (it would get missing/stale inputs). `--upload`-bound handlers
-  // are un-gated (they get their input at execution) so drop out of the barrier set.
+  // handler feeds (it would get missing/stale inputs). Exclude `starts` from the
+  // barriers: a valid start (a schedule/manual root, or an `--upload`-bound
+  // handler) runs with its own input even if it ALSO carries a non-autorun
+  // trigger — cutting it would drop a legitimately-scheduled root and its chain.
   const barriers = new Set(
-    [...nonAutorunTriggerScripts(graph)].filter((id) => !boundNodeIds.has(id)),
+    [...nonAutorunTriggerScripts(graph)].filter((id) => !starts.has(id)),
   );
   let selectedScripts: Set<string>;
   let reachableEnds: string[] = [];

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -12,7 +12,6 @@ import {
   type BCGraph,
   boundedSet,
   buildLineageDag,
-  descendants,
   nonAutorunTriggerScripts,
   reachableCutting,
   resolveToken,
@@ -341,17 +340,17 @@ async function waitJob(workspace: string, id: string): Promise<boolean> {
 // S3Object parameter (explicit `:param`, else the script's sole S3Object arg)
 // and turn the source into an object key — an `s3://` source is used as-is, a
 // local path is uploaded to the workspace store under a deterministic dev key.
-async function resolveUploadArg(
-  binding: UploadBinding,
+async function resolveUploadArgs(
+  bindings: UploadBinding[],
   scriptPath: string,
   workspaceId: string,
   local: boolean | undefined,
   localScripts: Map<string, LocalScript> | undefined,
-  folder: string,
 ): Promise<Record<string, any>> {
-  let param = binding.param;
-  if (!param) {
-    let schema: any;
+  // Fetch the schema at most once, and only when a binding omits `:param`.
+  let schema: any | undefined;
+  const loadSchema = async (): Promise<any> => {
+    if (schema) return schema;
     if (local) {
       const ls = localScripts?.get(scriptPath);
       if (!ls) {
@@ -361,30 +360,44 @@ async function resolveUploadArg(
     } else {
       schema = (await wmill.getScriptByPath({ workspace: workspaceId, path: scriptPath })).schema;
     }
-    const params = s3ObjectParams(schema);
-    if (params.length === 1) param = params[0];
-    else if (params.length === 0) {
-      throw new Error(`${scriptPath} declares no S3Object parameter to bind --upload to.`);
-    } else {
-      throw new Error(
-        `${scriptPath} has multiple S3Object parameters (${params.join(", ")}) — pick one with --upload ${binding.scriptTok}:<param>=${binding.source}`,
-      );
+    return schema;
+  };
+
+  const args: Record<string, any> = {};
+  for (const binding of bindings) {
+    let param = binding.param;
+    if (!param) {
+      const params = s3ObjectParams(await loadSchema());
+      if (params.length === 1) param = params[0];
+      else if (params.length === 0) {
+        throw new Error(`${scriptPath} declares no S3Object parameter to bind --upload to.`);
+      } else {
+        throw new Error(
+          `${scriptPath} has multiple S3Object parameters (${params.join(", ")}) — pick one with --upload ${binding.scriptTok}:<param>=${binding.source}`,
+        );
+      }
     }
+    if (param in args) {
+      throw new Error(`--upload binds ${scriptPath}:${param} more than once.`);
+    }
+    let key: string;
+    if (binding.source.startsWith("s3://")) {
+      key = binding.source.slice("s3://".length);
+    } else {
+      const buf = await readFile(binding.source);
+      // Key scoped by script + param so distinct sources sharing a basename
+      // (across scripts or params) don't clobber each other in the store.
+      key = devUploadKey(scriptPath, param, binding.source);
+      await wmill.fileUpload({
+        workspace: workspaceId,
+        fileKey: key,
+        requestBody: new Blob([buf]) as any,
+      });
+      log.info(colors.gray(`  ↑ ${binding.source} → s3://${key}`));
+    }
+    Object.assign(args, s3Arg(param, key));
   }
-  let key: string;
-  if (binding.source.startsWith("s3://")) {
-    key = binding.source.slice("s3://".length);
-  } else {
-    const buf = await readFile(binding.source);
-    key = devUploadKey(folder, binding.source);
-    await wmill.fileUpload({
-      workspace: workspaceId,
-      fileKey: key,
-      requestBody: new Blob([buf]) as any,
-    });
-    log.info(colors.gray(`  ↑ ${binding.source} → s3://${key}`));
-  }
-  return s3Arg(param, key);
+  return args;
 }
 
 async function run(
@@ -448,8 +461,9 @@ async function run(
 
   // `--upload <script>[:<param>]=<file|s3://key>` binds an object to a
   // data_upload/webhook entry point so it becomes a runnable start (and its
-  // downstream is no longer cut) — the arg is injected at execution.
-  const boundBindingByPath = new Map<string, UploadBinding>();
+  // downstream is no longer cut) — the arg is injected at execution. Repeatable
+  // per script (accumulated) so a multi-S3Object entry can bind each param.
+  const boundBindingsByPath = new Map<string, UploadBinding[]>();
   const boundNodeIds = new Set<string>();
   for (const spec of opts.upload ?? []) {
     const binding = parseUploadBinding(spec);
@@ -465,7 +479,8 @@ async function run(
       }
       throw new Error(`--upload '${binding.scriptTok}' matched no script in f/${f}.`);
     }
-    boundBindingByPath.set(scriptPathOf(id), binding);
+    const p = scriptPathOf(id);
+    (boundBindingsByPath.get(p) ?? boundBindingsByPath.set(p, []).get(p)!).push(binding);
     boundNodeIds.add(id);
   }
 
@@ -545,27 +560,27 @@ async function run(
   const idLabel = (id: string): string => (id.startsWith("script:") ? scriptPathOf(id) : id);
 
   const dag = buildLineageDag(graph);
+  // CUT the selection at scripts whose trigger needs caller-supplied input or
+  // per-event fanout (kafka/mqtt/nats/postgres/sqs/gcp/email/webhook/data_upload):
+  // they can't run with empty args, so no run mode — whole-pipeline, single-root,
+  // or bounded — may schedule them, nor a downstream consumer that only such a
+  // handler feeds (it would get missing/stale inputs). `--upload`-bound handlers
+  // are un-gated (they get their input at execution) so drop out of the barrier set.
+  const barriers = new Set(
+    [...nonAutorunTriggerScripts(graph)].filter((id) => !boundNodeIds.has(id)),
+  );
   let selectedScripts: Set<string>;
   let reachableEnds: string[] = [];
   let droppedEnds: string[] = [];
   if (runAll) {
     // Whole pipeline = everything reachable from the valid starts (schedule/manual
-    // roots), but CUT at scripts whose trigger needs caller-supplied input or
-    // per-event fanout (kafka/mqtt/nats/postgres/sqs/gcp/email/webhook/data_upload).
-    // They can't run with empty args, and cutting — rather than just deleting the
-    // handler after a descendant union — also drops its downstream, so `pipeline
-    // run <folder>` never runs a consumer whose skipped producer would leave it
-    // with missing/stale inputs. A node also reachable via another path still runs.
-    // `--upload`-bound handlers are un-gated: they get their input at execution.
-    const barriers = new Set(
-      [...nonAutorunTriggerScripts(graph)].filter((id) => !boundNodeIds.has(id)),
-    );
+    // roots), cutting at the barriers above. A node reachable via another,
+    // non-barrier path still runs.
     selectedScripts = new Set(scriptsOf(reachableCutting(dag, starts, barriers)));
   } else if (ends.length === 0) {
-    // No bound → full read-aware downstream of start (pure readers included).
-    const all = new Set(descendants(dag, start!));
-    all.add(start!);
-    selectedScripts = new Set(scriptsOf(all));
+    // No bound → full read-aware downstream of start (pure readers included),
+    // still cut at barriers so an event/upload descendant isn't run empty.
+    selectedScripts = new Set(scriptsOf(reachableCutting(dag, [start!], barriers)));
   } else {
     const res = boundedSet(dag, start!, ends);
     reachableEnds = res.reachableEnds;
@@ -573,7 +588,12 @@ async function run(
     for (const d of droppedEnds) {
       log.warn(`end '${idLabel(d)}' is not downstream of the start — ignored.`);
     }
-    selectedScripts = new Set(scriptsOf(res.nodes));
+    // Intersect the bounded window with the barrier-cut closure from the start so
+    // a barrier (or a node only reachable through one) inside the window is dropped.
+    const reachable = reachableCutting(dag, [start!], barriers);
+    selectedScripts = new Set(
+      scriptsOf([...res.nodes].filter((n) => reachable.has(n))),
+    );
   }
 
   const { order, cyclic } = topoOrder(graph, selectedScripts);
@@ -584,8 +604,8 @@ async function run(
   // A `--upload` whose script fell outside the selection is a no-op the user
   // should know about, rather than silently ignored.
   const orderSet = new Set(order);
-  const boundInOrder = [...boundBindingByPath.keys()].filter((p) => orderSet.has(p)).sort();
-  for (const p of boundBindingByPath.keys()) {
+  const boundInOrder = [...boundBindingsByPath.keys()].filter((p) => orderSet.has(p)).sort();
+  for (const p of boundBindingsByPath.keys()) {
     if (!orderSet.has(p)) log.warn(`--upload for ${p} is unused — it isn't in the run selection.`);
   }
 
@@ -618,7 +638,7 @@ async function run(
           colors.dim(runAll ? ` (whole pipeline)` : ` (from ${shortName(scriptPathOf(start!))})`),
       );
       order.forEach((p, i) =>
-        log.info(`  ${i + 1}. ${p}${boundBindingByPath.has(p) ? colors.dim(" (← --upload)") : ""}`),
+        log.info(`  ${i + 1}. ${p}${boundBindingsByPath.has(p) ? colors.dim(" (← --upload)") : ""}`),
       );
     }
     return;
@@ -631,13 +651,12 @@ async function run(
   for (const nodePath of boundInOrder) {
     uploadArgs.set(
       nodePath,
-      await resolveUploadArg(
-        boundBindingByPath.get(nodePath)!,
+      await resolveUploadArgs(
+        boundBindingsByPath.get(nodePath)!,
         nodePath,
         workspace.workspaceId,
         opts.local,
         localScripts,
-        f,
       ),
     );
   }
@@ -724,7 +743,7 @@ const command = new Command()
   )
   .option(
     "--upload <binding:string>",
-    "Bind an object to a data_upload/webhook entry point so it runs in the cascade: <script>[:<param>]=<local-file|s3://key>. Local files are uploaded to the workspace store; the S3Object param is inferred when the script has exactly one. Repeatable.",
+    "Bind an object to a data_upload/webhook entry point so it runs in the cascade, as SCRIPT[:PARAM]=SOURCE (SOURCE is a local file or an s3://key). Local files are uploaded to the workspace store; the S3Object param is inferred when the script has exactly one. Repeatable.",
     { collect: true },
   )
   .action(run as any)

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -114,7 +114,8 @@ async function show(
   let graph: AssetGraph;
   let enrich: ((nativeByScript: Map<string, NativeMarker[]>, roots: string[]) => Promise<void>) | undefined;
   if (opts.local) {
-    graph = (await buildLocalPipelineGraph({ root: workspaceRoot(), folder: f, defaultTs: opts.defaultTs })).graph;
+    const merged = await mergeConfigWithConfigFile(opts);
+    graph = (await buildLocalPipelineGraph({ root: workspaceRoot(), folder: f, defaultTs: merged.defaultTs })).graph;
   } else {
     const workspace = await resolveWorkspace(opts);
     await requireLogin(opts);
@@ -350,10 +351,13 @@ async function run(
   let localScripts: Map<string, LocalScript> | undefined;
   let tempScriptRefs: Record<string, string> | undefined;
   if (opts.local) {
+    // Resolve config (defaultTs drives .ts → bun/deno language inference, so a
+    // deno-default workspace previews under the right runtime).
+    const merged = await mergeConfigWithConfigFile(opts);
     const built = await buildLocalPipelineGraph({
       root: workspaceRoot(),
       folder: f,
-      defaultTs: opts.defaultTs,
+      defaultTs: merged.defaultTs,
     });
     graph = built.graph;
     localScripts = new Map(built.scripts.map((s) => [s.path, s]));
@@ -361,7 +365,6 @@ async function run(
     // that imports a sibling workspace lib previews against local edits. Same
     // trick as `wmill dev` / `wmill app dev`; degrades to undefined gracefully.
     try {
-      const merged = await mergeConfigWithConfigFile(opts);
       const codebases = await listSyncCodebases(merged);
       const { buildPreviewTempScriptRefs } = await import(
         "../generate-metadata/generate-metadata.ts"

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -34,8 +34,17 @@ import {
   type SyncOptions,
 } from "../../core/conf.ts";
 import { listSyncCodebases } from "../../utils/codebase.ts";
+import { inferSchema } from "../../utils/metadata.ts";
+import { readFile } from "node:fs/promises";
 import pipelineDev from "./dev.ts";
 import { generatePipelineDocs } from "./docs.ts";
+import {
+  type UploadBinding,
+  devUploadKey,
+  parseUploadBinding,
+  s3Arg,
+  s3ObjectParams,
+} from "./pipelineUpload.ts";
 
 // The graph payload types (AssetGraph / GraphRunnable / GraphEdge /
 // GraphTrigger) are defined in ./localGraph.ts — the canonical pipeline graph
@@ -328,6 +337,56 @@ async function waitJob(workspace: string, id: string): Promise<boolean> {
 // `--to`, runs the full read-aware downstream of `--from` (every descendant in
 // the lineage DAG, pure readers included — broader than the canvas cascade,
 // which dispatches subscribers only).
+// Resolve one `--upload` binding to the run-arg it injects: pick the target
+// S3Object parameter (explicit `:param`, else the script's sole S3Object arg)
+// and turn the source into an object key — an `s3://` source is used as-is, a
+// local path is uploaded to the workspace store under a deterministic dev key.
+async function resolveUploadArg(
+  binding: UploadBinding,
+  scriptPath: string,
+  workspaceId: string,
+  local: boolean | undefined,
+  localScripts: Map<string, LocalScript> | undefined,
+  folder: string,
+): Promise<Record<string, any>> {
+  let param = binding.param;
+  if (!param) {
+    let schema: any;
+    if (local) {
+      const ls = localScripts?.get(scriptPath);
+      if (!ls) {
+        throw new Error(`No local file for ${scriptPath} to infer its S3Object parameter.`);
+      }
+      schema = (await inferSchema(ls.language as any, ls.content, {}, scriptPath)).schema;
+    } else {
+      schema = (await wmill.getScriptByPath({ workspace: workspaceId, path: scriptPath })).schema;
+    }
+    const params = s3ObjectParams(schema);
+    if (params.length === 1) param = params[0];
+    else if (params.length === 0) {
+      throw new Error(`${scriptPath} declares no S3Object parameter to bind --upload to.`);
+    } else {
+      throw new Error(
+        `${scriptPath} has multiple S3Object parameters (${params.join(", ")}) — pick one with --upload ${binding.scriptTok}:<param>=${binding.source}`,
+      );
+    }
+  }
+  let key: string;
+  if (binding.source.startsWith("s3://")) {
+    key = binding.source.slice("s3://".length);
+  } else {
+    const buf = await readFile(binding.source);
+    key = devUploadKey(folder, binding.source);
+    await wmill.fileUpload({
+      workspace: workspaceId,
+      fileKey: key,
+      requestBody: new Blob([buf]) as any,
+    });
+    log.info(colors.gray(`  ↑ ${binding.source} → s3://${key}`));
+  }
+  return s3Arg(param, key);
+}
+
 async function run(
   opts: GlobalOptions & SyncOptions & {
     from?: string;
@@ -335,6 +394,7 @@ async function run(
     dryRun?: boolean;
     json?: boolean;
     local?: boolean;
+    upload?: string[];
     defaultTs?: "bun" | "deno";
   },
   folder: string,
@@ -386,9 +446,32 @@ async function run(
     );
   }
 
+  // `--upload <script>[:<param>]=<file|s3://key>` binds an object to a
+  // data_upload/webhook entry point so it becomes a runnable start (and its
+  // downstream is no longer cut) — the arg is injected at execution.
+  const boundBindingByPath = new Map<string, UploadBinding>();
+  const boundNodeIds = new Set<string>();
+  for (const spec of opts.upload ?? []) {
+    const binding = parseUploadBinding(spec);
+    const id = resolveToken(graph, binding.scriptTok);
+    if (!id || !id.startsWith("script:")) {
+      const matches = graph.runnables.filter(
+        (r) => r.usage_kind === "script" && (r.path.split("/").pop() ?? r.path) === binding.scriptTok,
+      );
+      if (matches.length > 1) {
+        throw new Error(
+          `--upload '${binding.scriptTok}' matches multiple scripts (${matches.map((r) => r.path).sort().join(", ")}) — use the full path.`,
+        );
+      }
+      throw new Error(`--upload '${binding.scriptTok}' matched no script in f/${f}.`);
+    }
+    boundBindingByPath.set(scriptPathOf(id), binding);
+    boundNodeIds.add(id);
+  }
+
   // Resolve the start: explicit --from (must be a valid start) or the folder's
-  // sole valid start.
-  const starts = validStarts(graph);
+  // sole valid start. `--upload`-bound scripts join the valid starts.
+  const starts = new Set([...validStarts(graph), ...boundNodeIds]);
   // `runAll` = no `--from` on a multi-root pipeline (fan-in): run the whole
   // pipeline in topological order rather than forcing a single start, the way
   // `dbt run` (no `--select`) runs the entire project. `--to` still needs an
@@ -473,7 +556,11 @@ async function run(
     // handler after a descendant union — also drops its downstream, so `pipeline
     // run <folder>` never runs a consumer whose skipped producer would leave it
     // with missing/stale inputs. A node also reachable via another path still runs.
-    selectedScripts = new Set(scriptsOf(reachableCutting(dag, starts, nonAutorunTriggerScripts(graph))));
+    // `--upload`-bound handlers are un-gated: they get their input at execution.
+    const barriers = new Set(
+      [...nonAutorunTriggerScripts(graph)].filter((id) => !boundNodeIds.has(id)),
+    );
+    selectedScripts = new Set(scriptsOf(reachableCutting(dag, starts, barriers)));
   } else if (ends.length === 0) {
     // No bound → full read-aware downstream of start (pure readers included).
     const all = new Set(descendants(dag, start!));
@@ -494,6 +581,14 @@ async function run(
     log.warn(`Skipping ${cyclic.length} script(s) on a dependency cycle: ${cyclic.sort().join(", ")}`);
   }
 
+  // A `--upload` whose script fell outside the selection is a no-op the user
+  // should know about, rather than silently ignored.
+  const orderSet = new Set(order);
+  const boundInOrder = [...boundBindingByPath.keys()].filter((p) => orderSet.has(p)).sort();
+  for (const p of boundBindingByPath.keys()) {
+    if (!orderSet.has(p)) log.warn(`--upload for ${p} is unused — it isn't in the run selection.`);
+  }
+
   if (opts.json) {
     // Surface reachable/dropped ends so a machine-readable plan reflects the
     // same trimming the human-facing warning does — a resolved-but-unreachable
@@ -506,6 +601,7 @@ async function run(
         droppedEnds: droppedEnds.map(idLabel),
         order,
         cyclic,
+        uploads: boundInOrder,
       }),
     );
   }
@@ -521,14 +617,35 @@ async function run(
         colors.bold(`Bounded run plan — ${order.length} script${order.length === 1 ? "" : "s"}`) +
           colors.dim(runAll ? ` (whole pipeline)` : ` (from ${shortName(scriptPathOf(start!))})`),
       );
-      order.forEach((p, i) => log.info(`  ${i + 1}. ${p}`));
+      order.forEach((p, i) =>
+        log.info(`  ${i + 1}. ${p}${boundBindingByPath.has(p) ? colors.dim(" (← --upload)") : ""}`),
+      );
     }
     return;
+  }
+
+  // Resolve `--upload` bindings to their injected args up front (uploading any
+  // local sources) so a bad path / missing S3Object param fails before we start
+  // launching jobs.
+  const uploadArgs = new Map<string, Record<string, any>>();
+  for (const nodePath of boundInOrder) {
+    uploadArgs.set(
+      nodePath,
+      await resolveUploadArg(
+        boundBindingByPath.get(nodePath)!,
+        nodePath,
+        workspace.workspaceId,
+        opts.local,
+        localScripts,
+        f,
+      ),
+    );
   }
 
   // Execute in topological order, stopping on the first failure.
   for (const nodePath of order) {
     if (!opts.json) log.info(colors.gray(`▶ running ${nodePath}…`));
+    const nodeArgs = { _wmill_skip_asset_dispatch: true, ...(uploadArgs.get(nodePath) ?? {}) };
     let id: string;
     if (opts.local) {
       const ls = localScripts!.get(nodePath);
@@ -543,7 +660,7 @@ async function run(
           content: ls.content,
           language: ls.language as any,
           path: nodePath,
-          args: { _wmill_skip_asset_dispatch: true },
+          args: nodeArgs,
           temp_script_refs: tempScriptRefs,
           // `// tag` routes to the same worker the deployed pipeline would.
           ...(ls.tag ? { tag: ls.tag } : {}),
@@ -553,7 +670,7 @@ async function run(
       id = await wmill.runScriptByPath({
         workspace: workspace.workspaceId,
         path: nodePath,
-        requestBody: { _wmill_skip_asset_dispatch: true },
+        requestBody: nodeArgs,
       });
     }
     const ok = await waitJob(workspace.workspaceId, id);
@@ -604,6 +721,11 @@ const command = new Command()
   .option(
     "--local",
     "Run the local working-tree scripts via preview (no deploy) instead of the deployed versions; the graph is built from local files.",
+  )
+  .option(
+    "--upload <binding:string>",
+    "Bind an object to a data_upload/webhook entry point so it runs in the cascade: <script>[:<param>]=<local-file|s3://key>. Local files are uploaded to the workspace store; the S3Object param is inferred when the script has exactly one. Repeatable.",
+    { collect: true },
   )
   .action(run as any)
   .command(

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -384,7 +384,12 @@ async function run(
   // Resolve the start: explicit --from (must be a valid start) or the folder's
   // sole valid start.
   const starts = validStarts(graph);
-  let start: string;
+  // `runAll` = no `--from` on a multi-root pipeline (fan-in): run the whole
+  // pipeline in topological order rather than forcing a single start, the way
+  // `dbt run` (no `--select`) runs the entire project. `--to` still needs an
+  // explicit `--from` since bounding is relative to one start.
+  let runAll = false;
+  let start: string | undefined;
   if (opts.from) {
     const resolved = resolveToken(graph, opts.from);
     if (!resolved) {
@@ -412,9 +417,12 @@ async function run(
     throw new Error(
       `No schedule or manual root in f/${f} to start a bounded run from.`,
     );
+  } else if ((opts.to ?? []).length === 0) {
+    // Multiple roots, no `--from`, no `--to` → run the whole pipeline.
+    runAll = true;
   } else {
     throw new Error(
-      `f/${f} has ${starts.size} possible starts — pass --from <script>. Candidates: ${scriptsOf(starts).sort().join(", ")}`,
+      `f/${f} has ${starts.size} possible starts — pass --from <script> when using --to. Candidates: ${scriptsOf(starts).sort().join(", ")}`,
     );
   }
 
@@ -452,13 +460,18 @@ async function run(
   let selectedScripts: Set<string>;
   let reachableEnds: string[] = [];
   let droppedEnds: string[] = [];
-  if (ends.length === 0) {
+  if (runAll) {
+    // Whole pipeline: every `// pipeline` script, globally topo-ordered below.
+    selectedScripts = new Set(
+      graph.runnables.filter((r) => r.usage_kind === "script").map((r) => r.path),
+    );
+  } else if (ends.length === 0) {
     // No bound → full read-aware downstream of start (pure readers included).
-    const all = new Set(descendants(dag, start));
-    all.add(start);
+    const all = new Set(descendants(dag, start!));
+    all.add(start!);
     selectedScripts = new Set(scriptsOf(all));
   } else {
-    const res = boundedSet(dag, start, ends);
+    const res = boundedSet(dag, start!, ends);
     reachableEnds = res.reachableEnds;
     droppedEnds = res.droppedEnds;
     for (const d of droppedEnds) {
@@ -478,7 +491,7 @@ async function run(
     // `--to` must not look like a clean plan that silently runs only the start.
     console.log(
       JSON.stringify({
-        start: scriptPathOf(start),
+        start: runAll ? null : scriptPathOf(start!),
         ends: ends.map(idLabel),
         reachableEnds: reachableEnds.map(idLabel),
         droppedEnds: droppedEnds.map(idLabel),
@@ -497,7 +510,7 @@ async function run(
     if (!opts.json) {
       log.info(
         colors.bold(`Bounded run plan — ${order.length} script${order.length === 1 ? "" : "s"}`) +
-          colors.dim(` (from ${shortName(scriptPathOf(start))})`),
+          colors.dim(runAll ? ` (whole pipeline)` : ` (from ${shortName(scriptPathOf(start!))})`),
       );
       order.forEach((p, i) => log.info(`  ${i + 1}. ${p}`));
     }

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -742,7 +742,9 @@ async function run(
   // Execute in topological order, stopping on the first failure.
   for (const nodePath of order) {
     if (!opts.json) log.info(colors.gray(`▶ running ${nodePath}…`));
-    const nodeArgs = { _wmill_skip_asset_dispatch: true, ...(uploadArgs.get(nodePath) ?? {}) };
+    // Spread the internal dispatch guard LAST so an `--upload`-bound arg can't
+    // re-enable backend dispatch (the CLI owns the whole closure here).
+    const nodeArgs = { ...(uploadArgs.get(nodePath) ?? {}), _wmill_skip_asset_dispatch: true };
     let id: string;
     if (opts.local) {
       const ls = localScripts!.get(nodePath);

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -20,7 +20,25 @@ import {
   topoOrder,
   validStarts,
 } from "./boundedCascade.ts";
+import {
+  type AssetGraph,
+  type GraphTrigger,
+  type LocalScript,
+  buildLocalPipelineGraph,
+  workspaceRoot,
+} from "./localGraph.ts";
+import {
+  mergeConfigWithConfigFile,
+  type SyncOptions,
+} from "../../core/conf.ts";
+import { listSyncCodebases } from "../../utils/codebase.ts";
+import pipelineDev from "./dev.ts";
+import { generatePipelineDocs } from "./docs.ts";
 
+// The graph payload types (AssetGraph / GraphRunnable / GraphEdge /
+// GraphTrigger) are defined in ./localGraph.ts — the canonical pipeline graph
+// module — and shared by the local (wasm-built) and deployed (apiGet) paths.
+//
 // Mirrors the asset-graph endpoint payload (backend/windmill-api-assets).
 // TODO: the checked-in generated client (cli/gen, last regenerated 2025-04)
 // predates these routes, so we raw-fetch and hand-roll the types. Once
@@ -29,39 +47,6 @@ import {
 // `apiGet` + these types with the generated `wmill.getAssetsGraph(...)`
 // (operationId getAssetsGraph) and `wmill.listPipelineFolders(...)`
 // (operationId listPipelineFolders).
-type GraphRunnable = {
-  path: string;
-  usage_kind: "script" | "flow" | "job";
-  in_pipeline?: boolean;
-};
-type GraphEdge = {
-  runnable_kind: string;
-  runnable_path: string;
-  asset_kind: string;
-  asset_path: string;
-  access_type?: "r" | "w" | "rw";
-};
-type GraphTrigger =
-  | {
-      trigger_kind: "asset";
-      asset_kind: string;
-      asset_path: string;
-      runnable_kind: string;
-      runnable_path: string;
-    }
-  | {
-      trigger_kind: string;
-      path?: string;
-      runnable_kind: string;
-      runnable_path: string;
-      missing?: boolean;
-    };
-type AssetGraph = {
-  runnables: GraphRunnable[];
-  assets: { kind: string; path: string }[];
-  edges: GraphEdge[];
-  triggers: GraphTrigger[];
-};
 
 async function apiGet<T>(path: string): Promise<T> {
   const response = await fetch(`${OpenAPI.BASE}${path}`, {
@@ -116,28 +101,94 @@ function pushTo<K, V>(map: Map<K, V[]>, key: K, val: V): void {
 }
 
 async function show(
-  opts: GlobalOptions & { json?: boolean },
+  opts: GlobalOptions & { json?: boolean; local?: boolean; defaultTs?: "bun" | "deno" },
   folder: string,
 ) {
   if (opts.json) log.setSilent(true);
-  const workspace = await resolveWorkspace(opts);
-  await requireLogin(opts);
-
   const f = folder.replace(/^f\//, "").replace(/\/$/, "");
-  const graph = await apiGet<AssetGraph>(
-    `/w/${workspace.workspaceId}/assets/graph?folder=${encodeURIComponent(f)}&asset_kinds=${ASSET_KINDS}`,
-  );
+
+  // Acquire the graph: `--local` builds it from working-tree files (wasm
+  // inference, no deploy); otherwise fetch the deployed asset graph. The
+  // deployed path also enriches roots with UI-only source markers (the local
+  // path gets those from the wasm directly, so no enrichment).
+  let graph: AssetGraph;
+  let enrich: ((nativeByScript: Map<string, NativeMarker[]>, roots: string[]) => Promise<void>) | undefined;
+  if (opts.local) {
+    graph = (await buildLocalPipelineGraph({ root: workspaceRoot(), folder: f, defaultTs: opts.defaultTs })).graph;
+  } else {
+    const workspace = await resolveWorkspace(opts);
+    await requireLogin(opts);
+    graph = await apiGet<AssetGraph>(
+      `/w/${workspace.workspaceId}/assets/graph?folder=${encodeURIComponent(f)}&asset_kinds=${ASSET_KINDS}`,
+    );
+    enrich = (nativeByScript, roots) => enrichRootMarkers(workspace.workspaceId, graph, nativeByScript, roots);
+  }
+
   if (opts.json) {
     console.log(JSON.stringify(graph));
     return;
   }
   if (graph.runnables.length === 0) {
     log.info(
-      `No pipeline scripts in f/${f}. Mark scripts with a \`// pipeline\` comment and push them.`,
+      opts.local
+        ? `No \`// pipeline\` scripts found in f/${f} locally. Mark scripts with a \`// pipeline\` comment.`
+        : `No pipeline scripts in f/${f}. Mark scripts with a \`// pipeline\` comment and push them.`,
     );
     return;
   }
 
+  await renderGraph(graph, f, enrich);
+}
+
+type NativeMarker = { kind: string; path?: string; missing?: boolean };
+
+// Deployed-only: UI-first markers (data_upload, webhook, email) have no trigger
+// row — the graph endpoint's trigger enum can't surface them, so they only exist
+// as `// on <kind>` annotations in the script body. Fetch just the root bodies
+// and lift the marker kinds the canvas would show. (Local mode skips this: the
+// wasm asset parser already returns these as triggers.)
+//
+// DRIFT RISK: this regex + MARKER_KINDS is a divergent, partial copy of the
+// canonical annotation parser. The proper fix is to have the graph endpoint emit
+// these UI-only markers as trigger rows (a backend change), after which this can
+// be deleted. Until then, keep this list in sync with the canonical parser.
+async function enrichRootMarkers(
+  workspaceId: string,
+  graph: AssetGraph,
+  nativeByScript: Map<string, NativeMarker[]>,
+  roots: string[],
+): Promise<void> {
+  const MARKER_KINDS = ["data_upload", "webhook", "email"];
+  await Promise.all(
+    roots.map(async (p) => {
+      const r = graph.runnables.find((x) => x.path === p);
+      if (r?.usage_kind !== "script") return;
+      try {
+        const script = await wmill.getScriptByPath({ workspace: workspaceId, path: p });
+        const existing = nativeByScript.get(p) ?? [];
+        for (const line of (script.content ?? "").split("\n")) {
+          const m = line.match(/^\s*(?:\/\/|--|#)\s*on\s+(\w+)\s*$/);
+          if (!m) continue;
+          const kind = m[1];
+          if (!MARKER_KINDS.includes(kind)) continue;
+          if (!existing.some((t) => t.kind === kind)) existing.push({ kind });
+        }
+        if (existing.length > 0) nativeByScript.set(p, existing);
+      } catch {
+        // body fetch is best-effort enrichment only
+      }
+    }),
+  );
+}
+
+// Index a pipeline graph and render its DAG as an ASCII tree. Shared by the
+// deployed (`show`) and local (`show --local`) paths; `enrich` lifts deployed
+// UI-only root markers when provided.
+async function renderGraph(
+  graph: AssetGraph,
+  f: string,
+  enrich?: (nativeByScript: Map<string, NativeMarker[]>, roots: string[]) => Promise<void>,
+) {
   // Index the graph: writes per script, subscribers per asset, native
   // trigger markers per script, asset subscriptions per script.
   const writesByScript = new Map<string, string[]>();
@@ -149,10 +200,7 @@ async function show(
   }
   const subsByAsset = new Map<string, string[]>();
   const subsByScript = new Map<string, string[]>();
-  const nativeByScript = new Map<
-    string,
-    { kind: string; path?: string; missing?: boolean }[]
-  >();
+  const nativeByScript = new Map<string, NativeMarker[]>();
   for (const t of graph.triggers) {
     if (t.trigger_kind === "asset") {
       const at = t as Extract<GraphTrigger, { trigger_kind: "asset" }>;
@@ -222,43 +270,9 @@ async function show(
     .filter((p) => !(subsByScript.get(p)?.length))
     .sort();
 
-  // UI-first markers (data_upload, webhook) have no trigger row — the
-  // graph endpoint's trigger enum (schedule/email/kafka/mqtt/nats/postgres/
-  // sqs/gcp) can't surface them, so they only exist as `// on <kind>`
-  // annotations in the script body. Roots are where sources matter, so fetch
-  // just those bodies and lift the marker kinds the canvas would show.
-  //
-  // DRIFT RISK: this regex + MARKER_KINDS is a divergent, partial copy of the
-  // canonical annotation parser. The proper fix is to have the graph endpoint
-  // emit these UI-only markers as trigger rows (a backend change), after which
-  // this whole Promise.all body-fetch can be deleted and read straight from
-  // the response. Until then, keep this list in sync with the canonical parser.
-  const MARKER_KINDS = ["data_upload", "webhook", "email"];
-  await Promise.all(
-    roots.map(async (p) => {
-      const r = graph.runnables.find((x) => x.path === p);
-      if (r?.usage_kind !== "script") return;
-      try {
-        const script = await wmill.getScriptByPath({
-          workspace: workspace.workspaceId,
-          path: p,
-        });
-        const existing = nativeByScript.get(p) ?? [];
-        for (const line of (script.content ?? "").split("\n")) {
-          const m = line.match(/^\s*(?:\/\/|--|#)\s*on\s+(\w+)\s*$/);
-          if (!m) continue;
-          const kind = m[1];
-          if (!MARKER_KINDS.includes(kind)) continue;
-          if (!existing.some((t) => t.kind === kind)) {
-            existing.push({ kind });
-          }
-        }
-        if (existing.length > 0) nativeByScript.set(p, existing);
-      } catch {
-        // body fetch is best-effort enrichment only
-      }
-    }),
-  );
+  // Deployed-only: lift UI-only source markers (data_upload/webhook/email) onto
+  // the roots. No-op in local mode (the wasm already emitted them as triggers).
+  if (enrich) await enrich(nativeByScript, roots);
 
   const scriptCount = graph.runnables.length;
   const assetCount = graph.assets.length;
@@ -312,11 +326,13 @@ async function waitJob(workspace: string, id: string): Promise<boolean> {
 // the lineage DAG, pure readers included — broader than the canvas cascade,
 // which dispatches subscribers only).
 async function run(
-  opts: GlobalOptions & {
+  opts: GlobalOptions & SyncOptions & {
     from?: string;
     to?: string[];
     dryRun?: boolean;
     json?: boolean;
+    local?: boolean;
+    defaultTs?: "bun" | "deno";
   },
   folder: string,
 ) {
@@ -325,9 +341,45 @@ async function run(
   await requireLogin(opts);
 
   const f = folder.replace(/^f\//, "").replace(/\/$/, "");
-  const graph = await apiGet<BCGraph>(
-    `/w/${workspace.workspaceId}/assets/graph?folder=${encodeURIComponent(f)}&asset_kinds=${ASSET_KINDS}`,
-  );
+
+  // `--local` runs the working-tree scripts via preview (no deploy); the graph
+  // is built from local files. Otherwise run deployed scripts by path off the
+  // deployed asset graph. Both still execute against the remote backend, with
+  // `_wmill_skip_asset_dispatch` so the CLI owns the whole closure.
+  let graph: BCGraph;
+  let localScripts: Map<string, LocalScript> | undefined;
+  let tempScriptRefs: Record<string, string> | undefined;
+  if (opts.local) {
+    const built = await buildLocalPipelineGraph({
+      root: workspaceRoot(),
+      folder: f,
+      defaultTs: opts.defaultTs,
+    });
+    graph = built.graph;
+    localScripts = new Map(built.scripts.map((s) => [s.path, s]));
+    // Resolve relative imports from local (not-yet-deployed) content so a script
+    // that imports a sibling workspace lib previews against local edits. Same
+    // trick as `wmill dev` / `wmill app dev`; degrades to undefined gracefully.
+    try {
+      const merged = await mergeConfigWithConfigFile(opts);
+      const codebases = await listSyncCodebases(merged);
+      const { buildPreviewTempScriptRefs } = await import(
+        "../generate-metadata/generate-metadata.ts"
+      );
+      tempScriptRefs = await buildPreviewTempScriptRefs(
+        workspace,
+        merged,
+        codebases,
+        { kind: "all" },
+      );
+    } catch {
+      // best-effort: relative imports fall back to deployed versions
+    }
+  } else {
+    graph = await apiGet<BCGraph>(
+      `/w/${workspace.workspaceId}/assets/graph?folder=${encodeURIComponent(f)}&asset_kinds=${ASSET_KINDS}`,
+    );
+  }
 
   // Resolve the start: explicit --from (must be a valid start) or the folder's
   // sole valid start.
@@ -453,18 +505,38 @@ async function run(
   }
 
   // Execute in topological order, stopping on the first failure.
-  for (const path of order) {
-    if (!opts.json) log.info(colors.gray(`▶ running ${path}…`));
-    const id = await wmill.runScriptByPath({
-      workspace: workspace.workspaceId,
-      path,
-      requestBody: { _wmill_skip_asset_dispatch: true },
-    });
+  for (const nodePath of order) {
+    if (!opts.json) log.info(colors.gray(`▶ running ${nodePath}…`));
+    let id: string;
+    if (opts.local) {
+      const ls = localScripts!.get(nodePath);
+      if (!ls) {
+        throw new Error(
+          `No local file for ${nodePath} — is it a \`// pipeline\` script in f/${f}?`,
+        );
+      }
+      id = await wmill.runScriptPreview({
+        workspace: workspace.workspaceId,
+        requestBody: {
+          content: ls.content,
+          language: ls.language as any,
+          path: nodePath,
+          args: { _wmill_skip_asset_dispatch: true },
+          temp_script_refs: tempScriptRefs,
+        } as any,
+      });
+    } else {
+      id = await wmill.runScriptByPath({
+        workspace: workspace.workspaceId,
+        path: nodePath,
+        requestBody: { _wmill_skip_asset_dispatch: true },
+      });
+    }
     const ok = await waitJob(workspace.workspaceId, id);
     if (!ok) {
-      throw new Error(`Bounded run failed at ${path} (job ${id}).`);
+      throw new Error(`Bounded run failed at ${nodePath} (job ${id}).`);
     }
-    if (!opts.json) log.info(colors.green(`  ✓ ${path}`));
+    if (!opts.json) log.info(colors.green(`  ✓ ${nodePath}`));
   }
   if (!opts.json) {
     log.info(colors.green.bold(`Bounded run complete — ${order.length} script(s) succeeded.`));
@@ -484,6 +556,10 @@ const command = new Command()
   )
   .arguments("<folder:string>")
   .option("--json", "Output the raw asset graph as JSON")
+  .option(
+    "--local",
+    "Build the graph from local working-tree files (// pipeline scripts) instead of the deployed workspace — no deploy needed.",
+  )
   .action(show as any)
   .command(
     "run",
@@ -501,6 +577,21 @@ const command = new Command()
   )
   .option("--dry-run", "Print the topological run plan without executing.")
   .option("--json", "Output the plan as JSON (for piping to jq).")
-  .action(run as any);
+  .option(
+    "--local",
+    "Run the local working-tree scripts via preview (no deploy) instead of the deployed versions; the graph is built from local files.",
+  )
+  .action(run as any)
+  .command(
+    "docs",
+    "generate PIPELINE.md (+ AGENTS.md pointer) describing a folder's pipeline graph and datatable schemas, for an editor / agentic loop",
+  )
+  .arguments("<folder:string>")
+  .option(
+    "--local",
+    "Build the graph from local working-tree files instead of the deployed workspace.",
+  )
+  .action(generatePipelineDocs as any)
+  .command("dev", pipelineDev);
 
 export default command;

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -547,6 +547,8 @@ async function run(
           path: nodePath,
           args: { _wmill_skip_asset_dispatch: true },
           temp_script_refs: tempScriptRefs,
+          // `// tag` routes to the same worker the deployed pipeline would.
+          ...(ls.tag ? { tag: ls.tag } : {}),
         } as any,
       });
     } else {

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -14,6 +14,7 @@ import {
   buildLineageDag,
   descendants,
   eventTriggerScripts,
+  reachableCutting,
   resolveToken,
   scriptNodeId,
   scriptPathOf,
@@ -465,20 +466,14 @@ async function run(
   let reachableEnds: string[] = [];
   let droppedEnds: string[] = [];
   if (runAll) {
-    // Whole pipeline = every valid start (schedule/manual root) plus all its
-    // descendants, unioned — then subtract event-trigger scripts. Event handlers
-    // (kafka/mqtt/nats/postgres/sqs/gcp/email) fan out per-event and can't run
-    // with empty args; `validStarts` already keeps them out of `starts`, but one
-    // can still be a lineage DESCENDANT of a valid start (it also reads an
-    // upstream asset), so it must be removed after the descendant union too — or
-    // an unqualified `pipeline run <folder>` would fire it with empty args.
-    const all = new Set<string>();
-    for (const s of starts) {
-      all.add(s);
-      for (const d of descendants(dag, s)) all.add(d);
-    }
-    for (const ev of eventTriggerScripts(graph)) all.delete(ev);
-    selectedScripts = new Set(scriptsOf(all));
+    // Whole pipeline = everything reachable from the valid starts (schedule/manual
+    // roots), but CUT at event-trigger scripts (kafka/mqtt/nats/postgres/sqs/gcp/
+    // email). They fan out per-event and can't run with empty args, and cutting —
+    // rather than just deleting the handler after a descendant union — also drops
+    // its event-only downstream, so `pipeline run <folder>` never runs a consumer
+    // whose skipped producer would leave it with missing/stale inputs. A node also
+    // reachable via a non-event path still runs.
+    selectedScripts = new Set(scriptsOf(reachableCutting(dag, starts, eventTriggerScripts(graph))));
   } else if (ends.length === 0) {
     // No bound → full read-aware downstream of start (pure readers included).
     const all = new Set(descendants(dag, start!));

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -13,7 +13,7 @@ import {
   boundedSet,
   buildLineageDag,
   descendants,
-  eventTriggerScripts,
+  nonAutorunTriggerScripts,
   reachableCutting,
   resolveToken,
   scriptNodeId,
@@ -467,13 +467,13 @@ async function run(
   let droppedEnds: string[] = [];
   if (runAll) {
     // Whole pipeline = everything reachable from the valid starts (schedule/manual
-    // roots), but CUT at event-trigger scripts (kafka/mqtt/nats/postgres/sqs/gcp/
-    // email). They fan out per-event and can't run with empty args, and cutting —
-    // rather than just deleting the handler after a descendant union — also drops
-    // its event-only downstream, so `pipeline run <folder>` never runs a consumer
-    // whose skipped producer would leave it with missing/stale inputs. A node also
-    // reachable via a non-event path still runs.
-    selectedScripts = new Set(scriptsOf(reachableCutting(dag, starts, eventTriggerScripts(graph))));
+    // roots), but CUT at scripts whose trigger needs caller-supplied input or
+    // per-event fanout (kafka/mqtt/nats/postgres/sqs/gcp/email/webhook/data_upload).
+    // They can't run with empty args, and cutting — rather than just deleting the
+    // handler after a descendant union — also drops its downstream, so `pipeline
+    // run <folder>` never runs a consumer whose skipped producer would leave it
+    // with missing/stale inputs. A node also reachable via another path still runs.
+    selectedScripts = new Set(scriptsOf(reachableCutting(dag, starts, nonAutorunTriggerScripts(graph))));
   } else if (ends.length === 0) {
     // No bound → full read-aware downstream of start (pure readers included).
     const all = new Set(descendants(dag, start!));

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -13,6 +13,7 @@ import {
   boundedSet,
   buildLineageDag,
   descendants,
+  eventTriggerScripts,
   resolveToken,
   scriptNodeId,
   scriptPathOf,
@@ -465,16 +466,18 @@ async function run(
   let droppedEnds: string[] = [];
   if (runAll) {
     // Whole pipeline = every valid start (schedule/manual root) plus all its
-    // descendants, unioned. Deriving from `starts` (not all runnables) keeps
-    // event-trigger roots — kafka/mqtt/nats/postgres/sqs/gcp/email, which
-    // `validStarts` excludes because they fan out per-event — out of an
-    // unqualified `pipeline run <folder>`, so it never fires an event handler
-    // with empty args + side effects.
+    // descendants, unioned — then subtract event-trigger scripts. Event handlers
+    // (kafka/mqtt/nats/postgres/sqs/gcp/email) fan out per-event and can't run
+    // with empty args; `validStarts` already keeps them out of `starts`, but one
+    // can still be a lineage DESCENDANT of a valid start (it also reads an
+    // upstream asset), so it must be removed after the descendant union too — or
+    // an unqualified `pipeline run <folder>` would fire it with empty args.
     const all = new Set<string>();
     for (const s of starts) {
       all.add(s);
       for (const d of descendants(dag, s)) all.add(d);
     }
+    for (const ev of eventTriggerScripts(graph)) all.delete(ev);
     selectedScripts = new Set(scriptsOf(all));
   } else if (ends.length === 0) {
     // No bound → full read-aware downstream of start (pure readers included).

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -40,10 +40,10 @@ import { generatePipelineDocs } from "./docs.ts";
 import {
   type UploadBinding,
   devUploadKey,
+  parseS3Uri,
   parseUploadBinding,
   s3Arg,
   s3ObjectParams,
-  s3UriKey,
 } from "./pipelineUpload.ts";
 
 // The graph payload types (AssetGraph / GraphRunnable / GraphEdge /
@@ -439,23 +439,24 @@ async function resolveUploadArgs(
     if (param in args) {
       throw new Error(`--upload binds ${scriptPath}:${param} more than once.`);
     }
-    let key: string;
+    let obj: { s3: string; storage?: string };
     if (binding.source.startsWith("s3://")) {
-      // Default-storage object key (whole path); see s3UriKey.
-      key = s3UriKey(binding.source);
+      // Canonical `s3://<storage>/<key>`; keeps named storage (see parseS3Uri).
+      obj = parseS3Uri(binding.source);
     } else {
       const buf = await readFile(binding.source);
       // Key scoped by script + param so distinct sources sharing a basename
       // (across scripts or params) don't clobber each other in the store.
-      key = devUploadKey(scriptPath, param, binding.source);
+      const key = devUploadKey(scriptPath, param, binding.source);
       await wmill.fileUpload({
         workspace: workspaceId,
         fileKey: key,
         requestBody: new Blob([buf]) as any,
       });
       log.info(colors.gray(`  ↑ ${binding.source} → s3://${key}`));
+      obj = { s3: key };
     }
-    Object.assign(args, s3Arg(param, key));
+    Object.assign(args, s3Arg(param, obj));
   }
   return args;
 }

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -464,10 +464,18 @@ async function run(
   let reachableEnds: string[] = [];
   let droppedEnds: string[] = [];
   if (runAll) {
-    // Whole pipeline: every `// pipeline` script, globally topo-ordered below.
-    selectedScripts = new Set(
-      graph.runnables.filter((r) => r.usage_kind === "script").map((r) => r.path),
-    );
+    // Whole pipeline = every valid start (schedule/manual root) plus all its
+    // descendants, unioned. Deriving from `starts` (not all runnables) keeps
+    // event-trigger roots — kafka/mqtt/nats/postgres/sqs/gcp/email, which
+    // `validStarts` excludes because they fan out per-event — out of an
+    // unqualified `pipeline run <folder>`, so it never fires an event handler
+    // with empty args + side effects.
+    const all = new Set<string>();
+    for (const s of starts) {
+      all.add(s);
+      for (const d of descendants(dag, s)) all.add(d);
+    }
+    selectedScripts = new Set(scriptsOf(all));
   } else if (ends.length === 0) {
     // No bound → full read-aware downstream of start (pure readers included).
     const all = new Set(descendants(dag, start!));

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -40,10 +40,10 @@ import { generatePipelineDocs } from "./docs.ts";
 import {
   type UploadBinding,
   devUploadKey,
-  parseS3Uri,
   parseUploadBinding,
   s3Arg,
   s3ObjectParams,
+  s3UriKey,
 } from "./pipelineUpload.ts";
 
 // The graph payload types (AssetGraph / GraphRunnable / GraphEdge /
@@ -164,13 +164,31 @@ type NativeMarker = { kind: string; path?: string; missing?: boolean };
 // canonical annotation parser. The proper fix is to have the graph endpoint emit
 // these UI-only markers as trigger rows (a backend change), after which this can
 // be deleted. Until then, keep this list in sync with the canonical parser.
+const MARKER_KINDS = new Set(["data_upload", "webhook", "email"]);
+
+// Recover marker-only native triggers (`// on data_upload`/`webhook`/`email`) from
+// a deployed script body — they have no trigger row for the graph endpoint to
+// emit. Scans the LEADING comment header only (stops at the first non-comment
+// line, blank lines allowed) like the canonical/fallback annotation parsers, so a
+// body comment can't inject a phantom trigger.
+export function recoverHeaderMarkers(content: string): string[] {
+  const found: string[] = [];
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "") continue;
+    if (!trimmed.startsWith("//") && !trimmed.startsWith("--") && !trimmed.startsWith("#")) break;
+    const m = line.match(/^\s*(?:\/\/|--|#)\s*on\s+(\w+)\s*$/);
+    if (m && MARKER_KINDS.has(m[1]) && !found.includes(m[1])) found.push(m[1]);
+  }
+  return found;
+}
+
 async function enrichRootMarkers(
   workspaceId: string,
   graph: AssetGraph,
   nativeByScript: Map<string, NativeMarker[]>,
   roots: string[],
 ): Promise<void> {
-  const MARKER_KINDS = ["data_upload", "webhook", "email"];
   await Promise.all(
     roots.map(async (p) => {
       const r = graph.runnables.find((x) => x.path === p);
@@ -178,11 +196,7 @@ async function enrichRootMarkers(
       try {
         const script = await wmill.getScriptByPath({ workspace: workspaceId, path: p });
         const existing = nativeByScript.get(p) ?? [];
-        for (const line of (script.content ?? "").split("\n")) {
-          const m = line.match(/^\s*(?:\/\/|--|#)\s*on\s+(\w+)\s*$/);
-          if (!m) continue;
-          const kind = m[1];
-          if (!MARKER_KINDS.includes(kind)) continue;
+        for (const kind of recoverHeaderMarkers(script.content ?? "")) {
           if (!existing.some((t) => t.kind === kind)) existing.push({ kind });
         }
         if (existing.length > 0) nativeByScript.set(p, existing);
@@ -203,7 +217,6 @@ async function enrichDeployedNonAutorunTriggers(
   workspaceId: string,
   graph: BCGraph,
 ): Promise<void> {
-  const MARKER_KINDS = new Set(["data_upload", "webhook", "email"]);
   const scripts = (graph.runnables ?? []).filter((r) => r.usage_kind === "script");
   await Promise.all(
     scripts.map(async (r) => {
@@ -212,20 +225,27 @@ async function enrichDeployedNonAutorunTriggers(
           .filter((t) => t.runnable_path === r.path && MARKER_KINDS.has(t.trigger_kind))
           .map((t) => t.trigger_kind),
       );
+      let script;
       try {
-        const script = await wmill.getScriptByPath({ workspace: workspaceId, path: r.path });
-        for (const line of (script.content ?? "").split("\n")) {
-          const m = line.match(/^\s*(?:\/\/|--|#)\s*on\s+(\w+)\s*$/);
-          if (!m || !MARKER_KINDS.has(m[1]) || known.has(m[1])) continue;
-          known.add(m[1]);
-          graph.triggers.push({
-            trigger_kind: m[1],
-            runnable_kind: "script",
-            runnable_path: r.path,
-          });
-        }
-      } catch {
-        // best-effort: a fetch failure just leaves the row absent (prior behaviour)
+        script = await wmill.getScriptByPath({ workspace: workspaceId, path: r.path });
+      } catch (e: any) {
+        // Fail CLOSED: if we can't read a script's body we can't rule out a
+        // marker-only input trigger, so aborting is safer than auto-running it
+        // with empty args. (The `show` enrichment stays best-effort — it only
+        // affects the rendered tree, not what runs.)
+        throw new Error(
+          `Could not verify triggers for ${r.path} (${e?.body ?? e?.message ?? e}) — ` +
+            `aborting so an input-only entrypoint isn't run with empty args; retry once resolved.`,
+        );
+      }
+      for (const kind of recoverHeaderMarkers(script.content ?? "")) {
+        if (known.has(kind)) continue;
+        known.add(kind);
+        graph.triggers.push({
+          trigger_kind: kind,
+          runnable_kind: "script",
+          runnable_path: r.path,
+        });
       }
     }),
   );
@@ -419,25 +439,23 @@ async function resolveUploadArgs(
     if (param in args) {
       throw new Error(`--upload binds ${scriptPath}:${param} more than once.`);
     }
-    let obj: { s3: string; storage?: string };
+    let key: string;
     if (binding.source.startsWith("s3://")) {
-      // `s3://<storage>/<key>` — keep the named storage (authority) so the worker
-      // downloads from the right store, not `{ s3: "<storage>/<key>" }`.
-      obj = parseS3Uri(binding.source);
+      // Default-storage object key (whole path); see s3UriKey.
+      key = s3UriKey(binding.source);
     } else {
       const buf = await readFile(binding.source);
       // Key scoped by script + param so distinct sources sharing a basename
       // (across scripts or params) don't clobber each other in the store.
-      const key = devUploadKey(scriptPath, param, binding.source);
+      key = devUploadKey(scriptPath, param, binding.source);
       await wmill.fileUpload({
         workspace: workspaceId,
         fileKey: key,
         requestBody: new Blob([buf]) as any,
       });
       log.info(colors.gray(`  ↑ ${binding.source} → s3://${key}`));
-      obj = { s3: key };
     }
-    Object.assign(args, s3Arg(param, obj));
+    Object.assign(args, s3Arg(param, key));
   }
   return args;
 }

--- a/cli/src/commands/pipeline/pipelineUpload.ts
+++ b/cli/src/commands/pipeline/pipelineUpload.ts
@@ -43,25 +43,18 @@ export function devUploadKey(scriptPath: string, param: string, source: string):
   return `wmilldev/pipeline/${scriptPath}/${param}/${basename(source)}`;
 }
 
-export type S3Object = { s3: string; storage?: string };
-
 /**
- * Parse an `s3://<storage>/<key>` source into an S3Object. The authority is the
- * named storage (empty ⇒ default), matching Windmill's canonical round-trip
- * (`{ s3, storage }` ⇄ `s3://<storage>/<key>`, `s3:///key` for default). A source
- * with no `/` after the scheme has no authority to name a storage, so the whole
- * remainder is the key in the default store.
+ * Object key from an `s3://<key>` source. The whole remainder is the key in the
+ * workspace default storage — matching how pipeline `s3://` asset URIs are read
+ * (`s3://a/b/c` → key `a/b/c`), so a nested default-storage key isn't misread as
+ * a named-storage authority. (`--upload` sources are default-storage, like the
+ * local-file upload path; named storage is out of scope.)
  */
-export function parseS3Uri(source: string): S3Object {
-  const rest = source.slice("s3://".length);
-  const slash = rest.indexOf("/");
-  if (slash < 0) return { s3: rest };
-  const storage = rest.slice(0, slash);
-  const key = rest.slice(slash + 1);
-  return storage ? { s3: key, storage } : { s3: key };
+export function s3UriKey(source: string): string {
+  return source.slice("s3://".length);
 }
 
-/** The S3Object run-arg (`{ <param>: <S3Object> }`). */
-export function s3Arg(param: string, obj: S3Object): Record<string, S3Object> {
-  return { [param]: obj };
+/** The S3Object run-arg (`{ <param>: { s3: <key> } }`). */
+export function s3Arg(param: string, key: string): Record<string, { s3: string }> {
+  return { [param]: { s3: key } };
 }

--- a/cli/src/commands/pipeline/pipelineUpload.ts
+++ b/cli/src/commands/pipeline/pipelineUpload.ts
@@ -1,0 +1,45 @@
+// Helpers for `wmill pipeline run --upload <script>[:<param>]=<file|s3://key>`:
+// bind an object to a `data_upload` / `webhook` entry point so it (and its
+// downstream) runs in the cascade instead of being skipped for want of input.
+import { basename } from "node:path";
+
+export type UploadBinding = { scriptTok: string; param?: string; source: string };
+
+/**
+ * Parse a `--upload` spec: `<script>[:<param>]=<file-or-s3-uri>`.
+ * Split on the FIRST `=` so an `s3://…` source (whose `:` sits to the right of
+ * it) stays unambiguous; an optional `:<param>` on the left names the target
+ * S3Object argument when the script declares more than one.
+ */
+export function parseUploadBinding(spec: string): UploadBinding {
+  const eq = spec.indexOf("=");
+  const left = eq < 0 ? "" : spec.slice(0, eq).trim();
+  const source = eq < 0 ? "" : spec.slice(eq + 1).trim();
+  if (!left || !source) {
+    throw new Error(`--upload '${spec}' must be <script>[:<param>]=<file-or-s3-uri>`);
+  }
+  const colon = left.indexOf(":");
+  if (colon < 0) return { scriptTok: left, source };
+  const scriptTok = left.slice(0, colon).trim();
+  const param = left.slice(colon + 1).trim();
+  if (!scriptTok || !param) {
+    throw new Error(`--upload '${spec}' must be <script>[:<param>]=<file-or-s3-uri>`);
+  }
+  return { scriptTok, param, source };
+}
+
+/** Names of a schema's S3Object properties (`format: resource-s3_object`). */
+export function s3ObjectParams(schema: any): string[] {
+  const props = schema?.properties ?? {};
+  return Object.keys(props).filter((k) => props[k]?.format === "resource-s3_object");
+}
+
+/** Deterministic dev object key for a local sample bound to a pipeline folder. */
+export function devUploadKey(folder: string, source: string): string {
+  return `wmilldev/pipeline/${folder}/${basename(source)}`;
+}
+
+/** The S3Object run-arg (`{ <param>: { s3: <key> } }`). */
+export function s3Arg(param: string, key: string): Record<string, { s3: string }> {
+  return { [param]: { s3: key } };
+}

--- a/cli/src/commands/pipeline/pipelineUpload.ts
+++ b/cli/src/commands/pipeline/pipelineUpload.ts
@@ -43,7 +43,25 @@ export function devUploadKey(scriptPath: string, param: string, source: string):
   return `wmilldev/pipeline/${scriptPath}/${param}/${basename(source)}`;
 }
 
-/** The S3Object run-arg (`{ <param>: { s3: <key> } }`). */
-export function s3Arg(param: string, key: string): Record<string, { s3: string }> {
-  return { [param]: { s3: key } };
+export type S3Object = { s3: string; storage?: string };
+
+/**
+ * Parse an `s3://<storage>/<key>` source into an S3Object. The authority is the
+ * named storage (empty ⇒ default), matching Windmill's canonical round-trip
+ * (`{ s3, storage }` ⇄ `s3://<storage>/<key>`, `s3:///key` for default). A source
+ * with no `/` after the scheme has no authority to name a storage, so the whole
+ * remainder is the key in the default store.
+ */
+export function parseS3Uri(source: string): S3Object {
+  const rest = source.slice("s3://".length);
+  const slash = rest.indexOf("/");
+  if (slash < 0) return { s3: rest };
+  const storage = rest.slice(0, slash);
+  const key = rest.slice(slash + 1);
+  return storage ? { s3: key, storage } : { s3: key };
+}
+
+/** The S3Object run-arg (`{ <param>: <S3Object> }`). */
+export function s3Arg(param: string, obj: S3Object): Record<string, S3Object> {
+  return { [param]: obj };
 }

--- a/cli/src/commands/pipeline/pipelineUpload.ts
+++ b/cli/src/commands/pipeline/pipelineUpload.ts
@@ -43,20 +43,25 @@ export function devUploadKey(scriptPath: string, param: string, source: string):
   return `wmilldev/pipeline/${scriptPath}/${param}/${basename(source)}`;
 }
 
+export type S3Object = { s3: string; storage?: string };
+
 /**
- * Object key from an `s3://<key>` source. The whole remainder is the key in the
- * workspace default storage — matching how pipeline `s3://` asset URIs are read
- * (`s3://a/b/c` → key `a/b/c`), so a nested default-storage key isn't misread as
- * a named-storage authority. (`--upload` sources are default-storage, like the
- * local-file upload path; named storage is out of scope.) A leading slash — the
- * canonical empty-authority default form `s3:///key` — is trimmed so it doesn't
- * leak into the key.
+ * Parse an `s3://<storage>/<key>` source into an S3Object, matching Windmill's
+ * canonical `parseS3Object` (frontend `utils.ts`): the authority is the named
+ * storage — empty ⇒ default — and the rest is the object key. So
+ * `s3://secondary/k.csv` → `{ s3: "k.csv", storage: "secondary" }`, and the
+ * default-storage form is `s3:///key` (empty authority), including nested keys
+ * (`s3:///raw/2026/events.csv`). A source with no `/` after the scheme has no
+ * authority, so the whole remainder is the key in the default store.
  */
-export function s3UriKey(source: string): string {
-  return source.slice("s3://".length).replace(/^\//, "");
+export function parseS3Uri(source: string): S3Object {
+  const m = source.match(/^s3:\/\/([^/]*)\/(.*)$/);
+  if (!m) return { s3: source.slice("s3://".length) };
+  const storage = m[1] || undefined;
+  return storage ? { s3: m[2], storage } : { s3: m[2] };
 }
 
-/** The S3Object run-arg (`{ <param>: { s3: <key> } }`). */
-export function s3Arg(param: string, key: string): Record<string, { s3: string }> {
-  return { [param]: { s3: key } };
+/** The S3Object run-arg (`{ <param>: <S3Object> }`). */
+export function s3Arg(param: string, obj: S3Object): Record<string, S3Object> {
+  return { [param]: obj };
 }

--- a/cli/src/commands/pipeline/pipelineUpload.ts
+++ b/cli/src/commands/pipeline/pipelineUpload.ts
@@ -48,10 +48,12 @@ export function devUploadKey(scriptPath: string, param: string, source: string):
  * workspace default storage — matching how pipeline `s3://` asset URIs are read
  * (`s3://a/b/c` → key `a/b/c`), so a nested default-storage key isn't misread as
  * a named-storage authority. (`--upload` sources are default-storage, like the
- * local-file upload path; named storage is out of scope.)
+ * local-file upload path; named storage is out of scope.) A leading slash — the
+ * canonical empty-authority default form `s3:///key` — is trimmed so it doesn't
+ * leak into the key.
  */
 export function s3UriKey(source: string): string {
-  return source.slice("s3://".length);
+  return source.slice("s3://".length).replace(/^\//, "");
 }
 
 /** The S3Object run-arg (`{ <param>: { s3: <key> } }`). */

--- a/cli/src/commands/pipeline/pipelineUpload.ts
+++ b/cli/src/commands/pipeline/pipelineUpload.ts
@@ -34,9 +34,13 @@ export function s3ObjectParams(schema: any): string[] {
   return Object.keys(props).filter((k) => props[k]?.format === "resource-s3_object");
 }
 
-/** Deterministic dev object key for a local sample bound to a pipeline folder. */
-export function devUploadKey(folder: string, source: string): string {
-  return `wmilldev/pipeline/${folder}/${basename(source)}`;
+/**
+ * Deterministic dev object key for a local sample bound to a script's param.
+ * Scoped by script path + param so two different sources that share a basename
+ * (across scripts or params) resolve to distinct keys instead of clobbering.
+ */
+export function devUploadKey(scriptPath: string, param: string, source: string): string {
+  return `wmilldev/pipeline/${scriptPath}/${param}/${basename(source)}`;
 }
 
 /** The S3Object run-arg (`{ <param>: { s3: <key> } }`). */

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -6924,7 +6924,7 @@ inspect asset-driven pipelines (scripts marked \`// pipeline\`, wired by \`// on
   - \`--dry-run\` - Print the topological run plan without executing.
   - \`--json\` - Output the plan as JSON (for piping to jq).
   - \`--local\` - Run the local working-tree scripts via preview (no deploy) instead of the deployed versions; the graph is built from local files.
-  - \`--upload <binding:string>\` - Bind an object to a data_upload/webhook entry point so it runs in the cascade: <script>[:<param>]=<local-file|s3://key>. Local files are uploaded to the workspace store; the S3Object param is inferred when the script has exactly one. Repeatable.
+  - \`--upload <binding:string>\` - Bind an object to a data_upload/webhook entry point so it runs in the cascade, as SCRIPT[:PARAM]=SOURCE (SOURCE is a local file or an s3://key). Local files are uploaded to the workspace store; the S3Object param is inferred when the script has exactly one. Repeatable.
 - \`pipeline docs <folder:string>\` - generate PIPELINE.md (+ AGENTS.md pointer) describing a folder's pipeline graph and datatable schemas, for an editor / agentic loop
   - \`--local\` - Build the graph from local working-tree files instead of the deployed workspace.
 - \`pipeline dev [folder:string]\` - Live-preview a data pipeline from local files: watch an \`f/<folder>\` of \`// pipeline\` scripts, push the working-tree graph to the dev page, and run the cascade via preview (no deploy).

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -6917,11 +6917,18 @@ inspect asset-driven pipelines (scripts marked \`// pipeline\`, wired by \`// on
   - \`--json\` - Output as JSON (for piping to jq)
 - \`pipeline show <folder:string>\` - render a pipeline folder's DAG (sources, lineage, subscriptions) in the terminal
   - \`--json\` - Output the raw asset graph as JSON
+  - \`--local\` - Build the graph from local working-tree files (// pipeline scripts) instead of the deployed workspace — no deploy needed.
 - \`pipeline run <folder:string>\` - run a bounded cascade: from a schedule/manual root, fan downstream up to the --to end node(s)
   - \`--from <script:string>\` - Start script (short name or path). Defaults to the folder's sole schedule/manual root.
   - \`--to <node:string>\` - End node(s) to stop at — script names/paths or asset URIs (e.g. datatable://main/staged). Repeatable or comma-separated. Omit to run the full downstream.
   - \`--dry-run\` - Print the topological run plan without executing.
   - \`--json\` - Output the plan as JSON (for piping to jq).
+  - \`--local\` - Run the local working-tree scripts via preview (no deploy) instead of the deployed versions; the graph is built from local files.
+- \`pipeline docs <folder:string>\` - generate PIPELINE.md (+ AGENTS.md pointer) describing a folder's pipeline graph and datatable schemas, for an editor / agentic loop
+  - \`--local\` - Build the graph from local working-tree files instead of the deployed workspace.
+- \`pipeline dev [folder:string]\` - Live-preview a data pipeline from local files: watch an \`f/<folder>\` of \`// pipeline\` scripts, push the working-tree graph to the dev page, and run the cascade via preview (no deploy).
+  - \`--port <port:number>\` - Port for the dev WebSocket server.
+  - \`--no-open\` - Do not open the browser automatically.
 
 ### protection-rules
 

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -6924,6 +6924,7 @@ inspect asset-driven pipelines (scripts marked \`// pipeline\`, wired by \`// on
   - \`--dry-run\` - Print the topological run plan without executing.
   - \`--json\` - Output the plan as JSON (for piping to jq).
   - \`--local\` - Run the local working-tree scripts via preview (no deploy) instead of the deployed versions; the graph is built from local files.
+  - \`--upload <binding:string>\` - Bind an object to a data_upload/webhook entry point so it runs in the cascade: <script>[:<param>]=<local-file|s3://key>. Local files are uploaded to the workspace store; the S3Object param is inferred when the script has exactly one. Repeatable.
 - \`pipeline docs <folder:string>\` - generate PIPELINE.md (+ AGENTS.md pointer) describing a folder's pipeline graph and datatable schemas, for an editor / agentic loop
   - \`--local\` - Build the graph from local working-tree files instead of the deployed workspace.
 - \`pipeline dev [folder:string]\` - Live-preview a data pipeline from local files: watch an \`f/<folder>\` of \`// pipeline\` scripts, push the working-tree graph to the dev page, and run the cascade via preview (no deploy).

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -6929,6 +6929,7 @@ inspect asset-driven pipelines (scripts marked \`// pipeline\`, wired by \`// on
 - \`pipeline dev [folder:string]\` - Live-preview a data pipeline from local files: watch an \`f/<folder>\` of \`// pipeline\` scripts, push the working-tree graph to the dev page, and run the cascade via preview (no deploy).
   - \`--port <port:number>\` - Port for the dev WebSocket server.
   - \`--no-open\` - Do not open the browser automatically.
+  - \`--frontend <origin:string>\` - Origin serving the /pipeline_dev page (e.g. http://localhost:3000 for a locally-run frontend). Defaults to the workspace remote; use it when the remote's deployed frontend predates the dev page.
 
 ### protection-rules
 

--- a/cli/test/pipeline_bounded_cascade_unit.test.ts
+++ b/cli/test/pipeline_bounded_cascade_unit.test.ts
@@ -15,6 +15,7 @@ import {
   scriptsOf,
   topoOrder,
   validStarts,
+  eventTriggerScripts,
 } from "../src/commands/pipeline/boundedCascade.ts";
 
 type W = [script: string, asset: string];
@@ -113,6 +114,18 @@ test("validStarts: schedule and manual roots, not events or subscribers", () => 
   expect(starts.has(sn("sched"))).toBe(true); // schedule overrides subscriber
   expect(starts.has(sn("sub"))).toBe(false); // pure subscriber
   expect(starts.has(sn("kfk"))).toBe(false); // event-only
+});
+
+test("eventTriggerScripts: event handlers, incl. ones that also subscribe (descendants)", () => {
+  const g = graph({
+    scripts: ["a", "evt"],
+    writes: [["a", "x"]],
+    subs: [["evt", "x"]], // evt is a lineage descendant of a…
+    native: [["kafka", "evt"]], // …and a kafka event handler
+  });
+  const ev = eventTriggerScripts(g);
+  expect(ev.has(sn("evt"))).toBe(true); // excluded from a whole-pipeline run despite being a descendant
+  expect(ev.has(sn("a"))).toBe(false);
 });
 
 test("assetUriToNodeId maps s3 → s3object, others verbatim", () => {

--- a/cli/test/pipeline_bounded_cascade_unit.test.ts
+++ b/cli/test/pipeline_bounded_cascade_unit.test.ts
@@ -127,6 +127,33 @@ test("validStarts: schedule and manual roots, not events/uploads/webhooks or sub
   expect(starts.has(sn("hook"))).toBe(false);
 });
 
+test("a scheduled root with a secondary data_upload trigger stays a start and isn't cut", () => {
+  // Regression: the barrier set must exclude valid starts, else a script with
+  // both `// on schedule` and `// on data_upload` resolves as the start yet is
+  // also a barrier, so reachableCutting skips it → empty run plan.
+  const g = graph({
+    scripts: ["sched_upload", "consumer"],
+    writes: [["sched_upload", "x"]],
+    subs: [["consumer", "x"]],
+    native: [
+      ["schedule", "sched_upload"],
+      ["data_upload", "sched_upload"],
+    ],
+  });
+  const starts = validStarts(g);
+  expect(starts.has(sn("sched_upload"))).toBe(true); // schedule wins over the upload trigger
+  // Mirror run()'s barrier set: nonAutorun handlers minus the valid starts.
+  const barriers = new Set([...nonAutorunTriggerScripts(g)].filter((id) => !starts.has(id)));
+  expect(barriers.has(sn("sched_upload"))).toBe(false); // the scheduled root is protected
+  const sel = new Set(
+    [...reachableCutting(buildLineageDag(g), starts, barriers)]
+      .filter(isScriptNode)
+      .map(scriptPathOf),
+  );
+  expect(sel.has("sched_upload")).toBe(true); // runs on its schedule path…
+  expect(sel.has("consumer")).toBe(true); // …and its downstream isn't cut off
+});
+
 test("nonAutorunTriggerScripts: event + upload/webhook handlers, incl. subscribers (descendants)", () => {
   const g = graph({
     scripts: ["a", "evt", "upl"],

--- a/cli/test/pipeline_bounded_cascade_unit.test.ts
+++ b/cli/test/pipeline_bounded_cascade_unit.test.ts
@@ -16,6 +16,9 @@ import {
   topoOrder,
   validStarts,
   eventTriggerScripts,
+  reachableCutting,
+  isScriptNode,
+  scriptPathOf,
 } from "../src/commands/pipeline/boundedCascade.ts";
 
 type W = [script: string, asset: string];
@@ -126,6 +129,35 @@ test("eventTriggerScripts: event handlers, incl. ones that also subscribe (desce
   const ev = eventTriggerScripts(g);
   expect(ev.has(sn("evt"))).toBe(true); // excluded from a whole-pipeline run despite being a descendant
   expect(ev.has(sn("a"))).toBe(false);
+});
+
+test("reachableCutting: drops barrier + its exclusive downstream, keeps alt-path nodes", () => {
+  // root_a → x → handler(kafka) → y → consumer ; root_b → z ; (variant: consumer also ← z)
+  const g = graph({
+    scripts: ["root_a", "root_b", "handler", "consumer"],
+    writes: [["root_a", "x"], ["root_b", "z"], ["handler", "y"]],
+    subs: [["handler", "x"], ["consumer", "y"]],
+    native: [["kafka", "handler"]],
+  });
+  const dag = buildLineageDag(g);
+  const scripts = (s: Set<string>) =>
+    new Set([...s].filter(isScriptNode).map(scriptPathOf));
+
+  // consumer only reachable via the event handler → both excluded
+  expect(scripts(reachableCutting(dag, validStarts(g), eventTriggerScripts(g)))).toEqual(
+    new Set(["root_a", "root_b"]),
+  );
+
+  // now consumer also reads z (a non-event path via root_b) → it stays
+  const g2 = graph({
+    scripts: ["root_a", "root_b", "handler", "consumer"],
+    writes: [["root_a", "x"], ["root_b", "z"], ["handler", "y"]],
+    subs: [["handler", "x"], ["consumer", "y"], ["consumer", "z"]],
+    native: [["kafka", "handler"]],
+  });
+  expect(
+    scripts(reachableCutting(buildLineageDag(g2), validStarts(g2), eventTriggerScripts(g2))),
+  ).toEqual(new Set(["root_a", "root_b", "consumer"]));
 });
 
 test("assetUriToNodeId maps s3 → s3object, others verbatim", () => {

--- a/cli/test/pipeline_bounded_cascade_unit.test.ts
+++ b/cli/test/pipeline_bounded_cascade_unit.test.ts
@@ -15,7 +15,7 @@ import {
   scriptsOf,
   topoOrder,
   validStarts,
-  eventTriggerScripts,
+  nonAutorunTriggerScripts,
   reachableCutting,
   isScriptNode,
   scriptPathOf,
@@ -105,29 +105,39 @@ test("boundedSet drops ends not downstream of start", () => {
   expect([...res.nodes]).toEqual([sn("c")]);
 });
 
-test("validStarts: schedule and manual roots, not events or subscribers", () => {
+test("validStarts: schedule and manual roots, not events/uploads/webhooks or subscribers", () => {
   const g = graph({
-    scripts: ["a", "sub", "sched", "kfk"],
+    scripts: ["a", "sub", "sched", "kfk", "upl", "hook"],
     writes: [["a", "x"]],
     subs: [["sub", "x"], ["sched", "x"]],
-    native: [["schedule", "sched"], ["kafka", "kfk"]],
+    native: [
+      ["schedule", "sched"],
+      ["kafka", "kfk"],
+      ["data_upload", "upl"],
+      ["webhook", "hook"],
+    ],
   });
   const starts = validStarts(g);
   expect(starts.has(sn("a"))).toBe(true); // manual root
   expect(starts.has(sn("sched"))).toBe(true); // schedule overrides subscriber
   expect(starts.has(sn("sub"))).toBe(false); // pure subscriber
   expect(starts.has(sn("kfk"))).toBe(false); // event-only
+  // data_upload / webhook need caller-supplied input → not auto-run roots
+  expect(starts.has(sn("upl"))).toBe(false);
+  expect(starts.has(sn("hook"))).toBe(false);
 });
 
-test("eventTriggerScripts: event handlers, incl. ones that also subscribe (descendants)", () => {
+test("nonAutorunTriggerScripts: event + upload/webhook handlers, incl. subscribers (descendants)", () => {
   const g = graph({
-    scripts: ["a", "evt"],
+    scripts: ["a", "evt", "upl"],
     writes: [["a", "x"]],
-    subs: [["evt", "x"]], // evt is a lineage descendant of a…
-    native: [["kafka", "evt"]], // …and a kafka event handler
+    subs: [["evt", "x"], ["upl", "x"]], // both are lineage descendants of a…
+    native: [["kafka", "evt"], ["data_upload", "upl"]], // …and input-requiring handlers
   });
-  const ev = eventTriggerScripts(g);
-  expect(ev.has(sn("evt"))).toBe(true); // excluded from a whole-pipeline run despite being a descendant
+  const ev = nonAutorunTriggerScripts(g);
+  // excluded from a whole-pipeline run despite being descendants
+  expect(ev.has(sn("evt"))).toBe(true);
+  expect(ev.has(sn("upl"))).toBe(true);
   expect(ev.has(sn("a"))).toBe(false);
 });
 
@@ -144,7 +154,7 @@ test("reachableCutting: drops barrier + its exclusive downstream, keeps alt-path
     new Set([...s].filter(isScriptNode).map(scriptPathOf));
 
   // consumer only reachable via the event handler → both excluded
-  expect(scripts(reachableCutting(dag, validStarts(g), eventTriggerScripts(g)))).toEqual(
+  expect(scripts(reachableCutting(dag, validStarts(g), nonAutorunTriggerScripts(g)))).toEqual(
     new Set(["root_a", "root_b"]),
   );
 
@@ -156,7 +166,7 @@ test("reachableCutting: drops barrier + its exclusive downstream, keeps alt-path
     native: [["kafka", "handler"]],
   });
   expect(
-    scripts(reachableCutting(buildLineageDag(g2), validStarts(g2), eventTriggerScripts(g2))),
+    scripts(reachableCutting(buildLineageDag(g2), validStarts(g2), nonAutorunTriggerScripts(g2))),
   ).toEqual(new Set(["root_a", "root_b", "consumer"]));
 });
 

--- a/cli/test/pipeline_enrich_unit.test.ts
+++ b/cli/test/pipeline_enrich_unit.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import { recoverHeaderMarkers } from "../src/commands/pipeline/pipeline.ts";
+
+// The deployed graph omits marker-only `// on data_upload`/`webhook`/`email`
+// triggers, so `pipeline run` recovers them from script bodies. It must scan the
+// LEADING comment header only (like the canonical/fallback parsers) so a body
+// comment can't inject a phantom trigger and over-cut the run selection.
+
+test("recovers marker triggers from the leading comment header", () => {
+  expect(recoverHeaderMarkers("-- pipeline\n-- on data_upload\nSELECT 1;")).toEqual([
+    "data_upload",
+  ]);
+  // multiple kinds, blank lines allowed inside the header
+  expect(
+    recoverHeaderMarkers("// pipeline\n\n// on webhook\n// on email\nexport function main(){}"),
+  ).toEqual(["webhook", "email"]);
+});
+
+test("ignores a marker in a body comment (stops at first non-comment line)", () => {
+  const code = `-- pipeline
+-- on schedule
+SELECT * FROM t;
+-- on data_upload`;
+  // the body `-- on data_upload` is past the header → not recovered
+  expect(recoverHeaderMarkers(code)).toEqual([]);
+});
+
+test("ignores non-marker `on` kinds and dedupes", () => {
+  // kafka/asset `on` lines aren't marker kinds; data_upload deduped
+  const code = `# pipeline
+# on data_upload
+# on kafka
+# on data_upload
+def main(): pass`;
+  expect(recoverHeaderMarkers(code)).toEqual(["data_upload"]);
+});

--- a/cli/test/pipeline_local_graph_unit.test.ts
+++ b/cli/test/pipeline_local_graph_unit.test.ts
@@ -152,6 +152,21 @@ test("defaultTs (from wmill.yaml) drives bare `.ts` runtime — deno, not always
   );
 });
 
+test("`// tag <worker>` is carried on the pushed script for preview routing", async () => {
+  await withFolder(
+    {
+      "gpu_job.duckdb.sql": `-- pipeline\n-- tag gpu\nSELECT 1;\n`,
+      "plain.duckdb.sql": `-- pipeline\nSELECT 2;\n`,
+    },
+    async (root, folder) => {
+      const { scripts } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+      expect(scripts.find((s) => s.path === "f/mypipe/gpu_job")?.tag).toBe("gpu");
+      // a node without `// tag` carries no tag (→ default worker)
+      expect(scripts.find((s) => s.path === "f/mypipe/plain")?.tag).toBeUndefined();
+    },
+  );
+});
+
 test("go/bash fallback: leading-header `// on` only, options stripped, no body phantoms", async () => {
   await withFolder(
     {

--- a/cli/test/pipeline_local_graph_unit.test.ts
+++ b/cli/test/pipeline_local_graph_unit.test.ts
@@ -170,13 +170,13 @@ test("`// tag <worker>` is carried on the pushed script for preview routing", as
 test("go/bash fallback: leading-header `// on` only, options stripped, no body phantoms", async () => {
   await withFolder(
     {
-      // header annotations (one with a trailing option) + a body comment that
-      // must NOT become a phantom trigger.
+      // header annotations (incl. `// tag`, one `// on` with a trailing option) +
+      // a body comment that must NOT become a phantom trigger.
       "ingest.go":
-        `// pipeline\n// on s3://demo/raw.csv debounce=5s\npackage inner\nfunc main() {\n\t// on s3://demo/PHANTOM.csv\n}\n`,
+        `// pipeline\n// tag heavy\n// on s3://demo/raw.csv debounce=5s\npackage inner\nfunc main() {\n\t// on s3://demo/PHANTOM.csv\n}\n`,
     },
     async (root, folder) => {
-      const { graph } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+      const { graph, scripts } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
       const ats = graph.triggers.filter((t) => t.trigger_kind === "asset") as Extract<
         (typeof graph.triggers)[number],
         { trigger_kind: "asset" }
@@ -186,6 +186,9 @@ test("go/bash fallback: leading-header `// on` only, options stripped, no body p
       // the trailing `debounce=5s` option is stripped from the asset path
       expect(ats[0].asset_path).toBe("demo/raw.csv");
       expect(graph.assets.some((a) => a.path.includes("PHANTOM"))).toBe(false);
+      // `// tag` is recovered by the fallback too (routes the preview)
+      expect(scripts.find((s) => s.path === "f/mypipe/ingest")?.tag).toBe("heavy");
+      expect(graph.runnables.find((r) => r.path === "f/mypipe/ingest")?.tag).toBe("heavy");
     },
   );
 });

--- a/cli/test/pipeline_local_graph_unit.test.ts
+++ b/cli/test/pipeline_local_graph_unit.test.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildLocalPipelineGraph } from "../src/commands/pipeline/localGraph.ts";
+
+// Build a throwaway workspace tree with `f/<folder>/<file>` scripts and a
+// wmill.yaml at the root, then assert the graph the wasm-backed builder derives.
+function withFolder(
+  files: Record<string, string>,
+  fn: (root: string, folder: string) => Promise<void> | void,
+) {
+  const root = mkdtempSync(join(tmpdir(), "wm-pl-"));
+  writeFileSync(join(root, "wmill.yaml"), "defaultTs: bun\n");
+  const folder = "mypipe";
+  mkdirSync(join(root, "f", folder), { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(root, "f", folder, name), content);
+  }
+  return Promise.resolve(fn(root, folder)).finally(() =>
+    rmSync(root, { recursive: true, force: true }),
+  );
+}
+
+test("only `// pipeline` scripts become nodes; `// on` asset triggers wire edges", async () => {
+  await withFolder(
+    {
+      // a source: pipeline member, subscribes to nothing, but is annotated.
+      "raw.bun.ts":
+        `// pipeline\nimport * as wmill from "windmill-client"\nexport async function main() {}\n`,
+      // a transform: pipeline member, subscribes to raw.
+      "staged.duckdb.sql":
+        `-- pipeline\n-- on datatable://main/raw\nINSERT INTO main.staged SELECT 1;\n`,
+      // not a pipeline member — must be excluded.
+      "helper.bun.ts":
+        `export async function main() {}\n`,
+    },
+    async (root, folder) => {
+      const { graph, scripts } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+
+      const paths = graph.runnables.map((r) => r.path).sort();
+      expect(paths).toEqual(["f/mypipe/raw", "f/mypipe/staged"]);
+      // helper is excluded
+      expect(paths).not.toContain("f/mypipe/helper");
+      expect(scripts.map((s) => s.path).sort()).toEqual(paths);
+
+      // staged subscribes to datatable://main/raw via an asset trigger
+      const assetTriggers = graph.triggers.filter((t) => t.trigger_kind === "asset");
+      expect(assetTriggers).toHaveLength(1);
+      const at = assetTriggers[0] as Extract<
+        (typeof graph.triggers)[number],
+        { trigger_kind: "asset" }
+      >;
+      expect(at.asset_kind).toBe("datatable");
+      expect(at.asset_path).toBe("main/raw");
+      expect(at.runnable_path).toBe("f/mypipe/staged");
+
+      // the referenced asset exists in the asset set
+      expect(graph.assets).toContainEqual({ kind: "datatable", path: "main/raw" });
+    },
+  );
+});
+
+test("native triggers surface as trigger rows (no deploy needed)", async () => {
+  await withFolder(
+    {
+      "ingest.bun.ts":
+        `// pipeline\n// on data_upload\nimport * as wmill from "windmill-client"\nexport async function main() {}\n`,
+    },
+    async (root, folder) => {
+      const { graph } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+      const native = graph.triggers.filter((t) => t.trigger_kind !== "asset");
+      expect(native.map((t) => t.trigger_kind)).toContain("data_upload");
+    },
+  );
+});
+
+test("empty / no-pipeline folder yields an empty graph", async () => {
+  await withFolder(
+    { "plain.bun.ts": `export async function main() {}\n` },
+    async (root, folder) => {
+      const { graph } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+      expect(graph.runnables).toHaveLength(0);
+      expect(graph.assets).toHaveLength(0);
+    },
+  );
+});

--- a/cli/test/pipeline_local_graph_unit.test.ts
+++ b/cli/test/pipeline_local_graph_unit.test.ts
@@ -152,6 +152,29 @@ test("defaultTs (from wmill.yaml) drives bare `.ts` runtime — deno, not always
   );
 });
 
+test("go/bash fallback: leading-header `// on` only, options stripped, no body phantoms", async () => {
+  await withFolder(
+    {
+      // header annotations (one with a trailing option) + a body comment that
+      // must NOT become a phantom trigger.
+      "ingest.go":
+        `// pipeline\n// on s3://demo/raw.csv debounce=5s\npackage inner\nfunc main() {\n\t// on s3://demo/PHANTOM.csv\n}\n`,
+    },
+    async (root, folder) => {
+      const { graph } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+      const ats = graph.triggers.filter((t) => t.trigger_kind === "asset") as Extract<
+        (typeof graph.triggers)[number],
+        { trigger_kind: "asset" }
+      >[];
+      // exactly one trigger: the body `// on …PHANTOM` is past the header → ignored
+      expect(ats).toHaveLength(1);
+      // the trailing `debounce=5s` option is stripped from the asset path
+      expect(ats[0].asset_path).toBe("demo/raw.csv");
+      expect(graph.assets.some((a) => a.path.includes("PHANTOM"))).toBe(false);
+    },
+  );
+});
+
 test("`# volume:` producer connects to its `# on volume://` consumer", async () => {
   // Volume annotations are parsed separately from the wasm body parser (mirrors
   // the frontend/backend); without that pass the producer has no write edge.

--- a/cli/test/pipeline_local_graph_unit.test.ts
+++ b/cli/test/pipeline_local_graph_unit.test.ts
@@ -193,6 +193,31 @@ test("go/bash fallback: leading-header `// on` only, options stripped, no body p
   );
 });
 
+test("go/bash fallback: a native marker with trailing content is rejected (parity)", async () => {
+  // The canonical parser rejects a marker line with trailing content, so the
+  // fallback must too — else a `// on data_upload f/foo` / `# on kafka topic`
+  // shows up locally as an upload/event trigger that deployed parsing drops.
+  await withFolder(
+    {
+      "bare.go": `// pipeline\n// on data_upload\npackage inner\nfunc main() {}\n`,
+      "trailing.go": `// pipeline\n// on data_upload f/foo\npackage inner\nfunc main() {}\n`,
+      "kafka.rb": `# pipeline\n# on kafka topic\nputs "hi"\n`,
+    },
+    async (root, folder) => {
+      const { graph } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+      const nativeOf = (p: string) =>
+        graph.triggers
+          .filter((t) => t.trigger_kind !== "asset" && t.runnable_path === p)
+          .map((t) => t.trigger_kind);
+      // bare marker stands alone → recognized
+      expect(nativeOf("f/mypipe/bare")).toEqual(["data_upload"]);
+      // trailing content → rejected (no native trigger)
+      expect(nativeOf("f/mypipe/trailing")).toEqual([]);
+      expect(nativeOf("f/mypipe/kafka")).toEqual([]);
+    },
+  );
+});
+
 test("go/bash fallback: a multi-word `// tag` is rejected (single token only)", async () => {
   // A worker tag is one token; trailing prose must NOT smuggle a bogus tag that
   // would route the preview to a non-existent worker.

--- a/cli/test/pipeline_local_graph_unit.test.ts
+++ b/cli/test/pipeline_local_graph_unit.test.ts
@@ -193,6 +193,23 @@ test("go/bash fallback: leading-header `// on` only, options stripped, no body p
   );
 });
 
+test("go/bash fallback: a multi-word `// tag` is rejected (single token only)", async () => {
+  // A worker tag is one token; trailing prose must NOT smuggle a bogus tag that
+  // would route the preview to a non-existent worker.
+  await withFolder(
+    {
+      "single.go": `// pipeline\n// tag gpu\npackage inner\nfunc main() {}\n`,
+      "multi.go": `// pipeline\n// tag gpu for heavy jobs\npackage inner\nfunc main() {}\n`,
+    },
+    async (root, folder) => {
+      const { scripts } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+      expect(scripts.find((s) => s.path === "f/mypipe/single")?.tag).toBe("gpu");
+      // multi-word → no tag (default worker), not "gpu for heavy jobs"
+      expect(scripts.find((s) => s.path === "f/mypipe/multi")?.tag).toBeUndefined();
+    },
+  );
+});
+
 test("`# volume:` producer connects to its `# on volume://` consumer", async () => {
   // Volume annotations are parsed separately from the wasm body parser (mirrors
   // the frontend/backend); without that pass the producer has no write edge.

--- a/cli/test/pipeline_local_graph_unit.test.ts
+++ b/cli/test/pipeline_local_graph_unit.test.ts
@@ -86,3 +86,38 @@ test("empty / no-pipeline folder yields an empty graph", async () => {
     },
   );
 });
+
+test("`// materialize <asset>` producer connects to its `// on` consumer", async () => {
+  // The wasm asset parser doesn't surface `// materialize`; the CLI-side scan
+  // must still emit the producer's write edge so it links to the consumer.
+  await withFolder(
+    {
+      "load.duckdb.sql": `-- pipeline\n-- materialize ducklake://main/users\nSELECT 1 AS id;\n`,
+      "consume.duckdb.sql":
+        `-- pipeline\n-- on ducklake://main/users\nSELECT count(*) FROM users;\n`,
+    },
+    async (root, folder) => {
+      const { graph } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+
+      // the materialize target is a shared asset
+      expect(graph.assets).toContainEqual({ kind: "ducklake", path: "main/users" });
+
+      // the producer carries its materialize_target and a write edge
+      const load = graph.runnables.find((r) => r.path === "f/mypipe/load");
+      expect(load?.materialize_target).toEqual({ kind: "ducklake", path: "main/users" });
+      expect(graph.edges).toContainEqual({
+        runnable_kind: "script",
+        runnable_path: "f/mypipe/load",
+        asset_kind: "ducklake",
+        asset_path: "main/users",
+        access_type: "w",
+      });
+
+      // the consumer subscribes to the same asset (the connecting trigger)
+      const at = graph.triggers.find(
+        (t) => t.trigger_kind === "asset" && t.runnable_path === "f/mypipe/consume",
+      ) as Extract<(typeof graph.triggers)[number], { trigger_kind: "asset" }> | undefined;
+      expect(at?.asset_path).toBe("main/users");
+    },
+  );
+});

--- a/cli/test/pipeline_local_graph_unit.test.ts
+++ b/cli/test/pipeline_local_graph_unit.test.ts
@@ -121,3 +121,48 @@ test("`// materialize <asset>` producer connects to its `// on` consumer", async
     },
   );
 });
+
+test("a bare `.sql` (ambiguous dialect) is skipped, not a build-aborting crash", async () => {
+  // `inferContentTypeFromFilePath` throws on a dialect-less `.sql`; one such file
+  // must not abort the whole graph build (it also wedged `pipeline dev` at start).
+  await withFolder(
+    {
+      "good.duckdb.sql": `-- pipeline\nSELECT 1;\n`,
+      "ambiguous.sql": `-- pipeline\nSELECT 1;\n`,
+    },
+    async (root, folder) => {
+      const { graph } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+      const paths = graph.runnables.map((r) => r.path);
+      expect(paths).toContain("f/mypipe/good");
+      // the unclassifiable file is dropped — the build still succeeds
+      expect(paths).not.toContain("f/mypipe/ambiguous");
+    },
+  );
+});
+
+test("defaultTs (from wmill.yaml) drives bare `.ts` runtime — deno, not always bun", async () => {
+  await withFolder(
+    { "etl.ts": `// pipeline\nexport async function main() {}\n` },
+    async (root, folder) => {
+      const bun = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+      const deno = await buildLocalPipelineGraph({ root, folder, defaultTs: "deno" });
+      expect(bun.scripts.find((s) => s.path === "f/mypipe/etl")?.language).toBe("bun");
+      expect(deno.scripts.find((s) => s.path === "f/mypipe/etl")?.language).toBe("deno");
+    },
+  );
+});
+
+test("`#`-comment languages (ruby) use the `#` annotation fallback (no wasm parser)", async () => {
+  await withFolder(
+    { "ingest.rb": `# pipeline\n# on s3://demo/raw.csv\nputs "hi"\n` },
+    async (root, folder) => {
+      const { graph } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+      expect(graph.runnables.map((r) => r.path)).toContain("f/mypipe/ingest");
+      const at = graph.triggers.find(
+        (t) => t.trigger_kind === "asset" && t.runnable_path === "f/mypipe/ingest",
+      ) as Extract<(typeof graph.triggers)[number], { trigger_kind: "asset" }> | undefined;
+      expect(at?.asset_kind).toBe("s3object");
+      expect(at?.asset_path).toBe("demo/raw.csv");
+    },
+  );
+});

--- a/cli/test/pipeline_local_graph_unit.test.ts
+++ b/cli/test/pipeline_local_graph_unit.test.ts
@@ -152,6 +152,36 @@ test("defaultTs (from wmill.yaml) drives bare `.ts` runtime — deno, not always
   );
 });
 
+test("`# volume:` producer connects to its `# on volume://` consumer", async () => {
+  // Volume annotations are parsed separately from the wasm body parser (mirrors
+  // the frontend/backend); without that pass the producer has no write edge.
+  await withFolder(
+    {
+      "producer.py": `# pipeline\n# volume: cache /tmp/cache\ndef main():\n    pass\n`,
+      "consumer.py": `# pipeline\n# on volume://cache\ndef main():\n    pass\n`,
+    },
+    async (root, folder) => {
+      const { graph } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+
+      expect(graph.assets).toContainEqual({ kind: "volume", path: "cache" });
+      // producer carries the rw write edge to the volume
+      const producerEdge = graph.edges.find(
+        (e) =>
+          e.runnable_path === "f/mypipe/producer" &&
+          e.asset_kind === "volume" &&
+          e.asset_path === "cache",
+      );
+      expect(producerEdge?.access_type).toBe("rw");
+      // consumer subscribes to the same volume (the connecting trigger)
+      const at = graph.triggers.find(
+        (t) => t.trigger_kind === "asset" && t.runnable_path === "f/mypipe/consumer",
+      ) as Extract<(typeof graph.triggers)[number], { trigger_kind: "asset" }> | undefined;
+      expect(at?.asset_kind).toBe("volume");
+      expect(at?.asset_path).toBe("cache");
+    },
+  );
+});
+
 test("`#`-comment languages (ruby) use the `#` annotation fallback (no wasm parser)", async () => {
   await withFolder(
     { "ingest.rb": `# pipeline\n# on s3://demo/raw.csv\nputs "hi"\n` },

--- a/cli/test/pipeline_upload_unit.test.ts
+++ b/cli/test/pipeline_upload_unit.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "bun:test";
 import {
   devUploadKey,
+  parseS3Uri,
   parseUploadBinding,
   s3Arg,
   s3ObjectParams,
-  s3UriKey,
 } from "../src/commands/pipeline/pipelineUpload.ts";
 
 test("parseUploadBinding: bare script + local source infers the param later", () => {
@@ -70,16 +70,25 @@ test("devUploadKey: key scoped by script path + param so basenames don't clobber
 });
 
 test("s3Arg: shapes the S3Object run-arg", () => {
-  expect(s3Arg("file", "wmilldev/pipeline/analytics/events.csv")).toEqual({
+  expect(s3Arg("file", { s3: "wmilldev/pipeline/analytics/events.csv" })).toEqual({
     file: { s3: "wmilldev/pipeline/analytics/events.csv" },
+  });
+  expect(s3Arg("file", { s3: "k.csv", storage: "secondary" })).toEqual({
+    file: { s3: "k.csv", storage: "secondary" },
   });
 });
 
-test("s3UriKey: whole path is the default-storage key (nested keys kept intact)", () => {
-  // a nested default-storage key must NOT be misread as a named-storage authority
-  expect(s3UriKey("s3://raw/2026/events.csv")).toBe("raw/2026/events.csv");
-  expect(s3UriKey("s3://events.csv")).toBe("events.csv");
-  // canonical empty-authority default form `s3:///key` → leading slash trimmed
-  expect(s3UriKey("s3:///events.csv")).toBe("events.csv");
-  expect(s3UriKey("s3:///nested/key.csv")).toBe("nested/key.csv");
+test("parseS3Uri: canonical `s3://<storage>/<key>` (authority is the named storage)", () => {
+  // named storage — the authority is the storage, the rest is the key
+  expect(parseS3Uri("s3://secondary/k.csv")).toEqual({ s3: "k.csv", storage: "secondary" });
+  // empty authority (`s3:///key`) ⇒ default storage, incl. nested keys
+  expect(parseS3Uri("s3:///events.csv")).toEqual({ s3: "events.csv" });
+  expect(parseS3Uri("s3:///raw/2026/events.csv")).toEqual({ s3: "raw/2026/events.csv" });
+  // named storage with a nested key
+  expect(parseS3Uri("s3://secondary/raw/2026/events.csv")).toEqual({
+    s3: "raw/2026/events.csv",
+    storage: "secondary",
+  });
+  // no `/` after the scheme → no authority; whole rest is the default-storage key
+  expect(parseS3Uri("s3://events.csv")).toEqual({ s3: "events.csv" });
 });

--- a/cli/test/pipeline_upload_unit.test.ts
+++ b/cli/test/pipeline_upload_unit.test.ts
@@ -79,4 +79,7 @@ test("s3UriKey: whole path is the default-storage key (nested keys kept intact)"
   // a nested default-storage key must NOT be misread as a named-storage authority
   expect(s3UriKey("s3://raw/2026/events.csv")).toBe("raw/2026/events.csv");
   expect(s3UriKey("s3://events.csv")).toBe("events.csv");
+  // canonical empty-authority default form `s3:///key` → leading slash trimmed
+  expect(s3UriKey("s3:///events.csv")).toBe("events.csv");
+  expect(s3UriKey("s3:///nested/key.csv")).toBe("nested/key.csv");
 });

--- a/cli/test/pipeline_upload_unit.test.ts
+++ b/cli/test/pipeline_upload_unit.test.ts
@@ -55,12 +55,16 @@ test("s3ObjectParams: only resource-s3_object properties, in declaration order",
   expect(s3ObjectParams(undefined)).toEqual([]);
 });
 
-test("devUploadKey: deterministic folder-scoped key from the source basename", () => {
-  expect(devUploadKey("analytics", "./fixtures/events.csv")).toBe(
-    "wmilldev/pipeline/analytics/events.csv",
+test("devUploadKey: key scoped by script path + param so basenames don't clobber", () => {
+  expect(devUploadKey("f/analytics/ingest", "file", "./fixtures/events.csv")).toBe(
+    "wmilldev/pipeline/f/analytics/ingest/file/events.csv",
   );
-  expect(devUploadKey("analytics", "/abs/path/to/data.parquet")).toBe(
-    "wmilldev/pipeline/analytics/data.parquet",
+  // same basename, different script/param → distinct keys
+  expect(devUploadKey("f/analytics/other", "file", "/abs/events.csv")).toBe(
+    "wmilldev/pipeline/f/analytics/other/file/events.csv",
+  );
+  expect(devUploadKey("f/analytics/ingest", "backup", "/abs/events.csv")).toBe(
+    "wmilldev/pipeline/f/analytics/ingest/backup/events.csv",
   );
 });
 

--- a/cli/test/pipeline_upload_unit.test.ts
+++ b/cli/test/pipeline_upload_unit.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test";
+import {
+  devUploadKey,
+  parseUploadBinding,
+  s3Arg,
+  s3ObjectParams,
+} from "../src/commands/pipeline/pipelineUpload.ts";
+
+test("parseUploadBinding: bare script + local source infers the param later", () => {
+  expect(parseUploadBinding("ingest=./fixtures/events.csv")).toEqual({
+    scriptTok: "ingest",
+    source: "./fixtures/events.csv",
+  });
+});
+
+test("parseUploadBinding: explicit :param on the left", () => {
+  expect(parseUploadBinding("f/analytics/ingest:file=./events.csv")).toEqual({
+    scriptTok: "f/analytics/ingest",
+    param: "file",
+    source: "./events.csv",
+  });
+});
+
+test("parseUploadBinding: s3:// source — its `:` is right of the first `=`, so it stays intact", () => {
+  expect(parseUploadBinding("ingest=s3://bucket/2026/events.csv")).toEqual({
+    scriptTok: "ingest",
+    source: "s3://bucket/2026/events.csv",
+  });
+  expect(parseUploadBinding("ingest:file=s3://bucket/k")).toEqual({
+    scriptTok: "ingest",
+    param: "file",
+    source: "s3://bucket/k",
+  });
+});
+
+test("parseUploadBinding: malformed specs throw", () => {
+  expect(() => parseUploadBinding("ingest")).toThrow(); // no `=`
+  expect(() => parseUploadBinding("=./x.csv")).toThrow(); // no script
+  expect(() => parseUploadBinding("ingest=")).toThrow(); // no source
+  expect(() => parseUploadBinding("ingest:=./x.csv")).toThrow(); // empty param
+  expect(() => parseUploadBinding(":file=./x.csv")).toThrow(); // empty script
+});
+
+test("s3ObjectParams: only resource-s3_object properties, in declaration order", () => {
+  const schema = {
+    properties: {
+      note: { type: "string" },
+      file: { type: "object", format: "resource-s3_object" },
+      db: { type: "object", format: "resource-postgresql" },
+      backup: { type: "object", format: "resource-s3_object" },
+    },
+  };
+  expect(s3ObjectParams(schema)).toEqual(["file", "backup"]);
+  expect(s3ObjectParams({})).toEqual([]);
+  expect(s3ObjectParams(undefined)).toEqual([]);
+});
+
+test("devUploadKey: deterministic folder-scoped key from the source basename", () => {
+  expect(devUploadKey("analytics", "./fixtures/events.csv")).toBe(
+    "wmilldev/pipeline/analytics/events.csv",
+  );
+  expect(devUploadKey("analytics", "/abs/path/to/data.parquet")).toBe(
+    "wmilldev/pipeline/analytics/data.parquet",
+  );
+});
+
+test("s3Arg: shapes the S3Object run-arg", () => {
+  expect(s3Arg("file", "wmilldev/pipeline/analytics/events.csv")).toEqual({
+    file: { s3: "wmilldev/pipeline/analytics/events.csv" },
+  });
+});

--- a/cli/test/pipeline_upload_unit.test.ts
+++ b/cli/test/pipeline_upload_unit.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "bun:test";
 import {
   devUploadKey,
-  parseS3Uri,
   parseUploadBinding,
   s3Arg,
   s3ObjectParams,
+  s3UriKey,
 } from "../src/commands/pipeline/pipelineUpload.ts";
 
 test("parseUploadBinding: bare script + local source infers the param later", () => {
@@ -70,22 +70,13 @@ test("devUploadKey: key scoped by script path + param so basenames don't clobber
 });
 
 test("s3Arg: shapes the S3Object run-arg", () => {
-  expect(s3Arg("file", { s3: "wmilldev/pipeline/analytics/events.csv" })).toEqual({
+  expect(s3Arg("file", "wmilldev/pipeline/analytics/events.csv")).toEqual({
     file: { s3: "wmilldev/pipeline/analytics/events.csv" },
-  });
-  expect(s3Arg("file", { s3: "k", storage: "secondary" })).toEqual({
-    file: { s3: "k", storage: "secondary" },
   });
 });
 
-test("parseS3Uri: authority is the named storage (empty ⇒ default)", () => {
-  // named storage: s3://<storage>/<key>
-  expect(parseS3Uri("s3://secondary/2026/events.csv")).toEqual({
-    s3: "2026/events.csv",
-    storage: "secondary",
-  });
-  // empty authority ⇒ default storage
-  expect(parseS3Uri("s3:///events.csv")).toEqual({ s3: "events.csv" });
-  // no `/` after the scheme → no authority to name a storage; whole rest is the key
-  expect(parseS3Uri("s3://events.csv")).toEqual({ s3: "events.csv" });
+test("s3UriKey: whole path is the default-storage key (nested keys kept intact)", () => {
+  // a nested default-storage key must NOT be misread as a named-storage authority
+  expect(s3UriKey("s3://raw/2026/events.csv")).toBe("raw/2026/events.csv");
+  expect(s3UriKey("s3://events.csv")).toBe("events.csv");
 });

--- a/cli/test/pipeline_upload_unit.test.ts
+++ b/cli/test/pipeline_upload_unit.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import {
   devUploadKey,
+  parseS3Uri,
   parseUploadBinding,
   s3Arg,
   s3ObjectParams,
@@ -69,7 +70,22 @@ test("devUploadKey: key scoped by script path + param so basenames don't clobber
 });
 
 test("s3Arg: shapes the S3Object run-arg", () => {
-  expect(s3Arg("file", "wmilldev/pipeline/analytics/events.csv")).toEqual({
+  expect(s3Arg("file", { s3: "wmilldev/pipeline/analytics/events.csv" })).toEqual({
     file: { s3: "wmilldev/pipeline/analytics/events.csv" },
   });
+  expect(s3Arg("file", { s3: "k", storage: "secondary" })).toEqual({
+    file: { s3: "k", storage: "secondary" },
+  });
+});
+
+test("parseS3Uri: authority is the named storage (empty ⇒ default)", () => {
+  // named storage: s3://<storage>/<key>
+  expect(parseS3Uri("s3://secondary/2026/events.csv")).toEqual({
+    s3: "2026/events.csv",
+    storage: "secondary",
+  });
+  // empty authority ⇒ default storage
+  expect(parseS3Uri("s3:///events.csv")).toEqual({ s3: "events.csv" });
+  // no `/` after the scheme → no authority to name a storage; whole rest is the key
+  expect(parseS3Uri("s3://events.csv")).toEqual({ s3: "events.csv" });
 });

--- a/docs/pipeline-local-dev.md
+++ b/docs/pipeline-local-dev.md
@@ -38,7 +38,12 @@ makes the client own the whole cascade so the backend dispatcher never double-fi
 ### Headless CLI (agentic loop) — `cli/src/commands/pipeline/`
 - `pipeline show <folder> --local` — render the DAG from working-tree files (fully offline).
 - `pipeline run <folder> --local [--from/--to/--dry-run/--json]` — run the cascade via preview of
-  local content, reusing the `boundedCascade.ts` topo/lineage engine.
+  local content, reusing the `boundedCascade.ts` topo/lineage engine. Scripts whose only trigger
+  needs caller input or per-event fanout (`data_upload`/`webhook`/kafka/…) are skipped by default.
+- `pipeline run … --upload <script>[:<param>]=<local-file|s3://key>` — bind an object to a
+  `data_upload`/`webhook` entry point so it (and its downstream) runs: a local path is uploaded to
+  the workspace store, an `s3://` source is used as-is, and the target S3Object arg is inferred when
+  the script declares exactly one (else name it with `:<param>`). Repeatable.
 - `pipeline docs <folder> [--local]` — write `PIPELINE.md` + `AGENTS.md`/`CLAUDE.md` pointers
   (graph + datatable schemas) so an editor/agent has the same context the UI surfaces.
 

--- a/docs/pipeline-local-dev.md
+++ b/docs/pipeline-local-dev.md
@@ -1,8 +1,10 @@
 # Local development for Data Pipelines
 
-Status: **first iteration, draft PR.** Headless CLI paths verified offline + unit-tested;
-the live browser preview (`pipeline dev` → `/pipeline_dev`) is implemented but **not yet
-exercised against a running stack**. This document is the handoff for continuing the work.
+Status: **draft PR, validated end-to-end.** Both the headless CLI paths and the live browser
+preview (`pipeline dev` → `/pipeline_dev`) have been exercised against a running EE + MinIO
+stack — headless `pipeline run --local`, browser `Run` / `Run + downstream` cascades writing
+real assets, live-reload on save, failure/cascade UX, parameterized run-forms, and the
+`--frontend` flag. This document captures the design and the remaining follow-ups.
 
 ## What & why
 
@@ -112,21 +114,21 @@ cd ~/pl-demo && wmilld pipeline dev demo_pipeline --no-open
 ## Validation status
 
 - ✅ `pipeline show --local` verified offline against a fixture (renders a connected DAG).
-- ✅ `localGraph` unit tests (3) + all 883 CLI unit tests pass.
-- ✅ CLI `tsc` clean (pipeline files); frontend `npm run check` 0 errors; svelte-autofixer clean.
+- ✅ `localGraph` unit tests (7) + the CLI suite pass; CLI `tsc` clean; frontend `npm run check`
+  0 errors on changed files; svelte-autofixer clean.
 - ✅ CLI agent docs regenerated.
-- ❌ Live `pipeline dev` → `/pipeline_dev` browser preview **NOT exercised** against a running stack
-  (no backend/frontend was available). No PR screenshots captured for the same reason.
+- ✅ Live `pipeline dev` → `/pipeline_dev` browser preview **exercised against a running EE + MinIO
+  stack**: graph render + live-reload on save, single-node `Run` and `Run + downstream` cascades
+  writing real assets, parameterized run-forms, failure/cascade UX, responsive layout, and the
+  `--frontend` flag. Screenshots in the PR body.
 
 ## TODO for the takeover agent
 
-1. **Verify the browser preview end-to-end** (Playwright per AGENTS.md): bring up a stack, run
-   `pipeline dev`, confirm the graph matches the UI, a save live-reloads, and Run executes the
-   cascade. Attach screenshots to the PR.
-2. **Dev-page route reachability on remotes**: `/pipeline_dev` must be served by the frontend the
-   user actually opens. Either (a) document the local-frontend workflow, or (b) add a
-   `--dev-url`/`--frontend <origin>` flag to `pipeline dev` so the opened URL can target a local
-   frontend while the API/token stay pointed at the remote.
+(Items 1–2 below are **done**; left here for context.)
+
+1. ~~Verify the browser preview end-to-end~~ — done (see Validation status; screenshots in PR).
+2. ~~Dev-page route reachability on remotes~~ — done: added `--frontend <origin>` so `pipeline dev`
+   can open the page on a locally-run frontend while the API/token target the remote.
 3. **Route-page dedup**: optionally refactor `frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte`
    to consume `cascadeRun.ts` (its `launchCascadeScript`/`runDraftAwareCascade`/`waitJobTerminal`
    are the source of the extraction) — eliminates duplication. Keep behavior identical.

--- a/docs/pipeline-local-dev.md
+++ b/docs/pipeline-local-dev.md
@@ -40,10 +40,11 @@ makes the client own the whole cascade so the backend dispatcher never double-fi
 - `pipeline run <folder> --local [--from/--to/--dry-run/--json]` — run the cascade via preview of
   local content, reusing the `boundedCascade.ts` topo/lineage engine. Scripts whose only trigger
   needs caller input or per-event fanout (`data_upload`/`webhook`/kafka/…) are skipped by default.
-- `pipeline run … --upload <script>[:<param>]=<local-file|s3://key>` — bind an object to a
+- `pipeline run … --upload <script>[:<param>]=<local-file|s3://storage/key>` — bind an object to a
   `data_upload`/`webhook` entry point so it (and its downstream) runs: a local path is uploaded to
-  the workspace store, an `s3://` source is used as-is, and the target S3Object arg is inferred when
-  the script declares exactly one (else name it with `:<param>`). Repeatable.
+  the workspace store; an `s3://<storage>/<key>` source binds an existing object (authority = named
+  storage, `s3:///key` for the default store). The target S3Object arg is inferred when the script
+  declares exactly one (else name it with `:<param>`). Repeatable.
 - `pipeline docs <folder> [--local]` — write `PIPELINE.md` + `AGENTS.md`/`CLAUDE.md` pointers
   (graph + datatable schemas) so an editor/agent has the same context the UI surfaces.
 

--- a/docs/pipeline-local-dev.md
+++ b/docs/pipeline-local-dev.md
@@ -102,13 +102,18 @@ wmilld pipeline docs demo_pipeline
 ```
 Or pull real pipelines: `wmilld sync pull --yes && wmilld pipeline list && wmilld pipeline show <folder> --local`.
 
-Browser preview: the `/pipeline_dev` route isn't deployed to remotes yet, so the URL `pipeline dev`
-auto-opens (`<remote>/pipeline_dev?…`) 404s on internal. Test it by running THIS branch's frontend
-locally and opening the localhost URL:
+Browser preview: against a remote whose deployed frontend predates the `/pipeline_dev` route, the
+auto-opened `<remote>/pipeline_dev?…` 404s. Run THIS branch's frontend locally and point the dev
+page at it with `--frontend`:
 ```
 cd frontend && REMOTE=https://internal.windmill.dev npm run dev      # or a local backend
-cd ~/pl-demo && wmilld pipeline dev demo_pipeline --no-open
-# open http://localhost:3000/pipeline_dev?workspace=data-pipelines&wm_token=<TOK>&folder=demo_pipeline&port=3201
+cd ~/pl-demo && wmilld pipeline dev demo_pipeline --frontend http://localhost:3000
+```
+`pipeline dev` then opens (and prints) the full URL — **copy that printed URL**, don't hand-write it.
+It carries both `wm_token` (workspace auth) and `ws_token` (the per-session WS token); the dev
+server rejects the WebSocket without `ws_token`, so the page would sit disconnected:
+```
+http://localhost:3000/pipeline_dev?workspace=<WS>&wm_token=<TOK>&folder=demo_pipeline&port=3201&ws_token=<WS_TOK>
 ```
 
 ## Validation status

--- a/docs/pipeline-local-dev.md
+++ b/docs/pipeline-local-dev.md
@@ -1,0 +1,143 @@
+# Local development for Data Pipelines
+
+Status: **first iteration, draft PR.** Headless CLI paths verified offline + unit-tested;
+the live browser preview (`pipeline dev` → `/pipeline_dev`) is implemented but **not yet
+exercised against a running stack**. This document is the handoff for continuing the work.
+
+## What & why
+
+Windmill "data pipelines" are folders of scripts marked with a `// pipeline` comment, wired
+together by asset annotations (`// on <asset-uri>`, `// partitioned`, `// schedule`). Until now
+they could only be built/run in the browser at `/pipeline/<folder>` (the `PipelineGraphEditor`),
+and the CLI only inspected/ran the **deployed** workspace (`wmill pipeline list|show|run`).
+
+This adds the **local edit → preview → run** loop, the pipeline analog of `wmill dev`
+(flows/scripts) and `wmill app dev` (raw apps), usable both from a code editor and from an
+agentic loop — building a pipeline from working-tree files, seeing the same graph the UI shows,
+and running it, all **without deploying**.
+
+## The key design decision (no backend changes)
+
+Full body inference is obtained in the CLI from the **same wasm the frontend uses**:
+`windmill-parser-wasm-asset` (`parse_assets_ts | parse_assets_py | parse_assets_sql`). That wasm
+returns the entire serialized Rust `ParseAssetsOutput` — `assets` (with `r`/`w`/`rw` access)
+**and** the parsed pipeline annotations (`in_pipeline`, `triggers`, `partition`, …) in one call.
+The CLI already loads sibling wasm parsers via `loadParser()`; we just added the `-asset` dep.
+
+Running local content reuses the existing preview API:
+`runScriptPreview({ content, language, path, args: { _wmill_skip_asset_dispatch: true }, temp_script_refs })`
+per node in topological order. Data flows through real asset storage; `_wmill_skip_asset_dispatch`
+makes the client own the whole cascade so the backend dispatcher never double-fires.
+
+⇒ No new backend endpoint, no Rust changes, no TS re-port of the annotation parser.
+
+## Surfaces
+
+### Headless CLI (agentic loop) — `cli/src/commands/pipeline/`
+- `pipeline show <folder> --local` — render the DAG from working-tree files (fully offline).
+- `pipeline run <folder> --local [--from/--to/--dry-run/--json]` — run the cascade via preview of
+  local content, reusing the `boundedCascade.ts` topo/lineage engine.
+- `pipeline docs <folder> [--local]` — write `PIPELINE.md` + `AGENTS.md`/`CLAUDE.md` pointers
+  (graph + datatable schemas) so an editor/agent has the same context the UI surfaces.
+
+### Browser live-preview — `pipeline dev` + `/pipeline_dev`
+- `pipeline dev [folder]` — folder arg or cwd auto-detect; watches the folder, rebuilds the graph
+  on each save, pushes `{type:'pipeline', folder, graph, scripts, temp_script_refs}` over a
+  WebSocket (direct mode, default port 3201), opens the dev page.
+- `/pipeline_dev` route → `PipelineDevView.svelte` renders the **same** `PipelineGraphEditor`
+  (mode `view`) fed by the pushed graph; runs the cascade via preview. Editing stays in the
+  user's editor; each save live-reloads.
+
+## Files
+
+**New**
+- `cli/src/commands/pipeline/localGraph.ts` — the enabler. Walks `f/<folder>` scripts, wasm-infers
+  each (`parse_assets_<lang>`), assembles the `/assets/graph`-shaped payload (`runnables`,
+  `assets`, `edges`, `triggers`). Exports `buildLocalPipelineGraph`, `collectScripts`,
+  `inferScriptAssets`, `workspaceRoot`, and the canonical graph types.
+- `cli/src/commands/pipeline/docs.ts` — `pipeline docs`.
+- `cli/src/commands/pipeline/dev.ts` — `pipeline dev` watcher + WS server.
+- `cli/test/pipeline_local_graph_unit.test.ts` — unit tests for the builder.
+- `frontend/src/lib/components/assets/AssetGraph/cascadeRun.ts` — reusable run primitives
+  (`makeLaunch`, `makeWaitJobTerminal`, `runDownstreamCascade`, `runBoundedCascade`) wrapping
+  `cascadeOrchestrator` + `graphTraversal`.
+- `frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte` + `frontend/src/routes/pipeline_dev/+page.svelte`.
+
+**Modified**
+- `cli/src/commands/pipeline/pipeline.ts` — `--local` on `show`/`run`; `show` split into graph
+  acquisition + `renderGraph()` + deployed-only `enrichRootMarkers()`; registers `docs`/`dev`;
+  graph types moved to `localGraph.ts`.
+- `cli/package.json` (+ `windmill-parser-wasm-asset`), `cli/package-lock.json`.
+- `system_prompts/auto-generated/*`, `cli/src/guidance/skills.gen.ts` — regenerated via
+  `python system_prompts/generate.py` (required by AGENTS.md for CLI command changes).
+
+## Language coverage
+
+`inferScriptAssets` mirrors `frontend/src/lib/infer.ts:inferAssets`: ts (bun/deno/nativets),
+python3, and SQL dialects all get wasm inference (SQL dialects route to `parse_assets_sql`; its
+comment-header annotation scan is dialect-independent). `go`/`bash` have no wasm asset parser, so
+they fall back to a minimal `// pipeline` + `// on` scan (annotation-only). Note inferred asset
+**paths must match exactly** to connect nodes: DuckDB `read_csv('s3://x')` / `COPY ... TO 's3://x'`
+and `// on s3://x` all yield path `x` (no leading slash), whereas TS `writeS3File({s3:"x"})` yields
+`/x` — so an all-DuckDB example connects cleanly; mixing TS-write with annotation-read needs care.
+
+## How to test
+
+Run the CLI from source (`alias wmilld='bun run /home/rfiszel/windmill/cli/src/main.ts'`).
+
+Headless (works directly against any remote, e.g. internal.windmill.dev / `data-pipelines`):
+```
+wmilld workspace add internal data-pipelines https://internal.windmill.dev/   # paste a token
+# build an example (connected all-DuckDB DAG):
+mkdir -p ~/pl-demo/f/demo_pipeline && cd ~/pl-demo && printf 'defaultTs: bun\n' > wmill.yaml
+#   ingest.duckdb.sql:    -- pipeline\nCOPY (SELECT 1 id,'a' name) TO 's3://demo/raw.csv';
+#   transform.duckdb.sql: -- pipeline\n-- on s3://demo/raw.csv\nCOPY (SELECT * FROM read_csv('s3://demo/raw.csv')) TO 's3://demo/clean.csv';
+#   report.duckdb.sql:    -- pipeline\n-- on s3://demo/clean.csv\nSELECT count(*) FROM read_csv('s3://demo/clean.csv');
+wmilld pipeline show demo_pipeline --local
+wmilld pipeline run  demo_pipeline --local --dry-run
+wmilld pipeline run  demo_pipeline --local          # writes real s3 assets; needs object storage
+wmilld pipeline docs demo_pipeline
+```
+Or pull real pipelines: `wmilld sync pull --yes && wmilld pipeline list && wmilld pipeline show <folder> --local`.
+
+Browser preview: the `/pipeline_dev` route isn't deployed to remotes yet, so the URL `pipeline dev`
+auto-opens (`<remote>/pipeline_dev?…`) 404s on internal. Test it by running THIS branch's frontend
+locally and opening the localhost URL:
+```
+cd frontend && REMOTE=https://internal.windmill.dev npm run dev      # or a local backend
+cd ~/pl-demo && wmilld pipeline dev demo_pipeline --no-open
+# open http://localhost:3000/pipeline_dev?workspace=data-pipelines&wm_token=<TOK>&folder=demo_pipeline&port=3201
+```
+
+## Validation status
+
+- ✅ `pipeline show --local` verified offline against a fixture (renders a connected DAG).
+- ✅ `localGraph` unit tests (3) + all 883 CLI unit tests pass.
+- ✅ CLI `tsc` clean (pipeline files); frontend `npm run check` 0 errors; svelte-autofixer clean.
+- ✅ CLI agent docs regenerated.
+- ❌ Live `pipeline dev` → `/pipeline_dev` browser preview **NOT exercised** against a running stack
+  (no backend/frontend was available). No PR screenshots captured for the same reason.
+
+## TODO for the takeover agent
+
+1. **Verify the browser preview end-to-end** (Playwright per AGENTS.md): bring up a stack, run
+   `pipeline dev`, confirm the graph matches the UI, a save live-reloads, and Run executes the
+   cascade. Attach screenshots to the PR.
+2. **Dev-page route reachability on remotes**: `/pipeline_dev` must be served by the frontend the
+   user actually opens. Either (a) document the local-frontend workflow, or (b) add a
+   `--dev-url`/`--frontend <origin>` flag to `pipeline dev` so the opened URL can target a local
+   frontend while the API/token stay pointed at the remote.
+3. **Route-page dedup**: optionally refactor `frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte`
+   to consume `cascadeRun.ts` (its `launchCascadeScript`/`runDraftAwareCascade`/`waitJobTerminal`
+   are the source of the extraction) — eliminates duplication. Keep behavior identical.
+4. **Proxy mode for `pipeline dev`**: currently direct-mode only. Port `dev/dev.ts`'s
+   `startProxyServer` for embedders that need a localhost origin (e.g. Claude Code preview).
+5. **`pipeline dev` editing**: the dev page is view+run only (editing stays in the user's editor).
+   If in-browser editing with file round-trip is wanted, mirror flow-dev's `handleFlowRoundTrip`.
+6. **Asset-path normalization**: the TS-write leading-slash vs annotation/DuckDB no-slash mismatch
+   (see Language coverage) is inherited from the wasm/backend inference, not introduced here, but
+   it silently breaks lineage connection across languages — worth normalizing in the parser.
+
+## Plan reference
+
+Original plan: `/home/rfiszel/.claude/plans/tingly-wandering-whistle.md` (local to the author).

--- a/docs/pipeline-local-dev.md
+++ b/docs/pipeline-local-dev.md
@@ -98,7 +98,7 @@ mkdir -p ~/pl-demo/f/demo_pipeline && cd ~/pl-demo && printf 'defaultTs: bun\n' 
 wmilld pipeline show demo_pipeline --local
 wmilld pipeline run  demo_pipeline --local --dry-run
 wmilld pipeline run  demo_pipeline --local          # writes real s3 assets; needs object storage
-wmilld pipeline docs demo_pipeline
+wmilld pipeline docs demo_pipeline --local   # --local: document the working tree (default path queries the deployed graph)
 ```
 Or pull real pipelines: `wmilld sync pull --yes && wmilld pipeline list && wmilld pipeline show <folder> --local`.
 

--- a/frontend/src/lib/components/JobArgs.svelte
+++ b/frontend/src/lib/components/JobArgs.svelte
@@ -29,13 +29,21 @@
 	// dispatcher. Not a real input: shown as a badge instead of a table row,
 	// but kept in the expanded JSON drawer and download.
 	const SKIP_ASSET_DISPATCH_ARG = '_wmill_skip_asset_dispatch'
+	// Internal map (path -> content digest) injected by local-dev previews so
+	// relative imports resolve from not-yet-deployed local content. Same
+	// treatment: badge, not a noisy table row.
+	const TEMP_SCRIPT_REFS_ARG = '_TEMP_SCRIPT_REFS'
+	const INTERNAL_ARGS = [SKIP_ASSET_DISPATCH_ARG, TEMP_SCRIPT_REFS_ARG]
 
 	let skippedAssetDispatch = $derived(
 		args != undefined && typeof args === 'object' && args[SKIP_ASSET_DISPATCH_ARG] === true
 	)
+	let hasTempScriptRefs = $derived(
+		args != undefined && typeof args === 'object' && args[TEMP_SCRIPT_REFS_ARG] != undefined
+	)
 	let displayArgs = $derived(
 		args != undefined && typeof args === 'object'
-			? Object.fromEntries(Object.entries(args).filter(([k]) => k !== SKIP_ASSET_DISPATCH_ARG))
+			? Object.fromEntries(Object.entries(args).filter(([k]) => !INTERNAL_ARGS.includes(k)))
 			: args
 	)
 
@@ -102,6 +110,15 @@ ${Object.entries(displayArgs)
 								title="This run was started with {SKIP_ASSET_DISPATCH_ARG} and did not auto-trigger downstream asset consumers"
 							>
 								asset dispatch skipped
+							</Badge>
+						{/if}
+						{#if hasTempScriptRefs}
+							<Badge
+								color="gray"
+								verySmall
+								title="This preview carried {TEMP_SCRIPT_REFS_ARG} so relative imports resolve from local (not-yet-deployed) script content"
+							>
+								local import refs
 							</Badge>
 						{/if}
 					</Cell>

--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
@@ -159,6 +159,9 @@
 			bounded: ReadonlySet<string>
 		}
 		onPickEnd?: (canvasNodeId: string) => void
+		/** Hide the minimap when the canvas is too narrow for it to be worth the
+		 * space (e.g. stacked layout in a side panel). Defaults to shown. */
+		showMinimap?: boolean
 	}
 	let {
 		graph,
@@ -184,7 +187,8 @@
 		validStartPaths,
 		onStartBoundedRun,
 		boundPick,
-		onPickEnd
+		onPickEnd,
+		showMinimap = true
 	}: Props = $props()
 
 	// `${kind}:${path}` ids for the hovered / pinned runs (both script and flow
@@ -1021,19 +1025,21 @@
 		<div class="absolute inset-0 !bg-surface-secondary h-full"></div>
 		<PanToNode targetId={panToNodeId} {nodes} />
 		<Controls position="top-right" orientation="horizontal" showLock={false} class="!mr-10" />
-		<MiniMap
-			pannable
-			zoomable
-			class="!bg-surface !mb-10"
-			nodeColor={(n) =>
-				n.type === 'asset'
-					? 'rgb(96 165 250 / 0.5)'
-					: n.type === 'trigger'
-						? 'rgb(251 191 36 / 0.5)'
-						: 'rgb(52 211 153 / 0.5)'}
-			nodeStrokeColor="transparent"
-			maskColor="rgb(0 0 0 / 0.2)"
-		/>
+		{#if showMinimap}
+			<MiniMap
+				pannable
+				zoomable
+				class="!bg-surface !mb-10"
+				nodeColor={(n) =>
+					n.type === 'asset'
+						? 'rgb(96 165 250 / 0.5)'
+						: n.type === 'trigger'
+							? 'rgb(251 191 36 / 0.5)'
+							: 'rgb(52 211 153 / 0.5)'}
+				nodeStrokeColor="transparent"
+				maskColor="rgb(0 0 0 / 0.2)"
+			/>
+		{/if}
 	</SvelteFlow>
 </div>
 

--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphDetailsPane.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphDetailsPane.svelte
@@ -55,6 +55,11 @@
 		// which is intentionally not-runnable until deployed). May be async so the
 		// caller can infer the args schema for the run form.
 		resolveLocalScript?: (path: string) => Script | undefined | Promise<Script | undefined>
+		// Bump this whenever `resolveLocalScript`'s backing content changes (a
+		// `pipeline dev` live-reload pushes a new bundle). It's in the `scriptRes`
+		// key so the open pane re-resolves the selected node's source even though
+		// `selection` is unchanged — otherwise the pane sticks on stale content.
+		localScriptsVersion?: unknown
 		workspace: string
 		onclose: () => void
 		// Optional: dismiss the pane while preserving the current selection /
@@ -227,6 +232,7 @@
 		selection,
 		draftScript,
 		resolveLocalScript,
+		localScriptsVersion,
 		workspace,
 		onclose,
 		onHide,
@@ -398,7 +404,7 @@
 	// When `draftScript` is provided we bypass the fetch entirely and edit
 	// it locally; saving calls ScriptService.createScript to deploy it.
 	let scriptRes = resource(
-		[() => workspace, () => selection, () => draftScript],
+		[() => workspace, () => selection, () => draftScript, () => localScriptsVersion],
 		async ([ws, sel, draft]) => {
 			if (draft) return undefined
 			if (!sel || sel.kind !== 'runnable' || sel.runnable_kind !== 'script') return undefined

--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphDetailsPane.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphDetailsPane.svelte
@@ -48,6 +48,12 @@
 		// `selection` when present. Used by the pipeline + menu so a new
 		// pipeline script opens inline instead of navigating to /scripts/add.
 		draftScript?: Script | undefined
+		// Local-dev preview (`/pipeline_dev`): resolve a selected node to its
+		// working-tree content instead of fetching the deployed script (there is
+		// none — the pipeline is local-only). Returns a read-only `Script` so the
+		// pane renders the source + an ENABLED Run button (unlike `draftScript`,
+		// which is intentionally not-runnable until deployed).
+		resolveLocalScript?: (path: string) => Script | undefined
 		workspace: string
 		onclose: () => void
 		// Optional: dismiss the pane while preserving the current selection /
@@ -219,6 +225,7 @@
 	let {
 		selection,
 		draftScript,
+		resolveLocalScript,
 		workspace,
 		onclose,
 		onHide,
@@ -394,6 +401,9 @@
 		async ([ws, sel, draft]) => {
 			if (draft) return undefined
 			if (!sel || sel.kind !== 'runnable' || sel.runnable_kind !== 'script') return undefined
+			// Local-dev: serve the working-tree script (no deployed row exists).
+			const local = resolveLocalScript?.(sel.path)
+			if (local) return local
 			return await ScriptService.getScriptByPath({ workspace: ws, path: sel.path })
 		}
 	)

--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphDetailsPane.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphDetailsPane.svelte
@@ -227,6 +227,10 @@
 		// NO _wmill_skip_asset_dispatch, so the backend asset-trigger
 		// dispatcher cascades downstream for real.
 		onRunByPath?: (path: string, args: Record<string, any>) => Promise<string | undefined>
+		// Run the open script AND its downstream closure with the form args (dev
+		// preview only — the client orchestrates the chain). Unset on the deployed
+		// pane, whose single run already cascades via the backend dispatcher.
+		onRunCascadeByPath?: (path: string, args: Record<string, any>) => Promise<string | undefined>
 	}
 	let {
 		selection,
@@ -264,7 +268,8 @@
 		mode = 'edit',
 		onRequestEdit,
 		canRunByPath = false,
-		onRunByPath
+		onRunByPath,
+		onRunCascadeByPath
 	}: Props = $props()
 
 	let readOnly = $derived(mode !== 'edit')
@@ -1108,6 +1113,8 @@
 					{isDraft}
 					canRun={canRunByPath}
 					onRun={onRunByPath}
+					onRunCascade={onRunCascadeByPath}
+					downstreamCount={downstreamSubscribers}
 					{runsRefreshKey}
 					{runsPendingJobId}
 					onRunCompleted={() => {

--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphDetailsPane.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphDetailsPane.svelte
@@ -52,8 +52,9 @@
 		// working-tree content instead of fetching the deployed script (there is
 		// none — the pipeline is local-only). Returns a read-only `Script` so the
 		// pane renders the source + an ENABLED Run button (unlike `draftScript`,
-		// which is intentionally not-runnable until deployed).
-		resolveLocalScript?: (path: string) => Script | undefined
+		// which is intentionally not-runnable until deployed). May be async so the
+		// caller can infer the args schema for the run form.
+		resolveLocalScript?: (path: string) => Script | undefined | Promise<Script | undefined>
 		workspace: string
 		onclose: () => void
 		// Optional: dismiss the pane while preserving the current selection /
@@ -402,7 +403,7 @@
 			if (draft) return undefined
 			if (!sel || sel.kind !== 'runnable' || sel.runnable_kind !== 'script') return undefined
 			// Local-dev: serve the working-tree script (no deployed row exists).
-			const local = resolveLocalScript?.(sel.path)
+			const local = await resolveLocalScript?.(sel.path)
 			if (local) return local
 			return await ScriptService.getScriptByPath({ workspace: ws, path: sel.path })
 		}

--- a/frontend/src/lib/components/assets/AssetGraph/PartitionStatusGrid.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PartitionStatusGrid.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { resource } from 'runed'
-	import { OpenAPI } from '$lib/gen'
+	import { OpenAPI, AssetService, type MaterializedPartition } from '$lib/gen'
 	import { Button } from '$lib/components/common'
 	import { Loader2, RefreshCw, History } from 'lucide-svelte'
 	import { sendUserToast } from '$lib/utils'
@@ -13,23 +13,9 @@
 	}
 	let { path, workspace }: Props = $props()
 
-	type MaterializedPartition = {
-		partition: string
-		status: 'running' | 'materialized' | 'failed'
-		snapshot_id?: number | null
-		row_count?: number | null
-		materialized_at: string
-		error?: string | null
-	}
-
-	let partitions = resource([() => workspace, () => path], async ([ws, p], _prev, { signal }) => {
+	let partitions = resource([() => workspace, () => path], async ([ws, p]) => {
 		if (!ws || !p) return [] as MaterializedPartition[]
-		const res = await fetch(
-			`${OpenAPI.BASE ?? ''}/w/${ws}/assets/partitions?path=${encodeURIComponent(p)}`,
-			{ credentials: 'include', signal }
-		)
-		if (!res.ok) throw new Error(`GET /assets/partitions → ${res.status}`)
-		return (await res.json()) as MaterializedPartition[]
+		return await AssetService.listAssetPartitions({ workspace: ws, path: p })
 	})
 
 	let backfillOpen = $state(false)
@@ -42,11 +28,16 @@
 
 	async function onBackfill(from: string, to: string) {
 		// The fan-out runner is an enterprise feature; the dialog only submits
-		// when licensed. This posts the intent to the (EE) backfill endpoint.
+		// when licensed. This posts the intent to the (EE) backfill endpoint — a raw
+		// fetch since it's not in the OSS OpenAPI, so carry the bearer token
+		// explicitly (matches how `/pipeline_dev` authenticates: no session cookie).
+		const token = OpenAPI.TOKEN
+		const authHeader: Record<string, string> =
+			typeof token === 'string' && token ? { Authorization: `Bearer ${token}` } : {}
 		const res = await fetch(`${OpenAPI.BASE ?? ''}/w/${workspace}/assets/backfill`, {
 			method: 'POST',
 			credentials: 'include',
-			headers: { 'content-type': 'application/json' },
+			headers: { 'content-type': 'application/json', ...authHeader },
 			body: JSON.stringify({ path, from, to })
 		})
 		if (!res.ok) throw new Error(`backfill → ${res.status}`)

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineActivityPanel.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineActivityPanel.svelte
@@ -36,8 +36,12 @@
 		// History preload hit its page cap before the days cutoff.
 		truncated?: boolean
 		error?: string | undefined
-		days: number
-		onDaysChange: (days: number) => void
+		days?: number
+		onDaysChange?: (days: number) => void
+		// Live-only surfaces (local-dev preview) have no historical fetch: hide
+		// the day-range Select + histogram (both are history-window concepts) and
+		// show only the live run stream.
+		liveOnly?: boolean
 		// Hover a run row → emphasize its node(s) on the canvas; a group header
 		// passes the whole cascade's paths. `undefined` clears.
 		onHoverRun?: (paths: string[] | undefined) => void
@@ -51,8 +55,9 @@
 		loading = false,
 		truncated = false,
 		error,
-		days,
+		days = 30,
 		onDaysChange,
+		liveOnly = false,
 		onHoverRun,
 		onSelectRun
 	}: Props = $props()
@@ -99,7 +104,7 @@
 	// Quick reset: drop the brush and return to the default 30-day window.
 	function resetWindow() {
 		selectedRange = undefined
-		if (days !== 30) onDaysChange(30)
+		if (days !== 30) onDaysChange?.(30)
 	}
 	function fmtRange(r: { from: number; to: number }): string {
 		const opt: Intl.DateTimeFormatOptions = {
@@ -236,7 +241,9 @@
 		{ label: 'Last 30 days', value: 30 },
 		{ label: 'Last 90 days', value: 90 }
 	]
-	let windowLabel = $derived(DAY_OPTIONS.find((o) => o.value === days)?.label ?? `Last ${days} days`)
+	let windowLabel = $derived(
+		DAY_OPTIONS.find((o) => o.value === days)?.label ?? `Last ${days} days`
+	)
 
 	// Excludes future-scheduled queued jobs (a schedule's next planned run
 	// is not activity) — see isActiveEvent.
@@ -341,17 +348,19 @@
 				<Loader2 size={12} class="animate-spin text-tertiary" />
 			{/if}
 		</span>
-		<div class="w-36 shrink-0">
-			<Select
-				items={DAY_OPTIONS}
-				size="sm"
-				clearable={false}
-				bind:value={() => days, (v) => onDaysChange(v ?? 30)}
-			/>
-		</div>
+		{#if !liveOnly}
+			<div class="w-36 shrink-0">
+				<Select
+					items={DAY_OPTIONS}
+					size="sm"
+					clearable={false}
+					bind:value={() => days, (v) => onDaysChange?.(v ?? 30)}
+				/>
+			</div>
+		{/if}
 	</div>
 
-	{#if events.length > 0}
+	{#if events.length > 0 && !liveOnly}
 		<div class="border-b shrink-0">
 			<ActivityHistogram
 				{events}
@@ -390,8 +399,12 @@
 				</div>
 			{:else}
 				<div class="px-3 py-6 text-center text-xs text-tertiary">
-					No runs in this window ({windowLabel.toLowerCase()}) — executions of this pipeline will
-					appear here live.
+					{#if liveOnly}
+						No runs yet — executions of this pipeline will appear here live.
+					{:else}
+						No runs in this window ({windowLabel.toLowerCase()}) — executions of this pipeline will
+						appear here live.
+					{/if}
 				</div>
 			{/if}
 		{:else}
@@ -555,7 +568,8 @@
 								title={`Join fed by ${g.extraTriggers + 1} triggers`}>+{g.extraTriggers}</span
 							>
 						{/if}
-						<span class="shrink-0 text-3xs text-tertiary tabular-nums">{g.members.length} runs</span>
+						<span class="shrink-0 text-3xs text-tertiary tabular-nums">{g.members.length} runs</span
+						>
 						<span class="shrink-0 text-3xs text-tertiary tabular-nums w-14 text-right">
 							{ago(g.latestAt)}
 						</span>

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte
@@ -7,6 +7,7 @@
 	import { PipelineEditorState } from './pipelineEditorState.svelte'
 	import { useActiveRunnableIds } from './activeRunnables.svelte'
 	import { makeLaunch, makeWaitJobTerminal, runDownstreamCascade } from './cascadeRun'
+	import { assetProducers } from './graphTraversal'
 	import type { AssetGraphResponse, AssetGraphSelection } from './types'
 	import { JobService, OpenAPI, type Preview, type Script } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
@@ -72,23 +73,11 @@
 	const pathPrefix = $derived(`f/${folder}/`)
 
 	// Producers of the selected asset — the local scripts that write it (`w`/`rw`
-	// edge, incl. the `// materialize` target). Mirrors the route page so the
-	// details pane shows the producer + its runs instead of "No producer for this
-	// asset" (which only holds for the deployed graph, absent here).
-	const selectionProducers = $derived.by(() => {
-		const sel = pe.selection
-		if (!sel || sel.kind !== 'asset') return []
-		return displayGraph.edges
-			.filter((e) => {
-				const access = e.access_type ?? 'r'
-				return (
-					(access === 'w' || access === 'rw') &&
-					e.asset_kind === sel.asset_kind &&
-					e.asset_path === sel.path
-				)
-			})
-			.map((e) => ({ kind: e.runnable_kind as 'script' | 'flow', path: e.runnable_path }))
-	})
+	// edge, incl. the `// materialize` target). Shared `assetProducers` keeps this
+	// in lockstep with the route page so the details pane shows the producer + its
+	// runs instead of "No producer for this asset" (which only holds for the
+	// deployed graph, absent here).
+	const selectionProducers = $derived(assetProducers(displayGraph, pe.selection))
 
 	// path -> pushed local content, for preview-running each node.
 	const scriptByPath = $derived(

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte
@@ -34,6 +34,9 @@
 	const workspace = sp.get('workspace') ?? undefined
 	const port = sp.get('port') ?? '3201'
 	const folder = sp.get('folder') ?? ''
+	// Per-session token gating the dev WS — the server rejects connections without
+	// it so a stray localhost page can't read the pushed script source.
+	const wsToken = sp.get('ws_token') ?? undefined
 
 	$effect.pre(() => {
 		if (token) {
@@ -153,7 +156,8 @@
 			if (disposed) return
 			wsState = 'connecting'
 			try {
-				socket = new WebSocket(`ws://localhost:${_port}/ws`)
+				const q = wsToken ? `?token=${encodeURIComponent(wsToken)}` : ''
+				socket = new WebSocket(`ws://localhost:${_port}/ws${q}`)
 			} catch {
 				scheduleReconnect()
 				return
@@ -333,6 +337,7 @@
 				onRunProducer={runProducer}
 				onRunByPath={(path, args) => runNode(path, args)}
 				{resolveLocalScript}
+				localScriptsVersion={bundle}
 				canRunByPath
 				onRunCompleted={() => {
 					activeRunnable = undefined

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte
@@ -1,0 +1,273 @@
+<script lang="ts">
+	import { untrack } from 'svelte'
+	import { Loader2, Workflow } from 'lucide-svelte'
+	import { page } from '$app/state'
+	import PipelineGraphEditor from './PipelineGraphEditor.svelte'
+	import { PipelineEditorState } from './pipelineEditorState.svelte'
+	import { useActiveRunnableIds } from './activeRunnables.svelte'
+	import { makeLaunch, makeWaitJobTerminal, runDownstreamCascade } from './cascadeRun'
+	import type { AssetGraphResponse, AssetGraphSelection } from './types'
+	import { JobService, OpenAPI, type Preview } from '$lib/gen'
+	import { workspaceStore } from '$lib/stores'
+	import { sendUserToast } from '$lib/utils'
+
+	// A local-dev pipeline preview driven by `wmill pipeline dev`. The CLI watches
+	// an `f/<folder>` of `// pipeline` scripts, builds the asset graph from the
+	// working tree, and pushes it over a WebSocket; this page renders that graph
+	// with the same editor the UI uses and runs the cascade by PREVIEWING the
+	// pushed local content (no deploy). Editing happens in the user's own editor;
+	// each save live-reloads the graph here.
+
+	type PushedScript = { path: string; content: string; language: Preview['language'] }
+	type PipelineBundle = {
+		type: 'pipeline'
+		folder: string
+		graph: AssetGraphResponse
+		scripts: PushedScript[]
+		temp_script_refs?: Record<string, string>
+	}
+
+	const sp = page.url.searchParams
+	const token = sp.get('wm_token') ?? undefined
+	const workspace = sp.get('workspace') ?? undefined
+	const port = sp.get('port') ?? '3201'
+	const folder = sp.get('folder') ?? ''
+
+	$effect.pre(() => {
+		if (token) {
+			OpenAPI.WITH_CREDENTIALS = true
+			OpenAPI.TOKEN = token
+		}
+	})
+	$effect.pre(() => {
+		if (workspace) $workspaceStore = workspace
+	})
+
+	const EMPTY_GRAPH: AssetGraphResponse = { assets: [], runnables: [], edges: [], triggers: [] }
+
+	let bundle = $state<PipelineBundle | undefined>(undefined)
+	let wsState = $state<'connecting' | 'open' | 'closed'>('connecting')
+
+	// Externalized editor state (selection only — this view has no DB drafts; the
+	// local files are the source of truth).
+	const pe = new PipelineEditorState()
+	$effect(() => {
+		const f = folder
+		untrack(() => {
+			if (pe.folder !== f) pe.folder = f
+		})
+	})
+
+	const displayGraph = $derived((bundle?.graph ?? EMPTY_GRAPH) as AssetGraphResponse)
+	const pathPrefix = $derived(`f/${folder}/`)
+
+	// path -> pushed local content, for preview-running each node.
+	const scriptByPath = $derived(
+		new Map<string, PushedScript>((bundle?.scripts ?? []).map((s) => [s.path, s]))
+	)
+
+	// Live run state (node badges + event log), shared with the route page's poll.
+	const activeRunnables = useActiveRunnableIds(
+		() => workspace,
+		() => pathPrefix
+	)
+	let activeRunnable = $state<{ kind: 'script' | 'flow'; path: string } | undefined>(undefined)
+	let activeRunnableJobId = $state<string | undefined>(undefined)
+	$effect(() => {
+		pathPrefix
+		activeRunnables.setObserving(true)
+		return () => activeRunnables.dispose()
+	})
+	$effect(() => {
+		if (!activeRunnableJobId) return
+		const ev = activeRunnables.events.find((e) => e.id === activeRunnableJobId)
+		if (ev && (ev.status === 'success' || ev.status === 'failure')) {
+			activeRunnable = undefined
+			activeRunnableJobId = undefined
+		}
+	})
+
+	function connectWs() {
+		let socket: WebSocket | undefined
+		try {
+			wsState = 'connecting'
+			socket = new WebSocket(`ws://localhost:${port}/ws`)
+			socket.addEventListener('open', () => (wsState = 'open'))
+			socket.addEventListener('close', () => (wsState = 'closed'))
+			socket.addEventListener('error', () => (wsState = 'closed'))
+			socket.addEventListener('message', (event) => {
+				try {
+					const data = JSON.parse(event.data)
+					if (data?.type === 'pipeline') bundle = data as PipelineBundle
+				} catch {
+					// ignore malformed frames
+				}
+			})
+		} catch {
+			wsState = 'closed'
+		}
+		return () => socket?.close()
+	}
+	$effect(() => connectWs())
+
+	function resolveLocal(
+		path: string
+	): { content: string; language: Preview['language'] } | undefined {
+		const s = scriptByPath.get(path)
+		return s ? { content: s.content, language: s.language } : undefined
+	}
+
+	// Run a single node as a preview of its local content. Never fans out to
+	// downstream deployed subscribers (skip-dispatch) — single-node runs stay local.
+	async function runNode(
+		nodePath: string,
+		args: Record<string, any> = {}
+	): Promise<string | undefined> {
+		const local = resolveLocal(nodePath)
+		if (!local || !workspace) {
+			sendUserToast(`No local content for ${nodePath}`, true)
+			return undefined
+		}
+		activeRunnables.arm(`script:${nodePath}`)
+		try {
+			const jobId = await JobService.runScriptPreview({
+				workspace,
+				requestBody: {
+					content: local.content,
+					language: local.language,
+					path: nodePath,
+					args: { ...args, _wmill_skip_asset_dispatch: true },
+					...(bundle?.temp_script_refs ? { temp_script_refs: bundle.temp_script_refs } : {})
+				}
+			})
+			activeRunnable = { kind: 'script', path: nodePath }
+			activeRunnableJobId = jobId
+			return jobId
+		} catch (e: any) {
+			sendUserToast(`Run failed: ${e?.body ?? e?.message ?? e}`, true)
+			return undefined
+		}
+	}
+
+	let cascadeRunningRoot = $state<string | undefined>(undefined)
+
+	// "Run + downstream" — the client orchestrates the closure (preview each node
+	// in topological order) since the backend dispatcher only resolves deployed rows.
+	async function runCascadeFrom(rootPath: string): Promise<string | undefined> {
+		if (!workspace) return undefined
+		if (cascadeRunningRoot) {
+			sendUserToast(`A chain run from ${cascadeRunningRoot} is still in progress`, true)
+			return undefined
+		}
+		cascadeRunningRoot = rootPath
+		let rootJobId: string | undefined
+		const launch = makeLaunch({
+			workspace,
+			resolveLocal,
+			tempScriptRefs: bundle?.temp_script_refs,
+			onLaunched: (p, jobId) => {
+				activeRunnables.arm(`script:${p}`)
+				if (p === rootPath) {
+					rootJobId = jobId
+					activeRunnable = { kind: 'script', path: p }
+					activeRunnableJobId = jobId
+				}
+			}
+		})
+		try {
+			const res = await runDownstreamCascade({
+				graph: displayGraph,
+				root: rootPath,
+				launch,
+				waitTerminal: makeWaitJobTerminal(workspace)
+			})
+			if (res.cyclic.length > 0) {
+				sendUserToast(
+					`Skipped ${res.cyclic.length} script(s) on a cycle: ${res.cyclic.join(', ')}`,
+					true
+				)
+			}
+			const n = res.statuses.size
+			if (res.ok) {
+				sendUserToast(`Chain run complete — ${n} script${n === 1 ? '' : 's'} succeeded`)
+			} else {
+				const failed = [...res.statuses.entries()].filter(([, s]) => s.status === 'failure')
+				sendUserToast(`Chain run failed at ${failed.map(([p]) => p).join(', ')}`, true)
+			}
+		} finally {
+			cascadeRunningRoot = undefined
+		}
+		return rootJobId
+	}
+
+	function runProducer(producer: { kind: 'script' | 'flow'; path: string; cascade?: boolean }) {
+		if (producer.kind !== 'script') return Promise.resolve(undefined)
+		return producer.cascade ? runCascadeFrom(producer.path) : runNode(producer.path)
+	}
+
+	function handleCanvasSelect(s: AssetGraphSelection | undefined) {
+		pe.selection = s
+	}
+</script>
+
+<div class="flex flex-col h-full w-full bg-surface">
+	<div
+		class="flex items-center gap-2 px-3 py-1.5 border-b border-light text-xs text-secondary shrink-0"
+	>
+		<Workflow size={14} />
+		<span class="font-mono text-emphasis truncate">f/{folder}</span>
+		<span class="text-tertiary">· local pipeline dev</span>
+		<span class="ml-auto flex items-center gap-1.5">
+			<span
+				class="inline-block w-2 h-2 rounded-full {wsState === 'open'
+					? 'bg-green-500'
+					: wsState === 'connecting'
+						? 'bg-yellow-500'
+						: 'bg-red-500'}"
+			></span>
+			<span class="text-tertiary"
+				>{wsState === 'open'
+					? 'watching'
+					: wsState === 'connecting'
+						? 'connecting…'
+						: 'disconnected'}</span
+			>
+		</span>
+	</div>
+	<div class="flex-1 min-h-0">
+		{#if !bundle}
+			<div class="h-full flex items-center justify-center gap-2 text-tertiary">
+				<Loader2 size={18} class="animate-spin" />
+				<span>Connecting to <code>wmill pipeline dev</code>…</span>
+			</div>
+		{:else if displayGraph.runnables.length === 0}
+			<div class="h-full flex items-center justify-center text-sm text-tertiary px-4 text-center">
+				No <code class="mx-1">// pipeline</code> scripts found in f/{folder}. Mark a script with a
+				bare
+				<code class="mx-1">// pipeline</code> comment.
+			</div>
+		{:else}
+			<PipelineGraphEditor
+				editor={pe}
+				{folder}
+				{displayGraph}
+				mode="view"
+				{workspace}
+				{pathPrefix}
+				{activeRunnable}
+				activeRunnableIds={activeRunnables.ids}
+				runStates={activeRunnables.states}
+				eventLogEvents={activeRunnables.events}
+				onRunProducer={runProducer}
+				onRunByPath={(path, args) => runNode(path, args)}
+				canRunByPath
+				onRunCompleted={() => {
+					activeRunnable = undefined
+					activeRunnableJobId = undefined
+				}}
+				onSelect={handleCanvasSelect}
+				onClose={() => (pe.selection = undefined)}
+			/>
+		{/if}
+	</div>
+</div>

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte
@@ -3,13 +3,14 @@
 	import { Loader2, Workflow } from 'lucide-svelte'
 	import { page } from '$app/state'
 	import PipelineGraphEditor from './PipelineGraphEditor.svelte'
+	import PipelineActivityPanel from './PipelineActivityPanel.svelte'
 	import { PipelineEditorState } from './pipelineEditorState.svelte'
 	import { useActiveRunnableIds } from './activeRunnables.svelte'
 	import { makeLaunch, makeWaitJobTerminal, runDownstreamCascade } from './cascadeRun'
 	import type { AssetGraphResponse, AssetGraphSelection } from './types'
-	import { JobService, OpenAPI, type Preview } from '$lib/gen'
+	import { JobService, OpenAPI, type Preview, type Script } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
-	import { sendUserToast } from '$lib/utils'
+	import { emptySchema, sendUserToast } from '$lib/utils'
 
 	// A local-dev pipeline preview driven by `wmill pipeline dev`. The CLI watches
 	// an `f/<folder>` of `// pipeline` scripts, builds the asset graph from the
@@ -66,6 +67,33 @@
 		new Map<string, PushedScript>((bundle?.scripts ?? []).map((s) => [s.path, s]))
 	)
 
+	// Selecting a node must render its working-tree source + Run button, NOT
+	// fetch the deployed script (this pipeline is local-only — that fetch 404s).
+	// Synthesize a read-only `Script` from the pushed content. The details pane
+	// only reads path/language/content/schema; args inference is a follow-up, so
+	// the run form starts from an empty schema (fine for no-arg DuckDB nodes).
+	function resolveLocalScript(path: string): Script | undefined {
+		const s = scriptByPath.get(path)
+		if (!s) return undefined
+		return {
+			hash: '',
+			path,
+			summary: '',
+			description: '',
+			content: s.content,
+			schema: emptySchema(),
+			is_template: false,
+			extra_perms: {},
+			language: s.language as Script['language'],
+			kind: 'script',
+			created_by: '',
+			created_at: '',
+			archived: false,
+			deleted: false,
+			starred: false
+		} as unknown as Script
+	}
+
 	// Live run state (node badges + event log), shared with the route page's poll.
 	const activeRunnables = useActiveRunnableIds(
 		() => workspace,
@@ -73,6 +101,15 @@
 	)
 	let activeRunnable = $state<{ kind: 'script' | 'flow'; path: string } | undefined>(undefined)
 	let activeRunnableJobId = $state<string | undefined>(undefined)
+
+	// Activity-panel cross-highlighting: hovering/expanding a run row emphasizes
+	// its node(s) on the canvas (same wiring the route page uses).
+	let activityHoverPaths = $state<string[]>([])
+	let activitySelectPaths = $state<string[]>([])
+
+	// Collapse the details/activity pane to give the graph full width/height —
+	// works in both side-by-side and stacked layouts.
+	let panelHidden = $state(false)
 	$effect(() => {
 		pathPrefix
 		activeRunnables.setObserving(true)
@@ -258,8 +295,13 @@
 				activeRunnableIds={activeRunnables.ids}
 				runStates={activeRunnables.states}
 				eventLogEvents={activeRunnables.events}
+				hoveredPaths={activityHoverPaths}
+				selectedRunPaths={activitySelectPaths}
+				{panelHidden}
+				onTogglePanelHidden={() => (panelHidden = !panelHidden)}
 				onRunProducer={runProducer}
 				onRunByPath={(path, args) => runNode(path, args)}
+				{resolveLocalScript}
 				canRunByPath
 				onRunCompleted={() => {
 					activeRunnable = undefined
@@ -267,7 +309,16 @@
 				}}
 				onSelect={handleCanvasSelect}
 				onClose={() => (pe.selection = undefined)}
-			/>
+			>
+				{#snippet idlePane()}
+					<PipelineActivityPanel
+						events={activeRunnables.events}
+						liveOnly
+						onHoverRun={(p) => (activityHoverPaths = p ?? [])}
+						onSelectRun={(p) => (activitySelectPaths = p ?? [])}
+					/>
+				{/snippet}
+			</PipelineGraphEditor>
 		{/if}
 	</div>
 </div>

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte
@@ -71,6 +71,25 @@
 	const displayGraph = $derived((bundle?.graph ?? EMPTY_GRAPH) as AssetGraphResponse)
 	const pathPrefix = $derived(`f/${folder}/`)
 
+	// Producers of the selected asset — the local scripts that write it (`w`/`rw`
+	// edge, incl. the `// materialize` target). Mirrors the route page so the
+	// details pane shows the producer + its runs instead of "No producer for this
+	// asset" (which only holds for the deployed graph, absent here).
+	const selectionProducers = $derived.by(() => {
+		const sel = pe.selection
+		if (!sel || sel.kind !== 'asset') return []
+		return displayGraph.edges
+			.filter((e) => {
+				const access = e.access_type ?? 'r'
+				return (
+					(access === 'w' || access === 'rw') &&
+					e.asset_kind === sel.asset_kind &&
+					e.asset_path === sel.path
+				)
+			})
+			.map((e) => ({ kind: e.runnable_kind as 'script' | 'flow', path: e.runnable_path }))
+	})
+
 	// path -> pushed local content, for preview-running each node.
 	const scriptByPath = $derived(
 		new Map<string, PushedScript>((bundle?.scripts ?? []).map((s) => [s.path, s]))
@@ -344,6 +363,7 @@
 				onRunByPath={(path, args) => runNode(path, args)}
 				{resolveLocalScript}
 				localScriptsVersion={bundle}
+				{selectionProducers}
 				canRunByPath
 				onRunCompleted={() => {
 					activeRunnable = undefined

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte
@@ -20,7 +20,12 @@
 	// pushed local content (no deploy). Editing happens in the user's own editor;
 	// each save live-reloads the graph here.
 
-	type PushedScript = { path: string; content: string; language: Preview['language'] }
+	type PushedScript = {
+		path: string
+		content: string
+		language: Preview['language']
+		tag?: string
+	}
 	type PipelineBundle = {
 		type: 'pipeline'
 		folder: string
@@ -184,9 +189,9 @@
 
 	function resolveLocal(
 		path: string
-	): { content: string; language: Preview['language'] } | undefined {
+	): { content: string; language: Preview['language']; tag?: string } | undefined {
 		const s = scriptByPath.get(path)
-		return s ? { content: s.content, language: s.language } : undefined
+		return s ? { content: s.content, language: s.language, tag: s.tag } : undefined
 	}
 
 	// Run a single node as a preview of its local content. Never fans out to
@@ -209,6 +214,7 @@
 					language: local.language,
 					path: nodePath,
 					args: { ...args, _wmill_skip_asset_dispatch: true },
+					...(local.tag ? { tag: local.tag } : {}),
 					...(bundle?.temp_script_refs ? { temp_script_refs: bundle.temp_script_refs } : {})
 				}
 			})

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte
@@ -11,6 +11,7 @@
 	import { JobService, OpenAPI, type Preview, type Script } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
 	import { emptySchema, sendUserToast } from '$lib/utils'
+	import { inferArgs } from '$lib/infer'
 
 	// A local-dev pipeline preview driven by `wmill pipeline dev`. The CLI watches
 	// an `f/<folder>` of `// pipeline` scripts, builds the asset graph from the
@@ -69,19 +70,25 @@
 
 	// Selecting a node must render its working-tree source + Run button, NOT
 	// fetch the deployed script (this pipeline is local-only — that fetch 404s).
-	// Synthesize a read-only `Script` from the pushed content. The details pane
-	// only reads path/language/content/schema; args inference is a follow-up, so
-	// the run form starts from an empty schema (fine for no-arg DuckDB nodes).
-	function resolveLocalScript(path: string): Script | undefined {
+	// Synthesize a read-only `Script` from the pushed content and infer its args
+	// schema (same wasm the script editor uses) so a parameterized node shows its
+	// run-form inputs. The details pane only reads path/language/content/schema.
+	async function resolveLocalScript(path: string): Promise<Script | undefined> {
 		const s = scriptByPath.get(path)
 		if (!s) return undefined
+		const schema = emptySchema()
+		try {
+			await inferArgs(s.language as any, s.content ?? '', schema)
+		} catch {
+			// Inference failure (unsupported lang / parse error) → no inputs, still runnable.
+		}
 		return {
 			hash: '',
 			path,
 			summary: '',
 			description: '',
 			content: s.content,
-			schema: emptySchema(),
+			schema,
 			is_template: false,
 			extra_perms: {},
 			language: s.language as Script['language'],
@@ -124,14 +131,34 @@
 		}
 	})
 
-	function connectWs() {
+	// Connect to the `wmill pipeline dev` WS, auto-reconnecting while mounted —
+	// the dev server may bounce (the agent/user restarts it after changing config
+	// or the folder), and the page should recover without a manual reload.
+	$effect(() => {
+		const _port = port
 		let socket: WebSocket | undefined
-		try {
+		let retry: ReturnType<typeof setTimeout> | undefined
+		let disposed = false
+
+		function scheduleReconnect() {
+			if (disposed) return
+			wsState = 'closed'
+			if (retry) return
+			retry = setTimeout(() => {
+				retry = undefined
+				open()
+			}, 1500)
+		}
+		function open() {
+			if (disposed) return
 			wsState = 'connecting'
-			socket = new WebSocket(`ws://localhost:${port}/ws`)
+			try {
+				socket = new WebSocket(`ws://localhost:${_port}/ws`)
+			} catch {
+				scheduleReconnect()
+				return
+			}
 			socket.addEventListener('open', () => (wsState = 'open'))
-			socket.addEventListener('close', () => (wsState = 'closed'))
-			socket.addEventListener('error', () => (wsState = 'closed'))
 			socket.addEventListener('message', (event) => {
 				try {
 					const data = JSON.parse(event.data)
@@ -140,12 +167,16 @@
 					// ignore malformed frames
 				}
 			})
-		} catch {
-			wsState = 'closed'
+			socket.addEventListener('close', scheduleReconnect)
+			socket.addEventListener('error', () => socket?.close())
 		}
-		return () => socket?.close()
-	}
-	$effect(() => connectWs())
+		open()
+		return () => {
+			disposed = true
+			if (retry) clearTimeout(retry)
+			socket?.close()
+		}
+	})
 
 	function resolveLocal(
 		path: string

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte
@@ -125,6 +125,13 @@
 	let activeRunnable = $state<{ kind: 'script' | 'flow'; path: string } | undefined>(undefined)
 	let activeRunnableJobId = $state<string | undefined>(undefined)
 
+	// Drive the selected node's runs pane (AssetRunsPanel): a just-launched
+	// preview is `runsPendingJobId` (shown immediately), and bumping
+	// `runsRefreshKey` re-fetches the list — mirrors the route page so a local run
+	// appears + selects in the pane instead of only updating the node badge.
+	let runsPendingJobId = $state<string | undefined>(undefined)
+	let runsRefreshKey = $state(0)
+
 	// Activity-panel cross-highlighting: hovering/expanding a run row emphasizes
 	// its node(s) on the canvas (same wiring the route page uses).
 	let activityHoverPaths = $state<string[]>([])
@@ -144,6 +151,10 @@
 		if (ev && (ev.status === 'success' || ev.status === 'failure')) {
 			activeRunnable = undefined
 			activeRunnableJobId = undefined
+			// The job reached a terminal state — refetch the runs pane so it shows
+			// the completed run + result, and drop the pending placeholder.
+			runsPendingJobId = undefined
+			runsRefreshKey += 1
 		}
 	})
 
@@ -228,6 +239,8 @@
 			})
 			activeRunnable = { kind: 'script', path: nodePath }
 			activeRunnableJobId = jobId
+			runsPendingJobId = jobId
+			runsRefreshKey += 1
 			return jobId
 		} catch (e: any) {
 			sendUserToast(`Run failed: ${e?.body ?? e?.message ?? e}`, true)
@@ -257,6 +270,8 @@
 					rootJobId = jobId
 					activeRunnable = { kind: 'script', path: p }
 					activeRunnableJobId = jobId
+					runsPendingJobId = jobId
+					runsRefreshKey += 1
 				}
 			}
 		})
@@ -341,6 +356,8 @@
 				{workspace}
 				{pathPrefix}
 				{activeRunnable}
+				{runsPendingJobId}
+				{runsRefreshKey}
 				activeRunnableIds={activeRunnables.ids}
 				runStates={activeRunnables.states}
 				eventLogEvents={activeRunnables.events}

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineDevView.svelte
@@ -7,7 +7,7 @@
 	import { PipelineEditorState } from './pipelineEditorState.svelte'
 	import { useActiveRunnableIds } from './activeRunnables.svelte'
 	import { makeLaunch, makeWaitJobTerminal, runDownstreamCascade } from './cascadeRun'
-	import { assetProducers } from './graphTraversal'
+	import { assetProducers, buildDownstreamMap } from './graphTraversal'
 	import type { AssetGraphResponse, AssetGraphSelection } from './types'
 	import { JobService, OpenAPI, type Preview, type Script } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
@@ -78,6 +78,17 @@
 	// runs instead of "No producer for this asset" (which only holds for the
 	// deployed graph, absent here).
 	const selectionProducers = $derived(assetProducers(displayGraph, pe.selection))
+
+	// Subscriber count of the open script — gates the detail form's "Run +
+	// downstream" (only meaningful when the script has a chain to fan out to).
+	const openScriptPath = $derived(
+		pe.selection?.kind === 'runnable' && pe.selection.runnable_kind === 'script'
+			? pe.selection.path
+			: undefined
+	)
+	const selectionDownstreamCount = $derived(
+		openScriptPath ? (buildDownstreamMap(displayGraph).get(openScriptPath)?.size ?? 0) : 0
+	)
 
 	// path -> pushed local content, for preview-running each node.
 	const scriptByPath = $derived(
@@ -252,7 +263,12 @@
 
 	// "Run + downstream" — the client orchestrates the closure (preview each node
 	// in topological order) since the backend dispatcher only resolves deployed rows.
-	async function runCascadeFrom(rootPath: string): Promise<string | undefined> {
+	// `rootArgs` feeds the root node its inputs (e.g. an uploaded S3Object from the
+	// detail-pane form) so a `data_upload` entry can seed the whole chain.
+	async function runCascadeFrom(
+		rootPath: string,
+		rootArgs: Record<string, any> = {}
+	): Promise<string | undefined> {
 		if (!workspace) return undefined
 		if (cascadeRunningRoot) {
 			sendUserToast(`A chain run from ${cascadeRunningRoot} is still in progress`, true)
@@ -264,6 +280,7 @@
 			workspace,
 			resolveLocal,
 			tempScriptRefs: bundle?.temp_script_refs,
+			argsFor: (p) => (p === rootPath ? rootArgs : undefined),
 			onLaunched: (p, jobId) => {
 				activeRunnables.arm(`script:${p}`)
 				if (p === rootPath) {
@@ -367,6 +384,8 @@
 				onTogglePanelHidden={() => (panelHidden = !panelHidden)}
 				onRunProducer={runProducer}
 				onRunByPath={(path, args) => runNode(path, args)}
+				onRunCascadeByPath={(path, args) => runCascadeFrom(path, args)}
+				downstreamSubscribers={selectionDownstreamCount}
 				{resolveLocalScript}
 				localScriptsVersion={bundle}
 				{selectionProducers}

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineGraphEditor.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineGraphEditor.svelte
@@ -147,8 +147,9 @@
 		canRunByPath?: boolean
 		onRunByPath?: (path: string, args: Record<string, any>) => Promise<string | undefined>
 		/** Local-dev (`/pipeline_dev`): resolve a node to its working-tree content
-		 * so the details pane skips the (nonexistent) deployed-script fetch. */
-		resolveLocalScript?: (path: string) => Script | undefined
+		 * so the details pane skips the (nonexistent) deployed-script fetch. May
+		 * be async (to infer the args schema for the run form). */
+		resolveLocalScript?: (path: string) => Script | undefined | Promise<Script | undefined>
 		selectionProducers?: Array<{ kind: 'script' | 'flow'; path: string; unsaved?: boolean }>
 		/** Transitive column-lineage trace for a selected ducklake asset (route page). */
 		selectionColumnGraph?: ColumnLineageGraph

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineGraphEditor.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineGraphEditor.svelte
@@ -67,6 +67,7 @@
 		canRunByPath = false,
 		onRunByPath,
 		resolveLocalScript,
+		localScriptsVersion,
 		selectionProducers = [],
 		selectionColumnGraph,
 		schemaCanEvolve = true,
@@ -150,6 +151,9 @@
 		 * so the details pane skips the (nonexistent) deployed-script fetch. May
 		 * be async (to infer the args schema for the run form). */
 		resolveLocalScript?: (path: string) => Script | undefined | Promise<Script | undefined>
+		/** Bumped on each `pipeline dev` bundle so the open details pane re-resolves
+		 * the selected node's source on live-reload. */
+		localScriptsVersion?: unknown
 		selectionProducers?: Array<{ kind: 'script' | 'flow'; path: string; unsaved?: boolean }>
 		/** Transitive column-lineage trace for a selected ducklake asset (route page). */
 		selectionColumnGraph?: ColumnLineageGraph
@@ -461,6 +465,7 @@
 						{canRunByPath}
 						{onRunByPath}
 						{resolveLocalScript}
+						{localScriptsVersion}
 						selection={activeDraft ? undefined : editor.selection}
 						selectionProducers={activeDraft ? [] : selectionProducers}
 						{selectionColumnGraph}

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineGraphEditor.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineGraphEditor.svelte
@@ -18,7 +18,7 @@
 		NativeTriggerKind,
 		PipelineMode
 	} from './types'
-	import type { AssetKind, ScriptLang } from '$lib/gen'
+	import type { AssetKind, Script, ScriptLang } from '$lib/gen'
 	import type { RunnableRunState, PipelineEvent } from './activeRunnables.svelte'
 	import type { PipelineOutputKind } from './pipelineTemplates'
 	import type { PipelineEditorState } from './pipelineEditorState.svelte'
@@ -31,6 +31,7 @@
 		mode,
 		workspace,
 		folder,
+		stackBelow = 680,
 		persistDrafts = false,
 		pathPrefix,
 		defaultPathSuffix = 'new_pipeline_script',
@@ -65,6 +66,7 @@
 		onRequestEdit,
 		canRunByPath = false,
 		onRunByPath,
+		resolveLocalScript,
 		selectionProducers = [],
 		selectionColumnGraph,
 		schemaCanEvolve = true,
@@ -91,6 +93,10 @@
 		workspace: string | undefined
 		/** Folder the pipeline is scoped to — drives the autosave draft path. */
 		folder: string
+		/** Below this container width (px) the graph/details split stacks
+		 * vertically instead of side-by-side — for narrow side panels / AI
+		 * session previews. Defaults to 680. */
+		stackBelow?: number
 		/** Persist drafts as a per-folder `data_pipeline` DraftService bundle (enabled
 		 * by both the route page and the in-session preview). FlowBuilder's autosave
 		 * analogue. */
@@ -140,6 +146,9 @@
 		onRequestEdit?: () => void
 		canRunByPath?: boolean
 		onRunByPath?: (path: string, args: Record<string, any>) => Promise<string | undefined>
+		/** Local-dev (`/pipeline_dev`): resolve a node to its working-tree content
+		 * so the details pane skips the (nonexistent) deployed-script fetch. */
+		resolveLocalScript?: (path: string) => Script | undefined
 		selectionProducers?: Array<{ kind: 'script' | 'flow'; path: string; unsaved?: boolean }>
 		/** Transitive column-lineage trace for a selected ducklake asset (route page). */
 		selectionColumnGraph?: ColumnLineageGraph
@@ -166,6 +175,11 @@
 	let rightPaneSize = $state(40)
 	let storedRightPaneSize = $state(40)
 
+	// Container width drives the split orientation: stack vertically (graph over
+	// details) when too narrow for a comfortable side-by-side split.
+	let containerWidth = $state(0)
+	let stacked = $derived(containerWidth > 0 && containerWidth < stackBelow)
+
 	let effectiveSelection = $derived<AssetGraphSelection | undefined>(
 		editor.activeDraftPath
 			? { kind: 'runnable', runnable_kind: 'script', path: editor.activeDraftPath }
@@ -189,11 +203,14 @@
 	// the effect tracks only `detailsPaneOpen` / `storedRightPaneSize` — without it,
 	// the Pane `bind:size` feedback loops the effect and pegs the main thread.
 	$effect(() => {
+		// Stacked (vertical) splits give the details pane more room — the run
+		// form + result need height more than the graph needs it.
+		const fallback = stacked ? 55 : 40
 		if (detailsPaneOpen) {
 			const restore = storedRightPaneSize
 			untrack(() => {
-				rightPaneSize = restore > 0 ? restore : 40
-				leftPaneSize = 100 - (restore > 0 ? restore : 40)
+				rightPaneSize = restore > 0 ? restore : fallback
+				leftPaneSize = 100 - (restore > 0 ? restore : fallback)
 			})
 		} else {
 			untrack(() => {
@@ -375,103 +392,111 @@
 	})
 </script>
 
-<Splitpanes class="!h-full">
-	<Pane bind:size={leftPaneSize}>
-		<div class="relative h-full">
-			<AssetGraphCanvas
-				graph={displayGraph}
-				selection={effectiveSelection}
-				{hoveredPaths}
-				{selectedRunPaths}
-				{activeRunnable}
-				{activeRunnableIds}
-				{runStates}
-				{pathPrefix}
-				{defaultPathSuffix}
-				{onCreateMissingTrigger}
-				{onEditTrigger}
-				{onDeleteTrigger}
-				{onOpenWebhook}
-				{onOpenDataUpload}
-				onselect={onSelect}
-				{onAddScriptForAsset}
-				{onAddPipelineScript}
-				{onRunnableMenuRemove}
-				{onRunProducer}
-				{validStartPaths}
-				{onStartBoundedRun}
-				{boundPick}
-				{onPickEnd}
-				{panToNodeId}
-			/>
-			{#if boundBar}{@render boundBar()}{/if}
-			{#if mode === 'edit'}
-				<PipelineEventLog events={eventLogEvents} />
-			{/if}
-			{#if prefetchingAssets}
-				<div
-					class="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-1.5 px-2 py-1 rounded-md bg-surface/95 backdrop-blur-sm border border-gray-200 dark:border-gray-700 text-2xs text-secondary shadow-sm"
-					title="Inferring assets for every script in this folder so the graph is complete"
-				>
-					<Loader2 size={11} class="animate-spin" />
-					Parsing assets…
-				</div>
-			{/if}
-			{#if onTogglePanelHidden && (mode !== 'edit' || editor.selection != undefined || editor.activeDraftPath != undefined)}
-				<div
-					class="absolute top-2 right-2 z-50 rounded-md bg-surface shadow-sm border border-gray-200 dark:border-gray-700"
-				>
-					<HideButton hidden={panelHidden} direction="right" on:click={onTogglePanelHidden} />
-				</div>
-			{/if}
-		</div></Pane
-	>
-	{#if detailsPaneOpen && workspace}
-		<Pane bind:size={rightPaneSize} minSize={25}>
-			{#if idleView && idlePane}
-				{@render idlePane()}
-			{:else}
-				<AssetGraphDetailsPane
-					{mode}
-					{onRequestEdit}
-					{canRunByPath}
-					{onRunByPath}
-					selection={activeDraft ? undefined : editor.selection}
-					selectionProducers={activeDraft ? [] : selectionProducers}
-					{selectionColumnGraph}
-					{schemaCanEvolve}
-					{runsRefreshKey}
-					{runsPendingJobId}
+<div class="h-full w-full" bind:clientWidth={containerWidth}>
+	<Splitpanes class="!h-full" horizontal={stacked}>
+		<Pane bind:size={leftPaneSize}>
+			<div class="relative h-full">
+				<AssetGraphCanvas
+					graph={displayGraph}
+					selection={effectiveSelection}
+					{hoveredPaths}
+					{selectedRunPaths}
 					{activeRunnable}
-					{downstreamSubscribers}
-					onStartBoundedRun={canBoundedRunOpenScript &&
-					editor.openScriptPath &&
-					onStartBoundedRunForOpen
-						? () => onStartBoundedRunForOpen?.(editor.openScriptPath!)
-						: undefined}
-					{onRunCompleted}
-					{onTestStateChange}
-					{requestRemoveSignal}
-					{requestRunSignal}
-					{requestRunCascadeSignal}
-					{focusUploadSignal}
-					draftScript={activeDraft?.script}
+					{activeRunnableIds}
+					{runStates}
 					{pathPrefix}
-					{onDraftPathChange}
-					{workspace}
-					onAnnotationsChange={editor.handleAnnotationsChange}
-					onAssetsChange={editor.handleAssetsChange}
-					onContentChange={editor.handleContentChange}
-					onDraftPersist={editor.handleDraftPersist}
-					onclose={onClose}
-					onHide={onTogglePanelHidden}
-					{onDiscard}
-					{onDraftSaved}
-					{onPersistedSaved}
-					{onScriptRenamed}
-					{onScriptRemoved}
+					{defaultPathSuffix}
+					{onCreateMissingTrigger}
+					{onEditTrigger}
+					{onDeleteTrigger}
+					{onOpenWebhook}
+					{onOpenDataUpload}
+					onselect={onSelect}
+					{onAddScriptForAsset}
+					{onAddPipelineScript}
+					{onRunnableMenuRemove}
+					{onRunProducer}
+					{validStartPaths}
+					{onStartBoundedRun}
+					{boundPick}
+					{onPickEnd}
+					{panToNodeId}
+					showMinimap={!stacked}
 				/>
-			{/if}
-		</Pane>
-	{/if}
-</Splitpanes>
+				{#if boundBar}{@render boundBar()}{/if}
+				{#if mode === 'edit'}
+					<PipelineEventLog events={eventLogEvents} />
+				{/if}
+				{#if prefetchingAssets}
+					<div
+						class="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-1.5 px-2 py-1 rounded-md bg-surface/95 backdrop-blur-sm border border-gray-200 dark:border-gray-700 text-2xs text-secondary shadow-sm"
+						title="Inferring assets for every script in this folder so the graph is complete"
+					>
+						<Loader2 size={11} class="animate-spin" />
+						Parsing assets…
+					</div>
+				{/if}
+				{#if onTogglePanelHidden && (mode !== 'edit' || editor.selection != undefined || editor.activeDraftPath != undefined)}
+					<div
+						class="absolute top-2 right-2 z-50 rounded-md bg-surface shadow-sm border border-gray-200 dark:border-gray-700"
+					>
+						<HideButton
+							hidden={panelHidden}
+							direction={stacked ? 'bottom' : 'right'}
+							on:click={onTogglePanelHidden}
+						/>
+					</div>
+				{/if}
+			</div></Pane
+		>
+		{#if detailsPaneOpen && workspace}
+			<Pane bind:size={rightPaneSize} minSize={25}>
+				{#if idleView && idlePane}
+					{@render idlePane()}
+				{:else}
+					<AssetGraphDetailsPane
+						{mode}
+						{onRequestEdit}
+						{canRunByPath}
+						{onRunByPath}
+						{resolveLocalScript}
+						selection={activeDraft ? undefined : editor.selection}
+						selectionProducers={activeDraft ? [] : selectionProducers}
+						{selectionColumnGraph}
+						{schemaCanEvolve}
+						{runsRefreshKey}
+						{runsPendingJobId}
+						{activeRunnable}
+						{downstreamSubscribers}
+						onStartBoundedRun={canBoundedRunOpenScript &&
+						editor.openScriptPath &&
+						onStartBoundedRunForOpen
+							? () => onStartBoundedRunForOpen?.(editor.openScriptPath!)
+							: undefined}
+						{onRunCompleted}
+						{onTestStateChange}
+						{requestRemoveSignal}
+						{requestRunSignal}
+						{requestRunCascadeSignal}
+						{focusUploadSignal}
+						draftScript={activeDraft?.script}
+						{pathPrefix}
+						{onDraftPathChange}
+						{workspace}
+						onAnnotationsChange={editor.handleAnnotationsChange}
+						onAssetsChange={editor.handleAssetsChange}
+						onContentChange={editor.handleContentChange}
+						onDraftPersist={editor.handleDraftPersist}
+						onclose={onClose}
+						onHide={onTogglePanelHidden}
+						{onDiscard}
+						{onDraftSaved}
+						{onPersistedSaved}
+						{onScriptRenamed}
+						{onScriptRemoved}
+					/>
+				{/if}
+			</Pane>
+		{/if}
+	</Splitpanes>
+</div>

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineGraphEditor.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineGraphEditor.svelte
@@ -178,7 +178,9 @@
 
 	let leftPaneSize = $state(60)
 	let rightPaneSize = $state(40)
-	let storedRightPaneSize = $state(40)
+	// 0 = "no user-chosen size yet" so the orientation-aware default (55% stacked /
+	// 40% side-by-side) applies on first open; a real drag overwrites it below.
+	let storedRightPaneSize = $state(0)
 
 	// Container width drives the split orientation: stack vertically (graph over
 	// details) when too narrow for a comfortable side-by-side split.

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineGraphEditor.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineGraphEditor.svelte
@@ -66,6 +66,7 @@
 		onRequestEdit,
 		canRunByPath = false,
 		onRunByPath,
+		onRunCascadeByPath,
 		resolveLocalScript,
 		localScriptsVersion,
 		selectionProducers = [],
@@ -147,6 +148,9 @@
 		onRequestEdit?: () => void
 		canRunByPath?: boolean
 		onRunByPath?: (path: string, args: Record<string, any>) => Promise<string | undefined>
+		// Run the open script AND its downstream closure (dev preview only; the
+		// deployed pane leaves this unset — its single run cascades via the backend).
+		onRunCascadeByPath?: (path: string, args: Record<string, any>) => Promise<string | undefined>
 		/** Local-dev (`/pipeline_dev`): resolve a node to its working-tree content
 		 * so the details pane skips the (nonexistent) deployed-script fetch. May
 		 * be async (to infer the args schema for the run form). */
@@ -466,6 +470,7 @@
 						{onRequestEdit}
 						{canRunByPath}
 						{onRunByPath}
+						{onRunCascadeByPath}
 						{resolveLocalScript}
 						{localScriptsVersion}
 						selection={activeDraft ? undefined : editor.selection}

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineRunForm.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineRunForm.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import SchemaForm from '$lib/components/SchemaForm.svelte'
+	import { emptySchema } from '$lib/utils'
+
+	interface Props {
+		// The script's schema to render inputs for. SchemaForm normalizes/mutates
+		// its schema in place, so we clone it into local state below.
+		schema: any
+		args: Record<string, any>
+		isValid: boolean
+	}
+
+	let { schema, args = $bindable(), isValid = $bindable() }: Props = $props()
+
+	// Mutable clone SchemaForm can normalize without touching the parent's script.
+	// Seeded ONCE per mount — the parent remounts this via `{#key <schema content>}`
+	// when a local edit adds/removes args, so the clone reseeds without a prop→state
+	// $effect, and an unchanged re-resolve (a WS bundle with the same schema) keeps
+	// in-progress input.
+	// svelte-ignore state_referenced_locally
+	let formSchema = $state<any>(structuredClone($state.snapshot(schema) ?? emptySchema()))
+</script>
+
+<SchemaForm bind:schema={formSchema} bind:args bind:isValid compact />

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineScriptView.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineScriptView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Script } from '$lib/gen'
-	import { Loader2, Play, Upload } from 'lucide-svelte'
+	import { Loader2, Play, Upload, Zap } from 'lucide-svelte'
 	import Button from '$lib/components/common/button/Button.svelte'
 	import HighlightCode from '$lib/components/HighlightCode.svelte'
 	import SchemaForm from '$lib/components/SchemaForm.svelte'
@@ -20,6 +20,13 @@
 		// Legitimate dispatch (runScriptByPath, real cascade) owned by the
 		// page. Returns the launched job id.
 		onRun?: (path: string, args: Record<string, any>) => Promise<string | undefined>
+		// Run this script AND its downstream closure with the same form args (dev
+		// preview: the client orchestrates the chain). When unset — the deployed
+		// pane — the single `onRun` already cascades via the backend dispatcher, so
+		// no separate "Run + downstream" affordance is shown.
+		onRunCascade?: (path: string, args: Record<string, any>) => Promise<string | undefined>
+		// Downstream subscriber count; the cascade button is offered only when > 0.
+		downstreamCount?: number
 		// Threaded through to AssetRunsPanel — same semantics as the asset
 		// selection branch of the details pane.
 		runsRefreshKey?: any
@@ -32,6 +39,8 @@
 		isDraft = false,
 		canRun = false,
 		onRun,
+		onRunCascade,
+		downstreamCount = 0,
 		runsRefreshKey,
 		runsPendingJobId,
 		onRunCompleted
@@ -40,6 +49,9 @@
 	let args = $state<Record<string, any>>({})
 	let isValid = $state(true)
 	let running = $state(false)
+	// Offer "Run + downstream" only when a cascade dispatch is wired (dev preview)
+	// and the script actually has subscribers to fan out to.
+	let hasCascade = $derived(!!onRunCascade && downstreamCount > 0)
 
 	// Local clone for SchemaForm's bindable schema prop — the incoming
 	// script is owned by the parent and must not be mutated from here.
@@ -48,11 +60,12 @@
 	// svelte-ignore state_referenced_locally
 	let formSchema = $state<any>(structuredClone($state.snapshot(script.schema) ?? emptySchema()))
 
-	async function run() {
-		if (!onRun || running) return
+	async function run(cascade = false) {
+		const dispatch = cascade ? onRunCascade : onRun
+		if (!dispatch || running) return
 		running = true
 		try {
-			await onRun(script.path, $state.snapshot(args))
+			await dispatch(script.path, $state.snapshot(args))
 		} finally {
 			running = false
 		}
@@ -77,18 +90,34 @@
 								<Upload size={13} class="text-fuchsia-600 dark:text-fuchsia-400" />
 								Run pipeline
 							</span>
-							<Button
-								variant="accent"
-								unifiedSize="sm"
-								startIcon={{ icon: running ? Loader2 : Play }}
-								onclick={run}
-								disabled={isDraft || running || !isValid || !onRun}
-								title={isDraft
-									? 'Deploy this draft to run it for real'
-									: 'Run the deployed script — downstream pipeline scripts cascade for real'}
-							>
-								{running ? 'Starting…' : 'Run'}
-							</Button>
+							<div class="flex items-center gap-1.5">
+								{#if hasCascade}
+									<Button
+										variant="accent-secondary"
+										unifiedSize="sm"
+										startIcon={{ icon: running ? Loader2 : Zap }}
+										onclick={() => run(true)}
+										disabled={isDraft || running || !isValid}
+										title={`Run this script with these inputs, then run its ${downstreamCount} downstream pipeline script${downstreamCount === 1 ? '' : 's'} in order`}
+									>
+										Run + downstream
+									</Button>
+								{/if}
+								<Button
+									variant="accent"
+									unifiedSize="sm"
+									startIcon={{ icon: running ? Loader2 : Play }}
+									onclick={() => run(false)}
+									disabled={isDraft || running || !isValid || !onRun}
+									title={isDraft
+										? 'Deploy this draft to run it for real'
+										: hasCascade
+											? 'Run just this step — downstream scripts are not triggered'
+											: 'Run the deployed script — downstream pipeline scripts cascade for real'}
+								>
+									{running ? 'Starting…' : 'Run'}
+								</Button>
+							</div>
 						</div>
 						<SchemaForm bind:schema={formSchema} bind:args bind:isValid compact />
 					</div>

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineScriptView.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineScriptView.svelte
@@ -3,10 +3,9 @@
 	import { Loader2, Play, Upload, Zap } from 'lucide-svelte'
 	import Button from '$lib/components/common/button/Button.svelte'
 	import HighlightCode from '$lib/components/HighlightCode.svelte'
-	import SchemaForm from '$lib/components/SchemaForm.svelte'
+	import PipelineRunForm from './PipelineRunForm.svelte'
 	import AssetRunsPanel from './AssetRunsPanel.svelte'
 	import { Pane, Splitpanes } from 'svelte-splitpanes'
-	import { emptySchema } from '$lib/utils'
 
 	interface Props {
 		script: Script
@@ -53,12 +52,13 @@
 	// and the script actually has subscribers to fan out to.
 	let hasCascade = $derived(!!onRunCascade && downstreamCount > 0)
 
-	// Local clone for SchemaForm's bindable schema prop — the incoming
-	// script is owned by the parent and must not be mutated from here.
-	// Seeded once: the details pane keys this component on script.path, so
-	// switching scripts remounts with a fresh clone.
-	// svelte-ignore state_referenced_locally
-	let formSchema = $state<any>(structuredClone($state.snapshot(script.schema) ?? emptySchema()))
+	// The details pane keys this component on script.path only, so a same-path
+	// re-resolve (in /pipeline_dev the selected node re-resolves on every WS
+	// bundle) does NOT remount us. `PipelineRunForm` owns the SchemaForm clone and
+	// is keyed on the serialized schema below, so a local edit that adds/removes
+	// args reseeds the run form while an unchanged re-resolve keeps in-progress
+	// input (else the form could run against a stale schema with missing inputs).
+	let schemaKey = $derived(JSON.stringify(script.schema ?? null))
 
 	async function run(cascade = false) {
 		const dispatch = cascade ? onRunCascade : onRun
@@ -119,7 +119,9 @@
 								</Button>
 							</div>
 						</div>
-						<SchemaForm bind:schema={formSchema} bind:args bind:isValid compact />
+						{#key schemaKey}
+							<PipelineRunForm schema={script.schema} bind:args bind:isValid />
+						{/key}
 					</div>
 				{/if}
 				<div class="flex-1 min-h-0 overflow-auto text-xs p-3">

--- a/frontend/src/lib/components/assets/AssetGraph/SchemaHistoryPanel.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/SchemaHistoryPanel.svelte
@@ -11,7 +11,7 @@
 	//   fixed-schema table, so the schema is pinned at first materialize; there's
 	//   only ever one version, shown as a single current-schema table.
 	import { resource } from 'runed'
-	import { OpenAPI } from '$lib/gen'
+	import { AssetService, type AssetSchemaVersion } from '$lib/gen'
 	import { Button } from '$lib/components/common'
 	import { Loader2, RefreshCw, Lock } from 'lucide-svelte'
 	import { Pane, Splitpanes } from 'svelte-splitpanes'
@@ -26,23 +26,12 @@
 	}
 	let { path, workspace, canEvolve = true }: Props = $props()
 
+	// One column of a captured schema version (the generated `columns` element).
 	type SchemaColumn = { name: string; type: string }
-	type AssetSchemaVersion = {
-		version: number
-		columns: SchemaColumn[]
-		snapshot_id?: number | null
-		job_id?: string | null
-		captured_at: string
-	}
 
-	let schemas = resource([() => workspace, () => path], async ([ws, p], _prev, { signal }) => {
+	let schemas = resource([() => workspace, () => path], async ([ws, p]) => {
 		if (!ws || !p) return [] as AssetSchemaVersion[]
-		const res = await fetch(
-			`${OpenAPI.BASE ?? ''}/w/${ws}/assets/asset_schemas?path=${encodeURIComponent(p)}`,
-			{ credentials: 'include', signal }
-		)
-		if (!res.ok) throw new Error(`GET /assets/asset_schemas → ${res.status}`)
-		return (await res.json()) as AssetSchemaVersion[]
+		return await AssetService.listAssetSchemas({ workspace: ws, path: p })
 	})
 
 	// The user's explicit pick (undefined until they click). Falls back to the

--- a/frontend/src/lib/components/assets/AssetGraph/cascadeRun.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/cascadeRun.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { JobService } from '$lib/gen'
+import { makeLaunch } from './cascadeRun'
+
+afterEach(() => vi.restoreAllMocks())
+
+// The client orchestrates the cascade closure, so every launch must carry
+// `_wmill_skip_asset_dispatch: true`. A caller arg (e.g. the run form for the
+// root node) must NOT be able to override that guard back to false and let the
+// backend also dispatch deployed subscribers.
+describe('makeLaunch dispatch guard', () => {
+	it('local preview: a caller `_wmill_skip_asset_dispatch: false` cannot re-enable dispatch', async () => {
+		const spy = vi.spyOn(JobService, 'runScriptPreview').mockResolvedValue('job-1' as any)
+		const launch = makeLaunch({
+			workspace: 'w',
+			resolveLocal: () => ({ content: 'x', language: 'bun' as any }),
+			argsFor: () => ({ _wmill_skip_asset_dispatch: false, foo: 1 })
+		})
+		await launch('f/x/root')
+		const body = (spy.mock.calls[0][0] as any).requestBody
+		expect(body.args._wmill_skip_asset_dispatch).toBe(true) // guard wins
+		expect(body.args.foo).toBe(1) // other caller args preserved
+	})
+
+	it('deployed by-path: a caller `_wmill_skip_asset_dispatch: false` cannot re-enable dispatch', async () => {
+		const spy = vi.spyOn(JobService, 'runScriptByPath').mockResolvedValue('job-2' as any)
+		const launch = makeLaunch({
+			workspace: 'w',
+			argsFor: () => ({ _wmill_skip_asset_dispatch: false })
+		})
+		await launch('f/x/deployed')
+		const body = (spy.mock.calls[0][0] as any).requestBody
+		expect(body._wmill_skip_asset_dispatch).toBe(true)
+	})
+})

--- a/frontend/src/lib/components/assets/AssetGraph/cascadeRun.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/cascadeRun.ts
@@ -1,0 +1,123 @@
+// Reusable cascade-execution primitives shared by the pipeline route page and
+// the local-dev preview (`PipelineDevView`). The backend asset-trigger
+// dispatcher only resolves DEPLOYED rows, so whenever a run involves local /
+// draft content the client must orchestrate the closure itself: topological
+// order over the graph the user is looking at, each node launched with
+// `_wmill_skip_asset_dispatch` so the backend never double-fires the deployed
+// part of a mixed chain.
+
+import { JobService, type Preview } from '$lib/gen'
+import {
+	runCascade,
+	runSelection,
+	type CascadeRunResult,
+	type CascadeNodeState
+} from './cascadeOrchestrator'
+import { computeDownstreamClosure, computeInducedSchedule } from './graphTraversal'
+import type { AssetGraphResponse } from './types'
+
+export const CASCADE_POLL_INTERVAL_MS = 1000
+export const CASCADE_JOB_TIMEOUT_MS = 30 * 60 * 1000
+
+export type LocalScriptContent = { content: string; language: Preview['language'] }
+
+// Poll a launched cascade job to a terminal state. Capped so a never-terminating
+// job can't pin a run guard forever; on timeout it throws, surfaced as a chain
+// failure by the orchestrator.
+export function makeWaitJobTerminal(
+	workspace: string
+): (jobId: string) => Promise<'success' | 'failure'> {
+	return async function waitJobTerminal(jobId: string): Promise<'success' | 'failure'> {
+		const deadline = Date.now() + CASCADE_JOB_TIMEOUT_MS
+		while (Date.now() < deadline) {
+			try {
+				const r = await JobService.getCompletedJobResultMaybe({
+					workspace,
+					id: jobId,
+					getStarted: false
+				})
+				if (r.completed) return r.success ? 'success' : 'failure'
+			} catch {
+				// transient — retry on the next tick
+			}
+			await new Promise((res) => setTimeout(res, CASCADE_POLL_INTERVAL_MS))
+		}
+		throw new Error(
+			`Timed out after ${Math.round(CASCADE_JOB_TIMEOUT_MS / 60000)}min waiting for job ${jobId} to finish`
+		)
+	}
+}
+
+// Build a per-script launch function. When `resolveLocal(path)` yields content,
+// the script runs as a preview of that local content (no deploy); otherwise it
+// runs the deployed version by path. Always passes `_wmill_skip_asset_dispatch`.
+export function makeLaunch(opts: {
+	workspace: string
+	resolveLocal?: (path: string) => LocalScriptContent | undefined
+	tempScriptRefs?: Record<string, string>
+	onLaunched?: (path: string, jobId: string) => void
+}): (path: string) => Promise<string> {
+	return async function launch(path: string): Promise<string> {
+		const local = opts.resolveLocal?.(path)
+		let jobId: string
+		if (local) {
+			if (!local.content || !local.language) {
+				throw new Error(`local script ${path} has no content/language`)
+			}
+			jobId = await JobService.runScriptPreview({
+				workspace: opts.workspace,
+				requestBody: {
+					content: local.content,
+					language: local.language,
+					path,
+					args: { _wmill_skip_asset_dispatch: true },
+					...(opts.tempScriptRefs ? { temp_script_refs: opts.tempScriptRefs } : {})
+				}
+			})
+		} else {
+			jobId = await JobService.runScriptByPath({
+				workspace: opts.workspace,
+				path,
+				requestBody: { _wmill_skip_asset_dispatch: true }
+			})
+		}
+		opts.onLaunched?.(path, jobId)
+		return jobId
+	}
+}
+
+// Run `root` plus its full downstream closure over the given graph.
+export async function runDownstreamCascade(opts: {
+	graph: AssetGraphResponse
+	root: string
+	launch: (path: string) => Promise<string>
+	waitTerminal: (jobId: string) => Promise<'success' | 'failure'>
+	onUpdate?: (statuses: Map<string, CascadeNodeState>) => void
+}): Promise<CascadeRunResult & { cyclic: string[] }> {
+	const closure = computeDownstreamClosure(opts.graph, opts.root)
+	const res = await runCascade({
+		closure,
+		root: opts.root,
+		launch: opts.launch,
+		waitTerminal: opts.waitTerminal,
+		onUpdate: opts.onUpdate
+	})
+	return { ...res, cyclic: closure.cyclic }
+}
+
+// Run a bounded selection of scripts (the induced schedule over the lineage DAG).
+export async function runBoundedCascade(opts: {
+	graph: AssetGraphResponse
+	scripts: Set<string>
+	launch: (path: string) => Promise<string>
+	waitTerminal: (jobId: string) => Promise<'success' | 'failure'>
+	onUpdate?: (statuses: Map<string, CascadeNodeState>) => void
+}): Promise<CascadeRunResult> {
+	const schedule = computeInducedSchedule(opts.graph, opts.scripts)
+	return await runSelection({
+		schedule,
+		launch: opts.launch,
+		waitTerminal: opts.waitTerminal,
+		onUpdate: opts.onUpdate
+	})
+}

--- a/frontend/src/lib/components/assets/AssetGraph/cascadeRun.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/cascadeRun.ts
@@ -14,6 +14,7 @@ import {
 	type CascadeNodeState
 } from './cascadeOrchestrator'
 import { computeDownstreamClosure, computeInducedSchedule } from './graphTraversal'
+import { buildLineageDownstreamMap } from './boundedCascade'
 import type { AssetGraphResponse } from './types'
 
 export const CASCADE_POLL_INTERVAL_MS = 1000
@@ -112,12 +113,21 @@ export async function runBoundedCascade(opts: {
 	launch: (path: string) => Promise<string>
 	waitTerminal: (jobId: string) => Promise<'success' | 'failure'>
 	onUpdate?: (statuses: Map<string, CascadeNodeState>) => void
-}): Promise<CascadeRunResult> {
-	const schedule = computeInducedSchedule(opts.graph, opts.scripts)
-	return await runSelection({
+}): Promise<CascadeRunResult & { cyclic: string[] }> {
+	// Read-aware adjacency (NOT the default write-edge map) so a pure-reader
+	// member runs after its producer — parity with the route page's bounded run
+	// and the CLI `topoOrder`. `cyclic` is surfaced so callers can warn instead of
+	// silently dropping scripts stuck on a dependency cycle.
+	const schedule = computeInducedSchedule(
+		opts.graph,
+		opts.scripts,
+		buildLineageDownstreamMap(opts.graph)
+	)
+	const res = await runSelection({
 		schedule,
 		launch: opts.launch,
 		waitTerminal: opts.waitTerminal,
 		onUpdate: opts.onUpdate
 	})
+	return { ...res, cyclic: schedule.cyclic }
 }

--- a/frontend/src/lib/components/assets/AssetGraph/cascadeRun.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/cascadeRun.ts
@@ -69,7 +69,12 @@ export function makeLaunch(opts: {
 }): (path: string) => Promise<string> {
 	return async function launch(path: string): Promise<string> {
 		const local = opts.resolveLocal?.(path)
-		const extra = opts.argsFor?.(path) ?? {}
+		// Caller args (e.g. the run form for the cascade root) must NOT be able to
+		// re-enable backend asset dispatch while the client orchestrates the closure
+		// — that would double-run downstream / run deployed subscribers. Drop any
+		// `_wmill_skip_asset_dispatch` a caller supplied, and always spread it LAST.
+		const { _wmill_skip_asset_dispatch: _reserved, ...extra } = opts.argsFor?.(path) ?? {}
+		void _reserved
 		let jobId: string
 		if (local) {
 			if (!local.content || !local.language) {
@@ -81,7 +86,7 @@ export function makeLaunch(opts: {
 					content: local.content,
 					language: local.language,
 					path,
-					args: { _wmill_skip_asset_dispatch: true, ...extra },
+					args: { ...extra, _wmill_skip_asset_dispatch: true },
 					...(local.tag ? { tag: local.tag } : {}),
 					...(opts.tempScriptRefs ? { temp_script_refs: opts.tempScriptRefs } : {})
 				}
@@ -90,7 +95,7 @@ export function makeLaunch(opts: {
 			jobId = await JobService.runScriptByPath({
 				workspace: opts.workspace,
 				path,
-				requestBody: { _wmill_skip_asset_dispatch: true, ...extra }
+				requestBody: { ...extra, _wmill_skip_asset_dispatch: true }
 			})
 		}
 		opts.onLaunched?.(path, jobId)

--- a/frontend/src/lib/components/assets/AssetGraph/cascadeRun.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/cascadeRun.ts
@@ -61,10 +61,15 @@ export function makeLaunch(opts: {
 	workspace: string
 	resolveLocal?: (path: string) => LocalScriptContent | undefined
 	tempScriptRefs?: Record<string, string>
+	// Extra run args for a specific node (e.g. the uploaded S3Object bound to a
+	// `data_upload` cascade root). Merged over `_wmill_skip_asset_dispatch`; all
+	// other nodes run with empty inputs as before.
+	argsFor?: (path: string) => Record<string, any> | undefined
 	onLaunched?: (path: string, jobId: string) => void
 }): (path: string) => Promise<string> {
 	return async function launch(path: string): Promise<string> {
 		const local = opts.resolveLocal?.(path)
+		const extra = opts.argsFor?.(path) ?? {}
 		let jobId: string
 		if (local) {
 			if (!local.content || !local.language) {
@@ -76,7 +81,7 @@ export function makeLaunch(opts: {
 					content: local.content,
 					language: local.language,
 					path,
-					args: { _wmill_skip_asset_dispatch: true },
+					args: { _wmill_skip_asset_dispatch: true, ...extra },
 					...(local.tag ? { tag: local.tag } : {}),
 					...(opts.tempScriptRefs ? { temp_script_refs: opts.tempScriptRefs } : {})
 				}
@@ -85,7 +90,7 @@ export function makeLaunch(opts: {
 			jobId = await JobService.runScriptByPath({
 				workspace: opts.workspace,
 				path,
-				requestBody: { _wmill_skip_asset_dispatch: true }
+				requestBody: { _wmill_skip_asset_dispatch: true, ...extra }
 			})
 		}
 		opts.onLaunched?.(path, jobId)

--- a/frontend/src/lib/components/assets/AssetGraph/cascadeRun.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/cascadeRun.ts
@@ -20,7 +20,12 @@ import type { AssetGraphResponse } from './types'
 export const CASCADE_POLL_INTERVAL_MS = 1000
 export const CASCADE_JOB_TIMEOUT_MS = 30 * 60 * 1000
 
-export type LocalScriptContent = { content: string; language: Preview['language'] }
+export type LocalScriptContent = {
+	content: string
+	language: Preview['language']
+	// `// tag <worker-tag>` — routes the preview to that worker (deployed parity).
+	tag?: string
+}
 
 // Poll a launched cascade job to a terminal state. Capped so a never-terminating
 // job can't pin a run guard forever; on timeout it throws, surfaced as a chain
@@ -72,6 +77,7 @@ export function makeLaunch(opts: {
 					language: local.language,
 					path,
 					args: { _wmill_skip_asset_dispatch: true },
+					...(local.tag ? { tag: local.tag } : {}),
 					...(opts.tempScriptRefs ? { temp_script_refs: opts.tempScriptRefs } : {})
 				}
 			})

--- a/frontend/src/lib/components/assets/AssetGraph/graphTraversal.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/graphTraversal.ts
@@ -1,5 +1,30 @@
-import type { AssetGraphResponse } from './types'
+import type { AssetGraphResponse, AssetGraphSelection } from './types'
 import { assetKey, buildAssetSubscribers, isWriteEdge } from './lib'
+
+// Scripts that WRITE the selected asset (its producers), from the graph's
+// `w`/`rw` lineage edges. `[]` for a non-asset selection. Shared by the route
+// page and the dev preview so "who writes this asset" is defined once and can't
+// drift between the two surfaces.
+export function assetProducers(
+	graph: AssetGraphResponse,
+	selection: AssetGraphSelection | undefined
+): Array<{ kind: 'script' | 'flow'; path: string; unsaved?: boolean }> {
+	if (!selection || selection.kind !== 'asset') return []
+	return graph.edges
+		.filter((e) => {
+			const access = e.access_type ?? 'r'
+			return (
+				(access === 'w' || access === 'rw') &&
+				e.asset_kind === selection.asset_kind &&
+				e.asset_path === selection.path
+			)
+		})
+		.map((e) => ({
+			kind: e.runnable_kind as 'script' | 'flow',
+			path: e.runnable_path,
+			unsaved: e.unsaved
+		}))
+}
 
 // Execution-DAG traversal over the resolved asset graph (drafts included).
 //

--- a/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
@@ -37,7 +37,8 @@
 	import { resolveGraph } from '$lib/components/assets/AssetGraph/resolveGraph'
 	import {
 		computeDownstreamClosure,
-		computeInducedSchedule
+		computeInducedSchedule,
+		assetProducers
 	} from '$lib/components/assets/AssetGraph/graphTraversal'
 	import { runCascade, runSelection } from '$lib/components/assets/AssetGraph/cascadeOrchestrator'
 	import {
@@ -1620,20 +1621,7 @@
 	// runs panel can list jobs for the right scripts. We include drafts —
 	// running a draft via runScriptPreview creates a `preview`-kind job at
 	// the same path, which the panel's listing query picks up.
-	let selectionProducers = $derived.by(() => {
-		const sel = pe.selection
-		if (!sel || sel.kind !== 'asset') return []
-		return graphWithDraft.edges
-			.filter((e) => {
-				const access = e.access_type ?? 'r'
-				return (
-					(access === 'w' || access === 'rw') &&
-					e.asset_kind === sel.asset_kind &&
-					e.asset_path === sel.path
-				)
-			})
-			.map((e) => ({ kind: e.runnable_kind, path: e.runnable_path, unsaved: e.unsaved }))
-	})
+	let selectionProducers = $derived(assetProducers(graphWithDraft, pe.selection))
 
 	// Empty graph reused when the trace isn't shown (no ducklake-asset selection,
 	// or a draft is actively edited) so the pane blanks out like the other

--- a/frontend/src/routes/pipeline_dev/+page.svelte
+++ b/frontend/src/routes/pipeline_dev/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import PipelineDevView from '$lib/components/assets/AssetGraph/PipelineDevView.svelte'
+</script>
+
+<div class="h-screen w-screen">
+	<PipelineDevView />
+</div>

--- a/system_prompts/auto-generated/cli/cli-commands.md
+++ b/system_prompts/auto-generated/cli/cli-commands.md
@@ -431,6 +431,7 @@ inspect asset-driven pipelines (scripts marked `// pipeline`, wired by `// on <s
 - `pipeline dev [folder:string]` - Live-preview a data pipeline from local files: watch an `f/<folder>` of `// pipeline` scripts, push the working-tree graph to the dev page, and run the cascade via preview (no deploy).
   - `--port <port:number>` - Port for the dev WebSocket server.
   - `--no-open` - Do not open the browser automatically.
+  - `--frontend <origin:string>` - Origin serving the /pipeline_dev page (e.g. http://localhost:3000 for a locally-run frontend). Defaults to the workspace remote; use it when the remote's deployed frontend predates the dev page.
 
 ### protection-rules
 

--- a/system_prompts/auto-generated/cli/cli-commands.md
+++ b/system_prompts/auto-generated/cli/cli-commands.md
@@ -426,7 +426,7 @@ inspect asset-driven pipelines (scripts marked `// pipeline`, wired by `// on <s
   - `--dry-run` - Print the topological run plan without executing.
   - `--json` - Output the plan as JSON (for piping to jq).
   - `--local` - Run the local working-tree scripts via preview (no deploy) instead of the deployed versions; the graph is built from local files.
-  - `--upload <binding:string>` - Bind an object to a data_upload/webhook entry point so it runs in the cascade: <script>[:<param>]=<local-file|s3://key>. Local files are uploaded to the workspace store; the S3Object param is inferred when the script has exactly one. Repeatable.
+  - `--upload <binding:string>` - Bind an object to a data_upload/webhook entry point so it runs in the cascade, as SCRIPT[:PARAM]=SOURCE (SOURCE is a local file or an s3://key). Local files are uploaded to the workspace store; the S3Object param is inferred when the script has exactly one. Repeatable.
 - `pipeline docs <folder:string>` - generate PIPELINE.md (+ AGENTS.md pointer) describing a folder's pipeline graph and datatable schemas, for an editor / agentic loop
   - `--local` - Build the graph from local working-tree files instead of the deployed workspace.
 - `pipeline dev [folder:string]` - Live-preview a data pipeline from local files: watch an `f/<folder>` of `// pipeline` scripts, push the working-tree graph to the dev page, and run the cascade via preview (no deploy).

--- a/system_prompts/auto-generated/cli/cli-commands.md
+++ b/system_prompts/auto-generated/cli/cli-commands.md
@@ -426,6 +426,7 @@ inspect asset-driven pipelines (scripts marked `// pipeline`, wired by `// on <s
   - `--dry-run` - Print the topological run plan without executing.
   - `--json` - Output the plan as JSON (for piping to jq).
   - `--local` - Run the local working-tree scripts via preview (no deploy) instead of the deployed versions; the graph is built from local files.
+  - `--upload <binding:string>` - Bind an object to a data_upload/webhook entry point so it runs in the cascade: <script>[:<param>]=<local-file|s3://key>. Local files are uploaded to the workspace store; the S3Object param is inferred when the script has exactly one. Repeatable.
 - `pipeline docs <folder:string>` - generate PIPELINE.md (+ AGENTS.md pointer) describing a folder's pipeline graph and datatable schemas, for an editor / agentic loop
   - `--local` - Build the graph from local working-tree files instead of the deployed workspace.
 - `pipeline dev [folder:string]` - Live-preview a data pipeline from local files: watch an `f/<folder>` of `// pipeline` scripts, push the working-tree graph to the dev page, and run the cascade via preview (no deploy).

--- a/system_prompts/auto-generated/cli/cli-commands.md
+++ b/system_prompts/auto-generated/cli/cli-commands.md
@@ -419,11 +419,18 @@ inspect asset-driven pipelines (scripts marked `// pipeline`, wired by `// on <s
   - `--json` - Output as JSON (for piping to jq)
 - `pipeline show <folder:string>` - render a pipeline folder's DAG (sources, lineage, subscriptions) in the terminal
   - `--json` - Output the raw asset graph as JSON
+  - `--local` - Build the graph from local working-tree files (// pipeline scripts) instead of the deployed workspace — no deploy needed.
 - `pipeline run <folder:string>` - run a bounded cascade: from a schedule/manual root, fan downstream up to the --to end node(s)
   - `--from <script:string>` - Start script (short name or path). Defaults to the folder's sole schedule/manual root.
   - `--to <node:string>` - End node(s) to stop at — script names/paths or asset URIs (e.g. datatable://main/staged). Repeatable or comma-separated. Omit to run the full downstream.
   - `--dry-run` - Print the topological run plan without executing.
   - `--json` - Output the plan as JSON (for piping to jq).
+  - `--local` - Run the local working-tree scripts via preview (no deploy) instead of the deployed versions; the graph is built from local files.
+- `pipeline docs <folder:string>` - generate PIPELINE.md (+ AGENTS.md pointer) describing a folder's pipeline graph and datatable schemas, for an editor / agentic loop
+  - `--local` - Build the graph from local working-tree files instead of the deployed workspace.
+- `pipeline dev [folder:string]` - Live-preview a data pipeline from local files: watch an `f/<folder>` of `// pipeline` scripts, push the working-tree graph to the dev page, and run the cascade via preview (no deploy).
+  - `--port <port:number>` - Port for the dev WebSocket server.
+  - `--no-open` - Do not open the browser automatically.
 
 ### protection-rules
 

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -3094,7 +3094,7 @@ inspect asset-driven pipelines (scripts marked \`// pipeline\`, wired by \`// on
   - \`--dry-run\` - Print the topological run plan without executing.
   - \`--json\` - Output the plan as JSON (for piping to jq).
   - \`--local\` - Run the local working-tree scripts via preview (no deploy) instead of the deployed versions; the graph is built from local files.
-  - \`--upload <binding:string>\` - Bind an object to a data_upload/webhook entry point so it runs in the cascade: <script>[:<param>]=<local-file|s3://key>. Local files are uploaded to the workspace store; the S3Object param is inferred when the script has exactly one. Repeatable.
+  - \`--upload <binding:string>\` - Bind an object to a data_upload/webhook entry point so it runs in the cascade, as SCRIPT[:PARAM]=SOURCE (SOURCE is a local file or an s3://key). Local files are uploaded to the workspace store; the S3Object param is inferred when the script has exactly one. Repeatable.
 - \`pipeline docs <folder:string>\` - generate PIPELINE.md (+ AGENTS.md pointer) describing a folder's pipeline graph and datatable schemas, for an editor / agentic loop
   - \`--local\` - Build the graph from local working-tree files instead of the deployed workspace.
 - \`pipeline dev [folder:string]\` - Live-preview a data pipeline from local files: watch an \`f/<folder>\` of \`// pipeline\` scripts, push the working-tree graph to the dev page, and run the cascade via preview (no deploy).

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -3094,6 +3094,7 @@ inspect asset-driven pipelines (scripts marked \`// pipeline\`, wired by \`// on
   - \`--dry-run\` - Print the topological run plan without executing.
   - \`--json\` - Output the plan as JSON (for piping to jq).
   - \`--local\` - Run the local working-tree scripts via preview (no deploy) instead of the deployed versions; the graph is built from local files.
+  - \`--upload <binding:string>\` - Bind an object to a data_upload/webhook entry point so it runs in the cascade: <script>[:<param>]=<local-file|s3://key>. Local files are uploaded to the workspace store; the S3Object param is inferred when the script has exactly one. Repeatable.
 - \`pipeline docs <folder:string>\` - generate PIPELINE.md (+ AGENTS.md pointer) describing a folder's pipeline graph and datatable schemas, for an editor / agentic loop
   - \`--local\` - Build the graph from local working-tree files instead of the deployed workspace.
 - \`pipeline dev [folder:string]\` - Live-preview a data pipeline from local files: watch an \`f/<folder>\` of \`// pipeline\` scripts, push the working-tree graph to the dev page, and run the cascade via preview (no deploy).

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -3099,6 +3099,7 @@ inspect asset-driven pipelines (scripts marked \`// pipeline\`, wired by \`// on
 - \`pipeline dev [folder:string]\` - Live-preview a data pipeline from local files: watch an \`f/<folder>\` of \`// pipeline\` scripts, push the working-tree graph to the dev page, and run the cascade via preview (no deploy).
   - \`--port <port:number>\` - Port for the dev WebSocket server.
   - \`--no-open\` - Do not open the browser automatically.
+  - \`--frontend <origin:string>\` - Origin serving the /pipeline_dev page (e.g. http://localhost:3000 for a locally-run frontend). Defaults to the workspace remote; use it when the remote's deployed frontend predates the dev page.
 
 ### protection-rules
 

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -3087,11 +3087,18 @@ inspect asset-driven pipelines (scripts marked \`// pipeline\`, wired by \`// on
   - \`--json\` - Output as JSON (for piping to jq)
 - \`pipeline show <folder:string>\` - render a pipeline folder's DAG (sources, lineage, subscriptions) in the terminal
   - \`--json\` - Output the raw asset graph as JSON
+  - \`--local\` - Build the graph from local working-tree files (// pipeline scripts) instead of the deployed workspace — no deploy needed.
 - \`pipeline run <folder:string>\` - run a bounded cascade: from a schedule/manual root, fan downstream up to the --to end node(s)
   - \`--from <script:string>\` - Start script (short name or path). Defaults to the folder's sole schedule/manual root.
   - \`--to <node:string>\` - End node(s) to stop at — script names/paths or asset URIs (e.g. datatable://main/staged). Repeatable or comma-separated. Omit to run the full downstream.
   - \`--dry-run\` - Print the topological run plan without executing.
   - \`--json\` - Output the plan as JSON (for piping to jq).
+  - \`--local\` - Run the local working-tree scripts via preview (no deploy) instead of the deployed versions; the graph is built from local files.
+- \`pipeline docs <folder:string>\` - generate PIPELINE.md (+ AGENTS.md pointer) describing a folder's pipeline graph and datatable schemas, for an editor / agentic loop
+  - \`--local\` - Build the graph from local working-tree files instead of the deployed workspace.
+- \`pipeline dev [folder:string]\` - Live-preview a data pipeline from local files: watch an \`f/<folder>\` of \`// pipeline\` scripts, push the working-tree graph to the dev page, and run the cascade via preview (no deploy).
+  - \`--port <port:number>\` - Port for the dev WebSocket server.
+  - \`--no-open\` - Do not open the browser automatically.
 
 ### protection-rules
 

--- a/system_prompts/auto-generated/skills/cli-commands/SKILL.md
+++ b/system_prompts/auto-generated/skills/cli-commands/SKILL.md
@@ -431,7 +431,7 @@ inspect asset-driven pipelines (scripts marked `// pipeline`, wired by `// on <s
   - `--dry-run` - Print the topological run plan without executing.
   - `--json` - Output the plan as JSON (for piping to jq).
   - `--local` - Run the local working-tree scripts via preview (no deploy) instead of the deployed versions; the graph is built from local files.
-  - `--upload <binding:string>` - Bind an object to a data_upload/webhook entry point so it runs in the cascade: <script>[:<param>]=<local-file|s3://key>. Local files are uploaded to the workspace store; the S3Object param is inferred when the script has exactly one. Repeatable.
+  - `--upload <binding:string>` - Bind an object to a data_upload/webhook entry point so it runs in the cascade, as SCRIPT[:PARAM]=SOURCE (SOURCE is a local file or an s3://key). Local files are uploaded to the workspace store; the S3Object param is inferred when the script has exactly one. Repeatable.
 - `pipeline docs <folder:string>` - generate PIPELINE.md (+ AGENTS.md pointer) describing a folder's pipeline graph and datatable schemas, for an editor / agentic loop
   - `--local` - Build the graph from local working-tree files instead of the deployed workspace.
 - `pipeline dev [folder:string]` - Live-preview a data pipeline from local files: watch an `f/<folder>` of `// pipeline` scripts, push the working-tree graph to the dev page, and run the cascade via preview (no deploy).

--- a/system_prompts/auto-generated/skills/cli-commands/SKILL.md
+++ b/system_prompts/auto-generated/skills/cli-commands/SKILL.md
@@ -431,6 +431,7 @@ inspect asset-driven pipelines (scripts marked `// pipeline`, wired by `// on <s
   - `--dry-run` - Print the topological run plan without executing.
   - `--json` - Output the plan as JSON (for piping to jq).
   - `--local` - Run the local working-tree scripts via preview (no deploy) instead of the deployed versions; the graph is built from local files.
+  - `--upload <binding:string>` - Bind an object to a data_upload/webhook entry point so it runs in the cascade: <script>[:<param>]=<local-file|s3://key>. Local files are uploaded to the workspace store; the S3Object param is inferred when the script has exactly one. Repeatable.
 - `pipeline docs <folder:string>` - generate PIPELINE.md (+ AGENTS.md pointer) describing a folder's pipeline graph and datatable schemas, for an editor / agentic loop
   - `--local` - Build the graph from local working-tree files instead of the deployed workspace.
 - `pipeline dev [folder:string]` - Live-preview a data pipeline from local files: watch an `f/<folder>` of `// pipeline` scripts, push the working-tree graph to the dev page, and run the cascade via preview (no deploy).

--- a/system_prompts/auto-generated/skills/cli-commands/SKILL.md
+++ b/system_prompts/auto-generated/skills/cli-commands/SKILL.md
@@ -436,6 +436,7 @@ inspect asset-driven pipelines (scripts marked `// pipeline`, wired by `// on <s
 - `pipeline dev [folder:string]` - Live-preview a data pipeline from local files: watch an `f/<folder>` of `// pipeline` scripts, push the working-tree graph to the dev page, and run the cascade via preview (no deploy).
   - `--port <port:number>` - Port for the dev WebSocket server.
   - `--no-open` - Do not open the browser automatically.
+  - `--frontend <origin:string>` - Origin serving the /pipeline_dev page (e.g. http://localhost:3000 for a locally-run frontend). Defaults to the workspace remote; use it when the remote's deployed frontend predates the dev page.
 
 ### protection-rules
 

--- a/system_prompts/auto-generated/skills/cli-commands/SKILL.md
+++ b/system_prompts/auto-generated/skills/cli-commands/SKILL.md
@@ -424,11 +424,18 @@ inspect asset-driven pipelines (scripts marked `// pipeline`, wired by `// on <s
   - `--json` - Output as JSON (for piping to jq)
 - `pipeline show <folder:string>` - render a pipeline folder's DAG (sources, lineage, subscriptions) in the terminal
   - `--json` - Output the raw asset graph as JSON
+  - `--local` - Build the graph from local working-tree files (// pipeline scripts) instead of the deployed workspace — no deploy needed.
 - `pipeline run <folder:string>` - run a bounded cascade: from a schedule/manual root, fan downstream up to the --to end node(s)
   - `--from <script:string>` - Start script (short name or path). Defaults to the folder's sole schedule/manual root.
   - `--to <node:string>` - End node(s) to stop at — script names/paths or asset URIs (e.g. datatable://main/staged). Repeatable or comma-separated. Omit to run the full downstream.
   - `--dry-run` - Print the topological run plan without executing.
   - `--json` - Output the plan as JSON (for piping to jq).
+  - `--local` - Run the local working-tree scripts via preview (no deploy) instead of the deployed versions; the graph is built from local files.
+- `pipeline docs <folder:string>` - generate PIPELINE.md (+ AGENTS.md pointer) describing a folder's pipeline graph and datatable schemas, for an editor / agentic loop
+  - `--local` - Build the graph from local working-tree files instead of the deployed workspace.
+- `pipeline dev [folder:string]` - Live-preview a data pipeline from local files: watch an `f/<folder>` of `// pipeline` scripts, push the working-tree graph to the dev page, and run the cascade via preview (no deploy).
+  - `--port <port:number>` - Port for the dev WebSocket server.
+  - `--no-open` - Do not open the browser automatically.
 
 ### protection-rules
 


### PR DESCRIPTION
## Summary

Adds the local **edit → preview → run** loop for data pipelines (folders of `// pipeline`
scripts wired by `// on <asset>` annotations) — the pipeline analog of `wmill dev`
(flows/scripts) and `wmill app dev` (raw apps). A user (in their own editor or an agentic
loop) can build a full pipeline from working-tree files, see the same graph the UI shows,
and run it — **without deploying**.

**Key design decision — no backend changes.** Full body inference in the CLI comes from the
same wasm the frontend uses (`windmill-parser-wasm-asset`): `parse_assets_<ts|py|sql>` returns
body-inferred `assets` (r/w/rw) **and** the parsed pipeline annotations (`in_pipeline`,
`triggers`, `partition`) in one call. Local runs reuse the existing
`runScriptPreview(... _wmill_skip_asset_dispatch ...)` per node in topological order. No new
endpoint, no Rust, no TS re-port of the annotation parser.

📄 **Full design, language-coverage notes, test steps, and handoff TODOs:
[`docs/pipeline-local-dev.md`](../blob/feat/pipeline-local-dev/docs/pipeline-local-dev.md)** (committed in this PR).

## Changes

**CLI (`cli/src/commands/pipeline/`)**
- `localGraph.ts` (new) — the enabler: walks `f/<folder>` scripts, wasm-infers each, assembles
  the `/assets/graph`-shaped payload (`runnables`/`assets`/`edges`/`triggers`). SQL dialects route
  to `parse_assets_sql`; `go`/`bash` fall back to a minimal `// pipeline` + `// on` scan.
- `pipeline.ts` — `--local` on `show`/`run`; `show` split into graph-acquire + `renderGraph()` +
  deployed-only `enrichRootMarkers()`; `run --local` previews local content with `temp_script_refs`.
- `docs.ts` (new) — `pipeline docs <folder>`: writes `PIPELINE.md` (+ `AGENTS.md`/`CLAUDE.md`
  pointers) describing the graph + datatable schemas, for an editor/agent.
- `dev.ts` (new) — `pipeline dev [folder]`: folder arg or cwd auto-detect, watches the folder,
  pushes the rebuilt graph over a WebSocket, opens the dev page.
- Added `windmill-parser-wasm-asset` dep; regenerated CLI agent docs (`system_prompts/…`,
  `skills.gen.ts`) via `python system_prompts/generate.py`.

**Frontend**
- `cascadeRun.ts` (new) — reusable run primitives (`makeLaunch`/`makeWaitJobTerminal`/
  `runDownstreamCascade`/`runBoundedCascade`) wrapping `cascadeOrchestrator` + `graphTraversal`.
- `PipelineDevView.svelte` + `routes/pipeline_dev/+page.svelte` (new) — receives the WS bundle and
  renders the **same** `PipelineGraphEditor` (mode `view`) from the pushed local graph, running the
  cascade via preview. Editing stays in the user's editor; each save live-reloads.

## Screenshots

Live `/pipeline_dev` page rendering the demo all-DuckDB pipeline
(`ingest → s3://demo/raw.csv → transform → s3://demo/clean.csv → report`), built from local files
by the CLI's `localGraph` builder and pushed over the `pipeline dev` WebSocket — driven with
Playwright against this branch's frontend.

![Live graph](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/feat/pipeline-local-dev/1782815142-1-pipeline-dev-graph.png)

![Node selected — Run button + details pane](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/feat/pipeline-local-dev/1782815142-2-pipeline-dev-node-run.png)

![Run / Run + downstream cascade options](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/feat/pipeline-local-dev/1782815142-3-pipeline-dev-run-options.png)

Note: the demo used a placeholder token, so the details pane's deployed-script fetch shows
"Unauthorized" and the run buttons were not clicked through to execution — the graph render, live
"watching" WS status, node selection, and the Run / Run + downstream cascade affordances are what
these confirm. Executing a real cascade against a backend remains a test-plan item.

## Test plan

- [x] `pipeline show --local` renders a connected DAG from local files, fully offline (fixture verified)
- [x] `localGraph` unit tests + all 883 CLI unit tests pass; CLI `tsc` clean
- [x] frontend `npm run check` → 0 errors; svelte-autofixer clean
- [x] **`/pipeline_dev` browser preview renders** the pushed local graph (WS bundle → `PipelineGraphEditor`),
  with working node selection + Run / Run+downstream affordances (Playwright, screenshots above)
- [x] Execute a real `Run` / `Run + downstream` cascade against a backend (writes real assets) — validated on a live EE+MinIO stack
- [x] `pipeline run --local` against a real backend (executes via preview) — cascade all green, assets written

---

## Update — live-stack validation + dev-preview UX

The previously-deferred "execute a real cascade against a backend" item is now **done**. Brought up a
full EE stack (`duckdb,parquet,private,enterprise`) with MinIO object storage, seeded the all-DuckDB
demo, and ran the cascade both headlessly (`pipeline run --local`) and through the `/pipeline_dev`
browser UI. While validating, fixed one real bug and added dev-preview UX polish (one focused commit).

**Fixes & changes (frontend)**
- **Node selection no longer 404s.** The details pane fetched the *deployed* script for a selected
  node, but a local-dev pipeline has none → "Failed to load: Not Found" with no Run button. Added a
  `resolveLocalScript` path so `/pipeline_dev` serves the working-tree content as a read-only script
  with an **enabled Run** button (`AssetGraphDetailsPane`, `PipelineGraphEditor`, `PipelineDevView`).
- **Internal args as badges.** `_TEMP_SCRIPT_REFS` (+ `_wmill_skip_asset_dispatch`) now render as
  header badges instead of noisy arg rows; raw values stay in the JSON drawer/download (`JobArgs`).
- **Responsive layout.** Below 680px the graph/details split stacks vertically (all surfaces), and the
  minimap is hidden when stacked (`PipelineGraphEditor`, `AssetGraphCanvas`).
- **Activity panel in dev mode.** New `liveOnly` mode on `PipelineActivityPanel`, wired as the idle
  pane fed by live run events; the pane is collapsible in both orientations.

**Validation (live stack)**
- DuckDB→S3 write landed in MinIO; `pipeline run --local` cascade (ingest→transform→report) all green,
  `clean.csv` written with transformed rows.
- `/pipeline_dev` Run clicked in-browser → fresh job executed successfully.
- Type-check clean (no new errors in changed files), svelte-autofixer clean, 0 console errors.

### Screenshots

![Node selected — local source + enabled Run + result (404 fixed)](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/feat/pipeline-local-dev/1782837873-1-pipeline-dev-node-run-fixed.png)

![Activity panel in dev mode — live cascade runs](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/feat/pipeline-local-dev/1782837873-2-pipeline-dev-activity-populated.png)

![Narrow/vertical layout — stacked split, minimap hidden, activity pane collapsed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/feat/pipeline-local-dev/1782837873-3-pipeline-dev-stacked-collapsed.png)

![Internal args shown as badges (`_TEMP_SCRIPT_REFS`, asset-dispatch-skipped)](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/feat/pipeline-local-dev/1782837873-4-jobargs-temp-refs-badge.png)

**Follow-up:** the synthesized local script starts from an empty args schema, so a dev-preview node
with declared args won't render input fields yet — needs client-side schema inference (frontend
`inferArgs`).

---

## Dogfooding pass — canonical use-cases (edit-local → preview/run in web UI, agentic-loop framing)

Exercised the dev loop as an agent/editor would (scripts edited on disk, webview live-previews & runs). Verified correctness across simple + complex pipeline shapes and fixed the friction found.

**Verified correct**
- Single extract, linear ETL chain, **fan-out** (one asset → many consumers), **fan-in** (one consumer ← many sources).
- **Live reload**: add/edit/delete/rename a script → watcher rebuilds, WS pushes, graph updates with no page reload.
- **Failure mid-cascade**: cascade stops at the failing node (downstream not run, DB-verified), node badges show green ✓ / red ⊗, clicking the failed node shows the full DuckDB error.
- **Broken-edit resilience**: a Python syntax error degrades to annotation-only inference — the graph survives, the webview stays usable (important for an agent writing temporarily-invalid code).
- **Healthy fan-out cascade** runs all branches in topological order.

**Fixed (this PR)**
- **Parameterized nodes**: the dev-preview Run form showed "No inputs" for a node with declared args (`-- $min_id (INTEGER)`). Now infers the args schema client-side (`inferArgs`) so the run form renders inputs. Verified `min_id=3` → result `n=1`.
- **Multi-root pipelines**: `pipeline run <folder> --local` errored ("2 possible starts, pass --from") on a fan-in DAG. Now runs the whole pipeline in topological order (dbt-style) when no `--from`/`--to` — sources before the join.
- **Webview WS auto-reconnect**: the page never reconnected; restarting `pipeline dev` left it stuck "disconnected". Now auto-reconnects (1.5s backoff). Verified kill → "disconnected" → restart → auto-recovers to "watching".
- **`pipeline docs` footgun**: `pipeline docs <folder>` (no `--local`) said "No pipeline scripts" while local scripts existed; now detects them and hints `--local`.

### Dogfooding screenshots
![Parameterized node — run form now renders the `min_id` input](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/feat/pipeline-local-dev/1782839806-1-dogfood-param-runform-after.png)

![Live-reload + fan-out — added `aggregate` node appeared over the WS, no reload](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/feat/pipeline-local-dev/1782839806-2-dogfood-fanout-livereload.png)

![Mid-cascade failure — red node badge + full DuckDB Binder Error on the failed node](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/feat/pipeline-local-dev/1782839806-3-dogfood-transform-error.png)

- **Managed-materialize producer disconnect** — `-- materialize ducklake://…` producers showed as disconnected roots in the local graph. Root cause: the CLI pinned `windmill-parser-wasm-asset ^1.728.1`, which **predates** managed-materialize support (added in 1.733.1); the frontend already pins 1.740.0, so its wasm emits `// materialize` while the CLI's did not. Fix: bump the CLI to **1.740.0** (matching the frontend) and translate the parsed materialize target into the producer's write-edge + `materialize_target`, mirroring `resolveGraph.ts`. Regression test added. (Side benefit: the CLI's asset parser now matches the frontend across the other parser changes between 1.728.1→1.740.0 — column lineage, data tests, annotation false-positive fixes.)

![Managed-materialize producer now connects: load → users (ducklake) → consume](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/feat/pipeline-local-dev/1782840463-materialize-connected.png)

### Known follow-ups (noted, not fixed)
- **`/pipeline_dev` requires this build's frontend** — `wmill pipeline dev` opens `<remote>/pipeline_dev`, a route only present in this branch, so it 404s against a remote not yet running this build. Use the new **`--frontend <origin>`** flag to point the page at a locally-run frontend (`cd frontend && REMOTE=<remote> npm run dev`) while the API/token still target the remote: `wmill pipeline dev <folder> --frontend http://localhost:3000`.
- **Cross-language lineage**: connects only with the string-literal `'s3://bucket/key'` form; the object/constructor forms (`S3Object(s3="x")`, TS `{s3:"x"}`) yield inconsistent paths (no edge / leading slash) → silent lineage break. Root cause is the shared wasm asset parser (deployed inference too); fixing in `localGraph` alone would diverge local-dev from the deployed graph.
- **Cascade failure UX**: the details pane stays on the originally-selected node; the user must click the red node to read the error (badge + toast point to it).
- **`PIPELINE.md` (agent context)** omits node params — a reader can't tell a node is parameterized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





