### PR TITLE
security(docker): apt-get upgrade base OS packages in slim runtime images

### DIFF
--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -39,6 +39,7 @@ ENV PATH=/usr/local/bin:/root/.local/bin:/tmp/.local/bin:$PATH
 
 # Install system dependencies
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends ca-certificates wget curl git jq unzip unixodbc xmlsec1 gnupg lsb-release libgnutls30t64 libgcrypt20 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -39,6 +39,7 @@ ENV PATH=/usr/local/bin:/root/.local/bin:/tmp/.local/bin:$PATH
 
 # Install system dependencies
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends ca-certificates wget curl git jq unzip unixodbc xmlsec1 gnupg lsb-release libgnutls30t64 libgcrypt20 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

The Docker runtime images run `apt-get update && apt-get install` but never `apt-get upgrade`. As a result the base-OS packages stay frozen at whatever versions the base image shipped with and never receive Debian security point-release fixes, so self-hosters steadily accumulate unpatched base-OS CVEs even on fresh builds.

This PR adds `apt-get upgrade -y` to the first apt block of the two base runtime stages (`DockerfileSlim` and `DockerfileSlimEe`, the `FROM ${DEBIAN_IMAGE}` stages). `DockerfileFull`, `DockerfileFullEe`, and `DockerfileExtra` build `FROM` the resulting `windmill`/`windmill-ee-slim` images, so they inherit the patched base automatically — no change needed there. `DockerfileMultiplayer` (`node:slim`) has no apt block. RHEL/dnf images and `DockerfileCli`/`DockerfileCuda`/`DockerfileCaddyL4` were left untouched.

## Evidence

Findings are from a Microsoft Defender for Cloud image scan of `windmill-ee-slim:1.714.1` (Debian bookworm). ~493 base-OS findings, all with fixes available in newer Debian point releases. The base was bookworm on that tag; `main` has since moved to `debian:trixie-slim`, but the "no `apt upgrade` → stale base packages" pattern is identical regardless of the Debian release. Representative examples:

| Package | Installed → Fixed | CVEs |
|---|---|---|
| linux / linux-libc-dev | 6.1.174-1 → 6.1.176-1 | 496 CVEs (242 High) — e.g. CVE-2024-53221, CVE-2024-27012 |
| protobuf (libprotobuf) | 3.21.12-3 → 3.21.12-3+deb12u1 | 4 High — CVE-2024-7254, CVE-2025-4565, CVE-2026-0994, CVE-2026-6409 |
| jq | 1.6-2.1+deb12u1 → +deb12u2 | 15 CVEs (3 High) — CVE-2026-39956, CVE-2026-40164, CVE-2026-41256 |
| openssl | 3.0.20-1~deb12u1 → +deb12u2 | 9 CVEs (1 High) — CVE-2026-7383, CVE-2026-34180, CVE-2026-45445 |
| libxml2 | 2.9.14+dfsg-1.3~deb12u5 → u6 | CVE-2026-0989/0990/0992/1757 |
| curl | 7.88.1-10+deb12u14 → u15 | CVE-2025-10148, CVE-2026-7168 |

A single `apt-get upgrade` picks up all of these at build time. Existing `apt-get clean && rm -rf /var/lib/apt/lists/*` cleanup is preserved.

## Reproducibility tradeoff

A blanket `apt-get upgrade` trades byte-for-byte reproducibility (builds now depend on the current state of the Debian mirror) for current security patches. If you prefer pinned reproducibility, an alternative is to upgrade only the specific affected packages, e.g.:

```
apt-get -y --only-upgrade install libprotobuf32t64 jq openssl libxml2 curl ...
```

Happy to switch to whichever approach you prefer.

## Out of scope (for your awareness, not changed here)

Separate from the base OS, the scan also flagged a couple of bundled app deps with fixes available: npm `form-data 4.0.5 → 4.0.6` (CVE-2026-12143) and `pip 25.3 → 26.x`. This PR is intentionally scoped to the Dockerfile base-OS fix only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `apt-get upgrade -y` during build for the slim runtime Docker images to apply Debian security updates. This keeps base OS packages current and reduces unpatched CVEs for self-hosted installs.

- **Bug Fixes**
  - Added `apt-get upgrade -y` to the first apt block in `docker/DockerfileSlim` and `docker/DockerfileSlimEe`.
  - `DockerfileFull`, `DockerfileFullEe`, and `DockerfileExtra` inherit the updated base; no changes needed.

<sup>Written for commit 88afb102dad4acfbaf0f8215614ea99897793b94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

