### PR TITLE
feat(pipelines): add managed SCD2 history materialize strategy

### DIFF
--- a/backend/parsers/windmill-parser/src/asset_parser.rs
+++ b/backend/parsers/windmill-parser/src/asset_parser.rs
@@ -224,15 +224,20 @@ pub struct RetrySpec {
     pub delay: Option<String>,
 }
 
-// `// materialize [manual] <asset> [append] [key=<col>]` — declares that this
-// script produces a *managed* materialization of `<asset>` (a `ducklake://`
-// table). By default the runtime generates the write DDL around the script's
-// single trailing `SELECT` and owns idempotency, partition-state and snapshot
-// capture. `manual` is the escape hatch: the script writes its own DDL and the
-// runtime only records state (track-only). The reconciliation strategy options
-// (`append`, `key=<col>`) apply to managed mode: none → DELETE-by-partition +
-// INSERT (replace); `key=<col>` → MERGE (dedup within slice); `append` →
+// `// materialize [manual] <asset> [append] [key=<col>] [history] [track=<c1,c2>]`
+// — declares that this script produces a *managed* materialization of `<asset>`
+// (a `ducklake://` table). By default the runtime generates the write DDL around
+// the script's single trailing `SELECT` and owns idempotency, partition-state
+// and snapshot capture. `manual` is the escape hatch: the script writes its own
+// DDL and the runtime only records state (track-only). The reconciliation
+// strategy options apply to managed mode: none → DELETE-by-partition + INSERT
+// (replace); `key=<col>` → MERGE (dedup within slice, SCD type 1); `append` →
 // INSERT-only. `append` wins if both are given (deploy-time warning).
