### PR TITLE
fix(frontend): only carry custom-tag overrides on 'Run again'

### DIFF
--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -538,4 +538,12 @@ describe('findMatchingCustomTag', () => {
 			findMatchingCustomTag('worker-gpu', ['worker-$args[env]'], workspace, { env: 'cpu' })
 		).toBeUndefined()
 	})
+
+	it('does not falsely match a template against the truncated-args placeholder', () => {
+		expect(
+			findMatchingCustomTag('worker-gpu', ['worker-$args[env]'], workspace, {
+				reason: 'WINDMILL_TOO_BIG'
+			})
+		).toBeUndefined()
+	})
 })

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -3,7 +3,10 @@ import {
 	cleanValueProperties,
 	computeSharableHash,
 	extractTagFromSharableHash,
+	findMatchingCustomTag,
+	interpolateTag,
 	isDynamicTag,
+	isTagTemplate,
 	getQueryStmtCountHeuristic,
 	parseDbInputFromAssetSyntax
 } from './utils'
@@ -449,5 +452,90 @@ describe('isDynamicTag', () => {
 		expect(isDynamicTag('$workspace-gpu')).toBe(false)
 		expect(isDynamicTag('')).toBe(false)
 		expect(isDynamicTag(undefined)).toBe(false)
+	})
+})
+
+describe('isTagTemplate', () => {
+	it('detects $workspace and $args placeholders', () => {
+		expect(isTagTemplate('deno-$workspace')).toBe(true)
+		expect(isTagTemplate('worker-$args[env]')).toBe(true)
+		expect(isTagTemplate('worker-$args[obj.env]')).toBe(true)
+	})
+
+	it('is false for plain tags, non-placeholder $ text, and undefined', () => {
+		expect(isTagTemplate('gpu-heavy')).toBe(false)
+		expect(isTagTemplate('price-$100')).toBe(false)
+		expect(isTagTemplate('$args[]')).toBe(false)
+		expect(isTagTemplate(undefined)).toBe(false)
+	})
+})
+
+describe('interpolateTag', () => {
+	it('replaces every $workspace occurrence', () => {
+		expect(interpolateTag('deno-$workspace-$workspace', 'staging', {})).toBe('deno-staging-staging')
+	})
+
+	it('resolves $args placeholders from string, number, and boolean args', () => {
+		const args = { env: 'prod', n: 3, ok: true }
+		expect(interpolateTag('w-$args[env]', 'ws', args)).toBe('w-prod')
+		expect(interpolateTag('w-$args[n]', 'ws', args)).toBe('w-3')
+		expect(interpolateTag('w-$args[ok]', 'ws', args)).toBe('w-true')
+	})
+
+	it('resolves dotted paths through nested objects', () => {
+		expect(interpolateTag('w-$args[conf.env]', 'ws', { conf: { env: 'prod' } })).toBe('w-prod')
+	})
+
+	it('resolves missing args and dead paths to the empty string', () => {
+		expect(interpolateTag('w-$args[gone]', 'ws', {})).toBe('w-')
+		expect(interpolateTag('w-$args[gone]', 'ws', undefined)).toBe('w-')
+		expect(interpolateTag('w-$args[conf.gone]', 'ws', { conf: 'not-an-object' })).toBe('w-')
+	})
+
+	it('combines $workspace and $args in one tag', () => {
+		expect(interpolateTag('$args[env]-$workspace', 'staging', { env: 'gpu' })).toBe('gpu-staging')
+	})
+})
+
+describe('findMatchingCustomTag', () => {
+	const workspace = 'staging'
+
+	it('returns an exact custom-tag match', () => {
+		expect(findMatchingCustomTag('gpu-heavy', ['gpu-heavy', 'other'], workspace, {})).toBe(
+			'gpu-heavy'
+		)
+	})
+
+	it('maps a resolved tag back to its raw $workspace template', () => {
+		expect(findMatchingCustomTag('deno-staging', ['deno-$workspace'], workspace, {})).toBe(
+			'deno-$workspace'
+		)
+	})
+
+	it('maps a resolved tag back to its raw $args template using the run args', () => {
+		expect(
+			findMatchingCustomTag('worker-gpu', ['worker-$args[env]'], workspace, { env: 'gpu' })
+		).toBe('worker-$args[env]')
+	})
+
+	it('prefers an exact entry over a template resolving to the same value', () => {
+		expect(
+			findMatchingCustomTag('worker-gpu', ['worker-$args[env]', 'worker-gpu'], workspace, {
+				env: 'gpu'
+			})
+		).toBe('worker-gpu')
+	})
+
+	it('returns undefined for backend-derived tags (default and workspaced defaults)', () => {
+		expect(findMatchingCustomTag('deno', [], workspace, {})).toBeUndefined()
+		expect(
+			findMatchingCustomTag('deno-staging', ['python3-production'], workspace, {})
+		).toBeUndefined()
+	})
+
+	it('does not match a template whose resolution differs from the stored tag', () => {
+		expect(
+			findMatchingCustomTag('worker-gpu', ['worker-$args[env]'], workspace, { env: 'cpu' })
+		).toBeUndefined()
 	})
 })

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1179,6 +1179,59 @@ export function isDynamicTag(tag: string | undefined): boolean {
 	return !!tag && tag.includes('$args[')
 }
 
