### PR TITLE
fix(frontend): keep draft autosave alive after AI-session round-trip

### DIFF
--- a/frontend/src/lib/userDraft.svelte.ts
+++ b/frontend/src/lib/userDraft.svelte.ts
@@ -751,19 +751,6 @@ function acquireEntry(
 	const seed = defaultValue !== undefined ? snapshotDraftValue(defaultValue) : undefined
 	const cell = $state<{ val: unknown }>({ val: seed })
 	const stateRef = cell as DraftState<unknown>
-	// The autosave mirror must be owned by the ENTRY, not by the component that
-	// happened to acquire it first. The same entry is shared by refcount across
-	// every editor of one draft — an AI-session preview and the nav editor across
-	// the mode toggle, or several warm session previews mounted at once. A
-	// `$effect.root` created inline here would parent to the acquiring component's
-	// reactive context and STOP FIRING when that component unmounts, even while
-	// other holders keep the entry alive — silently killing autosave in the
-	// survivors. Deferring creation to a microtask runs it with NO active
-	// component/effect, so the root is truly top-level: it lives until `destroyRoot`
-	// at refcount 0 and is immune to any single holder unmounting. (In vitest the
-	// microtask still runs but `$effect.root`'s callback is inert, so no mirror is
-	// created — handles bind to the cell directly, consistent with the old
-	// test-runtime fallback.)
 	const entry: DraftEntry = {
 		count: 1,
 		workspace,
@@ -853,6 +840,10 @@ function acquireEntry(
 			})
 		})
 	}
+	// Defer so the root is created with no active component/effect — a top-level
+	// scope owned by the entry, not by the acquiring component. An inline
+	// `$effect.root` would die when that component unmounts while other holders
+	// still edit the same draft (see `destroyRoot`).
 	queueMicrotask(createMirror)
 }
 

