### PR TITLE
fix: critical alerts modal mute toggles no longer close popover or fail to save

### DIFF
--- a/frontend/src/lib/components/sidebar/CriticalAlertModal.svelte
+++ b/frontend/src/lib/components/sidebar/CriticalAlertModal.svelte
@@ -297,6 +297,7 @@
 
 	<CriticalAlertModalInner
 		bind:workspaceContext
+		{muteSettings}
 		{numUnacknowledgedCriticalAlerts}
 		{updateHasUnacknowledgedCriticalAlerts}
 		{getCriticalAlerts}

--- a/frontend/src/lib/components/sidebar/CriticalAlertModal.svelte
+++ b/frontend/src/lib/components/sidebar/CriticalAlertModal.svelte
@@ -186,10 +186,14 @@
 	{#snippet headerRight()}
 		<List horizontal>
 			{#if $superadmin || $userStore?.is_admin}
+				<!-- Portal to `body` (not the trigger) so toggle clicks don't bubble to the melt
+				     trigger and toggle the popover shut. `dropdown-portal` on the content root is a
+				     `portalDivs` marker, so the enclosing Modal2's clickOutside treats the whole
+				     popover surface — padding included — as inside a portal and stays open. -->
 				<Popover
 					floatingConfig={{ strategy: 'fixed', placement: 'bottom-end' }}
 					portal="body"
-					contentClasses="p-4"
+					contentClasses="p-4 dropdown-portal"
 				>
 					{#snippet trigger()}
 						<div id="mute-settings-button">
@@ -203,37 +207,31 @@
 						</div>
 					{/snippet}
 					{#snippet content()}
-						<!-- The popover floats above the enclosing Modal2. `.dropdown-portal` is in
-						     `portalDivs`, so the modal's clickOutside treats interactions here as
-						     inside a portal and stays open (portaling into the trigger instead would
-						     bubble clicks to the melt trigger and toggle the popover shut). -->
-						<div class="dropdown-portal">
-							<List justify="start">
-								<div class="w-full">
-									{#if $superadmin}
-										<Toggle
-											on:change={saveGlobalMuteSetting}
-											bind:checked={muteSettings.global}
-											options={{
-												right: 'Automatically acknowledge critical alerts instance wide'
-											}}
-											size="xs"
-										/>
-									{/if}
-								</div>
-
-								<div class="w-full">
+						<List justify="start">
+							<div class="w-full">
+								{#if $superadmin}
 									<Toggle
-										on:change={saveWorkSpaceMuteSetting}
-										bind:checked={muteSettings.workspace}
+										on:change={saveGlobalMuteSetting}
+										bind:checked={muteSettings.global}
 										options={{
-											right: 'Automatically acknowledge critical alerts for current workspace'
+											right: 'Automatically acknowledge critical alerts instance wide'
 										}}
 										size="xs"
 									/>
-								</div>
-							</List>
-						</div>
+								{/if}
+							</div>
+
+							<div class="w-full">
+								<Toggle
+									on:change={saveWorkSpaceMuteSetting}
+									bind:checked={muteSettings.workspace}
+									options={{
+										right: 'Automatically acknowledge critical alerts for current workspace'
+									}}
+									size="xs"
+								/>
+							</div>
+						</List>
 					{/snippet}
 				</Popover>
 			{/if}
@@ -242,7 +240,7 @@
 				<Popover
 					floatingConfig={{ strategy: 'fixed', placement: 'bottom-end' }}
 					portal="body"
-					contentClasses="p-4"
+					contentClasses="p-4 dropdown-portal"
 				>
 					{#snippet trigger()}
 						<div id="settings-button">
@@ -252,35 +250,33 @@
 						</div>
 					{/snippet}
 					{#snippet content()}
-						<div class="dropdown-portal">
-							<List justify="start" gap="none">
-								<div class="w-full">
-									<Button
-										size="xs"
-										color="light"
-										href="{base}/?workspace=admins#superadmin-settings"
-										target="_blank"
-									>
-										<div class="w-full">
-											<List horizontal justify="between" gap="sm">
-												<div>Instance Critical Alert Settings</div>
-												<ExternalLink size="16" />
-											</List>
-										</div>
-									</Button>
-								</div>
-								<div class="w-full">
-									<Button
-										size="xs"
-										color="light"
-										href="{base}/workspace_settings?tab=error_handler"
-										target="_blank"
-									>
-										Workspace Critical Alert Settings <ExternalLink size="16" />
-									</Button>
-								</div>
-							</List>
-						</div>
+						<List justify="start" gap="none">
+							<div class="w-full">
+								<Button
+									size="xs"
+									color="light"
+									href="{base}/?workspace=admins#superadmin-settings"
+									target="_blank"
+								>
+									<div class="w-full">
+										<List horizontal justify="between" gap="sm">
+											<div>Instance Critical Alert Settings</div>
+											<ExternalLink size="16" />
+										</List>
+									</div>
+								</Button>
+							</div>
+							<div class="w-full">
+								<Button
+									size="xs"
+									color="light"
+									href="{base}/workspace_settings?tab=error_handler"
+									target="_blank"
+								>
+									Workspace Critical Alert Settings <ExternalLink size="16" />
+								</Button>
+							</div>
+						</List>
 					{/snippet}
 				</Popover>
 			{:else}

--- a/frontend/src/lib/components/sidebar/CriticalAlertModal.svelte
+++ b/frontend/src/lib/components/sidebar/CriticalAlertModal.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { run } from 'svelte/legacy'
-
 	import { onMount, onDestroy } from 'svelte'
 	import CriticalAlertModalInner from './CriticalAlertModalInner.svelte'
 	import { SettingService, type CriticalAlert } from '$lib/gen'
@@ -35,26 +33,11 @@
 	let workspaceContext = $state(false)
 	let childRef: CriticalAlertModalInner | undefined = $state()
 
-	function setupApiFunctions(_ctx?) {
-		getCriticalAlerts = withSuperadminLogic(
-			SettingService.getCriticalAlerts,
-			SettingService.workspaceGetCriticalAlerts
-		)
-
-		acknowledgeCriticalAlert = withSuperadminLogic(
-			SettingService.acknowledgeCriticalAlert,
-			SettingService.workspaceAcknowledgeCriticalAlert
-		)
-
-		acknowledgeAllCriticalAlerts = withSuperadminLogic(
-			SettingService.acknowledgeAllCriticalAlerts,
-			SettingService.workspaceAcknowledgeAllCriticalAlerts
-		)
-	}
-
 	let checkForNewAlertsInterval: ReturnType<typeof setInterval>
 	let checkingForNewAlerts = false
 
+	// The returned closure reads workspaceContext / $workspaceStore / $devopsRole at
+	// call time, so the wrappers are stable and never need recreating.
 	const withSuperadminLogic = (superadminFunction, workspaceFunction) => {
 		return async (params = {}) => {
 			if (!$devopsRole || workspaceContext) {
@@ -68,12 +51,21 @@
 		}
 	}
 
-	type AckFn = (params?: {}) => Promise<any>
-	let getCriticalAlerts: AckFn | undefined = $state()
-	let acknowledgeCriticalAlert: AckFn | undefined = $state()
-	let acknowledgeAllCriticalAlerts: AckFn | undefined = $state()
-
-	setupApiFunctions()
+	let getCriticalAlerts = $derived(
+		withSuperadminLogic(SettingService.getCriticalAlerts, SettingService.workspaceGetCriticalAlerts)
+	)
+	let acknowledgeCriticalAlert = $derived(
+		withSuperadminLogic(
+			SettingService.acknowledgeCriticalAlert,
+			SettingService.workspaceAcknowledgeCriticalAlert
+		)
+	)
+	let acknowledgeAllCriticalAlerts = $derived(
+		withSuperadminLogic(
+			SettingService.acknowledgeAllCriticalAlerts,
+			SettingService.workspaceAcknowledgeAllCriticalAlerts
+		)
+	)
 
 	onMount(async () => {
 		await updateHasUnacknowledgedCriticalAlerts(false)
@@ -173,13 +165,10 @@
 		await acknowledgeCriticalAlert?.({ id })
 		updateHasUnacknowledgedCriticalAlerts()
 	}
-	run(() => {
-		setupApiFunctions(workspaceContext)
-	})
-	run(() => {
+	$effect(() => {
 		if ($isCriticalAlertsUIOpen) open = $isCriticalAlertsUIOpen
 	})
-	run(() => {
+	$effect(() => {
 		isCriticalAlertsUIOpen.set(open)
 	})
 </script>
@@ -199,7 +188,7 @@
 			{#if $superadmin || $userStore?.is_admin}
 				<Popover
 					floatingConfig={{ strategy: 'fixed', placement: 'bottom-end' }}
-					portal="#mute-settings-button"
+					portal="body"
 					contentClasses="p-4"
 				>
 					{#snippet trigger()}
@@ -214,31 +203,37 @@
 						</div>
 					{/snippet}
 					{#snippet content()}
-						<List justify="start">
-							<div class="w-full">
-								{#if $superadmin}
+						<!-- The popover floats above the enclosing Modal2. `.dropdown-portal` is in
+						     `portalDivs`, so the modal's clickOutside treats interactions here as
+						     inside a portal and stays open (portaling into the trigger instead would
+						     bubble clicks to the melt trigger and toggle the popover shut). -->
+						<div class="dropdown-portal">
+							<List justify="start">
+								<div class="w-full">
+									{#if $superadmin}
+										<Toggle
+											on:change={saveGlobalMuteSetting}
+											bind:checked={muteSettings.global}
+											options={{
+												right: 'Automatically acknowledge critical alerts instance wide'
+											}}
+											size="xs"
+										/>
+									{/if}
+								</div>
+
+								<div class="w-full">
 									<Toggle
-										on:change={saveGlobalMuteSetting}
-										bind:checked={muteSettings.global}
+										on:change={saveWorkSpaceMuteSetting}
+										bind:checked={muteSettings.workspace}
 										options={{
-											right: 'Automatically acknowledge critical alerts instance wide'
+											right: 'Automatically acknowledge critical alerts for current workspace'
 										}}
 										size="xs"
 									/>
-								{/if}
-							</div>
-
-							<div class="w-full">
-								<Toggle
-									on:change={saveWorkSpaceMuteSetting}
-									bind:checked={muteSettings.workspace}
-									options={{
-										right: 'Automatically acknowledge critical alerts for current workspace'
-									}}
-									size="xs"
-								/>
-							</div>
-						</List>
+								</div>
+							</List>
+						</div>
 					{/snippet}
 				</Popover>
 			{/if}
@@ -246,7 +241,7 @@
 			{#if $superadmin}
 				<Popover
 					floatingConfig={{ strategy: 'fixed', placement: 'bottom-end' }}
-					portal="#settings-button"
+					portal="body"
 					contentClasses="p-4"
 				>
 					{#snippet trigger()}
@@ -257,33 +252,35 @@
 						</div>
 					{/snippet}
 					{#snippet content()}
-						<List justify="start" gap="none">
-							<div class="w-full">
-								<Button
-									size="xs"
-									color="light"
-									href="{base}/?workspace=admins#superadmin-settings"
-									target="_blank"
-								>
-									<div class="w-full">
-										<List horizontal justify="between" gap="sm">
-											<div>Instance Critical Alert Settings</div>
-											<ExternalLink size="16" />
-										</List>
-									</div>
-								</Button>
-							</div>
-							<div class="w-full">
-								<Button
-									size="xs"
-									color="light"
-									href="{base}/workspace_settings?tab=error_handler"
-									target="_blank"
-								>
-									Workspace Critical Alert Settings <ExternalLink size="16" />
-								</Button>
-							</div>
-						</List>
+						<div class="dropdown-portal">
+							<List justify="start" gap="none">
+								<div class="w-full">
+									<Button
+										size="xs"
+										color="light"
+										href="{base}/?workspace=admins#superadmin-settings"
+										target="_blank"
+									>
+										<div class="w-full">
+											<List horizontal justify="between" gap="sm">
+												<div>Instance Critical Alert Settings</div>
+												<ExternalLink size="16" />
+											</List>
+										</div>
+									</Button>
+								</div>
+								<div class="w-full">
+									<Button
+										size="xs"
+										color="light"
+										href="{base}/workspace_settings?tab=error_handler"
+										target="_blank"
+									>
+										Workspace Critical Alert Settings <ExternalLink size="16" />
+									</Button>
+								</div>
+							</List>
+						</div>
 					{/snippet}
 				</Popover>
 			{:else}

--- a/frontend/src/lib/components/sidebar/CriticalAlertModalInner.svelte
+++ b/frontend/src/lib/components/sidebar/CriticalAlertModalInner.svelte
@@ -11,7 +11,7 @@
 	import CriticalAlertTable from './CriticalAlertTable.svelte'
 	import Alert from '$lib/components/common/alert/Alert.svelte'
 	import { sendUserToast } from '$lib/toast'
-	import { untrack } from 'svelte'
+	import { onMount, untrack } from 'svelte'
 
 	let filteredAlerts: CriticalAlert[] = $state([])
 
@@ -30,6 +30,7 @@
 		acknowledgeCriticalAlert: any
 		acknowledgeAllCriticalAlerts: any
 		numUnacknowledgedCriticalAlerts: any
+		muteSettings?: { global?: boolean; workspace?: boolean }
 		workspaceContext?: boolean
 	}
 
@@ -39,8 +40,11 @@
 		acknowledgeCriticalAlert,
 		acknowledgeAllCriticalAlerts,
 		numUnacknowledgedCriticalAlerts,
+		muteSettings,
 		workspaceContext = $bindable(false)
 	}: Props = $props()
+
+	let isMuted = $derived(Boolean(muteSettings?.global || muteSettings?.workspace))
 
 	async function acknowledgeAll() {
 		await acknowledgeAllCriticalAlerts()
@@ -81,6 +85,12 @@
 		const channels = (await SettingService.getGlobal({ key: 'critical_error_channels' })) as any[]
 		hasCriticalAlertChannels = channels && channels.length > 0
 	}
+
+	// Load the channel state on mount so the "no channels" warning doesn't depend on
+	// there being unacknowledged alerts to trigger a refresh (muting auto-acks them).
+	onMount(() => {
+		if ($superadmin) checkCriticalAlertChannels()
+	})
 
 	async function acknowledgeAlert(id: number) {
 		await acknowledgeCriticalAlert({ id })
@@ -133,7 +143,7 @@
 </script>
 
 <List gap="sm">
-	{#if !hasCriticalAlertChannels && $superadmin}
+	{#if $superadmin && isMuted && !hasCriticalAlertChannels}
 		<div class="w-full">
 			<Alert title="No critical alert channels are set up" type="warning" size="xs">
 				Go to the


### PR DESCRIPTION
## Summary

Fixes several issues with the Critical Alerts modal's mute popover and its warning banner.

**1. Mute toggles did nothing and closed the popover.** The popover content was portaled into its own melt trigger (`portal="#mute-settings-button"`). Because the melt trigger toggles the popover on click, clicking a toggle bubbled up to the trigger and closed it — and melt's `preventDefault` on that click cancelled the checkbox's default toggle, so `on:change` never fired and the setting never saved.

**2. Clicking the popover's padding closed the whole modal.** Switching to `portal="body"` fixes melt, but puts the content outside `Modal2`'s body, so `Modal2`'s capture-phase `clickOutside` (in `frontend/src/lib/utils.ts`) would close the modal. Marking only the inner toggle wrapper as `.dropdown-portal` left the popover's own `p-4` padding ring uncovered — clicking it (still `[data-popover]` but not `.dropdown-portal`) dismissed the modal.

**3. "No critical alert channels" banner was inconsistent.** It appeared when you toggled mute but vanished on modal reopen, and its condition ignored mute entirely. `hasCriticalAlertChannels` was only refreshed inside `refreshAlerts()`, which on open is gated behind there being unacknowledged alerts — but muting auto-acknowledges them, so the refresh never ran and the banner reverted to its hidden default.

## Changes

- **Popover portal** (`CriticalAlertModal.svelte`): repoint both the mute (bell) and settings (gear) popovers from `portal="#<trigger-id>"` to `portal="body"`, and put the `dropdown-portal` marker on the popover **content root** via `contentClasses="p-4 dropdown-portal"` so the entire popover surface — padding included — is excluded from `Modal2`'s outside-click detection.
- **Warning banner** (`CriticalAlertModalInner.svelte`): pass `muteSettings` into the inner component and make the banner a dead-simple reactive condition — `$superadmin && isMuted && !hasCriticalAlertChannels` — where `isMuted` is `$derived` from the mute settings. Load the channel state on mount (`onMount`) instead of relying on `refreshAlerts()`, so it no longer depends on unacknowledged alerts existing.
- **Runes cleanup** (`CriticalAlertModal.svelte`): replace the three leftover `run(...)` (`svelte/legacy`) blocks with runes — the API-wrapper setup becomes `$derived` (the wrappers read reactive state at call time, so they never need recreating; removes `setupApiFunctions` and its `$state` decls), and the two `open` ↔ `isCriticalAlertsUIOpen` store syncs become `$effect`. Removes the `svelte/legacy` import.

## Screenshots

Mute popover open after toggling — popover stays open, workspace toggle on (blue), header bell shows the muted state, modal still open behind it:

![critical-alerts-mute-fix](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-critical-alert-mute-toggle/1783360870-v2-pr-fix.png)

## Test plan

Verified end-to-end in the browser (EE backend, superadmin, live critical alerts):

- [x] Clicking a mute toggle flips it, persists the setting, and keeps both popover and modal open (both the workspace and instance-wide toggles)
- [x] Clicking the popover's padding ring no longer closes the modal
- [x] Clicking outside the popover (in the modal chrome) closes the popover only; clicking the backdrop still closes the modal
- [x] Banner: unmuted + no channels → hidden; mute → appears; **close & reopen while muted → still shown**; unmute → disappears
- [x] Opening the modal does not spuriously write the mute setting
- [x] Modal still opens via the `isCriticalAlertsUIOpen` store and the alerts table loads (exercising the `$derived` API functions)
- [x] `npm run check:fast` passes with 0 warnings