### PR TITLE
feat(raw-apps): runtime-error overlay + AI import-React instruction

### DIFF
--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -5561,6 +5561,8 @@ A raw app has three logical parts:
 
 \`index.tsx\` is the bundling entrypoint. It typically renders a top-level \`App\` component. The bundler is esbuild.
 
+**Always begin every React file (\`.tsx\`/\`.jsx\`) that uses JSX with \`import React from 'react'\`.** esbuild uses the classic JSX transform, so \`React\` must be in scope wherever JSX appears — a missing import compiles fine but throws \`React is not defined\` at runtime, leaving a blank screen.
+
 ### Generated bindings (\`wmill.d.ts\` / \`wmill.ts\`)
 
 The frontend imports a generated module that mirrors the backend runnables. **Never write to it directly** — it gets regenerated whenever backend runnables change. Modifying it by hand will be overwritten.

--- a/frontend/scripts/ui_builder_artifact.json
+++ b/frontend/scripts/ui_builder_artifact.json
@@ -1,5 +1,5 @@
 {
 	"baseUrl": "https://pub-06154ed168a24e73a86ab84db6bf15d8.r2.dev",
-	"version": "062d11c",
-	"sha256": "355bf3acfb935080e4a4fa23d0509e03e4bc01aeed622db110663d7ec6c1c438"
+	"version": "f8cecf9",
+	"sha256": "2a79b838e21e06abe06119263872afbe83c4a13f7aa72c722af3e34b819f0ce3"
 }

--- a/frontend/src/lib/components/copilot/chat/app/core.ts
+++ b/frontend/src/lib/components/copilot/chat/app/core.ts
@@ -927,6 +927,7 @@ export function prepareAppSystemMessage(customPrompt?: string): ChatCompletionSy
 - The frontend is bundled using esbuild with entrypoint \`index.tsx\`
 - Frontend files are managed separately from backend runnables
 - The \`wmill.d.ts\` file is generated automatically from the backend runnables shape
+- Begin every React file (\`.tsx\`/\`.jsx\`) that uses JSX with \`import React from 'react'\`. Raw apps bundle with the classic JSX transform, so \`React\` must be in scope wherever JSX is used — a missing import compiles fine but throws \`React is not defined\` at runtime.
 
 ### Backend
 Backend runnables can be of different types:

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -275,6 +275,8 @@
 
 	// Latest UI Builder error; cleared on next successful build.
 	let buildError = $state<string | undefined>(undefined)
+	// Latest uncaught runtime error thrown by the rendered app; cleared on next build.
+	let runtimeError = $state<string | undefined>(undefined)
 	let logsCollapsed = $state(false)
 	let logsDiv: HTMLDivElement | undefined = $state(undefined)
 	$effect(() => {
@@ -1034,10 +1036,7 @@
 		// the preview iframe so it renders the new app.
 		if (fromUiBuilder && e.data.type === 'preview') {
 			lastBuild = { css: e.data.css, js: e.data.js }
-			previewIframe?.contentWindow?.postMessage(
-				{ type: 'preview', css: e.data.css, js: e.data.js },
-				'*'
-			)
+			feedPreviewIframe(lastBuild)
 			syncExternalPreview()
 			return
 		}
@@ -1064,6 +1063,16 @@
 
 		if (fromPreview && e.data.type === 'runtimeLogsResponse') {
 			resolvePendingRuntimeLogRequest(e.data.requestId, normalizeRawAppRuntimeLogs(e.data.logs))
+			return
+		}
+
+		// Uncaught error/rejection from the rendered app — surfaced in the preview
+		// overlay so a runtime crash isn't a silent blank error.
+		if (fromPreview && e.data.type === 'runtimeError') {
+			runtimeError =
+				typeof e.data.message === 'string' && e.data.message
+					? e.data.message
+					: 'Unknown runtime error'
 			return
 		}
 
@@ -1154,6 +1163,17 @@
 		if (lastBuild) {
 			postToExternalPreview({ type: 'preview', css: lastBuild.css, js: lastBuild.js })
 		}
+	}
+
+	// Feed a build into the inline preview iframe. Clears any prior runtime-error
+	// overlay first: a fresh render supersedes the old crash, and if the new
+	// render throws again app-preview.html re-posts `runtimeError`.
+	function feedPreviewIframe(build: { css: string; js: string }) {
+		runtimeError = undefined
+		previewIframe?.contentWindow?.postMessage(
+			{ type: 'preview', css: build.css, js: build.js },
+			'*'
+		)
 	}
 
 	// Full (re)feed of the detached window: theme first, then the build. Used
@@ -1300,10 +1320,7 @@
 			// Replay the last build so the preview repopulates without
 			// waiting for the user to trigger another bundle.
 			if (lastBuild) {
-				previewIframe?.contentWindow?.postMessage(
-					{ type: 'preview', css: lastBuild.css, js: lastBuild.js },
-					'*'
-				)
+				feedPreviewIframe(lastBuild)
 			}
 			// Escape inside the preview exits inspect mode — the keydown fires in
 			// the iframe's document, so the parent window listener can't see it.
@@ -1854,14 +1871,7 @@
 												aria-label="Rebuild"
 												onclick={() => {
 													if (lastBuild) {
-														previewIframe?.contentWindow?.postMessage(
-															{
-																type: 'preview',
-																css: lastBuild.css,
-																js: lastBuild.js
-															},
-															'*'
-														)
+														feedPreviewIframe(lastBuild)
 													}
 												}}
 											>
@@ -1908,6 +1918,18 @@
 										>
 											<pre class="overflow-auto whitespace-pre-wrap text-xs max-h-60"
 												>{buildError}</pre
+											>
+										</Alert>
+									</div>
+								{:else if runtimeError}
+									<div class="absolute top-12 left-2 right-2 z-20 isolate" role="alert">
+										<Alert
+											type="error"
+											title="Runtime error"
+											class="relative before:absolute before:inset-0 before:-z-10 before:rounded-md before:bg-surface before:content-['']"
+										>
+											<pre class="overflow-auto whitespace-pre-wrap text-xs max-h-60"
+												>{runtimeError}</pre
 											>
 										</Alert>
 									</div>

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -587,6 +587,8 @@ A raw app has three logical parts:
 
 \`index.tsx\` is the bundling entrypoint. It typically renders a top-level \`App\` component. The bundler is esbuild.
 
+**Always begin every React file (\`.tsx\`/\`.jsx\`) that uses JSX with \`import React from 'react'\`.** esbuild uses the classic JSX transform, so \`React\` must be in scope wherever JSX appears — a missing import compiles fine but throws \`React is not defined\` at runtime, leaving a blank screen.
+
 ### Generated bindings (\`wmill.d.ts\` / \`wmill.ts\`)
 
 The frontend imports a generated module that mirrors the backend runnables. **Never write to it directly** — it gets regenerated whenever backend runnables change. Modifying it by hand will be overwritten.

--- a/system_prompts/auto-generated/skills/raw-app/SKILL.md
+++ b/system_prompts/auto-generated/skills/raw-app/SKILL.md
@@ -251,6 +251,8 @@ A raw app has three logical parts:
 
 `index.tsx` is the bundling entrypoint. It typically renders a top-level `App` component. The bundler is esbuild.
 
+**Always begin every React file (`.tsx`/`.jsx`) that uses JSX with `import React from 'react'`.** esbuild uses the classic JSX transform, so `React` must be in scope wherever JSX appears — a missing import compiles fine but throws `React is not defined` at runtime, leaving a blank screen.
+
 ### Generated bindings (`wmill.d.ts` / `wmill.ts`)
 
 The frontend imports a generated module that mirrors the backend runnables. **Never write to it directly** — it gets regenerated whenever backend runnables change. Modifying it by hand will be overwritten.

--- a/system_prompts/base/raw-app.md
+++ b/system_prompts/base/raw-app.md
@@ -16,6 +16,8 @@ A raw app has three logical parts:
 
 `index.tsx` is the bundling entrypoint. It typically renders a top-level `App` component. The bundler is esbuild.
 
+**Always begin every React file (`.tsx`/`.jsx`) that uses JSX with `import React from 'react'`.** esbuild uses the classic JSX transform, so `React` must be in scope wherever JSX appears — a missing import compiles fine but throws `React is not defined` at runtime, leaving a blank screen.
+
 ### Generated bindings (`wmill.d.ts` / `wmill.ts`)
 
 The frontend imports a generated module that mirrors the backend runnables. **Never write to it directly** — it gets regenerated whenever backend runnables change. Modifying it by hand will be overwritten.


### PR DESCRIPTION
> 🔗 **Part of a two-repo change.** Companion PR: **windmill-labs/windmill-code-ui-builder#15** — the raw-app preview frame pushes the uncaught runtime error that this PR renders as an overlay. Merge together (the builder change also needs a ui_builder tarball rebuild + artifact bump).

## Summary

Make the raw-app "missing `import React`" failure **visible and preventable** instead of a silent blank screen — without changing the JSX transform.

Raw apps bundle with esbuild's classic JSX transform, so a file using JSX without `import React` compiles fine but throws `ReferenceError: React is not defined` at runtime, leaving the author a blank preview with no error. Rather than paper over it at the bundler (which drags the editor's type-checker into a rabbit hole), we **report the error clearly** and **tell the AI generators to import React**.

## Changes

- **`RawAppEditor.svelte`**: handle the `runtimeError` message the preview frame now posts (source-gated on `fromPreview`) and render a "Runtime error" Alert — shown only when there's no build error. A shared `feedPreviewIframe` helper routes all three preview-feed paths (fresh build, iframe `load`, "Replay the last build") so the overlay clears consistently on any re-render.
- **AI generation prompts** — add "always begin JSX files with `import React`" to **both** surfaces that write raw-app React code:
  - `copilot/chat/app/core.ts` — the dedicated app chat's inline prompt.
  - `system_prompts/base/raw-app.md` — the shared reference used by the global chat and the raw-app CLI skill (derived files regenerated via `system_prompts/generate.py`).

## Screenshot

A raw app that omits `import React` — the bundle builds fine, but the runtime crash is now surfaced instead of a blank preview:

![ReferenceError: React is not defined overlay](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-app-instructions/1783357469-react-not-defined-overlay.png)

## Test plan

- [ ] Open a raw app whose React code throws at runtime (e.g. omit `import React`) → "Runtime error" overlay appears with the message
- [ ] Fix the code so it rebuilds successfully → overlay clears
- [ ] Introduce a build error on top of a runtime error → "Build failed" overlay takes precedence
- [ ] Click "Replay the last build" while a runtime error shows → overlay clears
- [ ] Generate a raw app via the app chat and via the global chat → both include `import React`

## Companion

- **windmill-labs/windmill-code-ui-builder#15** — the preview frame pushes uncaught exceptions to the editor (needs a ui_builder tarball rebuild + `frontend/scripts/ui_builder_artifact.json` bump to ship).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
