### PR TITLE
fix(ai-chat): replay anthropic turns verbatim to keep thinking valid

### DIFF
--- a/frontend/src/lib/components/copilot/chat/anthropic.test.ts
+++ b/frontend/src/lib/components/copilot/chat/anthropic.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ChatCompletionMessageParam } from 'openai/resources/index.mjs'
+import { convertOpenAIToAnthropicMessages } from './anthropic'
+
+// anthropic.ts pulls in the chat client/registry layer at import time; the
+// converter under test is pure, so stub those side-effecting modules away.
+vi.mock('../lib', () => ({
+	getProviderAndCompletionConfig: vi.fn(),
+	workspaceAIClients: {}
+}))
+
+vi.mock('../reasoningRegistry', () => ({
+	applyReasoningToConfig: vi.fn()
+}))
+
+vi.mock('./shared', () => ({
+	processToolCall: vi.fn()
+}))
+
+describe('convertOpenAIToAnthropicMessages', () => {
+	it('replays a captured assistant turn verbatim, skips the standalone text copy, and leaves the turn untouched', () => {
+		const anthropicContent = [
+			{ type: 'thinking', thinking: 'first', signature: 'sig-1' },
+			{
+				type: 'server_tool_use',
+				id: 'srv_1',
+				name: 'web_search',
+				input: { query: 'nist password length' }
+			},
+			{
+				type: 'web_search_tool_result',
+				tool_use_id: 'srv_1',
+				content: [{ type: 'web_search_result', title: 'NIST', url: 'https://nist.gov' }]
+			},
+			{ type: 'thinking', thinking: 'second', signature: 'sig-2' },
+			{ type: 'tool_use', id: 'tool_1', name: 'list_resources', input: {} }
+		]
+		// Snapshot to assert the stored content is never mutated by the converter.
+		const anthropicContentSnapshot = JSON.parse(JSON.stringify(anthropicContent))
+
+		const messages: ChatCompletionMessageParam[] = [
+			{ role: 'user', content: 'find the nist length then list resources' },
+			// Standalone text the streamer emits before the tool-call message.
+			{ role: 'assistant', content: 'Let me search the web.' },
+			{
+				role: 'assistant',
+				tool_calls: [
+					{
+						id: 'tool_1',
+						type: 'function',
+						function: { name: 'list_resources', arguments: '{}' }
+					}
+				],
+				_anthropicContent: anthropicContent
+			} as any,
+			{ role: 'tool', tool_call_id: 'tool_1', content: 'resource A, resource B' }
+		]
+
+		const { messages: out } = convertOpenAIToAnthropicMessages(messages)
+
+		// user + the verbatim assistant turn + the tool result; the standalone text is dropped.
+		expect(out).toHaveLength(3)
+		expect(out[0]).toEqual({ role: 'user', content: 'find the nist length then list resources' })
+
+		// Assistant turn replayed in original order, no reordering or dropped blocks.
+		expect(out[1].role).toBe('assistant')
+		expect((out[1].content as any[]).map((b) => b.type)).toEqual([
+			'thinking',
+			'server_tool_use',
+			'web_search_tool_result',
+			'thinking',
+			'tool_use'
+		])
+		// The verbatim turn must stay byte-identical — no cache_control injected into it,
+		// or a thinking-block signature would no longer validate.
+		expect(out[1].content).toEqual(anthropicContentSnapshot)
+		expect((out[1].content as any[]).some((b) => 'cache_control' in b)).toBe(false)
+		expect(anthropicContent).toEqual(anthropicContentSnapshot)
+
+		// The cache breakpoint lands on the trailing tool result, not the assistant turn.
+		expect(out[2]).toEqual({
+			role: 'user',
+			content: [
+				{
+					type: 'tool_result',
+					tool_use_id: 'tool_1',
+					content: 'resource A, resource B',
+					cache_control: { type: 'ephemeral' }
+				}
+			]
+		})
+	})
+
+	it('converts a plain text assistant turn (no tools) and caches the trailing text block', () => {
+		const messages: ChatCompletionMessageParam[] = [
+			{ role: 'user', content: 'hello' },
+			{ role: 'assistant', content: 'hi there' }
+		]
+
+		const { messages: out } = convertOpenAIToAnthropicMessages(messages)
+
+		expect(out).toHaveLength(2)
+		expect(out[0]).toEqual({ role: 'user', content: 'hello' })
+		expect(out[1].role).toBe('assistant')
+		expect(out[1].content).toEqual([
+			{ type: 'text', text: 'hi there', cache_control: { type: 'ephemeral' } }
+		])
+	})
+
+	it('falls back to _anthropicThinkingBlocks for turns persisted before _anthropicContent', () => {
+		const thinkingBlocks = [{ type: 'thinking', thinking: 'reasoning', signature: 'sig-old' }]
+
+		const messages: ChatCompletionMessageParam[] = [
+			{ role: 'user', content: 'do a thing' },
+			// The standalone text persisted alongside an old-style turn must NOT be skipped
+			// (the fallback reconstruction relies on it for the assistant text).
+			{ role: 'assistant', content: 'working on it' },
+			{
+				role: 'assistant',
+				tool_calls: [
+					{
+						id: 'tool_old',
+						type: 'function',
+						function: { name: 'list_resources', arguments: '{}' }
+					}
+				],
+				_anthropicThinkingBlocks: thinkingBlocks
+			} as any
+		]
+
+		const { messages: out } = convertOpenAIToAnthropicMessages(messages)
+
+		expect(out).toHaveLength(3)
+		expect(out[1]).toEqual({ role: 'assistant', content: 'working on it' })
+		const content = out[2].content as any[]
+		// Thinking block re-injected first, then the tool_use.
+		expect(content.map((b) => b.type)).toEqual(['thinking', 'tool_use'])
+		expect(content[0]).toEqual(thinkingBlocks[0])
+		expect(content[1]).toMatchObject({ type: 'tool_use', id: 'tool_old', name: 'list_resources' })
+	})
+
+	it('caches a trailing tool result even when the prior turn used no captured content', () => {
+		const messages: ChatCompletionMessageParam[] = [
+			{ role: 'user', content: 'q' },
+			{
+				role: 'assistant',
+				tool_calls: [
+					{ id: 't1', type: 'function', function: { name: 'list_resources', arguments: '{}' } }
+				]
+			} as any,
+			{ role: 'tool', tool_call_id: 't1', content: 'done' }
+		]
+
+		const { messages: out } = convertOpenAIToAnthropicMessages(messages)
+
+		const last = out[out.length - 1]
+		expect(last.role).toBe('user')
+		expect((last.content as any[])[0]).toMatchObject({
+			type: 'tool_result',
+			tool_use_id: 't1',
+			cache_control: { type: 'ephemeral' }
+		})
+	})
+})

