### PR TITLE
feat(forks): add "Hide unchanged drafts" toggle to fork deploy-draft tab

### DIFF
--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -8598,6 +8598,11 @@ paths:
           description: List every draft in the workspace (all users), not just the current user's own + legacy rows. Other users' rows come back with `mine=false` (view-only).
           schema:
             type: boolean
+        - name: compare_to_workspace
+          in: query
+          description: A fork passes its parent workspace id here to have each row flagged with `unchanged_from_parent`. Ignored unless it is exactly this workspace's parent.
+          schema:
+            type: string
       responses:
         "200":
           description: the user's drafts
@@ -8633,6 +8638,9 @@ paths:
                     mine:
                       type: boolean
                       description: The row belongs to the current user (own draft or the legacy no-owner row) and is therefore actionable. Always true in the default listing; with `all_users=true`, other users' rows are false (view-only).
+                    unchanged_from_parent:
+                      type: boolean
+                      description: Only present when `compare_to_workspace` was passed. True when this draft is identical to the parent's draft at the same path/kind/owner (cloned in on fork and never edited here).
                     draft_users:
                       description: |
                         Draft authors at this (path, kind) — the legacy NULL-email row surfaced as a null username.

--- a/backend/windmill-api/src/drafts.rs
+++ b/backend/windmill-api/src/drafts.rs
@@ -64,6 +64,11 @@ pub struct DraftListItem {
     /// so it defaults to `false` when read from the row.
     #[sqlx(default)]
     pub can_write: bool,
+    /// `true` when this draft is identical (jsonb-equal) to the parent's draft at
+    /// the same (path, kind, owner). `None` unless the request passed a valid
+    /// `compare_to_workspace`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unchanged_from_parent: Option<bool>,
     /// The listed row belongs to the authed user (own draft or the legacy
     /// no-owner row) and is therefore actionable by them. Always `true` in the
     /// default (own-drafts) listing; only meaningful with `all_users=true`,
@@ -77,6 +82,10 @@ pub struct ListDraftsQuery {
     /// List every draft in the workspace (all users), not just the authed
     /// user's own + legacy rows. Other users' rows come back with `mine=false`.
     pub all_users: Option<bool>,
+    /// A fork passes its parent workspace id here to have each row flagged with
+    /// `unchanged_from_parent`. Honored only when it is this workspace's actual
+    /// `parent_workspace_id` (enforced in `list_drafts`).
+    pub compare_to_workspace: Option<String>,
 }
 
 /// Every draft the authed user has in this workspace, across all kinds — the
@@ -97,9 +106,31 @@ async fn list_drafts(
         return Ok(Json(vec![]));
     }
     let all_users = query.all_users.unwrap_or(false);
+    // Only honor `compare_to_workspace` when it is genuinely this workspace's
+    // parent (a fork comparing against its source). Any other value is dropped
+    // so the value-equality subquery can't be used to probe an unrelated
+    // workspace's draft contents.
+    let compare_to_workspace = match &query.compare_to_workspace {
+        Some(candidate) => {
+            let parent: Option<String> = sqlx::query_scalar::<_, Option<String>>(
+                "SELECT parent_workspace_id FROM workspace WHERE id = $1",
+            )
+            .bind(&w_id)
+            .fetch_optional(&db)
+            .await?
+            .flatten();
+            if parent.as_deref() == Some(candidate.as_str()) {
+                Some(candidate.clone())
+            } else {
+                None
+            }
+        }
+        None => None,
+    };
     let rows = sqlx::query_as::<_, DraftListItem>(&list_drafts_query(all_users))
         .bind(&w_id)
         .bind(&authed.email)
+        .bind(&compare_to_workspace)
         .fetch_all(&db)
         .await?;
     // Per-row permission gating:
@@ -145,8 +176,10 @@ async fn list_drafts(
 /// `deployed_table()` (shared single source — can't drift from the access
 /// check). Table names come from the closed enum, never user input. Kinds
 /// with no path-keyed table get no arm and fall to `ELSE true`.
-/// `$1` = workspace_id, `$2` = email. With `all_users` the owner filter is
-/// dropped so every workspace draft is listed (others' rows get `mine=false`).
+/// `$1` = workspace_id, `$2` = email, `$3` = the parent workspace to compare
+/// against (nullable; drives `unchanged_from_parent`). With `all_users` the
+/// owner filter is dropped so every workspace draft is listed (others' rows get
+/// `mine=false`).
 fn list_drafts_query(all_users: bool) -> String {
     let mut case = String::from("CASE d.typ::text\n");
     for kind in UserDraftItemKind::ALL {
@@ -217,7 +250,18 @@ fn list_drafts_query(all_users: bool) -> String {
                   ) AS draft_path,
                   (d.email IS NULL) AS legacy_draft,
                   (d.email = $2 OR d.email IS NULL) AS mine,
-                  {case} AS draft_only
+                  {case} AS draft_only,
+                  -- value is a `json` column (no `=` operator), so compare as jsonb.
+                  CASE WHEN $3::text IS NULL THEN NULL::bool
+                       ELSE EXISTS(
+                         SELECT 1 FROM draft pd
+                         WHERE pd.workspace_id = $3
+                           AND pd.path = d.path
+                           AND pd.typ = d.typ
+                           AND pd.email IS NOT DISTINCT FROM d.email
+                           AND pd.value::jsonb = d.value::jsonb
+                       )
+                  END AS unchanged_from_parent
            FROM draft d
            WHERE d.workspace_id = $1{owner_filter}
            ORDER BY d.path, d.typ,

--- a/frontend/src/lib/components/CompareDrafts.svelte
+++ b/frontend/src/lib/components/CompareDrafts.svelte
@@ -94,6 +94,9 @@
 		 * actionable. Other users' rows (shown when "Show all drafts" is on) are
 		 * view-only: you can't deploy/discard someone else's draft. */
 		mine: boolean
+		/** Fork only: true when this draft is identical to the parent's (inherited
+		 * on fork, never edited here). Drives "Hide unchanged drafts". */
+		unchanged_from_parent?: boolean
 	}
 	function getItemKey(kind: string, path: string): string {
 		return `${kind}:${path}`
@@ -133,10 +136,15 @@
 	let showAll = $state(false)
 	const allDrafts = useWorkspaceDrafts(
 		() => (showAll ? currentWorkspaceId : undefined),
-		() => true
+		() => true,
+		() => (isFork ? parentWorkspaceId : undefined)
 	)
 	const sourceItems = $derived(showAll ? allDrafts.items : draftItems)
 	const loading = $derived(showAll ? allDrafts.loading : draftsLoading)
+
+	// On by default: a fork inherits the parent's drafts on creation, and those
+	// (unrelated to the fork's own work) are the common case worth hiding.
+	let hideUnchanged = $state(true)
 
 	// The list (and, in the default view, the Draft Count) come from the Workspace
 	// Drafts module; deploy/discard invalidate the resource, so the list refetches
@@ -164,10 +172,11 @@
 			.filter((u): u is string => !!u && u !== currentUsername)
 	}
 
-	// The backend already returns exactly the rows for the current view (own +
-	// legacy, or every user's with "Show all drafts"), so there's no client-side
-	// filtering — `visibleItems` is just the mapped list.
-	const visibleItems = $derived(items)
+	// The backend returns exactly the rows for the current view; the only
+	// client-side filter is "Hide unchanged drafts".
+	const visibleItems = $derived(
+		isFork && hideUnchanged ? items.filter((i) => i.unchanged_from_parent !== true) : items
+	)
 
 	// A row is actionable when it isn't already deployed this session, the user has
 	// write permission, AND it's their own draft (you can't deploy someone else's
@@ -546,20 +555,35 @@
 			onDeselectAll={deselectAll}
 			emptyMessage={loading
 				? 'Loading drafts…'
-				: showAll
-					? 'No drafts in this workspace'
-					: 'No drafts you authored in this workspace'}
+				: isFork && hideUnchanged && items.length > 0
+					? 'All drafts are unchanged from the parent workspace. Turn off "Hide unchanged drafts" to show them.'
+					: showAll
+						? 'No drafts in this workspace'
+						: 'No drafts you authored in this workspace'}
 		>
 			{#snippet selectAllActions()}
-				<Toggle
-					bind:checked={showAll}
-					size="xs"
-					options={{
-						right: 'Show all drafts',
-						rightTooltip:
-							"Show every user's drafts in this workspace, not just yours. Others' drafts are view-only — you can only deploy or discard your own."
-					}}
-				/>
+				<div class="flex items-center gap-4">
+					{#if isFork}
+						<Toggle
+							bind:checked={hideUnchanged}
+							size="xs"
+							options={{
+								right: 'Hide unchanged drafts',
+								rightTooltip:
+									"Hide drafts identical to the parent workspace. A fork inherits the parent's drafts when it's created; those are unrelated to the changes made in this fork."
+							}}
+						/>
+					{/if}
+					<Toggle
+						bind:checked={showAll}
+						size="xs"
+						options={{
+							right: 'Show all drafts',
+							rightTooltip:
+								"Show every user's drafts in this workspace, not just yours. Others' drafts are view-only — you can only deploy or discard your own."
+						}}
+					/>
+				</div>
 			{/snippet}
 
 			{#snippet header()}

--- a/frontend/src/lib/workspaceDrafts.svelte.ts
+++ b/frontend/src/lib/workspaceDrafts.svelte.ts
@@ -47,13 +47,22 @@ export interface DraftItem {
 	 * `allUsers` listing surfaces other users' rows as `false` (view-only).
 	 * Defaults to true when the field is absent (older backend). */
 	mine: boolean
+	/** Only set when listed with a `compareToWorkspace` (a fork comparing against
+	 * its parent): true when this draft is identical to the parent's — cloned in
+	 * on fork and never edited here. Undefined when no comparison was requested. */
+	unchanged_from_parent?: boolean
 }
 
 export async function getDraftItems(
 	workspace: string,
-	allUsers: boolean = false
+	allUsers: boolean = false,
+	compareToWorkspace?: string
 ): Promise<DraftItem[]> {
-	const rows = await DraftService.listDrafts({ workspace, allUsers: allUsers || undefined })
+	const rows = await DraftService.listDrafts({
+		workspace,
+		allUsers: allUsers || undefined,
+		compareToWorkspace
+	})
 	return rows.map((r) => ({
 		kind: r.kind,
 		path: r.path,
@@ -64,7 +73,8 @@ export async function getDraftItems(
 		raw_app: r.kind === 'raw_app',
 		can_write: r.can_write ?? true,
 		draft_users: r.draft_users,
-		mine: r.mine ?? true
+		mine: r.mine ?? true,
+		unchanged_from_parent: r.unchanged_from_parent
 	}))
 }
 
@@ -92,14 +102,15 @@ export interface WorkspaceDraftsHandle {
  */
 export function useWorkspaceDrafts(
 	workspace: () => string | undefined,
-	allUsers: () => boolean = () => false
+	allUsers: () => boolean = () => false,
+	compareToWorkspace: () => string | undefined = () => undefined
 ): WorkspaceDraftsHandle {
 	const res = resource(
 		() => {
 			const ws = workspace()
-			return { ws, all: allUsers(), v: ws ? (versions[ws] ?? 0) : 0 }
+			return { ws, all: allUsers(), compare: compareToWorkspace(), v: ws ? (versions[ws] ?? 0) : 0 }
 		},
-		async ({ ws, all }) => (ws ? getDraftItems(ws, all) : [])
+		async ({ ws, all, compare }) => (ws ? getDraftItems(ws, all, compare) : [])
 	)
 	return {
 		get items() {

--- a/frontend/src/routes/(root)/(logged)/forks/compare/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/forks/compare/+page.svelte
@@ -92,8 +92,17 @@
 	// Draft count drives the "Deployed ↔ draft" toggle badge. Reads the shared
 	// Workspace Drafts resource — count ≡ the draft list, and it refreshes itself
 	// when a deploy/discard invalidates the workspace.
-	const drafts = useWorkspaceDrafts(() => currentWorkspaceId)
-	const draftCount = $derived(drafts.count)
+	const drafts = useWorkspaceDrafts(
+		() => currentWorkspaceId,
+		() => false,
+		() => (isFork ? (parentWorkspaceId ?? undefined) : undefined)
+	)
+	// On a fork, match the badge to the default deploy-draft view, which hides
+	// drafts unchanged from the parent (else a fresh fork shows a count over an
+	// empty list).
+	const draftCount = $derived(
+		isFork ? drafts.items.filter((d) => d.unchanged_from_parent !== true).length : drafts.count
+	)
 
 	// Keys (`kind:path`) of fork items that are deployed *and* carry a pending
 	// draft (has_draft, i.e. not draft_only). CompareWorkspaces uses this to flag


### PR DESCRIPTION
## Summary

When a workspace is forked, its drafts are cloned into the fork on creation. The fork's **Deploy draft** tab then listed every one of those drafts as deployable — even the ones the fork never touched — so a fresh fork proposed deploying `n` drafts unrelated to its actual changes.

This adds a **"Hide unchanged drafts"** toggle (fork-only, on by default) that hides drafts identical to the parent workspace's, leaving only the drafts that represent real changes made in the fork.

"Unchanged" is defined against the parent: a fork draft is unchanged iff the parent workspace still has a draft at the same `(path, kind, owner)` with an equal value. `clone_drafts` copies `value`/`email`/`created_at` verbatim on fork, so an untouched clone stays equal to the parent's; editing it in the fork makes it diverge (shown), and a brand-new fork draft has no parent counterpart (shown).

## Changes

- **Backend** (`backend/windmill-api/src/drafts.rs`): the drafts-list endpoint accepts an optional `compare_to_workspace` query param and returns an `unchanged_from_parent` flag per row, computed via a `jsonb`-equality correlated subquery against that workspace's draft. The param is only honored when it equals the workspace's real `parent_workspace_id` (otherwise dropped) so it can't be used to probe an unrelated workspace's draft contents.
- **OpenAPI** (`openapi.yaml`) + regenerated client for the new param/field.
- **Frontend**:
  - `useWorkspaceDrafts` / `getDraftItems` thread an optional `compareToWorkspace`; the fork compare page passes its parent.
  - `CompareDrafts.svelte` renders the toggle (fork-only, default on) and filters out `unchanged_from_parent` rows — which also drops them from the selection and the "Deploy N drafts" count.
  - The fork's draft-count badge counts only changed drafts, so a fresh fork no longer advertises a non-zero badge over an all-hidden list.

## Screenshots

Fork deploy-draft tab, **default (toggle on)** — only the edited (`foo`) and fork-only (`newinfork`) drafts show; inherited `bar`/`baz` are hidden; badge reads "Deploy draft (2)":

![hide_on](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/hide-unchanged-drafts-toggle/1783586325-hide_on.png)

**Toggle off** — all four drafts including the two inherited-unchanged ones:

![hide_off](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/hide-unchanged-drafts-toggle/1783586328-hide_off.png)

## Test plan

Verified end-to-end against a real parent + fork (created via the API so `clone_drafts` ran authentically):
- [x] Backend: `GET /drafts/list?compare_to_workspace=<parent>` returns `unchanged_from_parent=true` for inherited/untouched drafts, `false` for an edited draft and a fork-only draft.
- [x] Backend guard: passing a non-parent workspace id returns rows with `unchanged_from_parent` absent (ignored); omitting the param omits the field entirely.
- [x] Frontend: default view hides the inherited drafts (list + "Deploy N drafts" + tab badge all show 2); toggling off reveals all 4.
- [x] `npm run check` — 0 errors.
- [ ] Reviewer: confirm behavior with "Show all drafts" combined with "Hide unchanged drafts", and on a fork whose only drafts are all inherited-unchanged (empty list + explanatory copy, badge 0).