### PR TITLE
chore: bump Rust to 1.97.0 in worker build images and CI

### DIFF
--- a/.github/workflows/ai-agent-tests.yml
+++ b/.github/workflows/ai-agent-tests.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-workspaces: backend
-          toolchain: 1.93.0
+          toolchain: 1.97.0
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/ai-evals-test.yml
+++ b/.github/workflows/ai-evals-test.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-workspaces: backend
-          toolchain: 1.93.0
+          toolchain: 1.97.0
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/backend-check.yml
+++ b/.github/workflows/backend-check.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache: false
-          toolchain: 1.93.0
+          toolchain: 1.97.0
       - name: cargo check
         working-directory: ./backend
         timeout-minutes: 16
@@ -44,7 +44,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache: false
-          toolchain: 1.93.0
+          toolchain: 1.97.0
       - name: cargo check
         working-directory: ./backend
         timeout-minutes: 16
@@ -81,7 +81,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache: false
-          toolchain: 1.93.0
+          toolchain: 1.97.0
       - name: cargo check
         working-directory: ./backend
         timeout-minutes: 16
@@ -118,7 +118,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-workspaces: backend
-          toolchain: 1.93.0
+          toolchain: 1.97.0
       - name: Fix stale v8 build cache
         working-directory: ./backend
         run: |

--- a/.github/workflows/backend-test-windows.yml
+++ b/.github/workflows/backend-test-windows.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-workspaces: backend
-          toolchain: 1.93.0
+          toolchain: 1.97.0
 
       - uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -90,7 +90,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-workspaces: backend
-          toolchain: 1.93.0
+          toolchain: 1.97.0
       - name: Fix stale v8 build cache
         working-directory: ./backend
         run: |

--- a/.github/workflows/build_windows_worker_.yml
+++ b/.github/workflows/build_windows_worker_.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-workspaces: backend
-          toolchain: 1.93.0
+          toolchain: 1.97.0
 
       - name: Substitute EE code
         shell: bash

--- a/.github/workflows/git-commands.yaml
+++ b/.github/workflows/git-commands.yaml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-workspaces: backend
-          toolchain: 1.93.0
+          toolchain: 1.97.0
 
       - name: Install xmlsec and gssapi build-time deps
         run: |

--- a/.github/workflows/git-sync-test.yml
+++ b/.github/workflows/git-sync-test.yml
@@ -121,7 +121,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-workspaces: backend
-          toolchain: 1.93.0
+          toolchain: 1.97.0
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/publish_windows_worker.yml
+++ b/.github/workflows/publish_windows_worker.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-workspaces: backend
-          toolchain: 1.93.0
+          toolchain: 1.97.0
 
       - name: Substitute EE code
         shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG DEBIAN_IMAGE=debian:trixie-slim
-ARG RUST_IMAGE=rust:1.93-slim-trixie
+ARG RUST_IMAGE=rust:1.97-slim-trixie
 
 FROM debian:trixie-slim AS nsjail
 

--- a/docker/DockerfileFull
+++ b/docker/DockerfileFull
@@ -1,8 +1,8 @@
 FROM ghcr.io/windmill-labs/windmill:dev
 
 # Rust
-COPY --from=rust:1.93.0 /usr/local/cargo /usr/local/cargo
-COPY --from=rust:1.93.0 /usr/local/rustup /usr/local/rustup
+COPY --from=rust:1.97.0 /usr/local/cargo /usr/local/cargo
+COPY --from=rust:1.97.0 /usr/local/rustup /usr/local/rustup
 RUN RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo /usr/local/cargo/bin/cargo install cargo-sweep --version ^0.7
 
 # Ansible

--- a/docker/DockerfileFullEe
+++ b/docker/DockerfileFullEe
@@ -20,8 +20,8 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
 FROM ghcr.io/windmill-labs/windmill-ee:dev
 
 # Rust
-COPY --from=rust:1.93.0 /usr/local/cargo /usr/local/cargo
-COPY --from=rust:1.93.0 /usr/local/rustup /usr/local/rustup
+COPY --from=rust:1.97.0 /usr/local/cargo /usr/local/cargo
+COPY --from=rust:1.97.0 /usr/local/rustup /usr/local/rustup
 RUN RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo /usr/local/cargo/bin/cargo install cargo-sweep --version ^0.7
 
 # Ansible


### PR DESCRIPTION
## What

Bumps the pinned Rust toolchain from **1.93.0** to **1.97.0** (latest stable, [released 2026-07-09](https://blog.rust-lang.org/2026/07/09/Rust-1.97.0/)) across the worker/server build configuration:

- `Dockerfile` — `rust:1.93-slim-trixie` → `rust:1.97-slim-trixie` (main worker/server build image)
- `docker/DockerfileFull`, `docker/DockerfileFullEe` — `rust:1.93.0` → `rust:1.97.0`
- CI workflows pinning a toolchain (`backend-check`, `backend-test`, `backend-test-windows`, `build_windows_worker_`, `publish_windows_worker`, `ai-agent-tests`, `ai-evals-test`, `git-commands`, `git-sync-test`) — `toolchain: 1.93.0` → `1.97.0`

## Why

Keep the workers on the current stable Rust toolchain.

## Notes / scope decisions

- The RHEL8/RHEL9 images install Rust via `rustup` unpinned (they already track latest stable) — no change needed.
- `.github/DockerfileBackendTests` (pinned at `rust:1.80`) is not referenced by any workflow (stale image: bookworm / go1.21 / deno2.0.2) and was left out of scope to keep this focused.
- `change-versions.yml` uses `toolchain: stable` — left as-is.

## Validation

Ran `cargo check` (default features) with the **1.97.0** toolchain and `RUSTFLAGS="-D warnings"` (the default `actions-rust-lang/setup-rust-toolchain` uses) — compiles cleanly, no new warnings. This is the real risk in a toolchain bump (new lints breaking `-D warnings` builds); the Docker image builds themselves run in CI.

## EE companion

Depends on / pairs with windmill-labs/windmill-ee-private#656 (bumps the same toolchain in the EE `claude-with-public-repo` check workflow).

Fixes WIN-2155

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Rust from 1.93.0 to 1.97.0 across worker/server build images and CI to stay on latest stable and keep builds consistent. Aligns with WIN-2155.

- **Dependencies**
  - `Dockerfile`: `rust:1.93-slim-trixie` → `rust:1.97-slim-trixie`
  - `docker/DockerfileFull`, `docker/DockerfileFullEe`: copy from `rust:1.97.0`
  - CI workflows pinning Rust (`backend-check`, `backend-test`, `backend-test-windows`, `build_windows_worker_`, `publish_windows_worker`, `ai-agent-tests`, `ai-evals-test`, `git-commands`, `git-sync-test`): `1.93.0` → `1.97.0`

- **Migration**
  - No runtime changes.
  - If building workers locally, switch to Rust 1.97.0 (e.g., `rustup default 1.97.0`).

<sup>Written for commit 0f9b1be0430a12a27cd63231cdd49e7d2f046803. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

