### PR TITLE
fix(raw-apps): don't save a draft (or reload the editor) on template pick

### DIFF
--- a/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
@@ -93,9 +93,12 @@
 	// fallback keeps the suspension from leaking if the user walks away.
 	$effect(() => {
 		if (templatePicker || !autosaveSuspendedForPicker) return
+		// Bail WITHOUT disarming while the workspace is still resolving: clearing the
+		// flag here would strand the bootstrap `stopSync` unpaired, silently killing
+		// autosave for the session. Tracked, so a late workspace re-runs this.
+		if (!$workspaceStore) return
 		autosaveSuspendedForPicker = false
-		const workspace = untrack(() => $workspaceStore)
-		if (workspace) armRestartOnFirstInteraction(workspace, 'raw_app', path)
+		armRestartOnFirstInteraction($workspaceStore, 'raw_app', path)
 	})
 
 	/** Deployed raw-app bundle this load, the baseline the autosave `discardIf`
@@ -171,7 +174,14 @@
 	let loadAppToken = 0
 	/** Drops the previous load's `new_draft` strip-on-save listener. */
 	let cleanupNewDraftFlag: (() => void) | undefined
-	onDestroy(() => cleanupNewDraftFlag?.())
+	onDestroy(() => {
+		cleanupNewDraftFlag?.()
+		// Leaving with the picker still open: pair the bootstrap `stopSync`, or the
+		// suspension outlives the page (it's keyed in a module-level map).
+		if (autosaveSuspendedForPicker && $workspaceStore) {
+			UserDraft.restartSync('raw_app', path, { workspace: $workspaceStore })
+		}
+	})
 	/** No deployed row at the URL path; flips RawAppEditor's deploy from
 	 * `updateApp` to `createApp`. See /apps/edit's `isNewApp`. */
 	let isNewApp = $state(false)
