### PR TITLE
fix(sessions): reopen script test panel when preview goes full screen

### DIFF
--- a/frontend/src/lib/components/ScriptBuilder.svelte
+++ b/frontend/src/lib/components/ScriptBuilder.svelte
@@ -135,7 +135,7 @@
 		onNavigate,
 		onTestJob,
 		disableAi,
-		initialTestPanelCollapsed = false,
+		testPanelCollapsed = false,
 		initialPathChosen = false,
 		onResetToDeployed,
 		loadedFromDraft = false,
@@ -2152,7 +2152,7 @@
 			bind:assets={script.assets}
 			bind:modules={script.modules}
 			enablePreprocessorSnippet
-			{initialTestPanelCollapsed}
+			{testPanelCollapsed}
 		/>
 	</div>
 {:else}

--- a/frontend/src/lib/components/ScriptEditor.svelte
+++ b/frontend/src/lib/components/ScriptEditor.svelte
@@ -210,11 +210,13 @@
 		// Fired whenever a test run is started from this editor, with the
 		// preview job id. Used by whitelabel embedders to track test jobs.
 		onTestJob?: (e: { jobId: string }) => void
-		// When true the right-hand test/run pane mounts collapsed. The user
-		// can still expand it via `toggleTestPanel`. Defaults to false so the
-		// regular /scripts/edit route keeps its current open-by-default UX;
-		// the session preview opts in to save vertical real estate.
-		initialTestPanelCollapsed?: boolean
+		// Drives the right-hand test/run pane collapsed state. Seeds the pane
+		// collapsed at mount when true, and is edge-triggered afterwards: a later
+		// change collapses/expands the pane (but the user's own toggles in between
+		// are preserved — the effect only acts on a transition). Defaults to false
+		// so the regular /scripts/edit route keeps its open-by-default UX; the
+		// session preview collapses it to save space and reopens it in full screen.
+		testPanelCollapsed?: boolean
 		// Lets the AI toolbar button open the script in a fresh AI session
 		// instead of the inline chat panel (see OpenInSessionButton for gating).
 		sessionOpen?: OpenInSessionSource
@@ -269,7 +271,7 @@
 		previewLayout = 'right',
 		onTestStateChange,
 		onTestJob,
-		initialTestPanelCollapsed = false,
+		testPanelCollapsed = false,
 		sessionOpen = undefined,
 		schemaContractContext = undefined,
 		workspaceOverride = undefined
@@ -1626,10 +1628,10 @@
 	// dynamic minimum below — so when the editor shrinks, the displayed test
 	// pane grows to honor the new minimum without needing an effect. The code
 	// pane's size is purely derived from it (100 - test).
-	// `initialTestPanelCollapsed` seeds the raw value at 0 (collapsed) while
+	// `testPanelCollapsed` seeds the raw value at 0 (collapsed) while
 	// keeping the "remembered" size at 30, so the user's first toggle expands
 	// the pane to a sensible width rather than 0.
-	let rawTestPanelSize = $state(untrack(() => (initialTestPanelCollapsed ? 0 : 30)))
+	let rawTestPanelSize = $state(untrack(() => (testPanelCollapsed ? 0 : 30)))
 	let storedTestPanelSize = 30
 	const testPanelSize = $derived(
 		rawTestPanelSize === 0 ? 0 : Math.max(rawTestPanelSize, testPaneMinPercent)
@@ -1637,7 +1639,12 @@
 	const codePanelSize = $derived(100 - testPanelSize)
 
 	function expandTestPanel() {
-		rawTestPanelSize = Math.max(storedTestPanelSize, testPaneMinPercent)
+		// Restore the remembered *intent* only. `testPanelSize` clamps up to the
+		// dynamic pixel-min reactively, so we must NOT bake `testPaneMinPercent`
+		// into the raw size here: when the container is still narrow (e.g. the
+		// frame the session preview enters full screen, before the pane widens),
+		// that min is a huge fraction and would stick as an oversized pane.
+		rawTestPanelSize = storedTestPanelSize
 	}
 
 	function collapseTestPanel() {
@@ -1654,6 +1661,22 @@
 			expandTestPanel()
 		}
 	}
+
+	// React to an external `testPanelCollapsed` change (e.g. the session preview
+	// entering/leaving full screen) without clobbering the user's own toggles:
+	// only act on a genuine transition, reading the live size untracked so a drag
+	// never re-runs this. The mount seed already matches `testPanelCollapsed`, so
+	// the initial run is a no-op.
+	$effect(() => {
+		const collapsed = testPanelCollapsed
+		untrack(() => {
+			if (collapsed && testPanelSize > 0) {
+				collapseTestPanel()
+			} else if (!collapsed && testPanelSize === 0) {
+				expandTestPanel()
+			}
+		})
+	})
 
 	// When the compact preview shows a SchemaForm above the logs
 	// (`argsAboveLogs`), give the preview pane extra height so the args

