### PR TITLE
fix(assets): responsive layout for small screens

### DIFF
--- a/frontend/src/routes/(root)/(logged)/assets/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/assets/+page.svelte
@@ -26,7 +26,7 @@
 	import AssetsUsageDrawer from '$lib/components/assets/AssetsUsageDrawer.svelte'
 	import AssetGenericIcon from '$lib/components/icons/AssetGenericIcon.svelte'
 	import { Tooltip } from '$lib/components/meltComponents'
-	import { AlertTriangle, Loader2, SettingsIcon, StarIcon } from 'lucide-svelte'
+	import { AlertTriangle, BookOpen, Loader2, SettingsIcon, StarIcon } from 'lucide-svelte'
 	import { StaleWhileLoading, useInfiniteQuery, useScrollToBottom } from '$lib/svelte5Utils.svelte'
 	import { resource, watch, type ResourceReturn } from 'runed'
 	import RefreshButton from '$lib/components/common/button/RefreshButton.svelte'
@@ -148,6 +148,11 @@
 			.filter((f) => f.kind === 'asset' && f.path.startsWith(kind))
 			.map((f) => parseFavoriteAsset(f.path))
 	}
+
+	// Per-card width (keyed by title) drives collapsing the header docs button to icon-only
+	// when a card is too narrow to fit the "See documentation" label alongside the gear.
+	let cardWidths = $state<Record<string, number>>({})
+	const CARD_COLLAPSE_WIDTH = 340
 </script>
 
 {#if $userStore?.operator && $workspaceStore && !$userWorkspaces.find((_) => _.id === $workspaceStore)?.operator_settings?.assets}
@@ -164,7 +169,7 @@
 		/>
 
 		<Section label="All workspace assets" class="mb-20">
-			<div class="flex gap-4">
+			<div class="flex flex-wrap gap-4">
 				{#snippet card(props: {
 					title: string
 					assetKind: AssetKind
@@ -174,20 +179,39 @@
 					favorites?: { table: string; schema?: string; assetName: string; path: string }[]
 					itemExtra?: import('svelte').Snippet<[{ label: string; value: string }]>
 				})}
