### PR TITLE
feat: open runs/schedules pages from AI chat in session preview tabs

### DIFF
--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -872,6 +872,103 @@
     - fetches the logs for the requested job id
     - explains the failure from the returned logs (connection refused to the upstream API)
 
+# --- Page navigation (open_page) ---
+# The assistant should take the user to a Windmill page (Runs/Schedules) with the
+# right filters via open_page, rather than describing where to click or dumping the
+# data. No draft is produced, so the global judge is skipped and we validate the
+# tool call and its arguments.
+
+- id: global-openpage1-runs-failed-of-script
+  prompt: |-
+    Take me to the failed runs of the script at f/evals/global/greet_user so I can see what's going wrong.
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - open_page
+    forbiddenToolsUsed:
+      - write_script
+      - deploy_workspace_item
+      - delete_workspace_item
+    toolCallArgs:
+      - tool: open_page
+        field: page
+        stringIncludesAnyOf:
+          - runs
+      - tool: open_page
+        field: status
+        stringIncludesAnyOf:
+          - failure
+      - tool: open_page
+        field: path
+        stringIncludesAnyOf:
+          - f/evals/global/greet_user
+  skipJudge: true
+  judgeChecklist:
+    - opens the Runs page filtered to the failed runs of f/evals/global/greet_user
+    - applies both the failure status and the script path as filters
+    - does not write, deploy, or delete anything
+
+- id: global-openpage2-runs-of-schedule
+  prompt: |-
+    Open the runs page filtered to the jobs triggered by the schedule f/evals/global/nightly_digest.
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - open_page
+    forbiddenToolsUsed:
+      - write_script
+      - deploy_workspace_item
+      - delete_workspace_item
+    toolCallArgs:
+      - tool: open_page
+        field: page
+        stringIncludesAnyOf:
+          - runs
+      - tool: open_page
+        field: schedule_path
+        stringIncludesAnyOf:
+          - f/evals/global/nightly_digest
+  skipJudge: true
+  judgeChecklist:
+    - opens the Runs page filtered to jobs triggered by the f/evals/global/nightly_digest schedule
+    - passes the schedule path as the filter
+    - does not write, deploy, or delete anything
+
+- id: global-openpage3-open-schedule
+  prompt: |-
+    Open the schedule f/evals/global/nightly_digest so I can review and edit it.
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - open_page
+    forbiddenToolsUsed:
+      - write_schedule
+      - deploy_workspace_item
+      - delete_workspace_item
+    toolCallArgs:
+      - tool: open_page
+        field: page
+        stringIncludesAnyOf:
+          - schedules
+      - tool: open_page
+        field: open
+        stringIncludesAnyOf:
+          - f/evals/global/nightly_digest
+  skipJudge: true
+  judgeChecklist:
+    - opens the Schedules page and targets the f/evals/global/nightly_digest schedule for editing
+    - passes the schedule path so the editor opens on it
+    - does not write, deploy, or delete anything
+
 # --- Documentation search (search_docs) ---
 # Pure product-knowledge questions: the assistant should consult the docs via
 # search_docs and answer conversationally, not draft or mutate anything. No

--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -1023,6 +1023,33 @@
     - opens the Audit logs page filtered to the admin user
     - does not write, deploy, or delete anything
 
+- id: global-openpage6-triggers-kind
+  prompt: |-
+    Take me to the Kafka triggers for this workspace.
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - open_page
+    forbiddenToolsUsed:
+      - deploy_workspace_item
+      - delete_workspace_item
+    toolCallArgs:
+      - tool: open_page
+        field: page
+        stringIncludesAnyOf:
+          - triggers
+      - tool: open_page
+        field: trigger_kind
+        stringIncludesAnyOf:
+          - kafka
+  skipJudge: true
+  judgeChecklist:
+    - opens the Kafka triggers page
+    - does not write, deploy, or delete anything
+
 # --- Documentation search (search_docs) ---
 # Pure product-knowledge questions: the assistant should consult the docs via
 # search_docs and answer conversationally, not draft or mutate anything. No

--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -1050,6 +1050,29 @@
     - opens the Kafka triggers page
     - does not write, deploy, or delete anything
 
+- id: global-closepage1-close-runs-tab
+  prompt: |-
+    You just opened the runs page for me in the side panel. Close that tab, I'm done looking at it.
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - close_page
+    forbiddenToolsUsed:
+      - deploy_workspace_item
+      - delete_workspace_item
+    toolCallArgs:
+      - tool: close_page
+        field: match
+        stringIncludesAnyOf:
+          - runs
+  skipJudge: true
+  judgeChecklist:
+    - closes the runs preview tab in the side panel
+    - does not write, deploy, or delete anything
+
 # --- Documentation search (search_docs) ---
 # Pure product-knowledge questions: the assistant should consult the docs via
 # search_docs and answer conversationally, not draft or mutate anything. No

--- a/ai_evals/cases/global.yaml
+++ b/ai_evals/cases/global.yaml
@@ -969,6 +969,60 @@
     - passes the schedule path so the editor opens on it
     - does not write, deploy, or delete anything
 
+- id: global-openpage4-workspace-settings-tab
+  prompt: |-
+    Take me to the Git sync configuration for this workspace.
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - open_page
+    forbiddenToolsUsed:
+      - deploy_workspace_item
+      - delete_workspace_item
+    toolCallArgs:
+      - tool: open_page
+        field: page
+        stringIncludesAnyOf:
+          - workspace_settings
+      - tool: open_page
+        field: tab
+        stringIncludesAnyOf:
+          - git_sync
+  skipJudge: true
+  judgeChecklist:
+    - opens the Workspace settings page on the git_sync tab
+    - does not write, deploy, or delete anything
+
+- id: global-openpage5-audit-logs-user
+  prompt: |-
+    Open the audit logs filtered to actions performed by the user admin.
+  runtime:
+    maxTurns: 6
+  validate:
+    draftCountExactly: 0
+  toolExpect:
+    requiredToolsUsed:
+      - open_page
+    forbiddenToolsUsed:
+      - deploy_workspace_item
+      - delete_workspace_item
+    toolCallArgs:
+      - tool: open_page
+        field: page
+        stringIncludesAnyOf:
+          - audit_logs
+      - tool: open_page
+        field: username
+        stringIncludesAnyOf:
+          - admin
+  skipJudge: true
+  judgeChecklist:
+    - opens the Audit logs page filtered to the admin user
+    - does not write, deploy, or delete anything
+
 # --- Documentation search (search_docs) ---
 # Pure product-knowledge questions: the assistant should consult the docs via
 # search_docs and answer conversationally, not draft or mutate anything. No

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -1073,7 +1073,12 @@ export class AIChatManager {
 			skills: this.globalSkills
 		})
 		const baseHelpers: GlobalToolHelpers = {
-			...(this.isSessionChat ? { sessionId: this.sessionId } : {}),
+			// A session targets its own fixed (possibly forked) workspace, so capture it for
+			// permission gating. The global side-panel chat follows the live navigation
+			// workspace instead, so leave it unset there — allowedOpenPages reads the store.
+			...(this.isSessionChat
+				? { sessionId: this.sessionId, operatingWorkspace: this.operatingWorkspace }
+				: {}),
 			testActiveFlow: async (args?: Record<string, any>) => this.flowAiChatHelpers?.testFlow(args),
 			attachedFiles: this.attachedFiles,
 			getUserInstructions: () => getUserCustomPrompts()[AIMode.GLOBAL] ?? '',

--- a/frontend/src/lib/components/copilot/chat/ToolMessageActions.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolMessageActions.svelte
@@ -2,13 +2,17 @@
 	import { Button } from '$lib/components/common'
 	import {
 		ArrowRight,
+		Boxes,
 		Calendar,
 		Database,
+		DollarSign,
 		KeyRound,
 		Mail,
 		Package,
 		Play,
 		Route,
+		ScrollText,
+		Settings,
 		SquarePen,
 		Unplug,
 		Webhook
@@ -52,14 +56,20 @@
 		email: { title: 'Email trigger', icon: Mail }
 	}
 
+	const navigatePageConfig: Record<string, ActionCardConfig> = {
+		runs: { title: 'Runs', icon: Play },
+		schedules: { title: 'Schedules', icon: Calendar },
+		variables: { title: 'Variables', icon: DollarSign },
+		resources: { title: 'Resources', icon: Boxes },
+		assets: { title: 'Assets', icon: Database },
+		audit_logs: { title: 'Audit logs', icon: ScrollText },
+		workspace_settings: { title: 'Workspace settings', icon: Settings }
+	}
+
 	function getActionCard(action: ToolDisplayAction): ActionCard {
 		if (action.type === 'navigate') {
-			return {
-				title: action.page === 'runs' ? 'Runs' : 'Schedules',
-				subtitle: action.label,
-				icon: action.page === 'runs' ? Play : Calendar,
-				buttonIcon: ArrowRight
-			}
+			const config = navigatePageConfig[action.page] ?? { title: action.page, icon: Route }
+			return { ...config, subtitle: action.label, buttonIcon: ArrowRight }
 		}
 		const key: ActionCardKey | undefined =
 			action.resource === 'trigger' ? action.triggerKind : action.resource

--- a/frontend/src/lib/components/copilot/chat/ToolMessageActions.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolMessageActions.svelte
@@ -6,6 +6,7 @@
 		Calendar,
 		Database,
 		DollarSign,
+		FolderOpen,
 		KeyRound,
 		Mail,
 		Package,
@@ -15,7 +16,9 @@
 		Settings,
 		SquarePen,
 		Unplug,
-		Webhook
+		Users,
+		Webhook,
+		Zap
 	} from 'lucide-svelte'
 	import AwsIcon from '$lib/components/icons/AwsIcon.svelte'
 	import AzureIcon from '$lib/components/icons/AzureIcon.svelte'
@@ -63,6 +66,9 @@
 		resources: { title: 'Resources', icon: Boxes },
 		assets: { title: 'Assets', icon: Database },
 		audit_logs: { title: 'Audit logs', icon: ScrollText },
+		folders: { title: 'Folders', icon: FolderOpen },
+		groups: { title: 'Groups', icon: Users },
+		triggers: { title: 'Triggers', icon: Zap },
 		workspace_settings: { title: 'Workspace settings', icon: Settings }
 	}
 

--- a/frontend/src/lib/components/copilot/chat/ToolMessageActions.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolMessageActions.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 	import { Button } from '$lib/components/common'
 	import {
+		ArrowRight,
 		Calendar,
 		Database,
 		KeyRound,
 		Mail,
 		Package,
+		Play,
 		Route,
 		SquarePen,
 		Unplug,
@@ -29,6 +31,7 @@
 		title: string
 		icon: any
 	}
+	type ActionCard = ActionCardConfig & { subtitle: string; buttonIcon: any }
 
 	let { actions }: Props = $props()
 	let runningActionId: string | undefined = $state(undefined)
@@ -49,12 +52,21 @@
 		email: { title: 'Email trigger', icon: Mail }
 	}
 
