### PR TITLE
fix(self-host): resolve caddy-l4 "unrecognized global option: layer4" error (Fixes GIT-903)

### DIFF
--- a/.github/workflows/build-caddy-l4-image.yml
+++ b/.github/workflows/build-caddy-l4-image.yml
@@ -5,6 +5,12 @@ env:
 name: Build caddy-l4
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - docker/DockerfileCaddyL4
+      - .github/workflows/build-caddy-l4-image.yml
 
 permissions: write-all
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,8 +1,10 @@
 {
 	layer4 {
 		:25 {
-			proxy {
-				to windmill_server:2525
+			route {
+				proxy {
+					upstream windmill_server:2525
+				}
 			}
 		}
 	}

--- a/docker/DockerfileCaddyL4
+++ b/docker/DockerfileCaddyL4
@@ -1,10 +1,12 @@
-FROM caddy:2.8.4-builder-alpine AS builder
+FROM caddy:2.11.4-builder-alpine AS builder
 
+# caddy-l4 natively registers the `layer4` global option used by the Caddyfile.
+# Do NOT also add RussellLuo/caddy-ext/layer4: it registers the same global
+# option, and building both panics with "global option 'layer4' already registered".
 RUN xcaddy build \
-  --with github.com/mholt/caddy-l4@145ec36251a44286f05a10d231d8bfb3a8192e09 \
-  --with github.com/RussellLuo/caddy-ext/layer4@ab1e18cfe426012af351a68463937ae2e934a2a1
+  --with github.com/mholt/caddy-l4@bd96009ea7373869bb07d61055554f966b1f5088
 
 
-FROM caddy:2.8.4-alpine
+FROM caddy:2.11.4-alpine
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/flake.nix
+++ b/flake.nix
@@ -354,8 +354,7 @@
           (pkgs.writeScriptBin "wm-caddy" ''
             cd ./frontend
             xcaddy build "$@" \
-              --with github.com/mholt/caddy-l4@145ec36251a44286f05a10d231d8bfb3a8192e09 \
-              --with github.com/RussellLuo/caddy-ext/layer4@ab1e18cfe426012af351a68463937ae2e934a2a1
+              --with github.com/mholt/caddy-l4@bd96009ea7373869bb07d61055554f966b1f5088
           '')
           (pkgs.writeScriptBin "wm-setup" ''
             sqlx database create


### PR DESCRIPTION
## Problem

Self-hosting the current `docker-compose.yml` can fail at the Caddy container with:

```
Error: adapting config using caddyfile: /etc/caddy/Caddyfile:2: unrecognized global option: layer4{
```

even though `caddy list-modules` shows the `layer4` modules are compiled in. The `layer4` *modules* are present, but the `layer4` Caddyfile **global option** is not registered.

## Root cause

The `ghcr.io/windmill-labs/caddy-l4` image was built from two layer4 sources:

- `mholt/caddy-l4` pinned to `145ec362` (2024-05-03) — a commit that predates mholt's native Caddyfile support, so it provides the layer4 *modules* but **not** the `layer4` global option.
- `RussellLuo/caddy-ext/layer4` (an abandoned shim) — the only thing registering the `layer4` global option and the `proxy { to ... }` syntax the checked-in `Caddyfile` used.

This arrangement is a maintenance timebomb:

- Build the image **without** the RussellLuo shim → the `layer4` global option disappears → `unrecognized global option: layer4` (the reported error).
- Bump `mholt/caddy-l4` to **any** version with native Caddyfile support → both modules call `RegisterGlobalOption("layer4", …)` → Caddy panics at startup with `global option 'layer4' already registered`.

I reproduced all four combinations locally with `xcaddy`/`docker build` (old-mholt+RussellLuo works; new-mholt+RussellLuo panics; new-mholt alone works; new-mholt rejects the old `proxy { to }` syntax).

## Fix

- **Drop `RussellLuo/caddy-ext/layer4`** and bump `mholt/caddy-l4` to a current commit that natively registers the `layer4` global option (`docker/DockerfileCaddyL4`, `flake.nix`).
- **Rewrite the `Caddyfile`** layer4 block to the native `route { proxy { upstream … } }` syntax. The adapted layer4 JSON is **byte-identical** to the previous output, so runtime behavior is unchanged:
  ```json
  {"layer4":{"servers":{"srv0":{"listen":[":25"],"routes":[{"handle":[{"handler":"proxy","upstreams":[{"dial":["windmill_server:2525"]}]}]}]}}}}
  ```
- **Bump the Caddy base image** `2.8.4 → 2.11.4` (required by current caddy-l4).
- **Add a path-filtered `push` trigger** to `build-caddy-l4-image.yml` so `:latest` is rebuilt whenever the Caddy Dockerfile changes, instead of only on manual `workflow_dispatch` — the manual-only trigger is how `:latest` drifted out of sync with the checked-in Caddyfile.

## Validation

Built the new `docker/DockerfileCaddyL4` with a real `docker build` and, using the resulting image:

- `caddy adapt` / `caddy validate` succeed for both `BASE_URL=:80` (default self-host) and a domain `BASE_URL` (HTTPS path) — no `unrecognized global option`.
- `caddy run` boots and reaches `serving initial configuration` with no panic or error (the exact failure mode from the issue is gone).
- `caddy list-modules` shows `layer4` + `layer4.handlers.proxy` present.

> Note: merging this rebuilds and republishes `ghcr.io/windmill-labs/caddy-l4:latest`. The self-host guide already instructs users to `curl` the matching `Caddyfile`, so the native-syntax Caddyfile and the new image stay in sync.

Fixes GIT-903

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes self-hosted Caddy startup by switching to native `caddy-l4` Caddyfile support and updating the `Caddyfile` syntax, removing the “unrecognized global option: layer4” error with no behavior change. Also updates the `caddy` base image and CI so the published image stays in sync. Fixes GIT-903.

- **Bug Fixes**
  - Dropped `RussellLuo/caddy-ext/layer4` to avoid duplicate global option registration.
  - Rewrote the `Caddyfile` to native `route { proxy { upstream ... } }` for `layer4`.

- **Dependencies**
  - Bumped `caddy` images to 2.11.4 and build now uses only `github.com/mholt/caddy-l4`.
  - Added path-filtered `push` trigger to rebuild `ghcr.io/windmill-labs/caddy-l4:latest` on Dockerfile/workflow changes.

<sup>Written for commit cec2965936da9ee1183125d287fde239da90a2c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

