### PR TITLE
feat(pipelines): mid-DAG selective execution (dbt `model+`) for pipeline runs

### DIFF
--- a/cli/src/commands/pipeline/boundedCascade.ts
+++ b/cli/src/commands/pipeline/boundedCascade.ts
@@ -216,6 +216,28 @@ export function validStarts(g: BCGraph): Set<string> {
 }
 
 /**
+ * Script node ids eligible as an EXPLICIT bounded-run start from *anywhere* in
+ * the DAG (dbt's `--select model+`): every script that can run with empty args —
+ * i.e. all scripts except non-autorun-trigger ones (kafka/mqtt/…/webhook/
+ * data_upload, which fan out per event or need caller-supplied input). Unlike
+ * `validStarts` (schedule/manual roots only), this INCLUDES mid-DAG asset
+ * subscribers and pure readers, so `--from <mid-model>` runs that node plus its
+ * transitive downstream WITHOUT re-running upstream. Roots stay a subset of this
+ * set. A non-autorun handler still qualifies once it's `--upload`-bound (handled
+ * by the caller, which unions in the bound node ids).
+ */
+export function validFromStarts(g: BCGraph): Set<string> {
+  const nonAutorun = nonAutorunTriggerScripts(g);
+  const out = new Set<string>();
+  for (const r of g.runnables ?? []) {
+    if (r.usage_kind !== "script") continue;
+    const id = scriptNodeId(r.path);
+    if (!nonAutorun.has(id)) out.add(id);
+  }
+  return out;
+}
+
+/**
  * Script node ids that carry a trigger requiring caller-supplied input or
  * per-event fanout (kafka/mqtt/nats/postgres/sqs/gcp/email/webhook/data_upload).
  * These can't be run with empty args, so a whole-pipeline run must exclude them

--- a/cli/src/commands/pipeline/boundedCascade.ts
+++ b/cli/src/commands/pipeline/boundedCascade.ts
@@ -228,7 +228,11 @@ export function validStarts(g: BCGraph): Set<string> {
  */
 export function validFromStarts(g: BCGraph): Set<string> {
   const nonAutorun = nonAutorunTriggerScripts(g);
-  const out = new Set<string>();
+  // Seed with the schedule/manual roots: `validStarts` lets a schedule identity
+  // win over a secondary non-autorun trigger (a `// on schedule` + `// on
+  // data_upload` script IS a scheduled root), so a root must stay `--from`-
+  // eligible even though it's also in `nonAutorunTriggerScripts`.
+  const out = new Set<string>(validStarts(g));
   for (const r of g.runnables ?? []) {
     if (r.usage_kind !== "script") continue;
     const id = scriptNodeId(r.path);

--- a/cli/src/commands/pipeline/pipeline.ts
+++ b/cli/src/commands/pipeline/pipeline.ts
@@ -20,6 +20,7 @@ import {
   scriptsOf,
   topoOrder,
   validStarts,
+  validFromStarts,
 } from "./boundedCascade.ts";
 import {
   type AssetGraph,
@@ -445,13 +446,15 @@ function formatJobFailure(result: unknown): string | undefined {
   }
 }
 
-// Bounded-cascade run: start at a schedule / manual root, fan downstream, but
-// stop at the `--to` end node(s). Scripts run in topological order; each is
-// launched with `_wmill_skip_asset_dispatch` so the CLI owns the whole closure
-// (the backend dispatcher never double-fires the deployed part). With no
-// `--to`, runs the full read-aware downstream of `--from` (every descendant in
-// the lineage DAG, pure readers included — broader than the canvas cascade,
-// which dispatches subscribers only).
+// Bounded-cascade run: start at `--from` — a schedule/manual root OR any mid-DAG
+// model (asset subscriber / pure reader) — fan downstream, but stop at the
+// `--to` end node(s). A mid-DAG start runs that node plus its transitive
+// downstream and never re-runs upstream (dbt `--select model+`). Scripts run in
+// topological order; each is launched with `_wmill_skip_asset_dispatch` so the
+// CLI owns the whole closure (the backend dispatcher never double-fires the
+// deployed part). With no `--to`, runs the full read-aware downstream of
+// `--from` (every descendant in the lineage DAG, pure readers included — broader
+// than the canvas cascade, which dispatches subscribers only).
 // Resolve one `--upload` binding to the run-arg it injects: pick the target
 // S3Object parameter (explicit `:param`, else the script's sole S3Object arg)
 // and turn the source into an object key — an `s3://` source is used as-is, a
@@ -669,10 +672,23 @@ async function run(
       .map((r) => r.path),
   );
 
-  // Resolve the start: explicit --from (must be a valid start) or the folder's
-  // sole valid start. `--upload`-bound scripts join the valid starts.
+  // Resolve the start. Two eligibility sets:
+  //   `starts`       — schedule/manual roots (+ `--upload`-bound handlers). The
+  //                    fan-in candidates for an IMPLICIT start (`runAll`, or the
+  //                    folder's sole root).
+  //   `fromEligible` — every autorun-able script, roots AND mid-DAG models
+  //                    (asset subscribers, pure readers). An EXPLICIT `--from`
+  //                    may name any of these: `--from <mid-model>` runs that node
+  //                    plus its transitive downstream, without re-running upstream
+  //                    (dbt `--select model+`). Non-autorun handlers stay out
+  //                    unless `--upload`-bound.
   const starts = new Set(
     [...validStarts(graph), ...boundNodeIds].filter(
+      (id) => !macroLibPaths.has(scriptPathOf(id)),
+    ),
+  );
+  const fromEligible = new Set(
+    [...validFromStarts(graph), ...boundNodeIds].filter(
       (id) => !macroLibPaths.has(scriptPathOf(id)),
     ),
   );
@@ -702,9 +718,14 @@ async function run(
         `--from '${opts.from}' is a \`// macros\` library — definition-only, injected into consuming scripts at run time, never a runnable step.`,
       );
     }
-    if (!starts.has(resolved)) {
+    if (!resolved.startsWith("script:")) {
       throw new Error(
-        `--from '${opts.from}' is not a valid bounded-run start. Starts must be schedule-triggered or manual roots; row-backed event triggers (kafka/mqtt/nats/postgres/sqs/gcp/email) fan out per-event and can't be bounded.`,
+        `--from '${opts.from}' is an asset, not a runnable — start a run from a script (assets are produced, not run).`,
+      );
+    }
+    if (!fromEligible.has(resolved)) {
+      throw new Error(
+        `--from '${opts.from}' can't start a run: row-backed event triggers (kafka/mqtt/nats/postgres/sqs/gcp/email) and input-only entrypoints (webhook/data_upload) fan out per-event or need caller-supplied input — bind it with --upload to run it.`,
       );
     }
     start = resolved;
@@ -762,8 +783,12 @@ async function run(
   // barriers: a valid start (a schedule/manual root, or an `--upload`-bound
   // handler) runs with its own input even if it ALSO carries a non-autorun
   // trigger — cutting it would drop a legitimately-scheduled root and its chain.
+  // An explicit mid-DAG `--from` is likewise protected: the user named it as the
+  // start, so it runs even if it also carries a non-autorun trigger.
   const barriers = new Set(
-    [...nonAutorunTriggerScripts(graph)].filter((id) => !starts.has(id)),
+    [...nonAutorunTriggerScripts(graph)].filter(
+      (id) => !starts.has(id) && id !== start,
+    ),
   );
   let selectedScripts: Set<string>;
   let reachableEnds: string[] = [];
@@ -994,12 +1019,12 @@ const command = new Command()
   .action(show as any)
   .command(
     "run",
-    "run a bounded cascade: from a schedule/manual root, fan downstream up to the --to end node(s)",
+    "run a cascade: from --from (a root OR any mid-DAG model), fan downstream up to the --to end node(s)",
   )
   .arguments("<folder:string>")
   .option(
     "--from <script:string>",
-    "Start script (short name or path). Defaults to the folder's sole schedule/manual root.",
+    "Start script (short name or path). May be any node, including a mid-DAG model — that node plus its transitive downstream runs, upstream is NOT re-run (dbt `--select model+`). Defaults to the folder's sole schedule/manual root.",
   )
   .option(
     "--to <node:string>",

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -6934,8 +6934,8 @@ inspect asset-driven pipelines (scripts marked \`// pipeline\`, wired by \`// on
 - \`pipeline show <folder:string>\` - render a pipeline folder's DAG (sources, lineage, subscriptions) in the terminal
   - \`--json\` - Output the raw asset graph as JSON
   - \`--local\` - Build the graph from local working-tree files (// pipeline scripts) instead of the deployed workspace — no deploy needed.
-- \`pipeline run <folder:string>\` - run a bounded cascade: from a schedule/manual root, fan downstream up to the --to end node(s)
-  - \`--from <script:string>\` - Start script (short name or path). Defaults to the folder's sole schedule/manual root.
+- \`pipeline run <folder:string>\` - run a cascade: from --from (a root OR any mid-DAG model), fan downstream up to the --to end node(s)
+  - \`--from <script:string>\` - Start script (short name or path). May be any node, including a mid-DAG model — that node plus its transitive downstream runs, upstream is NOT re-run (dbt \`--select model+\`). Defaults to the folder's sole schedule/manual root.
   - \`--to <node:string>\` - End node(s) to stop at — script names/paths or asset URIs (e.g. datatable://main/staged). Repeatable or comma-separated. Omit to run the full downstream.
   - \`--dry-run\` - Print the topological run plan without executing.
   - \`--json\` - Output the plan as JSON (for piping to jq).

--- a/cli/test/pipeline_bounded_cascade_unit.test.ts
+++ b/cli/test/pipeline_bounded_cascade_unit.test.ts
@@ -15,6 +15,7 @@ import {
   scriptsOf,
   topoOrder,
   validStarts,
+  validFromStarts,
   nonAutorunTriggerScripts,
   reachableCutting,
   isScriptNode,
@@ -152,6 +153,42 @@ test("a scheduled root with a secondary data_upload trigger stays a start and is
   );
   expect(sel.has("sched_upload")).toBe(true); // runs on its schedule path…
   expect(sel.has("consumer")).toBe(true); // …and its downstream isn't cut off
+});
+
+test("validFromStarts: mid-DAG models are eligible starts, event/upload/webhook are not", () => {
+  // a(root) → x → sub → y → reader ; k=kafka, upl=data_upload, hook=webhook.
+  const g = graph({
+    scripts: ["a", "sub", "reader", "k", "upl", "hook"],
+    writes: [["a", "x"], ["sub", "y"]],
+    reads: [["reader", "y"]],
+    subs: [["sub", "x"]],
+    native: [["kafka", "k"], ["data_upload", "upl"], ["webhook", "hook"]],
+  });
+  const from = validFromStarts(g);
+  expect(from.has(sn("a"))).toBe(true); // root
+  expect(from.has(sn("sub"))).toBe(true); // mid-DAG subscriber — NOT a validStart
+  expect(from.has(sn("reader"))).toBe(true); // pure reader
+  expect(validStarts(g).has(sn("sub"))).toBe(false); // old root-only gate rejected it
+  // Non-autorun handlers stay out (they need caller input / fan out per event).
+  expect(from.has(sn("k"))).toBe(false);
+  expect(from.has(sn("upl"))).toBe(false);
+  expect(from.has(sn("hook"))).toBe(false);
+});
+
+test("a mid-DAG start runs itself + downstream, never upstream", () => {
+  // Starting at `sub`, the unbounded downstream is {sub, reader}; `a`/`x` upstream
+  // are never pulled in (dbt `--select sub+`).
+  const g = graph({
+    scripts: ["a", "sub", "reader"],
+    writes: [["a", "x"], ["sub", "y"]],
+    reads: [["reader", "y"]],
+    subs: [["sub", "x"]],
+  });
+  const dag = buildLineageDag(g);
+  const downstream = new Set([sn("sub"), ...descendants(dag, sn("sub"))]);
+  expect(sorted(scriptsOf(downstream))).toEqual(["reader", "sub"]);
+  expect(downstream.has(sn("a"))).toBe(false);
+  expect(downstream.has("datatable:x")).toBe(false);
 });
 
 test("nonAutorunTriggerScripts: event + upload/webhook handlers, incl. subscribers (descendants)", () => {

--- a/cli/test/pipeline_bounded_cascade_unit.test.ts
+++ b/cli/test/pipeline_bounded_cascade_unit.test.ts
@@ -175,6 +175,22 @@ test("validFromStarts: mid-DAG models are eligible starts, event/upload/webhook 
   expect(from.has(sn("hook"))).toBe(false);
 });
 
+test("validFromStarts keeps a scheduled root that also carries a non-autorun trigger", () => {
+  // Regression: `--from sched_upload` must be accepted just like the implicit
+  // start. `sched_upload` is a scheduled root AND a data_upload handler — schedule
+  // wins in validStarts, so it stays --from-eligible despite being a nonAutorun
+  // handler (else explicit --from throws where the implicit start succeeds).
+  const g = graph({
+    scripts: ["sched_upload", "consumer"],
+    writes: [["sched_upload", "x"]],
+    subs: [["consumer", "x"]],
+    native: [["schedule", "sched_upload"], ["data_upload", "sched_upload"]],
+  });
+  expect(validStarts(g).has(sn("sched_upload"))).toBe(true);
+  expect(nonAutorunTriggerScripts(g).has(sn("sched_upload"))).toBe(true);
+  expect(validFromStarts(g).has(sn("sched_upload"))).toBe(true); // union with roots
+});
+
 test("a mid-DAG start runs itself + downstream, never upstream", () => {
   // Starting at `sub`, the unbounded downstream is {sub, reader}; `a`/`x` upstream
   // are never pulled in (dbt `--select sub+`).

--- a/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/AssetGraphCanvas.svelte
@@ -142,8 +142,8 @@
 		// editor passes it, so the asset-graph page is unaffected. The page
 		// clears it once the pan has had time to settle.
 		panToNodeId?: string | undefined
-		// Script paths eligible to *start* a bounded-cascade run (schedule
-		// roots + manual roots — see boundedCascade.validStarts). When a path is
+		// Script paths eligible to *start* a bounded-cascade run — roots AND
+		// mid-DAG models (see boundedCascade.validFromStarts). When a path is
 		// in this set and `onStartBoundedRun` is wired, its node's cascade menu
 		// gains a "Run downstream up to…" entry.
 		validStartPaths?: ReadonlySet<string>

--- a/frontend/src/lib/components/assets/AssetGraph/RunnableNode.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/RunnableNode.svelte
@@ -410,10 +410,10 @@
 								>
 									<Target size={14} class="mt-0.5 shrink-0 text-secondary" />
 									<div class="flex flex-col min-w-0">
-										<span class="font-medium">Run downstream up to…</span>
+										<span class="font-medium">Run + downstream…</span>
 										<span class="text-2xs text-secondary">
-											Pick end node(s) on the graph, then run only the cascade between this script
-											and them.
+											Run this script and everything downstream. Or pick end node(s) on the graph to
+											bound the cascade between this script and them.
 										</span>
 									</div>
 								</button>

--- a/frontend/src/lib/components/assets/AssetGraph/TriggerNode.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/TriggerNode.svelte
@@ -183,7 +183,7 @@
 		...(data.onStartBoundedRun
 			? [
 					{
-						displayName: 'Run downstream up to…',
+						displayName: 'Run + downstream…',
 						icon: Target,
 						action: () => data.onStartBoundedRun?.()
 					}

--- a/frontend/src/lib/components/assets/AssetGraph/boundedCascade.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/boundedCascade.test.ts
@@ -7,9 +7,12 @@ import {
 	buildLineageDag,
 	buildLineageDownstreamMap,
 	descendants,
+	nonAutorunTriggerScripts,
+	reachableCutting,
 	scriptNodeId,
 	scriptsOf,
-	validStarts
+	validStarts,
+	validFromStarts
 } from './boundedCascade'
 import { computeInducedSchedule } from './graphTraversal'
 
@@ -244,6 +247,83 @@ describe('validStarts', () => {
 		expect(starts.has(sn('a'))).toBe(true) // manual root
 		expect(starts.has(sn('sub'))).toBe(false) // event-less but a subscriber
 		expect(starts.has(sn('sched'))).toBe(true) // schedule overrides subscriber
+	})
+})
+
+describe('validFromStarts (mid-DAG selective execution)', () => {
+	// a → x → sub (subscriber) → y → reader (pure read). `k` is event-triggered.
+	const g = () =>
+		graph({
+			scripts: ['a', 'sub', 'reader', 'k'],
+			writes: [
+				['a', 'x'],
+				['sub', 'y']
+			],
+			reads: [['reader', 'y']],
+			subs: [['sub', 'x']],
+			native: [['kafka', 'k']]
+		})
+
+	it('includes mid-DAG subscribers and pure readers, not just roots', () => {
+		const from = validFromStarts(g())
+		expect(from.has(sn('a'))).toBe(true) // root
+		expect(from.has(sn('sub'))).toBe(true) // mid-DAG subscriber — NOT a validStart
+		expect(from.has(sn('reader'))).toBe(true) // pure reader
+		// The old root-only gate would have rejected the mid-DAG nodes.
+		expect(validStarts(g()).has(sn('sub'))).toBe(false)
+	})
+
+	it('excludes event-triggered scripts (no run-now gesture)', () => {
+		expect(validFromStarts(g()).has(sn('k'))).toBe(false)
+	})
+
+	it('runs a mid-DAG start plus its downstream WITHOUT re-running upstream', () => {
+		// Starting at `sub`, the unbounded downstream is {sub, y, reader} — `a`/`x`
+		// upstream are never pulled in (dbt `--select sub+`).
+		const dag = buildLineageDag(g())
+		const downstream = new Set([sn('sub'), ...descendants(dag, sn('sub'))])
+		expect(scriptsOf(downstream).sort()).toEqual(['reader', 'sub'])
+		expect(downstream.has(sn('a'))).toBe(false)
+		expect(downstream.has(asset('x'))).toBe(false)
+	})
+})
+
+describe('reachableCutting (barrier cut for "Run + downstream")', () => {
+	// a → x → k(kafka, also reads x) → z → consumer. Starting at `a` and running
+	// downstream must cut the event handler `k` AND `consumer` (only reachable
+	// through it) — else they'd launch with empty args. Mirrors the CLI cut.
+	const g = () =>
+		graph({
+			scripts: ['a', 'k', 'consumer'],
+			writes: [
+				['a', 'x'],
+				['k', 'z']
+			],
+			reads: [['k', 'x']],
+			subs: [['consumer', 'z']],
+			native: [['kafka', 'k']]
+		})
+
+	it('detects event-triggered scripts as barriers', () => {
+		expect(nonAutorunTriggerScripts(g()).has(sn('k'))).toBe(true)
+		expect(nonAutorunTriggerScripts(g()).has(sn('a'))).toBe(false)
+	})
+
+	it('cuts an event descendant and its event-only downstream from a run set', () => {
+		const dag = buildLineageDag(g())
+		const barriers = nonAutorunTriggerScripts(g())
+		const runNodes = reachableCutting(dag, [sn('a')], barriers)
+		expect(scriptsOf(runNodes).sort()).toEqual(['a']) // k + consumer cut
+		expect(runNodes.has(sn('k'))).toBe(false)
+		expect(runNodes.has(sn('consumer'))).toBe(false)
+	})
+
+	it('protects an explicit start even if it carries an event trigger', () => {
+		const dag = buildLineageDag(g())
+		// start = k itself (user named it); it runs, and so does its downstream.
+		const barriers = new Set([...nonAutorunTriggerScripts(g())].filter((id) => id !== sn('k')))
+		const runNodes = reachableCutting(dag, [sn('k')], barriers)
+		expect(scriptsOf(runNodes).sort()).toEqual(['consumer', 'k'])
 	})
 })
 

--- a/frontend/src/lib/components/assets/AssetGraph/boundedCascade.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/boundedCascade.test.ts
@@ -277,6 +277,23 @@ describe('validFromStarts (mid-DAG selective execution)', () => {
 		expect(validFromStarts(g()).has(sn('k'))).toBe(false)
 	})
 
+	it('keeps a scheduled root that also carries an event trigger', () => {
+		// schedule wins over the secondary kafka trigger in validStarts, so the
+		// scheduled root stays --from-eligible (regression guard).
+		const g2 = graph({
+			scripts: ['sched_evt', 'consumer'],
+			writes: [['sched_evt', 'x']],
+			subs: [['consumer', 'x']],
+			native: [
+				['schedule', 'sched_evt'],
+				['kafka', 'sched_evt']
+			]
+		})
+		expect(validStarts(g2).has(sn('sched_evt'))).toBe(true)
+		expect(nonAutorunTriggerScripts(g2).has(sn('sched_evt'))).toBe(true)
+		expect(validFromStarts(g2).has(sn('sched_evt'))).toBe(true) // union with roots
+	})
+
 	it('runs a mid-DAG start plus its downstream WITHOUT re-running upstream', () => {
 		// Starting at `sub`, the unbounded downstream is {sub, y, reader} — `a`/`x`
 		// upstream are never pulled in (dbt `--select sub+`).

--- a/frontend/src/lib/components/assets/AssetGraph/boundedCascade.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/boundedCascade.test.ts
@@ -277,6 +277,37 @@ describe('validFromStarts (mid-DAG selective execution)', () => {
 		expect(validFromStarts(g()).has(sn('k'))).toBe(false)
 	})
 
+	it('excludes webhook/data_upload mid-DAG subscribers (need caller input)', () => {
+		// a → x → upload_mid (subscribes x AND `// on data_upload`) → y → consumer.
+		// upload_mid must NOT be an eligible start (empty-arg run has no S3Object),
+		// and must be a barrier so `consumer` isn't run with a skipped producer.
+		const g2 = graph({
+			scripts: ['a', 'upload_mid', 'hook_mid', 'consumer'],
+			writes: [
+				['a', 'x'],
+				['upload_mid', 'y']
+			],
+			subs: [
+				['upload_mid', 'x'],
+				['hook_mid', 'x'],
+				['consumer', 'y']
+			],
+			native: [
+				['data_upload', 'upload_mid'],
+				['webhook', 'hook_mid']
+			]
+		})
+		const from = validFromStarts(g2)
+		expect(from.has(sn('upload_mid'))).toBe(false)
+		expect(from.has(sn('hook_mid'))).toBe(false)
+		expect(from.has(sn('a'))).toBe(true) // the plain root is still eligible
+		// and they're barriers, so running downstream from `a` cuts them + consumer.
+		const bars = nonAutorunTriggerScripts(g2)
+		expect(bars.has(sn('upload_mid'))).toBe(true)
+		expect(bars.has(sn('hook_mid'))).toBe(true)
+		expect(scriptsOf(reachableCutting(buildLineageDag(g2), [sn('a')], bars)).sort()).toEqual(['a'])
+	})
+
 	it('keeps a scheduled root that also carries an event trigger', () => {
 		// schedule wins over the secondary kafka trigger in validStarts, so the
 		// scheduled root stays --from-eligible (regression guard).

--- a/frontend/src/lib/components/assets/AssetGraph/boundedCascade.test.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/boundedCascade.test.ts
@@ -342,6 +342,40 @@ describe('reachableCutting (barrier cut for "Run + downstream")', () => {
 		const runNodes = reachableCutting(dag, [sn('k')], barriers)
 		expect(scriptsOf(runNodes).sort()).toEqual(['consumer', 'k'])
 	})
+
+	it('keeps a scheduled event root (and its downstream) reachable from an upstream start', () => {
+		// a → x → sched_evt(schedule + kafka) → y → consumer. Running downstream
+		// from `a`, sched_evt is a scheduled root so it must NOT be a barrier even
+		// though it carries an event trigger — matching the CLI, which excludes all
+		// valid roots (`starts`), not just the picked start. Mirror of the page's
+		// barrier construction: nonAutorunTriggerScripts minus validStarts minus start.
+		const g2 = graph({
+			scripts: ['a', 'sched_evt', 'consumer'],
+			writes: [
+				['a', 'x'],
+				['sched_evt', 'y']
+			],
+			subs: [
+				['sched_evt', 'x'],
+				['consumer', 'y']
+			],
+			native: [
+				['schedule', 'sched_evt'],
+				['kafka', 'sched_evt']
+			]
+		})
+		const dag = buildLineageDag(g2)
+		const roots = validStarts(g2)
+		const barriers = new Set(
+			[...nonAutorunTriggerScripts(g2)].filter((id) => !roots.has(id) && id !== sn('a'))
+		)
+		const runNodes = reachableCutting(dag, [sn('a')], barriers)
+		expect(scriptsOf(runNodes).sort()).toEqual(['a', 'consumer', 'sched_evt'])
+		// Without the validStarts exclusion, sched_evt (a kafka handler) would be a
+		// barrier and `consumer` would be dropped — the bug this guards.
+		const naiveBarriers = new Set([...nonAutorunTriggerScripts(g2)].filter((id) => id !== sn('a')))
+		expect(scriptsOf(reachableCutting(dag, [sn('a')], naiveBarriers)).sort()).toEqual(['a'])
+	})
 })
 
 describe('buildLineageDownstreamMap (read-aware scheduling)', () => {

--- a/frontend/src/lib/components/assets/AssetGraph/boundedCascade.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/boundedCascade.ts
@@ -249,7 +249,10 @@ export function validFromStarts(g: AssetGraphResponse): Set<string> {
 		if (t.runnable_kind !== 'script') continue
 		if (EVENT_TRIGGER_KINDS.has(t.trigger_kind)) eventScripts.add(t.runnable_path)
 	}
-	const out = new Set<string>()
+	// Seed with schedule/manual roots: `validStarts` lets a schedule identity win
+	// over a secondary event trigger, so a scheduled root that also carries e.g.
+	// a `// on kafka` stays `--from`-eligible even though it's an event script.
+	const out = new Set<string>(validStarts(g))
 	for (const r of g.runnables ?? []) {
 		if (r.usage_kind !== 'script') continue
 		if (!eventScripts.has(r.path)) out.add(scriptNodeId(r.path))

--- a/frontend/src/lib/components/assets/AssetGraph/boundedCascade.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/boundedCascade.ts
@@ -138,6 +138,37 @@ export function ancestors(dag: LineageDag, n: string): Set<string> {
 	return closure(dag.up, n)
 }
 
+/**
+ * Nodes reachable from `starts` over the lineage DAG, treating `barriers` as cut
+ * points: a barrier node is neither included NOR traversed through, so a node
+ * reachable ONLY via a barrier is excluded while one also reachable via another
+ * path stays. Mirror of the CLI `reachableCutting`. Used to keep event handlers
+ * (and their event-only downstream) out of a cascade run — running such a
+ * consumer whose producer was skipped would feed it missing/stale inputs.
+ */
+export function reachableCutting(
+	dag: LineageDag,
+	starts: Iterable<string>,
+	barriers: Set<string>
+): Set<string> {
+	const seen = new Set<string>()
+	const queue: string[] = []
+	for (const s of starts) {
+		if (barriers.has(s) || seen.has(s)) continue
+		seen.add(s)
+		queue.push(s)
+	}
+	while (queue.length > 0) {
+		const n = queue.shift()!
+		for (const next of dag.down.get(n) ?? []) {
+			if (barriers.has(next) || seen.has(next)) continue
+			seen.add(next)
+			queue.push(next)
+		}
+	}
+	return seen
+}
+
 export type BoundedResult = {
 	/** Path-between node set (scripts + assets), always including `start`. */
 	nodes: Set<string>
@@ -197,6 +228,50 @@ export function validStarts(g: AssetGraphResponse): Set<string> {
 		const p = r.path
 		if (scheduleScripts.has(p)) out.add(scriptNodeId(p))
 		else if (!subscribers.has(p) && !eventScripts.has(p)) out.add(scriptNodeId(p))
+	}
+	return out
+}
+
+/**
+ * Script node ids eligible as an EXPLICIT bounded-run start from *anywhere* in
+ * the DAG (dbt's `--select model+`): every script that can run with empty args —
+ * i.e. all scripts except event-triggered ones (kafka/mqtt/nats/postgres/sqs/
+ * gcp/email fan out per event and have no "run now" gesture). Unlike
+ * `validStarts` (schedule/manual roots only), this INCLUDES mid-DAG asset
+ * subscribers and pure readers, so "Run + downstream" can begin at any model —
+ * that node plus its transitive downstream runs, upstream is never re-run.
+ * (`webhook`/`data_upload` have no trigger row here — same as `validStarts` they
+ * read as manual roots and are already included.)
+ */
+export function validFromStarts(g: AssetGraphResponse): Set<string> {
+	const eventScripts = new Set<string>()
+	for (const t of g.triggers ?? []) {
+		if (t.runnable_kind !== 'script') continue
+		if (EVENT_TRIGGER_KINDS.has(t.trigger_kind)) eventScripts.add(t.runnable_path)
+	}
+	const out = new Set<string>()
+	for (const r of g.runnables ?? []) {
+		if (r.usage_kind !== 'script') continue
+		if (!eventScripts.has(r.path)) out.add(scriptNodeId(r.path))
+	}
+	return out
+}
+
+/**
+ * Script node ids carrying an event trigger (kafka/mqtt/nats/postgres/sqs/gcp/
+ * email) — they fan out per event and can't run with empty args, so a cascade
+ * must cut them (as `barriers` for `reachableCutting`) even when they're a
+ * lineage descendant of the start. Mirror of the CLI `nonAutorunTriggerScripts`,
+ * minus `webhook`/`data_upload`: those have no trigger row in `/assets/graph`
+ * so they can't be detected here and read as manual roots (same limitation as
+ * `validStarts`).
+ */
+export function nonAutorunTriggerScripts(g: AssetGraphResponse): Set<string> {
+	const out = new Set<string>()
+	for (const t of g.triggers ?? []) {
+		if (t.runnable_kind === 'script' && EVENT_TRIGGER_KINDS.has(t.trigger_kind)) {
+			out.add(scriptNodeId(t.runnable_path))
+		}
 	}
 	return out
 }

--- a/frontend/src/lib/components/assets/AssetGraph/boundedCascade.ts
+++ b/frontend/src/lib/components/assets/AssetGraph/boundedCascade.ts
@@ -44,8 +44,6 @@ export function assetUriToNodeId(uri: string): string | undefined {
 // Native trigger kinds that fan out *per event*: a single event always flows
 // through the whole reactive downstream, so "run up to X now" is not a
 // meaningful gesture and these are never offered as bounded-run starts.
-// `webhook`/`data_upload` have no trigger row in `/assets/graph`, so a root
-// whose only entry is one of those reads as a *manual* root below.
 const EVENT_TRIGGER_KINDS: ReadonlySet<string> = new Set<NativeTriggerKind>([
 	'kafka',
 	'mqtt',
@@ -54,6 +52,20 @@ const EVENT_TRIGGER_KINDS: ReadonlySet<string> = new Set<NativeTriggerKind>([
 	'sqs',
 	'gcp',
 	'email'
+])
+
+// Trigger kinds a cascade must NOT auto-run: the per-event kinds above PLUS the
+// input-only entrypoints `webhook`/`data_upload`, which need caller-supplied
+// input (a request body / an uploaded S3Object) and would run the wrong thing
+// with empty args. Mirror of the CLI `NON_AUTORUN_TRIGGER_KINDS`. When the
+// deployed `/assets/graph` omits a `webhook`/`data_upload` row (it has none for
+// them), such a script simply reads as a manual root here — but whenever the
+// marker IS visible (editor overlay / draft), it's excluded from bounded-run
+// starts and cut as a barrier, exactly as the CLI does.
+const NON_AUTORUN_TRIGGER_KINDS: ReadonlySet<string> = new Set<string>([
+	...EVENT_TRIGGER_KINDS,
+	'webhook',
+	'data_upload'
 ])
 
 export type LineageDag = {
@@ -244,35 +256,38 @@ export function validStarts(g: AssetGraphResponse): Set<string> {
  * read as manual roots and are already included.)
  */
 export function validFromStarts(g: AssetGraphResponse): Set<string> {
-	const eventScripts = new Set<string>()
+	const nonAutorunScripts = new Set<string>()
 	for (const t of g.triggers ?? []) {
 		if (t.runnable_kind !== 'script') continue
-		if (EVENT_TRIGGER_KINDS.has(t.trigger_kind)) eventScripts.add(t.runnable_path)
+		if (NON_AUTORUN_TRIGGER_KINDS.has(t.trigger_kind)) nonAutorunScripts.add(t.runnable_path)
 	}
 	// Seed with schedule/manual roots: `validStarts` lets a schedule identity win
-	// over a secondary event trigger, so a scheduled root that also carries e.g.
-	// a `// on kafka` stays `--from`-eligible even though it's an event script.
+	// over a secondary non-autorun trigger, so a scheduled root that also carries
+	// e.g. a `// on kafka` stays `--from`-eligible. The mid-DAG loop then adds only
+	// scripts that can run with empty args — a `webhook`/`data_upload` subscriber
+	// is NOT added (it needs caller-supplied input).
 	const out = new Set<string>(validStarts(g))
 	for (const r of g.runnables ?? []) {
 		if (r.usage_kind !== 'script') continue
-		if (!eventScripts.has(r.path)) out.add(scriptNodeId(r.path))
+		if (!nonAutorunScripts.has(r.path)) out.add(scriptNodeId(r.path))
 	}
 	return out
 }
 
 /**
- * Script node ids carrying an event trigger (kafka/mqtt/nats/postgres/sqs/gcp/
- * email) — they fan out per event and can't run with empty args, so a cascade
- * must cut them (as `barriers` for `reachableCutting`) even when they're a
- * lineage descendant of the start. Mirror of the CLI `nonAutorunTriggerScripts`,
- * minus `webhook`/`data_upload`: those have no trigger row in `/assets/graph`
- * so they can't be detected here and read as manual roots (same limitation as
- * `validStarts`).
+ * Script node ids carrying a non-autorun trigger (event kinds kafka/mqtt/…/email
+ * PLUS input-only webhook/data_upload) — they fan out per event or need
+ * caller-supplied input, so a cascade must cut them (as `barriers` for
+ * `reachableCutting`) even when they're a lineage descendant of the start.
+ * Mirror of the CLI `nonAutorunTriggerScripts`. Only detects what the graph
+ * surfaces: the deployed `/assets/graph` omits `webhook`/`data_upload` rows, so
+ * such a handler is only cut when its marker is visible (editor overlay / draft)
+ * — the same limitation as `validStarts`; the CLI closes it via graph enrichment.
  */
 export function nonAutorunTriggerScripts(g: AssetGraphResponse): Set<string> {
 	const out = new Set<string>()
 	for (const t of g.triggers ?? []) {
-		if (t.runnable_kind === 'script' && EVENT_TRIGGER_KINDS.has(t.trigger_kind)) {
+		if (t.runnable_kind === 'script' && NON_AUTORUN_TRIGGER_KINDS.has(t.trigger_kind)) {
 			out.add(scriptNodeId(t.runnable_path))
 		}
 	}

--- a/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
@@ -47,7 +47,6 @@
 		boundedSet,
 		buildLineageDag,
 		buildLineageDownstreamMap,
-		descendants,
 		isScriptNode,
 		nonAutorunTriggerScripts,
 		reachableCutting,
@@ -1525,9 +1524,6 @@
 
 	// Rebuilt only while a pick is active (cheap to skip otherwise).
 	let boundDag = $derived(boundPickStart ? buildLineageDag(displayGraph) : undefined)
-	let boundEligible = $derived(
-		boundDag && boundPickStart ? descendants(boundDag, boundPickStart) : new Set<string>()
-	)
 	let boundResult = $derived(
 		boundDag && boundPickStart
 			? boundedSet(boundDag, boundPickStart, [...boundPickEnds])
@@ -1545,17 +1541,23 @@
 				)
 			: new Set<string>()
 	)
-	// No end picked → "Run + downstream" (dbt `model+`): the start plus its full
-	// transitive downstream. Picking end(s) narrows it to the path-between set.
-	// Either way, intersect with the barrier-cut closure so an event descendant is
-	// never launched empty.
-	let boundScripts = $derived(
+	// Nodes pickable as end bounds: the barrier-cut downstream (excluding the
+	// start), NOT raw descendants — else an event handler or a node only reachable
+	// through one could be clicked as an end yet get silently dropped from the run.
+	let boundEligible = $derived(new Set([...boundReachable].filter((id) => id !== boundPickStart)))
+	// The actual run set (nodes, scripts + assets). No end picked → "Run +
+	// downstream" (dbt `model+`): the start plus its full transitive downstream.
+	// Picking end(s) narrows it to the path-between set. Either way, intersect with
+	// the barrier-cut closure so an event descendant is never launched empty. The
+	// canvas highlights exactly this set, so the ring matches what will run.
+	let boundRunNodes = $derived(
 		boundPickStart
 			? boundPickEnds.size === 0
-				? scriptsOf(boundReachable)
-				: scriptsOf([...(boundResult?.nodes ?? [])].filter((n) => boundReachable.has(n)))
-			: []
+				? boundReachable
+				: new Set([...(boundResult?.nodes ?? [])].filter((n) => boundReachable.has(n)))
+			: new Set<string>()
 	)
+	let boundScripts = $derived(scriptsOf(boundRunNodes))
 
 	// Engine id → canvas id: scripts keep `script:path`; assets gain the
 	// canvas's `asset:` prefix (AssetGraphCanvas node ids).
@@ -1573,7 +1575,7 @@
 					start: boundPickStart,
 					eligible: new Set([...boundEligible].map(toCanvasId)),
 					ends: new Set([...boundPickEnds].map(toCanvasId)),
-					bounded: new Set([...(boundResult?.nodes ?? [])].map(toCanvasId))
+					bounded: new Set([...boundRunNodes].map(toCanvasId))
 				}
 			: undefined
 	)

--- a/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
@@ -49,9 +49,11 @@
 		buildLineageDownstreamMap,
 		descendants,
 		isScriptNode,
+		nonAutorunTriggerScripts,
+		reachableCutting,
 		scriptNodeId,
 		scriptsOf,
-		validStarts
+		validFromStarts
 	} from '$lib/components/assets/AssetGraph/boundedCascade'
 	import {
 		diffDeployedGraph,
@@ -1510,7 +1512,11 @@
 	let boundPickEnds = $state<Set<string>>(new Set())
 
 	// Script paths eligible to start a bounded run, for the canvas menu gate.
-	let validStartPaths = $derived(new Set(scriptsOf(validStarts(displayGraph))))
+	// Any node with downstream — roots AND mid-DAG models — can be a "Run +
+	// downstream" start (dbt `model+`); only event-triggered scripts are excluded
+	// (see boundedCascade.validFromStarts). The canvas additionally requires the
+	// node to have lineage downstream before offering the entry.
+	let validStartPaths = $derived(new Set(scriptsOf(validFromStarts(displayGraph))))
 	// Scripts with read-aware downstream — the same gate the canvas applies
 	// (AssetGraphCanvas `hasLineageDownstream`). A valid start with no downstream
 	// has no end to pick, so the bounded-run entry is suppressed everywhere,
@@ -1527,7 +1533,29 @@
 			? boundedSet(boundDag, boundPickStart, [...boundPickEnds])
 			: undefined
 	)
-	let boundScripts = $derived(boundResult ? scriptsOf(boundResult.nodes) : [])
+	// Event handlers (kafka/mqtt/…) can't run with empty args, so they're cut from
+	// any cascade run — as is a consumer reachable only through one. The explicit
+	// start is protected (the user named it). Parity with the CLI `barriers` set.
+	let boundReachable = $derived(
+		boundDag && boundPickStart
+			? reachableCutting(
+					boundDag,
+					[boundPickStart],
+					new Set([...nonAutorunTriggerScripts(displayGraph)].filter((id) => id !== boundPickStart))
+				)
+			: new Set<string>()
+	)
+	// No end picked → "Run + downstream" (dbt `model+`): the start plus its full
+	// transitive downstream. Picking end(s) narrows it to the path-between set.
+	// Either way, intersect with the barrier-cut closure so an event descendant is
+	// never launched empty.
+	let boundScripts = $derived(
+		boundPickStart
+			? boundPickEnds.size === 0
+				? scriptsOf(boundReachable)
+				: scriptsOf([...(boundResult?.nodes ?? [])].filter((n) => boundReachable.has(n)))
+			: []
+	)
 
 	// Engine id → canvas id: scripts keep `script:path`; assets gain the
 	// canvas's `asset:` prefix (AssetGraphCanvas node ids).
@@ -2316,7 +2344,7 @@
 							<div class="flex flex-col leading-tight">
 								<span class="text-xs font-semibold text-emphasis">
 									{boundPickEnds.size === 0
-										? 'Click end node(s) to bound the run'
+										? `Run + all downstream · ${boundScripts.length} script${boundScripts.length === 1 ? '' : 's'} (click node(s) to bound)`
 										: `${boundScripts.length} script${boundScripts.length === 1 ? '' : 's'} up to ${boundPickEnds.size} end${boundPickEnds.size === 1 ? '' : 's'}`}
 								</span>
 								<span class="text-2xs text-tertiary">
@@ -2328,10 +2356,10 @@
 								variant="accent"
 								unifiedSize="sm"
 								startIcon={{ icon: Play }}
-								disabled={boundPickEnds.size === 0 || boundScripts.length === 0}
+								disabled={boundScripts.length === 0}
 								onclick={confirmBoundedRun}
 							>
-								Run selection
+								{boundPickEnds.size === 0 ? 'Run + downstream' : 'Run selection'}
 							</Button>
 						</div>
 					{/if}

--- a/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
@@ -52,7 +52,8 @@
 		reachableCutting,
 		scriptNodeId,
 		scriptsOf,
-		validFromStarts
+		validFromStarts,
+		validStarts
 	} from '$lib/components/assets/AssetGraph/boundedCascade'
 	import {
 		diffDeployedGraph,
@@ -1530,17 +1531,22 @@
 			: undefined
 	)
 	// Event handlers (kafka/mqtt/…) can't run with empty args, so they're cut from
-	// any cascade run — as is a consumer reachable only through one. The explicit
-	// start is protected (the user named it). Parity with the CLI `barriers` set.
-	let boundReachable = $derived(
-		boundDag && boundPickStart
-			? reachableCutting(
-					boundDag,
-					[boundPickStart],
-					new Set([...nonAutorunTriggerScripts(displayGraph)].filter((id) => id !== boundPickStart))
-				)
-			: new Set<string>()
-	)
+	// any cascade run — as is a consumer reachable only through one. But a
+	// scheduled/manual root is NEVER a barrier even if it also carries an event
+	// trigger: it runs on its own schedule/manual identity (schedule wins in
+	// validStarts), so it — and its downstream — stay reachable when running from
+	// an upstream start. The explicit start is likewise protected. Parity with the
+	// CLI `barriers` set (`nonAutorunTriggerScripts` minus `starts` minus start).
+	let boundReachable = $derived.by(() => {
+		if (!boundDag || !boundPickStart) return new Set<string>()
+		const roots = validStarts(displayGraph)
+		const barriers = new Set(
+			[...nonAutorunTriggerScripts(displayGraph)].filter(
+				(id) => !roots.has(id) && id !== boundPickStart
+			)
+		)
+		return reachableCutting(boundDag, [boundPickStart], barriers)
+	})
 	// Nodes pickable as end bounds: the barrier-cut downstream (excluding the
 	// start), NOT raw descendants — else an event handler or a node only reachable
 	// through one could be clicked as an end yet get silently dropped from the run.

--- a/system_prompts/auto-generated/cli/cli-commands.md
+++ b/system_prompts/auto-generated/cli/cli-commands.md
@@ -420,8 +420,8 @@ inspect asset-driven pipelines (scripts marked `// pipeline`, wired by `// on <s
 - `pipeline show <folder:string>` - render a pipeline folder's DAG (sources, lineage, subscriptions) in the terminal
   - `--json` - Output the raw asset graph as JSON
   - `--local` - Build the graph from local working-tree files (// pipeline scripts) instead of the deployed workspace — no deploy needed.
-- `pipeline run <folder:string>` - run a bounded cascade: from a schedule/manual root, fan downstream up to the --to end node(s)
-  - `--from <script:string>` - Start script (short name or path). Defaults to the folder's sole schedule/manual root.
+- `pipeline run <folder:string>` - run a cascade: from --from (a root OR any mid-DAG model), fan downstream up to the --to end node(s)
+  - `--from <script:string>` - Start script (short name or path). May be any node, including a mid-DAG model — that node plus its transitive downstream runs, upstream is NOT re-run (dbt `--select model+`). Defaults to the folder's sole schedule/manual root.
   - `--to <node:string>` - End node(s) to stop at — script names/paths or asset URIs (e.g. datatable://main/staged). Repeatable or comma-separated. Omit to run the full downstream.
   - `--dry-run` - Print the topological run plan without executing.
   - `--json` - Output the plan as JSON (for piping to jq).

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -3096,8 +3096,8 @@ inspect asset-driven pipelines (scripts marked \`// pipeline\`, wired by \`// on
 - \`pipeline show <folder:string>\` - render a pipeline folder's DAG (sources, lineage, subscriptions) in the terminal
   - \`--json\` - Output the raw asset graph as JSON
   - \`--local\` - Build the graph from local working-tree files (// pipeline scripts) instead of the deployed workspace — no deploy needed.
-- \`pipeline run <folder:string>\` - run a bounded cascade: from a schedule/manual root, fan downstream up to the --to end node(s)
-  - \`--from <script:string>\` - Start script (short name or path). Defaults to the folder's sole schedule/manual root.
+- \`pipeline run <folder:string>\` - run a cascade: from --from (a root OR any mid-DAG model), fan downstream up to the --to end node(s)
+  - \`--from <script:string>\` - Start script (short name or path). May be any node, including a mid-DAG model — that node plus its transitive downstream runs, upstream is NOT re-run (dbt \`--select model+\`). Defaults to the folder's sole schedule/manual root.
   - \`--to <node:string>\` - End node(s) to stop at — script names/paths or asset URIs (e.g. datatable://main/staged). Repeatable or comma-separated. Omit to run the full downstream.
   - \`--dry-run\` - Print the topological run plan without executing.
   - \`--json\` - Output the plan as JSON (for piping to jq).

--- a/system_prompts/auto-generated/skills/cli-commands/SKILL.md
+++ b/system_prompts/auto-generated/skills/cli-commands/SKILL.md
@@ -425,8 +425,8 @@ inspect asset-driven pipelines (scripts marked `// pipeline`, wired by `// on <s
 - `pipeline show <folder:string>` - render a pipeline folder's DAG (sources, lineage, subscriptions) in the terminal
   - `--json` - Output the raw asset graph as JSON
   - `--local` - Build the graph from local working-tree files (// pipeline scripts) instead of the deployed workspace — no deploy needed.
-- `pipeline run <folder:string>` - run a bounded cascade: from a schedule/manual root, fan downstream up to the --to end node(s)
-  - `--from <script:string>` - Start script (short name or path). Defaults to the folder's sole schedule/manual root.
+- `pipeline run <folder:string>` - run a cascade: from --from (a root OR any mid-DAG model), fan downstream up to the --to end node(s)
+  - `--from <script:string>` - Start script (short name or path). May be any node, including a mid-DAG model — that node plus its transitive downstream runs, upstream is NOT re-run (dbt `--select model+`). Defaults to the folder's sole schedule/manual root.
   - `--to <node:string>` - End node(s) to stop at — script names/paths or asset URIs (e.g. datatable://main/staged). Repeatable or comma-separated. Omit to run the full downstream.
   - `--dry-run` - Print the topological run plan without executing.
   - `--json` - Output the plan as JSON (for piping to jq).


### PR DESCRIPTION
## Summary

Adds **mid-DAG selective execution** to Windmill data pipelines. Previously `wmill pipeline run <folder> --from <node>` required `<node>` to be a schedule/manual **root** — it rejected `--from fct_orders_daily` with *"Starts must be schedule-triggered or manual roots"*. So dbt's most common gesture — rebuild a mid-DAG model **and** everything downstream (`dbt run --select model+`) — had no form.

Now `--from` accepts **any autorun-able script**, including a mid-DAG asset subscriber or pure reader. A mid-DAG start runs that node **plus its transitive downstream** and **never re-runs upstream**:

```
wmill pipeline run f/orders --from fct_orders_daily      # = dbt run --select fct_orders_daily+
```

![selective-exec-diagram](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/feat/pipeline-selective-exec/1783286361-selective-exec-diagram.png)

The bounded-run engine already computed downstream / path-between sets generically; only the eligibility *gate* was root-only. Relaxing it is purely additive — root behavior is unchanged, and event/input-only handlers (kafka/mqtt/…/webhook/data_upload) that can't run with empty args stay excluded unless `--upload`-bound.

## Changes

**Shared engine** (`boundedCascade.ts` — CLI + frontend mirror)
- Add `validFromStarts(g)`: every script that can run with empty args (roots **and** mid-DAG subscribers/readers), excluding only non-autorun-trigger handlers. `validStarts` (roots only) stays a subset, still used for implicit-start / whole-pipeline resolution.

**CLI** (`cli/src/commands/pipeline/pipeline.ts`)
- `--from` accepts any `validFromStarts` node. Asset `--from` and non-autorun handlers get distinct, actionable errors (the latter runnable via `--upload`).
- An explicit mid-DAG `--from` is protected from the barrier cut (`id !== start`), so a start that also carries a non-autorun trigger still runs.
- Updated `run` command + `--from` help text; regenerated `system_prompts/` (`generate.py`) so the agent-facing CLI docs match.

**Frontend graph UI parity** (`+page.svelte`, `RunnableNode.svelte`, `TriggerNode.svelte`, `AssetGraphCanvas.svelte`)
- Any node with downstream now offers **"Run + downstream…"** (was roots-only). With no end picked, the bounded-run bar runs the full downstream closure (`model+`); picking end(s) still bounds the path-between set.
- Ported `reachableCutting` + `nonAutorunTriggerScripts` to the frontend engine and applied the **barrier cut** to the run set (both the new no-ends path and the pre-existing bounded path), so an event-triggered descendant is never launched with empty args — closing a CLI/UI parity gap flagged in review.

**Tests**
- New unit tests in both engines for `validFromStarts` (mid-DAG eligibility, event exclusion, downstream-not-upstream) and the frontend `reachableCutting` barrier cut.

## Screenshots

Seeded a `stg_orders → raw → fct_orders_daily → orders → report` pipeline (`fct_orders_daily` is a mid-DAG **asset subscriber**, not a root) and verified on the running dev server.

Pipeline graph:

![pipeline-graph](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/feat/pipeline-selective-exec/1783286361-pipeline-graph.png)

The mid-DAG node `fct_orders_daily` now shows the split run pill with the **"Run + downstream" caret** — it has no subscriber cascade (its only downstream `report` is a pure reader), so the caret can only be present because `validFromStarts` now includes it:

![pipeline-caret-pill](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/feat/pipeline-selective-exec/1783286361-pipeline-caret-pill.png)

Reproduced on a fresh load (edit mode, per-node run-pill button counts): root `stg_orders` → 4 buttons **+caret**, mid-DAG `fct_orders_daily` → 4 buttons **+caret** (the new capability), leaf `report` → 3 buttons **no caret**.

## Test plan
- [x] CLI unit tests — `bun test` (916 pass, incl. new `validFromStarts` / mid-DAG selection tests)
- [x] Frontend unit tests — `vitest` AssetGraph suite (194 pass, incl. new `validFromStarts` + barrier-cut parity tests)
- [x] `npm run check:fast` — no problems
- [x] Runtime: mid-DAG node gains the "Run + downstream" caret; leaf node does not (screenshots above)
- [ ] Reviewer sanity: `--from <asset-uri>` and `--from <kafka-script>` produce the two distinct new error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add mid-DAG selective execution for pipelines so you can start a run from any model and run it plus all downstream without re-running upstream. Matches dbt `model+` in the CLI and graph UI, with barrier-aware selection.

- **New Features**
  - CLI: `wmill pipeline run <folder> --from <node>` accepts any autorun script (roots, mid-DAG subscribers, pure readers). Assets are rejected; event/webhook/data_upload require `--upload`. Help text updated.
  - Engine: added `validFromStarts` and a barrier cut so non-autorun-trigger descendants are skipped; an explicit `--from` start is protected even if it carries a non-autorun trigger.
  - Frontend: “Run + downstream…” on any node with downstream. No end picks run full downstream; picked ends bound the path-between set. Barrier cut applied to the run set.

- **Bug Fixes**
  - CLI/Engine: `validFromStarts` now unions `validStarts`, so a scheduled root with a secondary non-autorun trigger stays `--from`-eligible. Tests added in both engines.
  - Frontend: pick mode now builds eligible end nodes from the barrier-cut closure, and the highlighted ring matches the actual (barrier-cut) run set. The barrier set excludes all valid roots, not just the picked start, matching the CLI; scheduled-event roots and their downstream stay reachable.
  - Frontend: `webhook`/`data_upload` mid-DAG subscribers are excluded as autorun starts and cut as barriers when visible, matching the CLI. Regression tests added.

<sup>Written for commit 7ba9a613aa5c6eacd25a4ad9b5bb92d4168abe3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

