### PR TITLE
fix: relock go steps whose stored lock is not a go.mod

### DIFF
--- a/backend/windmill-worker/src/go_executor.rs
+++ b/backend/windmill-worker/src/go_executor.rs
@@ -15,6 +15,7 @@ use windmill_common::{
     error::{self, Error},
     utils::calculate_hash,
     worker::{write_file, Connection, GoAnnotations},
+    workspace_dependencies::WorkspaceDependenciesPrefetched,
 };
 use windmill_parser_go::{parse_go_imports, REQUIRE_PARSE};
 use windmill_queue::{append_logs, CanceledBy, MiniPulledJob};
@@ -76,6 +77,15 @@ fn set_windows_env_vars(cmd: &mut Command) {
 }
 
 const GO_REQ_SPLITTER: &str = "//go.sum\n";
+
+/// A usable go lock always embeds a go.mod, which requires a `module` directive.
+/// Locks that fail this check (e.g. a package.json left over from a step that was
+/// switched from TypeScript to Go) would be written verbatim into go.mod and make
+/// `go mod tidy` fail with "unknown directive".
+pub(crate) fn is_go_mod_lock(lock: &str) -> bool {
+    lock.lines()
+        .any(|l| l.split_whitespace().next() == Some("module"))
+}
 const NSJAIL_CONFIG_RUN_GO_CONTENT: &str = include_str!("../nsjail/run.go.config.proto");
 
 lazy_static::lazy_static! {
@@ -107,6 +117,30 @@ pub async fn handle_go_job(
         .recursive(true)
         .create(&job_dir)
         .expect("could not create go job dir");
+
+    let maybe_lock = match maybe_lock {
+        MaybeLock::Resolved { ref lock } if !is_go_mod_lock(lock) => {
+            append_logs(
+                &job.id,
+                &job.workspace_id,
+                "\nstored lockfile is not a go.mod (likely generated for another language), ignoring it and resolving dependencies from imports\n",
+                conn,
+            )
+            .await;
+            MaybeLock::Unresolved {
+                workspace_dependencies: WorkspaceDependenciesPrefetched::extract(
+                    inner_content,
+                    ScriptLang::Go,
+                    &job.workspace_id,
+                    &None,
+                    job.runnable_path(),
+                    conn.clone(),
+                )
+                .await?,
+            }
+        }
+        _ => maybe_lock,
+    };
 
     let hash = calculate_hash(&format!("{}{:?}v2", inner_content, &maybe_lock));
     let bin_path = format!("{}/{hash}", *GO_BIN_CACHE_DIR);
@@ -699,6 +733,24 @@ pub async fn install_go_dependencies(
         return Ok(String::new());
     } else {
         Ok(req_content)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_go_mod_lock;
+
+    #[test]
+    fn test_is_go_mod_lock() {
+        assert!(is_go_mod_lock("module mymod\n\ngo 1.26.3\n//go.sum\n"));
+        assert!(is_go_mod_lock(
+            "module mymod\n\ngo 1.22\n\nrequire rsc.io/quote v1.5.2\n//go.sum\nrsc.io/quote v1.5.2 h1:...\n"
+        ));
+        // package.json left over from a step that was TypeScript before
+        assert!(!is_go_mod_lock("{\n  \"dependencies\": {}\n}"));
+        assert!(!is_go_mod_lock(""));
+        // "module" as a substring of another token or inside a JSON string is not a directive
+        assert!(!is_go_mod_lock("{\n  \"module\": \"esnext\"\n}"));
     }
 }
 

--- a/backend/windmill-worker/src/worker_lockfiles.rs
+++ b/backend/windmill-worker/src/worker_lockfiles.rs
@@ -1333,7 +1333,7 @@ async fn lock_modules(
             }
         } else {
             if lock.as_ref().is_some_and(|x| !x.trim().is_empty()) {
-                if skip_creating_new_lock(&language, &content)
+                if skip_creating_new_lock(&language, &content, lock.as_deref().unwrap_or_default())
                     && (MIN_VERSION_SUPPORTS_DEBOUNCING_V2.met().await
                         || *WMDEBUG_FORCE_NO_LEGACY_DEBOUNCING_COMPAT)
                 {
@@ -1759,7 +1759,7 @@ async fn reduce_app(
     Ok(())
 }
 
-fn skip_creating_new_lock(language: &ScriptLang, content: &str) -> bool {
+fn skip_creating_new_lock(language: &ScriptLang, content: &str, lock: &str) -> bool {
     if language == &ScriptLang::Bun || language == &ScriptLang::Bunnative {
         let anns = windmill_common::worker::TypeScriptAnnotations::parse(&content);
         if anns.native && language == &ScriptLang::Bun {
@@ -1767,6 +1767,11 @@ fn skip_creating_new_lock(language: &ScriptLang, content: &str) -> bool {
         } else if !anns.native && language == &ScriptLang::Bunnative {
             return false;
         };
+    }
+    // A lock left over from the step's previous language (e.g. a package.json after a
+    // TypeScript -> Go switch) is unusable as a go.mod — relock instead of keeping it.
+    if language == &ScriptLang::Go && !crate::go_executor::is_go_mod_lock(lock) {
+        return false;
     }
     true
 }
@@ -1864,9 +1869,12 @@ async fn lock_modules_app(
                                 .get("lock")
                                 .is_some_and(|x| !x.as_str().unwrap().trim().is_empty())
                             {
-                                if skip_creating_new_lock(&language, &content)
-                                    && (MIN_VERSION_SUPPORTS_DEBOUNCING_V2.met().await
-                                        || *WMDEBUG_FORCE_NO_LEGACY_DEBOUNCING_COMPAT)
+                                if skip_creating_new_lock(
+                                    &language,
+                                    &content,
+                                    v.get("lock").and_then(|x| x.as_str()).unwrap_or_default(),
+                                ) && (MIN_VERSION_SUPPORTS_DEBOUNCING_V2.met().await
+                                    || *WMDEBUG_FORCE_NO_LEGACY_DEBOUNCING_COMPAT)
                                 {
                                     dependency_map
                                         .patch(


### PR DESCRIPTION
Fixes WIN-2141

## Summary

A Go script or flow step whose stored lockfile is not actually a go.mod fails at runtime with:

```
exit code for "go tidy": 1
go: errors parsing go.mod:
go.mod:1: unknown directive: {
go.mod:2:3: unknown directive: "dependencies"
go.mod:3: unknown directive: }
```

That content is exactly bun's no-dependencies `package.json` — a lock left over from the step's previous language (e.g. a flow step created as TypeScript, later switched to Go). Two compounding causes:

1. **Deploy**: the flow/app dependency job keeps any non-empty existing lock (`skip_creating_new_lock` only special-cases bun↔bunnative), so the stale cross-language lock survives redeploys.
2. **Runtime**: `handle_go_job` writes the stored lock verbatim into `go.mod` and runs `go mod tidy`, which explodes on non-go.mod content.

The reported "single import fails, parenthesized import works, then single import works again" was sequencing, not parsing (`parse_go_imports` handles single-line imports fine — verified): any content edit clears the module lock in the editor and forces a proper relock, and the follow-up relock is served from `pip_resolution_cache` (both import styles hash to the same empty-imports key), which is the "like it was using some cached version" observation.

## Changes

- `go_executor.rs`: new `is_go_mod_lock` helper — a usable Go lock always embeds a go.mod, which requires a `module` directive (token-based check, immune to JSON keys like `"module": "esnext"`). Unit tests included.
- `go_executor.rs` (`handle_go_job`): a `Resolved` lock that fails the check is ignored — a warning is appended to the job logs and the job falls back to `MaybeLock::Unresolved`, resolving dependencies from imports. This self-heals already-deployed scripts/flows carrying a bad lock, without redeploy. Placed before the binary-cache hash so the cache key reflects the regenerated resolution.
- `worker_lockfiles.rs` (`skip_creating_new_lock`, used by flow and app dependency jobs): a Go step whose existing lock is not a plausible go.mod is relocked instead of keeping the stale lock, repairing the stored flow/app value at deploy time.

## Test plan

- [x] `cargo test -p windmill-worker --lib is_go_mod_lock` passes
- [x] **Exact repro before fix**: flow with a Go rawscript step carrying lock `{"dependencies": {}}` → dep job kept the JSON lock → run failed byte-for-byte with the reported `go tidy` / `unknown directive: {` error
- [x] **Dep-job fix**: redeploying the same flow regenerates the lock (`module mymod` + `//go.sum`) and the flow runs successfully
- [x] **Runtime self-heal**: Go script created with a bad JSON lock (dep job skipped) runs successfully; job log shows `stored lockfile is not a go.mod (likely generated for another language), ignoring it and resolving dependencies from imports`
- [x] Healthy paths unaffected: fresh single-line-import Go script deploy + run, and preview run, both succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WIN-2141. Prevents Go steps from failing when a stale non-`go.mod` lock (e.g., a `package.json`) is stored by relocking on deploy and ignoring the bad lock at runtime.

- **Bug Fixes**
  - Added `is_go_mod_lock` to validate Go locks by checking for a `module` directive (with tests).
  - Runtime: `handle_go_job` now ignores a stored lock that isn’t a valid `go.mod`, logs a warning, and resolves deps from imports; cache key reflects the regenerated resolution.
  - Deploy: `skip_creating_new_lock` now relocks Go steps when the existing lock isn’t a valid `go.mod`, fixing stored locks during flow/app deploys.

<sup>Written for commit 78388d48e550106f07d07b071b6d66a4a932bb8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/9995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

