### PR TITLE
fix(migrations): run bootstrap housekeeping on the migrator's held connection

### DIFF
--- a/backend/windmill-api/src/db.rs
+++ b/backend/windmill-api/src/db.rs
@@ -96,6 +96,14 @@ lazy_static::lazy_static! {
 pub struct CustomMigrator {
     inner: PoolConnection<Postgres>,
 }
+impl CustomMigrator {
+    /// The connection the migrator already holds (with the migration advisory lock).
+    /// Migration housekeeping runs on it instead of re-acquiring: a second connection
+    /// while this one is held deadlocks a single-connection backend (e.g. embedded pglite).
+    pub fn connection(&mut self) -> &mut PgConnection {
+        &mut *self.inner
+    }
+}
 impl Migrate for CustomMigrator {
     fn ensure_migrations_table(
         &mut self,
@@ -272,7 +280,7 @@ pub async fn migrate(
         version=20250131115248 OR version=20250902085503 OR version=20250201145630 OR
         version=20250201145631 OR version=20250201145632 OR version=20251006143821"
     )
-    .execute(db)
+    .execute(custom_migrator.connection())
     .await
     {
         tracing::info!("Could not remove sqlx migrations: {err:#}");
@@ -310,7 +318,7 @@ pub async fn migrate(
                 sqlx::query("DELETE FROM _sqlx_migrations WHERE version = $1 AND checksum != $2")
                     .bind(m.version)
                     .bind(&*m.checksum)
-                    .execute(db)
+                    .execute(custom_migrator.connection())
                     .await
             {
                 tracing::info!("Could not clean up stale migration {}: {err:#}", m.version);
@@ -340,7 +348,7 @@ pub async fn migrate(
         }
     }
 
-    crate::live_migrations::custom_migrations(&mut custom_migrator, db).await?;
+    crate::live_migrations::custom_migrations(&mut custom_migrator).await?;
     Ok(None)
 }
 

--- a/backend/windmill-api/src/live_migrations.rs
+++ b/backend/windmill-api/src/live_migrations.rs
@@ -9,26 +9,26 @@
 use sqlx::Postgres;
 use windmill_common::error::Error;
 
-use crate::db::{CustomMigrator, DB};
+use crate::db::CustomMigrator;
 use sqlx::migrate::Migrate;
+use sqlx::Acquire;
 use sqlx::Executor;
 
-pub async fn custom_migrations(migrator: &mut CustomMigrator, db: &DB) -> Result<(), Error> {
-    if let Err(err) = fix_flow_versioning_migration(migrator, db).await {
+pub async fn custom_migrations(migrator: &mut CustomMigrator) -> Result<(), Error> {
+    if let Err(err) = fix_flow_versioning_migration(migrator).await {
         tracing::error!("Could not apply flow versioning fix migration: {err:#}");
     }
 
     Ok(())
 }
 
-async fn fix_flow_versioning_migration(
-    migrator: &mut CustomMigrator,
-    db: &DB,
-) -> Result<(), Error> {
+// Runs on the migrator's held connection (see CustomMigrator::connection): re-acquiring
+// from the pool here would deadlock a single-connection backend.
+async fn fix_flow_versioning_migration(migrator: &mut CustomMigrator) -> Result<(), Error> {
     let has_done_migration = sqlx::query_scalar!(
         "SELECT EXISTS(SELECT name FROM windmill_migrations WHERE name = 'fix_flow_versioning_2')",
     )
-    .fetch_one(db)
+    .fetch_one(migrator.connection())
     .await?
     .unwrap_or(false);
 
@@ -44,14 +44,14 @@ async fn fix_flow_versioning_migration(
             let has_done_migration = sqlx::query_scalar!(
                 "SELECT EXISTS(SELECT name FROM windmill_migrations WHERE name = 'fix_flow_versioning_2')",
             )
-            .fetch_one(db)
+            .fetch_one(migrator.connection())
             .await?
             .unwrap_or(false);
 
             if !has_done_migration {
                 let query = include_str!("../../custom_migrations/fix_flow_versioning_2.sql");
                 tracing::info!("Applying fix_flow_versioning_2.sql");
-                let mut tx: sqlx::Transaction<'_, Postgres> = db.begin().await?;
+                let mut tx: sqlx::Transaction<'_, Postgres> = migrator.connection().begin().await?;
                 tx.execute(query).await?;
                 tracing::info!("Applied fix_flow_versioning_2.sql");
                 sqlx::query!(


### PR DESCRIPTION
## Summary

During startup, `migrate()` and `fix_flow_versioning_migration` re-acquired a **second** connection from the pool while already holding one — the connection the migrator has checked out (and holds the migration advisory lock on). That's a self-deadlock against any backend limited to one connection at a time:

- connection-constrained managed Postgres (tight `max_connections`),
- PgBouncer in transaction-pooling mode,
- an embedded single-connection dev database (pglite/oliphaunt — see WIN-2130).

The runtime itself is fine on a single connection; this was purely a **migration-bootstrap** issue.

## Fix

Add a `CustomMigrator::connection()` accessor that exposes the already-checked-out connection, and route the migration-phase housekeeping onto it instead of re-acquiring from the pool:

- `windmill-api/src/db.rs` — the two `DELETE … _sqlx_migrations` housekeeping queries in `migrate()` now run on `custom_migrator.connection()`.
- `windmill-api/src/live_migrations.rs` — `fix_flow_versioning_migration` runs its existence check and its transaction on the migrator's connection (drops the now-unused pool parameter).

This reduces connection usage during migration, and for `fix_flow_versioning` the existence check and the write now happen on the **same advisory-locked connection** (tighter, not looser). Normal multi-connection deployments are unaffected — same SQL, same ordering, just a different (already-held) executor.

## Test plan
- [x] Default multi-connection dev backend rebuilds and boots healthy (`workers_alive`, `database_healthy=true`).
- [x] Fresh Postgres DB with the runtime pool capped at one connection (`DATABASE_CONNECTIONS=1`): server+worker boot, a bash script and a 2-step flow complete, `pg_stat_activity` shows a single connection.
- [x] End-to-end on an embedded single-connection Postgres (WIN-2130 experiment): migrations apply, server+worker boot, scripts and flows run.

Context / experiment that surfaced this: WIN-2130 (#9967).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent self-deadlock during startup migrations by running bootstrap housekeeping on the migrator’s already-held connection instead of acquiring another. Unblocks single-connection backends (PgBouncer tx-pool, low max_connections, embedded dev DB) with no behavior change for multi-connection deployments; addresses WIN-2130.

- **Bug Fixes**
  - Added CustomMigrator::connection() to use the migrator’s checked-out, advisory-locked connection.
  - Routed housekeeping DELETEs in migrate() and the flow versioning fix to that connection; removed the DB/pool param from custom_migrations.
  - Existence check and write for fix_flow_versioning_2 now run on the same connection; prevents self-deadlock on single-connection setups (WIN-2130).

<sup>Written for commit 54ce0c4dba4867afa0b6c149f228d53a8693c85d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

