### PR TITLE
fix(frontend): show nested restart button for subflows nested in containers

### DIFF
--- a/frontend/src/lib/components/restartFromStepPath.test.ts
+++ b/frontend/src/lib/components/restartFromStepPath.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from 'vitest'
+import type { FlowModule } from '$lib/gen'
+import {
+	buildNestedRestartPath,
+	findStepPath,
+	parseExpandedSubflowId,
+	type ForloopGraphState,
+	type FlowStatusModuleLite
+} from './restartFromStepPath'
+
+// --- minimal FlowModule fixtures (findStepPath only reads type/modules/branches/parallel) ---
+const script = (id: string): FlowModule =>
+	({ id, value: { type: 'rawscript', language: 'bun', content: '', input_transforms: {} } }) as any
+const subflow = (id: string, path = 'f/x'): FlowModule =>
+	({ id, value: { type: 'flow', path } }) as any
+const forloop = (id: string, modules: FlowModule[], parallel = false): FlowModule =>
+	({
+		id,
+		value: { type: 'forloopflow', modules, iterator: { type: 'static', value: [] }, parallel }
+	}) as any
+const whileloop = (id: string, modules: FlowModule[]): FlowModule =>
+	({ id, value: { type: 'whileloopflow', modules, parallel: false } }) as any
+const branchone = (id: string, def: FlowModule[], branches: FlowModule[][]): FlowModule =>
+	({
+		id,
+		value: { type: 'branchone', default: def, branches: branches.map((m) => ({ modules: m })) }
+	}) as any
+const branchall = (id: string, branches: FlowModule[][], parallel = false): FlowModule =>
+	({
+		id,
+		value: { type: 'branchall', branches: branches.map((m) => ({ modules: m })), parallel }
+	}) as any
+
+function build(opts: {
+	selectedJobStep: string
+	rawFlowModules: FlowModule[]
+	flowStatusModules?: FlowStatusModuleLite[]
+	graphModuleStates?: Record<string, ForloopGraphState>
+	expandedSubflows?: Record<string, { modules: FlowModule[] }>
+}) {
+	return buildNestedRestartPath({
+		flowStatusModules: [],
+		graphModuleStates: {},
+		expandedSubflows: {},
+		...opts
+	})
+}
+
+describe('parseExpandedSubflowId', () => {
+	it('parses a multi-level subflow id', () => {
+		expect(parseExpandedSubflowId('subflow:a:b:leaf')).toEqual({
+			subflowSteps: ['a', 'b'],
+			leaf: 'leaf'
+		})
+	})
+	it('returns undefined for a bare id or a single segment', () => {
+		expect(parseExpandedSubflowId('leaf')).toBeUndefined()
+		expect(parseExpandedSubflowId('subflow:leaf')).toBeUndefined()
+	})
+})
+
+describe('buildNestedRestartPath', () => {
+	it('pure nested subflows: top is the outer subflow, no iterations', () => {
+		const r = build({
+			selectedJobStep: 'subflow:stop:smid:a',
+			rawFlowModules: [subflow('stop', 'f/mid')],
+			expandedSubflows: {
+				stop: { modules: [subflow('smid', 'f/leaf')] },
+				'subflow:stop:smid': { modules: [script('a')] }
+			}
+		})
+		expect(r).toEqual({
+			topStepId: 'stop',
+			topBranchOrIterationN: undefined,
+			path: [{ step_id: 'smid' }, { step_id: 'a' }],
+			iterationCounts: {}
+		})
+	})
+
+	it('subflow nested inside a ForLoop: recovers the ForLoop as the top step (the reported bug)', () => {
+		const r = build({
+			selectedJobStep: 'subflow:s:a',
+			rawFlowModules: [forloop('L', [subflow('s', 'f/leaf')])],
+			expandedSubflows: { s: { modules: [script('a')] } },
+			graphModuleStates: { L: { selectedForloopIndex: 1, flow_jobs: ['j0', 'j1'] } }
+		})
+		expect(r).toEqual({
+			topStepId: 'L',
+			topBranchOrIterationN: 1,
+			path: [{ step_id: 's' }, { step_id: 'a' }],
+			iterationCounts: { top: 2 }
+		})
+	})
+
+	it('ForLoop sitting between two subflow boundaries is recovered as an inner path step', () => {
+		const r = build({
+			selectedJobStep: 'subflow:sa:sb:a',
+			rawFlowModules: [subflow('sa', 'f/mid')],
+			expandedSubflows: {
+				sa: { modules: [forloop('L', [subflow('sb', 'f/leaf')])] },
+				'subflow:sa:sb': { modules: [script('a')] }
+			},
+			graphModuleStates: { 'subflow:sa:L': { selectedForloopIndex: 0, flow_jobs: ['j0', 'j1'] } }
+		})
+		expect(r).toEqual({
+			topStepId: 'sa',
+			topBranchOrIterationN: undefined,
+			path: [{ step_id: 'L', branch_or_iteration_n: 0 }, { step_id: 'sb' }, { step_id: 'a' }],
+			iterationCounts: { 'inner-0': 2 }
+		})
+	})
+
+	it('leaf directly inside a top-level ForLoop (no subflow)', () => {
+		const r = build({
+			selectedJobStep: 'x',
+			rawFlowModules: [forloop('L', [script('x')])],
+			graphModuleStates: { L: { selectedForloopIndex: 2, flow_jobs: ['a', 'b', 'c'] } }
+		})
+		expect(r).toEqual({
+			topStepId: 'L',
+			topBranchOrIterationN: 2,
+			path: [{ step_id: 'x' }],
+			iterationCounts: { top: 3 }
+		})
+	})
+
+	it('the leaf itself is a ForLoop: exposes its own iteration too', () => {
+		const r = build({
+			selectedJobStep: 'M',
+			rawFlowModules: [forloop('L', [forloop('M', [script('y')])])],
+			graphModuleStates: {
+				L: { selectedForloopIndex: 0, flow_jobs: ['a'] },
+				M: { selectedForloopIndex: 1, flow_jobs: ['p', 'q'] }
+			}
+		})
+		expect(r).toEqual({
+			topStepId: 'L',
+			topBranchOrIterationN: 0,
+			path: [{ step_id: 'M', branch_or_iteration_n: 1 }],
+			iterationCounts: { top: 1, 'inner-0': 2 }
+		})
+	})
+
+	it('BranchOne top step: no iteration sent (backend locks the branch from the run)', () => {
+		const r = build({
+			selectedJobStep: 'x',
+			rawFlowModules: [branchone('BO', [script('d')], [[script('x')]])],
+			flowStatusModules: [{ id: 'BO', branch_chosen: { type: 'branch', branch: 0 } }]
+		})
+		expect(r).toEqual({
+			topStepId: 'BO',
+			topBranchOrIterationN: undefined,
+			path: [{ step_id: 'x' }],
+			iterationCounts: {}
+		})
+	})
+
+	it('BranchOne default branch taken and leaf is in the default branch', () => {
+		const r = build({
+			selectedJobStep: 'd',
+			rawFlowModules: [branchone('BO', [script('d')], [[script('x')]])],
+			flowStatusModules: [{ id: 'BO', branch_chosen: { type: 'default' } }]
+		})
+		expect(r?.topStepId).toBe('BO')
+		expect(r?.path).toEqual([{ step_id: 'd' }])
+	})
+
+	it('rejects a leaf inside a BranchOne branch the original run did not take', () => {
+		const r = build({
+			selectedJobStep: 'x',
+			rawFlowModules: [branchone('BO', [script('d')], [[script('x')]])],
+			// Original run took the default, not branch 0 (which contains x).
+			flowStatusModules: [{ id: 'BO', branch_chosen: { type: 'default' } }]
+		})
+		expect(r).toBeNull()
+	})
+
+	it('rejects unsupported containers: parallel ForLoop, BranchAll, WhileLoop', () => {
+		expect(
+			build({ selectedJobStep: 'x', rawFlowModules: [forloop('L', [script('x')], true)] })
+		).toBeNull()
+		expect(
+			build({ selectedJobStep: 'x', rawFlowModules: [branchall('B', [[script('x')]])] })
+		).toBeNull()
+		expect(
+			build({ selectedJobStep: 'x', rawFlowModules: [whileloop('W', [script('x')])] })
+		).toBeNull()
+	})
+
+	it('returns null for a top-level step (handled by the top-level path)', () => {
+		expect(build({ selectedJobStep: 'top', rawFlowModules: [script('top')] })).toBeNull()
+	})
+
+	it('falls back to a flat path when a subflow’s modules are not loaded yet', () => {
+		const r = build({
+			selectedJobStep: 'subflow:stop:smid:a',
+			rawFlowModules: [subflow('stop', 'f/mid')],
+			expandedSubflows: {} // stop not expanded → modules unavailable at level 1
+		})
+		expect(r).toEqual({
+			topStepId: 'stop',
+			topBranchOrIterationN: undefined,
+			path: [{ step_id: 'smid' }, { step_id: 'a' }],
+			iterationCounts: {}
+		})
+	})
+})
+
+describe('findStepPath', () => {
+	it('locates a leaf inside a ForLoop and reports the ancestor chain', () => {
+		const p = findStepPath([forloop('L', [script('x')])], 'x')
+		expect(p?.target.id).toBe('x')
+		expect(p?.ancestors).toEqual([{ stepId: 'L', type: 'forloopflow', parallel: false }])
+	})
+	it('does not cross subflow boundaries', () => {
+		expect(findStepPath([subflow('s')], 'a')).toBeUndefined()
+	})
+})

