### PR TITLE
fix(jseval): increase QuickJS memory limit from 32MB to 256MB

### DIFF
--- a/backend/windmill-jseval/src/lib.rs
+++ b/backend/windmill-jseval/src/lib.rs
@@ -327,7 +327,7 @@ pub async fn eval_timeout_quickjs(
 }
 
 #[cfg(feature = "quickjs")]
-const QUICKJS_MEMORY_LIMIT: usize = 32 * 1024 * 1024;
+const QUICKJS_MEMORY_LIMIT: usize = 256 * 1024 * 1024;
 
 #[cfg(feature = "quickjs")]
 async fn eval_quickjs_inner(


### PR DESCRIPTION
Flow expression evaluation uses QuickJS to evaluate step input transforms. The 32MB memory limit was too restrictive for payloads that construct large arrays — for example `Array.from({length: 1e6}, ...).flat()` exceeds 32MB and causes QuickJS to throw `Exception generated by quickjs`, surfacing as an opaque eval failure.

Increasing the limit to 256MB. QuickJS evaluations are always authenticated and run inside the worker per-job isolation, so this is safe.

Closes #8073.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the QuickJS memory limit for flow expression evaluation from 32MB to 256MB to prevent opaque eval failures on large payloads (e.g., million-element arrays). Evaluations are authenticated and run in per‑job isolated workers, so this increase is safe.

<sup>Written for commit 5c5b6b9f187afd6bf7c64694edc0adb74ab80256. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

