### PR TITLE
fix(ai-chat): size AI-created flow notes to fit their text

### DIFF
--- a/frontend/src/lib/components/copilot/chat/flow/helperUtils.test.ts
+++ b/frontend/src/lib/components/copilot/chat/flow/helperUtils.test.ts
@@ -476,6 +476,25 @@ describe('validateFlowNotes', () => {
 		expect(notes[0].position!.y).not.toEqual(notes[1].position!.y)
 	})
 
+	it('stacks auto-placed notes by their real heights so tall notes do not overlap', () => {
+		const longText = Array.from({ length: 20 }, (_, i) => `Line ${i} of note content`).join('\n')
+		const notes = validateFlowNotes([
+			{ id: 'a', text: longText },
+			{ id: 'b', text: 'short' }
+		])!
+		// Second note must start at or below the bottom of the first (tall) note.
+		expect(notes[1].position!.y).toBeGreaterThanOrEqual(
+			notes[0].position!.y + notes[0].size!.height
+		)
+	})
+
+	it('grows a note whose single source line wraps across many display lines', () => {
+		const short = validateFlowNotes([{ id: 's', text: 'hi' }])![0]
+		const oneLongLine = 'word '.repeat(200).trim() // no newlines, wraps many times
+		const wrapped = validateFlowNotes([{ id: 'w', text: oneLongLine }])![0]
+		expect(wrapped.size!.height).toBeGreaterThan(short.size!.height)
+	})
+
 	it('does not override a free note that already has geometry', () => {
 		const [note] = validateFlowNotes([
 			{ id: 'n', text: 't', position: { x: 5, y: 6 }, size: { width: 400, height: 90 } }

--- a/frontend/src/lib/components/copilot/chat/flow/helperUtils.test.ts
+++ b/frontend/src/lib/components/copilot/chat/flow/helperUtils.test.ts
@@ -488,6 +488,23 @@ describe('validateFlowNotes', () => {
 		)
 	})
 
+	it('does not drop an auto-placed note on top of a preserved note in the same column', () => {
+		// A round-tripped note keeps its existing auto-column geometry {-375, 0};
+		// a freshly added geometry-less note must stack below it, not overlap.
+		const notes = validateFlowNotes([
+			{
+				id: 'existing',
+				text: 'kept',
+				position: { x: -375, y: 0 },
+				size: { width: 275, height: 120 }
+			},
+			{ id: 'new', text: 'added' }
+		])!
+		expect(notes[1].position!.y).toBeGreaterThanOrEqual(
+			notes[0].position!.y + notes[0].size!.height
+		)
+	})
+
 	it('grows a note whose single source line wraps across many display lines', () => {
 		const short = validateFlowNotes([{ id: 's', text: 'hi' }])![0]
 		const oneLongLine = 'word '.repeat(200).trim() // no newlines, wraps many times

--- a/frontend/src/lib/components/copilot/chat/flow/helperUtils.test.ts
+++ b/frontend/src/lib/components/copilot/chat/flow/helperUtils.test.ts
@@ -453,6 +453,21 @@ describe('validateFlowNotes', () => {
 		expect(note.size!.height).toBeGreaterThan(0)
 	})
 
+	it('sizes a geometry-less free note tall enough for its text so it does not overflow', () => {
+		const [short] = validateFlowNotes([{ id: 's', text: 'hi' }])!
+		const longText = Array.from({ length: 20 }, (_, i) => `Line ${i} of note content`).join('\n')
+		const [long] = validateFlowNotes([{ id: 'l', text: longText }])!
+		expect(long.size!.height).toBeGreaterThan(short.size!.height)
+	})
+
+	it('clamps a short free note to the minimum height and a huge one to the max', () => {
+		const [short] = validateFlowNotes([{ id: 's', text: 'hi' }])!
+		expect(short.size!.height).toBe(60) // MIN_NOTE_HEIGHT
+		const hugeText = Array.from({ length: 500 }, (_, i) => `Line ${i}`).join('\n')
+		const [huge] = validateFlowNotes([{ id: 'h', text: hugeText }])!
+		expect(huge.size!.height).toBe(600) // MAX_HEIGHT
+	})
+
 	it('staggers the default y position of multiple geometry-less free notes', () => {
 		const notes = validateFlowNotes([
 			{ id: 'a', text: 't' },

--- a/frontend/src/lib/components/copilot/chat/flow/helperUtils.ts
+++ b/frontend/src/lib/components/copilot/chat/flow/helperUtils.ts
@@ -15,6 +15,39 @@ import type { InlineScriptSession } from './inlineScriptsUtils'
  * break the color picker UI at worst. */
 const ALLOWED_NOTE_COLORS = new Set<string>(Object.values(NoteColor))
 
+/**
+ * Estimate a free note's size from its markdown text so AI-created notes (which
+ * omit `size`) don't clip. Free notes render at a fixed height and never grow to
+ * fit their content — the renderer's text div overflows the node box — so the
+ * geometry seeded here must already be tall enough to hold the text.
+ *
+ * The note renders at `text-xs` (12px / line-height 1.4 ≈ 17px per line) inside
+ * `p-4` (16px padding on each side). We wrap each source line to the content
+ * width, sum the wrapped line count, and clamp the result to sane bounds.
+ */
+function estimateFreeNoteSize(text: string): { width: number; height: number } {
+	const width = MIN_NOTE_WIDTH
+	const HORIZONTAL_PADDING = 32 // p-4 left + right
+	const VERTICAL_PADDING = 32 // p-4 top + bottom
+	const LINE_HEIGHT = 17 // 12px * 1.4
+	const AVG_CHAR_WIDTH = 6.2 // approx width of a char at 12px
+	const MAX_HEIGHT = 600
+
+	const charsPerLine = Math.max(1, Math.floor((width - HORIZONTAL_PADDING) / AVG_CHAR_WIDTH))
+	const sourceLines = (text ?? '').split('\n')
+	const wrappedLineCount = sourceLines.reduce(
+		(sum, line) => sum + Math.max(1, Math.ceil(line.length / charsPerLine)),
+		0
+	)
+
+	const height = Math.min(
+		MAX_HEIGHT,
+		Math.max(MIN_NOTE_HEIGHT, Math.ceil(wrappedLineCount * LINE_HEIGHT) + VERTICAL_PADDING)
+	)
+
+	return { width, height }
+}
+
 type FlowLike = Pick<OpenFlow, 'value'> & {
 	schema?: Record<string, any>
 }
@@ -216,7 +249,7 @@ export function validateFlowNotes(rawNotes: unknown, moduleIds?: Set<string>): F
 				}
 			}
 			if (normalized.size == null) {
-				normalized.size = { width: MIN_NOTE_WIDTH, height: MIN_NOTE_HEIGHT }
+				normalized.size = estimateFreeNoteSize(normalized.text)
 			}
 		}
 

--- a/frontend/src/lib/components/copilot/chat/flow/helperUtils.ts
+++ b/frontend/src/lib/components/copilot/chat/flow/helperUtils.ts
@@ -159,10 +159,13 @@ export function validateFlowNotes(rawNotes: unknown, moduleIds?: Set<string>): F
 	}
 
 	const seenIds = new Set<string>()
-	// Running y-cursor for auto-placed free notes so consecutive ones stack
-	// below each other by their actual heights instead of overlapping.
-	let autoStackY = 0
+	// Column and running y-cursor for auto-placed free notes so consecutive ones
+	// stack below each other by their actual heights instead of overlapping. A
+	// preserved note (explicit geometry) sitting in this column also advances the
+	// cursor, so a later auto-placed note doesn't land on top of it.
+	const AUTO_STACK_X = -(MIN_NOTE_WIDTH + 100)
 	const AUTO_STACK_GAP = 24
+	let autoStackY = 0
 	return rawNotes.map((note, index) => {
 		if (!note || typeof note !== 'object' || Array.isArray(note)) {
 			throw new Error(`Invalid note at index ${index}: must be an object`)
@@ -250,12 +253,18 @@ export function validateFlowNotes(rawNotes: unknown, moduleIds?: Set<string>): F
 			if (normalized.size == null) {
 				normalized.size = estimateFreeNoteSize(normalized.text)
 			}
+			const height = normalized.size?.height ?? MIN_NOTE_HEIGHT
+			const width = normalized.size?.width ?? MIN_NOTE_WIDTH
 			if (normalized.position == null) {
-				normalized.position = {
-					x: -(MIN_NOTE_WIDTH + 100),
-					y: autoStackY
-				}
-				autoStackY += (normalized.size?.height ?? MIN_NOTE_HEIGHT) + AUTO_STACK_GAP
+				normalized.position = { x: AUTO_STACK_X, y: autoStackY }
+				autoStackY += height + AUTO_STACK_GAP
+			} else if (
+				// A preserved note overlapping the auto-stack column pushes the cursor
+				// below it so a later auto-placed note isn't dropped on top of it.
+				normalized.position.x < AUTO_STACK_X + MIN_NOTE_WIDTH &&
+				normalized.position.x + width > AUTO_STACK_X
+			) {
+				autoStackY = Math.max(autoStackY, normalized.position.y + height + AUTO_STACK_GAP)
 			}
 		}
 

--- a/frontend/src/lib/components/copilot/chat/flow/helperUtils.ts
+++ b/frontend/src/lib/components/copilot/chat/flow/helperUtils.ts
@@ -15,16 +15,10 @@ import type { InlineScriptSession } from './inlineScriptsUtils'
  * break the color picker UI at worst. */
 const ALLOWED_NOTE_COLORS = new Set<string>(Object.values(NoteColor))
 
-/**
- * Estimate a free note's size from its markdown text so AI-created notes (which
- * omit `size`) don't clip. Free notes render at a fixed height and never grow to
- * fit their content — the renderer's text div overflows the node box — so the
- * geometry seeded here must already be tall enough to hold the text.
- *
- * The note renders at `text-xs` (12px / line-height 1.4 ≈ 17px per line) inside
- * `p-4` (16px padding on each side). We wrap each source line to the content
- * width, sum the wrapped line count, and clamp the result to sane bounds.
- */
+// Free notes render at a fixed height and never grow to fit their content (the
+// renderer's text div overflows the node box), so an AI-created note that omits
+// `size` must be seeded tall enough for its text. Constants below mirror the
+// renderer (text-xs 12px, line-height 1.4, p-4 padding).
 function estimateFreeNoteSize(text: string): { width: number; height: number } {
 	const width = MIN_NOTE_WIDTH
 	const HORIZONTAL_PADDING = 32 // p-4 left + right

--- a/frontend/src/lib/components/copilot/chat/flow/helperUtils.ts
+++ b/frontend/src/lib/components/copilot/chat/flow/helperUtils.ts
@@ -159,6 +159,10 @@ export function validateFlowNotes(rawNotes: unknown, moduleIds?: Set<string>): F
 	}
 
 	const seenIds = new Set<string>()
+	// Running y-cursor for auto-placed free notes so consecutive ones stack
+	// below each other by their actual heights instead of overlapping.
+	let autoStackY = 0
+	const AUTO_STACK_GAP = 24
 	return rawNotes.map((note, index) => {
 		if (!note || typeof note !== 'object' || Array.isArray(note)) {
 			throw new Error(`Invalid note at index ${index}: must be an object`)
@@ -237,19 +241,21 @@ export function validateFlowNotes(rawNotes: unknown, moduleIds?: Set<string>): F
 			color: typeof n.color === 'string' ? n.color : DEFAULT_NOTE_COLOR
 		} as FlowNote
 
-		// Free notes need explicit geometry to be draggable/resizable. Place
-		// missing ones to the left of the flow column, staggered by index so
-		// several new notes don't land exactly on top of each other. Group notes
+		// Free notes need explicit geometry to be draggable/resizable. Size first
+		// (from text, so tall notes get a tall box), then place any note missing a
+		// position to the left of the flow column, stacking auto-placed notes by
+		// their real heights so several generated notes don't overlap. Group notes
 		// derive their layout from contained nodes, so they are left alone.
 		if (type === 'free') {
+			if (normalized.size == null) {
+				normalized.size = estimateFreeNoteSize(normalized.text)
+			}
 			if (normalized.position == null) {
 				normalized.position = {
 					x: -(MIN_NOTE_WIDTH + 100),
-					y: index * (MIN_NOTE_HEIGHT + 24)
+					y: autoStackY
 				}
-			}
-			if (normalized.size == null) {
-				normalized.size = estimateFreeNoteSize(normalized.text)
+				autoStackY += (normalized.size?.height ?? MIN_NOTE_HEIGHT) + AUTO_STACK_GAP
 			}
 		}
 


### PR DESCRIPTION
## Summary
When the flow AI chat creates a sticky note, the tool prompt tells the model to omit `size` and let the editor size it. But `validateFlowNotes` seeded a fixed **275×60px** box for every geometry-less free note, and free notes never grow to fit their content (only *group* notes drive layout from measured text height in `computeNoteNodes`). The result: any multi-line markdown note spilled out below its 60px box.

This seeds a text-proportional height when the AI omits `size`, so AI-created notes contain their text.

## Changes
- Add `estimateFreeNoteSize(text)` (module-private) in `helperUtils.ts`: wraps each source line to the content width (`text-xs` ≈ 17px/line, `p-4` padding) and clamps height to `[MIN_NOTE_HEIGHT (60), 600]`; width stays `MIN_NOTE_WIDTH`.
- `validateFlowNotes` uses it for free notes with omitted `size` (notes with explicit AI-provided or user-resized geometry are untouched).
- Tests: long text → taller box than short; short clamps to 60; huge clamps to 600.

## Notes / limitations
- The estimate is intentionally markdown-unaware (flat 17px/line on source characters), so notes dominated by markdown chrome (headers, code blocks) may still be slightly under-sized — render mode uses `overflow-auto` so content scrolls rather than being lost. This is a best-effort seed; the user can still resize.

## Test plan
- [x] `npx vitest run helperUtils.test.ts` — 44/44 pass
- [ ] In the flow editor, ask the AI to create a note with ~15–20 lines of markdown (incl. a couple of `#` headers) → box is tall enough to read without an immediate scrollbar
- [ ] Ask the AI for a one-line note → still renders at the compact default size

## Screenshots
No screenshot captured: exercising this path end-to-end requires a workspace with a configured AI provider driving the flow chat to emit a note, which isn't set up in the dev environment here. The change is a deterministic pure-function fix on note geometry, verified via unit tests and by reading the render path (`NoteNode.svelte`, `noteUtils.svelte.ts` `computeNoteNodes`) directly. The manual browser checks above are left in the test plan for a reviewer with an AI-enabled workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)