### PR TITLE
fix(frontend): graceful small-screen timeframe picker on the runs page

### DIFF
--- a/frontend/src/lib/components/common/InlineCalendarInput.svelte
+++ b/frontend/src/lib/components/common/InlineCalendarInput.svelte
@@ -63,9 +63,18 @@
 
 	type Props = (DateProps | RangeProps) & {
 		class?: string
+		// Portal the month/year dropdowns to the body so they escape an `overflow`
+		// ancestor (e.g. a scroll-contained popover). Off by default: in-flow.
+		portalSelects?: boolean
 	}
 
-	let { mode = 'date', value = $bindable(), class: className, ...rest }: Props = $props()
+	let {
+		mode = 'date',
+		value = $bindable(),
+		class: className,
+		portalSelects = false,
+		...rest
+	}: Props = $props()
 
 	const onClickBehavior = $derived(
 		mode === 'range' ? ((rest as RangeProps).onClickBehavior ?? 'set-range') : 'set-range'
@@ -425,14 +434,14 @@
 			<Select
 				class="basis-1/2"
 				inputClass="text-center !rounded-r-none !border-r-0"
-				disablePortal
+				disablePortal={!portalSelects}
 				bind:value={viewMonth}
 				items={MONTH_NAMES.map((name, i) => ({ label: name, value: i + 1 }))}
 			/>
 			<Select
 				class="basis-1/2"
 				inputClass="text-center !rounded-l-none !border-l-0"
-				disablePortal
+				disablePortal={!portalSelects}
 				bind:value={viewYear}
 				onCreateItem={(val) => (viewYear = parseInt(val) || viewYear)}
 				items={YEAR_LIST.map((year) => ({ label: year.toString(), value: year }))}

--- a/frontend/src/lib/components/runs/TimeframeSelect.svelte
+++ b/frontend/src/lib/components/runs/TimeframeSelect.svelte
@@ -134,7 +134,7 @@
 			Reset
 		</Button>
 	{/if}
-	<Popover enableFlyTransition bind:isOpen>
+	<Popover enableFlyTransition placement="bottom-end" bind:isOpen>
 		{#snippet trigger()}
 			<Button
 				unifiedSize="md"
@@ -152,8 +152,10 @@
 					value.type === 'manual' && value.minTs ? new Date(value.minTs) : undefined
 				)
 			}}
