### PR TITLE
fix(parsers): infer py s3 assets from S3Object constructor and dict forms

### DIFF
--- a/backend/parsers/windmill-parser-py-asset/src/lib.rs
+++ b/backend/parsers/windmill-parser-py-asset/src/lib.rs
@@ -262,6 +262,14 @@ impl AssetsFinder {
         };
 
         match arg_val {
+            // S3 helpers take an `S3Object` (constructor or dict literal) or an
+            // `s3://bucket/key` string. Other helpers take a bare resource-path
+            // string literal.
+            Some(arg) if matches!(kind, AssetKind::S3Object) => {
+                let path = s3_object_arg_path(arg).ok_or(())?;
+                self.assets
+                    .push(ParseAssetsResult { kind, path, access_type, columns: None });
+            }
             Some(Expr::Constant(ExprConstant { value: Constant::Str(value), .. })) => {
                 let path = parse_asset_syntax(&value, false)
                     .map(|(_, p)| p)
@@ -281,6 +289,69 @@ impl AssetsFinder {
 
 // Positional arguments in python can also be used by their name
 struct Arg(usize, &'static str);
+
+/// Extract a string-literal keyword argument, e.g. `s3="value"` in a call.
+fn keyword_str_value(keywords: &[rustpython_ast::Keyword], name: &str) -> Option<String> {
+    keywords
+        .iter()
+        .find(|kw| kw.arg.as_deref() == Some(name))
+        .and_then(|kw| match &kw.value {
+            Expr::Constant(ExprConstant { value: Constant::Str(s), .. }) => Some(s.clone()),
+            _ => None,
+        })
+}
+
+/// Extract a string-literal value from a dict literal, e.g. `{"s3": "value"}`.
+fn dict_str_value(dict: &rustpython_ast::ExprDict, name: &str) -> Option<String> {
+    dict.keys
+        .iter()
+        .zip(dict.values.iter())
+        .find_map(|(key, value)| match (key.as_ref()?, value) {
+            (
+                Expr::Constant(ExprConstant { value: Constant::Str(k), .. }),
+                Expr::Constant(ExprConstant { value: Constant::Str(v), .. }),
+            ) if k.as_str() == name => Some(v.clone()),
+            _ => None,
+        })
+}
+
+/// Resolve the SDK `S3Object` argument of `load_s3_file`/`load_s3_file_reader`/
+/// `write_s3_file` to a canonical asset path, mirroring `windmill-parser-ts-asset`:
+/// `S3Object(s3="<key>", storage="<bucket>"?)` — or the equivalent dict literal —
+/// maps to the URI `s3://<bucket>/<key>` (empty bucket for default storage, i.e.
+/// `s3:///<key>`), and a bare `"s3://bucket/key"` string is passed through.
+/// The resulting URI is fed through `parse_asset_syntax` so the stored path
+/// matches the TS object form and the `# on s3:///…` trigger form exactly.
+fn s3_object_arg_path(expr: &Expr) -> Option<String> {
+    let uri = match expr {
+        Expr::Constant(ExprConstant { value: Constant::Str(s), .. }) => s.clone(),
+        Expr::Call(call) => {
+            // `S3Object(...)` imported directly or as `wmill.S3Object(...)`
+            let func_name = call
+                .func
+                .as_name_expr()
+                .map(|n| n.id.as_str())
+                .or_else(|| call.func.as_attribute_expr().map(|a| a.attr.as_str()))?;
+            if func_name != "S3Object" {
+                return None;
+            }
+            let key = keyword_str_value(&call.keywords, "s3")?;
+            let storage = keyword_str_value(&call.keywords, "storage").unwrap_or_default();
+            format!("s3://{storage}/{key}")
+        }
+        Expr::Dict(dict) => {
+            let key = dict_str_value(dict, "s3")?;
+            let storage = dict_str_value(dict, "storage").unwrap_or_default();
+            format!("s3://{storage}/{key}")
+        }
+        _ => return None,
+    };
+    Some(
+        parse_asset_syntax(&uri, false)
+            .map(|(_, p)| p.to_string())
+            .unwrap_or(uri),
+    )
+}
 
 #[cfg(test)]
 mod tests {
@@ -305,6 +376,162 @@ def main():
                 columns: None,
             },])
         );
+    }
+
+    #[test]
+    fn test_py_asset_parser_write_s3_object_constructor() {
+        // The SDK signature is `write_s3_file(s3object: S3Object | str, ...)` and
+        // its docstring recommends the constructor form with a bare key. It must
+        // resolve to the same canonical path as the TS object form and a
+        // `# on s3:///<key>` trigger.
+        let input = r#"
+import wmill
+from wmill import S3Object
+def main():
+    wmill.write_s3_file(S3Object(s3="analytics/x.csv"), b"content")
+"#;
+        let s = parse_assets(input).map(|o| o.assets);
+        assert_eq!(
+            s.map_err(|e| e.to_string()),
+            Ok(vec![ParseAssetsResult {
+                kind: AssetKind::S3Object,
+                path: "/analytics/x.csv".to_string(),
+                access_type: Some(W),
+                columns: None,
+            },])
+        );
+    }
+
+    #[test]
+    fn test_py_asset_parser_s3_object_with_storage() {
+        // `S3Object(s3=..., storage=...)` maps to `s3://<storage>/<key>`,
+        // matching the `s3://bucket/key` string form and the TS object form.
+        let input = r#"
+import wmill
+from wmill import S3Object
+def main():
+    wmill.load_s3_file(S3Object(s3="dir/in.csv", storage="mybucket"))
+"#;
+        let s = parse_assets(input).map(|o| o.assets);
+        assert_eq!(
+            s.map_err(|e| e.to_string()),
+            Ok(vec![ParseAssetsResult {
+                kind: AssetKind::S3Object,
+                path: "mybucket/dir/in.csv".to_string(),
+                access_type: Some(R),
+                columns: None,
+            },])
+        );
+    }
+
+    #[test]
+    fn test_py_asset_parser_s3_object_reader_and_keyword_arg() {
+        // load_s3_file_reader + passing the S3Object via the `s3object` keyword
+        // and via the `wmill.S3Object` attribute form.
+        let input = r#"
+import wmill
+def main():
+    wmill.load_s3_file_reader(s3object=wmill.S3Object(s3="dir/in.csv"))
+"#;
+        let s = parse_assets(input).map(|o| o.assets);
+        assert_eq!(
+            s.map_err(|e| e.to_string()),
+            Ok(vec![ParseAssetsResult {
+                kind: AssetKind::S3Object,
+                path: "/dir/in.csv".to_string(),
+                access_type: Some(R),
+                columns: None,
+            },])
+        );
+    }
+
+    #[test]
+    fn test_py_asset_parser_s3_object_dict_literal() {
+        // `S3Object` subclasses dict, so the SDK also accepts a plain dict
+        // literal — same resolution as the constructor form.
+        let input = r#"
+import wmill
+def main():
+    wmill.write_s3_file({"s3": "out.json"}, b"{}")
+    wmill.load_s3_file({"s3": "dir/in.csv", "storage": "mybucket"})
+"#;
+        let s = parse_assets(input).map(|o| o.assets);
+        assert_eq!(
+            s.map_err(|e| e.to_string()),
+            Ok(vec![
+                ParseAssetsResult {
+                    kind: AssetKind::S3Object,
+                    path: "/out.json".to_string(),
+                    access_type: Some(W),
+                    columns: None,
+                },
+                ParseAssetsResult {
+                    kind: AssetKind::S3Object,
+                    path: "mybucket/dir/in.csv".to_string(),
+                    access_type: Some(R),
+                    columns: None,
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn test_py_asset_parser_multiple_s3_object_writes() {
+        // Several direct constructor-form writes in main() — all outputs must
+        // be detected (merge_assets returns a deterministic path-sorted order).
+        let input = r#"
+import wmill
+from wmill import S3Object
+def main():
+    wmill.write_s3_file(S3Object(s3="pipelines/km_real/raw_events.json"), b"[]")
+    wmill.write_s3_file(S3Object(s3="pipelines/km_real/enriched.json"), b"[]")
+    wmill.write_s3_file(S3Object(s3="pipelines/km_real/summary.json"), b"[]")
+    wmill.write_s3_file(S3Object(s3="pipelines/km_real/report.json"), b"{}")
+"#;
+        let s = parse_assets(input).map(|o| o.assets);
+        assert_eq!(
+            s.map_err(|e| e.to_string()),
+            Ok(vec![
+                ParseAssetsResult {
+                    kind: AssetKind::S3Object,
+                    path: "/pipelines/km_real/enriched.json".to_string(),
+                    access_type: Some(W),
+                    columns: None,
+                },
+                ParseAssetsResult {
+                    kind: AssetKind::S3Object,
+                    path: "/pipelines/km_real/raw_events.json".to_string(),
+                    access_type: Some(W),
+                    columns: None,
+                },
+                ParseAssetsResult {
+                    kind: AssetKind::S3Object,
+                    path: "/pipelines/km_real/report.json".to_string(),
+                    access_type: Some(W),
+                    columns: None,
+                },
+                ParseAssetsResult {
+                    kind: AssetKind::S3Object,
+                    path: "/pipelines/km_real/summary.json".to_string(),
+                    access_type: Some(W),
+                    columns: None,
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn test_py_asset_parser_s3_object_dynamic_key_no_false_positive() {
+        // A computed key can't be resolved statically — must yield nothing
+        // rather than a bogus path.
+        let input = r#"
+import wmill
+from wmill import S3Object
+def main(name: str):
+    wmill.write_s3_file(S3Object(s3=f"pipelines/{name}.json"), b"{}")
+"#;
+        let s = parse_assets(input).map(|o| o.assets);
+        assert_eq!(s.map_err(|e| e.to_string()), Ok(vec![]));
     }
 
     #[test]

--- a/docs/pipeline-local-dev.md
+++ b/docs/pipeline-local-dev.md
@@ -86,8 +86,12 @@ python3, and SQL dialects all get wasm inference (SQL dialects route to `parse_a
 comment-header annotation scan is dialect-independent). `go`/`bash` have no wasm asset parser, so
 they fall back to a minimal `// pipeline` + `// on` scan (annotation-only). Note inferred asset
 **paths must match exactly** to connect nodes: DuckDB `read_csv('s3://x')` / `COPY ... TO 's3://x'`
-and `// on s3://x` all yield path `x` (no leading slash), whereas TS `writeS3File({s3:"x"})` yields
-`/x` — so an all-DuckDB example connects cleanly; mixing TS-write with annotation-read needs care.
+and `// on s3://x` all yield path `x` (no leading slash), whereas the SDK object forms — TS
+`writeS3File({s3:"x"})` and python `write_s3_file(S3Object(s3="x"))` (or the equivalent dict
+literal), both resolved as `s3://<storage>/<key>` with empty default storage — yield `/x`, matching
+the `// on s3:///x` (triple-slash) annotation form. So an all-DuckDB example connects cleanly, and
+SDK writes connect to `s3:///…` annotations; mixing SDK-write with the no-slash annotation form
+needs care.
 
 ## How to test
 
@@ -147,9 +151,11 @@ http://localhost:3000/pipeline_dev?workspace=<WS>&wm_token=<TOK>&folder=demo_pip
    `startProxyServer` for embedders that need a localhost origin (e.g. Claude Code preview).
 5. **`pipeline dev` editing**: the dev page is view+run only (editing stays in the user's editor).
    If in-browser editing with file round-trip is wanted, mirror flow-dev's `handleFlowRoundTrip`.
-6. **Asset-path normalization**: the TS-write leading-slash vs annotation/DuckDB no-slash mismatch
-   (see Language coverage) is inherited from the wasm/backend inference, not introduced here, but
-   it silently breaks lineage connection across languages — worth normalizing in the parser.
+6. **Asset-path normalization**: partially done — the python parser now resolves the
+   `S3Object(s3=…, storage=…?)` constructor / dict-literal forms to the same canonical path as the
+   TS `{s3, storage}` object form (see Language coverage), so SDK writes and reads connect across
+   ts/python. Still open: the SDK-form leading-slash (`/x`) vs bare-URI no-slash (`x`, DuckDB and
+   `// on s3://x`) mismatch silently breaks lineage across those two conventions.
 
 ## Plan reference
 


### PR DESCRIPTION
## Summary

The python asset parser only inferred s3 assets from **string-literal** arguments to the SDK s3 helpers. The form the SDK docstring itself recommends — `wmill.write_s3_file(S3Object(s3="analytics/x.csv"), content)` — produced **no write edge**, so a python producer script silently showed disconnected from its consumers in the pipeline asset graph (found while dogfooding; tracked in `docs/pipeline-local-dev.md` §Language coverage / TODO 6).

This adds `s3_object_arg_path` to `windmill-parser-py-asset`, mirroring the function of the same name in `windmill-parser-ts-asset`: the `S3Object(s3="<key>", storage="<bucket>"?)` constructor (imported directly or as `wmill.S3Object`) and the equivalent dict literal (`S3Object` subclasses `dict`) resolve to the canonical URI `s3://<storage>/<key>` (empty storage for default → `s3:///<key>`), fed through `parse_asset_syntax`. Same object → same path across languages:

| form | path |
|---|---|
| py `S3Object(s3="key")` / dict `{"s3": "key"}` | `/key` |
| py `S3Object(s3="key", storage="b")` | `b/key` |
| TS `{s3: "key"}` / `{s3: "key", storage: "b"}` | `/key` / `b/key` (unchanged) |
| annotation `# on s3:///key` | `/key` (unchanged) |

Computed keys (f-strings, variables) still yield nothing rather than a bogus path. Bare-string arguments keep their exact previous behavior. Asset inference for ts/py lives only in this Rust wasm parser (frontend and CLI load the same wasm), so there is no TS mirror to keep in lockstep — the existing parser-parity test family covers pipeline *annotations* only.

## Changes

- `backend/parsers/windmill-parser-py-asset/src/lib.rs`: route the s3-helper argument (`load_s3_file`, `load_s3_file_reader`, `write_s3_file`) through a new `s3_object_arg_path` resolver handling string / `S3Object(...)` call / dict-literal forms; add `keyword_str_value` / `dict_str_value` helpers; 6 new unit tests mirroring the TS ones (constructor write, storage keyword, reader + `s3object=` keyword + `wmill.S3Object` attribute form, dict literals, multiple writes, dynamic-key negative).
- `docs/pipeline-local-dev.md`: update §Language coverage path-matching note and TODO 6 (py↔TS S3Object parity done; the SDK-form `/x` vs bare-URI `x` slash divergence remains open).

## End-to-end check

Fixture pipeline (`f/py_s3demo`): python producer `wmill.write_s3_file(S3Object(s3="analytics/x.csv"), ...)`, python consumer `load_s3_file(S3Object(...))`, TS consumer `loadS3File({s3: "analytics/x.csv"})`, consumers annotated `on s3:///analytics/x.csv`. Ran `wmill pipeline show py_s3demo --local` with the CLI loading the wasm.

Before (released `windmill-parser-wasm-asset@1.740.0`) — producer disconnected, flat list:

```
Pipeline f/py_s3demo — 3 scripts · 1 asset

producer

consumer

report
```

After (wasm rebuilt from this branch, swapped into the CLI's node_modules):

```
Pipeline f/py_s3demo — 3 scripts · 1 asset

producer
└─▶ s3:///analytics/x.csv
    ├─ consumer
    └─ report
```

## Test plan

- [x] `cargo test -p windmill-parser-py-asset` — 16 passed (6 new)
- [x] `cargo test -p windmill-parser-ts-asset` — 22 passed (untouched, parity reference)
- [x] `cargo check --features asset-parser` in `windmill-parser-wasm` + full `wasm-pack` release build of the `asset` target
- [x] End-to-end `wmill pipeline show --local` before/after (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Python S3 asset inference so `S3Object(...)` and dict-literal forms in `load_s3_file`, `load_s3_file_reader`, and `write_s3_file` produce correct lineage edges. Aligns Python paths with the TS object form to connect producers and consumers in the pipeline graph.

- **Bug Fixes**
  - Added `s3_object_arg_path` in `windmill-parser-py-asset` to resolve `S3Object(s3, storage?)`, dict `{s3, storage}`, and `s3://...` strings to a canonical `s3://<storage>/<key>` (default storage → `s3:///<key>`), then feed through `parse_asset_syntax`.
  - Preserves existing bare-string handling; ignores dynamic keys to avoid false positives.
  - Added small helpers and 6 tests mirroring TS cases; updated docs to note py↔TS `S3Object` parity and the remaining slash mismatch with bare-URI forms.

<sup>Written for commit 323730e6d0c5571dbcc83f26c609e549f2084b1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

