### PR TITLE
fix(tree-view): align file indentation with sibling folders

### DIFF
--- a/frontend/src/lib/components/common/table/Row.svelte
+++ b/frontend/src/lib/components/common/table/Row.svelte
@@ -150,6 +150,10 @@
 		}}
 	></div>
 {/if}
+<!-- Tree-view alignment: a folder header's icon sits at px-4 (16px) + its inner
+     padding-left of depth*16, i.e. (depth+1)*16. This row's inline padding-left
+     overrides px-4, so it must carry the full (depth+1)*16 for a file to line up
+     with its sibling folder at the same depth. -->
 <div
 	bind:this={rowEl}
 	class={twMerge(
@@ -159,7 +163,7 @@
 		clickToSelect ? 'cursor-pointer select-none' : '',
 		selected ? 'bg-surface-accent-selected' : keyboardSelected ? 'bg-gray-200 dark:bg-gray-700' : ''
 	)}
-	style={depth > 0 ? `padding-left: ${depth * 32}px;` : ''}
+	style={depth > 0 ? `padding-left: ${(depth + 1) * 16}px;` : ''}
 	role={clickToSelect ? 'button' : undefined}
 	tabindex={clickToSelect ? 0 : undefined}
 	onclick={handleRowClick}


### PR DESCRIPTION
## Summary

In the tree view, file rows were indented progressively further than their sibling folder rows at each nesting level (issue #9726). This fixes the alignment so a file lines up exactly with a folder at the same depth.

**Root cause.** A tree-view folder header (`TreeView.svelte`, and the `Dev.svelte` picker) places its icon inside `px-4` (16px) **plus** an inner `padding-left: depth*16`, giving an effective indent of `(depth+1)*16`. But `Row.svelte`'s inline `padding-left` *overrides* the `px-4` entirely, so a file row only ever got the raw inline value.

- Old `depth*32`: aligns only coincidentally at depth 1, then drifts +16px further right per level (the reported bug).
- The `depth*16` value proposed in #9861 overcorrects — files land 16px *left* of their sibling folders at every depth.
- Correct: **`(depth+1)*16`** reproduces the folder's `px-4 + depth*16` geometry, so files align at every depth.

Verified by measuring icon x-positions in the running app:

| depth | folder icon | file `depth*32` (before) | file `(depth+1)*16` (after) |
|---|---|---|---|
| 1 | 278 | 278 ✓ | 278 ✓ |
| 2 | 294 | 310 ✗ (+16) | 294 ✓ |
| 3 | 310 | 342 ✗ (+32) | 310 ✓ |

`Row.svelte` receives `depth>0` from exactly two places — the home `TreeView` and the `Dev.svelte` picker — both of which use the identical folder-header geometry, so this also corrects the picker tree. All other `Row`/`*Row` callers leave `depth` at `0` (inline style empty, `px-4` unchanged).

## Changes

- `frontend/src/lib/components/common/table/Row.svelte`: tree-view row indentation `depth * 32` → `(depth + 1) * 16`, with a comment recording the coupling to the folder-header `px-4 + depth*16` geometry.

## Screenshots

Nested folders/scripts, four levels deep, Tree view expanded:

**Before** — file icons staircase right of their sibling folders (`script_c` far right of `sub3`):

![tree-before](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/treeview-file-indentation/1784072987-tree-before.png)

**After** — each file icon aligns with its sibling folder at the same depth:

![tree-after](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/treeview-file-indentation/1784072990-tree-after.png)

## Test plan

- [ ] Home → enable **Tree view** → **Expand all** on a workspace with folders nested several levels deep
- [ ] Confirm each file icon aligns horizontally with sibling folder icons at the same depth
- [ ] Confirm root-level (depth 0) rows and collapse/expand behavior are unchanged
- [ ] Confirm the `Dev.svelte` script/flow picker tree still aligns correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tree-view indentation so file rows align with sibling folders at every nesting level. Updates row padding to mirror folder header spacing and remove the 16px drift.

- **Bug Fixes**
  - In `frontend/src/lib/components/common/table/Row.svelte`, set `padding-left` to `(depth + 1) * 16` instead of `depth * 32` to match folder header `px-4 + depth*16`.
  - Also corrects alignment in the `Dev.svelte` picker tree.

<sup>Written for commit 97d1117438f18fe9c18c135d1846da9772beca77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