-	function getActionCardConfig(action: ToolDisplayAction): ActionCardConfig {
+	function getActionCard(action: ToolDisplayAction): ActionCard {
+		if (action.type === 'navigate') {
+			return {
+				title: action.page === 'runs' ? 'Runs' : 'Schedules',
+				subtitle: action.label,
+				icon: action.page === 'runs' ? Play : Calendar,
+				buttonIcon: ArrowRight
+			}
+		}
 		const key: ActionCardKey | undefined =
 			action.resource === 'trigger' ? action.triggerKind : action.resource
-		return key
+		const config = key
 			? actionCardConfigs[key]
 			: { title: action.label.replace(/^Open\s+/i, ''), icon: Webhook }
+		return { ...config, subtitle: action.path, buttonIcon: SquarePen }
 	}
 
 	async function handleAction(action: ToolDisplayAction) {
@@ -73,7 +85,7 @@
 {#if actions.length > 0}
 	<div class="space-y-2">
 		{#each actions as action (action.id)}
-			{@const card = getActionCardConfig(action)}
+			{@const card = getActionCard(action)}
 			{@const Icon = card.icon}
 			<div class="flex items-center gap-3 rounded-md border !border-green-500/40 bg-surface p-3">
 				<div
@@ -83,7 +95,7 @@
 				</div>
 				<div class="min-w-0 flex-1">
 					<div class="truncate text-xs font-semibold text-primary">{card.title}</div>
-					<div class="truncate text-2xs text-secondary">{action.path}</div>
+					<div class="truncate text-2xs text-secondary">{card.subtitle}</div>
 				</div>
 				<Button
 					size="xs"
@@ -91,7 +103,7 @@
 					title={action.label}
 					loading={runningActionId === action.id}
 					disabled={runningActionId !== undefined && runningActionId !== action.id}
-					startIcon={{ icon: SquarePen }}
+					startIcon={{ icon: card.buttonIcon }}
 					onClick={() => handleAction(action)}
 				>
 					Open

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -108,6 +108,9 @@ import { get } from 'svelte/store'
 import { deployDraft as deployDraftToWorkspace } from '$lib/utils_draft_deploy'
 import { UserDraftDbSyncer } from '$lib/userDraftDbSyncer.svelte'
 import { bundleRawAppDraft } from './rawAppBundlerBridge'
+import { chatNavigate, isCurrentPage } from '$lib/navigation'
+import { buildRunsUrl, buildSchedulesUrl, RUNS_PATH, SCHEDULES_PATH } from './pageNavigation'
+import { pageHref } from '$lib/components/sessions/previewRouter'
 import {
 	clearEphemeralSecretVariableDraftValue,
 	deleteGlobalDraft,
@@ -836,6 +839,7 @@ Rules:
 - A "data pipeline" is NOT a flow: it is a DAG of independent scripts in one folder, wired by storage assets (DuckLake/data tables/S3) and triggers via top-of-file \`pipeline\` / \`on <ref>\` annotation comments written in each script's comment syntax (\`--\` for SQL, \`#\` for Python/Bash, \`//\` for TS — a \`//\` line in a SQL node is a syntax error). When the user asks for a data pipeline (or to ingest/transform/materialize data across steps), call get_instructions with subject "pipeline" and build annotated script drafts — do not build a flow.
 - After creating or editing a script or flow draft, run test_run_script, test_run_flow, or test_run_step with representative args before reporting that it works. These tools prefer drafts, so testing does not require deployment.
 - Use list_runs to find recent runs (optionally filtered by path, creator, label, or status), then get_job_logs with a returned id to inspect a specific run's logs — without starting a new test run.
+- Use open_page to show the Runs or Schedules page with filters applied — e.g. after discussing a script's failures ("open the failed runs of f/foo/bar") or a specific schedule. In a session it opens as a tab in the side-panel preview next to the chat; it is the ONLY way to show a Runs/Schedules page there (open_preview handles only editable items). Changing filters on a page that's already open updates that same tab — only pass new_tab when the user explicitly asks for a separate tab. Don't use it as a substitute for list_runs when you just need the data yourself.
 - When a required decision is ambiguous, use askUserQuestion with two to ten clear proposed answer strings instead of guessing. The user can also type a custom answer when none of the proposed answers fit.
 - When the user asks you to remember a lasting preference, always/never do something, or change/stop a behavior going forward, call update_user_instructions to persist it. It edits only the USER INSTRUCTIONS block (not WORKSPACE INSTRUCTIONS). Keep each instruction concise; do not use it for one-off requests scoped to the current task.
 - Keep context targeted.${
@@ -1682,8 +1686,135 @@ export const readSkillTool: Tool<{}> = {
 	}
 }
 
+// One flat object (not a discriminated union): `page` selects the target and the
+// per-page fields are optional. Top-level `type: object` is what Anthropic's
+// input_schema requires; a top-level oneOf would be rejected. `path`/`schedule_path`
+// are shared by both pages, and the per-page URL builders drop any key that isn't in
+// their page's filter schema, so a cross-page field is harmless.
+const openPageSchema = z.object({
+	page: z.enum(['runs', 'schedules']).describe('Which page to open'),
+	status: z
+		.enum(['running', 'success', 'failure', 'canceled', 'waiting', 'suspended'])
+		.optional()
+		.describe('Runs: filter by job execution status'),
+	path: z
+		.string()
+		.optional()
+		.describe('Runs & Schedules: the script or flow path to filter by, e.g. f/foo/bar'),
+	schedule_path: z
+		.string()
+		.optional()
+		.describe(
+			'Runs: only runs triggered by this schedule path. Schedules: filter by this exact schedule path.'
+		),
+	job_kinds: z
+		.enum(['all', 'runs', 'dependencies', 'previews', 'deploymentcallbacks'])
+		.optional()
+		.describe('Runs: filter by job category (defaults to top-level runs)'),
+	user: z.string().optional().describe('Runs: filter by the user who created the job'),
+	open: z
+		.string()
+		.optional()
+		.describe('Schedules: exact schedule path to open in the edit drawer, e.g. f/foo/my_schedule'),
+	summary: z
+		.string()
+		.optional()
+		.describe('Schedules: search text matched against schedule summaries'),
+	new_tab: z
+		.boolean()
+		.optional()
+		.describe(
+			'Open in a NEW preview tab instead of updating the tab already showing this page. Only set true when the user explicitly asks for a new or separate tab; by default changing filters reuses the existing tab.'
+		)
+})
+
+type OpenPageArgs = z.infer<typeof openPageSchema>
+
+function summarizeRunsFilters(a: OpenPageArgs): string {
+	const bits: string[] = []
+	if (a.status) bits.push(a.status)
+	if (a.path) bits.push(a.path)
+	if (a.schedule_path) bits.push(`schedule ${a.schedule_path}`)
+	if (a.job_kinds) bits.push(a.job_kinds)
+	if (a.user) bits.push(`by ${a.user}`)
+	return bits.length ? bits.join(', ') : 'all runs'
+}
+
+function summarizeSchedulesTarget(a: OpenPageArgs): string {
+	if (a.open) return a.open
+	const bits: string[] = []
+	if (a.path) bits.push(a.path)
+	if (a.schedule_path) bits.push(a.schedule_path)
+	if (a.summary) bits.push(`"${a.summary}"`)
+	return bits.length ? bits.join(', ') : 'all schedules'
+}
+
+export const openPageTool: Tool<{}> = {
+	def: createToolDef(
+		openPageSchema,
+		'open_page',
+		'Open a Windmill page (Runs or Schedules) with filters applied. Inside an AI session it opens as a tab in the side-panel preview next to the chat; elsewhere it applies the filters in place or offers a clickable link. Use after surfacing runs or schedules the user likely wants to inspect (e.g. "show me the failed runs of X", "open the schedule for Y"). This is the only way to show a Runs/Schedules page in the session preview — open_preview only handles editable items (scripts, flows, raw apps, pipelines).'
+	),
+	// Keep the row expanded so the link chip (attached below as an action) is visible
+	// without the user having to expand the tool call.
+	showDetails: true,
+	autoCollapseDetails: false,
+	fn: async (ctx) => {
+		const { args, toolId, toolCallbacks } = ctx
+		const parsed = openPageSchema.parse(args)
+		let url: string
+		let appPath: string
+		let page: 'runs' | 'schedules'
+		let summary: string
+		if (parsed.page === 'runs') {
+			const { page: _p, open: _o, summary: _s, new_tab: _n, ...filters } = parsed
+			url = buildRunsUrl(filters)
+			appPath = RUNS_PATH
+			page = 'runs'
+			summary = summarizeRunsFilters(parsed)
+		} else {
+			const { page: _p, open, new_tab: _n, ...filters } = parsed
+			url = buildSchedulesUrl({ open, filters })
+			appPath = SCHEDULES_PATH
+			page = 'schedules'
+			summary = summarizeSchedulesTarget(parsed)
+		}
+		const pageLabel = page === 'runs' ? 'Runs' : 'Schedules'
+
+		// In a session, show the page as a preview tab alongside the chat (the primary
+		// UX). By default a filter change reuses the tab already showing this page;
+		// new_tab forces a separate tab. openPagePreview returns undefined when there
+		// is no active session, in which case we fall through to browser navigation.
+		const previewResult = openPagePreview({
+			sessionId: sessionIdFromCtx(ctx),
+			href: pageHref(url),
+			label: pageLabel,
+			newTab: parsed.new_tab ?? false
+		})
+		if (previewResult) {
+			toolCallbacks.setToolStatus(toolId, { content: `Opened ${page} preview: ${summary}` })
+			return previewResult
+		}
+
+		// Hybrid delivery outside a session: in-context filter change navigates
+		// directly; a cross-page jump offers a link chip so the user is never yanked
+		// out of context. If no navigator is registered, fall back to the chip.
+		if (isCurrentPage(appPath) && chatNavigate(url)) {
+			toolCallbacks.setToolStatus(toolId, { content: `Opened ${page}: ${summary}` })
+			return `Applied the ${page} filters in place (${summary}).`
+		}
+
+		toolCallbacks.setToolStatus(toolId, {
+			content: `Prepared a link to ${page}: ${summary}`,
+			actions: [{ id: `open-page:${page}:${url}`, type: 'navigate', label: summary, url, page }]
+		})
+		return `Offered the user a link to the ${page} page (${summary}). They can click it to open.`
+	}
+}
+
 export const globalTools: Tool<{}>[] = [
 	readSkillTool,
+	openPageTool,
 	{
 		def: createToolDef(
 			getInstructionsSchema,
@@ -2524,6 +2655,34 @@ function openSessionPreview(
 		return 'Error: open_preview is only available inside an AI session. Tell the user to switch to a session to view the preview, or describe the item textually.'
 	}
 	return openPreviewHandler({ ...args, sessionId })
+}
+
+// Opens a workspace *page* (Runs, Schedules, …) as a page tab in the session's
+// side-panel preview, so open_page can show it next to the chat instead of
+// navigating the whole browser. Registered by the session runtime. Returns a
+// status string when opened in a session, or undefined when there is no active
+// session — signalling open_page to fall back to a link chip / direct navigation.
+export type OpenPagePreviewHandler = (req: {
+	sessionId: string | undefined
+	href: string
+	label: string
+	// Force a separate tab instead of reusing the tab already showing this page.
+	newTab: boolean
+}) => string | undefined
+
+let openPagePreviewHandler: OpenPagePreviewHandler | undefined
+
+export function setOpenPagePreviewHandler(handler: OpenPagePreviewHandler | undefined): void {
+	openPagePreviewHandler = handler
+}
+
+function openPagePreview(req: {
+	sessionId: string | undefined
+	href: string
+	label: string
+	newTab: boolean
+}): string | undefined {
+	return openPagePreviewHandler?.(req)
 }
 
 // Companion to `open_preview`: lets the assistant query the current preview

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -713,6 +713,19 @@ const openPreviewSchema = z.object({
 
 const getPreviewStatusSchema = z.object({})
 
+const closePageSchema = z.object({
+	all: z
+		.boolean()
+		.optional()
+		.describe('Close every open preview tab, clearing the side panel. Ignores `match` when true.'),
+	match: z
+		.string()
+		.optional()
+		.describe(
+			'Close the preview tab(s) whose page name or item path contains this text (case-insensitive), e.g. "runs", "schedules", or a script path. Call get_preview_status first if unsure what is open.'
+		)
+})
+
 type SessionToolResult = {
 	aiResult: string
 	uiMessage: string
@@ -2709,6 +2722,17 @@ export const globalTools: Tool<{}>[] = [
 	},
 	{
 		def: createToolDef(
+			closePageSchema,
+			'close_page',
+			'Close one or more preview tabs in the side panel of this AI session. Pass `match` to close the tab(s) whose page name or item path contains that text, or `all: true` to clear the panel. Use this when the user asks to close/dismiss a tab they no longer need. Only works inside a session.'
+		),
+		fn: async (ctx) => {
+			const parsed = closePageSchema.parse(ctx.args)
+			return closeSessionPreviewTabs(parsed, sessionIdFromCtx(ctx))
+		}
+	},
+	{
+		def: createToolDef(
 			getRuntimeLogsSchema,
 			'get_app_runtime_logs',
 			'Fetch the most recent browser console logs (and uncaught errors) from the raw app preview currently open in this AI session.'
@@ -2756,6 +2780,7 @@ export const globalTools: Tool<{}>[] = [
 export const SESSION_PREVIEW_TOOL_NAMES = new Set([
 	'open_preview',
 	'get_preview_status',
+	'close_page',
 	'get_app_runtime_logs',
 	'list_app_runs'
 ])
@@ -2885,6 +2910,35 @@ function getSessionPreviewStatus(sessionId: string | undefined): string {
 		return 'Error: get_preview_status is only available inside an AI session.'
 	}
 	return getPreviewStatusHandler(sessionId)
+}
+
+// Closes preview tabs in the calling session's side panel. Registered by the
+// session runtime, which owns the tab model. Returns a status string the model
+// relays to the user. `all` clears the panel; otherwise `match` is a
+// case-insensitive substring tested against each tab's page label / item path.
+export type ClosePreviewTabsHandler = (req: {
+	sessionId: string | undefined
+	all: boolean
+	match: string | undefined
+}) => string
+
+let closePreviewTabsHandler: ClosePreviewTabsHandler | undefined
+
+export function setClosePreviewTabsHandler(handler: ClosePreviewTabsHandler | undefined): void {
+	closePreviewTabsHandler = handler
+}
+
+function closeSessionPreviewTabs(
+	args: { all?: boolean; match?: string },
+	sessionId: string | undefined
+): string {
+	if (!closePreviewTabsHandler) {
+		return 'Error: close_page is only available inside an AI session.'
+	}
+	if (!args.all && !args.match?.trim()) {
+		return 'Nothing to close: pass `match` with the tab to close, or `all: true` to close every tab.'
+	}
+	return closePreviewTabsHandler({ sessionId, all: args.all ?? false, match: args.match })
 }
 
 export type GetRuntimeLogsHandler = (req: {

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -103,7 +103,7 @@ import {
 	type WorkspaceItem,
 	type WorkspaceItemType
 } from './workspaceItems'
-import { userStore, superadmin } from '$lib/stores'
+import { userStore, superadmin, enterpriseLicense } from '$lib/stores'
 import { get } from 'svelte/store'
 import { deployDraft as deployDraftToWorkspace } from '$lib/utils_draft_deploy'
 import { UserDraftDbSyncer } from '$lib/userDraftDbSyncer.svelte'
@@ -116,9 +116,16 @@ import {
 	buildAssetsUrl,
 	buildAuditLogsUrl,
 	buildWorkspaceSettingsUrl,
+	buildFoldersUrl,
+	buildGroupsUrl,
+	buildTriggersUrl,
 	WORKSPACE_SETTINGS_TABS
 } from './pageNavigation'
-import { pageHref } from '$lib/components/sessions/previewRouter'
+import {
+	pageHref,
+	TRIGGER_PAGES,
+	type TriggerKind as PageTriggerKind
+} from '$lib/components/sessions/previewRouter'
 import {
 	clearEphemeralSecretVariableDraftValue,
 	deleteGlobalDraft,
@@ -1701,6 +1708,9 @@ const OPEN_PAGE_NAMES = [
 	'resources',
 	'assets',
 	'audit_logs',
+	'folders',
+	'groups',
+	'triggers',
 	'workspace_settings'
 ] as const
 type OpenPageName = (typeof OPEN_PAGE_NAMES)[number]
@@ -1712,13 +1722,23 @@ const OPEN_PAGE_LABELS: Record<OpenPageName, string> = {
 	resources: 'Resources',
 	assets: 'Assets',
 	audit_logs: 'Audit logs',
+	folders: 'Folders',
+	groups: 'Groups',
+	triggers: 'Triggers',
 	workspace_settings: 'Workspace settings'
+}
+
+// Trigger kinds available given the workspace's license — the EE-gated kinds
+// (kafka/nats/sqs/gcp/azure) are only offered with an enterprise license.
+function allowedTriggerKinds(): PageTriggerKind[] {
+	const ee = !!get(enterpriseLicense)
+	return (Object.keys(TRIGGER_PAGES) as PageTriggerKind[]).filter((k) => ee || !TRIGGER_PAGES[k].ee)
 }
 
 // Which pages the current user can actually reach — mirrors the sidebar's gating
 // (operators are restricted to runs/assets by default; workspace settings is
-// admin/superadmin only; operators see audit logs only when granted). The tool only
-// ever advertises, and only ever acts on, pages in this set.
+// admin/superadmin only). The tool only ever advertises, and only ever acts on, pages
+// in this set.
 function allowedOpenPages(): OpenPageName[] {
 	const u = get(userStore)
 	const isOperator = !!u?.operator
@@ -1729,6 +1749,9 @@ function allowedOpenPages(): OpenPageName[] {
 		allowed.add('variables')
 		allowed.add('resources')
 		allowed.add('audit_logs')
+		allowed.add('folders')
+		allowed.add('groups')
+		allowed.add('triggers')
 	}
 	if (isAdmin) allowed.add('workspace_settings')
 	return OPEN_PAGE_NAMES.filter((p) => allowed.has(p))
@@ -1749,6 +1772,9 @@ const openPageFullSchema = z.object({
 			'resources',
 			'assets',
 			'audit_logs',
+			'folders',
+			'groups',
+			'triggers',
 			'workspace_settings'
 		])
 		.describe('Which page to open'),
@@ -1776,11 +1802,17 @@ const openPageFullSchema = z.object({
 	open: z
 		.string()
 		.optional()
-		.describe('Schedules: exact schedule path to open in the edit drawer, e.g. f/foo/my_schedule'),
+		.describe(
+			'Schedules/Triggers: exact schedule or trigger path to open in the edit drawer, e.g. f/foo/my_schedule'
+		),
 	summary: z
 		.string()
 		.optional()
 		.describe('Schedules: search text matched against schedule summaries'),
+	trigger_kind: z
+		.enum([...(Object.keys(TRIGGER_PAGES) as [PageTriggerKind, ...PageTriggerKind[]])])
+		.optional()
+		.describe('Triggers: which trigger kind page to open (http, websocket, postgres, kafka, ...)'),
 	resource_type: z
 		.string()
 		.optional()
@@ -1814,8 +1846,9 @@ const OPEN_PAGE_FIELD_PAGES: Record<string, OpenPageName[]> = {
 	schedule_path: ['runs', 'schedules'],
 	job_kinds: ['runs'],
 	user: ['runs'],
-	open: ['schedules'],
+	open: ['schedules', 'triggers'],
 	summary: ['schedules'],
+	trigger_kind: ['triggers'],
 	resource_type: ['resources'],
 	owner: ['variables', 'resources'],
 	username: ['audit_logs'],
@@ -1825,21 +1858,32 @@ const OPEN_PAGE_FIELD_PAGES: Record<string, OpenPageName[]> = {
 }
 
 // The model-facing schema for the given allowed pages: the `page` enum plus only the
-// fields relevant to those pages (reusing the full schema's field definitions).
-function buildOpenPageDefSchema(pages: readonly OpenPageName[]): z.ZodTypeAny {
+// fields relevant to those pages (reusing the full schema's field definitions). The
+// `trigger_kind` enum is narrowed to the license-available kinds.
+function buildOpenPageDefSchema(
+	pages: readonly OpenPageName[],
+	triggerKinds: readonly PageTriggerKind[]
+): z.ZodTypeAny {
 	const full = openPageFullSchema.shape as Record<string, z.ZodTypeAny>
 	const shape: Record<string, z.ZodTypeAny> = {
 		page: z.enum([...pages] as [OpenPageName, ...OpenPageName[]]).describe('Which page to open')
 	}
 	for (const [field, fieldPages] of Object.entries(OPEN_PAGE_FIELD_PAGES)) {
-		if (fieldPages.some((p) => pages.includes(p))) shape[field] = full[field]
+		if (!fieldPages.some((p) => pages.includes(p))) continue
+		shape[field] =
+			field === 'trigger_kind'
+				? z
+						.enum([...triggerKinds] as [string, ...string[]])
+						.optional()
+						.describe('Triggers: which trigger kind page to open')
+				: full[field]
 	}
 	shape.new_tab = full.new_tab
 	return z.object(shape)
 }
 
 const OPEN_PAGE_DESCRIPTION =
-	'Open a Windmill page with filters applied — Runs, Schedules, Variables, Resources, Assets, Audit logs, or Workspace settings (on a specific tab). Inside an AI session it opens as a tab in the side-panel preview next to the chat; elsewhere it offers a clickable link. Use after surfacing something the user likely wants to inspect (e.g. "show me the failed runs of X", "open the schedule for Y", "open the git sync settings"). This is the only way to show one of these pages in the session preview — open_preview only handles editable items (scripts, flows, raw apps, pipelines). Only pages listed in the `page` enum are available to this user.'
+	'Open a Windmill page with filters applied — Runs, Schedules, Variables, Resources, Assets, Audit logs, Folders, Groups, Triggers (by kind), or Workspace settings (on a specific tab). Inside an AI session it opens as a tab in the side-panel preview next to the chat; elsewhere it offers a clickable link. Use after surfacing something the user likely wants to inspect (e.g. "show me the failed runs of X", "open the schedule for Y", "open the git sync settings", "open the kafka triggers"). This is the only way to show one of these pages in the session preview — open_preview only handles editable items (scripts, flows, raw apps, pipelines). Only pages listed for this user are available; do not offer others.'
 
 function buildOpenPageUrl(page: OpenPageName, a: OpenPageArgs): string {
 	switch (page) {
@@ -1868,6 +1912,16 @@ function buildOpenPageUrl(page: OpenPageName, a: OpenPageArgs): string {
 				operation: a.operation,
 				resource: a.resource
 			})
+		case 'folders':
+			return buildFoldersUrl()
+		case 'groups':
+			return buildGroupsUrl()
+		case 'triggers':
+			return buildTriggersUrl({
+				// Default to HTTP routes when the model names no kind.
+				trigger_kind: (a.trigger_kind as PageTriggerKind | undefined) ?? 'http',
+				open: a.open
+			})
 		case 'workspace_settings':
 			return buildWorkspaceSettingsUrl({ tab: a.tab })
 	}
@@ -1885,7 +1939,7 @@ function summarizeOpenPage(url: string, page: OpenPageName): string {
 
 export const openPageTool: Tool<{}> = {
 	def: createToolDef(
-		buildOpenPageDefSchema(allowedOpenPages()),
+		buildOpenPageDefSchema(allowedOpenPages(), allowedTriggerKinds()),
 		'open_page',
 		OPEN_PAGE_DESCRIPTION
 	),
@@ -1897,7 +1951,7 @@ export const openPageTool: Tool<{}> = {
 	// the model never sees (or suggests) a page the user can't reach.
 	setSchema: async function () {
 		this.def = createToolDef(
-			buildOpenPageDefSchema(allowedOpenPages()),
+			buildOpenPageDefSchema(allowedOpenPages(), allowedTriggerKinds()),
 			'open_page',
 			OPEN_PAGE_DESCRIPTION
 		)

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -1978,6 +1978,13 @@ export const openPageTool: Tool<{}> = {
 		if (!allowedOpenPages().includes(page)) {
 			return `You don't have access to the ${OPEN_PAGE_LABELS[page] ?? page} page in this workspace.`
 		}
+		// Same fail-closed check for trigger_kind, which is narrowed to license-available
+		// kinds in the advertised schema: a model ignoring that narrowing must not get an
+		// EE-only trigger route built on a non-EE instance.
+		const triggerKind = parsed.trigger_kind as PageTriggerKind | undefined
+		if (page === 'triggers' && triggerKind && !allowedTriggerKinds().includes(triggerKind)) {
+			return `${TRIGGER_PAGES[triggerKind].label} aren't available on this instance.`
+		}
 		const url = buildOpenPageUrl(page, parsed)
 		const pageLabel = OPEN_PAGE_LABELS[page]
 		const summary = summarizeOpenPage(url, page)

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -1756,18 +1756,18 @@ function allowedTriggerKinds(): PageTriggerKind[] {
 }
 
 // Which pages the current user can actually reach — mirrors the sidebar's gating.
-// Operators see exactly the pages enabled in this workspace's operator_settings (the
-// same source OperatorMenu gates on); a missing/false flag means no access, and
+// Operators see exactly the pages enabled in the operating workspace's operator_settings
+// (the same source OperatorMenu gates on); a missing/false flag means no access, and
 // operators are never admins so workspace_settings is always excluded. Non-operators
-// get every page except workspace_settings, which is admin/superadmin only. The tool
-// only ever advertises, and only ever acts on, pages in this set.
-function allowedOpenPages(): OpenPageName[] {
+// get every page except workspace_settings, which is admin/superadmin only. `workspaceId`
+// is the chat's operating workspace (a session targets its own, possibly forked workspace);
+// it defaults to the navigation workspace for the global side-panel chat. The tool only
+// ever advertises, and only ever acts on, pages in this set.
+function allowedOpenPages(workspaceId: string | undefined = get(workspaceStore)): OpenPageName[] {
 	const u = get(userStore)
 	const isAdmin = !!u?.is_admin || !!get(superadmin)
 	if (u?.operator) {
-		const settings = get(userWorkspaces).find(
-			(w) => w.id === get(workspaceStore)
-		)?.operator_settings
+		const settings = get(userWorkspaces).find((w) => w.id === workspaceId)?.operator_settings
 		return OPEN_PAGE_NAMES.filter(
 			(p) =>
 				p !== 'workspace_settings' && settings?.[p as keyof NonNullable<typeof settings>] === true
@@ -1984,10 +1984,14 @@ export const openPageTool: Tool<{}> = {
 	showDetails: true,
 	autoCollapseDetails: false,
 	// Re-narrow the advertised `page` enum to this user's permissions each iteration, so
-	// the model never sees (or suggests) a page the user can't reach.
-	setSchema: async function () {
+	// the model never sees (or suggests) a page the user can't reach. Gates on the chat's
+	// operating workspace (the session's, when different from the navigation workspace).
+	setSchema: async function (helpers) {
 		this.def = createToolDef(
-			buildOpenPageDefSchema(allowedOpenPages(), allowedTriggerKinds()),
+			buildOpenPageDefSchema(
+				allowedOpenPages(operatingWorkspaceFromHelpers(helpers)),
+				allowedTriggerKinds()
+			),
 			'open_page',
 			OPEN_PAGE_DESCRIPTION
 		)
@@ -1996,9 +2000,10 @@ export const openPageTool: Tool<{}> = {
 		const { args, toolId, toolCallbacks } = ctx
 		const parsed = openPageFullSchema.parse(args)
 		const page = parsed.page as OpenPageName
+		const workspaceId = operatingWorkspaceFromHelpers(ctx.helpers)
 		// Defense in depth: never act on a page the user can't reach, even if the model
 		// requests one outside the advertised enum.
-		if (!allowedOpenPages().includes(page)) {
+		if (!allowedOpenPages(workspaceId).includes(page)) {
 			return `You don't have access to the ${OPEN_PAGE_LABELS[page] ?? page} page in this workspace.`
 		}
 		// Same fail-closed check for trigger_kind, which is narrowed to license-available
@@ -2856,10 +2861,18 @@ export type GlobalToolHelpers = SessionToolHelpers & {
 	// iteration. Backed by the update_user_instructions tool.
 	getUserInstructions?: () => string
 	setUserInstructions?: (instructions: string) => void
+	// The workspace this chat actually operates on — a session chat targets its own
+	// (possibly forked) workspace while $workspaceStore stays on the navigation workspace,
+	// so permission gating (open_page) must read this, not the global store.
+	operatingWorkspace?: string
 }
 
 function sessionIdFromCtx(ctx: { helpers?: unknown }): string | undefined {
 	return (ctx.helpers as GlobalToolHelpers | undefined)?.sessionId
+}
+
+function operatingWorkspaceFromHelpers(helpers: unknown): string | undefined {
+	return (helpers as GlobalToolHelpers | undefined)?.operatingWorkspace
 }
 
 function activeFlowTestFromCtx(

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -103,12 +103,21 @@ import {
 	type WorkspaceItem,
 	type WorkspaceItemType
 } from './workspaceItems'
-import { userStore } from '$lib/stores'
+import { userStore, superadmin } from '$lib/stores'
 import { get } from 'svelte/store'
 import { deployDraft as deployDraftToWorkspace } from '$lib/utils_draft_deploy'
 import { UserDraftDbSyncer } from '$lib/userDraftDbSyncer.svelte'
 import { bundleRawAppDraft } from './rawAppBundlerBridge'
-import { buildRunsUrl, buildSchedulesUrl } from './pageNavigation'
+import {
+	buildRunsUrl,
+	buildSchedulesUrl,
+	buildVariablesUrl,
+	buildResourcesUrl,
+	buildAssetsUrl,
+	buildAuditLogsUrl,
+	buildWorkspaceSettingsUrl,
+	WORKSPACE_SETTINGS_TABS
+} from './pageNavigation'
 import { pageHref } from '$lib/components/sessions/previewRouter'
 import {
 	clearEphemeralSecretVariableDraftValue,
@@ -838,7 +847,7 @@ Rules:
 - A "data pipeline" is NOT a flow: it is a DAG of independent scripts in one folder, wired by storage assets (DuckLake/data tables/S3) and triggers via top-of-file \`pipeline\` / \`on <ref>\` annotation comments written in each script's comment syntax (\`--\` for SQL, \`#\` for Python/Bash, \`//\` for TS — a \`//\` line in a SQL node is a syntax error). When the user asks for a data pipeline (or to ingest/transform/materialize data across steps), call get_instructions with subject "pipeline" and build annotated script drafts — do not build a flow.
 - After creating or editing a script or flow draft, run test_run_script, test_run_flow, or test_run_step with representative args before reporting that it works. These tools prefer drafts, so testing does not require deployment.
 - Use list_runs to find recent runs (optionally filtered by path, creator, label, or status), then get_job_logs with a returned id to inspect a specific run's logs — without starting a new test run.
-- Use open_page to show the Runs or Schedules page with filters applied — e.g. after discussing a script's failures ("open the failed runs of f/foo/bar") or a specific schedule. In a session it opens as a tab in the side-panel preview next to the chat; it is the ONLY way to show a Runs/Schedules page there (open_preview handles only editable items). Changing filters on a page that's already open updates that same tab — only pass new_tab when the user explicitly asks for a separate tab. Don't use it as a substitute for list_runs when you just need the data yourself.
+- Use open_page to show a workspace page with filters applied — Runs, Schedules, Variables, Resources, Assets, Audit logs, or Workspace settings on a specific tab (e.g. "open the failed runs of f/foo/bar", "open the schedule for X", "open the git sync settings"). Only the pages listed for this user in the tool are available; don't offer pages that aren't listed. In a session it opens as a tab in the side-panel preview next to the chat; it is the ONLY way to show these pages there (open_preview handles only editable items). Changing filters on a page that's already open updates that same tab — only pass new_tab when the user explicitly asks for a separate tab. Don't use it as a substitute for list_runs when you just need the data yourself.
 - When a required decision is ambiguous, use askUserQuestion with two to ten clear proposed answer strings instead of guessing. The user can also type a custom answer when none of the proposed answers fit.
 - When the user asks you to remember a lasting preference, always/never do something, or change/stop a behavior going forward, call update_user_instructions to persist it. It edits only the USER INSTRUCTIONS block (not WORKSPACE INSTRUCTIONS). Keep each instruction concise; do not use it for one-off requests scoped to the current task.
 - Keep context targeted.${
@@ -1685,21 +1694,74 @@ export const readSkillTool: Tool<{}> = {
 	}
 }
 
+const OPEN_PAGE_NAMES = [
+	'runs',
+	'schedules',
+	'variables',
+	'resources',
+	'assets',
+	'audit_logs',
+	'workspace_settings'
+] as const
+type OpenPageName = (typeof OPEN_PAGE_NAMES)[number]
+
+const OPEN_PAGE_LABELS: Record<OpenPageName, string> = {
+	runs: 'Runs',
+	schedules: 'Schedules',
+	variables: 'Variables',
+	resources: 'Resources',
+	assets: 'Assets',
+	audit_logs: 'Audit logs',
+	workspace_settings: 'Workspace settings'
+}
+
+// Which pages the current user can actually reach — mirrors the sidebar's gating
+// (operators are restricted to runs/assets by default; workspace settings is
+// admin/superadmin only; operators see audit logs only when granted). The tool only
+// ever advertises, and only ever acts on, pages in this set.
+function allowedOpenPages(): OpenPageName[] {
+	const u = get(userStore)
+	const isOperator = !!u?.operator
+	const isAdmin = !!u?.is_admin || !!get(superadmin)
+	const allowed = new Set<OpenPageName>(['runs', 'assets']) // available to everyone
+	if (!isOperator) {
+		allowed.add('schedules')
+		allowed.add('variables')
+		allowed.add('resources')
+		allowed.add('audit_logs')
+	}
+	if (isAdmin) allowed.add('workspace_settings')
+	return OPEN_PAGE_NAMES.filter((p) => allowed.has(p))
+}
+
 // One flat object (not a discriminated union): `page` selects the target and the
 // per-page fields are optional. Top-level `type: object` is what Anthropic's
-// input_schema requires; a top-level oneOf would be rejected. `path`/`schedule_path`
-// are shared by both pages, and the per-page URL builders drop any key that isn't in
-// their page's filter schema, so a cross-page field is harmless.
-const openPageSchema = z.object({
-	page: z.enum(['runs', 'schedules']).describe('Which page to open'),
+// input_schema requires; a top-level oneOf would be rejected. Each per-page URL builder
+// drops any key that isn't one of its page's real query params, so a field that doesn't
+// apply to the chosen page is harmless. This full schema is used to PARSE tool args; the
+// advertised schema (what the model sees) is narrowed per-user in `setSchema`.
+const openPageFullSchema = z.object({
+	page: z
+		.enum([
+			'runs',
+			'schedules',
+			'variables',
+			'resources',
+			'assets',
+			'audit_logs',
+			'workspace_settings'
+		])
+		.describe('Which page to open'),
+	path: z
+		.string()
+		.optional()
+		.describe(
+			'Runs/Schedules/Variables/Resources/Assets: the script, flow or item path to filter by'
+		),
 	status: z
 		.enum(['running', 'success', 'failure', 'canceled', 'waiting', 'suspended'])
 		.optional()
 		.describe('Runs: filter by job execution status'),
-	path: z
-		.string()
-		.optional()
-		.describe('Runs & Schedules: the script or flow path to filter by, e.g. f/foo/bar'),
 	schedule_path: z
 		.string()
 		.optional()
@@ -1719,6 +1781,21 @@ const openPageSchema = z.object({
 		.string()
 		.optional()
 		.describe('Schedules: search text matched against schedule summaries'),
+	resource_type: z
+		.string()
+		.optional()
+		.describe('Resources: filter by resource type, e.g. postgres'),
+	owner: z
+		.string()
+		.optional()
+		.describe('Variables/Resources: filter by owner, e.g. u/alice or f/team'),
+	username: z.string().optional().describe('Audit logs: filter by the acting username'),
+	operation: z.string().optional().describe('Audit logs: filter by operation, e.g. jobs.run'),
+	resource: z.string().optional().describe('Audit logs: filter by the affected resource path'),
+	tab: z
+		.enum([...WORKSPACE_SETTINGS_TABS] as [string, ...string[]])
+		.optional()
+		.describe('Workspace settings: which settings tab to open'),
 	new_tab: z
 		.boolean()
 		.optional()
@@ -1727,55 +1804,116 @@ const openPageSchema = z.object({
 		)
 })
 
-type OpenPageArgs = z.infer<typeof openPageSchema>
+type OpenPageArgs = z.infer<typeof openPageFullSchema>
 
-function summarizeRunsFilters(a: OpenPageArgs): string {
-	const bits: string[] = []
-	if (a.status) bits.push(a.status)
-	if (a.path) bits.push(a.path)
-	if (a.schedule_path) bits.push(`schedule ${a.schedule_path}`)
-	if (a.job_kinds) bits.push(a.job_kinds)
-	if (a.user) bits.push(`by ${a.user}`)
-	return bits.length ? bits.join(', ') : 'all runs'
+// Which pages each optional field applies to — drives narrowing the advertised schema
+// so the model isn't shown fields for pages it can't open.
+const OPEN_PAGE_FIELD_PAGES: Record<string, OpenPageName[]> = {
+	path: ['runs', 'schedules', 'variables', 'resources', 'assets'],
+	status: ['runs'],
+	schedule_path: ['runs', 'schedules'],
+	job_kinds: ['runs'],
+	user: ['runs'],
+	open: ['schedules'],
+	summary: ['schedules'],
+	resource_type: ['resources'],
+	owner: ['variables', 'resources'],
+	username: ['audit_logs'],
+	operation: ['audit_logs'],
+	resource: ['audit_logs'],
+	tab: ['workspace_settings']
 }
 
-function summarizeSchedulesTarget(a: OpenPageArgs): string {
-	if (a.open) return a.open
-	const bits: string[] = []
-	if (a.path) bits.push(a.path)
-	if (a.schedule_path) bits.push(a.schedule_path)
-	if (a.summary) bits.push(`"${a.summary}"`)
-	return bits.length ? bits.join(', ') : 'all schedules'
+// The model-facing schema for the given allowed pages: the `page` enum plus only the
+// fields relevant to those pages (reusing the full schema's field definitions).
+function buildOpenPageDefSchema(pages: readonly OpenPageName[]): z.ZodTypeAny {
+	const full = openPageFullSchema.shape as Record<string, z.ZodTypeAny>
+	const shape: Record<string, z.ZodTypeAny> = {
+		page: z.enum([...pages] as [OpenPageName, ...OpenPageName[]]).describe('Which page to open')
+	}
+	for (const [field, fieldPages] of Object.entries(OPEN_PAGE_FIELD_PAGES)) {
+		if (fieldPages.some((p) => pages.includes(p))) shape[field] = full[field]
+	}
+	shape.new_tab = full.new_tab
+	return z.object(shape)
+}
+
+const OPEN_PAGE_DESCRIPTION =
+	'Open a Windmill page with filters applied — Runs, Schedules, Variables, Resources, Assets, Audit logs, or Workspace settings (on a specific tab). Inside an AI session it opens as a tab in the side-panel preview next to the chat; elsewhere it offers a clickable link. Use after surfacing something the user likely wants to inspect (e.g. "show me the failed runs of X", "open the schedule for Y", "open the git sync settings"). This is the only way to show one of these pages in the session preview — open_preview only handles editable items (scripts, flows, raw apps, pipelines). Only pages listed in the `page` enum are available to this user.'
+
+function buildOpenPageUrl(page: OpenPageName, a: OpenPageArgs): string {
+	switch (page) {
+		case 'runs':
+			return buildRunsUrl({
+				status: a.status,
+				path: a.path,
+				schedule_path: a.schedule_path,
+				job_kinds: a.job_kinds,
+				user: a.user
+			})
+		case 'schedules':
+			return buildSchedulesUrl({
+				open: a.open,
+				filters: { path: a.path, schedule_path: a.schedule_path, summary: a.summary }
+			})
+		case 'variables':
+			return buildVariablesUrl({ path: a.path, owner: a.owner })
+		case 'resources':
+			return buildResourcesUrl({ path: a.path, resource_type: a.resource_type, owner: a.owner })
+		case 'assets':
+			return buildAssetsUrl({ path: a.path })
+		case 'audit_logs':
+			return buildAuditLogsUrl({
+				username: a.username,
+				operation: a.operation,
+				resource: a.resource
+			})
+		case 'workspace_settings':
+			return buildWorkspaceSettingsUrl({ tab: a.tab })
+	}
+}
+
+// Human-readable one-liner for the tool status/chip: the applied query params (and any
+// hash target), or "all <page>" when unfiltered.
+function summarizeOpenPage(url: string, page: OpenPageName): string {
+	const u = new URL(url, 'http://x')
+	const parts: string[] = []
+	u.searchParams.forEach((v, k) => parts.push(`${k}=${v}`))
+	if (u.hash) parts.push(u.hash.slice(1))
+	return parts.length ? parts.join(', ') : `all ${OPEN_PAGE_LABELS[page].toLowerCase()}`
 }
 
 export const openPageTool: Tool<{}> = {
 	def: createToolDef(
-		openPageSchema,
+		buildOpenPageDefSchema(allowedOpenPages()),
 		'open_page',
-		'Open a Windmill page (Runs or Schedules) with filters applied. Inside an AI session it opens as a tab in the side-panel preview next to the chat; elsewhere it applies the filters in place or offers a clickable link. Use after surfacing runs or schedules the user likely wants to inspect (e.g. "show me the failed runs of X", "open the schedule for Y"). This is the only way to show a Runs/Schedules page in the session preview — open_preview only handles editable items (scripts, flows, raw apps, pipelines).'
+		OPEN_PAGE_DESCRIPTION
 	),
 	// Keep the row expanded so the link chip (attached below as an action) is visible
 	// without the user having to expand the tool call.
 	showDetails: true,
 	autoCollapseDetails: false,
+	// Re-narrow the advertised `page` enum to this user's permissions each iteration, so
+	// the model never sees (or suggests) a page the user can't reach.
+	setSchema: async function () {
+		this.def = createToolDef(
+			buildOpenPageDefSchema(allowedOpenPages()),
+			'open_page',
+			OPEN_PAGE_DESCRIPTION
+		)
+	},
 	fn: async (ctx) => {
 		const { args, toolId, toolCallbacks } = ctx
-		const parsed = openPageSchema.parse(args)
-		let url: string
-		let page: 'runs' | 'schedules'
-		let summary: string
-		if (parsed.page === 'runs') {
-			const { page: _p, open: _o, summary: _s, new_tab: _n, ...filters } = parsed
-			url = buildRunsUrl(filters)
-			page = 'runs'
-			summary = summarizeRunsFilters(parsed)
-		} else {
-			const { page: _p, open, new_tab: _n, ...filters } = parsed
-			url = buildSchedulesUrl({ open, filters })
-			page = 'schedules'
-			summary = summarizeSchedulesTarget(parsed)
+		const parsed = openPageFullSchema.parse(args)
+		const page = parsed.page as OpenPageName
+		// Defense in depth: never act on a page the user can't reach, even if the model
+		// requests one outside the advertised enum.
+		if (!allowedOpenPages().includes(page)) {
+			return `You don't have access to the ${OPEN_PAGE_LABELS[page] ?? page} page in this workspace.`
 		}
-		const pageLabel = page === 'runs' ? 'Runs' : 'Schedules'
+		const url = buildOpenPageUrl(page, parsed)
+		const pageLabel = OPEN_PAGE_LABELS[page]
+		const summary = summarizeOpenPage(url, page)
 
 		// In a session, show the page as a preview tab alongside the chat (the primary
 		// UX). By default a filter change reuses the tab already showing this page;
@@ -1788,7 +1926,7 @@ export const openPageTool: Tool<{}> = {
 			newTab: parsed.new_tab ?? false
 		})
 		if (previewResult) {
-			toolCallbacks.setToolStatus(toolId, { content: `Opened ${page} preview: ${summary}` })
+			toolCallbacks.setToolStatus(toolId, { content: `Opened ${pageLabel} preview: ${summary}` })
 			return previewResult
 		}
 
@@ -1796,10 +1934,10 @@ export const openPageTool: Tool<{}> = {
 		// controls. (We deliberately don't navigate in place: a same-route goto would
 		// not re-sync the page's URL-driven filter state, so the change wouldn't land.)
 		toolCallbacks.setToolStatus(toolId, {
-			content: `Prepared a link to ${page}: ${summary}`,
+			content: `Prepared a link to ${pageLabel}: ${summary}`,
 			actions: [{ id: `open-page:${page}:${url}`, type: 'navigate', label: summary, url, page }]
 		})
-		return `Offered the user a link to the ${page} page (${summary}). They can click it to open.`
+		return `Offered the user a link to the ${pageLabel} page (${summary}). They can click it to open.`
 	}
 }
 

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -108,8 +108,7 @@ import { get } from 'svelte/store'
 import { deployDraft as deployDraftToWorkspace } from '$lib/utils_draft_deploy'
 import { UserDraftDbSyncer } from '$lib/userDraftDbSyncer.svelte'
 import { bundleRawAppDraft } from './rawAppBundlerBridge'
-import { chatNavigate, isCurrentPage } from '$lib/navigation'
-import { buildRunsUrl, buildSchedulesUrl, RUNS_PATH, SCHEDULES_PATH } from './pageNavigation'
+import { buildRunsUrl, buildSchedulesUrl } from './pageNavigation'
 import { pageHref } from '$lib/components/sessions/previewRouter'
 import {
 	clearEphemeralSecretVariableDraftValue,
@@ -1763,19 +1762,16 @@ export const openPageTool: Tool<{}> = {
 		const { args, toolId, toolCallbacks } = ctx
 		const parsed = openPageSchema.parse(args)
 		let url: string
-		let appPath: string
 		let page: 'runs' | 'schedules'
 		let summary: string
 		if (parsed.page === 'runs') {
 			const { page: _p, open: _o, summary: _s, new_tab: _n, ...filters } = parsed
 			url = buildRunsUrl(filters)
-			appPath = RUNS_PATH
 			page = 'runs'
 			summary = summarizeRunsFilters(parsed)
 		} else {
 			const { page: _p, open, new_tab: _n, ...filters } = parsed
 			url = buildSchedulesUrl({ open, filters })
-			appPath = SCHEDULES_PATH
 			page = 'schedules'
 			summary = summarizeSchedulesTarget(parsed)
 		}
@@ -1784,7 +1780,7 @@ export const openPageTool: Tool<{}> = {
 		// In a session, show the page as a preview tab alongside the chat (the primary
 		// UX). By default a filter change reuses the tab already showing this page;
 		// new_tab forces a separate tab. openPagePreview returns undefined when there
-		// is no active session, in which case we fall through to browser navigation.
+		// is no active session, in which case we offer a link chip instead.
 		const previewResult = openPagePreview({
 			sessionId: sessionIdFromCtx(ctx),
 			href: pageHref(url),
@@ -1796,14 +1792,9 @@ export const openPageTool: Tool<{}> = {
 			return previewResult
 		}
 
-		// Hybrid delivery outside a session: in-context filter change navigates
-		// directly; a cross-page jump offers a link chip so the user is never yanked
-		// out of context. If no navigator is registered, fall back to the chip.
-		if (isCurrentPage(appPath) && chatNavigate(url)) {
-			toolCallbacks.setToolStatus(toolId, { content: `Opened ${page}: ${summary}` })
-			return `Applied the ${page} filters in place (${summary}).`
-		}
-
+		// Outside a session there is no preview panel — offer a clickable link the user
+		// controls. (We deliberately don't navigate in place: a same-route goto would
+		// not re-sync the page's URL-driven filter state, so the change wouldn't land.)
 		toolCallbacks.setToolStatus(toolId, {
 			content: `Prepared a link to ${page}: ${summary}`,
 			actions: [{ id: `open-page:${page}:${url}`, type: 'navigate', label: summary, url, page }]

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -103,7 +103,13 @@ import {
 	type WorkspaceItem,
 	type WorkspaceItemType
 } from './workspaceItems'
-import { userStore, superadmin, enterpriseLicense } from '$lib/stores'
+import {
+	userStore,
+	superadmin,
+	enterpriseLicense,
+	userWorkspaces,
+	workspaceStore
+} from '$lib/stores'
 import { get } from 'svelte/store'
 import { deployDraft as deployDraftToWorkspace } from '$lib/utils_draft_deploy'
 import { UserDraftDbSyncer } from '$lib/userDraftDbSyncer.svelte'
@@ -867,7 +873,7 @@ Rules:
 - A "data pipeline" is NOT a flow: it is a DAG of independent scripts in one folder, wired by storage assets (DuckLake/data tables/S3) and triggers via top-of-file \`pipeline\` / \`on <ref>\` annotation comments written in each script's comment syntax (\`--\` for SQL, \`#\` for Python/Bash, \`//\` for TS — a \`//\` line in a SQL node is a syntax error). When the user asks for a data pipeline (or to ingest/transform/materialize data across steps), call get_instructions with subject "pipeline" and build annotated script drafts — do not build a flow.
 - After creating or editing a script or flow draft, run test_run_script, test_run_flow, or test_run_step with representative args before reporting that it works. These tools prefer drafts, so testing does not require deployment.
 - Use list_runs to find recent runs (optionally filtered by path, creator, label, or status), then get_job_logs with a returned id to inspect a specific run's logs — without starting a new test run.
-- Use open_page to show a workspace page with filters applied — Runs, Schedules, Variables, Resources, Assets, Audit logs, or Workspace settings on a specific tab (e.g. "open the failed runs of f/foo/bar", "open the schedule for X", "open the git sync settings"). Only the pages listed for this user in the tool are available; don't offer pages that aren't listed. In a session it opens as a tab in the side-panel preview next to the chat; it is the ONLY way to show these pages there (open_preview handles only editable items). Changing filters on a page that's already open updates that same tab — only pass new_tab when the user explicitly asks for a separate tab. Don't use it as a substitute for list_runs when you just need the data yourself.
+- Use open_page to show a workspace page with filters applied — Runs, Schedules, Variables, Resources, Assets, Audit logs, or Workspace settings on a specific tab (e.g. "open the failed runs of f/foo/bar", "open the schedule for X", "open the git sync settings"). Only the pages listed for this user in the tool are available; don't offer pages that aren't listed. Don't use it as a substitute for list_runs when you just need the data yourself.
 - When a required decision is ambiguous, use askUserQuestion with two to ten clear proposed answer strings instead of guessing. The user can also type a custom answer when none of the proposed answers fit.
 - When the user asks you to remember a lasting preference, always/never do something, or change/stop a behavior going forward, call update_user_instructions to persist it. It edits only the USER INSTRUCTIONS block (not WORKSPACE INSTRUCTIONS). Keep each instruction concise; do not use it for one-off requests scoped to the current task.
 - Keep context targeted.${
@@ -876,7 +882,8 @@ Rules:
 - After writing or substantially editing a script / flow / app draft, show it via open_preview(kind, path) so the user sees the editor and live preview right next to the chat. First check whether it is already shown: if unsure, call get_preview_status. Only call open_preview (or offer to) when no preview is open or it is showing a different item — don't re-open a preview already showing the item you just edited.
 - Building a data pipeline: call open_preview(kind="pipeline", path="<folder>") as the FIRST step, before creating any node — this opens the pipeline editor the user reviews in. path is the folder, not an item; an empty or not-yet-created folder is fine (create_folder first if needed, then open it). Opening it registers build_pipeline_node / edit_pipeline_node — use ONLY those to add or change pipeline nodes, never write_script for a pipeline node — they apply directly as unsaved drafts on the canvas (no separate accept/reject step) that the user reviews and deploys. Do not write pipeline scripts without first opening the editor.
 - When debugging a running raw app, call get_app_runtime_logs to read the live preview's browser console output. It needs the raw app preview open (open_preview kind="raw_app").
-- get_app_runtime_logs only shows the app's browser console. For the server-side logs of a backend runnable the app invoked (a backend.<id> call), call list_app_runs to get that run's job_id from the live preview, then get_job_logs with it. Use this when a backend call errors or returns something unexpected.`
+- get_app_runtime_logs only shows the app's browser console. For the server-side logs of a backend runnable the app invoked (a backend.<id> call), call list_app_runs to get that run's job_id from the live preview, then get_job_logs with it. Use this when a backend call errors or returns something unexpected.
+- open_page opens its page as a tab in the side-panel preview next to the chat — the only way to show one of these pages there (open_preview only handles editable items). Changing filters on a page already open updates that same tab; only pass new_tab when the user explicitly asks for a separate tab.`
 			: ''
 	}
 
@@ -1748,24 +1755,35 @@ function allowedTriggerKinds(): PageTriggerKind[] {
 	return (Object.keys(TRIGGER_PAGES) as PageTriggerKind[]).filter((k) => ee || !TRIGGER_PAGES[k].ee)
 }
 
-// Which pages the current user can actually reach — mirrors the sidebar's gating
-// (operators are restricted to runs/assets by default; workspace settings is
-// admin/superadmin only). The tool only ever advertises, and only ever acts on, pages
-// in this set.
+// Which pages the current user can actually reach — mirrors the sidebar's gating.
+// Operators see exactly the pages enabled in this workspace's operator_settings (the
+// same source OperatorMenu gates on); a missing/false flag means no access, and
+// operators are never admins so workspace_settings is always excluded. Non-operators
+// get every page except workspace_settings, which is admin/superadmin only. The tool
+// only ever advertises, and only ever acts on, pages in this set.
 function allowedOpenPages(): OpenPageName[] {
 	const u = get(userStore)
-	const isOperator = !!u?.operator
 	const isAdmin = !!u?.is_admin || !!get(superadmin)
-	const allowed = new Set<OpenPageName>(['runs', 'assets']) // available to everyone
-	if (!isOperator) {
-		allowed.add('schedules')
-		allowed.add('variables')
-		allowed.add('resources')
-		allowed.add('audit_logs')
-		allowed.add('folders')
-		allowed.add('groups')
-		allowed.add('triggers')
+	if (u?.operator) {
+		const settings = get(userWorkspaces).find(
+			(w) => w.id === get(workspaceStore)
+		)?.operator_settings
+		return OPEN_PAGE_NAMES.filter(
+			(p) =>
+				p !== 'workspace_settings' && settings?.[p as keyof NonNullable<typeof settings>] === true
+		)
 	}
+	const allowed = new Set<OpenPageName>([
+		'runs',
+		'assets',
+		'schedules',
+		'variables',
+		'resources',
+		'audit_logs',
+		'folders',
+		'groups',
+		'triggers'
+	])
 	if (isAdmin) allowed.add('workspace_settings')
 	return OPEN_PAGE_NAMES.filter((p) => allowed.has(p))
 }
@@ -1878,8 +1896,13 @@ function buildOpenPageDefSchema(
 	triggerKinds: readonly PageTriggerKind[]
 ): z.ZodTypeAny {
 	const full = openPageFullSchema.shape as Record<string, z.ZodTypeAny>
+	// z.enum() rejects an empty list, and a user with no reachable pages (e.g. an operator
+	// with every operator_settings flag off) yields exactly that. Fall back to a plain
+	// string so schema-building can't throw; the handler still fails closed on every page.
 	const shape: Record<string, z.ZodTypeAny> = {
-		page: z.enum([...pages] as [OpenPageName, ...OpenPageName[]]).describe('Which page to open')
+		page: pages.length
+			? z.enum([...pages] as [OpenPageName, ...OpenPageName[]]).describe('Which page to open')
+			: z.string().describe('No pages are available to you in this workspace')
 	}
 	for (const [field, fieldPages] of Object.entries(OPEN_PAGE_FIELD_PAGES)) {
 		if (!fieldPages.some((p) => pages.includes(p))) continue

--- a/frontend/src/lib/components/copilot/chat/global/pageNavigation.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/pageNavigation.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import {
+	buildWorkspaceSettingsUrl,
+	buildAuditLogsUrl,
+	buildResourcesUrl,
+	buildVariablesUrl
+} from './pageNavigation'
+
+function parse(appPath: string): URL {
+	return new URL(appPath, 'http://x')
+}
+
+describe('pageNavigation builders', () => {
+	it('opens workspace settings on a specific tab', () => {
+		const u = parse(buildWorkspaceSettingsUrl({ tab: 'git_sync' }))
+		expect(u.pathname).toBe('/workspace_settings')
+		expect(u.searchParams.get('tab')).toBe('git_sync')
+	})
+
+	it('opens workspace settings with no tab', () => {
+		const u = parse(buildWorkspaceSettingsUrl({}))
+		expect(u.pathname).toBe('/workspace_settings')
+		expect(u.search).toBe('')
+	})
+
+	it('audit logs allow-lists its own keys and drops others', () => {
+		const u = parse(
+			buildAuditLogsUrl({ username: 'admin', operation: 'jobs.run', status: 'failure' })
+		)
+		expect(u.pathname).toBe('/audit_logs')
+		expect(u.searchParams.get('username')).toBe('admin')
+		expect(u.searchParams.get('operation')).toBe('jobs.run')
+		expect(u.searchParams.has('status')).toBe(false) // not an audit-logs key
+	})
+
+	it('resources keeps resource_type + path, drops runs-only keys', () => {
+		const u = parse(
+			buildResourcesUrl({ resource_type: 'postgres', path: 'f/x', status: 'failure' })
+		)
+		expect(u.searchParams.get('resource_type')).toBe('postgres')
+		expect(u.searchParams.get('path')).toBe('f/x')
+		expect(u.searchParams.has('status')).toBe(false)
+	})
+
+	it('variables keeps path + owner only', () => {
+		const u = parse(buildVariablesUrl({ path: 'f/x', owner: 'u/alice', resource_type: 'postgres' }))
+		expect(u.searchParams.get('path')).toBe('f/x')
+		expect(u.searchParams.get('owner')).toBe('u/alice')
+		expect(u.searchParams.has('resource_type')).toBe(false)
+	})
+})

--- a/frontend/src/lib/components/copilot/chat/global/pageNavigation.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/pageNavigation.test.ts
@@ -3,7 +3,9 @@ import {
 	buildWorkspaceSettingsUrl,
 	buildAuditLogsUrl,
 	buildResourcesUrl,
-	buildVariablesUrl
+	buildVariablesUrl,
+	buildTriggersUrl,
+	buildFoldersUrl
 } from './pageNavigation'
 
 function parse(appPath: string): URL {
@@ -47,5 +49,18 @@ describe('pageNavigation builders', () => {
 		expect(u.searchParams.get('path')).toBe('f/x')
 		expect(u.searchParams.get('owner')).toBe('u/alice')
 		expect(u.searchParams.has('resource_type')).toBe(false)
+	})
+
+	it('triggers route to the kind page, opening a specific trigger via hash', () => {
+		expect(parse(buildTriggersUrl({ trigger_kind: 'kafka' })).pathname).toBe('/kafka_triggers')
+		const u = parse(buildTriggersUrl({ trigger_kind: 'http', open: 'f/a/b' }))
+		expect(u.pathname).toBe('/routes')
+		expect(u.hash).toBe('#f/a/b')
+	})
+
+	it('folders opens the list page with no params', () => {
+		const u = parse(buildFoldersUrl())
+		expect(u.pathname).toBe('/folders')
+		expect(u.search).toBe('')
 	})
 })

--- a/frontend/src/lib/components/copilot/chat/global/pageNavigation.ts
+++ b/frontend/src/lib/components/copilot/chat/global/pageNavigation.ts
@@ -1,0 +1,45 @@
+import { buildFilterUrl } from '$lib/navigation'
+import { buildRunsFilterSearchbarSchema } from '$lib/components/runs/runsFilter'
+import { buildSchedulesFilterSchema } from '$lib/components/schedules/schedulesFilter'
+
+// In-app paths for the deep-linkable preview pages the AI chat can open.
+export const RUNS_PATH = '/runs'
+export const SCHEDULES_PATH = '/schedules'
+
+// Valid query-param keys are derived from the real filter schemas (option arrays are
+// irrelevant to the key set), so a renamed filter key propagates here for free.
+const RUNS_FILTER_KEYS = Object.keys(
+	buildRunsFilterSearchbarSchema({
+		paths: [],
+		usernames: [],
+		folders: [],
+		jobTriggerKinds: [],
+		isSuperAdminOrDevops: false,
+		isAdminsWorkspace: false
+	})
+)
+const SCHEDULES_FILTER_KEYS = Object.keys(
+	buildSchedulesFilterSchema({ paths: [], scriptPaths: [] })
+)
+
+/** Deep-link to the Runs page with the given filters (keys must match `runsFilter`). */
+export function buildRunsUrl(filters: Record<string, unknown>): string {
+	return buildFilterUrl(RUNS_PATH, filters, { validKeys: RUNS_FILTER_KEYS })
+}
+
+/**
+ * Deep-link to the Schedules page. When `open` is set, the schedule at that exact path
+ * is opened in the edit drawer via the `#<schedule_path>` hash the page already handles.
+ */
+export function buildSchedulesUrl({
+	open,
+	filters
+}: {
+	open?: string
+	filters?: Record<string, unknown>
+}): string {
+	return buildFilterUrl(SCHEDULES_PATH, filters ?? {}, {
+		validKeys: SCHEDULES_FILTER_KEYS,
+		hash: open
+	})
+}

--- a/frontend/src/lib/components/copilot/chat/global/pageNavigation.ts
+++ b/frontend/src/lib/components/copilot/chat/global/pageNavigation.ts
@@ -5,6 +5,39 @@ import { buildSchedulesFilterSchema } from '$lib/components/schedules/schedulesF
 // In-app paths for the deep-linkable preview pages the AI chat can open.
 export const RUNS_PATH = '/runs'
 export const SCHEDULES_PATH = '/schedules'
+export const VARIABLES_PATH = '/variables'
+export const RESOURCES_PATH = '/resources'
+export const ASSETS_PATH = '/assets'
+export const AUDIT_LOGS_PATH = '/audit_logs'
+export const WORKSPACE_SETTINGS_PATH = '/workspace_settings'
+
+// Selectable tabs on the Workspace settings page (the `?tab=` query param). Mirrors the
+// union in routes/(root)/(logged)/workspace_settings/+page.svelte.
+export const WORKSPACE_SETTINGS_TABS = [
+	'users',
+	'slack',
+	'teams',
+	'premium',
+	'general',
+	'webhook',
+	'deploy_to',
+	'dev_workspace',
+	'error_handler',
+	'success_handler',
+	'critical_alerts',
+	'ai',
+	'windmill_data_tables',
+	'windmill_lfs',
+	'volume_storage',
+	'ducklake',
+	'git_sync',
+	'default_app',
+	'native_triggers',
+	'encryption',
+	'dependencies',
+	'rulesets',
+	'shared_ui'
+] as const
 
 // Valid query-param keys are derived from the real filter schemas (option arrays are
 // irrelevant to the key set), so a renamed filter key propagates here for free.
@@ -42,4 +75,33 @@ export function buildSchedulesUrl({
 		validKeys: SCHEDULES_FILTER_KEYS,
 		hash: open
 	})
+}
+
+// The remaining pages expose a curated subset of each page's real query params (not the
+// full filter schema), so the allow-list is the exact set of keys the builder emits —
+// these names match the query params the pages read (variablesFilter/resourcesFilter/
+// assetsFilter and audit_logs/+page.svelte).
+export function buildVariablesUrl(filters: Record<string, unknown>): string {
+	return buildFilterUrl(VARIABLES_PATH, filters, { validKeys: ['path', 'owner'] })
+}
+
+export function buildResourcesUrl(filters: Record<string, unknown>): string {
+	return buildFilterUrl(RESOURCES_PATH, filters, {
+		validKeys: ['path', 'resource_type', 'owner']
+	})
+}
+
+export function buildAssetsUrl(filters: Record<string, unknown>): string {
+	return buildFilterUrl(ASSETS_PATH, filters, { validKeys: ['path'] })
+}
+
+export function buildAuditLogsUrl(filters: Record<string, unknown>): string {
+	return buildFilterUrl(AUDIT_LOGS_PATH, filters, {
+		validKeys: ['username', 'operation', 'resource']
+	})
+}
+
+/** Deep-link to the Workspace settings page, optionally on a specific `?tab=`. */
+export function buildWorkspaceSettingsUrl({ tab }: { tab?: string }): string {
+	return buildFilterUrl(WORKSPACE_SETTINGS_PATH, tab ? { tab } : {})
 }

--- a/frontend/src/lib/components/copilot/chat/global/pageNavigation.ts
+++ b/frontend/src/lib/components/copilot/chat/global/pageNavigation.ts
@@ -1,6 +1,7 @@
 import { buildFilterUrl } from '$lib/navigation'
 import { buildRunsFilterSearchbarSchema } from '$lib/components/runs/runsFilter'
 import { buildSchedulesFilterSchema } from '$lib/components/schedules/schedulesFilter'
+import { TRIGGER_PAGES, type TriggerKind } from '$lib/components/sessions/previewRouter'
 
 // In-app paths for the deep-linkable preview pages the AI chat can open.
 export const RUNS_PATH = '/runs'
@@ -10,6 +11,8 @@ export const RESOURCES_PATH = '/resources'
 export const ASSETS_PATH = '/assets'
 export const AUDIT_LOGS_PATH = '/audit_logs'
 export const WORKSPACE_SETTINGS_PATH = '/workspace_settings'
+export const FOLDERS_PATH = '/folders'
+export const GROUPS_PATH = '/groups'
 
 // Selectable tabs on the Workspace settings page (the `?tab=` query param). Mirrors the
 // union in routes/(root)/(logged)/workspace_settings/+page.svelte.
@@ -104,4 +107,27 @@ export function buildAuditLogsUrl(filters: Record<string, unknown>): string {
 /** Deep-link to the Workspace settings page, optionally on a specific `?tab=`. */
 export function buildWorkspaceSettingsUrl({ tab }: { tab?: string }): string {
 	return buildFilterUrl(WORKSPACE_SETTINGS_PATH, tab ? { tab } : {})
+}
+
+/** Folders and Groups list pages have no query filters — just open them. */
+export function buildFoldersUrl(): string {
+	return FOLDERS_PATH
+}
+
+export function buildGroupsUrl(): string {
+	return GROUPS_PATH
+}
+
+/**
+ * Deep-link to a trigger list page (by kind). When `open` is set, the trigger at that
+ * exact path is opened in the edit drawer via the `#<path>` hash the page handles.
+ */
+export function buildTriggersUrl({
+	trigger_kind,
+	open
+}: {
+	trigger_kind: TriggerKind
+	open?: string
+}): string {
+	return buildFilterUrl(TRIGGER_PAGES[trigger_kind].path, {}, { hash: open })
 }

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -490,7 +490,18 @@ export type CreatedResourceAction = {
 	triggerKind?: CreatedResourceTriggerKind
 }
 
-export type ToolDisplayAction = CreatedResourceAction
+// A clickable chip that deep-links the user to an in-app page (e.g. Runs filtered to
+// a script's failures). Used for cross-page navigation from the chat; the handler is
+// registered by a top-level layout and calls `goto(url)`.
+export type NavigateAction = {
+	id: string
+	type: 'navigate'
+	label: string
+	url: string
+	page: 'runs' | 'schedules'
+}
+
+export type ToolDisplayAction = CreatedResourceAction | NavigateAction
 
 export type UserQuestionDisplay = {
 	question: string

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -498,7 +498,8 @@ export type NavigateAction = {
 	type: 'navigate'
 	label: string
 	url: string
-	page: 'runs' | 'schedules'
+	// Which page the chip opens (runs, schedules, variables, …); drives its icon/title.
+	page: string
 }
 
 export type ToolDisplayAction = CreatedResourceAction | NavigateAction

--- a/frontend/src/lib/components/copilot/chat/workspaceItems.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/workspaceItems.svelte.ts
@@ -20,7 +20,7 @@ import { itemHref as offboardingItemHref } from '$lib/components/offboarding-uti
 import { findAndReplace } from 'mdast-util-find-and-replace'
 import { visit } from 'unist-util-visit'
 import type { Root, InlineCode, Link } from 'mdast'
-import type { ToolDisplayAction } from './shared'
+import type { CreatedResourceAction, ToolDisplayAction } from './shared'
 
 export type WindmillItemKind =
 	| 'script'
@@ -67,9 +67,9 @@ export const WINDMILL_PATH_REGEX =
  */
 const WINDMILL_PATH_EXACT_REGEX = /^[uf]\/[A-Za-z0-9_.\-]+\/[A-Za-z0-9_./\-]*[A-Za-z0-9_\-]$/
 
-function workspaceItemTriggerKind(kind: WindmillItemKind): ToolDisplayAction['triggerKind'] {
+function workspaceItemTriggerKind(kind: WindmillItemKind): CreatedResourceAction['triggerKind'] {
 	if (!kind.endsWith('_trigger')) return undefined
-	return kind.slice(0, -'_trigger'.length) as ToolDisplayAction['triggerKind']
+	return kind.slice(0, -'_trigger'.length) as CreatedResourceAction['triggerKind']
 }
 
 /**

--- a/frontend/src/lib/components/sessions/previewRouter.ts
+++ b/frontend/src/lib/components/sessions/previewRouter.ts
@@ -94,6 +94,21 @@ export function matchPreviewPage(path: string): PreviewPage | undefined {
 	return PREVIEW_PAGES.find((p) => p.path === clean)
 }
 
+/** Human label for a preview tab's location — the workspace page name, trigger
+ * page, run detail, or item path. Shared by the sessions tab strip and the
+ * close_page matcher so both name a tab the same way. */
+export function previewLocationLabel(url: string): string {
+	const page = matchPreviewPage(url)
+	if (page) return page.label
+	const trigger = triggerLabelForPath(url)
+	if (trigger) return trigger
+	const run = stripBase(url).match(/^\/run\/([^/?#]+)/)
+	if (run) return `Run ${decodeURIComponent(run[1]).slice(0, 8)}`
+	const parsed = parsePreviewItemRoute(url)
+	if (parsed) return parsed.itemPath.split('/').pop() ?? parsed.itemPath
+	return stripBase(url)
+}
+
 export type PreviewItemRoute = { kind: WorkspaceItemKind; raw_app: boolean; itemPath: string }
 
 // Parse a preview URL/pathname into the workspace item it edits, or null for a

--- a/frontend/src/lib/components/sessions/previewRouter.ts
+++ b/frontend/src/lib/components/sessions/previewRouter.ts
@@ -41,6 +41,41 @@ export const PREVIEW_PAGES: PreviewPage[] = [
 	{ label: 'Audit logs', path: '/audit_logs', icon: ScrollText }
 ]
 
+// Trigger list pages, by kind. Deliberately kept out of PREVIEW_PAGES (the curated
+// breadcrumb picker) but shared here so open_page can route to them and the preview tab
+// can label them. `ee` kinds require an enterprise license. Each supports `#<path>` to
+// open a specific trigger, like Schedules.
+export type TriggerKind =
+	| 'http'
+	| 'websocket'
+	| 'postgres'
+	| 'kafka'
+	| 'nats'
+	| 'sqs'
+	| 'gcp'
+	| 'azure'
+	| 'mqtt'
+	| 'email'
+
+export const TRIGGER_PAGES: Record<TriggerKind, { path: string; label: string; ee?: boolean }> = {
+	http: { path: '/routes', label: 'HTTP routes' },
+	websocket: { path: '/websocket_triggers', label: 'WebSocket triggers' },
+	postgres: { path: '/postgres_triggers', label: 'Postgres triggers' },
+	kafka: { path: '/kafka_triggers', label: 'Kafka triggers', ee: true },
+	nats: { path: '/nats_triggers', label: 'NATS triggers', ee: true },
+	sqs: { path: '/sqs_triggers', label: 'SQS triggers', ee: true },
+	gcp: { path: '/gcp_triggers', label: 'GCP Pub/Sub triggers', ee: true },
+	azure: { path: '/azure_triggers', label: 'Azure Event Grid triggers', ee: true },
+	mqtt: { path: '/mqtt_triggers', label: 'MQTT triggers' },
+	email: { path: '/email_triggers', label: 'Email triggers' }
+}
+
+/** Label a trigger list page from its (base-stripped) pathname, or undefined. */
+export function triggerLabelForPath(path: string): string | undefined {
+	const clean = stripBase(path)
+	return Object.values(TRIGGER_PAGES).find((t) => t.path === clean)?.label
+}
+
 export const pageKey = (path: string) => `page:${path}`
 export const pageHref = (path: string) => `${base}${path}`
 

--- a/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
@@ -4,6 +4,7 @@ import { editPathFor, type WorkspaceItem } from '$lib/components/workspacePicker
 import {
 	matchPreviewPage,
 	parsePreviewItemRoute,
+	previewLocationLabel,
 	resolvePreviewTab,
 	stripBase,
 	type PreviewTarget
@@ -292,6 +293,26 @@ export class SessionPreviewTabs {
 			collapsed: this.#collapsed
 		})
 	}
+}
+
+// Which tabs the `close_page` AI tool should close: every tab when `all`, else
+// those whose page label or stripped path contains `match` (case-insensitive).
+// Pure over a tab snapshot so the runtime handler can close by id and this stays
+// unit-testable. An empty/whitespace match closes nothing (the handler reports it).
+export function selectPreviewTabsToClose(
+	tabs: SessionPreviewTab[],
+	opts: { all: boolean; match: string | undefined }
+): SessionPreviewTab[] {
+	if (opts.all) return tabs.slice()
+	const needle = opts.match?.trim().toLowerCase()
+	if (!needle) return []
+	return tabs.filter((t) => {
+		const where = t.loc || t.url
+		return (
+			previewLocationLabel(where).toLowerCase().includes(needle) ||
+			where.toLowerCase().includes(needle)
+		)
+	})
 }
 
 // Human-readable summary of a session's open preview tabs, for the

--- a/frontend/src/lib/components/sessions/sessionPreviewTabs.test.ts
+++ b/frontend/src/lib/components/sessions/sessionPreviewTabs.test.ts
@@ -4,6 +4,7 @@ import {
 	describePreview,
 	hydratePreviewTabs,
 	previewTargetForSessionTarget,
+	selectPreviewTabsToClose,
 	type PreviewTabsAdapter,
 	type PreviewTabsSnapshot
 } from './sessionPreviewTabs.svelte'
@@ -407,5 +408,36 @@ describe('describePreview', () => {
 		const out = describePreview(tabs, 'a', { kind: 'script', path: 'u/me/foo' })
 		expect(out).toContain('page "Runs"')
 		expect(out).not.toContain('live editor')
+	})
+})
+
+describe('selectPreviewTabsToClose', () => {
+	const tabs: SessionPreviewTab[] = [
+		{ id: 'runs', url: '/runs?status=failure', loc: '/runs?status=failure' },
+		{ id: 'sched', url: '/schedules', loc: '/schedules' },
+		{ id: 'script', url: '/scripts/edit/u/me/foo', loc: '/scripts/edit/u/me/foo' }
+	]
+
+	it('closes every tab when `all`', () => {
+		expect(
+			selectPreviewTabsToClose(tabs, { all: true, match: undefined }).map((t) => t.id)
+		).toEqual(['runs', 'sched', 'script'])
+	})
+
+	it('matches a page by its label, case-insensitively', () => {
+		expect(selectPreviewTabsToClose(tabs, { all: false, match: 'Runs' }).map((t) => t.id)).toEqual([
+			'runs'
+		])
+	})
+
+	it('matches an item tab by its path fragment', () => {
+		expect(
+			selectPreviewTabsToClose(tabs, { all: false, match: 'u/me/foo' }).map((t) => t.id)
+		).toEqual(['script'])
+	})
+
+	it('closes nothing for an empty/whitespace match or no match', () => {
+		expect(selectPreviewTabsToClose(tabs, { all: false, match: '   ' })).toEqual([])
+		expect(selectPreviewTabsToClose(tabs, { all: false, match: 'nonexistent' })).toEqual([])
 	})
 })

--- a/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
@@ -45,15 +45,17 @@ import {
 	SessionPreviewTabs,
 	describePreview,
 	hydratePreviewTabs,
-	previewTargetForSessionTarget
+	previewTargetForSessionTarget,
+	selectPreviewTabsToClose
 } from './sessionPreviewTabs.svelte'
-import { matchPreviewPage } from './previewRouter'
+import { matchPreviewPage, previewLocationLabel } from './previewRouter'
 import { UserDraft } from '$lib/userDraft.svelte'
 import { UserDraftDbSyncer } from '$lib/userDraftDbSyncer.svelte'
 import { armRestartOnFirstInteraction } from '$lib/userDraftToast'
 import { applyDraftToRuntimeRawApp, runtimeRawAppToDraft, type RawAppDraft } from './appDraftCodec'
 import {
 	setDeployedInSessionHandler,
+	setClosePreviewTabsHandler,
 	setGetPreviewStatusHandler,
 	setGetRuntimeLogsHandler,
 	setListAppRunsHandler,
@@ -871,6 +873,29 @@ setGetPreviewStatusHandler((callerSessionId) => {
 	if (!session) return 'No active session; the preview panel is unavailable.'
 	const owner = getOrCreateRuntime(session).previewTabs
 	return describePreview(owner.tabs, owner.activeId, session.target)
+})
+
+// close_page dispatches here to close preview tabs in the calling session's
+// panel. `all` clears every tab; otherwise `match` is a case-insensitive
+// substring tested against each tab's page label and stripped path.
+setClosePreviewTabsHandler(({ sessionId: callerSessionId, all, match }) => {
+	const sessionId = callerSessionId ?? sessionState.currentSessionId
+	if (!sessionId) return 'No active session; the preview panel is unavailable.'
+	const session = sessionState.sessions.find((s) => s.id === sessionId)
+	if (!session) return 'No active session; the preview panel is unavailable.'
+	const owner = getOrCreateRuntime(session).previewTabs
+	if (owner.tabs.length === 0) return 'The preview panel has no open tabs.'
+
+	const labelFor = (t: (typeof owner.tabs)[number]) => previewLocationLabel(t.loc || t.url)
+	// Resolve the doomed tabs to ids up front — close() re-indexes on each call.
+	const doomed = selectPreviewTabsToClose(owner.tabs, { all, match })
+	if (doomed.length === 0) {
+		const open = owner.tabs.map(labelFor).join(', ')
+		return `No open tab matched "${match}". Open tabs: ${open}.`
+	}
+	const closedLabels = doomed.map(labelFor)
+	for (const t of doomed) owner.close(t.id)
+	return `Closed ${closedLabels.length} preview tab${closedLabels.length === 1 ? '' : 's'} (${closedLabels.join(', ')}).`
 })
 
 // After a chat deploy, reload the calling session's preview — only if it's open

--- a/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
@@ -47,6 +47,7 @@ import {
 	hydratePreviewTabs,
 	previewTargetForSessionTarget
 } from './sessionPreviewTabs.svelte'
+import { matchPreviewPage } from './previewRouter'
 import { UserDraft } from '$lib/userDraft.svelte'
 import { UserDraftDbSyncer } from '$lib/userDraftDbSyncer.svelte'
 import { armRestartOnFirstInteraction } from '$lib/userDraftToast'
@@ -56,6 +57,7 @@ import {
 	setGetPreviewStatusHandler,
 	setGetRuntimeLogsHandler,
 	setListAppRunsHandler,
+	setOpenPagePreviewHandler,
 	setOpenPreviewHandler
 } from '$lib/components/copilot/chat/global/core'
 import {
@@ -824,6 +826,39 @@ setOpenPreviewHandler(({ sessionId: callerSessionId, kind, path }) => {
 	return result.status === 'focused'
 		? `A preview tab is already showing ${kind} "${path}" — focused it.`
 		: `Opened ${kind} preview for ${path} in a new tab in the side panel.`
+})
+
+// open_page dispatches here to show a workspace page (Runs/Schedules) as a page
+// tab in the calling session's preview panel. Returns undefined when there is no
+// session so open_page can fall back to browser navigation.
+setOpenPagePreviewHandler(({ sessionId: callerSessionId, href, label, newTab }) => {
+	const sessionId = callerSessionId ?? sessionState.currentSessionId
+	if (!sessionId) return undefined
+	const session = sessionState.sessions.find((s) => s.id === sessionId)
+	if (!session) return undefined
+	const owner = getOrCreateRuntime(session).previewTabs
+	// Re-point the tab already showing this page (matched ignoring query/hash) so a
+	// filter change updates it in place instead of spawning a duplicate — unless the
+	// user asked for a separate tab. open() dedupes on the exact URL, so differing
+	// filters would otherwise always open a new tab.
+	const targetPage = matchPreviewPage(href)
+	if (!newTab && targetPage) {
+		const existing = owner.tabs.find(
+			(t) => matchPreviewPage(t.loc || t.url)?.path === targetPage.path
+		)
+		if (existing) {
+			owner.select(existing.id)
+			owner.navigate({ type: 'page', href, label })
+			owner.setCollapsed(false)
+			promoteEditorWarm(sessionId)
+			return `Updated the ${label} preview tab with the new filters.`
+		}
+	}
+	const result = owner.open({ type: 'page', href, label })
+	promoteEditorWarm(sessionId)
+	return result.status === 'focused'
+		? `A preview tab is already showing ${label} — focused it and applied the filters.`
+		: `Opened ${label} in a new preview tab in the side panel.`
 })
 
 // Companion to the open_preview handler: report the calling session's open

--- a/frontend/src/lib/navigation.test.ts
+++ b/frontend/src/lib/navigation.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { buildFilterUrl } from './navigation'
+
+// Parse the (un-based) app path the builder returns against a dummy origin so we can
+// assert on pathname / searchParams / hash without caring about ordering.
+function parse(appPath: string): URL {
+	return new URL(appPath, 'http://x')
+}
+
+describe('buildFilterUrl', () => {
+	it('drops keys not in validKeys, and nullish/empty values', () => {
+		const u = parse(
+			buildFilterUrl(
+				'/runs',
+				{
+					status: 'failure',
+					path: 'f/foo/bar',
+					bogus: 'x',
+					user: '',
+					tag: null,
+					worker: undefined
+				},
+				{ validKeys: ['status', 'path', 'user', 'tag', 'worker'] }
+			)
+		)
+		expect(u.pathname).toBe('/runs')
+		expect(u.searchParams.get('status')).toBe('failure')
+		expect(u.searchParams.get('path')).toBe('f/foo/bar')
+		expect(u.searchParams.has('bogus')).toBe(false) // not in validKeys
+		expect(u.searchParams.has('user')).toBe(false) // empty string dropped
+		expect(u.searchParams.has('tag')).toBe(false) // null dropped
+		expect(u.searchParams.has('worker')).toBe(false) // undefined dropped
+	})
+
+	it('keeps every key when no validKeys are given', () => {
+		const u = parse(buildFilterUrl('/runs', { anything: 'yes' }))
+		expect(u.searchParams.get('anything')).toBe('yes')
+	})
+
+	it('appends a hash and no query when there are no params', () => {
+		const u = parse(buildFilterUrl('/schedules', {}, { hash: 'f/a/b' }))
+		expect(u.pathname).toBe('/schedules')
+		expect(u.search).toBe('')
+		expect(u.hash).toBe('#f/a/b')
+	})
+
+	it('combines params and hash', () => {
+		const u = parse(buildFilterUrl('/schedules', { path: 'f/x' }, { hash: 'f/a/b' }))
+		expect(u.searchParams.get('path')).toBe('f/x')
+		expect(u.hash).toBe('#f/a/b')
+	})
+})

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -1,5 +1,6 @@
 import { goto as svelteGoto } from '$app/navigation'
 import { base as svelteBase } from '$app/paths'
+import { serializeParam } from '$lib/svelte5UtilsKit.svelte'
 
 export function goto(path: string, options = {}) {
 	if (svelteBase == '' || path.startsWith('?')) {
@@ -8,6 +9,59 @@ export function goto(path: string, options = {}) {
 		const fullPath = path.startsWith(svelteBase) ? path : `${svelteBase}${path}`
 		return svelteGoto(fullPath, options)
 	}
+}
+
+/**
+ * Build an in-app deep-link to `pathname` with query-param filters, encoded exactly
+ * as the pages write them (via `serializeParam`) so `useUrlSyncedFilterInstance`
+ * round-trips them back into filter state. Nullish/empty values are dropped; when
+ * `validKeys` is provided, unknown keys are dropped too (structured output guarantees
+ * shape, not truth). Returns an un-prefixed app path — pass it to `goto`, which adds
+ * the SvelteKit base.
+ */
+export function buildFilterUrl(
+	pathname: string,
+	values: Record<string, unknown>,
+	opts?: { validKeys?: Iterable<string>; hash?: string }
+): string {
+	const allow = opts?.validKeys ? new Set(opts.validKeys) : undefined
+	const sp = new URLSearchParams()
+	for (const [key, value] of Object.entries(values)) {
+		if (value === undefined || value === null || value === '') continue
+		if (allow && !allow.has(key)) continue
+		sp.set(key, serializeParam(value))
+	}
+	const qs = sp.toString()
+	const hash = opts?.hash ? `#${opts.hash}` : ''
+	return qs ? `${pathname}?${qs}${hash}` : `${pathname}${hash}`
+}
+
+/** Current in-app pathname with the SvelteKit base stripped. */
+function currentAppPathname(): string {
+	const p = window.location.pathname
+	return svelteBase && p.startsWith(svelteBase) ? p.slice(svelteBase.length) : p
+}
+
+/** True when the user is already on `appPath` (base-agnostic prefix match). */
+export function isCurrentPage(appPath: string): boolean {
+	return currentAppPathname().startsWith(appPath)
+}
+
+// Module-global navigation slot, mirroring the copilot handler-registration seams
+// (e.g. setOpenPreviewHandler). A top-level logged-in layout registers the actual
+// `goto`-based navigator at mount so callers that must stay router-free — notably AI
+// chat tools — can trigger navigation without importing $app/navigation.
+let chatNavigateHandler: ((appPath: string) => void) | undefined
+
+export function setChatNavigateHandler(fn: ((appPath: string) => void) | undefined): void {
+	chatNavigateHandler = fn
+}
+
+/** Navigate to an in-app path via the registered handler. Returns false if none is registered. */
+export function chatNavigate(appPath: string): boolean {
+	if (!chatNavigateHandler) return false
+	chatNavigateHandler(appPath)
+	return true
 }
 
 export async function setQuery(

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -36,34 +36,6 @@ export function buildFilterUrl(
 	return qs ? `${pathname}?${qs}${hash}` : `${pathname}${hash}`
 }
 
-/** Current in-app pathname with the SvelteKit base stripped. */
-function currentAppPathname(): string {
-	const p = window.location.pathname
-	return svelteBase && p.startsWith(svelteBase) ? p.slice(svelteBase.length) : p
-}
-
-/** True when the user is already on `appPath` (base-agnostic prefix match). */
-export function isCurrentPage(appPath: string): boolean {
-	return currentAppPathname().startsWith(appPath)
-}
-
-// Module-global navigation slot, mirroring the copilot handler-registration seams
-// (e.g. setOpenPreviewHandler). A top-level logged-in layout registers the actual
-// `goto`-based navigator at mount so callers that must stay router-free — notably AI
-// chat tools — can trigger navigation without importing $app/navigation.
-let chatNavigateHandler: ((appPath: string) => void) | undefined
-
-export function setChatNavigateHandler(fn: ((appPath: string) => void) | undefined): void {
-	chatNavigateHandler = fn
-}
-
-/** Navigate to an in-app path via the registered handler. Returns false if none is registered. */
-export function chatNavigate(appPath: string): boolean {
-	if (!chatNavigateHandler) return false
-	chatNavigateHandler(appPath)
-	return true
-}
-
 export async function setQuery(
 	url: URL,
 	key: string,

--- a/frontend/src/lib/svelte5UtilsKit.svelte.ts
+++ b/frontend/src/lib/svelte5UtilsKit.svelte.ts
@@ -9,7 +9,7 @@ export type SearchParamsResult<S extends z.ZodType> =
 		: z.infer<S> & Record<string, unknown>
 
 /** Serialize a value to a URL search param string. Primitives are written as-is; anything else is JSON. */
-function serializeParam(value: unknown): string {
+export function serializeParam(value: unknown): string {
 	if (typeof value === 'string') return value
 	if (typeof value === 'number') return String(value)
 	if (typeof value === 'boolean') return String(value)

--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -41,7 +41,8 @@
 	} from '$lib/stores'
 	import CenteredModal from '$lib/components/CenteredModal.svelte'
 	import { afterNavigate, beforeNavigate } from '$app/navigation'
-	import { goto } from '$lib/navigation'
+	import { goto, setChatNavigateHandler } from '$lib/navigation'
+	import { registerToolDisplayActionHandler } from '$lib/components/copilot/chat/createdResourceActions.svelte'
 	import UserSettings from '$lib/components/UserSettings.svelte'
 	import SuperadminSettings from '$lib/components/SuperadminSettings.svelte'
 	import WindmillIcon from '$lib/components/icons/WindmillIcon.svelte'
@@ -193,6 +194,19 @@
 	}
 
 	onDestroy(() => stopSidebarResize?.())
+
+	// Give router-free callers (AI chat tools) a way to navigate: a direct-nav slot
+	// for in-context moves and the 'navigate' display-action for cross-page link chips.
+	$effect(() => {
+		setChatNavigateHandler((path) => goto(path))
+		const unregisterNavigate = registerToolDisplayActionHandler('navigate', (action) => {
+			if (action.type === 'navigate') goto(action.url)
+		})
+		return () => {
+			setChatNavigateHandler(undefined)
+			unregisterNavigate()
+		}
+	})
 	let userSettings: UserSettings | undefined = $state()
 	let superadminSettings: SuperadminSettings | undefined = $state()
 	let menuHidden = $state(false)
@@ -326,6 +340,20 @@
 		}
 	}
 
+	// A job-detail navigation (/run/<id>) inside a preview tab should open the job in
+	// a NEW tab rather than navigate the current tab away from its page (e.g. clicking
+	// a job in the Runs tab keeps Runs put and opens the run beside it). Returns the
+	// href to open (nomenubar dropped — the preview host re-adds it) and a short label.
+	function previewRunTarget(url: URL | undefined): { href: string; label: string } | undefined {
+		if (!url) return undefined
+		const m = url.pathname.match(/\/run\/([^/?#]+)/)
+		if (!m) return undefined
+		const u = new URL(url.href)
+		u.searchParams.delete('nomenubar')
+		const id = decodeURIComponent(m[1])
+		return { href: u.pathname + u.search, label: `Run ${id.slice(0, 8)}` }
+	}
+
 	// Map a navigation target to the session editor it should open as a component,
 	// or undefined for anything without a live-editor wrapper (regular apps, pages,
 	// /get viewers). Only /edit routes — the wrappers are editors.
@@ -365,6 +393,17 @@
 				try {
 					window.parent.postMessage(
 						{ type: 'wm.session.openEditor', kind: target.kind, path: target.path },
+						window.location.origin
+					)
+				} catch {}
+				return
+			}
+			const runTarget = previewRunTarget(navigation.to?.url)
+			if (runTarget) {
+				navigation.cancel()
+				try {
+					window.parent.postMessage(
+						{ type: 'wm.session.openRun', href: runTarget.href, label: runTarget.label },
 						window.location.origin
 					)
 				} catch {}

--- a/frontend/src/routes/(root)/(logged)/+layout.svelte
+++ b/frontend/src/routes/(root)/(logged)/+layout.svelte
@@ -41,7 +41,7 @@
 	} from '$lib/stores'
 	import CenteredModal from '$lib/components/CenteredModal.svelte'
 	import { afterNavigate, beforeNavigate } from '$app/navigation'
-	import { goto, setChatNavigateHandler } from '$lib/navigation'
+	import { goto } from '$lib/navigation'
 	import { registerToolDisplayActionHandler } from '$lib/components/copilot/chat/createdResourceActions.svelte'
 	import UserSettings from '$lib/components/UserSettings.svelte'
 	import SuperadminSettings from '$lib/components/SuperadminSettings.svelte'
@@ -195,17 +195,13 @@
 
 	onDestroy(() => stopSidebarResize?.())
 
-	// Give router-free callers (AI chat tools) a way to navigate: a direct-nav slot
-	// for in-context moves and the 'navigate' display-action for cross-page link chips.
+	// Let AI chat's 'navigate' link chips route through the app router without the
+	// tool layer importing $app/navigation.
 	$effect(() => {
-		setChatNavigateHandler((path) => goto(path))
 		const unregisterNavigate = registerToolDisplayActionHandler('navigate', (action) => {
 			if (action.type === 'navigate') goto(action.url)
 		})
-		return () => {
-			setChatNavigateHandler(undefined)
-			unregisterNavigate()
-		}
+		return unregisterNavigate
 	})
 	let userSettings: UserSettings | undefined = $state()
 	let superadminSettings: SuperadminSettings | undefined = $state()

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -48,9 +48,8 @@
 	import {
 		matchPreviewPage,
 		pageKey,
-		stripBase,
 		parsePreviewItemRoute,
-		triggerLabelForPath,
+		previewLocationLabel,
 		type PreviewTarget
 	} from '$lib/components/sessions/previewRouter'
 	import { leafKeyFor, type WorkspaceItem } from '$lib/components/workspacePicker'
@@ -430,15 +429,7 @@
 	// Short tab label: a known page's name, else a run detail, else the item's leaf
 	// name, else path.
 	function tabLabel(url: string): string {
-		const page = matchPreviewPage(url)
-		if (page) return page.label
-		const trigger = triggerLabelForPath(url)
-		if (trigger) return trigger
-		const run = stripBase(url).match(/^\/run\/([^/?#]+)/)
-		if (run) return `Run ${decodeURIComponent(run[1]).slice(0, 8)}`
-		const parsed = parsePreviewItemRoute(url)
-		if (parsed) return parsed.itemPath.split('/').pop() ?? parsed.itemPath
-		return stripBase(url)
+		return previewLocationLabel(url)
 	}
 
 	// A link click inside a live editor (e.g. a subflow reference) re-points the

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -426,10 +426,13 @@
 		owner?.navigate(target)
 	}
 
-	// Short tab label: a known page's name, else the item's leaf name, else path.
+	// Short tab label: a known page's name, else a run detail, else the item's leaf
+	// name, else path.
 	function tabLabel(url: string): string {
 		const page = matchPreviewPage(url)
 		if (page) return page.label
+		const run = stripBase(url).match(/^\/run\/([^/?#]+)/)
+		if (run) return `Run ${decodeURIComponent(run[1]).slice(0, 8)}`
 		const parsed = parsePreviewItemRoute(url)
 		if (parsed) return parsed.itemPath.split('/').pop() ?? parsed.itemPath
 		return stripBase(url)
@@ -458,14 +461,31 @@
 		function onMessage(e: MessageEvent) {
 			if (e.origin !== window.location.origin) return
 			const d = e.data
-			if (!d || d.type !== 'wm.session.openEditor') return
-			if (d.kind !== 'script' && d.kind !== 'flow' && d.kind !== 'raw_app') return
-			if (typeof d.path !== 'string') return
-			const item: WorkspaceItem =
-				d.kind === 'raw_app'
-					? { kind: 'app', raw_app: true, path: d.path, summary: '' }
-					: { kind: d.kind, path: d.path, summary: '' }
-			owner?.navigate({ type: 'item', item })
+			if (!d) return
+			// A preview frame navigating to an editor route: re-point the active tab to
+			// the live in-process editor instead of booting a second one in the frame.
+			if (d.type === 'wm.session.openEditor') {
+				if (d.kind !== 'script' && d.kind !== 'flow' && d.kind !== 'raw_app') return
+				if (typeof d.path !== 'string') return
+				const item: WorkspaceItem =
+					d.kind === 'raw_app'
+						? { kind: 'app', raw_app: true, path: d.path, summary: '' }
+						: { kind: d.kind, path: d.path, summary: '' }
+				owner?.navigate({ type: 'item', item })
+				return
+			}
+			// A job clicked inside a preview tab: open the run detail in a NEW tab so the
+			// originating page (e.g. Runs) stays put. open() focuses an existing tab for
+			// the same run rather than duplicating it.
+			if (d.type === 'wm.session.openRun') {
+				if (typeof d.href !== 'string') return
+				owner?.open({
+					type: 'page',
+					href: d.href,
+					label: typeof d.label === 'string' ? d.label : 'Run'
+				})
+				return
+			}
 		}
 		window.addEventListener('message', onMessage)
 		return () => window.removeEventListener('message', onMessage)

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -50,6 +50,7 @@
 		pageKey,
 		stripBase,
 		parsePreviewItemRoute,
+		triggerLabelForPath,
 		type PreviewTarget
 	} from '$lib/components/sessions/previewRouter'
 	import { leafKeyFor, type WorkspaceItem } from '$lib/components/workspacePicker'
@@ -431,6 +432,8 @@
 	function tabLabel(url: string): string {
 		const page = matchPreviewPage(url)
 		if (page) return page.label
+		const trigger = triggerLabelForPath(url)
+		if (trigger) return trigger
 		const run = stripBase(url).match(/^\/run\/([^/?#]+)/)
 		if (run) return `Run ${decodeURIComponent(run[1]).slice(0, 8)}`
 		const parsed = parsePreviewItemRoute(url)


### PR DESCRIPTION
## Summary

Lets the Windmill AI chat (global mode) take the user to a workspace **page** with the right filters applied — **Runs, Schedules, Variables, Resources, Assets, Audit logs, Folders, Groups, Triggers** (by kind), or **Workspace settings** (on a specific tab). Inside an AI session it opens as a **page tab in the side-panel preview** next to the chat (the primary UX); outside a session it offers a clickable link chip. Also lets the chat **close** preview tabs (`close_page`), and makes clicking a job inside a preview tab open the run detail in a **new** preview tab instead of navigating the current tab away.

> Rebased onto `main` — the session-preview infrastructure this depends on (`previewRouter`, `previewTabs`, `PreviewTabHost`) landed in `main` via #9816, so the base is now `main` and the diff is just the five `open_page`/`close_page` commits.

## Changes

- **`open_page` global-chat tool** (`copilot/chat/global/core.ts`): flat Zod schema (`page` enum + per-page filter fields — a top-level `oneOf` is rejected by Anthropic's `input_schema`, so not a discriminated union).
- **Permission-gated pages**: the advertised `page` enum is rebuilt **per-user** via the `setSchema` hook, mirroring the sidebar — `runs`/`assets` for everyone; `schedules`/`variables`/`resources`/`audit_logs`/`folders`/`groups`/`triggers` for non-operators; `workspace_settings` for admins/superadmins only. The `trigger_kind` enum is narrowed to license-available kinds (kafka/nats/sqs/gcp/azure require EE). A defense-in-depth guard in the handler refuses any page not in the user's allowed set.
- **URL builders** (`$lib/navigation.ts` `buildFilterUrl` + `global/pageNavigation.ts`): reuse the pages' own filter-key vocabularies and `serializeParam` (now exported from `svelte5UtilsKit.svelte.ts`) so a renamed query key can't desync. Schedules/Triggers item-open uses the `#<path>` hash; workspace settings uses `?tab=`. Trigger route metadata lives in `previewRouter.ts` (`TRIGGER_PAGES`), which also labels trigger preview tabs.
- **Session preview delivery**: `setOpenPagePreviewHandler` seam (in `sessionRuntime.svelte.ts`) opens the page as a `{type:'page'}` tab. A filter/tab change **reuses** the tab already showing that page (matched by `matchPreviewPage`, ignoring query/hash); a `new_tab` arg forces a separate tab.
- **Link-chip fallback** outside a session: new `navigate` variant on `ToolDisplayAction`, rendered by `ToolMessageActions.svelte`.
- **Job → new tab**: extended the session-preview `beforeNavigate` postMessage interceptor in `(logged)/+layout.svelte` — a `/run/<id>` client navigation inside a preview tab posts `wm.session.openRun` up, and `sessions/+page.svelte` opens it as a new preview tab (Runs tab stays put). `tabLabel` renders run tabs as `Run <8hex>`.
- **`close_page` global-chat tool** (session-only): closes preview tabs — `all: true` clears the panel, else `match` is a case-insensitive substring tested against each tab's page label and path. Dispatch uses a pure, unit-tested `selectPreviewTabsToClose`; tab labels come from a shared `previewLocationLabel` (also now backs the sessions tab strip's `tabLabel`).
- **Review fix**: dropped the outside-a-session "apply in place" branch (a same-route `goto` doesn't re-sync the pages' popstate-driven filter state) — now always offers a link chip when not in a session.
- **Tests/evals**: unit tests for `buildFilterUrl` + the page builders (`navigation.test.ts`, `pageNavigation.test.ts`); 7 `open_page`/`close_page` eval cases in `ai_evals/cases/global.yaml`.

## Blast radius

Frontend-only — **no backend, EE, migration, or API surface touched**. Only global chat gains new behavior; the shared surfaces this reaches are either additive or behavior-preserving:

- **All AI chat modes** (not just global) render tool-action cards through the shared `ToolMessageActions.svelte` + the `ToolDisplayAction` union, which gained a `NavigateAction` member. Existing `CreatedResourceAction` cards are byte-identical (subtitle still `= action.path`, button icon still `SquarePen`) — **browser-verified in the script-mode in-editor chat** (see below). Union exhaustiveness is enforced by `svelte-check`.
- **`(logged)/+layout.svelte`** mounts on every authenticated page: it registers the `navigate` action handler (inert unless a chip is clicked) and adds a `/run/<id>` interception **gated behind `isSessionPreviewEmbed()`** — normal run-page navigation everywhere else is untouched.
- **`$lib/navigation.ts` `buildFilterUrl`** is a new additive export; **`serializeParam`** is a visibility-only change (no behavior).

## AI evals (global mode)

Ran on `sonnet` against a local backend.

- **Feature cases: 7/7 pass** — 6 `open_page` (Runs filtered by script/schedule, open Schedule, `workspace_settings→git_sync`, `audit_logs→user`, `triggers→kafka`) + 1 `close_page` (`match: runs`). Each selects the right tool with the correct `page`/filter args (deterministic `toolExpect`, `skipJudge`).
- **Context-window A/B** (same 4 pre-existing docs cases, tools present vs. `core.ts` reverted to `main`): the two tool schemas add a flat **~+1,190 tokens** to the per-iteration window (~+4.4% of a ~27k window) — bounded, well clear of overflow/compaction. `open_page`'s page/filter/trigger enums are the bulk; `close_page` is tiny.

  | case | with tools | without | Δ |
  |---|---|---|---|
  | ai-agent-step | 28,007 | 26,810 | +1,197 |
  | retry-step | 27,969 | 26,788 | +1,181 |
  | key-value-store | 28,000 | 26,806 | +1,194 |
  | cron-schedule-format | 27,780 | 26,579 | +1,201 |

- **No regression**: the one diverging pre-existing case never invokes the new tools (it's `search_docs`-only); it's a tight-`maxTurns` flake on an open-ended docs question, reproducible independent of the change.

## Screenshots

Runs page opened with filters as a preview tab, next to the chat:

![open-page-preview-tab](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/improve-tooling/1783414490-open-page-preview-tab.png)

Changing the filter re-points the **same** tab (no duplicate):

![tab-reuse-filter-change](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/improve-tooling/1783414492-tab-reuse-filter-change.png)

`close_page` closes the Runs tab on request (Schedules stays open):

![close-page](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm-improve-tooling/1783419330-close-page-runs-closed.png)

Shared-renderer regression check — an existing `CreatedResourceAction` card (a schedule created by the **script-mode in-editor chat**) still renders correctly through the refactored `ToolMessageActions` (icon, title, path subtitle, "Open" button):

![in-editor-resource-card](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm-improve-tooling/1783440363-incard-resource-card.png)

## Test plan

- [x] `svelte-check` — 0 errors in changed files (1 unrelated pre-existing error in `utils_workspace_deploy.ts` from the data-tables feature on `main`); `buildFilterUrl` + page-builder + preview-tabs unit tests pass
- [x] Session chat: "open the failed runs of X" → Runs tab opens in preview with filters; "now show successful runs" → same tab re-points (no duplicate)
- [x] "open the schedule for X" → `/schedules#<path>` opens the edit drawer
- [x] Deep-link vocabulary (deterministic): `/workspace_settings?tab=git_sync` renders the Git sync tab; `/kafka_triggers` renders the Kafka triggers page
- [x] Job → new tab: `wm.session.openRun` opens the run in a new preview tab; tab label `Run <id>`
- [x] `close_page`: with Runs + Schedules tabs open, "close the runs tab" → AI calls `close_page`, Runs tab removed, Schedules stays (browser-verified)
- [x] `ai_evals` global mode: 7/7 feature cases pass; context-tax A/B measured (+~1,190 tokens, no regression)
- [x] Shared renderer: existing `CreatedResourceAction` card verified un-regressed in a non-global (script-mode in-editor) chat
- [ ] Operator permission gating: log in as an operator and confirm `open_page` doesn't offer the restricted pages (unit-reasoned + fail-closed; not browser-tested)
- [ ] Manual: click "Show run details" on a job inside a session Runs tab and confirm the run opens in a new preview tab
