### PR TITLE
feat(pipelines): partition run-arg picker + first-run setup signpost

### DIFF
--- a/frontend/src/lib/components/assets/AssetGraph/PartitionArgControl.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PartitionArgControl.svelte
@@ -5,12 +5,14 @@
 	import { CalendarClock, CircleCheck, CircleDashed, TriangleAlert } from 'lucide-svelte'
 	import type { PartitionSpec } from './parsePipelineAnnotations'
 	import {
-		bucketFor,
 		bucketFromInputValue,
+		defaultBucket,
 		inputValueFromBucket,
+		isBeforeStart,
 		partitionInputType,
 		recentBuckets,
 		recentWindow,
+		startBucketOf,
 		usesCalendarPicker
 	} from './partitionBuckets'
 
@@ -43,13 +45,19 @@
 
 	// Seed the default bucket once: the backend resolves an absent `partition`
 	// arg to the current bucket, so seeding it makes the picker show that same
-	// value while keeping the run behaviour identical. Dynamic / custom-format
-	// specs stay empty (free text the user fills in).
+	// value while keeping the run behaviour identical. `defaultBucket` honours
+	// the `start=` anchor (never seeds a pre-start bucket the worker would take
+	// verbatim). Dynamic / custom-format specs stay empty (free text the user
+	// fills in).
 	$effect(() => {
 		if (calendarPicker && (value === undefined || value === '')) {
-			value = bucketFor(spec, new Date())
+			value = defaultBucket(spec, new Date())
 		}
 	})
+
+	// Whether the producer hasn't reached its `start=` anchor yet — explains why
+	// the default bucket is the start rather than today.
+	let beforeStart = $derived(calendarPicker && isBeforeStart(spec, new Date()))
 
 	// The native <input> string mirrors `value`; hourly carries an extra minute
 	// component that the canonical bucket drops.
@@ -86,41 +94,48 @@
 	let selectedMaterialized = $derived(!!value && materializedSet.has(value))
 
 	// Recently-missing buckets: the last N cadence buckets not yet materialized.
+	// Pre-`start=` buckets are dropped — they never materialize on their own, so
+	// offering them as run chips would let a click launch a pre-start partition.
 	let recentlyMissing = $derived.by(() => {
 		if (!materializeTarget || materializeTarget.kind !== 'ducklake' || !calendarPicker) return []
 		if (ownPartitions.loading) return []
+		const startBucket = startBucketOf(spec)
 		return recentBuckets(spec, new Date(), recentWindow(spec.kind)).filter(
-			(b) => !materializedSet.has(b)
+			(b) => !materializedSet.has(b) && (!startBucket || b >= startBucket)
 		)
 	})
 
-	// Upstream ducklake inputs — union of their materialized partitions, plus a
-	// flag for whether any upstream is actually partition-tracked (has a row
-	// with a non-empty partition). Without that flag a non-partitioned upstream
-	// (single whole-table row) would false-alarm as "no data for this bucket".
+	// Upstream ducklake inputs, one materialized-set PER input (not unioned).
+	// A per-input `tracked` flag (has ≥1 non-empty partition) distinguishes a
+	// partitioned input from a whole-table one, so a non-partitioned upstream
+	// (single whole-table row) never false-alarms as "no data for this bucket".
 	let ducklakeUpstreams = $derived(upstreamAssets.filter((a) => a.kind === 'ducklake'))
 	let upstream = resource(
 		[() => workspace, () => ducklakeUpstreams.map((a) => a.path).join('\n')],
 		async ([ws, joined]) => {
 			const paths = joined ? joined.split('\n') : []
-			if (!ws || paths.length === 0) return { tracked: false, materialized: new Set<string>() }
-			const rows = (await Promise.all(paths.map((p) => listPartitions('ducklake', p)))).flat()
-			return {
-				tracked: rows.some((r) => r.partition !== ''),
-				materialized: new Set(
-					rows.filter((r) => r.status === 'materialized').map((r) => r.partition)
-				)
-			}
+			if (!ws || paths.length === 0) return [] as { tracked: boolean; materialized: Set<string> }[]
+			return await Promise.all(
+				paths.map(async (p) => {
+					const rows = await listPartitions('ducklake', p)
+					return {
+						tracked: rows.some((r) => r.partition !== ''),
+						materialized: new Set(
+							rows.filter((r) => r.status === 'materialized').map((r) => r.partition)
+						)
+					}
+				})
+			)
 		}
 	)
-	// Warn only when we positively know the upstream is partition-tracked and is
-	// missing the selected bucket — never while loading or for untracked inputs.
+	// Warn when ANY partition-tracked upstream is missing the selected bucket —
+	// checked per-input so a fan-in where one input has the bucket doesn't mask
+	// another that lacks it. Never fires while loading or for untracked inputs.
 	let upstreamMissing = $derived(
 		!!value &&
 			calendarPicker &&
 			!upstream.loading &&
-			(upstream.current?.tracked ?? false) &&
-			!(upstream.current?.materialized.has(value) ?? false)
+			(upstream.current ?? []).some((u) => u.tracked && !u.materialized.has(value!))
 	)
 
 	const MAX_MISSING_CHIPS = 8
@@ -142,6 +157,11 @@
 			value={inputValue}
 			onchange={(e) => onNativeInput(e.currentTarget.value)}
 		/>
