### PR TITLE
fix(mcp): advertise flow input variables in MCP tools

### DIFF
--- a/backend/windmill-mcp/src/common/schema.rs
+++ b/backend/windmill-mcp/src/common/schema.rs
@@ -376,6 +376,36 @@ mod tests {
     use serde_json::json;
     use std::collections::HashMap;
 
+    fn raw_schema(raw: &str) -> Option<Schema> {
+        Some(serde_json::from_str::<Schema>(raw).unwrap())
+    }
+
+    #[test]
+    fn flow_schema_without_required_keeps_properties() {
+        // Real flow input schema shape (see backend/tests/worker.rs): it omits
+        // `required` and carries an `order` key instead. This shape must keep its
+        // properties, not fall back to an empty schema, so MCP flow tools still
+        // advertise their inputs.
+        let flow = raw_schema(
+            r#"{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"world":{"type":"string"}},"type":"object","order":["world"]}"#,
+        );
+        let schema_type = convert_schema_to_schema_type(flow);
+        assert_eq!(schema_type.r#type, "object");
+        assert!(schema_type.properties.contains_key("world"));
+        assert!(schema_type.required.is_empty());
+    }
+
+    #[test]
+    fn script_schema_with_required_keeps_properties() {
+        // Script schemas always include `required`; this must remain unaffected.
+        let script = raw_schema(
+            r#"{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"world":{"type":"string"}},"required":["world"],"type":"object"}"#,
+        );
+        let schema_type = convert_schema_to_schema_type(script);
+        assert!(schema_type.properties.contains_key("world"));
+        assert_eq!(schema_type.required, vec!["world".to_string()]);
+    }
+
     fn aws_resources() -> (HashMap<String, Vec<ResourceInfo>>, Vec<ResourceType>) {
         let mut cache = HashMap::new();
         cache.insert(
@@ -965,9 +995,11 @@ mod tests {
         make_schema_compatible(&mut schema);
 
         assert_eq!(schema["properties"]["services"]["type"], json!("array"));
-        assert!(schema["properties"]["services"]["items"]["properties"]["value"]
-            .get("type")
-            .is_none());
+        assert!(
+            schema["properties"]["services"]["items"]["properties"]["value"]
+                .get("type")
+                .is_none()
+        );
         assert_all_types_valid(&schema);
     }
 }

--- a/backend/windmill-mcp/src/common/types.rs
+++ b/backend/windmill-mcp/src/common/types.rs
@@ -53,12 +53,24 @@ pub struct HubScriptInfo {
 }
 
 /// Schema type structure for JSON schemas
+///
+/// The `#[serde(default)]` attributes are load-bearing: flow input schemas
+/// legitimately omit `required` (they carry an `order` key instead) and can omit
+/// `type`. Without the defaults, `serde_json::from_str::<SchemaType>` errors on
+/// those schemas and callers fall back to an empty schema, dropping every input.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[cfg_attr(feature = "server", derive(FromRow))]
 pub struct SchemaType {
+    #[serde(default = "default_schema_type")]
     pub r#type: String,
+    #[serde(default)]
     pub properties: HashMap<String, Value>,
+    #[serde(default)]
     pub required: Vec<String>,
+}
+
+fn default_schema_type() -> String {
+    "object".to_string()
 }
 
 impl Default for SchemaType {


### PR DESCRIPTION
## Summary

MCP flow tools advertised no input variables, while scripts worked correctly. Root cause: flow input schemas legitimately omit `required` (they carry an `order` key instead), so `serde_json::from_str::<SchemaType>` failed in `convert_schema_to_schema_type`. The error was swallowed and callers fell back to an empty `SchemaType::default()`, dropping every input from the tool's `inputSchema`. Scripts always include `"required": []` in their schema, so they were unaffected.

The flow still *ran* fine when called with arguments (the schema is only used for discovery/advertising here), which is why the UI was unaffected and why wrapping the flow in a script worked as a workaround.

## Changes

- `types.rs`: add `#[serde(default)]` to `type`, `properties`, and `required` on `SchemaType`, so flow schemas that omit those fields deserialize correctly instead of falling back to an empty schema. `type` defaults to `"object"`, consistent with the existing `Default` impl. Extra keys (`order`, `$schema`) are already ignored by serde.
- `schema.rs`: add two regression tests exercising both branches, a flow schema without `required` (keeps its properties) and a script schema with `required` (unaffected).

## Test plan

- [x] `cargo test -p windmill-mcp --lib` — both new tests pass, all pre-existing schema tests green
- [x] Crate compiles with `--features server` (confirms serde defaults don't conflict with the `FromRow` derive)
- [ ] End-to-end: invoke an MCP flow tool for a flow whose input schema omits `required` and confirm the advertised tool now exposes the input variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP flow tools not advertising input variables by correctly parsing flow input schemas that omit "required". Tools now show the expected inputs; runtime behavior is unchanged.

- **Bug Fixes**
  - Added `#[serde(default)]` on `SchemaType` fields `type`, `properties`, and `required` (default `type` to "object") to prevent fallback to an empty schema.
  - Kept properties when converting schemas; extra keys like `order` and `$schema` are ignored as before.
  - Added regression tests for a flow schema without `required` and a script schema with `required`.

<sup>Written for commit 56623b0bae02e6f2d337cd6f9bcc56aec5fcefb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

