### PR TITLE
ci: cap build jobs and disable incremental in backend tests to prevent OOM

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -245,7 +245,19 @@ jobs:
           RUST_LOG: "off"
           RUST_LOG_STYLE: never
           CARGO_NET_GIT_FETCH_WITH_CLI: true
-          CARGO_BUILD_JOBS: 12
+          # Cap parallel rustc/link jobs below the 16 available cores. The tail of
+          # the build links ~128 full-graph test binaries (one per tests/*.rs file
+          # across the workspace); at high parallelism enough heavy codegen+link
+          # units (rustc ~2.6GB, mold ~1GB each) overlap to exhaust the 64GB
+          # runner. Matches backend-test-windows.yml, which already uses 8.
+          CARGO_BUILD_JOBS: 8
+          # Incremental compilation is per-run dead weight in CI: rust-cache
+          # (cache-workspaces above) restores compiled dependency artifacts but
+          # never persists target/**/incremental, so there is no prior state to
+          # reuse in a one-shot `cargo test`. It only adds per-crate memory
+          # overhead and extra disk. Off here (kept on for local dev via
+          # .cargo/config.toml). Matches backend-test-windows.yml.
+          CARGO_INCREMENTAL: "0"
           # backend/Cargo.toml leaves profile.dev at the default debug = 2 for
           # the (large) windmill workspace crates; that debug info is emitted
           # into every object file and embedded in each test binary. Across the


### PR DESCRIPTION
## Summary

The `backend-test.yml` (Linux) `cargo test` job intermittently fails with runner OOM (surfaced as a "lost runner" / canceled step). The recent debuginfo drop (#10088) helped but did not address the dominant driver: `cargo test --all` builds and links **~128 full-graph test binaries** (one per `tests/*.rs` across the workspace — 55 in the main crate, 47 in `windmill-api-integration-tests`, plus others), each statically linking `windmill-api` + `windmill-worker` + `windmill-common` (+ v8 under the CI feature set). At the tail of the build, enough heavy codegen+link units overlap (measured ~2.6GB rustc and ~1GB mold each, larger with v8) to exhaust the 64GB `ubicloud-standard-16` runner.

This PR applies two low-risk knobs that the sibling **`backend-test-windows.yml`** job already uses, bringing the Linux job in line with it:

- **`CARGO_BUILD_JOBS: 12 → 8`** — caps how many heavy codegen+link units run concurrently in the tail, lowering peak memory. (Windows already uses 8.)
- **`CARGO_INCREMENTAL: "0"`** — incremental compilation is dead weight in CI: `rust-cache` (via `cache-workspaces`) restores compiled *dependency* artifacts but never persists `target/**/incremental`, so a one-shot `cargo test` has no prior state to reuse. It only adds per-crate memory overhead and disk. Local dev keeps incremental on via `.cargo/config.toml`. (Windows already sets this.)

This is the fast-relief pair. A structural follow-up (consolidating the per-file test binaries into fewer binaries) is being evaluated separately.

## Changes
- `.github/workflows/backend-test.yml`: set `CARGO_BUILD_JOBS: 8` (was 12) and add `CARGO_INCREMENTAL: "0"` to the `cargo test` step env, each with an explanatory comment.

## Test plan
- [ ] CI `Backend only integration tests` job completes without OOM / lost-runner.
- [ ] Job stays within the 30-minute timeout at `-j8` (deps are cached, so most wall-time is workspace + test compile).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent OOM in Linux backend tests by setting CARGO_BUILD_JOBS to 8 and CARGO_INCREMENTAL to 0 in backend-test.yml, matching the Windows workflow. This reduces peak memory during heavy codegen/linking of many test binaries and stabilizes the CI job.

<sup>Written for commit 15e9ebbcb72dfff48c680aec75faa707717b8f6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

