### PR TITLE
fix: clear old path asset usage when renaming a script

### DIFF
--- a/backend/tests/script_rename_clears_assets.rs
+++ b/backend/tests/script_rename_clears_assets.rs
@@ -1,0 +1,106 @@
+//! Regression test: renaming a script clears the OLD path's static asset
+//! usage rows.
+//!
+//! A script deploy persists its producer/consumer asset lineage as `asset`
+//! rows keyed by `usage_path = <script path>`, `usage_kind = 'script'`. A
+//! rename is a deploy with a new `path` and a `parent_hash` pointing at the
+//! version being renamed. The new path's rows are (re)written by the deploy,
+//! but the old path's rows must be cleared — otherwise the renamed script
+//! keeps lingering in the asset graph at a path where it no longer exists.
+//!
+//! The clear used to be attempted with the NEW (not-yet-inserted) script hash,
+//! which resolved to no path and cleared nothing.
+
+use serde_json::json;
+use sqlx::{Pool, Postgres};
+use windmill_test_utils::*;
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+fn authed(builder: reqwest::RequestBuilder, token: &str) -> reqwest::RequestBuilder {
+    builder.header("Authorization", format!("Bearer {}", token))
+}
+
+fn new_script_with_asset(path: &str, content: &str) -> serde_json::Value {
+    json!({
+        "path": path,
+        "summary": "",
+        "description": "",
+        "content": content,
+        "language": "bash",
+        "assets": [{
+            "path": "u/test-user/my_db",
+            "kind": "resource",
+            "access_type": "rw"
+        }]
+    })
+}
+
+async fn asset_usage_paths(db: &Pool<Postgres>) -> anyhow::Result<Vec<String>> {
+    Ok(sqlx::query_scalar(
+        "SELECT usage_path FROM asset \
+         WHERE usage_kind = 'script' AND path = $1 AND workspace_id = $2 \
+         ORDER BY usage_path",
+    )
+    .bind("u/test-user/my_db")
+    .bind("test-workspace")
+    .fetch_all(db)
+    .await?)
+}
+
+#[sqlx::test(fixtures("base"))]
+async fn test_rename_clears_old_path_asset_usage(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base = format!("http://localhost:{port}/api/w/test-workspace");
+
+    let original_path = "u/test-user/asset_rename_orig";
+    let renamed_path = "u/test-user/asset_rename_renamed";
+
+    // 1. Deploy a script that produces (rw) a resource asset.
+    let resp = authed(
+        client().post(format!("{base}/scripts/create")),
+        "SECRET_TOKEN",
+    )
+    .json(&new_script_with_asset(original_path, "# v1"))
+    .send()
+    .await?;
+    assert_eq!(resp.status(), 201, "create should succeed");
+    let original_hash: String = resp.text().await?;
+
+    assert_eq!(
+        asset_usage_paths(&db).await?,
+        vec![original_path.to_string()],
+        "asset usage should be recorded at the original path"
+    );
+
+    // 2. Rename: deploy at a new path with parent_hash = v1.
+    let mut rename = new_script_with_asset(renamed_path, "# v2");
+    rename["parent_hash"] = json!(original_hash);
+    let resp = authed(
+        client().post(format!("{base}/scripts/create")),
+        "SECRET_TOKEN",
+    )
+    .json(&rename)
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        201,
+        "rename should succeed: {}",
+        resp.text().await?
+    );
+
+    // 3. Only the new path retains the asset usage; the old path is cleared.
+    assert_eq!(
+        asset_usage_paths(&db).await?,
+        vec![renamed_path.to_string()],
+        "after rename the old path's asset usage must be cleared and only the new path kept"
+    );
+
+    Ok(())
+}

--- a/backend/windmill-api-scripts/src/scripts.rs
+++ b/backend/windmill-api-scripts/src/scripts.rs
@@ -1124,8 +1124,6 @@ async fn create_script_internal<'c>(
             .execute(&mut *tx)
             .await?;
 
-            clear_static_asset_usage_by_script_hash(&mut *tx, &w_id, hash).await?;
-
             r
         }
     }?;
@@ -1989,15 +1987,17 @@ async fn create_script_internal<'c>(
     // discovered by the graph endpoint directly from the per-kind trigger
     // tables, so `trigger_spec_to_row` returns None for those.
     clear_script_triggers(&mut *tx, &w_id, &ns.path, AssetUsageKind::Script).await?;
-    // On rename, also drop the OLD path's trigger rows. clear is keyed by
-    // path (no by-hash variant), and only `ns.path` is wiped above — without
-    // this, stale `// on` edges for the old path keep matching producers and
-    // would trigger a script later recreated at that path even if it has no
-    // annotation (P1). (Producer/asset rows for the old path are already
-    // cleared via clear_static_asset_usage_by_script_hash on the parent.)
+    // On rename, also drop the OLD path's trigger and producer/asset rows.
+    // Both clears are keyed by path, and only `ns.path` is (re)written above
+    // (script_triggers here, asset rows via replace_static_asset_usage) — the
+    // renamed script no longer lives at the old path, so without this its
+    // stale `// on` edges keep matching producers (and would trigger a script
+    // later recreated at that path with no annotation, P1) and its producer
+    // rows keep it lingering in the asset graph.
     if let Some(ref old) = p_path_opt {
         if old != &ns.path {
             clear_script_triggers(&mut *tx, &w_id, old, AssetUsageKind::Script).await?;
+            clear_static_asset_usage(&mut *tx, &w_id, old, AssetUsageKind::Script).await?;
         }
     }
     for spec in &pipeline_triggers {


### PR DESCRIPTION
## Summary

Renaming a script left stale `asset` producer/consumer rows at the **old** path. A script rename is a deploy with a new `path` and a `parent_hash` pointing at the version being renamed; the new path's asset-usage rows are (re)written by the deploy, but the old path's rows were never cleared, so the renamed script kept lingering in the asset graph at a path where it no longer exists.

The deploy handler *tried* to clear them via `clear_static_asset_usage_by_script_hash(&mut *tx, &w_id, hash)`, but `hash` was the **new** script's hash, computed before the new `script` row is inserted in the same transaction. Its subquery `SELECT path FROM script WHERE hash = $2` therefore resolved to `NULL` and the `DELETE ... WHERE usage_path = (NULL)` matched nothing — a silent no-op.

## Changes

- `backend/windmill-api-scripts/src/scripts.rs`: remove the no-op `clear_static_asset_usage_by_script_hash(hash)` call, and clear the old path's static asset usage in the existing rename-guarded block (`if old != &ns.path`), right next to the analogous `clear_script_triggers(old)` call. This runs in the deploy transaction, is keyed by the old path, and only fires on an actual rename — so same-path redeploys (handled by `replace_static_asset_usage` with its own notify-dedup) are unaffected.
- Update the now-stale comment that claimed the old path's asset rows were "already cleared ... on the parent".
- `backend/tests/script_rename_clears_assets.rs`: new `#[sqlx::test]` integration regression test that drives the real `/scripts/create` endpoint — deploys a script producing an `rw` resource asset, renames it, and asserts only the new path retains the asset row.

## Test plan

- [x] `cargo test -p windmill --test script_rename_clears_assets` passes
- [x] Manual API repro: create script with asset → rename → old path's `asset` row is gone, new path's row present
- [x] Same-path redeploy still keeps its asset row (no regression)
- [x] Backend recompiles cleanly under cargo watch

🤖 Generated with [Claude Code](https://claude.com/claude-code)