### PR TITLE
fix(ai-chat): replay anthropic turns verbatim to keep thinking valid

### DIFF
--- a/frontend/src/lib/components/copilot/chat/anthropic.test.ts
+++ b/frontend/src/lib/components/copilot/chat/anthropic.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ChatCompletionMessageParam } from 'openai/resources/index.mjs'
+import { convertOpenAIToAnthropicMessages } from './anthropic'
+
+// anthropic.ts pulls in the chat client/registry layer at import time; the
+// converter under test is pure, so stub those side-effecting modules away.
+vi.mock('../lib', () => ({
+	getProviderAndCompletionConfig: vi.fn(),
+	workspaceAIClients: {}
+}))
+
+vi.mock('../reasoningRegistry', () => ({
+	applyReasoningToConfig: vi.fn()
+}))
+
+vi.mock('./shared', () => ({
+	processToolCall: vi.fn()
+}))
+
+describe('convertOpenAIToAnthropicMessages', () => {
+	it('replays a captured assistant turn verbatim, skips the standalone text copy, and leaves the turn untouched', () => {
+		const anthropicContent = [
+			{ type: 'thinking', thinking: 'first', signature: 'sig-1' },
+			{
+				type: 'server_tool_use',
+				id: 'srv_1',
+				name: 'web_search',
+				input: { query: 'nist password length' }
+			},
+			{
+				type: 'web_search_tool_result',
+				tool_use_id: 'srv_1',
+				content: [{ type: 'web_search_result', title: 'NIST', url: 'https://nist.gov' }]
+			},
+			{ type: 'thinking', thinking: 'second', signature: 'sig-2' },
+			{ type: 'tool_use', id: 'tool_1', name: 'list_resources', input: {} }
+		]
+		// Snapshot to assert the stored content is never mutated by the converter.
+		const anthropicContentSnapshot = JSON.parse(JSON.stringify(anthropicContent))
+
+		const messages: ChatCompletionMessageParam[] = [
+			{ role: 'user', content: 'find the nist length then list resources' },
+			// Standalone text the streamer emits before the tool-call message.
+			{ role: 'assistant', content: 'Let me search the web.' },
+			{
+				role: 'assistant',
+				tool_calls: [
+					{
+						id: 'tool_1',
+						type: 'function',
+						function: { name: 'list_resources', arguments: '{}' }
+					}
+				],
+				_anthropicContent: anthropicContent
+			} as any,
+			{ role: 'tool', tool_call_id: 'tool_1', content: 'resource A, resource B' }
+		]
+
+		const { messages: out } = convertOpenAIToAnthropicMessages(messages)
+
+		// user + the verbatim assistant turn + the tool result; the standalone text is dropped.
+		expect(out).toHaveLength(3)
+		expect(out[0]).toEqual({ role: 'user', content: 'find the nist length then list resources' })
+
+		// Assistant turn replayed in original order, no reordering or dropped blocks.
+		expect(out[1].role).toBe('assistant')
+		expect((out[1].content as any[]).map((b) => b.type)).toEqual([
+			'thinking',
+			'server_tool_use',
+			'web_search_tool_result',
+			'thinking',
+			'tool_use'
+		])
+		// The verbatim turn must stay byte-identical — no cache_control injected into it,
+		// or a thinking-block signature would no longer validate.
+		expect(out[1].content).toEqual(anthropicContentSnapshot)
+		expect((out[1].content as any[]).some((b) => 'cache_control' in b)).toBe(false)
+		expect(anthropicContent).toEqual(anthropicContentSnapshot)
+
+		// The cache breakpoint lands on the trailing tool result, not the assistant turn.
+		expect(out[2]).toEqual({
+			role: 'user',
+			content: [
+				{
+					type: 'tool_result',
+					tool_use_id: 'tool_1',
+					content: 'resource A, resource B',
+					cache_control: { type: 'ephemeral' }
+				}
+			]
+		})
+	})
+
+	it('converts a plain text assistant turn (no tools) and caches the trailing text block', () => {
+		const messages: ChatCompletionMessageParam[] = [
+			{ role: 'user', content: 'hello' },
+			{ role: 'assistant', content: 'hi there' }
+		]
+
+		const { messages: out } = convertOpenAIToAnthropicMessages(messages)
+
+		expect(out).toHaveLength(2)
+		expect(out[0]).toEqual({ role: 'user', content: 'hello' })
+		expect(out[1].role).toBe('assistant')
+		expect(out[1].content).toEqual([
+			{ type: 'text', text: 'hi there', cache_control: { type: 'ephemeral' } }
+		])
+	})
+
+	it('falls back to _anthropicThinkingBlocks for turns persisted before _anthropicContent', () => {
+		const thinkingBlocks = [{ type: 'thinking', thinking: 'reasoning', signature: 'sig-old' }]
+
+		const messages: ChatCompletionMessageParam[] = [
+			{ role: 'user', content: 'do a thing' },
+			// The standalone text persisted alongside an old-style turn must NOT be skipped
+			// (the fallback reconstruction relies on it for the assistant text).
+			{ role: 'assistant', content: 'working on it' },
+			{
+				role: 'assistant',
+				tool_calls: [
+					{
+						id: 'tool_old',
+						type: 'function',
+						function: { name: 'list_resources', arguments: '{}' }
+					}
+				],
+				_anthropicThinkingBlocks: thinkingBlocks
+			} as any
+		]
+
+		const { messages: out } = convertOpenAIToAnthropicMessages(messages)
+
+		expect(out).toHaveLength(3)
+		expect(out[1]).toEqual({ role: 'assistant', content: 'working on it' })
+		const content = out[2].content as any[]
+		// Thinking block re-injected first, then the tool_use.
+		expect(content.map((b) => b.type)).toEqual(['thinking', 'tool_use'])
+		expect(content[0]).toEqual(thinkingBlocks[0])
+		expect(content[1]).toMatchObject({ type: 'tool_use', id: 'tool_old', name: 'list_resources' })
+	})
+
+	it('caches a trailing tool result even when the prior turn used no captured content', () => {
+		const messages: ChatCompletionMessageParam[] = [
+			{ role: 'user', content: 'q' },
+			{
+				role: 'assistant',
+				tool_calls: [
+					{ id: 't1', type: 'function', function: { name: 'list_resources', arguments: '{}' } }
+				]
+			} as any,
+			{ role: 'tool', tool_call_id: 't1', content: 'done' }
+		]
+
+		const { messages: out } = convertOpenAIToAnthropicMessages(messages)
+
+		const last = out[out.length - 1]
+		expect(last.role).toBe('user')
+		expect((last.content as any[])[0]).toMatchObject({
+			type: 'tool_result',
+			tool_use_id: 't1',
+			cache_control: { type: 'ephemeral' }
+		})
+	})
+})

