### PR TITLE
feat(forks): partial-visibility deploy + surface hidden items

### DIFF
--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -6948,6 +6948,27 @@ pub struct WorkspaceComparison {
     pub skipped_comparison: bool,
     pub diffs: Vec<WorkspaceDiffRow>,
     pub summary: CompareSummary,
+    /// Items that exist in the diff but were dropped from `diffs` because they
+    /// are not visible to the caller (excluded from the partial deploy). Split
+    /// by direction: `hidden_ahead` lives in the fork, `hidden_behind` in the
+    /// parent. `by_kind`/`total` are always populated (aggregate, no names);
+    /// `items` (kind+path) is only filled for a caller who is admin of that side
+    /// — never leak the paths of items the ACL is hiding from a regular user.
+    pub hidden_ahead: HiddenItemsSummary,
+    pub hidden_behind: HiddenItemsSummary,
+}
+
+#[derive(Serialize, Default)]
+pub struct HiddenItemsSummary {
+    pub total: usize,
+    pub by_kind: std::collections::BTreeMap<String, usize>,
+    pub items: Vec<HiddenItem>,
+}
+
+#[derive(Serialize)]
+pub struct HiddenItem {
+    pub kind: String,
+    pub path: String,
 }
 
 #[derive(Serialize, Default)]
@@ -7032,6 +7053,8 @@ async fn compare_workspaces(
             skipped_comparison,
             diffs: vec![],
             summary: Default::default(),
+            hidden_ahead: Default::default(),
+            hidden_behind: Default::default(),
         }));
     }
 
@@ -7313,12 +7336,51 @@ async fn compare_workspaces(
     let all_ahead_items_visible = all_ahead_items_visible || sees_all_items;
     let all_behind_items_visible = all_behind_items_visible || sees_all_items;
 
+    // Items dropped by the visibility filter (in confirmed_diffs but not in the
+    // returned visible_diffs). Surface what the partial deploy excludes: aggregate
+    // counts by kind for everyone, but kind+path only to a caller who `sees_all_items`
+    // (superadmin, or admin of the source AND the fork). For them a dropped item is
+    // provably a phantom/stale row, not an ACL-hidden secret, so no path leaks —
+    // fork-admin alone is not enough (a fork-deleted ahead item lives only in the
+    // parent, whose path a non-parent-admin must not see).
+    let visible_keys: HashSet<(&str, &str)> = visible_diffs
+        .iter()
+        .map(|d| (d.kind.as_str(), d.path.as_str()))
+        .collect();
+    let mut hidden_ahead = HiddenItemsSummary::default();
+    let mut hidden_behind = HiddenItemsSummary::default();
+    for d in &confirmed_diffs {
+        if visible_keys.contains(&(d.kind.as_str(), d.path.as_str())) {
+            continue;
+        }
+        if d.ahead > 0 {
+            hidden_ahead.total += 1;
+            *hidden_ahead.by_kind.entry(d.kind.clone()).or_default() += 1;
+            if sees_all_items {
+                hidden_ahead
+                    .items
+                    .push(HiddenItem { kind: d.kind.clone(), path: d.path.clone() });
+            }
+        }
+        if d.behind > 0 {
+            hidden_behind.total += 1;
+            *hidden_behind.by_kind.entry(d.kind.clone()).or_default() += 1;
+            if sees_all_items {
+                hidden_behind
+                    .items
+                    .push(HiddenItem { kind: d.kind.clone(), path: d.path.clone() });
+            }
+        }
+    }
+
     return Ok(Json(WorkspaceComparison {
         all_ahead_items_visible,
         all_behind_items_visible,
         skipped_comparison: false,
         diffs: visible_diffs,
         summary,
+        hidden_ahead,
+        hidden_behind,
     }));
 }
 

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -29330,6 +29330,8 @@ components:
         - skipped_comparison
         - diffs
         - summary
+        - hidden_ahead
+        - hidden_behind
       properties:
         all_ahead_items_visible:
           type: boolean
@@ -29348,6 +29350,46 @@ components:
         summary:
           $ref: "#/components/schemas/CompareSummary"
           description: Summary statistics of the comparison
