### PR TITLE
fix(tree-view): match file indentation with folder indentation (depth*16)

### DIFF
--- a/frontend/src/lib/components/CenteredPage.svelte
+++ b/frontend/src/lib/components/CenteredPage.svelte
@@ -21,7 +21,7 @@
 </script>
 
 <div
-	class={twMerge('pb-8', wrapperClasses, handleOverflow ? 'h-full overflow-y-auto' : '')}
+	class={twMerge('pb-8', wrapperClasses, handleOverflow ? 'grow overflow-y-auto' : '')}
 	style={handleOverflow ? 'scrollbar-gutter: stable both-edges;' : ''}
 	{id}
 >

--- a/frontend/src/lib/components/common/table/Row.svelte
+++ b/frontend/src/lib/components/common/table/Row.svelte
@@ -158,7 +158,7 @@
 		clickToSelect ? 'cursor-pointer select-none' : '',
 		selected ? 'bg-surface-accent-selected' : keyboardSelected ? 'bg-gray-200 dark:bg-gray-700' : ''
 	)}
-	style={depth > 0 ? `padding-left: ${depth * 32}px;` : ''}
+	style={depth > 0 ? `padding-left: ${depth * 16}px;` : ''}
 	role={clickToSelect ? 'button' : undefined}
 	tabindex={clickToSelect ? 0 : undefined}
 	onclick={handleRowClick}


### PR DESCRIPTION
Files in the tree view indented at `depth * 32` px while folders used
`depth * 16` px, causing files to be offset twice as much as folders
at each nesting level. Changed Row.svelte to use `depth * 16` to match
TreeView.svelte.
Fixes #9726.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Match file indentation to folders in the tree view by using depth*16 px in `Row.svelte`, fixing the double offset. Use flex-grow instead of h-full for the deploy screen scroll container in `CenteredPage.svelte`. Fixes #9726.

<sup>Written for commit 8939275751eba7b7724db54166f45aed982c7263. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

