### PR TITLE
fix(frontend): persist forked "Copy of X" script drafts

### DIFF
--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -397,13 +397,10 @@
 	let pathError = $state('')
 	let loadingSave = $state(false)
 
-	// Lifts the route's `?new_draft=true` autosave suspension (`UserDraft.stopSync`)
-	// once the bootstrap settles. Resumes only after the stores-gated `initPath →
-	// reset → onMetaChange → bind:path` auto-naming chain — and, for an empty seed,
-	// the async `initContent` (gated via the returned `markContentReady`) — otherwise
-	// the auto-generated path or template seed posts as the user's first "edit". The
-	// `restarted` guard makes the conditional `$effect` self-cleaning on cold reload
-	// (auth stores loading after mount) and a post-unmount call harmless.
+	// Lifts the route's `?new_draft=true` `stopSync` suspension, but only after the
+	// stores-gated bind:path cascade (and, for an empty seed, `initContent` via
+	// `markContentReady`) settles — resuming earlier posts the seed/auto-generated
+	// path as the user's first "edit". `restarted` keeps re-entry idempotent.
 	function scheduleRestartSync(
 		path: string,
 		opts?: { waitForContent?: boolean }
@@ -460,11 +457,9 @@
 		const restarter = scheduleRestartSync(userDraftPath, { waitForContent: true })
 		initContent(script.language, script.kind, template).finally(() => restarter.markContentReady())
 	} else if (userDraftPath && untrack(() => searchParams).get('new_draft') == 'true') {
-		// Pre-filled new-draft seed (fork "Copy of X", hub fork, URL/YAML import): the
-		// route already suspended autosave before mount so the seed write wouldn't POST
-		// as the user's first edit. There's no template to seed here (content is
-		// non-empty), but we MUST still lift that suspension or autosave stays dead for
-		// the session and the draft is never persisted (never shows up in the list).
+		// Pre-filled new-draft seed (fork "Copy of X", hub fork, URL/YAML import): no
+		// template to seed, but the route still suspended autosave — lift it or the
+		// draft never persists (autosave stays dead for the session).
 		scheduleRestartSync(userDraftPath)
 	}
 

--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -397,6 +397,46 @@
 	let pathError = $state('')
 	let loadingSave = $state(false)
 
+	// Lifts the route's `?new_draft=true` autosave suspension (`UserDraft.stopSync`)
+	// once the bootstrap settles. Resumes only after the stores-gated `initPath →
+	// reset → onMetaChange → bind:path` auto-naming chain — and, for an empty seed,
+	// the async `initContent` (gated via the returned `markContentReady`) — otherwise
+	// the auto-generated path or template seed posts as the user's first "edit". The
+	// `restarted` guard makes the conditional `$effect` self-cleaning on cold reload
+	// (auth stores loading after mount) and a post-unmount call harmless.
+	function scheduleRestartSync(
+		path: string,
+		opts?: { waitForContent?: boolean }
+	): { markContentReady: () => void } {
+		let contentReady = !opts?.waitForContent
+		let storesReady = !!($userStore && $workspaceStore)
+		let restarted = false
+		async function tryRestart() {
+			if (restarted || !contentReady || !storesReady) return
+			// 500ms covers the bind:path cascade even on cold reload; two ticks
+			// weren't enough (bind:path fired ~100ms after restart, posting an edit).
+			await new Promise((r) => setTimeout(r, 500))
+			if (restarted) return
+			restarted = true
+			UserDraft.restartSync('script', path)
+		}
+		if (!storesReady) {
+			$effect(() => {
+				if ($userStore && $workspaceStore) {
+					storesReady = true
+					untrack(() => void tryRestart())
+				}
+			})
+		}
+		void tryRestart()
+		return {
+			markContentReady() {
+				contentReady = true
+				void tryRestart()
+			}
+		}
+	}
+
 	if (script.content == '') {
 		// Suspend autosave around the bootstrap mutations: seeding the template
 		// content is a programmatic write, not the user's first edit. The handle
@@ -417,36 +457,15 @@
 				}
 			}
 		}
