### PR TITLE
fix(cli): publish all windmill-parser-wasm-* deps so local pipeline graph keeps write edges

### DIFF
--- a/cli/build-npm.ts
+++ b/cli/build-npm.ts
@@ -9,12 +9,10 @@ const outDir = "./npm";
 const cliDeps: Record<string, string> =
   JSON.parse(readFileSync("./package.json", "utf-8")).dependencies ?? {};
 
-// Parser npm packages — used as externals and added to generated package.json.
-// Derived from package.json rather than hand-listed: a parser dependency that
-// is missing here ships a CLI whose loadParser() silently falls back (e.g. the
-// local pipeline graph loses every inferred write edge), so the set must stay
-// in lockstep with the dependencies. test/parser_packages_unit.test.ts keeps
-// package.json in lockstep with the loadParser() call sites in src/.
+// Parser packages: bundle externals + published dependencies. Derived from
+// package.json (not hand-listed) — a parser missing from this set ships a CLI
+// whose loadParser() silently falls back. package.json itself is kept in sync
+// with loadParser() call sites by test/parser_packages_unit.test.ts.
 const parserPackages = Object.keys(cliDeps).filter((p) =>
   p.startsWith("windmill-parser-wasm")
 );

--- a/cli/build-npm.ts
+++ b/cli/build-npm.ts
@@ -4,23 +4,21 @@ import { join } from "node:path";
 
 const outDir = "./npm";
 
-// Parser npm packages — used as externals and added to generated package.json
-const parserPackages = [
-  "windmill-parser-wasm-py", "windmill-parser-wasm-ts",
-  "windmill-parser-wasm-regex", "windmill-parser-wasm-go",
-  "windmill-parser-wasm-php", "windmill-parser-wasm-rust",
-  "windmill-parser-wasm-yaml", "windmill-parser-wasm-csharp",
-  "windmill-parser-wasm-nu", "windmill-parser-wasm-java",
-  "windmill-parser-wasm-ruby",
-  "windmill-parser-wasm-py-imports",
-];
-const parserExternals = parserPackages.flatMap(p => ["--external", p]);
-
 // Forward parser specs from the dev package.json so the published CLI pins
-// to the same versions devs install/test against. Falls back to "*" if not
-// listed locally.
+// to the same versions devs install/test against.
 const cliDeps: Record<string, string> =
   JSON.parse(readFileSync("./package.json", "utf-8")).dependencies ?? {};
+
+// Parser npm packages — used as externals and added to generated package.json.
+// Derived from package.json rather than hand-listed: a parser dependency that
+// is missing here ships a CLI whose loadParser() silently falls back (e.g. the
+// local pipeline graph loses every inferred write edge), so the set must stay
+// in lockstep with the dependencies. test/parser_packages_unit.test.ts keeps
+// package.json in lockstep with the loadParser() call sites in src/.
+const parserPackages = Object.keys(cliDeps).filter((p) =>
+  p.startsWith("windmill-parser-wasm")
+);
+const parserExternals = parserPackages.flatMap(p => ["--external", p]);
 
 // Clean output directory
 rmSync(outDir, { recursive: true, force: true });

--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -27,6 +27,7 @@
         "windmill-parser-wasm-php": "1.647.1",
         "windmill-parser-wasm-py": "1.693.1",
         "windmill-parser-wasm-py-imports": "1.693.1",
+        "windmill-parser-wasm-r": "1.668.1",
         "windmill-parser-wasm-regex": "1.692.0",
         "windmill-parser-wasm-ruby": "1.526.1",
         "windmill-parser-wasm-rust": "1.647.1",
@@ -304,6 +305,8 @@
     "windmill-parser-wasm-py": ["windmill-parser-wasm-py@1.693.1", "", {}, "sha512-qSXKxDsKjt1UOEK1NnpKJmDrXIx/sZaGHktC6+Sj6CfhLi1X/Qj37FalOq4Es5l2qzm2NPvk4jkCXsV1QdkcHA=="],
 
     "windmill-parser-wasm-py-imports": ["windmill-parser-wasm-py-imports@1.693.1", "", {}, "sha512-FC0KbREe2G/sa/9kYIR930wmWw+VL6PvEIqg12J3dsJes3A+0x5JIUPT/jeD+c24DrG0ko/Ub7yDnYs56Bem7g=="],
+
+    "windmill-parser-wasm-r": ["windmill-parser-wasm-r@1.668.1", "", {}, "sha512-5YNeUibxpNBvYrxCgQcz1PxGhTFx2CyEpg2udtIhq7bx0d4gF/KDZVupMeQmAObmrEtTSFGUWNRJ4zXSWNrSpQ=="],
 
     "windmill-parser-wasm-regex": ["windmill-parser-wasm-regex@1.692.0", "", {}, "sha512-BHGTxrinZJ9ef6hFxbKiBqBEr5uqgG/QySOgMA5r1LswO9n/8fyGswr8JcPT2kGaoeoweV6/RQ+RHVaOhosnKw=="],
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -28,6 +28,7 @@
         "windmill-parser-wasm-php": "1.647.1",
         "windmill-parser-wasm-py": "1.693.1",
         "windmill-parser-wasm-py-imports": "1.693.1",