-			<div class="flex divide-x">
-				<div class="flex flex-col p-2">
+			<div
+				class="flex flex-col sm:flex-row divide-y sm:divide-y-0 sm:divide-x max-w-[calc(100vw-2rem)] max-h-[80vh] overflow-auto"
+			>
+				<div class="flex flex-row flex-wrap sm:flex-col gap-1 sm:gap-0 p-2">
 					{#each items as item}
 						<Button
 							onClick={() => (value = { ...item })}
@@ -166,26 +168,28 @@
 						</Button>
 					{/each}
 				</div>
-				<InlineCalendarInput
-					class="p-4 max-w-[18rem]"
-					infiniteRange
-					mode="range"
-					onClickBehavior="set-start"
-					bind:value={
-						() => range,
-						(v) => onManualInput({ minTs: fromCalendarDate(v.start)?.toISOString() ?? null })
-					}
-				/>
-				<InlineCalendarInput
-					class="p-4 max-w-[18rem]"
-					infiniteRange
-					mode="range"
-					onClickBehavior="set-end"
-					bind:value={
-						() => range,
-						(v) => onManualInput({ maxTs: fromCalendarDate(v.end)?.toISOString() ?? null })
-					}
-				/>
+				<div class="flex flex-col sm:flex-row divide-y sm:divide-y-0 sm:divide-x">
+					<InlineCalendarInput
+						class="p-4 w-full sm:max-w-[18rem]"
+						infiniteRange
+						mode="range"
+						onClickBehavior="set-start"
+						bind:value={
+							() => range,
+							(v) => onManualInput({ minTs: fromCalendarDate(v.start)?.toISOString() ?? null })
+						}
+					/>
+					<InlineCalendarInput
+						class="p-4 w-full sm:max-w-[18rem]"
+						infiniteRange
+						mode="range"
+						onClickBehavior="set-end"
+						bind:value={
+							() => range,
+							(v) => onManualInput({ maxTs: fromCalendarDate(v.end)?.toISOString() ?? null })
+						}
+					/>
+				</div>
 			</div>
 		{/snippet}
 	</Popover>

--- a/frontend/src/lib/components/runs/TimeframeSelect.svelte
+++ b/frontend/src/lib/components/runs/TimeframeSelect.svelte
@@ -78,6 +78,8 @@
 <script lang="ts">
 	import { CalendarIcon, RefreshCw } from 'lucide-svelte'
 	import { Button } from '../common'
+	import ToggleButtonGroup from '../common/toggleButton-v2/ToggleButtonGroup.svelte'
+	import ToggleButton from '../common/toggleButton-v2/ToggleButton.svelte'
 	import Popover from '../meltComponents/Popover.svelte'
 	import { watch } from 'runed'
 	import { page } from '$app/state'
@@ -98,6 +100,14 @@
 
 	let isOpen = $state(false)
 
+	// The two-calendar desktop popover needs ~780px (two min-w-9 grids + presets +
+	// popover padding); below that it overflows. Under 800px use a single calendar
+	// with a Start/End toggle, which keeps each bound's date + time inputs.
+	const TWO_CALENDAR_MIN_WIDTH = 800
+	let innerWidth = $state<number | undefined>(undefined)
+	const isSmall = $derived(innerWidth != undefined && innerWidth < TWO_CALENDAR_MIN_WIDTH)
+	let smallBound = $state<'start' | 'end'>('start')
+
 	function onManualInput(input: { minTs?: string | null; maxTs?: string | null }) {
 		if (value.type !== 'manual')
 			value = buildManualTimeframe(input.minTs ?? null, input.maxTs ?? null)
@@ -112,6 +122,22 @@
 		}
 	}
 </script>
+
+<svelte:window bind:innerWidth />
+
+{#snippet presetButtons()}
+	{#each items as item (item.label)}
+		<Button
+			onClick={() => (value = { ...item })}
+			variant="subtle"
+			unifiedSize="md"
+			selected={value.label === item.label}
+			btnClasses="justify-start text-nowrap"
+		>
+			{item.label}
+		</Button>
+	{/each}
+{/snippet}
 
 <div class="relative flex {wrapperClasses}">
 	<Button
@@ -134,7 +160,12 @@
 			Reset
 		</Button>
 	{/if}
-	<Popover enableFlyTransition placement="bottom-end" bind:isOpen>
+	<Popover
+		enableFlyTransition
+		placement="bottom-end"
+		contentClasses={isSmall ? 'overflow-y-auto' : ''}
+		bind:isOpen
+	>
 		{#snippet trigger()}
 			<Button
 				unifiedSize="md"
@@ -152,25 +183,42 @@
 					value.type === 'manual' && value.minTs ? new Date(value.minTs) : undefined
 				)
 			}}
