### PR TITLE
fix(mcp): stop double-escaping string query params in build_query_string

### DIFF
--- a/backend/windmill-api/src/mcp/utils.rs
+++ b/backend/windmill-api/src/mcp/utils.rs
@@ -382,12 +382,18 @@ pub fn build_query_string(
                 .map(|value| {
                     // Use the original name for the query parameter key
                     let original_name = get_original_name(param_name, query_field_renames);
-                    let value_str = value.to_string();
-                    let str_val = value_str.trim_matches('"');
+                    // For string values, use the raw content: to_string() would JSON-encode
+                    // it, and stripping the outer quotes leaves inner quotes backslash-escaped
+                    // (e.g. `{\"k\":\"v\"}`), which breaks downstream JSON parsing of params
+                    // like `args`/`result`. Non-string values keep their JSON serialization.
+                    let str_val = value
+                        .as_str()
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| value.to_string());
                     format!(
                         "{}={}",
                         urlencoding::encode(&original_name),
-                        urlencoding::encode(str_val)
+                        urlencoding::encode(&str_val)
                     )
                 })
         })
@@ -623,5 +629,56 @@ mod tests {
         )
         .expect("legitimate path should substitute");
         assert_eq!(result, "/w/dev/scripts/get/p/u/alice/my_script");
+    }
+
+    fn single_query_schema(param: &str) -> Option<Value> {
+        Some(json!({
+            "type": "object",
+            "properties": { param: { "type": "string" } }
+        }))
+    }
+
+    #[test]
+    fn build_query_string_preserves_json_string_content() {
+        // A string param carrying JSON (e.g. the `args` filter on listJobs) must be
+        // emitted as its raw content so the backend can `serde_json::from_str` it.
+        let mut args = serde_json::Map::new();
+        args.insert("args".to_string(), json!("{\"key\":\"val\"}"));
+
+        let qs = build_query_string(&args, &single_query_schema("args"), &None);
+
+        // No backslash escaping: %5C must not appear; the encoded braces/quotes are exact.
+        assert_eq!(qs, "?args=%7B%22key%22%3A%22val%22%7D");
+        assert!(
+            !qs.contains("%5C"),
+            "must not contain backslash escapes: {qs}"
+        );
+    }
+
+    #[test]
+    fn build_query_string_keeps_non_string_serialization() {
+        let mut args = serde_json::Map::new();
+        args.insert("per_page".to_string(), json!(42));
+        assert_eq!(
+            build_query_string(&args, &single_query_schema("per_page"), &None),
+            "?per_page=42"
+        );
+
+        let mut args = serde_json::Map::new();
+        args.insert("running".to_string(), json!(true));
+        assert_eq!(
+            build_query_string(&args, &single_query_schema("running"), &None),
+            "?running=true"
+        );
+    }
+
+    #[test]
+    fn build_query_string_encodes_plain_string() {
+        let mut args = serde_json::Map::new();
+        args.insert("path".to_string(), json!("u/alice/my script"));
+        assert_eq!(
+            build_query_string(&args, &single_query_schema("path"), &None),
+            "?path=u%2Falice%2Fmy%20script"
+        );
     }
 }


### PR DESCRIPTION
## Problem

`build_query_string` in `backend/windmill-api/src/mcp/utils.rs` converted MCP tool arguments into URL query values using `value.to_string()` (serde_json JSON serialization) followed by `trim_matches('"')`.

For string values that carry JSON — e.g. the `args`/`result` filters on job listing endpoints, or `args` on schedule listing — `to_string()` JSON-encodes the string and escapes its inner quotes with backslashes. Stripping only the outer quotes leaves a value like `{\"key\":\"val\"}`. The backend's `serde_json::from_str()` then fails to parse it, hits the `FALSE` fallback, and the endpoint returns zero results.

## Fix

Extract the raw string content with `value.as_str()` for `Value::String`, falling back to `value.to_string()` for non-string types (numbers, booleans). This preserves existing behavior for non-string values while correctly handling strings that contain quotes.

```rust
let str_val = value
    .as_str()
    .map(|s| s.to_string())
    .unwrap_or_else(|| value.to_string());
```

## Tests

Added regression tests in the existing `mcp::utils::tests` module:
- `build_query_string_preserves_json_string_content` — JSON-string param encodes to raw content with no `%5C` backslash escapes
- `build_query_string_keeps_non_string_serialization` — numbers/booleans keep their JSON serialization
- `build_query_string_encodes_plain_string` — plain strings are URL-encoded correctly

```
running 3 tests
test mcp::utils::tests::build_query_string_keeps_non_string_serialization ... ok
test mcp::utils::tests::build_query_string_encodes_plain_string ... ok
test mcp::utils::tests::build_query_string_preserves_json_string_content ... ok
test result: ok. 3 passed; 0 failed
```

Compiles cleanly with `cargo test -p windmill-api --features mcp`. Backend-only change; no frontend or SQL touched.

Fixes WIN-2114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double-escaped string query params in MCP `build_query_string`, which broke JSON-carrying filters like `args` and `result`. Endpoints now parse these filters correctly and return results. Addresses WIN-2114.

- **Bug Fixes**
  - Emit raw string values via `value.as_str()`; fallback to `to_string()` for non-strings.
  - Added regression tests covering JSON-string, non-string, and plain-string params.

<sup>Written for commit 49a0b39e7488dd24cd79a650d54f311884ecc6ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

