### PR TITLE
fix(frontend): persist per-session preview panel resize width

### DIFF
--- a/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionPreviewTabs.svelte.ts
@@ -23,6 +23,7 @@ export type PreviewTabsSnapshot = {
 	tabs: SessionPreviewTab[]
 	activeId: string
 	collapsed: boolean
+	previewSize?: number
 }
 
 export type PreviewTabsAdapter = {
@@ -99,6 +100,7 @@ export function hydratePreviewTabs(session: {
 	previewTabs?: SessionPreviewTab[]
 	activePreviewTabId?: string
 	previewCollapsed?: boolean
+	previewSize?: number
 }): PreviewTabsSnapshot {
 	// Saved tabs come straight from IndexedDB — drop malformed records (missing
 	// id/url) and duplicate ids, which would break the page's keyed {#each}.
@@ -114,9 +116,19 @@ export function hydratePreviewTabs(session: {
 	if (tabs.length > 0) {
 		const wantActive = session.activePreviewTabId
 		const activeId = wantActive && tabs.some((t) => t.id === wantActive) ? wantActive : tabs[0].id
-		return { tabs, activeId, collapsed: session.previewCollapsed ?? false }
+		return {
+			tabs,
+			activeId,
+			collapsed: session.previewCollapsed ?? false,
+			previewSize: session.previewSize
+		}
 	}
-	return { tabs: [], activeId: '', collapsed: session.previewCollapsed ?? true }
+	return {
+		tabs: [],
+		activeId: '',
+		collapsed: session.previewCollapsed ?? true,
+		previewSize: session.previewSize
+	}
 }
 
 const FLUSH_DELAY_MS = 400
@@ -129,6 +141,7 @@ export class SessionPreviewTabs {
 	#tabs = $state<SessionPreviewTab[]>([])
 	#activeId = $state('')
 	#collapsed = $state(false)
+	#previewSize = $state<number | undefined>(undefined)
 	readonly #adapter: PreviewTabsAdapter
 	readonly #flushDelay: number
 	#flushHandle: ReturnType<typeof setTimeout> | undefined
@@ -141,6 +154,7 @@ export class SessionPreviewTabs {
 		this.#tabs = initial.tabs.map((t) => ({ ...t }))
 		this.#activeId = initial.activeId
 		this.#collapsed = initial.collapsed
+		this.#previewSize = initial.previewSize
 		this.#adapter = adapter
 		this.#flushDelay = flushDelay
 	}
@@ -156,6 +170,17 @@ export class SessionPreviewTabs {
 	}
 	get collapsed(): boolean {
 		return this.#collapsed
+	}
+	get previewSize(): number | undefined {
+		return this.#previewSize
+	}
+
+	setPreviewSize(size: number): void {
+		if (this.#previewSize === size) return
+		this.#previewSize = size
+		// A size change never touches the tab set, so skip the editor-cell prune
+		// (onTabsChanged) and only schedule the debounced persist.
+		this.#schedulePersist()
 	}
 
 	// Open — or focus, if already shown — a tab for a destination, and reveal the
@@ -324,6 +349,10 @@ export class SessionPreviewTabs {
 		// Prune cells promptly (cheap, synchronous) even though the durable persist
 		// stays debounced — a closed tab's editor cell should be reclaimable now.
 		this.#adapter.onTabsChanged?.()
+		this.#schedulePersist()
+	}
+
+	#schedulePersist(): void {
 		clearTimeout(this.#flushHandle)
 		this.#flushHandle = setTimeout(() => {
 			this.#flushHandle = undefined
@@ -335,7 +364,8 @@ export class SessionPreviewTabs {
 		this.#adapter.persist({
 			tabs: this.#tabs.map((t) => ({ ...t })),
 			activeId: this.#activeId,
-			collapsed: this.#collapsed
+			collapsed: this.#collapsed,
+			previewSize: this.#previewSize
 		})
 	}
 }

--- a/frontend/src/lib/components/sessions/sessionPreviewTabs.test.ts
+++ b/frontend/src/lib/components/sessions/sessionPreviewTabs.test.ts
@@ -93,6 +93,16 @@ describe('hydratePreviewTabs', () => {
 		expect(hydratePreviewTabs({ previewCollapsed: false }).collapsed).toBe(false)
 	})
 
+	it('restores the saved previewSize (with tabs and empty)', () => {
+		const withTabs = hydratePreviewTabs({
+			previewTabs: [{ id: 'a', url: '/x', loc: '/x' }],
+			previewSize: 70
+		})
+		expect(withTabs.previewSize).toBe(70)
+		expect(hydratePreviewTabs({ previewSize: 40 }).previewSize).toBe(40)
+		expect(hydratePreviewTabs({}).previewSize).toBeUndefined()
+	})
+
 	it('drops malformed saved tabs, duplicate ids and stray fields, defaulting loc to url', () => {
 		const snap = hydratePreviewTabs({
 			previewTabs: [
@@ -324,6 +334,39 @@ describe('SessionPreviewTabs.select / close / setCollapsed', () => {
 		const o = owner({ collapsed: false })
 		o.setCollapsed(true)
 		expect(o.collapsed).toBe(true)
+	})
+
+	it('sets previewSize and flushes it into the snapshot', () => {
+		const { adapter, persisted } = makeAdapter()
+		const o = owner({ previewSize: 50 }, adapter)
+		o.setPreviewSize(70)
+		expect(o.previewSize).toBe(70)
+		vi.runAllTimers()
+		expect(persisted.at(-1)?.previewSize).toBe(70)
+	})
+
+	it('setPreviewSize dedupes an unchanged value (no persist)', () => {
+		const { adapter, persisted } = makeAdapter()
+		const o = owner({ previewSize: 70 }, adapter)
+		o.setPreviewSize(70)
+		vi.runAllTimers()
+		expect(persisted).toHaveLength(0)
+	})
+
+	it('a never-resized owner persists previewSize as undefined, never a default', () => {
+		const { adapter, persisted } = makeAdapter()
+		const o = owner({}, adapter) // no previewSize
+		o.open(scriptTarget) // any tab mutation triggers a flush
+		vi.runAllTimers()
+		expect(persisted.at(-1)?.previewSize).toBeUndefined()
+	})
+
+	it('setPreviewSize skips the tab-cell prune (onTabsChanged)', () => {
+		const onTabsChanged = vi.fn()
+		const o = owner({ previewSize: 50 }, { persist: () => {}, onTabsChanged })
+		o.setPreviewSize(70)
+		vi.runAllTimers()
+		expect(onTabsChanged).not.toHaveBeenCalled()
 	})
 
 	it('reset replaces the whole model and reveals the panel', () => {

--- a/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
@@ -38,6 +38,7 @@ import {
 	setGeneratedSessionSummary,
 	setSessionChatId,
 	setSessionPreviewCollapsed,
+	setSessionPreviewSize,
 	setSessionTabs,
 	type Session
 } from './sessionState.svelte'
@@ -404,6 +405,8 @@ function createRuntime(session: Session): SessionRuntime {
 		persist: (snap) => {
 			setSessionTabs(session.id, snap.tabs, snap.activeId)
 			setSessionPreviewCollapsed(session.id, snap.collapsed)
+			// Only persist a real width; undefined means "never resized" (defaults to 50).
+			if (snap.previewSize != null) setSessionPreviewSize(session.id, snap.previewSize)
 		},
 		onTabsChanged: pruneEditorCells
 	})

--- a/frontend/src/lib/components/sessions/sessionState.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionState.svelte.ts
@@ -117,6 +117,9 @@ export type Session = {
 	// Whether the user collapsed the preview panel for this session (to give the
 	// chat full width). Per-session so each session restores its own layout.
 	previewCollapsed?: boolean
+	// Preview split size (preview pane %, 0-100) the user dragged for this session.
+	// Per-session so each session restores its own layout.
+	previewSize?: number
 }
 
 // One preview tab: `url` is the URL we command the iframe to load, `loc` the
@@ -810,6 +813,15 @@ export function setSessionPreviewCollapsed(id: string, collapsed: boolean): void
 	const s = sessionState.sessions.find((x) => x.id === id)
 	if (!s || !!s.previewCollapsed === collapsed) return
 	s.previewCollapsed = collapsed
+	void putSession(s)
+}
+
+// Persist the preview split size the user dragged for this session. Fire-and-forget
+// write-behind (transient sessions land in the localStorage draft slot).
+export function setSessionPreviewSize(id: string, size: number): void {
+	const s = sessionState.sessions.find((x) => x.id === id)
+	if (!s || s.previewSize === size) return
+	s.previewSize = size
 	void putSession(s)
 }
 

--- a/frontend/src/lib/components/sessions/sessionStateIndexedDb.test.ts
+++ b/frontend/src/lib/components/sessions/sessionStateIndexedDb.test.ts
@@ -42,6 +42,7 @@ import {
 	queueTransientDraftPrompt,
 	reconcileSessionsLifecycle,
 	setSessionArchived,
+	setSessionPreviewSize,
 	type Session
 } from './sessionState.svelte'
 
@@ -125,7 +126,8 @@ describe('sessionState IndexedDB persistence', () => {
 				transient: true,
 				previewTabs: [{ id: 'session', url: '/x', loc: '/x' }],
 				activePreviewTabId: 'session',
-				previewCollapsed: false
+				previewCollapsed: false,
+				previewSize: 70
 			})
 		)
 		await rehydrate(user)
@@ -134,6 +136,24 @@ describe('sessionState IndexedDB persistence', () => {
 		expect(restored?.previewTabs).toEqual([{ id: 'session', url: '/x', loc: '/x' }])
 		expect(restored?.activePreviewTabId).toBe('session')
 		expect(restored?.previewCollapsed).toBe(false)
+		expect(restored?.previewSize).toBe(70)
+	})
+
+	it('setSessionPreviewSize persists a dragged width and round-trips it', async () => {
+		const user = freshUser()
+		userStore.set(user)
+		await flush()
+
+		const s = session({ id: 'ps1', createdAt: 1 })
+		sessionState.sessions = [s]
+		await putSession(s)
+
+		setSessionPreviewSize('ps1', 42)
+		await flush()
+
+		await rehydrate(user)
+		await flush()
+		expect(sessionState.sessions.find((x) => x.id === 'ps1')?.previewSize).toBe(42)
 	})
 
 	it('materializeTransient promotes the draft to IndexedDB and clears the slot', async () => {

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -267,19 +267,43 @@
 	// null = let Splitpanes auto-distribute (initial even split).
 	let previewPaneSize = $state<number | null>(null)
 	let chatPaneSize = $state<number | null>(null)
-	let lastExpandedPreviewSize = 50
+	// Even split for a session with no saved width. Effect A's seed and effect B's
+	// write-back-skip guard must share this exact value, or B persists the default
+	// and breaks the never-resized (undefined) invariant.
+	const DEFAULT_SPLIT = 50
+	let lastExpandedPreviewSize = DEFAULT_SPLIT
+	// Which owner previewPaneSize is currently seeded for. The Pane is shared across
+	// warm sessions, so we reseed the expanded width when the active session changes.
+	let seededOwner: SessionPreviewTabs | undefined = undefined
+
+	// Effect A — layout: reseed on session switch, then apply collapse/fullscreen.
 	$effect(() => {
+		const o = owner
 		const collapsed = previewCollapsed
 		const full = fullscreen
 		untrack(() => {
+			const switched = o !== seededOwner
+			if (switched) {
+				seededOwner = o
+				// Read the saved size UNTRACKED: this must not re-run when effect B
+				// writes it back, or the two effects loop.
+				lastExpandedPreviewSize = o?.previewSize ?? DEFAULT_SPLIT
+				// Seed the pane for the incoming session on the switch frame. The
+				// collapsed case seeds 0, so the capture below never captures the
+				// outgoing session's leftover width as this session's.
+				previewPaneSize = collapsed ? 0 : lastExpandedPreviewSize
+			}
+			// effect A doesn't track previewPaneSize, so a drag never re-runs it: this is
+			// the only place the live width is saved before a sentinel (collapse→0 /
+			// fullscreen→100) overwrites it. The switch-frame value is the seed, not a drag.
+			if (!switched && previewPaneSize && previewPaneSize > 0 && previewPaneSize < 100) {
+				lastExpandedPreviewSize = previewPaneSize
+			}
 			if (full) {
 				// Chat pane is unmounted: the preview is the only pane and must own
 				// the full width, not its remembered split share.
 				previewPaneSize = 100
 			} else if (collapsed) {
-				if (previewPaneSize && previewPaneSize > 0 && previewPaneSize < 100) {
-					lastExpandedPreviewSize = previewPaneSize
-				}
 				previewPaneSize = 0
 				chatPaneSize = 100
 			} else {
@@ -287,6 +311,27 @@
 					previewPaneSize = lastExpandedPreviewSize
 				}
 				chatPaneSize = 100 - previewPaneSize
+			}
+		})
+	})
+
+	// Effect B — write-back: persist a genuine user-dragged width to the model.
+	$effect(() => {
+		const size = previewPaneSize
+		untrack(() => {
+			// Skip when size still matches the model's saved width, or the 50 default
+			// for a never-resized session (owner.previewSize === undefined): effect A's
+			// reseed sets previewPaneSize to exactly that, and persisting it would
+			// materialize the default and lose the "never resized" (undefined) state.
+			if (
+				!previewCollapsed &&
+				!fullscreen &&
+				size != null &&
+				size > 0 &&
+				size < 100 &&
+				size !== (owner?.previewSize ?? DEFAULT_SPLIT)
+			) {
+				owner?.setPreviewSize(size)
 			}
 		})
 	})


### PR DESCRIPTION
## Summary

On the sessions page, dragging the splitter to resize the right-hand preview panel worked while the page was open, but the width was never remembered — on refresh (or when switching sessions) the panel snapped back to the default 50/50 split. This is a behavioral fix: the dragged split width is now persisted **per session**, mirroring the existing `previewCollapsed` machinery, so each session restores its own layout across reloads and switches.

The split size round-trips through the same chain the collapsed flag already uses: preview-tab model → runtime persist adapter → session record → IndexedDB.

## Changes

- **`sessionState.svelte.ts`** — new `previewSize?: number` field on the session record and a `setSessionPreviewSize` write-behind setter (dedupes on equality), modelled on `setSessionPreviewCollapsed`.
- **`sessionPreviewTabs.svelte.ts`** — carry `previewSize` through the snapshot type, `#previewSize` state + getter + `setPreviewSize`, constructor init, hydration (both branches), and `#persistNow`. Split a persist-only `#schedulePersist()` out of `#flush()` so a size change (fired per frame during a drag) does not trigger the editor-cell prune.
- **`sessionRuntime.svelte.ts`** — persist adapter forwards the size, guarding `if (snap.previewSize != null)` so a never-resized session never materializes the default in IndexedDB.
- **`+page.svelte`** — two effects over the shared `<Pane>`: Effect A reseeds `previewPaneSize` from the incoming session's saved width on a switch (reads `owner.previewSize` **untracked** so the write-back can't form a loop) and recaptures the live dragged width before a collapse (→0) / fullscreen (→100) sentinel overwrites it; Effect B persists a genuine dragged width, skipping sentinels and the seeded default. A shared `DEFAULT_SPLIT = 50` backs the seed and the write-back-skip guard so they can't drift.
- **Tests** — `sessionPreviewTabs.test.ts` (hydration incl. absent→undefined, flush, dedupe, never-resized-stays-undefined, prune-skip) and `sessionStateIndexedDb.test.ts` (`setSessionPreviewSize` round-trip). 65 tests pass.

## Notable design points

- **Never-resized stays `undefined`.** A session the user never dragged keeps `previewSize` absent in IndexedDB (guarded on both write paths), so the default is never stored.
- **Sentinels never persist.** Collapse (0) and fullscreen (100) are excluded from the write-back — only a genuine `(0, 100)` width is saved.
- **Fullscreen recapture.** The dragged width is captured before *both* the collapse and fullscreen sentinels, so a drag → fullscreen → exit round-trip restores the dragged width rather than resetting (and persisting) the default.

## Known limitation (pre-existing, out of scope)

Dragging, then switching sessions **and** reloading all within the 400 ms debounce window can drop the last drag — the same write-behind window that already exists for `previewCollapsed` and tab writes. Fixing it would require a broader flush-on-switch change and is intentionally left consistent with the sibling machinery.

## Test plan

- [ ] Drag the preview panel wider → refresh → width is restored (the original bug).
- [ ] Session A wide, session B narrow → switch A→B→A → each shows its own width.
- [ ] Collapse a session → refresh → still collapsed; expanding restores the pre-collapse width.
- [ ] Switch from a wide session into a *collapsed* session with a different saved width → expand it → it shows **its own** saved width, and the first session's width is unchanged.
- [ ] Drag a session, then toggle fullscreen on/off (no session switch) → width returns to the dragged value; confirm no `100` (or default) is persisted.
- [ ] Confirm a never-dragged session never writes a `previewSize` to IndexedDB.

## Screenshots

No static visual change — the preview panel and its resizable splitter already existed; this PR only makes the dragged width **persist** across reload / session-switch, which a single screenshot can't convey. Verified end-to-end in a real browser (drag → fullscreen round-trip → reload all confirmed, including the fullscreen-recapture edge and the never-resized-stays-undefined invariant).