### PR TITLE
perf(rls): wrap session GUC reads in RLS policies for per-statement InitPlan (GIT-919)

### DIFF
--- a/.agents/skills/adding-a-trigger/SKILL.md
+++ b/.agents/skills/adding-a-trigger/SKILL.md
@@ -35,12 +35,15 @@ The `up.sql` usually defines:
 
 **RLS: wrap every session GUC read in a scalar sub-select.** Write the session
 reads as `(select current_setting('session.user'))`,
-`= any((select regexp_split_to_array(current_setting('session.groups'), ',')::text[]))`,
-`?| (select regexp_split_to_array(current_setting('session.pgroups'), ',')::text[])`,
+`= any((select regexp_split_to_array(current_setting('session.groups'), ','))::text[])`,
+`?| (select regexp_split_to_array(current_setting('session.pgroups'), ','))::text[]`,
 `? (select concat('u/', current_setting('session.user')))`, etc. — not the bare
 `current_setting(...)`. The GUCs are set with `SET LOCAL`, so the sub-select
 hoists them to a one-time InitPlan instead of re-evaluating per scanned row.
-The array cases keep the `::text[]` cast so `= any (...)` / `?|` stay in
+Put the `::text[]` cast **outside** the sub-select for the array cases: in an
+`= any (...)` context, casting inside — `= any((select ...::text[]))` — makes
+Postgres parse the operand as a row-returning subquery and fails at CREATE with
+`operator does not exist: text = text[]`. The outside cast keeps it in
 array-operand form. See migration `20260714230440_wrap_session_gucs_in_rls_policies`
 for the canonical wrapped forms.
 

--- a/.agents/skills/adding-a-trigger/SKILL.md
+++ b/.agents/skills/adding-a-trigger/SKILL.md
@@ -31,6 +31,18 @@ The `up.sql` usually defines:
   - trigger-specific fields
 - Indexes on foreign keys + any frequently-filtered columns
 - Foreign key to `workspace`
+- The RLS policies (`see_own`, `see_member`, `see_folder_extra_perms_user_*`, `see_extra_perms_user_*`, `see_extra_perms_groups_*`), copied from an existing trigger table
+
+**RLS: wrap every session GUC read in a scalar sub-select.** Write the session
+reads as `(select current_setting('session.user'))`,
+`= any((select regexp_split_to_array(current_setting('session.groups'), ',')::text[]))`,
+`?| (select regexp_split_to_array(current_setting('session.pgroups'), ',')::text[])`,
+`? (select concat('u/', current_setting('session.user')))`, etc. — not the bare
+`current_setting(...)`. The GUCs are set with `SET LOCAL`, so the sub-select
+hoists them to a one-time InitPlan instead of re-evaluating per scanned row.
+The array cases keep the `::text[]` cast so `= any (...)` / `?|` stay in
+array-operand form. See migration `20260714230440_wrap_session_gucs_in_rls_policies`
+for the canonical wrapped forms.
 
 Down migration drops the table and any enum types.
 

--- a/backend/migrations/20260714230440_wrap_session_gucs_in_rls_policies.down.sql
+++ b/backend/migrations/20260714230440_wrap_session_gucs_in_rls_policies.down.sql
@@ -1,0 +1,68 @@
+-- Inverse of the up migration: strip the scalar sub-select wrapping from the
+-- session GUC reads in RLS predicates, restoring the bare per-row forms.
+--
+-- Postgres re-deparses the wrapped sub-selects into a canonical shape
+-- ( SELECT <expr> AS <alias>), and drops the redundant ::text[] cast in the
+-- jsonb `?|` context while keeping it in the `= ANY (...)` context, so the
+-- unwrap tolerates the alias and the optional trailing cast.
+
+CREATE FUNCTION pg_temp.unwrap_session_gucs(expr text) RETURNS text AS $fn$
+DECLARE e text := expr;
+BEGIN
+  IF e IS NULL THEN
+    RETURN NULL;
+  END IF;
+  -- ( SELECT regexp_split_to_array(current_setting('session.<g>'::text), ','::text) AS regexp_split_to_array)[::text[]]
+  e := regexp_replace(e,
+    '\( SELECT (regexp_split_to_array\(current_setting\(''session\.(?:pgroups|groups|folders_read|folders_write)''::text\), '',''::text\)) AS regexp_split_to_array\)(?:::text\[\])?',
+    '\1', 'g');
+  -- ( SELECT concat('u/', current_setting('session.user'::text)) AS concat)
+  e := regexp_replace(e,
+    '\( SELECT (concat\(''u/'', current_setting\(''session\.user''::text\)\)) AS concat\)',
+    '\1', 'g');
+  -- ( SELECT current_setting('session.user'::text) AS current_setting)
+  e := regexp_replace(e,
+    '\( SELECT (current_setting\(''session\.user''::text\)) AS current_setting\)',
+    '\1', 'g');
+  RETURN e;
+END;
+$fn$ LANGUAGE plpgsql IMMUTABLE;
+
+DO $do$
+DECLARE
+  r record;
+  new_qual text;
+  new_check text;
+  stmt text;
+BEGIN
+  FOR r IN
+    SELECT schemaname, tablename, policyname, permissive, cmd, roles, qual, with_check
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND (coalesce(qual, '') LIKE '%current_setting(''session.%'
+           OR coalesce(with_check, '') LIKE '%current_setting(''session.%')
+  LOOP
+    new_qual := pg_temp.unwrap_session_gucs(r.qual);
+    new_check := pg_temp.unwrap_session_gucs(r.with_check);
+
+    EXECUTE format('DROP POLICY %I ON %I.%I', r.policyname, r.schemaname, r.tablename);
+
+    stmt := format(
+      'CREATE POLICY %I ON %I.%I AS %s FOR %s TO %s',
+      r.policyname, r.schemaname, r.tablename,
+      r.permissive, r.cmd,
+      (SELECT string_agg(quote_ident(role_name), ', ') FROM unnest(r.roles) AS role_name)
+    );
+    IF new_qual IS NOT NULL THEN
+      stmt := stmt || format(' USING (%s)', new_qual);
+    END IF;
+    IF new_check IS NOT NULL THEN
+      stmt := stmt || format(' WITH CHECK (%s)', new_check);
+    END IF;
+
+    EXECUTE stmt;
+  END LOOP;
+END;
+$do$;
+
+DROP FUNCTION pg_temp.unwrap_session_gucs(text);