--- a/frontend/src/lib/components/copilot/chat/anthropic.test.ts
+++ b/frontend/src/lib/components/copilot/chat/anthropic.test.ts
@@ -161,4 +161,64 @@ describe('convertOpenAIToAnthropicMessages', () => {
 			cache_control: { type: 'ephemeral' }
 		})
 	})
+
+	it("preserves an earlier turn's standalone answer separated by a user message", () => {
+		const anthropicContent = [
+			{ type: 'thinking', thinking: 't', signature: 'sig' },
+			{ type: 'tool_use', id: 'tool_2', name: 'list_resources', input: {} }
+		]
+
+		const messages: ChatCompletionMessageParam[] = [
+			{ role: 'user', content: 'first question' },
+			// Turn 1's final answer — must survive; it belongs to a different turn.
+			{ role: 'assistant', content: 'answer to the first turn' },
+			{ role: 'user', content: 'second question' },
+			// Turn 2's standalone text — this is the one that should be dropped.
+			{ role: 'assistant', content: 'let me check' },
+			{
+				role: 'assistant',
+				tool_calls: [
+					{ id: 'tool_2', type: 'function', function: { name: 'list_resources', arguments: '{}' } }
+				],
+				_anthropicContent: anthropicContent
+			} as any
+		]
+
+		const { messages: out } = convertOpenAIToAnthropicMessages(messages)
+
+		// Only turn 2's standalone text is dropped; turn 1's answer is untouched.
+		expect(out).toHaveLength(4)
+		expect(out[0]).toEqual({ role: 'user', content: 'first question' })
+		expect(out[1]).toEqual({ role: 'assistant', content: 'answer to the first turn' })
+		expect(out[2]).toEqual({ role: 'user', content: 'second question' })
+		expect((out[3].content as any[]).map((b) => b.type)).toEqual(['thinking', 'tool_use'])
+	})
+
+	it('skips every standalone text message preceding one captured turn', () => {
+		const anthropicContent = [
+			{ type: 'text', text: 'part one' },
+			{ type: 'text', text: 'part two' },
+			{ type: 'tool_use', id: 'tool_3', name: 'list_resources', input: {} }
+		]
+
+		const messages: ChatCompletionMessageParam[] = [
+			{ role: 'user', content: 'go' },
+			{ role: 'assistant', content: 'part one' },
+			{ role: 'assistant', content: 'part two' },
+			{
+				role: 'assistant',
+				tool_calls: [
+					{ id: 'tool_3', type: 'function', function: { name: 'list_resources', arguments: '{}' } }
+				],
+				_anthropicContent: anthropicContent
+			} as any
+		]
+
+		const { messages: out } = convertOpenAIToAnthropicMessages(messages)
+
+		// Both standalone copies dropped; the verbatim turn already carries the text.
+		expect(out).toHaveLength(2)
+		expect(out[0]).toEqual({ role: 'user', content: 'go' })
+		expect((out[1].content as any[]).map((b) => b.type)).toEqual(['text', 'text', 'tool_use'])
+	})
 })

