### PR TITLE
fix(backend): propagate script timeout when restarting perpetual scripts (WIN-2149)

### DIFF
--- a/backend/.sqlx/query-1debd472c9ffd2fc78877484f93db51f9aabed54f9894eda8ad610053ad76ce6.json
+++ b/backend/.sqlx/query-1debd472c9ffd2fc78877484f93db51f9aabed54f9894eda8ad610053ad76ce6.json
@@ -1,12 +1,17 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT restart_unless_cancelled FROM script WHERE hash = $1 AND workspace_id = $2",
+  "query": "SELECT restart_unless_cancelled, timeout FROM script WHERE hash = $1 AND workspace_id = $2",
   "describe": {
     "columns": [
       {
         "ordinal": 0,
         "name": "restart_unless_cancelled",
         "type_info": "Bool"
+      },
+      {
+        "ordinal": 1,
+        "name": "timeout",
+        "type_info": "Int4"
       }
     ],
     "parameters": {
@@ -16,8 +21,9 @@
       ]
     },
     "nullable": [
+      true,
       true
     ]
   },
-  "hash": "1d27895aa42ccbb542479b19baefd62790205b529ab0d8af36f18c470e8bb838"
+  "hash": "1debd472c9ffd2fc78877484f93db51f9aabed54f9894eda8ad610053ad76ce6"
 }

--- a/backend/windmill-queue/src/jobs.rs
+++ b/backend/windmill-queue/src/jobs.rs
@@ -921,8 +921,8 @@ lazy_static::lazy_static! {
     pub static ref GLOBAL_ERROR_HANDLER_PATH_IN_ADMINS_WORKSPACE: Option<String> = std::env::var("GLOBAL_ERROR_HANDLER_PATH_IN_ADMINS_WORKSPACE").ok();
     pub static ref MAX_RESULT_SIZE_MB: usize = std::env::var("MAX_RESULT_SIZE_MB").unwrap_or("500".to_string()).parse().unwrap_or(500);
 
-    // Cache for restart_unless_cancelled flag - keyed by (hash, workspace_id)
-    static ref RESTART_UNLESS_CANCELLED_CACHE: Cache<(i64, String), bool> = Cache::new(10000);
+    // Cache for perpetual-restart settings (restart_unless_cancelled, timeout) - keyed by (hash, workspace_id)
+    static ref RESTART_UNLESS_CANCELLED_CACHE: Cache<(i64, String), (bool, Option<i32>)> = Cache::new(10000);
 
     // Cache for workspace error handler settings with 60s TTL
     // Key: workspace_id, Value: (error_handler, error_handler_extra_args, error_handler_muted_on_cancel, error_handler_muted_on_user_path, expiry_timestamp)
@@ -1538,21 +1538,27 @@ async fn restart_job_if_perpetual_inner(
 ) -> Result<(), Error> {
     let cache_key = (hash.0, queued_job.workspace_id.clone());
 
-    let restart = if let Some(cached) = RESTART_UNLESS_CANCELLED_CACHE.get(&cache_key) {
+    let (restart, script_timeout) = if let Some(cached) =
+        RESTART_UNLESS_CANCELLED_CACHE.get(&cache_key)
+    {
         cached
     } else {
-        let restart = sqlx::query_scalar!(
-            "SELECT restart_unless_cancelled FROM script WHERE hash = $1 AND workspace_id = $2",
+        let row = sqlx::query!(
+            "SELECT restart_unless_cancelled, timeout FROM script WHERE hash = $1 AND workspace_id = $2",
             hash.0,
             &queued_job.workspace_id
         )
         .fetch_optional(db)
-        .await?
-        .flatten()
-        .unwrap_or(false);
+        .await?;
 
-        RESTART_UNLESS_CANCELLED_CACHE.insert(cache_key, restart);
-        restart
+        let restart = row
+            .as_ref()
+            .and_then(|r| r.restart_unless_cancelled)
+            .unwrap_or(false);
+        let script_timeout = row.and_then(|r| r.timeout);
+
+        RESTART_UNLESS_CANCELLED_CACHE.insert(cache_key, (restart, script_timeout));
+        (restart, script_timeout)
     };
 
     if restart {
@@ -1623,7 +1629,7 @@ async fn restart_job_if_perpetual_inner(
             None,
             true,
             Some(queued_job.tag.clone()),
-            None,
+            script_timeout,
             None,
             queued_job.priority,
             None,


### PR DESCRIPTION
## Problem

When a perpetual script (`restart_unless_cancelled`) exits and restarts, `restart_job_if_perpetual_inner` in `backend/windmill-queue/src/jobs.rs` re-pushed the next job with `custom_timeout = None`. `custom_timeout` is written straight into `v2_job.timeout`, and a `NULL` timeout makes the worker fall back to the instance-level `job_default_timeout`.

The result: the **first** run honored the script's configured timeout (fetched via `script_path_to_payload`), but **every perpetual restart** silently ignored it and used the instance default instead.

## Fix

`restart_job_if_perpetual_inner` already queries the `script` table for `restart_unless_cancelled` (cached by the immutable `(hash, workspace_id)` key). This PR fetches `timeout` in that same query, caches it alongside the flag, and passes it as `custom_timeout` when re-pushing the perpetual job.

Because the cache key includes the immutable script `hash`, caching the timeout is safe — a new deploy produces a new hash and therefore a new cache entry, so there is no staleness. This also avoids adding a second round-trip to the `script` table on the hot restart path.

## Scope

- `backend/windmill-queue/src/jobs.rs` — extend the cached query + pass `script_timeout` as `custom_timeout`
- `backend/.sqlx/` — regenerated offline query cache for the modified query

## Validation

- `cargo check -p windmill-queue` (offline sqlx) — compiles clean.
- **End-to-end against the running dev backend:** created a perpetual bash script (`restart_unless_cancelled: true`, `timeout: 42`), triggered it, and let it restart several times. Every job — including restarts pushed 10s apart — carried `timeout = 42` instead of `NULL`:

  | created_at (UTC) | v2_job.timeout |
  |---|---|
  | 17:15:13 (first run) | 42 |
  | 17:15:13 (restart) | 42 |
  | 17:15:23 (restart) | 42 |
  | 17:15:33 (restart) | 42 |

  Before the fix, the restart rows would be `NULL` (→ instance `job_default_timeout`). Test workspace was cleaned up afterward.

Fixes WIN-2149

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Perpetual script restarts now honor the script’s configured timeout by passing it through as `custom_timeout` when re-queuing. This prevents restarts from falling back to the instance `job_default_timeout`. Fixes WIN-2149.

- **Bug Fixes**
  - Fetch `timeout` alongside `restart_unless_cancelled`, cache by `(hash, workspace_id)`.
  - Use the cached `timeout` as `custom_timeout` when re-pushing the restart job.

<sup>Written for commit 2d9d8ece0fb060c0b00a1e9f884276ff427c5616. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

