### PR TITLE
fix: grant workspace_diff, materialized_partition, debounce_stale_data to windmill roles

### DIFF
--- a/backend/migrations/20260701083047_grant_user_db_tables_to_windmill_roles.down.sql
+++ b/backend/migrations/20260701083047_grant_user_db_tables_to_windmill_roles.down.sql
@@ -1,0 +1,6 @@
+REVOKE ALL ON workspace_diff FROM windmill_user;
+REVOKE ALL ON workspace_diff FROM windmill_admin;
+REVOKE ALL ON materialized_partition FROM windmill_user;
+REVOKE ALL ON materialized_partition FROM windmill_admin;
+REVOKE ALL ON debounce_stale_data FROM windmill_user;
+REVOKE ALL ON debounce_stale_data FROM windmill_admin;

--- a/backend/migrations/20260701083047_grant_user_db_tables_to_windmill_roles.up.sql
+++ b/backend/migrations/20260701083047_grant_user_db_tables_to_windmill_roles.up.sql
@@ -1,0 +1,22 @@
+-- Same grant gap fixed for notify_event (20260619091631), script_trigger
+-- (20260619112847), and dispatch_event: tables created after the one-time
+-- GRANT ALL in 20250205131523 rely on ALTER DEFAULT PRIVILEGES, which only
+-- applies to objects created by the role that set them. On deployments whose
+-- migration runner is a different role, these tables end up ungranted, and
+-- writes that run under the RLS role (a transaction opened via
+-- user_db.begin(&authed) -> SET LOCAL ROLE windmill_user/windmill_admin) fail
+-- with "permission denied for table <name>".
+--
+-- Each table below has a confirmed write on a user_db transaction:
+--   * workspace_diff        -- UPDATE in set_ws_specific (workspaces.rs)
+--   * materialized_partition -- INSERT via record_materialization (assets API)
+--   * debounce_stale_data   -- DELETE in resume_suspended_trigger_jobs
+--                              (global_handler.rs), the same tx that reaps a
+--                              job's side rows
+-- None has a sequence, so only table grants are needed.
+GRANT ALL ON workspace_diff TO windmill_user;
+GRANT ALL ON workspace_diff TO windmill_admin;
+GRANT ALL ON materialized_partition TO windmill_user;
+GRANT ALL ON materialized_partition TO windmill_admin;
+GRANT ALL ON debounce_stale_data TO windmill_user;
+GRANT ALL ON debounce_stale_data TO windmill_admin;


### PR DESCRIPTION
## Context

Follow-up to the `dispatch_event` grant fix (#9852, WIN-2112). While fixing that, I audited **every** table created after the one-time `GRANT ALL` migration `20250205131523_grant_all_in_current_schema` for the same latent bug.

## The bug class

Tables created after `20250205131523` rely on `ALTER DEFAULT PRIVILEGES` to reach `windmill_user`/`windmill_admin`. Those default privileges only apply to objects created **by the role that set them**, so on deployments whose migration runner is a different role the tables end up ungranted. Any write that runs under the RLS role — a transaction opened via `user_db.begin(&authed)`, which does `SET LOCAL ROLE windmill_user`/`windmill_admin` — then fails with `permission denied for table <name>`.

This is the 4th instance: previously fixed for `notify_event` (`20260619091631`), `script_trigger` (`20260619112847`), and `dispatch_event` (#9852).

## Audit result

I checked all ~26 post-cutoff tables with direct writes. A table is only at risk if it's written on a **user_db** transaction (raw-`db`-pool writes run as the login role, and `SECURITY DEFINER` writes run as the owner — both unaffected). Exactly three qualified and lacked a grant:

| Table | Confirmed user_db write |
|---|---|
| `workspace_diff` | `UPDATE` in `set_ws_specific` — `windmill-api-workspaces/src/workspaces.rs:8523` (tx from `user_db.begin` @ :8474) |
| `materialized_partition` | `INSERT` via `record_materialization` — `windmill-common/src/materialization.rs:91`, handler `windmill-api-assets/src/lib.rs:90`. Sibling `materialized_asset_schema` was already granted — same oversight. |
| `debounce_stale_data` | `DELETE` in `resume_suspended_trigger_jobs` — `windmill-trigger/src/global_handler.rs:261` (same user_db tx that calls `delete_jobs` → the `dispatch_event` delete) |

None has a sequence, so table-only grants.

### Explicitly ruled out
- All `mcp_oauth_*`, `workspace_fork_deployment_request*`, `workspace_protection_rule`, `volume`, `background_task_state`, `worker_group_job_stats`, `ai_chat_usage`, `raw_script_temp`, `job_delete_schedule` — writes are raw-pool only.
- `v2_job_debounce_batch` / `debounce_batch_seq` — the debounce INSERT/DELETE run raw-pool by design (`maybe_apply_debouncing` uses `&DB`; run-endpoint pushes use `IsolatedRoot`; the one user_db push path passes `debouncing_settings: Default`, so `maybe_debounce` early-returns). `debounce_key`'s `SELECT, UPDATE`-only grant is intentional (only SELECT/UPDATE occur under user_db).
- `folder_permission_history` / `group_permission_history`, `job_result_stream` / `job_result_stream_v2` — already granted.

## Verification

For each of the three, reproduced the exact failing statement as `windmill_user`:

```
-- before grant:  ERROR: permission denied for table workspace_diff / materialized_partition / debounce_stale_data
-- after grant:   succeeds
```

Migration applies cleanly and re-runs without error (GRANT is idempotent). Pure SQL, no `query!` changes → no sqlx cache update needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grant `windmill_user` and `windmill_admin` access to `workspace_diff`, `materialized_partition`, and `debounce_stale_data` to fix permission errors on `user_db` transactions. Follow-up to WIN-2112; stops "permission denied" errors on UPDATE/INSERT/DELETE paths touching these tables.

- **Bug Fixes**
  - Resolves a default-privileges gap when migrations run under a different role; writes under `SET LOCAL ROLE` (`user_db`) now succeed.
  - Migration is idempotent and table-only (no sequences).

<sup>Written for commit 80d222dcc381baf6538ebc1cf4784510ee7af9f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

