### PR TITLE
ci: bypass Codex sandbox in PR review to fix bwrap netns failure

### DIFF
--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -306,14 +306,11 @@ jobs:
           if [ "$PR_IS_FORK" = "true" ]; then
             # Fork code is untrusted. Read the review policy/prompt from the base
             # ref (git show) rather than the attacker-controlled merge checkout,
-            # so a malicious fork can't rewrite the reviewer's own instructions,
-            # and run in a network-disabled sandbox to block secret exfiltration.
+            # so a malicious fork can't rewrite the reviewer's own instructions.
             git show "origin/$PR_BASE_REF:REVIEW.md" > /tmp/codex-prompt.md
             git show "origin/$PR_BASE_REF:.github/codex/pr-review.prompt.md" >> /tmp/codex-prompt.md
-            SANDBOX_MODE=workspace-write
           else
             cat REVIEW.md .github/codex/pr-review.prompt.md > /tmp/codex-prompt.md
-            SANDBOX_MODE=danger-full-access
           fi
           # The context file lives in RUNNER_TEMP (outside the attacker-controlled
           # checkout); tell the agent its absolute path.
@@ -321,11 +318,17 @@ jobs:
           # Write the final message outside the checkout too: a fork could commit
           # codex-final-message.md as a symlink and redirect this write to overwrite
           # e.g. a GitHub Action's index.js, which then runs with our credentials.
+          #
+          # Bypass the sandbox entirely instead of selecting a sandbox mode: Codex's
+          # bwrap sandbox fails to initialize its network namespace on this runner
+          # (`bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`) and aborts
+          # before reading any file, so no review is possible with it enabled. The
+          # runner is already an ephemeral, externally sandboxed CI environment.
           codex exec \
             -C "$GITHUB_WORKSPACE" \
             -m gpt-5.6-sol \
             -c 'model_reasoning_effort="xhigh"' \
-            -s "$SANDBOX_MODE" \
+            --dangerously-bypass-approvals-and-sandbox \
             -o "$RUNNER_TEMP/codex-final-message.md" \
             - < /tmp/codex-prompt.md
 


### PR DESCRIPTION
## Problem

`/codex` on **fork PRs** posts *"Unable to complete the review"* instead of a verdict. Reproduced deterministically on #10064 (two runs, identical failure):

> `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`

Codex's Bubblewrap sandbox fails to bring up its network-namespace loopback on the `ubicloud-standard-2` runner and aborts **before reading any file**, so the model never sees the diff.

## Why the sandbox mode flag isn't enough

Both failing runs already ran under #10069's code, which sets `SANDBOX_MODE=workspace-write` (network-disabled) for forks. That sandbox hits the same bwrap netns failure, so fork Codex reviews are broken today regardless of mode. Widening or narrowing the sandbox doesn't help: bwrap still initializes the network namespace and fails. Non-fork auto-runs on the same pool succeed (23/23 in the same window), so it's specific to the sandboxed command path, not a flaky host.

## Fix

Replace `-s "$SANDBOX_MODE"` with `--dangerously-bypass-approvals-and-sandbox`, which skips sandbox setup entirely (no bwrap, no netns, nothing to fail). Per Codex's own help this flag is *"intended solely for running in environments that are externally sandboxed"*, which an ephemeral CI runner is.

## Security tradeoff (please review)

#10069 introduced the network-disabled sandbox specifically to stop untrusted fork code from exfiltrating the on-disk Codex auth token while it reviews. This PR removes that containment on the fork path in exchange for a working fork-review path. The tradeoff is bounded by:

- `/codex` on a fork only runs when a **maintainer** (write access) triggers it.
- The runner is ephemeral and short-lived; the Codex auth is the main secret present during the exec.

All of #10069's other fork hardening is **preserved**: review policy read from the base ref (a fork can't rewrite the reviewer's own instructions), `persist-credentials: false` on checkout, and the final message written outside the checkout.

If keeping the network isolation is preferred, the alternative is to fix the bwrap netns failure at the runner level (e.g. codex network config or an egress allowlist) rather than bypassing the sandbox; that's more work and out of scope here.

## Verification

Failing runs (both under #10069's sandboxed code):
- https://github.com/windmill-labs/windmill/actions/runs/29333365567
- https://github.com/windmill-labs/windmill/actions/runs/29345538352

After merge, a `/codex` on any fork PR (e.g. #10064) should post a real review. CI-only change; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)