### PR TITLE
fix(frontend): scope session pipeline trigger editors to the session workspace

### DIFF
--- a/frontend/src/lib/components/ChannelSelector.svelte
+++ b/frontend/src/lib/components/ChannelSelector.svelte
@@ -21,6 +21,9 @@
 		showRefreshButton?: boolean
 		onError?: (error: Error) => void
 		onSelectedChannelChange?: (channel: ChannelItem | undefined) => void
+		/** Workspace to list Teams channels from; defaults to the nav
+		 * `$workspaceStore`. A forked session passes its acting workspace. */
+		workspace?: string
 	}
 
 	let {
@@ -33,8 +36,11 @@
 		teamId,
 		showRefreshButton = true,
 		onError,
-		onSelectedChannelChange
+		onSelectedChannelChange,
+		workspace = undefined
 	}: Props = $props()
+
+	let effectiveWorkspace = $derived(workspace ?? $workspaceStore)
 
 	let isFetching = $state(false)
 	let loadedChannels = $state<ChannelItem[]>([])
@@ -88,7 +94,7 @@
 		isFetching = true
 		try {
 			const response = await WorkspaceService.listAvailableTeamsChannels({
-				workspace: $workspaceStore!,
+				workspace: effectiveWorkspace!,
 				teamId: teamId
 			})
 
@@ -130,10 +136,7 @@
 						clearable
 						disabled={disabled || !teamId}
 						loading={isFetching}
-						bind:value={
-							() => selectedChannel?.channel_id,
-							(newId) => setSelectedChannelById(newId)
-						}
+						bind:value={() => selectedChannel?.channel_id, (newId) => setSelectedChannelById(newId)}
 					/>
 				{:else}
 					<Select
@@ -147,10 +150,7 @@
 						{placeholder}
 						clearable
 						disabled={disabled || displayChannels.length === 0}
-						bind:value={
-							() => selectedChannel?.channel_id,
-							(newId) => setSelectedChannelById(newId)
-						}
+						bind:value={() => selectedChannel?.channel_id, (newId) => setSelectedChannelById(newId)}
 					/>
 				{/if}
 			</div>

--- a/frontend/src/lib/components/ErrorOrRecoveryHandler.svelte
+++ b/frontend/src/lib/components/ErrorOrRecoveryHandler.svelte
@@ -81,6 +81,10 @@
 		customHandlerKind?: 'flow' | 'script'
 		customTabTooltip?: import('svelte').Snippet
 		noMargin?: boolean
+		/** Workspace for handler lookup / settings / test jobs. Defaults to the
+		 * nav `$workspaceStore`; a trigger editor in a forked session passes its
+		 * acting workspace so the handler is resolved and saved there. */
+		workspace?: string
 	}
 
 	let {
@@ -94,8 +98,11 @@
 		customScriptTemplate,
 		customHandlerKind = $bindable('script'),
 		customTabTooltip,
-		noMargin = false
+		noMargin = false,
+		workspace = undefined
 	}: Props = $props()
+
+	let effectiveWorkspace = $derived(workspace ?? $workspaceStore)
 
 	let customHandlerSchema: Schema | undefined = $state()
 	let slackHandlerSchema: Schema | undefined = $state()
