### PR TITLE
fix(folders): allow dots and at-signs in folder owner validation

### DIFF
--- a/backend/windmill-api-groups/src/folders.rs
+++ b/backend/windmill-api-groups/src/folders.rs
@@ -146,12 +146,11 @@ async fn list_foldernames(
 }
 
 fn validate_owner(owner: &str) -> Result<()> {
-    if !owner
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '/' || c == '-')
-    {
+    if !owner.chars().all(|c| {
+        c.is_ascii_alphanumeric() || c == '_' || c == '/' || c == '-' || c == '.' || c == '@'
+    }) {
         return Err(error::Error::BadRequest(
-            "Invalid owner: must contain only alphanumeric characters, underscores, hyphens, or slashes".to_string(),
+            "Invalid owner: must contain only alphanumeric characters, underscores, hyphens, slashes, dots, or at-signs".to_string(),
         ));
     }
     Ok(())


### PR DESCRIPTION
## Problem

`validate_owner()` in `backend/windmill-api-groups/src/folders.rs` only permitted `[a-zA-Z0-9_/-]` in owner strings. Folder owners use the format `u/<username>`, and usernames are frequently email addresses containing `.` and `@`.

The folder **creation** path bypasses `validate_owner()` and inserts these owners successfully, but `add_owner` and `remove_owner` both call `validate_owner()`, so any later modification of owners with email-style usernames failed with:

> Invalid owner: must contain only alphanumeric characters, underscores, hyphens, or slashes

## Fix

Extend the character allowlist in `validate_owner()` to also accept `.` and `@`, and update the error message accordingly.

The SQL injection risk these characters might pose is already fully mitigated by the bind-parameter queries introduced in the same commit (`a26a2e809`) that added this validation.

## Validation

- Backend compiled cleanly under `cargo watch` (worker came back up listening for jobs, no errors).

Fixes WIN-2116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow '.' and '@' in folder owner validation so email-style usernames can be added/removed without errors. Aligns validation with the creation path and fixes WIN-2116.

- **Bug Fixes**
  - Expanded `validate_owner()` to accept '.' and '@'.
  - Updated the invalid-owner message to list all allowed characters.
  - Queries remain parameterized to mitigate injection risks.

<sup>Written for commit c656d155d29af185abeeba53f3e9a94c0a061781. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