--- a/backend/migrations/20260714230440_wrap_session_gucs_in_rls_policies.up.sql
+++ b/backend/migrations/20260714230440_wrap_session_gucs_in_rls_policies.up.sql
@@ -1,0 +1,80 @@
+-- Wrap per-row session GUC reads in RLS predicates in a scalar sub-select so
+-- Postgres hoists them to a one-time InitPlan instead of re-evaluating
+-- current_setting('session.*') once per scanned row.
+--
+-- The session GUCs are set with SET LOCAL (set_config(..., true)) in
+-- set_session_context(), so they are constant for the duration of a statement.
+-- Wrapping the session-derived subexpression in (select ...) is therefore
+-- value-preserving: same rows in, same rows out, N per-row GUC lookups collapse
+-- to 1. Array-producing subexpressions keep an explicit ::text[] cast on the
+-- sub-select so `= ANY (...)` / `?|` stay in their array-operand form rather
+-- than being reparsed as a row-returning subquery.
+--
+-- This rewrites every existing policy (recorded across ~30 prior migrations)
+-- whose USING / WITH CHECK predicate reads a session GUC, by deparsing the
+-- current predicate and substituting the wrapped forms. See the .down.sql for
+-- the inverse.
+
+CREATE FUNCTION pg_temp.wrap_session_gucs(expr text) RETURNS text AS $fn$
+DECLARE e text := expr;
+BEGIN
+  IF e IS NULL THEN
+    RETURN NULL;
+  END IF;
+  -- Protect the maximal session-derived subexpressions with placeholders first,
+  -- so the bare-scalar pass below only touches genuinely-bare session.user reads.
+  e := replace(e, 'regexp_split_to_array(current_setting(''session.pgroups''::text), '',''::text)', '@@WM_P0@@');
+  e := replace(e, 'regexp_split_to_array(current_setting(''session.groups''::text), '',''::text)', '@@WM_P1@@');
+  e := replace(e, 'regexp_split_to_array(current_setting(''session.folders_read''::text), '',''::text)', '@@WM_P2@@');
+  e := replace(e, 'regexp_split_to_array(current_setting(''session.folders_write''::text), '',''::text)', '@@WM_P3@@');
+  e := replace(e, 'concat(''u/'', current_setting(''session.user''::text))', '@@WM_P4@@');
+  -- Wrap any remaining bare scalar session.user read.
+  e := replace(e, 'current_setting(''session.user''::text)', '(select current_setting(''session.user''::text))');
+  -- Restore the protected subexpressions, now wrapped in a scalar sub-select.
+  e := replace(e, '@@WM_P0@@', '(select regexp_split_to_array(current_setting(''session.pgroups''::text), '',''::text))::text[]');
+  e := replace(e, '@@WM_P1@@', '(select regexp_split_to_array(current_setting(''session.groups''::text), '',''::text))::text[]');
+  e := replace(e, '@@WM_P2@@', '(select regexp_split_to_array(current_setting(''session.folders_read''::text), '',''::text))::text[]');
+  e := replace(e, '@@WM_P3@@', '(select regexp_split_to_array(current_setting(''session.folders_write''::text), '',''::text))::text[]');
+  e := replace(e, '@@WM_P4@@', '(select concat(''u/'', current_setting(''session.user''::text)))');
+  RETURN e;
+END;
+$fn$ LANGUAGE plpgsql IMMUTABLE;
+
+DO $do$
+DECLARE
+  r record;
+  new_qual text;
+  new_check text;
+  stmt text;
+BEGIN
+  FOR r IN
+    SELECT schemaname, tablename, policyname, permissive, cmd, roles, qual, with_check
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND (coalesce(qual, '') LIKE '%current_setting(''session.%'
+           OR coalesce(with_check, '') LIKE '%current_setting(''session.%')
+  LOOP
+    new_qual := pg_temp.wrap_session_gucs(r.qual);
+    new_check := pg_temp.wrap_session_gucs(r.with_check);
+
+    EXECUTE format('DROP POLICY %I ON %I.%I', r.policyname, r.schemaname, r.tablename);
+
+    stmt := format(
+      'CREATE POLICY %I ON %I.%I AS %s FOR %s TO %s',
+      r.policyname, r.schemaname, r.tablename,
+      r.permissive, r.cmd,
+      (SELECT string_agg(quote_ident(role_name), ', ') FROM unnest(r.roles) AS role_name)
+    );
+    IF new_qual IS NOT NULL THEN
+      stmt := stmt || format(' USING (%s)', new_qual);
+    END IF;
+    IF new_check IS NOT NULL THEN
+      stmt := stmt || format(' WITH CHECK (%s)', new_check);
+    END IF;
+
+    EXECUTE stmt;
+  END LOOP;
+END;
+$do$;
+
+DROP FUNCTION pg_temp.wrap_session_gucs(text);


