### PR TITLE
fix(ai): flow writer builds approval steps as scripts, not identity

### DIFF
--- a/ai_evals/cases/flow.yaml
+++ b/ai_evals/cases/flow.yaml
@@ -359,6 +359,8 @@
       - request_approval
       - finalize_purchase
     topLevelStepTypes:
+      - id: request_approval
+        type: rawscript
       - id: finalize_purchase
         type: rawscript
     schemaRequiredPaths:
@@ -373,6 +375,7 @@
   judgeChecklist:
     - "the flow includes an approval step named `request_approval`"
     - "`request_approval` pauses the flow and asks the approver for a comment"
+    - "`request_approval` is a real script step that generates approval/resume URLs (e.g. via `getResumeUrls`) so approvers receive an actionable link, not a no-op passthrough (identity) step"
     - one approval is enough to continue
     - "the flow includes a final step named `finalize_purchase`"
     - "`finalize_purchase` returns an approved status object after approval"

--- a/ai_evals/cases/flow.yaml
+++ b/ai_evals/cases/flow.yaml
@@ -360,7 +360,7 @@
       - finalize_purchase
     topLevelStepTypes:
       - id: request_approval
-        type: rawscript
+        type: [rawscript, script]
       - id: finalize_purchase
         type: rawscript
     schemaRequiredPaths:

--- a/ai_evals/core/types.ts
+++ b/ai_evals/core/types.ts
@@ -47,7 +47,7 @@ export interface FlowValidationSpec {
   }>;
   topLevelStepTypes?: Array<{
     id: string;
-    type: string;
+    type: string | string[];
   }>;
   moduleRules?: Array<{
     id: string;

--- a/ai_evals/core/validators.ts
+++ b/ai_evals/core/validators.ts
@@ -1378,11 +1378,14 @@ function validateFlowRequirements(
       continue;
     }
 
+    const allowedTypes = Array.isArray(requiredStep.type)
+      ? requiredStep.type
+      : [requiredStep.type];
     checks.push(
       check(
         `${requiredStep.id} type matches required`,
-        getModuleType(module) === requiredStep.type,
-        `expected ${requiredStep.type}, got ${getModuleType(module) ?? "(missing)"}`
+        allowedTypes.includes(getModuleType(module) ?? ""),
+        `expected ${allowedTypes.join(" or ")}, got ${getModuleType(module) ?? "(missing)"}`
       )
     );
   }

--- a/cli/src/guidance/skills.gen.ts
+++ b/cli/src/guidance/skills.gen.ts
@@ -5151,8 +5151,11 @@ input_transforms:
 
 ## Approval / Suspend Structure
 
