### PR TITLE
fix: make SMTP username and password optional in frontend validation

### DIFF
--- a/frontend/src/lib/components/instanceSettings/SmtpSettings.svelte
+++ b/frontend/src/lib/components/instanceSettings/SmtpSettings.svelte
@@ -5,10 +5,6 @@
 			smtpSettings.smtp_host &&
 			smtpSettings.smtp_host.trim() !== '' &&
 			smtpSettings.smtp_port &&
-			smtpSettings.smtp_username &&
-			smtpSettings.smtp_username.trim() !== '' &&
-			smtpSettings.smtp_password &&
-			smtpSettings.smtp_password.trim() !== '' &&
 			smtpSettings.smtp_from &&
 			smtpSettings.smtp_from.trim() !== ''
 		)


### PR DESCRIPTION
## Summary

`isSmtpSettingsValid` in `SmtpSettings.svelte` required `smtp_username` and `smtp_password` to be non-empty, which disabled the "Send test email" button for SMTP relays that authenticate via IP whitelisting rather than credentials. The backend (`email_ee.rs`) already treats these fields as optional — credentials are only applied when both username and password are present and non-empty.

This relaxes the frontend validation to match the backend: only `smtp_host`, `smtp_port`, and `smtp_from` are required. The same predicate is also used by `ErrorOrRecoveryHandler.svelte` and `CriticalAlertChannels.svelte` to detect whether SMTP is configured; the relaxed check is correct for those consumers too.

Fixes WIN-2125

## Changes

- Remove the `smtp_username` / `smtp_password` non-empty checks from `isSmtpSettingsValid` in `frontend/src/lib/components/instanceSettings/SmtpSettings.svelte`. The function now requires only `smtp_host`, `smtp_port`, and `smtp_from`.

## Screenshots

Instance settings → SMTP with Host, Port, and From Address filled but **Username and Password left blank** — the "Send test email" button is enabled:

![smtp-optional-auth](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/diego/win-2125-make-smtp-username-and-password-optional-in-frontend/1783008967-smtp-optional-auth.png)

## Test plan

Verified end-to-end by driving the running dev server with Playwright:

- [x] With Host / Port / From filled and Username / Password **empty**, and a test email entered → "Send test email" button is **enabled**.
- [x] Clearing a still-required field (From Address) → button becomes **disabled** again (required-field validation intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)