### PR TITLE
ci: drop debuginfo in Windows backend tests to fix disk exhaustion (WIN-2162)

### DIFF
--- a/.github/workflows/backend-test-windows.yml
+++ b/.github/workflows/backend-test-windows.yml
@@ -174,13 +174,17 @@ jobs:
           # binary link spikes several hundred MB of transient I/O. Capping at
           # 8 trades ~25% wall time for headroom on the ~75GB runner disk.
           CARGO_BUILD_JOBS: 8
-          # backend/Cargo.toml sets split-debuginfo = "unpacked", which on
-          # windows-msvc is coerced to "packed": every test-binary link spawns
-          # the mspdbsrv.exe PDB type server and writes a large .pdb. CI needs
-          # no debug info, so disable PDB generation for the dev/test profiles
-          # here (avoids both LNK1318 type-server limit and PDB disk usage).
-          CARGO_PROFILE_DEV_SPLIT_DEBUGINFO: "off"
-          CARGO_PROFILE_TEST_SPLIT_DEBUGINFO: "off"
+          # backend/Cargo.toml leaves profile.dev at the default debug = 2 for
+          # the (large) windmill workspace crates; that debuginfo is emitted
+          # into every object file and embedded in each test binary, and on
+          # windows-msvc also spawns the mspdbsrv.exe PDB type server. Across a
+          # full --all --features build it is the dominant consumer of the
+          # ~63GB free on the runner disk (LNK1180 / disk-full during linking).
+          # CI needs no debug info, so drop it entirely for the dev/test
+          # profiles here. debug = 0 supersedes the previous split-debuginfo=off
+          # knob (no debuginfo => no .pdb and no LNK1318 type-server limit).
+          CARGO_PROFILE_DEV_DEBUG: "0"
+          CARGO_PROFILE_TEST_DEBUG: "0"
           # Tests' poll-time stack frames (deep nested async fn chains in
           # debug builds) reach ~1.8MB. 4MB gives ~2x headroom against flaky
           # overflows under parallel-test contention.


### PR DESCRIPTION
## Problem

The Windows integration-test job (`Backend integration tests (Windows)`) failed on the v1.755.0 release build with the C: drive completely full — even the runner's own diagnostic logging couldn't write:

```
System.IO.IOException: There is not enough space on the disk. : 'C:\runner\_diag\blocks\...'
```

Run: https://github.com/windmill-labs/windmill/actions/runs/29169841051/job/86589088267 (died at ~16min, during the link phase; healthy runs take ~30-37min).

## Root cause

`backend/Cargo.toml`'s `[profile.dev]` leaves the (large) windmill **workspace** crates at the default `debug = 2` — only dependencies are set to `debug = false` via `[profile.dev.package."*"]`. So full debug info is emitted into every object file and embedded into each test binary produced by `cargo test --all --features …`, and it is the dominant consumer of the ~63GB free on the runner disk.

The previous mitigation (`CARGO_PROFILE_*_SPLIT_DEBUGINFO=off`) only suppressed the *separate* `.pdb`; the embedded debug info stayed. It was already borderline, and the Rust 1.97.0 bump in v1.755.0 (#10047) pushed the footprint over the edge.

## Fix

Set `CARGO_PROFILE_DEV_DEBUG=0` and `CARGO_PROFILE_TEST_DEBUG=0` in the `cargo test` step so **no** debug info is generated for the CI dev/test profiles. This:

- substantially shrinks object files, rlibs, and every test binary → real disk headroom;
- **supersedes** the old `split-debuginfo=off` knob (no debuginfo ⇒ no `.pdb` and no `mspdbsrv.exe` PDB type server ⇒ no LNK1318/LNK1180).

CI-only change (env vars on the Windows test step). Local dev builds keep their debug info.

## Validation

CI-workflow-only change with no local runtime surface to exercise. Validated by dispatching the workflow against this branch: https://github.com/windmill-labs/windmill/actions/runs/29183179181

Fixes WIN-2162

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent Windows backend tests from exhausting the runner disk by disabling debuginfo in CI builds. Sets `CARGO_PROFILE_DEV_DEBUG=0` and `CARGO_PROFILE_TEST_DEBUG=0` to remove embedded debug data and `.pdb` generation; fixes WIN-2162.

- **Bug Fixes**
  - Apply the env vars in the Windows integration-test job to drop debuginfo entirely.
  - Replaces prior `split-debuginfo=off`; no `.pdb`, no `mspdbsrv`, and avoids LNK disk-full failures.
  - CI-only change; local dev builds keep debug info.

<sup>Written for commit a9ac7119d7e8fb0439049a65c62010ad65729e4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

