### PR TITLE
feat(object-store): make GCS service account key optional for Workload Identity

### DIFF
--- a/backend/windmill-api-settings/src/lib.rs
+++ b/backend/windmill-api-settings/src/lib.rs
@@ -406,7 +406,11 @@ async fn validate_object_storage_test(settings: &ObjectSettings) -> error::Resul
             )
         }
         ObjectSettings::Gcs(gcs) => {
-            if gcs.service_account_key.is_empty() {
+            // Mirror `build_gcs_client`'s blank-key check (shared predicate): a blank/`{}` key falls
+            // back to the instance's ambient credentials there, so it must be rejected here too —
+            // otherwise an untrusted caller could probe with the server's identity (the very
+            // SSRF/credential-exfil this function guards against).
+            if windmill_object_store::gcs_service_account_key_is_blank(&gcs.service_account_key) {
                 return Err(error::Error::NotAuthorized(
                     "Testing GCS storage without a service account key requires a super admin"
                         .to_string(),
@@ -2185,6 +2189,26 @@ mod object_storage_test_hardening {
                 .await
                 .is_ok()
         );
+    }
+
+    #[tokio::test]
+    async fn rejects_gcs_blank_service_account_key() {
+        // A blank key makes build_gcs_client fall back to the instance's ambient credentials, so an
+        // untrusted caller must not be allowed to test with it. The `serviceAccountKey` field is
+        // serialized via serde's `as_string` (`to_string` of the JSON value), so the settings UI's
+        // "no key" empty object arrives as `"{}"` and a null as `"null"` — both must be rejected.
+        for key in [serde_json::json!({}), serde_json::json!(null)] {
+            let settings: ObjectSettings = serde_json::from_value(serde_json::json!({
+                "type": "Gcs",
+                "bucket": "b",
+                "serviceAccountKey": key
+            }))
+            .unwrap();
+            assert!(
+                validate_object_storage_test(&settings).await.is_err(),
+                "blank key {key:?} should be rejected"
+            );
+        }
     }
 
     fn ip(s: &str) -> IpAddr {

--- a/backend/windmill-object-store/src/lib.rs
+++ b/backend/windmill-object-store/src/lib.rs
@@ -494,6 +494,23 @@ fn build_azure_blob_client(
     return Ok(Arc::new(store));
 }
 
+/// Whether a GCS `service_account_key` carries no static credentials, in which case the client
+/// should fall back to the instance's ambient credentials (GKE Workload Identity / metadata server)
+/// instead of being handed an unparseable key. Besides an empty/whitespace string, the settings UI
+/// stores "no key" as an empty JSON object `{}` (and `serde_json` may yield `null`), so treat those
+/// as absent too. Shared with the connectivity-test SSRF guard so both agree on what "no key" means.
+pub fn gcs_service_account_key_is_blank(service_account_key: &str) -> bool {
+    let trimmed = service_account_key.trim();
+    if trimmed.is_empty() {
+        return true;
+    }
+    match serde_json::from_str::<serde_json::Value>(trimmed) {
+        Ok(serde_json::Value::Null) => true,
+        Ok(serde_json::Value::Object(map)) => map.is_empty(),
+        _ => false,
+    }
+}
+
 #[cfg(feature = "parquet")]
 async fn build_gcs_client(gcs_resource_ref: &GcsResource) -> error::Result<Arc<dyn ObjectStore>> {
     let gcs_resource = gcs_resource_ref.clone();
@@ -509,7 +526,12 @@ async fn build_gcs_client(gcs_resource_ref: &GcsResource) -> error::Result<Arc<d
         )
         .with_bucket_name(gcs_resource.bucket);
 
-    store_builder = store_builder.with_service_account_key(gcs_resource.service_account_key);
+    // A blank key means no static credentials: let the builder fall back to the metadata server
+    // (InstanceCredentialProvider) so GKE Workload Identity / ambient credentials work. Passing a
+    // blank/`{}` key to `with_service_account_key` would instead fail to parse.
+    if !gcs_service_account_key_is_blank(&gcs_resource.service_account_key) {
+        store_builder = store_builder.with_service_account_key(gcs_resource.service_account_key);
+    }
 
     let store = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| store_builder.build()))
         .map_err(|panic_info| {
@@ -1701,6 +1723,40 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("GCS is not supported"));
+    }
+
+    #[test]
+    fn test_gcs_service_account_key_is_blank() {
+        for blank in ["", "   ", "\n\t", "{}", "  {}  ", "null"] {
+            assert!(
+                gcs_service_account_key_is_blank(blank),
+                "{blank:?} should be treated as no key"
+            );
+        }
+        for present in ["{\"client_email\":\"x@y.z\"}", "not json"] {
+            assert!(
+                !gcs_service_account_key_is_blank(present),
+                "{present:?} should be treated as a key"
+            );
+        }
+    }
+
+    #[cfg(feature = "parquet")]
+    #[tokio::test]
+    async fn test_build_gcs_client_blank_key_uses_instance_credentials() {
+        // A blank service account key must not be passed to `with_service_account_key`
+        // (which would fail to parse): the builder should fall back to instance credentials
+        // (GKE Workload Identity / metadata server) and construct successfully. `{}` is the
+        // settings UI's representation of "no key".
+        for key in ["", "   ", "{}"] {
+            let resource =
+                GcsResource { bucket: "bucket".to_string(), service_account_key: key.to_string() };
+            assert!(
+                build_gcs_client(&resource).await.is_ok(),
+                "blank key {:?} should build via instance credentials",
+                key
+            );
+        }
     }
 
     #[test]

--- a/frontend/src/lib/components/ObjectStoreConfigSettings.svelte
+++ b/frontend/src/lib/components/ObjectStoreConfigSettings.svelte
@@ -690,7 +690,10 @@
 					/>
 				</Label>
 				<Label label="Service Account Key">
-					<span class="text-primary text-2xs">JSON content of the service account key file</span>
+					<span class="text-primary text-2xs">
+						JSON content of the service account key file. Leave empty to use the instance's ambient
+						credentials (e.g. GKE Workload Identity / the GCP metadata server).
+					</span>
 					{#if hasServiceAccountKey && !showServiceAccountKey}
 						<div class="flex items-center gap-3 mt-1">
 							<span class="text-tertiary text-xs">


### PR DESCRIPTION
## Summary

Make the GCS `service_account_key` optional so a Windmill deployment can rely on **GKE Workload Identity** (or any ambient GCP credentials via the metadata server) instead of a static key — useful when the bucket lives in the same GCP project as Windmill.

Previously `build_gcs_client` always called `.with_service_account_key(...)`. The settings UI stores "no key" as the empty JSON object `{}` (serialized to the string `"{}"` via serde's `as_string`), so the builder was handed `"{}"`, which fails to parse instead of falling through to the `object_store` crate's `InstanceCredentialProvider`. We now skip the call when the key is blank.

Fixes WIN-2110

## Changes

- `windmill-object-store`: add a shared `gcs_service_account_key_is_blank` predicate (treats empty / whitespace-only / `{}` / `null` as "no key") and skip `with_service_account_key` in `build_gcs_client` when blank, so GCS falls back to instance credentials.
- `windmill-api-settings`: the non-super-admin connectivity-test SSRF guard (`validate_object_storage_test`) now uses the **same** predicate. This is load-bearing: without it a blank key would slip past the guard yet still trigger the ambient-credential fallback in `build_gcs_client`, letting an untrusted Cloud caller probe arbitrary buckets signed with the server's instance role. Super admins still bypass the guard entirely, and a real key is still URL-validated against internal/metadata hosts.
- Frontend: clarify the "Service Account Key" hint that it may be left empty for ambient credentials (GKE Workload Identity / GCP metadata server).
- Tests: `gcs_service_account_key_is_blank` unit test, `build_gcs_client` blank-key build path, and a guard regression test asserting `{}`/`null` keys are rejected for untrusted callers.

## Screenshots

Instance settings → Object storage → Google Cloud Storage, showing the updated hint:

![gcs-form-optional-key](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2110-make-gcs-service-account-key-optional-for-workload-identity/1782830285-gcs-form-optional-key.png)

## Test plan

- [x] `cargo test -p windmill-object-store -p windmill-api-settings --features parquet` (new + existing GCS/SSRF tests pass)
- [x] Frontend `check:fast` clean for the touched file; UI hint verified in browser
- [ ] On a GKE/Workload-Identity instance: leave the key empty, confirm reads/writes succeed via the metadata server
- [ ] As a non-super-admin on Cloud: testing GCS with a blank/`{}` key returns "requires a super admin" (no ambient fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the GCS service account key optional and fall back to ambient GCP credentials (e.g. GKE Workload Identity) when the key is blank. Align the connectivity-test guard to prevent untrusted callers from using the server’s instance identity. Fixes WIN-2110.

- New Features
  - `windmill-object-store`: Skip `with_service_account_key` when `gcs_service_account_key_is_blank(...)` is true (treats `""`, whitespace, `{}`, `null` as no key), so GCS uses metadata-server credentials.
  - Frontend: Clarified the “Service Account Key” hint to note that it can be left empty for ambient credentials.

- Bug Fixes
  - `windmill-api-settings`: Connectivity-test guard uses the same blank-key predicate and rejects blank keys for non–super-admins to avoid SSRF/credential abuse.
  - Tests: Added unit and regression tests for the predicate, blank-key build path, and guard behavior.

<sup>Written for commit a980bbba1cf693c71c4fb09c296c567dbac778c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