--- a/frontend/src/lib/components/copilot/chat/anthropic.ts
+++ b/frontend/src/lib/components/copilot/chat/anthropic.ts
@@ -286,15 +286,15 @@ export async function parseAnthropicCompletion(
 			role: 'assistant',
 			tool_calls: toolCallsToProcess
 		}
-		// Preserve thinking blocks (with signatures) so the next request keeps the
-		// reasoning chain — Anthropic requires this when thinking is combined with tool
-		// use. They are re-injected by convertOpenAIToAnthropicMessages.
-		const thinkingBlocks = finalMessage.content.filter(
-			(b) => b.type === 'thinking' || b.type === 'redacted_thinking'
-		)
-		if (thinkingBlocks.length > 0) {
-			;(assistantWithTools as any)._anthropicThinkingBlocks = thinkingBlocks
-		}
+		// Preserve the assistant turn verbatim (thinking/redacted_thinking with their
+		// signatures, server_tool_use + web_search_tool_result, text and tool_use) in
+		// original order. Anthropic binds each thinking block's signature to the blocks
+		// that precede it in the latest assistant message, so when this turn is replayed
+		// to continue past its tool call it must be byte-identical: reordering thinking to
+		// the front or dropping the web-search blocks invalidates a later block's
+		// signature and the request 400s with "thinking blocks ... cannot be modified".
+		// convertOpenAIToAnthropicMessages replays this content as-is.
+		;(assistantWithTools as any)._anthropicContent = finalMessage.content
 		messages.push(assistantWithTools)
 		addedMessages.push(assistantWithTools)
 
