### PR TITLE
fix(apps): cover script/flow component outputs in deployed-app S3 provenance gate

### DIFF
--- a/backend/.sqlx/query-75d1618e12c4dfe5e9632ba8dc45b5aeb572e51ebd0732e6ebf80197acb3e577.json
+++ b/backend/.sqlx/query-75d1618e12c4dfe5e9632ba8dc45b5aeb572e51ebd0732e6ebf80197acb3e577.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS (\n                SELECT 1 FROM v2_job_completed c JOIN v2_job j USING (id)\n                WHERE j.workspace_id = $2\n                    AND c.started_at > now() - interval '3 hours'\n                    AND c.result @> ('{\"s3\":\"' || $1 ||  '\"}')::jsonb\n                    AND j.trigger_kind = 'app'\n                    AND j.trigger = $3\n                    AND j.created_by = $4\n            )",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "75d1618e12c4dfe5e9632ba8dc45b5aeb572e51ebd0732e6ebf80197acb3e577"
+}

--- a/backend/tests/app_s3_onbehalf.rs
+++ b/backend/tests/app_s3_onbehalf.rs
@@ -143,3 +143,367 @@ async fn test_deployed_app_s3_onbehalf_provenance(db: Pool<Postgres>) -> anyhow:
 
     Ok(())
 }
