### PR TITLE
chore(docker): slim default image — remove helm & Claude Code CLI with init-script guidance (WIN-2144)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -206,6 +206,8 @@ RUN if [ "$WITH_HELM" = "true" ]; then \
     mv linux-$arch/helm /usr/local/bin/helm &&\
     chmod +x /usr/local/bin/helm; \
     else \
+    # Stub lives in /usr/bin (last in PATH) so any real helm installed later via an
+    # init script — to /usr/local/bin, ~/.local/bin, /tmp/.local/bin, etc. — shadows it.
     printf '%s\n' \
     '#!/bin/sh' \
     '# helm has been removed from the default Windmill image to keep it lean.' \
@@ -214,7 +216,7 @@ RUN if [ "$WITH_HELM" = "true" ]; then \
     'echo "  curl -fsSL https://get.helm.sh/helm-v3.14.3-linux-amd64.tar.gz | tar -xz -C /tmp && mv /tmp/linux-amd64/helm /usr/local/bin/helm" >&2' \
     'echo "See https://www.windmill.dev/docs/core_concepts/worker_groups#init-scripts for details." >&2' \
     'exit 127' \
-    > /usr/local/bin/helm && chmod +x /usr/local/bin/helm; \
+    > /usr/bin/helm && chmod +x /usr/bin/helm; \
     echo 'Building the image without helm (installed a stub pointing to init scripts)'; fi
 
 RUN if [ "$WITH_KUBECTL" = "true" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -210,7 +210,7 @@ RUN if [ "$WITH_HELM" = "true" ]; then \
     chmod +x /usr/local/bin/helm; \
     else \
     # Stub lives in /usr/bin (last in PATH) so any real helm installed later via an
-    # init script — to /usr/local/bin, ~/.local/bin, /tmp/.local/bin, etc. — shadows it.
+    # init script (to /usr/local/bin, ~/.local/bin, /tmp/.local/bin, etc.) shadows it.
     # The suggested command mirrors the WITH_HELM=true branch: ${HELM_VERSION} is baked in
     # at build time and $arch is resolved at run time so the hint is correct on any arch.
     printf '%s\n' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -143,10 +143,10 @@ ARG GO_VERSION=1.26.0
 ARG APP=/usr/src/app
 ARG WITH_POWERSHELL=true
 ARG WITH_KUBECTL=true
-# helm is no longer bundled in the default image; opt back in with WITH_HELM=true
+# Default images omit helm to stay lean; set WITH_HELM=true to bundle it
 ARG WITH_HELM=false
-# the Claude Code CLI (~245MB, used only by the claude sandbox template) is no longer
-# bundled in the default image; opt back in with WITH_CLAUDE_CODE=true
+# Default images omit the Claude Code CLI (~245MB, used only by the claude sandbox
+# template) to stay lean; set WITH_CLAUDE_CODE=true to bundle it
 ARG WITH_CLAUDE_CODE=false
 ARG WITH_GIT=true
 ARG features=""
@@ -211,12 +211,14 @@ RUN if [ "$WITH_HELM" = "true" ]; then \
     else \
     # Stub lives in /usr/bin (last in PATH) so any real helm installed later via an
     # init script — to /usr/local/bin, ~/.local/bin, /tmp/.local/bin, etc. — shadows it.
+    # The suggested command mirrors the WITH_HELM=true branch: ${HELM_VERSION} is baked in
+    # at build time and $arch is resolved at run time so the hint is correct on any arch.
     printf '%s\n' \
     '#!/bin/sh' \
-    '# helm has been removed from the default Windmill image to keep it lean.' \
-    'echo "helm is no longer bundled in the default Windmill image." >&2' \
+    'echo "helm is not included in the default Windmill image." >&2' \
     'echo "Install it at worker startup with a worker init script, e.g.:" >&2' \
-    'echo "  curl -fsSL https://get.helm.sh/helm-v3.14.3-linux-amd64.tar.gz | tar -xz -C /tmp && mv /tmp/linux-amd64/helm /usr/local/bin/helm" >&2' \
+    'arch="$(dpkg --print-architecture)"; arch="${arch##*-}"' \
+    "echo \"  wget https://get.helm.sh/helm-v${HELM_VERSION}-linux-\$arch.tar.gz && tar -zxvf helm-v${HELM_VERSION}-linux-\$arch.tar.gz && mv linux-\$arch/helm /usr/local/bin/helm\" >&2" \
     'echo "See https://www.windmill.dev/docs/core_concepts/worker_groups#init-scripts for details." >&2' \
     'exit 127' \
     > /usr/bin/helm && chmod +x /usr/bin/helm; \
@@ -302,10 +304,10 @@ COPY --from=oven/bun:1.3.10 /usr/local/bin/bun /usr/bin/bun
 RUN bun install -g windmill-cli \
     && ln -s $(bun pm bin -g)/wmill /usr/bin/wmill
 
-# Claude Code CLI (used only by the claude sandbox script template). Not bundled by
-# default to keep the image lean (~245MB); opt in with --build-arg WITH_CLAUDE_CODE=true,
-# or install it at worker startup via an init script. When absent, the claude sandbox
-# template fails fast with instructions (frontend/src/lib/templates/claude_sandbox.ts.template).
+# Claude Code CLI (~245MB), used only by the claude sandbox script template. Omitted from
+# the default image to stay lean; opt in with --build-arg WITH_CLAUDE_CODE=true, or install
+# it at worker startup via an init script. When absent, the agent SDK reports a missing
+# /usr/bin/claude at run time (the template header comment names the init-script install).
 # The installer puts the binary in ~/.local/bin/claude (symlink to ~/.local/share/claude/versions/*);
 # copy it to /usr/bin/claude so it's reachable inside the nsjail sandbox (which mounts /usr but not /root).
 RUN if [ "$WITH_CLAUDE_CODE" = "true" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,6 +145,9 @@ ARG WITH_POWERSHELL=true
 ARG WITH_KUBECTL=true
 # helm is no longer bundled in the default image; opt back in with WITH_HELM=true
 ARG WITH_HELM=false
+# the Claude Code CLI (~245MB, used only by the claude sandbox template) is no longer
+# bundled in the default image; opt back in with WITH_CLAUDE_CODE=true
+ARG WITH_CLAUDE_CODE=false
 ARG WITH_GIT=true
 ARG features=""
 
@@ -299,11 +302,16 @@ COPY --from=oven/bun:1.3.10 /usr/local/bin/bun /usr/bin/bun
 RUN bun install -g windmill-cli \
     && ln -s $(bun pm bin -g)/wmill /usr/bin/wmill
 
-# Install Claude Code CLI (used by claude sandbox scripts)
-# The installer puts the binary in ~/.local/bin/claude (symlink to ~/.local/share/claude/versions/*)
-# Copy it to /usr/bin/claude so it's accessible inside nsjail sandbox (which mounts /usr but not /root)
-RUN curl -fsSL https://claude.ai/install.sh | bash \
-    && cp /root/.local/share/claude/versions/* /usr/bin/claude
+# Claude Code CLI (used only by the claude sandbox script template). Not bundled by
+# default to keep the image lean (~245MB); opt in with --build-arg WITH_CLAUDE_CODE=true,
+# or install it at worker startup via an init script. When absent, the claude sandbox
+# template fails fast with instructions (frontend/src/lib/templates/claude_sandbox.ts.template).
+# The installer puts the binary in ~/.local/bin/claude (symlink to ~/.local/share/claude/versions/*);
+# copy it to /usr/bin/claude so it's reachable inside the nsjail sandbox (which mounts /usr but not /root).
+RUN if [ "$WITH_CLAUDE_CODE" = "true" ]; then \
+    curl -fsSL https://claude.ai/install.sh | bash \
+    && cp /root/.local/share/claude/versions/* /usr/bin/claude; \
+    else echo 'Building the image without the Claude Code CLI'; fi
 
 COPY --from=php:8.3.30-cli-bookworm /usr/local/bin/php /usr/bin/php
 COPY --from=composer:2.9.5 /usr/bin/composer /usr/bin/composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -143,7 +143,8 @@ ARG GO_VERSION=1.26.0
 ARG APP=/usr/src/app
 ARG WITH_POWERSHELL=true
 ARG WITH_KUBECTL=true
-ARG WITH_HELM=true
+# helm is no longer bundled in the default image; opt back in with WITH_HELM=true
+ARG WITH_HELM=false
 ARG WITH_GIT=true
 ARG features=""
 
@@ -204,7 +205,17 @@ RUN if [ "$WITH_HELM" = "true" ]; then \
     tar -zxvf "helm-v${HELM_VERSION}-linux-$arch.tar.gz"  && \
     mv linux-$arch/helm /usr/local/bin/helm &&\
     chmod +x /usr/local/bin/helm; \
-    else echo 'Building the image without helm'; fi
+    else \
+    printf '%s\n' \
+    '#!/bin/sh' \
+    '# helm has been removed from the default Windmill image to keep it lean.' \
+    'echo "helm is no longer bundled in the default Windmill image." >&2' \
+    'echo "Install it at worker startup with a worker init script, e.g.:" >&2' \
+    'echo "  curl -fsSL https://get.helm.sh/helm-v3.14.3-linux-amd64.tar.gz | tar -xz -C /tmp && mv /tmp/linux-amd64/helm /usr/local/bin/helm" >&2' \
+    'echo "See https://www.windmill.dev/docs/core_concepts/worker_groups#init-scripts for details." >&2' \
+    'exit 127' \
+    > /usr/local/bin/helm && chmod +x /usr/local/bin/helm; \
+    echo 'Building the image without helm (installed a stub pointing to init scripts)'; fi
 
 RUN if [ "$WITH_KUBECTL" = "true" ]; then \
     arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -3445,7 +3445,7 @@ pub async fn start_worker(
     let py_version = if let Some(requirements) = requirements_o {
         PyV::parse_from_requirements(&split_python_requirements(requirements.as_str()))
     } else {
-        tracing::warn!(workspace_id = %w_id, "lockfile is empty for dedicated worker, thus python version cannot be inferred. Fallback to 3.11");
+        tracing::warn!(workspace_id = %w_id, "lockfile is empty for dedicated worker, thus python version cannot be inferred. Fallback to default python version");
         PyVAlias::default().into()
     };
 

--- a/backend/windmill-worker/src/python_versions.rs
+++ b/backend/windmill-worker/src/python_versions.rs
@@ -372,10 +372,10 @@ impl PyV {
     }
 
     /// Parse lockfile for assigned python version.
-    /// If not found returns 3.11
+    /// If not found returns the default version (`PyVAlias::default()`).
     pub fn parse_from_requirements<S: AsRef<str>>(requirements_lines: &[S]) -> Self {
         Self::try_parse_from_requirements(requirements_lines).unwrap_or(
-            // If there is no assigned version in lockfile we automatically fallback to 3.11
+            // If there is no assigned version in lockfile we automatically fallback to the default version
             // In this case we have dependencies or other metadata, but no associated python version
             // This is the case for old deployed scripts
             PyVAlias::default().into(),

--- a/frontend/src/lib/templates/claude_sandbox.ts.template
+++ b/frontend/src/lib/templates/claude_sandbox.ts.template
@@ -1,7 +1,6 @@
 // sandbox
 // volume: claude .claude
-// Requires the Claude Code CLI at /usr/bin/claude — not in the default image. Install it via a
-// worker init script: curl -fsSL https://claude.ai/install.sh | bash && cp /root/.local/share/claude/versions/* /usr/bin/claude
+// Needs the Claude Code CLI at /usr/bin/claude — install via a worker init script if absent
 
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import * as fs from "fs";

--- a/frontend/src/lib/templates/claude_sandbox.ts.template
+++ b/frontend/src/lib/templates/claude_sandbox.ts.template
@@ -8,7 +8,22 @@ import * as path from "path";
 // path -> content, fileset resource, that contains your CLAUDE.md, and skills
 type AgentInstructions = Record<string, string>
 
+// The Claude Code CLI is not bundled in the default Windmill image. Install it on the
+// worker via an init script (Worker Management > Init scripts) with:
+//   curl -fsSL https://claude.ai/install.sh | bash && cp /root/.local/share/claude/versions/* /usr/bin/claude
+// See https://www.windmill.dev/docs/core_concepts/worker_groups#init-scripts
+const CLAUDE_CODE_EXECUTABLE = "/usr/bin/claude";
+
 export async function main(anthropic: RT.Anthropic, agent_instructions?: AgentInstructions) {
+
+  if (!fs.existsSync(CLAUDE_CODE_EXECUTABLE)) {
+    throw new Error(
+      `Claude Code CLI not found at ${CLAUDE_CODE_EXECUTABLE}. It is not bundled in the default Windmill image. ` +
+      `Install it on this worker with an init script (Worker Management > Init scripts):\n` +
+      `  curl -fsSL https://claude.ai/install.sh | bash && cp /root/.local/share/claude/versions/* /usr/bin/claude\n` +
+      `See https://www.windmill.dev/docs/core_concepts/worker_groups#init-scripts`
+    );
+  }
 
   const sessionFile = path.join(".claude/session-id.txt");
 
@@ -40,7 +55,7 @@ export async function main(anthropic: RT.Anthropic, agent_instructions?: AgentIn
     prompt,
     options: {
       model: "opus",
-      pathToClaudeCodeExecutable: "/usr/bin/claude",
+      pathToClaudeCodeExecutable: CLAUDE_CODE_EXECUTABLE,
       permissionMode: 'bypassPermissions',
       allowDangerouslySkipPermissions: true,
       ...(isResume ? { resume: sessionId } : {}),

--- a/frontend/src/lib/templates/claude_sandbox.ts.template
+++ b/frontend/src/lib/templates/claude_sandbox.ts.template
@@ -1,6 +1,6 @@
 // sandbox
 // volume: claude .claude
-// Needs the Claude Code CLI at /usr/bin/claude — install via a worker init script if absent
+// Needs the Claude Code CLI at /usr/bin/claude - install via a worker init script if absent
 
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import * as fs from "fs";

--- a/frontend/src/lib/templates/claude_sandbox.ts.template
+++ b/frontend/src/lib/templates/claude_sandbox.ts.template
@@ -1,5 +1,7 @@
 // sandbox
 // volume: claude .claude
+// Requires the Claude Code CLI at /usr/bin/claude — not in the default image. Install it via a
+// worker init script: curl -fsSL https://claude.ai/install.sh | bash && cp /root/.local/share/claude/versions/* /usr/bin/claude
 
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import * as fs from "fs";
@@ -8,22 +10,7 @@ import * as path from "path";
 // path -> content, fileset resource, that contains your CLAUDE.md, and skills
 type AgentInstructions = Record<string, string>
 
-// The Claude Code CLI is not bundled in the default Windmill image. Install it on the
-// worker via an init script (Worker Management > Init scripts) with:
-//   curl -fsSL https://claude.ai/install.sh | bash && cp /root/.local/share/claude/versions/* /usr/bin/claude
-// See https://www.windmill.dev/docs/core_concepts/worker_groups#init-scripts
-const CLAUDE_CODE_EXECUTABLE = "/usr/bin/claude";
-
 export async function main(anthropic: RT.Anthropic, agent_instructions?: AgentInstructions) {
-
-  if (!fs.existsSync(CLAUDE_CODE_EXECUTABLE)) {
-    throw new Error(
-      `Claude Code CLI not found at ${CLAUDE_CODE_EXECUTABLE}. It is not bundled in the default Windmill image. ` +
-      `Install it on this worker with an init script (Worker Management > Init scripts):\n` +
-      `  curl -fsSL https://claude.ai/install.sh | bash && cp /root/.local/share/claude/versions/* /usr/bin/claude\n` +
-      `See https://www.windmill.dev/docs/core_concepts/worker_groups#init-scripts`
-    );
-  }
 
   const sessionFile = path.join(".claude/session-id.txt");
 
@@ -55,7 +42,7 @@ export async function main(anthropic: RT.Anthropic, agent_instructions?: AgentIn
     prompt,
     options: {
       model: "opus",
-      pathToClaudeCodeExecutable: CLAUDE_CODE_EXECUTABLE,
+      pathToClaudeCodeExecutable: "/usr/bin/claude",
       permissionMode: 'bypassPermissions',
       allowDangerouslySkipPermissions: true,
       ...(isResume ? { resume: sessionId } : {}),


### PR DESCRIPTION
## What & why

Trims two large, optional binaries from the default Windmill runtime image, each with a clear "how to add it back" path so nothing silently breaks.

| Removed | Size | Used by | Fallback when absent |
|---|---|---|---|
| **helm** `v3.14.3` | ~48 MB | user jobs calling `helm` | `/usr/bin/helm` stub prints removal notice + init-script example, exits 127 |
| **Claude Code CLI** | **~245 MB** | the claude sandbox script template only | the agent SDK's own preflight throws "executable not found at /usr/bin/claude…"; template header comment documents the init-script install |

Neither is needed by Windmill itself — in particular, **autoscaling talks to the Kubernetes API via the `kube` Rust crate, not `kubectl`/`helm`**, and the `# sandbox <image>` runtime uses `crane` + nsjail, not the docker client.

## Changes

### helm (`Dockerfile`)
- Flip `WITH_HELM` default `true` → `false`. `--build-arg WITH_HELM=true` restores the real binary (that branch is unchanged).
- When not bundled, install a `helm` **stub** at **`/usr/bin/helm`** — deliberately last in the image PATH, so any real helm an init script installs (to `/usr/local/bin`, `~/.local/bin`, `/tmp/.local/bin`, …) shadows it automatically. The stub prints the removal notice, an example init script, and the docs link, then exits 127.

### Claude Code CLI (`Dockerfile` + template)
- Gate the install behind a new `ARG WITH_CLAUDE_CODE=false`. `--build-arg WITH_CLAUDE_CODE=true` installs it as before. When off, **nothing** is installed at `/usr/bin/claude` (no stub — see below).
- `frontend/src/lib/templates/claude_sandbox.ts.template`: **no runtime logic added** — just a two-line header comment documenting the worker-init-script install. When the binary is absent the `@anthropic-ai/claude-agent-sdk` `query()` already preflights `pathToClaudeCodeExecutable` and throws:
  > `Claude Code executable not found at /usr/bin/claude. Please ensure Claude Code is installed via native installer or specify a valid path with options.pathToClaudeCodeExecutable.`

  A stub was **deliberately avoided**: it would make the path exist so the SDK spawns it, and the SDK sets the child's stderr to `"ignore"` by default, discarding the stub's message and leaving only an opaque `exited with code 127`. Absence yields the clearer error, and the header comment supplies the Windmill-specific next step (the SDK message only says "native installer"):
  ```
  // Requires the Claude Code CLI at /usr/bin/claude — not in the default image. Install it via a
  // worker init script: curl -fsSL https://claude.ai/install.sh | bash && cp /root/.local/share/claude/versions/* /usr/bin/claude
  ```

### Drive-by: stale python-fallback comments
While auditing the image I noticed the lockfile-less Python fallback comments still said "3.11", but the fallback is `PyVAlias::default()` which moved to **3.12** in #7405. Reworded the comments and the dedicated-worker warn log to reference "the default version" so they won't re-stale on the next bump. No behavior change.

## Validation

- **Docker**: `docker build --check` + real builds of both the helm and claude `RUN` blocks, each branch — confirmed the conditionals and that standalone `#` comment lines inside a `RUN` are stripped (don't swallow the command). Verified the helm stub shadowing with a PATH-resolution test.
- **SDK behavior**: read the installed `claude-agent-sdk` source — confirmed it `existsSync`-checks `pathToClaudeCodeExecutable` and throws the clear "executable not found" error, and that it defaults child stderr to `"ignore"` (why a stub would be worse).
- **Frontend**: loaded the Claude Sandbox template in the script editor via Playwright — renders with just the two header comment lines, no leftover logic. No console errors attributable to the change (only pre-existing ATA `node:*` 404s).
- **Backend**: `cargo watch` rebuilt clean and healthy after the comment edits.
- Measured sizes directly: helm 48.3 MB, Claude Code CLI native binary 245 MB.

## Screenshots

Claude Sandbox template after simplification (two header comment lines, no runtime guard):

![claude-sandbox-template-comment](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2144-remove-helm-from-default-image-with-init-script-guide/1783507603-claude-sandbox-template-comment.png)

Fixes WIN-2144

🤖 Generated with [Claude Code](https://claude.com/claude-code)