### PR TITLE
fix: session preview editors and picker dropdown overflow

### DIFF
--- a/frontend/src/lib/components/DrillPicker.svelte
+++ b/frontend/src/lib/components/DrillPicker.svelte
@@ -412,7 +412,7 @@ leaves and ignores the current scope.
 	bind:this={pickerRoot}
 	class={flush
 		? 'flex flex-col w-full h-full'
-		: 'flex flex-col w-[min(420px,calc(100vw-20px))] max-h-[60vh]'}
+		: 'flex flex-col w-[min(420px,calc(100vw-20px))] max-h-[60vh] min-h-0'}
 	onkeydown={handleSearchKeydown}
 	onmousemove={() => (mouseActive = true)}
 >

--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -1097,7 +1097,7 @@
 		<ScriptEditorDrawer bind:this={$scriptEditorDrawer} />
 		<FlowEditorDrawer bind:this={$flowEditorDrawer} />
 
-		<div bind:this={flowBuilderRoot} class="flex flex-col h-screen">
+		<div bind:this={flowBuilderRoot} class="flex flex-col h-full">
 			<!-- Nav between steps-->
 			<div
 				bind:clientWidth={topbarWidth}

--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -1897,7 +1897,7 @@
 		</DrawerContent>
 	</Drawer>
 
-	<div class="flex flex-col h-screen">
+	<div class="flex flex-col h-full">
 		<div bind:clientWidth={topbarWidth} class="flex h-12 items-center px-4">
 			<div class="flex gap-2 lg:gap-2 w-full items-center">
 				<div class="flex flex-row items-center gap-2 min-w-0 shrink">

--- a/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditor.svelte
@@ -1643,10 +1643,7 @@
 	gateJobIds={false}
 	extraSourceWindow={() => externalPreviewWindow}
 />
-<div
-	bind:clientWidth={rootWidth}
-	class="max-h-screen overflow-hidden h-screen min-h-0 flex flex-col"
->
+<div bind:clientWidth={rootWidth} class="max-h-full overflow-hidden h-full min-h-0 flex flex-col">
 	<RawAppEditorHeader
 		bind:jobs
 		bind:jobsById

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -655,6 +655,7 @@
 											enableFlyTransition
 											bind:isOpen={activeTabPickerOpen}
 											openFocus="[data-workspace-picker-search]"
+											contentClasses="flex flex-col overflow-hidden"
 											class="flex items-center shrink-0 cursor-pointer text-tertiary hover:text-primary"
 										>
 											{#snippet trigger()}
@@ -685,6 +686,7 @@
 										bind:isOpen={newTabOpen}
 										enableFlyTransition
 										openFocus="[data-workspace-picker-search]"
+										contentClasses="flex flex-col overflow-hidden"
 										class="shrink-0 inline-flex items-center justify-center w-6 h-6 rounded text-tertiary hover:text-primary hover:bg-surface-hover cursor-pointer"
 									>
 										{#snippet trigger()}
@@ -753,6 +755,7 @@
 											bind:isOpen={emptyStateNewTabOpen}
 											enableFlyTransition
 											openFocus="[data-workspace-picker-search]"
+											contentClasses="flex flex-col overflow-hidden"
 										>
 											{#snippet trigger()}
 												<span


### PR DESCRIPTION
## Summary

Two overflow fixes in the AI **session preview** panel (`/sessions`):

1. **Editors overflowed the preview pane.** `ScriptBuilder`, `FlowBuilder`, and `RawAppEditor` used `h-screen` (100vh) at their root. In the session preview — a bounded pane shorter than the viewport (it sits below the tab bar) — this rendered the builder taller than its container, so the bottom of the editor (Monaco tail, flow graph controls, raw-app logs panel) spilled past the pane and couldn't be scrolled to. Switched to `h-full` so each builder fits its container. Every full-page consumer already provides a definite-height flex parent (`scripts/edit` / `flows/edit` via `AiChatLayout`'s `flex-1 min-h-0`, `apps_raw/edit` via an explicit `<div class="h-screen">`, the flow drawer via `DrawerContent`'s `grow min-h-0`), so `h-full` resolves correctly there with no visible change.

2. **The "Open a preview" picker dropdown overflowed the page.** floating-ui's `fitViewport` correctly set a `max-height` on the popover box, but the box didn't clip and the inner `DrillPicker` used a fixed `max-h-[60vh]` that ignored it. From the empty-state trigger (vertically centered, ~239px of room below), the 60vh list rendered ~418px tall and spilled past the box to the page edge. Added `min-h-0` to `DrillPicker`'s root so it can shrink, and passed `contentClasses="flex flex-col overflow-hidden"` to the three preview popovers so the box clips and the list scrolls internally. Scoped via the existing `contentClasses` prop — the shared `Popover` is untouched for other consumers.

## Changes
- `ScriptBuilder.svelte`, `FlowBuilder.svelte`, `RawAppEditor.svelte`: root `h-screen` → `h-full` (raw app also `max-h-screen` → `max-h-full`)
- `DrillPicker.svelte`: add `min-h-0` to the non-flush root
- `sessions/+page.svelte`: add `contentClasses="flex flex-col overflow-hidden"` to the three preview `Popover`s (active-tab picker, new-tab picker, empty-state picker)

## Screenshots

**Script editor now fits the preview pane (top toolbar + editor both visible, no page scroll):**
![pr-script-preview-fitted](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-session-script-preview-scroll/1783516812-pr-script-preview-fitted.png)

**Picker dropdown clipped to its popover with an internal scrollbar, no longer running off the page:**
![pr-picker-fixed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-session-script-preview-scroll/1783516814-pr-picker-fixed.png)

## Test plan
- [ ] In `/sessions`, open a **script**, **flow**, and **raw-app** preview tab — confirm the top toolbar and the bottom of the editor are both visible with no page-level scroll
- [ ] Open the session preview's **empty-state** "Open a preview" picker and the **new-tab** / **active-tab** pickers, search a broad term for a long list — confirm the dropdown is clipped to the popover, scrolls internally, and never runs off the bottom of the page
- [ ] Short-list case: the picker box shrinks to content (no oversized empty box)
- [ ] Regression: full-page `/scripts/edit`, `/flows/edit`, `/apps_raw/edit`, and the inline flow sub-editor drawer still fill the viewport height and scroll their internal panels normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)