### PR TITLE
fix(frontend): show inline workspace name editor on general settings (Fixes GIT-911)

### DIFF
--- a/frontend/src/lib/components/settings/ChangeWorkspaceName.svelte
+++ b/frontend/src/lib/components/settings/ChangeWorkspaceName.svelte
@@ -1,16 +1,13 @@
 <script lang="ts">
 	import { workspaceStore } from '$lib/stores'
 	import Button from '../common/button/Button.svelte'
+	import TextInput from '../text_input/TextInput.svelte'
 	import { sendUserToast } from '$lib/toast'
 	import { WorkspaceService } from '$lib/gen'
-	import Modal from '../common/modal/Modal.svelte'
-	import { Pen } from 'lucide-svelte'
 	import { untrack } from 'svelte'
 
-	let { open = false }: { open?: boolean } = $props()
-
-	let newName = $state('')
 	let currentName = $state('')
+	let newName = $state('')
 
 	$effect(() => {
 		if ($workspaceStore) {
@@ -20,10 +17,10 @@
 
 	async function getWorkspaceName() {
 		currentName = await WorkspaceService.getWorkspaceName({ workspace: $workspaceStore! })
+		newName = currentName
 	}
 
 	async function renameWorkspace() {
-		open = false
 		await WorkspaceService.changeWorkspaceName({
 			workspace: $workspaceStore!,
 			requestBody: {
@@ -32,7 +29,6 @@
 		})
 
 		sendUserToast(`Changed workspace name to ${newName}`)
-		newName = ''
 		getWorkspaceName()
 	}
 </script>
@@ -41,44 +37,21 @@
 	<p class="font-semibold text-xs text-emphasis">Workspace name</p>
 	<p class="text-xs text-secondary font-normal">Displayable name</p>
 	<div class="flex flex-row gap-2 items-center">
-		<p class="text-primary text-xs">{currentName}</p>
-		<Button
-			on:click={() => {
-				open = true
-			}}
-			unifiedSize="sm"
-			iconOnly
-			variant="subtle"
-			startIcon={{
-				icon: Pen
-			}}
+		<TextInput
+			bind:value={newName}
+			size="sm"
+			class="max-w-xs"
+			inputProps={{ placeholder: 'Workspace name', 'aria-label': 'Workspace name' }}
 		/>
-	</div>
-</div>
-
-<Modal bind:open title="Change workspace name">
-	<div class="flex flex-col gap-4 mt-4">
-		{#if currentName}
-			<p class="text-secondary text-xs"
-				>Current name <br /> <span class="text-emphasis">{currentName}</span></p
-			>
-		{/if}
-		<label class="flex flex-col gap-1">
-			<span class="text-emphasis text-xs">New name</span>
-			<input type="text" bind:value={newName} />
-		</label>
-	</div>
-
-	{#snippet actions()}
 		<Button
 			size="sm"
 			variant="accent"
-			disabled={!newName}
+			disabled={!newName || newName === currentName}
 			on:click={() => {
 				renameWorkspace()
 			}}
 		>
 			Save
 		</Button>
-	{/snippet}
-</Modal>
+	</div>
+</div>

--- a/frontend/src/lib/components/settings/ChangeWorkspaceName.svelte
+++ b/frontend/src/lib/components/settings/ChangeWorkspaceName.svelte
@@ -21,6 +21,9 @@
 	}
 
 	async function renameWorkspace() {
+		if (!newName || newName === currentName) {
+			return
+		}
 		await WorkspaceService.changeWorkspaceName({
 			workspace: $workspaceStore!,
 			requestBody: {
@@ -41,7 +44,15 @@
 			bind:value={newName}
 			size="sm"
 			class="max-w-xs"
-			inputProps={{ placeholder: 'Workspace name', 'aria-label': 'Workspace name' }}
+			inputProps={{
+				placeholder: 'Workspace name',
+				'aria-label': 'Workspace name',
+				onkeydown: (e) => {
+					if (e.key === 'Enter') {
+						renameWorkspace()
+					}
+				}
+			}}
 		/>
 		<Button
 			size="sm"


### PR DESCRIPTION
## Summary

Fixes GIT-911. On `/workspace_settings?tab=general`, the workspace name was only shown as static text next to a small, unlabeled pen icon that opened a modal — so there was no discoverable, labeled "Workspace name" input on the page, and even the modal's field was empty rather than pre-filled. Admins (and automated checks) could not find a rename input.

This replaces the pen-icon + modal with an inline, pre-filled `TextInput` and a `Save` button, matching the documented expectation (W04.S2): an admin viewing the General tab sees a "Workspace name" input pre-filled with the current name and a Save button.

## Changes

- `frontend/src/lib/components/settings/ChangeWorkspaceName.svelte`:
  - Render an inline `TextInput` (design-system component, replacing the old raw `<input>` in the modal) with `aria-label`/placeholder "Workspace name", pre-filled with the current name.
  - Add an inline `Save` button, disabled until the value actually changes and re-disabled after a successful save.
  - Support Enter-to-save, with a guard in `renameWorkspace()` so empty/unchanged values are ignored.
  - Remove the now-unused `open` prop, `Modal`, and `Pen` icon. The only caller (`workspace_settings/+page.svelte`) uses `<ChangeWorkspaceName />` with no props, so dropping the export is safe.

Note: the sibling rows `ChangeWorkspaceId` and `ChangeWorkspaceColor` still use the pen-icon+modal pattern (the ID change carries destructive consequences and color needs a picker, so a modal is appropriate there). Aligning them is intentionally left out of scope.

## Screenshots

Inline "Workspace name" input pre-filled with the current name, Save disabled while unchanged:

![general-fixed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/diego/git-911-bug-workspace-name-editor-missing-on/1782997695-general-fixed.png)

After editing + Save — success toast, displayed name updated:

![general-after-save](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/diego/git-911-bug-workspace-name-editor-missing-on/1782997697-general-after-save.png)

## Test plan

Verified in-browser (headless Chromium) on `/workspace_settings?tab=general` as `admin@windmill.dev` in the `admins` workspace:

- [x] Input renders visible + pre-filled with the current workspace name
- [x] Save is disabled while the value is unchanged and re-disables after a successful save
- [x] Editing + Save persists the rename across a page reload and shows the success toast
- [x] Enter in the input saves (persists across reload)
- [x] `npm run check:fast` passes; Svelte autofixer reports no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)