--- a/frontend/src/lib/components/copilot/chat/anthropic.ts
+++ b/frontend/src/lib/components/copilot/chat/anthropic.ts
@@ -286,15 +286,15 @@ export async function parseAnthropicCompletion(
 			role: 'assistant',
 			tool_calls: toolCallsToProcess
 		}
-		// Preserve thinking blocks (with signatures) so the next request keeps the
-		// reasoning chain — Anthropic requires this when thinking is combined with tool
-		// use. They are re-injected by convertOpenAIToAnthropicMessages.
-		const thinkingBlocks = finalMessage.content.filter(
-			(b) => b.type === 'thinking' || b.type === 'redacted_thinking'
-		)
-		if (thinkingBlocks.length > 0) {
-			;(assistantWithTools as any)._anthropicThinkingBlocks = thinkingBlocks
-		}
+		// Preserve the assistant turn verbatim (thinking/redacted_thinking with their
+		// signatures, server_tool_use + web_search_tool_result, text and tool_use) in
+		// original order. Anthropic binds each thinking block's signature to the blocks
+		// that precede it in the latest assistant message, so when this turn is replayed
+		// to continue past its tool call it must be byte-identical: reordering thinking to
+		// the front or dropping the web-search blocks invalidates a later block's
+		// signature and the request 400s with "thinking blocks ... cannot be modified".
+		// convertOpenAIToAnthropicMessages replays this content as-is.
+		;(assistantWithTools as any)._anthropicContent = finalMessage.content
 		messages.push(assistantWithTools)
 		addedMessages.push(assistantWithTools)
 
