### PR TITLE
fix: grant dispatch_event table to windmill roles (WIN-2112)

### DIFF
--- a/backend/migrations/20260701080313_grant_dispatch_event_to_windmill_roles.down.sql
+++ b/backend/migrations/20260701080313_grant_dispatch_event_to_windmill_roles.down.sql
@@ -1,0 +1,4 @@
+REVOKE ALL ON dispatch_event FROM windmill_user;
+REVOKE ALL ON dispatch_event FROM windmill_admin;
+REVOKE ALL ON SEQUENCE dispatch_event_id_seq FROM windmill_user;
+REVOKE ALL ON SEQUENCE dispatch_event_id_seq FROM windmill_admin;

--- a/backend/migrations/20260701080313_grant_dispatch_event_to_windmill_roles.up.sql
+++ b/backend/migrations/20260701080313_grant_dispatch_event_to_windmill_roles.up.sql
@@ -1,0 +1,15 @@
+-- The dispatch_event table (migration 20260523055641_dispatch_event) was
+-- created relying on ALTER DEFAULT PRIVILEGES to grant access to windmill_user
+-- and windmill_admin. Those default privileges only apply to objects created by
+-- the role that set them (migration 20250205131523), so deployments whose
+-- migration runner is a different role leave dispatch_event ungranted. Direct
+-- writes run as the invoking role -- the dispatcher insert (asset_dispatch.rs)
+-- and the DELETE in delete_jobs (windmill-common/src/jobs.rs), reached whenever
+-- a job's side rows are reaped, e.g. on schedule disable -- and fail with
+-- "permission denied for table dispatch_event". Grant explicitly to guarantee
+-- access regardless of who ran the migrations (same fix as notify_event in
+-- 20260619091631 and script_trigger in 20260619112847).
+GRANT ALL ON dispatch_event TO windmill_user;
+GRANT ALL ON dispatch_event TO windmill_admin;
+GRANT ALL ON SEQUENCE dispatch_event_id_seq TO windmill_user;
+GRANT ALL ON SEQUENCE dispatch_event_id_seq TO windmill_admin;


### PR DESCRIPTION
## Problem

Customer report: disabling a schedule fails with

```
Cannot disable schedule: SqlErr: error returned from database: permission denied for table dispatch_event @jobs.rs:481
```

## Root cause

The `dispatch_event` table (migration `20260523055641_dispatch_event`) was created relying on `ALTER DEFAULT PRIVILEGES` to grant access to `windmill_user`/`windmill_admin`. Those default privileges only apply to objects created **by the role that set them** (migration `20250205131523_grant_all_in_current_schema`). Deployments whose migration runner is a *different* role therefore leave `dispatch_event` ungranted.

Direct writes then run as the invoking application role and fail:
- the `DELETE FROM dispatch_event` in `delete_jobs` (`windmill-common/src/jobs.rs:482`), reached whenever a job's side rows are reaped — e.g. **on schedule disable** (`clear_schedule`), and
- the dispatcher insert in `windmill-queue/src/asset_dispatch.rs`.

This is the same recurring gap already fixed for `notify_event` (`20260619091631`) and `script_trigger` (`20260619112847`) — any table written directly by the application after `20250205131523` needs an explicit grant.

I checked the other two tables `delete_jobs` touches: `flow_conversation_message` is already explicitly granted, and `zombie_job_counter` (created one second before `...131523`) is covered by that migration's one-time `GRANT ALL ON ALL TABLES`. Only `dispatch_event` was missing.

## Fix

New migration `20260701080313_grant_dispatch_event_to_windmill_roles` grants the table and its sequence to both roles. `GRANT` is idempotent, so re-application (a migration squash, or an operator who already granted it manually) is a harmless no-op.

## Verification

Reproduced the exact failing SQL locally against the app role:

```
-- as windmill_user, before grant:
DELETE FROM dispatch_event WHERE producer_job_id = ANY(...)
  -> ERROR: permission denied for table dispatch_event   (matches customer report)
-- after applying the migration:
  -> DELETE 0   (succeeds)
```

Migration applies cleanly via `cargo sqlx migrate run` and re-runs without error (idempotent). No Rust changed (pure SQL migration), so no sqlx query-cache update needed.

Fixes WIN-2112

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes schedule disable failures by granting the `dispatch_event` table and sequence to `windmill_user` and `windmill_admin`. Addresses WIN-2112 and ensures deletes and dispatcher inserts work regardless of who ran migrations.

- Bug Fixes
  - Adds SQL migration `20260701080313_grant_dispatch_event_to_windmill_roles` to GRANT ALL on `dispatch_event` and `dispatch_event_id_seq` for both roles. Idempotent; no app code changes required.

<sup>Written for commit 7867ca294cbb1c0c9a976d176c649f46ed97b7f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

