### PR TITLE
fix(nativets): apply parameter defaults for missing args instead of null

### DIFF
--- a/backend/windmill-runtime-nativets/src/lib.rs
+++ b/backend/windmill-runtime-nativets/src/lib.rs
@@ -1010,7 +1010,7 @@ function processStreamIterative(res) {{
 
 {otel_context_inject}
 
-let args = Deno.core.ops.op_get_static_args().map(JSON.parse)
+let args = globalThis.__getMainArgs()
 import("file:///eval.ts").then((module) => module.{main_fn}(...args))
     .then(res => {{
         if (isAsyncIterable(res)) {{

--- a/backend/windmill-runtime-nativets/src/runtime.js
+++ b/backend/windmill-runtime-nativets/src/runtime.js
@@ -49,6 +49,18 @@ Object.assign(globalThis, {
   setTimeout: timers.setTimeout,
 });
 
+// Build the positional argument list for the user's entrypoint from the static
+// args captured on the Rust side (op_get_static_args). Each slot is either:
+//   - `null`:   the argument was not provided. Pass `undefined` (not `null`) so
+//               the parameter's default value applies, matching normal JS call
+//               semantics and the bun runner.
+//   - a string: the JSON text of the provided value; parse it. An explicitly
+//               provided JSON `null` arrives as the string "null", so it stays `null`.
+globalThis.__getMainArgs = () =>
+  globalThis.Deno.core.ops.op_get_static_args().map((arg) =>
+    arg === null ? undefined : JSON.parse(arg)
+  );
+
 // Expose bootstrapOtel globally so it can be called from Rust after runtime creation.
 // We use dynamic import so deno_telemetry isn't loaded during snapshot creation.
 // Config: [tracingEnabled, metricsEnabled, consoleConfig, deterministic]

--- a/backend/windmill-runtime-nativets/src/smoke_tests.rs
+++ b/backend/windmill-runtime-nativets/src/smoke_tests.rs
@@ -57,6 +57,37 @@ export async function main(x: number): Promise<number> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "deno_core upgrade smoke; run with --ignored"]
+async fn smoke_missing_optional_arg_uses_default() {
+    // A missing optional argument must fall back to the parameter's default:
+    // it has to arrive as `undefined`, not `null`. With `null` the default is
+    // suppressed and `arr.slice(0, limit)` becomes `slice(0, null)` -> `[]`.
+    let ts = r#"
+export async function main(limit = 50): Promise<number> {
+    // With the default applied, slice(0, 50) keeps all 10 -> length 10.
+    // If `limit` were null, slice(0, null) -> [] -> length 0.
+    return [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].slice(0, limit).length;
+}
+"#;
+    let r = run_ts(ts, &["limit"], serde_json::json!({})).await;
+    assert_eq!(unwrap_value(&r), serde_json::json!(10));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "deno_core upgrade smoke; run with --ignored"]
+async fn smoke_explicit_null_arg_is_preserved() {
+    // An explicitly-provided JSON null must stay null (it arrives as the string
+    // "null", distinct from a missing arg), so the default does NOT apply.
+    let ts = r#"
+export async function main(x: number | null = 7): Promise<string> {
+    return x === null ? "null" : String(x);
+}
+"#;
+    let r = run_ts(ts, &["x"], serde_json::json!({ "x": null })).await;
+    assert_eq!(unwrap_value(&r), serde_json::json!("null"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "deno_core upgrade smoke; run with --ignored"]
 async fn smoke_transpile_enum_and_union() {
     // Enums + discriminated union + as-cast exercise the swc_ecma_ast +
     // swc_ecma_parser TS-syntax paths the bare value tests don't.


### PR DESCRIPTION
## Summary
A missing script argument was passed into the in-process native
(nativets/deno_core) runtime as JS `null` instead of `undefined`, so parameter
default values never applied. This silently produced wrong results for any
nativets script that relies on a default parameter and is called without that
arg — no error, just wrong output.

## Root cause
`op_get_static_args` returns `null` for an argument that wasn't provided, and
the entrypoint is then invoked as `main(...args)` with that `null`. Since JS
defaults only apply for `undefined`, `function main(limit = 50)` called without
args runs with `limit === null`, not `50`. Downstream this is easy to miss —
e.g. `arr.slice(0, limit)` becomes `slice(0, null)` → `[]`. The bun runner
passes `undefined` for a missing arg, so the same script works there; the
divergence is nativets-only.

## Fix
Resolve the entrypoint's arguments through a small `__getMainArgs` helper in the
runtime module that maps a missing arg (`null`) to `undefined` so the parameter
default applies. An explicitly-provided JSON `null` arrives as the string
`"null"` and is preserved as `null`. Covers both the regular and
dedicated/prewarmed execution paths (both go through `execute_main`).

## Tests
Added regression smoke tests in `windmill-runtime-nativets`:
- `smoke_missing_optional_arg_uses_default` — missing optional arg → default applies (not `null`)
- `smoke_explicit_null_arg_is_preserved` — explicit JSON `null` → stays `null`

Run: `cargo test -p windmill-runtime-nativets _arg_ -- --ignored`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix argument handling in the native TS runtime so missing script args arrive as `undefined`, letting JS default parameters apply and matching bun behavior.

- **Bug Fixes**
  - Added and now use `globalThis.__getMainArgs()` to map `null` from `op_get_static_args()` to `undefined` and JSON-parse provided values; the entrypoint uses it in both regular and dedicated/prewarmed runs.
  - Added smoke tests to ensure a missing optional arg uses its default and an explicit JSON `"null"` is preserved as `null`.

<sup>Written for commit dbca0a5cc5295ba00daa8a5691faad816a30f49d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

