### PR TITLE
fix(frontend): home New submenus fall back below, hugging the right edge

### DIFF
--- a/frontend/src/lib/components/home/CreateActionsMenu.svelte
+++ b/frontend/src/lib/components/home/CreateActionsMenu.svelte
@@ -243,7 +243,9 @@
 		forceVisible: true
 	})
 
-	// per-row fan-out submenus, anchored toward the page center (popover hugs the right edge)
+	// per-row fan-out submenus: open to the right when there's room. The popover hugs
+	// the right viewport edge on most screens, so the default flip (right → left) would
+	// cover the doc panel — fall back below the trigger row instead.
 	const {
 		elements: { subTrigger: wacSubTrigger, subMenu: wacSubMenu },
 		states: { subOpen: wacSubOpen }
@@ -251,7 +253,7 @@
 		positioning: {
 			placement: 'right-start',
 			gutter: 4,
-			flip: true,
+			flip: { fallbackPlacements: ['bottom-end', 'bottom-start', 'top-end', 'top-start'] },
 			fitViewport: true,
 			overflowPadding: 8
 		}
@@ -263,11 +265,34 @@
 		positioning: {
 			placement: 'right-end',
 			gutter: 4,
-			flip: true,
+			flip: { fallbackPlacements: ['bottom-end', 'bottom-start', 'top-end', 'top-start'] },
 			fitViewport: true,
 			overflowPadding: 8
 		}
 	})
+
+	// When a fan-out submenu falls below its row ('bottom'/'top' data-side), melt aligns
+	// it to the row's right edge, but free viewport space may remain beside the popover —
+	// slide it right until it hugs the viewport edge. Melt repositions on scroll/resize
+	// via style/data-side writes, so re-apply on attribute mutations.
+	function hugViewportRight(node: HTMLElement) {
+		let delta = 0
+		const apply = () => {
+			const side = node.getAttribute('data-side')
+			const baseRight = node.getBoundingClientRect().right - delta
+			const next =
+				side === 'bottom' || side === 'top'
+					? Math.max(0, document.documentElement.clientWidth - 8 - baseRight)
+					: 0
+			if (Math.abs(next - delta) < 0.5) return
+			delta = next
+			node.style.transform = next ? `translateX(${next}px)` : ''
+		}
+		const observer = new MutationObserver(apply)
+		observer.observe(node, { attributeFilter: ['style', 'data-side'] })
+		apply()
+		return { destroy: () => observer.disconnect() }
+	}
 
 	// attach the menu trigger to the design-system <Button>'s DOM node, so it keeps its
 	// styling — melt element stores are callable on a node, exactly like `use:melt`.
@@ -438,6 +463,7 @@
 						{#if $wacSubOpen}
 							<div
 								use:melt={$wacSubMenu}
+								use:hugViewportRight
 								class="z-[6001] flex flex-col gap-0.5 p-1 w-52 rounded-lg border border-gray-200 dark:border-gray-700 bg-surface shadow-xl focus:outline-none"
 							>
 								{#each option.variants ?? [] as variant (variant.label)}
@@ -485,6 +511,7 @@
 				{#if $importSubOpen}
 					<div
 						use:melt={$importSubMenu}
+						use:hugViewportRight
 						class="z-[6001] flex flex-col gap-0.5 p-1 w-52 rounded-lg border border-gray-200 dark:border-gray-700 bg-surface shadow-xl focus:outline-none"
 					>
 						{#each importActions as action (action.label)}

--- a/frontend/src/lib/components/home/CreateActionsMenu.svelte
+++ b/frontend/src/lib/components/home/CreateActionsMenu.svelte
@@ -290,8 +290,16 @@
 		}
 		const observer = new MutationObserver(apply)
 		observer.observe(node, { attributeFilter: ['style', 'data-side'] })
+		// melt only rewrites style when the reposition moves the submenu — a resize that
+		// changes clientWidth without moving it (scrollbar appearing, zoom) needs a direct hook
+		window.addEventListener('resize', apply)
 		apply()
-		return { destroy: () => observer.disconnect() }
+		return {
+			destroy: () => {
+				observer.disconnect()
+				window.removeEventListener('resize', apply)
+			}
+		}
 	}
 
 	// attach the menu trigger to the design-system <Button>'s DOM node, so it keeps its


### PR DESCRIPTION
## Summary

On the home page "New" popover, the Workflow-as-Code and Import fan-out submenus open to the right of their row (`right-start` / `right-end`). When there is no room on the right — the popover hugs the right viewport edge on most screen sizes — floating-ui's default `flip()` mirrored them to the **left**, covering the description panel.

Now they fall back **below** the trigger row instead, and slide as far right as the screen allows (right edge 8px from the viewport edge) so any free space beside the popover is used instead of wasted.

## Changes

- `CreateActionsMenu.svelte`: replace `flip: true` with explicit `flip: { fallbackPlacements: [...] }` on both submenus, preferring `bottom-*` (then `top-*` as a last resort) over the default left mirror.
- Add a small `hugViewportRight` Svelte action on both submenu elements: melt stamps `data-side` on the floating element after each reposition, and when the side is `bottom`/`top` the action translates the submenu right until it hugs the viewport edge. It re-applies on melt's `style`/`data-side` attribute mutations (scroll/resize repositions) and converges via a 0.5px threshold guard, so there is no observer feedback loop. When the submenu opens on the right normally, the action does nothing.

## Test plan

- [x] Wide viewport (2400px): submenu opens to the right of the row, unchanged.
- [x] 1900px (some free space, not enough for the submenu): falls back below and hugs the viewport right edge, sitting mostly beside the popover.
- [x] 1280px: falls back below, right edge flush with the viewport edge.
- [x] Import submenu behaves the same (below + edge-hugging).
- [x] Hover from the row into the translated submenu keeps it open (melt's pointer grace area reads the transformed rect); resizing while open re-hugs the edge (right edge = viewport − 8px).
- [x] `npm run check:fast` passes; no console errors while exercising the menu.

## Screenshots

Bottom fallback hugging the right screen edge at 1900px (free room beside the popover is used):

![hug-1900](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/improve-new-picker-fallback/1783003961-hug-1900.png)

Narrow 1280px — falls below, flush with the screen edge:

![hug-1280](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/improve-new-picker-fallback/1783003963-hug-1280.png)

Wide 2400px — right-side placement unchanged:

![hug-2400](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/improve-new-picker-fallback/1783003966-hug-2400.png)

Import submenu at 1900px:

![import-hug-1900](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/improve-new-picker-fallback/1783003968-import-hug-1900.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)