### PR TITLE
fix(cli): pipeline + workspace UX improvements

### DIFF
--- a/cli/src/commands/init/init.ts
+++ b/cli/src/commands/init/init.ts
@@ -251,7 +251,7 @@ async function initAction(opts: InitOptions) {
     );
   }
 
-  // Generate resource type namespace (only if a workspace was bound)
+  // Generate resource type namespace (needs a bound workspace)
   if (didBindWorkspace && boundProfile) {
     try {
       // Cache the bound profile so resolveWorkspace doesn't re-resolve and prompt again
@@ -266,9 +266,51 @@ async function initAction(opts: InitOptions) {
       );
     }
   } else {
-    log.info(
-      colors.gray("Skipped resource type namespace generation (no workspace bound). Run 'wmill workspace bind' then 'wmill init' to generate it.")
+    // generateRTNamespace resolves a workspace; its non-interactive
+    // multiple-workspaces path process.exit(-1)s (uncatchable), aborting init.
+    // So generate only for a single resolvable workspace (baseUrl + matching
+    // profile), passed via __secret_workspace to skip resolution; else skip.
+    const { readConfigFile, getWorkspaceNames, getEffectiveWorkspaceId } =
+      await import("../../core/conf.ts");
+    const config = await readConfigFile({ warnIfMissing: false });
+    const resolvable = getWorkspaceNames(config.workspaces).filter(
+      (n) => !!(config.workspaces as any)?.[n]?.baseUrl
     );
+    let boundProfileForGen: Workspace | undefined;
+    if (resolvable.length === 1) {
+      const name = resolvable[0];
+      const entry = (config.workspaces as any)[name];
+      let normalizedBaseUrl: string | undefined;
+      try {
+        normalizedBaseUrl = new URL(entry.baseUrl).toString();
+      } catch {
+        normalizedBaseUrl = undefined;
+      }
+      if (normalizedBaseUrl) {
+        const workspaceId = getEffectiveWorkspaceId(name, entry);
+        const profiles = await allWorkspaces(opts.configDir);
+        boundProfileForGen = profiles.find(
+          (p) => p.remote === normalizedBaseUrl && p.workspaceId === workspaceId
+        );
+      }
+    }
+    if (boundProfileForGen) {
+      try {
+        const rtOpts = { ...opts } as GlobalOptions;
+        (rtOpts as any).__secret_workspace = boundProfileForGen;
+        await generateRTNamespace(rtOpts);
+      } catch (error) {
+        log.warn(
+          `Could not pull resource types and generate TypeScript namespace: ${
+            error instanceof Error ? error.message : error
+          }`
+        );
+      }
+    } else {
+      log.info(
+        colors.gray("Skipped resource type namespace generation (no workspace bound). Run 'wmill workspace bind' then 'wmill init' to generate it.")
+      );
+    }
   }
 }
 

