### PR TITLE
fix(pipelines): link SCD2 <dim>_current view to its producer across all graph surfaces

### DIFF
--- a/backend/parsers/windmill-parser/src/asset_parser.rs
+++ b/backend/parsers/windmill-parser/src/asset_parser.rs
@@ -293,6 +293,30 @@ pub struct MaterializeSpec {
     pub on_schema_change: OnSchemaChange,
 }
 
+impl MaterializeSpec {
+    /// The `<target>_current` SCD2 companion view this managed materialize also
+    /// produces, or `None` when it isn't a managed scd2 target. Managed scd2
+    /// creates the base table *and* a `<dim>_current` "latest row per key" view
+    /// each run (see `sql_materialize.rs`); `manual` mode owns its own DDL and
+    /// short-circuits before that codegen, so it produces no companion.
+    pub fn scd2_current_target(&self) -> Option<(AssetKind, String)> {
+        (self.scd2 && !self.manual)
+            .then(|| (self.target_kind, format!("{}_current", self.target_path)))
+    }
+
+    /// Every asset this managed materialize produces: the base table, plus — for
+    /// managed scd2 — the `<target>_current` companion view. The producer's
+    /// trailing `SELECT` doesn't express these writes (the runtime generates the
+    /// DDL), so this is the single source of truth every graph surface (deploy
+    /// asset rows, the CLI `--local` graph, and the frontend live graph) uses to
+    /// link reads of the base *and* the `_current` view back to this producer.
+    pub fn write_targets(&self) -> Vec<(AssetKind, String)> {
+        let mut targets = vec![(self.target_kind, self.target_path.clone())];
+        targets.extend(self.scd2_current_target());
+        targets
+    }
+}
+
 // dbt's `on_schema_change`, covering both the save-time contract check and the
 // run-time write guardrail for the positional persist-and-mutate strategies:
 //   • `warn` (default): surface consumer contract warnings; at write time, log