+// `key=<col> history` upgrades the merge to SCD type 2: the SELECT is the current
+// snapshot (one row per key), and a change to any tracked column (`track=`,
+// default all non-key) closes the prior version and opens a new one, keeping full
+// history (`valid_from`/`valid_to`/`is_current`). The leading keyword `scd2` is a
+// recognized alias for `history`.
 #[derive(Serialize, Debug, PartialEq, Clone)]
 pub struct MaterializeSpec {
     pub target_kind: AssetKind,
@@ -243,6 +248,15 @@ pub struct MaterializeSpec {
     pub append: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub unique_key: Option<String>,
+    // `scd2` managed history mode: the SELECT is the current snapshot (one row
+    // per `unique_key`), and the runtime maintains a Slowly-Changing-Dimension
+    // type-2 history (`valid_from`/`valid_to`/`is_current`). `unique_key` (the
+    // `key=` opt) is the natural key; `track` lists the columns whose change
+    // opens a new version (empty ⇒ all non-key columns). Managed mode only.
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub scd2: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub track: Vec<String>,
 }
 
 // `// data_test <kind> …` — a data-quality assertion run against the
@@ -800,19 +814,30 @@ fn parse_retry_spec(s: &str) -> Option<RetrySpec> {
     Some(RetrySpec { count, delay })
 }
 
-// Parse a `// materialize [manual] <asset> [append] [key=<col>]` right-hand
-// side. An optional leading `manual` token (whitespace-delimited) opts out of
-// managed mode (track-only). The next whitespace token is the target asset URI
+// Parse a `// materialize [manual] <asset> [append] [key=<col>] [history]
+// [track=<c1,c2>]` right-hand side. An optional leading `manual` token opts out
+// of managed mode (track-only); a leading `scd2` token is an alias for the
+// `history` flag. The next whitespace token is the target asset URI
 // (default-syntax shorthands enabled, so `ducklake` → `ducklake://main`); the
-// remainder are strategy options — bare `append` and `key=<col>` (merge key),
-// which apply to managed mode only. A missing/empty target yields `None` (the
-// annotation is dropped, fail-safe).
+// remainder are strategy options — bare `append`, bare `history` (SCD type-2 on
+// a keyed merge), `key=<col>` (merge/scd2 key), and `track=<c1,c2,…>` (scd2
+// tracked columns) — which apply to managed mode only. A missing/empty target
+// yields `None` (the annotation is dropped, fail-safe).
 fn parse_materialize_spec(s: &str) -> Option<MaterializeSpec> {
-    let (manual, rest) = match s.strip_prefix("manual") {
-        Some(after) if after.is_empty() || after.starts_with(char::is_whitespace) => {
-            (true, after.trim_start())
-        }
-        _ => (false, s),
+    // One optional leading mode keyword: `manual` (escape hatch, track-only) or
+    // `scd2` (alias for the `history` flag below). A missing keyword is the
+    // default managed mode.
+    fn strip_mode<'a>(s: &'a str, kw: &str) -> Option<&'a str> {
+        s.strip_prefix(kw)
+            .filter(|after| after.is_empty() || after.starts_with(char::is_whitespace))
+            .map(|after| after.trim_start())
+    }
+    let (manual, scd2_kw, rest) = if let Some(after) = strip_mode(s, "manual") {
+        (true, false, after)
+    } else if let Some(after) = strip_mode(s, "scd2") {
+        (false, true, after)
+    } else {
+        (false, false, s)
     };
     let mut it = rest.trim().splitn(2, char::is_whitespace);
     let asset_tok = it.next()?;
@@ -822,11 +847,32 @@ fn parse_materialize_spec(s: &str) -> Option<MaterializeSpec> {
         return None;
     }
     let append = opts_str.split_whitespace().any(|t| t == "append");
-    let unique_key = parse_kv_opts(opts_str)
-        .get("key")
-        .filter(|k| !k.is_empty())
-        .cloned();
-    Some(MaterializeSpec { target_kind, target_path: path.to_string(), manual, append, unique_key })
+    // SCD type-2 history mode. The primary spelling is the bare `history` flag on
+    // a keyed merge (`key=<col> history`) — it reads as "a keyed upsert that keeps
+    // history"; the leading `scd2` keyword is a recognized alias for the same.
+    let scd2 = scd2_kw || opts_str.split_whitespace().any(|t| t == "history");
+    let opts = parse_kv_opts(opts_str);
+    let unique_key = opts.get("key").filter(|k| !k.is_empty()).cloned();
+    // `track=<c1,c2,…>` (scd2 only): comma-separated columns whose change opens a
+    // new version. Empty entries dropped; an empty list ⇒ track all non-key cols.
+    let track = opts
+        .get("track")
+        .map(|v| {
+            v.split(',')
+                .map(|c| c.trim().to_string())
+                .filter(|c| !c.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    Some(MaterializeSpec {
+        target_kind,
+        target_path: path.to_string(),
+        manual,
+        append,
+        unique_key,
+        scd2,
+        track,
+    })
 }
 
 // Parse a `// data_test <kind> …` right-hand side into one `DataTest`. The
@@ -1455,6 +1501,36 @@ mod pipeline_annotation_tests {
         let m = out.materialize.expect("materialize");
         assert!(m.append);
         assert_eq!(m.unique_key, None);
+    }
+
+    #[test]
+    fn materialize_scd2_history_flag_with_key_and_track() {
+        // Primary spelling: `key=<col> history` on a merge.
+        let out = parse_pipeline_annotations(
+            "// materialize ducklake://a/dim key=id history track=name,tier",
+        );
+        let m = out.materialize.expect("materialize");
+        assert!(m.scd2);
+        assert!(!m.manual);
+        assert_eq!(m.unique_key.as_deref(), Some("id"));
+        assert_eq!(m.track, vec!["name".to_string(), "tier".to_string()]);
+    }
+
+    #[test]
+    fn materialize_scd2_keyword_is_alias_for_history() {
+        let out = parse_pipeline_annotations("// materialize scd2 ducklake://a/dim key=id");
+        let m = out.materialize.expect("materialize");
+        assert!(m.scd2);
+        assert_eq!(m.unique_key.as_deref(), Some("id"));
+        assert!(m.track.is_empty());
+    }
+
+    #[test]
+    fn materialize_key_without_history_is_plain_merge() {
+        let out = parse_pipeline_annotations("// materialize ducklake://a/dim key=id");
+        let m = out.materialize.expect("materialize");
+        assert!(!m.scd2, "no history flag ⇒ SCD1 merge, not scd2");
+        assert_eq!(m.unique_key.as_deref(), Some("id"));
     }
 
     #[test]

--- a/backend/parsers/windmill-parser/src/asset_parser.rs
+++ b/backend/parsers/windmill-parser/src/asset_parser.rs
@@ -855,6 +855,8 @@ fn parse_materialize_spec(s: &str) -> Option<MaterializeSpec> {
     let unique_key = opts.get("key").filter(|k| !k.is_empty()).cloned();
     // `track=<c1,c2,…>` (scd2 only): comma-separated columns whose change opens a
     // new version. Empty entries dropped; an empty list ⇒ track all non-key cols.
+    // Like every `=`-option here the value is whitespace-terminated, so the list
+    // must contain no spaces (`track=a,b`, not `track=a, b` — the rest is dropped).
     let track = opts
         .get("track")
         .map(|v| {

--- a/backend/parsers/windmill-parser/src/asset_parser.rs
+++ b/backend/parsers/windmill-parser/src/asset_parser.rs
@@ -237,7 +237,8 @@ pub struct RetrySpec {
 // snapshot (one row per key), and a change to any tracked column (`track=`,
 // default all non-key) closes the prior version and opens a new one, keeping full
 // history (`valid_from`/`valid_to`/`is_current`). The leading keyword `scd2` is a
-// recognized alias for `history`.
+// recognized alias for `history`. `deletes=close` (scd2 only) also closes a key
+// that disappears from the snapshot; default leaves absent keys current.
 #[derive(Serialize, Debug, PartialEq, Clone)]
 pub struct MaterializeSpec {
     pub target_kind: AssetKind,
@@ -257,6 +258,11 @@ pub struct MaterializeSpec {
     pub scd2: bool,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub track: Vec<String>,
+    // scd2 only: `deletes=close` opts into hard-delete-close — a key that
+    // disappears from the snapshot has its current version closed (dbt's
+    // `hard_deletes=close`). Default (false) leaves absent keys current.
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub close_deleted: bool,
 }
 
 // `// data_test <kind> …` — a data-quality assertion run against the
@@ -820,9 +826,10 @@ fn parse_retry_spec(s: &str) -> Option<RetrySpec> {
 // `history` flag. The next whitespace token is the target asset URI
 // (default-syntax shorthands enabled, so `ducklake` → `ducklake://main`); the
 // remainder are strategy options — bare `append`, bare `history` (SCD type-2 on
-// a keyed merge), `key=<col>` (merge/scd2 key), and `track=<c1,c2,…>` (scd2
-// tracked columns) — which apply to managed mode only. A missing/empty target
-// yields `None` (the annotation is dropped, fail-safe).
+// a keyed merge), `key=<col>` (merge/scd2 key), `track=<c1,c2,…>` (scd2 tracked
+// columns), and `deletes=close` (scd2 hard-delete-close) — which apply to managed
+// mode only. A missing/empty target yields `None` (the annotation is dropped,
+// fail-safe).
 fn parse_materialize_spec(s: &str) -> Option<MaterializeSpec> {
     // One optional leading mode keyword: `manual` (escape hatch, track-only) or
     // `scd2` (alias for the `history` flag below). A missing keyword is the
@@ -866,6 +873,9 @@ fn parse_materialize_spec(s: &str) -> Option<MaterializeSpec> {
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
+    // `deletes=close` (scd2 only) opts into hard-delete-close; any other value
+    // (or absence) keeps the soft-delete default.
+    let close_deleted = opts.get("deletes").map(|v| v == "close").unwrap_or(false);
     Some(MaterializeSpec {
         target_kind,
         target_path: path.to_string(),
@@ -874,6 +884,7 @@ fn parse_materialize_spec(s: &str) -> Option<MaterializeSpec> {
         unique_key,
         scd2,
         track,
+        close_deleted,
     })
 }
 
@@ -1525,6 +1536,23 @@ mod pipeline_annotation_tests {
         assert!(m.scd2);
         assert_eq!(m.unique_key.as_deref(), Some("id"));
         assert!(m.track.is_empty());
+        // soft-delete default
+        assert!(!m.close_deleted);
+    }
+
+    #[test]
+    fn materialize_scd2_deletes_close_opt() {
+        let out = parse_pipeline_annotations(
+            "// materialize ducklake://a/dim key=id history deletes=close",
+        );
+        let m = out.materialize.expect("materialize");
+        assert!(m.scd2);
+        assert!(m.close_deleted);
+        // any other value keeps the soft-delete default
+        let out = parse_pipeline_annotations(
+            "// materialize ducklake://a/dim key=id history deletes=ignore",
+        );
+        assert!(!out.materialize.expect("materialize").close_deleted);
     }
 
     #[test]

--- a/backend/parsers/windmill-parser/src/sql_materialize.rs
+++ b/backend/parsers/windmill-parser/src/sql_materialize.rs
@@ -488,7 +488,17 @@ impl<'a> MaterializeCodegen<'a> {
     ///     diff after it would see a different set;
     ///  3. close the prior open version of those keys (`UPDATE` — not `MERGE`:
     ///     DuckLake's MERGE is the unreliable path, plain UPDATE works);
-    ///  4. open a new current version from the snapshot.
+    ///  4. open a new current version from the snapshot;
+    ///  5. (re)create the `<dim>_current` convenience view — inside the same
+    ///     transaction so it doesn't advance the DuckLake snapshot past the data
+    ///     write the summary records.
+    ///
+    /// Close/open match keys with `IS NOT DISTINCT FROM` (via a correlated
+    /// `EXISTS`), not `key IN (…)`: SQL `IN` never matches `NULL`, so a `NULL`
+    /// natural key would be flagged as changed yet silently skipped by both the
+    /// close and the open, dropping the row. Null-safe matching materializes it
+    /// instead (a `NULL` key is still ill-formed for a dimension — guard it with
+    /// `// data_test not_null <key>` — but it must not vanish).
     ///
     /// Keys present in the table but absent from the SELECT are left current
     /// (soft delete — dbt's `hard_deletes=ignore` default; closing on absence is
@@ -551,24 +561,27 @@ impl<'a> MaterializeCodegen<'a> {
             "BEGIN TRANSACTION;".to_string(),
             format!(
                 "UPDATE {t} SET {vt} = {ts}, {ic} = false \
-                 WHERE {ic} AND {k} IN (SELECT {k} FROM {changed});"
+                 WHERE {ic} AND EXISTS (SELECT 1 FROM {changed} \
+                 WHERE {changed}.{k} IS NOT DISTINCT FROM {t}.{k});"
             ),
             format!(
-                "INSERT INTO {t} SELECT *, {ts} AS {vf}, CAST(NULL AS TIMESTAMP) AS {vt}, \
-                 true AS {ic} FROM ({sel}) WHERE {k} IN (SELECT {k} FROM {changed});"
+                "INSERT INTO {t} SELECT s.*, {ts} AS {vf}, CAST(NULL AS TIMESTAMP) AS {vt}, \
+                 true AS {ic} FROM ({sel}) s WHERE EXISTS (SELECT 1 FROM {changed} c \
+                 WHERE c.{k} IS NOT DISTINCT FROM s.{k});"
             ),
-            "COMMIT;".to_string(),
             // Consumer convenience: a `<dim>_current` view (the live slice) so the
             // common "just the latest version" read needs no `WHERE is_current`,
-            // and downstream scripts can `// on` / read it directly. Idempotent
-            // (`CREATE OR REPLACE`); catalog metadata, so it lives outside the
-            // write transaction. For the effective-dated payoff, consumers `ASOF
-            // JOIN <dim> ON fact.key = dim.<key> AND fact.ts >= dim.valid_from`.
+            // and downstream scripts can `// on` / read it directly. Created inside
+            // the write transaction: `CREATE OR REPLACE VIEW` is a catalog change
+            // that itself advances the DuckLake snapshot, so leaving it outside
+            // would make the summary's `max(snapshot_id)` record the view DDL
+            // instead of the data write. For the effective-dated payoff, consumers
+            // `ASOF JOIN <dim> ON fact.key = dim.<key> AND fact.ts >= dim.valid_from`.
             // The `<dim>_current` name is reserved: if a real table by that name
-            // already exists, `CREATE OR REPLACE VIEW` errors (can't replace a
-            // table with a view) — after the history commit above, so the write
-            // still landed. Documented as a reserved suffix rather than guarded.
+            // already exists, this errors (can't replace a table with a view) and
+            // rolls back with the transaction. Documented as a reserved suffix.
             format!("CREATE OR REPLACE VIEW {t}_current AS SELECT * FROM {t} WHERE {ic};"),
+            "COMMIT;".to_string(),
         ]
     }
 }
@@ -1261,24 +1274,31 @@ mod tests {
         assert!(st[1].contains("SELECT * FROM (SELECT id, name FROM dl.src) EXCEPT"));
         assert!(st[1].contains("SELECT * EXCLUDE (valid_from, valid_to, is_current) FROM _wm_target.dim_scd2 WHERE is_current"));
         assert_eq!(st[2], "BEGIN TRANSACTION;");
-        // close: UPDATE (not MERGE) the prior open version of changed keys
+        // close: UPDATE (not MERGE) the prior open version of changed keys, with
+        // null-safe key matching (IS NOT DISTINCT FROM, not IN — IN drops NULLs)
         assert!(st[3].starts_with("UPDATE _wm_target.dim_scd2 SET valid_to = CAST(now() AS TIMESTAMP), is_current = false"));
-        assert!(
-            st[3].contains("WHERE is_current AND \"id\" IN (SELECT \"id\" FROM _wm_scd2_changed);")
-        );
-        // open: INSERT the new current version
-        assert!(st[4].starts_with(
-            "INSERT INTO _wm_target.dim_scd2 SELECT *, CAST(now() AS TIMESTAMP) AS valid_from"
+        assert!(st[3].contains(
+            "WHERE is_current AND EXISTS (SELECT 1 FROM _wm_scd2_changed \
+             WHERE _wm_scd2_changed.\"id\" IS NOT DISTINCT FROM _wm_target.dim_scd2.\"id\");"
         ));
-        assert!(st[4].contains("true AS is_current FROM (SELECT id, name FROM dl.src) WHERE \"id\" IN (SELECT \"id\" FROM _wm_scd2_changed);"));
-        assert_eq!(st[5], "COMMIT;");
-        // consumer-convenience `<dim>_current` view (live slice), created after commit
+        // open: INSERT the new current version, null-safe key matching
+        assert!(st[4].starts_with(
+            "INSERT INTO _wm_target.dim_scd2 SELECT s.*, CAST(now() AS TIMESTAMP) AS valid_from"
+        ));
+        assert!(st[4].contains(
+            "true AS is_current FROM (SELECT id, name FROM dl.src) s WHERE EXISTS \
+             (SELECT 1 FROM _wm_scd2_changed c WHERE c.\"id\" IS NOT DISTINCT FROM s.\"id\");"
+        ));
+        // consumer-convenience `<dim>_current` view, created INSIDE the txn so it
+        // doesn't advance the snapshot past the data write
         assert_eq!(
-            st[6],
+            st[5],
             "CREATE OR REPLACE VIEW _wm_target.dim_scd2_current AS SELECT * FROM _wm_target.dim_scd2 WHERE is_current;"
         );
-        // never MERGE INTO (DuckLake MERGE is unreliable)
+        assert_eq!(st[6], "COMMIT;");
+        // no fragile constructs: no MERGE INTO, and no NULL-dropping `IN (SELECT`
         assert!(!st.iter().any(|s| s.contains("MERGE INTO")));
+        assert!(!st.iter().any(|s| s.contains("IN (SELECT")));
     }
 
     #[test]

--- a/backend/parsers/windmill-parser/src/sql_materialize.rs
+++ b/backend/parsers/windmill-parser/src/sql_materialize.rs
@@ -327,19 +327,37 @@ fn snippet(stmt: &str) -> String {
 // ---------------------------------------------------------------------------
 
 /// How a (partition of a) materialized table is reconciled on each run.
-/// Derived at deploy from `unique_key`/`append`: `append` → `Append`, else
-/// `unique_key` → `Merge`, else `Replace`.
+/// Derived at deploy from the annotation: `key=<col> history` (or the `scd2`
+/// alias) → `Scd2`, else `append` → `Append`, else `unique_key` → `Merge`, else
+/// `Replace`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MaterializeStrategy {
     /// DELETE the current partition, then INSERT — partition becomes exactly
     /// what the SELECT returned. Full-refresh of the slice.
     Replace,
     /// Upsert within the slice on `unique_key` (delete-by-key + insert); rows
-    /// absent from the SELECT are left in place.
+    /// absent from the SELECT are left in place. This is SCD type 1: a changed
+    /// row overwrites the prior value, keeping no history.
     Merge { unique_key: String },
     /// INSERT only — immutable event-log semantics.
     Append,
+    /// Slowly Changing Dimension type 2: the SELECT is the *current* snapshot
+    /// (one row per `key`); a change to any tracked column closes the prior
+    /// version (`valid_to`/`is_current=false`) and opens a new one, so the full
+    /// history is preserved. `track` empty ⇒ every non-key column is tracked.
+    /// Unpartitioned only (the worker rejects `// partitioned` + scd2).
+    Scd2 { key: String, track: Vec<String> },
 }
+
+/// SCD2 metadata columns appended to the managed history table. Fixed names so
+/// the generated diff/close/open SQL and any `// data_test` on them agree.
+const SCD2_VALID_FROM: &str = "valid_from";
+const SCD2_VALID_TO: &str = "valid_to";
+const SCD2_IS_CURRENT: &str = "is_current";
+/// Connection-local temp table holding the keys whose version must be rotated
+/// this run (changed + new). Captured before the write so the close and the
+/// open see the same set. `_wm_` prefix so it never collides with user tables.
+const SCD2_CHANGED_KEYS: &str = "_wm_scd2_changed";
 
 /// Inputs to materialization codegen, all resolved at run time by the worker.
 /// Pure: produces SQL text; executes nothing.
@@ -376,6 +394,13 @@ impl<'a> MaterializeCodegen<'a> {
         let pcol = self.partition_col;
         let pval = self.partition_value_sql;
         let mut out = Vec::new();
+
+        // SCD2 has a shape unlike the DELETE/INSERT strategies (diff → close old
+        // → open new) and does not support partitioning (rejected at the worker),
+        // so it is generated up front by its own helper.
+        if let MaterializeStrategy::Scd2 { key, track } = &self.strategy {
+            return self.scd2_statements(key, track);
+        }
 
         // Whole-table replace: rebuild the table to match the SELECT's *current*
         // schema each run with one atomic `CREATE OR REPLACE` (which DuckLake
@@ -441,9 +466,106 @@ impl<'a> MaterializeCodegen<'a> {
                 ));
                 out.push(format!("INSERT INTO {t} {source};"));
             }
+            // Handled by the early return above (scd2 has no partitioned form).
+            MaterializeStrategy::Scd2 { .. } => unreachable!("scd2 handled before this match"),
         }
         out.push("COMMIT;".to_string());
         out
+    }
+
+    /// SCD2 codegen: the incoming SELECT is the *current desired snapshot* (one
+    /// row per `key`); we diff it against the live current rows, close the prior
+    /// version of every changed/new key, and open a fresh one — so history is
+    /// kept. `track` empty ⇒ every non-key column is tracked for change
+    /// detection.
+    ///
+    /// Shape (all one transaction for the mutation, mirroring the other
+    /// strategies so a partial failure leaves the prior snapshot intact):
+    ///  1. bootstrap the table (business columns + `valid_from/valid_to/
+    ///     is_current`), idempotent;
+    ///  2. capture changed+new keys into a connection-local temp table *before*
+    ///     the write — the close below flips `is_current`, so recomputing the
+    ///     diff after it would see a different set;
+    ///  3. close the prior open version of those keys (`UPDATE` — not `MERGE`:
+    ///     DuckLake's MERGE is the unreliable path, plain UPDATE works);
+    ///  4. open a new current version from the snapshot.
+    ///
+    /// Keys present in the table but absent from the SELECT are left current
+    /// (soft delete — dbt's `hard_deletes=ignore` default; closing on absence is
+    /// a follow-up). The effective timestamp is `now()`, which DuckDB fixes to
+    /// the transaction start, so `valid_from`/`valid_to` are consistent within a
+    /// run without a nondeterministic per-statement clock.
+    ///
+    /// Reserved columns: `valid_from`/`valid_to`/`is_current` are appended to the
+    /// user's SELECT with these fixed names (kept clean so consumers write
+    /// `WHERE is_current` / `ASOF JOIN … >= valid_from`). A SELECT that already
+    /// projects one of them is a v1 constraint violation — the bootstrap then
+    /// produces a duplicate output column and the run fails at execution
+    /// (documented; not statically checkable here since the SELECT's columns
+    /// aren't known at codegen time).
+    fn scd2_statements(&self, key: &str, track: &[String]) -> Vec<String> {
+        let t = self.target_qualified;
+        let sel = self.select_sql;
+        let k = quote_ident(key);
+        let vf = SCD2_VALID_FROM;
+        let vt = SCD2_VALID_TO;
+        let ic = SCD2_IS_CURRENT;
+        let changed = SCD2_CHANGED_KEYS;
+        // Transaction-stable effective timestamp (see doc above). Cast to plain
+        // TIMESTAMP so it matches the bootstrapped column type (now() is TZ-aware).
+        let ts = "CAST(now() AS TIMESTAMP)";
+
+        // Projection compared to detect change. Empty `track` ⇒ all business
+        // columns via `* EXCLUDE (<scd cols>)` on the table side (which carries
+        // the extra metadata columns) and `*` on the snapshot side. An explicit
+        // `track` ⇒ key + those columns on both sides. `EXCEPT` treats NULLs as
+        // equal, so an unchanged NULL is not read as a change.
+        let (src_proj, tgt_proj) = if track.is_empty() {
+            (
+                format!("SELECT * FROM ({sel})"),
+                format!("SELECT * EXCLUDE ({vf}, {vt}, {ic}) FROM {t} WHERE {ic}"),
+            )
+        } else {
+            let cols = std::iter::once(key)
+                .chain(track.iter().map(String::as_str))
+                .map(quote_ident)
+                .collect::<Vec<_>>()
+                .join(", ");
+            (
+                format!("SELECT {cols} FROM ({sel})"),
+                format!("SELECT {cols} FROM {t} WHERE {ic}"),
+            )
+        };
+
+        vec![
+            format!(
+                "CREATE TABLE IF NOT EXISTS {t} AS SELECT *, \
+                 CAST(NULL AS TIMESTAMP) AS {vf}, \
+                 CAST(NULL AS TIMESTAMP) AS {vt}, \
+                 CAST(NULL AS BOOLEAN) AS {ic} FROM ({sel}) WHERE false;"
+            ),
+            format!(
+                "CREATE OR REPLACE TEMP TABLE {changed} AS \
+                 SELECT {k} FROM ({src_proj} EXCEPT {tgt_proj});"
+            ),
+            "BEGIN TRANSACTION;".to_string(),
+            format!(
+                "UPDATE {t} SET {vt} = {ts}, {ic} = false \
+                 WHERE {ic} AND {k} IN (SELECT {k} FROM {changed});"
+            ),
+            format!(
+                "INSERT INTO {t} SELECT *, {ts} AS {vf}, CAST(NULL AS TIMESTAMP) AS {vt}, \
+                 true AS {ic} FROM ({sel}) WHERE {k} IN (SELECT {k} FROM {changed});"
+            ),
+            "COMMIT;".to_string(),
+            // Consumer convenience: a `<dim>_current` view (the live slice) so the
+            // common "just the latest version" read needs no `WHERE is_current`,
+            // and downstream scripts can `// on` / read it directly. Idempotent
+            // (`CREATE OR REPLACE`); catalog metadata, so it lives outside the
+            // write transaction. For the effective-dated payoff, consumers `ASOF
+            // JOIN <dim> ON fact.key = dim.<key> AND fact.ts >= dim.valid_from`.
+            format!("CREATE OR REPLACE VIEW {t}_current AS SELECT * FROM {t} WHERE {ic};"),
+        ]
     }
 }
 
@@ -1109,6 +1231,68 @@ mod tests {
                     .to_string()
             ]
         );
+    }
+
+    #[test]
+    fn codegen_scd2_default_track_closes_old_opens_new() {
+        // Empty `track` ⇒ diff on all business columns via `* EXCLUDE (scd cols)`.
+        let cg = MaterializeCodegen {
+            target_qualified: "_wm_target.dim_scd2",
+            select_sql: "SELECT id, name FROM dl.src",
+            partition_col: "_wm_partition",
+            partition_value_sql: "''",
+            partitioned: false,
+            strategy: MaterializeStrategy::Scd2 { key: "id".to_string(), track: vec![] },
+        };
+        let st = cg.statements();
+        // bootstrap adds the three SCD metadata columns
+        assert!(st[0].starts_with("CREATE TABLE IF NOT EXISTS _wm_target.dim_scd2 AS SELECT *,"));
+        assert!(st[0].contains("AS valid_from"));
+        assert!(st[0].contains("AS valid_to"));
+        assert!(st[0].contains("AS is_current"));
+        // changed-key set captured before the transaction, all cols compared
+        assert!(
+            st[1].contains("CREATE OR REPLACE TEMP TABLE _wm_scd2_changed AS SELECT \"id\" FROM")
+        );
+        assert!(st[1].contains("SELECT * FROM (SELECT id, name FROM dl.src) EXCEPT"));
+        assert!(st[1].contains("SELECT * EXCLUDE (valid_from, valid_to, is_current) FROM _wm_target.dim_scd2 WHERE is_current"));
+        assert_eq!(st[2], "BEGIN TRANSACTION;");
+        // close: UPDATE (not MERGE) the prior open version of changed keys
+        assert!(st[3].starts_with("UPDATE _wm_target.dim_scd2 SET valid_to = CAST(now() AS TIMESTAMP), is_current = false"));
+        assert!(
+            st[3].contains("WHERE is_current AND \"id\" IN (SELECT \"id\" FROM _wm_scd2_changed);")
+        );
+        // open: INSERT the new current version
+        assert!(st[4].starts_with(
+            "INSERT INTO _wm_target.dim_scd2 SELECT *, CAST(now() AS TIMESTAMP) AS valid_from"
+        ));
+        assert!(st[4].contains("true AS is_current FROM (SELECT id, name FROM dl.src) WHERE \"id\" IN (SELECT \"id\" FROM _wm_scd2_changed);"));
+        assert_eq!(st[5], "COMMIT;");
+        // consumer-convenience `<dim>_current` view (live slice), created after commit
+        assert_eq!(
+            st[6],
+            "CREATE OR REPLACE VIEW _wm_target.dim_scd2_current AS SELECT * FROM _wm_target.dim_scd2 WHERE is_current;"
+        );
+        // never MERGE INTO (DuckLake MERGE is unreliable)
+        assert!(!st.iter().any(|s| s.contains("MERGE INTO")));
+    }
+
+    #[test]
+    fn codegen_scd2_explicit_track_projects_key_and_tracked_cols() {
+        let cg = MaterializeCodegen {
+            target_qualified: "_wm_target.dim",
+            select_sql: "SELECT id, name, addr FROM dl.src",
+            partition_col: "_wm_partition",
+            partition_value_sql: "''",
+            partitioned: false,
+            strategy: MaterializeStrategy::Scd2 {
+                key: "id".to_string(),
+                track: vec!["name".to_string()],
+            },
+        };
+        let st = cg.statements();
+        // only key + tracked cols are compared (addr changes don't rotate a version)
+        assert!(st[1].contains("SELECT \"id\", \"name\" FROM (SELECT id, name, addr FROM dl.src) EXCEPT SELECT \"id\", \"name\" FROM _wm_target.dim WHERE is_current"));
     }
 
     #[test]

--- a/backend/parsers/windmill-parser/src/sql_materialize.rs
+++ b/backend/parsers/windmill-parser/src/sql_materialize.rs
@@ -345,8 +345,11 @@ pub enum MaterializeStrategy {
     /// (one row per `key`); a change to any tracked column closes the prior
     /// version (`valid_to`/`is_current=false`) and opens a new one, so the full
     /// history is preserved. `track` empty ⇒ every non-key column is tracked.
+    /// `close_deleted` (opt-in `deletes=close`) also closes the current version
+    /// of a key that disappears from the snapshot (dbt's `hard_deletes=close`);
+    /// default (false) leaves absent keys current (soft delete).
     /// Unpartitioned only (the worker rejects `// partitioned` + scd2).
-    Scd2 { key: String, track: Vec<String> },
+    Scd2 { key: String, track: Vec<String>, close_deleted: bool },
 }
 
 /// SCD2 metadata columns appended to the managed history table. Fixed names so
@@ -358,6 +361,10 @@ const SCD2_IS_CURRENT: &str = "is_current";
 /// this run (changed + new). Captured before the write so the close and the
 /// open see the same set. `_wm_` prefix so it never collides with user tables.
 const SCD2_CHANGED_KEYS: &str = "_wm_scd2_changed";
+/// Connection-local temp table holding the keys that disappeared from the
+/// snapshot this run (present-and-current in the table, absent from the SELECT).
+/// Only used when `close_deleted` (`deletes=close`) is set.
+const SCD2_DELETED_KEYS: &str = "_wm_scd2_deleted";
 
 /// Inputs to materialization codegen, all resolved at run time by the worker.
 /// Pure: produces SQL text; executes nothing.
@@ -398,8 +405,8 @@ impl<'a> MaterializeCodegen<'a> {
         // SCD2 has a shape unlike the DELETE/INSERT strategies (diff → close old
         // → open new) and does not support partitioning (rejected at the worker),
         // so it is generated up front by its own helper.
-        if let MaterializeStrategy::Scd2 { key, track } = &self.strategy {
-            return self.scd2_statements(key, track);
+        if let MaterializeStrategy::Scd2 { key, track, close_deleted } = &self.strategy {
+            return self.scd2_statements(key, track, *close_deleted);
         }
 
         // Whole-table replace: rebuild the table to match the SELECT's *current*
@@ -488,6 +495,9 @@ impl<'a> MaterializeCodegen<'a> {
     ///     diff after it would see a different set;
     ///  3. close the prior open version of those keys (`UPDATE` — not `MERGE`:
     ///     DuckLake's MERGE is the unreliable path, plain UPDATE works);
+    ///  3b. when `close_deleted`, also capture the keys that vanished from the
+    ///     snapshot and close their current version (no reopen) — dbt's
+    ///     `hard_deletes=close`;
     ///  4. open a new current version from the snapshot;
     ///  5. create the `<dim>_current` convenience view once (`IF NOT EXISTS`),
     ///     inside the same transaction so it doesn't advance the DuckLake snapshot
@@ -501,9 +511,10 @@ impl<'a> MaterializeCodegen<'a> {
     /// instead (a `NULL` key is still ill-formed for a dimension — guard it with
     /// `// data_test not_null <key>` — but it must not vanish).
     ///
-    /// Keys present in the table but absent from the SELECT are left current
-    /// (soft delete — dbt's `hard_deletes=ignore` default; closing on absence is
-    /// a follow-up). The effective timestamp is `now()`, which DuckDB fixes to
+    /// Without `close_deleted`, keys present in the table but absent from the
+    /// SELECT are left current (soft delete — dbt's `hard_deletes=ignore` default;
+    /// with `close_deleted` they are closed instead — see step 3b). The effective
+    /// timestamp is `now()`, which DuckDB fixes to
     /// the transaction start, so `valid_from`/`valid_to` are consistent within a
     /// run without a nondeterministic per-statement clock.
     ///
@@ -514,7 +525,7 @@ impl<'a> MaterializeCodegen<'a> {
     /// produces a duplicate output column and the run fails at execution
     /// (documented; not statically checkable here since the SELECT's columns
     /// aren't known at codegen time).
-    fn scd2_statements(&self, key: &str, track: &[String]) -> Vec<String> {
+    fn scd2_statements(&self, key: &str, track: &[String], close_deleted: bool) -> Vec<String> {
         let t = self.target_qualified;
         let sel = self.select_sql;
         let k = quote_ident(key);
@@ -522,6 +533,7 @@ impl<'a> MaterializeCodegen<'a> {
         let vt = SCD2_VALID_TO;
         let ic = SCD2_IS_CURRENT;
         let changed = SCD2_CHANGED_KEYS;
+        let deleted = SCD2_DELETED_KEYS;
         // Transaction-stable effective timestamp (see doc above). Cast to plain
         // TIMESTAMP so it matches the bootstrapped column type (now() is TZ-aware).
         let ts = "CAST(now() AS TIMESTAMP)";
@@ -548,7 +560,7 @@ impl<'a> MaterializeCodegen<'a> {
             )
         };
 
-        vec![
+        let mut out = vec![
             format!(
                 "CREATE TABLE IF NOT EXISTS {t} AS SELECT *, \
                  CAST(NULL AS TIMESTAMP) AS {vf}, \
@@ -559,17 +571,40 @@ impl<'a> MaterializeCodegen<'a> {
                 "CREATE OR REPLACE TEMP TABLE {changed} AS \
                  SELECT {k} FROM ({src_proj} EXCEPT {tgt_proj});"
             ),
-            "BEGIN TRANSACTION;".to_string(),
-            format!(
+        ];
+        // Hard-delete-close (`deletes=close`): the keys that vanished from the
+        // snapshot — present-and-current in the table, absent from the SELECT.
+        // Captured before the transaction (like `changed`) and disjoint from it (a
+        // key is either in the snapshot or not), so the two closes never overlap.
+        if close_deleted {
+            out.push(format!(
+                "CREATE OR REPLACE TEMP TABLE {deleted} AS \
+                 SELECT {k} FROM (SELECT {k} FROM {t} WHERE {ic} EXCEPT SELECT {k} FROM ({sel}));"
+            ));
+        }
+        out.push("BEGIN TRANSACTION;".to_string());
+        out.push(format!(
+            "UPDATE {t} SET {vt} = {ts}, {ic} = false \
+             WHERE {ic} AND EXISTS (SELECT 1 FROM {changed} \
+             WHERE {changed}.{k} IS NOT DISTINCT FROM {t}.{k});"
+        ));
+        // Close vanished keys — no matching INSERT below, so they close without
+        // reopening. A key that later reappears isn't in `WHERE is_current`, so the
+        // `changed` diff treats it as new and opens a fresh version (a validity gap
+        // between the delete and the reactivation — correct SCD2).
+        if close_deleted {
+            out.push(format!(
                 "UPDATE {t} SET {vt} = {ts}, {ic} = false \
-                 WHERE {ic} AND EXISTS (SELECT 1 FROM {changed} \
-                 WHERE {changed}.{k} IS NOT DISTINCT FROM {t}.{k});"
-            ),
-            format!(
-                "INSERT INTO {t} SELECT s.*, {ts} AS {vf}, CAST(NULL AS TIMESTAMP) AS {vt}, \
-                 true AS {ic} FROM ({sel}) s WHERE EXISTS (SELECT 1 FROM {changed} c \
-                 WHERE c.{k} IS NOT DISTINCT FROM s.{k});"
-            ),
+                 WHERE {ic} AND EXISTS (SELECT 1 FROM {deleted} \
+                 WHERE {deleted}.{k} IS NOT DISTINCT FROM {t}.{k});"
+            ));
+        }
+        out.push(format!(
+            "INSERT INTO {t} SELECT s.*, {ts} AS {vf}, CAST(NULL AS TIMESTAMP) AS {vt}, \
+             true AS {ic} FROM ({sel}) s WHERE EXISTS (SELECT 1 FROM {changed} c \
+             WHERE c.{k} IS NOT DISTINCT FROM s.{k});"
+        ));
+        out.push(
             // Consumer convenience: a `<dim>_current` view (the live slice) so the
             // common "just the latest version" read needs no `WHERE is_current`,
             // and downstream scripts can `// on` / read it directly. For the
@@ -588,8 +623,9 @@ impl<'a> MaterializeCodegen<'a> {
             // that name already exists, `IF NOT EXISTS` skips silently (no view,
             // no error) — documented as a reserved suffix.
             format!("CREATE VIEW IF NOT EXISTS {t}_current AS SELECT * FROM {t} WHERE {ic};"),
-            "COMMIT;".to_string(),
-        ]
+        );
+        out.push("COMMIT;".to_string());
+        out
     }
 }
 
@@ -1266,7 +1302,11 @@ mod tests {
             partition_col: "_wm_partition",
             partition_value_sql: "''",
             partitioned: false,
-            strategy: MaterializeStrategy::Scd2 { key: "id".to_string(), track: vec![] },
+            strategy: MaterializeStrategy::Scd2 {
+                key: "id".to_string(),
+                track: vec![],
+                close_deleted: false,
+            },
         };
         let st = cg.statements();
         // bootstrap adds the three SCD metadata columns
@@ -1306,6 +1346,8 @@ mod tests {
         // no fragile constructs: no MERGE INTO, and no NULL-dropping `IN (SELECT`
         assert!(!st.iter().any(|s| s.contains("MERGE INTO")));
         assert!(!st.iter().any(|s| s.contains("IN (SELECT")));
+        // soft-delete default: no deleted-key set, no second close
+        assert!(!st.iter().any(|s| s.contains("_wm_scd2_deleted")));
     }
 
     #[test]
@@ -1319,11 +1361,61 @@ mod tests {
             strategy: MaterializeStrategy::Scd2 {
                 key: "id".to_string(),
                 track: vec!["name".to_string()],
+                close_deleted: false,
             },
         };
         let st = cg.statements();
         // only key + tracked cols are compared (addr changes don't rotate a version)
         assert!(st[1].contains("SELECT \"id\", \"name\" FROM (SELECT id, name, addr FROM dl.src) EXCEPT SELECT \"id\", \"name\" FROM _wm_target.dim WHERE is_current"));
+    }
+
+    #[test]
+    fn codegen_scd2_close_deleted_adds_deleted_set_and_second_close() {
+        let cg = MaterializeCodegen {
+            target_qualified: "_wm_target.dim",
+            select_sql: "SELECT id, name FROM dl.src",
+            partition_col: "_wm_partition",
+            partition_value_sql: "''",
+            partitioned: false,
+            strategy: MaterializeStrategy::Scd2 {
+                key: "id".to_string(),
+                track: vec![],
+                close_deleted: true,
+            },
+        };
+        let st = cg.statements();
+        // the deleted-key set: current keys absent from the snapshot, captured
+        // before the transaction (like `changed`)
+        assert!(st.iter().any(|s| s.contains(
+            "CREATE OR REPLACE TEMP TABLE _wm_scd2_deleted AS SELECT \"id\" FROM \
+             (SELECT \"id\" FROM _wm_target.dim WHERE is_current EXCEPT SELECT \"id\" FROM (SELECT id, name FROM dl.src));"
+        )));
+        // a second close UPDATE against the deleted set (null-safe), and NO INSERT
+        // that reopens deleted keys (the only INSERT filters on `_wm_scd2_changed`)
+        assert!(st
+            .iter()
+            .any(|s| s.starts_with("UPDATE _wm_target.dim SET valid_to")
+                && s.contains(
+                    "EXISTS (SELECT 1 FROM _wm_scd2_deleted \
+                WHERE _wm_scd2_deleted.\"id\" IS NOT DISTINCT FROM _wm_target.dim.\"id\");"
+                )));
+        assert_eq!(
+            st.iter().filter(|s| s.starts_with("INSERT INTO")).count(),
+            1
+        );
+        assert!(st
+            .iter()
+            .find(|s| s.starts_with("INSERT INTO"))
+            .unwrap()
+            .contains("_wm_scd2_changed"));
+        // the deleted close is inside the transaction (between BEGIN and COMMIT)
+        let begin = st.iter().position(|s| s == "BEGIN TRANSACTION;").unwrap();
+        let commit = st.iter().position(|s| s == "COMMIT;").unwrap();
+        let del_close = st
+            .iter()
+            .position(|s| s.starts_with("UPDATE") && s.contains("_wm_scd2_deleted"))
+            .unwrap();
+        assert!(begin < del_close && del_close < commit);
     }
 
     #[test]

--- a/backend/parsers/windmill-parser/src/sql_materialize.rs
+++ b/backend/parsers/windmill-parser/src/sql_materialize.rs
@@ -564,6 +564,10 @@ impl<'a> MaterializeCodegen<'a> {
             // (`CREATE OR REPLACE`); catalog metadata, so it lives outside the
             // write transaction. For the effective-dated payoff, consumers `ASOF
             // JOIN <dim> ON fact.key = dim.<key> AND fact.ts >= dim.valid_from`.
+            // The `<dim>_current` name is reserved: if a real table by that name
+            // already exists, `CREATE OR REPLACE VIEW` errors (can't replace a
+            // table with a view) — after the history commit above, so the write
+            // still landed. Documented as a reserved suffix rather than guarded.
             format!("CREATE OR REPLACE VIEW {t}_current AS SELECT * FROM {t} WHERE {ic};"),
         ]
     }

--- a/backend/parsers/windmill-parser/src/sql_materialize.rs
+++ b/backend/parsers/windmill-parser/src/sql_materialize.rs
@@ -489,9 +489,10 @@ impl<'a> MaterializeCodegen<'a> {
     ///  3. close the prior open version of those keys (`UPDATE` — not `MERGE`:
     ///     DuckLake's MERGE is the unreliable path, plain UPDATE works);
     ///  4. open a new current version from the snapshot;
-    ///  5. (re)create the `<dim>_current` convenience view — inside the same
-    ///     transaction so it doesn't advance the DuckLake snapshot past the data
-    ///     write the summary records.
+    ///  5. create the `<dim>_current` convenience view once (`IF NOT EXISTS`),
+    ///     inside the same transaction so it doesn't advance the DuckLake snapshot
+    ///     past the data write the summary records (and so an unchanged rerun,
+    ///     whose UPDATE/INSERT touch no rows, stays a true no-op).
     ///
     /// Close/open match keys with `IS NOT DISTINCT FROM` (via a correlated
     /// `EXISTS`), not `key IN (…)`: SQL `IN` never matches `NULL`, so a `NULL`
@@ -571,16 +572,22 @@ impl<'a> MaterializeCodegen<'a> {
             ),
             // Consumer convenience: a `<dim>_current` view (the live slice) so the
             // common "just the latest version" read needs no `WHERE is_current`,
-            // and downstream scripts can `// on` / read it directly. Created inside
-            // the write transaction: `CREATE OR REPLACE VIEW` is a catalog change
-            // that itself advances the DuckLake snapshot, so leaving it outside
-            // would make the summary's `max(snapshot_id)` record the view DDL
-            // instead of the data write. For the effective-dated payoff, consumers
-            // `ASOF JOIN <dim> ON fact.key = dim.<key> AND fact.ts >= dim.valid_from`.
-            // The `<dim>_current` name is reserved: if a real table by that name
-            // already exists, this errors (can't replace a table with a view) and
-            // rolls back with the transaction. Documented as a reserved suffix.
-            format!("CREATE OR REPLACE VIEW {t}_current AS SELECT * FROM {t} WHERE {ic};"),
+            // and downstream scripts can `// on` / read it directly. For the
+            // effective-dated payoff, consumers `ASOF JOIN <dim> ON fact.key =
+            // dim.<key> AND fact.ts >= dim.valid_from`.
+            //
+            // `CREATE VIEW IF NOT EXISTS` (not `OR REPLACE`), created inside the
+            // write transaction, on purpose: the view definition never changes
+            // (`SELECT * WHERE is_current` always reflects live data), and a
+            // catalog write advances the DuckLake snapshot — so `OR REPLACE` on
+            // every run would (a) advance the snapshot on an otherwise no-op
+            // unchanged run and (b) make the summary's `max(snapshot_id)` record
+            // the view DDL instead of the data write. `IF NOT EXISTS` creates it
+            // once (folded into the first data-write snapshot) and is a true no-op
+            // afterwards. The `<dim>_current` name is reserved: if a real table by
+            // that name already exists, `IF NOT EXISTS` skips silently (no view,
+            // no error) — documented as a reserved suffix.
+            format!("CREATE VIEW IF NOT EXISTS {t}_current AS SELECT * FROM {t} WHERE {ic};"),
             "COMMIT;".to_string(),
         ]
     }
@@ -1289,11 +1296,11 @@ mod tests {
             "true AS is_current FROM (SELECT id, name FROM dl.src) s WHERE EXISTS \
              (SELECT 1 FROM _wm_scd2_changed c WHERE c.\"id\" IS NOT DISTINCT FROM s.\"id\");"
         ));
-        // consumer-convenience `<dim>_current` view, created INSIDE the txn so it
-        // doesn't advance the snapshot past the data write
+        // consumer-convenience `<dim>_current` view: `IF NOT EXISTS` (created once,
+        // no-op on unchanged reruns) and INSIDE the txn (folded into the write snapshot)
         assert_eq!(
             st[5],
-            "CREATE OR REPLACE VIEW _wm_target.dim_scd2_current AS SELECT * FROM _wm_target.dim_scd2 WHERE is_current;"
+            "CREATE VIEW IF NOT EXISTS _wm_target.dim_scd2_current AS SELECT * FROM _wm_target.dim_scd2 WHERE is_current;"
         );
         assert_eq!(st[6], "COMMIT;");
         // no fragile constructs: no MERGE INTO, and no NULL-dropping `IN (SELECT`

--- a/backend/parsers/windmill-parser/tests/fixtures/pipeline_annotations.json
+++ b/backend/parsers/windmill-parser/tests/fixtures/pipeline_annotations.json
@@ -254,6 +254,63 @@
 		}
 	},
 	{
+		"name": "materialize scd2 via history flag with key and track",
+		"code": "// pipeline\n// materialize ducklake://analytics/dim_customer key=id history track=name,tier\nSELECT 1;",
+		"expected": {
+			"in_pipeline": true,
+			"asset_triggers": [],
+			"native_triggers": [],
+			"partition": null,
+			"freshness": null,
+			"tag": null,
+			"retry": null,
+			"materialize": {
+				"target_kind": "ducklake",
+				"target_path": "analytics/dim_customer",
+				"unique_key": "id",
+				"scd2": true,
+				"track": ["name", "tier"]
+			}
+		}
+	},
+	{
+		"name": "materialize scd2 keyword alias with key only (track all non-key cols)",
+		"code": "// materialize scd2 ducklake://analytics/dim key=id\nSELECT 1;",
+		"expected": {
+			"in_pipeline": false,
+			"asset_triggers": [],
+			"native_triggers": [],
+			"partition": null,
+			"freshness": null,
+			"tag": null,
+			"retry": null,
+			"materialize": {
+				"target_kind": "ducklake",
+				"target_path": "analytics/dim",
+				"unique_key": "id",
+				"scd2": true
+			}
+		}
+	},
+	{
+		"name": "materialize key without history is plain merge (SCD1, not scd2)",
+		"code": "// materialize ducklake://analytics/dim key=id\nSELECT 1;",
+		"expected": {
+			"in_pipeline": false,
+			"asset_triggers": [],
+			"native_triggers": [],
+			"partition": null,
+			"freshness": null,
+			"tag": null,
+			"retry": null,
+			"materialize": {
+				"target_kind": "ducklake",
+				"target_path": "analytics/dim",
+				"unique_key": "id"
+			}
+		}
+	},
+	{
 		"name": "materialize manual escape hatch, first value wins",
 		"code": "// materialize manual ducklake://analytics/orders_daily\n// materialize ducklake://other/x\nexport function main() {}",
 		"expected": {

--- a/backend/parsers/windmill-parser/tests/fixtures/pipeline_annotations.json
+++ b/backend/parsers/windmill-parser/tests/fixtures/pipeline_annotations.json
@@ -254,8 +254,8 @@
 		}
 	},
 	{
-		"name": "materialize scd2 via history flag with key and track",
-		"code": "// pipeline\n// materialize ducklake://analytics/dim_customer key=id history track=name,tier\nSELECT 1;",
+		"name": "materialize scd2 via history flag with key, track and deletes=close",
+		"code": "// pipeline\n// materialize ducklake://analytics/dim_customer key=id history track=name,tier deletes=close\nSELECT 1;",
 		"expected": {
 			"in_pipeline": true,
 			"asset_triggers": [],
@@ -269,7 +269,8 @@
 				"target_path": "analytics/dim_customer",
 				"unique_key": "id",
 				"scd2": true,
-				"track": ["name", "tier"]
+				"track": ["name", "tier"],
+				"close_deleted": true
 			}
 		}
 	},

--- a/backend/parsers/windmill-parser/tests/pipeline_annotations_parity.rs
+++ b/backend/parsers/windmill-parser/tests/pipeline_annotations_parity.rs
@@ -59,6 +59,10 @@ struct ExpectedMaterialize {
     append: bool,
     #[serde(default)]
     unique_key: Option<String>,
+    #[serde(default)]
+    scd2: bool,
+    #[serde(default)]
+    track: Vec<String>,
 }
 
 #[derive(Deserialize)]
@@ -191,6 +195,8 @@ fn pipeline_annotation_fixtures_match() {
                 assert_eq!(m.manual, e.manual, "{ctx}: materialize manual");
                 assert_eq!(m.append, e.append, "{ctx}: materialize append");
                 assert_eq!(m.unique_key, e.unique_key, "{ctx}: materialize key");
+                assert_eq!(m.scd2, e.scd2, "{ctx}: materialize scd2");
+                assert_eq!(m.track, e.track, "{ctx}: materialize track");
             }
             (got, want) => panic!(
                 "{ctx}: materialize mismatch — got {:?}, want present={}",

--- a/backend/parsers/windmill-parser/tests/pipeline_annotations_parity.rs
+++ b/backend/parsers/windmill-parser/tests/pipeline_annotations_parity.rs
@@ -63,6 +63,8 @@ struct ExpectedMaterialize {
     scd2: bool,
     #[serde(default)]
     track: Vec<String>,
+    #[serde(default)]
+    close_deleted: bool,
 }
 
 #[derive(Deserialize)]
@@ -197,6 +199,10 @@ fn pipeline_annotation_fixtures_match() {
                 assert_eq!(m.unique_key, e.unique_key, "{ctx}: materialize key");
                 assert_eq!(m.scd2, e.scd2, "{ctx}: materialize scd2");
                 assert_eq!(m.track, e.track, "{ctx}: materialize track");
+                assert_eq!(
+                    m.close_deleted, e.close_deleted,
+                    "{ctx}: materialize close_deleted"
+                );
             }
             (got, want) => panic!(
                 "{ctx}: materialize mismatch — got {:?}, want present={}",

--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -1349,14 +1349,16 @@ async fn create_script_internal<'c>(
     let effective_assets = if let Some(m) = pipeline_annotations.materialize.as_ref() {
         let kind = windmill_common::assets::asset_kind_from_parser(m.target_kind);
         let mut a = effective_assets.unwrap_or_default();
-        // Produced assets: the managed table, plus — for scd2 — the
+        // Produced assets: the managed table, plus — for managed scd2 — the
         // `<dim>_current` companion view the runtime (re)creates each run.
         // Registering the view as a write asset lets `// on
         // ducklake://…/<dim>_current` subscribers be dispatched by the cascade
         // (which fans out from these deploy-time asset rows); without it a
-        // subscriber on the view would silently never fire.
+        // subscriber on the view would silently never fire. Gated on `!manual`:
+        // manual mode owns its own DDL and short-circuits before the scd2 codegen
+        // (no view is created), so registering it there would be a false edge.
         let mut targets = vec![m.target_path.clone()];
-        if m.scd2 {
+        if m.scd2 && !m.manual {
             targets.push(format!("{}_current", m.target_path));
         }
         for path in targets {

--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -1349,14 +1349,26 @@ async fn create_script_internal<'c>(
     let effective_assets = if let Some(m) = pipeline_annotations.materialize.as_ref() {
         let kind = windmill_common::assets::asset_kind_from_parser(m.target_kind);
         let mut a = effective_assets.unwrap_or_default();
-        if !a.iter().any(|x| x.kind == kind && x.path == m.target_path) {
-            a.push(windmill_common::assets::AssetWithAltAccessType {
-                path: m.target_path.clone(),
-                kind,
-                access_type: Some(windmill_common::assets::AssetUsageAccessType::W),
-                alt_access_type: None,
-                columns: None,
-            });
+        // Produced assets: the managed table, plus — for scd2 — the
+        // `<dim>_current` companion view the runtime (re)creates each run.
+        // Registering the view as a write asset lets `// on
+        // ducklake://…/<dim>_current` subscribers be dispatched by the cascade
+        // (which fans out from these deploy-time asset rows); without it a
+        // subscriber on the view would silently never fire.
+        let mut targets = vec![m.target_path.clone()];
+        if m.scd2 {
+            targets.push(format!("{}_current", m.target_path));
+        }
+        for path in targets {
+            if !a.iter().any(|x| x.kind == kind && x.path == path) {
+                a.push(windmill_common::assets::AssetWithAltAccessType {
+                    path,
+                    kind,
+                    access_type: Some(windmill_common::assets::AssetUsageAccessType::W),
+                    alt_access_type: None,
+                    columns: None,
+                });
+            }
         }
         Some(a)
     } else {

--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -1297,10 +1297,16 @@ async fn create_script_internal<'c>(
             // but the executor parses the signature from the un-wrapped script, so
             // `$name` references in the SELECT stay bound at run time.
         }
-        // `key=` (merge) and `append` are mutually exclusive reconciliation
-        // strategies; append (INSERT-only) wins. Surface the conflict rather
-        // than silently dropping the dedup the author may have intended.
-        if m.unique_key.is_some() && m.append {
+        // Reconciliation strategies are mutually exclusive; surface a conflict
+        // rather than silently dropping behavior the author may have intended.
+        // Precedence must mirror the runtime (`duckdb_executor` strategy
+        // derivation): scd2 (`history`) > append > merge (`key=`) > replace.
+        if m.scd2 && m.append {
+            tracing::warn!(
+                "script {}: both `history`/`scd2` and `append` set on // materialize; history wins (SCD2), append ignored",
+                ns.path
+            );
+        } else if m.unique_key.is_some() && m.append {
             tracing::warn!(
                 "script {}: both `key=` and `append` set on // materialize; append wins (INSERT-only, no dedup)",
                 ns.path

--- a/backend/windmill-worker/src/duckdb_executor.rs
+++ b/backend/windmill-worker/src/duckdb_executor.rs
@@ -195,7 +195,21 @@ fn build_materialized_query(
     for s in plan.setup.iter_mut() {
         *s = substitute(s);
     }
-    let strategy = if m.append {
+    let strategy = if m.scd2 {
+        // SCD2 needs a natural key to identify an entity across versions, and its
+        // diff/close/open shape has no partition-scoped form in v1.
+        let key = m.unique_key.clone().ok_or_else(|| {
+            Error::ExecutionErr(
+                "materialize scd2: requires a natural key — add `key=<col>`".to_string(),
+            )
+        })?;
+        if partitioned {
+            return Err(Error::ExecutionErr(
+                "materialize scd2: `// partitioned` is not supported with scd2 in v1".to_string(),
+            ));
+        }
+        MaterializeStrategy::Scd2 { key, track: m.track.clone() }
+    } else if m.append {
         MaterializeStrategy::Append
     } else if let Some(uk) = m.unique_key {
         MaterializeStrategy::Merge { unique_key: uk }
@@ -1518,6 +1532,71 @@ mod tests {
         // The declaration comment is gone (wrap strips line comments) — which is
         // exactly why the sig must come from the original, not the rewrite.
         assert!(!rewritten.contains("-- $file"));
+    }
+
+    // SCD2 managed mode wraps the SELECT into the diff → close-old → open-new
+    // shape (unit-covered in the parser's codegen tests); here we pin the
+    // executor-level wiring: the natural key flows through and the wrap is
+    // generated (not the manual track-only path).
+    #[test]
+    fn materialize_scd2_wraps_with_history() {
+        // Primary spelling: `key=<col> history` on a merge.
+        let script = "-- materialize ducklake://main/dim key=id history track=name\n\
+                      SELECT id, name FROM dl.src";
+        let (rewritten, _) =
+            build_materialized_query(script, None, &std::collections::HashMap::new())
+                .expect("materialize builds")
+                .expect("materialize present");
+        let rewritten = rewritten.expect("scd2 is managed — must rewrite");
+        assert!(
+            rewritten.contains("valid_from"),
+            "adds SCD2 columns:\n{rewritten}"
+        );
+        assert!(rewritten.contains("is_current"));
+        assert!(
+            rewritten.contains("_wm_scd2_changed"),
+            "captures changed keys"
+        );
+        assert!(
+            rewritten.contains("UPDATE _wm_target.dim SET valid_to"),
+            "closes prior version"
+        );
+        assert!(
+            rewritten.contains("CREATE OR REPLACE VIEW _wm_target.dim_current"),
+            "emits the consumer-convenience current view"
+        );
+        assert!(!rewritten.contains("MERGE INTO"));
+    }
+
+    #[test]
+    fn materialize_scd2_requires_key() {
+        let script = "-- materialize scd2 ducklake://main/dim\nSELECT id, name FROM dl.src";
+        let err = match build_materialized_query(script, None, &std::collections::HashMap::new()) {
+            Err(e) => e,
+            Ok(_) => panic!("scd2 without key must error"),
+        };
+        assert!(
+            format!("{err}").contains("requires a natural key"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn materialize_scd2_rejects_partitioned() {
+        let script = "-- pipeline\n-- partitioned daily\n\
+                      -- materialize scd2 ducklake://main/dim key=id\nSELECT id, name FROM dl.src";
+        let err = match build_materialized_query(
+            script,
+            Some("2026-07-01"),
+            &std::collections::HashMap::new(),
+        ) {
+            Err(e) => e,
+            Ok(_) => panic!("partitioned + scd2 must error"),
+        };
+        assert!(
+            format!("{err}").contains("not supported with scd2"),
+            "got: {err}"
+        );
     }
 
     // Tests for parse_attach_db_resource function

--- a/backend/windmill-worker/src/duckdb_executor.rs
+++ b/backend/windmill-worker/src/duckdb_executor.rs
@@ -1562,7 +1562,7 @@ mod tests {
             "closes prior version"
         );
         assert!(
-            rewritten.contains("CREATE OR REPLACE VIEW _wm_target.dim_current"),
+            rewritten.contains("CREATE VIEW IF NOT EXISTS _wm_target.dim_current"),
             "emits the consumer-convenience current view"
         );
         assert!(!rewritten.contains("MERGE INTO"));

--- a/backend/windmill-worker/src/duckdb_executor.rs
+++ b/backend/windmill-worker/src/duckdb_executor.rs
@@ -208,7 +208,7 @@ fn build_materialized_query(
                 "materialize scd2: `// partitioned` is not supported with scd2 in v1".to_string(),
             ));
         }
-        MaterializeStrategy::Scd2 { key, track: m.track.clone() }
+        MaterializeStrategy::Scd2 { key, track: m.track.clone(), close_deleted: m.close_deleted }
     } else if m.append {
         MaterializeStrategy::Append
     } else if let Some(uk) = m.unique_key {
@@ -1565,7 +1565,24 @@ mod tests {
             rewritten.contains("CREATE VIEW IF NOT EXISTS _wm_target.dim_current"),
             "emits the consumer-convenience current view"
         );
+        // default is soft-delete — no deleted-key set without `deletes=close`
+        assert!(!rewritten.contains("_wm_scd2_deleted"));
         assert!(!rewritten.contains("MERGE INTO"));
+    }
+
+    #[test]
+    fn materialize_scd2_deletes_close_wires_through() {
+        let script = "-- materialize ducklake://main/dim key=id history deletes=close\n\
+                      SELECT id, name FROM dl.src";
+        let (rewritten, _) =
+            build_materialized_query(script, None, &std::collections::HashMap::new())
+                .expect("materialize builds")
+                .expect("materialize present");
+        let rewritten = rewritten.expect("scd2 is managed — must rewrite");
+        assert!(
+            rewritten.contains("_wm_scd2_deleted"),
+            "deletes=close adds the vanished-key set + close:\n{rewritten}"
+        );
     }
 
     #[test]

--- a/docs/ducklake-materialization.md
+++ b/docs/ducklake-materialization.md
@@ -70,8 +70,19 @@ stays separate because it is cross-cutting (cascade + scheduling + materialize).
   self-consistent. Keys absent from the SELECT stay current (soft delete). v1 is
   **non-partitioned only** (`// partitioned` + history is rejected). Unlike
   `manual`, it is managed, so `// data_test` and schema capture work.
-  `valid_from`/`valid_to`/`is_current` are **reserved** column names in this mode
-  — a SELECT that already projects one of them fails at run time (v1 constraint).
+  - **Reserved names.** `valid_from`/`valid_to`/`is_current` are reserved column
+    names in this mode — a SELECT that already projects one fails at run time —
+    and the `<dim>_current` suffix is reserved for the companion view (below), so
+    don't separately materialize a table by that name in the same lake.
+  - **`track=` takes no spaces.** Like every `=`-option in the annotation grammar
+    (which is whitespace-tokenized), the `track=` value must be a bare
+    comma-separated list with no spaces: `track=name,tier`, not `track=name, tier`
+    (a space ends the value and the rest is silently ignored).
+  - **Schema is frozen at first run** (persist-and-mutate, like `merge`/`append`):
+    the history table is `CREATE TABLE IF NOT EXISTS`, so adding/removing a
+    projected column later fails the run — an append-only history can't retroactively
+    reshape closed versions. Changing the SELECT's columns needs a manual rebuild
+    (the `replace` strategy is the only one that re-derives schema each run).
   - **Consumer convenience.** Each run (re)creates a `<dim>_current` view (`WHERE
     is_current`) in the same catalog, so the common "latest version" read needs no
     filter and downstream scripts can `// on ducklake://…/<dim>_current`. The

--- a/docs/ducklake-materialization.md
+++ b/docs/ducklake-materialization.md
@@ -73,7 +73,13 @@ stays separate because it is cross-cutting (cascade + scheduling + materialize).
   - **Reserved names.** `valid_from`/`valid_to`/`is_current` are reserved column
     names in this mode — a SELECT that already projects one fails at run time —
     and the `<dim>_current` suffix is reserved for the companion view (below), so
-    don't separately materialize a table by that name in the same lake.
+    don't separately materialize a table by that name in the same lake (the view
+    is created inside the write transaction, so such a collision rolls the whole
+    run back rather than leaving a half-applied write).
+  - **Key should be non-null.** A `NULL` natural key is ill-formed for a
+    dimension; the codegen matches keys null-safely so a `NULL`-key row is
+    materialized rather than silently dropped, but you should enforce it with
+    `// data_test not_null <key>`.
   - **`track=` takes no spaces.** Like every `=`-option in the annotation grammar
     (which is whitespace-tokenized), the `track=` value must be a bare
     comma-separated list with no spaces: `track=name,tier`, not `track=name, tier`

--- a/docs/ducklake-materialization.md
+++ b/docs/ducklake-materialization.md
@@ -60,16 +60,22 @@ stays separate because it is cross-cutting (cascade + scheduling + materialize).
 - **`key=<col>`** → MERGE (dedup within slice, SCD type 1 — overwrites history);
   **`append`** → INSERT-only; neither → DELETE-by-partition + INSERT (replace).
   `append` wins over `key` if both are given (deploy warning).
-- **`key=<col> history [track=<c1,c2,…>]`** → upgrades the keyed merge to managed
-  SCD **type 2** history (the leading keyword `scd2` is an alias). The SELECT is
-  the *current snapshot* (one row per `key`), and the runtime adds
+- **`key=<col> history [track=<c1,c2,…>] [deletes=close]`** → upgrades the keyed
+  merge to managed SCD **type 2** history (the leading keyword `scd2` is an alias).
+  The SELECT is the *current snapshot* (one row per `key`), and the runtime adds
   `valid_from`/`valid_to`/`is_current`; a change to any tracked column (`track=`,
   default all non-key) closes the prior version and opens a new one, keeping full
   history. Diff → close-old (`UPDATE`) → open-new (`INSERT`) in one transaction;
   the effective timestamp is the transaction clock (`now()`), so a run is
-  self-consistent. Keys absent from the SELECT stay current (soft delete). v1 is
-  **non-partitioned only** (`// partitioned` + history is rejected). Unlike
-  `manual`, it is managed, so `// data_test` and schema capture work.
+  self-consistent. v1 is **non-partitioned only** (`// partitioned` + history is
+  rejected). Unlike `manual`, it is managed, so `// data_test` and schema capture
+  work.
+  - **Deletes.** By default a key that disappears from the snapshot stays current
+    (soft delete — dbt's `hard_deletes=ignore`). `deletes=close` opts into
+    hard-delete-close: the vanished key's current version is closed (`valid_to`
+    set, `is_current=false`) with no new version — dbt's `hard_deletes=close`. If
+    that key later reappears in the snapshot it opens a fresh version, leaving a
+    validity gap between the delete and the reactivation (correct SCD2).
   - **Reserved names.** `valid_from`/`valid_to`/`is_current` are reserved column
     names in this mode — a SELECT that already projects one fails at run time —
     and the `<dim>_current` suffix is reserved for the companion view (below), so

--- a/docs/ducklake-materialization.md
+++ b/docs/ducklake-materialization.md
@@ -74,8 +74,9 @@ stays separate because it is cross-cutting (cascade + scheduling + materialize).
     names in this mode — a SELECT that already projects one fails at run time —
     and the `<dim>_current` suffix is reserved for the companion view (below), so
     don't separately materialize a table by that name in the same lake (the view
-    is created inside the write transaction, so such a collision rolls the whole
-    run back rather than leaving a half-applied write).
+    is created `IF NOT EXISTS` inside the write transaction, so such a collision
+    is skipped silently — the `_current` convenience is simply absent — rather
+    than erroring).
   - **Key should be non-null.** A `NULL` natural key is ill-formed for a
     dimension; the codegen matches keys null-safely so a `NULL`-key row is
     materialized rather than silently dropped, but you should enforce it with

--- a/docs/ducklake-materialization.md
+++ b/docs/ducklake-materialization.md
@@ -45,8 +45,9 @@ stays separate because it is cross-cutting (cascade + scheduling + materialize).
 
 ```
 // materialize ducklake://analytics/orders_daily              → managed, replace (default)
-// materialize ducklake://analytics/orders_daily key=order_id → managed, merge
+// materialize ducklake://analytics/orders_daily key=order_id → managed, merge (SCD type 1)
 // materialize ducklake://analytics/orders_daily append       → managed, append
+// materialize ducklake://analytics/dim_customer key=id history → managed, SCD type 2 history
 // materialize manual ducklake://analytics/orders_daily       → track-only escape hatch
 ```
 
@@ -56,9 +57,28 @@ stays separate because it is cross-cutting (cascade + scheduling + materialize).
   error pointing to the `wmll.ducklake` helpers).
 - **`manual`** — escape hatch: the script writes its own DDL; Windmill only
   records state (no snapshot capture, no idempotency guarantee). Rare; explicit.
-- **`key=<col>`** → MERGE (dedup within slice); **`append`** → INSERT-only;
-  neither → DELETE-by-partition + INSERT (replace). `append` wins over `key` if
-  both are given (deploy warning).
+- **`key=<col>`** → MERGE (dedup within slice, SCD type 1 — overwrites history);
+  **`append`** → INSERT-only; neither → DELETE-by-partition + INSERT (replace).
+  `append` wins over `key` if both are given (deploy warning).
+- **`key=<col> history [track=<c1,c2,…>]`** → upgrades the keyed merge to managed
+  SCD **type 2** history (the leading keyword `scd2` is an alias). The SELECT is
+  the *current snapshot* (one row per `key`), and the runtime adds
+  `valid_from`/`valid_to`/`is_current`; a change to any tracked column (`track=`,
+  default all non-key) closes the prior version and opens a new one, keeping full
+  history. Diff → close-old (`UPDATE`) → open-new (`INSERT`) in one transaction;
+  the effective timestamp is the transaction clock (`now()`), so a run is
+  self-consistent. Keys absent from the SELECT stay current (soft delete). v1 is
+  **non-partitioned only** (`// partitioned` + history is rejected). Unlike
+  `manual`, it is managed, so `// data_test` and schema capture work.
+  `valid_from`/`valid_to`/`is_current` are **reserved** column names in this mode
+  — a SELECT that already projects one of them fails at run time (v1 constraint).
+  - **Consumer convenience.** Each run (re)creates a `<dim>_current` view (`WHERE
+    is_current`) in the same catalog, so the common "latest version" read needs no
+    filter and downstream scripts can `// on ducklake://…/<dim>_current`. The
+    effective-dated payoff is a native DuckDB `ASOF JOIN` against the history
+    table: `… ASOF JOIN <dim> d ON fact.key = d.<key> AND fact.ts >= d.valid_from`
+    returns, for each fact, the dimension version that was current at `fact.ts` —
+    something neither `merge` nor DuckLake time-travel can do in one query.
 - **`// partitioned <kind>`** — unit of work + state + backfill (separate;
   cross-cutting). Polyglot / multi-statement writes use the `wmll.ducklake`
   helpers instead of `// materialize`.
@@ -224,9 +244,12 @@ without anyone asking. This is deliberately **not** built, for three reasons:
 If a workload ever shows the consistency race in practice, pinning can be layered
 on top — the capture and the snapshot surfacing built here are its foundation.
 
-It also means **we do not build SCD2 snapshots** (gap #4 in `pipelines-vs-dbt.md`):
-DuckLake time-travel is a strictly better answer for most of what dbt's
-`{% snapshot %}` is used for. One fewer engine to write.
+This is distinct from **SCD2 history** (`// materialize … key=… history`), which *is* built:
+DuckLake time-travel answers "what did the whole table look like at snapshot N?"
+but not "give me each entity's version history as queryable rows"
+(`valid_from`/`valid_to`/`is_current`) — the shape dbt's `{% snapshot %}` produces
+and downstream dimensional queries join against. The scd2 strategy generates and
+manages that history table (see the strategy bullet above).
 
 ## Data tests (`// data_test`) — and the extensible-annotation pattern
 

--- a/docs/pipelines-vs-dbt.md
+++ b/docs/pipelines-vs-dbt.md
@@ -49,7 +49,7 @@ Asset-centric, polyglot, annotation-driven, event-aware:
 | Data tests | No | **Shipped** (`// data_test`) |
 | Incremental materializations | No, but pick a philosophy | TODO with design decision |
 | Column lineage | No | **Shipped** (`// column`); docs site still TODO |
-| Snapshots / SCD2 | No | New output kind |
+| Snapshots / SCD2 | Yes (`key=… history`) | Managed strategy |
 | Selective execution grammar | No | UI/CLI surface |
 | Schema contracts | No, but design metadata model | TODO with design work |
 | Packages / community | Closed annotation parser starts to bind | Decide extensibility model |
@@ -117,12 +117,20 @@ buffer, and `resolveGraph` merges its `column_lineage` with the buffer's
 preview matches what deploys. The `dbt docs serve`-style static lineage *site*
 is still TODO.
 
-### 4. Snapshots / SCD2
+### 4. Snapshots / SCD2 — **shipped**
 
 dbt: `{% snapshot %}` blocks with `strategy='timestamp'` or `'check'`.
-Today: nothing. Add as a new `PipelineOutputKind` + `// snapshot strategy=
-timestamp updated_at=updated_at unique_key=id` annotation. Same shape as
-other output kinds.
+Shipped as a modifier on the keyed merge: `// materialize ducklake://<lake>/<dim>
+key=<natural_key> history [track=<c1,c2,…>]` (the leading keyword `scd2` is an
+alias). The SELECT returns the current snapshot (one row per key); the runtime
+adds `valid_from`/`valid_to`/`is_current` and, on each run, diffs against the live
+current rows to close changed versions and open new ones (dbt's `strategy='check'`
+shape — `track=` is the check-columns list; empty ⇒ all non-key columns). Because
+it's a managed strategy (not a new output kind), it inherits `// data_test` and
+schema capture, and each run (re)creates a `<dim>_current` view; consumers get
+effective-dated joins via native `ASOF JOIN … >= valid_from`. v1 is non-partitioned
+and soft-deletes (keys absent from the SELECT stay current); hard-delete/CDC and
+partitioned history are follow-ups. See `ducklake-materialization.md`.
 
 ### 5. Selective execution grammar
 

--- a/docs/pipelines-vs-dbt.md
+++ b/docs/pipelines-vs-dbt.md
@@ -128,9 +128,10 @@ current rows to close changed versions and open new ones (dbt's `strategy='check
 shape — `track=` is the check-columns list; empty ⇒ all non-key columns). Because
 it's a managed strategy (not a new output kind), it inherits `// data_test` and
 schema capture, and each run (re)creates a `<dim>_current` view; consumers get
-effective-dated joins via native `ASOF JOIN … >= valid_from`. v1 is non-partitioned
-and soft-deletes (keys absent from the SELECT stay current); hard-delete/CDC and
-partitioned history are follow-ups. See `ducklake-materialization.md`.
+effective-dated joins via native `ASOF JOIN … >= valid_from`. Deletes follow dbt:
+soft by default (absent keys stay current), or `deletes=close` for
+`hard_deletes=close`. v1 is non-partitioned; partitioned history is a follow-up.
+See `ducklake-materialization.md`.
 
 ### 5. Selective execution grammar
 

--- a/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.parity.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.parity.test.ts
@@ -69,6 +69,7 @@ type Fixture = {
 			unique_key?: string | null
 			scd2?: boolean
 			track?: string[]
+			close_deleted?: boolean
 		} | null
 		// Snake_case form matching the Rust `DataTest` serde output, so the one
 		// corpus drives both sides. The TS parser emits this shape verbatim
@@ -169,6 +170,9 @@ describe('parsePipelineAnnotations matches the shared Rust fixture corpus', () =
 				)
 				expect(got.materialize?.track ?? [], 'materialize track').toEqual(
 					f.expected.materialize.track ?? []
+				)
+				expect(got.materialize?.closeDeleted ?? false, 'materialize close_deleted').toBe(
+					f.expected.materialize.close_deleted ?? false
 				)
 			}
 

--- a/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.parity.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.parity.test.ts
@@ -67,6 +67,8 @@ type Fixture = {
 			manual?: boolean
 			append?: boolean
 			unique_key?: string | null
+			scd2?: boolean
+			track?: string[]
 		} | null
 		// Snake_case form matching the Rust `DataTest` serde output, so the one
 		// corpus drives both sides. The TS parser emits this shape verbatim
@@ -161,6 +163,12 @@ describe('parsePipelineAnnotations matches the shared Rust fixture corpus', () =
 				)
 				expect(got.materialize?.uniqueKey, 'materialize key').toEqual(
 					f.expected.materialize.unique_key ?? undefined
+				)
+				expect(got.materialize?.scd2 ?? false, 'materialize scd2').toBe(
+					f.expected.materialize.scd2 ?? false
+				)
+				expect(got.materialize?.track ?? [], 'materialize track').toEqual(
+					f.expected.materialize.track ?? []
 				)
 			}
 

--- a/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.ts
@@ -264,6 +264,8 @@ function parseMaterializeSpec(s: string): MaterializeSpec | undefined {
 	const key = opts.get('key')
 	const uniqueKey = key && key !== '' ? key : undefined
 	// `track=<c1,c2,…>` (scd2): comma-separated tracked columns; empty ⇒ all.
+	// The value is whitespace-terminated (like every `=`-option), so it must have
+	// no spaces (`track=a,b`, not `track=a, b` — the rest is dropped).
 	const track = (opts.get('track') ?? '')
 		.split(',')
 		.map((c) => c.trim())

--- a/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.ts
@@ -77,7 +77,8 @@ export type RetrySpec = {
 // `// materialize [manual] <asset> [append] [key=<col>]` — see backend
 // MaterializeSpec. Managed by default (the runtime generates the write DDL
 // around a single SELECT); `manual` opts out (the script writes its own DDL,
-// track-only). `append` / `key` are managed-mode strategy options.
+// track-only). `append` / `key` / `history` / `track` are managed-mode strategy
+// options; `key=<col> history` (or the `scd2` alias) selects SCD type-2 history.
 export type MaterializeSpec = {
 	targetKind: AssetKind
 	targetPath: string
@@ -85,8 +86,12 @@ export type MaterializeSpec = {
 	manual?: boolean
 	// INSERT-only strategy; absent === false
 	append?: boolean
-	// merge key; absent === replace (or append)
+	// merge key; absent === replace (or append). Also the SCD2 natural key.
 	uniqueKey?: string
+	// SCD2 managed history mode (valid_from/valid_to/is_current); absent === false
+	scd2?: boolean
+	// SCD2 tracked columns (change ⇒ new version); empty ⇒ all non-key columns
+	track?: string[]
 }
 
 // `// data_test <kind> …` — a data-quality assertion run against the
@@ -223,18 +228,26 @@ function parseAssetSyntaxDefault(s: string): PipelineTriggerAsset | undefined {
 	return parseAssetSyntax(s)
 }
 
-// Parse a `// materialize [manual] <asset> [append] [key=<col>]` right-hand
-// side. Optional leading `manual` word opts out of managed mode; the next token
-// is the target asset URI (default-syntax shorthands enabled); the remainder
-// are strategy options (`append` flag, `key=<col>`). Missing/empty target →
-// undefined (dropped).
+// Parse a `// materialize [manual] <asset> [append] [key=<col>] [history]
+// [track=<c1,c2>]` right-hand side. Optional leading `manual` word opts out of
+// managed mode; a leading `scd2` word is an alias for the `history` flag; the
+// next token is the target asset URI (default-syntax shorthands enabled); the
+// remainder are strategy options (`append` flag, `key=<col>`, `history` flag,
+// `track=<c1,c2,…>`). Missing/empty target → undefined (dropped).
 function parseMaterializeSpec(s: string): MaterializeSpec | undefined {
+	// One optional leading mode keyword: `manual` (track-only) or `scd2` (an alias
+	// for the `history` flag below).
 	let manual = false
+	let scd2Kw = false
 	let rest = s
 	const afterManual = consumeKeyword(s, 'manual')
+	const afterScd2 = afterManual === undefined ? consumeKeyword(s, 'scd2') : undefined
 	if (afterManual !== undefined) {
 		manual = true
 		rest = afterManual.trimStart()
+	} else if (afterScd2 !== undefined) {
+		scd2Kw = true
+		rest = afterScd2.trimStart()
 	}
 	rest = rest.trim()
 	const m = rest.match(/^(\S+)(?:\s+(.*))?$/)
@@ -242,10 +255,20 @@ function parseMaterializeSpec(s: string): MaterializeSpec | undefined {
 	const asset = parseAssetSyntaxDefault(m[1])
 	if (!asset || asset.path === '') return undefined
 	const optsStr = m[2] ?? ''
-	const append = optsStr.split(/\s+/).some((t) => t === 'append')
-	const key = parseKvOpts(optsStr).get('key')
+	const optTokens = optsStr.split(/\s+/)
+	const append = optTokens.some((t) => t === 'append')
+	// SCD type-2 history: primary spelling is the bare `history` flag on a keyed
+	// merge; the leading `scd2` keyword is a recognized alias.
+	const scd2 = scd2Kw || optTokens.some((t) => t === 'history')
+	const opts = parseKvOpts(optsStr)
+	const key = opts.get('key')
 	const uniqueKey = key && key !== '' ? key : undefined
-	return { targetKind: asset.kind, targetPath: asset.path, manual, append, uniqueKey }
+	// `track=<c1,c2,…>` (scd2): comma-separated tracked columns; empty ⇒ all.
+	const track = (opts.get('track') ?? '')
+		.split(',')
+		.map((c) => c.trim())
+		.filter((c) => c !== '')
+	return { targetKind: asset.kind, targetPath: asset.path, manual, append, uniqueKey, scd2, track }
 }
 
 // A single bare identifier token (column name). Rejects empty / multi-token

--- a/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.ts
@@ -78,7 +78,8 @@ export type RetrySpec = {
 // MaterializeSpec. Managed by default (the runtime generates the write DDL
 // around a single SELECT); `manual` opts out (the script writes its own DDL,
 // track-only). `append` / `key` / `history` / `track` are managed-mode strategy
-// options; `key=<col> history` (or the `scd2` alias) selects SCD type-2 history.
+// options; `key=<col> history` (or the `scd2` alias) selects SCD type-2 history,
+// and `deletes=close` opts scd2 into hard-delete-close.
 export type MaterializeSpec = {
 	targetKind: AssetKind
 	targetPath: string
@@ -92,6 +93,8 @@ export type MaterializeSpec = {
 	scd2?: boolean
 	// SCD2 tracked columns (change ⇒ new version); empty ⇒ all non-key columns
 	track?: string[]
+	// SCD2 hard-delete-close (`deletes=close`): close absent keys; absent === false
+	closeDeleted?: boolean
 }
 
 // `// data_test <kind> …` — a data-quality assertion run against the
@@ -233,7 +236,7 @@ function parseAssetSyntaxDefault(s: string): PipelineTriggerAsset | undefined {
 // managed mode; a leading `scd2` word is an alias for the `history` flag; the
 // next token is the target asset URI (default-syntax shorthands enabled); the
 // remainder are strategy options (`append` flag, `key=<col>`, `history` flag,
-// `track=<c1,c2,…>`). Missing/empty target → undefined (dropped).
+// `track=<c1,c2,…>`, `deletes=close`). Missing/empty target → undefined (dropped).
 function parseMaterializeSpec(s: string): MaterializeSpec | undefined {
 	// One optional leading mode keyword: `manual` (track-only) or `scd2` (an alias
 	// for the `history` flag below).
@@ -270,7 +273,19 @@ function parseMaterializeSpec(s: string): MaterializeSpec | undefined {
 		.split(',')
 		.map((c) => c.trim())
 		.filter((c) => c !== '')
-	return { targetKind: asset.kind, targetPath: asset.path, manual, append, uniqueKey, scd2, track }
+	// `deletes=close` (scd2 only) opts into hard-delete-close; any other value
+	// (or absence) keeps the soft-delete default.
+	const closeDeleted = opts.get('deletes') === 'close'
+	return {
+		targetKind: asset.kind,
+		targetPath: asset.path,
+		manual,
+		append,
+		uniqueKey,
+		scd2,
+		track,
+		closeDeleted
+	}
 }
 
 // A single bare identifier token (column name). Rejects empty / multi-token


### PR DESCRIPTION
## Summary

Adds a first-class **SCD type 2 (Slowly Changing Dimension) history** strategy to the DuckLake pipeline `// materialize` annotation. Instead of overwriting a dimension on change (SCD1 `merge`) or losing history entirely, the runtime keeps every version of every row — a change closes the prior version (`valid_to`, `is_current = false`) and opens a new one.

Before this PR the only way to get per-entity history was `// materialize manual` with hand-written `CREATE`/`UPDATE`/`INSERT` SQL, which **drops `// data_test` and schema capture**. This makes SCD2 a *managed* strategy, so history is generated for you and the quality/metadata features keep working.

---

## Why build it (vs. what we already had)

DuckLake time-travel and the `merge` (SCD1) strategy already exist, but neither answers *"give me each entity's version history as queryable rows, joinable by effective date."*

| Question | Answered by |
|---|---|
| "What did the *whole table* look like at commit N?" | **Time-travel** (`AT (VERSION n)`) — free, strictly better |
| "Roll back / reproduce / audit a past run" | **Time-travel** — free |
| "Current state only, overwrite on change" | **`merge`** (SCD1) — already exists |
| "Each *entity's* version history as rows, joinable by effective date" | **SCD2** ← this PR |

The single decisive justification is the **as-of join** — for a fact row at time `T`, join the dimension version that was current *at `T`*:

```sql
… ASOF JOIN dim d ON fact.customer_id = d.id AND fact.ordered_at >= d.valid_from
```

Time-travel (keyed by commit, not business-effective time) can't express this in one set-based query; `merge` overwrites history. This closes the documented dbt-parity gap #4 (`docs/pipelines-vs-dbt.md`).

---

## Documentation

### Annotation syntax

```
// materialize ducklake://<lake>/<dim> key=<natural_key> history [track=<c1,c2,…>] [deletes=close] [// data_test …]
SELECT <natural_key>, <col1>, <col2>, …   -- the CURRENT snapshot of the dimension (one row per key)
FROM …
```

- **`history`** (the flag that turns a keyed merge into SCD2). The leading keyword **`scd2`** is a recognized alias: `// materialize scd2 ducklake://… key=id`.
- **`key=<col>`** *(required)* — the natural/business key that identifies an entity across versions.
- **`track=<c1,c2,…>`** *(optional)* — the columns whose change opens a new version. Default = **all non-key columns**. Must be a bare comma list with **no spaces** (`track=name,tier`, not `track=name, tier`).
- **`deletes=close`** *(optional)* — hard-delete-close: a key that disappears from the snapshot has its current version closed. Default is soft-delete (absent keys stay current). See the reconciliation table.
- The `SELECT` returns the **current desired state**, one row per key — exactly like `merge`. You never write `valid_from`/`valid_to`/`is_current`; the runtime manages them.

### Managed columns

The runtime appends three columns to your dimension (kept clean so consumers can write `WHERE is_current` / `ASOF JOIN … >= valid_from`):

| Column | Type | Meaning |
|---|---|---|
| `valid_from` | `TIMESTAMP` | when this version became effective (the run's transaction clock) |
| `valid_to` | `TIMESTAMP` | when it was superseded; `NULL` = still open |
| `is_current` | `BOOLEAN` | `true` for the live version of each key |

### Reconciliation semantics (each run)

The `SELECT` (the current snapshot) is diffed against the live rows:

| Case | Behavior |
|---|---|
| **Initial load** (empty table) | all rows opened, no closes |
| **Tracked column changed** | prior version closed (`valid_to = now()`, `is_current = false`), new version opened |
| **New key** (in SELECT, not in table) | opened as current |
| **No change** | no-op — 0 rows written, no churn (idempotent) |
| **Untracked column changed** | ignored — no new version |
| **Key absent from SELECT** (deleted upstream) | default: **stays current** (soft delete — dbt's `hard_deletes=ignore`); with `deletes=close`: current version **closed**, no reopen |
| **Deleted key reappears** (with `deletes=close`) | opens a fresh version, leaving a validity gap between the delete and the reactivation |

The effective timestamp is the run's transaction clock (`now()`), which DuckDB fixes to transaction start — so within a run `valid_to(old) == valid_from(new)` (contiguous, gap-free versions).

### Constraints (v1)

- **Non-partitioned only** — `// partitioned` + `history` is rejected with a clear error.
- **Reserved names** — `valid_from`/`valid_to`/`is_current` are reserved columns (a SELECT projecting one fails at run time); the `<dim>_current` suffix is reserved for the companion view.
- **Schema frozen at first run** — like `merge`/`append`, the table is `CREATE TABLE IF NOT EXISTS`; changing the SELECT's projected columns later fails (an append-only history can't reshape closed versions) and needs a manual rebuild.
- **Deletes** — soft by default; `deletes=close` for hard-delete-close (both dbt behaviors). Full CDC (`cdc_operation` column) is a follow-up.

---

## Examples

### 1. A dimension with history

```sql
-- pipeline
-- on ducklake://analytics/stg_customers
-- materialize ducklake://analytics/dim_customer key=id history track=name,tier
-- data_test not_null valid_from
-- data_test accepted_values tier = free,pro,enterprise
SELECT id, name, tier          -- current snapshot, one row per id
FROM ducklake://analytics/stg_customers;
```

Run 1 loads `(1,alice,free) (2,bob,pro)`. Run 2 changes bob `pro→enterprise` and adds `(3,carol,free)` → the resulting `dim_customer`:

```
┌─────┬───────┬────────────┬─────────────────────────┬─────────────────────────┬────────────┐
│ id  │ name  │    tier    │       valid_from        │        valid_to         │ is_current │
├─────┼───────┼────────────┼─────────────────────────┼─────────────────────────┼────────────┤
│  1  │ alice │ free       │ 2026-07-01 06:16:44.848 │ NULL                    │ true       │ ← untouched
│  2  │ bob   │ pro        │ 2026-07-01 06:16:44.848 │ 2026-07-01 06:16:45.932 │ false      │ ← closed
│  2  │ bob   │ enterprise │ 2026-07-01 06:16:45.932 │ NULL                    │ true       │ ← new version
│  3  │ carol │ free       │ 2026-07-01 06:16:45.932 │ NULL                    │ true       │ ← new key
└─────┴───────┴────────────┴─────────────────────────┴─────────────────────────┴────────────┘
```

(bob's `valid_to` == his new version's `valid_from` — contiguous. Re-running with no change writes 0 rows.)

### 2. Reading the latest version — the auto-generated `_current` view

Each run (re)creates a `<dim>_current` view, so the common case needs no filter:

```sql
-- pipeline
-- on ducklake://analytics/dim_customer_current
SELECT * FROM ducklake://analytics/dim_customer_current;   -- only is_current rows
```

### 3. The payoff — effective-dated (as-of) join

Get the tier each customer had *at the moment they ordered*:

```sql
-- pipeline
-- on ducklake://analytics/dim_customer
-- on ducklake://analytics/stg_orders
-- materialize ducklake://analytics/fct_orders
SELECT o.order_id, o.amount, o.ordered_at,
       d.tier AS tier_at_order_time
FROM ducklake://analytics/stg_orders o
ASOF JOIN ducklake://analytics/dim_customer d
  ON o.customer_id = d.id AND o.ordered_at >= d.valid_from;
```

### 4. Track all columns (default)

Omit `track=` to open a new version on any non-key column change:

```sql
-- materialize ducklake://analytics/dim_product key=sku history
SELECT sku, name, category, price FROM ducklake://analytics/stg_products;
```

### 5. `scd2` keyword alias

```sql
-- materialize scd2 ducklake://analytics/dim_customer key=id
```

### 6. Hard-delete-close (`deletes=close`)

When a customer disappears from the source, close their current version instead of leaving it open forever:

```sql
-- materialize ducklake://analytics/dim_customer key=id history deletes=close
SELECT id, name, tier FROM ducklake://analytics/stg_customers;
```

If id=2 vanishes from the snapshot → its current version is closed (`valid_to` set, `is_current=false`), no new version. If id=2 later reappears → a fresh version opens, leaving a validity gap. Verified end-to-end against a real DuckLake.

---

## What gets generated (the codegen)

For `key=id history` (default track), the runtime replaces the trailing SELECT with (one transaction for the mutation):

```sql
CREATE TABLE IF NOT EXISTS <t> AS
  SELECT *, CAST(NULL AS TIMESTAMP) AS valid_from, CAST(NULL AS TIMESTAMP) AS valid_to,
         CAST(NULL AS BOOLEAN) AS is_current FROM (<select>) WHERE false;                -- bootstrap
CREATE OR REPLACE TEMP TABLE _wm_scd2_changed AS                                          -- diff BEFORE the write
  SELECT "id" FROM (SELECT * FROM (<select>)
                    EXCEPT SELECT * EXCLUDE (valid_from, valid_to, is_current) FROM <t> WHERE is_current);
BEGIN TRANSACTION;
  UPDATE <t> SET valid_to = CAST(now() AS TIMESTAMP), is_current = false                  -- close old
    WHERE is_current AND EXISTS (SELECT 1 FROM _wm_scd2_changed
                                 WHERE _wm_scd2_changed."id" IS NOT DISTINCT FROM <t>."id");
  INSERT INTO <t> SELECT s.*, CAST(now() AS TIMESTAMP), CAST(NULL AS TIMESTAMP), true      -- open new
    FROM (<select>) s WHERE EXISTS (SELECT 1 FROM _wm_scd2_changed c
                                    WHERE c."id" IS NOT DISTINCT FROM s."id");
  CREATE VIEW IF NOT EXISTS <t>_current AS SELECT * FROM <t> WHERE is_current;            -- companion view (in-txn, once)
COMMIT;
```

With `deletes=close`, a second temp set `_wm_scd2_deleted` (current keys `EXCEPT` snapshot keys) and a second null-safe close `UPDATE` are inserted before the open — with **no** matching `INSERT`, so vanished keys close without reopening.

Key correctness points:
- The changed-key set is captured **before** the transaction (the close flips `is_current`, so recomputing the diff after it would be wrong).
- Close is `UPDATE` (not `MERGE INTO` — DuckLake's MERGE is unreliable on fresh parquet); `EXCEPT` treats NULLs as equal so unchanged NULLs aren't false changes.
- Key matching is **null-safe** (`IS NOT DISTINCT FROM` via `EXISTS`, not `key IN (…)` — `IN` never matches `NULL`, which would drop a NULL-key row).
- The `<dim>_current` view is created **inside** the transaction with **`IF NOT EXISTS`** (created once), because `CREATE VIEW` advances the DuckLake snapshot — `CREATE OR REPLACE` outside the txn would both record the wrong snapshot and churn a snapshot on every unchanged rerun.

---

## Changes

- **Parser (both surfaces, kept in parity):** `MaterializeSpec` gains `scd2` + `track`; `history` flag / `scd2` alias / `track=` parsed in `backend/parsers/windmill-parser/src/asset_parser.rs` and `frontend/…/parsePipelineAnnotations.ts`. Shared fixture corpus + Rust & TS parity harnesses extended.
- **Codegen (`sql_materialize.rs`):** new `MaterializeStrategy::Scd2 { key, track }` + `scd2_statements()` (diff → close → open → `_current` view).
- **Worker (`duckdb_executor.rs`):** strategy derivation + guards (`history` requires `key=`; `// partitioned` + history rejected). Flows through the same summary → `// data_test` + schema-capture path as other managed strategies.
- **Docs:** `ducklake-materialization.md`, `pipelines-vs-dbt.md`.

**Not touched:** no `*_ee` files (no companion PR); no `.svelte` files (the frontend change is pure parser logic).

---

## Test plan

- [x] `cargo test -p windmill-parser` — parser unit tests (history flag, `scd2` alias, key-without-history stays SCD1) + codegen tests (diff/close/open shape, `_current` view, no `MERGE INTO`) + parity harness.
- [x] `cargo test -p windmill-worker --features duckdb,parquet` — wiring tests (managed wrap emitted, key required, partitioned rejected).
- [x] `npx vitest run parsePipelineAnnotations` — TS parser + parity.
- [x] **SQL-level e2e against a real DuckLake** (`duckdb` CLI, sqlite catalog + local storage): ran the exact generated statements across runs — confirmed correct type-2 history (change→close+open, new key→insert, absent key→soft-delete, idempotent no-op), `deletes=close` (vanished key closed, reactivation opens a fresh version with a validity gap), the `<dim>_current` view persisting across sessions, and an `ASOF JOIN … >= valid_from` resolving the effective-dated version.
- [ ] Manual verification on a full EE + object-store stack (the local CE instance has no configured ducklake): deploy `// materialize ducklake://<lake>/<dim> key=id history`, run twice, confirm the history table + `<dim>_current` view + both rejection errors.

## CI review

All findings from the automated reviewers (Claude, Pi, Codex, cubic) addressed:

- **Codex [P1]** — NULL natural keys silently dropped (`key IN (…)` never matches NULL): fixed with null-safe `IS NOT DISTINCT FROM` matching (`8f09010`).
- **cubic [P2]** — `_current` view advanced the recorded DuckLake snapshot: fixed by creating the view inside the write transaction (`8f09010`).
- **Codex [P2]** — unchanged reruns still advanced the snapshot via `CREATE OR REPLACE VIEW`: fixed with `CREATE VIEW IF NOT EXISTS` (created once, no-op thereafter) (`a9d27e3`).
- **Claude/cubic [P2 ×3]** — `track=` spacing, `_current` reserved name, schema-freeze: documented contracts (`1dd682e`).

Both substantive fixes verified against a real DuckLake (NULL-key row materialized; exactly one snapshot per run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
