### PR TITLE
feat: add datatable read and write MCP tools

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -14470,6 +14470,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "sqlparser 0.59.0",
  "sqlx",
  "strum",
  "tokio",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -14473,6 +14473,7 @@ dependencies = [
  "sqlx",
  "strum",
  "tokio",
+ "tokio-postgres",
  "tracing",
  "uuid",
  "windmill-api-auth",

--- a/backend/windmill-api-workspaces/Cargo.toml
+++ b/backend/windmill-api-workspaces/Cargo.toml
@@ -47,6 +47,7 @@ serde_json.workspace = true
 sha2.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
+tokio-postgres.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 strum.workspace = true

--- a/backend/windmill-api-workspaces/Cargo.toml
+++ b/backend/windmill-api-workspaces/Cargo.toml
@@ -46,6 +46,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 sqlx.workspace = true
+sqlparser = { version = "0.59.0", features = ["visitor"] }
 tokio.workspace = true
 tokio-postgres.workspace = true
 tracing.workspace = true

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -131,6 +131,9 @@ pub fn workspaced_service() -> Router {
             "/get_datatable_table_schema",
             get(get_datatable_table_schema),
         )
+        .route("/query_datatable", get(query_datatable))
+        .route("/insert_datatable", post(insert_datatable))
+        .route("/update_datatable", post(update_datatable))
         .route("/edit_datatable_config", post(edit_datatable_config))
         .route("/git_sync_enabled", get(get_git_sync_enabled))
         .route("/edit_git_sync_config", post(edit_git_sync_config))
@@ -1875,6 +1878,261 @@ fn is_system_pg_schema(schema_name: &str) -> bool {
     ) || schema_name.starts_with("pg_")
 }
 
+// ---------------------------------------------------------------------------
+// Datatable data operations (read/write) — exposed as MCP tools.
+//
+// These connect directly to the datatable's underlying Postgres (same idiom as
+// `get_datatable_schema`) and run a single, structurally-fixed statement. Only
+// the SELECT/INSERT/UPDATE shape is ours; identifiers are always quoted and
+// values are bound through `jsonb_populate_record` so Postgres does the type
+// coercion, never string interpolation. A caller-supplied `where_clause` is the
+// one raw fragment — it is trusted like the DB-manager's predicate, and because
+// `client.query`/`execute` prepare a single statement, it cannot chain a second
+// one.
+// ---------------------------------------------------------------------------
+
+const DATATABLE_QUERY_MAX_LIMIT: i64 = 1000;
+const DATATABLE_QUERY_DEFAULT_LIMIT: i64 = 100;
+
+fn default_public_schema() -> String {
+    "public".to_string()
+}
+
+/// Connect to a datatable's underlying Postgres, spawning the connection driver.
+async fn connect_datatable(
+    db: &DB,
+    w_id: &str,
+    datatable_name: &str,
+) -> Result<tokio_postgres::Client> {
+    let db_resource = get_datatable_resource_from_db_unchecked(db, w_id, datatable_name).await?;
+    let pg_db: PgDatabase = serde_json::from_value(db_resource)
+        .map_err(|e| Error::internal_err(format!("Failed to parse database credentials: {}", e)))?;
+    let (client, connection) = pg_db.connect(Some(db)).await?;
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            tracing::error!("Datatable connection error: {}", e);
+        }
+    });
+    Ok(client)
+}
+
+/// Quote a Postgres identifier by doubling embedded quotes. Rejects empty
+/// identifiers and NUL bytes so a column/table/schema name can never break out
+/// of the quotes.
+fn quote_pg_ident(ident: &str) -> Result<String> {
+    if ident.is_empty() || ident.contains('\0') {
+        return Err(Error::BadRequest(format!(
+            "Invalid SQL identifier: {:?}",
+            ident
+        )));
+    }
+    Ok(format!("\"{}\"", ident.replace('"', "\"\"")))
+}
+
+fn check_datatable_schema(schema_name: &str) -> Result<()> {
+    if is_system_pg_schema(schema_name) {
+        return Err(Error::BadRequest(format!(
+            "Schema '{}' is a system schema and cannot be used for datatable data operations",
+            schema_name
+        )));
+    }
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct QueryDataTableQuery {
+    datatable_name: String,
+    #[serde(default = "default_public_schema")]
+    schema_name: String,
+    table_name: String,
+    /// Raw SQL predicate AND-ed into the SELECT (e.g. `status = 'active' AND age > 18`).
+    where_clause: Option<String>,
+    /// Comma-separated columns to return. Defaults to all columns.
+    select: Option<String>,
+    /// Raw ORDER BY expression (e.g. `created_at DESC`).
+    order_by: Option<String>,
+    limit: Option<i64>,
+    offset: Option<i64>,
+}
+
+/// SELECT rows from a datatable table with an optional WHERE predicate.
+async fn query_datatable(
+    _authed: ApiAuthed,
+    Extension(db): Extension<DB>,
+    Path(w_id): Path<String>,
+    Query(q): Query<QueryDataTableQuery>,
+) -> JsonResult<Vec<serde_json::Value>> {
+    check_datatable_schema(&q.schema_name)?;
+
+    let limit = q
+        .limit
+        .unwrap_or(DATATABLE_QUERY_DEFAULT_LIMIT)
+        .clamp(1, DATATABLE_QUERY_MAX_LIMIT);
+    let offset = q.offset.unwrap_or(0).max(0);
+
+    let qualified = format!(
+        "{}.{}",
+        quote_pg_ident(&q.schema_name)?,
+        quote_pg_ident(&q.table_name)?
+    );
+
+    let select_list = match q.select.as_ref().filter(|s| !s.trim().is_empty()) {
+        Some(cols) => cols
+            .split(',')
+            .map(|c| quote_pg_ident(c.trim()))
+            .collect::<Result<Vec<_>>>()?
+            .join(", "),
+        None => "*".to_string(),
+    };
+
+    let mut inner = format!("SELECT {} FROM {}", select_list, qualified);
+    if let Some(w) = q.where_clause.as_ref().filter(|w| !w.trim().is_empty()) {
+        inner.push_str(&format!(" WHERE {}", w));
+    }
+    if let Some(o) = q.order_by.as_ref().filter(|o| !o.trim().is_empty()) {
+        inner.push_str(&format!(" ORDER BY {}", o));
+    }
+    inner.push_str(&format!(" LIMIT {} OFFSET {}", limit, offset));
+
+    let sql = format!("SELECT to_jsonb(_wm_row) AS row FROM ({}) _wm_row", inner);
+
+    let client = connect_datatable(&db, &w_id, &q.datatable_name).await?;
+    let rows = client
+        .query(&sql, &[])
+        .await
+        .map_err(|e| Error::BadRequest(format!("Datatable query failed: {}", e)))?;
+
+    let out = rows
+        .into_iter()
+        .map(|r| r.get::<_, serde_json::Value>(0))
+        .collect();
+    Ok(Json(out))
+}
+
+#[derive(Deserialize)]
+struct InsertDataTableRequest {
+    datatable_name: String,
+    #[serde(default = "default_public_schema")]
+    schema_name: String,
+    table_name: String,
+    /// Column name -> value. Types are coerced by Postgres from the JSON object;
+    /// columns not listed keep their table default.
+    values: serde_json::Map<String, serde_json::Value>,
+}
+
+/// INSERT a single row into a datatable table, returning the inserted row.
+async fn insert_datatable(
+    _authed: ApiAuthed,
+    Extension(db): Extension<DB>,
+    Path(w_id): Path<String>,
+    Json(req): Json<InsertDataTableRequest>,
+) -> JsonResult<serde_json::Value> {
+    check_datatable_schema(&req.schema_name)?;
+    if req.values.is_empty() {
+        return Err(Error::BadRequest(
+            "`values` must contain at least one column".to_string(),
+        ));
+    }
+
+    let qualified = format!(
+        "{}.{}",
+        quote_pg_ident(&req.schema_name)?,
+        quote_pg_ident(&req.table_name)?
+    );
+
+    let cols = req
+        .values
+        .keys()
+        .map(|k| quote_pg_ident(k))
+        .collect::<Result<Vec<_>>>()?;
+    let col_list = cols.join(", ");
+    let select_list = cols.join(", ");
+
+    let json_obj = serde_json::Value::Object(req.values.clone());
+    let sql = format!(
+        "INSERT INTO {qualified} AS _wm_t ({col_list}) \
+         SELECT {select_list} FROM jsonb_populate_record(NULL::{qualified}, $1::jsonb) \
+         RETURNING to_jsonb(_wm_t)"
+    );
+
+    let client = connect_datatable(&db, &w_id, &req.datatable_name).await?;
+    let row = client
+        .query_one(&sql, &[&json_obj])
+        .await
+        .map_err(|e| Error::BadRequest(format!("Datatable insert failed: {}", e)))?;
+
+    Ok(Json(row.get::<_, serde_json::Value>(0)))
+}
+
+#[derive(Deserialize)]
+struct UpdateDataTableRequest {
+    datatable_name: String,
+    #[serde(default = "default_public_schema")]
+    schema_name: String,
+    table_name: String,
+    /// Column name -> new value. Types are coerced by Postgres from the JSON object.
+    set: serde_json::Map<String, serde_json::Value>,
+    /// Raw SQL predicate selecting which rows to update. Required to prevent an
+    /// accidental full-table update.
+    where_clause: String,
+}
+
+/// UPDATE rows of a datatable table matching a WHERE predicate. Returns the
+/// number of updated rows.
+async fn update_datatable(
+    _authed: ApiAuthed,
+    Extension(db): Extension<DB>,
+    Path(w_id): Path<String>,
+    Json(req): Json<UpdateDataTableRequest>,
+) -> JsonResult<serde_json::Value> {
+    check_datatable_schema(&req.schema_name)?;
+    if req.set.is_empty() {
+        return Err(Error::BadRequest(
+            "`set` must contain at least one column".to_string(),
+        ));
+    }
+    if req.where_clause.trim().is_empty() {
+        return Err(Error::BadRequest(
+            "`where_clause` is required to avoid updating the whole table".to_string(),
+        ));
+    }
+
+    let qualified = format!(
+        "{}.{}",
+        quote_pg_ident(&req.schema_name)?,
+        quote_pg_ident(&req.table_name)?
+    );
+
+    // Each SET value is pulled as a scalar out of a per-column
+    // `jsonb_populate_record` so there is no FROM-join — the WHERE predicate's
+    // bare column names then resolve unambiguously to the target table.
+    let set_clause = req
+        .set
+        .keys()
+        .map(|k| {
+            let col = quote_pg_ident(k)?;
+            Ok(format!(
+                "{col} = (jsonb_populate_record(NULL::{qualified}, $1::jsonb)).{col}"
+            ))
+        })
+        .collect::<Result<Vec<_>>>()?
+        .join(", ");
+
+    let json_obj = serde_json::Value::Object(req.set.clone());
+    let sql = format!(
+        "UPDATE {qualified} SET {set_clause} WHERE {}",
+        req.where_clause
+    );
+
+    let client = connect_datatable(&db, &w_id, &req.datatable_name).await?;
+    let updated = client
+        .execute(&sql, &[&json_obj])
+        .await
+        .map_err(|e| Error::BadRequest(format!("Datatable update failed: {}", e)))?;
+
+    Ok(Json(serde_json::json!({ "updated": updated })))
+}
+
 fn compact_column_type(
     udt_name: String,
     is_nullable: String,
@@ -1920,6 +2178,24 @@ mod tests {
             compact_column_type("text".to_string(), "NO".to_string(), Some(default)),
             format!("text={}...", "é".repeat(27))
         );
+    }
+
+    #[test]
+    fn quote_pg_ident_wraps_and_escapes() {
+        assert_eq!(quote_pg_ident("id").unwrap(), "\"id\"");
+        assert_eq!(quote_pg_ident("my Table").unwrap(), "\"my Table\"");
+        // A caller injecting a closing quote must be neutralized by doubling it,
+        // not by breaking out of the quotes.
+        assert_eq!(
+            quote_pg_ident("a\"; DROP TABLE t; --").unwrap(),
+            "\"a\"\"; DROP TABLE t; --\""
+        );
+    }
+
+    #[test]
+    fn quote_pg_ident_rejects_empty_and_nul() {
+        assert!(quote_pg_ident("").is_err());
+        assert!(quote_pg_ident("a\0b").is_err());
     }
 }
 

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -1939,6 +1939,109 @@ fn check_datatable_schema(schema_name: &str) -> Result<()> {
     Ok(())
 }
 
