### PR TITLE
fix(pipelines): make node & pipeline-level run affordances always visible

### DIFF
--- a/frontend/src/lib/components/assets/AssetGraph/PipelineScriptView.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineScriptView.svelte
@@ -81,6 +81,12 @@
 	// A partitioned producer that isn't a data-upload entry is materializing a
 	// partition rather than uploading data — reflect that in the header.
 	let partitionOnly = $derived(!canRun && !!partitionSpec)
+	// `isValid` is only meaningful while a form is mounted to vouch for it; with
+	// no form the run fires with `{}`, which is always valid. Deriving this rather
+	// than reading `isValid` directly avoids a stuck-disabled Run button when a
+	// required-input form leaves `isValid=false` behind as it unmounts on a
+	// same-path re-resolve to an input-less script (we're keyed on script.path).
+	let runValid = $derived(showRunForm ? isValid : true)
 
 	// The details pane keys this component on script.path only, so a same-path
 	// re-resolve (in /pipeline_dev the selected node re-resolves on every WS
@@ -142,7 +148,7 @@
 									unifiedSize="sm"
 									startIcon={{ icon: running ? Loader2 : Zap }}
 									onclick={() => run(true)}
-									disabled={isDraft || running || !isValid}
+									disabled={isDraft || running || !runValid}
 									title={`Run this script with these inputs, then run its ${downstreamCount} downstream pipeline script${downstreamCount === 1 ? '' : 's'} in order`}
 								>
 									Run + downstream
@@ -153,7 +159,7 @@
 								unifiedSize="sm"
 								startIcon={{ icon: running ? Loader2 : Play }}
 								onclick={() => run(false)}
-								disabled={isDraft || running || !isValid || !onRun}
+								disabled={isDraft || running || !runValid || !onRun}
 								title={isDraft
 									? 'Deploy this draft to run it for real'
 									: hasCascade

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineScriptView.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineScriptView.svelte
@@ -69,10 +69,15 @@
 		annotations.triggerAssets.map((a) => ({ kind: a.kind, path: a.path }))
 	)
 
-	// The run form appears for data-upload entry points (S3 picker) and for any
-	// partitioned producer — materializing a single partition is available in
-	// OSS, and the picker is where the user chooses which one.
-	let showRunForm = $derived(canRun || !!partitionSpec)
+	// Whether the script declares any inputs — a run then needs the SchemaForm
+	// to collect them, so the form must render even for a plain (non-upload,
+	// non-partitioned) script rather than firing with empty args.
+	let hasInputs = $derived(Object.keys(script.schema?.properties ?? {}).length > 0)
+	// The run form appears for data-upload entry points (S3 picker), for any
+	// partitioned producer (materialize a single partition — available in OSS,
+	// and the picker is where the user chooses which one), and whenever the
+	// script takes inputs the run needs.
+	let showRunForm = $derived(canRun || !!partitionSpec || hasInputs)
 	// A partitioned producer that isn't a data-upload entry is materializing a
 	// partition rather than uploading data — reflect that in the header.
 	let partitionOnly = $derived(!canRun && !!partitionSpec)
@@ -112,47 +117,54 @@
 	<Splitpanes horizontal class="!h-full">
 		<Pane size={55} minSize={20}>
 			<div class="flex flex-col h-full overflow-auto">
