### PR TITLE
fix(frontend): don't reset editor on stale ?new_draft after draft exists

### DIFF
--- a/frontend/src/lib/newDraftFlag.test.ts
+++ b/frontend/src/lib/newDraftFlag.test.ts
@@ -11,10 +11,15 @@ vi.mock('./gen', () => ({
 	DraftService: { updateDraft: (...a: unknown[]) => updateDraft(...(a as [])) }
 }))
 vi.mock('./gen/core/OpenAPI', () => ({ OpenAPI: { BASE: '' } }))
-vi.mock('./localDraftHints.svelte', () => ({ setLocalDraftHint: vi.fn() }))
+// `getLocalDraftHint` gates the seed branch; drive it per-test via `hints.value`.
+const hints = vi.hoisted(() => ({ value: undefined as boolean | undefined }))
+vi.mock('./localDraftHints.svelte', () => ({
+	setLocalDraftHint: vi.fn(),
+	getLocalDraftHint: () => hints.value
+}))
 
 import { UserDraftDbSyncer } from './userDraftDbSyncer.svelte'
-import { stripNewDraftFlagOnSave } from './newDraftFlag'
+import { stripNewDraftFlagOnSave, shouldSeedNewDraft } from './newDraftFlag'
 
 /** Minimal `window` stand-in: `history.replaceState` rewrites `location.href`,
  * mirroring what jsdom does, so the helper's strip is observable. */
