### PR TITLE
fix(forks): require admin of both sides for the compare visibility guard

### DIFF
--- a/backend/.sqlx/query-0ff0b7abad7717d7de398f629853b22cb831e91026dcd59d362a6d4382dc240b.json
+++ b/backend/.sqlx/query-0ff0b7abad7717d7de398f629853b22cb831e91026dcd59d362a6d4382dc240b.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO script (workspace_id, path, hash, content, summary, description, language, created_by, created_at, archived, schema_validation, ws_error_handler_muted, deleted, extra_perms)\n         VALUES ('test-workspace', 'f/restricted/item', 314159, 'def main(): return 1', '', '', 'python3', 'test-user', NOW(), false, false, false, false, '{}'::jsonb)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "0ff0b7abad7717d7de398f629853b22cb831e91026dcd59d362a6d4382dc240b"
+}

--- a/backend/.sqlx/query-3211c7631f46975fc0127f106e84676237a3b37ffa59ff6c9134df79eed3b680.json
+++ b/backend/.sqlx/query-3211c7631f46975fc0127f106e84676237a3b37ffa59ff6c9134df79eed3b680.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO workspace_diff\n         (source_workspace_id, fork_workspace_id, path, kind, ahead, behind, has_changes, exists_in_source, exists_in_fork)\n         VALUES ('test-workspace', 'wm-fork-guard-test', 'f/restricted/item', 'script', 1, 0, true, true, true)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "3211c7631f46975fc0127f106e84676237a3b37ffa59ff6c9134df79eed3b680"
+}

--- a/backend/.sqlx/query-3535965aed37a1cc853b229e062d4aac2dbb2ef7596d819db222fb87187d9c4b.json
+++ b/backend/.sqlx/query-3535965aed37a1cc853b229e062d4aac2dbb2ef7596d819db222fb87187d9c4b.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM skip_workspace_diff_tally WHERE workspace_id IN ('test-workspace', 'wm-fork-guard-test')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "3535965aed37a1cc853b229e062d4aac2dbb2ef7596d819db222fb87187d9c4b"
+}

--- a/backend/.sqlx/query-80f526a401d5f26021b5eb424e7481e28c360367f144f172b746cd11abfa67a2.json
+++ b/backend/.sqlx/query-80f526a401d5f26021b5eb424e7481e28c360367f144f172b746cd11abfa67a2.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO folder (workspace_id, name, display_name, owners, extra_perms, summary, created_by)\n         VALUES ('test-workspace', 'restricted', 'restricted', ARRAY['u/test-user']::varchar[], '{\"u/test-user\": true}'::jsonb, '', 'test-user')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "80f526a401d5f26021b5eb424e7481e28c360367f144f172b746cd11abfa67a2"
+}

--- a/backend/.sqlx/query-b55b0f11b8d73ff9fd19da3bc5555e8365dbd4766f273ef3f68e734972a96cd6.json
+++ b/backend/.sqlx/query-b55b0f11b8d73ff9fd19da3bc5555e8365dbd4766f273ef3f68e734972a96cd6.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO workspace_diff\n         (source_workspace_id, fork_workspace_id, path, kind, ahead, behind, has_changes, exists_in_source, exists_in_fork)\n         VALUES\n         ('test-workspace', 'wm-fork-test-workspace', 'f/rt/ghost', 'http_trigger', 1, 0, true, false, true),\n         ('test-workspace', 'wm-fork-test-workspace', 'f/rt/ghost_behind', 'http_trigger', 0, 1, true, true, false)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "b55b0f11b8d73ff9fd19da3bc5555e8365dbd4766f273ef3f68e734972a96cd6"
+}

