### PR TITLE
fix(sessions): open test pane when enabling debug so the debug UI is visible

### DIFF
--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -1289,6 +1289,13 @@
 			updateCurrentLineDecoration(undefined)
 		} else {
 			debugMode = true
+			// The debug UI mounts inside the test pane, which is collapsed to 0 in
+			// AI sessions. Must stay a one-shot expand at the toggle, not a reactive
+			// effect: an effect would reopen the pane whenever the user collapsed it
+			// while debugging.
+			if (testPanelSize === 0) {
+				expandTestPanel()
+			}
 		}
 	}
 
@@ -1621,14 +1628,22 @@
 	)
 	const codePanelSize = $derived(100 - testPanelSize)
 
+	function expandTestPanel() {
+		rawTestPanelSize = Math.max(storedTestPanelSize, testPaneMinPercent)
+	}
+
+	function collapseTestPanel() {
+		// Store the raw (unclamped) preference so reopening on a wider screen
+		// restores the user's intent, not the pixel-min that inflated the pane.
+		storedTestPanelSize = rawTestPanelSize
+		rawTestPanelSize = 0
+	}
+
 	function toggleTestPanel() {
 		if (testPanelSize > 0) {
-			// Store the raw (unclamped) preference so reopening on a wider screen
-			// restores the user's intent, not the pixel-min that inflated the pane.
-			storedTestPanelSize = rawTestPanelSize
-			rawTestPanelSize = 0
+			collapseTestPanel()
 		} else {
-			rawTestPanelSize = Math.max(storedTestPanelSize, testPaneMinPercent)
+			expandTestPanel()
 		}
 	}
 


### PR DESCRIPTION
## Summary

In an AI session (`frontend/src/lib/components/sessions`) with a script open in the right-hand preview panel, clicking **Toggle Debug Mode** did nothing visible — the debug pane never appeared. Clicking **Test** afterwards revealed it.

The debug UI (`DebugToolbar` + `DebugPanel`) is rendered **inside the script editor's right-hand test/preview pane**. In an AI session that pane is force-collapsed to width 0 (`initialTestPanelCollapsed`), and enabling debug flipped `debugMode` on and connected the DAP client but never widened the pane — so the debug UI mounted inside a **zero-width pane** and stayed invisible. The debug pane and the collapsed test panel are the same layout slot.

## Changes

- `toggleDebugMode()`: on the enable path, expand the test pane when it's collapsed (`testPanelSize === 0`) so the debug UI is immediately visible without a follow-up Test click.
- Extract `expandTestPanel()` / `collapseTestPanel()` out of `toggleTestPanel()` so the debug enable path can express "expand" directly instead of relying on the toggle's branch semantics. Behavior-preserving: `toggleTestPanel()` keeps its `testPanelSize > 0 ? collapse : expand` dispatch and all four existing callers are unchanged.

### Design decisions (deliberate)

- **One-shot imperative expand, not a reactive `$effect`.** A standing "`debugMode && collapsed → open`" effect would fight the user — they could never collapse the pane while debugging. The invariant belongs at the transition (toggle time), not as a continuous rule.
- **Asymmetric: leave the pane open on disable.** Auto-collapsing on disable would need "debug owns this pane" ownership state invalidated across every width-change path (drag handle, HideButton, Cmd+U, runTest resizes) — miss one and we collapse a pane the user deliberately kept open. It's also worse UX: the user is looking at the pane they just opened.
- **`=== 0` guard** avoids re-toggling or snapping a pane the user already has open at a custom width.

## Known limitation (future work)

The debug UI and the test pane still share one layout slot, so `debugMode` can be `true` while the UI is invisible on other width-change paths. This PR patches the one transition that matters today. If this slot keeps accreting modes (test / debug / preview / args), the real fix is to give debug its own slot or add an explicit "what is this pane showing" discriminant — out of scope here.

## Test plan

- [ ] `npm run check` — clean for `ScriptEditor.svelte` (pre-existing unrelated errors elsewhere untouched)
- [ ] AI session, script open, pane collapsed → Toggle Debug Mode opens the pane immediately and shows the DebugPanel once the DAP client connects
- [ ] Toggle Debug Mode off → debug turns off, pane stays open (deliberate)
- [ ] Standalone `/scripts/edit` unchanged (pane already open; the `=== 0` branch never fires)
- [ ] Glance at the pipeline asset-graph details pane (`previewLayout="bottom"`) for the documented cosmetic re-open-on-enable case (min-clamped, non-breaking)

## Screenshots

**Before** — AI session with a script open in the right panel; the test/preview pane is collapsed to width 0. Clicking Toggle Debug Mode used to do nothing visible.

<img width="1280" height="720" alt="page-2026-07-08T06-52-45-932Z" src="https://github.com/user-attachments/assets/23d5819b-599c-4b5d-b33e-f88e996db524" />

**After enabling debug** — one click on Toggle Debug Mode now expands the pane and, once the DAP client connects, shows the DebugPanel (step controls, breakpoints hint, args + logs).

<img width="1280" height="720" alt="page-2026-07-08T06-53-19-159Z" src="https://github.com/user-attachments/assets/4a4177b6-2bf8-4e43-bd01-e43e609b7190" />

**After disabling debug** — debug turns off and the toolbar reverts to the normal Test button, but the pane is deliberately left open (see design decisions).

<img width="1280" height="720" alt="page-2026-07-08T06-54-04-862Z" src="https://github.com/user-attachments/assets/880e1ff2-e9b2-4d98-a16d-4f4ceef723c7" />

**Standalone `/scripts/edit` (regression check)** — unchanged: the pane is open by default, so the new `=== 0` branch never fires.

<img width="1280" height="720" alt="page-2026-07-08T06-54-39-397Z" src="https://github.com/user-attachments/assets/232bdcc2-a683-455f-a612-35b293806f99" />