### PR TITLE
fix(cli): auto-derive cascade triggers in --local pipeline graph

### DIFF
--- a/cli/src/commands/pipeline/localGraph.ts
+++ b/cli/src/commands/pipeline/localGraph.ts
@@ -341,6 +341,72 @@ function normalizeRetry(retry: ParseAssetsRaw["retry"]): ParseAssetsRaw["retry"]
   return { ...retry, delay: retry.delay.replace(/^delay=/, "") };
 }
 
+// Read-asset kinds whose read auto-derives a cascade trigger edge inside a
+// `// pipeline`. Mirror of backend `is_auto_trigger_kind` (windmill-common
+// assets.rs) / frontend `AUTO_TRIGGER_KINDS` (resolveGraph.ts) — ducklake
+// tables and s3 objects only; resource/datatable/volume stay explicit-`// on`.
+const AUTO_TRIGGER_KINDS = new Set(["ducklake", "s3object"]);
+
+// Asset-URI prefixes accepted by `// mute <asset>`, in lockstep with the
+// canonical `parse_asset_syntax` / frontend `ASSET_PREFIXES`. Non-derivable
+// kinds are parsed too (their muted key simply never matches a derived edge),
+// so a mute line is never REinterpreted differently from the deploy path.
+const MUTE_ASSET_PREFIXES: [string, string][] = [
+  ["s3://", "s3object"],
+  ["res://", "resource"],
+  ["$res:", "resource"],
+  ["ducklake://", "ducklake"],
+  ["datatable://", "datatable"],
+  ["volume://", "volume"],
+];
+
+// `// mute <asset>` / `// mute all` from the LEADING comment header, as
+// `<kind>:<path>` keys. Parsed locally because the pinned wasm asset parser
+// predates the mute annotations; mirrors the canonical parsers (Rust
+// `parse_pipeline_annotations`, frontend parsePipelineAnnotations.ts): any of
+// the three comment prefixes is accepted regardless of language, blank lines
+// are skipped, scanning stops at the first non-comment line, and `mute` must
+// be a complete word (`// muted for now` never matches).
+export function parseMuteAnnotations(content: string): {
+  muteAll: boolean;
+  muted: Set<string>;
+} {
+  const muted = new Set<string>();
+  let muteAll = false;
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trimStart();
+    if (line === "") continue;
+    let rest: string;
+    if (line.startsWith("//")) rest = line.slice(2);
+    else if (line.startsWith("--")) rest = line.slice(2);
+    else if (line.startsWith("#")) rest = line.slice(1);
+    else break;
+    rest = rest.trimStart();
+    if (!rest.startsWith("mute")) continue;
+    const after = rest.slice("mute".length);
+    if (after !== "" && !/^\s/.test(after)) continue;
+    const arg = after.trim();
+    if (arg === "all") {
+      muteAll = true;
+      continue;
+    }
+    for (const [prefix, kind] of MUTE_ASSET_PREFIXES) {
+      if (arg.startsWith(prefix)) {
+        // S3 canonicalization as in `parse_asset_syntax`: strip every leading
+        // slash so `s3:///key` (default storage) mutes the same node as the
+        // inferred bare `key`.
+        const p =
+          kind === "s3object"
+            ? arg.slice(prefix.length).replace(/^\/+/, "")
+            : arg.slice(prefix.length);
+        muted.add(`${kind}:${p}`);
+        break;
+      }
+    }
+  }
+  return { muteAll, muted };
+}
+
 // Comment prefix for `volume:` annotations. Deliberately NOT `commentPrefix`
 // above (which returns `--` for SQL): volume annotations are only recognized for
 // the languages the backend/frontend recognize them for — mirrors
@@ -684,6 +750,49 @@ export async function buildLocalPipelineGraph(args: {
         runnable_kind: "script",
         runnable_path: s.path,
       });
