### PR TITLE
docs: how to run DuckLake data pipelines from source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Open-source platform for internal tools, workflows, API integrations, background
 
 - **Backend**: `cargo run` from `backend/` (API at http://localhost:8000)
 - **DuckDB local jobs**: before running DuckDB scripts locally, build the FFI shared library with `cd backend/windmill-duckdb-ffi-internal && ./build_dev.sh`. Re-run it after clean builds or when `backend/target/debug/libwindmill_duckdb_ffi_internal.*` is missing.
+- **Data pipelines (DuckLake) from source**: a plain `cargo run` (even `--features quickjs`) advertises a `duckdb` worker tag but **cannot** execute DuckDB scripts and has **no** working S3 proxy (DuckLake writes 404). Build CE DuckLake with `cargo run --features quickjs,duckdb,parquet,private` (add `,python` for Python scripts, `,enterprise,license` for EE) **and** build the FFI (bullet above). See `backend/CLAUDE.md` → "Running data pipelines (DuckLake) from source" for the exact feature sets and the two feature-gate gotchas.
 - **Frontend**: `REMOTE=http://localhost:8000 npm run dev` from `frontend/` (port 3000+)
 - **DB**: `psql postgres://postgres:changeme@localhost:5432/windmill`
 - **Login**: `admin@windmill.dev` / `changeme`

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -11,6 +11,41 @@
   cd backend/windmill-duckdb-ffi-internal && ./build_dev.sh
   ```
   Re-run after clean builds or when `target/debug/libwindmill_duckdb_ffi_internal.*` is missing.
+- **Running data pipelines (DuckLake) from source**: see the section below — a plain build
+  advertises the `duckdb` tag but cannot execute DuckDB scripts and has no working S3 proxy.
+
+## Running data pipelines (DuckLake) from source
+
+DuckLake pipelines need **both** the right cargo features **and** the prebuilt DuckDB FFI. A
+plain `cargo run` (or `cargo run --features quickjs`) does **not** suffice, and the failure modes
+are silent-ish, so agents lose time. Verify feature names against `backend/Cargo.toml` `[features]`.
+
+**Feature sets** (run from `backend/`):
+
+| Goal | Command |
+|---|---|
+| CE DuckLake (DuckDB scripts + S3 proxy) | `cargo run --features quickjs,duckdb,parquet,private` |
+| + Python scripts | add `,python` |
+| EE features (WAP, partitioning, forks, …) | add `,enterprise,license` |
+
+`enterprise` already pulls in `license`, but list both when you want the license-gated paths.
+`quickjs` is for JS eval, not DuckLake per se — keep it if your baseline build had it.
+
+**Before running any DuckDB script**, build the FFI (see the bullet above):
+`cd backend/windmill-duckdb-ffi-internal && ./build_dev.sh`.
+
+**Two gotchas that a wrong feature set produces:**
+
+1. **`duckdb` tag advertised, feature missing.** The `duckdb` worker tag is in the *unconditional*
+   default tag list (`windmill-common/src/worker.rs`, `DEFAULT_TAGS`), so a worker advertises it even
+   without the `duckdb` feature. Jobs then dispatch but fail at execution with
+   `"Duck DB requires the duckdb feature to be enabled"` (`windmill-worker/src/worker.rs`). Fix:
+   compile with `--features duckdb`.
+2. **DuckLake writes 404 (no S3 proxy).** The workspace S3 proxy (`/w/{ws}/s3_proxy/*`) that
+   DuckLake uses for reads/writes only mounts the real service under
+   `#[cfg(all(feature = "private", feature = "parquet"))]` (`windmill-api/src/s3_proxy_oss.rs`);
+   otherwise it's an empty router and every proxied request 404s. Fix: compile with **both**
+   `private` and `parquet`.
 
 ## Cloud vs self-hosted gating
 


### PR DESCRIPTION
## Summary

From-source developers repeatedly lose time trying to run DuckLake data pipelines because a plain `cargo run` (even `--features quickjs`) advertises a `duckdb` worker tag but cannot execute DuckDB scripts and has no working S3 proxy. This documents the exact feature sets (CE vs EE), the required DuckDB FFI build step, and the two feature-gate gotchas.

## Changes

- `backend/CLAUDE.md`: new "Running data pipelines (DuckLake) from source" section — feature-set table (CE DuckLake = `quickjs,duckdb,parquet,private`; `+python` for Python scripts; `+enterprise,license` for EE), the FFI build reminder, and two gotchas:
  1. `duckdb` tag is in the unconditional `DEFAULT_TAGS` (`windmill-common/src/worker.rs`), so jobs dispatch but fail at execution without `--features duckdb` (error `\"Duck DB requires the duckdb feature to be enabled\"`, `windmill-worker/src/worker.rs`).
  2. The workspace S3 proxy only mounts the real service under `#[cfg(all(feature = \"private\", feature = \"parquet\"))]` (`windmill-api/src/s3_proxy_oss.rs`); without both, it's an empty router and DuckLake reads/writes 404.
- `AGENTS.md`: Dev Environment bullet summarizing the same, pointing to the backend/CLAUDE.md section.

All feature names verified against `backend/Cargo.toml` `[features]`; all cfg gates and error strings verified against source.

## Test plan

- [ ] Docs-only change — no build/typecheck impact.
- [ ] Sanity: `cargo run --features quickjs,duckdb,parquet,private` + FFI build (`backend/windmill-duckdb-ffi-internal/build_dev.sh`) runs a DuckLake pipeline end-to-end (DuckDB script executes, S3 proxy writes succeed).
- [ ] Negative: omitting `duckdb` yields the feature error; omitting `private`/`parquet` yields 404 on DuckLake writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)