### PR TITLE
fix(security): remove git from Deno sandbox allow-run (GHSA-gj6h-vw66-mr8f)

### DIFF
--- a/backend/windmill-worker/src/deno_executor.rs
+++ b/backend/windmill-worker/src/deno_executor.rs
@@ -481,7 +481,11 @@ try {{
             args.push("--allow-write=./");
             args.push("--allow-env");
             args.push("--allow-import");
-            args.push("--allow-run=git,/usr/bin/chromium");
+            // git is intentionally NOT in this allowlist: git can be coerced into
+            // spawning /bin/sh via hook configs (e.g. `-c core.fsmonitor=<cmd>`),
+            // which escapes Deno's permission model and defeats the sandbox
+            // (GHSA-gj6h-vw66-mr8f). Only allow the specific chromium binary.
+            args.push("--allow-run=/usr/bin/chromium");
         } else {
             args.push("-A");
         }


### PR DESCRIPTION
## Summary

Fixes part of a critical (CVSS 9.9) Deno sandbox escape reported in **GHSA-gj6h-vw66-mr8f**.

The `// sandbox` annotation restricts Deno scripts to `--allow-run=git,/usr/bin/chromium`. `git` can be coerced into spawning `/bin/sh` via hook configuration — e.g. `git -c core.fsmonitor='/bin/sh -c <cmd>' status` — and that subprocess is launched by git itself, so it is invisible to Deno's permission model. Any authenticated user with script-execution permission could therefore run arbitrary OS commands as `root` inside the worker container, defeating the sandbox.

This PR removes `git` from the allowlist. git was originally allowed for git-sync-adjacent tooling that no longer needs it in the Deno runtime, and git-sync itself is unaffected (it runs as a normal full-permission sync script, not under `// sandbox`).

The advisory's alternative (inject `-c core.fsmonitor=false -c core.hooksPath=/dev/null`) does **not** apply: the exploit runs from the user's own script, which controls the git argv, so any injected hardening flag is overridden (git's last-`-c`-wins).

> **Note:** `/usr/bin/chromium` in the same allowlist is an *equivalent* escape (via `--renderer-cmd-prefix` / `--gpu-launcher`). It is removed in the follow-up PR so each vector is reviewable independently.

## Changes

- `backend/windmill-worker/src/deno_executor.rs`: `--allow-run=git,/usr/bin/chromium` → `--allow-run=/usr/bin/chromium`.

## Test plan

Verified against the advisory PoC (a `// sandbox` Deno script) on a running worker:

- Before: `git -c core.fsmonitor=... status` executed `/bin/sh` and returned `uid=0(root)`.
- After: `Requires run access to "git", run again with the --allow-run flag` — the git escape is closed.
- Direct `/bin/sh` remains blocked.

Fixes WIN-2151