### PR TITLE
feat(frontend): add zoom and download to Mermaid graphs

### DIFF
--- a/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
@@ -70,8 +70,13 @@
 
 	function panzoomAction(node: HTMLElement) {
 		let instance: PanZoom | undefined
+		// Guard the async import against a close-before-resolve: without it,
+		// destroy() (instance still undefined) disposes nothing and the late
+		// .then() would build a leaked panzoom on an already-detached node.
+		let disposed = false
 		panzoomNode = node
 		import('panzoom').then(({ default: panzoom }) => {
+			if (disposed) return
 			instance = panzoom(node, {
 				bounds: true,
 				boundsPadding: 0.1,
@@ -84,6 +89,7 @@
 		})
 		return {
 			destroy() {
+				disposed = true
 				instance?.dispose()
 				panzoomInstance = undefined
 				panzoomNode = undefined

--- a/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/script/MermaidDisplay.svelte
@@ -2,8 +2,10 @@
 	import { randomUUID } from '$lib/utils/uuid'
 	import { useIsDarkMode } from '$lib/components/DarkModeObserver.svelte'
 	import { Button } from '$lib/components/common'
-	import { copyToClipboard } from '$lib/utils'
-	import { ClipboardCopy } from 'lucide-svelte'
+	import Modal from '$lib/components/common/modal/Modal.svelte'
+	import { copyToClipboard, download } from '$lib/utils'
+	import { ClipboardCopy, Download, Maximize2, Minus, Plus, RotateCcw } from 'lucide-svelte'
+	import type { PanZoom } from 'panzoom'
 
 	let { code }: { code: string } = $props()
 
@@ -17,6 +19,8 @@
 	// Monotonic token so an earlier-started render that resolves late can't
 	// overwrite the result of a newer one (out-of-order async on rapid code/theme changes).
 	let renderSeq = 0
+
+	let expanded = $state(false)
 
 	async function render(source: string, dark: boolean) {
 		const seq = ++renderSeq
@@ -52,26 +56,137 @@
 
 	// Only show the diagram while it corresponds to the current source.
 	let showSvg = $derived(svg !== undefined && renderedCode === code)
+
+	function downloadSvg() {
+		if (svg) {
+			download('mermaid.svg', svg, 'image/svg+xml')
+		}
+	}
+
+	// Pan/zoom is only wired up inside the fullscreen modal so the inline preview
+	// stays a plain, non-interactive thumbnail.
+	let panzoomInstance = $state<PanZoom | undefined>(undefined)
+	let panzoomNode: HTMLElement | undefined = undefined
+
+	function panzoomAction(node: HTMLElement) {
+		let instance: PanZoom | undefined
+		panzoomNode = node
+		import('panzoom').then(({ default: panzoom }) => {
+			instance = panzoom(node, {
+				bounds: true,
+				boundsPadding: 0.1,
+				maxZoom: 8,
+				minZoom: 0.2,
+				zoomDoubleClickSpeed: 1,
+				smoothScroll: false
+			})
+			panzoomInstance = instance
+		})
+		return {
+			destroy() {
+				instance?.dispose()
+				panzoomInstance = undefined
+				panzoomNode = undefined
+			}
+		}
+	}
+
+	function zoomBy(ratio: number) {
+		if (!panzoomInstance || !panzoomNode) return
+		// smoothZoom anchors on client coordinates — zoom around the viewport center.
+		const rect = panzoomNode.getBoundingClientRect()
+		panzoomInstance.smoothZoom(rect.left + rect.width / 2, rect.top + rect.height / 2, ratio)
+	}
+
+	function resetZoom() {
+		if (!panzoomInstance) return
+		panzoomInstance.moveTo(0, 0)
+		panzoomInstance.zoomAbs(0, 0, 1)
+	}
 </script>
 
 {#if showSvg}
 	<div class="relative">
-		<Button
-			wrapperClasses="absolute top-2 right-2 z-20"
-			onclick={() => copyToClipboard(code)}
-			color="light"
-			size="xs2"
-			startIcon={{
-				icon: ClipboardCopy
-			}}
-			iconOnly
-			title="Copy to clipboard"
-		/>
+		<div class="absolute top-2 right-2 z-20 flex flex-row gap-1">
+			<Button
+				onclick={() => copyToClipboard(code)}
+				color="light"
+				size="xs2"
+				startIcon={{ icon: ClipboardCopy }}
+				iconOnly
+				title="Copy diagram source"
+			/>
+			<Button
+				onclick={downloadSvg}
+				color="light"
+				size="xs2"
+				startIcon={{ icon: Download }}
+				iconOnly
+				title="Download as SVG"
+			/>
+			<Button
+				onclick={() => (expanded = true)}
+				color="light"
+				size="xs2"
+				startIcon={{ icon: Maximize2 }}
+				iconOnly
+				title="Expand and zoom"
+			/>
+		</div>
 		<div class="p-2 flex justify-center overflow-x-auto">
 			<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 			{@html svg}
 		</div>
 	</div>
+
+	<Modal bind:open={expanded} title="Diagram" kind="X" class="sm:max-w-none w-[92vw]">
+		{#snippet settings()}
+			<div class="flex flex-row gap-1 mr-8">
+				<Button
+					onclick={() => zoomBy(1 / 1.3)}
+					color="light"
+					size="xs2"
+					startIcon={{ icon: Minus }}
+					iconOnly
+					title="Zoom out"
+				/>
+				<Button
+					onclick={() => zoomBy(1.3)}
+					color="light"
+					size="xs2"
+					startIcon={{ icon: Plus }}
+					iconOnly
+					title="Zoom in"
+				/>
+				<Button
+					onclick={resetZoom}
+					color="light"
+					size="xs2"
+					startIcon={{ icon: RotateCcw }}
+					iconOnly
+					title="Reset zoom"
+				/>
+				<Button
+					onclick={downloadSvg}
+					color="light"
+					size="xs2"
+					startIcon={{ icon: Download }}
+					iconOnly
+					title="Download as SVG"
+				/>
+			</div>
+		{/snippet}
+		<div
+			class="relative w-full h-[78vh] overflow-hidden rounded border cursor-grab bg-surface-secondary"
+		>
+			{#if expanded}
+				<div use:panzoomAction class="w-full h-full flex items-center justify-center">
+					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+					{@html svg}
+				</div>
+			{/if}
+		</div>
+	</Modal>
 {:else}
 	<!-- Fallback while loading or when rendering fails: show the raw source -->
 	<pre class="overflow-auto max-h-screen text-xs p-2">{code}</pre>


### PR DESCRIPTION
## Summary

Mermaid diagrams rendered in the AI chat (`MermaidDisplay.svelte`) could
only be viewed inline with horizontal scroll — there was no way to zoom
into a large graph or save it. This adds both.

Fixes WIN-2117

## Changes

- **Download as SVG**: a download button next to the existing copy button
  saves the rendered diagram as `mermaid.svg` (uses the client-side
  `download` util; mirrors the existing SVG-download pattern in
  `DisplayResult.svelte`).
- **Expand & zoom**: a `Maximize2` button opens a large modal
  (`Modal.svelte`, `kind="X"`) that renders the diagram with pan/drag and
  zoom via the already-present `panzoom` dependency (mouse wheel + drag,
  plus zoom-in / zoom-out / reset controls in the modal header). Download
  is also available from the modal.
- Pan/zoom is only wired up inside the modal, so the inline preview stays
  a plain non-interactive thumbnail.

## Test plan

Verified end-to-end in the browser (Playwright, headless) via a temporary
test route mounting `MermaidDisplay` with a sample flowchart, since the
component only renders inside the AI copilot chat:

- [x] Inline preview shows copy / download / expand buttons
- [x] Download button produces a valid `mermaid.svg` (24 KB, well-formed)
- [x] Expand opens the fullscreen modal with the diagram + zoom controls
- [x] Zoom-in enlarges the diagram (panzoom active)
- [x] Download from the modal works
- [x] No console errors
- [x] `svelte-check` reports no new errors for the file (pre-existing
  repo-wide `Timeout`-type errors are unrelated)

## Screenshots

Inline preview with copy / download / expand buttons:

![mermaid-inline](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2117-add-zoom-and-download-to-mermaid-graphs/1782904274-mermaid-inline.png)

Fullscreen zoom modal:

![mermaid-modal](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2117-add-zoom-and-download-to-mermaid-graphs/1782904276-mermaid-modal.png)

Zoomed in:

![mermaid-zoomed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2117-add-zoom-and-download-to-mermaid-graphs/1782904278-mermaid-zoomed.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds zoom and SVG download to Mermaid diagrams in the AI chat. Adds a fullscreen modal for pan/zoom and inline copy/download/expand, and guards against a `panzoom` init race when the modal closes early (WIN-2117).

- **New Features**
  - Download SVG (inline and modal) as mermaid.svg.
  - Fullscreen modal with pan/drag, wheel zoom via `panzoom`, and +/−/reset.
  - Inline preview stays non-interactive.

<sup>Written for commit b6086fc675f03582600411ceb4f1e3928ee72d6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

