### PR TITLE
fix(security): enforce variables:write scope on resource-delete var cascade (GHSA-xmr2-98m6-cjf7)

### DIFF
--- a/backend/tests/ws_specific.rs
+++ b/backend/tests/ws_specific.rs
@@ -24,6 +24,39 @@ fn authed(builder: reqwest::RequestBuilder, token: &str) -> reqwest::RequestBuil
     builder.header("Authorization", format!("Bearer {}", token))
 }
 
+/// Helper: does a variable exist at (workspace, path)?
+async fn variable_exists(db: &Pool<Postgres>, workspace: &str, path: &str) -> anyhow::Result<bool> {
+    let n: Option<i64> =
+        sqlx::query_scalar("SELECT COUNT(*) FROM variable WHERE workspace_id = $1 AND path = $2")
+            .bind(workspace)
+            .bind(path)
+            .fetch_one(db)
+            .await?;
+    Ok(n.unwrap_or(0) > 0)
+}
+
+/// Helper: mint an API token restricted to `scopes`, using the admin SECRET_TOKEN.
+async fn mint_scoped_token(port: u16, scopes: Vec<&str>) -> anyhow::Result<String> {
+    let resp = authed(
+        client().post(format!("http://localhost:{port}/api/users/tokens/create")),
+        "SECRET_TOKEN",
+    )
+    .json(&json!({
+        "label": "scoped",
+        "scopes": scopes,
+        "workspace_id": "test-workspace",
+    }))
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        201,
+        "mint scoped token: {}",
+        resp.text().await?
+    );
+    Ok(resp.text().await?)
+}
+
 /// Helper: count rows in ws_specific for (workspace, kind, path).
 async fn ws_specific_row_count(
     db: &Pool<Postgres>,
@@ -351,6 +384,67 @@ async fn test_create_resource_upsert_clears_ws_specific(db: Pool<Postgres>) -> a
         .await?,
         1,
         "absent ws_specific field must leave the existing flag alone"
+    );
+
+    Ok(())
+}
+
+/// Regression for GHSA-xmr2-98m6-cjf7: a token scoped only to `resources:write:<r>`
+/// must NOT use the resource-delete cascade to delete a linked secret variable it has
+/// no `variables:write` scope for.
+#[sqlx::test(fixtures("ws_specific"))]
+async fn test_scoped_token_cannot_cascade_delete_linked_variable(
+    db: Pool<Postgres>,
+) -> anyhow::Result<()> {
+    initialize_tracing().await;
+    let server = ApiServer::start(db.clone()).await?;
+    let port = server.addr.port();
+    let base = format!("http://localhost:{port}/api/w/test-workspace");
+
+    let resp = authed(
+        client().post(format!("{base}/variables/create")),
+        "SECRET_TOKEN",
+    )
+    .json(&json!({
+        "path": "u/test-user/victim_secret",
+        "value": "hunter2",
+        "is_secret": true,
+        "description": ""
+    }))
+    .send()
+    .await?;
+    assert_eq!(resp.status(), 201, "create victim: {}", resp.text().await?);
+
+    let resp = authed(
+        client().post(format!("{base}/resources/create")),
+        "SECRET_TOKEN",
+    )
+    .json(&json!({
+        "path": "u/test-user/db",
+        "value": { "password": "$var:u/test-user/victim_secret" },
+        "resource_type": "object"
+    }))
+    .send()
+    .await?;
+    assert_eq!(resp.status(), 201, "create res: {}", resp.text().await?);
+
+    // resources:write only, no variables:write for the linked secret.
+    let scoped = mint_scoped_token(port, vec!["resources:write:u/test-user/db"]).await?;
+    let resp = authed(
+        client().delete(format!("{base}/resources/delete/u/test-user/db")),
+        &scoped,
+    )
+    .send()
+    .await?;
+    assert_eq!(
+        resp.status(),
+        403,
+        "scoped resource token must not cascade-delete the linked variable: {}",
+        resp.text().await?
+    );
+    assert!(
+        variable_exists(&db, "test-workspace", "u/test-user/victim_secret").await?,
+        "victim variable must survive the denied cascade"
     );
 
     Ok(())

--- a/backend/windmill-store/src/resources.rs
+++ b/backend/windmill-store/src/resources.rs
@@ -1239,6 +1239,9 @@ async fn delete_resource(
         collect_var_refs(value, &mut linked_var_paths);
     }
 
+    // A scoped token must not delete linked variables it lacks variables:write for.
+    check_linked_var_delete_scopes(&authed, &linked_var_paths)?;
+
     // Capture linked variables for trashbin before deleting them
     let trash_linked_vars: Vec<serde_json::Value> = if linked_var_paths.is_empty() {
         Vec::new()
@@ -1412,6 +1415,23 @@ fn collect_var_refs(value: &serde_json::Value, out: &mut Vec<String>) {
     }
 }
 
+/// Deleting a resource cascades into the `$var:` variables its value references. A
+/// scoped token must not use that cascade to delete variables it could not delete
+/// directly via `delete_variable` (which gates on `variables:write:<path>`), so require
+/// `variables:write` for EVERY linked variable and fail the whole delete otherwise.
+///
+/// No co-located-path exemption: a resource and a variable may share a path, and a
+/// resource-write token can create a resource over an existing standalone variable and
+/// self-reference it, so "same path as the deleted resource" is attacker-forgeable and
+/// cannot stand in for variable scope. No-op for unscoped tokens (`check_scopes` passes),
+/// so a full token's cascade cleanup is unchanged.
+fn check_linked_var_delete_scopes(authed: &ApiAuthed, linked_var_paths: &[String]) -> Result<()> {
+    for var_path in linked_var_paths {
+        check_scopes(authed, || format!("variables:write:{}", var_path))?;
+    }
+    Ok(())
+}
+
 /// Marks every variable referenced by the resource at `resource_path` as workspace-specific.
 ///
 /// AUTH CONTRACT: this mutates `ws_specific` and does NOT check authorization itself. The caller
@@ -1565,6 +1585,9 @@ async fn delete_resources_bulk(
     }
     linked_var_paths.sort();
     linked_var_paths.dedup();
+
+    // A scoped token must not delete linked variables it lacks variables:write for.
+    check_linked_var_delete_scopes(&authed, &linked_var_paths)?;
 
     sqlx::query!(
         "DELETE FROM ws_specific WHERE workspace_id = $1 AND item_kind = 'resource' AND path = ANY($2)",


### PR DESCRIPTION
## Summary

Fixes **GHSA-xmr2-98m6-cjf7**. A token scoped only to `resources:write:<path>` could delete linked secret **variables** it had no `variables:write` scope for: `delete_resource`/`delete_resources_bulk` recursively harvest every `$var:<path>` from the (attacker-controlled) resource JSON and `DELETE` those `variable` rows, with only a `resources:write` check. `delete_variable` itself gates on `variables:write:<path>`, so the cascade bypassed that boundary. #9712 tightened scoped-token boundaries broadly but missed this path.

## Fix

`check_linked_var_delete_scopes` requires `variables:write:<var>` for every linked variable before any delete, failing (and rolling back) otherwise. No-op for unscoped/full tokens, so normal cascade cleanup is unchanged; a token holding both `resources:write` + `variables:write` still cascades.

No co-located-path exemption: a resource and a variable may share a path, and a `resources:write` token can create a resource over an existing standalone variable and self-reference it, so "same path as the deleted resource" is attacker-forgeable and can't stand in for variable scope (per the Codex CI review of an earlier iteration).

Core change is ~23 lines; `update_resource`/`update_resource_value` have no `$var:` delete cascade and are unaffected. No SQL changes, no `*_ee.rs` touched.

## Test

`backend/tests/ws_specific.rs`: a `resources:write:<r>`-only token deleting a resource that references an out-of-scope `$var:` → **403**, variable survives; a full token still cascades. `cargo test --test ws_specific` passes.

(The `cargo_test` CI failure is an unrelated pre-existing flake: `ee::audit_s3_export::audit_export_end_to_end`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)