### PR TITLE
security(docker): apt-get upgrade base OS in all runtime base stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -162,6 +162,7 @@ ENV PATH /usr/local/bin:/root/.local/bin:/tmp/.local/bin:$PATH
 
 
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends netbase tzdata ca-certificates wget curl jq unzip build-essential unixodbc xmlsec1 tini gnupg libargon2-1 \
     && if echo "$features" | grep -q "ee"; then apt-get install -y --no-install-recommends libsasl2-modules-gssapi-mit krb5-user; fi \
     && apt-get clean \

--- a/docker/DockerfileSlim
+++ b/docker/DockerfileSlim
@@ -39,6 +39,7 @@ ENV PATH=/usr/local/bin:/root/.local/bin:/tmp/.local/bin:$PATH
 
 # Install system dependencies
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends ca-certificates wget curl git jq unzip unixodbc xmlsec1 gnupg lsb-release libgnutls30t64 libgcrypt20 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/DockerfileSlimEe
+++ b/docker/DockerfileSlimEe
@@ -39,6 +39,7 @@ ENV PATH=/usr/local/bin:/root/.local/bin:/tmp/.local/bin:$PATH
 
 # Install system dependencies
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends ca-certificates wget curl git jq unzip unixodbc xmlsec1 gnupg lsb-release libgnutls30t64 libgcrypt20 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/docs/docker-security.md
+++ b/docs/docker-security.md
@@ -1,0 +1,65 @@
+# Docker base-OS security patching
+
+The runtime images are built on `debian:trixie-slim` (Debian stable). The base
+runtime stages run `apt-get update && apt-get upgrade -y && apt-get install …`
+so that base-OS packages pick up Debian security and point-release fixes at
+build time, instead of staying frozen at whatever versions the base tag shipped.
+
+## Where the upgrade lives
+
+`apt-get upgrade -y` is applied in the first apt block of the three stages that
+establish a runtime Debian layer:
+
+- `Dockerfile` (the primary `windmill` / `windmill-ee` image)
+- `docker/DockerfileSlim` (`windmill-slim`)
+- `docker/DockerfileSlimEe` (`windmill-ee-slim`)
+
+Every other runtime image inherits its base OS from one of these transitively,
+so patching here is sufficient:
+
+- `DockerfileFull`, `DockerfileFullEe`, `DockerfileCuda` build `FROM` the primary
+  `windmill` / `windmill-ee` image.
+- `DockerfileExtra` builds `FROM windmill-ee-slim`.
+
+The nsjail *builder* stages are throwaway (only the compiled `nsjail` binary is
+copied out), so they are intentionally not upgraded. `DockerfileMultiplayer`
+(`node:slim`), the CLI, Caddy-L4, CUDA-only, and RHEL/dnf images are out of scope
+for this apt-based patching.
+
+## Why `apt-get upgrade` and not `unattended-upgrades` / pinning
+
+Debian stable's archive only receives security updates and ABI-stable point
+releases (e.g. `openssl 3.0.x → 3.0.x+deb12u2`, same soname). It does not ship
+feature/major bumps, so a build-time `apt-get upgrade` cannot silently break a
+pinned runtime dependency the way it might on a rolling distro. The default
+`debian.sources` already includes the `*-security` suite, so a plain upgrade
+picks up security fixes without extra machinery. `unattended-upgrades` adds a
+package and config for no benefit in a build context (it does not run at build
+time), and a pinned base digest would freeze the CVEs in place.
+
+Note the runtime apt installs were already unpinned (only the throwaway nsjail
+builder pins versions), so these images were never byte-for-byte reproducible in
+this dimension; `upgrade` moves the same already-floating packages to their
+patched versions rather than changing the reproducibility posture.
+
+## Caching and freshness
+
+`apt-get upgrade` sits in the same `RUN` as `apt-get update && install`. Docker
+keys that layer on the command string plus the parent layer, not on package
+contents, so an unchanged build is a cache hit and the upgrade does not re-run.
+The layer is invalidated — and fresh patches are pulled — when the parent layer
+changes, primarily when the mutable `debian:trixie-slim` base digest moves on a
+Debian point release. That self-aligns: the cache refreshes when there is
+something new to pick up.
+
+Because of apt-cache staleness, a security fix that lands between base-digest
+bumps will not be picked up by a cached build until the next bump. To close that
+gap, rebuild and republish the `latest` / patch tags:
+
+- on each Debian point release (base digest bump), and
+- on a periodic cadence (e.g. per Windmill release), rebuilding the base stages
+  with `--no-cache` if you need to force a fresh `apt-get upgrade` regardless of
+  the base digest.
+
+Scan the published images (e.g. Trivy / Defender) after rebuilds to confirm the
+base-OS finding count stays low.