+		{#if beforeStart}
+			<span class="text-3xs text-tertiary">
+				Partitioning starts <span class="font-mono">{spec.start}</span> — defaulted to the first partition.
+			</span>
+		{/if}
 	{:else}
 		<TextInput
 			bind:value={() => value ?? '', (v) => (value = v)}

--- a/frontend/src/lib/components/assets/AssetGraph/PartitionArgControl.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PartitionArgControl.svelte
@@ -4,12 +4,14 @@
 	import TextInput from '$lib/components/text_input/TextInput.svelte'
 	import { CalendarClock, CircleCheck, CircleDashed, TriangleAlert } from 'lucide-svelte'
 	import type { PartitionSpec } from './parsePipelineAnnotations'
+	import { untrack } from 'svelte'
 	import {
 		bucketFromInputValue,
 		defaultBucket,
 		inputValueFromBucket,
 		isBeforeStart,
 		partitionInputType,
+		partitionMetadataError,
 		recentBuckets,
 		recentWindow,
 		startBucketOf,
@@ -42,22 +44,28 @@
 
 	const inputType = $derived(partitionInputType(spec))
 	const calendarPicker = $derived(usesCalendarPicker(spec))
+	// Non-undefined when the `// partitioned` metadata is unusable (bad tz/start).
+	const metadataError = $derived(partitionMetadataError(spec))
 
-	// Seed the default bucket once: the backend resolves an absent `partition`
-	// arg to the current bucket, so seeding it makes the picker show that same
-	// value while keeping the run behaviour identical. `defaultBucket` honours
-	// the `start=` anchor (never seeds a pre-start bucket the worker would take
-	// verbatim). Dynamic / custom-format specs stay empty (free text the user
-	// fills in).
+	// Seed the default bucket on (re)mount. The run form is keyed on the schema
+	// AND the partition spec (PipelineScriptView), so a real change to either
+	// remounts this and reseeds — an identical re-resolve keeps the user's
+	// in-progress pick. `defaultBucket` honours the `start=` anchor (never seeds
+	// a pre-start bucket the worker would take verbatim). We deliberately do NOT
+	// auto-seed when the metadata is invalid (bad tz/start): the worker takes an
+	// explicit `partition` arg verbatim, so seeding one would bypass the
+	// backend's own tz/start validation — leave it empty and let the backend
+	// surface the error. Dynamic / custom-format specs also stay empty (free
+	// text). `untrack` so this fires once per mount, not on every `value` edit.
 	$effect(() => {
-		if (calendarPicker && (value === undefined || value === '')) {
-			value = defaultBucket(spec, new Date())
-		}
+		untrack(() => {
+			value = calendarPicker && !metadataError ? defaultBucket(spec, new Date()) : undefined
+		})
 	})
 
 	// Whether the producer hasn't reached its `start=` anchor yet — explains why
 	// the default bucket is the start rather than today.
-	let beforeStart = $derived(calendarPicker && isBeforeStart(spec, new Date()))
+	let beforeStart = $derived(calendarPicker && !metadataError && isBeforeStart(spec, new Date()))
 
 	// The native <input> string mirrors `value`; hourly carries an extra minute
 	// component that the canonical bucket drops.
@@ -98,7 +106,7 @@
 	// offering them as run chips would let a click launch a pre-start partition.
 	let recentlyMissing = $derived.by(() => {
 		if (!materializeTarget || materializeTarget.kind !== 'ducklake' || !calendarPicker) return []
-		if (ownPartitions.loading) return []
+		if (metadataError || ownPartitions.loading) return []
 		const startBucket = startBucketOf(spec)
 		return recentBuckets(spec, new Date(), recentWindow(spec.kind)).filter(
 			(b) => !materializedSet.has(b) && (!startBucket || b >= startBucket)
@@ -157,7 +165,15 @@
 			value={inputValue}
 			onchange={(e) => onNativeInput(e.currentTarget.value)}
 		/>
-		{#if beforeStart}
+		{#if metadataError}
+			<span class="text-3xs inline-flex items-start gap-1 text-amber-700 dark:text-amber-400">
+				<TriangleAlert size={12} class="mt-0.5 shrink-0" />
+				<span>
+					The <span class="font-mono">// partitioned</span> header has {metadataError} — fix it in the
+					script; no default is filled in.
+				</span>
+			</span>
+		{:else if beforeStart}
 			<span class="text-3xs text-tertiary">
 				Partitioning starts <span class="font-mono">{spec.start}</span> — defaulted to the first partition.
 			</span>

--- a/frontend/src/lib/components/assets/AssetGraph/PartitionArgControl.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PartitionArgControl.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+	import { resource } from 'runed'
+	import { AssetService, type AssetKind, type MaterializedPartition } from '$lib/gen'
+	import TextInput from '$lib/components/text_input/TextInput.svelte'
+	import { CalendarClock, CircleCheck, CircleDashed, TriangleAlert } from 'lucide-svelte'
+	import type { PartitionSpec } from './parsePipelineAnnotations'
+	import {
+		bucketFor,
+		bucketFromInputValue,
+		inputValueFromBucket,
+		partitionInputType,
+		recentBuckets,
+		recentWindow,
+		usesCalendarPicker
+	} from './partitionBuckets'
+
+	interface Props {
+		// The partition cadence parsed from the script's `// partitioned` header.
+		spec: PartitionSpec
+		// Bound to `args.partition`. `$bindable()` without a default per the
+		// AGENTS.md ban on `$bindable(default)` for optional props.
+		value?: string | undefined
+		workspace: string
+		// The `// materialize` ducklake target, if any — enables the
+		// "already materialized / recently missing" hints against this
+		// producer's own output.
+		materializeTarget?: { kind: AssetKind; path: string }
+		// Partitioned ducklake inputs (`// on ducklake://…`) — enables the
+		// "no upstream data for this bucket yet" hint.
+		upstreamAssets?: { kind: AssetKind; path: string }[]
+	}
+
+	let {
+		value = $bindable(),
+		spec,
+		workspace,
+		materializeTarget,
+		upstreamAssets = []
+	}: Props = $props()
+
+	const inputType = $derived(partitionInputType(spec))
+	const calendarPicker = $derived(usesCalendarPicker(spec))
+
+	// Seed the default bucket once: the backend resolves an absent `partition`
+	// arg to the current bucket, so seeding it makes the picker show that same
+	// value while keeping the run behaviour identical. Dynamic / custom-format
+	// specs stay empty (free text the user fills in).
+	$effect(() => {
+		if (calendarPicker && (value === undefined || value === '')) {
+			value = bucketFor(spec, new Date())
+		}
+	})
+
+	// The native <input> string mirrors `value`; hourly carries an extra minute
+	// component that the canonical bucket drops.
+	let inputValue = $derived(value ? inputValueFromBucket(spec, value) : '')
+	function onNativeInput(raw: string) {
+		value = raw ? bucketFromInputValue(spec, raw) : ''
+	}
+
+	function listPartitions(kind: AssetKind, path: string) {
+		// Only ducklake assets carry materialized-partition rows.
+		if (kind !== 'ducklake' || !path) return Promise.resolve([] as MaterializedPartition[])
+		return AssetService.listAssetPartitions({ workspace, path }).catch(
+			() => [] as MaterializedPartition[]
+		)
+	}
+
+	// This producer's own materialized partitions — powers the selected-bucket
+	// status and the recently-missing list.
+	let ownPartitions = resource(
+		[() => workspace, () => materializeTarget?.kind, () => materializeTarget?.path],
+		async ([ws, kind, path]) => {
+			if (!ws || !kind || !path) return [] as MaterializedPartition[]
+			return listPartitions(kind, path)
+		}
+	)
+	let materializedSet = $derived(
+		new Set(
+			(ownPartitions.current ?? [])
+				.filter((p) => p.status === 'materialized')
+				.map((p) => p.partition)
+		)
+	)
+
+	let selectedMaterialized = $derived(!!value && materializedSet.has(value))
+
+	// Recently-missing buckets: the last N cadence buckets not yet materialized.
+	let recentlyMissing = $derived.by(() => {
+		if (!materializeTarget || materializeTarget.kind !== 'ducklake' || !calendarPicker) return []
+		if (ownPartitions.loading) return []
+		return recentBuckets(spec, new Date(), recentWindow(spec.kind)).filter(
+			(b) => !materializedSet.has(b)
+		)
+	})
+
+	// Upstream ducklake inputs — union of their materialized partitions, plus a
+	// flag for whether any upstream is actually partition-tracked (has a row
+	// with a non-empty partition). Without that flag a non-partitioned upstream
+	// (single whole-table row) would false-alarm as "no data for this bucket".
+	let ducklakeUpstreams = $derived(upstreamAssets.filter((a) => a.kind === 'ducklake'))
+	let upstream = resource(
+		[() => workspace, () => ducklakeUpstreams.map((a) => a.path).join('\n')],
+		async ([ws, joined]) => {
+			const paths = joined ? joined.split('\n') : []
+			if (!ws || paths.length === 0) return { tracked: false, materialized: new Set<string>() }
+			const rows = (await Promise.all(paths.map((p) => listPartitions('ducklake', p)))).flat()
+			return {
+				tracked: rows.some((r) => r.partition !== ''),
+				materialized: new Set(
+					rows.filter((r) => r.status === 'materialized').map((r) => r.partition)
+				)
+			}
+		}
+	)
+	// Warn only when we positively know the upstream is partition-tracked and is
+	// missing the selected bucket — never while loading or for untracked inputs.
+	let upstreamMissing = $derived(
+		!!value &&
+			calendarPicker &&
+			!upstream.loading &&
+			(upstream.current?.tracked ?? false) &&
+			!(upstream.current?.materialized.has(value) ?? false)
+	)
+
+	const MAX_MISSING_CHIPS = 8
+</script>
+
+<div class="flex flex-col gap-1.5">
+	<span class="text-xs font-semibold text-emphasis inline-flex items-center gap-1.5">
+		<CalendarClock size={13} class="text-fuchsia-600 dark:text-fuchsia-400" />
+		Partition
+		<span class="text-3xs font-medium text-tertiary px-1 py-0.5 rounded bg-surface-secondary">
+			{spec.kind}
+		</span>
+	</span>
+
+	{#if calendarPicker}
+		<input
+			type={inputType}
+			class="app-editor-input !w-full text-xs"
+			value={inputValue}
+			onchange={(e) => onNativeInput(e.currentTarget.value)}
+		/>
+	{:else}
+		<TextInput
+			bind:value={() => value ?? '', (v) => (value = v)}
+			size="sm"
+			inputProps={{
+				placeholder: spec.kind === 'dynamic' ? 'Partition key value' : 'Partition bucket'
+			}}
+		/>
+		<span class="text-3xs text-tertiary">
+			{#if spec.kind === 'dynamic'}
+				Dynamic partition — leave blank to let the run resolve it from the payload.
+			{:else}
+				Custom partition format — enter the bucket exactly as the producer renders it.
+			{/if}
+		</span>
+	{/if}
+
+	<!-- Selected-bucket status against this producer's own materialized set. -->
+	{#if calendarPicker && materializeTarget?.kind === 'ducklake' && value}
+		{#if selectedMaterialized}
+			<span class="text-3xs inline-flex items-center gap-1 text-green-700 dark:text-green-400">
+				<CircleCheck size={12} />
+				<span class="font-mono">{value}</span> is already materialized — running replaces it.
+			</span>
+		{:else}
+			<span class="text-3xs inline-flex items-center gap-1 text-tertiary">
+				<CircleDashed size={12} />
+				<span class="font-mono">{value}</span> not materialized yet — running creates it.
+			</span>
+		{/if}
+	{/if}
+
+	<!-- No upstream data for the selected bucket. -->
+	{#if upstreamMissing}
+		<span class="text-3xs inline-flex items-start gap-1 text-amber-700 dark:text-amber-400">
+			<TriangleAlert size={12} class="mt-0.5 shrink-0" />
+			<span>
+				No upstream data for <span class="font-mono">{value}</span> yet — this run may materialize an
+				empty partition.
+			</span>
+		</span>
+	{/if}
+
+	<!-- Recently-missing buckets, a compact "what's not filled in" hint. -->
+	{#if recentlyMissing.length > 0}
+		<div class="flex flex-col gap-1">
+			<span class="text-3xs text-tertiary">
+				{recentlyMissing.length} of the last {recentWindow(spec.kind)}
+				{spec.kind} partitions are not materialized:
+			</span>
+			<div class="flex flex-wrap gap-1">
+				{#each recentlyMissing.slice(0, MAX_MISSING_CHIPS) as b (b)}
+					<button
+						type="button"
+						class="px-1.5 py-0.5 rounded text-3xs font-mono bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300 hover:ring-1 hover:ring-amber-400"
+						title="Set the partition to {b}"
+						onclick={() => (value = b)}
+					>
+						{b}
+					</button>
+				{/each}
+				{#if recentlyMissing.length > MAX_MISSING_CHIPS}
+					<span class="text-3xs text-tertiary self-center">
+						+{recentlyMissing.length - MAX_MISSING_CHIPS} more
+					</span>
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineRunForm.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineRunForm.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import SchemaForm from '$lib/components/SchemaForm.svelte'
 	import { emptySchema } from '$lib/utils'
+	import type { AssetKind } from '$lib/gen'
+	import type { PartitionSpec } from './parsePipelineAnnotations'
+	import PartitionArgControl from './PartitionArgControl.svelte'
 
 	interface Props {
 		// The script's schema to render inputs for. SchemaForm normalizes/mutates
@@ -8,9 +11,40 @@
 		schema: any
 		args: Record<string, any>
 		isValid: boolean
+		// When the script is `// partitioned`, the bare `partition` string arg is
+		// pulled out of the SchemaForm and rendered by PartitionArgControl (a
+		// cadence-appropriate date picker + missing/upstream hints) instead.
+		partitionSpec?: PartitionSpec
+		workspace?: string
+		materializeTarget?: { kind: AssetKind; path: string }
+		upstreamAssets?: { kind: AssetKind; path: string }[]
 	}
 
-	let { schema, args = $bindable(), isValid = $bindable() }: Props = $props()
+	let {
+		schema,
+		args = $bindable(),
+		isValid = $bindable(),
+		partitionSpec,
+		workspace = '',
+		materializeTarget,
+		upstreamAssets = []
+	}: Props = $props()
+
+	// Drop the `partition` property from the schema clone so SchemaForm doesn't
+	// also render it as a bare string — PartitionArgControl owns `args.partition`.
+	function stripPartition(s: any): any {
+		if (!s || typeof s !== 'object') return s
+		if (s.properties && 'partition' in s.properties) {
+			delete s.properties.partition
+		}
+		if (Array.isArray(s.order)) {
+			s.order = s.order.filter((k: string) => k !== 'partition')
+		}
+		if (Array.isArray(s.required)) {
+			s.required = s.required.filter((k: string) => k !== 'partition')
+		}
+		return s
+	}
 
 	// Mutable clone SchemaForm can normalize without touching the parent's script.
 	// Seeded ONCE per mount — the parent remounts this via `{#key <schema content>}`
@@ -18,7 +52,22 @@
 	// $effect, and an unchanged re-resolve (a WS bundle with the same schema) keeps
 	// in-progress input.
 	// svelte-ignore state_referenced_locally
-	let formSchema = $state<any>(structuredClone($state.snapshot(schema) ?? emptySchema()))
+	let formSchema = $state<any>(
+		partitionSpec
+			? stripPartition(structuredClone($state.snapshot(schema) ?? emptySchema()))
+			: structuredClone($state.snapshot(schema) ?? emptySchema())
+	)
 </script>
 
-<SchemaForm bind:schema={formSchema} bind:args bind:isValid compact />
+<div class="flex flex-col gap-2">
+	{#if partitionSpec}
+		<PartitionArgControl
+			spec={partitionSpec}
+			bind:value={() => args.partition, (v) => (args.partition = v)}
+			{workspace}
+			{materializeTarget}
+			{upstreamAssets}
+		/>
+	{/if}
+	<SchemaForm bind:schema={formSchema} bind:args bind:isValid compact />
+</div>

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineScriptView.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineScriptView.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
-	import type { Script } from '$lib/gen'
-	import { Loader2, Play, Upload, Zap } from 'lucide-svelte'
+	import type { AssetKind, Script } from '$lib/gen'
+	import { CalendarClock, Loader2, Play, Upload, Zap } from 'lucide-svelte'
 	import Button from '$lib/components/common/button/Button.svelte'
 	import HighlightCode from '$lib/components/HighlightCode.svelte'
 	import PipelineRunForm from './PipelineRunForm.svelte'
 	import AssetRunsPanel from './AssetRunsPanel.svelte'
 	import { Pane, Splitpanes } from 'svelte-splitpanes'
+	import { workspaceStore } from '$lib/stores'
+	import { parsePipelineAnnotations } from './parsePipelineAnnotations'
 
 	interface Props {
 		script: Script
@@ -52,6 +54,29 @@
 	// and the script actually has subscribers to fan out to.
 	let hasCascade = $derived(!!onRunCascade && downstreamCount > 0)
 
+	// Parse the pipeline header for the partition cadence + materialize target +
+	// ducklake inputs, so a partitioned producer's run form swaps the bare
+	// `partition` string for a cadence-aware date picker with missing/upstream
+	// hints (see PartitionArgControl).
+	let annotations = $derived(parsePipelineAnnotations(script.content ?? ''))
+	let partitionSpec = $derived(annotations.partition)
+	let materializeTarget = $derived<{ kind: AssetKind; path: string } | undefined>(
+		annotations.materialize
+			? { kind: annotations.materialize.targetKind, path: annotations.materialize.targetPath }
+			: undefined
+	)
+	let upstreamAssets = $derived(
+		annotations.triggerAssets.map((a) => ({ kind: a.kind, path: a.path }))
+	)
+
+	// The run form appears for data-upload entry points (S3 picker) and for any
+	// partitioned producer — materializing a single partition is available in
+	// OSS, and the picker is where the user chooses which one.
+	let showRunForm = $derived(canRun || !!partitionSpec)
+	// A partitioned producer that isn't a data-upload entry is materializing a
+	// partition rather than uploading data — reflect that in the header.
+	let partitionOnly = $derived(!canRun && !!partitionSpec)
+
 	// The details pane keys this component on script.path only, so a same-path
 	// re-resolve (in /pipeline_dev the selected node re-resolves on every WS
 	// bundle) does NOT remount us. `PipelineRunForm` owns the SchemaForm clone and
@@ -83,12 +108,17 @@
 	<Splitpanes horizontal class="!h-full">
 		<Pane size={55} minSize={20}>
 			<div class="flex flex-col h-full overflow-auto">
-				{#if canRun}
+				{#if showRunForm}
 					<div class="shrink-0 flex flex-col gap-2 p-3 border-b" data-run-form>
 						<div class="flex items-center justify-between gap-2">
 							<span class="text-xs font-semibold text-emphasis inline-flex items-center gap-1.5">
-								<Upload size={13} class="text-fuchsia-600 dark:text-fuchsia-400" />
-								Run pipeline
+								{#if partitionOnly}
+									<CalendarClock size={13} class="text-fuchsia-600 dark:text-fuchsia-400" />
+									Materialize a partition
+								{:else}
+									<Upload size={13} class="text-fuchsia-600 dark:text-fuchsia-400" />
+									Run pipeline
+								{/if}
 							</span>
 							<div class="flex items-center gap-1.5">
 								{#if hasCascade}
@@ -120,7 +150,15 @@
 							</div>
 						</div>
 						{#key schemaKey}
-							<PipelineRunForm schema={script.schema} bind:args bind:isValid />
+							<PipelineRunForm
+								schema={script.schema}
+								bind:args
+								bind:isValid
+								{partitionSpec}
+								workspace={$workspaceStore ?? ''}
+								{materializeTarget}
+								{upstreamAssets}
+							/>
 						{/key}
 					</div>
 				{/if}

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineScriptView.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineScriptView.svelte
@@ -80,10 +80,14 @@
 	// The details pane keys this component on script.path only, so a same-path
 	// re-resolve (in /pipeline_dev the selected node re-resolves on every WS
 	// bundle) does NOT remount us. `PipelineRunForm` owns the SchemaForm clone and
-	// is keyed on the serialized schema below, so a local edit that adds/removes
-	// args reseeds the run form while an unchanged re-resolve keeps in-progress
-	// input (else the form could run against a stale schema with missing inputs).
-	let schemaKey = $derived(JSON.stringify(script.schema ?? null))
+	// is keyed on the serialized schema + partition spec below: a local edit that
+	// adds/removes args OR changes the `// partitioned` header (which the schema
+	// alone wouldn't capture) reseeds the run form and re-strips the `partition`
+	// field, while an unchanged re-resolve keeps in-progress input (else the form
+	// could run against a stale schema/spec — e.g. keep a pre-`start=` bucket).
+	let schemaKey = $derived(
+		JSON.stringify(script.schema ?? null) + '|' + JSON.stringify(partitionSpec ?? null)
+	)
 
 	async function run(cascade = false) {
 		const dispatch = cascade ? onRunCascade : onRun

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineSetupSignpost.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineSetupSignpost.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	import { resource } from 'runed'
+	import { WorkspaceService } from '$lib/gen'
+	import { base } from '$lib/base'
+	import { CircleCheck, CircleAlert, Database, HardDrive, ArrowRight } from 'lucide-svelte'
+
+	interface Props {
+		workspace: string
+	}
+	let { workspace }: Props = $props()
+
+	// A pipeline can't materialize anything until the workspace has (a) object
+	// storage for the parquet files and (b) at least one DuckLake catalog. A
+	// brand-new user has no signal these are prerequisites — this first-run
+	// checklist surfaces them and links straight to the settings that fix them.
+	//
+	// Both probes fail SAFE: an errored settings read (e.g. non-admin) resolves
+	// to `undefined`, and an undefined state never renders a red "missing" —
+	// the signpost only asserts "not configured" when it positively knows so.
+	let storage = resource([() => workspace], async ([ws]) => {
+		if (!ws) return undefined
+		try {
+			const s = await WorkspaceService.getSettings({ workspace: ws })
+			return !!s.large_file_storage
+		} catch {
+			return undefined
+		}
+	})
+	let ducklakes = resource([() => workspace], async ([ws]) => {
+		if (!ws) return undefined
+		try {
+			return (await WorkspaceService.listDucklakes({ workspace: ws })).length > 0
+		} catch {
+			return undefined
+		}
+	})
+
+	// Only surface the signpost once we have a definite "not configured" for at
+	// least one prerequisite — never while loading, and never on an errored
+	// probe (which would nag a user who can't act on it anyway).
+	let storageMissing = $derived(storage.current === false)
+	let ducklakeMissing = $derived(ducklakes.current === false)
+	let show = $derived(storageMissing || ducklakeMissing)
+
+	type Step = {
+		done: boolean | undefined
+		icon: typeof Database
+		title: string
+		description: string
+		href: string
+		cta: string
+	}
+	let steps = $derived<Step[]>([
+		{
+			done: storage.current,
+			icon: HardDrive,
+			title: 'Workspace object storage',
+			description:
+				'Materialized partitions and DuckLake data files are written to S3 / object storage.',
+			href: `${base}/workspace_settings?tab=windmill_lfs`,
+			cta: 'Configure object storage'
+		},
+		{
+			done: ducklakes.current,
+			icon: Database,
+			title: 'A DuckLake catalog',
+			description:
+				'DuckLake is the table format pipelines materialize into — add at least one catalog.',
+			href: `${base}/workspace_settings?tab=ducklake`,
+			cta: 'Configure DuckLake'
+		}
+	])
+</script>
+
+{#if show}
+	<div
+		class="flex flex-col gap-3 rounded-lg border border-amber-300 dark:border-amber-900/60 bg-amber-50 dark:bg-amber-950/30 p-4"
+	>
+		<div class="flex items-start gap-2">
+			<CircleAlert size={18} class="text-amber-600 dark:text-amber-400 mt-0.5 shrink-0" />
+			<div class="flex flex-col gap-0.5">
+				<h3 class="text-sm font-semibold text-emphasis">Finish setting up pipelines</h3>
+				<p class="text-xs text-tertiary">
+					Pipelines materialize data into DuckLake tables backed by object storage. Configure the
+					following before your first pipeline can run.
+				</p>
+			</div>
+		</div>
+
+		<ul class="flex flex-col gap-2">
+			{#each steps as step (step.title)}
+				{@const Icon = step.icon}
+				<li class="flex items-center gap-3 rounded-md border bg-surface px-3 py-2">
+					{#if step.done === true}
+						<CircleCheck size={16} class="text-green-600 dark:text-green-400 shrink-0" />
+					{:else if step.done === false}
+						<CircleAlert size={16} class="text-amber-600 dark:text-amber-400 shrink-0" />
+					{:else}
+						<Icon size={16} class="text-tertiary shrink-0" />
+					{/if}
+					<div class="flex flex-col min-w-0 flex-1">
+						<span class="text-xs font-semibold text-primary">{step.title}</span>
+						<span class="text-2xs text-tertiary">{step.description}</span>
+					</div>
+					{#if step.done !== true}
+						<a
+							href={step.href}
+							class="shrink-0 inline-flex items-center gap-1 text-xs text-blue-500 hover:underline whitespace-nowrap"
+						>
+							{step.cta}
+							<ArrowRight size={12} />
+						</a>
+					{:else}
+						<span class="shrink-0 text-2xs text-green-700 dark:text-green-400">Configured</span>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	</div>
+{/if}

--- a/frontend/src/lib/components/assets/AssetGraph/partitionBuckets.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/partitionBuckets.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from 'vitest'
 import {
 	bucketFor,
 	bucketFromInputValue,
+	defaultBucket,
 	inputValueFromBucket,
+	isBeforeStart,
 	partitionInputType,
 	recentBuckets,
+	startBucketOf,
 	usesCalendarPicker
 } from './partitionBuckets'
 import type { PartitionSpec } from './parsePipelineAnnotations'
@@ -44,6 +47,31 @@ describe('bucketFor honours spec.tz', () => {
 		expect(bucketFor(spec('hourly', { tz: 'America/New_York' }), nearMidnight)).toBe(
 			'2026-07-04T22'
 		)
+	})
+})
+
+describe('defaultBucket honours the start= anchor', () => {
+	// `at` is 2026-07-05.
+	it('seeds the current bucket when at or after start', () => {
+		expect(defaultBucket(spec('daily'), at)).toBe('2026-07-05')
+		expect(defaultBucket(spec('daily', { start: '2026-01-01' }), at)).toBe('2026-07-05')
+		expect(defaultBucket(spec('daily', { start: '2026-07-05' }), at)).toBe('2026-07-05') // == start, not before
+	})
+	it('seeds the start bucket (never a pre-start one) when before start', () => {
+		expect(defaultBucket(spec('daily', { start: '2026-08-01' }), at)).toBe('2026-08-01')
+		expect(defaultBucket(spec('monthly', { start: '2026-08-01' }), at)).toBe('2026-08')
+		expect(defaultBucket(spec('hourly', { start: '2026-08-01' }), at)).toBe('2026-08-01T00')
+	})
+	it('isBeforeStart mirrors the backend date comparison', () => {
+		expect(isBeforeStart(spec('daily', { start: '2026-08-01' }), at)).toBe(true)
+		expect(isBeforeStart(spec('daily', { start: '2026-07-05' }), at)).toBe(false)
+		expect(isBeforeStart(spec('daily'), at)).toBe(false)
+	})
+	it('startBucketOf renders the anchor in the cadence, undefined when unset', () => {
+		expect(startBucketOf(spec('daily', { start: '2026-08-01' }))).toBe('2026-08-01')
+		expect(startBucketOf(spec('monthly', { start: '2026-08-15' }))).toBe('2026-08')
+		expect(startBucketOf(spec('hourly', { start: '2026-08-01' }))).toBe('2026-08-01T00')
+		expect(startBucketOf(spec('daily'))).toBeUndefined()
 	})
 })
 

--- a/frontend/src/lib/components/assets/AssetGraph/partitionBuckets.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/partitionBuckets.test.ts
@@ -5,7 +5,10 @@ import {
 	defaultBucket,
 	inputValueFromBucket,
 	isBeforeStart,
+	isValidStart,
+	isValidTimeZone,
 	partitionInputType,
+	partitionMetadataError,
 	recentBuckets,
 	startBucketOf,
 	usesCalendarPicker
@@ -72,6 +75,38 @@ describe('defaultBucket honours the start= anchor', () => {
 		expect(startBucketOf(spec('monthly', { start: '2026-08-15' }))).toBe('2026-08')
 		expect(startBucketOf(spec('hourly', { start: '2026-08-01' }))).toBe('2026-08-01T00')
 		expect(startBucketOf(spec('daily'))).toBeUndefined()
+	})
+})
+
+describe('malformed metadata fails safe (parity with backend validation)', () => {
+	it('isValidTimeZone rejects garbage, accepts real zones and absence', () => {
+		expect(isValidTimeZone(undefined)).toBe(true)
+		expect(isValidTimeZone('UTC')).toBe(true)
+		expect(isValidTimeZone('America/New_York')).toBe(true)
+		expect(isValidTimeZone('Not/AZone')).toBe(false)
+		expect(isValidTimeZone('garbage')).toBe(false)
+	})
+	it('isValidStart rejects malformed and JS-normalized dates', () => {
+		expect(isValidStart(undefined)).toBe(true)
+		expect(isValidStart('2026-08-01')).toBe(true)
+		expect(isValidStart('2026-02-31')).toBe(false) // JS would roll to Mar 3
+		expect(isValidStart('2026-13-01')).toBe(false)
+		expect(isValidStart('08/01/2026')).toBe(false)
+	})
+	it('partitionMetadataError reports the first problem, else undefined', () => {
+		expect(partitionMetadataError(spec('daily'))).toBeUndefined()
+		expect(
+			partitionMetadataError(spec('daily', { tz: 'America/New_York', start: '2026-08-01' }))
+		).toBeUndefined()
+		expect(partitionMetadataError(spec('daily', { tz: 'Not/AZone' }))).toContain('timezone')
+		expect(partitionMetadataError(spec('daily', { start: '2026-02-31' }))).toContain('start date')
+	})
+	it('bucketFor never throws on an invalid tz (falls back to UTC)', () => {
+		expect(bucketFor(spec('daily', { tz: 'Not/AZone' }), at)).toBe('2026-07-05')
+	})
+	it('an invalid start is treated as no anchor (isBeforeStart/startBucketOf)', () => {
+		expect(isBeforeStart(spec('daily', { start: '2026-02-31' }), at)).toBe(false)
+		expect(startBucketOf(spec('daily', { start: '2026-02-31' }))).toBeUndefined()
 	})
 })
 

--- a/frontend/src/lib/components/assets/AssetGraph/partitionBuckets.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/partitionBuckets.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import {
+	bucketFor,
+	bucketFromInputValue,
+	inputValueFromBucket,
+	partitionInputType,
+	recentBuckets,
+	usesCalendarPicker
+} from './partitionBuckets'
+import type { PartitionSpec } from './parsePipelineAnnotations'
+
+const spec = (kind: PartitionSpec['kind'], extra: Partial<PartitionSpec> = {}): PartitionSpec =>
+	({ kind, ...extra }) as PartitionSpec
+
+// A fixed UTC instant: 2026-07-05 14:37Z (a Sunday — ISO week 27 of 2026).
+// Explicit UTC so the assertions are independent of the test runner's TZ, and
+// they exercise the same UTC default the backend uses when `spec.tz` is absent.
+const at = new Date(Date.UTC(2026, 6, 5, 14, 37, 0))
+
+describe('bucketFor mirrors backend default_format (UTC)', () => {
+	it('daily -> %Y-%m-%d', () => {
+		expect(bucketFor(spec('daily'), at)).toBe('2026-07-05')
+	})
+	it('hourly -> %Y-%m-%dT%H', () => {
+		expect(bucketFor(spec('hourly'), at)).toBe('2026-07-05T14')
+	})
+	it('monthly -> %Y-%m', () => {
+		expect(bucketFor(spec('monthly'), at)).toBe('2026-07')
+	})
+	it('weekly -> ISO %G-W%V', () => {
+		expect(bucketFor(spec('weekly'), at)).toBe('2026-W27')
+	})
+})
+
+describe('bucketFor honours spec.tz', () => {
+	// 2026-07-05 02:30Z is still 2026-07-04 in America/New_York (UTC-4 in July).
+	const nearMidnight = new Date(Date.UTC(2026, 6, 5, 2, 30, 0))
+	it('shifts the day boundary by the producer tz', () => {
+		expect(bucketFor(spec('daily'), nearMidnight)).toBe('2026-07-05') // UTC default
+		expect(bucketFor(spec('daily', { tz: 'America/New_York' }), nearMidnight)).toBe('2026-07-04')
+	})
+	it('shifts the hour bucket by the producer tz', () => {
+		// 02:30Z -> 22 (previous day) in New York.
+		expect(bucketFor(spec('hourly', { tz: 'America/New_York' }), nearMidnight)).toBe(
+			'2026-07-04T22'
+		)
+	})
+})
+
+describe('partitionInputType', () => {
+	it('maps each calendar kind to its native input', () => {
+		expect(partitionInputType(spec('daily'))).toBe('date')
+		expect(partitionInputType(spec('hourly'))).toBe('datetime-local')
+		expect(partitionInputType(spec('weekly'))).toBe('week')
+		expect(partitionInputType(spec('monthly'))).toBe('month')
+	})
+	it('falls back to text for dynamic and custom-format specs', () => {
+		expect(partitionInputType(spec('dynamic', { key: '$.tenant' }))).toBe('text')
+		expect(partitionInputType(spec('daily', { format: '%Y/%m/%d' }))).toBe('text')
+		expect(usesCalendarPicker(spec('dynamic', { key: '$.tenant' }))).toBe(false)
+		expect(usesCalendarPicker(spec('daily', { format: '%Y/%m/%d' }))).toBe(false)
+	})
+})
+
+describe('native input <-> bucket round-trip', () => {
+	it('hourly truncates the datetime-local minutes and restores :00', () => {
+		expect(bucketFromInputValue(spec('hourly'), '2026-07-05T14:37')).toBe('2026-07-05T14')
+		expect(inputValueFromBucket(spec('hourly'), '2026-07-05T14')).toBe('2026-07-05T14:00')
+	})
+	it('non-hourly kinds pass through unchanged', () => {
+		expect(bucketFromInputValue(spec('daily'), '2026-07-05')).toBe('2026-07-05')
+		expect(inputValueFromBucket(spec('weekly'), '2026-W27')).toBe('2026-W27')
+	})
+	it('empty stays empty', () => {
+		expect(bucketFromInputValue(spec('hourly'), '')).toBe('')
+		expect(inputValueFromBucket(spec('daily'), '')).toBe('')
+	})
+})
+
+describe('recentBuckets (UTC)', () => {
+	it('walks back day by day, most recent first', () => {
+		expect(recentBuckets(spec('daily'), at, 3)).toEqual(['2026-07-05', '2026-07-04', '2026-07-03'])
+	})
+	it('walks back hour by hour', () => {
+		expect(recentBuckets(spec('hourly'), at, 3)).toEqual([
+			'2026-07-05T14',
+			'2026-07-05T13',
+			'2026-07-05T12'
+		])
+	})
+	it('walks back month by month across a year boundary without day roll-over', () => {
+		const jan31 = new Date(Date.UTC(2026, 0, 31, 0, 0, 0))
+		expect(recentBuckets(spec('monthly'), jan31, 3)).toEqual(['2026-01', '2025-12', '2025-11'])
+	})
+	it('walks back week by week', () => {
+		expect(recentBuckets(spec('weekly'), at, 3)).toEqual(['2026-W27', '2026-W26', '2026-W25'])
+	})
+})

--- a/frontend/src/lib/components/assets/AssetGraph/partitionBuckets.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/partitionBuckets.ts
@@ -43,24 +43,73 @@ function pad(n: number): string {
 	return String(n).padStart(2, '0')
 }
 
+const ZONED_PARTS_OPTS: Intl.DateTimeFormatOptions = {
+	year: 'numeric',
+	month: '2-digit',
+	day: '2-digit',
+	hour: '2-digit',
+	minute: '2-digit',
+	second: '2-digit',
+	hourCycle: 'h23'
+}
+
 // Re-express `at` as a Date whose UTC fields equal the wall-clock in `tz`, so
 // all downstream field reads / calendar arithmetic can use the UTC getters and
-// stay in the producer's zone. `hourCycle: 'h23'` keeps hours 00–23.
+// stay in the producer's zone. `hourCycle: 'h23'` keeps hours 00–23. A
+// malformed `tz` (rejected by `Intl`) falls back to UTC rather than throwing —
+// the backend validates `tz=` and is the source of truth for the error; the
+// picker must never crash the graph view (`partitionMetadataError` gates
+// auto-seeding so a bogus bucket isn't silently sent).
 function zonedAsUtc(at: Date, tz: string): Date {
-	const parts = new Intl.DateTimeFormat('en-US', {
-		timeZone: tz,
-		year: 'numeric',
-		month: '2-digit',
-		day: '2-digit',
-		hour: '2-digit',
-		minute: '2-digit',
-		second: '2-digit',
-		hourCycle: 'h23'
-	}).formatToParts(at)
+	let parts: Intl.DateTimeFormatPart[]
+	try {
+		parts = new Intl.DateTimeFormat('en-US', { ...ZONED_PARTS_OPTS, timeZone: tz }).formatToParts(
+			at
+		)
+	} catch {
+		parts = new Intl.DateTimeFormat('en-US', {
+			...ZONED_PARTS_OPTS,
+			timeZone: 'UTC'
+		}).formatToParts(at)
+	}
 	const g = (t: string) => Number(parts.find((p) => p.type === t)?.value)
 	return new Date(
 		Date.UTC(g('year'), g('month') - 1, g('day'), g('hour'), g('minute'), g('second'))
 	)
+}
+
+// `tz=` is valid iff `Intl` accepts it (absent === UTC === valid).
+export function isValidTimeZone(tz?: string): boolean {
+	if (!tz) return true
+	try {
+		new Intl.DateTimeFormat('en-US', { timeZone: tz })
+		return true
+	} catch {
+		return false
+	}
+}
+
+// `start=` is valid iff it's a real `YYYY-MM-DD` calendar date. The round-trip
+// check rejects dates JS would silently normalize (e.g. `2026-02-31` → Mar 3),
+// which the backend's `NaiveDate::parse_from_str` also rejects.
+export function isValidStart(start?: string): boolean {
+	if (!start) return true
+	const m = start.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+	if (!m) return false
+	const y = Number(m[1])
+	const mo = Number(m[2])
+	const d = Number(m[3])
+	const dt = new Date(Date.UTC(y, mo - 1, d))
+	return dt.getUTCFullYear() === y && dt.getUTCMonth() === mo - 1 && dt.getUTCDate() === d
+}
+
+// A human-readable reason the `// partitioned` metadata is unusable, or
+// undefined when it's sound. Mirrors the backend's `tz=` / `start=` validation
+// so the picker can refuse to auto-seed a bucket the backend would reject.
+export function partitionMetadataError(spec: PartitionSpec): string | undefined {
+	if (!isValidTimeZone(spec.tz)) return `invalid timezone "${spec.tz}"`
+	if (!isValidStart(spec.start)) return `invalid start date "${spec.start}" (want YYYY-MM-DD)`
+	return undefined
 }
 
 // ISO 8601 week-numbering year + week (chrono's %G / %V) of a UTC-substituted
@@ -105,9 +154,8 @@ export function bucketFor(spec: PartitionSpec, at: Date): string {
 // 00:00, or undefined if unset/malformed. `start` is a plain date in the
 // producer's tz — the backend parses it as a NaiveDate and compares by date.
 function startDate(spec: PartitionSpec): Date | undefined {
-	if (!spec.start) return undefined
-	const m = spec.start.match(/^(\d{4})-(\d{2})-(\d{2})$/)
-	if (!m) return undefined
+	if (!spec.start || !isValidStart(spec.start)) return undefined
+	const m = spec.start.match(/^(\d{4})-(\d{2})-(\d{2})$/)!
 	return new Date(Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3])))
 }
 

--- a/frontend/src/lib/components/assets/AssetGraph/partitionBuckets.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/partitionBuckets.ts
@@ -101,6 +101,49 @@ export function bucketFor(spec: PartitionSpec, at: Date): string {
 	return fmtBucket(spec.kind, zonedAsUtc(at, spec.tz ?? 'UTC'))
 }
 
+// The zoned start date (`spec.start`, `YYYY-MM-DD`) as a UTC-substituted Date at
+// 00:00, or undefined if unset/malformed. `start` is a plain date in the
+// producer's tz — the backend parses it as a NaiveDate and compares by date.
+function startDate(spec: PartitionSpec): Date | undefined {
+	if (!spec.start) return undefined
+	const m = spec.start.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+	if (!m) return undefined
+	return new Date(Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3])))
+}
+
+// True when `at` (localized to the producer tz) falls on a date before the
+// `start=` anchor — exactly the backend's `local.date_naive() < start_date`
+// check (`resolve_time_partition`), which resolves such an instant to no
+// partition.
+export function isBeforeStart(spec: PartitionSpec, at: Date): boolean {
+	const start = startDate(spec)
+	if (!start) return false
+	const zoned = zonedAsUtc(at, spec.tz ?? 'UTC')
+	const zonedDate = Date.UTC(zoned.getUTCFullYear(), zoned.getUTCMonth(), zoned.getUTCDate())
+	return zonedDate < start.getTime()
+}
+
+// The canonical bucket of the `start=` anchor (its date at 00:00), or undefined
+// if unset. Buckets sort lexicographically within a cadence, so callers can
+// compare against it to drop pre-start buckets.
+export function startBucketOf(spec: PartitionSpec): string | undefined {
+	const start = startDate(spec)
+	return start ? fmtBucket(spec.kind, start) : undefined
+}
+
+// The bucket to pre-fill the picker with. Normally the current bucket (matching
+// the backend's "absent partition arg -> current bucket" resolution), but when
+// the current instant is before the `start=` anchor the backend would resolve
+// to NO partition — so default to the first valid bucket (the start) rather
+// than a pre-start one the worker would take verbatim and materialize early.
+export function defaultBucket(spec: PartitionSpec, at: Date): string {
+	if (isBeforeStart(spec, at)) {
+		const start = startDate(spec)
+		if (start) return fmtBucket(spec.kind, start)
+	}
+	return bucketFor(spec, at)
+}
+
 // Native input value -> canonical bucket. Only hourly differs: datetime-local
 // carries a minute component the hourly bucket drops. The picked wall-clock is
 // taken verbatim as the bucket (the user picks in the producer's frame), so no

--- a/frontend/src/lib/components/assets/AssetGraph/partitionBuckets.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/partitionBuckets.ts
@@ -1,0 +1,170 @@
+// Client-side partition-bucket math for the run form's partition picker.
+// Produces the same canonical bucket strings the backend renders in
+// `windmill-common/src/partition_ee.rs` (`resolve_time_partition` /
+// `default_format`): the instant is localized to the spec's timezone
+// (`spec.tz`, defaulting to UTC — NOT the browser's zone) and then formatted.
+// Getting the zone right matters — a browser in a non-UTC zone would otherwise
+// seed a default bucket, and compare against materialized rows, off by a
+// day/hour near every boundary and always for an explicit `tz=` spec.
+//
+//   daily   %Y-%m-%d      -> 2026-07-05
+//   hourly  %Y-%m-%dT%H   -> 2026-07-05T14
+//   weekly  %G-W%V (ISO)  -> 2026-W27
+//   monthly %Y-%m         -> 2026-07
+//
+// Pure module (no Svelte runes) so the mapping is unit-testable.
+
+import type { PartitionSpec } from './parsePipelineAnnotations'
+
+export type PartitionInputType = 'date' | 'month' | 'week' | 'datetime-local' | 'text'
+
+// A spec carrying a custom strftime `format` can't be reproduced by the native
+// date pickers (arbitrary strftime), and `dynamic` partitions are a free-form
+// key extracted from the payload — both fall back to a plain text input.
+export function usesCalendarPicker(spec: PartitionSpec): boolean {
+	return spec.kind !== 'dynamic' && !spec.format
+}
+
+export function partitionInputType(spec: PartitionSpec): PartitionInputType {
+	if (!usesCalendarPicker(spec)) return 'text'
+	switch (spec.kind) {
+		case 'monthly':
+			return 'month'
+		case 'weekly':
+			return 'week'
+		case 'hourly':
+			return 'datetime-local'
+		default:
+			return 'date'
+	}
+}
+
+function pad(n: number): string {
+	return String(n).padStart(2, '0')
+}
+
+// Re-express `at` as a Date whose UTC fields equal the wall-clock in `tz`, so
+// all downstream field reads / calendar arithmetic can use the UTC getters and
+// stay in the producer's zone. `hourCycle: 'h23'` keeps hours 00–23.
+function zonedAsUtc(at: Date, tz: string): Date {
+	const parts = new Intl.DateTimeFormat('en-US', {
+		timeZone: tz,
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+		hour: '2-digit',
+		minute: '2-digit',
+		second: '2-digit',
+		hourCycle: 'h23'
+	}).formatToParts(at)
+	const g = (t: string) => Number(parts.find((p) => p.type === t)?.value)
+	return new Date(
+		Date.UTC(g('year'), g('month') - 1, g('day'), g('hour'), g('minute'), g('second'))
+	)
+}
+
+// ISO 8601 week-numbering year + week (chrono's %G / %V) of a UTC-substituted
+// date. Standard "nearest Thursday" algorithm, all in UTC.
+function isoWeekOf(d: Date): { isoYear: number; week: number } {
+	const date = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+	const dayNum = (date.getUTCDay() + 6) % 7 // Mon=0 … Sun=6
+	date.setUTCDate(date.getUTCDate() - dayNum + 3) // Thursday of this week
+	const isoYear = date.getUTCFullYear()
+	const firstThursday = new Date(Date.UTC(isoYear, 0, 4))
+	const fdNum = (firstThursday.getUTCDay() + 6) % 7
+	firstThursday.setUTCDate(firstThursday.getUTCDate() - fdNum + 3)
+	const week = 1 + Math.round((date.getTime() - firstThursday.getTime()) / (7 * 86400000))
+	return { isoYear, week }
+}
+
+// Render a UTC-substituted date into its canonical bucket for the cadence.
+function fmtBucket(kind: PartitionSpec['kind'], d: Date): string {
+	const y = d.getUTCFullYear()
+	const m = d.getUTCMonth() + 1
+	const day = d.getUTCDate()
+	const h = d.getUTCHours()
+	switch (kind) {
+		case 'hourly':
+			return `${y}-${pad(m)}-${pad(day)}T${pad(h)}`
+		case 'monthly':
+			return `${y}-${pad(m)}`
+		case 'weekly': {
+			const { isoYear, week } = isoWeekOf(d)
+			return `${isoYear}-W${pad(week)}`
+		}
+		default:
+			return `${y}-${pad(m)}-${pad(day)}`
+	}
+}
+
+export function bucketFor(spec: PartitionSpec, at: Date): string {
+	return fmtBucket(spec.kind, zonedAsUtc(at, spec.tz ?? 'UTC'))
+}
+
+// Native input value -> canonical bucket. Only hourly differs: datetime-local
+// carries a minute component the hourly bucket drops. The picked wall-clock is
+// taken verbatim as the bucket (the user picks in the producer's frame), so no
+// timezone conversion happens here.
+export function bucketFromInputValue(spec: PartitionSpec, inputValue: string): string {
+	if (!inputValue) return ''
+	if (spec.kind === 'hourly') {
+		const m = inputValue.match(/^(\d{4}-\d{2}-\d{2}T\d{2})/)
+		return m ? m[1] : inputValue
+	}
+	return inputValue
+}
+
+// Canonical bucket -> native input value. Only hourly differs: datetime-local
+// needs a minute component the bucket omits.
+export function inputValueFromBucket(spec: PartitionSpec, bucket: string): string {
+	if (!bucket) return ''
+	if (spec.kind === 'hourly') {
+		return /T\d{2}$/.test(bucket) ? `${bucket}:00` : bucket
+	}
+	return bucket
+}
+
+// The last `count` buckets ending at (and including) `now`, most-recent first,
+// localized to `spec.tz`. Arithmetic walks calendar units in the zoned frame,
+// so it's exact across DST (no ±1 drift). Undefined for non-calendar specs
+// (the caller guards on `usesCalendarPicker`).
+export function recentBuckets(spec: PartitionSpec, now: Date, count: number): string[] {
+	const base = zonedAsUtc(now, spec.tz ?? 'UTC')
+	const out: string[] = []
+	for (let i = 0; i < count; i++) {
+		const d = new Date(base)
+		switch (spec.kind) {
+			case 'hourly':
+				d.setUTCHours(d.getUTCHours() - i)
+				break
+			case 'weekly':
+				d.setUTCDate(d.getUTCDate() - 7 * i)
+				break
+			case 'monthly':
+				// Normalize to the 1st first so subtracting months can't roll over
+				// a short target month (e.g. Mar 31 − 1mo → Mar 3).
+				d.setUTCDate(1)
+				d.setUTCMonth(d.getUTCMonth() - i)
+				break
+			default:
+				d.setUTCDate(d.getUTCDate() - i)
+		}
+		out.push(fmtBucket(spec.kind, d))
+	}
+	return out
+}
+
+// How many recent buckets the "missing partitions" hint scans, per kind — a
+// window that reads as "recent" for each cadence without flooding the hint.
+export function recentWindow(kind: PartitionSpec['kind']): number {
+	switch (kind) {
+		case 'hourly':
+			return 24
+		case 'weekly':
+			return 8
+		case 'monthly':
+			return 6
+		default:
+			return 14
+	}
+}

--- a/frontend/src/routes/(root)/(logged)/pipeline/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-	import { userStore } from '$lib/stores'
+	import { userStore, workspaceStore } from '$lib/stores'
 	import PipelineFolderList from '$lib/components/assets/AssetGraph/PipelineFolderList.svelte'
+	import PipelineSetupSignpost from '$lib/components/assets/AssetGraph/PipelineSetupSignpost.svelte'
 	import PipelineAlphaAckModal from '$lib/components/assets/AssetGraph/PipelineAlphaAckModal.svelte'
 	import { BookOpen, NetworkIcon } from 'lucide-svelte'
 	import { onMount } from 'svelte'
@@ -72,6 +73,10 @@
 					Pipelines documentation
 				</a>
 			</div>
+
+			{#if !$userStore?.operator && $workspaceStore}
+				<PipelineSetupSignpost workspace={$workspaceStore} />
+			{/if}
 
 			<PipelineFolderList />
 		</div>


### PR DESCRIPTION
## Summary

Two frontend UX gaps in data pipelines, both about giving a user the signal they're missing:

1. **Partition run-arg picker.** A partitioned producer's run form exposed a bare `partition` **string** input — the user had to know the exact bucket format by heart. It now renders a cadence-appropriate date picker (date / week / month / datetime-local) plus hints for which partitions are missing and whether the chosen bucket has upstream data.
2. **First-run setup signpost.** A brand-new user got no signal that a pipeline needs workspace object storage **and** a configured DuckLake before anything materializes. The pipeline landing page now shows a checklist/signpost when either is unconfigured, linking straight to the settings that fix it.

## Changes

### (1) Partition run-arg picker
- `partitionBuckets.ts` (new, unit-tested): pure date→bucket-string math that mirrors the backend `windmill-common/src/partition_ee.rs` `resolve_time_partition` / `default_format` — daily `%Y-%m-%d`, hourly `%Y-%m-%dT%H`, weekly ISO `%G-W%V`, monthly `%Y-%m`. Localizes to `spec.tz` (default **UTC**, not the browser zone) so the seeded default and the missing/upstream hints match the buckets scheduled runs actually wrote.
- `PartitionArgControl.svelte` (new): kind-appropriate native picker; `dynamic` / custom-format specs fall back to a text input. Shows:
  - selected-bucket status vs the producer's own materialized partitions ("already materialized — running replaces it" / "not materialized yet — running creates it"),
  - a compact "N of the last M partitions are not materialized" list with clickable chips,
  - an amber "no upstream data for this bucket yet" hint when a partition-tracked ducklake input is missing the selected bucket (fail-safe: never warns while loading or for untracked inputs).
- `PipelineRunForm.svelte`: strips the `partition` property from the schema clone and renders `PartitionArgControl` for it, leaving the rest of the args to `SchemaForm`.
- `PipelineScriptView.svelte`: derives the partition spec / materialize target / ducklake upstreams from the parsed pipeline annotations, and shows the run form for any partitioned producer (not only data-upload entries) — materializing a single partition is available in OSS. Header reads "Materialize a partition" for a partition-only producer.

### (2) Setup signpost
- `PipelineSetupSignpost.svelte` (new): probes `WorkspaceService.getSettings` (object storage) and `listDucklakes` (DuckLake). Renders a checklist only when it *positively* knows a prerequisite is unconfigured — an errored probe (e.g. non-admin) resolves to `undefined` and never nags. Each row links to `/workspace_settings?tab=windmill_lfs` / `?tab=ducklake`.
- `pipeline/+page.svelte`: renders the signpost above the folder list for non-operators.

## Screenshots

### First-run setup signpost (fresh workspace, nothing configured)
![signpost-light](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/pipeline-partitioning-onboarding-ux/1783286123-signpost-light.png)

### Partition picker — daily producer
![partition-picker](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/pipeline-partitioning-onboarding-ux/1783286125-partition-picker.png)

### Partition picker — hourly producer (datetime-local input)
![partition-hourly](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/pipeline-partitioning-onboarding-ux/1783286127-partition-hourly.png)

## Test plan
- [x] `partitionBuckets.test.ts` — 15 cases: per-cadence formats, `spec.tz` day/hour shift, native-input round-trips, `recentBuckets` walk-back (day/hour/week + month across a year boundary). Passes under `TZ=Asia/Kolkata` (tz-independent).
- [x] `npm run check` — 0 errors; svelte-autofixer clean on all new components.
- [x] Manual (Playwright): deployed a `// partitioned daily` and a `// partitioned hourly` DuckDB producer, opened each in the pipeline graph → the bare `partition` string is replaced by the correct native picker seeded to today's bucket, the "not materialized / N of last M missing" hints render, and clicking a missing chip sets the partition.
- [x] Manual (Playwright): fresh workspace with no object storage / DuckLake → signpost renders with both items and the correct settings links.
- [ ] Reviewer: confirm behaviour once in a non-UTC browser and with a `// partitioned … tz=<zone>` script (the picker frames buckets in the producer's tz, not the browser's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the bare `partition` input with a cadence-aware picker that seeds in the producer’s timezone, honors `start=`, fails safe on bad tz/start, and adds a first‑run setup signpost for object storage and DuckLake. This helps choose the right bucket and gets new workspaces to a runnable state.

- **New Features**
  - Partition picker:
    - Native inputs for `daily` (`date`), `weekly` (`week`), `monthly` (`month`), `hourly` (`datetime-local`); text for `dynamic` or custom `format`.
    - Seeds to the current bucket in the producer’s timezone (`spec.tz`, default UTC).
    - Shows selected-bucket status, chips for recent missing partitions, and per-input upstream warnings for partitioned DuckLake inputs.
    - Run form appears for any partitioned producer; header reads “Materialize a partition” when not a data‑upload entry.
  - First-run setup signpost:
    - Detects missing workspace object storage and DuckLake catalogs; links to `?tab=windmill_lfs` and `?tab=ducklake`.
    - Renders only on confirmed missing states; never nags on errors (e.g., non-admins).

- **Bug Fixes**
  - Picker now honors `start=`:
    - Never seeds or offers pre-start buckets; recent-missing chips exclude them.
    - Shows a hint when defaulting to the start bucket.
  - Resilience and correctness:
    - Reseeds when the `// partitioned` header changes (form keyed on schema + spec) to avoid stale buckets.
    - Bad `tz` no longer throws and falls back to UTC; invalid `start` is rejected and no default is auto-seeded. A warning points at the header.

<sup>Written for commit 6e257ebc585fb79d58f88d17cfcd6e1271062d89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

