### PR TITLE
fix(deploy-screen): use flex-grow instead of h-full for scroll container

### DIFF
--- a/frontend/src/lib/components/CenteredPage.svelte
+++ b/frontend/src/lib/components/CenteredPage.svelte
@@ -21,7 +21,7 @@
 </script>
 
 <div
-	class={twMerge('pb-8', wrapperClasses, handleOverflow ? 'h-full overflow-y-auto' : '')}
+	class={twMerge('pb-8', wrapperClasses, handleOverflow ? 'grow overflow-y-auto' : '')}
 	style={handleOverflow ? 'scrollbar-gutter: stable both-edges;' : ''}
 	{id}
 >


### PR DESCRIPTION
**Issue:** #3687

**Root cause:** CenteredPage used `h-full` (`height: 100%`) which fails to resolve during SvelteKit client-side navigation because the parent height comes from `flex-1` (a calculated value), not an explicit height. On full reload, all heights are pre-computed so it works.

**Fix:** Changed `h-full` → `grow` (`flex-grow: 1`) in `CenteredPage.svelte`. Uses flexbox's own sizing instead of CSS `height: 100%`, which is reliable in both initial load and client-side navigation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Deploy screen scroll container during client-side navigation by switching from `h-full` to `grow` in `CenteredPage.svelte`. Uses flexbox sizing instead of `height: 100%` so the container height is reliable on both initial load and in-app navigation.

<sup>Written for commit e5d9f23577dc8a48be2eb034c4014f4ec7cd1858. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