-					<div class="flex flex-col bg-surface-tertiary drop-shadow-base rounded-md flex-1">
-						<div class="flex justify-between border-b">
-							<h3 class="text-sm font-bold mb-4 pt-5 pl-6">{props.title}</h3>
-							<div class="flex items-center h-fit gap-2 mt-4 mr-4">
-								<Button
-									wrapperClasses="h-fit"
-									btnClasses="text-accent"
-									variant="subtle"
-									unifiedSize="sm"
-									href={props.docsHref}
-									target="_blank"
-								>
-									See documentation
-								</Button>
+					<div
+						class="flex flex-col bg-surface-tertiary drop-shadow-base rounded-md grow basis-[280px] min-w-0"
+						bind:clientWidth={cardWidths[props.title]}
+					>
+						<div class="flex justify-between border-b gap-2">
+							<h3 class="text-sm font-bold mb-4 pt-5 pl-6 min-w-0 truncate" title={props.title}
+								>{props.title}</h3
+							>
+							<div class="flex items-center h-fit gap-2 mt-4 mr-4 shrink-0">
+								{#if (cardWidths[props.title] ?? Infinity) < CARD_COLLAPSE_WIDTH}
+									<Button
+										wrapperClasses="h-fit"
+										btnClasses="text-accent"
+										variant="subtle"
+										unifiedSize="sm"
+										iconOnly
+										startIcon={{ icon: BookOpen }}
+										href={props.docsHref}
+										target="_blank"
+										title="See documentation"
+									/>
+								{:else}
+									<Button
+										wrapperClasses="h-fit"
+										btnClasses="text-accent"
+										variant="subtle"
+										unifiedSize="sm"
+										href={props.docsHref}
+										target="_blank"
+									>
+										See documentation
+									</Button>
+								{/if}
 								{#if !($userStore?.operator || (!$userStore?.is_admin && !$superadmin))}
 									<Button
 										wrapperClasses="h-fit"
@@ -204,9 +228,11 @@
 						{#if props.data.current?.length}
 							<div class="max-h-96 overflow-y-auto pb-1">
 								{#each props.data.current ?? [] as item}
-									<div class="text-xs py-2 text-primary flex justify-between items-center px-6">
-										{item.label}
-										<div class="flex items-center gap-2">
+									<div
+										class="text-xs py-2 text-primary flex justify-between items-center gap-2 px-6"
+									>
+										<span class="min-w-0 truncate" title={item.label}>{item.label}</span>
+										<div class="flex items-center gap-2 shrink-0">
 											{#if props.itemExtra}
 												{@render props.itemExtra(item)}
 											{/if}
@@ -306,7 +332,7 @@
 		</Section>
 		<Section label="Latest assets used">
 			{#snippet action()}
-				<div class="flex gap-2 grow justify-end">
+				<div class="flex gap-2 grow justify-end min-w-0">
 					<RefreshButton
 						variant="default"
 						onClick={() => assetsQuery.reset()}

--- a/frontend/src/routes/(root)/(logged)/assets/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/assets/+page.svelte
@@ -330,16 +330,16 @@
 				})}
 			</div>
 		</Section>
-		<Section label="Latest assets used">
+		<Section label="Latest assets used" headerClass="whitespace-nowrap shrink-0">
 			{#snippet action()}
-				<div class="flex gap-2 grow justify-end min-w-0">
+				<div class="flex gap-2 grow justify-end min-w-0 ml-4">
 					<RefreshButton
 						variant="default"
 						onClick={() => assetsQuery.reset()}
 						loading={assetsQuery.isLoading}
 					/>
 					<FilterSearchbar
-						class="grow max-w-[26rem]"
+						class="grow max-w-[26rem] min-w-0"
 						schema={assetsFilterSchema}
 						bind:value={filterValues.val}
 						placeholder="Filter assets..."

--- a/frontend/src/routes/(root)/(logged)/assets/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/assets/+page.svelte
@@ -26,7 +26,7 @@
 	import AssetsUsageDrawer from '$lib/components/assets/AssetsUsageDrawer.svelte'
 	import AssetGenericIcon from '$lib/components/icons/AssetGenericIcon.svelte'
 	import { Tooltip } from '$lib/components/meltComponents'
-	import { AlertTriangle, BookOpen, Loader2, SettingsIcon, StarIcon } from 'lucide-svelte'
+	import { AlertTriangle, Loader2, SettingsIcon, StarIcon } from 'lucide-svelte'
 	import { StaleWhileLoading, useInfiniteQuery, useScrollToBottom } from '$lib/svelte5Utils.svelte'
 	import { resource, watch, type ResourceReturn } from 'runed'
 	import RefreshButton from '$lib/components/common/button/RefreshButton.svelte'
@@ -148,11 +148,6 @@
 			.filter((f) => f.kind === 'asset' && f.path.startsWith(kind))
 			.map((f) => parseFavoriteAsset(f.path))
 	}
-
-	// Per-card width (keyed by title) drives collapsing the header docs button to icon-only
-	// when a card is too narrow to fit the "See documentation" label alongside the gear.
-	let cardWidths = $state<Record<string, number>>({})
-	const CARD_COLLAPSE_WIDTH = 340
 </script>
 
 {#if $userStore?.operator && $workspaceStore && !$userWorkspaces.find((_) => _.id === $workspaceStore)?.operator_settings?.assets}
@@ -181,37 +176,20 @@
 				})}
 					<div
 						class="flex flex-col bg-surface-tertiary drop-shadow-base rounded-md grow basis-[280px] min-w-0"
-						bind:clientWidth={cardWidths[props.title]}
 					>
-						<div class="flex justify-between border-b gap-2">
-							<h3 class="text-sm font-bold mb-4 pt-5 pl-6 min-w-0 truncate" title={props.title}
-								>{props.title}</h3
-							>
-							<div class="flex items-center h-fit gap-2 mt-4 mr-4 shrink-0">
-								{#if (cardWidths[props.title] ?? Infinity) < CARD_COLLAPSE_WIDTH}
-									<Button
-										wrapperClasses="h-fit"
-										btnClasses="text-accent"
-										variant="subtle"
-										unifiedSize="sm"
-										iconOnly
-										startIcon={{ icon: BookOpen }}
-										href={props.docsHref}
-										target="_blank"
-										title="See documentation"
-									/>
-								{:else}
-									<Button
-										wrapperClasses="h-fit"
-										btnClasses="text-accent"
-										variant="subtle"
-										unifiedSize="sm"
-										href={props.docsHref}
-										target="_blank"
-									>
-										See documentation
-									</Button>
-								{/if}
+						<div class="flex flex-wrap justify-between items-center gap-2 border-b pt-5 px-6 pb-4">
+							<h3 class="text-sm font-bold min-w-0 truncate" title={props.title}>{props.title}</h3>
+							<div class="flex items-center h-fit gap-2 shrink-0">
+								<Button
+									wrapperClasses="h-fit"
+									btnClasses="text-accent"
+									variant="subtle"
+									unifiedSize="sm"
+									href={props.docsHref}
+									target="_blank"
+								>
+									See documentation
+								</Button>
 								{#if !($userStore?.operator || (!$userStore?.is_admin && !$superadmin))}
 									<Button
 										wrapperClasses="h-fit"

--- a/frontend/src/routes/(root)/(logged)/assets/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/assets/+page.svelte
@@ -175,7 +175,7 @@
 					itemExtra?: import('svelte').Snippet<[{ label: string; value: string }]>
 				})}
 					<div
