### PR TITLE
feat: allow invoking AI chat skills mid-input, not only at the start

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -1516,19 +1516,21 @@ export class AIChatManager {
 	}
 
 	private expandGlobalSkillCommand = (instructions: string): string => {
-		if (!this.isSessionChat || this.mode !== AIMode.GLOBAL || !instructions.startsWith('/')) {
+		if (!this.isSessionChat || this.mode !== AIMode.GLOBAL || this.globalSkills.length === 0) {
 			return instructions
 		}
-		const match = /^\/([a-z0-9-]+)(?:\s+([\s\S]*))?$/.exec(instructions)
-		if (!match) {
-			return instructions
-		}
-		const skill = this.globalSkills.find((s) => s.name === match[1])
-		if (!skill) {
-			return instructions
-		}
-		const rest = match[2]?.trim()
-		return rest ? `Use the "${skill.name}" skill. ${rest}` : `Use the "${skill.name}" skill.`
+		// A skill call is `/name` at input start or after whitespace (so paths like
+		// `a/b` are left untouched). Expanded wherever it appears, not just the
+		// leading token: a bare leading call reads as a directive ("Use the ...
+		// skill."), mid-sentence calls splice in inline so the surrounding text
+		// keeps its word order.
+		return instructions.replace(/(^|\s)\/([a-z0-9-]+)/g, (whole, pre, name, offset) => {
+			const skill = this.globalSkills.find((s) => s.name === name)
+			if (!skill) {
+				return whole
+			}
+			return offset === 0 ? `Use the "${skill.name}" skill.` : `${pre}use the "${skill.name}" skill`
+		})
 	}
 
 	canApplyCode = $derived(this.allowedModes.script && this.mode === AIMode.SCRIPT)

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.test.ts
@@ -297,6 +297,34 @@ describe('AIChatManager global skills', () => {
 
 		expect(manager.displayMessages[0]?.content).toBe('/review-code find bugs')
 	})
+
+	it('expands a mid-sentence slash skill command inline while preserving the displayed text', async () => {
+		mocks.listAiSkills.mockResolvedValue([
+			{ name: 'review-code', description: 'review code for bugs' }
+		])
+		mocks.runChatLoop.mockImplementation(async (config: any) => {
+			const userMessage = config.messages[config.messages.length - 1]
+			expect(userMessage.content).toContain('please use the "review-code" skill on this')
+			expect(userMessage.content).not.toContain('/review-code')
+			const message = { role: 'assistant' as const, content: 'done' }
+			config.addedMessages?.push(message)
+			return {
+				addedMessages: [message],
+				tokenUsage: { prompt: 0, completion: 0, total: 0 },
+				hitMaxIterations: false
+			}
+		})
+
+		const manager = new AIChatManager()
+		manager.isSessionChat = true
+
+		await manager.sendRequest({
+			instructions: 'please /review-code on this',
+			mode: AIMode.GLOBAL
+		})
+
+		expect(manager.displayMessages[0]?.content).toBe('please /review-code on this')
+	})
 })
 
 describe('AIChatManager autonomy mode', () => {

--- a/frontend/src/lib/components/copilot/chat/ContextTextarea.svelte
+++ b/frontend/src/lib/components/copilot/chat/ContextTextarea.svelte
@@ -72,6 +72,9 @@
 	let contextTooltipWord = $state('')
 	let showCommandTooltip = $state(false)
 	let commandTooltipWord = $state('')
+	// Index of the `/` that opened the command picker, so insertion and the
+	// picker anchor target the in-progress token wherever it sits in the input.
+	let commandSlashIndex = $state(0)
 	let textarea = $state<HTMLTextAreaElement | undefined>(undefined)
 	let tooltipElement = $state<HTMLDivElement | undefined>(undefined)
 	let chatContextPicker: ChatContextPicker | undefined = $state()
@@ -547,10 +550,16 @@
 		})
 	}
 
