### PR TITLE
fix: resolve extensionless bun relative imports on windows loader

### DIFF
--- a/backend/windmill-worker/loader.bun.windows.js
+++ b/backend/windmill-worker/loader.bun.windows.js
@@ -10,7 +10,7 @@ const p = {
   name: "windmill-relative-resolver",
   async setup(build) {
     const { readFileSync } = await import("fs");
-    const { resolve } = await import("node:path");
+    const { resolve, dirname } = await import("node:path");
 
     const base_internal_url = "BASE_INTERNAL_URL".replace(
       "localhost",
@@ -134,15 +134,20 @@ const p = {
         return undefined;
       }
       // Check if the import resolves to a local module file (written by
-      // write_module_files). Those are written with a `.ts` extension, so for a
-      // bare relative import try the extensionless path and the `.ts` variant
-      // before falling through to the remote windmill resolver.
+      // write_module_files, which can nest files in subdirectories). Resolve
+      // candidates against the importer's own directory — not the job root — so
+      // a subdir module importing a sibling (`dir/a.ts` → `./b`) finds
+      // `dir/b.ts` rather than a phantom `job_dir/b.ts`. For imports from
+      // `main.ts` the importer dir IS the job root, so behavior is unchanged.
+      // Module files carry a `.ts` extension, so also try the `.ts` variant of
+      // a bare relative import before falling through to the remote resolver.
       if (args.path.startsWith(".")) {
+        const importerDir = args.importer ? dirname(args.importer) : cdir;
         const candidates = args.path.endsWith(".ts")
           ? [args.path]
           : [args.path, args.path + ".ts"];
         for (const candidate of candidates) {
-          const cwdPath = resolve(cdir, candidate);
+          const cwdPath = resolve(importerDir, candidate);
           try {
             readFileSync(cwdPath);
             return { path: cwdPath };

--- a/backend/windmill-worker/loader.bun.windows.js
+++ b/backend/windmill-worker/loader.bun.windows.js
@@ -26,20 +26,21 @@ const p = {
     // Normalize path to forward slashes to match Bun's resolver output on Windows
     const cdirFwd = cdir.replace(/\\/g, "/");
     const cdirPosix = cdirFwd.replace(/^[a-zA-Z]:/, "");
-    // Match either an already-normalized `.ts` specifier OR a bare windmill
-    // relative/workspace import (`./`, `../`, `f/`, `/f/`, `u/`, `/u/`) that has
-    // no extension yet. The extensionless branch is essential on Windows: the
-    // `main.ts` onLoad that would rewrite `./mid` → `./mid.ts` only fires when
-    // its path filter matches bun's resolver output, and the 8.3 short-name
-    // (`RUNNER~1`) vs canonical-path mismatch makes that unreliable — so bare
-    // imports must be resolvable here directly rather than depending on the
-    // rewrite. Bare npm specifiers (no `./` prefix, not `f/`/`u/`) still fall
-    // through to bun's default resolver.
+    // Match either an already-normalized `.ts` specifier OR an *extensionless*
+    // windmill relative/workspace import (`./`, `../`, `f/`, `/f/`, `u/`, `/u/`).
+    // The extensionless branch is essential on Windows: the `main.ts` onLoad that
+    // would rewrite `./mid` → `./mid.ts` only fires when its path filter matches
+    // bun's resolver output, and the 8.3 short-name (`RUNNER~1`) vs canonical-path
+    // mismatch makes that unreliable — so bare imports must be resolvable here
+    // directly rather than depending on the rewrite. The `(?!.*\.[A-Za-z0-9]+$)`
+    // guard keeps extension-bearing relative imports (a package's internal
+    // `./foo.js`/`./x.json` requires) OUT of this resolver so they fall through
+    // to bun's default resolver — a windmill script import is always `.ts` or
+    // extensionless. Bare npm specifiers (no `./` prefix, not `f/`/`u/`) never
+    // match either branch.
     const filterResolve = new RegExp(
-      `^(?!\\.\/main\\.ts)(?!\\.\/_wm_)(?!${cdirFwd}\/main\\.ts)(?!${cdirFwd}\/_wm_)(?!${cdirPosix}\/main\\.ts)(?!${cdirPosix}\/_wm_)(?!(?:/private)?${cdirNoPrivate}\/wrapper\\.mjs)(?:.*\\.ts|(?:\\.\\.?\/|\/?f\/|\/?u\/).*)$`
+      `^(?!\\.\/main\\.ts)(?!\\.\/_wm_)(?!${cdirFwd}\/main\\.ts)(?!${cdirFwd}\/_wm_)(?!${cdirPosix}\/main\\.ts)(?!${cdirPosix}\/_wm_)(?!(?:/private)?${cdirNoPrivate}\/wrapper\\.mjs)(?:.*\\.ts|(?:\\.\\.?\/|\/?f\/|\/?u\/)(?!.*\\.[A-Za-z0-9]+$).*)$`
     );
-
-    let cdirNodeModules = `${cdirFwd}/node_modules/`;
 
     // Match the entry main.ts against bun's forward-slash resolver output on
     // Windows — raw `cdir` carries backslashes that corrupt the regex, so the
@@ -130,7 +131,13 @@ const p = {
     // Resolve windmill script imports from the file namespace (e.g. from main.ts)
     build.onResolve({ filter: filterResolve }, (args) => {
       const importerFwd = args.importer?.replace(/\\/g, "/") ?? "";
-      if (importerFwd.startsWith(cdirNodeModules)) {
+      // Let bun natively resolve any import originating INSIDE a dependency, so a
+      // package's own relative requires (`./string.js`, extensionless `./foo`)
+      // are never sent to the windmill resolver. Match `/node_modules/` anywhere
+      // rather than a `cdir`-anchored prefix: on Windows `cdir` (canonical, e.g.
+      // `runneradmin`) and the importer path (8.3 short name, e.g. `RUNNER~1`)
+      // disagree, so a prefix check silently fails and dependency imports 404.
+      if (importerFwd.includes("/node_modules/")) {
         return undefined;
       }
       // Check if the import resolves to a local module file (written by

--- a/backend/windmill-worker/loader.bun.windows.js
+++ b/backend/windmill-worker/loader.bun.windows.js
@@ -26,8 +26,17 @@ const p = {
     // Normalize path to forward slashes to match Bun's resolver output on Windows
     const cdirFwd = cdir.replace(/\\/g, "/");
     const cdirPosix = cdirFwd.replace(/^[a-zA-Z]:/, "");
+    // Match either an already-normalized `.ts` specifier OR a bare windmill
+    // relative/workspace import (`./`, `../`, `f/`, `/f/`, `u/`, `/u/`) that has
+    // no extension yet. The extensionless branch is essential on Windows: the
+    // `main.ts` onLoad that would rewrite `./mid` → `./mid.ts` only fires when
+    // its path filter matches bun's resolver output, and the 8.3 short-name
+    // (`RUNNER~1`) vs canonical-path mismatch makes that unreliable — so bare
+    // imports must be resolvable here directly rather than depending on the
+    // rewrite. Bare npm specifiers (no `./` prefix, not `f/`/`u/`) still fall
+    // through to bun's default resolver.
     const filterResolve = new RegExp(
-      `^(?!\\.\/main\\.ts)(?!\\.\/_wm_)(?!${cdirFwd}\/main\\.ts)(?!${cdirFwd}\/_wm_)(?!${cdirPosix}\/main\\.ts)(?!${cdirPosix}\/_wm_)(?!(?:/private)?${cdirNoPrivate}\/wrapper\\.mjs).*\\.ts$`
+      `^(?!\\.\/main\\.ts)(?!\\.\/_wm_)(?!${cdirFwd}\/main\\.ts)(?!${cdirFwd}\/_wm_)(?!${cdirPosix}\/main\\.ts)(?!${cdirPosix}\/_wm_)(?!(?:/private)?${cdirNoPrivate}\/wrapper\\.mjs)(?:.*\\.ts|(?:\\.\\.?\/|\/?f\/|\/?u\/).*)$`
     );
 
     let cdirNodeModules = `${cdirFwd}/node_modules/`;
@@ -124,13 +133,21 @@ const p = {
       if (importerFwd.startsWith(cdirNodeModules)) {
         return undefined;
       }
-      // Check if the import resolves to a local module file (written by write_module_files)
+      // Check if the import resolves to a local module file (written by
+      // write_module_files). Those are written with a `.ts` extension, so for a
+      // bare relative import try the extensionless path and the `.ts` variant
+      // before falling through to the remote windmill resolver.
       if (args.path.startsWith(".")) {
-        const cwdPath = resolve(cdir, args.path);
-        try {
-          readFileSync(cwdPath);
-          return { path: cwdPath };
-        } catch {}
+        const candidates = args.path.endsWith(".ts")
+          ? [args.path]
+          : [args.path, args.path + ".ts"];
+        for (const candidate of candidates) {
+          const cwdPath = resolve(cdir, candidate);
+          try {
+            readFileSync(cwdPath);
+            return { path: cwdPath };
+          } catch {}
+        }
       }
       const isMainTs =
         args.importer == "./main.ts" || importerFwd.endsWith("/main.ts");


### PR DESCRIPTION
## Summary

Fixes the Windows-only CI failure of `test_bun_transitive_import_change_rebundles`, where `bun build` failed with `error: Could not resolve: "./mid"`.

The Windows bun loader (`loader.bun.windows.js`) relied on the `main.ts` `onLoad` handler firing to rewrite extensionless relative imports (`./mid` → `./mid.ts`) so that `filterResolve` (which required a `.ts$` suffix) would then match them. That `onLoad` filter is built from `resolve("./")`, whose canonical path does not match the entrypoint path carrying the 8.3 short name (`RUNNER~1`) that Windows CI runners use. When the filter fails to fire, extensionless imports slip past `filterResolve` entirely and bun's native resolver errors out.

The previous attempt (#9946) tried to make the `onLoad` filter match more reliably, but path-string matching remains fragile on Windows. This PR removes the dependency on that rewrite by resolving extensionless windmill imports directly in the `onResolve` phase.

## Changes

- Broaden `filterResolve` to also match bare (extensionless) windmill relative/workspace specifiers — `./`, `../`, `f/`, `/f/`, `u/`, `/u/` — in addition to already-normalized `.ts` paths. Bare npm specifiers (no `./` prefix, not `f/`/`u/`) still fall through to bun's default resolver, and the existing `main.ts`/`_wm_`/`wrapper.mjs` negative lookaheads still apply.
- Make the local-module-file check try both the extensionless path and its `.ts` variant, so on-disk module files (written with a `.ts` extension) still resolve locally even when the `onLoad` rewrite didn't fire.

Linux/macOS use a structurally different `.url`-file loader (`loader.bun.js`, `#[cfg(not(windows))]`) where the `onLoad` rewrite fires reliably, so it is intentionally left unchanged.

## Test plan

- [ ] Windows CI: `cargo test --test bun_jobs test_bun_transitive_import_change_rebundles` passes (the failure is Windows-only and cannot be reproduced on Linux since the loader is `#[cfg(windows)]`)
- [ ] Existing Linux/macOS bun_jobs tests remain green (loader.bun.js untouched)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows-only resolution of extensionless relative/workspace imports in the `bun` loader, correctly resolves relatives from subdirectories, and avoids intercepting dependency-internal imports. Prevents "Could not resolve: ./mid" errors and unblocks the Windows transitive rebundle test.

- **Bug Fixes**
  - Expanded `filterResolve` to match extensionless `./`, `../`, `f/`, `/f/`, `u/`, `/u/` imports, not just `.ts`.
  - For relative imports, resolve against the importer’s directory and try the bare path, then `.ts`, before falling back.
  - Skip any import whose importer is inside `node_modules` to let `bun` handle dependency-internal requires (robust to 8.3 vs canonical path mismatches).
  - No changes to non-Windows loaders.

<sup>Written for commit aff09abc239aca4cfe4fc9a450b740aa4c922406. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

