### PR TITLE
fix(frontend): theme-aware code block background in prose markdown

### DIFF
--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -456,6 +456,20 @@ const config = {
 			]
 		},
 		extend: {
+			// Tailwind Typography hardcodes `pre` code blocks to a dark background
+			// (gray-800) in both light and dark mode, so they render dark-on-light in
+			// light mode. Point the pre/pre-code variables at theme-aware surface
+			// tokens (light and inverted) so code blocks track the active theme.
+			typography: {
+				DEFAULT: {
+					css: {
+						'--tw-prose-pre-bg': 'rgb(var(--color-surface-secondary))',
+						'--tw-prose-pre-code': 'rgb(var(--color-text-primary))',
+						'--tw-prose-invert-pre-bg': 'rgb(var(--color-surface-secondary))',
+						'--tw-prose-invert-pre-code': 'rgb(var(--color-text-primary))'
+					}
+				}
+			},
 			border: {
 				color: 'red'
 			},


### PR DESCRIPTION
## Summary

Code blocks (`<pre>`) rendered inside any `.prose` markdown container showed a **dark gray background in light mode** — both in the AI chat markdown render and outside it.

The dark background comes from `@tailwindcss/typography`: its `.prose` class hardcodes `--tw-prose-pre-bg: #1f2937` (gray-800) and applies it via `.prose :where(pre) { background-color: var(--tw-prose-pre-bg) }`, using the same dark value in light *and* dark mode. So plain fenced code blocks on any full-`.prose` surface (e.g. `AppMarkdown.svelte`, copilot reasoning blocks, `DisplayResult`, `ChatMessage`) rendered dark-on-light.

This points the pre/pre-code typography variables at Windmill's theme-aware surface tokens instead, so code blocks track the active theme.

## Changes

- `frontend/tailwind.config.cjs`: override the typography plugin's `--tw-prose-pre-bg` / `--tw-prose-pre-code` (and the `-invert-` variants) to `rgb(var(--color-surface-secondary))` / `rgb(var(--color-text-primary))`. Done in `extend.typography.DEFAULT.css` so it becomes part of the generated `.prose` / `.prose-invert` rules — no cascade/specificity fight.

## Verification

Verified against the running dev server's live CSS on a real `.prose` code block:

- **Light mode**: `pre` background → `rgb(239, 239, 244)` (light surface), text → dark. (was `rgb(31, 41, 55)` gray-800)
- **Dark mode** (`html.dark`): `pre` background → `rgb(39, 44, 53)` (dark surface), text → light — still correct.

## Screenshots

![prose-code-light](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-73879892/1783359712-prose-code-light.png)

![prose-code-dark](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/change-73879892/1783359715-prose-code-dark.png)

## Test plan

- [ ] Open a `.prose` markdown surface with a fenced code block (Copilot chat assistant message, or a script/flow markdown description via the App Markdown component) in **light mode** → code block renders on a light surface with readable dark text.
- [ ] Toggle to **dark mode** → code block surface and text invert correctly with the theme.