### PR TITLE
ci: pin cpina/github-action-push-to-another-repository@devel to a full commit SHA

### DIFF
--- a/.github/workflows/go_on_release.yml
+++ b/.github/workflows/go_on_release.yml
@@ -27,7 +27,7 @@ jobs:
           go build
       - name: Pushes to another repository
         id: push_directory
-        uses: cpina/github-action-push-to-another-repository@devel
+        uses: cpina/github-action-push-to-another-repository@55306faa4ed53b815ae49e564af8cfb359d32ae2 # v1.7.3
         env:
           API_TOKEN_GITHUB: ${{ secrets.DENO_PAT }}
         with:


### PR DESCRIPTION
Hi, and thank you for Windmill.

Small supply-chain hardening for the Go release workflow. In `.github/workflows/go_on_release.yml`, the "Pushes to another repository" step uses the third-party action `cpina/github-action-push-to-another-repository@devel`. `@devel` is a mutable branch, so whatever code lives at that ref runs when the release job executes — and that step is handed `secrets.DENO_PAT`, a write-scoped token used to push the generated `go-client` into another repo.

If that upstream branch were repointed or compromised, the action could read the PAT on the next tagged release (the same class of risk as the `tj-actions/changed-files` incident). This PR pins the action to a full commit SHA — I used the current latest release `v1.7.3` (`55306fa`) — which removes the mutable-ref exposure and matches how the other actions in the repo are already pinned. If you'd rather preserve the exact current `@devel` behaviour, I'm happy to pin to the current `devel` head SHA instead — just let me know.

I'm glad to sign the CLA (I'll follow the CLAssistant prompt on this PR). Happy to adjust anything.

For transparency: I used AI assistance to help identify this and draft the change; I verified every line against the live workflow myself.
