### PR TITLE
fix: validate workspace name length (max 50 chars) on create and fork

### DIFF
--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -44,9 +44,9 @@ use windmill_common::workspaces::GitRepositorySettings;
 use windmill_common::workspaces::WorkspaceDeploymentUISettings;
 use windmill_common::workspaces::{
     check_deploy_rules, check_user_against_rule, get_datatable_resource_from_db_unchecked,
-    validate_dev_workspace_id, validate_fork_workspace_id, DataTable, DataTableCatalogResourceType,
-    DataTableForkBehavior, ProtectionRuleKind, ProtectionRules, ProtectionRuleset, RuleCheckResult,
-    WorkspaceGitSyncSettings, DEV_WORKSPACE_LOCK_RULE_NAME,
+    validate_dev_workspace_id, validate_fork_workspace_id, validate_workspace_name, DataTable,
+    DataTableCatalogResourceType, DataTableForkBehavior, ProtectionRuleKind, ProtectionRules,
+    ProtectionRuleset, RuleCheckResult, WorkspaceGitSyncSettings, DEV_WORKSPACE_LOCK_RULE_NAME,
 };
 use windmill_common::workspaces::{Ducklake, DucklakeCatalogResourceType};
 use windmill_common::PgDatabase;
@@ -3845,6 +3845,8 @@ async fn create_workspace(
         }
     }
 
+    validate_workspace_name(&nw.name)?;
+
     let mut tx: Transaction<'_, Postgres> = db.begin().await?;
 
     check_w_id_conflict(&mut tx, &nw.id).await?;
@@ -5021,6 +5023,7 @@ async fn create_workspace_fork_branch(
     } else {
         validate_fork_workspace_id(&nw.id)?;
     }
+    validate_workspace_name(&nw.name)?;
 
     // Fail before creating any git branch so a name conflict doesn't leave a
     // dangling branch on the synced repos.
@@ -5170,6 +5173,7 @@ async fn create_workspace_fork(
     } else {
         validate_fork_workspace_id(&nw.id)?;
     }
+    validate_workspace_name(&nw.name)?;
     // Check the id conflict before the CE workspace-count limit so that
     // re-using a taken (possibly archived) fork id reports the actual
     // conflict instead of a misleading "maximum number of workspaces" error.

--- a/backend/windmill-common/src/workspaces.rs
+++ b/backend/windmill-common/src/workspaces.rs
@@ -189,6 +189,19 @@ pub fn validate_dev_workspace_id(id: &str) -> error::Result<()> {
     validate_workspace_branch_id(id, false)
 }
 
+/// The `workspace.name` column is `character varying(50)`, so a name longer than 50 characters
+/// triggers a raw `value too long for type character varying(50)` SQL error on insert. Validate
+/// up front to return a clear message instead.
+pub fn validate_workspace_name(name: &str) -> error::Result<()> {
+    if name.chars().count() > 50 {
+        return Err(Error::BadRequest(format!(
+            "Workspace name is too long ({} chars). Maximum length is 50 characters.",
+            name.chars().count()
+        )));
+    }
+    Ok(())
+}
+
 fn validate_workspace_branch_id(id: &str, require_fork_prefix: bool) -> error::Result<()> {
     if id.is_empty() {
         return Err(Error::BadRequest(

--- a/cli/src/commands/workspace/fork.ts
+++ b/cli/src/commands/workspace/fork.ts
@@ -186,6 +186,15 @@ async function createWorkspaceFork(
   // branch creation — a late backend rejection would leave cloned databases
   // behind.
   validateForkWorkspaceId(trueWorkspaceId);
+  // The workspace.name column is character varying(50); reject an over-long name
+  // up front (matching the name actually sent to the backend below) instead of
+  // failing late after databases are cloned and the git branch is created.
+  const effectiveName = opts.createWorkspaceName ?? workspaceName ?? trueWorkspaceId;
+  if (effectiveName.length > 50) {
+    throw new Error(
+      `Fork workspace name is too long (${effectiveName.length} chars; max 50). Choose a shorter name.`
+    );
+  }
   let alreadyExists = false;
   try {
     alreadyExists = await wmill.existsWorkspace({


### PR DESCRIPTION
Fixes WIN-2113

## Problem

The `workspace.name` column is `character varying(50)`, but the workspace
create/fork handlers only validated the workspace **id** length (≤50), not the
**name**. A name exceeding 50 characters passed id validation and then surfaced
as a raw SQL error — `value too long for type character varying(50)` — returned
to the client as an opaque 500. For forks this failure happened *late*, after
datatables were cloned and the git branch was created.

## Fix

- Add a shared `validate_workspace_name` helper in `windmill-common`
  (`chars().count() > 50`, matching Postgres character semantics) that returns a
  clear `BadRequest`.
- Call it in `create_workspace`, `create_workspace_fork`, and
  `create_workspace_fork_branch`. For the fork endpoints the check runs up front
  (before branch creation / datatable cloning) so a bad name fails fast without
  leaving dangling git branches or cloned databases.
- CLI: `wmill workspace fork` now rejects an over-long name before
  `existsWorkspace`, datatable cloning, and branch creation, validating the same
  effective name (`opts.createWorkspaceName ?? workspaceName ?? trueWorkspaceId`)
  that is actually sent to the backend.

## Validation

- **Backend**: compiles cleanly (`windmill-common` + `windmill-api-workspaces` via
  cargo watch, `Finished dev` with no errors).
- **CLI**: `bunx tsc --noEmit` introduces no new errors in `fork.ts` (remaining
  errors are pre-existing in unrelated files).
- **End-to-end** against the running backend:
  - `POST /api/workspaces/create` with a 60-char name → `HTTP 400 Bad request:
    Workspace name is too long (60 chars). Maximum length is 50 characters.`
  - Same with a 50-char name → `HTTP 200` (created, then cleaned up).

The fork endpoints share the same helper, so they are covered by construction
(they require a git-synced setup that is impractical to exercise in the dev box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate workspace name length (max 50) on create and fork to match the DB column and return a clear 400 instead of an opaque 500. Fixes WIN-2113 and fails fast on forks to avoid creating branches or cloning databases.

- **Bug Fixes**
  - Added `validate_workspace_name` in `windmill-common` (Unicode-aware `chars().count() > 50`) returning a BadRequest.
  - Called in `create_workspace`, `create_workspace_fork`, and `create_workspace_fork_branch` before any side effects.
  - CLI: `wmill workspace fork` validates the effective name before `existsWorkspace`, datatable cloning, and branch creation.

<sup>Written for commit 696c69476b43cc92db4c427cb65ab066575c50e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

