### PR TITLE
fix(sessions): scope fork session Edits to session-edited items only

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -367,10 +367,11 @@ export class AIChatManager {
 
 	// Workspace items the CURRENT chat modified via AI tool calls, as
 	// `${UserDraftItemKind}:${storagePath}` keys (see modifiedItemsMask.ts).
-	// undefined = untracked: the global side-panel chat (never initialised) and
-	// loaded legacy chats with no stored mask, both of which fall back to the
-	// show-all bar. A SvelteSet (even empty) = tracked. Reactive so the session
-	// bar updates as tools record mid-turn.
+	// undefined = untracked: only the global side-panel chat (never initialised),
+	// which falls back to the show-all bar. Session chats are always tracked (a
+	// SvelteSet, even empty) — see loadPastChat/initRuntime — so their Edits
+	// surface never claims drafts the session didn't touch. Reactive so the
+	// session bar updates as tools record mid-turn.
 	modifiedItems = $state<SvelteSet<string> | undefined>(undefined)
 
 	// Start tracking for a brand-new session chat (empty = "tracked, nothing yet").
@@ -2159,13 +2160,14 @@ export class AIChatManager {
 			this.displayMessages = chat.displayMessages
 			this.messages = chat.actualMessages
 			this.contextUsage = normalizeContextUsage(chat.contextUsage)
-			// Seed the modified-items mask from the stored chat. A stored array
-			// (even empty) → tracked; a legacy chat with no field stays untracked
-			// (undefined) so the session bar falls back to showing all drafts. The
-			// global side-panel chat never tracks, so leave it untouched there.
+			// Seed the modified-items mask from the stored chat. A session's Edits
+			// surface is scoped strictly to what this session edited, so it must never
+			// fall back to showing every draft in the (possibly forked) workspace: a
+			// legacy chat with no stored mask seeds an empty tracked set, not undefined.
+			// The global side-panel chat never tracks, so leave it untouched there.
 			if (this.isSessionChat) {
 				const stored = this.historyManager.getModifiedItems(id)
-				this.modifiedItems = stored !== undefined ? new SvelteSet(stored) : undefined
+				this.modifiedItems = new SvelteSet(stored ?? [])
 			}
 			this.#automaticScroll = true
 			this.onChatRotated?.(id)

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
@@ -634,6 +634,47 @@ describe('AIChatManager queued messages', () => {
 		await session.saveAndClear()
 		expect(session.attachedFiles.count).toBe(1)
 	})
+
+	it('tracks (empty mask) a session chat loaded with no stored modified-items', async () => {
+		// A legacy session chat has no persisted mask. It must NOT stay untracked
+		// (undefined) — that makes the Edits surface fall back to showing every
+		// draft in the (possibly forked) workspace. Seed an empty tracked set so the
+		// session only ever surfaces what it actually edited.
+		const manager = createManager(createInputMock())
+		manager.isSessionChat = true
+		vi.spyOn(manager.historyManager, 'loadPastChat').mockReturnValue({
+			id: 'legacy-session-chat',
+			title: 'Legacy',
+			displayMessages: [],
+			actualMessages: [],
+			lastModified: 0
+		} as unknown as ReturnType<typeof manager.historyManager.loadPastChat>)
+		vi.spyOn(manager.historyManager, 'getModifiedItems').mockReturnValue(undefined)
+
+		await manager.loadPastChat('legacy-session-chat')
+
+		expect(manager.modifiedItems).toBeInstanceOf(Set)
+		expect(manager.modifiedItems?.size).toBe(0)
+	})
+
+	it('seeds a session chat mask from its stored modified-items', async () => {
+		const manager = createManager(createInputMock())
+		manager.isSessionChat = true
+		vi.spyOn(manager.historyManager, 'loadPastChat').mockReturnValue({
+			id: 'tracked-session-chat',
+			title: 'Tracked',
+			displayMessages: [],
+			actualMessages: [],
+			lastModified: 0
+		} as unknown as ReturnType<typeof manager.historyManager.loadPastChat>)
+		vi.spyOn(manager.historyManager, 'getModifiedItems').mockReturnValue([
+			'script:u/admin/hello_world'
+		])
+
+		await manager.loadPastChat('tracked-session-chat')
+
+		expect([...(manager.modifiedItems ?? [])]).toEqual(['script:u/admin/hello_world'])
+	})
 })
 
 describe('AIChatManager context compaction', () => {

--- a/frontend/src/lib/components/copilot/chat/HistoryManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/HistoryManager.svelte.ts
@@ -239,12 +239,13 @@ export default class HistoryManager {
 				lastModified: Date.now(),
 				...(this.sessionId ? { sessionId: this.sessionId } : {}),
 				...(contextUsage !== undefined ? { contextUsage } : {}),
-				// Only persist when the caller passes a defined array. Loaded legacy
-				// chats keep their accumulator undefined, so we never retroactively
-				// stamp them with [] (which would flip them to the filtered view).
-				// But since `put` replaces the whole record, a caller that omits the
-				// argument must not ERASE a tracked chat's stored mask — fall back to
-				// the previously saved field.
+				// Only persist when the caller passes a defined array — an untracked
+				// chat (the global side-panel chat, mask still undefined) must not be
+				// stamped with [], which would flip it to the filtered view. Session
+				// chats are always tracked (see AIChatManager.loadPastChat), so they do
+				// pass a defined array and persist it. Since `put` replaces the whole
+				// record, a caller that omits the argument must not ERASE a tracked
+				// chat's stored mask — fall back to the previously saved field.
 				...(modifiedItems !== undefined
 					? { modifiedItems }
 					: this.savedChats[this.currentChatId]?.modifiedItems !== undefined

--- a/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
@@ -713,6 +713,11 @@ async function initRuntime(runtime: SessionRuntime, session: Session) {
 		manager.historyManager.setCurrentChatId(session.chatId)
 		await manager.historyManager.tagChatWithSession(session.chatId, session.id)
 		await manager.loadPastChat(session.chatId)
+		// loadPastChat only seeds the mask when the chat exists in history; a chatId
+		// pointing at a chat not yet persisted (no turn saved) would leave it
+		// undefined, and the Edits surface would then show every workspace draft.
+		// Start tracking so this session is scoped to its own edits from the outset.
+		if (manager.modifiedItems === undefined) manager.initModifiedItemsTracking()
 	} else {
 		// Brand-new session chat: start tracking modified items now (empty mask)
 		// so the session bar filters to this chat's changes from the first turn.


### PR DESCRIPTION
## Summary

Opening an AI session whose workspace is a **fork** could show the *entire* fork's draft list in the session **"Edits"** bar and diff drawer — even though that surface is labeled *"Edited by the chat during this session"*. Forks accumulate drafts from the fork operation and from other sessions, so this dumped many unrelated items under the session's edits.

Root cause: the Edits surface scopes drafts through a per-chat **modified-items mask** (`AIChatManager.modifiedItems`, a `SvelteSet` of `${kind}:${path}` keys). `buildDeployItems` treats `mask === undefined` as *"untracked → show every workspace draft"*. A session chat's mask was left `undefined` in two cases:

1. `loadPastChat` seeded `undefined` for a legacy chat with no persisted mask.
2. `initRuntime` took the `session.chatId` branch but `loadPastChat`'s `if (chat)` block was skipped when the chat wasn't in history yet (fresh `chatId`, no turn saved), so nothing initialized tracking.

Fresh sessions were fine (they call `initModifiedItemsTracking()`), so this bit legacy/reloaded sessions.

The fix makes **session chats always tracked** — they never fall back to show-all. Only the global side-panel chat (which doesn't render this bar) stays untracked.

Tradeoff: a legacy session with real prior edits now shows nothing rather than every unrelated fork draft — the correct behavior for a surface scoped to "edited during this session".

## Changes
- `AIChatManager.svelte.ts`: `loadPastChat` seeds `new SvelteSet(stored ?? [])` for session chats (was `undefined` when no mask was stored); updated the `modifiedItems` field doc to match.
- `sessionRuntime.svelte.ts`: `initRuntime` adds `if (manager.modifiedItems === undefined) manager.initModifiedItemsTracking()` after `loadPastChat`, covering the not-yet-persisted-chat case.
- `AIChatManager.test.ts`: 2 regression tests — a legacy session chat seeds an empty tracked set; a stored-mask session chat seeds from it.

## Verification
Reproduced empirically by seeding IndexedDB with two sessions in a fork (`wm-fork-skillful-fork`, 13 drafts): a chat **with** `modifiedItems` and one **without**.
- **Before:** the untracked session's Edits bar showed **"13 drafts"** (all fork drafts).
- **After:** the untracked session shows **nothing**; the tracked session still shows its **1 real edit**.

`AIChatManager.test.ts` + `sessionState.test.ts`: all pass (incl. 2 new tests). `check:fast` clean on the touched files (one pre-existing unrelated error in `utils_workspace_deploy.ts` from the data-tables migration).

## Screenshots
Untracked fork session after the fix — the Edits surface is scoped (only the genuinely-tracked session shows "1 draft"; the untracked one no longer dumps all 13 fork drafts):

![after-fix-untracked-session-scoped](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-session-diff-scope/1783443350-after-fix-untracked-session-scoped.png)

## Test plan
- [ ] In a forked workspace containing unrelated drafts, open a legacy AI session (chat with no persisted modified-items mask) and confirm its Edits bar / diff drawer show nothing until the session itself edits an item.
- [ ] Open a session whose `chatId` points at a chat with no saved turn yet and confirm it starts with an empty Edits surface.
- [ ] Confirm a session that does edit items still lists exactly those items (regression check on the happy path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)