### PR TITLE
fix(jobs): give flow dynselect a path and its worker tag, aligned with scripts

### DIFF
--- a/backend/.sqlx/query-919bee5afcaba361f23760b5f64ce48f63e4d6d3e2d4fa9247b50963112f47ad.json
+++ b/backend/.sqlx/query-919bee5afcaba361f23760b5f64ce48f63e4d6d3e2d4fa9247b50963112f47ad.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT tag FROM flow WHERE workspace_id = $1 AND path = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "tag",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "919bee5afcaba361f23760b5f64ce48f63e4d6d3e2d4fa9247b50963112f47ad"
+}

--- a/backend/.sqlx/query-ad07e40790b947d1e8da17dd4ae30365210bba4bff0b7e32d06c53ed13572360.json
+++ b/backend/.sqlx/query-ad07e40790b947d1e8da17dd4ae30365210bba4bff0b7e32d06c53ed13572360.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT 1 FROM flow WHERE workspace_id = $1 AND path = $2 LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "?column?",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "ad07e40790b947d1e8da17dd4ae30365210bba4bff0b7e32d06c53ed13572360"
+}

--- a/backend/windmill-api/src/jobs.rs
+++ b/backend/windmill-api/src/jobs.rs
@@ -7602,26 +7602,32 @@ async fn run_dynamic_select(
         ));
     }
 
+    if !is_valid_entrypoint_name(&request.entrypoint_function) {
+        return Err(error::Error::BadRequest(format!(
+            "Invalid entrypoint_function {:?}: must match \
+             ^[A-Za-z_][A-Za-z0-9_]*$ (letters, digits and underscores, \
+             not starting with a digit)",
+            request.entrypoint_function
+        )));
+    }
+
+    // Deployed scripts keep their normal deployed-run path (a `script` job, resolved below by
+    // push_script_job_by_path_into_queue). Deployed flows and inline snippets have no deployed
+    // runnable, so they run their dyn-select code as a `preview`; the flow carries its path and
+    // worker tag so its option-fetching job lines up with the script run.
     let dynamic_input: DynamicInput;
