### PR TITLE
fix(pipelines): dedup guard for keyed merge + deploy-time SCD2 validation

### DIFF
--- a/backend/parsers/windmill-parser/src/asset_parser.rs
+++ b/backend/parsers/windmill-parser/src/asset_parser.rs
@@ -333,6 +333,40 @@ impl OnSchemaChange {
     }
 }
 
+impl MaterializeSpec {
+    /// Deploy-time validation of the option combination against the script's
+    /// partitioning, returning a human-facing error for combinations the
+    /// runtime cannot honor. Called at save (`create_script_internal`) so a
+    /// misconfigured script is rejected up front, and again in the DuckDB
+    /// executor as a safety net for preview/test runs that never deploy. Both
+    /// checks are SCD2-specific and inert for `manual` mode (which owns its DDL
+    /// and ignores the reconciliation strategy). `partitioned` is whether the
+    /// script declares `// partitioned`.
+    pub fn validate(&self, partitioned: bool) -> Result<(), String> {
+        if self.manual || !self.scd2 {
+            return Ok(());
+        }
+        // SCD2 needs a natural key to identify an entity across versions.
+        if self.unique_key.as_deref().map_or(true, str::is_empty) {
+            return Err(
+                "materialize scd2: requires a natural key — add `key=<col>` (e.g. \
+                 `// materialize ducklake://<name>/<table> key=id history`)"
+                    .to_string(),
+            );
+        }
+        // SCD2's diff/close/open shape has no partition-scoped form in v1.
+        if partitioned {
+            return Err(
+                "materialize scd2: `// partitioned` is not supported with scd2 in v1 — remove \
+                 `// partitioned`, or drop `history`/`scd2` to materialize the partition without \
+                 history"
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
+}
+
 // `// data_test <kind> …` — a data-quality assertion run against the
 // freshly-materialized asset (post DELETE+INSERT), failing the run on
 // violation. The first extensible annotation family: the parser turns a
@@ -1719,6 +1753,51 @@ mod pipeline_annotation_tests {
             "// materialize ducklake://a/dim key=id history deletes=ignore",
         );
         assert!(!out.materialize.expect("materialize").close_deleted);
+    }
+
+    #[test]
+    fn materialize_validate_scd2_requires_key() {
+        // scd2 without `key=` is rejected at deploy (was a run-time error).
+        let m = parse_pipeline_annotations("// materialize ducklake://a/dim history")
+            .materialize
+            .expect("materialize");
+        assert!(m.scd2 && m.unique_key.is_none());
+        let err = m.validate(false).expect_err("scd2 without key must fail");
+        assert!(err.contains("requires a natural key"));
+        // with a key it validates
+        let m = parse_pipeline_annotations("// materialize ducklake://a/dim key=id history")
+            .materialize
+            .expect("materialize");
+        assert!(m.validate(false).is_ok());
+    }
+
+    #[test]
+    fn materialize_validate_scd2_rejects_partitioned() {
+        // scd2 + `// partitioned` has no v1 form — rejected at deploy.
+        let m = parse_pipeline_annotations("// materialize ducklake://a/dim key=id history")
+            .materialize
+            .expect("materialize");
+        let err = m.validate(true).expect_err("scd2 + partitioned must fail");
+        assert!(err.contains("`// partitioned` is not supported with scd2"));
+        // unpartitioned scd2 is fine
+        assert!(m.validate(false).is_ok());
+    }
+
+    #[test]
+    fn materialize_validate_non_scd2_and_manual_are_inert() {
+        // Non-scd2 strategies are unconstrained by these checks, partitioned or not.
+        let m = parse_pipeline_annotations("// materialize ducklake://a/orders key=id")
+            .materialize
+            .expect("materialize");
+        assert!(m.validate(true).is_ok());
+        assert!(m.validate(false).is_ok());
+        // `manual` owns its DDL and ignores the strategy — never rejected here,
+        // even with a partitioned scd2-looking combo.
+        let m = parse_pipeline_annotations("// materialize manual ducklake://a/dim history")
+            .materialize
+            .expect("materialize");
+        assert!(m.manual && m.scd2);
+        assert!(m.validate(true).is_ok());
     }
 
     #[test]

--- a/backend/parsers/windmill-parser/src/sql_materialize.rs
+++ b/backend/parsers/windmill-parser/src/sql_materialize.rs
@@ -514,6 +514,11 @@ impl<'a> MaterializeCodegen<'a> {
                 // same write shape as `replace`, which is reliable. The DELETE is
                 // scoped to the current partition when partitioned so it stays
                 // slice-local (a key present in another partition is untouched).
+                //
+                // Guard first: the DELETE+INSERT does not dedup the source, so
+                // two incoming rows sharing a key would both persist under it.
+                // Raise instead of silently double-writing (see the helper).
+                out.push(duplicate_source_key_guard_sql(sel, unique_key));
                 let scope = if self.partitioned {
                     format!("{pcol} = {pval} AND ")
                 } else {
@@ -743,6 +748,29 @@ fn schema_drift_guard_sql(sel_sql: &str, target_qualified: &str, partition_col: 
          or align the SELECT with the table.') AS VARCHAR) ELSE 'ok' END \
          FROM (SELECT {added} AS _wm_added, {removed} AS _wm_removed);",
         tq = tq,
+    )
+}
+
+/// In-transaction guard for the keyed `merge` strategy: raises via DuckDB
+/// `error(...)` when the source SELECT holds more than one row for the same
+/// non-NULL `unique_key`. A keyed merge is delete-by-key + insert-all (it does
+/// NOT deduplicate the source), so duplicate source keys would land every
+/// duplicate row under one key — the exact silent double-write this guards
+/// against. Erroring keeps the semantics explicit: the author must deduplicate
+/// in the SELECT (or use `append`). NULL keys are excluded to match the delete's
+/// `key IN (...)` scope, which never matches NULL. `unique_key` is embedded raw
+/// in identifier position (matching the merge's own DELETE/IN) and doubled-quote
+/// escaped where it lands inside the error string literal.
+fn duplicate_source_key_guard_sql(sel_sql: &str, unique_key: &str) -> String {
+    let key_lit = unique_key.replace('\'', "''");
+    format!(
+        "SELECT CASE WHEN _wm_dup_keys > 0 THEN CAST(error('managed materialize: keyed merge on \
+         `{key_lit}` blocked — the source has ' || _wm_dup_keys || ' key value(s) with more than \
+         one row. A keyed merge keeps one row per key and does not deduplicate; deduplicate in the \
+         SELECT (e.g. QUALIFY row_number() OVER (PARTITION BY {key_lit} ORDER BY …) = 1) or use \
+         `append`.') AS VARCHAR) ELSE 'ok' END FROM (SELECT count(*) AS _wm_dup_keys FROM (SELECT \
+         {unique_key} FROM ({sel_sql}) WHERE {unique_key} IS NOT NULL GROUP BY {unique_key} HAVING \
+         count(*) > 1));"
     )
 }
 
@@ -1553,6 +1581,42 @@ mod tests {
         assert!(st
             .iter()
             .any(|s| s.starts_with("INSERT INTO _wm_target.orders_daily SELECT *, '2026-06-19'")));
+    }
+
+    #[test]
+    fn codegen_merge_emits_duplicate_source_key_guard() {
+        // A keyed merge does not dedup its source, so codegen must emit a guard
+        // that fails the write when the SELECT has >1 row per key — otherwise
+        // duplicate source keys silently double-write.
+        let cg = MaterializeCodegen {
+            target_qualified: "_wm_target.orders_daily",
+            select_sql: "SELECT order_id, amount FROM dl.orders",
+            partition_col: "_wm_partition",
+            partition_value_sql: "'2026-06-19'",
+            partitioned: false,
+            strategy: MaterializeStrategy::Merge { unique_key: "order_id".to_string() },
+            on_schema_change: OnSchemaChange::Warn,
+        };
+        let st = cg.statements();
+        let guard = st
+            .iter()
+            .find(|s| s.contains("_wm_dup_keys"))
+            .expect("duplicate-key guard stmt");
+        // raises via error(), counts non-NULL keys appearing more than once
+        assert!(guard.contains("error('managed materialize: keyed merge on `order_id` blocked"));
+        assert!(guard.contains("GROUP BY order_id HAVING count(*) > 1"));
+        assert!(guard.contains("WHERE order_id IS NOT NULL"));
+        // must run before the mutations so a violation aborts before any write
+        let guard_pos = st.iter().position(|s| s.contains("_wm_dup_keys")).unwrap();
+        let del_pos = st
+            .iter()
+            .position(|s| s.starts_with("DELETE FROM"))
+            .unwrap();
+        let ins_pos = st
+            .iter()
+            .position(|s| s.starts_with("INSERT INTO"))
+            .unwrap();
+        assert!(guard_pos < del_pos && guard_pos < ins_pos);
     }
 
     #[test]

--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -1307,6 +1307,13 @@ async fn create_script_internal<'c>(
                 ns.path
             );
         }
+        // SCD2 (`key=<col> history` / `scd2`) option-combination checks the
+        // runtime cannot honor: reject at deploy with a clear message rather
+        // than letting the script deploy and fail on its first run. Mirrors the
+        // executor's safety-net `MaterializeSpec::validate` (duckdb_executor).
+        if let Err(e) = m.validate(pipeline_annotations.partition.is_some()) {
+            return Err(Error::BadRequest(e));
+        }
         // `manual` materialize never captures a schema (no wrap codegen), so
         // there is no contract for `on_schema_change` to mute downstream.
         if m.manual && m.on_schema_change == windmill_parser::asset_parser::OnSchemaChange::Ignore {

--- a/backend/windmill-worker/src/duckdb_executor.rs
+++ b/backend/windmill-worker/src/duckdb_executor.rs
@@ -219,19 +219,18 @@ fn build_materialized_query(
     for s in plan.setup.iter_mut() {
         *s = substitute(s);
     }
+    // Deploy (`create_script_internal`) already rejects the invalid SCD2 combos,
+    // but preview/test runs reach the executor without a deploy — re-check so a
+    // bad combo fails with the same clear message instead of a raw DuckDB error.
+    m.validate(partitioned).map_err(Error::ExecutionErr)?;
     let strategy = if m.scd2 {
-        // SCD2 needs a natural key to identify an entity across versions, and its
-        // diff/close/open shape has no partition-scoped form in v1.
+        // SCD2 needs a natural key to identify an entity across versions (checked
+        // by `validate` above, which guarantees a non-empty key here).
         let key = m.unique_key.clone().ok_or_else(|| {
             Error::ExecutionErr(
                 "materialize scd2: requires a natural key — add `key=<col>`".to_string(),
             )
         })?;
-        if partitioned {
-            return Err(Error::ExecutionErr(
-                "materialize scd2: `// partitioned` is not supported with scd2 in v1".to_string(),
-            ));
-        }
         MaterializeStrategy::Scd2 { key, track: m.track.clone(), close_deleted: m.close_deleted }
     } else if m.append {
         MaterializeStrategy::Append
@@ -3510,7 +3509,10 @@ mod tests {
             rewritten.contains("AS schema_drift"),
             "warn folds drift into the summary: {rewritten}"
         );
-        assert!(!rewritten.contains("CAST(error("));
+        // No schema-drift *fail* guard in warn mode (the keyed merge still emits
+        // its own duplicate-source-key guard, which is a different `error(...)`).
+        assert!(!rewritten.contains("on_schema_change=fail blocked"));
+        assert!(rewritten.contains("keyed merge on `id` blocked"));
         assert!(!rewritten.contains("BY NAME"));
         assert!(meta.sync_prepass.is_none());
     }

--- a/docs/ducklake-materialization.md
+++ b/docs/ducklake-materialization.md
@@ -62,9 +62,18 @@ stays separate because it is cross-cutting (cascade + scheduling + materialize).
   error pointing to the `wmll.ducklake` helpers).
 - **`manual`** — escape hatch: the script writes its own DDL; Windmill only
   records state (no snapshot capture, no idempotency guarantee). Rare; explicit.
-- **`key=<col>`** → MERGE (dedup within slice, SCD type 1 — overwrites history);
-  **`append`** → INSERT-only; neither → DELETE-by-partition + INSERT (replace).
-  `append` wins over `key` if both are given (deploy warning).
+- **`key=<col>`** → MERGE (upsert-by-key within the slice, SCD type 1 —
+  overwrites history); **`append`** → INSERT-only; neither → DELETE-by-partition
+  + INSERT (replace). `append` wins over `key` if both are given (deploy warning).
+  - **Source must have unique keys.** The merge is delete-by-key + insert-all: it
+    reconciles the incoming rows against the *target* (rows whose key is in the
+    SELECT are replaced), but it does **not** deduplicate the *source*. Two
+    incoming rows sharing a key would therefore both land under that key, silently
+    breaking the "one row per key" contract. The managed write guards against this
+    — the run **fails** with a clear error when the SELECT returns more than one
+    row for a non-NULL key (`NULL` keys are exempt, matching the insert-only path).
+    Deduplicate in the SELECT (e.g. `QUALIFY row_number() OVER (PARTITION BY <key>
+    ORDER BY <recency-col> DESC) = 1`) or use `append` if duplicates are intended.
 - **`key=<col> history [track=<c1,c2,…>] [deletes=close]`** → upgrades the keyed
   merge to managed SCD **type 2** history (the leading keyword `scd2` is an alias).
   The SELECT is the *current snapshot* (one row per `key`), and the runtime adds
@@ -73,7 +82,9 @@ stays separate because it is cross-cutting (cascade + scheduling + materialize).
   history. Diff → close-old (`UPDATE`) → open-new (`INSERT`) in one transaction;
   the effective timestamp is the transaction clock (`now()`), so a run is
   self-consistent. v1 is **non-partitioned only** (`// partitioned` + history is
-  rejected). Unlike `manual`, it is managed, so `// data_test` and schema capture
+  rejected **at deploy**), and it **requires `key=`** (also rejected at deploy).
+  Both misconfigurations fail fast at save with a clear message instead of on the
+  first run. Unlike `manual`, it is managed, so `// data_test` and schema capture
   work.
   - **Deletes.** By default a key that disappears from the snapshot stays current
     (soft delete — dbt's `hard_deletes=ignore`). `deletes=close` opts into

--- a/docs/pipelines-vs-dbt.md
+++ b/docs/pipelines-vs-dbt.md
@@ -137,7 +137,9 @@ schema capture, and each run (re)creates a `<dim>_current` view; consumers get
 effective-dated joins via native `ASOF JOIN … >= valid_from`. Deletes follow dbt:
 soft by default (absent keys stay current), or `deletes=close` for
 `hard_deletes=close`. v1 is non-partitioned; partitioned history is a follow-up.
-See `ducklake-materialization.md`.
+Both misconfigurations — `history` without `key=`, and `history` + `//
+partitioned` — are rejected **at deploy** (fail-fast at save, not on the first
+run). See `ducklake-materialization.md`.
 
 ### 5. Selective execution grammar
 
@@ -433,6 +435,13 @@ You want `orders_daily` to hold the latest version per `order_id`.
 DELETE-by-partition + INSERT works only if you reprocess from a
 source-of-truth source. If you're consuming amendments and need dedup
 *within* the slice, you need MERGE on `order_id`, not DELETE on partition.
+
+Note the boundary: the keyed merge reconciles the incoming rows against the
+*target* (delete-by-key + insert), but it does not deduplicate the *source*.
+"Latest version per `order_id`" is still your SELECT's job — pick one row per
+key (e.g. `QUALIFY row_number() OVER (PARTITION BY order_id ORDER BY updated_at
+DESC) = 1`). A source that still has two rows for one key is rejected at run
+time rather than double-written (see `ducklake-materialization.md`).
 
 This is what dbt's `unique_key` does. Orthogonal to partitioning:
 `partitioned` answers "which slice?"; `unique_key` answers "how do I dedup


### PR DESCRIPTION
## Summary

Two correctness/validation improvements to Windmill managed materialization.

### 1. Keyed `merge` no longer silently double-writes duplicate source keys

A `key=<col>` merge is delete-by-key + insert-all (`dbt`'s `delete+insert`): it reconciles the incoming rows against the *target*, but does **not** deduplicate the *source*. So a SELECT returning `(A,10), (B,20), (A,15)` with `key=sku` produced **3 rows** (two `A`s), silently breaking the one-row-per-key contract.

The managed write now emits an in-transaction guard — structurally identical to the existing, in-production `schema_drift_guard_sql` (`SELECT CASE WHEN … THEN CAST(error(…) AS VARCHAR) ELSE 'ok' END`) — that **fails the run with a clear error** when the SELECT holds more than one row for a non-NULL key, naming the key and pointing at the fix:

> `managed materialize: keyed merge on \`sku\` blocked — the source has N key value(s) with more than one row. A keyed merge keeps one row per key and does not deduplicate; deduplicate in the SELECT (e.g. QUALIFY row_number() OVER (PARTITION BY sku ORDER BY …) = 1) or use \`append\`.`

I chose **erroring (option b)** over keep-last dedup (option a): a keyed merge has no natural tie-break column, so "keep-last" would be non-deterministic and would silently drop rows — the exact footgun the codebase avoids elsewhere. NULL keys are exempt, matching the delete's `key IN (...)` scope (which never matches NULL) — those rows are insert-only. The guard runs before the DELETE/INSERT, so a violation aborts before any mutation.

### 2. SCD2 misconfigurations now fail fast at deploy

`history` without `key=`, and `history` + `// partitioned`, were only caught at **run time** in `duckdb_executor.rs`. Both now fail at **deploy** via a shared `MaterializeSpec::validate(partitioned)`, called from `create_script_internal` (`Error::BadRequest`). The executor keeps the same check as a **safety net for preview/test runs that never deploy** — it calls the same `validate`, so the messages stay in sync (no drift). Error text is preserved (`requires a natural key`, `not supported with scd2`), so existing executor tests still assert cleanly.

## Files
- `parsers/windmill-parser/src/sql_materialize.rs` — `duplicate_source_key_guard_sql` helper, emitted in the `Merge` arm.
- `parsers/windmill-parser/src/asset_parser.rs` — `MaterializeSpec::validate`.
- `windmill-api-scripts/src/scripts.rs` — deploy-time `validate` call.
- `windmill-worker/src/duckdb_executor.rs` — runtime `validate` safety net, drops the two inline error returns.
- `docs/ducklake-materialization.md`, `docs/pipelines-vs-dbt.md` — document source-uniqueness requirement + deploy-time SCD2 rejection.

## Tests
- `codegen_merge_emits_duplicate_source_key_guard` — guard shape + ordering (before DELETE/INSERT).
- `materialize_validate_scd2_requires_key` / `_rejects_partitioned` / `_non_scd2_and_manual_are_inert` — all four `validate` branches.
- Updated `materialize_warn_summary_carries_schema_drift` to distinguish the merge dup-key guard from the schema-drift fail-guard.

## Validation
- `cargo test -p windmill-parser --lib` → 151 passed.
- `cargo test -p windmill-worker --features duckdb duckdb_executor::tests` → 74 passed.
- `cargo check -p windmill-worker --features duckdb`, `cargo check -p windmill-api-scripts` → clean.
- `rustfmt --check` on all touched files → clean.
- No SQL query changes → no sqlx cache update needed.

**Note:** end-to-end DuckDB execution of the guard SQL could not be run in this sandbox (the bundled `duckdb-sys` fails to compile from source here; the executor uses a prebuilt FFI dylib). The guard is structurally identical to the proven in-production `schema_drift_guard_sql` and is covered by codegen unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents silent double-writes in keyed merges and adds deploy-time validation for SCD2 configs to fail fast with clear errors.

- **Bug Fixes**
  - Keyed merge (`key=<col>`) now errors if the source SELECT returns multiple rows for the same non-NULL key; guard runs before DELETE/INSERT. Deduplicate in the SELECT (e.g. QUALIFY row_number() … = 1) or use `append`. NULL keys are insert-only and exempt.
  - SCD2 now validates at deploy: requires `key=`, and rejects `// partitioned`. The executor mirrors this check for preview/test runs to keep messages in sync.

<sup>Written for commit 7f78049ef91f2e33c7c7059e620c60664e31951f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

