### PR TITLE
feat: add multi-select mode to copilot askUserQuestion

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -20,6 +20,7 @@ import {
 	type Tool,
 	type ToolCallbacks,
 	type ToolDisplayMessage,
+	type UserQuestionDisplay,
 	type ChatJob,
 	type ChatJobInit,
 	type ChatJobStatus,
@@ -389,7 +390,7 @@ export class AIChatManager {
 	cachedDatatables = $state<AppDatatableElement[]>([])
 
 	private confirmationCallbacks = new Map<string, (value: boolean) => void>()
-	private userQuestionCallbacks = new Map<string, (choice: string | undefined) => void>()
+	private userQuestionCallbacks = new Map<string, (choices: string[] | undefined) => void>()
 	private appDatatablesRefreshTimeout: ReturnType<typeof setTimeout> | undefined = undefined
 
 	disabledModes: Partial<Record<AIMode, boolean>> = $state({})
@@ -1240,35 +1241,40 @@ export class AIChatManager {
 
 	requestUserQuestion = (
 		toolId: string,
-		_question: { question: string; choices: string[] }
-	): Promise<string | undefined> => {
+		_question: UserQuestionDisplay
+	): Promise<string[] | undefined> => {
 		return new Promise((resolve) => {
 			this.userQuestionCallbacks.set(toolId, resolve)
 		})
 	}
 
-	handleUserQuestionAnswer = (toolId: string, choice: string) => {
+	handleUserQuestionAnswer = (toolId: string, choices: string[]) => {
 		const callback = this.userQuestionCallbacks.get(toolId)
 		if (!callback) {
 			return
 		}
 
+		// Display-only readback for the collapsed tool-header: a compact comma list.
+		// The model-facing return (bare string / newline-bulleted) is built by the
+		// tool fn from the resolved choices below.
+		const answerSummary = choices.join(', ')
+
 		this.displayMessages = this.displayMessages.map((message) => {
 			if (message.role === 'tool' && message.tool_call_id === toolId && message.userQuestion) {
 				return {
 					...message,
-					content: `User answered question: ${choice}`,
+					content: `User answered question: ${answerSummary}`,
 					isLoading: false,
 					userQuestion: {
 						...message.userQuestion,
-						selectedChoice: choice
+						selectedChoices: choices
 					}
 				}
 			}
 			return message
 		})
 
-		callback(choice)
+		callback(choices)
 		this.userQuestionCallbacks.delete(toolId)
 	}
 

--- a/frontend/src/lib/components/copilot/chat/AskUserQuestionDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AskUserQuestionDisplay.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount, tick } from 'svelte'
-	import { CircleHelp, ArrowUp } from 'lucide-svelte'
+	import { SvelteSet } from 'svelte/reactivity'
+	import { CircleHelp, ArrowUp, Plus, Square, SquareCheck } from 'lucide-svelte'
 	import Button from '$lib/components/common/button/Button.svelte'
 	import TextInput from '$lib/components/text_input/TextInput.svelte'
 	import { getAiChatManager } from './aiChatManagerContext'
@@ -20,36 +21,86 @@
 
 	let { toolCallId, userQuestion }: Props = $props()
 
+	const multiSelect = $derived(userQuestion.multiSelect === true)
+
+	// Multi-select choices accumulate here until the user explicitly submits — a
+	// SvelteSet (not a plain Set) so `.add()/.delete()` drive Svelte reactivity.
+	let picked = new SvelteSet<string>()
+
+	// Surface picked custom answers as their own toggle rows so the user can see
+	// and un-pick them before submitting; a value equal to a proposed choice just
+	// checks that choice rather than adding a duplicate row.
+	const customPicked = $derived(
+		multiSelect ? [...picked].filter((p) => !userQuestion.choices.includes(p)) : []
+	)
+	const displayedChoices = $derived([...userQuestion.choices, ...customPicked])
+
+	let cardNode = $state<HTMLDivElement | undefined>()
 	let choiceButtons = $state<(HTMLButtonElement | undefined)[]>([])
+	let submitButton = $state<HTMLButtonElement | undefined>()
 	let customAnswerInput = $state<TextInput | undefined>()
 	let customAnswer = $state('')
 	let canSubmitCustomAnswer = $derived(customAnswer.trim().length > 0)
 
-	// The custom-answer input is the last stop in the roving cursor, after all
-	// choices, so arrow navigation can reach it from the keyboard.
-	const customAnswerIndex = $derived(userQuestion.choices.length)
-	const itemCount = $derived(userQuestion.choices.length + 1)
-	// The item currently under the keyboard cursor. Mirrored onto the matching
-	// choice's `selected` prop so the highlight comes from the Button itself.
+	// Submit joins the roving cursor only while it is actionable: a disabled
+	// Button carries tabindex=-1, so an empty-selection Submit can't take focus
+	// and would strand arrow-key navigation on it. Excluding it from itemCount
+	// when unreachable keeps the wraparound landing on real, focusable stops.
+	const submitReachable = $derived(multiSelect && picked.size > 0)
+
+	// The custom-answer input is the next stop in the roving cursor after all
+	// (proposed + custom) choice rows; Submit follows it when reachable.
+	const customAnswerIndex = $derived(displayedChoices.length)
+	const submitIndex = $derived(submitReachable ? displayedChoices.length + 1 : -1)
+	const itemCount = $derived(displayedChoices.length + 1 + (submitReachable ? 1 : 0))
+	// The item currently under the keyboard cursor. In single mode it is mirrored
+	// onto the matching choice's `selected` prop for the highlight; in multi mode
+	// `selected` is reserved for checked state, so the cursor shows as a focus ring.
 	let activeIndex = $state(0)
 
 	onMount(() => {
 		void tick().then(() => {
-			focusIndex(0)
+			// preventScroll: a scrolling focus() strands the taller multi-select card's
+			// Submit below the fold. The container auto-scroll is a stick-to-bottom that
+			// stops once the user scrolls up, so reveal the card itself instead.
+			focusIndex(0, { preventScroll: true })
+			cardNode?.scrollIntoView({ block: 'nearest' })
 		})
 	})
 
-	function focusIndex(index: number) {
+	function focusIndex(index: number, opts?: FocusOptions) {
 		activeIndex = index
 		if (index === customAnswerIndex) {
 			customAnswerInput?.focus()
+		} else if (index === submitIndex) {
+			submitButton?.focus(opts)
 		} else {
-			choiceButtons[index]?.focus()
+			choiceButtons[index]?.focus(opts)
 		}
 	}
 
+	// Cmd/Ctrl+Enter finalizes a multi-select answer from anywhere in the card.
+	function isSubmitShortcut(event: KeyboardEvent): boolean {
+		return event.key === 'Enter' && (event.metaKey || event.ctrlKey)
+	}
+
 	function selectChoice(choice: string) {
-		aiChatManager.handleUserQuestionAnswer(toolCallId, choice)
+		if (multiSelect) {
+			if (picked.has(choice)) {
+				picked.delete(choice)
+			} else {
+				picked.add(choice)
+			}
+			return
+		}
+		aiChatManager.handleUserQuestionAnswer(toolCallId, [choice])
+	}
+
+	function submitPicked() {
+		if (!multiSelect || picked.size === 0) {
+			return
+		}
+		aiChatManager.handleUserQuestionAnswer(toolCallId, [...picked])
 	}
 
 	function submitCustomAnswer() {
@@ -58,10 +109,27 @@
 			return
 		}
 
-		aiChatManager.handleUserQuestionAnswer(toolCallId, answer)
+		if (multiSelect) {
+			// Clear after queuing so the user can add more answers before Submit.
+			picked.add(answer)
+			customAnswer = ''
+			// The list grew under the still-focused input, shifting its roving index;
+			// resync so a later background-area click refocuses the input, not the new row.
+			activeIndex = customAnswerIndex
+			return
+		}
+
+		aiChatManager.handleUserQuestionAnswer(toolCallId, [answer])
 	}
 
 	function handleChoiceKeydown(event: KeyboardEvent, choice: string, index: number) {
+		if (multiSelect && isSubmitShortcut(event)) {
+			event.preventDefault()
+			event.stopPropagation()
+			submitPicked()
+			return
+		}
+
 		if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
 			event.preventDefault()
 			event.stopPropagation()
@@ -79,7 +147,14 @@
 		if (event.key === 'Enter') {
 			event.preventDefault()
 			event.stopPropagation()
+			// A custom row is only present while picked, so toggling it here removes
+			// it and unmounts the button — redirect focus to a stable stop so the
+			// keyboard flow survives. Proposed choices stay mounted when unchecked.
+			const removesRow = customPicked.includes(choice)
 			selectChoice(choice)
+			if (removesRow) {
+				void tick().then(() => focusIndex(customAnswerIndex))
+			}
 		}
 	}
 
@@ -113,6 +188,13 @@
 	}
 
 	function handleCustomAnswerKeydown(event: KeyboardEvent) {
+		if (multiSelect && isSubmitShortcut(event)) {
+			event.preventDefault()
+			event.stopPropagation()
+			submitPicked()
+			return
+		}
+
 		// Only ArrowUp/ArrowDown roam out of the input — Left/Right stay free for
 		// moving the text caret within the answer.
 		if (event.key === 'ArrowUp') {
@@ -135,32 +217,67 @@
 			submitCustomAnswer()
 		}
 	}
+
+	function handleSubmitKeydown(event: KeyboardEvent) {
+		if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+			event.preventDefault()
+			event.stopPropagation()
+			focusIndex((submitIndex + 1) % itemCount)
+			return
+		}
+
+		if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+			event.preventDefault()
+			event.stopPropagation()
+			focusIndex((submitIndex - 1 + itemCount) % itemCount)
+			return
+		}
+
+		if (event.key === 'Enter') {
+			event.preventDefault()
+			event.stopPropagation()
+			submitPicked()
+		}
+	}
 </script>
 
