### PR TITLE
fix(frontend): keep session-exit URL clean by syncing new_draft strip with the router

### DIFF
--- a/frontend/src/lib/newDraftFlag.test.ts
+++ b/frontend/src/lib/newDraftFlag.test.ts
@@ -17,6 +17,18 @@ vi.mock('./localDraftHints.svelte', () => ({
 	setLocalDraftHint: vi.fn(),
 	getLocalDraftHint: () => hints.value
 }))
+// `stripNewDraftFlag` now rewrites the URL through SvelteKit's router and
+// refreshes the session-switch's remembered nav route. Mock those so the strip
+// is observable via `window.location.href` (mirroring jsdom) and we can assert
+// the remembered route is kept in sync.
+const rememberNavRoute = vi.hoisted(() => vi.fn())
+vi.mock('$app/navigation', () => ({
+	replaceState: (url: URL | string, _state: unknown) => {
+		window.location.href = new URL(url, window.location.href).toString()
+	}
+}))
+vi.mock('$app/state', () => ({ page: { state: {} } }))
+vi.mock('$lib/components/sessions/sessionSwitch.svelte', () => ({ rememberNavRoute }))
 
 import { UserDraftDbSyncer } from './userDraftDbSyncer.svelte'
 import { stripNewDraftFlagOnSave, shouldSeedNewDraft } from './newDraftFlag'
