### PR TITLE
ci: run Codex/Pi review on fork PRs when a maintainer triggers it

### DIFF
--- a/.github/codex/pr-review.prompt.md
+++ b/.github/codex/pr-review.prompt.md
@@ -1,5 +1,5 @@
 # Codex output format
 
-- Read `./.github/codex/pr-review-context.md` for PR metadata and the diff commands.
+- Read the review context file whose absolute path is given at the end of these instructions; it holds the PR metadata and the diff commands.
 - Return a markdown PR comment starting with `## Codex Review`.
 - Tag each finding with a severity (P0 / P1 / P2), file path, and line number when known confidently.

--- a/.github/pi/pr-review.prompt.md
+++ b/.github/pi/pr-review.prompt.md
@@ -1,6 +1,6 @@
 # Pi output format
 
-- Read `./.github/pi/pr-review-context.md` for PR metadata and the diff commands.
+- Read the review context file whose absolute path is given at the end of these instructions; it holds the PR metadata and the diff (or the git commands to produce it).
 - Return a markdown PR comment starting with `## Pi Review`.
 - Tag each finding with a severity (P0 / P1 / P2), file path, and line number when known confidently.
 - Output ONLY the final review markdown — no preamble, no thinking, no tool transcripts.

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -114,6 +114,14 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # PR title/body are attacker-controlled free text. Use an unguessable
+          # per-run delimiter so a fork can't embed a fixed heredoc terminator to
+          # close the block early and inject extra outputs — e.g. is_fork=false,
+          # which (last-write-wins) would re-enable the EE checkout and the
+          # trusted-path agent settings for fork code.
+          RAND=$(head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')
+          TITLE_EOF="TITLE_EOF_${RAND}"
+          BODY_EOF="BODY_EOF_${RAND}"
           {
             echo "skip=false"
             echo "is_fork=$IS_FORK"
@@ -122,12 +130,12 @@ jobs:
             echo "base_sha=$BASE_SHA"
             echo "head_sha=$HEAD_SHA"
             echo "pr_author=$PR_AUTHOR"
-            echo 'title<<PR_TITLE_EOF'
+            echo "title<<$TITLE_EOF"
             printf '%s\n' "$PR_TITLE"
-            echo 'PR_TITLE_EOF'
-            echo 'body<<PR_BODY_EOF'
+            echo "$TITLE_EOF"
+            echo "body<<$BODY_EOF"
             printf '%s\n' "$PR_BODY"
-            echo 'PR_BODY_EOF'
+            echo "$BODY_EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -106,9 +106,8 @@ jobs:
           fi
           # Fork PRs run untrusted code with secrets present, so the automatic
           # pull_request trigger never reviews them. A non-empty INPUT_PR_NUMBER
-          # means we arrived via workflow_call, which only happens after an
-          # authorized maintainer opted in (e.g. a /codex comment gated by
-          # check-write-access), so allow forks on that path.
+          # means we arrived via workflow_call (a maintainer /codex comment gated
+          # by check-write-access), so allow forks only on that path.
           if [ "$IS_FORK" = "true" ] && [ -z "$INPUT_PR_NUMBER" ]; then
             echo "Skipping Codex review for fork PR (automatic trigger)."
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -116,9 +115,8 @@ jobs:
           fi
           # PR title/body are attacker-controlled free text. Use an unguessable
           # per-run delimiter so a fork can't embed a fixed heredoc terminator to
-          # close the block early and inject extra outputs — e.g. is_fork=false,
-          # which (last-write-wins) would re-enable the EE checkout and the
-          # trusted-path agent settings for fork code.
+          # inject extra outputs — e.g. is_fork=false (last-write-wins), which
+          # would re-enable the EE checkout and trusted-path settings for forks.
           RAND=$(head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')
           TITLE_EOF="TITLE_EOF_${RAND}"
           BODY_EOF="BODY_EOF_${RAND}"
@@ -354,10 +352,9 @@ jobs:
               return;
             }
             // Defense-in-depth for fork reviews: the model call needs the provider
-            // credential in the environment, and the posted comment is an
-            // exfiltration channel that bypasses GitHub Actions log masking. Strip
-            // any credential value (the API key, the raw auth JSON, and the tokens
-            // nested inside it) that leaked into the review text before posting.
+            // credential in the env, and the posted comment bypasses Actions log
+            // masking. Strip any credential (API key, raw auth JSON, nested
+            // tokens) that leaked into the review text before posting.
             const secrets = [];
             const addSecret = (v, min) => {
               if (typeof v === 'string' && v.length >= min) secrets.push(v);

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -136,6 +136,11 @@ jobs:
         with:
           ref: refs/pull/${{ steps.pr.outputs.pr_number }}/merge
           fetch-depth: 1
+          # Don't persist github.token in .git/config: the review agent can read
+          # the checkout, and on the fork path that token (issue/PR write) would
+          # otherwise be exfiltratable. All later git ops target the public origin
+          # and need no auth; EE checkout and gh use their own explicit tokens.
+          persist-credentials: false
 
       # Never expose the EE private-repo token to untrusted fork code. Skipping
       # this step leaves steps.ee.outputs.available empty, so the EE checkout and
@@ -316,6 +321,7 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+          GH_JOB_TOKEN: ${{ github.token }}
         with:
           github-token: ${{ github.token }}
           script: |
@@ -341,6 +347,7 @@ jobs:
             };
             addSecret(process.env.OPENAI_API_KEY, 8);
             addSecret(process.env.CODEX_AUTH_JSON, 8);
+            addSecret(process.env.GH_JOB_TOKEN, 8);
             if (process.env.CODEX_AUTH_JSON) {
               try {
                 const collect = (o) => {

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -228,9 +228,12 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
         run: |
+          # Write outside the checkout: on the fork path the merge tree is
+          # attacker-controlled, and a committed symlink at this path would
+          # redirect the write.
           gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
             --jq '[.[] | {user: .user.login, created_at: .created_at, body: (.body | .[:4000])}] | sort_by(.created_at) | .[-20:]' \
-            > prior-comments.json || echo "[]" > prior-comments.json
+            > "$RUNNER_TEMP/prior-comments.json" || echo "[]" > "$RUNNER_TEMP/prior-comments.json"
 
       - name: Write Codex review context
         if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
@@ -244,9 +247,9 @@ jobs:
           PR_AUTHOR: ${{ steps.pr.outputs.pr_author }}
           EXTRA_PROMPT: ${{ inputs.extra_prompt }}
         run: |
-          mkdir -p .github/codex
           node <<'NODE'
           const fs = require('fs');
+          const tmp = process.env.RUNNER_TEMP;
           const lines = [
             `Repository: ${process.env.PR_REPOSITORY}`,
             `PR number: ${process.env.PR_NUMBER}`,
@@ -276,9 +279,9 @@ jobs:
           if (process.env.EXTRA_PROMPT && process.env.EXTRA_PROMPT.trim()) {
             lines.push('', 'Additional reviewer instructions:', process.env.EXTRA_PROMPT.trim());
           }
-          if (fs.existsSync('prior-comments.json')) {
+          if (fs.existsSync(`${tmp}/prior-comments.json`)) {
             try {
-              const comments = JSON.parse(fs.readFileSync('prior-comments.json', 'utf8'));
+              const comments = JSON.parse(fs.readFileSync(`${tmp}/prior-comments.json`, 'utf8'));
               if (Array.isArray(comments) && comments.length > 0) {
                 lines.push(
                   '',
@@ -293,7 +296,7 @@ jobs:
               }
             } catch (_) {}
           }
-          fs.writeFileSync('.github/codex/pr-review-context.md', `${lines.join('\n')}\n`);
+          fs.writeFileSync(`${tmp}/pr-review-context.md`, `${lines.join('\n')}\n`);
           NODE
 
       - name: Run Codex review
@@ -314,12 +317,18 @@ jobs:
             cat REVIEW.md .github/codex/pr-review.prompt.md > /tmp/codex-prompt.md
             SANDBOX_MODE=danger-full-access
           fi
+          # The context file lives in RUNNER_TEMP (outside the attacker-controlled
+          # checkout); tell the agent its absolute path.
+          printf '\nReview context file (absolute path): %s\n' "$RUNNER_TEMP/pr-review-context.md" >> /tmp/codex-prompt.md
+          # Write the final message outside the checkout too: a fork could commit
+          # codex-final-message.md as a symlink and redirect this write to overwrite
+          # e.g. a GitHub Action's index.js, which then runs with our credentials.
           codex exec \
             -C "$GITHUB_WORKSPACE" \
             -m gpt-5.6-sol \
             -c 'model_reasoning_effort="xhigh"' \
             -s "$SANDBOX_MODE" \
-            -o codex-final-message.md \
+            -o "$RUNNER_TEMP/codex-final-message.md" \
             - < /tmp/codex-prompt.md
 
       - name: Post Codex review comment
@@ -334,7 +343,7 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
-            const path = `${process.env.GITHUB_WORKSPACE}/codex-final-message.md`;
+            const path = `${process.env.RUNNER_TEMP}/codex-final-message.md`;
             if (!fs.existsSync(path)) {
               core.info('Codex did not produce a final message; skipping PR comment.');
               return;

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -314,6 +314,8 @@ jobs:
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
         with:
           github-token: ${{ github.token }}
           script: |
@@ -323,9 +325,38 @@ jobs:
               core.info('Codex did not produce a final message; skipping PR comment.');
               return;
             }
-            const body = fs.readFileSync(path, 'utf8').trim();
+            let body = fs.readFileSync(path, 'utf8').trim();
             if (!body) {
               core.info('Codex final message was empty; skipping PR comment.');
+              return;
+            }
+            // Defense-in-depth for fork reviews: the model call needs the provider
+            // credential in the environment, and the posted comment is an
+            // exfiltration channel that bypasses GitHub Actions log masking. Strip
+            // any credential value (the API key, the raw auth JSON, and the tokens
+            // nested inside it) that leaked into the review text before posting.
+            const secrets = [];
+            const addSecret = (v, min) => {
+              if (typeof v === 'string' && v.length >= min) secrets.push(v);
+            };
+            addSecret(process.env.OPENAI_API_KEY, 8);
+            addSecret(process.env.CODEX_AUTH_JSON, 8);
+            if (process.env.CODEX_AUTH_JSON) {
+              try {
+                const collect = (o) => {
+                  if (typeof o === 'string') addSecret(o, 20);
+                  else if (Array.isArray(o)) o.forEach(collect);
+                  else if (o && typeof o === 'object') Object.values(o).forEach(collect);
+                };
+                collect(JSON.parse(process.env.CODEX_AUTH_JSON));
+              } catch (_) {}
+            }
+            for (const s of [...new Set(secrets)].sort((a, b) => b.length - a.length)) {
+              body = body.split(s).join('[REDACTED]');
+            }
+            body = body.trim();
+            if (!body) {
+              core.info('Codex final message was empty after redaction; skipping PR comment.');
               return;
             }
             await github.rest.issues.createComment({

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -104,8 +104,13 @@ jobs:
             IS_FORK="$EVENT_FORK"
             PR_AUTHOR="$EVENT_AUTHOR"
           fi
-          if [ "$IS_FORK" = "true" ]; then
-            echo "Skipping Codex review for fork PR."
+          # Fork PRs run untrusted code with secrets present, so the automatic
+          # pull_request trigger never reviews them. A non-empty INPUT_PR_NUMBER
+          # means we arrived via workflow_call, which only happens after an
+          # authorized maintainer opted in (e.g. a /codex comment gated by
+          # check-write-access), so allow forks on that path.
+          if [ "$IS_FORK" = "true" ] && [ -z "$INPUT_PR_NUMBER" ]; then
+            echo "Skipping Codex review for fork PR (automatic trigger)."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -116,6 +116,7 @@ jobs:
           fi
           {
             echo "skip=false"
+            echo "is_fork=$IS_FORK"
             echo "pr_number=$PR_NUMBER"
             echo "base_ref=$BASE_REF"
             echo "base_sha=$BASE_SHA"
@@ -136,8 +137,11 @@ jobs:
           ref: refs/pull/${{ steps.pr.outputs.pr_number }}/merge
           fetch-depth: 1
 
+      # Never expose the EE private-repo token to untrusted fork code. Skipping
+      # this step leaves steps.ee.outputs.available empty, so the EE checkout and
+      # substitution steps below are skipped too.
       - name: Check EE access
-        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true' && steps.pr.outputs.is_fork != 'true'
         id: ee
         env:
           EE_TOKEN: ${{ secrets.WINDMILL_EE_PRIVATE_ACCESS }}
@@ -281,13 +285,27 @@ jobs:
 
       - name: Run Codex review
         if: steps.codex_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        env:
+          PR_IS_FORK: ${{ steps.pr.outputs.is_fork }}
+          PR_BASE_REF: ${{ steps.pr.outputs.base_ref }}
         run: |
-          cat REVIEW.md .github/codex/pr-review.prompt.md > /tmp/codex-prompt.md
+          if [ "$PR_IS_FORK" = "true" ]; then
+            # Fork code is untrusted. Read the review policy/prompt from the base
+            # ref (git show) rather than the attacker-controlled merge checkout,
+            # so a malicious fork can't rewrite the reviewer's own instructions,
+            # and run in a network-disabled sandbox to block secret exfiltration.
+            git show "origin/$PR_BASE_REF:REVIEW.md" > /tmp/codex-prompt.md
+            git show "origin/$PR_BASE_REF:.github/codex/pr-review.prompt.md" >> /tmp/codex-prompt.md
+            SANDBOX_MODE=workspace-write
+          else
+            cat REVIEW.md .github/codex/pr-review.prompt.md > /tmp/codex-prompt.md
+            SANDBOX_MODE=danger-full-access
+          fi
           codex exec \
             -C "$GITHUB_WORKSPACE" \
             -m gpt-5.6-sol \
             -c 'model_reasoning_effort="xhigh"' \
-            -s danger-full-access \
+            -s "$SANDBOX_MODE" \
             -o codex-final-message.md \
             - < /tmp/codex-prompt.md
 

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -97,8 +97,13 @@ jobs:
             IS_FORK="$EVENT_FORK"
             PR_AUTHOR="$EVENT_AUTHOR"
           fi
-          if [ "$IS_FORK" = "true" ]; then
-            echo "Skipping Pi review for fork PR."
+          # Fork PRs run untrusted code with secrets present, so the automatic
+          # pull_request trigger never reviews them. A non-empty INPUT_PR_NUMBER
+          # means we arrived via workflow_call, which only happens after an
+          # authorized maintainer opted in (e.g. a /pi comment gated by
+          # check-write-access), so allow forks on that path.
+          if [ "$IS_FORK" = "true" ] && [ -z "$INPUT_PR_NUMBER" ]; then
+            echo "Skipping Pi review for fork PR (automatic trigger)."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -107,6 +107,14 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # PR title/body are attacker-controlled free text. Use an unguessable
+          # per-run delimiter so a fork can't embed a fixed heredoc terminator to
+          # close the block early and inject extra outputs — e.g. is_fork=false,
+          # which (last-write-wins) would re-enable the EE checkout and the
+          # trusted-path agent settings for fork code.
+          RAND=$(head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')
+          TITLE_EOF="TITLE_EOF_${RAND}"
+          BODY_EOF="BODY_EOF_${RAND}"
           {
             echo "skip=false"
             echo "is_fork=$IS_FORK"
@@ -115,12 +123,12 @@ jobs:
             echo "base_sha=$BASE_SHA"
             echo "head_sha=$HEAD_SHA"
             echo "pr_author=$PR_AUTHOR"
-            echo 'title<<PR_TITLE_EOF'
+            echo "title<<$TITLE_EOF"
             printf '%s\n' "$PR_TITLE"
-            echo 'PR_TITLE_EOF'
-            echo 'body<<PR_BODY_EOF'
+            echo "$TITLE_EOF"
+            echo "body<<$BODY_EOF"
             printf '%s\n' "$PR_BODY"
-            echo 'PR_BODY_EOF'
+            echo "$BODY_EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -269,6 +269,7 @@ jobs:
           PR_BASE_REF: ${{ steps.pr.outputs.base_ref }}
         run: |
           set -o pipefail
+          PI_HARDEN_FLAGS=()
           if [ "$PR_IS_FORK" = "true" ]; then
             # Fork code is untrusted. Read the review policy/prompt from the base
             # ref (git show) rather than the attacker-controlled merge checkout,
@@ -277,6 +278,13 @@ jobs:
             git show "origin/$PR_BASE_REF:REVIEW.md" > /tmp/pi-prompt.md
             git show "origin/$PR_BASE_REF:.github/pi/pr-review.prompt.md" >> /tmp/pi-prompt.md
             PI_TOOLS=read,grep,find,ls
+            # cwd is the fork checkout, so disable every project-local discovery:
+            # --no-extensions stops fork-supplied .pi extensions (.ts/.js) from
+            # executing at startup with DEEPSEEK_API_KEY in env (before the tool
+            # allowlist even applies); the rest stop fork-controlled skills,
+            # prompt templates, themes, and AGENTS.md/CLAUDE.md from being
+            # auto-loaded into the reviewer's prompt as an injection vector.
+            PI_HARDEN_FLAGS=(--no-extensions --no-skills --no-prompt-templates --no-themes --no-context-files)
           else
             cat REVIEW.md .github/pi/pr-review.prompt.md > /tmp/pi-prompt.md
             PI_TOOLS=read,grep,find,ls,bash
@@ -285,6 +293,7 @@ jobs:
             --provider deepseek \
             --model deepseek-v4-pro \
             --tools "$PI_TOOLS" \
+            "${PI_HARDEN_FLAGS[@]}" \
             --mode json \
             < /tmp/pi-prompt.md \
             | tee pi-events.jsonl \

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -275,9 +275,14 @@ jobs:
           PI_SKIP_VERSION_CHECK: '1'
           PR_IS_FORK: ${{ steps.pr.outputs.is_fork }}
           PR_BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          PR_BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         run: |
           set -o pipefail
           PI_HARDEN_FLAGS=()
+          # Pi writes its event stream and final message here; on the fork path cwd
+          # moves to an isolated dir, so keep these on absolute workspace paths.
+          OUT_DIR="$GITHUB_WORKSPACE"
           if [ "$PR_IS_FORK" = "true" ]; then
             # Fork code is untrusted. Read the review policy/prompt from the base
             # ref (git show) rather than the attacker-controlled merge checkout,
@@ -286,19 +291,38 @@ jobs:
             git show "origin/$PR_BASE_REF:REVIEW.md" > /tmp/pi-prompt.md
             git show "origin/$PR_BASE_REF:.github/pi/pr-review.prompt.md" >> /tmp/pi-prompt.md
             PI_TOOLS=read,grep,find,ls
-            # cwd is the fork checkout, so disable every project-local discovery:
-            # --no-extensions stops fork-supplied .pi extensions (.ts/.js) from
-            # loading at startup with DEEPSEEK_API_KEY in env (before the tool
-            # allowlist even applies); the rest stop fork-controlled skills,
-            # prompt templates, themes, and AGENTS.md/CLAUDE.md from being
-            # auto-loaded into the reviewer's prompt as an injection vector.
+
+            # Root cause of the fork-review secret surface: Pi resolves ALL project
+            # config from <cwd>/.pi — settings/packages, extensions, skills, themes,
+            # prompts, SYSTEM.md, APPEND_SYSTEM.md. Running inside the fork checkout
+            # lets a fork inject any of these to execute code or rewrite the
+            # reviewer's own system prompt, with DEEPSEEK_API_KEY in the env. So run
+            # Pi from an isolated, empty, trusted directory: none of the fork's
+            # .pi/* is on the discovery path there (discovery is cwd-based, no
+            # walk-up). The agent has no shell here, so pre-compute the diff (the
+            # base...head SHAs are trusted) into the context file it reads; it may
+            # still read fork files by absolute path for extra context — reads are
+            # safe, only config discovery and code execution were the risk.
+            PI_WORKDIR=$(mktemp -d)
+            mkdir -p "$PI_WORKDIR/.github/pi"
+            cp "$GITHUB_WORKSPACE/.github/pi/pr-review-context.md" "$PI_WORKDIR/.github/pi/pr-review-context.md"
+            {
+              echo ""
+              echo "## Pre-computed review diff (base...head)"
+              echo "You have no shell. The full diff is inlined below. The repository"
+              echo "checkout is at $GITHUB_WORKSPACE — you may read files there by"
+              echo "absolute path for additional context."
+              echo '```diff'
+              git -C "$GITHUB_WORKSPACE" diff --unified=0 "$PR_BASE_SHA...$PR_HEAD_SHA"
+              echo '```'
+            } >> "$PI_WORKDIR/.github/pi/pr-review-context.md"
+            cd "$PI_WORKDIR"
+
+            # Belt-and-suspenders on top of the isolated cwd: refuse discovery of
+            # extensions/skills/templates/themes/context-files, and PI_OFFLINE=1 to
+            # block any startup network op or package install. PI_OFFLINE gates only
+            # startup network ops, not the provider inference call.
             PI_HARDEN_FLAGS=(--no-extensions --no-skills --no-prompt-templates --no-themes --no-context-files)
-            # --no-extensions only filters what is *loaded*; package resolution
-            # from a fork .pi/settings.json still runs `npm install`/npmCommand and
-            # lifecycle scripts *before* that filter. PI_OFFLINE=1 makes the
-            # resolver skip every missing-package install, closing that exec path.
-            # It gates only startup network ops (installs, tool downloads), not the
-            # provider inference call.
             export PI_OFFLINE=1
           else
             cat REVIEW.md .github/pi/pr-review.prompt.md > /tmp/pi-prompt.md
@@ -311,7 +335,7 @@ jobs:
             "${PI_HARDEN_FLAGS[@]}" \
             --mode json \
             < /tmp/pi-prompt.md \
-            | tee pi-events.jsonl \
+            | tee "$OUT_DIR/pi-events.jsonl" \
             | jq -rc --unbuffered '
                 if .type == "agent_start" then "🤖 pi agent started"
                 elif .type == "turn_start" then "── turn ──"
@@ -339,7 +363,7 @@ jobs:
             | map(select(.role == "assistant"))
             | last
             | (.content[]? | select(.type == "text") | .text)
-          ' pi-events.jsonl > pi-final-message.md
+          ' "$OUT_DIR/pi-events.jsonl" > "$OUT_DIR/pi-final-message.md"
 
       - name: Post Pi review comment
         if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -109,6 +109,7 @@ jobs:
           fi
           {
             echo "skip=false"
+            echo "is_fork=$IS_FORK"
             echo "pr_number=$PR_NUMBER"
             echo "base_ref=$BASE_REF"
             echo "base_sha=$BASE_SHA"
@@ -129,8 +130,11 @@ jobs:
           ref: refs/pull/${{ steps.pr.outputs.pr_number }}/merge
           fetch-depth: 1
 
+      # Never expose the EE private-repo token to untrusted fork code. Skipping
+      # this step leaves steps.ee.outputs.available empty, so the EE checkout and
+      # substitution steps below are skipped too.
       - name: Check EE access
-        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
+        if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true' && steps.pr.outputs.is_fork != 'true'
         id: ee
         env:
           EE_TOKEN: ${{ secrets.WINDMILL_EE_PRIVATE_ACCESS }}
@@ -256,13 +260,26 @@ jobs:
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           PI_SKIP_VERSION_CHECK: '1'
+          PR_IS_FORK: ${{ steps.pr.outputs.is_fork }}
+          PR_BASE_REF: ${{ steps.pr.outputs.base_ref }}
         run: |
           set -o pipefail
-          cat REVIEW.md .github/pi/pr-review.prompt.md > /tmp/pi-prompt.md
+          if [ "$PR_IS_FORK" = "true" ]; then
+            # Fork code is untrusted. Read the review policy/prompt from the base
+            # ref (git show) rather than the attacker-controlled merge checkout,
+            # so a malicious fork can't rewrite the reviewer's own instructions,
+            # and drop the bash tool so the agent has no shell to exfiltrate with.
+            git show "origin/$PR_BASE_REF:REVIEW.md" > /tmp/pi-prompt.md
+            git show "origin/$PR_BASE_REF:.github/pi/pr-review.prompt.md" >> /tmp/pi-prompt.md
+            PI_TOOLS=read,grep,find,ls
+          else
+            cat REVIEW.md .github/pi/pr-review.prompt.md > /tmp/pi-prompt.md
+            PI_TOOLS=read,grep,find,ls,bash
+          fi
           pi -p \
             --provider deepseek \
             --model deepseek-v4-pro \
-            --tools read,grep,find,ls,bash \
+            --tools "$PI_TOOLS" \
             --mode json \
             < /tmp/pi-prompt.md \
             | tee pi-events.jsonl \

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -288,11 +288,18 @@ jobs:
             PI_TOOLS=read,grep,find,ls
             # cwd is the fork checkout, so disable every project-local discovery:
             # --no-extensions stops fork-supplied .pi extensions (.ts/.js) from
-            # executing at startup with DEEPSEEK_API_KEY in env (before the tool
+            # loading at startup with DEEPSEEK_API_KEY in env (before the tool
             # allowlist even applies); the rest stop fork-controlled skills,
             # prompt templates, themes, and AGENTS.md/CLAUDE.md from being
             # auto-loaded into the reviewer's prompt as an injection vector.
             PI_HARDEN_FLAGS=(--no-extensions --no-skills --no-prompt-templates --no-themes --no-context-files)
+            # --no-extensions only filters what is *loaded*; package resolution
+            # from a fork .pi/settings.json still runs `npm install`/npmCommand and
+            # lifecycle scripts *before* that filter. PI_OFFLINE=1 makes the
+            # resolver skip every missing-package install, closing that exec path.
+            # It gates only startup network ops (installs, tool downloads), not the
+            # provider inference call.
+            export PI_OFFLINE=1
           else
             cat REVIEW.md .github/pi/pr-review.prompt.md > /tmp/pi-prompt.md
             PI_TOOLS=read,grep,find,ls,bash

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -200,9 +200,12 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
         run: |
+          # Write outside the checkout: on the fork path the merge tree is
+          # attacker-controlled, and a committed symlink at this path would
+          # redirect the write.
           gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
             --jq '[.[] | {user: .user.login, created_at: .created_at, body: (.body | .[:4000])}] | sort_by(.created_at) | .[-20:]' \
-            > prior-comments.json || echo "[]" > prior-comments.json
+            > "$RUNNER_TEMP/prior-comments.json" || echo "[]" > "$RUNNER_TEMP/prior-comments.json"
 
       - name: Write Pi review context
         if: steps.pi_config.outputs.enabled == 'true' && steps.pr.outputs.skip != 'true'
@@ -216,9 +219,9 @@ jobs:
           PR_AUTHOR: ${{ steps.pr.outputs.pr_author }}
           EXTRA_PROMPT: ${{ inputs.extra_prompt }}
         run: |
-          mkdir -p .github/pi
           node <<'NODE'
           const fs = require('fs');
+          const tmp = process.env.RUNNER_TEMP;
           const lines = [
             `Repository: ${process.env.PR_REPOSITORY}`,
             `PR number: ${process.env.PR_NUMBER}`,
@@ -248,9 +251,9 @@ jobs:
           if (process.env.EXTRA_PROMPT && process.env.EXTRA_PROMPT.trim()) {
             lines.push('', 'Additional reviewer instructions:', process.env.EXTRA_PROMPT.trim());
           }
-          if (fs.existsSync('prior-comments.json')) {
+          if (fs.existsSync(`${tmp}/prior-comments.json`)) {
             try {
-              const comments = JSON.parse(fs.readFileSync('prior-comments.json', 'utf8'));
+              const comments = JSON.parse(fs.readFileSync(`${tmp}/prior-comments.json`, 'utf8'));
               if (Array.isArray(comments) && comments.length > 0) {
                 lines.push(
                   '',
@@ -265,7 +268,7 @@ jobs:
               }
             } catch (_) {}
           }
-          fs.writeFileSync('.github/pi/pr-review-context.md', `${lines.join('\n')}\n`);
+          fs.writeFileSync(`${tmp}/pr-review-context.md`, `${lines.join('\n')}\n`);
           NODE
 
       - name: Run Pi review
@@ -280,9 +283,13 @@ jobs:
         run: |
           set -o pipefail
           PI_HARDEN_FLAGS=()
-          # Pi writes its event stream and final message here; on the fork path cwd
-          # moves to an isolated dir, so keep these on absolute workspace paths.
-          OUT_DIR="$GITHUB_WORKSPACE"
+          # Keep generated files outside the checkout: on the fork path the merge
+          # tree is attacker-controlled, so a committed symlink at any of these
+          # paths (final message, events, context) would redirect the write and, in
+          # the worst case, overwrite an action's code that then runs with our
+          # credentials. RUNNER_TEMP is runner-created and outside the checkout.
+          OUT_DIR="$RUNNER_TEMP"
+          CTX="$RUNNER_TEMP/pr-review-context.md"
           if [ "$PR_IS_FORK" = "true" ]; then
             # Fork code is untrusted. Read the review policy/prompt from the base
             # ref (git show) rather than the attacker-controlled merge checkout,
@@ -292,30 +299,28 @@ jobs:
             git show "origin/$PR_BASE_REF:.github/pi/pr-review.prompt.md" >> /tmp/pi-prompt.md
             PI_TOOLS=read,grep,find,ls
 
-            # Root cause of the fork-review secret surface: Pi resolves ALL project
-            # config from <cwd>/.pi — settings/packages, extensions, skills, themes,
-            # prompts, SYSTEM.md, APPEND_SYSTEM.md. Running inside the fork checkout
-            # lets a fork inject any of these to execute code or rewrite the
-            # reviewer's own system prompt, with DEEPSEEK_API_KEY in the env. So run
-            # Pi from an isolated, empty, trusted directory: none of the fork's
-            # .pi/* is on the discovery path there (discovery is cwd-based, no
-            # walk-up). The agent has no shell here, so pre-compute the diff (the
-            # base...head SHAs are trusted) into the context file it reads; it may
-            # still read fork files by absolute path for extra context — reads are
-            # safe, only config discovery and code execution were the risk.
-            PI_WORKDIR=$(mktemp -d)
-            mkdir -p "$PI_WORKDIR/.github/pi"
-            cp "$GITHUB_WORKSPACE/.github/pi/pr-review-context.md" "$PI_WORKDIR/.github/pi/pr-review-context.md"
+            # The agent has no shell, so pre-compute the diff (base...head SHAs are
+            # trusted) into the context file it reads. It may still read fork files
+            # by absolute path for extra context — reads are safe.
             {
               echo ""
               echo "## Pre-computed review diff (base...head)"
-              echo "You have no shell. The full diff is inlined below. The repository"
-              echo "checkout is at $GITHUB_WORKSPACE — you may read files there by"
-              echo "absolute path for additional context."
+              echo "You have no shell. The full diff is below. The repository checkout"
+              echo "is at $GITHUB_WORKSPACE — you may read files there by absolute path."
               echo '```diff'
               git -C "$GITHUB_WORKSPACE" diff --unified=0 "$PR_BASE_SHA...$PR_HEAD_SHA"
               echo '```'
-            } >> "$PI_WORKDIR/.github/pi/pr-review-context.md"
+            } >> "$CTX"
+
+            # Root cause of the recurring fork-review exposure: Pi resolves ALL
+            # project config from <cwd>/.pi — settings/packages, extensions, skills,
+            # themes, prompts, SYSTEM.md, APPEND_SYSTEM.md. Running inside the fork
+            # checkout lets a fork inject any of these to execute code or rewrite the
+            # reviewer's system prompt with DEEPSEEK_API_KEY in env. Discovery is
+            # cwd-based (single level, no walk-up; global fallback is the trusted
+            # runner home), so run Pi from a fresh empty dir where no fork .pi/* is
+            # on the path.
+            PI_WORKDIR=$(mktemp -d)
             cd "$PI_WORKDIR"
 
             # Belt-and-suspenders on top of the isolated cwd: refuse discovery of
@@ -328,6 +333,9 @@ jobs:
             cat REVIEW.md .github/pi/pr-review.prompt.md > /tmp/pi-prompt.md
             PI_TOOLS=read,grep,find,ls,bash
           fi
+          # The context file lives in RUNNER_TEMP (outside the checkout); tell the
+          # agent its absolute path.
+          printf '\nReview context file (absolute path): %s\n' "$CTX" >> /tmp/pi-prompt.md
           pi -p \
             --provider deepseek \
             --model deepseek-v4-pro \
@@ -376,7 +384,7 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
-            const path = `${process.env.GITHUB_WORKSPACE}/pi-final-message.md`;
+            const path = `${process.env.RUNNER_TEMP}/pi-final-message.md`;
             if (!fs.existsSync(path)) {
               core.info('Pi did not produce a final message; skipping PR comment.');
               return;

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -129,6 +129,11 @@ jobs:
         with:
           ref: refs/pull/${{ steps.pr.outputs.pr_number }}/merge
           fetch-depth: 1
+          # Don't persist github.token in .git/config: the review agent can read
+          # the checkout, and on the fork path that token (issue/PR write) would
+          # otherwise be exfiltratable. All later git ops target the public origin
+          # and need no auth; EE checkout and gh use their own explicit tokens.
+          persist-credentials: false
 
       # Never expose the EE private-repo token to untrusted fork code. Skipping
       # this step leaves steps.ee.outputs.available empty, so the EE checkout and
@@ -318,6 +323,7 @@ jobs:
         env:
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          GH_JOB_TOKEN: ${{ github.token }}
         with:
           github-token: ${{ github.token }}
           script: |
@@ -336,10 +342,12 @@ jobs:
             // credential in the environment (readable via /proc/self/environ), and
             // the posted comment is an exfiltration channel that bypasses GitHub
             // Actions log masking. Strip the credential if it leaked into the text.
-            const apiKey = process.env.DEEPSEEK_API_KEY;
-            if (typeof apiKey === 'string' && apiKey.length >= 8) {
-              body = body.split(apiKey).join('[REDACTED]').trim();
+            for (const s of [process.env.DEEPSEEK_API_KEY, process.env.GH_JOB_TOKEN]) {
+              if (typeof s === 'string' && s.length >= 8) {
+                body = body.split(s).join('[REDACTED]');
+              }
             }
+            body = body.trim();
             if (!body) {
               core.info('Pi final message was empty after redaction; skipping PR comment.');
               return;

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -99,9 +99,8 @@ jobs:
           fi
           # Fork PRs run untrusted code with secrets present, so the automatic
           # pull_request trigger never reviews them. A non-empty INPUT_PR_NUMBER
-          # means we arrived via workflow_call, which only happens after an
-          # authorized maintainer opted in (e.g. a /pi comment gated by
-          # check-write-access), so allow forks on that path.
+          # means we arrived via workflow_call (a maintainer /pi comment gated by
+          # check-write-access), so allow forks only on that path.
           if [ "$IS_FORK" = "true" ] && [ -z "$INPUT_PR_NUMBER" ]; then
             echo "Skipping Pi review for fork PR (automatic trigger)."
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -109,9 +108,8 @@ jobs:
           fi
           # PR title/body are attacker-controlled free text. Use an unguessable
           # per-run delimiter so a fork can't embed a fixed heredoc terminator to
-          # close the block early and inject extra outputs — e.g. is_fork=false,
-          # which (last-write-wins) would re-enable the EE checkout and the
-          # trusted-path agent settings for fork code.
+          # inject extra outputs — e.g. is_fork=false (last-write-wins), which
+          # would re-enable the EE checkout and trusted-path settings for forks.
           RAND=$(head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')
           TITLE_EOF="TITLE_EOF_${RAND}"
           BODY_EOF="BODY_EOF_${RAND}"
@@ -283,11 +281,10 @@ jobs:
         run: |
           set -o pipefail
           PI_HARDEN_FLAGS=()
-          # Keep generated files outside the checkout: on the fork path the merge
-          # tree is attacker-controlled, so a committed symlink at any of these
-          # paths (final message, events, context) would redirect the write and, in
-          # the worst case, overwrite an action's code that then runs with our
-          # credentials. RUNNER_TEMP is runner-created and outside the checkout.
+          # Keep generated files (final message, events, context) outside the
+          # checkout: on the fork path a committed symlink at any of these paths
+          # would redirect our write and could overwrite an action's code that
+          # then runs with our credentials. RUNNER_TEMP is outside the checkout.
           OUT_DIR="$RUNNER_TEMP"
           CTX="$RUNNER_TEMP/pr-review-context.md"
           if [ "$PR_IS_FORK" = "true" ]; then
@@ -312,14 +309,10 @@ jobs:
               echo '```'
             } >> "$CTX"
 
-            # Root cause of the recurring fork-review exposure: Pi resolves ALL
-            # project config from <cwd>/.pi — settings/packages, extensions, skills,
-            # themes, prompts, SYSTEM.md, APPEND_SYSTEM.md. Running inside the fork
-            # checkout lets a fork inject any of these to execute code or rewrite the
-            # reviewer's system prompt with DEEPSEEK_API_KEY in env. Discovery is
-            # cwd-based (single level, no walk-up; global fallback is the trusted
-            # runner home), so run Pi from a fresh empty dir where no fork .pi/* is
-            # on the path.
+            # Pi resolves ALL project config from <cwd>/.pi (settings/packages,
+            # extensions, skills, themes, prompts, SYSTEM.md); inside the fork
+            # checkout a fork could inject any to run code or rewrite our system
+            # prompt. Discovery is cwd-based, so run from a fresh empty dir.
             PI_WORKDIR=$(mktemp -d)
             cd "$PI_WORKDIR"
 

--- a/.github/workflows/pi-pr-review.yml
+++ b/.github/workflows/pi-pr-review.yml
@@ -317,6 +317,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
         with:
           github-token: ${{ github.token }}
           script: |
@@ -326,9 +327,21 @@ jobs:
               core.info('Pi did not produce a final message; skipping PR comment.');
               return;
             }
-            const body = fs.readFileSync(path, 'utf8').trim();
+            let body = fs.readFileSync(path, 'utf8').trim();
             if (!body) {
               core.info('Pi final message was empty; skipping PR comment.');
+              return;
+            }
+            // Defense-in-depth for fork reviews: the model call needs the provider
+            // credential in the environment (readable via /proc/self/environ), and
+            // the posted comment is an exfiltration channel that bypasses GitHub
+            // Actions log masking. Strip the credential if it leaked into the text.
+            const apiKey = process.env.DEEPSEEK_API_KEY;
+            if (typeof apiKey === 'string' && apiKey.length >= 8) {
+              body = body.split(apiKey).join('[REDACTED]').trim();
+            }
+            if (!body) {
+              core.info('Pi final message was empty after redaction; skipping PR comment.');
               return;
             }
             await github.rest.issues.createComment({


### PR DESCRIPTION
## Summary

Lets a maintainer's `/codex`, `/pi`, `/claude`, or `/review` comment run the automated review on **external/fork PRs**. Previously the Codex and Pi workflows unconditionally skipped every cross-repository PR, so the maintainer-triggered command path (`pr-review-commands.yml` → `workflow_call`, gated by `check-write-access`) bailed out on forks too.

Note: the GitHub Actions "Approve workflow to run" button does **not** help here — fork `pull_request` runs always get a read-only token and no secrets, so the review jobs (need API-key secrets + write to post the comment) can never run through that path. The maintainer-comment path is the correct opt-in mechanism, and it runs in the trusted base-repo context.

## Changes

**Enable fork review on the maintainer-command path** (`codex-pr-review.yml`, `pi-pr-review.yml`): gate the fork-skip on the automatic `pull_request` trigger only, detected via an empty `INPUT_PR_NUMBER` (`inputs.pr_number` is only set on `workflow_call` — the same discriminator the metadata step already uses).

**Harden the fork path against secret exfiltration** (addresses the CI review). For fork PRs only (detected via a new `is_fork` step output):
- **Withhold `WINDMILL_EE_PRIVATE_ACCESS`**: skip the EE access/checkout/substitution steps, so the private-repo token is never present in the job environment.
- **Read the review policy/prompt from the trusted base ref** (`git show origin/<base>:REVIEW.md` and the prompt file) instead of the attacker-controlled merge checkout — a malicious fork can no longer rewrite the reviewer's own instructions.
- **Restrict the agent**: Codex runs with `-s workspace-write` (network disabled) instead of `danger-full-access`; Pi drops the `bash` tool (`read,grep,find,ls` only).

Non-fork PRs are unchanged in every respect.

`pr-ready-review.yml` (Claude): **no change needed.** It has no fork skip, checks out `main` (not the fork ref), and reviews via `gh pr diff`/`gh pr view` with a restricted API-only tool allowlist — so it already reviews fork PRs on the command path without executing fork code or exposing this surface.

## Residual risk

The provider API key (`OPENAI_API_KEY`/`CODEX_AUTH_JSON`, `DEEPSEEK_API_KEY`) still has to be available for the model call. Indirect prompt injection via the diff → secret echoed into the public review comment is inherent to "an LLM reviews untrusted code"; it's mitigated by removing the highest-value secret (the EE token) and by the trusted-prompt + no-network / no-shell restrictions above, all behind the maintainer opt-in gate.

## Test plan

- [ ] Maintainer comments `/codex` (and `/pi`) on a fork PR → the "Resolve PR metadata" step does **not** print the skip line and a review comment is posted.
- [ ] On that fork run, the "Check EE access" step is skipped (no EE token), the prompt is sourced from the base ref, and Codex uses `workspace-write` / Pi uses the bash-less tool set.
- [ ] `/claude` on a fork PR still posts a review (already worked).
- [ ] A normal (non-fork) `pull_request` still auto-reviews with unchanged behavior (EE substitution active, full sandbox / bash tool).
- [ ] A fork PR on the automatic `pull_request` trigger is still skipped for Codex and Pi.