-	function getCommandFilter(text: string): string | undefined {
-		if (aiChatManager.mode !== AIMode.GLOBAL || !aiChatManager.isSessionChat) return undefined
-		const match = /^\/([a-z0-9-]*)$/.exec(text)
-		return match?.[1]
+	// Detect a slash-command token ending at the caret. The `/` must sit at input
+	// start or right after whitespace, so file paths like `foo/bar` never trigger
+	// — but the token can appear anywhere in the input, not just the beginning.
+	function getCommandTrigger(): { query: string; slashIndex: number } | undefined {
+		if (aiChatManager.mode !== AIMode.GLOBAL || !aiChatManager.isSessionChat || !textarea)
+			return undefined
+		const caret = textarea.selectionStart ?? value.length
+		const match = /(^|\s)\/([a-z0-9-]*)$/.exec(value.slice(0, caret))
+		if (!match) return undefined
+		return { query: match[2], slashIndex: match.index + match[1].length }
 	}
 
 	function updateAnchorRect() {
@@ -558,9 +567,11 @@
 		const triggerWord = activeTooltipWord
 		if (!triggerWord) return
 		try {
-			// Inline `@` anchors to the last word; slash commands only open when
-			// `/...` is the whole input, so the trigger sits at index 0.
-			const triggerIndex = triggerWord.startsWith('/') ? 0 : value.length - triggerWord.length
+			// Inline `@` anchors to the last word; a slash command anchors to its
+			// `/`, which may sit anywhere in the input.
+			const triggerIndex = showCommandTooltip
+				? commandSlashIndex
+				: value.length - triggerWord.length
 			const coords = getCaretCoordinates(textarea, triggerIndex)
 			const rect = textarea.getBoundingClientRect()
 			// getCaretCoordinates returns content-relative coords; subtract the
@@ -585,11 +596,12 @@
 	function handleInput(e: Event) {
 		textarea = e.target as HTMLTextAreaElement
 
-		const commandFilter = getCommandFilter(value)
-		if (commandFilter !== undefined) {
+		const commandTrigger = getCommandTrigger()
+		if (commandTrigger !== undefined) {
 			const wasShowing = showCommandTooltip
 			showCommandTooltip = true
-			commandTooltipWord = `/${commandFilter}`
+			commandTooltipWord = `/${commandTrigger.query}`
+			commandSlashIndex = commandTrigger.slashIndex
 			showContextTooltip = false
 			contextTooltipWord = ''
 			if (!wasShowing) refreshCommandSkills()
@@ -615,9 +627,19 @@
 	}
 
 	function handleCommandSelection(skill: { name: string }) {
-		value = `/${skill.name} `
+		// Replace the in-progress `/query` token (from its `/` to the caret) with the
+		// chosen command, keeping any text on either side so a skill can be inserted
+		// mid-sentence. A trailing space is appended only when nothing follows.
+		const caret = textarea?.selectionStart ?? value.length
+		const after = value.slice(caret)
+		const insert = `/${skill.name}` + (after.startsWith(' ') ? '' : ' ')
+		value = value.slice(0, commandSlashIndex) + insert + after
 		showCommandTooltip = false
-		setTimeout(() => textarea?.focus(), 0)
+		const newCaret = commandSlashIndex + insert.length
+		setTimeout(() => {
+			textarea?.focus()
+			textarea?.setSelectionRange(newCaret, newCaret)
+		}, 0)
 	}
 
 	function handleKeyDown(e: KeyboardEvent) {


### PR DESCRIPTION
## Summary
In session-chat GLOBAL mode you could previously only invoke a skill (slash command) when `/` was the very first thing in the input. This makes `/skill` work **anywhere** in the message, so you can weave a skill into a sentence (e.g. `review this code with /pr`).

## Changes
- **Picker trigger** (`ContextTextarea.svelte`): replaced whole-input `getCommandFilter` with caret-aware `getCommandTrigger` — scans back from the caret for a `/token` whose `/` sits at input start or right after whitespace (so paths like `foo/bar` never trigger).
- **Insertion** (`handleCommandSelection`): splices `/skill ` at the token's `/` position, preserving text on both sides and placing the caret right after the inserted command; omits the trailing space when text already follows.
- **Anchor** (`updateAnchorRect`): the popover now anchors to the `/`'s actual position (`commandSlashIndex`) instead of index 0.
- **Model-facing expansion** (`AIChatManager.svelte.ts` `expandGlobalSkillCommand`): expands every `/skill` token wherever it appears via a global regex. A leading call keeps the exact prior output (`Use the "X" skill.`); mid-sentence calls splice in inline (`… use the "X" skill …`) so word order is preserved. Unknown tokens are left verbatim.
- **Test**: added a mid-sentence expansion unit test; existing leading-token test unchanged and still green.

The built-in commands `/compact` / `/clear` remain whole-input-only local commands (they only execute when they're the entire input), but the picker still offers them at any `/` for discoverability.

## Screenshots
Mid-sentence `/` opens the picker anchored at the `/` (not the start of the input):

![skill-picker-mid](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/chat-improve-skill-call/1783516769-skill-picker-mid.png)

## Test plan
- [ ] `npm run check:fast` clean on touched files
- [ ] `AIChatManager.test.ts` — both leading and mid-sentence expansion tests pass
- [ ] In a global-mode session chat, type `please /` mid-sentence → picker opens anchored at the `/`
- [ ] Select a skill by click **and** by Enter → token spliced in place with correct spacing, caret lands right after it
- [ ] Send → displayed message keeps literal `/skill`, model receives inline-expanded `use the "…" skill`

🤖 Generated with [Claude Code](https://claude.com/claude-code)