### PR TITLE
fix(workspaces): enforce CE workspace limit when unarchiving

### DIFF
--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -5788,6 +5788,13 @@ async fn unarchive_workspace(
     authed: ApiAuthed,
 ) -> Result<String> {
     require_admin(authed.is_admin, &authed.username)?;
+
+    // Unarchiving re-activates a soft-deleted workspace, so it must respect the
+    // same CE workspace-count cap as creating one. The archived workspace is
+    // deleted = true and thus excluded from the count until it is restored.
+    #[cfg(not(feature = "enterprise"))]
+    _check_nb_of_workspaces(&db).await?;
+
     let mut tx = db.begin().await?;
     sqlx::query!("UPDATE workspace SET deleted = false WHERE id = $1", &w_id)
         .execute(&mut *tx)

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -3818,6 +3818,21 @@ async fn _check_nb_of_workspaces(db: &DB) -> Result<()> {
     return Ok(());
 }
 
+async fn _check_nb_of_archived_workspaces(db: &DB) -> Result<()> {
+    let nb_archived = sqlx::query_scalar!(
+        "SELECT COUNT(*) FROM workspace WHERE id != 'admins' AND deleted = true",
+    )
+    .fetch_one(db)
+    .await?;
+    if nb_archived.unwrap_or(0) >= 1 {
+        return Err(Error::BadRequest(
+            "You have reached the maximum number of archived workspaces (1) without an enterprise license. Permanently delete or unarchive the existing archived workspace first"
+                .to_string(),
+        ));
+    }
+    return Ok(());
+}
+
 async fn create_workspace(
     authed: ApiAuthed,
     Extension(db): Extension<DB>,
@@ -5675,6 +5690,11 @@ async fn archive_workspace(
     authed: ApiAuthed,
 ) -> Result<String> {
     require_admin(authed.is_admin, &authed.username)?;
+
+    // CE caps the number of archived (soft-deleted) workspaces so archiving can't be used to
+    // stockpile hidden workspaces. Enforced here so a second archive is refused up front.
+    #[cfg(not(feature = "enterprise"))]
+    _check_nb_of_archived_workspaces(&db).await?;
 
     // If this is an attached dev workspace, archiving it leaves the prod with no active dev (the
     // unique index and user_workspaces both ignore deleted=true), so clear the prod's


### PR DESCRIPTION
## Problem

On the community edition, workspace creation is capped at 2 workspaces (outside the default `admins` workspace) via `_check_nb_of_workspaces`. Archiving a workspace is a soft delete (`deleted = true`), and unarchiving flips it back to `deleted = false`. Two gaps let CE users get around the cap:

1. **Unarchive bypassed the count check** — a user could archive one workspace, create new ones, then later unarchive the old one, ending up with more active workspaces than CE allows.
2. **No limit on archived workspaces** — archived workspaces still occupy their workspace id and can be unarchived later, so a user could stockpile many soft-deleted workspaces.

## Fix

- `unarchive_workspace`: run the existing `_check_nb_of_workspaces` guard before flipping `deleted` back to `false`. Since the count query excludes `deleted = true` rows, the workspace being restored isn't counted against itself — the check passes exactly when there's room for one more active workspace.
- `archive_workspace`: refuse a new archive when an archived workspace already exists (new `_check_nb_of_archived_workspaces` helper, cap of 1).

Both are gated to CE (`#[cfg(not(feature = "enterprise"))]`) and mirror the existing create-workspace guard.

## Testing

Exercised the endpoints directly against the local CE backend:

**Unarchive limit**
- 2 active + 1 archived → unarchive **blocked** `HTTP 400` ("maximum number of workspaces (2)...")
- 1 active + 1 archived → unarchive **succeeds** `HTTP 200`, row flipped to `deleted = false`

**Archive limit**
- 1 active + 1 already archived → archive **blocked** `HTTP 400` ("maximum number of archived workspaces (1)...")
- active + 0 archived → archive **succeeds** `HTTP 200`, row flipped to `deleted = true`

Backend recompiled cleanly under cargo-watch (no errors/warnings). No new SQL query cache entries needed beyond the compile-time-checked `query_scalar!` (verified by clean build). Change is CE-only; no EE files affected.

Fixes WIN-2119

🤖 Generated with [Claude Code](https://claude.com/claude-code)