### PR TITLE
fix(ci): unblock EE CUDA image build on trixie by allowing SHA1 for NVIDIA repo

### DIFF
--- a/docker/DockerfileCuda
+++ b/docker/DockerfileCuda
@@ -6,14 +6,22 @@ RUN apt-get update && apt-get install -y curl gnupg2
 RUN curl "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb" -o cuda.deb && \
   dpkg -i cuda.deb && rm cuda.deb
 
-RUN apt-get update -y && \
+# NVIDIA's CUDA apt repo signing key carries a SHA1 self-binding signature,
+# which the Debian trixie base image's Sequoia-based apt verifier (sqv) rejects
+# as of 2026-02-01, leaving the repo treated as unsigned. Re-enable SHA1 via a
+# scoped crypto policy applied only to the apt runs that touch the CUDA repo.
+RUN printf '[hash_algorithms.sha1]\ncollision_resistance = "always"\nsecond_preimage_resistance = "always"\n' > /etc/apt-nvidia-sqv-policy.toml
+
+RUN export SEQUOIA_CRYPTO_POLICY=/etc/apt-nvidia-sqv-policy.toml && \
+  apt-get update -y && \
   apt-get install -y --no-install-recommends \
   cuda-cudart-12-2 cuda-nvcc-12-2 cuda-nvrtc-12-2 \
   libcudnn8 libcublas-12-2 && \
   rm -rf /var/lib/apt/lists/*
 
 # Install FFmpeg if needed
-RUN apt-get update && \
+RUN export SEQUOIA_CRYPTO_POLICY=/etc/apt-nvidia-sqv-policy.toml && \
+    apt-get update && \
     apt-get install -y ffmpeg && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
The `build_ee_cuda` job started failing (e.g. [run 29098175209](https://github.com/windmill-labs/windmill/actions/runs/29098175209/job/86383819907)) with the NVIDIA CUDA apt repo treated as unsigned:

```
Err: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64  InRelease
  Sub-process /usr/bin/sqv returned an error code (1) ...
  Signing key on EB693B...863CC is not bound ... SHA1 is not considered secure since 2026-02-01
E: The repository '...' is not signed.
```

Root cause: `docker/DockerfileCuda` builds on the EE base image, which is now **Debian 13 (trixie)**. Trixie replaced GnuPG apt verification with Sequoia's `sqv`, whose default policy **rejects SHA1 signatures as of 2026-02-01**. NVIDIA's CUDA repo signing key carries a SHA1 self-binding signature, so `sqv` refuses it and `apt-get` aborts (exit 100). This is a purely external breakage surfaced by the bookworm→trixie migration crossing the SHA1 cutoff.

Upgrading to `cuda-keyring_1.1-1` does **not** help — it ships the same SHA1-bound key. The fix re-enables SHA1 via a **scoped** Sequoia crypto policy, applied only to the build-time `apt` runs that touch the NVIDIA repo (via `export SEQUOIA_CRYPTO_POLICY` inside each `RUN`), so the final image's runtime apt keeps the strict default policy and only SHA1 is re-permitted (SHA256/Ed25519 repos still verify normally).

## Changes
- `docker/DockerfileCuda`: write `/etc/apt-nvidia-sqv-policy.toml` re-enabling SHA1, and `export SEQUOIA_CRYPTO_POLICY` for the CUDA-package and ffmpeg `apt` runs (the ffmpeg `apt-get update` re-fetches the now-registered NVIDIA repo index, so it needs the policy too).

## Test plan
- [x] Reproduced the exact `sqv` failure on a minimal `debian:trixie` image
- [x] Confirmed `cuda-keyring_1.1-1` still fails (same SHA1-bound key)
- [x] Built the real `docker/DockerfileCuda` from the actual `ghcr.io/windmill-labs/windmill-ee:dev` base — succeeds
- [x] Verified in the resulting image: `cuda-cudart/nvcc/nvrtc-12-2`, `libcudnn8`, `libcublas-12-2` installed, `nvcc` present, `ffmpeg 7.1.5` working
- [ ] CI `build_ee_cuda` job goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks the EE CUDA image build on Debian 13 (trixie) by allowing SHA1 signatures for the NVIDIA CUDA apt repo during build only. Fixes `apt-get` failures where `sqv` treated the repo as unsigned.

- **Bug Fixes**
  - Add `/etc/apt-nvidia-sqv-policy.toml` and export `SEQUOIA_CRYPTO_POLICY` for the CUDA and `ffmpeg` `apt` runs in `docker/DockerfileCuda`.
  - Scope the relaxed SHA1 policy to those build steps only; the final image keeps the default strict crypto policy.

<sup>Written for commit 783133ef117b82b92201360834b17bdb6dea3580. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