+
+/// Seed a completed job whose result carries an s3 object. `app_trigger` sets the
+/// app-origination marker exactly as `execute_component` stamps it: `Some(app_path)`
+/// => `trigger_kind = 'app'` + `trigger = <app_path>` (an app-launched run);
+/// `None` => an ordinary direct `/jobs/run` (no app marker). `created_by` is the user
+/// the job ran as (the isolation key the gate confines downloads to).
+async fn seed_completed_job(
+    db: &Pool<Postgres>,
+    created_by: &str,
+    app_trigger: Option<&str>,
+    s3_key: &str,
+) -> anyhow::Result<()> {
+    let result = format!(r#"{{"s3":"{s3_key}"}}"#);
+    sqlx::query(
+        r#"
+        WITH j AS (
+            INSERT INTO v2_job (id, workspace_id, kind, runnable_path, created_by,
+                                permissioned_as, trigger_kind, trigger)
+            VALUES (gen_random_uuid(), 'test-workspace', 'script', 'u/test-user/query_to_s3',
+                    $1, 'u/test-user',
+                    CASE WHEN $2::text IS NULL THEN NULL ELSE 'app'::job_trigger_kind END, $2)
+            RETURNING id
+        )
+        INSERT INTO v2_job_completed (id, workspace_id, duration_ms, status, result, started_at)
+        SELECT id, 'test-workspace', 1, 'success', $3::jsonb, now() FROM j
+        "#,
+    )
+    .bind(created_by)
+    .bind(app_trigger)
+    .bind(&result)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+/// A deployed app that renders S3 files it produced (e.g. a SQL query persisted to
+/// S3 by a component) must clear the provenance gate for the viewer whose own app
+/// run produced them, while (a) a viewer cannot forge provenance by running a
+/// runnable directly (no app marker), (b) another app's outputs stay denied, and
+/// (c) another viewer's outputs stay denied (cross-viewer isolation). Provenance is
+/// keyed on the app-origination marker (`trigger_kind='app'` + `trigger=<app path>`)
+/// that `execute_component` stamps, plus `created_by = <this caller>` for isolation.
+#[sqlx::test(fixtures("base"))]
+async fn test_deployed_app_s3_onbehalf_flow_script_provenance(
+    db: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let ws = format!("http://localhost:{port}/api/w/test-workspace");
+
+    const FS_APP: &str = "u/test-user/s3flowscript";
+    const OTHER_APP: &str = "u/test-user/other_app";
+    // Produced by test-user-2's own app run of THIS app.
+    const USER_KEY: &str = "results/user2_output.parquet";
+    // Produced by test-user's own app run of THIS app.
+    const ADMIN_KEY: &str = "results/admin_output.parquet";
+    // Produced by an app run of a DIFFERENT app → must stay denied.
+    const OTHER_APP_KEY: &str = "results/other_app_output.parquet";
+    // Produced by a DIRECT run (no app marker) → the forgery attempt, must stay denied.
+    const FORGED_KEY: &str = "results/author_only_secret.parquet";
+
+    let resp = authed(client().post(format!("{ws}/apps/create")), ADMIN_TOKEN)
+        .json(&json!({
+            "path": FS_APP,
+            "summary": "s3 app-origination provenance test",
+            "value": {},
+            "policy": { "execution_mode": "anonymous", "triggerables": {} }
+        }))
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 201, "app create: {}", resp.text().await?);
+
+    // Seed the produced-file jobs (all within the 3h window).
+    seed_completed_job(&db, "test-user-2", Some(FS_APP), USER_KEY).await?;
+    seed_completed_job(&db, "test-user", Some(FS_APP), ADMIN_KEY).await?;
+    seed_completed_job(&db, "test-user-2", Some(OTHER_APP), OTHER_APP_KEY).await?;
+    seed_completed_job(&db, "test-user-2", None, FORGED_KEY).await?;
+
+    let get = |route: &str, token: &'static str| {
+        let url = format!("{ws}/apps_u/{route}");
+        authed(client().get(url), token).send()
+    };
+    let denied = |body: &str| body.contains("File restricted");
+    let body_of = |route: String, token: &'static str| async move {
+        get(&route, token).await.unwrap().text().await.unwrap()
+    };
+
+    // The viewer's own app run's output clears the gate (the case that regressed to
+    // "File restricted").
+    let body = body_of(
+        format!("download_s3_file/{FS_APP}?s3={USER_KEY}"),
+        USER_TOKEN,
+    )
+    .await;
+    assert!(
+        !denied(&body),
+        "viewer's own app-produced key must clear the gate: {body}"
+    );
+
+    // The admin viewer's own app run's output clears — the gate has no admin bypass,
+    // it just matches the caller's own runs.
+    let body = body_of(
+        format!("download_s3_file/{FS_APP}?s3={ADMIN_KEY}"),
+        ADMIN_TOKEN,
+    )
+    .await;
+    assert!(
+        !denied(&body),
+        "admin's own app-produced key must clear the gate: {body}"
+    );
+
+    // Cross-viewer isolation: the admin cannot pull test-user-2's result even though
+    // it is a genuine app-marked job of the same app (no admin bypass either).
+    let body = body_of(
+        format!("download_s3_file/{FS_APP}?s3={USER_KEY}"),
+        ADMIN_TOKEN,
+    )
+    .await;
+    assert!(
+        denied(&body),
+        "another viewer's app-produced key must stay denied (isolation): {body}"
+    );
+
+    // A key produced by a direct run (no app marker) stays denied — the forgery the
+    // app-origination marker closes.
+    let body = body_of(
+        format!("download_s3_file/{FS_APP}?s3={FORGED_KEY}"),
+        USER_TOKEN,
+    )
+    .await;
+    assert!(
+        denied(&body),
+        "key from a direct run (no app marker) must stay denied: {body}"
+    );
+
+    // A key produced by a DIFFERENT app stays denied — provenance is scoped to THIS
+    // app's path.
+    let body = body_of(
+        format!("download_s3_file/{FS_APP}?s3={OTHER_APP_KEY}"),
+        USER_TOKEN,
+    )
+    .await;
+    assert!(
+        denied(&body),
+        "key produced by a different app must stay denied: {body}"
+    );
+
+    Ok(())
+}
+
+/// Seed a minimal deployed script so `execute_component` can resolve `script/<path>`.
+async fn seed_script(db: &Pool<Postgres>, path: &str, content: &str) -> anyhow::Result<()> {
+    let mut h = 0i64;
+    for b in path.bytes().chain(content.bytes()) {
+        h = h.wrapping_mul(31).wrapping_add(b as i64);
+    }
+    sqlx::query(
+        r#"INSERT INTO script (workspace_id, hash, path, summary, description, content,
+                                created_by, language, tag, lock)
+           VALUES ('test-workspace', $1, $2, '', '', $3, 'test-user', 'deno'::script_lang, 'deno', '')
+           ON CONFLICT DO NOTHING"#,
+    )
+    .bind(h)
+    .bind(path)
+    .bind(content)
+    .execute(db)
+    .await?;
+    // #[sqlx::test] isolated DBs share one workspace id and reuse script paths; the
+    // process-global deployed-script cache is keyed by (workspace, path), so disable
+    // it here so `execute_component` resolves against this test's own DB.
+    windmill_common::DEPLOYED_SCRIPT_CACHE_DISABLED
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    Ok(())
+}
+
+/// End-to-end: `execute_component` must stamp the job it enqueues with
+/// `trigger_kind = 'app'` + `trigger = <app path>`. This is the marker the S3
+/// provenance gate relies on; the gate tests seed it directly, so this test proves
+/// the runtime actually produces it. `execute_component` commits the job row and
+/// returns its id, so we assert on the row without needing a worker to run it.
+#[sqlx::test(fixtures("base"))]
+async fn test_execute_component_stamps_app_trigger(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let ws = format!("http://localhost:{port}/api/w/test-workspace");
+
+    const APP_PATH: &str = "u/test-user/trigger_marker_app";
+    const SCRIPT_PATH: &str = "u/test-user/query_to_s3";
+
+    seed_script(&db, SCRIPT_PATH, "export function main() { return 1 }").await?;
+
+    // Anonymous app wired to run the deployed script; keys use the production
+    // component-prefixed triggerable form.
+    let resp = authed(client().post(format!("{ws}/apps/create")), ADMIN_TOKEN)
+        .json(&json!({
+            "path": APP_PATH,
+            "summary": "trigger marker test",
+            "value": {},
+            "policy": {
+                "execution_mode": "anonymous",
+                "triggerables_v2": {
+                    format!("comp1:script/{SCRIPT_PATH}"): { "static_inputs": {}, "one_of_inputs": {} }
+                }
+            }
+        }))
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 201, "app create: {}", resp.text().await?);
+
+    // Run the script component through the app runtime.
+    let resp = authed(
+        client().post(format!("{ws}/apps_u/execute_component/{APP_PATH}")),
+        ADMIN_TOKEN,
+    )
+    .json(&json!({
+        "component": "comp1",
+        "path": format!("script/{SCRIPT_PATH}"),
+        "args": {}
+    }))
+    .send()
+    .await?;
+    let status = resp.status();
+    let job_id = resp.text().await?;
+    assert_eq!(status, 200, "execute_component: {job_id}");
+    let job_id = job_id.trim().trim_matches('"');
+
+    // The enqueued job must carry the app-origination marker: trigger_kind = 'app'
+    // and trigger = the app path (NOT the runnable path).
+    let (trigger_kind, trigger): (Option<String>, Option<String>) = sqlx::query_as(
+        "SELECT trigger_kind::text, trigger FROM v2_job WHERE id = $1::uuid AND workspace_id = 'test-workspace'",
+    )
+    .bind(job_id)
+    .fetch_one(&db)
+    .await?;
+
+    assert_eq!(
+        trigger_kind.as_deref(),
+        Some("app"),
+        "execute_component must stamp trigger_kind = 'app' (got {trigger_kind:?})"
+    );
+    assert_eq!(
+        trigger.as_deref(),
+        Some(APP_PATH),
+        "trigger must be the app path, not the runnable path (got {trigger:?})"
+    );
+
+    Ok(())
+}
+
+/// `JobTriggerKind::App` (added for the app-origination S3 marker) is now a valid
+/// value for the suspended-trigger reassignment routes, but there is no
+/// `app_trigger` table. The handler must reject it with a clean 400 rather than
+/// failing on a missing-relation database error (500).
+#[sqlx::test(fixtures("base"))]
+async fn test_app_trigger_kind_rejected_for_reassignment(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let ws = format!("http://localhost:{port}/api/w/test-workspace");
+
+    let resp = authed(
+        client().post(format!(
+            "{ws}/trigger/app/resume_suspended_trigger_jobs/u/test-user/x"
+        )),
+        ADMIN_TOKEN,
+    )
+    .json(&json!({}))
+    .send()
+    .await?;
+    let status = resp.status();
+    let body = resp.text().await?;
+    assert_eq!(
+        status, 400,
+        "app reassignment must be a clean 400, not 500: {body}"
+    );
+    assert!(
+        body.contains("do not support job reassignment"),
+        "expected reassignment-unsupported message, got: {body}"
+    );
+
+    Ok(())
+}
+
+/// A preview run is NEVER app-provenanced. Preview executes as the *caller* (Viewer
+/// mode), so its results are read back as the caller via the viewer-scoped
+/// job_helpers endpoint — never author-mode. Marking a preview would let any
+/// `jobs:run` caller supply arbitrary `raw_code` against a victim app path and forge
+/// the marker the S3 gate trusts; and it is never needed. Even the app owner's own
+/// preview stays unmarked.
+#[sqlx::test(fixtures("base"))]
+async fn test_preview_is_not_app_provenanced(db: Pool<Postgres>) -> anyhow::Result<()> {
+    initialize_tracing().await;
+
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let ws = format!("http://localhost:{port}/api/w/test-workspace");
+
+    const APP: &str = "u/test-user/preview_app";
+    let resp = authed(client().post(format!("{ws}/apps/create")), ADMIN_TOKEN)
+        .json(&json!({
+            "path": APP,
+            "summary": "preview marker test",
+            "value": {},
+            "policy": { "execution_mode": "anonymous", "triggerables": {} }
+        }))
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 201, "app create: {}", resp.text().await?);
+
+    // Preview arbitrary inline code against the app (force_viewer_static_fields =>
+    // preview mode; raw_code with no path/id skips all app authorization), as `token`.
+    let preview_trigger_kind = |token: &'static str| {
+        let ws = ws.clone();
+        let db = db.clone();
+        async move {
+            let resp = authed(
+                client().post(format!("{ws}/apps_u/execute_component/{APP}")),
+                token,
+            )
+            .json(&json!({
+                "component": "comp1",
+                "raw_code": { "content": "export function main() { return 1 }", "language": "deno" },
+                "force_viewer_static_fields": {},
+                "args": {}
+            }))
+            .send()
+            .await
+            .unwrap();
+            let status = resp.status();
+            let job_id = resp.text().await.unwrap();
+            assert_eq!(status, 200, "preview execute_component: {job_id}");
+            let job_id = job_id.trim().trim_matches('"').to_string();
+            let trigger_kind: Option<String> = sqlx::query_scalar(
+                "SELECT trigger_kind::text FROM v2_job WHERE id = $1::uuid AND workspace_id = 'test-workspace'",
+            )
+            .bind(job_id)
+            .fetch_one(&db)
+            .await
+            .unwrap();
+            trigger_kind
+        }
+    };
+
+    // The app owner (test-user, admin) previewing their own app → still NOT marked.
+    let trigger_kind = preview_trigger_kind(ADMIN_TOKEN).await;
+    assert_eq!(
+        trigger_kind, None,
+        "the app owner's own preview must NOT be app-provenanced (got {trigger_kind:?})"
+    );
+
+    // A non-editor (test-user-2) previewing a victim app → NOT marked.
+    let trigger_kind = preview_trigger_kind(USER_TOKEN).await;
+    assert_eq!(
+        trigger_kind, None,
+        "a non-editor's preview must NOT be app-provenanced (got {trigger_kind:?})"
+    );
+
+    Ok(())
+}

