### PR TITLE
fix(cli): HD-1 test_edges + HD-2 scd2 _current write in --local pipeline graph

### DIFF
--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -19,7 +19,7 @@
         "pg-gateway": "0.3.0-beta.4",
         "svelte": "^5.45.2",
         "tar-stream": "^3.1.7",
-        "windmill-parser-wasm-asset": "1.740.0",
+        "windmill-parser-wasm-asset": "1.749.0",
         "windmill-parser-wasm-csharp": "1.510.1",
         "windmill-parser-wasm-go": "1.510.1",
         "windmill-parser-wasm-java": "1.510.1",
@@ -290,7 +290,7 @@
 
     "utility-types": ["utility-types@3.11.0", "", {}, "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw=="],
 
-    "windmill-parser-wasm-asset": ["windmill-parser-wasm-asset@1.740.0", "", {}, "sha512-Dgn5sQ93vJpqTQkv9iAy25+bqH2bUnIMdCfERb2Tia0Ql9T6iHbQhi4yzH9FbGW4Drv9GP46Qyetphqvp8vFOw=="],
+    "windmill-parser-wasm-asset": ["windmill-parser-wasm-asset@1.749.0", "", {}, "sha512-gj8g9sWQ0tXKfXso7xJxR56sS8Loe/RsnFy+0af5R8siZeCag9ikquGbQ8d8kOqIK2U8eCNA0LqsU/xAFDJIOg=="],
 
     "windmill-parser-wasm-csharp": ["windmill-parser-wasm-csharp@1.510.1", "", {}, "sha512-qm09YmnbeYHLwYn1jUnObVzPhYO9NZKMlIO7nlo7zPJBXqksgG5fK/KCtwGw9rChrnz+DsvM9wP5FhrwRLMtwQ=="],
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -20,7 +20,7 @@
         "pg-gateway": "0.3.0-beta.4",
         "svelte": "^5.45.2",
         "tar-stream": "^3.1.7",
-        "windmill-parser-wasm-asset": "1.740.0",
+        "windmill-parser-wasm-asset": "1.749.0",
         "windmill-parser-wasm-csharp": "1.510.1",
         "windmill-parser-wasm-go": "1.510.1",
         "windmill-parser-wasm-java": "1.510.1",
@@ -1412,9 +1412,9 @@
       }
     },
     "node_modules/windmill-parser-wasm-asset": {
-      "version": "1.740.0",
-      "resolved": "https://registry.npmjs.org/windmill-parser-wasm-asset/-/windmill-parser-wasm-asset-1.740.0.tgz",
-      "integrity": "sha512-Dgn5sQ93vJpqTQkv9iAy25+bqH2bUnIMdCfERb2Tia0Ql9T6iHbQhi4yzH9FbGW4Drv9GP46Qyetphqvp8vFOw=="
+      "version": "1.749.0",
+      "resolved": "https://registry.npmjs.org/windmill-parser-wasm-asset/-/windmill-parser-wasm-asset-1.749.0.tgz",
+      "integrity": "sha512-gj8g9sWQ0tXKfXso7xJxR56sS8Loe/RsnFy+0af5R8siZeCag9ikquGbQ8d8kOqIK2U8eCNA0LqsU/xAFDJIOg=="
     },
     "node_modules/windmill-parser-wasm-csharp": {
       "version": "1.510.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -28,7 +28,7 @@
     "pg-gateway": "0.3.0-beta.4",
     "svelte": "^5.45.2",
     "tar-stream": "^3.1.7",
-    "windmill-parser-wasm-asset": "1.740.0",
+    "windmill-parser-wasm-asset": "1.749.0",
     "windmill-parser-wasm-csharp": "1.510.1",
     "windmill-parser-wasm-go": "1.510.1",
     "windmill-parser-wasm-java": "1.510.1",

--- a/cli/src/commands/pipeline/boundedCascade.ts
+++ b/cli/src/commands/pipeline/boundedCascade.ts
@@ -41,6 +41,18 @@ export type BCGraph = {
       }
     | { trigger_kind: string; runnable_kind: string; runnable_path: string }
   )[];