-		// Sync resumes only after two cascades settle: the async `initContent`,
-		// and the stores-gated `initPath → reset → onMetaChange → bind:path`
-		// auto-naming chain. Whichever lands last calls `tryRestart`; otherwise
-		// the auto-generated path posts as the first "user edit".
-		let initContentDone = false
-		let storesReady = !!($userStore && $workspaceStore)
-		let restarted = false
-		async function tryRestart() {
-			if (restarted || !initContentDone || !storesReady) return
-			// 500ms covers the bind:path cascade even on cold reload; two ticks
-			// weren't enough (bind:path fired ~100ms after restart, posting an edit).
-			await new Promise((r) => setTimeout(r, 500))
-			if (restarted) return
-			restarted = true
-			UserDraft.restartSync('script', userDraftPath)
-		}
-		initContent(script.language, script.kind, template).finally(() => {
-			initContentDone = true
-			void tryRestart()
-		})
-		// Cold reload: auth stores may load after mount; the `restarted` guard
-		// makes the effect self-cleaning.
-		if (!storesReady) {
-			$effect(() => {
-				if ($userStore && $workspaceStore) {
-					storesReady = true
-					untrack(() => void tryRestart())
-				}
-			})
-		}
+		const restarter = scheduleRestartSync(userDraftPath, { waitForContent: true })
+		initContent(script.language, script.kind, template).finally(() => restarter.markContentReady())
+	} else if (userDraftPath && untrack(() => searchParams).get('new_draft') == 'true') {
+		// Pre-filled new-draft seed (fork "Copy of X", hub fork, URL/YAML import): the
+		// route already suspended autosave before mount so the seed write wouldn't POST
+		// as the user's first edit. There's no template to seed here (content is
+		// non-empty), but we MUST still lift that suspension or autosave stays dead for
+		// the session and the draft is never persisted (never shows up in the list).
+		scheduleRestartSync(userDraftPath)
 	}
 
 	async function isTemplateScript() {


### PR DESCRIPTION
## Summary

Forking a script ("Copy of X"), hub-forking, or seeding a new draft from a URL / YAML / JSON import opened the editor pre-filled with content, but the saved draft **never appeared in the scripts list** — the save silently did nothing.

**Root cause:** the edit route suspends autosave for every `?new_draft=true` load (`UserDraft.stopSync`, `scripts/edit/[...path]/+page.svelte:141`) so the seed write isn't mistaken for the user's first edit, expecting `ScriptBuilder` to lift it. But `ScriptBuilder`'s matching `restartSync` only ran inside `if (script.content == '')`. A fork / hub / import seed has **non-empty** content, so that block was skipped and `restartSync` never fired — autosave stayed suspended for the rest of the session. With sync suspended, the reactive effect returns before parking a save (`userDraft.svelte.ts:769`), so **both autosave and explicit Ctrl+S** (`UserDraftDbSyncer.flush` finds nothing parked → no-op) did nothing. The draft was never written to the `draft` table, so `listScripts(include_draft_only)` never returned it.

## Changes

- `frontend/src/lib/components/ScriptBuilder.svelte`: extract the route-suspension-lifting logic into a small `scheduleRestartSync(path, { waitForContent })` helper and call it from **both** the empty-seed branch and a new `else if` branch for pre-filled `new_draft` seeds. The pre-filled branch restores parity with the empty-new-script flow (`lastSerialized` advances during suspension, so only a genuine post-restart edit posts). The empty-seed behaviour is unchanged.

## Notes

- No visible UI change — this is a pure autosave-persistence logic fix (the editor looks identical; only whether the draft is saved differs), so no screenshots.
- Not browser-verified end-to-end: the change runs against `app.windmill.dev` via the dev proxy and the Playwright browser is a separate, logged-out session (SSO), so I couldn't drive the full flow. `npm run check:fast` is clean for this file and the dev server HMR-compiled it without errors.

## Test plan

- [ ] From an existing script editor, use **Fork ("Copy of X")** to land on `/scripts/edit/...?new_draft=true` with pre-filled content, make one edit, and confirm the draft autosaves and shows up in the scripts list (previously it silently never persisted).
- [ ] Repeat with a **hub fork** and a **YAML/JSON import** (both non-empty seeds).
- [ ] Cold hard-reload of a fork URL (auth stores unresolved at mount) → after the first edit, autosave still resumes and the seed content itself does not post as a spurious first edit.
- [ ] Regression: a **new empty script** still autosaves as before, and reverting a draft on an existing deployed script still discards correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)