### PR TITLE
fix(ai): disable redirects on worker AI provider client (GHSA-5q4v)

### DIFF
--- a/backend/windmill-ai/src/utils.rs
+++ b/backend/windmill-ai/src/utils.rs
@@ -2,8 +2,23 @@ use crate::{
     ai_providers::AIProvider,
     ai_types::{ContentPart, OpenAIContent},
 };
+use windmill_common::utils::configure_client;
 
 lazy_static::lazy_static! {
+    /// HTTP client for requests to user-configured AI provider endpoints. Must be
+    /// used instead of the shared `HTTP_CLIENT` for anything targeting a provider
+    /// `base_url`. SSRF validation on `base_url` is single-shot (see
+    /// `AIProvider::get_base_url`), so redirects MUST stay disabled: otherwise a
+    /// validated public host could 3xx the worker into a private/internal address.
+    /// AI APIs respond directly, so this holds even for ALLOW_PRIVATE_AI_BASE_URLS.
+    /// Mirrors the API proxy client (windmill-api/src/ai.rs, GHSA-5q4v-c4v3-v7wr).
+    pub static ref AI_HTTP_CLIENT: reqwest::Client = configure_client(reqwest::ClientBuilder::new()
+        .user_agent("windmill/beta")
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .redirect(reqwest::redirect::Policy::none()))
+        .build()
+        .expect("Failed to build AI HTTP client - check system TLS configuration");
+
     /// Parse AI_HTTP_HEADERS environment variable into a vector of (header_name, header_value) tuples
     /// Format: "header1: value1, header2: value2"
     pub static ref AI_HTTP_HEADERS: Vec<(String, String)> = {
@@ -52,5 +67,45 @@ pub fn extract_text_content(content: &OpenAIContent) -> String {
             })
             .collect::<Vec<_>>()
             .join(""),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    /// Regression test for GHSA-5q4v-c4v3-v7wr: `AI_HTTP_CLIENT` must not follow redirects.
+    #[tokio::test]
+    async fn ai_http_client_does_not_follow_redirects() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Serve a single 302 to the link-local metadata address; the client must
+        // surface the 302 rather than connect onward to it.
+        tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                let mut buf = [0u8; 1024];
+                let _ = socket.read(&mut buf).await;
+                let response = "HTTP/1.1 302 Found\r\n\
+                    Location: http://169.254.169.254/latest/meta-data\r\n\
+                    Content-Length: 0\r\n\r\n";
+                let _ = socket.write_all(response.as_bytes()).await;
+                let _ = socket.flush().await;
+            }
+        });
+
+        let resp = AI_HTTP_CLIENT
+            .get(format!("http://{}/", addr))
+            .send()
+            .await
+            .expect("request should succeed without following the redirect");
+
+        assert_eq!(
+            resp.status().as_u16(),
+            302,
+            "AI HTTP client must surface the redirect response, not follow it"
+        );
     }
 }