+    }
+    // Auto-derived cascade edges (backend `derive_pipeline_asset_trigger_refs`,
+    // frontend `deriveAutoAssetTriggers`): a pipeline script's read-only
+    // ducklake/s3 input wires its cascade trigger straight from the body read,
+    // so `// on <asset>` is only needed for edges inference can't see. Skipped:
+    // assets this script also writes — including the `// materialize` target and
+    // its scd2 `_current` companion, whose writes the body SELECT doesn't
+    // express — plus `// mute <asset>` opt-outs and explicit `// on` (which wins
+    // the dedup); `// mute all` opts the script out of derivation entirely.
+    // Ambiguous access (no `access_type`) fails safe and derives nothing.
+    const mute = parseMuteAnnotations(s.content);
+    if (!mute.muteAll) {
+      const skip = new Set<string>(mute.muted);
+      for (const a of out.assets ?? []) {
+        if (a.access_type === "w" || a.access_type === "rw") {
+          skip.add(`${a.kind}:${a.path}`);
+        }
+      }
+      if (mat) {
+        skip.add(`${mat.target_kind}:${mat.target_path}`);
+        if (mat.scd2 && !mat.manual) {
+          skip.add(`${mat.target_kind}:${mat.target_path}_current`);
+        }
+      }
+      for (const t of out.triggers ?? []) {
+        if (t.kind === "asset") {
+          const at = t as { kind: "asset"; asset_kind: string; path: string };
+          skip.add(`${at.asset_kind}:${at.path}`);
+        }
+      }
+      for (const a of out.assets ?? []) {
+        if (a.access_type !== "r" || !AUTO_TRIGGER_KINDS.has(a.kind)) continue;
+        const key = `${a.kind}:${a.path}`;
+        if (skip.has(key)) continue;
+        skip.add(key);
+        triggers.push({
+          trigger_kind: "asset",
+          asset_kind: a.kind,
+          asset_path: a.path,
+          runnable_kind: "script",
+          runnable_path: s.path,
+        });
+      }
     }
   }
 

--- a/cli/test/pipeline_local_graph_unit.test.ts
+++ b/cli/test/pipeline_local_graph_unit.test.ts
@@ -3,7 +3,10 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { buildLocalPipelineGraph } from "../src/commands/pipeline/localGraph.ts";
+import {
+  buildLocalPipelineGraph,
+  parseMuteAnnotations,
+} from "../src/commands/pipeline/localGraph.ts";
 
 // Build a throwaway workspace tree with `f/<folder>/<file>` scripts and a
 // wmill.yaml at the root, then assert the graph the wasm-backed builder derives.
@@ -288,6 +291,120 @@ test("HD-2: an scd2 `history` producer writes both `<dim>` and `<dim>_current` s
       expect(at?.asset_path).toBe("main/dim_customers_current");
     },
   );