--- a/backend/.sqlx/query-d3334846d5928e9b260d17e7ca99f6f24e83e019d6cd1590c42b14524c00f4d3.json
+++ b/backend/.sqlx/query-d3334846d5928e9b260d17e7ca99f6f24e83e019d6cd1590c42b14524c00f4d3.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO usr (workspace_id, email, username, is_admin, role)\n         VALUES ('wm-fork-guard-test', 'test2@windmill.dev', 'test-user-2', true, 'Admin')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "d3334846d5928e9b260d17e7ca99f6f24e83e019d6cd1590c42b14524c00f4d3"
+}

--- a/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
+++ b/backend/windmill-api-integration-tests/tests/workspace_comparison.rs
@@ -1642,3 +1642,130 @@ async fn test_compare_workspaces_phantom_trigger_shortfuse(
 
     Ok(())
 }
+
+/// Regression: the "sees everything" guard must require admin of BOTH sides, not
+/// just the fork. `filter_visible_diffs` keeps a modified/conflict row (one that
+/// exists in the source AND the fork) only when the caller can see it on both
+/// sides, so an ahead diff can be dropped for a *source-side* visibility gap even
+/// when the caller is a fork admin. If the guard cleared the ahead flag on
+/// fork-admin alone, the UI would report "all ahead visible" and let the user
+/// deploy from an incomplete comparison. Here test-user-2 is admin of the fork
+/// but only a plain member of the parent with no access to folder `restricted`,
+/// so the parent copy of the modified script is hidden from them and the ahead
+/// diff is (correctly) dropped — the flag must stay false.
+#[sqlx::test(migrations = "../migrations", fixtures("base"))]
+async fn test_compare_workspaces_fork_admin_source_hidden_ahead(
+    db: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base_url = format!("http://localhost:{port}/api");
+    let admin = windmill_api_client::create_client(
+        &format!("http://localhost:{port}"),
+        "SECRET_TOKEN".to_string(),
+    );
+    let fork_admin_user = windmill_api_client::create_client(
+        &format!("http://localhost:{port}"),
+        "SECRET_TOKEN_2".to_string(),
+    );
+
+    // Parent folder `restricted` owned by test-user (the admin), NOT test-user-2,
+    // and a script inside it (access flows through the folder). test-user-2 is a
+    // plain member of the parent, so RLS hides this script from them.
+    sqlx::query!(
+        "INSERT INTO folder (workspace_id, name, display_name, owners, extra_perms, summary, created_by)
+         VALUES ('test-workspace', 'restricted', 'restricted', ARRAY['u/test-user']::varchar[], '{\"u/test-user\": true}'::jsonb, '', 'test-user')"
+    )
+    .execute(&db)
+    .await?;
+    sqlx::query!(
+        "INSERT INTO script (workspace_id, path, hash, content, summary, description, language, created_by, created_at, archived, schema_validation, ws_error_handler_muted, deleted, extra_perms)
+         VALUES ('test-workspace', 'f/restricted/item', 314159, 'def main(): return 1', '', '', 'python3', 'test-user', NOW(), false, false, false, false, '{}'::jsonb)"
+    )
+    .execute(&db)
+    .await?;
+
+    // Fork (clones the folder + script into the fork).
+    let resp = admin
+        .client()
+        .post(&format!(
+            "{base_url}/w/test-workspace/workspaces/create_fork"
+        ))
+        .json(&json!({"id": "wm-fork-guard-test", "name": "Guard Fork", "color": "#0000ff"}))
+        .send()
+        .await?;
+    assert!(
+        resp.status().is_success(),
+        "fork creation failed: {}",
+        resp.status()
+    );
+
+    // test-user-2 is ADMIN of the fork (so they see the fork copy via RLS bypass)
+    // but only a plain member of the parent.
+    sqlx::query!(
+        "INSERT INTO usr (workspace_id, email, username, is_admin, role)
+         VALUES ('wm-fork-guard-test', 'test2@windmill.dev', 'test-user-2', true, 'Admin')"
+    )
+    .execute(&db)
+    .await?;
+
+    // A confirmed modified/ahead diff on the script that exists on both sides.
+    sqlx::query!(
+        "INSERT INTO workspace_diff
+         (source_workspace_id, fork_workspace_id, path, kind, ahead, behind, has_changes, exists_in_source, exists_in_fork)
+         VALUES ('test-workspace', 'wm-fork-guard-test', 'f/restricted/item', 'script', 1, 0, true, true, true)"
+    )
+    .execute(&db)
+    .await?;
+    sqlx::query!(
+        "DELETE FROM skip_workspace_diff_tally WHERE workspace_id IN ('test-workspace', 'wm-fork-guard-test')"
+    )
+    .execute(&db)
+    .await?;
+
+    let comparison: serde_json::Value = fork_admin_user
+        .client()
+        .get(&format!(
+            "{base_url}/w/test-workspace/workspaces/compare/wm-fork-guard-test"
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    // The parent copy is hidden from test-user-2, so the ahead diff is dropped.
+    // Fork-admin alone must NOT clear the flag — the comparison is incomplete.
+    assert_eq!(
+        comparison["all_ahead_items_visible"].as_bool(),
+        Some(false),
+        "fork admin without source-side visibility must not be reported as seeing all ahead items: {comparison}"
+    );
+    assert!(
+        !comparison["diffs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|d| d["path"] == "f/restricted/item"),
+        "source-hidden item must not appear in the fork admin's diff list: {comparison}"
+    );
+
+    // Sanity: a superadmin (admin of both sides) still sees everything.
+    let comparison: serde_json::Value = admin
+        .client()
+        .get(&format!(
+            "{base_url}/w/test-workspace/workspaces/compare/wm-fork-guard-test"
+        ))
+        .send()
+        .await?
+        .json()
+        .await?;
+    assert_eq!(
+        comparison["all_ahead_items_visible"].as_bool(),
+        Some(true),
+        "superadmin must see all ahead items: {comparison}"
+    );
+
+    Ok(())
+}

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -7293,22 +7293,25 @@ async fn compare_workspaces(
             .fold(0, |acc, s| acc + s.try_into().unwrap_or(0));
 
     // Blast-radius guard for the "changes not visible to your user" warning
-    // (which hides the deploy button entirely). The flag is a pure visibility
-    // guarantee — the actual deploy/update is separately authorized against the
-    // target workspace's create/update endpoints — so it must be forced true for
-    // anyone who, as a rule, sees every item on the relevant side (RLS is bypassed
-    // for admins); any diff the visibility filter dropped for them is provably a
-    // stale/phantom row, never a permission gap. Crucially the two sides live in
-    // different workspaces: ahead items are the fork's own changes (gated by the
-    // TARGET/fork admin), behind items physically live in the parent (gated by the
-    // SOURCE/parent admin). A target admin does NOT see the parent side, so it must
-    // not clear the behind flag, and vice versa. `target_admin` already folds in
-    // superadmin; `source_admin` (parent side) ORs it in explicitly.
+    // (which hides the deploy button). The flag is a pure visibility guarantee —
+    // the deploy re-authorizes each item against the target workspace's
+    // create/update endpoints — so it is safe to force true for a caller who sees
+    // every item on BOTH sides, for whom any diff the filter dropped is provably a
+    // stale/phantom row, never a permission gap.
+    //
+    // It must be BOTH sides, not per-side: `filter_visible_diffs` keeps a modified
+    // or conflict row (one that exists in the source AND the fork) only when the
+    // caller can see it on both sides, so an ahead/conflict diff can be dropped for
+    // a source-side visibility gap even when the caller is a fork admin. Gating the
+    // ahead flag on fork-admin alone would then wrongly report "all ahead visible"
+    // and let the UI deploy from an incomplete comparison. So require admin of the
+    // source AND the fork (superadmin satisfies both), which guarantees full
+    // visibility of every item on every side. `fork_authed.is_admin` already folds
+    // in superadmin; `authed.is_admin` (source side) does not, so OR it in.
     let is_super_admin = windmill_common::auth::is_super_admin_email(&db, &authed.email).await?;
-    let target_admin = fork_authed.is_admin;
-    let source_admin = is_super_admin || authed.is_admin;
-    let all_ahead_items_visible = all_ahead_items_visible || target_admin;
-    let all_behind_items_visible = all_behind_items_visible || source_admin;
+    let sees_all_items = is_super_admin || (authed.is_admin && fork_authed.is_admin);
+    let all_ahead_items_visible = all_ahead_items_visible || sees_all_items;
+    let all_behind_items_visible = all_behind_items_visible || sees_all_items;
 
     return Ok(Json(WorkspaceComparison {
         all_ahead_items_visible,


### PR DESCRIPTION
## Summary

Addresses the [P1] review feedback on #9866 (merged): the visibility guard was too broad on the ahead side, and fixes the SQLx offline-cache gap that #9866 left behind.

### The bug (P1)
#9866 forced `all_ahead_items_visible = true` for **any fork/target admin**. But `filter_visible_diffs` keeps a **modified/conflict** row (one that exists in the source *and* the fork) only when the caller can see it on **both** sides. So an ahead/conflict diff can be legitimately dropped because of a **source-side** visibility gap — even when the caller is a fork admin. Forcing the flag on fork-admin alone then reports "all ahead items visible" anyway, so the UI enables deployment from an **incomplete comparison** instead of showing the "changes not visible" guard.

### Fix
Gate the guard on admin of **both** the source and the fork (superadmin satisfies both), which is what actually guarantees full visibility of every item on every side:

```rust
let sees_all_items = is_super_admin || (authed.is_admin && fork_authed.is_admin);
let all_ahead_items_visible  = all_ahead_items_visible  || sees_all_items;
let all_behind_items_visible = all_behind_items_visible || sees_all_items;
```

- Superadmin (the originally reported case) → still forced true, still fixed.
- Admin of both workspaces → forced true (they genuinely see everything).
- Fork-admin-only with a source-hidden ahead item → **no longer** forced true → the guard correctly fires. ✅

### SQLx cache
#9866 merged a test `INSERT` without regenerating the offline cache, so `SQLX_OFFLINE=true` builds fail with *"no cached data for this query"*. Restored that entry and added entries for the new test's (all-literal) queries. `.sqlx` changes are **purely additive** — no existing/EE caches touched.

## Changes
- `windmill-api-workspaces/src/workspaces.rs`: per-side guard → both-sides (`sees_all_items`).
- New regression test `test_compare_workspaces_fork_admin_source_hidden_ahead`: a fork admin who is a plain parent member with no access to the item's folder must get `all_ahead_items_visible = false`; superadmin still gets `true`.
- 6 additive `.sqlx` cache files.

## Test plan
- [x] `cargo test -p windmill-api-integration-tests --test workspace_comparison` — 8/8 pass (incl. the new test, which force-trues under the old guard).
- [x] `SQLX_OFFLINE=true cargo test --no-run` — compiles clean (was failing on main).
- [x] `.sqlx` diff vs main is additions only (no deletions/modifications).

## Related
Follow-up correctness fix to #9866. (Frontend partial-deploy is #9868.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the compare visibility guard to require admin of both the source and the fork (or superadmin) so we don’t enable deploys from incomplete comparisons. Restores SQLx offline cache entries to fix `SQLX_OFFLINE` build failures.

- **Bug Fixes**
  - Require admin of both workspaces (or superadmin) to force `all_ahead_items_visible` and `all_behind_items_visible` to true; fork-only admin no longer clears the ahead flag when source-side items are hidden.
  - Added a regression test ensuring a fork admin without source access gets `all_ahead_items_visible = false`; superadmin still gets `true`.
  - Re-added and extended `.sqlx` cache files to cover inserted test queries, fixing `SQLX_OFFLINE=true` builds.

<sup>Written for commit d0501e9d1505a19c052703ca0ee4791adfe05d97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

