### PR TITLE
fix(self-host): make Caddy bind tolerate unset ADDRESS on caddy >= 2.9 (Fixes GIT-903)

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -11,7 +11,10 @@
 }
 
 {$BASE_URL} {
-        bind {$ADDRESS}
+        # Default to all interfaces (IPv4 + IPv6) when ADDRESS is unset. A bare
+        # `bind {$ADDRESS}` with an empty value makes Caddy >= 2.9 drop this whole
+        # site, silently disabling the HTTP proxy while the :25 layer4 listener stays up.
+        bind {$ADDRESS:0.0.0.0 ::}
 
         # Extra services: LSP, Multiplayer, Debugger (windmill_extra gateway)
         reverse_proxy /ws/* /ws_mp/* /ws_debug/* http://windmill_extra:3000


### PR DESCRIPTION
## Follow-up to #10106

While verifying #10106 **end-to-end** (running the built image and pushing real traffic through it, not just `caddy adapt`/`validate`), I found that the caddy base-image bump to 2.11.4 introduced a silent regression in the shipped `Caddyfile`.

## The regression

caddy ≥ 2.9 changed how the `bind` directive handles an **empty** argument. The shipped `Caddyfile` uses:

```
{$BASE_URL} {
	bind {$ADDRESS}
	...
}
```

The `caddy` service in `docker-compose.yml` does **not** set `ADDRESS`, so `{$ADDRESS}` is empty in the default self-host setup. On caddy 2.8.4 that was a harmless no-op (bind all interfaces). On caddy 2.11.4 it makes the entire `{$BASE_URL}` site adapt to `{}` — so the container listens only on `:25` (layer4) and the `:80` HTTP reverse proxy to `windmill_server` **silently disappears**. The layer4 email proxy still works, which is why config-only checks (`caddy adapt`/`validate`/boot) don't catch it.

## Fix

Fix it **in the Caddyfile**, keeping the patched Caddy core (2.11.4) rather than downgrading:

```
bind {$ADDRESS:0.0.0.0 ::}
```

- `ADDRESS` **unset** (default compose) → binds all interfaces `0.0.0.0:80` + `[::]:80` (IPv4 + IPv6), matching pre-2.9 behavior.
- `ADDRESS` **set** → honored unchanged (the interface-restriction knob is preserved).

> Addresses the Codex P1: this keeps `caddy:2.11.4` (no CVE downgrade). The earlier revision of this PR pinned back to 2.8.4 to dodge the regression — that was the wrong trade-off; fixing the `bind` default is the right one. Net change vs `main` is now **only** the Caddyfile `bind` line; `DockerfileCaddyL4`/`flake.nix` stay on 2.11.4 + `bd96009` from #10106.

## End-to-end validation

Built the `caddy:2.11.4` image and ran it on a docker network with a mock `windmill_server` backend (HTTP on :8000, layer4 echo on :2525):

| Scenario | `:80` + `:25` bound | HTTP `/*` → :8000 | layer4 `:25` → :2525 |
|---|---|---|---|
| `ADDRESS` unset | ✅ | `windmill-http-ok` | `LAYER4-PING-903` |
| `ADDRESS=0.0.0.0` | ✅ | `windmill-http-ok` | `LAYER4-PING-903` |
| `ADDRESS=127.0.0.1` | HTTP binds `127.0.0.1:80` (knob preserved) | — | — |

`caddy version` = `v2.11.4`. Domain `BASE_URL` (HTTPS path) also `caddy validate`s clean.

Fixes GIT-903

🤖 Generated with [Claude Code](https://claude.com/claude-code)