### PR TITLE
fix(frontend): refresh picomatch in lockfile to unbreak `npm ci`

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10163,9 +10163,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -12782,9 +12782,9 @@
 			}
 		},
 		"node_modules/svelte-check/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -13352,9 +13352,9 @@
 			}
 		},
 		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {
@@ -13931,9 +13931,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {
@@ -14067,9 +14067,9 @@
 			"license": "MIT"
 		},
 		"node_modules/vitest/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {


### PR DESCRIPTION
## Summary

The `ai-evals` CI job (also any job running `npm ci` in `frontend/`) fails at the **Install frontend deps** step — before any eval runs:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Missing: picomatch@4.0.5 from lock file
```

This is a **lockfile drift on `main`**, not tied to any one feature PR — it surfaced on [#9985](https://github.com/windmill-labs/windmill/pull/9985) but that PR touched no frontend deps.

## Root cause

`picomatch` is a floating transitive: `svelte-check` pulls it as an **`optional peer`** at `^4.0.4` (and `vite`/`vitest`/`tinyglobby` at `^4.0.x`). The lockfile pinned 4.0.3/4.0.4, but **4.0.5 was published upstream**. On a **cold-cache CI runner**, `npm ci` re-resolves those ranges against the registry and picks the latest (4.0.5) — which isn't in the lock, so the sync check fails. It passes on developer machines only because a warm npm cache still serves 4.0.4.

Confirmed the failing run used node `v22.22.3` / npm `10.9.8`.

## Fix

`npm update picomatch --package-lock-only` (npm 10.9.8, matching CI's node 22) — refreshes every `picomatch` node to 4.0.5 (and the separate 2.x line to 2.3.2). **Lockfile-only, all semver-patch, no `package.json` change**, no dev-flag churn:

| node | before | after |
|---|---|---|
| `svelte-check/node_modules/picomatch` (optional peer — the culprit) | 4.0.4 | 4.0.5 |
| `tinyglobby/node_modules/picomatch` | 4.0.4 | 4.0.5 |
| `vite/node_modules/picomatch` | 4.0.4 | 4.0.5 |
| `vitest/node_modules/picomatch` | 4.0.3 | 4.0.5 |
| `node_modules/picomatch` | 2.3.1 | 2.3.2 |

## Test plan

- [x] `npm ci --dry-run` is back in sync with a **cold cache** (reproduced CI's environment)
- [x] `picomatch@4.0.5` is present in all four 4.x lock slots, so a fresh registry resolution finds it
- [ ] `ai-evals` CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes frontend `npm ci` failures by refreshing `frontend/package-lock.json` to include `picomatch@4.0.5` (and `2.3.2` for the 2.x line), removing lockfile drift on fresh CI runners. Lockfile-only change.

- **Bug Fixes**
  - Ensures `picomatch@4.0.5` is present under `svelte-check`, `vite`, `vitest`, and `tinyglobby`.
  - Resolves the "Missing: picomatch@4.0.5 from lock file" error; no `package.json` edits.

<sup>Written for commit 2520cb74b331f6bccb06b1799040bbe97b56957c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

