### PR TITLE
fix(cli): quote non-identifier property names in resource-type namespace

### DIFF
--- a/cli/src/utils/resource_types.ts
+++ b/cli/src/utils/resource_types.ts
@@ -1,5 +1,9 @@
 import { Schema, SchemaProperty } from "../../bootstrap/common.ts";
 
+function quotePropName(name: string): string {
+  return /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(name) ? name : JSON.stringify(name);
+}
+
 export function compileResourceTypeToTsType(schema: Schema) {
   function rec(x: { [name: string]: SchemaProperty }, root = false) {
     let res = "{\n";
@@ -10,15 +14,15 @@ export function compileResourceTypeToTsType(schema: Schema) {
     let i = 0;
     for (let [name, prop] of entries) {
       if (prop.type == "object") {
-        res += `  ${name}: ${rec(prop.properties ?? {})}`;
+        res += `  ${quotePropName(name)}: ${rec(prop.properties ?? {})}`;
       } else if (prop.type == "array") {
-        res += `  ${name}: ${prop?.items?.type ?? "any"}[]`;
+        res += `  ${quotePropName(name)}: ${prop?.items?.type ?? "any"}[]`;
       } else {
         let typ = prop?.type ?? "any";
         if (typ == "integer") {
           typ = "number";
         }
-        res += `  ${name}: ${typ}`;
+        res += `  ${quotePropName(name)}: ${typ}`;
       }
       i++;
       if (i < entries.length) {

--- a/cli/test/resource_types_unit.test.ts
+++ b/cli/test/resource_types_unit.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test";
+
+import { compileResourceTypeToTsType } from "../src/utils/resource_types.ts";
+import type { Schema } from "../bootstrap/common.ts";
+
+// =============================================================================
+// Resource-type namespace generation (WIN-2132)
+//
+// `compileResourceTypeToTsType` renders a JSON Schema into the body of a
+// TypeScript type used in the generated `rt.d.ts` (RT namespace). JSON Schema
+// property names are unconstrained, so a name with a colon, hyphen, or space
+// is legal in the schema but not a valid bare TS identifier. Emitting it raw
+// produced syntactically invalid output that broke `tsc`. These tests pin that
+// such names are quoted while plain identifiers stay bare.
+// =============================================================================
+
+function schema(properties: Schema["properties"]): Schema {
+  return {
+    $schema: undefined,
+    type: "object",
+    properties,
+    required: [],
+  };
+}
+
+test("plain identifiers are emitted without quotes", () => {
+  const out = compileResourceTypeToTsType(
+    schema({
+      host: { type: "string" },
+      _port: { type: "integer" },
+      $ref: { type: "boolean" },
+    })
+  );
+  expect(out).toContain("  host: string");
+  expect(out).toContain("  _port: number");
+  expect(out).toContain("  $ref: boolean");
+  expect(out).not.toContain('"host"');
+});
+
+test("non-identifier property names are double-quoted", () => {
+  const out = compileResourceTypeToTsType(
+    schema({
+      "content-type": { type: "string" },
+      "x:api:key": { type: "string" },
+      "with space": { type: "integer" },
+      "3leading": { type: "boolean" },
+    })
+  );
+  expect(out).toContain('  "content-type": string');
+  expect(out).toContain('  "x:api:key": string');
+  expect(out).toContain('  "with space": number');
+  expect(out).toContain('  "3leading": boolean');
+});
+
+test("nested object and array property names are quoted too", () => {
+  const out = compileResourceTypeToTsType(
+    schema({
+      "nested-obj": {
+        type: "object",
+        properties: { "inner-key": { type: "string" } },
+      },
+      "arr-field": { type: "array", items: { type: "string" } },
+    })
+  );
+  expect(out).toContain('"nested-obj": {');
+  expect(out).toContain('"inner-key": string');
+  expect(out).toContain('"arr-field": string[]');
+});


### PR DESCRIPTION
## Summary

Fixes WIN-2132.

`compileResourceTypeToTsType` in `cli/src/utils/resource_types.ts` interpolated JSON Schema property names directly into the generated TypeScript (`rt.d.ts` RT namespace). JSON Schema property names are unconstrained, so a name containing characters that aren't valid in a bare TS identifier (colons, hyphens, spaces, a leading digit, etc.) produced syntactically invalid output that broke `tsc` parsing.

This wraps each property name in double quotes when it isn't a valid identifier, leaving plain identifiers bare.

## Changes

- Add a `quotePropName` helper that returns the name unchanged when it matches `/^[a-zA-Z_$][a-zA-Z0-9_$]*$/`, otherwise `JSON.stringify`s it (safe double-quoted form).
- Use `quotePropName(name)` at the three property-emission sites (object, array, and scalar branches).
- Add `cli/test/resource_types_unit.test.ts` pinning that plain identifiers stay bare and non-identifier names (including nested object/array keys) are quoted.

## Test plan

- [x] `UNIT_ONLY=1 bun test test/resource_types_unit.test.ts` — 3 pass, 0 fail (13ms, no backend)
- [x] Full `bun test test/resource_types_unit.test.ts` (with backend setup) — 3 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quotes non-identifier JSON Schema property names when generating the resource-type TS namespace to prevent invalid output and `tsc` parse errors. Addresses WIN-2132.

- **Bug Fixes**
  - Added `quotePropName` to leave valid identifiers bare and JSON-quote others.
  - Applied quoting for object, array, and scalar property emissions in `compileResourceTypeToTsType`.
  - Added unit tests to pin behavior for plain identifiers, special characters, leading digits, and nested keys.

<sup>Written for commit d7143700aa1553455b254f9d95c7bb6d5e02c681. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