+// Must mirror the backend's RE_ARG_TAG (windmill-queue/src/jobs.rs) so frontend
+// interpolation resolves exactly the same placeholders as push time.
+const RE_ARG_TAG = /\$args\[((?:\w+\.)*\w+)\]/
+
+// True when the tag contains placeholders that the backend resolves at push time.
+// A carried tag override that is itself a template re-resolves on every run, so
+// it never pins a stale resolved value.
+export function isTagTemplate(tag: string | undefined): boolean {
+	return !!tag && (tag.includes('$workspace') || RE_ARG_TAG.test(tag))
+}
+
+// Frontend mirror of the backend's `interpolate_args` (windmill-queue/src/jobs.rs):
+// `$workspace` first, then each `$args[name]` from the run's args — simple names use
+// the arg's JSON text with surrounding quotes trimmed, dotted names traverse nested
+// objects, anything missing resolves to the empty string.
+export function interpolateTag(
+	template: string,
+	workspaceId: string,
+	args: Record<string, any> | undefined
+): string {
+	const workspaced = template.replaceAll('$workspace', workspaceId)
+	return workspaced.replace(new RegExp(RE_ARG_TAG.source, 'g'), (_, name: string) => {
+		const parts = name.split('.')
+		let value: any = args?.[parts[0]]
+		for (const part of parts.slice(1)) {
+			value = value != null && typeof value === 'object' ? value[part] : undefined
+		}
+		if (value === undefined) {
+			return ''
+		}
+		return (JSON.stringify(value) ?? '').replace(/^"+|"+$/g, '')
+	})
+}
+
+// Maps a job's stored (resolved) tag back to the raw custom-tag entry it can only
+// have come from: an exact entry, or a templated entry that resolves to it with the
+// job's workspace and args. Custom tags are the only tags a user can pick as an
+// override and the only ones non-superadmins may pass explicitly, so a tag that maps
+// to no entry is backend-derived and must be re-derived on re-run, not carried.
+export function findMatchingCustomTag(
+	resolvedTag: string,
+	customTags: string[],
+	workspaceId: string,
+	args: Record<string, any> | undefined
+): string | undefined {
+	if (customTags.includes(resolvedTag)) {
+		return resolvedTag
+	}
+	return customTags.find(
+		(t) => isTagTemplate(t) && interpolateTag(t, workspaceId, args) === resolvedTag
+	)
+}
+
 // Counterpart of computeSharableHash's `tag`: extracts and removes the carried tag.
 // Only SHARABLE_HASH_TAG_PREFIX-prefixed `__tag` values are carried tags; any other
 // `__tag` value is a genuine arg with that name and is left in `params` for arg parsing.

--- a/frontend/src/routes/(root)/(logged)/flows/get/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/flows/get/[...path]/+page.svelte
@@ -14,6 +14,7 @@
 		emptyString,
 		urlParamsToObject,
 		extractTagFromSharableHash,
+		interpolateTag,
 		isDynamicTag,
 		isTagTemplate
 	} from '$lib/utils'
@@ -179,10 +180,16 @@
 			})
 			pinnedVersion = undefined
 		}