--- a/cli/src/commands/init/template.ts
+++ b/cli/src/commands/init/template.ts
@@ -180,8 +180,12 @@ export const CONFIG_REFERENCE: ConfigOption[] = [
     additionalProperties: WORKSPACE_CONFIG_SCHEMA,
     section: "Workspace bindings",
     sectionNote: "Map workspace names to Windmill instances and override settings per workspace.\nThe key is a human-friendly workspace name. gitBranch and workspaceId default to the key name.",
-    templateValue: "\n  {{BRANCH}}: {}",
+    // Empty ` {}`, not a live `<name>: {}` stub: a stub has no baseUrl yet
+    // counts as a configured workspace, breaking auto-selection and making a
+    // later `workspace bind` ambiguous. The example stays commented.
+    templateValue: " {}",
     example: [
+      "  # {{BRANCH}}:",
       "{{BASEURL_LINE}}",
       "{{WORKSPACE_ID_LINE}}",
       "    # gitBranch: main                        # git branch (defaults to workspace name)",

--- a/cli/src/commands/pipeline/boundedCascade.ts
+++ b/cli/src/commands/pipeline/boundedCascade.ts
@@ -19,6 +19,9 @@ export type BCGraph = {
     // `// partitioned <kind>` on the script (daily/hourly/weekly/monthly/dynamic).
     // Emitted by both the deployed graph endpoint and the local builder.
     partition_kind?: string;
+    // `// macros` library: non-empty on a workspace macro library (deployed
+    // graph only). Definition-only — never a runnable cascade step.
+    macros?: { name: string }[];
   }[];
   assets: { kind: string; path: string }[];
   edges: {

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -52,6 +52,9 @@ export type GraphRunnable = {
   // schema-contract warnings; only present when set (default `warn` is absent),
   // mirroring the deployed graph node.
   materialize_on_schema_change?: string;
+  // `// macros` library: the macros it defines (deployed graph only — the wasm
+  // asset parser does not emit them). Non-empty ⇒ definition-only node.
+  macros?: { name: string; params?: string; is_table?: boolean }[];
 };
 export type GraphEdge = {
   runnable_kind: string;
@@ -80,6 +83,14 @@ export type AssetGraph = {
   assets: { kind: string; path: string }[];
   edges: GraphEdge[];
   triggers: GraphTrigger[];
+  // ƒ edges from a `// macros` library to the scripts calling its macros
+  // (deployed graph only).
+  macro_edges?: {
+    lib_path: string;
+    consumer_path: string;
+    macro_names: string[];
+    via_use?: boolean;
+  }[];
 };
 
 export type LocalScript = {

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -302,6 +302,25 @@ async function renderGraph(
     return out.length > 0 ? " " + out.join(" ") : "";
   }
 
+  // `// macros` libraries: badge the node with the macros it defines and list
+  // its consumers as ƒ edges. Deployed graphs only — the local wasm parse does
+  // not emit `macros`/`macro_edges`, so local mode renders them as plain nodes.
+  const macrosByLib = new Map(
+    graph.runnables
+      .filter((r) => (r.macros?.length ?? 0) > 0)
+      .map((r) => [r.path, r.macros!]),
+  );
+  const macroConsumersByLib = new Map<
+    string,
+    { consumer: string; names: string[] }[]
+  >();
+  for (const me of graph.macro_edges ?? []) {
+    pushTo(macroConsumersByLib, me.lib_path, {
+      consumer: me.consumer_path,
+      names: me.macro_names,
+    });
+  }
+
   const printed = new Set<string>();
   const lines: string[] = [];
 
@@ -317,8 +336,22 @@ async function renderGraph(
       return;
     }
     printed.add(script);
-    lines.push(`${prefix}${colors.bold(shortName(script))}${triggerBadges(script)}${alsoOn}`);
+    const libMacros = macrosByLib.get(script);
+    const macroBadge = libMacros
+      ? " " +
+        colors.magenta(`[ƒ macros: ${libMacros.map((m) => m.name).join(", ")}]`)
+      : "";
+    lines.push(`${prefix}${colors.bold(shortName(script))}${macroBadge}${triggerBadges(script)}${alsoOn}`);
     const childPrefix = prefix.replace(/├─ $/, "│  ").replace(/└─ $/, "   ");
+    const macroConsumers = [...(macroConsumersByLib.get(script) ?? [])].sort(
+      (a, b) => a.consumer.localeCompare(b.consumer),
+    );
+    macroConsumers.forEach(({ consumer, names }, i) => {
+      const branch = i === macroConsumers.length - 1 ? "└─ƒ " : "├─ƒ ";
+      lines.push(
+        `${childPrefix}${branch}${shortName(consumer)} ${colors.dim(`(uses ${names.join(", ")})`)}`,
+      );
+    });
     const writes = [...(writesByScript.get(script) ?? [])].sort();
     writes.forEach((uri, i) => {
       const lastAsset = i === writes.length - 1;
@@ -368,7 +401,10 @@ async function renderGraph(
 
 // Poll a launched job to a terminal state. Modest fixed cadence; capped so a
 // wedged job can't hang the CLI forever.
-async function waitJob(workspace: string, id: string): Promise<boolean> {
+async function waitJob(
+  workspace: string,
+  id: string,
+): Promise<{ ok: boolean; result?: unknown }> {
   const MAX_RETRIES = 6000; // ~10min at 100ms
   for (let i = 0; i < MAX_RETRIES; i++) {
     try {
@@ -380,13 +416,33 @@ async function waitJob(workspace: string, id: string): Promise<boolean> {
       // A completed job without an explicit `success: true` is a failure
       // (mirrors the frontend `waitJobTerminal`): the cascade only advances on
       // a confirmed success.
-      if (r.completed) return r.success === true;
+      if (r.completed) return { ok: r.success === true, result: r.result };
     } catch {
       // transient — retry
     }
     await new Promise((res) => setTimeout(res, 100));
   }
   throw new Error(`Timed out waiting for job ${id}`);
+}
+
+// Render a failed job's `{error: {name, message}}` result for the terminal, so
+// the user sees WHY the cascade stopped without opening the UI. Result shapes
+// vary (structured data-test payloads, plain strings), so fall back to raw
+// JSON when the canonical error shape is absent.
+function formatJobFailure(result: unknown): string | undefined {
+  if (result == null) return undefined;
+  const err = (result as any)?.error;
+  if (err && typeof err === "object") {
+    const name = typeof err.name === "string" ? err.name : undefined;
+    const message = typeof err.message === "string" ? err.message : undefined;
+    if (message) return name ? `${name}: ${message}` : message;
+  }
+  if (typeof result === "string") return result;
+  try {
+    return JSON.stringify(result, null, 2);
+  } catch {
+    return undefined;
+  }
 }
 
 // Bounded-cascade run: start at a schedule / manual root, fan downstream, but
@@ -603,9 +659,23 @@ async function run(
     merged[b.param] = b.value;
   }
 
+  // `// macros` libraries are definition-only: their macros are injected into
+  // consuming DuckDB scripts at run time, so "running" one is a no-op preview.
+  // They are excluded from starts and from every selection below (they'd
+  // otherwise read as manual roots, since nothing triggers them).
+  const macroLibPaths = new Set(
+    graph.runnables
+      .filter((r) => r.usage_kind === "script" && (r.macros?.length ?? 0) > 0)
+      .map((r) => r.path),
+  );
+
   // Resolve the start: explicit --from (must be a valid start) or the folder's
   // sole valid start. `--upload`-bound scripts join the valid starts.
-  const starts = new Set([...validStarts(graph), ...boundNodeIds]);
+  const starts = new Set(
+    [...validStarts(graph), ...boundNodeIds].filter(
+      (id) => !macroLibPaths.has(scriptPathOf(id)),
+    ),
+  );
   // `runAll` = no `--from` on a multi-root pipeline (fan-in): run the whole
   // pipeline in topological order rather than forcing a single start, the way
   // `dbt run` (no `--select`) runs the entire project. `--to` still needs an
@@ -626,6 +696,11 @@ async function run(
         );
       }
       throw new Error(`--from '${opts.from}' matched no script in f/${f}.`);
+    }
+    if (macroLibPaths.has(scriptPathOf(resolved))) {
+      throw new Error(
+        `--from '${opts.from}' is a \`// macros\` library — definition-only, injected into consuming scripts at run time, never a runnable step.`,
+      );
     }
     if (!starts.has(resolved)) {
       throw new Error(
@@ -728,6 +803,11 @@ async function run(
       }
     }
   }
+
+  // Selections can still pull a macro library in via graph reachability (e.g.
+  // whole-pipeline mode collects every root's closure) — drop them before
+  // ordering so they never run.
+  for (const p of macroLibPaths) selectedScripts.delete(p);
 
   const { order, cyclic } = topoOrder(graph, selectedScripts);
   if (cyclic.length > 0) {
@@ -877,9 +957,15 @@ async function run(
         requestBody: nodeArgs,
       });
     }
-    const ok = await waitJob(workspace.workspaceId, id);
+    const { ok, result } = await waitJob(workspace.workspaceId, id);
     if (!ok) {
-      throw new Error(`Bounded run failed at ${nodePath} (job ${id}).`);
+      const detail = formatJobFailure(result);
+      const runUrl = `${workspace.remote}run/${id}?workspace=${workspace.workspaceId}`;
+      throw new Error(
+        `Bounded run failed at ${nodePath} (job ${id}).` +
+          (detail ? `\n${detail}` : "") +
+          `\nFull logs: ${runUrl}`,
+      );
     }
     if (!opts.json) log.info(colors.green(`  ✓ ${nodePath}`));
   }

--- a/cli/src/commands/sync/sync.ts
+++ b/cli/src/commands/sync/sync.ts
@@ -41,6 +41,7 @@ import { handleFile } from "../script/script.ts";
 import {
   deepEqual,
   fetchRemoteVersion,
+  getHeaders,
   isFileResource,
   isFilesetResource,
   isRawAppFile,
@@ -3550,6 +3551,61 @@ function removeSuffix(str: string, suffix: string) {
 const SYNC_PUSH_DESTRUCTIVE_WARNING =
   "`wmill sync push` is destructive: applying it deploys these changes to the remote workspace and overwrites or deletes remote items that differ from or are absent locally — this is not automatically reversible. If you are an AI agent, do NOT run `wmill sync push` (without --dry-run) until the user has explicitly confirmed this deploy, unless your custom instructions explicitly allow bypassing that confirmation.";
 
+// A script pushed without a local lock queues a server-side dependency job; if
+// that job fails the script deploys broken (no lock/assets) with no CLI signal.
+// One-shot (no polling): report this push's already-failed + still-running
+// dependency jobs.
+async function checkServerLockJobs(
+  workspaceId: string,
+  sinceIso: string,
+  changedPaths: string[],
+): Promise<{ pending: number; failed: { path: string; error?: string }[] }> {
+  // A dependency job's script_path has no file extension; changed paths do.
+  const belongsToPush = (scriptPath?: string) =>
+    !!scriptPath &&
+    changedPaths.some(
+      (p) => p === scriptPath || p.startsWith(scriptPath + "."),
+    );
+  // Raw fetch: the checked-in generated client predates the `created_after` /
+  // `success` filters on the job list routes (see the `apiGet` note in
+  // pipeline.ts).
+  const listJobs = async (path: string): Promise<unknown[]> => {
+    const { OpenAPI } = await import("../../../gen/index.ts");
+    const resp = await fetch(`${OpenAPI.BASE}${path}`, {
+      headers: { ...getHeaders(), Authorization: `Bearer ${OpenAPI.TOKEN}` },
+    });
+    if (!resp.ok) throw new Error(`GET ${path} -> ${resp.status}`);
+    return (await resp.json()) as unknown[];
+  };
+  try {
+    const since = encodeURIComponent(sinceIso);
+    const [queued, completed] = await Promise.all([
+      listJobs(
+        `/w/${workspaceId}/jobs/queue/list?job_kinds=dependencies&created_after=${since}`,
+      ),
+      listJobs(
+        `/w/${workspaceId}/jobs/completed/list?job_kinds=dependencies&created_after=${since}&success=false`,
+      ),
+    ]);
+    const pending = (queued as { script_path?: string }[]).filter((j) =>
+      belongsToPush(j.script_path),
+    ).length;
+    const failed = (
+      completed as { script_path?: string; result?: unknown }[]
+    )
+      .filter((j) => belongsToPush(j.script_path))
+      .map((j) => ({
+        path: j.script_path!,
+        error: (j.result as { error?: { message?: string } } | undefined)
+          ?.error?.message,
+      }));
+    return { pending, failed };
+  } catch {
+    // Advisory only: a failed check must not fail an otherwise-complete push.
+    return { pending: 0, failed: [] };
+  }
+}
+
 export async function push(
   opts: GlobalOptions & SyncOptions & { repository?: string; branch?: string; acceptOverridingPermissionedAsWithSelf?: boolean },
 ) {
@@ -4176,6 +4232,7 @@ export async function push(
     }
 
     const start = performance.now();
+    const pushStartedAt = new Date().toISOString();
     log.info(colors.gray(`Applying changes to files ...`));
 
     let stateful = opts.stateful;
@@ -4917,9 +4974,30 @@ export async function push(
     } catch (e) {
       log.warn(`Failed to push shared UI folder: ${e}`);
     }
+    const lockJobs = await checkServerLockJobs(
+      workspace.workspaceId,
+      pushStartedAt,
+      changes.map((c) => c.path.replaceAll(SEP, "/")),
+    );
+    if (!opts.jsonOutput) {
+      for (const f of lockJobs.failed) {
+        log.warn(
+          `⚠ server-side lock generation FAILED for ${f.path} — the deployed script is broken until it locks.` +
+            (f.error ? `\n  ${f.error.split("\n")[0]}` : ""),
+        );
+      }
+      if (lockJobs.pending > 0) {
+        log.info(
+          colors.gray(
+            `${lockJobs.pending} server-side lock job(s) still running — locks (and inferred assets) land when they finish; check the Runs page if a script stays broken.`,
+          ),
+        );
+      }
+    }
     if (opts.jsonOutput) {
       const result = {
         success: true,
+        lock_jobs: lockJobs,
         message: `All ${changes.length} changes pushed to the remote workspace ${workspace.workspaceId} named ${workspace.name}`,
         changes: changes.map((change) => ({
           type: change.name,

--- a/cli/src/commands/workspace/workspace.ts
+++ b/cli/src/commands/workspace/workspace.ts
@@ -669,6 +669,26 @@ async function bind(
     }
     (config.workspaces as any)[wsName] = entry;
 
+    // Drop empty `{}` placeholder entries (older `wmill init` scaffolded one):
+    // they resolve to nothing (no baseUrl) yet count as configured workspaces,
+    // so leaving one beside the real binding makes every later command demand
+    // --workspace to disambiguate.
+    for (const [name, e] of Object.entries(
+      config.workspaces as Record<string, unknown>
+    )) {
+      if (
+        name !== wsName &&
+        !!e &&
+        typeof e === "object" &&
+        Object.keys(e).length === 0
+      ) {
+        delete (config.workspaces as any)[name];
+        log.info(
+          colors.gray(`Removed empty placeholder workspace entry '${name}'`)
+        );
+      }
+    }
+
     log.info(
       colors.green(
         `✓ Bound workspace '${wsName}'` +

--- a/cli/src/utils/upgrade.ts
+++ b/cli/src/utils/upgrade.ts
@@ -57,6 +57,64 @@ export class NpmProvider extends Provider {
   async hasRequiredPermissions(): Promise<boolean> {
     return true;
   }
+
+  // Cliffy's default runtime runs `npm install --silent`, so a failed upgrade
+  // throws with an empty message. Override to run npm without --silent and put
+  // the captured output + recovery hint in the error, so failures are actionable.
+  override async upgrade({
+    name,
+    to,
+    main,
+    verbose,
+  }: {
+    name: string;
+    to: string;
+    main?: string;
+    verbose?: boolean;
+  }): Promise<void> {
+    const specifier = this.getSpecifier(name, to, main).replace(/^npm:/, "");
+    const args = ["install", "--global", "--force", specifier];
+    this.logger?.log(`$ npm ${args.join(" ")}`);
+    const { spawn } = await import("node:child_process");
+    const HINT =
+      "If this is a permissions error, retry with sudo, or reinstall with: npm uninstall -g windmill-cli && npm install -g windmill-cli";
+    // `shell: true` so `npm` resolves on Windows (npm.cmd) — same spawn
+    // pattern as commands/app/bundle.ts.
+    const proc = spawn("npm", args, {
+      stdio: [null, "pipe", "pipe"],
+      shell: true,
+    });
+    const output: string[] = [];
+    proc.stdout?.on("data", (d) => {
+      output.push(String(d));
+      if (verbose) process.stdout.write(d);
+    });
+    proc.stderr?.on("data", (d) => {
+      output.push(String(d));
+      if (verbose) process.stderr.write(d);
+    });
+    // `error` fires when npm can't be spawned at all; without a listener that
+    // is an uncaught exception, crashing before any hint prints. `close`
+    // resolves null when npm died from a signal — a failure too.
+    const exitCode: number | null = await new Promise<number | null>(
+      (resolve, reject) => {
+        proc.on("error", reject);
+        proc.on("close", resolve);
+      }
+    ).catch((e) => {
+      throw new Error(
+        `failed to run npm: ${e instanceof Error ? e.message : e}\n\n${HINT}`
+      );
+    });
+    if (exitCode !== 0) {
+      const detail = output.join("").trim();
+      throw new Error(
+        `npm exited with ${
+          exitCode === null ? "a signal" : `code ${exitCode}`
+        }${detail ? `:\n${detail}` : ""}\n\n${HINT}`
+      );
+    }
+  }
 }
 
 type NpmApiPackageMetadata = {

--- a/cli/test/init_template_unit.test.ts
+++ b/cli/test/init_template_unit.test.ts
@@ -25,23 +25,44 @@ describe("generateCommentedTemplate", () => {
     expect(typeof config).toBe("object");
   });
 
-  test("uses provided branch name in workspaces", () => {
-    const config = parse(generateCommentedTemplate("my-feature"));
-    expect(config.workspaces["my-feature"]).toBeDefined();
+  // Without bindings, `workspaces` must stay EMPTY (a live `<branch>: {}`
+  // placeholder is unresolvable — no baseUrl — yet counts as a configured
+  // workspace, breaking auto-selection and making a later bind ambiguous).
+  // The branch name only appears in the commented example.
+  test("uses provided branch name in the commented workspaces example only", () => {
+    const yaml = generateCommentedTemplate("my-feature");
+    const config = parse(yaml);
+    expect(config.workspaces).toEqual({});
+    expect(yaml).toContain("# my-feature:");
   });
 
   test("defaults to 'main' when no branch name given", () => {
-    const config = parse(generateCommentedTemplate());
-    expect(config.workspaces["main"]).toBeDefined();
+    const yaml = generateCommentedTemplate();
+    const config = parse(yaml);
+    expect(config.workspaces).toEqual({});
+    expect(yaml).toContain("# main:");
   });
 
   test("quotes branch names with YAML-special characters", () => {
     const specialBranches = ["fix: something", "feat/my branch", "release#1"];
     for (const branch of specialBranches) {
       const yaml = generateCommentedTemplate(branch);
+      // Still valid YAML with an empty workspaces map; the (quoted) branch
+      // name only appears in comments.
       const config = parse(yaml);
-      expect(config.workspaces[branch]).toBeDefined();
+      expect(config.workspaces).toEqual({});
+      expect(yaml).toContain(branch);
     }
+  });
+
+  test("renders live workspaces entries when bindings are provided", () => {
+    const yaml = generateCommentedTemplate("main", undefined, [
+      { name: "prod", baseUrl: "https://app.windmill.dev/", workspaceId: "prod-ws" },
+    ]);
+    const config = parse(yaml);
+    expect(config.workspaces["prod"]).toBeDefined();
+    expect(config.workspaces["prod"].baseUrl).toBe("https://app.windmill.dev/");
+    expect(config.workspaces["prod"].workspaceId).toBe("prod-ws");
   });
 
   test("contains yaml-language-server schema directive", () => {


### PR DESCRIPTION
## Summary

Five CLI friction fixes found while dogfooding data pipelines end-to-end as a dbt/Dagster-style user (companion parser-packaging fix in #9926). Each fix was E2E-verified against a live backend.

> Two items from the original batch were dropped after review: the `--workspace <workspace-id>` fork fallback (the git-branch fork mechanism already resolves the primary fork-dev workflow automatically, and the fallback rested on a user-scoped-token assumption for a marginal explicit-flag case), and the non-interactive-`init`-binds-by-default flip (a debatable default change not needed for the stub fix).

## Changes

- **init/bind stub poisoning**: `wmill init` scaffolded a live `workspaces: { main: {} }` placeholder — unresolvable (no baseUrl) yet counted as configured, so auto-selection broke and `wmill workspace bind` sat beside it as an ambiguous second entry, while `init` kept telling the user to run the bind they had just run. Now: the template keeps `workspaces: {}` with a commented example; re-running `init` on an already-bound project generates the RT namespace instead of claiming "no workspace bound"; and `workspace bind` removes empty `{}` placeholder entries. (Non-interactive init behavior is unchanged from main.)
- **`pipeline run` failures were a bare job uuid**: now prints the failed job's error payload (name + message, JSON fallback) and the run URL.
- **`// macros` libraries ran as cascade steps**: they are definition-only (injected into consumers at run time), so they are now excluded from run plans/starts, `--from <macro-lib>` gets a specific error, and `pipeline show` renders an `[ƒ macros: …]` badge with ƒ consumer edges from the graph's `macro_edges`.
- **`sync push` reported success while server-side lock jobs failed**: pushing a script without a local lock queues a dependency job; on failure the script is deployed broken with no CLI signal. Push now does a one-shot post-push check (raw fetch; `cli/gen` is knowingly stale): warns per already-failed lock job and reports the still-running count (`lock_jobs` field in `--json`). Advisory only — check errors never fail the push.
- **`wmill upgrade` failures printed nothing**: cliffy runs `npm --silent` non-verbose, so the thrown error had an empty message. `NpmProvider` now implements `upgrade()` itself: no `--silent`, captured npm output + recovery hint in the error, `shell: true` for Windows npm.cmd, spawn-`error` handled, signal exit treated as failure.

## Test plan

- [x] 913 CLI unit tests pass (`UNIT_ONLY=1 bun test test/*_unit*`); `init_template_unit.test.ts` pins the new no-stub contract + a live-bindings rendering test.
- [x] `bunx tsc --noEmit` error count identical to main (pre-existing JSZip typing only).
- [x] E2E (live backend): fresh-dir `wmill init` writes empty `workspaces: {}`; re-run generates `rt.d.ts`; `workspace bind` heals a poisoned wmill.yaml (`Removed empty placeholder workspace entry 'main'`).
- [x] E2E: failed pipeline run prints the WAP data-test breakdown + run URL inline.
- [x] E2E: whole-pipeline plan drops the macro lib (9 steps, was 10); `pipeline show` renders `shop_macros [ƒ macros: aov, pct]` with ƒ edges; `--from shop_macros` errors specifically.
- [x] E2E: push with an unresolvable import warns `server-side lock generation FAILED for f/ecommerce/bad_dep`; busy pushes report `N server-side lock job(s) still running`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)