### PR TITLE
feat(frontend): add federatedTokenFile to instance object storage Azure config

### DIFF
--- a/frontend/src/lib/components/ObjectStoreConfigSettings.svelte
+++ b/frontend/src/lib/components/ObjectStoreConfigSettings.svelte
@@ -30,6 +30,7 @@
 		tenantId: string
 		clientId: string
 		accessKey: string
+		federatedTokenFile?: string
 		endpoint?: string
 	}
 
@@ -631,6 +632,26 @@
 						bind:value={
 							() => (bucket_config as AzureConfig).clientId,
 							(v) => (bucket_config = { ...(bucket_config as AzureConfig), clientId: v })
+						}
+					/>
+				</label>
+				<label class="block pb-2">
+					<span class="text-xs font-semibold text-emphasis"
+						>Federated token file <span class="text-2xs text-primary">(optional)</span></span
+					>
+					<span class="text-primary text-2xs"
+						>Path to the projected service account token when using AKS Workload Identity with the
+						tenant ID and client ID above</span
+					>
+					<TextInput
+						inputProps={{ placeholder: '/var/run/secrets/azure/tokens/azure-identity-token' }}
+						bind:value={
+							() => (bucket_config as AzureConfig).federatedTokenFile,
+							(v) =>
+								(bucket_config = {
+									...(bucket_config as AzureConfig),
+									federatedTokenFile: v === '' ? undefined : v
+								})
 						}
 					/>
 				</label>


### PR DESCRIPTION
Fixes WIN-2127

## Summary
The Instance Object Storage Azure form did not expose a `federatedTokenFile` field, so AKS Workload Identity setups (tenant ID + client ID, no access key) could not be configured from the UI: the `object_store` crate fell back to IMDS-based authentication and failed with "Identity not found". The backend already supports the field end-to-end — `AzureBlobResource.federated_token_file` (`backend/windmill-types/src/s3.rs`, serde-renamed to `federatedTokenFile`) is passed to `MicrosoftAzureBuilder::with_federated_token_file` in `build_azure_blob_client`. This PR surfaces it in the UI.

## Changes
- Added optional `federatedTokenFile` to the `AzureConfig` type in `ObjectStoreConfigSettings.svelte` (matches the backend serde rename exactly).
- Added a "Federated token file (optional)" text input between Client ID and Endpoint, with placeholder `/var/run/secrets/azure/tokens/azure-identity-token` and helper text pointing at AKS Workload Identity usage.
- An empty input is normalized to `undefined` so the key is dropped from the saved config instead of persisting an empty string (the backend also tolerates `""`).

No backend or OpenAPI change needed: the instance settings value is free-form JSON and deserializes through the existing `AzureBlobResource`.

## Test plan
- [x] `npm run check` — 0 errors (all warnings pre-existing, none in this file)
- [x] svelte-autofixer — no issues
- [x] Verified in the browser (Playwright, headless): field renders in the Azure tab, typed value appears as `federatedTokenFile: /var/run/secrets/azure/tokens/azure-identity-token` in the "Review changes" settings diff
- [ ] End-to-end auth against a real AKS Workload Identity cluster (not reproducible in this dev environment)

## Screenshots
![azure-object-store-form](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2127-add-federatedtokenfile-field-to-instance-object-storage/1783084058-azure-object-store-form.png)
![azure-object-store-federated-token](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2127-add-federatedtokenfile-field-to-instance-object-storage/1783084058-azure-object-store-federated-token.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the optional `federatedTokenFile` in Instance → Object Storage → Azure settings so AKS Workload Identity (tenant ID + client ID) can be configured from the UI. Fixes WIN-2127 by avoiding IMDS fallback and “Identity not found” errors when using a projected service account token.

- **New Features**
  - Added “Federated token file (optional)” input between Client ID and Endpoint with placeholder `/var/run/secrets/azure/tokens/azure-identity-token`.
  - Empty input is saved as undefined to omit the key, matching backend expectations.

<sup>Written for commit d0c47ab8d7e7652358ee17cbef09fea7fced52fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

