### PR TITLE
fix(frontend): open current editor item in session when toggling to AI Sessions

### DIFF
--- a/frontend/src/lib/components/FlowBuilder.svelte
+++ b/frontend/src/lib/components/FlowBuilder.svelte
@@ -34,7 +34,8 @@
 	import DeployOverrideConfirmationModal from '$lib/components/common/confirmationModal/DeployOverrideConfirmationModal.svelte'
 	import AIChangesWarningModal from '$lib/components/copilot/chat/flow/AIChangesWarningModal.svelte'
 
-	import { createRawSnippet, setContext, untrack } from 'svelte'
+	import { createRawSnippet, getContext, setContext, untrack } from 'svelte'
+	import { registerEditorSessionSource } from '$lib/components/sessions/editorSessionSource'
 	import { writable } from 'svelte/store'
 	import CenteredPage from './CenteredPage.svelte'
 	import { Button } from './common'
@@ -527,6 +528,26 @@
 	// (which for a new flow differs from the live-edited friendly `$pathStore`),
 	// falling back to `$pathStore` in drawer mounts that carry no storage path.
 	const sessionTargetPath = $derived(liveEditorDraftStoragePath || $pathStore)
+
+	// True when this builder is the session preview itself (SessionEditorTarget
+	// injects the `aiChatManager` context) — it must not publish itself as the
+	// editor to open in a session.
+	const inSessionPane = !!getContext('aiChatManager')
+
+	// "Open in AI session" source for this flow. Shared by the inline graph button
+	// and published to the sidebar Workspace↔AI Sessions toggle via
+	// `registerEditorSessionSource`, so switching into session mode from here opens
+	// this flow in the preview instead of an empty session.
+	const editorSessionSource = $derived(
+		sessionTargetPath && !inSessionPane
+			? {
+					target: { kind: 'flow' as const, path: sessionTargetPath },
+					workspaceId: opWorkspace ?? undefined,
+					beforeOpen: persistDraftForSession
+				}
+			: undefined
+	)
+	$effect(() => registerEditorSessionSource(editorSessionSource))
 
 	$effect(() => {
 		if (liveEditorDraftStoragePath === undefined || !opWorkspace) return
@@ -1275,13 +1296,7 @@
 					aiChatOpen={aiChatManager.open}
 					showFlowAiButton={!disableAi && customUi?.topBar?.aiBuilder != false}
 					toggleAiChat={() => aiChatManager.toggleOpen()}
-					sessionOpen={sessionTargetPath
-						? {
-								target: { kind: 'flow', path: sessionTargetPath },
-								workspaceId: opWorkspace ?? undefined,
-								beforeOpen: persistDraftForSession
-							}
-						: undefined}
+					sessionOpen={editorSessionSource}
 					onOpenPreview={flowPreviewButtons?.openPreview}
 					localModuleStates={showJobStatus ? localModuleStates : {}}
 					{showJobStatus}

--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -86,6 +86,7 @@
 	import { defaultScriptLanguages, processLangs } from '$lib/scripts'
 	import DefaultScripts from './DefaultScripts.svelte'
 	import { getContext, onMount, setContext, tick, untrack } from 'svelte'
+	import { registerEditorSessionSource } from '$lib/components/sessions/editorSessionSource'
 	import EditorHeader from './EditorHeader.svelte'
 	import AutosaveIndicator from './AutosaveIndicator.svelte'
 	import LabelsInput from './LabelsInput.svelte'
@@ -773,6 +774,23 @@
 	// stays put and is already scoped to a fork. Diff is exposed as a standalone
 	// top-bar button (rendered independently of the session pane), not here.
 	const inSessionPane = !!getContext('aiChatManager')
+
+	// "Open in AI session" source for this editor. Shared by the inline button
+	// (below) and published to the sidebar Workspace↔AI Sessions toggle via
+	// `registerEditorSessionSource`, so switching into session mode from here
+	// opens this script in the preview. Target the URL draft path (a new script's
+	// friendly `script.path` has no row → "not found"). Never from a session pane
+	// (that's the preview itself).
+	const editorSessionSource = $derived(
+		userDraftPath && !inSessionPane
+			? {
+					target: { kind: 'script' as const, path: userDraftPath },
+					workspaceId: opWorkspace ?? undefined,
+					beforeOpen: persistDraftForSession
+				}
+			: undefined
+	)
+	$effect(() => registerEditorSessionSource(editorSessionSource))
 
 	async function openDiffDrawer() {
 		if (!savedScript) {
@@ -2109,15 +2127,7 @@
 		<ScriptEditor
 			{disableAi}
 			workspaceOverride={opWorkspace}
-			sessionOpen={userDraftPath
-				? {
-						// URL draft path the editor loads/saves by, not the friendly
-						// `script.path` (a new script's has no row → "not found").
-						target: { kind: 'script', path: userDraftPath },
-						workspaceId: opWorkspace ?? undefined,
-						beforeOpen: persistDraftForSession
-					}
-				: undefined}
+			sessionOpen={editorSessionSource}
 			bind:selectedTab={selectedInputTab}
 			{customUi}
 			{onTestJob}

--- a/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
+++ b/frontend/src/lib/components/raw_apps/RawAppEditorHeader.svelte
@@ -59,6 +59,7 @@
 	import { updateRawAppPolicy } from './rawAppPolicy'
 	import { aiChatManager } from '../copilot/chat/AIChatManager.svelte'
 	import { getContext } from 'svelte'
+	import { registerEditorSessionSource } from '$lib/components/sessions/editorSessionSource'
 
 	// Forward-looking hook for the upcoming session-pane feature: that PR will
 	// `setContext('aiChatManager', ...)` from the session wrapper so this editor
@@ -238,6 +239,21 @@
 			await UserDraft.forcePersist('raw_app', indicatorPath, { workspace: opWorkspace })
 		}
 	}
+
+	// "Open in AI session" source for this app. Shared by the inline button (below)
+	// and published to the sidebar Workspace↔AI Sessions toggle via
+	// `registerEditorSessionSource`, so switching into session mode from here opens
+	// this app in the preview. Never from a session pane (that's the preview itself).
+	const editorSessionSource = $derived(
+		appPath && !inSessionPane
+			? {
+					target: { kind: 'raw_app' as const, path: appPath },
+					workspaceId: opWorkspace ?? undefined,
+					beforeOpen: persistDraftForSession
+				}
+			: undefined
+	)
+	$effect(() => registerEditorSessionSource(editorSessionSource))
 
 	$effect(() => {
 		const typed = newEditedPath
@@ -909,17 +925,7 @@
 			</Button>
 		</div>
 		<AppExportButton bind:this={appExport} />
-		<OpenInSessionButton
-			source={appPath
-				? {
-						target: { kind: 'raw_app', path: appPath },
-						workspaceId: opWorkspace ?? undefined,
-						// Persist the draft (and materialize a brand-new one) so the session
-						// preview opens the app exactly as it is in the editor right now.
-						beforeOpen: persistDraftForSession
-					}
-				: undefined}
-		>
+		<OpenInSessionButton source={editorSessionSource}>
 			{#snippet fallback()}
 				<Button
 					unifiedSize={headerBtnSize}

--- a/frontend/src/lib/components/sessions/SessionModeSwitch.svelte
+++ b/frontend/src/lib/components/sessions/SessionModeSwitch.svelte
@@ -17,7 +17,7 @@
 	function onSelected(next: 'nav' | 'session') {
 		if (next === mode) return
 		onToggle?.()
-		if (next === 'session') void enterSessionMode()
+		if (next === 'session') void enterSessionMode({ seedFromEditor: true })
 		else void exitSessionMode()
 	}
 </script>

--- a/frontend/src/lib/components/sessions/editorSessionSource.ts
+++ b/frontend/src/lib/components/sessions/editorSessionSource.ts
@@ -1,0 +1,30 @@
+import type { OpenInSessionSource } from './OpenInSessionButton.svelte'
+
+/**
+ * The "Open in AI session" source published by the editor the user is currently
+ * on (flow / script / raw-app builder). The sidebar Workspace↔AI Sessions toggle
+ * (`enterSessionMode`) reads it so switching into session mode from an editor
+ * opens that item in the preview — the same handoff the in-editor "Open in AI
+ * session" button performs — instead of dropping the user in an empty session.
+ *
+ * Editors register on mount and the returned cleanup drops the entry on
+ * teardown; the session preview's own editor (marked by the `aiChatManager`
+ * context) MUST NOT register, else the toggle would re-seed from the preview.
+ *
+ * A plain module ref, not `$state`: the only reader is `enterSessionMode`'s
+ * click handler, which reads it imperatively at the moment of the toggle.
+ */
+let current: OpenInSessionSource | undefined
+
+export function registerEditorSessionSource(source: OpenInSessionSource | undefined): () => void {
+	current = source
+	return () => {
+		// Only clear if we're still the active registration — a newer editor may
+		// have taken over before this one tore down.
+		if (current === source) current = undefined
+	}
+}
+
+export function getEditorSessionSource(): OpenInSessionSource | undefined {
+	return current
+}

--- a/frontend/src/lib/components/sessions/sessionSwitch.svelte.ts
+++ b/frontend/src/lib/components/sessions/sessionSwitch.svelte.ts
@@ -10,6 +10,7 @@ import {
 	type SessionTarget
 } from './sessionState.svelte'
 import { sessionTargetHref } from './sessionMode.svelte'
+import { getEditorSessionSource } from './editorSessionSource'
 
 // The session/navigation switch turns the global rail into either the workspace
 // navigation (navigation mode) or the sessions sidebar (session mode). Session
@@ -35,7 +36,25 @@ export function rememberNavRoute(pathnameWithSearch: string): void {
 // `replace` swaps the current history entry instead of pushing — for the
 // sessions page's family reconcile, where Back must not return to the
 // redirected-away URL just to bounce here again.
-export async function enterSessionMode(opts?: { replace?: boolean }): Promise<void> {
+// `seedFromEditor` (the sidebar toggle) opens the item the user is currently
+// editing in the session preview, matching the in-editor "Open in AI session"
+// button — so a brand-new flow/script the user just built lands in the preview
+// instead of an empty session. Off for the sessions-page reconcile, which has
+// no editor to seed from.
+export async function enterSessionMode(opts?: {
+	replace?: boolean
+	seedFromEditor?: boolean
+}): Promise<void> {
+	if (opts?.seedFromEditor) {
+		const source = getEditorSessionSource()
+		if (source?.target) {
+			// Persist (and materialize a brand-new) draft first, then open it in a
+			// fresh session preview — the same handoff OpenInSessionButton runs.
+			await source.beforeOpen?.()
+			await openEditorInSession(source.target, source.workspaceId)
+			return
+		}
+	}
 	const current = sessionState.currentSessionId
 		? sessionState.sessions.find((s) => s.id === sessionState.currentSessionId)
 		: undefined

--- a/frontend/src/lib/components/sessions/sessionSwitch.test.ts
+++ b/frontend/src/lib/components/sessions/sessionSwitch.test.ts
@@ -2,10 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { get } from 'svelte/store'
 import { enterSessionMode } from './sessionSwitch.svelte'
 import { sessionState, type Session } from './sessionState.svelte'
+import { registerEditorSessionSource } from './editorSessionSource'
 import { usersWorkspaceStore, workspaceStore, type UserWorkspace } from '$lib/stores'
 
 vi.mock('$lib/navigation', () => ({ goto: vi.fn().mockResolvedValue(undefined) }))
 import { goto } from '$lib/navigation'
+// `openEditorInSession` lazy-imports the runtime (monaco-heavy) — stub it so the
+// seed path is testable in node.
+vi.mock('./sessionRuntime.svelte', () => ({ resetSessionPreviewTabs: vi.fn() }))
 
 function session(over: Partial<Session> = {}): Session {
 	return { id: 's1', name: 'sess', createdAt: 0, ...over }
@@ -43,7 +47,9 @@ describe('enterSessionMode — restore is scoped to the active family', () => {
 		try {
 			await enterSessionMode()
 			expect(sessionState.currentSessionId).toBe('sw-in-family')
-			expect(goto).toHaveBeenCalledWith('/sessions?session_name=session-911', { replaceState: false })
+			expect(goto).toHaveBeenCalledWith('/sessions?session_name=session-911', {
+				replaceState: false
+			})
 		} finally {
 			sessionState.sessions = sessionState.sessions.filter((s) => s.id !== 'sw-in-family')
 			sessionState.currentSessionId = prevCurrent
@@ -61,7 +67,9 @@ describe('enterSessionMode — restore is scoped to the active family', () => {
 		try {
 			await enterSessionMode()
 			expect(sessionState.currentSessionId).toBe('sw-local')
-			expect(goto).toHaveBeenCalledWith('/sessions?session_name=session-913', { replaceState: false })
+			expect(goto).toHaveBeenCalledWith('/sessions?session_name=session-913', {
+				replaceState: false
+			})
 		} finally {
 			sessionState.sessions = sessionState.sessions.filter(
 				(s) => s.id !== 'sw-foreign' && s.id !== 'sw-local'
@@ -89,6 +97,81 @@ describe('enterSessionMode — restore is scoped to the active family', () => {
 			sessionState.sessions = sessionState.sessions.filter(
 				(s) => s.id !== 'sw-only-foreign' && s.id !== createdId
 			)
+			sessionState.currentSessionId = prevCurrent
+			restore()
+		}
+	})
+})
+
+describe('enterSessionMode — seedFromEditor', () => {
+	beforeEach(() => {
+		vi.mocked(goto).mockClear()
+		// Drop any registration a prior test left behind.
+		registerEditorSessionSource(undefined)
+	})
+
+	it('opens the current editor item in a fresh session preview when a source is registered', async () => {
+		const restore = withTwoFamilies('rootA')
+		const prevCurrent = sessionState.currentSessionId
+		const beforeOpen = vi.fn().mockResolvedValue(undefined)
+		const cleanup = registerEditorSessionSource({
+			target: { kind: 'flow', path: 'u/me/draft_x' },
+			workspaceId: 'rootA',
+			beforeOpen
+		})
+		let createdId: string | undefined
+		try {
+			await enterSessionMode({ seedFromEditor: true })
+			// Persist ran, and we opened a fresh session scoped to the editor workspace.
+			expect(beforeOpen).toHaveBeenCalledTimes(1)
+			createdId = sessionState.currentSessionId
+			const created = sessionState.sessions.find((s) => s.id === createdId)
+			expect(created?.pending_workspace_id).toBe('rootA')
+			expect(goto).toHaveBeenCalledWith(expect.stringContaining('/sessions?session_name='))
+		} finally {
+			cleanup()
+			sessionState.sessions = sessionState.sessions.filter((s) => s.id !== createdId)
+			sessionState.currentSessionId = prevCurrent
+			restore()
+		}
+	})
+
+	it('falls back to generic restore when no editor source is registered', async () => {
+		const restore = withTwoFamilies('rootB')
+		const prevCurrent = sessionState.currentSessionId
+		const local = session({ id: 'sw-seed-fallback', name: 'session-920', workspace_id: 'rootB' })
+		sessionState.sessions.push(local)
+		sessionState.currentSessionId = 'sw-seed-fallback'
+		try {
+			await enterSessionMode({ seedFromEditor: true })
+			expect(sessionState.currentSessionId).toBe('sw-seed-fallback')
+			expect(goto).toHaveBeenCalledWith('/sessions?session_name=session-920', {
+				replaceState: false
+			})
+		} finally {
+			sessionState.sessions = sessionState.sessions.filter((s) => s.id !== 'sw-seed-fallback')
+			sessionState.currentSessionId = prevCurrent
+			restore()
+		}
+	})
+
+	it('ignores a registered source when seedFromEditor is not set (reconcile path)', async () => {
+		const restore = withTwoFamilies('rootB')
+		const prevCurrent = sessionState.currentSessionId
+		const local = session({ id: 'sw-no-seed', name: 'session-921', workspace_id: 'rootB' })
+		sessionState.sessions.push(local)
+		sessionState.currentSessionId = 'sw-no-seed'
+		const cleanup = registerEditorSessionSource({
+			target: { kind: 'flow', path: 'u/me/draft_y' },
+			workspaceId: 'rootB',
+			beforeOpen: vi.fn()
+		})
+		try {
+			await enterSessionMode()
+			expect(sessionState.currentSessionId).toBe('sw-no-seed')
+		} finally {
+			cleanup()
+			sessionState.sessions = sessionState.sessions.filter((s) => s.id !== 'sw-no-seed')
 			sessionState.currentSessionId = prevCurrent
 			restore()
 		}


### PR DESCRIPTION
## Summary

Follow-up to #10044 (WIN-2154). While verifying that PR I confirmed a second,
related issue: **switching a brand-new flow/script/app into an AI session via the
sidebar Workspace↔AI Sessions toggle drops you in an empty session** — the item
you were editing is nowhere in the preview.

Root cause: there are two entry points into a session and they behaved
differently:

| Entry point | Function | Seeds the preview with the current item? |
|---|---|---|
| "Open in AI session" (icon in the editor toolbar) | `openEditorInSession` | ✅ yes |
| **Workspace↔AI Sessions sidebar toggle** | `enterSessionMode` | ❌ no — restores the last/new session, never looks at the editor you're on |

So a freshly-built flow (which has no pre-existing session) lands you in an empty
session when you use the toggle.

## Fix

Editors now **publish** their "Open in AI session" source to a small module
registry; the toggle **reads** it and opens that item in the preview — the same
handoff the in-editor button already performs — falling back to the previous
generic restore when you're not on an editor.

- `frontend/src/lib/components/sessions/editorSessionSource.ts` (new) — a plain
  module ref with `registerEditorSessionSource(source)` (returns a cleanup that
  clears the entry, identity-guarded) and `getEditorSessionSource()`.
- `ScriptBuilder`, `FlowBuilder`, `RawAppEditorHeader` — each publishes its
  existing `OpenInSessionSource` via `$effect(() => registerEditorSessionSource(src))`,
  gated on `!inSessionPane` so the session preview itself never registers (it
  would otherwise re-seed from itself). The source object was hoisted to a
  `$derived` and reused by the inline button, so there's a single source of truth.
- `enterSessionMode({ seedFromEditor })` — when set (passed by `SessionModeSwitch`),
  runs the source's `beforeOpen` (persist + materialize the draft) then
  `openEditorInSession(target, workspaceId)`. The sessions-page reconcile caller
  (`{ replace: true }`) does **not** set it, so its behavior is unchanged.

## Verification

End-to-end in a real browser (system Chromium via Playwright, workspace AI
configured with a placeholder provider so the session actually opens):

1. New flow → add a step + summary `TOGGLEMARK` → click the **AI Sessions**
   toggle → the preview shows the flow (step node + friendly path). ✅
   (Before the fix: empty session, `TOGGLEMARK` absent.)
2. Regression — visit a flow editor, navigate away to `/runs`, then toggle
   AI Sessions → the flow does **not** leak into the preview; generic restored
   session opens. ✅ (Confirms the `$effect` cleanup clears the registry.)
3. The "Open in AI session" toolbar button still opens the item in the preview
   (source refactor didn't regress it). ✅

`sessionSwitch.test.ts` adds three cases (seed / no-source fallback /
reconcile-ignores-source) — 6 tests pass. `check:fast` clean for the changed
files (the pre-existing unrelated `utils_workspace_deploy.ts` error is on main).
svelte-autofixer clean.

## Screenshots

AI session preview after clicking the **AI Sessions** toggle from an edited new
flow — the flow (step node `TOGGLEMARK`, path `u/admin/beautiful_flow`) is in the
preview instead of an empty session:

![toggle-seeds-flow](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2154-ai-session-toggle-seed/1783700444-toggle-seeds-flow.png)

## Test plan

- [ ] New (unsaved) flow / script / raw-app → flip Workspace→AI Sessions toggle:
      the just-built item appears in the session preview (draft persisted first).
- [ ] Toggle into AI Sessions from a non-editor page (home/workspace view):
      still lands on the generic restored session (fallback branch).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the AI Sessions toggle so it opens the item you’re editing (flow/script/raw-app) instead of an empty session. Matches the in-editor “Open in AI session” behavior and addresses WIN-2154.

- **Bug Fixes**
  - Added a small registry (`editorSessionSource.ts`) to track the current editor’s session source via `registerEditorSessionSource` and `getEditorSessionSource`.
  - Editors publish their source on mount and clean up on unmount; guarded by the `aiChatManager` context to avoid registering the session pane itself.
  - The toggle now calls `enterSessionMode({ seedFromEditor: true })`, which runs `beforeOpen` to persist/materialize drafts, then `openEditorInSession`. Falls back to the previous restore when no source is present or during reconcile.
  - Builders reuse the same source for their inline “Open in session” button to keep a single source of truth.
  - Added tests for seed-from-editor, fallback, and reconcile behavior.

<sup>Written for commit e9f4e488157234b65f5377c3302ed7dc54b08cc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