-				{#if showRunForm}
-					<div class="shrink-0 flex flex-col gap-2 p-3 border-b" data-run-form>
-						<div class="flex items-center justify-between gap-2">
-							<span class="text-xs font-semibold text-emphasis inline-flex items-center gap-1.5">
-								{#if partitionOnly}
-									<CalendarClock size={13} class="text-fuchsia-600 dark:text-fuchsia-400" />
-									Materialize a partition
-								{:else}
-									<Upload size={13} class="text-fuchsia-600 dark:text-fuchsia-400" />
-									Run pipeline
-								{/if}
-							</span>
-							<div class="flex items-center gap-1.5">
-								{#if hasCascade}
-									<Button
-										variant="accent-secondary"
-										unifiedSize="sm"
-										startIcon={{ icon: running ? Loader2 : Zap }}
-										onclick={() => run(true)}
-										disabled={isDraft || running || !isValid}
-										title={`Run this script with these inputs, then run its ${downstreamCount} downstream pipeline script${downstreamCount === 1 ? '' : 's'} in order`}
-									>
-										Run + downstream
-									</Button>
-								{/if}
+				<!-- Run affordance is always the first thing in the node panel so
+				     it's discoverable the moment a script is selected — never
+				     buried below the source. The parameter form renders under it
+				     only when the run actually needs inputs (upload/partition/args). -->
+				<div class="shrink-0 flex flex-col gap-2 p-3 border-b" data-run-form>
+					<div class="flex items-center justify-between gap-2">
+						<span class="text-xs font-semibold text-emphasis inline-flex items-center gap-1.5">
+							{#if partitionOnly}
+								<CalendarClock size={13} class="text-fuchsia-600 dark:text-fuchsia-400" />
+								Materialize a partition
+							{:else if canRun}
+								<Upload size={13} class="text-fuchsia-600 dark:text-fuchsia-400" />
+								Run pipeline
+							{:else}
+								<Play size={13} class="text-fuchsia-600 dark:text-fuchsia-400" />
+								Run this step
+							{/if}
+						</span>
+						<div class="flex items-center gap-1.5">
+							{#if hasCascade}
 								<Button
-									variant="accent"
+									variant="accent-secondary"
 									unifiedSize="sm"
-									startIcon={{ icon: running ? Loader2 : Play }}
-									onclick={() => run(false)}
-									disabled={isDraft || running || !isValid || !onRun}
-									title={isDraft
-										? 'Deploy this draft to run it for real'
-										: hasCascade
-											? 'Run just this step — downstream scripts are not triggered'
-											: 'Run the deployed script — downstream pipeline scripts cascade for real'}
+									startIcon={{ icon: running ? Loader2 : Zap }}
+									onclick={() => run(true)}
+									disabled={isDraft || running || !isValid}
+									title={`Run this script with these inputs, then run its ${downstreamCount} downstream pipeline script${downstreamCount === 1 ? '' : 's'} in order`}
 								>
-									{running ? 'Starting…' : 'Run'}
+									Run + downstream
 								</Button>
-							</div>
+							{/if}
+							<Button
+								variant="accent"
+								unifiedSize="sm"
+								startIcon={{ icon: running ? Loader2 : Play }}
+								onclick={() => run(false)}
+								disabled={isDraft || running || !isValid || !onRun}
+								title={isDraft
+									? 'Deploy this draft to run it for real'
+									: hasCascade
+										? 'Run just this step — downstream scripts are not triggered'
+										: 'Run the deployed script — downstream pipeline scripts cascade for real'}
+							>
+								{running ? 'Starting…' : 'Run'}
+							</Button>
 						</div>
+					</div>
+					{#if showRunForm}
 						{#key schemaKey}
 							<PipelineRunForm
 								schema={script.schema}
@@ -164,8 +176,8 @@
 								{upstreamAssets}
 							/>
 						{/key}
-					</div>
-				{/if}
+					{/if}
+				</div>
 				<div class="flex-1 min-h-0 overflow-auto text-xs p-3">
 					<HighlightCode code={script.content ?? ''} language={script.language} />
 				</div>

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineScriptView.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineScriptView.svelte
@@ -105,7 +105,9 @@
 		if (!dispatch || running) return
 		running = true
 		try {
-			await dispatch(script.path, $state.snapshot(args))
+			// No form rendered ⇒ no inputs to collect: run with {} rather than args a
+			// prior (input-carrying) resolve of this same path left behind unmounted.
+			await dispatch(script.path, showRunForm ? $state.snapshot(args) : {})
 		} finally {
 			running = false
 		}

--- a/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/pipeline/[folder]/+page.svelte
@@ -2170,10 +2170,12 @@
 			</div>
 		{/if}
 		<div class="flex flex-row items-center gap-2 flex-1 justify-end">
-			{#if mode === 'edit' && !isOperator && allPipelineScripts.length > 0}
-				<!-- Pipeline-level run: always visible so a run doesn't require
-				     hovering a specific node's play button. Runs every script in
-				     dependency order (roots first, cascading downstream). -->
+			{#if !isOperator && allPipelineScripts.length > 0}
+				<!-- Pipeline-level run: always visible in both View and Edit so a
+				     run never requires hunting for a specific node's play button
+				     (dbt `build` / Dagster "Materialize all"). Runs every script in
+				     dependency order (roots first, cascading downstream) over the
+				     displayed graph — deployed in View, draft-overlaid in Edit. -->
 				<Button
 					variant="accent-secondary"
 					unifiedSize="sm"


### PR DESCRIPTION
## Summary

Runing a pipeline — a single step or the whole DAG — required hunting for the right control. Node-level Run only appeared for data-upload entry points or partitioned producers, so selecting a plain script node showed just its source with no way to run it. The pipeline-level "Run pipeline" button only rendered in Edit mode, so in View mode there was no one-click "materialize all". This makes both affordances always discoverable.

Frontend-only; no dispatch logic changed.

## Changes

- **`PipelineScriptView.svelte`** — the Run button block is now the first thing in the node panel and always renders when a script node is selected, instead of being gated behind `showRunForm` (upload/partition only). The parameter form still renders below the button *only when the run needs inputs* (`canRun` upload, `partitionSpec`, or the script declares schema inputs — new `hasInputs` derived), so a plain no-input script fires with empty args rather than showing an empty form. Header label adapts: "Materialize a partition" / "Run pipeline" / "Run this step".
- **`pipeline/[folder]/+page.svelte`** — the pipeline-header "Run pipeline" button (runs every script in dependency order via the existing `runWholePipeline` → `runBoundedCascade` machinery) now shows in both View and Edit (dropped the `mode === 'edit'` gate; still gated on `!isOperator && allPipelineScripts.length > 0`). In View it cascades the deployed scripts; in Edit it overlays drafts — `launchCascadeScript` already handles that split.

## Screenshots

### Pipeline header — "Run pipeline" now visible in View mode
Before (main): only Activity / Macros / Refresh.

![before-header-view-mode](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/pipeline-run-affordance/1783298468-before-header-view-mode.png)

After: "Run pipeline" button present.

![after-header-view-mode](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/pipeline-run-affordance/1783298468-after-header-view-mode.png)

### Node panel — Run button on a plain (no-input) script node
Before (main): selecting a no-input, non-upload, non-partitioned script showed no run affordance at all.

![before-node-run-button](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/pipeline-run-affordance/1783298468-before-node-run-button.png)

After: "Run this step" header + Run button always present; no parameter form (script has no inputs).

![after-node-run-button](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/pipeline-run-affordance/1783298468-after-node-run-button.png)

After: a node *with* inputs shows the button plus the parameter form (Run disabled until required field filled).

![after-node-ingest-form](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/fix/pipeline-run-affordance/1783298468-after-node-ingest-form.png)

## Test plan

- [x] `npm run check` — 0 errors (pre-existing warnings only)
- [x] View mode as non-operator: header "Run pipeline" button appears and cascades the deployed scripts in dependency order
- [x] Select a plain no-input script node: "Run this step" + enabled Run button render immediately, no empty form beneath
- [x] Select a script node with a required input: button + form render, Run disabled until the field is valid
- [ ] Operator role: neither pipeline-level button nor node run affordance grants runs beyond folder ACL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make pipeline- and node-level run controls always visible in both View and Edit, so runs are easy to find. Parameter forms render only when inputs are needed; input-less steps run with {}; no backend logic changed.

- **Bug Fixes**
  - Pipeline header: “Run pipeline” now shows in both View and Edit (still hidden for operators; only when scripts exist). It runs all scripts in dependency order using existing cascade logic (deployed in View, draft-overlaid in Edit).
  - Node panel: Run controls are always at the top for any selected script. The form appears only when inputs/partitions are required; otherwise the run dispatches {}. Fixed stale state by deriving `runValid` when no form is mounted and sending {} instead of stale args on same-path re-resolves. Labels adapt (“Materialize a partition” / “Run pipeline” / “Run this step”).

<sup>Written for commit 2fae8bd1966122603af89d5799cf6175c937d987. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

