### PR TITLE
feat(dev-workspace): reflect existing protection rules in lock toggles

### DIFF
--- a/frontend/src/lib/components/DevWorkspaceSetting.svelte
+++ b/frontend/src/lib/components/DevWorkspaceSetting.svelte
@@ -273,7 +273,7 @@
 					}}
 				/>
 				{#if alreadyBlocksDeploy}
-					<span class="text-2xs text-secondary ml-8"
+					<span class="text-2xs text-secondary ml-11"
 						>Already enforced by an existing protection rule</span
 					>
 				{/if}
@@ -290,7 +290,7 @@
 			<div class="flex flex-col gap-0.5">
 				<Toggle checked disabled options={{ right: 'Prevent forking this workspace' }} />
 				{#if alreadyBlocksForking}
-					<span class="text-2xs text-secondary ml-8"
+					<span class="text-2xs text-secondary ml-11"
 						>Already enforced by an existing protection rule</span
 					>
 				{/if}

--- a/frontend/src/lib/components/DevWorkspaceSetting.svelte
+++ b/frontend/src/lib/components/DevWorkspaceSetting.svelte
@@ -73,10 +73,20 @@
 	let alreadyBlocksForking = $derived(
 		isRuleActiveInRulesets(rootProtectionRules.current ?? [], 'DisableWorkspaceForking')
 	)
-	// Sent to the backend: an already-enforced restriction stays on regardless of the (locked) toggle's
-	// raw state, keeping the request consistent with what the locked toggle shows.
-	let effectiveLockProdDeploy = $derived(alreadyBlocksDeploy || lockProdDeploy)
-	let effectiveLockProdForking = $derived(alreadyBlocksForking || lockProdForking)
+	// Until the fetch resolves the workspace's rules are unknown (current === undefined also covers the
+	// first frame before loading flips). Treat each lock as engaged during that window so the toggle is
+	// locked on and the effective value stays true: otherwise a user could turn a lock off and attach
+	// before an existing rule is detected, sending false and omitting the reserved rule — leaving prod
+	// unprotected if that existing rule is later removed.
+	let rulesUnknown = $derived(
+		rootProtectionRules.loading || rootProtectionRules.current === undefined
+	)
+	let deployLocked = $derived(alreadyBlocksDeploy || rulesUnknown)
+	let forkingLocked = $derived(alreadyBlocksForking || rulesUnknown)
+	// Sent to the backend: a locked restriction (enforced or not-yet-known) stays on regardless of the
+	// toggle's raw state, keeping the request consistent with what the locked toggle shows.
+	let effectiveLockProdDeploy = $derived(deployLocked || lockProdDeploy)
+	let effectiveLockProdForking = $derived(forkingLocked || lockProdForking)
 
 	// A standalone root workspace, or an existing fork of this prod (same family), can be attached.
 	// A fork parented to a different workspace can't (the backend rejects a parent that isn't this
@@ -240,7 +250,7 @@
 				Change to {attachLabel === 'staging' ? 'dev' : 'staging'}
 			</button>
 		</div>
-		{#if alreadyBlocksDeploy}
+		{#if deployLocked}
 			<div class="flex flex-col gap-0.5">
 				<Toggle
 					checked
@@ -249,9 +259,11 @@
 						right: 'Block direct edits in this workspace (deploy via the dev workspace)'
 					}}
 				/>
-				<span class="text-2xs text-secondary ml-8"
-					>Already enforced by an existing protection rule</span
-				>
+				{#if alreadyBlocksDeploy}
+					<span class="text-2xs text-secondary ml-8"
+						>Already enforced by an existing protection rule</span
+					>
+				{/if}
 			</div>
 		{:else}
 			<Toggle
@@ -261,12 +273,14 @@
 				}}
 			/>
 		{/if}
-		{#if alreadyBlocksForking}
+		{#if forkingLocked}
 			<div class="flex flex-col gap-0.5">
 				<Toggle checked disabled options={{ right: 'Prevent forking this workspace' }} />
-				<span class="text-2xs text-secondary ml-8"
-					>Already enforced by an existing protection rule</span
-				>
+				{#if alreadyBlocksForking}
+					<span class="text-2xs text-secondary ml-8"
+						>Already enforced by an existing protection rule</span
+					>
+				{/if}
 			</div>
 		{:else}
 			<Toggle

--- a/frontend/src/lib/components/DevWorkspaceSetting.svelte
+++ b/frontend/src/lib/components/DevWorkspaceSetting.svelte
@@ -61,8 +61,8 @@
 
 	// If this workspace already blocks direct deploy / forking through an existing protection rule, keep
 	// the matching lock toggle on but locked: attaching only manages its own reserved dev-workspace rule,
-	// so turning it "off" here couldn't lift a separately-defined block. Only fetched when the attach form
-	// (a root without a paired dev) is on screen. Fail-open (empty rules) on error.
+	// so turning it "off" here couldn't lift a separately-defined block. Fetched only while the attach form
+	// is on screen; a failed fetch falls back to the editable default-on toggle (real rules still enforce).
 	const rootProtectionRules = resource(
 		() => (!parentId && !pairedDev ? $workspaceStore : undefined),
 		async (ws) => (ws ? await fetchProtectionRulesForWorkspace(ws) : [])

--- a/frontend/src/lib/components/DevWorkspaceSetting.svelte
+++ b/frontend/src/lib/components/DevWorkspaceSetting.svelte
@@ -13,7 +13,7 @@
 	import {
 		loadProtectionRules,
 		fetchProtectionRulesForWorkspace,
-		isRuleActiveInRulesets
+		isRuleUnconditionallyActiveInRulesets
 	} from '$lib/workspaceProtectionRules.svelte'
 	import { GitFork, ExternalLink } from 'lucide-svelte'
 	import { resource } from 'runed'
@@ -65,22 +65,35 @@
 	// is on screen; a failed fetch falls back to the editable default-on toggle (real rules still enforce).
 	const rootProtectionRules = resource(
 		() => (!parentId && !pairedDev ? $workspaceStore : undefined),
-		async (ws) => (ws ? await fetchProtectionRulesForWorkspace(ws) : [])
+		async (ws, _prev, { signal }) => {
+			if (!ws) return undefined
+			const rules = await fetchProtectionRulesForWorkspace(ws)
+			// The generated client can't take an abort signal, so drop a superseded response here: a late
+			// result for a previously selected workspace must not overwrite the current one's rules.
+			if (signal.aborted) throw new DOMException('superseded', 'AbortError')
+			return { ws, rules }
+		}
 	)
+	// Only trust a result that belongs to the current workspace (guards the in-flight window and any
+	// out-of-order response); undefined means "not known yet" and is treated as locked below.
+	let rootRules = $derived.by(() => {
+		const current = rootProtectionRules.current
+		return current && current.ws === $workspaceStore ? current.rules : undefined
+	})
+	// Only a rule with no bypass users/groups matches the empty-bypass reserved lock we would create; a
+	// bypassable rule stays editable, otherwise forcing the lock on would revoke the bypassed users'
+	// direct-deploy / forking access.
 	let alreadyBlocksDeploy = $derived(
-		isRuleActiveInRulesets(rootProtectionRules.current ?? [], 'DisableDirectDeployment')
+		isRuleUnconditionallyActiveInRulesets(rootRules ?? [], 'DisableDirectDeployment')
 	)
 	let alreadyBlocksForking = $derived(
-		isRuleActiveInRulesets(rootProtectionRules.current ?? [], 'DisableWorkspaceForking')
+		isRuleUnconditionallyActiveInRulesets(rootRules ?? [], 'DisableWorkspaceForking')
 	)
-	// Until the fetch resolves the workspace's rules are unknown (current === undefined also covers the
-	// first frame before loading flips). Treat each lock as engaged during that window so the toggle is
-	// locked on and the effective value stays true: otherwise a user could turn a lock off and attach
-	// before an existing rule is detected, sending false and omitting the reserved rule — leaving prod
-	// unprotected if that existing rule is later removed.
-	let rulesUnknown = $derived(
-		rootProtectionRules.loading || rootProtectionRules.current === undefined
-	)
+	// Until the fetch resolves for the current workspace its rules are unknown. Treat each lock as
+	// engaged during that window so the toggle is locked on and the effective value stays true:
+	// otherwise a user could turn a lock off and attach before an existing rule is detected, sending
+	// false and omitting the reserved rule — leaving prod unprotected if that rule is later removed.
+	let rulesUnknown = $derived(rootProtectionRules.loading || rootRules === undefined)
 	let deployLocked = $derived(alreadyBlocksDeploy || rulesUnknown)
 	let forkingLocked = $derived(alreadyBlocksForking || rulesUnknown)
 	// Sent to the backend: a locked restriction (enforced or not-yet-known) stays on regardless of the

--- a/frontend/src/lib/components/DevWorkspaceSetting.svelte
+++ b/frontend/src/lib/components/DevWorkspaceSetting.svelte
@@ -10,7 +10,11 @@
 	import { base } from '$lib/base'
 	import { findCanonicalDevWorkspace } from '$lib/utils/workspaceHierarchy'
 	import { devBadgeText, devLabelKey, devLabelNoun } from '$lib/utils/devWorkspaceLabel'
-	import { loadProtectionRules } from '$lib/workspaceProtectionRules.svelte'
+	import {
+		loadProtectionRules,
+		fetchProtectionRulesForWorkspace,
+		isRuleActiveInRulesets
+	} from '$lib/workspaceProtectionRules.svelte'
 	import { GitFork, ExternalLink } from 'lucide-svelte'
 	import { resource } from 'runed'
 
@@ -55,6 +59,25 @@
 	let busy = $state(false)
 	let labelBusy = $state(false)
 
+	// If this workspace already blocks direct deploy / forking through an existing protection rule, keep
+	// the matching lock toggle on but locked: attaching only manages its own reserved dev-workspace rule,
+	// so turning it "off" here couldn't lift a separately-defined block. Only fetched when the attach form
+	// (a root without a paired dev) is on screen. Fail-open (empty rules) on error.
+	const rootProtectionRules = resource(
+		() => (!parentId && !pairedDev ? $workspaceStore : undefined),
+		async (ws) => (ws ? await fetchProtectionRulesForWorkspace(ws) : [])
+	)
+	let alreadyBlocksDeploy = $derived(
+		isRuleActiveInRulesets(rootProtectionRules.current ?? [], 'DisableDirectDeployment')
+	)
+	let alreadyBlocksForking = $derived(
+		isRuleActiveInRulesets(rootProtectionRules.current ?? [], 'DisableWorkspaceForking')
+	)
+	// Sent to the backend: an already-enforced restriction stays on regardless of the (locked) toggle's
+	// raw state, keeping the request consistent with what the locked toggle shows.
+	let effectiveLockProdDeploy = $derived(alreadyBlocksDeploy || lockProdDeploy)
+	let effectiveLockProdForking = $derived(alreadyBlocksForking || lockProdForking)
+
 	// A standalone root workspace, or an existing fork of this prod (same family), can be attached.
 	// A fork parented to a different workspace can't (the backend rejects a parent that isn't this
 	// prod), so it's excluded here.
@@ -92,8 +115,8 @@
 				workspace: $workspaceStore,
 				requestBody: {
 					dev_workspace_id: selectedDevId,
-					lock_prod_deploy: lockProdDeploy,
-					lock_prod_forking: lockProdForking,
+					lock_prod_deploy: effectiveLockProdDeploy,
+					lock_prod_forking: effectiveLockProdForking,
 					dev_workspace_label: attachLabel
 				}
 			})
@@ -217,13 +240,40 @@
 				Change to {attachLabel === 'staging' ? 'dev' : 'staging'}
 			</button>
 		</div>
-		<Toggle
-			bind:checked={lockProdDeploy}
-			options={{
-				right: 'Block direct edits in this workspace (deploy via the dev workspace)'
-			}}
-		/>
-		<Toggle bind:checked={lockProdForking} options={{ right: 'Prevent forking this workspace' }} />
+		{#if alreadyBlocksDeploy}
+			<div class="flex flex-col gap-0.5">
+				<Toggle
+					checked
+					disabled
+					options={{
+						right: 'Block direct edits in this workspace (deploy via the dev workspace)'
+					}}
+				/>
+				<span class="text-2xs text-secondary ml-8"
+					>Already enforced by an existing protection rule</span
+				>
+			</div>
+		{:else}
+			<Toggle
+				bind:checked={lockProdDeploy}
+				options={{
+					right: 'Block direct edits in this workspace (deploy via the dev workspace)'
+				}}
+			/>
+		{/if}
+		{#if alreadyBlocksForking}
+			<div class="flex flex-col gap-0.5">
+				<Toggle checked disabled options={{ right: 'Prevent forking this workspace' }} />
+				<span class="text-2xs text-secondary ml-8"
+					>Already enforced by an existing protection rule</span
+				>
+			</div>
+		{:else}
+			<Toggle
+				bind:checked={lockProdForking}
+				options={{ right: 'Prevent forking this workspace' }}
+			/>
+		{/if}
 		<div class="flex gap-2">
 			<Button variant="accent" disabled={busy || !selectedDevId} onclick={attach}>
 				Attach dev workspace

--- a/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
+++ b/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
@@ -823,7 +823,7 @@
 											options={{ right: 'Block direct edits (deploy via the dev workspace)' }}
 										/>
 										{#if rootAlreadyBlocksDeploy}
-											<span class="text-2xs text-secondary ml-8"
+											<span class="text-2xs text-secondary ml-11"
 												>Already enforced by an existing protection rule</span
 											>
 										{/if}
@@ -838,7 +838,7 @@
 									<div class="flex flex-col gap-0.5">
 										<Toggle checked disabled options={{ right: 'Prevent forking' }} />
 										{#if rootAlreadyBlocksForking}
-											<span class="text-2xs text-secondary ml-8"
+											<span class="text-2xs text-secondary ml-11"
 												>Already enforced by an existing protection rule</span
 											>
 										{/if}

--- a/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
+++ b/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
@@ -161,10 +161,20 @@
 	let rootAlreadyBlocksForking = $derived(
 		isRuleActiveInRulesets(rootProtectionRules.current ?? [], 'DisableWorkspaceForking')
 	)
-	// Sent to the backend: an already-enforced restriction stays on regardless of the (locked) toggle's
-	// raw state, keeping the request consistent with what the locked toggle shows.
-	let effectiveLockProdDeploy = $derived(rootAlreadyBlocksDeploy || lockProdDeploy)
-	let effectiveLockProdForking = $derived(rootAlreadyBlocksForking || lockProdForking)
+	// Until the fetch resolves the root's rules are unknown (current === undefined also covers the first
+	// frame before loading flips). Treat each lock as engaged during that window so the toggle is locked
+	// on and the effective value stays true: otherwise a user could turn a lock off and submit before an
+	// existing rule is detected, sending false and omitting the reserved rule — leaving prod unprotected
+	// if that existing rule is later removed.
+	let rootRulesUnknown = $derived(
+		rootProtectionRules.loading || rootProtectionRules.current === undefined
+	)
+	let deployLocked = $derived(rootAlreadyBlocksDeploy || rootRulesUnknown)
+	let forkingLocked = $derived(rootAlreadyBlocksForking || rootRulesUnknown)
+	// Sent to the backend: a locked restriction (enforced or not-yet-known) stays on regardless of the
+	// toggle's raw state, keeping the request consistent with what the locked toggle shows.
+	let effectiveLockProdDeploy = $derived(deployLocked || lockProdDeploy)
+	let effectiveLockProdForking = $derived(forkingLocked || lockProdForking)
 
 	let id = $state('')
 	let name = $state('')
@@ -792,16 +802,18 @@
 										dev workspace and promoted here.
 									</span>
 								</div>
-								{#if rootAlreadyBlocksDeploy}
+								{#if deployLocked}
 									<div class="flex flex-col gap-0.5">
 										<Toggle
 											checked
 											disabled
 											options={{ right: 'Block direct edits (deploy via the dev workspace)' }}
 										/>
-										<span class="text-2xs text-secondary ml-8"
-											>Already enforced by an existing protection rule</span
-										>
+										{#if rootAlreadyBlocksDeploy}
+											<span class="text-2xs text-secondary ml-8"
+												>Already enforced by an existing protection rule</span
+											>
+										{/if}
 									</div>
 								{:else}
 									<Toggle
@@ -809,12 +821,14 @@
 										options={{ right: 'Block direct edits (deploy via the dev workspace)' }}
 									/>
 								{/if}
-								{#if rootAlreadyBlocksForking}
+								{#if forkingLocked}
 									<div class="flex flex-col gap-0.5">
 										<Toggle checked disabled options={{ right: 'Prevent forking' }} />
-										<span class="text-2xs text-secondary ml-8"
-											>Already enforced by an existing protection rule</span
-										>
+										{#if rootAlreadyBlocksForking}
+											<span class="text-2xs text-secondary ml-8"
+												>Already enforced by an existing protection rule</span
+											>
+										{/if}
 									</div>
 								{:else}
 									<Toggle bind:checked={lockProdForking} options={{ right: 'Prevent forking' }} />

--- a/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
+++ b/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
@@ -21,6 +21,10 @@
 		findWorkspaceDescendants
 	} from '$lib/utils/workspaceHierarchy'
 	import { useForkableWorkspaces } from '$lib/utils/useForkableWorkspaces.svelte'
+	import {
+		fetchProtectionRulesForWorkspace,
+		isRuleActiveInRulesets
+	} from '$lib/workspaceProtectionRules.svelte'
 	import { resource } from 'runed'
 	import { Badge, Button } from '$lib/components/common'
 	import { devBadgeText } from '$lib/utils/devWorkspaceLabel'
@@ -142,6 +146,24 @@
 	let currentWorkspaceName = $derived(
 		baseWorkspaceEntry?.name ?? baseWorkspaceId ?? 'the root workspace'
 	)
+
+	// If the root already blocks direct deploy / forking through an existing protection rule, keep the
+	// matching lock toggle on but locked: this flow only manages its own reserved dev-workspace rule, so
+	// turning it "off" here couldn't lift a separately-defined block. Fail-open (empty rules) on error.
+	const rootProtectionRules = resource(
+		() => (canDesignateDevWorkspace && createAsDevWorkspace ? baseWorkspaceId : undefined),
+		async (ws) => (ws ? await fetchProtectionRulesForWorkspace(ws) : [])
+	)
+	let rootAlreadyBlocksDeploy = $derived(
+		isRuleActiveInRulesets(rootProtectionRules.current ?? [], 'DisableDirectDeployment')
+	)
+	let rootAlreadyBlocksForking = $derived(
+		isRuleActiveInRulesets(rootProtectionRules.current ?? [], 'DisableWorkspaceForking')
+	)
+	// Sent to the backend: an already-enforced restriction stays on regardless of the (locked) toggle's
+	// raw state, keeping the request consistent with what the locked toggle shows.
+	let effectiveLockProdDeploy = $derived(rootAlreadyBlocksDeploy || lockProdDeploy)
+	let effectiveLockProdForking = $derived(rootAlreadyBlocksForking || lockProdForking)
 
 	let id = $state('')
 	let name = $state('')
@@ -306,8 +328,8 @@
 					dev_workspace_label: createAsDevWorkspace ? devWorkspaceLabel : undefined,
 					// Send the lock intent in this first phase too so the backend can reject a non-admin's
 					// locked-dev request before any branch is created (avoids dangling branches).
-					lock_prod_deploy: createAsDevWorkspace && lockProdDeploy,
-					lock_prod_forking: createAsDevWorkspace && lockProdForking,
+					lock_prod_deploy: createAsDevWorkspace && effectiveLockProdDeploy,
+					lock_prod_forking: createAsDevWorkspace && effectiveLockProdForking,
 					copy_members: copyMembers
 				}
 			})
@@ -374,8 +396,8 @@
 					shared_ducklakes: forkDucklakeSection?.getSharedDucklakes() ?? [],
 					is_dev_workspace: createAsDevWorkspace,
 					dev_workspace_label: createAsDevWorkspace ? devWorkspaceLabel : undefined,
-					lock_prod_deploy: createAsDevWorkspace && lockProdDeploy,
-					lock_prod_forking: createAsDevWorkspace && lockProdForking,
+					lock_prod_deploy: createAsDevWorkspace && effectiveLockProdDeploy,
+					lock_prod_forking: createAsDevWorkspace && effectiveLockProdForking,
 					copy_members: copyMembers
 				}
 			})
@@ -769,11 +791,33 @@
 										dev workspace and promoted here.
 									</span>
 								</div>
-								<Toggle
-									bind:checked={lockProdDeploy}
-									options={{ right: 'Block direct edits (deploy via the dev workspace)' }}
-								/>
-								<Toggle bind:checked={lockProdForking} options={{ right: 'Prevent forking' }} />
+								{#if rootAlreadyBlocksDeploy}
+									<div class="flex flex-col gap-0.5">
+										<Toggle
+											checked
+											disabled
+											options={{ right: 'Block direct edits (deploy via the dev workspace)' }}
+										/>
+										<span class="text-2xs text-secondary ml-8"
+											>Already enforced by an existing protection rule</span
+										>
+									</div>
+								{:else}
+									<Toggle
+										bind:checked={lockProdDeploy}
+										options={{ right: 'Block direct edits (deploy via the dev workspace)' }}
+									/>
+								{/if}
+								{#if rootAlreadyBlocksForking}
+									<div class="flex flex-col gap-0.5">
+										<Toggle checked disabled options={{ right: 'Prevent forking' }} />
+										<span class="text-2xs text-secondary ml-8"
+											>Already enforced by an existing protection rule</span
+										>
+									</div>
+								{:else}
+									<Toggle bind:checked={lockProdForking} options={{ right: 'Prevent forking' }} />
+								{/if}
 							</div>
 						{/if}
 					</div>

--- a/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
+++ b/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
@@ -149,7 +149,8 @@
 
 	// If the root already blocks direct deploy / forking through an existing protection rule, keep the
 	// matching lock toggle on but locked: this flow only manages its own reserved dev-workspace rule, so
-	// turning it "off" here couldn't lift a separately-defined block. Fail-open (empty rules) on error.
+	// turning it "off" here couldn't lift a separately-defined block. On a failed fetch we fall back to the
+	// editable default-on toggle, which can't drop protection (any real rule still enforces server-side).
 	const rootProtectionRules = resource(
 		() => (canDesignateDevWorkspace && createAsDevWorkspace ? baseWorkspaceId : undefined),
 		async (ws) => (ws ? await fetchProtectionRulesForWorkspace(ws) : [])

--- a/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
+++ b/frontend/src/lib/components/workspaceSettings/CreateWorkspaceInner.svelte
@@ -23,7 +23,7 @@
 	import { useForkableWorkspaces } from '$lib/utils/useForkableWorkspaces.svelte'
 	import {
 		fetchProtectionRulesForWorkspace,
-		isRuleActiveInRulesets
+		isRuleUnconditionallyActiveInRulesets
 	} from '$lib/workspaceProtectionRules.svelte'
 	import { resource } from 'runed'
 	import { Badge, Button } from '$lib/components/common'
@@ -153,22 +153,35 @@
 	// editable default-on toggle, which can't drop protection (any real rule still enforces server-side).
 	const rootProtectionRules = resource(
 		() => (canDesignateDevWorkspace && createAsDevWorkspace ? baseWorkspaceId : undefined),
-		async (ws) => (ws ? await fetchProtectionRulesForWorkspace(ws) : [])
+		async (ws, _prev, { signal }) => {
+			if (!ws) return undefined
+			const rules = await fetchProtectionRulesForWorkspace(ws)
+			// The generated client can't take an abort signal, so drop a superseded response here: a late
+			// result for a previous base must not overwrite the newly selected base's rules.
+			if (signal.aborted) throw new DOMException('superseded', 'AbortError')
+			return { ws, rules }
+		}
 	)
+	// Only trust a result that belongs to the currently selected base (guards the in-flight window and
+	// any out-of-order response); undefined means "not known yet" and is treated as locked below.
+	let rootRules = $derived.by(() => {
+		const current = rootProtectionRules.current
+		return current && current.ws === baseWorkspaceId ? current.rules : undefined
+	})
+	// Only a rule with no bypass users/groups matches the empty-bypass reserved lock we would create; a
+	// bypassable rule stays editable, otherwise forcing the lock on would revoke the bypassed users'
+	// direct-deploy / forking access.
 	let rootAlreadyBlocksDeploy = $derived(
-		isRuleActiveInRulesets(rootProtectionRules.current ?? [], 'DisableDirectDeployment')
+		isRuleUnconditionallyActiveInRulesets(rootRules ?? [], 'DisableDirectDeployment')
 	)
 	let rootAlreadyBlocksForking = $derived(
-		isRuleActiveInRulesets(rootProtectionRules.current ?? [], 'DisableWorkspaceForking')
+		isRuleUnconditionallyActiveInRulesets(rootRules ?? [], 'DisableWorkspaceForking')
 	)
-	// Until the fetch resolves the root's rules are unknown (current === undefined also covers the first
-	// frame before loading flips). Treat each lock as engaged during that window so the toggle is locked
-	// on and the effective value stays true: otherwise a user could turn a lock off and submit before an
-	// existing rule is detected, sending false and omitting the reserved rule — leaving prod unprotected
-	// if that existing rule is later removed.
-	let rootRulesUnknown = $derived(
-		rootProtectionRules.loading || rootProtectionRules.current === undefined
-	)
+	// Until the fetch resolves for the selected base its rules are unknown. Treat each lock as engaged
+	// during that window so the toggle is locked on and the effective value stays true: otherwise a user
+	// could turn a lock off and submit before an existing rule is detected, sending false and omitting
+	// the reserved rule — leaving prod unprotected if that existing rule is later removed.
+	let rootRulesUnknown = $derived(rootProtectionRules.loading || rootRules === undefined)
 	let deployLocked = $derived(rootAlreadyBlocksDeploy || rootRulesUnknown)
 	let forkingLocked = $derived(rootAlreadyBlocksForking || rootRulesUnknown)
 	// Sent to the backend: a locked restriction (enforced or not-yet-known) stays on regardless of the

--- a/frontend/src/lib/workspaceProtectionRules.svelte.ts
+++ b/frontend/src/lib/workspaceProtectionRules.svelte.ts
@@ -183,6 +183,25 @@ export function isRuleActiveInRulesets(
 }
 
 /**
+ * Whether a rule kind is enforced unconditionally — active in a ruleset that has no bypass users or
+ * groups — in at least one ruleset. Only such a rule is equivalent to the empty-bypass reserved
+ * dev-workspace lock; a rule that lets some users bypass is NOT, since layering the unconditional lock
+ * on top would revoke those users' access. Used to decide when a lock toggle can be shown as already
+ * enforced (locked) rather than editable.
+ */
+export function isRuleUnconditionallyActiveInRulesets(
+	rulesets: ProtectionRuleset[],
+	ruleKind: ProtectionRuleKind
+): boolean {
+	return rulesets.some(
+		(ruleset) =>
+			ruleset.rules.includes(ruleKind) &&
+			ruleset.bypass_users.length === 0 &&
+			ruleset.bypass_groups.length === 0
+	)
+}
+
+/**
  * Checks if user can bypass a rule kind in given rulesets (workspace-agnostic version)
  * @param rulesets Array of protection rulesets to check
  * @param ruleKind The rule type to check

--- a/frontend/src/lib/workspaceProtectionRules.svelte.ts
+++ b/frontend/src/lib/workspaceProtectionRules.svelte.ts
@@ -183,11 +183,9 @@ export function isRuleActiveInRulesets(
 }
 
 /**
- * Whether a rule kind is enforced unconditionally — active in a ruleset that has no bypass users or
- * groups — in at least one ruleset. Only such a rule is equivalent to the empty-bypass reserved
- * dev-workspace lock; a rule that lets some users bypass is NOT, since layering the unconditional lock
- * on top would revoke those users' access. Used to decide when a lock toggle can be shown as already
- * enforced (locked) rather than editable.
+ * Whether a rule kind is enforced with no bypass users/groups in at least one ruleset, the only case
+ * that matches the empty-bypass reserved dev-workspace lock. A bypassable rule does not, since adding
+ * the unconditional lock would revoke those users' access; callers keep such a toggle editable.
  */
 export function isRuleUnconditionallyActiveInRulesets(
 	rulesets: ProtectionRuleset[],


### PR DESCRIPTION
## Summary

When creating or attaching a dev workspace, the two lock toggles ("Block direct edits" → `DisableDirectDeployment`, "Prevent forking" → `DisableWorkspaceForking`) apply protection rules to the root/prod workspace. Previously they were always presented from a blank slate: on by default and fully editable, regardless of what the root already enforced. That made the toggles easy to misread — flipping them silently mutated the root, and if the root was *already* locked by an existing rule, an editable "off" toggle implied it could unblock something it can't (this flow only manages its own reserved `dev_workspace_lock` rule).

This makes the toggles aware of the root's current protection state. A restriction that's already enforced by an existing rule is shown **on but locked**, with a note, instead of offering a fresh default.

## Changes

- Both flows now fetch the root's protection rules (`fetchProtectionRulesForWorkspace`, fail-open on error), gated to fire only while the relevant form is visible:
  - `CreateWorkspaceInner.svelte` — the "Create a new dev workspace" fork flow.
  - `DevWorkspaceSetting.svelte` — the "Attach an existing workspace as dev" flow in workspace settings.
- Each lock toggle renders two ways:
  - **Not already enforced** → on by default, fully interactive (unchanged).
  - **Already enforced by an existing rule** → shown on, locked (disabled/grayed), with the note *"Already enforced by an existing protection rule."*
- The value sent to the backend is a `$derived` effective value (`alreadyBlocks || userToggle`), so the request always matches what the locked toggle shows.
- Kept both toggles defaulting to on (only the presentation/awareness changed, not the default).

## Screenshots

Set up a root workspace with a manual `DisableDirectDeployment` rule and no forking rule, to show the mixed state (deploy locked, forking still interactive) in one screen.

**Fork flow — "Create a new dev workspace":**

![fork-dev-workspace-aware](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/dev-workspace-restrict-buttons/1784040043-fork-dev-workspace-aware.png)

**Attach flow — workspace settings → Dev workspace:**

![attach-dev-workspace-aware](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/dev-workspace-restrict-buttons/1784040043-attach-dev-workspace-aware.png)

## Test plan

- [ ] Root with an existing rule blocking direct deployment: both flows show "Block direct edits" on + locked with the note, and "Prevent forking" interactive + on by default.
- [ ] Root with no protection rules: both toggles interactive and on by default (unchanged).
- [ ] The locked toggle can't be turned off; the interactive one can.
- [ ] Fetch failure falls back to the editable default-on toggle (protection still enforced server-side by the real rule).
- [ ] Backend contract: attaching/creating with `lock_prod_*: true` when an equivalent user rule already exists does not error (reserved rule is upserted by name), and detach removes only the reserved rule, leaving the pre-existing rule intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dev workspace lock toggles now mirror the root workspace’s protection rules and honor bypasses. If a restriction is enforced—or rules are still loading—the toggle shows on and disabled, and requests use the effective value.

- **New Features**
  - Fetch root protection rules while the form is visible via `fetchProtectionRulesForWorkspace`; on failure, fall back to editable default-on toggles (real rules still enforce).
  - Show toggles locked (on + disabled) with a note when an existing rule unconditionally enforces `DisableDirectDeployment` or `DisableWorkspaceForking` (no bypass users/groups); send derived values so the backend matches the UI in both create and attach flows.

- **Bug Fixes**
  - Lock toggles during the rules-loading window to prevent submitting false before rules resolve.
  - Guard stale fetches when switching the base/selected workspace by tagging results and ignoring superseded responses.
  - Align the “Already enforced...” note under the toggle label for clearer UI.

<sup>Written for commit 90b277d71fdab56959cf72c7a6ff82cb9f25c984. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

