### PR TITLE
chore: update base image to debian 13 (trixie)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-ARG DEBIAN_IMAGE=debian:bookworm-slim
-ARG RUST_IMAGE=rust:1.93-slim-bookworm
+ARG DEBIAN_IMAGE=debian:trixie-slim
+ARG RUST_IMAGE=rust:1.93-slim-trixie
 
-FROM debian:bookworm-slim AS nsjail
+FROM debian:trixie-slim AS nsjail
 
 WORKDIR /nsjail
 
@@ -9,12 +9,12 @@ RUN apt-get -y update \
     && apt-get install -y \
     bison=2:3.8.* \
     flex=2.6.* \
-    g++=4:12.2.* \
-    gcc=4:12.2.* \
-    git=1:2.39.* \
+    g++=4:14.2.* \
+    gcc=4:14.2.* \
+    git=1:2.47.* \
     libprotobuf-dev=3.21.* \
     libnl-route-3-dev=3.7.* \
-    make=4.3-4.1 \
+    make=4.4.* \
     pkg-config=1.8.* \
     protobuf-compiler=3.21.*
 
@@ -44,7 +44,7 @@ FROM rust_base AS windmill_duckdb_ffi_internal_builder
 
 WORKDIR /windmill-duckdb-ffi-internal
 
-RUN apt-get update && apt-get install -y clang=1:14.0-55.* libclang-dev=1:14.0-55.* cmake=3.25.* && \
+RUN apt-get update && apt-get install -y clang=1:19.0* libclang-dev=1:19.0* cmake=3.31.* && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -98,7 +98,7 @@ ARG features=""
 
 COPY --from=planner /windmill/recipe.json recipe.json
 
-RUN apt-get update && apt-get install -y libxml2-dev=2.9.* libxmlsec1-dev=1.2.* libkrb5-dev libsasl2-dev libcurl4-openssl-dev clang=1:14.0-55.* libclang-dev=1:14.0-55.* cmake=3.25.* && \
+RUN apt-get update && apt-get install -y libxml2-dev=2.12.* libxmlsec1-dev=1.2.* libkrb5-dev libsasl2-dev libcurl4-openssl-dev clang=1:19.0* libclang-dev=1:19.0* cmake=3.31.* && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -135,7 +135,6 @@ FROM ${DEBIAN_IMAGE}
 
 ARG TARGETPLATFORM
 ARG POWERSHELL_VERSION=7.5.0
-ARG POWERSHELL_DEB_VERSION=7.5.0-1
 ARG KUBECTL_VERSION=1.28.7
 ARG HELM_VERSION=3.14.3
 # NOTE: If changing, also change go version in workspace dependencies template at WorkspaceDependenciesEditor.svelte