--- a/frontend/src/lib/components/script_builder.ts
+++ b/frontend/src/lib/components/script_builder.ts
@@ -78,9 +78,10 @@ export interface ScriptBuilderProps {
 	// Fired whenever a test run is started from the script editor, with the
 	// preview job id. Used by whitelabel embedders to track test jobs.
 	onTestJob?: (e: { jobId: string }) => void
-	// Forwarded to the underlying ScriptEditor. When true, the right-hand
-	// test/run pane opens collapsed. Used by the session preview.
-	initialTestPanelCollapsed?: boolean
+	// Forwarded to the underlying ScriptEditor. Seeds the right-hand test/run
+	// pane collapsed, and edge-triggers a collapse/expand on later changes. The
+	// session preview drives it from full-screen state.
+	testPanelCollapsed?: boolean
 	// Treat the path as already chosen (seeds the path "dirty" flag) so the
 	// summary→path auto-slug for new scripts (initialPath == '') doesn't
 	// overwrite it. Used by the session preview, which opens AI-created scripts

--- a/frontend/src/lib/components/sessions/PreviewTabHost.svelte
+++ b/frontend/src/lib/components/sessions/PreviewTabHost.svelte
@@ -23,6 +23,7 @@
 		mounted,
 		label,
 		darkMode,
+		fullscreen = false,
 		onNavigate,
 		onLoad
 	}: {
@@ -31,6 +32,9 @@
 		runtime: SessionRuntime | undefined
 		/** Visible tab — only one is at a time; the rest stay mounted but hidden. */
 		active: boolean
+		/** Preview panel is in full screen — forwarded to editor views so a script
+		 * editor reopens its test pane when there's room. */
+		fullscreen?: boolean
 		/** Lazy-mount gate: content only renders once the tab has been activated. */
 		mounted: boolean
 		/** Short tab label, for the iframe title. */
@@ -122,7 +126,7 @@
 				{onNavigate}
 				{isActiveSession}
 				{active}
-				initialTestPanelCollapsed
+				{fullscreen}
 			/>
 		{:else if slot.editorKind === 'pipeline'}
 			<PipelineEditorView {runtime} path={slot.path} {workspaceId} {isActiveSession} {active} />

--- a/frontend/src/lib/components/sessions/ScriptEditorView.svelte
+++ b/frontend/src/lib/components/sessions/ScriptEditorView.svelte
@@ -15,7 +15,7 @@
 		path,
 		workspaceId,
 		onNavigate,
-		initialTestPanelCollapsed = false,
+		fullscreen = false,
 		isActiveSession = true,
 		active = true
 	}: {
@@ -23,7 +23,9 @@
 		path: string
 		workspaceId: string
 		onNavigate?: (item: WorkspaceItem) => void
-		initialTestPanelCollapsed?: boolean
+		/** Preview panel is in full screen: collapse the test pane in the narrow
+		 * side-by-side layout, reopen it when there's room in full screen. */
+		fullscreen?: boolean
 		/** Forwarded to SessionEditorTarget — only the visible session claims the
 		 * workspace's single live-editor slot. */
 		isActiveSession?: boolean
@@ -112,7 +114,7 @@
 				condensedHeader={true}
 				{diffDrawer}
 				{onNavigate}
-				{initialTestPanelCollapsed}
+				testPanelCollapsed={!fullscreen}
 				onDeploy={(e) => {
 					// Fires on every deploy (primary, "Deploy & Stay here", and lib — we
 					// ignore e.stay since the session always stays). Toast, then sync the

--- a/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/sessions/+page.svelte
@@ -761,6 +761,7 @@
 											mounted={mountedTabKeys.has(tabKey(s.id, tab.id))}
 											label={tabLabelFor(tab)}
 											darkMode={isDarkMode.val}
+											{fullscreen}
 											onNavigate={navigateEditorTo}
 											onLoad={(frame) => tabs && onTabLoad(tabs, tab, frame)}
 										/>


### PR DESCRIPTION
## Summary

In the AI session preview panel, a hosted script editor mounts its test/run pane collapsed to save space in the narrow side-by-side layout. Previously this was a one-shot mount seed (`initialTestPanelCollapsed`), so the pane stayed collapsed even after the user expanded the preview to full screen — wasting the extra room. This makes the collapse reactive: entering full screen reopens the test pane, and exiting re-collapses it, while the user's own manual toggles in between are preserved.

## Changes

- **`ScriptEditor.svelte`**: renamed `initialTestPanelCollapsed` → `testPanelCollapsed` and made it reactive via an edge-triggered `$effect`. The effect reads the prop tracked and the live pane size untracked, so it only acts on a genuine transition (a splitter drag never re-triggers it); the mount seed already matches the prop, so the initial run is a no-op.
- **`ScriptEditor.svelte`**: fixed `expandTestPanel` to restore only the remembered size intent instead of baking `testPaneMinPercent` into the raw size. The derived `testPanelSize` already clamps up to the dynamic pixel-min reactively, so baking it caused an oversized pane when expand fired while the container was still at the narrow width (the full-screen transition frame).
- Threaded a `fullscreen` prop from the sessions page down the preview chain: `sessions/+page.svelte` → `PreviewTabHost` → `ScriptEditorView` (which passes `testPanelCollapsed={!fullscreen}`) → `ScriptBuilder` → `ScriptEditor`. The generic components only ever see "collapse the test pane"; only the session layer maps full-screen state onto it.

## Screenshots

Narrow side-by-side layout — test pane collapsed (only the run button):

![narrow-collapsed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/session-preview-script-full-screen/1784027714-pr-narrow-collapsed.png)

Full screen — test pane reopened at a sensible width (~400px minimum, not an inflated fraction):

![fullscreen-open](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/session-preview-script-full-screen/1784027714-pr-fullscreen-open.png)

## Test plan

- [ ] On `/sessions`, open a script in the preview panel → test pane starts collapsed in the narrow layout
- [ ] Click full screen → test pane reopens at ~400px (code editor keeps the majority of the width, not the previous oversized ~66%)
- [ ] Exit full screen → test pane re-collapses
- [ ] While full screen, manually collapse the pane via its toggle → an unrelated re-render does not force it back open (effect only acts when `fullscreen` flips)