### PR TITLE
fix: prevent truncated tool call args from bricking AI chat sessions

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -67,6 +67,7 @@ import type { Selection } from 'monaco-editor'
 import type AIChatInput from './AIChatInput.svelte'
 import { prepareApiSystemMessage, prepareApiUserMessage } from './api/core'
 import { runChatLoop, truncateToToolPairedPrefix } from './chatLoop'
+import { sanitizeToolCallArguments } from './toolCallArguments'
 import { normalizeContextUsage } from './tokenUsage'
 import type { ReviewChangesOpts } from './monaco-adapter'
 import {
@@ -485,7 +486,10 @@ export class AIChatManager {
 		this.compacting = true
 		try {
 			const raw = await getNonStreamingCompletion(
-				[...prefix, { role: 'user', content: getCompactionSummaryPrompt() }],
+				[
+					...sanitizeToolCallArguments(prefix),
+					{ role: 'user', content: getCompactionSummaryPrompt() }
+				],
 				abortController
 			)
 			const formatted = formatCompactSummary(raw ?? '')
@@ -649,18 +653,11 @@ export class AIChatManager {
 			)
 			switch (result) {
 				case 'ok':
-					await this.historyManager.saveChat(
-						this.displayMessages,
-						this.messages,
-						this.contextUsage
-					)
+					await this.historyManager.saveChat(this.displayMessages, this.messages, this.contextUsage)
 					sendUserToast('Conversation compacted.')
 					break
 				case 'empty':
-					sendUserToast(
-						'Compaction produced an empty summary — conversation left unchanged.',
-						true
-					)
+					sendUserToast('Compaction produced an empty summary — conversation left unchanged.', true)
 					break
 				case 'error':
 					sendUserToast('Failed to compact the conversation.', true)
@@ -2132,7 +2129,7 @@ export class AIChatManager {
 						moduleState && !moduleState.previewSuccess
 							? getStringError(moduleState.previewResult)
 							: undefined,
-					getCode: () => module.value.type === 'rawscript' ? module.value.content : '',
+					getCode: () => (module.value.type === 'rawscript' ? module.value.content : ''),
 					lang: module.value.language,
 					path: module.id,
 					...editorRelated

--- a/frontend/src/lib/components/copilot/chat/chatLoop.test.ts
+++ b/frontend/src/lib/components/copilot/chat/chatLoop.test.ts
@@ -399,3 +399,42 @@ describe('truncateToToolPairedPrefix', () => {
 		expect(truncateToToolPairedPrefix(msgs)).toEqual(msgs)
 	})
 })
+
+describe('runChatLoop history sanitization', () => {
+	beforeEach(() => {
+		vi.resetAllMocks()
+		mocks.providerSupportsWebSearch.mockReturnValue(false)
+		mocks.resolveRequestReasoning.mockReturnValue(undefined)
+		mocks.getOpenAIResponsesCompletion.mockResolvedValue({})
+		mocks.parseOpenAIResponsesCompletion.mockResolvedValue({
+			shouldContinue: false,
+			tokenUsage
+		})
+	})
+
+	it('replaces unparseable historical tool_call arguments before sending, without mutating the stored history', async () => {
+		const config = createConfig({ workspace: `workspace-${randomUUID()}` })
+		const poisoned: ChatCompletionMessageParam = {
+			role: 'assistant',
+			tool_calls: [
+				{
+					id: 'call_1',
+					type: 'function',
+					function: { name: 'patch_app_file', arguments: '{"path": "u/x", "old_string": "trunc' }
+				}
+			]
+		}
+		config.messages.push(poisoned, {
+			role: 'tool',
+			tool_call_id: 'call_1',
+			content: 'Error while calling tool'
+		})
+
+		await runChatLoop(config)
+
+		const sent = mocks.getOpenAIResponsesCompletion.mock.calls[0][0] as any[]
+		const sentAssistant = sent.find((m) => m.role === 'assistant' && m.tool_calls)
+		expect(sentAssistant.tool_calls[0].function.arguments).toBe('{}')
+		expect((poisoned as any).tool_calls[0].function.arguments).toContain('trunc')
+	})
+})

--- a/frontend/src/lib/components/copilot/chat/chatLoop.ts
+++ b/frontend/src/lib/components/copilot/chat/chatLoop.ts
@@ -10,6 +10,7 @@ import { resolveRequestReasoning, type ReasoningProviderModel } from '../reasoni
 import { getAnthropicCompletion, parseAnthropicCompletion } from './anthropic'
 import { getOpenAIResponsesCompletion, parseOpenAIResponsesCompletion } from './openai-responses'
 import type { Tool, ToolCallbacks } from './shared'
+import { sanitizeToolCallArguments } from './toolCallArguments'
 import { addChatTokenUsage, emptyChatTokenUsage, type ChatTokenUsage } from './tokenUsage'
 
 export interface ChatClients {
@@ -266,7 +267,7 @@ export async function runChatLoop(config: ChatLoopConfig): Promise<ChatLoopResul
 
 		const messageParams = [
 			systemMessage,
-			...messages,
+			...sanitizeToolCallArguments(messages),
 			...(pendingUserMessage ? [pendingUserMessage] : [])
 		]
 		const toolDefs = tools.map((t) => t.def)

--- a/frontend/src/lib/components/copilot/chat/toolCallArguments.test.ts
+++ b/frontend/src/lib/components/copilot/chat/toolCallArguments.test.ts
@@ -41,6 +41,15 @@ describe('sanitizeToolCallArguments', () => {
 		expect((poisoned as any).tool_calls[0].function.arguments).toContain('trunc')
 	})
 
+	it('rewrites empty arguments to {} so replayed history stays parseable', () => {
+		const emptyArgs: ChatCompletionMessageParam = {
+			role: 'assistant',
+			tool_calls: [{ id: 'c1', type: 'function', function: { name: 'list_files', arguments: '' } }]
+		}
+		const [sanitized] = sanitizeToolCallArguments([emptyArgs]) as any[]
+		expect(sanitized.tool_calls[0].function.arguments).toBe('{}')
+	})
+
 	it('returns untouched messages by reference', () => {
 		const user: ChatCompletionMessageParam = { role: 'user', content: 'hi' }
 		const validAssistant: ChatCompletionMessageParam = {

--- a/frontend/src/lib/components/copilot/chat/toolCallArguments.test.ts
+++ b/frontend/src/lib/components/copilot/chat/toolCallArguments.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions.mjs'
+import { hasValidToolCallArguments, sanitizeToolCallArguments } from './toolCallArguments'
+
+describe('hasValidToolCallArguments', () => {
+	it('accepts empty or valid JSON arguments', () => {
+		expect(hasValidToolCallArguments(undefined)).toBe(true)
+		expect(hasValidToolCallArguments('')).toBe(true)
+		expect(hasValidToolCallArguments('{}')).toBe(true)
+		expect(hasValidToolCallArguments('{"path": "u/admin/app", "content": "x"}')).toBe(true)
+	})
+
+	it('rejects arguments truncated mid-stream', () => {
+		expect(hasValidToolCallArguments('{"path": "u/admin/app", "old_string": "setMess')).toBe(false)
+		expect(hasValidToolCallArguments('{"path": "u/admin/app"')).toBe(false)
+	})
+})
+
+describe('sanitizeToolCallArguments', () => {
+	const poisoned: ChatCompletionMessageParam = {
+		role: 'assistant',
+		tool_calls: [
+			{
+				id: 'call_bad',
+				type: 'function',
+				function: { name: 'patch_app_file', arguments: '{"path": "u/x", "old_string": "trunc' }
+			},
+			{
+				id: 'call_ok',
+				type: 'function',
+				function: { name: 'read_file', arguments: '{"file": "a.txt"}' }
+			}
+		]
+	}
+
+	it('replaces only unparseable arguments with {}', () => {
+		const [sanitized] = sanitizeToolCallArguments([poisoned]) as any[]
+		expect(sanitized.tool_calls[0].function.arguments).toBe('{}')
+		expect(sanitized.tool_calls[1].function.arguments).toBe('{"file": "a.txt"}')
+		// The stored history object is not mutated
+		expect((poisoned as any).tool_calls[0].function.arguments).toContain('trunc')
+	})
+
+	it('returns untouched messages by reference', () => {
+		const user: ChatCompletionMessageParam = { role: 'user', content: 'hi' }
+		const validAssistant: ChatCompletionMessageParam = {
+			role: 'assistant',
+			tool_calls: [{ id: 'c1', type: 'function', function: { name: 'read_file', arguments: '{}' } }]
+		}
+		const result = sanitizeToolCallArguments([user, validAssistant])
+		expect(result[0]).toBe(user)
+		expect(result[1]).toBe(validAssistant)
+	})
+})

--- a/frontend/src/lib/components/copilot/chat/toolCallArguments.ts
+++ b/frontend/src/lib/components/copilot/chat/toolCallArguments.ts
@@ -30,10 +30,9 @@ function isReplayableArguments(args: string | undefined): boolean {
 
 /**
  * Replaces unparseable or empty assistant tool_call arguments with '{}' in the
- * outgoing copy of the history, so a session that already persisted a
- * truncated tool call (before parseOpenAICompletion guarded against it)
- * recovers instead of failing every request. The paired tool result already
- * tells the model the call failed.
+ * outgoing copy of the history, so a session whose persisted history contains
+ * a truncated tool call recovers instead of failing every request. The paired
+ * tool result already tells the model the call failed.
  */
 export function sanitizeToolCallArguments(
 	messages: ChatCompletionMessageParam[]

--- a/frontend/src/lib/components/copilot/chat/toolCallArguments.ts
+++ b/frontend/src/lib/components/copilot/chat/toolCallArguments.ts
@@ -5,6 +5,10 @@ import type { ChatCompletionMessageParam } from 'openai/resources/chat/completio
  * cut mid-arguments) must never reach a provider: the whole request is
  * rejected, and once persisted in the session history every follow-up request
  * fails the same way.
+ *
+ * Empty arguments count as valid: some providers stream '' for no-arg tool
+ * calls, and flagging those would wrongly report the tool as not executed.
+ * Callers persisting arguments must normalize '' to '{}' themselves.
  */
 export function hasValidToolCallArguments(args: string | undefined): boolean {
 	if (!args) {
@@ -18,12 +22,18 @@ export function hasValidToolCallArguments(args: string | undefined): boolean {
 	}
 }
 
+// '' is valid per hasValidToolCallArguments but JSON.parse('') still throws
+// provider-side, so replaying history additionally requires non-empty args.
+function isReplayableArguments(args: string | undefined): boolean {
+	return !!args && hasValidToolCallArguments(args)
+}
+
 /**
- * Replaces unparseable assistant tool_call arguments with '{}' in the outgoing
- * copy of the history, so a session that already persisted a truncated tool
- * call (before parseOpenAICompletion guarded against it) recovers instead of
- * failing every request. The paired tool result already tells the model the
- * call failed.
+ * Replaces unparseable or empty assistant tool_call arguments with '{}' in the
+ * outgoing copy of the history, so a session that already persisted a
+ * truncated tool call (before parseOpenAICompletion guarded against it)
+ * recovers instead of failing every request. The paired tool result already
+ * tells the model the call failed.
  */
 export function sanitizeToolCallArguments(
 	messages: ChatCompletionMessageParam[]
@@ -32,7 +42,7 @@ export function sanitizeToolCallArguments(
 		if (
 			m.role !== 'assistant' ||
 			!m.tool_calls?.some(
-				(t) => t.type === 'function' && !hasValidToolCallArguments(t.function.arguments)
+				(t) => t.type === 'function' && !isReplayableArguments(t.function.arguments)
 			)
 		) {
 			return m
@@ -40,7 +50,7 @@ export function sanitizeToolCallArguments(
 		return {
 			...m,
 			tool_calls: m.tool_calls.map((t) =>
-				t.type === 'function' && !hasValidToolCallArguments(t.function.arguments)
+				t.type === 'function' && !isReplayableArguments(t.function.arguments)
 					? { ...t, function: { ...t.function, arguments: '{}' } }
 					: t
 			)

--- a/frontend/src/lib/components/copilot/chat/toolCallArguments.ts
+++ b/frontend/src/lib/components/copilot/chat/toolCallArguments.ts
@@ -1,0 +1,49 @@
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions.mjs'
+
+/**
+ * A tool call whose `arguments` string is not valid JSON (typically a stream
+ * cut mid-arguments) must never reach a provider: the whole request is
+ * rejected, and once persisted in the session history every follow-up request
+ * fails the same way.
+ */
+export function hasValidToolCallArguments(args: string | undefined): boolean {
+	if (!args) {
+		return true
+	}
+	try {
+		JSON.parse(args)
+		return true
+	} catch {
+		return false
+	}
+}
+
+/**
+ * Replaces unparseable assistant tool_call arguments with '{}' in the outgoing
+ * copy of the history, so a session that already persisted a truncated tool
+ * call (before parseOpenAICompletion guarded against it) recovers instead of
+ * failing every request. The paired tool result already tells the model the
+ * call failed.
+ */
+export function sanitizeToolCallArguments(
+	messages: ChatCompletionMessageParam[]
+): ChatCompletionMessageParam[] {
+	return messages.map((m) => {
+		if (
+			m.role !== 'assistant' ||
+			!m.tool_calls?.some(
+				(t) => t.type === 'function' && !hasValidToolCallArguments(t.function.arguments)
+			)
+		) {
+			return m
+		}
+		return {
+			...m,
+			tool_calls: m.tool_calls.map((t) =>
+				t.type === 'function' && !hasValidToolCallArguments(t.function.arguments)
+					? { ...t, function: { ...t.function, arguments: '{}' } }
+					: t
+			)
+		}
+	})
+}

--- a/frontend/src/lib/components/copilot/lib.toolCalls.test.ts
+++ b/frontend/src/lib/components/copilot/lib.toolCalls.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ChatCompletionMessageParam } from 'openai/resources/index.mjs'
+
+vi.mock('monaco-editor', () => ({
+	editor: {}
+}))
+
+vi.mock('$lib/stores', () => ({
+	workspaceStore: { subscribe: () => () => undefined }
+}))
+
+vi.mock('$lib/components/flows/flowTree', () => ({
+	findModuleInModules: () => undefined
+}))
+
+vi.mock('$lib/gen', () => ({
+	OpenAPI: {},
+	ResourceService: {},
+	ScriptService: {},
+	FlowService: {},
+	JobService: {},
+	ScheduleService: {},
+	HttpTriggerService: {},
+	WebsocketTriggerService: {},
+	KafkaTriggerService: {},
+	NatsTriggerService: {},
+	PostgresTriggerService: {},
+	MqttTriggerService: {},
+	SqsTriggerService: {},
+	GcpTriggerService: {},
+	AzureTriggerService: {}
+}))
+
+vi.mock('$lib/utils', () => ({
+	emptyString: (value: string | undefined | null) => !value,
+	generateRandomString: () => 'generated_id'
+}))
+
+vi.mock('$lib/scripts', () => ({
+	scriptLangToEditorLang: (language: string) => language
+}))
+
+vi.mock('$lib/aiStore', () => ({
+	getCurrentModel: () => undefined,
+	getMetadataModel: () => undefined,
+	copilotInfo: {
+		subscribe: (run: (value: unknown) => void) => {
+			run({})
+			return () => undefined
+		}
+	}
+}))
+
+vi.mock('@leeoniya/ufuzzy', () => ({
+	default: class {
+		search() {
+			return [[], [], []]
+		}
+	}
+}))
+
+function streamOf(chunks: unknown[]): any {
+	return (async function* () {
+		for (const chunk of chunks) {
+			yield chunk
+		}
+	})()
+}
+
+function toolCallChunk(delta: Record<string, unknown>) {
+	return { choices: [{ delta: { tool_calls: [{ index: 0, ...delta }] } }] }
+}
+
+function createCallbacks() {
+	return {
+		onNewToken: vi.fn(),
+		onMessageEnd: vi.fn(),
+		setToolStatus: vi.fn(),
+		removeToolStatus: vi.fn()
+	}
+}
+
+function createTool(fn = vi.fn().mockResolvedValue('tool ok')) {
+	return {
+		def: {
+			type: 'function' as const,
+			function: { name: 'patch_app_file', parameters: { type: 'object' } }
+		},
+		fn
+	}
+}
+
+describe('parseOpenAICompletion tool call arguments', () => {
+	it('does not execute nor persist a tool call whose streamed arguments are truncated', async () => {
+		const { parseOpenAICompletion } = await import('./lib')
+		const fn = vi.fn()
+		const callbacks = createCallbacks()
+		const messages: ChatCompletionMessageParam[] = []
+		const addedMessages: ChatCompletionMessageParam[] = []
+
+		const result = await parseOpenAICompletion(
+			streamOf([
+				toolCallChunk({
+					id: 'call_1',
+					function: { name: 'patch_app_file', arguments: '{"path": "u/admin/app", ' }
+				}),
+				// The stream ends mid-arguments (e.g. output token limit or dropped connection)
+				toolCallChunk({ function: { arguments: '"old_string": "setMessages(prev' } })
+			]),
+			callbacks,
+			messages,
+			addedMessages,
+			[createTool(fn)] as any,
+			{},
+			undefined,
+			{ workspace: 'test' }
+		)
+
+		expect(fn).not.toHaveBeenCalled()
+		expect(result.shouldContinue).toBe(true)
+
+		const assistant = messages.find((m) => m.role === 'assistant') as any
+		// Persisting the truncated arguments string would make every follow-up
+		// request fail provider-side JSON parsing, bricking the session.
+		expect(assistant.tool_calls[0].function.arguments).toBe('{}')
+
+		const toolResult = messages.find((m) => m.role === 'tool') as any
+		expect(toolResult.tool_call_id).toBe('call_1')
+		expect(toolResult.content).toContain('NOT executed')
+		expect(callbacks.setToolStatus).toHaveBeenCalledWith(
+			'call_1',
+			expect.objectContaining({ error: expect.stringContaining('invalid or truncated') })
+		)
+		expect(addedMessages).toEqual(messages)
+	})
+
+	it('executes a tool call with valid streamed arguments and keeps them verbatim', async () => {
+		const { parseOpenAICompletion } = await import('./lib')
+		const fn = vi.fn().mockResolvedValue('tool ok')
+		const messages: ChatCompletionMessageParam[] = []
+
+		const result = await parseOpenAICompletion(
+			streamOf([
+				toolCallChunk({
+					id: 'call_1',
+					function: { name: 'patch_app_file', arguments: '{"path": ' }
+				}),
+				toolCallChunk({ function: { arguments: '"u/admin/app"}' } })
+			]),
+			createCallbacks(),
+			messages,
+			[],
+			[createTool(fn)] as any,
+			{},
+			undefined,
+			{ workspace: 'test' }
+		)
+
+		expect(fn).toHaveBeenCalledWith(expect.objectContaining({ args: { path: 'u/admin/app' } }))
+		expect(result.shouldContinue).toBe(true)
+
+		const assistant = messages.find((m) => m.role === 'assistant') as any
+		expect(assistant.tool_calls[0].function.arguments).toBe('{"path": "u/admin/app"}')
+		const toolResult = messages.find((m) => m.role === 'tool') as any
+		expect(toolResult.content).toBe('tool ok')
+	})
+})

--- a/frontend/src/lib/components/copilot/lib.ts
+++ b/frontend/src/lib/components/copilot/lib.ts
@@ -18,6 +18,7 @@ import { requiresMaxCompletionTokens } from './modelConfig'
 import { applyReasoningToConfig } from './reasoningRegistry'
 import { formatResourceTypes } from './utils'
 import { processToolCall, type Tool, type ToolCallbacks } from './chat/shared'
+import { hasValidToolCallArguments } from './chat/toolCallArguments'
 import {
 	getNonStreamingOpenAIResponsesCompletion,
 	getOpenAIResponsesCompletionStream
@@ -286,7 +287,6 @@ export function getModelMaxTokens(provider: AIProvider, model: string) {
 	}
 	return 8192
 }
-
 
 function getModelSpecificConfig(
 	modelProvider: AIProviderModel,
@@ -1094,11 +1094,14 @@ export async function parseOpenAICompletion(
 	}
 
 	if (toolCalls.length > 0) {
+		const invalidToolCallIds = new Set(
+			toolCalls.filter((t) => !hasValidToolCallArguments(t.function.arguments)).map((t) => t.id)
+		)
 		const normalizedToolCalls = toolCalls.map((t) => ({
 			...t,
 			function: {
 				...t.function,
-				arguments: t.function.arguments || '{}'
+				arguments: invalidToolCallIds.has(t.id) ? '{}' : t.function.arguments || '{}'
 			}
 		}))
 		const toAdd = buildAssistantToolCallMessage({
@@ -1113,6 +1116,22 @@ export async function parseOpenAICompletion(
 		messages.push(toAdd)
 		addedMessages.push(toAdd)
 		for (const toolCall of toolCalls) {
+			if (invalidToolCallIds.has(toolCall.id)) {
+				callbacks.setToolStatus(toolCall.id, {
+					isLoading: false,
+					isStreamingArguments: false,
+					error: 'Tool call arguments were invalid or truncated'
+				})
+				const messageToAdd = {
+					role: 'tool' as const,
+					tool_call_id: toolCall.id,
+					content:
+						'The tool call arguments were invalid or truncated JSON, so the tool was NOT executed. Retry the call; if the arguments were long, split the work into several smaller calls.'
+				}
+				messages.push(messageToAdd)
+				addedMessages.push(messageToAdd)
+				continue
+			}
 			const messageToAdd = await processToolCall({
 				tools,
 				toolCall,


### PR DESCRIPTION
## Summary

A streamed AI-chat tool call whose JSON `arguments` were cut mid-stream (provider output-token limit, dropped connection) was persisted verbatim into the chat history. Every subsequent request then re-sent the broken JSON and failed provider-side parsing — e.g. litellm/Vertex AI: `400 … Failed to parse tool call arguments for tool 'patch_app_file' … Unterminated string` — permanently bricking the session, including across reloads (the history is persisted). Neither existing safeguard caught it: `truncateToToolPairedPrefix` only validates tool-call *pairing*, and only the direct-Anthropic converter (not the OpenAI-compatible path) degraded unparseable args gracefully.

This PR guards both directions:

- **Prevention** — `parseOpenAICompletion` never persists unparseable tool-call arguments: it stores `{}` instead, skips execution, marks the tool chip with an "invalid or truncated" error, and adds a tool result telling the model the call was NOT executed so it retries (with a hint to split large edits).
- **Healing** — `sanitizeToolCallArguments` rewrites unparseable historical arguments to `{}` in the *outgoing copy* of the history (stored history untouched) in `runChatLoop` (covers all provider paths) and the compaction summarizer. Sessions already poisoned before this fix recover on their next message.

## Changes

- New `frontend/src/lib/components/copilot/chat/toolCallArguments.ts`: `hasValidToolCallArguments` + `sanitizeToolCallArguments` (copy-on-write; untouched messages returned by reference).
- `lib.ts` `parseOpenAICompletion`: detect tool calls with invalid accumulated arguments; persist `{}`, skip execution, emit error status + informative tool result, keep the loop alive.
- `chatLoop.ts` `runChatLoop`: sanitize the history when building `messageParams` (single build site shared by the OpenAI Responses, Completions-fallback, Anthropic, and generic provider branches).
- `AIChatManager.svelte.ts` `runSummarization`: sanitize the compaction prefix sent to the summarizer.
- Tests: `toolCallArguments.test.ts` (pure helpers), `lib.toolCalls.test.ts` (truncated stream → not executed + `{}` persisted + retry tool result; valid multi-chunk stream control), `chatLoop.test.ts` (outgoing copy sanitized without mutating stored history).

## Test plan

- [x] `npx vitest run src/lib/components/copilot` — new suites pass (82 tests across the 4 affected files); the 6 pre-existing failures in `ContextManager.test.ts`/`app/core.test.ts` reproduce identically on `main`.
- [x] `npm run check:fast` clean.
- [ ] Manual (recovery path): doctor a stored session history to cut a `tool_calls[].function.arguments` string mid-value, reload, send a message — the request should succeed instead of returning the provider 400.

## Screenshots

No screenshots: the change has no visible UI effect on any normally reachable state — the only new UI (an "invalid or truncated" error on the tool-call chip) renders exclusively when a provider streams broken JSON mid-tool-call, which cannot be reproduced on demand against a real provider. That path is covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)