### PR TITLE
feat: shared tab system, universal markdown code blocks, subtle scrollbars

### DIFF
--- a/frontend/src/lib/assets/app.css
+++ b/frontend/src/lib/assets/app.css
@@ -129,6 +129,36 @@
 			scrollbar-width: none; /* Firefox */
 		}
 	}
+
+	/* Subtle scrollbar: a thin, rounded thumb that only appears on hover, on both
+	   axes. Shared by ScrollableX (tab strips, code blocks) and the AI chat. Size
+	   via the `--wm-scrollbar-size` var (default 6px). Higher specificity than the
+	   app-wide `*::-webkit-scrollbar`, so it overrides it. */
+	.scrollbar-subtle {
+		scrollbar-width: thin;
+		scrollbar-color: transparent transparent;
+	}
+	.scrollbar-subtle:hover {
+		scrollbar-color: rgb(var(--color-text-hint) / 0.4) transparent;
+	}
+	.scrollbar-subtle::-webkit-scrollbar {
+		width: var(--wm-scrollbar-size, 6px);
+		height: var(--wm-scrollbar-size, 6px);
+	}
+	.scrollbar-subtle::-webkit-scrollbar-track {
+		background: transparent;
+	}
+	.scrollbar-subtle::-webkit-scrollbar-thumb {
+		background: transparent;
+		border-radius: 9999px;
+		transition: background-color 0.15s;
+	}
+	.scrollbar-subtle:hover::-webkit-scrollbar-thumb {
+		background: rgb(var(--color-text-hint) / 0.35);
+	}
+	.scrollbar-subtle:hover::-webkit-scrollbar-thumb:hover {
+		background: rgb(var(--color-text-secondary) / 0.55);
+	}
 }
 
 .driver-popover-title {

--- a/frontend/src/lib/components/HighlightCode.svelte
+++ b/frontend/src/lib/components/HighlightCode.svelte
@@ -17,7 +17,8 @@
 	import r from 'svelte-highlight/languages/r'
 	import type { Script } from '$lib/gen'
 	import { Button } from './common'
-	import { copyToClipboard } from '$lib/utils'
+	import CopyButton from './common/button/CopyButton.svelte'
+	import ScrollableX from './common/ScrollableX.svelte'
 	import { ClipboardCopy } from 'lucide-svelte'
 	import HighlightTheme from './HighlightTheme.svelte'
 	import { json, type LanguageType } from 'svelte-highlight/languages'
@@ -31,6 +32,10 @@
 		onApplyCode?: () => void
 		showApplyButton?: boolean
 		applyButtonIcon?: typeof ClipboardCopy
+		/** Keep the copy/apply buttons hidden until the block is hovered, and render them subtly. */
+		buttonsOnHover?: boolean
+		/** Wrap the code in ScrollableX (native scroll, subtle hover-revealed scrollbar) for horizontal overflow. */
+		customScrollbarX?: boolean
 	}
 
 	let {
@@ -41,8 +46,14 @@
 		className = '',
 		onApplyCode = undefined,
 		showApplyButton = false,
-		applyButtonIcon = undefined
+		applyButtonIcon = undefined,
+		buttonsOnHover = false,
+		customScrollbarX = false
 	}: Props = $props()