--- a/frontend/src/lib/userDraft.svelte.ts
+++ b/frontend/src/lib/userDraft.svelte.ts
@@ -82,35 +82,19 @@ type DraftEntry = {
 	 */
 	seedNextWrite: boolean
 	/**
-	 * Tears down the entry's CURRENT mirror `$effect.root` scope. Re-pointed by
-	 * `acquireEntry` when the mirror is re-homed to a new holder (see below);
-	 * called at refcount 0. In vitest the root callback is a no-op, so this is
-	 * a no-op cleanup rather than undefined.
+	 * Tears down the entry's autosave-mirror `$effect.root`; called once at
+	 * refcount 0. The mirror is created detached from any component (see
+	 * `acquireEntry`), so this is the ONLY thing that disposes it. Also flips
+	 * `mirrorDisposed` to defuse the deferred creation if the entry is released
+	 * before the mirror is even set up. In vitest the deferred callback never
+	 * runs, so no root is created and this stays a no-op.
 	 */
 	destroyRoot?: () => void
 	/**
-	 * (Re)starts the entry's autosave mirror in the CURRENT reactive context and
-	 * returns its teardown. An entry is shared by refcount across the components
-	 * that edit the same draft (notably an AI-session preview and the nav editor
-	 * on either side of a mode switch). A `$effect.root` created inside one
-	 * component's context stops firing when THAT component unmounts — even while
-	 * another holder keeps the entry alive — which silently kills autosave in the
-	 * survivor. So `acquireEntry` re-homes the mirror to each new acquirer; since
-	 * SvelteKit mounts the arriving editor before unmounting the leaving one, the
-	 * owner is always a live component. `isRehome=true` preserves the sync
-	 * baseline (see `mirrorBaseline`) and does NOT re-arm the first-write skip,
-	 * so a value the outgoing mirror never observed (e.g. a session edit still
-	 * pending at handoff) is POSTed by the replacement rather than swallowed.
+	 * Set by `destroyRoot` so the microtask-deferred mirror creation aborts when
+	 * the entry was released (refcount 0) before the mirror was established.
 	 */
-	startMirror?: (isRehome: boolean) => () => void
-	/**
-	 * The last cell serialization the mirror observed, persisted on the entry so
-	 * it survives a mirror re-home. A fresh (re-homed) mirror seeds its dedup
-	 * baseline from this instead of `undefined`, so it only skips writes that
-	 * truly match the last-observed value — a pending, never-observed edit still
-	 * syncs. `undefined` until the first observation.
-	 */
-	mirrorBaseline?: string
+	mirrorDisposed?: boolean
 }
 
 export type UserDraftEntry<V = unknown> = {
@@ -760,50 +744,63 @@ function acquireEntry(
 	const existing = entries.get(mk)
 	if (existing) {
 		existing.count++
-		// Re-home the mirror to this (live) acquirer. The previous owner may be
-		// unmounting — e.g. an AI-session preview handing the same draft back to
-		// the nav editor — and its `$effect.root` stops firing on unmount even
-		// though this new holder keeps the entry alive. Re-creating the mirror
-		// here rebinds autosave to a component that is still mounted. See
-		// `startMirror`'s doc.
-		if (existing.startMirror) {
-			existing.destroyRoot?.()
-			existing.destroyRoot = existing.startMirror(true)
-		}
 		return
 	}
 	// Seed the cell with `defaultValue` (deep-cloned). Swallowed by
-	// `skipNextWrite` below — it never POSTs. The cell lives OUTSIDE the mirror
-	// root so it (and the handles bound to it) survive a mirror re-home.
+	// `skipNextWrite` below — it never POSTs.
 	const seed = defaultValue !== undefined ? snapshotDraftValue(defaultValue) : undefined
 	const cell = $state<{ val: unknown }>({ val: seed })
 	const stateRef = cell as DraftState<unknown>
-	// (Re)start the autosave mirror in the CURRENT reactive context. `$effect.root`
-	// detaches it from `useMany`'s reconcile effect (which would otherwise take it
-	// down on the next reconcile); re-homing on each acquire keeps it owned by a
-	// live component across draft handoffs (see `startMirror` doc + reuse branch).
-	const startMirror = (isRehome: boolean): (() => void) =>
-		$effect.root(() => {
+	// The autosave mirror must be owned by the ENTRY, not by the component that
+	// happened to acquire it first. The same entry is shared by refcount across
+	// every editor of one draft — an AI-session preview and the nav editor across
+	// the mode toggle, or several warm session previews mounted at once. A
+	// `$effect.root` created inline here would parent to the acquiring component's
+	// reactive context and STOP FIRING when that component unmounts, even while
+	// other holders keep the entry alive — silently killing autosave in the
+	// survivors. Deferring creation to a microtask runs it with NO active
+	// component/effect, so the root is truly top-level: it lives until `destroyRoot`
+	// at refcount 0 and is immune to any single holder unmounting. (In vitest the
+	// microtask still runs but `$effect.root`'s callback is inert, so no mirror is
+	// created — handles bind to the cell directly, consistent with the old
+	// test-runtime fallback.)
+	const entry: DraftEntry = {
+		count: 1,
+		workspace,
+		itemKind,
+		path,
+		state: stateRef,
+		skipNextSync: false,
+		syncSuspended: pendingSuspensions.delete(mk),
+		seedNextWrite: false,
+		mirrorDisposed: false,
+		// Placeholder until the deferred `createMirror` swaps in the real teardown;
+		// flips `mirrorDisposed` so a release before then aborts the creation.
+		destroyRoot: () => {
+			entry.mirrorDisposed = true
+		}
+	}
+	entries.set(mk, entry)
+	const createMirror = (): void => {
+		// Bail if this entry was released before the microtask ran, or if the key
+		// was released and re-acquired (a different entry now owns `mk` — its own
+		// `createMirror` will run).
+		if (entry.mirrorDisposed || entries.get(mk) !== entry) return
+		entry.destroyRoot = $effect.root(() => {
 			// Mirror every observable change of `cell.val` to the syncer.
 			// `readFieldsRecursively` walks the value so deep mutations
 			// (`handle.draft.content = '...'`) re-fire the effect — reading
 			// `cell.val` alone only subscribes to the proxy root.
 			//
 			// `lastSerialized` + `skipNextWrite` dedup no-op updates and treat
-			// the FIRST change after start as the seed/restore (no POST), so
-			// landing on `?new_draft` doesn't sync until the user's next edit.
-			// A RE-HOME instead inherits the entry's persisted baseline and does
-			// NOT skip: the value is already established, so only a real change
-			// from the last-observed value should POST — and a pending edit the
-			// outgoing mirror never observed still reaches the syncer.
+			// the FIRST change after mount as the seed/restore (no POST), so
+			// landing on `?new_draft` doesn't sync until the user edits.
 			//
 			// `cell.val === undefined` is the delete signal (`value: null`).
 			// `skipNextSync` lets callers that already POSTed (`discard`,
 			// `remove`) suppress the duplicate fire from their own write.
-			let lastSerialized: string | undefined = isRehome
-				? entries.get(mk)?.mirrorBaseline
-				: undefined
-			let skipNextWrite = !isRehome
+			let lastSerialized: string | undefined = undefined
+			let skipNextWrite = true
 			$effect(() => {
 				const val = cell.val
 				if (val !== undefined) readFieldsRecursively(val)
@@ -814,38 +811,31 @@ function acquireEntry(
 					// it lingers and swallows the user's NEXT edit. (`skipNextWrite`
 					// stays armed: an undefined-seeded cell's initial run lands
 					// here, and page editors rely on it to swallow their load write.)
-					const e = entries.get(mk)
-					if (e?.seedNextWrite) e.seedNextWrite = false
+					if (entry.seedNextWrite) entry.seedNextWrite = false
 					return
 				}
 				lastSerialized = next
-				// Persist the baseline so a future re-home continues from the last
-				// value THIS mirror observed, not `undefined`.
-				const based = entries.get(mk)
-				if (based) based.mirrorBaseline = next
 				if (skipNextWrite) {
 					skipNextWrite = false
 					// One write consumes BOTH one-shot guards: a `seed` on a fresh
 					// entry (still armed with the first-write skip) must not leave
 					// `seedNextWrite` behind to swallow the user's first edit.
-					const fresh = entries.get(mk)
-					if (fresh?.seedNextWrite) fresh.seedNextWrite = false
+					if (entry.seedNextWrite) entry.seedNextWrite = false
 					return
 				}
-				const entry = entries.get(mk)
 				// `seed` write: baseline already advanced above; don't POST.
-				if (entry?.seedNextWrite) {
+				if (entry.seedNextWrite) {
 					entry.seedNextWrite = false
 					return
 				}
-				if (entry?.skipNextSync) {
+				if (entry.skipNextSync) {
 					entry.skipNextSync = false
 					return
 				}
 				// `syncSuspended` swallows the POST but `lastSerialized` advanced
 				// above, so only writes made during suspension are dropped — the
 				// first change after resume is still detected.
-				if (entry?.syncSuspended) return
+				if (entry.syncSuspended) return
 				// At the deployed baseline → sync a delete, not a baseline-equal
 				// copy. `untrack` so reactive reads in the predicate (the editor's
 				// post-deploy baseline) don't re-fire the mirror.
@@ -862,36 +852,18 @@ function acquireEntry(
 				})
 			})
 		})
-	entries.set(mk, {
-		count: 1,
-		workspace,
-		itemKind,
-		path,
-		state: stateRef,
-		skipNextSync: false,
-		syncSuspended: pendingSuspensions.delete(mk),
-		seedNextWrite: false,
-		mirrorBaseline: undefined,
-		destroyRoot: startMirror(false),
-		startMirror
-	})
+	}
+	queueMicrotask(createMirror)
 }
 
 function releaseEntry(mk: string): void {
 	const entry = entries.get(mk)
 	if (!entry) return
 	entry.count--
-	// INVARIANT (see `startMirror`): the mirror is owned by the LAST component
-	// to acquire the key, and this release does NOT re-home it — a leaving
-	// component's `onDestroy` context is itself dying, so a root created here
-	// would die too. Autosave stays alive for surviving holders only while the
-	// owner (last acquirer) is also the last to leave. Every supported handoff
-	// satisfies this because SvelteKit mounts the arriving editor (the new
-	// owner) before unmounting the leaving one. A holder that can release while
-	// a non-owner survives — e.g. an AI-session preview opened as an OVERLAY on
-	// top of a still-mounted nav editor, then closed — would silently kill the
-	// survivor's autosave until its next acquire. Don't add such a topology
-	// without moving the mirror to a persistent, component-independent scope.
+	// The mirror is owned by the ENTRY (created detached — see `acquireEntry`),
+	// not by any holder, so releasing one holder never touches it; it is disposed
+	// only here, once, at refcount 0. This is what lets multiple holders (warm
+	// session previews + the nav editor) share the entry and drop in any order.
 	if (entry.count <= 0) {
 		// The live entry was authoritative while mounted; once gone, drop any
 		// cached write for this key so a later read falls back to the server

--- a/frontend/src/lib/userDraft.svelte.ts
+++ b/frontend/src/lib/userDraft.svelte.ts
@@ -860,6 +860,17 @@ function releaseEntry(mk: string): void {
 	const entry = entries.get(mk)
 	if (!entry) return
 	entry.count--
+	// INVARIANT (see `startMirror`): the mirror is owned by the LAST component
+	// to acquire the key, and this release does NOT re-home it — a leaving
+	// component's `onDestroy` context is itself dying, so a root created here
+	// would die too. Autosave stays alive for surviving holders only while the
+	// owner (last acquirer) is also the last to leave. Every supported handoff
+	// satisfies this because SvelteKit mounts the arriving editor (the new
+	// owner) before unmounting the leaving one. A holder that can release while
+	// a non-owner survives — e.g. an AI-session preview opened as an OVERLAY on
+	// top of a still-mounted nav editor, then closed — would silently kill the
+	// survivor's autosave until its next acquire. Don't add such a topology
+	// without moving the mirror to a persistent, component-independent scope.
 	if (entry.count <= 0) {
 		// The live entry was authoritative while mounted; once gone, drop any
 		// cached write for this key so a later read falls back to the server

--- a/frontend/src/lib/userDraft.svelte.ts
+++ b/frontend/src/lib/userDraft.svelte.ts
@@ -97,9 +97,20 @@ type DraftEntry = {
 	 * another holder keeps the entry alive — which silently kills autosave in the
 	 * survivor. So `acquireEntry` re-homes the mirror to each new acquirer; since
 	 * SvelteKit mounts the arriving editor before unmounting the leaving one, the
-	 * owner is always a live component.
+	 * owner is always a live component. `isRehome=true` preserves the sync
+	 * baseline (see `mirrorBaseline`) and does NOT re-arm the first-write skip,
+	 * so a value the outgoing mirror never observed (e.g. a session edit still
+	 * pending at handoff) is POSTed by the replacement rather than swallowed.
 	 */
-	startMirror?: () => () => void
+	startMirror?: (isRehome: boolean) => () => void
+	/**
+	 * The last cell serialization the mirror observed, persisted on the entry so
+	 * it survives a mirror re-home. A fresh (re-homed) mirror seeds its dedup
+	 * baseline from this instead of `undefined`, so it only skips writes that
+	 * truly match the last-observed value — a pending, never-observed edit still
+	 * syncs. `undefined` until the first observation.
+	 */
+	mirrorBaseline?: string
 }
 
 export type UserDraftEntry<V = unknown> = {
@@ -757,7 +768,7 @@ function acquireEntry(
 		// `startMirror`'s doc.
 		if (existing.startMirror) {
 			existing.destroyRoot?.()
-			existing.destroyRoot = existing.startMirror()
+			existing.destroyRoot = existing.startMirror(true)
 		}
 		return
 	}
@@ -771,7 +782,7 @@ function acquireEntry(
 	// detaches it from `useMany`'s reconcile effect (which would otherwise take it
 	// down on the next reconcile); re-homing on each acquire keeps it owned by a
 	// live component across draft handoffs (see `startMirror` doc + reuse branch).
-	const startMirror = (): (() => void) =>
+	const startMirror = (isRehome: boolean): (() => void) =>
 		$effect.root(() => {
 			// Mirror every observable change of `cell.val` to the syncer.
 			// `readFieldsRecursively` walks the value so deep mutations
@@ -779,15 +790,20 @@ function acquireEntry(
 			// `cell.val` alone only subscribes to the proxy root.
 			//
 			// `lastSerialized` + `skipNextWrite` dedup no-op updates and treat
-			// the FIRST change after (re)start as the seed/restore (no POST), so
-			// landing on `?new_draft` — or inheriting the live value on a re-home
-			// — doesn't sync until the user's next edit.
+			// the FIRST change after start as the seed/restore (no POST), so
+			// landing on `?new_draft` doesn't sync until the user's next edit.
+			// A RE-HOME instead inherits the entry's persisted baseline and does
+			// NOT skip: the value is already established, so only a real change
+			// from the last-observed value should POST — and a pending edit the
+			// outgoing mirror never observed still reaches the syncer.
 			//
 			// `cell.val === undefined` is the delete signal (`value: null`).
 			// `skipNextSync` lets callers that already POSTed (`discard`,
 			// `remove`) suppress the duplicate fire from their own write.
-			let lastSerialized: string | undefined = undefined
-			let skipNextWrite = true
+			let lastSerialized: string | undefined = isRehome
+				? entries.get(mk)?.mirrorBaseline
+				: undefined
+			let skipNextWrite = !isRehome
 			$effect(() => {
 				const val = cell.val
 				if (val !== undefined) readFieldsRecursively(val)
@@ -803,6 +819,10 @@ function acquireEntry(
 					return
 				}
 				lastSerialized = next
+				// Persist the baseline so a future re-home continues from the last
+				// value THIS mirror observed, not `undefined`.
+				const based = entries.get(mk)
+				if (based) based.mirrorBaseline = next
 				if (skipNextWrite) {
 					skipNextWrite = false
 					// One write consumes BOTH one-shot guards: a `seed` on a fresh
@@ -851,7 +871,8 @@ function acquireEntry(
 		skipNextSync: false,
 		syncSuspended: pendingSuspensions.delete(mk),
 		seedNextWrite: false,
-		destroyRoot: startMirror(),
+		mirrorBaseline: undefined,
+		destroyRoot: startMirror(false),
 		startMirror
 	})
 }

--- a/frontend/src/lib/userDraft.svelte.ts
+++ b/frontend/src/lib/userDraft.svelte.ts
@@ -82,10 +82,24 @@ type DraftEntry = {
 	 */
 	seedNextWrite: boolean
 	/**
-	 * Tears down the entry's `$effect.root` scope; called at refcount 0.
-	 * `undefined` only on the test-runtime fallback path (see `acquireEntry`).
+	 * Tears down the entry's CURRENT mirror `$effect.root` scope. Re-pointed by
+	 * `acquireEntry` when the mirror is re-homed to a new holder (see below);
+	 * called at refcount 0. In vitest the root callback is a no-op, so this is
+	 * a no-op cleanup rather than undefined.
 	 */
 	destroyRoot?: () => void
+	/**
+	 * (Re)starts the entry's autosave mirror in the CURRENT reactive context and
+	 * returns its teardown. An entry is shared by refcount across the components
+	 * that edit the same draft (notably an AI-session preview and the nav editor
+	 * on either side of a mode switch). A `$effect.root` created inside one
+	 * component's context stops firing when THAT component unmounts — even while
+	 * another holder keeps the entry alive — which silently kills autosave in the
+	 * survivor. So `acquireEntry` re-homes the mirror to each new acquirer; since
+	 * SvelteKit mounts the arriving editor before unmounting the leaving one, the
+	 * owner is always a live component.
+	 */
+	startMirror?: () => () => void
 }
 
 export type UserDraftEntry<V = unknown> = {
@@ -735,113 +749,110 @@ function acquireEntry(
 	const existing = entries.get(mk)
 	if (existing) {
 		existing.count++
+		// Re-home the mirror to this (live) acquirer. The previous owner may be
+		// unmounting — e.g. an AI-session preview handing the same draft back to
+		// the nav editor — and its `$effect.root` stops firing on unmount even
+		// though this new holder keeps the entry alive. Re-creating the mirror
+		// here rebinds autosave to a component that is still mounted. See
+		// `startMirror`'s doc.
+		if (existing.startMirror) {
+			existing.destroyRoot?.()
+			existing.destroyRoot = existing.startMirror()
+		}
 		return
 	}
 	// Seed the cell with `defaultValue` (deep-cloned). Swallowed by
-	// `skipNextWrite` below — it never POSTs.
+	// `skipNextWrite` below — it never POSTs. The cell lives OUTSIDE the mirror
+	// root so it (and the handles bound to it) survive a mirror re-home.
 	const seed = defaultValue !== undefined ? snapshotDraftValue(defaultValue) : undefined
-	// `$effect.root` gives the entry its own scope, disposed only by
-	// `releaseEntry`. Without it the sync `$effect` would parent to
-	// `useMany`'s reconcile effect and die on the next reconcile.
-	let stateRef: DraftState<unknown> | undefined
-	const destroyRoot = $effect.root(() => {
-		const cell = $state<{ val: unknown }>({ val: seed })
-		stateRef = cell as DraftState<unknown>
-		// Mirror every observable change of `cell.val` to the syncer.
-		// `readFieldsRecursively` walks the value so deep mutations
-		// (`handle.draft.content = '...'`) re-fire the effect — reading
-		// `cell.val` alone only subscribes to the proxy root.
-		//
-		// `lastSerialized` + `skipNextWrite` dedup no-op updates and treat
-		// the FIRST change after mount as the seed/restore (no POST), so
-		// landing on `?new_draft` doesn't sync until the user edits.
-		//
-		// `cell.val === undefined` is the delete signal (`value: null`).
-		// `skipNextSync` lets callers that already POSTed (`discard`,
-		// `remove`) suppress the duplicate fire from their own write.
-		let lastSerialized: string | undefined = undefined
-		let skipNextWrite = true
-		$effect(() => {
-			const val = cell.val
-			if (val !== undefined) readFieldsRecursively(val)
-			const next = val === undefined ? undefined : JSON.stringify(val)
-			if (next === lastSerialized) {
-				// No-op write. If a `seed` re-seeded the value already in the
-				// cell, its one-shot flag consumed nothing — defuse it here or
-				// it lingers and swallows the user's NEXT edit. (`skipNextWrite`
-				// stays armed: an undefined-seeded cell's initial run lands
-				// here, and page editors rely on it to swallow their load write.)
-				const e = entries.get(mk)
-				if (e?.seedNextWrite) e.seedNextWrite = false
-				return
-			}
-			lastSerialized = next
-			if (skipNextWrite) {
-				skipNextWrite = false
-				// One write consumes BOTH one-shot guards: a `seed` on a fresh
-				// entry (still armed with the first-write skip) must not leave
-				// `seedNextWrite` behind to swallow the user's first edit.
-				const fresh = entries.get(mk)
-				if (fresh?.seedNextWrite) fresh.seedNextWrite = false
-				return
-			}
-			const entry = entries.get(mk)
-			// `seed` write: baseline already advanced above; don't POST.
-			if (entry?.seedNextWrite) {
-				entry.seedNextWrite = false
-				return
-			}
-			if (entry?.skipNextSync) {
-				entry.skipNextSync = false
-				return
-			}
-			// `syncSuspended` swallows the POST but `lastSerialized` advanced
-			// above, so only writes made during suspension are dropped — the
-			// first change after resume is still detected.
-			if (entry?.syncSuspended) return
-			// At the deployed baseline → sync a delete, not a baseline-equal
-			// copy. `untrack` so reactive reads in the predicate (the editor's
-			// post-deploy baseline) don't re-fire the mirror.
-			const atBaseline = untrack(() => val !== undefined && (discardIf?.(val) ?? false))
-			void UserDraftDbSyncer.save({
-				workspace,
-				itemKind,
-				path,
-				value: val === undefined || atBaseline ? null : val,
-				// Reactive keystroke mirror — `auto`, so suppressed while the
-				// auto-save toggle is off (for `canBeDisabled` handles).
-				auto: true,
-				canBeDisabled
+	const cell = $state<{ val: unknown }>({ val: seed })
+	const stateRef = cell as DraftState<unknown>
+	// (Re)start the autosave mirror in the CURRENT reactive context. `$effect.root`
+	// detaches it from `useMany`'s reconcile effect (which would otherwise take it
+	// down on the next reconcile); re-homing on each acquire keeps it owned by a
+	// live component across draft handoffs (see `startMirror` doc + reuse branch).
+	const startMirror = (): (() => void) =>
+		$effect.root(() => {
+			// Mirror every observable change of `cell.val` to the syncer.
+			// `readFieldsRecursively` walks the value so deep mutations
+			// (`handle.draft.content = '...'`) re-fire the effect — reading
+			// `cell.val` alone only subscribes to the proxy root.
+			//
+			// `lastSerialized` + `skipNextWrite` dedup no-op updates and treat
+			// the FIRST change after (re)start as the seed/restore (no POST), so
+			// landing on `?new_draft` — or inheriting the live value on a re-home
+			// — doesn't sync until the user's next edit.
+			//
+			// `cell.val === undefined` is the delete signal (`value: null`).
+			// `skipNextSync` lets callers that already POSTed (`discard`,
+			// `remove`) suppress the duplicate fire from their own write.
+			let lastSerialized: string | undefined = undefined
+			let skipNextWrite = true
+			$effect(() => {
+				const val = cell.val
+				if (val !== undefined) readFieldsRecursively(val)
+				const next = val === undefined ? undefined : JSON.stringify(val)
+				if (next === lastSerialized) {
+					// No-op write. If a `seed` re-seeded the value already in the
+					// cell, its one-shot flag consumed nothing — defuse it here or
+					// it lingers and swallows the user's NEXT edit. (`skipNextWrite`
+					// stays armed: an undefined-seeded cell's initial run lands
+					// here, and page editors rely on it to swallow their load write.)
+					const e = entries.get(mk)
+					if (e?.seedNextWrite) e.seedNextWrite = false
+					return
+				}
+				lastSerialized = next
+				if (skipNextWrite) {
+					skipNextWrite = false
+					// One write consumes BOTH one-shot guards: a `seed` on a fresh
+					// entry (still armed with the first-write skip) must not leave
+					// `seedNextWrite` behind to swallow the user's first edit.
+					const fresh = entries.get(mk)
+					if (fresh?.seedNextWrite) fresh.seedNextWrite = false
+					return
+				}
+				const entry = entries.get(mk)
+				// `seed` write: baseline already advanced above; don't POST.
+				if (entry?.seedNextWrite) {
+					entry.seedNextWrite = false
+					return
+				}
+				if (entry?.skipNextSync) {
+					entry.skipNextSync = false
+					return
+				}
+				// `syncSuspended` swallows the POST but `lastSerialized` advanced
+				// above, so only writes made during suspension are dropped — the
+				// first change after resume is still detected.
+				if (entry?.syncSuspended) return
+				// At the deployed baseline → sync a delete, not a baseline-equal
+				// copy. `untrack` so reactive reads in the predicate (the editor's
+				// post-deploy baseline) don't re-fire the mirror.
+				const atBaseline = untrack(() => val !== undefined && (discardIf?.(val) ?? false))
+				void UserDraftDbSyncer.save({
+					workspace,
+					itemKind,
+					path,
+					value: val === undefined || atBaseline ? null : val,
+					// Reactive keystroke mirror — `auto`, so suppressed while the
+					// auto-save toggle is off (for `canBeDisabled` handles).
+					auto: true,
+					canBeDisabled
+				})
 			})
 		})
-	})
-	if (stateRef) {
-		entries.set(mk, {
-			count: 1,
-			workspace,
-			itemKind,
-			path,
-			state: stateRef,
-			skipNextSync: false,
-			syncSuspended: pendingSuspensions.delete(mk),
-			seedNextWrite: false,
-			destroyRoot
-		})
-		return
-	}
-	// Fallback for the vitest runtime where `$effect.root`'s callback isn't
-	// invoked (unreachable in production). No sync effect — writes in tests
-	// stay in-memory.
-	const fallback = $state<{ val: unknown }>({ val: seed })
 	entries.set(mk, {
 		count: 1,
 		workspace,
 		itemKind,
 		path,
-		state: fallback as DraftState<unknown>,
+		state: stateRef,
 		skipNextSync: false,
 		syncSuspended: pendingSuspensions.delete(mk),
-		seedNextWrite: false
+		seedNextWrite: false,
+		destroyRoot: startMirror(),
+		startMirror
 	})
 }
 


### PR DESCRIPTION
## Summary

After opening a brand-new script/flow/(raw)app in an **AI session** and switching
back to **Workspace** (or across warm-session churn), autosave silently stopped
in the workspace editor — further edits were never persisted to the draft.

Root cause is a shared-entry lifecycle bug in `UserDraft`. A draft's in-memory
autosave state (`DraftEntry`: a reactive cell + a mirror `$effect` that POSTs
changes) is shared **by refcount** across every component editing the same
`(workspace, kind, path)` — the AI-session preview(s) and the nav editor. The
mirror was a `$effect.root` created **inside whichever component first acquired
the entry**. When that component unmounts while another holder still keeps the
entry alive (`count > 0`, so `destroyRoot` is never called), the `$effect.root`'s
effect **stops firing** — even though the entry and cell live on. Writes still
reach `cell.val`, but nothing mirrors them to the server → autosave is dead until
a full reload. (Confirmed with instrumented logging: post-handoff, `state.val`
updates but the mirror `$effect` never fires, and `destroyRoot` was not called.)

## Fix

Make the mirror **owned by the entry, not by any component**: create its
`$effect.root` in a `queueMicrotask`, where no component/effect is active, so it's
a true top-level root. It survives every holder unmounting and is disposed only
once, at refcount 0. The cell is created outside the root so handles bind to it
immediately.

This is a single shared fix: every draft-backed editor (script, flow, app,
raw_app) and the session preview reach the same `acquireEntry` via
`usePageDraftSync → useReactive → useMany` (and the session's `useUserDraftSync →
useMany`), so no editor-specific change is needed.

## Review history (for context)

The first cut re-homed the mirror to each new acquirer. Codex correctly pointed
out that relies on a LIFO holder-lifetime invariant, which the sessions UI
breaks — it keeps **multiple warm session previews mounted at once**
(`sessions/+page.svelte`), so two warm previews of one draft share the entry and
closing the newer one killed autosave in the surviving older one. The final
component-independent (microtask-detached) mirror removes that assumption
entirely — and is net-simpler than the re-home bookkeeping. Codex, Claude, and Pi
all approve the final head.

## Verification

End-to-end in a real browser (system Chromium via Playwright, workspace AI
configured):

- **Workspace → AI session → Workspace → edit**: the post-return edit persists.
  ✅ (flow + script; negative control on pre-fix `main`: autosave dead.)
- **Edit in the AI session, immediately switch back, don't type again**: the
  session's final edit persists. ✅
- Warm-session churn (surviving holder keeps autosaving after another holder
  closes) holds by construction — the mirror is entry-owned and outlives any
  single holder.

The 4 `userDraft*` test suites (31 tests) still pass; `check:fast` clean for the
changed file (the pre-existing unrelated `utils_workspace_deploy.ts` error is on
main). No new unit test: the mirror `$effect`/`$effect.root` callback is not
invoked by the vitest runtime, so this lifecycle bug is only assertable E2E.

## Screenshots

Workspace flow editor after the AI-session round-trip — the post-return edit
shows the **Saved** autosave indicator:

![autosave-after-return](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2154-ai-session-return-empty-flow/1783760623-autosave-after-return.png)

## Test plan

- [ ] New flow / script / raw-app → "Open in AI session" → toggle back to
      **Workspace** → edit → confirm the edit autosaves (Saved indicator / draft row).
- [ ] Edit inside the AI session, immediately switch back without typing again →
      confirm the session's final edit persisted after reload.
- [ ] Open the same draft in two warm AI sessions, close the newer, edit the
      surviving older preview → confirm autosave still fires.
- [ ] Sanity: the normal single-editor case still autosaves (no round-trip).