### PR TITLE
fix: windows bun loader misses extensionless relative imports in main.ts

### DIFF
--- a/backend/windmill-worker/loader.bun.windows.js
+++ b/backend/windmill-worker/loader.bun.windows.js
@@ -32,7 +32,11 @@ const p = {
 
     let cdirNodeModules = `${cdirFwd}/node_modules/`;
 
-    const filterLoad = new RegExp(`^${cdir}\/main\\.ts$`);
+    // Match the entry main.ts against bun's forward-slash resolver output on
+    // Windows — raw `cdir` carries backslashes that corrupt the regex, so the
+    // onLoad below would never fire and extensionless relative imports in
+    // main.ts would slip past filterResolve unrewritten.
+    const filterLoad = new RegExp(`^(?:${cdirFwd}|${cdirPosix})\/main\\.ts$`);
     const transpiler = new Bun.Transpiler({
       loader: "ts",
     });


### PR DESCRIPTION
## Summary

The **Backend integration tests (Windows)** CI check has failed on every release since **v1.748.0/1.747.0/1.746.0** (v1.745.0 was the last green run). The failing test is `test_bun_transitive_import_change_rebundles` (`backend/tests/bun_jobs.rs`), added by #9891, with:

```
error: Could not resolve: "./mid"   at ...\main.ts:1:26
Failed to build node bundle
```

### Root cause

Latent bug in the Windows-only bun loader plugin (`backend/windmill-worker/loader.bun.windows.js`):

- On Windows, bun's resolver feeds the plugin **forward-slash** paths. The loader is written for this — it normalizes `cdir` to `cdirFwd`/`cdirPosix` for the `filterResolve` regex and the node_modules guard.
- But `filterLoad` (which gates the `onLoad` for `main.ts`) still used the raw `cdir`, which on Windows contains **backslashes**. Interpolated into a `RegExp`, those backslashes become regex escapes (`\U`, `\A`, `\s`, …), corrupting the pattern so it never matches the forward-slash entrypoint path.
- Consequence: the `main.ts` `onLoad` never fires, so `replaceRelativeImports` never appends `.ts` to **extensionless** relative imports. `./mid` then slips past `filterResolve` (which requires `.ts$`), bun's default resolver runs, and it can't find `./mid` on disk (it's a deployed script fetched via the `windmill-url` namespace).

This stayed invisible until #9891 because that test is the first to use an **extensionless** relative import inside `main.ts`. The existing `test_bun_shared_imports_both_styles` uses `.ts` extensions, so it doesn't rely on `replaceRelativeImports` and passes on Windows — which also confirms bun feeds the loader forward-slash paths.

## Changes

- Rebuild `filterLoad` from the already-normalized `cdirFwd`/`cdirPosix` (mirroring the sibling `filterResolve` regex) so it matches bun's Windows entrypoint path form and the `main.ts` `onLoad` fires.

## Test plan

- [ ] Windows CI: `Backend integration tests (Windows)` — `test_bun_transitive_import_change_rebundles` passes.
- [ ] Confirmed regex behavior with a node simulation: raw-`cdir` pattern does not match `C:/…/main.ts`; the `cdirFwd`/`cdirPosix` pattern matches both drive-prefixed and drive-stripped forms.
- [ ] Change is confined to the `#[cfg(windows)]` loader — Linux/macOS behavior unaffected (Linux CI already green for this test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Windows-only Bun loader so `main.ts` is matched and extensionless relative imports are rewritten. This restores the failing Windows backend test run.

- **Bug Fixes**
  - Rebuilt `filterLoad` to use forward-slash paths (`cdirFwd`/`cdirPosix`) so it matches Bun’s Windows resolver and triggers `onLoad` for `main.ts`.
  - Restores `.ts` suffix injection for imports like `./mid`, fixing `test_bun_transitive_import_change_rebundles`; Linux/macOS unaffected.

<sup>Written for commit 5587529f0a606836a8a8ca9a41c9af70ca6b5a7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

