### PR TITLE
fix(ai): test key routes Azure Foundry Claude models via Anthropic Messages API

### DIFF
--- a/frontend/src/lib/components/copilot/lib.ts
+++ b/frontend/src/lib/components/copilot/lib.ts
@@ -14,7 +14,7 @@ import Anthropic from '@anthropic-ai/sdk'
 import { get, type Writable } from 'svelte/store'
 import { OpenAPI, ResourceService, type Script } from '../../gen'
 import { EDIT_CONFIG, FIX_CONFIG, GEN_CONFIG } from './prompts'
-import { requiresMaxCompletionTokens } from './modelConfig'
+import { requiresMaxCompletionTokens, usesAnthropicMessagesApi } from './modelConfig'
 import { applyReasoningToConfig } from './reasoningRegistry'
 import { formatResourceTypes } from './utils'
 import { processToolCall, type Tool, type ToolCallbacks } from './chat/shared'
@@ -466,15 +466,19 @@ export async function testKey({
 		throw new Error('Missing a model to test')
 	}
 
-	// Use Anthropic SDK for Anthropic provider
-	if (aiProvider === 'anthropic') {
+	// Providers served through the Anthropic Messages API (native Anthropic, and
+	// Claude deployments on Azure Foundry) must use the Anthropic SDK path rather
+	// than OpenAI chat completions. Mirrors the chat loop's routing so the test
+	// key exercises the same request shape the chat actually sends.
+	if (usesAnthropicMessagesApi(aiProvider, modelToTest)) {
 		await testAnthropicKey({
 			apiKey,
 			workspace,
 			resourcePath,
 			model: modelToTest,
 			abortController,
-			messages
+			messages,
+			aiProvider
 		})
 		return
 	}
@@ -496,7 +500,8 @@ async function testAnthropicKey({
 	resourcePath,
 	model,
 	abortController,
-	messages
+	messages,
+	aiProvider
 }: {
 	apiKey?: string
 	workspace?: string
@@ -504,11 +509,15 @@ async function testAnthropicKey({
 	model: string
 	abortController: AbortController
 	messages: ChatCompletionMessageParam[]
+	aiProvider: AIProvider
 }) {
 	const { system, messages: anthropicMessages } = convertOpenAIToAnthropicMessages(messages)
 
+	// X-Provider must be the real provider (e.g. azure_foundry) so the backend
+	// resolves the right credentials and Anthropic URL; the SDK headers tell it to
+	// route through the Anthropic Messages API.
 	const headers: Record<string, string> = {
-		'X-Provider': 'anthropic',
+		'X-Provider': aiProvider,
 		'anthropic-version': '2023-06-01',
 		'X-Anthropic-SDK': 'true'
 	}


### PR DESCRIPTION
## Summary

The **Test key** button in the Windmill AI settings failed for Azure AI Foundry when the model under test was a Claude deployment. Foundry serves Claude only through the Anthropic Messages API (`/anthropic/v1/messages`), but `testKey` decided whether to use the Anthropic SDK path solely from `aiProvider === 'anthropic'`. Foundry Claude models therefore fell through to the OpenAI `chat/completions` path, sending an OpenAI-format body to the wrong endpoint, so the test always failed.

The chat loop already routes correctly via the shared `usesAnthropicMessagesApi(provider, model)` predicate (`chatLoop.ts`) and forwards the real provider as `X-Provider` (`chat/anthropic.ts`). `testKey` had simply diverged from that canonical logic. This aligns it.

Only two providers route through the Anthropic Messages API — native `anthropic` and `azure_foundry` + Claude — so no other provider is affected: native Anthropic is unchanged, and every OpenAI-compatible provider (including Azure Foundry with GPT/DeepSeek/Llama/etc.) keeps using the chat/completions path.

## Changes

- `testKey` now gates the Anthropic-SDK path on `usesAnthropicMessagesApi(aiProvider, modelToTest)` instead of `aiProvider === 'anthropic'`, matching the chat loop.
- `testAnthropicKey` now forwards the real `aiProvider` as the `X-Provider` header instead of hardcoding `'anthropic'`, so the backend resolves the correct provider credentials and Foundry Anthropic URL.

## Verification

Tested end-to-end in a real browser against a **live Azure Foundry `claude-sonnet-5` deployment** (and gpt-4o for the OpenAI-family path):

| Model | Request the frontend builds | Result |
|---|---|---|
| `gpt-4o` | `POST /ai/proxy/chat/completions` (`X-Provider: azure_foundry`) | **200 OK** |
| `claude-sonnet-5` | `POST /ai/proxy/v1/messages` (`X-Provider: azure_foundry`, Anthropic body) | **200 OK** |

The Claude request returned a genuine Anthropic Messages payload (`{"content":[{"type":"text","text":"ok"}], ...}`). Before the fix, the Claude test hit `/chat/completions` with an OpenAI body and failed.

Also: `npm run check` passes (0 errors); the routing predicate `usesAnthropicMessagesApi` is already covered by `modelConfig.test.ts` including the `azure_foundry` + Claude / gpt-4o cases.

## Screenshots

![azure-foundry-claude-testkey](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/test-key-azure-foundry/1783324893-azure-foundry-claude-testkey-toast.png)

## Test plan

- [ ] AI settings → enable Azure AI Foundry with a Claude deployment as the first model → **Test key** succeeds; request hits `/ai/proxy/v1/messages` with `X-Provider: azure_foundry`
- [ ] Azure Foundry with a non-Claude model (e.g. gpt-4o) → **Test key** still routes via `/ai/proxy/chat/completions`
- [ ] Native Anthropic → **Test key** still succeeds (`X-Provider: anthropic`, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Test key for Azure AI Foundry Claude deployments by routing through the Anthropic Messages API and sending the correct `X-Provider`, matching the chat loop. Other providers are unchanged.

- **Bug Fixes**
  - `testKey` now uses `usesAnthropicMessagesApi(provider, model)` to choose the Anthropic SDK path.
  - `testAnthropicKey` forwards the actual `aiProvider` in `X-Provider` instead of hardcoding `'anthropic'`.

<sup>Written for commit 899dd4c6415bd9300423f2c3ef8cb36b09373c3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

