### PR TITLE
perf(runs): index-bound batch re-run selection with a lossless completed_at bound (WIN-2168)

### DIFF
--- a/frontend/src/lib/components/RunsPage.svelte
+++ b/frontend/src/lib/components/RunsPage.svelte
@@ -427,8 +427,13 @@
 			loadingToast.destroy()
 			return
 		}
+		// started_at is unindexed on v2_job_completed, so windowing by it alone seq-scans the
+		// workspace. started_at >= minTs implies completed_at >= minTs, so completedAfter adds a
+		// lossless indexed lower bound ((workspace_id, completed_at DESC)); started_at stays the
+		// exact recheck. (completedBefore is omitted: it would drop jobs that finish after maxTs.)
 		selectedIds = await JobService.listFilteredJobsUuids({
 			...selectedFilters,
+			completedAfter: selectedFilters.startedAfter,
 			jobKinds: 'script,flow'
 		})
 		loadingToast.destroy()


### PR DESCRIPTION
Fixes WIN-2168

## Problem

The runs page's batch **"Re-run all jobs matching filters"** action selects completed jobs via `list_filtered_uuids`, windowed by `started_before`/`started_after` (the timeframe slider):

```sql
... FROM v2_job_completed JOIN v2_job ON v2_job_completed.id = v2_job.id
WHERE ... AND runnable_path IN (...) AND (status = 'success' OR status = 'skipped')
  AND started_at <= '<maxTs>' AND started_at >= '<minTs>' ...
```

`v2_job_completed` has **no index on `started_at`** (only `completed_at`), so this filter can't use an index and Postgres seq-scans the workspace's completed jobs — a query observed at ~48s on a large instance (`EXPLAIN`: `Rows Removed by Filter: 133273` on synthetic data).

## Fix

Add a **lossless** `completed_at` lower bound and let the index do the work. Because a job completes at or after it starts, `started_at ≥ minTs` implies `completed_at ≥ minTs` — so `completedAfter = minTs`:

- **drops no rows** the `started_at` window keeps (it's implied), so the **selected cohort is identical to today's** — `started_at` remains the exact filter;
- lets the `(workspace_id, completed_at DESC)` index start the scan at the window's lower edge instead of scanning the whole table.

`EXPLAIN` on synthetic data: **seq scan → `completed_at` index scan** (0.8ms for a recent window; ~2.6ms for an 8-day-old window vs ~24ms seq scan on the same data — and orders of magnitude more on production-scale data).

### Why not also `completedBefore = maxTs`?

That bound is **not** lossless: a job can start in-window but finish after `maxTs`, and `completed_at ≤ maxTs` would drop it — changing the selection. So only the lossless lower bound is added. (The trade-off is that for a window far in the past the scan covers `[minTs, now]` rather than just `[minTs, maxTs]`; still an index scan, still far better than the seq scan, and — crucially — no row is silently dropped.)

## Scope

Net change vs `main`: a single `completedAfter` argument added to the re-run call — a pure query-plan improvement, no behavior change. Batch **cancel** (`listFilteredQueueUuids`) is untouched: it scans `v2_job_queue` (small — only pending/running jobs), so `started_at` there is not a perf problem. The paginated runs list and the count are unaffected.

## Note on `yyyy-MM-ddTHH:mm:ss.SSSSSSxxx` in the original report

A redaction (the format placeholder replaced the real timestamp); the follow-up log has the real values. `started_before`/`started_after` are typed `chrono::DateTime<Utc>`, so axum 400s a non-timestamp before any SQL runs.

## For a direct API/SDK caller hitting the same shape

Same idea: add `completed_after` (indexed, and lossless w.r.t. a `started_after` window) so the scan is index-bounded. No new index required.

## Validation

- `EXPLAIN (ANALYZE)` on synthetic data: `started_at` window alone → seq scan of `v2_job_completed`; `+ completed_after` → `completed_at` index scan, same result set.
- `npm run check:fast`: no type errors.
- Ran the runs page in the browser (Playwright): loads, Batch actions menu works.
- No new index; no migration; no backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)