### PR TITLE
fix(mcp): let MCP tokens call preview run tools (jobs:run scope) — Fixes GIT-920

### DIFF
--- a/backend/windmill-api-auth/src/scopes.rs
+++ b/backend/windmill-api-auth/src/scopes.rs
@@ -596,16 +596,15 @@ fn map_http_method_to_action(method: &str, route_path: &str) -> ScopeAction {
 /// Returns `"flows"` or `"scripts"` based on the match, or `None` if no match is found.
 fn determine_kind_from_route(route_path: &str) -> Option<String> {
     if route_path.starts_with("jobs") {
-        // Preview/bundle runs execute arbitrary, request-supplied code with no
-        // deployed path, so their handlers require the broad `jobs:run` scope
-        // (not `jobs:run:scripts`/`jobs:run:flows`). They must therefore carry no
-        // kind here, otherwise the derived scope is narrower than the handler
-        // demands. This diverged for the MCP proxy, which mints exactly the
-        // derived scope and was then rejected by the handler's `jobs:run` check.
-        // Preview routes also share a `.../p...` prefix with by-path runs (e.g.
-        // `run_wait_result/preview` vs `run_wait_result/p/*`), which the
-        // SCRIPT_JOBS prefix match would otherwise classify as scripts.
-        if route_path.contains("preview") {
+        // Preview/bundle runs execute arbitrary code with no deployed path, so
+        // their handlers require the broad `jobs:run` scope: they must carry no
+        // kind, else the derived scope is narrower than the handler demands.
+        // Anchor to the endpoint segment so by-path runs of a deployed runnable
+        // whose path contains "preview" (e.g. `run/p/f/team/preview_report`) are
+        // still classified by their kind.
+        if route_path.starts_with("jobs/run/preview")
+            || route_path.starts_with("jobs/run_wait_result/preview")
+        {
             return None;
         }
         if FLOW_JOBS.iter().any(|path| route_path.starts_with(path)) {
@@ -1309,9 +1308,7 @@ mod tests {
         );
 
         // Preview/bundle runs have no deployed path and their handlers require the
-        // broad `jobs:run` scope, so the derived scope must not carry a kind
-        // (GIT-920: MCP's `runScriptPreviewAndWaitResult` proxy minted
-        // `jobs:run:scripts` and was then denied by the handler's `jobs:run` check).
+        // broad `jobs:run` scope, so the derived scope must not carry a kind.
         for path in [
             "/api/w/ws/jobs/run/preview",
             "/api/w/ws/jobs/run/preview_bundle",
@@ -1325,6 +1322,26 @@ mod tests {
                 "preview route {path} must derive the broad jobs:run scope"
             );
         }
+
+        // By-path runs of a deployed runnable whose path contains "preview" must
+        // still derive their kind (not be swept into the broad jobs:run above),
+        // otherwise a `jobs:run:scripts:*`/`jobs:run:flows:*` token is denied.
+        assert_eq!(
+            scope_for_route("POST", "/api/w/ws/jobs/run/p/u/alice/preview_report").as_deref(),
+            Some("jobs:run:scripts")
+        );
+        assert_eq!(
+            scope_for_route(
+                "POST",
+                "/api/w/ws/jobs/run_wait_result/p/f/team/preview_report"
+            )
+            .as_deref(),
+            Some("jobs:run:scripts")
+        );
+        assert_eq!(
+            scope_for_route("POST", "/api/w/ws/jobs/run/f/f/team/preview_report").as_deref(),
+            Some("jobs:run:flows")
+        );
 
         // The minted scope actually satisfies the route check it targets.
         let s = scope_for_route("POST", "/api/w/ws/variables/create").unwrap();

--- a/backend/windmill-api-auth/src/scopes.rs
+++ b/backend/windmill-api-auth/src/scopes.rs
@@ -596,6 +596,18 @@ fn map_http_method_to_action(method: &str, route_path: &str) -> ScopeAction {
 /// Returns `"flows"` or `"scripts"` based on the match, or `None` if no match is found.
 fn determine_kind_from_route(route_path: &str) -> Option<String> {
     if route_path.starts_with("jobs") {
+        // Preview/bundle runs execute arbitrary, request-supplied code with no
+        // deployed path, so their handlers require the broad `jobs:run` scope
+        // (not `jobs:run:scripts`/`jobs:run:flows`). They must therefore carry no
+        // kind here, otherwise the derived scope is narrower than the handler
+        // demands. This diverged for the MCP proxy, which mints exactly the
+        // derived scope and was then rejected by the handler's `jobs:run` check.
+        // Preview routes also share a `.../p...` prefix with by-path runs (e.g.
+        // `run_wait_result/preview` vs `run_wait_result/p/*`), which the
+        // SCRIPT_JOBS prefix match would otherwise classify as scripts.
+        if route_path.contains("preview") {
+            return None;
+        }
         if FLOW_JOBS.iter().any(|path| route_path.starts_with(path)) {
             return Some("flows".to_string());
         } else if SCRIPT_JOBS.iter().any(|path| route_path.starts_with(path)) {
@@ -1295,6 +1307,24 @@ mod tests {
             scope_for_route("POST", "/api/w/ws/jobs/run/f/u/x/y").as_deref(),
             Some("jobs:run:flows")
         );
+
+        // Preview/bundle runs have no deployed path and their handlers require the
+        // broad `jobs:run` scope, so the derived scope must not carry a kind
+        // (GIT-920: MCP's `runScriptPreviewAndWaitResult` proxy minted
+        // `jobs:run:scripts` and was then denied by the handler's `jobs:run` check).
+        for path in [
+            "/api/w/ws/jobs/run/preview",
+            "/api/w/ws/jobs/run/preview_bundle",
+            "/api/w/ws/jobs/run/preview_flow",
+            "/api/w/ws/jobs/run_wait_result/preview",
+            "/api/w/ws/jobs/run_wait_result/preview_flow",
+        ] {
+            assert_eq!(
+                scope_for_route("POST", path).as_deref(),
+                Some("jobs:run"),
+                "preview route {path} must derive the broad jobs:run scope"
+            );
+        }
 
         // The minted scope actually satisfies the route check it targets.
         let s = scope_for_route("POST", "/api/w/ws/variables/create").unwrap();


### PR DESCRIPTION
## Problem

An MCP token (e.g. `mcp:all`) could not call the built-in `runScriptPreviewAndWaitResult` tool. Every call returned:

```
HTTP 403 Forbidden: Permission denied: Required scope: jobs:run
POST /w/{workspace}/jobs/run_wait_result/preview
```

Read tools and deployed-script tools over the same token worked fine; only ad-hoc preview runs failed. Reported as fallout from the scope-enforcement work (#9712).

## Root cause

The MCP proxy (`create_http_request` in `mcp/utils.rs`) mints an internal JWT scoped to **exactly** `scope_for_route(method, path)` for the endpoint it forwards to, so a scope-restricted MCP token can't be widened into a blank check.

For preview run routes, `determine_kind_from_route("jobs/run_wait_result/preview")` matched the `SCRIPT_JOBS` prefix `"jobs/run_wait_result/p"` — because `"preview"` starts with `"p"` — and derived the runnable kind `scripts`, producing the minted scope `jobs:run:scripts`.

But preview handlers (`run_preview_script` / `run_preview_flow_job`) run **arbitrary, request-supplied code with no deployed path**, and deliberately require the *broad* `jobs:run` scope so a narrowly-scoped token can't escape its scope. `jobs:run:scripts` does not include `jobs:run`, so `check_scopes` rejected it with 403.

The route-derivation (`scope_for_route`) and the handler requirement (`check_scopes(jobs:run)`) had silently diverged for preview routes.

## Fix

`determine_kind_from_route` now returns no kind for preview/bundle routes, so `scope_for_route` derives the broad `jobs:run` that the handlers require. The match is **anchored to the endpoint segment** (`jobs/run/preview*` or `jobs/run_wait_result/preview*`) rather than a `contains("preview")` substring test.

This matters because `determine_kind_from_route` also feeds the direct-API `check_route_access` middleware. A substring test would also match a **by-path** run of a deployed runnable whose own path contains `preview` (e.g. `jobs/run_wait_result/p/f/team/preview_report`): that route would then derive the broad `jobs:run`, and a legitimately kind-scoped `jobs:run:scripts:*` / `jobs:run:flows:*` token would be rejected with 403. Anchoring to the endpoint segment keeps those by-path runs on their correct kind.

`scope_for_route` is only consumed by the MCP proxy; the by-path run routes (`run/p/*`, `run/f/*`, etc.) keep their kind.

## Validation

**Unit tests** (`test_scope_for_route`):
- All five preview routes derive `jobs:run`.
- By-path runs with a `preview`-named path still derive their kind: `run/p/u/alice/preview_report` and `run_wait_result/p/f/team/preview_report` → `jobs:run:scripts`; `run/f/f/team/preview_report` → `jobs:run:flows`.

**End-to-end**, against a local backend built with `--features mcp,quickjs`, before/after each change:

_MCP preview path_ — driving the real MCP streamable-HTTP protocol with an `mcp:all` token calling `runScriptPreviewAndWaitResult`:
- Before (guard disabled, rebuilt): reproduces the exact reported `403 Required scope: jobs:run`.
- After: `200`, result `"hello-git920"`.

_By-path regression_ — a deployed bash script at `u/admin/preview_report`, run via `POST /w/admins/jobs/run_wait_result/p/u/admin/preview_report` with a token scoped only to `jobs:run:scripts:u/admin/preview_report`:
- With `contains("preview")` (rebuilt): `403 Access denied. Required scope: jobs:run` — confirms the substring approach was a real functional break.
- With the endpoint-anchored fix: `200`, result `"bypath-git920"`, while the MCP preview path still returns `200`.

Fixes GIT-920

🤖 Generated with [Claude Code](https://claude.com/claude-code)