-		// A carried non-template tag is a pinned value; when the flow's tag is dynamic,
-		// drop it so the backend re-resolves from the (possibly edited) args. A carried
-		// template ($workspace/$args) re-resolves at push time, so it is kept as-is.
-		if (carriedTag && isDynamicTag(flow.tag) && !isTagTemplate(carriedTag)) {
+		// A carried non-template value equal to the resolution of the flow's own dynamic
+		// tag for these args is not an override but the previous run's pinned resolution:
+		// drop it so the backend re-resolves from the (possibly edited) args. A differing
+		// value is a genuine user override and a template re-resolves at push, so both stay.
+		if (
+			carriedTag &&
+			isDynamicTag(flow.tag) &&
+			!isTagTemplate(carriedTag) &&
+			interpolateTag(flow.tag ?? '', $workspaceStore!, args) === carriedTag
+		) {
 			if (overrideTag === carriedTag) {
 				overrideTag = undefined
 				overrideTagNote = `tag ${flow.tag} is resolved at run time, so the previous run's tag ${carriedTag} was not applied`

--- a/frontend/src/routes/(root)/(logged)/flows/get/[...path]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/flows/get/[...path]/+page.svelte
@@ -14,7 +14,8 @@
 		emptyString,
 		urlParamsToObject,
 		extractTagFromSharableHash,
-		isDynamicTag
+		isDynamicTag,
+		isTagTemplate
 	} from '$lib/utils'
 	import { isDeployable, ALL_DEPLOYABLE } from '$lib/utils_deployable'
 
@@ -178,9 +179,10 @@
 			})
 			pinnedVersion = undefined
 		}