--- a/backend/windmill-api/openapi.yaml
+++ b/backend/windmill-api/openapi.yaml
@@ -26282,6 +26282,7 @@ components:
         - github
         - asset
         - freshness
+        - app
 
     TriggerMode:
       description: job trigger mode

--- a/backend/windmill-api/src/apps.rs
+++ b/backend/windmill-api/src/apps.rs
@@ -62,8 +62,9 @@ use windmill_common::{
     error::{to_anyhow, Error, JsonResult, Result},
     jobs::{
         get_payload_tag_from_prefixed_path, resolve_delete_after_secs, schedule_job_deletion,
-        JobPayload, RawCode,
+        JobPayload, JobTriggerKind, RawCode,
     },
+    triggers::TriggerMetadata,
     user_drafts::{overlay_or_draft_only, DraftUserRef, UserDraftItemKind, WithDraftOverlay},
     users::username_to_permissioned_as,
     utils::{
@@ -3179,6 +3180,21 @@ async fn execute_component(
     let end_user_email =
         get_end_user_email(&db, opt_authed.as_ref(), tokened.token.as_deref()).await;
 
+    // Mark the job as app-originated (trigger = the app path) — the provenance
+    // signal the deployed-app S3 gate trusts to distinguish files an app produced
+    // from files a viewer forged by running a declared runnable directly (a direct
+    // `/jobs/run` cannot set trigger_kind = 'app').
+    //
+    // ONLY deployed, policy-checked runs are marked. A preview executes as the
+    // *caller* (Viewer mode), not as the author, so its results are read back as the
+    // caller via the viewer-scoped `job_helpers` endpoint — never author-mode — and
+    // must never be app-provenanced. Marking a preview would let any `jobs:run`
+    // caller supply arbitrary `raw_code` against a victim app path and forge the
+    // marker; and it is never needed, since the caller already reads a preview's
+    // output as themselves.
+    let app_trigger =
+        (!is_preview).then(|| TriggerMetadata::new(Some(path.to_string()), JobTriggerKind::App));
+
     let (uuid, mut tx) = push(
         &db,
         tx,
@@ -3209,7 +3225,7 @@ async fn execute_component(
         None,
         false,
         end_user_email,
-        None,
+        app_trigger,
         None,
     )
     .await?;
@@ -3870,7 +3886,21 @@ async fn check_if_allowed_to_access_s3_file_from_app(
         // Author-mode (Anonymous/Publisher) or embed token: confine to the app's
         // declared keys or files it recently produced. Without this gate a
         // logged-in viewer could launder the author's S3 perms via an arbitrary
-        // file_key (confused deputy). Producing identity = caller else `anonymous`.
+        // file_key (confused deputy).
+        //
+        // "Recently produced" is keyed on the app-origination marker
+        // (`trigger_kind = 'app'` + `trigger = <this app path>`) that
+        // `execute_component` stamps on every job it launches — NOT on
+        // `created_by`/`permissioned_as`/`runnable_path` as the security boundary:
+        // those are forgeable (a viewer running a declared runnable directly, with
+        // un-pinned inputs, and — if the runnable carries its own `on_behalf_of` —
+        // even `permissioned_as` resolving to the author). Only a genuine
+        // app-launched run carries the marker (a direct `/jobs/run` cannot set it).
+        //
+        // `created_by = <this caller>` is then an additional *isolation* filter, not
+        // the boundary: it confines a viewer to keys their OWN app runs produced, so
+        // one viewer can't pull another viewer's result. It can only narrow (it is
+        // ANDed under the un-forgeable marker), so it re-introduces no forgery.
         let creator = opt_authed
             .as_ref()
             .map(|authed| authed.username.clone())
@@ -3883,11 +3913,11 @@ async fn check_if_allowed_to_access_s3_file_from_app(
                 r#"SELECT EXISTS (
                 SELECT 1 FROM v2_job_completed c JOIN v2_job j USING (id)
                 WHERE j.workspace_id = $2
-                    AND (j.kind = 'appscript' OR j.kind = 'preview')
-                    AND j.created_by = $4
                     AND c.started_at > now() - interval '3 hours'
-                    AND j.runnable_path LIKE $3 || '/%'
                     AND c.result @> ('{"s3":"' || $1 ||  '"}')::jsonb
+                    AND j.trigger_kind = 'app'
+                    AND j.trigger = $3
+                    AND j.created_by = $4
             )"#,
                 file_query.s3,
                 w_id,

--- a/backend/windmill-trigger/src/global_handler.rs
+++ b/backend/windmill-trigger/src/global_handler.rs
@@ -36,8 +36,11 @@ async fn get_suspended_trigger(
     trigger_kind: &JobTriggerKind,
     path: &str,
 ) -> Result<SuspendedTrigger> {
+    // Only trigger kinds backed by a `<kind>_trigger` table support reassignment.
+    // `app` (and webhook/schedule) have no such table, so reject them with a clear
+    // error instead of failing on a missing-relation database error below.
     match trigger_kind {
-        JobTriggerKind::Webhook | JobTriggerKind::Schedule => {
+        JobTriggerKind::Webhook | JobTriggerKind::Schedule | JobTriggerKind::App => {
             return Err(Error::BadRequest(format!(
                 "{} triggers do not support job reassignment",
                 trigger_kind

--- a/backend/windmill-types/src/jobs.rs
+++ b/backend/windmill-types/src/jobs.rs
@@ -49,6 +49,11 @@ pub enum JobTriggerKind {
     // A run pushed by the pipeline freshness watchdog (EE) because the
     // script's `// freshness` window elapsed without a successful run.
     Freshness,
+    // A run launched by a deployed app's runtime (`execute_component`). `trigger`
+    // carries the app path. This is the authoritative app-origination marker: a
+    // direct `/jobs/run` cannot set it, so it distinguishes files an app actually
+    // produced from files a viewer forged by running a declared runnable directly.
+    App,
 }
 
 impl std::fmt::Display for JobTriggerKind {
@@ -72,6 +77,7 @@ impl std::fmt::Display for JobTriggerKind {
             JobTriggerKind::CiTest => "ci_test",
             JobTriggerKind::Asset => "asset",
             JobTriggerKind::Freshness => "freshness",
+            JobTriggerKind::App => "app",
         };
         write!(f, "{}", kind)
     }

--- a/frontend/src/lib/components/apps/editor/appUtilsS3.ts
+++ b/frontend/src/lib/components/apps/editor/appUtilsS3.ts
@@ -90,20 +90,6 @@ export function isPartialS3Object(
 	return input != undefined && typeof input === 'object' && typeof input['s3'] === 'string'
 }
 
-function computeForceViewerPolicies({
-	isEditor,
-	configuration
-}: {
-	isEditor: boolean
-	configuration: RichConfigurations
-}) {
-	if (!isEditor) {
-		return undefined
-	}
-	const policy = computeS3FileViewerPolicy(configuration)
-	return policy
-}
-
 export async function getS3File({
 	source,
 	storage,
@@ -112,8 +98,7 @@ export async function getS3File({
 	username,
 	workspace,
 	token,
-	isEditor,
-	configuration
+	isEditor
 }: {
 	source: string | undefined
 	storage?: string
@@ -123,22 +108,37 @@ export async function getS3File({
 	workspace: string
 	token: string | undefined
 	isEditor: boolean
-	configuration: RichConfigurations
+	// Still accepted (callers pass it) but no longer used: editor reads go through
+	// the viewer-scoped endpoint regardless of the component configuration.
+	configuration?: RichConfigurations
 }) {
 	if (!source) return ''
+
+	// Editor/preview runs execute as the *caller* (Viewer mode), so read their
+	// results back as the caller through the viewer-scoped `job_helpers` endpoint —
+	// never author-mode — consistent with DisplayResult/ParqetCsvTableRenderer. Only
+	// a deployed app view reads on-behalf of the author via the provenance-gated
+	// `apps_u` endpoint.
+	if (isEditor) {
+		const params = new URLSearchParams()
+		params.append('file_key', source)
+		if (storage) {
+			params.append('storage', storage)
+		}
+		if (token && token != '') {
+			params.append('token', token)
+		}
+		return `/api/w/${workspace}/job_helpers/download_s3_file?${params.toString()}${presigned ? `&${presigned}` : ''}`
+	}
+
 	const appPathOrUser = defaultIfEmptyString(appPath, `u/${username ?? 'unknown'}/newapp`)
 	const params = new URLSearchParams()
 	params.append('s3', source)
 	if (storage) {
 		params.append('storage', storage)
 	}
-
 	if (token && token != '') {
 		params.append('token', token)
-	}
-	const forceViewerPolicies = computeForceViewerPolicies({ isEditor, configuration })
-	if (forceViewerPolicies) {
-		params.append('force_viewer_allowed_s3_keys', JSON.stringify([forceViewerPolicies]))
 	}
 
 	return `/api/w/${workspace}/apps_u/download_s3_file/${appPathOrUser}?${params.toString()}${presigned ? `&${presigned}` : ''}`


### PR DESCRIPTION
## Problem

The provenance gate in `check_if_allowed_to_access_s3_file_from_app` (`apps.rs`) only matched inline `appscript`/`preview` jobs whose `runnable_path` was prefixed with the app path. When a deployed app component triggers a **flow or script**, the resulting job has kind `flow`/`script`/`flowscript`/`flownode` and its own `runnable_path` (e.g. `f/my_flow`), so the gate failed with **"File restricted"** for every logged-in viewer — including admins (the gate has no admin bypass).

This broke the common pattern of a deployed app displaying an S3 result produced by a flow/script component (e.g. a SQL query persisted to S3) in author/anonymous/publisher execution mode, a regression introduced by #10048 (which moved logged-in viewers onto the author-mode `apps_u` on-behalf path).

## Fix

`created_by`, `permissioned_as`, and `runnable_path` are all **forgeable** by a viewer who runs a declared runnable directly with un-pinned inputs (and, if the runnable carries its own `on_behalf_of`, even `permissioned_as` resolves to the author). So instead of enumerating job kinds/identities, stamp an **authoritative app-origination marker** on every job `execute_component` launches for a deployed run:

- New `JobTriggerKind::App` with `trigger = <app path>`. A direct `/jobs/run` cannot set `trigger_kind = 'app'`, so it cleanly distinguishes files an app produced from forged ones and covers all component kinds (script/flow/flowscript/flownode/appscript/preview) without enumeration.
- The gate matches `trigger_kind = 'app' AND trigger = <this app path>`, with `created_by = <caller>` retained as an additional **isolation** filter (ANDed under the un-forgeable marker) so one viewer cannot pull another viewer's result.
- **Preview runs are never app-provenanced**: a preview executes as the *caller* (Viewer mode), so the editor reads its results back as the caller via the viewer-scoped `job_helpers` endpoint (`appUtilsS3.ts`), never author-mode — matching `DisplayResult`/`ParqetCsvTableRenderer`. Marking a preview would let any `jobs:run` caller forge the marker against a victim app path, and is never needed.
- `JobTriggerKind::App` has no `<kind>_trigger` table, so suspended-trigger reassignment rejects it with a clean 400 (not a 500 missing-relation error).

## Testing

`cargo test --features enterprise,private,parquet --test app_s3_onbehalf` — **5 passed**:

- `test_deployed_app_s3_onbehalf_flow_script_provenance` — a viewer's own app-produced key clears the gate; another viewer's / another app's / a direct-run (forged) key stay denied (incl. no admin bypass, cross-viewer isolation).
- `test_execute_component_stamps_app_trigger` — the enqueued job carries `trigger_kind='app'` + `trigger = <app path>`.
- `test_preview_is_not_app_provenanced` — preview runs (owner's own and a non-editor's) are never stamped.
- `test_app_trigger_kind_rejected_for_reassignment` — clean 400 for `app` reassignment.
- existing `test_deployed_app_s3_onbehalf_provenance` still passes.

Frontend `appUtilsS3.ts` type-checks; the edited region introduces no new errors. The editor-mode S3 read path can't be exercised end-to-end in the dev box (S3/parquet not compiled into the `quickjs`-only dev backend), but the security-critical gate logic is covered directly by the backend tests above.

Fixes WIN-2164