### PR TITLE
fix(frontend): show optimistic user message and fork-creation label before beforeSend

### DIFF
--- a/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/AIChatDisplay.svelte
@@ -636,13 +636,15 @@ the panel, or the Escape-to-stop focus check would wrongly reject them. -->
 							{:else}
 								<ChatTypingIndicator
 									loading={aiChatManager.loading}
-									label={aiChatManager.compacting
-										? 'Compacting conversation'
-										: aiChatManager.currentReasoningActive &&
-											  !aiChatManager.currentReply &&
-											  !aiChatManager.currentReasoning
-											? 'Thinking'
-											: undefined}
+									label={aiChatManager.loadingLabel
+										? aiChatManager.loadingLabel
+										: aiChatManager.compacting
+											? 'Compacting conversation'
+											: aiChatManager.currentReasoningActive &&
+												  !aiChatManager.currentReply &&
+												  !aiChatManager.currentReasoning
+												? 'Thinking'
+												: undefined}
 								/>
 							{/if}
 						</div>

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -1902,10 +1902,10 @@ export class AIChatManager {
 		}
 	}
 
-	// Optional pre-flight hook called once per send, after validation but
-	// before any UI state mutates or backend calls go out. Sessions use
-	// this to commit/materialise the workspace (creating a staged fork via
-	// the API) so the first message targets the correct workspace.
+	// Optional pre-flight hook called once per send, after the user's message
+	// bubble + loading indicator are shown optimistically but before the request
+	// goes out. Sessions use this to commit/materialise the workspace (creating a
+	// staged fork via the API) so the first message targets the correct workspace.
 	beforeSend?: () => Promise<void> | void
 	afterFirstTurnSaved?: () => Promise<void> | void
 
