### PR TITLE
fix(pipelines): activity-axis label clarity + select failed node on cascade failure

### DIFF
--- a/frontend/src/lib/components/assets/AssetGraph/ActivityHistogram.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/ActivityHistogram.svelte
@@ -147,9 +147,10 @@
 			></div>
 		{/if}
 	</div>
-	<!-- Always-on window axis: the period the bars span. -->
+	<!-- Always-on window axis: the period the bars span. The `from` prefix keeps
+	     the left edge from reading as a date header for the run list below it. -->
 	<div class="flex justify-between text-3xs text-tertiary tabular-nums mt-0.5">
-		<span>{fmtTime(from)}</span>
+		<span>from {fmtTime(from)}</span>
 		<span>now</span>
 	</div>
 </div>

--- a/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
@@ -1480,9 +1480,12 @@
 			} else {
 				const failed = [...res.statuses.entries()].filter(([, s]) => s.status === 'failure')
 				const skipped = [...res.statuses.values()].filter((s) => s.status === 'skipped').length
-				// Surface the failed node in the details pane so its error is visible
-				// without hunting for the red node on the canvas.
+				// Surface the failed node's error in the details pane. Clear the
+				// active draft too — it has pane priority over `selection`
+				// (openScriptPath), so a bare selection would stay masked while a
+				// draft is open.
 				if (failed.length > 0) {
+					pe.activeDraftPath = undefined
 					pe.selection = { kind: 'runnable', runnable_kind: 'script', path: failed[0][0] }
 				}
 				sendUserToast(
@@ -1621,9 +1624,12 @@
 			} else {
 				const failed = [...res.statuses.entries()].filter(([, s]) => s.status === 'failure')
 				const skipped = [...res.statuses.values()].filter((s) => s.status === 'skipped').length
-				// Surface the failed node in the details pane so its error is visible
-				// without hunting for the red node on the canvas.
+				// Surface the failed node's error in the details pane. Clear the
+				// active draft too — it has pane priority over `selection`
+				// (openScriptPath), so a bare selection would stay masked while a
+				// draft is open.
 				if (failed.length > 0) {
+					pe.activeDraftPath = undefined
 					pe.selection = { kind: 'runnable', runnable_kind: 'script', path: failed[0][0] }
 				}
 				sendUserToast(

--- a/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
@@ -1480,6 +1480,11 @@
 			} else {
 				const failed = [...res.statuses.entries()].filter(([, s]) => s.status === 'failure')
 				const skipped = [...res.statuses.values()].filter((s) => s.status === 'skipped').length
+				// Surface the failed node in the details pane so its error is visible
+				// without hunting for the red node on the canvas.
+				if (failed.length > 0) {
+					pe.selection = { kind: 'runnable', runnable_kind: 'script', path: failed[0][0] }
+				}
 				sendUserToast(
 					`Chain run failed at ${failed.map(([p]) => p).join(', ')}` +
 						(skipped > 0 ? ` — ${skipped} downstream skipped` : ''),
@@ -1616,6 +1621,11 @@
 			} else {
 				const failed = [...res.statuses.entries()].filter(([, s]) => s.status === 'failure')
 				const skipped = [...res.statuses.values()].filter((s) => s.status === 'skipped').length
+				// Surface the failed node in the details pane so its error is visible
+				// without hunting for the red node on the canvas.
+				if (failed.length > 0) {
+					pe.selection = { kind: 'runnable', runnable_kind: 'script', path: failed[0][0] }
+				}
 				sendUserToast(
 					`Bounded run failed at ${failed.map(([p]) => p).join(', ')}` +
 						(skipped > 0 ? ` — ${skipped} downstream skipped` : ''),


### PR DESCRIPTION
## Summary

Two small frontend-polish fixes from the pipeline dogfooding session (F13, F23 of the friction report). The other two frontend items are not included: **F22** (console 404s on pipeline pages) turned out to be environmental — native-trigger integrations simply not enabled in the dev instance, not a product bug — and **F15** (unreadable WAP data-test error) is really an EE change (the escaped-blob message is built in `pipeline_advanced_ee.rs`), scoped as a separate follow-up.

## Changes

- **F13 — activity-window axis label.** The histogram's left-edge time label (`fmtTime(from)`, i.e. 30 days before now) sits directly above the run list and reads as a date-group *header* for the runs — I initially misread it as a month-off bug before realizing it's the window's left edge. Prefixed it with `from ` so `from Jun 5, 02:10 PM … now` reads unambiguously as a time-span axis. (`ActivityHistogram.svelte`)
- **F23 — select the failed node on cascade failure.** After a "Run + downstream" / bounded run fails, the details pane stayed on whatever node was selected (the run source), so the user had to hunt for the red node to see the error. Both cascade-failure branches now set `pe.selection` to the first failed node, surfacing its error immediately. (`pipeline/[folder]/+page.svelte`)

## Verification

- **F13** — verified live in the running dev server: the axis now renders `from Jun 5, 02:10 PM`. Screenshot below.
- **F23** — `svelte-check` clean; the change uses the exact `pe.selection = { kind: 'runnable', runnable_kind: 'script', path }` API used at 5+ other call sites to switch the pane (I confirmed live that setting the selection switches the details pane), added to the existing, already-shipped cascade-failure branch (the one that fires the "run failed at X" toast). **I could not drive the full cascade-to-downstream-failure end-to-end in the browser this session** — the "Run + downstream" popup control didn't surface reliably through the automation — so the auto-switch itself is verified by its constituent pieces (proven trigger branch + proven selection API + clean types), not by a full in-browser run. Worth a manual confirm: break a downstream node, run the cascade from an upstream root, and confirm the pane jumps to the failed node.

## Screenshots

### F13 — window axis now reads "from …"
![f13-axis](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix-pipeline-frontend-polish/1783262309-f13-axis.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves pipeline UI clarity: the activity histogram now reads “from … now,” and after cascade/bounded failures the UI auto-focuses the first failed node, even if a draft pane is open.

- **Bug Fixes**
  - Activity window axis: prefix the left-edge timestamp with “from” to avoid it reading like a run list date header.
  - Cascade/bounded runs: clear `pe.activeDraftPath` and set `pe.selection` to the first failed node so its error opens immediately.

<sup>Written for commit 173cd1347f0292955d8f60f0a1b5412cf822e9ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