@@ -36,7 +41,30 @@ function stubWindow(href: string): { current: () => string } {
 afterEach(() => {
 	vi.unstubAllGlobals()
 	vi.clearAllMocks()
+	hints.value = undefined
 	updateDraft.mockResolvedValue({ status: 'saved', current_timestamp: '2020-01-01T00:00:00Z' })
+})
+
+describe('shouldSeedNewDraft', () => {
+	const q = { workspace: 'w', itemKind: 'script' as const, path: 'u/me/draft_a' }
+
+	it('is false without the flag', () => {
+		expect(shouldSeedNewDraft(new URLSearchParams(''), q.workspace, q.itemKind, q.path)).toBe(false)
+	})
+
+	it('is true for a fresh, never-persisted new draft', () => {
+		hints.value = undefined
+		expect(
+			shouldSeedNewDraft(new URLSearchParams('new_draft=true'), q.workspace, q.itemKind, q.path)
+		).toBe(true)
+	})
+
+	it('is false once the draft is persisted this session (stale flag → load, not re-seed)', () => {
+		hints.value = true
+		expect(
+			shouldSeedNewDraft(new URLSearchParams('new_draft=true'), q.workspace, q.itemKind, q.path)
+		).toBe(false)
+	})
 })
 
 describe('UserDraftDbSyncer.onSaved', () => {

--- a/frontend/src/lib/newDraftFlag.ts
+++ b/frontend/src/lib/newDraftFlag.ts
@@ -1,4 +1,43 @@
 import { UserDraftDbSyncer, type UserDraftLastSyncQuery } from '$lib/userDraftDbSyncer.svelte'
+import { getLocalDraftHint } from '$lib/localDraftHints.svelte'
+import type { UserDraftItemKind } from '$lib/gen'
+
+/** Drop `?new_draft=true` from the current URL (preserving every other param),
+ * mutating the address bar without a navigation. No-op when the flag is absent
+ * or `window` is unavailable (SSR). */
+export function stripNewDraftFlag(): void {
+	if (typeof window === 'undefined') return
+	const url = new URL(window.location.href)
+	if (url.searchParams.get('new_draft') !== 'true') return
+	url.searchParams.delete('new_draft')
+	window.history.replaceState(window.history.state, '', url.toString())
+}
+
+/**
+ * Whether an editor load should take the `?new_draft` seed-empty branch.
+ *
+ * The `/{scripts,flows,apps,apps_raw}/add` redirect lands the editor on
+ * `u/<user>/draft_<uuid>?new_draft=true`; the seed branch bootstraps an empty
+ * (or template/hub/fork-seeded) editor instead of fetching a row that doesn't
+ * exist yet. But the flag can outlive the seed: exiting an AI session restores
+ * the remembered nav route (still `?new_draft=true`) even though the draft was
+ * already materialized — by the first autosave, or by "Open in AI session"'s
+ * `forcePersist`. Re-running the seed branch then blanks the saved draft.
+ *
+ * So gate the seed branch on `new_draft=true` AND no persisted draft this
+ * session (`getLocalDraftHint`): a never-saved draft still seeds empty (and a
+ * pre-edit refresh re-seeds instead of 404-ing), while a re-entry after the
+ * draft exists falls through to the normal load that reflects it.
+ */
+export function shouldSeedNewDraft(
+	searchParams: URLSearchParams,
+	workspace: string | undefined,
+	itemKind: UserDraftItemKind,
+	path: string
+): boolean {
+	if (searchParams.get('new_draft') !== 'true') return false
+	return getLocalDraftHint(workspace, itemKind, path) !== true
+}
 
 /**
  * Defer stripping `?new_draft=true` from the URL until the draft's first save
@@ -18,11 +57,7 @@ export function stripNewDraftFlagOnSave(query: UserDraftLastSyncQuery): () => vo
 	unsub = UserDraftDbSyncer.onSaved(query, () => {
 		unsub?.()
 		unsub = undefined
-		if (typeof window === 'undefined') return
-		const url = new URL(window.location.href)
-		if (url.searchParams.get('new_draft') !== 'true') return
-		url.searchParams.delete('new_draft')
-		window.history.replaceState(window.history.state, '', url.toString())
+		stripNewDraftFlag()
 	})
 	return () => {
 		unsub?.()

--- a/frontend/src/routes/(root)/(logged)/apps/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps/edit/[...path]/+page.svelte
@@ -18,7 +18,7 @@
 	import { onDestroy, tick, untrack } from 'svelte'
 	import { page } from '$app/state'
 	import { UserDraft } from '$lib/userDraft.svelte'
-	import { stripNewDraftFlagOnSave } from '$lib/newDraftFlag'
+	import { stripNewDraftFlag, stripNewDraftFlagOnSave, shouldSeedNewDraft } from '$lib/newDraftFlag'
 	import { OtherUserDraftLoad } from '$lib/components/otherUserDraftLoad.svelte'
 	import { runResetToDeployed } from '$lib/userDraftToast'
 
@@ -70,7 +70,10 @@
 		// `?new_draft=true` (from `/apps/add`'s redirect): a fresh, never-saved
 		// `draft_{uuid}` path. Skip the backend fetch (would 404) and seed empty
 		// with `path = ''` for the friendly auto-name. See /scripts/edit's loader.
-		if (page.url.searchParams.get('new_draft') === 'true') {
+		// Skip the seed branch once the draft is persisted this session so a stale
+		// `?new_draft` loads the saved draft instead of blanking it — see
+		// shouldSeedNewDraft.
+		if (shouldSeedNewDraft(page.url.searchParams, $workspaceStore, 'app', path)) {
 			// Suspend autosave across the bootstrap: the seed assignment and
 			// AppEditor's `firstMirror` are programmatic writes that must not POST
 			// as the first edit. AppEditor lifts it in `onMount`.
@@ -208,6 +211,10 @@
 			}
 			return
 		}
+		// Falling through with `?new_draft=true` still set means the draft is
+		// already persisted (see shouldSeedNewDraft) — drop the now-meaningless
+		// flag so it doesn't linger in the URL / remembered nav route.
+		stripNewDraftFlag()
 		let backendApp = await AppService.getAppByPath({
 			path: page.params.path ?? '',
 			workspace: $workspaceStore!,

--- a/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { run } from 'svelte/legacy'
 	import { onDestroy } from 'svelte'
-	import { stripNewDraftFlagOnSave } from '$lib/newDraftFlag'
+	import { stripNewDraftFlag, stripNewDraftFlagOnSave, shouldSeedNewDraft } from '$lib/newDraftFlag'
 
 	import { AppService } from '$lib/gen'
 	import { userStore, workspaceStore } from '$lib/stores'
@@ -174,7 +174,10 @@
 		// `draft_{uuid}` path. Skip the backend fetch (would 404) and seed every
 		// piece of state RawAppEditor needs — rendering gates on `files`, so an
 		// unset `files` blanks the page. `path = ''` for the friendly auto-name.
-		if (page.url.searchParams.get('new_draft') === 'true') {
+		// Skip the seed branch once the draft is persisted this session so a stale
+		// `?new_draft` loads the saved draft instead of blanking it — see
+		// shouldSeedNewDraft.
+		if (shouldSeedNewDraft(page.url.searchParams, $workspaceStore, 'raw_app', path)) {
 			isNewApp = true
 			// Page reused across same-route nav: clear the previous path's
 			// draft-presence state so it doesn't bleed onto the fresh draft.
@@ -273,6 +276,10 @@
 			templatePicker = true
 			return
 		}
+		// Falling through with `?new_draft=true` still set means the draft is
+		// already persisted (see shouldSeedNewDraft) — drop the now-meaningless
+		// flag so it doesn't linger in the URL / remembered nav route.
+		stripNewDraftFlag()
 		const backendApp = (await AppService.getAppByPath({
 			path: page.params.path ?? '',
 			workspace: $workspaceStore!,

--- a/frontend/src/routes/(root)/(logged)/flows/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/flows/edit/[...path]/+page.svelte
@@ -18,7 +18,7 @@
 	import type { ScheduleTrigger } from '$lib/components/triggers'
 	import type { Trigger } from '$lib/components/triggers/utils'
 	import { onDestroy, tick, untrack } from 'svelte'
-	import { stripNewDraftFlagOnSave } from '$lib/newDraftFlag'
+	import { stripNewDraftFlag, stripNewDraftFlagOnSave, shouldSeedNewDraft } from '$lib/newDraftFlag'
 	import type { stepState } from '$lib/components/stepHistoryLoader.svelte'
 	import { page } from '$app/state'
 	import { UserDraft, draftValuesEqual } from '$lib/userDraft.svelte'
@@ -146,7 +146,10 @@
 		// `?new_draft=true` (from `/flows/add`'s redirect): a fresh, never-saved
 		// `draft_{uuid}` path. Skip both fetches (they 404) and seed empty with
 		// `path = ''` for the friendly auto-name. See /scripts/edit's loader.
-		if (page.url.searchParams.get('new_draft') === 'true') {
+		// Skip the seed branch once the draft is persisted this session (so a
+		// stale `?new_draft` from exiting an AI session loads the saved draft
+		// instead of blanking it) — see shouldSeedNewDraft.
+		if (shouldSeedNewDraft(page.url.searchParams, $workspaceStore, 'flow', flowDraftPath)) {
 			// Deploy must `createFlow` at the user-typed path, not `updateFlow` at the URL.
 			isNewFlow = true
 			// Page reused across same-route nav: clear the previous path's
@@ -323,6 +326,10 @@
 			}
 			return
 		}
+		// Falling through with `?new_draft=true` still set means the draft is
+		// already persisted (see shouldSeedNewDraft) — drop the now-meaningless
+		// flag so it doesn't linger in the URL / remembered nav route.
+		stripNewDraftFlag()
 		// Version isn't carried on the flow, so fetch it separately. Tolerate a
 		// missing one: draft-only paths have no version row, but `getFlowByPath`
 		// still returns the draft, so mount with `version = undefined`.

--- a/frontend/src/routes/(root)/(logged)/scripts/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/scripts/edit/[...path]/+page.svelte
@@ -16,7 +16,7 @@
 	import type { Trigger } from '$lib/components/triggers/utils'
 	import { get } from 'svelte/store'
 	import { onDestroy, untrack } from 'svelte'
-	import { stripNewDraftFlagOnSave } from '$lib/newDraftFlag'
+	import { stripNewDraftFlag, stripNewDraftFlagOnSave, shouldSeedNewDraft } from '$lib/newDraftFlag'
 	import { page } from '$app/state'
 	import { UserDraft, draftValuesEqual } from '$lib/userDraft.svelte'
 	import { UserDraftDbSyncer } from '$lib/userDraftDbSyncer.svelte'
@@ -133,7 +133,11 @@
 		// `initPath` calls `reset()`, generating the friendly `<adj>_<kind>` name;
 		// any non-empty value is parsed verbatim. Empty `initialPath` also opens the
 		// metadata drawer. The flag is stripped only once the first save lands.
-		if (page.url.searchParams.get('new_draft') === 'true') {
+		// Once the draft is persisted this session (autosave or "Open in AI
+		// session"'s forcePersist), a stale `?new_draft` — e.g. carried back by
+		// exiting a session to the remembered nav route — falls through to the
+		// normal load instead of re-seeding empty over the saved draft.
+		if (shouldSeedNewDraft(page.url.searchParams, $workspaceStore, 'script', draftPath)) {
 			// Suspend autosave across the bootstrap: both the seed and
 			// ScriptBuilder's `initContent` are programmatic writes that must not
 			// post as the user's first edit. ScriptBuilder lifts it in
@@ -275,6 +279,10 @@
 			renderEditor = true
 			return
 		}
+		// Falling through with `?new_draft=true` still set means the draft is
+		// already persisted (see shouldSeedNewDraft) — drop the now-meaningless
+		// flag so it doesn't linger in the URL / remembered nav route.
+		stripNewDraftFlag()
 		if (hash) {
 			const scriptByHash = await ScriptService.getScriptByHash({
 				workspace: $workspaceStore!,


### PR DESCRIPTION
## Summary

Fixes WIN-2154.

The `/{scripts,flows,apps,apps_raw}/add` redirect lands the editor on
`u/<user>/draft_<uuid>?new_draft=true`, and a seed branch bootstraps an empty
(or template/hub/fork-seeded) editor instead of fetching a row that doesn't exist
yet. Previously the flag was only stripped from the URL on the first confirmed
save.

The problem: the flag can outlive the seed. Switching a brand-new item into an
**AI session** and back restores the remembered nav route (still
`?new_draft=true`) via a client-side `goto` — even though the draft was already
materialized (by the first autosave, or by "Open in AI session"'s
`forcePersist`). The in-memory draft state survives that client-side navigation,
but the seed branch re-ran anyway and **blanked the saved draft**.

The fix makes `?new_draft` idempotent: the seed branch now runs only when the
draft has **not** been persisted this session. Once a draft exists, a stale
`?new_draft` falls through to the normal load (which reflects the saved draft)
and the now-meaningless flag is stripped from the URL. A never-saved draft still
seeds empty, and a pre-edit full refresh still re-seeds (avoiding the 404 that
motivated keeping the flag until first save in the first place).

## Changes

- `frontend/src/lib/newDraftFlag.ts`:
  - `shouldSeedNewDraft(searchParams, workspace, itemKind, path)` — returns true
    only when `new_draft=true` **and** `getLocalDraftHint(...) !== true` (no
    draft persisted this session).
  - `stripNewDraftFlag()` — extracted the immediate URL-strip (reused by the
    existing on-save listener and the new fall-through).
- The four editor loaders (`scripts`, `flows`, `apps`, `apps_raw` `edit/[...path]/+page.svelte`)
  gate their `new_draft` seed branch on `shouldSeedNewDraft(...)` and call
  `stripNewDraftFlag()` when they fall through to a normal load.
- `frontend/src/lib/newDraftFlag.test.ts` — adds cases for the three hint states
  (no flag / fresh / persisted-this-session).

## Verification

Verified end-to-end in a real browser (system Chromium via Playwright) against
the running dev server, reproducing the exact bug via **client-side** SPA
navigation (what exiting an AI session does):

1. `/scripts/add` → edit → autosave persists the draft and strips `?new_draft`.
2. Client-side hop away, then back to the stale `/scripts/edit/<draft>?new_draft=true`.
3. **With the fix:** the editor loads the saved draft ("Loaded from draft",
   friendly name preserved), the metadata drawer does **not** re-open empty, and
   `?new_draft` is stripped from the URL.
4. **Negative control (fix reverted):** the empty metadata drawer re-opens and
   `?new_draft` is retained — i.e. the reset the issue describes.

`newDraftFlag.test.ts` (9 tests) passes; `check:fast` is clean for the changed
files (the one unrelated pre-existing `utils_workspace_deploy.ts` error is not
touched here).

## Screenshots

Editor after the stale `?new_draft` re-entry — draft loaded, not blanked
(breadcrumb keeps the friendly name `capable_script`, "Loaded from draft"
indicator, content intact):

![scenario1_fixed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2154-remove-new_draft-query-param-after-draft-creation/1783697525-scenario1_fixed.png)

## Second reported scenario (new flow → edit → AI session preview): verified working, not reproducible

A second scenario was raised during development: *"in a new flow, edit it, then
start an AI session — the flow content is not in the session preview."* I
configured workspace AI (a placeholder OpenAI provider/key) so the "Open in AI
session" button actually opens a session — without a configured AI model that
button only shows an "enable AI" popover, which is likely why it looked broken —
then drove the full flow end-to-end:

- New flow → edit the **summary** → "Open in AI session": the preview shows the
  edited summary and friendly path. ✅
- New flow → **add a step** (Inline Bun) → "Open in AI session": the preview
  graph shows the added step. ✅
- Same, but clicking "Open in AI session" **immediately** after the edit (no
  autosave settle — the worst-case race): the preview still shows the step. ✅

So on the current branch the flow content **does** appear in the session preview.
This scenario was most likely already fixed by #10028 (commit `03535691d6`,
merged the same day), which added the `UserDraft.forcePersist` materialization
this path depends on. No code change is needed here for it; this PR remains
scoped to the WIN-2154 stale-`?new_draft` reset.

## Test plan

- [ ] `/scripts/add` → edit → autosave → "Open in AI session" → exit session:
      editor shows the saved draft (not blank), `?new_draft` gone from the URL.
- [ ] Repeat for a flow, an app, and a raw app (fix applied identically to all four).
- [ ] Brand-new item, no edit, hard refresh with `?new_draft=true`: still seeds
      empty (no 404).