### PR TITLE
fix(mcp): align script auto_kind filter with scripts list API

### DIFF
--- a/backend/windmill-api/src/mcp/utils.rs
+++ b/backend/windmill-api/src/mcp/utils.rs
@@ -149,7 +149,10 @@ pub async fn get_items<T: for<'a> sqlx::FromRow<'a, sqlx::postgres::PgRow> + Sen
         .and_where("o.archived = false");
 
     if item_type == "script" {
-        sqlb.and_where("o.auto_kind IS NULL");
+        // only exclude library scripts (no main function); pipeline, test, WAC,
+        // and any future `auto_kind` values remain callable. Mirrors the scripts
+        // list API deny-list.
+        sqlb.and_where("(o.auto_kind IS NULL OR o.auto_kind <> 'lib')");
     }
 
     if let Some(prefix) = path_prefix {


### PR DESCRIPTION
## Problem

The MCP `get_items` function (`backend/windmill-api/src/mcp/utils.rs`) filtered scripts with `o.auto_kind IS NULL`, which excluded **every** script that has any `auto_kind` value (`pipeline`, `test`, `wac`, ...). Those are valid runnable scripts and should surface as MCP tools.

The scripts list API (`backend/windmill-api-scripts/src/scripts.rs:262`) already uses the correct deny-list `(o.auto_kind IS NULL OR o.auto_kind <> 'lib')` — fixed in #8951 — but the MCP filter was never updated to match.

## Fix

```diff
 if item_type == "script" {
-    sqlb.and_where("o.auto_kind IS NULL");
+    sqlb.and_where("(o.auto_kind IS NULL OR o.auto_kind <> 'lib')");
 }
```

Only library scripts (no main function) are excluded; `pipeline`, `test`, `wac`, and any future `auto_kind` values are included — mirroring the scripts list API.

## Validation

- **Compiles**: `cargo check -p windmill-api --features mcp` — clean (the `mcp` module is gated behind the `mcp` feature, not part of the default dev build).
- **No sqlx cache change**: the predicate is a runtime SQL string built via `SqlBuilder` (`sqlx::query_as::<_, T>(&sql)`), not a compile-checked macro, so no offline query cache update is needed.
- **SQL semantics verified against the DB** with a synthetic `VALUES` set covering each `auto_kind`:

  | path | auto_kind | old (`IS NULL`) | new (`IS NULL OR <> 'lib'`) |
  |---|---|---|---|
  | regular_script | (null) | ✅ included | ✅ included |
  | lib_script | lib | ❌ excluded | ❌ excluded |
  | pipeline_script | pipeline | ❌ excluded | ✅ **included** |
  | test_script | test | ❌ excluded | ✅ **included** |
  | wac_script | wac | ❌ excluded | ✅ **included** |

  `lib` stays excluded (no runnable entrypoint); everything else becomes callable — exactly the intended behavior.

Fixes WIN-2190

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the MCP `get_items` script filter with the scripts list API so all runnable non-`lib` scripts (e.g., `pipeline`, `test`, `wac`) appear as MCP tools. Fixes WIN-2190 by switching to the deny-list `(o.auto_kind IS NULL OR o.auto_kind <> 'lib')`, excluding only `lib` scripts.

<sup>Written for commit 784fdfe128b9f77a2875b344eb3339f8515834b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

