### PR TITLE
feat(nsjail): make python/ansible rlimit_as configurable per worker (GIT-921)

### DIFF
--- a/backend/windmill-worker/nsjail/run.ansible.config.proto
+++ b/backend/windmill-worker/nsjail/run.ansible.config.proto
@@ -5,7 +5,7 @@ hostname: "ansible"
 log_level: ERROR
 time_limit: {TIMEOUT}
 
-rlimit_as: 4096
+{RLIMIT_AS}
 rlimit_cpu: 1000
 rlimit_fsize: 1000
 rlimit_nofile: 10000

--- a/backend/windmill-worker/nsjail/run.python3.config.proto
+++ b/backend/windmill-worker/nsjail/run.python3.config.proto
@@ -5,7 +5,7 @@ hostname: "python"
 log_level: ERROR
 time_limit: {TIMEOUT}
 
-rlimit_as: 4096
+{RLIMIT_AS}
 rlimit_cpu: 1000
 rlimit_fsize: 1000
 rlimit_nofile: 10000

--- a/backend/windmill-worker/src/ansible_executor.rs
+++ b/backend/windmill-worker/src/ansible_executor.rs
@@ -31,13 +31,14 @@ use crate::{
     bash_executor::BIN_BASH,
     common::{
         build_command_with_isolation, check_executor_binary_exists, get_reserved_variables,
-        read_and_check_result, resolve_nsjail_timeout, resolve_nsjail_tmp_mount_block,
-        start_child_process, transform_json, OccupancyMetrics,
+        read_and_check_result, render_nsjail_rlimit_as, resolve_nsjail_timeout,
+        resolve_nsjail_tmp_mount_block, start_child_process, transform_json, OccupancyMetrics,
     },
     handle_child::handle_child,
     is_sandboxing_enabled,
     python_executor::{create_dependencies_dir, handle_python_reqs, uv_pip_compile},
-    DISABLE_NUSER, GIT_PATH, HOME_ENV, NSJAIL_PATH, PATH_ENV, PROXY_ENVS, PY_INSTALL_DIR, TZ_ENV,
+    DISABLE_NUSER, GIT_PATH, HOME_ENV, NSJAIL_ANSIBLE_RLIMIT_AS_MB, NSJAIL_PATH, PATH_ENV,
+    PROXY_ENVS, PY_INSTALL_DIR, TZ_ENV,
 };
 use windmill_common::client::AuthedClient;
 