+  // `// data_test` ordering edges (HD-1): the referenced asset's producer must
+  // materialize before the tested script runs. Fed into the lineage DAG so a
+  // bounded/cold cascade orders the referenced dimension first. Optional — the
+  // deployed graph omits it when empty, and older local graphs never emit it.
+  test_edges?: {
+    producer_kind: string;
+    producer_path: string;
+    runnable_kind: string;
+    runnable_path: string;
+    asset_kind: string;
+    asset_path: string;
+  }[];
 };
 
 export const SCRIPT_PREFIX = "script:";
@@ -117,6 +129,14 @@ export function buildLineageDag(g: BCGraph): LineageDag {
     if (t.trigger_kind !== "asset" || t.runnable_kind !== "script") continue;
     const at = t as Extract<BCGraph["triggers"][number], { trigger_kind: "asset" }>;
     addEdge(dag, assetNodeId(at.asset_kind, at.asset_path), scriptNodeId(at.runnable_path));
+  }
+  // Data-test ordering edges: route through the referenced asset node so the
+  // existing producer → asset write edge extends into producer → asset → testing
+  // script (mirrors frontend boundedCascade.ts) — the tested script runs after
+  // the referenced dimension materializes.
+  for (const t of g.test_edges ?? []) {
+    if (t.runnable_kind !== "script") continue;
+    addEdge(dag, assetNodeId(t.asset_kind, t.asset_path), scriptNodeId(t.runnable_path));
   }
   return dag;
 }

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -388,10 +388,11 @@ function parseVolumeAnnotations(
 }
 
 // Infer a single script's assets + pipeline annotations. Returns the raw