+An approval step is a normal **script** step (\`type: rawscript\` or \`type: script\`) that is turned into an approval by adding a module-level \`suspend\`. Its script calls \`wmill.getResumeUrls(approver)\` to generate the secret resume/cancel URLs and returns them so they can be sent to the approver(s) (Slack, email, etc.) or approved from the run page.
+
 - \`suspend\` belongs on the flow module object itself, as a sibling of \`id\` and \`value\`
 - Never put \`suspend\` inside \`value\`
+- Do NOT use \`type: identity\` for an approval step. An identity step suspends but never produces the resume URLs, so approvers have no link to act on — it is not a functional approval.
 
 Correct shape:
 
@@ -5168,10 +5171,23 @@ Correct shape:
             type: string
         required: [comment]
   value:
-    type: identity
+    type: rawscript
+    language: bun
+    input_transforms:
+      approver:
+        type: static
+        value: ''
+    content: |
+      import * as wmill from "windmill-client"
+
+      export async function main(approver?: string) {
+        const urls = await wmill.getResumeUrls(approver)
+        // send urls.resume / urls.cancel to the approver(s), e.g. via Slack or email
+        return urls
+      }
 \`\`\`
 
-Incorrect shape:
+Incorrect shape (suspend misplaced inside \`value\`):
 
 \`\`\`yaml
 - id: request_approval
@@ -5179,6 +5195,16 @@ Incorrect shape:
     type: rawscript
     suspend:
       required_events: 1
+\`\`\`
+
+Incorrect shape (identity has no resume URLs — not a real approval):
+
+\`\`\`yaml
+- id: request_approval
+  suspend:
+    required_events: 1
+  value:
+    type: identity
 \`\`\`
 
 ## Branch Result Scope Rules

--- a/system_prompts/auto-generated/flow.md
+++ b/system_prompts/auto-generated/flow.md
@@ -139,8 +139,11 @@ input_transforms:
 
 ## Approval / Suspend Structure
 
+An approval step is a normal **script** step (`type: rawscript` or `type: script`) that is turned into an approval by adding a module-level `suspend`. Its script calls `wmill.getResumeUrls(approver)` to generate the secret resume/cancel URLs and returns them so they can be sent to the approver(s) (Slack, email, etc.) or approved from the run page.
+
 - `suspend` belongs on the flow module object itself, as a sibling of `id` and `value`
 - Never put `suspend` inside `value`
+- Do NOT use `type: identity` for an approval step. An identity step suspends but never produces the resume URLs, so approvers have no link to act on — it is not a functional approval.
 
 Correct shape:
 
@@ -156,10 +159,23 @@ Correct shape:
             type: string
         required: [comment]
   value:
-    type: identity
+    type: rawscript
+    language: bun
+    input_transforms:
+      approver:
+        type: static
+        value: ''
+    content: |
+      import * as wmill from "windmill-client"
+
+      export async function main(approver?: string) {
+        const urls = await wmill.getResumeUrls(approver)
+        // send urls.resume / urls.cancel to the approver(s), e.g. via Slack or email
+        return urls
+      }
 ```
 
-Incorrect shape:
+Incorrect shape (suspend misplaced inside `value`):
 
 ```yaml
 - id: request_approval
@@ -167,6 +183,16 @@ Incorrect shape:
     type: rawscript
     suspend:
       required_events: 1
+```
+
+Incorrect shape (identity has no resume URLs — not a real approval):
+
+```yaml
+- id: request_approval
+  suspend:
+    required_events: 1
+  value:
+    type: identity
 ```
 
 ## Branch Result Scope Rules

--- a/system_prompts/auto-generated/prompts.ts
+++ b/system_prompts/auto-generated/prompts.ts
@@ -170,8 +170,11 @@ input_transforms:
 
 ## Approval / Suspend Structure
 
+An approval step is a normal **script** step (\`type: rawscript\` or \`type: script\`) that is turned into an approval by adding a module-level \`suspend\`. Its script calls \`wmill.getResumeUrls(approver)\` to generate the secret resume/cancel URLs and returns them so they can be sent to the approver(s) (Slack, email, etc.) or approved from the run page.
+
 - \`suspend\` belongs on the flow module object itself, as a sibling of \`id\` and \`value\`
 - Never put \`suspend\` inside \`value\`
+- Do NOT use \`type: identity\` for an approval step. An identity step suspends but never produces the resume URLs, so approvers have no link to act on — it is not a functional approval.
 
 Correct shape:
 
@@ -187,10 +190,23 @@ Correct shape:
             type: string
         required: [comment]
   value:
-    type: identity
+    type: rawscript
+    language: bun
+    input_transforms:
+      approver:
+        type: static
+        value: ''
+    content: |
+      import * as wmill from "windmill-client"
+
+      export async function main(approver?: string) {
+        const urls = await wmill.getResumeUrls(approver)
+        // send urls.resume / urls.cancel to the approver(s), e.g. via Slack or email
+        return urls
+      }
 \`\`\`
 
-Incorrect shape:
+Incorrect shape (suspend misplaced inside \`value\`):
 
 \`\`\`yaml
 - id: request_approval
@@ -198,6 +214,16 @@ Incorrect shape:
     type: rawscript
     suspend:
       required_events: 1
+\`\`\`
+
+Incorrect shape (identity has no resume URLs — not a real approval):
+
+\`\`\`yaml
+- id: request_approval
+  suspend:
+    required_events: 1
+  value:
+    type: identity
 \`\`\`
 
 ## Branch Result Scope Rules

--- a/system_prompts/auto-generated/skills/write-flow/SKILL.md
+++ b/system_prompts/auto-generated/skills/write-flow/SKILL.md
@@ -225,8 +225,11 @@ input_transforms:
 
 ## Approval / Suspend Structure
 
+An approval step is a normal **script** step (`type: rawscript` or `type: script`) that is turned into an approval by adding a module-level `suspend`. Its script calls `wmill.getResumeUrls(approver)` to generate the secret resume/cancel URLs and returns them so they can be sent to the approver(s) (Slack, email, etc.) or approved from the run page.
+
 - `suspend` belongs on the flow module object itself, as a sibling of `id` and `value`
 - Never put `suspend` inside `value`
+- Do NOT use `type: identity` for an approval step. An identity step suspends but never produces the resume URLs, so approvers have no link to act on — it is not a functional approval.
 
 Correct shape:
 
@@ -242,10 +245,23 @@ Correct shape:
             type: string
         required: [comment]
   value:
-    type: identity
+    type: rawscript
+    language: bun
+    input_transforms:
+      approver:
+        type: static
+        value: ''
+    content: |
+      import * as wmill from "windmill-client"
+
+      export async function main(approver?: string) {
+        const urls = await wmill.getResumeUrls(approver)
+        // send urls.resume / urls.cancel to the approver(s), e.g. via Slack or email
+        return urls
+      }
 ```
 
-Incorrect shape:
+Incorrect shape (suspend misplaced inside `value`):
 
 ```yaml
 - id: request_approval
@@ -253,6 +269,16 @@ Incorrect shape:
     type: rawscript
     suspend:
       required_events: 1
+```
+
+Incorrect shape (identity has no resume URLs — not a real approval):
+
+```yaml
+- id: request_approval
+  suspend:
+    required_events: 1
+  value:
+    type: identity
 ```
 
 ## Branch Result Scope Rules

--- a/system_prompts/base/flow-base.md
+++ b/system_prompts/base/flow-base.md
@@ -139,8 +139,11 @@ input_transforms:
 
 ## Approval / Suspend Structure
 
+An approval step is a normal **script** step (`type: rawscript` or `type: script`) that is turned into an approval by adding a module-level `suspend`. Its script calls `wmill.getResumeUrls(approver)` to generate the secret resume/cancel URLs and returns them so they can be sent to the approver(s) (Slack, email, etc.) or approved from the run page.
+
 - `suspend` belongs on the flow module object itself, as a sibling of `id` and `value`
 - Never put `suspend` inside `value`
+- Do NOT use `type: identity` for an approval step. An identity step suspends but never produces the resume URLs, so approvers have no link to act on — it is not a functional approval.
 
 Correct shape:
 
@@ -156,10 +159,23 @@ Correct shape:
             type: string
         required: [comment]
   value:
-    type: identity
+    type: rawscript
+    language: bun
+    input_transforms:
+      approver:
+        type: static
+        value: ''
+    content: |
+      import * as wmill from "windmill-client"
+
+      export async function main(approver?: string) {
+        const urls = await wmill.getResumeUrls(approver)
+        // send urls.resume / urls.cancel to the approver(s), e.g. via Slack or email
+        return urls
+      }
 ```
 
-Incorrect shape:
+Incorrect shape (suspend misplaced inside `value`):
 
 ```yaml
 - id: request_approval
@@ -167,6 +183,16 @@ Incorrect shape:
     type: rawscript
     suspend:
       required_events: 1
+```
+
+Incorrect shape (identity has no resume URLs — not a real approval):
+
+```yaml
+- id: request_approval
+  suspend:
+    required_events: 1
+  value:
+    type: identity
 ```
 
 ## Branch Result Scope Rules


### PR DESCRIPTION
## Summary

When asked to build a flow with an approval, the AI flow writer produced an approval step whose module value was `type: identity` — a no-op passthrough. An identity step suspends the flow but never calls `wmill.getResumeUrls()`, so no secret approve/cancel URLs are generated: approvers get no actionable link and the step is only resolvable from the run page. The canonical approval step (what the flow editor's "Approval" insert button creates) is a `rawscript` that generates and returns those resume URLs.

The root cause was in the shared flow-authoring prompt (`system_prompts/base/flow-base.md`, embedded into both the global chat and flow-editor chat via `getFlowPrompt()`): its "Correct shape" approval example used `type: identity` purely as filler to demonstrate `suspend` placement, and the model copied it literally.

## Changes

- Rewrote the **Approval / Suspend Structure** section in `system_prompts/base/flow-base.md`: the "Correct shape" is now a `rawscript` calling `wmill.getResumeUrls(approver)`, with an explicit "Do NOT use `type: identity`" rule and an identity example moved to the "Incorrect" set. Kept the existing lesson that `suspend` is module-level (sibling of `id`/`value`).
- Regenerated the downstream artifacts via `system_prompts/generate.py`: `auto-generated/flow.md`, `prompts.ts`, `skills/write-flow/SKILL.md`, and `cli/src/guidance/skills.gen.ts`.
- Hardened the `flow-test12-approval-step` eval case (`ai_evals/cases/flow.yaml`): added a deterministic `topLevelStepTypes` assertion requiring `request_approval` to be `rawscript` (an `identity` step now fails it), plus a judge-checklist item about generating actionable approval URLs. Previously the case only checked the `suspend` config, so the `identity` bug passed unnoticed.

## Eval A/B (`flow-test12-approval-step`, sonnet, 3 runs each, judge on)

| | Pass rate | `request_approval` step | Judge |
|---|---|---|---|
| Before (old prompt) | 0/3 | `identity` + suspend (no resume URLs) | 52 / 40 / 30 |
| After (this PR) | 3/3 | `rawscript` (bun) + `getResumeUrls` + suspend | 97 / 97 / 97 |

## Test plan

- [ ] `cd ai_evals && WMILL_AI_EVAL_BACKEND_URL=<backend> WMILL_AI_EVAL_BACKEND_WORKSPACE=integration-tests bun run cli -- run flow flow-test12-approval-step --model sonnet` passes
- [ ] Generated `request_approval` step is a `rawscript` calling `getResumeUrls` (not `identity`)
- [ ] `system_prompts/auto-generated/*` is in sync with `flow-base.md` (re-running `generate.py` produces no diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)