@@ -113,7 +120,7 @@
 	const CHANNEL_KEY = 'channel'
 
 	async function loadSlackResources() {
-		const settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
+		const settings = await WorkspaceService.getPublicSettings({ workspace: effectiveWorkspace! })
 		if (!emptyString(settings.slack_name) && !emptyString(settings.slack_team_id)) {
 			workspaceConnectedToSlack = true
 			slack_team_name = settings.slack_name
@@ -124,7 +131,7 @@
 	}
 
 	async function loadTeamsResources() {
-		const settings = await WorkspaceService.getPublicSettings({ workspace: $workspaceStore! })
+		const settings = await WorkspaceService.getPublicSettings({ workspace: effectiveWorkspace! })
 		if (!emptyString(settings.teams_team_name) && !emptyString(settings.teams_team_id)) {
 			workspaceConnectedToTeams = true
 		} else {
@@ -155,11 +162,11 @@
 				: WorkspaceService.runTeamsMessageTestJob
 
 		let submitted_job = await testJobFunction({
-			workspace: $workspaceStore!,
+			workspace: effectiveWorkspace!,
 			requestBody: {
 				hub_script_path: handlerPath,
 				channel: channel,
-				test_msg: `This is a notification to test the connection between ${platform} and Windmill workspace '${$workspaceStore!}'`
+				test_msg: `This is a notification to test the connection between ${platform} and Windmill workspace '${effectiveWorkspace!}'`
 			}
 		})
 
@@ -171,7 +178,7 @@
 		tryEvery({
 			tryCode: async () => {
 				const testResult = await JobService.getCompletedJob({
-					workspace: $workspaceStore!,
+					workspace: effectiveWorkspace!,
 					id: connectionTestJob!.uuid
 				})
 				connectionTestJob!.in_progress = false
@@ -180,7 +187,7 @@
 			timeoutCode: async () => {
 				try {
 					await JobService.cancelQueuedJob({
-						workspace: $workspaceStore!,
+						workspace: effectiveWorkspace!,
 						id: connectionTestJob!.uuid,
 						requestBody: {
 							reason: 'Slack message not sent after 10s'
@@ -219,8 +226,8 @@
 			} else {
 				let scriptOrFlow: Script | Flow =
 					customHandlerKind === 'script'
-						? await ScriptService.getScriptByPath({ workspace: $workspaceStore!, path: p })
-						: await FlowService.getFlowByPath({ workspace: $workspaceStore!, path: p })
+						? await ScriptService.getScriptByPath({ workspace: effectiveWorkspace!, path: p })
+						: await FlowService.getFlowByPath({ workspace: effectiveWorkspace!, path: p })
 				schema = scriptOrFlow.schema as Schema
 			}
 			if (schema && schema.properties) {
@@ -278,7 +285,7 @@
 	}
 
 	$effect(() => {
-		if ($workspaceStore) {
+		if (effectiveWorkspace) {
 			loadSlackResources()
 			loadTeamsResources()
 		}
@@ -493,7 +500,7 @@
 
 									<a
 										target="_blank"
-										href={`${base}/run/${connectionTestJob.uuid}?workspace=${$workspaceStore}`}
+										href={`${base}/run/${connectionTestJob.uuid}?workspace=${effectiveWorkspace}`}
 										class="inline-flex items-center gap-1"
 									>
 										{connectionTestJob.uuid}
@@ -585,7 +592,7 @@
 								Message sent via Windmill job
 								<a
 									target="_blank"
-									href={`${base}/run/${connectionTestJob.uuid}?workspace=${$workspaceStore}`}
+									href={`${base}/run/${connectionTestJob.uuid}?workspace=${effectiveWorkspace}`}
 								>
 									{connectionTestJob.uuid}
 								</a>

--- a/frontend/src/lib/components/ErrorOrRecoveryHandler.svelte
+++ b/frontend/src/lib/components/ErrorOrRecoveryHandler.svelte
@@ -103,6 +103,14 @@
 	}: Props = $props()
 
 	let effectiveWorkspace = $derived(workspace ?? $workspaceStore)
+	// Carry the acting workspace onto the "create from template" route when an
+	// explicit override is set, so a forked session creates the handler script
+	// there. `customScriptTemplate` already has a query string (`?hub=…`).
+	let templateHref = $derived(
+		workspace
+			? `${customScriptTemplate}&workspace=${encodeURIComponent(workspace)}`
+			: customScriptTemplate
+	)
 
 	let customHandlerSchema: Schema | undefined = $state()
 	let slackHandlerSchema: Schema | undefined = $state()
@@ -384,6 +392,7 @@
 						bind:scriptPath={handlerPath}
 						bind:itemKind={customHandlerKind}
 						allowRefresh={isEditable}
+						workspace={effectiveWorkspace}
 						clearable
 					/>
 
@@ -392,7 +401,7 @@
 							btnClasses="ml-4 whitespace-nowrap"
 							variant="default"
 							size="xs"
-							href={customScriptTemplate}
+							href={templateHref}
 							disabled={!isEditable}
 							target="_blank"
 						>
@@ -557,6 +566,7 @@
 								containerClass="flex-grow"
 								minWidth="200px"
 								placeholder="Search Teams channels"
+								workspace={effectiveWorkspace}
 								teamId={teams_team_guid}
 								selectedChannel={handlerExtraArgs['channel']
 									? {

--- a/frontend/src/lib/components/ScriptPicker.svelte
+++ b/frontend/src/lib/components/ScriptPicker.svelte
@@ -30,6 +30,10 @@
 		allowEdit?: boolean
 		allowView?: boolean
 		clearable?: boolean
+		/** Workspace to list runnables from. Defaults to the navigation
+		 * `$workspaceStore`; pass the session's acting workspace so a forked
+		 * session lists its own scripts/flows/apps rather than the parent's. */
+		workspace?: string
 	}
 
 	let {
@@ -42,8 +46,11 @@
 		allowRefresh = false,
 		allowEdit = true,
 		allowView = true,
-		clearable = false
+		clearable = false,
+		workspace = undefined
 	}: Props = $props()
+
+	let effectiveWorkspace = $derived(workspace ?? $workspaceStore)
 
 	let items: { value: string; label: string }[] = $state([])
 	let drawerViewer: Drawer | undefined = $state()
@@ -58,7 +65,7 @@
 	async function loadItems(): Promise<void> {
 		if (itemKind == 'flow') {
 			items = (
-				await FlowService.listFlows({ workspace: $workspaceStore!, withoutDescription: true })
+				await FlowService.listFlows({ workspace: effectiveWorkspace!, withoutDescription: true })
 			).map((flow) => ({
 				value: flow.path,
 				label: `${flow.path}${flow.summary ? ` | ${truncate(flow.summary, 20)}` : ''}`,
@@ -67,7 +74,7 @@
 		} else if (itemKind == 'script') {
 			items = (
 				await ScriptService.listScripts({
-					workspace: $workspaceStore!,
+					workspace: effectiveWorkspace!,
 					kinds: kinds.join(','),
 					withoutDescription: true
 				})
@@ -76,7 +83,7 @@
 				label: `${script.path}${script.summary ? ` | ${truncate(script.summary, 20)}` : ''}`
 			}))
 		} else if (itemKind == 'app') {
-			items = (await AppService.listApps({ workspace: $workspaceStore! })).map((app) => ({
+			items = (await AppService.listApps({ workspace: effectiveWorkspace! })).map((app) => ({
 				value: app.path,
 				label: `${app.path}${app.summary ? ` | ${truncate(app.summary, 20)}` : ''}`
 			}))
@@ -84,7 +91,7 @@
 	}
 
 	$effect(() => {
-		itemKind && $workspaceStore && untrack(() => loadItems())
+		itemKind && effectiveWorkspace && untrack(() => loadItems())
 	})
 	let darkMode: boolean = $state(false)
 </script>

--- a/frontend/src/lib/components/ScriptPicker.svelte
+++ b/frontend/src/lib/components/ScriptPicker.svelte
@@ -51,6 +51,9 @@
 	}: Props = $props()
 
 	let effectiveWorkspace = $derived(workspace ?? $workspaceStore)
+	// Only carry the workspace onto Edit/View routes when an explicit override
+	// was passed, so existing callers' links are unchanged.
+	let wsParam = $derived(workspace ? `?workspace=${encodeURIComponent(workspace)}` : '')
 
 	let items: { value: string; label: string }[] = $state([])
 	let drawerViewer: Drawer | undefined = $state()
@@ -106,7 +109,7 @@
 
 <Drawer bind:this={drawerFlowViewer} size="900px">
 	<DrawerContent title="Flow {scriptPath}" on:close={drawerFlowViewer.closeDrawer}>
-		<FlowPathViewer path={scriptPath ?? ''} />
+		<FlowPathViewer path={scriptPath ?? ''} workspace={effectiveWorkspace} />
 	</DrawerContent>
 </Drawer>
 
@@ -165,7 +168,7 @@
 						target="_blank"
 						variant="default"
 						size="xs"
-						href="{base}/flows/edit/{scriptPath}">Edit</Button
+						href="{base}/flows/edit/{scriptPath}{wsParam}">Edit</Button
 					>
 				{/if}
 				{#if allowView}
@@ -188,7 +191,7 @@
 						target="_blank"
 						variant="default"
 						size="xs"
-						href="{base}/apps/edit/{scriptPath}"
+						href="{base}/apps/edit/{scriptPath}{wsParam}"
 					>
 						Edit
 					</Button>
@@ -199,7 +202,7 @@
 						size="xs"
 						target="_blank"
 						startIcon={{ icon: Code }}
-						href="{base}/apps/get/{scriptPath}"
+						href="{base}/apps/get/{scriptPath}{wsParam}"
 					>
 						View
 					</Button>
@@ -213,7 +216,7 @@
 						target="_blank"
 						variant="default"
 						size="xs"
-						href="{base}/scripts/edit/{scriptPath}"
+						href="{base}/scripts/edit/{scriptPath}{wsParam}"
 					>
 						Edit
 					</Button>
@@ -224,7 +227,10 @@
 						size="xs"
 						startIcon={{ icon: Code }}
 						on:click={async () => {
-							const { language, content } = await getScriptByPath(scriptPath ?? '')
+							const { language, content } = await getScriptByPath(
+								scriptPath ?? '',
+								effectiveWorkspace
+							)
 							code = content
 							lang = language
 							drawerViewer?.openDrawer()

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineTriggerEditors.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineTriggerEditors.svelte
@@ -22,6 +22,7 @@
 	import EmailTriggerEditor from '$lib/components/triggers/email/EmailTriggerEditor.svelte'
 	import ScheduleEditor from '$lib/components/triggers/schedules/ScheduleEditor.svelte'
 	import WebhookEditor from '$lib/components/triggers/webhook/WebhookEditor.svelte'
+	import { setTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 
 	// Owns the native-trigger drawer wiring for the pipeline canvas: the nine
 	// editor instances, the create/edit dispatch by kind, and the delete
@@ -34,8 +35,16 @@
 	// (matching the previous `{#if mode === 'edit'}` wrapper). The webhook
 	// editor stays mounted in every mode — its node is clickable in view mode
 	// too (informational endpoint URLs/token).
-	type Props = { onUpdate: () => void; mountTriggerEditors: boolean }
-	let { onUpdate, mountTriggerEditors }: Props = $props()
+	// `workspace` scopes every native-trigger backend call in this subtree (the
+	// nine editors + the delete handler below) to the session/embedding
+	// workspace, which can differ from the nav `$workspaceStore` (a forked-
+	// workspace AI session never switches the global store). Provided to the
+	// editor subtree via context; unset everywhere else → each editor falls back
+	// to `$workspaceStore`.
+	type Props = { onUpdate: () => void; mountTriggerEditors: boolean; workspace?: string }
+	let { onUpdate, mountTriggerEditors, workspace: triggerWorkspace }: Props = $props()
+
+	setTriggerWorkspace(() => triggerWorkspace ?? $workspaceStore)
 
 	let kafkaEditor: KafkaTriggerEditor | undefined = $state()
 	let mqttEditor: MqttTriggerEditor | undefined = $state()
@@ -115,9 +124,9 @@
 	}
 
 	async function confirmDeleteAttachedTrigger() {
-		if (!triggerDeleteTarget || !$workspaceStore) return
+		const workspace = triggerWorkspace ?? $workspaceStore
+		if (!triggerDeleteTarget || !workspace) return
 		const { kind, path: triggerPath } = triggerDeleteTarget
-		const workspace = $workspaceStore
 		triggerDeleteLoading = true
 		try {
 			switch (kind) {

--- a/frontend/src/lib/components/assets/AssetGraph/PipelineTriggerEditors.svelte
+++ b/frontend/src/lib/components/assets/AssetGraph/PipelineTriggerEditors.svelte
@@ -35,15 +35,11 @@
 	// (matching the previous `{#if mode === 'edit'}` wrapper). The webhook
 	// editor stays mounted in every mode — its node is clickable in view mode
 	// too (informational endpoint URLs/token).
-	// `workspace` scopes every native-trigger backend call in this subtree (the
-	// nine editors + the delete handler below) to the session/embedding
-	// workspace, which can differ from the nav `$workspaceStore` (a forked-
-	// workspace AI session never switches the global store). Provided to the
-	// editor subtree via context; unset everywhere else → each editor falls back
-	// to `$workspaceStore`.
 	type Props = { onUpdate: () => void; mountTriggerEditors: boolean; workspace?: string }
 	let { onUpdate, mountTriggerEditors, workspace: triggerWorkspace }: Props = $props()
 
+	// Register the trigger-workspace resolver for the whole editor subtree (the
+	// nine editors + the delete handler below). See triggerWorkspace.ts.
 	setTriggerWorkspace(() => triggerWorkspace ?? $workspaceStore)
 
 	let kafkaEditor: KafkaTriggerEditor | undefined = $state()

--- a/frontend/src/lib/components/flows/content/FlowPathViewer.svelte
+++ b/frontend/src/lib/components/flows/content/FlowPathViewer.svelte
@@ -15,12 +15,15 @@
 		path: string
 		noSide?: boolean
 		fillAvailableHeight?: boolean
+		/** Explicit workspace override; takes precedence over the flow-editor
+		 * `opWorkspace` context and the nav `$workspaceStore`. */
+		workspace?: string
 	}
 
-	let { path, noSide = false, fillAvailableHeight = false }: Props = $props()
+	let { path, noSide = false, fillAvailableHeight = false, workspace = undefined }: Props = $props()
 
 	const flowEditorContext = getContext<FlowEditorContext>('FlowEditorContext')
-	let opWs = $derived(flowEditorContext?.opWorkspace?.() ?? $workspaceStore)
+	let opWs = $derived(workspace ?? flowEditorContext?.opWorkspace?.() ?? $workspaceStore)
 
 	let flow: Flow | undefined = $state(undefined)
 

--- a/frontend/src/lib/components/sessions/PipelineEditorView.svelte
+++ b/frontend/src/lib/components/sessions/PipelineEditorView.svelte
@@ -392,14 +392,13 @@
 
 <!-- Native trigger editor drawers (schedule/kafka/webhook/…), shared with the
      route page; opened imperatively from the canvas via the handlers above.
-     KNOWN LIMITATION: the whole native-trigger editor subsystem reads the global
-     `$workspaceStore` and exposes no workspace override, so trigger create/edit/
-     delete here targets the nav workspace — NOT this view's `workspaceId`.
-     SessionPicker intentionally does not switch `$workspaceStore` on activation,
-     so for a forked-workspace session these writes go to the wrong workspace.
-     Fixing it means threading a workspace override through the trigger editors. -->
+     `workspace={workspaceId}` scopes every trigger backend call to THIS
+     session's (possibly forked) workspace — a session never switches the global
+     `$workspaceStore` (SessionPicker), so without this the editors would write
+     to the nav workspace. -->
 <PipelineTriggerEditors
 	bind:this={triggerEditors}
 	mountTriggerEditors
+	workspace={workspaceId}
 	onUpdate={() => graphRes.refetch()}
 />

--- a/frontend/src/lib/components/triggers/PermissionedAsLine.svelte
+++ b/frontend/src/lib/components/triggers/PermissionedAsLine.svelte
@@ -31,7 +31,10 @@
 
 	const myPermissionedAs = $derived($userStore?.username ? `u/${$userStore.username}` : undefined)
 
-	const folderDefault = useFolderDefaultPermissionedAs(() => path)
+	const folderDefault = useFolderDefaultPermissionedAs(
+		() => path,
+		() => wsId
+	)
 
 	let onBehalfOfChoice = $state<OnBehalfOfChoice>(undefined)
 	let customPermissionedAs = $state<string | undefined>(undefined)

--- a/frontend/src/lib/components/triggers/PermissionedAsLine.svelte
+++ b/frontend/src/lib/components/triggers/PermissionedAsLine.svelte
@@ -22,8 +22,6 @@
 	}
 
 	let { permissionedAs, onPermissionedAsChange, path = undefined }: Props = $props()
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 

--- a/frontend/src/lib/components/triggers/PermissionedAsLine.svelte
+++ b/frontend/src/lib/components/triggers/PermissionedAsLine.svelte
@@ -5,6 +5,7 @@
 	} from '$lib/components/OnBehalfOfSelector.svelte'
 	import { useFolderDefaultPermissionedAs } from '$lib/components/useFolderDefaultPermissionedAs.svelte'
 	import { userStore, workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	import { AlertTriangle } from 'lucide-svelte'
 
 	interface Props {
@@ -21,6 +22,10 @@
 	}
 
 	let { permissionedAs, onPermissionedAsChange, path = undefined }: Props = $props()
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	const canPreserve = $derived(
 		$userStore?.is_admin || ($userStore?.groups ?? []).includes('wm_deployers')
@@ -66,7 +71,7 @@
 			permissionedAs !== effectivePermissionedAs
 	)
 
-	const shouldRender = $derived(!!$workspaceStore && (permissionedAs !== undefined || canPreserve))
+	const shouldRender = $derived(!!wsId && (permissionedAs !== undefined || canPreserve))
 
 	// For non-admin users editing a trigger owned by someone else: signal that
 	// permissioned_as will change to the current user (backend ignores preserve for non-admins).
@@ -93,12 +98,12 @@
 	}
 </script>
 
-{#if shouldRender && $workspaceStore}
+{#if shouldRender && wsId}
 	<div class="flex items-center gap-1.5 text-2xs text-tertiary mb-4">
 		<span>Permissioned as</span>
 		{#if canPreserve}
 			<OnBehalfOfSelector
-				targetWorkspace={$workspaceStore}
+				targetWorkspace={wsId}
 				targetValue={permissionedAs}
 				selected={onBehalfOfChoice}
 				onSelect={handleSelect}

--- a/frontend/src/lib/components/triggers/TestTriggerConnection.svelte
+++ b/frontend/src/lib/components/triggers/TestTriggerConnection.svelte
@@ -10,6 +10,7 @@
 		GcpTriggerService
 	} from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	import { sendUserToast } from '$lib/toast'
 	import Button from '../common/button/Button.svelte'
 
@@ -26,6 +27,10 @@
 		noButton = false,
 		testLoading = $bindable(false)
 	}: Props = $props();
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	const kindToName: { [key: string]: string } = {
 		websocket: 'WebSocket',
@@ -48,37 +53,37 @@
 		try {
 			if (kind === 'websocket') {
 				promise = WebsocketTriggerService.testWebsocketConnection({
-					workspace: $workspaceStore!,
+					workspace: wsId!,
 					requestBody: args as any
 				})
 			} else if (kind === 'nats') {
 				promise = NatsTriggerService.testNatsConnection({
-					workspace: $workspaceStore!,
+					workspace: wsId!,
 					requestBody: args as any
 				})
 			} else if (kind === 'kafka') {
 				promise = KafkaTriggerService.testKafkaConnection({
-					workspace: $workspaceStore!,
+					workspace: wsId!,
 					requestBody: args as any
 				})
 			} else if (kind === 'mqtt') {
 				promise = MqttTriggerService.testMqttConnection({
-					workspace: $workspaceStore!,
+					workspace: wsId!,
 					requestBody: args as any
 				})
 			} else if (kind === 'sqs') {
 				promise = SqsTriggerService.testSqsConnection({
-					workspace: $workspaceStore!,
+					workspace: wsId!,
 					requestBody: args as any
 				})
 			} else if (kind === 'postgres') {
 				promise = PostgresTriggerService.testPostgresConnection({
-					workspace: $workspaceStore!,
+					workspace: wsId!,
 					requestBody: args as any
 				})
 			} else if (kind === 'gcp') {
 				promise = GcpTriggerService.testGcpConnection({
-					workspace: $workspaceStore!,
+					workspace: wsId!,
 					requestBody: args as any
 				})
 			}

--- a/frontend/src/lib/components/triggers/TestTriggerConnection.svelte
+++ b/frontend/src/lib/components/triggers/TestTriggerConnection.svelte
@@ -27,8 +27,6 @@
 		noButton = false,
 		testLoading = $bindable(false)
 	}: Props = $props();
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 

--- a/frontend/src/lib/components/triggers/TriggerRetriesAndErrorHandler.svelte
+++ b/frontend/src/lib/components/triggers/TriggerRetriesAndErrorHandler.svelte
@@ -14,7 +14,8 @@
 		errorHandlerSelected = $bindable(),
 		error_handler_path = $bindable(),
 		error_handler_args = $bindable(),
-		retry = $bindable()
+		retry = $bindable(),
+		workspace = undefined
 	}: {
 		optionTabSelected: 'error_handler' | 'retries' | string
 		itemKind: 'script' | 'flow'
@@ -23,6 +24,7 @@
 		error_handler_path: string | undefined
 		error_handler_args: Record<string, any>
 		retry: Retry | undefined
+		workspace?: string
 	} = $props()
 </script>
 
@@ -39,6 +41,7 @@
 		isEditable={can_write}
 		errorOrRecovery="error"
 		showScriptHelpText={true}
+		{workspace}
 		bind:handlerSelected={errorHandlerSelected}
 		bind:handlerPath={error_handler_path}
 		toggleText="Alert channel on error"

--- a/frontend/src/lib/components/triggers/TriggerRunnablePicker.svelte
+++ b/frontend/src/lib/components/triggers/TriggerRunnablePicker.svelte
@@ -18,6 +18,7 @@
 		isOperator: boolean
 		promptText?: string
 		promptClass?: string
+		workspace?: string
 		// Per-trigger "Create from template" button (hub URL, variant and any
 		// extra guard/tooltip differ per trigger kind, so the caller owns it).
 		createButton?: Snippet
@@ -32,6 +33,7 @@
 		isOperator,
 		promptText = 'Pick a script or flow to be triggered',
 		promptClass = 'text-xs mb-1 text-primary',
+		workspace = undefined,
 		createButton
 	}: Props = $props()
 </script>
@@ -52,6 +54,7 @@
 			bind:scriptPath
 			allowRefresh={canWrite}
 			allowEdit={!isOperator}
+			{workspace}
 			clearable
 		/>
 		{@render createButton?.()}

--- a/frontend/src/lib/components/triggers/TriggerSuspendedJobsModal.svelte
+++ b/frontend/src/lib/components/triggers/TriggerSuspendedJobsModal.svelte
@@ -20,6 +20,7 @@
 	} from '$lib/gen/types.gen'
 	import Button from '../common/button/Button.svelte'
 	import { workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	import { JobService, TriggerService } from '$lib/gen'
 	import { sendUserToast } from '$lib/toast'
 	import Cell from '$lib/components/table/Cell.svelte'
@@ -48,13 +49,17 @@
 	}
 
 	let { triggerKind, triggerPath, onToggleMode, hasChanged, runnableConfig }: Props = $props()
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	let shouldShowModal = $state(false)
 	let queuedJobs = $state<QueuedJob[]>([])
 	let selectedJobs = $state<Set<string>>(new Set())
 	let loading = $state(false)
 	let processingAction = $state(false)
-	let workspace = $workspaceStore!
+	const workspace = $derived(wsId!)
 	let currentPage = $state(1)
 	let perPage = $state(20)
 	let hasMorePages = $derived(queuedJobs.length === perPage)

--- a/frontend/src/lib/components/triggers/TriggerSuspendedJobsModal.svelte
+++ b/frontend/src/lib/components/triggers/TriggerSuspendedJobsModal.svelte
@@ -49,8 +49,6 @@
 	}
 
 	let { triggerKind, triggerPath, onToggleMode, hasChanged, runnableConfig }: Props = $props()
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 

--- a/frontend/src/lib/components/triggers/TriggerTokens.svelte
+++ b/frontend/src/lib/components/triggers/TriggerTokens.svelte
@@ -3,6 +3,7 @@
 
 	import { FlowService, ScriptService, UserService, type TruncatedToken } from '$lib/gen'
 	import { userStore, workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	import { getContext } from 'svelte'
 	import { Skeleton } from '../common'
 	import Label from '../Label.svelte'
@@ -16,6 +17,10 @@
 	}
 
 	let { isFlow, path, labelPrefix }: Props = $props()
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	const { triggersCount } = getContext<TriggerContext>('TriggerContext')
 
@@ -23,8 +28,8 @@
 
 	export async function listTokens() {
 		tokens = isFlow
-			? await FlowService.listTokensOfFlow({ workspace: $workspaceStore!, path })
-			: await ScriptService.listTokensOfScript({ workspace: $workspaceStore!, path })
+			? await FlowService.listTokensOfFlow({ workspace: wsId!, path })
+			: await ScriptService.listTokensOfScript({ workspace: wsId!, path })
 		if (labelPrefix == 'email') {
 			$triggersCount = { ...($triggersCount ?? {}), default_email_count: tokens?.length }
 		} else {
@@ -40,7 +45,7 @@
 	}
 
 	run(() => {
-		$workspaceStore && listTokens()
+		wsId && listTokens()
 	})
 </script>
 

--- a/frontend/src/lib/components/triggers/TriggerTokens.svelte
+++ b/frontend/src/lib/components/triggers/TriggerTokens.svelte
@@ -17,8 +17,6 @@
 	}
 
 	let { isFlow, path, labelPrefix }: Props = $props()
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 

--- a/frontend/src/lib/components/triggers/email/EmailTriggerEditorConfigSection.svelte
+++ b/frontend/src/lib/components/triggers/email/EmailTriggerEditorConfigSection.svelte
@@ -35,8 +35,6 @@
 		isDraftOnly = true,
 		showTestingBadge = false
 	}: Props = $props()
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 

--- a/frontend/src/lib/components/triggers/email/EmailTriggerEditorConfigSection.svelte
+++ b/frontend/src/lib/components/triggers/email/EmailTriggerEditorConfigSection.svelte
@@ -3,6 +3,7 @@
 	import Required from '$lib/components/Required.svelte'
 	import Section from '$lib/components/Section.svelte'
 	import { userStore, workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	// import { page } from '$app/state'
 	import { getEmailAddress, getEmailDomain } from './utils'
 	import { isCloudHosted } from '$lib/cloud'
@@ -34,6 +35,10 @@
 		isDraftOnly = true,
 		showTestingBadge = false
 	}: Props = $props()
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	let validateTimeout: number | undefined = undefined
 
@@ -59,7 +64,7 @@
 	}
 	async function emailTriggerExists(local_part: string, workspaced_local_part: boolean) {
 		return await EmailTriggerService.existsEmailLocalPart({
-			workspace: $workspaceStore!,
+			workspace: wsId!,
 			requestBody: {
 				local_part,
 				trigger_path: initialTriggerPath,
@@ -85,7 +90,7 @@
 	})
 
 	let fullEmailAddress = $derived(
-		getEmailAddress(local_part, workspaced_local_part, $workspaceStore ?? '', emailDomain ?? '')
+		getEmailAddress(local_part, workspaced_local_part, wsId ?? '', emailDomain ?? '')
 	)
 
 	$effect.pre(() => {

--- a/frontend/src/lib/components/triggers/email/EmailTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/email/EmailTriggerEditorInner.svelte
@@ -393,6 +393,7 @@
 			{#if !hideTarget}
 				<Section label="Target">
 					<TriggerRunnablePicker
+						workspace={wsId}
 						{fixedScriptPath}
 						bind:itemKind
 						bind:scriptPath={script_path}

--- a/frontend/src/lib/components/triggers/email/EmailTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/email/EmailTriggerEditorInner.svelte
@@ -13,6 +13,7 @@
 		type TriggerMode
 	} from '$lib/gen'
 	import { usedTriggerKinds, userStore, workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	import { canWrite, capitalize, emptyString, sendUserToast } from '$lib/utils'
 	import Section from '$lib/components/Section.svelte'
 	import { Loader2 } from 'lucide-svelte'
@@ -49,6 +50,10 @@
 		trigger = undefined,
 		customSaveBehavior = undefined
 	} = $props()
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	// Form data state
 	let initialPath = $state('')
@@ -93,7 +98,7 @@
 	const draftSync = useTriggerDraftSync({
 		itemKind: 'trigger_email',
 		path: () => initialPath,
-		workspace: () => $workspaceStore,
+		workspace: () => wsId,
 		drawerLoading: () => drawerLoading,
 		getCfg: () => emailConfig,
 		applyCfg: (c) => loadTriggerConfig(c as Partial<EmailTrigger>),
@@ -229,7 +234,7 @@
 			return { overlay: undefined, noDeployed: false }
 		}
 		const s = await EmailTriggerService.getEmailTrigger({
-			workspace: $workspaceStore!,
+			workspace: wsId!,
 			path: initialPath,
 			getDraft: true
 		})
@@ -255,7 +260,7 @@
 				initialPath,
 				saveCfg,
 				edit,
-				$workspaceStore!,
+				wsId!,
 				!!$userStore?.is_admin || !!$userStore?.is_super_admin,
 				usedTriggerKinds
 			)
@@ -299,7 +304,7 @@
 			// excludes workspaced_local_part=false) — no fork-conflict warning.
 			await EmailTriggerService.setEmailTriggerMode({
 				path: initialPath,
-				workspace: $workspaceStore ?? '',
+				workspace: wsId ?? '',
 				requestBody: { mode: newMode }
 			})
 			sendUserToast(`${capitalize(newMode)} email trigger ${initialPath}`)

--- a/frontend/src/lib/components/triggers/email/EmailTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/email/EmailTriggerEditorInner.svelte
@@ -440,6 +440,7 @@
 						</Tabs>
 						<div class="mt-4">
 							<TriggerRetriesAndErrorHandler
+								workspace={wsId}
 								{optionTabSelected}
 								{itemKind}
 								{can_write}

--- a/frontend/src/lib/components/triggers/email/EmailTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/email/EmailTriggerEditorInner.svelte
@@ -50,8 +50,6 @@
 		trigger = undefined,
 		customSaveBehavior = undefined
 	} = $props()
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
@@ -377,6 +375,7 @@
 				<div class="flex flex-col gap-2">
 					<Label label="Path">
 						<Path
+							workspaceOverride={wsId}
 							bind:dirty={dirtyPath}
 							bind:error={pathError}
 							bind:path

--- a/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorConfigSection.svelte
+++ b/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorConfigSection.svelte
@@ -25,8 +25,6 @@
 	import Select from '$lib/components/select/Select.svelte'
 	import { safeSelectItems } from '$lib/components/select/utils.svelte'
 
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	// Declared before `DEFAULT_PUSH_CONFIG` / the `base_endpoint` prop default,
 	// which call `getBaseUrl()` (a `wsId` reader) during component init.
 	const triggerWs = getTriggerWorkspace()
@@ -156,6 +154,7 @@
 			<Subsection label="Connection setup">
 				<div class="flex flex-col gap-1 mt-2">
 					<ResourcePicker
+						workspace={wsId}
 						resourceType="gcloud"
 						bind:value={
 							() => gcp_resource_path,

--- a/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorConfigSection.svelte
+++ b/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorConfigSection.svelte
@@ -25,6 +25,13 @@
 	import Select from '$lib/components/select/Select.svelte'
 	import { safeSelectItems } from '$lib/components/select/utils.svelte'
 
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	// Declared before `DEFAULT_PUSH_CONFIG` / the `base_endpoint` prop default,
+	// which call `getBaseUrl()` (a `wsId` reader) during component init.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
+
 	let topic_items: string[] = $state([])
 	let subscription_items: string[] = $state([])
 	let loadingTopic = $state(false)
@@ -105,10 +112,6 @@
 		cloud_subscription_id = $bindable(''),
 		create_update_subscription_id = $bindable('')
 	}: Props = $props()
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
-	const triggerWs = getTriggerWorkspace()
-	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	if (gcp_resource_path) {
 		loadAllPubSubTopicsFromProject()

--- a/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorConfigSection.svelte
+++ b/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorConfigSection.svelte
@@ -16,6 +16,7 @@
 	import { base } from '$lib/base'
 	import Toggle from '$lib/components/Toggle.svelte'
 	import { workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 
 	import { Button, Url } from '$lib/components/common'
 	import { RefreshCw } from 'lucide-svelte'
@@ -39,7 +40,7 @@
 			try {
 				loadingTopic = true
 				topic_items = await GcpTriggerService.listGoogleTopics({
-					workspace: $workspaceStore!,
+					workspace: wsId!,
 					path: gcp_resource_path
 				})
 			} catch (error) {
@@ -54,7 +55,7 @@
 			try {
 				loadingSubscription = true
 				subscription_items = await GcpTriggerService.listAllTgoogleTopicSubscriptions({
-					workspace: $workspaceStore!,
+					workspace: wsId!,
 					path: gcp_resource_path,
 					requestBody: {
 						topic_id
@@ -104,6 +105,10 @@
 		cloud_subscription_id = $bindable(''),
 		create_update_subscription_id = $bindable('')
 	}: Props = $props()
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	if (gcp_resource_path) {
 		loadAllPubSubTopicsFromProject()
@@ -123,7 +128,7 @@
 		}
 	})
 	function getBaseUrl() {
-		return `${window.location.origin}${base}/api/gcp/w/${$workspaceStore!}`
+		return `${window.location.origin}${base}/api/gcp/w/${wsId!}`
 	}
 
 	$effect(() => {
@@ -132,7 +137,7 @@
 
 	$effect(() => {
 		if (emptyStringTrimmed(subscription_id) && !emptyStringTrimmed(path)) {
-			subscription_id = `windmill-${$workspaceStore!}-${path.replaceAll('/', '_')}`
+			subscription_id = `windmill-${wsId!}-${path.replaceAll('/', '_')}`
 		}
 	})
 </script>

--- a/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
@@ -107,8 +107,6 @@
 		onReset?: () => void
 		cloudDisabled?: boolean
 	} = $props()
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
@@ -467,6 +465,7 @@
 			<div class="flex flex-col gap-4">
 				<Label label="Path">
 					<Path
+						workspaceOverride={wsId}
 						bind:dirty={dirtyPath}
 						bind:error={pathError}
 						bind:path

--- a/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
@@ -4,6 +4,7 @@
 	import DrawerContent from '$lib/components/common/drawer/DrawerContent.svelte'
 	import Path from '$lib/components/Path.svelte'
 	import { usedTriggerKinds, userStore, workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	import { canWrite, capitalize, emptyString, sendUserToast } from '$lib/utils'
 	import { withForkConflictRetry } from '$lib/utils/forkConflict'
 	import { Loader2 } from 'lucide-svelte'
@@ -106,6 +107,10 @@
 		onReset?: () => void
 		cloudDisabled?: boolean
 	} = $props()
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	let hasChanged = $derived(!deepEqual(getGcpConfig(), originalConfig ?? {}))
 	const gcpConfig = $derived.by(getGcpConfig)
@@ -113,7 +118,7 @@
 	const draftSync = useTriggerDraftSync({
 		itemKind: 'trigger_gcp',
 		path: () => initialPath,
-		workspace: () => $workspaceStore,
+		workspace: () => wsId,
 		drawerLoading: () => drawerLoading,
 		getCfg: () => gcpConfig,
 		applyCfg: loadTriggerConfig,
@@ -204,7 +209,7 @@
 		}
 		try {
 			const s = await GcpTriggerService.getGcpTrigger({
-				workspace: $workspaceStore!,
+				workspace: wsId!,
 				path: initialPath,
 				getDraft: true
 			})
@@ -256,7 +261,7 @@
 			initialPath,
 			cfg,
 			edit,
-			$workspaceStore!,
+			wsId!,
 			usedTriggerKinds
 		)
 		if (isSaved) {
@@ -318,7 +323,7 @@
 				(force) =>
 					GcpTriggerService.setGcpTriggerMode({
 						path: initialPath,
-						workspace: $workspaceStore ?? '',
+						workspace: wsId ?? '',
 						requestBody: { mode: newMode, force }
 					}),
 				'GCP Pub/Sub trigger'

--- a/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
@@ -588,6 +588,7 @@
 								</div>
 							{:else}
 								<TriggerRetriesAndErrorHandler
+									workspace={wsId}
 									{optionTabSelected}
 									{itemKind}
 									{can_write}

--- a/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/gcp/GcpTriggerEditorInner.svelte
@@ -482,6 +482,7 @@
 			{#if !hideTarget}
 				<Section label="Runnable">
 					<TriggerRunnablePicker
+						workspace={wsId}
 						{fixedScriptPath}
 						bind:itemKind
 						bind:scriptPath={script_path}

--- a/frontend/src/lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte
@@ -648,6 +648,7 @@
 						</Tabs>
 						<div class="mt-4">
 							<TriggerRetriesAndErrorHandler
+								workspace={wsId}
 								{optionTabSelected}
 								{itemKind}
 								{can_write}

--- a/frontend/src/lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte
@@ -530,6 +530,7 @@
 			{#if !hideTarget}
 				<Section label="Runnable">
 					<TriggerRunnablePicker
+						workspace={wsId}
 						{fixedScriptPath}
 						bind:itemKind
 						bind:scriptPath={script_path}

--- a/frontend/src/lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte
@@ -67,8 +67,6 @@
 		onDelete = undefined,
 		onReset = undefined
 	}: Props = $props()
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
@@ -515,6 +513,7 @@
 			<div class="flex flex-col gap-4">
 				<Label label="Path">
 					<Path
+						workspaceOverride={wsId}
 						bind:dirty={dirtyPath}
 						bind:error={pathError}
 						bind:path

--- a/frontend/src/lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/kafka/KafkaTriggerEditorInner.svelte
@@ -7,6 +7,7 @@
 	import TriggerRunnablePicker from '$lib/components/triggers/TriggerRunnablePicker.svelte'
 	import { KafkaTriggerService, type ErrorHandler, type Retry, type TriggerMode } from '$lib/gen'
 	import { usedTriggerKinds, userStore, workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	import { canWrite, capitalize, emptyString, sendUserToast } from '$lib/utils'
 	import { withForkConflictRetry } from '$lib/utils/forkConflict'
 	import Section from '$lib/components/Section.svelte'
@@ -66,6 +67,10 @@
 		onDelete = undefined,
 		onReset = undefined
 	}: Props = $props()
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	let drawer: Drawer | undefined = $state()
 	let is_flow: boolean = $state(false)
@@ -131,7 +136,7 @@
 	const draftSync = useTriggerDraftSync({
 		itemKind: 'trigger_kafka',
 		path: () => initialPath,
-		workspace: () => $workspaceStore,
+		workspace: () => wsId,
 		drawerLoading: () => drawerLoading,
 		getCfg: () => kafkaConfig,
 		applyCfg: loadTriggerConfig,
@@ -260,7 +265,7 @@
 			return { overlay: undefined, noDeployed: false }
 		}
 		const s = await KafkaTriggerService.getKafkaTrigger({
-			workspace: $workspaceStore!,
+			workspace: wsId!,
 			path: initialPath,
 			getDraft: true
 		})
@@ -304,7 +309,7 @@
 			initialPath,
 			cfg,
 			edit,
-			$workspaceStore!,
+			wsId!,
 			usedTriggerKinds
 		)
 		if (isSaved) {
@@ -333,7 +338,7 @@
 		resetLoading = true
 		try {
 			await KafkaTriggerService.resetKafkaOffsets({
-				workspace: $workspaceStore!,
+				workspace: wsId!,
 				path: initialPath
 			})
 			sendUserToast(
@@ -355,7 +360,7 @@
 				(force) =>
 					KafkaTriggerService.setKafkaTriggerMode({
 						path: initialPath,
-						workspace: $workspaceStore ?? '',
+						workspace: wsId ?? '',
 						requestBody: { mode: newMode, force }
 					}),
 				'Kafka trigger'

--- a/frontend/src/lib/components/triggers/kafka/KafkaTriggersConfigSection.svelte
+++ b/frontend/src/lib/components/triggers/kafka/KafkaTriggersConfigSection.svelte
@@ -26,8 +26,6 @@
 		can_write = true,
 		showTestingBadge = false
 	}: Props = $props()
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
@@ -76,6 +74,7 @@
 			<div class="block grow w-full">
 				<Subsection label="Connection">
 					<ResourcePicker
+						workspace={wsId}
 						resourceType="kafka"
 						bind:value={kafkaResourcePath}
 						disabled={!can_write}

--- a/frontend/src/lib/components/triggers/kafka/KafkaTriggersConfigSection.svelte
+++ b/frontend/src/lib/components/triggers/kafka/KafkaTriggersConfigSection.svelte
@@ -4,6 +4,7 @@
 	import Subsection from '$lib/components/Subsection.svelte'
 	import SchemaForm from '../../SchemaForm.svelte'
 	import { workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	import TestTriggerConnection from '../TestTriggerConnection.svelte'
 	import TestingBadge from '../testingBadge.svelte'
 	import { untrack } from 'svelte'
@@ -25,6 +26,10 @@
 		can_write = true,
 		showTestingBadge = false
 	}: Props = $props()
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	const kafkaConfigSchema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
@@ -51,7 +56,7 @@
 
 	function setGroupId() {
 		if (!kafkaCfg.group_id) {
-			kafkaCfg.group_id = `windmill_consumer-${$workspaceStore}-${path.replaceAll('/', '__')}`
+			kafkaCfg.group_id = `windmill_consumer-${wsId}-${path.replaceAll('/', '__')}`
 		}
 	}
 

--- a/frontend/src/lib/components/triggers/mqtt/MqttEditorConfigSection.svelte
+++ b/frontend/src/lib/components/triggers/mqtt/MqttEditorConfigSection.svelte
@@ -16,6 +16,8 @@
 	import Tooltip from '$lib/components/Tooltip.svelte'
 	import ToggleButtonGroup from '$lib/components/common/toggleButton-v2/ToggleButtonGroup.svelte'
 	import TestingBadge from '../testingBadge.svelte'
+	import { workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 
 	interface Props {
 		can_write?: boolean
@@ -36,6 +38,9 @@
 		client_id = $bindable(''),
 		showTestingBadge = false
 	}: Props = $props()
+
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	const isValidSubscribeTopics = (subscribe_topics: MqttSubscribeTopic[]): boolean => {
 		if (
@@ -61,7 +66,12 @@
 		{/snippet}
 		<div class="flex flex-col w-full gap-12">
 			<Subsection label="Connection setup">
-				<ResourcePicker resourceType="mqtt" disabled={!can_write} bind:value={mqtt_resource_path} />
+				<ResourcePicker
+					workspace={wsId}
+					resourceType="mqtt"
+					disabled={!can_write}
+					bind:value={mqtt_resource_path}
+				/>
 				{#if !emptyStringTrimmed(mqtt_resource_path)}
 					<TestTriggerConnection kind="mqtt" args={{ mqtt_resource_path, client_version }} />
 				{/if}

--- a/frontend/src/lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte
@@ -505,6 +505,7 @@
 			{#if !hideTarget}
 				<Section label="Runnable">
 					<TriggerRunnablePicker
+						workspace={wsId}
 						{fixedScriptPath}
 						bind:itemKind
 						bind:scriptPath={script_path}

--- a/frontend/src/lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte
@@ -6,6 +6,7 @@
 	import Path from '$lib/components/Path.svelte'
 	import TriggerRunnablePicker from '$lib/components/triggers/TriggerRunnablePicker.svelte'
 	import { usedTriggerKinds, userStore, workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	import { canWrite, capitalize, emptyString, sendUserToast } from '$lib/utils'
 	import { withForkConflictRetry } from '$lib/utils/forkConflict'
 	import Section from '$lib/components/Section.svelte'
@@ -76,6 +77,10 @@
 		onReset = undefined,
 		cloudDisabled = false
 	}: Props = $props()
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	let mqtt_resource_path: string = $state('')
 	let drawer: Drawer | undefined = $state(undefined)
@@ -120,7 +125,7 @@
 	const draftSync = useTriggerDraftSync({
 		itemKind: 'trigger_mqtt',
 		path: () => initialPath,
-		workspace: () => $workspaceStore,
+		workspace: () => wsId,
 		drawerLoading: () => drawerLoading,
 		getCfg: () => mqttConfig,
 		applyCfg: loadTriggerConfig,
@@ -260,7 +265,7 @@
 				return { overlay: undefined, noDeployed: false }
 			}
 			const s = await MqttTriggerService.getMqttTrigger({
-				workspace: $workspaceStore!,
+				workspace: wsId!,
 				path: initialPath,
 				getDraft: true
 			})
@@ -318,7 +323,7 @@
 			initialPath,
 			cfg,
 			edit,
-			$workspaceStore!,
+			wsId!,
 			usedTriggerKinds
 		)
 		if (isSaved) {
@@ -342,7 +347,7 @@
 				(force) =>
 					MqttTriggerService.setMqttTriggerMode({
 						path: initialPath,
-						workspace: $workspaceStore ?? '',
+						workspace: wsId ?? '',
 						requestBody: { mode: newMode, force }
 					}),
 				'MQTT trigger'

--- a/frontend/src/lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte
@@ -676,6 +676,7 @@
 								</div>
 							{:else}
 								<TriggerRetriesAndErrorHandler
+									workspace={wsId}
 									{optionTabSelected}
 									{itemKind}
 									{can_write}

--- a/frontend/src/lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/mqtt/MqttTriggerEditorInner.svelte
@@ -77,8 +77,6 @@
 		onReset = undefined,
 		cloudDisabled = false
 	}: Props = $props()
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
@@ -490,6 +488,7 @@
 			<div class="flex flex-col gap-4">
 				<Label label="Path">
 					<Path
+						workspaceOverride={wsId}
 						bind:dirty={dirtyPath}
 						bind:error={pathError}
 						bind:path

--- a/frontend/src/lib/components/triggers/nats/NatsTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/nats/NatsTriggerEditorInner.svelte
@@ -549,6 +549,7 @@
 						</Tabs>
 						<div class="mt-4">
 							<TriggerRetriesAndErrorHandler
+								workspace={wsId}
 								{optionTabSelected}
 								{itemKind}
 								{can_write}

--- a/frontend/src/lib/components/triggers/nats/NatsTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/nats/NatsTriggerEditorInner.svelte
@@ -500,6 +500,7 @@
 			{#if !hideTarget}
 				<Section label="Runnable">
 					<TriggerRunnablePicker
+						workspace={wsId}
 						{fixedScriptPath}
 						bind:itemKind
 						bind:scriptPath={script_path}

--- a/frontend/src/lib/components/triggers/nats/NatsTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/nats/NatsTriggerEditorInner.svelte
@@ -6,6 +6,7 @@
 	import TriggerRunnablePicker from '$lib/components/triggers/TriggerRunnablePicker.svelte'
 	import { NatsTriggerService, type ErrorHandler, type Retry, type TriggerMode } from '$lib/gen'
 	import { usedTriggerKinds, userStore, workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	import { canWrite, capitalize, emptyString, sendUserToast } from '$lib/utils'
 	import { withForkConflictRetry } from '$lib/utils/forkConflict'
 	import Section from '$lib/components/Section.svelte'
@@ -63,6 +64,10 @@
 		onDelete = undefined,
 		onReset = undefined
 	}: Props = $props()
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	let drawer: Drawer | undefined = $state(undefined)
 	let is_flow: boolean = $state(false)
@@ -115,7 +120,7 @@
 	const draftSync = useTriggerDraftSync({
 		itemKind: 'trigger_nats',
 		path: () => initialPath,
-		workspace: () => $workspaceStore,
+		workspace: () => wsId,
 		drawerLoading: () => drawerLoading,
 		getCfg: () => natsConfig,
 		applyCfg: loadTriggerConfig,
@@ -256,7 +261,7 @@
 			return { overlay: undefined, noDeployed: false }
 		}
 		const s = await NatsTriggerService.getNatsTrigger({
-			workspace: $workspaceStore!,
+			workspace: wsId!,
 			path: initialPath,
 			getDraft: true
 		})
@@ -297,7 +302,7 @@
 			initialPath,
 			cfg,
 			edit,
-			$workspaceStore!,
+			wsId!,
 			usedTriggerKinds
 		)
 		if (isSaved) {
@@ -335,7 +340,7 @@
 				(force) =>
 					NatsTriggerService.setNatsTriggerMode({
 						path: initialPath,
-						workspace: $workspaceStore ?? '',
+						workspace: wsId ?? '',
 						requestBody: { mode: newMode, force }
 					}),
 				'NATS trigger'

--- a/frontend/src/lib/components/triggers/nats/NatsTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/nats/NatsTriggerEditorInner.svelte
@@ -64,8 +64,6 @@
 		onDelete = undefined,
 		onReset = undefined
 	}: Props = $props()
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
@@ -487,6 +485,7 @@
 			<div class="flex flex-col gap-4">
 				<Label label="Path">
 					<Path
+						workspaceOverride={wsId}
 						bind:dirty={dirtyPath}
 						bind:error={pathError}
 						bind:path

--- a/frontend/src/lib/components/triggers/nats/NatsTriggersConfigSection.svelte
+++ b/frontend/src/lib/components/triggers/nats/NatsTriggersConfigSection.svelte
@@ -2,6 +2,7 @@
 	import Section from '$lib/components/Section.svelte'
 	import Subsection from '$lib/components/Subsection.svelte'
 	import { workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	import ResourcePicker from '$lib/components/ResourcePicker.svelte'
 	import SchemaForm from '$lib/components/SchemaForm.svelte'
 	import TestTriggerConnection from '../TestTriggerConnection.svelte'
@@ -34,6 +35,10 @@
 		can_write = true,
 		showTestingBadge = false
 	}: Props = $props()
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	let otherArgsValid = $state(false)
 	let globalError = $derived(
@@ -99,10 +104,10 @@
 
 	function setStreamAndConsumerNames() {
 		if (!natsCfg.stream_name) {
-			natsCfg.stream_name = `windmill_stream-${$workspaceStore}-${path.replaceAll('/', '__')}`
+			natsCfg.stream_name = `windmill_stream-${wsId}-${path.replaceAll('/', '__')}`
 		}
 		if (!natsCfg.consumer_name) {
-			natsCfg.consumer_name = `windmill_consumer-${$workspaceStore}-${path.replaceAll('/', '__')}`
+			natsCfg.consumer_name = `windmill_consumer-${wsId}-${path.replaceAll('/', '__')}`
 		}
 	}
 

--- a/frontend/src/lib/components/triggers/nats/NatsTriggersConfigSection.svelte
+++ b/frontend/src/lib/components/triggers/nats/NatsTriggersConfigSection.svelte
@@ -35,8 +35,6 @@
 		can_write = true,
 		showTestingBadge = false
 	}: Props = $props()
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
@@ -129,6 +127,7 @@
 			<div class="block grow w-full">
 				<Subsection label="Connection">
 					<ResourcePicker
+						workspace={wsId}
 						resourceType="nats"
 						bind:value={natsResourcePath}
 						{defaultValues}

--- a/frontend/src/lib/components/triggers/postgres/CheckPostgresRequirement.svelte
+++ b/frontend/src/lib/components/triggers/postgres/CheckPostgresRequirement.svelte
@@ -3,6 +3,7 @@
 	import Tooltip from '$lib/components/Tooltip.svelte'
 	import { PostgresTriggerService } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	import { sendUserToast } from '$lib/toast'
 	import { emptyString } from '$lib/utils'
 
@@ -15,7 +16,7 @@
 		}
 		try {
 			const invalidConfig = !(await PostgresTriggerService.isValidPostgresConfiguration({
-				workspace: $workspaceStore!,
+				workspace: wsId!,
 				path: postgres_resource_path
 			}))
 
@@ -54,6 +55,10 @@
 	}
 
 	let { can_write, postgres_resource_path, checkConnection = undefined }: Props = $props();
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 </script>
 
 {#if postgres_resource_path}

--- a/frontend/src/lib/components/triggers/postgres/CheckPostgresRequirement.svelte
+++ b/frontend/src/lib/components/triggers/postgres/CheckPostgresRequirement.svelte
@@ -55,8 +55,6 @@
 	}
 
 	let { can_write, postgres_resource_path, checkConnection = undefined }: Props = $props();
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 </script>

--- a/frontend/src/lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte
@@ -678,6 +678,7 @@
 			{#if !hideTarget}
 				<Section label="Runnable">
 					<TriggerRunnablePicker
+						workspace={wsId}
 						{fixedScriptPath}
 						bind:itemKind
 						bind:scriptPath={script_path}

--- a/frontend/src/lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte
@@ -85,8 +85,6 @@
 		onDelete = undefined,
 		onReset = undefined
 	}: Props = $props()
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
@@ -665,6 +663,7 @@
 			{/if}
 			<Label label="Path">
 				<Path
+					workspaceOverride={wsId}
 					bind:dirty={dirtyPath}
 					bind:error={pathError}
 					bind:path
@@ -726,6 +725,7 @@
 				<div class="flex flex-col gap-8">
 					<div class="flex flex-col gap-2">
 						<ResourcePicker
+							workspace={wsId}
 							disabled={!can_write}
 							bind:value={postgres_resource_path}
 							resourceType={'postgresql'}

--- a/frontend/src/lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte
@@ -955,6 +955,7 @@
 						</Tabs>
 						<div class="mt-4">
 							<TriggerRetriesAndErrorHandler
+								workspace={wsId}
 								{optionTabSelected}
 								{itemKind}
 								{can_write}

--- a/frontend/src/lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/postgres/PostgresTriggerEditorInner.svelte
@@ -14,6 +14,7 @@
 		type TriggerMode
 	} from '$lib/gen'
 	import { usedTriggerKinds, userStore, workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	import { canWrite, emptyString, emptyStringTrimmed, sendUserToast } from '$lib/utils'
 	import { withForkConflictRetry } from '$lib/utils/forkConflict'
 	import Section from '$lib/components/Section.svelte'
@@ -84,6 +85,10 @@
 		onDelete = undefined,
 		onReset = undefined
 	}: Props = $props()
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	let drawer: Drawer | undefined = $state(undefined)
 	let is_flow: boolean = $state(false)
@@ -168,7 +173,7 @@
 	const draftSync = useTriggerDraftSync({
 		itemKind: 'trigger_postgres',
 		path: () => initialPath,
-		workspace: () => $workspaceStore,
+		workspace: () => wsId,
 		drawerLoading: () => drawerLoading,
 		getCfg: () => postgresConfig,
 		applyCfg: loadTriggerConfig,
@@ -191,7 +196,7 @@
 			const message = await PostgresTriggerService.createPostgresPublication({
 				path: postgres_resource_path,
 				publication: publication_name as string,
-				workspace: $workspaceStore!,
+				workspace: wsId!,
 				requestBody: {
 					transaction_to_track: transaction_to_track,
 					table_to_track: relations
@@ -211,7 +216,7 @@
 			creatingSlot = true
 			const message = await PostgresTriggerService.createPostgresReplicationSlot({
 				path: postgres_resource_path,
-				workspace: $workspaceStore!,
+				workspace: wsId!,
 				requestBody: {
 					name: replication_slot_name
 				}
@@ -391,7 +396,7 @@
 			return { overlay: undefined, noDeployed: false }
 		}
 		const s = await PostgresTriggerService.getPostgresTrigger({
-			workspace: $workspaceStore!,
+			workspace: wsId!,
 			path: initialPath,
 			getDraft: true
 		})
@@ -402,7 +407,7 @@
 		// Deployed config + publication become the `originalConfig` baseline.
 		const deployedPublication = await PostgresTriggerService.getPostgresPublication({
 			path: deployedTrigger.postgres_resource_path,
-			workspace: $workspaceStore!,
+			workspace: wsId!,
 			publication: deployedTrigger.publication_name
 		})
 		loadTriggerConfig({ ...deployedTrigger, publication: deployedPublication })
@@ -417,7 +422,7 @@
 				? deployedPublication
 				: await PostgresTriggerService.getPostgresPublication({
 						path: effective.postgres_resource_path,
-						workspace: $workspaceStore!,
+						workspace: wsId!,
 						publication: effective.publication_name
 					})
 		return { overlay: { ...effective, publication: effectivePublication }, noDeployed }
@@ -451,7 +456,7 @@
 			initialPath,
 			cfg,
 			edit,
-			$workspaceStore!,
+			wsId!,
 			usedTriggerKinds
 		)
 		if (isSaved) {
@@ -475,7 +480,7 @@
 		try {
 			loading = true
 			let templateId = await PostgresTriggerService.createTemplateScript({
-				workspace: $workspaceStore!,
+				workspace: wsId!,
 				requestBody: {
 					relations,
 					language,
@@ -498,7 +503,7 @@
 				(force) =>
 					PostgresTriggerService.setPostgresTriggerMode({
 						path: initialPath,
-						workspace: $workspaceStore ?? '',
+						workspace: wsId ?? '',
 						requestBody: { mode: newMode, force }
 					}),
 				'postgres trigger'
@@ -530,7 +535,7 @@
 		if (postgres_resource_path) {
 			loadingPostgres = true
 			PostgresTriggerService.getPostgresVersion({
-				workspace: $workspaceStore!,
+				workspace: wsId!,
 				path: postgres_resource_path
 			})
 				.then((version: string) => {

--- a/frontend/src/lib/components/triggers/postgres/PublicationPicker.svelte
+++ b/frontend/src/lib/components/triggers/postgres/PublicationPicker.svelte
@@ -31,8 +31,6 @@
 		transaction_to_track = $bindable([]),
 		disabled = false
 	}: Props = $props();
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 

--- a/frontend/src/lib/components/triggers/postgres/PublicationPicker.svelte
+++ b/frontend/src/lib/components/triggers/postgres/PublicationPicker.svelte
@@ -7,6 +7,7 @@
 	import type { Relations } from '$lib/gen'
 	import { PostgresTriggerService } from '$lib/gen/services.gen'
 	import { workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	import { sendUserToast } from '$lib/toast'
 	import { emptyString } from '$lib/utils'
 	import { RefreshCw } from 'lucide-svelte'
@@ -30,6 +31,10 @@
 		transaction_to_track = $bindable([]),
 		disabled = false
 	}: Props = $props();
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	let loadingPublication: boolean = $state(false)
 	let deletingPublication: boolean = $state(false)
@@ -39,7 +44,7 @@
 			loadingPublication = true
 			const publications = await PostgresTriggerService.listPostgresPublication({
 				path: postgres_resource_path,
-				workspace: $workspaceStore!
+				workspace: wsId!
 			})
 
 			items = publications
@@ -55,7 +60,7 @@
 			updatingPublication = true
 			const message = await PostgresTriggerService.updatePostgresPublication({
 				path: postgres_resource_path,
-				workspace: $workspaceStore!,
+				workspace: wsId!,
 				publication: publication_name,
 				requestBody: {
 					table_to_track: relations,
@@ -75,7 +80,7 @@
 			deletingPublication = true
 			const message = await PostgresTriggerService.deletePostgresPublication({
 				path: postgres_resource_path,
-				workspace: $workspaceStore!,
+				workspace: wsId!,
 				publication: publication_name
 			})
 			items = items.filter((item) => item != publication_name)
@@ -94,7 +99,7 @@
 		try {
 			const publication_data = await PostgresTriggerService.getPostgresPublication({
 				path: postgres_resource_path,
-				workspace: $workspaceStore!,
+				workspace: wsId!,
 				publication: publication_name
 			})
 			transaction_to_track = [...publication_data.transaction_to_track]

--- a/frontend/src/lib/components/triggers/postgres/SlotPicker.svelte
+++ b/frontend/src/lib/components/triggers/postgres/SlotPicker.svelte
@@ -22,8 +22,6 @@
 		postgres_resource_path = '',
 		disabled = false
 	}: Props = $props();
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 

--- a/frontend/src/lib/components/triggers/postgres/SlotPicker.svelte
+++ b/frontend/src/lib/components/triggers/postgres/SlotPicker.svelte
@@ -4,6 +4,7 @@
 	import { safeSelectItems } from '$lib/components/select/utils.svelte'
 	import { PostgresTriggerService } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	import { sendUserToast } from '$lib/toast'
 	import { emptyString } from '$lib/utils'
 	import { RefreshCw } from 'lucide-svelte'
@@ -21,6 +22,10 @@
 		postgres_resource_path = '',
 		disabled = false
 	}: Props = $props();
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	let deletingSlot: boolean = $state(false)
 	let loadingSlot: boolean = $state(false)
@@ -30,7 +35,7 @@
 			loadingSlot = true
 			const result = await PostgresTriggerService.listPostgresReplicationSlot({
 				path: postgres_resource_path,
-				workspace: $workspaceStore!
+				workspace: wsId!
 			})
 
 			let exist = false
@@ -63,7 +68,7 @@
 			deletingSlot = true
 			const message = await PostgresTriggerService.deletePostgresReplicationSlot({
 				path: postgres_resource_path,
-				workspace: $workspaceStore!,
+				workspace: wsId!,
 				requestBody: {
 					name: replication_slot_name
 				}

--- a/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
@@ -44,6 +44,7 @@
 	import TextInput from '$lib/components/text_input/TextInput.svelte'
 	import { twMerge } from 'tailwind-merge'
 	import PermissionedAsLine from '../PermissionedAsLine.svelte'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 
 	let {
 		useDrawer = true,
@@ -135,12 +136,14 @@
 				emptyString(errorHandlerExtraArgs['channel'])) ||
 			!can_write
 	)
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 	const scheduleCfg = $derived.by(getScheduleCfg)
 
 	const draftSync = useTriggerDraftSync({
 		itemKind: 'trigger_schedule',
 		path: () => initialPath,
-		workspace: () => $workspaceStore,
+		workspace: () => wsId,
 		drawerLoading: () => drawerLoading,
 		getCfg: () => scheduleCfg,
 		applyCfg: loadScheduleCfg,
@@ -228,15 +231,15 @@
 			let defaultErrorHandlerMaybe = undefined
 			let defaultRecoveryHandlerMaybe = undefined
 			let defaultSuccessHandlerMaybe = undefined
-			if ($workspaceStore) {
+			if (wsId) {
 				defaultErrorHandlerMaybe = (await SettingService.getGlobal({
-					key: 'default_error_handler_' + $workspaceStore!
+					key: 'default_error_handler_' + wsId!
 				})) as any
 				defaultRecoveryHandlerMaybe = (await SettingService.getGlobal({
-					key: 'default_recovery_handler_' + $workspaceStore!
+					key: 'default_recovery_handler_' + wsId!
 				})) as any
 				defaultSuccessHandlerMaybe = (await SettingService.getGlobal({
-					key: 'default_success_handler_' + $workspaceStore!
+					key: 'default_success_handler_' + wsId!
 				})) as any
 			}
 
@@ -305,7 +308,7 @@
 			let s: Schedule | undefined
 			if (schedule_path) {
 				const resp = await ScheduleService.getSchedule({
-					workspace: $workspaceStore!,
+					workspace: wsId!,
 					path: schedule_path,
 					getDraft
 				})
@@ -385,9 +388,9 @@
 			runnable = undefined
 			try {
 				if (is_flow) {
-					runnable = await FlowService.getFlowByPath({ workspace: $workspaceStore!, path: p })
+					runnable = await FlowService.getFlowByPath({ workspace: wsId!, path: p })
 				} else {
-					runnable = await ScriptService.getScriptByPath({ workspace: $workspaceStore!, path: p })
+					runnable = await ScriptService.getScriptByPath({ workspace: wsId!, path: p })
 				}
 			} catch (err) {}
 		} else {
@@ -400,9 +403,9 @@
 			sendUserToast(`Setting default error handler is an enterprise edition feature`, true)
 			return
 		}
-		if ($workspaceStore) {
+		if (wsId) {
 			await ScheduleService.setDefaultErrorOrRecoveryHandler({
-				workspace: $workspaceStore!,
+				workspace: wsId!,
 				requestBody: {
 					handler_type: 'error',
 					override_existing: overrideExisting,
@@ -429,9 +432,9 @@
 			sendUserToast(`Setting default recovery handler is an enterprise edition feature`, true)
 			return
 		}
-		if ($workspaceStore) {
+		if (wsId) {
 			await ScheduleService.setDefaultErrorOrRecoveryHandler({
-				workspace: $workspaceStore!,
+				workspace: wsId!,
 				requestBody: {
 					handler_type: 'recovery',
 					override_existing: overrideExisting,
@@ -456,9 +459,9 @@
 			sendUserToast(`Setting default success handler is an enterprise edition feature`, true)
 			return
 		}
-		if ($workspaceStore) {
+		if (wsId) {
 			await ScheduleService.setDefaultErrorOrRecoveryHandler({
-				workspace: $workspaceStore!,
+				workspace: wsId!,
 				requestBody: {
 					handler_type: 'success',
 					override_existing: overrideExisting,
@@ -492,7 +495,7 @@
 		}
 		try {
 			const s = await ScheduleService.getSchedule({
-				workspace: $workspaceStore!,
+				workspace: wsId!,
 				path: initialPath,
 				getDraft: true
 			})
@@ -591,7 +594,7 @@
 		const previousPath = initialPath
 		const scheduleCfg = getScheduleCfg()
 		deploymentLoading = true
-		const isSaved = await saveScheduleFromCfg(scheduleCfg, edit, $workspaceStore!)
+		const isSaved = await saveScheduleFromCfg(scheduleCfg, edit, wsId!)
 		if (isSaved) {
 			draftSync.discard(previousPath, scheduleCfg)
 			onUpdate?.(scheduleCfg.path)
@@ -698,7 +701,7 @@
 				(force) =>
 					ScheduleService.setScheduleEnabled({
 						path: initialPath,
-						workspace: $workspaceStore ?? '',
+						workspace: wsId ?? '',
 						requestBody: { enabled: nEnabled, force }
 					}),
 				'schedule'
@@ -754,7 +757,7 @@
 							variant="default"
 							disabled={!allowSchedule || pathError != '' || emptyString(script_path)}
 							on:click={() => {
-								runScheduleNow(script_path, path, is_flow, $workspaceStore!)
+								runScheduleNow(script_path, path, is_flow, wsId!)
 							}}
 						>
 							Run now

--- a/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
@@ -934,6 +934,7 @@
 							Pick a script or flow to be triggered by the schedule<Required required={true} />
 						</p>
 						<ScriptPicker
+							workspace={wsId}
 							disabled={(initialScriptPath != '' && !initNewPath) || !can_write}
 							initialPath={initialScriptPath}
 							kinds={['script']}
@@ -953,6 +954,7 @@
 						</Alert>
 						<div class="my-2"></div>
 						<ScriptPicker
+							workspace={wsId}
 							disabled
 							initialPath={script_path}
 							scriptPath={script_path}
@@ -1341,6 +1343,7 @@
 						<Label label="Dynamic skip script">
 							<div class="flex flex-row">
 								<ScriptPicker
+									workspace={wsId}
 									disabled={!can_write}
 									bind:scriptPath={dynamicSkipPath}
 									kinds={['script']}

--- a/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
@@ -138,6 +138,9 @@
 	)
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
+	// Carry the acting workspace onto "create from template" routes when a
+	// session override is set, so the script is created in the session workspace.
+	const wsParam = $derived(triggerWs?.() ? `&workspace=${encodeURIComponent(wsId!)}` : '')
 	const scheduleCfg = $derived.by(getScheduleCfg)
 
 	const draftSync = useTriggerDraftSync({
@@ -1091,6 +1094,7 @@
 					</div>
 
 					<ErrorOrRecoveryHandler
+						workspace={wsId}
 						isEditable={can_write}
 						errorOrRecovery="error"
 						showScriptHelpText={true}
@@ -1185,6 +1189,7 @@
 						</div>
 					{/snippet}
 					<ErrorOrRecoveryHandler
+						workspace={wsId}
 						isEditable={!disabled}
 						errorOrRecovery="recovery"
 						bind:handlerSelected={recoveryHandlerSelected}
@@ -1274,6 +1279,7 @@
 						</div>
 					{/snippet}
 					<ErrorOrRecoveryHandler
+						workspace={wsId}
 						isEditable={!disabled}
 						errorOrRecovery="success"
 						bind:handlerSelected={successHandlerSelected}
@@ -1355,7 +1361,7 @@
 										btnClasses="ml-4 whitespace-nowrap"
 										variant="default"
 										size="xs"
-										href="/scripts/add?hub=hub%2F19822%2Fwindmill%2Fdynamic_skip_template"
+										href="/scripts/add?hub=hub%2F19822%2Fwindmill%2Fdynamic_skip_template{wsParam}"
 										disabled={!can_write}
 										target="_blank"
 									>
@@ -1375,7 +1381,12 @@
 					label="Custom script tag"
 					tooltip="When set, the script tag will be overridden by this tag"
 				>
-					<WorkerTagPicker bind:tag popupPlacement="top-end" disabled={!can_write} />
+					<WorkerTagPicker
+						bind:tag
+						workspaceId={wsId}
+						popupPlacement="top-end"
+						disabled={!can_write}
+					/>
 				</Section>
 			{/if}
 		{:else}

--- a/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/schedules/ScheduleEditorInner.svelte
@@ -816,6 +816,7 @@
 						<label for="path" class="text-xs font-semibold text-emphasis">Path</label>
 						{#if !edit && !trigger?.isPrimary}
 							<Path
+								workspaceOverride={wsId}
 								bind:dirty={dirtyPath}
 								bind:this={pathC}
 								checkInitialPathExistence={!edit}

--- a/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorConfigSection.svelte
+++ b/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorConfigSection.svelte
@@ -40,8 +40,6 @@
 		message_attributes = $bindable([]),
 		showTestingBadge = false
 	}: Props = $props()
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
@@ -87,9 +85,13 @@
 						</ToggleButtonGroup>
 
 						{#if aws_auth_resource_type === 'credentials'}
-							<ResourcePicker resourceType="aws" bind:value={aws_resource_path} />
+							<ResourcePicker workspace={wsId} resourceType="aws" bind:value={aws_resource_path} />
 						{:else if aws_auth_resource_type === 'oidc'}
-							<ResourcePicker resourceType="aws_oidc" bind:value={aws_resource_path} />
+							<ResourcePicker
+								workspace={wsId}
+								resourceType="aws_oidc"
+								bind:value={aws_resource_path}
+							/>
 						{/if}
 						{#if isValid}
 							<TestTriggerConnection kind="sqs" args={{ aws_resource_path, queue_url }} />
@@ -188,4 +190,4 @@
 	{/snippet}
 </ItemPicker>
 
-<VariableEditor bind:this={variableEditor} on:create={itemPicker.openDrawer} />
+<VariableEditor bind:this={variableEditor} workspace={wsId} on:create={itemPicker.openDrawer} />

--- a/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorConfigSection.svelte
+++ b/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorConfigSection.svelte
@@ -14,6 +14,7 @@
 	import { Button } from '$lib/components/common'
 	import { VariableService, type AwsAuthResourceType } from '$lib/gen'
 	import { workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	import TestingBadge from '../testingBadge.svelte'
 	import MultiSelect from '$lib/components/select/MultiSelect.svelte'
 	import { safeSelectItems } from '$lib/components/select/utils.svelte'
@@ -39,9 +40,13 @@
 		message_attributes = $bindable([]),
 		showTestingBadge = false
 	}: Props = $props()
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	async function loadVariables() {
-		return await VariableService.listVariable({ workspace: $workspaceStore ?? '' })
+		return await VariableService.listVariable({ workspace: wsId ?? '' })
 	}
 	let itemPicker: ItemPicker | undefined = $state()
 	let variableEditor: VariableEditor | undefined = $state()

--- a/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorInner.svelte
@@ -484,6 +484,7 @@
 			{#if !hideTarget}
 				<Section label="Runnable">
 					<TriggerRunnablePicker
+						workspace={wsId}
 						{fixedScriptPath}
 						bind:itemKind
 						bind:scriptPath={script_path}

--- a/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorInner.svelte
@@ -69,8 +69,6 @@
 		onDelete = undefined,
 		onReset = undefined
 	}: Props = $props()
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
@@ -469,6 +467,7 @@
 			<div class="flex flex-col gap-4">
 				<Label label="Path">
 					<Path
+						workspaceOverride={wsId}
 						bind:dirty={dirtyPath}
 						bind:error={pathError}
 						bind:path

--- a/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorInner.svelte
@@ -534,6 +534,7 @@
 						</Tabs>
 						<div class="mt-4">
 							<TriggerRetriesAndErrorHandler
+								workspace={wsId}
 								{optionTabSelected}
 								{itemKind}
 								{can_write}

--- a/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorInner.svelte
+++ b/frontend/src/lib/components/triggers/sqs/SqsTriggerEditorInner.svelte
@@ -4,6 +4,7 @@
 	import DrawerContent from '$lib/components/common/drawer/DrawerContent.svelte'
 	import Path from '$lib/components/Path.svelte'
 	import { usedTriggerKinds, userStore, workspaceStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	import { canWrite, capitalize, emptyString, sendUserToast } from '$lib/utils'
 	import { withForkConflictRetry } from '$lib/utils/forkConflict'
 	import { Loader2 } from 'lucide-svelte'
@@ -68,6 +69,10 @@
 		onDelete = undefined,
 		onReset = undefined
 	}: Props = $props()
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
 	let drawer: Drawer | undefined = $state(undefined)
 	let is_flow: boolean = $state(false)
@@ -107,7 +112,7 @@
 	const draftSync = useTriggerDraftSync({
 		itemKind: 'trigger_sqs',
 		path: () => initialPath,
-		workspace: () => $workspaceStore,
+		workspace: () => wsId,
 		drawerLoading: () => drawerLoading,
 		getCfg: () => sqsConfig,
 		applyCfg: loadTriggerConfig,
@@ -238,7 +243,7 @@
 				return { overlay: undefined, noDeployed: false }
 			}
 			const s = await SqsTriggerService.getSqsTrigger({
-				workspace: $workspaceStore!,
+				workspace: wsId!,
 				path: initialPath,
 				getDraft: true
 			})
@@ -282,7 +287,7 @@
 				(force) =>
 					SqsTriggerService.setSqsTriggerMode({
 						path: initialPath,
-						workspace: $workspaceStore ?? '',
+						workspace: wsId ?? '',
 						requestBody: { mode: newMode, force }
 					}),
 				'SQS trigger'
@@ -307,7 +312,7 @@
 			initialPath,
 			cfg,
 			edit,
-			$workspaceStore!,
+			wsId!,
 			usedTriggerKinds
 		)
 		if (isSaved) {

--- a/frontend/src/lib/components/triggers/triggerWorkspace.ts
+++ b/frontend/src/lib/components/triggers/triggerWorkspace.ts
@@ -1,0 +1,29 @@
+import { getContext, setContext } from 'svelte'
+
+const TRIGGER_WORKSPACE_KEY = 'triggerWorkspace'
+
+/**
+ * Context seam letting the native-trigger editors operate on a workspace other
+ * than the globally-active `$workspaceStore`. An AI session can run against a
+ * (possibly forked) workspace that differs from the nav workspace WITHOUT
+ * switching `$workspaceStore` (see `SessionPicker`), so a host that embeds the
+ * trigger editors in that context registers a resolver here.
+ *
+ * Every workspace-scoped backend call / navigation inside the trigger subtree
+ * reads its workspace via {@link getTriggerWorkspace} and falls back to
+ * `$workspaceStore` when no resolver is set — the default everywhere outside
+ * such a host, so behavior there is unchanged. Mirrors the AI chat manager's
+ * `operatingWorkspace` resolver.
+ */
+export function setTriggerWorkspace(resolver: () => string | undefined): void {
+	setContext(TRIGGER_WORKSPACE_KEY, resolver)
+}
+
+/**
+ * The trigger-workspace resolver set by an embedding host, or `undefined` when
+ * none is set (fall back to `$workspaceStore`). Read once during component init;
+ * use in a `$derived`: `const ws = $derived(triggerWs?.() ?? $workspaceStore)`.
+ */
+export function getTriggerWorkspace(): (() => string | undefined) | undefined {
+	return getContext<(() => string | undefined) | undefined>(TRIGGER_WORKSPACE_KEY)
+}

--- a/frontend/src/lib/components/triggers/webhook/WebhooksConfigSection.svelte
+++ b/frontend/src/lib/components/triggers/webhook/WebhooksConfigSection.svelte
@@ -19,6 +19,7 @@
 	import { base } from '$lib/base'
 	import TriggerTokens from '../TriggerTokens.svelte'
 	import { workspaceStore, userStore } from '$lib/stores'
+	import { getTriggerWorkspace } from '$lib/components/triggers/triggerWorkspace'
 	import UserSettings from '../../UserSettings.svelte'
 	import { generateRandomString } from '$lib/utils'
 	import TextInput from '$lib/components/text_input/TextInput.svelte'
@@ -42,8 +43,12 @@
 		triggerTokens = $bindable(undefined),
 		scopes = []
 	}: Props = $props()
+	// Scope trigger backend calls to the embedding host's workspace (an AI
+	// session's forked workspace) when set; otherwise the nav workspace.
+	const triggerWs = getTriggerWorkspace()
+	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 
-	const WEBHOOK_BASE_URL = `${location.origin}${base}/api/w/${$workspaceStore}/jobs`
+	const WEBHOOK_BASE_URL = $derived(`${location.origin}${base}/api/w/${wsId}/jobs`)
 
 	let baseWebhookUrl = $derived.by(() => {
 		let webhookUrlPath: string
@@ -222,7 +227,7 @@ function waitForJobCompletion(UUID) {
     try {
       const endpoint = \`${
 				location.origin
-			}/api/w/${$workspaceStore}/jobs_u/completed/get_result_maybe/\${UUID}\`;
+			}/api/w/${wsId}/jobs_u/completed/get_result_maybe/\${UUID}\`;
       const checkResponse = await fetch(endpoint, {
         method: 'GET',
         headers: ${JSON.stringify(headers(), null, 2).replaceAll('\n', '\n\t\t\t\t')}
@@ -265,7 +270,7 @@ ${
 		? 'echo -E $RESULT | jq'
 		: requestType === 'async'
 			? `
-URL="${location.origin}/api/w/${$workspaceStore}/jobs_u/completed/get_result_maybe/$UUID"
+URL="${location.origin}/api/w/${wsId}/jobs_u/completed/get_result_maybe/$UUID"
 while true; do
   curl -s -H "Authorization: Bearer $TOKEN" $URL -o res.json
   COMPLETED=$(cat res.json | jq .completed)
@@ -287,7 +292,7 @@ done`
 		token = e.detail
 		triggerTokens?.listTokens()
 	}}
-	newTokenWorkspace={$workspaceStore}
+	newTokenWorkspace={wsId}
 	newTokenLabel={`webhook-${$userStore?.username ?? 'superadmin'}-${generateRandomString(4)}`}
 	{scopes}
 />

--- a/frontend/src/lib/components/triggers/webhook/WebhooksConfigSection.svelte
+++ b/frontend/src/lib/components/triggers/webhook/WebhooksConfigSection.svelte
@@ -43,8 +43,6 @@
 		triggerTokens = $bindable(undefined),
 		scopes = []
 	}: Props = $props()
-	// Scope trigger backend calls to the embedding host's workspace (an AI
-	// session's forked workspace) when set; otherwise the nav workspace.
 	const triggerWs = getTriggerWorkspace()
 	const wsId = $derived(triggerWs?.() ?? $workspaceStore)
 

--- a/frontend/src/lib/components/useFolderDefaultPermissionedAs.svelte.ts
+++ b/frontend/src/lib/components/useFolderDefaultPermissionedAs.svelte.ts
@@ -12,13 +12,18 @@ import { workspaceStore, userStore } from '$lib/stores'
  * switch or permission change. Uses `runed`'s `resource()` which handles race conditions
  * and loading state automatically.
  */
-export function useFolderDefaultPermissionedAs(pathGetter: () => string | undefined) {
+export function useFolderDefaultPermissionedAs(
+	pathGetter: () => string | undefined,
+	// The acting workspace; defaults to the nav `$workspaceStore` when omitted so
+	// a forked session resolves the folder default from its own workspace.
+	wsGetter?: () => string | undefined
+) {
 	// Subscribe to the stores so the effect re-runs on changes.
-	let workspace = $state<string | undefined>(undefined)
+	let navWorkspace = $state<string | undefined>(undefined)
 	let user = $state<any>(undefined)
 
 	$effect(() => {
-		const unsubWs = workspaceStore.subscribe((w) => (workspace = w))
+		const unsubWs = workspaceStore.subscribe((w) => (navWorkspace = w))
 		const unsubUser = userStore.subscribe((u) => (user = u))
 		return () => {
 			unsubWs()
@@ -27,7 +32,7 @@ export function useFolderDefaultPermissionedAs(pathGetter: () => string | undefi
 	})
 
 	const folderResource = resource(
-		() => ({ path: pathGetter(), workspace, user }),
+		() => ({ path: pathGetter(), workspace: wsGetter?.() ?? navWorkspace, user }),
 		async ({ path, workspace, user }) => {
 			const canPreserve =
 				user?.is_admin || user?.is_super_admin || (user?.groups ?? []).includes('wm_deployers')


### PR DESCRIPTION
## Summary

In an AI **session** whose workspace is a **fork** (session workspace ≠ nav `$workspaceStore`), creating / editing / deleting a native trigger (schedule, kafka, mqtt, nats, postgres, sqs, gcp, email, webhook) from the **pipeline canvas** wrote to the **nav workspace**, not the session's — silent cross-workspace data corruption. `SessionPicker` intentionally never switches the global `$workspaceStore`, but every native-trigger editor and its subtree read that store directly for their backend calls.

Fix: a small **`triggerWorkspace` svelte context resolver** (mirrors the AI chat manager's `operatingWorkspace`). The session pipeline host registers a resolver; every trigger component reads its workspace through it and **falls back to `$workspaceStore` when unset** — so behavior everywhere outside the session pipeline canvas is unchanged.

## Changes

- **New `frontend/src/lib/components/triggers/triggerWorkspace.ts`** — `setTriggerWorkspace(resolver)` / `getTriggerWorkspace()` context helpers. The full rationale for the pattern lives here (per AGENTS.md, stated once).
- **`PipelineTriggerEditors.svelte`** — takes a `workspace` prop, calls `setTriggerWorkspace(() => workspace ?? $workspaceStore)`, and its delete handler uses the resolved workspace.
- **`PipelineEditorView.svelte`** — passes `workspace={workspaceId}`.
- **Trigger components** — each adds `const wsId = $derived(triggerWs?.() ?? $workspaceStore)` and routes its workspace-scoped work through `wsId`:
  - **Direct backend calls / saved config values / API URLs** — schedule / kafka / mqtt / nats / postgres / sqs / gcp / email / webhook editors, their `*Inner` / `*ConfigSection` / pickers, plus `TestTriggerConnection`, `TriggerTokens`, `TriggerSuspendedJobsModal`, `PermissionedAsLine`.
  - **Nested pickers** — these are separate sub-components that own their own workspace-override prop, otherwise defaulting to the nav workspace:
    - `<Path workspaceOverride={wsId}>` in the 8 editors with a path field — scopes path-existence checks and folder listing.
    - `<ResourcePicker workspace={wsId}>` in the 6 config sections with a resource picker — scopes the resource list **and resource creation**. `MqttEditorConfigSection` had a `ResourcePicker` but no `wsId`, so it gets the resolver too.
    - SQS `<VariableEditor workspace={wsId}>` — scopes variable creation.
  - **Runnable picker** — `ScriptPicker` (reached via `TriggerRunnablePicker` in 7 editors, and used directly by the schedule editor) listed scripts/flows/apps from the nav workspace. Added an optional `workspace` prop to `ScriptPicker` (defaults to `$workspaceStore` → no change for existing callers across the app), threaded it through `TriggerRunnablePicker`, and wired `wsId` from the trigger editors — so a forked session offers its own runnables when attaching a script/flow to a trigger. The picker's **View** drawer (`getScriptByPath` / `FlowPathViewer`) and its **Edit/View** route links are scoped too: the links carry `?workspace=` (consumed by the logged-in layout, same mechanism as `editInFork`) — appended only when an explicit override is set, so existing callers' links are unchanged.
  - **Error handler** — `ErrorOrRecoveryHandler` (via `TriggerRetriesAndErrorHandler` in the 7 in-scope editors) listed/tested handlers, read Slack/Teams settings, and ran test jobs against the nav workspace, then saved the handler path onto a trigger in the session workspace. Added a `workspace` prop (defaults to `$workspaceStore`) and routed all of it through the resolved workspace.
  - **Folder permission default** — `useFolderDefaultPermissionedAs` resolved a `f/...` trigger's `default_permissioned_as` from the nav workspace; it now accepts an optional workspace getter, and `PermissionedAsLine` passes `() => wsId`, so the preselected execution identity comes from the session workspace.

### Scope notes
- Only the **9 kinds mounted by the pipeline canvas** are affected. `azure` / `http` / `websocket` / `native` trigger editors are never mounted from the canvas, and capture UI is rendered by the normal Triggers tab (not the drawer), so both are correctly out of scope — their own `ScriptPicker` / `ResourcePicker` usages are left unchanged.
- `useTriggerDraftSync.svelte.ts` already accepts a `workspace` getter, so its callers just pass `wsId` — the file is unchanged.

## Test plan

- [x] `npm run check` — clean; my changes introduce 0 new errors / warnings. (The remaining errors — `utils_workspace_deploy.ts`, `triggers/utils.ts` `'app'`/`JobTriggerKind`, `ParqetCsvTableRenderer` — are pre-existing on `main` and untouched here.)
- [x] **Regression (fallback path), browser-verified:** with the context unset (standalone `/schedules` → New schedule), the editor renders `Path` + `PermissionedAsLine` + the runnable `ScriptPicker` with **0 console errors**, and the network tab shows the list / folder / path-existence requests all correctly hitting the nav workspace — `GET /api/w/guilhem/scripts/list?kinds=script`, `/folders/listnames`, `/path_autocomplete/list_paths`, `/schedules/exists/...`. `wsId` (and `effectiveWorkspace` in `ScriptPicker`) fall back exactly as before.
- [x] **P1 caught in review — GCP editor mount:** a TDZ crash (`getBaseUrl()` read `wsId` before its declaration, in unconditional init code) was fixed by hoisting the declaration; verified the GCP Pub/Sub editor drawer opens with zero console errors (screenshot below).
- [x] **Local Codex review** (`/local-review-codex`), two rounds — round 1's in-scope P1 (nested pickers) and P2 (repeated comment) fixed; round 2's three P1s (error-handler subtree, folder-default identity, ScriptPicker View/Edit actions) and P2 (comment consolidation) all addressed in this branch.
- [x] **Fix path (fork session), browser-verified:** drove a real AI session acting on a fork (`wm-fork-dazzled` = B) while nav stayed on `ai-meta-e2e` (A) — session workspace ≠ nav `$workspaceStore`, the exact bug condition — and opened that fork's `demo_pipeline` in the session preview. `PipelineEditorView` mounted with `workspace=B`, and **every** backend call from the pipeline view targeted `/api/w/wm-fork-dazzled/` (`drafts/get_own/data_pipeline`, `assets/graph?folder=demo_pipeline`, `drafts/update`, `concurrency_groups/list_jobs`, and the in-session pipeline **script** editor) — **zero** calls to the nav workspace A (the only A hit was the nav sidebar's own `assets/pipelines` list, which is correct). This is the exact `workspace` that `PipelineTriggerEditors` registers via `setTriggerWorkspace(() => workspace)`, and every trigger component reads `getTriggerWorkspace()?.() ?? $workspaceStore`. 0 console errors from these components.
  - Not directly captured: the trigger-editor **drawer's own** request in-session — the demo pipeline's schedule node is in `MISSING · "click to create (after draft save)"` state, and creating it requires materializing/deploying the pipeline draft (a mutation avoided during verification). That last hop is inferred: the resolver returns the same `workspace` proven to route all sibling calls to B, and the editors' correct consumption of the resolved workspace is exactly what the standalone fallback test above exercises (same code path, resolver → nav).

## Screenshots

GCP Pub/Sub trigger editor mounts cleanly after the TDZ fix (the crash site was unconditional init code, so this reproduces on the standalone editor):

![gcp-trigger-editor-renders](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm-fix-pipeline-workspace-scoping/1783617805-gcp-trigger-editor-renders.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
