### PR TITLE
perf: skip redundant retry-chain job query for successful top-level scripts

### DIFF
--- a/frontend/src/lib/components/runs/ScriptRetryChain.svelte
+++ b/frontend/src/lib/components/runs/ScriptRetryChain.svelte
@@ -4,6 +4,7 @@
 	import { goto } from '$lib/navigation'
 	import { workspaceStore } from '$lib/stores'
 	import { resource } from 'runed'
+	import { canSkipRetryChainQuery } from './scriptRetryChain'
 
 	let { job }: { job: Job } = $props()
 
@@ -65,6 +66,11 @@
 			// first attempt (the chain root, itself a script). Flow steps also carry
 			// `parent_job`, but their parent is a flow — a non-script root means flow step.
 			if (job.job_kind !== 'script') return { retries: [], handlers: [] }
+
+			// Skip the child-job query when it provably has nothing to show (see
+			// canSkipRetryChainQuery) — this runs on every script run view.
+			if (canSkipRetryChainQuery(job)) return { retries: [], handlers: [] }
+
 			const root = job.parent_job ?? job.id
 			const rootJob = job.id === root ? job : await JobService.getJob({ workspace: ws, id: root })
 			if (rootJob?.job_kind !== 'script') return { retries: [], handlers: [] }

--- a/frontend/src/lib/components/runs/scriptRetryChain.test.ts
+++ b/frontend/src/lib/components/runs/scriptRetryChain.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import type { Job } from '$lib/gen'
+import { canSkipRetryChainQuery } from './scriptRetryChain'
+
+// Minimal CompletedJob/QueuedJob factories — canSkipRetryChainQuery only reads
+// type/parent_job/success/schedule_path, so the rest is cast away.
+function completed(overrides: Partial<Job> = {}): Job {
+	return {
+		type: 'CompletedJob',
+		id: 'j1',
+		job_kind: 'script',
+		success: true,
+		...overrides
+	} as Job
+}
+
+function queued(overrides: Partial<Job> = {}): Job {
+	return { type: 'QueuedJob', id: 'j1', job_kind: 'script', ...overrides } as Job
+}
+
+describe('canSkipRetryChainQuery', () => {
+	it('skips a successful, non-scheduled, top-level script (nothing to show)', () => {
+		expect(canSkipRetryChainQuery(completed())).toBe(true)
+	})
+
+	it('does NOT skip a failed script — it may have retry attempts', () => {
+		expect(canSkipRetryChainQuery(completed({ success: false }))).toBe(false)
+	})
+
+	it('does NOT skip a chain member (parent_job set) — e.g. a successful final retry', () => {
+		expect(canSkipRetryChainQuery(completed({ parent_job: 'root' }))).toBe(false)
+	})
+
+	it('does NOT skip a schedule-triggered success — it may have a recovery handler', () => {
+		expect(canSkipRetryChainQuery(completed({ schedule_path: 'f/s/daily' }))).toBe(false)
+	})
+
+	it('does NOT skip a still-running (queued) job — outcome not yet known', () => {
+		expect(canSkipRetryChainQuery(queued({ running: true }))).toBe(false)
+	})
+})

--- a/frontend/src/lib/components/runs/scriptRetryChain.ts
+++ b/frontend/src/lib/components/runs/scriptRetryChain.ts
@@ -1,0 +1,18 @@
+import type { Job } from '$lib/gen'
+
+/**
+ * A successful, non-scheduled, top-level script can have neither retry attempts
+ * (retries only spawn after a failure, so the first attempt would not be
+ * `success`) nor schedule handlers (they only fire for schedule triggers, i.e.
+ * when `schedule_path` is set). Its child-job (`parent_job = ?`) query would
+ * always come back empty, so it can be skipped — this runs on every script run
+ * view, so avoiding the round-trip on the common success path matters.
+ */
+export function canSkipRetryChainQuery(job: Job): boolean {
+	return (
+		job.type === 'CompletedJob' &&
+		job.parent_job == null &&
+		job.success === true &&
+		job.schedule_path == null
+	)
+}


### PR DESCRIPTION
## Summary

Follow-up to #10034. On every **script run-detail view**, `ScriptRetryChain.svelte` fires `JobService.listJobs({ parentJob })` (the `parent_job = ?` query #10034 indexed) to look for retry attempts and schedule handlers. For the common case — a script that **succeeded on the first try and wasn't schedule-triggered** — that query can only ever come back empty, yet it still costs an API round-trip (plus a follow-up `getJob`) on every such page load.

This adds a guard that skips the query when it provably has nothing to return.

## Changes

- **`scriptRetryChain.ts`** (new) — pure helper `canSkipRetryChainQuery(job)`: returns `true` only for a `CompletedJob` that is top-level (`parent_job == null`), succeeded (`success === true`), and non-scheduled (`schedule_path == null`).
  - Retry attempts only spawn *after a failure*, so a successful first attempt has none.
  - Schedule handlers (error/recovery) only fire for schedule triggers; `schedule_path` is non-null iff schedule-triggered (backend derives it as `CASE WHEN trigger_kind='schedule' THEN trigger END`).
- **`ScriptRetryChain.svelte`** — calls the helper and early-returns `{ retries: [], handlers: [] }` before the `listJobs` call.
- **`scriptRetryChain.test.ts`** (new) — unit tests for all five decision cases.

## Correctness (must-NOT-skip cases, all covered by tests)

- Failed job → may have retry attempts → not skipped
- Successful chain member (`parent_job` set, e.g. a final retry) → not skipped
- Schedule-triggered success → may have a recovery/success handler → not skipped
- Running/queued job → outcome unknown → not skipped

## No visible UI change

The skipped case renders **nothing either way** — before this change the query simply returned empty and the widget showed no retry/handler rows. The only observable difference is the absence of an unnecessary network request, so there is no UI to screenshot.

## Test plan

- [x] `vitest run scriptRetryChain.test.ts` — 5/5 pass
- [x] `svelte-autofixer` clean; type-check adds 0 errors in the changed files
- [ ] Live browser check (network panel): open a successful non-scheduled top-level script run → no `listJobs?parentJob=` request; open a schedule-triggered success that had a recovery handler → handler link still appears.

> **Note:** the live browser check above is **not yet done** — `origin/main`'s backend currently fails to compile in the dev env (`windmill-api-workspaces/src/datatable_migrations.rs`, unrelated to this change), so the dev server has no backend to drive. The guard logic is fully covered by the unit tests in the meantime; I'll complete the network-panel check once main is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the retry-chain child-job query on script run pages for successful, non-scheduled top-level scripts to avoid an unnecessary network round-trip. No UI change.

- **Performance**
  - Added `canSkipRetryChainQuery(job)` and early return in `ScriptRetryChain.svelte` to bypass a `parent_job` query that would always be empty.
  - Applies only to Completed, top-level, successful, non-scheduled scripts; includes unit tests in `scriptRetryChain.test.ts`.

<sup>Written for commit 11b92bfb82efad9a256bc39090c992791e16ab03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