@@ -323,7 +323,33 @@ export function convertOpenAIToAnthropicMessages(messages: ChatCompletionMessage
 	let system: TextBlockParam[] | undefined
 	const anthropicMessages: MessageParam[] = []
 
-	for (const message of messages) {
+	// A streamed assistant turn that ends in tool calls is persisted as one or more
+	// standalone text messages followed by the tool-call message carrying
+	// _anthropicContent. That text is already inside _anthropicContent (replayed verbatim
+	// below), so drop the standalone copies — otherwise the text is duplicated and
+	// emitted ahead of the turn's thinking blocks. The scan stops at the preceding
+	// user/tool message, so only the current turn's own text is skipped.
+	const skipStandaloneText = new Set<number>()
+	for (let i = 0; i < messages.length; i++) {
+		if (!(messages[i] as any)._anthropicContent) continue
+		for (let j = i - 1; j >= 0; j--) {
+			const m = messages[j]
+			if (
+				m.role === 'assistant' &&
+				typeof m.content === 'string' &&
+				!m.tool_calls &&
+				!(m as any)._anthropicContent
+			) {
+				skipStandaloneText.add(j)
+			} else {
+				break
+			}
+		}
+	}
+
+	for (let i = 0; i < messages.length; i++) {
+		const message = messages[i]
+		if (skipStandaloneText.has(i)) continue
 		if (message.role === 'system') {
 			const systemText =
 				typeof message.content === 'string' ? message.content : JSON.stringify(message.content)
@@ -345,10 +371,19 @@ export function convertOpenAIToAnthropicMessages(messages: ChatCompletionMessage
 					typeof message.content === 'string' ? message.content : JSON.stringify(message.content)
 			})
 		} else if (message.role === 'assistant') {
+			// Replay a captured assistant turn verbatim so its thinking-block signatures
+			// stay valid (see the _anthropicContent note where the streamed turn is stored).
+			const anthropicContent = (message as any)._anthropicContent
+			if (Array.isArray(anthropicContent) && anthropicContent.length > 0) {
+				anthropicMessages.push({ role: 'assistant', content: anthropicContent as any })
+				continue
+			}
+
 			const content: any[] = []
 
-			// Re-inject preserved thinking blocks first (Anthropic requires thinking to
-			// precede tool_use in the same assistant turn when thinking is enabled).
+			// Fallback for sessions persisted before _anthropicContent existed: re-inject
+			// the preserved thinking blocks first (Anthropic requires thinking to precede
+			// tool_use in the same assistant turn when thinking is enabled).
 			const thinkingBlocks = (message as any)._anthropicThinkingBlocks
 			if (Array.isArray(thinkingBlocks) && thinkingBlocks.length > 0) {
 				content.push(...thinkingBlocks)
@@ -404,26 +439,29 @@ export function convertOpenAIToAnthropicMessages(messages: ChatCompletionMessage
 		}
 	}
 
-	// Add cache_control to the last message content blocks
+	// Cache the conversation prefix: put an ephemeral breakpoint on the last content
+	// block of the last message. Each continuation only appends a tool result plus the
+	// next turn, so everything up to here is read from cache — which is what keeps
+	// replaying assistant turns verbatim (web-search results included) affordable.
+	// cache_control is valid on text/tool_use/tool_result blocks, but a thinking or
+	// redacted_thinking block must never be modified, so skip the breakpoint there.
 	if (anthropicMessages.length > 0) {
 		const lastMessage = anthropicMessages[anthropicMessages.length - 1]
-		if (Array.isArray(lastMessage.content)) {
-			// Add cache_control to the last content block
-			if (lastMessage.content.length > 0) {
-				const lastBlock = lastMessage.content[lastMessage.content.length - 1]
-				if (lastBlock.type === 'text') {
-					lastBlock.cache_control = { type: 'ephemeral' }
-				}
-			}
-		} else if (typeof lastMessage.content === 'string') {
-			// Convert string content to array format with cache_control
+		if (typeof lastMessage.content === 'string') {
 			lastMessage.content = [
-				{
-					type: 'text',
-					text: lastMessage.content,
-					cache_control: { type: 'ephemeral' }
-				}
+				{ type: 'text', text: lastMessage.content, cache_control: { type: 'ephemeral' } }
 			]
+		} else if (Array.isArray(lastMessage.content) && lastMessage.content.length > 0) {
+			const lastIndex = lastMessage.content.length - 1
+			const lastBlock = lastMessage.content[lastIndex] as any
+			if (lastBlock.type !== 'thinking' && lastBlock.type !== 'redacted_thinking') {
+				// Clone the block instead of mutating in place: the array may be a verbatim
+				// _anthropicContent turn that must stay unaltered for later requests.
+				lastMessage.content = [
+					...lastMessage.content.slice(0, lastIndex),
+					{ ...lastBlock, cache_control: { type: 'ephemeral' } }
+				]
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Reimplements #9841 (which will be closed in favor of this PR).

In the global AI chat, an Anthropic assistant turn that combines **extended thinking + the native `web_search` tool + a client tool call** dies with a 400 on the auto-continuation request:

```
400 invalid_request_error
messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest assistant
message cannot be modified. These blocks must remain as they were in the original response.
```

**Root cause.** Each assistant turn is stored OpenAI-shaped and the Anthropic `content` array is reconstructed on replay. Only `thinking`/`redacted_thinking` blocks were preserved, re-injected **at the front**, while the turn's `server_tool_use` + `web_search_tool_result` blocks were dropped. Anthropic binds each thinking block's signature to the blocks that precede it in the latest assistant message. With interleaved thinking (a 2nd thinking block after the web-search result), moving the thinking blocks to the front and dropping the web-search blocks invalidates the 2nd block's signature → 400.

This only triggers on the **auto-continuation** request (when a tool result is sent back to continue past the tool call), and only for that specific shape — a normal `thinking + tool_use` turn has a single leading thinking block, so re-fronting it is a no-op and it validates.

## Changes

- **Store the turn verbatim**: persist `finalMessage.content` as `_anthropicContent` on the tool-call message (replaces the thinking-only `_anthropicThinkingBlocks` extraction).
- **Replay verbatim**: in `convertOpenAIToAnthropicMessages`, when `_anthropicContent` is present, emit it unchanged (thinking signatures keep their exact positions, `server_tool_use` + `web_search_tool_result` retained). The old `_anthropicThinkingBlocks` reconstruction is kept as a **fallback** for sessions persisted before this change.
- **Skip the duplicate standalone text**: the streamer emits the turn's text as a standalone message before the tool-call message; that text is already inside `_anthropicContent`, so it is dropped on replay. The backward scan is bounded by the preceding user/tool message, so only the current turn's own text is skipped (never an earlier turn's answer).
- **Cache-control correctness**: the trailing breakpoint now lands on the **last content block of the last message** for any non-thinking block type (text / tool_use / tool_result), instead of only `text`. Continuation requests end in a `tool_result`, which previously got no breakpoint at all — so the conversation prefix is now actually cached, which is what keeps replaying the verbatim turn (web-search results included) affordable. The verbatim turn is never mutated: cache_control is added by **cloning** the block, and thinking/redacted_thinking blocks are never touched.

## Test plan

- [x] `frontend/.../anthropic.test.ts` (6 cases): verbatim ordering with no dropped/reordered blocks, byte-identical replay (no cache_control injected into the turn, input array left unmutated), standalone-text drop, the skip bound across turns, multiple standalone texts, plain-text path, the `_anthropicThinkingBlocks` fallback, and the cache breakpoint on the trailing tool result.
- [x] `npm run check:fast` passes.
- [x] **Live end-to-end** against the real Anthropic API (`claude-sonnet-4-6`, effort `high`, web search on). The repro prompt drives web search → thinking → a workspace tool call → continuation. Captured the continuation request body (the one that 400s on `main`):
  - HTTP **200** (was 400 on `main`)
  - assistant content replayed verbatim: `[thinking, text, server_tool_use, web_search_tool_result, thinking, text, tool_use]` (not collapsed to `["thinking","thinking","tool_use"]`), 2nd thinking block keeps its signature
  - no `cache_control` on any block of the verbatim turn
  - cache breakpoint on the trailing `tool_result`; system prompt still cached

Only new sessions are fixed; sessions already persisted in the old shape use the fallback (unchanged behavior).

## Screenshots

Global AI chat completing the full web-search → thinking → workspace-tool → answer flow (continuation no longer 400s):

![global-chat-thinking-websearch-fix](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/hugo/fix-ai-chat-thinking-verbatim/1782834416-global-chat-thinking-websearch-fix.png)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic auto-continuations failing with 400 by storing and replaying assistant turns verbatim, preserving thinking signatures and all tool/web-search blocks. This keeps continuation requests valid and allows caching of the conversation prefix.

- **Bug Fixes**
  - Persist assistant turn content as `_anthropicContent` and replay it unchanged in `convertOpenAIToAnthropicMessages`.
  - Drop duplicate standalone assistant text that precedes a captured tool-call turn.
  - Keep fallback to `_anthropicThinkingBlocks` for older sessions.
  - Add `cache_control: { type: 'ephemeral' }` to the last non-thinking content block by cloning it, so the prefix is cached without mutating verbatim turns.

<sup>Written for commit 21a9cf6d062e2761fd5913e72d1d246826650162. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

