### PR TITLE
fix(ai-agent): don't mark repeated tool calls as failed in flow graph

### DIFF
--- a/frontend/src/lib/components/graph/renderers/nodes/AIToolNode.svelte
+++ b/frontend/src/lib/components/graph/renderers/nodes/AIToolNode.svelte
@@ -160,7 +160,12 @@
 					data: {
 						tool: tool.name,
 						type: tool.type,
-						nameError: getToolNameError(tool.name, tool.type, siblingNames),
+						// agentActions are runtime tool calls: the same tool called multiple times
+						// yields duplicate names, which is expected and must not read as a Failure.
+						// Only validate names in the editor, where they define the static tool set.
+						nameError: agentActions
+							? undefined
+							: getToolNameError(tool.name, tool.type, siblingNames),
 						eventHandlers,
 						moduleId: tool.id,
 						insertable,

--- a/frontend/src/lib/components/graph/renderers/nodes/AIToolNode.test.ts
+++ b/frontend/src/lib/components/graph/renderers/nodes/AIToolNode.test.ts
@@ -43,6 +43,46 @@ describe('computeAIToolNodes', () => {
 		}
 	})
 
+	it('does not flag any node in a mixed run where one tool repeats (reporter scenario)', () => {
+		// Repo-intel run: query_stored called 3x plus two single calls, all succeeded.
+		// Before the fix the three query_stored nodes rendered red (Failure) purely
+		// from the duplicate-name check, while the unique tools stayed green.
+		const node = aiAgentNode('chat', [
+			{ id: 'q', summary: 'query_stored', value: { tool_type: 'flowmodule', type: 'script' } },
+			{ id: 'h', summary: 'hybrid_search', value: { tool_type: 'flowmodule', type: 'script' } },
+			{
+				id: 't',
+				summary: 'trace_outbound_calls',
+				value: { tool_type: 'flowmodule', type: 'script' }
+			}
+		])
+		const call = (name: string, job: string) => ({
+			type: 'tool_call',
+			function_name: name,
+			module_id: name[0],
+			job_id: job
+		})
+		const flowModuleStates = {
+			chat: {
+				type: 'Success',
+				agent_actions: [
+					call('query_stored', 'j1'),
+					call('query_stored', 'j2'),
+					call('query_stored', 'j3'),
+					call('hybrid_search', 'j4'),
+					call('trace_outbound_calls', 'j5')
+				]
+			}
+		} as any
+
+		const { toolNodes } = computeAIToolNodes([node], eventHandlers, false, flowModuleStates)
+
+		expect(toolNodes.length).toBe(5)
+		for (const n of toolNodes) {
+			expect((n.data as any).nameError).toBeUndefined()
+		}
+	})
+
 	it('still flags genuinely duplicate tool names in the editor (static tool set)', () => {
 		const node = aiAgentNode('agent2', [
 			{ id: 't1', summary: 'dup', value: { tool_type: 'flowmodule', type: 'script' } },

--- a/frontend/src/lib/components/graph/renderers/nodes/AIToolNode.test.ts
+++ b/frontend/src/lib/components/graph/renderers/nodes/AIToolNode.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock the component wrapper so importing the .svelte module doesn't pull in the
+// full render-time dependency graph.
+vi.mock('./NodeWrapper.svelte', () => ({ default: {} }))
+
+import { computeAIToolNodes } from './AIToolNode.svelte'
+
+const eventHandlers = {} as any
+
+function aiAgentNode(id: string, tools: any[]): any {
+	return {
+		id,
+		type: 'module',
+		position: { x: 0, y: 0 },
+		data: { module: { id, value: { type: 'aiagent', tools } } }
+	}
+}
+
+describe('computeAIToolNodes', () => {
+	it('does not flag duplicate names when the same tool is called multiple times at runtime', () => {
+		// One statically-defined tool that the agent called twice. The runtime
+		// agent_actions therefore carry the same function_name twice — this is
+		// expected and must not surface as a `nameError` (which renders as Failure).
+		const node = aiAgentNode('agent', [
+			{ id: 'tool_a', summary: 'my_tool', value: { tool_type: 'flowmodule', type: 'script' } }
+		])
+		const flowModuleStates = {
+			agent: {
+				type: 'Success',
+				agent_actions: [
+					{ type: 'tool_call', function_name: 'my_tool', module_id: 'tool_a', job_id: 'j1' },
+					{ type: 'tool_call', function_name: 'my_tool', module_id: 'tool_a', job_id: 'j2' }
+				]
+			}
+		} as any
+
+		const { toolNodes } = computeAIToolNodes([node], eventHandlers, false, flowModuleStates)
+
+		expect(toolNodes.length).toBe(2)
+		for (const n of toolNodes) {
+			expect((n.data as any).nameError).toBeUndefined()
+		}
+	})
+
+	it('still flags genuinely duplicate tool names in the editor (static tool set)', () => {
+		const node = aiAgentNode('agent2', [
+			{ id: 't1', summary: 'dup', value: { tool_type: 'flowmodule', type: 'script' } },
+			{ id: 't2', summary: 'dup', value: { tool_type: 'flowmodule', type: 'script' } }
+		])
+
+		const { toolNodes } = computeAIToolNodes([node], eventHandlers, true, undefined)
+
+		const toolCallNodes = toolNodes.filter((n) => n.type === 'aiTool')
+		expect(toolCallNodes.length).toBe(2)
+		for (const n of toolCallNodes) {
+			expect((n.data as any).nameError).toBe('Duplicate tool name')
+		}
+	})
+})


### PR DESCRIPTION
## Summary

In the AI-agent flow graph, when the same tool was called multiple times during a run, the repeated tool-call nodes rendered as **Failure** (red) even though the calls succeeded. This was a follow-up issue to the earlier websearch/MCP status-alignment fix.

### Root cause

`computeAIToolNodes` (in `AIToolNode.svelte`) computed a `nameError` for **every** tool node via `getToolNameError(name, type, siblingNames)` — including nodes built from the runtime `agent_actions`. `getToolNameError` flags `'Duplicate tool name'` when a name appears more than once in its sibling list. For runtime actions, the sibling list is the list of *called* function names, so the same tool called twice produced duplicate names → `nameError` set. `AIToolNode` then colors the node from `data.nameError ? 'Failure' : flowModuleState?.type`, so a successful repeated call showed up as a failure.

Duplicate-name validation is an **editor-time** concern about the static tool-definition set; it is meaningless against runtime call names (an LLM legitimately calling one tool multiple times, or multiple `Message` pseudo-tool actions).

## Changes

- `AIToolNode.svelte`: skip name validation when rendering runtime `agentActions`; only validate names in the editor (`insertable`), where tools are the static definition set. Runtime nodes now reflect the actual execution status (`flowModuleState?.type`).
- `AIToolNode.test.ts`: new regression test for the pure `computeAIToolNodes` logic.

## Test plan

- [x] `npm run check:fast` — clean
- [x] New unit test passes: same tool called twice at runtime → both nodes have no `nameError`; editor with two identically-named tools still surfaces `'Duplicate tool name'`.
- [x] Negative control: reverting the one-line fix makes the runtime test fail with `expected 'Duplicate tool name' to be undefined` — i.e. it reproduces the exact reported symptom.
- [ ] Manual: run an AI-agent flow that calls the same tool more than once, open the flow graph run view, confirm repeated tool-call nodes show their normal success color; then in the editor give two tools the same name and confirm the duplicate-name error still renders.

## Screenshots

No screenshot attached. The change has a visible UI effect, but reproducing this specific state live requires an AI-provider key **and** a non-deterministic run where the model calls one tool at least twice; this worktree currently has no running backend to drive. The fix is instead verified deterministically by the added regression test with a negative control (reverting the fix reproduces the exact "Duplicate tool name" → Failure symptom).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the AI-agent flow graph so repeated tool calls no longer render as Failure. Runtime tool-call nodes now skip duplicate-name checks and show their actual execution status.

- **Bug Fixes**
  - Skip name validation for runtime `agent_actions`; keep validation only in the editor.
  - Extend `AIToolNode.test.ts` with regression tests, including a mixed run where one tool repeats, to ensure no `nameError` on repeated runtime calls while editor duplicates still warn.

<sup>Written for commit 33350b0af0728d7a38ce7893940f60b362a2f972. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

