### PR TITLE
feat(frontend): pipelines index page and sql editor hint

### DIFF
--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -56,6 +56,7 @@
 		Code,
 		DiffIcon,
 		EllipsisVertical,
+		Network,
 		Plus,
 		Rocket,
 		Settings,
@@ -63,6 +64,9 @@
 		Tag,
 		X
 	} from 'lucide-svelte'
+	import { base } from '$lib/base'
+	import { useLocalStorageValue } from '$lib/svelte5Utils.svelte'
+	import { parsePipelineAnnotations } from './assets/AssetGraph/parsePipelineAnnotations'
 	import DropdownV2 from './DropdownV2.svelte'
 	import { type Item } from '$lib/utils'
 	import { sendUserToast } from '$lib/toast'
@@ -313,6 +317,21 @@
 	})
 
 	const enterpriseLangs = ['bigquery', 'snowflake', 'mssql', 'oracledb']
+
+	// Languages the pipeline editor treats as warehouse/dataset transforms —
+	// the ones where a `-- pipeline` annotation is a natural next step.
+	const pipelineHintLangs = ['duckdb', 'postgresql', 'bigquery', 'snowflake', 'mysql', 'mssql']
+	const pipelineHintDismissed = useLocalStorageValue(
+		'pipelineScriptHintDismissed',
+		false,
+		'boolean'
+	)
+	let showPipelineHint = $derived(
+		!pipelineHintDismissed.val &&
+			(script.kind === 'script' || script.kind === undefined) &&
+			pipelineHintLangs.includes(script.language ?? '') &&
+			!parsePipelineAnnotations(script.content ?? '').inPipeline
+	)
 
 	export function setCode(code: string): void {
 		editor?.setCode(code)
@@ -1992,6 +2011,42 @@
 				/>
 			</div>
 		</div>
+
+		{#if showPipelineHint}
+			<div
+				class="flex items-center gap-2 px-4 py-1 border-y bg-surface-secondary text-xs text-secondary"
+			>
+				<Network size={14} class="shrink-0 text-tertiary" />
+				<span class="truncate">
+					This script can become a data pipeline step: annotate it with
+					<code class="font-mono text-2xs bg-surface px-1 py-0.5 rounded border">-- pipeline</code>
+					and
+					<code class="font-mono text-2xs bg-surface px-1 py-0.5 rounded border">
+						-- materialize
+					</code>
+					to materialize its result, or build it in the
+					<a href="{base}/pipeline" class="text-blue-500 hover:underline">pipeline editor</a>.
+					<a
+						href="https://www.windmill.dev/docs/pipelines"
+						target="_blank"
+						rel="noreferrer"
+						class="text-blue-500 hover:underline"
+					>
+						Learn more
+					</a>
+				</span>
+				<div class="ml-auto shrink-0">
+					<Button
+						iconOnly
+						variant="subtle"
+						unifiedSize="sm"
+						startIcon={{ icon: X }}
+						title="Dismiss pipelines hint"
+						onclick={() => (pipelineHintDismissed.val = true)}
+					/>
+				</div>
+			</div>
+		{/if}
 
 		<ScriptEditor
 			{disableAi}

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineFolderList.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineFolderList.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+	import { userStore, workspaceStore } from '$lib/stores'
+	import { base } from '$lib/base'
+	import { goto } from '$app/navigation'
+	import Button from '$lib/components/common/button/Button.svelte'
+	import FolderPicker from '$lib/components/FolderPicker.svelte'
+	import { AssetService, type ListPipelineFoldersResponse } from '$lib/gen'
+	import { resource } from 'runed'
+	import { ArrowRight, Loader2 } from 'lucide-svelte'
+
+	interface Props {
+		// When provided, the current folder is dropped from the existing list
+		// so users don't "switch" to the folder they're already on.
+		currentFolder?: string | undefined
+		// Carried over to the target URL so switching folders from the
+		// editor keeps the user in edit mode; the default view mode needs
+		// no param.
+		mode?: 'view' | 'edit'
+		// Called right before navigating — lets a wrapping modal close itself.
+		onOpen?: () => void
+	}
+	let { currentFolder = undefined, mode = 'view', onOpen = undefined }: Props = $props()
+
+	let pipelines = resource(
+		() => $workspaceStore,
+		async (ws) => {
+			if (!ws) return [] as ListPipelineFoldersResponse
+			return await AssetService.listPipelineFolders({ workspace: ws })
+		}
+	)
+
+	let pickedFolder = $state('')
+
+	let visiblePipelines = $derived(
+		(pipelines.current ?? []).filter((p) => p.folder !== currentFolder)
+	)
+
+	async function openExistingPipeline(folder: string) {
+		onOpen?.()
+		const modeQuery = mode !== 'view' ? `?mode=${mode}` : ''
+		await goto(`${base}/pipeline/${encodeURIComponent(folder)}${modeQuery}`)
+	}
+
+	async function openPicked() {
+		const name = pickedFolder.trim()
+		if (!name) return
+		await openExistingPipeline(name)
+	}
+</script>
+
+<div class="flex flex-col gap-6 w-full min-w-0">
+	<section class="flex flex-col gap-2">
+		<h3 class="text-xs font-semibold text-secondary uppercase tracking-wide">
+			Existing pipelines
+		</h3>
+		{#if pipelines.loading && !pipelines.current}
+			<div class="text-tertiary text-sm flex items-center gap-2">
+				<Loader2 size={14} class="animate-spin" />
+				Loading…
+			</div>
+		{:else if pipelines.error}
+			<div class="text-red-500 text-sm">Failed: {pipelines.error.message}</div>
+		{:else if visiblePipelines.length === 0}
+			<div class="text-tertiary text-sm">
+				{currentFolder
+					? 'No other pipelines in this workspace.'
+					: 'No pipelines yet. A pipeline is any folder whose scripts carry pipeline annotations.'}
+			</div>
+		{:else}
+			<div class="flex flex-col border rounded-md overflow-hidden max-h-64 overflow-y-auto">
+				{#each visiblePipelines as p (p.folder)}
+					<button
+						type="button"
+						class="flex items-center justify-between px-3 py-2 border-b last:border-b-0 bg-surface hover:bg-surface-hover transition-colors text-left"
+						onclick={() => openExistingPipeline(p.folder)}
+					>
+						<span class="font-mono text-sm">f/{p.folder}</span>
+						<span class="text-2xs text-tertiary">
+							{p.script_count}
+							{p.script_count === 1 ? 'script' : 'scripts'}
+						</span>
+					</button>
+				{/each}
+			</div>
+		{/if}
+	</section>
+
+	{#if !$userStore?.operator}
+		<!-- Operators only view existing pipelines — opening an arbitrary
+		     folder is a build-a-new-pipeline affordance. -->
+		<section class="flex flex-col gap-2">
+			<h3 class="text-xs font-semibold text-secondary uppercase tracking-wide">
+				Pick or create a folder
+			</h3>
+			<div class="flex items-center gap-2">
+				<div class="flex-1 min-w-0">
+					<FolderPicker bind:folderName={pickedFolder} />
+				</div>
+				<Button
+					variant="accent"
+					unifiedSize="sm"
+					disabled={!pickedFolder.trim()}
+					onclick={openPicked}
+					startIcon={{ icon: ArrowRight }}
+				>
+					Open
+				</Button>
+			</div>
+		</section>
+	{/if}
+</div>

--- a/frontend/src/lib/components/assets/AssetGraph/PipelinePickerModal.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelinePickerModal.svelte
@@ -1,13 +1,6 @@
 <script lang="ts">
-	import { userStore, workspaceStore } from '$lib/stores'
-	import { base } from '$lib/base'
-	import { goto } from '$app/navigation'
-	import Button from '$lib/components/common/button/Button.svelte'
-	import FolderPicker from '$lib/components/FolderPicker.svelte'
 	import Modal from '$lib/components/common/modal/Modal.svelte'
-	import { AssetService, type ListPipelineFoldersResponse } from '$lib/gen'
-	import { resource } from 'runed'
-	import { ArrowRight, Loader2 } from 'lucide-svelte'
+	import PipelineFolderList from './PipelineFolderList.svelte'
 
 	interface Props {
 		open: boolean
@@ -20,90 +13,8 @@
 		mode?: 'view' | 'edit'
 	}
 	let { open = $bindable(), currentFolder = undefined, mode = 'view' }: Props = $props()
-
-	let pipelines = resource(
-		() => $workspaceStore,
-		async (ws) => {
-			if (!ws) return [] as ListPipelineFoldersResponse
-			return await AssetService.listPipelineFolders({ workspace: ws })
-		}
-	)
-
-	let pickedFolder = $state('')
-
-	let visiblePipelines = $derived(
-		(pipelines.current ?? []).filter((p) => p.folder !== currentFolder)
-	)
-
-	async function openExistingPipeline(folder: string) {
-		open = false
-		const modeQuery = mode !== 'view' ? `?mode=${mode}` : ''
-		await goto(`${base}/pipeline/${encodeURIComponent(folder)}${modeQuery}`)
-	}
-
-	async function openPicked() {
-		const name = pickedFolder.trim()
-		if (!name) return
-		await openExistingPipeline(name)
-	}
 </script>
 
 <Modal bind:open title="Open a pipeline">
-	<div class="flex flex-col gap-6 w-full min-w-0">
-		{#if visiblePipelines.length > 0 || pipelines.loading}
-			<section class="flex flex-col gap-2">
-				<h3 class="text-xs font-semibold text-secondary uppercase tracking-wide">
-					Existing pipelines
-				</h3>
-				{#if pipelines.loading && !pipelines.current}
-					<div class="text-tertiary text-sm flex items-center gap-2">
-						<Loader2 size={14} class="animate-spin" />
-						Loading…
-					</div>
-				{:else if pipelines.error}
-					<div class="text-red-500 text-sm">Failed: {pipelines.error.message}</div>
-				{:else}
-					<div class="flex flex-col border rounded-md overflow-hidden max-h-64 overflow-y-auto">
-						{#each visiblePipelines as p}
-							<button
-								type="button"
-								class="flex items-center justify-between px-3 py-2 border-b last:border-b-0 bg-surface hover:bg-surface-hover transition-colors text-left"
-								onclick={() => openExistingPipeline(p.folder)}
-							>
-								<span class="font-mono text-sm">f/{p.folder}</span>
-								<span class="text-2xs text-tertiary">
-									{p.script_count}
-									{p.script_count === 1 ? 'script' : 'scripts'}
-								</span>
-							</button>
-						{/each}
-					</div>
-				{/if}
-			</section>
-		{/if}
-
-		{#if !$userStore?.operator}
-			<!-- Operators only view existing pipelines — opening an arbitrary
-			     folder is a build-a-new-pipeline affordance. -->
-			<section class="flex flex-col gap-2">
-				<h3 class="text-xs font-semibold text-secondary uppercase tracking-wide">
-					Pick or create a folder
-				</h3>
-				<div class="flex items-center gap-2">
-					<div class="flex-1 min-w-0">
-						<FolderPicker bind:folderName={pickedFolder} />
-					</div>
-					<Button
-						variant="accent"
-						unifiedSize="sm"
-						disabled={!pickedFolder.trim()}
-						onclick={openPicked}
-						startIcon={{ icon: ArrowRight }}
-					>
-						Open
-					</Button>
-				</div>
-			</section>
-		{/if}
-	</div>
+	<PipelineFolderList {currentFolder} {mode} onOpen={() => (open = false)} />
 </Modal>

--- a/frontend/src/lib/components/sidebar/SidebarContent.svelte
+++ b/frontend/src/lib/components/sidebar/SidebarContent.svelte
@@ -30,6 +30,7 @@
 		HelpCircle,
 		Home,
 		LogOut,
+		Network,
 		Newspaper,
 		Play,
 		Route,
@@ -354,6 +355,13 @@
 			icon: Pyramid,
 			aiId: 'sidebar-menu-link-assets',
 			aiDescription: 'Button to navigate to assets'
+		},
+		{
+			label: 'Pipelines',
+			href: `${base}/pipeline`,
+			icon: Network,
+			aiId: 'sidebar-menu-link-pipelines',
+			aiDescription: 'Button to navigate to data pipelines (alpha feature)'
 		},
 		// Add Tutorials to main menu only if not all completed and not skipped
 		...($tutorialsToDo.length > 0 && !$skippedAll

--- a/frontend/src/lib/components/sidebar/SidebarContent.svelte
+++ b/frontend/src/lib/components/sidebar/SidebarContent.svelte
@@ -30,7 +30,6 @@
 		HelpCircle,
 		Home,
 		LogOut,
-		Network,
 		Newspaper,
 		Play,
 		Route,
@@ -355,13 +354,6 @@
 			icon: Pyramid,
 			aiId: 'sidebar-menu-link-assets',
 			aiDescription: 'Button to navigate to assets'
-		},
-		{
-			label: 'Pipelines',
-			href: `${base}/pipeline`,
-			icon: Network,
-			aiId: 'sidebar-menu-link-pipelines',
-			aiDescription: 'Button to navigate to data pipelines (alpha feature)'
 		},
 		// Add Tutorials to main menu only if not all completed and not skipped
 		...($tutorialsToDo.length > 0 && !$skippedAll

--- a/frontend/src/routes/(root)/(logged)/pipeline/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/+page.svelte
@@ -1,24 +1,20 @@
 <script lang="ts">
 	import { userStore } from '$lib/stores'
-	import Button from '$lib/components/common/button/Button.svelte'
-	import PipelinePickerModal from '$lib/components/assets/AssetGraph/PipelinePickerModal.svelte'
+	import PipelineFolderList from '$lib/components/assets/AssetGraph/PipelineFolderList.svelte'
 	import PipelineAlphaAckModal from '$lib/components/assets/AssetGraph/PipelineAlphaAckModal.svelte'
-	import { ArrowRight, NetworkIcon } from 'lucide-svelte'
+	import { BookOpen, NetworkIcon } from 'lucide-svelte'
 	import { onMount } from 'svelte'
 
 	const ACK_STORAGE_KEY = 'pipeline-alpha-ack'
 
-	// Gate the picker behind a one-time alpha acknowledgement. We read
+	// Gate the index behind a one-time alpha acknowledgement. We read
 	// localStorage in onMount (not at module scope) so SSR doesn't blow up.
 	let ackOpen = $state(false)
-	let pickerOpen = $state(false)
 
 	onMount(() => {
 		const acked =
 			typeof localStorage !== 'undefined' && localStorage.getItem(ACK_STORAGE_KEY) === 'true'
-		if (acked) {
-			pickerOpen = true
-		} else {
+		if (!acked) {
 			ackOpen = true
 		}
 	})
@@ -31,12 +27,11 @@
 			// flows through for this visit, the user just sees the modal again next time.
 		}
 		ackOpen = false
-		pickerOpen = true
 	}
 </script>
 
 <svelte:head>
-	<title>Pipeline editor — Windmill</title>
+	<title>Pipelines — Windmill</title>
 </svelte:head>
 
 <div class="flex flex-col h-full">
@@ -45,28 +40,42 @@
 	>
 		<div class="flex flex-row items-center gap-2">
 			<NetworkIcon size={16} class="text-tertiary shrink-0" />
-			<h1 class="text-sm font-semibold">
-				{$userStore?.operator ? 'Pipelines' : 'Pipeline editor'}
-			</h1>
-			<span class="text-xs text-tertiary">· no folder selected</span>
+			<h1 class="text-sm font-semibold">Pipelines</h1>
+			<span
+				class="text-2xs px-1.5 py-0.5 rounded font-semibold bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
+			>
+				Alpha
+			</span>
 		</div>
 	</div>
 
-	<div class="flex-1 min-h-0 relative bg-surface-secondary">
-		<div class="absolute inset-0 flex flex-col items-center justify-center gap-3 text-tertiary">
-			<NetworkIcon size={32} class="opacity-50" />
-			<span class="text-sm">Pick a folder to open its pipeline.</span>
-			<Button
-				variant="accent"
-				unifiedSize="sm"
-				onclick={() => (pickerOpen = true)}
-				startIcon={{ icon: ArrowRight }}
-			>
-				Choose a folder
-			</Button>
+	<div class="flex-1 min-h-0 overflow-y-auto bg-surface-secondary">
+		<div class="max-w-2xl mx-auto flex flex-col gap-6 px-4 py-8">
+			<div class="flex flex-col gap-2">
+				<h2 class="text-lg font-semibold">Data pipelines</h2>
+				<p class="text-sm text-tertiary">
+					Chain ingestion, transformation and materialization steps into an asset-aware graph.
+					{#if !$userStore?.operator}
+						Each pipeline lives in a folder: open one below, or pick a folder to start a new
+						pipeline.
+					{:else}
+						Open a pipeline below to view its graph and runs.
+					{/if}
+				</p>
+				<a
+					href="https://www.windmill.dev/docs/pipelines"
+					target="_blank"
+					rel="noreferrer"
+					class="text-xs text-blue-500 hover:underline inline-flex items-center gap-1"
+				>
+					<BookOpen size={12} />
+					Pipelines documentation
+				</a>
+			</div>
+
+			<PipelineFolderList />
 		</div>
 	</div>
 </div>
 
 <PipelineAlphaAckModal bind:open={ackOpen} onAck={handleAck} />
-<PipelinePickerModal bind:open={pickerOpen} />


### PR DESCRIPTION
## Summary

The Data Pipelines feature (alpha) is well-presented *inside* the pipeline editor but nearly invisible outside it: `/pipeline` was a picker-modal over an empty canvas, and nothing in the plain script editor hints that `-- pipeline` / `-- materialize` annotations exist. This PR adds those entry points without touching the alpha ack modal (explicitly out of scope — its behavior is preserved unchanged).

## Changes

- **`/pipeline` is now a proper index page** instead of a modal over an empty canvas: title + alpha badge + docs link, inline list of existing pipeline folders (with script counts), and the pick/create-a-folder affordance (hidden for operators, as before). The "Pipelines is in alpha" one-time ack modal still shows on first visit exactly as before.
- **Shared `PipelineFolderList.svelte`**: the picker modal's body was extracted into a reusable component; `PipelinePickerModal.svelte` is now a thin `Modal` wrapper around it and keeps serving the folder-switch flow on `/pipeline/[folder]` (same props: `currentFolder` exclusion, `mode` carry-over).
- **Dismissible pipeline hint in the script editor** (`ScriptBuilder.svelte`): when editing a duckdb/SQL script (`duckdb`, `postgresql`, `bigquery`, `snowflake`, `mysql`, `mssql` — the SQL subset of `PIPELINE_LANGUAGES`) whose header has no `-- pipeline` annotation, a one-line banner below the topbar suggests the annotations and links to the pipeline editor and docs. It disappears live once the annotation is typed, and the X dismisses it permanently (localStorage `pipelineScriptHintDismissed`). It only shows for kind=script, and never inside the pipeline editor (which embeds `ScriptEditor` directly, not `ScriptBuilder`).

A "Pipelines" sidebar nav item was initially included, then removed by request — entry points to `/pipeline` remain the Home rows, the Home "New" menu, the script-editor hint, and the URL.

## Test plan

- [x] `npm run check` — 0 errors
- [x] Playwright (headless, real backend): first visit to `/pipeline` shows the alpha ack modal; after ack, the index lists seeded folders (`f/etl` 2 scripts, `f/analytics` 1 script); clicking one opens `/pipeline/etl`
- [x] Folder-switch modal on `/pipeline/etl` still works and excludes the current folder
- [x] New duckdb script shows the hint banner; typing `-- pipeline` at the top hides it live; undo brings it back; dismiss persists across reload (localStorage `true`)
- [x] No banner for bun scripts, nor for an already-annotated pipeline script
- [ ] Reviewer: sanity-check the hint copy and index page layout

## Screenshots

`/pipeline` index page (new):

![pipeline-index](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/pipelines-nav-discoverability/1782980908-pipeline-index-no-sidebar.png)

Alpha ack modal preserved on first visit:

![pipeline-index-alpha-ack](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/pipelines-nav-discoverability/1782980315-pipeline-index-alpha-ack.png)

Dismissible hint on an un-annotated duckdb script:

![script-editor-pipeline-hint](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/pipelines-nav-discoverability/1782980317-script-editor-pipeline-hint.png)

Folder-switch modal (now a wrapper over the shared list component):

![pipeline-picker-modal](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/pipelines-nav-discoverability/1782980319-pipeline-picker-modal.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)