-						class="flex flex-col bg-surface-tertiary drop-shadow-base rounded-md grow basis-[280px] min-w-0"
+						class="flex flex-col bg-surface-tertiary drop-shadow-base rounded-md grow basis-[340px] min-w-0"
 					>
 						<div class="flex flex-wrap justify-between items-center gap-2 border-b pt-5 px-6 pb-4">
 							<h3 class="text-sm font-bold min-w-0 truncate" title={props.title}>{props.title}</h3>


### PR DESCRIPTION
## Summary
The Assets page overflowed on small screens: the three workspace-asset cards were a fixed, non-wrapping flex row, and each card header crammed its title + "See documentation" + settings gear into one row that overflowed once the cards got narrow. This makes the layout responsive down to phone widths.

Scope is intentionally limited to **layout/overflow handling**. A separate follow-up PR will cover the card's visual redesign (kept on branch `glm/assets-cosmetics-wip`).

## Changes
- **Cards wrap**: the card row is now `flex flex-wrap gap-4`; each card is `grow basis-[340px] min-w-0`, so it reflows 3-up → 2-up → 1-up as width drops. `340px` is the measured minimum width the widest header ("Object storage" + "See documentation" + gear) needs to stay on one row, so multi-column cards never wrap their header.
- **Header wrap fallback**: the card header is `flex flex-wrap` with container padding, so on a single column narrower than ~355px (tiny phones) the actions drop below the title instead of overflowing. On real devices (≥360px) it stays one row.
- **Item labels truncate**: long storage/ducklake/data-table names use `min-w-0 truncate` (+ `title`), with the Explore/volumes actions in a `shrink-0` group so they stay pinned right.
- **Filter row**: "Latest assets used" keeps its label on one line (`whitespace-nowrap shrink-0`) with a guaranteed gap before the refresh button, and `FilterSearchbar` gets `min-w-0` so it shrinks instead of overflowing onto the label.

## Screenshots
Wide — 3-up:
![wide-3up](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-small-screen-assets/1783360564-wide-3up.png)
Medium — 2-up:
![medium-2up](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-small-screen-assets/1783360564-medium-2up.png)
Phone — 1-up (header still one row):
![phone-1up](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-small-screen-assets/1783360564-phone-1up.png)

## Test plan
- [x] `npm run check:fast` passes (0 warnings)
- [x] 1400px: 3-up cards, headers on one row
- [x] 1100px: cards wrap to 2-up, lone card grows full-width
- [x] 375px: cards stack 1-up, "Object storage" header still fits on one row, no horizontal overflow
- [x] 300px: header actions wrap below the title (graceful fallback), no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)