### PR TITLE
fix: polish pipeline graph view (layout, viewport, minimap, lineage, timestamps)

### DIFF
--- a/backend/parsers/windmill-parser-sql-asset/src/asset_parser.rs
+++ b/backend/parsers/windmill-parser-sql-asset/src/asset_parser.rs
@@ -745,12 +745,15 @@ impl Visitor for AssetCollector {
                     if let Some(asset) = self.get_s3_asset_from_str_literal_table(table_factor) {
                         self.assets.push(asset);
                     }
-                    // Avoid Table Functions
-                    self.handle_obj_name_pre(name);
-                } else if let Some(asset) = self.get_s3_asset_from_table_function(table_factor) {
-                    // read_csv/read_parquet/read_json('s3:///…') likewise.
-                    self.assets.push(asset);
                 }
+                // For a read-function table factor this pushes ReadFn, making
+                // every literal inside its arguments a definitive read — the
+                // direct form (read_csv('s3:///…')) but also list and named
+                // arguments (read_parquet(['s3:///…'])). Must run for BOTH the
+                // plain-table and table-function branches: post_visit_table_factor
+                // pops via handle_obj_name_post unconditionally, so skipping the
+                // push here would unbalance the stack.
+                self.handle_obj_name_pre(name);
             }
             _ => {}
         }
@@ -1216,6 +1219,51 @@ mod tests {
                 access_type: Some(RW),
                 columns: None
             }])
+        );
+    }
+
+    #[test]
+    fn test_read_fn_list_arg_plus_copy_stays_rw() {
+        // read_parquet's list form is as definitive as the direct literal —
+        // it must not be demoted to a weak mention when the file is rewritten.
+        let input = r#"
+            CREATE TABLE tmp AS SELECT * FROM read_parquet(['s3:///data.parquet']);
+            COPY (SELECT * FROM tmp) TO 's3:///data.parquet';
+        "#;
+        let s = parse_assets(input).map(|s| s.assets);
+        assert_eq!(
+            s.map_err(|e| e.to_string()),
+            Ok(vec![ParseAssetsResult {
+                kind: AssetKind::S3Object,
+                path: "/data.parquet".to_string(),
+                access_type: Some(RW),
+                columns: None
+            }])
+        );
+    }
+
+    #[test]
+    fn test_read_fn_list_arg_multiple_files_are_reads() {
+        let input = r#"
+            SELECT * FROM read_parquet(['s3:///a.parquet', 's3:///b.parquet']);
+        "#;
+        let s = parse_assets(input).map(|s| s.assets);
+        assert_eq!(
+            s.map_err(|e| e.to_string()),
+            Ok(vec![
+                ParseAssetsResult {
+                    kind: AssetKind::S3Object,
+                    path: "/a.parquet".to_string(),
+                    access_type: Some(R),
+                    columns: None
+                },
+                ParseAssetsResult {
+                    kind: AssetKind::S3Object,
+                    path: "/b.parquet".to_string(),
+                    access_type: Some(R),
+                    columns: None
+                }
+            ])
         );
     }
 