@@ -1704,6 +1728,62 @@ mod pipeline_annotation_tests {
         assert!(m.track.is_empty());
         // soft-delete default
         assert!(!m.close_deleted);
+    }
+
+    #[test]
+    fn materialize_scd2_write_targets_include_current_view() {
+        // A managed scd2 materialize produces the base table AND the
+        // `<dim>_current` companion view, so the producer must be recorded as
+        // writing both (reads of the view otherwise resolve to an orphan asset).
+        let out = parse_pipeline_annotations(
+            "// materialize ducklake://main/dim_customers key=id history",
+        );
+        let m = out.materialize.expect("materialize");
+        assert_eq!(
+            m.write_targets(),
+            vec![
+                (AssetKind::Ducklake, "main/dim_customers".to_string()),
+                (
+                    AssetKind::Ducklake,
+                    "main/dim_customers_current".to_string()
+                ),
+            ]
+        );
+        assert_eq!(
+            m.scd2_current_target(),
+            Some((
+                AssetKind::Ducklake,
+                "main/dim_customers_current".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn materialize_non_scd2_write_targets_are_base_only() {
+        // A plain merge (no `history`) creates no companion view — only the base.
+        let out = parse_pipeline_annotations("// materialize ducklake://main/dim_customers key=id");
+        let m = out.materialize.expect("materialize");
+        assert_eq!(
+            m.write_targets(),
+            vec![(AssetKind::Ducklake, "main/dim_customers".to_string())]
+        );
+        assert_eq!(m.scd2_current_target(), None);
+    }
+
+    #[test]
+    fn materialize_manual_scd2_has_no_companion_view() {
+        // `manual` mode owns its own DDL and never creates the `_current` view,
+        // so registering it would be a false producer edge.
+        let out = parse_pipeline_annotations(
+            "// materialize manual ducklake://main/dim_customers key=id history",
+        );
+        let m = out.materialize.expect("materialize");
+        assert!(m.manual && m.scd2);
+        assert_eq!(m.scd2_current_target(), None);
+        assert_eq!(
+            m.write_targets(),
+            vec![(AssetKind::Ducklake, "main/dim_customers".to_string())]
+        );
     }
 
     #[test]

--- a/backend/windmill-api-assets/src/lib.rs
+++ b/backend/windmill-api-assets/src/lib.rs
@@ -620,6 +620,15 @@ struct GraphAssetNode {
     // anywhere. Lockstep with TS `AssetGraphAssetNode.fork_materialization`.
     #[serde(skip_serializing_if = "Option::is_none")]
     fork_materialization: Option<String>,
+    // The base dimension this asset is the SCD2 `<dim>_current` companion view
+    // of — set only on a `ducklake://…/<dim>_current` node whose producer
+    // declares `// materialize … history` on `<dim>`. The producer edge already
+    // links it to that script (both writes are registered at deploy); this lets
+    // the canvas render it as a derived "current view" of the base rather than an
+    // unrelated table. Absent for every other asset. Lockstep with TS
+    // `AssetGraphAssetNode.derived_from`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    derived_from: Option<String>,
 }
 
 #[derive(Serialize, Debug)]
@@ -1327,6 +1336,24 @@ async fn asset_graph(
         }
     };
 
+    // (kind, `<dim>_current` path) → base `<dim>` path, for every managed scd2
+    // producer in the graph. Reads of the companion view resolve to a node
+    // whose producer edge already exists (the deploy path registers both writes)
+    // — this map lets that node advertise which base dimension it derives from.
+    let scd2_current_base: std::collections::HashMap<(AssetKind, String), String> =
+        annotations_by_path
+            .values()
+            .filter_map(|a| a.materialize.as_ref())
+            .filter_map(|m| {
+                m.scd2_current_target().map(|(k, current)| {
+                    (
+                        (windmill_common::assets::asset_kind_from_parser(k), current),
+                        m.target_path.clone(),
+                    )
+                })
+            })
+            .collect();
+
     let mut assets: Vec<GraphAssetNode> = asset_set
         .into_iter()
         .map(|(kind, path)| GraphAssetNode {
@@ -1337,6 +1364,7 @@ async fn asset_graph(
                         .map(|s| s.to_string())
                 })
                 .flatten(),
+            derived_from: scd2_current_base.get(&(kind, path.clone())).cloned(),
             kind,
             path,
         })

--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -1439,21 +1439,17 @@ async fn create_script_internal<'c>(
     // body's `SELECT` doesn't express the write (the runtime generates it), so
     // server-side inference wouldn't otherwise link it.
     let effective_assets = if let Some(m) = pipeline_annotations.materialize.as_ref() {
-        let kind = windmill_common::assets::asset_kind_from_parser(m.target_kind);
         let mut a = effective_assets.unwrap_or_default();
         // Produced assets: the managed table, plus — for managed scd2 — the
-        // `<dim>_current` companion view the runtime (re)creates each run.
-        // Registering the view as a write asset lets `// on
-        // ducklake://…/<dim>_current` subscribers be dispatched by the cascade
-        // (which fans out from these deploy-time asset rows); without it a
-        // subscriber on the view would silently never fire. Gated on `!manual`:
-        // manual mode owns its own DDL and short-circuits before the scd2 codegen
-        // (no view is created), so registering it there would be a false edge.
-        let mut targets = vec![m.target_path.clone()];
-        if m.scd2 && !m.manual {
-            targets.push(format!("{}_current", m.target_path));
-        }
-        for path in targets {
+        // `<dim>_current` companion view the runtime (re)creates each run
+        // (`MaterializeSpec::write_targets`). Registering the view as a write
+        // asset lets `// on ducklake://…/<dim>_current` subscribers be
+        // dispatched by the cascade (which fans out from these deploy-time asset
+        // rows) and connects a consumer that reads only the view back to this
+        // producer; without it a subscriber on the view would silently never
+        // fire and the view would be an orphan node in the lineage graph.
+        for (target_kind, path) in m.write_targets() {
+            let kind = windmill_common::assets::asset_kind_from_parser(target_kind);
             if !a.iter().any(|x| x.kind == kind && x.path == path) {
                 a.push(windmill_common::assets::AssetWithAltAccessType {
                     path,

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -81,7 +81,11 @@ export type GraphTrigger =
     };
 export type AssetGraph = {
   runnables: GraphRunnable[];
-  assets: { kind: string; path: string }[];
+  // `derived_from` is the base `<dim>` path when this node is the SCD2
+  // `<dim>_current` companion view of a managed `// materialize … history`
+  // producer — lets the canvas mark it as a derived "current view". Absent
+  // otherwise. Lockstep with backend `GraphAssetNode`.
+  assets: { kind: string; path: string; derived_from?: string }[];
   edges: GraphEdge[];
   triggers: GraphTrigger[];
   // ƒ edges from a `// macros` library to the scripts calling its macros
@@ -449,7 +453,14 @@ export async function buildLocalPipelineGraph(args: {
   const runnables: GraphRunnable[] = [];
   const edges: GraphEdge[] = [];
   const triggers: GraphTrigger[] = [];
-  const assetSet = new Map<string, { kind: string; path: string }>();
+  const assetSet = new Map<
+    string,
+    { kind: string; path: string; derived_from?: string }
+  >();
+  // `<kind>:<current-path>` → base `<dim>` path, for scd2 `_current` companion
+  // views. Applied to the final asset nodes so a consumer's `// on …_current`
+  // trigger (processed after the producer) can't clobber the derived marker.
+  const derivedFromByKey = new Map<string, string>();
   const pipelineScripts: LocalScript[] = [];
 
   for (const s of all) {
@@ -507,27 +518,44 @@ export async function buildLocalPipelineGraph(args: {
     // SQL body, so body-inference misses it. Translate the parsed materialize
     // target into the producer's write edge here (mirrors frontend
     // resolveGraph.ts) so the materialized asset connects to its `// on`
-    // consumers; dedup against any body write.
+    // consumers; dedup against any body write. A managed scd2 materialize also
+    // produces the `<dim>_current` companion view — register it as a second
+    // write (mirrors the deploy path) so a consumer reading only the view links
+    // back to this producer instead of orphaning.
     if (mat) {
-      assetSet.set(`${mat.target_kind}:${mat.target_path}`, {
-        kind: mat.target_kind,
-        path: mat.target_path,
-      });
-      const hasWrite = edges.some(
-        (e) =>
-          e.runnable_path === s.path &&
-          e.asset_kind === mat.target_kind &&
-          e.asset_path === mat.target_path &&
-          (e.access_type === "w" || e.access_type === "rw"),
-      );
-      if (!hasWrite) {
-        edges.push({
-          runnable_kind: "script",
-          runnable_path: s.path,
-          asset_kind: mat.target_kind,
-          asset_path: mat.target_path,
-          access_type: "w",
+      const matWrites: { path: string; derived_from?: string }[] = [
+        { path: mat.target_path },
+      ];
+      if (mat.scd2 && !mat.manual) {
+        const currentPath = `${mat.target_path}_current`;
+        matWrites.push({ path: currentPath, derived_from: mat.target_path });
+        derivedFromByKey.set(
+          `${mat.target_kind}:${currentPath}`,
+          mat.target_path,
+        );
+      }
+      for (const w of matWrites) {
+        assetSet.set(`${mat.target_kind}:${w.path}`, {
+          kind: mat.target_kind,
+          path: w.path,
+          ...(w.derived_from ? { derived_from: w.derived_from } : {}),
         });
+        const hasWrite = edges.some(
+          (e) =>
+            e.runnable_path === s.path &&
+            e.asset_kind === mat.target_kind &&
+            e.asset_path === w.path &&
+            (e.access_type === "w" || e.access_type === "rw"),
+        );
+        if (!hasWrite) {
+          edges.push({
+            runnable_kind: "script",
+            runnable_path: s.path,
+            asset_kind: mat.target_kind,
+            asset_path: w.path,
+            access_type: "w",
+          });
+        }
       }
     }
     const existingNativeTriggers = new Set<string>();
@@ -564,10 +592,15 @@ export async function buildLocalPipelineGraph(args: {
     }
   }
 
+  const assets = [...assetSet.entries()].map(([key, a]) => {
+    const derived_from = a.derived_from ?? derivedFromByKey.get(key);
+    return derived_from ? { ...a, derived_from } : a;
+  });
+
   return {
     graph: {
       runnables,
-      assets: [...assetSet.values()],
+      assets,
       edges,
       triggers,
     },

--- a/cli/test/pipeline_local_graph_unit.test.ts
+++ b/cli/test/pipeline_local_graph_unit.test.ts
@@ -143,6 +143,15 @@ test("`// materialize <asset>` producer connects to its `// on` consumer", async
   );
 });
 
+// NOTE: the scd2 `<dim>_current` companion-view write edge (buildLocalPipelineGraph)
+// is exercised end-to-end by the backend parser test
+// (`materialize_scd2_write_targets_include_current_view`) and the frontend
+// live-graph test (`resolveGraph.test.ts` — "scd2 materialize draft"). It has no
+// unit test here because it depends on the `scd2` flag emitted by the bundled
+// `windmill-parser-wasm-asset`, which lags the source (the vendored build
+// predates the scd2 fields); the branch activates once a wasm carrying `scd2` is
+// republished (cf. the wasm-publish plumbing in #9926).
+
 test("a bare `.sql` (ambiguous dialect) is skipped, not a build-aborting crash", async () => {
   // `inferContentTypeFromFilePath` throws on a dialect-less `.sql`; one such file
   // must not abort the whole graph build (it also wedged `pipeline dev` at start).

--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
@@ -331,6 +331,7 @@
 					asset_kind: a.kind,
 					path: a.path,
 					fork_materialization: a.fork_materialization,
+					derived_from: a.derived_from,
 					onAddScript: onAddScriptForAsset,
 					pathPrefix,
 					defaultPathSuffix,

--- a/frontend/src/lib/components/assets/AssetGraph/AssetNode.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetNode.svelte
@@ -5,7 +5,7 @@
 	import { formatShortAssetPath, type AssetKind } from '$lib/components/assets/lib'
 	import { NODE } from '$lib/components/graph/util'
 	import PipelineInsertMenu, { type PipelineInsertPick } from './PipelineInsertMenu.svelte'
-	import { ArrowUpRight, Code2, GitFork, Play, Loader2, Plus } from 'lucide-svelte'
+	import { ArrowUpRight, Code2, GitFork, History, Play, Loader2, Plus } from 'lucide-svelte'
 	import type { ScriptLang } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
 	import { sendUserToast } from '$lib/utils'
@@ -29,6 +29,11 @@
 			// Fork workspaces: 'fork' = materialized in this fork, 'deferred' =
 			// reads fall back to the parent workspace's current data.
 			fork_materialization?: 'fork' | 'deferred'
+			// Set on an SCD2 `<dim>_current` companion view: the base `<dim>` path
+			// its producer materializes with `// materialize … history`. Drives the
+			// "current view of <dim>" marker so it reads as a derived node, not an
+			// unrelated table.
+			derived_from?: string
 			onAddScript?: (
 				asset: { kind: AssetKind; path: string },
 				language: ScriptLang,
@@ -154,6 +159,17 @@
 				title="Materialized in this fork: reads and writes use the fork's isolated copy."
 			>
 				<GitFork size={12} />
+			</span>
+		{/if}
+		<!-- SCD2 companion marker: this node is the `<dim>_current` "latest row
+		     per key" view its producer maintains alongside the base dimension.
+		     Icon-only (the pill already truncates); the title names the base. -->
+		{#if data.derived_from}
+			<span
+				class="shrink-0 mr-1.5 text-violet-600 dark:text-violet-400"
+				title={`SCD2 current view of ${data.derived_from}: latest row per key, maintained by the same producer as the base dimension.`}
+			>
+				<History size={12} />
 			</span>
 		{/if}
 	</div>

--- a/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.ts
@@ -123,6 +123,16 @@ export type MaterializeSpec = {
 	onSchemaChange?: 'warn' | 'ignore'
 }
 
+// The `<targetPath>_current` SCD2 companion view this managed materialize also
+// produces, or `undefined` when it isn't a managed scd2 target. Mirrors Rust
+// `MaterializeSpec::scd2_current_target`: managed scd2 creates the base table
+// *and* the `_current` view each run; `manual` mode owns its own DDL and creates
+// no companion. The graph surfaces register it as a second write of the producer
+// so a read of the view links back instead of orphaning.
+export function scd2CurrentTargetPath(m: MaterializeSpec): string | undefined {
+	return m.scd2 && !m.manual ? `${m.targetPath}_current` : undefined
+}
+
 // `// data_test <kind> …` — a data-quality assertion run against the
 // freshly-materialized asset, failing the run on violation. See backend
 // `DataTest`. The first extensible annotation family: a keyword head selects

--- a/frontend/src/lib/components/assets/AssetGraph/resolveGraph.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/resolveGraph.test.ts
@@ -99,6 +99,50 @@ describe('resolveGraph', () => {
 		})
 	})
 
+	it('scd2 materialize draft: writes both the base dim and its _current companion view', () => {
+		const drafts = new Map([
+			[
+				'f/x/dim',
+				{
+					script: {
+						content: '-- materialize ducklake://main/dim_customers key=id history\nselect 1'
+					}
+				}
+			]
+		])
+		const r = resolveGraph(input({ drafts }))
+		// Base dimension: a plain write output node.
+		expect(r.assets).toContainEqual({ kind: 'ducklake', path: 'main/dim_customers' })
+		// Companion `_current` view: same producer, marked derived from the base.
+		expect(r.assets).toContainEqual({
+			kind: 'ducklake',
+			path: 'main/dim_customers_current',
+			derived_from: 'main/dim_customers'
+		})
+		for (const path of ['main/dim_customers', 'main/dim_customers_current']) {
+			expect(r.edges).toContainEqual({
+				runnable_path: 'f/x/dim',
+				runnable_kind: 'script',
+				asset_kind: 'ducklake',
+				asset_path: path,
+				access_type: 'w',
+				unsaved: true
+			})
+		}
+	})
+
+	it('non-scd2 materialize draft: writes only the base dim, no _current companion', () => {
+		const drafts = new Map([
+			[
+				'f/x/dim',
+				{ script: { content: '-- materialize ducklake://main/dim_customers key=id\nselect 1' } }
+			]
+		])
+		const r = resolveGraph(input({ drafts }))
+		expect(r.assets).toContainEqual({ kind: 'ducklake', path: 'main/dim_customers' })
+		expect(r.assets.some((a) => a.path === 'main/dim_customers_current')).toBe(false)
+	})
+
 	it('active draft: live body writes are authoritative over the snapshot', () => {
 		const drafts = new Map([
 			[

--- a/frontend/src/lib/components/assets/AssetGraph/resolveGraph.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/resolveGraph.test.ts
@@ -385,6 +385,55 @@ describe('resolveGraph', () => {
 		expect(r.edges.some((e) => e.asset_path === 'main/out' && e.access_type === 'w')).toBe(true)
 	})
 
+	it('editing a saved scd2 producer keeps both the base and _current persisted write edges', () => {
+		// Deploy persists a write to both `main/dim` and `main/dim_current`.
+		// Opening the producer for editing must not judge the companion `_current`
+		// write stale — otherwise a consumer of only the view orphans mid-edit.
+		const base = baseGraph({
+			runnables: [{ path: 'f/x/dim', usage_kind: 'script' }],
+			edges: [
+				{
+					runnable_path: 'f/x/dim',
+					runnable_kind: 'script',
+					asset_kind: 'ducklake',
+					asset_path: 'main/dim_customers',
+					access_type: 'w'
+				},
+				{
+					runnable_path: 'f/x/dim',
+					runnable_kind: 'script',
+					asset_kind: 'ducklake',
+					asset_path: 'main/dim_customers_current',
+					access_type: 'w'
+				}
+			]
+		})
+		const r = resolveGraph(
+			input({
+				base,
+				liveAnnotations: {
+					scriptPath: 'f/x/dim',
+					annotations: ann({
+						materialize: {
+							targetKind: 'ducklake',
+							targetPath: 'main/dim_customers',
+							uniqueKey: 'id',
+							scd2: true
+						}
+					})
+				},
+				liveBodyAssets: { scriptPath: 'f/x/dim', assets: [] }
+			})
+		)
+		for (const path of ['main/dim_customers', 'main/dim_customers_current']) {
+			expect(
+				r.edges.some(
+					(e) => e.runnable_path === 'f/x/dim' && e.asset_path === path && e.access_type === 'w'
+				)
+			).toBe(true)
+		}
+	})
+
 	it('selecting a saved script unchanged drops nothing (no stale removal)', () => {
 		const base = baseGraph({
 			runnables: [{ path: 'f/x/prod', usage_kind: 'script' }],

--- a/frontend/src/lib/components/assets/AssetGraph/resolveGraph.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/resolveGraph.ts
@@ -266,9 +266,16 @@ function makeContext(input: ResolveGraphInput): ResolveContext {
 			// lives in an annotation (not the SQL body), so neither triggerAssets
 			// (inputs) nor the body-inferred assets cover it. Without this its
 			// persisted write-edge is judged stale and dropped the moment the
-			// script is selected/edited — leaving the output asset unlinked.
+			// script is selected/edited — leaving the output asset unlinked. A
+			// managed scd2 producer persists a second write to the `<dim>_current`
+			// companion view, so keep that too or a consumer of only the view
+			// orphans while the producer is open for editing.
 			const m = liveAnnotations.annotations.materialize
-			if (m) liveRefKeys.add(`${m.targetKind}:${m.targetPath}`)
+			if (m) {
+				liveRefKeys.add(`${m.targetKind}:${m.targetPath}`)
+				const currentPath = scd2CurrentTargetPath(m)
+				if (currentPath) liveRefKeys.add(`${m.targetKind}:${currentPath}`)
+			}
 		}
 		for (const a of liveBodyAssets.assets) liveRefKeys.add(`${a.kind}:${a.path}`)
 	}

--- a/frontend/src/lib/components/assets/AssetGraph/resolveGraph.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/resolveGraph.ts
@@ -2,6 +2,7 @@ import type { AssetGraphMacroEdge, AssetGraphResponse, NativeTriggerKind } from 
 import {
 	mergeColumnLineage,
 	parsePipelineAnnotations,
+	scd2CurrentTargetPath,
 	type ColumnLineage,
 	type PipelineAnnotations
 } from './parsePipelineAnnotations'
@@ -373,7 +374,7 @@ function seedDraftOverlays(acc: Accumulator, input: ResolveGraphInput) {
 		//      creation/last edit, or the seeded output for a fresh draft
 		//      whose body doesn't yet write anything inferable).
 		const liveForThisDraft = liveBodyAssets.scriptPath === path
-		const writeOuts: Array<{ kind: AssetKind; path: string }> = []
+		const writeOuts: Array<{ kind: AssetKind; path: string; derivedFrom?: string }> = []
 		if (liveForThisDraft) {
 			writeOuts.push(...extractWrites(liveBodyAssets.assets))
 		} else if (d.outputAssets) {
@@ -382,16 +383,35 @@ function seedDraftOverlays(acc: Accumulator, input: ResolveGraphInput) {
 		// `// materialize <asset>` declares a write output via annotation, not
 		// the SQL body, so the body-inference tiers above miss it. Add it from
 		// the live-parsed annotations so an edited materialize script keeps its
-		// output edge (the loop below dedups against existing assets/edges).
+		// output edge (the loop below dedups against existing assets/edges). A
+		// managed scd2 materialize also produces the `<dim>_current` companion
+		// view — add it too (mirrors the deploy path) so a draft consuming only
+		// the view links back to this producer instead of orphaning.
 		if (parsed.materialize) {
 			writeOuts.push({
 				kind: parsed.materialize.targetKind,
 				path: parsed.materialize.targetPath
 			})
+			const currentPath = scd2CurrentTargetPath(parsed.materialize)
+			if (currentPath) {
+				writeOuts.push({
+					kind: parsed.materialize.targetKind,
+					path: currentPath,
+					derivedFrom: parsed.materialize.targetPath
+				})
+			}
 		}
 		for (const out of writeOuts) {
-			const hasAsset = assets.some((a) => a.kind === out.kind && a.path === out.path)
-			if (!hasAsset) assets.push({ kind: out.kind, path: out.path })
+			const existing = assets.find((a) => a.kind === out.kind && a.path === out.path)
+			if (!existing) {
+				assets.push({
+					kind: out.kind,
+					path: out.path,
+					...(out.derivedFrom ? { derived_from: out.derivedFrom } : {})
+				})
+			} else if (out.derivedFrom && existing.derived_from == undefined) {
+				existing.derived_from = out.derivedFrom
+			}
 			// Dedup against edges already in the overlay (this draft's base
 			// edges were dropped above, so this only guards against duplicate
 			// writeOuts entries — not against the persisted version).

--- a/frontend/src/lib/components/assets/AssetGraph/types.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/types.ts
@@ -11,6 +11,11 @@ export interface AssetGraphAssetNode {
 	// current table via a defer view. Absent outside forks / for other kinds /
 	// when never materialized anywhere. Lockstep with Rust `GraphAssetNode`.
 	fork_materialization?: 'fork' | 'deferred'
+	// Base dimension path this node is the SCD2 `<dim>_current` companion view of
+	// (its producer declares `// materialize … history` on `<dim>`). Set only on
+	// the `_current` node; lets the canvas mark it as a derived "current view"
+	// rather than an unrelated table. Lockstep with Rust `GraphAssetNode`.
+	derived_from?: string
 }
 
 export interface AssetGraphRunnableNode {


### PR DESCRIPTION
## Summary

Fixes **HD-2** from the pipeline hidden-dependencies work package: the SCD2 `<dim>_current` view was an orphan asset in the lineage graph.

An SCD2 producer (`// materialize ducklake://…/<dim> key=<col> history`) creates **two** physical objects at runtime — the base table `<dim>` **and** the view `<dim>_current` (the documented "latest row per key" consumption pattern). The producer's trailing `SELECT` expresses neither write (the runtime generates the DDL), so the write of `<dim>_current` was only synthesized on the **deploy** path (#9850). The CLI `--local` graph and the frontend **live-editor** graph emitted only the base write, so a consumer reading only `<dim>_current` (with no explicit `// on` of the base) produced an asset node with **no producer edge** — broken lineage/impact analysis across the SCD2 boundary on those surfaces.

This centralizes the companion derivation and emits the `_current` write on every graph surface, then renders the companion as a derived "current view" node instead of an unrelated table.

## Changes

- **Parser (`asset_parser.rs`)** — new `MaterializeSpec::write_targets()` (base + `_current` for managed scd2) and `scd2_current_target()` as the single source of truth; gated on `scd2 && !manual` (manual mode owns its own DDL, creates no view). +3 unit tests.
- **Deploy (`scripts.rs`)** — refactored to consume `write_targets()` (no behavior change; DRY over the previously-inlined logic).
- **Backend graph (`lib.rs`)** — `GraphAssetNode.derived_from`: builds a `(kind, <dim>_current) → <dim>` map from the pipeline's scd2 materialize annotations and marks the companion node.
- **CLI local graph (`localGraph.ts`)** — emits the `_current` write edge and `derived_from`, with a `derivedFromByKey` fallback so a later consumer `// on …_current` read can't clobber the marker.
- **Frontend live graph (`resolveGraph.ts`)** — emits the `_current` write edge + `derived_from` for scd2 drafts; new TS mirror helper `scd2CurrentTargetPath`.
- **Frontend node (`AssetNode.svelte` / `types.ts` / `AssetGraphCanvas.svelte`)** — renders a violet History marker ("SCD2 current view of `<dim>`…") on the companion node, following the existing fork-materialization icon pattern.

Schema capture is unchanged — the two logical assets stay distinct and the `_current` view already falls back to the base table's captured schema.

## Screenshots

Deployed graph for a pipeline where `mart_customer_revenue` reads only `main/dim_customers_current` (no explicit `// on` of the base). The producer writes **both** nodes, the `_current` node carries the companion marker, and the mart links back to the producer through the view:

![scd2-current-companion-graph](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/pipeline-scd2-current-asset/1783279945-scd2-current-companion-graph.png)

## Test plan

- [x] `cargo test -p windmill-parser` — 3 new tests (managed scd2 → base + `_current`; plain merge → base only; manual scd2 → base only).
- [x] `cargo check -p windmill-api-assets -p windmill-api-scripts`.
- [x] Frontend `resolveGraph.test.ts` — 2 new cases (scd2 draft emits both nodes + write edges + `derived_from`; non-scd2 draft emits no companion). `npm run check:fast` clean.
- [x] E2E: deployed an scd2 producer + a consumer reading only `_current` against the running backend; `/assets/graph` returns `derived_from` on the companion node and write edges to both targets; verified the graph render in-app (screenshot above).

## Notes

- The deploy-path producer edge already shipped in #9850; this PR extends the same fix to the CLI/live surfaces and adds the derived-node rendering + a centralized, tested helper.
- The CLI `--local` branch is inert until a fresh `windmill-parser-wasm-asset` carrying the `scd2` field is republished — the bundled npm wasm predates it (same publish-lag class as #9926). This is documented at the code site and the test note; the backend parser test and frontend live-graph test exercise the equivalent logic with current parsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Links the SCD2 `<dim>_current` view to its producer across deploy, CLI `--local`, and live-editor graphs by centralizing companion derivation and marking it as a derived node. Also preserves the saved producer’s `_current` write edge while editing. Addresses Linear HD-2 by fixing orphaned `_current` assets and restoring accurate lineage and trigger dispatch.

- **Bug Fixes**
  - Emit the `_current` write for managed SCD2 materializes (`// materialize … history`) on every graph; skip in manual mode.
  - Add `derived_from` to asset nodes so `_current` is rendered as a derived “current view” and not an unrelated table; UI shows a violet marker.
  - Keep the `_current` persisted write edge when opening a saved SCD2 producer for editing by adding it to `liveRefKeys` (via `scd2CurrentTargetPath`); prevents orphaning mid-edit.
  - Ensure consumers that read only `_current` link back to the producer; includes a CLI fallback to avoid derived marker clobbering.

- **Refactors**
  - Introduce `MaterializeSpec::write_targets()` and `scd2_current_target()` as the single source of truth; deploy and graph builders reuse them.
  - Add TS mirror `scd2CurrentTargetPath`; update types to carry `derived_from`. New tests cover managed SCD2 (base + `_current`), non-SCD2, manual SCD2, and preserving `_current` on saved edits.

<sup>Written for commit 20ae45e0281e8322b62a8da86d0fd164411027b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

