### PR TITLE
fix: preserve worker group tag override on 'Run again'

### DIFF
--- a/frontend/src/lib/components/RunForm.svelte
+++ b/frontend/src/lib/components/RunForm.svelte
@@ -201,6 +201,7 @@
 		jsonEditor?.setCode(code)
 	}
 	$effect(() => {
+		overrideTag
 		Object.keys(args ?? {}).forEach((key) => {
 			args?.[key]
 		})

--- a/frontend/src/lib/components/RunForm.svelte
+++ b/frontend/src/lib/components/RunForm.svelte
@@ -160,7 +160,7 @@
 			debounced && clearTimeout(debounced)
 			debounced = setTimeout(() => {
 				const nurl = new URL(window.location.href)
-				nurl.hash = computeSharableHash(args)
+				nurl.hash = computeSharableHash(args, overrideTag)
 
 				try {
 					replaceState(nurl.toString(), page.state)

--- a/frontend/src/lib/components/RunForm.svelte
+++ b/frontend/src/lib/components/RunForm.svelte
@@ -114,6 +114,7 @@
 		scheduledForStr: string | undefined
 		invisible_to_owner: boolean | undefined
 		overrideTag: string | undefined
+		overrideTagNote?: string
 		args?: Record<string, any>
 		jsonView?: boolean
 		isValid?: boolean
@@ -132,6 +133,7 @@
 		scheduledForStr = $bindable(),
 		invisible_to_owner = $bindable(),
 		overrideTag = $bindable(),
+		overrideTagNote = undefined,
 		args = $bindable(),
 		jsonView = false,
 		isValid = $bindable(true)
@@ -387,6 +389,10 @@
 			{#if overrideTag}
 				<div class="flex-row-reverse flex w-full text-primary text-sm">
 					tag override: {overrideTag}
+				</div>
+			{:else if overrideTagNote}
+				<div class="flex-row-reverse flex w-full text-secondary text-xs">
+					{overrideTagNote}
 				</div>
 			{/if}
 			{#if invisible_to_owner}

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import {
 	cleanValueProperties,
+	computeSharableHash,
+	extractTagFromSharableHash,
 	getQueryStmtCountHeuristic,
 	parseDbInputFromAssetSyntax
 } from './utils'
@@ -388,5 +390,41 @@ describe('cleanValueProperties', () => {
 		const input: any = { summary: 'hi', created_at: '2024-01-01' }
 		cleanValueProperties(input)
 		expect(input).toHaveProperty('created_at')
+	})
+})
+
+describe('computeSharableHash / extractTagFromSharableHash', () => {
+	function roundTrip(hash: string) {
+		const params = new URLSearchParams(hash)
+		const tag = extractTagFromSharableHash(params)
+		const args = Object.fromEntries(
+			[...params.entries()].map(([k, v]) => [k, JSON.parse(v)])
+		)
+		return { tag, args }
+	}
+
+	it('carries the tag as raw __tag alongside JSON-encoded args', () => {
+		const hash = computeSharableHash({ name: 'world' }, 'my-custom-tag')
+		expect(roundTrip(hash)).toEqual({ tag: 'my-custom-tag', args: { name: 'world' } })
+	})
+
+	it('omits __tag when no tag is given', () => {
+		const hash = computeSharableHash({ name: 'world' })
+		expect(roundTrip(hash)).toEqual({ tag: undefined, args: { name: 'world' } })
+	})
+
+	it('preserves an arg named __tag instead of misreading it as a tag', () => {
+		const hash = computeSharableHash({ __tag: 'value', name: 'world' })
+		expect(roundTrip(hash)).toEqual({ tag: undefined, args: { __tag: 'value', name: 'world' } })
+	})
+
+	it('lets an arg named __tag win over a carried tag', () => {
+		const hash = computeSharableHash({ __tag: 'value' }, 'my-custom-tag')
+		expect(roundTrip(hash)).toEqual({ tag: undefined, args: { __tag: 'value' } })
+	})
+
+	it('drops a JSON-parseable tag rather than corrupting args', () => {
+		const hash = computeSharableHash({ name: 'world' }, '123')
+		expect(roundTrip(hash)).toEqual({ tag: undefined, args: { name: 'world' } })
 	})
 })

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -436,13 +436,14 @@ describe('computeSharableHash / extractTagFromSharableHash', () => {
 })
 
 describe('isDynamicTag', () => {
-	it('detects interpolation placeholders', () => {
+	it('detects args interpolation placeholders', () => {
 		expect(isDynamicTag('worker-$args[env]')).toBe(true)
-		expect(isDynamicTag('$workspace-gpu')).toBe(true)
 	})
 
-	it('is false for plain tags and undefined', () => {
+	it('is false for plain tags, $workspace-only tags, and undefined', () => {
 		expect(isDynamicTag('gpu-heavy')).toBe(false)
+		// $workspace resolves identically on a re-run, so pinning the resolved value is fine
+		expect(isDynamicTag('$workspace-gpu')).toBe(false)
 		expect(isDynamicTag('')).toBe(false)
 		expect(isDynamicTag(undefined)).toBe(false)
 	})

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -397,13 +397,11 @@ describe('computeSharableHash / extractTagFromSharableHash', () => {
 	function roundTrip(hash: string) {
 		const params = new URLSearchParams(hash)
 		const tag = extractTagFromSharableHash(params)
-		const args = Object.fromEntries(
-			[...params.entries()].map(([k, v]) => [k, JSON.parse(v)])
-		)
+		const args = Object.fromEntries([...params.entries()].map(([k, v]) => [k, JSON.parse(v)]))
 		return { tag, args }
 	}
 
-	it('carries the tag as raw __tag alongside JSON-encoded args', () => {
+	it('carries the tag under the reserved __tag key alongside JSON-encoded args', () => {
 		const hash = computeSharableHash({ name: 'world' }, 'my-custom-tag')
 		expect(roundTrip(hash)).toEqual({ tag: 'my-custom-tag', args: { name: 'world' } })
 	})
@@ -423,8 +421,15 @@ describe('computeSharableHash / extractTagFromSharableHash', () => {
 		expect(roundTrip(hash)).toEqual({ tag: undefined, args: { __tag: 'value' } })
 	})
 
-	it('drops a JSON-parseable tag rather than corrupting args', () => {
-		const hash = computeSharableHash({ name: 'world' }, '123')
-		expect(roundTrip(hash)).toEqual({ tag: undefined, args: { name: 'world' } })
+	it('carries JSON-parseable tags like 123 or true without corrupting args', () => {
+		expect(roundTrip(computeSharableHash({ name: 'world' }, '123'))).toEqual({
+			tag: '123',
+			args: { name: 'world' }
+		})
+		expect(roundTrip(computeSharableHash({}, 'true'))).toEqual({ tag: 'true', args: {} })
+	})
+
+	it('carries a tag that itself starts with the value prefix', () => {
+		expect(roundTrip(computeSharableHash({}, 't:odd'))).toEqual({ tag: 't:odd', args: {} })
 	})
 })

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -3,6 +3,7 @@ import {
 	cleanValueProperties,
 	computeSharableHash,
 	extractTagFromSharableHash,
+	isDynamicTag,
 	getQueryStmtCountHeuristic,
 	parseDbInputFromAssetSyntax
 } from './utils'
@@ -431,5 +432,18 @@ describe('computeSharableHash / extractTagFromSharableHash', () => {
 
 	it('carries a tag that itself starts with the value prefix', () => {
 		expect(roundTrip(computeSharableHash({}, 't:odd'))).toEqual({ tag: 't:odd', args: {} })
+	})
+})
+
+describe('isDynamicTag', () => {
+	it('detects interpolation placeholders', () => {
+		expect(isDynamicTag('worker-$args[env]')).toBe(true)
+		expect(isDynamicTag('$workspace-gpu')).toBe(true)
+	})
+
+	it('is false for plain tags and undefined', () => {
+		expect(isDynamicTag('gpu-heavy')).toBe(false)
+		expect(isDynamicTag('')).toBe(false)
+		expect(isDynamicTag(undefined)).toBe(false)
 	})
 })

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -417,9 +417,12 @@ describe('computeSharableHash / extractTagFromSharableHash', () => {
 		expect(roundTrip(hash)).toEqual({ tag: undefined, args: { __tag: 'value', name: 'world' } })
 	})
 
-	it('lets an arg named __tag win over a carried tag', () => {
-		const hash = computeSharableHash({ __tag: 'value' }, 'my-custom-tag')
-		expect(roundTrip(hash)).toEqual({ tag: undefined, args: { __tag: 'value' } })
+	it('carries a tag alongside an arg named __tag, preserving both', () => {
+		const hash = computeSharableHash({ __tag: 'value', name: 'world' }, 'my-custom-tag')
+		expect(roundTrip(hash)).toEqual({
+			tag: 'my-custom-tag',
+			args: { __tag: 'value', name: 'world' }
+		})
 	})
 
 	it('carries JSON-parseable tags like 123 or true without corrupting args', () => {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1137,11 +1137,22 @@ export function extractCustomProperties(styleStr: string): string {
 	return customStyleStr
 }
 
-// `tag` is carried as the reserved key `__tag` (raw, not JSON-encoded) and must be
-// stripped from the params before they are parsed as args (see scripts/flows get pages)
+function isJsonEncoded(value: string): boolean {
+	try {
+		JSON.parse(value)
+		return true
+	} catch {
+		return false
+	}
+}
+
+// `tag` is carried as the reserved key `__tag`, kept raw (unlike args, which are
+// JSON-encoded) so extractTagFromSharableHash can tell it apart from a genuine arg
+// named `__tag`. A JSON-parseable tag would be ambiguous, so it is not carried,
+// and an arg named `__tag` overwrites (wins over) the reserved key.
 export function computeSharableHash(args: any, tag?: string) {
 	let nargs = {}
-	if (tag) {
+	if (tag && !isJsonEncoded(tag)) {
 		nargs['__tag'] = tag
 	}
 	for (let k in args) {
@@ -1163,6 +1174,18 @@ export function computeSharableHash(args: any, tag?: string) {
 		console.error('Error computing sharable hash', e)
 		return ''
 	}
+}
+
+// Counterpart of computeSharableHash's `tag`: extracts and removes the reserved raw
+// `__tag` key. A JSON-parseable value is a genuine arg named `__tag`, not a carried
+// tag, so it is left in `params` for arg parsing.
+export function extractTagFromSharableHash(params: URLSearchParams): string | undefined {
+	const value = params.get('__tag')
+	if (value != null && !isJsonEncoded(value)) {
+		params.delete('__tag')
+		return value
+	}
+	return undefined
 }
 
 export function toCamel(s: string) {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1137,23 +1137,17 @@ export function extractCustomProperties(styleStr: string): string {
 	return customStyleStr
 }
 
-function isJsonEncoded(value: string): boolean {
-	try {
-		JSON.parse(value)
-		return true
-	} catch {
-		return false
-	}
-}
+// Value prefix marking the reserved `__tag` key as a carried tag: no JSON-encoded
+// arg value can start with `t:` (JSON strings start with `"`, numbers with a digit
+// or `-`, etc.), so it cannot be confused with a genuine arg named `__tag`
+const SHARABLE_HASH_TAG_PREFIX = 't:'
 
-// `tag` is carried as the reserved key `__tag`, kept raw (unlike args, which are
-// JSON-encoded) so extractTagFromSharableHash can tell it apart from a genuine arg
-// named `__tag`. A JSON-parseable tag would be ambiguous, so it is not carried,
-// and an arg named `__tag` overwrites (wins over) the reserved key.
+// `tag` is carried as the reserved key `__tag` with a SHARABLE_HASH_TAG_PREFIX value;
+// an arg named `__tag` overwrites (wins over) the reserved key in the loop below
 export function computeSharableHash(args: any, tag?: string) {
 	let nargs = {}
-	if (tag && !isJsonEncoded(tag)) {
-		nargs['__tag'] = tag
+	if (tag) {
+		nargs['__tag'] = SHARABLE_HASH_TAG_PREFIX + tag
 	}
 	for (let k in args) {
 		let v = args[k]
@@ -1176,14 +1170,14 @@ export function computeSharableHash(args: any, tag?: string) {
 	}
 }
 
-// Counterpart of computeSharableHash's `tag`: extracts and removes the reserved raw
-// `__tag` key. A JSON-parseable value is a genuine arg named `__tag`, not a carried
-// tag, so it is left in `params` for arg parsing.
+// Counterpart of computeSharableHash's `tag`: extracts and removes the reserved
+// `__tag` key. Only a SHARABLE_HASH_TAG_PREFIX-prefixed value is a carried tag; any
+// other value is a genuine arg named `__tag` and is left in `params` for arg parsing.
 export function extractTagFromSharableHash(params: URLSearchParams): string | undefined {
 	const value = params.get('__tag')
-	if (value != null && !isJsonEncoded(value)) {
+	if (value?.startsWith(SHARABLE_HASH_TAG_PREFIX)) {
 		params.delete('__tag')
-		return value
+		return value.slice(SHARABLE_HASH_TAG_PREFIX.length)
 	}
 	return undefined
 }

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1170,11 +1170,12 @@ export function computeSharableHash(args: any, tag?: string) {
 	}
 }
 
-// Tags with interpolation placeholders are resolved by the backend at push time from
-// the run's args/workspace; a job's stored tag is the resolved value, so re-running
-// with it would pin a value that no longer matches edited args
+// `$args[...]` tags are resolved by the backend at push time from the run's args; a
+// job's stored tag is the resolved value, so re-running with it would pin a value
+// that no longer matches edited args. `$workspace` is also interpolated but resolves
+// identically on a re-run (same workspace), so it does not make a tag dynamic here.
 export function isDynamicTag(tag: string | undefined): boolean {
-	return !!tag && (tag.includes('$args[') || tag.includes('$workspace'))
+	return !!tag && tag.includes('$args[')
 }
 
 // Counterpart of computeSharableHash's `tag`: extracts and removes the reserved

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1143,11 +1143,12 @@ export function extractCustomProperties(styleStr: string): string {
 const SHARABLE_HASH_TAG_PREFIX = 't:'
 
 // `tag` is carried as the reserved key `__tag` with a SHARABLE_HASH_TAG_PREFIX value;
-// an arg named `__tag` overwrites (wins over) the reserved key in the loop below
+// entry pairs allow a duplicate `__tag` key so an arg with that name can coexist with
+// the carried tag (they are told apart by the value prefix)
 export function computeSharableHash(args: any, tag?: string) {
-	let nargs = {}
+	let entries: [string, string][] = []
 	if (tag) {
-		nargs['__tag'] = SHARABLE_HASH_TAG_PREFIX + tag
+		entries.push(['__tag', SHARABLE_HASH_TAG_PREFIX + tag])
 	}
 	for (let k in args) {
 		let v = args[k]
@@ -1158,11 +1159,11 @@ export function computeSharableHash(args: any, tag?: string) {
 				console.error(`Value at key ${k} too big (${size}) to be shared`)
 				return ''
 			}
-			nargs[k] = JSON.stringify(v)
+			entries.push([k, JSON.stringify(v)])
 		}
 	}
 	try {
-		let r = new URLSearchParams(nargs).toString()
+		let r = new URLSearchParams(entries).toString()
 		return r.length > 1000000 ? '' : r
 	} catch (e) {
 		console.error('Error computing sharable hash', e)
@@ -1178,16 +1179,22 @@ export function isDynamicTag(tag: string | undefined): boolean {
 	return !!tag && tag.includes('$args[')
 }
 
-// Counterpart of computeSharableHash's `tag`: extracts and removes the reserved
-// `__tag` key. Only a SHARABLE_HASH_TAG_PREFIX-prefixed value is a carried tag; any
-// other value is a genuine arg named `__tag` and is left in `params` for arg parsing.
+// Counterpart of computeSharableHash's `tag`: extracts and removes the carried tag.
+// Only SHARABLE_HASH_TAG_PREFIX-prefixed `__tag` values are carried tags; any other
+// `__tag` value is a genuine arg with that name and is left in `params` for arg parsing.
 export function extractTagFromSharableHash(params: URLSearchParams): string | undefined {
-	const value = params.get('__tag')
-	if (value?.startsWith(SHARABLE_HASH_TAG_PREFIX)) {
-		params.delete('__tag')
-		return value.slice(SHARABLE_HASH_TAG_PREFIX.length)
+	const values = params.getAll('__tag')
+	const carried = values.find((v) => v.startsWith(SHARABLE_HASH_TAG_PREFIX))
+	if (carried == undefined) {
+		return undefined
 	}
-	return undefined
+	params.delete('__tag')
+	for (const v of values) {
+		if (!v.startsWith(SHARABLE_HASH_TAG_PREFIX)) {
+			params.append('__tag', v)
+		}
+	}
+	return carried.slice(SHARABLE_HASH_TAG_PREFIX.length)
 }
 
 export function toCamel(s: string) {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1137,8 +1137,13 @@ export function extractCustomProperties(styleStr: string): string {
 	return customStyleStr
 }
 
-export function computeSharableHash(args: any) {
+// `tag` is carried as the reserved key `__tag` (raw, not JSON-encoded) and must be
+// stripped from the params before they are parsed as args (see scripts/flows get pages)
+export function computeSharableHash(args: any, tag?: string) {
 	let nargs = {}
+	if (tag) {
+		nargs['__tag'] = tag
+	}
 	for (let k in args) {
 		let v = args[k]
 		if (v !== undefined) {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1170,6 +1170,13 @@ export function computeSharableHash(args: any, tag?: string) {
 	}
 }
 
+// Tags with interpolation placeholders are resolved by the backend at push time from
+// the run's args/workspace; a job's stored tag is the resolved value, so re-running
+// with it would pin a value that no longer matches edited args
+export function isDynamicTag(tag: string | undefined): boolean {
+	return !!tag && (tag.includes('$args[') || tag.includes('$workspace'))
+}
+
 // Counterpart of computeSharableHash's `tag`: extracts and removes the reserved
 // `__tag` key. Only a SHARABLE_HASH_TAG_PREFIX-prefixed value is a carried tag; any
 // other value is a genuine arg named `__tag` and is left in `params` for arg parsing.

--- a/frontend/src/routes/(root)/(logged)/flows/get/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/flows/get/[...path]/+page.svelte
@@ -246,6 +246,12 @@
 	if (hash.length > 1) {
 		try {
 			let searchParams = new URLSearchParams(hash.slice(1))
+			// `__tag` is a reserved key set by computeSharableHash ('Run again'), not a flow arg
+			const tagParam = searchParams.get('__tag')
+			if (tagParam) {
+				overrideTag = tagParam
+				searchParams.delete('__tag')
+			}
 			let params = [...Object.entries(urlParamsToObject(searchParams))].map(([k, v]) => [
 				k,
 				JSON.parse(v)

--- a/frontend/src/routes/(root)/(logged)/flows/get/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/flows/get/[...path]/+page.svelte
@@ -13,7 +13,8 @@
 		defaultIfEmptyString,
 		emptyString,
 		urlParamsToObject,
-		extractTagFromSharableHash
+		extractTagFromSharableHash,
+		isDynamicTag
 	} from '$lib/utils'
 	import { isDeployable, ALL_DEPLOYABLE } from '$lib/utils_deployable'
 
@@ -84,6 +85,9 @@
 	let scheduledForStr: string | undefined = $state(undefined)
 	let invisible_to_owner: boolean | undefined = $state(undefined)
 	let overrideTag: string | undefined = $state(undefined)
+	let overrideTagNote: string | undefined = $state(undefined)
+	// Tag carried over from 'Run again', pending the dynamic-tag check in loadFlow
+	let carriedTag: string | undefined = undefined
 	let inputSelected: 'saved' | 'history' | undefined = $state(undefined)
 	let jsonView = $state(false)
 	let deploymentInProgress = $state(false)
@@ -174,6 +178,15 @@
 			})
 			pinnedVersion = undefined
 		}
+		// A carried tag is the previous run's resolved value; when the flow's tag is
+		// dynamic, drop it so the backend re-resolves from the (possibly edited) args
+		if (carriedTag && isDynamicTag(flow.tag)) {
+			if (overrideTag === carriedTag) {
+				overrideTag = undefined
+				overrideTagNote = `tag ${flow.tag} is resolved at run time, so the previous run's tag ${carriedTag} was not applied`
+			}
+			carriedTag = undefined
+		}
 		if (!flow.path.startsWith(`u/${$userStore?.username}`) && flow.path.split('/').length > 2) {
 			invisible_to_owner = flow.visible_to_runner_only
 		}
@@ -252,7 +265,8 @@
 	if (hash.length > 1) {
 		try {
 			let searchParams = new URLSearchParams(hash.slice(1))
-			overrideTag = extractTagFromSharableHash(searchParams)
+			carriedTag = extractTagFromSharableHash(searchParams)
+			overrideTag = carriedTag
 			let params = [...Object.entries(urlParamsToObject(searchParams))].map(([k, v]) => [
 				k,
 				JSON.parse(v)
@@ -717,6 +731,7 @@
 									bind:scheduledForStr
 									bind:invisible_to_owner
 									bind:overrideTag
+									{overrideTagNote}
 									viewKeybinding
 									{loading}
 									autofocus

--- a/frontend/src/routes/(root)/(logged)/flows/get/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/flows/get/[...path]/+page.svelte
@@ -8,7 +8,13 @@
 		type TriggersCount,
 		type WorkspaceDeployUISettings
 	} from '$lib/gen'
-	import { canWrite, defaultIfEmptyString, emptyString, urlParamsToObject } from '$lib/utils'
+	import {
+		canWrite,
+		defaultIfEmptyString,
+		emptyString,
+		urlParamsToObject,
+		extractTagFromSharableHash
+	} from '$lib/utils'
 	import { isDeployable, ALL_DEPLOYABLE } from '$lib/utils_deployable'
 
 	import DetailPageLayout from '$lib/components/details/DetailPageLayout.svelte'
@@ -246,12 +252,7 @@
 	if (hash.length > 1) {
 		try {
 			let searchParams = new URLSearchParams(hash.slice(1))
-			// `__tag` is a reserved key set by computeSharableHash ('Run again'), not a flow arg
-			const tagParam = searchParams.get('__tag')
-			if (tagParam) {
-				overrideTag = tagParam
-				searchParams.delete('__tag')
-			}
+			overrideTag = extractTagFromSharableHash(searchParams)
 			let params = [...Object.entries(urlParamsToObject(searchParams))].map(([k, v]) => [
 				k,
 				JSON.parse(v)

--- a/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
@@ -378,7 +378,8 @@
 
 			const commonArgs = {
 				workspace: $workspaceStore!,
-				requestBody: args
+				requestBody: args,
+				tag: job?.tag
 			}
 			if (job?.job_kind == 'script' || job?.job_kind == 'script_hub' || job?.job_kind == 'flow') {
 				let id
@@ -723,7 +724,7 @@
 			{#if job?.job_kind === 'script' || job?.job_kind === 'script_hub' || job?.job_kind === 'flow'}
 				<Button
 					on:click|once={() => {
-						goto(viewHref + `#${computeSharableHash(job?.args)}`)
+						goto(viewHref + `#${computeSharableHash(job?.args, job?.tag)}`)
 					}}
 					unifiedSize="md"
 					variant="default"

--- a/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
@@ -15,7 +15,8 @@
 		truncateHash,
 		copyToClipboard,
 		urlParamsToObject,
-		extractTagFromSharableHash
+		extractTagFromSharableHash,
+		isDynamicTag
 	} from '$lib/utils'
 	import Tooltip from '$lib/components/Tooltip.svelte'
 	import ShareModal from '$lib/components/ShareModal.svelte'
@@ -118,6 +119,9 @@
 	let scheduledForStr: string | undefined = $state(undefined)
 	let invisible_to_owner: boolean | undefined = $state(undefined)
 	let overrideTag: string | undefined = $state(undefined)
+	let overrideTagNote: string | undefined = $state(undefined)
+	// Tag carried over from 'Run again', pending the dynamic-tag check in loadScript
+	let carriedTag: string | undefined = undefined
 	let inputSelected: 'saved' | 'history' | undefined = $state(undefined)
 	let jsonView = $state(false)
 
@@ -259,6 +263,15 @@
 				return
 			}
 		}
+		// A carried tag is the previous run's resolved value; when the script's tag is
+		// dynamic, drop it so the backend re-resolves from the (possibly edited) args
+		if (carriedTag && isDynamicTag(script.tag)) {
+			if (overrideTag === carriedTag) {
+				overrideTag = undefined
+				overrideTagNote = `tag ${script.tag} is resolved at run time, so the previous run's tag ${carriedTag} was not applied`
+			}
+			carriedTag = undefined
+		}
 		can_write =
 			script.workspace_id == $workspaceStore &&
 			canWrite(script.path, script.extra_perms!, $userStore)
@@ -335,7 +348,8 @@
 	if (hash.length > 1) {
 		try {
 			let searchParams = new URLSearchParams(hash.slice(1))
-			overrideTag = extractTagFromSharableHash(searchParams)
+			carriedTag = extractTagFromSharableHash(searchParams)
+			overrideTag = carriedTag
 			let params = [...Object.entries(urlParamsToObject(searchParams))].map(([k, v]) => [
 				k,
 				JSON.parse(v)
@@ -879,6 +893,7 @@
 								bind:scheduledForStr
 								bind:invisible_to_owner
 								bind:overrideTag
+								{overrideTagNote}
 								viewKeybinding
 								loading={runLoading}
 								autofocus

--- a/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
@@ -14,7 +14,8 @@
 		canWrite,
 		truncateHash,
 		copyToClipboard,
-		urlParamsToObject
+		urlParamsToObject,
+		extractTagFromSharableHash
 	} from '$lib/utils'
 	import Tooltip from '$lib/components/Tooltip.svelte'
 	import ShareModal from '$lib/components/ShareModal.svelte'
@@ -334,12 +335,7 @@
 	if (hash.length > 1) {
 		try {
 			let searchParams = new URLSearchParams(hash.slice(1))
-			// `__tag` is a reserved key set by computeSharableHash ('Run again'), not a script arg
-			const tagParam = searchParams.get('__tag')
-			if (tagParam) {
-				overrideTag = tagParam
-				searchParams.delete('__tag')
-			}
+			overrideTag = extractTagFromSharableHash(searchParams)
 			let params = [...Object.entries(urlParamsToObject(searchParams))].map(([k, v]) => [
 				k,
 				JSON.parse(v)

--- a/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
@@ -334,6 +334,12 @@
 	if (hash.length > 1) {
 		try {
 			let searchParams = new URLSearchParams(hash.slice(1))
+			// `__tag` is a reserved key set by computeSharableHash ('Run again'), not a script arg
+			const tagParam = searchParams.get('__tag')
+			if (tagParam) {
+				overrideTag = tagParam
+				searchParams.delete('__tag')
+			}
 			let params = [...Object.entries(urlParamsToObject(searchParams))].map(([k, v]) => [
 				k,
 				JSON.parse(v)


### PR DESCRIPTION
Fixes WIN-2142

## Summary

When clicking 'Run again' on a job, the worker group tag override from the original run was lost: the main button only encoded args in the URL hash, and the 'Run immediately with same args' dropdown did not pass a tag to the run APIs. Both paths now carry the original job's tag forward, with dynamic (templated) tags re-resolved instead of pinned.

## Changes

- `computeSharableHash` (utils.ts) accepts an optional tag and encodes it in the URL hash under the reserved key `__tag`, with a `t:` value prefix. No JSON-encoded arg value can start with `t:` (JSON strings start with `"`, numbers with a digit or `-`, etc.), so the new `extractTagFromSharableHash` counterpart can unambiguously tell a carried tag apart from a genuine arg named `__tag` for every possible tag value, including JSON-parseable tags like `123`. A carried tag and an arg named `__tag` coexist as duplicate keys, so both are preserved.
- Run detail page: the 'Run again' button passes `job?.tag` into the hash, and `runImmediately()` passes `tag: job?.tag` to `runScriptByHash` / `runScriptByPath` / `runFlowByPath`.
- Scripts and flows detail pages: the tag is extracted from the parsed hash into `overrideTag` via `extractTagFromSharableHash` and removed before the remaining params are parsed as args, so it never leaks into the input form.
- Dynamic tags: a job only stores the resolved tag (backend interpolates `$args[...]`/`$workspace` at push time), so pinning it would go stale if the user edits args before re-running. When the loaded script/flow's configured tag is `$args[...]`-templated (`isDynamicTag`), the carried tag is dropped so the backend re-resolves it from the submitted args, and `RunForm` shows a note in place of the tag override line explaining that the previous run's tag was not applied.
- `RunForm`'s debounced hash rewrite includes `overrideTag` and reacts to tag changes as well as arg changes, so the URL stays in sync when the worker group is changed or reset from the Advanced popup, and the tag survives a page refresh or a copied link.
- Unit tests in `utils.test.ts` cover the round-trip, the `__tag` arg collision cases, JSON-parseable tags, a tag that itself starts with the value prefix, and `isDynamicTag`.

## Notes

- A job record only stores the final tag, not whether it was an override, so 'Run again' pins the original run's tag for scripts/flows with a plain (non-templated) tag. For runs without an override this is the default tag (same routing). If the script/flow's tag configuration changes between runs, a re-run keeps the original run's tag rather than picking up the new default, which matches the "same run" intent of the button; the override is visible in the form and can be reset from Advanced.
- A genuine manual override on a script/flow whose configured tag is templated is indistinguishable from the resolved default in the job record, so it is also re-resolved on 'Run again' (with the note shown). Persisting an "explicit override" flag on jobs backend-side would remove that ambiguity and is left as a follow-up if it matters in practice.

## Test plan

- [x] `npm run check:fast` passes; `npx vitest run src/lib/utils.test.ts` passes (73 tests)
- [x] Script run with `?tag=my-custom-tag` → 'Run again' navigates to `/scripts/get/...#__tag=t%3Amy-custom-tag&name=...`, the form shows `tag override: my-custom-tag`, the arg is prefilled, and submitting creates a job with tag `my-custom-tag` (verified in DB)
- [x] 'Run immediately with same args' creates a job with tag `my-custom-tag` (verified in DB)
- [x] Flow run with a tag override → 'Run again' lands on `/flows/get/...` with the tag override captured
- [x] After landing on the get page, the URL hash keeps `__tag` through the debounced rewrite and the override survives a browser refresh
- [x] Changing the worker group from the Advanced popup without touching args updates the URL hash; resetting it removes `__tag` (verified in browser)
- [x] Script with tag `worker-$args[env]` run with `env=prod` (job tag `worker-prod`) → 'Run again' shows the dynamic-tag note instead of a tag override; editing `env` to `dev` and running creates a job with tag `worker-dev`, re-resolved from the edited args (verified in DB)
- [x] Args named `__tag` round-trip as args, including alongside a carried tag (both preserved); JSON-parseable tags like `123` are preserved (unit tests + browser check)

## Screenshots

Script 'Run again' with the original run's tag override prefilled:

![run-again-tag-override](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/hugo/win-2142-preserve-worker-group-tag-override-on-run-again/1783501208-run-again-tag-override.png)

Flow 'Run again' with the tag override prefilled:

![run-again-tag-override-flow](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/hugo/win-2142-preserve-worker-group-tag-override-on-run-again/1783501209-run-again-tag-override-flow.png)

'Run again' on a job whose script has a dynamic tag (`worker-$args[env]`): the resolved tag is not pinned and a note explains why:

![run-again-dynamic-tag-note](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/hugo/win-2142-preserve-worker-group-tag-override-on-run-again/1783513931-run-again-dynamic-tag-note.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
