### PR TITLE
fix(forks): clone only the current raw-app bundle, via server-side copy

### DIFF
--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -4734,9 +4734,18 @@ async fn clone_apps(
     .await?;
 
     let mut app_id_mapping: HashMap<i64, i64> = HashMap::new();
+    // Only a raw app's current (last) version has a bundle worth carrying into the fork: bundles exist
+    // only for raw apps, and older versions aren't viewable/runnable (the bundle secret is only ever
+    // minted for `versions.last()`). Copying a bundle for every version of every app is what makes
+    // forking a workspace with many app versions hang — a serial S3 round-trip per version, held inside
+    // the fork transaction. Collect each app's current version here; intersect with raw versions below.
+    let mut latest_version_ids: HashSet<i64> = HashSet::new();
 
     // Clone apps with new IDs
     for app in apps {
+        if let Some(&current_version) = app.versions.last() {
+            latest_version_ids.insert(current_version);
+        }
         let new_app_id = sqlx::query_scalar!(
             "INSERT INTO app (workspace_id, path, summary, policy, versions, extra_perms, custom_path)
              VALUES ($1, $2, $3, $4, $5, $6, $7)
@@ -4756,6 +4765,7 @@ async fn clone_apps(
     }
 
     let mut version_id_mapping: HashMap<i64, i64> = HashMap::new();
+    let mut raw_version_ids: HashSet<i64> = HashSet::new();
 
     {
         // Clone app versions
@@ -4771,6 +4781,9 @@ async fn clone_apps(
 
         for version in app_versions {
             if let Some(&new_app_id) = app_id_mapping.get(&version.app_id) {
+                if version.raw_app {
+                    raw_version_ids.insert(version.id);
+                }
                 let new_version_id = sqlx::query_scalar!(
                     "INSERT INTO app_version (app_id, value, created_by, created_at, raw_app)
                  VALUES ($1, $2, $3, $4, $5) RETURNING id",
@@ -4788,9 +4801,16 @@ async fn clone_apps(
         }
     }
 
-    // Clone app bundles for raw apps
-    if !version_id_mapping.is_empty() {
-        let old_ids: Vec<i64> = version_id_mapping.keys().copied().collect();
+    // The bundles worth cloning: each raw app's current version (latest ∩ raw). Everything else either
+    // has no bundle (low-code apps) or an unreachable one (older versions), so we don't touch S3 for it.
+    let bundle_version_ids: HashSet<i64> = latest_version_ids
+        .intersection(&raw_version_ids)
+        .copied()
+        .collect();
+
+    // Clone app bundles — only the current version of each raw app (see bundle_version_ids).
+    if !bundle_version_ids.is_empty() {
+        let old_ids: Vec<i64> = bundle_version_ids.iter().copied().collect();
         let bundles = sqlx::query!(
             "SELECT app_version_id, file_type, data FROM app_bundles
              WHERE app_version_id = ANY($1) AND w_id = $2",
@@ -4826,40 +4846,30 @@ async fn clone_apps(
             let object_store = windmill_object_store::get_object_store().await;
             if let Some(os) = object_store {
                 for (&old_version_id, &new_version_id) in &version_id_mapping {
+                    if !bundle_version_ids.contains(&old_version_id) {
+                        continue;
+                    }
                     for file_type in &["js", "css"] {
                         if cloned_from_db.contains(&(old_version_id, file_type.to_string())) {
                             continue;
                         }
-                        let src_path = format!(
-                            "/app_bundles/{}/{}.{}",
-                            source_workspace_id, old_version_id, file_type
-                        );
-                        let get_result = os
-                            .get(&windmill_object_store::object_store_reexports::Path::from(
-                                src_path,
-                            ))
-                            .await;
-                        match get_result {
-                            Ok(result) => {
-                                let data = result.bytes().await.map_err(
-                                    windmill_object_store::object_store_error_to_error,
-                                )?;
-                                let dst_path = format!(
-                                    "/app_bundles/{}/{}.{}",
-                                    target_workspace_id, new_version_id, file_type
-                                );
-                                os.put(
-                                    &windmill_object_store::object_store_reexports::Path::from(
-                                        dst_path.clone(),
-                                    ),
-                                    data.into(),
-                                )
-                                .await
-                                .map_err(
-                                    windmill_object_store::object_store_error_to_error,
-                                )?;
+                        // Server-side copy (no bytes through the backend) rather than get+put. A missing source
+                        // — e.g. a raw app with a js bundle but no css — surfaces as NotFound and is skipped,
+                        // exactly as the previous get did.
+                        let src_path =
+                            windmill_object_store::object_store_reexports::Path::from(format!(
+                                "/app_bundles/{}/{}.{}",
+                                source_workspace_id, old_version_id, file_type
+                            ));
+                        let dst_path =
+                            windmill_object_store::object_store_reexports::Path::from(format!(
+                                "/app_bundles/{}/{}.{}",
+                                target_workspace_id, new_version_id, file_type
+                            ));
+                        match os.copy(&src_path, &dst_path).await {
+                            Ok(()) => {
                                 tracing::info!(
-                                    "Cloned app bundle from S3: {}.{} -> {}.{}",
+                                    "Cloned app bundle in object store: {}.{} -> {}.{}",
                                     old_version_id,
                                     file_type,
                                     new_version_id,
@@ -4867,7 +4877,7 @@ async fn clone_apps(
                                 );
                             }
                             Err(windmill_object_store::object_store_reexports::ObjectStoreError::NotFound { .. }) => {
-                                // No bundle in S3 for this version/type, skip
+                                // No bundle in the object store for this version/type, skip
                             }
                             Err(e) => {
                                 return Err(

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -4853,9 +4853,10 @@ async fn clone_apps(
                         if cloned_from_db.contains(&(old_version_id, file_type.to_string())) {
                             continue;
                         }
-                        // Server-side copy (no bytes through the backend) rather than get+put. A missing source
-                        // — e.g. a raw app with a js bundle but no css — surfaces as NotFound and is skipped,
-                        // exactly as the previous get did.
+                        // Prefer a server-side copy (no bytes through the backend). A missing source —
+                        // e.g. a raw app with a js bundle but no css — surfaces as NotFound and is
+                        // skipped. Not every object-store provider supports server-side copy, so fall
+                        // back to download+upload on any other error.
                         let src_path =
                             windmill_object_store::object_store_reexports::Path::from(format!(
                                 "/app_bundles/{}/{}.{}",
@@ -4879,10 +4880,37 @@ async fn clone_apps(
                             Err(windmill_object_store::object_store_reexports::ObjectStoreError::NotFound { .. }) => {
                                 // No bundle in the object store for this version/type, skip
                             }
-                            Err(e) => {
-                                return Err(
-                                    windmill_object_store::object_store_error_to_error(e),
+                            Err(copy_err) => {
+                                // Provider may not support server-side copy — fall back to get+put.
+                                tracing::warn!(
+                                    "object store copy failed ({copy_err:#}), falling back to get+put for app bundle {}.{}",
+                                    old_version_id, file_type
                                 );
+                                match os.get(&src_path).await {
+                                    Ok(result) => {
+                                        let data = result.bytes().await.map_err(
+                                            windmill_object_store::object_store_error_to_error,
+                                        )?;
+                                        os.put(&dst_path, data.into()).await.map_err(
+                                            windmill_object_store::object_store_error_to_error,
+                                        )?;
+                                        tracing::info!(
+                                            "Cloned app bundle via get+put fallback: {}.{} -> {}.{}",
+                                            old_version_id,
+                                            file_type,
+                                            new_version_id,
+                                            file_type
+                                        );
+                                    }
+                                    Err(windmill_object_store::object_store_reexports::ObjectStoreError::NotFound { .. }) => {
+                                        // No bundle for this version/type, skip
+                                    }
+                                    Err(e) => {
+                                        return Err(
+                                            windmill_object_store::object_store_error_to_error(e),
+                                        );
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

Forking a workspace with many bundled app versions could hang for minutes — and hold a DB transaction open the whole time (`idle in transaction`) — because `clone_apps` copied **every** app version's compiled bundle from object storage: a serial download+upload per version, inside the fork transaction. A workspace with thousands of app versions means thousands of serial S3 round-trips.

Two independent problems, both fixed here:

1. **We copied bundles for every version of every app.** Only a raw app's **current** version bundle is ever reachable: the bundle is served via a signed secret, and `compute_bundle_secret` only ever mints one for `versions.last()`. Older versions aren't viewable/runnable, and low-code (non-raw) apps have no bundle at all.
2. **We did `get`+`put`** (bytes round-tripping through the backend) rather than a server-side copy.

## Changes

- Clone bundles only for each raw app's current version (`latest ∩ raw`) — for both the DB-stored and object-store paths. Drops the work from "every version of every app" to one-per-raw-app.
- Replace `get`+`put` with a server-side `object_store::copy` (no bytes through the backend). The `NotFound` skip for an absent bundle (e.g. a raw app with a `.js` but no `.css`) is preserved unchanged.

## Validation

Reproduced locally against minio with a workspace of 700 app versions (400 raw + 300 low-code):

| | before | after |
|---|---|---|
| fork time | 5.9s (400 versions, txn held throughout) | **0.27s** |
| bundles copied | 400 | 1–2 (current raw version only) |

- css-absent (js only): fork succeeds, only `.js` copied, missing `.css` skipped (no error).
- css-present: both copied, **byte-identical** to source (verified sha256).

## Test plan

- [ ] Fork a workspace with a raw app that has many versions → completes quickly; the fork's app renders.
- [ ] Fork a workspace with low-code apps → no object-store calls for them.
- [ ] Raw app with `.js` but no `.css` → fork succeeds, only `.js` copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kUxmczySsf7ZfsyENmtui

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up workspace forks by cloning only each raw app’s current bundle and using a server‑side object‑store copy with a safe fallback. This removes thousands of object‑store round trips and shortens how long the fork transaction stays open.

- **Bug Fixes**
  - Clone bundles only for the latest raw app version; skip low‑code apps and older versions.
  - Prefer server‑side `copy`; fall back to download+upload when unsupported, and continue skipping missing file types (`NotFound`) without error.
  - Forks in large workspaces are much faster (~5.9s → ~0.27s in local test) with far less time spent idle in transaction.

<sup>Written for commit c7092277c2cf2bdf618f4599471bf464f90e42e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