-			<div
-				class="flex flex-col sm:flex-row divide-y sm:divide-y-0 sm:divide-x max-w-[calc(100vw-2rem)] max-h-[80vh] overflow-auto"
-			>
-				<div class="flex flex-row flex-wrap sm:flex-col gap-1 sm:gap-0 p-2">
-					{#each items as item}
-						<Button
-							onClick={() => (value = { ...item })}
-							variant="subtle"
-							unifiedSize="md"
-							selected={value.label === item.label}
-							btnClasses="justify-start text-nowrap"
-						>
-							{item.label}
-						</Button>
-					{/each}
+			{#if isSmall}
+				<div class="flex flex-col divide-y max-w-[calc(100vw-2rem)]">
+					<div class="flex flex-row flex-wrap gap-1 p-2">
+						{@render presetButtons()}
+					</div>
+					<div class="flex flex-col gap-2 p-2">
+						<ToggleButtonGroup bind:selected={smallBound} class="w-full">
+							{#snippet children({ item })}
+								<ToggleButton value="start" label="Start" {item} />
+								<ToggleButton value="end" label="End" {item} />
+							{/snippet}
+						</ToggleButtonGroup>
+						<InlineCalendarInput
+							class="w-full"
+							infiniteRange
+							mode="range"
+							onClickBehavior={smallBound === 'end' ? 'set-end' : 'set-start'}
+							bind:value={
+								() => range,
+								(v) =>
+									onManualInput(
+										smallBound === 'end'
+											? { maxTs: fromCalendarDate(v.end)?.toISOString() ?? null }
+											: { minTs: fromCalendarDate(v.start)?.toISOString() ?? null }
+									)
+							}
+						/>
+					</div>
 				</div>
-				<div class="flex flex-col sm:flex-row divide-y sm:divide-y-0 sm:divide-x">
+			{:else}
+				<div class="flex divide-x">
+					<div class="flex flex-col p-2">
+						{@render presetButtons()}
+					</div>
 					<InlineCalendarInput
-						class="p-4 w-full sm:max-w-[18rem]"
+						class="p-4 max-w-[18rem]"
 						infiniteRange
 						mode="range"
 						onClickBehavior="set-start"
@@ -180,7 +228,7 @@
 						}
 					/>
 					<InlineCalendarInput
-						class="p-4 w-full sm:max-w-[18rem]"
+						class="p-4 max-w-[18rem]"
 						infiniteRange
 						mode="range"
 						onClickBehavior="set-end"
@@ -190,7 +238,7 @@
 						}
 					/>
 				</div>
-			</div>
+			{/if}
 		{/snippet}
 	</Popover>
 </div>

--- a/frontend/src/lib/components/runs/TimeframeSelect.svelte
+++ b/frontend/src/lib/components/runs/TimeframeSelect.svelte
@@ -198,6 +198,7 @@
 						<InlineCalendarInput
 							class="w-full"
 							infiniteRange
+							portalSelects
 							mode="range"
 							onClickBehavior={smallBound === 'end' ? 'set-end' : 'set-start'}
 							bind:value={


### PR DESCRIPTION
## Summary

On narrow viewports, the timeframe/calendar popover on the **Runs** page overflowed off the right edge and was partly unreachable. The desktop content is a wide 3-column row (preset list + two side-by-side calendars, each ~288px ≈ 750px), and with a right-aligned trigger + center-anchored `bottom` placement — where floating-ui's `flip` only handles the vertical axis — the popup ran past the right edge.

Rather than just containing the overflow, small screens get a dedicated compact layout: below the two-calendar layout's minimum width, the picker shows a **single calendar with a Start/End toggle** that picks which bound the calendar edits. It uses `set-start`/`set-end` mode so each bound keeps its full date + HH:MM time inputs — the same precision the desktop start/end pair offers.

## Changes

- `frontend/src/lib/components/runs/TimeframeSelect.svelte`:
  - Anchor the popover to the right edge with `placement="bottom-end"` (where the trigger sits), so it opens leftward instead of spilling off the right.
  - Below `TWO_CALENDAR_MIN_WIDTH` (800px — the two-calendar layout has a hard ~780px minimum: two `min-w-9` grids + preset column + popover padding): presets (as wrapping chips) + a `ToggleButtonGroup` **Start / End** switch + **one** `InlineCalendarInput` whose `onClickBehavior` follows the toggle. Full date + time inputs preserved per bound.
  - The compact popover is scroll-contained on short/landscape viewports via `contentClasses="overflow-y-auto"` (scoped to the small layout), so it scrolls within floating-ui's own fitViewport max-height and its lower controls stay reachable.
  - At/above 800px: the original two-calendar (start / end) layout, unchanged.
  - Presets are shared between both layouts via a snippet; the active range is preserved across the breakpoint since both branches drive the same `value`.
- `frontend/src/lib/components/common/InlineCalendarInput.svelte`:
  - Add an opt-in `portalSelects` prop (default off → in-flow, existing consumers unchanged). The compact picker enables it so the month/year dropdowns portal to `body` (`fixed z-[10000]`) and escape the scroll-contained popover instead of being clipped.

`TimeframeSelect` is also reused in `ServiceLogsInner.svelte` (right-aligned, `w-full`); the same behavior applies there with no regression.

## Screenshots

**Small screen — presets + Start/End toggle + single calendar, with date & time inputs:**

![runs-375-toggle-start](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-calendar-overflow/1784024390-runs-375-toggle-start.png)

**Small screen — End bound selected, range 07/08→07/22 highlighted, time input targets the end:**

![runs-375-toggle-end-range](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-calendar-overflow/1784024390-runs-375-toggle-end-range.png)

**Short/landscape viewport (740×380) — popover scroll-contained within the viewport, bottom time inputs reachable:**

![runs-740x380-scrolled](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-calendar-overflow/1784036348-runs-740x380-scrolled.png)

**Month/year dropdown portals out of the scroll container (not clipped):**

![month-dropdown-portaled](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-calendar-overflow/1784036236-runs-month-dropdown-portaled.png)

**Desktop (1400px) — original two-calendar layout, unchanged, right-anchored:**

![runs-1400-desktop-final](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-calendar-overflow/1784024390-runs-1400-desktop-final.png)

## Test plan

- [ ] Runs page at a narrow width (<800px): open the picker → presets wrap as chips, a Start/End toggle switches which bound the single calendar edits, date + HH:MM inputs present, no horizontal overflow.
- [ ] Short/landscape viewport (e.g. 740×380): the popover stays within the viewport and scrolls; the bottom time inputs are reachable.
- [ ] Open the month/year dropdown on a compact viewport → it renders fully (portaled), not clipped by the scroll container.
- [ ] Set start (Start selected, tap a day), switch to End, tap a later day → `min_ts`/`max_ts` both set, range highlighted.
- [ ] Desktop width (≥800px): two calendars side by side, right-anchored, no overflow, month/year dropdowns still in-flow.
- [ ] Resize across the 800px boundary with a range set → the selected range is preserved.
- [ ] Service logs page (`ServiceLogsInner`): the full-width `TimeframeSelect` popover positions correctly with `bottom-end`.

## Verification

Browser-verified via Playwright against the live EE backend (logged in), measuring `document.documentElement.scrollWidth`/heights vs the viewport:
- 375/700/780px: compact layout, no overflow; toggling Start→day, End→day writes `min_ts`/`max_ts`; range highlighted.
- 740×380 landscape: popover contained (bottom 364 ≤ 380), scrolls (`scrollHeight 482 > clientHeight 264`), bottom time input reachable after scroll.
- Month dropdown at compact width: portaled to `body` (`fixed z-[10000]`, outside the popover), fully within the viewport.
- 800/850/900/1400px: two calendars, right-anchored, no overflow, outer popover `overflow: visible` (dropdowns in-flow).

`npm run check:fast` reports the changed files clean, and the Svelte autofixer reports no issues. (The one remaining check:fast error is a pre-existing `DeployProvider`/generated-client mismatch in `utils_workspace_deploy.ts`, unrelated to this change.)

## Review notes

Two review passes shaped this:
- A single `set-range` calendar was dropping hour/minute precision on mobile (`set-range` hides the time inputs) → switched to the Start/End toggle (`set-start`/`set-end`), which keeps full date + time.
- Codex flagged the compact panel lacked scroll containment on short/landscape viewports (lower controls unreachable) → scoped `overflow-y-auto` to the compact popover so it scrolls within floating-ui's max-height. To keep the month/year dropdowns from being clipped by that scroll container, they now portal to `body` (opt-in `portalSelects`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
