### PR TITLE
fix: align copy button on fork-less workspace rows

### DIFF
--- a/frontend/src/lib/components/sidebar/WorkspaceMenu.svelte
+++ b/frontend/src/lib/components/sidebar/WorkspaceMenu.svelte
@@ -324,6 +324,11 @@
 									<ChevronRight size={14} />
 								{/if}
 							</button>
+						{:else}
+							<!-- Reserve the expand-chevron's slot on fork-less rows so the hover copy
+							     button lines up with the forked rows' and never sits flush against the
+							     menu's right edge. Matches the chevron's px-2 (30px) + mr-1. -->
+							<div class="shrink-0 mr-1 w-[30px]" aria-hidden="true"></div>
 						{/if}
 					</div>
 				{/each}


### PR DESCRIPTION
## Summary

In the workspace picker dropdown, the hover-revealed **Copy id** button on a workspace row that has no forks sat flush against the menu's right edge ("glued to the right"). Only forked rows render an expand chevron, which insets the copy button; fork-less rows had no such element, so the copy button became the last item and hugged the edge — misaligned with the copy buttons on forked rows.

## Changes

- `frontend/src/lib/components/sidebar/WorkspaceMenu.svelte`: add an `{:else}` spacer div that reserves the expand-chevron's slot on fork-less rows (matching its `px-2` width, 30px, + `mr-1`). Copy buttons now align across forked and fork-less rows, and never touch the menu edge. The spacer is an inert `aria-hidden` layout element mirroring the existing raw hover-wrapper div directly above it.

## Screenshots

Fork-less row (`Manual testing sessions`) — copy button inset and aligned:

![after-nofork](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-copy-button-display/1783448216-after-nofork.png)

Forked row (`Linear`) — copy button lands at the same x-position, left of the chevron:

![after-fork](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-copy-button-display/1783448216-after-fork.png)

## Test plan

- [ ] Open the workspace switcher menu
- [ ] Hover a workspace row with **no** forks → copy button is inset from the right edge, not flush against it
- [ ] Hover a workspace row **with** forks → copy button sits at the same horizontal position, immediately left of the expand chevron
- [ ] Toggle between fork-less and forked rows → no horizontal shift of the copy-button column