+        hidden_ahead:
+          $ref: "#/components/schemas/HiddenItemsSummary"
+          description: Ahead items excluded from `diffs` because they are not visible to the caller
+        hidden_behind:
+          $ref: "#/components/schemas/HiddenItemsSummary"
+          description: Behind items excluded from `diffs` because they are not visible to the caller
+
+    HiddenItemsSummary:
+      type: object
+      required:
+        - total
+        - by_kind
+        - items
+      properties:
+        total:
+          type: integer
+          description: Total number of hidden items on this side
+        by_kind:
+          type: object
+          additionalProperties:
+            type: integer
+          description: Count of hidden items keyed by item kind (always populated)
+        items:
+          type: array
+          description: Kind and path of each hidden item; only populated when the caller is an admin of the relevant side (empty otherwise)
+          items:
+            $ref: "#/components/schemas/HiddenItem"
+
+    HiddenItem:
+      type: object
+      required:
+        - kind
+        - path
+      properties:
+        kind:
+          type: string
+          description: Type of the hidden item
+        path:
+          type: string
+          description: Path of the hidden item
 
     WorkspaceItemDiff:
       type: object

--- a/frontend/src/lib/components/CompareWorkspaces.svelte
+++ b/frontend/src/lib/components/CompareWorkspaces.svelte
@@ -897,6 +897,28 @@
 		azure_trigger: 'Azure trigger',
 		email_trigger: 'Email trigger'
 	}
