### PR TITLE
fix: clearer errors on auto-draft save failure (WIN-2157)

### DIFF
--- a/backend/windmill-api-auth/src/lib.rs
+++ b/backend/windmill-api-auth/src/lib.rs
@@ -541,6 +541,16 @@ pub fn require_owner_of_path(authed: &ApiAuthed, path: &str) -> Result<()> {
     }
     if !path.is_empty() {
         let splitted = path.split("/").collect::<Vec<&str>>();
+        // A valid path is at least `<kind>/<name>` (e.g. `u/alice/...`,
+        // `f/folder/...`). Guard the `splitted[1]` accesses below so a
+        // malformed single-segment path returns a clear error instead of
+        // panicking with an out-of-bounds index.
+        if splitted.len() < 2 {
+            return Err(Error::BadRequest(format!(
+                "Invalid path '{}': a valid path starts with 'u/<user>/' or 'f/<folder>/'",
+                path
+            )));
+        }
         if splitted[0] == "u" {
             if splitted[1] == authed.username {
                 Ok(())
@@ -1129,6 +1139,26 @@ mod tests {
         assert!(
             require_path_read_access_for_preview(&admin, &Some("f/team/my..script".into())).is_ok()
         );
+    }
+
+    // Regression for WIN-2157: a malformed single-segment path (e.g. a draft
+    // saved at a bare `u`) must return a clear error, not panic on the
+    // `splitted[1]` index. Non-admins reach this branch (admins short-circuit).
+    #[test]
+    fn require_owner_of_path_rejects_malformed_path_without_panicking() {
+        let alice = ApiAuthed { username: "alice".into(), ..Default::default() };
+        for path in ["u", "f", "g", "nonsense"] {
+            let err =
+                require_owner_of_path(&alice, path).expect_err("malformed path must be rejected");
+            assert!(
+                matches!(err, Error::BadRequest(_)),
+                "expected BadRequest for '{path}', got {err:?}"
+            );
+        }
+        // A well-formed foreign path still returns the owner error (unchanged).
+        assert!(require_owner_of_path(&alice, "u/bob/script").is_err());
+        // The user's own namespace still resolves.
+        assert!(require_owner_of_path(&alice, "u/alice/script").is_ok());
     }
 
     #[test]

--- a/backend/windmill-api-auth/src/lib.rs
+++ b/backend/windmill-api-auth/src/lib.rs
@@ -1155,9 +1155,9 @@ mod tests {
                 "expected BadRequest for '{path}', got {err:?}"
             );
         }
-        // A well-formed foreign path still returns the owner error (unchanged).
+        // A well-formed foreign path returns the owner error, not a malformed one.
         assert!(require_owner_of_path(&alice, "u/bob/script").is_err());
-        // The user's own namespace still resolves.
+        // The user's own namespace resolves.
         assert!(require_owner_of_path(&alice, "u/alice/script").is_ok());
     }
 

--- a/backend/windmill-api/src/drafts.rs
+++ b/backend/windmill-api/src/drafts.rs
@@ -745,11 +745,9 @@ async fn require_can_write_path(
             return Ok(());
         }
     }
