### PR TITLE
fix(ai-agent): align agent_actions_success with agent_actions for mcp and websearch

### DIFF
--- a/backend/windmill-worker/src/ai/tools.rs
+++ b/backend/windmill-worker/src/ai/tools.rs
@@ -198,6 +198,10 @@ async fn execute_mcp_tool_call(
         arguments: arguments.clone(),
     });
 
+    if let Some(parent_job) = ctx.parent_job {
+        update_flow_status_module_with_actions(ctx.db, parent_job, actions).await?;
+    }
+
     match tool_result {
         Ok(result) => {
             let result_str =
@@ -225,6 +229,10 @@ async fn execute_mcp_tool_call(
                     success: true,
                 };
                 stream_event_processor.send(event, final_events_str).await?;
+            }
+
+            if let Some(parent_job) = ctx.parent_job {
+                update_flow_status_module_with_actions_success(ctx.db, parent_job, true).await?;
             }
 
             // Add tool message to conversation if chat_input_enabled
@@ -257,6 +265,10 @@ async fn execute_mcp_tool_call(
                     success: false,
                 };
                 stream_event_processor.send(event, final_events_str).await?;
+            }
+
+            if let Some(parent_job) = ctx.parent_job {
+                update_flow_status_module_with_actions_success(ctx.db, parent_job, false).await?;
             }
 
             // Add tool message to conversation if chat_input_enabled

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -1030,6 +1030,11 @@ pub async fn run_agent(
                 // Add websearch tool message if websearch was used
                 if used_websearch {
                     actions.push(AgentAction::WebSearch {});
+                    if let Some(parent_job) = parent_job {
+                        update_flow_status_module_with_actions(db, parent_job, &actions).await?;
+                        update_flow_status_module_with_actions_success(db, parent_job, true)
+                            .await?;
+                    }
                     messages.push(OpenAIMessage {
                         role: "tool".to_string(),
                         content: Some(OpenAIContent::Text(


### PR DESCRIPTION
Fixes WIN-2136

## Summary

The AI agent flow-status module keeps two parallel arrays, `agent_actions` and `agent_actions_success`, and the frontend (`FlowStatusViewerInner.svelte`) looks up per-action status by positional index (`agent_actions_success?.[idx]`). MCP tool calls and WebSearch actions pushed entries to `agent_actions` but never appended to `agent_actions_success`, so any agent run mixing them with regular tool calls shifted all subsequent indices and displayed wrong Success/Failure/InProgress colors on tool-call nodes in the flow graph.

This PR makes MCP and WebSearch actions write to both arrays, mirroring the pattern already used for Windmill tool calls and assistant messages, so every `agent_actions` entry gets exactly one paired `agent_actions_success` entry.

## Changes

- `backend/windmill-worker/src/ai/tools.rs` (`execute_mcp_tool_call`): persist the pushed `McpToolCall` action via `update_flow_status_module_with_actions`, then append `true`/`false` to `agent_actions_success` on the tool-result Ok/Err branches respectively.
- `backend/windmill-worker/src/ai_executor.rs` (`used_websearch` block): after pushing `AgentAction::WebSearch`, persist the actions array and append `true` to `agent_actions_success` (websearch outcome is known at push time), guarded by `parent_job` like the existing Message path.

## Test plan

- [x] `cargo check -p windmill-worker` passes
- [x] Fresh-context code review (branch-diff-reviewer): verified all four `AgentAction` push sites now have exactly one paired success append per outcome path; no issues found
- [ ] Manual: run a flow with an AI agent step using an MCP tool + websearch + a regular Windmill tool and confirm node status colors are no longer shifted (not runnable in this dev environment: no AI provider key or MCP server available)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures `agent_actions` and `agent_actions_success` stay aligned for MCP tool calls and WebSearch, fixing misaligned Success/Failure states in the flow graph. Addresses WIN-2136.

- **Bug Fixes**
  - MCP: after pushing the action, persist actions and append `true`/`false` to `agent_actions_success` based on result, guarded by `parent_job` (`execute_mcp_tool_call` in `backend/windmill-worker/src/ai/tools.rs`).
  - WebSearch: when `used_websearch`, push `AgentAction::WebSearch`, persist actions, and append `true` to `agent_actions_success`, guarded by `parent_job` (`run_agent` in `backend/windmill-worker/src/ai_executor.rs`).

<sup>Written for commit cbe07308a921ec84b82be6655bc22803d4a807f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

