### PR TITLE
fix(frontend): stop spurious raw-app reload that 404s on "Start without AI"

### DIFF
--- a/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	import { run } from 'svelte/legacy'
-	import { onDestroy } from 'svelte'
+	import { onDestroy, untrack } from 'svelte'
 	import { stripNewDraftFlag, stripNewDraftFlagOnSave, shouldSeedNewDraft } from '$lib/newDraftFlag'
 
 	import { AppService } from '$lib/gen'
@@ -419,16 +418,23 @@
 		}
 	}
 
-	run(() => {
+	$effect(() => {
 		// Re-run on workspace OR path change so navigating from one raw app editor
 		// to another (e.g. via the workspace picker) reloads the new app.
 		const currentPath = page.params.path
 		if ($workspaceStore && currentPath !== undefined) {
-			// Clear files so RawAppEditor unmounts; it will remount when loadApp
-			// completes with fresh data, re-initializing its internal stores.
-			files = undefined
-			path = currentPath
-			loadApp()
+			untrack(() => {
+				// Clear files so RawAppEditor unmounts; it will remount when loadApp
+				// completes with fresh data, re-initializing its internal stores.
+				// untrack so loadApp's own reactive reads (e.g. the draft-hint
+				// SvelteMap via shouldSeedNewDraft) don't subscribe this effect —
+				// otherwise the first autosave's optimistic hint flip re-fires
+				// loadApp mid-bootstrap, taking the backend-fetch branch before the
+				// draft POST lands → 404 "App not found". See /apps/edit.
+				files = undefined
+				path = currentPath
+				loadApp()
+			})
 		}
 	})
 

--- a/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
@@ -423,14 +423,13 @@
 		// to another (e.g. via the workspace picker) reloads the new app.
 		const currentPath = page.params.path
 		if ($workspaceStore && currentPath !== undefined) {
+			// untrack so loadApp's reactive reads (the draft-hint SvelteMap via
+			// shouldSeedNewDraft) don't subscribe this effect — else the first
+			// autosave's optimistic hint flip re-fires loadApp mid-bootstrap and
+			// 404s on the not-yet-POSTed draft. Depend only on path/workspace above.
 			untrack(() => {
-				// Clear files so RawAppEditor unmounts; it will remount when loadApp
+				// Clear files so RawAppEditor unmounts; it remounts when loadApp
 				// completes with fresh data, re-initializing its internal stores.
-				// untrack so loadApp's own reactive reads (e.g. the draft-hint
-				// SvelteMap via shouldSeedNewDraft) don't subscribe this effect —
-				// otherwise the first autosave's optimistic hint flip re-fires
-				// loadApp mid-bootstrap, taking the backend-fetch branch before the
-				// draft POST lands → 404 "App not found". See /apps/edit.
 				files = undefined
 				path = currentPath
 				loadApp()


### PR DESCRIPTION
## Summary

Creating a new raw app (`/apps_raw/add`) and clicking **Start without AI** surfaced an `App not found` toast. The editor's load effect re-ran `loadApp()` mid-bootstrap and fetched the draft via `getAppByPath(getDraft:true)` **before** the first autosave POST had landed, so the backend 404'd on a draft it hadn't received yet.

**Root cause — a two-ingredient regression:**
- The `apps_raw/edit` route's load effect used the legacy `run()` from `svelte/legacy` **without `untrack`** (unlike its siblings `apps/edit` and `flows/edit`, which were migrated to `$effect` + `untrack` long ago). So `loadApp()`'s synchronous reactive reads leaked into the effect's dependency set.
- #10044 (4 days ago) changed the new-draft seed gate from `page.url.searchParams.get('new_draft') === 'true'` (pure `$app/state`) to `shouldSeedNewDraft(...)`, which reads `getLocalDraftHint` — a reactive **`SvelteMap`** introduced by the DB-drafts refactor (#9351). That pulled a hint read into `loadApp`'s synchronous prefix.
- The first autosave **optimistically flips that hint** (`setLocalDraftHint(..., true)`) *before* its debounced POST. Inside the un-`untrack`ed effect, that flip re-fired the effect → spurious `loadApp()` → `getAppByPath` on a not-yet-persisted draft → **404**.

Neither ingredient alone triggered it, which is why it only started ~4 days ago and only on raw apps.

## Changes
- `frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte`: convert the legacy `run(() => { … loadApp() })` block to `$effect(() => { … untrack(() => { … loadApp() }) })`, matching the sibling `apps/edit` / `flows/edit` routes. The effect now depends only on `page.params.path` / `$workspaceStore`; `loadApp`'s internal reactive reads (the draft-hint `SvelteMap`) no longer subscribe it.
- Swap `import { run } from 'svelte/legacy'` for `import { untrack } from 'svelte'`.

Autosave and draft persistence are unchanged — only the phantom reload is removed. Persisting on the first interaction (the intended new-draft behavior) still happens.

## Screenshots

After the fix — clicking "Start without AI" loads the editor cleanly, the draft autosaves (POST 200), and no "App not found" toast appears:

![start-without-ai loads cleanly, no App-not-found toast](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/raw-app-create-notfound/1784046291-start-without-ai.png)

## Test plan
- [ ] Create a new raw app via `/apps_raw/add`, pick a framework, click **Start without AI** → editor loads, no "App not found" toast; verify a single `POST /drafts/update/raw_app/...` (200) and **no** `GET /apps/get/...` 404 in the network tab.
- [ ] Non-regression: navigate between two different raw-app editors via the workspace/app picker → the editor still reloads the newly selected app (the tracked `page.params.path` / `$workspaceStore` path still drives reloads).
- [ ] Refresh the new-draft URL before any edit → still re-seeds the empty template (doesn't 404), preserving #10044's fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)