### PR TITLE
fix: session preview tab labels, splitter hover, and diff-drawer sizing

### DIFF
--- a/frontend/src/lib/components/WorkspaceItemDiffViewer.svelte
+++ b/frontend/src/lib/components/WorkspaceItemDiffViewer.svelte
@@ -44,9 +44,8 @@ doesn't reflow the parent.
 		disableAutoInline?: boolean
 		/** For `raw_app_file`: the synthesized per-file diff item to render. */
 		rawFile?: RawAppFileItem
-		/** Cap (px) on the rendered diff height so a long item scrolls internally
-		 * instead of growing unbounded and dominating the drawer. Ignored while ≤ 0
-		 * (unmeasured). */
+		/** Cap (px) on the rendered diff height; the drawer owns the rationale.
+		 * Ignored while ≤ 0 (unmeasured). */
 		maxHeight?: number
 	}
 
@@ -67,6 +66,13 @@ doesn't reflow the parent.
 		return `max-height: ${Math.max(0, maxHeight - reserved)}px;`
 	}
 	const maxHeightStyle = $derived(capStyle(0))
+	// FlowDiffViewer enforces its own `min-h-[500px]`; capping the flow below that
+	// makes its pane spill out of the card instead of scrolling, so never cap the
+	// flow diff below that minimum (a very short drawer just scrolls to it).
+	const FLOW_MIN_HEIGHT = 500
+	const flowMaxHeightStyle = $derived(
+		maxHeight && maxHeight > 0 ? `max-height: ${Math.max(FLOW_MIN_HEIGHT, maxHeight)}px;` : ''
+	)
 	// The Content|Metadata tab bar sits above the script editor and eats into the
 	// viewer's height; measure it so the editor's cap leaves room for it and the
 	// whole viewer still fits `maxHeight`.
@@ -129,7 +135,7 @@ doesn't reflow the parent.
 </script>
 
 {#if kind === 'flow'}
-	<div class="h-[600px]" style={maxHeightStyle}>
+	<div class="h-[600px]" style={flowMaxHeightStyle}>
 		<FlowDiffViewer
 			beforeYaml={beforeFlowYaml}
 			afterYaml={afterFlowYaml}

--- a/frontend/src/lib/components/WorkspaceItemDiffViewer.svelte
+++ b/frontend/src/lib/components/WorkspaceItemDiffViewer.svelte
@@ -44,6 +44,10 @@ doesn't reflow the parent.
 		disableAutoInline?: boolean
 		/** For `raw_app_file`: the synthesized per-file diff item to render. */
 		rawFile?: RawAppFileItem
+		/** Cap (px) on the rendered diff height so a long item scrolls internally
+		 * instead of growing unbounded and dominating the drawer. Ignored while ≤ 0
+		 * (unmeasured). */
+		maxHeight?: number
 	}
 
 	let {
@@ -52,8 +56,22 @@ doesn't reflow the parent.
 		currentRaw,
 		inlineDiff = false,
 		disableAutoInline = false,
-		rawFile
+		rawFile,
+		maxHeight
 	}: Props = $props()
+
+	// Applied alongside each block's content-sized `height` so the block never
+	// exceeds the drawer's visible height — Monaco then scrolls internally.
+	function capStyle(reserved: number): string {
+		if (!maxHeight || maxHeight <= 0) return ''
+		return `max-height: ${Math.max(0, maxHeight - reserved)}px;`
+	}
+	const maxHeightStyle = $derived(capStyle(0))
+	// The Content|Metadata tab bar sits above the script editor and eats into the
+	// viewer's height; measure it so the editor's cap leaves room for it and the
+	// whole viewer still fits `maxHeight`.
+	let tabsChromeH = $state(0)
+	const contentMaxHeightStyle = $derived(capStyle(tabsChromeH))
 
 	type Prepared = { lang?: string; content?: string; metadata: string }
 
