### PR TITLE
fix(docker): pin ansible tool interpreter to persistent path

### DIFF
--- a/docker/DockerfileFull
+++ b/docker/DockerfileFull
@@ -6,7 +6,12 @@ COPY --from=rust:1.93.0 /usr/local/rustup /usr/local/rustup
 RUN RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo /usr/local/cargo/bin/cargo install cargo-sweep --version ^0.7
 
 # Ansible
-RUN uv tool install ansible && [ -d "$(uv tool dir)/ansible/bin/" ] && find "$(uv tool dir)/ansible/bin/" -mindepth 1 -maxdepth 1 -type f -executable -regextype posix-extended -regex '^((.+/)?)[^.]+' -print0 | xargs -0 ln -s -t "$UV_TOOL_BIN_DIR/" || true
+# UV_PYTHON_INSTALL_DIR defaults to /tmp/windmill/cache/py_runtime, which is an
+# ephemeral runtime cache (fresh volume/tmpfs, and pruned by the worker). Installing
+# ansible there leaves its venv interpreter as a dangling symlink at runtime, so every
+# ansible-* executable fails with ENOENT ("ansible-galaxy not found"). Pin the tool's
+# interpreter to a persistent image path so the install stays self-contained.
+RUN UV_PYTHON_INSTALL_DIR=/usr/local/uv/py uv tool install ansible && [ -d "$(uv tool dir)/ansible/bin/" ] && find "$(uv tool dir)/ansible/bin/" -mindepth 1 -maxdepth 1 -type f -executable -regextype posix-extended -regex '^((.+/)?)[^.]+' -print0 | xargs -0 ln -sf -t "$UV_TOOL_BIN_DIR/" || true
 
 # C#
 RUN wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh \

--- a/docker/DockerfileFullEe
+++ b/docker/DockerfileFullEe
@@ -25,7 +25,12 @@ COPY --from=rust:1.93.0 /usr/local/rustup /usr/local/rustup
 RUN RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo /usr/local/cargo/bin/cargo install cargo-sweep --version ^0.7
 
 # Ansible
-RUN uv tool install ansible && [ -d "$(uv tool dir)/ansible/bin/" ] && find "$(uv tool dir)/ansible/bin/" -mindepth 1 -maxdepth 1 -type f -executable -regextype posix-extended -regex '^((.+/)?)[^.]+' -print0 | xargs -0 ln -s -t "$UV_TOOL_BIN_DIR/" || true
+# UV_PYTHON_INSTALL_DIR defaults to /tmp/windmill/cache/py_runtime, which is an
+# ephemeral runtime cache (fresh volume/tmpfs, and pruned by the worker). Installing
+# ansible there leaves its venv interpreter as a dangling symlink at runtime, so every
+# ansible-* executable fails with ENOENT ("ansible-galaxy not found"). Pin the tool's
+# interpreter to a persistent image path so the install stays self-contained.
+RUN UV_PYTHON_INSTALL_DIR=/usr/local/uv/py uv tool install ansible && [ -d "$(uv tool dir)/ansible/bin/" ] && find "$(uv tool dir)/ansible/bin/" -mindepth 1 -maxdepth 1 -type f -executable -regextype posix-extended -regex '^((.+/)?)[^.]+' -print0 | xargs -0 ln -sf -t "$UV_TOOL_BIN_DIR/" || true
 # dotnet SDK
 RUN wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh \
     && chmod +x dotnet-install.sh \


### PR DESCRIPTION
## Summary

Fixes WIN-2158.

Ansible jobs on the `windmill-full` / `windmill-full-ee` images can fail with:

```
Error: Internal: Executable /usr/local/bin/ansible-galaxy not found on worker.
PATH: /usr/local/bin:/root/.local/bin:/tmp/.local/bin:... @common.rs:1702:16 @ansible_executor.rs:1575:13
```

**Root cause.** The Dockerfiles install ansible with `uv tool install ansible`. Because the images set `UV_PYTHON_PREFERENCE=only-managed` and `UV_PYTHON_INSTALL_DIR=/tmp/windmill/cache/py_runtime`, uv builds the ansible tool venv against a uv-managed Python **pinned to the exact cpython version uv resolved at image-build time**, living inside the ephemeral runtime cache:

