### PR TITLE
fix(cli-image): patch fixable CRITICAL CVEs in windmill-cli image (GIT-922)

### DIFF
--- a/docker/DockerfileCli
+++ b/docker/DockerfileCli
@@ -1,7 +1,15 @@
 FROM oven/bun:slim
 
-RUN bun install -g windmill-cli
+# Pick up upstream OS security fixes present in the base image (e.g. openssl CVE-2026-34182).
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN ln -s $(bun pm bin -g)/wmill /usr/bin/wmill
+# Install the CLI, then drop bun's package download cache: its cached manifests
+# (e.g. esrap's dev-only vitest devDependency) trip vulnerability scanners and are
+# unused at runtime.
+RUN bun install -g windmill-cli \
+    && ln -s $(bun pm bin -g)/wmill /usr/bin/wmill \
+    && rm -rf /root/.bun/install/cache
 
 ENTRYPOINT [ "wmill" ]


### PR DESCRIPTION
## Problem

`ghcr.io/windmill-labs/windmill-cli:latest` (built from `docker/DockerfileCli`) shipped two **fixable CRITICAL** findings reported in GIT-922:

| Package | CVE | Installed | Fixed in |
|---|---|---|---|
| `libssl3t64` / `openssl-provider-legacy` (OS) | CVE-2026-34182 | `3.5.5-1~deb13u2` | `3.5.6-1~deb13u2` |
| `vitest` (npm, transitive via `esrap`) | CVE-2026-47429 / GHSA-5xrq-8626-4rwp | `2.1.9` | `3.2.6` |

Both live in bundled OS/npm dependencies, not in the CLI logic.

## Fix

`docker/DockerfileCli`:

1. **openssl** — the stale packages come from the `oven/bun:slim` base image. An `apt-get update && apt-get -y upgrade` pulls in the patched Debian packages.
2. **vitest** — this is a dev-only `devDependency` reference inside `esrap`'s cached `package.json` sitting in bun's package **download cache** (`/root/.bun/install/cache`). The scanner reads it there; `vitest` itself is never installed. The cache has no purpose at runtime, so it is removed right after the install.

## Validation

Built the image locally and scanned it with Trivy (`--severity CRITICAL --pkg-types os,library`):

- `libssl3t64` / `openssl-provider-legacy` now report **`3.5.6-1~deb13u2`** (fixed) — no longer flagged.
- `vitest` is **entirely absent** from the image (confirmed no `vitest` directory installed; the only remaining library finding is `esbuild` GHSA-g7r4-m6w7-qqqr at LOW).
- `wmill --version` still runs correctly.

The only remaining CRITICALs after the fix are three `perl-base` CVEs (CVE-2026-13221, CVE-2026-42496, CVE-2026-8376) which have **no upstream fix available** (`fixed=(none)` in Debian trixie) and were not part of the original report — nothing actionable in the Dockerfile.

Fixes GIT-922

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GIT-922 by removing two fixable CRITICAL CVEs from the `ghcr.io/windmill-labs/windmill-cli` image. We upgrade OS packages and purge Bun’s cache; Trivy confirms `openssl` is patched and `vitest` is absent, with no runtime changes.

- **Bug Fixes**
  - OS: run `apt-get update && apt-get -y upgrade` to pull patched `libssl3t64`/`openssl-provider-legacy` (CVE-2026-34182 → `3.5.6-1~deb13u2`).
  - NPM: remove `/root/.bun/install/cache` to drop transitive dev-only `vitest@2.1.9` (CVE-2026-47429 / GHSA-5xrq-8626-4rwp) from the image.

<sup>Written for commit e3fd01940904eb59e09be5c048eecb770f1c02d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