+
+	const hoverButtonClasses = buttonsOnHover
+		? 'opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-150'
+		: ''
 
 	function getLang(lang: Script['language'] | 'bunnative' | 'frontend' | 'json' | undefined) {
 		switch (lang) {
@@ -107,21 +118,14 @@
 
 <HighlightTheme />
 
-<div class="relative">
-	<Button
-		wrapperClasses="absolute top-2 right-2 z-20"
-		onclick={() => copyToClipboard(code)}
-		color="light"
-		size="xs2"
-		startIcon={{
-			icon: ClipboardCopy
-		}}
-		iconOnly
-		title="Copy to clipboard"
+<div class="relative group">
+	<CopyButton
+		value={code}
+		class="absolute top-2 right-2 z-20 bg-surface rounded-md {hoverButtonClasses}"
 	/>
 	{#if showApplyButton}
 		<Button
-			wrapperClasses="absolute top-2 right-10 z-20"
+			wrapperClasses="absolute top-2 right-10 z-20 {hoverButtonClasses}"
 			onclick={onApplyCode}
 			color="light"
 			size="xs2"
@@ -132,19 +136,29 @@
 			title="Apply code"
 		/>
 	{/if}
-	<div class="overflow-x-auto">
-		{#if code?.length < 10000}
-			{#if !lines}
-				<Highlight class="nowrap {className}" language={lang} {code} />
-			{:else}
-				<Highlight class="nowrap {className}" language={lang} {code} let:highlighted>
-					<LineNumbers {highlighted} />
-				</Highlight>
-			{/if}
-		{:else}
-			<pre class="overflow-auto max-h-screen text-xs {className}"
-				><code class="language-{language}">{code}</code></pre
-			>
-		{/if}
-	</div>
+	{#if customScrollbarX}
+		<ScrollableX>
+			{@render codeBody()}
+		</ScrollableX>
+	{:else}
+		<div class="overflow-x-auto">
+			{@render codeBody()}
+		</div>
+	{/if}
 </div>
+
+{#snippet codeBody()}
+	{#if code?.length < 10000}
+		{#if !lines}
+			<Highlight class="nowrap {className}" language={lang} {code} />
+		{:else}
+			<Highlight class="nowrap {className}" language={lang} {code} let:highlighted>
+				<LineNumbers {highlighted} />
+			</Highlight>
+		{/if}
+	{:else}
+		<pre class="overflow-auto max-h-screen text-xs {className}"
+			><code class="language-{language}">{code}</code></pre
+		>
+	{/if}
+{/snippet}

--- a/frontend/src/lib/components/HighlightCode.svelte
+++ b/frontend/src/lib/components/HighlightCode.svelte
@@ -19,6 +19,7 @@
 	import { Button } from './common'
 	import CopyButton from './common/button/CopyButton.svelte'
 	import ScrollableX from './common/ScrollableX.svelte'
+	import { copyToClipboard } from '$lib/utils'
 	import { ClipboardCopy } from 'lucide-svelte'
 	import HighlightTheme from './HighlightTheme.svelte'
 	import { json, type LanguageType } from 'svelte-highlight/languages'
@@ -119,10 +120,23 @@
 <HighlightTheme />
 
 <div class="relative group">
-	<CopyButton
-		value={code}
-		class="absolute top-2 right-2 z-20 bg-surface rounded-md {hoverButtonClasses}"
-	/>
+	{#if buttonsOnHover}
+		<!-- Chat/markdown code blocks: subtle CopyButton on a surface chip. -->
+		<CopyButton
+			value={code}
+			class="absolute top-2 right-2 z-20 bg-surface rounded-md {hoverButtonClasses}"
+		/>
+	{:else}
+		<Button
+			wrapperClasses="absolute top-2 right-2 z-20"
+			onclick={() => copyToClipboard(code)}
+			color="light"
+			size="xs2"
+			startIcon={{ icon: ClipboardCopy }}
+			iconOnly
+			title="Copy to clipboard"
+		/>
+	{/if}
 	{#if showApplyButton}
 		<Button
 			wrapperClasses="absolute top-2 right-10 z-20 {hoverButtonClasses}"

--- a/frontend/src/lib/components/MarkdownCodeBlock.svelte
+++ b/frontend/src/lib/components/MarkdownCodeBlock.svelte
@@ -7,6 +7,7 @@
 		graphql,
 		javascript,
 		php,
+		plaintext,
 		python,
 		rust,
 		shell,
@@ -37,24 +38,38 @@
 
 	const astNode = getAstNode()
 
-	function getSmartLang(lang: string) {
+	// Map a fence language to a known highlighter key, or undefined when the fence
+	// is unlabeled/unrecognized — those render as plaintext rather than being
+	// mis-colored as TypeScript (this renderer runs on all user markdown).
+	function getSmartLang(lang: string | undefined) {
 		switch (lang) {
 			case 'python':
 			case 'python3':
+			case 'py':
 				return 'python'
 			case 'deno':
 			case 'nativets':
 			case 'bun':
 			case 'bunnative':
 			case 'typescript':
+			case 'ts':
+			case 'tsx':
 				return 'typescript'
 			case 'go':
+			case 'golang':
 				return 'go'
 			case 'shell':
 			case 'bash':
+			case 'sh':
+			case 'zsh':
+			case 'console':
 				return 'shell'
 			case 'frontend':
 			case 'javascript':
+			case 'js':
+			case 'jsx':
+			case 'mjs':
+			case 'cjs':
 				return 'javascript'
 			case 'graphql':
 				return 'graphql'
@@ -64,19 +79,23 @@
 			case 'oracledb':
 			case 'powershell':
 			case 'postgresql':
+			case 'postgres':
 			case 'sql':
 				return 'sql'
 			case 'php':
 				return 'php'
 			case 'rust':
+			case 'rs':
 				return 'rust'
 			case 'csharp':
+			case 'cs':
 				return 'csharp'
 			case 'ansible':
 			case 'yaml':
+			case 'yml':
 				return 'yaml'
 			default:
-				return 'typescript'
+				return undefined
 		}
 	}
 
@@ -99,6 +118,9 @@
 	let language = $derived(
 		(astNode.current.children?.[0]?.properties?.class as string | undefined)?.split('-')[1]
 	)
+
+	let smartLang = $derived(getSmartLang(language))
+	let highlightLanguage = $derived(smartLang ? SMART_LANG_TO_HIGHLIGHT_LANG[smartLang] : plaintext)
 </script>
 
 <div class="flex flex-col gap-0.5 rounded-md relative not-prose !text-xs">
@@ -109,7 +131,7 @@
 			<HighlightCode
 				className="px-3 py-2.5 !text-xs"
 				code={code ?? ''}
-				highlightLanguage={SMART_LANG_TO_HIGHLIGHT_LANG[getSmartLang(language as string)]}
+				{highlightLanguage}
 				language={undefined}
 				{onApplyCode}
 				{showApplyButton}

--- a/frontend/src/lib/components/MarkdownCodeBlock.svelte
+++ b/frontend/src/lib/components/MarkdownCodeBlock.svelte
@@ -77,7 +77,6 @@
 			case 'snowflake':
 			case 'bigquery':
 			case 'oracledb':
-			case 'powershell':
 			case 'postgresql':
 			case 'postgres':
 			case 'sql':

--- a/frontend/src/lib/components/MarkdownCodeBlock.svelte
+++ b/frontend/src/lib/components/MarkdownCodeBlock.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+	import { getAstNode } from 'svelte-exmarkdown'
+	import HighlightCode from './HighlightCode.svelte'
+	import {
+		csharp,
+		go,
+		graphql,
+		javascript,
+		php,
+		python,
+		rust,
+		shell,
+		sql,
+		typescript,
+		yaml
+	} from 'svelte-highlight/languages'
+	import type { ClipboardCopy } from 'lucide-svelte'
+	import MermaidDisplay from './copilot/chat/script/MermaidDisplay.svelte'
+
+	// Shared `pre` renderer for fenced code blocks in svelte-exmarkdown markdown.
+	// Chat-agnostic: gives every markdown surface the highlighted panel + subtle
+	// hover copy button + custom horizontal scrollbar. The AI chat wraps this to
+	// add its Apply button (via the apply props) and mermaid diagrams.
+	let {
+		showApplyButton = false,
+		onApplyCode = undefined,
+		applyButtonIcon = undefined,
+		// Render ```mermaid blocks as diagrams. Off by default so untrusted
+		// markdown surfaces don't execute mermaid — the chat opts in.
+		renderMermaid = false
+	}: {
+		showApplyButton?: boolean
+		onApplyCode?: () => void
+		applyButtonIcon?: typeof ClipboardCopy
+		renderMermaid?: boolean
+	} = $props()
+
+	const astNode = getAstNode()
+
+	function getSmartLang(lang: string) {
+		switch (lang) {
+			case 'python':
+			case 'python3':
+				return 'python'
+			case 'deno':
+			case 'nativets':
+			case 'bun':
+			case 'bunnative':
+			case 'typescript':
+				return 'typescript'
+			case 'go':
+				return 'go'
+			case 'shell':
+			case 'bash':
+				return 'shell'
+			case 'frontend':
+			case 'javascript':
+				return 'javascript'
+			case 'graphql':
+				return 'graphql'
+			case 'mysql':
+			case 'snowflake':
+			case 'bigquery':
+			case 'oracledb':
+			case 'powershell':
+			case 'postgresql':
+			case 'sql':
+				return 'sql'
+			case 'php':
+				return 'php'
+			case 'rust':
+				return 'rust'
+			case 'csharp':
+				return 'csharp'
+			case 'ansible':
+			case 'yaml':
+				return 'yaml'
+			default:
+				return 'typescript'
+		}
+	}
+
+	const SMART_LANG_TO_HIGHLIGHT_LANG = {
+		python: python,
+		typescript: typescript,
+		go: go,
+		shell: shell,
+		javascript: javascript,
+		graphql: graphql,
+		sql: sql,
+		php: php,
+		rust: rust,
+		csharp: csharp,
+		yaml: yaml
+	}
+
+	let code = $derived(astNode.current.children?.[0]?.children?.[0]?.value)
+
+	let language = $derived(
+		(astNode.current.children?.[0]?.properties?.class as string | undefined)?.split('-')[1]
+	)
+</script>
+
+<div class="flex flex-col gap-0.5 rounded-md relative not-prose !text-xs">
+	<div class="relative w-full bg-surface-secondary rounded-md overflow-hidden">
+		{#if renderMermaid && language === 'mermaid'}
+			<MermaidDisplay code={code ?? ''} />
+		{:else}
+			<HighlightCode
+				className="px-3 py-2.5 !text-xs"
+				code={code ?? ''}
+				highlightLanguage={SMART_LANG_TO_HIGHLIGHT_LANG[getSmartLang(language as string)]}
+				language={undefined}
+				{onApplyCode}
+				{showApplyButton}
+				{applyButtonIcon}
+				buttonsOnHover
+				customScrollbarX
+			/>
+		{/if}
+	</div>
+</div>

--- a/frontend/src/lib/components/MarkdownCodeBlock.svelte
+++ b/frontend/src/lib/components/MarkdownCodeBlock.svelte
@@ -112,7 +112,13 @@
 		yaml: yaml
 	}
 
-	let code = $derived(astNode.current.children?.[0]?.children?.[0]?.value)
+	// Fenced code is `<pre><code>text</code></pre>` (text nested under <code>).
+	// Sanitized raw HTML through rehypeRaw is `<pre>text</pre>` — the text is a
+	// direct child of <pre> with no <code>, so fall back to it or the block would
+	// render empty now that this renderer handles every <pre>.
+	let code = $derived(
+		astNode.current.children?.[0]?.children?.[0]?.value ?? astNode.current.children?.[0]?.value
+	)
 
 	let language = $derived(
 		(astNode.current.children?.[0]?.properties?.class as string | undefined)?.split('-')[1]

--- a/frontend/src/lib/components/common/ScrollableX.svelte
+++ b/frontend/src/lib/components/common/ScrollableX.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte'
+
+	// Subtle horizontal scroll: native overflow (so wheel/trackpad/drag always
+	// work) with a thin, rounded scrollbar that stays invisible until the region
+	// is hovered. Bar thickness is tunable via the `--wm-scrollx-size` CSS var
+	// (pass through `style`), so denser callers (e.g. the tab strip) can shrink it.
+	let {
+		class: c = '',
+		style = '',
+		children
+	}: { class?: string; style?: string; children: Snippet } = $props()
+</script>
+
+<div class="wm-scrollx {c}" {style}>
+	{@render children()}
+</div>
+
+<style>
+	.wm-scrollx {
+		overflow-x: auto;
+		overflow-y: hidden;
+		/* Firefox: thin bar, transparent until hover. */
+		scrollbar-width: thin;
+		scrollbar-color: transparent transparent;
+	}
+	.wm-scrollx:hover {
+		scrollbar-color: rgb(var(--color-text-hint) / 0.4) transparent;
+	}
+
+	/* WebKit: override the app-wide `*::-webkit-scrollbar` bar with a subtle,
+	   hover-revealed thumb (higher specificity than the global `*` rule). */
+	.wm-scrollx::-webkit-scrollbar {
+		height: var(--wm-scrollx-size, 6px);
+	}
+	.wm-scrollx::-webkit-scrollbar-track {
+		background: transparent;
+	}
+	.wm-scrollx::-webkit-scrollbar-thumb {
+		background: transparent;
+		border-radius: 9999px;
+		transition: background-color 0.15s;
+	}
+	.wm-scrollx:hover::-webkit-scrollbar-thumb {
+		background: rgb(var(--color-text-hint) / 0.35);
+	}
+	.wm-scrollx:hover::-webkit-scrollbar-thumb:hover {
+		background: rgb(var(--color-text-secondary) / 0.55);
+	}
+</style>

--- a/frontend/src/lib/components/common/ScrollableX.svelte
+++ b/frontend/src/lib/components/common/ScrollableX.svelte
@@ -2,9 +2,9 @@
 	import type { Snippet } from 'svelte'
 
 	// Subtle horizontal scroll: native overflow (so wheel/trackpad/drag always
-	// work) with a thin, rounded scrollbar that stays invisible until the region
-	// is hovered. Bar thickness is tunable via the `--wm-scrollx-size` CSS var
-	// (pass through `style`), so denser callers (e.g. the tab strip) can shrink it.
+	// work) with the shared `.scrollbar-subtle` thumb (thin, hover-revealed). Bar
+	// thickness is tunable via the `--wm-scrollbar-size` CSS var (pass through
+	// `style`), so denser callers (e.g. the tab strip) can shrink it.
 	let {
 		class: c = '',
 		style = '',
@@ -12,7 +12,7 @@
 	}: { class?: string; style?: string; children: Snippet } = $props()
 </script>
 
-<div class="wm-scrollx {c}" {style}>
+<div class="wm-scrollx scrollbar-subtle {c}" {style}>
 	{@render children()}
 </div>
 
@@ -20,31 +20,5 @@
 	.wm-scrollx {
 		overflow-x: auto;
 		overflow-y: hidden;
-		/* Firefox: thin bar, transparent until hover. */
-		scrollbar-width: thin;
-		scrollbar-color: transparent transparent;
-	}
-	.wm-scrollx:hover {
-		scrollbar-color: rgb(var(--color-text-hint) / 0.4) transparent;
-	}
-
-	/* WebKit: override the app-wide `*::-webkit-scrollbar` bar with a subtle,
-	   hover-revealed thumb (higher specificity than the global `*` rule). */
-	.wm-scrollx::-webkit-scrollbar {
-		height: var(--wm-scrollx-size, 6px);
-	}
-	.wm-scrollx::-webkit-scrollbar-track {
-		background: transparent;
-	}
-	.wm-scrollx::-webkit-scrollbar-thumb {
-		background: transparent;
-		border-radius: 9999px;
-		transition: background-color 0.15s;
-	}
-	.wm-scrollx:hover::-webkit-scrollbar-thumb {
-		background: rgb(var(--color-text-hint) / 0.35);
-	}
-	.wm-scrollx:hover::-webkit-scrollbar-thumb:hover {
-		background: rgb(var(--color-text-secondary) / 0.55);
 	}
 </style>

--- a/frontend/src/lib/components/common/ScrollableX.svelte
+++ b/frontend/src/lib/components/common/ScrollableX.svelte
@@ -12,13 +12,6 @@
 	}: { class?: string; style?: string; children: Snippet } = $props()
 </script>
 
-<div class="wm-scrollx scrollbar-subtle {c}" {style}>
+<div class="overflow-x-auto overflow-y-hidden scrollbar-subtle {c}" {style}>
 	{@render children()}
 </div>
-
-<style>
-	.wm-scrollx {
-		overflow-x: auto;
-		overflow-y: hidden;
-	}
-</style>

--- a/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
+++ b/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
@@ -167,7 +167,7 @@
 
 <div class={twMerge('flex items-center bg-surface', c)}>
 	<!-- 4px bar to match the strip's `pb-1` reserve. -->
-	<ScrollableX class="flex-1 min-w-0 pt-1 pl-1 pb-1" style="--wm-scrollx-size: 4px;">
+	<ScrollableX class="flex-1 min-w-0 pt-1 pl-1 pb-1" style="--wm-scrollbar-size: 4px;">
 		<div class="flex items-center" role="tablist">
 			{#each pinnedLeft as tab (tab.id)}
 				{@render tabButton(tab)}

--- a/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
+++ b/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
@@ -25,8 +25,8 @@
 	import { dndzone, type DndEvent } from '@windmill-labs/svelte-dnd-action'
 	import { X } from 'lucide-svelte'
 	import { twMerge } from 'tailwind-merge'
-	import { createScrollArea, melt } from '@melt-ui/svelte'
 	import { untrack } from 'svelte'
+	import ScrollableX from '../ScrollableX.svelte'
 
 	interface Props {
 		tabs: TabItem[]
@@ -58,27 +58,6 @@
 		const next = middle
 		// Re-sync from props except mid-drag, where the dnd zone owns the list.
 		if (!isDragging) dndMiddle = next
-	})
-
-	// `type: 'hover'` shows the custom bar only while hovering/scrolling the strip.
-	const {
-		elements: { root, viewport, content, scrollbarX, thumbX }
-	} = createScrollArea({ type: 'hover', hideDelay: 600, dir: 'ltr' })
-
-	// melt only re-measures the thumb when its *content* resizes, not the
-	// viewport — so a pane resize leaves the thumb stale. Detect width changes
-	// via `bind:clientWidth` and nudge melt by perturbing the 0×0 sentinel's box.
-	let viewportWidth = $state(0)
-	let resizeSentinel: HTMLSpanElement | undefined = $state(undefined)
-	$effect(() => {
-		void viewportWidth
-		const el = untrack(() => resizeSentinel)
-		if (!el) return
-		el.style.width = '1px'
-		const raf = requestAnimationFrame(() => {
-			el.style.width = '0px'
-		})
-		return () => cancelAnimationFrame(raf)
 	})
 
 	function handleConsider(e: CustomEvent<DndEvent<TabItem>>) {
@@ -161,52 +140,36 @@
 {/snippet}
 
 <div class={twMerge('flex items-center bg-surface', c)}>
-	<div use:melt={$root} class="tabs-root flex-1 min-w-0 relative pt-1 pl-1 pb-1">
-		<div use:melt={$viewport} bind:clientWidth={viewportWidth} class="tabs-viewport w-full">
-			<!-- Inner flex wrapper — melt's content element is forced to
-				 `display: table` which would stack the tabs vertically. -->
-			<div use:melt={$content}>
-				<div class="flex items-center" role="tablist">
-					{#each pinnedLeft as tab (tab.id)}
-						{@render tabButton(tab)}
-					{/each}
+	<!-- 4px bar to match the strip's `pb-1` reserve. -->
+	<ScrollableX class="flex-1 min-w-0 pt-1 pl-1 pb-1" style="--wm-scrollx-size: 4px;">
+		<div class="flex items-center" role="tablist">
+			{#each pinnedLeft as tab (tab.id)}
+				{@render tabButton(tab)}
+			{/each}
 
-					<div
-						class="flex items-center"
-						use:dndzone={{
-							items: dndMiddle,
-							flipDurationMs: 150,
-							type: dndType,
-							dropTargetStyle: {}
-						}}
-						onconsider={handleConsider}
-						onfinalize={handleFinalize}
-					>
-						{#each dndMiddle as tab (tab.id)}
-							<div>
-								{@render tabButton(tab)}
-							</div>
-						{/each}
+			<div
+				class="flex items-center"
+				use:dndzone={{
+					items: dndMiddle,
+					flipDurationMs: 150,
+					type: dndType,
+					dropTargetStyle: {}
+				}}
+				onconsider={handleConsider}
+				onfinalize={handleFinalize}
+			>
+				{#each dndMiddle as tab (tab.id)}
+					<div>
+						{@render tabButton(tab)}
 					</div>
-
-					{#each pinnedRight as tab (tab.id)}
-						{@render tabButton(tab)}
-					{/each}
-
-					<!-- resize nudge for melt (see the $effect above) -->
-					<span
-						bind:this={resizeSentinel}
-						aria-hidden="true"
-						style="display:inline-block;width:0;height:0"
-					></span>
-				</div>
+				{/each}
 			</div>
-		</div>
 
-		<div use:melt={$scrollbarX} class="tabs-scrollbar">
-			<div use:melt={$thumbX} class="tabs-thumb"></div>
+			{#each pinnedRight as tab (tab.id)}
+				{@render tabButton(tab)}
+			{/each}
 		</div>
-	</div>
+	</ScrollableX>
 
 	{#if trailing}
 		<div class="ml-1 pr-1 flex items-center shrink-0">
@@ -214,38 +177,3 @@
 		</div>
 	{/if}
 </div>
-
-<style>
-	.tabs-viewport {
-		height: 100%;
-	}
-
-	/* Custom 4px bar, absolutely positioned so toggling it never shifts layout. */
-	:global([data-melt-scroll-area-scrollbar].tabs-scrollbar) {
-		height: 4px;
-		background: transparent;
-		touch-action: none;
-		user-select: none;
-		transition: opacity 0.15s;
-	}
-	/* Hide the whole bar when melt marks it hidden (key off the scrollbar, not
-	   the thumb — the thumb's data-state doesn't track overflow). */
-	:global([data-melt-scroll-area-scrollbar].tabs-scrollbar[data-state='hidden']) {
-		opacity: 0;
-		pointer-events: none;
-	}
-	:global([data-melt-scroll-area-thumb].tabs-thumb) {
-		/* melt leaves the thumb-height var empty for a horizontal bar, collapsing
-		   the inline height to 0 — supply it so the thumb fills the 4px track. */
-		--melt-scroll-area-thumb-height: 100%;
-		height: 100%;
-		width: var(--melt-scroll-area-thumb-width);
-		background: rgb(var(--color-text-hint) / 0.35);
-		border-radius: 2px;
-		position: relative;
-		transition: background-color 0.15s;
-	}
-	:global([data-melt-scroll-area-thumb].tabs-thumb:hover) {
-		background: rgb(var(--color-text-secondary) / 0.6);
-	}
-</style>

--- a/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
+++ b/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
@@ -91,7 +91,7 @@
 		return twMerge(
 			'group inline-flex items-center gap-1.5 px-2.5 h-7 text-xs rounded-md select-none cursor-pointer whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-border-selected focus-visible:ring-inset',
 			isActive
-				? 'bg-surface-tertiary text-emphasis shadow-sm'
+				? 'bg-surface-tertiary text-emphasis'
 				: 'bg-transparent text-hint hover:text-secondary'
 		)
 	}

--- a/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
+++ b/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
@@ -38,9 +38,21 @@
 		class?: string
 		/** Render after the right-pinned tabs (e.g. a "Split with Preview" toggle). */
 		trailing?: import('svelte').Snippet
+		/** Render inside each tab, after the label and before the close button (e.g. a
+		 * per-tab chevron/breadcrumb picker). Receives the tab and whether it's active. */
+		tabAccessory?: import('svelte').Snippet<[TabItem, boolean]>
 	}
 
-	let { tabs, activeId, onSelect, onClose, onReorder, class: c = '', trailing }: Props = $props()
+	let {
+		tabs,
+		activeId,
+		onSelect,
+		onClose,
+		onReorder,
+		class: c = '',
+		trailing,
+		tabAccessory
+	}: Props = $props()
 
 	const pinnedLeft = $derived(tabs.filter((t) => t.pinned === 'left'))
 	const middle = $derived(tabs.filter((t) => !t.pinned))
@@ -123,6 +135,15 @@
 			<Icon size={12} class={tab.iconClass} />
 		{/if}
 		<span class={twMerge('truncate max-w-[180px]', tab.labelClass)}>{tab.label}</span>
+		{#if tabAccessory}
+			<!-- The accessory is its own control (e.g. a picker): a click on it must not
+				 also select/re-select the tab, mirroring the close button below. -->
+			<!-- svelte-ignore a11y_click_events_have_key_events -->
+			<!-- svelte-ignore a11y_no_static_element_interactions -->
+			<span class="inline-flex items-center" onclick={(e) => e.stopPropagation()}>
+				{@render tabAccessory(tab, isActive)}
+			</span>
+		{/if}
 		{#if tab.closable !== false}
 			<button
 				type="button"

--- a/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
+++ b/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
@@ -91,7 +91,7 @@
 		return twMerge(
 			'group inline-flex items-center gap-1.5 px-2.5 h-7 text-xs rounded-md select-none cursor-pointer whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-border-selected focus-visible:ring-inset',
 			isActive
-				? 'bg-surface-tertiary text-emphasis'
+				? 'bg-surface-tertiary text-emphasis shadow-sm'
 				: 'bg-transparent text-hint hover:text-secondary'
 		)
 	}

--- a/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
+++ b/frontend/src/lib/components/common/tabs/DraggableTabs.svelte
@@ -36,7 +36,11 @@
 		onReorder?: (newOrder: TabItem[]) => void
 		/** Extra classes for the outer tab strip. */
 		class?: string
-		/** Render after the right-pinned tabs (e.g. a "Split with Preview" toggle). */
+		/** Render inside the scroll row, right after the last tab (e.g. a "+" new-tab
+		 * button) — scrolls with the tabs, unlike `trailing`. */
+		afterTabs?: import('svelte').Snippet
+		/** Render after the right-pinned tabs, outside the scroll area so it stays
+		 * pinned (e.g. a "Split with Preview" toggle). */
 		trailing?: import('svelte').Snippet
 		/** Render inside each tab, after the label and before the close button (e.g. a
 		 * per-tab chevron/breadcrumb picker). Receives the tab and whether it's active. */
@@ -50,6 +54,7 @@
 		onClose,
 		onReorder,
 		class: c = '',
+		afterTabs,
 		trailing,
 		tabAccessory
 	}: Props = $props()
@@ -189,6 +194,10 @@
 			{#each pinnedRight as tab (tab.id)}
 				{@render tabButton(tab)}
 			{/each}
+
+			{#if afterTabs}
+				{@render afterTabs()}
+			{/if}
 		</div>
 	</ScrollableX>
 

--- a/frontend/src/lib/components/common/tabs/Tabs.svelte
+++ b/frontend/src/lib/components/common/tabs/Tabs.svelte
@@ -77,7 +77,9 @@
 <svelte:window onhashchange={hashChange} />
 {#if !hideTabs}
 	<ScrollableX class={wrapperClass}>
-		<div class={twMerge('border-b flex flex-row whitespace-nowrap', c)} {style}>
+		<!-- `scrollbar-hidden` is inert on this non-scrolling row (ScrollableX owns the
+			 scroll), but TroubleshootFlowTutorial targets it as a selector hook — keep it. -->
+		<div class={twMerge('border-b flex flex-row whitespace-nowrap scrollbar-hidden', c)} {style}>
 			{@render children?.({ selected })}
 		</div>
 	</ScrollableX>

--- a/frontend/src/lib/components/common/tabs/Tabs.svelte
+++ b/frontend/src/lib/components/common/tabs/Tabs.svelte
@@ -3,6 +3,7 @@
 	import { writable } from 'svelte/store'
 	import { createEventDispatcher } from 'svelte'
 	import { twMerge } from 'tailwind-merge'
+	import ScrollableX from '../ScrollableX.svelte'
 	import type { TabsContext } from '$lib/components/apps/editor/settingsPanel/inputEditor/tabs.svelte'
 
 	const dispatch = createEventDispatcher<{ selected: string }>()
@@ -75,10 +76,10 @@
 
 <svelte:window onhashchange={hashChange} />
 {#if !hideTabs}
-	<div class="overflow-x-auto {wrapperClass}">
-		<div class={twMerge('border-b flex flex-row whitespace-nowrap scrollbar-hidden', c)} {style}>
+	<ScrollableX class={wrapperClass}>
+		<div class={twMerge('border-b flex flex-row whitespace-nowrap', c)} {style}>
 			{@render children?.({ selected })}
 		</div>
-	</div>
+	</ScrollableX>
 {/if}
 {@render content?.()}

--- a/frontend/src/lib/components/common/tabs/TabsV2.svelte
+++ b/frontend/src/lib/components/common/tabs/TabsV2.svelte
@@ -2,6 +2,7 @@
 	import { setContext, untrack } from 'svelte'
 	import { writable } from 'svelte/store'
 	import { twMerge } from 'tailwind-merge'
+	import ScrollableX from '../ScrollableX.svelte'
 	import type { TabsContext } from '$lib/components/apps/editor/settingsPanel/inputEditor/tabs.svelte'
 
 	interface Props {
@@ -72,10 +73,10 @@
 
 <svelte:window onhashchange={hashChange} />
 {#if !hideTabs}
-	<div class="overflow-x-auto {wrapperClass}">
-		<div class={twMerge('border-b flex flex-row whitespace-nowrap scrollbar-hidden', c)} {style}>
+	<ScrollableX class={wrapperClass}>
+		<div class={twMerge('border-b flex flex-row whitespace-nowrap', c)} {style}>
 			{@render children?.({ selected })}
 		</div>
-	</div>
+	</ScrollableX>
 {/if}
 {@render content?.()}

--- a/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
@@ -591,7 +591,11 @@ the panel, or the Escape-to-stop focus check would wrongly reject them. -->
 
 	{#if messages.length > 0}
 		<div class="flex-1 min-h-0 relative">
-			<div class="absolute inset-0 overflow-y-scroll pt-2" bind:this={scrollEl} onscroll={onScroll}>
+			<div
+				class="absolute inset-0 overflow-y-scroll pt-2 scrollbar-subtle"
+				bind:this={scrollEl}
+				onscroll={onScroll}
+			>
 				<div
 					class={wideLayout
 						? 'w-full max-w-3xl mx-auto px-7 flex flex-col pb-2'

--- a/frontend/src/lib/components/copilot/chat/ChatTypingIndicator.svelte
+++ b/frontend/src/lib/components/copilot/chat/ChatTypingIndicator.svelte
@@ -42,14 +42,16 @@
 	aria-label="AI is generating a response"
 >
 	<span class={compact ? 'inline-flex items-end gap-0.5' : 'inline-flex items-end gap-1'}>
-		<span class={(compact ? 'w-1 h-1' : 'w-1.5 h-1.5') + ' rounded-full bg-accent chat-typing-dot'}
+		<span
+			class={(compact ? 'w-[3px] h-[3px]' : 'w-[5px] h-[5px]') +
+				' rounded-full bg-accent chat-typing-dot'}
 		></span>
 		<span
-			class={(compact ? 'w-1 h-1' : 'w-1.5 h-1.5') +
+			class={(compact ? 'w-[3px] h-[3px]' : 'w-[5px] h-[5px]') +
 				' rounded-full bg-accent chat-typing-dot chat-typing-dot-2'}
 		></span>
 		<span
-			class={(compact ? 'w-1 h-1' : 'w-1.5 h-1.5') +
+			class={(compact ? 'w-[3px] h-[3px]' : 'w-[5px] h-[5px]') +
 				' rounded-full bg-accent chat-typing-dot chat-typing-dot-3'}
 		></span>
 	</span>

--- a/frontend/src/lib/components/copilot/chat/script/CodeDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/script/CodeDisplay.svelte
@@ -1,92 +1,17 @@
 <script lang="ts">
 	import { getAstNode } from 'svelte-exmarkdown'
-	import HighlightCode from '$lib/components/HighlightCode.svelte'
-	import {
-		csharp,
-		go,
-		graphql,
-		javascript,
-		php,
-		python,
-		rust,
-		shell,
-		sql,
-		typescript,
-		yaml
-	} from 'svelte-highlight/languages'
+	import MarkdownCodeBlock from '$lib/components/MarkdownCodeBlock.svelte'
 	import { AIMode } from '../AIChatManager.svelte'
 	import { getAiChatManager } from '../aiChatManagerContext'
 	import { Check, Play } from 'lucide-svelte'
-	import MermaidDisplay from './MermaidDisplay.svelte'
 
+	// Chat `pre` renderer: the shared MarkdownCodeBlock plus the chat-only Apply
+	// button (wired to the script editor) and mermaid diagrams.
 	const aiChatManager = getAiChatManager()
 
 	const astNode = getAstNode()
-
-	function getSmartLang(lang: string) {
-		switch (lang) {
-			case 'python':
-			case 'python3':
-				return 'python'
-			case 'deno':
-			case 'nativets':
-			case 'bun':
-			case 'bunnative':
-			case 'typescript':
-				return 'typescript'
-			case 'go':
-				return 'go'
-			case 'shell':
-			case 'bash':
-				return 'shell'
-			case 'frontend':
-			case 'javascript':
-				return 'javascript'
-			case 'graphql':
-				return 'graphql'
-			case 'mysql':
-			case 'snowflake':
-			case 'bigquery':
-			case 'oracledb':
-			case 'powershell':
-			case 'postgresql':
-			case 'sql':
-				return 'sql'
-			case 'php':
-				return 'php'
-			case 'rust':
-				return 'rust'
-			case 'csharp':
-				return 'csharp'
-			case 'ansible':
-			case 'yaml':
-				return 'yaml'
-			default:
-				return 'typescript'
-		}
-	}
-
-	const SMART_LANG_TO_HIGHLIGHT_LANG = {
-		python: python,
-		typescript: typescript,
-		go: go,
-		shell: shell,
-		javascript: javascript,
-		graphql: graphql,
-		sql: sql,
-		php: php,
-		rust: rust,
-		csharp: csharp,
-		yaml: yaml
-	}
-
 	let code = $derived(astNode.current.children?.[0]?.children?.[0]?.value)
 
-	let language = $derived(
-		(astNode.current.children?.[0]?.properties?.class as string | undefined)?.split('-')[1]
-	)
-
-	// Check if the apply button should be shown
 	let showApplyButton = $derived.by(() => {
 		if (
 			aiChatManager.mode !== AIMode.SCRIPT ||
@@ -105,22 +30,9 @@
 	}
 </script>
 
-<div class="flex flex-col gap-0.5 rounded-lg relative not-prose !text-xs">
-	<div
-		class="relative w-full border border-gray-300 dark:border-gray-600 rounded-lg overflow-hidden"
-	>
-		{#if language === 'mermaid'}
-			<MermaidDisplay code={code ?? ''} />
-		{:else}
-			<HighlightCode
-				className="p-1"
-				code={code ?? ''}
-				highlightLanguage={SMART_LANG_TO_HIGHLIGHT_LANG[getSmartLang(language as string)]}
-				language={undefined}
-				onApplyCode={handleApplyCode}
-				{showApplyButton}
-				applyButtonIcon={aiChatManager.pendingNewCode ? Check : Play}
-			/>
-		{/if}
-	</div>
-</div>
+<MarkdownCodeBlock
+	{showApplyButton}
+	onApplyCode={handleApplyCode}
+	applyButtonIcon={aiChatManager.pendingNewCode ? Check : Play}
+	renderMermaid
+/>

--- a/frontend/src/lib/components/markdownPlugins.ts
+++ b/frontend/src/lib/components/markdownPlugins.ts
@@ -3,6 +3,7 @@ import { gfmPlugin } from 'svelte-exmarkdown/gfm'
 import rehypeRaw from 'rehype-raw'
 import rehypeSanitize from 'rehype-sanitize'
 import { rehypeGithubAlerts } from 'rehype-github-alerts'
+import MarkdownCodeBlock from './MarkdownCodeBlock.svelte'
 
 /**
  * Shared plugin chain for rendering user-supplied Markdown (script/flow/resource
@@ -19,6 +20,11 @@ import { rehypeGithubAlerts } from 'rehype-github-alerts'
  *                            injects (including inline SVG icons) is preserved
  *                            without having to allowlist SVG for user input.
  *
+ * The `pre` renderer gives fenced code blocks syntax highlighting, a copy
+ * button, and a subtle scrollbar everywhere this chain is used. It reads the
+ * `language-*` class rehypeSanitize preserves on `<code>`; it highlights code as
+ * escaped text and never renders mermaid on untrusted input (chat opts in).
+ *
  * Any Markdown sink that renders user input MUST use this chain rather than
  * assembling its own `rehypeRaw` pipeline.
  */
@@ -26,5 +32,6 @@ export const markdownPlugins: Plugin[] = [
 	gfmPlugin(),
 	{ rehypePlugin: [rehypeRaw] },
 	{ rehypePlugin: [rehypeSanitize] },
-	{ rehypePlugin: [rehypeGithubAlerts] }
+	{ rehypePlugin: [rehypeGithubAlerts] },
+	{ renderer: { pre: MarkdownCodeBlock } }
 ]

--- a/frontend/src/lib/components/sessions/SessionStatusDot.svelte
+++ b/frontend/src/lib/components/sessions/SessionStatusDot.svelte
@@ -47,9 +47,9 @@
 <span class="inline-flex items-center justify-center w-4 h-3 shrink-0" {title}>
 	{#if status === 'streaming'}
 		<span class="inline-flex items-end gap-0.5">
-			<span class="w-1 h-1 rounded-full bg-blue-500 typing-dot"></span>
-			<span class="w-1 h-1 rounded-full bg-blue-500 typing-dot dot-2"></span>
-			<span class="w-1 h-1 rounded-full bg-blue-500 typing-dot dot-3"></span>
+			<span class="w-[3px] h-[3px] rounded-full bg-blue-500 typing-dot"></span>
+			<span class="w-[3px] h-[3px] rounded-full bg-blue-500 typing-dot dot-2"></span>
+			<span class="w-[3px] h-[3px] rounded-full bg-blue-500 typing-dot dot-3"></span>
 		</span>
 	{:else if status === 'needs-confirmation'}
 		<AlertCircle class="w-3 h-3 text-amber-500" />

--- a/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
@@ -240,6 +240,25 @@ export class SessionPreviewTabs {
 		this.#flush()
 	}
 
+	// Reorder the tabs to the given id order (drag-and-drop). Ids absent from the
+	// current set are ignored; any current tab the caller omitted is kept at the
+	// end so a stale/partial order can never drop a tab. No-op if unchanged.
+	reorder(orderedIds: string[]): void {
+		const byId = new Map(this.#tabs.map((t) => [t.id, t]))
+		const next: SessionPreviewTab[] = []
+		for (const id of orderedIds) {
+			const t = byId.get(id)
+			if (t) {
+				next.push(t)
+				byId.delete(id)
+			}
+		}
+		for (const t of this.#tabs) if (byId.has(t.id)) next.push(t)
+		if (next.length === this.#tabs.length && next.every((t, i) => t === this.#tabs[i])) return
+		this.#tabs = next
+		this.#flush()
+	}
+
 	close(id: string): void {
 		const idx = this.#tabs.findIndex((t) => t.id === id)
 		if (idx < 0) return

--- a/frontend/src/lib/components/sessions/sessionPreviewTabs.test.ts
+++ b/frontend/src/lib/components/sessions/sessionPreviewTabs.test.ts
@@ -343,6 +343,59 @@ describe('SessionPreviewTabs.select / close / setCollapsed', () => {
 	})
 })
 
+describe('SessionPreviewTabs.reorder', () => {
+	it('reorders tabs to the given id order and persists, keeping the active id', () => {
+		const { adapter, persisted } = makeAdapter()
+		const o = owner(
+			{
+				tabs: [
+					{ id: 'a', url: '/x', loc: '/x' },
+					{ id: 'b', url: '/y', loc: '/y' },
+					{ id: 'c', url: '/z', loc: '/z' }
+				],
+				activeId: 'a'
+			},
+			adapter
+		)
+		o.reorder(['c', 'a', 'b'])
+		expect(o.tabs.map((t) => t.id)).toEqual(['c', 'a', 'b'])
+		expect(o.activeId).toBe('a')
+		vi.runAllTimers()
+		expect(persisted.at(-1)?.tabs.map((t) => t.id)).toEqual(['c', 'a', 'b'])
+	})
+
+	it('ignores unknown ids and keeps omitted tabs at the end', () => {
+		const o = owner({
+			tabs: [
+				{ id: 'a', url: '/x', loc: '/x' },
+				{ id: 'b', url: '/y', loc: '/y' },
+				{ id: 'c', url: '/z', loc: '/z' }
+			],
+			activeId: 'a'
+		})
+		// 'zzz' doesn't exist (ignored); 'c' omitted from the order (kept at the end).
+		o.reorder(['b', 'zzz', 'a'])
+		expect(o.tabs.map((t) => t.id)).toEqual(['b', 'a', 'c'])
+	})
+
+	it('is a no-op (no persist) when the order is unchanged', () => {
+		const { adapter, persisted } = makeAdapter()
+		const o = owner(
+			{
+				tabs: [
+					{ id: 'a', url: '/x', loc: '/x' },
+					{ id: 'b', url: '/y', loc: '/y' }
+				],
+				activeId: 'a'
+			},
+			adapter
+		)
+		o.reorder(['a', 'b'])
+		vi.runAllTimers()
+		expect(persisted).toHaveLength(0)
+	})
+})
+
 describe('SessionPreviewTabs.observeLocation', () => {
 	it('updates loc without touching url', () => {
 		const o = owner({

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -673,7 +673,7 @@
 										</Popover>
 									{/if}
 								{/snippet}
-								{#snippet trailing()}
+								{#snippet afterTabs()}
 									<Popover
 										placement="bottom-start"
 										usePointerDownOutside

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -638,9 +638,7 @@
 								onSelect={selectTab}
 								onClose={closeTab}
 								onReorder={reorderTabs}
-								class="h-8 border-b border-light bg-surface-secondary {fullscreen
-									? 'pl-1.5'
-									: 'pl-9'} pr-16"
+								class="h-8 border-b border-light bg-surface {fullscreen ? 'pl-1.5' : 'pl-9'} pr-16"
 							>
 								{#snippet tabAccessory(_tab, isActive)}
 									{#if isActive}

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -593,7 +593,7 @@
 									onclick={() => owner?.setCollapsed(true)}
 									title="Collapse preview"
 									aria-label="Collapse preview"
-									class="absolute top-1 left-1 z-30 inline-flex items-center justify-center w-6 h-6 rounded text-tertiary hover:text-primary hover:bg-surface-hover bg-surface-secondary"
+									class="absolute top-1 left-1 z-30 inline-flex items-center justify-center w-6 h-6 rounded text-tertiary hover:text-primary hover:bg-surface-hover"
 								>
 									<PanelRightClose size={14} />
 								</button>
@@ -609,7 +609,7 @@
 									)}
 									title="Open in workspace"
 									aria-label="Open in workspace"
-									class="inline-flex items-center justify-center w-6 h-6 rounded text-tertiary hover:text-primary hover:bg-surface-hover bg-surface-secondary"
+									class="inline-flex items-center justify-center w-6 h-6 rounded text-tertiary hover:text-primary hover:bg-surface-hover"
 								>
 									<ExternalLink size={14} />
 								</a>
@@ -618,7 +618,7 @@
 									onclick={() => (fullscreen = !fullscreen)}
 									title={fullscreen ? 'Exit full screen' : 'Full screen'}
 									aria-label={fullscreen ? 'Exit full screen' : 'Full screen'}
-									class="inline-flex items-center justify-center w-6 h-6 rounded text-tertiary hover:text-primary hover:bg-surface-hover bg-surface-secondary"
+									class="inline-flex items-center justify-center w-6 h-6 rounded text-tertiary hover:text-primary hover:bg-surface-hover"
 								>
 									{#if fullscreen}
 										<Minimize2 size={14} />

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -638,7 +638,9 @@
 								onSelect={selectTab}
 								onClose={closeTab}
 								onReorder={reorderTabs}
-								class="h-8 border-b border-light bg-surface {fullscreen ? 'pl-1.5' : 'pl-9'} pr-16"
+								class="h-8 border-b border-light bg-surface-secondary/50 {fullscreen
+									? 'pl-1.5'
+									: 'pl-9'} pr-16"
 							>
 								{#snippet tabAccessory(_tab, isActive)}
 									{#if isActive}

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -11,11 +11,11 @@
 		PanelRightOpen,
 		ChevronDown,
 		MonitorPlay,
-		Loader2,
-		X
+		Loader2
 	} from 'lucide-svelte'
 	import { Pane, Splitpanes } from 'svelte-splitpanes'
 	import { Button } from '$lib/components/common'
+	import DraggableTabs, { type TabItem } from '$lib/components/common/tabs/DraggableTabs.svelte'
 	import Popover from '$lib/components/meltComponents/Popover.svelte'
 	import PreviewRouterPicker, {
 		type Scope
@@ -243,6 +243,14 @@
 		const sid = activeRuntime?.sessionId
 		if (sid) mountedTabKeys.delete(tabKey(sid, id))
 	}
+	function reorderTabs(next: TabItem[]) {
+		owner?.reorder(next.map((t) => t.id))
+	}
+	// Adapt the session tab model to DraggableTabs items (labels derived from the
+	// observed location; every tab closable, none pinned).
+	const previewTabItems = $derived<TabItem[]>(
+		(owner?.tabs ?? []).map((t) => ({ id: t.id, label: tabLabel(t.loc) }))
+	)
 	let newTabOpen = $state(false)
 	// Separate open flag for the empty-state launcher: it can be mounted at the
 	// same time as the tab-strip "+" popover, so sharing one flag would open both
@@ -620,96 +628,78 @@
 								</button>
 							</div>
 
-							<!-- Tab strip: open preview pages. "+" opens the router picker to
-								     add more. -->
-							<div
-								class="flex items-center gap-1 h-8 border-b border-light shrink-0 bg-surface-secondary overflow-x-auto {fullscreen
+							<!-- Tab strip: open preview pages, shared with the raw-app editor
+								     (DraggableTabs). The active tab hosts its own breadcrumb picker via
+								     the accessory chevron; the "+" trailing opens the router picker.
+								     Left/right padding clears the floating collapse/fullscreen buttons. -->
+							<DraggableTabs
+								tabs={previewTabItems}
+								activeId={owner?.activeId ?? ''}
+								onSelect={selectTab}
+								onClose={closeTab}
+								onReorder={reorderTabs}
+								class="h-8 border-b border-light bg-surface-secondary {fullscreen
 									? 'pl-1.5'
 									: 'pl-9'} pr-16"
 							>
-								{#each owner?.tabs ?? [] as tab (tab.id)}
-									<div
-										class="group/tab flex items-center gap-1 shrink-0 max-w-[14rem] h-6 pl-2 pr-1 rounded-md text-xs border transition-colors {tab.id ===
-										owner?.activeId
-											? 'bg-surface text-primary border-light'
-											: 'text-secondary border-transparent hover:bg-surface-hover'}"
-									>
-										{#if tab.id === owner?.activeId}
-											<!-- Active tab doubles as its own breadcrumb picker. -->
-											<Popover
-												placement="bottom-start"
-												usePointerDownOutside
-												excludeSelectors=".drawer"
-												disableFocusTrap
-												closeOnOtherPopoverOpen
-												enableFlyTransition
-												bind:isOpen={activeTabPickerOpen}
-												openFocus="[data-workspace-picker-search]"
-												class="flex items-center gap-1.5 min-w-0 cursor-pointer"
-											>
-												{#snippet trigger()}
-													<span class="truncate">{tabLabel(tab.loc)}</span>
-													<ChevronDown size={12} class="shrink-0 text-tertiary" />
-												{/snippet}
-												{#snippet content()}
-													<PreviewRouterPicker
-														initialScope={activePickerScope}
-														initialHighlight={activePickerHighlight}
-														{currentItem}
-														workspaceId={previewWorkspace}
-														onPick={(t) => {
-															activeTabPickerOpen = false
-															navigatePreviewTo(t)
-														}}
-													/>
-												{/snippet}
-											</Popover>
-										{:else}
-											<button
-												type="button"
-												class="flex items-center gap-1.5 min-w-0"
-												onclick={() => selectTab(tab.id)}
-												title={tabLabel(tab.loc)}
-											>
-												<span class="truncate">{tabLabel(tab.loc)}</span>
-											</button>
-										{/if}
-										<button
-											type="button"
-											onclick={() => closeTab(tab.id)}
-											title="Close tab"
-											aria-label="Close tab"
-											class="shrink-0 inline-flex items-center justify-center w-4 h-4 rounded text-tertiary hover:text-primary hover:bg-surface-hover opacity-0 group-hover/tab:opacity-100"
+								{#snippet tabAccessory(_tab, isActive)}
+									{#if isActive}
+										<Popover
+											placement="bottom-start"
+											usePointerDownOutside
+											excludeSelectors=".drawer"
+											disableFocusTrap
+											closeOnOtherPopoverOpen
+											enableFlyTransition
+											bind:isOpen={activeTabPickerOpen}
+											openFocus="[data-workspace-picker-search]"
+											class="flex items-center shrink-0 cursor-pointer text-tertiary hover:text-primary"
 										>
-											<X size={11} />
-										</button>
-									</div>
-								{/each}
-								<Popover
-									placement="bottom-start"
-									usePointerDownOutside
-									excludeSelectors=".drawer"
-									disableFocusTrap
-									closeOnOtherPopoverOpen
-									bind:isOpen={newTabOpen}
-									enableFlyTransition
-									openFocus="[data-workspace-picker-search]"
-									class="shrink-0 inline-flex items-center justify-center w-6 h-6 rounded text-tertiary hover:text-primary hover:bg-surface-hover cursor-pointer"
-								>
-									{#snippet trigger()}
-										<Plus size={14} />
-									{/snippet}
-									{#snippet content()}
-										<PreviewRouterPicker
-											workspaceId={previewWorkspace}
-											onPick={(t) => {
-												newTabOpen = false
-												openInNewTab(t)
-											}}
-										/>
-									{/snippet}
-								</Popover>
-							</div>
+											{#snippet trigger()}
+												<ChevronDown size={12} />
+											{/snippet}
+											{#snippet content()}
+												<PreviewRouterPicker
+													initialScope={activePickerScope}
+													initialHighlight={activePickerHighlight}
+													{currentItem}
+													workspaceId={previewWorkspace}
+													onPick={(t) => {
+														activeTabPickerOpen = false
+														navigatePreviewTo(t)
+													}}
+												/>
+											{/snippet}
+										</Popover>
+									{/if}
+								{/snippet}
+								{#snippet trailing()}
+									<Popover
+										placement="bottom-start"
+										usePointerDownOutside
+										excludeSelectors=".drawer"
+										disableFocusTrap
+										closeOnOtherPopoverOpen
+										bind:isOpen={newTabOpen}
+										enableFlyTransition
+										openFocus="[data-workspace-picker-search]"
+										class="shrink-0 inline-flex items-center justify-center w-6 h-6 rounded text-tertiary hover:text-primary hover:bg-surface-hover cursor-pointer"
+									>
+										{#snippet trigger()}
+											<Plus size={14} />
+										{/snippet}
+										{#snippet content()}
+											<PreviewRouterPicker
+												workspaceId={previewWorkspace}
+												onPick={(t) => {
+													newTabOpen = false
+													openInNewTab(t)
+												}}
+											/>
+										{/snippet}
+									</Popover>
+								{/snippet}
+							</DraggableTabs>
 
 							<!-- One host per tab of every warm session, stacked and
 								     visibility-toggled so switching tabs or sessions never reloads

--- a/frontend/src/routes/kitchen_sink/+page.svelte
+++ b/frontend/src/routes/kitchen_sink/+page.svelte
@@ -45,6 +45,10 @@ just some plain text
 no language, no coloring
 \`\`\`
 
+Raw sanitized HTML (via rehypeRaw) must keep its content, not render empty:
+
+<pre>raw pre content stays visible</pre>
+
 | Column A | Column B |
 | -------- | -------- |
 | one      | two      |

--- a/frontend/src/routes/kitchen_sink/+page.svelte
+++ b/frontend/src/routes/kitchen_sink/+page.svelte
@@ -5,9 +5,19 @@
 	import Tabs from '$lib/components/common/tabs/Tabs.svelte'
 	import DarkModeToggle from '$lib/components/sidebar/DarkModeToggle.svelte'
 	import GfmMarkdown from '$lib/components/GfmMarkdown.svelte'
+	import AssistantMessage from '$lib/components/copilot/chat/AssistantMessage.svelte'
+	import type { DisplayMessage } from '$lib/components/copilot/chat/shared'
+	import DraggableTabs, { type TabItem } from '$lib/components/common/tabs/DraggableTabs.svelte'
 	import { Globe } from 'lucide-svelte'
 
 	let tab = $state('button')
+
+	// Enough tabs to overflow a narrow strip so the shared ScrollableX hover
+	// scrollbar is exercised: drag to reorder, hover to reveal the 4px thumb.
+	let draggableTabs = $state<TabItem[]>(
+		Array.from({ length: 14 }, (_, i) => ({ id: `t${i}`, label: `Preview tab ${i + 1}` }))
+	)
+	let activeDraggableTab = $state('t0')
 
 	const sampleMarkdown = `# Heading 1
 
@@ -41,6 +51,68 @@ console.log(block)
 			onClick: () => {}
 		}
 	]
+
+	// Mirrors how the AI chat renders assistant answers: markdown flows through
+	// AssistantMessage, and fenced code blocks go through CodeDisplay →
+	// HighlightCode. Exercise several languages + prose so the code-block styling
+	// can be tuned against the real render path, not an approximation.
+	const chatSampleContent = `Here's how you'd wire up the trigger. First, some prose with \`inline code\`, a [link](https://windmill.dev), and **bold** text so we can see how code sits next to surrounding content.
+
+\`\`\`python
+def main(name: str = "world"):
+    # a short python snippet
+    greeting = f"hello, {name}!"
+    print(greeting)
+    return {"greeting": greeting}
+\`\`\`
+
+A one-liner in the middle of a sentence like \`SELECT * FROM users\` should stay inline. Now a TypeScript block:
+
+\`\`\`ts
+export async function main(count: number) {
+  const rows = await Promise.all(
+    Array.from({ length: count }, (_, i) => fetchRow(i))
+  )
+  return rows.filter((r) => r.active).map((r) => r.id)
+}
+\`\`\`
+
+A block with a very long line to check horizontal overflow behaviour:
+
+\`\`\`bash
+curl -sSL "https://app.windmill.dev/api/w/demo/jobs/run_wait_result/p/u/admin/very_long_script_path?token=abcdef0123456789&include_header=Authorization" | jq '.result.value'
+\`\`\`
+
+Some SQL:
+
+\`\`\`sql
+select id, name, created_at
+from users
+where active = true
+order by created_at desc
+limit 10;
+\`\`\`
+
+And a bulleted list where an item carries \`code\`:
+
+- First item with \`some_var\`
+- Second item
+- Third item
+
+\`\`\`rust
+fn main() {
+    let items = vec![1, 2, 3];
+    let sum: i32 = items.iter().sum();
+    println!("sum = {sum}");
+}
+\`\`\`
+
+That's the full round-trip.`
+
+	const chatMessage: DisplayMessage = {
+		role: 'assistant',
+		content: chatSampleContent
+	}
 </script>
 
 <DarkModeToggle forcedDarkMode={false} />
@@ -48,6 +120,8 @@ console.log(block)
 <Tabs bind:selected={tab}>
 	<Tab value="button" label="Buttons" />
 	<Tab value="markdown" label="Markdown" />
+	<Tab value="chat" label="AI Chat" />
+	<Tab value="scrollbar" label="Scrollbar" />
 
 	{#snippet content()}
 		<TabContent value="button" class="p-4 flex gap-4 flex-col ">
@@ -103,6 +177,29 @@ console.log(block)
 		</TabContent>
 		<TabContent value="markdown" class="p-4">
 			<GfmMarkdown md={sampleMarkdown} />
+		</TabContent>
+		<TabContent value="chat" class="p-4">
+			<div class="text-xs text-tertiary mb-3">
+				Rendered through the real chat path (<code>AssistantMessage</code> →
+				<code>CodeDisplay</code> → <code>HighlightCode</code>), constrained to the chat panel width.
+			</div>
+			<div class="border border-border-light rounded-lg p-3 bg-surface" style="max-width: 420px;">
+				<AssistantMessage message={chatMessage} />
+			</div>
+		</TabContent>
+		<TabContent value="scrollbar" class="p-4">
+			<div class="text-xs text-tertiary mb-3">
+				DraggableTabs (uses the shared <code>ScrollableX</code>, 4px bar): hover to reveal the
+				thumb, drag to reorder.
+			</div>
+			<div class="border border-border-light rounded-md" style="max-width: 420px;">
+				<DraggableTabs
+					tabs={draggableTabs}
+					activeId={activeDraggableTab}
+					onSelect={(id) => (activeDraggableTab = id)}
+					onReorder={(next) => (draggableTabs = next)}
+				/>
+			</div>
 		</TabContent>
 	{/snippet}
 </Tabs>

--- a/frontend/src/routes/kitchen_sink/+page.svelte
+++ b/frontend/src/routes/kitchen_sink/+page.svelte
@@ -38,6 +38,13 @@ const block = 'code block'
 console.log(block)
 \`\`\`
 
+An unlabeled fence should render plain (no forced syntax colors):
+
+\`\`\`
+just some plain text
+no language, no coloring
+\`\`\`
+
 | Column A | Column B |
 | -------- | -------- |
 | one      | two      |


### PR DESCRIPTION
## Summary

A batch of frontend polish across the AI chat, markdown rendering, and tab strips, unified around two new shared primitives (`MarkdownCodeBlock`, a `.scrollbar-subtle` utility) and the existing `DraggableTabs`:

1. **Universal styled markdown code blocks** — the nice chat code-block styling (highlighting, copy button, subtle scrollbar) now applies to every `GfmMarkdown`/`AppMarkdown` surface, not just the two AI-chat renderers.
2. **Shared session ↔ raw-app tab system** — the session preview tab strip now uses the same `DraggableTabs` component the raw-app editor uses (drag-reorder, keyboard nav, close), keeping its active-tab breadcrumb/router picker.
3. **Subtle scrollbars everywhere** — one `.scrollbar-subtle` utility (thin, hover-revealed thumb) shared by the tab strips, code blocks, `Tabs`/`TabsV2` headers, and the AI chat message list — replacing a broken melt scrollbar and the chunky native ones.

## Markdown code blocks

- **New `MarkdownCodeBlock.svelte`** — chat-agnostic `svelte-exmarkdown` `pre` renderer: highlighted panel (`bg-surface-secondary`, rounded, `text-xs`), hover-revealed copy button on a `bg-surface` chip, subtle horizontal scrollbar. Apply button + mermaid are opt-in props (default off) so untrusted markdown never executes mermaid. Recognized fence languages (incl. common aliases like `ts`/`js`/`py`) are highlighted; **unlabeled/unknown fences render as plaintext** rather than being mis-colored as TypeScript.
- **`markdownPlugins.ts`** — added `{ renderer: { pre: MarkdownCodeBlock } }` to the shared chain. Language read from the `language-*` class `rehypeSanitize` preserves; code highlighted as escaped text (no new XSS surface).
- **`CodeDisplay.svelte`** (chat) — slimmed to a thin wrapper delegating to `MarkdownCodeBlock`, adding the Apply button + mermaid.
- **`HighlightCode.svelte`** — the subtle `CopyButton`-on-a-surface-chip is **opt-in via `buttonsOnHover`** (set by the markdown/chat renderer only); the ~20 other callers keep the original light copy `Button`. Also gains optional `customScrollbarX`.

_Scope note: markdown sinks that bypass the shared chain (`DisplayResult`, `AiSkillsSettings`, the chat "Thinking" block) intentionally keep plain code blocks._

## Tabs

- **`DraggableTabs.svelte`** — new `tabAccessory` snippet (per-tab, e.g. the session's active-tab picker; a click on it stops propagation so it doesn't re-select the tab) and `afterTabs` snippet (rendered inside the scroll row after the last tab, e.g. a "+" button — vs `trailing`, which stays pinned outside). Now consumes `ScrollableX`.
- **`sessions/+page.svelte`** — bespoke tab markup replaced with `DraggableTabs`; active-tab router picker → `tabAccessory` chevron, "+" new-tab → `afterTabs` (right after the last tab). Tab strip `bg-surface-secondary/50`; preview-bar buttons (collapse / open-in-workspace / fullscreen) are hover-only background. (Adopting `DraggableTabs` restyles the active tab to its `bg-surface-tertiary` — an intended consequence of sharing the component.)
- **`sessionPreviewTabs.svelte.ts`** — new `reorder(orderedIds)` method (with persistence) for drag-reorder.
- **`Tabs.svelte` / `TabsV2.svelte`** — header rows use `ScrollableX` for the subtle scrollbar.

## Scrollbars

- **New `.scrollbar-subtle` utility** (`app.css`) — thin, hover-revealed rounded thumb on both axes, thickness via `--wm-scrollbar-size`, out-specifying the app-wide `*::-webkit-scrollbar`.
- **New `ScrollableX.svelte`** — native horizontal scroll (Tailwind `overflow-x-auto`) consuming `.scrollbar-subtle`, replacing melt's `createScrollArea` (whose thumb never tracked scroll position).
- **`AIChatDisplay.svelte`** — the chat message list uses `.scrollbar-subtle` so it matches the tabs.

## Screenshots

**Universal markdown (`GfmMarkdown`) — highlighted with hover copy button:**

![pr-universal-md](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/improve-session/1783500285-v4-pr-universal-md.png)

**AI chat code blocks:**

![pr-ai-chat](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/improve-session/1783500285-v4-pr-ai-chat.png)

**Sessions — preview tabs on the shared DraggableTabs (active "Runs ⌄" with picker, "+" after last tab, subtle chat scrollbar):**

![pr-sessions-final](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/improve-session/1783503861-pr-sessions-final.png)

## Test plan

- [ ] Script/flow/resource markdown description with fenced code blocks (labeled and unlabeled), and an App `Markdown` component with a code block → labeled highlight, unlabeled render plain, hover copy, subtle scrollbar, copy works
- [ ] A non-markdown `HighlightCode` caller (editor bar, log panel, script/run page) → copy button unchanged (light Button)
- [ ] AI chat: code blocks highlight, Apply button (Script mode) + mermaid still render; message-list scrollbar is thin/hover-revealed
- [ ] Sessions preview tabs: open/select/close/drag-reorder (persists across reload), active-tab chevron opens the router picker, "+" (after last tab) opens it
- [ ] `Tabs`/`TabsV2` header overflow shows the subtle scrollbar
- [ ] Verify in light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)