### PR TITLE
fix(apps): allow setting sandbox isolation and public access before first deploy

### DIFF
--- a/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
@@ -349,9 +349,14 @@
 				checked={policy.execution_mode == 'anonymous'}
 				on:change={(e) => {
 					policy.execution_mode = e.detail ? 'anonymous' : 'publisher'
-					setPublishState()
+					// Same as sandbox: a not-yet-deployed app has no row to PATCH, so
+					// `setPublishState` would 404. The mode is carried by the first
+					// deploy's policy; persist incrementally only once the app exists.
+					if (savedApp && !newApp) {
+						setPublishState()
+					}
 				}}
-				disabled={!savedApp || newApp || (!canSetAnonymous && policy.execution_mode != 'anonymous')}
+				disabled={!savedApp || (!canSetAnonymous && policy.execution_mode != 'anonymous')}
 			/>
 		</div>
 		{#if !savedApp || newApp}

--- a/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
+++ b/frontend/src/lib/components/apps/editor/AppEditorHeaderDeploy.svelte
@@ -299,7 +299,13 @@
 		checked={policy.sandbox == true}
 		on:change={(e) => {
 			policy.sandbox = e.detail || undefined
-			setPublishState(e.detail ? 'Sandbox isolation enabled' : 'Sandbox isolation disabled')
+			// A not-yet-deployed app has no row to PATCH — `setPublishState` (POST
+			// /apps/update) would 404. The flag rides along in the `policy` the first
+			// deploy sends (createApp), so here we only mutate it locally. Persist
+			// incrementally once the app exists.
+			if (savedApp && !newApp) {
+				setPublishState(e.detail ? 'Sandbox isolation enabled' : 'Sandbox isolation disabled')
+			}
 		}}
 		disabled={!savedApp}
 	/>
@@ -310,8 +316,8 @@
 		on every surface (public URL and in-workspace). Leave it off if the app needs full browser
 		features (IndexedDB, third-party auth/SDKs, OAuth redirects).
 	</div>
-	{#if !savedApp}
-		<div class="text-xs text-tertiary mt-1">Save the app once to change this setting.</div>
+	{#if newApp}
+		<div class="text-xs text-tertiary mt-1">Takes effect when you first deploy this app.</div>
 	{/if}
 	{#if policy.sandbox == true}
 		<div class="mt-2">


### PR DESCRIPTION
## Summary

Two deploy-drawer policy toggles used to throw for a not-yet-deployed app because their `on:change` calls `setPublishState()` → `AppService.updateApp()` → `POST /apps/update/{path}`, which 404s when there is no deployed app row yet. **Sandbox isolation** hit this directly; the **public-access** ("No login required") toggle sidestepped it only by being disabled until deploy.

This lets you set both **before** the first deploy and have them applied on deploy: the toggle sets the policy field locally, and the incremental persist runs only once the app actually exists. The flags are carried by the first deploy — `createApp` / `createAppRaw` send the full `policy`, and `updatePolicy` / `updateRawAppPolicy` spread `...currentPolicy`, preserving `sandbox` and `execution_mode`.

The change is in the shared `AppEditorHeaderDeploy.svelte`, so it covers both low-code and raw apps.

## Changes

Both toggles now follow the same pattern:
- `on:change` always mutates the local policy field; `setPublishState()` runs only when `savedApp && !newApp` (already deployed).
- **Sandbox**: guard reverted to `disabled={!savedApp}`; helper text (shown when `newApp`) changed to `Takes effect when you first deploy this app.`
- **Public access**: dropped `newApp` from `disabled` (now `!savedApp || (!canSetAnonymous && policy.execution_mode != 'anonymous')`); the `canSetAnonymous` protection-rule guard is preserved. The secret-URL placeholder still shows `Deploy this app once to get the public secret URL` pre-deploy (the URL genuinely only exists post-deploy).

Behavior for already-deployed apps is unchanged: toggling persists immediately via `POST /apps/update` (200) and shows the toast.

**Security note:** making an app anonymous is governed by the `RestrictAnonymousAppDeployment` protection rule. The backend enforces it on **create** (`apps.rs` `create_app_internal`, ~L1978) as well as update, so pre-setting `anonymous` and persisting it on first deploy does not bypass the rule; the UI also keeps the `canSetAnonymous` guard on the toggle.

**Known limitation:** deploy-drawer policy fields (sandbox, execution mode, on-behalf-of, custom path) are not stored in the autosaved *draft* — the draft-reload path resets policy to the default. So flipping a toggle on a brand-new app and then doing a full page reload *before* deploying resets it. It survives closing/reopening the drawer and editing within the session; only a hard reload-before-deploy loses it. Persisting policy into the draft is a larger change (it touches the value/policy separation and stale-draft compare logic), left as a follow-up.

## Test plan

- [x] Low-code brand-new app (`/apps/add`): both toggles interactive; flipping either fires **no** `POST /apps/update` (previously sandbox 404'd, anonymous was disabled).
- [x] Deploy after enabling → DB shows `policy.sandbox = true` and `policy.execution_mode = anonymous`.
- [x] Public-URL placeholder still shows "Deploy this app once to get the public secret URL" while the toggle is enabled pre-deploy.
- [x] Already-deployed app: toggling either still persists incrementally via `POST /apps/update` → 200.
- [x] Raw app draft: shared component, same behavior.
- [x] `npm run check:fast` clean; svelte-autofixer clean.

## Screenshots

Deploy drawer on a not-yet-deployed app, both toggles enabled pre-deploy (URL still shows the deploy-once placeholder):

![predeploy-both-toggles](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/sandbox-undeployed-app-error/1784039286-predeploy-both-toggles.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)