### PR TITLE
fix: stale AI chat context picker after workspace item changes

### DIFF
--- a/frontend/src/lib/components/workspaceItemsLoader.svelte.ts
+++ b/frontend/src/lib/components/workspaceItemsLoader.svelte.ts
@@ -21,6 +21,17 @@ import {
  * Both getters are read inside the returned closures so changing
  * workspace or kinds after mount Just Works.
  */
+function itemsEqual(a: WorkspaceItem[] | undefined, b: WorkspaceItem[]): boolean {
+	if (!a || a.length !== b.length) return false
+	return a.every(
+		(item, i) =>
+			item.path === b[i].path &&
+			item.summary === b[i].summary &&
+			item.kind === b[i].kind &&
+			item.raw_app === b[i].raw_app
+	)
+}
+
 export function useWorkspaceItemsLoader(
 	workspace: () => string | undefined,
 	kinds: () => readonly WorkspaceItemKind[]
@@ -41,18 +52,36 @@ export function useWorkspaceItemsLoader(
 		})()
 	)
 	let loadingKind = $state<Partial<Record<WorkspaceItemKind, boolean>>>({})
+	// Workspace+kind pairs already revalidated by this loader instance. The
+	// module-level cache is never expired on its own, so each loader (one per
+	// picker mount) re-fetches each kind once: cached items render instantly,
+	// fresh data quietly swaps in. Without this, items created/deleted since
+	// the cache was filled would stay wrong until a full page reload.
+	const revalidated = new Set<string>()
 
 	async function ensureLoaded(kind: WorkspaceItemKind) {
 		const ws = workspace()
 		if (!ws) return
+		const revalidateKey = `${ws}:${kind}`
 		// `loaded[kind]` read inside `untrack` so callers wiring this into
 		// a reactive context (DrillPicker's onFilterChange effect) don't
 		// subscribe to a signal `ensureLoaded` itself writes — that would
 		// re-fire the effect on every assignment and busy-loop.
-		if (!untrack(() => loaded[kind])) loadingKind[kind] = true
+		const hasCached = !!untrack(() => loaded[kind])
+		if (hasCached && revalidated.has(revalidateKey)) return
+		revalidated.add(revalidateKey)
+		if (!hasCached) loadingKind[kind] = true
 		try {
-			const items = await loadKind(ws, kind)
-			loaded[kind] = items
+			const items = await loadKind(ws, kind, { revalidate: true })
+			// Keep the reference stable when nothing changed so an open picker's
+			// derived tree isn't rebuilt under the user on every revalidation.
+			if (
+				!itemsEqual(
+					untrack(() => loaded[kind]),
+					items
+				)
+			)
+				loaded[kind] = items
 		} finally {
 			loadingKind[kind] = false
 		}

--- a/frontend/src/lib/components/workspaceItemsLoader.svelte.ts
+++ b/frontend/src/lib/components/workspaceItemsLoader.svelte.ts
@@ -37,8 +37,7 @@ export function useWorkspaceItemsLoader(
 	kinds: () => readonly WorkspaceItemKind[]
 ) {
 	// Seed from the module-level cache so kinds already fetched in this
-	// session render on the first frame. Re-fetching `ensureLoaded` later
-	// quietly swaps in fresh data (stale-while-revalidate).
+	// session render on the first frame.
 	let loaded = $state<Partial<Record<WorkspaceItemKind, WorkspaceItem[]>>>(
 		(() => {
 			const ws = untrack(workspace)
@@ -52,11 +51,9 @@ export function useWorkspaceItemsLoader(
 		})()
 	)
 	let loadingKind = $state<Partial<Record<WorkspaceItemKind, boolean>>>({})
-	// Workspace+kind pairs already revalidated by this loader instance. The
-	// module-level cache is never expired on its own, so each loader (one per
-	// picker mount) re-fetches each kind once: cached items render instantly,
-	// fresh data quietly swaps in. Without this, items created/deleted since
-	// the cache was filled would stay wrong until a full page reload.
+	// Workspace+kind pairs this loader instance has refreshed — at most one
+	// background re-fetch per kind per mount. Marked on success only, so a
+	// failed fetch is retried by the next call instead of stranding stale data.
 	const revalidated = new Set<string>()
 
 	async function ensureLoaded(kind: WorkspaceItemKind) {
@@ -69,10 +66,10 @@ export function useWorkspaceItemsLoader(
 		// re-fire the effect on every assignment and busy-loop.
 		const hasCached = !!untrack(() => loaded[kind])
 		if (hasCached && revalidated.has(revalidateKey)) return
-		revalidated.add(revalidateKey)
 		if (!hasCached) loadingKind[kind] = true
 		try {
 			const items = await loadKind(ws, kind, { revalidate: true })
+			revalidated.add(revalidateKey)
 			// Keep the reference stable when nothing changed so an open picker's
 			// derived tree isn't rebuilt under the user on every revalidation.
 			if (
@@ -82,6 +79,10 @@ export function useWorkspaceItemsLoader(
 				)
 			)
 				loaded[kind] = items
+		} catch (e) {
+			// Callers fire-and-forget; surface the failure without an
+			// unhandled rejection. Cached items (if any) keep rendering.
+			console.error(`Failed to load workspace ${kind}s`, e)
 		} finally {
 			loadingKind[kind] = false
 		}

--- a/frontend/src/lib/components/workspacePicker.ts
+++ b/frontend/src/lib/components/workspacePicker.ts
@@ -44,9 +44,10 @@ type WorkspaceCache = {
 }
 
 /** Module-level session cache. Persists across picker mounts within a single
- * page session. NOT invalidated automatically — call `invalidate()` after
- * creating/deleting an item if the picker may be opened again before a full
- * reload. */
+ * page session so cached kinds render on the first frame. Pickers revalidate
+ * once per mount via `loadKind(..., { revalidate: true })`, so stale entries
+ * self-heal on the next open; call `invalidate()` after creating/deleting an
+ * item when even a brief flash of the stale list must be avoided. */
 const cache = new Map<string, WorkspaceCache>()
 const inflight = new Map<string, Promise<WorkspaceItem[]>>()
 /** Bumped by `invalidate()`. Each in-flight `loadKind` captures the version
@@ -87,11 +88,14 @@ export function invalidate(workspace: string, kind?: WorkspaceItemKind) {
 
 export async function loadKind(
 	workspace: string,
-	kind: WorkspaceItemKind
+	kind: WorkspaceItemKind,
+	opts?: { revalidate?: boolean }
 ): Promise<WorkspaceItem[]> {
 	const existing = cache.get(workspace)?.[kind]
-	if (existing) return existing
+	if (existing && !opts?.revalidate) return existing
 	const key = cacheKey(workspace, kind)
+	// An in-flight fetch is already hitting the network, so it satisfies a
+	// revalidate request too.
 	const flying = inflight.get(key)
 	if (flying) return flying
 


### PR DESCRIPTION
## Summary

The AI chat `@`-context picker (and the workspace drill pickers sharing the same loader) reads workspace items from a module-level session cache in `workspacePicker.ts`. That cache was only invalidated from two editor save paths, so items created or deleted anywhere else — home page, chat deploys, the API, another tab — stayed invisible (or lingered as ghosts) in the picker until a full page reload.

This makes the loader do real stale-while-revalidate: cached items still render on the first frame, and each workspace+kind is re-fetched once per picker mount. Since the picker mounts fresh on every open, every open triggers one silent background refresh.

## Changes

- `workspacePicker.ts`: `loadKind` accepts `{ revalidate: true }` to bypass the cached early-return. Concurrent fetches still dedupe through the `inflight` map, and the existing `cacheVersion` guard still prevents a fetch started before an explicit `invalidate()` from writing stale data back.
- `workspaceItemsLoader.svelte.ts`: `ensureLoaded` tracks which workspace+kind pairs this loader instance already revalidated and re-fetches each once — cached data shows instantly, fresh data quietly swaps in. A new `itemsEqual` check keeps the `$state` reference stable when nothing changed, so an open picker's derived tree isn't rebuilt for no reason.
- A kind is marked revalidated only after the fetch succeeds, so a failed revalidation retries on the next call instead of stranding stale data for the rest of the mount; the rejection is caught and logged (callers fire-and-forget).
- Also covers `WorkspaceItemDrillPicker` (editor breadcrumb switcher), which shares this loader — each dropdown open now costs at most one list call per kind shown.

Known limitation: items that change *while the picker stays open* only appear on the next open — the refresh is per-mount, not continuous.

## Test plan

- [x] `npm run check`: 0 errors, no warnings in the changed files
- [x] Browser-verified with Playwright against the dev stack (Global chat mode): opened the `@` picker to populate the cache, created a script via the API, reopened the picker — the new script appeared without a page reload; deleted it via the API — gone on the next open. No console errors.
- [x] Post-review smoke test: picker opens, drills Scripts → `u/admin`, and lists workspace scripts with the success-gated revalidation marking in place.
- [x] Regression: editor deploy paths that call `invalidate()` still show the new item immediately (version guard unchanged) — verified in-browser: populated the picker cache, created a script via API, deployed from the script editor (fires `invalidate()`), and the very next picker open listed the fresh item

## Screenshots

New script `u/admin/ctx_picker_fresh_item` created via API appears in the reopened picker (no reload):

![picker-shows-new-item](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-context-picker/1782998017-picker-shows-new-item.png)

After deleting it via API, it's gone on the next open:

![picker-after-delete](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-context-picker/1782998019-picker-after-delete.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
