### PR TITLE
feat(ai-chat): show live token count in the thinking indicator

### DIFF
--- a/.github/scripts/check-docs-links.mjs
+++ b/.github/scripts/check-docs-links.mjs
@@ -1,0 +1,126 @@
+// Extracts every windmill.dev/docs link referenced in the frontend source and
+// verifies none of them 404. Run: `node .github/scripts/check-docs-links.mjs`.
+// Used by the check-docs-links GitHub workflow (release / manual trigger only).
+
+import { readdir, readFile } from 'node:fs/promises'
+import { join, extname } from 'node:path'
+
+const ROOT = 'frontend/src'
+const EXTS = new Set(['.ts', '.js', '.svelte', '.mjs', '.cjs'])
+const DOCS_RE = /https?:\/\/(?:www\.)?windmill\.dev\/docs\/[^\s"'`)>\]}]*/g
+// `const someBaseUrl = 'https://www.windmill.dev/docs/...'` used later as `${someBaseUrl}/foo`
+const BASE_RE = /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*['"`](https?:\/\/(?:www\.)?windmill\.dev\/docs\/[^'"`]+)['"`]/g
+
+const CONCURRENCY = 24
+const TIMEOUT_MS = 20000
+const RETRIES = 2
+
+async function walk(dir) {
+	const out = []
+	for (const entry of await readdir(dir, { withFileTypes: true })) {
+		const p = join(dir, entry.name)
+		if (entry.isDirectory()) {
+			if (entry.name === 'node_modules' || entry.name === '.svelte-kit') continue
+			out.push(...(await walk(p)))
+		} else if (EXTS.has(extname(entry.name))) {
+			out.push(p)
+		}
+	}
+	return out
+}
+
+// url (no fragment) -> Set of source files it appears in
+const urls = new Map()
+const unresolved = []
+
+function record(url, file) {
+	const clean = url
+		.replace(/\\.*$/, '') // cut at an escape sequence embedded in a string literal (e.g. \n)
+		.replace(/#.*$/, '') // drop anchor fragment — irrelevant to a 404 check
+		.replace(/[.,;:'")\]]+$/, '')
+	if (!clean) return
+	// A `{`/`${` means the URL is built from an unresolved template/interpolation var.
+	if (clean.includes('{')) {
+		unresolved.push(`${clean}  (${file})`)
+		return
+	}
+	if (!urls.has(clean)) urls.set(clean, new Set())
+	urls.get(clean).add(file)
+}
+
+for (const file of await walk(ROOT)) {
+	let content = await readFile(file, 'utf8')
+	// Inline file-local base-url constants so `${base}/page` template literals resolve.
+	const bases = []
+	for (const m of content.matchAll(BASE_RE)) bases.push({ name: m[1], value: m[2], decl: m[0] })
+	for (const { name, value } of bases) {
+		content = content.replaceAll('${' + name + '}', value)
+	}
+	// Blank each base declaration so a prefix-only base (no index page of its own,
+	// e.g. .../app_configuration_settings) isn't checked as a standalone link.
+	// A genuinely bare `${base}` usage was already inlined above, so it's still covered.
+	for (const { decl } of bases) content = content.replace(decl, '')
+	for (const m of content.matchAll(DOCS_RE)) record(m[0], file)
+}
+
+const allUrls = [...urls.keys()].sort()
+console.log(`Found ${allUrls.length} distinct docs links across ${ROOT}`)
+if (unresolved.length) {
+	console.log(`\n⚠️  ${unresolved.length} link(s) built from an unrecognized base URL — skipped (register the base const so they can be checked):`)
+	for (const u of [...new Set(unresolved)].sort()) console.log(`   ${u}`)
+}
+
+async function check(url) {
+	for (let attempt = 0; attempt <= RETRIES; attempt++) {
+		const ctrl = new AbortController()
+		const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS)
+		try {
+			let res = await fetch(url, {
+				method: 'HEAD',
+				redirect: 'follow',
+				signal: ctrl.signal,
+				headers: { 'user-agent': 'windmill-docs-link-check' }
+			})
+			// Some hosts reject HEAD — fall back to GET.
+			if (res.status === 405 || res.status === 501) {
+				res = await fetch(url, {
+					method: 'GET',
+					redirect: 'follow',
+					signal: ctrl.signal,
+					headers: { 'user-agent': 'windmill-docs-link-check' }
+				})
+			}
+			clearTimeout(timer)
+			return { url, status: res.status, ok: res.status < 400 }
+		} catch (err) {
+			clearTimeout(timer)
+			if (attempt === RETRIES) return { url, status: 0, ok: false, error: String(err?.message || err) }
+			await new Promise((r) => setTimeout(r, 500 * (attempt + 1)))
+		}
+	}
+}
+
+// Simple concurrency pool.
+const results = []
+let idx = 0
+async function worker() {
+	while (idx < allUrls.length) {
+		const url = allUrls[idx++]
+		results.push(await check(url))
+	}
+}
+await Promise.all(Array.from({ length: CONCURRENCY }, worker))
+
+const failures = results.filter((r) => !r.ok)
+if (failures.length === 0) {
+	console.log(`\n✅ All ${allUrls.length} docs links are reachable.`)
+	process.exit(0)
+}
+
+console.log(`\n❌ ${failures.length} broken docs link(s):`)
+for (const f of failures.sort((a, b) => a.url.localeCompare(b.url))) {
+	console.log(`\n  ${f.url}`)
+	console.log(`    status: ${f.error ? `error (${f.error})` : f.status}`)
+	for (const file of urls.get(f.url)) console.log(`    ↳ ${file}`)
+}
+process.exit(1)

--- a/.github/workflows/check-docs-links.yml
+++ b/.github/workflows/check-docs-links.yml
@@ -1,0 +1,23 @@
+name: Check frontend docs links
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  check-docs-links:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            frontend/src
+            .github/scripts
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+      - name: Verify docs links are not 404
+        run: node .github/scripts/check-docs-links.mjs

--- a/frontend/src/lib/components/apps/editor/component/components.ts
+++ b/frontend/src/lib/components/apps/editor/component/components.ts
@@ -1171,7 +1171,7 @@ export const components = {
 	chatcomponent: {
 		name: 'Chat',
 		icon: MessageSquare,
-		documentationLink: `${documentationBaseUrl}/chat`,
+		documentationLink: `${documentationBaseUrl}/app_component_library`,
 		dims: '3:8-6:12' as AppComponentDimensions,
 		customCss: {
 			container: { class: '', style: '' },
@@ -1299,7 +1299,7 @@ export const components = {
 	jobprogressbarcomponent: {
 		name: 'Progress Bar by Job Id',
 		icon: Monitor,
-		documentationLink: `${documentationBaseUrl}/progress_bar`,
+		documentationLink: `${documentationBaseUrl}/app_component_library`,
 		dims: '2:2-6:2' as AppComponentDimensions,
 		customCss: {
 			header: { class: '', style: '' },
@@ -1467,7 +1467,7 @@ export const components = {
 		name: 'Code Input',
 		icon: Code,
 		dims: '2:1-4:4' as AppComponentDimensions,
-		documentationLink: `${documentationBaseUrl}/code`,
+		documentationLink: `${documentationBaseUrl}/code_input`,
 		customCss: {
 			text: { class: '', style: '' },
 			container: { class: '', style: '' }
@@ -1810,7 +1810,7 @@ export const components = {
 	piechartcomponent: {
 		name: 'Pie Chart',
 		icon: PieChart,
-		documentationLink: `${documentationBaseUrl}/pie_chart`,
+		documentationLink: `${documentationBaseUrl}/chartjs`,
 		dims: '2:8-6:8' as AppComponentDimensions,
 		customCss: {
 			container: { class: '', style: '' }
@@ -1919,7 +1919,7 @@ export const components = {
 	barchartcomponent: {
 		name: 'Bar/Line Chart',
 		icon: BarChart4,
-		documentationLink: `${documentationBaseUrl}/bar_line_chart`,
+		documentationLink: `${documentationBaseUrl}/chartjs`,
 		dims: '2:8-6:8' as AppComponentDimensions,
 		customCss: {
 			container: { class: '', style: '' }
@@ -2132,7 +2132,7 @@ This is a paragraph.
 	timeseriescomponent: {
 		name: 'Timeseries',
 		icon: GripHorizontal,
-		documentationLink: `${documentationBaseUrl}/timeseries`,
+		documentationLink: `${documentationBaseUrl}/chartjs`,
 		dims: '2:8-6:8' as AppComponentDimensions,
 		customCss: {
 			container: { class: '', style: '' }
@@ -2206,7 +2206,7 @@ This is a paragraph.
 	scatterchartcomponent: {
 		name: 'Scatter Chart',
 		icon: GripHorizontal,
-		documentationLink: `${documentationBaseUrl}/scatter_chart`,
+		documentationLink: `${documentationBaseUrl}/chartjs`,
 		dims: '2:8-6:8' as AppComponentDimensions,
 		customCss: {
 			container: { class: '', style: '' }

--- a/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
@@ -621,6 +621,7 @@ the panel, or the Escape-to-stop focus check would wrongly reject them. -->
 							{:else}
 								<ChatTypingIndicator
 									loading={aiChatManager.loading}
+									tokens={aiChatManager.compacting ? undefined : aiChatManager.currentOutputTokens}
 									label={aiChatManager.compacting
 										? 'Compacting conversation'
 										: aiChatManager.currentReasoningActive &&

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -273,9 +273,15 @@ export class AIChatManager {
 	currentReply = $state<string>('')
 	currentReasoning = $state<string>('')
 	currentReasoningActive = $state<boolean>(false)
-	// Live output-token count for the in-flight assistant message; drives the typing
-	// indicator's progress readout. Only populated by providers that stream usage.
+	// Live output-token count for the current turn; drives the typing indicator's
+	// progress readout. Only populated by providers that stream usage.
 	currentOutputTokens = $state<number>(0)
+	// A turn can span several API round-trips (one per tool-use step). Each round-trip's
+	// streamed usage.output_tokens is a running total scoped to that one message, so it
+	// restarts from near-zero every step. To keep the readout monotonic across the whole
+	// turn, fold each finished step's total into a base and add the in-flight step on top.
+	#outputTokensBase = 0
+	#outputTokensStep = 0
 	displayMessages = $state<DisplayMessage[]>([])
 	messages = $state<ChatCompletionMessageParam[]>([])
 	/** Provider-reported context size of the last committed turn (prompt +
@@ -1641,6 +1647,8 @@ export class AIChatManager {
 			this.currentReasoning = ''
 			this.currentReasoningActive = false
 			this.currentOutputTokens = 0
+			this.#outputTokensBase = 0
+			this.#outputTokensStep = 0
 
 			// Compaction trigger. Without a known context window there is no limit
 			// to enforce, so compaction stays off rather than guessing one.
@@ -1696,7 +1704,14 @@ export class AIChatManager {
 					onNewToken: (token) => (this.currentReply += token),
 					onReasoningDelta: (token) => (this.currentReasoning += token),
 					onReasoningStart: () => (this.currentReasoningActive = true),
-					onOutputTokens: (n) => (this.currentOutputTokens = n),
+					onOutputTokens: (n) => {
+						// A drop means a new step's message started; bank the prior step's total.
+						if (n < this.#outputTokensStep) {
+							this.#outputTokensBase += this.#outputTokensStep
+						}
+						this.#outputTokensStep = n
+						this.currentOutputTokens = this.#outputTokensBase + n
+					},
 					onMessageEnd: () => {
 						// Keep the streamed text for the abort/error paths. Non-empty only:
 						// parsers flush (and reset) when a tool call starts after text, and

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -273,6 +273,9 @@ export class AIChatManager {
 	currentReply = $state<string>('')
 	currentReasoning = $state<string>('')
 	currentReasoningActive = $state<boolean>(false)
+	// Live output-token count for the in-flight assistant message; drives the typing
+	// indicator's progress readout. Only populated by providers that stream usage.
+	currentOutputTokens = $state<number>(0)
 	displayMessages = $state<DisplayMessage[]>([])
 	messages = $state<ChatCompletionMessageParam[]>([])
 	/** Provider-reported context size of the last committed turn (prompt +
@@ -1637,6 +1640,7 @@ export class AIChatManager {
 			this.currentReply = ''
 			this.currentReasoning = ''
 			this.currentReasoningActive = false
+			this.currentOutputTokens = 0
 
 			// Compaction trigger. Without a known context window there is no limit
 			// to enforce, so compaction stays off rather than guessing one.
@@ -1692,6 +1696,7 @@ export class AIChatManager {
 					onNewToken: (token) => (this.currentReply += token),
 					onReasoningDelta: (token) => (this.currentReasoning += token),
 					onReasoningStart: () => (this.currentReasoningActive = true),
+					onOutputTokens: (n) => (this.currentOutputTokens = n),
 					onMessageEnd: () => {
 						// Keep the streamed text for the abort/error paths. Non-empty only:
 						// parsers flush (and reset) when a tool call starts after text, and

--- a/frontend/src/lib/components/copilot/chat/ChatTypingIndicator.svelte
+++ b/frontend/src/lib/components/copilot/chat/ChatTypingIndicator.svelte
@@ -2,8 +2,9 @@
 	let {
 		loading,
 		compact = false,
-		label
-	}: { loading: boolean; compact?: boolean; label?: string } = $props()
+		label,
+		tokens
+	}: { loading: boolean; compact?: boolean; label?: string; tokens?: number } = $props()
 
 	// Wall-clock for the typing-dots indicator. Starts on the rising edge of
 	// `loading`, ticks once a second, frozen on the last value when loading
@@ -33,6 +34,11 @@
 		const rm = m % 60
 		return rm === 0 ? `${h}h` : `${h}h ${rm}m`
 	}
+
+	function formatTokens(n: number): string {
+		if (n < 1000) return `${n}`
+		return `${(n / 1000).toFixed(n < 10000 ? 1 : 0)}k`
+	}
 </script>
 
 <span
@@ -54,7 +60,9 @@
 		></span>
 	</span>
 	<span class={(compact ? 'text-[10px]' : 'text-2xs') + ' text-tertiary tabular-nums leading-none'}
-		>{label ? label + ' · ' : ''}{formatElapsed(loadingElapsedMs)}</span
+		>{label ? label + ' · ' : ''}{tokens ? `${formatTokens(tokens)} tokens · ` : ''}{formatElapsed(
+			loadingElapsedMs
+		)}</span
 	>
 </span>
 

--- a/frontend/src/lib/components/copilot/chat/anthropic.ts
+++ b/frontend/src/lib/components/copilot/chat/anthropic.ts
@@ -156,6 +156,15 @@ export async function parseAnthropicCompletion(
 		}
 	})
 
+	// Surface the cumulative output-token count as it streams (message_delta carries a
+	// running total for the in-flight message) so the typing indicator can show progress
+	// while the model thinks.
+	completion.on('streamEvent', (event: RawMessageStreamEvent) => {
+		if (event.type === 'message_delta' && event.usage?.output_tokens != null) {
+			callbacks.onOutputTokens?.(event.usage.output_tokens)
+		}
+	})
+
 	// Stream summarized thinking deltas to the chat's collapsible reasoning block.
 	completion.on('streamEvent', (event: RawMessageStreamEvent) => {
 		if (event.type === 'content_block_start') {

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -753,6 +753,10 @@ export interface ToolCallbacks {
 	/** Fired when the model starts reasoning — drives a "Thinking" indicator even when
 	 * no summary text is returned (e.g. OpenAI reasoning models). */
 	onReasoningStart?: () => void
+	/** Live cumulative output-token count for the in-flight assistant message (thinking +
+	 * text), so the typing indicator can show progress. Only providers that stream usage
+	 * (Anthropic) invoke it. */
+	onOutputTokens?: (outputTokens: number) => void
 	requestConfirmation?: (toolId: string) => Promise<boolean>
 	shouldAutoAcceptToolConfirmations?: () => boolean
 	requestUserQuestion?: (


### PR DESCRIPTION
## Summary

While the AI chat model is thinking, the typing indicator only showed elapsed seconds — no sign that anything is actually progressing. This surfaces a **live output-token count** next to the elapsed time (e.g. `Thinking · 1.2k tokens · 5s`), so there's real progress feedback during long thinking/streaming.

The count is real usage data, not an estimate: Anthropic's streaming API emits a cumulative `output_tokens` on every `message_delta` event, and extended-thinking tokens are billed as output tokens so they're included.

## Changes

- `shared.ts` — added optional `onOutputTokens?: (outputTokens: number) => void` to the `ToolCallbacks` interface.
- `anthropic.ts` — a `streamEvent` listener reads `event.usage.output_tokens` on `message_delta` and forwards it via the new callback.
- `AIChatManager.svelte.ts` — new `currentOutputTokens` state fed by the callback. A turn can span several API round-trips (one per tool-use step), and each step's streamed total restarts from near-zero; the manager folds each finished step's total into a base so the displayed count stays **monotonic across the whole turn**. Reset at turn start.
- `ChatTypingIndicator.svelte` — new optional `tokens` prop, formatted compactly (`900`, `1.2k`, `15k`), rendered between the label and the seconds; hidden when zero.
- `AIChatDisplay.svelte` — passes `currentOutputTokens` through (suppressed while the "Compacting conversation" label is showing).

## Notes / scope

- **Anthropic-only.** Other providers don't stream incremental usage, so they fall back to just elapsed seconds (no regression). The chat's default is Claude models, so this covers the primary case; easy to extend if another provider adds incremental usage.
- Pure UI/telemetry surface change — no prompt, tool-schema, or tool-result changes, so it doesn't affect model behavior or context-window occupancy (no `ai_evals` A/B needed).

## Test plan

- [ ] Run a global-mode AI chat turn against an Anthropic model; confirm the thinking indicator shows a live `N tokens · <elapsed>` readout that increments while the model streams.
- [ ] Trigger a turn with several sequential tool calls; confirm the token count keeps climbing across steps (does not drop back to a small number between steps).
- [ ] Confirm the count is suppressed (only elapsed shown) while the "Compacting conversation" label is active.
- [ ] Confirm a non-Anthropic provider still shows only elapsed seconds, with no errors.

## Screenshots

Not captured: the readout only appears during an in-flight Anthropic streaming turn (requires a running backend + a configured model + a live request mid-generation), and no dev server was available in this environment. The change is confined to the transient typing indicator and has no static UI state to screenshot. Happy to attach a capture from a running instance if wanted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a live output‑token count in the chat thinking indicator for real progress feedback during Anthropic streaming. Also add CI to catch broken docs links and fix outdated component docs URLs.

- **New Features**
  - Typing indicator shows a live token count (e.g., “1.2k tokens · 5s”).
  - Reads Anthropic `message_delta.usage.output_tokens` and accumulates across tool steps so the count stays monotonic; resets at turn start.
  - Hidden during “Compacting conversation” and for providers without streamed usage; others continue to show only elapsed time.

- **Bug Fixes**
  - Updated editor component `documentationLink` values to current docs pages.
  - Added `check-docs-links` CI workflow and script (`.github/scripts/check-docs-links.mjs`) to verify `windmill.dev/docs` links on tag pushes or manual runs (HEAD/GET with retries).

<sup>Written for commit ecb406d1ef3eb8bf85d8f47451160110662764a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