--- a/backend/windmill-ai/src/utils.rs
+++ b/backend/windmill-ai/src/utils.rs
@@ -5,19 +5,40 @@ use crate::{
 use windmill_common::utils::configure_client;
 
 lazy_static::lazy_static! {
+    /// Debug escape hatch: when set, `AI_HTTP_CLIENT` follows redirects again. Off by
+    /// default because SSRF validation on `base_url` is single-shot, so a redirect can
+    /// bounce a validated public host into a private/internal one (GHSA-5q4v-c4v3-v7wr).
+    /// Only enable to debug a non-standard/self-hosted gateway you control.
+    pub static ref ALLOW_AI_BASE_URL_REDIRECTS: bool = std::env::var("ALLOW_AI_BASE_URL_REDIRECTS")
+        .ok()
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false);
+
     /// HTTP client for requests to user-configured AI provider endpoints. Must be
     /// used instead of the shared `HTTP_CLIENT` for anything targeting a provider
     /// `base_url`. SSRF validation on `base_url` is single-shot (see
-    /// `AIProvider::get_base_url`), so redirects MUST stay disabled: otherwise a
-    /// validated public host could 3xx the worker into a private/internal address.
-    /// AI APIs respond directly, so this holds even for ALLOW_PRIVATE_AI_BASE_URLS.
-    /// Mirrors the API proxy client (windmill-api/src/ai.rs, GHSA-5q4v-c4v3-v7wr).
-    pub static ref AI_HTTP_CLIENT: reqwest::Client = configure_client(reqwest::ClientBuilder::new()
-        .user_agent("windmill/beta")
-        .connect_timeout(std::time::Duration::from_secs(10))
-        .redirect(reqwest::redirect::Policy::none()))
-        .build()
-        .expect("Failed to build AI HTTP client - check system TLS configuration");
+    /// `AIProvider::get_base_url`), so redirects stay disabled unless the
+    /// `ALLOW_AI_BASE_URL_REDIRECTS` escape hatch is set: otherwise a validated public
+    /// host could 3xx the worker into a private/internal address. AI APIs respond
+    /// directly, so this holds even for ALLOW_PRIVATE_AI_BASE_URLS. Mirrors the API
+    /// proxy client (windmill-api/src/ai.rs, GHSA-5q4v-c4v3-v7wr).
+    pub static ref AI_HTTP_CLIENT: reqwest::Client = {
+        let redirect = if *ALLOW_AI_BASE_URL_REDIRECTS {
+            tracing::warn!(
+                "ALLOW_AI_BASE_URL_REDIRECTS is enabled - the AI HTTP client will follow \
+                 redirects, weakening SSRF protection on provider base URLs"
+            );
+            reqwest::redirect::Policy::default()
+        } else {
+            reqwest::redirect::Policy::none()
+        };
+        configure_client(reqwest::ClientBuilder::new()
+            .user_agent("windmill/beta")
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .redirect(redirect))
+            .build()
+            .expect("Failed to build AI HTTP client - check system TLS configuration")
+    };
 
     /// Parse AI_HTTP_HEADERS environment variable into a vector of (header_name, header_value) tuples
     /// Format: "header1: value1, header2: value2"

--- a/backend/windmill-ai/src/utils.rs
+++ b/backend/windmill-ai/src/utils.rs
@@ -14,14 +14,10 @@ lazy_static::lazy_static! {
         .map(|v| v == "true" || v == "1")
         .unwrap_or(false);
 
-    /// HTTP client for requests to user-configured AI provider endpoints. Must be
-    /// used instead of the shared `HTTP_CLIENT` for anything targeting a provider
-    /// `base_url`. SSRF validation on `base_url` is single-shot (see
-    /// `AIProvider::get_base_url`), so redirects stay disabled unless the
-    /// `ALLOW_AI_BASE_URL_REDIRECTS` escape hatch is set: otherwise a validated public
-    /// host could 3xx the worker into a private/internal address. AI APIs respond
-    /// directly, so this holds even for ALLOW_PRIVATE_AI_BASE_URLS. Mirrors the API
-    /// proxy client (windmill-api/src/ai.rs, GHSA-5q4v-c4v3-v7wr).
+    /// HTTP client for anything targeting a user-configured AI provider `base_url`;
+    /// use it instead of the shared `HTTP_CLIENT`. Redirects are governed by
+    /// `ALLOW_AI_BASE_URL_REDIRECTS` (disabled by default). Mirrors the API proxy
+    /// client (windmill-api/src/ai.rs).
     pub static ref AI_HTTP_CLIENT: reqwest::Client = {
         let redirect = if *ALLOW_AI_BASE_URL_REDIRECTS {
             tracing::warn!(

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -986,9 +986,8 @@ pub async fn run_agent(
 
             // Helper to build HTTP request with headers
             let build_http_request = |body: String| {
-                // `endpoint` is derived from the user-controlled provider base_url, so it
-                // MUST go through AI_HTTP_CLIENT (redirects disabled by default), not the
-                // shared HTTP_CLIENT which always follows them. See AI_HTTP_CLIENT.
+                // `endpoint` derives from the user-controlled provider base_url: use
+                // AI_HTTP_CLIENT, not the shared HTTP_CLIENT. See AI_HTTP_CLIENT.
                 let mut req = AI_HTTP_CLIENT
                     .post(&endpoint)
                     .timeout(timeout)

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -987,7 +987,8 @@ pub async fn run_agent(
             // Helper to build HTTP request with headers
             let build_http_request = |body: String| {
                 // `endpoint` is derived from the user-controlled provider base_url, so it
-                // MUST go through the redirect-disabled AI_HTTP_CLIENT, not HTTP_CLIENT.
+                // MUST go through AI_HTTP_CLIENT (redirects disabled by default), not the
+                // shared HTTP_CLIENT which always follows them. See AI_HTTP_CLIENT.
                 let mut req = AI_HTTP_CLIENT
                     .post(&endpoint)
                     .timeout(timeout)

--- a/backend/windmill-worker/src/ai_executor.rs
+++ b/backend/windmill-worker/src/ai_executor.rs
@@ -26,7 +26,7 @@ use windmill_ai::{
     providers::create_query_builder,
     query_builder::{BuildRequestArgs, ParsedResponse},
     types::*,
-    utils::{should_use_structured_output_tool, AI_HTTP_HEADERS},
+    utils::{should_use_structured_output_tool, AI_HTTP_CLIENT, AI_HTTP_HEADERS},
 };
 use windmill_common::{
     cache,
@@ -986,7 +986,9 @@ pub async fn run_agent(
 
             // Helper to build HTTP request with headers
             let build_http_request = |body: String| {
-                let mut req = HTTP_CLIENT
+                // `endpoint` is derived from the user-controlled provider base_url, so it
+                // MUST go through the redirect-disabled AI_HTTP_CLIENT, not HTTP_CLIENT.
+                let mut req = AI_HTTP_CLIENT
                     .post(&endpoint)
                     .timeout(timeout)
                     .header("Content-Type", "application/json");


### PR DESCRIPTION
## Summary

Fixes the SSRF advisory **GHSA-5q4v-c4v3-v7wr**. A low-privileged AI-provider resource writer could bypass private-endpoint SSRF protection because the **worker** AI request path followed HTTP redirects into private hosts.

SSRF validation on a provider `base_url` is single-shot (`AIProvider::get_base_url` → `validate_url_for_ssrf`), but the worker then issued the request with the shared `windmill_common::utils::HTTP_CLIENT`, which sets no redirect policy. reqwest's default follows up to 10 redirects without revalidating each hop, so a public-looking `base_url` that 3xx-redirects to `127.0.0.1` / `169.254.169.254` (cloud metadata) got followed into the internal host, forwarding attacker-chosen headers. `ALLOW_PRIVATE_AI_BASE_URLS` being off did not help.

The API proxy was already hardened in #9370 (`windmill-api/src/ai.rs` uses `reqwest::redirect::Policy::none()`); the worker path was missed. This PR mirrors that fix.

## Changes

- Add a dedicated `AI_HTTP_CLIENT` lazy_static in `backend/windmill-ai/src/utils.rs`, built via `configure_client(...).redirect(reqwest::redirect::Policy::none())` (also preserves `FORCE_IPV4`). Redirects are disabled unconditionally, which holds even for `ALLOW_PRIVATE_AI_BASE_URLS` deployments since AI APIs respond directly.
- `backend/windmill-worker/src/ai_executor.rs` `build_http_request` — the only worker call targeting the user-controlled provider `endpoint` — now uses `AI_HTTP_CLIENT` instead of the redirect-following `HTTP_CLIENT`.
- Add a Tokio regression test that stands up a loopback listener returning a `302` to the link-local metadata address and asserts the client surfaces the `302` rather than following it.

### Left unchanged (verified internal-only)
- `ai_executor.rs:397` — Hub-script fetch against Windmill's own hub, not the user `base_url`.
- `ai/utils.rs` OAuth token refresh — targets `windmill_common::BASE_URL` (internal).
- `handle_google_ai_chat_proxy` / `handle_google_ai_models_proxy` take a client param and are only called from `windmill-api/src/ai.rs` with the already-fixed API client. The worker's Google path goes through `build_http_request`, so it is covered. Bedrock uses the AWS SDK (region-scoped endpoints), a separate surface.

## Test plan

- [x] `cargo check -p windmill-ai -p windmill-worker --tests --features quickjs` — clean
- [x] `cargo test -p windmill-ai ai_http_client_does_not_follow_redirects` — passes
- [ ] (optional e2e) Configure an AI provider whose `base_url` returns a 3xx to an internal host; confirm the worker AI step surfaces the redirect response instead of connecting onward.

No SQL / API-surface changes (no `update_sqlx` / openapi regeneration needed). No `*_ee.rs` files touched, so no EE companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables HTTP redirects for worker requests to user‑configured AI providers to close the SSRF bypass (GHSA-5q4v-c4v3-v7wr). Redirects now return 3xx to the caller instead of being followed to private hosts.

- **Bug Fixes**
  - Added `AI_HTTP_CLIENT` with redirects disabled (`reqwest::redirect::Policy::none()`) and switched worker provider `endpoint` requests to use it, mirroring the API proxy policy.
  - Added `ALLOW_AI_BASE_URL_REDIRECTS` escape hatch to re-enable redirects for debugging; default off with a startup warning. Condensed comments and anchored the SSRF rationale to this override.
  - Added a regression test ensuring a 302 to link‑local metadata is surfaced, not followed.

<sup>Written for commit a7f5693d944fc32eb45c94f3b8440f4e258d2556. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