+    let runnable_path: Option<String>;
+    let mut tag: Option<String> = None;
 
     match request.runnable_ref {
         DynamicSelectRunnableRef::Deployed { path, runnable_kind } => match runnable_kind {
             RunnableKind::Script => {
-                if !is_valid_entrypoint_name(&request.entrypoint_function) {
-                    return Err(error::Error::BadRequest(format!(
-                        "Invalid entrypoint_function {:?}: must match \
-                         ^[A-Za-z_][A-Za-z0-9_]*$ (letters, digits and underscores, \
-                         not starting with a digit)",
-                        request.entrypoint_function
-                    )));
-                }
                 let mut script_args = request.args.unwrap_or_default();
                 script_args.insert(
-                    "_ENTRYPOINT_OVERRIDE".to_string(),
+                    ENTRYPOINT_OVERRIDE.to_string(),
                     serde_json::value::to_raw_value(&request.entrypoint_function)?,
                 );
-
-                let push_args = PushArgsOwned { extra: None, args: script_args.clone() };
+                let push_args = PushArgsOwned { extra: None, args: script_args };
 
                 let (uuid, _, _) = push_script_job_by_path_into_queue(
                     authed.clone(),
@@ -7631,7 +7637,7 @@ async fn run_dynamic_select(
                     w_id.clone(),
                     StripPath(path),
                     run_query.clone(),
-                    push_args.clone(),
+                    push_args,
                     None,
                 )
                 .await?;
@@ -7639,12 +7645,39 @@ async fn run_dynamic_select(
                 return Ok((StatusCode::CREATED, uuid.to_string()).into_response());
             }
             RunnableKind::Flow => {
-                // Runs the deployed flow's dynamic-select code. Enforce the same
-                // path-scoped check the script branch gets via
-                // push_script_job_by_path_into_queue, so a token not scoped to this
-                // flow cannot trigger its code through dynamic select.
+                // Runs the deployed flow's dynamic-select code. Path-scoped so a token not
+                // scoped to this flow cannot trigger its code through dynamic select.
                 check_scopes(&authed, || format!("jobs:run:flows:{path}"))?;
                 let mut conn = user_db.clone().begin(&authed).await?;
+
+                // Read the flow's tag under RLS. This runs on every request (including the
+                // cache hit below), so it doubles as the access check and routes the
+                // option-fetching preview to the flow's worker group, matching the script branch.
+                let Some(flow_tag) = sqlx::query_scalar!(
+                    "SELECT tag FROM flow WHERE workspace_id = $1 AND path = $2",
+                    &w_id,
+                    &path
+                )
+                .fetch_optional(&mut *conn)
+                .await?
+                else {
+                    conn.commit().await?;
+                    let exists = sqlx::query_scalar!(
+                        "SELECT 1 FROM flow WHERE workspace_id = $1 AND path = $2 LIMIT 1",
+                        &w_id,
+                        &path
+                    )
+                    .fetch_optional(&db)
+                    .await?
+                    .is_some();
+                    if exists {
+                        return Err(error::Error::NotAuthorized(format!(
+                            "You are not authorized to access this flow: {path}"
+                        )));
+                    }
+                    return Err(Error::NotFound(format!("Flow not found at path {path}")));
+                };
+                tag = flow_tag;
 
                 let dynamic_input_res = match DYNAMIC_INPUT_CACHE.get(&format!("{}:{}", w_id, path))
                 {
@@ -7688,20 +7721,33 @@ async fn run_dynamic_select(
                 conn.commit().await?;
 
                 dynamic_input = dynamic_input_res;
+                runnable_path = Some(path);
             }
         },
         DynamicSelectRunnableRef::Inline { code, lang: language } => {
             // Inline dynamic select runs arbitrary, request-supplied code; require the broad
             // jobs:run scope so a narrowly-scoped token cannot escape its scope. The Deployed
-            // branches are path-scoped instead (scripts via push_script_job_by_path_into_queue,
-            // flows via the check_scopes above).
+            // branches are path-scoped instead.
             check_scopes(&authed, || format!("jobs:run"))?;
             dynamic_input = DynamicInput {
                 x_windmill_dyn_select_code: code,
                 x_windmill_dyn_select_lang: language.unwrap_or_default(),
             };
+            runnable_path = None;
         }
     }
+
+    // Same tag-permission gate a normal run gets (run_flow / push_script_job_by_path_into_queue):
+    // a caller allowed to read the flow must still be allowed to use its worker tag. No-op for
+    // inline (tag is None); the script branch checked this inside its helper and returned above.
+    check_tag_available_for_workspace(&db, &w_id, &tag, &authed).await?;
+
+    // Invoke the dyn-select entrypoint instead of `main`.
+    let mut args = request.args.unwrap_or_default();
+    args.insert(
+        ENTRYPOINT_OVERRIDE.to_string(),
+        serde_json::value::to_raw_value(&request.entrypoint_function)?,
+    );
 
     let scheduled_for = run_query.get_scheduled_for(&db).await?;
     let tx = PushIsolationLevel::Isolated(user_db.clone(), authed.clone().into());
@@ -7713,7 +7759,7 @@ async fn run_dynamic_select(
         JobPayload::Code(RawCode {
             hash: None,
             content: dynamic_input.x_windmill_dyn_select_code,
-            path: None,
+            path: runnable_path,
             language: dynamic_input.x_windmill_dyn_select_lang,
             lock: None,
             cache_ttl: None,
@@ -7722,9 +7768,11 @@ async fn run_dynamic_select(
             concurrency_settings: ConcurrencySettings::default().into(),
             debouncing_settings: DebouncingSettings::default(),
             modules: None,
+            // RawCode.tag is ignored by the queue path (`JobPayload::Code` destructures it as
+            // `tag: _`); the effective tag is the `tag` argument to `push` below.
             tag: None,
         }),
-        PushArgs::from(&request.args.unwrap_or_default()),
+        PushArgs::from(&args),
         authed.display_username(),
         &authed.email,
         username_to_permissioned_as(&authed.username),
@@ -7739,7 +7787,8 @@ async fn run_dynamic_select(
         false,
         None,
         true,
-        None,
+        // Deployed flow → the flow's worker tag; inline → `None` (language default).
+        tag,
         run_query.timeout,
         None,
         None,


### PR DESCRIPTION
## Summary

`Fixes WIN-2118`

Fetching options for a `dynselect` / `dynmultiselect` input was inconsistent between deployed scripts and deployed flows:

| | before |
|---|---|
| deployed **script** | `script` job, **with a path**, on the **script's tag** (via `push_script_job_by_path_into_queue`) |
| deployed **flow** | anonymous `preview`, **no path**, always on the **language-default tag**, access failures surfaced as a raw `SqlErr: no rows` |

This PR takes the **low-risk** path: **deployed scripts are left exactly as they were** (that path already handles tag / lock / codebase / on-behalf-of correctly — no reason to re-derive all of it). Only the flow branch is brought into line.

> `dynmultiselect` and `dynselect` are the same code path (same `/jobs/run/dynamic_select` endpoint, same `DynamicInput` component), so everything here applies identically to both.

## Changes (`backend/windmill-api/src/jobs.rs`, `run_dynamic_select`)

- **Flow branch**: reads the flow's `tag` under RLS and routes the option-fetch preview to it (falling back to the language default when unset) and carries the flow **path** on the job — so it lines up with the script run's path + worker group. The tag read runs on every request (including cache hits), so it doubles as the per-request **access check**, replacing the raw `SqlErr` with a clean `NotAuthorized` / `NotFound`.
- **Flow tag authorization**: the flow's tag now goes through `check_tag_available_for_workspace` before `push()` — the same gate a normal flow run (`run_flow`) and the script path apply — so a caller who can read the flow but isn't allowed to use its (custom/scoped) worker tag is rejected consistently.
- **Script branch**: unchanged behaviour (still `push_script_job_by_path_into_queue`); only cosmetic (`ENTRYPOINT_OVERRIDE` const instead of a string literal, dropped needless `.clone()`s).
- **Inline**: unchanged — a `preview` with no path on the language default, blocked for operators.
- Entrypoint-name validation now runs for **all** branches (it's interpolated into the generated wrapper), closing that gap for the flow/inline paths.

### Worker-tag rules after this PR

| Source | Worker tag | Tag authorization checked? |
|---|---|---|
| Deployed **script** | script's `tag` (unset → language default, `//native` → `nativets`) | yes (inside `push_script_job_by_path_into_queue`) |
| Deployed **flow** | flow's `tag` (unset → language default) | yes (`check_tag_available_for_workspace`, new) |
| **Inline** | language default | n/a (tag is `None`) |

### What is and isn't aligned
- **Aligned**: both now carry a **path**, route to their **worker tag**, gate that tag, and work for **operators**.
- **Not aligned (by design, for safety)**: scripts remain a `script` **run** and flows remain a `preview`. A flow's dyn-select code lives in the flow schema (there's no deployed runnable to "run"), so it can only be a preview — and turning the script into a preview to match would mean re-deriving the whole deployed-run path (hash/codebase, lock, on_behalf_of, delete_after_use, …), which is exactly the fragile surface this PR avoids.

## Operators

Operators (and scoped tokens) can fetch options for every flow/script they can actually **run**:
- untagged flows/scripts and flows tagged with an **allowed** custom tag → work;
- a flow tagged with a worker tag the caller isn't permitted to use → rejected — **identical to a normal run of that flow** (verified: the normal run endpoint returns the same tag error), so the caller couldn't run it anyway;
- inline remains blocked for operators (request-supplied code).

Note: before this PR, an operator could fetch options for a restricted-tag flow only because the helper ran on the language-default tag (ignoring `flow.tag`); routing to the flow's tag (the requested behavior) makes it consistent with — and gated like — a real run.

## Test plan (verified e2e locally)

- [x] **Script** dyn-select → `kind=script` (unchanged run), correct options
- [x] **Flow** dyn-select → `kind=preview`, `runnable_path` set, correct options
- [x] Flow tagged `deno` → job `tag=deno`; flow tagged `chromium` → queued on `chromium`; untagged flow/inline → language default (`bun`)
- [x] **Operator**: shared script + untagged/allowed-tag flow work; inaccessible flow → `NotAuthorized`; inline → blocked
- [x] **Tag authorization**: non-super-admin scoped `if_jobs:filter_tags:othertag` on a `deno`-tagged flow → `Tag deno is not available in your scope`; same rejection as a normal flow run (super-admins & untagged unaffected)
- [x] `SQLX_OFFLINE=true cargo check -p windmill-api --features enterprise,private` passes
- [x] UI: option dropdown renders in both the script and flow run forms

## Screenshots

Script run form (dynselect renders Alpha/Beta):

![script-dynselect-open](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2118-align-dynmultiselect-job-behavior-between-scripts-and-flows/1782921609-script-dynselect-open.png)

Flow run form (dynselect renders FlowAlpha/FlowBeta):

![flow-dynselect-open](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2118-align-dynmultiselect-job-behavior-between-scripts-and-flows/1782921612-flow-dynselect-open.png)
