### PR TITLE
fix(offboarding): make global reassignment per-workspace and optional

### DIFF
--- a/frontend/src/lib/components/GlobalUserOffboardingModal.svelte
+++ b/frontend/src/lib/components/GlobalUserOffboardingModal.svelte
@@ -309,7 +309,7 @@
 										different user/folder.</p
 									>
 									<ul class="text-xs list-disc list-inside max-h-32 overflow-y-auto">
-										{#each conflicts as conflict (conflict)}
+										{#each conflicts as conflict, i (i)}
 											<li>{conflict}</li>
 										{/each}
 									</ul>

--- a/frontend/src/lib/components/GlobalUserOffboardingModal.svelte
+++ b/frontend/src/lib/components/GlobalUserOffboardingModal.svelte
@@ -118,8 +118,17 @@
 				: undefined
 	}
 
+	// At least one workspace can be reassigned (has another assignable user).
+	let anyReassignableWorkspace = $derived(
+		workspacesWithItems.some((wp) => (wsConfigs[wp.workspace_id]?.users.length ?? 0) > 0)
+	)
+	// At least one workspace is actually selected for reassignment.
+	let anyWorkspaceReassigned = $derived(
+		workspacesWithItems.some((wp) => wsConfigs[wp.workspace_id]?.reassign)
+	)
+
 	let canSubmit = $derived(
-		!doReassign ||
+		(!doReassign ||
 			workspacesWithItems.every((wp) => {
 				const cfg = wsConfigs[wp.workspace_id]
 				if (!cfg?.reassign) return true
@@ -127,7 +136,10 @@
 				if (!target) return false
 				if (!cfg?.selectedOperator) return false
 				return true
-			})
+			})) &&
+			// Reassign-only runs (no deletion) must reassign at least one workspace,
+			// otherwise the request is an empty no-op reported as success.
+			(deleteUser || anyWorkspaceReassigned)
 	)
 
 	async function submit() {
@@ -319,7 +331,11 @@
 					{/if}
 
 					<div class="flex items-center space-x-2 flex-row-reverse space-x-reverse mt-4">
-						{#if workspacesWithItems.length > 0 || deleteUser}
+						{#if !deleteUser && workspacesWithItems.length > 0 && !anyReassignableWorkspace}
+							{#if !loading}
+								<Button onclick={onClose} variant="accent" size="sm">Close</Button>
+							{/if}
+						{:else if workspacesWithItems.length > 0 || deleteUser}
 							<Button
 								disabled={submitting || !canSubmit}
 								onclick={submit}

--- a/frontend/src/lib/components/GlobalUserOffboardingModal.svelte
+++ b/frontend/src/lib/components/GlobalUserOffboardingModal.svelte
@@ -34,6 +34,7 @@
 	let wsConfigs: Record<
 		string,
 		{
+			reassign: boolean
 			targetKind: 'user' | 'folder'
 			selectedUser: string | undefined
 			selectedFolder: string | undefined
@@ -71,16 +72,21 @@
 						UserService.listUsernames({ workspace: wp.workspace_id }),
 						FolderService.listFolders({ workspace: wp.workspace_id })
 					])
+					const users = usernamesList
+						.filter((u: string) => u !== wp.username)
+						.map((u: string) => ({ label: u, value: u }))
 					return {
 						workspace_id: wp.workspace_id,
 						config: {
+							// Reassignment requires another workspace user to own items and back
+							// triggers/runnables; with no other user (e.g. single-member forks) it
+							// is impossible, so default off and leave items as-is.
+							reassign: users.length > 0,
 							targetKind: 'user' as const,
 							selectedUser: undefined as string | undefined,
 							selectedFolder: undefined as string | undefined,
 							selectedOperator: undefined as string | undefined,
-							users: usernamesList
-								.filter((u: string) => u !== wp.username)
-								.map((u: string) => ({ label: u, value: u })),
+							users,
 							folders: foldersList.map((f: { name: string }) => ({
 								label: f.name,
 								value: f.name
@@ -115,8 +121,9 @@
 	let canSubmit = $derived(
 		!doReassign ||
 			workspacesWithItems.every((wp) => {
-				const target = getReassignTo(wp.workspace_id)
 				const cfg = wsConfigs[wp.workspace_id]
+				if (!cfg?.reassign) return true
+				const target = getReassignTo(wp.workspace_id)
 				if (!target) return false
 				if (!cfg?.selectedOperator) return false
 				return true
@@ -129,13 +136,16 @@
 		try {
 			const reassignments: Record<string, { reassign_to: string; new_on_behalf_of_user?: string }> =
 				{}
-			for (const wp of workspacesWithItems) {
-				const target = getReassignTo(wp.workspace_id)
-				const cfg = wsConfigs[wp.workspace_id]
-				if (target) {
-					reassignments[wp.workspace_id] = {
-						reassign_to: target,
-						new_on_behalf_of_user: cfg?.selectedOperator
+			if (doReassign) {
+				for (const wp of workspacesWithItems) {
+					const cfg = wsConfigs[wp.workspace_id]
+					if (!cfg?.reassign) continue
+					const target = getReassignTo(wp.workspace_id)
+					if (target) {
+						reassignments[wp.workspace_id] = {
+							reassign_to: target,
+							new_on_behalf_of_user: cfg?.selectedOperator
+						}
 					}
 				}
 			}
@@ -222,7 +232,7 @@
 								{/if}
 
 								{#if doReassign}
-									{#each workspacesWithItems as wp}
+									{#each workspacesWithItems as wp (wp.workspace_id)}
 										{@const cfg = wsConfigs[wp.workspace_id]}
 										<div class="border border-border rounded-md p-3 space-y-2">
 											<div class="flex items-center justify-between">
@@ -230,23 +240,39 @@
 													{wp.workspace_id}
 													<span class="text-secondary font-normal">({wp.username})</span>
 												</span>
+												{#if cfg}
+													<Toggle
+														bind:checked={cfg.reassign}
+														disabled={cfg.users.length === 0}
+														size="xs"
+														options={{ right: 'Reassign' }}
+													/>
+												{/if}
 											</div>
 
 											{#if cfg}
-												<OffboardWorkspaceSection
-													preview={wp.preview}
-													username={wp.username}
-													{deleteUser}
-													bind:targetKind={cfg.targetKind}
-													bind:selectedUser={cfg.selectedUser}
-													bind:selectedFolder={cfg.selectedFolder}
-													bind:selectedOperator={cfg.selectedOperator}
-													users={cfg.users}
-													folders={cfg.folders}
-													size="sm"
-													csvFilename="offboard-{email}-{wp.workspace_id}.csv"
-													instanceLevel
-												/>
+												{#if cfg.users.length === 0}
+													<p class="text-xs text-tertiary">
+														No other users in this workspace. Items will be left as-is.
+													</p>
+												{:else if cfg.reassign}
+													<OffboardWorkspaceSection
+														preview={wp.preview}
+														username={wp.username}
+														{deleteUser}
+														bind:targetKind={cfg.targetKind}
+														bind:selectedUser={cfg.selectedUser}
+														bind:selectedFolder={cfg.selectedFolder}
+														bind:selectedOperator={cfg.selectedOperator}
+														users={cfg.users}
+														folders={cfg.folders}
+														size="sm"
+														csvFilename="offboard-{email}-{wp.workspace_id}.csv"
+														instanceLevel
+													/>
+												{:else}
+													<p class="text-xs text-tertiary">Items will be left as-is.</p>
+												{/if}
 											{/if}
 										</div>
 									{/each}
@@ -283,7 +309,7 @@
 										different user/folder.</p
 									>
 									<ul class="text-xs list-disc list-inside max-h-32 overflow-y-auto">
-										{#each conflicts as conflict}
+										{#each conflicts as conflict (conflict)}
 											<li>{conflict}</li>
 										{/each}
 									</ul>

--- a/frontend/src/lib/components/UserOffboardingModal.svelte
+++ b/frontend/src/lib/components/UserOffboardingModal.svelte
@@ -83,6 +83,11 @@
 			preview = previewResult
 			users = usernamesList.filter((u) => u !== username).map((u) => ({ label: u, value: u }))
 			folders = foldersList.map((f) => ({ label: f.name, value: f.name }))
+			// Reassignment needs another workspace user as target/operator; with none
+			// (sole-member workspace) it is impossible, so fall back to plain removal.
+			if (!reassignOnly && users.length === 0) {
+				doReassign = false
+			}
 		} catch (e) {
 			sendUserToast('Failed to load offboard preview', true)
 			onClose()
@@ -173,33 +178,40 @@
 					{:else if preview}
 						<div class="mt-4 space-y-3">
 							{#if hasItems}
-								{#if !reassignOnly}
-									<Toggle
-										bind:checked={doReassign}
-										size="xs"
-										options={{ right: 'Reassign items before removing' }}
-									/>
-								{/if}
-
-								{#if doReassign}
-									<OffboardWorkspaceSection
-										{preview}
-										{username}
-										{deleteUser}
-										bind:targetKind
-										bind:selectedUser
-										bind:selectedFolder
-										bind:selectedOperator
-										{users}
-										{folders}
-									/>
+								{#if users.length === 0}
+									<p class="text-xs text-tertiary">
+										No other users in this workspace. Items will be left as-is.
+									</p>
 								{:else}
-									<Alert type="warning" title="Items will not be reassigned">
-										<p class="text-xs">
-											All items owned by {username} ({ownedCount} owned, {onBehalfCount} running on behalf)
-											will be left as-is. Triggers and runnables may stop working if the user is removed.
-										</p>
-									</Alert>
+									{#if !reassignOnly}
+										<Toggle
+											bind:checked={doReassign}
+											size="xs"
+											options={{ right: 'Reassign items before removing' }}
+										/>
+									{/if}
+
+									{#if doReassign}
+										<OffboardWorkspaceSection
+											{preview}
+											{username}
+											{deleteUser}
+											bind:targetKind
+											bind:selectedUser
+											bind:selectedFolder
+											bind:selectedOperator
+											{users}
+											{folders}
+										/>
+									{:else}
+										<Alert type="warning" title="Items will not be reassigned">
+											<p class="text-xs">
+												All items owned by {username} ({ownedCount} owned, {onBehalfCount} running on
+												behalf) will be left as-is. Triggers and runnables may stop working if the user
+												is removed.
+											</p>
+										</Alert>
+									{/if}
 								{/if}
 							{:else}
 								<p class="text-sm text-secondary">
@@ -214,7 +226,7 @@
 										different user/folder.</p
 									>
 									<ul class="text-xs list-disc list-inside max-h-32 overflow-y-auto">
-										{#each conflicts as conflict}
+										{#each conflicts as conflict, i (i)}
 											<li>{conflict}</li>
 										{/each}
 									</ul>

--- a/frontend/src/lib/components/UserOffboardingModal.svelte
+++ b/frontend/src/lib/components/UserOffboardingModal.svelte
@@ -43,6 +43,7 @@
 	let ownedCount = $derived(preview ? countPaths(preview.owned) : 0)
 	let onBehalfCount = $derived(preview ? countPaths(preview.executing_on_behalf) : 0)
 	let hasItems = $derived(ownedCount > 0 || onBehalfCount > 0)
+	let canReassignHere = $derived(hasItems && users.length > 0)
 
 	let reassignTo = $derived(
 		targetKind === 'user'
@@ -236,7 +237,7 @@
 					{/if}
 
 					<div class="flex items-center space-x-2 flex-row-reverse space-x-reverse mt-4">
-						{#if hasItems || deleteUser}
+						{#if deleteUser || canReassignHere}
 							<Button
 								disabled={submitting || !canSubmit}
 								onclick={submit}


### PR DESCRIPTION
## Summary

Fixes a bad-request during instance-level (global) user offboarding, and makes offboarding work cleanly for workspaces where the user is the only member (common for forks). Applies to both the global (instance settings) and workspace-level offboarding modals.

When an admin offboarded a user via **Instance settings → Users → Remove**, the modal could return `400 new_on_behalf_of_user is required when reassigning to a folder` **even when the admin chose not to reassign**. The submit handler built the `reassignments` payload from stale per-workspace form state without checking the "Reassign items before removing" toggle, so a previously-selected folder target (with no on-behalf-of user) leaked into the request.

Separately, offboarding was awkward or blocked for workspaces where the user is the only member: the on-behalf-of operator must be a user of that same workspace, so reassignment there is impossible, yet the flow still surfaced (unusable) reassignment controls, and a reassign-only run could submit an empty no-op reported as success.

## Changes

**Global modal (`GlobalUserOffboardingModal.svelte`)**
- Gate the `reassignments` payload construction and `canSubmit` on the global reassign toggle, so turning it off sends an empty map instead of stale state.
- Add a per-workspace **Reassign** toggle in each workspace block:
  - Defaults **ON** when the workspace has at least one other assignable user (covers forks with more than one member).
  - Defaults **OFF and disabled** when there is no other user, showing "No other users in this workspace. Items will be left as-is."
- `canSubmit` / `submit()` skip workspaces whose per-workspace toggle is off, so single-user workspaces no longer block the whole offboard.
- Reassign-only runs (no deletion) require at least one workspace actually selected for reassignment, so an empty `{"reassignments":{}}` request can't be submitted and reported as success. When no workspace is reassignable at all, present a **Close** action instead of a Reassign button.

**Workspace modal (`UserOffboardingModal.svelte`)**
- Mirror the sole-member affordance: when the target is the only workspace member, show "No other users in this workspace. Items will be left as-is." and fall back to plain removal (`deleteUser`) instead of showing an empty, unusable reassignment target. Reassign-only mode is left untouched so it never deletes a user.
- In reassign-only mode on a sole-member workspace (nothing can be reassigned and the user must not be deleted), present a **Close** action instead of a permanently-disabled Reassign button.

Both: key the transient conflicts `{#each}` by index (a message string is not a guaranteed-unique key).

Frontend-only; no backend or API change. The backend contract (`resolve_new_permissioned_as` requiring the operator to be a workspace user) is unchanged and still correctly rejects an invalid folder reassignment for any other API client.

## Screenshots

Global modal, two-workspace offboard: `test` has another member so its per-workspace Reassign toggle is ON with full controls; `solows` is a sole-member workspace so the toggle is OFF and disabled with an explanatory note.

![offboard-two-workspaces](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/offboard-behalf-required-fix/1782911008-offboard-two-workspaces.png)

Global modal, reassignment turned off now succeeds (previously 400):

![offboard-fix-success](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/offboard-behalf-required-fix/1782911008-offboard-fix-success.png)

Global modal, reassign-only for a user whose items live only in a sole-member workspace: a Close action is shown instead of an enabled Reassign that would no-op:

![global-reassignonly-solo](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/offboard-behalf-required-fix/1782916406-global-reassignonly-solo.png)

Workspace modal, sole-member workspace (Remove): shows the note and an enabled Offboard button (removes the user, items left as-is):

![ws-offboard-solo2](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/offboard-behalf-required-fix/1782912751-ws-offboard-solo2.png)

Workspace modal, sole-member workspace (Reassign-only): nothing to reassign, so a Close action is shown instead of a dead-end:

![ws-reassignonly-solo3](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/offboard-behalf-required-fix/1782914402-ws-reassignonly-solo3.png)

Workspace modal, multi-member workspace (unchanged reassignment flow):

![ws-offboard-duo](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/offboard-behalf-required-fix/1782912751-ws-offboard-duo.png)

## Test plan

Verified manually against the running dev server:

- [x] Global: select a folder target, toggle reassignment off, submit → request body `{"reassignments":{},"delete_user":true}`, returns 200 (previously 400).
- [x] Global: offboard a user owning items in a multi-member workspace and a sole-member workspace → multi-member requires target+operator; sole-member shows disabled toggle + note; submit reassigns only the multi-member workspace and leaves the sole-member items in place; user fully removed.
- [x] Global (Reassign-only): user with items only in a sole-member workspace → Close action shown, no submittable no-op.
- [x] Workspace-level (Remove): sole-member user → note shown, Offboard enabled, `DELETE /users/delete/{user}` returns 200, items left as-is.
- [x] Workspace-level (Reassign-only): sole-member user → Close action shown, closing is a no-op (user not deleted).
- [x] Workspace-level: multi-member workspace → unchanged reassignment controls shown.
- [x] `npm run check` (svelte-check): 0 errors.