@@ -183,12 +182,14 @@ RUN if [ "$WITH_GIT" = "true" ]; then \
     && rm -rf /var/lib/apt/lists/*; \
     else echo 'Building the image without git'; fi;
 
+# PowerShell ships as a tarball: the upstream .deb depends on libicu<=74 which no longer exists in trixie
 RUN if [ "$WITH_POWERSHELL" = "true" ]; then \
-    if [ "$TARGETPLATFORM" = "linux/amd64" ]; then apt-get update -y && apt install libicu72 -y && wget -O 'pwsh.deb' "https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell_${POWERSHELL_DEB_VERSION}.deb_amd64.deb" && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* && \
-    dpkg --install 'pwsh.deb' && \
-    rm 'pwsh.deb'; \
-    elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then apt-get update -y && apt install libicu72 -y && wget -O powershell.tar.gz "https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell-${POWERSHELL_VERSION}-linux-arm64.tar.gz" && apt-get clean \
+    case "$TARGETPLATFORM" in \
+    "linux/amd64") pwsh_arch=x64 ;; \
+    "linux/arm64") pwsh_arch=arm64 ;; \
+    *) pwsh_arch="" ;; \
+    esac; \
+    if [ -n "$pwsh_arch" ]; then apt-get update -y && apt install libicu76 -y && wget -O powershell.tar.gz "https://github.com/PowerShell/PowerShell/releases/download/v${POWERSHELL_VERSION}/powershell-${POWERSHELL_VERSION}-linux-${pwsh_arch}.tar.gz" && apt-get clean \
     && rm -rf /var/lib/apt/lists/* && \
     mkdir -p /opt/microsoft/powershell/7 && \
     tar zxf powershell.tar.gz -C /opt/microsoft/powershell/7 && \
@@ -292,7 +293,7 @@ RUN bun install -g windmill-cli \
 RUN curl -fsSL https://claude.ai/install.sh | bash \
     && cp /root/.local/share/claude/versions/* /usr/bin/claude
 
-COPY --from=php:8.3.30-cli-bookworm /usr/local/bin/php /usr/bin/php
+COPY --from=php:8.3.30-cli-trixie /usr/local/bin/php /usr/bin/php
 COPY --from=composer:2.9.5 /usr/bin/composer /usr/bin/composer
 
 # add the docker client to call docker from a worker if enabled
@@ -303,7 +304,7 @@ ENV CARGO_HOME="/tmp/windmill/cache/cargo"
 ENV LD_LIBRARY_PATH="."
 
 # nsjail runtime deps and binary
-RUN apt-get update && apt-get install -y --no-install-recommends libprotobuf32 libnl-route-3-200 libnl-3-200 \
+RUN apt-get update && apt-get install -y --no-install-recommends libprotobuf32t64 libnl-route-3-200 libnl-3-200 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 

--- a/docker/DockerfileFullEe
+++ b/docker/DockerfileFullEe
@@ -35,7 +35,10 @@ RUN wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh \
 
 # Oracle DB Client
 COPY --from=oracledb-client /opt/oracle/23/lib /opt/oracle/23/lib
-RUN apt-get -y update && apt-get install -y libaio1
+# libaio1t64 only ships libaio.so.1t64; Oracle instantclient loads libaio.so.1, so add a compat symlink
+RUN apt-get -y update && apt-get install -y libaio1t64 \
+    && libaio="$(find /usr/lib -name 'libaio.so.1t64' -print -quit)" \
+    && ln -s "$(basename "$libaio")" "$(dirname "$libaio")/libaio.so.1"
 RUN echo /opt/oracle/23/lib > /etc/ld.so.conf.d/oracle-instantclient.conf && ldconfig
 
 # Nushell

--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -1,6 +1,6 @@
-ARG DEBIAN_IMAGE=debian:bookworm-slim
+ARG DEBIAN_IMAGE=debian:trixie-slim
 
-FROM debian:bookworm-slim AS nsjail
+FROM debian:trixie-slim AS nsjail
 
 WORKDIR /nsjail
 
@@ -9,12 +9,12 @@ RUN apt-get -y update \
     bison=2:3.8.* \
     ca-certificates \
     flex=2.6.* \
-    g++=4:12.2.* \
-    gcc=4:12.2.* \
-    git=1:2.39.* \
+    g++=4:14.2.* \
+    gcc=4:14.2.* \
+    git=1:2.47.* \
     libprotobuf-dev=3.21.* \
     libnl-route-3-dev=3.7.* \
-    make=4.3-4.1 \
+    make=4.4.* \
     pkg-config=1.8.* \
     protobuf-compiler=3.21.* \
     && apt-get clean \
@@ -39,7 +39,7 @@ ENV PATH=/usr/local/bin:/root/.local/bin:/tmp/.local/bin:$PATH
 
 # Install system dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates wget curl git jq unzip unixodbc xmlsec1 gnupg lsb-release libgnutls30 libgcrypt20 \
+    && apt-get install -y --no-install-recommends ca-certificates wget curl git jq unzip unixodbc xmlsec1 gnupg lsb-release libgnutls30t64 libgcrypt20 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -86,7 +86,7 @@ COPY --from=docker:29-dind /usr/local/bin/docker /usr/local/bin/
 
 # nsjail runtime deps and binary
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libprotobuf32 libnl-route-3-200 libnl-3-200 \
+    && apt-get install -y --no-install-recommends libprotobuf32t64 libnl-route-3-200 libnl-3-200 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -1,6 +1,6 @@
-ARG DEBIAN_IMAGE=debian:bookworm-slim
+ARG DEBIAN_IMAGE=debian:trixie-slim
 
-FROM debian:bookworm-slim AS nsjail
+FROM debian:trixie-slim AS nsjail
 
 WORKDIR /nsjail
 
@@ -9,12 +9,12 @@ RUN apt-get -y update \
     bison=2:3.8.* \
     ca-certificates \
     flex=2.6.* \
-    g++=4:12.2.* \
-    gcc=4:12.2.* \
-    git=1:2.39.* \
+    g++=4:14.2.* \
+    gcc=4:14.2.* \
+    git=1:2.47.* \
     libprotobuf-dev=3.21.* \
     libnl-route-3-dev=3.7.* \
-    make=4.3-4.1 \
+    make=4.4.* \
     pkg-config=1.8.* \
     protobuf-compiler=3.21.* \
     && apt-get clean \
@@ -39,7 +39,7 @@ ENV PATH=/usr/local/bin:/root/.local/bin:/tmp/.local/bin:$PATH
 
 # Install system dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates wget curl git jq unzip unixodbc xmlsec1 gnupg lsb-release libgnutls30 libgcrypt20 \
+    && apt-get install -y --no-install-recommends ca-certificates wget curl git jq unzip unixodbc xmlsec1 gnupg lsb-release libgnutls30t64 libgcrypt20 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -86,7 +86,7 @@ COPY --from=docker:29-dind /usr/local/bin/docker /usr/local/bin/
 
 # nsjail runtime deps and binary
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libprotobuf32 libnl-route-3-200 libnl-3-200 \
+    && apt-get install -y --no-install-recommends libprotobuf32t64 libnl-route-3-200 libnl-3-200 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=nsjail /nsjail/nsjail /bin/nsjail
 

--- a/sandbox-image/Dockerfile.sandbox
+++ b/sandbox-image/Dockerfile.sandbox
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 # ── Minimal system deps ──────────────────────────────────────────────────────
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

Fixes WIN-2135

Migrates all Debian-based Windmill images from Debian 12 (bookworm) to Debian 13 (trixie), ahead of bookworm's EOL (July 11, 2026). This applies to the final runtime image, the Rust builder (`rust:1.93-slim-trixie`), and the nsjail build stage, so the shipped binary and every shared library it loads come from the same (current) distro.

OS-package vulnerability counts (trivy, `--pkg-types os`), comparing `ghcr.io/windmill-labs/windmill:main` against the runtime stage of this Dockerfile rebuilt on trixie:

| Severity | bookworm (`:main`) | trixie (this PR) |
|---|---|---|
| CRITICAL | 19 | 15 |
| HIGH | 287 | 90 |
| MEDIUM | 1301 | 438 |
| LOW | 928 | 746 |

## Changes

- `Dockerfile`: `DEBIAN_IMAGE` → `debian:trixie-slim`, `RUST_IMAGE` → `rust:1.93-slim-trixie`; nsjail stage on trixie with updated toolchain pins (gcc/g++ 14.2, git 2.47, make 4.4); builder stages move to clang 19 / cmake 3.31 / libxml2-dev 2.12 (trixie still ships xmlsec1 **1.2** and protobuf **3.21**, so no library-major bumps ride along); `php:8.3.30-cli-trixie`
- **PowerShell**: installed from the tarball on both amd64 and arm64. The upstream `.deb` declares `Depends: libicu74|libicu72|…` which is uninstallable on trixie (verified: dpkg dependency failure); trixie ships `libicu76`. Same install prefix (`/opt/microsoft/powershell/7`), so the nsjail mount contract (`run.powershell.config.proto`) is unchanged. Drops the now-unused `POWERSHELL_DEB_VERSION` arg.
- **t64 package renames** (Debian's 64-bit `time_t` ABI transition): `libprotobuf32` → `libprotobuf32t64` (Dockerfile, Slim, SlimEe), `libgnutls30` → `libgnutls30t64` (Slim, SlimEe), `libaio1` → `libaio1t64` (FullEe)
- `docker/DockerfileFullEe`: `libaio1t64` only ships `libaio.so.1t64`, but Oracle instantclient loads `libaio.so.1` — added a compat symlink (standard workaround on t64 distros)
- `docker/DockerfileSlim`, `docker/DockerfileSlimEe`: nsjail stage + base image to trixie, same pin updates
- `sandbox-image/Dockerfile.sandbox`: base to trixie-slim

Not changed on purpose: `docker/RHEL{8,9}/Dockerfile` (their `DEBIAN_IMAGE` arg is declared but never consumed), `.devcontainer` (independent dev environment), `.github/DockerfileBackendTests` (CI-only, not shipped), nushell `0.101.0-bookworm` binary copy in Full images (no trixie tag for that release; bookworm-built binary is forward-compatible with trixie's glibc).

## Validation

Every image was built and smoke-tested, either in this PR's CI or locally (amd64):

| Image | How it was validated |
|---|---|
| `Dockerfile` cargo builder stages (CE + EE, amd64 + arm64) | ✅ **CI on this PR**: `build` (23m46s) and `build_ee` (26m34s) passed — full cargo build on `rust:1.93-slim-trixie` incl. EE features (samael/xmlsec against trixie's xmlsec1 1.2.41), plus `windmill cache`/`cache-rt` executing in the trixie runtime stage |
| `Dockerfile` nsjail stage | ✅ local build on trixie (gcc 14), binary runs |
| `Dockerfile` final runtime stage | ✅ local build on trixie with the published `windmill:main` binary; `windmill cache` + `cache-rt` executed in-image; smoke: pwsh 7.5, php 8.3.30, node 20 (nodesource ok), bun, deno, go 1.26, uv + Py 3.11/3.12, awscli (now v2, from trixie repos), pg_dump 18 (pgdg has trixie dists), helm, kubectl, wmill, crane, docker, nsjail; `ldd` clean on `windmill`, DuckDB FFI lib, nsjail, php |
| `docker/DockerfileSlim` | ✅ local full build on trixie (incl. nsjail stage, `libgnutls30t64` deps, cache/cache-rt); smoke: nsjail, bun, wmill, uv/python, pg_dump, docker, crane, claude; `ldd` clean |
| `docker/DockerfileSlimEe` | ✅ apt/install layers are identical to Slim (only the binary source differs); additionally verified the **EE** `windmill-ee:dev` binary on the trixie slim image: `ldd` fully resolved, starts up to the expected missing-`DATABASE_URL` error |
| `docker/DockerfileFullEe` (superset of `DockerfileFull`) | ✅ local build on top of the trixie runtime image as a stand-in for `windmill-ee:dev`; smoke: java 21 + coursier, ruby 3.3, R 4.5 + renv, dotnet 9, nushell (bookworm binary), ansible, cargo-sweep, iptables, krb5; **Oracle instantclient resolves `libaio.so.1` via the new compat symlink** (`ldd libclntsh.so` clean) |
| `sandbox-image/Dockerfile.sandbox` | ✅ local build on trixie; smoke: nix profile, chromium (nix), node 24, psql 17, claude, codex, mermaid-cli |

All trixie apt pins were verified against actual trixie candidates (`apt-cache policy` in `debian:trixie-slim`).

## Test plan

- [x] CI image builds on this PR (CE + EE, amd64 + arm64) pass
- [x] All derived images (Slim/SlimEe/Full/FullEe/sandbox) built and smoke-tested locally on trixie
- [x] Oracle instantclient `libaio.so.1` resolution verified through the compat symlink
- [x] **Per-language job e2e on the trixie FullEe image** (built on trixie with the `windmill-ee:dev` binary, booted standalone + a `native` worker-group container against a fresh DB, one preview job per language via API):

  `python3`, `deno`, `bun`, `bunnative`, `nativets`, `go`, `bash`, `powershell`, `php`, `rust` (with cargo manifest, compiles 10 crates in-image), `csharp`, `java`, `ruby`, `nu`, `rlang`, `ansible`, `postgresql`, `duckdb`, `graphql` — **19/19 returned their expected results.** Not locally testable (need external servers): `mysql`, `bigquery`, `snowflake`, `mssql`, `oracledb` (Oracle client-library linkage verified via `ldd` instead).

- [x] **nsjail-sandboxed execution on trixie**: re-ran `python3`, `bun`, `bash`, `powershell`, `go`, `deno` with `DISABLE_NSJAIL=false` — all pass, job logs confirm `isolation=nsjail` (the trixie-built nsjail binary sandboxing for real)

🤖 Generated with [Claude Code](https://claude.com/claude-code)