@@ -111,7 +129,7 @@ doesn't reflow the parent.
 </script>
 
 {#if kind === 'flow'}
-	<div class="h-[600px]">
+	<div class="h-[600px]" style={maxHeightStyle}>
 		<FlowDiffViewer
 			beforeYaml={beforeFlowYaml}
 			afterYaml={afterFlowYaml}
@@ -131,14 +149,17 @@ doesn't reflow the parent.
 		fullYamlCurrent={rawFile.fullYamlCurrent}
 		{inlineDiff}
 		{disableAutoInline}
+		{maxHeight}
 	/>
 {:else if hasContent}
 	<div class="flex flex-col">
-		<Tabs bind:selected={contentTab}>
-			<Tab value="content" label="Content" />
-			<Tab value="metadata" label="Metadata" />
-		</Tabs>
-		<div style="height: {activeTabHeight}">
+		<div bind:clientHeight={tabsChromeH}>
+			<Tabs bind:selected={contentTab}>
+				<Tab value="content" label="Content" />
+				<Tab value="metadata" label="Metadata" />
+			</Tabs>
+		</div>
+		<div style="height: {activeTabHeight}; {contentMaxHeightStyle}">
 			{#if contentTab === 'content'}
 				{#await import('$lib/components/DiffEditor.svelte')}
 					<div class="p-3"><Loader2 class="w-3.5 h-3.5 animate-spin" /></div>
@@ -178,7 +199,7 @@ doesn't reflow the parent.
 	{#await import('$lib/components/DiffEditor.svelte')}
 		<div class="p-3"><Loader2 class="w-3.5 h-3.5 animate-spin" /></div>
 	{:then Module}
-		<div style="height: {metadataHeight}">
+		<div style="height: {metadataHeight}; {maxHeightStyle}">
 			<Module.default
 				open={true}
 				automaticLayout

--- a/frontend/src/lib/components/raw_apps/RawAppFileDiff.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppFileDiff.svelte
@@ -23,6 +23,9 @@ the escape hatch, shown only on demand.
 		isMetadata?: boolean
 		fullYamlOriginal?: string
 		fullYamlCurrent?: string
+		/** Cap (px) on the rendered diff height so a long file scrolls internally
+		 * instead of growing unbounded. Ignored while ≤ 0 (unmeasured). */
+		maxHeight?: number
 	}
 
 	let {
@@ -34,7 +37,8 @@ the escape hatch, shown only on demand.
 		lineBudget = 1500,
 		isMetadata = false,
 		fullYamlOriginal,
-		fullYamlCurrent
+		fullYamlCurrent,
+		maxHeight
 	}: Props = $props()
 
 	let showFullYaml = $state(false)
@@ -58,6 +62,13 @@ the escape hatch, shown only on demand.
 	// editor height), so it's the right metric for the size guard.
 	const lineCount = $derived(Math.max(linesIn(activeOriginal), linesIn(activeModified)))
 	const height = $derived(`${lineCount * LINE_HEIGHT + EDITOR_CHROME}px`)
+	// Cap the block at the drawer's visible height so a long file scrolls inside
+	// Monaco instead of stretching the card, leaving room for the "expand to full
+	// YAML" toolbar above it (measured). Skipped until measured (> 0).
+	let chromeH = $state(0)
+	const maxHeightStyle = $derived(
+		maxHeight && maxHeight > 0 ? `max-height: ${Math.max(0, maxHeight - chromeH)}px;` : ''
+	)
 	// The full-YAML view is opt-in, so never guard it; only guard the default
 	// per-file view.
 	const guarded = $derived(!showFullYaml && !forceLoad && lineCount > lineBudget)
@@ -65,7 +76,10 @@ the escape hatch, shown only on demand.
 
 <div class="flex flex-col">
 	{#if canExpandYaml}
-		<div class="flex items-center justify-end px-3 py-1 border-b border-light">
+		<div
+			bind:clientHeight={chromeH}
+			class="flex items-center justify-end px-3 py-1 border-b border-light"
+		>
 			<Button variant="subtle" unifiedSize="sm" onclick={() => (showFullYaml = !showFullYaml)}>
 				{showFullYaml ? 'Show metadata only' : 'Expand to full app YAML'}
 			</Button>
@@ -83,7 +97,7 @@ the escape hatch, shown only on demand.
 		{#await import('$lib/components/DiffEditor.svelte')}
 			<div class="p-3"><Loader2 class="w-3.5 h-3.5 animate-spin" /></div>
 		{:then Module}
-			<div style="height: {height}">
+			<div style="height: {height}; {maxHeightStyle}">
 				<Module.default
 					open={true}
 					automaticLayout

--- a/frontend/src/lib/components/raw_apps/RawAppFileDiff.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppFileDiff.svelte
@@ -23,8 +23,8 @@ the escape hatch, shown only on demand.
 		isMetadata?: boolean
 		fullYamlOriginal?: string
 		fullYamlCurrent?: string
-		/** Cap (px) on the rendered diff height so a long file scrolls internally
-		 * instead of growing unbounded. Ignored while ≤ 0 (unmeasured). */
+		/** Cap (px) on the rendered diff height; the drawer owns the rationale.
+		 * Ignored while ≤ 0 (unmeasured). */
 		maxHeight?: number
 	}
 

--- a/frontend/src/lib/components/sessions/WorkspaceDiffDrawer.svelte
+++ b/frontend/src/lib/components/sessions/WorkspaceDiffDrawer.svelte
@@ -485,6 +485,16 @@
 	// Visible height of the scroll area, used to size the trailing spacer so the
 	// last item can always be scrolled until its header reaches the top.
 	let mainHeight = $state(0)
+	// Height of a card's sticky header (measured — all cards share it), so the diff
+	// cap can reserve exactly that plus a small gap and the whole card (header +
+	// diff) fits the viewport instead of overflowing it.
+	let cardHeaderH = $state(0)
+	// Cap each diff block so a long one (a big script/app file) scrolls inside
+	// Monaco instead of stretching its card past a screenful: the visible height
+	// less the card header and an inter-card gap so a whole card fits the viewport.
+	// 0 (unmeasured) means "no cap" so nothing collapses before mainHeight lands.
+	const CARD_GAP = 24
+	const maxHeight = $derived(mainHeight > 0 ? mainHeight - cardHeaderH - CARD_GAP : 0)
 	// The trailing spacer only needs to cover the gap the last item can't fill on
 	// its own: viewport − lastItemHeight (0 when the item already fills the view).
 	// Reserving the full viewport would let you scroll a whole item-height into
@@ -830,6 +840,7 @@
 							rawFile={sub as RawAppFileItem}
 							{inlineDiff}
 							disableAutoInline
+							{maxHeight}
 						/>
 					{:else}
 						{@const runnable = sub as RawAppRunnableItem}
@@ -839,6 +850,7 @@
 							currentRaw={runnable.currentRaw}
 							{inlineDiff}
 							disableAutoInline
+							{maxHeight}
 						/>
 					{/if}
 				</div>
@@ -851,6 +863,7 @@
 			currentRaw={loaded.after}
 			{inlineDiff}
 			disableAutoInline
+			{maxHeight}
 		/>
 	{/if}
 {/snippet}
@@ -983,6 +996,7 @@
 											: 'ring-0 ring-transparent'}"
 									>
 										<div
+											bind:clientHeight={cardHeaderH}
 											class="sticky top-0 z-30 bg-surface-tertiary rounded-t-md flex items-center gap-2 px-3 py-2 border-b border-transparent"
 										>
 											<RowIcon kind={d.deployKind as any} path={d.path} size={14} />

--- a/frontend/src/lib/components/sessions/previewRouter.test.ts
+++ b/frontend/src/lib/components/sessions/previewRouter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { parsePreviewItemRoute, resolvePreviewTab } from './previewRouter'
+import { parsePreviewItemRoute, previewTabLabel, resolvePreviewTab } from './previewRouter'
 import type { SessionTarget } from './sessionState.svelte'
 
 describe('parsePreviewItemRoute', () => {
@@ -30,6 +30,38 @@ describe('parsePreviewItemRoute', () => {
 		expect(parsePreviewItemRoute('/')).toBeNull()
 		expect(parsePreviewItemRoute('/runs')).toBeNull()
 		expect(parsePreviewItemRoute('/workspace_settings')).toBeNull()
+	})
+})
+
+describe('previewTabLabel', () => {
+	it('labels a new raw app by its pending friendly path, not the draft uuid', () => {
+		const rawApp = { path: 'u/admin/draft_abc123', draft_path: 'u/admin/my_pretty_app' }
+		expect(previewTabLabel('/apps_raw/edit/u/admin/draft_abc123', rawApp)).toBe('my_pretty_app')
+	})
+
+	it('falls back to the uuid leaf when no friendly draft_path is pending', () => {
+		const rawApp = { path: 'u/admin/draft_abc123' }
+		expect(previewTabLabel('/apps_raw/edit/u/admin/draft_abc123', rawApp)).toBe('draft_abc123')
+	})
+
+	it('keeps the real leaf for a raw app already at a named (non-draft) path', () => {
+		const rawApp = { path: 'u/admin/my_app', draft_path: 'u/admin/renamed' }
+		expect(previewTabLabel('/apps_raw/edit/u/admin/my_app', rawApp)).toBe('my_app')
+	})
+
+	it('ignores a draft_path that belongs to a different raw app than the tab shows', () => {
+		const rawApp = { path: 'u/admin/draft_other', draft_path: 'u/admin/friendly' }
+		expect(previewTabLabel('/apps_raw/edit/u/admin/draft_abc123', rawApp)).toBe('draft_abc123')
+	})
+
+	it('does not touch non-raw-app tabs', () => {
+		const rawApp = { path: 'u/admin/draft_abc123', draft_path: 'u/admin/friendly' }
+		expect(previewTabLabel('/scripts/edit/f/foo/bar', rawApp)).toBe('bar')
+		expect(previewTabLabel('/runs', rawApp)).toBe('Runs')
+	})
+
+	it('falls back to the plain location label when no raw app is loaded', () => {
+		expect(previewTabLabel('/apps_raw/edit/u/admin/draft_abc123', undefined)).toBe('draft_abc123')
 	})
 })
 

--- a/frontend/src/lib/components/sessions/previewRouter.ts
+++ b/frontend/src/lib/components/sessions/previewRouter.ts
@@ -109,6 +109,29 @@ export function previewLocationLabel(url: string): string {
 	return stripBase(url)
 }
 
+/** Tab label for a preview location, preferring the friendly path a raw-app
+ * editor was renamed to while still parked at its throwaway `…/draft_<uuid>`
+ * storage path. `rawAppDraft` is the session's live raw app (its storage `path`
+ * plus the pending `draft_path` the user typed in the editor). When the tab
+ * shows that app at a draft placeholder path, it's labelled by the friendly
+ * leaf rather than the uuid. Display-only — the tab's URL keeps the storage
+ * path. Falls back to `previewLocationLabel` for every other tab. */
+export function previewTabLabel(
+	url: string,
+	rawAppDraft?: { path: string; draft_path?: string }
+): string {
+	const route = parsePreviewItemRoute(url)
+	if (
+		route?.raw_app &&
+		rawAppDraft?.draft_path &&
+		rawAppDraft.path === route.itemPath &&
+		route.itemPath.split('/').pop()?.startsWith('draft_')
+	) {
+		return rawAppDraft.draft_path.split('/').pop() ?? rawAppDraft.draft_path
+	}
+	return previewLocationLabel(url)
+}
+
 export type PreviewItemRoute = { kind: WorkspaceItemKind; raw_app: boolean; itemPath: string }
 
 // Parse a preview URL/pathname into the workspace item it edits, or null for a

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -552,7 +552,7 @@
 		<div class="flex-1 min-h-0 flex flex-row relative" use:splitterPointerCapture>
 			<Splitpanes
 				horizontal={false}
-				class="flex-1 min-h-0 splitter-hidden {previewCollapsed ? 'splitter-off' : ''}"
+				class="flex-1 min-h-0 session-splitter {previewCollapsed ? 'splitter-off' : ''}"
 			>
 				{#if !fullscreen}
 					<!-- Chat column. Warm sessions stay mounted (stacked, visibility-toggled)
@@ -799,19 +799,31 @@
 </div>
 
 <style>
-	/* Invisible-but-draggable splitter between the chat and the preview: a real
-	   (layout-occupying) gutter, wide enough to grab. No overlap tricks — the
-	   zone can't cover the chat's scrollbar or the preview's edge. */
-	:global(.splitpanes--vertical.splitter-hidden) > :global(.splitpanes__splitter) {
+	/* Draggable gutter between the chat and the preview: a real (layout-occupying)
+	   10px-wide grab zone, wide enough to grab without overlap tricks that could
+	   cover the chat's scrollbar or the preview's edge. Transparent so no divider
+	   shows at rest; on hover the app-global `.splitpanes__splitter::after` grabber
+	   fades in — a subtle centered line, consistent with every other splitter.
+	   A dedicated class (not the shared `.splitter-hidden`, which force-zeroes the
+	   splitter opacity and would suppress that hover hint). */
+	:global(.splitpanes--vertical.session-splitter) > :global(.splitpanes__splitter) {
 		background-color: transparent !important;
 		border: none !important;
-		opacity: 0 !important;
 		width: 10px !important;
+	}
+	/* Inset the global hover grabber from the pane's top/bottom edges so the line
+	   doesn't run the full height, and round its ends into a pill — a lighter,
+	   more contained hint. */
+	:global(.splitpanes--vertical.session-splitter) > :global(.splitpanes__splitter)::after {
+		top: 8px !important;
+		bottom: 8px !important;
+		height: auto !important;
+		border-radius: 9999px !important;
 	}
 
 	/* Collapsed preview: the pane is resized to 0 but stays mounted, so remove
-	   the (invisible) gutter entirely — it would otherwise leave a dead 10px
-	   drag zone on the chat's right edge. */
+	   the gutter entirely — it would otherwise leave a dead 10px drag zone on the
+	   chat's right edge. */
 	:global(.splitpanes--vertical.splitter-off) > :global(.splitpanes__splitter) {
 		display: none !important;
 	}

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -800,12 +800,11 @@
 
 <style>
 	/* Draggable gutter between the chat and the preview: a real (layout-occupying)
-	   10px-wide grab zone, wide enough to grab without overlap tricks that could
-	   cover the chat's scrollbar or the preview's edge. Transparent so no divider
-	   shows at rest; on hover the app-global `.splitpanes__splitter::after` grabber
-	   fades in — a subtle centered line, consistent with every other splitter.
-	   A dedicated class (not the shared `.splitter-hidden`, which force-zeroes the
-	   splitter opacity and would suppress that hover hint). */
+	   10px-wide grab zone, no overlap tricks that could cover the chat's scrollbar
+	   or the preview's edge. Transparent at rest; on hover the app-global
+	   `.splitpanes__splitter::after` grabber fades in. Uses a dedicated class, not
+	   the shared `.splitter-hidden`, which force-zeroes splitter opacity and would
+	   hide that grabber. */
 	:global(.splitpanes--vertical.session-splitter) > :global(.splitpanes__splitter) {
 		background-color: transparent !important;
 		border: none !important;

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -39,7 +39,8 @@
 		getOrCreateRuntime,
 		getRuntime,
 		listRuntimes,
-		promoteEditorWarm
+		promoteEditorWarm,
+		type SessionRuntime
 	} from '$lib/components/sessions/sessionRuntime.svelte'
 	import { markSessionSeen } from '$lib/components/sessions/sessionUnread.svelte'
 	import { isGlobalAiEnabled } from '$lib/components/copilot/chat/global/gate'
@@ -49,7 +50,7 @@
 		matchPreviewPage,
 		pageKey,
 		parsePreviewItemRoute,
-		previewLocationLabel,
+		previewTabLabel,
 		type PreviewTarget
 	} from '$lib/components/sessions/previewRouter'
 	import { leafKeyFor, type WorkspaceItem } from '$lib/components/workspacePicker'
@@ -251,7 +252,7 @@
 	// Adapt the session tab model to DraggableTabs items (labels derived from the
 	// observed location; every tab closable, none pinned).
 	const previewTabItems = $derived<TabItem[]>(
-		(owner?.tabs ?? []).map((t) => ({ id: t.id, label: tabLabel(t.loc) }))
+		(owner?.tabs ?? []).map((t) => ({ id: t.id, label: tabLabelFor(activeRuntime, t.loc) }))
 	)
 	let newTabOpen = $state(false)
 	// Separate open flag for the empty-state launcher: it can be mounted at the
@@ -436,10 +437,10 @@
 		owner?.navigate(target)
 	}
 
-	// Short tab label: a known page's name, else a run detail, else the item's leaf
-	// name, else path.
-	function tabLabel(url: string): string {
-		return previewLocationLabel(url)
+	// Short tab label. Scoped to the tab's own runtime so a warm session's raw-app
+	// tab is labelled by that session's pending draft path, not another session's.
+	function tabLabelFor(rt: SessionRuntime | undefined, url: string): string {
+		return previewTabLabel(url, rt?.rawApp?.val)
 	}
 
 	// A link click inside a live editor (e.g. a subflow reference) re-points the
@@ -725,7 +726,7 @@
 											runtime={rt}
 											active={s.id === activeSession?.id && tab.id === tabs?.activeId}
 											mounted={mountedTabKeys.has(tabKey(s.id, tab.id))}
-											label={tabLabel(tab.loc)}
+											label={tabLabelFor(rt, tab.loc)}
 											onNavigate={navigateEditorTo}
 											onLoad={(frame) => tabs && onTabLoad(tabs, tab, frame)}
 										/>


### PR DESCRIPTION
## Summary

Three focused fixes to the AI-sessions preview UI (plus a sync merge with `main`).

## Changes

**1. Friendly raw-app tab label** (`previewRouter.ts`, `previewRouter.test.ts`, `+page.svelte`)
When creating a new raw app, the session preview tab showed the throwaway storage path leaf (`draft_<uuid>`) instead of the pretty name pending in the editor. New pure `previewTabLabel(url, rawAppDraft?)` labels a raw-app tab by its pending `draft_path` leaf when the app is parked at a `draft_<uuid>` path; falls back to `previewLocationLabel` otherwise. Display-only — the tab URL keeps the storage path. `tabLabelFor(rt, url)` scopes it to the tab's own runtime cell so a warm session isn't mislabelled by another's app. 6 new unit tests.

**2. Subtle splitter grabber on hover** (`+page.svelte`)
The chat/preview gutter used the shared `.splitter-hidden` class, which force-zeroed the splitter's opacity and suppressed the app-global hover grabber. Swapped to a dedicated `.session-splitter` class so the `::after` grabber fades in on hover as a subtle rounded pill, inset from the pane's top/bottom edges. Collapse still hides via `.splitter-off`. Purely visual.

**3. Diff-drawer viewport cap** (`WorkspaceItemDiffViewer.svelte`, `RawAppFileDiff.svelte`, `WorkspaceDiffDrawer.svelte`)
The session diff drawer sized each item's diff to its full content height, so a long script/app file stretched its card far past the viewport. Each diff is now capped to the drawer's measured visible height (less the measured card header, inter-card gap, and each viewer's own tab/toolbar chrome) so Monaco scrolls internally and the whole card fits the viewport. Flow diffs are floored at their `min-h-[500px]` to avoid spill.

## Test plan

- [x] `previewRouter.test.ts` — 15 pass (6 new for `previewTabLabel`)
- [x] `npm run check:fast` clean for changed files
- [x] Both auto-reviews (Codex, Pi): good to merge
- [x] Browser-verified: new raw-app tab shows friendly leaf; splitter pill fades in on hover with margin + rounded ends; a 70-line script diff card (764px) fits the 785px drawer with Monaco scrolling internally
- [x] Synced with `main` (conflicts resolved: `promoteEditorWarm` drop, `SessionTarget` import, raw-app state moved to per-path cells)

🤖 Generated with [Claude Code](https://claude.com/claude-code)