-    // Nothing granted write access. Give the caller an actionable reason: a
-    // path that doesn't start with a recognized namespace prefix can never be
-    // writable (no namespace rule and no deployed row can apply), so surface it
-    // as a malformed path rather than a bare "no permission" — this is the most
-    // common cause of an autosave failure and the vague message hid it.
+    // A path without a recognized namespace prefix (u/, f/, g/) can never be
+    // writable — no namespace rule and no deployed row can apply — so report it
+    // as malformed rather than as a plain permission denial.
     if !(path.starts_with("u/") || path.starts_with("f/") || path.starts_with("g/")) {
         return Err(Error::BadRequest(format!(
             "Invalid path '{path}': a valid path starts with 'u/<user>/', 'f/<folder>/' or 'g/<group>/'"

--- a/backend/windmill-api/src/drafts.rs
+++ b/backend/windmill-api/src/drafts.rs
@@ -120,7 +120,12 @@ async fn list_drafts(
                     .await
                 {
                     Ok(()) => true,
-                    Err(Error::NotAuthorized(_)) => false,
+                    // A stored draft can sit at an unwritable path: unauthorized,
+                    // or malformed (`BadRequest` — the `draft` table has no path
+                    // constraint, so legacy/admin-authored rows may be malformed).
+                    // Either way it's just not writable; one bad row must not 400
+                    // the whole listing.
+                    Err(Error::NotAuthorized(_)) | Err(Error::BadRequest(_)) => false,
                     Err(e) => return Err(e),
                 };
             out.push(row);

--- a/backend/windmill-api/src/drafts.rs
+++ b/backend/windmill-api/src/drafts.rs
@@ -120,11 +120,10 @@ async fn list_drafts(
                     .await
                 {
                     Ok(()) => true,
-                    // A stored draft can sit at an unwritable path: unauthorized,
-                    // or malformed (`BadRequest` — the `draft` table has no path
-                    // constraint, so legacy/admin-authored rows may be malformed).
-                    // Either way it's just not writable; one bad row must not 400
-                    // the whole listing.
+                    // A stored draft can sit at an unwritable path — unauthorized,
+                    // or malformed (`BadRequest`; the `draft` table has no path
+                    // constraint). Either way it's not writable, and one bad row
+                    // must not 400 the whole listing.
                     Err(Error::NotAuthorized(_)) | Err(Error::BadRequest(_)) => false,
                     Err(e) => return Err(e),
                 };

--- a/backend/windmill-api/src/drafts.rs
+++ b/backend/windmill-api/src/drafts.rs
@@ -745,8 +745,19 @@ async fn require_can_write_path(
             return Ok(());
         }
     }
+    // Nothing granted write access. Give the caller an actionable reason: a
+    // path that doesn't start with a recognized namespace prefix can never be
+    // writable (no namespace rule and no deployed row can apply), so surface it
+    // as a malformed path rather than a bare "no permission" — this is the most
+    // common cause of an autosave failure and the vague message hid it.
+    if !(path.starts_with("u/") || path.starts_with("f/") || path.starts_with("g/")) {
+        return Err(Error::BadRequest(format!(
+            "Invalid path '{path}': a valid path starts with 'u/<user>/', 'f/<folder>/' or 'g/<group>/'"
+        )));
+    }
     Err(Error::NotAuthorized(format!(
-        "you don't have write permission on {path}"
+        "You don't have write permission on '{path}'. It must be in your own 'u/{}/' namespace, or in a folder ('f/<folder>/') or group ('g/<group>/') you can write to.",
+        authed.username
     )))
 }
 

--- a/frontend/src/lib/components/AutosaveIndicator.svelte
+++ b/frontend/src/lib/components/AutosaveIndicator.svelte
@@ -258,7 +258,12 @@
 		closeOnOutsideClick
 	>
 		{#snippet trigger()}
-			<div class="relative rounded-md p-1.5 hover:bg-surface-hover cursor-pointer">
+			<div
+				class="relative rounded-md p-1.5 hover:bg-surface-hover cursor-pointer"
+				title={syncState === 'failed'
+					? `Save failed${failureMessage ? `: ${failureMessage}` : ''} — click for details`
+					: undefined}
+			>
 				{#if editingOtherUserDraft}
 					<!-- Viewing another user's draft: not saved, distinct from the saved check-mark. -->
 					<Eye size={16} class="text-blue-500" />


### PR DESCRIPTION
Fixes WIN-2157

## Problem
When the auto-draft save (the cloud icon in editor headers) fails, the user had little insight into *why*. The most common cause is that they can't write a draft at the target path — because the path is malformed or they lack permission — but the backend returned a vague `you don't have write permission on {path}`, and there was no hover affordance to see the reason.

## Changes

**Frontend** (`AutosaveIndicator.svelte`)
- The failed cloud icon now exposes the backend reason on **hover** via a native `title` tooltip, in addition to the existing click-to-open popover. The issue asked for "something to hover/click" — both are now covered.

**Backend**
- `require_can_write_path` (`drafts.rs`): the failure now distinguishes a **malformed path** (unrecognized `u/`/`f/`/`g/` prefix → `BadRequest` with a clear "a valid path starts with…" message) from a genuine **permission denial**, and the deny message now spells out *where* the user is allowed to write (own `u/<user>/` namespace, a writable folder, or a group).
- `require_owner_of_path` (`windmill-api-auth`): fixed a potential **out-of-bounds panic** on a malformed single-segment path (e.g. a bare `u`/`f`) — it now returns a clear `BadRequest` instead of a 500. Covered by a new regression test.

## Verification

**Unit / compile**
- `cargo test -p windmill-api-auth require_owner_of_path` — passes (new regression test).
- `cargo check -p windmill-api` — compiles cleanly.
- `svelte-check` on the changed component — no new errors.

**Full end-to-end against a real EE backend + real non-admin user** (created the `member` non-admin user in a regular workspace — user creation is EE-only — and called `POST /drafts/update` directly):

| Scenario | Path | Result |
|---|---|---|
| No permission | `u/otheruser/foo` | **401** `Not authorized: You don't have write permission on 'u/otheruser/foo'. It must be in your own 'u/member/' namespace, or in a folder ('f/<folder>/') or group ('g/<group>/') you can write to.` |
| Malformed prefix | `weirdpath/foo` | **400** `Bad request: Invalid path 'weirdpath/foo': a valid path starts with 'u/<user>/', 'f/<folder>/' or 'g/<group>/'` |
| Malformed single-segment (panic fix) | bare `u` / `f` | **400** clean — no 500/panic |
| Control (legitimate) | `u/member/ok` | **200** saved |

The bare `u`/`f` case is the key proof of the panic fix: previously `require_owner_of_path` panicked on the `splitted[1]` index (HTTP 500); it now returns a clean 400.

**Frontend display** (Playwright against the running editor): forced the failing `/drafts/update/` response carrying the exact backend message and confirmed the indicator shows the sticky "Save failed" label, the hover tooltip with the full reason, and the popover contents.

![autosave-failure-popover](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2157-show-error-details-on-auto-draft-save-failure/1783777525-autosave-failure-clean.png)

## CI review
Addressed the shared P2 nit (Codex / Claude / Pi): trimmed the narrative comment in `drafts.rs` to a concise invariant per AGENTS.md ("comments record constraints, not narration", ≤4 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)