### PR DESCRIPTION
## Summary

Self-hosters building the Windmill runtime images accumulate unpatched base-OS CVEs even on fresh builds: the Dockerfiles run `apt-get update && install` but never `apt-get upgrade`, so base packages stay frozen at whatever the base image shipped and never pick up Debian security/point-release fixes (a Defender scan of a slim tag found ~493 base-OS findings with fixes available).

This is an alternative to #10097. It applies the same in-build `apt-get upgrade` idea, but corrects its scope: #10097 patches only the two slim Dockerfiles and states that Full/Extra inherit the fix. That is only true for `DockerfileExtra` (`FROM windmill-ee-slim`). The **primary `windmill` / `windmill-ee` image is built from the root `./Dockerfile`**, and `DockerfileFull` / `DockerfileFullEe` / `DockerfileCuda` build `FROM windmill:dev` / `windmill-ee:dev` (that root image) — none of which #10097 touches. So the flagship and heavy images would stay unpatched. (The `linux-libc-dev` / kernel findings in the scan actually trace to `build-essential` in the root Dockerfile, not slim.)

This PR instead patches the **three stages that establish a runtime Debian layer**, which transitively covers every downstream image.

## Changes

- Add `apt-get upgrade -y` to the first apt block of the runtime base stages:
  - `Dockerfile` (primary `windmill` / `windmill-ee`)
  - `docker/DockerfileSlim` (`windmill-slim`)
  - `docker/DockerfileSlimEe` (`windmill-ee-slim`)
- Downstream images inherit the patched base transitively: Full/FullEe/Cuda `FROM` the primary image; Extra `FROM windmill-ee-slim`. No changes needed there.
- Existing `apt-get clean && rm -rf /var/lib/apt/lists/*` cleanup is preserved in each block.
- Add `docs/docker-security.md` documenting the mechanism, the Debian-stable rationale, caching behavior, and the rebuild/scan cadence.

## Why `apt-get upgrade` (not unattended-upgrades / pinning)

- Debian **stable** only ships security + ABI-stable point releases (e.g. `openssl 3.0.x → 3.0.x+deb12u2`, same soname), so a build-time upgrade cannot silently break a pinned runtime dep the way it might on a rolling distro. Nothing that matters is apt-pinned in the runtime stages anyway (PowerShell/Go/kubectl/helm/uv/bun/crane come from pinned tarballs/tags).
- The runtime apt installs were already unpinned, so these images were never byte-for-byte reproducible in this dimension; upgrade moves the same already-floating packages to their patched versions.
- `unattended-upgrades` adds a package + config for no benefit at build time; a pinned base digest would freeze the CVEs in place.

## Caching / reproducibility

`apt-get upgrade` sits in the same `RUN` as `update && install`. Docker keys that layer on the command string + parent layer, not package contents — so unchanged builds are a cache hit and it does not re-run or thrash the cache. The layer refreshes (and pulls fresh patches) when the parent changes, primarily when the mutable `debian:trixie-slim` base digest moves on a Debian point release — self-aligning with when new fixes exist. The remaining apt-cache staleness gap is closed by the rebuild cadence documented in `docs/docker-security.md`.

## Scope

Out of scope, intentionally untouched: nsjail *builder* stages (throwaway), `DockerfileMultiplayer` (`node:slim`, no apt block), CLI, CaddyL4, CUDA-only extras, and RHEL/dnf images.

## Test plan

- [ ] CI builds all images (root, slim, ee-slim, full, ee-full, extra, cuda) successfully with the added `apt-get upgrade`.
- [ ] Scan a rebuilt `windmill` / `windmill-slim` / `windmill-ee-slim` image (Trivy/Defender) and confirm base-OS finding count drops vs. the current published tags.
- [ ] Confirm image size delta is negligible (upgrade replaces packages in-layer; cleanup preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `apt-get upgrade` in all runtime Debian base stages so fresh builds pick up security and point‑release fixes and reduce base‑OS CVEs across `windmill` images. Adds `docs/docker-security.md` to document the approach and rebuild cadence.

- **Bug Fixes**
  - Added `apt-get upgrade -y` to the first apt block in `Dockerfile`, `docker/DockerfileSlim`, and `docker/DockerfileSlimEe`.
  - Downstream images (`Full`, `FullEe`, `Cuda`, `Extra`) inherit the patched base via their `FROM` chains; no changes needed.
  - Kept `apt-get clean && rm -rf /var/lib/apt/lists/*`; cache behavior remains stable.

<sup>Written for commit eca30ddf8bfc556ffc29829856742a6931d90bde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