+<!-- scroll-mb clears the chat's sticky "Waiting for your input" chip (pinned at the
+     viewport bottom) so the mount scrollIntoView leaves the Submit button uncovered. -->
 <div
-	class="rounded-md border border-border-light bg-surface p-3"
+	bind:this={cardNode}
+	class="scroll-mb-8 rounded-md border border-border-light bg-surface p-3"
 	data-chat-keyboard-scope="ask-user-question"
 	use:focusActiveOnBackgroundClick
 >
 	<div class="flex items-start gap-2">
-		<CircleHelp class="mt-0.5 h-4 w-4 shrink-0 text-accent" />
+		<CircleHelp class="h-4 w-4 shrink-0 text-accent" />
 		<p class="min-w-0 flex-1 whitespace-pre-wrap text-xs font-semibold text-emphasis"
 			>{userQuestion.question}</p
 		>
 	</div>
 
 	<div class="mt-3 flex flex-col gap-2">
-		{#each userQuestion.choices as choice, index (index)}
+		{#each displayedChoices as choice, index (index)}
 			<Button
 				variant="default"
 				unifiedSize="sm"
-				selected={activeIndex === index}
+				selected={multiSelect ? picked.has(choice) : activeIndex === index}
 				bind:element={choiceButtons[index]}
 				onClick={() => selectChoice(choice)}
 				onkeydown={(event) => handleChoiceKeydown(event, choice, index)}
 				onfocus={() => (activeIndex = index)}
-				btnClasses="h-auto min-h-7 justify-start whitespace-normal py-1.5 text-left focus-visible:!ring-0 focus-visible:!outline-none"
+				btnClasses={`h-auto min-h-7 justify-start whitespace-normal py-1.5 text-left ${
+					multiSelect ? '' : 'focus-visible:!ring-0 focus-visible:!outline-none'
+				}`}
 			>
+				{#if multiSelect}
+					<!-- Show an empty box on every row, not only when checked, so multi-select is obvious up front. -->
+					{#if picked.has(choice)}
+						<SquareCheck class="mr-2 h-4 w-4 shrink-0" />
+					{:else}
+						<Square class="mr-2 h-4 w-4 shrink-0 text-secondary" />
+					{/if}
+				{/if}
 				<span class="break-words">{choice}</span>
 			</Button>
 		{/each}
@@ -182,12 +299,27 @@
 				variant="subtle"
 				unifiedSize="sm"
 				iconOnly
-				title="Send"
-				startIcon={{ icon: ArrowUp }}
+				title={multiSelect ? 'Add answer' : 'Send'}
+				startIcon={{ icon: multiSelect ? Plus : ArrowUp }}
 				disabled={!canSubmitCustomAnswer}
 				onClick={submitCustomAnswer}
 				btnClasses="shrink-0"
 			/>
 		</div>
+
+		{#if multiSelect}
+			<Button
+				variant="accent"
+				unifiedSize="sm"
+				bind:element={submitButton}
+				disabled={picked.size === 0}
+				onClick={submitPicked}
+				onkeydown={handleSubmitKeydown}
+				onfocus={() => (activeIndex = submitIndex)}
+				btnClasses="mt-1"
+			>
+				Submit{picked.size > 0 ? ` (${picked.size})` : ''}
+			</Button>
+		{/if}
 	</div>
 </div>

--- a/frontend/src/lib/components/copilot/chat/global/core.test.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.test.ts
@@ -3126,7 +3126,7 @@ describe('global AI tools', () => {
 		const callbacks: ToolCallbacks = {
 			setToolStatus: vi.fn(),
 			removeToolStatus: vi.fn(),
-			requestUserQuestion: vi.fn(async (_toolId, question) => question.choices[1])
+			requestUserQuestion: vi.fn(async (_toolId, question) => [question.choices[1]])
 		}
 
 		const raw = await callGlobalTool(
@@ -3152,7 +3152,45 @@ describe('global AI tools', () => {
 				content: 'User answered question: python3',
 				isLoading: false,
 				result: 'python3',
-				userQuestion: expect.objectContaining({ selectedChoice: 'python3' })
+				userQuestion: expect.objectContaining({ selectedChoices: ['python3'] })
+			})
+		)
+	})
+
+	it('returns a newline-bulleted list when several answers are selected', async () => {
+		const callbacks: ToolCallbacks = {
+			setToolStatus: vi.fn(),
+			removeToolStatus: vi.fn(),
+			requestUserQuestion: vi.fn(async (_toolId, question) => [
+				question.choices[0],
+				question.choices[2]
+			])
+		}
+
+		const raw = await callGlobalTool(
+			'askUserQuestion',
+			{
+				question: 'Which languages should be supported?',
+				choices: ['bun', 'python3', 'go'],
+				multiSelect: true
+			},
+			callbacks
+		)
+
+		// Model-facing return stays newline-bulleted; the header readback is a
+		// compact comma list.
+		expect(raw).toBe('- bun\n- go')
+		expect(callbacks.requestUserQuestion).toHaveBeenCalledWith(
+			'test-askUserQuestion',
+			expect.objectContaining({ multiSelect: true })
+		)
+		expect(callbacks.setToolStatus).toHaveBeenLastCalledWith(
+			'test-askUserQuestion',
+			expect.objectContaining({
+				content: 'User answered question: bun, go',
+				isLoading: false,
+				result: '- bun\n- go',
+				userQuestion: expect.objectContaining({ selectedChoices: ['bun', 'go'] })
 			})
 		)
 	})
@@ -3162,7 +3200,7 @@ describe('global AI tools', () => {
 		const callbacks: ToolCallbacks = {
 			setToolStatus: vi.fn(),
 			removeToolStatus: vi.fn(),
-			requestUserQuestion: vi.fn(async (_toolId, question) => question.choices[9])
+			requestUserQuestion: vi.fn(async (_toolId, question) => [question.choices[9]])
 		}
 
 		const raw = await callGlobalTool(
@@ -3207,7 +3245,7 @@ describe('global AI tools', () => {
 		const callbacks: ToolCallbacks = {
 			setToolStatus: vi.fn(),
 			removeToolStatus: vi.fn(),
-			requestUserQuestion: vi.fn(async () => 'use deno instead')
+			requestUserQuestion: vi.fn(async () => ['use deno instead'])
 		}
 
 		const raw = await callGlobalTool(
@@ -3225,7 +3263,7 @@ describe('global AI tools', () => {
 			expect.objectContaining({
 				content: 'User answered question: use deno instead',
 				result: 'use deno instead',
-				userQuestion: expect.objectContaining({ selectedChoice: 'use deno instead' })
+				userQuestion: expect.objectContaining({ selectedChoices: ['use deno instead'] })
 			})
 		)
 	})

--- a/frontend/src/lib/components/copilot/chat/global/core.ts
+++ b/frontend/src/lib/components/copilot/chat/global/core.ts
@@ -217,7 +217,13 @@ const askUserQuestionSchema = z.object({
 		.array(z.string().min(1).describe('Proposed answer text shown to the user and returned as-is.'))
 		.min(2)
 		.max(10)
-		.describe('Two to ten mutually exclusive proposed answer strings.')
+		.describe('Two to ten proposed answer strings.'),
+	multiSelect: z
+		.boolean()
+		.optional()
+		.describe(
+			'When true, the user may select several answers; use only when the choices can genuinely co-apply (not mutually exclusive). Defaults to single-select.'
+		)
 })
 
 // Matches the per-mode cap enforced by the prompt-settings UI (AIPromptsModal) and
@@ -905,7 +911,7 @@ Rules:
 - After creating or editing a script or flow draft, run test_run_script, test_run_flow, or test_run_step with representative args before reporting that it works. These tools prefer drafts, so testing does not require deployment.
 - Use list_runs to find recent runs (optionally filtered by path, creator, label, or status), then get_job_logs with a returned id to inspect a specific run's logs — without starting a new test run.
 - Use open_page to show a workspace page with filters applied — Runs, Schedules, Variables, Resources, Assets, Audit logs, or Workspace settings on a specific tab (e.g. "open the failed runs of f/foo/bar", "open the schedule for X", "open the git sync settings"). Only the pages listed for this user in the tool are available; don't offer pages that aren't listed. Don't use it as a substitute for list_runs when you just need the data yourself.
-- When a required decision is ambiguous, use askUserQuestion with two to ten clear proposed answer strings instead of guessing. The user can also type a custom answer when none of the proposed answers fit.
+- When a required decision is ambiguous, use askUserQuestion with two to ten clear proposed answer strings instead of guessing. The user can also type a custom answer when none of the proposed answers fit. Set multiSelect: true only when the answers can genuinely co-apply and the user may pick several (not mutually exclusive).
 - When the user asks you to remember a lasting preference, always/never do something, or change/stop a behavior going forward, call update_user_instructions to persist it. It edits only the USER INSTRUCTIONS block (not WORKSPACE INSTRUCTIONS). Keep each instruction concise; do not use it for one-off requests scoped to the current task.
 - Keep context targeted.${
 		previewTools
@@ -2106,7 +2112,8 @@ export const globalTools: Tool<{}>[] = [
 			const parsed = askUserQuestionSchema.parse(args)
 			const userQuestion = {
 				question: parsed.question,
-				choices: parsed.choices
+				choices: parsed.choices,
+				multiSelect: parsed.multiSelect
 			}
 
 			toolCallbacks.setToolStatus(toolId, {
@@ -2126,8 +2133,8 @@ export const globalTools: Tool<{}>[] = [
 				return JSON.stringify({ success: false, error: message })
 			}
 
-			const selectedChoice = await toolCallbacks.requestUserQuestion(toolId, userQuestion)
-			if (!selectedChoice) {
+			const selected = await toolCallbacks.requestUserQuestion(toolId, userQuestion)
+			if (!selected?.length) {
 				const message = 'Question cancelled by user'
 				toolCallbacks.setToolStatus(toolId, {
 					content: message,
@@ -2138,16 +2145,26 @@ export const globalTools: Tool<{}>[] = [
 				return JSON.stringify({ success: false, error: message })
 			}
 
+			// Model-facing answer: bare string for one pick (preserves the single-select
+			// contract, even when multiSelect was set), newline-bulleted list for several.
+			// Comma-joining is avoided here so a choice that itself contains a comma
+			// ("Yes, immediately") stays unambiguous to the model reading it back.
+			const answerText =
+				selected.length === 1 ? selected[0] : selected.map((c) => `- ${c}`).join('\n')
+			// The collapsed tool-header is a human glance, not model input, so the picks
+			// read as a compact comma list there instead of a stacked bullet list.
+			const answerSummary = selected.join(', ')
+
 			toolCallbacks.setToolStatus(toolId, {
-				content: `User answered question: ${selectedChoice}`,
+				content: `User answered question: ${answerSummary}`,
 				userQuestion: {
 					...userQuestion,
-					selectedChoice
+					selectedChoices: selected
 				},
-				result: selectedChoice,
+				result: answerText,
 				isLoading: false
 			})
-			return selectedChoice
+			return answerText
 		}
 	},
 	{

--- a/frontend/src/lib/components/copilot/chat/shared.test.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.test.ts
@@ -651,7 +651,18 @@ describe('isActiveUserQuestion', () => {
 		expect(isActiveUserQuestion(toolMessage())).toBe(true)
 	})
 
-	it('is false once a choice has been selected', async () => {
+	it('is false once choices have been selected', async () => {
+		const { isActiveUserQuestion } = await import('./shared')
+		expect(
+			isActiveUserQuestion(
+				toolMessage({
+					userQuestion: { question: 'Pick one', choices: ['a', 'b'], selectedChoices: ['a'] }
+				})
+			)
+		).toBe(false)
+	})
+
+	it('is false once a legacy scalar selectedChoice is present', async () => {
 		const { isActiveUserQuestion } = await import('./shared')
 		expect(
 			isActiveUserQuestion(
@@ -660,6 +671,17 @@ describe('isActiveUserQuestion', () => {
 				})
 			)
 		).toBe(false)
+	})
+
+	it('stays active when selectedChoices is present but empty', async () => {
+		const { isActiveUserQuestion } = await import('./shared')
+		expect(
+			isActiveUserQuestion(
+				toolMessage({
+					userQuestion: { question: 'Pick one', choices: ['a', 'b'], selectedChoices: [] }
+				})
+			)
+		).toBe(true)
 	})
 
 	it('is false when the question was canceled', async () => {

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -509,8 +509,17 @@ export type ToolDisplayAction = CreatedResourceAction | NavigateAction
 export type UserQuestionDisplay = {
 	question: string
 	choices: string[]
-	selectedChoice?: string
+	multiSelect?: boolean
+	selectedChoices?: string[] // canonical answer (new code writes only this)
+	selectedChoice?: string // legacy/read-only: pre-multiselect persisted history
 	canceled?: boolean
+}
+
+// The single place that understands the legacy answer shape: new code writes
+// selectedChoices, but history persisted before multi-select only has the
+// scalar selectedChoice. Read answers through this so both shapes resolve.
+export function answeredChoices(q: UserQuestionDisplay): string[] | undefined {
+	return q.selectedChoices ?? (q.selectedChoice ? [q.selectedChoice] : undefined)
 }
 
 export type ToolDisplayMessage = {
@@ -573,7 +582,7 @@ export function isActiveUserQuestion(message: DisplayMessage | undefined): boole
 			message.userQuestion &&
 			message.isLoading &&
 			!message.error &&
-			!message.userQuestion.selectedChoice &&
+			!answeredChoices(message.userQuestion)?.length &&
 			!message.userQuestion.canceled
 	)
 }
@@ -878,7 +887,7 @@ export interface ToolCallbacks {
 	requestUserQuestion?: (
 		toolId: string,
 		question: UserQuestionDisplay
-	) => Promise<string | undefined>
+	) => Promise<string[] | undefined>
 	/** Records a workspace item the tool call created/edited/deleted, by its
 	 * canonical (itemKind, storagePath). Session chats wire this to accumulate the
 	 * chat's modified-items mask; the global side-panel chat omits it (no-op). */


### PR DESCRIPTION
## Summary

Lets the Global copilot's `askUserQuestion` tool optionally ask a question where the user can pick **several** answers, not just one. The model opts in per call with `multiSelect: true`; existing single-select questions are unchanged.

Internally this widens the answer channel from a single `string` to `string[]` end-to-end while keeping the **model-facing return contract byte-identical** for single answers, and reworks the question card UI to support toggling, an explicit Submit step, and coherent keyboard navigation.

## Changes

- **Schema & prompt** (`global/core.ts`): add optional `multiSelect` to `askUserQuestionSchema`; drop "mutually exclusive" from the `choices` description; mention `multiSelect` in the prompt guidance.
- **Return serialization by count** (`global/core.ts`): one pick → bare string (preserves the single-select contract even when `multiSelect` is set); several → newline-bulleted list to the model. Comma-joining is deliberately avoided so a choice containing a comma (e.g. `Yes, immediately`) stays unambiguous. The collapsed tool-header shows a compact comma summary (human glance), separate from the model return.
- **Display type & legacy read** (`shared.ts`): `selectedChoices: string[]` becomes canonical; `selectedChoice` kept read-only for pre-multiselect persisted history; new `answeredChoices()` normalizer is the single reader of both shapes; `isActiveUserQuestion` routes through it.
- **Callback widening** (`AIChatManager.svelte.ts`, `shared.ts`): `requestUserQuestion` / `handleUserQuestionAnswer` / the pending-callback map all move to `string[] | undefined`.
- **UI** (`AskUserQuestionDisplay.svelte`): checkbox affordance (empty `Square` / checked `SquareCheck` on every multi row), click/Enter toggles, custom answers render as removable toggle rows, an explicit **Submit (N)** button (disabled at zero), roving-cursor keyboard nav (arrows + `Cmd/Ctrl+Enter` submit), and a mount-time `scrollIntoView({ block: 'nearest' })` so the card reveals itself (the chat's stick-to-bottom auto-scroll can't be relied on). Single-select keeps immediate-submit-on-click.
- **Tests** (`core.test.ts`, `shared.test.ts`): multi-select serialization + `selectedChoices` shape, the `answeredChoices` branch matrix (new field, legacy scalar, empty-array-stays-active), and single-select cases migrated to the array channel.

## Screenshots

<img width="457" height="278" alt="msel-01-initial" src="https://github.com/user-attachments/assets/7d05c175-6f41-4549-9f1b-bbd0d0cca315" />

multi-select card: empty checkboxes, disabled Submit

<img width="457" height="316" alt="msel-02-picked" src="https://github.com/user-attachments/assets/1a9d0c3e-77db-4703-8784-3dbfa49090bb" />

bun/go + custom "rust" checked, **Submit (3)**

<img width="531" height="672" alt="msel-03-answered" src="https://github.com/user-attachments/assets/36a6a5b3-a0dc-4c41-8c14-f082e55ebe03" />

answered readback ("User answered question: bun, go") + model reply

## Test plan

- [ ] `npm run check` passes (frontend)
- [ ] Unit: `core.test.ts` + `shared.test.ts` green (multi serialization, legacy/empty answer shapes)
- [ ] Global copilot: trigger a `multiSelect: true` question — toggle several choices, add + remove a custom answer, **Submit (N)** disabled at zero
- [ ] Keyboard-only: arrows roam choices → custom input → Submit and wrap; `Cmd/Ctrl+Enter` submits; single-select still submits on first click
- [ ] Model receives a newline-bulleted list for several picks and a bare string for one; collapsed header shows the comma summary
- [ ] Card scrolls fully into view on appear for both single and multi select
- [ ] Legacy persisted question (scalar `selectedChoice`) still renders as answered