### PR TITLE
fix(duckdb): render FFI errors with real newlines and no stray quoting

### DIFF
--- a/backend/windmill-worker/src/duckdb_executor.rs
+++ b/backend/windmill-worker/src/duckdb_executor.rs
@@ -2004,6 +2004,17 @@ fn cgroup_bytes_to_duckdb_memory_limit(bytes: i64) -> Option<String> {
 }
 
 // Read backend/windmill-duckdb-ffi-internal/README_DEV.md for details about why we use FFI
+// The FFI returns errors as `ERROR <json-encoded-message>`: the DuckDB error
+// string is `serde_json::to_string`'d, so it arrives wrapped in quotes with
+// newlines/quotes escaped. Decode it back to the raw message so multi-line
+// errors — e.g. the write-audit-publish data-test ✓/✗ breakdown — render with
+// real newlines and no stray quoting. Falls back to the raw slice if it is not
+// a JSON string (defensive; the FFI always JSON-encodes).
+fn decode_ffi_error(result_str: &str) -> String {
+    let raw = result_str.strip_prefix("ERROR ").unwrap_or(result_str);
+    serde_json::from_str::<String>(raw).unwrap_or_else(|_| raw.to_string())
+}
+
 fn run_duckdb_ffi_safe<'a>(
     query_block_list: impl Iterator<Item = &'a str>,
     query_block_list_count: usize,
@@ -2069,7 +2080,7 @@ fn run_duckdb_ffi_safe<'a>(
     };
 
     if result_str.starts_with("ERROR") {
-        Err(Error::ExecutionErr(result_str[6..].to_string()))
+        Err(Error::ExecutionErr(decode_ffi_error(&result_str)))
     } else {
         let result = if collection_strategy == SqlResultCollectionStrategy::AllStatementsAllRows {
             // Avoid parsing JSON
@@ -2133,7 +2144,7 @@ fn prepare_duckdb_ffi_safe<'a>(
     };
 
     if result_str.starts_with("ERROR") {
-        Err(Error::ExecutionErr(result_str[6..].to_string()))
+        Err(Error::ExecutionErr(decode_ffi_error(&result_str)))
     } else {
         Ok(serde_json::value::RawValue::from_string(result_str).map_err(to_anyhow)?)
     }
@@ -2628,6 +2639,31 @@ pub struct Arg {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn decode_ffi_error_unescapes_multiline_and_strips_quotes() {
+        // Mirror the FFI: JSON-encode the raw DuckDB message, prefix "ERROR ".
+        let raw_msg = "Invalid Input Error: data tests failed on main/raw_orders \
+             (1/3 failed) — write rolled back, previous version left live:\n  \
+             ✓ not_null(order_id)\n  ✗ accepted_values(status) — 12 violating row(s)";
+        let ffi = format!("ERROR {}", serde_json::to_string(raw_msg).unwrap());
+        let decoded = decode_ffi_error(&ffi);
+        assert_eq!(decoded, raw_msg);
+        // real newlines, no literal `\n`, no wrapping quotes
+        assert!(decoded.contains('\n') && !decoded.contains("\\n"));
+        assert!(!decoded.starts_with('"'));
+        // single-line error with inner quotes round-trips unescaped
+        let single = format!(
+            "ERROR {}",
+            serde_json::to_string("Binder Error: column \"x\" not found").unwrap()
+        );
+        assert_eq!(
+            decode_ffi_error(&single),
+            "Binder Error: column \"x\" not found"
+        );
+        // non-JSON payload falls back to the raw slice
+        assert_eq!(decode_ffi_error("ERROR not json"), "not json");
+    }
 
     fn test_ancestor(wid: &str) -> windmill_common::workspaces::DucklakeAncestorAttach {
         windmill_common::workspaces::DucklakeAncestorAttach {

--- a/backend/windmill-worker/src/duckdb_executor.rs
+++ b/backend/windmill-worker/src/duckdb_executor.rs
@@ -2004,12 +2004,10 @@ fn cgroup_bytes_to_duckdb_memory_limit(bytes: i64) -> Option<String> {
 }
 
 // Read backend/windmill-duckdb-ffi-internal/README_DEV.md for details about why we use FFI
-// The FFI returns errors as `ERROR <json-encoded-message>`: the DuckDB error
-// string is `serde_json::to_string`'d, so it arrives wrapped in quotes with
-// newlines/quotes escaped. Decode it back to the raw message so multi-line
-// errors — e.g. the write-audit-publish data-test ✓/✗ breakdown — render with
-// real newlines and no stray quoting. Falls back to the raw slice if it is not
-// a JSON string (defensive; the FFI always JSON-encodes).
+// The FFI returns errors as `ERROR <json-encoded-message>` (the message is
+// serde_json::to_string'd). Decode the JSON string back so multi-line errors
+// render with real newlines, not escaped `\n` inside wrapping quotes; fall back
+// to the raw slice if it is somehow not a JSON string.
 fn decode_ffi_error(result_str: &str) -> String {
     let raw = result_str.strip_prefix("ERROR ").unwrap_or(result_str);
     serde_json::from_str::<String>(raw).unwrap_or_else(|_| raw.to_string())


### PR DESCRIPTION
## Summary
DuckDB job errors were surfacing in their `serde_json`-escaped form — wrapped in quotes with literal `\n` instead of real newlines. The FFI boundary returns errors as `ERROR <json-encoded-message>` (the DuckDB message is `serde_json::to_string`'d in `windmill-duckdb-ffi-internal`), and the worker was slicing off the `ERROR ` prefix but never decoding the JSON string back. Multi-line errors — most visibly the write-audit-publish data-test ✓/✗ breakdown — rendered as a single quoted line with escaped newlines, making them hard to read.

This decodes the JSON string back to the raw message at both FFI error sites, so multi-line errors render with real line breaks and no stray quoting.

## Changes
- Add `decode_ffi_error` helper in `duckdb_executor.rs` that strips the `ERROR ` prefix and `serde_json::from_str`s the payload back to the raw `String` (falls back to the raw slice if it is not a JSON string — defensive).
- Use it at both FFI error sites: `run_duckdb_ffi_safe` and `prepare_duckdb_ffi_safe` (replacing the raw `result_str[6..]` slice).
- Unit test `decode_ffi_error_unescapes_multiline_and_strips_quotes` covering multi-line unescaping, inner-quote round-trip, and the non-JSON fallback.

## Test plan
- [x] `cargo test -p windmill-worker --features duckdb,parquet decode_ffi_error` passes
- [ ] Run a DuckDB job that raises a multi-line error (e.g. a materialization with a failing data_test under write-audit-publish) and confirm the error renders in the job result with real newlines and no wrapping quotes

No frontend or `*_ee.rs` changes — the FFI JSON-encodes on the producing side and the fix is purely in the CE consumer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix DuckDB FFI errors to show real newlines and remove stray quotes, so multi-line errors are readable. Decodes JSON-encoded error messages returned from the FFI.

- **Bug Fixes**
  - Added `decode_ffi_error` to strip `ERROR ` and `serde_json`-decode the payload (fallback on non-JSON); clarified its invariant in the comment.
  - Used in `run_duckdb_ffi_safe` and `prepare_duckdb_ffi_safe`.
  - Added a unit test for multiline unescaping, inner quotes, and non-JSON fallback.

<sup>Written for commit a18c69f16ba7f9e76f6ee947a9d922c0f41571cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

