### PR TITLE
docs: mandate local-review-codex alongside local-review before PRs

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -96,7 +96,11 @@ and continue once they confirm it's done.
 1. Run `git status` to check for uncommitted changes
 2. Run `git log main..HEAD --oneline` to see all commits in this branch
 3. Run `git diff main...HEAD` to see the full diff against main
-4. **Invoke the `local-review` skill** before creating the PR (`/local-review` in Claude Code, `$local-review` in Codex, `pi --skill local-review` / `/skill:local-review` in Pi). If issues are found, fix them and commit before proceeding. Do not skip this step.
+4. **Review the diff before creating the PR — run both reviews, do not skip:**
+   - **`local-review`** — Claude-native branch-diff-reviewer (`/local-review` in Claude Code, `$local-review` in Codex, `pi --skill local-review` / `/skill:local-review` in Pi).
+   - **`local-review-codex`** — cold Codex pass, the same review CI runs, for an independent perspective the Claude pass misses (`/local-review-codex` in Claude Code, or `bash .agents/skills/local-review-codex/run.sh`). If the `codex` CLI is missing or older than the version pinned in that skill, note it in your summary and continue — never block the PR on codex being unavailable.
+
+   Run both — they catch different things. If either surfaces issues, fix them and commit before proceeding.
 5. **Screenshots for frontend changes**: if `git diff main...HEAD --name-only` matches `^frontend/`, capture and embed screenshots of the affected UI per "Screenshots" above before writing the PR body (skip only if there is no visible UI effect).
 6. Check if remote branch exists and is up to date:
    ```bash


### PR DESCRIPTION
## Summary

Step 4 of the `pr` skill previously mandated only `local-review` before opening a PR, so agents ran the Claude-native branch-diff review on every PR but never the Codex counterpart. This wires `local-review-codex` into the same gate so both reviews run every time, matching that skill's own stated intent to "run both for independent perspectives."

## Changes

- `.agents/skills/pr/SKILL.md` step 4: run both `local-review` and `local-review-codex` before creating the PR — they catch different things.
- The Codex pass degrades gracefully: if the `codex` CLI is missing or older than the version pinned in the skill (`>= 0.144.1`), note it and continue rather than blocking the PR on codex being unavailable.

## Test plan

- [ ] Invoke the `pr` skill on a branch and confirm both `local-review` and `local-review-codex` are requested before push.
- [ ] With the `codex` CLI missing or below the pinned version, confirm the flow reports it and continues without blocking the PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require running both `local-review` and `local-review-codex` before creating a PR to ensure two independent diff reviews. The Codex pass is non-blocking: if the `codex` CLI is missing or below the pinned version, it reports the issue and continues.

<sup>Written for commit 6b6a8c4cac293d000d7c6f9a160c74f994a735f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

