### PR TITLE
fix(nativets): apply parameter defaults for missing args instead of null

### DIFF
--- a/backend/windmill-runtime-nativets/src/lib.rs
+++ b/backend/windmill-runtime-nativets/src/lib.rs
@@ -1010,7 +1010,10 @@ function processStreamIterative(res) {{
 
 {otel_context_inject}
 
-let args = Deno.core.ops.op_get_static_args().map(JSON.parse)
+// A slot is `null` only when the arg was not provided: pass `undefined` so the
+// parameter default applies (JS defaults ignore `null`), matching the bun runner.
+// A provided JSON `null` arrives as the string "null" and stays `null`.
+let args = Deno.core.ops.op_get_static_args().map((arg) => arg === null ? undefined : JSON.parse(arg))
 import("file:///eval.ts").then((module) => module.{main_fn}(...args))
     .then(res => {{
         if (isAsyncIterable(res)) {{

--- a/backend/windmill-runtime-nativets/src/smoke_tests.rs
+++ b/backend/windmill-runtime-nativets/src/smoke_tests.rs
@@ -57,6 +57,34 @@ export async function main(x: number): Promise<number> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "deno_core upgrade smoke; run with --ignored"]
+async fn smoke_missing_optional_arg_uses_default() {
+    // A missing optional arg must arrive as `undefined`, not `null`, so the
+    // parameter default applies. With `null`, slice(0, null) -> [] -> length 0.
+    let ts = r#"
+export async function main(limit = 50): Promise<number> {
+    return [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].slice(0, limit).length;
+}
+"#;
+    let r = run_ts(ts, &["limit"], serde_json::json!({})).await;
+    assert_eq!(unwrap_value(&r), serde_json::json!(10));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "deno_core upgrade smoke; run with --ignored"]
+async fn smoke_explicit_null_arg_is_preserved() {
+    // An explicitly-provided JSON null must stay null (distinct from a missing
+    // arg), so the default does NOT apply.
+    let ts = r#"
+export async function main(x: number | null = 7): Promise<string> {
+    return x === null ? "null" : String(x);
+}
+"#;
+    let r = run_ts(ts, &["x"], serde_json::json!({ "x": null })).await;
+    assert_eq!(unwrap_value(&r), serde_json::json!("null"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "deno_core upgrade smoke; run with --ignored"]
 async fn smoke_transpile_enum_and_union() {
     // Enums + discriminated union + as-cast exercise the swc_ecma_ast +
     // swc_ecma_parser TS-syntax paths the bare value tests don't.


### PR DESCRIPTION
## Summary
In the nativets in-process runtime (`windmill-runtime-nativets`, deno_core based), a script argument that wasn't provided was passed to the entrypoint as JS `null` instead of `undefined`. Because JS default parameters only apply for `undefined`, a script like `function main(limit = 50)` called without that arg ran with `limit === null`, silently producing wrong results (e.g. `arr.slice(0, null)` → `[]`). No error, just wrong output. The bun runner passes `undefined` for a missing arg, so the same script works there; the divergence was nativets-only.

## Root cause
`op_get_static_args()` (`lib.rs:516`) returns `Vec<Option<String>>` — `None` for an arg absent from the args map, `Some(json_text)` for a provided value (an explicit JSON `null` becomes `Some("null")`, built at `lib.rs:732-738`). The entrypoint builder did `.map(JSON.parse)`, which turned the `null` for a missing arg into `JSON.parse("null")` → `null`, defeating the parameter default.

## Fix
Map a missing slot (`null`) to `undefined` at the single JS call site in `execute_main`, which both the regular and dedicated/prewarmed paths route through (`dedicated.rs` calls `execute_main`):

```js
let args = Deno.core.ops.op_get_static_args().map((arg) => arg === null ? undefined : JSON.parse(arg))
```

- **Missing arg** → `None` → `undefined` → parameter default applies.
- **Explicit JSON `null`** → `Some("null")` → `JSON.parse("null")` → `null` preserved.

## Consistency with other runners
This makes nativets match how bun, deno, and python already behave — missing arg falls back to the language default, explicit null is preserved:
- **bun** / **deno** destructure the args *object* by param name (`argsObjToArr({limit}){return [limit]}`): an absent key is `undefined`, a `null` stays `null`.
- **python** calls `main(**args)` on the kwargs dict: an absent key applies the Python default, `None` is passed through.

nativets instead receives a positional `Vec<Option<String>>` that already preserved the missing-vs-null distinction; the old `.map(JSON.parse)` just collapsed both to `null`. This fix restores the positional equivalent of the object-destructuring semantics.

## Changes
- `lib.rs`: entrypoint arg builder maps an unprovided (`null`) slot to `undefined` instead of parsing it to `null`.
- `smoke_tests.rs`: two regression tests — `smoke_missing_optional_arg_uses_default` (missing optional arg applies its default) and `smoke_explicit_null_arg_is_preserved` (explicit JSON null stays null).

## Test plan
- [x] `cargo test -p windmill-runtime-nativets _arg_ -- --ignored` → 2 passed
- [ ] Run a `//native` TS script with `main(limit = 50)` without the arg → default applies (not `null`)
- [ ] Same script with an explicit JSON `null` for a nullable param → stays `null`

## Notes
The two regression tests carry `#[ignore]`, consistent with the rest of `smoke_tests.rs` (an opt-in module run via `cargo test -p windmill-runtime-nativets smoke -- --ignored`). They therefore don't run in the default CI `cargo test` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nativets arg handling so missing args are passed as `undefined`, not `null`, allowing JS default parameters to apply. Explicit JSON `null` is preserved; behavior now matches bun/deno and prevents silent wrong results.

- **Bug Fixes**
  - Map `null` slots from `op_get_static_args()` to `undefined` at the entrypoint: `map(arg => arg === null ? undefined : JSON.parse(arg))` in `windmill-runtime-nativets/src/lib.rs`.
  - Add smoke tests to ensure a missing optional arg uses its default and an explicit `null` stays `null` (`smoke_tests.rs`, ignored by default).

<sup>Written for commit d1f84bf240e81f6a9ceda165680195ae868d7387. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

