### PR TITLE
feat(triggers): serve binary HTTP-route responses via base64 transfer encoding

### DIFF
--- a/backend/windmill-api-jobs/src/execution.rs
+++ b/backend/windmill-api-jobs/src/execution.rs
@@ -12,6 +12,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use base64::Engine as _;
 use http::{HeaderMap, HeaderName, HeaderValue};
 use hyper::StatusCode;
 use serde::Deserialize;
@@ -254,6 +255,8 @@ pub struct WindmillCompositeResult {
     windmill_content_type: Option<String>,
     #[serde(alias = "wm_headers")]
     windmill_headers: Option<HashMap<String, String>>,
+    #[serde(alias = "wm_content_transfer_encoding")]
+    windmill_content_transfer_encoding: Option<String>,
     result: Option<Box<RawValue>>,
 }
 
@@ -375,11 +378,13 @@ pub fn result_to_response(result: Box<RawValue>, success: bool) -> error::Result
             windmill_status_code,
             windmill_content_type,
             windmill_headers,
+            windmill_content_transfer_encoding,
             result: result_value,
         }) => {
             if windmill_content_type.is_none()
                 && windmill_status_code.is_none()
                 && windmill_headers.is_none()
+                && windmill_content_transfer_encoding.is_none()
             {
                 return Ok((
                     if success {
@@ -425,17 +430,53 @@ pub fn result_to_response(result: Box<RawValue>, success: bool) -> error::Result
                 let serialized_json_result = result_value
                     .map(|val| val.get().to_owned())
                     .unwrap_or_else(String::new);
-                let serialized_result =
-                    serde_json::from_str::<String>(serialized_json_result.as_str())
-                        .ok()
-                        .unwrap_or(serialized_json_result);
+                let parsed_string =
+                    serde_json::from_str::<String>(serialized_json_result.as_str()).ok();
+                let result_is_json_string = parsed_string.is_some();
+                let serialized_result = parsed_string.unwrap_or(serialized_json_result);
                 headers.insert(
                     http::header::CONTENT_TYPE,
                     HeaderValue::from_str(content_type.as_str()).map_err(|err| {
                         Error::internal_err(format!("Invalid content type {content_type}: {err}"))
                     })?,
                 );
+                // Invalid base64 is a hard error, never a silent fallback to the encoded text.
+                match windmill_content_transfer_encoding.as_deref() {
+                    Some("base64") => {
+                        // Only a JSON string carries base64; a number/bool/null/array/object
+                        // must not have its raw JSON text decoded into arbitrary bytes.
+                        if !result_is_json_string {
+                            return Err(Error::ExecutionErr(
+                                "windmill_content_transfer_encoding \"base64\" requires result \
+                                 to be a base64-encoded string"
+                                    .to_string(),
+                            ));
+                        }
+                        let decoded = base64::engine::general_purpose::STANDARD
+                            .decode(serialized_result.as_bytes())
+                            .map_err(|err| {
+                                Error::ExecutionErr(format!(
+                                    "windmill_content_transfer_encoding is \"base64\" but the \
+                                     result is not valid base64: {err}"
+                                ))
+                            })?;
+                        return Ok((status_code_or_default, headers, decoded).into_response());
+                    }
+                    Some(other) => {
+                        return Err(Error::ExecutionErr(format!(
+                            "Unsupported windmill_content_transfer_encoding \"{other}\" \
+                             (only \"base64\" is supported)"
+                        )));
+                    }
+                    None => {}
+                }
                 return Ok((status_code_or_default, headers, serialized_result).into_response());
+            }
+            if windmill_content_transfer_encoding.is_some() {
+                return Err(Error::ExecutionErr(
+                    "windmill_content_transfer_encoding requires windmill_content_type to be set"
+                        .to_string(),
+                ));
             }
             if let Some(result_value) = result_value {
                 return Ok((status_code_or_default, headers, Json(result_value)).into_response());
@@ -958,5 +999,108 @@ pub async fn push_script_job_by_path_into_queue<'c>(
     } else {
         tx.commit().await?;
         Ok((uuid, resolved_delete_secs, None))
+    }
+}
+
+#[cfg(test)]
+mod result_to_response_tests {
+    use super::*;
+
+    fn raw(json: &str) -> Box<RawValue> {
+        serde_json::from_str(json).expect("valid json")
+    }
+
+    async fn body_bytes(resp: Response) -> Vec<u8> {
+        axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("read body")
+            .to_vec()
+    }
+
+    #[tokio::test]
+    async fn base64_result_is_decoded_to_raw_bytes() {
+        // 0x00 0x01 0x02 0xFF is not valid UTF-8, so it can only survive as bytes.
+        let bytes = vec![0u8, 1, 2, 255];
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        let resp = result_to_response(
+            raw(&format!(
+                r#"{{"wm_content_type":"application/pdf","wm_content_transfer_encoding":"base64","result":"{b64}"}}"#
+            )),
+            true,
+        )
+        .expect("response");
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(http::header::CONTENT_TYPE).unwrap(),
+            "application/pdf"
+        );
+        assert_eq!(body_bytes(resp).await, bytes);
+    }
+
+    #[tokio::test]
+    async fn invalid_base64_is_a_hard_error() {
+        let res = result_to_response(
+            raw(
+                r#"{"wm_content_type":"application/pdf","wm_content_transfer_encoding":"base64","result":"not valid base64!!"}"#,
+            ),
+            true,
+        );
+        assert!(res.is_err(), "invalid base64 must not silently fall back");
+    }
+
+    #[tokio::test]
+    async fn base64_mode_rejects_non_string_results() {
+        // A number/bool whose raw JSON text happens to be valid base64 (right length,
+        // base64 alphabet) must not be decoded into bytes — it must be a hard error.
+        for result in ["12345678", "true", "null", "[1,2,3]"] {
+            let res = result_to_response(
+                raw(&format!(
+                    r#"{{"wm_content_type":"application/octet-stream","wm_content_transfer_encoding":"base64","result":{result}}}"#
+                )),
+                true,
+            );
+            assert!(
+                res.is_err(),
+                "base64 mode must reject non-string result: {result}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn unsupported_transfer_encoding_is_rejected() {
+        let res = result_to_response(
+            raw(
+                r#"{"wm_content_type":"text/plain","wm_content_transfer_encoding":"gzip","result":"x"}"#,
+            ),
+            true,
+        );
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn transfer_encoding_without_content_type_is_rejected() {
+        let res = result_to_response(
+            raw(r#"{"wm_content_transfer_encoding":"base64","result":"aGk="}"#),
+            true,
+        );
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn string_result_is_still_served_verbatim() {
+        // Regression: without a transfer encoding, a string result is sent as-is
+        // (quotes stripped), not base64-decoded.
+        let resp = result_to_response(
+            raw(r#"{"wm_content_type":"text/html","result":"<h1>hi</h1>"}"#),
+            true,
+        )
+        .expect("response");
+
+        assert_eq!(
+            resp.headers().get(http::header::CONTENT_TYPE).unwrap(),
+            "text/html"
+        );
+        assert_eq!(body_bytes(resp).await, b"<h1>hi</h1>");
     }
 }


### PR DESCRIPTION
## Summary
Lets sync HTTP routes / webhooks return **real binary** bodies with **any**
MIME type, without requiring workspace object storage.

A script returns the standard composite result plus a new opt-in field:

    {
      "wm_content_type": "application/pdf",          // any MIME type
      "wm_content_transfer_encoding": "base64",       // NEW — opt-in
      "wm_status_code": 200,                           // optional
      "wm_headers": { "content-disposition": "inline; filename=\"r.pdf\"" },
      "result": "<base64 string>"
    }

`result_to_response` then base64-decodes `result` into raw bytes and sends them
with the given content type.

This generalizes #5986 (which was scoped to `application/octet-stream`): the
decode is decoupled from the content type, so any type works.

## Design choices (vs. the earlier auto-generated attempt in #5988)
- **Explicit opt-in**, never guessing: decoding only happens when
  `wm_content_transfer_encoding == "base64"`. A legitimate octet-stream *string*
  that happens to be valid base64 is never silently mangled.
- **Any content type**, not just `application/octet-stream`.
- **Hard errors instead of silent fallback**: invalid base64, an unsupported
  encoding, or a transfer encoding without a content type all return an error.
- **Backward compatible**: without the new field, behavior is identical
  (string served verbatim / JSON as before).

## Limitations (documented, out of scope)
Still buffered through the JSON job result (base64 ~+33 %, bound by
`wait_result` timeout) — for large/streamed downloads the static-asset/S3 path
remains the right tool. This targets small/medium payloads without storage.

## Tests
Added `result_to_response_tests` (5, all passing):
- base64 result → raw bytes (uses non-UTF-8 bytes to prove it's real binary)
- invalid base64 → hard error (no silent fallback)
- unsupported encoding → rejected
- transfer encoding without content type → rejected
- plain string result → still served verbatim (regression)

Aliases `windmill_content_transfer_encoding` / `wm_content_transfer_encoding`
match the existing `wm_*` naming.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable sync HTTP routes/webhooks to return real binary bodies for any MIME type by accepting a base64-encoded `result` and decoding it to bytes at response time. This removes the need for object storage for small/medium binary payloads.

- **New Features**
  - Adds optional `wm_content_transfer_encoding: "base64"` (requires `wm_content_type`); when set, decodes string `result` from base64 and sends raw bytes.
  - Strict validation: only JSON string results are allowed in base64 mode; invalid base64, unsupported encodings, or encoding without `wm_content_type` return errors.
  - Backward compatible: existing string/JSON responses are unchanged.

<sup>Written for commit cd46fdf25fb58274384f927c9639341a04791eb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

