### PR TITLE
fix(security): enforce read authorization when signing S3 objects

### DIFF
--- a/backend/tests/sign_s3_objects_authz.rs
+++ b/backend/tests/sign_s3_objects_authz.rs
@@ -1,0 +1,124 @@
+//! Regression test for the `sign_s3_objects` permission bypass.
+//!
+//! Invariant: minting an S3 read signature (`apps/sign_s3_objects`) requires the
+//! CALLER to hold `S3Permission::READ` on the key. The signature is a transferable
+//! bearer capability (`validate_s3_signature` only checks HMAC + expiry), so a
+//! caller must not be able to sign a key they cannot themselves read — otherwise
+//! any workspace member could bypass the advanced S3 permission rules.
+//!
+//! Pinned against a FilesystemStorage LFS whose advanced permissions grant a
+//! non-admin READ on `allowed/*` but nothing on `secret/*`:
+//!   - the non-admin CAN sign `allowed/*` (authorized), and the minted signature
+//!     validates end-to-end through the presigned s3_proxy fetch route;
+//!   - the non-admin CANNOT sign `secret/*` (bypass closed);
+//! Advanced S3 permissions are an enterprise feature, so this test requires the
+//! `enterprise` + `private` + `parquet` features.
+#![cfg(all(feature = "enterprise", feature = "private", feature = "parquet"))]
+
+use serde_json::json;
+use sqlx::{Pool, Postgres};
+use windmill_test_utils::*;
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+fn authed(builder: reqwest::RequestBuilder, token: &str) -> reqwest::RequestBuilder {
+    builder.header("Authorization", format!("Bearer {}", token))
+}
+
+/// Configure the workspace LFS as a filesystem store rooted at `root_path`, with
+/// an advanced permission rule granting READ on `allowed/*` to everyone the glob
+/// matches (non-admins included). No rule covers `secret/*`, so it is denied.
+async fn configure_lfs(db: &Pool<Postgres>, root_path: &str) -> anyhow::Result<()> {
+    let lfs_config = json!({
+        "type": "FilesystemStorage",
+        "root_path": root_path,
+        "public_resource": null,
+        "advanced_permissions": [
+            { "pattern": "allowed/*", "allow": "read" }
+        ]
+    });
+    sqlx::query!(
+        "UPDATE workspace_settings SET large_file_storage = $1 WHERE workspace_id = $2",
+        lfs_config,
+        "test-workspace"
+    )
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+#[sqlx::test(fixtures("base"))]
+async fn test_sign_s3_objects_enforces_read_authz(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base = format!("http://localhost:{port}/api/w/test-workspace");
+
+    let storage_dir = tempfile::tempdir()?;
+    let storage_root = storage_dir.path().to_string_lossy().to_string();
+    configure_lfs(&db, &storage_root).await?;
+
+    // A real object so the signed fetch can stream bytes end-to-end.
+    let allowed_dir = storage_dir.path().join("allowed");
+    std::fs::create_dir_all(&allowed_dir)?;
+    std::fs::write(allowed_dir.join("file.txt"), b"authorized payload")?;
+
+    // ---- CORE REGRESSION: a non-admin (test-user-2) may NOT sign a key they have
+    //      no READ permission on. Before the fix this returned a valid signature.
+    let resp = authed(
+        client().post(format!("{base}/apps/sign_s3_objects")),
+        "SECRET_TOKEN_2",
+    )
+    .json(&json!({ "s3_objects": [{ "s3": "secret/file.txt" }] }))
+    .send()
+    .await?;
+    let status = resp.status();
+    let body = resp.text().await?;
+    assert!(
+        !status.is_success(),
+        "non-admin must NOT be able to sign a key they cannot read (bypass): {status} {body}"
+    );
+
+    // ---- NO OVER-BLOCKING: the same non-admin CAN sign a key their advanced
+    //      permissions allow them to read.
+    let resp = authed(
+        client().post(format!("{base}/apps/sign_s3_objects")),
+        "SECRET_TOKEN_2",
+    )
+    .json(&json!({ "s3_objects": [{ "s3": "allowed/file.txt" }] }))
+    .send()
+    .await?;
+    let status = resp.status();
+    let signed: serde_json::Value = resp.json().await?;
+    assert!(
+        status.is_success(),
+        "non-admin must be able to sign a key they can read: {status} {signed}"
+    );
+    let presigned = signed[0]["presigned"]
+        .as_str()
+        .expect("authorized sign must return a presigned string")
+        .to_string();
+
+    // ---- END-TO-END: the minted signature is accepted by the fetch-side gate.
+    //      Hit the presigned s3_proxy route (default storage) and confirm it
+    //      streams the object rather than rejecting the signature.
+    let fetch_url = format!("{base}/s3_proxy/_default_/allowed/file.txt?{presigned}");
+    let resp = client().get(&fetch_url).send().await?;
+    let status = resp.status();
+    let body = resp.bytes().await?;
+    assert!(
+        status.is_success(),
+        "signed fetch of an authorized key must succeed end-to-end: {status} {:?}",
+        String::from_utf8_lossy(&body)
+    );
+    assert_eq!(
+        body.as_ref(),
+        b"authorized payload",
+        "signed fetch must stream the authorized object's bytes"
+    );
+
+    Ok(())
+}

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -11924,7 +11924,7 @@ paths:
 
   /w/{workspace}/apps/sign_s3_objects:
     post:
-      summary: sign s3 objects, to be used by anonymous users in public apps
+      summary: sign s3 objects (caller must have S3 read permission on each key); the signed URLs can then be used by anonymous users in public apps
       operationId: signS3Objects
       tags:
         - app

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -3266,6 +3266,7 @@ struct S3TokenRequestBody {
 }
 #[cfg(feature = "parquet")]
 async fn sign_s3_objects(
+    authed: ApiAuthed,
     Extension(db): Extension<DB>,
     Path(w_id): Path<String>,
     Json(body): Json<S3TokenRequestBody>,
@@ -3273,6 +3274,22 @@ async fn sign_s3_objects(
     let workspace_key = get_workspace_key(&w_id, &db).await?;
 
     let futures = body.s3_objects.into_iter().map(|s3_object| async {
+        // The signature this mints is a transferable bearer capability: `validate_s3_signature`
+        // only checks the HMAC and expiry, so anyone who obtains the string can read this key.
+        // Authorize the CALLER's own read permission before signing — otherwise any workspace
+        // member (operators included) could mint a signature for any key and bypass the advanced
+        // S3 permission rules. This is the fix; do NOT move the check to validation time.
+        let db_with_opt_authed = DbWithOptAuthed::from_authed(&authed, db.clone(), None);
+        get_workspace_s3_resource_and_check_paths(
+            &db_with_opt_authed,
+            Some(&authed),
+            &w_id,
+            s3_object.storage.clone(),
+            &[(&s3_object.s3, S3Permission::READ)],
+            None,
+        )
+        .await?;
+
         let exp = (chrono::Utc::now() + chrono::Duration::hours(12)).timestamp();
         let mut message = format!("file_key={}&exp={}", s3_object.s3.clone(), exp);
         if let Some(ref storage) = s3_object.storage {


### PR DESCRIPTION
## Summary

`sign_s3_objects` (`POST /w/{workspace}/apps/sign_s3_objects`) minted a long-lived HMAC **bearer** signature for any S3 key handed to it, by any authenticated workspace member, with **no check that the caller was allowed to read that key**. At fetch time, `validate_s3_signature` only verifies the HMAC and expiry. Net effect: any workspace member (operators included) could mint a transferable capability to read arbitrary S3 keys, **bypassing the advanced S3 permission rules** (`check_lfs_object_path_permissions`).

This PR authorizes the read **at mint time**: a caller may only sign keys they are actually allowed to read. The fetch-side validators are intentionally left unchanged — the mint-time check is the fix.

## Investigation

- **Sole minter**: `sign_s3_objects` is the only place `presigned` is ever set. It had no auth extractor and no permission check.
- **Callers**: `signS3Objects` is never called from frontend source or the CLI — only the generated client method exists. It is invoked exclusively via the `wmill` SDK **from inside app-author jobs**, whose ephemeral token authenticates as the executing identity (the author, in on-behalf execution mode). That identity *can* read the key, so a caller-read check does not break legitimate app display.
- **Fetch side**: `validate_s3_signature` (used by the presigned `s3_proxy` `get_object` path and by `download_s3_file_from_app`'s `sig` branch) is unchanged.
- **Operators / any member**: the route is on the authenticated `workspaced_service`; the read-permission check naturally constrains them to keys they can read.
- No caller legitimately signs a key the executing identity cannot read, so **no app-scoped on-behalf signing endpoint is needed** — that display-side concern is handled by the separate `deployed-app-s3-onbehalf` work. This PR stays focused on the mint bypass.

## Changes

- `sign_s3_objects` gains an `ApiAuthed` extractor and, before signing each object, requires the **caller's** `S3Permission::READ` on that key via `get_workspace_s3_resource_and_check_paths` (per-object `storage` passed through so the correct LFS advanced-permission rules apply). A caller that is not authorized to read a key is refused instead of receiving a signature.
- A code comment at the mint site documents the bearer/transferability caveat and why the check must be at mint time (not validation time).
- `openapi.yaml`: corrected the endpoint summary to state the caller must hold S3 read permission (schema unchanged; no client regeneration needed).
- New integration test `backend/tests/sign_s3_objects_authz.rs` (gated `enterprise + private + parquet`).

## Behavior change (intended)

An authenticated member who is **not** granted `READ` by the workspace's advanced S3 permission rules now gets an authorization error from `sign_s3_objects` where they previously received a working signature. Broad-audience app display should rely on a `public_resource`-backed store or an advanced-permissions `read` rule. Legacy (non-advanced) permissions and admins are unaffected.

## Known tradeoff

The per-object authorization reuses the canonical `get_workspace_s3_resource_and_check_paths` gate, which also materializes (and discards) the S3 resource. For OIDC/workload-identity storages this mints a throwaway token per object. Kept for consistency with the other S3 endpoints and to stay within the security-fix scope; a lighter permission-only path is possible as a follow-up.

## Test plan

- [x] `cargo check --features enterprise,private,parquet -p windmill-api`
- [x] `cargo check --features parquet -p windmill-api` (CE stub path)
- [x] `cargo test -p windmill --features enterprise,private,parquet --test sign_s3_objects_authz` — passes:
  - authorized non-admin **can** sign a key their advanced-permission rule allows (`allowed/*`);
  - unauthorized non-admin **cannot** sign a key with no rule (`secret/*`) — bypass closed;
  - the minted signature validates **end-to-end** through the presigned `s3_proxy` fetch route (streams the object bytes).
- No frontend changes (pure backend fix); the dev backend runs `--features quickjs` which does not compile the parquet-gated path or serve S3, so this is validated by the integration test rather than the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces read authorization when minting S3 signatures to close a bypass where any authenticated workspace member could create a transferable read token for arbitrary keys. The POST /w/{workspace}/apps/sign_s3_objects endpoint now only signs keys the caller can read.

- **Bug Fixes**
  - Added `ApiAuthed` and per-object checks via get_workspace_s3_resource_and_check_paths to require caller read permission before signing.
  - Updated OpenAPI summary to state the read-permission requirement (no schema/client changes).
  - Added an integration test: unauthorized user cannot sign `secret/*`; authorized user can sign `allowed/*`; signature validates end-to-end through the presigned fetch route.

<sup>Written for commit c47f8a416ebcabd2f7bb8fa7327d13938bce223a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

