### PR TITLE
fix: scope AI-session flow/script editors to the session workspace

### DIFF
--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -640,7 +640,9 @@
 		for (const mod of restoredModules) {
 			if (mod) {
 				try {
-					loadFlowModuleState(mod).then((state) => (flowStateStore.val[mod.id] = state))
+					loadFlowModuleState(mod, opWorkspace).then(
+						(state) => (flowStateStore.val[mod.id] = state)
+					)
 				} catch (e) {
 					console.error('Error loading state for restored node', e)
 				}

--- a/frontend/src/lib/components/GitRepoResourcePicker.svelte
+++ b/frontend/src/lib/components/GitRepoResourcePicker.svelte
@@ -13,6 +13,8 @@
 		currentInventories?: string
 		currentPlaybook?: string
 		gitSshIdentity?: string[]
+		/** Acting workspace (fork/session); falls back to the nav workspace. */
+		workspace?: string
 	}
 
 	let {
@@ -21,8 +23,11 @@
 		currentCommit = undefined,
 		currentInventories = undefined,
 		currentPlaybook = undefined,
-		gitSshIdentity = undefined
+		gitSshIdentity = undefined,
+		workspace: workspaceProp = undefined
 	}: Props = $props()
+
+	let ws = $derived(workspaceProp ?? $workspaceStore)
 
 	const dispatch = createEventDispatcher<{
 		selected: {
@@ -44,12 +49,12 @@
 	let loadingInventories = $state(false)
 
 	async function loadGitRepoResources() {
-		if (!$workspaceStore) return
+		if (!ws) return
 
 		loading = true
 		try {
 			const resources = await ResourceService.listResource({
-				workspace: $workspaceStore,
+				workspace: ws,
 				resourceType: 'git_repository'
 			})
 
@@ -66,7 +71,7 @@
 	}
 
 	$effect(() => {
-		if (open && $workspaceStore) {
+		if (open && ws) {
 			loadGitRepoResources()
 			// Set current resource as selected when opening
 			selectedResource = currentResource
@@ -95,12 +100,12 @@
 		inventoriesPath: string,
 		commitHash: string
 	): Promise<string[]> {
-		const rootPath = `gitrepos/${$workspaceStore}/${resourcePath}/${commitHash}/`
+		const rootPath = `gitrepos/${ws}/${resourcePath}/${commitHash}/`
 
 		if (inventoriesPath.startsWith('./')) inventoriesPath = inventoriesPath.slice(2)
 
 		let files = await HelpersService.listGitRepoFiles({
-			workspace: $workspaceStore!,
+			workspace: ws!,
 			maxKeys: 100,
 			marker: undefined,
 			prefix: `${rootPath}/${inventoriesPath}`
@@ -121,7 +126,7 @@
 			if (!commitHash) {
 				try {
 					const result = await ResourceService.getGitCommitHash({
-						workspace: $workspaceStore!,
+						workspace: ws!,
 						path: selectedResource,
 						gitSshIdentity: gitSshIdentity?.join(',')
 					})

--- a/frontend/src/lib/components/GitRepoViewer.svelte
+++ b/frontend/src/lib/components/GitRepoViewer.svelte
@@ -315,6 +315,7 @@
 	{#key `${gitRepoResourcePath}-${commitHash}`}
 		<S3FilePickerInner
 			bind:this={s3FilePicker}
+			workspace={ws}
 			readOnlyMode
 			hideS3SpecificDetails
 			rootPath={`gitrepos/${ws}/${gitRepoResourcePath}/${commitHash}/`}

--- a/frontend/src/lib/components/GitRepoViewer.svelte
+++ b/frontend/src/lib/components/GitRepoViewer.svelte
@@ -31,14 +31,23 @@
 		gitRepoResourcePath: string
 		gitSshIdentity?: string[]
 		commitHashInput?: string
+		/** Acting workspace (fork/session); falls back to the nav workspace. */
+		workspace?: string
 	}
 
-	let { gitRepoResourcePath, gitSshIdentity, commitHashInput = $bindable() }: Props = $props()
+	let {
+		gitRepoResourcePath,
+		gitSshIdentity,
+		commitHashInput = $bindable(),
+		workspace: workspaceProp = undefined
+	}: Props = $props()
+
+	let ws = $derived(workspaceProp ?? $workspaceStore)
 
 	let commitHash = $derived(commitHashInput)
 
 	async function populateS3WithGitRepo() {
-		const workspace = $workspaceStore
+		const workspace = ws
 		if (!workspace) return
 
 		const payload = {
@@ -172,7 +181,7 @@
 			error = null
 			isLoadingCommitHash = true
 			const result = await ResourceService.getGitCommitHash({
-				workspace: $workspaceStore!,
+				workspace: ws!,
 				path: gitRepoResourcePath,
 				gitSshIdentity: gitSshIdentity?.join(',')
 			})
@@ -189,9 +198,9 @@
 		try {
 			error = null
 			isCheckingPathExists = true
-			const s3Path = `gitrepos/${$workspaceStore}/${gitRepoResourcePath}/${commitHash}/`
+			const s3Path = `gitrepos/${ws}/${gitRepoResourcePath}/${commitHash}/`
 			const pathCheck = await HelpersService.checkS3FolderExists({
-				workspace: $workspaceStore!,
+				workspace: ws!,
 				fileKey: s3Path,
 				markerFile: CLONE_MARKER_FILE
 			})
@@ -226,7 +235,7 @@
 			{#if runningJobId}
 				<a
 					class="inline-flex items-center gap-1 mt-2 text-sm underline"
-					href={`${base}/run/${runningJobId}?workspace=${$workspaceStore}`}
+					href={`${base}/run/${runningJobId}?workspace=${ws}`}
 					target="_blank"
 					rel="noreferrer noopener"
 				>
@@ -261,7 +270,7 @@
 				{#if runningJobId}
 					<a
 						class="inline-flex items-center gap-1 text-xs underline text-secondary"
-						href={`${base}/run/${runningJobId}?workspace=${$workspaceStore}`}
+						href={`${base}/run/${runningJobId}?workspace=${ws}`}
 						target="_blank"
 						rel="noreferrer noopener"
 					>
@@ -308,7 +317,7 @@
 			bind:this={s3FilePicker}
 			readOnlyMode
 			hideS3SpecificDetails
-			rootPath={`gitrepos/${$workspaceStore}/${gitRepoResourcePath}/${commitHash}/`}
+			rootPath={`gitrepos/${ws}/${gitRepoResourcePath}/${commitHash}/`}
 			listStoredFilesRequest={HelpersService.listGitRepoFiles}
 			loadFilePreviewRequest={HelpersService.loadGitRepoFilePreview}
 			testConnectionRequest={(async (_d) => {

--- a/frontend/src/lib/components/ModuleTest.svelte
+++ b/frontend/src/lib/components/ModuleTest.svelte
@@ -125,7 +125,7 @@
 		} else if (val.type == 'flow') {
 			await jobLoader?.runFlowByPath(val.path, args, callbacks)
 		} else if (val.type == 'aiagent') {
-			const { schema } = await loadSchemaFromModule(mod)
+			const { schema } = await loadSchemaFromModule(mod, opWs)
 
 			const inputTransforms: { [key: string]: JavascriptTransform } = Object.fromEntries(
 				Object.keys(args).map((key) => [

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -2555,7 +2555,7 @@
 				</Popover>
 			</div>
 		{/if}
-		<div class="relative flex-1 !overflow-visible">
+		<div class="relative flex-1 min-h-0 !overflow-visible">
 			<div class="absolute bg-surface top-2 right-4 z-10 flex flex-row gap-2">
 				{#if assets?.length}
 					<AssetsDropdownButton {assets} />

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -1850,6 +1850,7 @@
 									<h4 class="text-sm font-semibold text-primary">File Browser</h4>
 								</div>
 								<GitRepoViewer
+									workspace={opWs}
 									gitRepoResourcePath={ansibleAlternativeExecutionMode?.resource || ''}
 									gitSshIdentity={ansibleGitSshIdentity}
 									bind:commitHashInput={commitHashForGitRepo}
@@ -2311,6 +2312,7 @@
 {#snippet testLogPanel()}
 	<LogPanel
 		bind:this={logPanel}
+		workspace={opWs}
 		{lang}
 		previewJob={debugMode
 			? ({
@@ -2760,6 +2762,7 @@
 {/snippet}
 
 <GitRepoResourcePicker
+	workspace={opWs}
 	bind:open={gitRepoResourcePickerOpen}
 	currentResource={ansibleAlternativeExecutionMode?.resource}
 	currentCommit={commitHashForGitRepo || ansibleAlternativeExecutionMode?.commit}

--- a/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
+++ b/frontend/src/lib/components/copilot/chat/flow/FlowAIChat.svelte
@@ -23,7 +23,7 @@
 		onTestFlow?: (conversationId?: string) => Promise<string | undefined>
 	} = $props()
 
-	const { flowStore, flowStateStore, selectionManager, currentEditor, previewArgs } =
+	const { flowStore, flowStateStore, selectionManager, currentEditor, previewArgs, opWorkspace } =
 		getContext<FlowEditorContext>('FlowEditorContext')
 	const selectedId = $derived(selectionManager.getSelectedId())
 
@@ -102,7 +102,7 @@
 			}
 
 			inlineScriptSession.set(id, code)
-			const { input_transforms, schema } = await loadSchemaFromModule(module)
+			const { input_transforms, schema } = await loadSchemaFromModule(module, opWorkspace?.())
 			module.value.input_transforms = input_transforms
 			refreshStateStore(flowStore)
 

--- a/frontend/src/lib/components/flows/content/FlowEditorDrawer.svelte
+++ b/frontend/src/lib/components/flows/content/FlowEditorDrawer.svelte
@@ -37,7 +37,7 @@
 
 			flow = backendFlow
 
-			await initFlow(flow, flowStore, flowStateStore)
+			await initFlow(flow, flowStore, flowStateStore, opWs)
 			loading = false
 		} catch (error: any) {
 			console.error('Failed to load flow:', error)

--- a/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleComponent.svelte
@@ -207,7 +207,7 @@
 	async function reload(flowModule: FlowModule) {
 		reloadError = undefined
 		try {
-			const { input_transforms, schema } = await loadSchemaFromModule(flowModule)
+			const { input_transforms, schema } = await loadSchemaFromModule(flowModule, opWs)
 			validCode = true
 
 			if (inputTransformSchemaForm) {

--- a/frontend/src/lib/components/flows/content/FlowModuleHeader.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleHeader.svelte
@@ -28,7 +28,7 @@
 	}
 
 	let { module, tag }: Props = $props()
-	const { scriptEditorDrawer, flowEditorDrawer } =
+	const { scriptEditorDrawer, flowEditorDrawer, opWorkspace } =
 		getContext<FlowEditorContext>('FlowEditorContext')
 
 	const dispatch = createEventDispatcher()
@@ -112,7 +112,9 @@
 				variant="subtle"
 				onClick={async () => {
 					if (module.value.type == 'script') {
-						const hash = module.value.hash ?? (await getLatestHashForScript(module.value.path))
+						const hash =
+							module.value.hash ??
+							(await getLatestHashForScript(module.value.path, opWorkspace?.()))
 						$scriptEditorDrawer?.openDrawer(hash, () => {
 							dispatch('reload')
 							sendUserToast('Script has been updated')

--- a/frontend/src/lib/components/flows/content/FlowModuleWrapper.svelte
+++ b/frontend/src/lib/components/flows/content/FlowModuleWrapper.svelte
@@ -23,7 +23,8 @@
 	import { formatCron } from '$lib/utils'
 	import AgentToolWrapper from './AgentToolWrapper.svelte'
 
-	const { selectionManager, flowStateStore } = getContext<FlowEditorContext>('FlowEditorContext')
+	const { selectionManager, flowStateStore, opWorkspace } =
+		getContext<FlowEditorContext>('FlowEditorContext')
 	const selectedId = $derived(selectionManager.getSelectedId())
 
 	const { triggersState, triggersCount } = getContext<TriggerContext>('TriggerContext')
@@ -99,7 +100,14 @@
 		kind: string,
 		hash: string | undefined
 	) {
-		const [module, state] = await pickScript(path, summary, flowModule.id, hash)
+		const [module, state] = await pickScript(
+			path,
+			summary,
+			flowModule.id,
+			hash,
+			undefined,
+			opWorkspace?.()
+		)
 
 		if (kind == 'approval') {
 			module.suspend = { required_events: 1, timeout: 1800 }
@@ -146,7 +154,7 @@
 			<FlowInputsFlow
 				on:pick={async ({ detail }) => {
 					const { path, summary } = detail
-					const [module, state] = await pickFlow(path, summary, flowModule.id)
+					const [module, state] = await pickFlow(path, summary, flowModule.id, opWorkspace?.())
 
 					flowModule = module
 					flowStateStore.val[module.id] = state

--- a/frontend/src/lib/components/flows/flowInfers.ts
+++ b/frontend/src/lib/components/flows/flowInfers.ts
@@ -220,7 +220,11 @@ function migrateAiAgentInputTransforms(
 	return inputTransforms
 }
 
-export async function loadSchemaFromModule(module: FlowModule): Promise<{
+export async function loadSchemaFromModule(
+	module: FlowModule,
+	// The acting workspace when the flow editor runs in an AI session; else the nav workspace.
+	workspace?: string
+): Promise<{
 	input_transforms: Record<string, InputTransform>
 	schema: Schema
 }> {
@@ -237,9 +241,9 @@ export async function loadSchemaFromModule(module: FlowModule): Promise<{
 				module.id === 'preprocessor' ? 'preprocessor' : undefined
 			)
 		} else if (mod.type == 'script' && mod.path && mod.path != '') {
-			schema = await loadSchemaFromPath(mod.path!, mod.hash)
+			schema = await loadSchemaFromPath(mod.path!, mod.hash, workspace)
 		} else if (mod.type == 'flow' && mod.path && mod.path != '') {
-			schema = await loadSchemaFlow(mod.path!)
+			schema = await loadSchemaFlow(mod.path!, workspace)
 		} else {
 			return {
 				input_transforms: {},

--- a/frontend/src/lib/components/flows/flowState.ts
+++ b/frontend/src/lib/components/flows/flowState.ts
@@ -22,13 +22,18 @@ export type FlowState = Record<string, FlowModuleState>
  * We also hold the data of the results of a test job, ran by the user.
  */
 
-export async function initFlowState(flow: Flow, flowStateStore: StateStore<FlowState>) {
+export async function initFlowState(
+	flow: Flow,
+	flowStateStore: StateStore<FlowState>,
+	// The acting workspace when the flow editor runs in an AI session; else the nav workspace.
+	workspace?: string
+) {
 	const modulesState: FlowState = {}
 
-	await mapFlowModules(flow.value.modules, modulesState)
+	await mapFlowModules(flow.value.modules, modulesState, workspace)
 
 	const failureModule = flow.value.failure_module
-		? await loadFlowModuleState(flow.value.failure_module)
+		? await loadFlowModuleState(flow.value.failure_module, workspace)
 		: emptyFlowModuleState()
 
 	flowStateStore.val = {
@@ -41,21 +46,21 @@ export async function initFlowState(flow: Flow, flowStateStore: StateStore<FlowS
  * mapFlowModule recursively explore the flow, following deeply nested loop and branches modules
  * to build the initial state.
  */
-async function mapFlowModule(flowModule: FlowModule, modulesState: FlowState) {
+async function mapFlowModule(flowModule: FlowModule, modulesState: FlowState, workspace?: string) {
 	const value = flowModule.value
 	if (value.type === 'forloopflow') {
-		await mapFlowModules(value.modules, modulesState)
+		await mapFlowModules(value.modules, modulesState, workspace)
 	}
 
 	if (value.type === 'branchone') {
-		await mapFlowModules(value.default, modulesState)
+		await mapFlowModules(value.default, modulesState, workspace)
 	}
 
 	if (value.type === 'branchone' || value.type === 'branchall') {
 		await Promise.all(
 			value.branches.map(
 				(branchModule: { summary?: string; skip_failure?: boolean; modules: Array<FlowModule> }) =>
-					mapFlowModules(branchModule.modules, modulesState)
+					mapFlowModules(branchModule.modules, modulesState, workspace)
 			)
 		)
 	}
@@ -63,7 +68,7 @@ async function mapFlowModule(flowModule: FlowModule, modulesState: FlowState) {
 	if (value.type === 'aiagent' && value.tools) {
 		await Promise.all(
 			value.tools.filter(isFlowModuleTool).map(async (tool) => {
-				modulesState[tool.id] = await loadFlowModuleState(agentToolToFlowModule(tool))
+				modulesState[tool.id] = await loadFlowModuleState(agentToolToFlowModule(tool), workspace)
 			})
 		)
 	}
@@ -71,13 +76,17 @@ async function mapFlowModule(flowModule: FlowModule, modulesState: FlowState) {
 	if (value.type === 'identity') {
 		modulesState[flowModule.id] = emptyFlowModuleState()
 	} else {
-		const flowModuleState = await loadFlowModuleState(flowModule)
+		const flowModuleState = await loadFlowModuleState(flowModule, workspace)
 		modulesState[flowModule.id] = flowModuleState
 	}
 }
 
-async function mapFlowModules(flowModules: FlowModule[], modulesState: FlowState) {
+async function mapFlowModules(
+	flowModules: FlowModule[],
+	modulesState: FlowState,
+	workspace?: string
+) {
 	await Promise.all(
-		flowModules.map((flowModule: FlowModule) => mapFlowModule(flowModule, modulesState))
+		flowModules.map((flowModule: FlowModule) => mapFlowModule(flowModule, modulesState, workspace))
 	)
 }

--- a/frontend/src/lib/components/flows/flowStateUtils.svelte.ts
+++ b/frontend/src/lib/components/flows/flowStateUtils.svelte.ts
@@ -23,9 +23,13 @@ import type { ExtendedOpenFlow } from './types'
 import { emptySchema, type StateStore } from '$lib/utils'
 import { loadStoredConfig } from '../aiProviderStorage'
 
-export async function loadFlowModuleState(flowModule: FlowModule): Promise<FlowModuleState> {
+export async function loadFlowModuleState(
+	flowModule: FlowModule,
+	// The acting workspace when the flow editor runs in an AI session; else the nav workspace.
+	workspace?: string
+): Promise<FlowModuleState> {
 	try {
-		const { input_transforms, schema } = await loadSchemaFromModule(flowModule)
+		const { input_transforms, schema } = await loadSchemaFromModule(flowModule, workspace)
 
 		if (
 			flowModule.value.type == 'script' ||
@@ -55,7 +59,9 @@ export async function pickScript(
 	summary: string,
 	id: string,
 	hash?: string,
-	kind?: string
+	kind?: string,
+	// The acting workspace when the flow editor runs in an AI session; else the nav workspace.
+	workspace?: string
 ): Promise<[FlowModule & { value: PathScript }, FlowModuleState]> {
 	const flowModule: FlowModule & { value: PathScript } = {
 		id,
@@ -63,13 +69,15 @@ export async function pickScript(
 		summary
 	}
 
-	return [flowModule, await loadFlowModuleState(flowModule)]
+	return [flowModule, await loadFlowModuleState(flowModule, workspace)]
 }
 
 export async function pickFlow(
 	path: string,
 	summary: string,
-	id: string
+	id: string,
+	// The acting workspace when the flow editor runs in an AI session; else the nav workspace.
+	workspace?: string
 ): Promise<[FlowModule & { value: PathFlow }, FlowModuleState]> {
 	const flowModule: FlowModule & { value: PathFlow } = {
 		id,
@@ -77,7 +85,7 @@ export async function pickFlow(
 		summary
 	}
 
-	return [flowModule, await loadFlowModuleState(flowModule)]
+	return [flowModule, await loadFlowModuleState(flowModule, workspace)]
 }
 
 export async function createInlineScriptModule(
@@ -299,7 +307,14 @@ export async function createScriptFromInlineScript(
 		}
 	})
 
-	return pickScript(availablePath, flowModule.summary ?? '', flowModule.id, hash)
+	return pickScript(
+		availablePath,
+		flowModule.summary ?? '',
+		flowModule.id,
+		hash,
+		undefined,
+		workspace
+	)
 }
 
 export function deleteFlowStateById(id: string, flowStateStore: StateStore<FlowState>) {
@@ -341,7 +356,9 @@ export async function insertNewPreprocessorModule(
 	inlineScript?: {
 		language: RawScript['language']
 	},
-	wsScript?: { path: string; summary: string; hash: string | undefined }
+	wsScript?: { path: string; summary: string; hash: string | undefined },
+	// The acting workspace when the flow editor runs in an AI session; else the nav workspace.
+	workspace?: string
 ) {
 	let module: FlowModule = {
 		id: 'preprocessor',
@@ -357,7 +374,14 @@ export async function insertNewPreprocessorModule(
 			'preprocessor'
 		)
 	} else if (wsScript) {
-		;[module, state] = await pickScript(wsScript.path, wsScript.summary, module.id, wsScript.hash)
+		;[module, state] = await pickScript(
+			wsScript.path,
+			wsScript.summary,
+			module.id,
+			wsScript.hash,
+			undefined,
+			workspace
+		)
 	}
 
 	flowStore.val.value.preprocessor_module = module
@@ -373,7 +397,9 @@ export async function insertNewFailureModule(
 		subkind: 'pgsql' | 'flow'
 		instructions?: string
 	},
-	wsScript?: { path: string; summary: string; hash: string | undefined }
+	wsScript?: { path: string; summary: string; hash: string | undefined },
+	// The acting workspace when the flow editor runs in an AI session; else the nav workspace.
+	workspace?: string
 ) {
 	let module: FlowModule = {
 		id: 'failure',
@@ -392,7 +418,14 @@ export async function insertNewFailureModule(
 			'failure'
 		)
 	} else if (wsScript) {
-		;[module, state] = await pickScript(wsScript.path, wsScript.summary, module.id, wsScript.hash)
+		;[module, state] = await pickScript(
+			wsScript.path,
+			wsScript.summary,
+			module.id,
+			wsScript.hash,
+			undefined,
+			workspace
+		)
 	}
 
 	flowStore.val.value.failure_module = module

--- a/frontend/src/lib/components/flows/flowStore.svelte.ts
+++ b/frontend/src/lib/components/flows/flowStore.svelte.ts
@@ -10,9 +10,11 @@ export const importFlowStore = writable<Flow | undefined>(undefined)
 export async function initFlow(
 	flow: Flow,
 	flowStore: StateStore<Flow>,
-	flowStateStore: StateStore<FlowState>
+	flowStateStore: StateStore<FlowState>,
+	// The acting workspace when the flow editor runs in an AI session; else the nav workspace.
+	workspace?: string
 ) {
-	await initFlowState(flow, flowStateStore)
+	await initFlowState(flow, flowStateStore, workspace)
 	flowStore.val = flow
 }
 

--- a/frontend/src/lib/components/flows/map/FlowErrorHandlerItem.svelte
+++ b/frontend/src/lib/components/flows/map/FlowErrorHandlerItem.svelte
@@ -28,7 +28,7 @@
 		generateStep: { moduleId: string; instructions: string; lang: ScriptLang }
 	}>()
 
-	const { selectionManager, flowStateStore, flowStore } =
+	const { selectionManager, flowStateStore, flowStore, opWorkspace } =
 		getContext<FlowEditorContext>('FlowEditorContext')
 
 	const failureModuleId = $derived(flowStore.val?.value?.failure_module?.id)
@@ -47,7 +47,7 @@
 		},
 		wsScript?: { path: string; summary: string; hash: string | undefined }
 	) {
-		await insertNewFailureModule(flowStore, flowStateStore, inlineScript, wsScript)
+		await insertNewFailureModule(flowStore, flowStateStore, inlineScript, wsScript, opWorkspace?.())
 
 		if (inlineScript?.instructions) {
 			dispatch('generateStep', {

--- a/frontend/src/lib/components/flows/map/FlowModuleSchemaMap.svelte
+++ b/frontend/src/lib/components/flows/map/FlowModuleSchemaMap.svelte
@@ -171,14 +171,15 @@
 		let state = emptyFlowModuleState()
 		flowStateStore.val[module.id] = state
 		if (wsFlow) {
-			;[module, state] = await pickFlow(wsFlow.path, wsFlow.summary, module.id)
+			;[module, state] = await pickFlow(wsFlow.path, wsFlow.summary, module.id, opWs)
 		} else if (wsScript) {
 			;[module, state] = await pickScript(
 				wsScript.path,
 				wsScript.summary,
 				module.id,
 				wsScript.hash,
-				kind
+				kind,
+				opWs
 			)
 		} else if (kind == 'forloop') {
 			;[module, state] = await createLoop(module.id, !disableAi && $copilotInfo.enabled)
@@ -244,7 +245,10 @@
 		} else if (toolKind === 'aiAgentTool') {
 			// Create AI Agent tool (nested agent)
 			const aiAgentTool = createAiAgentTool(module.id)
-			flowStateStore.val[module.id] = await loadFlowModuleState(agentToolToFlowModule(aiAgentTool))
+			flowStateStore.val[module.id] = await loadFlowModuleState(
+				agentToolToFlowModule(aiAgentTool),
+				opWs
+			)
 			;(modules as AgentTool[]).splice(index, 0, aiAgentTool)
 			return modules as AgentTool[]
 		} else if (toolKind === 'flowmoduleTool') {
@@ -705,7 +709,8 @@
 						flowStore,
 						flowStateStore,
 						detail.inlineScript,
-						detail.script
+						detail.script,
+						opWs
 					)
 					selectionManager.selectId('preprocessor')
 					if (detail.inlineScript?.instructions) {

--- a/frontend/src/lib/components/sessions/PipelineEditorView.svelte
+++ b/frontend/src/lib/components/sessions/PipelineEditorView.svelte
@@ -392,11 +392,12 @@
 
 <!-- Native trigger editor drawers (schedule/kafka/webhook/…), shared with the
      route page; opened imperatively from the canvas via the handlers above.
-     NOTE: these operate on the global `$workspaceStore`, not the `workspaceId`
-     prop. That's correct only because activating a session syncs the store to
-     the session's workspace (SessionPicker), and triggers are only opened from
-     the visible/active session — so for a forked-workspace session the store is
-     already pointed at the right workspace by the time a drawer opens. -->
+     KNOWN LIMITATION: the whole native-trigger editor subsystem reads the global
+     `$workspaceStore` and exposes no workspace override, so trigger create/edit/
+     delete here targets the nav workspace — NOT this view's `workspaceId`.
+     SessionPicker intentionally does not switch `$workspaceStore` on activation,
+     so for a forked-workspace session these writes go to the wrong workspace.
+     Fixing it means threading a workspace override through the trigger editors. -->
 <PipelineTriggerEditors
 	bind:this={triggerEditors}
 	mountTriggerEditors

--- a/frontend/src/lib/components/sessions/SessionEditorTarget.svelte
+++ b/frontend/src/lib/components/sessions/SessionEditorTarget.svelte
@@ -68,7 +68,11 @@
 
 	function buildCodec(): DraftSyncCodec<any> {
 		if (kind === 'flow')
-			return makeFlowCodec(runtime.flowCell(path).store, runtime.flowCell(path).stateStore)
+			return makeFlowCodec(
+				runtime.flowCell(path).store,
+				runtime.flowCell(path).stateStore,
+				workspaceId
+			)
 		if (kind === 'script') return makeScriptCodec(runtime.scriptCell(path).store, () => path)
 		return makeRawAppCodec(runtime.rawAppCell(path).store)
 	}

--- a/frontend/src/lib/components/sessions/sessionDraftCodecs.ts
+++ b/frontend/src/lib/components/sessions/sessionDraftCodecs.ts
@@ -14,7 +14,10 @@ const DEBOUNCE_MS = 150
 // same kind sync to their own drafts without crossing.
 export function makeFlowCodec(
 	store: StateStore<Flow>,
-	stateStore: { val: Record<string, any> }
+	stateStore: { val: Record<string, any> },
+	// The session's workspace, so schema rebuilds after an AI write resolve
+	// path-referenced scripts/subflows against it rather than the nav workspace.
+	workspace?: string
 ): DraftSyncCodec<Flow> {
 	return {
 		itemKind: 'flow',
@@ -33,7 +36,7 @@ export function makeFlowCodec(
 			// stateStore is keyed by module_id; after an AI write the set of
 			// module ids may differ, so rebuild the UI state. This wipes per-module
 			// test args / preview output — a known v1 trade-off.
-			void initFlowState(store.val, stateStore)
+			void initFlowState(store.val, stateStore, workspace)
 		},
 		storeToDraft() {
 			return store.val

--- a/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
@@ -472,7 +472,7 @@ function createRuntime(session: Session): SessionRuntime {
 					} catch {
 						saved.val = undefined
 					}
-					await initFlow(aiDraft, store, stateStore)
+					await initFlow(aiDraft, store, stateStore, workspace)
 					if (deployedVersionId != null && store.val) store.val.version_id = deployedVersionId
 					slot.loadedPath = path
 					slot.loadedWorkspace = workspace
@@ -494,7 +494,7 @@ function createRuntime(session: Session): SessionRuntime {
 					(result as SavedFlow).draft_saved_at
 				)
 				UserDraft.save('flow', path, flow, { workspace })
-				await initFlow(flow, store, stateStore)
+				await initFlow(flow, store, stateStore, workspace)
 				if (deployedVersionId != null && store.val) store.val.version_id = deployedVersionId
 				slot.loadedPath = path
 				slot.loadedWorkspace = workspace

--- a/frontend/src/lib/infer.ts
+++ b/frontend/src/lib/infer.ts
@@ -579,7 +579,12 @@ export async function inferArgs(
 	}
 }
 
-export async function loadSchemaFromPath(path: string, hash?: string): Promise<Schema> {
+export async function loadSchemaFromPath(
+	path: string,
+	hash?: string,
+	// The acting workspace when the flow editor runs in an AI session; else the nav workspace.
+	workspace?: string
+): Promise<Schema> {
 	if (path.startsWith('hub/')) {
 		const { content, language, schema } = await ScriptService.getHubScriptByPath({ path })
 
@@ -592,14 +597,14 @@ export async function loadSchemaFromPath(path: string, hash?: string): Promise<S
 		}
 	} else if (hash) {
 		const script = await ScriptService.getScriptByHash({
-			workspace: get(workspaceStore)!,
+			workspace: workspace ?? get(workspaceStore)!,
 			hash
 		})
 
 		return inferSchemaIfNecessary(script)
 	} else {
 		const script = await ScriptService.getScriptByPath({
-			workspace: get(workspaceStore)!,
+			workspace: workspace ?? get(workspaceStore)!,
 			path: path ?? ''
 		})
 		return inferSchemaIfNecessary(script)

--- a/frontend/src/lib/scripts.ts
+++ b/frontend/src/lib/scripts.ts
@@ -116,9 +116,13 @@ export async function loadScriptSchedule(
 	}
 }
 
-export async function loadSchemaFlow(path: string): Promise<Schema> {
+export async function loadSchemaFlow(
+	path: string,
+	// The acting workspace when the flow editor runs in an AI session; else the nav workspace.
+	workspace?: string
+): Promise<Schema> {
 	const flow = await FlowService.getFlowByPath({
-		workspace: get(workspaceStore)!,
+		workspace: workspace ?? get(workspaceStore)!,
 		path: path ?? ''
 	})
 	return flow.schema as any


### PR DESCRIPTION
## Summary

In an AI **session** whose fork targets a workspace different from the user's active (navigation) workspace, several flow/script editor surfaces read or write the **nav** workspace (`$workspaceStore`) instead of the **session** workspace. This loads schemas / scripts / results from — and in some cases writes to — the wrong workspace. This PR scopes those surfaces to the session's operating workspace, plus a small scroll fix in the script-edit drawer.

All new parameters/props are **optional and default to `$workspaceStore`**, so behavior outside sessions is unchanged.

## Changes

**Flow script-edit drawer + scroll** (`246807b3d5`)
- `FlowModuleHeader` passes the op workspace to `getLatestHashForScript` (the ✏️ Edit button was resolving the hash from the nav workspace).
- `ScriptEditor`: add `min-h-0` to the flex-1 editor wrapper so the drawer content fits and Monaco scrolls internally instead of overflowing below the viewport (was un-scrollable).

**Flow schema-inference chain** (`f4532c0f62`)
- Thread an optional `workspace?` through `loadSchemaFromPath`, `loadSchemaFlow`, `loadSchemaFromModule`, `loadFlowModuleState`, `initFlowState`/`mapFlowModules`/`mapFlowModule`, `initFlow`, `pickScript`, `pickFlow`, `insertNewPreprocessorModule`, `insertNewFailureModule`, `makeFlowCodec`.
- Pass the op/session workspace at every fork-context call site: `sessionRuntime` (flow load), `SessionEditorTarget`/`sessionDraftCodecs` (AI-write rebuild), `FlowModuleComponent` (reload), `ModuleTest`, `FlowBuilder` (restore), `FlowModuleWrapper`/`FlowModuleSchemaMap` (pick/insert), `FlowErrorHandlerItem`, `FlowAIChat`, `FlowEditorDrawer`.
- `create*`/`fork` unchanged (local inference / already threaded).

**Script editor: LogPanel + git-repo pickers** (`316e7085f5`)
- `ScriptEditor` passes `workspace={opWs}` to `LogPanel` (history-tab result/logs/run link were hitting the nav workspace).
- Add a `workspace?` prop to `GitRepoViewer` and `GitRepoResourcePicker` (Ansible git-repo path) and thread it through Resource/Helpers/Job calls, S3 paths and run links; `ScriptEditor` passes `workspace={opWs}`.

**Docs** (`86c4ce1dfe`)
- Correct the `PipelineEditorView` comment: `SessionPicker` intentionally does **not** switch `$workspaceStore`, so the native-trigger editors (which read the global store, no override seam) write to the nav workspace from a fork session's pipeline canvas. Documented as a known limitation — the full trigger-editor override is deferred to its own PR (recommended approach: a workspace context resolver).

## Screenshots

No meaningful visual change: the workspace-scoping edits are behavioral (which workspace backend calls target). The one visible change is the script-edit drawer scroll fix, verified by DOM measurement — the editor's bottom moved from **900px → 862px** (within the 863px viewport) so content no longer overflows unreachably, and the full-page editor is unchanged (`.overflow-guard` fits at 862px). Playwright screenshots hang on a font fetch on the flow-editor/sessions pages, so verification was done via DOM measurement rather than image capture.

## Test plan

Requires a session whose fork targets a **different** workspace than the nav workspace.
- [ ] In such a session's flow editor, pick an existing workspace **script** and a **subflow** into a step → input schemas load (no 404 / empty schema).
- [ ] Open the ✏️ Edit script drawer from a step header → latest hash resolves and the correct workspace's script loads; content is fully scrollable.
- [ ] Add a failure/error-handler and a preprocessor module referencing a workspace script → schema loads.
- [ ] Run a step, then use the LogPanel history tab (result / logs / open run) → targets the session workspace.
- [ ] Ansible path: open `GitRepoViewer` (file browser) and `GitRepoResourcePicker` → resource list + S3 file listing populate from the session workspace.
- [ ] Regression: full-page (non-session) script editor code pane fills and scrolls internally (no overflow/collapse); non-session trigger creation still targets the nav workspace.