-// `ParseAssetsOutput` (incl. `materialize`, which the wasm asset parser emits as
-// of windmill-parser-wasm-asset 1.740.0 — kept in lockstep with the frontend's
-// pin so the local graph mirrors the deployed one), plus `volume:` annotation
-// assets the wasm doesn't surface (merged in below, like the frontend/backend).
+// `ParseAssetsOutput` (incl. `materialize` with its `scd2` flag, which the wasm
+// asset parser emits as of windmill-parser-wasm-asset 1.749.0 — kept in lockstep
+// with the frontend's pin so the local graph mirrors the deployed one), plus
+// `volume:` annotation assets the wasm doesn't surface (merged in below, like
+// the frontend/backend).
 // wasm parse errors degrade to the annotation fallback so a syntactically-broken
 // script still shows as a pipeline node if it's annotated.
 export async function inferScriptAssets(
@@ -497,13 +498,7 @@ export async function buildLocalPipelineGraph(args: {
   root: string;
   folder: string;
   defaultTs?: "bun" | "deno";
-  // Injectable asset inferrer (defaults to the wasm-backed `inferScriptAssets`).
-  // The pinned `windmill-parser-wasm-asset` (1.740.0) predates the `scd2`
-  // materialize flag, so tests inject a parser to exercise the scd2 `<dim>_current`
-  // companion-write branch until a wasm carrying `scd2` is republished (cf. #9926).
-  infer?: (content: string, language: string) => Promise<ParseAssetsRaw>;
 }): Promise<{ graph: AssetGraph; scripts: LocalScript[] }> {
-  const infer = args.infer ?? inferScriptAssets;
   const folderClean = args.folder.replace(/^f\//, "").replace(/\/$/, "");
   const folderDir = path.join(args.root, "f", folderClean);
   const all = await collectScripts(folderDir, args.root, args.defaultTs);
@@ -532,7 +527,7 @@ export async function buildLocalPipelineGraph(args: {
   const readsByRunnable = new Map<string, { kind: string; path: string }[]>();
 
   for (const s of all) {
-    const out = await infer(s.content, s.language);
+    const out = await inferScriptAssets(s.content, s.language);
     const reads = (out.assets ?? [])
       .filter(
         (a) =>

--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -71,6 +71,23 @@ export type GraphEdge = {
   asset_path: string;
   access_type?: "r" | "w" | "rw";
 };
+// Ordering-only "must-run-after" edge (HD-1): a `// data_test relationships`
+// (or, best-effort, a custom `// data_test <script>` whose body reads an
+// in-pipeline asset) needs the referenced asset's producer to materialize before
+// the tested script runs — a dependency otherwise absent from the DAG, so a cold
+// cascade could run the tested script first and hard-fail. Synthesized locally
+// from the parsed `data_tests` + write edges; mirrors the deployed graph's
+// `test_edges` (backend `asset_graph`) so `--local` orders a cold cascade the
+// same way. Only emitted when the referenced asset has an in-pipeline producer;
+// an external table (no producer) adds no edge. NOT a data-consumption edge.
+export type GraphTestEdge = {
+  producer_kind: string;
+  producer_path: string;
+  runnable_kind: string;
+  runnable_path: string;
+  asset_kind: string;
+  asset_path: string;
+};
 export type GraphTrigger =
   | {
       trigger_kind: "asset";
@@ -103,6 +120,10 @@ export type AssetGraph = {
     macro_names: string[];
     via_use?: boolean;
   }[];
+  // `// data_test` ordering edges (HD-1); present on both the deployed graph and
+  // this local one. Absent when empty (matches the deployed graph's
+  // `skip_serializing_if = Vec::is_empty`).
+  test_edges?: GraphTestEdge[];
 };
 
 export type LocalScript = {
@@ -118,7 +139,25 @@ export type LocalScript = {
 // `ParseAssetsOutput`). `triggers` is internally tagged on `kind`
 // (`#[serde(tag = "kind", rename_all = "lowercase")]`): asset triggers carry
 // `asset_kind` + `path`; native triggers are bare `{ kind }`.
-type ParseAssetsRaw = {
+// One parsed `// data_test` entry (serialized Rust `DataTest`, tagged on `type`).
+// A proper discriminated union over the five built-ins so a `dt.type` switch
+// narrows; only `relationships` / `custom` carry a cross-asset ref that the
+// local test-edge synthesis reads. Kept structurally identical to the wasm
+// output and the deployed graph's `data_tests`.
+export type ParsedDataTest =
+  | { type: "unique"; column: string }
+  | { type: "not_null"; column: string }
+  | { type: "accepted_values"; column: string; values: string[] }
+  | {
+      type: "relationships";
+      column: string;
+      to_kind: string;
+      to_path: string;
+      to_column: string;
+    }
+  | { type: "custom"; path: string };
+
+export type ParseAssetsRaw = {
   assets?: {
     kind: string;
     path: string;
@@ -148,7 +187,7 @@ type ParseAssetsRaw = {
   partition?: { kind: string };
   freshness?: { duration: string };
   retry?: { count: number; delay?: string };
-  data_tests?: unknown[];
+  data_tests?: ParsedDataTest[];
   column_lineage?: unknown[];
 };
 
@@ -458,7 +497,13 @@ export async function buildLocalPipelineGraph(args: {
   root: string;
   folder: string;
   defaultTs?: "bun" | "deno";
+  // Injectable asset inferrer (defaults to the wasm-backed `inferScriptAssets`).
+  // The pinned `windmill-parser-wasm-asset` (1.740.0) predates the `scd2`
+  // materialize flag, so tests inject a parser to exercise the scd2 `<dim>_current`
+  // companion-write branch until a wasm carrying `scd2` is republished (cf. #9926).
+  infer?: (content: string, language: string) => Promise<ParseAssetsRaw>;
 }): Promise<{ graph: AssetGraph; scripts: LocalScript[] }> {
+  const infer = args.infer ?? inferScriptAssets;
   const folderClean = args.folder.replace(/^f\//, "").replace(/\/$/, "");
   const folderDir = path.join(args.root, "f", folderClean);
   const all = await collectScripts(folderDir, args.root, args.defaultTs);
@@ -479,9 +524,24 @@ export async function buildLocalPipelineGraph(args: {
   // trigger (processed after the producer) can't clobber the derived marker.
   const derivedFromByKey = new Map<string, string>();
   const pipelineScripts: LocalScript[] = [];
+  // For HD-1 test edges: a pipeline member's parsed `// data_test`s, and the
+  // assets each script READS (any script, so a custom test resolves against a
+  // non-member test script's reads — best-effort, mirroring the backend, which
+  // resolves custom tests against every deployed runnable's asset usages).
+  const dataTestsByPath = new Map<string, ParsedDataTest[]>();
+  const readsByRunnable = new Map<string, { kind: string; path: string }[]>();
 
   for (const s of all) {
-    const out = await inferScriptAssets(s.content, s.language);
+    const out = await infer(s.content, s.language);
+    const reads = (out.assets ?? [])
+      .filter(
+        (a) =>
+          a.access_type == null ||
+          a.access_type === "r" ||
+          a.access_type === "rw",
+      )
+      .map((a) => ({ kind: a.kind, path: a.path }));
+    if (reads.length > 0) readsByRunnable.set(s.path, reads);
     // A `// macros` library is a pipeline-member node carrying its macro
     // signatures — whether or not any consumer uses it — matching the deployed
     // graph, which marks every macro library `auto_kind='pipeline'`. It is
@@ -503,6 +563,9 @@ export async function buildLocalPipelineGraph(args: {
       continue;
     }
     if (!out.in_pipeline) continue; // not a pipeline member
+    if (out.data_tests && out.data_tests.length > 0) {
+      dataTestsByPath.set(s.path, out.data_tests);
+    }
     const retry = normalizeRetry(out.retry);
     const nativeTriggers = recoverHeaderNativeTriggers(s.content, s.language);
     // Carry the parsed `// tag` so previews route to the same worker the
@@ -631,6 +694,8 @@ export async function buildLocalPipelineGraph(args: {
 
   const macroEdges = buildMacroEdges(all, libMacros, runnables);
 
+  const testEdges = buildTestEdges(dataTestsByPath, readsByRunnable, edges);
+
   const assets = [...assetSet.entries()].map(([key, a]) => {
     const derived_from = a.derived_from ?? derivedFromByKey.get(key);
     return derived_from ? { ...a, derived_from } : a;
@@ -643,9 +708,81 @@ export async function buildLocalPipelineGraph(args: {
       edges,
       triggers,
       ...(macroEdges.length > 0 ? { macro_edges: macroEdges } : {}),
+      ...(testEdges.length > 0 ? { test_edges: testEdges } : {}),
     },
     scripts: pipelineScripts,
   };
+}
+
+// Synthesize HD-1 ordering edges from parsed `// data_test`s. Ports backend
+// `asset_graph` (windmill-api-assets): resolve each test's referenced asset(s)
+// to their in-pipeline producer(s) via the write edges, and add an ordering-only
+// producer → tested-script edge. A `relationships` test references its `to_path`
+// asset directly; a `custom` test references the tested/other script's parsed
+// reads (best-effort). Self-edges (a script testing its own output) and assets
+// with no in-pipeline producer are dropped, exactly like the backend.
+function buildTestEdges(
+  dataTestsByPath: Map<string, ParsedDataTest[]>,
+  readsByRunnable: Map<string, { kind: string; path: string }[]>,
+  edges: GraphEdge[],
+): GraphTestEdge[] {
+  const producersByAsset = new Map<string, { kind: string; path: string }[]>();
+  for (const e of edges) {
+    if (e.access_type !== "w" && e.access_type !== "rw") continue;
+    // `\u0000` as the (kind, path) separator: it can't occur in an asset path,
+    // so no packed key can collide.
+    const key = `${e.asset_kind}\u0000${e.asset_path}`;
+    (producersByAsset.get(key) ?? producersByAsset.set(key, []).get(key)!).push({
+      kind: e.runnable_kind,
+      path: e.runnable_path,
+    });
+  }
+
+  const out: GraphTestEdge[] = [];
+  // Dedup on (producer, tested_script, asset) so repeated tests / producers
+  // referencing the same asset yield one edge (mirrors the backend's set).
+  const seen = new Set<string>();
+  for (const [memberPath, dts] of dataTestsByPath) {
+    for (const dt of dts) {
+      let referenced: { kind: string; path: string }[] = [];
+      if (dt.type === "relationships") {
+        referenced = [{ kind: dt.to_kind, path: dt.to_path }];
+      } else if (dt.type === "custom") {
+        // The custom test script's own parsed reads. Reading the member's OWN
+        // output resolves to the member as producer and is dropped below.
+        referenced = readsByRunnable.get(dt.path) ?? [];
+      }
+      for (const ref of referenced) {
+        const producers = producersByAsset.get(`${ref.kind}\u0000${ref.path}`);
+        if (!producers) continue; // external table (no producer) ⇒ no edge
+        for (const p of producers) {
+          // Skip a self-edge: the tested script produces the asset it tests.
+          if (p.kind === "script" && p.path === memberPath) continue;
+          const key = [p.path, memberPath, ref.kind, ref.path].join("\u0000");
+          if (seen.has(key)) continue;
+          seen.add(key);
+          out.push({
+            producer_kind: p.kind,
+            producer_path: p.path,
+            runnable_kind: "script",
+            runnable_path: memberPath,
+            asset_kind: ref.kind,
+            asset_path: ref.path,
+          });
+        }
+      }
+    }
+  }
+  // Deterministic order for stable `--json` output (the deployed graph iterates
+  // an unordered map; the local one sorts so snapshots don't churn).
+  out.sort(
+    (a, b) =>
+      a.producer_path.localeCompare(b.producer_path) ||
+      a.runnable_path.localeCompare(b.runnable_path) ||
+      a.asset_kind.localeCompare(b.asset_kind) ||
+      a.asset_path.localeCompare(b.asset_path),
+  );
+  return out;
 }
 
 // Every `// macros` DuckDB library in the workspace, keyed by its windmill path,

--- a/cli/test/pipeline_local_graph_unit.test.ts
+++ b/cli/test/pipeline_local_graph_unit.test.ts
@@ -3,10 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import {
-  buildLocalPipelineGraph,
-  inferScriptAssets,
-} from "../src/commands/pipeline/localGraph.ts";
+import { buildLocalPipelineGraph } from "../src/commands/pipeline/localGraph.ts";
 
 // Build a throwaway workspace tree with `f/<folder>/<file>` scripts and a
 // wmill.yaml at the root, then assert the graph the wasm-backed builder derives.
@@ -239,18 +236,12 @@ test("HD-1: a custom `// data_test <script>` whose body reads an in-pipeline ass
   );
 });
 
-// The scd2 `<dim>_current` companion-view write edge (HD-2) can't be driven by
-// the pinned `windmill-parser-wasm-asset` (1.740.0), which predates the `scd2`
-// materialize flag, so we inject a parser that re-adds `scd2` for a `history`
-// materialize — exactly what a republished wasm will emit (cf. #9926) — and let
-// the real (already-shipped) companion-write branch assemble the graph.
-async function inferWithScd2(content: string, language: string) {
-  const out = await inferScriptAssets(content, language);
-  if (out.materialize && /\bhistory\b/.test(content)) out.materialize.scd2 = true;
-  return out;
-}
-
 test("HD-2: an scd2 `history` producer writes both `<dim>` and `<dim>_current` so a `_current` reader resolves to it", async () => {
+  // Managed `// materialize … history` (scd2) also produces a `<dim>_current`
+  // companion view (backend `MaterializeSpec::write_targets`). The wasm asset
+  // parser emits the `scd2` flag; the local builder must add the second write
+  // edge and mark the view `derived_from` its base dimension so a consumer
+  // reading only the view links back to the producer instead of orphaning.
   await withFolder(
     {
       "dim.duckdb.sql":
@@ -264,7 +255,6 @@ test("HD-2: an scd2 `history` producer writes both `<dim>` and `<dim>_current` s
         root,
         folder,
         defaultTs: "bun",
-        infer: inferWithScd2,
       });
 
       // the producer carries BOTH write edges (base dim + `_current` companion)

--- a/cli/test/pipeline_local_graph_unit.test.ts
+++ b/cli/test/pipeline_local_graph_unit.test.ts
@@ -3,7 +3,10 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { buildLocalPipelineGraph } from "../src/commands/pipeline/localGraph.ts";
+import {
+  buildLocalPipelineGraph,
+  inferScriptAssets,
+} from "../src/commands/pipeline/localGraph.ts";
 
 // Build a throwaway workspace tree with `f/<folder>/<file>` scripts and a
 // wmill.yaml at the root, then assert the graph the wasm-backed builder derives.
@@ -143,14 +146,159 @@ test("`// materialize <asset>` producer connects to its `// on` consumer", async
   );
 });
 
-// NOTE: the scd2 `<dim>_current` companion-view write edge (buildLocalPipelineGraph)
-// is exercised end-to-end by the backend parser test
-// (`materialize_scd2_write_targets_include_current_view`) and the frontend
-// live-graph test (`resolveGraph.test.ts` — "scd2 materialize draft"). It has no
-// unit test here because it depends on the `scd2` flag emitted by the bundled
-// `windmill-parser-wasm-asset`, which lags the source (the vendored build
-// predates the scd2 fields); the branch activates once a wasm carrying `scd2` is
-// republished (cf. the wasm-publish plumbing in #9926).
+test("HD-1: `// data_test relationships` adds a producer → tested-script ordering edge", async () => {
+  // Mirror of the deployed graph's `test_edges` (backend `asset_graph`): the
+  // referenced dimension's in-pipeline producer must materialize before the
+  // tested script runs, so a cold cascade orders it first. The wasm emits the
+  // parsed `relationships` test; the local builder resolves its producer.
+  await withFolder(
+    {
+      "dim_customers.duckdb.sql":
+        `-- pipeline\n-- materialize ducklake://main/dim_customers\nSELECT 1 AS id;\n`,
+      "fct_orders_daily.duckdb.sql":
+        `-- pipeline\n-- on ducklake://main/orders\n-- data_test relationships customer_id -> ducklake://main/dim_customers.id\nSELECT customer_id FROM main.orders;\n`,
+    },
+    async (root, folder) => {
+      const { graph } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+      expect(graph.test_edges).toEqual([
+        {
+          producer_kind: "script",
+          producer_path: "f/mypipe/dim_customers",
+          runnable_kind: "script",
+          runnable_path: "f/mypipe/fct_orders_daily",
+          asset_kind: "ducklake",
+          asset_path: "main/dim_customers",
+        },
+      ]);
+    },
+  );
+});
+
+test("HD-1: a relationships ref to an asset with no in-pipeline producer adds no edge", async () => {
+  // No producer (external / not-yet-in-pipeline table) ⇒ no ordering edge — the
+  // runtime error stands, exactly like the backend (`test_edges` stays empty and
+  // is omitted from the graph).
+  await withFolder(
+    {
+      "fct.duckdb.sql":
+        `-- pipeline\n-- on ducklake://main/orders\n-- data_test relationships customer_id -> ducklake://main/external_dim.id\nSELECT customer_id FROM main.orders;\n`,
+    },
+    async (root, folder) => {
+      const { graph } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+      expect(graph.test_edges).toBeUndefined();
+    },
+  );
+});
+
+test("HD-1: a self-test (relationships on the script's own materialize output) is dropped", async () => {
+  // The tested script produces the very asset it references — the backend's
+  // self-edge guard drops it, and so must the local builder (no self-ordering).
+  await withFolder(
+    {
+      "dim.duckdb.sql":
+        `-- pipeline\n-- materialize ducklake://main/dim\n-- data_test relationships id -> ducklake://main/dim.id\nSELECT 1 AS id;\n`,
+    },
+    async (root, folder) => {
+      const { graph } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+      expect(graph.test_edges).toBeUndefined();
+    },
+  );
+});
+
+test("HD-1: a custom `// data_test <script>` whose body reads an in-pipeline asset orders it (best-effort)", async () => {
+  // Escape-hatch test: the tested member declares `// data_test f/mypipe/test_dim`;
+  // that script reads `s3://demo/dim.parquet`, which a pipeline member produces.
+  // The producer must run before the tested script, so the custom test resolves
+  // to a producer → tested-script edge through the shared asset (mirrors the
+  // backend resolving custom tests against the script's parsed reads).
+  await withFolder(
+    {
+      // producer writes the S3 asset the custom test reads
+      "export_dim.duckdb.sql":
+        `-- pipeline\nCOPY (SELECT 1 AS id) TO 's3://demo/dim.parquet';\n`,
+      // the escape-hatch test script (NOT a pipeline member) reads that asset
+      "test_dim.duckdb.sql":
+        `SELECT * FROM read_parquet('s3://demo/dim.parquet') WHERE id IS NULL;\n`,
+      // the tested member points at the custom test
+      "fct.duckdb.sql":
+        `-- pipeline\n-- on ducklake://main/orders\n-- data_test f/mypipe/test_dim\nSELECT 1 AS id;\n`,
+    },
+    async (root, folder) => {
+      const { graph } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+      expect(graph.test_edges).toEqual([
+        {
+          producer_kind: "script",
+          producer_path: "f/mypipe/export_dim",
+          runnable_kind: "script",
+          runnable_path: "f/mypipe/fct",
+          asset_kind: "s3object",
+          asset_path: "demo/dim.parquet",
+        },
+      ]);
+    },
+  );
+});
+
+// The scd2 `<dim>_current` companion-view write edge (HD-2) can't be driven by
+// the pinned `windmill-parser-wasm-asset` (1.740.0), which predates the `scd2`
+// materialize flag, so we inject a parser that re-adds `scd2` for a `history`
+// materialize — exactly what a republished wasm will emit (cf. #9926) — and let
+// the real (already-shipped) companion-write branch assemble the graph.
+async function inferWithScd2(content: string, language: string) {
+  const out = await inferScriptAssets(content, language);
+  if (out.materialize && /\bhistory\b/.test(content)) out.materialize.scd2 = true;
+  return out;
+}
+
+test("HD-2: an scd2 `history` producer writes both `<dim>` and `<dim>_current` so a `_current` reader resolves to it", async () => {
+  await withFolder(
+    {
+      "dim.duckdb.sql":
+        `-- pipeline\n-- materialize ducklake://main/dim_customers key=id history\nSELECT 1 AS id;\n`,
+      // a consumer reading ONLY the `_current` companion view
+      "consume.duckdb.sql":
+        `-- pipeline\n-- on ducklake://main/dim_customers_current\nSELECT * FROM main.dim_customers_current;\n`,
+    },
+    async (root, folder) => {
+      const { graph } = await buildLocalPipelineGraph({
+        root,
+        folder,
+        defaultTs: "bun",
+        infer: inferWithScd2,
+      });
+
+      // the producer carries BOTH write edges (base dim + `_current` companion)
+      const writes = graph.edges
+        .filter(
+          (e) =>
+            e.runnable_path === "f/mypipe/dim" && e.access_type === "w",
+        )
+        .map((e) => e.asset_path)
+        .sort();
+      expect(writes).toEqual(["main/dim_customers", "main/dim_customers_current"]);
+
+      // the strategy is derived as scd2 on the producer node
+      expect(
+        graph.runnables.find((r) => r.path === "f/mypipe/dim")?.materialize_strategy,
+      ).toBe("scd2");
+
+      // the `_current` asset is marked as derived from its base dimension, so the
+      // canvas renders it as a companion view rather than an orphan table
+      expect(graph.assets).toContainEqual({
+        kind: "ducklake",
+        path: "main/dim_customers_current",
+        derived_from: "main/dim_customers",
+      });
+
+      // the `_current` reader's `// on` trigger points at the same node the
+      // producer now writes — no orphaned read
+      const at = graph.triggers.find(
+        (t) => t.trigger_kind === "asset" && t.runnable_path === "f/mypipe/consume",
+      ) as Extract<(typeof graph.triggers)[number], { trigger_kind: "asset" }> | undefined;
+      expect(at?.asset_path).toBe("main/dim_customers_current");
+    },
+  );
+});
 
 test("a bare `.sql` (ambiguous dialect) is skipped, not a build-aborting crash", async () => {
   // `inferContentTypeFromFilePath` throws on a dialect-less `.sql`; one such file

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -79,7 +79,7 @@
 				"vscode-languageclient": "~9.0.1",
 				"vscode-uri": "~3.1.0",
 				"vscode-ws-jsonrpc": "~3.5.0",
-				"windmill-parser-wasm-asset": "1.740.0",
+				"windmill-parser-wasm-asset": "1.749.0",
 				"windmill-parser-wasm-csharp": "1.510.1",
 				"windmill-parser-wasm-go": "1.510.1",
 				"windmill-parser-wasm-java": "1.510.1",
@@ -14321,9 +14321,9 @@
 			}
 		},
 		"node_modules/windmill-parser-wasm-asset": {
-			"version": "1.740.0",
-			"resolved": "https://registry.npmjs.org/windmill-parser-wasm-asset/-/windmill-parser-wasm-asset-1.740.0.tgz",
-			"integrity": "sha512-Dgn5sQ93vJpqTQkv9iAy25+bqH2bUnIMdCfERb2Tia0Ql9T6iHbQhi4yzH9FbGW4Drv9GP46Qyetphqvp8vFOw=="
+			"version": "1.749.0",
+			"resolved": "https://registry.npmjs.org/windmill-parser-wasm-asset/-/windmill-parser-wasm-asset-1.749.0.tgz",
+			"integrity": "sha512-gj8g9sWQ0tXKfXso7xJxR56sS8Loe/RsnFy+0af5R8siZeCag9ikquGbQ8d8kOqIK2U8eCNA0LqsU/xAFDJIOg=="
 		},
 		"node_modules/windmill-parser-wasm-csharp": {
 			"version": "1.510.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -154,7 +154,7 @@
 		"vscode-languageclient": "~9.0.1",
 		"vscode-uri": "~3.1.0",
 		"vscode-ws-jsonrpc": "~3.5.0",
-		"windmill-parser-wasm-asset": "1.740.0",
+		"windmill-parser-wasm-asset": "1.749.0",
 		"windmill-parser-wasm-csharp": "1.510.1",
 		"windmill-parser-wasm-go": "1.510.1",
 		"windmill-parser-wasm-java": "1.510.1",


### PR DESCRIPTION
## Summary

Close the remaining local-vs-deployed graph parity gaps so `wmill pipeline show <folder> --local` matches the deployed graph (backend `asset_graph` in `windmill-api-assets`). Two ordering/edge families the local builder previously omitted are now synthesized from the parsed annotations, mirroring the backend set semantics and the frontend live graph.

## Changes

**HD-1 — `test_edges` (relationships ordering).** `buildTestEdges` synthesizes ordering-only `producer → tested-script` edges from parsed `// data_test` annotations:
- a `relationships` test references its `to_path` asset directly;
- a custom `// data_test <script>` resolves best-effort against that script's parsed reads;
- each referenced asset is resolved to its in-pipeline producer via the write edges; self-edges (a script testing its own output) and producer-less (external) assets are dropped — matching the backend's `seen_test_edges` set and self-edge guard.
- Output is sorted for stable `--json` snapshots (the one deliberate, semantically-irrelevant divergence from the backend's unordered map).
- `boundedCascade.ts` routes `test_edges` through the referenced asset node (`asset → tested script`) so a cold/bounded cascade orders the referenced dimension first — byte-for-byte the frontend's `buildLineageDag`.

**HD-2 — scd2 `<dim>_current` companion write.** A managed `// materialize … history` (`scd2 && !manual`) also produces a `<dim>_current` view. The producer now carries a second write edge to it and the asset node is marked `derived_from` its base dimension, so a consumer reading only the view links back to the producer instead of orphaning. Gated exactly like the backend `MaterializeSpec::scd2_current_target` / `write_targets`.

**wasm dependency.** HD-2 needs the `scd2` materialize flag, which the wasm asset parser only emits as of **`windmill-parser-wasm-asset` 1.749.0** (the previous pin, 1.740.0, predated it). That build has been published and both the CLI (`cli/package.json`) and frontend (`frontend/package.json`) pins are bumped in lockstep — every other `windmill-parser-wasm-*` package is already pinned identically across the two. `buildLocalPipelineGraph` now uses the wasm-backed `inferScriptAssets` directly and the HD-2 test drives the real parser — no injection seam. (The frontend derives materialize/scd2 from its own TS annotation parser `parsePipelineAnnotations`, so the frontend bump only realigns body asset inference in the live graph with the CLI/backend.)

## Test plan
- [x] `UNIT_ONLY=1 bun test test/pipeline_local_graph_unit.test.ts test/pipeline_bounded_cascade_unit.test.ts` — 45 pass (4 new HD-1 cases + 1 HD-2 case, HD-2 driving the real 1.749.0 wasm)
- [x] `bunx tsc --noEmit` (cli) — no new errors in the changed files (pre-existing repo-wide noise unaffected)
- [x] Frontend `npm run check:fast` clean + `vitest run src/lib/components/assets/AssetGraph/` — 242 pass against the bumped wasm
- [x] Parity verified by reading against backend `asset_graph` (`windmill-api-assets/src/lib.rs`), `MaterializeSpec` (`windmill-parser/src/asset_parser.rs`), and frontend `boundedCascade.ts`
- [ ] Optional e2e: on a folder with a `// data_test relationships` producer/consumer pair, confirm `--local` `test_edges` matches the deployed `/assets/graph`

🤖 Generated with [Claude Code](https://claude.com/claude-code)