@@ -108,6 +120,9 @@ describe('stripNewDraftFlagOnSave', () => {
 		expect(window.location.href).not.toContain('new_draft')
 		// Sibling seeding params are preserved.
 		expect(window.location.href).toContain('template=foo')
+		// The remembered nav route is refreshed to the stripped URL so exiting an
+		// AI session returns here without re-adding ?new_draft.
+		expect(rememberNavRoute).toHaveBeenCalledWith('/scripts/edit/u/me/draft_d?template=foo')
 	})
 
 	it('does not strip on a delete save', async () => {

--- a/frontend/src/lib/newDraftFlag.test.ts
+++ b/frontend/src/lib/newDraftFlag.test.ts
@@ -17,10 +17,10 @@ vi.mock('./localDraftHints.svelte', () => ({
 	setLocalDraftHint: vi.fn(),
 	getLocalDraftHint: () => hints.value
 }))
-// `stripNewDraftFlag` now rewrites the URL through SvelteKit's router and
-// refreshes the session-switch's remembered nav route. Mock those so the strip
-// is observable via `window.location.href` (mirroring jsdom) and we can assert
-// the remembered route is kept in sync.
+// `stripNewDraftFlag` rewrites the URL through SvelteKit's router and
+// refreshes the session-switch's remembered nav route. Mock both so the strip
+// is observable via `window.location.href` (mirroring jsdom) and the
+// remembered-route refresh can be asserted.
 const rememberNavRoute = vi.hoisted(() => vi.fn())
 vi.mock('$app/navigation', () => ({
 	replaceState: (url: URL | string, _state: unknown) => {

--- a/frontend/src/lib/newDraftFlag.test.ts
+++ b/frontend/src/lib/newDraftFlag.test.ts
@@ -17,10 +17,10 @@ vi.mock('./localDraftHints.svelte', () => ({
 	setLocalDraftHint: vi.fn(),
 	getLocalDraftHint: () => hints.value
 }))
-// `stripNewDraftFlag` rewrites the URL through SvelteKit's router and
-// refreshes the session-switch's remembered nav route. Mock both so the strip
-// is observable via `window.location.href` (mirroring jsdom) and the
-// remembered-route refresh can be asserted.
+// `stripNewDraftFlag` rewrites the URL through SvelteKit's `replaceState` and
+// refreshes the session-switch's remembered nav route. Mock those so the strip
+// is observable via `window.location.href` (mirroring jsdom) and the remembered
+// route can be asserted.
 const rememberNavRoute = vi.hoisted(() => vi.fn())
 vi.mock('$app/navigation', () => ({
 	replaceState: (url: URL | string, _state: unknown) => {

--- a/frontend/src/lib/newDraftFlag.ts
+++ b/frontend/src/lib/newDraftFlag.ts
@@ -1,16 +1,26 @@
+import { page } from '$app/state'
+import { replaceState } from '$app/navigation'
+import { rememberNavRoute } from '$lib/components/sessions/sessionSwitch.svelte'
 import { UserDraftDbSyncer, type UserDraftLastSyncQuery } from '$lib/userDraftDbSyncer.svelte'
 import { getLocalDraftHint } from '$lib/localDraftHints.svelte'
 import type { UserDraftItemKind } from '$lib/gen'
 
 /** Drop `?new_draft=true` from the current URL (preserving every other param),
  * mutating the address bar without a navigation. No-op when the flag is absent
- * or `window` is unavailable (SSR). */
+ * or `window` is unavailable (SSR).
+ *
+ * Uses SvelteKit's `replaceState` (not raw `history.replaceState`, which the
+ * router warns conflicts with it) so `page.url` stays in sync. Also refreshes
+ * the remembered nav route: `afterNavigate` never observes this in-place
+ * rewrite, so without it `exitSessionMode` would restore the pre-strip URL —
+ * still carrying `?new_draft=true` — and re-enter the seed-empty branch. */
 export function stripNewDraftFlag(): void {
 	if (typeof window === 'undefined') return
 	const url = new URL(window.location.href)
 	if (url.searchParams.get('new_draft') !== 'true') return
 	url.searchParams.delete('new_draft')
-	window.history.replaceState(window.history.state, '', url.toString())
+	replaceState(url, page.state)
+	rememberNavRoute(url.pathname + url.search)
 }
 
 /**

--- a/frontend/src/lib/newDraftFlag.ts
+++ b/frontend/src/lib/newDraftFlag.ts
@@ -10,10 +10,11 @@ import type { UserDraftItemKind } from '$lib/gen'
  * or `window` is unavailable (SSR).
  *
  * Uses SvelteKit's `replaceState` (not raw `history.replaceState`, which the
- * router warns conflicts with it) so `page.url` stays in sync. Also refreshes
- * the remembered nav route: `afterNavigate` never observes this in-place
- * rewrite, so without it `exitSessionMode` would restore the pre-strip URL —
- * still carrying `?new_draft=true` — and re-enter the seed-empty branch. */
+ * router warns against) to keep the router's history bookkeeping intact.
+ * `afterNavigate` never observes this in-place rewrite, so the remembered
+ * nav route is refreshed explicitly: without it, `exitSessionMode` would
+ * restore the pre-strip URL — still carrying `?new_draft=true` — and
+ * re-enter the seed-empty branch. */
 export function stripNewDraftFlag(): void {
 	if (typeof window === 'undefined') return
 	const url = new URL(window.location.href)

--- a/frontend/src/lib/newDraftFlag.ts
+++ b/frontend/src/lib/newDraftFlag.ts
@@ -10,11 +10,11 @@ import type { UserDraftItemKind } from '$lib/gen'
  * or `window` is unavailable (SSR).
  *
  * Uses SvelteKit's `replaceState` (not raw `history.replaceState`, which the
- * router warns against) to keep the router's history bookkeeping intact.
- * `afterNavigate` never observes this in-place rewrite, so the remembered
- * nav route is refreshed explicitly: without it, `exitSessionMode` would
- * restore the pre-strip URL — still carrying `?new_draft=true` — and
- * re-enter the seed-empty branch. */
+ * router warns conflicts with it) so the history entry keeps the router's
+ * bookkeeping and `page.state`. Also refreshes the remembered nav route:
+ * `afterNavigate` never observes this in-place rewrite, so without it
+ * `exitSessionMode` would restore the pre-strip URL — still carrying
+ * `?new_draft=true` — and re-enter the seed-empty branch. */
 export function stripNewDraftFlag(): void {
 	if (typeof window === 'undefined') return
 	const url = new URL(window.location.href)


### PR DESCRIPTION
## Summary

Creating a new raw app, opening it in an AI session, editing, then toggling back to navigation mode returned the user to a URL that still carried `?new_draft=true`. That stale flag re-enters the "seed an empty app" branch (`shouldSeedNewDraft`) unless an in-memory draft hint happens to be set — so the editor could come back blank instead of showing the draft.

Root cause: `stripNewDraftFlag()` cleaned `?new_draft=true` from the address bar with **raw `window.history.replaceState`**, which SvelteKit's router does not observe. So `afterNavigate` never fired, the session switch's remembered nav route (`lastNavRoute`) kept the pre-strip URL, and `exitSessionMode()` restored it — reviving `?new_draft=true`.

The fix uses SvelteKit's `replaceState` (so `page.url` stays in sync) and refreshes the remembered nav route to the stripped URL. Because it lives in the shared helper, it covers scripts, flows, and apps too — not just raw apps. It composes with #10099 (the `$effect` + `untrack` fix), which this branch is rebased on top of.

## Changes

- `frontend/src/lib/newDraftFlag.ts` — `stripNewDraftFlag()` now calls `replaceState(url, page.state)` from `$app/navigation` instead of `window.history.replaceState`, then `rememberNavRoute(url.pathname + url.search)` so exiting an AI session returns to the clean URL.
- `frontend/src/lib/newDraftFlag.test.ts` — mock `$app/navigation` / `$app/state` / `sessionSwitch`; assert `rememberNavRoute` is called with the stripped route.

## Screenshots

Faithful SPA flow (`/apps_raw/add` → dismiss picker → Open in AI session → toggle back). Returns to the clean path `…/draft_<uuid>` (no `?new_draft=true`) with the editor fully rendered — no blank, no stale flag:

![session-exit-returns-to-clean-url](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/glm/fix-raw-app-url-switch/v2-session-exit-clean.png)

## Test plan

- [x] `npx vitest run src/lib/newDraftFlag.test.ts` — 9/9 pass
- [x] Browser: new raw app → "Start without AI" → Open in AI session → edit → toggle back to navigation mode → URL is `…/draft_<uuid>` with **no** `?new_draft=true`, editor renders (not blank)
- [ ] Regression: refreshing a never-saved new raw app still re-seeds (does not 404), and a post-save refresh loads the draft