@@ -1981,6 +1981,12 @@ export class AIChatManager {
 		const pastes = options.pastes ?? []
 		const optimisticIndex = this.displayMessages.length
 		this.loading = true
+		// Create the abort controller before the (possibly slow) beforeSend pre-flight,
+		// not after: the loading indicator below exposes Stop/Escape during "Creating
+		// workspace fork...", and those call cancel() → abortController.abort(). Without a
+		// controller here that abort would hit nothing and the request would still fire
+		// once the pre-flight resolves; the pre-flight-cancel check after beforeSend honours it.
+		this.abortController = new AbortController()
 		this.displayMessages = [
 			...this.displayMessages,
 			{
@@ -1990,6 +1996,13 @@ export class AIChatManager {
 				index: this.messages.length // matching with actual messages index. not -1 because it's not yet added to the messages array
 			}
 		]
+		// Undo the optimistic bubble + loading/label. Shared by the beforeSend-failure and
+		// pre-flight-cancel paths below; the input keeps the message text either way.
+		const rollbackOptimisticSend = () => {
+			this.displayMessages = this.displayMessages.filter((_, i) => i !== optimisticIndex)
+			this.loading = false
+			this.loadingLabel = undefined
+		}
 		if (this.beforeSend) {
 			try {
 				await this.beforeSend()
@@ -1999,11 +2012,7 @@ export class AIChatManager {
 				// silently target the wrong workspace (typically the parent), so
 				// abort and tell the user — their message text stays in the input.
 				console.error('AIChatManager beforeSend hook failed', e)
-				// Roll back the optimistic bubble + loading state; the input still
-				// holds the message text so the user can retry.
-				this.displayMessages = this.displayMessages.filter((_, i) => i !== optimisticIndex)
-				this.loading = false
-				this.loadingLabel = undefined
+				rollbackOptimisticSend()
 				sendUserToast(
 					`Could not prepare the session before sending: ${
 						e instanceof Error ? e.message : String(e)
@@ -2017,6 +2026,12 @@ export class AIChatManager {
 		// committed workspace before the system prompt is sent.
 		if (this.mode === AIMode.GLOBAL) {
 			await this.refreshGlobalSkills(this.operatingWorkspace ?? '')
+		}
+		// Stop/Escape pressed during the beforeSend pre-flight aborted this send: roll
+		// back the optimistic turn and don't fire the request.
+		if (this.abortController.signal.aborted) {
+			rollbackOptimisticSend()
+			return false
 		}
 		// Declared outside `try` so the catch can recover what the loop produced
 		// before a failure: the structured messages and the latest streamed text
@@ -2036,9 +2051,8 @@ export class AIChatManager {
 			if (this.mode === AIMode.SCRIPT || this.mode === AIMode.FLOW) {
 				this.contextManager?.updateContextOnRequest(options)
 			}
-			// loading was set optimistically before beforeSend, above.
+			// loading + abortController were set optimistically before beforeSend, above.
 			this.#automaticScroll = true
-			this.abortController = new AbortController()
 
 			const model = tryGetCurrentModel()
 			if (model) {

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -349,6 +349,11 @@ export class AIChatManager {
 	// True while the summarization round-trip is in flight, so the UI can show a
 	// "Compacting conversation" label on the processing indicator.
 	compacting = $state(false)
+	// General-purpose label for the processing indicator, set by a beforeSend hook
+	// to describe pre-flight work (e.g. "Creating workspace fork...") that runs
+	// before the request goes out. Takes precedence over the compacting/thinking
+	// labels while set; the hook clears it back to undefined when done.
+	loadingLabel = $state<string | undefined>(undefined)
 	autonomyMode = $state<AIAutonomyMode>(getPersistedAutonomyMode())
 	autoAcceptEditsAvailable = $derived(supportsAutoAcceptEdits(this.mode))
 	autoAcceptEditsActive = $derived(
@@ -1968,6 +1973,23 @@ export class AIChatManager {
 		} catch (e) {
 			console.error('Attached-files upkeep failed before send', e)
 		}
+		// beforeSend runs sequential API calls (session materialise + workspace fork
+		// creation) that can take seconds. Show the user bubble and loading indicator
+		// optimistically before it so the input doesn't just clear into a void.
+		// Context elements and the snapshot are attached after beforeSend (see below).
+		const isFirstUserTurn = !this.displayMessages.some((message) => message.role === 'user')
+		const pastes = options.pastes ?? []
+		const optimisticIndex = this.displayMessages.length
+		this.loading = true
+		this.displayMessages = [
+			...this.displayMessages,
+			{
+				role: 'user',
+				content: this.instructions,
+				pastes: pastes.length > 0 ? pastes : undefined,
+				index: this.messages.length // matching with actual messages index. not -1 because it's not yet added to the messages array
+			}
+		]
 		if (this.beforeSend) {
 			try {
 				await this.beforeSend()
@@ -1977,6 +1999,11 @@ export class AIChatManager {
 				// silently target the wrong workspace (typically the parent), so
 				// abort and tell the user — their message text stays in the input.
 				console.error('AIChatManager beforeSend hook failed', e)
+				// Roll back the optimistic bubble + loading state; the input still
+				// holds the message text so the user can retry.
+				this.displayMessages = this.displayMessages.filter((_, i) => i !== optimisticIndex)
+				this.loading = false
+				this.loadingLabel = undefined
 				sendUserToast(
 					`Could not prepare the session before sending: ${
 						e instanceof Error ? e.message : String(e)
@@ -1991,7 +2018,6 @@ export class AIChatManager {
 		if (this.mode === AIMode.GLOBAL) {
 			await this.refreshGlobalSkills(this.operatingWorkspace ?? '')
 		}
-		const isFirstUserTurn = !this.displayMessages.some((message) => message.role === 'user')
 		// Declared outside `try` so the catch can recover what the loop produced
 		// before a failure: the structured messages and the latest streamed text
 		// that never became one.
@@ -2010,7 +2036,7 @@ export class AIChatManager {
 			if (this.mode === AIMode.SCRIPT || this.mode === AIMode.FLOW) {
 				this.contextManager?.updateContextOnRequest(options)
 			}
-			this.loading = true
+			// loading was set optimistically before beforeSend, above.
 			this.#automaticScroll = true
 			this.abortController = new AbortController()
 
@@ -2042,21 +2068,22 @@ export class AIChatManager {
 				snapshot = { type: 'app', value: this.appAiChatHelpers!.snapshot() }
 			}
 
-			const pastes = options.pastes ?? []
-			this.displayMessages = [
-				...this.displayMessages,
-				{
-					role: 'user',
-					content: this.instructions,
-					contextElements:
-						this.mode === AIMode.SCRIPT || this.mode === AIMode.FLOW || this.mode === AIMode.GLOBAL
-							? oldSelectedContext
-							: undefined,
-					pastes: pastes.length > 0 ? pastes : undefined,
-					snapshot,
-					index: this.messages.length // matching with actual messages index. not -1 because it's not yet added to the messages array
-				}
-			]
+			// Attach the enrichments that are only known after beforeSend (selected
+			// context + snapshot) to the optimistic user message pushed before it.
+			this.displayMessages = this.displayMessages.map((m, i) =>
+				i === optimisticIndex
+					? {
+							...m,
+							contextElements:
+								this.mode === AIMode.SCRIPT ||
+								this.mode === AIMode.FLOW ||
+								this.mode === AIMode.GLOBAL
+									? oldSelectedContext
+									: undefined,
+							snapshot
+						}
+					: m
+			)
 			// For restoreUnsentTurn: the compact composer form (with paste tokens),
 			// not the expanded LLM text, plus the rollback anchor after the user turn.
 			const sentInstructions = this.instructions

--- a/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
+++ b/frontend/src/lib/components/copilot/chat/AIChatManager.svelte.ts
@@ -2027,11 +2027,22 @@ export class AIChatManager {
 		if (this.mode === AIMode.GLOBAL) {
 			await this.refreshGlobalSkills(this.operatingWorkspace ?? '')
 		}
-		// Stop/Escape pressed during the beforeSend pre-flight aborted this send: roll
-		// back the optimistic turn and don't fire the request.
+		// Stop/Escape during the beforeSend pre-flight aborted this send before any
+		// request went out. Mirror the main "cancelled before usable output" recovery:
+		// roll the optimistic turn back, then either hand off to a queued message (the
+		// input cleared the composer on send, so a deliberate cancel with a queued
+		// message auto-sends it) or restore this prompt to the composer so it isn't lost.
 		if (this.abortController.signal.aborted) {
 			rollbackOptimisticSend()
-			return false
+			if (this.wasCancelledByUser() && this.queuedMessage) {
+				const next = this.queuedMessage
+				this.queuedMessage = ''
+				const accepted = await this.sendRequest({ instructions: next })
+				if (accepted === false) this.queuedMessage = next
+			} else {
+				this.aiChatInput?.restoreInstructions(this.instructions, pastes)
+			}
+			return true
 		}
 		// Declared outside `try` so the catch can recover what the loop produced
 		// before a failure: the structured messages and the latest streamed text

--- a/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionRuntime.svelte.ts
@@ -321,7 +321,11 @@ function createRuntime(session: Session): SessionRuntime {
 		materializeTransient(session.id)
 		// Session is now persisted → flush any linked files buffered while it was transient.
 		await manager.attachedFiles.flushPending()
+		// Fork creation is the slow part of the pre-flight; label the loading
+		// indicator so the user knows why the send is taking a moment.
+		manager.loadingLabel = 'Creating workspace fork...'
 		const committed = await commitSessionWorkspace(session.id, get(workspaceStore) ?? undefined)
+		manager.loadingLabel = undefined
 		// commitSessionWorkspace returns undefined only when the session did NOT
 		// commit to a workspace — most importantly when a staged fork failed to
 		// materialise (materializeFork is built to toast + return undefined rather


### PR DESCRIPTION
## Summary

In AI chat, `sendRequest` used to set `loading = true` and push the optimistic user message only **after** the `beforeSend()` hook completed. For forked sessions, `beforeSend` runs several sequential API calls (materialize the transient session, flush pending files, create the workspace fork via `commitSessionWorkspace`, load copilot config) that take seconds, while `AIChatInput` clears the textarea immediately. The result was a poor UX: the message text disappeared into a void with no bubble and no loading indicator until the fork finished.

This PR shows the user bubble and loading indicator **optimistically, before** `beforeSend`, and adds a general-purpose `loadingLabel` so the pre-flight step can explain itself ("Creating workspace fork...").

Fixes WIN-2150

## Changes

- **`AIChatManager.svelte.ts`**
  - Add `loadingLabel = $state<string | undefined>(undefined)` — a general-purpose label any `beforeSend` hook can set.
  - Move `this.loading = true` and the optimistic user-message push (text + pastes) to **before** `beforeSend()`. Context elements and the snapshot (only known after `beforeSend`) are attached to that same message afterwards via a `.map()` keyed on the captured index.
  - Move the `isFirstUserTurn` computation before the optimistic push so it still measures whether a *prior* user turn existed.
  - On `beforeSend` failure, roll back: remove the optimistic message, set `loading = false`, and clear `loadingLabel`.
- **`sessionRuntime.svelte.ts`**: set `manager.loadingLabel = 'Creating workspace fork...'` before `commitSessionWorkspace()` and clear it right after.
- **`AIChatDisplay.svelte`**: wire `loadingLabel` into the `ChatTypingIndicator` label ternary as the highest priority (before `compacting`/`Thinking`).

## Test plan

Verified end-to-end in the browser (Playwright), driving a forked AI session:

- [x] Sending the first message in a session that stages a fork immediately shows the user bubble **and** a "Creating workspace fork..." loading indicator while the fork is being created (fork request artificially delayed to observe the transient state).
- [x] On a simulated fork-creation failure, the optimistic bubble and loading indicator are rolled back cleanly (no orphaned bubble/spinner), and the session reverts to its previous target.
- [x] `npm run check` passes (the single reported error is pre-existing in `utils_workspace_deploy.ts`, unrelated to this change).

## Screenshots

**Optimistic user bubble + "Creating workspace fork..." indicator, shown during fork creation (before the request goes out):**

![fork-creating-label-2](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/hugo/win-2150-show-optimistic-user-message-and-fork-creation-label-before/1783677176-fork-creating-label-2.png)

**Rollback on fork-creation failure — optimistic bubble and spinner removed:**

![fork-fail-rollback](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/hugo/win-2150-show-optimistic-user-message-and-fork-creation-label-before/1783677179-fork-fail-rollback.png)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the user’s message and spinner immediately when sending, even during pre‑flight. Adds a `loadingLabel` for “Creating workspace fork...”, and makes Stop/Escape cancel before the request while restoring the prompt or auto‑sending a queued message; fixes WIN-2150.

- **Bug Fixes**
  - Push the optimistic user message and set `loading` before `beforeSend` in `AIChatManager.svelte.ts`.
  - Create `abortController` before `beforeSend`; Stop/Escape now cancel during pre‑flight, roll back the UI, and restore the prompt or hand off a queued message.
  - Attach context and snapshot after `beforeSend` to the same optimistic message; roll back message/`loading`/`loadingLabel` on failure or cancel.

- **New Features**
  - Add `loadingLabel` to `AIChatManager` for pre‑flight status text.
  - Set `loadingLabel` to “Creating workspace fork...” around `commitSessionWorkspace()` in `sessionRuntime.svelte.ts`, and show it with highest priority in `AIChatDisplay.svelte`.

<sup>Written for commit bc34038f5c8e342b8e79e82b9141bde86236d041. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

