### PR TITLE
fix(frontend): theme-aware prose palette for markdown in dark mode

### DIFF
--- a/frontend/src/routes/kitchen_sink/+page.svelte
+++ b/frontend/src/routes/kitchen_sink/+page.svelte
@@ -4,9 +4,37 @@
 	import TabContent from '$lib/components/common/tabs/TabContent.svelte'
 	import Tabs from '$lib/components/common/tabs/Tabs.svelte'
 	import DarkModeToggle from '$lib/components/sidebar/DarkModeToggle.svelte'
+	import GfmMarkdown from '$lib/components/GfmMarkdown.svelte'
 	import { Globe } from 'lucide-svelte'
 
 	let tab = $state('button')
+
+	const sampleMarkdown = `# Heading 1
+
+## Heading 2
+
+Body text with **bold**, *italic*, a [link](https://windmill.dev), and \`inline code\` that must stay readable in both themes.
+
+> A block quote should be legible too.
+
+- First bullet
+- Second bullet with \`code\`
+
+1. Ordered one
+2. Ordered two
+
+\`\`\`ts
+const block = 'code block'
+console.log(block)
+\`\`\`
+
+| Column A | Column B |
+| -------- | -------- |
+| one      | two      |
+| three    | four     |
+
+---
+`
 	let dropdownItems = [
 		{
 			label: 'Lorem ipsum',
@@ -19,6 +47,7 @@
 
 <Tabs bind:selected={tab}>
 	<Tab value="button" label="Buttons" />
+	<Tab value="markdown" label="Markdown" />
 
 	{#snippet content()}
 		<TabContent value="button" class="p-4 flex gap-4 flex-col ">
@@ -71,6 +100,9 @@
 				<Button variant="default" {dropdownItems}>Lorem</Button>
 				<Button variant="default" {dropdownItems}>Lorem</Button>
 			</div>
+		</TabContent>
+		<TabContent value="markdown" class="p-4">
+			<GfmMarkdown md={sampleMarkdown} />
 		</TabContent>
 	{/snippet}
 </Tabs>

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -456,17 +456,46 @@ const config = {
 			]
 		},
 		extend: {
-			// Tailwind Typography hardcodes `pre` code blocks to a dark background
-			// (gray-800) in both light and dark mode, so they render dark-on-light in
-			// light mode. Point the pre/pre-code variables at theme-aware surface
-			// tokens (light and inverted) so code blocks track the active theme.
+			// Tailwind Typography hardcodes every `prose` color (body, headings,
+			// borders, code, ...) to fixed gray shades. Our `.prose` usages mostly
+			// render without `dark:prose-invert`, so in dark mode those light-mode
+			// grays stay put and text/borders/code render near-black on a dark
+			// surface. Point the whole palette at our theme tokens — which already
+			// flip with the active theme — for BOTH the default and inverted sets, so
+			// bare `.prose` and `dark:prose-invert` usages both track the theme.
 			typography: {
 				DEFAULT: {
 					css: {
-						'--tw-prose-pre-bg': 'rgb(var(--color-surface-secondary))',
+						'--tw-prose-body': 'rgb(var(--color-text-secondary))',
+						'--tw-prose-headings': 'rgb(var(--color-text-primary))',
+						'--tw-prose-lead': 'rgb(var(--color-text-secondary))',
+						'--tw-prose-bold': 'rgb(var(--color-text-primary))',
+						'--tw-prose-counters': 'rgb(var(--color-text-tertiary))',
+						'--tw-prose-bullets': 'rgb(var(--color-text-tertiary))',
+						'--tw-prose-hr': 'rgb(var(--color-border-light))',
+						'--tw-prose-quotes': 'rgb(var(--color-text-secondary))',
+						'--tw-prose-quote-borders': 'rgb(var(--color-border-light))',
+						'--tw-prose-captions': 'rgb(var(--color-text-tertiary))',
+						'--tw-prose-code': 'rgb(var(--color-text-primary))',
 						'--tw-prose-pre-code': 'rgb(var(--color-text-primary))',
+						'--tw-prose-pre-bg': 'rgb(var(--color-surface-secondary))',
+						'--tw-prose-th-borders': 'rgb(var(--color-border-light))',
+						'--tw-prose-td-borders': 'rgb(var(--color-border-light))',
+						'--tw-prose-invert-body': 'rgb(var(--color-text-secondary))',
+						'--tw-prose-invert-headings': 'rgb(var(--color-text-primary))',
+						'--tw-prose-invert-lead': 'rgb(var(--color-text-secondary))',
+						'--tw-prose-invert-bold': 'rgb(var(--color-text-primary))',
+						'--tw-prose-invert-counters': 'rgb(var(--color-text-tertiary))',
+						'--tw-prose-invert-bullets': 'rgb(var(--color-text-tertiary))',
+						'--tw-prose-invert-hr': 'rgb(var(--color-border-light))',
+						'--tw-prose-invert-quotes': 'rgb(var(--color-text-secondary))',
+						'--tw-prose-invert-quote-borders': 'rgb(var(--color-border-light))',
+						'--tw-prose-invert-captions': 'rgb(var(--color-text-tertiary))',
+						'--tw-prose-invert-code': 'rgb(var(--color-text-primary))',
+						'--tw-prose-invert-pre-code': 'rgb(var(--color-text-primary))',
 						'--tw-prose-invert-pre-bg': 'rgb(var(--color-surface-secondary))',
-						'--tw-prose-invert-pre-code': 'rgb(var(--color-text-primary))'
+						'--tw-prose-invert-th-borders': 'rgb(var(--color-border-light))',
+						'--tw-prose-invert-td-borders': 'rgb(var(--color-border-light))'
 					}
 				}
 			},


### PR DESCRIPTION
## Summary

Markdown rendered via Tailwind Typography (`.prose`) was hardcoded to fixed gray shades for every element. Since most of our `.prose` usages render **without** `dark:prose-invert` (e.g. `GfmMarkdown.svelte`), in dark mode those light-mode grays stayed put and text/borders/inline-code rendered near-black on a dark surface.

This extends the earlier fix (#9968, which only covered `pre`/block code) to the **whole** prose palette by pointing the prose CSS variables at the app's runtime theme tokens — which already flip with the active theme — for **both** the default and inverted sets.

## Changes

- `frontend/tailwind.config.cjs`: map `--tw-prose-*` and `--tw-prose-invert-*` (body, headings, lead, bold, counters, bullets, hr, quotes, quote-borders, captions, code, pre-code, pre-bg, th/td-borders) to theme tokens:
  - text → `--color-text-primary` / `--color-text-secondary` / `--color-text-tertiary`
  - borders → `--color-border-light`
  - code-block background → `--color-surface-secondary`
- `frontend/src/routes/kitchen_sink/+page.svelte`: add a **Markdown** tab rendering the real `GfmMarkdown` component with a representative sample, so the theme-aware rendering can be eyeballed (and regressions caught) via the showcase's dark-mode toggle.

Links are intentionally left alone — `app.css` already styles `.prose a` with `text-accent` (theme-aware), which overrides the prose link variable.

## Screenshots

Real `GfmMarkdown` component on `/kitchen_sink`:

| Light | Dark |
|-------|------|
| ![md-light](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-markdown-dark/1783363903-md-light.png) | ![md-dark](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-markdown-dark/1783363903-md-dark.png) |

## Test plan

- [ ] Open `/kitchen_sink` → **Markdown** tab; toggle dark mode. Confirm headings, body, bold, inline `code`, block `pre`, block quote, bullets, table borders, and `hr` are all legible in both themes.
- [ ] Verify a `dark:prose-invert` surface (AI chat assistant message) still renders correctly in both light and dark mode (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)