+/// Datatable data writes resolve credentials through the unchecked resolver
+/// (there is no per-resource ACL on a data table, mirroring the read handlers),
+/// so gate the mutating endpoints to non-operator workspace members — operators
+/// are the workspace's read-mostly tier and must not write shared data.
+fn require_datatable_writer(authed: &ApiAuthed) -> Result<()> {
+    if authed.is_operator {
+        return Err(Error::NotAuthorized(
+            "Operators cannot write to data tables".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Flags any nested `SELECT` (subquery) inside an expression tree.
+struct SubqueryDetector {
+    found: bool,
+}
+impl sqlparser::ast::Visitor for SubqueryDetector {
+    type Break = ();
+    fn pre_visit_query(
+        &mut self,
+        _query: &sqlparser::ast::Query,
+    ) -> std::ops::ControlFlow<Self::Break> {
+        self.found = true;
+        std::ops::ControlFlow::Break(())
+    }
+}
+
+fn expr_has_subquery(expr: &sqlparser::ast::Expr) -> bool {
+    use sqlparser::ast::Visit;
+    let mut det = SubqueryDetector { found: false };
+    let _ = expr.visit(&mut det);
+    det.found
+}
+
+/// Validate a caller-supplied SQL boolean predicate (a `WHERE` body) and return
+/// its canonical, parser-rendered form. Parsing plus re-serialization is what
+/// makes interpolation safe: a fragment that tries to close the surrounding
+/// query and append a `UNION` (`false) _wm_row UNION ALL SELECT …`), smuggle a
+/// comment, or embed a subquery (`… = (SELECT secret …)`) is rejected here, and
+/// the returned string is the parser's own rendering of a single scalar
+/// expression — never the raw bytes. NB: the datatable connection role's own
+/// privileges remain the trust boundary — a permitted expression may still call
+/// any function that role can (e.g. `pg_sleep`), so scope datatable roles
+/// accordingly.
+fn sanitize_sql_predicate(input: &str, field: &str) -> Result<String> {
+    let dialect = sqlparser::dialect::PostgreSqlDialect {};
+    let mut parser = sqlparser::parser::Parser::new(&dialect)
+        .try_with_sql(input)
+        .map_err(|e| Error::BadRequest(format!("Invalid {}: {}", field, e)))?;
+    let expr = parser
+        .parse_expr()
+        .map_err(|e| Error::BadRequest(format!("Invalid {}: {}", field, e)))?;
+    if parser.peek_token().token != sqlparser::tokenizer::Token::EOF {
+        return Err(Error::BadRequest(format!(
+            "{} must be a single boolean expression",
+            field
+        )));
+    }
+    if expr_has_subquery(&expr) {
+        return Err(Error::BadRequest(format!(
+            "subqueries are not allowed in {}",
+            field
+        )));
+    }
+    Ok(expr.to_string())
+}
+
+/// Validate a caller-supplied `ORDER BY` list and return its canonical form.
+/// Same defense as `sanitize_sql_predicate`: it must parse as the ORDER BY of a
+/// plain single `SELECT` (no set operations, no subqueries, no trailing tokens).
+fn sanitize_sql_order_by(input: &str) -> Result<String> {
+    let dialect = sqlparser::dialect::PostgreSqlDialect {};
+    let statements =
+        sqlparser::parser::Parser::parse_sql(&dialect, &format!("SELECT 1 ORDER BY {}", input))
+            .map_err(|e| Error::BadRequest(format!("Invalid order_by: {}", e)))?;
+    let query = match statements.as_slice() {
+        [sqlparser::ast::Statement::Query(q)] => q,
+        _ => return Err(Error::BadRequest("Invalid order_by".to_string())),
+    };
+    if !matches!(query.body.as_ref(), sqlparser::ast::SetExpr::Select(_)) {
+        return Err(Error::BadRequest(
+            "order_by must not contain set operations".to_string(),
+        ));
+    }
+    let exprs = match query.order_by.as_ref().map(|o| &o.kind) {
+        Some(sqlparser::ast::OrderByKind::Expressions(exprs)) => exprs,
+        _ => return Err(Error::BadRequest("Invalid order_by".to_string())),
+    };
+    for oe in exprs {
+        if expr_has_subquery(&oe.expr) {
+            return Err(Error::BadRequest(
+                "subqueries are not allowed in order_by".to_string(),
+            ));
+        }
+    }
+    Ok(exprs
+        .iter()
+        .map(|oe| oe.to_string())
+        .collect::<Vec<_>>()
+        .join(", "))
+}
+
 #[derive(Deserialize)]
 struct QueryDataTableQuery {
     datatable_name: String,
@@ -1987,10 +2090,13 @@ async fn query_datatable(
 
     let mut inner = format!("SELECT {} FROM {}", select_list, qualified);
     if let Some(w) = q.where_clause.as_ref().filter(|w| !w.trim().is_empty()) {
-        inner.push_str(&format!(" WHERE {}", w));
+        inner.push_str(&format!(
+            " WHERE {}",
+            sanitize_sql_predicate(w, "where_clause")?
+        ));
     }
     if let Some(o) = q.order_by.as_ref().filter(|o| !o.trim().is_empty()) {
-        inner.push_str(&format!(" ORDER BY {}", o));
+        inner.push_str(&format!(" ORDER BY {}", sanitize_sql_order_by(o)?));
     }
     inner.push_str(&format!(" LIMIT {} OFFSET {}", limit, offset));
 
@@ -2022,11 +2128,12 @@ struct InsertDataTableRequest {
 
 /// INSERT a single row into a datatable table, returning the inserted row.
 async fn insert_datatable(
-    _authed: ApiAuthed,
+    authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Path(w_id): Path<String>,
     Json(req): Json<InsertDataTableRequest>,
 ) -> JsonResult<serde_json::Value> {
+    require_datatable_writer(&authed)?;
     check_datatable_schema(&req.schema_name)?;
     if req.values.is_empty() {
         return Err(Error::BadRequest(
@@ -2080,11 +2187,12 @@ struct UpdateDataTableRequest {
 /// UPDATE rows of a datatable table matching a WHERE predicate. Returns the
 /// number of updated rows.
 async fn update_datatable(
-    _authed: ApiAuthed,
+    authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Path(w_id): Path<String>,
     Json(req): Json<UpdateDataTableRequest>,
 ) -> JsonResult<serde_json::Value> {
+    require_datatable_writer(&authed)?;
     check_datatable_schema(&req.schema_name)?;
     if req.set.is_empty() {
         return Err(Error::BadRequest(
@@ -2096,6 +2204,7 @@ async fn update_datatable(
             "`where_clause` is required to avoid updating the whole table".to_string(),
         ));
     }
+    let where_clause = sanitize_sql_predicate(&req.where_clause, "where_clause")?;
 
     let qualified = format!(
         "{}.{}",
@@ -2119,10 +2228,7 @@ async fn update_datatable(
         .join(", ");
 
     let json_obj = serde_json::Value::Object(req.set.clone());
-    let sql = format!(
-        "UPDATE {qualified} SET {set_clause} WHERE {}",
-        req.where_clause
-    );
+    let sql = format!("UPDATE {qualified} SET {set_clause} WHERE {}", where_clause);
 
     let client = connect_datatable(&db, &w_id, &req.datatable_name).await?;
     let updated = client
@@ -2196,6 +2302,46 @@ mod tests {
     fn quote_pg_ident_rejects_empty_and_nul() {
         assert!(quote_pg_ident("").is_err());
         assert!(quote_pg_ident("a\0b").is_err());
+    }
+
+    #[test]
+    fn sanitize_predicate_accepts_and_canonicalizes() {
+        assert_eq!(
+            sanitize_sql_predicate("status = 'active' AND age > 18", "where_clause").unwrap(),
+            "status = 'active' AND age > 18"
+        );
+        // A trailing comment is dropped by re-serialization, so it can never
+        // comment out the surrounding LIMIT/paren once interpolated.
+        let out = sanitize_sql_predicate("active = true --", "where_clause").unwrap();
+        assert!(!out.contains("--"));
+    }
+
+    #[test]
+    fn sanitize_predicate_rejects_injection() {
+        // Subquery-closing UNION breakout (the reported P0).
+        assert!(sanitize_sql_predicate(
+            "false) _wm_row UNION ALL SELECT to_jsonb(s) AS row FROM pg_catalog.pg_tables s --",
+            "where_clause"
+        )
+        .is_err());
+        // Error-based / IN subqueries reaching other tables.
+        assert!(
+            sanitize_sql_predicate("1 = (SELECT count(*) FROM users)", "where_clause").is_err()
+        );
+        assert!(sanitize_sql_predicate("id IN (SELECT id FROM other)", "where_clause").is_err());
+        // Anything with trailing tokens beyond one expression.
+        assert!(sanitize_sql_predicate("true) extra", "where_clause").is_err());
+    }
+
+    #[test]
+    fn sanitize_order_by_accepts_and_rejects() {
+        assert_eq!(
+            sanitize_sql_order_by("created_at DESC").unwrap(),
+            "created_at DESC"
+        );
+        assert_eq!(sanitize_sql_order_by("a, b DESC").unwrap(), "a, b DESC");
+        assert!(sanitize_sql_order_by("id) UNION ALL SELECT 1 --").is_err());
+        assert!(sanitize_sql_order_by("(SELECT 1)").is_err());
     }
 }
 

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -4495,6 +4495,8 @@ paths:
     get:
       summary: list Datatables
       operationId: listDataTables
+      x-mcp-tool: true
+      x-mcp-instructions: "Use this first to discover which data tables (named Postgres databases) exist in the workspace. Returns each data table's name; pass that name as `datatable_name` to the other data table tools."
       tags:
         - workspace
       parameters:
@@ -4540,6 +4542,8 @@ paths:
     get:
       summary: list tables of all connected Datatables
       operationId: listDataTableTables
+      x-mcp-tool: true
+      x-mcp-instructions: "Lists, for every data table in the workspace, its schemas and the tables inside them. Use this to find which tables you can read from or write to before calling getDataTableTableSchema or queryDataTable."
       tags:
         - workspace
       parameters:
@@ -4558,6 +4562,8 @@ paths:
     get:
       summary: get one Datatable table schema
       operationId: getDataTableTableSchema
+      x-mcp-tool: true
+      x-mcp-instructions: "Returns the columns of a single data table table, each with its Postgres type, nullability and default. Call this before queryDataTable/insertDataTable/updateDataTable so you know the exact column names and types."
       tags:
         - workspace
       parameters:
@@ -4584,6 +4590,158 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DataTableTableSchema"
+
+  /w/{workspace}/workspaces/query_datatable:
+    get:
+      summary: query rows from a datatable table
+      operationId: queryDataTable
+      x-mcp-tool: true
+      x-mcp-instructions: "Read rows from a data table table with an optional WHERE predicate. `where_clause` is a raw SQL boolean expression on the table's columns (e.g. `status = 'active' AND age > 18`); use single quotes for string literals. Only the columns you need should be listed in `select`. Results are capped at 1000 rows (default 100) — use `limit`, `offset` and `order_by` to page. Call getDataTableTableSchema first to learn the column names and types."
+      tags:
+        - workspace
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - name: datatable_name
+          in: query
+          required: true
+          description: "Name of the data table (from listDataTables)"
+          schema:
+            type: string
+        - name: table_name
+          in: query
+          required: true
+          description: "Table to read from"
+          schema:
+            type: string
+        - name: schema_name
+          in: query
+          required: false
+          description: "Postgres schema of the table (defaults to `public`)"
+          schema:
+            type: string
+        - name: select
+          in: query
+          required: false
+          description: "Comma-separated list of columns to return. Defaults to all columns."
+          schema:
+            type: string
+        - name: where_clause
+          in: query
+          required: false
+          description: "Raw SQL predicate on the table's columns (the WHERE clause body, without the `WHERE` keyword)."
+          schema:
+            type: string
+        - name: order_by
+          in: query
+          required: false
+          description: "Raw SQL ORDER BY expression, e.g. `created_at DESC`."
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          description: "Maximum number of rows to return (1-1000, default 100)."
+          schema:
+            type: integer
+        - name: offset
+          in: query
+          required: false
+          description: "Number of rows to skip, for pagination."
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: rows matching the query, each as a JSON object
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+
+  /w/{workspace}/workspaces/insert_datatable:
+    post:
+      summary: insert a row into a datatable table
+      operationId: insertDataTable
+      x-mcp-tool: true
+      x-mcp-instructions: "Insert a single row into a data table table. `values` maps column names to values; Postgres coerces the JSON values to each column's type. Columns you omit keep their table default (so you can leave out serial/auto-generated primary keys). Returns the full inserted row. Call getDataTableTableSchema first to learn the column names and types."
+      tags:
+        - workspace
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+      requestBody:
+        description: Row to insert
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [datatable_name, table_name, values]
+              properties:
+                datatable_name:
+                  type: string
+                  description: "Name of the data table (from listDataTables)"
+                table_name:
+                  type: string
+                  description: "Table to insert into"
+                schema_name:
+                  type: string
+                  description: "Postgres schema of the table (defaults to `public`)"
+                values:
+                  type: object
+                  description: "Column name -> value for the row to insert"
+      responses:
+        "200":
+          description: the inserted row as a JSON object
+          content:
+            application/json:
+              schema:
+                type: object
+
+  /w/{workspace}/workspaces/update_datatable:
+    post:
+      summary: update rows of a datatable table
+      operationId: updateDataTable
+      x-mcp-tool: true
+      x-mcp-instructions: "Update rows of a data table table that match a WHERE predicate. `set` maps column names to their new values (types are coerced by Postgres). `where_clause` is a raw SQL predicate selecting which rows to update and is REQUIRED to prevent an accidental full-table update — target rows precisely (e.g. by primary key). Returns the number of updated rows. Call getDataTableTableSchema first to learn the column names and types."
+      tags:
+        - workspace
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+      requestBody:
+        description: Update specification
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [datatable_name, table_name, set, where_clause]
+              properties:
+                datatable_name:
+                  type: string
+                  description: "Name of the data table (from listDataTables)"
+                table_name:
+                  type: string
+                  description: "Table to update"
+                schema_name:
+                  type: string
+                  description: "Postgres schema of the table (defaults to `public`)"
+                set:
+                  type: object
+                  description: "Column name -> new value"
+                where_clause:
+                  type: string
+                  description: "Raw SQL predicate selecting the rows to update (required)"
+      responses:
+        "200":
+          description: number of updated rows
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  updated:
+                    type: integer
 
   /w/{workspace}/workspaces/edit_ducklake_config:
     post:

--- a/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
+++ b/backend/windmill-api/src/mcp/auto_generated_endpoints.rs
@@ -59,6 +59,197 @@ pub fn all_tools() -> Vec<EndpointTool> {
         body_field_renames: None,
     },
     EndpointTool {
+        name: Cow::Borrowed("listDataTables"),
+        description: Cow::Borrowed("list Datatables"),
+        instructions: Cow::Borrowed("Use this first to discover which data tables (named Postgres databases) exist in the workspace. Returns each data table's name; pass that name as `datatable_name` to the other data table tools."),
+        path: Cow::Borrowed("/w/{workspace}/workspaces/list_datatables"),
+        method: Cow::Borrowed("GET"),
+        path_params_schema: None,
+        query_params_schema: None,
+        body_schema: None,
+        path_field_renames: None,
+        query_field_renames: None,
+        body_field_renames: None,
+    },
+    EndpointTool {
+        name: Cow::Borrowed("listDataTableTables"),
+        description: Cow::Borrowed("list tables of all connected Datatables"),
+        instructions: Cow::Borrowed("Lists, for every data table in the workspace, its schemas and the tables inside them. Use this to find which tables you can read from or write to before calling getDataTableTableSchema or queryDataTable."),
+        path: Cow::Borrowed("/w/{workspace}/workspaces/list_datatable_tables"),
+        method: Cow::Borrowed("GET"),
+        path_params_schema: None,
+        query_params_schema: None,
+        body_schema: None,
+        path_field_renames: None,
+        query_field_renames: None,
+        body_field_renames: None,
+    },
+    EndpointTool {
+        name: Cow::Borrowed("getDataTableTableSchema"),
+        description: Cow::Borrowed("get one Datatable table schema"),
+        instructions: Cow::Borrowed("Returns the columns of a single data table table, each with its Postgres type, nullability and default. Call this before queryDataTable/insertDataTable/updateDataTable so you know the exact column names and types."),
+        path: Cow::Borrowed("/w/{workspace}/workspaces/get_datatable_table_schema"),
+        method: Cow::Borrowed("GET"),
+        path_params_schema: None,
+        query_params_schema: Some(serde_json::json!({
+        "type": "object",
+        "properties": {
+                "datatable_name": {
+                        "type": "string"
+                },
+                "schema_name": {
+                        "type": "string"
+                },
+                "table_name": {
+                        "type": "string"
+                }
+        },
+        "required": [
+                "datatable_name",
+                "schema_name",
+                "table_name"
+        ]
+})),
+        body_schema: None,
+        path_field_renames: None,
+        query_field_renames: None,
+        body_field_renames: None,
+    },
+    EndpointTool {
+        name: Cow::Borrowed("queryDataTable"),
+        description: Cow::Borrowed("query rows from a datatable table"),
+        instructions: Cow::Borrowed("Read rows from a data table table with an optional WHERE predicate. `where_clause` is a raw SQL boolean expression on the table's columns (e.g. `status = 'active' AND age > 18`); use single quotes for string literals. Only the columns you need should be listed in `select`. Results are capped at 1000 rows (default 100) — use `limit`, `offset` and `order_by` to page. Call getDataTableTableSchema first to learn the column names and types."),
+        path: Cow::Borrowed("/w/{workspace}/workspaces/query_datatable"),
+        method: Cow::Borrowed("GET"),
+        path_params_schema: None,
+        query_params_schema: Some(serde_json::json!({
+        "type": "object",
+        "properties": {
+                "datatable_name": {
+                        "type": "string",
+                        "description": "Name of the data table (from listDataTables)"
+                },
+                "table_name": {
+                        "type": "string",
+                        "description": "Table to read from"
+                },
+                "schema_name": {
+                        "type": "string",
+                        "description": "Postgres schema of the table (defaults to `public`)"
+                },
+                "select": {
+                        "type": "string",
+                        "description": "Comma-separated list of columns to return. Defaults to all columns."
+                },
+                "where_clause": {
+                        "type": "string",
+                        "description": "Raw SQL predicate on the table's columns (the WHERE clause body, without the `WHERE` keyword)."
+                },
+                "order_by": {
+                        "type": "string",
+                        "description": "Raw SQL ORDER BY expression, e.g. `created_at DESC`."
+                },
+                "limit": {
+                        "type": "integer",
+                        "description": "Maximum number of rows to return (1-1000, default 100)."
+                },
+                "offset": {
+                        "type": "integer",
+                        "description": "Number of rows to skip, for pagination."
+                }
+        },
+        "required": [
+                "datatable_name",
+                "table_name"
+        ]
+})),
+        body_schema: None,
+        path_field_renames: None,
+        query_field_renames: None,
+        body_field_renames: None,
+    },
+    EndpointTool {
+        name: Cow::Borrowed("insertDataTable"),
+        description: Cow::Borrowed("insert a row into a datatable table"),
+        instructions: Cow::Borrowed("Insert a single row into a data table table. `values` maps column names to values; Postgres coerces the JSON values to each column's type. Columns you omit keep their table default (so you can leave out serial/auto-generated primary keys). Returns the full inserted row. Call getDataTableTableSchema first to learn the column names and types."),
+        path: Cow::Borrowed("/w/{workspace}/workspaces/insert_datatable"),
+        method: Cow::Borrowed("POST"),
+        path_params_schema: None,
+        query_params_schema: None,
+        body_schema: Some(serde_json::json!({
+        "type": "object",
+        "required": [
+                "datatable_name",
+                "table_name",
+                "values"
+        ],
+        "properties": {
+                "datatable_name": {
+                        "type": "string",
+                        "description": "Name of the data table (from listDataTables)"
+                },
+                "table_name": {
+                        "type": "string",
+                        "description": "Table to insert into"
+                },
+                "schema_name": {
+                        "type": "string",
+                        "description": "Postgres schema of the table (defaults to `public`)"
+                },
+                "values": {
+                        "type": "object",
+                        "description": "Column name -> value for the row to insert"
+                }
+        }
+})),
+        path_field_renames: None,
+        query_field_renames: None,
+        body_field_renames: None,
+    },
+    EndpointTool {
+        name: Cow::Borrowed("updateDataTable"),
+        description: Cow::Borrowed("update rows of a datatable table"),
+        instructions: Cow::Borrowed("Update rows of a data table table that match a WHERE predicate. `set` maps column names to their new values (types are coerced by Postgres). `where_clause` is a raw SQL predicate selecting which rows to update and is REQUIRED to prevent an accidental full-table update — target rows precisely (e.g. by primary key). Returns the number of updated rows. Call getDataTableTableSchema first to learn the column names and types."),
+        path: Cow::Borrowed("/w/{workspace}/workspaces/update_datatable"),
+        method: Cow::Borrowed("POST"),
+        path_params_schema: None,
+        query_params_schema: None,
+        body_schema: Some(serde_json::json!({
+        "type": "object",
+        "required": [
+                "datatable_name",
+                "table_name",
+                "set",
+                "where_clause"
+        ],
+        "properties": {
+                "datatable_name": {
+                        "type": "string",
+                        "description": "Name of the data table (from listDataTables)"
+                },
+                "table_name": {
+                        "type": "string",
+                        "description": "Table to update"
+                },
+                "schema_name": {
+                        "type": "string",
+                        "description": "Postgres schema of the table (defaults to `public`)"
+                },
+                "set": {
+                        "type": "object",
+                        "description": "Column name -> new value"
+                },
+                "where_clause": {
+                        "type": "string",
+                        "description": "Raw SQL predicate selecting the rows to update (required)"
+                }
+        }
+})),
+        path_field_renames: None,
+        query_field_renames: None,
+        body_field_renames: None,
+    },
+    EndpointTool {
         name: Cow::Borrowed("createVariable"),
         description: Cow::Borrowed("create variable"),
         instructions: Cow::Borrowed(""),

--- a/backend/windmill-api/src/mcp/core.rs
+++ b/backend/windmill-api/src/mcp/core.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use windmill_common::{db::UserDB, utils::StripPath, DB};
 use windmill_mcp::common::schema::enrich_resource_schemas;
+use windmill_mcp::common::scope::{parse_mcp_scopes, McpScopeConfig};
 use windmill_mcp::common::transform::apply_key_transformation;
 use windmill_mcp::common::types::{
     FlowInfo, HubScriptInfo, ResourceInfo, ResourceType, SchemaType, ScriptInfo,
@@ -46,6 +47,39 @@ use axum::{
 use windmill_common::{auth::hash_token, db::GatewayWorkspaceId, error::JsonResult};
 
 // McpAuth impl for ApiAuthed is in windmill-api-auth (same crate as the type)
+
+/// Datatable MCP tools that take a `datatable_name` argument and must be gated
+/// per-datatable by the `mcp:datatables:` scope.
+const DATATABLE_NAME_ARG_TOOLS: &[&str] = &[
+    "getDataTableTableSchema",
+    "queryDataTable",
+    "insertDataTable",
+    "updateDataTable",
+];
+
+/// Datatable list tools whose array response must be filtered to the allowed
+/// datatables, keyed by the JSON field naming each item's datatable.
+fn datatable_list_filter_key(tool_name: &str) -> Option<&'static str> {
+    match tool_name {
+        "listDataTables" => Some("name"),
+        "listDataTableTables" | "listDataTableSchemas" => Some("datatable_name"),
+        _ => None,
+    }
+}
+
+/// Per-datatable scope enforcement for MCP endpoint tools.
+///
+/// The proxied JWT minted for the HTTP call is route-scoped and no longer
+/// carries the `mcp:` scopes, so the restriction has to be applied here, where
+/// the original MCP token's scopes are still available. `None` means the token
+/// has no MCP scopes (not an MCP path) — no datatable gating applies.
+fn datatable_scope_config(auth: &ApiAuthed) -> Option<McpScopeConfig> {
+    let scopes = auth.scopes.as_deref()?;
+    if !scopes.iter().any(|s| s.starts_with("mcp:")) {
+        return None;
+    }
+    parse_mcp_scopes(scopes).ok()
+}
 
 /// Windmill's MCP backend implementation
 #[derive(Clone)]
@@ -281,6 +315,26 @@ impl McpBackend for WindmillBackend {
             }
         };
 
+        // Enforce per-datatable access for datatable tools that name a datatable
+        // in their args. Runs before the request so a disallowed datatable never
+        // reaches the DB.
+        let dt_scope = datatable_scope_config(auth);
+        if let Some(config) = &dt_scope {
+            if DATATABLE_NAME_ARG_TOOLS.contains(&endpoint_tool.name.as_ref()) {
+                if let Some(name) = args_map.get("datatable_name").and_then(|v| v.as_str()) {
+                    if !config.is_datatable_allowed(name) {
+                        return Err(ErrorData::invalid_params(
+                            format!(
+                                "Access denied: datatable '{}' is not in this token's scope",
+                                name
+                            ),
+                            None,
+                        ));
+                    }
+                }
+            }
+        }
+
         // Build URL with path substitutions
         let path_template = substitute_path_params(
             &endpoint_tool.path,
@@ -323,8 +377,25 @@ impl McpBackend for WindmillBackend {
         })?;
 
         if status.is_success() {
-            Ok(serde_json::from_str(&response_text)
-                .unwrap_or_else(|_| Value::String(response_text)))
+            let mut result: Value = serde_json::from_str(&response_text)
+                .unwrap_or_else(|_| Value::String(response_text));
+            // Filter datatable list responses down to the datatables this token
+            // is scoped to, so restricted tokens never even see other names.
+            if let Some(config) = &dt_scope {
+                if config.datatables_restricted && !config.all {
+                    if let Some(key) = datatable_list_filter_key(&endpoint_tool.name) {
+                        if let Value::Array(items) = &mut result {
+                            items.retain(|item| {
+                                item.get(key)
+                                    .and_then(|v| v.as_str())
+                                    .map(|n| config.is_datatable_allowed(n))
+                                    .unwrap_or(false)
+                            });
+                        }
+                    }
+                }
+            }
+            Ok(result)
         } else {
             Err(ErrorData::internal_error(
                 format!(

--- a/backend/windmill-api/src/mcp/core.rs
+++ b/backend/windmill-api/src/mcp/core.rs
@@ -382,16 +382,14 @@ impl McpBackend for WindmillBackend {
             // Filter datatable list responses down to the datatables this token
             // is scoped to, so restricted tokens never even see other names.
             if let Some(config) = &dt_scope {
-                if config.datatables_restricted && !config.all {
-                    if let Some(key) = datatable_list_filter_key(&endpoint_tool.name) {
-                        if let Value::Array(items) = &mut result {
-                            items.retain(|item| {
-                                item.get(key)
-                                    .and_then(|v| v.as_str())
-                                    .map(|n| config.is_datatable_allowed(n))
-                                    .unwrap_or(false)
-                            });
-                        }
+                if let Some(key) = datatable_list_filter_key(&endpoint_tool.name) {
+                    if let Value::Array(items) = &mut result {
+                        items.retain(|item| {
+                            item.get(key)
+                                .and_then(|v| v.as_str())
+                                .map(|n| config.is_datatable_allowed(n))
+                                .unwrap_or(false)
+                        });
                     }
                 }
             }

--- a/backend/windmill-api/src/mcp/oauth_server.rs
+++ b/backend/windmill-api/src/mcp/oauth_server.rs
@@ -231,6 +231,7 @@ fn supported_scopes() -> Vec<String> {
         "mcp:scripts:*".to_string(),
         "mcp:flows:*".to_string(),
         "mcp:endpoints:*".to_string(),
+        "mcp:datatables:*".to_string(),
     ]
 }
 

--- a/backend/windmill-api/src/mcp/oauth_server.rs
+++ b/backend/windmill-api/src/mcp/oauth_server.rs
@@ -231,7 +231,8 @@ fn supported_scopes() -> Vec<String> {
         "mcp:scripts:*".to_string(),
         "mcp:flows:*".to_string(),
         "mcp:endpoints:*".to_string(),
-        "mcp:datatables:*".to_string(),
+        "mcp:datatables:read:*".to_string(),
+        "mcp:datatables:write:*".to_string(),
     ]
 }
 

--- a/backend/windmill-mcp/src/common/scope.rs
+++ b/backend/windmill-mcp/src/common/scope.rs
@@ -12,6 +12,12 @@ pub struct McpScopeConfig {
     pub flows: Vec<String>,
     /// Endpoint names/patterns allowed by this token
     pub endpoints: Vec<String>,
+    /// Datatable names/patterns this token may read/write. Only meaningful when
+    /// `datatables_restricted` is set; otherwise datatable access is unrestricted.
+    pub datatables: Vec<String>,
+    /// Whether any `mcp:datatables:` scope was present. Absent = opt-out (all
+    /// datatables allowed, backward compatible); present = restrict to the list.
+    pub datatables_restricted: bool,
     /// Whether this is a legacy "all" scope
     pub all: bool,
     /// Whether this is a "favorites" scope
@@ -33,10 +39,22 @@ impl McpScopeConfig {
             "script" => &self.scripts,
             "flow" => &self.flows,
             "endpoint" => &self.endpoints,
+            "datatable" => &self.datatables,
             _ => return false,
         };
 
         is_resource_allowed(path, patterns)
+    }
+
+    /// Whether the token may touch datatable `name`. Datatable filtering is
+    /// opt-in: a token with no `mcp:datatables:` scope (`datatables_restricted`
+    /// false) may reach every datatable, so existing tokens keep working. Once a
+    /// restriction is present, only the listed names/patterns (or `*`) pass.
+    pub fn is_datatable_allowed(&self, name: &str) -> bool {
+        if self.all || !self.datatables_restricted {
+            return true;
+        }
+        is_resource_allowed(name, &self.datatables)
     }
 
     /// Directional subset check: does this config grant at least everything
@@ -73,6 +91,25 @@ impl McpScopeConfig {
                 None => return false,
             }
         }
+        // Datatable containment: an unrestricted request grants every datatable,
+        // so a restricted caller (without `*`) cannot cover it. A restricted
+        // request must be covered by the caller's list — treating an unrestricted
+        // caller as `*`.
+        if !requested.datatables_restricted {
+            if self.datatables_restricted && !self.datatables.iter().any(|d| d == "*") {
+                return false;
+            }
+        } else {
+            let caller = if self.datatables_restricted {
+                self.datatables.clone()
+            } else {
+                vec!["*".to_string()]
+            };
+            if !resource_list_covers(&caller, &requested.datatables) {
+                return false;
+            }
+        }
+
         resource_list_covers(&self.scripts, &requested.scripts)
             && resource_list_covers(&self.flows, &requested.flows)
             && resource_list_covers(&self.endpoints, &requested.endpoints)
@@ -120,6 +157,7 @@ pub fn parse_mcp_scopes(scopes: &[String]) -> Result<McpScopeConfig, String> {
             config.scripts.push("*".to_string());
             config.flows.push("*".to_string());
             config.endpoints.push("*".to_string());
+            config.datatables.push("*".to_string());
             continue;
         }
 
@@ -163,6 +201,13 @@ pub fn parse_mcp_scopes(scopes: &[String]) -> Result<McpScopeConfig, String> {
         if let Some(resources) = scope.strip_prefix("mcp:endpoints:") {
             // New granular endpoint scope: mcp:endpoints:name1,name2
             config.endpoints.extend(parse_resource_list(resources));
+            continue;
+        }
+
+        if let Some(resources) = scope.strip_prefix("mcp:datatables:") {
+            // Datatable restriction: mcp:datatables:name1,name2 or mcp:datatables:*
+            config.datatables_restricted = true;
+            config.datatables.extend(parse_resource_list(resources));
             continue;
         }
 
@@ -350,6 +395,46 @@ mod tests {
         assert!(subtree.contains(&cfg(&["mcp:scripts:f/team/sub"])));
         assert!(subtree.contains(&cfg(&["mcp:scripts:f/team/sub/*"])));
         assert!(!subtree.contains(&cfg(&["mcp:scripts:f/other/x"])));
+    }
+
+    #[test]
+    fn test_datatable_scope_parsing_and_allow() {
+        // No datatable scope => unrestricted (opt-in), every datatable allowed.
+        let c = cfg(&["mcp:endpoints:queryDataTable"]);
+        assert!(!c.datatables_restricted);
+        assert!(c.is_datatable_allowed("main"));
+        assert!(c.is_datatable_allowed("anything"));
+
+        // mcp:all grants all datatables.
+        assert!(cfg(&["mcp:all"]).is_datatable_allowed("main"));
+
+        // Explicit restriction to specific names.
+        let c = cfg(&["mcp:datatables:main,analytics"]);
+        assert!(c.datatables_restricted);
+        assert!(c.is_datatable_allowed("main"));
+        assert!(c.is_datatable_allowed("analytics"));
+        assert!(!c.is_datatable_allowed("secret"));
+
+        // Wildcard restriction allows all.
+        let c = cfg(&["mcp:datatables:*"]);
+        assert!(c.datatables_restricted);
+        assert!(c.is_datatable_allowed("anything"));
+    }
+
+    #[test]
+    fn test_contains_datatables() {
+        // Unrestricted caller covers a restricted request.
+        assert!(cfg(&["mcp:endpoints:*"]).contains(&cfg(&["mcp:datatables:main"])));
+        // Restricted caller covers a subset request.
+        assert!(cfg(&["mcp:datatables:main,analytics"]).contains(&cfg(&["mcp:datatables:main"])));
+        // Restricted caller must NOT widen into a sibling or into unrestricted.
+        assert!(!cfg(&["mcp:datatables:main"]).contains(&cfg(&["mcp:datatables:analytics"])));
+        assert!(!cfg(&["mcp:datatables:main"]).contains(&cfg(&["mcp:endpoints:queryDataTable"])));
+        // `*` restriction covers both a subset and an unrestricted request.
+        assert!(cfg(&["mcp:datatables:*"]).contains(&cfg(&["mcp:datatables:main"])));
+        assert!(cfg(&["mcp:datatables:*"]).contains(&cfg(&[])));
+        // mcp:all covers any datatable request.
+        assert!(cfg(&["mcp:all"]).contains(&cfg(&["mcp:datatables:main"])));
     }
 
     #[test]

--- a/backend/windmill-mcp/src/common/scope.rs
+++ b/backend/windmill-mcp/src/common/scope.rs
@@ -12,12 +12,15 @@ pub struct McpScopeConfig {
     pub flows: Vec<String>,
     /// Endpoint names/patterns allowed by this token
     pub endpoints: Vec<String>,
-    /// Datatable names/patterns this token may read/write. Only meaningful when
-    /// `datatables_restricted` is set; otherwise datatable access is unrestricted.
+    /// Whether the datatable read tools (list/query/get schema) are granted.
+    /// Datatable access is opt-in and off by default — it is never implied by the
+    /// generic endpoint or favorites scopes, only by an explicit `mcp:datatables:`
+    /// scope (or the legacy `mcp:all`).
+    pub datatables_read: bool,
+    /// Whether the datatable write tools (insert/update) are granted. Implies read.
+    pub datatables_write: bool,
+    /// Datatable names/patterns access is restricted to. `*` (or empty) means all.
     pub datatables: Vec<String>,
-    /// Whether any `mcp:datatables:` scope was present. Absent = opt-out (all
-    /// datatables allowed, backward compatible); present = restrict to the list.
-    pub datatables_restricted: bool,
     /// Whether this is a legacy "all" scope
     pub all: bool,
     /// Whether this is a "favorites" scope
@@ -39,22 +42,30 @@ impl McpScopeConfig {
             "script" => &self.scripts,
             "flow" => &self.flows,
             "endpoint" => &self.endpoints,
-            "datatable" => &self.datatables,
             _ => return false,
         };
 
         is_resource_allowed(path, patterns)
     }
 
-    /// Whether the token may touch datatable `name`. Datatable filtering is
-    /// opt-in: a token with no `mcp:datatables:` scope (`datatables_restricted`
-    /// false) may reach every datatable, so existing tokens keep working. Once a
-    /// restriction is present, only the listed names/patterns (or `*`) pass.
+    /// Whether datatable `name` is within this token's datatable restriction.
+    /// This is only the name filter — whether datatable access is granted at all
+    /// (and at which level) is `datatable_tool_allowed`. An empty list or `*`
+    /// means all datatables.
     pub fn is_datatable_allowed(&self, name: &str) -> bool {
-        if self.all || !self.datatables_restricted {
-            return true;
+        self.datatables.is_empty()
+            || self.datatables.iter().any(|d| d == "*")
+            || is_resource_allowed(name, &self.datatables)
+    }
+
+    /// Whether a datatable tool with the given access level (`"read"` or
+    /// `"write"`) may be exposed/called. Write tools require write access; read
+    /// tools require read (write implies read).
+    pub fn datatable_tool_allowed(&self, access: &str) -> bool {
+        match access {
+            "write" => self.datatables_write,
+            _ => self.datatables_read || self.datatables_write,
         }
-        is_resource_allowed(name, &self.datatables)
     }
 
     /// Directional subset check: does this config grant at least everything
@@ -91,21 +102,27 @@ impl McpScopeConfig {
                 None => return false,
             }
         }
-        // Datatable containment: an unrestricted request grants every datatable,
-        // so a restricted caller (without `*`) cannot cover it. A restricted
-        // request must be covered by the caller's list — treating an unrestricted
-        // caller as `*`.
-        if !requested.datatables_restricted {
-            if self.datatables_restricted && !self.datatables.iter().any(|d| d == "*") {
-                return false;
-            }
-        } else {
-            let caller = if self.datatables_restricted {
-                self.datatables.clone()
-            } else {
+        // Datatable containment: the caller must grant at least the requested
+        // access level, and its datatable name list must cover the requested one
+        // (empty list = all datatables, i.e. `*`).
+        if requested.datatables_read && !(self.datatables_read || self.datatables_write) {
+            return false;
+        }
+        if requested.datatables_write && !self.datatables_write {
+            return false;
+        }
+        if requested.datatables_read || requested.datatables_write {
+            let caller = if self.datatables.is_empty() {
                 vec!["*".to_string()]
+            } else {
+                self.datatables.clone()
             };
-            if !resource_list_covers(&caller, &requested.datatables) {
+            let req = if requested.datatables.is_empty() {
+                vec!["*".to_string()]
+            } else {
+                requested.datatables.clone()
+            };
+            if !resource_list_covers(&caller, &req) {
                 return false;
             }
         }
@@ -152,11 +169,14 @@ pub fn parse_mcp_scopes(scopes: &[String]) -> Result<McpScopeConfig, String> {
         }
 
         if scope == "mcp:all" {
-            // Legacy scope: grant access to everything
+            // Legacy scope: grant access to everything, including datatable
+            // read+write on every datatable.
             config.all = true;
             config.scripts.push("*".to_string());
             config.flows.push("*".to_string());
             config.endpoints.push("*".to_string());
+            config.datatables_read = true;
+            config.datatables_write = true;
             config.datatables.push("*".to_string());
             continue;
         }
@@ -204,10 +224,23 @@ pub fn parse_mcp_scopes(scopes: &[String]) -> Result<McpScopeConfig, String> {
             continue;
         }
 
-        if let Some(resources) = scope.strip_prefix("mcp:datatables:") {
-            // Datatable restriction: mcp:datatables:name1,name2 or mcp:datatables:*
-            config.datatables_restricted = true;
-            config.datatables.extend(parse_resource_list(resources));
+        if let Some(rest) = scope.strip_prefix("mcp:datatables:") {
+            // Datatable access (opt-in). Forms:
+            //   mcp:datatables:write:<names|*>  -> read+write on those datatables
+            //   mcp:datatables:read:<names|*>   -> read-only
+            //   mcp:datatables:<names|*>        -> read-only (shorthand)
+            let (write, names) = if let Some(n) = rest.strip_prefix("write:") {
+                (true, n)
+            } else if let Some(n) = rest.strip_prefix("read:") {
+                (false, n)
+            } else {
+                (false, rest)
+            };
+            config.datatables_read = true;
+            if write {
+                config.datatables_write = true;
+            }
+            config.datatables.extend(parse_resource_list(names));
             continue;
         }
 
@@ -217,6 +250,23 @@ pub fn parse_mcp_scopes(scopes: &[String]) -> Result<McpScopeConfig, String> {
     config.granular = !config.all && !config.favorites;
 
     Ok(config)
+}
+
+/// Classify an MCP endpoint tool as a datatable tool and its required access
+/// level (`"read"` or `"write"`), or `None` if it is not a datatable tool.
+/// Datatable tools are gated by the dedicated `mcp:datatables:` scope rather
+/// than the generic endpoint/all scopes, so both the tool lister and the caller
+/// need this classification.
+pub fn datatable_access_level(tool_name: &str) -> Option<&'static str> {
+    match tool_name {
+        "listDataTables"
+        | "listDataTableTables"
+        | "listDataTableSchemas"
+        | "getDataTableTableSchema"
+        | "queryDataTable" => Some("read"),
+        "insertDataTable" | "updateDataTable" => Some("write"),
+        _ => None,
+    }
 }
 
 /// Parse comma-separated resource list
@@ -398,43 +448,59 @@ mod tests {
     }
 
     #[test]
-    fn test_datatable_scope_parsing_and_allow() {
-        // No datatable scope => unrestricted (opt-in), every datatable allowed.
-        let c = cfg(&["mcp:endpoints:queryDataTable"]);
-        assert!(!c.datatables_restricted);
-        assert!(c.is_datatable_allowed("main"));
+    fn test_datatable_scope_opt_in_and_levels() {
+        // Datatable access is off by default — the generic endpoint/favorites
+        // scopes never grant it.
+        let c = cfg(&["mcp:endpoints:*"]);
+        assert!(!c.datatables_read && !c.datatables_write);
+        assert!(!c.datatable_tool_allowed("read"));
+        assert!(!c.datatable_tool_allowed("write"));
+
+        // mcp:all grants read+write on all datatables.
+        let c = cfg(&["mcp:all"]);
+        assert!(c.datatable_tool_allowed("read"));
+        assert!(c.datatable_tool_allowed("write"));
         assert!(c.is_datatable_allowed("anything"));
 
-        // mcp:all grants all datatables.
-        assert!(cfg(&["mcp:all"]).is_datatable_allowed("main"));
+        // Read scope grants read tools only.
+        let c = cfg(&["mcp:datatables:read:*"]);
+        assert!(c.datatable_tool_allowed("read"));
+        assert!(!c.datatable_tool_allowed("write"));
 
-        // Explicit restriction to specific names.
-        let c = cfg(&["mcp:datatables:main,analytics"]);
-        assert!(c.datatables_restricted);
+        // Write scope implies read.
+        let c = cfg(&["mcp:datatables:write:main,analytics"]);
+        assert!(c.datatable_tool_allowed("read"));
+        assert!(c.datatable_tool_allowed("write"));
         assert!(c.is_datatable_allowed("main"));
         assert!(c.is_datatable_allowed("analytics"));
         assert!(!c.is_datatable_allowed("secret"));
 
-        // Wildcard restriction allows all.
-        let c = cfg(&["mcp:datatables:*"]);
-        assert!(c.datatables_restricted);
-        assert!(c.is_datatable_allowed("anything"));
+        // Shorthand (no read/write segment) is read-only.
+        let c = cfg(&["mcp:datatables:main"]);
+        assert!(c.datatable_tool_allowed("read"));
+        assert!(!c.datatable_tool_allowed("write"));
+        assert!(c.is_datatable_allowed("main"));
+        assert!(!c.is_datatable_allowed("other"));
     }
 
     #[test]
     fn test_contains_datatables() {
-        // Unrestricted caller covers a restricted request.
-        assert!(cfg(&["mcp:endpoints:*"]).contains(&cfg(&["mcp:datatables:main"])));
-        // Restricted caller covers a subset request.
-        assert!(cfg(&["mcp:datatables:main,analytics"]).contains(&cfg(&["mcp:datatables:main"])));
-        // Restricted caller must NOT widen into a sibling or into unrestricted.
-        assert!(!cfg(&["mcp:datatables:main"]).contains(&cfg(&["mcp:datatables:analytics"])));
-        assert!(!cfg(&["mcp:datatables:main"]).contains(&cfg(&["mcp:endpoints:queryDataTable"])));
-        // `*` restriction covers both a subset and an unrestricted request.
-        assert!(cfg(&["mcp:datatables:*"]).contains(&cfg(&["mcp:datatables:main"])));
-        assert!(cfg(&["mcp:datatables:*"]).contains(&cfg(&[])));
+        // A write caller covers a read request on a subset.
+        assert!(cfg(&["mcp:datatables:write:main,analytics"])
+            .contains(&cfg(&["mcp:datatables:read:main"])));
+        // A read caller must NOT grant write.
+        assert!(!cfg(&["mcp:datatables:read:*"]).contains(&cfg(&["mcp:datatables:write:main"])));
+        // No datatable caller cannot grant datatable access.
+        assert!(!cfg(&["mcp:endpoints:*"]).contains(&cfg(&["mcp:datatables:read:main"])));
+        // Restricted caller must NOT widen into a sibling or into `*`.
+        assert!(
+            !cfg(&["mcp:datatables:read:main"]).contains(&cfg(&["mcp:datatables:read:analytics"]))
+        );
+        assert!(!cfg(&["mcp:datatables:read:main"]).contains(&cfg(&["mcp:datatables:read:*"])));
+        // `*` caller covers a subset request.
+        assert!(cfg(&["mcp:datatables:write:*"]).contains(&cfg(&["mcp:datatables:read:main"])));
         // mcp:all covers any datatable request.
-        assert!(cfg(&["mcp:all"]).contains(&cfg(&["mcp:datatables:main"])));
+        assert!(cfg(&["mcp:all"]).contains(&cfg(&["mcp:datatables:write:main"])));
     }
 
     #[test]

--- a/backend/windmill-mcp/src/server/runner.rs
+++ b/backend/windmill-mcp/src/server/runner.rs
@@ -244,7 +244,16 @@ impl<B: McpBackend> ServerHandler for Runner<B> {
         // Add endpoint tools from the generated MCP tools, filtered by scope
         let endpoint_tools = self.backend.all_endpoint_tools();
         for endpoint_tool in endpoint_tools {
-            if scope_config.granular && !scope_config.is_allowed("endpoint", &endpoint_tool.name) {
+            // Datatable tools are opt-in via the dedicated `mcp:datatables:` scope,
+            // independent of the generic endpoint/favorites/all scopes.
+            if let Some(access) = crate::common::scope::datatable_access_level(&endpoint_tool.name)
+            {
+                if !scope_config.datatable_tool_allowed(access) {
+                    continue;
+                }
+            } else if scope_config.granular
+                && !scope_config.is_allowed("endpoint", &endpoint_tool.name)
+            {
                 continue;
             }
             if read_only && !crate::server::is_endpoint_read_only(&endpoint_tool) {
@@ -276,8 +285,21 @@ impl<B: McpBackend> ServerHandler for Runner<B> {
         let endpoint_tools = self.backend.all_endpoint_tools();
         for endpoint_tool in &endpoint_tools {
             if endpoint_tool.name.as_ref() == request.name {
-                // Validate endpoint scope
-                if scope_config.granular
+                // Validate endpoint scope. Datatable tools are gated by the
+                // dedicated datatable scope, not the generic endpoint scope.
+                if let Some(access) =
+                    crate::common::scope::datatable_access_level(&endpoint_tool.name)
+                {
+                    if !scope_config.datatable_tool_allowed(access) {
+                        return Err(ErrorData::internal_error(
+                            format!(
+                                "Access denied: datatable {} access is not in this token's scope (tool '{}')",
+                                access, endpoint_tool.name
+                            ),
+                            None,
+                        ));
+                    }
+                } else if scope_config.granular
                     && !scope_config.is_allowed("endpoint", &endpoint_tool.name)
                 {
                     return Err(ErrorData::internal_error(

--- a/frontend/src/lib/components/mcp/McpScopeSelector.svelte
+++ b/frontend/src/lib/components/mcp/McpScopeSelector.svelte
@@ -6,7 +6,13 @@
 	import MultiSelect from '$lib/components/select/MultiSelect.svelte'
 	import { safeSelectItems } from '$lib/components/select/utils.svelte'
 	import TextInput from '$lib/components/text_input/TextInput.svelte'
-	import { FlowService, FolderService, IntegrationService, ScriptService } from '$lib/gen'
+	import {
+		FlowService,
+		FolderService,
+		IntegrationService,
+		ScriptService,
+		WorkspaceService
+	} from '$lib/gen'
 	import { mcpEndpointTools } from '$lib/mcpEndpointTools'
 	import InfoIcon from 'lucide-svelte/icons/info'
 	import { SvelteMap } from 'svelte/reactivity'
@@ -47,6 +53,9 @@
 	let selectedScripts = $state<string[]>(parsedInitial.scripts)
 	let selectedFlows = $state<string[]>(parsedInitial.flows)
 	let selectedEndpoints = $state<string[]>(parsedInitial.endpoints)
+	let selectedDatatables = $state<string[]>(parsedInitial.datatables)
+	let allDatatables = $state<string[]>([])
+	let loadingDatatables = $state(false)
 	let customScriptPatterns = $state<string>(parsedInitial.scriptPatterns)
 	let customFlowPatterns = $state<string>(parsedInitial.flowPatterns)
 	let newMcpApps = $state<string[]>(parsedInitial.hubApps)
@@ -74,6 +83,7 @@
 		scripts: string[]
 		flows: string[]
 		endpoints: string[]
+		datatables: string[]
 		scriptPatterns: string
 		flowPatterns: string
 		hubApps: string[]
@@ -86,6 +96,7 @@
 			scripts: [],
 			flows: [],
 			endpoints: [],
+			datatables: [],
 			scriptPatterns: '',
 			flowPatterns: '',
 			hubApps: []
@@ -112,6 +123,8 @@
 				byKind.flows = parsePatterns(part.slice('mcp:flows:'.length))
 			} else if (part.startsWith('mcp:endpoints:')) {
 				byKind.endpoints = parsePatterns(part.slice('mcp:endpoints:'.length))
+			} else if (part.startsWith('mcp:datatables:')) {
+				byKind.datatables = parsePatterns(part.slice('mcp:datatables:'.length))
 			}
 		}
 
@@ -136,6 +149,7 @@
 				scripts: [],
 				flows: [],
 				endpoints: [],
+				datatables: [],
 				scriptPatterns: '',
 				flowPatterns: '',
 				hubApps
@@ -157,6 +171,7 @@
 			scripts: [],
 			flows: [],
 			endpoints: byKind.endpoints ?? [],
+			datatables: byKind.datatables ?? [],
 			scriptPatterns: (byKind.scripts ?? []).join(','),
 			flowPatterns: (byKind.flows ?? []).join(','),
 			hubApps
@@ -186,6 +201,12 @@
 
 			if (selectedEndpoints.length > 0) {
 				scopeParts.push(`mcp:endpoints:${selectedEndpoints.join(',')}`)
+			}
+
+			// Restrict which data tables the datatable tools may touch. Omitting
+			// this leaves datatable access unrestricted (all data tables).
+			if (selectedDatatables.length > 0) {
+				scopeParts.push(`mcp:datatables:${selectedDatatables.join(',')}`)
 			}
 		} else if (selectedMode === 'folder') {
 			const folderPaths = selectedFolders.map((f) => `f/${f}/*`).join(',')
@@ -377,6 +398,31 @@
 		}
 	})
 
+	let datatablesCache = new Map<string, string[]>()
+	async function loadDatatables(workspace: string) {
+		if (datatablesCache.has(workspace)) {
+			allDatatables = datatablesCache.get(workspace)!
+			return
+		}
+		try {
+			loadingDatatables = true
+			const names = (await WorkspaceService.listDataTables({ workspace })).map((d) => d.name)
+			datatablesCache.set(workspace, names)
+			allDatatables = names
+		} catch {
+			allDatatables = []
+		} finally {
+			loadingDatatables = false
+		}
+	}
+
+	// Load data table names for the custom-mode restriction picker
+	$effect(() => {
+		if (selectedMode === 'custom' && workspaceId) {
+			loadDatatables(workspaceId)
+		}
+	})
+
 	// One-shot: once allScripts/allFlows are loaded, split the
 	// initial pattern text into known paths (selectedScripts/Flows) vs
 	// remaining wildcards/unknowns (kept in pattern textbox).
@@ -432,6 +478,12 @@
 	}
 	function clearAllEndpoints() {
 		selectedEndpoints = []
+	}
+	function selectAllDatatables() {
+		selectedDatatables = [...allDatatables]
+	}
+	function clearAllDatatables() {
+		selectedDatatables = []
 	}
 </script>
 
@@ -553,9 +605,28 @@
 					/>
 				</div>
 
+				{#if allDatatables.length > 0 || loadingDatatables}
+					<div class="flex flex-col gap-2 mt-2">
+						{@render sectionHeader('Data tables', selectAllDatatables, clearAllDatatables)}
+						{#if loadingDatatables}
+							<p class="text-xs text-primary">Loading data tables...</p>
+						{:else}
+							<MultiSelect
+								items={safeSelectItems(allDatatables)}
+								placeholder="Restrict to specific data tables (leave empty for all)"
+								bind:value={selectedDatatables}
+							/>
+							<p class="text-xs text-tertiary">
+								Applies only to the datatable tools (query/insert/update/list). Leave empty to allow
+								every data table.
+							</p>
+						{/if}
+					</div>
+				{/if}
+
 				<div class="text-xs text-primary mt-2">
 					Selected: {selectedScripts.length} scripts, {selectedFlows.length} flows, {selectedEndpoints.length}
-					endpoints
+					endpoints{#if selectedDatatables.length > 0}, {selectedDatatables.length} data tables{/if}
 				</div>
 
 				<!-- Wildcard Patterns Section -->

--- a/frontend/src/lib/components/mcp/McpScopeSelector.svelte
+++ b/frontend/src/lib/components/mcp/McpScopeSelector.svelte
@@ -14,6 +14,7 @@
 		WorkspaceService
 	} from '$lib/gen'
 	import { mcpEndpointTools } from '$lib/mcpEndpointTools'
+	import Toggle from '../Toggle.svelte'
 	import InfoIcon from 'lucide-svelte/icons/info'
 	import { SvelteMap } from 'svelte/reactivity'
 
@@ -26,10 +27,24 @@
 
 	let { workspaceId, scope = $bindable(), initialScope, readOnly = false }: Props = $props()
 
+	// Datatable tools are controlled by the dedicated "Data tables" section, not
+	// the generic API-endpoint picker, so they're excluded from that list.
+	const DATATABLE_TOOL_NAMES = new Set([
+		'listDataTables',
+		'listDataTableTables',
+		'listDataTableSchemas',
+		'getDataTableTableSchema',
+		'queryDataTable',
+		'insertDataTable',
+		'updateDataTable'
+	])
+
 	// Endpoints we can actually advertise to a read-only MCP token. Mirrors the
-	// runner's filter (only GET endpoints).
+	// runner's filter (only GET endpoints) and drops the datatable tools.
 	const visibleEndpointTools = $derived(
-		readOnly ? mcpEndpointTools.filter((e) => e.method === 'GET') : mcpEndpointTools
+		(readOnly ? mcpEndpointTools.filter((e) => e.method === 'GET') : mcpEndpointTools).filter(
+			(e) => !DATATABLE_TOOL_NAMES.has(e.name)
+		)
 	)
 
 	// When read-only flips on, prune already-selected non-GET endpoints so the
@@ -54,6 +69,8 @@
 	let selectedFlows = $state<string[]>(parsedInitial.flows)
 	let selectedEndpoints = $state<string[]>(parsedInitial.endpoints)
 	let selectedDatatables = $state<string[]>(parsedInitial.datatables)
+	let datatablesEnabled = $state(parsedInitial.datatablesEnabled)
+	let datatablesWrite = $state(parsedInitial.datatablesWrite)
 	let allDatatables = $state<string[]>([])
 	let loadingDatatables = $state(false)
 	let customScriptPatterns = $state<string>(parsedInitial.scriptPatterns)
@@ -84,6 +101,8 @@
 		flows: string[]
 		endpoints: string[]
 		datatables: string[]
+		datatablesEnabled: boolean
+		datatablesWrite: boolean
 		scriptPatterns: string
 		flowPatterns: string
 		hubApps: string[]
@@ -97,6 +116,8 @@
 			flows: [],
 			endpoints: [],
 			datatables: [],
+			datatablesEnabled: false,
+			datatablesWrite: false,
 			scriptPatterns: '',
 			flowPatterns: '',
 			hubApps: []
@@ -109,6 +130,9 @@
 		const byKind: Record<string, string[]> = {}
 		let mode: ParsedScope['mode'] = 'custom'
 		const hubApps: string[] = []
+		let datatablesEnabled = false
+		let datatablesWrite = false
+		let datatableNames: string[] = []
 
 		for (const part of parts) {
 			if (part === 'mcp:favorites') {
@@ -124,9 +148,19 @@
 			} else if (part.startsWith('mcp:endpoints:')) {
 				byKind.endpoints = parsePatterns(part.slice('mcp:endpoints:'.length))
 			} else if (part.startsWith('mcp:datatables:')) {
-				byKind.datatables = parsePatterns(part.slice('mcp:datatables:'.length))
+				datatablesEnabled = true
+				let rest = part.slice('mcp:datatables:'.length)
+				if (rest.startsWith('write:')) {
+					datatablesWrite = true
+					rest = rest.slice('write:'.length)
+				} else if (rest.startsWith('read:')) {
+					rest = rest.slice('read:'.length)
+				}
+				// `*` means "all data tables" — an empty explicit selection.
+				datatableNames = parsePatterns(rest).filter((n) => n !== '*')
 			}
 		}
+		const dt = { datatables: datatableNames, datatablesEnabled, datatablesWrite }
 
 		// Detect folder mode: scripts and flows are exclusively `f/X/*` patterns
 		// for the same set of folders, and endpoints is exactly `*`.
@@ -149,7 +183,7 @@
 				scripts: [],
 				flows: [],
 				endpoints: [],
-				datatables: [],
+				...dt,
 				scriptPatterns: '',
 				flowPatterns: '',
 				hubApps
@@ -157,7 +191,7 @@
 		}
 
 		if (mode === 'favorites' || mode === 'all') {
-			return { ...empty, mode, hubApps }
+			return { ...empty, mode, hubApps, ...dt }
 		}
 
 		// Custom mode: split each list into "selectable" entries (later filtered
@@ -171,7 +205,7 @@
 			scripts: [],
 			flows: [],
 			endpoints: byKind.endpoints ?? [],
-			datatables: byKind.datatables ?? [],
+			...dt,
 			scriptPatterns: (byKind.scripts ?? []).join(','),
 			flowPatterns: (byKind.flows ?? []).join(','),
 			hubApps
@@ -202,12 +236,6 @@
 			if (selectedEndpoints.length > 0) {
 				scopeParts.push(`mcp:endpoints:${selectedEndpoints.join(',')}`)
 			}
-
-			// Restrict which data tables the datatable tools may touch. Omitting
-			// this leaves datatable access unrestricted (all data tables).
-			if (selectedDatatables.length > 0) {
-				scopeParts.push(`mcp:datatables:${selectedDatatables.join(',')}`)
-			}
 		} else if (selectedMode === 'folder') {
 			const folderPaths = selectedFolders.map((f) => `f/${f}/*`).join(',')
 			if (selectedFolders.length > 0) {
@@ -219,6 +247,14 @@
 
 		if (newMcpApps.length > 0) {
 			scopeParts.push(`mcp:hub:${newMcpApps.join(',')}`)
+		}
+
+		// Data table access is opt-in and independent of the mode. In "all" mode
+		// `mcp:all` already grants full datatable access, so no separate scope.
+		if (datatablesEnabled && selectedMode !== 'all') {
+			const level = datatablesWrite && !readOnly ? 'write' : 'read'
+			const names = selectedDatatables.length > 0 ? selectedDatatables.join(',') : '*'
+			scopeParts.push(`mcp:datatables:${level}:${names}`)
 		}
 
 		scope = scopeParts.join(' ')
@@ -416,10 +452,18 @@
 		}
 	}
 
-	// Load data table names for the custom-mode restriction picker
+	// Load data table names once the Data tables section is enabled.
 	$effect(() => {
-		if (selectedMode === 'custom' && workspaceId) {
+		if (datatablesEnabled && workspaceId) {
 			loadDatatables(workspaceId)
+		}
+	})
+
+	// A read-only token can never expose the write tools, so keep the write
+	// sub-toggle off while read-only is on.
+	$effect(() => {
+		if (readOnly && datatablesWrite) {
+			datatablesWrite = false
 		}
 	})
 
@@ -478,12 +522,6 @@
 	}
 	function clearAllEndpoints() {
 		selectedEndpoints = []
-	}
-	function selectAllDatatables() {
-		selectedDatatables = [...allDatatables]
-	}
-	function clearAllDatatables() {
-		selectedDatatables = []
 	}
 </script>
 
@@ -550,6 +588,53 @@
 		{/if}
 	</div>
 
+	{#if selectedMode !== 'all'}
+		<div class="flex flex-col gap-2 rounded-md border border-surface-hover p-3">
+			<Toggle
+				bind:checked={datatablesEnabled}
+				options={{
+					right: 'Data tables',
+					rightTooltip:
+						'Expose tools to read (and optionally write) the workspace data tables directly via MCP.'
+				}}
+				size="2xs"
+			/>
+			{#if datatablesEnabled}
+				<p class="text-xs text-tertiary">
+					This grants the MCP client <b>full access to the data</b> in the selected data tables (all
+					of them if none is selected). Data tables have no per-user or row-level permissions yet
+					<span class="text-secondary">(coming soon)</span>, so only enable this for trusted or
+					development use.
+				</p>
+
+				{#if !readOnly}
+					<Toggle
+						bind:checked={datatablesWrite}
+						options={{
+							right: 'Write access (insert & update)',
+							rightTooltip:
+								'Also expose the insert and update tools. Leave off for read-only access.'
+						}}
+						size="2xs"
+					/>
+				{/if}
+
+				<span class="block text-xs font-semibold mt-1">Restrict to specific data tables</span>
+				{#if loadingDatatables}
+					<p class="text-xs text-primary">Loading data tables...</p>
+				{:else if allDatatables.length > 0}
+					<MultiSelect
+						items={safeSelectItems(allDatatables)}
+						placeholder="Leave empty to allow all data tables"
+						bind:value={selectedDatatables}
+					/>
+				{:else}
+					<p class="text-xs text-primary">No data tables configured in this workspace.</p>
+				{/if}
+			{/if}
+		</div>
+	{/if}
+
 	{#if selectedMode === 'custom'}
 		{#if loadingRunnables}
 			<div class="flex flex-col gap-2">
@@ -605,28 +690,9 @@
 					/>
 				</div>
 
-				{#if allDatatables.length > 0 || loadingDatatables}
-					<div class="flex flex-col gap-2 mt-2">
-						{@render sectionHeader('Data tables', selectAllDatatables, clearAllDatatables)}
-						{#if loadingDatatables}
-							<p class="text-xs text-primary">Loading data tables...</p>
-						{:else}
-							<MultiSelect
-								items={safeSelectItems(allDatatables)}
-								placeholder="Restrict to specific data tables (leave empty for all)"
-								bind:value={selectedDatatables}
-							/>
-							<p class="text-xs text-tertiary">
-								Applies only to the datatable tools (query/insert/update/list). Leave empty to allow
-								every data table.
-							</p>
-						{/if}
-					</div>
-				{/if}
-
 				<div class="text-xs text-primary mt-2">
 					Selected: {selectedScripts.length} scripts, {selectedFlows.length} flows, {selectedEndpoints.length}
-					endpoints{#if selectedDatatables.length > 0}, {selectedDatatables.length} data tables{/if}
+					endpoints
 				</div>
 
 				<!-- Wildcard Patterns Section -->

--- a/frontend/src/lib/mcpEndpointTools.ts
+++ b/frontend/src/lib/mcpEndpointTools.ts
@@ -69,6 +69,197 @@ export const mcpEndpointTools: EndpointTool[] = [
         bodyFieldRenames: undefined
     },
     {
+        name: "listDataTables",
+        description: "list Datatables",
+        instructions: "Use this first to discover which data tables (named Postgres databases) exist in the workspace. Returns each data table's name; pass that name as `datatable_name` to the other data table tools.",
+        path: "/w/{workspace}/workspaces/list_datatables",
+        method: "GET",
+        pathParamsSchema: undefined,
+        queryParamsSchema: undefined,
+        bodySchema: undefined,
+        pathFieldRenames: undefined,
+        queryFieldRenames: undefined,
+        bodyFieldRenames: undefined
+    },
+    {
+        name: "listDataTableTables",
+        description: "list tables of all connected Datatables",
+        instructions: "Lists, for every data table in the workspace, its schemas and the tables inside them. Use this to find which tables you can read from or write to before calling getDataTableTableSchema or queryDataTable.",
+        path: "/w/{workspace}/workspaces/list_datatable_tables",
+        method: "GET",
+        pathParamsSchema: undefined,
+        queryParamsSchema: undefined,
+        bodySchema: undefined,
+        pathFieldRenames: undefined,
+        queryFieldRenames: undefined,
+        bodyFieldRenames: undefined
+    },
+    {
+        name: "getDataTableTableSchema",
+        description: "get one Datatable table schema",
+        instructions: "Returns the columns of a single data table table, each with its Postgres type, nullability and default. Call this before queryDataTable/insertDataTable/updateDataTable so you know the exact column names and types.",
+        path: "/w/{workspace}/workspaces/get_datatable_table_schema",
+        method: "GET",
+        pathParamsSchema: undefined,
+        queryParamsSchema: {
+        "type": "object",
+        "properties": {
+                "datatable_name": {
+                        "type": "string"
+                },
+                "schema_name": {
+                        "type": "string"
+                },
+                "table_name": {
+                        "type": "string"
+                }
+        },
+        "required": [
+                "datatable_name",
+                "schema_name",
+                "table_name"
+        ]
+},
+        bodySchema: undefined,
+        pathFieldRenames: undefined,
+        queryFieldRenames: undefined,
+        bodyFieldRenames: undefined
+    },
+    {
+        name: "queryDataTable",
+        description: "query rows from a datatable table",
+        instructions: "Read rows from a data table table with an optional WHERE predicate. `where_clause` is a raw SQL boolean expression on the table's columns (e.g. `status = 'active' AND age > 18`); use single quotes for string literals. Only the columns you need should be listed in `select`. Results are capped at 1000 rows (default 100) — use `limit`, `offset` and `order_by` to page. Call getDataTableTableSchema first to learn the column names and types.",
+        path: "/w/{workspace}/workspaces/query_datatable",
+        method: "GET",
+        pathParamsSchema: undefined,
+        queryParamsSchema: {
+        "type": "object",
+        "properties": {
+                "datatable_name": {
+                        "type": "string",
+                        "description": "Name of the data table (from listDataTables)"
+                },
+                "table_name": {
+                        "type": "string",
+                        "description": "Table to read from"
+                },
+                "schema_name": {
+                        "type": "string",
+                        "description": "Postgres schema of the table (defaults to `public`)"
+                },
+                "select": {
+                        "type": "string",
+                        "description": "Comma-separated list of columns to return. Defaults to all columns."
+                },
+                "where_clause": {
+                        "type": "string",
+                        "description": "Raw SQL predicate on the table's columns (the WHERE clause body, without the `WHERE` keyword)."
+                },
+                "order_by": {
+                        "type": "string",
+                        "description": "Raw SQL ORDER BY expression, e.g. `created_at DESC`."
+                },
+                "limit": {
+                        "type": "integer",
+                        "description": "Maximum number of rows to return (1-1000, default 100)."
+                },
+                "offset": {
+                        "type": "integer",
+                        "description": "Number of rows to skip, for pagination."
+                }
+        },
+        "required": [
+                "datatable_name",
+                "table_name"
+        ]
+},
+        bodySchema: undefined,
+        pathFieldRenames: undefined,
+        queryFieldRenames: undefined,
+        bodyFieldRenames: undefined
+    },
+    {
+        name: "insertDataTable",
+        description: "insert a row into a datatable table",
+        instructions: "Insert a single row into a data table table. `values` maps column names to values; Postgres coerces the JSON values to each column's type. Columns you omit keep their table default (so you can leave out serial/auto-generated primary keys). Returns the full inserted row. Call getDataTableTableSchema first to learn the column names and types.",
+        path: "/w/{workspace}/workspaces/insert_datatable",
+        method: "POST",
+        pathParamsSchema: undefined,
+        queryParamsSchema: undefined,
+        bodySchema: {
+        "type": "object",
+        "required": [
+                "datatable_name",
+                "table_name",
+                "values"
+        ],
+        "properties": {
+                "datatable_name": {
+                        "type": "string",
+                        "description": "Name of the data table (from listDataTables)"
+                },
+                "table_name": {
+                        "type": "string",
+                        "description": "Table to insert into"
+                },
+                "schema_name": {
+                        "type": "string",
+                        "description": "Postgres schema of the table (defaults to `public`)"
+                },
+                "values": {
+                        "type": "object",
+                        "description": "Column name -> value for the row to insert"
+                }
+        }
+},
+        pathFieldRenames: undefined,
+        queryFieldRenames: undefined,
+        bodyFieldRenames: undefined
+    },
+    {
+        name: "updateDataTable",
+        description: "update rows of a datatable table",
+        instructions: "Update rows of a data table table that match a WHERE predicate. `set` maps column names to their new values (types are coerced by Postgres). `where_clause` is a raw SQL predicate selecting which rows to update and is REQUIRED to prevent an accidental full-table update — target rows precisely (e.g. by primary key). Returns the number of updated rows. Call getDataTableTableSchema first to learn the column names and types.",
+        path: "/w/{workspace}/workspaces/update_datatable",
+        method: "POST",
+        pathParamsSchema: undefined,
+        queryParamsSchema: undefined,
+        bodySchema: {
+        "type": "object",
+        "required": [
+                "datatable_name",
+                "table_name",
+                "set",
+                "where_clause"
+        ],
+        "properties": {
+                "datatable_name": {
+                        "type": "string",
+                        "description": "Name of the data table (from listDataTables)"
+                },
+                "table_name": {
+                        "type": "string",
+                        "description": "Table to update"
+                },
+                "schema_name": {
+                        "type": "string",
+                        "description": "Postgres schema of the table (defaults to `public`)"
+                },
+                "set": {
+                        "type": "object",
+                        "description": "Column name -> new value"
+                },
+                "where_clause": {
+                        "type": "string",
+                        "description": "Raw SQL predicate selecting the rows to update (required)"
+                }
+        }
+},
+        pathFieldRenames: undefined,
+        queryFieldRenames: undefined,
+        bodyFieldRenames: undefined
+    },
+    {
         name: "createVariable",
         description: "create variable",
         instructions: "",


### PR DESCRIPTION
## Summary

Fixes WIN-2143.

Exposes Windmill **data tables** as MCP operations. Data table access is a dedicated, **opt-in capability** in the MCP URL generator — off by default in every mode — with a read/write sub-toggle and an optional restriction to specific data tables. When enabled, the client gets tools to list tables, read rows (with WHERE conditions), and (if write is on) insert/update rows.

New/existing REST endpoints are marked `x-mcp-tool: true` in the OpenAPI spec and auto-generated into the Rust tool registry + the frontend endpoint list; the datatable tools are then gated by a dedicated `mcp:datatables:` scope rather than the generic endpoint scopes.

### Tools
Read: `listDataTables`, `listDataTableTables`, `getDataTableTableSchema` *(existing endpoints, now MCP-exposed)*, and new `queryDataTable` (SELECT with `where_clause`/`select`/`order_by`/`limit`/`offset`, capped at 1000).
Write: new `insertDataTable` (row insert; omitted columns keep their default) and `updateDataTable` (update rows matching a required `where_clause`).

### Data tables access control
A dedicated **"Data tables"** section (shown in every mode except "All", where `mcp:all` already grants everything):
- **Master toggle** — off by default. Datatable tools are never exposed unless this is on, independent of the favorites/all/folder/endpoint scopes.
- **Write access** sub-toggle — off by default (read-only); hidden when the token is read-only. On ⇒ also exposes insert/update.
- **Restrict to specific data tables** — optional multiselect; empty = all data tables.
- A warning that this grants **full access to the data** (no per-user/row-level permissions on data tables yet — coming soon — so it's meant for trusted/dev use).

Scope grammar: `mcp:datatables:read:<names|*>` / `mcp:datatables:write:<names|*>`. Absence ⇒ no datatable access. `mcp:all` grants read+write on all data tables.

Enforcement:
- **Tool exposure**: gated in the MCP runner by `datatable_tool_allowed(read|write)` — datatable tools are opt-in regardless of mode; write tools also require a non-read-only token (they're POST).
- **Per-datatable name + list filtering**: in `WindmillBackend::call_endpoint` (the only place with the original MCP scopes — the JWT the runner mints for the proxied HTTP call is route-scoped and no longer carries `mcp:` scopes). Per-call `datatable_name` is rejected if out of scope; `listDataTables`/`listDataTableTables` responses are filtered so a restricted token never sees other names.

## Changes
- `backend/windmill-api-workspaces/src/workspaces.rs`: `query_datatable`/`insert_datatable`/`update_datatable` handlers + `connect_datatable`/`quote_pg_ident`/`check_datatable_schema` helpers and routes.
- `backend/windmill-api/openapi.yaml`: six datatable endpoints marked `x-mcp-tool`; regenerated `auto_generated_endpoints.rs` + `mcpEndpointTools.ts`.
- `backend/windmill-mcp/src/common/scope.rs`: `datatables_read`/`datatables_write`/`datatables` on `McpScopeConfig`; parse `mcp:datatables:read|write:`; `datatable_access_level`, `datatable_tool_allowed`, `is_datatable_allowed`; OAuth subset (`contains`); tests.
- `backend/windmill-mcp/src/server/runner.rs`: gate datatable tools by the dedicated scope in `list_tools` + `call_tool`.
- `backend/windmill-api/src/mcp/core.rs`: per-datatable arg check + list-response filtering in `call_endpoint`.
- `backend/windmill-api/src/mcp/oauth_server.rs`: advertise `mcp:datatables:read:*`/`write:*`.
- `frontend/src/lib/components/mcp/McpScopeSelector.svelte`: dedicated Data tables section (master + write toggle + restriction picker + warning); datatable tools excluded from the generic endpoint picker.
- `tokio-postgres` dep on `windmill-api-workspaces`; unit tests for `quote_pg_ident` and the datatable scope logic.

## Safety
- Identifiers (schema/table/column/select) always quoted via `quote_pg_ident` (doubles `"`, rejects empty/NUL).
- Values bound as one `$1::jsonb` param via `jsonb_populate_record` — Postgres coerces types, no value interpolation.
- `where_clause`/`order_by` are **validated with `sqlparser` and re-serialized from the parsed AST** before interpolation: a fragment must be a single self-contained predicate / ORDER-BY list with no set operations, no subqueries, and no trailing tokens. This blocks the `UNION`/subquery-closing breakout (which would otherwise bypass the system-schema guard and LIMIT) and the error-based/`IN (SELECT …)` cross-table exfiltration. Complex boolean predicates and multi-column ordering still work.
- Residual trust boundary: a permitted expression can still call any function the datatable's **connection role** is granted (`pg_sleep`, or `pg_read_file` if that role is superuser) — scope datatable roles accordingly (not superuser).
- Datatable access requires the explicit `mcp:datatables:` scope; write additionally requires a non-read-only token, and the REST write endpoints reject **operators** (`require_datatable_writer`).

## Design decisions
- Datatable access is **off by default and orthogonal to scripts/flows/endpoints** — only the dedicated toggle (or `mcp:all`) grants it.
- Data tables are PostgreSQL only (DuckLake is a separate substrate); non-postgres fails at connect with a clear error.

## Test plan
- [x] `cargo check` (windmill-api, windmill-api-workspaces); `cargo test -p windmill-mcp scope::` (9 tests) and `-p windmill-api-workspaces` (quote_pg_ident + `where_clause`/`order_by` sanitizer incl. the reported UNION-injection payload)
- [x] Verified the exact handler SQL against a real Postgres via `psql` (type coercion, serial default, `to_jsonb`, per-column update, quoted identifiers)
- [x] `npm run check:fast`; svelte-autofixer
- [x] Browser: "Data tables" toggle is off by default in Favorites mode; enabling reveals the warning + Write toggle + restriction picker; datatable tools are absent from the generic API Endpoints list; generating with write + `main` produces token scope `mcp:favorites mcp:datatables:write:main` (verified in the DB)
- [ ] End-to-end MCP client call against a live data table, incl. a read-only token rejected on write and a restricted token rejected on an out-of-scope data table

## Screenshots

Dedicated "Data tables" section — opt-in master toggle, write sub-toggle, restriction picker, and access warning:
![mcp-datatable-toggle](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2143-add-datatable-read-and-write-as-mcp-operations/1783510854-mcp-datatable-toggle.png)

MCP URL generator — datatable read tools shown (read-only token hides insert/update):
![mcp-datatable-readonly](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2143-add-datatable-read-and-write-as-mcp-operations/1783496770-mcp-datatable-readonly.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