```
/usr/local/uv/ansible/bin/python -> /tmp/windmill/cache/py_runtime/cpython-3.12.13-.../bin/python3.12
```

Every `ansible-*` executable has shebang `#!/usr/local/uv/ansible/bin/python`, so if that specific interpreter isn't present at runtime, the kernel returns `ENOENT` on exec and the worker surfaces it as *"Executable … not found on worker"* (`common.rs:tentatively_improve_error`). `ansible-galaxy` is the first ansible binary invoked when a playbook has roles/collections.

**Why it's intermittent (and doesn't reproduce on a fresh `docker run` of latest).** `/tmp/windmill/cache/py_runtime` is a runtime cache. The worker installs *its own* default Python there at boot (`INSTALLING PYTHON (3.12) → cpython-3.12.13`). On the current image that version **coincides** with ansible's build version, so it self-heals and normal jobs work. The failure appears when ansible's build-pinned version **diverges** from the version the worker provides at runtime — which happens as the cpython patch/minor drifts across image upgrades, when the cache is wiped/re-created (k8s `emptyDir`, fresh PVC) and the worker re-resolves a newer patch, or when the instance/worker default Python differs from ansible's. In all those cases ansible's pinned interpreter is simply not on disk.

**Fix.** Install the ansible tool against a **persistent** Python dir baked into the image layer (`UV_PYTHON_INSTALL_DIR=/usr/local/uv/py`), so the tool venv is fully self-contained and no longer depends on whatever the worker puts in the ephemeral cache. Also switched the symlink step to `ln -sf` so the pre-existing `ansible-community` link (uv auto-creates it) no longer throws a spurious "File exists" mid-batch.

## Verified end-to-end on real windmill ansible jobs

Ran actual ansible preview jobs (galaxy collection install + playbook) through a standalone windmill worker, with `/tmp/windmill/cache` empty and ansible's build Python (3.11) deliberately differing from the worker's runtime Python (3.12) — the version-mismatch trigger:

| Scenario | Real job result |
|---|---|
| **Unfixed** (ansible interpreter in ephemeral `py_runtime`) | ❌ **fails** with the exact reported error: `Executable /usr/local/bin/ansible-galaxy not found on worker … @common.rs:1702:16 @ansible_executor.rs:1575:13` |
| **Fixed** (interpreter in persistent `/usr/local/uv/py`) | ✅ **success** — `ANSIBLE GALAXY INSTALL` runs, playbook runs (`PLAY RECAP … ok=1 failed=0`) |
| **Fixed + nsjail enabled** (`DISABLE_NSJAIL=false`, `isolation=nsjail`) | ✅ **success** — galaxy + playbook run inside the sandbox |

The unfixed reproduction reproduces the reported message character-for-character, including the same PATH and source locations. The fixed image succeeds under the identical mismatch because ansible's interpreter is now a permanent part of the tool, present regardless of the cache.

## nsjail

**No nsjail change needed.** `run.ansible.config.proto` already bind-mounts `/usr` (which contains the new `/usr/local/uv/py`), so the persistent interpreter is reachable inside the sandbox — confirmed by the "Fixed + nsjail" real-job run above (`isolation=nsjail`, job succeeded). The stale `mandatory: false` mount of the old `/root/.local/share/uv/tools/ansible` path (dead since `UV_TOOL_DIR` moved to `/usr/local/uv`) is left untouched as it's harmless and out of scope.

## Changes
- `docker/DockerfileFull` — install ansible with `UV_PYTHON_INSTALL_DIR=/usr/local/uv/py`; symlink with `ln -sf`; comment documenting the constraint.
- `docker/DockerfileFullEe` — same fix.

## Test plan
- [x] Real windmill ansible job on the unfixed image (galaxy + playbook, version mismatch) fails with the exact reported error.
- [x] Same real job on the fixed image succeeds (galaxy install + playbook run).
- [x] Same real job succeeds with nsjail sandboxing enabled (`isolation=nsjail`).
- [x] Fix verified as root and non-root (`--user 1000:1000`; persistent Python dir is 755).
- [ ] CI builds `windmill-full` / `windmill-full-ee` and confirms ansible resolves after a fresh-cache / version-drift start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
