### PR TITLE
fix(frontend): reserve fixed height for unsaved-changes banner to avoid content shift

### DIFF
--- a/frontend/src/lib/components/AppConnectInner.svelte
+++ b/frontend/src/lib/components/AppConnectInner.svelte
@@ -991,13 +991,15 @@
 		</div>
 	{:else if step == 2 && manual}
 		<div class="flex flex-col gap-8">
-			<Path
-				bind:error={pathError}
-				bind:path
-				initialPath=""
-				namePlaceholder={resourceType}
-				kind="resource"
-			/>
+			<Label label="Path">
+				<Path
+					bind:error={pathError}
+					bind:path
+					initialPath=""
+					namePlaceholder={resourceType}
+					kind="resource"
+				/>
+			</Label>
 			<LabelsInput bind:labels class="-mt-5" />
 			{#if deployTo}
 				<Label
@@ -1247,13 +1249,15 @@
 			<span class="text-xs text-primary font-normal"> Finish connection in popup window </span>
 		{/if}
 	{:else}
-		<Path
-			initialPath=""
-			namePlaceholder={resourceType}
-			bind:error={pathError}
-			bind:path
-			kind="resource"
-		/>
+		<Label label="Path">
+			<Path
+				initialPath=""
+				namePlaceholder={resourceType}
+				bind:error={pathError}
+				bind:path
+				kind="resource"
+			/>
+		</Label>
 		<LabelsInput bind:labels class="-mt-5" />
 		{#if deployTo}
 			<Label

--- a/frontend/src/lib/components/LocalDraftBanner.svelte
+++ b/frontend/src/lib/components/LocalDraftBanner.svelte
@@ -26,11 +26,8 @@
 		/** Diff drawer title. */
 		title?: string
 		/**
-		 * Whether to reserve the banner's fixed-height slot (so toggling the
-		 * "unsaved changes" state doesn't shift the content below). Pass this when
-		 * `getDeployed()` reads a non-reactive source (the trigger editors back
-		 * their baseline with a plain `let`); otherwise it defaults to
-		 * `getDeployed() != null`, which is reactive for `$state`-backed baselines.
+		 * Reserve the banner's fixed-height slot so toggling it doesn't shift content.
+		 * Pass when `getDeployed()` is non-reactive; else defaults to `getDeployed() != null`.
 		 */
 		reserveSpace?: boolean
 	}
@@ -58,11 +55,9 @@
 		}
 	}
 
-	// A deployed baseline means the banner *can* toggle on/off while the
-	// user edits this entity, so we reserve its fixed-height slot up front
-	// (see the template) to keep the banner appearing/disappearing from
-	// shifting the content below. Brand-new entities have no baseline — the
-	// banner can never show there, so we reserve nothing and add no gap.
+	// Whether the banner can appear (a deployed baseline exists). Gates the
+	// reserved slot below so toggling it doesn't shift content; new entities
+	// have none, so no slot and no gap.
 	let hasBaseline = $derived(reserveSpace ?? getDeployed() != null)
 
 	// Suppress the banner when:
@@ -114,11 +109,9 @@
 <DiffDrawer bind:this={diffDrawer} />
 
 {#if hasBaseline}
-	<!-- The banner is h-8 (action-button height + a couple px so the buttons don't
-	     touch the edges). We reserve only about a THIRD of that height when idle
-	     (h-2.5) and grow to the full h-8 when the banner shows: this keeps the empty
-	     gap small when there are no unsaved changes while limiting the content shift
-	     on appear to ~22px. The height animates so the shift reads as a smooth expand. -->
+	<!-- Reserve ~a third of the banner height when idle (h-2.5), grow to the full
+	     h-8 when it shows: small idle gap, ~22px animated shift on appear. h-8 =
+	     button height + a couple px so the buttons don't touch the edges. -->
 	<div class={twMerge('shrink-0 transition-[height] duration-150', visible ? 'h-8' : 'h-2.5')}>
 		{#if visible}
 			<div

--- a/frontend/src/lib/components/LocalDraftBanner.svelte
+++ b/frontend/src/lib/components/LocalDraftBanner.svelte
@@ -26,8 +26,9 @@
 		/** Diff drawer title. */
 		title?: string
 		/**
-		 * Reserve the banner's fixed-height slot so toggling it doesn't shift content.
-		 * Pass when `getDeployed()` is non-reactive; else defaults to `getDeployed() != null`.
+		 * Whether the banner can appear, so it partially reserves its slot to keep
+		 * the shift small. Pass when `getDeployed()` is non-reactive; else defaults
+		 * to `getDeployed() != null`.
 		 */
 		reserveSpace?: boolean
 	}
@@ -56,7 +57,7 @@
 	}
 
 	// Whether the banner can appear (a deployed baseline exists). Gates the
-	// reserved slot below so toggling it doesn't shift content; new entities
+	// partially-reserved slot below (keeps the toggle shift small); new entities
 	// have none, so no slot and no gap.
 	let hasBaseline = $derived(reserveSpace ?? getDeployed() != null)
 