+
+	// Human label for a diff kind, lowercased for inline use in the hidden-items
+	// summary ("2 scripts, 1 http route").
+	function hiddenKindLabel(kind: string): string {
+		const base: Record<string, string> = {
+			script: 'script',
+			flow: 'flow',
+			app: 'app',
+			raw_app: 'app',
+			resource: 'resource',
+			variable: 'variable',
+			resource_type: 'resource type',
+			folder: 'folder'
+		}
+		return base[kind] ?? KIND_DISPLAY_NAMES[kind]?.toLowerCase() ?? kind
+	}
+
+	function formatHiddenByKind(byKind: Record<string, number>): string {
+		return Object.entries(byKind)
+			.map(([kind, n]) => `${n} ${hiddenKindLabel(kind)}${n !== 1 ? 's' : ''}`)
+			.join(', ')
+	}
 </script>
 
 {#if $workspaceStore != currentWorkspaceId}
@@ -1085,13 +1107,31 @@
 							</span>
 						</Alert>
 					{/if}
-					{#if mergeIntoParent ? !comparison.all_ahead_items_visible : !comparison.all_behind_items_visible}
+					{@const hiddenDir = mergeIntoParent ? comparison.hidden_ahead : comparison.hidden_behind}
+					{#if hiddenDir.items.length > 0}
+						<!-- Caller is an admin of this side, so the dropped items are provably
+						     stale/phantom diff rows (they can see every real item). List them with
+						     paths — useful for debugging the "why is this fork ahead" question. -->
+						<Alert title="Hidden diff rows (visible to you as admin)" type="info" class="my-2">
+							{hiddenDir.items.length}
+							{mergeIntoParent ? 'ahead' : 'behind'} item{hiddenDir.items.length !== 1 ? 's' : ''}
+							{hiddenDir.items.length !== 1 ? 'are' : 'is'} excluded from the list below — they are not
+							resolvable as live items and are most likely stale/phantom diff rows:
+							<ul class="mt-1 font-mono text-2xs">
+								{#each hiddenDir.items as it}
+									<li>{hiddenKindLabel(it.kind)} · {it.path}</li>
+								{/each}
+							</ul>
+						</Alert>
+					{:else if mergeIntoParent ? !comparison.all_ahead_items_visible : !comparison.all_behind_items_visible}
 						<Alert title="Some changes are hidden from you" type="warning" class="my-2">
-							{mergeIntoParent
-								? 'Some of the changes this fork is ahead by'
-								: 'Some of the changes this fork is behind by'} are not visible to your user and are
-							excluded from the list below. You can still {mergeIntoParent ? 'deploy' : 'update'} the
-							items you can see — share this page with someone who has full access to include the rest.
+							{hiddenDir.total}
+							{mergeIntoParent ? 'ahead' : 'behind'} item{hiddenDir.total !== 1 ? 's' : ''}
+							({formatHiddenByKind(hiddenDir.by_kind)})
+							{hiddenDir.total !== 1 ? 'are' : 'is'} not visible to your user and
+							{hiddenDir.total !== 1 ? 'are' : 'is'} excluded from the list below. You can still
+							{mergeIntoParent ? 'deploy' : 'update'} the items you can see — share this page with someone
+							who has full access to include the rest.
 						</Alert>
 					{/if}
 				{/snippet}

--- a/frontend/src/lib/components/CompareWorkspaces.svelte
+++ b/frontend/src/lib/components/CompareWorkspaces.svelte
@@ -1085,22 +1085,13 @@
 							</span>
 						</Alert>
 					{/if}
-					{#if !comparison.all_ahead_items_visible || !comparison.all_behind_items_visible}
-						<Alert
-							title="This fork has changes not visible to your user"
-							type="warning"
-							class="my-2"
-						>
-							{#if !comparison.all_ahead_items_visible && !comparison.all_behind_items_visible}
-								This fork is ahead and behind its parent
-							{:else if !comparison.all_behind_items_visible}
-								This fork is behind of its parent
-							{:else if !comparison.all_ahead_items_visible}
-								This fork is ahead of its parent
-							{/if}
-							and some of the changes are not visible by you. Only a user with access to the whole context
-							may deploy or update this fork. You can share the link to this page to someone with proper
-							permissions to get it deployed.
+					{#if mergeIntoParent ? !comparison.all_ahead_items_visible : !comparison.all_behind_items_visible}
+						<Alert title="Some changes are hidden from you" type="warning" class="my-2">
+							{mergeIntoParent
+								? 'Some of the changes this fork is ahead by'
+								: 'Some of the changes this fork is behind by'} are not visible to your user and are
+							excluded from the list below. You can still {mergeIntoParent ? 'deploy' : 'update'} the
+							items you can see — share this page with someone who has full access to include the rest.
 						</Alert>
 					{/if}
 				{/snippet}
@@ -1285,44 +1276,46 @@
 							<div></div>
 
 							<div class="flex flex-col items-end gap-2">
-								{#if comparison.all_behind_items_visible && comparison.all_ahead_items_visible}
-									<div class="flex items-center gap-2">
-										{#if mergeIntoParent && !hasOpenDeploymentRequest && !deploymentRequestPanel?.isDialogOpen()}
-											<Button
-												variant="default"
-												startIcon={{ icon: UserPlus }}
-												on:click={() => deploymentRequestPanel?.openRequestDialog()}
-											>
-												Request deployment
-											</Button>
-										{/if}
+								<!-- Always show the deploy footer: only the items visible to the user are
+								     listed and selectable, so a partial-visibility user deploys the subset they
+								     can see. The hidden items are surfaced by the non-blocking banner above,
+								     not by removing the action. -->
+								<div class="flex items-center gap-2">
+									{#if mergeIntoParent && !hasOpenDeploymentRequest && !deploymentRequestPanel?.isDialogOpen()}
 										<Button
-											variant="accent"
-											disabled={selectedItems.length === 0 ||
-												deploying ||
-												(hasBehindChanges && !allowBehindChangesOverride) ||
-												(mergeIntoParent && !canDeployToParent) ||
-												hasUnselectedOnBehalfOf}
-											loading={deploying}
-											on:click={requestDeploy}
+											variant="default"
+											startIcon={{ icon: UserPlus }}
+											on:click={() => deploymentRequestPanel?.openRequestDialog()}
 										>
-											{mergeIntoParent ? 'Deploy' : 'Update'}
-											{selectedItems.length} Item{selectedItems.length !== 1 ? 's' : ''}
-											{#if selectedConflicts != 0}
-												({selectedConflicts} conflicts)
-											{/if}
+											Request deployment
 										</Button>
-									</div>
-									{#if !(mergeIntoParent && !canDeployToParent) && hasUnselectedOnBehalfOf}
-										<span class="text-xs text-yellow-600">
-											You must set the "on behalf of" user for all items before deploying
-											<Tooltip class="text-yellow-600">
-												The "run on behalf of" field defines which user's permissions will be
-												applied during execution. Make sure this is set to an appropriate user
-												before deploying.
-											</Tooltip>
-										</span>
 									{/if}
+									<Button
+										variant="accent"
+										disabled={selectedItems.length === 0 ||
+											deploying ||
+											(hasBehindChanges && !allowBehindChangesOverride) ||
+											(mergeIntoParent && !canDeployToParent) ||
+											hasUnselectedOnBehalfOf}
+										loading={deploying}
+										on:click={requestDeploy}
+									>
+										{mergeIntoParent ? 'Deploy' : 'Update'}
+										{selectedItems.length} Item{selectedItems.length !== 1 ? 's' : ''}
+										{#if selectedConflicts != 0}
+											({selectedConflicts} conflicts)
+										{/if}
+									</Button>
+								</div>
+								{#if !(mergeIntoParent && !canDeployToParent) && hasUnselectedOnBehalfOf}
+									<span class="text-xs text-yellow-600">
+										You must set the "on behalf of" user for all items before deploying
+										<Tooltip class="text-yellow-600">
+											The "run on behalf of" field defines which user's permissions will be applied
+											during execution. Make sure this is set to an appropriate user before
+											deploying.
+										</Tooltip>
+									</span>
 								{/if}
 
 								{#if deploymentErrorMessage != ''}

--- a/frontend/src/lib/components/CompareWorkspaces.svelte
+++ b/frontend/src/lib/components/CompareWorkspaces.svelte
@@ -703,21 +703,32 @@
 		deselectAll()
 
 		// If every selected item deployed cleanly and the direction was
-		// merge-into-parent, close any open deployment request for this fork.
+		// merge-into-parent, resolve any open deployment request for this fork.
 		if (!anyFailed && mergeIntoParent) {
 			try {
 				const open = await WorkspaceService.getOpenDeploymentRequest({
 					workspace: currentWorkspaceId
 				})
 				if (open) {
-					await WorkspaceService.closeDeploymentRequestMerged({
-						workspace: currentWorkspaceId,
-						id: open.id
-					})
-					deploymentRequestPanel?.refresh()
+					if (comparison?.all_ahead_items_visible) {
+						await WorkspaceService.closeDeploymentRequestMerged({
+							workspace: currentWorkspaceId,
+							id: open.id
+						})
+						deploymentRequestPanel?.refresh()
+					} else {
+						// Hidden ahead changes remain: those items are excluded from the
+						// list and stay undeployed, so this deploy is only partial. Closing
+						// the request as "merged" (which marks its comments obsolete and
+						// notifies requester/assignees of a merge) would be a lie — leave it
+						// open so someone with full access can finish it.
+						sendUserToast(
+							'Deployed the changes visible to you. The deployment request stays open because some ahead changes are hidden from you and were not deployed.'
+						)
+					}
 				}
 			} catch (e) {
-				console.error('Failed to close open deployment request after merge', e)
+				console.error('Failed to resolve open deployment request after merge', e)
 			}
 		}
 


### PR DESCRIPTION
## Summary

Follow-up to #9866/#9869. Two related changes to the fork Compare & Deploy page:

1. **Let partial-visibility users deploy the visible subset** instead of hiding the deploy button entirely. The non-visible items are already filtered out of the diff list and the UI already supports deploying a subset via per-item selection, so the all-or-nothing block only prevented deploying the items the user *can* see.
2. **Surface what's excluded**: the compare response now reports the items dropped by the visibility filter — aggregate **counts by kind for everyone**, and **kind+path only for a caller who sees both sides in full** (superadmin or admin of source AND fork), for whom those are provably phantom/stale rows.

## Changes

**Frontend (`CompareWorkspaces.svelte`)**
- Deploy footer always renders (per-item `disabled` conditions unchanged); the "not visible" warning is now a non-blocking, direction-scoped banner.
- Banner shows the hidden **count by kind** ("1 http route…"); for a both-sides admin it instead lists the hidden **paths** (labeled as likely stale/phantom rows) — useful for debugging.
- **Don't close the fork deployment request on a partial deploy**: a clean merge-into-parent deploy now closes the open request as *merged* only when the full ahead set was visible (`all_ahead_items_visible`). With hidden ahead changes the deploy is partial, so the request stays open (with a toast) rather than falsely notifying requester/assignees of a merge.

**Backend (`workspaces.rs` + `openapi.yaml`)**
- `compare_workspaces` returns `hidden_ahead` / `hidden_behind` (`{ total, by_kind, items }`). `items` (kind+path) is populated only for superadmin / admin-of-both; counts always.

## Screenshots

Seeded a fork with a visible item + a phantom `http_trigger` so `all_ahead_items_visible=false`, driven on the dev server.

**Before** (blocking, no deploy button):
![before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fork-compare-partial-deploy/1782922538-partial-deploy-before.png)

**After** (partial deploy + non-blocking banner):
![after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fork-compare-partial-deploy/1782922538-partial-deploy-after.png)

## Test plan
- [x] `npm run check:fast` clean on `CompareWorkspaces.svelte`; svelte-autofixer clean.
- [x] Browser: partial deploy shows the footer; superadmin sees the hidden path list (`http route · f/demo/ghost`); backend `hidden_ahead` verified via API.
- [ ] The deployment-request-close guard is type-checked + reviewed but not exercised end-to-end locally (needs an open deployment request).

## Note
Based on pre-#9866 main; **needs a rebase onto main** (conflicts in `workspaces.rs` with #9866/#9869). The both-sides admin logic here intentionally matches #9869's guard and will reuse its `sees_all_items` after the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)