### PR TITLE
fix: replicate external secret backend secrets when forking a workspace

### DIFF
--- a/backend/.sqlx/query-e4a46d47aee96473a2bd0f1dbdc819520a2ba987fd29859845c2177563ab8cfb.json
+++ b/backend/.sqlx/query-e4a46d47aee96473a2bd0f1dbdc819520a2ba987fd29859845c2177563ab8cfb.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT path, value FROM variable\n             WHERE workspace_id = $1 AND is_secret = true AND value != ''",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "value",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "e4a46d47aee96473a2bd0f1dbdc819520a2ba987fd29859845c2177563ab8cfb"
+}

--- a/backend/windmill-api-workspaces/src/workspaces.rs
+++ b/backend/windmill-api-workspaces/src/workspaces.rs
@@ -71,6 +71,9 @@ use hyper::StatusCode;
 use serde::{Deserialize, Serialize};
 use sqlx::{FromRow, Postgres, Transaction};
 use windmill_common::oauth2::InstanceEvent;
+use windmill_common::secret_backend::{
+    get_secret_backend, is_external_stored_value, is_vault_backend_configured,
+};
 use windmill_common::utils::not_found_if_none;
 
 lazy_static::lazy_static! {
@@ -4041,6 +4044,7 @@ async fn create_workspace(
 // their drafts would dangle as orphans.
 async fn clone_workspace_data(
     tx: &mut Transaction<'_, Postgres>,
+    db: &DB,
     source_workspace_id: &str,
     target_workspace_id: &str,
     authed_email: &str,
@@ -4063,8 +4067,8 @@ async fn clone_workspace_data(
     // Clone resources
     clone_resources(tx, source_workspace_id, target_workspace_id).await?;
 
-    // Clone variables with re-encryption
-    clone_variables(tx, source_workspace_id, target_workspace_id).await?;
+    // Clone variables (including external secret backend replication)
+    clone_variables(tx, db, source_workspace_id, target_workspace_id).await?;
 
     // Clone scripts with new hashes
     clone_scripts(tx, source_workspace_id, target_workspace_id).await?;
@@ -4569,6 +4573,7 @@ async fn clone_resources(
 
 async fn clone_variables(
     tx: &mut Transaction<'_, Postgres>,
+    db: &DB,
     source_workspace_id: &str,
     target_workspace_id: &str,
 ) -> Result<()> {
@@ -4582,6 +4587,56 @@ async fn clone_variables(
     )
     .execute(&mut **tx)
     .await?;
+
+    // With an external secret backend (Vault / Azure KV / AWS SM), the copied
+    // `value` is only a `$vault:`/`$azure_kv:`/`$aws_sm:` marker: the actual
+    // secret lives in the external store under a key derived from
+    // (workspace_id, path). The row copy above therefore leaves the fork's
+    // markers pointing at keys that don't exist — replicate each secret under
+    // the fork's workspace id.
+    if is_vault_backend_configured(db).await? {
+        let secret_variables = sqlx::query!(
+            "SELECT path, value FROM variable
+             WHERE workspace_id = $1 AND is_secret = true AND value != ''",
+            target_workspace_id,
+        )
+        .fetch_all(&mut **tx)
+        .await?;
+
+        let backend = get_secret_backend(db).await?;
+        for variable in secret_variables
+            .into_iter()
+            .filter(|v| is_external_stored_value(&v.value))
+        {
+            match backend
+                .get_secret(source_workspace_id, &variable.path)
+                .await
+            {
+                Ok(plain_value) => {
+                    backend
+                        .set_secret(target_workspace_id, &variable.path, &plain_value)
+                        .await
+                        .map_err(|e| {
+                            Error::internal_err(format!(
+                                "Failed to replicate secret variable {} to the external secret backend for the forked workspace: {e}",
+                                variable.path
+                            ))
+                        })?;
+                }
+                // The source secret is unreadable (e.g. deleted out-of-band from
+                // the external store), so the variable is equally broken in the
+                // source workspace — don't let it block forking.
+                Err(e) => {
+                    tracing::warn!(
+                        workspace_id = %source_workspace_id,
+                        path = %variable.path,
+                        error = %e,
+                        "Could not read secret variable from the external secret backend while forking; the forked variable will not resolve"
+                    );
+                }
+            }
+        }
+    }
 
     Ok(())
 }
@@ -5543,7 +5598,14 @@ async fn create_workspace_fork(
     .await?;
 
     // Clone all data from the parent workspace using Rust implementation
-    clone_workspace_data(&mut tx, &parent_workspace_id, &forked_id, &authed.email).await?;
+    clone_workspace_data(
+        &mut tx,
+        &db,
+        &parent_workspace_id,
+        &forked_id,
+        &authed.email,
+    )
+    .await?;
 
     // Clone triggers and schedules unconditionally, always with mode='disabled' /
     // enabled=false. Disabled rows have no side effects (no listener


### PR DESCRIPTION
Fixes WIN-2146

## Summary

When an external secret backend (HashiCorp Vault / Azure Key Vault / AWS Secrets Manager) is configured, `variable.value` holds only a `$vault:`/`$azure_kv:`/`$aws_sm:` marker and the actual secret lives in the external store under a key derived from `(workspace_id, path)`. Workspace forking copied variable rows verbatim, so every secret variable in the fork pointed at an external key that only exists for the parent workspace — reading any secret in the fork failed with `Not found`.

`clone_variables` now replicates each external secret under the fork's workspace id: after the row copy, if an external backend is configured, it reads each secret variable with an external marker from the parent via `backend.get_secret` and writes it for the fork via `backend.set_secret`.

## Changes

- `clone_variables` (and `clone_workspace_data`) take `db: &DB` in addition to the transaction, since backend resolution reads global settings outside the fork transaction.
- After the `INSERT...SELECT` row copy, secret variables in the fork whose value is an external marker are replicated through the configured backend.
- Error semantics: a secret that cannot be **read** from the parent (e.g. deleted out-of-band from the external store) logs a warning and is skipped — it is equally unresolvable in the parent, so it doesn't block forking. A **write** failure aborts the fork (transaction rolls back), so a fork never silently completes with secrets that were readable in the parent but broken in the fork.
- No behavior change on OSS or with the database backend: the replication block is gated on `is_vault_backend_configured`, which is `false` there, and database-encrypted values already decrypt in the fork because the workspace key row is cloned.

## Test plan

Verified end-to-end on an EE build (`--features enterprise,private`) with a local HashiCorp Vault dev container configured as the secret backend:

- [x] Created a secret variable in a workspace: DB row holds `$vault:<path>`, plaintext stored in Vault under `secret/data/<ws>/<path>`.
- [x] Forked the workspace: the fork's variable resolves through the API to the parent's plaintext, and Vault contains the key under the fork's workspace id (this errored with `Not found` before the fix).
- [x] Updated the secret in the fork: parent value unchanged (fork and parent are independent).
- [x] Deleted a parent secret from Vault out-of-band, forked again: fork creation succeeds, a warning naming the variable is logged, and the remaining secrets still replicate.
- [x] `cargo check -p windmill-api-workspaces` with and without `enterprise,private`; SQLx offline cache updated for the new query.

## Known limitation

External-store writes for the fork happen while the fork transaction is open; if a later clone step fails, the DB rows roll back but already-replicated secrets remain in the external store under the never-created fork id (overwritten on retry with the same id). This mirrors the existing behavior of workspace deletion, which also does not purge external secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WIN-2146. Forking a workspace now replicates secrets stored in external backends (HashiCorp Vault, Azure Key Vault, AWS Secrets Manager) so secret variables in the fork resolve correctly.

- **Bug Fixes**
  - After copying variable rows, detect external markers and replicate each secret by reading from the parent and writing under the fork’s workspace ID.
  - Pass `db: &DB` into `clone_workspace_data` and `clone_variables` to resolve the secret backend outside the fork transaction.
  - Read failures log a warning and are skipped; write failures abort the fork to avoid silent breakage.
  - Gated by `is_vault_backend_configured`; no change for OSS or DB-backed secrets.
  - Added an `sqlx` query to list secret variables in the forked workspace.

<sup>Written for commit bb5c1142fa452756cfccb3089595e788dacbc542. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