--- a/frontend/src/lib/components/restartFromStepPath.test.ts
+++ b/frontend/src/lib/components/restartFromStepPath.test.ts
@@ -204,6 +204,26 @@ describe('buildNestedRestartPath', () => {
 			iterationCounts: {}
 		})
 	})
+
+	it('flat fallback still ends at the leaf when the deepest modules are loaded but stale', () => {
+		// smid IS expanded but its cached modules don't contain the leaf `a`
+		// (stale cache). The chain must still end at `a`, never at the `smid`
+		// subflow boundary.
+		const r = build({
+			selectedJobStep: 'subflow:stop:smid:a',
+			rawFlowModules: [subflow('stop', 'f/mid')],
+			expandedSubflows: {
+				stop: { modules: [subflow('smid', 'f/leaf')] },
+				'subflow:stop:smid': { modules: [script('z')] } // no `a`
+			}
+		})
+		expect(r).toEqual({
+			topStepId: 'stop',
+			topBranchOrIterationN: undefined,
+			path: [{ step_id: 'smid' }, { step_id: 'a' }],
+			iterationCounts: {}
+		})
+	})
 })
 
 describe('findStepPath', () => {

--- a/frontend/src/lib/components/restartFromStepPath.ts
+++ b/frontend/src/lib/components/restartFromStepPath.ts
@@ -230,8 +230,12 @@ export function buildNestedRestartPath(opts: {
 		}
 		const path = findStepPath(modules, target)
 		if (!path) {
+			// Target missing from these (loaded) modules — a stale/inconsistent
+			// cache. Same flat best-effort continuation as the not-loaded case:
+			// remaining boundaries then the leaf, so the chain always ends at the
+			// real leaf (never a subflow boundary) and the backend can validate.
 			for (let j = i; j < boundaries.length; j++) chain.push({ step_id: boundaries[j] })
-			if (!isLeafLevel) chain.push({ step_id: leaf })
+			chain.push({ step_id: leaf })
 			break
 		}
 		// Gate on unsupported containers along the way. BranchOne branch-mismatch

--- a/frontend/src/lib/components/restartFromStepPath.ts
+++ b/frontend/src/lib/components/restartFromStepPath.ts
@@ -1,5 +1,7 @@
 import type { FlowModule } from '$lib/gen'
 
+export type NestedRestartStep = { step_id: string; branch_or_iteration_n?: number }
+
 export type ContainerType = 'branchone' | 'forloopflow' | 'flow' | 'whileloopflow' | 'branchall'
 
 export type AncestorEntry = {
@@ -106,4 +108,170 @@ export function parseExpandedSubflowId(
 	const leaf = parts[parts.length - 1]
 	const subflowSteps = parts.slice(0, -1)
 	return { subflowSteps, leaf }
+}
+
+/** Per-module display state the graph tracks; only the ForLoop bits matter here. */
+export type ForloopGraphState = { selectedForloopIndex?: number; flow_jobs?: unknown[] }
+/** Minimal shape of a top-level `flow_status.modules` entry we need. */
+export type FlowStatusModuleLite = {
+	id?: string
+	branch_chosen?: { type: 'branch' | 'default'; branch?: number }
+}
+
+export type NestedRestartResult = {
+	topStepId: string
+	topBranchOrIterationN: number | undefined
+	path: NestedRestartStep[]
+	/** ForLoop iteration counts keyed by the popup's field key: `'top'` for the
+	 * outer container, `inner-${n}` for `path[n]`. */
+	iterationCounts: Record<string, number>
+}
+
+/**
+ * True when the BranchOne ancestor's path branch (encoded as `branchIndex`,
+ * where -1 is the default branch and 0..N-1 is `branches[i]`) is the branch the
+ * original run actually took. If the user clicked a step inside a branch the run
+ * didn't take, that step never executed and a restart there is impossible.
+ *
+ * `undefined` status means the BranchOne isn't at the level whose `flow_status`
+ * we have (it lives on a child job we don't fetch) — permissive fallback: let
+ * the backend reject if needed.
+ */
+function branchOneMatchesOriginal(
+	flowStatusModules: FlowStatusModuleLite[] | undefined,
+	stepId: string,
+	branchIndex: number | undefined
+): boolean {
+	const status = flowStatusModules?.find((m) => m.id === stepId)
+	const chosen = status?.branch_chosen
+	if (!chosen) return status === undefined
+	const taken = chosen.type === 'default' ? -1 : (chosen.branch ?? -1)
+	return branchIndex === taken
+}
+
+/**
+ * Build the restart chain from a top-level container of the running flow down to
+ * the selected leaf, flattening BOTH kinds of nesting into one list:
+ *   - containers within a flow value (sequential ForLoop / BranchOne), recovered
+ *     by walking each level's modules with `findStepPath`
+ *   - subflow boundaries (`Flow{path}` steps), encoded in the graph node id as
+ *     `subflow:A:B:leaf`
+ *
+ * The graph node id records ONLY subflow boundaries, so a ForLoop/BranchOne
+ * sitting above or between them is invisible to `parseExpandedSubflowId`; walking
+ * each level recovers it. Without this, a subflow nested inside a ForLoop yields
+ * an outer subflow step that isn't a top-level module, and the restart button
+ * never appeared.
+ *
+ * Returns `null` when the step is top-level (caller handles that separately), the
+ * leaf can't be located, or an unsupported container (parallel ForLoop/BranchAll,
+ * WhileLoop, or a BranchOne branch the run didn't take) sits on the path.
+ */
+export function buildNestedRestartPath(opts: {
+	selectedJobStep: string
+	rawFlowModules: FlowModule[]
+	flowStatusModules: FlowStatusModuleLite[] | undefined
+	graphModuleStates: Record<string, ForloopGraphState>
+	expandedSubflows: Record<string, { modules: FlowModule[] }>
+}): NestedRestartResult | null {
+	const {
+		selectedJobStep,
+		rawFlowModules,
+		flowStatusModules,
+		graphModuleStates,
+		expandedSubflows
+	} = opts
+
+	const parse = parseExpandedSubflowId(selectedJobStep)
+	const boundaries = parse?.subflowSteps ?? []
+	const leaf = parse?.leaf ?? selectedJobStep
+
+	// Graph-state key prefix for level `i`: '' at the running flow, then
+	// `subflow:<boundaries[0..i-1]>:` once inside subflow boundary `i-1`. Only
+	// subflow boundaries contribute to the prefix (ForLoop/BranchOne don't),
+	// matching how the graph builds node ids.
+	const graphPrefixFor = (i: number): string =>
+		i === 0 ? '' : 'subflow:' + boundaries.slice(0, i).join(':') + ':'
+	// Graph node id of subflow boundary `i` (also its `expandedSubflows` key).
+	const boundaryNodeId = (i: number): string => graphPrefixFor(i) + boundaries[i]
+
+	// One entry per container/subflow step from the top-level container down to
+	// the leaf. `chain[0]` becomes the top-level restart step; the rest is the
+	// nested path. `counts` maps a chain index to that ForLoop's recorded
+	// iteration count.
+	const chain: NestedRestartStep[] = []
+	const counts: Record<number, number> = {}
+	const appendStep = (stepId: string, isForloop: boolean, graphPrefix: string) => {
+		const entry: NestedRestartStep = { step_id: stepId }
+		if (isForloop) {
+			// Default to the user's currently-open iteration; the popup surfaces
+			// every value for confirmation/editing before submit.
+			const key = graphPrefix + stepId
+			entry.branch_or_iteration_n = graphModuleStates[key]?.selectedForloopIndex ?? 0
+			counts[chain.length] = graphModuleStates[key]?.flow_jobs?.length ?? 0
+		}
+		chain.push(entry)
+	}
+
+	for (let i = 0; i <= boundaries.length; i++) {
+		const isLeafLevel = i === boundaries.length
+		const target = isLeafLevel ? leaf : boundaries[i]
+		const graphPrefix = graphPrefixFor(i)
+		// Level modules: the running flow at level 0, else the cached modules of
+		// the subflow boundary we descended through.
+		const modules = i === 0 ? rawFlowModules : expandedSubflows[boundaryNodeId(i - 1)]?.modules
+		if (!modules) {
+			// Subflow modules not loaded yet (leaf clicked before the subflow was
+			// expanded): append the remaining boundaries and the leaf as a flat
+			// best-effort continuation so the button still shows.
+			for (let j = i; j < boundaries.length; j++) chain.push({ step_id: boundaries[j] })
+			chain.push({ step_id: leaf })
+			break
+		}
+		const path = findStepPath(modules, target)
+		if (!path) {
+			for (let j = i; j < boundaries.length; j++) chain.push({ step_id: boundaries[j] })
+			if (!isLeafLevel) chain.push({ step_id: leaf })
+			break
+		}
+		// Gate on unsupported containers along the way. BranchOne branch-mismatch
+		// is only checkable at the running flow's own level, where we have its
+		// `flow_status`; deeper levels live on child jobs we don't fetch here, so
+		// stay permissive and let the backend reject a branch the run didn't take.
+		const blocked = path.ancestors.some(
+			(a) =>
+				a.type === 'branchall' ||
+				a.type === 'whileloopflow' ||
+				a.parallel === true ||
+				(a.type === 'branchone' &&
+					i === 0 &&
+					!branchOneMatchesOriginal(flowStatusModules, a.stepId, a.branchIndex))
+		)
+		if (blocked) return null
+		for (const a of path.ancestors) {
+			appendStep(a.stepId, a.type === 'forloopflow', graphPrefix)
+		}
+		// Subflow boundaries are `Flow{path}` steps (no iteration); only the leaf
+		// can itself be a ForLoop the user wants to restart at an iteration of.
+		appendStep(target, isLeafLevel && path.target.value.type === 'forloopflow', graphPrefix)
+	}
+
+	// Need at least a top container plus the leaf; a lone entry means the leaf is
+	// effectively top-level (handled by the caller's top-level path).
+	if (chain.length < 2) return null
+
+	const [top, ...rest] = chain
+	// Re-key iteration counts to the popup's field keys: chain index 0 → 'top',
+	// index k → 'inner-(k-1)' (matching `path[k-1]`).
+	const iterationCounts: Record<string, number> = {}
+	for (const [idxStr, n] of Object.entries(counts)) {
+		const idx = Number(idxStr)
+		iterationCounts[idx === 0 ? 'top' : `inner-${idx - 1}`] = n
+	}
+	return {
+		topStepId: top.step_id,
+		topBranchOrIterationN: top.branch_or_iteration_n,
+		path: rest,
+		iterationCounts
+	}
 }

--- a/frontend/src/lib/components/useNestedRestartState.svelte.ts
+++ b/frontend/src/lib/components/useNestedRestartState.svelte.ts
@@ -1,34 +1,9 @@
 import type { FlowModule, Job } from '$lib/gen'
 import type { GraphModuleState } from './graph'
-import { findStepPath, parseExpandedSubflowId, type AncestorEntry } from './restartFromStepPath'
+import { buildNestedRestartPath, type NestedRestartStep } from './restartFromStepPath'
 import { emptyString } from '$lib/utils'
 
-export type NestedRestartStep = { step_id: string; branch_or_iteration_n?: number }
-
-/**
- * Returns true when the BranchOne ancestor's path branch (the one containing the
- * selected leaf, encoded as `branchIndex` where -1 means default and 0..N-1
- * means `branches[i]`) is the same branch the original run took. If the user
- * clicked a step inside an `else` branch the original run didn't take, the
- * step never executed — restart there is impossible.
- *
- * Three states for the lookup:
- *   - `status === undefined`: the BranchOne isn't at the parent's top level, so
- *     it lives on a child job we don't fetch here (e.g. nested inside a ForLoop
- *     iteration). Permissive fallback — let the backend reject if needed.
- *   - `status` defined but `chosen === undefined`: the BranchOne IS at the top
- *     level but has no chosen branch (never executed / skipped / still
- *     waiting). The leaf can't have run either, so reject.
- *   - both defined: compare against `branchIndex`.
- */
-function branchOneAncestorMatchesOriginal(job: Job, ancestor: AncestorEntry): boolean {
-	if (ancestor.type !== 'branchone') return true
-	const status = job.flow_status?.modules?.find((m) => m.id === ancestor.stepId)
-	const chosen = status?.branch_chosen
-	if (!chosen) return status === undefined
-	const taken = chosen.type === 'default' ? -1 : (chosen.branch ?? -1)
-	return ancestor.branchIndex === taken
-}
+export type { NestedRestartStep }
 
 /**
  * Reactive state shared by the run page and the editor's flow preview to drive
@@ -117,150 +92,24 @@ export function useNestedRestartState(opts: {
 		// it as a dependency of this effect, causing `effect_update_depth_exceeded`
 		// because each write would reschedule the effect.
 		if (isTopLevel) return
-
-		// Inline-expanded subflow: id is `subflow:outerStep:[innerSubflow:...]<leaf>`.
-		// The graph adds the `subflow:` prefix only for subflow expansions, so each
-		// segment is a `Flow{path}` step. We walk the chain and, at the deepest
-		// subflow, recurse into its cached modules to detect BranchOne / ForLoop
-		// ancestors of the leaf so the chain captures locked branches and
-		// iteration indices for those too.
-		const subflowParse = parseExpandedSubflowId(selectedJobStep)
-		if (subflowParse && job.raw_flow?.modules) {
-			const top = job.raw_flow.modules.find((m) => m.id === subflowParse.subflowSteps[0])
-			if (top && top.value.type === 'flow') {
-				const innerPath: NestedRestartStep[] = []
-				// Intermediate subflow boundaries: each is itself a Flow{path}, no
-				// branch_or_iteration_n applies.
-				for (const seg of subflowParse.subflowSteps.slice(1)) {
-					innerPath.push({ step_id: seg })
-				}
-
-				// Look up the deepest subflow's modules in expandedSubflows. The graph
-				// stores them under the prefixed key (the graph node id used at that
-				// nesting level).
-				const deepestKey =
-					subflowParse.subflowSteps.length === 1
-						? subflowParse.subflowSteps[0]
-						: 'subflow:' + subflowParse.subflowSteps.join(':')
-				const deepestModules = expandedSubflows[deepestKey]?.modules
-
-				if (deepestModules) {
-					const path = findStepPath(deepestModules, subflowParse.leaf)
-					if (path) {
-						// Same gating as the parent-flow case, minus the BranchOne
-						// branch-mismatch check (subflow's flow_status isn't directly
-						// reachable here; backend will still reject if the branch
-						// wasn't taken). Parallel and unsupported containers are checked.
-						const blocked = path.ancestors.some(
-							(a) => a.type === 'branchall' || a.type === 'whileloopflow' || a.parallel === true
-						)
-						if (!blocked) {
-							// Inside the subflow, the graph state for ForLoop ancestors
-							// is keyed by the prefixed graph id. Build that key here so
-							// `selectedForloopIndex` and `flow_jobs.length` lookups land
-							// on the right entry (avoiding collisions with same-step-id
-							// loops in the parent flow — e.g. parent has `e` with 4 iters
-							// and the subflow also has `e` with 1 iter).
-							const subflowPrefix = 'subflow:' + subflowParse.subflowSteps.join(':') + ':'
-							const iterationFor = (stepId: string): number =>
-								graphModuleStates[subflowPrefix + stepId]?.selectedForloopIndex ?? 0
-							const iterCountFor = (stepId: string): number =>
-								graphModuleStates[subflowPrefix + stepId]?.flow_jobs?.length ?? 0
-							const counts: Record<string, number> = {}
-							// Top-level (parent) container is the subflow step `h` —
-							// not a ForLoop, no count.
-							for (let i = 0; i < path.ancestors.length; i++) {
-								const a = path.ancestors[i]
-								const entry: NestedRestartStep = { step_id: a.stepId }
-								if (a.type === 'forloopflow') {
-									entry.branch_or_iteration_n = iterationFor(a.stepId)
-									// Path key: each subflow boundary already contributes an
-									// inner-N entry above (subflow steps without iterations).
-									// Match the index that FlowRestartButton will use when
-									// rendering iteration fields.
-									counts[`inner-${innerPath.length}`] = iterCountFor(a.stepId)
-								}
-								innerPath.push(entry)
-							}
-							const leafEntry: NestedRestartStep = { step_id: subflowParse.leaf }
-							if (path.target.value.type === 'forloopflow') {
-								leafEntry.branch_or_iteration_n = iterationFor(subflowParse.leaf)
-								counts[`inner-${innerPath.length}`] = iterCountFor(subflowParse.leaf)
-							}
-							innerPath.push(leafEntry)
-							nestedRestartTopStepId = top.id
-							nestedRestartPath = innerPath
-							nestedPathIterationCounts = counts
-							nestedRestartSupported = true
-							return
-						}
-					}
-				}
-
-				// Fallback: subflow's modules not yet loaded (user clicked a step
-				// without expanding the subflow first), or leaf not found / blocked.
-				// Send a flat path; the backend will reject if the leaf is nested
-				// inside an unsupported container.
-				innerPath.push({ step_id: subflowParse.leaf })
-				nestedRestartTopStepId = top.id
-				nestedRestartPath = innerPath
-				nestedRestartSupported = true
-				return
-			}
-		}
-
-		// BranchOne / sequential ForLoop within the parent's own flow_value. Walk
-		// the tree to find the path; supported when ancestors are BranchOne /
-		// sequential ForLoop only — and only when each BranchOne ancestor's chosen
-		// branch in the original run actually contains the leaf, otherwise the
-		// step never executed and the backend would error.
 		if (!job.raw_flow?.modules) return
-		const path = findStepPath(job.raw_flow.modules, selectedJobStep)
-		if (!path || path.ancestors.length === 0) return
-		const blocked = path.ancestors.some(
-			(a) =>
-				a.type === 'branchall' ||
-				a.type === 'whileloopflow' ||
-				a.parallel === true ||
-				(a.type === 'branchone' && !branchOneAncestorMatchesOriginal(job, a))
-		)
-		if (blocked) return
 
-		// For each ForLoop ancestor, default to the user's currently-open iteration
-		// (`selectedForloopIndex`); fall back to 0. The popup surfaces every value
-		// for confirmation/editing before submit, so we never silently send a guess.
-		const iterationFor = (stepId: string): number =>
-			graphModuleStates[stepId]?.selectedForloopIndex ?? 0
-		const iterCountFor = (stepId: string): number =>
-			graphModuleStates[stepId]?.flow_jobs?.length ?? 0
-		const top = path.ancestors[0]
-		const inner = path.ancestors.slice(1)
-		const innerPath: NestedRestartStep[] = []
-		const counts: Record<string, number> = {}
-		for (const a of inner) {
-			const entry: NestedRestartStep = { step_id: a.stepId }
-			if (a.type === 'forloopflow') {
-				entry.branch_or_iteration_n = iterationFor(a.stepId)
-				counts[`inner-${innerPath.length}`] = iterCountFor(a.stepId)
-			}
-			innerPath.push(entry)
-		}
-		// If the SELECTED step is itself a ForLoop, include its iteration too so
-		// the popup exposes a selector for it.
-		const leafEntry: NestedRestartStep = { step_id: selectedJobStep }
-		if (path.target.value.type === 'forloopflow') {
-			leafEntry.branch_or_iteration_n = iterationFor(selectedJobStep)
-			counts[`inner-${innerPath.length}`] = iterCountFor(selectedJobStep)
-		}
-		innerPath.push(leafEntry)
+		// Flatten container nesting (ForLoop/BranchOne) and subflow boundaries into
+		// one chain from a top-level container down to the leaf. See
+		// `buildNestedRestartPath` for why walking each level is required.
+		const result = buildNestedRestartPath({
+			selectedJobStep,
+			rawFlowModules: job.raw_flow.modules,
+			flowStatusModules: job.flow_status.modules,
+			graphModuleStates,
+			expandedSubflows
+		})
+		if (!result) return
 
-		nestedRestartTopStepId = top.stepId
-		if (top.type === 'forloopflow') {
-			nestedRestartTopBranchOrIterationN = iterationFor(top.stepId)
-			counts['top'] = iterCountFor(top.stepId)
-		}
-		nestedRestartPath = innerPath
-		nestedPathIterationCounts = counts
+		nestedRestartTopStepId = result.topStepId
+		nestedRestartTopBranchOrIterationN = result.topBranchOrIterationN
+		nestedRestartPath = result.path
+		nestedPathIterationCounts = result.iterationCounts
 		nestedRestartSupported = true
 	})
 


### PR DESCRIPTION
## Summary

Fixes the "Re-start from" button not appearing on a deeply nested sub-node when a flow is run **by itself** and its subflow lives inside a container (ForLoop / BranchOne).

For a node reached through expanded subflows, the graph encodes its id as `subflow:A:B:leaf` — that id records **only the subflow boundaries** and drops any ForLoop/BranchOne sitting above or between them. The old logic assumed the outermost subflow segment (`A`) was a top-level module of the running flow:

```ts
const top = job.raw_flow.modules.find((m) => m.id === subflowParse.subflowSteps[0])
if (top && top.value.type === 'flow') { ... }
```

When the subflow is nested inside a ForLoop (`forloop L → subflow s → leaf`, id `subflow:s:a`), `s` is not a top-level module, so `top` is `undefined`, the block is skipped, the flat fallback can't match a `subflow:`-prefixed id, and `nestedRestartSupported` stays `false` → **no button**. (Nested inside a larger flow the outer subflow *is* top-level, which is why it worked there — matching the "works generally, breaks when run standalone" report.)

## Changes

- Rewrite the nested-restart path derivation as a single walk down each nesting level (`findStepPath` per level), flattening container nesting (ForLoop/BranchOne) and subflow boundaries into one chain (`chain[0]` = top restart step, rest = `nested_path`). This recovers containers sitting above/between subflow boundaries — which the graph id omits — so the request matches what the backend's `resolve_nested_restart` walks. The old code had two separate branches (a subflow branch and a parent-flow branch), neither of which handled containers around subflow boundaries; they're replaced by the one walk.
- Extract that walk into a pure `buildNestedRestartPath` in `restartFromStepPath.ts` (alongside the existing sibling helpers `findStepPath`/`parseExpandedSubflowId`) so it is unit-testable; the `$effect` in `useNestedRestartState.svelte.ts` becomes a thin call into it (that file shrinks ~165 lines).
- Blocked containers (parallel ForLoop / BranchAll / WhileLoop, or a BranchOne branch the run didn't take) return `null` so the button is hidden consistently.
- Add `restartFromStepPath.test.ts` (16 cases).

One root-cause fix, two symptoms cleared: the reported "button missing" case, and the related case where a container sits *between* two subflow layers (previously showed a button but sent a path missing the intermediate ForLoop, so the restart failed at the backend).

## Screenshots

Reproduction — a leaf (`s:a`, "Inline Bun") inside subflow `s` nested in a sequential ForLoop `L`, run standalone. This is the node that previously showed **no** restart button:

![graph](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/nested-restart-multiflow-bug/1783696190-nested-restart-graph-context.png)

The button now appears ("Re-start from a", top toolbar), and its popup correctly exposes the recovered outer ForLoop `L` as the iteration selector (backend request: `step_id:"L"` + iteration, `nested_path:[{s},{a}]`):

![button and popup](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/nested-restart-multiflow-bug/1783696192-nested-restart-button-and-popup.png)

## Test plan

- [x] Unit: `npx vitest run src/lib/components/restartFromStepPath.test.ts` (16 pass) — pure nesting, subflow-in-ForLoop, ForLoop-between-boundaries, leaf-in-ForLoop, nested-ForLoop leaf, BranchOne match/mismatch/default, unsupported-container rejections, top-level short-circuit, and both flat-fallback paths.
- [x] `svelte-check`: no new errors/warnings.
- [x] Manual (EE dev build), each restart returned `201` and the run completed `success` with a correct `restarted_from` chain:
  - `forloop L → subflow s → leaf` (the report): button now appears; `step_id:"L"` + iteration, `nested_path:[{s},{a}]`.
  - `subflow → subflow → leaf` (pure): identical payload as before — no regression.
  - `subflow sa → forloop L → subflow sb → leaf`: 4-level chain resolves and runs; picked ForLoop iteration honored.
- [ ] Spot-check: leaf inside a parallel ForLoop / BranchAll / not-taken BranchOne branch still hides the button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)