-		// A carried tag is the previous run's resolved value; when the flow's tag is
-		// dynamic, drop it so the backend re-resolves from the (possibly edited) args
-		if (carriedTag && isDynamicTag(flow.tag)) {
+		// A carried non-template tag is a pinned value; when the flow's tag is dynamic,
+		// drop it so the backend re-resolves from the (possibly edited) args. A carried
+		// template ($workspace/$args) re-resolves at push time, so it is kept as-is.
+		if (carriedTag && isDynamicTag(flow.tag) && !isTagTemplate(carriedTag)) {
 			if (overrideTag === carriedTag) {
 				overrideTag = undefined
 				overrideTagNote = `tag ${flow.tag} is resolved at run time, so the previous run's tag ${carriedTag} was not applied`

--- a/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
@@ -9,6 +9,7 @@
 		type NewScript,
 		ConcurrencyGroupsService,
 		MetricsService,
+		WorkerService,
 		type ScriptArgs
 	} from '$lib/gen'
 	import {
@@ -16,6 +17,7 @@
 		computeSharableHash,
 		copyToClipboard,
 		encodeState,
+		findMatchingCustomTag,
 		getHubFlowIdFromPath,
 		isHubFlowPath,
 		isFlowPreview,
@@ -364,6 +366,31 @@
 
 	let scheduleEditor: ScheduleEditor | undefined = $state(undefined)
 
+	// A job's stored tag is usually backend-derived (language/flow default, possibly
+	// workspace-suffixed) and would be rejected by the CUSTOM_TAGS check if passed back
+	// explicitly. Only carry it into a re-run when it maps back to a custom-tag entry —
+	// the set the override dropdown offers — using the raw (possibly templated) entry.
+	// `args` must be the run's full args (job.args may be truncated for large runs), so
+	// that `$args[...]` entries resolve to the same value they had at push time.
+	let customTags: string[] | undefined = undefined
+	async function getRerunTagOverride(
+		args: Record<string, any> | undefined
+	): Promise<string | undefined> {
+		const tag = job?.tag
+		if (!tag) {
+			return undefined
+		}
+		try {
+			customTags ??= await WorkerService.getCustomTagsForWorkspace({
+				workspace: $workspaceStore!
+			})
+		} catch (e) {
+			console.error('Could not load custom tags, not carrying tag over for re-run', e)
+			return undefined
+		}
+		return findMatchingCustomTag(tag, customTags, $workspaceStore!, args)
+	}
+
 	let runImmediatelyLoading = $state(false)
 	async function runImmediately() {
 		runImmediatelyLoading = true
@@ -379,7 +406,7 @@
 			const commonArgs = {
 				workspace: $workspaceStore!,
 				requestBody: args,
-				tag: job?.tag
+				tag: await getRerunTagOverride(args)
 			}
 			if (job?.job_kind == 'script' || job?.job_kind == 'script_hub' || job?.job_kind == 'flow') {
 				let id
@@ -723,8 +750,10 @@
 			{/if}
 			{#if job?.job_kind === 'script' || job?.job_kind === 'script_hub' || job?.job_kind === 'flow'}
 				<Button
-					on:click|once={() => {
-						goto(viewHref + `#${computeSharableHash(job?.args, job?.tag)}`)
+					on:click|once={async () => {
+						goto(
+							viewHref + `#${computeSharableHash(job?.args, await getRerunTagOverride(job?.args))}`
+						)
 					}}
 					unifiedSize="md"
 					variant="default"

--- a/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/run/[...run]/+page.svelte
@@ -370,25 +370,40 @@
 	// workspace-suffixed) and would be rejected by the CUSTOM_TAGS check if passed back
 	// explicitly. Only carry it into a re-run when it maps back to a custom-tag entry —
 	// the set the override dropdown offers — using the raw (possibly templated) entry.
-	// `args` must be the run's full args (job.args may be truncated for large runs), so
-	// that `$args[...]` entries resolve to the same value they had at push time.
-	let customTags: string[] | undefined = undefined
+	// Pass the run's args if already fetched; template matching needs the full args
+	// (job.args may be truncated for large runs) and fetches them itself otherwise.
+	let customTags: { workspace: string; tags: string[] } | undefined = undefined
 	async function getRerunTagOverride(
 		args: Record<string, any> | undefined
 	): Promise<string | undefined> {
 		const tag = job?.tag
+		const workspace = $workspaceStore!
 		if (!tag) {
 			return undefined
 		}
 		try {
-			customTags ??= await WorkerService.getCustomTagsForWorkspace({
-				workspace: $workspaceStore!
-			})
+			if (customTags?.workspace !== workspace) {
+				customTags = {
+					workspace,
+					tags: await WorkerService.getCustomTagsForWorkspace({ workspace })
+				}
+			}
 		} catch (e) {
 			console.error('Could not load custom tags, not carrying tag over for re-run', e)
 			return undefined
 		}
-		return findMatchingCustomTag(tag, customTags, $workspaceStore!, args)
+		if (customTags.tags.includes(tag)) {
+			return tag
+		}
+		if (isWindmillTooBigObject(args)) {
+			try {
+				args = (await JobService.getJobArgs({ workspace, id: job?.id! })) as Record<string, any>
+			} catch (e) {
+				console.error('Could not load full args, not carrying tag over for re-run', e)
+				return undefined
+			}
+		}
+		return findMatchingCustomTag(tag, customTags.tags, workspace, args)
 	}
 
 	let runImmediatelyLoading = $state(false)

--- a/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
@@ -16,7 +16,8 @@
 		copyToClipboard,
 		urlParamsToObject,
 		extractTagFromSharableHash,
-		isDynamicTag
+		isDynamicTag,
+		isTagTemplate
 	} from '$lib/utils'
 	import Tooltip from '$lib/components/Tooltip.svelte'
 	import ShareModal from '$lib/components/ShareModal.svelte'
@@ -263,9 +264,10 @@
 				return
 			}
 		}
-		// A carried tag is the previous run's resolved value; when the script's tag is
-		// dynamic, drop it so the backend re-resolves from the (possibly edited) args
-		if (carriedTag && isDynamicTag(script.tag)) {
+		// A carried non-template tag is a pinned value; when the script's tag is dynamic,
+		// drop it so the backend re-resolves from the (possibly edited) args. A carried
+		// template ($workspace/$args) re-resolves at push time, so it is kept as-is.
+		if (carriedTag && isDynamicTag(script.tag) && !isTagTemplate(carriedTag)) {
 			if (overrideTag === carriedTag) {
 				overrideTag = undefined
 				overrideTagNote = `tag ${script.tag} is resolved at run time, so the previous run's tag ${carriedTag} was not applied`

--- a/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
+++ b/frontend/src/routes/(root)/(logged)/scripts/get/[...hash]/+page.svelte
@@ -16,6 +16,7 @@
 		copyToClipboard,
 		urlParamsToObject,
 		extractTagFromSharableHash,
+		interpolateTag,
 		isDynamicTag,
 		isTagTemplate
 	} from '$lib/utils'
@@ -264,10 +265,16 @@
 				return
 			}
 		}
-		// A carried non-template tag is a pinned value; when the script's tag is dynamic,
-		// drop it so the backend re-resolves from the (possibly edited) args. A carried
-		// template ($workspace/$args) re-resolves at push time, so it is kept as-is.
-		if (carriedTag && isDynamicTag(script.tag) && !isTagTemplate(carriedTag)) {
+		// A carried non-template value equal to the resolution of the script's own dynamic
+		// tag for these args is not an override but the previous run's pinned resolution:
+		// drop it so the backend re-resolves from the (possibly edited) args. A differing
+		// value is a genuine user override and a template re-resolves at push, so both stay.
+		if (
+			carriedTag &&
+			isDynamicTag(script.tag) &&
+			!isTagTemplate(carriedTag) &&
+			interpolateTag(script.tag ?? '', $workspaceStore!, args) === carriedTag
+		) {
 			if (overrideTag === carriedTag) {
 				overrideTag = undefined
 				overrideTagNote = `tag ${script.tag} is resolved at run time, so the previous run's tag ${carriedTag} was not applied`


### PR DESCRIPTION
## Summary

#10004 made 'Run again' pass the previous job's stored tag as an explicit tag override. The backend validates any explicitly-passed tag against the CUSTOM_TAGS allowlist (superadmins exempt), while backend-derived tags — language defaults like `deno`, workspaced defaults like `deno-{workspace}` when per-workspace default tags are enabled, `flow`/`dependency` — are never in that list. So for any non-superadmin, re-running a job whose tag was derived failed with `Bad request: Only super admins are allowed to use tags that are not included in the allowed CUSTOM_TAGS`. On instances with empty CUSTOM_TAGS (the default), this broke every 'Run again' for non-superadmins.

The fix keeps #10004's intent (preserving a genuine worker-group override across re-runs) while never passing a derived tag: the run page now carries the previous tag only when it maps back to an entry of the workspace's custom tags — the exact set the override dropdown offers and the only tags the backend accepts as explicit overrides. Since custom-tag entries can be templates (`$workspace`, `$args[...]`) whose raw string is what the allowlist checks, a stored tag that matches a templated entry's interpolation (with the job's own args) is carried as the **raw template**, so it re-resolves at push time instead of pinning a stale value.

## Changes

- `utils.ts`: new helpers — `interpolateTag` (frontend mirror of the backend's `interpolate_args`: `$workspace` first, then `$args[...]` incl. dotted paths, missing args resolve to empty), `findMatchingCustomTag` (maps a resolved tag back to the raw custom-tag entry it can only have come from, exact entry preferred over template), `isTagTemplate`
- run page: both 'Run again' entry points (navigate-to-form and 'Run immediately with same args') carry `findMatchingCustomTag(job.tag, …)` instead of `job.tag`; custom tags are cached per workspace; template matching fetches the full args itself when `job.args` is the too-big placeholder
- scripts/get + flows/get: the dynamic-tag drop now only clears a carried value that equals the resolution of the runnable's **own** dynamic tag for the run's args (a pinned self-resolution). A differing value is a genuine user override and a carried template re-resolves at push, so both are kept
- unit tests for the three helpers, including the truncated-args placeholder and exact-vs-template precedence

## Test plan

All verified in the browser as a non-superadmin workspace member (plus vitest 87/87, `npm run check` 0 errors):

- [x] derived workspaced tag (`deno-staging`, CUSTOM_TAGS without it): 'Run again' succeeds, no override carried, new job re-derives the same tag (was: 400)
- [x] derived default tag (`deno`, empty CUSTOM_TAGS): same
- [x] literal custom override (`gpu-heavy`): carried, form shows it, new job runs on it
- [x] templated custom override (`ctag-$workspace` stored as `ctag-staging`): carried as the raw template, re-resolves on the new job
- [x] `$args` templated custom override (`worker-$args[env]`, `env=gpu` → stored `worker-gpu`): carried as raw template; editing `env` to `cpu` on the form re-resolves the new job to `worker-cpu`
- [x] literal override on a runnable whose own tag is dynamic (`worker-$args[env]` + override `gpu-heavy`): override kept
- [x] no override on a runnable with dynamic tag whose resolution collides with a registered custom tag: carried value dropped with the explanatory note, backend re-resolves
- [x] 'Run immediately with same args' on derived and templated-override jobs

## Screenshots

'Run again' on a run whose tag came from the templated custom tag `worker-$args[env]` — the raw template is carried as the override (and re-resolves at push time):

![pr-template-carried](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/rerun-workspace-tags/1784127723-pr-template-carried.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Run again so only user-selected custom tag overrides are carried; backend-derived tags re-derive on rerun to avoid CUSTOM_TAGS 400s for non‑superadmins. Templated overrides (`$workspace`, `$args[...]`) are carried as raw templates so they re-resolve.

- **Bug Fixes**
  - Run page: carry previous tag only if it maps to a workspace custom tag; fetch full args when needed; cache custom tags per workspace.
  - Scripts/Flows forms: drop a carried tag only when it equals the runnable’s own dynamic tag resolution and is non-template; keep differing values and templates.
  - New helpers in `utils.ts`: `isTagTemplate`, `interpolateTag`, `findMatchingCustomTag` with unit tests.

<sup>Written for commit 8e0b42448f978ec8d73ed89c42569fdbbb20504b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



Fixes WIN-2193