@@ -519,6 +529,11 @@
 			schema: result.data.schema
 		}
 		if (withPrompt && result.prompt) {
+			// This path owns the resume (below), so keep the picker-resolve effect from
+			// also arming an interaction listener: a click landing inside the timeout
+			// would resume sync while the template writes are still flushing, and POST
+			// the bare template.
+			autosaveSuspendedForPicker = false
 			setTimeout(() => {
 				// The template writes above have flushed under the suspension by now, so
 				// resuming here syncs the files the AI is about to generate but not the

--- a/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	import { run } from 'svelte/legacy'
-	import { onDestroy } from 'svelte'
+	import { onDestroy, untrack } from 'svelte'
 	import { stripNewDraftFlag, stripNewDraftFlagOnSave, shouldSeedNewDraft } from '$lib/newDraftFlag'
 
 	import { AppService } from '$lib/gen'
@@ -82,6 +81,22 @@
 	/** Opens the framework picker on a brand-new draft (`new_draft=true`):
 	 * React/Svelte + data config + optional AI prompt before the editor goes live. */
 	let templatePicker = $state(false)
+	/** The new-draft bootstrap suspended autosave and nothing has re-armed it yet.
+	 * `$state` so the effect below re-runs once the bootstrap sets it. */
+	let autosaveSuspendedForPicker = $state(false)
+
+	// Re-arm autosave once the picker is resolved — started, dismissed, or never
+	// opened (the import path). Deferred to the next interaction rather than
+	// resumed outright, because the `onStart` template writes are still flushing:
+	// picking a framework is setup, not an edit, so an app left untouched after
+	// the pick must leave no draft behind. `armRestartOnFirstInteraction`'s
+	// fallback keeps the suspension from leaking if the user walks away.
+	$effect(() => {
+		if (templatePicker || !autosaveSuspendedForPicker) return
+		autosaveSuspendedForPicker = false
+		const workspace = untrack(() => $workspaceStore)
+		if (workspace) armRestartOnFirstInteraction(workspace, 'raw_app', path)
+	})
 
 	/** Deployed raw-app bundle this load, the baseline the autosave `discardIf`
 	 * compares against. `undefined` for draft-only paths so they never
@@ -193,11 +208,12 @@
 			deployedBaseline = undefined
 			// Suspend autosave across the bootstrap: the seed template and the
 			// picker's `onStart` are programmatic writes that must not POST as the
-			// first edit. Resume on first interaction (the template-card click or
-			// picker X) so the choice persists but earlier mutations don't.
+			// first edit. The suspension spans the whole picker and is re-armed when
+			// it resolves (see `autosaveSuspendedForPicker`), so the draft is born
+			// from the first real change — a keystroke, or the AI's generated files.
 			if ($workspaceStore) {
 				UserDraft.stopSync('raw_app', path, { workspace: $workspaceStore })
-				armRestartOnFirstInteraction($workspaceStore, 'raw_app', path)
+				autosaveSuspendedForPicker = true
 				// Keep `?new_draft=true` until the backend confirms the first autosave,
 				// so a refresh before any edit re-seeds here instead of 404-ing on the
 				// never-persisted `draft_{uuid}` path.
@@ -419,16 +435,25 @@
 		}
 	}
 
-	run(() => {
-		// Re-run on workspace OR path change so navigating from one raw app editor
-		// to another (e.g. via the workspace picker) reloads the new app.
+	$effect(() => {
+		// Re-run on workspace, path, or `?new_draft` change — and on NOTHING else.
+		// `loadApp` reads reactive state of its own (the local draft hint behind
+		// `shouldSeedNewDraft`, which the first autosave flips), and tracking its
+		// body reloaded the editor from the backend the moment a draft was born.
+		// See /apps/edit, /scripts/edit, /flows/edit, which all untrack the same way.
 		const currentPath = page.params.path
+		// A client-side nav can restore a stale `?new_draft` (exiting an AI session
+		// replays the route captured before the first save); re-run so the loader
+		// falls through and drops the flag instead of re-seeding over the draft.
+		void page.url.searchParams.get('new_draft')
 		if ($workspaceStore && currentPath !== undefined) {
-			// Clear files so RawAppEditor unmounts; it will remount when loadApp
-			// completes with fresh data, re-initializing its internal stores.
-			files = undefined
-			path = currentPath
-			loadApp()
+			untrack(() => {
+				// Clear files so RawAppEditor unmounts; it will remount when loadApp
+				// completes with fresh data, re-initializing its internal stores.
+				files = undefined
+				path = currentPath
+				loadApp()
+			})
 		}
 	})
 
@@ -495,6 +520,13 @@
 		}
 		if (withPrompt && result.prompt) {
 			setTimeout(() => {
+				// The template writes above have flushed under the suspension by now, so
+				// resuming here syncs the files the AI is about to generate but not the
+				// bare template. Can't wait for an interaction like the no-AI path does:
+				// a generation the user only watches would never reach the draft.
+				if ($workspaceStore) {
+					UserDraft.restartSync('raw_app', path, { workspace: $workspaceStore })
+				}
 				aiChatManager.changeMode(AIMode.APP)
 				if (!aiChatManager.open) aiChatManager.toggleOpen()
 				aiChatManager.instructions = result.prompt!


### PR DESCRIPTION
## Summary

Creating a new raw app opens the framework picker; clicking **Start with AI** / **Start without AI** immediately saved a draft *and* visibly reloaded the editor (blank pane, or the picker re-opening). Neither should happen — a brand-new app should only become a draft on the first meaningful change.

Two independent causes:

**1. The pick itself was autosaved.** The new-draft bootstrap suspends autosave and re-arms it on the next user interaction (`armRestartOnFirstInteraction`). But the `pointerdown` on the picker's own Start button *is* that interaction, and it fires in the capture phase before the click handler — so autosave was live by the time `onStart` wrote the template, and the bare template POSTed as the user's first edit.

**2. The first autosave reloaded the editor.** Since #10044, `shouldSeedNewDraft()` reads `getLocalDraftHint()` — a reactive `SvelteMap`. `/apps_raw/edit` was the only editor calling its loader inside a *tracked* `run()` block (`/scripts`, `/flows`, `/apps` all wrap theirs in `untrack`), so that hint became a dependency of the reload effect. `UserDraftDbSyncer.save` sets the hint optimistically, before the debounced POST — so the moment a draft was born the loader re-ran, fell through to `getAppByPath` for a draft the backend didn't have yet, and blanked the editor.

## Changes

`frontend/src/routes/(root)/(logged)/apps_raw/edit/[...path]/+page.svelte`:

- Loader effect: `run()` → `$effect` + `untrack`, matching the other three editors. It now re-runs on workspace, path, and `?new_draft` changes only — never on reactive state read *inside* `loadApp`. (`?new_draft` stays tracked so #10044's stale-flag fall-through still works; the flag-strip is a raw `history.replaceState`, which SvelteKit doesn't surface as a navigation, so it doesn't re-trigger the loader.)
- Autosave stays suspended for the whole picker, and is re-armed when the picker resolves — started, dismissed, or never opened (the YAML/JSON import path). The template writes flush under the suspension, so a picked-but-untouched app leaves no draft behind.
- On the **Start with AI** path, autosave resumes just before the AI request is sent, so the files the AI generates reach the draft even if the user never touches anything (the interaction gate would otherwise never open for a generation the user only watches).

## Screenshots

The picker on a new raw app:

![picker](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/defer-draft-save-app-create/1784047576-picker.png)

**Before** — right after clicking "Start without AI": a draft was POSTed and the editor reloaded into a blank pane (in other runs the picker re-opened instead):

![before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/defer-draft-save-app-create/1784047579-before-after-start.png)

**After** — same click: the editor comes up on the picked template, no reload, no draft:

![after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/defer-draft-save-app-create/1784047581-after-after-start.png)

**After** — first real edit (typing a summary): exactly one draft POST, `?new_draft` dropped from the URL, no reload:

![after-first-edit](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/defer-draft-save-app-create/1784047583-after-first-edit.png)

## Verification

Driven end-to-end in a real browser against a local backend, watching `POST /drafts/update/raw_app/...` and `GET /apps/get/...`, and checking the `draft` table after each step.

| | on "Start without AI" | on the first real edit |
|---|---|---|
| main | 1 draft POST, editor reloaded | — |
| this PR | 0 draft POSTs, no reload | 1 draft POST, no reload |

Same result when the picker is dismissed with the X instead of started: no draft, and the next edit still autosaves (i.e. the suspension doesn't leak).

`npm run check` is clean (0 errors).

## Test plan

- [ ] New raw app → "Start without AI" → editor loads on the chosen framework, no reload, and the app does **not** appear as a draft in the apps list.
- [ ] Then edit anything (summary, a file) → a draft is created and `?new_draft` disappears from the URL.
- [ ] New raw app → dismiss the picker with X → no draft; a later edit still autosaves.
- [ ] New raw app → "Start with AI" with a prompt → the generated files land in the draft without any manual interaction.
- [ ] Import a raw app from YAML/JSON → the imported content is the starting state, no draft until the first edit.
- [ ] An existing raw app still autosaves on edit and still reloads when switching workspace/app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)