@@ -323,7 +323,33 @@ export function convertOpenAIToAnthropicMessages(messages: ChatCompletionMessage
 	let system: TextBlockParam[] | undefined
 	const anthropicMessages: MessageParam[] = []
 
-	for (const message of messages) {
+	// A streamed assistant turn that ends in tool calls is persisted as one or more
+	// standalone text messages followed by the tool-call message carrying
+	// _anthropicContent. That text is already inside _anthropicContent (replayed verbatim
+	// below), so drop the standalone copies — otherwise the text is duplicated and
+	// emitted ahead of the turn's thinking blocks. The scan stops at the preceding
+	// user/tool message, so only the current turn's own text is skipped.
+	const skipStandaloneText = new Set<number>()
+	for (let i = 0; i < messages.length; i++) {
+		if (!(messages[i] as any)._anthropicContent) continue
+		for (let j = i - 1; j >= 0; j--) {
+			const m = messages[j]
+			if (
+				m.role === 'assistant' &&
+				typeof m.content === 'string' &&
+				!m.tool_calls &&
+				!(m as any)._anthropicContent
+			) {
+				skipStandaloneText.add(j)
+			} else {
+				break
+			}
+		}
+	}
+
+	for (let i = 0; i < messages.length; i++) {
+		const message = messages[i]
+		if (skipStandaloneText.has(i)) continue
 		if (message.role === 'system') {
 			const systemText =
 				typeof message.content === 'string' ? message.content : JSON.stringify(message.content)
@@ -345,10 +371,19 @@ export function convertOpenAIToAnthropicMessages(messages: ChatCompletionMessage
 					typeof message.content === 'string' ? message.content : JSON.stringify(message.content)
 			})
 		} else if (message.role === 'assistant') {
+			// Replay a captured assistant turn verbatim so its thinking-block signatures
+			// stay valid (see the _anthropicContent note where the streamed turn is stored).
+			const anthropicContent = (message as any)._anthropicContent
+			if (Array.isArray(anthropicContent) && anthropicContent.length > 0) {
+				anthropicMessages.push({ role: 'assistant', content: anthropicContent as any })
+				continue
+			}
+
 			const content: any[] = []
 
-			// Re-inject preserved thinking blocks first (Anthropic requires thinking to
-			// precede tool_use in the same assistant turn when thinking is enabled).
+			// Fallback for sessions persisted before _anthropicContent existed: re-inject
+			// the preserved thinking blocks first (Anthropic requires thinking to precede
+			// tool_use in the same assistant turn when thinking is enabled).
 			const thinkingBlocks = (message as any)._anthropicThinkingBlocks
 			if (Array.isArray(thinkingBlocks) && thinkingBlocks.length > 0) {
 				content.push(...thinkingBlocks)
@@ -404,26 +439,29 @@ export function convertOpenAIToAnthropicMessages(messages: ChatCompletionMessage
 		}
 	}
 
-	// Add cache_control to the last message content blocks
+	// Cache the conversation prefix: put an ephemeral breakpoint on the last content
+	// block of the last message. Each continuation only appends a tool result plus the
+	// next turn, so everything up to here is read from cache — which is what keeps
+	// replaying assistant turns verbatim (web-search results included) affordable.
+	// cache_control is valid on text/tool_use/tool_result blocks, but a thinking or
+	// redacted_thinking block must never be modified, so skip the breakpoint there.
 	if (anthropicMessages.length > 0) {
 		const lastMessage = anthropicMessages[anthropicMessages.length - 1]
-		if (Array.isArray(lastMessage.content)) {
-			// Add cache_control to the last content block
-			if (lastMessage.content.length > 0) {
-				const lastBlock = lastMessage.content[lastMessage.content.length - 1]
-				if (lastBlock.type === 'text') {
-					lastBlock.cache_control = { type: 'ephemeral' }
-				}
-			}
-		} else if (typeof lastMessage.content === 'string') {
-			// Convert string content to array format with cache_control
+		if (typeof lastMessage.content === 'string') {
 			lastMessage.content = [
-				{
-					type: 'text',
-					text: lastMessage.content,
-					cache_control: { type: 'ephemeral' }
-				}
+				{ type: 'text', text: lastMessage.content, cache_control: { type: 'ephemeral' } }
 			]
+		} else if (Array.isArray(lastMessage.content) && lastMessage.content.length > 0) {
+			const lastIndex = lastMessage.content.length - 1
+			const lastBlock = lastMessage.content[lastIndex] as any
+			if (lastBlock.type !== 'thinking' && lastBlock.type !== 'redacted_thinking') {
+				// Clone the block instead of mutating in place: the array may be a verbatim
+				// _anthropicContent turn that must stay unaltered for later requests.
+				lastMessage.content = [
+					...lastMessage.content.slice(0, lastIndex),
+					{ ...lastBlock, cache_control: { type: 'ephemeral' } }
+				]
+			}
 		}
 	}
 


### PR DESCRIPTION
Supersedes #9841 (same bug, reworked fix with correct cache_control and live verification).

## Problem

In the global AI chat, an Anthropic assistant turn that combines extended thinking + the native `web_search` tool + a client tool call dies with a 400 on the next (auto-continuation) request:

```
400 invalid_request_error
messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest assistant
message cannot be modified. These blocks must remain as they were in the original response.
```

Anthropic binds each thinking block's signature to the blocks that precede it in the latest assistant message. The replay path stored only the thinking blocks, re-injected them **at the front**, and dropped the `server_tool_use` / `web_search_tool_result` blocks. With interleaved thinking (a 2nd thinking block sitting *after* the web-search result), moving it to the front and dropping the web-search blocks changes its context, so its signature no longer validates.

This only bites when all three hold: thinking is on, the latest turn used `web_search` (producing a non-leading thinking block), and that turn ended in a client tool call (so the continuation resends it as the latest assistant message). A normal `[thinking, tool_use]` turn is unaffected because the single thinking block is already first.

## Fix

- Store the full assistant turn verbatim as `_anthropicContent = finalMessage.content` (thinking/redacted_thinking with signatures, `server_tool_use` + `web_search_tool_result`, text, `tool_use`) instead of the thinking-only `_anthropicThinkingBlocks`.
- Replay it unchanged in `convertOpenAIToAnthropicMessages` — original order, nothing dropped, nothing reordered.
- Skip the standalone text message the streamer emits before the tool-call message (its text is already inside `_anthropicContent`). The backward scan is bounded by the preceding user/tool message, so only the current turn's own text is dropped.
- Keep the old `_anthropicThinkingBlocks` reconstruction as a fallback for sessions persisted before this change.

## Cache-control rework

Previously the trailing `cache_control` breakpoint was added only when the last block was `text`. On a continuation request the last message is a `tool_result`, so **nothing** was cached — every continuation re-read the whole growing prefix at full price, which is exactly what makes resending verbatim web-search blocks expensive.

- The breakpoint now lands on the last content block of the last message for any non-thinking block type (text / tool_use / tool_result), so the conversation prefix is cached across the agentic loop and the resent verbatim blocks are a cache hit.
- `thinking` / `redacted_thinking` blocks are never given `cache_control` (modifying them re-breaks the signature).
- The block is **cloned** rather than mutated in place, so a verbatim `_anthropicContent` turn is never altered for a later request.

## Verification (live, against the real Anthropic API)

Ran the repro end-to-end in the global chat (`claude-sonnet-4-6`, effort `high`, web search enabled): *"Search the web for the current NIST SP 800-63B minimum password length. After you get the number, in a follow-up step list the resources in my workspace. Think step by step between each tool call."*

Captured the outgoing body of the continuation request (the one that 400s on `main`):

| Check | Result |
|---|---|
| HTTP status | **200** |
| Assistant turn blocks | `[thinking, text, server_tool_use, web_search_tool_result, thinking, text, tool_use]` — verbatim, **not** collapsed to `["thinking","thinking","tool_use"]` |
| 2nd thinking block signature | present, in original position |
| cache_control on verbatim blocks | none (turn left byte-identical) |
| Last message / block | `user` / `tool_result`, **cache_control present** |
| System prompt cache_control | present |

The turn completed: web search → reasoning → workspace tool call → final answer combining both.

## Screenshots

![global-chat-thinking-websearch-fix](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/hugo/fix-ai-chat-thinking-verbatim/1782834416-global-chat-thinking-websearch-fix.png)

## Notes

- Only new sessions are fixed; sessions already persisted in the old shape use the fallback and can still 400 in the web-search case. Start a fresh session to test.
- No change to display/persistence shape — only the Anthropic request reconstruction.

## Test plan

- [x] `frontend/src/lib/components/copilot/chat/anthropic.test.ts` — verbatim replay, standalone-text skip, verbatim turn left unmutated, cache breakpoint on the trailing tool_result, plain-text caching, and the `_anthropicThinkingBlocks` fallback (4 cases pass)
- [x] `npm run check:fast`
- [x] Live repro against the real Anthropic API (see Verification)
