### PR TITLE
fix(frontend): stack cron field and cron builder on narrow screens

### DIFF
--- a/frontend/src/lib/components/CronInput.svelte
+++ b/frontend/src/lib/components/CronInput.svelte
@@ -204,18 +204,20 @@
 		<div class="flex flex-col gap-1">
 			<label for="cron-schedule" class="text-xs font-semibold text-emphasis">Cron</label>
 
-			<div class="flex flex-row gap-2 items-center">
-				<TextInput
-					inputProps={{
-						type: 'text',
-						id: 'cron-schedule',
-						name: 'cron-schedule',
-						placeholder: '0 0 */1 * * *',
-						disabled: disabled
-					}}
-					bind:value={schedule}
-					error={!validCRON}
-				/>
+			<div class="flex flex-row flex-wrap gap-2 items-center">
+				<div class="flex-1 min-w-[160px]">
+					<TextInput
+						inputProps={{
+							type: 'text',
+							id: 'cron-schedule',
+							name: 'cron-schedule',
+							placeholder: '0 0 */1 * * *',
+							disabled: disabled
+						}}
+						bind:value={schedule}
+						error={!validCRON}
+					/>
+				</div>
 				{#if !disabled}
 					<div class="flex flex-row gap-2 shrink-0">
 						{@render cronBuilder()}


### PR DESCRIPTION
## Summary
On narrow layouts the schedule editor's cron row placed the input next to a `shrink-0` button group ("Cron builder" + AI generator), so the buttons kept their full width and squeezed the cron `TextInput` to near-zero — the field became effectively invisible. This makes the row wrap so the buttons drop below the input, keeping both visible.

Fixes WIN-2121

## Changes
- `frontend/src/lib/components/CronInput.svelte`: add `flex-wrap` to the cron row and wrap the `TextInput` in a `flex-1 min-w-[160px]` container so the input keeps a usable minimum width and the button group wraps onto its own line when there isn't room for both.

## Screenshots

Narrow (input and buttons stacked — cron field now visible):

![narrow-stacked](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2121-make-schedule-editor-fields-stack-on-narrow-screens/v2-1782970163-narrow-stacked.png)

Wide (unchanged — input and buttons on one line):

![wide-inline](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2121-make-schedule-editor-fields-stack-on-narrow-screens/v2-1782970165-wide-inline.png)

## Test plan
- [x] Open the schedule editor at a wide viewport → cron input and buttons share one line (no regression)
- [x] Shrink the viewport (≤640px) → the "Cron builder"/AI buttons wrap below the cron input and both remain visible
- [x] Verified down to ~440px viewport; input stays visible via the min width

🤖 Generated with [Claude Code](https://claude.com/claude-code)