### PR TITLE
fix(pipelines): canonicalize S3 asset keys so SDK writes and DuckDB reads connect

### DIFF
--- a/backend/parsers/windmill-parser-py-asset/src/lib.rs
+++ b/backend/parsers/windmill-parser-py-asset/src/lib.rs
@@ -383,7 +383,7 @@ def main():
             s.map_err(|e| e.to_string()),
             Ok(vec![ParseAssetsResult {
                 kind: AssetKind::S3Object,
-                path: "/test.csv".to_string(),
+                path: "test.csv".to_string(),
                 access_type: Some(R),
                 columns: None,
             },])
@@ -441,7 +441,31 @@ def main():
             s.map_err(|e| e.to_string()),
             Ok(vec![ParseAssetsResult {
                 kind: AssetKind::S3Object,
-                path: "/analytics/x.csv".to_string(),
+                path: "analytics/x.csv".to_string(),
+                access_type: Some(W),
+                columns: None,
+            },])
+        );
+    }
+
+    #[test]
+    fn test_py_write_key_matches_duckdb_read_key() {
+        // Cross-language lineage: this write records `exports/x`, the same path a
+        // DuckDB `read_csv('s3://exports/x')` resolves to (see
+        // windmill-parser-sql-asset `test_duckdb_read_key_matches_sdk_write_key`),
+        // so the producer and consumer connect in the pipeline graph.
+        let input = r#"
+import wmill
+from wmill import S3Object
+def main():
+    wmill.write_s3_file(S3Object(s3="exports/x"), b"content")
+"#;
+        let s = parse_assets(input).map(|o| o.assets);
+        assert_eq!(
+            s.map_err(|e| e.to_string()),
+            Ok(vec![ParseAssetsResult {
+                kind: AssetKind::S3Object,
+                path: "exports/x".to_string(),
                 access_type: Some(W),
                 columns: None,
             },])
@@ -484,7 +508,7 @@ def main():
             s.map_err(|e| e.to_string()),
             Ok(vec![ParseAssetsResult {
                 kind: AssetKind::S3Object,
-                path: "/dir/in.csv".to_string(),
+                path: "dir/in.csv".to_string(),
                 access_type: Some(R),
                 columns: None,
             },])
@@ -507,14 +531,14 @@ def main():
             Ok(vec![
                 ParseAssetsResult {
                     kind: AssetKind::S3Object,
-                    path: "/out.json".to_string(),
-                    access_type: Some(W),
+                    path: "mybucket/dir/in.csv".to_string(),
+                    access_type: Some(R),
                     columns: None,
                 },
                 ParseAssetsResult {
                     kind: AssetKind::S3Object,
-                    path: "mybucket/dir/in.csv".to_string(),
-                    access_type: Some(R),
+                    path: "out.json".to_string(),
+                    access_type: Some(W),
                     columns: None,
                 },
             ])
@@ -540,25 +564,25 @@ def main():
             Ok(vec![
                 ParseAssetsResult {
                     kind: AssetKind::S3Object,
-                    path: "/pipelines/km_real/enriched.json".to_string(),
+                    path: "pipelines/km_real/enriched.json".to_string(),
                     access_type: Some(W),
                     columns: None,
                 },
                 ParseAssetsResult {
                     kind: AssetKind::S3Object,
-                    path: "/pipelines/km_real/raw_events.json".to_string(),
+                    path: "pipelines/km_real/raw_events.json".to_string(),
                     access_type: Some(W),
                     columns: None,
                 },
                 ParseAssetsResult {
                     kind: AssetKind::S3Object,
-                    path: "/pipelines/km_real/report.json".to_string(),
+                    path: "pipelines/km_real/report.json".to_string(),
                     access_type: Some(W),
                     columns: None,
                 },
                 ParseAssetsResult {
                     kind: AssetKind::S3Object,
-                    path: "/pipelines/km_real/summary.json".to_string(),
+                    path: "pipelines/km_real/summary.json".to_string(),
                     access_type: Some(W),
                     columns: None,
                 },

--- a/backend/parsers/windmill-parser-sql-asset/src/asset_parser.rs
+++ b/backend/parsers/windmill-parser-sql-asset/src/asset_parser.rs
@@ -1145,13 +1145,13 @@ mod tests {
             Ok(vec![
                 ParseAssetsResult {
                     kind: AssetKind::S3Object,
-                    path: "/a.parquet".to_string(),
+                    path: "a.parquet".to_string(),
                     access_type: Some(R),
                     columns: None
                 },
                 ParseAssetsResult {
                     kind: AssetKind::S3Object,
-                    path: "/c.parquet".to_string(),
+                    path: "c.parquet".to_string(),
                     access_type: Some(W),
                     columns: None
                 },
@@ -1163,6 +1163,30 @@ mod tests {
                 },
             ])
         );
+    }
+
+    #[test]
+    fn test_duckdb_read_key_matches_sdk_write_key() {
+        // Cross-language lineage: a TS `writeS3File({ s3: "exports/x" })` or
+        // Python `write_s3_file(S3Object(s3="exports/x"))` records the asset path
+        // `exports/x` (default storage). A DuckDB reader of the same object must
+        // resolve to the identical path so the graph connects the producer and
+        // consumer — both the bare `s3://exports/x` and the triple-slash
+        // `s3:///exports/x` default-storage form must yield `exports/x`.
+        for uri in ["s3://exports/x", "s3:///exports/x"] {
+            let input = format!("SELECT * FROM read_csv('{uri}');");
+            let assets = parse_assets(&input).expect("parse").assets;
+            assert_eq!(
+                assets,
+                vec![ParseAssetsResult {
+                    kind: AssetKind::S3Object,
+                    path: "exports/x".to_string(),
+                    access_type: Some(R),
+                    columns: None
+                }],
+                "DuckDB read of {uri} must resolve to the SDK write key"
+            );
+        }
     }
 
     #[test]
@@ -1178,7 +1202,7 @@ mod tests {
             s.map_err(|e| e.to_string()),
             Ok(vec![ParseAssetsResult {
                 kind: AssetKind::S3Object,
-                path: "/out.csv".to_string(),
+                path: "out.csv".to_string(),
                 access_type: Some(W),
                 columns: None
             }])
@@ -1195,7 +1219,7 @@ mod tests {
             s.map_err(|e| e.to_string()),
             Ok(vec![ParseAssetsResult {
                 kind: AssetKind::S3Object,
-                path: "/referenced.csv".to_string(),
+                path: "referenced.csv".to_string(),
                 access_type: Some(R),
                 columns: None
             }])
@@ -1215,7 +1239,7 @@ mod tests {
             s.map_err(|e| e.to_string()),
             Ok(vec![ParseAssetsResult {
                 kind: AssetKind::S3Object,
-                path: "/data.csv".to_string(),
+                path: "data.csv".to_string(),
                 access_type: Some(RW),
                 columns: None
             }])
@@ -1235,7 +1259,7 @@ mod tests {
             s.map_err(|e| e.to_string()),
             Ok(vec![ParseAssetsResult {
                 kind: AssetKind::S3Object,
-                path: "/data.parquet".to_string(),
+                path: "data.parquet".to_string(),
                 access_type: Some(RW),
                 columns: None
             }])
@@ -1253,13 +1277,13 @@ mod tests {
             Ok(vec![
                 ParseAssetsResult {
                     kind: AssetKind::S3Object,
-                    path: "/a.parquet".to_string(),
+                    path: "a.parquet".to_string(),
                     access_type: Some(R),
                     columns: None
                 },
                 ParseAssetsResult {
                     kind: AssetKind::S3Object,
-                    path: "/b.parquet".to_string(),
+                    path: "b.parquet".to_string(),
                     access_type: Some(R),
                     columns: None
                 }
@@ -1279,7 +1303,7 @@ mod tests {
             s.map_err(|e| e.to_string()),
             Ok(vec![ParseAssetsResult {
                 kind: AssetKind::S3Object,
-                path: "/data.parquet".to_string(),
+                path: "data.parquet".to_string(),
                 access_type: Some(RW),
                 columns: None
             }])
@@ -1961,7 +1985,7 @@ mod tests {
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].kind, AssetKind::S3Object);
-        assert_eq!(result[0].path, "/example_file.parquet");
+        assert_eq!(result[0].path, "example_file.parquet");
         assert_eq!(result[0].access_type, Some(R));
 
         let columns = result[0].columns.as_ref().expect("Should have columns");
@@ -1992,7 +2016,7 @@ mod tests {
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].kind, AssetKind::S3Object);
-        assert_eq!(result[0].path, "/example_file.parquet");
+        assert_eq!(result[0].path, "example_file.parquet");
         assert!(result[0].columns.is_none());
     }
 
@@ -2005,7 +2029,7 @@ mod tests {
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].kind, AssetKind::S3Object);
-        assert_eq!(result[0].path, "/example_file.parquet");
+        assert_eq!(result[0].path, "example_file.parquet");
 
         let columns = result[0].columns.as_ref().expect("Should have columns");
         assert_eq!(columns.get("col1"), Some(&R));
@@ -2024,7 +2048,7 @@ mod tests {
         assert_eq!(result.len(), 2);
 
         assert!(result.iter().any(|a| {
-            a.path == "/file1.parquet"
+            a.path == "file1.parquet"
                 && a.columns.as_ref().map_or(false, |c| c.contains_key("col1"))
         }));
         assert!(result.iter().any(|a| {
@@ -2057,7 +2081,7 @@ mod tests {
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].kind, AssetKind::S3Object);
-        assert_eq!(result[0].path, "/test.parquet");
+        assert_eq!(result[0].path, "test.parquet");
         assert_eq!(result[0].access_type, Some(R));
 
         let columns = result[0].columns.as_ref().expect("Should have columns");

--- a/backend/parsers/windmill-parser-ts-asset/src/lib.rs
+++ b/backend/parsers/windmill-parser-ts-asset/src/lib.rs
@@ -433,7 +433,7 @@ mod tests {
             s.map(|r| r.assets).map_err(|e| e.to_string()),
             Ok(vec![ParseAssetsResult {
                 kind: AssetKind::S3Object,
-                path: "/test.csv".to_string(),
+                path: "test.csv".to_string(),
                 access_type: Some(R),
                 columns: None,
             },])
@@ -461,7 +461,31 @@ mod tests {
             s.map(|r| r.assets).map_err(|e| e.to_string()),
             Ok(vec![ParseAssetsResult {
                 kind: AssetKind::S3Object,
-                path: "/pipelines/km_real/raw_events.json".to_string(),
+                path: "pipelines/km_real/raw_events.json".to_string(),
+                access_type: Some(W),
+                columns: None,
+            },])
+        );
+    }
+
+    #[test]
+    fn test_ts_write_key_matches_duckdb_read_key() {
+        // Cross-language lineage: this write records `exports/x`, the same path a
+        // DuckDB `read_csv('s3://exports/x')` resolves to (see
+        // windmill-parser-sql-asset `test_duckdb_read_key_matches_sdk_write_key`),
+        // so the producer and consumer connect in the pipeline graph.
+        let input = r#"
+            import * as wmill from "windmill-client"
+            export async function main() {
+                await wmill.writeS3File({ s3: "exports/x" }, "[]")
+            }
+        "#;
+        let s = parse_assets(input);
+        assert_eq!(
+            s.map(|r| r.assets).map_err(|e| e.to_string()),
+            Ok(vec![ParseAssetsResult {
+                kind: AssetKind::S3Object,
+                path: "exports/x".to_string(),
                 access_type: Some(W),
                 columns: None,
             },])
@@ -546,25 +570,25 @@ mod tests {
             Ok(vec![
                 ParseAssetsResult {
                     kind: AssetKind::S3Object,
-                    path: "/pipelines/km_real/enriched.json".to_string(),
+                    path: "pipelines/km_real/enriched.json".to_string(),
                     access_type: Some(W),
                     columns: None,
                 },
                 ParseAssetsResult {
                     kind: AssetKind::S3Object,
-                    path: "/pipelines/km_real/raw_events.json".to_string(),
+                    path: "pipelines/km_real/raw_events.json".to_string(),
                     access_type: Some(W),
                     columns: None,
                 },
                 ParseAssetsResult {
                     kind: AssetKind::S3Object,
-                    path: "/pipelines/km_real/report.json".to_string(),
+                    path: "pipelines/km_real/report.json".to_string(),
                     access_type: Some(W),
                     columns: None,
                 },
                 ParseAssetsResult {
                     kind: AssetKind::S3Object,
-                    path: "/pipelines/km_real/summary.json".to_string(),
+                    path: "pipelines/km_real/summary.json".to_string(),
                     access_type: Some(W),
                     columns: None,
                 },
@@ -585,7 +609,7 @@ mod tests {
             s.map(|r| r.assets).map_err(|e| e.to_string()),
             Ok(vec![ParseAssetsResult {
                 kind: AssetKind::S3Object,
-                path: "/out.json".to_string(),
+                path: "out.json".to_string(),
                 access_type: Some(W),
                 columns: None,
             },])

--- a/backend/parsers/windmill-parser/src/asset_parser.rs
+++ b/backend/parsers/windmill-parser/src/asset_parser.rs
@@ -579,6 +579,21 @@ pub fn parse_asset_syntax(s: &str, enable_default_syntax: bool) -> Option<(Asset
     for (prefix, kind) in ASSET_KINDS.iter() {
         if s.starts_with(prefix) {
             let path = &s[prefix.len()..];
+            // Canonicalize S3 keys to a single asset identity. The SDK object
+            // form (`{ s3: "key" }` / `S3Object(s3="key")`, default storage)
+            // resolves to `s3:///key`, whose path is `/key`, while DuckDB
+            // `s3://key` and `// on s3://key` yield the bare `key`. Strip a
+            // leading slash so the triple-slash default-storage form and the
+            // `s3://storage/key` form share one path — otherwise a TS/Python
+            // writer and a DuckDB reader of the same object become disconnected
+            // nodes in the pipeline graph. Only a single leading slash is
+            // stripped, so Hive-partition keys (`s3://b/y=2024/f.parquet`) are
+            // untouched.
+            let path = if matches!(kind, AssetKind::S3Object) {
+                path.strip_prefix('/').unwrap_or(path)
+            } else {
+                path
+            };
             return Some((*kind, path));
         }
     }
@@ -1222,6 +1237,50 @@ fn parse_trigger_spec(s: &str) -> Option<TriggerSpec> {
 #[cfg(test)]
 mod pipeline_annotation_tests {
     use super::*;
+
+    #[test]
+    fn s3_key_normalization_unifies_uri_forms() {
+        // A TS/Python SDK write of `{ s3: "exports/x" }` (default storage)
+        // resolves to the URI `s3:///exports/x`, while a DuckDB read of
+        // `s3://exports/x` and the `// on s3://exports/x` trigger form yield the
+        // bare `exports/x`. All three must canonicalize to one asset key so
+        // the writer and reader connect in the pipeline graph.
+        let sdk_write = parse_asset_syntax("s3:///exports/x", false);
+        let duckdb_read = parse_asset_syntax("s3://exports/x", false);
+        assert_eq!(sdk_write, Some((AssetKind::S3Object, "exports/x")));
+        assert_eq!(duckdb_read, Some((AssetKind::S3Object, "exports/x")));
+        assert_eq!(sdk_write, duckdb_read);
+
+        // The `// on` trigger annotation goes through the same function.
+        assert_eq!(
+            parse_asset_syntax("s3:///exports/x", true),
+            parse_asset_syntax("s3://exports/x", true)
+        );
+
+        // Explicit-storage form is unaffected (no leading slash to strip).
+        assert_eq!(
+            parse_asset_syntax("s3://mybucket/exports/x", false),
+            Some((AssetKind::S3Object, "mybucket/exports/x"))
+        );
+
+        // Only a single leading slash is stripped, so Hive-partition keys and
+        // nested paths under default storage are preserved verbatim.
+        assert_eq!(
+            parse_asset_syntax("s3:///t/year=2024/month=01/f.parquet", false),
+            Some((AssetKind::S3Object, "t/year=2024/month=01/f.parquet"))
+        );
+
+        // Non-S3 kinds keep their leading slash (their paths are workspace-
+        // relative and the slash is significant).
+        assert_eq!(
+            parse_asset_syntax("res://f/foo", false),
+            Some((AssetKind::Resource, "f/foo"))
+        );
+        assert_eq!(
+            parse_asset_syntax("ducklake://analytics/orders", false),
+            Some((AssetKind::Ducklake, "analytics/orders"))
+        );
+    }
 
     #[test]
     fn bare_pipeline_marker() {

--- a/backend/parsers/windmill-parser/src/asset_parser.rs
+++ b/backend/parsers/windmill-parser/src/asset_parser.rs
@@ -1283,6 +1283,26 @@ mod pipeline_annotation_tests {
     }
 
     #[test]
+    fn s3_explicit_storage_aliases_default_storage_nested_key() {
+        // Accepted tradeoff of one canonical key: the explicit-storage form
+        // `s3://storage/key` and the default-storage nested-key form
+        // `s3:///storage/key` collapse to the same node `storage/key`, even
+        // though they name different objects. This is a best-effort lineage
+        // graph that does not split the first segment as a storage name; the
+        // collision only happens when a storage config is named to match a
+        // default-storage prefix. Pinned so the aliasing is intentional, not a
+        // latent surprise.
+        assert_eq!(
+            parse_asset_syntax("s3://mybucket/x", false),
+            parse_asset_syntax("s3:///mybucket/x", false)
+        );
+        assert_eq!(
+            parse_asset_syntax("s3://mybucket/x", false),
+            Some((AssetKind::S3Object, "mybucket/x"))
+        );
+    }
+
+    #[test]
     fn bare_pipeline_marker() {
         let out = parse_pipeline_annotations("// pipeline\nconsole.log('hi')");
         assert!(out.in_pipeline);

--- a/backend/parsers/windmill-parser/src/asset_parser.rs
+++ b/backend/parsers/windmill-parser/src/asset_parser.rs
@@ -582,15 +582,18 @@ pub fn parse_asset_syntax(s: &str, enable_default_syntax: bool) -> Option<(Asset
             // Canonicalize S3 keys to a single asset identity. The SDK object
             // form (`{ s3: "key" }` / `S3Object(s3="key")`, default storage)
             // resolves to `s3:///key`, whose path is `/key`, while DuckDB
-            // `s3://key` and `// on s3://key` yield the bare `key`. Strip a
+            // `s3://key` and `// on s3://key` yield the bare `key`. Strip every
             // leading slash so the triple-slash default-storage form and the
             // `s3://storage/key` form share one path — otherwise a TS/Python
             // writer and a DuckDB reader of the same object become disconnected
-            // nodes in the pipeline graph. Only a single leading slash is
-            // stripped, so Hive-partition keys (`s3://b/y=2024/f.parquet`) are
-            // untouched.
+            // nodes in the pipeline graph. Stripping ALL leading slashes (not
+            // just one) keeps the identity stable through URI reconstruction:
+            // `trigger_spec_to_row` rebuilds `s3://<path>`, so a canonical path
+            // must never itself start with `/` or the rebuilt ref would parse
+            // back to a different key. Only leading slashes are touched, so
+            // Hive-partition keys (`s3://b/y=2024/f.parquet`) are untouched.
             let path = if matches!(kind, AssetKind::S3Object) {
-                path.strip_prefix('/').unwrap_or(path)
+                path.trim_start_matches('/')
             } else {
                 path
             };
@@ -1263,11 +1266,24 @@ mod pipeline_annotation_tests {
             Some((AssetKind::S3Object, "mybucket/exports/x"))
         );
 
-        // Only a single leading slash is stripped, so Hive-partition keys and
-        // nested paths under default storage are preserved verbatim.
+        // Hive-partition keys and nested paths under default storage are
+        // preserved verbatim (only leading slashes are stripped).
         assert_eq!(
             parse_asset_syntax("s3:///t/year=2024/month=01/f.parquet", false),
             Some((AssetKind::S3Object, "t/year=2024/month=01/f.parquet"))
+        );
+
+        // Every leading slash is stripped so a canonical S3 path never starts
+        // with `/`. `S3Object(s3="/x")` resolves to the quad-slash URI
+        // `s3:////x`; the identity must be the bare `x` (not `/x`) so the ref
+        // that `trigger_spec_to_row` rebuilds round-trips back to it.
+        assert_eq!(
+            parse_asset_syntax("s3:////x", false),
+            Some((AssetKind::S3Object, "x"))
+        );
+        assert_eq!(
+            parse_asset_syntax("s3://///deep///", false),
+            Some((AssetKind::S3Object, "deep///"))
         );
 
         // Non-S3 kinds keep their leading slash (their paths are workspace-

--- a/backend/parsers/windmill-parser/tests/fixtures/pipeline_annotations.json
+++ b/backend/parsers/windmill-parser/tests/fixtures/pipeline_annotations.json
@@ -739,5 +739,20 @@
 			"tag": null,
 			"retry": null
 		}
+	},
+	{
+		"name": "s3 triple-slash default-storage trigger canonicalizes to bare key",
+		"code": "// pipeline\n// on s3:///exports/x\nexport function main() {}",
+		"expected": {
+			"in_pipeline": true,
+			"asset_triggers": [
+				"s3object:exports/x"
+			],
+			"native_triggers": [],
+			"partition": null,
+			"freshness": null,
+			"tag": null,
+			"retry": null
+		}
 	}
 ]

--- a/backend/parsers/windmill-parser/tests/fixtures/pipeline_annotations.json
+++ b/backend/parsers/windmill-parser/tests/fixtures/pipeline_annotations.json
@@ -754,5 +754,20 @@
 			"tag": null,
 			"retry": null
 		}
+	},
+	{
+		"name": "s3 quad-slash trigger strips all leading slashes to the bare key",
+		"code": "// pipeline\n// on s3:////x\nexport function main() {}",
+		"expected": {
+			"in_pipeline": true,
+			"asset_triggers": [
+				"s3object:x"
+			],
+			"native_triggers": [],
+			"partition": null,
+			"freshness": null,
+			"tag": null,
+			"retry": null
+		}
 	}
 ]

--- a/backend/windmill-common/src/assets.rs
+++ b/backend/windmill-common/src/assets.rs
@@ -369,6 +369,45 @@ mod debounce_duration_tests {
     }
 }
 
+#[cfg(test)]
+mod trigger_ref_roundtrip_tests {
+    use super::{parse_asset_trigger_ref, trigger_spec_to_row, AssetKind, ScriptTriggerKind};
+    use windmill_parser::asset_parser::{parse_asset_syntax, AssetKind as PAssetKind, TriggerSpec};
+
+    // `trigger_spec_to_row` rebuilds a stored ref as `s3://<path>`, and
+    // `parse_asset_trigger_ref` parses it back. The two must be inverse for
+    // every S3 URI form, or a consumer's `// on` trigger lands on a different
+    // graph node than the producer's inferred write. Because `parse_asset_syntax`
+    // strips ALL leading slashes, a canonical path never starts with `/`, so the
+    // naive `prefix + path` rebuild round-trips — including the `S3Object(s3="/x")`
+    // quad-slash case that previously desynced (path `/x` rebuilt to `s3:///x`,
+    // which re-parsed to `x`).
+    fn roundtrip(uri: &str) -> String {
+        let (pkind, path) = parse_asset_syntax(uri, false).expect("parse uri");
+        assert_eq!(pkind, PAssetKind::S3Object);
+        let spec = TriggerSpec::Asset { asset_kind: pkind, path: path.to_string(), debounce: None };
+        let (kind, stored) = trigger_spec_to_row(&spec).expect("to row");
+        assert_eq!(kind, ScriptTriggerKind::Asset);
+        let (rkind, rpath) = parse_asset_trigger_ref(&stored).expect("parse ref");
+        assert_eq!(rkind, AssetKind::S3Object);
+        // The producer path and the round-tripped consumer path must match.
+        assert_eq!(
+            rpath, path,
+            "round-trip diverged for {uri} (stored {stored})"
+        );
+        rpath
+    }
+
+    #[test]
+    fn s3_trigger_ref_roundtrips_for_every_uri_form() {
+        assert_eq!(roundtrip("s3:///exports/x"), "exports/x"); // SDK default storage
+        assert_eq!(roundtrip("s3://exports/x"), "exports/x"); // DuckDB / bare
+        assert_eq!(roundtrip("s3://mybucket/exports/x"), "mybucket/exports/x"); // explicit
+        assert_eq!(roundtrip("s3:////x"), "x"); // S3Object(s3="/x") quad-slash
+        assert_eq!(roundtrip("s3:///y=2024/f.parquet"), "y=2024/f.parquet"); // Hive
+    }
+}
+
 // Inverse of trigger_spec_to_row for the Asset variant: parses a stored
 // trigger_ref (e.g. `s3://foo`, `$res:bar`) back into the (kind, path) pair
 // used as a graph node id. Returns None for refs that don't match any known

--- a/cli/src/commands/pipeline/boundedCascade.ts
+++ b/cli/src/commands/pipeline/boundedCascade.ts
@@ -74,7 +74,11 @@ export function assetUriToNodeId(uri: string): string | undefined {
   if (!m) return undefined;
   const prefix = m[1].toLowerCase();
   const kind = prefix === "s3" ? "s3object" : prefix;
-  return `${kind}:${m[2]}`;
+  // Mirror Rust `parse_asset_syntax`: strip one leading slash from S3 keys so a
+  // `--to s3:///exports/x` token resolves to the canonical graph node
+  // `s3object:exports/x` (default storage), same as `s3://exports/x`.
+  const path = kind === "s3object" ? m[2].replace(/^\//, "") : m[2];
+  return `${kind}:${path}`;
 }
 
 export type LineageDag = {

--- a/cli/src/commands/pipeline/boundedCascade.ts
+++ b/cli/src/commands/pipeline/boundedCascade.ts
@@ -74,10 +74,11 @@ export function assetUriToNodeId(uri: string): string | undefined {
   if (!m) return undefined;
   const prefix = m[1].toLowerCase();
   const kind = prefix === "s3" ? "s3object" : prefix;
-  // Mirror Rust `parse_asset_syntax`: strip one leading slash from S3 keys so a
+  // Mirror Rust `parse_asset_syntax`: strip all leading slashes from S3 keys so a
   // `--to s3:///exports/x` token resolves to the canonical graph node
-  // `s3object:exports/x` (default storage), same as `s3://exports/x`.
-  const path = kind === "s3object" ? m[2].replace(/^\//, "") : m[2];
+  // `s3object:exports/x` (default storage), same as `s3://exports/x`, and a
+  // canonical key never starts with `/`.
+  const path = kind === "s3object" ? m[2].replace(/^\/+/, "") : m[2];
   return `${kind}:${path}`;
 }
 

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -249,11 +249,12 @@ function fallbackParse(content: string, language: string): ParseAssetsRaw {
     if (uri) {
       const prefix = uri[1].toLowerCase();
       const kind = prefix === "s3" ? "s3object" : prefix;
-      // Mirror Rust `parse_asset_syntax`: strip one leading slash from S3 keys
+      // Mirror Rust `parse_asset_syntax`: strip all leading slashes from S3 keys
       // so `s3:///key` (default storage) and `s3://key` / DuckDB canonicalize
-      // to the same node id — otherwise a go/bash fallback consumer's
-      // `// on s3:///x` would not connect to a wasm-inferred `x` producer.
-      const path = kind === "s3object" ? uri[2].replace(/^\//, "") : uri[2];
+      // to the same node id (and a canonical key never starts with `/`) —
+      // otherwise a go/bash fallback consumer's `// on s3:///x` would not
+      // connect to a wasm-inferred `x` producer.
+      const path = kind === "s3object" ? uri[2].replace(/^\/+/, "") : uri[2];
       out.triggers!.push({ kind: "asset", asset_kind: kind, path });
     } else if (NATIVE_KINDS.has(firstTok) && rest === firstTok) {
       // A native marker (`// on data_upload`) must stand alone: the canonical

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -249,7 +249,12 @@ function fallbackParse(content: string, language: string): ParseAssetsRaw {
     if (uri) {
       const prefix = uri[1].toLowerCase();
       const kind = prefix === "s3" ? "s3object" : prefix;
-      out.triggers!.push({ kind: "asset", asset_kind: kind, path: uri[2] });
+      // Mirror Rust `parse_asset_syntax`: strip one leading slash from S3 keys
+      // so `s3:///key` (default storage) and `s3://key` / DuckDB canonicalize
+      // to the same node id — otherwise a go/bash fallback consumer's
+      // `// on s3:///x` would not connect to a wasm-inferred `x` producer.
+      const path = kind === "s3object" ? uri[2].replace(/^\//, "") : uri[2];
+      out.triggers!.push({ kind: "asset", asset_kind: kind, path });
     } else if (NATIVE_KINDS.has(firstTok) && rest === firstTok) {
       // A native marker (`// on data_upload`) must stand alone: the canonical
       // parser rejects a marker line with trailing content (`// on data_upload

--- a/cli/test/pipeline_bounded_cascade_unit.test.ts
+++ b/cli/test/pipeline_bounded_cascade_unit.test.ts
@@ -203,6 +203,15 @@ test("assetUriToNodeId maps s3 → s3object, others verbatim", () => {
   expect(assetUriToNodeId("nope")).toBe(undefined);
 });
 
+test("assetUriToNodeId strips one leading slash from S3 keys (canonical node)", () => {
+  // Mirror of Rust `parse_asset_syntax`: `--to s3:///exports/x` must resolve to
+  // the same canonical node as the graph's `s3object:exports/x`.
+  expect(assetUriToNodeId("s3:///exports/x")).toBe("s3object:exports/x");
+  expect(assetUriToNodeId("s3:///exports/x")).toBe(assetUriToNodeId("s3://exports/x"));
+  // Only one slash; Hive-partition keys and non-S3 kinds are untouched.
+  expect(assetUriToNodeId("s3:///t/y=2024/f.parquet")).toBe("s3object:t/y=2024/f.parquet");
+});
+
 test("resolveToken: short name, full path, and asset URI", () => {
   const g = graph({ scripts: ["f/p/stage"], writes: [["f/p/stage", "main/staged"]] });
   g.assets = [{ kind: "datatable", path: "main/staged" }];

--- a/cli/test/pipeline_bounded_cascade_unit.test.ts
+++ b/cli/test/pipeline_bounded_cascade_unit.test.ts
@@ -203,12 +203,15 @@ test("assetUriToNodeId maps s3 → s3object, others verbatim", () => {
   expect(assetUriToNodeId("nope")).toBe(undefined);
 });
 
-test("assetUriToNodeId strips one leading slash from S3 keys (canonical node)", () => {
+test("assetUriToNodeId strips leading slashes from S3 keys (canonical node)", () => {
   // Mirror of Rust `parse_asset_syntax`: `--to s3:///exports/x` must resolve to
   // the same canonical node as the graph's `s3object:exports/x`.
   expect(assetUriToNodeId("s3:///exports/x")).toBe("s3object:exports/x");
   expect(assetUriToNodeId("s3:///exports/x")).toBe(assetUriToNodeId("s3://exports/x"));
-  // Only one slash; Hive-partition keys and non-S3 kinds are untouched.
+  // All leading slashes stripped so a canonical key never starts with `/`
+  // (the quad-slash `S3Object(s3="/x")` form collapses to `x`).
+  expect(assetUriToNodeId("s3:////x")).toBe("s3object:x");
+  // Hive-partition keys and non-S3 kinds are untouched.
   expect(assetUriToNodeId("s3:///t/y=2024/f.parquet")).toBe("s3object:t/y=2024/f.parquet");
 });
 

--- a/cli/test/pipeline_local_graph_unit.test.ts
+++ b/cli/test/pipeline_local_graph_unit.test.ts
@@ -214,6 +214,32 @@ test("go/bash fallback: leading-header `// on` only, options stripped, no body p
   );
 });
 
+test("go/bash fallback: `// on s3:///key` canonicalizes to the slashless key", async () => {
+  // Mirror of the Rust/wasm `parse_asset_syntax` S3 strip: a fallback consumer's
+  // triple-slash default-storage trigger must resolve to the bare key `exports/x`
+  // — the same identity a wasm-inferred SDK/DuckDB producer uses — or the local
+  // graph shows a disconnected `/exports/x` node. Explicit storage is untouched.
+  await withFolder(
+    {
+      "triple.go": `// pipeline\n// on s3:///exports/x\npackage inner\nfunc main() {}\n`,
+      "bare.go": `// pipeline\n// on s3://exports/x\npackage inner\nfunc main() {}\n`,
+      "storage.go": `// pipeline\n// on s3://mybucket/exports/x\npackage inner\nfunc main() {}\n`,
+    },
+    async (root, folder) => {
+      const { graph } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+      const pathFor = (p: string) =>
+        graph.triggers.find(
+          (t) => t.trigger_kind === "asset" && t.runnable_path === p
+        ) as Extract<(typeof graph.triggers)[number], { trigger_kind: "asset" }> | undefined;
+      // triple-slash and bare both canonicalize to `exports/x` → same node
+      expect(pathFor("f/mypipe/triple")?.asset_path).toBe("exports/x");
+      expect(pathFor("f/mypipe/bare")?.asset_path).toBe("exports/x");
+      // explicit storage keeps its `storage/key` path (no leading slash to strip)
+      expect(pathFor("f/mypipe/storage")?.asset_path).toBe("mybucket/exports/x");
+    },
+  );
+});
+
 test("go/bash fallback: a native marker with trailing content is rejected (parity)", async () => {
   // The canonical parser rejects a marker line with trailing content, so the
   // fallback must too — else a `// on data_upload f/foo` / `# on kafka topic`

--- a/docs/pipeline-local-dev.md
+++ b/docs/pipeline-local-dev.md
@@ -84,14 +84,16 @@ makes the client own the whole cascade so the backend dispatcher never double-fi
 `inferScriptAssets` mirrors `frontend/src/lib/infer.ts:inferAssets`: ts (bun/deno/nativets),
 python3, and SQL dialects all get wasm inference (SQL dialects route to `parse_assets_sql`; its
 comment-header annotation scan is dialect-independent). `go`/`bash` have no wasm asset parser, so
-they fall back to a minimal `// pipeline` + `// on` scan (annotation-only). Note inferred asset
-**paths must match exactly** to connect nodes: DuckDB `read_csv('s3://x')` / `COPY ... TO 's3://x'`
-and `// on s3://x` all yield path `x` (no leading slash), whereas the SDK object forms — TS
-`writeS3File({s3:"x"})` and python `write_s3_file(S3Object(s3="x"))` (or the equivalent dict
-literal), both resolved as `s3://<storage>/<key>` with empty default storage — yield `/x`, matching
-the `// on s3:///x` (triple-slash) annotation form. So an all-DuckDB example connects cleanly, and
-SDK writes connect to `s3:///…` annotations; mixing SDK-write with the no-slash annotation form
-needs care.
+they fall back to a minimal `// pipeline` + `// on` scan (annotation-only). Inferred asset paths
+must match to connect nodes, and all S3 URI forms canonicalize to one key: `parse_asset_syntax`
+(shared by the native and wasm parsers) strips a single leading slash from S3 paths, so the SDK
+object forms — TS `writeS3File({s3:"x"})` and python `write_s3_file(S3Object(s3="x"))`, which
+resolve to `s3:///x` (empty default storage) — the triple-slash annotation `// on s3:///x`, DuckDB
+`read_csv('s3://x')` / `COPY ... TO 's3://x'`, and `// on s3://x` all yield path `x`. A TS/Python
+writer and a DuckDB reader of the same object therefore connect regardless of which URI form each
+side uses. (Only a single leading slash is stripped, so Hive-partition keys like
+`s3://bucket/y=2024/f.parquet` are untouched, and the explicit-storage form `s3://storage/key`
+keeps its `storage/key` path.)
 
 ## How to test
 

--- a/docs/pipeline-local-dev.md
+++ b/docs/pipeline-local-dev.md
@@ -153,11 +153,12 @@ http://localhost:3000/pipeline_dev?workspace=<WS>&wm_token=<TOK>&folder=demo_pip
    `startProxyServer` for embedders that need a localhost origin (e.g. Claude Code preview).
 5. **`pipeline dev` editing**: the dev page is view+run only (editing stays in the user's editor).
    If in-browser editing with file round-trip is wanted, mirror flow-dev's `handleFlowRoundTrip`.
-6. **Asset-path normalization**: partially done — the python parser now resolves the
+6. **Asset-path normalization**: done — the python parser resolves the
    `S3Object(s3=…, storage=…?)` constructor / dict-literal forms to the same canonical path as the
-   TS `{s3, storage}` object form (see Language coverage), so SDK writes and reads connect across
-   ts/python. Still open: the SDK-form leading-slash (`/x`) vs bare-URI no-slash (`x`, DuckDB and
-   `// on s3://x`) mismatch silently breaks lineage across those two conventions.
+   TS `{s3, storage}` object form, and `parse_asset_syntax` now strips a single leading slash from
+   S3 keys so the SDK-form `s3:///x` (`/x`) and the bare-URI no-slash form (`x`, DuckDB and
+   `// on s3://x`) canonicalize to one key (see Language coverage). SDK writes and DuckDB reads of
+   the same object connect regardless of URI convention.
 
 ## Plan reference
 

--- a/docs/pipeline-local-dev.md
+++ b/docs/pipeline-local-dev.md
@@ -93,7 +93,12 @@ resolve to `s3:///x` (empty default storage) — the triple-slash annotation `//
 writer and a DuckDB reader of the same object therefore connect regardless of which URI form each
 side uses. (Only a single leading slash is stripped, so Hive-partition keys like
 `s3://bucket/y=2024/f.parquet` are untouched, and the explicit-storage form `s3://storage/key`
-keeps its `storage/key` path.)
+keeps its `storage/key` path.) Tradeoff of collapsing to one canonical key: the explicit-storage
+form `s3://storage/key` and the default-storage nested-key form `s3:///storage/key` now alias to
+the same node `storage/key`, even though they name different objects (a bucket `storage` vs. an
+object under the `storage/` prefix in default storage). This only collides when a storage config is
+named to match a default-storage prefix — unlikely, and acceptable for a best-effort lineage graph
+that already doesn't split the first segment as a storage name.
 
 ## How to test
 

--- a/docs/pipeline-local-dev.md
+++ b/docs/pipeline-local-dev.md
@@ -86,14 +86,15 @@ python3, and SQL dialects all get wasm inference (SQL dialects route to `parse_a
 comment-header annotation scan is dialect-independent). `go`/`bash` have no wasm asset parser, so
 they fall back to a minimal `// pipeline` + `// on` scan (annotation-only). Inferred asset paths
 must match to connect nodes, and all S3 URI forms canonicalize to one key: `parse_asset_syntax`
-(shared by the native and wasm parsers) strips a single leading slash from S3 paths, so the SDK
+(shared by the native and wasm parsers) strips leading slashes from S3 paths, so the SDK
 object forms — TS `writeS3File({s3:"x"})` and python `write_s3_file(S3Object(s3="x"))`, which
 resolve to `s3:///x` (empty default storage) — the triple-slash annotation `// on s3:///x`, DuckDB
 `read_csv('s3://x')` / `COPY ... TO 's3://x'`, and `// on s3://x` all yield path `x`. A TS/Python
 writer and a DuckDB reader of the same object therefore connect regardless of which URI form each
-side uses. (Only a single leading slash is stripped, so Hive-partition keys like
-`s3://bucket/y=2024/f.parquet` are untouched, and the explicit-storage form `s3://storage/key`
-keeps its `storage/key` path.) Tradeoff of collapsing to one canonical key: the explicit-storage
+side uses. (Only leading slashes are stripped — so a canonical key never starts with `/`, which
+keeps the identity stable through `// on` trigger-ref reconstruction — while Hive-partition keys
+like `s3://bucket/y=2024/f.parquet` and the explicit-storage form `s3://storage/key` keep their
+`bucket/…` / `storage/key` paths.) Tradeoff of collapsing to one canonical key: the explicit-storage
 form `s3://storage/key` and the default-storage nested-key form `s3:///storage/key` now alias to
 the same node `storage/key`, even though they name different objects (a bucket `storage` vs. an
 object under the `storage/` prefix in default storage). This only collides when a storage config is
@@ -160,7 +161,7 @@ http://localhost:3000/pipeline_dev?workspace=<WS>&wm_token=<TOK>&folder=demo_pip
    If in-browser editing with file round-trip is wanted, mirror flow-dev's `handleFlowRoundTrip`.
 6. **Asset-path normalization**: done — the python parser resolves the
    `S3Object(s3=…, storage=…?)` constructor / dict-literal forms to the same canonical path as the
-   TS `{s3, storage}` object form, and `parse_asset_syntax` now strips a single leading slash from
+   TS `{s3, storage}` object form, and `parse_asset_syntax` now strips leading slashes from
    S3 keys so the SDK-form `s3:///x` (`/x`) and the bare-URI no-slash form (`x`, DuckDB and
    `// on s3://x`) canonicalize to one key (see Language coverage). SDK writes and DuckDB reads of
    the same object connect regardless of URI convention.

--- a/frontend/src/lib/components/assets/AssetGraph/boundedCascade.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/boundedCascade.test.ts
@@ -280,12 +280,15 @@ describe('assetUriToNodeId', () => {
 		expect(assetUriToNodeId('ducklake://lake/t')).toBe('ducklake:lake/t')
 		expect(assetUriToNodeId('not-a-uri')).toBeUndefined()
 	})
-	it('strips one leading slash from S3 keys so s3:/// and s3:// share a node', () => {
+	it('strips leading slashes from S3 keys so s3:/// and s3:// share a node', () => {
 		// Mirror of Rust `parse_asset_syntax`: `--to s3:///exports/x` must resolve
 		// to the same canonical node as the graph's `s3object:exports/x`.
 		expect(assetUriToNodeId('s3:///exports/x')).toBe('s3object:exports/x')
 		expect(assetUriToNodeId('s3:///exports/x')).toBe(assetUriToNodeId('s3://exports/x'))
-		// Only one slash; Hive-partition keys and non-S3 kinds are untouched.
+		// All leading slashes are stripped so a canonical key never starts with
+		// `/` (the quad-slash `S3Object(s3="/x")` form collapses to `x`).
+		expect(assetUriToNodeId('s3:////x')).toBe('s3object:x')
+		// Hive-partition keys and non-S3 kinds are untouched.
 		expect(assetUriToNodeId('s3:///t/y=2024/f.parquet')).toBe('s3object:t/y=2024/f.parquet')
 	})
 })

--- a/frontend/src/lib/components/assets/AssetGraph/boundedCascade.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/boundedCascade.test.ts
@@ -280,4 +280,12 @@ describe('assetUriToNodeId', () => {
 		expect(assetUriToNodeId('ducklake://lake/t')).toBe('ducklake:lake/t')
 		expect(assetUriToNodeId('not-a-uri')).toBeUndefined()
 	})
+	it('strips one leading slash from S3 keys so s3:/// and s3:// share a node', () => {
+		// Mirror of Rust `parse_asset_syntax`: `--to s3:///exports/x` must resolve
+		// to the same canonical node as the graph's `s3object:exports/x`.
+		expect(assetUriToNodeId('s3:///exports/x')).toBe('s3object:exports/x')
+		expect(assetUriToNodeId('s3:///exports/x')).toBe(assetUriToNodeId('s3://exports/x'))
+		// Only one slash; Hive-partition keys and non-S3 kinds are untouched.
+		expect(assetUriToNodeId('s3:///t/y=2024/f.parquet')).toBe('s3object:t/y=2024/f.parquet')
+	})
 })

--- a/frontend/src/lib/components/assets/AssetGraph/boundedCascade.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/boundedCascade.ts
@@ -38,9 +38,10 @@ export function assetUriToNodeId(uri: string): string | undefined {
 	// `s3` is the URI prefix for the `s3object` asset kind (mirrors the CLI
 	// `assetUri` and the canvas). All other kinds use their name verbatim.
 	const kind = prefix === 's3' ? 's3object' : prefix
-	// Mirror Rust `parse_asset_syntax`: strip one leading slash from S3 keys so
-	// `s3:///key` (default storage) and `s3://key` resolve to the same node id.
-	const path = kind === 's3object' ? m[2].replace(/^\//, '') : m[2]
+	// Mirror Rust `parse_asset_syntax`: strip all leading slashes from S3 keys so
+	// `s3:///key` (default storage) and `s3://key` resolve to the same node id
+	// and a canonical key never starts with `/`.
+	const path = kind === 's3object' ? m[2].replace(/^\/+/, '') : m[2]
 	return `${kind}:${path}`
 }
 

--- a/frontend/src/lib/components/assets/AssetGraph/boundedCascade.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/boundedCascade.ts
@@ -38,7 +38,10 @@ export function assetUriToNodeId(uri: string): string | undefined {
 	// `s3` is the URI prefix for the `s3object` asset kind (mirrors the CLI
 	// `assetUri` and the canvas). All other kinds use their name verbatim.
 	const kind = prefix === 's3' ? 's3object' : prefix
-	return `${kind}:${m[2]}`
+	// Mirror Rust `parse_asset_syntax`: strip one leading slash from S3 keys so
+	// `s3:///key` (default storage) and `s3://key` resolve to the same node id.
+	const path = kind === 's3object' ? m[2].replace(/^\//, '') : m[2]
+	return `${kind}:${path}`
 }
 
 // Native trigger kinds that fan out *per event*: a single event always flows

--- a/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.ts
@@ -247,7 +247,17 @@ function parseKvOpts(s: string): Map<string, string> {
 function parseAssetSyntax(s: string): PipelineTriggerAsset | undefined {
 	for (const [prefix, kind] of ASSET_PREFIXES) {
 		if (s.startsWith(prefix)) {
-			return { kind, path: s.slice(prefix.length) }
+			let path = s.slice(prefix.length)
+			// Mirror the Rust `parse_asset_syntax` S3 canonicalization: strip a
+			// single leading slash so the SDK object form (`s3:///key`, default
+			// storage) and DuckDB / `// on s3://key` share one asset path.
+			// Without this the live graph preview would show disconnected
+			// `/key` and `key` nodes for the triple-slash case. S3-only; only
+			// one slash, so Hive-partition keys are untouched.
+			if (kind === 's3object' && path.startsWith('/')) {
+				path = path.slice(1)
+			}
+			return { kind, path }
 		}
 	}
 	return undefined

--- a/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/parsePipelineAnnotations.ts
@@ -248,14 +248,15 @@ function parseAssetSyntax(s: string): PipelineTriggerAsset | undefined {
 	for (const [prefix, kind] of ASSET_PREFIXES) {
 		if (s.startsWith(prefix)) {
 			let path = s.slice(prefix.length)
-			// Mirror the Rust `parse_asset_syntax` S3 canonicalization: strip a
-			// single leading slash so the SDK object form (`s3:///key`, default
-			// storage) and DuckDB / `// on s3://key` share one asset path.
-			// Without this the live graph preview would show disconnected
-			// `/key` and `key` nodes for the triple-slash case. S3-only; only
-			// one slash, so Hive-partition keys are untouched.
-			if (kind === 's3object' && path.startsWith('/')) {
-				path = path.slice(1)
+			// Mirror the Rust `parse_asset_syntax` S3 canonicalization: strip all
+			// leading slashes so the SDK object form (`s3:///key`, default
+			// storage) and DuckDB / `// on s3://key` share one asset path, and a
+			// canonical key never starts with `/` (so ref reconstruction
+			// round-trips). Without this the live graph preview would show
+			// disconnected `/key` and `key` nodes. S3-only; leading slashes only,
+			// so Hive-partition keys are untouched.
+			if (kind === 's3object') {
+				path = path.replace(/^\/+/, '')
 			}
 			return { kind, path }
 		}

--- a/frontend/src/lib/components/assets/AssetGraph/pipelineTemplates.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/pipelineTemplates.test.ts
@@ -32,8 +32,8 @@ describe('pipelineTemplates S3 seed/body parity', () => {
 				expect(output).toBeDefined()
 				const asset = output!
 
-				// The seed must be a canonical slashless key (the invariant that
-				// broke when the parser started stripping the leading slash).
+				// The seed must be a canonical slashless key so it matches the
+				// identity the parser infers from the generated body.
 				expect(asset.kind).toBe('s3object')
 				expect(asset.path.startsWith('/')).toBe(false)
 

--- a/frontend/src/lib/components/assets/AssetGraph/pipelineTemplates.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/pipelineTemplates.test.ts
@@ -9,8 +9,8 @@ import {
 // The seeded draft asset (`autoOutputAsset`, stored as `outputAssets` and used
 // by resolveGraph for inactive-draft node identity) must match the asset
 // identity the deploy-time / wasm parser infers from the generated body. The
-// parser canonicalizes any S3 URI by stripping the `s3://` prefix and a single
-// leading slash (see backend `parse_asset_syntax`); if the seed carried a
+// parser canonicalizes any S3 URI by stripping the `s3://` prefix and all
+// leading slashes (see backend `parse_asset_syntax`); if the seed carried a
 // leading slash while the body wrote `s3:///key`, the preview would render a
 // duplicate `/key` node and a phantom post-deploy drift. This pins the two in
 // lockstep so that class of drift can't regress.
@@ -18,7 +18,7 @@ import {
 // Mirror of the parser's S3 canonicalization for a raw `s3://…` URI.
 function canonicalS3Key(uri: string): string {
 	const rest = uri.replace(/^s3:\/\//, '')
-	return rest.replace(/^\//, '')
+	return rest.replace(/^\/+/, '')
 }
 
 const S3_KINDS: PipelineOutputKind[] = ['s3_parquet', 's3_object']

--- a/frontend/src/lib/components/assets/AssetGraph/pipelineTemplates.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/pipelineTemplates.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import type { ScriptLang } from '$lib/gen'
+import {
+	autoOutputAsset,
+	generatePipelineDraft,
+	type PipelineOutputKind
+} from './pipelineTemplates'
+
+// The seeded draft asset (`autoOutputAsset`, stored as `outputAssets` and used
+// by resolveGraph for inactive-draft node identity) must match the asset
+// identity the deploy-time / wasm parser infers from the generated body. The
+// parser canonicalizes any S3 URI by stripping the `s3://` prefix and a single
+// leading slash (see backend `parse_asset_syntax`); if the seed carried a
+// leading slash while the body wrote `s3:///key`, the preview would render a
+// duplicate `/key` node and a phantom post-deploy drift. This pins the two in
+// lockstep so that class of drift can't regress.
+
+// Mirror of the parser's S3 canonicalization for a raw `s3://…` URI.
+function canonicalS3Key(uri: string): string {
+	const rest = uri.replace(/^s3:\/\//, '')
+	return rest.replace(/^\//, '')
+}
+
+const S3_KINDS: PipelineOutputKind[] = ['s3_parquet', 's3_object']
+const LANGS: ScriptLang[] = ['bun', 'python3', 'duckdb']
+
+describe('pipelineTemplates S3 seed/body parity', () => {
+	for (const language of LANGS) {
+		for (const outputKind of S3_KINDS) {
+			it(`${language} ${outputKind}: seeded asset path matches the body's S3 write URI`, () => {
+				const output = autoOutputAsset(outputKind, 'demo', language)
+				expect(output).toBeDefined()
+				const asset = output!
+
+				// The seed must be a canonical slashless key (the invariant that
+				// broke when the parser started stripping the leading slash).
+				expect(asset.kind).toBe('s3object')
+				expect(asset.path.startsWith('/')).toBe(false)
+
+				const body = generatePipelineDraft({
+					language,
+					outputKind,
+					output: asset,
+					triggers: []
+				})
+
+				// Every S3 URI the generated body emits must canonicalize back to
+				// the seeded asset path — the write target especially.
+				const uris = body.match(/s3:\/\/[^'"`)\s]+/g) ?? []
+				expect(uris.length).toBeGreaterThan(0)
+				for (const uri of uris) {
+					// Runtime form must stay triple-slash (default storage); a bare
+					// `s3://key` would target a named storage `key` at run time.
+					expect(uri.startsWith('s3:///')).toBe(true)
+					expect(canonicalS3Key(uri)).toBe(asset.path)
+				}
+			})
+		}
+	}
+})

--- a/frontend/src/lib/components/assets/AssetGraph/pipelineTemplates.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/pipelineTemplates.ts
@@ -160,16 +160,16 @@ export function autoOutputAsset(
 		case 'ducklake':
 		case 'materialize':
 			return { kind: 'ducklake', path: `main/${adj}_${pick(TABLE_NOUNS)}_${slug}` }
-		// s3 paths carry the canonical leading slash of a default-storage
-		// object (`s3:///<key>` parses to path `/<key>`). The deploy-time
-		// parser stores writes in that form — a slashless seeded path would
-		// never match it, and the post-deploy drift check would report the
-		// output as lost (it isn't; the key differs by one '/'). Bodies that
-		// take a bare key (`{ s3: ... }`) strip the slash via `s3Key`.
+		// s3 outputs use the canonical slashless key. `parse_asset_syntax`
+		// normalizes `s3:///<key>` (default storage) and `s3://<key>` to the
+		// bare `<key>`, so the seeded draft asset must be slashless to match the
+		// deploy-time inferred identity — otherwise the post-deploy drift check
+		// would flag the output as a phantom `/`-prefixed node. The generated
+		// bodies still emit the `s3:///<key>` default-storage URI for runtime I/O.
 		case 's3_parquet':
 			return {
 				kind: 's3object',
-				path: `/pipelines/${folder}/${adj}_${pick(DATASET_NOUNS)}_${slug}.parquet`
+				path: `pipelines/${folder}/${adj}_${pick(DATASET_NOUNS)}_${slug}.parquet`
 			}
 		case 's3_object': {
 			// duckdb's natural output for a generic blob is CSV (one COPY TO
@@ -179,7 +179,7 @@ export function autoOutputAsset(
 			const ext = language === 'duckdb' ? 'csv' : 'json'
 			return {
 				kind: 's3object',
-				path: `/pipelines/${folder}/${adj}_${pick(FILE_NOUNS)}_${slug}.${ext}`
+				path: `pipelines/${folder}/${adj}_${pick(FILE_NOUNS)}_${slug}.${ext}`
 			}
 		}
 		// A macro library produces no asset — its "output" is the registry
@@ -205,8 +205,9 @@ export function assetUri(asset: { kind: AssetKind; path: string }): string {
 	return `${ASSET_URI_PREFIX[asset.kind]}${asset.path}`
 }
 
-// Bare object key for the SDK's `{ s3: <key> }` forms: the canonical asset
-// path of a default-storage object has a leading slash, the key must not.
+// Bare object key for the SDK's `{ s3: <key> }` / `s3:///<key>` forms. Asset
+// paths are already canonical slashless keys; strip a stray leading slash
+// defensively so the emitted key never starts with '/'.
 function s3Key(path: string): string {
 	return path.replace(/^\//, '')
 }
@@ -592,7 +593,7 @@ function bodyDuckdb(ctx: TemplateContext): string {
 		if (!input) return null
 		switch (input.kind) {
 			case 's3object':
-				return `read_parquet('s3://${input.path}')`
+				return `read_parquet('s3:///${input.path}')`
 			case 'datatable':
 				// `pg` is the attached Postgres catalog (see ATTACH above).
 				// Use a 2-part `pg.<table>` ref so the asset parser maps it
@@ -615,7 +616,7 @@ function bodyDuckdb(ctx: TemplateContext): string {
 					`COPY (`,
 					`  SELECT *`,
 					`  FROM ${fromExpr}`,
-					`) TO 's3://${output.path}' (FORMAT 'parquet');`
+					`) TO 's3:///${output.path}' (FORMAT 'parquet');`
 				)
 			}
 			break
@@ -626,7 +627,7 @@ function bodyDuckdb(ctx: TemplateContext): string {
 					`COPY (`,
 					`  SELECT *`,
 					`  FROM ${fromExpr}`,
-					`) TO 's3://${output.path}' (FORMAT 'csv', HEADER);`
+					`) TO 's3:///${output.path}' (FORMAT 'csv', HEADER);`
 				)
 			}
 			break

--- a/frontend/src/lib/components/assets/AssetGraph/pipelineTemplates.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/pipelineTemplates.ts
@@ -206,10 +206,10 @@ export function assetUri(asset: { kind: AssetKind; path: string }): string {
 }
 
 // Bare object key for the SDK's `{ s3: <key> }` / `s3:///<key>` forms. Asset
-// paths are already canonical slashless keys; strip a stray leading slash
+// paths are already canonical slashless keys; strip stray leading slashes
 // defensively so the emitted key never starts with '/'.
 function s3Key(path: string): string {
-	return path.replace(/^\//, '')
+	return path.replace(/^\/+/, '')
 }
 
 // Splits a datatable asset path (`<db>/<table>` or `<db>/<schema>.<table>`)


### PR DESCRIPTION
## Problem

A silent cross-language lineage break in data pipelines: the SDK object write forms

- TS `wmill.writeS3File({ s3: "exports/x" }, …)`
- Python `wmill.write_s3_file(S3Object(s3="exports/x"), …)`

resolve to the URI `s3:///exports/x` (empty default storage), whose parsed asset
path was `/exports/x` — **with a leading slash**. Meanwhile DuckDB
`read_csv('s3://exports/x')` / `COPY … TO 's3://exports/x'` and the
`// on s3://exports/x` trigger annotation yield the bare `exports/x` — **no slash**.

The same object therefore had two asset identities, so a DuckDB **consumer** never
connected to a TS/Python **producer** in the pipeline graph. This is open item #6
in `docs/pipeline-local-dev.md`.

## Fix

Choose one canonical normalization: **strip the leading slash**. `parse_asset_syntax`
in `windmill-parser` — the single shared function used by *both* the native backend
parsers (`windmill-parser-ts-asset` / `-sql-asset` / `-py-asset`) at deploy time *and*
the wasm parser that drives `frontend/src/lib/infer.ts` + the CLI `localGraph` at
editor/CLI time — now strips a single leading slash from S3 paths.

After the change, all four forms canonicalize to the same key `exports/x`:

| Form | Before | After |
|------|--------|-------|
| SDK `{s3:"exports/x"}` → `s3:///exports/x` | `/exports/x` | `exports/x` |
| `// on s3:///exports/x` | `/exports/x` | `exports/x` |
| DuckDB `s3://exports/x` | `exports/x` | `exports/x` |
| `// on s3://exports/x` | `exports/x` | `exports/x` |

So a producer's write edge and a consumer's read/trigger edge share one graph node,
and deploy-time inference agrees with editor/CLI inference.

### Preserved cases
- **`s3:///` triple-slash default storage** — collapses to the bare key (the whole point), still connects.
- **Hive-partition keys** (`s3://bucket/y=2024/f.parquet`) — only *one* leading slash is stripped; `=` segments untouched.
- **Explicit-storage** `s3://storage/key` — no leading slash, keeps `storage/key`. _Tradeoff:_ it now aliases the default-storage nested-key form `s3:///storage/key` (both → `storage/key`), which name different objects; this only collides when a storage config is named to match a default-storage prefix, and is inherent to a best-effort lineage graph that does not split the first segment as a storage name (pinned by `s3_explicit_storage_aliases_default_storage_nested_key`).
- **Non-S3 kinds** (`res://`, `ducklake://`, `datatable://`, `volume://`) — paths verbatim, normalization is gated on `AssetKind::S3Object`.

## Tests

- **`windmill-parser`** `s3_key_normalization_unifies_uri_forms`: proves all URI forms canonicalize to one key, and that Hive keys / explicit storage / non-S3 kinds are preserved.
- **`windmill-parser-sql-asset`** `test_duckdb_read_key_matches_sdk_write_key`: a DuckDB read of `s3://exports/x` and `s3:///exports/x` both resolve to `exports/x`.
- **`windmill-parser-ts-asset`** `test_ts_write_key_matches_duckdb_read_key` and **`-py-asset`** `test_py_write_key_matches_duckdb_read_key`: the SDK write records `exports/x` — the identical key the DuckDB read resolves to → **connected edge**.
- Updated the existing `s3:///…` test expectations (previously asserted `/key`) across the three asset crates.

## Validation

- ✅ All parser crate tests pass (`windmill-parser`, `-sql-asset`, `-ts-asset`, `-py-asset`).
- ✅ **wasm asset parser rebuilt** (`nu build.nu asset`) and exercised end-to-end through the compiled `node`-target wasm — `parse_assets_ts`/`_py`/`_sql` all emit path `exports/x` for the write and both DuckDB read forms:

  ```
  TS write   : [ 's3object:exports/x:w' ]
  PY write   : [ 's3object:exports/x:w' ]
  SQL read // : [ 's3object:exports/x:r' ]
  SQL read ///: [ 's3object:exports/x:r' ]
  ```
- ✅ Backend (running `cargo watch`) healthy; shared `windmill-parser` recompiles cleanly.

The wasm npm packages (`windmill-parser-wasm-asset`) are republished by release automation from this Rust source, matching how prior parser changes (e.g. #9912) shipped — no committed binaries or `package.json` version bump in this PR.

## Known limitation

Existing deployed pipelines that recorded `/key` paths need a **redeploy** to pick up the canonical `key`. The fix is forward-consistent for anything parsed after this change (the consumer trigger side is normalized at read time via `parse_asset_trigger_ref`, so a redeployed producer immediately reconnects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Canonicalize S3 asset keys by stripping all leading slashes so SDK writes, DuckDB reads, `// on` annotations, CLI cascade tokens, and preview resolve to one path; trigger refs now round‑trip across backend, CLI, and frontend.

- **Bug Fixes**
  - In `parse_asset_syntax`, strip all leading slashes from S3 paths; `s3:///x`, `s3:////x`, and `s3://x` → `x`. Preserves explicit storage (`s3://bucket/key`) and Hive partitions; non‑S3 unchanged. Note: `s3://storage/key` and `s3:///storage/key` alias to `storage/key`.
  - Mirror canonicalization in the live preview parser, CLI `localGraph` fallback `// on` scanner, both `boundedCascade` resolvers (frontend/CLI), and template `s3Key`; seed templates with slashless S3 keys and switch DuckDB template URIs to `s3:///<key>`.
  - Tests: cross‑language (TS/PY writes vs DuckDB reads), shared triple/quad‑slash fixtures, cascade/local‑graph cases, and a `windmill-common` ref round‑trip. Align the template parity helper to strip all leading slashes.

- **Migration**
  - Redeploy pipelines that recorded `/key` S3 paths to reconnect to the canonical `key`.

<sup>Written for commit e25f98c3409940d0f0004479b63bb955c9ad4546. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

