### PR TITLE
fix: sync theme into session page preview iframes on toggle

### DIFF
--- a/frontend/src/lib/components/sessions/PreviewTabHost.svelte
+++ b/frontend/src/lib/components/sessions/PreviewTabHost.svelte
@@ -8,7 +8,7 @@
 		type SessionPreviewTab
 	} from './sessionState.svelte'
 	import type { SessionRuntime } from './sessionRuntime.svelte'
-	import { resolvePreviewTab } from './previewRouter'
+	import { resolvePreviewTab, parsePreviewItemRoute } from './previewRouter'
 	import { withMenuHidden } from './sessionMode.svelte'
 	import ScriptEditorView from './ScriptEditorView.svelte'
 	import FlowEditorView from './FlowEditorView.svelte'
@@ -22,6 +22,7 @@
 		active,
 		mounted,
 		label,
+		darkMode,
 		onNavigate,
 		onLoad
 	}: {
@@ -34,6 +35,9 @@
 		mounted: boolean
 		/** Short tab label, for the iframe title. */
 		label: string
+		/** Current top-document theme — mirrored into page iframes so they follow
+		 * live toggles (app iframes pin their own theme and are excluded). */
+		darkMode: boolean
 		/** A link click inside a live editor re-points the active preview tab. */
 		onNavigate: (item: WorkspaceItem) => void
 		/** Iframe finished loading — the page reads back its observed location. */
@@ -50,6 +54,26 @@
 	const isActiveSession = $derived(!!session && sessionState.currentSessionId === session.id)
 
 	let frame: HTMLIFrameElement | undefined = $state()
+
+	// Pages whose theme we mirror on live toggles. Regular apps are the only item
+	// route that resolves to an iframe (scripts/flows/raw apps mount live editors)
+	// and they pin their own theme, so excluding item routes excludes exactly them.
+	const isPageIframe = $derived(slot.kind === 'iframe' && parsePreviewItemRoute(tab.url) === null)
+
+	function applyPageIframeTheme(dark: boolean, target: HTMLIFrameElement | undefined = frame) {
+		if (!isPageIframe) return
+		try {
+			target?.contentWindow?.document?.documentElement.classList.toggle('dark', dark)
+		} catch {
+			// Mid-navigation (or a defensively cross-origin frame); the next load re-applies.
+		}
+	}
+
+	// Only live toggles need this; initial paint is already correct — the iframe's
+	// own layout reads the global preference at load.
+	$effect(() => {
+		applyPageIframeTheme(darkMode)
+	})
 
 	export function reload() {
 		// A live editor shares the runtime store the chat mutates, so generic chat
@@ -117,7 +141,13 @@
 	<iframe
 		bind:this={frame}
 		src={withMenuHidden(tab.url, workspaceId || undefined)}
-		onload={(e) => onLoad(e.currentTarget as HTMLIFrameElement)}
+		onload={(e) => {
+			const f = e.currentTarget as HTMLIFrameElement
+			// Re-apply after load so a toggle that happened while the frame was
+			// loading (its layout read the pre-toggle preference) isn't lost.
+			applyPageIframeTheme(darkMode, f)
+			onLoad(f)
+		}}
 		title="Session preview: {label}"
 		class="absolute inset-0 w-full h-full border-0 bg-surface {visibility}"
 	></iframe>

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -23,6 +23,7 @@
 	import { goto } from '$lib/navigation'
 	import SessionWrapper from '$lib/components/sessions/SessionWrapper.svelte'
 	import PreviewTabHost from '$lib/components/sessions/PreviewTabHost.svelte'
+	import { useIsDarkMode } from '$lib/components/DarkModeObserver.svelte'
 	import {
 		createSession,
 		getEffectiveWorkspaceId,
@@ -56,6 +57,10 @@
 	import { splitterPointerCapture } from '$lib/utils/splitterPointerCapture'
 
 	const globalEnabled = isGlobalAiEnabled()
+
+	// One observer shared by every tab host, which mirrors it into page iframes
+	// (see PreviewTabHost).
+	const isDarkMode = useIsDarkMode()
 
 	// The sessions page hosts preview iframes that load Windmill pages. If one of
 	// those iframes navigates back to /sessions, mounting the full UI again would
@@ -708,6 +713,7 @@
 											active={s.id === activeSession?.id && tab.id === tabs?.activeId}
 											mounted={mountedTabKeys.has(tabKey(s.id, tab.id))}
 											label={tabLabel(tab.loc)}
+											darkMode={isDarkMode.val}
 											onNavigate={navigateEditorTo}
 											onLoad={(frame) => tabs && onTabLoad(tabs, tab, frame)}
 										/>


### PR DESCRIPTION
## Summary

With a session open, switching the app theme (light ↔ dark) updated the main Windmill UI but **not** the content of session preview iframes (e.g. Runs, Assets, Variables). Those pages read the theme once at load and never listened for later changes, and the toggle only mutated the top document.

This propagates a live theme toggle into **non-app "page" iframes** only. App iframes are deliberately excluded — a regular app pins its own theme (`app.darkMode`) and is intentionally its own environment; its behavior is unchanged (it reads the global preference once at load, as today).

Scoped to the sessions feature rather than a layout-level listener: `(root)/+layout.svelte` is shared by app pages too, so a listener there would fire inside app iframes and clobber their pin.

## Changes

- `sessions/+page.svelte` — one shared `useIsDarkMode()` observer of the top document's `dark` class, passed as `darkMode` to each `PreviewTabHost`.
- `PreviewTabHost.svelte` — new non-bindable `darkMode` prop; `isPageIframe` derived (`slot.kind === 'iframe' && parsePreviewItemRoute(tab.url) === null`, which excludes the only iframe-reachable theme-pinning route: regular apps); mirrors the `dark` class into the iframe's document on an `$effect` (live toggles) and on iframe `onload` (a toggle that landed mid-load). Same-origin write guarded by optional chaining + try/catch for mid-navigation/cross-origin.

## Out of scope (consequences of the Pages-only scope)

- App iframes don't follow live toggles (intended isolation; unchanged from today).
- No cross-tab theme sync; no `prefers-color-scheme` listener.

## Screenshots

No static screenshot: the change is a *live toggle* behavior — a single frame only shows "the iframe is dark," which is meaningless without the before/after transition. Verified instead by driving the real sessions page with Playwright (see test plan).

## Test plan

- [ ] **Page follows toggle** — opened `/runs` as a preview tab; toggling top theme light→dark propagated into the iframe, and dark→light propagated back (verified via Playwright, both directions).
- [ ] **App iframe does not follow** — open a regular app (`/apps/get|edit/...`) in a tab; toggle theme → app iframe keeps its own theme. (Static guard: `isPageIframe` is false for app routes; not exercised live — no reachable deployed regular app in the test workspace.)
- [ ] **Editor slots unaffected** — script/flow/raw-app editors render in the top document and follow theme as before.
- [ ] **Reload re-syncs** — a page iframe reloaded after a toggle shows the current theme (its layout reads the global preference at load).