### PR TITLE
fix(security): remove chromium from Deno sandbox allow-run (GHSA-gj6h-vw66-mr8f)

### DIFF
--- a/backend/windmill-worker/src/deno_executor.rs
+++ b/backend/windmill-worker/src/deno_executor.rs
@@ -481,11 +481,15 @@ try {{
             args.push("--allow-write=./");
             args.push("--allow-env");
             args.push("--allow-import");
-            // git is intentionally NOT in this allowlist: git can be coerced into
-            // spawning /bin/sh via hook configs (e.g. `-c core.fsmonitor=<cmd>`),
-            // which escapes Deno's permission model and defeats the sandbox
-            // (GHSA-gj6h-vw66-mr8f). Only allow the specific chromium binary.
-            args.push("--allow-run=/usr/bin/chromium");
+            // Deliberately NO --allow-run: unlike every other language, deno jobs
+            // are never nsjail-wrapped, so the Deno permission model is the *only*
+            // sandbox boundary. Any allowed binary that can spawn a subprocess
+            // therefore escapes it entirely — git via hook configs
+            // (`-c core.fsmonitor=<cmd>`) and chromium via subprocess-launcher flags
+            // (`--renderer-cmd-prefix` / `--gpu-launcher`) both coerce /bin/sh and
+            // defeat the guarantee (GHSA-gj6h-vw66-mr8f). Omitting the flag denies
+            // all subprocess execution. Admins who accept the risk (e.g. puppeteer)
+            // can re-add specific binaries via DENO_FLAGS.
         } else {
             args.push("-A");
         }


### PR DESCRIPTION
## Summary


The advisory reports `git` as the escape, but `/usr/bin/chromium` — the other entry in the sandbox `--allow-run` allowlist — is an **equivalent, unconditional escape**. Chromium accepts subprocess-launcher flags that specify a command to run when it spawns its child processes:

- `--renderer-cmd-prefix=<cmd>` — prefixed onto the renderer launch
- `--gpu-launcher=<cmd>` — used to launch the GPU process
- (also `--utility-cmd-prefix`, `--browser-subprocess-path`, …)

A `// sandbox` script controls chromium's full argv and can write a launcher into `./` (`--allow-write=./` is granted), so it runs arbitrary OS commands — same root RCE as the git vector.

### Why removal, and why unconditionally

The Deno runtime is the **one** language Windmill never wraps in nsjail (there is no `run.deno.config.proto`; every other language has one). So for deno jobs the Deno permission model is the *entire* sandbox — there is no OS-level containment to fall back on, regardless of `DISABLE_NSJAIL`. Handing that sandbox any subprocess-spawning binary is therefore an unconditional escape, and the class is open-ended (most rich binaries accept some "run this subprocess" config). Removing chromium leaves the restricted path with **no** `--allow-run`, denying all subprocess execution.

Admins who explicitly accept the risk (e.g. puppeteer / headless-chrome automation) can still re-add specific binaries via `DENO_FLAGS`; such automation is better run on a dedicated unrestricted worker than inside a sandbox that cannot contain it.

## Changes

- `backend/windmill-worker/src/deno_executor.rs`: drop `--allow-run=/usr/bin/chromium` from the restricted sandbox path (no `--allow-run` emitted).

> Stacked on #10038 (base branch is that PR's branch) so the diff is chromium-only. Merge #10038 first, or squash-merge both.

## Test plan

Verified end-to-end against a `// sandbox` Deno PoC on a running worker.

**Before:** chromium `--renderer-cmd-prefix` pointed at a script written into `./` executed arbitrary commands (`uid=...` returned).

**After:**
```json
{ "chromium_renderer_prefix_exec": "(not created)",
  "stderr0": "BLOCKED: Requires run access to \"/usr/bin/chromium\", run again with the --allow-run flag" }
```

Both the chromium and (from #10038) git escapes are closed; direct `/bin/sh` remains blocked.

### Defense-in-depth (not in this PR)
Root cause is that `// sandbox` advertises a boundary backed only by Deno permissions with `DISABLE_NSJAIL=true` by default. A worthwhile follow-up is defaulting `DISABLE_NSJAIL=false` in the official docker-compose (advisory rec #3) so any future escape is contained at the OS level.

Fixes WIN-2151


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `--allow-run=/usr/bin/chromium` and now emit no `--allow-run` in the Deno restricted sandbox, closing the GHSA-gj6h-vw66-mr8f escapes and fixing WIN-2151. This blocks all subprocesses; admins can re-add specific binaries via `DENO_FLAGS` if needed.

<sup>Written for commit d6fa90cf6d818acb98c59f7425bc9eaed2473fe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



