### PR TITLE
fix(sessions): auto-rename regression + preview-panel and fork nits

### DIFF
--- a/frontend/src/lib/components/copilot/chat/openai-responses.ts
+++ b/frontend/src/lib/components/copilot/chat/openai-responses.ts
@@ -454,12 +454,14 @@ export async function getNonStreamingOpenAIResponsesCompletion(
 		workspace?: string
 		resourcePath?: string
 		forceModelProvider?: AIProviderModel
+		maxTokensCap?: number
 	}
 ): Promise<string> {
 	const { provider, config } = getProviderAndCompletionConfig({
 		messages,
 		stream: false,
-		forceModelProvider: options?.forceModelProvider
+		forceModelProvider: options?.forceModelProvider,
+		maxTokensCap: options?.maxTokensCap
 	})
 
 	const { instructions, input } = convertMessagesToResponsesInput(messages)

--- a/frontend/src/lib/components/copilot/lib.anthropicRouting.test.ts
+++ b/frontend/src/lib/components/copilot/lib.anthropicRouting.test.ts
@@ -195,6 +195,23 @@ describe('Anthropic Messages API routing', () => {
 		expect(headers['X-Resource-Path']).toBe('u/admin/foundry')
 	})
 
+	it('caps max_tokens for metadata completions so the Anthropic SDK stays non-streaming', async () => {
+		const { getNonStreamingCompletion, getNonStreamingMetadataCompletion, METADATA_MAX_TOKENS } =
+			await import('./lib')
+		// claude-sonnet defaults to 64000 max_tokens; the Anthropic SDK refuses a
+		// non-streaming request that large (>10min worst case), which silently broke
+		// session auto-rename and the other metadata generators.
+		h.currentModel = { provider: 'anthropic', model: 'claude-sonnet-4-6' }
+
+		await getNonStreamingCompletion(messages, new AbortController())
+		expect(anthropicCreate.mock.calls[0][0].max_tokens).toBe(64000)
+
+		anthropicCreate.mockClear()
+		await getNonStreamingMetadataCompletion(messages, new AbortController())
+		expect(anthropicCreate.mock.calls[0][0].max_tokens).toBe(METADATA_MAX_TOKENS)
+		expect(METADATA_MAX_TOKENS).toBeLessThanOrEqual(21333)
+	})
+
 	it('getFimCompletion no-ops for Anthropic Messages API models', async () => {
 		const { getFimCompletion } = await import('./lib')
 		const fetchSpy = vi.spyOn(globalThis, 'fetch')

--- a/frontend/src/lib/components/copilot/lib.anthropicRouting.test.ts
+++ b/frontend/src/lib/components/copilot/lib.anthropicRouting.test.ts
@@ -79,6 +79,7 @@ const messages: ChatCompletionMessageParam[] = [{ role: 'user', content: 'hi' }]
 let anthropicCreate: ReturnType<typeof vi.fn>
 let anthropicStream: ReturnType<typeof vi.fn>
 let openaiCreate: ReturnType<typeof vi.fn>
+let openaiResponsesCreate: ReturnType<typeof vi.fn>
 
 async function setupClients() {
 	const { workspaceAIClients } = await import('./lib')
@@ -102,12 +103,14 @@ async function setupClients() {
 			])
 		)
 	openaiCreate = vi.fn().mockResolvedValue({ choices: [{ message: { content: 'openai text' } }] })
+	openaiResponsesCreate = vi.fn().mockResolvedValue({ output_text: 'responses text' })
 
 	vi.spyOn(workspaceAIClients, 'getAnthropicClient').mockReturnValue({
 		messages: { create: anthropicCreate, stream: anthropicStream }
 	} as any)
 	vi.spyOn(workspaceAIClients, 'getOpenaiClient').mockReturnValue({
-		chat: { completions: { create: openaiCreate } }
+		chat: { completions: { create: openaiCreate } },
+		responses: { create: openaiResponsesCreate }
 	} as any)
 }
 
@@ -210,6 +213,22 @@ describe('Anthropic Messages API routing', () => {
 		await getNonStreamingMetadataCompletion(messages, new AbortController())
 		expect(anthropicCreate.mock.calls[0][0].max_tokens).toBe(METADATA_MAX_TOKENS)
 		expect(METADATA_MAX_TOKENS).toBeLessThanOrEqual(21333)
+	})
+
+	it('caps max_output_tokens for metadata completions on the OpenAI Responses path', async () => {
+		const { getNonStreamingCompletion, getNonStreamingMetadataCompletion, METADATA_MAX_TOKENS } =
+			await import('./lib')
+		// OpenAI/Azure non-streaming routes through the Responses API; the cap must
+		// reach it too, not just the Anthropic and chat.completions paths.
+		h.currentModel = { provider: 'openai', model: 'gpt-4o' }
+
+		await getNonStreamingCompletion(messages, new AbortController())
+		expect(openaiResponsesCreate).toHaveBeenCalledTimes(1)
+		expect(openaiResponsesCreate.mock.calls[0][0].max_output_tokens).toBe(16384)
+
+		openaiResponsesCreate.mockClear()
+		await getNonStreamingMetadataCompletion(messages, new AbortController())
+		expect(openaiResponsesCreate.mock.calls[0][0].max_output_tokens).toBe(METADATA_MAX_TOKENS)
 	})
 
 	it('getFimCompletion no-ops for Anthropic Messages API models', async () => {

--- a/frontend/src/lib/components/copilot/lib.ts
+++ b/frontend/src/lib/components/copilot/lib.ts
@@ -304,8 +304,10 @@ export function getModelMaxTokens(provider: AIProvider, model: string) {
 
 // Resolves the completion token cap for a model: the workspace's per-model
 // override when set, otherwise the built-in default. Shared by the OpenAI and
-// Anthropic request paths so both honor the same limit.
-function resolveMaxTokens(modelProvider: AIProviderModel): number {
+// Anthropic request paths so both honor the same limit. `cap` bounds the result
+// (used by short metadata completions, see METADATA_MAX_TOKENS) — a hard ceiling
+// that wins over both the workspace override and the default.
+function resolveMaxTokens(modelProvider: AIProviderModel, cap?: number): number {
 	const defaultMaxTokens = getModelMaxTokens(modelProvider.provider, modelProvider.model)
 	const modelKey = `${modelProvider.provider}:${modelProvider.model}`
 	let customMaxTokensStore: Record<string, number> | undefined
@@ -314,14 +316,23 @@ function resolveMaxTokens(modelProvider: AIProviderModel): number {
 	} catch {
 		// copilotInfo store may not be initialized in vitest
 	}
-	return customMaxTokensStore?.[modelKey] ?? defaultMaxTokens
+	const resolved = customMaxTokensStore?.[modelKey] ?? defaultMaxTokens
+	return cap !== undefined ? Math.min(resolved, cap) : resolved
 }
+
+// Token cap for metadata completions (session titles, cron/predicate/step-input
+// generation). These outputs are short, and the Anthropic SDK refuses a
+// non-streaming request whose max_tokens implies a >10-minute worst case
+// (60min × max_tokens / 128000): the model defaults (sonnet/haiku 64000, opus
+// 32000) all trip it. Capping keeps every provider's metadata call non-streaming.
+export const METADATA_MAX_TOKENS = 4096
 
 function getModelSpecificConfig(
 	modelProvider: AIProviderModel,
-	tools?: OpenAI.Chat.Completions.ChatCompletionTool[]
+	tools?: OpenAI.Chat.Completions.ChatCompletionTool[],
+	maxTokensCap?: number
 ) {
-	const maxTokens = resolveMaxTokens(modelProvider)
+	const maxTokens = resolveMaxTokens(modelProvider, maxTokensCap)
 	if (
 		(modelProvider.provider === 'openai' ||
 			modelProvider.provider === 'azure_openai' ||
@@ -501,6 +512,7 @@ interface AnthropicCompletionParams {
 	apiKey?: string
 	workspace?: string
 	resourcePath?: string
+	maxTokensCap?: number
 }
 
 function buildAnthropicProxyRequest({
@@ -508,7 +520,8 @@ function buildAnthropicProxyRequest({
 	modelProvider,
 	apiKey,
 	workspace,
-	resourcePath
+	resourcePath,
+	maxTokensCap
 }: Omit<AnthropicCompletionParams, 'abortController'>) {
 	const { system, messages: anthropicMessages } = convertOpenAIToAnthropicMessages(messages)
 
@@ -535,7 +548,7 @@ function buildAnthropicProxyRequest({
 
 	const body = {
 		model: modelProvider.model,
-		max_tokens: resolveMaxTokens(modelProvider),
+		max_tokens: resolveMaxTokens(modelProvider, maxTokensCap),
 		messages: anthropicMessages,
 		...(system && { system })
 	}
@@ -777,12 +790,14 @@ export function getProviderAndCompletionConfig<K extends boolean>({
 	messages,
 	stream,
 	tools,
-	forceModelProvider
+	forceModelProvider,
+	maxTokensCap
 }: {
 	messages: ChatCompletionMessageParam[]
 	stream: K
 	tools?: OpenAI.Chat.Completions.ChatCompletionTool[]
 	forceModelProvider?: AIProviderModel
+	maxTokensCap?: number
 }): {
 	provider: AIProvider
 	config: K extends true
@@ -796,7 +811,7 @@ export function getProviderAndCompletionConfig<K extends boolean>({
 		provider: modelProvider.provider,
 		config: {
 			...providerConfig,
-			...getModelSpecificConfig(modelProvider, tools),
+			...getModelSpecificConfig(modelProvider, tools, maxTokensCap),
 			messages: processedMessages,
 			stream
 		} as any
@@ -811,6 +826,7 @@ export async function getNonStreamingCompletion(
 		resourcePath?: string // testing resource path passed as a header to the backend proxy
 		workspace?: string // use a specific workspace proxy when testing a workspace resource
 		forceModelProvider?: AIProviderModel
+		maxTokensCap?: number // hard ceiling on output tokens (see METADATA_MAX_TOKENS)
 	}
 ) {
 	const modelProvider = options?.forceModelProvider ?? getCurrentModel()
@@ -822,7 +838,8 @@ export async function getNonStreamingCompletion(
 			abortController,
 			apiKey: options?.apiKey,
 			workspace: options?.workspace,
-			resourcePath: options?.resourcePath
+			resourcePath: options?.resourcePath,
+			maxTokensCap: options?.maxTokensCap
 		})
 	}
 
@@ -830,7 +847,8 @@ export async function getNonStreamingCompletion(
 	const { provider, config } = getProviderAndCompletionConfig({
 		messages,
 		stream: false,
-		forceModelProvider: options?.forceModelProvider
+		forceModelProvider: options?.forceModelProvider,
+		maxTokensCap: options?.maxTokensCap
 	})
 
 	// Use Responses API for OpenAI and Azure OpenAI
@@ -887,7 +905,8 @@ export async function getNonStreamingMetadataCompletion(
 	abortController: AbortController
 ) {
 	return getNonStreamingCompletion(messages, abortController, {
-		forceModelProvider: getMetadataModel()
+		forceModelProvider: getMetadataModel(),
+		maxTokensCap: METADATA_MAX_TOKENS
 	})
 }
 

--- a/frontend/src/lib/components/sessions/SessionPicker.svelte
+++ b/frontend/src/lib/components/sessions/SessionPicker.svelte
@@ -340,9 +340,9 @@
 	}
 
 	let pendingDelete: Session | undefined = $state(undefined)
-	// Default to also deleting the fork: it's tied to this session and would be
-	// orphaned otherwise. The user can still untick it in the modal.
-	let deleteAlsoFork = $state(true)
+	// Default off: deleting a fork workspace is destructive and not what deleting a
+	// session implies. The user can tick it in the modal to also drop the fork.
+	let deleteAlsoFork = $state(false)
 	// Fork workspace tied to `pendingDelete`, if any, and still accessible.
 	const pendingDeleteForkId = $derived.by(() => {
 		const wsId = pendingDelete?.workspace_id
@@ -365,7 +365,7 @@
 			? $userWorkspaces.find((w) => w.id === forkToDelete)?.parent_workspace_id
 			: undefined
 		pendingDelete = undefined
-		deleteAlsoFork = true
+		deleteAlsoFork = false
 		if (!session) return
 		const wasActive = sessionState.currentSessionId === session.id
 		removeSession(session.id)
@@ -863,7 +863,7 @@
 	onConfirmed={handleConfirmedDelete}
 	onCanceled={() => {
 		pendingDelete = undefined
-		deleteAlsoFork = true
+		deleteAlsoFork = false
 	}}
 >
 	<div class="flex flex-col gap-3">

--- a/frontend/src/lib/components/sessions/WorkspaceFamilyPicker.svelte
+++ b/frontend/src/lib/components/sessions/WorkspaceFamilyPicker.svelte
@@ -232,10 +232,10 @@
 		const taken = new Set($userWorkspaces.map((w) => w.id))
 		if (pendingFork) taken.add(pendingFork.id)
 		for (let i = 0; i < 50; i++) {
-			const candidate = `${random_adj()}-fork`
+			const candidate = random_adj()
 			if (!taken.has(`${WM_FORK_PREFIX}${candidate}`)) return candidate
 		}
-		const base = `${random_adj()}-fork`
+		const base = random_adj()
 		let n = 1
 		while (taken.has(`${WM_FORK_PREFIX}${base}-${n}`)) n++
 		return `${base}-${n}`

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -210,11 +210,13 @@
 	}
 	// Mount the active session's active tab whenever either changes. Background
 	// sessions' activeId changes (a chat tool opening a tab) don't mount — their
-	// tabs boot lazily on first visible activation.
+	// tabs boot lazily on first visible activation. A collapsed preview mounts
+	// nothing: the pane is zero-width, so booting a full Windmill app the user
+	// can't see is wasted — it mounts on expand, when previewCollapsed flips.
 	$effect(() => {
 		const sid = activeRuntime?.sessionId
 		const activeId = owner?.activeId
-		if (!sid || !activeId) return
+		if (!sid || !activeId || previewCollapsed) return
 		untrack(() => mountTab(tabKey(sid, activeId)))
 	})
 	// A disposed runtime unmounts its hosts; drop its keys too, else a later


### PR DESCRIPTION
## Summary

Fixes four AI-sessions nits. The headline one: **new sessions stopped auto-generating a title** from the first message. Root-caused with runtime instrumentation to a silently-swallowed throw — the Anthropic SDK now refuses a *non-streaming* request whose `max_tokens` implies a >10-minute worst case (`60min × max_tokens / 128000 > 10min`, i.e. `max_tokens > ~21333`). The session-summary generator (and CronGen/PredicateGen/StepInputGen) run non-streaming with the model default (`claude-sonnet-4-6` → 64000, opus → 32000), so every current Anthropic model tripped the guard; the error was caught by the `afterFirstTurnSaved` hook's `.catch()` and only logged, leaving the placeholder `"Xxx session"` title.

The other three are small session-UX fixes bundled from the same pass.

## Changes

- **fix: cap metadata `max_tokens`** — new `METADATA_MAX_TOKENS = 4096`, threaded as a `maxTokensCap` ceiling through `resolveMaxTokens` → `getModelSpecificConfig`/`getProviderAndCompletionConfig` (OpenAI path) and `buildAnthropicProxyRequest` (Anthropic Messages path). Only `getNonStreamingMetadataCompletion` passes it, so streaming and normal completions are untouched. Metadata outputs are short, so the cap never truncates real output. Adds a regression test in `lib.anthropicRouting.test.ts`.
- **perf: don't mount preview tabs when the side panel is collapsed** — the lazy-mount `$effect` now bails when `previewCollapsed`, so switching to a collapsed session (or a chat tool opening a tab in one) no longer boots a full Windmill app/iframe behind a zero-width pane. Mounts on expand when `previewCollapsed` flips back.
- **fix: drop redundant `-fork` suffix** from auto-generated fork names (`defaultForkId`) — the id already carries the `wm-fork-` prefix.
- **fix: default "also delete forked workspace" to `false`** in the delete-session modal (safer default; was `true`).

## Test plan

- [x] Metadata cap: `vitest run lib.anthropicRouting.test.ts` (7/7 pass; asserts uncapped path stays 64000, metadata path caps to `METADATA_MAX_TOKENS`).
- [x] Auto-rename: browser-verified end-to-end on `/sessions` — new session, sent a message, header went `"Durable session"` → **"Primary Colors List"** (console confirmed `setGeneratedSessionSummary result {applied: true}` with no throw). See screenshot.
- [ ] Collapse-mount: on `/sessions`, collapse the preview panel, have a background chat tool open a tab, then expand and confirm the active tab boots on expand (no blank pane, no double-mount).
- [ ] Delete-forked default: delete a session tied to a fork workspace and confirm the "also delete forked workspace" checkbox now defaults to unticked.

## Screenshots

Auto-rename fix — a brand-new session's title generated from the first message (`"Primary Colors List"`), acting on the `guilhem` workspace:

![rename-auto-title](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm-session-nits/1783448350-rename-auto-title.png)

The other three surfaces are state-gated and not captured: the collapse-mount change has no visible DOM delta (behavior only); the fork-name default only appears in the transient create-fork input; the delete-forked toggle only renders for a session tied to a fork workspace. All three are one-line default/string flips, reviewed and type-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)