### PR TITLE
raw-apps: prevent + surface the silent blank-screen (unmounted #root)

### DIFF
--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -5585,7 +5585,21 @@ A raw app has three logical parts:
 
 ### Entrypoint
 
-\`index.tsx\` is the bundling entrypoint. It typically renders a top-level \`App\` component. The bundler is esbuild.
+\`index.tsx\` is the bundling **and mount** entrypoint (esbuild bundles it; the preview then executes it against an empty \`<div id="root">\`). It MUST itself mount a top-level \`App\` component into \`#root\` — nothing is auto-rendered for you. Keep your UI in \`App.tsx\` (or \`App.svelte\` / \`App.vue\`) and keep \`index.tsx\` as the mount shim.
+
+React:
+
+\`\`\`tsx
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+
+createRoot(document.getElementById('root')!).render(<App />)
+\`\`\`
+
+Svelte: \`mount(App, { target: document.getElementById('root')! })\`. Vue: \`createApp(App).mount('#root')\`.
+
+**Never turn \`index.tsx\` into a bare component** (e.g. \`export default function App() { ... }\` with no \`createRoot(...).render(...)\`). A component that is defined but never mounted renders **a blank screen with NO error thrown** — the JSX never executes, so nothing surfaces in the console or the error overlay. If the app is blank, the first thing to check is that \`index.tsx\` actually calls \`createRoot(document.getElementById('root')!).render(<App />)\`.
 
 **Always begin every React file (\`.tsx\`/\`.jsx\`) that uses JSX with \`import React from 'react'\`.** esbuild uses the classic JSX transform, so \`React\` must be in scope wherever JSX appears — a missing import compiles fine but throws \`React is not defined\` at runtime, leaving a blank screen.
 

--- a/frontend/src/lib/components/copilot/chat/app/core.ts
+++ b/frontend/src/lib/components/copilot/chat/app/core.ts
@@ -925,6 +925,16 @@ export function prepareAppSystemMessage(customPrompt?: string): ChatCompletionSy
 
 ### Frontend
 - The frontend is bundled using esbuild with entrypoint \`index.tsx\`
+- \`index.tsx\` is also the **mount** entrypoint: it MUST mount a top-level \`App\` into \`#root\` — nothing is auto-rendered. Keep your UI in \`App.tsx\` and keep \`index.tsx\` as the mount shim:
+  \`\`\`tsx
+  import React from 'react'
+  import { createRoot } from 'react-dom/client'
+  import App from './App'
+
+  createRoot(document.getElementById('root')!).render(<App />)
+  \`\`\`
+  (Svelte: \`mount(App, { target: document.getElementById('root')! })\`; Vue: \`createApp(App).mount('#root')\`.)
+- **Never replace \`index.tsx\` with a bare component.** A component that is defined but never mounted produces a **blank screen with NO error** (the JSX never runs, so nothing throws). If the app renders blank, first verify \`index.tsx\` calls \`createRoot(document.getElementById('root')!).render(<App />)\`.
 - Frontend files are managed separately from backend runnables
 - The \`wmill.d.ts\` file is generated automatically from the backend runnables shape
 - Begin every React file (\`.tsx\`/\`.jsx\`) that uses JSX with \`import React from 'react'\`. Raw apps bundle with the classic JSX transform, so \`React\` must be in scope wherever JSX is used — a missing import compiles fine but throws \`React is not defined\` at runtime.

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -1109,6 +1109,12 @@
 			emptyRender = true
 			return
 		}
+		// A slow app (async fetch, Suspense) mounted #root after the empty-render
+		// grace window, so the preview retracts the hint to avoid a false positive.
+		if (fromPreview && e.data.type === 'renderAppeared') {
+			emptyRender = false
+			return
+		}
 
 		// Inspector events come exclusively from the preview iframe.
 		if (fromPreview && e.data.type === 'inspectorSelect') {

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -282,6 +282,10 @@
 	let buildError = $state<string | undefined>(undefined)
 	// Latest uncaught runtime error thrown by the rendered app; cleared on next build.
 	let runtimeError = $state<string | undefined>(undefined)
+	// True when a build ran cleanly but never mounted anything into #root (e.g. the
+	// entrypoint defines a component but never calls createRoot(...).render(...)).
+	// Cleared on next build.
+	let emptyRender = $state(false)
 	let logsCollapsed = $state(false)
 	let logsDiv: HTMLDivElement | undefined = $state(undefined)
 	$effect(() => {
@@ -1099,6 +1103,13 @@
 			return
 		}
 
+		// Build ran but #root stayed empty — the entrypoint likely never mounted
+		// the app. Surfaced as a hint so a silent blank screen is self-explanatory.
+		if (fromPreview && e.data.type === 'emptyRender') {
+			emptyRender = true
+			return
+		}
+
 		// Inspector events come exclusively from the preview iframe.
 		if (fromPreview && e.data.type === 'inspectorSelect') {
 			inspectorElement = e.data.element as InspectorElementInfo
@@ -1193,6 +1204,7 @@
 	// render throws again app-preview.html re-posts `runtimeError`.
 	function feedPreviewIframe(build: { css: string; js: string }) {
 		runtimeError = undefined
+		emptyRender = false
 		previewIframe?.contentWindow?.postMessage(
 			{ type: 'preview', css: build.css, js: build.js },
 			'*'
@@ -1957,6 +1969,23 @@
 											<pre class="overflow-auto whitespace-pre-wrap text-xs max-h-60"
 												>{runtimeError}</pre
 											>
+										</Alert>
+									</div>
+								{:else if emptyRender}
+									<div class="absolute top-12 left-2 right-2 z-20 isolate" role="status">
+										<Alert
+											type="info"
+											title="Nothing rendered"
+											class="relative before:absolute before:inset-0 before:-z-10 before:rounded-md before:bg-surface before:content-['']"
+										>
+											<span class="text-xs">
+												The build succeeded but nothing was mounted into <code>#root</code>. Make
+												sure your entrypoint (<code>index.tsx</code>) calls
+												<code
+													>createRoot(document.getElementById('root')!).render(&lt;App /&gt;)</code
+												>
+												rather than only defining a component.
+											</span>
 										</Alert>
 									</div>
 								{/if}

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -611,7 +611,21 @@ A raw app has three logical parts:
 
 ### Entrypoint
 
-\`index.tsx\` is the bundling entrypoint. It typically renders a top-level \`App\` component. The bundler is esbuild.
+\`index.tsx\` is the bundling **and mount** entrypoint (esbuild bundles it; the preview then executes it against an empty \`<div id="root">\`). It MUST itself mount a top-level \`App\` component into \`#root\` — nothing is auto-rendered for you. Keep your UI in \`App.tsx\` (or \`App.svelte\` / \`App.vue\`) and keep \`index.tsx\` as the mount shim.
+
+React:
+
+\`\`\`tsx
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+
+createRoot(document.getElementById('root')!).render(<App />)
+\`\`\`
+
+Svelte: \`mount(App, { target: document.getElementById('root')! })\`. Vue: \`createApp(App).mount('#root')\`.
+
+**Never turn \`index.tsx\` into a bare component** (e.g. \`export default function App() { ... }\` with no \`createRoot(...).render(...)\`). A component that is defined but never mounted renders **a blank screen with NO error thrown** — the JSX never executes, so nothing surfaces in the console or the error overlay. If the app is blank, the first thing to check is that \`index.tsx\` actually calls \`createRoot(document.getElementById('root')!).render(<App />)\`.
 
 **Always begin every React file (\`.tsx\`/\`.jsx\`) that uses JSX with \`import React from 'react'\`.** esbuild uses the classic JSX transform, so \`React\` must be in scope wherever JSX appears — a missing import compiles fine but throws \`React is not defined\` at runtime, leaving a blank screen.
 

--- a/system_prompts/auto-generated/skills/raw-app/SKILL.md
+++ b/system_prompts/auto-generated/skills/raw-app/SKILL.md
@@ -249,7 +249,21 @@ A raw app has three logical parts:
 
 ### Entrypoint
 
-`index.tsx` is the bundling entrypoint. It typically renders a top-level `App` component. The bundler is esbuild.
+`index.tsx` is the bundling **and mount** entrypoint (esbuild bundles it; the preview then executes it against an empty `<div id="root">`). It MUST itself mount a top-level `App` component into `#root` — nothing is auto-rendered for you. Keep your UI in `App.tsx` (or `App.svelte` / `App.vue`) and keep `index.tsx` as the mount shim.
+
+React:
+
+```tsx
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+
+createRoot(document.getElementById('root')!).render(<App />)
+```
+
+Svelte: `mount(App, { target: document.getElementById('root')! })`. Vue: `createApp(App).mount('#root')`.
+
+**Never turn `index.tsx` into a bare component** (e.g. `export default function App() { ... }` with no `createRoot(...).render(...)`). A component that is defined but never mounted renders **a blank screen with NO error thrown** — the JSX never executes, so nothing surfaces in the console or the error overlay. If the app is blank, the first thing to check is that `index.tsx` actually calls `createRoot(document.getElementById('root')!).render(<App />)`.
 
 **Always begin every React file (`.tsx`/`.jsx`) that uses JSX with `import React from 'react'`.** esbuild uses the classic JSX transform, so `React` must be in scope wherever JSX appears — a missing import compiles fine but throws `React is not defined` at runtime, leaving a blank screen.
 

--- a/system_prompts/base/raw-app.md
+++ b/system_prompts/base/raw-app.md
@@ -14,7 +14,21 @@ A raw app has three logical parts:
 
 ### Entrypoint
 
-`index.tsx` is the bundling entrypoint. It typically renders a top-level `App` component. The bundler is esbuild.
+`index.tsx` is the bundling **and mount** entrypoint (esbuild bundles it; the preview then executes it against an empty `<div id="root">`). It MUST itself mount a top-level `App` component into `#root` — nothing is auto-rendered for you. Keep your UI in `App.tsx` (or `App.svelte` / `App.vue`) and keep `index.tsx` as the mount shim.
+
+React:
+
+```tsx
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+
+createRoot(document.getElementById('root')!).render(<App />)
+```
+
+Svelte: `mount(App, { target: document.getElementById('root')! })`. Vue: `createApp(App).mount('#root')`.
+
+**Never turn `index.tsx` into a bare component** (e.g. `export default function App() { ... }` with no `createRoot(...).render(...)`). A component that is defined but never mounted renders **a blank screen with NO error thrown** — the JSX never executes, so nothing surfaces in the console or the error overlay. If the app is blank, the first thing to check is that `index.tsx` actually calls `createRoot(document.getElementById('root')!).render(<App />)`.
 
 **Always begin every React file (`.tsx`/`.jsx`) that uses JSX with `import React from 'react'`.** esbuild uses the classic JSX transform, so `React` must be in scope wherever JSX appears — a missing import compiles fine but throws `React is not defined` at runtime, leaving a blank screen.
 


### PR DESCRIPTION
## Summary

AI-generated (or hand-written) React raw apps could render a **blank screen with no error** when `index.tsx` was written as a bare `export default function App() {...}` that never mounts anything. The preview harness bundles and executes `index.tsx` against an empty `<div id="root">` but does **not** auto-render a default export — the entrypoint must itself call `createRoot(document.getElementById('root')!).render(<App />)`. When it doesn't, the JSX lives inside an uncalled function, so nothing throws and the runtime-error overlay stays silent.

This PR tackles the failure mode from two sides:

1. **Prevent** it — strengthen the raw-app AI prompt so the mount requirement is explicit.
2. **Surface** it — when a build still renders nothing, show an info overlay in the editor that names the exact fix.

## Changes

### Prompt (prevention)
- `system_prompts/base/raw-app.md` — rewrote the Entrypoint section: `index.tsx` is the bundling **and mount** entrypoint, MUST mount `App` into `#root` (React/Svelte/Vue snippets), and never be replaced with a bare component. Added a blank-screen debugging note.
- `frontend/src/lib/components/copilot/chat/app/core.ts` — same mount-entrypoint guidance in the in-chat app system prompt's Frontend section.
- Regenerated derived files via `system_prompts/generate.py`: `prompts.ts`, `skills/raw-app/SKILL.md`, `cli/src/guidance/skills.gen.ts`.

### Overlay (detection)
- `frontend/src/lib/components/raw_apps/RawAppEditor.svelte` — handle a new `emptyRender` message from the preview iframe and render an info `Alert` ("Nothing rendered") pointing at the missing `createRoot(...).render(...)` call. Mirrors the existing runtime-error overlay; cleared on next build.
- Also handle `renderAppeared` — the preview **retracts** the hint if a slow app (async fetch, Suspense) mounts `#root` after the grace window, so a legitimate late render can't leave a false-positive overlay.
- Both messages are emitted by the preview harness in the builder repo: **windmill-labs/windmill-code-ui-builder#17**. That change polls `#root` after each build and posts `emptyRender` when nothing mounted (suppressed if a runtime error already explained the blank screen), then watches for a late mount to post `renderAppeared`.
- The host handlers here are **dormant-safe** until the builder tarball that emits these messages is pinned, so they land ahead of the artifact bump.

## Screenshots

![emptyrender-overlay](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm-fix-react-blank-app/emptyrender-overlay.png)

A bare-component `index.tsx` (`export default App`, no `createRoot`) builds successfully (see logs) yet mounts nothing — the "Nothing rendered" overlay names the fix.

## Sequencing

The overlay only fires once the builder tarball emits `emptyRender`:

1. Merge builder PR windmill-labs/windmill-code-ui-builder#17 → CI publishes a new tarball to R2.
2. Bump `frontend/scripts/ui_builder_artifact.json` (new version + sha256) — follow-up commit on this PR.

## Test plan

- [ ] Generate a React raw app via copilot chat; confirm `index.tsx` includes `createRoot(document.getElementById('root')!).render(<App />)` rather than a bare component.
- [ ] Confirm source↔generated consistency (grep the new wording in all three generated files).
- [x] Bare-component build shows the "Nothing rendered" overlay; overlay clears on a rebuild that mounts `#root`; runtime error suppresses it (browser-verified, see screenshot).
- [x] False-positive retraction (browser-verified against the running editor): late-mount build (`#root` filled at 1000ms) → overlay appears @612ms, **retracts @1018ms** via `renderAppeared`; permanently-empty build keeps the overlay; immediate render never shows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