+});
+
+test("auto-derived cascade triggers: a body ducklake read wires the edge, incl. the scd2 `_current` view", async () => {
+  // Backend parity (#9963 `derive_pipeline_asset_trigger_refs`): inside a
+  // `// pipeline`, a read-only ducklake/s3 body read derives its cascade
+  // trigger — no `// on` needed. The scd2 `_current` companion is both written
+  // by the producer AND a derivable read for its consumer, so the full chain
+  // stg → dim → consumer must connect without a single explicit trigger.
+  await withFolder(
+    {
+      "stg.duckdb.sql":
+        `-- pipeline\n-- materialize ducklake://main/stg\nSELECT 1 AS id;\n`,
+      "dim.duckdb.sql":
+        `-- pipeline\n-- materialize ducklake://main/dim key=id history\nATTACH 'ducklake' AS dl;\nUSE dl;\nSELECT * FROM stg;\n`,
+      "consume.duckdb.sql":
+        `-- pipeline\nATTACH 'ducklake' AS dl;\nUSE dl;\nSELECT * FROM dim_current;\n`,
+    },
+    async (root, folder) => {
+      const { graph } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+      const ats = graph.triggers.filter((t) => t.trigger_kind === "asset") as Extract<
+        (typeof graph.triggers)[number],
+        { trigger_kind: "asset" }
+      >[];
+      expect(
+        ats.map((t) => `${t.asset_path}->${t.runnable_path}`).sort(),
+      ).toEqual(["main/dim_current->f/mypipe/consume", "main/stg->f/mypipe/dim"]);
+      // the schema-level `main` read (ambiguous access) must NOT derive a trigger
+      expect(ats.some((t) => t.asset_path === "main")).toBe(false);
+      // the scd2 producer still carries the `_current` companion write the
+      // derived consumer edge resolves against (deployed-graph parity)
+      expect(graph.edges).toContainEqual({
+        runnable_kind: "script",
+        runnable_path: "f/mypipe/dim",
+        asset_kind: "ducklake",
+        asset_path: "main/dim_current",
+        access_type: "w",
+      });
+    },
+  );
+});
+
+test("`// mute <asset>` suppresses one derived trigger; `// mute all` opts the script out", async () => {
+  await withFolder(
+    {
+      // reads two tables, mutes one → only the unmuted read derives
+      "partial.duckdb.sql":
+        `-- pipeline\n-- mute ducklake://main/lookup\nATTACH 'ducklake' AS dl;\nUSE dl;\nSELECT * FROM lookup JOIN facts USING (id);\n`,
+      // mute all: body read derives nothing, the explicit `// on` still stands
+      "optout.duckdb.sql":
+        `-- pipeline\n-- mute all\n-- on ducklake://main/manual\nATTACH 'ducklake' AS dl;\nUSE dl;\nSELECT * FROM facts;\n`,
+    },
+    async (root, folder) => {
+      const { graph } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+      const ats = graph.triggers.filter((t) => t.trigger_kind === "asset") as Extract<
+        (typeof graph.triggers)[number],
+        { trigger_kind: "asset" }
+      >[];
+      expect(
+        ats.map((t) => `${t.asset_path}->${t.runnable_path}`).sort(),
+      ).toEqual(["main/facts->f/mypipe/partial", "main/manual->f/mypipe/optout"]);
+    },
+  );
+});
+
+test("derived triggers dedup against explicit `// on` and never self-trigger a materialize producer", async () => {
+  await withFolder(
+    {
+      // explicit `// on` for an asset the body also reads → exactly one trigger
+      "explicit.duckdb.sql":
+        `-- pipeline\n-- on ducklake://main/src debounce=60s\nATTACH 'ducklake' AS dl;\nUSE dl;\nSELECT * FROM src;\n`,
+      // an incremental model reading its own materialize target must not
+      // cascade on itself (the deploy path upgrades that read to rw)
+      "incremental.duckdb.sql":
+        `-- pipeline\n-- materialize ducklake://main/inc key=id\nATTACH 'ducklake' AS dl;\nUSE dl;\nSELECT * FROM inc;\n`,
+    },
+    async (root, folder) => {
+      const { graph } = await buildLocalPipelineGraph({ root, folder, defaultTs: "bun" });
+      const ats = graph.triggers.filter((t) => t.trigger_kind === "asset") as Extract<
+        (typeof graph.triggers)[number],
+        { trigger_kind: "asset" }
+      >[];
+      expect(
+        ats.map((t) => `${t.asset_path}->${t.runnable_path}`),
+      ).toEqual(["main/src->f/mypipe/explicit"]);
+    },
+  );
+});
+
+test("parseMuteAnnotations mirrors the canonical annotation grammar", () => {
+  // Any comment prefix regardless of language, header-only scan, complete-word
+  // keyword, s3 leading-slash canonicalization — in lockstep with the Rust
+  // `parse_pipeline_annotations` / frontend parsePipelineAnnotations.ts.
+  const all3 = parseMuteAnnotations(
+    `// mute ducklake://main/a\n-- mute datatable://main/b\n# mute s3:///lead/slash\nSELECT 1;\n// mute ducklake://main/body\n`,
+  );
+  expect(all3.muteAll).toBe(false);
+  // all three prefixes accepted; s3 triple-slash canonicalizes to the bare key;
+  // the line PAST the first non-comment line is ignored (header-only)
+  expect([...all3.muted].sort()).toEqual([
+    "datatable:main/b",
+    "ducklake:main/a",
+    "s3object:lead/slash",
+  ]);
+
+  // `mute` must be a complete word, and prose args are not asset URIs
+  const prose = parseMuteAnnotations(
+    `// muted for now\n// mutex ducklake://main/x\n// mute for now\n`,
+  );
+  expect(prose.muteAll).toBe(false);
+  expect(prose.muted.size).toBe(0);
+
+  // `mute all` sets the opt-out; blank header lines are skipped, not a stop
+  const optout = parseMuteAnnotations(`-- pipeline\n\n-- mute all\nSELECT 1;\n`);
+  expect(optout.muteAll).toBe(true);
 });
 
 test("a bare `.sql` (ambiguous dialect) is skipped, not a build-aborting crash", async () => {


### PR DESCRIPTION
## Summary

`wmill pipeline show/run/dev --local` was missing the auto-derived cascade trigger edges that #9963 added to the deployed graph, so a pipeline relying on body-read derivation (the default since #9963 — no `// on` needed for ducklake/s3 reads) rendered as disconnected islands locally while the deployed graph showed the full chain.

This was reported as "the scd2 `<dim>_current` companion write edge is missing from `--local`". That specific edge is **not** missing — #9947 covers it, the pinned `windmill-parser-wasm-asset` 1.749.0 does emit the `scd2` flag, and an e2e diff shows local/deployed `edges` byte-identical. What's actually missing is the derived **trigger** connecting `<dim>_current` to its consumer (and every other derived cascade edge): the local graph returned `triggers: []`, which on the canvas/tree reads as a missing edge.

Repro (`f/shop`: `stg_customers` → `dim_customers` = `-- materialize ducklake://main/dim_customers key=customer_id history` → `consumer` body-reads `dim_customers_current`, no explicit `// on` anywhere):

**Before** — `wmill pipeline show shop --local`:
```
Pipeline f/shop — 3 scripts · 4 assets

consumer

dim_customers
├─▶ ducklake://main/dim_customers
└─▶ ducklake://main/dim_customers_current

stg_customers
└─▶ ducklake://main/stg_customers
```

**After** (matches deployed):
```
Pipeline f/shop — 3 scripts · 4 assets

stg_customers
└─▶ ducklake://main/stg_customers
    └─ dim_customers
       ├─▶ ducklake://main/dim_customers
       └─▶ ducklake://main/dim_customers_current
           └─ consumer
```

## Changes

- `cli/src/commands/pipeline/localGraph.ts`: port #9963's derivation (backend `derive_pipeline_asset_trigger_refs`, frontend `deriveAutoAssetTriggers`) — a pipeline script's read-only ducklake/s3 body read derives an asset trigger, skipping assets the script also writes (including the `// materialize` target and its scd2 `_current` companion), `// mute <asset>` opt-outs, explicit `// on` (which wins the dedup), and everything under `// mute all`. Ambiguous access (no `access_type`) fails safe.
- `parseMuteAnnotations`: leading-comment-header scan for `// mute <asset>` / `// mute all`, mirroring the canonical parsers (any of `//`/`--`/`#` regardless of language, complete-word keyword, s3 leading-slash canonicalization). Parsed CLI-side because the pinned wasm asset parser (1.749.0, latest published) predates the mute annotations — this avoids a heavy wasm rebuild while keeping exact parity.
- `cli/test/pipeline_local_graph_unit.test.ts`: 4 new tests — full derivation chain incl. the scd2 `_current` consumer edge and the companion write (regression for the reported symptom), mute/mute-all suppression, explicit-`// on` dedup + no materialize self-trigger, and direct `parseMuteAnnotations` grammar coverage.

## Test plan

- [x] `bun test test/pipeline_local_graph_unit.test.ts` — 33 pass (4 new)
- [x] `UNIT_ONLY=1 bun test test/*_unit*` — 947 pass, 0 fail
- [x] `bunx tsc --noEmit` — same 16 pre-existing errors before and after (none in touched files)
- [x] e2e parity: pushed `f/shop` to a dev backend (CE v1.751.0), diffed `GET /api/w/shopws/assets/graph` vs `wmill pipeline show shop --local --json` — assets, runnables, edges, and triggers all match, including the `// mute` variant (deployed drops the muted trigger, local now does too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Local pipeline graphs now auto-derive cascade triggers from body reads. This matches the deployed graph and restores the missing SCD2 `<dim>_current` consumer edge in `wmill pipeline show/run/dev --local`.

- **Bug Fixes**
  - Ported auto-trigger derivation to `--local` for ducklake/s3 body reads. Skips assets also written (including the materialize target and its SCD2 `_current`), dedupes against explicit `// on`, honors `// mute <asset>` and `// mute all`, and derives nothing on ambiguous reads.
  - Added `parseMuteAnnotations` in the CLI to parse leading `// mute` directives, mirroring backend/frontend rules (`//`/`--`/`#`, header-only, complete-word match, S3 leading-slash canonicalization).
  - Ensured SCD2 parity: producer writes `_current`; consumer auto-triggers on it; no self-trigger for incremental models.
  - Added 4 unit tests for derivation, mutes, deduplication, and grammar; verified `--local --json` matches the deployed `/assets/graph` output.

<sup>Written for commit 39179ed1450aa222c8325569e895be25414a5de4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

