### PR TITLE
perf: index v2_job(parent_job) to speed up run child-job listing

### DIFF
--- a/backend/migrations/20260710073406_index_v2_job_parent_job.down.sql
+++ b/backend/migrations/20260710073406_index_v2_job_parent_job.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS ix_v2_job_parent_job;

--- a/backend/migrations/20260710073406_index_v2_job_parent_job.up.sql
+++ b/backend/migrations/20260710073406_index_v2_job_parent_job.up.sql
@@ -1,0 +1,11 @@
+-- Partial index for listing a run's child jobs (flow steps, loop iterations,
+-- native-retry attempts, schedule handlers) via the `parent_job = ?` filter on
+-- /jobs/list and /jobs/completed/list. Without it, Postgres walks the whole
+-- workspace (workspace_id, created_at) timeline filtering row-by-row for the
+-- parent. Children of one parent are few, so (parent_job, created_at DESC)
+-- returns them directly and serves both ASC and DESC orderings.
+-- Partial on parent_job IS NOT NULL keeps it small (root jobs are the majority).
+-- Created CONCURRENTLY via the OVERRIDDEN_MIGRATIONS rewrite in windmill-api/src/db.rs.
+CREATE INDEX IF NOT EXISTS ix_v2_job_parent_job
+    ON v2_job (parent_job, created_at DESC)
+    WHERE parent_job IS NOT NULL;

--- a/backend/windmill-api/src/db.rs
+++ b/backend/windmill-api/src/db.rs
@@ -90,6 +90,9 @@ lazy_static::lazy_static! {
                     (20260614075900, include_str!(
                         "../../migrations/20260614075900_dedup_folder_labels.up.sql"
                     ).replace("SET search_path = public", "SET search_path FROM CURRENT").to_string()),
+                    (20260710073406, include_str!(
+                        "../../migrations/20260710073406_index_v2_job_parent_job.up.sql"
+                    ).replace("CREATE INDEX", "CREATE INDEX CONCURRENTLY")),
                     ].into_iter().collect();
 }
 


### PR DESCRIPTION
## Summary

Listing a run's child jobs — flow steps, loop iterations, native-retry attempts, schedule handlers — filters `v2_job` by `parent_job = ?`. `v2_job` had **no index leading with `parent_job`** (every existing index leads with `workspace_id`), so Postgres walked the workspace-wide `(workspace_id, created_at)` timeline row-by-row to find the handful of children of one parent. Production slow-query logs show this as the single **highest-volume offender (~13.4K hits, up to 145 s)** on `/jobs/completed/list` and `/jobs/list` with a `parent_job` filter.

This adds a small partial index that serves the filter and the `ORDER BY created_at` directly.

## Changes

- **New migration** `20260710073406_index_v2_job_parent_job` adding:
  ```sql
  CREATE INDEX ix_v2_job_parent_job
      ON v2_job (parent_job, created_at DESC)
      WHERE parent_job IS NOT NULL;
  ```
  - `(parent_job, created_at DESC)` resolves both the filter and the ordering in one scan (the DESC key also serves the ascending variant via a backward scan).
  - `WHERE parent_job IS NOT NULL` excludes root jobs (the majority), keeping the index small and write-cheap.
- **Registered in `OVERRIDDEN_MIGRATIONS`** (`windmill-api/src/db.rs`) with the `CREATE INDEX → CREATE INDEX CONCURRENTLY` rewrite, so it builds **online without locking `v2_job`** on production — same convention as the existing `20260207*` / `20260228000000` concurrent-index migrations. Down migration is a plain (transaction-safe) `DROP INDEX IF EXISTS`.

## Verification

`EXPLAIN ANALYZE` on the exact production query shape, against 300k seeded jobs (one flow with 20 old children):

| | Access path | Rows scanned for 20 children | Time |
|---|---|---|---|
| Before | Parallel Seq Scan + Sort | 300,000 (`Rows Removed by Filter`) | 8.2 ms |
| After  | Index Scan on `ix_v2_job_parent_job` (`Index Cond: parent_job = …`) | 20 (direct) | 0.09 ms |

The seq-scan cost scales linearly with table size — at production scale (tens/hundreds of millions of rows) this is the 145 s → ms fix. Migration applied cleanly through the real override path locally (`_sqlx_migrations.success = t`); backend recompiled and restarted healthy.

## Scope

Addresses only the `parent_job` pattern (the top offender). The `args @>` GIN index and the `runnable_path + started_at` (Pattern C) items from the slow-query analysis are intentionally out of scope here.

## Test plan

- [ ] On a DB with a populated `v2_job`, run migrations and confirm `\d v2_job` shows a valid (not `INVALID`) `ix_v2_job_parent_job`
- [ ] `EXPLAIN` `/api/w/{ws}/jobs/completed/list?parent_job=<id>` and `/jobs/list?parent_job=<id>` and confirm an index scan on `ix_v2_job_parent_job` rather than a workspace-wide scan
- [ ] Open a flow run in the UI and confirm child jobs still list correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a partial index on `v2_job(parent_job, created_at DESC)` to speed up listing child jobs. Converts the top slow query on `/jobs/list` and `/jobs/completed/list` with `parent_job` filters into a fast index scan.

- **Migration**
  - Adds `20260710073406_index_v2_job_parent_job` to create `ix_v2_job_parent_job` where `parent_job IS NOT NULL`.
  - Registers in `windmill-api/src/db.rs` `OVERRIDDEN_MIGRATIONS` to run as `CREATE INDEX CONCURRENTLY` (online, no table lock).

<sup>Written for commit 374daee50bceaddd56405e636cfe30d2e89e7f6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