--- a/frontend/src/lib/components/LocalDraftBanner.svelte
+++ b/frontend/src/lib/components/LocalDraftBanner.svelte
@@ -116,8 +116,9 @@
 {#if hasBaseline}
 	<!-- Fixed-height slot reserved whenever the banner can appear, so toggling
 	     the "unsaved changes" state fades the banner in/out without pushing the
-	     content below. h-9 matches the banner's natural height. -->
-	<div class="h-9 shrink-0">
+	     content below. Kept intentionally snug (h-7 = the action buttons' height)
+	     so the empty gap it leaves when no banner shows stays small. -->
+	<div class="h-7 shrink-0">
 		{#if visible}
 			<div
 				transition:fade|local={{ duration: 120 }}

--- a/frontend/src/lib/components/LocalDraftBanner.svelte
+++ b/frontend/src/lib/components/LocalDraftBanner.svelte
@@ -10,7 +10,7 @@
 	} from '$lib/utils'
 	import { AlertCircle, Diff } from 'lucide-svelte'
 	import { twMerge } from 'tailwind-merge'
-	import { slide } from 'svelte/transition'
+	import { fade } from 'svelte/transition'
 
 	interface Props {
 		/** Whether there are unsaved local changes relative to the deployed baseline. */
@@ -25,6 +25,14 @@
 		disabled?: boolean
 		/** Diff drawer title. */
 		title?: string
+		/**
+		 * Whether to reserve the banner's fixed-height slot (so toggling the
+		 * "unsaved changes" state doesn't shift the content below). Pass this when
+		 * `getDeployed()` reads a non-reactive source (the trigger editors back
+		 * their baseline with a plain `let`); otherwise it defaults to
+		 * `getDeployed() != null`, which is reactive for `$state`-backed baselines.
+		 */
+		reserveSpace?: boolean
 	}
 
 	let {
@@ -33,7 +41,8 @@
 		getCurrent,
 		onDiscard,
 		disabled = false,
-		title = 'Deployed <> Local changes'
+		title = 'Deployed <> Local changes',
+		reserveSpace
 	}: Props = $props()
 
 	/** Same cleaning + YAML serialization the DiffDrawer applies before
@@ -49,6 +58,13 @@
 		}
 	}
 
+	// A deployed baseline means the banner *can* toggle on/off while the
+	// user edits this entity, so we reserve its fixed-height slot up front
+	// (see the template) to keep the banner appearing/disappearing from
+	// shifting the content below. Brand-new entities have no baseline — the
+	// banner can never show there, so we reserve nothing and add no gap.
+	let hasBaseline = $derived(reserveSpace ?? getDeployed() != null)
+
 	// Suppress the banner when:
 	//   • There's no deployed baseline (brand-new entity — "Show diff"
 	//     would early-return and "Discard" is semantically backwards),
@@ -58,10 +74,8 @@
 	//     from baseline" check that can stale-fire after a save lands
 	//     or when `false`/`undefined` toggle noise flips a field.
 	let visible = $derived.by(() => {
-		if (!show) return false
-		const deployed = getDeployed()
-		if (deployed == null) return false
-		return diffKey(deployed) !== diffKey(getCurrent())
+		if (!show || !hasBaseline) return false
+		return diffKey(getDeployed()) !== diffKey(getCurrent())
 	})
 
 	let diffDrawer: DiffDrawer | undefined = $state()
@@ -99,37 +113,44 @@
 
 <DiffDrawer bind:this={diffDrawer} />
 
-{#if visible}
-	<div
-		transition:slide|local={{ duration: 120 }}
-		class={twMerge(
-			'flex flex-row items-center justify-between gap-2 px-4 py-1',
-			classes.warning.bgClass,
-			'!border-0 !rounded-none'
-		)}
-	>
-		<div class="flex flex-row items-center gap-2 min-w-0">
-			<AlertCircle class={classes.warning.iconClass} size={16} />
-			<span class={twMerge('text-xs font-semibold truncate', classes.warning.titleClass)}>
-				You have unsaved changes
-			</span>
-		</div>
-		<div class="flex flex-row items-center gap-2 shrink-0">
-			<Button
-				unifiedSize="sm"
-				variant="default"
-				startIcon={{ icon: Diff }}
-				btnClasses={classes.warning.titleClass}
-				on:click={showDiff}>Show diff</Button
+{#if hasBaseline}
+	<!-- Fixed-height slot reserved whenever the banner can appear, so toggling
+	     the "unsaved changes" state fades the banner in/out without pushing the
+	     content below. h-9 matches the banner's natural height. -->
+	<div class="h-9 shrink-0">
+		{#if visible}
+			<div
+				transition:fade|local={{ duration: 120 }}
+				class={twMerge(
+					'flex flex-row items-center justify-between gap-2 px-4 h-full',
+					classes.warning.bgClass,
+					'!border-0 !rounded-none'
+				)}
 			>
-			{#if !disabled}
-				<Button
-					unifiedSize="sm"
-					variant="subtle"
-					btnClasses={classes.warning.titleClass}
-					on:click={onDiscard}>Discard</Button
-				>
-			{/if}
-		</div>
+				<div class="flex flex-row items-center gap-2 min-w-0">
+					<AlertCircle class={classes.warning.iconClass} size={16} />
+					<span class={twMerge('text-xs font-semibold truncate', classes.warning.titleClass)}>
+						You have unsaved changes
+					</span>
+				</div>
+				<div class="flex flex-row items-center gap-2 shrink-0">
+					<Button
+						unifiedSize="sm"
+						variant="default"
+						startIcon={{ icon: Diff }}
+						btnClasses={classes.warning.titleClass}
+						on:click={showDiff}>Show diff</Button
+					>
+					{#if !disabled}
+						<Button
+							unifiedSize="sm"
+							variant="subtle"
+							btnClasses={classes.warning.titleClass}
+							on:click={onDiscard}>Discard</Button
+						>
+					{/if}
+				</div>
+			</div>
+		{/if}
 	</div>
 {/if}

--- a/frontend/src/lib/components/LocalDraftBanner.svelte
+++ b/frontend/src/lib/components/LocalDraftBanner.svelte
@@ -114,12 +114,12 @@
 <DiffDrawer bind:this={diffDrawer} />
 
 {#if hasBaseline}
-	<!-- Fixed-height slot reserved whenever the banner can appear, so toggling
-	     the "unsaved changes" state fades the banner in/out without pushing the
-	     content below. Kept snug (h-8 = the action buttons' height plus a couple
-	     px so they don't touch the banner edges) so the empty gap it leaves when
-	     no banner shows stays small. -->
-	<div class="h-8 shrink-0">
+	<!-- The banner is h-8 (action-button height + a couple px so the buttons don't
+	     touch the edges). We reserve only HALF that height when idle (h-4) and grow
+	     to the full h-8 when the banner shows: this halves the empty gap left when
+	     there are no unsaved changes while limiting the content shift on appear to
+	     ~16px. The height animates so the shift reads as a smooth expand. -->
+	<div class={twMerge('shrink-0 transition-[height] duration-150', visible ? 'h-8' : 'h-4')}>
 		{#if visible}
 			<div
 				transition:fade|local={{ duration: 120 }}

--- a/frontend/src/lib/components/LocalDraftBanner.svelte
+++ b/frontend/src/lib/components/LocalDraftBanner.svelte
@@ -116,9 +116,10 @@
 {#if hasBaseline}
 	<!-- Fixed-height slot reserved whenever the banner can appear, so toggling
 	     the "unsaved changes" state fades the banner in/out without pushing the
-	     content below. Kept intentionally snug (h-7 = the action buttons' height)
-	     so the empty gap it leaves when no banner shows stays small. -->
-	<div class="h-7 shrink-0">
+	     content below. Kept snug (h-8 = the action buttons' height plus a couple
+	     px so they don't touch the banner edges) so the empty gap it leaves when
+	     no banner shows stays small. -->
+	<div class="h-8 shrink-0">
 		{#if visible}
 			<div
 				transition:fade|local={{ duration: 120 }}

--- a/frontend/src/lib/components/LocalDraftBanner.svelte
+++ b/frontend/src/lib/components/LocalDraftBanner.svelte
@@ -115,11 +115,11 @@
 
 {#if hasBaseline}
 	<!-- The banner is h-8 (action-button height + a couple px so the buttons don't
-	     touch the edges). We reserve only HALF that height when idle (h-4) and grow
-	     to the full h-8 when the banner shows: this halves the empty gap left when
-	     there are no unsaved changes while limiting the content shift on appear to
-	     ~16px. The height animates so the shift reads as a smooth expand. -->
-	<div class={twMerge('shrink-0 transition-[height] duration-150', visible ? 'h-8' : 'h-4')}>
+	     touch the edges). We reserve only about a THIRD of that height when idle
+	     (h-2.5) and grow to the full h-8 when the banner shows: this keeps the empty
+	     gap small when there are no unsaved changes while limiting the content shift
+	     on appear to ~22px. The height animates so the shift reads as a smooth expand. -->
+	<div class={twMerge('shrink-0 transition-[height] duration-150', visible ? 'h-8' : 'h-2.5')}>
 		{#if visible}
 			<div
 				transition:fade|local={{ duration: 120 }}

--- a/frontend/src/lib/components/ResourceEditor.svelte
+++ b/frontend/src/lib/components/ResourceEditor.svelte
@@ -374,7 +374,7 @@
 </script>
 
 <div>
-	<div class="flex flex-col gap-6 py-2">
+	<div class="flex flex-col gap-6 pb-2">
 		{#if otherDirty.length > 0}
 			<Alert type="warning" title="Editing multiple workspaces">
 				You are going to edit the value in: {otherDirty.join(', ')}

--- a/frontend/src/lib/components/ResourceEditorDrawer.svelte
+++ b/frontend/src/lib/components/ResourceEditorDrawer.svelte
@@ -58,6 +58,7 @@
 <Drawer bind:this={drawer} size="50rem" {disableChatOffset}>
 	<DrawerContent
 		title={mode == 'edit' ? 'Edit ' + path : 'Add a resource'}
+		bannerReserved={mode == 'edit'}
 		on:close={drawer?.closeDrawer}
 	>
 		{#await import('./ResourceEditor.svelte')}
@@ -79,6 +80,7 @@
 		{#snippet banner()}
 			<LocalDraftBanner
 				show={hasLocalDraft}
+				reserveSpace={mode == 'edit'}
 				getDeployed={() => resourceEditor?.localDraftDeployed()}
 				getCurrent={() => resourceEditor?.localDraftCurrent()}
 				onDiscard={() => resourceEditor?.discardLocalDraft()}

--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -1060,10 +1060,10 @@
 						<div class="min-h-0 grow overflow-y-auto">
 							<TabContent value="metadata">
 								<div class="flex flex-col gap-8 px-4 py-2 pb-12">
-									<Section headless>
-										<div class="flex flex-col gap-6">
+									<Section label="Metadata">
+										{#snippet action()}
 											{#if customUi?.settingsPanel?.metadata?.disableMute !== true}
-												<div class="flex flex-row items-center justify-end gap-2">
+												<div class="flex flex-row items-center gap-2">
 													<ErrorHandlerToggleButton
 														kind="script"
 														scriptOrFlowPath={script.path}
@@ -1072,6 +1072,8 @@
 													/>
 												</div>
 											{/if}
+										{/snippet}
+										<div class="flex flex-col gap-6">
 											<Label label="Summary">
 												<MetadataGen
 													aiId="create-script-summary-input"

--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -1060,10 +1060,10 @@
 						<div class="min-h-0 grow overflow-y-auto">
 							<TabContent value="metadata">
 								<div class="flex flex-col gap-8 px-4 py-2 pb-12">
-									<Section label="Metadata">
-										{#snippet action()}
+									<Section headless>
+										<div class="flex flex-col gap-6">
 											{#if customUi?.settingsPanel?.metadata?.disableMute !== true}
-												<div class="flex flex-row items-center gap-2">
+												<div class="flex flex-row items-center justify-end gap-2">
 													<ErrorHandlerToggleButton
 														kind="script"
 														scriptOrFlowPath={script.path}
@@ -1072,8 +1072,6 @@
 													/>
 												</div>
 											{/if}
-										{/snippet}
-										<div class="flex flex-col gap-6">
 											<Label label="Summary">
 												<MetadataGen
 													aiId="create-script-summary-input"

--- a/frontend/src/lib/components/Section.svelte
+++ b/frontend/src/lib/components/Section.svelte
@@ -104,7 +104,7 @@
 			{#if description}
 				<div class="text-xs text-primary mt-1 mb-2">{@html description}</div>
 			{/if}
-			<div class="flex flex-col gap-6 grow min-h-0 mt-4">
+			<div class={twMerge('flex flex-col gap-6 grow min-h-0', headless ? '' : 'mt-4')}>
 				<div class={twMerge('grow min-h-0', clazz)}>
 					{@render children?.()}
 				</div>

--- a/frontend/src/lib/components/VariableEditor.svelte
+++ b/frontend/src/lib/components/VariableEditor.svelte
@@ -308,7 +308,7 @@
 				disabled={!can_write}
 			/>
 		{/snippet}
-		<div class="flex flex-col gap-8">
+		<div class="flex flex-col gap-8 pb-2">
 			{#if !can_write}
 				<Alert type="warning" title="Only read access">
 					You only have read access to this resource and cannot edit it

--- a/frontend/src/lib/components/VariableEditor.svelte
+++ b/frontend/src/lib/components/VariableEditor.svelte
@@ -292,11 +292,13 @@
 <Drawer bind:this={drawer} size="50rem">
 	<DrawerContent
 		title={edit ? `Update variable at ${initialPath}` : 'Add a variable'}
+		bannerReserved={edit}
 		on:close={drawer?.closeDrawer}
 	>
 		{#snippet banner()}
 			<LocalDraftBanner
 				show={edit && selectedDirty}
+				reserveSpace={edit}
 				getDeployed={() => (selected ? initialStates[selected] : undefined)}
 				getCurrent={() => current}
 				onDiscard={() => {

--- a/frontend/src/lib/components/common/drawer/DrawerContent.svelte
+++ b/frontend/src/lib/components/common/drawer/DrawerContent.svelte
@@ -25,11 +25,8 @@
 		/** Rendered fixed below the header, above the scrollable content. */
 		banner?: import('svelte').Snippet
 		/**
-		 * Whether the `banner` is actually reserving vertical space (its baseline
-		 * exists so it can appear). Only then does the content hug it with a tight
-		 * top padding; for new entities where the banner can never show, the content
-		 * keeps normal padding. Defaults to false so a bannerless-but-passed snippet
-		 * doesn't compress the top.
+		 * Whether the `banner` reserves space (its baseline exists). Only then does
+		 * the content hug it with tight top padding; new entities keep normal padding.
 		 */
 		bannerReserved?: boolean
 		children?: import('svelte').Snippet
@@ -110,11 +107,9 @@
 	{/snippet}
 
 	{#if banner}
-		<!-- Banner + content share one `divide-y` cell so the header keeps its single
-		     divider and the banner's reserved-height slot doesn't get bracketed into a
-		     bordered empty strip when no banner is shown. The reserved slot already
-		     separates the banner from the content, so the content hugs it with a tight
-		     top padding. -->
+		<!-- Banner + content share one `divide-y` cell: the header keeps its single
+		     divider (no bordered strip around the reserved slot) and the content hugs
+		     the slot with tight top padding (see `contentBox`/`bannerReserved`). -->
 		<div class="flex flex-col grow min-h-0 max-h-full">
 			{@render banner()}
 			{@render contentBox(bannerReserved)}

--- a/frontend/src/lib/components/common/drawer/DrawerContent.svelte
+++ b/frontend/src/lib/components/common/drawer/DrawerContent.svelte
@@ -86,10 +86,10 @@
 		{/if}
 	</div>
 
-	{#snippet contentBox()}
+	{#snippet contentBox(tightTop = false)}
 		<div
 			class={classNames(
-				noPadding ? '' : 'p-4',
+				noPadding ? '' : tightTop ? 'px-4 pb-4 pt-1' : 'p-4',
 				'grow min-h-0 max-h-full',
 				forceOverflowVisible ? '!overflow-visible' : ''
 			)}
@@ -103,10 +103,12 @@
 	{#if banner}
 		<!-- Banner + content share one `divide-y` cell so the header keeps its single
 		     divider and the banner's reserved-height slot doesn't get bracketed into a
-		     bordered empty strip when no banner is shown. -->
+		     bordered empty strip when no banner is shown. The reserved slot already
+		     separates the banner from the content, so the content hugs it with a tight
+		     top padding. -->
 		<div class="flex flex-col grow min-h-0 max-h-full">
 			{@render banner()}
-			{@render contentBox()}
+			{@render contentBox(true)}
 		</div>
 	{:else}
 		{@render contentBox()}

--- a/frontend/src/lib/components/common/drawer/DrawerContent.svelte
+++ b/frontend/src/lib/components/common/drawer/DrawerContent.svelte
@@ -86,19 +86,29 @@
 		{/if}
 	</div>
 
-	{#if banner}
-		{@render banner()}
-	{/if}
+	{#snippet contentBox()}
+		<div
+			class={classNames(
+				noPadding ? '' : 'p-4',
+				'grow min-h-0 max-h-full',
+				forceOverflowVisible ? '!overflow-visible' : ''
+			)}
+			class:overflow-y-auto={overflow_y}
+			style={overflow_y ? 'scrollbar-gutter: stable;' : ''}
+		>
+			{@render children?.()}
+		</div>
+	{/snippet}
 
-	<div
-		class={classNames(
-			noPadding ? '' : 'p-4',
-			'grow min-h-0 max-h-full',
-			forceOverflowVisible ? '!overflow-visible' : ''
-		)}
-		class:overflow-y-auto={overflow_y}
-		style={overflow_y ? 'scrollbar-gutter: stable;' : ''}
-	>
-		{@render children?.()}
-	</div>
+	{#if banner}
+		<!-- Banner + content share one `divide-y` cell so the header keeps its single
+		     divider and the banner's reserved-height slot doesn't get bracketed into a
+		     bordered empty strip when no banner is shown. -->
+		<div class="flex flex-col grow min-h-0 max-h-full">
+			{@render banner()}
+			{@render contentBox()}
+		</div>
+	{:else}
+		{@render contentBox()}
+	{/if}
 </div>

--- a/frontend/src/lib/components/common/drawer/DrawerContent.svelte
+++ b/frontend/src/lib/components/common/drawer/DrawerContent.svelte
@@ -24,6 +24,14 @@
 		titleExtra?: import('svelte').Snippet
 		/** Rendered fixed below the header, above the scrollable content. */
 		banner?: import('svelte').Snippet
+		/**
+		 * Whether the `banner` is actually reserving vertical space (its baseline
+		 * exists so it can appear). Only then does the content hug it with a tight
+		 * top padding; for new entities where the banner can never show, the content
+		 * keeps normal padding. Defaults to false so a bannerless-but-passed snippet
+		 * doesn't compress the top.
+		 */
+		bannerReserved?: boolean
 		children?: import('svelte').Snippet
 	}
 
@@ -43,6 +51,7 @@
 		actions,
 		titleExtra,
 		banner,
+		bannerReserved = false,
 		children
 	}: Props = $props()
 
@@ -108,7 +117,7 @@
 		     top padding. -->
 		<div class="flex flex-col grow min-h-0 max-h-full">
 			{@render banner()}
-			{@render contentBox(true)}
+			{@render contentBox(bannerReserved)}
 		</div>
 	{:else}
 		{@render contentBox()}

--- a/frontend/src/lib/components/triggers/azure/AzureTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/azure/AzureTriggerEditorInner.svelte
@@ -364,6 +364,7 @@
 				<LocalDraftBanner
 					show={draftSync.hasDraft}
 					getDeployed={() => draftSync.deployed}
+					reserveSpace={draftSync.hasBaseline}
 					getCurrent={() => draftSync.current}
 					onDiscard={() => draftSync.resetToDeployed(initialPath)}
 					disabled={!can_write}

--- a/frontend/src/lib/components/triggers/azure/AzureTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/azure/AzureTriggerEditorInner.svelte
@@ -350,6 +350,7 @@
 {#if useDrawer}
 	<Drawer size="800px" bind:this={drawer}>
 		<DrawerContent
+			bannerReserved={draftSync.hasBaseline}
 			title={edit
 				? can_write
 					? `Edit Azure trigger ${initialPath}`

--- a/frontend/src/lib/components/triggers/email/EmailTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/email/EmailTriggerEditorInner.svelte
@@ -368,7 +368,7 @@
 			{#if mode === 'suspended'}
 				<TriggerSuspendedJobsAlert {suspendedJobsModal} />
 			{/if}
-			<Section label="Metadata">
+			<Section headless>
 				<div class="flex flex-col gap-2">
 					<Label label="Path">
 						<Path

--- a/frontend/src/lib/components/triggers/email/EmailTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/email/EmailTriggerEditorInner.svelte
@@ -489,6 +489,7 @@
 				<LocalDraftBanner
 					show={draftSync.hasDraft}
 					getDeployed={() => draftSync.deployed}
+					reserveSpace={draftSync.hasBaseline}
 					getCurrent={() => draftSync.current}
 					onDiscard={() => draftSync.resetToDeployed(initialPath)}
 					disabled={!can_write}

--- a/frontend/src/lib/components/triggers/email/EmailTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/email/EmailTriggerEditorInner.svelte
@@ -475,6 +475,7 @@
 {#if useDrawer}
 	<Drawer size="700px" bind:this={drawer}>
 		<DrawerContent
+			bannerReserved={draftSync.hasBaseline}
 			title={edit
 				? can_write
 					? `Edit email trigger ${initialPath}`

--- a/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
@@ -381,6 +381,7 @@
 				<LocalDraftBanner
 					show={draftSync.hasDraft}
 					getDeployed={() => draftSync.deployed}
+					reserveSpace={draftSync.hasBaseline}
 					getCurrent={() => draftSync.current}
 					onDiscard={() => draftSync.resetToDeployed(initialPath)}
 					disabled={!can_write}

--- a/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
@@ -367,6 +367,7 @@
 {#if useDrawer}
 	<Drawer size="800px" bind:this={drawer}>
 		<DrawerContent
+			bannerReserved={draftSync.hasBaseline}
 			title={edit
 				? can_write
 					? `Edit GCP Pub/Sub trigger ${initialPath}`

--- a/frontend/src/lib/components/triggers/http/RouteEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/http/RouteEditorInner.svelte
@@ -535,7 +535,7 @@
 			{#if mode === 'suspended'}
 				<TriggerSuspendedJobsAlert {suspendedJobsModal} />
 			{/if}
-			<Section label="Metadata">
+			<Section headless>
 				<div class="flex flex-col gap-6">
 					<Label label="Summary" for="summary">
 						<!-- svelte-ignore a11y_autofocus -->

--- a/frontend/src/lib/components/triggers/http/RouteEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/http/RouteEditorInner.svelte
@@ -1005,6 +1005,7 @@
 {#if useDrawer}
 	<Drawer size="700px" bind:this={drawer}>
 		<DrawerContent
+			bannerReserved={draftSync.hasBaseline}
 			title={edit
 				? can_write
 					? `Edit route ${initialPath}`

--- a/frontend/src/lib/components/triggers/http/RouteEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/http/RouteEditorInner.svelte
@@ -1019,6 +1019,7 @@
 				<LocalDraftBanner
 					show={draftSync.hasDraft}
 					getDeployed={() => draftSync.deployed}
+					reserveSpace={draftSync.hasBaseline}
 					getCurrent={() => draftSync.current}
 					onDiscard={() => draftSync.resetToDeployed(initialPath)}
 					disabled={!can_write}

--- a/frontend/src/lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte
@@ -430,6 +430,7 @@
 				<LocalDraftBanner
 					show={draftSync.hasDraft}
 					getDeployed={() => draftSync.deployed}
+					reserveSpace={draftSync.hasBaseline}
 					getCurrent={() => draftSync.current}
 					onDiscard={() => draftSync.resetToDeployed(initialPath)}
 					disabled={!can_write}

--- a/frontend/src/lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte
@@ -416,6 +416,7 @@
 {#if useDrawer}
 	<Drawer size="800px" bind:this={drawer}>
 		<DrawerContent
+			bannerReserved={draftSync.hasBaseline}
 			title={edit
 				? can_write
 					? `Edit Kafka trigger ${initialPath}`

--- a/frontend/src/lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte
@@ -391,6 +391,7 @@
 {#if useDrawer}
 	<Drawer size="800px" bind:this={drawer}>
 		<DrawerContent
+			bannerReserved={draftSync.hasBaseline}
 			title={edit
 				? can_write
 					? `Edit MQTT trigger ${initialPath}`

--- a/frontend/src/lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte
@@ -405,6 +405,7 @@
 				<LocalDraftBanner
 					show={draftSync.hasDraft}
 					getDeployed={() => draftSync.deployed}
+					reserveSpace={draftSync.hasBaseline}
 					getCurrent={() => draftSync.current}
 					onDiscard={() => draftSync.resetToDeployed(initialPath)}
 					disabled={!can_write}

--- a/frontend/src/lib/components/triggers/native/NativeTriggerEditor.svelte
+++ b/frontend/src/lib/components/triggers/native/NativeTriggerEditor.svelte
@@ -395,7 +395,7 @@
 			{/if}
 		</div>
 		<div class="flex flex-col gap-12 mt-6">
-			<Section label="Metadata">
+			<Section headless>
 				<div class="flex flex-col gap-6">
 					<label class="flex flex-col gap-1">
 						<span class="text-xs font-semibold text-emphasis">Summary</span>

--- a/frontend/src/lib/components/triggers/nats/NatsTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/nats/NatsTriggerEditorInner.svelte
@@ -402,6 +402,7 @@
 				<LocalDraftBanner
 					show={draftSync.hasDraft}
 					getDeployed={() => draftSync.deployed}
+					reserveSpace={draftSync.hasBaseline}
 					getCurrent={() => draftSync.current}
 					onDiscard={() => draftSync.resetToDeployed(initialPath)}
 					disabled={!can_write}

--- a/frontend/src/lib/components/triggers/nats/NatsTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/nats/NatsTriggerEditorInner.svelte
@@ -388,6 +388,7 @@
 {#if useDrawer}
 	<Drawer size="800px" bind:this={drawer}>
 		<DrawerContent
+			bannerReserved={draftSync.hasBaseline}
 			title={edit
 				? can_write
 					? `Edit NATS trigger ${initialPath}`

--- a/frontend/src/lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte
@@ -566,6 +566,7 @@
 {#if useDrawer}
 	<Drawer size="800px" bind:this={drawer}>
 		<DrawerContent
+			bannerReserved={draftSync.hasBaseline}
 			title={edit
 				? can_write
 					? `Edit Postgres trigger ${initialPath}`

--- a/frontend/src/lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte
@@ -578,6 +578,7 @@
 				<LocalDraftBanner
 					show={draftSync.hasDraft}
 					getDeployed={() => draftSync.deployed}
+					reserveSpace={draftSync.hasBaseline}
 					getCurrent={() => draftSync.current}
 					onDiscard={() => draftSync.resetToDeployed(initialPath)}
 					disabled={!can_write}

--- a/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
@@ -781,7 +781,7 @@
 			}}
 		/>
 		<div class="flex flex-col gap-8">
-			<Section label="Metadata">
+			<Section headless>
 				<div class="flex flex-col gap-6">
 					<label class="flex flex-col gap-1">
 						<span class="text-xs font-semibold text-emphasis">Summary</span>

--- a/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
@@ -1380,6 +1380,7 @@
 {#if useDrawer}
 	<Drawer size="900px" bind:this={drawer}>
 		<DrawerContent
+			bannerReserved={draftSync.hasBaseline}
 			title={edit
 				? can_write
 					? `Edit schedule ${initialPath}`

--- a/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
@@ -1396,6 +1396,7 @@
 				<LocalDraftBanner
 					show={draftSync.hasDraft}
 					getDeployed={() => draftSync.deployed}
+					reserveSpace={draftSync.hasBaseline}
 					getCurrent={() => draftSync.current}
 					onDiscard={() => draftSync.resetToDeployed(initialPath)}
 					disabled={!can_write}

--- a/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
@@ -807,7 +807,7 @@
 							bind:value={summary}
 						/>
 					</label>
-					<LabelsInput bind:labels />
+					<LabelsInput bind:labels class="-mt-4" />
 
 					<div class="flex flex-col gap-1">
 						<label for="path" class="text-xs font-semibold text-emphasis">Path</label>

--- a/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorInner.svelte
@@ -370,6 +370,7 @@
 {#if useDrawer}
 	<Drawer size="800px" bind:this={drawer}>
 		<DrawerContent
+			bannerReserved={draftSync.hasBaseline}
 			title={edit
 				? can_write
 					? `Edit SQS trigger ${initialPath}`

--- a/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorInner.svelte
@@ -384,6 +384,7 @@
 				<LocalDraftBanner
 					show={draftSync.hasDraft}
 					getDeployed={() => draftSync.deployed}
+					reserveSpace={draftSync.hasBaseline}
 					getCurrent={() => draftSync.current}
 					onDiscard={() => draftSync.resetToDeployed(initialPath)}
 					disabled={!can_write}

--- a/frontend/src/lib/components/triggers/useTriggerDraftSync.svelte.ts
+++ b/frontend/src/lib/components/triggers/useTriggerDraftSync.svelte.ts
@@ -49,10 +49,8 @@ export interface TriggerDraftSync {
 	 */
 	readonly hasDraft: boolean
 	/**
-	 * Whether a deployed baseline exists, i.e. the banner *can* toggle on/off
-	 * for this trigger. Reactive (unlike reading `deployed` directly, which the
-	 * editors back with a plain `let`), so the banner can reserve its slot up
-	 * front and keep the "unsaved changes" state from shifting the content below.
+	 * Whether a deployed baseline exists (banner can appear). Reactive, unlike
+	 * reading `deployed` directly (a plain `let`), so callers can reserve its slot.
 	 */
 	readonly hasBaseline: boolean
 	/** The deployed baseline the dirty check compares against. */

--- a/frontend/src/lib/components/triggers/useTriggerDraftSync.svelte.ts
+++ b/frontend/src/lib/components/triggers/useTriggerDraftSync.svelte.ts
@@ -48,6 +48,13 @@ export interface TriggerDraftSync {
 	 * loading and for brand-new triggers (no deployed baseline yet).
 	 */
 	readonly hasDraft: boolean
+	/**
+	 * Whether a deployed baseline exists, i.e. the banner *can* toggle on/off
+	 * for this trigger. Reactive (unlike reading `deployed` directly, which the
+	 * editors back with a plain `let`), so the banner can reserve its slot up
+	 * front and keep the "unsaved changes" state from shifting the content below.
+	 */
+	readonly hasBaseline: boolean
 	/** The deployed baseline the dirty check compares against. */
 	readonly deployed: Cfg | undefined
 	/** The current form config (the live local draft). */
@@ -103,6 +110,10 @@ export function useTriggerDraftSync(opts: TriggerDraftSyncOptions): TriggerDraft
 			opts.deployed() != null &&
 			cfgDiffers(opts.getCfg() as Cfg, opts.deployed() as Cfg)
 	)
+
+	// Reactive "banner is possible" — depends on `drawerLoading()` so it
+	// re-evaluates (and re-reads the plain-`let` baseline) once the load settles.
+	const hasBaseline = $derived(!opts.drawerLoading() && opts.deployed() != null)
 
 	/** `auto: true` marks a discard from the reactive persist-effect (not an
 	 * explicit user action), so it respects the "Enable auto-save" toggle — else
@@ -188,6 +199,9 @@ export function useTriggerDraftSync(opts: TriggerDraftSyncOptions): TriggerDraft
 		},
 		get hasDraft() {
 			return hasDraft
+		},
+		get hasBaseline() {
+			return hasBaseline
 		},
 		get deployed() {
 			return opts.deployed()

--- a/frontend/src/lib/components/triggers/websocket/WebsocketTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/websocket/WebsocketTriggerEditorInner.svelte
@@ -471,6 +471,7 @@
 				<LocalDraftBanner
 					show={draftSync.hasDraft}
 					getDeployed={() => draftSync.deployed}
+					reserveSpace={draftSync.hasBaseline}
 					getCurrent={() => draftSync.current}
 					onDiscard={() => draftSync.resetToDeployed(initialPath)}
 					disabled={!can_write}

--- a/frontend/src/lib/components/triggers/websocket/WebsocketTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/websocket/WebsocketTriggerEditorInner.svelte
@@ -457,6 +457,7 @@
 {#if useDrawer}
 	<Drawer size="800px" bind:this={drawer}>
 		<DrawerContent
+			bannerReserved={draftSync.hasBaseline}
 			title={edit
 				? can_write
 					? `Edit WebSocket trigger ${initialPath}`


### PR DESCRIPTION
## Summary

The shared "You have unsaved changes" banner (`LocalDraftBanner`) previously rendered only when a local draft existed, sliding into place and pushing all content below it down ~36px. This layout shift happens on every first edit and on discard/save, across all editors that use the banner.

This reserves a fixed-height slot for the banner **whenever it can appear** (a deployed baseline exists for the entity being edited) and fades the banner in/out within that slot, so toggling the unsaved state no longer moves the content below. Brand-new entities (no baseline — the banner can never show) reserve nothing, so no gap is added where it isn't needed.

Refinements from review feedback:
- **No border around the empty gap.** The banner sat directly in `DrawerContent`'s `divide-y` stack, so the reserved slot got bracketed by two divider lines (a bordered empty strip). Banner + content now share one `divide-y` cell, so the header keeps its single divider and the gap is clean empty space.
- **Compact slot.** The slot is `h-8` (32px) — just enough for the 28px action buttons plus ~2px so they don't touch the banner edges — so the banner stays compact while the empty gap it leaves when off stays small.
- **Tight top padding.** The content hugs the reserved slot (top padding `pt-1`), so the first field sits right below the banner instead of a full `p-4` gap.

## Changes

- `LocalDraftBanner.svelte`: render the banner inside a fixed `h-8` slot gated on `hasBaseline`; content fades (not slides) in/out. Added optional `reserveSpace` prop; `hasBaseline = reserveSpace ?? getDeployed() != null`.
- `common/drawer/DrawerContent.svelte`: when a `banner` is present, wrap banner + content in a single `divide-y` cell and tighten the content's top padding (content box extracted into a local snippet to avoid duplication).
- `useTriggerDraftSync.svelte.ts`: added a reactive `hasBaseline` (`!drawerLoading() && deployed() != null`) — the trigger/schedule editors back their baseline with a plain non-reactive `let`, so reading `getDeployed()` directly wouldn't re-run reactively.
- All 11 trigger/schedule editors: pass `reserveSpace={draftSync.hasBaseline}`.
- Variable/Resource editors: unchanged call sites — their `getDeployed()` reads `$state`, so the fallback is already reactive.

## Screenshots

For each editor: **clean** (banner off — small clean gap, no border) vs **dirty** (banner fills the same slot, buttons not touching the edges, first field right beneath it). Content stays at the same position — no shift.

**Variable editor**

![variable clean](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/unsaved-banner-preset-height/1782973207-final-variable-clean.png)
![variable dirty](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/unsaved-banner-preset-height/1782973207-final-variable-dirty.png)

**Resource editor**

![resource clean](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/unsaved-banner-preset-height/1782973207-final-resource-clean.png)
![resource dirty](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/unsaved-banner-preset-height/1782973207-final-resource-dirty.png)

**Schedule editor**

![schedule clean](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/unsaved-banner-preset-height/1782973207-final-schedule-clean.png)
![schedule dirty](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/unsaved-banner-preset-height/1782973207-final-schedule-dirty.png)

**New entity (no baseline) — no reserved gap:**

![variable new](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/unsaved-banner-preset-height/1782972055-v2-variable-new.png)

### Coverage note
The banner appears in 13 editors: Variable, Resource, and 11 trigger editors (HTTP route, WebSocket, Postgres, Kafka, NATS, MQTT, SQS, GCP, Azure, Email, Schedule). All render through the same `LocalDraftBanner` + `DrawerContent` wrapper + `useTriggerDraftSync` wiring, so behavior is identical by construction. Live screenshots cover the three reachable on a **CE** dev backend (Variable, Resource, Schedule); the other 10 trigger types are EE-gated (backend endpoints 404 on CE) and can't be exercised on this instance.

## Test plan

- [ ] Existing variable/resource/schedule: edit a field then discard — content below does not jump; no border line boxes the gap; first field sits right under the banner and the banner buttons don't touch its edges.
- [ ] Brand-new entity: no reserved gap is shown.
- [ ] (EE) Existing trigger of each kind: same no-shift, no-border behavior.

---

## Additional cleanup: drop the redundant "Metadata" section title

The "Metadata" section header (wrapping Summary / Path / Description) added no information — the fields are self-evident. Removed it from the Schedule, Email, HTTP-route and Native trigger editors (Section made `headless`). Other section titles (Schedule, …) are kept. (ScriptBuilder also has a redundant "Metadata" section title — deferred to a separate PR.)

![schedule editor without Metadata title](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/unsaved-banner-preset-height/1782973730-meta-schedule.png)