--- a/backend/parsers/windmill-parser-sql-asset/src/asset_parser.rs
+++ b/backend/parsers/windmill-parser-sql-asset/src/asset_parser.rs
@@ -83,18 +83,56 @@ pub fn parse_assets(input: &str) -> anyhow::Result<ParseAssetsOutput> {
     // Body-inferred column lineage, with `// column` annotations taking
     // precedence per output column (explicit declaration overrides inference).
     pipeline.column_lineage = merge_column_lineage(inferred, pipeline.column_lineage);
-    Ok(ParseAssetsOutput::new(
-        merge_assets(collector.assets),
-        Vec::new(),
-        pipeline,
-    ))
+    // A bare string literal in query position is only weak read evidence: a
+    // summary `SELECT 's3:///out.csv' AS target` after `COPY … TO
+    // 's3:///out.csv'` must not turn the write into rw (which draws a
+    // spurious read edge and an asset⇄script cycle in the pipeline graph).
+    // Surface weak reads only for assets with no other recorded usage, so a
+    // path that is *merely* mentioned still shows up linked to the script.
+    let mut assets = merge_assets(collector.assets);
+    for weak in merge_assets(collector.weak_string_reads) {
+        if !assets
+            .iter()
+            .any(|a| a.kind == weak.kind && a.path == weak.path)
+        {
+            assets.push(weak);
+        }
+    }
+    assets.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(ParseAssetsOutput::new(assets, Vec::new(), pipeline))
+}
+
+/// Provenance of the innermost access context. The access type alone can't
+/// tell a definitive read apart from a mere mention: a bare string literal in
+/// generic query position (`QueryRead`) is only *weak* read evidence — e.g. a
+/// summary `SELECT 's3:///out.csv' AS target` echoing a path — while the same
+/// literal as a read-function argument or a `COPY` target is definitive.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AccessCtx {
+    QueryRead,
+    ReadFn,
+    CopyWrite,
+}
+
+impl AccessCtx {
+    fn access_type(self) -> AssetUsageAccessType {
+        match self {
+            AccessCtx::QueryRead | AccessCtx::ReadFn => R,
+            AccessCtx::CopyWrite => W,
+        }
+    }
 }
 
 /// Visitor that collects S3 asset literals from SQL statements
 struct AssetCollector {
     assets: Vec<ParseAssetsResult>,
-    // e.g set to Read when we are inside a SELECT ... FROM ... statement
-    current_access_type_stack: Vec<AssetUsageAccessType>,
+    // Bare string literals seen in generic query position — weak read
+    // evidence, surfaced by `parse_assets` only when the script has no other
+    // recorded usage of the same asset (a real write must not gain a spurious
+    // read edge from a mention).
+    weak_string_reads: Vec<ParseAssetsResult>,
+    // e.g set to QueryRead when we are inside a SELECT ... FROM ... statement
+    current_access_type_stack: Vec<AccessCtx>,
     // e.g ATTACH 'ducklake://a' AS dl; => { "dl": (Ducklake, "a") }
     var_identifiers: BTreeMap<String, (AssetKind, String)>,
     // e.g USE dl;
@@ -119,6 +157,7 @@ impl AssetCollector {
     fn new() -> Self {
         Self {
             assets: Vec::new(),
+            weak_string_reads: Vec::new(),
             current_access_type_stack: Vec::with_capacity(8),
             var_identifiers: BTreeMap::new(),
             currently_used_asset: None,
@@ -162,7 +201,11 @@ impl AssetCollector {
         name: &ObjectName,
         access_type: Option<AssetUsageAccessType>,
     ) -> Option<ParseAssetsResult> {
-        let access_type = access_type.or_else(|| self.current_access_type_stack.last().copied());
+        let access_type = access_type.or_else(|| {
+            self.current_access_type_stack
+                .last()
+                .map(|c| c.access_type())
+        });
         if let Some((kind, path)) = &self.currently_used_asset {
             // We don't want to infer that any simple identifier refers to an asset if
             // we are not in a known R/W context
@@ -301,12 +344,18 @@ impl AssetCollector {
         // Check if the string matches our asset syntax patterns
         if let Some((kind, path)) = parse_asset_syntax(s, false) {
             if kind == AssetKind::S3Object {
-                self.assets.push(ParseAssetsResult {
+                let ctx = self.current_access_type_stack.last().copied();
+                let result = ParseAssetsResult {
                     kind,
                     path: path.to_string(),
-                    access_type: self.current_access_type_stack.last().copied(),
+                    access_type: ctx.map(AccessCtx::access_type),
                     columns: None,
-                });
+                };
+                if ctx == Some(AccessCtx::QueryRead) {
+                    self.weak_string_reads.push(result);
+                } else {
+                    self.assets.push(result);
+                }
             }
         }
     }
@@ -314,7 +363,7 @@ impl AssetCollector {
     fn handle_obj_name_pre(&mut self, name: &ObjectName) {
         if let Some(fname) = get_trivial_obj_name(name) {
             if is_read_fn(fname) {
-                self.current_access_type_stack.push(R);
+                self.current_access_type_stack.push(AccessCtx::ReadFn);
             }
         }
         if let Some(str_lit) = get_str_lit_from_obj_name(name) {
@@ -691,8 +740,16 @@ impl Visitor for AssetCollector {
         match table_factor {
             TableFactor::Table { name, args, .. } => {
                 if args.is_none() {
+                    // FROM 's3:///…' is a definitive read — record it directly
+                    // so it isn't demoted to a weak in-query mention.
+                    if let Some(asset) = self.get_s3_asset_from_str_literal_table(table_factor) {
+                        self.assets.push(asset);
+                    }
                     // Avoid Table Functions
                     self.handle_obj_name_pre(name);
+                } else if let Some(asset) = self.get_s3_asset_from_table_function(table_factor) {
+                    // read_csv/read_parquet/read_json('s3:///…') likewise.
+                    self.assets.push(asset);
                 }
             }
             _ => {}
@@ -718,6 +775,13 @@ impl Visitor for AssetCollector {
             }
             Expr::Value(ValueWithSpan { value: Value::DoubleQuotedString(s), .. }) => {
                 self.handle_string_literal(s);
+            }
+            // Read-function call in expression position: its argument literals
+            // are definitive reads. Balances the pop in `post_visit_expr`.
+            Expr::Function(func) => {
+                if get_trivial_obj_name(&func.name).is_some_and(is_read_fn) {
+                    self.current_access_type_stack.push(AccessCtx::ReadFn);
+                }
             }
             _ => {}
         }
@@ -946,7 +1010,7 @@ impl Visitor for AssetCollector {
             }
 
             sqlparser::ast::Statement::Copy { target: CopyTarget::File { filename }, .. } => {
-                self.current_access_type_stack.push(W);
+                self.current_access_type_stack.push(AccessCtx::CopyWrite);
                 self.handle_string_literal(filename);
                 self.current_access_type_stack.pop();
             }
@@ -1013,7 +1077,7 @@ impl Visitor for AssetCollector {
         &mut self,
         query: &sqlparser::ast::Query,
     ) -> std::ops::ControlFlow<Self::Break> {
-        self.current_access_type_stack.push(R);
+        self.current_access_type_stack.push(AccessCtx::QueryRead);
         self.cte_name_stack.push(collect_cte_names(query));
         std::ops::ControlFlow::Continue(())
     }
@@ -1095,6 +1159,82 @@ mod tests {
                     columns: None
                 },
             ])
+        );
+    }
+
+    #[test]
+    fn test_copy_target_echoed_in_select_stays_write_only() {
+        // The trailing summary SELECT merely mentions the COPY target — it
+        // must not add a read (rw would draw an asset⇄script cycle).
+        let input = r#"
+            COPY (SELECT 1 AS x) TO 's3:///out.csv';
+            SELECT 's3:///out.csv' AS target, 42 AS rows_written;
+        "#;
+        let s = parse_assets(input).map(|s| s.assets);
+        assert_eq!(
+            s.map_err(|e| e.to_string()),
+            Ok(vec![ParseAssetsResult {
+                kind: AssetKind::S3Object,
+                path: "/out.csv".to_string(),
+                access_type: Some(W),
+                columns: None
+            }])
+        );
+    }
+
+    #[test]
+    fn test_bare_string_mention_without_other_usage_is_a_read() {
+        let input = r#"
+            SELECT 's3:///referenced.csv' AS path;
+        "#;
+        let s = parse_assets(input).map(|s| s.assets);
+        assert_eq!(
+            s.map_err(|e| e.to_string()),
+            Ok(vec![ParseAssetsResult {
+                kind: AssetKind::S3Object,
+                path: "/referenced.csv".to_string(),
+                access_type: Some(R),
+                columns: None
+            }])
+        );
+    }
+
+    #[test]
+    fn test_self_refresh_read_fn_plus_copy_stays_rw() {
+        // A definitive read (read_csv) of the same file the script rewrites
+        // is a real rw — only *bare-literal* mentions are demoted.
+        let input = r#"
+            CREATE TABLE tmp AS SELECT * FROM read_csv('s3:///data.csv');
+            COPY (SELECT * FROM tmp) TO 's3:///data.csv';
+        "#;
+        let s = parse_assets(input).map(|s| s.assets);
+        assert_eq!(
+            s.map_err(|e| e.to_string()),
+            Ok(vec![ParseAssetsResult {
+                kind: AssetKind::S3Object,
+                path: "/data.csv".to_string(),
+                access_type: Some(RW),
+                columns: None
+            }])
+        );
+    }
+
+    #[test]
+    fn test_from_string_literal_of_written_file_stays_rw() {
+        // FROM-position string literal is likewise a definitive read.
+        let input = r#"
+            CREATE TABLE tmp AS SELECT * FROM 's3:///data.parquet';
+            COPY (SELECT * FROM tmp) TO 's3:///data.parquet';
+        "#;
+        let s = parse_assets(input).map(|s| s.assets);
+        assert_eq!(
+            s.map_err(|e| e.to_string()),
+            Ok(vec![ParseAssetsResult {
+                kind: AssetKind::S3Object,
+                path: "/data.parquet".to_string(),
+                access_type: Some(RW),
+                columns: None
+            }])
         );
     }
 

--- a/backend/windmill-duckdb-ffi-internal/src/lib.rs
+++ b/backend/windmill-duckdb-ffi-internal/src/lib.rs
@@ -635,7 +635,9 @@ fn duckdb_value_to_json_value(
                 .ok_or_else(|| "Could not convert to f64".to_string())?,
         ),
         duckdb::types::Value::Decimal(d) => serde_json::Value::String(d.to_string()),
-        duckdb::types::Value::Timestamp(_, ts) => serde_json::Value::String(ts.to_string()),
+        duckdb::types::Value::Timestamp(unit, ts) => {
+            serde_json::Value::String(duckdb_timestamp_to_iso(unit, ts))
+        }
         duckdb::types::Value::Text(s) if type_alias.as_deref().unwrap_or_default() == "JSON" => {
             serde_json::from_str(&s)
                 .map_err(|e| format!("Error parsing JSON text: {}", e.to_string()))?
@@ -646,8 +648,15 @@ fn duckdb_value_to_json_value(
                 .map(|byte| serde_json::Value::Number(byte.into()))
                 .collect(),
         ),
-        duckdb::types::Value::Date32(d) => serde_json::Value::Number(d.into()),
-        duckdb::types::Value::Time64(_, t) => serde_json::Value::String(t.to_string()),
+        duckdb::types::Value::Date32(d) => {
+            match chrono::DateTime::from_timestamp(i64::from(d) * 86_400, 0) {
+                Some(dt) => serde_json::Value::String(dt.date_naive().to_string()),
+                None => serde_json::Value::Number(d.into()),
+            }
+        }
+        duckdb::types::Value::Time64(unit, t) => {
+            serde_json::Value::String(duckdb_time_to_iso(unit, t).unwrap_or_else(|| t.to_string()))
+        }
         duckdb::types::Value::Interval { months, days, nanos } => serde_json::json!({
             "months": months,
             "days": days,
@@ -686,6 +695,105 @@ fn duckdb_value_to_json_value(
         duckdb::types::Value::Union(value) => serde_json::Value::String(format!("{:?}", *value)),
     };
     Ok(json_value)
+}
+
+// DuckDB surfaces TIMESTAMP[_S/_MS/_NS] values as a raw count since the epoch;
+// stringifying that count leaks values like "1782974022218435" into job
+// results. Render ISO-8601 instead (the Postgres executor's
+// "2024-01-15T10:30:00" shape); a count outside chrono's representable range
+// falls back to the raw number.
+fn duckdb_timestamp_to_iso(unit: duckdb::types::TimeUnit, ts: i64) -> String {
+    let dt = match unit {
+        duckdb::types::TimeUnit::Second => chrono::DateTime::from_timestamp(ts, 0),
+        duckdb::types::TimeUnit::Millisecond => chrono::DateTime::from_timestamp_millis(ts),
+        duckdb::types::TimeUnit::Microsecond => chrono::DateTime::from_timestamp_micros(ts),
+        duckdb::types::TimeUnit::Nanosecond => Some(chrono::DateTime::from_timestamp_nanos(ts)),
+    };
+    dt.map(|dt| dt.naive_utc().format("%Y-%m-%dT%H:%M:%S%.f").to_string())
+        .unwrap_or_else(|| ts.to_string())
+}
+
+// Same story for TIME: a raw count since midnight. None when out of range
+// (caller falls back to the raw number).
+fn duckdb_time_to_iso(unit: duckdb::types::TimeUnit, t: i64) -> Option<String> {
+    let (secs, nanos) = match unit {
+        duckdb::types::TimeUnit::Second => (t, 0),
+        duckdb::types::TimeUnit::Millisecond => (t / 1_000, (t % 1_000) * 1_000_000),
+        duckdb::types::TimeUnit::Microsecond => (t / 1_000_000, (t % 1_000_000) * 1_000),
+        duckdb::types::TimeUnit::Nanosecond => (t / 1_000_000_000, t % 1_000_000_000),
+    };
+    chrono::NaiveTime::from_num_seconds_from_midnight_opt(
+        u32::try_from(secs).ok()?,
+        u32::try_from(nanos).ok()?,
+    )
+    .map(|t| t.format("%H:%M:%S%.f").to_string())
+}
+
+#[cfg(test)]
+mod temporal_json_tests {
+    use super::*;
+    use duckdb::types::TimeUnit;
+
+    #[test]
+    fn timestamp_micros_renders_iso() {
+        // 2026-07-01 23:13:42.218435 UTC
+        assert_eq!(
+            duckdb_timestamp_to_iso(TimeUnit::Microsecond, 1_782_947_622_218_435),
+            "2026-07-01T23:13:42.218435"
+        );
+    }
+
+    #[test]
+    fn timestamp_seconds_renders_iso_without_subseconds() {
+        assert_eq!(
+            duckdb_timestamp_to_iso(TimeUnit::Second, 1_735_689_600),
+            "2025-01-01T00:00:00"
+        );
+    }
+
+    #[test]
+    fn out_of_range_timestamp_falls_back_to_raw() {
+        assert_eq!(
+            duckdb_timestamp_to_iso(TimeUnit::Second, i64::MAX),
+            i64::MAX.to_string()
+        );
+    }
+
+    #[test]
+    fn time_micros_renders_iso() {
+        assert_eq!(
+            duckdb_time_to_iso(TimeUnit::Microsecond, 37_800_500_000).as_deref(),
+            Some("10:30:00.500")
+        );
+    }
+
+    #[test]
+    fn temporal_values_render_iso_through_real_query() {
+        let conn = duckdb::Connection::open_in_memory().unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT TIMESTAMP '2026-07-01 23:13:42.218435' AS ts,
+                        TIMESTAMPTZ '2026-07-01 23:13:42+00' AS tstz,
+                        TIMESTAMP_NS '2026-07-01 23:13:42.218435678' AS ts_ns,
+                        DATE '2026-07-01' AS d,
+                        TIME '10:30:00' AS t",
+            )
+            .unwrap();
+        let mut rows = stmt.query([]).unwrap();
+        let row = rows.next().unwrap().unwrap();
+        let json_of = |i: usize| {
+            let v: duckdb::types::Value = row.get(i).unwrap();
+            duckdb_value_to_json_value(v, &None).unwrap()
+        };
+        assert_eq!(json_of(0), serde_json::json!("2026-07-01T23:13:42.218435"));
+        assert_eq!(json_of(1), serde_json::json!("2026-07-01T23:13:42"));
+        assert_eq!(
+            json_of(2),
+            serde_json::json!("2026-07-01T23:13:42.218435678")
+        );
+        assert_eq!(json_of(3), serde_json::json!("2026-07-01"));
+        assert_eq!(json_of(4), serde_json::json!("10:30:00"));
+    }
 }
 
 fn json_value_to_duckdb_value(

--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
@@ -16,6 +16,7 @@
 	import DataTestNode from './DataTestNode.svelte'
 	import AssetGraphEdge from './AssetGraphEdge.svelte'
 	import PanToNode from './PanToNode.svelte'
+	import InitialFitView from './InitialFitView.svelte'
 	import { layoutAssetGraph } from './assetGraphLayout'
 	import { buildDownstreamMap } from './graphTraversal'
 	import { buildLineageDownstreamMap } from './boundedCascade'
@@ -162,6 +163,10 @@
 		/** Hide the minimap when the canvas is too narrow for it to be worth the
 		 * space (e.g. stacked layout in a side panel). Defaults to shown. */
 		showMinimap?: boolean
+		/** Identity of the displayed graph (e.g. the pipeline folder). The
+		 * initial viewport fit re-arms when it changes, so switching folders
+		 * in-place gets a fresh fit. */
+		viewportFitKey?: string
 	}
 	let {
 		graph,
@@ -188,7 +193,8 @@
 		onStartBoundedRun,
 		boundPick,
 		onPickEnd,
-		showMinimap = true
+		showMinimap = true,
+		viewportFitKey = ''
 	}: Props = $props()
 
 	// `${kind}:${path}` ids for the hovered / pinned runs (both script and flow
@@ -1039,6 +1045,7 @@
 		--background-color={false}
 	>
 		<div class="absolute inset-0 !bg-surface-secondary h-full"></div>
+		<InitialFitView {nodes} fitKey={viewportFitKey} />
 		<PanToNode targetId={panToNodeId} {nodes} />
 		<Controls position="top-right" orientation="horizontal" showLock={false} class="!mr-10" />
 		{#if showMinimap}

--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
@@ -1049,18 +1049,31 @@
 		<PanToNode targetId={panToNodeId} {nodes} />
 		<Controls position="top-right" orientation="horizontal" showLock={false} class="!mr-10" />
 		{#if showMinimap}
+			<!-- Node hues mirror the canvas: blue asset cards, amber triggers,
+			     bordered neutral script cards. Visible strokes + rounded corners +
+			     a bordered container + the outlined viewport mask are what make
+			     this read as a minimap instead of a loading skeleton. -->
 			<MiniMap
 				pannable
 				zoomable
-				class="!bg-surface !mb-10"
+				class="!bg-surface !mb-10 rounded-md border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden"
+				nodeBorderRadius={12}
+				nodeStrokeWidth={6}
 				nodeColor={(n) =>
 					n.type === 'asset'
-						? 'rgb(96 165 250 / 0.5)'
+						? 'rgb(59 130 246 / 0.3)'
 						: n.type === 'trigger'
-							? 'rgb(251 191 36 / 0.5)'
-							: 'rgb(52 211 153 / 0.5)'}
-				nodeStrokeColor="transparent"
-				maskColor="rgb(0 0 0 / 0.2)"
+							? 'rgb(245 158 11 / 0.3)'
+							: 'rgb(148 163 184 / 0.15)'}
+				nodeStrokeColor={(n) =>
+					n.type === 'asset'
+						? 'rgb(59 130 246 / 0.8)'
+						: n.type === 'trigger'
+							? 'rgb(245 158 11 / 0.8)'
+							: 'rgb(100 116 139 / 0.7)'}
+				maskColor="rgb(100 116 139 / 0.12)"
+				maskStrokeColor="rgb(59 130 246 / 0.5)"
+				maskStrokeWidth={4}
 			/>
 		{/if}
 	</SvelteFlow>

--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
@@ -677,11 +677,27 @@
 	// edges + paths → same layout. Renames *do* change the layout for
 	// the renamed entry, since its id moves in the sort, but that's
 	// expected: a rename is a path change, which is part of the input.
+	// A script with rw access to an asset yields both a write (script → asset)
+	// and a read/trigger (asset → script) edge — a 2-cycle. The layout resolves
+	// it producer-above-asset by omitting the backward direction from its
+	// input; the rendered edges are untouched (both arrows still drawn).
+	let writeEdgePairs = $derived(
+		new Set(
+			model.edges.filter((e) => e.kind === 'lineage-write').map((e) => `${e.source}\n${e.target}`)
+		)
+	)
 	let layoutInput = $derived({
 		nodes: model.nodes
 			.map((n) => ({ id: n.id, data: n.data }))
 			.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)),
 		edges: model.edges
+			.filter(
+				(e) =>
+					!(
+						(e.kind === 'lineage-read' || e.kind === 'trigger-asset') &&
+						writeEdgePairs.has(`${e.target}\n${e.source}`)
+					)
+			)
 			.map((e) => ({ source: e.source, target: e.target }))
 			.sort((a, b) =>
 				a.source === b.source

--- a/frontend/src/lib/components/assets/AssetGraph/InitialFitView.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/InitialFitView.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import { useNodesInitialized, useSvelteFlow, type Node } from '@xyflow/svelte'
+
+	// One-shot initial fit of the viewport to the laid-out graph. The graph
+	// arrives async after the canvas mounts (the first render often holds only
+	// the + node), so SvelteFlow's own init-time `fitView` prop would fit the
+	// wrong content — instead wait for the first real node set to be measured.
+	// `maxZoom: 1` means small graphs are centered at natural scale and only
+	// oversized ones zoom out. Lives inside <SvelteFlow> so useSvelteFlow()
+	// has the flow context (same pattern as PanToNode).
+	//
+	// `fitKey` re-arms the fit when it changes: the in-app folder switcher
+	// swaps the whole graph without remounting the canvas, and the new
+	// pipeline deserves its own initial fit.
+	let { nodes, fitKey = '' }: { nodes: Node[]; fitKey?: string } = $props()
+
+	const { fitView } = useSvelteFlow()
+	const nodesInitialized = useNodesInitialized()
+
+	let fittedFor: string | undefined = $state(undefined)
+	$effect(() => {
+		if (fittedFor === fitKey) return
+		// useNodesInitialized flips false while any node is unmeasured, so by
+		// the time it's true again the fresh nodes have real dimensions.
+		if (!nodesInitialized.current) return
+		if (!nodes.some((n) => n.type !== 'add')) return
+		fittedFor = fitKey
+		void fitView({ padding: 0.1, maxZoom: 1 })
+	})
+</script>

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineGraphEditor.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineGraphEditor.svelte
@@ -31,6 +31,7 @@
 		mode,
 		workspace,
 		folder,
+		viewportFitKey = undefined,
 		stackBelow = 680,
 		persistDrafts = false,
 		pathPrefix,
@@ -95,6 +96,13 @@
 		workspace: string | undefined
 		/** Folder the pipeline is scoped to — drives the autosave draft path. */
 		folder: string
+		/** Folder whose graph is actually *loaded* (not the route param). On an
+		 * in-place folder switch the stale graph stays rendered while the new
+		 * fetch is in flight, so keying the canvas's one-shot initial fit on
+		 * `folder` would consume the new folder's fit on the old graph. Pages
+		 * that stale-while-revalidate should pass the folder captured when the
+		 * fetch resolved; defaults to `folder`. */
+		viewportFitKey?: string
 		/** Below this container width (px) the graph/details split stacks
 		 * vertically instead of side-by-side — for narrow side panels / AI
 		 * session previews. Defaults to 680. */
@@ -433,7 +441,7 @@
 					{onPickEnd}
 					{panToNodeId}
 					showMinimap={!stacked}
-					viewportFitKey={folder}
+					viewportFitKey={viewportFitKey ?? folder}
 				/>
 				{#if boundBar}{@render boundBar()}{/if}
 				{#if mode === 'edit'}

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineGraphEditor.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineGraphEditor.svelte
@@ -433,6 +433,7 @@
 					{onPickEnd}
 					{panToNodeId}
 					showMinimap={!stacked}
+					viewportFitKey={folder}
 				/>
 				{#if boundBar}{@render boundBar()}{/if}
 				{#if mode === 'edit'}

--- a/frontend/src/lib/components/assets/AssetGraph/assetGraphLayout.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/assetGraphLayout.test.ts
@@ -38,7 +38,14 @@ describe('layoutAssetGraph (tidy-tree with join breaks)', () => {
 		// stays strictly left of every node of the right branch.
 		const pos = layoutAssetGraph({
 			nodes: [n('root'), n('a'), n('b'), n('a1'), n('a2'), n('a3'), n('b1')],
-			edges: [e('root', 'a'), e('root', 'b'), e('a', 'a1'), e('a', 'a2'), e('a', 'a3'), e('b', 'b1')]
+			edges: [
+				e('root', 'a'),
+				e('root', 'b'),
+				e('a', 'a1'),
+				e('a', 'a2'),
+				e('a', 'a3'),
+				e('b', 'b1')
+			]
 		})
 		const leftMax = Math.max(...['a', 'a1', 'a2', 'a3'].map((id) => pos.get(id)!.x))
 		const rightMin = Math.min(...['b', 'b1'].map((id) => pos.get(id)!.x))
@@ -83,14 +90,37 @@ describe('layoutAssetGraph (tidy-tree with join breaks)', () => {
 		}
 	})
 
-	it('falls back to a grid on cyclic input', () => {
+	it('lays a 2-cycle out as a chain (feedback edge dropped, no grid)', () => {
 		const pos = layoutAssetGraph({
 			nodes: [n('a'), n('b')],
 			edges: [e('a', 'b'), e('b', 'a')]
 		})
-		expect(pos.size).toBe(2)
-		expect(pos.get('a')).toBeDefined()
-		expect(pos.get('b')).toBeDefined()
+		// First-in-input wins the top slot; the b→a feedback edge is ignored.
+		expect(pos.get('a')!.y).toBeLessThan(pos.get('b')!.y)
+		expect(pos.get('a')!.x).toBe(pos.get('b')!.x)
+	})
+
+	it('keeps the acyclic part of a graph layered when one cycle exists', () => {
+		// root → a ⇄ b → leaf: the a⇄b cycle must not degrade root/leaf layering.
+		const pos = layoutAssetGraph({
+			nodes: [n('root'), n('a'), n('b'), n('leaf')],
+			edges: [e('root', 'a'), e('a', 'b'), e('b', 'a'), e('b', 'leaf')]
+		})
+		expect(pos.get('root')!.y).toBeLessThan(pos.get('a')!.y)
+		expect(pos.get('a')!.y).toBeLessThan(pos.get('b')!.y)
+		expect(pos.get('b')!.y).toBeLessThan(pos.get('leaf')!.y)
+		// A linear chain stays in one column.
+		expect(new Set(['root', 'a', 'b', 'leaf'].map((id) => pos.get(id)!.x)).size).toBe(1)
+	})
+
+	it('handles a longer cycle without dropping nodes', () => {
+		const pos = layoutAssetGraph({
+			nodes: [n('a'), n('b'), n('c')],
+			edges: [e('a', 'b'), e('b', 'c'), e('c', 'a')]
+		})
+		expect(pos.size).toBe(3)
+		const ys = ['a', 'b', 'c'].map((id) => pos.get(id)!.y)
+		expect(new Set(ys).size).toBe(3)
 	})
 
 	it('packs disjoint components side by side without overlap', () => {

--- a/frontend/src/lib/components/assets/AssetGraph/assetGraphLayout.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/assetGraphLayout.ts
@@ -53,8 +53,8 @@ interface Band {
 //
 // y comes from longest-path layering (same top-down orientation as before:
 // producers above, assets in the middle, consumers below). Returns positions
-// (band centers) normalized so the component's min x,y = 0. Throws on cyclic
-// input (caller falls back to a grid for the whole graph).
+// (band centers) normalized so the component's min x,y = 0. Cyclic input is
+// handled by dropping feedback edges (see the Kahn step below).
 function layoutComponent(
 	nodes: GraphInput['nodes'],
 	edges: GraphInput['edges']
@@ -76,21 +76,42 @@ function layoutComponent(
 		if (!parents.get(e.target)!.includes(e.source)) parents.get(e.target)!.push(e.source)
 	}
 
-	// Kahn topological order — also the cycle guard.
+	// Kahn topological order. Cycles don't abort the layout: when the queue
+	// drains with nodes left, the unplaced node with the fewest outstanding
+	// parents (first in input order on ties) is forced into the order and its
+	// not-yet-placed parent edges are dropped as feedback edges — layering and
+	// tree-building then operate on the resulting DAG while the rendered graph
+	// keeps every edge. (The caller already resolves write⇄read 2-cycles by
+	// omitting the read direction; this handles any longer cycle.)
 	const indeg = new Map<string, number>()
 	for (const n of nodes) indeg.set(n.id, parents.get(n.id)!.length)
 	const queue = nodes.filter((n) => indeg.get(n.id) === 0).map((n) => n.id)
+	const placed = new Set<string>()
 	const topo: string[] = []
-	while (queue.length) {
+	while (topo.length < nodes.length) {
+		if (queue.length === 0) {
+			let pick: string | undefined
+			for (const n of nodes) {
+				if (placed.has(n.id)) continue
+				if (pick === undefined || indeg.get(n.id)! < indeg.get(pick)!) pick = n.id
+			}
+			parents.set(
+				pick!,
+				parents.get(pick!)!.filter((p) => placed.has(p))
+			)
+			queue.push(pick!)
+		}
 		const cur = queue.shift()!
+		if (placed.has(cur)) continue
+		placed.add(cur)
 		topo.push(cur)
 		for (const c of children.get(cur)!) {
+			if (placed.has(c)) continue
 			const d = indeg.get(c)! - 1
 			indeg.set(c, d)
 			if (d === 0) queue.push(c)
 		}
 	}
-	if (topo.length !== nodes.length) throw new Error('cyclic asset graph')
 
 	// Longest-path layering: a node sits one layer below its lowest parent.
 	const layer = new Map<string, number>()
@@ -141,8 +162,7 @@ function layoutComponent(
 		out.set(id, { x: left + w / 2, y: layer.get(id)! * LAYER_H })
 		const kids = treeChildren.get(id)!
 		if (kids.length === 0) return
-		const kidsW =
-			kids.reduce((acc, k) => acc + W.get(k)!, 0) + SIBLING_GAP * (kids.length - 1)
+		const kidsW = kids.reduce((acc, k) => acc + W.get(k)!, 0) + SIBLING_GAP * (kids.length - 1)
 		let cursor = left + (w - kidsW) / 2
 		for (const k of kids) {
 			placeTree(k, cursor)
@@ -221,7 +241,8 @@ function layoutComponent(
 // disjoint components, so it's excluded from component detection and instead
 // re-placed centered one layer above the whole packed graph.
 //
-// Falls back to a stable grid if the component layout throws (cyclic inputs).
+// Falls back to a stable grid if the component layout throws (defensive —
+// cycles are already absorbed by feedback-edge dropping in layoutComponent).
 export function layoutAssetGraph(graph: GraphInput, anchorId?: string): Map<string, Positioned> {
 	const byId = new Map<string, Positioned>()
 	if (graph.nodes.length === 0) return byId

--- a/frontend/src/lib/components/sessions/PipelineEditorView.svelte
+++ b/frontend/src/lib/components/sessions/PipelineEditorView.svelte
@@ -75,6 +75,15 @@
 			workspace && folder ? await AssetService.getAssetsGraph({ workspace, folder }) : EMPTY_GRAPH
 	)
 
+	// Folder whose graph is actually rendered — `graphRes.current` is stale-
+	// while-revalidate on a folder retarget, so the canvas's one-shot initial
+	// fit is keyed on the folder captured when a graph lands, not on `path`
+	// (same rationale as the pipeline route page).
+	let viewportFitFolder = $state('')
+	$effect(() => {
+		if (graphRes.current) untrack(() => (viewportFitFolder = path))
+	})
+
 	// Deployed graph + the in-flight draft overlay (AI-built nodes render as plain
 	// dashed unsaved drafts, same as manual drafts). The session
 	// skips the route page's folder-wide asset prefetch (empty inferred maps); the
@@ -304,6 +313,7 @@
 			<PipelineGraphEditor
 				editor={pe}
 				folder={path}
+				viewportFitKey={viewportFitFolder}
 				persistDrafts={true}
 				displayGraph={resolvedGraph}
 				mode="edit"

--- a/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
@@ -1867,6 +1867,16 @@
 		}
 	)
 
+	// Folder whose graph is actually rendered. `graphRes.current` is stale-
+	// while-revalidate on an in-place folder switch, so keying the canvas's
+	// one-shot initial fit on the route param would fire the new folder's fit
+	// on the old graph and leave the fresh one unfitted. `folder` is read
+	// untracked: the key must move only when a graph lands.
+	let viewportFitFolder = $state('')
+	$effect(() => {
+		if (graphRes.current) untrack(() => (viewportFitFolder = folder))
+	})
+
 	// Body / inferred-assets prefetch sweep. Watches `g.runnables`; for any
 	// non-draft path we haven't fetched yet, fetches `getScriptByPath` and
 	// `inferAssets`, and stores both in their respective only-add caches.
@@ -2121,6 +2131,7 @@
 			<PipelineGraphEditor
 				editor={pe}
 				{folder}
+				viewportFitKey={viewportFitFolder}
 				persistDrafts={true}
 				{displayGraph}
 				{mode}


### PR DESCRIPTION
## Summary

Five independent fixes from a pipeline dogfooding session, one commit each, covering the graph view (`/pipeline/<folder>`, PipelineGraphEditor/AssetGraph), the SQL asset parser, and DuckDB result serialization.

## Changes

1. **Layout: keep the graph layered when lineage has cycles** (`assetGraphLayout.ts`, `AssetGraphCanvas.svelte`). An `rw` asset access produces a write edge (script → asset) *and* a read edge (asset → script) — a 2-cycle. `layoutComponent` threw on any cycle and the whole graph fell back to an unordered grid: crossing edges everywhere, assets above their producers, consumers fanning out backwards. Now write⇄read 2-cycles are resolved producer-above-asset by omitting the backward direction from the layout input only (both arrows still render), and any longer cycle is absorbed in the Kahn step by dropping feedback edges instead of throwing. The grid fallback remains as a defensive catch only.
2. **Initial viewport: fit the graph to the visible canvas** (`InitialFitView.svelte`). There was no initial fit at all — content was anchored at zoom 1, so anything wider/taller than the pane was clipped and unclickable until manual Fit View. A one-shot `fitView({ maxZoom: 1 })` fires once the first real node set is measured (the graph arrives async after mount, so SvelteFlow's init-time `fitView` prop would fit the wrong content). The fit re-arms on folder switch, keyed on the folder whose graph is actually *loaded* — `graphRes.current` is stale-while-revalidate, so keying on the route param would consume the new folder's fit on the old graph (caught by local review).
3. **Minimap: make it read as a minimap** (`AssetGraphCanvas.svelte`). Flat pastel bars with no strokes read as a loading skeleton. Node hues now mirror the canvas (blue assets, amber triggers, bordered neutral scripts) with visible strokes and rounded corners, plus a bordered container and an outlined viewport mask.
4. **Parser: don't infer s3 reads from bare string-literal mentions** (`windmill-parser-sql-asset`). A trailing summary `SELECT 's3:///shop/raw/orders.csv' AS target` after a `COPY … TO` of the same path turned the write into `rw`, drawing a false asset⇄script cycle. Bare literals in generic query position are now *weak* read evidence, surfaced only when the script has no other usage of that asset. FROM-position literals and `read_csv`/`read_parquet`/`read_json` arguments are recorded as explicit strong reads, so genuine self-refresh `rw` patterns are preserved (covered by tests). Note: the fix lands in live-buffer inference (`windmill-parser-wasm-asset`) on its next wasm publish; the deployed-graph path takes effect immediately.
5. **DuckDB: render temporal values as ISO strings in job results** (`windmill-duckdb-ffi-internal`). `TIMESTAMP` columns (e.g. SCD2 `valid_from`/`valid_to`) serialized as raw epoch-micros strings like `"1782974022218435"`; `DATE` as raw day counts and `TIME` as raw micros. All three now render ISO (`2026-07-01T23:13:42.218435`, `2026-07-01`, `10:30:00`), matching the Postgres executor's shape, with raw-count fallback for out-of-range values.

## Test plan

- [x] `cargo test -p windmill-parser-sql-asset` — 69 pass (4 new: write-echo stays W, bare mention alone stays R, read-fn + COPY and FROM-literal + COPY stay RW)
- [x] `cargo test` in `windmill-duckdb-ffi-internal` — 5 pass, incl. an integration test through a real in-memory DuckDB connection (TIMESTAMP/TIMESTAMPTZ/TIMESTAMP_NS/DATE/TIME)
- [x] `npx vitest run assetGraphLayout.test.ts` — 10 pass (3 new cycle tests)
- [x] `npm run check` — 0 errors
- [x] Manual (Playwright, seeded `pipelines` workspace with `f/shop` + `f/analytics` duckdb pipelines): reproduced the grid-fallback chaos from a deployed script with the spurious `rw`; after the fixes the pipeline renders as a straight top-to-bottom chain, fully fitted on load, and re-deploying the ingest script yields a plain `w` edge (no cycle)
- [x] Manual: in-app folder switch shop → analytics refits the viewport to the new graph (all nodes inside the visible canvas, verified via bounding rects)
- [ ] Run a DuckDB job on a duckdb-feature worker and confirm ISO timestamps in the result viewer (dev worker here is built without the `duckdb` feature; covered by the in-memory integration test)

## Screenshots

Before (grid fallback from the spurious rw cycle; skeleton-looking minimap; content clipped at zoom 1):

![before-shop-layout](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/pipeline-graph-polish/1782982355-before-shop-layout.png)

After (same pipeline: layered chain, fitted viewport, restyled minimap, no spurious read edge):

![after-all-shop](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/pipeline-graph-polish/1782982357-after-all-shop.png)

View mode, second pipeline:

![after-analytics](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/pipeline-graph-polish/1782982359-after-analytics.png)

Edit mode (+ anchor, per-asset actions):

![after-editmode](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/pipeline-graph-polish/1782982361-after-editmode.png)

Minimap closeup:

![minimap-closeup](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/pipeline-graph-polish/1782982363-minimap-closeup.png)

After in-app folder switch (viewport refit on the newly loaded graph):

![after-folder-switch](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/pipeline-graph-polish/1782982364-after-folder-switch.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the pipeline graph so it loads fitted, stays layered even with lineage cycles, and shows a clearer minimap. Also fixes SQL asset inference and renders DuckDB temporal values as ISO strings.

- **New Features**
  - Auto fit-to-view on first render and when the loaded folder changes, keyed to the graph that actually arrived (`InitialFitView.svelte`).
  - Minimap restyled with node hues, strokes, rounded corners, and a clear viewport mask.

- **Bug Fixes**
  - Graph layout remains layered when cycles exist by dropping feedback edges during layout; `rw` 2-cycles resolve producer-above-asset while still rendering both arrows.
  - SQL asset parser (`windmill-parser-sql-asset`): bare string-literal mentions are treated as weak reads and only surfaced if no other usage; FROM-position literals and `read_csv`/`read_parquet`/`read_json` arguments are strong reads, including list and named arguments, so genuine self-refresh `rw` patterns are preserved.
  - DuckDB result JSON (`windmill-duckdb-ffi-internal`): `TIMESTAMP`, `DATE`, and `TIME` serialize as ISO strings, with raw-count fallback for out-of-range values.

<sup>Written for commit 0283cbcb04ce5f73ea12575e3e9e2e40fca5d00f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