+        "windmill-parser-wasm-r": "1.668.1",
         "windmill-parser-wasm-regex": "1.692.0",
         "windmill-parser-wasm-ruby": "1.526.1",
         "windmill-parser-wasm-rust": "1.647.1",
@@ -1449,6 +1450,11 @@
       "version": "1.693.1",
       "resolved": "https://registry.npmjs.org/windmill-parser-wasm-py-imports/-/windmill-parser-wasm-py-imports-1.693.1.tgz",
       "integrity": "sha512-FC0KbREe2G/sa/9kYIR930wmWw+VL6PvEIqg12J3dsJes3A+0x5JIUPT/jeD+c24DrG0ko/Ub7yDnYs56Bem7g=="
+    },
+    "node_modules/windmill-parser-wasm-r": {
+      "version": "1.668.1",
+      "resolved": "https://registry.npmjs.org/windmill-parser-wasm-r/-/windmill-parser-wasm-r-1.668.1.tgz",
+      "integrity": "sha512-5YNeUibxpNBvYrxCgQcz1PxGhTFx2CyEpg2udtIhq7bx0d4gF/KDZVupMeQmAObmrEtTSFGUWNRJ4zXSWNrSpQ=="
     },
     "node_modules/windmill-parser-wasm-regex": {
       "version": "1.692.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -36,6 +36,7 @@
     "windmill-parser-wasm-php": "1.647.1",
     "windmill-parser-wasm-py": "1.693.1",
     "windmill-parser-wasm-py-imports": "1.693.1",
+    "windmill-parser-wasm-r": "1.668.1",
     "windmill-parser-wasm-regex": "1.692.0",
     "windmill-parser-wasm-ruby": "1.526.1",
     "windmill-parser-wasm-rust": "1.647.1",

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -340,11 +340,9 @@ export async function inferScriptAssets(
   return out;
 }
 
-// A missing/broken wasm asset parser degrades every script to the
-// annotation-only fallback: the graph keeps `// on` edges but silently loses
-// all inferred writes (materialize targets, COPY TO, writeS3File), which reads
-// as "my pipeline has no lineage". Warn once so a packaging or install problem
-// is visible instead of masquerading as a parsing limitation.
+// Warn once when the wasm asset parser can't load: the annotation-only
+// fallback silently drops all inferred read/write edges, so a packaging or
+// install problem would otherwise masquerade as a parsing limitation.
 let warnedAssetParserUnavailable = false;
 
 async function inferScriptAssetsBody(

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -15,6 +15,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import process from "node:process";
 import { loadParser } from "../../utils/metadata.ts";
+import * as log from "../../core/log.ts";
 import { exts, removeExtensionToPath } from "../script/script.ts";
 import { inferContentTypeFromFilePath } from "../../utils/script_common.ts";
 import { getWmillYamlPath } from "../../core/conf.ts";
@@ -339,6 +340,13 @@ export async function inferScriptAssets(
   return out;
 }
 
+// A missing/broken wasm asset parser degrades every script to the
+// annotation-only fallback: the graph keeps `// on` edges but silently loses
+// all inferred writes (materialize targets, COPY TO, writeS3File), which reads
+// as "my pipeline has no lineage". Warn once so a packaging or install problem
+// is visible instead of masquerading as a parsing limitation.
+let warnedAssetParserUnavailable = false;
+
 async function inferScriptAssetsBody(
   content: string,
   language: string,
@@ -349,7 +357,15 @@ async function inferScriptAssetsBody(
   try {
     const mod = await loadParser(ASSET_WASM_PKG);
     raw = mod[fn](content) as string;
-  } catch {
+  } catch (e) {
+    if (!warnedAssetParserUnavailable) {
+      warnedAssetParserUnavailable = true;
+      log.warnStderr(
+        `warning: ${ASSET_WASM_PKG} failed to load (${
+          e instanceof Error ? e.message : e
+        }) — falling back to annotation-only parsing; inferred read/write edges (materialize targets, COPY TO, writeS3File) will be missing from the local graph`,
+      );
+    }
     return fallbackParse(content, language);
   }
   if (raw.startsWith("err:")) return fallbackParse(content, language);

--- a/cli/test/parser_packages_unit.test.ts
+++ b/cli/test/parser_packages_unit.test.ts
@@ -2,17 +2,9 @@ import { expect, test } from "bun:test";
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
-// =============================================================================
-// PARSER PACKAGE LOCKSTEP TEST
-//
-// The npm publish (build-npm.ts) derives its externals + published
-// dependencies from package.json's windmill-parser-wasm-* entries. A parser
-// package that src/ loads but package.json does not declare therefore ships a
-// CLI where loadParser() throws and callers silently degrade — e.g. the local
-// pipeline graph (`wmill pipeline show|dev --local`) loses every inferred
-// write edge. This test scans src/ for parser-package string literals and
-// requires each one to be a declared dependency.
-// =============================================================================
+// build-npm.ts derives the published CLI's parser dependencies from
+// package.json, so a parser package that src/ loads but package.json omits
+// ships a CLI where loadParser() throws and callers silently degrade.
 
 const cliRoot = join(import.meta.dir, "..");
 

--- a/cli/test/parser_packages_unit.test.ts
+++ b/cli/test/parser_packages_unit.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+// =============================================================================
+// PARSER PACKAGE LOCKSTEP TEST
+//
+// The npm publish (build-npm.ts) derives its externals + published
+// dependencies from package.json's windmill-parser-wasm-* entries. A parser
+// package that src/ loads but package.json does not declare therefore ships a
+// CLI where loadParser() throws and callers silently degrade — e.g. the local
+// pipeline graph (`wmill pipeline show|dev --local`) loses every inferred
+// write edge. This test scans src/ for parser-package string literals and
+// requires each one to be a declared dependency.
+// =============================================================================
+
+const cliRoot = join(import.meta.dir, "..");
+
+function collectSourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) collectSourceFiles(p, out);
+    else if (p.endsWith(".ts")) out.push(p);
+  }
+  return out;
+}
+
+test("every windmill-parser-wasm-* package referenced in src/ is a declared dependency", () => {
+  const deps: Record<string, string> =
+    JSON.parse(readFileSync(join(cliRoot, "package.json"), "utf-8"))
+      .dependencies ?? {};
+
+  const referenced = new Set<string>();
+  for (const file of collectSourceFiles(join(cliRoot, "src"))) {
+    for (const m of readFileSync(file, "utf-8").matchAll(
+      /"(windmill-parser-wasm-[a-z-]+)"/g,
+    )) {
+      referenced.add(m[1]);
+    }
+  }
+
+  // Sanity: the scan must see the known call sites, else the regex went stale.
+  expect(referenced.has("windmill-parser-wasm-ts")).toBe(true);
+  expect(referenced.has("windmill-parser-wasm-asset")).toBe(true);
+
+  const missing = [...referenced].filter((p) => !(p in deps)).sort();
+  expect(missing).toEqual([]);
+});


### PR DESCRIPTION
## Summary

The npm publish script (`cli/build-npm.ts`) hand-listed the parser wasm packages to mark as externals and to copy into the published `package.json` dependencies — and that list was never updated when `windmill-parser-wasm-asset` was added for pipeline local development (#9840). The published CLI (1.745–1.747) therefore cannot resolve the asset parser at runtime: `loadParser()` throws, the local pipeline graph silently degrades to annotation-only parsing, and **every inferred write edge (`-- materialize` targets, DuckDB `COPY TO`, `wmill.writeS3File`) is missing from `wmill pipeline show|docs|dev|run --local`** — the graph renders as disconnected fragments while the same folder renders a full DAG on the server. `windmill-parser-wasm-r` had the same problem one layer earlier: used by `src/` but never declared in `package.json` at all.

## Changes

- `cli/build-npm.ts`: derive the parser externals + published dependencies from `package.json`'s `windmill-parser-wasm-*` entries instead of a hand-maintained list, so a declared parser can no longer be dropped from the publish.
- `cli/package.json` / lockfiles: declare `windmill-parser-wasm-r@1.668.1` (already loaded by `src/utils/metadata.ts` for R scripts, previously unresolvable).
- `cli/src/commands/pipeline/localGraph.ts`: when the wasm asset parser fails to load, warn once on stderr (via `log.warnStderr`, silent-mode aware) instead of silently falling back — a packaging/install problem no longer masquerades as "my pipeline has no lineage".
- `cli/test/parser_packages_unit.test.ts`: lockstep test — every `windmill-parser-wasm-*` string literal in `src/` must be a declared dependency (guards the src → package.json link; build-npm now trivially mirrors package.json for the rest of the chain).

## Test plan

- [x] `bun test test/parser_packages_unit.test.ts` passes (and fails if the `-r` or `-asset` dependency is removed).
- [x] Full CLI unit suite: 913 pass / 0 fail; `bunx tsc --noEmit` error count unchanged vs main.
- [x] `bun run build-npm.ts` → generated `npm/package.json` now lists all 14 `windmill-parser-wasm-*` deps (was 12, missing `-asset` and `-r`).
- [x] E2E on the built package installed in a clean dir: `wmill pipeline show f/ecommerce --local` renders the full DAG with write edges (previously a flat list).
- [x] Negative path: removing `node_modules/windmill-parser-wasm-asset` from the clean install prints the once-only stderr warning and still completes with annotation-only edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI publishing so all `windmill-parser-wasm-*` packages are included, keeping inferred write edges and full DAGs in local pipeline graphs. Adds a once-only warning if `windmill-parser-wasm-asset` fails to load to avoid silent fallback parsing.

- **Bug Fixes**
  - Derive parser externals and published deps from `package.json` instead of a hardcoded list.
  - Declare `windmill-parser-wasm-r@1.668.1` in `cli/package.json` (previously used but undeclared).
  - Warn once on stderr when `windmill-parser-wasm-asset` cannot load; continue with annotation-only parsing.
  - Add a unit test to ensure every `windmill-parser-wasm-*` string in `src/` is a declared dependency.

<sup>Written for commit 20325a1a34055d4485a5fced86be22205d930c50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