@@ -1659,6 +1660,10 @@ mount {{
             job_dir,
             "run.config.proto",
             &NSJAIL_CONFIG_RUN_ANSIBLE_CONTENT
+                .replace(
+                    "{RLIMIT_AS}",
+                    &render_nsjail_rlimit_as(NSJAIL_ANSIBLE_RLIMIT_AS_MB.as_deref(), 4096),
+                )
                 .replace("{PY_INSTALL_DIR}", &*PY_INSTALL_DIR)
                 .replace("{JOB_DIR}", job_dir)
                 .replace("{CLONE_NEWUSER}", &(!*DISABLE_NUSER).to_string())

--- a/backend/windmill-worker/src/common.rs
+++ b/backend/windmill-worker/src/common.rs
@@ -1124,6 +1124,45 @@ pub async fn resolve_nsjail_timeout(
     (duration.as_secs() + 15).to_string()
 }
 
+/// Render the `rlimit_as` line for an nsjail run config, honoring a per-language
+/// env-var override.
+///
+/// nsjail caps a jailed job's virtual address space at `rlimit_as` MiB. JIT
+/// runtimes (Bun/JavaScriptCore, the JVM) reserve large virtual ranges up front,
+/// so a subprocess spawned from a jailed Python/Ansible job can crash against this
+/// cap even when its physical memory use is modest. Lifting it lets operators run
+/// such workloads on a dedicated worker pool (set the env var only there) without
+/// giving up the mount/PID/user-namespace isolation that provides the real
+/// security boundary. Only the address-space limit is affected; the other rlimits
+/// (cpu/fsize/nofile) in the proto are untouched.
+///
+/// `env_override` is the raw value of the language's `NSJAIL_*_RLIMIT_AS_MB` env var:
+/// - unset/empty -> historical default (`rlimit_as: {default_mb}`)
+/// - `unlimited`/`none`/`inf`/`0` -> `rlimit_as_type: INF` (address space uncapped)
+/// - a positive integer (MiB) -> `rlimit_as: {n}`
+pub fn render_nsjail_rlimit_as(env_override: Option<&str>, default_mb: u32) -> String {
+    match env_override.map(str::trim) {
+        None | Some("") => format!("rlimit_as: {default_mb}"),
+        Some(v)
+            if v.eq_ignore_ascii_case("unlimited")
+                || v.eq_ignore_ascii_case("none")
+                || v.eq_ignore_ascii_case("inf")
+                || v == "0" =>
+        {
+            "rlimit_as_type: INF".to_string()
+        }
+        Some(v) => match v.parse::<u32>() {
+            Ok(mb) => format!("rlimit_as: {mb}"),
+            Err(_) => {
+                tracing::warn!(
+                    "Invalid nsjail rlimit_as override {v:?}, using default {default_mb}MiB"
+                );
+                format!("rlimit_as: {default_mb}")
+            }
+        },
+    }
+}
+
 /// Default size (in bytes) of the `/tmp` tmpfs mount inside nsjail sandboxes,
 /// used when the `nsjail_tmpfs_size_mb` instance setting is unset.
 pub const DEFAULT_NSJAIL_TMPFS_SIZE_BYTES: u64 = 800_000_000;
@@ -1231,6 +1270,49 @@ pub(crate) async fn resolve_nsjail_tmp_mount_block(job_dir: &str) -> String {
         }
     }
     bind_mount_block(&jail_tmp)
+}
+
+#[cfg(test)]
+mod nsjail_rlimit_as_tests {
+    use super::render_nsjail_rlimit_as;
+
+    #[test]
+    fn unset_uses_default() {
+        assert_eq!(render_nsjail_rlimit_as(None, 4096), "rlimit_as: 4096");
+        assert_eq!(render_nsjail_rlimit_as(Some("  "), 4096), "rlimit_as: 4096");
+    }
+
+    #[test]
+    fn numeric_override_is_used() {
+        assert_eq!(
+            render_nsjail_rlimit_as(Some("16384"), 4096),
+            "rlimit_as: 16384"
+        );
+        assert_eq!(
+            render_nsjail_rlimit_as(Some("  8192 "), 4096),
+            "rlimit_as: 8192"
+        );
+    }
+
+    #[test]
+    fn unlimited_keywords_emit_inf() {
+        for v in ["unlimited", "UNLIMITED", "none", "inf", "0"] {
+            assert_eq!(
+                render_nsjail_rlimit_as(Some(v), 4096),
+                "rlimit_as_type: INF",
+                "value {v:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_falls_back_to_default() {
+        assert_eq!(
+            render_nsjail_rlimit_as(Some("abc"), 4096),
+            "rlimit_as: 4096"
+        );
+        assert_eq!(render_nsjail_rlimit_as(Some("-1"), 4096), "rlimit_as: 4096");
+    }
 }
 
 #[cfg(test)]

--- a/backend/windmill-worker/src/python_executor.rs
+++ b/backend/windmill-worker/src/python_executor.rs
@@ -155,16 +155,17 @@ use windmill_object_store::OBJECT_STORE_SETTINGS;
 use crate::{
     common::{
         build_command_with_isolation, create_args_and_out_file, get_reserved_variables, read_file,
-        read_result, resolve_nsjail_timeout, resolve_nsjail_tmp_mount_block, start_child_process,
-        OccupancyMetrics, StreamNotifier, DEV_CONF_NSJAIL,
+        read_result, render_nsjail_rlimit_as, resolve_nsjail_timeout,
+        resolve_nsjail_tmp_mount_block, start_child_process, OccupancyMetrics, StreamNotifier,
+        DEV_CONF_NSJAIL,
     },
     get_proxy_envs_for_lang,
     handle_child::handle_child,
     is_sandboxing_enabled, read_ee_registry_with_workspace_override,
     worker_utils::ping_job_status,
-    PyV, DISABLE_NUSER, HOME_ENV, NSJAIL_AVAILABLE, NSJAIL_PATH, PATH_ENV, PIP_EXTRA_INDEX_URL,
-    PIP_INDEX_URL, PROXY_ENVS, PY_INSTALL_DIR, TRACING_PROXY_CA_CERT_PATH, TZ_ENV, UV_CACHE_DIR,
-    UV_EXCLUDE_NEWER, UV_INDEX_STRATEGY, UV_PYTHON_INSTALL_MIRROR,
+    PyV, DISABLE_NUSER, HOME_ENV, NSJAIL_AVAILABLE, NSJAIL_PATH, NSJAIL_PY_RLIMIT_AS_MB, PATH_ENV,
+    PIP_EXTRA_INDEX_URL, PIP_INDEX_URL, PROXY_ENVS, PY_INSTALL_DIR, TRACING_PROXY_CA_CERT_PATH,
+    TZ_ENV, UV_CACHE_DIR, UV_EXCLUDE_NEWER, UV_INDEX_STRATEGY, UV_PYTHON_INSTALL_MIRROR,
 };
 use windmill_common::client::AuthedClient;
 
@@ -1077,6 +1078,10 @@ mount {{
             job_dir,
             "run.config.proto",
             &NSJAIL_CONFIG_RUN_PYTHON3_CONTENT
+                .replace(
+                    "{RLIMIT_AS}",
+                    &render_nsjail_rlimit_as(NSJAIL_PY_RLIMIT_AS_MB.as_deref(), 4096),
+                )
                 .replace("{JOB_DIR}", job_dir)
                 .replace("{PY_INSTALL_DIR}", &*PY_INSTALL_DIR)
                 .replace("{CLONE_NEWUSER}", &(!*DISABLE_NUSER).to_string())

--- a/backend/windmill-worker/src/worker.rs
+++ b/backend/windmill-worker/src/worker.rs
@@ -342,6 +342,14 @@ lazy_static::lazy_static! {
     .and_then(|x| x.parse::<bool>().ok())
     .unwrap_or(false);
 
+    /// Per-language override for the nsjail `rlimit_as` (virtual address space) cap.
+    /// Value is in MiB, or `unlimited`/`none`/`inf`/`0` to uncap. Unset keeps the
+    /// historical default baked into the proto. See `render_nsjail_rlimit_as`.
+    pub static ref NSJAIL_PY_RLIMIT_AS_MB: Option<String> =
+        std::env::var("NSJAIL_PY_RLIMIT_AS_MB").ok();
+    pub static ref NSJAIL_ANSIBLE_RLIMIT_AS_MB: Option<String> =
+        std::env::var("NSJAIL_ANSIBLE_RLIMIT_AS_MB").ok();
+
     // pub static ref DISABLE_NSJAIL: bool = false;
     pub static ref DISABLE_NSJAIL: bool = std::env::var("DISABLE_NSJAIL")
         .ok()


### PR DESCRIPTION
Fixes GIT-921. Closes #10132.

## Problem

nsjail caps a jailed job's virtual **address space** at `rlimit_as` MiB. `run.python3.config.proto` and `run.ansible.config.proto` hardcode `rlimit_as: 4096` (4 GiB) with no supported override short of forking Windmill and rebuilding the worker image.

This is a cap on *virtual address reservation*, not physical memory. JIT runtimes (Bun/JavaScriptCore, the JVM) reserve large virtual ranges up front, so a subprocess spawned from a jailed Python/Ansible job can crash against this cap even when its physical footprint is modest. The reporter hit this running Anthropic's `claude-agent-sdk`, which shells out to the Bun-compiled `claude` CLI: under the 4 GiB cap it nondeterministically fails with JSC `MemoryExhaustion`, Bun pthread-stack `SystemResources` panics, or an indefinite hang, all traced to this one value.

As the issue's follow-up analysis notes, most other language protos already run with `disable_rl: true` (unlimited address space, inherited from parent) - `bun`, `go`, `java`, `csharp`, `php`, `rust`, `ruby`, etc. `python3` and `ansible` are the outliers that still set an explicit `rlimit_as`, so a JIT subprocess spawned *from inside* one of those jobs inherits the low cap.

## Change

Expose the `rlimit_as` line for the two affected protos via a per-language env var, read once at worker startup:

- `NSJAIL_PY_RLIMIT_AS_MB` (python3)
- `NSJAIL_ANSIBLE_RLIMIT_AS_MB` (ansible)

Semantics (see `render_nsjail_rlimit_as` in `common.rs`):

| Value | Rendered proto line |
|---|---|
| unset / empty | `rlimit_as: 4096` (historical default, unchanged) |
| positive integer (MiB) | `rlimit_as: <n>` |
| `unlimited` / `none` / `inf` / `0` | `rlimit_as_type: INF` (address space uncapped) |
| invalid | falls back to default + a `warn!` log |

Only the address-space limit is affected; the `rlimit_cpu` / `rlimit_fsize` / `rlimit_nofile` caps in the proto stay in place, so this is a targeted lift rather than the blanket `disable_rl: true` other protos use.

### Why an env var (and why this satisfies the "per-worker-group" ask)

Env vars are per-worker-process, so an operator sets `NSJAIL_PY_RLIMIT_AS_MB=unlimited` only on the dedicated worker pool that runs JIT-heavy workloads, leaving every other pool at the 4 GiB default. This is exactly the per-worker-group isolation the issue asked for as the ideal, and it does not touch the mount/PID/user-namespace boundary that provides the actual security isolation. It also mirrors the existing nsjail env-var knobs (`DISABLE_NUSER`, `FAVOR_UNSHARE_PID`, `ENABLE_UNSHARE_PID`).

Scope is limited to the two **run** protos: dep-install protos (`download.py`, `download.ruby`, `lock.ruby`) don't spawn JIT runtimes, and `download.py` is already hand-tuned to `rlimit_as: 8192`.

## Testing

- `cargo check -p windmill-worker --features python` - clean (2 pre-existing warnings only).
- Added unit tests for `render_nsjail_rlimit_as` (default / numeric / unlimited-keywords / invalid-fallback); `cargo test ... nsjail_rlimit_as_tests` - 4/4 pass.

### Not exercised

The nsjail runtime path could not be driven end-to-end in this dev environment (nsjail is not installed and the dev backend builds `--features quickjs` only). The substitution and rendered-proto validity are covered by unit tests; a maintainer with an nsjail-enabled worker should confirm a jailed Python job with `NSJAIL_PY_RLIMIT_AS_MB=unlimited` reports `Max address space  unlimited` in `/proc/self/limits`. `rlimit_as_type: INF` is a documented value of nsjail's `RLimit` enum (`INF = RLIM64_INFINITY`) at the pinned commit `dccf911`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `nsjail` address-space limit for Python and Ansible configurable per worker via env vars. This meets GIT-921’s per-worker-group requirement and unblocks JIT-heavy subprocesses (e.g., Bun/JavaScriptCore) without changing other limits.

- **New Features**
  - Add env vars: NSJAIL_PY_RLIMIT_AS_MB and NSJAIL_ANSIBLE_RLIMIT_AS_MB (read at worker startup).
  - Values: unset -> 4096 MiB; positive int (MiB) -> that value; unlimited/none/inf/0 -> uncap via rlimit_as_type: INF.
  - Other rlimits (cpu/fsize/nofile) unchanged; only run configs are affected.

- **Migration**
  - No action needed by default.
  - To lift the cap on a specific worker pool, set NSJAIL_PY_RLIMIT_AS_MB=unlimited (or a higher MiB value); same for Ansible.
  - Optional check: inside a jailed job, /proc/self/limits should show “Max address space  unlimited” when uncapped.

<sup>Written for commit fdec197bf5a90b5d0076f8909e581879de8812d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