### PR DESCRIPTION
## Summary

RLS policies read `current_setting('session.user' / 'session.groups' / 'session.pgroups' / 'session.folders_read' / 'session.folders_write')` **unwrapped** inside their `USING` / `WITH CHECK` predicates. Postgres treats those calls as potentially row-varying and **re-evaluates them once per scanned row**, on the read path of every workspace-scoped object + trigger table.

Wrapping each session-derived subexpression in a scalar sub-select — `(select current_setting(…))` — lets the planner hoist it to a **one-time InitPlan** (evaluated once per statement, reused for every row). This is a pure planner optimization: same rows in, same rows out, N per-row GUC lookups collapse to 1.

Fixes GIT-919. Surfaced by [pgrls](https://github.com/pgrls/pgrls) (`PERF001`).

## Why it's safe

The session GUCs are set with `set_config('session.*', …, true)` (the `SET LOCAL` form) in `set_session_context()`, so they are constant for the duration of a statement — exactly the condition under which the InitPlan hoist is value-preserving. Same optimization Supabase documents for `auth.*()` / `current_setting()` in policies.

## Approach

A single consolidating migration (`20260714230440_wrap_session_gucs_in_rls_policies`) recreates every existing policy (recorded across ~30 prior migrations) whose predicate reads a session GUC. Rather than hand-writing ~280 `DROP/CREATE` statements, it iterates `pg_policies`, deparses each predicate, and substitutes the wrapped forms, preserving name / permissive / cmd / roles / `USING` / `WITH CHECK`. The `.down.sql` is the exact inverse.

### The one non-obvious detail: array operands

Naively wrapping the array operand of `= ANY (...)` **breaks** it — `x = ANY ((select arr))` reparses as the row-returning subquery form and errors (`malformed array literal`). The wrapped array subexpressions therefore keep an explicit `::text[]` cast — `= any ((select regexp_split_to_array(…))::text[])` — which keeps the operand in array form while still creating the InitPlan. Same for the jsonb `?|` operator.

## Validation

- **Applies cleanly** through the backend's normal sqlx path (`_sqlx_migrations.success = t`), no errors/panics.
- **Round-trip is byte-identical** — `up` then `down` reproduces the original `pg_policies` definitions exactly (all 502 policies, verified via `\copy` snapshot diff).
- **InitPlan hoist confirmed** on live RLS via `EXPLAIN (VERBOSE)`: every `current_setting` now appears only in InitPlan `Result → Output` lines (once per statement); **zero** appear in any `Filter:` clause (per-row). Covers all five patterns incl. the `jsonb_each_text(...) EXISTS` group policies used by INSERT/UPDATE/DELETE.
- **Row-equivalence on real data** — for a live session context, `SELECT count(*) FROM script` under the wrapped RLS returns the same set as a hand-written unwrapped union of the `USING` predicates.

The `adding-a-trigger` skill now documents the wrapped form so new trigger tables inherit it (trigger policies are hand-copied per migration; there is no runtime template).

No Rust queries changed → no `.sqlx` update needed. No frontend surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrap session GUC reads in RLS policies with scalar sub-selects so Postgres hoists them into per-statement InitPlans, removing per-row `current_setting` lookups. No behavior change; fixes GIT-919.

- **Refactors**
  - Wrapped all `current_setting('session.user'|'session.groups'|'session.pgroups'|'session.folders_read'|'session.folders_write')` calls in `(select ...)` inside RLS `USING` / `WITH CHECK` predicates to enable per-statement InitPlans.
  - Added migration `20260714230440_wrap_session_gucs_in_rls_policies` to recreate affected policies by deparsing `pg_policies`; the `.down.sql` reverses the rewrite.
  - Kept explicit `::text[]` on wrapped array expressions and fixed docs to place the cast outside the sub-select for `= ANY (...)` so it stays an array operand (also for `?|`); documented canonical forms in `./.agents/skills/adding-a-trigger/SKILL.md`.

<sup>Written for commit c39376552218015f1c60763524c3e60966977406. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

