### PR TITLE
ci: link backend integration tests with mold to fix OOM (exit 143)

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -239,6 +239,16 @@ jobs:
       - name: cargo test
         timeout-minutes: 30
         env:
+          # setup-rust-toolchain exports RUSTFLAGS=-D warnings, and the RUSTFLAGS env
+          # var fully REPLACES (never merges with) target.*.rustflags in
+          # backend/.cargo/config.toml. That silently drops the config's
+          # `-C link-arg=-fuse-ld=mold`, so CI links the many large integration-test
+          # binaries (v8 + duckdb + every language runtime, statically linked) with the
+          # default bfd linker. Its peak memory across ~12 parallel links OOM-kills the
+          # runner mid-link (SIGTERM => exit 143, before any test runs). Re-add the mold
+          # link arg here so CI links with mold like local dev, keeping -D warnings.
+          # (config.toml's `linker = "clang"` still applies; env only overrides rustflags.)
+          RUSTFLAGS: "-D warnings -C link-arg=-fuse-ld=mold"
           SQLX_OFFLINE: true
           DATABASE_URL: postgres://postgres:changeme@localhost:5432/windmill
           DISABLE_EMBEDDING: true


### PR DESCRIPTION
## Summary

The **Backend only integration tests** job (`.github/workflows/backend-test.yml`) has been failing intermittently with `##[error]Process completed with exit code 143` and "The runner has received a shutdown signal", always **during the `test`-profile build, before any test runs**. The same commit often passes on a re-run, so it reads as flaky.

Root cause: an **OOM during parallel linking of the integration-test binaries**, caused by the intended low-memory linker being silently disabled in CI.

- `backend/.cargo/config.toml` configures `linker = "clang"` + `rustflags = ["-C", "link-arg=-fuse-ld=mold"]` so links use **mold** (fast, low peak memory).
- `actions-rust-lang/setup-rust-toolchain@v1` exports `RUSTFLAGS=-D warnings`. The `RUSTFLAGS` env var **fully replaces** (never merges with) `target.*.rustflags` from `config.toml`, so `-C link-arg=-fuse-ld=mold` is dropped in CI.
- CI therefore links the many large integration-test binaries (each statically links v8 + duckdb + every language runtime) with the **default bfd linker**. With `CARGO_BUILD_JOBS=12`, the burst of ~12 concurrent heavy links peaks past the runner's RAM; Ubicloud reclaims the VM → SIGTERM (exit 143). It only reproduces in CI (locally there is no `RUSTFLAGS` env, so mold is used) and is flaky because it depends on how many heavy links overlap at the memory peak.

Evidence: in failing runs the log stops mid-compilation and never prints `Finished \`test\` profile` or any `Running unittests` line; in passing runs that build phase takes ~7m16s and completes before tests start.

## Changes

- Set `RUSTFLAGS: "-D warnings -C link-arg=-fuse-ld=mold"` on the `cargo test` step so CI links with mold (as local dev does) while keeping `-D warnings`. `config.toml`'s `linker = "clang"` still applies since the env var only overrides the `rustflags` key.

## Test plan

- [ ] CI **Backend only integration tests** job completes the `test`-profile build (reaches `Finished \`test\` profile` and `Running unittests`) instead of dying with exit 143.
- [ ] Build/link phase is faster than the previous ~7m16s (mold vs bfd).
- [ ] `-D warnings` is still enforced (warnings fail the build).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky OOM (exit 143) in backend integration tests by restoring `mold` linking in CI. Adds `RUSTFLAGS: "-D warnings -C link-arg=-fuse-ld=mold"` to the `cargo test` step to match local builds and reduce build time.

- **Bug Fixes**
  - `actions-rust-lang/setup-rust-toolchain@v1` set `RUSTFLAGS=-D warnings`, which replaced `config.toml` rustflags and disabled `mold`, leading to parallel bfd links OOMing. This restores `mold` while keeping `-D warnings`.

<sup>Written for commit 2e07af4b739944ea5d55ee44a9a9ac0e3897c478. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

