### PR TITLE
fix(sessions): sync AI-session preview with workspace edits + stop phantom autosave (WIN-2160)

### DIFF
--- a/frontend/src/lib/components/sessions/SessionEditorTarget.svelte
+++ b/frontend/src/lib/components/sessions/SessionEditorTarget.svelte
@@ -88,17 +88,10 @@
 		}
 	})
 
-	// The runtime cell (content store + `loadedPath`) outlives this component: it
-	// survives leaving the sessions page and MRU tab eviction. But the shared
-	// per-user draft can change while we're gone — most visibly by editing the
-	// same item in the workspace, or from another device. On the next mount
-	// `triggerLoad` early-returns on the still-`loadedPath` cell and the preview
-	// would show the pre-unmount content. So on unmount, invalidate the cell's
-	// `loadedPath` — the next mount then re-fetches the draft as a clean first
-	// load (loading overlay, no editor mounted, so no Monaco remount race), and
-	// the outbound draft-sync can't post the stale store back (`ready()` is false
-	// until the reload lands). The editor is fully disposed on unmount here, so
-	// the fresh mount hits no lingering Monaco model.
+	// The runtime cell (store + `loadedPath`) outlives this component, so a draft
+	// changed while unmounted (workspace edit, other device) would be masked by
+	// `triggerLoad`'s early-return on the stale `loadedPath`. Invalidate it on
+	// teardown so the next mount re-fetches as a clean first load.
 	$effect(() => {
 		const c = cell
 		const p = path

--- a/frontend/src/lib/components/sessions/SessionEditorTarget.svelte
+++ b/frontend/src/lib/components/sessions/SessionEditorTarget.svelte
@@ -88,6 +88,26 @@
 		}
 	})
 
+	// The runtime cell (content store + `loadedPath`) outlives this component: it
+	// survives leaving the sessions page and MRU tab eviction. But the shared
+	// per-user draft can change while we're gone — most visibly by editing the
+	// same item in the workspace, or from another device. On the next mount
+	// `triggerLoad` early-returns on the still-`loadedPath` cell and the preview
+	// would show the pre-unmount content. So on unmount, invalidate the cell's
+	// `loadedPath` — the next mount then re-fetches the draft as a clean first
+	// load (loading overlay, no editor mounted, so no Monaco remount race), and
+	// the outbound draft-sync can't post the stale store back (`ready()` is false
+	// until the reload lands). The editor is fully disposed on unmount here, so
+	// the fresh mount hits no lingering Monaco model.
+	$effect(() => {
+		const c = cell
+		const p = path
+		const w = workspaceId
+		return () => {
+			if (c.slot.loadedPath === p && c.slot.loadedWorkspace === w) c.slot.loadedPath = undefined
+		}
+	})
+
 	// Mark this editor as the live editor draft for the session's workspace so
 	// the chat's `isLiveDraft` hint / `discard_local_draft` tool resolve to this
 	// path — same registration the regular edit pages do. Only the visible tab of

--- a/frontend/src/lib/userDraft.svelte.ts
+++ b/frontend/src/lib/userDraft.svelte.ts
@@ -202,7 +202,10 @@ function snapshotDraftValue<V>(value: V | undefined): V | undefined {
  * comparing them would mask a true baseline match:
  * `draft_saved_at` (the draft's own save time), `edited_at` (deploy time),
  * `edited_by` (deploy author), `workspace_id`, `version_id` (deployed version),
- * and `is_draft` (backend presence flag).
+ * `is_draft` (backend presence flag), and `assets` (server-derived on deploy
+ * from the content — the editor's draft value never carries it, so a deployed
+ * baseline's `assets: []` would otherwise never equal the assets-less draft and
+ * every untouched load would autosave a phantom draft).
  */
 const DRAFT_COMPARE_IGNORED_FIELDS = [
 	'permissioned_as',
@@ -214,7 +217,8 @@ const DRAFT_COMPARE_IGNORED_FIELDS = [
 	'workspace_id',
 	'version_id',
 	'parent_version',
-	'is_draft'
+	'is_draft',
+	'assets'
 ] as const
 
 /**


### PR DESCRIPTION
## Summary

Fixes two related draft-sync issues surfaced by the new AI sessions preview (behind the `wm_dev_global_ai` localStorage gate). Fixes WIN-2160.

**1. Session preview went stale after a workspace edit.** With a script (or flow / raw app) open in a session's preview, toggling to workspace mode, editing that same item there, then toggling back left the preview showing the *pre-toggle* content. The session's editor runtime cell (content store + `loadedPath`) outlives the sessions page — it survives the workspace toggle and MRU tab eviction — so on the next mount the load early-returned on the still-set `loadedPath` and never re-read the (now-changed) shared per-user draft.

**2. Opening a deployed script autosaved a phantom draft with no user change.** The deployed baseline the autosave compares against carries a server-derived `assets: []` that the editor's draft value never reproduces, so `draftValuesEqual` never matched the baseline, `discardIf` returned `false`, and the editor's settle-time write posted a no-op draft.

## Changes

- **`SessionEditorTarget.svelte`** — invalidate the cell's `loadedPath` on unmount, so the next mount re-fetches the draft as a clean first load. This also sidesteps a Monaco model-reuse race (a force-reload that remounts the editor while the old one is still disposing renders a stale model — the actual cause of a one-frame lag I hit while iterating) and stops the outbound draft-sync from posting the stale store back (`ready()` stays `false` until the reload lands, so the backend draft is never clobbered). Shared by all three editor kinds (script / flow / raw app).
- **`userDraft.svelte.ts`** — add `assets` to `DRAFT_COMPARE_IGNORED_FIELDS`. It's derived from content on deploy, so ignoring it can't mask a real edit.

## Testing

- **Bug 1 (manual, Playwright):** opened `u/admin/hello` in a session preview, toggled to workspace, changed the draft, toggled back — the preview now shows the new content immediately (verified across several iterations), the backend draft is not clobbered, and the previously-observed Monaco `model already existed` / `parentNode` errors are gone.
- **Bug 2 (manual, Playwright + API):** deleted the draft, loaded `/scripts/edit/u/admin/hello` fresh, confirmed `is_draft` stays `false` (was `true` before the fix). Instrumented the comparison to confirm `assets` was the sole diverging field.
- `npm run check:fast` and `svelte-check` (0 errors); sessions unit tests pass.

Note: bug 1 was directly exercised for scripts; flow / raw app share the same `SessionEditorTarget` path but were verified by mechanism, not driven end-to-end — hence draft.

## Screenshots

Session preview after toggling back from a workspace edit — shows the latest edited content, in sync:

![synced-preview](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/ruben/win-2160-sync-ai-session-script-preview-with-workspace-changes/1783840556-win2160-synced-preview.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps AI-session preview in sync with workspace edits and stops phantom autosaves when opening deployed scripts. Fixes WIN-2160.

- **Bug Fixes**
  - Invalidate the editor runtime cell on unmount so the next mount reloads the per-user draft; prevents stale previews and avoids a Monaco model reuse race (applies to script/flow/raw app editors).
  - Ignore `assets` in draft-vs-baseline comparison to prevent autosaving an unchanged draft on fresh loads of deployed items.

- **Refactors**
  - Shortened the teardown-invalidation comment in `SessionEditorTarget.svelte` to meet repo comment-length rules; no behavior change.

<sup>Written for commit 08c375cd33bb03cf87ee7a1d1fc3ae6f46353dc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

