### PR TITLE
fix(frontend): surface real tool call errors in AI chat

### DIFF
--- a/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
+++ b/frontend/src/lib/components/copilot/chat/ToolExecutionDisplay.svelte
@@ -29,8 +29,12 @@
 	)
 	const autoCollapseDetails = $derived(message.autoCollapseDetails !== false)
 
+	// An errored tool must be expandable even if it never opted into details,
+	// otherwise the error set on its status would be invisible.
+	const detailsAvailable = $derived(message.showDetails === true || message.error !== undefined)
+
 	let isExpanded = $derived(
-		(message.showDetails && (!isSuccessful || !autoCollapseDetails)) ||
+		(detailsAvailable && (!isSuccessful || !autoCollapseDetails)) ||
 			(message.isStreamingArguments && hasParameters) ||
 			(message.isLoading && message.needsConfirmation)
 	)
@@ -57,7 +61,7 @@
 				message.needsConfirmation ? 'opacity-80' : ''
 			)}
 			onclick={() => (isExpanded = !isExpanded)}
-			disabled={!message.showDetails && !message.isStreamingArguments}
+			disabled={!detailsAvailable && !message.isStreamingArguments}
 		>
 			<div class="flex items-center gap-2">
 				{#if message.isLoading && !message.needsConfirmation}
@@ -67,7 +71,7 @@
 					{message.content}
 				</span>
 
-				{#if message.showDetails || message.isStreamingArguments}
+				{#if detailsAvailable || message.isStreamingArguments}
 					<ChevronRight
 						class={twMerge(
 							'w-3 h-3 text-secondary transition-transform duration-150',

--- a/frontend/src/lib/components/copilot/chat/shared.test.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.test.ts
@@ -211,6 +211,45 @@ describe('processToolCall', () => {
 		expect(result.content).toBe(error)
 	})
 
+	it('surfaces the real error in the tool status when the tool throws', async () => {
+		const { createToolDef, processToolCall } = await import('./shared')
+		const apiError = Object.assign(new Error('Bad Request'), {
+			status: 400,
+			body: { error: { message: 'script not found at path f/scripts/missing' } }
+		})
+		const setToolStatus = vi.fn()
+
+		const result = await processToolCall({
+			tools: [
+				{
+					def: createToolDef(z.object({}), 'run_script', 'Run script'),
+					fn: vi.fn().mockRejectedValue(apiError)
+				}
+			],
+			toolCall: {
+				id: 'call_err',
+				type: 'function',
+				function: { name: 'run_script', arguments: '{}' }
+			},
+			helpers: {},
+			workspace: 'test-workspace',
+			toolCallbacks: {
+				setToolStatus,
+				removeToolStatus: vi.fn()
+			}
+		})
+
+		const expectedError = 'script not found at path f/scripts/missing'
+		expect(setToolStatus).toHaveBeenLastCalledWith(
+			'call_err',
+			expect.objectContaining({
+				isLoading: false,
+				error: expectedError
+			})
+		)
+		expect(result.content).toBe(`Error while calling tool: ${expectedError}`)
+	})
+
 	it('continues to confirmation when pre-confirmation validation passes', async () => {
 		const { createToolDef, processToolCall } = await import('./shared')
 		const fn = vi.fn().mockResolvedValue('ok')

--- a/frontend/src/lib/components/copilot/chat/shared.ts
+++ b/frontend/src/lib/components/copilot/chat/shared.ts
@@ -629,6 +629,37 @@ async function callTool<T>({
 
 type MaybePromise<T> = T | Promise<T>
 
+const MAX_TOOL_ERROR_LENGTH = 2000
+
+/** ApiError from the generated client carries the server's message in `body`,
+ * not `message` — dig it out so tool failures show the real cause. Capped so a
+ * verbose error body (e.g. an HTML error page) can't flood the chat context. */
+export function formatToolError(error: any): string {
+	const bodyMessage =
+		error?.body?.error?.message ??
+		error?.body?.message ??
+		(typeof error?.body?.error === 'string' ? error.body.error : undefined)
+	const body =
+		bodyMessage ??
+		(typeof error?.body === 'string'
+			? error.body
+			: error?.body !== undefined
+				? stringifyErrorBody(error.body)
+				: undefined)
+	const message = String(body || error?.message || error)
+	return message.length > MAX_TOOL_ERROR_LENGTH
+		? message.slice(0, MAX_TOOL_ERROR_LENGTH) + '... (truncated)'
+		: message
+}
+
+function stringifyErrorBody(body: unknown): string {
+	try {
+		return JSON.stringify(body)
+	} catch {
+		return String(body)
+	}
+}
+
 export async function processToolCall<T>({
 	tools,
 	toolCall,
@@ -735,17 +766,12 @@ export async function processToolCall<T>({
 			})
 		} catch (err) {
 			console.error(err)
+			const errorMessage = formatToolError(err)
 			toolCallbacks.setToolStatus(toolCall.id, {
 				isLoading: false,
 				isStreamingArguments: false,
-				error: 'An error occurred while calling the tool'
+				error: errorMessage
 			})
-			const errorMessage =
-				typeof err === 'object' && 'message' in err
-					? err.message
-					: typeof err === 'string'
-						? err
-						: 'An error occurred while calling the tool'
 			result = `Error while calling tool: ${errorMessage}`
 		}
 		const toAdd = {
@@ -756,10 +782,16 @@ export async function processToolCall<T>({
 		return toAdd
 	} catch (err) {
 		console.error(err)
+		const errorMessage = formatToolError(err)
+		toolCallbacks.setToolStatus(toolCall.id, {
+			isLoading: false,
+			isStreamingArguments: false,
+			error: errorMessage
+		})
 		return {
 			role: 'tool' as const,
 			tool_call_id: toolCall.id,
-			content: 'Error while calling tool'
+			content: `Error while calling tool: ${errorMessage}`
 		}
 	}
 }

--- a/frontend/src/lib/components/copilot/chat/workspaceTools.ts
+++ b/frontend/src/lib/components/copilot/chat/workspaceTools.ts
@@ -28,6 +28,7 @@ import {
 import { z } from 'zod'
 import {
 	createToolDef,
+	formatToolError,
 	type CreatedResourceTriggerKind,
 	type Tool,
 	type ToolCallbacks,
@@ -237,30 +238,6 @@ function parseWithExplicitErrors<T>(schema: z.ZodType<T>, value: unknown, label:
 	return result.data
 }
 
-function formatApiError(error: any): string {
-	const bodyMessage =
-		error?.body?.error?.message ??
-		error?.body?.message ??
-		(typeof error?.body?.error === 'string' ? error.body.error : undefined)
-	const body =
-		bodyMessage ??
-		(typeof error?.body === 'string'
-			? error.body
-			: error?.body !== undefined
-				? stringifyErrorBody(error.body)
-				: undefined)
-	const message = body || error?.message || String(error)
-	return error?.status ? `HTTP ${error.status}: ${message}` : message
-}
-
-function stringifyErrorBody(body: unknown): string {
-	try {
-		return JSON.stringify(body)
-	} catch {
-		return String(body)
-	}
-}
-
 function setToolError(toolCallbacks: ToolCallbacks, toolId: string, error: unknown): string {
 	const errorMessage = error instanceof Error ? error.message : String(error)
 	toolCallbacks.setToolStatus(toolId, {
@@ -302,7 +279,7 @@ const createScheduleTool: Tool<any> = {
 					}
 				})
 			} catch (error) {
-				throw new Error(`Invalid schedule or timezone: ${formatApiError(error)}`)
+				throw new Error(`Invalid schedule or timezone: ${formatToolError(error)}`)
 			}
 
 			toolCallbacks.setToolStatus(toolId, {
@@ -325,7 +302,7 @@ const createScheduleTool: Tool<any> = {
 				})
 				return JSON.stringify(toolResult)
 			} catch (error) {
-				throw new Error(`Failed to create schedule "${requestBody.path}": ${formatApiError(error)}`)
+				throw new Error(`Failed to create schedule "${requestBody.path}": ${formatToolError(error)}`)
 			}
 		} catch (error) {
 			return setToolError(toolCallbacks, toolId, error)
@@ -383,7 +360,7 @@ const createTriggerTool: Tool<any> = {
 				return JSON.stringify(toolResult)
 			} catch (error) {
 				throw new Error(
-					`Failed to create ${triggerConfig.label} "${requestBody.path}": ${formatApiError(error)}`
+					`Failed to create ${triggerConfig.label} "${requestBody.path}": ${formatToolError(error)}`
 				)
 			}
 		} catch (error) {


### PR DESCRIPTION
## Summary
Tool call failures in the AI chat (including AI sessions) showed the opaque message "An error occurred while calling the tool" in the tool card, and tools that hadn't opted into `showDetails` showed no error at all — the card stayed a non-expandable header. This PR surfaces the real error message in the tool card and in the tool result returned to the model.

## Changes
- Added `formatToolError` in `shared.ts`: extracts the server's message from generated-client `ApiError` bodies (`body.error.message` / `body.message` / string body, falling back to `err.message`), capped at 2000 chars so a verbose error body can't flood the chat context.
- Both catch paths of `processToolCall` now set that real message on the tool status (rendered in the card's Result section) and in the tool message sent back to the model. The outer catch (e.g. unparseable arguments) previously never updated the tool status at all.
- `workspaceTools.ts` reuses the shared helper instead of its private `formatApiError`; the `HTTP <status>:` prefix is dropped since the message itself is what matters.
- `ToolExecutionDisplay.svelte`: a tool card whose status carries an error is now expandable and auto-expands, even when the tool didn't set `showDetails` — previously the error was set on the status but had nowhere to render.
- Regression test pinning that a thrown ApiError-shaped failure surfaces its body message in both the tool status and the tool message.

## Screenshots
`read_workspace_item` on a nonexistent path, in an AI session (previously: inert header with no error):

![tool-error-card](https://raw.githubusercontent.com/windmill-labs/agent-screenshots-internal/main/shots/expose-ai-tool-errors/1784190891-tool-error-card.png)

## Test plan
- [x] `vitest` on the copilot chat suite (51 tests pass, incl. new regression test)
- [x] `npm run check` (0 errors)
- [x] Manually verified in the browser: a failing `read_workspace_item` (404) auto-expands its card and shows the real server message; an "Unknown tool call" throw renders the same way; error text is scroll-capped (`max-h-28`) so long errors can't blow up the layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the real server error for failed tool calls in chat and return it to the model. Error cards now auto-expand so the message is visible even when details weren’t enabled.

- **Bug Fixes**
  - Added `formatToolError` to extract server messages (capped at 2000 chars) and used it in `processToolCall` for both status and returned tool message.
  - Made `ToolExecutionDisplay` expandable on error (even without `showDetails`) and auto-expand; updated disabled logic to respect error presence.
  - Replaced local formatter in `workspaceTools.ts` with the shared helper and removed the `HTTP <status>:` prefix from messages.
  - Added a regression test to pin that a thrown `ApiError` surfaces its body message in both the tool status and tool message.

<sup>Written for commit a985d6e92b9883bb8c99a731221c4101ec762565. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/windmill-labs/windmill/pull/10146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

