### PR TITLE
feat(frontend): group compare & deploy items by folder

### DIFF
--- a/frontend/src/lib/components/CompareWorkspaces.svelte
+++ b/frontend/src/lib/components/CompareWorkspaces.svelte
@@ -1028,6 +1028,20 @@
 						</div>
 					</div>
 				{/snippet}
+				{#snippet groupActions(groupItems)}
+					<!-- Conflicts stay visible at the folder level so a group can be
+					     (de)selected without scanning every row for orange badges. -->
+					{@const groupConflicts = groupItems.filter((i) => {
+						const d = i.diff as WorkspaceItemDiff
+						return d.ahead > 0 && d.behind > 0
+					}).length}
+					{#if groupConflicts > 0}
+						<Badge color="orange" size="xs">
+							<AlertTriangle class="w-3 h-3 inline mr-0.5" />
+							{groupConflicts} conflict{groupConflicts !== 1 ? 's' : ''}
+						</Badge>
+					{/if}
+				{/snippet}
 				{#if allCiTests.length > 0}
 					<div class="flex flex-col gap-1.5 mt-3 p-3 border bg-surface-secondary rounded text-xs">
 						<div class="flex items-center gap-1.5 font-semibold text-secondary">

--- a/frontend/src/lib/components/WorkspaceDeployLayout.svelte
+++ b/frontend/src/lib/components/WorkspaceDeployLayout.svelte
@@ -88,7 +88,9 @@
 
 	function groupOf(path: string): Pick<DeployGroup, 'key' | 'label' | 'groupKind'> {
 		const parts = path.split('/')
-		if (parts.length > 2 && (parts[0] === 'f' || parts[0] === 'u')) {
+		// >= 2 so a folder item itself (path `f/<name>`, kind 'folder') lands in
+		// its folder's group next to the items that need it, not in "other".
+		if (parts.length >= 2 && (parts[0] === 'f' || parts[0] === 'u')) {
 			const key = `${parts[0]}/${parts[1]}`
 			return { key, label: key, groupKind: parts[0] === 'f' ? 'folder' : 'user' }
 		}
@@ -182,18 +184,19 @@
 					{#if showGroupHeaders}
 						{@const selectable = groupSelectable(group)}
 						{@const selectedCount = selectable.filter((i) => selectedItems.includes(i.key)).length}
+						<!-- The disabled-state hint lives on the row: a disabled Checkbox is
+						     pointer-events-none, so a title on the input would never show. -->
 						<div
 							class="sticky top-0 z-10 flex items-center gap-2 px-4 py-1.5 bg-surface-secondary border-b first:rounded-t-md"
+							title={selectable.length === 0 ? 'No selectable items in this group' : undefined}
 						>
 							<Checkbox
 								checked={selectable.length > 0 && selectedCount === selectable.length}
 								indeterminate={selectedCount > 0 && selectedCount < selectable.length}
 								disabled={selectable.length === 0}
-								title={selectable.length === 0
-									? 'No selectable items in this group'
-									: selectedCount === selectable.length
-										? `Deselect all in ${group.label}`
-										: `Select all in ${group.label}`}
+								title={selectedCount === selectable.length
+									? `Deselect all in ${group.label}`
+									: `Select all in ${group.label}`}
 								onChange={() => toggleGroup(group)}
 							/>
 							{#if group.groupKind === 'folder'}

--- a/frontend/src/lib/components/WorkspaceDeployLayout.svelte
+++ b/frontend/src/lib/components/WorkspaceDeployLayout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Loader2 } from 'lucide-svelte'
+	import { Folder, Loader2, User } from 'lucide-svelte'
 	import { Badge } from './common'
 	import Checkbox from './common/checkbox/Checkbox.svelte'
 	import Row from './common/table/Row.svelte'
@@ -13,6 +13,14 @@
 		kind: Kind
 		triggerKind?: string
 		[key: string]: unknown
+	}
+
+	interface DeployGroup {
+		/** `f/<folder>` or `u/<user>`; '' for items outside both conventions. */
+		key: string
+		label: string
+		groupKind: 'folder' | 'user' | 'other'
+		items: DeployableItem[]
 	}
 
 	interface Props {
@@ -33,6 +41,9 @@
 		alerts?: Snippet
 		/** Rendered on the right of the "Select all" row (e.g. a filter toggle). */
 		selectAllActions?: Snippet
+		/** Rendered on the right of each folder/user group header — receives the
+		 * group's items so pages can roll up their own badges (e.g. conflicts). */
+		groupActions?: Snippet<[DeployableItem[]]>
 		itemSummary?: Snippet<[DeployableItem]>
 		/** Overrides the secondary path line per item (e.g. to strike a renamed path). */
 		itemPath?: Snippet<[DeployableItem]>
@@ -56,6 +67,7 @@
 		header,
 		alerts,
 		selectAllActions,
+		groupActions,
 		itemSummary,
 		itemPath,
 		itemActions,
@@ -72,6 +84,54 @@
 	// is the default, no modifier needed.
 	function handleSelect(item: DeployableItem) {
 		onToggleItem?.(item)
+	}
+
+	function groupOf(path: string): Pick<DeployGroup, 'key' | 'label' | 'groupKind'> {
+		const parts = path.split('/')
+		if (parts.length > 2 && (parts[0] === 'f' || parts[0] === 'u')) {
+			const key = `${parts[0]}/${parts[1]}`
+			return { key, label: key, groupKind: parts[0] === 'f' ? 'folder' : 'user' }
+		}
+		return { key: '', label: 'other', groupKind: 'other' }
+	}
+
+	let groups = $derived.by((): DeployGroup[] => {
+		const byKey = new Map<string, DeployGroup>()
+		for (const item of items) {
+			const g = groupOf(item.path)
+			let group = byKey.get(g.key)
+			if (!group) {
+				group = { ...g, items: [] }
+				byKey.set(g.key, group)
+			}
+			group.items.push(item)
+		}
+		const rank = { folder: 0, user: 1, other: 2 }
+		return [...byKey.values()].sort(
+			(a, b) => rank[a.groupKind] - rank[b.groupKind] || a.key.localeCompare(b.key)
+		)
+	})
+
+	// A lone catch-all group would just duplicate "Select all" — skip headers then.
+	let showGroupHeaders = $derived(groups.some((g) => g.groupKind !== 'other'))
+
+	// Mirrors the per-row checkbox condition: already-deployed rows keep their
+	// selection frozen, so they don't count toward the group's tri-state.
+	function groupSelectable(group: DeployGroup): DeployableItem[] {
+		return group.items.filter(
+			(i) => selectablePredicate(i) && deploymentStatus[i.key]?.status !== 'deployed'
+		)
+	}
+
+	function toggleGroup(group: DeployGroup) {
+		const selectable = groupSelectable(group)
+		const target = !selectable.every((i) => selectedItems.includes(i.key))
+		// Snapshot which items need flipping before mutating: onToggleItem updates
+		// the parent's selection, which feeds back into `selectedItems` mid-loop.
+		const toToggle = selectable.filter((i) => selectedItems.includes(i.key) !== target)
+		for (const item of toToggle) {
+			onToggleItem?.(item)
+		}
 	}
 </script>
 
@@ -118,70 +178,107 @@
 		<!-- Items list -->
 		<div class="overflow-y-auto">
 			<div class="border rounded-md bg-surface-tertiary">
-				{#each items as item (item.key)}
-					{@const isSelectable = selectablePredicate(item)}
-					{@const isSelected = selectedItems.includes(item.key)}
-					{@const status = deploymentStatus[item.key]}
-					{@const isDeployed = status?.status === 'deployed'}
-					{@const blockedReason =
-						!isSelectable && !isDeployed ? selectBlockedReason?.(item) : undefined}
-
-					<Row
-						isSelectable={isSelectable && !isDeployed}
-						selectDisabledReason={blockedReason}
-						selectOnRowClick={true}
-						alignWithSelectable={true}
-						disabled={blockedReason ? false : !isSelectable}
-						selected={isSelected && !isDeployed}
-						onSelect={() => handleSelect(item)}
-						path={item.kind !== 'resource' &&
-						item.kind !== 'variable' &&
-						item.kind !== 'resource_type'
-							? item.path
-							: ''}
-						marked={undefined}
-						kind={item.kind}
-						triggerKind={item.triggerKind}
-						canFavorite={false}
-						workspaceId=""
-					>
-						{#snippet customSummary()}
-							{#if itemSummary}
-								{@render itemSummary(item)}
-							{:else}
-								{item.path}
+				{#each groups as group (group.key)}
+					{#if showGroupHeaders}
+						{@const selectable = groupSelectable(group)}
+						{@const selectedCount = selectable.filter((i) => selectedItems.includes(i.key)).length}
+						<div
+							class="sticky top-0 z-10 flex items-center gap-2 px-4 py-1.5 bg-surface-secondary border-b first:rounded-t-md"
+						>
+							<Checkbox
+								checked={selectable.length > 0 && selectedCount === selectable.length}
+								indeterminate={selectedCount > 0 && selectedCount < selectable.length}
+								disabled={selectable.length === 0}
+								title={selectable.length === 0
+									? 'No selectable items in this group'
+									: selectedCount === selectable.length
+										? `Deselect all in ${group.label}`
+										: `Select all in ${group.label}`}
+								onChange={() => toggleGroup(group)}
+							/>
+							{#if group.groupKind === 'folder'}
+								<Folder size={14} class="text-tertiary shrink-0" />
+							{:else if group.groupKind === 'user'}
+								<User size={14} class="text-tertiary shrink-0" />
 							{/if}
-						{/snippet}
-						{#snippet pathDisplay()}
-							{#if itemPath}
-								{@render itemPath(item)}
-							{:else}
-								{item.kind !== 'resource' &&
-								item.kind !== 'variable' &&
-								item.kind !== 'resource_type'
-									? item.path
+							<span class="text-xs font-semibold text-secondary truncate">{group.label}</span>
+							<span class="text-2xs text-tertiary whitespace-nowrap">
+								{group.items.length} item{group.items.length !== 1 ? 's' : ''}{selectedCount > 0
+									? ` · ${selectedCount} selected`
 									: ''}
+							</span>
+							{#if groupActions}
+								<div class="ml-auto flex items-center gap-1">
+									{@render groupActions(group.items)}
+								</div>
 							{/if}
-						{/snippet}
-						{#snippet actions()}
-							{#if itemActions}
-								{@render itemActions(item)}
-							{/if}
-							<!-- Deployment status always shown -->
-							{#if status}
-								{#if status.status === 'loading'}
-									<Loader2 class="animate-spin" />
-								{:else if status.status === 'deployed'}
-									<Badge color="green">Deployed</Badge>
-								{:else if status.status === 'failed'}
-									<div class="inline-flex gap-1">
-										<Badge color="red">Failed</Badge>
-										<Tooltip>{status.error}</Tooltip>
-									</div>
+						</div>
+					{/if}
+					{#each group.items as item (item.key)}
+						{@const isSelectable = selectablePredicate(item)}
+						{@const isSelected = selectedItems.includes(item.key)}
+						{@const status = deploymentStatus[item.key]}
+						{@const isDeployed = status?.status === 'deployed'}
+						{@const blockedReason =
+							!isSelectable && !isDeployed ? selectBlockedReason?.(item) : undefined}
+						{@const showPath =
+							item.kind !== 'resource' && item.kind !== 'variable' && item.kind !== 'resource_type'}
+						<!-- The group header already names the folder — the path line only
+						     carries what's below it. -->
+						{@const subPath =
+							group.key && item.path.startsWith(group.key + '/')
+								? item.path.slice(group.key.length + 1)
+								: item.path}
+
+						<Row
+							isSelectable={isSelectable && !isDeployed}
+							selectDisabledReason={blockedReason}
+							selectOnRowClick={true}
+							alignWithSelectable={true}
+							disabled={blockedReason ? false : !isSelectable}
+							selected={isSelected && !isDeployed}
+							onSelect={() => handleSelect(item)}
+							path={showPath ? item.path : ''}
+							marked={undefined}
+							kind={item.kind}
+							triggerKind={item.triggerKind}
+							canFavorite={false}
+							workspaceId=""
+						>
+							{#snippet customSummary()}
+								{#if itemSummary}
+									{@render itemSummary(item)}
+								{:else}
+									{item.path}
 								{/if}
-							{/if}
-						{/snippet}
-					</Row>
+							{/snippet}
+							{#snippet pathDisplay()}
+								{#if itemPath}
+									{@render itemPath(item)}
+								{:else}
+									{showPath ? (showGroupHeaders ? subPath : item.path) : ''}
+								{/if}
+							{/snippet}
+							{#snippet actions()}
+								{#if itemActions}
+									{@render itemActions(item)}
+								{/if}
+								<!-- Deployment status always shown -->
+								{#if status}
+									{#if status.status === 'loading'}
+										<Loader2 class="animate-spin" />
+									{:else if status.status === 'deployed'}
+										<Badge color="green">Deployed</Badge>
+									{:else if status.status === 'failed'}
+										<div class="inline-flex gap-1">
+											<Badge color="red">Failed</Badge>
+											<Tooltip>{status.error}</Tooltip>
+										</div>
+									{/if}
+								{/if}
+							{/snippet}
+						</Row>
+					{/each}
 				{/each}
 			</div>
 		</div>

--- a/frontend/src/lib/components/common/checkbox/Checkbox.svelte
+++ b/frontend/src/lib/components/common/checkbox/Checkbox.svelte
@@ -4,6 +4,9 @@
 	interface Props {
 		/** Controlled checked state. */
 		checked?: boolean
+		/** Tri-state display (e.g. a group header with only part of its items
+		 * selected). Purely visual — `checked` still drives the value. */
+		indeterminate?: boolean
 		disabled?: boolean
 		/** Native title attribute (hover hint). */
 		title?: string | undefined
@@ -15,6 +18,7 @@
 
 	let {
 		checked = false,
+		indeterminate = false,
 		disabled = false,
 		title = undefined,
 		class: className = undefined,
@@ -25,6 +29,7 @@
 <input
 	type="checkbox"
 	{checked}
+	{indeterminate}
 	{disabled}
 	{title}
 	onchange={onChange}

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -641,6 +641,16 @@ const config = {
 				".dark [type='checkbox']:checked": {
 					backgroundImage: `url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e")`
 				},
+				// @tailwindcss/forms draws the indeterminate dash white-on-currentColor,
+				// but the checkbox theme above keeps a white/dark background — so restyle
+				// the dash to match the checkmark's fill in each mode.
+				"[type='checkbox']:indeterminate": {
+					backgroundColor: 'transparent',
+					backgroundImage: `url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='black' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M4 8a1 1 0 011-1h6a1 1 0 110 2H5a1 1 0 01-1-1z'/%3e%3c/svg%3e")`
+				},
+				".dark [type='checkbox']:indeterminate": {
+					backgroundImage: `url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M4 8a1 1 0 011-1h6a1 1 0 110 2H5a1 1 0 01-1-1z'/%3e%3c/svg%3e")`
+				},
 				'input:not(.windmillapp):not(.no-default-style),input[type="text"]:not(.windmillapp):not(.no-default-style),input[type="email"]:not(.windmillapp):not(.no-default-style),input[type="url"]:not(.windmillapp):not(.no-default-style),input[type="password"]:not(.windmillapp):not(.no-default-style),input[type="number"]:not(.windmillapp):not(.no-default-style),input[type="date"]:not(.windmillapp):not(.no-default-style),input[type="datetime-local"]:not(.windmillapp):not(.no-default-style),input[type="month"]:not(.windmillapp):not(.no-default-style),input[type="search"]:not(.windmillapp):not(.no-default-style),input[type="tel"]:not(.windmillapp):not(.no-default-style),input[type="time"]:not(.windmillapp):not(.no-default-style),input[type="week"]:not(.windmillapp):not(.no-default-style),textarea:not(.windmillapp):not(.no-default-style):not(.monaco-mouse-cursor-text),select:not(.windmillapp):not(.no-default-style)':
 					{
 						display: 'block',


### PR DESCRIPTION
## Summary

The Compare & Deploy page rendered all changed items as one flat list, which gets hard to scan and act on once a fork diverges across several folders. Items are now grouped under sticky folder section headers (`f/<folder>`, `u/<user>`, and a catch-all "other" for unprefixed paths like resource types), each with a tri-state checkbox to select/deselect the whole group at once.

Since the grouping lives in the shared `WorkspaceDeployLayout`, the drafts view and the deploy-to-workspace flow get the same treatment for free.

## Changes

- `WorkspaceDeployLayout.svelte`: group items by the first two path segments; folder groups first (alphabetical), then user groups, then "other". Headers are sticky while scrolling and show a tri-state checkbox (all / some / none of the group's *selectable* items — deployed and blocked rows don't count), the group's item + selected counts, and an optional page-provided `groupActions` snippet. Under a header, the default path line shows the path relative to the group (leaf name). Headers are skipped entirely when everything would land in the single catch-all group. Folder items themselves (path `f/<name>`, kind `folder`) group with their folder's contents.
- `CompareWorkspaces.svelte`: uses `groupActions` to roll up a per-folder conflict count badge, so conflicts stay visible at the folder level when bulk-selecting.
- `Checkbox.svelte`: new visual-only `indeterminate` prop.
- `tailwind.config.cjs`: theme-consistent styling for the indeterminate dash — @tailwindcss/forms draws it white-on-currentColor, but Windmill's checkbox theme keeps a white/dark background, so the default dash was invisible (white on white). Now black in light mode / white in dark mode, mirroring the existing `:checked` overrides.

## Screenshots

Deploy direction, everything selected (group headers with counts, folder-level conflict badge, leaf-name path lines):

![deploy-direction-grouped](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/compare-deploy-folder-group/1782978167-deploy-direction-grouped.png)

Partially selected group showing the tri-state dash, plus a folder item (`f/marketing`, kind `folder`) grouped with its contents:

![deploy-direction-indeterminate](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/compare-deploy-folder-group/1782978169-deploy-direction-indeterminate.png)

## Test plan

- [x] `npm run check` — 0 errors
- [x] Manually exercised on a seeded fork comparison (scripts across `f/marketing`, `f/etl`, `u/admin`, with ahead/behind/conflict/new items): groups render in folder→user order with correct counts; group checkbox selects/deselects only selectable rows; indeterminate dash renders after the tailwind fix; global "Select all" and the Deploy button count stay consistent; both deploy and update directions verified
- [x] Folder-kind diff row (`f/marketing`, kind `folder`) groups under its folder header
- [ ] Dark mode: confirm the indeterminate dash renders white (rule mirrors the existing dark `:checked` override)
- [ ] Drafts view (`mode=draft`) with drafts spread across folders shows the same grouping

## Known limitations

- Grouping is single-level: nested subfolder structure (`f/a/b/x`) stays in the item's path line rather than nesting headers.
- The comparison endpoint's item order within a group is preserved as-is; only groups themselves are ordered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Groups Compare & Deploy items by folder and user with sticky headers and tri‑state selection to make large diffs easier to scan and bulk‑select. The same grouping applies to drafts and deploy‑to‑workspace flows via the shared layout.

- **New Features**
  - Group by `f/<folder>`, `u/<user>`, then "other"; headers are sticky and ordered folder → user → other.
  - Tri‑state group checkbox selects only selectable, non‑deployed items; shows item and selected counts.
  - Path lines show the leaf path relative to the group; folder items group with their folder contents.
  - New `groupActions` slot for per‑group UI; used to show a rolled‑up conflict badge in Compare.
  - `Checkbox` adds a visual `indeterminate` prop.

- **Bug Fixes**
  - Make the indeterminate dash visible in both modes by overriding `@tailwindcss/forms` in `tailwind.config.cjs`.
  - Show a proper "no selectable items" hint on group headers when everything inside is blocked.

<sup>Written for commit 9987eeef267a815ff7a63d94d9aa3447c42b6da3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

