### PR TITLE
fix(apps): load themes when selecting the Resources → Theme tab

### DIFF
--- a/frontend/src/routes/(root)/(logged)/resources/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/resources/+page.svelte
@@ -449,6 +449,8 @@
 			await loadCache()
 		} else if (tab == 'states') {
 			await loadState()
+		} else if (tab == 'theme') {
+			await loadTheme()
 		} else {
 			await loadResources()
 		}
@@ -902,6 +904,9 @@
 					} else if (e.detail == 'states') {
 						loading.resources = true
 						loadState()
+					} else if (e.detail == 'theme') {
+						loading.resources = true
+						loadTheme()
 					}
 				}}
 			>


### PR DESCRIPTION
## Summary

The **Resources → Theme** tab renders empty even when app themes exist. Users report they can see their themes in the low-code app builder but not under Resources → Theme.

The Resources page dispatches per-tab data loads from the `Tabs` `on:selected` handler and from `reload()`, but both only handled `cache` and `states` — selecting the **Theme** tab never called `loadTheme()`, so `themeResources` stayed `undefined` and the table rendered empty. The reactive reload `$effect` reads `tab` inside `untrack`, so it doesn't re-fire on tab change either — only a filter or workspace change does, which is why typing anything in the filter box made the themes appear.

The app-builder theme list is unaffected because it's a separate component (`ThemeList.svelte`) with its own `onMount(getThemes)`. This is a pure frontend bug, edition-independent.

## Changes

- `frontend/src/routes/(root)/(logged)/resources/+page.svelte`
  - Add a `theme` branch to the `Tabs` `on:selected` handler so selecting the Theme tab calls `loadTheme()` (mirrors the existing `cache`/`states` branches).
  - Add a `theme` branch to `reload()` so the reload button reloads themes instead of falling through to `loadResources()` (which excludes `app_theme`).

## Screenshots

Before — Theme tab selected, empty despite `f/app_themes/theme_0` existing:

![theme-tab-empty](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/app-builder-themes-bug/1784028463-theme-tab-empty.png)

After — Theme tab selected, themes load immediately (no filter interaction needed):

![theme-tab-fixed](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/app-builder-themes-bug/1784028463-theme-tab-fixed.png)

## Test plan

- [ ] Open Resources → click the **Theme** tab → theme resources (e.g. `f/app_themes/theme_0`) appear immediately. Verified: `GET /resources/list?resource_type=app_theme` now fires on tab select (previously it never did).
- [ ] Switch between Workspace / States / Cache / Theme tabs → each still loads its own list.
- [ ] On the Theme tab, click the reload button → themes reload (previously fell back to the default resources view).
- [ ] Change a filter while on the Theme tab → still shows theme resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)